### PR TITLE
fix(Copy): always copy text as plain text in Wayland

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -73,9 +73,9 @@ function! provider#clipboard#Executable() abort
     let s:cache_enabled = 0
     return 'pbcopy'
   elseif exists('$WAYLAND_DISPLAY') && executable('wl-copy') && executable('wl-paste')
-    let s:copy['+'] = 'wl-copy --foreground'
+    let s:copy['+'] = 'wl-copy --foreground --type text/plain'
     let s:paste['+'] = 'wl-paste --no-newline'
-    let s:copy['*'] = 'wl-copy --foreground --primary'
+    let s:copy['*'] = 'wl-copy --foreground --primary --type text/plain'
     let s:paste['*'] = 'wl-paste --no-newline --primary'
     return 'wl-copy'
   elseif exists('$DISPLAY') && executable('xclip')


### PR DESCRIPTION
`wl-copy` by default tries to determine the mime type of a copied bit of text. From the [readme](https://github.com/bugaevc/wl-clipboard):

>wl-copy automatically infers the type of the copied content by running xdg-mime(1) on it. 

I was recently trying to copy a Ruby script from Neovim and paste it into a GitHub Gist inside Firefox. While the copied text was indeed in my clipboard, Firefox refused to paste it because the mime type was `application/x-ruby`. 

This is a small reproduction without Neovim involved:

```bash
$ cat test.rb
#!/usr/bin/env ruby
puts 'hello world'
$ cat test.rb | wl-copy
$ wl-paste --list-types
application/x-ruby
```

This PR fixes that by telling wl-copy that all text copied from Neovim has the mime type `text/plain`.

```bash
$ cat test.rb | wl-copy --type text/plain
$ wl-paste --list-types
text/plain;charset=utf-8
```