### PR TITLE
windows: float config changes

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1003,7 +1003,8 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///
 /// For a general overview of floats, see |api-floatwin|.
 ///
-/// Exactly one of `external` and `relative` must be specified.
+/// Exactly one of `external` and `relative` must be specified. The `width` and
+/// `height` of the new window must be specified.
 ///
 /// With editor positioning row=0, col=0 refers to the top-left corner of the
 /// screen-grid and row=Lines-1, Columns-1 refers to the bottom-right corner.
@@ -1035,7 +1036,7 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///      - "SW" south-west
 ///      - "SE" south-east
 ///   - `height`: window height (in character cells). Minimum of 1.
-///   - `width`: window width (in character cells). Minimum of 2.
+///   - `width`: window width (in character cells). Minimum of 1.
 ///   - `row`: row position. Screen cell height are used as unit. Can be
 ///       floating point.
 ///   - `col`: column position. Screen cell width is used as unit. Can be

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -363,7 +363,7 @@ void update_screen(int type)
     need_wait_return = FALSE;
   }
 
-  if (type >= NOT_VALID) {
+  if (type >= CLEAR || !default_grid.valid) {
     ui_comp_set_screen_valid(false);
   }
   win_ui_flush_positions();


### PR DESCRIPTION
- Allow floating windows of width 1. #9846
- For a new floating window the size must be specified. Later on we might try to calculate a reasonable size by buffer contents
- Remember the configured size of a window, just like its position.
- Make get_config and set_config more consistent. Handle `relative=''` properly in set_config. get_config doesn't return keys that don't make sense for a non-floating window.
- Don't use width=0 for non-changed width, just omit the key.