### PR TITLE
vim-patch:8.1.1088: quickfix height not retained with vertical split

### DIFF
--- a/src/nvim/testdir/test_winbuf_close.vim
+++ b/src/nvim/testdir/test_winbuf_close.vim
@@ -158,3 +158,29 @@ func Test_winfixwidth_on_close()
   %bwipeout!
   setlocal nowinfixwidth splitbelow& splitright&
 endfunction
+
+" Test that 'winfixheight' will be respected even there is non-leaf frame
+fun! Test_winfixheight_non_leaf_frame()
+  vsplit
+  botright 11new
+  let l:wid = win_getid()
+  setlocal winfixheight
+  call assert_equal(11, winheight(l:wid))
+  botright new
+  bwipe!
+  call assert_equal(11, winheight(l:wid))
+  %bwipe!
+endf
+
+" Test that 'winfixwidth' will be respected even there is non-leaf frame
+fun! Test_winfixwidth_non_leaf_frame()
+  split
+  topleft 11vnew
+  let l:wid = win_getid()
+  setlocal winfixwidth
+  call assert_equal(11, winwidth(l:wid))
+  topleft new
+  bwipe!
+  call assert_equal(11, winwidth(l:wid))
+  %bwipe!
+endf

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2679,9 +2679,9 @@ winframe_remove (
       frp3 = frp_close->fr_next;
       while (frp != NULL || frp3 != NULL) {
         if (frp != NULL) {
-          if (frp->fr_win != NULL && !frp->fr_win->w_p_wfh) {
+          if (!frame_fixed_height(frp)) {
             frp2 = frp;
-            wp = frp->fr_win;
+            wp = frame2win(frp2);
             break;
           }
           frp = frp->fr_prev;
@@ -2708,9 +2708,9 @@ winframe_remove (
       frp3 = frp_close->fr_next;
       while (frp != NULL || frp3 != NULL) {
         if (frp != NULL) {
-          if (frp->fr_win != NULL && !frp->fr_win->w_p_wfw) {
+          if (!frame_fixed_width(frp)) {
             frp2 = frp;
-            wp = frp->fr_win;
+            wp = frame2win(frp2);
             break;
           }
           frp = frp->fr_prev;


### PR DESCRIPTION
Problem:    Height of quickfix window not retained with vertical split.
Solution:   Use frame_fixed_height() and frame_fixed_width(). (Hongbo Liu,
            closes vim/vim#4013, closes vim/vim#2998)
https://github.com/vim/vim/commit/9e1e358d376284c3aaf3a9f1e568bca297405f62

closes #3608