### PR TITLE
[RDY] vim-patch:8.1.0544: setting 'filetype' in a modeline causes an error

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5561,7 +5561,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	After this option has been set successfully, Vim will source the files
 	"spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
-	up to the first comma, dot or underscore.
+	up to the first character that is not an ASCII letter and not a dash.
 	Also see |set-spc-auto|.
 
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4945,11 +4945,11 @@ chk_modeline (
       save_SID = current_SID;
       current_SID = SID_MODELINE;
       // Make sure no risky things are executed as a side effect.
-      sandbox++;
+      ++secure;
 
       retval = do_set(s, OPT_MODELINE | OPT_LOCAL | flags);
 
-      sandbox--;
+      --secure;
       current_SID = save_SID;
       if (retval == FAIL)                     /* stop if error found */
         break;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -117,7 +117,7 @@ read_buffer(
       flags | READ_BUFFER);
   if (retval == OK) {
     // Delete the binary lines.
-    while (--line_count >= 0) {
+    while (line_count-- > 0) {
       ml_delete((linenr_T)1, false);
     }
   } else {
@@ -150,11 +150,11 @@ read_buffer(
  * memory.
  * Return FAIL for failure, OK otherwise.
  */
-int 
-open_buffer (
-    int read_stdin,                     /* read file from stdin */
-    exarg_T *eap,                   /* for forced 'ff' and 'fenc' or NULL */
-    int flags                          /* extra flags for readfile() */
+int
+open_buffer(
+    int read_stdin,                     //  read file from stdin
+    exarg_T *eap,                   //  for forced 'ff' and 'fenc' or NULL
+    int flags                          //  extra flags for readfile()
 )
 {
   int retval = OK;
@@ -169,14 +169,14 @@ open_buffer (
    */
   if (readonlymode && curbuf->b_ffname != NULL
       && (curbuf->b_flags & BF_NEVERLOADED))
-    curbuf->b_p_ro = TRUE;
+    curbuf->b_p_ro = true;
 
   if (ml_open(curbuf) == FAIL) {
     /*
      * There MUST be a memfile, otherwise we can't do anything
      * If we can't create one for the current buffer, take another buffer
      */
-    close_buffer(NULL, curbuf, 0, FALSE);
+    close_buffer(NULL, curbuf, 0, false);
 
     curbuf = NULL;
     FOR_ALL_BUFFERS(buf) {
@@ -196,8 +196,9 @@ open_buffer (
     }
     EMSG(_("E83: Cannot allocate buffer, using other one..."));
     enter_buffer(curbuf);
-    if (old_tw != curbuf->b_p_tw)
+    if (old_tw != curbuf->b_p_tw) {
       check_colorcolumn(curwin);
+    }
     return FAIL;
   }
 
@@ -206,7 +207,7 @@ open_buffer (
   set_bufref(&old_curbuf, curbuf);
   modified_was_set = false;
 
-  /* mark cursor position as being invalid */
+  //  mark cursor position as being invalid
   curwin->w_valid = 0;
 
   if (curbuf->b_ffname != NULL) {
@@ -265,7 +266,7 @@ open_buffer (
      * it possible to retry when 'fileformat' or 'fileencoding' was
      * guessed wrong.
      */
-    curbuf->b_p_bin = TRUE;
+    curbuf->b_p_bin = true;
     retval = readfile(NULL, NULL, (linenr_T)0,
         (linenr_T)0, (linenr_T)MAXLNUM, NULL,
         flags | (READ_NEW + READ_STDIN));
@@ -275,7 +276,7 @@ open_buffer (
     }
   }
 
-  /* if first time loading this buffer, init b_chartab[] */
+  //  if first time loading this buffer, init b_chartab[]
   if (curbuf->b_flags & BF_NEVERLOADED) {
     (void)buf_init_chartab(curbuf, false);
     parse_cino(curbuf);
@@ -302,20 +303,21 @@ open_buffer (
   curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
   curbuf->b_last_changedtick_pum = buf_get_changedtick(curbuf);
 
-  /* require "!" to overwrite the file, because it wasn't read completely */
-  if (aborting())
+  // require "!" to overwrite the file, because it wasn't read completely
+  if (aborting()) {
     curbuf->b_flags |= BF_READERR;
+  }
 
   /* Need to update automatic folding.  Do this before the autocommands,
    * they may use the fold info. */
   foldUpdateAll(curwin);
 
-  /* need to set w_topline, unless some autocommand already did that. */
+  //  need to set w_topline, unless some autocommand already did that.
   if (!(curwin->w_valid & VALID_TOPLINE)) {
     curwin->w_topline = 1;
     curwin->w_topfill = 0;
   }
-  apply_autocmds_retval(EVENT_BUFENTER, NULL, NULL, FALSE, curbuf, &retval);
+  apply_autocmds_retval(EVENT_BUFENTER, NULL, NULL, false, curbuf, &retval);
 
   if (retval == FAIL) {
     return FAIL;
@@ -333,10 +335,10 @@ open_buffer (
     do_modelines(0);
     curbuf->b_flags &= ~(BF_CHECK_RO | BF_NEVERLOADED);
 
-    apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, FALSE, curbuf,
-        &retval);
+    apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, false, curbuf,
+                          &retval);
 
-    /* restore curwin/curbuf and a few other things */
+    //  restore curwin/curbuf and a few other things
     aucmd_restbuf(&aco);
   }
 
@@ -403,7 +405,7 @@ bool buf_valid(buf_T *buf)
 ///               caller should get a new buffer very soon!
 ///               The 'bufhidden' option can force freeing and deleting.
 /// @param abort_if_last
-///               If TRUE, do not close the buffer if autocommands cause
+///               If true, do not close the buffer if autocommands cause
 ///               there to be only one window with this buffer. e.g. when
 ///               ":quit" is supposed to close the window but autocommands
 ///               close all other windows.
@@ -457,14 +459,14 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
       set_last_cursor(win);
     }
     buflist_setfpos(buf, win,
-        win->w_cursor.lnum == 1 ? 0 : win->w_cursor.lnum,
-        win->w_cursor.col, TRUE);
+                    win->w_cursor.lnum == 1 ? 0 : win->w_cursor.lnum,
+                    win->w_cursor.col, true);
   }
 
   bufref_T bufref;
   set_bufref(&bufref, buf);
 
-  /* When the buffer is no longer in a window, trigger BufWinLeave */
+  //  When the buffer is no longer in a window, trigger BufWinLeave
   if (buf->b_nwindows == 1) {
     buf->b_locked++;
     if (apply_autocmds(EVENT_BUFWINLEAVE, buf->b_fname, buf->b_fname, false,
@@ -497,8 +499,9 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
         return;
       }
     }
-    if (aborting())         /* autocmds may abort script processing */
+    if (aborting()) {       //  autocmds may abort script processing
       return;
+    }
   }
 
   // If the buffer was in curwin and the window has changed, go back to that
@@ -531,13 +534,14 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
     terminal_close(buf->terminal, NULL);
   }
 
-  /* Always remove the buffer when there is no file name. */
-  if (buf->b_ffname == NULL)
-    del_buf = TRUE;
+  // Always remove the buffer when there is no file name.
+  if (buf->b_ffname == NULL) {
+    del_buf = true;
+  }
 
   /*
    * Free all things allocated for this buffer.
-   * Also calls the "BufDelete" autocommands when del_buf is TRUE.
+   * Also calls the "BufDelete" autocommands when del_buf is true.
    */
   /* Remember if we are closing the current buffer.  Restore the number of
    * windows, so that autocommands in buf_freeall() don't get confused. */
@@ -573,8 +577,9 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
    * obtained anyway.  Therefore only return if curbuf changed to the
    * deleted buffer.
    */
-  if (buf == curbuf && !is_curbuf)
+  if (buf == curbuf && !is_curbuf) {
     return;
+  }
 
   if (win != NULL  // Avoid bogus clang warning.
       && win_valid_any_tab(win)
@@ -588,7 +593,7 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
     buf->b_nwindows--;
   }
 
-  /* Change directories when the 'acd' option is set. */
+  //  Change directories when the 'acd' option is set.
   do_autochdir();
 
   // Disable buffer-updates for the current buffer.
@@ -601,30 +606,33 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
   if (wipe_buf) {
     xfree(buf->b_ffname);
     xfree(buf->b_sfname);
-    if (buf->b_prev == NULL)
+    if (buf->b_prev == NULL) {
       firstbuf = buf->b_next;
-    else
+    } else {
       buf->b_prev->b_next = buf->b_next;
-    if (buf->b_next == NULL)
+    }
+    if (buf->b_next == NULL) {
       lastbuf = buf->b_prev;
-    else
+    } else {
       buf->b_next->b_prev = buf->b_prev;
+    }
     free_buffer(buf);
   } else {
     if (del_buf) {
       /* Free all internal variables and reset option values, to make
        * ":bdel" compatible with Vim 5.7. */
-      free_buffer_stuff(buf, TRUE);
+      free_buffer_stuff(buf, true);
 
-      /* Make it look like a new buffer. */
+      //  Make it look like a new buffer.
       buf->b_flags = BF_CHECK_RO | BF_NEVERLOADED;
 
-      /* Init the options when loaded again. */
+      //  Init the options when loaded again.
       buf->b_p_initialized = false;
     }
     buf_clear_file(buf);
-    if (del_buf)
-      buf->b_p_bl = FALSE;
+    if (del_buf) {
+      buf->b_p_bl = false;
+    }
   }
 }
 
@@ -634,13 +642,13 @@ void close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last)
 void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
-  unchanged(buf, TRUE);
-  buf->b_p_eol = TRUE;
-  buf->b_start_eol = TRUE;
-  buf->b_p_bomb = FALSE;
-  buf->b_start_bomb = FALSE;
+  unchanged(buf, true);
+  buf->b_p_eol = true;
+  buf->b_start_eol = true;
+  buf->b_p_bomb = false;
+  buf->b_start_bomb = false;
   buf->b_ml.ml_mfp = NULL;
-  buf->b_ml.ml_flags = ML_EMPTY;                /* empty buffer */
+  buf->b_ml.ml_flags = ML_EMPTY;                //  empty buffer
 }
 
 /// Clears the current buffer contents.
@@ -714,29 +722,30 @@ void buf_freeall(buf_T *buf, int flags)
    * it's OK to delete the curbuf, because a new one is obtained anyway.
    * Therefore only return if curbuf changed to the deleted buffer.
    */
-  if (buf == curbuf && !is_curbuf)
+  if (buf == curbuf && !is_curbuf) {
     return;
+  }
   diff_buf_delete(buf);             // Can't use 'diff' for unloaded buffer.
   // Remove any ownsyntax, unless exiting.
   if (curwin != NULL && curwin->w_buffer == buf) {
     reset_synblock(curwin);
   }
 
-  /* No folds in an empty buffer. */
+  //  No folds in an empty buffer.
   FOR_ALL_TAB_WINDOWS(tp, win) {
     if (win->w_buffer == buf) {
       clearFolding(win);
     }
   }
 
-  ml_close(buf, TRUE);              /* close and delete the memline/memfile */
-  buf->b_ml.ml_line_count = 0;      /* no lines in buffer */
+  ml_close(buf, true);              // close and delete the memline/memfile
+  buf->b_ml.ml_line_count = 0;      // no lines in buffer
   if ((flags & BFA_KEEP_UNDO) == 0) {
-    u_blockfree(buf);               /* free the memory allocated for undo */
-    u_clearall(buf);                /* reset all undo information */
+    u_blockfree(buf);               // free the memory allocated for undo
+    u_clearall(buf);                // reset all undo information
   }
-  syntax_clear(&buf->b_s);          /* reset syntax info */
-  buf->b_flags &= ~BF_READERR;      /* a read error is no longer relevant */
+  syntax_clear(&buf->b_s);          // reset syntax info
+  buf->b_flags &= ~BF_READERR;      // a read error is no longer relevant
 }
 
 /*
@@ -775,10 +784,10 @@ static void free_buffer(buf_T *buf)
 /*
  * Free stuff in the buffer for ":bdel" and when wiping out the buffer.
  */
-static void 
-free_buffer_stuff (
+static void
+free_buffer_stuff(
     buf_T *buf,
-    int free_options                       /* free options as well */
+    int free_options                       //  free options as well
 )
 {
   if (free_options) {
@@ -842,14 +851,14 @@ void goto_buffer(exarg_T *eap, int start, int dir, int count)
   if (swap_exists_action == SEA_QUIT && *eap->cmd == 's') {
     cleanup_T cs;
 
-    /* Reset the error/interrupt/exception state here so that
-     * aborting() returns FALSE when closing a window. */
+    // Reset the error/interrupt/exception state here so that
+    // aborting() returns false when closing a window.
     enter_cleanup(&cs);
 
     // Quitting means closing the split window, nothing else.
     win_close(curwin, true);
     swap_exists_action = SEA_NONE;
-    swap_exists_did_quit = TRUE;
+    swap_exists_did_quit = true;
 
     /* Restore the error/interrupt/exception state if not discarded by a
      * new aborting error, interrupt, or uncaught exception. */
@@ -871,8 +880,8 @@ void handle_swap_exists(bufref_T *old_curbuf)
   buf_T *buf;
 
   if (swap_exists_action == SEA_QUIT) {
-    /* Reset the error/interrupt/exception state here so that
-     * aborting() returns FALSE when closing a buffer. */
+    // Reset the error/interrupt/exception state here so that
+    // aborting() returns false when closing a buffer.
     enter_cleanup(&cs);
 
     // User selected Quit at ATTENTION prompt.  Go back to previous
@@ -902,20 +911,20 @@ void handle_swap_exists(bufref_T *old_curbuf)
         check_colorcolumn(curwin);
       }
     }
-    /* If "old_curbuf" is NULL we are in big trouble here... */
+    //  If "old_curbuf" is NULL we are in big trouble here...
 
     /* Restore the error/interrupt/exception state if not discarded by a
      * new aborting error, interrupt, or uncaught exception. */
     leave_cleanup(&cs);
   } else if (swap_exists_action == SEA_RECOVER) {
-    /* Reset the error/interrupt/exception state here so that
-     * aborting() returns FALSE when closing a buffer. */
+    // Reset the error/interrupt/exception state here so that
+    // aborting() returns false when closing a buffer.
     enter_cleanup(&cs);
 
-    /* User selected Recover at ATTENTION prompt. */
-    msg_scroll = TRUE;
+    // User selected Recover at ATTENTION prompt.
+    msg_scroll = true;
     ml_recover();
-    MSG_PUTS("\n");     /* don't overwrite the last message */
+    MSG_PUTS("\n");     //  don't overwrite the last message
     cmdline_row = msg_row;
     do_modelines(0);
 
@@ -940,30 +949,32 @@ void handle_swap_exists(bufref_T *old_curbuf)
  * Returns error message or NULL
  */
 char_u *
-do_bufdel (
+do_bufdel(
     int command,
-    char_u *arg,               /* pointer to extra arguments */
+    char_u *arg,               //  pointer to extra arguments
     int addr_count,
-    int start_bnr,                  /* first buffer number in a range */
-    int end_bnr,                    /* buffer nr or last buffer nr in a range */
+    int start_bnr,                  //  first buffer number in a range
+    int end_bnr,                    //  buffer nr or last buffer nr in a range
     int forceit
 )
 {
-  int do_current = 0;           /* delete current buffer? */
-  int deleted = 0;              /* number of buffers deleted */
-  char_u      *errormsg = NULL;   /* return value */
-  int bnr;                      /* buffer number */
+  int do_current = 0;           //  delete current buffer?
+  int deleted = 0;              //  number of buffers deleted
+  char_u      *errormsg = NULL;   //  return value
+  int bnr;                      //  buffer number
   char_u      *p;
 
   if (addr_count == 0) {
     (void)do_buffer(command, DOBUF_CURRENT, FORWARD, 0, forceit);
   } else {
     if (addr_count == 2) {
-      if (*arg)                 /* both range and argument is not allowed */
+      if (*arg) {               //  both range and argument is not allowed
         return (char_u *)_(e_trailing);
+      }
       bnr = start_bnr;
-    } else      /* addr_count == 1 */
+    } else {    //  addr_count == 1
       bnr = end_bnr;
+    }
 
     for (; !got_int; os_breakcheck()) {
       /*
@@ -972,61 +983,71 @@ do_bufdel (
        * the current one and will be loaded, which may then
        * also be deleted, etc.
        */
-      if (bnr == curbuf->b_fnum)
+      if (bnr == curbuf->b_fnum) {
         do_current = bnr;
-      else if (do_buffer(command, DOBUF_FIRST, FORWARD, bnr,
-                   forceit) == OK)
-        ++deleted;
+      } else if (do_buffer(command, DOBUF_FIRST, FORWARD, bnr,
+                           forceit) == OK) {
+        deleted++;
+      }
 
       /*
        * find next buffer number to delete/unload
        */
       if (addr_count == 2) {
-        if (++bnr > end_bnr)
+        if (bnr++ >= end_bnr) {
           break;
-      } else {    /* addr_count == 1 */
+        }
+      } else {    // addr_count == 1
         arg = skipwhite(arg);
-        if (*arg == NUL)
+        if (*arg == NUL) {
           break;
+        }
         if (!ascii_isdigit(*arg)) {
           p = skiptowhite_esc(arg);
           bnr = buflist_findpat(arg, p, command == DOBUF_WIPE,
-              FALSE, FALSE);
-          if (bnr < 0)                      /* failed */
+                                false, false);
+          if (bnr < 0) {                    // failed
             break;
+          }
           arg = p;
         } else
           bnr = getdigits_int(&arg);
       }
     }
-    if (!got_int && do_current && do_buffer(command, DOBUF_FIRST,
-            FORWARD, do_current, forceit) == OK)
-      ++deleted;
+    if (!got_int && do_current
+        && do_buffer(command, DOBUF_FIRST,
+                     FORWARD, do_current, forceit) == OK) {
+      deleted++;
+    }
 
     if (deleted == 0) {
-      if (command == DOBUF_UNLOAD)
+      if (command == DOBUF_UNLOAD) {
         STRCPY(IObuff, _("E515: No buffers were unloaded"));
-      else if (command == DOBUF_DEL)
+      } else if (command == DOBUF_DEL) {
         STRCPY(IObuff, _("E516: No buffers were deleted"));
-      else
+      } else {
         STRCPY(IObuff, _("E517: No buffers were wiped out"));
+      }
       errormsg = IObuff;
     } else if (deleted >= p_report) {
       if (command == DOBUF_UNLOAD) {
-        if (deleted == 1)
+        if (deleted == 1) {
           MSG(_("1 buffer unloaded"));
-        else
+        } else {
           smsg(_("%d buffers unloaded"), deleted);
+        }
       } else if (command == DOBUF_DEL) {
-        if (deleted == 1)
+        if (deleted == 1) {
           MSG(_("1 buffer deleted"));
-        else
+        } else {
           smsg(_("%d buffers deleted"), deleted);
+        }
       } else {
-        if (deleted == 1)
+        if (deleted == 1) {
           MSG(_("1 buffer wiped out"));
-        else
+        } else {
           smsg(_("%d buffers wiped out"), deleted);
+        }
       }
     }
   }
@@ -1055,8 +1076,8 @@ static int empty_curbuf(int close_others, int forceit, int action)
   set_bufref(&bufref, buf);
 
   if (close_others) {
-    /* Close any other windows on this buffer, then make it empty. */
-    close_windows(buf, TRUE);
+    // Close any other windows on this buffer, then make it empty.
+    close_windows(buf, true);
   }
 
   setpcmark();
@@ -1092,13 +1113,13 @@ static int empty_curbuf(int close_others, int forceit, int action)
  *
  * Return FAIL or OK.
  */
-int 
-do_buffer (
+int
+do_buffer(
     int action,
     int start,
-    int dir,                        /* FORWARD or BACKWARD */
-    int count,                      /* buffer number or number of buffers */
-    int forceit                    /* TRUE for :...! */
+    int dir,                        // FORWARD or BACKWARD
+    int count,                      // buffer number or number of buffers
+    int forceit                     // true for :...!
 )
 {
   buf_T       *buf;
@@ -1111,51 +1132,56 @@ do_buffer (
   case DOBUF_LAST:    buf = lastbuf;  break;
   default:            buf = curbuf;   break;
   }
-  if (start == DOBUF_MOD) {         /* find next modified buffer */
+  if (start == DOBUF_MOD) {         //  find next modified buffer
     while (count-- > 0) {
       do {
         buf = buf->b_next;
-        if (buf == NULL)
+        if (buf == NULL) {
           buf = firstbuf;
+        }
       } while (buf != curbuf && !bufIsChanged(buf));
     }
     if (!bufIsChanged(buf)) {
       EMSG(_("E84: No modified buffer found"));
       return FAIL;
     }
-  } else if (start == DOBUF_FIRST && count) { /* find specified buffer number */
-    while (buf != NULL && buf->b_fnum != count)
+  } else if (start == DOBUF_FIRST && count) {  //  find specified buffer number
+    while (buf != NULL && buf->b_fnum != count) {
       buf = buf->b_next;
+    }
   } else {
     bp = NULL;
     while (count > 0 || (!unload && !buf->b_p_bl && bp != buf)) {
       /* remember the buffer where we start, we come back there when all
        * buffers are unlisted. */
-      if (bp == NULL)
+      if (bp == NULL) {
         bp = buf;
+      }
       if (dir == FORWARD) {
         buf = buf->b_next;
-        if (buf == NULL)
+        if (buf == NULL) {
           buf = firstbuf;
+        }
       } else {
         buf = buf->b_prev;
-        if (buf == NULL)
+        if (buf == NULL) {
           buf = lastbuf;
+        }
       }
-      /* don't count unlisted buffers */
+      //  don't count unlisted buffers
       if (unload || buf->b_p_bl) {
-        --count;
-        bp = NULL;              /* use this buffer as new starting point */
+        count--;
+        bp = NULL;              // use this buffer as new starting point
       }
       if (bp == buf) {
-        /* back where we started, didn't find anything. */
+        //  back where we started, didn't find anything.
         EMSG(_("E85: There is no listed buffer"));
         return FAIL;
       }
     }
   }
 
-  if (buf == NULL) {        /* could not find it */
+  if (buf == NULL) {        //  could not find it
     if (start == DOBUF_FIRST) {
       // don't warn when deleting
       if (!unload) {
@@ -1180,8 +1206,9 @@ do_buffer (
 
     /* When unloading or deleting a buffer that's already unloaded and
      * unlisted: fail silently. */
-    if (action != DOBUF_WIPE && buf->b_ml.ml_mfp == NULL && !buf->b_p_bl)
+    if (action != DOBUF_WIPE && buf->b_ml.ml_mfp == NULL && !buf->b_p_bl) {
       return FAIL;
+    }
 
     if (!forceit && (buf->terminal || bufIsChanged(buf))) {
       if ((p_confirm || cmdmod.confirm) && p_write && !buf->terminal) {
@@ -1231,8 +1258,9 @@ do_buffer (
         break;
       }
     }
-    if (bp == NULL && buf == curbuf)
-      return empty_curbuf(TRUE, forceit, action);
+    if (bp == NULL && buf == curbuf) {
+      return empty_curbuf(true, forceit, action);
+    }
 
     /*
      * If the deleted buffer is the current one, close the current window
@@ -1242,8 +1270,9 @@ do_buffer (
     while (buf == curbuf
            && !(curwin->w_closing || curwin->w_buffer->b_locked > 0)
            && (!ONE_WINDOW || first_tabpage->tp_next != NULL)) {
-      if (win_close(curwin, false) == FAIL)
+      if (win_close(curwin, false) == FAIL) {
         break;
+      }
     }
 
     /*
@@ -1273,61 +1302,72 @@ do_buffer (
       int jumpidx;
 
       jumpidx = curwin->w_jumplistidx - 1;
-      if (jumpidx < 0)
+      if (jumpidx < 0) {
         jumpidx = curwin->w_jumplistlen - 1;
+      }
 
       forward = jumpidx;
       while (jumpidx != curwin->w_jumplistidx) {
         buf = buflist_findnr(curwin->w_jumplist[jumpidx].fmark.fnum);
         if (buf != NULL) {
-          if (buf == curbuf || !buf->b_p_bl)
-            buf = NULL;                 /* skip current and unlisted bufs */
-          else if (buf->b_ml.ml_mfp == NULL) {
-            /* skip unloaded buf, but may keep it for later */
-            if (bp == NULL)
+          if (buf == curbuf || !buf->b_p_bl) {
+            buf = NULL;                 // skip current and unlisted bufs
+          } else if (buf->b_ml.ml_mfp == NULL) {
+            // skip unloaded buf, but may keep it for later
+            if (bp == NULL) {
               bp = buf;
+            }
             buf = NULL;
           }
         }
-        if (buf != NULL)           /* found a valid buffer: stop searching */
+        if (buf != NULL) {         //  found a valid buffer: stop searching
           break;
-        /* advance to older entry in jump list */
-        if (!jumpidx && curwin->w_jumplistidx == curwin->w_jumplistlen)
+        }
+        // advance to older entry in jump list
+        if (!jumpidx && curwin->w_jumplistidx == curwin->w_jumplistlen) {
           break;
-        if (--jumpidx < 0)
+        }
+        if (jumpidx-- <= 0) {
           jumpidx = curwin->w_jumplistlen - 1;
-        if (jumpidx == forward)                 /* List exhausted for sure */
+        }
+        if (jumpidx == forward) {               // List exhausted for sure
           break;
+        }
       }
     }
 
-    if (buf == NULL) {          /* No previous buffer, Try 2'nd approach */
-      forward = TRUE;
+    if (buf == NULL) {          // No previous buffer, Try 2'nd approach
+      forward = true;
       buf = curbuf->b_next;
       for (;; ) {
         if (buf == NULL) {
-          if (!forward)                 /* tried both directions */
+          if (!forward) {               //  tried both directions
             break;
+          }
           buf = curbuf->b_prev;
-          forward = FALSE;
+          forward = false;
           continue;
         }
-        /* in non-help buffer, try to skip help buffers, and vv */
+        //  in non-help buffer, try to skip help buffers, and vv
         if (buf->b_help == curbuf->b_help && buf->b_p_bl) {
-          if (buf->b_ml.ml_mfp != NULL)             /* found loaded buffer */
+          if (buf->b_ml.ml_mfp != NULL) {           //  found loaded buffer
             break;
-          if (bp == NULL)               /* remember unloaded buf for later */
+          }
+          if (bp == NULL) {             //  remember unloaded buf for later
             bp = buf;
+          }
         }
-        if (forward)
+        if (forward) {
           buf = buf->b_next;
-        else
+        } else {
           buf = buf->b_prev;
+        }
       }
     }
-    if (buf == NULL)            /* No loaded buffer, use unloaded one */
+    if (buf == NULL) {          //  No loaded buffer, use unloaded one
       buf = bp;
-    if (buf == NULL) {          /* No loaded buffer, find listed one */
+    }
+    if (buf == NULL) {          //  No loaded buffer, find listed one
       FOR_ALL_BUFFERS(buf2) {
         if (buf2->b_p_bl && buf2 != curbuf) {
           buf = buf2;
@@ -1335,39 +1375,44 @@ do_buffer (
         }
       }
     }
-    if (buf == NULL) {          /* Still no buffer, just take one */
-      if (curbuf->b_next != NULL)
+    if (buf == NULL) {          // Still no buffer, just take one
+      if (curbuf->b_next != NULL) {
         buf = curbuf->b_next;
-      else
+      } else {
         buf = curbuf->b_prev;
+      }
     }
   }
 
   if (buf == NULL) {
     /* Autocommands must have wiped out all other buffers.  Only option
      * now is to make the current buffer empty. */
-    return empty_curbuf(FALSE, forceit, action);
+    return empty_curbuf(false, forceit, action);
   }
 
   /*
    * make buf current buffer
    */
-  if (action == DOBUF_SPLIT) {      /* split window first */
-    /* If 'switchbuf' contains "useopen": jump to first window containing
-     * "buf" if one exists */
-    if ((swb_flags & SWB_USEOPEN) && buf_jump_open_win(buf))
+  if (action == DOBUF_SPLIT) {      //  split window first
+    // If 'switchbuf' contains "useopen": jump to first window containing
+    // "buf" if one exists
+    if ((swb_flags & SWB_USEOPEN) && buf_jump_open_win(buf)) {
       return OK;
-    /* If 'switchbuf' contains "usetab": jump to first window in any tab
-     * page containing "buf" if one exists */
-    if ((swb_flags & SWB_USETAB) && buf_jump_open_tab(buf))
+    }
+    // If 'switchbuf' contains "usetab": jump to first window in any tab
+    // page containing "buf" if one exists
+    if ((swb_flags & SWB_USETAB) && buf_jump_open_tab(buf)) {
       return OK;
-    if (win_split(0, 0) == FAIL)
+    }
+    if (win_split(0, 0) == FAIL) {
       return FAIL;
+    }
   }
 
-  /* go to current buffer - nothing to do */
-  if (buf == curbuf)
+  //  go to current buffer - nothing to do
+  if (buf == curbuf) {
     return OK;
+  }
 
   /*
    * Check if the current buffer may be abandoned.
@@ -1388,15 +1433,16 @@ do_buffer (
     }
   }
 
-  /* Go to the other buffer. */
+  //  Go to the other buffer.
   set_curbuf(buf, action);
 
   if (action == DOBUF_SPLIT) {
-    RESET_BINDING(curwin);      /* reset 'scrollbind' and 'cursorbind' */
+    RESET_BINDING(curwin);      //  reset 'scrollbind' and 'cursorbind'
   }
 
-  if (aborting())           /* autocmds may abort script processing */
+  if (aborting()) {         //  autocmds may abort script processing
     return FAIL;
+  }
 
   return OK;
 }
@@ -1419,12 +1465,13 @@ void set_curbuf(buf_T *buf, int action)
   long old_tw = curbuf->b_p_tw;
 
   setpcmark();
-  if (!cmdmod.keepalt)
-    curwin->w_alt_fnum = curbuf->b_fnum;     /* remember alternate file */
-  buflist_altfpos(curwin);                       /* remember curpos */
+  if (!cmdmod.keepalt) {
+    curwin->w_alt_fnum = curbuf->b_fnum;     //  remember alternate file
+  }
+  buflist_altfpos(curwin);                       //  remember curpos
 
-  /* Don't restart Select mode after switching to another buffer. */
-  VIsual_reselect = FALSE;
+  //  Don't restart Select mode after switching to another buffer.
+  VIsual_reselect = false;
 
   // close_windows() or apply_autocmds() may change curbuf and wipe out "buf"
   prevbuf = curbuf;
@@ -1470,8 +1517,9 @@ void set_curbuf(buf_T *buf, int action)
        ) || curwin->w_buffer == NULL
       ) {
     enter_buffer(buf);
-    if (old_tw != curbuf->b_p_tw)
+    if (old_tw != curbuf->b_p_tw) {
       check_colorcolumn(curwin);
+    }
   }
 
   if (bufref_valid(&prevbufref) && prevbuf->terminal != NULL) {
@@ -1486,75 +1534,83 @@ void set_curbuf(buf_T *buf, int action)
  */
 void enter_buffer(buf_T *buf)
 {
-  /* Copy buffer and window local option values.  Not for a help buffer. */
+  //  Copy buffer and window local option values.  Not for a help buffer.
   buf_copy_options(buf, BCO_ENTER | BCO_NOHELP);
-  if (!buf->b_help)
+  if (!buf->b_help) {
     get_winopts(buf);
-  else
-    /* Remove all folds in the window. */
+  } else {
+    //  Remove all folds in the window.
     clearFolding(curwin);
-  foldUpdateAll(curwin);        /* update folds (later). */
+  }
+  foldUpdateAll(curwin);        //  update folds (later).
 
-  /* Get the buffer in the current window. */
+  //  Get the buffer in the current window.
   curwin->w_buffer = buf;
   curbuf = buf;
-  ++curbuf->b_nwindows;
+  curbuf->b_nwindows++;
 
-  if (curwin->w_p_diff)
+  if (curwin->w_p_diff) {
     diff_buf_add(curbuf);
+  }
 
   curwin->w_s = &(buf->b_s);
 
-  /* Cursor on first line by default. */
+  //  Cursor on first line by default.
   curwin->w_cursor.lnum = 1;
   curwin->w_cursor.col = 0;
   curwin->w_cursor.coladd = 0;
-  curwin->w_set_curswant = TRUE;
-  curwin->w_topline_was_set = FALSE;
+  curwin->w_set_curswant = true;
+  curwin->w_topline_was_set = false;
 
-  /* mark cursor position as being invalid */
+  //  mark cursor position as being invalid
   curwin->w_valid = 0;
 
-  /* Make sure the buffer is loaded. */
-  if (curbuf->b_ml.ml_mfp == NULL) {    /* need to load the file */
-    /* If there is no filetype, allow for detecting one.  Esp. useful for
-     * ":ball" used in an autocommand.  If there already is a filetype we
-     * might prefer to keep it. */
-    if (*curbuf->b_p_ft == NUL)
-      did_filetype = FALSE;
+  //  Make sure the buffer is loaded.
+  if (curbuf->b_ml.ml_mfp == NULL) {    //  need to load the file
+    // If there is no filetype, allow for detecting one.  Esp. useful for
+    // ":ball" used in an autocommand.  If there already is a filetype we
+    // might prefer to keep it.
+    if (*curbuf->b_p_ft == NUL) {
+      did_filetype = false;
+    }
 
-    open_buffer(FALSE, NULL, 0);
+    open_buffer(false, NULL, 0);
   } else {
-    if (!msg_silent)
-      need_fileinfo = TRUE;             /* display file info after redraw */
-    (void)buf_check_timestamp(curbuf, FALSE);     /* check if file changed */
+    if (!msg_silent) {
+      need_fileinfo = true;             //  display file info after redraw
+    }
+    (void)buf_check_timestamp(curbuf, false);     //  check if file changed
     curwin->w_topline = 1;
     curwin->w_topfill = 0;
-    apply_autocmds(EVENT_BUFENTER, NULL, NULL, FALSE, curbuf);
-    apply_autocmds(EVENT_BUFWINENTER, NULL, NULL, FALSE, curbuf);
+    apply_autocmds(EVENT_BUFENTER, NULL, NULL, false, curbuf);
+    apply_autocmds(EVENT_BUFWINENTER, NULL, NULL, false, curbuf);
   }
 
   /* If autocommands did not change the cursor position, restore cursor lnum
    * and possibly cursor col. */
-  if (curwin->w_cursor.lnum == 1 && inindent(0))
+  if (curwin->w_cursor.lnum == 1 && inindent(0)) {
     buflist_getfpos();
+  }
 
-  check_arg_idx(curwin);                /* check for valid arg_idx */
+  check_arg_idx(curwin);                //  check for valid arg_idx
   maketitle();
-  /* when autocmds didn't change it */
-  if (curwin->w_topline == 1 && !curwin->w_topline_was_set)
-    scroll_cursor_halfway(FALSE);       /* redisplay at correct position */
+  //  when autocmds didn't change it
+  if (curwin->w_topline == 1 && !curwin->w_topline_was_set) {
+    scroll_cursor_halfway(false);       //  redisplay at correct position
+  }
 
 
-  /* Change directories when the 'acd' option is set. */
+  //  Change directories when the 'acd' option is set.
   do_autochdir();
 
-  if (curbuf->b_kmap_state & KEYMAP_INIT)
+  if (curbuf->b_kmap_state & KEYMAP_INIT) {
     (void)keymap_init();
-  /* May need to set the spell language.  Can only do this after the buffer
-   * has been properly setup. */
-  if (!curbuf->b_help && curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL)
+  }
+  // May need to set the spell language.  Can only do this after the buffer
+  // has been properly setup.
+  if (!curbuf->b_help && curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL) {
     (void)did_set_spelllang(curwin);
+  }
 
   redraw_later(NOT_VALID);
 }
@@ -1601,11 +1657,11 @@ static inline void buf_init_changedtick(buf_T *const buf)
 /// Add a file name to the buffer list.
 /// If the same file name already exists return a pointer to that buffer.
 /// If it does not exist, or if fname == NULL, a new entry is created.
-/// If (flags & BLN_CURBUF) is TRUE, may use current buffer.
-/// If (flags & BLN_LISTED) is TRUE, add new buffer to buffer list.
-/// If (flags & BLN_DUMMY) is TRUE, don't count it as a real buffer.
-/// If (flags & BLN_NEW) is TRUE, don't use an existing buffer.
-/// If (flags & BLN_NOOPT) is TRUE, don't copy options from the current buffer
+/// If (flags & BLN_CURBUF) is true, may use current buffer.
+/// If (flags & BLN_LISTED) is true, add new buffer to buffer list.
+/// If (flags & BLN_DUMMY) is true, don't count it as a real buffer.
+/// If (flags & BLN_NEW) is true, don't use an existing buffer.
+/// If (flags & BLN_NOOPT) is true, don't copy options from the current buffer
 ///                                 if the buffer already exists.
 /// This is the ONLY way to create a new buffer.
 ///
@@ -1672,14 +1728,17 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
     buf = curbuf;
     /* It's like this buffer is deleted.  Watch out for autocommands that
      * change curbuf!  If that happens, allocate a new buffer anyway. */
-    if (curbuf->b_p_bl)
-      apply_autocmds(EVENT_BUFDELETE, NULL, NULL, FALSE, curbuf);
-    if (buf == curbuf)
-      apply_autocmds(EVENT_BUFWIPEOUT, NULL, NULL, FALSE, curbuf);
-    if (aborting())             /* autocmds may abort script processing */
-      return NULL;
+    if (curbuf->b_p_bl) {
+      apply_autocmds(EVENT_BUFDELETE, NULL, NULL, false, curbuf);
+    }
     if (buf == curbuf) {
-      /* Make sure 'bufhidden' and 'buftype' are empty */
+      apply_autocmds(EVENT_BUFWIPEOUT, NULL, NULL, false, curbuf);
+    }
+    if (aborting()) {           //  autocmds may abort script processing
+      return NULL;
+    }
+    if (buf == curbuf) {
+      //  Make sure 'bufhidden' and 'buftype' are empty
       clear_string_option(&buf->b_p_bh);
       clear_string_option(&buf->b_p_bt);
     }
@@ -1706,35 +1765,38 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
     buf->b_ffname = NULL;
     xfree(buf->b_sfname);
     buf->b_sfname = NULL;
-    if (buf != curbuf)
+    if (buf != curbuf) {
       free_buffer(buf);
+    }
     return NULL;
   }
 
   if (buf == curbuf) {
-    /* free all things allocated for this buffer */
+    //  free all things allocated for this buffer
     buf_freeall(buf, 0);
-    if (buf != curbuf)           /* autocommands deleted the buffer! */
+    if (buf != curbuf) {         //  autocommands deleted the buffer!
       return NULL;
-    if (aborting())             /* autocmds may abort script processing */
+    }
+    if (aborting()) {           //  autocmds may abort script processing
       return NULL;
-    free_buffer_stuff(buf, FALSE);      /* delete local variables et al. */
+    }
+    free_buffer_stuff(buf, false);      //  delete local variables et al.
 
-    /* Init the options. */
+    //  Init the options.
     buf->b_p_initialized = false;
     buf_copy_options(buf, BCO_ENTER);
 
-    /* need to reload lmaps and set b:keymap_name */
+    //  need to reload lmaps and set b:keymap_name
     curbuf->b_kmap_state |= KEYMAP_INIT;
   } else {
     /*
      * put new buffer at the end of the buffer list
      */
     buf->b_next = NULL;
-    if (firstbuf == NULL) {             /* buffer list is empty */
+    if (firstbuf == NULL) {             //  buffer list is empty
       buf->b_prev = NULL;
       firstbuf = buf;
-    } else {                          /* append new buffer at end of list */
+    } else {                          //  append new buffer at end of list
       lastbuf->b_next = buf;
       buf->b_prev = lastbuf;
     }
@@ -1772,8 +1834,9 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
   }
   buf->b_u_synced = true;
   buf->b_flags = BF_CHECK_RO | BF_NEVERLOADED;
-  if (flags & BLN_DUMMY)
+  if (flags & BLN_DUMMY) {
     buf->b_flags |= BF_DUMMY;
+  }
   buf_clear_file(buf);
   clrallmarks(buf);                     // clear marks
   fmarks_check_names(buf);              // check file marks for this file
@@ -1806,7 +1869,7 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
 
 /*
  * Free the memory for the options of a buffer.
- * If "free_p_ff" is TRUE also free 'fileformat', 'buftype' and
+ * If "free_p_ff" is true also free 'fileformat', 'buftype' and
  * 'fileencoding'.
  */
 void free_buf_options(buf_T *buf, int free_p_ff)
@@ -1885,25 +1948,28 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
 
   buf = buflist_findnr(n);
   if (buf == NULL) {
-    if ((options & GETF_ALT) && n == 0)
+    if ((options & GETF_ALT) && n == 0) {
       EMSG(_(e_noalt));
-    else
+    } else {
       EMSGN(_("E92: Buffer %" PRId64 " not found"), n);
+    }
     return FAIL;
   }
 
-  /* if alternate file is the current buffer, nothing to do */
-  if (buf == curbuf)
+  //  if alternate file is the current buffer, nothing to do
+  if (buf == curbuf) {
     return OK;
+  }
 
   if (text_locked()) {
     text_locked_msg();
     return FAIL;
   }
-  if (curbuf_locked())
+  if (curbuf_locked()) {
     return FAIL;
+  }
 
-  /* altfpos may be changed by getfile(), get it now */
+  //  altfpos may be changed by getfile(), get it now
   if (lnum == 0) {
     fpos = buflist_findfpos(buf);
     lnum = fpos->lnum;
@@ -1943,12 +2009,12 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
                               (options & GETF_SETMARK), lnum, forceit))) {
     RedrawingDisabled--;
 
-    /* cursor is at to BOL and w_cursor.lnum is checked due to getfile() */
+    //  cursor is at to BOL and w_cursor.lnum is checked due to getfile()
     if (!p_sol && col != 0) {
       curwin->w_cursor.col = col;
       check_cursor_col();
       curwin->w_cursor.coladd = 0;
-      curwin->w_set_curswant = TRUE;
+      curwin->w_set_curswant = true;
     }
     return OK;
   }
@@ -1966,13 +2032,13 @@ void buflist_getfpos(void)
   curwin->w_cursor.lnum = fpos->lnum;
   check_cursor_lnum();
 
-  if (p_sol)
+  if (p_sol) {
     curwin->w_cursor.col = 0;
-  else {
+  } else {
     curwin->w_cursor.col = fpos->col;
     check_cursor_col();
     curwin->w_cursor.coladd = 0;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
   }
 }
 
@@ -1985,12 +2051,13 @@ buf_T *buflist_findname_exp(char_u *fname)
   char_u      *ffname;
   buf_T       *buf = NULL;
 
-  /* First make the name into a full path name */
+  //  First make the name into a full path name
   ffname = (char_u *)FullName_save((char *)fname,
 #ifdef UNIX
-      TRUE                  /* force expansion, get rid of symbolic links */
+                                   true
+//  force expansion, get rid of symbolic links
 #else
-      FALSE
+                                   false
 #endif
       );
   if (ffname != NULL) {
@@ -2060,34 +2127,34 @@ int buflist_findpat(
     if (diffmode && !(found_buf && diff_mode_buf(found_buf))) {
       match = -1;
     }
-  }
-  /*
-   * Try four ways of matching a listed buffer:
-   * attempt == 0: without '^' or '$' (at any position)
-   * attempt == 1: with '^' at start (only at position 0)
-   * attempt == 2: with '$' at end (only match at end)
-   * attempt == 3: with '^' at start and '$' at end (only full match)
-   * Repeat this for finding an unlisted buffer if there was no matching
-   * listed buffer.
-   */
-  else {
-    pat = file_pat_to_reg_pat(pattern, pattern_end, NULL, FALSE);
-    if (pat == NULL)
+  } else {
+    // Try four ways of matching a listed buffer:
+    // attempt == 0: without '^' or '$' (at any position)
+    // attempt == 1: with '^' at start (only at position 0)
+    // attempt == 2: with '$' at end (only match at end)
+    // attempt == 3: with '^' at start and '$' at end (only full match)
+    // Repeat this for finding an unlisted buffer if there was no matching
+    // listed buffer.
+    pat = file_pat_to_reg_pat(pattern, pattern_end, NULL, false);
+    if (pat == NULL) {
       return -1;
+    }
     patend = pat + STRLEN(pat) - 1;
     toggledollar = (patend > pat && *patend == '$');
 
-    /* First try finding a listed buffer.  If not found and "unlisted"
-     * is TRUE, try finding an unlisted buffer. */
-    find_listed = TRUE;
+    // First try finding a listed buffer.  If not found and "unlisted"
+    // is true, try finding an unlisted buffer.
+    find_listed = true;
     for (;; ) {
-      for (attempt = 0; attempt <= 3; ++attempt) {
-        /* may add '^' and '$' */
-        if (toggledollar)
-          *patend = (attempt < 2) ? NUL : '$';           /* add/remove '$' */
+      for (attempt = 0; attempt <= 3; attempt++) {
+        //  may add '^' and '$'
+        if (toggledollar) {
+          *patend = (attempt < 2) ? NUL : '$';           //  add/remove '$'
+        }
         p = pat;
-        if (*p == '^' && !(attempt & 1))                 /* add/remove '^' */
-          ++p;
+        if (*p == '^' && !(attempt & 1)) {               //  add/remove '^'
+          p++;
+        }
 
         regmatch_T regmatch;
         regmatch.regprog = vim_regcomp(p, p_magic ? RE_MAGIC : 0);
@@ -2114,33 +2181,36 @@ int buflist_findpat(
                 continue;
               }
             }
-            if (match >= 0) {                   /* already found a match */
+            if (match >= 0) {                   //  already found a match
               match = -2;
               break;
             }
-            match = buf->b_fnum;                /* remember first match */
+            match = buf->b_fnum;                //  remember first match
           }
         }
 
         vim_regfree(regmatch.regprog);
-        if (match >= 0)                         /* found one match */
+        if (match >= 0) {                       //  found one match
           break;
+        }
       }
 
       /* Only search for unlisted buffers if there was no match with
        * a listed buffer. */
-      if (!unlisted || !find_listed || match != -1)
+      if (!unlisted || !find_listed || match != -1) {
         break;
-      find_listed = FALSE;
+      }
+      find_listed = false;
     }
 
     xfree(pat);
   }
 
-  if (match == -2)
+  if (match == -2) {
     EMSG2(_("E93: More than one match for %s"), pattern);
-  else if (match < 0)
+  } else if (match < 0) {
     EMSG2(_("E94: No matching buffer for %s"), pattern);
+  }
   return match;
 }
 
@@ -2158,10 +2228,10 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
   int attempt;
   char_u      *patc;
 
-  *num_file = 0;                    /* return values in case of FAIL */
+  *num_file = 0;                    //  return values in case of FAIL
   *file = NULL;
 
-  /* Make a copy of "pat" and change "^" to "\(^\|[\/]\)". */
+  //  Make a copy of "pat" and change "^" to "\(^\|[\/]\)".
   if (*pat == '^') {
     patc = xmalloc(STRLEN(pat) + 11);
     STRCPY(patc, "\\(^\\|[\\/]\\)");
@@ -2173,15 +2243,17 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
    * attempt == 0: try match with    '\<', match at start of word
    * attempt == 1: try match without '\<', match anywhere
    */
-  for (attempt = 0; attempt <= 1; ++attempt) {
-    if (attempt > 0 && patc == pat)
-      break;            /* there was no anchor, no need to try again */
+  for (attempt = 0; attempt <= 1; attempt++) {
+    if (attempt > 0 && patc == pat) {
+      break;            //  there was no anchor, no need to try again
+    }
 
     regmatch_T regmatch;
     regmatch.regprog = vim_regcomp(patc + attempt * 11, RE_MAGIC);
     if (regmatch.regprog == NULL) {
-      if (patc != pat)
+      if (patc != pat) {
         xfree(patc);
+      }
       return FAIL;
     }
 
@@ -2189,37 +2261,42 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
      * round == 1: Count the matches.
      * round == 2: Build the array to keep the matches.
      */
-    for (round = 1; round <= 2; ++round) {
+    for (round = 1; round <= 2; round++) {
       count = 0;
       FOR_ALL_BUFFERS(buf) {
-        if (!buf->b_p_bl)               /* skip unlisted buffers */
+        if (!buf->b_p_bl) {             //  skip unlisted buffers
           continue;
+        }
         p = buflist_match(&regmatch, buf, p_wic);
         if (p != NULL) {
-          if (round == 1)
-            ++count;
-          else {
-            if (options & WILD_HOME_REPLACE)
+          if (round == 1) {
+            count++;
+          } else {
+            if (options & WILD_HOME_REPLACE) {
               p = home_replace_save(buf, p);
-            else
+            } else {
               p = vim_strsave(p);
+            }
             (*file)[count++] = p;
           }
         }
       }
-      if (count == 0)           /* no match found, break here */
+      if (count == 0) {         //  no match found, break here
         break;
+      }
       if (round == 1) {
         *file = xmalloc((size_t)count * sizeof(**file));
       }
     }
     vim_regfree(regmatch.regprog);
-    if (count)                  /* match(es) found, break here */
+    if (count) {                //  match(es) found, break here
       break;
+    }
   }
 
-  if (patc != pat)
+  if (patc != pat) {
     xfree(patc);
+  }
 
   *num_file = count;
   return count == 0 ? FAIL : OK;
@@ -2228,7 +2305,7 @@ int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options)
 
 /// Check for a match on the file name for buffer "buf" with regprog "prog".
 ///
-/// @param ignore_case When TRUE, ignore case. Use 'fic' otherwise.
+/// @param ignore_case When true, ignore case. Use 'fic' otherwise.
 static char_u *buflist_match(regmatch_T *rmp, buf_T *buf, bool ignore_case)
 {
   // First try the short file name, then the long file name.
@@ -2241,7 +2318,7 @@ static char_u *buflist_match(regmatch_T *rmp, buf_T *buf, bool ignore_case)
 
 /// Try matching the regexp in "prog" with file name "name".
 ///
-/// @param ignore_case When TRUE, ignore case. Use 'fileignorecase' otherwise.
+/// @param ignore_case When true, ignore case. Use 'fileignorecase' otherwise.
 /// @return "name" when there is a match, NULL when not.
 static char_u *fname_match(regmatch_T *rmp, char_u *name, bool ignore_case)
 {
@@ -2251,13 +2328,14 @@ static char_u *fname_match(regmatch_T *rmp, char_u *name, bool ignore_case)
   if (name != NULL) {
     // Ignore case when 'fileignorecase' or the argument is set.
     rmp->rm_ic = p_fic || ignore_case;
-    if (vim_regexec(rmp, name, (colnr_T)0))
+    if (vim_regexec(rmp, name, (colnr_T)0)) {
       match = name;
-    else {
-      /* Replace $(HOME) with '~' and try matching again. */
+    } else {
+      //  Replace $(HOME) with '~' and try matching again.
       p = home_replace_save(NULL, name);
-      if (vim_regexec(rmp, p, (colnr_T)0))
+      if (vim_regexec(rmp, p, (colnr_T)0)) {
         match = name;
+      }
       xfree(p);
     }
   }
@@ -2282,17 +2360,18 @@ buf_T *buflist_findnr(int nr)
  * Returns a pointer to allocated memory, of NULL when failed.
  */
 char_u *
-buflist_nr2name (
+buflist_nr2name(
     int n,
     int fullname,
-    int helptail                   /* for help buffers return tail only */
+    int helptail                   //  for help buffers return tail only
 )
 {
   buf_T       *buf;
 
   buf = buflist_findnr(n);
-  if (buf == NULL)
+  if (buf == NULL) {
     return NULL;
+  }
   return home_replace_save(helptail ? buf : NULL,
       fullname ? buf->b_ffname : buf->b_fname);
 }
@@ -2312,23 +2391,28 @@ void buflist_setfpos(buf_T *const buf, win_T *const win,
 {
   wininfo_T   *wip;
 
-  for (wip = buf->b_wininfo; wip != NULL; wip = wip->wi_next)
-    if (wip->wi_win == win)
+  for (wip = buf->b_wininfo; wip != NULL; wip = wip->wi_next) {
+    if (wip->wi_win == win) {
       break;
+    }
+  }
   if (wip == NULL) {
-    /* allocate a new entry */
+    //  allocate a new entry
     wip = xcalloc(1, sizeof(wininfo_T));
     wip->wi_win = win;
-    if (lnum == 0)              /* set lnum even when it's 0 */
+    if (lnum == 0) {            //  set lnum even when it's 0
       lnum = 1;
+    }
   } else {
-    /* remove the entry from the list */
-    if (wip->wi_prev)
+    //  remove the entry from the list
+    if (wip->wi_prev) {
       wip->wi_prev->wi_next = wip->wi_next;
-    else
+    } else {
       buf->b_wininfo = wip->wi_next;
-    if (wip->wi_next)
+    }
+    if (wip->wi_next) {
       wip->wi_next->wi_prev = wip->wi_prev;
+    }
     if (copy_options && wip->wi_optset) {
       clear_winopt(&wip->wi_opt);
       deleteFoldRecurse(&wip->wi_folds);
@@ -2339,19 +2423,20 @@ void buflist_setfpos(buf_T *const buf, win_T *const win,
     wip->wi_fpos.col = col;
   }
   if (copy_options) {
-    /* Save the window-specific option values. */
+    //  Save the window-specific option values.
     copy_winopt(&win->w_onebuf_opt, &wip->wi_opt);
     wip->wi_fold_manual = win->w_fold_manual;
     cloneFoldGrowArray(&win->w_folds, &wip->wi_folds);
     wip->wi_optset = true;
   }
 
-  /* insert the entry in front of the list */
+  //  insert the entry in front of the list
   wip->wi_next = buf->b_wininfo;
   buf->b_wininfo = wip;
   wip->wi_prev = NULL;
-  if (wip->wi_next)
+  if (wip->wi_next) {
     wip->wi_next->wi_prev = wip;
+  }
 
   return;
 }
@@ -2378,7 +2463,7 @@ static bool wininfo_other_tab_diff(wininfo_T *wip)
 /*
  * Find info for the current window in buffer "buf".
  * If not found, return the info for the most recently used window.
- * When "skip_diff_buffer" is TRUE avoid windows with 'diff' set that is in
+ * When "skip_diff_buffer" is true avoid windows with 'diff' set that is in
  * another tab page.
  * Returns NULL when there isn't any info.
  */
@@ -2396,11 +2481,14 @@ static wininfo_T *find_wininfo(buf_T *buf, int skip_diff_buffer)
    * 'diff' set and is in another tab page). */
   if (wip == NULL) {
     if (skip_diff_buffer) {
-      for (wip = buf->b_wininfo; wip != NULL; wip = wip->wi_next)
-        if (!wininfo_other_tab_diff(wip))
+      for (wip = buf->b_wininfo; wip != NULL; wip = wip->wi_next) {
+        if (!wininfo_other_tab_diff(wip)) {
           break;
-    } else
+        }
+      }
+    } else {
       wip = buf->b_wininfo;
+    }
   }
   return wip;
 }
@@ -2434,9 +2522,10 @@ void get_winopts(buf_T *buf)
   } else
     copy_winopt(&curwin->w_allbuf_opt, &curwin->w_onebuf_opt);
 
-  /* Set 'foldlevel' to 'foldlevelstart' if it's not negative. */
-  if (p_fdls >= 0)
+  //  Set 'foldlevel' to 'foldlevelstart' if it's not negative.
+  if (p_fdls >= 0) {
     curwin->w_p_fdl = p_fdls;
+  }
   didset_window_options(curwin);
 }
 
@@ -2449,7 +2538,7 @@ pos_T *buflist_findfpos(buf_T *buf)
 {
   static pos_T no_position = { 1, 0, 0 };
 
-  wininfo_T *wip = find_wininfo(buf, FALSE);
+  wininfo_T *wip = find_wininfo(buf, false);
   return (wip == NULL) ? &no_position : &(wip->wi_fpos);
 }
 
@@ -2510,17 +2599,17 @@ void buflist_list(exarg_T *eap)
         len = IOSIZE - 20;
     }
 
-    /* put "line 999" in column 40 or after the file name */
+    //  put "line 999" in column 40 or after the file name
     i = 40 - vim_strsize(IObuff);
     do {
       IObuff[len++] = ' ';
-    } while (--i > 0 && len < IOSIZE - 18);
+    } while (i-- > 1 && len < IOSIZE - 18);
     vim_snprintf((char *)IObuff + len, (size_t)(IOSIZE - len),
         _("line %" PRId64),
         buf == curbuf ? (int64_t)curwin->w_cursor.lnum
                       : (int64_t)buflist_findlnum(buf));
     msg_outtrans(IObuff);
-    ui_flush();            /* output one line at a time */
+    ui_flush();            //  output one line at a time
     os_breakcheck();
   }
 }
@@ -2536,8 +2625,9 @@ int buflist_name_nr(int fnum, char_u **fname, linenr_T *lnum)
   buf_T       *buf;
 
   buf = buflist_findnr(fnum);
-  if (buf == NULL || buf->b_fname == NULL)
+  if (buf == NULL || buf->b_fname == NULL) {
     return FAIL;
+  }
 
   *fname = buf->b_fname;
   *lnum = buflist_findlnum(buf);
@@ -2551,12 +2641,12 @@ int buflist_name_nr(int fnum, char_u **fname, linenr_T *lnum)
  * Returns FAIL for failure (file name already in use by other buffer)
  *	OK otherwise.
  */
-int 
-setfname (
+int
+setfname(
     buf_T *buf,
     char_u *ffname,
     char_u *sfname,
-    int message                    /* give message when buffer already exists */
+    int message                    //  give message when buffer already exists
 )
 {
   buf_T       *obuf = NULL;
@@ -2564,15 +2654,16 @@ setfname (
   bool file_id_valid = false;
 
   if (ffname == NULL || *ffname == NUL) {
-    /* Removing the name. */
+    //  Removing the name.
     xfree(buf->b_ffname);
     xfree(buf->b_sfname);
     buf->b_ffname = NULL;
     buf->b_sfname = NULL;
   } else {
-    fname_expand(buf, &ffname, &sfname);     /* will allocate ffname */
-    if (ffname == NULL)                     /* out of memory */
+    fname_expand(buf, &ffname, &sfname);     //  will allocate ffname
+    if (ffname == NULL) {                   //  out of memory
       return FAIL;
+    }
 
     /*
      * if the file name is already used in another buffer:
@@ -2584,18 +2675,19 @@ setfname (
       obuf = buflist_findname_file_id(ffname, &file_id, file_id_valid);
     }
     if (obuf != NULL && obuf != buf) {
-      if (obuf->b_ml.ml_mfp != NULL) {          /* it's loaded, fail */
-        if (message)
+      if (obuf->b_ml.ml_mfp != NULL) {          //  it's loaded, fail
+        if (message) {
           EMSG(_("E95: Buffer with this name already exists"));
+        }
         xfree(ffname);
         return FAIL;
       }
-      /* delete from the list */
-      close_buffer(NULL, obuf, DOBUF_WIPE, FALSE);
+      //  delete from the list
+      close_buffer(NULL, obuf, DOBUF_WIPE, false);
     }
     sfname = vim_strsave(sfname);
 #ifdef USE_FNAME_CASE
-    path_fix_case(sfname);            /* set correct case for short file name */
+    path_fix_case(sfname);            //  set correct case for short file name
 #endif
     xfree(buf->b_ffname);
     xfree(buf->b_sfname);
@@ -2644,15 +2736,17 @@ void buf_name_changed(buf_T *buf)
   /*
    * If the file name changed, also change the name of the swapfile
    */
-  if (buf->b_ml.ml_mfp != NULL)
+  if (buf->b_ml.ml_mfp != NULL) {
     ml_setname(buf);
+  }
 
-  if (curwin->w_buffer == buf)
-    check_arg_idx(curwin);      /* check file name for arg list */
-  maketitle();                  /* set window title */
-  status_redraw_all();          /* status lines need to be redrawn */
-  fmarks_check_names(buf);      /* check named file marks */
-  ml_timestamp(buf);            /* reset timestamp */
+  if (curwin->w_buffer == buf) {
+    check_arg_idx(curwin);      //  check file name for arg list
+  }
+  maketitle();                  //  set window title
+  status_redraw_all();          //  status lines need to be redrawn
+  fmarks_check_names(buf);      //  check named file marks
+  ml_timestamp(buf);            //  reset timestamp
 }
 
 /*
@@ -2685,8 +2779,9 @@ char_u * getaltfname(
   linenr_T dummy;
 
   if (buflist_name_nr(0, &fname, &dummy) == FAIL) {
-    if (errmsg)
+    if (errmsg) {
       EMSG(_(e_noalt));
+    }
     return NULL;
   }
   return fname;
@@ -2716,10 +2811,12 @@ int buflist_add(char_u *fname, int flags)
 void buflist_slash_adjust(void)
 {
   FOR_ALL_BUFFERS(bp) {
-    if (bp->b_ffname != NULL)
+    if (bp->b_ffname != NULL) {
       slash_adjust(bp->b_ffname);
-    if (bp->b_sfname != NULL)
+    }
+    if (bp->b_sfname != NULL) {
       slash_adjust(bp->b_sfname);
+    }
   }
 }
 
@@ -2731,7 +2828,7 @@ void buflist_slash_adjust(void)
  */
 void buflist_altfpos(win_T *win)
 {
-  buflist_setfpos(curbuf, win, win->w_cursor.lnum, win->w_cursor.col, TRUE);
+  buflist_setfpos(curbuf, win, win->w_cursor.lnum, win->w_cursor.col, true);
 }
 
 /// Check that "ffname" is not the same file as current file.
@@ -2819,9 +2916,9 @@ static bool buf_same_file_id(buf_T *buf, FileID *file_id)
 /*
  * Print info about the current buffer.
  */
-void 
-fileinfo (
-    int fullname,               /* when non-zero print full path */
+void
+fileinfo(
+    int fullname,               //  when non-zero print full path
     int shorthelp,
     int dont_truncate
 )
@@ -2834,20 +2931,21 @@ fileinfo (
 
   buffer = xmalloc(IOSIZE);
 
-  if (fullname > 1) {       /* 2 CTRL-G: include buffer number */
+  if (fullname > 1) {       //  2 CTRL-G: include buffer number
     vim_snprintf((char *)buffer, IOSIZE, "buf %d: ", curbuf->b_fnum);
     p = buffer + STRLEN(buffer);
   } else
     p = buffer;
 
   *p++ = '"';
-  if (buf_spname(curbuf) != NULL)
+  if (buf_spname(curbuf) != NULL) {
     STRLCPY(p, buf_spname(curbuf), IOSIZE - (p - buffer));
-  else {
-    if (!fullname && curbuf->b_fname != NULL)
+  } else {
+    if (!fullname && curbuf->b_fname != NULL) {
       name = curbuf->b_fname;
-    else
+    } else {
       name = curbuf->b_ffname;
+    }
     home_replace(shorthelp ? curbuf : NULL, name, p,
                  (size_t)(IOSIZE - (p - buffer)), true);
   }
@@ -2878,12 +2976,13 @@ fileinfo (
   if (curbuf->b_ml.ml_flags & ML_EMPTY) {
     vim_snprintf_add((char *)buffer, IOSIZE, "%s", _(no_lines_msg));
   } else if (p_ru) {
-    /* Current line and column are already on the screen -- webb */
-    if (curbuf->b_ml.ml_line_count == 1)
+    //  Current line and column are already on the screen -- webb
+    if (curbuf->b_ml.ml_line_count == 1) {
       vim_snprintf_add((char *)buffer, IOSIZE, _("1 line --%d%%--"), n);
-    else
+    } else {
       vim_snprintf_add((char *)buffer, IOSIZE, _("%" PRId64 " lines --%d%%--"),
-          (int64_t)curbuf->b_ml.ml_line_count, n);
+                       (int64_t)curbuf->b_ml.ml_line_count, n);
+    }
   } else {
     vim_snprintf_add((char *)buffer, IOSIZE,
         _("line %" PRId64 " of %" PRId64 " --%d%%-- col "),
@@ -2903,18 +3002,19 @@ fileinfo (
      * First call msg_start() to get the message in the right place. */
     msg_start();
     n = msg_scroll;
-    msg_scroll = TRUE;
+    msg_scroll = true;
     msg(buffer);
     msg_scroll = n;
   } else {
-    p = msg_trunc_attr(buffer, FALSE, 0);
-    if (restart_edit != 0 || (msg_scrolled && !need_wait_return))
-      /* Need to repeat the message after redrawing when:
-       * - When restart_edit is set (otherwise there will be a delay
-       *   before redrawing).
-       * - When the screen was scrolled but there is no wait-return
-       *   prompt. */
+    p = msg_trunc_attr(buffer, false, 0);
+    if (restart_edit != 0 || (msg_scrolled && !need_wait_return)) {
+      // Need to repeat the message after redrawing when:
+      // - When restart_edit is set (otherwise there will be a delay
+      //   before redrawing).
+      // - When the screen was scrolled but there is no wait-return
+      //   prompt.
       set_keep_msg(p, 0);
+    }
   }
 
   xfree(buffer);
@@ -2922,10 +3022,11 @@ fileinfo (
 
 void col_print(char_u *buf, size_t buflen, int col, int vcol)
 {
-  if (col == vcol)
+  if (col == vcol) {
     vim_snprintf((char *)buf, buflen, "%d", col);
-  else
+  } else {
     vim_snprintf((char *)buf, buflen, "%d-%d", col, vcol);
+  }
 }
 
 /*
@@ -2946,14 +3047,15 @@ void maketitle(void)
   char buf[IOSIZE];
 
   if (!redrawing()) {
-    /* Postpone updating the title when 'lazyredraw' is set. */
-    need_maketitle = TRUE;
+    //  Postpone updating the title when 'lazyredraw' is set.
+    need_maketitle = true;
     return;
   }
 
-  need_maketitle = FALSE;
-  if (!p_title && !p_icon && lasttitle == NULL && lasticon == NULL)
+  need_maketitle = false;
+  if (!p_title && !p_icon && lasttitle == NULL && lasticon == NULL) {
     return;
+  }
 
   if (p_title) {
     if (p_titlelen > 0) {
@@ -2965,7 +3067,7 @@ void maketitle(void)
 
     if (*p_titlestring != NUL) {
       if (stl_syntax & STL_IN_TITLE) {
-        int use_sandbox = FALSE;
+        int use_sandbox = false;
         int save_called_emsg = called_emsg;
 
         use_sandbox = was_set_insecurely((char_u *)"titlestring", 0);
@@ -3076,11 +3178,11 @@ void maketitle(void)
     i_str = (char_u *)buf;
     if (*p_iconstring != NUL) {
       if (stl_syntax & STL_IN_ICON) {
-        int use_sandbox = FALSE;
+        int use_sandbox = false;
         int save_called_emsg = called_emsg;
 
         use_sandbox = was_set_insecurely((char_u *)"iconstring", 0);
-        called_emsg = FALSE;
+        called_emsg = false;
         build_stl_str_hl(curwin, i_str, sizeof(buf),
             p_iconstring, use_sandbox,
             0, 0, NULL, NULL);
@@ -3091,17 +3193,19 @@ void maketitle(void)
       } else
         i_str = p_iconstring;
     } else {
-      if (buf_spname(curbuf) != NULL)
+      if (buf_spname(curbuf) != NULL) {
         i_name = buf_spname(curbuf);
-      else                          /* use file name only in icon */
+      } else {                        //  use file name only in icon
         i_name = path_tail(curbuf->b_ffname);
+      }
       *i_str = NUL;
-      /* Truncate name at 100 bytes. */
+      //  Truncate name at 100 bytes.
       len = (int)STRLEN(i_name);
       if (len > 100) {
         len -= 100;
-        if (has_mbyte)
+        if (has_mbyte) {
           len += (*mb_tail_off)(i_name, i_name + len) + 1;
+        }
         i_name += len;
       }
       STRCPY(i_str, i_name);
@@ -3111,8 +3215,9 @@ void maketitle(void)
 
   mustset |= ti_change(i_str, &lasticon);
 
-  if (mustset)
+  if (mustset) {
     resettitle();
+  }
 }
 
 /// Used for title and icon: Check if "str" differs from "*last".  Set "*last"
@@ -3234,15 +3339,17 @@ int build_stl_str_hl(
   // use the result as the actual format string.
   if (fmt[0] == '%' && fmt[1] == '!') {
     usefmt = eval_to_string_safe(fmt + 2, NULL, use_sandbox);
-    if (usefmt == NULL)
+    if (usefmt == NULL) {
       usefmt = fmt;
+    }
   }
 
-  if (fillchar == 0)
+  if (fillchar == 0) {
     fillchar = ' ';
-  // Can't handle a multi-byte fill character yet.
-  else if (mb_char2len(fillchar) > 1)
+  } else if (mb_char2len(fillchar) > 1) {
+    // Can't handle a multi-byte fill character yet.
     fillchar = '-';
+  }
 
   // Get line & check if empty (cursorpos will show "0-1").
   char_u *line_ptr = ml_get_buf(wp->w_buffer, wp->w_cursor.lnum, false);
@@ -3297,8 +3404,9 @@ int build_stl_str_hl(
 
     // If we have processed the entire format string or run out of
     // room in our output buffer, exit the loop.
-    if (*fmt_p == NUL || out_p >= out_end_p)
+    if (*fmt_p == NUL || out_p >= out_end_p) {
       break;
+    }
 
     // The rest of this loop will handle a single `%` item.
     // Note: We increment here to skip over the `%` character we are currently
@@ -3382,7 +3490,7 @@ int build_stl_str_hl(
         // { Determine the number of bytes to remove
         long n;
         if (has_mbyte) {
-          /* Find the first character that should be included. */
+          //  Find the first character that should be included.
           n = 0;
           while (group_len >= items[groupitems[groupdepth]].maxwid) {
             group_len -= ptr2cells(t + n);
@@ -3400,7 +3508,7 @@ int build_stl_str_hl(
         memmove(t + 1, t + n, (size_t)(out_p - (t + n)));
         out_p = out_p - n + 1;
         // Fill up space left over by half a double-wide char.
-        while (++group_len < items[groupitems[groupdepth]].minwid) {
+        while (group_len++ < items[groupitems[groupdepth]].minwid - 1) {
           *out_p++ = fillchar;
         }
         // }
@@ -3469,8 +3577,9 @@ int build_stl_str_hl(
     // The first digit group is the item's min width
     if (ascii_isdigit(*fmt_p)) {
       minwid = getdigits_int(&fmt_p);
-      if (minwid < 0)           /* overflow */
+      if (minwid < 0) {         //  overflow
         minwid = 0;
+      }
     }
 
     // User highlight groups override the min width field
@@ -3554,8 +3663,9 @@ int build_stl_str_hl(
       fmt_p++;
       if (ascii_isdigit(*fmt_p)) {
         maxwid = getdigits_int(&fmt_p);
-        if (maxwid <= 0)                /* overflow */
+        if (maxwid <= 0) {              //  overflow
           maxwid = 50;
+        }
       }
     }
 
@@ -3607,13 +3717,14 @@ int build_stl_str_hl(
         home_replace(wp->w_buffer, t, NameBuff, MAXPATHL, true);
       }
       trans_characters(NameBuff, MAXPATHL);
-      if (opt != STL_FILENAME)
+      if (opt != STL_FILENAME) {
         str = NameBuff;
-      else
+      } else {
         str = path_tail(NameBuff);
+      }
       break;
     }
-    case STL_VIM_EXPR:     /* '{' */
+    case STL_VIM_EXPR:     //  '{'
     {
       itemisflag = true;
 
@@ -3622,8 +3733,9 @@ int build_stl_str_hl(
       char_u *t = out_p;
       while (*fmt_p != '}' && *fmt_p != NUL && out_p < out_end_p)
         *out_p++ = *fmt_p++;
-      if (*fmt_p != '}')            /* missing '}' or out of space */
+      if (*fmt_p != '}') {          //  missing '}' or out of space
         break;
+      }
       fmt_p++;
       *out_p = 0;
 
@@ -3690,7 +3802,7 @@ int build_stl_str_hl(
         getvcol(wp, &wp->w_cursor, NULL, &virtcol, NULL);
         wp->w_p_list = true;
       }
-      ++virtcol;
+      virtcol++;
       // Don't display %V if it's the same as %c.
       if (opt == STL_VIRTCOL_ALT
           && (virtcol == (colnr_T)(!(State & INSERT) && empty_line
@@ -3731,8 +3843,9 @@ int build_stl_str_hl(
 
     case STL_KEYMAP:
       fillable = false;
-      if (get_keymap_str(wp, (char_u *)"<%s>", tmp, TMPLEN))
+      if (get_keymap_str(wp, (char_u *)"<%s>", tmp, TMPLEN)) {
         str = tmp;
+      }
       break;
     case STL_PAGENUM:
       num = printer_page_num;
@@ -3759,17 +3872,19 @@ int build_stl_str_hl(
       FALLTHROUGH;
     case STL_BYTEVAL:
       num = byteval;
-      if (num == NL)
+      if (num == NL) {
         num = 0;
-      else if (num == CAR && get_fileformat(wp->w_buffer) == EOL_MAC)
+      } else if (num == CAR && get_fileformat(wp->w_buffer) == EOL_MAC) {
         num = NL;
+      }
       break;
 
     case STL_ROFLAG:
     case STL_ROFLAG_ALT:
       itemisflag = true;
-      if (wp->w_buffer->b_p_ro)
+      if (wp->w_buffer->b_p_ro) {
         str = (char_u *)((opt == STL_ROFLAG_ALT) ? ",RO" : _("[RO]"));
+      }
       break;
 
     case STL_HELPFLAG:
@@ -3845,7 +3960,7 @@ int build_stl_str_hl(
       // { The name of the highlight is surrounded by `#`
       char_u *t = fmt_p;
       while (*fmt_p != '#' && *fmt_p != NUL) {
-        ++fmt_p;
+        fmt_p++;
       }
       // }
 
@@ -3900,8 +4015,9 @@ int build_stl_str_hl(
           }
 
         // Early out if there isn't enough room for the truncation marker
-        if (out_p >= out_end_p)
+        if (out_p >= out_end_p) {
           break;
+        }
 
         // Add the truncation marker
         *out_p++ = '<';
@@ -3912,10 +4028,11 @@ int build_stl_str_hl(
       if (minwid > 0) {
         for (; l < minwid && out_p < out_end_p; l++) {
           // Don't put a "-" in front of a digit.
-          if (l + 1 == minwid && fillchar == '-' && ascii_isdigit(*t))
+          if (l + 1 == minwid && fillchar == '-' && ascii_isdigit(*t)) {
             *out_p++ = ' ';
-          else
+          } else {
             *out_p++ = fillchar;
+          }
         }
         minwid = 0;
       } else {
@@ -3942,8 +4059,9 @@ int build_stl_str_hl(
 
     // Otherwise if the item is a number, copy that to the output buffer.
     } else if (num >= 0) {
-      if (out_p + 20 > out_end_p)
-        break;                  /* not sufficient space */
+      if (out_p + 20 > out_end_p) {
+        break;                  //  not sufficient space
+      }
       prevchar_isitem = true;
 
       // { Build the formatting string
@@ -4004,7 +4122,8 @@ int build_stl_str_hl(
         *t++ = '%';
         // Use the same base as the first number
         *t = t[-3];
-        *++t = 0;
+        t++;
+        *t = 0;
         // }
 
         vim_snprintf((char *)out_p, remaining_buf_len, (char *)nstr,
@@ -4029,8 +4148,9 @@ int build_stl_str_hl(
       xfree(str);
     }
 
-    if (num >= 0 || (!itemisflag && str && *str))
-      prevchar_isflag = false;              /* Item not NULL, but not a flag */
+    if (num >= 0 || (!itemisflag && str && *str)) {
+      prevchar_isflag = false;              //  Item not NULL, but not a flag
+    }
 
     // Item processed, move to the next
     curitem++;
@@ -4083,8 +4203,9 @@ int build_stl_str_hl(
         width = 0;
         for (;; ) {
           width += ptr2cells(trunc_p);
-          if (width >= maxwidth)
+          if (width >= maxwidth) {
             break;
+          }
 
           // Note: Only advance the pointer if the next
           //       character will fit in the available output space
@@ -4139,7 +4260,7 @@ int build_stl_str_hl(
       }
 
       // Fill up for half a double-wide character.
-      while (++width < maxwidth) {
+      while (width++ < maxwidth - 1) {
         *trunc_p++ = fillchar;
         *trunc_p = NUL;
       }
@@ -4288,8 +4409,8 @@ void get_rel_pos(win_T *wp, char_u *buf, int buflen)
     return;
   }
 
-  long above;          /* number of lines above window */
-  long below;          /* number of lines below window */
+  long above;          //  number of lines above window
+  long below;          //  number of lines below window
 
   above = wp->w_topline - 1;
   above += diff_check_fill(wp, wp->w_topline) - wp->w_topfill;
@@ -4299,14 +4420,15 @@ void get_rel_pos(win_T *wp, char_u *buf, int buflen)
     above = 0;
   }
   below = wp->w_buffer->b_ml.ml_line_count - wp->w_botline + 1;
-  if (below <= 0)
+  if (below <= 0) {
     STRLCPY(buf, (above == 0 ? _("All") : _("Bot")), buflen);
-  else if (above <= 0)
+  } else if (above <= 0) {
     STRLCPY(buf, _("Top"), buflen);
-  else
+  } else {
     vim_snprintf((char *)buf, (size_t)buflen, "%2d%%", above > 1000000L
-        ? (int)(above / ((above + below) / 100L))
-        : (int)(above * 100L / (above + below)));
+                 ? (int)(above / ((above + below) / 100L))
+                 : (int)(above * 100L / (above + below)));
+  }
 }
 
 /// Append (file 2 of 8) to "buf[buflen]", if editing more than one file.
@@ -4351,11 +4473,13 @@ static bool append_arg_number(win_T *wp, char_u *buf, int buflen, bool add_file)
  */
 void fname_expand(buf_T *buf, char_u **ffname, char_u **sfname)
 {
-  if (*ffname == NULL)          /* if no file name given, nothing to do */
+  if (*ffname == NULL) {        //  if no file name given, nothing to do
     return;
-  if (*sfname == NULL)          /* if no short file name given, use ffname */
+  }
+  if (*sfname == NULL) {        //  if no short file name given, use ffname
     *sfname = *ffname;
-  *ffname = (char_u *)fix_fname((char *)*ffname);     /* expand to full path */
+  }
+  *ffname = (char_u *)fix_fname((char *)(*ffname));     //  expand to full path
 
 #ifdef WIN32
   if (!buf->b_p_bin) {
@@ -4377,21 +4501,22 @@ char_u *alist_name(aentry_T *aep)
 {
   buf_T       *bp;
 
-  /* Use the name from the associated buffer if it exists. */
+  //  Use the name from the associated buffer if it exists.
   bp = buflist_findnr(aep->ae_fnum);
-  if (bp == NULL || bp->b_fname == NULL)
+  if (bp == NULL || bp->b_fname == NULL) {
     return aep->ae_fname;
+  }
   return bp->b_fname;
 }
 
 /*
  * do_arg_all(): Open up to 'count' windows, one for each argument.
  */
-void 
-do_arg_all (
+void
+do_arg_all(
     int count,
-    int forceit,                    /* hide buffers in current windows */
-    int keep_tabs                  /* keep current tabs, for ":tab drop file" */
+    int forceit,                    //  hide buffers in current windows
+    int keep_tabs                  //  keep current tabs, for ":tab drop file"
 )
 {
   int i;
@@ -4401,11 +4526,11 @@ do_arg_all (
                                  *  2: opened in curtab
                                  *  3: opened in curtab and curwin
                                  */
-  int opened_len;               /* length of opened[] */
-  int use_firstwin = FALSE;             /* use first window for arglist */
+  int opened_len;               //  length of opened[]
+  int use_firstwin = false;             //  use first window for arglist
   int split_ret = OK;
   bool p_ea_save;
-  alist_T     *alist;           /* argument list to be used */
+  alist_T     *alist;           //  argument list to be used
   buf_T       *buf;
   tabpage_T   *tpnext;
   int had_tab = cmdmod.tab;
@@ -4430,7 +4555,7 @@ do_arg_all (
    * freed while we are working here by "locking" it.  We still have to
    * watch out for its size to be changed. */
   alist = curwin->w_alist;
-  ++alist->al_refcount;
+  alist->al_refcount++;
 
   old_curwin = curwin;
   old_curtab = curtab;
@@ -4443,8 +4568,9 @@ do_arg_all (
    * Windows that have a changed buffer and can't be hidden won't be closed.
    * When the ":tab" modifier was used do this for all tab pages.
    */
-  if (had_tab > 0)
-    goto_tabpage_tp(first_tabpage, TRUE, TRUE);
+  if (had_tab > 0) {
+    goto_tabpage_tp(first_tabpage, true, true);
+  }
   for (;; ) {
     win_T *wpnext = NULL;
     tpnext = curtab->tp_next;
@@ -4456,7 +4582,7 @@ do_arg_all (
         i = opened_len;
       } else {
         // check if the buffer in this window is in the arglist
-        for (i = 0; i < opened_len; ++i) {
+        for (i = 0; i < opened_len; i++) {
           if (i < alist->al_ga.ga_len
               && (AARGLIST(alist)[i].ae_fnum == buf->b_fnum
                   || path_full_compare(alist_name(&AARGLIST(alist)[i]),
@@ -4464,28 +4590,31 @@ do_arg_all (
             int weight = 1;
 
             if (old_curtab == curtab) {
-              ++weight;
-              if (old_curwin == wp)
-                ++weight;
+              weight++;
+              if (old_curwin == wp) {
+                weight++;
+              }
             }
 
             if (weight > (int)opened[i]) {
               opened[i] = (char_u)weight;
               if (i == 0) {
-                if (new_curwin != NULL)
+                if (new_curwin != NULL) {
                   new_curwin->w_arg_idx = opened_len;
+                }
                 new_curwin = wp;
                 new_curtab = curtab;
               }
-            } else if (keep_tabs)
+            } else if (keep_tabs) {
               i = opened_len;
+            }
 
             if (wp->w_alist != alist) {
               /* Use the current argument list for all windows
                * containing a file from it. */
               alist_unlink(wp->w_alist);
               wp->w_alist = alist;
-              ++wp->w_alist->al_refcount;
+              wp->w_alist->al_refcount++;
             }
             break;
           }
@@ -4517,33 +4646,36 @@ do_arg_all (
             // check if autocommands removed the next window
             if (!win_valid(wpnext)) {
               // start all over...
-              wpnext = firstwin;                
+              wpnext = firstwin;
             }
           }
         }
       }
     }
 
-    /* Without the ":tab" modifier only do the current tab page. */
-    if (had_tab == 0 || tpnext == NULL)
+    //  Without the ":tab" modifier only do the current tab page.
+    if (had_tab == 0 || tpnext == NULL) {
       break;
+    }
 
-    /* check if autocommands removed the next tab page */
-    if (!valid_tabpage(tpnext))
-      tpnext = first_tabpage;           /* start all over...*/
-    goto_tabpage_tp(tpnext, TRUE, TRUE);
+    //  check if autocommands removed the next tab page
+    if (!valid_tabpage(tpnext)) {
+      tpnext = first_tabpage;           // start all over...
+    }
+    goto_tabpage_tp(tpnext, true, true);
   }
 
   /*
    * Open a window for files in the argument list that don't have one.
    * ARGCOUNT may change while doing this, because of autocommands.
    */
-  if (count > opened_len || count <= 0)
+  if (count > opened_len || count <= 0) {
     count = opened_len;
+  }
 
-  /* Don't execute Win/Buf Enter/Leave autocommands here. */
-  ++autocmd_no_enter;
-  ++autocmd_no_leave;
+  //  Don't execute Win/Buf Enter/Leave autocommands here.
+  autocmd_no_enter++;
+  autocmd_no_leave++;
   last_curwin = curwin;
   last_curtab = curtab;
   win_enter(lastwin, false);
@@ -4559,7 +4691,7 @@ do_arg_all (
       arg_had_last = true;
     }
     if (opened[i] > 0) {
-      /* Move the already present window to below the current window */
+      //  Move the already present window to below the current window
       if (curwin->w_arg_idx != i) {
         FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
           if (wp->w_arg_idx == i) {
@@ -4574,15 +4706,17 @@ do_arg_all (
         }
       }
     } else if (split_ret == OK) {
-      if (!use_firstwin) {              /* split current window */
+      if (!use_firstwin) {              //  split current window
         p_ea_save = p_ea;
-        p_ea = true;                    /* use space from all windows */
+        p_ea = true;                    //  use space from all windows
         split_ret = win_split(0, WSP_ROOM | WSP_BELOW);
         p_ea = p_ea_save;
-        if (split_ret == FAIL)
+        if (split_ret == FAIL) {
           continue;
-      } else        /* first window: do autocmd for leaving this buffer */
-        --autocmd_no_leave;
+        }
+      } else {      //  first window: do autocmd for leaving this buffer
+        autocmd_no_leave--;
+      }
 
       /*
        * edit file "i"
@@ -4604,12 +4738,13 @@ do_arg_all (
     }
     os_breakcheck();
 
-    /* When ":tab" was used open a new tab for a new window repeatedly. */
-    if (had_tab > 0 && tabpage_index(NULL) <= p_tpm)
+    //  When ":tab" was used open a new tab for a new window repeatedly.
+    if (had_tab > 0 && tabpage_index(NULL) <= p_tpm) {
       cmdmod.tab = 9999;
+    }
   }
 
-  /* Remove the "lock" on the argument list. */
+  //  Remove the "lock" on the argument list.
   alist_unlink(alist);
 
   autocmd_no_enter--;
@@ -4630,7 +4765,7 @@ do_arg_all (
     win_enter(new_curwin, false);
   }
 
-  --autocmd_no_leave;
+  autocmd_no_leave--;
   xfree(opened);
 }
 
@@ -4646,18 +4781,20 @@ void ex_buffer_all(exarg_T *eap)
   int open_wins = 0;
   int r;
   long count;                   // Maximum number of windows to open.
-  int all;                      // When TRUE also load inactive buffers.
+  int all;                      // When true also load inactive buffers.
   int had_tab = cmdmod.tab;
   tabpage_T   *tpnext;
 
-  if (eap->addr_count == 0)     /* make as many windows as possible */
+  if (eap->addr_count == 0) {   //  make as many windows as possible
     count = 9999;
-  else
-    count = eap->line2;         /* make as many windows as specified */
-  if (eap->cmdidx == CMD_unhide || eap->cmdidx == CMD_sunhide)
-    all = FALSE;
-  else
-    all = TRUE;
+  } else {
+    count = eap->line2;         //  make as many windows as specified
+  }
+  if (eap->cmdidx == CMD_unhide || eap->cmdidx == CMD_sunhide) {
+    all = false;
+  } else {
+    all = true;
+  }
 
   setpcmark();
 
@@ -4666,8 +4803,9 @@ void ex_buffer_all(exarg_T *eap)
    * Close superfluous windows (two windows for the same buffer).
    * Also close windows that are not full-width.
    */
-  if (had_tab > 0)
-    goto_tabpage_tp(first_tabpage, TRUE, TRUE);
+  if (had_tab > 0) {
+    goto_tabpage_tp(first_tabpage, true, true);
+  }
   for (;; ) {
     tpnext = curtab->tp_next;
     for (wp = firstwin; wp != NULL; wp = wpnext) {
@@ -4686,14 +4824,16 @@ void ex_buffer_all(exarg_T *eap)
                                         // something strange with windows
         tpnext = first_tabpage;         // start all over...
         open_wins = 0;
-      } else
-        ++open_wins;
+      } else {
+        open_wins++;
+      }
     }
 
-    /* Without the ":tab" modifier only do the current tab page. */
-    if (had_tab == 0 || tpnext == NULL)
+    //  Without the ":tab" modifier only do the current tab page.
+    if (had_tab == 0 || tpnext == NULL) {
       break;
-    goto_tabpage_tp(tpnext, TRUE, TRUE);
+    }
+    goto_tabpage_tp(tpnext, true, true);
   }
 
   /*
@@ -4701,29 +4841,34 @@ void ex_buffer_all(exarg_T *eap)
    * open one.  Otherwise move the window to the right position.
    * Watch out for autocommands that delete buffers or windows!
    */
-  /* Don't execute Win/Buf Enter/Leave autocommands here. */
-  ++autocmd_no_enter;
+  //  Don't execute Win/Buf Enter/Leave autocommands here.
+  autocmd_no_enter++;
   win_enter(lastwin, false);
-  ++autocmd_no_leave;
+  autocmd_no_leave++;
   for (buf = firstbuf; buf != NULL && open_wins < count; buf = buf->b_next) {
-    /* Check if this buffer needs a window */
-    if ((!all && buf->b_ml.ml_mfp == NULL) || !buf->b_p_bl)
+    //  Check if this buffer needs a window
+    if ((!all && buf->b_ml.ml_mfp == NULL) || !buf->b_p_bl) {
       continue;
+    }
 
     if (had_tab != 0) {
-      /* With the ":tab" modifier don't move the window. */
-      if (buf->b_nwindows > 0)
-        wp = lastwin;               /* buffer has a window, skip it */
-      else
+      //  With the ":tab" modifier don't move the window.
+      if (buf->b_nwindows > 0) {
+        wp = lastwin;               //  buffer has a window, skip it
+      } else {
         wp = NULL;
+      }
     } else {
-      /* Check if this buffer already has a window */
-      for (wp = firstwin; wp != NULL; wp = wp->w_next)
-        if (wp->w_buffer == buf)
+      //  Check if this buffer already has a window
+      for (wp = firstwin; wp != NULL; wp = wp->w_next) {
+        if (wp->w_buffer == buf) {
           break;
-      /* If the buffer already has a window, move it */
-      if (wp != NULL)
+        }
+      }
+      //  If the buffer already has a window, move it
+      if (wp != NULL) {
         win_move_after(wp, curwin);
+      }
     }
 
     if (wp == NULL && split_ret == OK) {
@@ -4731,14 +4876,15 @@ void ex_buffer_all(exarg_T *eap)
       set_bufref(&bufref, buf);
       // Split the window and put the buffer in it.
       p_ea_save = p_ea;
-      p_ea = true;                      /* use space from all windows */
+      p_ea = true;                      //  use space from all windows
       split_ret = win_split(0, WSP_ROOM | WSP_BELOW);
-      ++open_wins;
+      open_wins++;
       p_ea = p_ea_save;
-      if (split_ret == FAIL)
+      if (split_ret == FAIL) {
         continue;
+      }
 
-      /* Open the buffer in this window. */
+      //  Open the buffer in this window.
       swap_exists_action = SEA_DIALOG;
       set_curbuf(buf, DOBUF_GOTO);
       if (!bufref_valid(&bufref)) {
@@ -4749,15 +4895,15 @@ void ex_buffer_all(exarg_T *eap)
       if (swap_exists_action == SEA_QUIT) {
         cleanup_T cs;
 
-        /* Reset the error/interrupt/exception state here so that
-         * aborting() returns FALSE when closing a window. */
+        // Reset the error/interrupt/exception state here so that
+        // aborting() returns false when closing a window.
         enter_cleanup(&cs);
 
         // User selected Quit at ATTENTION prompt; close this window.
         win_close(curwin, true);
         open_wins--;
         swap_exists_action = SEA_NONE;
-        swap_exists_did_quit = TRUE;
+        swap_exists_did_quit = true;
 
         /* Restore the error/interrupt/exception state if not
          * discarded by a new aborting error, interrupt, or uncaught
@@ -4769,19 +4915,21 @@ void ex_buffer_all(exarg_T *eap)
 
     os_breakcheck();
     if (got_int) {
-      (void)vgetc();            /* only break the file loading, not the rest */
+      (void)vgetc();            //  only break the file loading, not the rest
       break;
     }
-    /* Autocommands deleted the buffer or aborted script processing!!! */
-    if (aborting())
+    //  Autocommands deleted the buffer or aborted script processing!!!
+    if (aborting()) {
       break;
-    /* When ":tab" was used open a new tab for a new window repeatedly. */
-    if (had_tab > 0 && tabpage_index(NULL) <= p_tpm)
+    }
+    //  When ":tab" was used open a new tab for a new window repeatedly.
+    if (had_tab > 0 && tabpage_index(NULL) <= p_tpm) {
       cmdmod.tab = 9999;
+    }
   }
-  --autocmd_no_enter;
-  win_enter(firstwin, false);           /* back to first window */
-  --autocmd_no_leave;
+  autocmd_no_enter--;
+  win_enter(firstwin, false);           //  back to first window
+  autocmd_no_leave--;
 
   /*
    * Close superfluous windows.
@@ -4790,7 +4938,7 @@ void ex_buffer_all(exarg_T *eap)
     r = (buf_hide(wp->w_buffer) || !bufIsChanged(wp->w_buffer)
          || autowrite(wp->w_buffer, false) == OK);
     if (!win_valid(wp)) {
-      /* BufWrite Autocommands made the window invalid, start over */
+      //  BufWrite Autocommands made the window invalid, start over
       wp = lastwin;
     } else if (r) {
       win_close(wp, !buf_hide(wp->w_buffer));
@@ -4798,8 +4946,9 @@ void ex_buffer_all(exarg_T *eap)
       wp = lastwin;
     } else {
       wp = wp->w_prev;
-      if (wp == NULL)
+      if (wp == NULL) {
         break;
+      }
     }
   }
 }
@@ -4821,40 +4970,46 @@ void do_modelines(int flags)
   int nmlines;
   static int entered = 0;
 
-  if (!curbuf->b_p_ml || (nmlines = (int)p_mls) == 0)
+  if (!curbuf->b_p_ml || (nmlines = (int)p_mls) == 0) {
     return;
+  }
 
   /* Disallow recursive entry here.  Can happen when executing a modeline
    * triggers an autocommand, which reloads modelines with a ":do". */
-  if (entered)
+  if (entered) {
     return;
+  }
 
-  ++entered;
+  entered++;
   for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count && lnum <= nmlines;
-       ++lnum)
-    if (chk_modeline(lnum, flags) == FAIL)
+       lnum++) {
+    if (chk_modeline(lnum, flags) == FAIL) {
       nmlines = 0;
+    }
+  }
 
   for (lnum = curbuf->b_ml.ml_line_count; lnum > 0 && lnum > nmlines
-       && lnum > curbuf->b_ml.ml_line_count - nmlines; --lnum)
-    if (chk_modeline(lnum, flags) == FAIL)
+       && lnum > curbuf->b_ml.ml_line_count - nmlines; lnum--) {
+    if (chk_modeline(lnum, flags) == FAIL) {
       nmlines = 0;
-  --entered;
+    }
+  }
+  entered--;
 }
 
 /*
  * chk_modeline() - check a single line for a mode string
  * Return FAIL if an error encountered.
  */
-static int 
-chk_modeline (
+static int
+chk_modeline(
     linenr_T lnum,
-    int flags                      /* Same as for do_modelines(). */
+    int flags                      //  Same as for do_modelines().
 )
 {
   char_u      *s;
   char_u      *e;
-  char_u      *linecopy;                /* local copy of any modeline found */
+  char_u      *linecopy;                //  local copy of any modeline found
   int prev;
   intmax_t vers;
   int end;
@@ -4864,17 +5019,18 @@ chk_modeline (
   scid_T save_SID;
 
   prev = -1;
-  for (s = ml_get(lnum); *s != NUL; ++s) {
+  for (s = ml_get(lnum); *s != NUL; s++) {
     if (prev == -1 || ascii_isspace(prev)) {
       if ((prev != -1 && STRNCMP(s, "ex:", (size_t)3) == 0)
           || STRNCMP(s, "vi:", (size_t)3) == 0)
         break;
-      /* Accept both "vim" and "Vim". */
+      //  Accept both "vim" and "Vim".
       if ((s[0] == 'v' || s[0] == 'V') && s[1] == 'i' && s[2] == 'm') {
-        if (s[3] == '<' || s[3] == '=' || s[3] == '>')
+        if (s[3] == '<' || s[3] == '=' || s[3] == '>') {
           e = s + 4;
-        else
+        } else {
           e = s + 3;
+        }
         if (getdigits_safe(&e, &vers) != OK) {
           continue;
         }
@@ -4898,32 +5054,36 @@ chk_modeline (
     return retval;
   }
 
-  do                                  /* skip over "ex:", "vi:" or "vim:" */
-    ++s;
-  while (s[-1] != ':');
+  do {                                //  skip over "ex:", "vi:" or "vim:"
+    s++;
+  } while (s[-1] != ':');
 
-  s = linecopy = vim_strsave(s);      /* copy the line, it will change */
+  s = linecopy = vim_strsave(s);      //  copy the line, it will change
 
   save_sourcing_lnum = sourcing_lnum;
   save_sourcing_name = sourcing_name;
-  sourcing_lnum = lnum;               /* prepare for emsg() */
+  sourcing_lnum = lnum;               //  prepare for emsg()
   sourcing_name = (char_u *)"modelines";
 
-  end = FALSE;
-  while (end == FALSE) {
+  end = false;
+  while (end == false) {
     s = skipwhite(s);
-    if (*s == NUL)
+    if (*s == NUL) {
       break;
+    }
 
     /*
      * Find end of set command: ':' or end of line.
      * Skip over "\:", replacing it with ":".
      */
-    for (e = s; *e != ':' && *e != NUL; ++e)
-      if (e[0] == '\\' && e[1] == ':')
+    for (e = s; *e != ':' && *e != NUL; e++) {
+      if (e[0] == '\\' && e[1] == ':') {
         STRMOVE(e, e + 1);
-    if (*e == NUL)
-      end = TRUE;
+      }
+    }
+    if (*e == NUL) {
+      end = true;
+    }
 
     /*
      * If there is a "set" command, require a terminating ':' and
@@ -4934,27 +5094,29 @@ chk_modeline (
      */
     if (STRNCMP(s, "set ", (size_t)4) == 0
         || STRNCMP(s, "se ", (size_t)3) == 0) {
-      if (*e != ':')                  /* no terminating ':'? */
+      if (*e != ':') {                //  no terminating ':'?
         break;
-      end = TRUE;
+      }
+      end = true;
       s = vim_strchr(s, ' ') + 1;
     }
-    *e = NUL;                         /* truncate the set command */
+    *e = NUL;                         //  truncate the set command
 
-    if (*s != NUL) {                  /* skip over an empty "::" */
+    if (*s != NUL) {                  //  skip over an empty "::"
       save_SID = current_SID;
       current_SID = SID_MODELINE;
       // Make sure no risky things are executed as a side effect.
-      ++secure;
+      secure++;
 
       retval = do_set(s, OPT_MODELINE | OPT_LOCAL | flags);
 
-      --secure;
+      secure--;
       current_SID = save_SID;
-      if (retval == FAIL)                     /* stop if error found */
+      if (retval == FAIL) {                   //  stop if error found
         break;
+      }
     }
-    s = e + 1;                        /* advance to next part */
+    s = e + 1;                        //  advance to next part
   }
 
   sourcing_lnum = save_sourcing_lnum;
@@ -4985,20 +5147,23 @@ char_u *buf_spname(buf_T *buf)
      * For location list window, w_llist_ref points to the location list.
      * For quickfix window, w_llist_ref is NULL.
      */
-    if (find_win_for_buf(buf, &win, &tp) && win->w_llist_ref != NULL)
+    if (find_win_for_buf(buf, &win, &tp) && win->w_llist_ref != NULL) {
       return (char_u *)_(msg_loclist);
-    else
+    } else {
       return (char_u *)_(msg_qflist);
+    }
   }
   /* There is no _file_ when 'buftype' is "nofile", b_sfname
    * contains the name as specified by the user */
   if (bt_nofile(buf)) {
-    if (buf->b_sfname != NULL)
+    if (buf->b_sfname != NULL) {
       return buf->b_sfname;
+    }
     return (char_u *)_("[Scratch]");
   }
-  if (buf->b_fname == NULL)
+  if (buf->b_fname == NULL) {
     return (char_u *)_("[No Name]");
+  }
   return NULL;
 }
 
@@ -5030,13 +5195,13 @@ bool find_win_for_buf(buf_T *buf, win_T **wp, tabpage_T **tp)
  * Insert the sign into the signlist.
  */
 static void insert_sign(
-    buf_T *buf,             /* buffer to store sign in */
-    signlist_T *prev,       /* previous sign entry */
-    signlist_T *next,       /* next sign entry */
-    int id,                 /* sign ID */
-    linenr_T lnum,          /* line number which gets the mark */
-    int typenr              /* typenr of sign we are adding */
-    )
+    buf_T *buf,             //  buffer to store sign in
+    signlist_T *prev,       //  previous sign entry
+    signlist_T *next,       //  next sign entry
+    int id,                 //  sign ID
+    linenr_T lnum,          //  line number which gets the mark
+    int typenr              //  typenr of sign we are adding
+)
 {
     signlist_T *newsign = xmalloc(sizeof(signlist_T));
     newsign->id = id;
@@ -5057,7 +5222,7 @@ static void insert_sign(
             changed_cline_bef_curs();
         }
 
-        /* first sign in signlist */
+        //  first sign in signlist
         buf->b_signlist = newsign;
     }
     else {
@@ -5159,11 +5324,11 @@ int buf_signcols(buf_T *buf)
  * Add the sign into the signlist. Find the right spot to do it though.
  */
 void buf_addsign(
-    buf_T *buf,     /* buffer to store sign in */
-    int id,         /* sign ID */
-    linenr_T lnum,  /* line number which gets the mark */
-    int typenr      /* typenr of sign we are adding */
-    )
+    buf_T *buf,     //  buffer to store sign in
+    int id,         //  sign ID
+    linenr_T lnum,  //  line number which gets the mark
+    int typenr      //  typenr of sign we are adding
+)
 {
     signlist_T **lastp;  // pointer to pointer to current sign
     signlist_T *sign;    // a sign in the signlist
@@ -5220,12 +5385,12 @@ void buf_addsign(
 // For an existing, placed sign "markId" change the type to "typenr".
 // Returns the line number of the sign, or zero if the sign is not found.
 linenr_T buf_change_sign_type(
-    buf_T *buf,         /* buffer to store sign in */
-    int markId,         /* sign ID */
-    int typenr          /* typenr of sign we are adding */
-    )
+    buf_T *buf,         //  buffer to store sign in
+    int markId,         //  sign ID
+    int typenr          //  typenr of sign we are adding
+)
 {
-    signlist_T *sign;  /* a sign in the signlist */
+    signlist_T *sign;  //  a sign in the signlist
 
     for (sign = buf->b_signlist; sign != NULL; sign = sign->next) {
         if (sign->id == markId) {
@@ -5289,14 +5454,14 @@ int buf_getsigntype(buf_T *buf, linenr_T lnum, SignType type,
 }
 
 linenr_T buf_delsign(
-        buf_T *buf, /* buffer sign is stored in */
-        int id      /* sign id */
-        )
+    buf_T *buf,  //  buffer sign is stored in
+    int id       //  sign id
+)
 {
-    signlist_T **lastp; /* pointer to pointer to current sign */
-    signlist_T *sign;   /* a sign in a b_signlist */
-    signlist_T *next;   /* the next sign in a b_signlist */
-    linenr_T lnum;      /* line number whose sign was deleted */
+    signlist_T **lastp;  //  pointer to pointer to current sign
+    signlist_T *sign;    //  a sign in a b_signlist
+    signlist_T *next;    //  the next sign in a b_signlist
+    linenr_T lnum;       //  line number whose sign was deleted
 
     buf->b_signcols_max = -1;
     lastp = &buf->b_signlist;
@@ -5333,11 +5498,11 @@ linenr_T buf_delsign(
  * get loaded.
  */
 int buf_findsign(
-    buf_T *buf,      /* buffer to store sign in */
-    int id          /* sign ID */
-    )
+    buf_T *buf,      //  buffer to store sign in
+    int id          //  sign ID
+)
 {
-    signlist_T *sign;  /* a sign in the signlist */
+    signlist_T *sign;  //  a sign in the signlist
 
     for (sign = buf->b_signlist; sign != NULL; sign = sign->next) {
         if (sign->id == id) {
@@ -5349,11 +5514,11 @@ int buf_findsign(
 }
 
 int buf_findsign_id(
-    buf_T *buf,         /* buffer whose sign we are searching for */
-    linenr_T lnum       /* line number of sign */
-    )
+    buf_T *buf,         //  buffer whose sign we are searching for
+    linenr_T lnum       //  line number of sign
+)
 {
-    signlist_T *sign;   /* a sign in the signlist */
+    signlist_T *sign;   //  a sign in the signlist
 
     for (sign = buf->b_signlist; sign != NULL; sign = sign->next) {
         if (sign->lnum == lnum) {
@@ -5456,9 +5621,9 @@ void sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_a
             } else {
                 sign->lnum += amount;
             }
-        }
-        else if (sign->lnum > line2)
+        } else if (sign->lnum > line2) {
             sign->lnum += amount_after;
+        }
         lastp = &sign->next;
     }
 }
@@ -5813,10 +5978,11 @@ void set_buflisted(int on)
 {
   if (on != curbuf->b_p_bl) {
     curbuf->b_p_bl = on;
-    if (on)
-      apply_autocmds(EVENT_BUFADD, NULL, NULL, FALSE, curbuf);
-    else
-      apply_autocmds(EVENT_BUFDELETE, NULL, NULL, FALSE, curbuf);
+    if (on) {
+      apply_autocmds(EVENT_BUFADD, NULL, NULL, false, curbuf);
+    } else {
+      apply_autocmds(EVENT_BUFDELETE, NULL, NULL, false, curbuf);
+    }
   }
 }
 
@@ -5852,7 +6018,7 @@ bool buf_contents_changed(buf_T *buf)
     // compare the two files line by line
     if (buf->b_ml.ml_line_count == curbuf->b_ml.ml_line_count) {
       differ = false;
-      for (linenr_T lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {
+      for (linenr_T lnum = 1; lnum <= curbuf->b_ml.ml_line_count; lnum++) {
         if (STRCMP(ml_get_buf(buf, lnum, false), ml_get(lnum)) != 0) {
           differ = true;
           break;
@@ -5877,10 +6043,10 @@ bool buf_contents_changed(buf_T *buf)
  * this buffer.  Call this to wipe out a temp buffer that does not contain any
  * marks.
  */
-void 
-wipe_buffer (
+void
+wipe_buffer(
     buf_T *buf,
-    int aucmd                   /* When TRUE trigger autocommands. */
+    int aucmd                   //  When true trigger autocommands.
 )
 {
   if (!aucmd) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3296,11 +3296,13 @@ ambw_end:
        * '.encoding'.
        */
       for (p = q; *p != NUL; ++p)
-        if (vim_strchr((char_u *)"_.,", *p) != NULL)
+        if (!ASCII_ISALPHA(*p) && *p != '-')
           break;
-      vim_snprintf((char *)fname, sizeof(fname), "spell/%.*s.vim",
-                   (int)(p - q), q);
-      source_runtime(fname, DIP_ALL);
+      if (p > q) {
+        vim_snprintf((char *)fname, sizeof(fname), "spell/%.*s.vim",
+                     (int)(p - q), q);
+        source_runtime(fname, DIP_ALL);
+      }
     }
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1958,8 +1958,8 @@ static char_u *illegal_char(char_u *errbuf, size_t errbuflen, int c)
   if (errbuf == NULL) {
     return (char_u *)"";
   }
-  snprintf((char *)errbuf, errbuflen, _("E539: Illegal character <%s>"),
-           (char *)transchar(c));
+  vim_snprintf((char *)errbuf, errbuflen, _("E539: Illegal character <%s>"),
+               (char *)transchar(c));
   return errbuf;
 }
 
@@ -2896,9 +2896,9 @@ ambw_end:
 
         if (!ascii_isdigit(*(s - 1))) {
           if (errbuf != NULL) {
-            snprintf((char *)errbuf, errbuflen,
-                     _("E526: Missing number after <%s>"),
-                     transchar_byte(*(s - 1)));
+            vim_snprintf((char *)errbuf, errbuflen,
+                         _("E526: Missing number after <%s>"),
+                         transchar_byte(*(s - 1)));
             errmsg = errbuf;
           } else
             errmsg = (char_u *)"";
@@ -3074,9 +3074,9 @@ ambw_end:
           }
         } else {
           if (errbuf != NULL) {
-            snprintf((char *)errbuf, errbuflen,
-                     _("E535: Illegal character after <%c>"),
-                     *--s);
+            vim_snprintf((char *)errbuf, errbuflen,
+                         _("E535: Illegal character after <%c>"),
+                         *--s);
             errmsg = errbuf;
           } else
             errmsg = (char_u *)"";

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -601,9 +601,10 @@ void set_init_1(void)
       if (*names[n] == NUL) {
         p = "/tmp";
         mustfree = false;
-      } else {
+      } else
 # endif
-      p = vim_getenv(names[n]);
+      {
+        p = vim_getenv(names[n]);
       }
       if (p != NULL && *p != NUL) {
         // First time count the NUL, otherwise count the ','.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -98,10 +98,10 @@
 #define OPT_BOTH(x) (idopt_T)(PV_BOTH + (int)(x))
 
 
-/* WV_ and BV_ values get typecasted to this for the "indir" field */
+//  WV_ and BV_ values get typecasted to this for the "indir" field
 typedef enum {
   PV_NONE = 0,
-  PV_MAXVAL = 0xffff      /* to avoid warnings for value out of range */
+  PV_MAXVAL = 0xffff      //  to avoid warnings for value out of range
 } idopt_T;
 
 /*
@@ -175,7 +175,7 @@ static int p_udf;
 static long p_wm;
 static char_u   *p_keymap;
 
-/* Saved values for when 'bin' is set. */
+//  Saved values for when 'bin' is set.
 static int p_et_nobin;
 static int p_ml_nobin;
 static long p_tw_nobin;
@@ -202,28 +202,28 @@ typedef struct vimoption {
 # define SCRIPTID_INIT , 0
 } vimoption_T;
 
-#define VI_DEFAULT  0       /* def_val[VI_DEFAULT] is Vi default value */
-#define VIM_DEFAULT 1       /* def_val[VIM_DEFAULT] is Vim default value */
+#define VI_DEFAULT  0       //  def_val[VI_DEFAULT] is Vi default value
+#define VIM_DEFAULT 1       //  def_val[VIM_DEFAULT] is Vim default value
 
 /*
  * Flags
  */
-#define P_BOOL          0x01U    /* the option is boolean */
-#define P_NUM           0x02U    /* the option is numeric */
-#define P_STRING        0x04U    /* the option is a string */
-#define P_ALLOCED       0x08U    /* the string option is in allocated memory,
-                                    must use free_string_option() when
-                                    assigning new value. Not set if default is
-                                    the same. */
-#define P_EXPAND        0x10U    /* environment expansion.  NOTE: P_EXPAND can
-                                    never be used for local or hidden options */
-#define P_NODEFAULT     0x40U    /* don't set to default value */
-#define P_DEF_ALLOCED   0x80U    /* default value is in allocated memory, must
-                                    use free() when assigning new value */
-#define P_WAS_SET       0x100U   /* option has been set/reset */
-#define P_NO_MKRC       0x200U   /* don't include in :mkvimrc output */
-#define P_VI_DEF        0x400U   /* Use Vi default for Vim */
-#define P_VIM           0x800U   /* Vim option */
+#define P_BOOL          0x01U    //  the option is boolean
+#define P_NUM           0x02U    //  the option is numeric
+#define P_STRING        0x04U    //  the option is a string
+#define P_ALLOCED       0x08U    // the string option is in allocated memory,
+                                 // must use free_string_option() when
+                                 // assigning new value. Not set if default is
+                                 // the same.
+#define P_EXPAND        0x10U    // environment expansion.  NOTE: P_EXPAND can
+                                 // never be used for local or hidden options
+#define P_NODEFAULT     0x40U    //  don't set to default value
+#define P_DEF_ALLOCED   0x80U    // default value is in allocated memory, must
+                                 // use free() when assigning new value
+#define P_WAS_SET       0x100U   //  option has been set/reset
+#define P_NO_MKRC       0x200U   //  don't include in :mkvimrc output
+#define P_VI_DEF        0x400U   //  Use Vi default for Vim
+#define P_VIM           0x800U   //  Vim option
 
 // when option changed, what to display:
 #define P_RSTAT         0x1000U  ///< redraw status lines
@@ -313,6 +313,8 @@ static char *(p_scl_values[]) =       { "yes", "no", "auto", "auto:1", "auto:2",
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"
 #endif
+
+#define ERROR_BUFFER_LENGTH 80
 
 /// Append string with escaped commas
 static char *strcpy_comma_escaped(char *dest, const char *src, const size_t len)
@@ -564,8 +566,8 @@ void set_init_1(void)
 
   langmap_init();
 
-  /* Be nocompatible */
-  p_cp = FALSE;
+  //  Be nocompatible
+  p_cp = false;
 
   /*
    * Find default value for 'shell' option.
@@ -592,23 +594,24 @@ void set_init_1(void)
     garray_T ga;
 
     ga_init(&ga, 1, 100);
-    for (size_t n = 0; n < ARRAY_SIZE(names); ++n) {
+    for (size_t n = 0; n < ARRAY_SIZE(names); n++) {
       bool mustfree = true;
       char *p;
 # ifdef UNIX
       if (*names[n] == NUL) {
         p = "/tmp";
         mustfree = false;
-      }
-      else
+      } else {
 # endif
       p = vim_getenv(names[n]);
+      }
       if (p != NULL && *p != NUL) {
         // First time count the NUL, otherwise count the ','.
         len = (int)strlen(p) + 3;
         ga_grow(&ga, len);
-        if (!GA_EMPTY(&ga))
+        if (!GA_EMPTY(&ga)) {
           STRCAT(ga.ga_data, ",");
+        }
         STRCAT(ga.ga_data, p);
         add_pathsep(ga.ga_data);
         STRCAT(ga.ga_data, "*");
@@ -629,19 +632,20 @@ void set_init_1(void)
     int i;
     int j;
 
-    /* Initialize the 'cdpath' option's default value. */
+    //  Initialize the 'cdpath' option's default value.
     cdpath = (char_u *)vim_getenv("CDPATH");
     if (cdpath != NULL) {
       buf = xmalloc(2 * STRLEN(cdpath) + 2);
       {
-        buf[0] = ',';               /* start with ",", current dir first */
+        buf[0] = ',';               //  start with ",", current dir first
         j = 1;
-        for (i = 0; cdpath[i] != NUL; ++i) {
-          if (vim_ispathlistsep(cdpath[i]))
+        for (i = 0; cdpath[i] != NUL; i++) {
+          if (vim_ispathlistsep(cdpath[i])) {
             buf[j++] = ',';
-          else {
-            if (cdpath[i] == ' ' || cdpath[i] == ',')
+          } else {
+            if (cdpath[i] == ' ' || cdpath[i] == ',') {
               buf[j++] = '\\';
+            }
             buf[j++] = cdpath[i];
           }
         }
@@ -650,15 +654,16 @@ void set_init_1(void)
         if (opt_idx >= 0) {
           options[opt_idx].def_val[VI_DEFAULT] = buf;
           options[opt_idx].flags |= P_DEF_ALLOCED;
-        } else
-          xfree(buf);           /* cannot happen */
+        } else {
+          xfree(buf);           //  cannot happen
+        }
       }
       xfree(cdpath);
     }
   }
 
 #if defined(MSWIN) || defined(MAC)
-  /* Set print encoding on platforms that don't default to latin1 */
+  //  Set print encoding on platforms that don't default to latin1
   set_string_default("printencoding", "hp-roman8", false);
 #endif
 
@@ -703,19 +708,19 @@ void set_init_1(void)
 
 
   curbuf->b_p_initialized = true;
-  curbuf->b_p_ar = -1;          /* no local 'autoread' value */
+  curbuf->b_p_ar = -1;          //  no local 'autoread' value
   curbuf->b_p_ul = NO_LOCAL_UNDOLEVEL;
   check_buf_options(curbuf);
   check_win_options(curwin);
   check_options();
 
-  /* Set all options to their Vim default */
+  //  Set all options to their Vim default
   set_options_default(OPT_FREE);
 
   // set 'laststatus'
   last_status(false);
 
-  /* Must be before option_expand(), because that one needs vim_isIDc() */
+  //  Must be before option_expand(), because that one needs vim_isIDc()
   didset_options();
 
   // Use the current chartab for the generic chartab. This is not in
@@ -750,14 +755,15 @@ void set_init_1(void)
        * and Vim.  When this changes, add some code here!  Also need to
        * split P_DEF_ALLOCED in two.
        */
-      if (options[opt_idx].flags & P_DEF_ALLOCED)
+      if (options[opt_idx].flags & P_DEF_ALLOCED) {
         xfree(options[opt_idx].def_val[VI_DEFAULT]);
-      options[opt_idx].def_val[VI_DEFAULT] = (char_u *) p;
+      }
+      options[opt_idx].def_val[VI_DEFAULT] = (char_u *)p;
       options[opt_idx].flags |= P_DEF_ALLOCED;
     }
   }
 
-  save_file_ff(curbuf);         /* Buffer is unchanged */
+  save_file_ff(curbuf);         //  Buffer is unchanged
 
   /* Detect use of mlterm.
    * Mlterm is a terminal emulator akin to xterm that has some special
@@ -789,7 +795,7 @@ void set_init_1(void)
   (void)bind_textdomain_codeset(PROJECT_NAME, (char *)p_enc);
 #endif
 
-  /* Set the default for 'helplang'. */
+  //  Set the default for 'helplang'.
   set_helplang_default(get_mess_lang());
 }
 
@@ -797,20 +803,20 @@ void set_init_1(void)
  * Set an option to its default value.
  * This does not take care of side effects!
  */
-static void 
-set_option_default (
+static void
+set_option_default(
     int opt_idx,
-    int opt_flags,                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
-    int compatible                 /* use Vi default value */
+    int opt_flags,                  //  OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
+    int compatible                 //  use Vi default value
 )
 {
-  char_u      *varp;            /* pointer to variable for current option */
-  int dvi;                      /* index in def_val[] */
+  char_u      *varp;            //  pointer to variable for current option
+  int dvi;                      //  index in def_val[]
   int both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
 
   varp = get_varp_scope(&(options[opt_idx]), both ? OPT_LOCAL : opt_flags);
   uint32_t flags = options[opt_idx].flags;
-  if (varp != NULL) {       /* skip hidden option, nothing to do for it */
+  if (varp != NULL) {       //  skip hidden option, nothing to do for it
     dvi = ((flags & P_VI_DEF) || compatible) ? VI_DEFAULT : VIM_DEFAULT;
     if (flags & P_STRING) {
       /* Use set_string_option_direct() for local options to handle
@@ -836,20 +842,22 @@ set_option_default (
             *(long *)varp;
         }
       }
-    } else {  /* P_BOOL */
+    } else {  //  P_BOOL
       *(int *)varp = (int)(intptr_t)options[opt_idx].def_val[dvi];
 #ifdef UNIX
-      /* 'modeline' defaults to off for root */
-      if (options[opt_idx].indir == PV_ML && getuid() == ROOT_UID)
-        *(int *)varp = FALSE;
+      //  'modeline' defaults to off for root
+      if (options[opt_idx].indir == PV_ML && getuid() == ROOT_UID) {
+        *(int *)varp = false;
+      }
 #endif
-      /* May also set global value for local option. */
-      if (both)
+      //  May also set global value for local option.
+      if (both) {
         *(int *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL) =
           *(int *)varp;
+      }
     }
 
-    /* The default value is not insecure. */
+    //  The default value is not insecure.
     uint32_t *flagsp = insecure_flag(opt_idx, opt_flags);
     *flagsp = *flagsp & ~P_INSECURE;
   }
@@ -860,9 +868,9 @@ set_option_default (
 /*
  * Set all options (except terminal options) to their default value.
  */
-static void 
-set_options_default (
-    int opt_flags                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
+static void
+set_options_default(
+    int opt_flags                  //  OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
 )
 {
   for (int i = 0; options[i].fullname; i++) {
@@ -871,7 +879,7 @@ set_options_default (
     }
   }
 
-  /* The 'scroll' option must be computed for all windows. */
+  //  The 'scroll' option must be computed for all windows.
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     win_comp_scroll(wp);
   }
@@ -1058,8 +1066,9 @@ void set_helplang_default(const char *lang)
   }
   int idx = findoption("hlg");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET)) {
-    if (options[idx].flags & P_ALLOCED)
+    if (options[idx].flags & P_ALLOCED) {
       free_string_option(p_hlg);
+    }
     p_hlg = (char_u *)xmemdupz(lang, lang_len);
     // zh_CN becomes "cn", zh_TW becomes "tw".
     if (STRNICMP(p_hlg, "zh_", 3) == 0 && STRLEN(p_hlg) >= 5) {
@@ -1119,40 +1128,40 @@ void set_title_defaults(void)
  *
  * returns FAIL if an error is detected, OK otherwise
  */
-int 
-do_set (
-    char_u *arg,               /* option string (may be written to!) */
+int
+do_set(
+    char_u *arg,               //  option string (may be written to!)
     int opt_flags
 )
 {
   int opt_idx;
   char_u      *errmsg;
-  char_u errbuf[80];
+  char_u errbuf[ERROR_BUFFER_LENGTH];
   char_u      *startarg;
-  int prefix;           /* 1: nothing, 0: "no", 2: "inv" in front of name */
-  char_u nextchar;                  /* next non-white char after option name */
-  int afterchar;                    /* character just after option name */
+  int prefix;           //  1: nothing, 0: "no", 2: "inv" in front of name
+  char_u nextchar;                  //  next non-white char after option name
+  int afterchar;                    //  character just after option name
   int len;
   int i;
   varnumber_T value;
   int key;
-  uint32_t flags;                   /* flags for current option */
-  char_u      *varp = NULL;         /* pointer to variable for current option */
-  int did_show = FALSE;             /* already showed one value */
-  int adding;                       /* "opt+=arg" */
-  int prepending;                   /* "opt^=arg" */
-  int removing;                     /* "opt-=arg" */
+  uint32_t flags;                   //  flags for current option
+  char_u      *varp = NULL;         //  pointer to variable for current option
+  int did_show = false;             //  already showed one value
+  int adding;                       //  "opt+=arg"
+  int prepending;                   //  "opt^=arg"
+  int removing;                     //  "opt-=arg"
   int cp_val = 0;
 
   if (*arg == NUL) {
     showoptions(0, opt_flags);
-    did_show = TRUE;
+    did_show = true;
     goto theend;
   }
 
-  while (*arg != NUL) {         /* loop to process all options */
+  while (*arg != NUL) {         //  loop to process all options
     errmsg = NULL;
-    startarg = arg;             /* remember for error message */
+    startarg = arg;             //  remember for error message
 
     if (STRNCMP(arg, "all", 3) == 0 && !isalpha(arg[3])
         && !(opt_flags & OPT_MODELINE)) {
@@ -1171,7 +1180,7 @@ do_set (
         redraw_all_later(CLEAR);
       } else {
         showoptions(1, opt_flags);
-        did_show = TRUE;
+        did_show = true;
       }
     } else {
       prefix = 1;
@@ -1183,17 +1192,18 @@ do_set (
         arg += 3;
       }
 
-      /* find end of name */
+      //  find end of name
       key = 0;
       if (*arg == '<') {
         opt_idx = -1;
-        /* look out for <t_>;> */
-        if (arg[1] == 't' && arg[2] == '_' && arg[3] && arg[4])
+        //  look out for <t_>;>
+        if (arg[1] == 't' && arg[2] == '_' && arg[3] && arg[4]) {
           len = 5;
-        else {
+        } else {
           len = 1;
-          while (arg[len] != NUL && arg[len] != '>')
-            ++len;
+          while (arg[len] != NUL && arg[len] != '>') {
+            len++;
+          }
         }
         if (arg[len] != '>') {
           errmsg = e_invarg;
@@ -1222,43 +1232,45 @@ do_set (
         }
       }
 
-      /* remember character after option name */
+      //  remember character after option name
       afterchar = arg[len];
 
-      /* skip white space, allow ":set ai  ?" */
-      while (ascii_iswhite(arg[len]))
-        ++len;
+      //  skip white space, allow ":set ai  ?"
+      while (ascii_iswhite(arg[len])) {
+        len++;
+      }
 
-      adding = FALSE;
-      prepending = FALSE;
-      removing = FALSE;
+      adding = false;
+      prepending = false;
+      removing = false;
       if (arg[len] != NUL && arg[len + 1] == '=') {
         if (arg[len] == '+') {
-          adding = TRUE;                        /* "+=" */
-          ++len;
+          adding = true;                        //  "+="
+          len++;
         } else if (arg[len] == '^') {
-          prepending = TRUE;                    /* "^=" */
-          ++len;
+          prepending = true;                    //  "^="
+          len++;
         } else if (arg[len] == '-') {
-          removing = TRUE;                      /* "-=" */
-          ++len;
+          removing = true;                      //  "-="
+          len++;
         }
       }
       nextchar = arg[len];
 
-      if (opt_idx == -1 && key == 0) {          /* found a mismatch: skip */
+      if (opt_idx == -1 && key == 0) {          //  found a mismatch: skip
         errmsg = (char_u *)N_("E518: Unknown option");
         goto skip;
       }
 
       if (opt_idx >= 0) {
-        if (options[opt_idx].var == NULL) {         /* hidden option: skip */
-          /* Only give an error message when requesting the value of
-           * a hidden option, ignore setting it. */
+        if (options[opt_idx].var == NULL) {         //  hidden option: skip
+          // Only give an error message when requesting the value of
+          // a hidden option, ignore setting it.
           if (vim_strchr((char_u *)"=:!&<", nextchar) == NULL
               && (!(options[opt_idx].flags & P_BOOL)
-                  || nextchar == '?'))
+                  || nextchar == '?')) {
             errmsg = (char_u *)_(e_unsupportedoption);
+          }
           goto skip;
         }
 
@@ -1274,28 +1286,30 @@ do_set (
           && (opt_idx < 0 || options[opt_idx].var != VAR_WIN))
         goto skip;
 
-      /* Skip all options that are window-local (used for :vimgrep). */
+      //  Skip all options that are window-local (used for :vimgrep).
       if ((opt_flags & OPT_NOWIN) && opt_idx >= 0
-          && options[opt_idx].var == VAR_WIN)
+          && options[opt_idx].var == VAR_WIN) {
         goto skip;
+      }
 
-      /* Disallow changing some options from modelines. */
+      //  Disallow changing some options from modelines.
       if (opt_flags & OPT_MODELINE) {
         if (flags & (P_SECURE | P_NO_ML)) {
           errmsg = (char_u *)_("E520: Not allowed in a modeline");
           goto skip;
         }
-        /* In diff mode some options are overruled.  This avoids that
-         * 'foldmethod' becomes "marker" instead of "diff" and that
-         * "wrap" gets set. */
+        // In diff mode some options are overruled.  This avoids that
+        // 'foldmethod' becomes "marker" instead of "diff" and that
+        // "wrap" gets set.
         if (curwin->w_p_diff
-            && opt_idx >= 0              /* shut up coverity warning */
+            && opt_idx >= 0              //  shut up coverity warning
             && (options[opt_idx].indir == PV_FDM
-                || options[opt_idx].indir == PV_WRAP))
+                || options[opt_idx].indir == PV_WRAP)) {
           goto skip;
+        }
       }
 
-      /* Disallow changing some options in the sandbox */
+      //  Disallow changing some options in the sandbox
       if (sandbox != 0 && (flags & P_SECURE)) {
         errmsg = (char_u *)_(e_sandbox);
         goto skip;
@@ -1305,11 +1319,11 @@ do_set (
         arg += len;
         cp_val = p_cp;
         if (nextchar == '&' && arg[1] == 'v' && arg[2] == 'i') {
-          if (arg[3] == 'm') {          /* "opt&vim": set to Vim default */
-            cp_val = FALSE;
+          if (arg[3] == 'm') {          //  "opt&vim": set to Vim default
+            cp_val = false;
             arg += 3;
-          } else {                    /* "opt&vi": set to Vi default */
-            cp_val = TRUE;
+          } else {                    //  "opt&vi": set to Vi default
+            cp_val = true;
             arg += 2;
           }
         }
@@ -1331,11 +1345,11 @@ do_set (
         /*
          * print value
          */
-        if (did_show)
-          msg_putchar('\n');                /* cursor below last one */
-        else {
-          gotocmdline(TRUE);                /* cursor at status line */
-          did_show = TRUE;                  /* remember that we did a line */
+        if (did_show) {
+          msg_putchar('\n');                //  cursor below last one
+        } else {
+          gotocmdline(true);                //  cursor at status line
+          did_show = true;                  //  remember that we did a line
         }
         if (opt_idx >= 0) {
           showoneopt(&options[opt_idx], opt_flags);
@@ -1359,11 +1373,10 @@ do_set (
             && nextchar != NUL && !ascii_iswhite(afterchar))
           errmsg = e_trailing;
       } else {
-
         int value_is_replaced = !prepending && !adding && !removing;
         int value_checked = false;
 
-        if (flags & P_BOOL) {                       /* boolean */
+        if (flags & P_BOOL) {                       // boolean
           if (nextchar == '=' || nextchar == ':') {
             errmsg = e_invarg;
             goto skip;
@@ -1374,20 +1387,21 @@ do_set (
            * ":set opt&": reset to default value
            * ":set opt<": reset to global value
            */
-          if (nextchar == '!')
+          if (nextchar == '!') {
             value = *(int *)(varp) ^ 1;
-          else if (nextchar == '&')
+          } else if (nextchar == '&') {
             value = (int)(intptr_t)options[opt_idx].def_val[
-              ((flags & P_VI_DEF) || cp_val)
-              ?  VI_DEFAULT : VIM_DEFAULT];
-          else if (nextchar == '<') {
-            /* For 'autoread' -1 means to use global value. */
+                ((flags & P_VI_DEF) || cp_val)
+                ?  VI_DEFAULT : VIM_DEFAULT];
+          } else if (nextchar == '<') {
+            //  For 'autoread' -1 means to use global value.
             if ((int *)varp == &curbuf->b_p_ar
-                && opt_flags == OPT_LOCAL)
+                && opt_flags == OPT_LOCAL) {
               value = -1;
-            else
+            } else {
               value = *(int *)get_varp_scope(&(options[opt_idx]),
-                  OPT_GLOBAL);
+                                             OPT_GLOBAL);
+            }
           } else {
             /*
              * ":set invopt": invert
@@ -1397,10 +1411,11 @@ do_set (
               errmsg = e_trailing;
               goto skip;
             }
-            if (prefix == 2)                    /* inv */
+            if (prefix == 2) {                  //  inv
               value = *(int *)(varp) ^ 1;
-            else
+            } else {
               value = prefix;
+            }
           }
 
           errmsg = (char_u *)set_bool_option(opt_idx, varp, (int)value,
@@ -1412,16 +1427,14 @@ do_set (
             goto skip;
           }
 
-          if (flags & P_NUM) {                      /* numeric */
-            /*
-             * Different ways to set a number option:
-             * &	    set to default value
-             * <	    set to global value
-             * <xx>	    accept special key codes for 'wildchar'
-             * c	    accept any non-digit for 'wildchar'
-             * [-]0-9   set number
-             * other    error
-             */
+          if (flags & P_NUM) {                      //  numeric
+            // Different ways to set a number option:
+            // &            set to default value
+            // <            set to global value
+            // <xx>         accept special key codes for 'wildchar'
+            // c            accept any non-digit for 'wildchar'
+            // [-]0-9   set number
+            // other    error
             arg++;
             if (nextchar == '&') {
               value = (long)(intptr_t)options[opt_idx].def_val[
@@ -1526,10 +1539,10 @@ do_set (
               }
             } else if (nextchar == '<') {  // set to global val
               newval = vim_strsave(*(char_u **)get_varp_scope(
-                      &(options[opt_idx]), OPT_GLOBAL));
-              new_value_alloced = TRUE;
+                  &(options[opt_idx]), OPT_GLOBAL));
+              new_value_alloced = true;
             } else {
-              ++arg;                    /* jump to after the '=' or ':' */
+              arg++;                    //  jump to after the '=' or ':'
 
               /*
                * Set 'keywordprg' to ":help" if an empty
@@ -1577,18 +1590,24 @@ do_set (
                        && ascii_isdigit(*arg)) {
                 *errbuf = NUL;
                 i = getdigits_int(&arg);
-                if (i & 1)
+                if (i & 1) {
                   STRCAT(errbuf, "b,");
-                if (i & 2)
+                }
+                if (i & 2) {
                   STRCAT(errbuf, "s,");
-                if (i & 4)
+                }
+                if (i & 4) {
                   STRCAT(errbuf, "h,l,");
-                if (i & 8)
+                }
+                if (i & 8) {
                   STRCAT(errbuf, "<,>,");
-                if (i & 16)
+                }
+                if (i & 16) {
                   STRCAT(errbuf, "[,],");
-                if (*errbuf != NUL)                     /* remove trailing , */
+                }
+                if (*errbuf != NUL) {                   //  remove trailing ,
                   errbuf[STRLEN(errbuf) - 1] = NUL;
+                }
                 save_arg = arg;
                 arg = errbuf;
               }
@@ -1599,7 +1618,7 @@ do_set (
               else if (  *arg == '>'
                          && (varp == (char_u *)&p_dir
                              || varp == (char_u *)&p_bdir)) {
-                ++arg;
+                arg++;
               }
 
               /*
@@ -1607,10 +1626,11 @@ do_set (
                * Can't use set_string_option_direct(), because
                * we need to remove the backslashes.
                */
-              /* get a bit too much */
+              //  get a bit too much
               newlen = (unsigned)STRLEN(arg) + 1;
-              if (adding || prepending || removing)
+              if (adding || prepending || removing) {
                 newlen += (unsigned)STRLEN(origval) + 1;
+              }
               newval = xmalloc(newlen);
               s = newval;
 
@@ -1632,10 +1652,10 @@ do_set (
                                  && arg[2] != '\\')))
 #endif
                     )
-                  ++arg;                        /* remove backslash */
+                  arg++;                        //  remove backslash
                 if (has_mbyte
                     && (i = (*mb_ptr2len)(arg)) > 1) {
-                  /* copy multibyte char */
+                  //  copy multibyte char
                   memmove(s, arg, (size_t)i);
                   arg += i;
                   s += i;
@@ -1655,8 +1675,9 @@ do_set (
                 if (s != NULL) {
                   xfree(newval);
                   newlen = (unsigned)STRLEN(s) + 1;
-                  if (adding || prepending || removing)
+                  if (adding || prepending || removing) {
                     newlen += (unsigned)STRLEN(origval) + 1;
+                  }
                   newval = xmalloc(newlen);
                   STRCPY(newval, s);
                 }
@@ -1664,11 +1685,11 @@ do_set (
 
               /* locate newval[] in origval[] when removing it
                * and when adding to avoid duplicates */
-              i = 0;                    /* init for GCC */
+              i = 0;                    //  init for GCC
               if (removing || (flags & P_NODUP)) {
                 i = (int)STRLEN(newval);
                 bs = 0;
-                for (s = origval; *s; ++s) {
+                for (s = origval; *s; s++) {
                   if ((!(flags & P_COMMA)
                        || s == origval
                        || (s[-1] == ',' && !(bs & 1)))
@@ -1691,8 +1712,8 @@ do_set (
 
                 // do not add if already there
                 if ((adding || prepending) && *s) {
-                  prepending = FALSE;
-                  adding = FALSE;
+                  prepending = false;
+                  adding = false;
                   STRCPY(newval, origval);
                 }
               }
@@ -1718,8 +1739,9 @@ do_set (
                   i = (int)STRLEN(newval);
                   STRMOVE(newval + i + comma, origval);
                 }
-                if (comma)
+                if (comma) {
                   newval[i] = ',';
+                }
               }
 
               /* Remove newval[] from origval[]. (Note: "i" has
@@ -1727,16 +1749,17 @@ do_set (
               if (removing) {
                 STRCPY(newval, origval);
                 if (*s) {
-                  /* may need to remove a comma */
+                  //  may need to remove a comma
                   if (flags & P_COMMA) {
                     if (s == origval) {
-                      /* include comma after string */
-                      if (s[i] == ',')
-                        ++i;
+                      //  include comma after string
+                      if (s[i] == ',') {
+                        i++;
+                      }
                     } else {
-                      /* include comma before string */
-                      --s;
-                      ++i;
+                      //  include comma before string
+                      s--;
+                      i++;
                     }
                   }
                   STRMOVE(newval + (s - origval), s + i);
@@ -1766,9 +1789,10 @@ do_set (
                 }
               }
 
-              if (save_arg != NULL)                 /* number for 'whichwrap' */
+              if (save_arg != NULL) {               //  number for 'whichwrap'
                 arg = save_arg;
-              new_value_alloced = TRUE;
+              }
+              new_value_alloced = true;
             }
 
             // Set the new value.
@@ -1784,7 +1808,7 @@ do_set (
 
             {
               unsigned int *p = insecure_flag(opt_idx, opt_flags);
-              int     did_inc_secure = FALSE;
+              int     did_inc_secure = false;
 
               // When an option is set in the sandbox, from a
               // modeline or in secure mode, then deal with side
@@ -1793,13 +1817,12 @@ do_set (
               // completely replaced.
               if (secure
 #ifdef HAVE_SANDBOX
-                      || sandbox != 0
+                  || sandbox != 0
 #endif
-                      || (opt_flags & OPT_MODELINE)
-                      || (!value_is_replaced && (*p & P_INSECURE)))
-              {
-                  did_inc_secure = TRUE;
-                  ++secure;
+                  || (opt_flags & OPT_MODELINE)
+                  || (!value_is_replaced && (*p & P_INSECURE))) {
+                  did_inc_secure = true;
+                  secure++;
               }
 
               // Handle side effects, and set the global value for
@@ -1807,10 +1830,12 @@ do_set (
               // or 'filetype' autocommands may be triggered that can
               // cause havoc.
               errmsg = did_set_string_option(opt_idx, (char_u **)varp,
-                  new_value_alloced, oldval, errbuf, opt_flags, &value_checked);
+                                             new_value_alloced, oldval,
+                                             errbuf, ERROR_BUFFER_LENGTH,
+                                             opt_flags, &value_checked);
 
               if (did_inc_secure) {
-                --secure;
+                secure--;
               }
           }
 
@@ -1838,8 +1863,9 @@ do_set (
           }
         }
 
-        if (opt_idx >= 0)
+        if (opt_idx >= 0) {
           did_set_option(opt_idx, opt_flags, value_is_replaced, value_checked);
+        }
       }
 
 skip:
@@ -1849,13 +1875,16 @@ skip:
        * - skip blanks
        * - skip one "=val" argument (for hidden options ":set gfn =xx")
        */
-      for (i = 0; i < 2; ++i) {
-        while (*arg != NUL && !ascii_iswhite(*arg))
-          if (*arg++ == '\\' && *arg != NUL)
-            ++arg;
+      for (i = 0; i < 2; i++) {
+        while (*arg != NUL && !ascii_iswhite(*arg)) {
+          if (*arg++ == '\\' && *arg != NUL) {
+            arg++;
+          }
+        }
         arg = skipwhite(arg);
-        if (*arg != '=')
+        if (*arg != '=') {
           break;
+        }
       }
     }
 
@@ -1863,18 +1892,18 @@ skip:
       STRLCPY(IObuff, _(errmsg), IOSIZE);
       i = (int)STRLEN(IObuff) + 2;
       if (i + (arg - startarg) < IOSIZE) {
-        /* append the argument with the error */
+        //  append the argument with the error
         STRCAT(IObuff, ": ");
         assert(arg >= startarg);
         memmove(IObuff + i, startarg, (size_t)(arg - startarg));
         IObuff[i + (arg - startarg)] = NUL;
       }
-      /* make sure all characters are printable */
+      //  make sure all characters are printable
       trans_characters(IObuff, IOSIZE);
 
-      ++no_wait_return;         /* wait_return done later */
-      emsg(IObuff);             /* show error highlighted */
-      --no_wait_return;
+      no_wait_return++;         //  wait_return done later
+      emsg(IObuff);             //  show error highlighted
+      no_wait_return--;
 
       return FAIL;
     }
@@ -1884,13 +1913,13 @@ skip:
 
 theend:
   if (silent_mode && did_show) {
-    /* After displaying option values in silent mode. */
-    silent_mode = FALSE;
-    info_message = TRUE;        /* use mch_msg(), not mch_errmsg() */
+    //  After displaying option values in silent mode.
+    silent_mode = false;
+    info_message = true;        //  use mch_msg(), not mch_errmsg()
     msg_putchar('\n');
     ui_flush();
-    silent_mode = TRUE;
-    info_message = FALSE;       /* use mch_msg(), not mch_errmsg() */
+    silent_mode = true;
+    info_message = false;       //  use mch_msg(), not mch_errmsg()
   }
 
   return OK;
@@ -1900,13 +1929,13 @@ theend:
  * Call this when an option has been given a new value through a user command.
  * Sets the P_WAS_SET flag and takes care of the P_INSECURE flag.
  */
-static void 
-did_set_option (
+static void
+did_set_option(
     int opt_idx,
-    int opt_flags,              /* possibly with OPT_MODELINE */
-    int new_value,              /* value was replaced completely */
-    int value_checked           /* value was checked to be safe, no need to
-                                   set P_INSECURE */
+    int opt_flags,              //  possibly with OPT_MODELINE
+    int new_value,              //  value was replaced completely
+    int value_checked           // value was checked to be safe, no need to
+                                // set P_INSECURE
 )
 {
   options[opt_idx].flags |= P_WAS_SET;
@@ -1916,19 +1945,21 @@ did_set_option (
    * flag. */
   uint32_t *p = insecure_flag(opt_idx, opt_flags);
   if (!value_checked && (secure
-      || sandbox != 0
-      || (opt_flags & OPT_MODELINE)))
+                         || sandbox != 0
+                         || (opt_flags & OPT_MODELINE))) {
     *p = *p | P_INSECURE;
-  else if (new_value)
+  } else if (new_value) {
     *p = *p & ~P_INSECURE;
+  }
 }
 
-static char_u *illegal_char(char_u *errbuf, int c)
+static char_u *illegal_char(char_u *errbuf, size_t errbuflen, int c)
 {
-  if (errbuf == NULL)
+  if (errbuf == NULL) {
     return (char_u *)"";
-  sprintf((char *)errbuf, _("E539: Illegal character <%s>"),
-      (char *)transchar(c));
+  }
+  snprintf((char *)errbuf, errbuflen, _("E539: Illegal character <%s>"),
+           (char *)transchar(c));
   return errbuf;
 }
 
@@ -1938,10 +1969,12 @@ static char_u *illegal_char(char_u *errbuf, int c)
  */
 static int string_to_key(char_u *arg)
 {
-  if (*arg == '<')
+  if (*arg == '<') {
     return find_key_option(arg + 1);
-  if (*arg == '^')
+  }
+  if (*arg == '^') {
     return Ctrl_chr(arg[1]);
+  }
   return *arg;
 }
 
@@ -1953,12 +1986,13 @@ static char_u *check_cedit(void)
 {
   int n;
 
-  if (*p_cedit == NUL)
+  if (*p_cedit == NUL) {
     cedit_key = -1;
-  else {
+  } else {
     n = string_to_key(p_cedit);
-    if (vim_isprintc(n))
+    if (vim_isprintc(n)) {
       return e_invarg;
+    }
     cedit_key = n;
   }
   return NULL;
@@ -1970,9 +2004,9 @@ static char_u *check_cedit(void)
  * When switching the title or icon off, call ui_set_{icon,title}(NULL) to get
  * the old value back.
  */
-static void 
-did_set_title (
-    int icon                   /* Did set icon instead of title */
+static void
+did_set_title(
+    int icon                   //  Did set icon instead of title
 )
 {
   if (starting != NO_SCREEN) {
@@ -1984,11 +2018,11 @@ did_set_title (
 /*
  * set_options_bin -  called when 'bin' changes value.
  */
-void 
-set_options_bin (
+void
+set_options_bin(
     int oldval,
     int newval,
-    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
+    int opt_flags                  //  OPT_LOCAL and/or OPT_GLOBAL
 )
 {
   /*
@@ -1996,7 +2030,7 @@ set_options_bin (
    * copied when 'bin is set and restored when 'bin' is reset.
    */
   if (newval) {
-    if (!oldval) {              /* switched on */
+    if (!oldval) {              //  switched on
       if (!(opt_flags & OPT_GLOBAL)) {
         curbuf->b_p_tw_nobin = curbuf->b_p_tw;
         curbuf->b_p_wm_nobin = curbuf->b_p_wm;
@@ -2012,19 +2046,19 @@ set_options_bin (
     }
 
     if (!(opt_flags & OPT_GLOBAL)) {
-      curbuf->b_p_tw = 0;       /* no automatic line wrap */
-      curbuf->b_p_wm = 0;       /* no automatic line wrap */
-      curbuf->b_p_ml = 0;       /* no modelines */
-      curbuf->b_p_et = 0;       /* no expandtab */
+      curbuf->b_p_tw = 0;       //  no automatic line wrap
+      curbuf->b_p_wm = 0;       //  no automatic line wrap
+      curbuf->b_p_ml = 0;       //  no modelines
+      curbuf->b_p_et = 0;       //  no expandtab
     }
     if (!(opt_flags & OPT_LOCAL)) {
       p_tw = 0;
       p_wm = 0;
-      p_ml = FALSE;
-      p_et = FALSE;
-      p_bin = TRUE;             /* needed when called for the "-b" argument */
+      p_ml = false;
+      p_et = false;
+      p_bin = true;             //  needed when called for the "-b" argument
     }
-  } else if (oldval) {        /* switched off */
+  } else if (oldval) {        //  switched off
     if (!(opt_flags & OPT_GLOBAL)) {
       curbuf->b_p_tw = curbuf->b_p_tw_nobin;
       curbuf->b_p_wm = curbuf->b_p_wm_nobin;
@@ -2052,8 +2086,9 @@ int get_shada_parameter(int type)
   char_u  *p;
 
   p = find_shada_parameter(type);
-  if (p != NULL && ascii_isdigit(*p))
+  if (p != NULL && ascii_isdigit(*p)) {
     return atoi((char *)p);
+  }
   return -1;
 }
 
@@ -2066,14 +2101,17 @@ char_u *find_shada_parameter(int type)
 {
   char_u  *p;
 
-  for (p = p_shada; *p; ++p) {
-    if (*p == type)
+  for (p = p_shada; *p; p++) {
+    if (*p == type) {
       return p + 1;
-    if (*p == 'n')                  /* 'n' is always the last one */
+    }
+    if (*p == 'n') {                //  'n' is always the last one
       break;
-    p = vim_strchr(p, ',');         /* skip until next ',' */
-    if (p == NULL)                  /* hit the end without finding parameter */
+    }
+    p = vim_strchr(p, ',');         //  skip until next ','
+    if (p == NULL) {                //  hit the end without finding parameter
       break;
+    }
   }
   return NULL;
 }
@@ -2086,9 +2124,10 @@ char_u *find_shada_parameter(int type)
  */
 static char_u *option_expand(int opt_idx, char_u *val)
 {
-  /* if option doesn't need expansion nothing to do */
-  if (!(options[opt_idx].flags & P_EXPAND) || options[opt_idx].var == NULL)
+  //  if option doesn't need expansion nothing to do
+  if (!(options[opt_idx].flags & P_EXPAND) || options[opt_idx].var == NULL) {
     return NULL;
+  }
 
   if (val == NULL) {
     val = *(char_u **)options[opt_idx].var;
@@ -2107,11 +2146,12 @@ static char_u *option_expand(int opt_idx, char_u *val)
    * For 'spellsuggest' expand after "file:".
    */
   expand_env_esc(val, NameBuff, MAXPATHL,
-      (char_u **)options[opt_idx].var == &p_tags, FALSE,
-      (char_u **)options[opt_idx].var == &p_sps ? (char_u *)"file:" :
-      NULL);
-  if (STRCMP(NameBuff, val) == 0)     /* they are the same */
+                 (char_u **)options[opt_idx].var == &p_tags, false,
+                 (char_u **)options[opt_idx].var == &p_sps ? (char_u *)"file:" :
+                 NULL);
+  if (STRCMP(NameBuff, val) == 0) {   //  they are the same
     return NULL;
+  }
 
   return NameBuff;
 }
@@ -2122,7 +2162,7 @@ static char_u *option_expand(int opt_idx, char_u *val)
  */
 static void didset_options(void)
 {
-  /* initialize the table for 'iskeyword' et.al. */
+  //  initialize the table for 'iskeyword' et.al.
   (void)init_chartab();
 
   (void)opt_strings_flags(p_cmp, p_cmp_values, &cmp_flags, true);
@@ -2171,9 +2211,11 @@ void check_options(void)
 {
   int opt_idx;
 
-  for (opt_idx = 0; options[opt_idx].fullname != NULL; opt_idx++)
-    if ((options[opt_idx].flags & P_STRING) && options[opt_idx].var != NULL)
+  for (opt_idx = 0; options[opt_idx].fullname != NULL; opt_idx++) {
+    if ((options[opt_idx].flags & P_STRING) && options[opt_idx].var != NULL) {
       check_string_option((char_u **)get_varp(&(options[opt_idx])));
+    }
+  }
 }
 
 /*
@@ -2239,28 +2281,29 @@ void check_buf_options(buf_T *buf)
  */
 void free_string_option(char_u *p)
 {
-  if (p != empty_option)
+  if (p != empty_option) {
     xfree(p);
+  }
 }
 
 void clear_string_option(char_u **pp)
 {
-  if (*pp != empty_option)
+  if (*pp != empty_option) {
     xfree(*pp);
+  }
   *pp = empty_option;
 }
 
 static void check_string_option(char_u **pp)
 {
-  if (*pp == NULL)
+  if (*pp == NULL) {
     *pp = empty_option;
+  }
 }
 
-/*
- * Return TRUE when option "opt" was set from a modeline or in secure mode.
- * Return FALSE when it wasn't.
- * Return -1 for an unknown option.
- */
+/// Return true when option "opt" was set from a modeline or in secure mode.
+/// Return false when it wasn't.
+/// Return -1 for an unknown option.
 int was_set_insecurely(char_u *opt, int opt_flags)
 {
   int idx = findoption((const char *)opt);
@@ -2289,7 +2332,7 @@ static uint32_t *insecure_flag(int opt_idx, int opt_flags)
     case PV_INEX:       return &curbuf->b_p_inex_flags;
     }
 
-  /* Nothing special, return global flags field. */
+  //  Nothing special, return global flags field.
   return &options[opt_idx].flags;
 }
 
@@ -2297,9 +2340,10 @@ static uint32_t *insecure_flag(int opt_idx, int opt_flags)
 /*
  * Redraw the window title and/or tab page text later.
  */
-static void redraw_titles(void) {
-  need_maketitle = TRUE;
-  redraw_tabline = TRUE;
+static void redraw_titles(void)
+{
+  need_maketitle = true;
+  redraw_tabline = true;
 }
 
 static int shada_idx = -1;
@@ -2311,12 +2355,12 @@ static int shada_idx = -1;
  * When "set_sid" is zero set the scriptID to current_SID.  When "set_sid" is
  * SID_NONE don't set the scriptID.  Otherwise set the scriptID to "set_sid".
  */
-void 
-set_string_option_direct (
+void
+set_string_option_direct(
     char_u *name,
     int opt_idx,
     char_u *val,
-    int opt_flags,                  /* OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL */
+    int opt_flags,                  //  OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
     int set_sid
 )
 {
@@ -2334,22 +2378,25 @@ set_string_option_direct (
     }
   }
 
-  if (options[idx].var == NULL)         /* can't set hidden option */
+  if (options[idx].var == NULL) {       //  can't set hidden option
     return;
+  }
 
   assert((void *) options[idx].var != (void *) &p_shada);
 
   s = vim_strsave(val);
   {
     varp = (char_u **)get_varp_scope(&(options[idx]),
-        both ? OPT_LOCAL : opt_flags);
-    if ((opt_flags & OPT_FREE) && (options[idx].flags & P_ALLOCED))
+                                     both ? OPT_LOCAL : opt_flags);
+    if ((opt_flags & OPT_FREE) && (options[idx].flags & P_ALLOCED)) {
       free_string_option(*varp);
+    }
     *varp = s;
 
-    /* For buffer/window local option may also set the global value. */
-    if (both)
+    //  For buffer/window local option may also set the global value.
+    if (both) {
       set_string_option_global(idx, varp);
+    }
 
     options[idx].flags |= P_ALLOCED;
 
@@ -2368,19 +2415,20 @@ set_string_option_direct (
 /*
  * Set global value for string option when it's a local option.
  */
-static void 
-set_string_option_global (
-    int opt_idx,                    /* option index */
-    char_u **varp             /* pointer to option variable */
+static void
+set_string_option_global(
+    int opt_idx,                    //  option index
+    char_u **varp             //  pointer to option variable
 )
 {
   char_u      **p, *s;
 
-  /* the global value is always allocated */
-  if (options[opt_idx].var == VAR_WIN)
+  //  the global value is always allocated
+  if (options[opt_idx].var == VAR_WIN) {
     p = (char_u **)GLOBAL_WO(varp);
-  else
+  } else {
     p = (char_u **)options[opt_idx].var;
+  }
   if (options[opt_idx].indir != PV_NONE && p != varp) {
     s = vim_strsave(*varp);
     free_string_option(*p);
@@ -2420,7 +2468,7 @@ static char *set_string_option(const int opt_idx, const char *const value,
   int value_checked = false;
   char *const r = (char *)did_set_string_option(
       opt_idx, (char_u **)varp, (int)true, (char_u *)oldval,
-      NULL, opt_flags, &value_checked);
+      NULL, 0, opt_flags, &value_checked);
   if (r == NULL) {
     did_set_option(opt_idx, opt_flags, true, value_checked);
   }
@@ -2463,20 +2511,21 @@ static bool valid_filetype(char_u *val)
  * Returns NULL for success, or an error message for an error.
  */
 static char_u *
-did_set_string_option (
-    int opt_idx,                            /* index in options[] table */
-    char_u **varp,                     /* pointer to the option variable */
-    int new_value_alloced,                  /* new value was allocated */
-    char_u *oldval,                    /* previous value of the option */
-    char_u *errbuf,                    /* buffer for errors, or NULL */
-    int opt_flags,                          /* OPT_LOCAL and/or OPT_GLOBAL */
-    int *value_checked                 /* value was checked to be safe, no
-                                          need to set P_INSECURE */
+did_set_string_option(
+    int opt_idx,                            //  index in options[] table
+    char_u **varp,                     //  pointer to the option variable
+    int new_value_alloced,                  //  new value was allocated
+    char_u *oldval,                    //  previous value of the option
+    char_u *errbuf,                    //  buffer for errors, or NULL
+    size_t errbuflen,                  // length of errors buffer
+    int opt_flags,                          //  OPT_LOCAL and/or OPT_GLOBAL
+    int *value_checked                 // value was checked to be safe, no
+                                       // need to set P_INSECURE
 )
 {
   char_u      *errmsg = NULL;
   char_u      *s, *p;
-  int did_chartab = FALSE;
+  int did_chartab = false;
   char_u      **gvarp;
   bool free_oldval = (options[opt_idx].flags & P_ALLOCED);
   bool value_changed = false;
@@ -2485,7 +2534,7 @@ did_set_string_option (
    * two values for all local options. */
   gvarp = (char_u **)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL);
 
-  /* Disallow changing some options from secure mode */
+  //  Disallow changing some options from secure mode
   if ((secure || sandbox != 0)
       && (options[opt_idx].flags & P_SECURE)) {
     errmsg = e_secure;
@@ -2498,9 +2547,7 @@ did_set_string_option (
     // path separator (slash and/or backslash), wildcards and characters that
     // are often illegal in a file name. Be more permissive if "secure" is off.
     errmsg = e_invarg;
-  }
-  /* 'backupcopy' */
-  else if (gvarp == &p_bkc) {
+  } else if (gvarp == &p_bkc) {  //  'backupcopy'
     char_u       *bkc   = p_bkc;
     unsigned int *flags = &bkc_flags;
 
@@ -2525,17 +2572,15 @@ did_set_string_option (
         errmsg = e_invarg;
       }
     }
-  }
-  /* 'backupext' and 'patchmode' */
-  else if (varp == &p_bex || varp == &p_pm) {
+  } else if (varp == &p_bex || varp == &p_pm) {  //  'backupext' and 'patchmode'
     if (STRCMP(*p_bex == '.' ? p_bex + 1 : p_bex,
-            *p_pm == '.' ? p_pm + 1 : p_pm) == 0)
+               *p_pm == '.' ? p_pm + 1 : p_pm) == 0) {
       errmsg = (char_u *)N_("E589: 'backupext' and 'patchmode' are equal");
-  }
-  /* 'breakindentopt' */
-  else if (varp == &curwin->w_p_briopt) {
-    if (briopt_check(curwin) == FAIL)
+    }
+  } else if (varp == &curwin->w_p_briopt) {  //  'breakindentopt'
+    if (briopt_check(curwin) == FAIL) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_isi
              || varp == &(curbuf->b_p_isk)
              || varp == &p_isp
@@ -2544,63 +2589,58 @@ did_set_string_option (
     // If the new option is invalid, use old value.  'lisp' option: refill
     // g_chartab[] for '-' char
     if (init_chartab() == FAIL) {
-      did_chartab = TRUE;           /* need to restore it below */
-      errmsg = e_invarg;            /* error in value */
+      did_chartab = true;           //  need to restore it below
+      errmsg = e_invarg;            //  error in value
     }
-  }
-  /* 'helpfile' */
-  else if (varp == &p_hf) {
-    /* May compute new values for $VIM and $VIMRUNTIME */
+  } else if (varp == &p_hf) {  //  'helpfile'
+    //  May compute new values for $VIM and $VIMRUNTIME
     if (didset_vim) {
       vim_setenv("VIM", "");
-      didset_vim = FALSE;
+      didset_vim = false;
     }
     if (didset_vimruntime) {
       vim_setenv("VIMRUNTIME", "");
-      didset_vimruntime = FALSE;
+      didset_vimruntime = false;
     }
-  }
-  /* 'colorcolumn' */
-  else if (varp == &curwin->w_p_cc)
+  } else if (varp == &curwin->w_p_cc) {  //  'colorcolumn'
     errmsg = check_colorcolumn(curwin);
-
-  /* 'helplang' */
-  else if (varp == &p_hlg) {
-    /* Check for "", "ab", "ab,cd", etc. */
+  } else if (varp == &p_hlg) {  //  'helplang'
+    //  Check for "", "ab", "ab,cd", etc.
     for (s = p_hlg; *s != NUL; s += 3) {
       if (s[1] == NUL || ((s[2] != ',' || s[3] == NUL) && s[2] != NUL)) {
         errmsg = e_invarg;
         break;
       }
-      if (s[2] == NUL)
+      if (s[2] == NUL) {
         break;
+      }
     }
   } else if (varp == &p_hl) {
     // 'highlight'
     if (strcmp((char *)(*varp), HIGHLIGHT_INIT) != 0) {
       errmsg = e_unsupportedoption;
     }
-  }
-  /* 'nrformats' */
-  else if (gvarp == &p_nf) {
-    if (check_opt_strings(*varp, p_nf_values, TRUE) != OK)
+  } else if (gvarp == &p_nf) {  //  'nrformats'
+    if (check_opt_strings(*varp, p_nf_values, true) != OK) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_ssop) {  // 'sessionoptions'
-    if (opt_strings_flags(p_ssop, p_ssop_values, &ssop_flags, true) != OK)
+    if (opt_strings_flags(p_ssop, p_ssop_values, &ssop_flags, true) != OK) {
       errmsg = e_invarg;
+    }
     if ((ssop_flags & SSOP_CURDIR) && (ssop_flags & SSOP_SESDIR)) {
-      /* Don't allow both "sesdir" and "curdir". */
+      //  Don't allow both "sesdir" and "curdir".
       (void)opt_strings_flags(oldval, p_ssop_values, &ssop_flags, true);
       errmsg = e_invarg;
     }
   } else if (varp == &p_vop) {  // 'viewoptions'
-    if (opt_strings_flags(p_vop, p_ssop_values, &vop_flags, true) != OK)
+    if (opt_strings_flags(p_vop, p_ssop_values, &vop_flags, true) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'scrollopt' */
-  else if (varp == &p_sbo) {
-    if (check_opt_strings(p_sbo, p_scbopt_values, TRUE) != OK)
+    }
+  } else if (varp == &p_sbo) {  //  'scrollopt'
+    if (check_opt_strings(p_sbo, p_scbopt_values, true) != OK) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_ambw || (int *)varp == &p_emoji) {
     // 'ambiwidth'
     if (check_opt_strings(p_ambw, p_ambw_values, false) != OK) {
@@ -2619,13 +2659,11 @@ did_set_string_option (
 ambw_end:
       {}  // clint prefers {} over ; as an empty statement
     }
-  }
-  /* 'background' */
-  else if (varp == &p_bg) {
-    if (check_opt_strings(p_bg, p_bg_values, FALSE) == OK) {
+  } else if (varp == &p_bg) {  //  'background'
+    if (check_opt_strings(p_bg, p_bg_values, false) == OK) {
       int dark = (*p_bg == 'd');
 
-      init_highlight(FALSE, FALSE);
+      init_highlight(false, false);
 
       if (dark != (*p_bg == 'd') && get_var_value("g:colors_name") != NULL) {
         // The color scheme must have set 'background' back to another
@@ -2635,31 +2673,28 @@ ambw_end:
         free_string_option(p_bg);
         p_bg = vim_strsave((char_u *)(dark ? "dark" : "light"));
         check_string_option(&p_bg);
-        init_highlight(FALSE, FALSE);
+        init_highlight(false, false);
       }
     } else
       errmsg = e_invarg;
-  }
-  /* 'wildmode' */
-  else if (varp == &p_wim) {
-    if (check_opt_wim() == FAIL)
+  } else if (varp == &p_wim) {  //  'wildmode'
+    if (check_opt_wim() == FAIL) {
       errmsg = e_invarg;
+    }
   // 'wildoptions'
   } else if (varp == &p_wop) {
     if (opt_strings_flags(p_wop, p_wop_values, &wop_flags, true) != OK) {
       errmsg = e_invarg;
     }
-  }
-  /* 'winaltkeys' */
-  else if (varp == &p_wak) {
+  } else if (varp == &p_wak) {  //  'winaltkeys'
     if (*p_wak == NUL
-        || check_opt_strings(p_wak, p_wak_values, FALSE) != OK)
+        || check_opt_strings(p_wak, p_wak_values, false) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'eventignore' */
-  else if (varp == &p_ei) {
-    if (check_ei() == FAIL)
+    }
+  } else if (varp == &p_ei) {  //  'eventignore'
+    if (check_ei() == FAIL) {
       errmsg = e_invarg;
+    }
   // 'encoding', 'fileencoding' and 'makeencoding'
   } else if (varp == &p_enc || gvarp == &p_fenc || gvarp == &p_menc) {
     if (gvarp == &p_fenc) {
@@ -2678,7 +2713,7 @@ ambw_end:
     }
 
     if (errmsg == NULL) {
-      /* canonize the value, so that STRCMP() can be used on it */
+      //  canonize the value, so that STRCMP() can be used on it
       p = enc_canonize(*varp);
       xfree(*varp);
       *varp = p;
@@ -2690,7 +2725,7 @@ ambw_end:
       }
     }
   } else if (varp == &p_penc) {
-    /* Canonize printencoding if VIM standard one */
+    //  Canonize printencoding if VIM standard one
     p = enc_canonize(p_penc);
     xfree(p_penc);
     p_penc = p;
@@ -2716,16 +2751,19 @@ ambw_end:
 
     if (errmsg == NULL) {
       if (*curbuf->b_p_keymap != NUL) {
-        /* Installed a new keymap, switch on using it. */
+        //  Installed a new keymap, switch on using it.
         curbuf->b_p_iminsert = B_IMODE_LMAP;
-        if (curbuf->b_p_imsearch != B_IMODE_USE_INSERT)
+        if (curbuf->b_p_imsearch != B_IMODE_USE_INSERT) {
           curbuf->b_p_imsearch = B_IMODE_LMAP;
+        }
       } else {
-        /* Cleared the keymap, may reset 'iminsert' and 'imsearch'. */
-        if (curbuf->b_p_iminsert == B_IMODE_LMAP)
+        //  Cleared the keymap, may reset 'iminsert' and 'imsearch'.
+        if (curbuf->b_p_iminsert == B_IMODE_LMAP) {
           curbuf->b_p_iminsert = B_IMODE_NONE;
-        if (curbuf->b_p_imsearch == B_IMODE_LMAP)
+        }
+        if (curbuf->b_p_imsearch == B_IMODE_LMAP) {
           curbuf->b_p_imsearch = B_IMODE_USE_INSERT;
+        }
       }
       if ((opt_flags & OPT_LOCAL) == 0) {
         set_iminsert_global();
@@ -2733,41 +2771,37 @@ ambw_end:
       }
       status_redraw_curbuf();
     }
-  }
-  /* 'fileformat' */
-  else if (gvarp == &p_ff) {
-    if (!MODIFIABLE(curbuf) && !(opt_flags & OPT_GLOBAL))
+  } else if (gvarp == &p_ff) {  //  'fileformat'
+    if (!MODIFIABLE(curbuf) && !(opt_flags & OPT_GLOBAL)) {
       errmsg = e_modifiable;
-    else if (check_opt_strings(*varp, p_ff_values, FALSE) != OK)
+    } else if (check_opt_strings(*varp, p_ff_values, false) != OK) {
       errmsg = e_invarg;
-    else {
+    } else {
       redraw_titles();
-      /* update flag in swap file */
+      //  update flag in swap file
       ml_setflags(curbuf);
       /* Redraw needed when switching to/from "mac": a CR in the text
        * will be displayed differently. */
-      if (get_fileformat(curbuf) == EOL_MAC || *oldval == 'm')
+      if (get_fileformat(curbuf) == EOL_MAC || *oldval == 'm') {
         redraw_curbuf_later(NOT_VALID);
+      }
     }
-  }
-  /* 'fileformats' */
-  else if (varp == &p_ffs) {
-    if (check_opt_strings(p_ffs, p_ff_values, TRUE) != OK) {
+  } else if (varp == &p_ffs) {  //  'fileformats'
+    if (check_opt_strings(p_ffs, p_ff_values, true) != OK) {
       errmsg = e_invarg;
     }
-  }
-
-  /* 'matchpairs' */
-  else if (gvarp == &p_mps) {
+  } else if (gvarp == &p_mps) {  //  'matchpairs'
     if (has_mbyte) {
-      for (p = *varp; *p != NUL; ++p) {
+      for (p = *varp; *p != NUL; p++) {
         int x2 = -1;
         int x3 = -1;
 
-        if (*p != NUL)
+        if (*p != NUL) {
           p += mb_ptr2len(p);
-        if (*p != NUL)
+        }
+        if (*p != NUL) {
           x2 = *p++;
+        }
         if (*p != NUL) {
           x3 = utf_ptr2char(p);
           p += mb_ptr2len(p);
@@ -2776,42 +2810,45 @@ ambw_end:
           errmsg = e_invarg;
           break;
         }
-        if (*p == NUL)
+        if (*p == NUL) {
           break;
+        }
       }
     } else {
-      /* Check for "x:y,x:y" */
+      //  Check for "x:y,x:y"
       for (p = *varp; *p != NUL; p += 4) {
         if (p[1] != ':' || p[2] == NUL || (p[3] != NUL && p[3] != ',')) {
           errmsg = e_invarg;
           break;
         }
-        if (p[3] == NUL)
+        if (p[3] == NUL) {
           break;
+        }
       }
     }
-  }
-  /* 'comments' */
-  else if (gvarp == &p_com) {
+  } else if (gvarp == &p_com) {  //  'comments'
     for (s = *varp; *s; ) {
       while (*s && *s != ':') {
         if (vim_strchr((char_u *)COM_ALL, *s) == NULL
             && !ascii_isdigit(*s) && *s != '-') {
-          errmsg = illegal_char(errbuf, *s);
+          errmsg = illegal_char(errbuf, errbuflen, *s);
           break;
         }
-        ++s;
+        s++;
       }
-      if (*s++ == NUL)
+      if (*s++ == NUL) {
         errmsg = (char_u *)N_("E524: Missing colon");
-      else if (*s == ',' || *s == NUL)
+      } else if (*s == ',' || *s == NUL) {
         errmsg = (char_u *)N_("E525: Zero length string");
-      if (errmsg != NULL)
+      }
+      if (errmsg != NULL) {
         break;
+      }
       while (*s && *s != ',') {
-        if (*s == '\\' && s[1] != NUL)
-          ++s;
-        ++s;
+        if (*s == '\\' && s[1] != NUL) {
+          s++;
+        }
+        s++;
       }
       s = skip_to_option_part(s);
     }
@@ -2819,17 +2856,14 @@ ambw_end:
     errmsg = set_chars_option(curwin, varp);
   } else if (varp == &curwin->w_p_fcs) {  // 'fillchars'
     errmsg = set_chars_option(curwin, varp);
-  }
-  /* 'cedit' */
-  else if (varp == &p_cedit) {
+  } else if (varp == &p_cedit) {  //  'cedit'
     errmsg = check_cedit();
-  }
-  /* 'verbosefile' */
-  else if (varp == &p_vfile) {
+  } else if (varp == &p_vfile) {  //  'verbosefile'
     verbose_stop();
-    if (*p_vfile != NUL && verbose_open() == FAIL)
+    if (*p_vfile != NUL && verbose_open() == FAIL) {
       errmsg = e_invarg;
-  /* 'shada' */
+    }
+  //  'shada'
   } else if (varp == &p_shada) {
     // TODO(ZyX-I): Remove this code in the future, alongside with &viminfo
     //              option.
@@ -2843,133 +2877,115 @@ ambw_end:
     // of the function and the set of P_ALLOCED at the end of the fuction.
     free_oldval = (options[opt_idx].flags & P_ALLOCED);
     for (s = p_shada; *s; ) {
-      /* Check it's a valid character */
+      //  Check it's a valid character
       if (vim_strchr((char_u *)"!\"%'/:<@cfhnrs", *s) == NULL) {
-        errmsg = illegal_char(errbuf, *s);
+        errmsg = illegal_char(errbuf, errbuflen, *s);
         break;
       }
-      if (*s == 'n') {          /* name is always last one */
+      if (*s == 'n') {          //  name is always last one
         break;
-      } else if (*s == 'r') { /* skip until next ',' */
-        while (*++s && *s != ',')
-          ;
+      } else if (*s == 'r') {  //  skip until next ','
+        while (*++s && *s != ',') {}
       } else if (*s == '%') {
-        /* optional number */
-        while (ascii_isdigit(*++s))
-          ;
-      } else if (*s == '!' || *s == 'h' || *s == 'c')
-        ++s;                    /* no extra chars */
-      else {                    /* must have a number */
-        while (ascii_isdigit(*++s))
-          ;
+        //  optional number
+        while (ascii_isdigit(*++s)) {}
+      } else if (*s == '!' || *s == 'h' || *s == 'c') {
+        s++;                    //  no extra chars
+      } else {                    //  must have a number
+        while (ascii_isdigit(*++s)) {}
 
         if (!ascii_isdigit(*(s - 1))) {
           if (errbuf != NULL) {
-            sprintf((char *)errbuf,
-                _("E526: Missing number after <%s>"),
-                transchar_byte(*(s - 1)));
+            snprintf((char *)errbuf, errbuflen,
+                     _("E526: Missing number after <%s>"),
+                     transchar_byte(*(s - 1)));
             errmsg = errbuf;
           } else
             errmsg = (char_u *)"";
           break;
         }
       }
-      if (*s == ',')
-        ++s;
-      else if (*s) {
-        if (errbuf != NULL)
+      if (*s == ',') {
+        s++;
+      } else if (*s) {
+        if (errbuf != NULL) {
           errmsg = (char_u *)N_("E527: Missing comma");
-        else
+        } else {
           errmsg = (char_u *)"";
+        }
         break;
       }
     }
-    if (*p_shada && errmsg == NULL && get_shada_parameter('\'') < 0)
+    if (*p_shada && errmsg == NULL && get_shada_parameter('\'') < 0) {
       errmsg = (char_u *)N_("E528: Must specify a ' value");
-  }
-  /* 'showbreak' */
-  else if (varp == &p_sbr) {
+    }
+  } else if (varp == &p_sbr) {  //  'showbreak'
     for (s = p_sbr; *s; ) {
-      if (ptr2cells(s) != 1)
+      if (ptr2cells(s) != 1) {
         errmsg = (char_u *)N_("E595: contains unprintable or wide character");
+      }
       MB_PTR_ADV(s);
     }
-  }
-
-  // 'guicursor'
-  else if (varp == &p_guicursor) {
+  } else if (varp == &p_guicursor) {  // 'guicursor'
     errmsg = parse_shape_opt(SHAPE_CURSOR);
-  }
-
-  else if (varp == &p_popt)
+  } else if (varp == &p_popt) {
     errmsg = parse_printoptions();
-  else if (varp == &p_pmfn)
+  } else if (varp == &p_pmfn) {
     errmsg = parse_printmbfont();
-
-  /* 'langmap' */
-  else if (varp == &p_langmap)
+  } else if (varp == &p_langmap) {  //  'langmap'
     langmap_set();
-
-  /* 'breakat' */
-  else if (varp == &p_breakat)
+  } else if (varp == &p_breakat) {  //  'breakat'
     fill_breakat_flags();
-
-  /* 'titlestring' and 'iconstring' */
-  else if (varp == &p_titlestring || varp == &p_iconstring) {
+  } else if (varp == &p_titlestring || varp == &p_iconstring) {
+    //  'titlestring' and 'iconstring'
     int flagval = (varp == &p_titlestring) ? STL_IN_TITLE : STL_IN_ICON;
 
-    /* NULL => statusline syntax */
-    if (vim_strchr(*varp, '%') && check_stl_option(*varp) == NULL)
+    //  NULL => statusline syntax
+    if (vim_strchr(*varp, '%') && check_stl_option(*varp) == NULL) {
       stl_syntax |= flagval;
-    else
+    } else {
       stl_syntax &= ~flagval;
+    }
     did_set_title(varp == &p_iconstring);
 
-  }
-
-  /* 'selection' */
-  else if (varp == &p_sel) {
+  } else if (varp == &p_sel) {  //  'selection'
     if (*p_sel == NUL
-        || check_opt_strings(p_sel, p_sel_values, FALSE) != OK)
+        || check_opt_strings(p_sel, p_sel_values, false) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'selectmode' */
-  else if (varp == &p_slm) {
-    if (check_opt_strings(p_slm, p_slm_values, TRUE) != OK)
+    }
+  } else if (varp == &p_slm) {  //  'selectmode'
+    if (check_opt_strings(p_slm, p_slm_values, true) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'keymodel' */
-  else if (varp == &p_km) {
-    if (check_opt_strings(p_km, p_km_values, TRUE) != OK)
+    }
+  } else if (varp == &p_km) {  //  'keymodel'
+    if (check_opt_strings(p_km, p_km_values, true) != OK) {
       errmsg = e_invarg;
-    else {
+    } else {
       km_stopsel = (vim_strchr(p_km, 'o') != NULL);
       km_startsel = (vim_strchr(p_km, 'a') != NULL);
     }
-  }
-  /* 'mousemodel' */
-  else if (varp == &p_mousem) {
-    if (check_opt_strings(p_mousem, p_mousem_values, FALSE) != OK)
+  } else if (varp == &p_mousem) {  //  'mousemodel'
+    if (check_opt_strings(p_mousem, p_mousem_values, false) != OK) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_swb) {  // 'switchbuf'
-    if (opt_strings_flags(p_swb, p_swb_values, &swb_flags, true) != OK)
+    if (opt_strings_flags(p_swb, p_swb_values, &swb_flags, true) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'debug' */
-  else if (varp == &p_debug) {
-    if (check_opt_strings(p_debug, p_debug_values, TRUE) != OK)
+    }
+  } else if (varp == &p_debug) {  //  'debug'
+    if (check_opt_strings(p_debug, p_debug_values, true) != OK) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_dy) {  // 'display'
-    if (opt_strings_flags(p_dy, p_dy_values, &dy_flags, true) != OK)
+    if (opt_strings_flags(p_dy, p_dy_values, &dy_flags, true) != OK) {
       errmsg = e_invarg;
-    else
+    } else {
       (void)init_chartab();
-
-  }
-  /* 'eadirection' */
-  else if (varp == &p_ead) {
-    if (check_opt_strings(p_ead, p_ead_values, FALSE) != OK)
+    }
+  } else if (varp == &p_ead) {  //  'eadirection'
+    if (check_opt_strings(p_ead, p_ead_values, false) != OK) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_cb) {  // 'clipboard'
     if (opt_strings_flags(p_cb, p_cb_values, &cb_flags, true) != OK) {
       errmsg = e_invarg;
@@ -2979,78 +2995,77 @@ ambw_end:
     // When 'spelllang' or 'spellfile' is set and there is a window for this
     // buffer in which 'spell' is set load the wordlists.
     errmsg = did_set_spell_option(varp == &(curwin->w_s->b_p_spf));
-  }
-  /* When 'spellcapcheck' is set compile the regexp program. */
-  else if (varp == &(curwin->w_s->b_p_spc)) {
+  } else if (varp == &(curwin->w_s->b_p_spc)) {
+    //  When 'spellcapcheck' is set compile the regexp program.
     errmsg = compile_cap_prog(curwin->w_s);
-  }
-  /* 'spellsuggest' */
-  else if (varp == &p_sps) {
-    if (spell_check_sps() != OK)
+  } else if (varp == &p_sps) {  //  'spellsuggest'
+    if (spell_check_sps() != OK) {
       errmsg = e_invarg;
-  }
-  /* 'mkspellmem' */
-  else if (varp == &p_msm) {
-    if (spell_check_msm() != OK)
+    }
+  } else if (varp == &p_msm) {  //  'mkspellmem'
+    if (spell_check_msm() != OK) {
       errmsg = e_invarg;
-  }
-  /* When 'bufhidden' is set, check for valid value. */
-  else if (gvarp == &p_bh) {
-    if (check_opt_strings(curbuf->b_p_bh, p_bufhidden_values, FALSE) != OK)
+    }
+  } else if (gvarp == &p_bh) {
+    // When 'bufhidden' is set, check for valid value.
+    if (check_opt_strings(curbuf->b_p_bh, p_bufhidden_values, false) != OK) {
       errmsg = e_invarg;
-  }
-  /* When 'buftype' is set, check for valid value. */
-  else if (gvarp == &p_bt) {
+    }
+  } else if (gvarp == &p_bt) {
+    //  When 'buftype' is set, check for valid value.
     if ((curbuf->terminal && curbuf->b_p_bt[0] != 't')
         || (!curbuf->terminal && curbuf->b_p_bt[0] == 't')
-        || check_opt_strings(curbuf->b_p_bt, p_buftype_values, FALSE) != OK) {
+        || check_opt_strings(curbuf->b_p_bt, p_buftype_values, false) != OK) {
       errmsg = e_invarg;
     } else {
       if (curwin->w_status_height) {
-        curwin->w_redr_status = TRUE;
+        curwin->w_redr_status = true;
         redraw_later(VALID);
       }
       curbuf->b_help = (curbuf->b_p_bt[0] == 'h');
       redraw_titles();
     }
-  }
-  /* 'statusline' or 'rulerformat' */
-  else if (gvarp == &p_stl || varp == &p_ruf) {
+  } else if (gvarp == &p_stl || varp == &p_ruf) {
+    //  'statusline' or 'rulerformat'
     int wid;
 
-    if (varp == &p_ruf)         /* reset ru_wid first */
+    if (varp == &p_ruf) {       //  reset ru_wid first
       ru_wid = 0;
+    }
     s = *varp;
     if (varp == &p_ruf && *s == '%') {
-      /* set ru_wid if 'ruf' starts with "%99(" */
-      if (*++s == '-')          /* ignore a '-' */
+      //  set ru_wid if 'ruf' starts with "%99("
+      if (*++s == '-') {        //  ignore a '-'
         s++;
+      }
       wid = getdigits_int(&s);
-      if (wid && *s == '(' && (errmsg = check_stl_option(p_ruf)) == NULL)
+      if (wid && *s == '(' && (errmsg = check_stl_option(p_ruf)) == NULL) {
         ru_wid = wid;
-      else
+      } else {
         errmsg = check_stl_option(p_ruf);
-    }
-    /* check 'statusline' only if it doesn't start with "%!" */
-    else if (varp == &p_ruf || s[0] != '%' || s[1] != '!')
+      }
+    } else if (varp == &p_ruf || s[0] != '%' || s[1] != '!') {
+      //  check 'statusline' only if it doesn't start with "%!"
       errmsg = check_stl_option(s);
-    if (varp == &p_ruf && errmsg == NULL)
+    }
+    if (varp == &p_ruf && errmsg == NULL) {
       comp_col();
-  }
-  /* check if it is a valid value for 'complete' -- Acevedo */
-  else if (gvarp == &p_cpt) {
+    }
+  } else if (gvarp == &p_cpt) {
+    //  check if it is a valid value for 'complete' -- Acevedo
     for (s = *varp; *s; ) {
       while (*s == ',' || *s == ' ')
         s++;
-      if (!*s)
+      if (!*s) {
         break;
+      }
       if (vim_strchr((char_u *)".wbuksid]tU", *s) == NULL) {
-        errmsg = illegal_char(errbuf, *s);
+        errmsg = illegal_char(errbuf, errbuflen, *s);
         break;
       }
       if (*++s != NUL && *s != ',' && *s != ' ') {
         if (s[-1] == 'k' || s[-1] == 's') {
-          /* skip optional filename after 'k' and 's' */
+          //  skip optional filename after 'k' and 's'
           while (*s && *s != ',' && *s != ' ') {
             if (*s == '\\' && s[1] != NUL) {
               s++;
@@ -3059,9 +3074,9 @@ ambw_end:
           }
         } else {
           if (errbuf != NULL) {
-            sprintf((char *)errbuf,
-                _("E535: Illegal character after <%c>"),
-                *--s);
+            snprintf((char *)errbuf, errbuflen,
+                     _("E535: Illegal character after <%c>"),
+                     *--s);
             errmsg = errbuf;
           } else
             errmsg = (char_u *)"";
@@ -3069,9 +3084,7 @@ ambw_end:
         }
       }
     }
-  }
-  /* 'completeopt' */
-  else if (varp == &p_cot) {
+  } else if (varp == &p_cot) {  //  'completeopt'
     if (check_opt_strings(p_cot, p_cot_values, true) != OK) {
       errmsg = e_invarg;
     } else {
@@ -3082,27 +3095,27 @@ ambw_end:
     if (check_opt_strings(*varp, p_scl_values, false) != OK) {
       errmsg = e_invarg;
     }
-  }
-  /* 'pastetoggle': translate key codes like in a mapping */
-  else if (varp == &p_pt) {
+  } else if (varp == &p_pt) {
+    //  'pastetoggle': translate key codes like in a mapping
     if (*p_pt) {
       (void)replace_termcodes(p_pt, STRLEN(p_pt), &p, true, true, true,
                               CPO_TO_CPO_FLAGS);
       if (p != NULL) {
-        if (new_value_alloced)
+        if (new_value_alloced) {
           free_string_option(p_pt);
+        }
         p_pt = p;
-        new_value_alloced = TRUE;
+        new_value_alloced = true;
       }
     }
-  }
-  /* 'backspace' */
-  else if (varp == &p_bs) {
+  } else if (varp == &p_bs) {  //  'backspace'
     if (ascii_isdigit(*p_bs)) {
-      if (*p_bs >'2' || p_bs[1] != NUL)
+      if (*p_bs >'2' || p_bs[1] != NUL) {
         errmsg = e_invarg;
-    } else if (check_opt_strings(p_bs, p_bs_values, TRUE) != OK)
+      }
+    } else if (check_opt_strings(p_bs, p_bs_values, true) != OK) {
       errmsg = e_invarg;
+    }
   } else if (varp == &p_bo) {
     if (opt_strings_flags(p_bo, p_bo_values, &bo_flags, true) != OK) {
       errmsg = e_invarg;
@@ -3126,64 +3139,59 @@ ambw_end:
       errmsg = e_invarg;
     }
   } else if (varp == &p_cmp) {  // 'casemap'
-    if (opt_strings_flags(p_cmp, p_cmp_values, &cmp_flags, true) != OK)
+    if (opt_strings_flags(p_cmp, p_cmp_values, &cmp_flags, true) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'diffopt' */
-  else if (varp == &p_dip) {
-    if (diffopt_changed() == FAIL)
-      errmsg = e_invarg;
-  }
-  /* 'foldmethod' */
-  else if (gvarp == &curwin->w_allbuf_opt.wo_fdm) {
-    if (check_opt_strings(*varp, p_fdm_values, FALSE) != OK
-        || *curwin->w_p_fdm == NUL)
-      errmsg = e_invarg;
-    else {
-      foldUpdateAll(curwin);
-      if (foldmethodIsDiff(curwin))
-        newFoldLevel();
     }
-  }
-  /* 'foldexpr' */
-  else if (varp == &curwin->w_p_fde) {
-    if (foldmethodIsExpr(curwin))
+  } else if (varp == &p_dip) {  //  'diffopt'
+    if (diffopt_changed() == FAIL) {
+      errmsg = e_invarg;
+    }
+  } else if (gvarp == &curwin->w_allbuf_opt.wo_fdm) {  //  'foldmethod'
+    if (check_opt_strings(*varp, p_fdm_values, false) != OK
+        || *curwin->w_p_fdm == NUL) {
+      errmsg = e_invarg;
+    } else {
       foldUpdateAll(curwin);
-  }
-  /* 'foldmarker' */
-  else if (gvarp == &curwin->w_allbuf_opt.wo_fmr) {
+      if (foldmethodIsDiff(curwin)) {
+        newFoldLevel();
+      }
+    }
+  } else if (varp == &curwin->w_p_fde) {  //  'foldexpr'
+    if (foldmethodIsExpr(curwin)) {
+      foldUpdateAll(curwin);
+    }
+  } else if (gvarp == &curwin->w_allbuf_opt.wo_fmr) {  //  'foldmarker'
     p = vim_strchr(*varp, ',');
-    if (p == NULL)
+    if (p == NULL) {
       errmsg = (char_u *)N_("E536: comma required");
-    else if (p == *varp || p[1] == NUL)
+    } else if (p == *varp || p[1] == NUL) {
       errmsg = e_invarg;
-    else if (foldmethodIsMarker(curwin))
+    } else if (foldmethodIsMarker(curwin)) {
       foldUpdateAll(curwin);
-  }
-  /* 'commentstring' */
-  else if (gvarp == &p_cms) {
-    if (**varp != NUL && strstr((char *)*varp, "%s") == NULL)
+    }
+  } else if (gvarp == &p_cms) {  //  'commentstring'
+    if (**varp != NUL && strstr((char *)(*varp), "%s") == NULL) {
       errmsg = (char_u *)N_(
-                "E537: 'commentstring' must be empty or contain %s");
+          "E537: 'commentstring' must be empty or contain %s");
+    }
   } else if (varp == &p_fdo) {  // 'foldopen'
-    if (opt_strings_flags(p_fdo, p_fdo_values, &fdo_flags, true) != OK)
+    if (opt_strings_flags(p_fdo, p_fdo_values, &fdo_flags, true) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'foldclose' */
-  else if (varp == &p_fcl) {
-    if (check_opt_strings(p_fcl, p_fcl_values, TRUE) != OK)
+    }
+  } else if (varp == &p_fcl) {  //  'foldclose'
+    if (check_opt_strings(p_fcl, p_fcl_values, true) != OK) {
       errmsg = e_invarg;
-  }
-  /* 'foldignore' */
-  else if (gvarp == &curwin->w_allbuf_opt.wo_fdi) {
-    if (foldmethodIsIndent(curwin))
+    }
+  } else if (gvarp == &curwin->w_allbuf_opt.wo_fdi) {  //  'foldignore'
+    if (foldmethodIsIndent(curwin)) {
       foldUpdateAll(curwin);
+    }
   } else if (varp == &p_ve) {  // 'virtualedit'
-    if (opt_strings_flags(p_ve, p_ve_values, &ve_flags, true) != OK)
+    if (opt_strings_flags(p_ve, p_ve_values, &ve_flags, true) != OK) {
       errmsg = e_invarg;
-    else if (STRCMP(p_ve, oldval) != 0) {
-      /* Recompute cursor position in case the new 've' setting
-       * changes something. */
+    } else if (STRCMP(p_ve, oldval) != 0) {
+      // Recompute cursor position in case the new 've' setting
+      // changes something.
       validate_virtcol();
       coladvance(curwin->w_virtcol);
     }
@@ -3197,16 +3205,15 @@ ambw_end:
             || (p[2] != NUL && p[2] != ',')) {
           errmsg = e_invarg;
           break;
-        } else if (p[2] == NUL)
+        } else if (p[2] == NUL) {
           break;
-        else
+        } else {
           p += 3;
+        }
       }
     }
-  }
-  /* 'cinoptions' */
-  else if (gvarp == &p_cino) {
-    /* TODO: recognize errors */
+  } else if (gvarp == &p_cino) {  //  'cinoptions'
+    // TODO(anyone): recognize errors
     parse_cino(curbuf);
   // inccommand
   } else if (varp == &p_icm) {
@@ -3255,11 +3262,12 @@ ambw_end:
       p = (char_u *)MOUSE_ALL;
     }
     if (p != NULL) {
-      for (s = *varp; *s; ++s)
+      for (s = *varp; *s; s++) {
         if (vim_strchr(p, *s) == NULL) {
-          errmsg = illegal_char(errbuf, *s);
+          errmsg = illegal_char(errbuf, errbuflen, *s);
           break;
         }
+      }
     }
   }
 
@@ -3267,28 +3275,32 @@ ambw_end:
    * If error detected, restore the previous value.
    */
   if (errmsg != NULL) {
-    if (new_value_alloced)
+    if (new_value_alloced) {
       free_string_option(*varp);
+    }
     *varp = oldval;
     /*
      * When resetting some values, need to act on it.
      */
-    if (did_chartab)
+    if (did_chartab) {
       (void)init_chartab();
+    }
   } else {
-    /* Remember where the option was set. */
+    //  Remember where the option was set.
     set_option_scriptID_idx(opt_idx, opt_flags, current_SID);
     /*
      * Free string options that are in allocated memory.
      * Use "free_oldval", because recursiveness may change the flags under
      * our fingers (esp. init_highlight()).
      */
-    if (free_oldval)
+    if (free_oldval) {
       free_string_option(oldval);
-    if (new_value_alloced)
+    }
+    if (new_value_alloced) {
       options[opt_idx].flags |= P_ALLOCED;
-    else
+    } else {
       options[opt_idx].flags &= ~P_ALLOCED;
+    }
 
     if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0
         && ((int)options[opt_idx].indir & PV_BOTH)) {
@@ -3297,15 +3309,15 @@ ambw_end:
       p = get_varp_scope(&(options[opt_idx]), OPT_LOCAL);
       free_string_option(*(char_u **)p);
       *(char_u **)p = empty_option;
-    }
-    /* May set global value for local option. */
-    else if (!(opt_flags & OPT_LOCAL) && opt_flags != OPT_GLOBAL)
+    } else if (!(opt_flags & OPT_LOCAL) && opt_flags != OPT_GLOBAL) {
+      //  May set global value for local option.
       set_string_option_global(opt_idx, varp);
+    }
 
     /*
      * Trigger the autocommand only after setting the flags.
      */
-    /* When 'syntax' is set, load the syntax of that name */
+    //  When 'syntax' is set, load the syntax of that name
     if (varp == &(curbuf->b_p_syn)) {
       static int syn_recursive = 0;
 
@@ -3345,9 +3357,10 @@ ambw_end:
       char_u fname[200];
       char_u      *q = curwin->w_s->b_p_spl;
 
-      /* Skip the first name if it is "cjk". */
-      if (STRNCMP(q, "cjk,", 4) == 0)
+      //  Skip the first name if it is "cjk".
+      if (STRNCMP(q, "cjk,", 4) == 0) {
         q += 4;
+      }
 
       /*
        * Source the spell/LANG.vim in 'runtimepath'.
@@ -3355,9 +3368,11 @@ ambw_end:
        * Use the first name in 'spelllang' up to '_region' or
        * '.encoding'.
        */
-      for (p = q; *p != NUL; ++p)
-        if (!ASCII_ISALPHA(*p) && *p != '-')
+      for (p = q; *p != NUL; p++) {
+        if (!ASCII_ISALPHA(*p) && *p != '-') {
           break;
+        }
+      }
       if (p > q) {
         vim_snprintf((char *)fname, sizeof(fname), "spell/%.*s.vim",
                      (int)(p - q), q);
@@ -3376,7 +3391,7 @@ ambw_end:
 
   if (curwin->w_curswant != MAXCOL
       && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0)
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 
   check_redraw(options[opt_idx].flags);
 
@@ -3406,19 +3421,22 @@ char_u *check_colorcolumn(win_T *wp)
   int color_cols[256];
   int j = 0;
 
-  if (wp->w_buffer == NULL)
-    return NULL;      /* buffer was closed */
+  if (wp->w_buffer == NULL) {
+    return NULL;      //  buffer was closed
+  }
 
   for (s = wp->w_p_cc; *s != NUL && count < 255; ) {
     if (*s == '-' || *s == '+') {
-      /* -N and +N: add to 'textwidth' */
+      //  -N and +N: add to 'textwidth'
       col = (*s == '-') ? -1 : 1;
-      ++s;
-      if (!ascii_isdigit(*s))
+      s++;
+      if (!ascii_isdigit(*s)) {
         return e_invarg;
+      }
       col = col * getdigits_int(&s);
-      if (wp->w_buffer->b_p_tw == 0)
-        goto skip;          /* 'textwidth' not set, skip this item */
+      if (wp->w_buffer->b_p_tw == 0) {
+        goto skip;          //  'textwidth' not set, skip this item
+      }
       assert((col >= 0
               && wp->w_buffer->b_p_tw <= INT_MAX - col
               && wp->w_buffer->b_p_tw + col >= INT_MIN)
@@ -3426,39 +3444,46 @@ char_u *check_colorcolumn(win_T *wp)
                  && wp->w_buffer->b_p_tw >= INT_MIN - col
                  && wp->w_buffer->b_p_tw + col <= INT_MAX));
       col += (int)wp->w_buffer->b_p_tw;
-      if (col < 0)
+      if (col < 0) {
         goto skip;
-    } else if (ascii_isdigit(*s))
+      }
+    } else if (ascii_isdigit(*s)) {
       col = getdigits_int(&s);
-    else
+    } else {
       return e_invarg;
-    color_cols[count++] = col - 1;      /* 1-based to 0-based */
+    }
+    color_cols[count++] = col - 1;      //  1-based to 0-based
 skip:
-    if (*s == NUL)
+    if (*s == NUL) {
       break;
-    if (*s != ',')
+    }
+    if (*s != ',') {
       return e_invarg;
-    if (*++s == NUL)
-      return e_invarg;        /* illegal trailing comma as in "set cc=80," */
+    }
+    if (*++s == NUL) {
+      return e_invarg;        //  illegal trailing comma as in "set cc=80,"
+    }
   }
 
   xfree(wp->w_p_cc_cols);
-  if (count == 0)
+  if (count == 0) {
     wp->w_p_cc_cols = NULL;
-  else {
+  } else {
     wp->w_p_cc_cols = xmalloc(sizeof(int) * (count + 1));
     /* sort the columns for faster usage on screen redraw inside
      * win_line() */
     qsort(color_cols, count, sizeof(int), int_cmp);
 
-    for (unsigned int i = 0; i < count; ++i)
-      /* skip duplicates */
-      if (j == 0 || wp->w_p_cc_cols[j - 1] != color_cols[i])
+    for (unsigned int i = 0; i < count; i++) {
+      //  skip duplicates
+      if (j == 0 || wp->w_p_cc_cols[j - 1] != color_cols[i]) {
         wp->w_p_cc_cols[j++] = color_cols[i];
-    wp->w_p_cc_cols[j] = -1;        /* end marker */
+      }
+    }
+    wp->w_p_cc_cols[j] = -1;        //  end marker
   }
 
-  return NULL;    /* no error */
+  return NULL;    //  no error
 }
 
 
@@ -3533,7 +3558,7 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
     }
     p = *varp;
     while (*p) {
-      for (i = 0; i < entries; ++i) {
+      for (i = 0; i < entries; i++) {
         len = (int)STRLEN(tab[i].name);
         if (STRNCMP(p, tab[i].name, len) == 0
             && p[len] == ':'
@@ -3580,14 +3605,16 @@ static char_u *set_chars_option(win_T *wp, char_u **varp)
         }
       }
 
-      if (i == entries)
+      if (i == entries) {
         return e_invarg;
-      if (*p == ',')
-        ++p;
+      }
+      if (*p == ',') {
+        p++;
+      }
     }
   }
 
-  return NULL;          /* no error */
+  return NULL;          //  no error
 }
 
 /*
@@ -3598,14 +3625,16 @@ char_u *check_stl_option(char_u *s)
 {
   int itemcnt = 0;
   int groupdepth = 0;
-  static char_u errbuf[80];
+  static char_u errbuf[ERROR_BUFFER_LENGTH];
 
   while (*s && itemcnt < STL_MAX_ITEM) {
-    /* Check for valid keys after % sequences */
-    while (*s && *s != '%')
+    //  Check for valid keys after % sequences
+    while (*s && *s != '%') {
       s++;
-    if (!*s)
+    }
+    if (!*s) {
       break;
+    }
     s++;
     if (*s != '%' && *s != ')') {
       itemcnt++;
@@ -3616,16 +3645,20 @@ char_u *check_stl_option(char_u *s)
     }
     if (*s == ')') {
       s++;
-      if (--groupdepth < 0)
+      if (--groupdepth < 0) {
         break;
+      }
       continue;
     }
-    if (*s == '-')
+    if (*s == '-') {
       s++;
-    while (ascii_isdigit(*s))
+    }
+    while (ascii_isdigit(*s)) {
       s++;
-    if (*s == STL_USER_HL)
+    }
+    if (*s == STL_USER_HL) {
       continue;
+    }
     if (*s == '.') {
       s++;
       while (*s && ascii_isdigit(*s))
@@ -3636,20 +3669,23 @@ char_u *check_stl_option(char_u *s)
       continue;
     }
     if (vim_strchr(STL_ALL, *s) == NULL) {
-      return illegal_char(errbuf, *s);
+      return illegal_char(errbuf, ERROR_BUFFER_LENGTH, *s);
     }
     if (*s == '{') {
       s++;
       while (*s != '}' && *s)
         s++;
-      if (*s != '}')
+      if (*s != '}') {
         return (char_u *)N_("E540: Unclosed expression sequence");
+      }
     }
   }
-  if (itemcnt >= STL_MAX_ITEM)
+  if (itemcnt >= STL_MAX_ITEM) {
     return (char_u *)N_("E541: too many items");
-  if (groupdepth != 0)
+  }
+  if (groupdepth != 0) {
     return (char_u *)N_("E542: unbalanced groups");
+  }
   return NULL;
 }
 
@@ -3686,15 +3722,15 @@ static char_u *compile_cap_prog(synblock_T *synblock)
   regprog_T   *rp = synblock->b_cap_prog;
   char_u      *re;
 
-  if (*synblock->b_p_spc == NUL)
+  if (*synblock->b_p_spc == NUL) {
     synblock->b_cap_prog = NULL;
-  else {
-    /* Prepend a ^ so that we only match at one column */
+  } else {
+    //  Prepend a ^ so that we only match at one column
     re = concat_str((char_u *)"^", synblock->b_p_spc);
     synblock->b_cap_prog = vim_regcomp(re, RE_MAGIC);
     xfree(re);
     if (synblock->b_cap_prog == NULL) {
-      synblock->b_cap_prog = rp;         /* restore the previous program */
+      synblock->b_cap_prog = rp;         //  restore the previous program
       return e_invarg;
     }
   }
@@ -3782,20 +3818,21 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
 {
   int old_value = *(int *)varp;
 
-  /* Disallow changing some options from secure mode */
+  //  Disallow changing some options from secure mode
   if ((secure || sandbox != 0)
       && (options[opt_idx].flags & P_SECURE)) {
     return (char *)e_secure;
   }
 
-  *(int *)varp = value;             /* set the new value */
-  /* Remember where the option was set. */
+  *(int *)varp = value;             //  set the new value
+  //  Remember where the option was set.
   set_option_scriptID_idx(opt_idx, opt_flags, current_SID);
 
 
-  /* May set global value for local option. */
-  if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0)
+  //  May set global value for local option.
+  if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0) {
     *(int *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL) = value;
+  }
 
   // Ensure that options set to p_force_on cannot be disabled.
   if ((int *)varp == &p_force_on && p_force_on == false) {
@@ -3839,72 +3876,65 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
       curbuf = save_curbuf;
     }
   } else if ((int *)varp == &curbuf->b_p_ro) {
-    /* when 'readonly' is reset globally, also reset readonlymode */
-    if (!curbuf->b_p_ro && (opt_flags & OPT_LOCAL) == 0)
-      readonlymode = FALSE;
+    //  when 'readonly' is reset globally, also reset readonlymode
+    if (!curbuf->b_p_ro && (opt_flags & OPT_LOCAL) == 0) {
+      readonlymode = false;
+    }
 
-    /* when 'readonly' is set may give W10 again */
-    if (curbuf->b_p_ro)
+    //  when 'readonly' is set may give W10 again
+    if (curbuf->b_p_ro) {
       curbuf->b_did_warn = false;
+    }
 
     redraw_titles();
-  }
-  /* when 'modifiable' is changed, redraw the window title */
-  else if ((int *)varp == &curbuf->b_p_ma) {
+  } else if ((int *)varp == &curbuf->b_p_ma) {
+    //  when 'modifiable' is changed, redraw the window title
     redraw_titles();
-  }
-  /* when 'endofline' is changed, redraw the window title */
-  else if ((int *)varp == &curbuf->b_p_eol) {
+  } else if ((int *)varp == &curbuf->b_p_eol) {
+    //  when 'endofline' is changed, redraw the window title
     redraw_titles();
   } else if ((int *)varp == &curbuf->b_p_fixeol) {
     // when 'fixeol' is changed, redraw the window title
     redraw_titles();
-  }
-  /* when 'bomb' is changed, redraw the window title and tab page text */
-  else if ((int *)varp == &curbuf->b_p_bomb) {
+  } else if ((int *)varp == &curbuf->b_p_bomb) {
+    //  when 'bomb' is changed, redraw the window title and tab page text
     redraw_titles();
-  }
-  /* when 'bin' is set also set some other options */
-  else if ((int *)varp == &curbuf->b_p_bin) {
+  } else if ((int *)varp == &curbuf->b_p_bin) {
+    //  when 'bin' is set also set some other options
     set_options_bin(old_value, curbuf->b_p_bin, opt_flags);
     redraw_titles();
-  }
-  /* when 'buflisted' changes, trigger autocommands */
-  else if ((int *)varp == &curbuf->b_p_bl && old_value != curbuf->b_p_bl) {
+  } else if ((int *)varp == &curbuf->b_p_bl && old_value != curbuf->b_p_bl) {
+    //  when 'buflisted' changes, trigger autocommands
     apply_autocmds(curbuf->b_p_bl ? EVENT_BUFADD : EVENT_BUFDELETE,
-        NULL, NULL, TRUE, curbuf);
-  }
-  /* when 'swf' is set, create swapfile, when reset remove swapfile */
-  else if ((int *)varp == (int *)&curbuf->b_p_swf) {
-    if (curbuf->b_p_swf && p_uc)
-      ml_open_file(curbuf);                     /* create the swap file */
-    else
-      /* no need to reset curbuf->b_may_swap, ml_open_file() will check
-       * buf->b_p_swf */
-      mf_close_file(curbuf, true);              /* remove the swap file */
-  }
-  /* when 'terse' is set change 'shortmess' */
-  else if ((int *)varp == &p_terse) {
+                   NULL, NULL, true, curbuf);
+  } else if ((int *)varp == (int *)&curbuf->b_p_swf) {
+    //  when 'swf' is set, create swapfile, when reset remove swapfile
+    if (curbuf->b_p_swf && p_uc) {
+      ml_open_file(curbuf);                     //  create the swap file
+    } else {
+      // no need to reset curbuf->b_may_swap, ml_open_file() will check
+      // buf->b_p_swf
+      mf_close_file(curbuf, true);              //  remove the swap file
+    }
+  } else if ((int *)varp == &p_terse) {
+    //  when 'terse' is set change 'shortmess'
     char_u  *p;
 
     p = vim_strchr(p_shm, SHM_SEARCH);
 
-    /* insert 's' in p_shm */
+    //  insert 's' in p_shm
     if (p_terse && p == NULL) {
       STRCPY(IObuff, p_shm);
       STRCAT(IObuff, "s");
       set_string_option_direct((char_u *)"shm", -1, IObuff, OPT_FREE, 0);
-    }
-    /* remove 's' from p_shm */
-    else if (!p_terse && p != NULL)
+    } else if (!p_terse && p != NULL) {  //  remove 's' from p_shm
       STRMOVE(p, p + 1);
-  }
-  /* when 'paste' is set or reset also change other options */
-  else if ((int *)varp == &p_paste) {
+    }
+  } else if ((int *)varp == &p_paste) {
+    //  when 'paste' is set or reset also change other options
     paste_option_changed();
-  }
-  /* when 'insertmode' is set from an autocommand need to do work here */
-  else if ((int *)varp == &p_im) {
+  } else if ((int *)varp == &p_im) {
+    //  when 'insertmode' is set from an autocommand need to do work here
     if (p_im) {
       if ((State & INSERT) == 0) {
         need_start_insertmode = true;
@@ -3918,25 +3948,21 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
       }
       restart_edit = 0;
     }
-  }
-  /* when 'ignorecase' is set or reset and 'hlsearch' is set, redraw */
-  else if ((int *)varp == &p_ic && p_hls) {
+  } else if ((int *)varp == &p_ic && p_hls) {
+    //  when 'ignorecase' is set or reset and 'hlsearch' is set, redraw
     redraw_all_later(SOME_VALID);
-  }
-  /* when 'hlsearch' is set or reset: reset no_hlsearch */
-  else if ((int *)varp == &p_hls) {
-    SET_NO_HLSEARCH(FALSE);
-  }
-  /* when 'scrollbind' is set: snapshot the current position to avoid a jump
-   * at the end of normal_cmd() */
-  else if ((int *)varp == &curwin->w_p_scb) {
+  } else if ((int *)varp == &p_hls) {
+    //  when 'hlsearch' is set or reset: reset no_hlsearch
+    SET_NO_HLSEARCH(false);
+  } else if ((int *)varp == &curwin->w_p_scb) {
+  // when 'scrollbind' is set: snapshot the current position to avoid a jump
+  // at the end of normal_cmd()
     if (curwin->w_p_scb) {
-      do_check_scrollbind(FALSE);
+      do_check_scrollbind(false);
       curwin->w_scbind_pos = curwin->w_topline;
     }
-  }
-  /* There can be only one window with 'previewwindow' set. */
-  else if ((int *)varp == &curwin->w_p_pvw) {
+  } else if ((int *)varp == &curwin->w_p_pvw) {
+    //  There can be only one window with 'previewwindow' set.
     if (curwin->w_p_pvw) {
       FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
         if (win->w_p_pvw && win != curwin) {
@@ -3974,17 +4000,17 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
       pseps[0] = '\\';
     }
 
-    /* need to adjust the file name arguments and buffer names. */
+    //  need to adjust the file name arguments and buffer names.
     buflist_slash_adjust();
     alist_slash_adjust();
     scriptnames_slash_adjust();
   }
 #endif
-
-  /* If 'wrap' is set, set w_leftcol to zero. */
   else if ((int *)varp == &curwin->w_p_wrap) {
-    if (curwin->w_p_wrap)
+    //  If 'wrap' is set, set w_leftcol to zero.
+    if (curwin->w_p_wrap) {
       curwin->w_leftcol = 0;
+    }
   } else if ((int *)varp == &p_ea) {
     if (p_ea && !old_value) {
       win_equal(curwin, false, 0);
@@ -3992,22 +4018,18 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
   } else if ((int *)varp == &p_acd) {
     // Change directories when the 'acd' option is set now.
     do_autochdir();
-  }
-  /* 'diff' */
-  else if ((int *)varp == &curwin->w_p_diff) {
-    /* May add or remove the buffer from the list of diff buffers. */
+  } else if ((int *)varp == &curwin->w_p_diff) {  //  'diff'
+    //  May add or remove the buffer from the list of diff buffers.
     diff_buf_adjust(curwin);
-    if (foldmethodIsDiff(curwin))
+    if (foldmethodIsDiff(curwin)) {
       foldUpdateAll(curwin);
-  }
-
-
-  /* 'spell' */
-  else if ((int *)varp == &curwin->w_p_spell) {
+    }
+  } else if ((int *)varp == &curwin->w_p_spell) {  //  'spell'
     if (curwin->w_p_spell) {
       char_u      *errmsg = did_set_spelllang(curwin);
-      if (errmsg != NULL)
+      if (errmsg != NULL) {
         EMSG(_(errmsg));
+      }
     }
   }
 
@@ -4017,13 +4039,13 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
        * 'arabic' is set, handle various sub-settings.
        */
       if (!p_tbidi) {
-        /* set rightleft mode */
+        //  set rightleft mode
         if (!curwin->w_p_rl) {
-          curwin->w_p_rl = TRUE;
+          curwin->w_p_rl = true;
           changed_window_setting();
         }
 
-        /* Enable Arabic shaping (major part of what Arabic requires) */
+        //  Enable Arabic shaping (major part of what Arabic requires)
         if (!p_arshape) {
           p_arshape = true;
           redraw_all_later(NOT_VALID);
@@ -4041,8 +4063,8 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
         set_vim_var_string(VV_WARNINGMSG, _(w_arabic), -1);
       }
 
-      /* set 'delcombine' */
-      p_deco = TRUE;
+      //  set 'delcombine'
+      p_deco = true;
 
       // Force-set the necessary keymap for arabic.
       set_option_value("keymap", 0L, "arabic", OPT_LOCAL);
@@ -4051,9 +4073,9 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
        * 'arabic' is reset, handle various sub-settings.
        */
       if (!p_tbidi) {
-        /* reset rightleft mode */
+        //  reset rightleft mode
         if (curwin->w_p_rl) {
-          curwin->w_p_rl = FALSE;
+          curwin->w_p_rl = false;
           changed_window_setting();
         }
 
@@ -4064,7 +4086,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
       /* 'delcombine' isn't reset, it is a global option and another
        * window may still want it "on". */
 
-      /* Revert to the default keymap */
+      //  Revert to the default keymap
       curbuf->b_p_iminsert = B_IMODE_NONE;
       curbuf->b_p_imsearch = B_IMODE_USE_INSERT;
     }
@@ -4104,10 +4126,11 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
                        BOOLEAN_OBJ(value));
   }
 
-  comp_col();                       /* in case 'ruler' or 'showcmd' changed */
+  comp_col();                       //  in case 'ruler' or 'showcmd' changed
   if (curwin->w_curswant != MAXCOL
-      && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0)
-    curwin->w_set_curswant = TRUE;
+      && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0) {
+    curwin->w_set_curswant = true;
+  }
   check_redraw(options[opt_idx].flags);
 
   return NULL;
@@ -4128,11 +4151,11 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
 {
   char_u      *errmsg = NULL;
   long old_value = *(long *)varp;
-  long old_Rows = Rows;                 /* remember old Rows */
-  long old_Columns = Columns;           /* remember old Columns */
+  long old_Rows = Rows;                 //  remember old Rows
+  long old_Columns = Columns;           //  remember old Columns
   long        *pp = (long *)varp;
 
-  /* Disallow changing some options from secure mode. */
+  //  Disallow changing some options from secure mode.
   if ((secure || sandbox != 0)
       && (options[opt_idx].flags & P_SECURE)) {
     return (char *)e_secure;
@@ -4438,21 +4461,22 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
            && curwin->w_height > 0))
       && full_screen) {
     if (pp == &(curwin->w_p_scr)) {
-      if (curwin->w_p_scr != 0)
+      if (curwin->w_p_scr != 0) {
         errmsg = e_scroll;
+      }
       win_comp_scroll(curwin);
-    }
-    /* If 'scroll' became invalid because of a side effect silently adjust
-     * it. */
-    else if (curwin->w_p_scr <= 0)
+    } else if (curwin->w_p_scr <= 0) {
+    // If 'scroll' became invalid because of a side effect silently adjust
+    // it.
       curwin->w_p_scr = 1;
-    else     /* curwin->w_p_scr > curwin->w_height */
+    } else {  //  curwin->w_p_scr > curwin->w_height
       curwin->w_p_scr = curwin->w_height;
+    }
   }
   if ((p_sj < -100 || p_sj >= Rows) && full_screen) {
-    if (Rows != old_Rows)       /* Rows changed, just adjust p_sj */
+    if (Rows != old_Rows) {     //  Rows changed, just adjust p_sj
       p_sj = Rows / 2;
-    else {
+    } else {
       errmsg = e_scroll;
       p_sj = 1;
     }
@@ -4488,10 +4512,11 @@ static char *set_num_option(int opt_idx, char_u *varp, long value,
                        INTEGER_OBJ(value));
   }
 
-  comp_col();                       /* in case 'columns' or 'ls' changed */
+  comp_col();                       //  in case 'columns' or 'ls' changed
   if (curwin->w_curswant != MAXCOL
-      && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0)
-    curwin->w_set_curswant = TRUE;
+      && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0) {
+    curwin->w_set_curswant = true;
+  }
   check_redraw(options[opt_idx].flags);
 
   return (char *)errmsg;
@@ -4522,7 +4547,7 @@ static void trigger_optionsset_string(int opt_idx, int opt_flags,
  */
 static void check_redraw(uint32_t flags)
 {
-  /* Careful: P_RCLR and P_RALL are a combination of other P_ flags */
+  //  Careful: P_RCLR and P_RALL are a combination of other P_ flags
   bool doclear = (flags & P_RCLR) == P_RCLR;
   bool all = ((flags & P_RALL) == P_RALL || doclear);
 
@@ -4755,7 +4780,7 @@ int get_option_value(
 // opt_type).
 //
 // Returned flags:
-//       0 hidden or unknown option, also option that does not have requested 
+//       0 hidden or unknown option, also option that does not have requested
 //         type (see SREQ_* in option_defs.h)
 //  see SOPT_* in option_defs.h for other flags
 //
@@ -4909,7 +4934,7 @@ char *set_option_value(const char *const name, const long number,
       return set_string_option(opt_idx, s, opt_flags);
     } else {
       varp = get_varp_scope(&(options[opt_idx]), opt_flags);
-      if (varp != NULL) {       /* hidden option is not changed */
+      if (varp != NULL) {       //  hidden option is not changed
         if (number == 0 && string != NULL) {
           int idx;
 
@@ -4968,10 +4993,10 @@ static int find_key_option(const char_u *arg)
  * if 'all' == 0: show changed options
  * if 'all' == 1: show all normal options
  */
-static void 
-showoptions (
+static void
+showoptions(
     int all,
-    int opt_flags                  /* OPT_LOCAL and/or OPT_GLOBAL */
+    int opt_flags                  //  OPT_LOCAL and/or OPT_GLOBAL
 )
 {
   vimoption_T    *p;
@@ -4998,28 +5023,26 @@ showoptions (
     MSG_PUTS_TITLE(_("\n--- Options ---"));
   }
 
-  /*
-   * do the loop two times:
-   * 1. display the short items
-   * 2. display the long items (only strings and numbers)
-   */
-  for (run = 1; run <= 2 && !got_int; ++run) {
-    /*
-     * collect the items in items[]
-     */
+  // do the loop two times:
+  // 1. display the short items
+  // 2. display the long items (only strings and numbers)
+  for (run = 1; run <= 2 && !got_int; run++) {
+    // collect the items in items[]
     item_count = 0;
     for (p = &options[0]; p->fullname != NULL; p++) {
       varp = NULL;
       if (opt_flags != 0) {
-        if (p->indir != PV_NONE)
+        if (p->indir != PV_NONE) {
           varp = get_varp_scope(p, opt_flags);
-      } else
+        }
+      } else {
         varp = get_varp(p);
+      }
       if (varp != NULL
           && (all == 1 || (all == 0 && !optval_default(p, varp)))) {
-        if (p->flags & P_BOOL)
-          len = 1;                      /* a toggle option fits always */
-        else {
+        if (p->flags & P_BOOL) {
+          len = 1;                      //  a toggle option fits always
+        } else {
           option_value2string(p, opt_flags);
           len = (int)STRLEN(p->fullname) + vim_strsize(NameBuff) + 1;
         }
@@ -5039,18 +5062,21 @@ showoptions (
              && (Columns + GAP - 3) / INC >= INT_MIN
              && (Columns + GAP - 3) / INC <= INT_MAX);
       cols = (int)((Columns + GAP - 3) / INC);
-      if (cols == 0)
+      if (cols == 0) {
         cols = 1;
+      }
       rows = (item_count + cols - 1) / cols;
-    } else      /* run == 2 */
+    } else {    //  run == 2
       rows = item_count;
-    for (row = 0; row < rows && !got_int; ++row) {
-      msg_putchar('\n');                        /* go to next line */
-      if (got_int)                              /* 'q' typed in more */
+    }
+    for (row = 0; row < rows && !got_int; row++) {
+      msg_putchar('\n');                        //  go to next line
+      if (got_int) {                            //  'q' typed in more
         break;
+      }
       col = 0;
       for (i = row; i < item_count; i += rows) {
-        msg_col = col;                          /* make columns */
+        msg_col = col;                          //  make columns
         showoneopt(items[i], opt_flags);
         col += INC;
       }
@@ -5061,15 +5087,14 @@ showoptions (
   xfree(items);
 }
 
-/*
- * Return TRUE if option "p" has its default value.
- */
+/// Return true if option "p" has its default value.
 static int optval_default(vimoption_T *p, char_u *varp)
 {
   int dvi;
 
-  if (varp == NULL)
-    return TRUE;            /* hidden option is always at default */
+  if (varp == NULL) {
+    return true;            //  hidden option is always at default
+  }
   dvi = ((p->flags & P_VI_DEF) || p_cp) ? VI_DEFAULT : VIM_DEFAULT;
   if (p->flags & P_NUM) {
     return *(long *)varp == (long)(intptr_t)p->def_val[dvi];
@@ -5108,17 +5133,17 @@ void ui_refresh_options(void)
  * showoneopt: show the value of one option
  * must not be called with a hidden option!
  */
-static void 
-showoneopt (
+static void
+showoneopt(
     vimoption_T *p,
-    int opt_flags                          /* OPT_LOCAL or OPT_GLOBAL */
+    int opt_flags                          //  OPT_LOCAL or OPT_GLOBAL
 )
 {
   char_u      *varp;
   int save_silent = silent_mode;
 
-  silent_mode = FALSE;
-  info_message = TRUE;          /* use mch_msg(), not mch_errmsg() */
+  silent_mode = false;
+  info_message = true;          //  use mch_msg(), not mch_errmsg()
 
   varp = get_varp_scope(p, opt_flags);
 
@@ -5134,13 +5159,13 @@ showoneopt (
   MSG_PUTS(p->fullname);
   if (!(p->flags & P_BOOL)) {
     msg_putchar('=');
-    /* put value string in NameBuff */
+    //  put value string in NameBuff
     option_value2string(p, opt_flags);
     msg_outtrans(NameBuff);
   }
 
   silent_mode = save_silent;
-  info_message = FALSE;
+  info_message = false;
 }
 
 /*
@@ -5159,7 +5184,7 @@ showoneopt (
  *			   may have set them when doing ":edit file" and the
  *			   user has set them back at the default or fresh
  *			   value.
- *			   When "local_only" is TRUE, don't write fresh
+ *			   When "local_only" is true, don't write fresh
  *			   values, only local values (for ":mkview").
  * (fresh value = value used for a new buffer or window for a local option).
  *
@@ -5168,9 +5193,9 @@ showoneopt (
 int makeset(FILE *fd, int opt_flags, int local_only)
 {
   vimoption_T    *p;
-  char_u              *varp;                    /* currently used value */
-  char_u              *varp_fresh;              /* local value */
-  char_u              *varp_local = NULL;       /* fresh value */
+  char_u              *varp;                    //  currently used value
+  char_u              *varp_fresh;              //  local value
+  char_u              *varp_local = NULL;       //  fresh value
   char                *cmd;
   int round;
   int pri;
@@ -5184,35 +5209,40 @@ int makeset(FILE *fd, int opt_flags, int local_only)
    * Do the loop over "options[]" twice: once for options with the
    * P_PRI_MKRC flag and once without.
    */
-  for (pri = 1; pri >= 0; --pri) {
-    for (p = &options[0]; p->fullname; p++)
+  for (pri = 1; pri >= 0; pri--) {
+    for (p = &options[0]; p->fullname; p++) {
       if (!(p->flags & P_NO_MKRC)
           && ((pri == 1) == ((p->flags & P_PRI_MKRC) != 0))) {
-        /* skip global option when only doing locals */
-        if (p->indir == PV_NONE && !(opt_flags & OPT_GLOBAL))
+        //  skip global option when only doing locals
+        if (p->indir == PV_NONE && !(opt_flags & OPT_GLOBAL)) {
           continue;
+        }
 
         /* Do not store options like 'bufhidden' and 'syntax' in a vimrc
          * file, they are always buffer-specific. */
-        if ((opt_flags & OPT_GLOBAL) && (p->flags & P_NOGLOB))
+        if ((opt_flags & OPT_GLOBAL) && (p->flags & P_NOGLOB)) {
           continue;
+        }
 
         varp = get_varp_scope(p, opt_flags);
-        /* Hidden options are never written. */
-        if (!varp)
+        //  Hidden options are never written.
+        if (!varp) {
           continue;
-        /* Global values are only written when not at the default value. */
-        if ((opt_flags & OPT_GLOBAL) && optval_default(p, varp))
+        }
+        //  Global values are only written when not at the default value.
+        if ((opt_flags & OPT_GLOBAL) && optval_default(p, varp)) {
           continue;
+        }
 
         round = 2;
         if (p->indir != PV_NONE) {
           if (p->var == VAR_WIN) {
-            /* skip window-local option when only doing globals */
-            if (!(opt_flags & OPT_LOCAL))
+            //  skip window-local option when only doing globals
+            if (!(opt_flags & OPT_LOCAL)) {
               continue;
-            /* When fresh value of window-local option is not at the
-             * default, need to write it too. */
+            }
+            // When fresh value of window-local option is not at the
+            // default, need to write it too.
             if (!(opt_flags & OPT_GLOBAL) && !local_only) {
               varp_fresh = get_varp_scope(p, OPT_GLOBAL);
               if (!optval_default(p, varp_fresh)) {
@@ -5226,20 +5256,23 @@ int makeset(FILE *fd, int opt_flags, int local_only)
 
         /* Round 1: fresh value for window-local options.
          * Round 2: other values */
-        for (; round <= 2; varp = varp_local, ++round) {
-          if (round == 1 || (opt_flags & OPT_GLOBAL))
+        for (; round <= 2; varp = varp_local, round++) {
+          if (round == 1 || (opt_flags & OPT_GLOBAL)) {
             cmd = "set";
-          else
+          } else {
             cmd = "setlocal";
+          }
 
           if (p->flags & P_BOOL) {
-            if (put_setbool(fd, cmd, p->fullname, *(int *)varp) == FAIL)
+            if (put_setbool(fd, cmd, p->fullname, *(int *)varp) == FAIL) {
               return FAIL;
+            }
           } else if (p->flags & P_NUM) {
-            if (put_setnum(fd, cmd, p->fullname, (long *)varp) == FAIL)
+            if (put_setnum(fd, cmd, p->fullname, (long *)varp) == FAIL) {
               return FAIL;
-          } else {    /* P_STRING */
-            int do_endif = FALSE;
+            }
+          } else {    //  P_STRING
+            int do_endif = false;
 
             // Don't set 'syntax' and 'filetype' again if the value is
             // already right, avoids reloading the syntax file.
@@ -5255,12 +5288,14 @@ int makeset(FILE *fd, int opt_flags, int local_only)
                     (p->flags & P_EXPAND) != 0) == FAIL)
               return FAIL;
             if (do_endif) {
-              if (put_line(fd, "endif") == FAIL)
+              if (put_line(fd, "endif") == FAIL) {
                 return FAIL;
+              }
             }
           }
         }
       }
+    }
   }
   return OK;
 }
@@ -5271,19 +5306,20 @@ int makeset(FILE *fd, int opt_flags, int local_only)
  */
 int makefoldset(FILE *fd)
 {
-  if (put_setstring(fd, "setlocal", "fdm", &curwin->w_p_fdm, FALSE) == FAIL
-      || put_setstring(fd, "setlocal", "fde", &curwin->w_p_fde, FALSE)
+  if (put_setstring(fd, "setlocal", "fdm", &curwin->w_p_fdm, false) == FAIL
+      || put_setstring(fd, "setlocal", "fde", &curwin->w_p_fde, false)
       == FAIL
-      || put_setstring(fd, "setlocal", "fmr", &curwin->w_p_fmr, FALSE)
+      || put_setstring(fd, "setlocal", "fmr", &curwin->w_p_fmr, false)
       == FAIL
-      || put_setstring(fd, "setlocal", "fdi", &curwin->w_p_fdi, FALSE)
+      || put_setstring(fd, "setlocal", "fdi", &curwin->w_p_fdi, false)
       == FAIL
       || put_setnum(fd, "setlocal", "fdl", &curwin->w_p_fdl) == FAIL
       || put_setnum(fd, "setlocal", "fml", &curwin->w_p_fml) == FAIL
       || put_setnum(fd, "setlocal", "fdn", &curwin->w_p_fdn) == FAIL
       || put_setbool(fd, "setlocal", "fen", curwin->w_p_fen) == FAIL
-      )
+      ) {
     return FAIL;
+  }
 
   return OK;
 }
@@ -5293,8 +5329,9 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int e
   char_u      *s;
   char_u      *buf;
 
-  if (fprintf(fd, "%s %s=", cmd, name) < 0)
+  if (fprintf(fd, "%s %s=", cmd, name) < 0) {
     return FAIL;
+  }
   if (*valuep != NULL) {
     /* Output 'pastetoggle' as key names.  For other
      * options some characters have to be escaped with
@@ -5310,17 +5347,19 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, int e
       }
     } else if (expand) {
       buf = xmalloc(MAXPATHL);
-      home_replace(NULL, *valuep, buf, MAXPATHL, FALSE);
+      home_replace(NULL, *valuep, buf, MAXPATHL, false);
       if (put_escstr(fd, buf, 2) == FAIL) {
         xfree(buf);
         return FAIL;
       }
       xfree(buf);
-    } else if (put_escstr(fd, *valuep, 2) == FAIL)
+    } else if (put_escstr(fd, *valuep, 2) == FAIL) {
       return FAIL;
+    }
   }
-  if (put_eol(fd) < 0)
+  if (put_eol(fd) < 0) {
     return FAIL;
+  }
   return OK;
 }
 
@@ -5328,26 +5367,32 @@ static int put_setnum(FILE *fd, char *cmd, char *name, long *valuep)
 {
   long wc;
 
-  if (fprintf(fd, "%s %s=", cmd, name) < 0)
+  if (fprintf(fd, "%s %s=", cmd, name) < 0) {
     return FAIL;
+  }
   if (wc_use_keyname((char_u *)valuep, &wc)) {
-    /* print 'wildchar' and 'wildcharm' as a key name */
-    if (fputs((char *)get_special_key_name((int)wc, 0), fd) < 0)
+    //  print 'wildchar' and 'wildcharm' as a key name
+    if (fputs((char *)get_special_key_name((int)wc, 0), fd) < 0) {
       return FAIL;
-  } else if (fprintf(fd, "%" PRId64, (int64_t)*valuep) < 0)
+    }
+  } else if (fprintf(fd, "%" PRId64, (int64_t)(*valuep)) < 0) {
     return FAIL;
-  if (put_eol(fd) < 0)
+  }
+  if (put_eol(fd) < 0) {
     return FAIL;
+  }
   return OK;
 }
 
 static int put_setbool(FILE *fd, char *cmd, char *name, int value)
 {
-  if (value < 0)        /* global/local option using global value */
+  if (value < 0) {      //  global/local option using global value
     return OK;
+  }
   if (fprintf(fd, "%s %s%s", cmd, value ? "" : "no", name) < 0
-      || put_eol(fd) < 0)
+      || put_eol(fd) < 0) {
     return FAIL;
+  }
   return OK;
 }
 
@@ -5358,7 +5403,7 @@ static int put_setbool(FILE *fd, char *cmd, char *name, int value)
  * of 'ru_col'.
  */
 
-#define COL_RULER 17        /* columns needed by standard ruler */
+#define COL_RULER 17        //  columns needed by standard ruler
 
 void comp_col(void)
 {
@@ -5368,14 +5413,16 @@ void comp_col(void)
   ru_col = 0;
   if (p_ru) {
     ru_col = (ru_wid ? ru_wid : COL_RULER) + 1;
-    /* no last status line, adjust sc_col */
-    if (!last_has_status)
+    //  no last status line, adjust sc_col
+    if (!last_has_status) {
       sc_col = ru_col;
+    }
   }
   if (p_sc) {
     sc_col += SHOWCMD_COLS;
-    if (!p_ru || last_has_status)           /* no need for separating space */
-      ++sc_col;
+    if (!p_ru || last_has_status) {         //  no need for separating space
+      sc_col++;
+    }
   }
   assert(sc_col >= 0
          && INT_MIN + sc_col <= Columns
@@ -5385,10 +5432,12 @@ void comp_col(void)
          && INT_MIN + ru_col <= Columns
          && Columns - ru_col <= INT_MAX);
   ru_col = (int)(Columns - ru_col);
-  if (sc_col <= 0)              /* screen too narrow, will become a mess */
+  if (sc_col <= 0) {            //  screen too narrow, will become a mess
     sc_col = 1;
-  if (ru_col <= 0)
+  }
+  if (ru_col <= 0) {
     ru_col = 1;
+  }
 }
 
 // Unset local option value, similar to ":set opt<".
@@ -5475,8 +5524,9 @@ void unset_global_local_option(char *name, void *from)
 static char_u *get_varp_scope(vimoption_T *p, int opt_flags)
 {
   if ((opt_flags & OPT_GLOBAL) && p->indir != PV_NONE) {
-    if (p->var == VAR_WIN)
+    if (p->var == VAR_WIN) {
       return (char_u *)GLOBAL_WO(get_varp(p));
+    }
     return p->var;
   }
   if ((opt_flags & OPT_LOCAL) && ((int)p->indir & PV_BOTH)) {
@@ -5501,7 +5551,7 @@ static char_u *get_varp_scope(vimoption_T *p, int opt_flags)
     case PV_BKC:  return (char_u *)&(curbuf->b_p_bkc);
     case PV_MENC: return (char_u *)&(curbuf->b_p_menc);
     }
-    return NULL;     /* "cannot happen" */
+    return NULL;     //  "cannot happen"
   }
   return get_varp(p);
 }
@@ -5511,14 +5561,15 @@ static char_u *get_varp_scope(vimoption_T *p, int opt_flags)
  */
 static char_u *get_varp(vimoption_T *p)
 {
-  /* hidden option, always return NULL */
-  if (p->var == NULL)
+  //  hidden option, always return NULL
+  if (p->var == NULL) {
     return NULL;
+  }
 
   switch ((int)p->indir) {
   case PV_NONE:   return p->var;
 
-  /* global option with local value: use local value if it's been set */
+  //  global option with local value: use local value if it's been set
   case PV_EP:     return *curbuf->b_p_ep != NUL
            ? (char_u *)&curbuf->b_p_ep : p->var;
   case PV_KP:     return *curbuf->b_p_kp != NUL
@@ -5657,7 +5708,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_LCS:    return (char_u *)&(curwin->w_p_lcs);
   default:        IEMSG(_("E356: get_varp ERROR"));
   }
-  /* always return a valid pointer to avoid a crash! */
+  //  always return a valid pointer to avoid a crash!
   return (char_u *)&(curbuf->b_p_wm);
 }
 
@@ -5666,8 +5717,9 @@ static char_u *get_varp(vimoption_T *p)
  */
 char_u *get_equalprg(void)
 {
-  if (*curbuf->b_p_ep == NUL)
+  if (*curbuf->b_p_ep == NUL) {
     return p_ep;
+  }
   return curbuf->b_p_ep;
 }
 
@@ -5810,10 +5862,10 @@ void didset_window_options(win_T *wp)
  */
 void buf_copy_options(buf_T *buf, int flags)
 {
-  int should_copy = TRUE;
-  char_u      *save_p_isk = NULL;           /* init for GCC */
+  int should_copy = true;
+  char_u      *save_p_isk = NULL;           //  init for GCC
   int dont_do_help;
-  int did_isk = FALSE;
+  int did_isk = false;
 
   /*
    * Skip this when the option defaults have not been set yet.  Happens when
@@ -5825,18 +5877,18 @@ void buf_copy_options(buf_T *buf, int flags)
      * Don't copy when already initialized.
      * Don't copy when 'cpo' contains 's' and not entering.
      * 'S'	BCO_ENTER  initialized	's'  should_copy
-     * yes	  yes	       X	 X	TRUE
-     * yes	  no	      yes	 X	FALSE
-     * no	   X	      yes	 X	FALSE
-     *  X	  no	      no	yes	FALSE
-     *  X	  no	      no	no	TRUE
-     * no	  yes	      no	 X	TRUE
+     * yes	  yes	       X	 X	true
+     * yes	  no	      yes	 X	false
+     * no	   X	      yes	 X	false
+     *  X	  no	      no	yes	false
+     *  X	  no	      no	no	true
+     * no	  yes	      no	 X	true
      */
     if ((vim_strchr(p_cpo, CPO_BUFOPTGLOB) == NULL || !(flags & BCO_ENTER))
         && (buf->b_p_initialized
             || (!(flags & BCO_ENTER)
                 && vim_strchr(p_cpo, CPO_BUFOPT) != NULL)))
-      should_copy = FALSE;
+      should_copy = false;
 
     if (should_copy || (flags & BCO_ALWAYS)) {
       /* Don't copy the options specific to a help buffer when
@@ -5844,7 +5896,7 @@ void buf_copy_options(buf_T *buf, int flags)
       * (jumping back to a help file with CTRL-T or CTRL-O) */
       dont_do_help = ((flags & BCO_NOHELP) && buf->b_help)
                      || buf->b_p_initialized;
-      if (dont_do_help) {               /* don't free b_p_isk */
+      if (dont_do_help) {               //  don't free b_p_isk
         save_p_isk = buf->b_p_isk;
         buf->b_p_isk = NULL;
       }
@@ -5853,8 +5905,8 @@ void buf_copy_options(buf_T *buf, int flags)
        * If not already initialized, set 'readonly' and copy 'fileformat'.
        */
       if (!buf->b_p_initialized) {
-        free_buf_options(buf, TRUE);
-        buf->b_p_ro = FALSE;                    /* don't copy readonly */
+        free_buf_options(buf, true);
+        buf->b_p_ro = false;                    //  don't copy readonly
         buf->b_p_fenc = vim_strsave(p_fenc);
         switch (*p_ffs) {
           case 'm': {
@@ -5917,12 +5969,12 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_cin = p_cin;
       buf->b_p_cink = vim_strsave(p_cink);
       buf->b_p_cino = vim_strsave(p_cino);
-      /* Don't copy 'filetype', it must be detected */
+      //  Don't copy 'filetype', it must be detected
       buf->b_p_ft = empty_option;
       buf->b_p_pi = p_pi;
       buf->b_p_cinw = vim_strsave(p_cinw);
       buf->b_p_lisp = p_lisp;
-      /* Don't copy 'syntax', it must be set */
+      //  Don't copy 'syntax', it must be set
       buf->b_p_syn = empty_option;
       buf->b_p_smc = p_smc;
       buf->b_s.b_syn_isk = empty_option;
@@ -5973,15 +6025,16 @@ void buf_copy_options(buf_T *buf, int flags)
        * Don't touch these at all when BCO_NOHELP is used and going from
        * or to a help buffer.
        */
-      if (dont_do_help)
+      if (dont_do_help) {
         buf->b_p_isk = save_p_isk;
-      else {
+      } else {
         buf->b_p_isk = vim_strsave(p_isk);
         did_isk = true;
         buf->b_p_ts = p_ts;
         buf->b_help = false;
-        if (buf->b_p_bt[0] == 'h')
+        if (buf->b_p_bt[0] == 'h') {
           clear_string_option(&buf->b_p_bt);
+        }
         buf->b_p_ma = p_ma;
       }
     }
@@ -5990,13 +6043,15 @@ void buf_copy_options(buf_T *buf, int flags)
      * When the options should be copied (ignoring BCO_ALWAYS), set the
      * flag that indicates that the options have been initialized.
      */
-    if (should_copy)
+    if (should_copy) {
       buf->b_p_initialized = true;
+    }
   }
 
-  check_buf_options(buf);           /* make sure we don't have NULLs */
-  if (did_isk)
-    (void)buf_init_chartab(buf, FALSE);
+  check_buf_options(buf);           //  make sure we don't have NULLs
+  if (did_isk) {
+    (void)buf_init_chartab(buf, false);
+  }
 }
 
 /*
@@ -6034,19 +6089,19 @@ static int expand_option_idx = -1;
 static char_u expand_option_name[5] = {'t', '_', NUL, NUL, NUL};
 static int expand_option_flags = 0;
 
-void 
-set_context_in_set_cmd (
+void
+set_context_in_set_cmd(
     expand_T *xp,
     char_u *arg,
-    int opt_flags                  /* OPT_GLOBAL and/or OPT_LOCAL */
+    int opt_flags                  //  OPT_GLOBAL and/or OPT_LOCAL
 )
 {
   char_u nextchar;
-  uint32_t flags = 0;           /* init for GCC */
-  int opt_idx = 0;              /* init for GCC */
+  uint32_t flags = 0;           //  init for GCC
+  int opt_idx = 0;              //  init for GCC
   char_u      *p;
   char_u      *s;
-  int is_term_option = FALSE;
+  int is_term_option = false;
   int key;
 
   expand_option_flags = opt_flags;
@@ -6063,17 +6118,18 @@ set_context_in_set_cmd (
   }
   while (p > arg) {
     s = p;
-    /* count number of backslashes before ' ' or ',' */
+    //  count number of backslashes before ' ' or ','
     if (*p == ' ' || *p == ',') {
-      while (s > arg && *(s - 1) == '\\')
-        --s;
+      while (s > arg && *(s - 1) == '\\') {
+        s--;
+      }
     }
-    /* break at a space with an even number of backslashes */
+    //  break at a space with an even number of backslashes
     if (*p == ' ' && ((p - s) & 1) == 0) {
-      ++p;
+      p++;
       break;
     }
-    --p;
+    p--;
   }
   if (STRNCMP(p, "no", 2) == 0) {
     xp->xp_context = EXPAND_BOOL_SETTINGS;
@@ -6085,27 +6141,31 @@ set_context_in_set_cmd (
   }
   xp->xp_pattern = arg = p;
   if (*arg == '<') {
-    while (*p != '>')
-      if (*p++ == NUL)              /* expand terminal option name */
+    while (*p != '>') {
+      if (*p++ == NUL) {            //  expand terminal option name
         return;
+      }
+    }
     key = get_special_key_code(arg + 1);
-    if (key == 0) {                 /* unknown name */
+    if (key == 0) {                 //  unknown name
       xp->xp_context = EXPAND_NOTHING;
       return;
     }
     nextchar = *++p;
-    is_term_option = TRUE;
+    is_term_option = true;
     expand_option_name[2] = (char_u)KEY2TERMCAP0(key);
     expand_option_name[3] = KEY2TERMCAP1(key);
   } else {
     if (p[0] == 't' && p[1] == '_') {
       p += 2;
-      if (*p != NUL)
-        ++p;
-      if (*p == NUL)
-        return;                 /* expand option name */
+      if (*p != NUL) {
+        p++;
+      }
+      if (*p == NUL) {
+        return;                 //  expand option name
+      }
       nextchar = *++p;
-      is_term_option = TRUE;
+      is_term_option = true;
       expand_option_name[2] = p[-2];
       expand_option_name[3] = p[-1];
     } else {
@@ -6129,9 +6189,9 @@ set_context_in_set_cmd (
       }
     }
   }
-  /* handle "-=" and "+=" */
+  //  handle "-=" and "+="
   if ((nextchar == '-' || nextchar == '+' || nextchar == '^') && p[1] == '=') {
-    ++p;
+    p++;
     nextchar = '=';
   }
   if ((nextchar != '=' && nextchar != ':')
@@ -6141,16 +6201,18 @@ set_context_in_set_cmd (
   }
   if (p[1] == NUL) {
     xp->xp_context = EXPAND_OLD_SETTING;
-    if (is_term_option)
+    if (is_term_option) {
       expand_option_idx = -1;
-    else
+    } else {
       expand_option_idx = opt_idx;
+    }
     xp->xp_pattern = p + 1;
     return;
   }
   xp->xp_context = EXPAND_NOTHING;
-  if (is_term_option || (flags & P_NUM))
+  if (is_term_option || (flags & P_NUM)) {
     return;
+  }
 
   xp->xp_pattern = p + 1;
 
@@ -6173,22 +6235,24 @@ set_context_in_set_cmd (
         xp->xp_backslash = XP_BS_ONE;
     } else {
       xp->xp_context = EXPAND_FILES;
-      /* for 'tags' need three backslashes for a space */
-      if (p == (char_u *)&p_tags)
+      //  for 'tags' need three backslashes for a space
+      if (p == (char_u *)&p_tags) {
         xp->xp_backslash = XP_BS_THREE;
-      else
+      } else {
         xp->xp_backslash = XP_BS_ONE;
+      }
     }
   }
 
   /* For an option that is a list of file names, find the start of the
    * last file name. */
-  for (p = arg + STRLEN(arg) - 1; p > xp->xp_pattern; --p) {
-    /* count number of backslashes before ' ' or ',' */
+  for (p = arg + STRLEN(arg) - 1; p > xp->xp_pattern; p--) {
+    //  count number of backslashes before ' ' or ','
     if (*p == ' ' || *p == ',') {
       s = p;
-      while (s > xp->xp_pattern && *(s - 1) == '\\')
-        --s;
+      while (s > xp->xp_pattern && *(s - 1) == '\\') {
+        s--;
+      }
       if ((*p == ' ' && (xp->xp_backslash == XP_BS_THREE && (p - s) < 3))
           || (*p == ',' && (flags & P_COMMA) && ((p - s) & 1) == 0)) {
         xp->xp_pattern = p + 1;
@@ -6196,7 +6260,7 @@ set_context_in_set_cmd (
       }
     }
 
-    /* for 'spellsuggest' start at "file:" */
+    //  for 'spellsuggest' start at "file:"
     if (options[opt_idx].var == (char_u *)&p_sps
         && STRNCMP(p, "file:", 5) == 0) {
       xp->xp_pattern = p + 5;
@@ -6221,31 +6285,36 @@ int ExpandSettings(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***
    * loop == 0: count the number of matching options
    * loop == 1: copy the matching options into allocated memory
    */
-  for (loop = 0; loop <= 1; ++loop) {
+  for (loop = 0; loop <= 1; loop++) {
     regmatch->rm_ic = ic;
     if (xp->xp_context != EXPAND_BOOL_SETTINGS) {
       for (match = 0; match < (int)ARRAY_SIZE(names);
-           ++match)
+           match++) {
         if (vim_regexec(regmatch, (char_u *)names[match], (colnr_T)0)) {
-          if (loop == 0)
+          if (loop == 0) {
             num_normal++;
-          else
+          } else {
             (*file)[count++] = vim_strsave((char_u *)names[match]);
+          }
         }
+      }
     }
     for (size_t opt_idx = 0; (str = (char_u *)options[opt_idx].fullname) != NULL;
          opt_idx++) {
-      if (options[opt_idx].var == NULL)
+      if (options[opt_idx].var == NULL) {
         continue;
+      }
       if (xp->xp_context == EXPAND_BOOL_SETTINGS
-          && !(options[opt_idx].flags & P_BOOL))
+          && !(options[opt_idx].flags & P_BOOL)) {
         continue;
-      match = FALSE;
+      }
+      match = false;
       if (vim_regexec(regmatch, str, (colnr_T)0)
           || (options[opt_idx].shortname != NULL
               && vim_regexec(regmatch,
-                  (char_u *)options[opt_idx].shortname, (colnr_T)0))){
-        match = TRUE;
+                             (char_u *)options[opt_idx].shortname,
+                             (colnr_T)0))) {
+        match = true;
       }
 
       if (match) {
@@ -6316,10 +6385,10 @@ void ExpandOldSetting(int *num_file, char_u ***file)
  * Get the value for the numeric or string option *opp in a nice format into
  * NameBuff[].  Must not be called with a hidden option!
  */
-static void 
-option_value2string (
+static void
+option_value2string(
     vimoption_T *opp,
-    int opt_flags                          /* OPT_GLOBAL and/or OPT_LOCAL */
+    int opt_flags                          //  OPT_GLOBAL and/or OPT_LOCAL
 )
 {
   char_u      *varp;
@@ -6354,19 +6423,18 @@ option_value2string (
   }
 }
 
-/*
- * Return TRUE if "varp" points to 'wildchar' or 'wildcharm' and it can be
- * printed as a keyname.
- * "*wcp" is set to the value of the option if it's 'wildchar' or 'wildcharm'.
- */
+/// Return true if "varp" points to 'wildchar' or 'wildcharm' and it can be
+/// printed as a keyname.
+/// "*wcp" is set to the value of the option if it's 'wildchar' or 'wildcharm'.
 static int wc_use_keyname(char_u *varp, long *wcp)
 {
   if (((long *)varp == &p_wc) || ((long *)varp == &p_wcm)) {
     *wcp = *(long *)varp;
-    if (IS_SPECIAL(*wcp) || find_special_key_in_table((int)*wcp) >= 0)
-      return TRUE;
+    if (IS_SPECIAL(*wcp) || find_special_key_in_table((int)(*wcp)) >= 0) {
+      return true;
+    }
   }
-  return FALSE;
+  return false;
 }
 
 /*
@@ -6378,7 +6446,7 @@ static int wc_use_keyname(char_u *varp, long *wcp)
  *
  * langmap_mapchar[] maps any of 256 chars to an ASCII char used for Vim
  * commands.
- * langmap_mapga.ga_data is a sorted table of langmap_entry_T. 
+ * langmap_mapga.ga_data is a sorted table of langmap_entry_T.
  * This does the same as langmap_mapchar[] for characters >= 256.
  */
 /*
@@ -6402,7 +6470,7 @@ static void langmap_set_entry(int from, int to)
   assert(langmap_mapga.ga_len >= 0);
   unsigned int b = (unsigned int)langmap_mapga.ga_len;
 
-  /* Do a binary search for an existing entry. */
+  //  Do a binary search for an existing entry.
   while (a != b) {
     unsigned int i = (a + b) / 2;
     int d = entries[i].from - from;
@@ -6411,19 +6479,20 @@ static void langmap_set_entry(int from, int to)
       entries[i].to = to;
       return;
     }
-    if (d < 0)
+    if (d < 0) {
       a = i + 1;
-    else
+    } else {
       b = i;
+    }
   }
 
   ga_grow(&langmap_mapga, 1);
 
-  /* insert new entry at position "a" */
+  //  insert new entry at position "a"
   entries = (langmap_entry_T *)(langmap_mapga.ga_data) + a;
   memmove(entries + 1, entries,
           ((unsigned int)langmap_mapga.ga_len - a) * sizeof(langmap_entry_T));
-  ++langmap_mapga.ga_len;
+  langmap_mapga.ga_len++;
   entries[0].from = from;
   entries[0].to = to;
 }
@@ -6441,20 +6510,23 @@ int langmap_adjust_mb(int c)
     int i = (a + b) / 2;
     int d = entries[i].from - c;
 
-    if (d == 0)
-      return entries[i].to;        /* found matching entry */
-    if (d < 0)
+    if (d == 0) {
+      return entries[i].to;        //  found matching entry
+    }
+    if (d < 0) {
       a = i + 1;
-    else
+    } else {
       b = i;
+    }
   }
-  return c;    /* no entry found, return "c" unmodified */
+  return c;    //  no entry found, return "c" unmodified
 }
 
 static void langmap_init(void)
 {
-  for (int i = 0; i < 256; i++)
-    langmap_mapchar[i] = (char_u)i;      /* we init with a one-to-one map */
+  for (int i = 0; i < 256; i++) {
+    langmap_mapchar[i] = (char_u)i;      //  we init with a one-to-one map
+  }
   ga_init(&langmap_mapga, sizeof(langmap_entry_T), 8);
 }
 
@@ -6468,8 +6540,8 @@ static void langmap_set(void)
   char_u  *p2;
   int from, to;
 
-  ga_clear(&langmap_mapga);                 /* clear the previous map first */
-  langmap_init();                           /* back to one-to-one map */
+  ga_clear(&langmap_mapga);                 //  clear the previous map first
+  langmap_init();                           //  back to one-to-one map
 
   for (p = p_langmap; p[0] != NUL; ) {
     for (p2 = p; p2[0] != NUL && p2[0] != ',' && p2[0] != ';';
@@ -6478,13 +6550,14 @@ static void langmap_set(void)
         p2++;
       }
     }
-    if (p2[0] == ';')
-      ++p2;                 /* abcd;ABCD form, p2 points to A */
-    else
-      p2 = NULL;            /* aAbBcCdD form, p2 is NULL */
+    if (p2[0] == ';') {
+      p2++;                 //  abcd;ABCD form, p2 points to A
+    } else {
+      p2 = NULL;            //  aAbBcCdD form, p2 is NULL
+    }
     while (p[0]) {
       if (p[0] == ',') {
-        ++p;
+        p++;
         break;
       }
       if (p[0] == '\\' && p[1] != NUL) {
@@ -6514,9 +6587,9 @@ static void langmap_set(void)
         return;
       }
 
-      if (from >= 256)
+      if (from >= 256) {
         langmap_set_entry(from, to);
-      else {
+      } else {
         assert(to <= UCHAR_MAX);
         langmap_mapchar[from & 255] = (char_u)to;
       }
@@ -6534,7 +6607,7 @@ static void langmap_set(void)
                   p);
               return;
             }
-            ++p;
+            p++;
           }
           break;
         }
@@ -6543,14 +6616,13 @@ static void langmap_set(void)
   }
 }
 
-/*
- * Return TRUE if format option 'x' is in effect.
- * Take care of no formatting when 'paste' is set.
- */
+/// Return true if format option 'x' is in effect.
+/// Take care of no formatting when 'paste' is set.
 int has_format_option(int x)
 {
-  if (p_paste)
-    return FALSE;
+  if (p_paste) {
+    return false;
+  }
   return vim_strchr(curbuf->b_p_fo, x) != NULL;
 }
 
@@ -6569,7 +6641,7 @@ bool shortmess(int x)
  */
 static void paste_option_changed(void)
 {
-  static int old_p_paste = FALSE;
+  static int old_p_paste = false;
   static int save_sm = 0;
   static int save_sta = 0;
   static int save_ru = 0;
@@ -6582,7 +6654,7 @@ static void paste_option_changed(void)
      * Save the current values, so they can be restored later.
      */
     if (!old_p_paste) {
-      /* save options for each buffer */
+      //  save options for each buffer
       FOR_ALL_BUFFERS(buf) {
         buf->b_p_tw_nopaste = buf->b_p_tw;
         buf->b_p_wm_nopaste = buf->b_p_wm;
@@ -6630,12 +6702,9 @@ static void paste_option_changed(void)
     p_wm = 0;
     p_sts = 0;
     p_ai = 0;
-  }
-  /*
-   * Paste switched from on to off: Restore saved values.
-   */
-  else if (old_p_paste) {
-    /* restore options for each buffer */
+  } else if (old_p_paste) {
+    // Paste switched from on to off: Restore saved values.
+    //  restore options for each buffer
     FOR_ALL_BUFFERS(buf) {
       buf->b_p_tw = buf->b_p_tw_nopaste;
       buf->b_p_wm = buf->b_p_wm_nopaste;
@@ -6644,7 +6713,7 @@ static void paste_option_changed(void)
       buf->b_p_et = buf->b_p_et_nopaste;
     }
 
-    /* restore global options */
+    //  restore global options
     p_sm = save_sm;
     p_sta = save_sta;
     if (p_ru != save_ru) {
@@ -6723,12 +6792,15 @@ static void fill_breakat_flags(void)
   char_u      *p;
   int i;
 
-  for (i = 0; i < 256; i++)
-    breakat_flags[i] = FALSE;
+  for (i = 0; i < 256; i++) {
+    breakat_flags[i] = false;
+  }
 
-  if (p_breakat != NULL)
-    for (p = p_breakat; *p; p++)
-      breakat_flags[*p] = TRUE;
+  if (p_breakat != NULL) {
+    for (p = p_breakat; *p; p++) {
+      breakat_flags[*p] = true;
+    }
+  }
 }
 
 /*
@@ -6740,7 +6812,7 @@ static void fill_breakat_flags(void)
 static int check_opt_strings(
     char_u *val,
     char **values,
-    int list                   /* when TRUE: accept a list of values */
+    int list                   //  when true: accept a list of values
 )
 {
   return opt_strings_flags(val, values, NULL, list);
@@ -6754,18 +6826,19 @@ static int check_opt_strings(
  * Empty is always OK.
  */
 static int opt_strings_flags(
-    char_u *val,             /* new value */
-    char **values,           /* array of valid string values */
+    char_u *val,             //  new value
+    char **values,           //  array of valid string values
     unsigned *flagp,
-    bool list                /* when TRUE: accept a list of values */
+    bool list                //  when true: accept a list of values
 )
 {
   unsigned int new_flags = 0;
 
   while (*val) {
-    for (unsigned int i = 0;; ++i) {
-      if (values[i] == NULL)            /* val not found in values[] */
+    for (unsigned int i = 0;; i++) {
+      if (values[i] == NULL) {          //  val not found in values[]
         return FAIL;
+      }
 
       size_t len = STRLEN(values[i]);
       if (STRNCMP(values[i], val, len) == 0
@@ -6773,12 +6846,13 @@ static int opt_strings_flags(
         val += len + (val[len] == ',');
         assert(i < sizeof(1U) * 8);
         new_flags |= (1U << i);
-        break;                  /* check next item in val list */
+        break;                  //  check next item in val list
       }
     }
   }
-  if (flagp != NULL)
+  if (flagp != NULL) {
     *flagp = new_flags;
+  }
 
   return OK;
 }
@@ -6793,55 +6867,60 @@ static int check_opt_wim(void)
   int i;
   int idx = 0;
 
-  for (i = 0; i < 4; ++i)
+  for (i = 0; i < 4; i++) {
     new_wim_flags[i] = 0;
+  }
 
-  for (p = p_wim; *p; ++p) {
-    for (i = 0; ASCII_ISALPHA(p[i]); ++i)
-      ;
-    if (p[i] != NUL && p[i] != ',' && p[i] != ':')
+  for (p = p_wim; *p; p++) {
+    for (i = 0; ASCII_ISALPHA(p[i]); i++) {}
+    if (p[i] != NUL && p[i] != ',' && p[i] != ':') {
       return FAIL;
-    if (i == 7 && STRNCMP(p, "longest", 7) == 0)
+    }
+    if (i == 7 && STRNCMP(p, "longest", 7) == 0) {
       new_wim_flags[idx] |= WIM_LONGEST;
-    else if (i == 4 && STRNCMP(p, "full", 4) == 0)
+    } else if (i == 4 && STRNCMP(p, "full", 4) == 0) {
       new_wim_flags[idx] |= WIM_FULL;
-    else if (i == 4 && STRNCMP(p, "list", 4) == 0)
+    } else if (i == 4 && STRNCMP(p, "list", 4) == 0) {
       new_wim_flags[idx] |= WIM_LIST;
-    else
+    } else {
       return FAIL;
+    }
     p += i;
-    if (*p == NUL)
+    if (*p == NUL) {
       break;
+    }
     if (*p == ',') {
-      if (idx == 3)
+      if (idx == 3) {
         return FAIL;
-      ++idx;
+      }
+      idx++;
     }
   }
 
-  /* fill remaining entries with last flag */
+  //  fill remaining entries with last flag
   while (idx < 3) {
     new_wim_flags[idx + 1] = new_wim_flags[idx];
-    ++idx;
+    idx++;
   }
 
-  /* only when there are no errors, wim_flags[] is changed */
-  for (i = 0; i < 4; ++i)
+  //  only when there are no errors, wim_flags[] is changed
+  for (i = 0; i < 4; i++) {
     wim_flags[i] = new_wim_flags[i];
+  }
   return OK;
 }
 
 /*
  * Check if backspacing over something is allowed.
- * The parameter what is one of the following: whatBS_INDENT, BS_EOL 
+ * The parameter what is one of the following: whatBS_INDENT, BS_EOL
  * or BS_START
  */
 bool can_bs(int what)
 {
   switch (*p_bs) {
-  case '2':       return TRUE;
+  case '2':       return true;
   case '1':       return what != BS_START;
-  case '0':       return FALSE;
+  case '0':       return false;
   }
   return vim_strchr(p_bs, what) != NULL;
 }
@@ -6856,7 +6935,7 @@ void save_file_ff(buf_T *buf)
   buf->b_start_eol = buf->b_p_eol;
   buf->b_start_bomb = buf->b_p_bomb;
 
-  /* Only use free/alloc when necessary, they take time. */
+  //  Only use free/alloc when necessary, they take time.
   if (buf->b_start_fenc == NULL
       || STRCMP(buf->b_start_fenc, buf->b_p_fenc) != 0) {
     xfree(buf->b_start_fenc);
@@ -6864,33 +6943,37 @@ void save_file_ff(buf_T *buf)
   }
 }
 
-/*
- * Return TRUE if 'fileformat' and/or 'fileencoding' has a different value
- * from when editing started (save_file_ff() called).
- * Also when 'endofline' was changed and 'binary' is set, or when 'bomb' was
- * changed and 'binary' is not set.
- * Also when 'endofline' was changed and 'fixeol' is not set.
- * When "ignore_empty" is true don't consider a new, empty buffer to be
- * changed.
- */
+/// Return true if 'fileformat' and/or 'fileencoding' has a different value
+/// from when editing started (save_file_ff() called).
+/// Also when 'endofline' was changed and 'binary' is set, or when 'bomb' was
+/// changed and 'binary' is not set.
+/// Also when 'endofline' was changed and 'fixeol' is not set.
+/// When "ignore_empty" is true don't consider a new, empty buffer to be
+/// changed.
 bool file_ff_differs(buf_T *buf, bool ignore_empty)
 {
-  /* In a buffer that was never loaded the options are not valid. */
-  if (buf->b_flags & BF_NEVERLOADED)
-    return FALSE;
+  //  In a buffer that was never loaded the options are not valid.
+  if (buf->b_flags & BF_NEVERLOADED) {
+    return false;
+  }
   if (ignore_empty
       && (buf->b_flags & BF_NEW)
       && buf->b_ml.ml_line_count == 1
-      && *ml_get_buf(buf, (linenr_T)1, FALSE) == NUL)
-    return FALSE;
-  if (buf->b_start_ffc != *buf->b_p_ff)
+      && *ml_get_buf(buf, (linenr_T)1, false) == NUL) {
+    return false;
+  }
+  if (buf->b_start_ffc != *buf->b_p_ff) {
     return true;
-  if ((buf->b_p_bin || !buf->b_p_fixeol) && buf->b_start_eol != buf->b_p_eol)
+  }
+  if ((buf->b_p_bin || !buf->b_p_fixeol) && buf->b_start_eol != buf->b_p_eol) {
     return true;
-  if (!buf->b_p_bin && buf->b_start_bomb != buf->b_p_bomb)
-    return TRUE;
-  if (buf->b_start_fenc == NULL)
+  }
+  if (!buf->b_p_bin && buf->b_start_bomb != buf->b_p_bomb) {
+    return true;
+  }
+  if (buf->b_start_fenc == NULL) {
     return *buf->b_p_fenc != NUL;
+  }
   return STRCMP(buf->b_start_fenc, buf->b_p_fenc) != 0;
 }
 
@@ -6899,7 +6982,7 @@ bool file_ff_differs(buf_T *buf, bool ignore_empty)
  */
 int check_ff_value(char_u *p)
 {
-  return check_opt_strings(p, p_ff_values, FALSE);
+  return check_opt_strings(p, p_ff_values, false);
 }
 
 /*
@@ -6926,7 +7009,7 @@ int get_sts_value(void)
  * Check matchpairs option for "*initc".
  * If there is a match set "*initc" to the matching character and "*findc" to
  * the opposite character.  Set "*backwards" to the direction.
- * When "switchit" is TRUE swap the direction.
+ * When "switchit" is true swap the direction.
  */
 void find_mps_values(int *initc, int *findc, int *backwards, int switchit)
 {
@@ -6991,10 +7074,12 @@ static bool briopt_check(win_T *wp)
       p += 3;
       bri_sbr = true;
     }
-    if (*p != ',' && *p != NUL)
+    if (*p != ',' && *p != NUL) {
       return false;
-    if (*p == ',')
-      ++p;
+    }
+    if (*p == ',') {
+      p++;
+    }
   }
 
   wp->w_p_brishift = bri_shift;
@@ -7150,7 +7235,7 @@ size_t copy_option_part(char_u **option, char_u *buf, size_t maxlen,
   return len;
 }
 
-/// Return TRUE when 'shell' has "csh" in the tail.
+/// Return true when 'shell' has "csh" in the tail.
 int csh_like_shell(void)
 {
   return strstr((char *)path_tail(p_sh), "csh") != NULL;

--- a/src/nvim/testdir/test_modeline.vim
+++ b/src/nvim/testdir/test_modeline.vim
@@ -1,0 +1,84 @@
+func Test_modeline_invalid()
+   let modeline = &modeline
+   set modeline
+   call assert_fails('set Xmodeline', 'E518:')
+
+   let &modeline = modeline
+   bwipe!
+   call delete('Xmodeline')
+ endfunc
+
+func Test_modeline_filetype()
+  call writefile(['vim: set ft=c :', 'nothing'], 'Xmodeline_filetype')
+  let modeline = &modeline
+  set modeline
+  filetype plugin on
+  split Xmodeline_filetype
+  call assert_equal("c", &filetype)
+  call assert_equal(1, b:did_ftplugin)
+  call assert_equal("ccomplete#Complete", &ofu)
+
+  bwipe!
+  call delete('Xmodeline_filetype')
+  let &modeline = modeline
+  filetype plugin off
+endfunc
+
+func Test_modeline_syntax()
+  call writefile(['vim: set syn=c :', 'nothing'], 'Xmodeline_syntax')
+  let modeline = &modeline
+  set modeline
+  syntax enable
+  split Xmodeline_syntax
+  call assert_equal("c", &syntax)
+  call assert_equal("c", b:current_syntax)
+
+  bwipe!
+  call delete('Xmodeline_syntax')
+  let &modeline = modeline
+  syntax off
+endfunc
+
+func Test_modeline_keymap()
+  call writefile(['vim: set keymap=greek :', 'nothing'], 'Xmodeline_keymap')
+  let modeline = &modeline
+  set modeline
+  split Xmodeline_keymap
+  call assert_equal("greek", &keymap)
+  call assert_match('greek\|grk', b:keymap_name)
+
+  bwipe!
+  call delete('Xmodeline_keymap')
+  let &modeline = modeline
+  set keymap= iminsert=0 imsearch=-1
+endfunc
+
+func s:modeline_fails(what, text)
+  let fname = "Xmodeline_fails_" . a:what
+  call writefile(['vim: set ' . a:text . ' :', 'nothing'], fname)
+  let modeline = &modeline
+  set modeline
+  filetype plugin on
+  syntax enable
+  call assert_fails('split ' . fname, 'E474:')
+  call assert_equal("", &filetype)
+  call assert_equal("", &syntax)
+
+  bwipe!
+  call delete(fname)
+  let &modeline = modeline
+  filetype plugin off
+  syntax off
+endfunc
+
+func Test_modeline_filetype_fails()
+  call s:modeline_fails('filetype', 'ft=evil$CMD')
+endfunc
+
+func Test_modeline_syntax_fails()
+  call s:modeline_fails('syntax', 'syn=evil$CMD')
+endfunc
+
+func Test_modeline_keymap_fails()
+  call s:modeline_fails('keymap', 'keymap=evil$CMD')
+endfunc


### PR DESCRIPTION
Problem:    Setting 'filetype' in a modeline causes an error (Hirohito Higashi).
Solution:   Don't add the P_INSECURE flag when setting 'filetype' from a modeline.  Also for 'syntax'.
https://github.com/vim/vim/commit/916a818cea5ba05a5f2117407674461b8bee6832

fixes https://github.com/neovim/neovim/issues/9791