### PR TITLE
RPC: eliminate NO_RESPONSE

### DIFF
--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -29,13 +29,12 @@ typedef enum {
 } ErrorType;
 
 typedef enum {
-  kMessageTypeRequest,
-  kMessageTypeResponse,
-  kMessageTypeNotification
+  kMessageTypeUnknown = -1,
+  // Per msgpack-rpc spec.
+  kMessageTypeRequest = 0,
+  kMessageTypeResponse = 1,
+  kMessageTypeNotification = 2,
 } MessageType;
-
-/// Used as the message ID of notifications.
-#define NO_RESPONSE UINT64_MAX
 
 /// Mask for all internal calls
 #define INTERNAL_CALL_MASK (((uint64_t)1) << (sizeof(uint64_t) * 8 - 1))

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -131,7 +131,7 @@ Object rpc_send_call(uint64_t id,
 
   channel_incref(channel);
   RpcState *rpc = &channel->rpc;
-  uint64_t request_id = rpc->next_request_id++;
+  uint32_t request_id = rpc->next_request_id++;
   // Send the msgpack-rpc request
   send_request(channel, request_id, method_name, args);
 
@@ -292,7 +292,7 @@ static void parse_msgpack(Channel *channel)
 static void handle_request(Channel *channel, msgpack_object *request)
   FUNC_ATTR_NONNULL_ALL
 {
-  uint64_t request_id;
+  uint32_t request_id;
   Error error = ERROR_INIT;
   MessageType type = msgpack_rpc_validate(&request_id, request, &error);
 
@@ -437,7 +437,7 @@ static void internal_read_event(void **argv)
   wstream_release_wbuffer(buffer);
 }
 
-static void send_error(Channel *chan, MessageType type, uint64_t id, char *err)
+static void send_error(Channel *chan, MessageType type, uint32_t id, char *err)
 {
   Error e = ERROR_INIT;
   api_set_error(&e, kErrorTypeException, "%s", err);
@@ -451,7 +451,7 @@ static void send_error(Channel *chan, MessageType type, uint64_t id, char *err)
 }
 
 static void send_request(Channel *channel,
-                         uint64_t id,
+                         uint32_t id,
                          const char *name,
                          Array args)
 {
@@ -584,7 +584,7 @@ static bool is_rpc_response(msgpack_object *obj)
 
 static bool is_valid_rpc_response(msgpack_object *obj, Channel *channel)
 {
-  uint64_t response_id = obj->via.array.ptr[1].via.u64;
+  uint32_t response_id = (uint32_t)obj->via.array.ptr[1].via.u64;
   if (kv_size(channel->rpc.call_stack) == 0) {
     return false;
   }
@@ -622,7 +622,7 @@ static void call_set_error(Channel *channel, char *msg, int loglevel)
 }
 
 static WBuffer *serialize_request(uint64_t channel_id,
-                                  uint64_t request_id,
+                                  uint32_t request_id,
                                   const String method,
                                   Array args,
                                   msgpack_sbuffer *sbuffer,
@@ -643,7 +643,7 @@ static WBuffer *serialize_request(uint64_t channel_id,
 
 static WBuffer *serialize_response(uint64_t channel_id,
                                    MessageType type,
-                                   uint64_t response_id,
+                                   uint32_t response_id,
                                    Error *err,
                                    Object arg,
                                    msgpack_sbuffer *sbuffer)

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -19,6 +19,7 @@ typedef struct {
 } ChannelCallFrame;
 
 typedef struct {
+  MessageType type;
   Channel *channel;
   MsgpackRpcRequestHandler handler;
   Array args;

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -13,7 +13,7 @@
 typedef struct Channel Channel;
 
 typedef struct {
-  uint64_t request_id;
+  uint32_t request_id;
   bool returned, errored;
   Object result;
 } ChannelCallFrame;
@@ -23,14 +23,14 @@ typedef struct {
   Channel *channel;
   MsgpackRpcRequestHandler handler;
   Array args;
-  uint64_t request_id;
+  uint32_t request_id;
 } RequestEvent;
 
 typedef struct {
   PMap(cstr_t) *subscribed_events;
   bool closed;
   msgpack_unpacker *unpacker;
-  uint64_t next_request_id;
+  uint32_t next_request_id;
   kvec_t(ChannelCallFrame *) call_stack;
   Dictionary info;
 } RpcState;

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -489,7 +489,7 @@ void msgpack_rpc_from_dictionary(Dictionary result, msgpack_packer *res)
 }
 
 /// Serializes a msgpack-rpc request or notification(id == 0)
-void msgpack_rpc_serialize_request(uint64_t request_id,
+void msgpack_rpc_serialize_request(uint32_t request_id,
                                    const String method,
                                    Array args,
                                    msgpack_packer *pac)
@@ -499,7 +499,7 @@ void msgpack_rpc_serialize_request(uint64_t request_id,
   msgpack_pack_int(pac, request_id ? 0 : 2);
 
   if (request_id) {
-    msgpack_pack_uint64(pac, request_id);
+    msgpack_pack_uint32(pac, request_id);
   }
 
   msgpack_rpc_from_string(method, pac);
@@ -507,7 +507,7 @@ void msgpack_rpc_serialize_request(uint64_t request_id,
 }
 
 /// Serializes a msgpack-rpc response
-void msgpack_rpc_serialize_response(uint64_t response_id,
+void msgpack_rpc_serialize_response(uint32_t response_id,
                                     Error *err,
                                     Object arg,
                                     msgpack_packer *pac)
@@ -515,7 +515,7 @@ void msgpack_rpc_serialize_response(uint64_t response_id,
 {
   msgpack_pack_array(pac, 4);
   msgpack_pack_int(pac, 1);
-  msgpack_pack_uint64(pac, response_id);
+  msgpack_pack_uint32(pac, response_id);
 
   if (ERROR_SET(err)) {
     // error represented by a [type, message] array
@@ -561,7 +561,7 @@ static msgpack_object *msgpack_rpc_msg_id(msgpack_object *req)
   return obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER ? obj : NULL;
 }
 
-MessageType msgpack_rpc_validate(uint64_t *response_id, msgpack_object *req,
+MessageType msgpack_rpc_validate(uint32_t *response_id, msgpack_object *req,
                                  Error *err)
 {
   *response_id = 0;
@@ -600,7 +600,7 @@ MessageType msgpack_rpc_validate(uint64_t *response_id, msgpack_object *req,
       api_set_error(err, kErrorTypeValidation, "ID must be a positive integer");
       return type;
     }
-    *response_id = id_obj->via.u64;
+    *response_id = (uint32_t)id_obj->via.u64;
   }
 
   if (!msgpack_rpc_method(req)) {


### PR DESCRIPTION
Using a sentinel value in the response-id is ambiguous because the
msgpack-rpc spec allows all values (including zero/max). And clients
control the id, so we can't be sure they won't use the sentinel value.

Instead of a sentinel value, check the message type explicitly.

fix #8850