### PR TITLE
vim-patch:8.0.{709,728},8.1.{135,308}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1550,7 +1550,7 @@ void enter_buffer(buf_T *buf)
     diff_buf_add(curbuf);
   }
 
-  curwin->w_s = &(buf->b_s);
+  curwin->w_s = &(curbuf->b_s);
 
   // Cursor on first line by default.
   curwin->w_cursor.lnum = 1;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11639,10 +11639,11 @@ static void dict_list(typval_T *const tv, typval_T *const rettv,
 static void f_id(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   FUNC_ATTR_NONNULL_ALL
 {
-  const int len = vim_vsnprintf(NULL, 0, "%p", dummy_ap, argvars);
+  const int len = vim_vsnprintf_typval(NULL, 0, "%p", dummy_ap, argvars);
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = xmalloc(len + 1);
-  vim_vsnprintf((char *)rettv->vval.v_string, len + 1, "%p", dummy_ap, argvars);
+  vim_vsnprintf_typval((char *)rettv->vval.v_string, len + 1, "%p",
+                       dummy_ap, argvars);
 }
 
 /*
@@ -13106,11 +13107,11 @@ static void f_printf(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     did_emsg = false;
     char buf[NUMBUFLEN];
     const char *fmt = tv_get_string_buf(&argvars[0], buf);
-    len = vim_vsnprintf(NULL, 0, fmt, dummy_ap, argvars + 1);
+    len = vim_vsnprintf_typval(NULL, 0, fmt, dummy_ap, argvars + 1);
     if (!did_emsg) {
       char *s = xmalloc(len + 1);
       rettv->vval.v_string = (char_u *)s;
-      (void)vim_vsnprintf(s, len + 1, fmt, dummy_ap, argvars + 1);
+      (void)vim_vsnprintf_typval(s, len + 1, fmt, dummy_ap, argvars + 1);
     }
     did_emsg |= saved_did_emsg;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -384,7 +384,7 @@ int smsg(char *s, ...)
   va_list arglist;
 
   va_start(arglist, s);
-  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist, NULL);
+  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
   va_end(arglist);
   return msg(IObuff);
 }
@@ -395,7 +395,7 @@ int smsg_attr(int attr, char *s, ...)
   va_list arglist;
 
   va_start(arglist, s);
-  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist, NULL);
+  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
   va_end(arglist);
   return msg_attr((const char *)IObuff, attr);
 }
@@ -662,7 +662,7 @@ bool emsgf_multiline(const char *const fmt, ...)
   }
 
   va_start(ap, fmt);
-  vim_vsnprintf(errbuf, sizeof(errbuf), fmt, ap, NULL);
+  vim_vsnprintf(errbuf, sizeof(errbuf), fmt, ap);
   va_end(ap);
 
   ret = emsg_multiline(errbuf, true);
@@ -678,7 +678,7 @@ static bool emsgfv(const char *fmt, va_list ap)
     return true;
   }
 
-  vim_vsnprintf(errbuf, sizeof(errbuf), fmt, ap, NULL);
+  vim_vsnprintf(errbuf, sizeof(errbuf), fmt, ap);
 
   return emsg((const char_u *)errbuf);
 }
@@ -726,7 +726,7 @@ void msg_schedule_emsgf(const char *const fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  vim_vsnprintf((char *)IObuff, IOSIZE, fmt, ap, NULL);
+  vim_vsnprintf((char *)IObuff, IOSIZE, fmt, ap);
   va_end(ap);
 
   char *s = xstrdup((char *)IObuff);
@@ -1826,7 +1826,7 @@ void msg_printf_attr(const int attr, const char *const fmt, ...)
 
   va_list ap;
   va_start(ap, fmt);
-  const size_t len = vim_vsnprintf(msgbuf, sizeof(msgbuf), fmt, ap, NULL);
+  const size_t len = vim_vsnprintf(msgbuf, sizeof(msgbuf), fmt, ap);
   va_end(ap);
 
   msg_scroll = true;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -400,6 +400,17 @@ int smsg_attr(int attr, char *s, ...)
   return msg_attr((const char *)IObuff, attr);
 }
 
+int smsg_attr_keep(int attr, char *s, ...)
+  FUNC_ATTR_PRINTF(2, 3)
+{
+  va_list arglist;
+
+  va_start(arglist, s);
+  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
+  va_end(arglist);
+  return msg_attr_keep(IObuff, attr, true, false);
+}
+
 /*
  * Remember the last sourcing name/lnum used in an error message, so that it
  * isn't printed each time when it didn't change.

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -678,12 +678,12 @@ static float_T tv_float(typval_T *const tvs, int *const idxp)
 // are discarded. If "str_m" is greater than zero it is guaranteed
 // the resulting string will be NUL-terminated.
 
-// vim_vsnprintf() can be invoked with either "va_list" or a list of
+// vim_vsnprintf_typval() can be invoked with either "va_list" or a list of
 // "typval_T".  When the latter is not used it must be NULL.
 
 /// Append a formatted value to the string
 ///
-/// @see vim_vsnprintf().
+/// @see vim_vsnprintf_typval().
 int vim_snprintf_add(char *str, size_t str_m, char *fmt, ...)
   FUNC_ATTR_PRINTF(3, 4)
 {
@@ -697,7 +697,7 @@ int vim_snprintf_add(char *str, size_t str_m, char *fmt, ...)
   }
   va_list ap;
   va_start(ap, fmt);
-  const int str_l = vim_vsnprintf(str + len, space, fmt, ap, NULL);
+  const int str_l = vim_vsnprintf(str + len, space, fmt, ap);
   va_end(ap);
   return str_l;
 }
@@ -715,7 +715,7 @@ int vim_snprintf(char *str, size_t str_m, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  const int str_l = vim_vsnprintf(str, str_m, fmt, ap, NULL);
+  const int str_l = vim_vsnprintf(str, str_m, fmt, ap);
   va_end(ap);
   return str_l;
 }
@@ -736,6 +736,10 @@ static const char *infinity_str(bool positive, char fmt_spec,
   return table[idx];
 }
 
+int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap)
+{
+  return vim_vsnprintf_typval(str, str_m, fmt, ap, NULL);
+}
 
 /// Write formatted value to the string
 ///
@@ -748,8 +752,8 @@ static const char *infinity_str(bool positive, char fmt_spec,
 ///
 /// @return Number of bytes excluding NUL byte that would be written to the
 ///         string if str_m was greater or equal to the return value.
-int vim_vsnprintf(char *str, size_t str_m, const char *fmt, va_list ap,
-                  typval_T *const tvs)
+int vim_vsnprintf_typval(
+    char *str, size_t str_m, const char *fmt, va_list ap, typval_T *const tvs)
 {
   size_t str_l = 0;
   bool str_avail = str_l < str_m;

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -24,7 +24,10 @@ func Test_cd_no_arg()
     call assert_equal(path, getcwd())
   else
     " Test that cd without argument echoes cwd on non-Unix systems.
+    let shellslash = &shellslash
+    set shellslash
     call assert_match(getcwd(), execute('cd'))
+    let &shellslash = shellslash
   endif
 endfunc
 

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -17,9 +17,9 @@ func Test_mksession()
     \   '    four leadinG spaces',
     \   'two		consecutive tabs',
     \   'two	tabs	in one line',
-    \   'one ä multibyteCharacter',
-    \   'aä Ä  two multiByte characters',
-    \   'Aäöü  three mulTibyte characters',
+    \   'one Ã¤ multibyteCharacter',
+    \   'aÃ¤ Ã„  two multiByte characters',
+    \   'AÃ¤Ã¶Ã¼  three mulTibyte characters',
     \   'short line',
     \ ])
   let tmpfile = 'Xtemp'
@@ -240,13 +240,14 @@ endfunc
 
 func Test_mksession_quote_in_filename()
   let v:errmsg = ''
+  let filename = has('win32') ? 'x''y' : 'x''y"z'
   %bwipe!
   split another
-  split x'y\"z
+  execute 'split' escape(filename, '"')
   mksession! Xtest_mks_quoted.out
   %bwipe!
   source Xtest_mks_quoted.out
-  call assert_true(bufexists("x'y\"z"))
+  call assert_true(bufexists(filename))
 
   %bwipe!
   call delete('Xtest_mks_quoted.out')

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2452,7 +2452,9 @@ static void u_undo_end(
     }
   }
 
-  smsg(_("%" PRId64 " %s; %s #%" PRId64 "  %s"),
+  smsg_attr_keep(
+      0,
+      _("%" PRId64 " %s; %s #%" PRId64 "  %s"),
       u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,
       _(msgstr),
       did_undo ? _("before") : _("after"),

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2587,9 +2587,13 @@ static void u_add_time(char_u *buf, size_t buflen, time_t tt)
     else
       /* longer ago */
       (void)strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", &curtime);
-  } else
-  vim_snprintf((char *)buf, buflen, _("%" PRId64 " seconds ago"),
-      (int64_t)(time(NULL) - tt));
+  } else {
+    int64_t seconds = time(NULL) - tt;
+    vim_snprintf((char *)buf, buflen,
+                 NGETTEXT("%" PRId64 " second ago",
+                          "%" PRId64 " seconds ago", (uint32_t)seconds),
+                 seconds);
+  }
 }
 
 /*


### PR DESCRIPTION
**vim-patch:8.0.0709: libvterm cannot use vsnprintf()**

Problem:    Libvterm cannot use vsnprintf(), it does not exist in C90.
Solution:   Use vim_vsnprintf() instead.
https://github.com/vim/vim/commit/8327d1df1754b33d8a93b3411f30692f0042f4ce

**vim-patch:8.0.0728: the terminal structure is never freed**
Problem:    The terminal structure is never freed.
Solution:   Free the structure and unreference what it contains.
vim/vim@96ca27a

**vim-patch:8.1.0135: undo message delays screen update for CTRL-O u**
Problem:    Undo message delays screen update for CTRL-O u.
Solution:   Add smsg_attr_keep(). (closes vim/vim#3125)
vim/vim@e042968

**vim-patch:8.1.0308: a quick undo shows "1 seconds ago"**
Problem:    A quick undo shows "1 seconds ago". (Tony Mechelynck)
Solution:   Add singular/plural message.
vim/vim@fd6100b