### PR TITLE
CI/AppVeyor: per-compiler deps cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,10 @@ build_script:
 - powershell ci\build.ps1
 cache:
 - C:\msys64\var\cache\pacman\pkg -> ci\build.ps1
-- .deps -> ci\build.ps1
-- .deps -> third-party\**
+- deps-MINGW  -> ci\build.ps1
+- deps-MSVC   -> ci\build.ps1
+- deps-MINGW  -> third-party\**
+- deps-MSVC   -> third-party\**
 artifacts:
 - path: build/Neovim.zip
 - path: build/bin/nvim.exe

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -6,7 +6,7 @@ $compiler = $Matches.compiler
 $compileOption = $Matches.option
 $bits = $Matches.bits
 $cmakeBuildType = 'RelWithDebInfo'
-$depsDir = "deps-$($compiler)"
+$depsDir = [System.IO.Path]::GetFullPath("deps-$($compiler)")
 $depsCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
 }

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -6,12 +6,15 @@ $compiler = $Matches.compiler
 $compileOption = $Matches.option
 $bits = $Matches.bits
 $cmakeBuildType = 'RelWithDebInfo'
+$depsDir = "deps-$($compiler)"
 $depsCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
 }
 $nvimCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
   BUSTED_OUTPUT_TYPE = 'nvim';
+  DEPS_BUILD_DIR=$depsDir;
+  DEPS_PREFIX="$($depsDir)/usr";
 }
 $uploadToCodeCov = $false
 
@@ -89,10 +92,10 @@ function convertToCmakeArgs($vars) {
   return $vars.GetEnumerator() | foreach { "-D$($_.Key)=$($_.Value)" }
 }
 
-if (-Not (Test-Path -PathType container .deps)) {
-  mkdir .deps
+if (-Not (Test-Path -PathType container $depsDir)) {
+  mkdir "$depsDir"
 }
-cd .deps
+cd "$depsDir"
 cmake -G $cmakeGenerator $(convertToCmakeArgs($depsCmakeVars)) ..\third-party\ ; exitIfFailed
 cmake --build . --config $cmakeBuildType -- $cmakeGeneratorArgs ; exitIfFailed
 cd ..

--- a/test/functional/api/rpc_fixture.lua
+++ b/test/functional/api/rpc_fixture.lua
@@ -1,7 +1,5 @@
-local deps_prefix = './.deps/usr'
-if os.getenv('DEPS_PREFIX') then
-  deps_prefix = os.getenv('DEPS_PREFIX')
-end
+local deps_prefix = (os.getenv('DEPS_PREFIX') and os.getenv('DEPS_PREFIX')
+                     or './.deps/usr')
 
 package.path = deps_prefix .. '/share/lua/5.1/?.lua;' ..
                deps_prefix .. '/share/lua/5.1/?/init.lua;' ..

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -268,7 +268,7 @@ local function check_cores(app, force)
   else
     initial_path = '.'
     re = '/core[^/]*$'
-    exc_re = { '^/%.deps$', '^/%'.deps_prefix().'$', local_tmpdir, '^/%node_modules$' }
+    exc_re = { '^/%.deps$', '^/%'..deps_prefix()..'$', local_tmpdir, '^/%node_modules$' }
     db_cmd = gdb_db_cmd
     random_skip = true
   end

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -235,6 +235,11 @@ local function hasenv(name)
   return nil
 end
 
+local function deps_prefix()
+  local env = os.getenv('DEPS_PREFIX')
+  return (env and env ~= '') and env or '.deps/usr'
+end
+
 local tests_skipped = 0
 
 local function check_cores(app, force)
@@ -263,7 +268,7 @@ local function check_cores(app, force)
   else
     initial_path = '.'
     re = '/core[^/]*$'
-    exc_re = { '^/%.deps$', local_tmpdir, '^/%node_modules$' }
+    exc_re = { '^/%.deps$', '^/%'.deps_prefix().'$', local_tmpdir, '^/%node_modules$' }
     db_cmd = gdb_db_cmd
     random_skip = true
   end


### PR DESCRIPTION
The deps cache does not work for MSVC builds because the MINGW builds
ovewrite it.  Cache saves 10+ minutes on the build.