### PR TITLE
API: emit nvim_error_event on failed async request

### DIFF
--- a/src/nvim/func_attr.h
+++ b/src/nvim/func_attr.h
@@ -205,10 +205,15 @@
 #endif
 
 #ifdef DEFINE_FUNC_ATTRIBUTES
+/// Non-deferred API function.
 # define FUNC_API_ASYNC
+/// Internal C function not exposed in the RPC API.
 # define FUNC_API_NOEXPORT
+/// API function not exposed in VimL/eval.
 # define FUNC_API_REMOTE_ONLY
+/// API function introduced at the given API level.
 # define FUNC_API_SINCE(X)
+/// API function deprecated since the given API level.
 # define FUNC_API_DEPRECATED_SINCE(X)
 # define FUNC_ATTR_MALLOC REAL_FATTR_MALLOC
 # define FUNC_ATTR_ALLOC_SIZE(x) REAL_FATTR_ALLOC_SIZE(x)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -49,9 +49,19 @@ describe('API', function()
 
   it('handles errors in async requests', function()
     local error_types = meths.get_api_info()[2].error_types
-    nvim_async("bogus")
+    nvim_async('bogus')
     eq({'notification', 'nvim_error_event',
         {error_types.Exception.id, 'Invalid method: nvim_bogus'}}, next_msg())
+    -- error didn't close channel.
+    eq(2, eval('1+1'))
+  end)
+
+  it('failed async request emits nvim_error_event', function()
+    local error_types = meths.get_api_info()[2].error_types
+    nvim_async('command', 'bogus')
+    eq({'notification', 'nvim_error_event',
+        {error_types.Exception.id, 'Vim:E492: Not an editor command: bogus'}},
+        next_msg())
     -- error didn't close channel.
     eq(2, eval('1+1'))
   end)

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -13,6 +13,7 @@ local rmdir = helpers.rmdir
 local set_session = helpers.set_session
 local spawn = helpers.spawn
 local nvim_async = helpers.nvim_async
+local expect_msg_seq = helpers.expect_msg_seq
 
 describe(':recover', function()
   before_each(clear)
@@ -163,6 +164,13 @@ describe('swapfile detection', function()
     screen2:expect{any=[[Found a swap file by the name ".*]]
                        ..[[Xtest_swapdialog_dir[/\].*]]..testfile..[[%.swp"]]}
     feed('e')  -- Chose "Edit" at the swap dialog.
-    feed('<c-c>')
+    expect_msg_seq({
+      ignore={'redraw'},
+      seqs={
+        { {'notification', 'nvim_error_event', {0, 'Vim(edit):E325: ATTENTION'}},
+        }
+      }
+    })
+    feed('<cr>')
   end)
 end)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -627,6 +627,19 @@ local function table_flatten(arr)
   return result
 end
 
+-- Checks if a list-like (vector) table contains `value`.
+local function table_contains(t, value)
+  if type(t) ~= 'table' then
+    error('t must be a table')
+  end
+  for _,v in ipairs(t) do
+    if v == value then
+      return true
+    end
+  end
+  return false
+end
+
 local function hexdump(str)
   local len = string.len(str)
   local dump = ""
@@ -771,6 +784,7 @@ local module = {
   repeated_read_cmd = repeated_read_cmd,
   shallowcopy = shallowcopy,
   sleep = sleep,
+  table_contains = table_contains,
   table_flatten = table_flatten,
   tmpname = tmpname,
   uname = uname,


### PR DESCRIPTION
We already do this for _invalid_ async requests #9300.
Now we also do it for failed invocation of valid requests.