### PR TITLE
vim-patch:8.1.{1025,1026}

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2001,10 +2001,7 @@ static void get_scroll_overlap(lineoff_T *lp, int dir)
   return;
 }
 
-/* #define KEEP_SCREEN_LINE */
-/*
- * Scroll 'scroll' lines up or down.
- */
+// Scroll 'scroll' lines up or down.
 void halfpage(bool flag, linenr_T Prenum)
 {
   long scrolled = 0;
@@ -2039,13 +2036,11 @@ void halfpage(bool flag, linenr_T Prenum)
         ++curwin->w_topline;
         curwin->w_topfill = diff_check_fill(curwin, curwin->w_topline);
 
-#ifndef KEEP_SCREEN_LINE
         if (curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
           ++curwin->w_cursor.lnum;
           curwin->w_valid &=
             ~(VALID_VIRTCOL|VALID_CHEIGHT|VALID_WCOL);
         }
-#endif
       }
       curwin->w_valid &= ~(VALID_CROW|VALID_WROW);
       scrolled += i;
@@ -2070,10 +2065,7 @@ void halfpage(bool flag, linenr_T Prenum)
       }
     }
 
-#ifndef KEEP_SCREEN_LINE
-    /*
-     * When hit bottom of the file: move cursor down.
-     */
+    // When hit bottom of the file: move cursor down.
     if (n > 0) {
       if (hasAnyFolding(curwin)) {
         while (--n >= 0
@@ -2086,18 +2078,6 @@ void halfpage(bool flag, linenr_T Prenum)
         curwin->w_cursor.lnum += n;
       check_cursor_lnum();
     }
-#else
-    /* try to put the cursor in the same screen line */
-    while ((curwin->w_cursor.lnum < curwin->w_topline || scrolled > 0)
-           && curwin->w_cursor.lnum < curwin->w_botline - 1) {
-      scrolled -= plines(curwin->w_cursor.lnum);
-      if (scrolled < 0 && curwin->w_cursor.lnum >= curwin->w_topline)
-        break;
-      (void)hasFolding(curwin->w_cursor.lnum, NULL,
-          &curwin->w_cursor.lnum);
-      ++curwin->w_cursor.lnum;
-    }
-#endif
   } else {
     /*
      * scroll the text down
@@ -2119,17 +2099,13 @@ void halfpage(bool flag, linenr_T Prenum)
       curwin->w_valid &= ~(VALID_CROW|VALID_WROW|
                            VALID_BOTLINE|VALID_BOTLINE_AP);
       scrolled += i;
-#ifndef KEEP_SCREEN_LINE
       if (curwin->w_cursor.lnum > 1) {
         --curwin->w_cursor.lnum;
         curwin->w_valid &= ~(VALID_VIRTCOL|VALID_CHEIGHT|VALID_WCOL);
       }
-#endif
     }
-#ifndef KEEP_SCREEN_LINE
-    /*
-     * When hit top of the file: move cursor up.
-     */
+
+    // When hit top of the file: move cursor up.
     if (n > 0) {
       if (curwin->w_cursor.lnum <= (linenr_T)n)
         curwin->w_cursor.lnum = 1;
@@ -2142,18 +2118,6 @@ void halfpage(bool flag, linenr_T Prenum)
       } else
         curwin->w_cursor.lnum -= n;
     }
-#else
-    /* try to put the cursor in the same screen line */
-    scrolled += n;          /* move cursor when topline is 1 */
-    while (curwin->w_cursor.lnum > curwin->w_topline
-           && (scrolled > 0 || curwin->w_cursor.lnum >= curwin->w_botline)) {
-      scrolled -= plines(curwin->w_cursor.lnum - 1);
-      if (scrolled < 0 && curwin->w_cursor.lnum < curwin->w_botline)
-        break;
-      --curwin->w_cursor.lnum;
-      foldAdjustCursor();
-    }
-#endif
   }
   /* Move cursor to first line of closed fold. */
   foldAdjustCursor();

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6963,10 +6963,11 @@ char_u *reg_submatch(int no)
         return NULL;
       }
 
-      s = reg_getline_submatch(lnum) + rsm.sm_mmatch->startpos[no].col;
+      s = reg_getline_submatch(lnum);
       if (s == NULL) {  // anti-crash check, cannot happen?
         break;
       }
+      s += rsm.sm_mmatch->startpos[no].col;
       if (rsm.sm_mmatch->endpos[no].lnum == lnum) {
         // Within one line: take form start to end col.
         len = rsm.sm_mmatch->endpos[no].col - rsm.sm_mmatch->startpos[no].col;


### PR DESCRIPTION
**vim-patch:8.1.1025: checking NULL pointer after addition**
Problem:    Checking NULL pointer after addition. (Coverity)
Solution:   First check for NULL, then add the column.
vim/vim@64c8ed3

**vim-patch:8.1.1026: unused condition**
Problem:    Unused condition. (Coverity)
Solution:   Remove the condition.  Also remove unused #define.
vim/vim@d00e024