### PR TITLE
vim-patch:8.1.1011

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -710,9 +710,6 @@ open_line (
         less_cols_off++;
       }
     }
-    if (*p_extra != NUL) {
-      did_ai = false;               // append some text, don't truncate now
-    }
 
     /* columns for marks adjusted for removed columns */
     less_cols = (int)(p_extra - saved_line);

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -402,8 +402,19 @@ func! Test_edit_13()
     call feedkeys("A {\<cr>more\<cr>}\<esc>", 'tnix')
     call assert_equal(["\tabc {", "\t\tmore", "\t}"], getline(1, '$'))
     set smartindent& autoindent&
-    bw!
+    bwipe!
   endif
+
+  " Test autoindent removing indent of blank line.
+  new
+  call setline(1, '    foo bar baz')
+  set autoindent
+  exe "normal 0eea\<CR>\<CR>\<Esc>"
+  call assert_equal("    foo bar", getline(1))
+  call assert_equal("", getline(2))
+  call assert_equal("    baz", getline(3))
+  set autoindent&
+  bwipe!
 endfunc
 
 func! Test_edit_CR()


### PR DESCRIPTION
**vim-patch:8.1.1011: indent from autoindent not removed from blank line**

Problem:    Indent from autoindent not removed from blank line. (Daniel Hahler)
Solution:   Do not reset did_ai when text follows. (closes vim/vim#4119)
https://github.com/vim/vim/commit/2ba4238818ca5ea52334de3037ef3729584cebf5