### PR TITLE
vim-patch:8.1.0019

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6328,8 +6328,12 @@ call_func(
   }
 
 
-  /* execute the function if no errors detected and executing */
-  if (evaluate && error == ERROR_NONE) {
+  // Execute the function if executing and no errors were detected.
+  if (!evaluate) {
+    // Not evaluating, which means the return value is unknown.  This
+    // matters for giving error messages.
+    rettv->v_type = VAR_UNKNOWN;
+  } else if (error == ERROR_NONE) {
     char_u *rfname = fname;
 
     /* Ignore "g:" before a function name. */

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -291,3 +291,9 @@ func Test_named_function_closure()
   call garbagecollect()
   call assert_equal(14, s:Abar())
 endfunc
+
+func Test_lambda_with_index()
+  let List = {x -> [x]}
+  let Extract = {-> function(List, ['foobar'])()[0]}
+  call assert_equal('foobar', Extract())
+endfunc

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -47,6 +47,9 @@ func Test_repeat_many()
   call timer_stopall()
   let g:val = 0
   let timer = timer_start(50, 'MyHandler', {'repeat': -1})
+  if has('mac')
+    sleep 200m
+  endif
   sleep 200m
   call timer_stop(timer)
   call assert_inrange((has('mac') ? 1 : 2), 4, g:val)


### PR DESCRIPTION
**vim-patch:8.1.0019: error when defining a Lambda with index of a function result**

Problem:    Error when defining a Lambda with index of a function result.
Solution:   When not evaluating an expression and skipping a function call,
            set the return value to VAR_UNKNOWN.
https://github.com/vim/vim/commit/b4518563c73460150344a57879bf5b22cb8b1c77