### PR TITLE
vim-patch:8.1.1095

### DIFF
--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -889,6 +889,17 @@ func Test_Executable()
   endif
 endfunc
 
+func Test_executable_longname()
+  if !has('win32')
+    return
+  endif
+
+  let fname = 'X' . repeat('あ', 200) . '.bat'
+  call writefile([], fname)
+  call assert_equal(1, executable(fname))
+  call delete(fname)
+endfunc
+
 func Test_hostname()
   let hostname_vim = hostname()
   if has('unix')


### PR DESCRIPTION
**vim-patch:8.1.1095: MS-Windows: executable() fails on very long filename**

Problem:    MS-Windows: executable() fails on very long filename.
Solution:   (Ken Takata, closes vim/vim#4015)
https://github.com/vim/vim/commit/8662189736e6cefb3fe852728adb5341f83973cf