### PR TITLE
[RFC] vim-patch:8.0.{647,768,797,1085,1092,1107,1133,1408}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4528,10 +4528,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 'redrawtime' 'rdt'	number	(default 2000)
 			global
 	Time in milliseconds for redrawing the display.  Applies to
-	'hlsearch', 'inccommand' and |:match| highlighting.
+	'hlsearch', 'inccommand', |:match| highlighting and syntax
+	highlighting.
 	When redrawing takes more than this many milliseconds no further
-	matches will be highlighted.  This is used to avoid that Vim hangs
-	when using a very complicated pattern.
+	matches will be highlighted.
+	For syntax highlighting the time applies per window.  When over the
+	limit syntax highlighting is disabled until |CTRL-L| is used.
+	This is used to avoid that Vim hangs when using a very complicated
+	pattern.
 
 						*'regexpengine'* *'re'*
 'regexpengine' 're'	number	(default 0)

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5211,8 +5211,8 @@ char_u *buf_spname(buf_T *buf)
       return (char_u *)_(msg_qflist);
     }
   }
-  /* There is no _file_ when 'buftype' is "nofile", b_sfname
-   * contains the name as specified by the user */
+  // There is no _file_ when 'buftype' is "nofile", b_sfname
+  // contains the name as specified by the user.
   if (bt_nofile(buf)) {
     if (buf->b_sfname != NULL) {
       return buf->b_sfname;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -388,25 +388,25 @@ typedef struct {
  * a window may have its own instance.
  */
 typedef struct {
-  hashtab_T b_keywtab;                  /* syntax keywords hash table */
-  hashtab_T b_keywtab_ic;               /* idem, ignore case */
-  int b_syn_error;                      /* TRUE when error occurred in HL */
+  hashtab_T b_keywtab;                  // syntax keywords hash table
+  hashtab_T b_keywtab_ic;               // idem, ignore case
+  int b_syn_error;                      // TRUE when error occurred in HL
   bool b_syn_slow;                      // true when 'redrawtime' reached
-  int b_syn_ic;                         /* ignore case for :syn cmds */
-  int b_syn_spell;                      /* SYNSPL_ values */
-  garray_T b_syn_patterns;              /* table for syntax patterns */
-  garray_T b_syn_clusters;              /* table for syntax clusters */
-  int b_spell_cluster_id;               /* @Spell cluster ID or 0 */
-  int b_nospell_cluster_id;             /* @NoSpell cluster ID or 0 */
-  int b_syn_containedin;                /* TRUE when there is an item with a
-                                           "containedin" argument */
-  int b_syn_sync_flags;                 /* flags about how to sync */
-  short b_syn_sync_id;                  /* group to sync on */
-  long b_syn_sync_minlines;             /* minimal sync lines offset */
-  long b_syn_sync_maxlines;             /* maximal sync lines offset */
-  long b_syn_sync_linebreaks;           /* offset for multi-line pattern */
-  char_u      *b_syn_linecont_pat;      /* line continuation pattern */
-  regprog_T   *b_syn_linecont_prog;     /* line continuation program */
+  int b_syn_ic;                         // ignore case for :syn cmds
+  int b_syn_spell;                      // SYNSPL_ values
+  garray_T b_syn_patterns;              // table for syntax patterns
+  garray_T b_syn_clusters;              // table for syntax clusters
+  int b_spell_cluster_id;               // @Spell cluster ID or 0
+  int b_nospell_cluster_id;             // @NoSpell cluster ID or 0
+  int b_syn_containedin;                // TRUE when there is an item with a
+                                        // "containedin" argument
+  int b_syn_sync_flags;                 // flags about how to sync
+  int16_t b_syn_sync_id;                // group to sync on
+  long b_syn_sync_minlines;             // minimal sync lines offset
+  long b_syn_sync_maxlines;             // maximal sync lines offset
+  long b_syn_sync_linebreaks;           // offset for multi-line pattern
+  char_u      *b_syn_linecont_pat;      // line continuation pattern
+  regprog_T   *b_syn_linecont_prog;     // line continuation program
   syn_time_T b_syn_linecont_time;
   int b_syn_linecont_ic;                /* ignore-case flag for above */
   int b_syn_topgrp;                     /* for ":syntax include" */

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -391,6 +391,7 @@ typedef struct {
   hashtab_T b_keywtab;                  /* syntax keywords hash table */
   hashtab_T b_keywtab_ic;               /* idem, ignore case */
   int b_syn_error;                      /* TRUE when error occurred in HL */
+  bool b_syn_slow;                      // true when 'redrawtime' reached
   int b_syn_ic;                         /* ignore case for :syn cmds */
   int b_syn_spell;                      /* SYNSPL_ values */
   garray_T b_syn_patterns;              /* table for syntax patterns */

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4642,6 +4642,9 @@ static void nv_clear(cmdarg_T *cap)
   if (!checkclearop(cap->oap)) {
     /* Clear all syntax states to force resyncing. */
     syn_stack_free_all(curwin->w_s);
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      wp->w_s->b_syn_slow = false;
+    }
     redraw_later(CLEAR);
   }
 }

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -7224,7 +7224,8 @@ static void report_re_switch(char_u *pat)
 /// @param nl
 ///
 /// @return TRUE if there is a match, FALSE if not.
-static int vim_regexec_string(regmatch_T *rmp, char_u *line, colnr_T col, bool nl)
+static int vim_regexec_string(regmatch_T *rmp, char_u *line, colnr_T col,
+                              bool nl)
 {
   regexec_T rex_save;
   bool rex_in_use_save = rex_in_use;
@@ -7273,7 +7274,7 @@ static int vim_regexec_string(regmatch_T *rmp, char_u *line, colnr_T col, bool n
 int vim_regexec_prog(regprog_T **prog, bool ignore_case, char_u *line,
                       colnr_T col)
 {
-  regmatch_T regmatch = {.regprog = *prog, .rm_ic = ignore_case};
+  regmatch_T regmatch = { .regprog = *prog, .rm_ic = ignore_case };
   int r = vim_regexec_string(&regmatch, line, col, false);
   *prog = regmatch.regprog;
   return r;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -5098,8 +5098,6 @@ static int regmatch(
         printf("Premature EOL\n");
 #endif
       }
-      if (status == RA_FAIL)
-        got_int = TRUE;
       return status == RA_MATCH;
     }
 
@@ -7226,7 +7224,7 @@ static void report_re_switch(char_u *pat)
 /// @param nl
 ///
 /// @return TRUE if there is a match, FALSE if not.
-static int vim_regexec_both(regmatch_T *rmp, char_u *line, colnr_T col, bool nl)
+static int vim_regexec_string(regmatch_T *rmp, char_u *line, colnr_T col, bool nl)
 {
   regexec_T rex_save;
   bool rex_in_use_save = rex_in_use;
@@ -7276,7 +7274,7 @@ int vim_regexec_prog(regprog_T **prog, bool ignore_case, char_u *line,
                       colnr_T col)
 {
   regmatch_T regmatch = {.regprog = *prog, .rm_ic = ignore_case};
-  int r = vim_regexec_both(&regmatch, line, col, false);
+  int r = vim_regexec_string(&regmatch, line, col, false);
   *prog = regmatch.regprog;
   return r;
 }
@@ -7285,7 +7283,7 @@ int vim_regexec_prog(regprog_T **prog, bool ignore_case, char_u *line,
 // Return TRUE if there is a match, FALSE if not.
 int vim_regexec(regmatch_T *rmp, char_u *line, colnr_T col)
 {
-  return vim_regexec_both(rmp, line, col, false);
+  return vim_regexec_string(rmp, line, col, false);
 }
 
 // Like vim_regexec(), but consider a "\n" in "line" to be a line break.
@@ -7293,7 +7291,7 @@ int vim_regexec(regmatch_T *rmp, char_u *line, colnr_T col)
 // Return TRUE if there is a match, FALSE if not.
 int vim_regexec_nl(regmatch_T *rmp, char_u *line, colnr_T col)
 {
-  return vim_regexec_both(rmp, line, col, true);
+  return vim_regexec_string(rmp, line, col, true);
 }
 
 /// Match a regexp against multiple lines.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4831,13 +4831,13 @@ static void win_redr_status(win_T *wp)
     p = NameBuff;
     len = (int)STRLEN(p);
 
-    if (wp->w_buffer->b_help
+    if (bt_help(wp->w_buffer)
         || wp->w_p_pvw
         || bufIsChanged(wp->w_buffer)
         || wp->w_buffer->b_p_ro) {
       *(p + len++) = ' ';
     }
-    if (wp->w_buffer->b_help) {
+    if (bt_help(wp->w_buffer)) {
       STRCPY(p + len, _("[Help]"));
       len += (int)STRLEN(p + len);
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1137,6 +1137,7 @@ static void win_update(win_T *wp)
   got_int = 0;
   // Set the time limit to 'redrawtime'.
   proftime_T syntax_tm = profile_setlimit(p_rdt);
+  syn_set_timeout(&syntax_tm);
   win_foldinfo.fi_level = 0;
 
   /*
@@ -1364,8 +1365,7 @@ static void win_update(win_T *wp)
         /*
          * Display one line.
          */
-        row = win_line(wp, lnum, srow, wp->w_grid.Rows, mod_top == 0, false,
-                       &syntax_tm);
+        row = win_line(wp, lnum, srow, wp->w_grid.Rows, mod_top == 0, false);
 
         wp->w_lines[idx].wl_folded = FALSE;
         wp->w_lines[idx].wl_lastlnum = lnum;
@@ -1396,8 +1396,7 @@ static void win_update(win_T *wp)
         if (fold_count != 0) {
           fold_line(wp, fold_count, &win_foldinfo, lnum, row);
         } else {
-          (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true,
-                         &syntax_tm);
+          (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
         }
       }
 
@@ -1497,6 +1496,7 @@ static void win_update(win_T *wp)
   if (wp->w_redr_type >= REDRAW_TOP) {
     draw_vsep_win(wp, 0);
   }
+  syn_set_timeout(NULL);
 
   /* Reset the type of redrawing required, the window has been updated. */
   wp->w_redr_type = 0;
@@ -2045,8 +2045,7 @@ win_line (
     int startrow,
     int endrow,
     bool nochange,                    // not updating for changed text
-    bool number_only,                 // only update the number column
-    proftime_T *syntax_tm
+    bool number_only                  // only update the number column
 )
 {
   int c = 0;                          // init for GCC
@@ -2199,7 +2198,7 @@ win_line (
       // error, stop syntax highlighting.
       save_did_emsg = did_emsg;
       did_emsg = false;
-      syntax_start(wp, lnum, syntax_tm);
+      syntax_start(wp, lnum);
       if (did_emsg) {
         wp->w_s->b_syn_error = true;
       } else {
@@ -2548,7 +2547,7 @@ win_line (
 
       // Need to restart syntax highlighting for this line.
       if (has_syntax) {
-        syntax_start(wp, lnum, syntax_tm);
+        syntax_start(wp, lnum);
       }
     }
   }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1364,7 +1364,8 @@ static void win_update(win_T *wp)
         /*
          * Display one line.
          */
-        row = win_line(wp, lnum, srow, wp->w_grid.Rows, mod_top == 0, false, &syntax_tm);
+        row = win_line(wp, lnum, srow, wp->w_grid.Rows, mod_top == 0, false,
+                       &syntax_tm);
 
         wp->w_lines[idx].wl_folded = FALSE;
         wp->w_lines[idx].wl_lastlnum = lnum;
@@ -1395,7 +1396,8 @@ static void win_update(win_T *wp)
         if (fold_count != 0) {
           fold_line(wp, fold_count, &win_foldinfo, lnum, row);
         } else {
-          (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true, &syntax_tm);
+          (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true,
+                         &syntax_tm);
         }
       }
 
@@ -2544,7 +2546,7 @@ win_line (
       }
       wp->w_cursor = pos;
 
-      /* Need to restart syntax highlighting for this line. */
+      // Need to restart syntax highlighting for this line.
       if (has_syntax) {
         syntax_start(wp, lnum, syntax_tm);
       }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -356,16 +356,16 @@ static reg_extmatch_T *next_match_extmatch = NULL;
  * The current state (within the line) of the recognition engine.
  * When current_state.ga_itemsize is 0 the current state is invalid.
  */
-static win_T    *syn_win;               /* current window for highlighting */
-static buf_T    *syn_buf;               /* current buffer for highlighting */
-static synblock_T *syn_block;           /* current buffer for highlighting */
+static win_T    *syn_win;               // current window for highlighting
+static buf_T    *syn_buf;               // current buffer for highlighting
+static synblock_T *syn_block;           // current buffer for highlighting
 static proftime_T *syn_tm;
-static linenr_T current_lnum = 0;       /* lnum of current state */
-static colnr_T current_col = 0;         /* column of current state */
-static int current_state_stored = 0;      /* TRUE if stored current state
-                                           * after setting current_finished */
-static int current_finished = 0;        /* current line has been finished */
-static garray_T current_state           /* current stack of state_items */
+static linenr_T current_lnum = 0;       // lnum of current state
+static colnr_T current_col = 0;         // column of current state
+static int current_state_stored = 0;    // TRUE if stored current state
+                                        // after setting current_finished
+static int current_finished = 0;        // current line has been finished
+static garray_T current_state           // current stack of state_items
   = GA_EMPTY_INIT_VALUE;
 static int16_t *current_next_list = NULL;   // when non-zero, nextgroup list
 static int current_next_flags = 0;          // flags for current_next_list
@@ -5764,7 +5764,7 @@ int syn_get_foldlevel(win_T *wp, long lnum)
 {
   int level = 0;
 
-  /* Return quickly when there are no fold items at all. */
+  // Return quickly when there are no fold items at all.
   if (wp->w_s->b_syn_folditems != 0
       && !wp->w_s->b_syn_error
       && !wp->w_s->b_syn_slow) {

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1379,6 +1379,11 @@ func XquickfixSetListWithAct(cchar)
   call assert_fails("call g:Xsetlist(list1, 0)", 'E928:')
 endfunc
 
+func Test_setqflist_invalid_nr()
+  " The following command used to crash Vim
+  call setqflist([], ' ', {'nr' : $XXX_DOES_NOT_EXIST})
+endfunc
+
 func Test_quickfix_set_list_with_act()
   call XquickfixSetListWithAct('c')
   call XquickfixSetListWithAct('l')
@@ -2647,6 +2652,15 @@ endfunc
 func Test_qf_id()
   call Xqfid_tests('c')
   call Xqfid_tests('l')
+endfunc
+
+func Test_getqflist_invalid_nr()
+  " The following commands used to crash Vim
+  cexpr ""
+  call getqflist({'nr' : $XXX_DOES_NOT_EXIST_XXX})
+
+  " Cleanup
+  call setqflist([], 'r')
 endfunc
 
 " Test for shortening/simplifying the file name when opening the

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -503,3 +503,37 @@ func Test_syn_wrong_z_one()
   " call test_override("ALL", 0)
   bwipe!
 endfunc
+
+func Test_syntax_hangs()
+  if !has('reltime') || !has('float') || !has('syntax')
+    return
+  endif
+
+  " This pattern takes a long time to match, it should timeout.
+  new
+  call setline(1, ['aaa', repeat('abc ', 1000), 'ccc'])
+  let start = reltime()
+  set nolazyredraw redrawtime=101
+  syn match Error /\%#=1a*.*X\@<=b*/
+  redraw
+  let elapsed = reltimefloat(reltime(start))
+  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed < 1.0)
+
+  " second time syntax HL is disabled
+  let start = reltime()
+  redraw
+  let elapsed = reltimefloat(reltime(start))
+  call assert_true(elapsed < 0.1)
+
+  " after CTRL-L the timeout flag is reset
+  let start = reltime()
+  exe "normal \<C-L>"
+  redraw
+  let elapsed = reltimefloat(reltime(start))
+  call assert_true(elapsed > 0.1)
+  call assert_true(elapsed < 1.0)
+
+  set redrawtime&
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.0.0647: syntax highlighting can make cause a freeze**
Problem:    Syntax highlighting can make cause a freeze.
Solution:   Apply 'redrawtime' to syntax highlighting, per window.
vim/vim@06f1ed2

**vim-patch:8.0.0768: terminal window status shows "[Scratch]"**
Problem:    Terminal window status shows "[Scratch]".
Solution:   Show "[Terminal]" when no title was set. (Yasuhiro Matsumoto)
            Store the terminal title that vterm sends and use it.  Update the
            special buffer name.  (closes vim/vim#1869)
vim/vim@2155441

**vim-patch:8.0.0797: finished job in terminal window is not handled**
Problem:    Finished job in terminal window is not handled.
Solution:   Add the scrollback buffer.  Use it to fill the buffer when the job
            has ended.
vim/vim@d85f271

**vim-patch:8.0.1085: terminal debugger can't set breakpoints**
Problem:    The terminal debugger can't set breakpoints.
Solution:   Add :Break and :Delete commands.  Also commands for stepping
            through code.
vim/vim@e09ba7b

**vim-patch:8.0.1092: terminal debugger can't evaluate expressions**
Problem:    Terminal debugger can't evaluate expressions.
Solution:   Add :Evaluate and K.  Various other improvements.
vim/vim@45d5f26

**vim-patch:8.0.1107: terminal debugger jumps to non-existing file**
Problem:    Terminal debugger jumps to non-existing file.
Solution:   Check that the file exists.  Add an option to make the Vim wide
            wide. Fix removing highlight groups.
vim/vim@38baa3e

**vim-patch:8.0.1133: syntax timeout not used correctly**
Problem:    Syntax timeout not used correctly.
Solution:   Do not pass the timeout to syntax_start() but set it explicitly.
            (Yasuhiro Matsumoto, closes vim/vim#2139)
vim/vim@f3d769a

**vim-patch:8.0.1408: crash in setqflist()**
Problem:    Crash in setqflist().
Solution:   Check for string to be NULL. (Dominique Pelle, closes vim/vim#2464)
vim/vim@a0ca7d0

Retry of #8662
~~Will followup with [vim-patch:8.0.1133]~~ Done. (https://github.com/vim/vim/commit/f3d769a585040ac47f7054057758809024ef6377). `+toolbar` is N/A, right?