### PR TITLE
vim-patch:8.1.{887,1061}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3831,6 +3831,12 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
           sublen = vim_regsub_multi(&regmatch,
                                     sub_firstlnum - regmatch.startpos[0].lnum,
                                     sub, sub_firstline, false, p_magic, true);
+          // If getting the substitute string caused an error, don't do
+          // the replacement.
+          if (aborting()) {
+            goto skip;
+          }
+
           // Don't keep flags set by a recursive call
           subflags = subflags_save;
           if (subflags.do_count) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3181,6 +3181,7 @@ static char_u *sub_parse_flags(char_u *cmd, subflags_T *subflags,
     subflags->do_ask = false;
     subflags->do_error = true;
     subflags->do_print = false;
+    subflags->do_list = false;
     subflags->do_count = false;
     subflags->do_number = false;
     subflags->do_ic = kSubHonorOptions;

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -611,3 +611,33 @@ func Test_sub_replace_10()
    call assert_equal('aa2a3a', substitute('123', '1\|\ze', 'a', 'g'))
    call assert_equal('1aaa', substitute('123', '1\zs\|[23]', 'a', 'g'))
 endfunc
+
+func Test_nocatch_sub_failure_handling()
+  " normal error results in all replacements 
+  func! Foo()
+    foobar
+  endfunc
+  new
+  call setline(1, ['1 aaa', '2 aaa', '3 aaa'])
+  %s/aaa/\=Foo()/g
+  call assert_equal(['1 0', '2 0', '3 0'], getline(1, 3))
+
+  " Trow without try-catch causes abort after the first line.
+  " We cannot test this, since it would stop executing the test script.
+
+  " try/catch does not result in any changes
+  func! Foo()
+    throw 'error'
+  endfunc
+  call setline(1, ['1 aaa', '2 aaa', '3 aaa'])
+  let error_caught = 0
+  try
+    %s/aaa/\=Foo()/g
+  catch
+    let error_caught = 1
+  endtry
+  call assert_equal(1, error_caught)
+  call assert_equal(['1 aaa', '2 aaa', '3 aaa'], getline(1, 3))
+
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -107,6 +107,32 @@ function! Test_substitute_variants()
   endfor
 endfunction
 
+" Test the l, p, # flags.
+func Test_substitute_flags_lp()
+  new
+  call setline(1, "abc\tdef\<C-h>ghi")
+
+  let a = execute('s/a/a/p')
+  call assert_equal("\nabc     def^Hghi", a)
+
+  let a = execute('s/a/a/l')
+  call assert_equal("\nabc^Idef^Hghi$", a)
+
+  let a = execute('s/a/a/#')
+  call assert_equal("\n  1 abc     def^Hghi", a)
+
+  let a = execute('s/a/a/p#')
+  call assert_equal("\n  1 abc     def^Hghi", a)
+
+  let a = execute('s/a/a/l#')
+  call assert_equal("\n  1 abc^Idef^Hghi$", a)
+
+  let a = execute('s/a/a/')
+  call assert_equal("", a)
+
+  bwipe!
+endfunc
+
 func Test_substitute_repeat()
   " This caused an invalid memory access.
   split Xfile


### PR DESCRIPTION
**vim-patch:8.1.0887: the 'l' flag in :subsitute is sticky**
Problem:    The 'l' flag in :subsitute is sticky.
Solution:   Reset the flag. (Dominique Pelle, closes vim/vim#3925)
vim/vim@9474716

**vim-patch:8.1.1061: when substitute string throws error, substitute happens anyway**
Problem:    When substitute string throws error, substitute happens anyway.
Solution:   Skip substitution when aborting. (closes vim/vim#4161)
vim/vim@0e97b94