### PR TITLE
ci/build.ps1: Respect CMAKE_BUILD_TYPE if provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 
 # Log level (MIN_LOG_LEVEL in log.h)
 if("${MIN_LOG_LEVEL}" MATCHES "^$")
-  message(STATUS "MIN_LOG_LEVEL not specified, default is 0 (DEBUG)")
+  message(STATUS "MIN_LOG_LEVEL not specified, default is 1 (INFO)")
 else()
   if(NOT MIN_LOG_LEVEL MATCHES "^[0-3]$")
     message(FATAL_ERROR "invalid MIN_LOG_LEVEL: " ${MIN_LOG_LEVEL})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ configuration:
 - MINGW_64-gcov
 init:
 - ps: |
-    # For pull requests, skip some build configurations to save time.
+    # Pull requests: skip some build configurations to save time.
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32|MINGW_64-gcov)$') {
       $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
       Exit-AppVeyorBuild

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -1,11 +1,12 @@
 $ErrorActionPreference = 'stop'
 Set-PSDebug -Strict -Trace 1
 
+$isPullRequest = ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -ne $null)
 $env:CONFIGURATION -match '^(?<compiler>\w+)_(?<bits>32|64)(?:-(?<option>\w+))?$'
 $compiler = $Matches.compiler
 $compileOption = $Matches.option
 $bits = $Matches.bits
-$cmakeBuildType = 'RelWithDebInfo'
+$cmakeBuildType = $(if ($env:CMAKE_BUILD_TYPE -ne $null) {$env:CMAKE_BUILD_TYPE} else {'RelWithDebInfo'});
 $buildDir = [System.IO.Path]::GetFullPath("$(pwd)")
 $depsCmakeVars = @{
   CMAKE_BUILD_TYPE = $cmakeBuildType;


### PR DESCRIPTION
- Respect the CMAKE_BUILD_TYPE env var if provided.
- ~~Use "Debug" build-type so that pull requests build faster.~~
  - Reverted for now because it triggers a rebuild of deps, and I don't want to do the whole cycle on `master` again:
    ```
    [00:01:24] CUSTOMBUILD : CMake warning :  [C:\projects\nvim-deps\libiconv.vcxproj]
    [00:01:24]     Manually-specified variables were not used by the project:
    [00:01:24]       CMAKE_BUILD_TYPE
    ```

---

Future:

- If appveyor logs are accurate, the `test_charsearch.vim` old test apparently adds 4 minutes to the build. Seems weird.
  ```
  [00:19:25] [OLDTEST] Running test_charsearch
  [00:24:25] [OLDTEST] Running test_cindent
  ```