### PR TITLE
help: ignore snapshotted window if invalid

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6062,7 +6062,7 @@ static win_T *get_snapshot_focus(int idx)
     }
   }
 
-  return sn->fr_win;
+  return win_valid(sn->fr_win) ? sn->fr_win : NULL;
 }
 
 /*

--- a/test/functional/ex_cmds/help_spec.lua
+++ b/test/functional/ex_cmds/help_spec.lua
@@ -1,0 +1,27 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local funcs = helpers.funcs
+
+describe(':help', function()
+  before_each(clear)
+
+  it('window closed makes cursor return to a valid win/buf #9773', function()
+    command('help help')
+    eq(1001, funcs.win_getid())
+    command('quit')
+    eq(1000, funcs.win_getid())
+
+    command('autocmd WinNew * wincmd p')
+
+    command('help help')
+    -- Window 1002 is opened, but the autocmd switches back to 1000 and
+    -- creates the help buffer there instead.
+    eq(1000, funcs.win_getid())
+    command('quit')
+    -- Before #9773, Nvim would crash on quitting the help window.
+    eq(1002, funcs.win_getid())
+  end)
+end)


### PR DESCRIPTION
Nvim doesn't expect a window-changing command on an created-window event.

    autocmd WinNew * wincmd p
    help help

- A snapshot for window 1000 is created.
- The window is split and the cursor changes to the new window 1001.
- The autocmd kicks in and switches back to 1000.
- The help buffer is opened.
- On closing the help window 1000, it tries to go back to the snapshotted window
  which is... 1000.
- wp1000->w_buffer == NULL
- w_buffer is used by check_cursor()
- 🧨 -> 💥

Fixes https://github.com/neovim/neovim/issues/9773