### PR TITLE
vim-patch:8.1.0858

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -56,12 +56,13 @@ typing certain characters or commands in certain contexts.  Note that this not
 only triggers C-indenting.  When 'indentexpr' is not empty 'indentkeys' is
 used instead.  The format of 'cinkeys' and 'indentkeys' is equal.
 
-The default is "0{,0},0),:,0#,!^F,o,O,e" which specifies that indenting occurs
-as follows:
+The default is "0{,0},0),0],:,0#,!^F,o,O,e" which specifies that indenting
+occurs as follows:
 
 	"0{"	if you type '{' as the first character in a line
 	"0}"	if you type '}' as the first character in a line
 	"0)"	if you type ')' as the first character in a line
+	"0]"	if you type ']' as the first character in a line
 	":"	if you type ':' after a label or case statement
 	"0#"	if you type '#' as the first character in a line
 	"!^F"	if you type CTRL-F (which is not inserted)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1214,7 +1214,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option is not used when 'paste' is set.
 
 							*'cinkeys'* *'cink'*
-'cinkeys' 'cink'	string	(default "0{,0},0),:,0#,!^F,o,O,e")
+'cinkeys' 'cink'	string	(default "0{,0},0),0],:,0#,!^F,o,O,e")
 			local to buffer
 	A list of keys that, when typed in Insert mode, cause reindenting of
 	the current line.  Only used if 'cindent' is on and 'indentexpr' is
@@ -3265,7 +3265,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 
 						*'indentkeys'* *'indk'*
-'indentkeys' 'indk'	string	(default "0{,0},:,0#,!^F,o,O,e")
+'indentkeys' 'indk'	string	(default "0{,0},0),0],:,0#,!^F,o,O,e")
 			local to buffer
 	A list of keys that, when typed in Insert mode, cause reindenting of
 	the current line.  Only happens if 'indentexpr' isn't empty.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -44,6 +44,8 @@ local N_=function(s)
     return 'N_(' .. cstr(s) .. ')'
   end
 end
+-- used for 'cinkeys' and 'indentkeys'
+local indentkeys_default = '0{,0},0),0],:,0#,!^F,o,O,e';
 return {
   cstr=cstr,
   options={
@@ -319,7 +321,7 @@ return {
       vi_def=true,
       alloced=true,
       varname='p_cink',
-      defaults={if_true={vi="0{,0},0),:,0#,!^F,o,O,e"}}
+      defaults={if_true={vi=indentkeys_default}}
     },
     {
       full_name='cinoptions', abbreviation='cino',
@@ -1218,7 +1220,7 @@ return {
       vi_def=true,
       alloced=true,
       varname='p_indk',
-      defaults={if_true={vi="0{,0},:,0#,!^F,o,O,e"}}
+      defaults={if_true={vi=indentkeys_default}}
     },
     {
       full_name='infercase', abbreviation='inf',

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -52,7 +52,7 @@ func Test_repeat_many()
   endif
   sleep 200m
   call timer_stop(timer)
-  call assert_inrange((has('mac') ? 1 : 2), 4, g:val)
+  call s:assert_inrange((has('mac') ? 1 : 2), 4, g:val)
 endfunc
 
 func Test_with_partial_callback()


### PR DESCRIPTION
**vim-patch:8.1.0858: 'indentkeys' and 'cinkeys' defaults are different**

Problem:    'indentkeys' and 'cinkeys' defaults are different.
Solution:   Make them the same, update docs. (close vim/vim#3882)
https://github.com/vim/vim/commit/ce655743ba5c56c00769e57e6a6608c0088211ab