### PR TITLE
build/Makefile: pass CMAKE_INSTALL_PREFIX explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ filter-true = $(strip $(filter-out 1 on ON true TRUE,$1))
 
 CMAKE_PRG ?= $(shell (command -v cmake3 || echo cmake))
 CMAKE_BUILD_TYPE ?= Debug
-CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
 # Extra CMake flags which extend the default set
 CMAKE_EXTRA_FLAGS ?=
 
@@ -16,6 +15,7 @@ CMAKE_EXTRA_FLAGS ?=
 #   - `checkprefix` target checks that it matches the CMake-cached value. #9615
 CMAKE_INSTALL_PREFIX ?= $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
 
 BUILD_TYPE ?= $(shell (type ninja > /dev/null 2>&1 && echo "Ninja") || \
     echo "Unix Makefiles")
@@ -166,7 +166,7 @@ appimage-%:
 lint: check-single-includes clint testlint lualint
 
 checkprefix:
-	@cached_prefix=$$($(CMAKE_PRG) -L -N build | 2>/dev/null grep 'CMAKE_INSTALL_PREFIX' | cut -d '=' -f2); \
+	@cached_prefix=$$("$(CMAKE_PRG)" -L -N build | 2>/dev/null grep 'CMAKE_INSTALL_PREFIX' | cut -d '=' -f2); \
 	if [ -n "$(CMAKE_INSTALL_PREFIX)" ] && [ -n "$$cached_prefix" ] && ! [ "$(CMAKE_INSTALL_PREFIX)" = "$$cached_prefix" ]; then \
 		printf "\nerror: CMAKE_INSTALL_PREFIX '$(CMAKE_INSTALL_PREFIX)' does not match cached value '%s'\n" "$$cached_prefix"; \
 		printf "       Run this command, then try again:\n"; \


### PR DESCRIPTION
On some systems this happens implicitly.

fixes #9743