### PR TITLE
[RDY] API: add nvim_win_get_config()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -625,7 +625,7 @@ nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
                 Return: ~
                     Buffer handle, or 0 on error
 
-nvim_open_win({buffer}, {enter}, {options})                  *nvim_open_win()*
+nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                 Open a new window.
 
                 Currently this is used to open floating and external windows.
@@ -643,18 +643,20 @@ nvim_open_win({buffer}, {enter}, {options})                  *nvim_open_win()*
                     {buffer}   handle of buffer to be displayed in the window
                     {enter}    whether the window should be entered (made the
                                current window)
-                    {options}  dict of options for configuring window
-                               positioning accepts the following keys:
+                    {config}   dictionary for the window configuration accepts
+                               these keys:
 
                         `relative`: If set, the window becomes a
                         floating window. The window will be placed with
                         row,col coordinates relative one of the
                         following:
                             "editor" the global editor grid
-                            "win"    a window. Use 'win' option below to
-                                     specify window id, or current window will
-                                     be used by default.
+                            "win"    a window. Use `win` to specify window id,
+                                     or current window will be used by default.
                             "cursor" the cursor position in current window.
+
+                        `win`: when using `relative='win'`, window id of the window
+                        where the position is defined.
 
                         `anchor`: the corner of the float that the row,col
                         position defines
@@ -668,11 +670,9 @@ nvim_open_win({buffer}, {enter}, {options})                  *nvim_open_win()*
                         the window can still be entered using
                         |nvim_set_current_win()| API call.
 
-                        `height`: window height in character cells. Cannot be
-                        smaller than 1.
+                        `height`: Window height in character cells. Minimum of 1.
 
-                        `width`: window width in character cells. Cannot be
-                        smaller than 2.
+                        `width`: Window width in character cells. Minimum of 2.
 
                         `row`: row position. Screen cell height are used as unit.
                         Can be floating point.
@@ -680,12 +680,9 @@ nvim_open_win({buffer}, {enter}, {options})                  *nvim_open_win()*
                         `col`: column position.  Screen cell width is used as
                         unit. Can be floating point.
 
-                        `win`: when using relative='win', window id of the window
-                        where the position is defined.
-
                         `external`: GUI should display the window as an external
                         top-level window. Currently accepts no other
-                        positioning options together with this.
+                        positioning configuration together with this.
 
                 With editor positioning row=0, col=0 refers to the top-left
                 corner of the screen-grid and row=Lines-1, Columns-1 refers to
@@ -1565,14 +1562,13 @@ nvim_win_is_valid({window})                              *nvim_win_is_valid()*
                 Return: ~
                     true if the window is valid, false otherwise
 
-nvim_win_set_config({window}, {options})               *nvim_win_set_config()*
+nvim_win_set_config({window}, {config})                *nvim_win_set_config()*
                 Configure window position. Currently this is only used to
                 configure floating and external windows (including changing a
                 split window to these types).
 
                 See documentation at |nvim_open_win()|, for the meaning of
-                parameters. Pass in 0 for `width` and `height` to keep
-                existing size.
+                parameters.
 
                 When reconfiguring a floating window, absent option keys will
                 not be changed. The following restriction apply: `row`, `col`
@@ -1580,16 +1576,16 @@ nvim_win_set_config({window}, {options})               *nvim_win_set_config()*
                 subset of these is an error.
 
                 Parameters: ~
-                    {window}   Window handle
-                    {options}  Dictionary of options
+                    {window}  Window handle
+                    {config}  Dictionary of window configuration
 
 nvim_win_get_config({window})                          *nvim_win_get_config()*
                 Return window configuration.
 
-                Return a dictionary containing the same options that can be
+                Return a dictionary containing the same config that can be
                 given to |nvim_open_win()|.
 
-                `relative` will be empty for normal windows.
+                `relative` will be an empty string for normal windows.
 
                 Parameters: ~
                     {window}  Window handle

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -245,10 +245,10 @@ functional buffer windows and support user editing. They support the standard
 'statusline' is not supported currently).
 
 Floating windows are created either by |nvim_open_win()| to open a new window,
-or |nvim_win_config()| to reconfigure a normal window into a float. Currently
-the position can either be grid coordinates relative the top-left of some
-window, or a position relative to the current window cursor.  The parameters
-for positioning are described in detail at |nvim_open_win()| help.
+or |nvim_win_set_config()| to reconfigure a normal window into a float.
+Currently the position can either be grid coordinates relative the top-left of
+some window, or a position relative to the current window cursor.  The
+parameters for positioning are described in detail at |nvim_open_win()|.
 
 |nvim_open_win()| assumes an existing buffer to display in the window. To create
 a scratch buffer for the float, |nvim_create_buffer()| can be used. The text in
@@ -264,8 +264,9 @@ Here is an example for creating a float with scratch buffer: >
 
     let buf = nvim_create_buf(v:false, v:true)
     call nvim_buf_set_lines(buf, 0, -1, v:true, ["test", "text"])
-    let opts = {'relative': 'cursor', 'col':0, 'row':1, 'anchor': 'NW'}
-    let win =  nvim_open_win(buf, 0, 10, 2, opts)
+    let opts = {'relative': 'cursor', 'width': 10, 'height': 2, 'col': 0,
+        \ 'row': 1, 'anchor': 'NW'}
+    let win = nvim_open_win(buf, 0, opts)
     " optional: change highlight, otherwise Pmenu is used
     call nvim_win_set_option(win, 'winhl', 'Normal:MyHighlight')
 >
@@ -624,8 +625,7 @@ nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
                 Return: ~
                     Buffer handle, or 0 on error
 
-                                                             *nvim_open_win()*
-nvim_open_win({buffer}, {enter}, {width}, {height}, {options})
+nvim_open_win({buffer}, {enter}, {options})                  *nvim_open_win()*
                 Open a new window.
 
                 Currently this is used to open floating and external windows.
@@ -643,8 +643,6 @@ nvim_open_win({buffer}, {enter}, {width}, {height}, {options})
                     {buffer}   handle of buffer to be displayed in the window
                     {enter}    whether the window should be entered (made the
                                current window)
-                    {width}    width of window (in character cells)
-                    {height}   height of window (in character cells)
                     {options}  dict of options for configuring window
                                positioning accepts the following keys:
 
@@ -669,6 +667,12 @@ nvim_open_win({buffer}, {enter}, {width}, {height}, {options})
                         mouse events. Defaults to true. Even if set to false,
                         the window can still be entered using
                         |nvim_set_current_win()| API call.
+
+                        `height`: window height in character cells. Cannot be
+                        smaller than 1.
+
+                        `width`: window width in character cells. Cannot be
+                        smaller than 2.
 
                         `row`: row position. Screen cell height are used as unit.
                         Can be floating point.
@@ -1561,20 +1565,37 @@ nvim_win_is_valid({window})                              *nvim_win_is_valid()*
                 Return: ~
                     true if the window is valid, false otherwise
 
-                                                           *nvim_win_config()*
-nvim_win_config({window}, {width}, {height}, {options})
+nvim_win_set_config({window}, {options})               *nvim_win_set_config()*
                 Configure window position. Currently this is only used to
                 configure floating and external windows (including changing a
                 split window to these types).
 
                 See documentation at |nvim_open_win()|, for the meaning of
-                parameters. Pass in -1 for 'witdh' and 'height' to keep
-                exiting size.
+                parameters. Pass in 0 for `width` and `height` to keep
+                existing size.
 
                 When reconfiguring a floating window, absent option keys will
                 not be changed. The following restriction apply: `row`, `col`
                 and `relative` must be reconfigured together. Only changing a
                 subset of these is an error.
+
+                Parameters: ~
+                    {window}   Window handle
+                    {options}  Dictionary of options
+
+nvim_win_get_config({window})                          *nvim_win_get_config()*
+                Return window configuration.
+
+                Return a dictionary containing the same options that can be
+                given to |nvim_open_win()|.
+
+                `relative` will be empty for normal windows.
+
+                Parameters: ~
+                    {window}  Window handle
+
+                Return: ~
+                    Window configuration
 
 nvim_win_close({window}, {force})                           *nvim_win_close()*
                 Close a window.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1003,35 +1003,35 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 /// Exactly one of `external` and `relative` must be specified.
 ///
 /// @param buffer handle of buffer to be displayed in the window
-/// @param enter whether the window should be entered (made the current window)
-/// @param options dict of options for configuring window positioning
-///                accepts the following keys:
+/// @param enter  whether the window should be entered (made the current window)
+/// @param config dictionary for the window configuration accepts these keys:
+///
 ///     `relative`: If set, the window becomes a floating window. The window
 ///         will be placed with row,col coordinates relative one of the
 ///         following:
 ///        "editor" the global editor grid
-///        "win"    a window. Use 'win' option below to specify window id,
-///                 or current window will be used by default.
+///        "win"    a window. Use `win` to specify a window id,
+///                 or the current window will be used by default.
 ///        "cursor" the cursor position in current window.
-///     `anchor`:   the corner of the float that the row,col position defines
+///     `win`: When using relative='win', window id of the window where the
+///         position is defined.
+///     `anchor`: The corner of the float that the row,col position defines:
 ///        "NW" north-west (default)
 ///        "NE" north-east
 ///        "SW" south-west
 ///        "SE" south-east
-///     `focusable`: Whether window can be focused by wincmds and
-///         mouse events. Defaults to true. Even if set to false, the window
-///         can still be entered using |nvim_set_current_win()| API call.
-///     `height`: window height (in character cells). Cannot be smaller than 1.
-///     `width`: window width (in character cells). Cannot be smaller than 2.
-///     `row`: row position. Screen cell height are used as unit.  Can be
+///     `height`: window height (in character cells). Minimum of 1.
+///     `width`: window width (in character cells). Minimum of 2.
+///     `row`: row position. Screen cell height are used as unit. Can be
 ///         floating point.
 ///     `col`: column position. Screen cell width is used as unit. Can be
 ///         floating point.
-///     `win`: when using relative='win', window id of the window where the
-///         position is defined.
-///     `external` GUI should display the window as an external
-///         top-level window. Currently accepts no other positioning options
-///         together with this.
+///     `focusable`: Whether window can be focused by wincmds and
+///         mouse events. Defaults to true. Even if set to false, the window
+///         can still be entered using |nvim_set_current_win()| API call.
+///     `external`: GUI should display the window as an external
+///         top-level window. Currently accepts no other positioning
+///         configuration together with this.
 ///
 /// With editor positioning row=0, col=0 refers to the top-left corner of the
 /// screen-grid and row=Lines-1, Columns-1 refers to the bottom-right corner.
@@ -1047,15 +1047,14 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///
 /// @param[out] err Error details, if any
 /// @return the window handle or 0 when error
-Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary options,
-                     Error *err)
+Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config, Error *err)
   FUNC_API_SINCE(6)
 {
-  FloatConfig config = FLOAT_CONFIG_INIT;
-  if (!parse_float_config(options, &config, false, err)) {
+  FloatConfig fconfig = FLOAT_CONFIG_INIT;
+  if (!parse_float_config(config, &fconfig, false, err)) {
     return 0;
   }
-  win_T *wp = win_new_float(NULL, config, err);
+  win_T *wp = win_new_float(NULL, fconfig, err);
   if (!wp) {
     return 0;
   }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1004,8 +1004,6 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///
 /// @param buffer handle of buffer to be displayed in the window
 /// @param enter whether the window should be entered (made the current window)
-/// @param width width of window (in character cells)
-/// @param height height of window (in character cells)
 /// @param options dict of options for configuring window positioning
 ///                accepts the following keys:
 ///     `relative`: If set, the window becomes a floating window. The window
@@ -1023,6 +1021,8 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///     `focusable`: Whether window can be focused by wincmds and
 ///         mouse events. Defaults to true. Even if set to false, the window
 ///         can still be entered using |nvim_set_current_win()| API call.
+///     `height`: window height (in character cells). Cannot be smaller than 1.
+///     `width`: window width (in character cells). Cannot be smaller than 2.
 ///     `row`: row position. Screen cell height are used as unit.  Can be
 ///         floating point.
 ///     `col`: column position. Screen cell width is used as unit. Can be
@@ -1047,16 +1047,15 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///
 /// @param[out] err Error details, if any
 /// @return the window handle or 0 when error
-Window nvim_open_win(Buffer buffer, Boolean enter,
-                     Integer width, Integer height,
-                     Dictionary options, Error *err)
+Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary options,
+                     Error *err)
   FUNC_API_SINCE(6)
 {
   FloatConfig config = FLOAT_CONFIG_INIT;
   if (!parse_float_config(options, &config, false, err)) {
     return 0;
   }
-  win_T *wp = win_new_float(NULL, (int)width, (int)height, config, err);
+  win_T *wp = win_new_float(NULL, config, err);
   if (!wp) {
     return 0;
   }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1047,7 +1047,8 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///
 /// @param[out] err Error details, if any
 /// @return the window handle or 0 when error
-Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config, Error *err)
+Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config,
+                     Error *err)
   FUNC_API_SINCE(6)
 {
   FloatConfig fconfig = FLOAT_CONFIG_INIT;

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -439,11 +439,15 @@ Boolean nvim_win_is_valid(Window window)
 /// types).
 ///
 /// See documentation at |nvim_open_win()|, for the meaning of parameters. Pass
-/// in 0 for 'witdh' and 'height' to keep exiting size.
+/// in 0 for `width` and `height` to keep existing size.
 ///
 /// When reconfiguring a floating window, absent option keys will not be
 /// changed. The following restriction apply: `row`, `col` and `relative`
 /// must be reconfigured together. Only changing a subset of these is an error.
+///
+/// @param      window  Window handle
+/// @param      options Dictionary of options
+/// @param[out] err     Error details, if any
 void nvim_win_set_config(Window window, Dictionary options, Error *err)
   FUNC_API_SINCE(6)
 {
@@ -475,6 +479,8 @@ void nvim_win_set_config(Window window, Dictionary options, Error *err)
 ///
 /// Return a dictionary containing the same options that can be given to
 /// |nvim_open_win()|.
+///
+/// `relative` will be empty for normal windows.
 ///
 /// @param window Window handle
 /// @param[out] err Error details, if any

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -438,17 +438,16 @@ Boolean nvim_win_is_valid(Window window)
 /// floating and external windows (including changing a split window to these
 /// types).
 ///
-/// See documentation at |nvim_open_win()|, for the meaning of parameters. Pass
-/// in 0 for `width` and `height` to keep existing size.
+/// See documentation at |nvim_open_win()|, for the meaning of parameters.
 ///
 /// When reconfiguring a floating window, absent option keys will not be
 /// changed. The following restriction apply: `row`, `col` and `relative`
 /// must be reconfigured together. Only changing a subset of these is an error.
 ///
 /// @param      window  Window handle
-/// @param      options Dictionary of options
+/// @param      config  Dictionary of window configuration
 /// @param[out] err     Error details, if any
-void nvim_win_set_config(Window window, Dictionary options, Error *err)
+void nvim_win_set_config(Window window, Dictionary config, Error *err)
   FUNC_API_SINCE(6)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -457,34 +456,34 @@ void nvim_win_set_config(Window window, Dictionary options, Error *err)
   }
   bool new_float = !win->w_floating;
   // reuse old values, if not overriden
-  FloatConfig config = new_float ? FLOAT_CONFIG_INIT : win->w_float_config;
+  FloatConfig fconfig = new_float ? FLOAT_CONFIG_INIT : win->w_float_config;
 
-  if (!parse_float_config(options, &config, !new_float, err)) {
+  if (!parse_float_config(config, &fconfig, !new_float, err)) {
     return;
   }
-  config.height = config.height > 0 ? config.height : win->w_height;
-  config.width = config.width > 0 ? config.width : win->w_width;
+  fconfig.height = fconfig.height > 0 ? fconfig.height : win->w_height;
+  fconfig.width = fconfig.width > 0 ? fconfig.width : win->w_width;
   if (new_float) {
-    if (!win_new_float(win, config, err)) {
+    if (!win_new_float(win, fconfig, err)) {
       return;
     }
     redraw_later(NOT_VALID);
   } else {
-    win_config_float(win, config);
+    win_config_float(win, fconfig);
     win->w_pos_changed = true;
   }
 }
 
 /// Return window configuration.
 ///
-/// Return a dictionary containing the same options that can be given to
+/// Return a dictionary containing the same config that can be given to
 /// |nvim_open_win()|.
 ///
-/// `relative` will be empty for normal windows.
+/// `relative` will be an empty string for normal windows.
 ///
-/// @param window Window handle
+/// @param      window Window handle
 /// @param[out] err Error details, if any
-/// @return Window configuration
+/// @return     Window configuration
 Dictionary nvim_win_get_config(Window window, Error *err)
   FUNC_API_SINCE(6)
 {

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -512,21 +512,9 @@ Dictionary nvim_win_get_config(Window window, Error *err)
   PUT(rv, "row", FLOAT_OBJ(wp->w_float_config.row));
   PUT(rv, "col", FLOAT_OBJ(wp->w_float_config.col));
 
-  if (wp->w_floating) {
-    switch (wp->w_float_config.relative) {
-      case kFloatRelativeEditor:
-        PUT(rv, "relative", STRING_OBJ(cstr_to_string("editor")));
-        break;
-      case kFloatRelativeWindow:
-        PUT(rv, "relative", STRING_OBJ(cstr_to_string("win")));
-        break;
-      case kFloatRelativeCursor:
-        PUT(rv, "relative", STRING_OBJ(cstr_to_string("cursor")));
-        break;
-    }
-  } else {
-    PUT(rv, "relative", STRING_OBJ(cstr_to_string("")));
-  }
+  const char *rel =
+    wp->w_floating ? float_relative_str[wp->w_float_config.relative] : "";
+  PUT(rv, "relative", STRING_OBJ(cstr_to_string(rel)));
 
   return rv;
 }

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -495,7 +495,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
   PUT(rv, "focusable", BOOLEAN_OBJ(wp->w_float_config.focusable));
   PUT(rv, "external", BOOLEAN_OBJ(wp->w_float_config.external));
   PUT(rv, "anchor", STRING_OBJ(cstr_to_string(
-          float_anchor_str[wp->w_float_config.anchor])));
+      float_anchor_str[wp->w_float_config.anchor])));
 
   if (wp->w_float_config.relative == kFloatRelativeWindow) {
     PUT(rv, "win", INTEGER_OBJ(wp->w_float_config.window));

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -444,8 +444,8 @@ Boolean nvim_win_is_valid(Window window)
 /// When reconfiguring a floating window, absent option keys will not be
 /// changed. The following restriction apply: `row`, `col` and `relative`
 /// must be reconfigured together. Only changing a subset of these is an error.
-void nvim_win_config(Window window, Integer width, Integer height,
-                     Dictionary options, Error *err)
+void nvim_win_set_config(Window window, Integer width, Integer height,
+                         Dictionary options, Error *err)
   FUNC_API_SINCE(6)
 {
   win_T *win = find_window_by_handle(window, err);

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -472,6 +472,61 @@ void nvim_win_config(Window window, Integer width, Integer height,
   }
 }
 
+/// Return window configuration.
+///
+/// Return a dictionary containing the same options that can be given to
+/// |nvim_open_win()|.
+///
+/// @param window Window handle
+/// @param[out] err Error details, if any
+/// @return Window configuration
+Dictionary nvim_win_get_config(Window window, Error *err)
+  FUNC_API_SINCE(6)
+{
+  Dictionary rv = ARRAY_DICT_INIT;
+
+  win_T *wp = find_window_by_handle(window, err);
+  if (!wp) {
+    return rv;
+  }
+
+  PUT(rv, "height", INTEGER_OBJ(wp->w_height));
+  PUT(rv, "width", INTEGER_OBJ(wp->w_width));
+  PUT(rv, "focusable", BOOLEAN_OBJ(wp->w_float_config.focusable));
+  PUT(rv, "external", BOOLEAN_OBJ(wp->w_float_config.external));
+  PUT(rv, "anchor", STRING_OBJ(cstr_to_string(
+          float_anchor_str[wp->w_float_config.anchor])));
+
+  if (wp->w_float_config.relative == kFloatRelativeWindow) {
+    PUT(rv, "win", INTEGER_OBJ(wp->w_float_config.window));
+  }
+
+  if (wp->w_float_config.external) {
+    return rv;
+  }
+
+  PUT(rv, "row", FLOAT_OBJ(wp->w_float_config.row));
+  PUT(rv, "col", FLOAT_OBJ(wp->w_float_config.col));
+
+  if (wp->w_floating) {
+    switch (wp->w_float_config.relative) {
+      case kFloatRelativeEditor:
+        PUT(rv, "relative", STRING_OBJ(cstr_to_string("editor")));
+        break;
+      case kFloatRelativeWindow:
+        PUT(rv, "relative", STRING_OBJ(cstr_to_string("win")));
+        break;
+      case kFloatRelativeCursor:
+        PUT(rv, "relative", STRING_OBJ(cstr_to_string("cursor")));
+        break;
+    }
+  } else {
+    PUT(rv, "relative", STRING_OBJ(cstr_to_string("")));
+  }
+
+  return rv;
+}
+
 /// Close a window.
 ///
 /// This is equivalent to |:close| with count except that it takes a window id.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -979,6 +979,7 @@ typedef enum {
 
 typedef struct {
   Window window;
+  int height, width;
   double row, col;
   FloatAnchor anchor;
   FloatRelative relative;
@@ -986,7 +987,8 @@ typedef struct {
   bool focusable;
 } FloatConfig;
 
-#define FLOAT_CONFIG_INIT ((FloatConfig){ .row = 0, .col = 0, .anchor = 0, \
+#define FLOAT_CONFIG_INIT ((FloatConfig){ .height = 0, .width = 0, \
+                                          .row = 0, .col = 0, .anchor = 0, \
                                           .relative = 0, .external = false, \
                                           .focusable = true })
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -959,6 +959,7 @@ struct matchitem {
 };
 
 typedef int FloatAnchor;
+typedef int FloatRelative;
 
 enum {
   kFloatAnchorEast  = 1,
@@ -971,11 +972,14 @@ enum {
 // SE -> kFloatAnchorSouth | kFloatAnchorEast
 EXTERN const char *const float_anchor_str[] INIT(= { "NW", "NE", "SW", "SE" });
 
-typedef enum {
+enum {
   kFloatRelativeEditor = 0,
   kFloatRelativeWindow = 1,
   kFloatRelativeCursor = 2,
-} FloatRelative;
+};
+
+EXTERN const char *const float_relative_str[] INIT(= { "editor", "window",
+                                                       "cursor" });
 
 typedef struct {
   Window window;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -958,20 +958,23 @@ struct matchitem {
   int conceal_char;         ///< cchar for Conceal highlighting
 };
 
-typedef enum {
-    kFloatAnchorEast = 1,
-    kFloatAnchorSouth = 2,
+typedef int FloatAnchor;
 
-    kFloatAnchorNW = 0,
-    kFloatAnchorNE = 1,
-    kFloatAnchorSW = 2,
-    kFloatAnchorSE = 3,
-} FloatAnchor;
+enum {
+  kFloatAnchorEast  = 1,
+  kFloatAnchorSouth = 2,
+};
+
+// NW -> 0
+// NE -> kFloatAnchorEast
+// SW -> kFloatAnchorSouth
+// SE -> kFloatAnchorSouth | kFloatAnchorEast
+EXTERN const char *const float_anchor_str[] INIT(= { "NW", "NE", "SW", "SE" });
 
 typedef enum {
-    kFloatRelativeEditor = 0,
-    kFloatRelativeWindow = 1,
-    kFloatRelativeCursor = 2,
+  kFloatRelativeEditor = 0,
+  kFloatRelativeWindow = 1,
+  kFloatRelativeCursor = 2,
 } FloatRelative;
 
 typedef struct {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -460,7 +460,9 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
 
   if (wp->w_floating) {
     if (width != wp->w_width && height != wp->w_height) {
-      win_config_float(wp, (int)width, (int)height, wp->w_float_config);
+      wp->w_float_config.width = width;
+      wp->w_float_config.height = height;
+      win_config_float(wp, wp->w_float_config);
     }
   } else {
     // non-positive indicates no request

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -614,12 +614,6 @@ static void ui_ext_win_position(win_T *wp)
                     wp->w_wincol, wp->w_width, wp->w_height);
     return;
   }
-  const char *const anchor_str[] = {
-    "NW",
-    "NE",
-    "SW",
-    "SE"
-  };
 
   FloatConfig c = wp->w_float_config;
   if (!c.external) {
@@ -635,7 +629,7 @@ static void ui_ext_win_position(win_T *wp)
       api_clear_error(&dummy);
     }
     if (ui_has(kUIMultigrid)) {
-      String anchor = cstr_to_string(anchor_str[c.anchor]);
+      String anchor = cstr_to_string(float_anchor_str[c.anchor]);
       ui_call_win_float_pos(wp->w_grid.handle, wp->handle, anchor, grid->handle,
                             row, col, c.focusable);
     } else {
@@ -672,14 +666,14 @@ static bool parse_float_anchor(String anchor, FloatAnchor *out)
     *out = (FloatAnchor)0;
   }
   char *str = anchor.data;
-  if (!STRICMP(str, "NW")) {
-    *out = kFloatAnchorNW;
-  } else if (!STRICMP(str, "NE")) {
-    *out = kFloatAnchorNE;
-  } else if (!STRICMP(str, "SW")) {
-    *out = kFloatAnchorSW;
-  } else if (!STRICMP(str, "SE")) {
-    *out = kFloatAnchorSE;
+  if (striequal(str, "NW")) {
+    *out = 0;  //  NW is the default
+  } else if (striequal(str, "NE")) {
+    *out = kFloatAnchorEast;
+  } else if (striequal(str, "SW")) {
+    *out = kFloatAnchorSouth;
+  } else if (striequal(str, "SE")) {
+    *out = kFloatAnchorSouth | kFloatAnchorEast;
   } else {
     return false;
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -685,11 +685,11 @@ static bool parse_float_relative(String relative, FloatRelative *out)
     *out = (FloatRelative)0;
   }
   char *str = relative.data;
-  if (!STRICMP(str, "editor")) {
+  if (striequal(str, "editor")) {
     *out = kFloatRelativeEditor;
-  }  else if (!STRICMP(str, "win")) {
+  }  else if (striequal(str, "win")) {
     *out = kFloatRelativeWindow;
-  } else if (!STRICMP(str, "cursor")) {
+  } else if (striequal(str, "cursor")) {
     *out = kFloatRelativeCursor;
   } else {
     return false;
@@ -804,7 +804,8 @@ bool parse_float_config(Dictionary config, FloatConfig *fconfig, bool reconf,
     }
   }
 
-  if (has_window && !(has_relative && fconfig->relative == kFloatRelativeWindow)) {
+  if (has_window && !(has_relative
+                      && fconfig->relative == kFloatRelativeWindow)) {
     api_set_error(err, kErrorTypeValidation,
                   "'win' key is only valid with relative='win'");
     return false;

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -231,15 +231,15 @@ describe('floating windows', function()
 
     it('API has proper error messages', function()
       local buf = meths.create_buf(false,false)
-      eq({false, "Invalid options key 'bork'"},
+      eq({false, "Invalid key 'bork'"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,bork=true}))
-      eq({false, "'win' option is only valid with relative='win'"},
+      eq({false, "'win' key is only valid with relative='win'"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,win=0}))
-      eq({false, "Only one of 'relative' and 'external' should be used"},
+      eq({false, "Only one of 'relative' and 'external' must be used"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,external=true}))
-      eq({false, "Invalid value of 'relative' option"},
+      eq({false, "Invalid value of 'relative' key"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='shell',row=0,col=0}))
-      eq({false, "Invalid value of 'anchor' option"},
+      eq({false, "Invalid value of 'anchor' key"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,anchor='bottom'}))
       eq({false, "All of 'relative', 'row', and 'col' has to be specified at once"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor'}))

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -84,7 +84,7 @@ describe('floating windows', function()
       end
 
 
-      meths.win_config(win,0,0,{relative='editor', row=0, col=10})
+      meths.win_set_config(win,0,0,{relative='editor', row=0, col=10})
       expected_pos[3][4] = 0
       expected_pos[3][5] = 10
       if multigrid then
@@ -329,7 +329,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_config(win, -1, -1, {relative='cursor', row=1, col=-2})
+      meths.win_set_config(win, -1, -1, {relative='cursor', row=1, col=-2})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -370,7 +370,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_config(win, -1, -1, {relative='cursor', row=0, col=0, anchor='SW'})
+      meths.win_set_config(win, -1, -1, {relative='cursor', row=0, col=0, anchor='SW'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -412,7 +412,7 @@ describe('floating windows', function()
       end
 
 
-      meths.win_config(win, -1, -1, {relative='win', win=oldwin, row=1, col=10, anchor='NW'})
+      meths.win_set_config(win, -1, -1, {relative='win', win=oldwin, row=1, col=10, anchor='NW'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -453,7 +453,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_config(win, -1, -1, {relative='win', win=oldwin, row=3, col=39, anchor='SE'})
+      meths.win_set_config(win, -1, -1, {relative='win', win=oldwin, row=3, col=39, anchor='SE'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -494,7 +494,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_config(win, -1, -1, {relative='win', win=0, row=0, col=50, anchor='NE'})
+      meths.win_set_config(win, -1, -1, {relative='win', win=0, row=0, col=50, anchor='NE'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -756,7 +756,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_config(win, -1, 3, {})
+      meths.win_set_config(win, -1, 3, {})
       feed('gg')
       if multigrid then
         screen:expect{grid=[[
@@ -1824,7 +1824,7 @@ describe('floating windows', function()
       end)
 
       it("w with focusable=false", function()
-        meths.win_config(win, -1, -1, {focusable=false})
+        meths.win_set_config(win, -1, -1, {focusable=false})
         expected_pos[3][6] = false
         feed("<c-w>wi") -- i to provoke redraw
         if multigrid then
@@ -2038,7 +2038,7 @@ describe('floating windows', function()
       end)
 
       it("focus by mouse (focusable=false)", function()
-        meths.win_config(win, -1, -1, {focusable=false})
+        meths.win_set_config(win, -1, -1, {focusable=false})
         meths.buf_set_lines(0, -1, -1, true, {"a"})
         expected_pos[3][6] = false
         if multigrid then
@@ -2939,7 +2939,7 @@ describe('floating windows', function()
         end
 
         if multigrid then
-          meths.win_config(0,-1,-1,{external=true})
+          meths.win_set_config(0,-1,-1,{external=true})
           expected_pos = {[3]={external=true}}
           screen:expect{grid=[[
           ## grid 1
@@ -2962,7 +2962,7 @@ describe('floating windows', function()
         ]], float_pos=expected_pos}
         else
           eq({false, "UI doesn't support external windows"},
-             meth_pcall(meths.win_config, 0,-1,-1,{external=true}))
+             meth_pcall(meths.win_set_config, 0,-1,-1,{external=true}))
           return
         end
 
@@ -3228,7 +3228,7 @@ describe('floating windows', function()
 
       it(":tabnew and :tabnext (external)", function()
         if multigrid then
-          meths.win_config(win,-1,-1,{external=true})
+          meths.win_set_config(win,-1,-1,{external=true})
           expected_pos = {[3]={external=true}}
           feed(":tabnew<cr>")
           screen:expect{grid=[[
@@ -3259,7 +3259,7 @@ describe('floating windows', function()
         ]], float_pos=expected_pos}
         else
           eq({false, "UI doesn't support external windows"},
-             meth_pcall(meths.win_config, 0,-1,-1,{external=true}))
+             meth_pcall(meths.win_set_config, 0,-1,-1,{external=true}))
         end
 
         feed(":tabnext<cr>")

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -45,7 +45,7 @@ describe('floating windows', function()
 
     it('can be created and reconfigured', function()
       local buf = meths.create_buf(false,false)
-      local win = meths.open_win(buf, false, 20, 2, {relative='editor', row=2, col=5})
+      local win = meths.open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
       local expected_pos = {
           [3]={{id=1001}, 'NW', 1, 2, 5, true},
       }
@@ -84,7 +84,7 @@ describe('floating windows', function()
       end
 
 
-      meths.win_set_config(win,0,0,{relative='editor', row=0, col=10})
+      meths.win_set_config(win, {relative='editor', row=0, col=10})
       expected_pos[3][4] = 0
       expected_pos[3][5] = 10
       if multigrid then
@@ -156,7 +156,7 @@ describe('floating windows', function()
       command('set number')
       command('hi NormalFloat guibg=#333333')
       feed('ix<cr>y<cr><esc>gg')
-      local win = meths.open_win(0, false, 20, 4, {relative='editor', row=4, col=10})
+      local win = meths.open_win(0, false, {relative='editor', width=20, height=4, row=4, col=10})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -232,17 +232,17 @@ describe('floating windows', function()
     it('API has proper error messages', function()
       local buf = meths.create_buf(false,false)
       eq({false, "Invalid options key 'bork'"},
-         meth_pcall(meths.open_win,buf, false, 20, 2, {bork=true}))
+         meth_pcall(meths.open_win,buf, false, {width=20,height=2,bork=true}))
       eq({false, "'win' option is only valid with relative='win'"},
-         meth_pcall(meths.open_win,buf, false, 20, 2, {relative='editor',row=0,col=0,win=0}))
+         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,win=0}))
       eq({false, "Only one of 'relative' and 'external' should be used"},
-         meth_pcall(meths.open_win,buf, false, 20, 2, {relative='editor',row=0,col=0,external=true}))
+         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,external=true}))
       eq({false, "Invalid value of 'relative' option"},
-         meth_pcall(meths.open_win,buf, false, 20, 2, {relative='shell',row=0,col=0}))
+         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='shell',row=0,col=0}))
       eq({false, "Invalid value of 'anchor' option"},
-         meth_pcall(meths.open_win,buf, false, 20, 2, {relative='editor',row=0,col=0,anchor='bottom'}))
+         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,anchor='bottom'}))
       eq({false, "All of 'relative', 'row', and 'col' has to be specified at once"},
-         meth_pcall(meths.open_win,buf, false, 20, 2, {relative='editor'}))
+         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor'}))
     end)
 
     it('can be placed relative window or cursor', function()
@@ -288,7 +288,7 @@ describe('floating windows', function()
 
       local buf = meths.create_buf(false,false)
       -- no 'win' arg, relative default window
-      local win = meths.open_win(buf, false, 20, 2, {relative='win', row=0, col=10})
+      local win = meths.open_win(buf, false, {relative='win', width=20, height=2, row=0, col=10})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -329,7 +329,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_set_config(win, -1, -1, {relative='cursor', row=1, col=-2})
+      meths.win_set_config(win, {relative='cursor', row=1, col=-2})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -370,7 +370,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_set_config(win, -1, -1, {relative='cursor', row=0, col=0, anchor='SW'})
+      meths.win_set_config(win, {relative='cursor', row=0, col=0, anchor='SW'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -412,7 +412,7 @@ describe('floating windows', function()
       end
 
 
-      meths.win_set_config(win, -1, -1, {relative='win', win=oldwin, row=1, col=10, anchor='NW'})
+      meths.win_set_config(win, {relative='win', win=oldwin, row=1, col=10, anchor='NW'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -453,7 +453,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_set_config(win, -1, -1, {relative='win', win=oldwin, row=3, col=39, anchor='SE'})
+      meths.win_set_config(win, {relative='win', win=oldwin, row=3, col=39, anchor='SE'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -494,7 +494,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_set_config(win, -1, -1, {relative='win', win=0, row=0, col=50, anchor='NE'})
+      meths.win_set_config(win, {relative='win', win=0, row=0, col=50, anchor='NE'})
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -544,7 +544,7 @@ describe('floating windows', function()
         screen2:attach(nil, session2)
         screen2:set_default_attr_ids(attrs)
         local buf = meths.create_buf(false,false)
-        meths.open_win(buf, true, 20, 2, {relative='editor', row=2, col=5})
+        meths.open_win(buf, true, {relative='editor', width=20, height=2, row=2, col=5})
         local expected_pos = {
           [2]={{id=1001}, 'NW', 1, 2, 5}
         }
@@ -577,7 +577,7 @@ describe('floating windows', function()
     it('handles resized screen', function()
       local buf = meths.create_buf(false,false)
       meths.buf_set_lines(buf, 0, -1, true, {'such', 'very', 'float'})
-      local win = meths.open_win(buf, false, 15, 4, {relative='editor', row=2, col=10})
+      local win = meths.open_win(buf, false, {relative='editor', width=15, height=4, row=2, col=10})
       local expected_pos = {
           [4]={{id=1002}, 'NW', 1, 2, 10, true},
       }
@@ -756,7 +756,7 @@ describe('floating windows', function()
         ]])
       end
 
-      meths.win_set_config(win, -1, 3, {})
+      meths.win_set_config(win, {width=0, height=3})
       feed('gg')
       if multigrid then
         screen:expect{grid=[[
@@ -1096,7 +1096,7 @@ describe('floating windows', function()
 
     it('does not crash when set cmdheight #9680', function()
       local buf = meths.create_buf(false,false)
-      meths.open_win(buf, false, 20, 2, {relative='editor', row=2, col=5})
+      meths.open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
       command("set cmdheight=2")
       eq(1, meths.eval('1'))
     end)
@@ -1104,7 +1104,7 @@ describe('floating windows', function()
     describe('and completion', function()
       before_each(function()
         local buf = meths.create_buf(false,false)
-        local win = meths.open_win(buf, true, 12, 4, {relative='editor', row=2, col=5})
+        local win = meths.open_win(buf, true, {relative='editor', width=12, height=4, row=2, col=5})
         meths.win_set_option(win , 'winhl', 'Normal:ErrorMsg')
         if multigrid then
           screen:expect{grid=[[
@@ -1523,7 +1523,7 @@ describe('floating windows', function()
 
         local buf = meths.create_buf(false,true)
         meths.buf_set_lines(buf,0,-1,true,{"some info", "about item"})
-        win = meths.open_win(buf, false, 12, 2, {relative='cursor', row=1, col=10})
+        win = meths.open_win(buf, false, {relative='cursor', width=12, height=2, row=1, col=10})
         if multigrid then
           screen:expect{grid=[[
           ## grid 1
@@ -1714,7 +1714,7 @@ describe('floating windows', function()
         command("set hidden")
         meths.buf_set_lines(0,0,-1,true,{"x"})
         local buf = meths.create_buf(false,false)
-        win = meths.open_win(buf, false, 20, 2, {relative='editor', row=2, col=5})
+        win = meths.open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
         meths.buf_set_lines(buf,0,-1,true,{"y"})
         expected_pos = {
           [3]={{id=1001}, 'NW', 1, 2, 5, true}
@@ -1824,7 +1824,7 @@ describe('floating windows', function()
       end)
 
       it("w with focusable=false", function()
-        meths.win_set_config(win, -1, -1, {focusable=false})
+        meths.win_set_config(win, {focusable=false})
         expected_pos[3][6] = false
         feed("<c-w>wi") -- i to provoke redraw
         if multigrid then
@@ -2038,7 +2038,7 @@ describe('floating windows', function()
       end)
 
       it("focus by mouse (focusable=false)", function()
-        meths.win_set_config(win, -1, -1, {focusable=false})
+        meths.win_set_config(win, {focusable=false})
         meths.buf_set_lines(0, -1, -1, true, {"a"})
         expected_pos[3][6] = false
         if multigrid then
@@ -2939,7 +2939,7 @@ describe('floating windows', function()
         end
 
         if multigrid then
-          meths.win_set_config(0,-1,-1,{external=true})
+          meths.win_set_config(0, {external=true})
           expected_pos = {[3]={external=true}}
           screen:expect{grid=[[
           ## grid 1
@@ -2962,7 +2962,7 @@ describe('floating windows', function()
         ]], float_pos=expected_pos}
         else
           eq({false, "UI doesn't support external windows"},
-             meth_pcall(meths.win_set_config, 0,-1,-1,{external=true}))
+             meth_pcall(meths.win_set_config, 0, {external=true}))
           return
         end
 
@@ -3228,7 +3228,7 @@ describe('floating windows', function()
 
       it(":tabnew and :tabnext (external)", function()
         if multigrid then
-          meths.win_set_config(win,-1,-1,{external=true})
+          meths.win_set_config(win, {external=true})
           expected_pos = {[3]={external=true}}
           feed(":tabnew<cr>")
           screen:expect{grid=[[
@@ -3259,7 +3259,7 @@ describe('floating windows', function()
         ]], float_pos=expected_pos}
         else
           eq({false, "UI doesn't support external windows"},
-             meth_pcall(meths.win_set_config, 0,-1,-1,{external=true}))
+             meth_pcall(meths.win_set_config, 0, {external=true}))
         end
 
         feed(":tabnext<cr>")

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -152,6 +152,13 @@ describe('floating windows', function()
       end
     end)
 
+    it('return their configuration', function()
+      local buf = meths.create_buf(false, false)
+      local win = meths.open_win(buf, false, {relative='editor', width=20, height=2, row=3, col=5})
+      local expected = {anchor='NW', col=5, external=false, focusable=true, height=2, relative='editor', row=3, width=20}
+      eq(expected, meths.win_get_config(win))
+    end)
+
     it('defaults to nonumber and NormalFloat highlight', function()
       command('set number')
       command('hi NormalFloat guibg=#333333')
@@ -243,6 +250,10 @@ describe('floating windows', function()
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,anchor='bottom'}))
       eq({false, "All of 'relative', 'row', and 'col' has to be specified at once"},
          meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor'}))
+      eq({false, "'width' key must be a positive Integer"},
+         meth_pcall(meths.open_win,buf, false, {width=-1,height=2,relative='editor'}))
+      eq({false, "'height' key must be a positive Integer"},
+         meth_pcall(meths.open_win,buf, false, {width=20,height=-1,relative='editor'}))
     end)
 
     it('can be placed relative window or cursor', function()


### PR DESCRIPTION
- Rename `nvim_win_config()` to `nvim_win_set_config()`.
- `width` and `height` are now of part of the floating window configuration itself, so they get removed as arguments from `nvim_open_win()` and `nvim_win_set_config()`.
- Add `nvim_win_get_config()`. It returns `relative: ''` when used on a normal window, which can be used for testing for floatness.

Closes https://github.com/neovim/neovim/issues/9723
