### PR TITLE
vim-patch:8.0.0629: checking for ambigous width is not working

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -547,10 +547,12 @@ int main(int argc, char **argv)
   if (params.n_commands > 0)
     exe_commands(&params);
 
+  /* Must come before the may_req_ calls. */
+  starting = 0;
+
   RedrawingDisabled = 0;
   redraw_all_later(NOT_VALID);
   no_wait_return = FALSE;
-  starting = 0;
 
   // 'autochdir' has been postponed.
   do_autochdir();


### PR DESCRIPTION
vim-patch:8.0.0629

Problem:    Checking for ambigous width is not working. (Hirohito Higashi)
Solution:   Reset "starting" earlier.
https://github.com/vim/vim/commit/6b1da3312e15c065b373c9ec2732f31a77cee61f