### PR TITLE
cmdline: revert <down> and <up> mappings for wildoptions=pum

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -609,13 +609,6 @@ static int command_line_execute(VimState *state, int key)
     } else if (s->c == K_RIGHT) {
       s->c = Ctrl_N;
     }
-    if (compl_match_array) {
-      if (s->c == K_UP) {
-        s->c = Ctrl_P;
-      } else if (s->c == K_DOWN) {
-        s->c = Ctrl_N;
-      }
-    }
   }
 
   // Hitting CR after "emenu Name.": complete submenu


### PR DESCRIPTION
These confict with navigation mappings.  Better leave them to the user to reverse them for now for users that want it.