### PR TITLE
startup: Remove special case of TUI initialization

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -467,7 +467,7 @@ int main(int argc, char **argv)
   if (exmode_active || early_ui) {
     // Don't clear the screen when starting in Ex mode, or when an
     // embedding UI might have displayed messages
-    must_redraw = CLEAR;
+    must_redraw = VALID;
   } else {
     screenclear();  // clear screen
     TIME_MSG("clearing screen");

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -467,7 +467,7 @@ int main(int argc, char **argv)
   if (exmode_active || early_ui) {
     // Don't clear the screen when starting in Ex mode, or when an
     // embedding UI might have displayed messages
-    must_redraw = VALID;
+    redraw_later(VALID);
   } else {
     screenclear();  // clear screen
     TIME_MSG("clearing screen");

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -378,6 +378,14 @@ int main(int argc, char **argv)
     TIME_MSG("initialized screen early for embedder");
   }
 
+  if (!headless_mode && !embedded_mode && !silent_mode) {
+    input_stop();  // Stop reading input, let the UI take over.
+    ui_builtin_start();
+    starting = NO_BUFFERS;
+    screenclear();
+    early_ui = true;
+  }
+
   // Execute --cmd arguments.
   exe_pre_commands(&params);
 
@@ -475,11 +483,6 @@ int main(int argc, char **argv)
     // messages and that is done with a call to wait_return.
     TIME_MSG("waiting for return");
     wait_return(true);
-  }
-
-  if (!headless_mode && !embedded_mode && !silent_mode) {
-    input_stop();  // Stop reading input, let the UI take over.
-    ui_builtin_start();
   }
 
   setmouse();  // may start using the mouse

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -357,8 +357,7 @@ int main(int argc, char **argv)
   bool use_builtin_ui = (!headless_mode && !embedded_mode && !silent_mode);
   if (use_remote_ui || use_builtin_ui) {
     TIME_MSG("waiting for user interface to make request");
-    if (use_remote_ui)
-    {
+    if (use_remote_ui) {
       remote_ui_wait_for_attach();
     } else {
       ui_builtin_start();

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -48,6 +48,20 @@ void tinput_init(TermInput *input, Loop *loop)
 
   int curflags = termkey_get_canonflags(input->tk);
   termkey_set_canonflags(input->tk, curflags | TERMKEY_CANON_DELBS);
+#ifdef WIN32
+  if (!os_isatty(0)) {
+      const HANDLE conin_handle = CreateFile("CONIN$", GENERIC_READ | GENERIC_WRITE,
+                                             FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                             (LPSECURITY_ATTRIBUTES)NULL,
+                                             OPEN_EXISTING, 0, (HANDLE)NULL);
+      input->in_fd = _open_osfhandle(conin_handle, _O_RDONLY);
+      assert(input->in_fd != -1);
+  }
+#else
+  if (!os_isatty(0) && os_isatty(2)) {
+    input->in_fd = 2;
+  }
+#endif
   // setup input handle
   rstream_init_fd(loop, &input->read_stream, input->in_fd, 0xfff);
   // initialize a timer handle for handling ESC with libtermkey
@@ -435,24 +449,7 @@ static void tinput_read_cb(Stream *stream, RBuffer *buf, size_t count_,
   TermInput *input = data;
 
   if (eof) {
-    if (input->in_fd == 0 && !os_isatty(0) && os_isatty(2)) {
-      // Started reading from stdin which is not a pty but failed. Switch to
-      // stderr since it is a pty.
-      //
-      // This is how we support commands like:
-      //
-      // echo q | nvim -es
-      //
-      // and
-      //
-      // ls *.md | xargs nvim
-      input->in_fd = 2;
-      stream_close(&input->read_stream, NULL, NULL);
-      multiqueue_put(input->loop->fast_events, tinput_restart_reading, 1,
-                     input);
-    } else {
-      loop_schedule(&main_loop, event_create(tinput_done_event, 0));
-    }
+    loop_schedule(&main_loop, event_create(tinput_done_event, 0));
     return;
   }
 
@@ -495,11 +492,4 @@ static void tinput_read_cb(Stream *stream, RBuffer *buf, size_t count_,
   // Make sure the next input escape sequence fits into the ring buffer
   // without wrap around, otherwise it could be misinterpreted.
   rbuffer_reset(input->read_stream.buffer);
-}
-
-static void tinput_restart_reading(void **argv)
-{
-  TermInput *input = argv[0];
-  rstream_init_fd(input->loop, &input->read_stream, input->in_fd, 0xfff);
-  rstream_start(&input->read_stream, tinput_read_cb, input);
 }

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -50,7 +50,8 @@ void tinput_init(TermInput *input, Loop *loop)
   termkey_set_canonflags(input->tk, curflags | TERMKEY_CANON_DELBS);
 #ifdef WIN32
   if (!os_isatty(0)) {
-      const HANDLE conin_handle = CreateFile("CONIN$", GENERIC_READ | GENERIC_WRITE,
+      const HANDLE conin_handle = CreateFile("CONIN$",
+                                             GENERIC_READ | GENERIC_WRITE,
                                              FILE_SHARE_READ | FILE_SHARE_WRITE,
                                              (LPSECURITY_ATTRIBUTES)NULL,
                                              OPEN_EXISTING, 0, (HANDLE)NULL);

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -46,7 +46,7 @@ describe('startup', function()
     ]])
   end)
   it('in a TTY: has("ttyin")==1 has("ttyout")==1', function()
-    local screen = Screen.new(25, 3)
+    local screen = Screen.new(25, 4)
     screen:attach()
     if iswin() then
       command([[set shellcmdflag=/s\ /c shellxquote=\"]])
@@ -58,6 +58,7 @@ describe('startup', function()
             ..[[, shellescape(v:progpath))]])
     screen:expect([[
       ^                         |
+      ~                        |
       1 1                      |
                                |
     ]])
@@ -96,7 +97,7 @@ describe('startup', function()
     end)
   end)
   it('input from pipe (implicit) #7679', function()
-    local screen = Screen.new(25, 3)
+    local screen = Screen.new(25, 4)
     screen:attach()
     if iswin() then
       command([[set shellcmdflag=/s\ /c shellxquote=\"]])
@@ -109,6 +110,7 @@ describe('startup', function()
             ..[[, shellescape(v:progpath))]])
     screen:expect([[
       ^foo                      |
+      ~                        |
       0 1                      |
                                |
     ]])


### PR DESCRIPTION
fixes #7967

Implemented according to https://github.com/neovim/neovim/pull/9825#issuecomment-478868745.

- [x] Move `ui_builtin_start()` to the same position as embedded_mode `remote_ui_wait_for_attch()`.
- [x] If stdin is redirected, save the original `stdin` and replace fd 0 with tty before calling `ui_builtin_start()`.
- [x] ~Remove unnecessary code such as `start_input()`, `stop_input()` etc.~
- [x] Fix the problem that the display of `nvim -u NORC -c "echo 'Hello'"` is cleared.
- [x] ~Examine the behavior of `exmode_active` and correct if necessary.~
- [x] ~Write a test.~