### PR TITLE
make terminal state redraw like any other state

### DIFF
--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -142,15 +142,15 @@ describe(':terminal scrollback', function()
     describe('and height decreased by 1', function()
       if helpers.pending_win32(pending) then return end
       local function will_hide_top_line()
-        feed([[<C-\><C-N>:]])  -- Go to cmdline-mode, so cursor is at bottom.
+        feed([[<C-\><C-N>]])
         screen:try_resize(screen._width - 2, screen._height - 1)
         screen:expect([[
           line2                       |
           line3                       |
           line4                       |
           rows: 5, cols: 28           |
-          {2: }                           |
-          :^                           |
+          {2:^ }                           |
+                                      |
         ]])
       end
 
@@ -166,11 +166,11 @@ describe(':terminal scrollback', function()
           screen:expect([[
             rows: 5, cols: 28         |
             rows: 3, cols: 26         |
-            {2: }                         |
-            :^                         |
+            {2:^ }                         |
+                                      |
           ]])
           eq(8, curbuf('line_count'))
-          feed([[<C-\><C-N>3k]])
+          feed([[3k]])
           screen:expect([[
             ^line4                     |
             rows: 5, cols: 28         |

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -69,7 +69,7 @@ describe(':terminal', function()
   end)
 
   it('forwards resize request to the program', function()
-    feed([[<C-\><C-N>G:]])  -- Go to cmdline-mode, so cursor is at bottom.
+    feed([[<C-\><C-N>G]])
     local w1, h1 = screen._width - 3, screen._height - 2
     local w2, h2 = w1 - 6, h1 - 3
 
@@ -92,16 +92,16 @@ describe(':terminal', function()
                                                      |
                                                      |
                                                      |
+      ^                                               |
                                                      |
-      :^                                              |
     ]])
     screen:try_resize(w2, h2)
     screen:expect([[
       tty ready                                |
       rows: 7, cols: 47                        |
       rows: 4, cols: 41                        |
-      {2: }                                        |
-      :^                                        |
+      {2:^ }                                        |
+                                               |
     ]])
   end)
 end)

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -163,12 +163,14 @@ describe('search highlighting', function()
     ]])
     feed('/foo')
     sleep(50)  -- Allow some terminal activity.
+    -- NB: in earlier versions terminal output was redrawn during cmdline mode.
+    -- For now just assert that the screens remain unchanged.
     screen:expect([[
-        {3:foo} bar baz       {3:│}xxx                |
-        bar baz {2:foo}       {3:│}xxx                |
-        bar {2:foo} baz       {3:│}xxx                |
-                          {3:│}xxx                |
-      {1:~                   }{3:│}xxx                |
+        {3:foo} bar baz       {3:│}                   |
+        bar baz {2:foo}       {3:│}                   |
+        bar {2:foo} baz       {3:│}                   |
+                          {3:│}                   |
+      {1:~                   }{3:│}                   |
       {5:[No Name] [+]        }{3:term               }|
       /foo^                                    |
     ]], { [1] = {bold = true, foreground = Screen.colors.Blue1},

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -95,10 +95,12 @@ describe("'wildmenu'", function()
 
     feed([[<C-\><C-N>gg]])
     feed([[:sign <Tab>]])   -- Invoke wildmenu.
+    -- NB: in earlier versions terminal output was redrawn during cmdline mode.
+    -- For now just assert that the screen remains unchanged.
     expect_stay_unchanged{grid=[[
-      foo                      |
-      foo                      |
-      foo                      |
+                               |
+                               |
+                               |
       define  jump  list  >    |
       :sign define^             |
     ]]}


### PR DESCRIPTION
try to simplify redraw logic in terminal mode and make it more similar to other modes. Fixes issues

- async events in an unrelated ordinary buffer was not always redrawn in terminal mode
- screen cursor position was not properly updated (tangents #9882)
- ad-hoc logic was needed for interaction with "special" modes (logic that will get out of date when such modes are added or changed). 
- Under some undocumented circumstance cursor was needed to be saved and restored.


