### PR TITLE
[RDY] vim-patch:8.0.{0714, 0720}

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1351,8 +1351,8 @@ static int command_line_handle_key(CommandLineState *s)
     if (s->i == Ctrl_R) {
       s->c = plain_vgetc();              // CTRL-R CTRL-R <char>
     }
+    --no_mapping;
     ccline.special_char = NUL;
-    no_mapping--;
     // Insert the result of an expression.
     // Need to save the current command line, to be able to enter
     // a new one...
@@ -1449,7 +1449,7 @@ static int command_line_handle_key(CommandLineState *s)
 
     set_cmdspos_cursor();
     if (ccline.special_char != NUL) {
-      putcmdline(ccline.special_char, true);
+      putcmdline(ccline.special_char, ccline.special_shift);
     }
 
     return command_line_not_changed(s);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1351,8 +1351,7 @@ static int command_line_handle_key(CommandLineState *s)
     if (s->i == Ctrl_R) {
       s->c = plain_vgetc();              // CTRL-R CTRL-R <char>
     }
-    ccline.special_char = NUL;
-    no_mapping--;
+    --no_mapping;
     // Insert the result of an expression.
     // Need to save the current command line, to be able to enter
     // a new one...
@@ -1449,7 +1448,7 @@ static int command_line_handle_key(CommandLineState *s)
 
     set_cmdspos_cursor();
     if (ccline.special_char != NUL) {
-      putcmdline(ccline.special_char, true);
+      putcmdline(ccline.special_char, ccline.special_shift);
     }
 
     return command_line_not_changed(s);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1352,7 +1352,7 @@ static int command_line_handle_key(CommandLineState *s)
       s->c = plain_vgetc();              // CTRL-R CTRL-R <char>
     }
     ccline.special_char = NUL;
-    --no_mapping;
+    no_mapping--;
     // Insert the result of an expression.
     // Need to save the current command line, to be able to enter
     // a new one...
@@ -1448,8 +1448,9 @@ static int command_line_handle_key(CommandLineState *s)
              && ccline.cmdbuff[ccline.cmdpos - 1] != ' ');
 
     set_cmdspos_cursor();
-    if (ccline.special_char != NUL)
-	putcmdline(ccline.special_char, true);
+    if (ccline.special_char != NUL) {
+      putcmdline(ccline.special_char, true);
+    }
 
     return command_line_not_changed(s);
 
@@ -1725,7 +1726,7 @@ static int command_line_handle_key(CommandLineState *s)
     s->ignore_drag_release = true;
     putcmdline('?', true);
     s->c = get_digraph(true);
-    ccline.special_char = 'NUL';
+    ccline.special_char = NUL;
 
     if (s->c != NUL) {
       break;
@@ -3472,8 +3473,9 @@ void redrawcmd(void)
 
   set_cmdspos_cursor();
 
-  if (ccline.special_char != NUL)
+  if (ccline.special_char != NUL) {
     putcmdline(ccline.special_char, ccline.special_shift);
+  }
 
   /*
    * An emsg() before may have set msg_scroll. This is used in normal mode,

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -191,6 +191,8 @@ static int cmd_showtail;                /* Only show path tail in lists ? */
 
 static int new_cmdpos;          /* position set by set_cmdline_pos() */
 
+static int extra_char = NUL; /* extra character to display when redrawing the command line */
+
 /// currently displayed block of context
 static Array cmdline_block = ARRAY_DICT_INIT;
 
@@ -1342,6 +1344,7 @@ static int command_line_handle_key(CommandLineState *s)
 
   case Ctrl_R:                        // insert register
     putcmdline('"', true);
+    extra_char = '"';
     ++no_mapping;
     s->i = s->c = plain_vgetc();      // CTRL-R <char>
     if (s->i == Ctrl_O) {
@@ -1351,6 +1354,7 @@ static int command_line_handle_key(CommandLineState *s)
     if (s->i == Ctrl_R) {
       s->c = plain_vgetc();              // CTRL-R CTRL-R <char>
     }
+    extra_char = NUL;
     --no_mapping;
     // Insert the result of an expression.
     // Need to save the current command line, to be able to enter
@@ -1447,6 +1451,8 @@ static int command_line_handle_key(CommandLineState *s)
              && ccline.cmdbuff[ccline.cmdpos - 1] != ' ');
 
     set_cmdspos_cursor();
+    if (extra_char != NUL)
+	putcmdline(extra_char, TRUE);
 
     return command_line_not_changed(s);
 
@@ -1702,8 +1708,10 @@ static int command_line_handle_key(CommandLineState *s)
   case Ctrl_Q:
     s->ignore_drag_release = true;
     putcmdline('^', true);
+    extra_char = '^';
     s->c = get_literal();                 // get next (two) character(s)
     s->do_abbr = false;                   // don't do abbreviation now
+    extra_char = NUL;
     // may need to remove ^ when composing char was typed
     if (enc_utf8 && utf_iscomposing(s->c) && !cmd_silent) {
       if (ui_has(kUICmdline)) {
@@ -1720,7 +1728,9 @@ static int command_line_handle_key(CommandLineState *s)
   case Ctrl_K:
     s->ignore_drag_release = true;
     putcmdline('?', true);
+    extra_char = '?';
     s->c = get_digraph(true);
+    extra_char = 'NUL';
 
     if (s->c != NUL) {
       break;
@@ -3467,6 +3477,9 @@ void redrawcmd(void)
   msg_no_more = FALSE;
 
   set_cmdspos_cursor();
+
+  if (extra_char != NUL)
+    putcmdline(extra_char, true);
 
   /*
    * An emsg() before may have set msg_scroll. This is used in normal mode,

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -975,8 +975,6 @@ describe('Expressions coloring support', function()
     ]])
     funcs.setreg('a', {'\192'})
     feed('<C-r>="<C-r><C-r>a"<C-r><C-r>a"foo"')
-    -- TODO(ZyX-I): Parser highlighting should not override special character
-    --              highlighting.
     screen:expect([[
                                               |
       {EOB:~                                       }|
@@ -985,7 +983,7 @@ describe('Expressions coloring support', function()
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      ={SQ:"}{SB:<c0>}{SQ:"}{E:<c0>"}{SB:foo}{E:"}^                        |
+      ={SQ:"}{SB:<c0>}{SQ:"}{E:<c0>"}{SB:foo}{E:"}^"                       |
     ]])
   end)
 end)


### PR DESCRIPTION
patch 8.0.0714

**Problem:** When a timer causes a command line redraw the " that is displayed for CTRL-R goes missing.
**Solution:** Remember an extra character to display.
https://github.com/vim/vim/commit/a92522fbf3a49d06e08caf010f7d7b0f58d2e131

patch 8.0.0720
    
**Problem:** Unfinished mapping not displayed when running timer.
**Solution:** Also use the extra_char while waiting for a mapping and digraph.
https://github.com/vim/vim/commit/6a77d2667e982655f6adacee774ee7aa2581bd8a

