### PR TITLE
[RFC] Check to redrawcmdline after handling K_EVENT or K_COMMAND

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -547,7 +547,10 @@ static int command_line_execute(VimState *state, int key)
     } else {
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
     }
-    redrawcmdline();
+
+    if (!cmdline_was_last_drawn) {
+      redrawcmdline();
+    }
     return 1;
   }
 
@@ -3457,6 +3460,8 @@ void redrawcmd(void)
     return;
   }
 
+  redrawing_cmdline = true;
+
   msg_start();
   redrawcmdprompt();
 
@@ -3478,9 +3483,11 @@ void redrawcmd(void)
    */
   msg_scroll = FALSE;           /* next message overwrites cmdline */
 
-  /* Typing ':' at the more prompt may set skip_redraw.  We don't want this
-   * in cmdline mode */
-  skip_redraw = FALSE;
+  // Typing ':' at the more prompt may set skip_redraw.  We don't want this
+  // in cmdline mode.
+  skip_redraw = false;
+
+  redrawing_cmdline = false;
 }
 
 void compute_cmdrow(void)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -146,12 +146,14 @@ EXTERN int mod_mask INIT(= 0x0);                /* current key modifiers */
  */
 EXTERN int cmdline_row;
 
-EXTERN int redraw_cmdline INIT(= FALSE);        /* cmdline must be redrawn */
-EXTERN int clear_cmdline INIT(= FALSE);         /* cmdline must be cleared */
-EXTERN int mode_displayed INIT(= FALSE);        /* mode is being displayed */
-EXTERN int cmdline_star INIT(= FALSE);          /* cmdline is crypted */
+EXTERN int redraw_cmdline INIT(= false);          // cmdline must be redrawn
+EXTERN int clear_cmdline INIT(= false);           // cmdline must be cleared
+EXTERN int mode_displayed INIT(= false);          // mode is being displayed
+EXTERN int cmdline_star INIT(= false);            // cmdline is crypted
+EXTERN int redrawing_cmdline INIT(= false);       // cmdline is being redrawn
+EXTERN int cmdline_was_last_drawn INIT(= false);  // cmdline was last drawn
 
-EXTERN int exec_from_reg INIT(= FALSE);         /* executing register */
+EXTERN int exec_from_reg INIT(= false);         // executing register
 
 /*
  * When '$' is included in 'cpoptions' option set:

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1881,6 +1881,8 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr,
     return;
   }
 
+  cmdline_was_last_drawn = redrawing_cmdline;
+
   while ((maxlen < 0 || (int)(s - str) < maxlen) && *s != NUL) {
     // We are at the end of the screen line when:
     // - When outputting a newline.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -507,6 +507,8 @@ void update_screen(int type)
     maybe_intro_message();
   did_intro = TRUE;
 
+  // either cmdline is cleared, not drawn or mode is last drawn
+  cmdline_was_last_drawn = false;
 }
 
 /*


### PR DESCRIPTION
2nd attempt at #9790.

Check if cmdline needs to be drawn and redraws it accordingly.

2 cases:
1. Cmdline has been moved up due to a message - set `cmdline_was_last_drawn` in `msg_puts_display`, which both `MSG` and `EMSG` will call.
2. `update_screen` has been called - this clears the cmdline so it needs to be redrawn.

