### PR TITLE
vim-patch:8.1.{199,200}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16764,6 +16764,7 @@ static void f_spellbadword(typval_T *argvars, typval_T *rettv, FunPtr fptr)
         }
         str += len;
         capcol -= len;
+        len = 0;
       }
     }
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16763,6 +16763,7 @@ static void f_spellbadword(typval_T *argvars, typval_T *rettv, FunPtr fptr)
           break;
         }
         str += len;
+        capcol -= len;
       }
     }
   }

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -69,6 +69,47 @@ func Test_z_equal_on_invalid_utf8_word()
   bwipe!
 endfunc
 
+" Test spellbadword() with argument
+func Test_spellbadword()
+  set spell
+
+  call assert_equal(['bycycle', 'bad'],  spellbadword('My bycycle.'))
+  call assert_equal(['another', 'caps'], spellbadword('A sentence. another sentence'))
+
+  set spelllang=en
+  call assert_equal(['', ''],            spellbadword('centre'))
+  call assert_equal(['', ''],            spellbadword('center'))
+  set spelllang=en_us
+  call assert_equal(['centre', 'local'], spellbadword('centre'))
+  call assert_equal(['', ''],            spellbadword('center'))
+  set spelllang=en_gb
+  call assert_equal(['', ''],            spellbadword('centre'))
+  call assert_equal(['center', 'local'], spellbadword('center'))
+
+  " Create a small word list to test that spellbadword('...')
+  " can return ['...', 'rare'].
+  e Xwords
+  insert
+foo
+foobar/?
+.
+   w!
+   mkspell! Xwords.spl Xwords
+   set spelllang=Xwords.spl
+   call assert_equal(['foobar', 'rare'], spellbadword('foo foobar'))
+
+  " Typo should not be detected without the 'spell' option.
+  set spelllang=en_gb nospell
+  call assert_equal(['', ''], spellbadword('centre'))
+  call assert_equal(['', ''], spellbadword('My bycycle.'))
+  call assert_equal(['', ''], spellbadword('A sentence. another sentence'))
+
+  call delete('Xwords.spl')
+  call delete('Xwords')
+  set spelllang&
+  set spell&
+endfunc
+
 func Test_spellreall()
   new
   set spell


### PR DESCRIPTION
**vim-patch:8.1.0199: spellbadword() does not check for caps error**
Problem:    spellbadword() does not check for caps error. (Dominique Pelle)
Solution:   Adjust capcol when advancing.
vim/vim@66ab916

**vim-patch:8.1.0200: spellbadword() not tested**
Problem:    spellbadword() not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3235)
vim/vim@872e451