### PR TITLE
vim-patch:8.1.{771,775,1017}

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1,7 +1,7 @@
 " Vim functions for file type detection
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2017 Dec 05
+" Last Change:	2019 Jan 18
 
 " These functions are moved here from runtime/filetype.vim to make startup
 " faster.
@@ -484,6 +484,10 @@ endfunc
 
 " Called from filetype.vim and scripts.vim.
 func dist#ft#SetFileTypeSH(name)
+  if did_filetype()
+    " Filetype was already detected
+    return
+  endif
   if expand("<amatch>") =~ g:ft_ignore_pat
     return
   endif
@@ -531,6 +535,10 @@ endfunc
 " as used for Tcl.
 " Also called from scripts.vim, thus can't be local to this script.
 func dist#ft#SetFileTypeShell(name)
+  if did_filetype()
+    " Filetype was already detected
+    return
+  endif
   if expand("<amatch>") =~ g:ft_ignore_pat
     return
   endif
@@ -551,6 +559,10 @@ func dist#ft#SetFileTypeShell(name)
 endfunc
 
 func dist#ft#CSH()
+  if did_filetype()
+    " Filetype was already detected
+    return
+  endif
   if exists("g:filetype_csh")
     call dist#ft#SetFileTypeShell(g:filetype_csh)
   elseif &shell =~ "tcsh"

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -197,7 +197,7 @@ func dist#ft#FTe()
     exe 'setf ' . g:filetype_euphoria
   else
     let n = 1
-    while n < 100 && n < line("$")
+    while n < 100 && n <= line("$")
       if getline(n) =~ "^\\s*\\(<'\\|'>\\)\\s*$"
 	setf specman
 	return
@@ -211,7 +211,7 @@ endfunc
 " Distinguish between HTML, XHTML and Django
 func dist#ft#FThtml()
   let n = 1
-  while n < 10 && n < line("$")
+  while n < 10 && n <= line("$")
     if getline(n) =~ '\<DTD\s\+XHTML\s'
       setf xhtml
       return
@@ -222,13 +222,13 @@ func dist#ft#FThtml()
     endif
     let n = n + 1
   endwhile
-  setf html
+  setf FALLBACK html
 endfunc
 
 " Distinguish between standard IDL and MS-IDL
 func dist#ft#FTidl()
   let n = 1
-  while n < 50 && n < line("$")
+  while n < 50 && n <= line("$")
     if getline(n) =~ '^\s*import\s\+"\(unknwn\|objidl\)\.idl"'
       setf msidl
       return
@@ -687,7 +687,7 @@ endfunc
 
 func dist#ft#FTxml()
   let n = 1
-  while n < 100 && n < line("$")
+  while n < 100 && n <= line("$")
     let line = getline(n)
     " DocBook 4 or DocBook 5.
     let is_docbook4 = line =~ '<!DOCTYPE.*DocBook'
@@ -713,7 +713,7 @@ endfunc
 
 func dist#ft#FTy()
   let n = 1
-  while n < 100 && n < line("$")
+  while n < 100 && n <= line("$")
     let line = getline(n)
     if line =~ '^\s*%'
       setf yacc

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1472,15 +1472,16 @@ au BufNewFile,BufRead *.install
 	\   call dist#ft#SetFileTypeSH("bash") |
 	\ endif
 
-" tcsh scripts
+" tcsh scripts (patterns ending in a star further below)
 au BufNewFile,BufRead .tcshrc,*.tcsh,tcsh.tcshrc,tcsh.login	call dist#ft#SetFileTypeShell("tcsh")
 
 " csh scripts, but might also be tcsh scripts (on some systems csh is tcsh)
+" (patterns ending in a start further below)
 au BufNewFile,BufRead .login,.cshrc,csh.cshrc,csh.login,csh.logout,*.csh,.alias  call dist#ft#CSH()
 
-" Z-Shell script
+" Z-Shell script (patterns ending in a star further below)
 au BufNewFile,BufRead .zprofile,*/etc/zprofile,.zfbfmarks  setf zsh
-au BufNewFile,BufRead .zsh,.zlog,.zcompdump  	call s:StarSetf('zsh')
+au BufNewFile,BufRead .zshrc,.zshenv,.zlogin,.zlogout,.zcompdump setf zsh
 au BufNewFile,BufRead *.zsh			setf zsh
 
 " Scheme
@@ -2086,9 +2087,6 @@ au BufNewFile,BufRead .tcshrc*	call dist#ft#SetFileTypeShell("tcsh")
 " csh scripts ending in a star
 au BufNewFile,BufRead .login*,.cshrc*  call dist#ft#CSH()
 
-" Z-Shell script ending in a star
-au BufNewFile,BufRead .zsh*,.zlog*,.zcompdump*  call s:StarSetf('zsh')
-
 " Vim script
 au BufNewFile,BufRead *vimrc*			call s:StarSetf('vim')
 
@@ -2116,7 +2114,8 @@ au BufNewFile,BufRead */etc/xinetd.d/*		call s:StarSetf('xinetd')
 " yum conf (close enough to dosini)
 au BufNewFile,BufRead */etc/yum.repos.d/*	call s:StarSetf('dosini')
 
-" Z-Shell script
+" Z-Shell script ending in a star
+au BufNewFile,BufRead .zsh*,.zlog*,.zcompdump*  call s:StarSetf('zsh')
 au BufNewFile,BufRead zsh*,zlog*		call s:StarSetf('zsh')
 
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1458,9 +1458,11 @@ au BufNewFile,BufRead sgml.catalog*		call s:StarSetf('catalog')
 
 " Shell scripts (sh, ksh, bash, bash2, csh); Allow .profile_foo etc.
 " Gentoo ebuilds and Arch Linux PKGBUILDs are actually bash scripts
-au BufNewFile,BufRead .bashrc*,bashrc,bash.bashrc,.bash[_-]profile*,.bash[_-]logout*,.bash[_-]aliases*,bash-fc[-.]*,*.bash,*/{,.}bash[_-]completion{,.d,.sh}{,/*},*.ebuild,*.eclass,PKGBUILD* call dist#ft#SetFileTypeSH("bash")
-au BufNewFile,BufRead .kshrc*,*.ksh call dist#ft#SetFileTypeSH("ksh")
-au BufNewFile,BufRead */etc/profile,.profile*,*.sh,*.env call dist#ft#SetFileTypeSH(getline(1))
+" NOTE: Patterns ending in a star are further down, these have lower priority.
+au BufNewFile,BufRead .bashrc,bashrc,bash.bashrc,.bash[_-]profile,.bash[_-]logout,.bash[_-]aliases,bash-fc[-.],*.bash,*/{,.}bash[_-]completion{,.d,.sh}{,/*},*.ebuild,*.eclass,PKGBUILD call dist#ft#SetFileTypeSH("bash")
+au BufNewFile,BufRead .kshrc,*.ksh call dist#ft#SetFileTypeSH("ksh")
+au BufNewFile,BufRead */etc/profile,.profile,*.sh,*.env call dist#ft#SetFileTypeSH(getline(1))
+
 
 " Shell script (Arch Linux) or PHP file (Drupal)
 au BufNewFile,BufRead *.install
@@ -1471,14 +1473,14 @@ au BufNewFile,BufRead *.install
 	\ endif
 
 " tcsh scripts
-au BufNewFile,BufRead .tcshrc*,*.tcsh,tcsh.tcshrc,tcsh.login	call dist#ft#SetFileTypeShell("tcsh")
+au BufNewFile,BufRead .tcshrc,*.tcsh,tcsh.tcshrc,tcsh.login	call dist#ft#SetFileTypeShell("tcsh")
 
 " csh scripts, but might also be tcsh scripts (on some systems csh is tcsh)
-au BufNewFile,BufRead .login*,.cshrc*,csh.cshrc,csh.login,csh.logout,*.csh,.alias  call dist#ft#CSH()
+au BufNewFile,BufRead .login,.cshrc,csh.cshrc,csh.login,csh.logout,*.csh,.alias  call dist#ft#CSH()
 
 " Z-Shell script
 au BufNewFile,BufRead .zprofile,*/etc/zprofile,.zfbfmarks  setf zsh
-au BufNewFile,BufRead .zsh*,.zlog*,.zcompdump*  call s:StarSetf('zsh')
+au BufNewFile,BufRead .zsh,.zlog,.zcompdump  	call s:StarSetf('zsh')
 au BufNewFile,BufRead *.zsh			setf zsh
 
 " Scheme
@@ -2072,6 +2074,20 @@ au BufRead,BufNewFile *.rdf			call dist#ft#Redif()
 
 " Remind
 au BufNewFile,BufRead .reminders*		call s:StarSetf('remind')
+
+" Shell scripts ending in a star
+au BufNewFile,BufRead .bashrc*,.bash[_-]profile*,.bash[_-]logout*,.bash[_-]aliases*,bash-fc[-.]*,,PKGBUILD* call dist#ft#SetFileTypeSH("bash")
+au BufNewFile,BufRead .kshrc* call dist#ft#SetFileTypeSH("ksh")
+au BufNewFile,BufRead .profile* call dist#ft#SetFileTypeSH(getline(1))
+
+" tcsh scripts ending in a star
+au BufNewFile,BufRead .tcshrc*	call dist#ft#SetFileTypeShell("tcsh")
+
+" csh scripts ending in a star
+au BufNewFile,BufRead .login*,.cshrc*  call dist#ft#CSH()
+
+" Z-Shell script ending in a star
+au BufNewFile,BufRead .zsh*,.zlog*,.zcompdump*  call s:StarSetf('zsh')
 
 " Vim script
 au BufNewFile,BufRead *vimrc*			call s:StarSetf('vim')


### PR DESCRIPTION
**vim-patch:8.1.0771: some shell filetype patterns end in a star**
Problem:    Some shell filetype patterns end in a star.
Solution:   Make sure that patterns not ending in a star are preferred.
https://github.com/vim/vim/commit/147e7d0caba8b66ff11622e514142bcc3d24403a

**vim-patch:8.1.0775: matching too many files as zsh**
Problem:    Matching too many files as zsh. (Danek Duvall)
Solution:   Be more specific with zsh filetype patterns.
https://github.com/vim/vim/commit/2bf60b300188a7a733408a21a9716362ef4e2c44

**vim-patch:8.1.1017: off-by-one error in filetype detection**
Problem:    Off-by-one error in filetype detection.
Solution:   Also check the last line of the file.
https://github.com/vim/vim/commit/493fbe4abee660d30b4f2aef87b754b0a720213c