### PR TITLE
[WIP] Fix extra redrawcmdline when handling events

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -19582,6 +19582,10 @@ void ex_echo(exarg_T *eap)
   bool atstart = true;
   const int did_emsg_before = did_emsg;
 
+  if (State & CMDLINE) {
+    return;
+  }
+
   if (eap->skip)
     ++emsg_skip;
   while (*arg != NUL && *arg != '|' && *arg != '\n' && !got_int) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7805,13 +7805,13 @@ static void ex_redraw(exarg_T *eap)
 
   // When NOT_VALID windows are redrawn, they lose incsearch highlighting since
   // the last search pattern is reset.
-  // With display+=msg_sep, windows covered by the messages are NOT_VALID.
+  // With display+=msg_sep, windows overlapping the messages are NOT_VALID.
+  // With display-=msg_sep, windows starting below the messages are NOT_VALID.
+  // To catch both cases, check msg_scrolled > 0
   int need_redraw_highlight = (State & CMDLINE)
-      && (get_ccline_cmdfirstc() == '/' || get_ccline_cmdfirstc() == '?')
-      && ((p_is
-           && msg_scrolled > 0
-           && (dy_flags & DY_MSGSEP))
-          || eap->forceit);
+      && (eap->forceit
+          || ((get_ccline_cmdfirstc() == '/' || get_ccline_cmdfirstc() == '?')
+              && p_is && msg_scrolled > 0));
 
   // To fix this, set the last search pattern to the current cmdline and
   // then call update_screen().

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7807,6 +7807,16 @@ static void ex_redraw(exarg_T *eap)
   if (need_maketitle) {
     maketitle();
   }
+
+  if (State & CMDLINE) {
+    int save_msg_silent = msg_silent;
+    msg_silent = 0;
+    // Reset lines_left since messages will be cleared
+    lines_left = Rows - 1;
+    redrawcmdline();
+    msg_silent = save_msg_silent;
+  }
+
   RedrawingDisabled = r;
   p_lz = p;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7807,6 +7807,7 @@ static void ex_redraw(exarg_T *eap)
   // the last search pattern is reset.
   // With display+=msg_sep, windows covered by the messages are NOT_VALID.
   int need_redraw_highlight = (State & CMDLINE)
+      && (get_ccline_cmdfirstc() == '/' || get_ccline_cmdfirstc() == '?')
       && ((p_is
            && msg_scrolled > 0
            && (dy_flags & DY_MSGSEP))

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7802,15 +7802,19 @@ static void ex_redraw(exarg_T *eap)
   if (eap->forceit) {
     redraw_all_later(NOT_VALID);
   }
-  if ((State & CMDLINE) &&
-    p_is &&
-    msg_scrolled > 0 &&
-    (dy_flags & DY_MSGSEP)) {
-    // with display+=msg_sep, windows covered by the messages are NOT_VALID.
-    // When redrawn, these windows lose incsearch highlighting since the
-    // last search pattern is reset.
-    // To fix this, set the last search pattern to the current cmdline and
-    // then call update_screen().
+
+  // When NOT_VALID windows are redrawn, they lose incsearch highlighting since
+  // the last search pattern is reset.
+  // With display+=msg_sep, windows covered by the messages are NOT_VALID.
+  int need_redraw_highlight = (State & CMDLINE) &&
+      ((p_is &&
+        msg_scrolled > 0 &&
+        (dy_flags & DY_MSGSEP)) ||
+      eap->forceit);
+
+  // To fix this, set the last search pattern to the current cmdline and
+  // then call update_screen().
+  if (need_redraw_highlight) {
     save_last_search_pattern();
     char_u *cmdbuf = get_ccline_cmdbuf();
     pos_T old_w_cursor = curwin->w_cursor;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7806,11 +7806,11 @@ static void ex_redraw(exarg_T *eap)
   // When NOT_VALID windows are redrawn, they lose incsearch highlighting since
   // the last search pattern is reset.
   // With display+=msg_sep, windows covered by the messages are NOT_VALID.
-  int need_redraw_highlight = (State & CMDLINE) &&
-      ((p_is &&
-        msg_scrolled > 0 &&
-        (dy_flags & DY_MSGSEP)) ||
-      eap->forceit);
+  int need_redraw_highlight = (State & CMDLINE)
+      && ((p_is
+           && msg_scrolled > 0
+           && (dy_flags & DY_MSGSEP))
+          || eap->forceit);
 
   // To fix this, set the last search pattern to the current cmdline and
   // then call update_screen().
@@ -7831,7 +7831,7 @@ static void ex_redraw(exarg_T *eap)
 
     // turn off no_hlsearch
     // will be reset when calling restore_last_search_pattern()
-    SET_NO_HLSEARCH(FALSE);
+    SET_NO_HLSEARCH(false);
 
     update_screen(NOT_VALID);
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -544,6 +544,10 @@ static int command_line_execute(VimState *state, int key)
   if (s->c == K_EVENT || s->c == K_COMMAND) {
     if (s->c == K_EVENT) {
       multiqueue_process_events(main_loop.events);
+
+      if (exmode_active) {
+        redrawcmdprompt();
+      }
     } else {
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
       redrawcmdline();

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -541,17 +541,17 @@ static int command_line_execute(VimState *state, int key)
   CommandLineState *s = (CommandLineState *)state;
   s->c = key;
 
-  if (s->c == K_EVENT || s->c == K_COMMAND) {
-    if (s->c == K_EVENT) {
-      multiqueue_process_events(main_loop.events);
+  if (s->c == K_EVENT) {
+    multiqueue_process_events(main_loop.events);
 
-      if (exmode_active) {
-        redrawcmdprompt();
-      }
-    } else {
-      do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
-      redrawcmdline();
+    if (exmode_active) {
+      redrawcmdprompt();
     }
+
+    return 1;
+  } else if (s->c == K_COMMAND) {
+    do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
+
     return 1;
   }
 
@@ -2478,6 +2478,11 @@ bool cmdline_at_end(void)
 // Returns a copy of the current cmdbuff.
 char_u *get_ccline_cmdbuf(void) {
   return vim_strsave(ccline.cmdbuff);
+}
+
+// Returns the current cmdfirstc.
+int get_ccline_cmdfirstc(void) {
+  return ccline.cmdfirstc;
 }
 
 /*

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1987,7 +1987,7 @@ static void abandon_cmdline(void)
   if (msg_scrolled == 0) {
     compute_cmdrow();
   }
-  MSG("");
+  msg_clr_cmdline();
   redraw_cmdline = true;
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -546,8 +546,8 @@ static int command_line_execute(VimState *state, int key)
       multiqueue_process_events(main_loop.events);
     } else {
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
+      redrawcmdline();
     }
-    redrawcmdline();
     return 1;
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2474,6 +2474,13 @@ bool cmdline_at_end(void)
 }
 
 /*
+ * Returns a copy of the current cmdbuff.
+ */
+char_u *get_ccline_cmdbuf(void) {
+  return vim_strsave(ccline.cmdbuff);
+}
+
+/*
  * Allocate a new command line buffer.
  * Assigns the new buffer to ccline.cmdbuff and ccline.cmdbufflen.
  * Returns the new value of ccline.cmdbuff and ccline.cmdbufflen.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1108,6 +1108,8 @@ static void command_line_next_incsearch(CommandLineState *s, bool next_match)
 
     set_search_match(&s->match_end);
     curwin->w_cursor = s->match_start;
+    search_match_startcol = s->match_start.col;
+    search_match_startline = s->match_start.lnum;
     changed_cline_bef_curs();
     update_topline();
     validate_cursor();
@@ -1895,6 +1897,8 @@ static int command_line_changed(CommandLineState *s)
       pos_T save_pos = curwin->w_cursor;
 
       s->match_start = curwin->w_cursor;
+      search_match_startcol = s->match_start.col;
+      search_match_startline = s->match_start.lnum;
       set_search_match(&curwin->w_cursor);
       validate_cursor();
       end_pos = curwin->w_cursor;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2475,9 +2475,7 @@ bool cmdline_at_end(void)
   return (ccline.cmdpos >= ccline.cmdlen);
 }
 
-/*
- * Returns a copy of the current cmdbuff.
- */
+// Returns a copy of the current cmdbuff.
 char_u *get_ccline_cmdbuf(void) {
   return vim_strsave(ccline.cmdbuff);
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1120,6 +1120,8 @@ static void command_line_next_incsearch(CommandLineState *s, bool next_match)
     s->old_topfill = curwin->w_topfill;
     s->old_botline = curwin->w_botline;
     update_screen(NOT_VALID);
+    // reset lines_left since messages are cleared after update_screen
+    lines_left = Rows - 1;
     redrawcmdline();
   } else {
     vim_beep(BO_ERROR);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -368,6 +368,8 @@ EXTERN int t_colors INIT(= 256);                // int value of T_CCO
 EXTERN int highlight_match INIT(= FALSE);       /* show search match pos */
 EXTERN linenr_T search_match_lines;             /* lines of of matched string */
 EXTERN colnr_T search_match_endcol;             /* col nr of match end */
+EXTERN colnr_T search_match_startcol;           /* col nr of match start */
+EXTERN colnr_T search_match_startline;          /* line nr of match start */
 
 EXTERN int no_smartcase INIT(= FALSE);          /* don't use 'smartcase' once */
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -581,10 +581,6 @@ static bool emsg_multiline(const char *s, bool multiline)
           xfree(p);
         }
         redir_write(s, strlen(s));
-
-        if (State & CMDLINE) {
-          redrawcmdline();
-        }
       }
       return true;
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -228,7 +228,7 @@ bool msg_attr_keep(char_u *s, int attr, bool keep, bool multiline)
   }
 
   if ((State & CMDLINE) && !emsg_on_display && !redraw_cmdline) {
-    --entered;
+    entered--;
     return true;
   }
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -227,7 +227,7 @@ bool msg_attr_keep(char_u *s, int attr, bool keep, bool multiline)
     add_msg_hist((const char *)s, -1, attr, multiline);
   }
 
-  if ((State & CMDLINE) && !emsg_on_display) {
+  if ((State & CMDLINE) && !emsg_on_display && !redraw_cmdline) {
     --entered;
     return true;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -227,7 +227,7 @@ bool msg_attr_keep(char_u *s, int attr, bool keep, bool multiline)
     add_msg_hist((const char *)s, -1, attr, multiline);
   }
 
-  if ((State & CMDLINE) && !emsg_on_display && !redraw_cmdline) {
+  if ((State & CMDLINE) && !emsg_on_display) {
     entered--;
     return true;
   }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -452,10 +452,11 @@ void set_last_search_pat(const char_u *s, int idx, int magic, int setlast)
   set_last_search_pat_save(s, idx, magic, setlast, save_level);
 }
 
-/*
- * Same as set_last_search_pat, but save the search pattern only if `save` is true.
- */
-void set_last_search_pat_save(const char_u *s, int idx, int magic, int setlast, int save)
+
+// Same as set_last_search_pat, but save the search pattern only if `save`
+// is true.
+void set_last_search_pat_save(const char_u *s, int idx, int magic, int setlast,
+                              int save)
 {
   free_spat(&spats[idx]);
   /* An empty string means that nothing should be matched. */

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -449,6 +449,14 @@ void reset_search_dir(void)
  */
 void set_last_search_pat(const char_u *s, int idx, int magic, int setlast)
 {
+  set_last_search_pat_save(s, idx, magic, setlast, save_level);
+}
+
+/*
+ * Same as set_last_search_pat, but save the search pattern only if `save` is true.
+ */
+void set_last_search_pat_save(const char_u *s, int idx, int magic, int setlast, int save)
+{
   free_spat(&spats[idx]);
   /* An empty string means that nothing should be matched. */
   if (*s == NUL)
@@ -466,7 +474,7 @@ void set_last_search_pat(const char_u *s, int idx, int magic, int setlast)
   spats[idx].off.off = 0;
   if (setlast)
     last_idx = idx;
-  if (save_level) {
+  if (save) {
     free_spat(&saved_spats[idx]);
     saved_spats[idx] = spats[0];
     if (spats[idx].pat == NULL)

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -218,6 +218,8 @@ describe('timers', function()
       :good^                                   |
     ]])
 
+    run(nil, nil, nil, load_adjust(300))
+
     screen:expect{grid=[[
                                               |
       {0:~                                       }|
@@ -225,7 +227,7 @@ describe('timers', function()
       {0:~                                       }|
       {0:~                                       }|
       :good^                                   |
-    ]], intermediate=true, timeout=200}
+    ]], unchanged=true}
 
     eq(1, eval('g:val'))
   end)


### PR DESCRIPTION
Fixes #8490.

When handling `K_EVENT` in `command_line_execute`, `redrawcmdline` is called without `update_screen`. `redrawcmdline` scrolls the screen up if the cmdline cannot fit in one screen line, causing the above issue.

Still WIP, currently redrawing from a timer will result in `incsearch` disappearing and `hlsearch` using to the previous search (instead of using the current cmdline). Only occurs with `display+=msgsep` and for windows which the cmdline overlaps since those windows will have `w_redr_type = NOT_VALID`.

Not sure what the best solution will be here, since a lot of the `incsearch` logic is in `ex_getln.c`.

Related to #9777 and #9783, since one choice is to disable redrawing in such a scenario.