### PR TITLE
vim-patch:8.1.0384

### DIFF
--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -13,6 +13,7 @@ struct signlist
     linenr_T lnum;      // line number which has this sign
     int typenr;         // typenr of sign
     signlist_T *next;   // next signlist entry
+    signlist_T *prev;   // previous entry -- for easy reordering
 };
 
 // type argument for buf_getsigntype() and sign_get_attr()


### PR DESCRIPTION
**vim-patch:8.1.0384: sign ordering depends on +netbeans feature**

Problem:    Sign ordering depends on +netbeans feature.
Solution:   Also order signs without +netbeans. (Christian Brabandt,
            closes vim/vim#3224)
https://github.com/vim/vim/commit/8aeb504fc68e3fea9da5567d2d9a31a132fbf90f