### PR TITLE
Correct clint warning

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2491,10 +2491,10 @@ static bool valid_filetype(char_u *val)
 // incorrectly generates an empty string for SHM_ALL.
 #pragma optimize("", off)
 #endif
-/*
- * Handle string options that need some action to perform when changed.
- * Returns NULL for success, or an error message for an error.
- */
+//
+// Handle string options that need some action to perform when changed.
+// Returns NULL for success, or an error message for an error.
+//
 static char_u *
 did_set_string_option(
     int opt_idx,                       // index in options[] table


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://travis-ci.org/neovim/neovim/jobs/517022470

```
src/nvim/option.c:2498:  /*-style comment found, it should be replaced with //-style.  /*-style comments are only allowed inside macros.  Note that you should not use /*-style comments to document macros itself, use doxygen-style comments for this.  [readability/old_style_comment] [5]
Total errors found: 1
```