### PR TITLE
vim-patch:8.1.{1073,1074,1082,1087}

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2963,8 +2963,11 @@ win_line (
                 shl->endcol = tmp_col;
               }
               shl->attr_cur = shl->attr;
-              if (cur != NULL && syn_name2id((char_u *)"Conceal")
-                  == cur->hlg_id) {
+              // Match with the "Conceal" group results in hiding
+              // the match.
+              if (cur != NULL
+                  && shl != &search_hl
+                  && syn_name2id((char_u *)"Conceal") == cur->hlg_id) {
                 has_match_conc = v == (long)shl->startcol ? 2 : 1;
                 match_conc = cur->conceal_char;
               } else {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2772,8 +2772,15 @@ win_line (
             if (wp->w_skipcol > 0)
               for (p_extra = extra; *p_extra == ' '; ++p_extra)
                 *p_extra = '-';
-            if (wp->w_p_rl)                         /* reverse line numbers */
-              rl_mirror(extra);
+            if (wp->w_p_rl) {                       // reverse line numbers
+              // like rl_mirror(), but keep the space at the end
+              char_u *p2 = skiptowhite(extra) - 1;
+              for (char_u *p1 = extra; p1 < p2; p1++, p2--) {
+                const int t = *p1;
+                *p1 = *p2;
+                *p2 = t;
+              }
+            }
             p_extra = extra;
             c_extra = NUL;
             c_final = NUL;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -436,11 +436,15 @@ do_tag (
         tagmatchname = vim_strsave(name);
       }
 
-      if (type == DT_TAG || type == DT_SELECT || type == DT_JUMP
+      if (type == DT_SELECT || type == DT_JUMP
           || type == DT_LTAG) {
         cur_match = MAXCOL - 1;
       }
-      max_num_matches = cur_match + 1;
+      if (type == DT_TAG) {
+        max_num_matches = MAXCOL;
+      } else {
+        max_num_matches = cur_match + 1;
+      }
 
       /* when the argument starts with '/', use it as a regexp */
       if (!no_regexp && *name == '/') {
@@ -495,7 +499,7 @@ do_tag (
       if (type == DT_CSCOPE && num_matches > 1) {
         cs_print_tags();
         ask_for_selection = true;
-      } else if (type == DT_TAG) {
+      } else if (type == DT_TAG && *tag != NUL) {
         // If a count is supplied to the ":tag <name>" command, then
         // jump to count'th matching tag.
         cur_match = count > 0 ? count - 1 : 0;

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -763,6 +763,9 @@ func Test_diff_of_diff()
 
   call VerifyScreenDump(buf, 'Test_diff_of_diff_01', {})
 
+  call term_sendkeys(buf, ":set rightleft\<cr>")
+  call VerifyScreenDump(buf, 'Test_diff_of_diff_02', {})
+
   " clean up
   call StopVimInTerminal(buf)
   call delete('Xtest_diff_diff')

--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -70,32 +70,37 @@ func _SetUpHiddenBuffer()
   call assert_equal( line( '.' ), 11 )
 endfunc
 
+func _CleanUpHiddenBuffer()
+  bwipe! hidden
+  bwipe!
+endfunc
+
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Clear()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_List()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = [ 'test' ]
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Str()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = 'test'
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_ClearLine()
   call _SetUpHiddenBuffer()
   py vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func _SetUpVisibleBuffer()

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -70,32 +70,37 @@ func _SetUpHiddenBuffer()
   call assert_equal( line( '.' ), 11 )
 endfunc
 
+func _CleanUpHiddenBuffer()
+  bwipe! hidden
+  bwipe!
+endfunc
+
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Clear()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_List()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][:] = [ 'test' ]
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_Str()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = 'test'
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func Test_Write_To_HiddenBuffer_Does_Not_Fix_Cursor_ClearLine()
   call _SetUpHiddenBuffer()
   py3 vim.buffers[ int( vim.eval( 'bufnr("hidden")' ) ) ][0] = None
   call assert_equal( line( '.' ), 11 )
-  bwipe!
+  call _CleanUpHiddenBuffer()
 endfunc
 
 func _SetUpVisibleBuffer()

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -258,4 +258,77 @@ func Test_tagjump_etags()
   bwipe!
 endfunc
 
+func Test_tag_with_count()
+  call writefile([
+	\ 'test	Xtest.h	/^void test();$/;"	p	typeref:typename:void	signature:()',
+	\ ], 'Xtags')
+  call writefile([
+	\ 'main	Xtest.c	/^int main()$/;"	f	typeref:typename:int	signature:()',
+	\ 'test	Xtest.c	/^void test()$/;"	f	typeref:typename:void	signature:()',
+	\ ], 'Ytags')
+  cal writefile([
+	\ 'int main()',
+	\ 'void test()',
+	\ ], 'Xtest.c')
+  cal writefile([
+	\ 'void test();',
+	\ ], 'Xtest.h')
+  set tags=Xtags,Ytags
+
+  new Xtest.c
+  let tl = taglist('test', 'Xtest.c')
+  call assert_equal(tl[0].filename, 'Xtest.c')
+  call assert_equal(tl[1].filename, 'Xtest.h')
+
+  tag test
+  call assert_equal(bufname('%'), 'Xtest.c')
+  1tag test
+  call assert_equal(bufname('%'), 'Xtest.c')
+  2tag test
+  call assert_equal(bufname('%'), 'Xtest.h')
+
+  set tags&
+  call delete('Xtags')
+  call delete('Ytags')
+  bwipe Xtest.h
+  bwipe Xtest.c
+  call delete('Xtest.h')
+  call delete('Xtest.c')
+endfunc
+
+func Test_tagnr_recall()
+  call writefile([
+	\ 'test	Xtest.h	/^void test();$/;"	p',
+	\ 'main	Xtest.c	/^int main()$/;"	f',
+	\ 'test	Xtest.c	/^void test()$/;"	f',
+	\ ], 'Xtags')
+  cal writefile([
+	\ 'int main()',
+	\ 'void test()',
+	\ ], 'Xtest.c')
+  cal writefile([
+	\ 'void test();',
+	\ ], 'Xtest.h')
+  set tags=Xtags
+
+  new Xtest.c
+  let tl = taglist('test', 'Xtest.c')
+  call assert_equal(tl[0].filename, 'Xtest.c')
+  call assert_equal(tl[1].filename, 'Xtest.h')
+
+  2tag test
+  call assert_equal(bufname('%'), 'Xtest.h')
+  pop
+  call assert_equal(bufname('%'), 'Xtest.c')
+  tag
+  call assert_equal(bufname('%'), 'Xtest.h')
+
+  set tag&
+  call delete('Xtags')
+  bwipe Xtest.h
+  bwipe Xtest.c
+  call delete('Xtest.h')
+  call delete('Xtest.c')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.1.1073: space in number column is on wrong side with 'rightleft' set**

Problem:    Space in number column is on wrong side with 'rightleft' set.
Solution:   Move the space to the text side.  Add a test.
vim/vim@e73f911

**vim-patch:8.1.1074: Python test doesn't wipe out hidden buffer**
Problem:    Python test doesn't wipe out hidden buffer.
Solution:   Wipe out the buffer. (Ben Jackson, closes vim/vim#4189)
vim/vim@bfd3603

**vim-patch:8.1.1082: "Conceal" match is mixed up with 'hlsearch' match.**
Problem:    "Conceal" match is mixed up with 'hlsearch' match.
Solution:   Check that a match is found, not a 'hlsearch' item. (Andy
            Massimino, closes vim/vim#4073)
vim/vim@ab62c19

**vim-patch:8.1.1087: tag stack is incorrect after CTRL-T and then :tag**
Problem:    tag stack is incorrect after CTRL-T and then :tag
Solution:   Handle DT_TAG differently. (test by Andy Massimino, closes vim/vim#3944,
            closes vim/vim#4177)
vim/vim@7559dce