### PR TITLE
vim-patch:8.0.0705: crash when there is an error in a timer callback

### DIFF
--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -569,12 +569,10 @@ static void discard_exception(except_T *excp, int was_finished)
  */
 void discard_current_exception(void)
 {
-  if (current_exception != NULL)
-  {
+  if (current_exception != NULL) {
     discard_exception(current_exception, false);
     current_exception = NULL;
   }
-
   // Note: all globals manipulated here should be saved/restored in
   // try_enter/try_leave.
   need_rethrow = false;

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -578,7 +578,6 @@ void discard_current_exception(void)
   // Note: all globals manipulated here should be saved/restored in
   // try_enter/try_leave.
   need_rethrow = false;
-
 }
 
 /*

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -569,11 +569,16 @@ static void discard_exception(except_T *excp, int was_finished)
  */
 void discard_current_exception(void)
 {
-  discard_exception(current_exception, false);
+  if (current_exception != NULL)
+  {
+    discard_exception(current_exception, false);
+    current_exception = NULL;
+  }
+
   // Note: all globals manipulated here should be saved/restored in
   // try_enter/try_leave.
-  current_exception = NULL;
   need_rethrow = false;
+
 }
 
 /*
@@ -1766,6 +1771,7 @@ void enter_cleanup(cleanup_T *csp)
      */
     if (current_exception || need_rethrow) {
       csp->exception = current_exception;
+      current_exception = NULL;
     } else {
       csp->exception = NULL;
       if (did_emsg) {


### PR DESCRIPTION
**Problem:** Crash when there is an error in a timer callback. (Aron Griffis, Ozaki Kiichi)
**Solution:** Check did_throw before discarding an exception.  NULLify current_exception when no longer valid.
https://github.com/vim/vim/commit/cae24be4a808d60313913cc6feea6c2bee2e2a42

Changes in `ex_cmds2.c` ignored according to #9801