### PR TITLE
Make session restoration compatible with tab-local working directories

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9130,6 +9130,7 @@ makeopens(
           || put_eol(fd) == FAIL) {
         return FAIL;
       }
+      did_lcd = true;
     }
 
     /* Don't continue in another tab page when doing only the current one

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -64,7 +64,8 @@ describe(':mksession', function()
     -- Create a new test instance of Nvim.
     clear()
 
-    command('source ' .. session_path)
+    -- Use :silent to avoid press-enter prompt due to long path
+    command('silent source ' .. session_path)
     command('tabnext 1')
     eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '1', eval("fnamemodify(bufname('%'), ':p')"))
     command('tabnext 2')

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -7,7 +7,6 @@ local get_pathsep = helpers.get_pathsep
 local eq = helpers.eq
 local funcs = helpers.funcs
 local rmdir = helpers.rmdir
-local eval = helpers.eval
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
@@ -67,8 +66,8 @@ describe(':mksession', function()
     -- Use :silent to avoid press-enter prompt due to long path
     command('silent source ' .. session_path)
     command('tabnext 1')
-    eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '1', eval("fnamemodify(bufname('%'), ':p')"))
+    eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '1', funcs.expand('%:p'))
     command('tabnext 2')
-    eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', eval("fnamemodify(bufname('%'), ':p')"))
+    eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', funcs.expand('%:p'))
   end)
 end)


### PR DESCRIPTION
Fixes #9753

The implementation here is pretty quick-n-dirty. Basically, when writing a session file, there's a flag that is set to `false` initially called `did_lcd`, and gets flipped to `true` if any `:lcd` command is written to the session file. The flag is read when writing any file path out to the session file to determine if a "short path" should be written or not:

https://github.com/neovim/neovim/blob/291d7d75223c3aa2334fc780de50a7dc0565d0c3/src/nvim/ex_docmd.c#L9579-L9589

The proposed change abuses the same flag for whenever a `:tcd` command is written to the session file, guaranteeing that we write out correct paths after that command.

A more elegant solution might be to use a new flag (`did_tcd`) or rename the flag (`did_lcd_or_tcd`). I'm open to collaborating on another solution if the proposed one is too janky.