### PR TITLE
[RFC] vim-patch:8.0.{761,776,1093,1112}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1412,7 +1412,7 @@ v:beval_text	The text under or after the mouse pointer.  Usually a word as
 		but a dot and "->" before the position is included.  When on a
 		']' the text before it is used, including the matching '[' and
 		word before it.  When on a Visual area within one line the
-		highlighted text is used.
+		highlighted text is used.  Also see |<cexpr>|.
 		Only valid while evaluating the 'balloonexpr' option.
 
 					*v:beval_winnr* *beval_winnr-variable*
@@ -3270,7 +3270,7 @@ escape({string}, {chars})				*escape()*
 			:echo escape('c:\program files\vim', ' \')
 <		results in: >
 			c:\\program\ files\\vim
-<		Also see |shellescape()|.
+<		Also see |shellescape()| and |fnameescape()|.
 
 							*eval()*
 eval({string})	Evaluate {string} and return the result.  Especially useful to
@@ -3680,7 +3680,7 @@ float2nr({expr})					*float2nr()*
 		When the value of {expr} is out of range for a |Number| the
 		result is truncated to 0x7fffffff or -0x7fffffff (or when
 		64-bit Number support is enabled, 0x7fffffffffffffff or
-		-0x7fffffffffffffff.  NaN results in -0x80000000 (or when
+		-0x7fffffffffffffff).  NaN results in -0x80000000 (or when
 		64-bit Number support is enabled, -0x8000000000000000).
 		Examples: >
 			echo float2nr(3.95)
@@ -6933,6 +6933,7 @@ setline({lnum}, {text})					*setline()*
 			:for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
 			:  call setline(n, l)
 			:endfor
+
 <		Note: The '[ and '] marks are not set.
 
 setloclist({nr}, {list} [, {action}[, {what}]])		*setloclist()*
@@ -7137,16 +7138,17 @@ setreg({regname}, {value} [, {options}])
 			:call setreg('a', "1\n2\n3", 'b5')
 
 <		This example shows using the functions to save and restore a
-		register (note: you may not reliably restore register value
-		without using the third argument to |getreg()| as without it
-		newlines are represented as newlines AND Nul bytes are
-		represented as newlines as well, see |NL-used-for-Nul|). >
+		register: >
 			:let var_a = getreg('a', 1, 1)
 			:let var_amode = getregtype('a')
 			    ....
 			:call setreg('a', var_a, var_amode)
+<		Note: you may not reliably restore register value
+		without using the third argument to |getreg()| as without it
+		newlines are represented as newlines AND Nul bytes are
+		represented as newlines as well, see |NL-used-for-Nul|.
 
-<		You can also change the type of a register by appending
+		You can also change the type of a register by appending
 		nothing: >
 			:call setreg('a', '', 'al')
 
@@ -8343,7 +8345,7 @@ win_getid([{win} [, {tab}]])				*win_getid()*
 		Get the |window-ID| for the specified window.
 		When {win} is missing use the current window.
 		With {win} this is the window number.  The top window has
-		number 1.
+		number 1.  Use `win_getid(winnr())` for the current window.
 		Without {tab} use the current tab, otherwise the tab with
 		number {tab}.  The first tab has number one.
 		Return zero if the window cannot be found.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5142,6 +5142,55 @@ bool bt_help(const buf_T *const buf)
   return buf != NULL && buf->b_help;
 }
 
+// Return true if "buf" is the quickfix buffer.
+bool bt_quickfix(const buf_T *const buf)
+{
+  return buf != NULL && buf->b_p_bt[0] == 'q';
+}
+
+// Return true if "buf" is a terminal buffer.
+bool bt_terminal(const buf_T *const buf)
+{
+  return buf != NULL && buf->b_p_bt[0] == 't';
+}
+
+// Return true if "buf" is a "nofile", "acwrite" or "terminal" buffer.
+// This means the buffer name is not a file name.
+bool bt_nofile(const buf_T *const buf)
+{
+  return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
+                         || buf->b_p_bt[0] == 'a' || buf->terminal);
+}
+
+// Return true if "buf" is a "nowrite", "nofile" or "terminal" buffer.
+bool bt_dontwrite(const buf_T *const buf)
+{
+  return buf != NULL && (buf->b_p_bt[0] == 'n' || buf->terminal);
+}
+
+bool bt_dontwrite_msg(const buf_T *const buf)
+{
+  if (bt_dontwrite(buf)) {
+    EMSG(_("E382: Cannot write, 'buftype' option is set"));
+    return true;
+  }
+  return false;
+}
+
+// Return true if the buffer should be hidden, according to 'hidden', ":hide"
+// and 'bufhidden'.
+bool buf_hide(const buf_T *const buf)
+{
+  // 'bufhidden' overrules 'hidden' and ":hide", check it first
+  switch (buf->b_p_bh[0]) {
+  case 'u':                         // "unload"
+  case 'w':                         // "wipe"
+  case 'd': return false;           // "delete"
+  case 'h': return true;            // "hide"
+  }
+  return p_hid || cmdmod.hide;
+}
+
 /*
  * Return special buffer name.
  * Returns NULL when the buffer has a normal file name.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10065,7 +10065,7 @@ static void get_qf_loc_list(int is_qf, win_T *wp, typval_T *what_arg,
         dict_T *d = what_arg->vval.v_dict;
 
         if (d != NULL) {
-          get_errorlist_properties(wp, d, rettv->vval.v_dict);
+          qf_get_properties(wp, d, rettv->vval.v_dict);
         }
       } else {
         EMSG(_(e_dictreq));

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6920,10 +6920,11 @@ static void ex_resize(exarg_T *eap)
       n = 9999;
     win_setwidth_win(n, wp);
   } else {
-    if (*eap->arg == '-' || *eap->arg == '+')
+    if (*eap->arg == '-' || *eap->arg == '+') {
       n += curwin->w_height;
-    else if (n == 0 && eap->arg[0] == NUL)      /* default is very wide */
+    } else if (n == 0 && eap->arg[0] == NUL) {  // default is very high
       n = 9999;
+    }
     win_setheight_win(n, wp);
   }
 }

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -16,11 +16,10 @@
 #include <inttypes.h>
 #include <fcntl.h>
 
-#include "nvim/vim.h"
+#include "nvim/buffer.h"
 #include "nvim/ascii.h"
 #include "nvim/if_cscope.h"
 #include "nvim/charset.h"
-#include "nvim/eval.h"
 #include "nvim/fileio.h"
 #include "nvim/message.h"
 #include "nvim/memory.h"
@@ -29,7 +28,6 @@
 #include "nvim/quickfix.h"
 #include "nvim/strings.h"
 #include "nvim/tag.h"
-#include "nvim/window.h"
 #include "nvim/os/os.h"
 #include "nvim/os/input.h"
 #include "nvim/event/stream.h"

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3174,6 +3174,12 @@ int bt_quickfix(const buf_T *const buf)
   return buf != NULL && buf->b_p_bt[0] == 'q';
 }
 
+// Return true if "buf" is a terminal buffer.
+bool bt_terminal(const buf_T *buf)
+{
+  return buf != NULL && buf->b_p_bt[0] == 't';
+}
+
 // Return TRUE if "buf" is a "nofile", "acwrite" or "terminal" buffer.
 // This means the buffer name is not a file name.
 int bt_nofile(buf_T *buf)

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3167,59 +3167,6 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
 }
 
 /*
- * Return TRUE if "buf" is the quickfix buffer.
- */
-int bt_quickfix(const buf_T *const buf)
-{
-  return buf != NULL && buf->b_p_bt[0] == 'q';
-}
-
-// Return true if "buf" is a terminal buffer.
-bool bt_terminal(const buf_T *buf)
-{
-  return buf != NULL && buf->b_p_bt[0] == 't';
-}
-
-// Return TRUE if "buf" is a "nofile", "acwrite" or "terminal" buffer.
-// This means the buffer name is not a file name.
-int bt_nofile(buf_T *buf)
-{
-  return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
-                         || buf->b_p_bt[0] == 'a' || buf->terminal);
-}
-
-// Return TRUE if "buf" is a "nowrite", "nofile" or "terminal" buffer.
-int bt_dontwrite(buf_T *buf)
-{
-  return buf != NULL && (buf->b_p_bt[0] == 'n' || buf->terminal);
-}
-
-int bt_dontwrite_msg(buf_T *buf)
-{
-  if (bt_dontwrite(buf)) {
-    EMSG(_("E382: Cannot write, 'buftype' option is set"));
-    return TRUE;
-  }
-  return FALSE;
-}
-
-/*
- * Return TRUE if the buffer should be hidden, according to 'hidden', ":hide"
- * and 'bufhidden'.
- */
-int buf_hide(buf_T *buf)
-{
-  /* 'bufhidden' overrules 'hidden' and ":hide", check it first */
-  switch (buf->b_p_bh[0]) {
-  case 'u':                         /* "unload" */
-  case 'w':                         /* "wipe" */
-  case 'd': return FALSE;           /* "delete" */
-  case 'h': return TRUE;            /* "hide" */
-  }
-  return p_hid || cmdmod.hide;
-}
-
-/*
  * Return TRUE when using ":vimgrep" for ":grep".
  */
 int grep_internal(cmdidx_T cmdidx)

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -430,6 +430,19 @@ func Xtest_browse(cchar)
 
   call delete('Xqftestfile1')
   call delete('Xqftestfile2')
+
+  " Should be able to use next/prev with invalid entries
+  Xexpr ""
+  call assert_equal(0, g:Xgetlist({'idx' : 0}).idx)
+  call assert_equal(0, g:Xgetlist({'size' : 0}).size)
+  Xaddexpr ['foo', 'bar', 'baz', 'quux', 'shmoo']
+  call assert_equal(5, g:Xgetlist({'size' : 0}).size)
+  Xlast
+  call assert_equal(5, g:Xgetlist({'idx' : 0}).idx)
+  Xfirst
+  call assert_equal(1, g:Xgetlist({'idx' : 0}).idx)
+  2Xnext
+  call assert_equal(3, g:Xgetlist({'idx' : 0}).idx)
 endfunc
 
 func Test_browse()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -469,6 +469,19 @@ func s:test_xhelpgrep(cchar)
   " This wipes out the buffer, make sure that doesn't cause trouble.
   Xclose
 
+  if a:cchar == 'l'
+      " When a help window is present, running :lhelpgrep should reuse the
+      " help window and not the current window
+      new | only
+      call g:Xsetlist([], 'f')
+      help index.txt
+      wincmd w
+      lhelpgrep quickfix
+      call assert_equal(1, winnr())
+      call assert_notequal([], getloclist(1))
+      call assert_equal([], getloclist(2))
+  endif
+
   new | only
 
   " Search for non existing help string
@@ -1666,6 +1679,10 @@ func HistoryTest(cchar)
   call assert_equal('  error list 1 of 3; 1 ' . common, res[0])
   call assert_equal('  error list 2 of 3; 2 ' . common, res[1])
   call assert_equal('> error list 3 of 3; 3 ' . common, res[2])
+
+  call g:Xsetlist([], 'f')
+  let l = split(execute(a:cchar . 'hist'), "\n")
+  call assert_equal('No entries', l[0])
 endfunc
 
 func Test_history()
@@ -1844,6 +1861,11 @@ func Xproperty_tests(cchar)
     let l = g:Xgetlist({'items':1})
     call assert_equal(0, len(l.items))
 
+    call g:Xsetlist([], 'r', {'title' : 'TestTitle'})
+    call g:Xsetlist([], 'r', {'items' : [{'filename' : 'F1', 'lnum' : 10, 'text' : 'L10'}]})
+    call g:Xsetlist([], 'r', {'items' : [{'filename' : 'F1', 'lnum' : 10, 'text' : 'L10'}]})
+    call assert_equal('TestTitle', g:Xgetlist({'title' : 1}).title)
+
     " The following used to crash Vim with address sanitizer
     call g:Xsetlist([], 'f')
     call g:Xsetlist([], 'a', {'items' : [{'filename':'F1', 'lnum':10}]})
@@ -1886,10 +1908,10 @@ func Xproperty_tests(cchar)
     call g:Xsetlist([], 'r', l2)
     let newl1=g:Xgetlist({'nr':1,'all':1})
     let newl2=g:Xgetlist({'nr':2,'all':1})
-    call assert_equal(':Fruits', newl1.title)
+    call assert_equal('Fruits', newl1.title)
     call assert_equal(['Fruits'], newl1.context)
     call assert_equal('Line20', newl1.items[0].text)
-    call assert_equal(':Colors', newl2.title)
+    call assert_equal('Colors', newl2.title)
     call assert_equal(['Colors'], newl2.context)
     call assert_equal('Line10', newl2.items[0].text)
     call g:Xsetlist([], 'f')

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -83,13 +83,11 @@
 #include <string.h>
 #include <fcntl.h>
 
-#include "nvim/vim.h"
+#include "nvim/buffer.h"
 #include "nvim/ascii.h"
 #include "nvim/undo.h"
-#include "nvim/macros.h"
 #include "nvim/cursor.h"
 #include "nvim/edit.h"
-#include "nvim/eval.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
 #include "nvim/buffer_updates.h"
@@ -102,8 +100,6 @@
 #include "nvim/option.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
-#include "nvim/quickfix.h"
-#include "nvim/screen.h"
 #include "nvim/sha256.h"
 #include "nvim/state.h"
 #include "nvim/strings.h"


### PR DESCRIPTION
**vim-patch:8.0.0761: options not set properly for a terminal buffer**
Problem:    Options of a buffer for a terminal window are not set properly.
Solution:   Add "terminal" value for 'buftype'.  Make 'buftype' and
            'bufhidden' not depend on the quickfix feature.
            Also set the buffer name and show "running" or "finished" in the
            window title.
vim/vim@1f2903c

**vim-patch:8.0.0776: function prototypes missing without the quickfix feature**
Problem:    Function prototypes missing without the quickfix feature. (Tony
            Mechelynck)
Solution:   Move non-quickfix functions to buffer.c.
vim/vim@f0a521f

**vim-patch:8.0.1093: various small quickfix issues**
Problem:    Various small quickfix issues.
Solution:   Remove ":" prefix from title set by a user. Add the qf_id2nr().
            function. Add a couple more tests.  Update documentation.
            (Yegappan Lakshmanan)
vim/vim@b4d5fba

**vim-patch:8.0.1112: can't get size or current index from quickfix list**
Problem:    Can't get size or current index from quickfix list.
Solution:   Add "idx" and "size" options. (Yegappan Lakshmanan)
vim/vim@fc2b270