### PR TITLE
vim-patch:8.1.{0849,1001}: 'cursorline' highlight

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2377,27 +2377,30 @@ win_line (
     filler_lines = wp->w_topfill;
   filler_todo = filler_lines;
 
-  // Cursor line highlighting for 'cursorline' in the current window.  Not
-  // when Visual mode is active, because it's not clear what is selected
-  // then.
-  if (wp->w_p_cul && lnum == wp->w_cursor.lnum
-      && !(wp == curwin && VIsual_active)) {
-    int cul_attr = win_hl_attr(wp, HLF_CUL);
-    HlAttrs ae = syn_attr2entry(cul_attr);
+  // Cursor line highlighting for 'cursorline' in the current window.
+  if (wp->w_p_cul && lnum == wp->w_cursor.lnum) {
+    // Do not show the cursor line when Visual mode is active, because it's
+    // not clear what is selected then.
+    if (!(wp == curwin && VIsual_active)) {
+      int cul_attr = win_hl_attr(wp, HLF_CUL);
+      HlAttrs ae = syn_attr2entry(cul_attr);
 
-    // We make a compromise here (#7383):
-    //  * low-priority CursorLine if fg is not set
-    //  * high-priority ("same as Vim" priority) CursorLine if fg is set
-    if (ae.rgb_fg_color == -1 && ae.cterm_fg_color == 0) {
-      line_attr_lowprio = cul_attr;
-    } else {
-      if (!(State & INSERT) && bt_quickfix(wp->w_buffer)
-          && qf_current_entry(wp) == lnum) {
-        line_attr = hl_combine_attr(cul_attr, line_attr);
+      // We make a compromise here (#7383):
+      //  * low-priority CursorLine if fg is not set
+      //  * high-priority ("same as Vim" priority) CursorLine if fg is set
+      if (ae.rgb_fg_color == -1 && ae.cterm_fg_color == 0) {
+        line_attr_lowprio = cul_attr;
       } else {
-        line_attr = cul_attr;
+        if (!(State & INSERT) && bt_quickfix(wp->w_buffer)
+            && qf_current_entry(wp) == lnum) {
+          line_attr = hl_combine_attr(cul_attr, line_attr);
+        } else {
+          line_attr = cul_attr;
+        }
       }
     }
+    // Update w_last_cursorline even if Visual mode is active.
+    wp->w_last_cursorline = wp->w_cursor.lnum;
   }
 
   // If this line has a sign with line highlighting set line_attr.

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -129,10 +129,6 @@ func Test_highlight_eol_with_cursorline()
 endfunc
 
 func Test_highlight_eol_with_cursorline_vertsplit()
-  if !has('vertsplit')
-    return
-  endif
-
   let [hiCursorLine, hi_ul, hi_bg] = HiCursorLine()
 
   call NewWindow('topleft 5', 5)
@@ -532,4 +528,46 @@ func Test_termguicolors()
   redraw
   set t_Co=0
   redraw
+endfunc
+
+func Test_cursorline_after_yank()
+  if !CanRunVimInTerminal()
+    return
+  endif
+
+  call writefile([
+	\ 'set cul rnu',
+	\ 'call setline(1, ["","1","2","3",""])',
+	\ ], 'Xtest_cursorline_yank')
+  let buf = RunVimInTerminal('-S Xtest_cursorline_yank', {'rows': 8})
+  call term_wait(buf)
+  call term_sendkeys(buf, "Gy3k")
+  call term_wait(buf)
+  call term_sendkeys(buf, "jj")
+
+  call VerifyScreenDump(buf, 'Test_cursorline_yank_01', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_cursorline_yank')
+endfunc
+
+func Test_cursorline_with_visualmode()
+  if !CanRunVimInTerminal()
+    return
+  endif
+
+  call writefile([
+	\ 'set cul',
+	\ 'call setline(1, repeat(["abc"], 50))',
+	\ ], 'Xtest_cursorline_with_visualmode')
+  let buf = RunVimInTerminal('-S Xtest_cursorline_with_visualmode', {'rows': 12})
+  call term_wait(buf)
+  call term_sendkeys(buf, "V\<C-f>kkkjk")
+
+  call VerifyScreenDump(buf, 'Test_cursorline_with_visualmode_01', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_cursorline_with_visualmode')
 endfunc

--- a/test/functional/example_spec.lua
+++ b/test/functional/example_spec.lua
@@ -17,7 +17,7 @@ describe('example', function()
     } )
   end)
 
-  it("works with buffer switch and 'hidden'", function()
+  it('screen test', function()
     -- Do some stuff.
     feed('iline1<cr>line2<esc>')
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -748,6 +748,66 @@ describe('CursorLine highlight', function()
     ]])
   end)
 
+  it('always updated. vim-patch:8.1.0849', function()
+    local screen = Screen.new(50,5)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.SlateBlue},
+      [2] = {bold = true, foreground = Screen.colors.Brown},
+      [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [4] = {foreground = Screen.colors.SlateBlue, background = Screen.colors.Gray90},
+      [5] = {background = Screen.colors.Gray90},
+      [6] = {bold = true, foreground = Screen.colors.Blue1},
+      [7] = {background = Screen.colors.LightRed},
+      [8] = {foreground = Screen.colors.Brown},
+    })
+    screen:attach()
+    command('set cursorline relativenumber')
+    command('call setline(1, ["","1","2","3",""])')
+    feed('Gy3k')
+    screen:expect([[
+      {2:  0 }{5:^1                                             }|
+      {8:  1 }2                                             |
+      {8:  2 }3                                             |
+      {8:  3 }                                              |
+      4 lines yanked                                    |
+    ]])
+    feed('jj')
+    screen:expect([[
+      {8:  2 }1                                             |
+      {8:  1 }2                                             |
+      {2:  0 }{5:^3                                             }|
+      {8:  1 }                                              |
+      4 lines yanked                                    |
+    ]])
+  end)
+
+  it('with visual area. vim-patch:8.1.1001', function()
+    local screen = Screen.new(50,5)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.SlateBlue},
+      [2] = {bold = true, foreground = Screen.colors.Brown},
+      [3] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [4] = {foreground = Screen.colors.SlateBlue, background = Screen.colors.Gray90},
+      [5] = {background = Screen.colors.Gray90},
+      [6] = {bold = true, foreground = Screen.colors.Blue1},
+      [7] = {background = Screen.colors.LightRed},
+      [8] = {foreground = Screen.colors.Brown},
+      [9] = {background = Screen.colors.LightGrey},
+      [10] = {bold = true},
+    })
+    screen:attach()
+    command('set cursorline')
+    command('call setline(1, repeat(["abc"], 50))')
+    feed('V<C-f>zbkkjk')
+    screen:expect([[
+      {9:abc}                                               |
+      ^a{9:bc}                                               |
+      abc                                               |
+      abc                                               |
+      {10:-- VISUAL LINE --}                                 |
+    ]])
+  end)
+
   it('with split-windows in diff-mode', function()
     local screen = Screen.new(50,12)
     screen:set_default_attr_ids({


### PR DESCRIPTION
- The Lua test correctly fails when 8.1.0849 is reverted.
-  The 8.1.1001 bug does not manifest in Neovim.

vim-patch:8.1.0849: cursorline highlight is not always updated
Problem:    Cursorline highlight is not always updated.
Solution:   Set w_last_cursorline when redrawing.  Fix resetting cursor flags
            when using the popup menu.
https://github.com/vim/vim/commit/c07ff5c60ad35982e9cdaa9dd72d3d1669935e87

vim-patch:8.1.1001: Visual area not correct when using 'cursorline'
Problem:    Visual area not correct when using 'cursorline'.
Solution:   Update w_last_cursorline also in Visual mode. (Hirohito Higashi,
            closes vim/vim#4086)
https://github.com/vim/vim/commit/8156ed37558231a8167a1a61a147713d84c9af59