### PR TITLE
win/defaults: Use "…/nvim-data/site" in 'runtimepath'

### DIFF
--- a/runtime/autoload/spellfile.vim
+++ b/runtime/autoload/spellfile.vim
@@ -195,16 +195,6 @@ function! spellfile#GetDirChoices()
 endfunc
 
 function! spellfile#WritableSpellDir()
-  " Always use the $XDG_DATA_HOME/nvim/site directory
-  if exists('$XDG_DATA_HOME')
-    return $XDG_DATA_HOME . "/nvim/site/spell"
-  elseif !(has('win32') || has('win64'))
-    return $HOME . "/.local/share/nvim/site/spell"
-  endif
-  for dir in split(&rtp, ',')
-    if filewritable(dir) == 2
-      return dir . "/spell"
-    endif
-  endfor
-  return ''
+  " Always use the $XDG_DATA_HOME/…/site directory
+  return stdpath('data').'/site/spell'
 endfunction

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4663,12 +4663,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:set rulerformat=%15(%c%V\ %p%%%)
 <
 				*'runtimepath'* *'rtp'* *vimfiles*
-'runtimepath' 'rtp'	string	(default:
-					Unix: "$XDG_CONFIG_HOME/nvim,
+'runtimepath' 'rtp'	string	(default:     "$XDG_CONFIG_HOME/nvim,
 					       $XDG_CONFIG_DIRS[1]/nvim,
 					       $XDG_CONFIG_DIRS[2]/nvim,
 					       …
-					       $XDG_DATA_HOME/nvim/site,
+					       $XDG_DATA_HOME/nvim[-data]/site,
 					       $XDG_DATA_DIRS[1]/nvim/site,
 					       $XDG_DATA_DIRS[2]/nvim/site,
 					       …
@@ -4676,14 +4675,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 					       …
 					       $XDG_DATA_DIRS[2]/nvim/site/after,
 					       $XDG_DATA_DIRS[1]/nvim/site/after,
-					       $XDG_DATA_HOME/nvim/site/after,
+					       $XDG_DATA_HOME/nvim[-data]/site/after,
 					       …
 					       $XDG_CONFIG_DIRS[2]/nvim/after,
 					       $XDG_CONFIG_DIRS[1]/nvim/after,
 					       $XDG_CONFIG_HOME/nvim/after")
 			global
-	This is a list of directories which will be searched for runtime
-	files:
+	List of directories to be searched for these runtime files:
 	  filetype.vim	filetypes by file name |new-filetype|
 	  scripts.vim	filetypes by file contents |new-filetype-scripts|
 	  autoload/	automatically loaded scripts |autoload-functions|
@@ -4705,19 +4703,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	And any other file searched for with the |:runtime| command.
 
-	The defaults for most systems are setup to search these locations:
-	1. In your home directory (XDG_CONFIG_HOME defaults to $HOME/.config), 
-	   for your personal preferences.
-	2. In directories which must contain configuration files according to 
-	   XDG ($XDG_CONFIG_DIRS).  This also contains preferences from system 
-	   administrator (XDG_CONFIG_DIRS defaults to /etc/xdg).
-	3. In data home directory, for plugins installed by user.
-	4. In nvim/site subdirectories for each directory in $XDG_DATA_DIRS.  
-	   This is for plugins which were installed by system administrator, 
-	   but are not part of the Neovim distribution. XDG_DATA_DIRS defaults 
-	   to /usr/local/share/:/usr/share/, so system administrators are 
+	Defaults are setup to search these locations:
+	1. Your home directory, for personal preferences.
+	   Given by `stdpath("config")`.  |$XDG_CONFIG_HOME|
+	2. Directories which must contain configuration files according to 
+	   |xdg| ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
+	   preferences from system administrator.
+	3. Data home directory, for plugins installed by user.
+	   Given by `stdpath("data")`.  |$XDG_DATA_HOME|
+	4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
+	   This is for plugins which were installed by system administrator,
+	   but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
+	   to /usr/local/share/:/usr/share/, so system administrators are
 	   expected to install site plugins to /usr/share/nvim/site.
-	5. In $VIMRUNTIME, for files distributed with Neovim.
+	5. $VIMRUNTIME, for files distributed with Neovim.
 							*after-directory*
 	6, 7, 8, 9. In after/ subdirectories of 1, 2, 3 and 4, with reverse 
 	   ordering.  This is for preferences to overrule or add to the 
@@ -6163,9 +6162,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the file should contain words with similar meaning, separated by
 	non-keyword characters (white space is preferred).  Maximum line
 	length is 510 bytes.
-	To obtain a file to be used here, check out this ftp site:
-	[Sorry this link doesn't work anymore, do you know the right one?]
-	ftp://ftp.ox.ac.uk/pub/wordlists/  First get the README file.
+
 	To include a comma in a file name precede it with a backslash.  Spaces
 	after a comma are ignored, otherwise spaces are included in the file
 	name.  See |option-backslash| about using backslashes.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -432,13 +432,17 @@ static inline char *add_colon_dirs(char *dest, const char *const val,
   return dest;
 }
 
-/// Add directory to a comma-separated list of directories
+/// Adds directory `dest` to a comma-separated list of directories.
 ///
-/// In the added directory comma is escaped.
+/// Commas in the added directory are escaped.
+///
+/// Windows: Appends "nvim-data" instead of "nvim" if `type` is kXDGDataHome.
+///
+/// @see get_xdg_home
 ///
 /// @param[in,out]  dest  Destination comma-separated array.
 /// @param[in]  dir  Directory to append.
-/// @param[in]  append_nvim  If true, append "nvim" as the very first suffix.
+/// @param[in]  type  Decides whether to append "nvim" (Win: or "nvim-data").
 /// @param[in]  suf1  If not NULL, suffix appended to destination. Prior to it
 ///                   directory separator is appended. Suffix must not contain
 ///                   commas.
@@ -452,7 +456,7 @@ static inline char *add_colon_dirs(char *dest, const char *const val,
 ///
 /// @return (dest + appended_characters_length)
 static inline char *add_dir(char *dest, const char *const dir,
-                            const size_t dir_len, const bool append_nvim,
+                            const size_t dir_len, const XDGVarType type,
                             const char *const suf1, const size_t len1,
                             const char *const suf2, const size_t len2)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_WARN_UNUSED_RESULT
@@ -461,12 +465,19 @@ static inline char *add_dir(char *dest, const char *const dir,
     return dest;
   }
   dest = strcpy_comma_escaped(dest, dir, dir_len);
+  bool append_nvim = (type == kXDGDataHome || type == kXDGConfigHome);
   if (append_nvim) {
     if (!after_pathsep(dest - 1, dest)) {
       *dest++ = PATHSEP;
     }
+#if defined(WIN32)
+    size_t size = (type == kXDGDataHome ? sizeof("nvim-data") - 1 : NVIM_SIZE);
+    memmove(dest, (type == kXDGDataHome ? "nvim-data" : "nvim"), size);
+    dest += size;
+#else
     memmove(dest, "nvim", NVIM_SIZE);
     dest += NVIM_SIZE;
+#endif
     if (suf1 != NULL) {
       *dest++ = PATHSEP;
       memmove(dest, suf1, len1);
@@ -482,7 +493,10 @@ static inline char *add_dir(char *dest, const char *const dir,
   return dest;
 }
 
-/// Set &runtimepath to default value
+/// Sets &runtimepath to default value.
+///
+/// Windows: Uses "…/nvim-data" for kXDGDataHome to avoid storing
+/// configuration and data files in the same path. #4403
 static void set_runtimepath_default(void)
 {
   size_t rtp_size = 0;
@@ -499,8 +513,13 @@ static void set_runtimepath_default(void)
   if (data_home != NULL) {
     data_len = strlen(data_home);
     if (data_len != 0) {
+#if defined(WIN32)
+      size_t nvim_size = (sizeof("nvim-data") - 1);
+#else
+      size_t nvim_size = NVIM_SIZE;
+#endif
       rtp_size += ((data_len + memcnt(data_home, ',', data_len)
-                    + NVIM_SIZE + 1 + SITE_SIZE + 1
+                    + nvim_size + 1 + SITE_SIZE + 1
                     + !after_pathsep(data_home, data_home + data_len)) * 2
                    + AFTER_SIZE + 1);
     }
@@ -529,21 +548,22 @@ static void set_runtimepath_default(void)
   }
   char *const rtp = xmalloc(rtp_size);
   char *rtp_cur = rtp;
-  rtp_cur = add_dir(rtp_cur, config_home, config_len, true, NULL, 0, NULL, 0);
+  rtp_cur = add_dir(rtp_cur, config_home, config_len, kXDGConfigHome,
+                    NULL, 0, NULL, 0);
   rtp_cur = add_colon_dirs(rtp_cur, config_dirs, NULL, 0, NULL, 0, true);
-  rtp_cur = add_dir(rtp_cur, data_home, data_len, true, "site", SITE_SIZE,
-                    NULL, 0);
+  rtp_cur = add_dir(rtp_cur, data_home, data_len, kXDGDataHome,
+                    "site", SITE_SIZE, NULL, 0);
   rtp_cur = add_colon_dirs(rtp_cur, data_dirs, "site", SITE_SIZE, NULL, 0,
                            true);
-  rtp_cur = add_dir(rtp_cur, vimruntime, vimruntime_len, false, NULL, 0,
-                    NULL, 0);
+  rtp_cur = add_dir(rtp_cur, vimruntime, vimruntime_len, kXDGNone,
+                    NULL, 0, NULL, 0);
   rtp_cur = add_colon_dirs(rtp_cur, data_dirs, "site", SITE_SIZE,
                            "after", AFTER_SIZE, false);
-  rtp_cur = add_dir(rtp_cur, data_home, data_len, true, "site", SITE_SIZE,
-                    "after", AFTER_SIZE);
+  rtp_cur = add_dir(rtp_cur, data_home, data_len, kXDGDataHome,
+                    "site", SITE_SIZE, "after", AFTER_SIZE);
   rtp_cur = add_colon_dirs(rtp_cur, config_dirs, "after", AFTER_SIZE, NULL, 0,
                            false);
-  rtp_cur = add_dir(rtp_cur, config_home, config_len, true,
+  rtp_cur = add_dir(rtp_cur, config_home, config_len, kXDGConfigHome,
                     "after", AFTER_SIZE, NULL, 0);
   // Strip trailing comma.
   rtp_cur[-1] = NUL;

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -80,14 +80,14 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
   return ret;
 }
 
-/// Return nvim-specific XDG directory subpath
+/// Return Nvim-specific XDG directory subpath.
+///
+/// Windows: Uses "…/nvim-data" for kXDGDataHome to avoid storing
+/// configuration and data files in the same path. #4403
 ///
 /// @param[in]  idx  XDG directory to use.
 ///
-/// @return [allocated] `{xdg_directory}/nvim`
-///
-/// In WIN32 get_xdg_home(kXDGDataHome) returns `{xdg_directory}/nvim-data` to
-/// avoid storing configuration and data files in the same path.
+/// @return [allocated] "{xdg_directory}/nvim"
 char *get_xdg_home(const XDGVarType idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {

--- a/src/nvim/os/stdpaths_defs.h
+++ b/src/nvim/os/stdpaths_defs.h
@@ -3,6 +3,7 @@
 
 /// List of possible XDG variables
 typedef enum {
+  kXDGNone = -1,
   kXDGConfigHome,  ///< XDG_CONFIG_HOME
   kXDGDataHome,    ///< XDG_DATA_HOME
   kXDGCacheHome,   ///< XDG_CACHE_HOME

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local global_helpers = require('test.helpers')
 
 local Screen = require('test.functional.ui.screen')
 
@@ -15,6 +16,7 @@ local neq = helpers.neq
 local mkdir = helpers.mkdir
 local rmdir = helpers.rmdir
 local alter_slashes = helpers.alter_slashes
+local table_contains = global_helpers.table_contains
 
 describe('startup defaults', function()
   describe(':filetype', function()
@@ -249,6 +251,23 @@ end)
 describe('XDG-based defaults', function()
   -- Need separate describe() blocks to not run clear() twice.
   -- Do not put before_each() here for the same reasons.
+
+  it("&runtimepath data-dir matches stdpath('data') #9910", function()
+    clear()
+    local rtp = eval('split(&runtimepath, ",")')
+    local rv = {}
+    local expected = (iswin()
+                      and { [[\nvim-data\site]], [[\nvim-data\site\after]], }
+                      or { '/nvim/site', '/nvim/site/after', })
+
+    for _,v in ipairs(rtp) do
+      local m = string.match(v, [=[[/\]nvim[^/\]*[/\]site.*$]=])
+      if m and not table_contains(rv, m) then
+        table.insert(rv, m)
+      end
+    end
+    eq(expected, rv)
+  end)
 
   describe('with empty/broken environment', function()
     it('sets correct defaults', function()


### PR DESCRIPTION
On Windows we store non-config data in "$XDG_DATA_HOME/nvim-data". But the "…/site" items in 'runtimepath' did not correctly point to that location, they used "…/nvim/site".

Fix the init logic to use  "…/nvim-data/site".

closes #9910