### PR TITLE
float: always change to valid windows

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4037,7 +4037,7 @@ win_T *win_vert_neighbor(tabpage_T *tp, win_T *wp, bool up, long count)
   foundfr = wp->w_frame;
 
   if (wp->w_floating) {
-    return prevwin;
+    return win_valid(prevwin) && !prevwin->w_floating ? prevwin : firstwin;
   }
 
   while (count--) {
@@ -4118,7 +4118,7 @@ win_T *win_horz_neighbor(tabpage_T *tp, win_T *wp, bool left, long count)
   foundfr = wp->w_frame;
 
   if (wp->w_floating) {
-    return prevwin;
+    return win_valid(prevwin) && !prevwin->w_floating ? prevwin : firstwin;
   }
 
   while (count--) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -37,6 +37,20 @@ describe('floating windows', function()
     [17] = {background = Screen.colors.Yellow},
   }
 
+  it('behavior', function()
+    -- Create three windows and test that ":wincmd <direction>" changes to the
+    -- first window, if the previous window is invalid.
+    command('split')
+    meths.open_win(0, true, {width=10, height=10, relative='editor', row=0, col=0})
+    eq(1002, funcs.win_getid())
+    eq('editor', meths.win_get_config(1002).relative)
+    command([[
+      call nvim_win_close(1001, v:false)
+      wincmd j
+    ]])
+    eq(1000, funcs.win_getid())
+  end)
+
   local function with_ext_multigrid(multigrid)
     local screen
     before_each(function()


### PR DESCRIPTION
Using `:wincmd j` and friends doesn't make much sense to a floating window. For convenience though, any direction will simply change to the previous window.

Make sure the previous window is valid, not the current window, and not another floating window. Change to the first window (which is never a floating window) otherwise.