### PR TITLE
mac: do not use libintl_setlocale()

### DIFF
--- a/src/nvim/gettext.h
+++ b/src/nvim/gettext.h
@@ -11,6 +11,11 @@
 #  define N_(x) x
 # endif
 # define NGETTEXT(x, xs, n) ngettext(x, xs, n)
+// On a Mac, gettext's libintl.h defines "setlocale" to be replaced by
+// "libintl_setlocal" which leads to wrong return values. #9789
+# if defined(__APPLE__) && defined(setlocale)
+#  undef setlocale
+# endif
 #else
 # define _(x) ((char *)(x))
 # define N_(x) x


### PR DESCRIPTION
gettext contains libintl.h. That header file defines a macro that replaces
`setlocale` by `libintl_setlocale`. That function eventually calls the original
`setlocale()` from Apple's libc, but is known to make it fail.

Mac users with gettext from Homebrew can easily reproduce this:

    #include <stdio.h>
    #include <locale.h>
    #include <libintl.h>

    int main(void) {
      setlocale(LC_ALL, "");
      printf("locale: %s\n", setlocale(LC_CTYPE, NULL));
    }

Compile and run it:

    cc -I/usr/local/opt/gettext/include -L/usr/local/opt/gettext/lib -lintl -o test test.c && ./test

When $LC_CTYPE is set to a valid value like UTF-8, it should output:

    locale: UTF-8

But it does not. It returns C anyway. Remove libintl.h and recompile and you get
the expected UTF-8.

Fixes https://github.com/neovim/neovim/issues/9787