### PR TITLE
vim-patch:8.0.1528,8.1.0528

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6371,14 +6371,12 @@ void grid_del_lines(ScreenGrid *grid, int row, int line_count, int end, int col,
 }
 
 
-/*
- * show the current mode and ruler
- *
- * If clear_cmdline is TRUE, clear the rest of the cmdline.
- * If clear_cmdline is FALSE there may be a message there that needs to be
- * cleared only if a mode is shown.
- * Return the length of the message (0 if no message).
- */
+// Show the current mode and ruler.
+//
+// If clear_cmdline is TRUE, clear the rest of the cmdline.
+// If clear_cmdline is FALSE there may be a message there that needs to be
+// cleared only if a mode is shown.
+// Return the length of the message (0 if no message).
 int showmode(void)
 {
   int need_clear;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -310,7 +310,7 @@ void free_search_patterns(void)
 /// Save and restore the search pattern for incremental highlight search
 /// feature.
 ///
-/// It's similar but different from save_search_patterns() and
+/// It's similar to but different from save_search_patterns() and
 /// restore_search_patterns(), because the search pattern must be restored when
 /// cancelling incremental searching even if it's called inside user functions.
 void save_last_search_pattern(void)

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2294,7 +2294,7 @@ static void use_midword(slang_T *lp, win_T *wp)
 }
 
 // Find the region "region[2]" in "rp" (points to "sl_regions").
-// Each region is simply stored as the two characters of it's name.
+// Each region is simply stored as the two characters of its name.
 // Returns the index if found (first is 0), REGION_ALL if not found.
 static int find_region(char_u *rp, char_u *region)
 {

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3227,7 +3227,7 @@ static int get_pfxlist(afffile_T *affile, char_u *afflist, char_u *store_afflist
     prevp = p;
     if (get_affitem(affile->af_flagtype, &p) != 0) {
       // A flag is a postponed prefix flag if it appears in "af_pref"
-      // and it's ID is not zero.
+      // and its ID is not zero.
       STRLCPY(key, prevp, p - prevp + 1);
       hi = hash_find(&affile->af_pref, key);
       if (!HASHITEM_EMPTY(hi)) {


### PR DESCRIPTION
**vim-patch:8.0.1528: dead code found**
Problem:    Dead code found.
Solution:   Remove the useless lines. (CodeAi, closes vim/vim#2656)
vim/vim@81226e0

**vim-patch:8.1.0528: various typos in comments**
Problem:    Various typos in comments.
Solution:   Fix the typos.
vim/vim@c4568ab