### PR TITLE
vim-patch:8.0.0716: "--clean", 'shadafile'

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -199,6 +199,8 @@ do not read or write a ShaDa file.
 Skip loading plugins.
 Implied by
 .Cm -u NONE .
+.It Fl -clean
+Skip loading plugins and shada (viminfo) file.
 .It Fl o Ns Op Ar N
 Open
 .Ar N

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -62,6 +62,7 @@ Options ~
 *'langnoremap'*		Deprecated alias to 'nolangremap'.
 *'vi'*
 *'viminfo'*		Deprecated alias to 'shada' option.
+*'viminfofile'*		Deprecated alias to 'shadafile' option.
 
 UI extensions~
 *ui-wildmenu*		Use `ext_cmdline` and `ext_popupmenu` instead.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5044,6 +5044,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
+				*'shadafile'* *'sdf'*
+'shadafile' 'vif'	string	(default: "")
+			global
+	When non-empty, overrides the file name used for |shada| (viminfo).
+	When equal to "NONE" no shada file will be read or written.
+	This option can be set with the |-i| command line flag.  The |--clean|
+	command line flag sets it to "NONE".
+
 						*'shell'* *'sh'* *E91*
 'shell' 'sh'		string	(default $SHELL or "sh",
 					Windows: "cmd.exe")
@@ -6409,14 +6417,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"slash" and "unix" are useful on Windows when sharing view files
 	with Unix.  The Unix version of Vim cannot source dos format scripts,
 	but the Windows version of Vim can source unix format scripts.
-
-				*'shadafile'* *'sdf'*
-'shadafile' 'vif'	string	(default: "")
-			global
-	When non-empty, overrides the file name used for |shada| (viminfo).
-	When equal to "NONE" no shada file will be read or written.
-	This option can be set with the |-i| command line flag.  The |--clean|
-	command line flag sets it to "NONE".
 
 					    *'virtualedit'* *'ve'*
 'virtualedit' 've'	string	(default "")

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5000,9 +5000,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		has been used since the last search command.
 							*shada-n*
 	n	Name of the shada file.  The name must immediately follow
-		the 'n'.  Must be at the end of the option!  If the "-i"
-		argument was given when starting Vim, that file name overrides
-		the one given here with 'shada'.  Environment variables are
+		the 'n'.  Must be at the end of the option!  If the
+		'shadafile' option is set, that file name overrides the one
+		given here with 'shada'.  Environment variables are
 		expanded when opening the file, not when setting the option.
 							*shada-r*
 	r	Removable media.  The argument is a string (up to the next
@@ -5822,7 +5822,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	Watch out for errors in expressions.  They may render Vim unusable!
 	If you are stuck, hold down ':' or 'Q' to get a prompt, then quit and
-	edit your vimrc or whatever with "vim -u NONE" to get it right.
+	edit your vimrc or whatever with "vim --clean" to get it right.
 
 	Examples:
 	Emulate standard status line with 'ruler' set >
@@ -6409,6 +6409,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"slash" and "unix" are useful on Windows when sharing view files
 	with Unix.  The Unix version of Vim cannot source dos format scripts,
 	but the Windows version of Vim can source unix format scripts.
+
+				*'shadafile'* *'sdf'*
+'shadafile' 'vif'	string	(default: "")
+			global
+	When non-empty, overrides the file name used for |shada| (viminfo).
+	When equal to "NONE" no shada file will be read or written.
+	This option can be set with the |-i| command line flag.  The |--clean|
+	command line flag sets it to "NONE".
 
 					    *'virtualedit'* *'ve'*
 'virtualedit' 've'	string	(default "")

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -86,6 +86,11 @@ argument.
 		|:version| command.
 		See |info-message| about capturing the text.
 
+							*--clean*
+--clean		Equivalent to "-u NONE -i NONE":
+		- Skips initializations from files and environment variables.
+		- No 'shada' file is read or written.
+
 							*--noplugin*
 --noplugin	Skip loading plugins.  Resets the 'loadplugins' option.
 		Note that the |-u| argument may also disable loading plugins:
@@ -295,19 +300,21 @@ argument.
 
 							*-u* *E282*
 -u {vimrc}	The file {vimrc} is read for initializations.  Most other
-		initializations are skipped; see |initialization|.  This can
-		be used to start Vim in a special mode, with special
+		initializations are skipped; see |initialization|.
+
+		This can be used to start Vim in a special mode, with special
 		mappings and settings.  A shell alias can be used to make
 		this easy to use.  For example: >
 			alias vimc vim -u ~/.config/nvim/c_init.vim !*
 <		Also consider using autocommands; see |autocommand|.
-		When {vimrc} is equal to "NONE" (all uppercase), all
-		initializations from files and environment variables are
-		skipped, including reading the |ginit.vim| file when the GUI
-		starts.  Plugins and syntax highlighting are also skipped.
-		When {vimrc} is equal to "NORC" (all uppercase), this has the
-		same effect as "NONE", but plugins and syntax highlighting are
-		not skipped.
+
+		When {vimrc} is "NONE" (all uppercase), all initializations
+		from files and environment variables are skipped.  Plugins and
+		syntax highlighting are also skipped.
+
+		When {vimrc} is "NORC" (all uppercase), this has the same
+		effect as "NONE", but plugins and syntax highlighting are not
+		skipped.
 
 							*-i*
 -i {shada}	The file {shada} is used instead of the default ShaDa
@@ -482,6 +489,7 @@ accordingly.  Vim proceeds in this order:
 	Loading plugins won't be done when:
 	- The 'loadplugins' option was reset in a vimrc file.
 	- The |--noplugin| command line argument is used.
+	- The |--clean| command line argument is used.
 	- The "-u NONE" command line argument is used |-u|.
 	- When Vim was compiled without the |+eval| feature.
 	Note that using "-c 'set noloadplugins'" doesn't work, because the

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -754,7 +754,6 @@ EXTERN int skip_redraw INIT(= FALSE);       /* skip redraw once */
 EXTERN int do_redraw INIT(= FALSE);         /* extra redraw once */
 
 EXTERN int need_highlight_changed INIT(= true);
-EXTERN char *used_shada_file INIT(= NULL);  // name of the ShaDa file to use
 
 EXTERN FILE *scriptout INIT(= NULL);  ///< Stream to write script to.
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -871,6 +871,9 @@ static void command_line_scan(mparm_T *parmp)
           } else if (STRNICMP(argv[0] + argv_idx, "startuptime", 11) == 0) {
             want_argument = true;
             argv_idx += 11;
+          } else if (STRNICMP(argv[0] + argv_idx, "clean", 5) == 0) {
+            parmp->use_vimrc = "NONE";
+            set_option_value("shadafile", 0L, "NONE", 0);
           } else {
             if (argv[0][argv_idx])
               mainerr(err_opt_unknown, argv[0]);
@@ -1129,7 +1132,7 @@ static void command_line_scan(mparm_T *parmp)
           }
 
           case 'i': {  // "-i {shada}" use for shada
-            used_shada_file = argv[0];
+            set_option_value("shadafile", 0L, argv[0], 0);
             break;
           }
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -630,6 +630,7 @@ EXTERN long p_ur;               ///< 'undoreload'
 EXTERN long p_uc;               ///< 'updatecount'
 EXTERN long p_ut;               ///< 'updatetime'
 EXTERN char_u *p_shada;         ///< 'shada'
+EXTERN char *p_shadafile;       ///< 'shadafile'
 EXTERN char_u *p_vdir;          ///< 'viewdir'
 EXTERN char_u *p_vop;           ///< 'viewoptions'
 EXTERN unsigned vop_flags;      ///< uses SSOP_ flags

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2015,6 +2015,15 @@ return {
       defaults={if_true={vi="", vim="!,'100,<50,s10,h"}}
     },
     {
+      full_name='shadafile', abbreviation='sdf',
+      type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
+      vi_def=true,
+      secure=true,
+      varname='p_shadafile',
+      defaults={if_true={vi=""}}
+    },
+    {
       full_name='shell', abbreviation='sh',
       type='string', scope={'global'},
       secure=true,
@@ -2631,6 +2640,15 @@ return {
       secure=true,
       varname='p_shada',
       defaults={if_true={vi="", vim="!,'100,<50,s10,h"}}
+    },
+    {
+      full_name='viminfofile', abbreviation='vif',
+      type='string', list='onecomma', scope={'global'},
+      deny_duplicates=true,
+      vi_def=true,
+      secure=true,
+      varname='p_shadafile',
+      defaults={if_true={vi=""}}
     },
     {
       full_name='virtualedit', abbreviation='ve',

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -856,13 +856,13 @@ static int msgpack_sd_writer_write(void *data, const char *buf, size_t len)
   return 0;
 }
 
-/// Check whether writing to shada file was disabled with -i NONE
+/// Check whether writing to shada file was disabled ("-i NONE" or "--clean").
 ///
 /// @return true if it was disabled, false otherwise.
 static bool shada_disabled(void)
   FUNC_ATTR_PURE
 {
-  return used_shada_file != NULL && STRCMP(used_shada_file, "NONE") == 0;
+  return strequal(p_shadafile, "NONE");
 }
 
 /// Read ShaDa file
@@ -1542,14 +1542,14 @@ static char *shada_filename(const char *file)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (file == NULL || *file == NUL) {
-    if (used_shada_file != NULL) {
-      file = used_shada_file;
+    if (p_shadafile != NULL) {
+      file = p_shadafile;
     } else {
       if ((file = find_shada_parameter('n')) == NULL || *file == NUL) {
         file =  shada_get_default_file();
       }
       // XXX It used to be one level lower, so that whatever is in
-      //     `used_shada_file` was expanded. I intentionally moved it here
+      //     `p_shadafile` was expanded. I intentionally moved it here
       //     because various expansions must have already be done by the shell.
       //     If shell is not performing them then they should be done in main.c
       //     where arguments are parsed, *not here*.


### PR DESCRIPTION
Nvim notes:
- Nvim does not support "-u DEFAULTS", that change is omitted.
- Also add 'shadafile' as an alias to 'viminfofile'.
- Deprecate 'viminfofile'.

Problem:    Not easy to start Vim cleanly without changing the viminfo file.
            Not possible to know whether the -i command line flag was used.
Solution:   Add the --clean command line argument.  Add the 'viminfofile'
            option.  Add "-u DEFAULTS".
https://github.com/vim/vim/commit/c4da113ef98dcfd6f2a088b1693c0317dcb5bf42