### PR TITLE
[RFC] options: comma-separated options don't allow duplicates

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -181,6 +181,7 @@ return {
     {
       full_name='backupskip', abbreviation='bsk',
       type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
       vi_def=true,
       varname='p_bsk',
       defaults={if_true={vi=""}}
@@ -189,6 +190,7 @@ return {
       full_name='belloff', abbreviation='bo',
       deny_duplicates=true,
       type='string', list='comma', scope={'global'},
+      deny_duplicates=true,
       vi_def=true,
       varname='p_bo',
       defaults={if_true={vi="all"}}
@@ -756,6 +758,7 @@ return {
     {
       full_name='fileencodings', abbreviation='fencs',
       type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
       vi_def=true,
       varname='p_fencs',
       defaults={if_true={vi="ucs-bom,utf-8,default,latin1"}}
@@ -1016,6 +1019,7 @@ return {
     {
       full_name='guifontset', abbreviation='gfs',
       type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
       vi_def=true,
       varname='p_guifontset',
       redraw={'ui_option'},
@@ -1070,6 +1074,7 @@ return {
     {
       full_name='helplang', abbreviation='hlg',
       type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
       vi_def=true,
       varname='p_hlg',
       defaults={if_true={vi=""}}
@@ -2240,6 +2245,7 @@ return {
     {
       full_name='spellfile', abbreviation='spf',
       type='string', list='onecomma', scope={'buffer'},
+      deny_duplicates=true,
       secure=true,
       vi_def=true,
       alloced=true,
@@ -2250,6 +2256,7 @@ return {
     {
       full_name='spelllang', abbreviation='spl',
       type='string', list='onecomma', scope={'buffer'},
+      deny_duplicates=true,
       vi_def=true,
       alloced=true,
       expand=true,
@@ -2260,6 +2267,7 @@ return {
     {
       full_name='spellsuggest', abbreviation='sps',
       type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
       secure=true,
       vi_def=true,
       expand=true,
@@ -2702,6 +2710,7 @@ return {
     {
       full_name='wildoptions', abbreviation='wop',
       type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
       vi_def=true,
       varname='p_wop',
       defaults={if_true={vi=""}}


### PR DESCRIPTION
Change all options that use `list=comma` or `list=onecomma` to not allow duplicate values.

Closes https://github.com/neovim/neovim/issues/9890