### PR TITLE
vim-patch:8.0.{725,1411}

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6528,6 +6528,8 @@ static void nv_window(cmdarg_T *cap)
 {
   if (cap->nchar == ':') {
     // "CTRL-W :" is the same as typing ":"; useful in a terminal window
+    cap->cmdchar = ':';
+    cap->nchar = NUL;
     nv_colon(cap);
   } else if (!checkclearop(cap->oap)) {
     do_window(cap->nchar, cap->count0, NUL);  // everything is in window.c

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6526,8 +6526,12 @@ static void n_start_visual_mode(int c)
  */
 static void nv_window(cmdarg_T *cap)
 {
-  if (!checkclearop(cap->oap))
-    do_window(cap->nchar, cap->count0, NUL);     /* everything is in window.c */
+  if (cap->nchar == ':') {
+    // "CTRL-W :" is the same as typing ":"; useful in a terminal window
+    nv_colon(cap);
+  } else if (!checkclearop(cap->oap)) {
+    do_window(cap->nchar, cap->count0, NUL);  // everything is in window.c
+  }
 }
 
 /*

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -153,6 +153,10 @@ int get_op_type(int char1, int char2)
     if (opchars[i][0] == char1 && opchars[i][1] == char2) {
       break;
     }
+    if (i == (int)(sizeof(opchars) / sizeof(char [3]) - 1)) {
+      internal_error("get_op_type()");
+      break;
+    }
   }
   return i;
 }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -153,7 +153,7 @@ int get_op_type(int char1, int char2)
     if (opchars[i][0] == char1 && opchars[i][1] == char2) {
       break;
     }
-    if (i == (int)(sizeof(opchars) / sizeof(char [3]) - 1)) {
+    if (i == (int)(ARRAY_SIZE(opchars) - 1)) {
       internal_error("get_op_type()");
       break;
     }

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -691,4 +691,9 @@ func Test_winnr()
   only | tabonly
 endfunc
 
+func Test_window_colon_command()
+  " This was reading invalid memory.
+  exe "norm! v\<C-W>:\<C-U>echo v:version"
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:8.0.0725: a terminal window does not handle keyboard input**
Problem:    A terminal window does not handle keyboard input.
Solution:   Add terminal_loop().  ":term bash -i" sort of works now.
vim/vim@938783d
de2e86a

**vim-patch:8.0.1411: reading invalid memory with CTRL-W :**
Problem:    Reading invalid memory with CTRL-W :.
Solution:   Correct the command characters. (closes vim/vim#2469)
vim/vim@2efb323

Follow-up from https://github.com/neovim/neovim/pull/9879. I included both patches just to see if vim-patch:8.0.0725 is really N/A such that only the test code from vim-patch:8.0.1411 is useful.