### PR TITLE
Make SHM_ALL to a variable instead of a compound literal #define

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2495,11 +2495,6 @@ static bool valid_filetype(char_u *val)
   return true;
 }
 
-#ifdef _MSC_VER
-// MSVC optimizations are disabled for this function because it
-// incorrectly generates an empty string for SHM_ALL.
-#pragma optimize("", off)
-#endif
 /*
  * Handle string options that need some action to perform when changed.
  * Returns NULL for success, or an error message for an error.
@@ -3391,9 +3386,6 @@ ambw_end:
 
   return errmsg;
 }
-#ifdef _MSC_VER
-#pragma optimize("", on)
-#endif
 
 /*
  * Simple int comparison function for use with qsort()

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -310,6 +310,15 @@ static char *(p_scl_values[]) =       { "yes", "no", "auto", "auto:1", "auto:2",
   "yes:1", "yes:2", "yes:3", "yes:4", "yes:5", "yes:6", "yes:7", "yes:8",
   "yes:9", NULL };
 
+/// All possible flags for 'shm'.
+static char_u SHM_ALL[] = {
+  SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW, SHM_WRI,
+  SHM_ABBREVIATIONS, SHM_WRITE, SHM_TRUNC, SHM_TRUNCALL, SHM_OVER,
+  SHM_OVERALL, SHM_SEARCH, SHM_ATTENTION, SHM_INTRO, SHM_COMPLETIONMENU,
+  SHM_RECORDING, SHM_FILEINFO,
+  0,
+};
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"
 #endif

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2495,10 +2495,8 @@ static bool valid_filetype(char_u *val)
   return true;
 }
 
-/*
- * Handle string options that need some action to perform when changed.
- * Returns NULL for success, or an error message for an error.
- */
+/// Handle string options that need some action to perform when changed.
+/// Returns NULL for success, or an error message for an error.
 static char_u *
 did_set_string_option(
     int opt_idx,                       // index in options[] table
@@ -3387,18 +3385,15 @@ ambw_end:
   return errmsg;
 }
 
-/*
- * Simple int comparison function for use with qsort()
- */
+/// Simple int comparison function for use with qsort()
 static int int_cmp(const void *a, const void *b)
 {
   return *(const int *)a - *(const int *)b;
 }
 
-/*
- * Handle setting 'colorcolumn' or 'textwidth' in window "wp".
- * Returns error message, NULL if it's OK.
- */
+/// Handle setting 'colorcolumn' or 'textwidth' in window "wp".
+///
+/// @return error message, NULL if it's OK.
 char_u *check_colorcolumn(win_T *wp)
 {
   char_u      *s;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -179,14 +179,6 @@ enum {
   SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW, SHM_WRI, \
   0, \
 })
-/// All possible flags for 'shm'.
-#define SHM_ALL ((char_u[]) { \
-  SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW, SHM_WRI, \
-  SHM_ABBREVIATIONS, SHM_WRITE, SHM_TRUNC, SHM_TRUNCALL, SHM_OVER, \
-  SHM_OVERALL, SHM_SEARCH, SHM_ATTENTION, SHM_INTRO, SHM_COMPLETIONMENU, \
-  SHM_RECORDING, SHM_FILEINFO, \
-  0, \
-})
 
 /* characters for p_go: */
 #define GO_ASEL         'a'             /* autoselect */


### PR DESCRIPTION
gcc-9 has [improved compliance] with the C spec for lifetime of compound
literals, tying their lifetime to block scope instead of function scope.
This makes the behavior comparable to all other automatic variables.

Using the SHM_ALL #define instantiated a compound literal local to an if
clause and assigned the address to a "char_u *".  Since the pointer was
then being used outside of the if clause, it was using an invalid
address.

[improved compliance]: https://gcc.gnu.org/gcc-9/porting_to.html#complit

Closes #9855