### PR TITLE
[RFC] Fix bug where empty $HOME breaks init_homedir().

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -300,6 +300,14 @@ void init_homedir(void)
 #endif
     homedir = xstrdup(var);
   }
+  else {
+    size_t maxpathl = MAXPATHL;
+    if (uv_os_homedir((char *)IObuff, &maxpathl)) {
+      var = (char *) IObuff;
+      homedir = xstrdup(var);
+      os_setenv("HOME", var, 0);
+    }
+  }
 }
 
 #if defined(EXITFREE)

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -302,10 +302,14 @@ void init_homedir(void)
   }
   else {
     size_t maxpathl = MAXPATHL;
-    if (uv_os_homedir((char *)IObuff, &maxpathl)) {
+    int ret_value = uv_os_homedir((char *)IObuff, &maxpathl);
+    if (ret_value == 0) {
       var = (char *) IObuff;
       homedir = xstrdup(var);
       os_setenv("HOME", var, 0);
+    }
+    else {
+      ELOG("uv_os_homedir failed: %d: %s", ret_value, os_strerror(ret_value));
     }
   }
 }

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -300,6 +300,19 @@ void init_homedir(void)
 #endif
     homedir = xstrdup(var);
   }
+  else {
+    size_t maxpathl = MAXPATHL;
+    int ret_value = uv_os_homedir((char *)IObuff, &maxpathl);
+    if (ret_value == 0) {
+      var = (char *)IObuff;
+      homedir = xstrdup(var);
+      os_setenv("HOME", var, 1);
+    }
+    else {
+      ELOG("uv_os_homedir failed: %d: %s", ret_value, os_strerror(ret_value));
+      emsgf("E00: uv_os_homedir failed: %d: %s", ret_value, os_strerror(ret_value));
+    }
+  }
 }
 
 #if defined(EXITFREE)


### PR DESCRIPTION
This is a pull request which finishes the pull request (#8641 and #8643) made by tomeaton17
Here I use `uv_os_homedir()` to get `$HOME` for the current process. I don't use any new buffer for passing as an argument in `uv_os_homedir()`, but I do create a local variable for storing `MAXPATHL`. I also set the `HOME` env variable to the return value of `uv_os_homedir()`.

All the tests are passing.

Fixes the issue #8614