### PR TITLE
vim-patch:8.1.0048

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1777,9 +1777,12 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len,
 #define PARSE_NUMBER(base, cond, conv) \
   do { \
     while (!STRING_ENDED(ptr) && (cond)) { \
+      const uvarnumber_T digit = (uvarnumber_T)(conv); \
       /* avoid ubsan error for overflow */ \
-      if (un < UVARNUMBER_MAX / base) { \
-        un = base * un + (uvarnumber_T)(conv); \
+      if (un < UVARNUMBER_MAX / base \
+          || (un == UVARNUMBER_MAX / base \
+              && (base != 10 || digit <= UVARNUMBER_MAX % 10))) { \
+        un = base * un + digit; \
       } else { \
         un = UVARNUMBER_MAX; \
       } \


### PR DESCRIPTION
vim-patch:8.1.0048: vim_str2nr() does not handle numbers close to the maximum

Problem:    vim_str2nr() does not handle numbers close to the maximum.
Solution:   Check for overflow more precisely. (Ken Takata, closes vim/vim#2746)
https://github.com/vim/vim/commit/07ccf7ce7fb948fd4d080b817e9fbaea9e721dab