### PR TITLE
vim-patch:{8.0.1763,8.1.1134}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1717,11 +1717,7 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
    * buffer.)
    */
   buf = NULL;
-  if ((flags & BLN_CURBUF)
-      && curbuf != NULL
-      && curbuf->b_ffname == NULL
-      && curbuf->b_nwindows <= 1
-      && (curbuf->b_ml.ml_mfp == NULL || BUFEMPTY())) {
+  if ((flags & BLN_CURBUF) && curbuf_reusable()) {
     buf = curbuf;
     /* It's like this buffer is deleted.  Watch out for autocommands that
      * change curbuf!  If that happens, allocate a new buffer anyway. */
@@ -1862,6 +1858,17 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
   }
 
   return buf;
+}
+
+/// Return true if the current buffer is empty, unnamed, unmodified and used in
+/// only one window. That means it can be reused.
+bool curbuf_reusable(void)
+{
+  return (curbuf != NULL
+          && curbuf->b_ffname == NULL
+          && curbuf->b_nwindows <= 1
+          && (curbuf->b_ml.ml_mfp == NULL || BUFEMPTY())
+          && !curbufIsChanged());
 }
 
 /*

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1868,6 +1868,7 @@ bool curbuf_reusable(void)
           && curbuf->b_ffname == NULL
           && curbuf->b_nwindows <= 1
           && (curbuf->b_ml.ml_mfp == NULL || BUFEMPTY())
+          && !bt_quickfix(curbuf)
           && !curbufIsChanged());
 }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1952,14 +1952,17 @@ void ex_next(exarg_T *eap)
 void ex_argedit(exarg_T *eap)
 {
   int i = eap->addr_count ? (int)eap->line2 : curwin->w_arg_idx + 1;
+  // Whether curbuf will be reused, curbuf->b_ffname will be set.
+  bool curbuf_is_reusable = curbuf_reusable();
 
   if (do_arglist(eap->arg, AL_ADD, i) == FAIL) {
     return;
   }
   maketitle();
 
-  if (curwin->w_arg_idx == 0 && (curbuf->b_ml.ml_flags & ML_EMPTY)
-      && curbuf->b_ffname == NULL) {
+  if (curwin->w_arg_idx == 0
+      && (curbuf->b_ml.ml_flags & ML_EMPTY)
+      && (curbuf->b_ffname == NULL || curbuf_is_reusable)) {
     i = 0;
   }
   // Edit the argument.
@@ -2257,7 +2260,8 @@ static int alist_add_list(int count, char_u **files, int after)
     }
     for (int i = 0; i < count; i++) {
       ARGLIST[after + i].ae_fname = files[i];
-      ARGLIST[after + i].ae_fnum = buflist_add(files[i], BLN_LISTED);
+      ARGLIST[after + i].ae_fnum = buflist_add(files[i],
+                                               BLN_LISTED | BLN_CURBUF);
     }
     ALIST(curwin)->al_ga.ga_len += count;
     if (old_argcount > 0 && curwin->w_arg_idx >= after) {

--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -329,6 +329,18 @@ func Test_argedit()
   %argd
   bwipe! C
   bwipe! D
+
+  " :argedit reuses the current buffer if it is empty
+  %argd
+  " make sure to use a new buffer number for x when it is loaded
+  bw! x
+  new
+  let a = bufnr('')
+  argedit x
+  call assert_equal(a, bufnr(''))
+  call assert_equal('x', bufname(''))
+  %argd
+  bw! x
 endfunc
 
 " Test for the :argdelete command

--- a/src/nvim/testdir/test_command_count.vim
+++ b/src/nvim/testdir/test_command_count.vim
@@ -173,7 +173,6 @@ func Test_command_count_4()
   only!
 
   exe bufnr . 'buf'
-  bnext
   let bufnr = bufnr('%')
   let buffers = []
   .,$-bufdo call add(buffers, bufnr('%'))

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2664,3 +2664,17 @@ func Test_qfwin_pos()
   call assert_equal(3, winnr())
   close
 endfunc
+
+" Test to make sure that an empty quickfix buffer is not reused for loading
+" a normal buffer.
+func Test_empty_qfbuf()
+  enew | only
+  call writefile(["Test"], 'Xfile1')
+  call setqflist([], 'f')
+  copen | only
+  let qfbuf = bufnr('')
+  edit Xfile1
+  call assert_notequal(qfbuf, bufnr(''))
+  enew
+  call delete('Xfile1')
+endfunc


### PR DESCRIPTION
__vim-patch:8.0.1763: :argedit does not reuse an empty unnamed buffer__

    Problem:    :argedit does not reuse an empty unnamed buffer.
    Solution:   Add the BLN_CURBUF flag and fix all the side effects. (Christian Brabandt)

https://github.com/vim/vim/commit/46a53dfc29689c6a0d80e3820e8b0a48dba6b6ec

__vim-patch:8.1.1134: buffer for quickfix window is reused for another file__

    Problem:    Buffer for quickfix window is reused for another file.
    Solution:   Don't reuse the quickfx buffer. (Yegappan Lakshmanan)

https://github.com/vim/vim/commit/39803d82dbb215d2eea9fcd6cf2961b71515a438
