### PR TITLE
vim-patch:8.0.0681,8.1.{118,119}

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2791,8 +2791,8 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
   }
 
   if (!curbuf->terminal) {
-    // Autocommands may be executed when saving lines for undo, which may make
-    // y_array invalid.  Start undo now to avoid that.
+    // Autocommands may be executed when saving lines for undo.  This might
+    // make y_array invalid, so we start undo now to avoid that.
     if (u_save(curwin->w_cursor.lnum, curwin->w_cursor.lnum + 1) == FAIL) {
       return;
     }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1408,7 +1408,9 @@ int op_delete(oparg_T *oap)
       free_register(&y_regs[9]); /* free register "9 */
       for (n = 9; n > 1; n--)
         y_regs[n] = y_regs[n - 1];
-      y_previous = &y_regs[1];
+      if (!is_append_register(oap->regname)) {
+        y_previous = &y_regs[1];
+      }
       y_regs[1].y_array = NULL;                 /* set register "1 to empty */
       reg = &y_regs[1];
       op_yank_reg(oap, false, reg, false);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1411,7 +1411,7 @@ int op_delete(oparg_T *oap)
       if (!is_append_register(oap->regname)) {
         y_previous = &y_regs[1];
       }
-      y_regs[1].y_array = NULL;                 /* set register "1 to empty */
+      y_regs[1].y_array = NULL;                 // set register "1 to empty
       reg = &y_regs[1];
       op_yank_reg(oap, false, reg, false);
     }

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -62,7 +62,7 @@ endfunc
 
 func Test_put_fails_when_nomodifiable()
   new
-  set nomodifiable
+  setlocal nomodifiable
 
   normal! yy
   call assert_fails(':put', 'E21')
@@ -85,7 +85,7 @@ endfunc
 " output duplicate error messages when invoked in a non-modifiable buffer.
 func Test_put_p_errmsg_nodup()
   new
-  set nomodifiable
+  setlocal nomodifiable
 
   normal! yy
 

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -47,3 +47,14 @@ func Test_put_expr()
   call assert_equal(['A1','A2','A3','4A','5A','6A'], getline(1,'$'))
   bw!
 endfunc
+
+func Test_put_lines()
+  new
+  let a = [ getreg('a'), getregtype('a') ]
+  call setline(1, ['Line 1', 'Line2', 'Line 3', ''])
+  exe 'norm! gg"add"AddG""p'
+  call assert_equal(['Line 3', '', 'Line 1', 'Line2'], getline(1,'$'))
+  " clean up
+  bw!
+  call setreg('a', a[0], a[1])
+endfunc

--- a/src/nvim/testdir/test_true_false.vim
+++ b/src/nvim/testdir/test_true_false.vim
@@ -134,6 +134,8 @@ func Test_non_zero_arg()
   " call test_settime(93784)
   " call Try_arg_non_zero("mode(%v%)", 'x', 'x!')
   " call test_settime(0)
+  let shellslash = &shellslash
+  set shellslash
 
   call Try_arg_non_zero("shellescape('foo%', %v%)", "'foo%'", "'foo\\%'")
 
@@ -152,4 +154,6 @@ func Test_non_zero_arg()
     let r = visualmode(v)
     call assert_equal('', r, 'result for ' . v . ' is not "" but ' . r)
   endfor
+
+  let &shellslash = shellslash
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.0681: unnamed register only contains the last deleted text**
Problem:    Unnamed register only contains the last deleted text when
            appending deleted text to a register. (Wolfgang Jeltsch)
Solution:   Only set y_previous when not using y_append. (Christian Brabandt)
https://github.com/vim/vim/commit/18d90b95c49d9ff1c635dd762864022aab8e71f1

**vim-patch:8.1.0118: duplicate error message for put command**
Problem:    Duplicate error message for put command.
Solution:   Check return value of u_save(). (Jason Franklin)
vim/vim@f52f9ea

**vim-patch:8.1.0119: failing test goes unnoticed because messages is not written**
Problem:    Failing test goes unnoticed because testdir/messages is not
            written.
Solution:   Set 'nomodifiable' only local to the buffer.
vim/vim@ec12d64