### PR TITLE
[RFC] doc: Fix english and formatting in api.txt.

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -246,8 +246,8 @@ functional buffer windows and support user editing. They support the standard
 
 Floating windows are created either by |nvim_open_win()| to open a new window,
 or |nvim_win_set_config()| to reconfigure a normal window into a float.
-Currently the position can either be grid coordinates relative the top-left of
-some window, or a position relative to the current window cursor.  The
+Currently the position can either be grid coordinates relative to the top-left
+of some window, or a position relative to the current window cursor.  The
 parameters for positioning are described in detail at |nvim_open_win()|.
 
 |nvim_open_win()| assumes an existing buffer to display in the window. To create
@@ -643,12 +643,12 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                     {buffer}   handle of buffer to be displayed in the window
                     {enter}    whether the window should be entered (made the
                                current window)
-                    {config}   dictionary for the window configuration accepts
+                    {config}   Dictionary for the window configuration accepts
                                these keys:
 
                         `relative`: If set, the window becomes a
                         floating window. The window will be placed with
-                        row,col coordinates relative one of the
+                        row,col coordinates relative to one of the
                         following:
                             "editor" the global editor grid
                             "win"    a window. Use `win` to specify window id,
@@ -863,12 +863,31 @@ nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
 
                 Return: ~
                     a Dictionary, describing a channel with the following
-                    keys:   "stream" the stream underlying the channel
-                    "stdio" stdin and stdout of this Nvim instance  "stderr"
-                    stderr of this Nvim instance  "socket" TCP/IP socket or
-                    named pipe  "job" job with communication over its stdio
+                    keys:
 
-                  "mode" how data received on the channel is interpreted   "bytes" send and recieve raw bytes  "terminal" a |terminal| instance interprets ASCII sequences  "rpc" |RPC| communication on the channel is active  "pty" Name of pseudoterminal, if one is used (optional). On a POSIX system, this will be a device path like /dev/pts/1. Even if the name is unknown, the key will still be present to indicate a pty is used. This is currently the case when using winpty on windows.  "buffer" buffer with connected |terminal| instance (optional)  "client" information about the client on the other end of the RPC channel, if it has added it using |nvim_set_client_info()|. (optional)
+                    `stream`: the stream underlying the channel:
+                        "stdio"   stdin and stdout of this Nvim instance.
+                        "stderr"  stderr of this Nvim instance.
+                        "socket"  TCP/IP socket or named pipe.
+                        "job"     job with communication over its stdio.
+
+                    `mode`: how data received on the channel is interpreted:
+                        "bytes"    send and recieve raw bytes.
+                        "terminal" a |terminal| instance interprets ASCII sequences
+                        "rpc"      |RPC| communication on the channel is active
+
+                    `pty`: Name of pseudoterminal, if one is used (optional).
+                    On a POSIX system, this will be a device path like
+                    /dev/pts/1. Even if the name is unknown, the key will
+                    still be present to indicate a pty is used. This is
+                    currently the case when using winpty on windows.
+
+                    `buffer`: buffer with connected |terminal|
+                    instance (optional).
+
+                    `client`: information about the client on the other end of
+                    the RPC channel, if it has added it using
+                    |nvim_set_client_info()| (optional).
 
 nvim_list_chans()                                          *nvim_list_chans()*
                 Get information about all open channels.
@@ -881,7 +900,13 @@ nvim_call_atomic({calls})                                 *nvim_call_atomic()*
                 Calls many API methods atomically.
 
                 This has two main usages:
-                  To perform several requests from an async context atomically, i.e. without interleaving redraws, RPC requests from other clients, or user interactions (however API methods may trigger autocommands or event processing which have such side-effects, e.g. |:sleep| may wake timers).  To minimize RPC overhead (roundtrips) of a sequence of many requests.
+                1. To perform several requests from an async context
+                atomically, i.e. without interleaving redraws, RPC requests
+                from other clients, or user interactions (however API methods
+                may trigger autocommands or event processing which have such
+                side-effects, e.g. |:sleep| may wake timers).
+                2. To minimize RPC overhead (roundtrips) of a sequence of many
+                requests.
 
                 Parameters: ~
                     {calls}  an array of calls, where each call is described
@@ -1033,9 +1058,14 @@ nvim_list_uis()                                              *nvim_list_uis()*
                 Gets a list of dictionaries representing attached UIs.
 
                 Return: ~
-                    Array of UI dictionaries
-                Each dictionary has the following keys:
-                  "height" requested height of the UI  "width" requested width of the UI  "rgb" whether the UI uses rgb colors (false implies cterm colors)  "ext_..." Requested UI extensions, see |ui-options|  "chan" Channel id of remote UI (not present for TUI)
+                    Array of UI dictionaries. Each dictionary has the
+                    following keys:
+                        `height`:  requested height of the UI
+                        `width`:   requested width of the UI
+                        `rgb`:     whether the UI uses rgb colors
+                                   (false implies cterm colors)
+                        `ext_...`: Requested UI extensions, see |ui-options|
+                        `chan`:    Channel id of remote UI (not present for TUI)
 
 nvim_get_proc_children({pid})                       *nvim_get_proc_children()*
                 Gets the immediate children of process `pid`.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1004,10 +1004,10 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///
 /// @param buffer handle of buffer to be displayed in the window
 /// @param enter  whether the window should be entered (made the current window)
-/// @param config dictionary for the window configuration accepts these keys:
+/// @param config Dictionary for the window configuration accepts these keys:
 ///
 ///     `relative`: If set, the window becomes a floating window. The window
-///         will be placed with row,col coordinates relative one of the
+///         will be placed with row,col coordinates relative to one of the
 ///         following:
 ///        "editor" the global editor grid
 ///        "win"    a window. Use `win` to specify a window id,


### PR DESCRIPTION
Fixed some formatting that was broken in api.txt. I noticed that the documentation for `nvim_open_win` was formatted quite well and the documentation for a few other functions was messed up so I formatted the other ones in the same spirit as `nvim_open_win`. Didn't change any content except for adding some missing prepositions.

I inadvertently fixed the same problems as #9750.