### PR TITLE
CI/AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ before_build:
 build_script:
 - powershell ci\build.ps1
 cache:
-- C:\projects\nvim-deps -> ci\build.ps1
 - C:\projects\nvim-deps -> third-party\**
 artifacts:
 - path: build/Neovim.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ before_build:
 build_script:
 - powershell ci\build.ps1
 cache:
-- C:\msys64\var\cache\pacman\pkg -> ci\build.ps1
 - C:\projects\nvim-deps -> ci\build.ps1
 - C:\projects\nvim-deps -> third-party\**
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: '{build}'
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
+  DEPS_BUILD_DIR: "C:/projects/nvim-deps"
+  DEPS_PREFIX: "C:/projects/nvim-deps/usr"
 image: Visual Studio 2017
 configuration:
 - MSVC_64
@@ -15,6 +17,8 @@ init:
       $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
       Exit-AppVeyorBuild
     }
+# RDP
+#- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 matrix:
   allow_failures:
     - configuration: MINGW_64-gcov
@@ -25,10 +29,8 @@ build_script:
 - powershell ci\build.ps1
 cache:
 - C:\msys64\var\cache\pacman\pkg -> ci\build.ps1
-- deps-MINGW  -> ci\build.ps1
-- deps-MSVC   -> ci\build.ps1
-- deps-MINGW  -> third-party\**
-- deps-MSVC   -> third-party\**
+- C:\projects\nvim-deps -> ci\build.ps1
+- C:\projects\nvim-deps -> third-party\**
 artifacts:
 - path: build/Neovim.zip
 - path: build/bin/nvim.exe

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -6,15 +6,15 @@ $compiler = $Matches.compiler
 $compileOption = $Matches.option
 $bits = $Matches.bits
 $cmakeBuildType = 'RelWithDebInfo'
-$depsDir = [System.IO.Path]::GetFullPath("deps-$($compiler)")
+$buildDir = [System.IO.Path]::GetFullPath("$(pwd)")
 $depsCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
 }
 $nvimCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;
   BUSTED_OUTPUT_TYPE = 'nvim';
-  DEPS_BUILD_DIR=$depsDir;
-  DEPS_PREFIX="$($depsDir)/usr";
+  DEPS_BUILD_DIR=$(if ($env:DEPS_BUILD_DIR -ne $null) {$env:DEPS_BUILD_DIR} else {".deps"});
+  DEPS_PREFIX=$(if ($env:DEPS_PREFIX -ne $null) {$env:DEPS_PREFIX} else {".deps/usr"});
 }
 $uploadToCodeCov = $false
 
@@ -23,6 +23,11 @@ function exitIfFailed() {
     Set-PSDebug -Off
     exit $LastExitCode
   }
+}
+
+if (-Not (Test-Path -PathType container $nvimCmakeVars["DEPS_BUILD_DIR"])) {
+  write-host "cache not restored (deps dir not found): $($nvimCmakeVars['DEPS_BUILD_DIR'])"
+  mkdir $nvimCmakeVars["DEPS_BUILD_DIR"]
 }
 
 if ($compiler -eq 'MINGW') {
@@ -87,13 +92,10 @@ function convertToCmakeArgs($vars) {
   return $vars.GetEnumerator() | foreach { "-D$($_.Key)=$($_.Value)" }
 }
 
-if (-Not (Test-Path -PathType container $depsDir)) {
-  mkdir "$depsDir"
-}
-cd "$depsDir"
-cmake -G $cmakeGenerator $(convertToCmakeArgs($depsCmakeVars)) ..\third-party\ ; exitIfFailed
+cd $nvimCmakeVars["DEPS_BUILD_DIR"]
+cmake -G $cmakeGenerator $(convertToCmakeArgs($depsCmakeVars)) "$buildDir/third-party/" ; exitIfFailed
 cmake --build . --config $cmakeBuildType -- $cmakeGeneratorArgs ; exitIfFailed
-cd ..
+cd $buildDir
 
 # Build Neovim
 mkdir build

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -26,8 +26,10 @@ function exitIfFailed() {
 }
 
 if (-Not (Test-Path -PathType container $nvimCmakeVars["DEPS_BUILD_DIR"])) {
-  write-host "cache not restored (deps dir not found): $($nvimCmakeVars['DEPS_BUILD_DIR'])"
+  write-host "cache dir not found: $($nvimCmakeVars['DEPS_BUILD_DIR'])"
   mkdir $nvimCmakeVars["DEPS_BUILD_DIR"]
+} else {
+  write-host "cache dir ($nvimCmakeVars['DEPS_BUILD_DIR']) size: $(Get-ChildItem $nvimCmakeVars['DEPS_BUILD_DIR'] -recurse | Measure-Object -property length -sum | Select -expand sum)"
 }
 
 if ($compiler -eq 'MINGW') {


### PR DESCRIPTION
- build.ps1: support out-of-tree deps directory
- appveyor.yml: set cache to an absolute path.

Desperate attempt to get AppVeyor cache to work.

Assumption in a7a5629 #9852 that that different jobs were overwriting each other's cache is probably wrong: AppVeyor docs/discussions hint that the cache is per-config (though I haven't
found a clear, unambiguous statement as such).