### PR TITLE
test: clear(): `args_rm` parameter

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5049,7 +5049,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 				*'shadafile'* *'sdf'*
-'shadafile' 'vif'	string	(default: "")
+'shadafile' 'sdf'	string	(default: "")
 			global
 	When non-empty, overrides the file name used for |shada| (viminfo).
 	When equal to "NONE" no shada file will be read or written.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1081,15 +1081,16 @@ even if other entries (with known name/type/etc) are merged. |shada-merging|
 
 SHADA FILE NAME						*shada-file-name*
 
-- The default name of the ShaDa file is "$XDG_DATA_HOME/nvim/shada/main.shada" 
-  for Unix. Default for $XDG_DATA_HOME is ~/.local/share. |base-directories|
-- The 'n' flag in the 'shada' option can be used to specify another ShaDa
-  file name |'shada'|.
-- The "-i" Vim argument can be used to set another file name, |-i|.  When the
-  file name given is "NONE" (all uppercase), no ShaDa file is ever read or
-  written.  Also not for the commands below!
-- The 'viminfofile' option can be used like the "-i" argument.  In fact, the
-  value form the "-i" argument is stored in the 'viminfofile' option.
+- Default name of the |shada| file is:
+      Unix:     "$XDG_DATA_HOME/nvim/shada/main.shada"
+      Windows:  "$XDG_DATA_HOME/nvim-data/shada/main.shada"
+  See also |base-directories|.
+- To choose a different file name you can use:
+    - The "n" flag in the 'shada' option.
+    - The |-i| startup argument.  "NONE" means no shada file is ever read or
+      written.  Also not for the commands below!
+    - The 'shadafile' option.  The value from the "-i" argument (if any) is
+      stored in the 'shadafile' option.
 - For the commands below, another file name can be given, overriding the
   default and the name given with 'shada' or "-i" (unless it's NONE).
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -13,9 +13,7 @@ local nvim_set = helpers.nvim_set
 local read_file = helpers.read_file
 local retry = helpers.retry
 local rmdir = helpers.rmdir
-local set_session = helpers.set_session
 local sleep = helpers.sleep
-local spawn = helpers.spawn
 local iswin = helpers.iswin
 local write_file = helpers.write_file
 
@@ -228,10 +226,6 @@ describe('sysinit', function()
   local vimdir = 'Xvim'
   local xhome = 'Xhome'
   local pathsep = helpers.get_pathsep()
-  local argv = {
-    nvim_prog, '--headless', '--embed', '-i', 'NONE', '-n',
-    '--cmd', 'set nomore undodir=. directory=. belloff='
-  }
 
   before_each(function()
     rmdir(xdgdir)
@@ -260,19 +254,21 @@ describe('sysinit', function()
   end)
 
   it('prefers XDG_CONFIG_DIRS over VIM', function()
-    set_session(spawn(argv, nil,
-                      { 'HOME='..xhome,
-                        'XDG_CONFIG_DIRS='..xdgdir,
-                        'VIM='..vimdir }))
+    clear{args={'--cmd', 'set nomore undodir=. directory=. belloff='},
+          args_rm={'-u', '--cmd'},
+          env={ HOME=xhome,
+                XDG_CONFIG_DIRS=xdgdir,
+                VIM=vimdir }}
     eq('loaded 1 xdg 1 vim 0',
        eval('printf("loaded %d xdg %d vim %d", g:loaded, get(g:, "xdg", 0), get(g:, "vim", 0))'))
   end)
 
   it('uses VIM if XDG_CONFIG_DIRS unset', function()
-    set_session(spawn(argv, nil,
-                      { 'HOME='..xhome,
-                        'XDG_CONFIG_DIRS=',
-                        'VIM='..vimdir }))
+    clear{args={'--cmd', 'set nomore undodir=. directory=. belloff='},
+          args_rm={'-u', '--cmd'},
+          env={ HOME=xhome,
+                XDG_CONFIG_DIRS='',
+                VIM=vimdir }}
     eq('loaded 1 xdg 0 vim 1',
        eval('printf("loaded %d xdg %d vim %d", g:loaded, get(g:, "xdg", 0), get(g:, "vim", 0))'))
   end)

--- a/test/functional/ex_cmds/oldfiles_spec.lua
+++ b/test/functional/ex_cmds/oldfiles_spec.lua
@@ -1,18 +1,18 @@
 local Screen = require('test.functional.ui.screen')
 local helpers = require('test.functional.helpers')(after_each)
 
+local clear = helpers.clear
 local buf, eq, feed_command = helpers.curbufmeths, helpers.eq, helpers.feed_command
-local feed, nvim_prog, wait = helpers.feed, helpers.nvim_prog, helpers.wait
-local ok, set_session, spawn = helpers.ok, helpers.set_session, helpers.spawn
+local feed, wait = helpers.feed, helpers.wait
+local ok = helpers.ok
 local eval = helpers.eval
 
 local shada_file = 'Xtest.shada'
 
 local function _clear()
-  set_session(spawn({nvim_prog, '--embed', '--headless', '-u', 'NONE',
-                     -- Need shada for these tests.
-                     '-i', shada_file,
-                     '--cmd', 'set noswapfile undodir=. directory=. viewdir=. backupdir=. belloff= noshowcmd noruler'}))
+  clear{args={'-i', shada_file, -- Need shada for these tests.
+              '--cmd', 'set noswapfile undodir=. directory=. viewdir=. backupdir=. belloff= noshowcmd noruler'},
+        args_rm={'-i', '--cmd'}}
 end
 
 describe(':oldfiles', function()

--- a/test/functional/ex_cmds/wviminfo_spec.lua
+++ b/test/functional/ex_cmds/wviminfo_spec.lua
@@ -1,23 +1,21 @@
 local helpers = require('test.functional.helpers')(after_each)
 local lfs = require('lfs')
-local command, eq, neq, spawn, nvim_prog, set_session, write_file =
-  helpers.command, helpers.eq, helpers.neq, helpers.spawn,
-  helpers.nvim_prog, helpers.set_session, helpers.write_file
+local clear = helpers.clear
+local command, eq, neq, write_file =
+  helpers.command, helpers.eq, helpers.neq, helpers.write_file
 local iswin = helpers.iswin
 local read_file = helpers.read_file
 
 describe(':wshada', function()
   local shada_file = 'wshada_test'
-  local session
 
   before_each(function()
-    -- Override the default session because we need 'swapfile' for these tests.
-    session = spawn({nvim_prog, '-u', 'NONE', '-i', iswin() and 'nul' or '/dev/null', '--embed',
-                           '--cmd', 'set swapfile'})
-    set_session(session)
+    clear{args={'-i', iswin() and 'nul' or '/dev/null',
+                -- Need 'swapfile' for these tests.
+                '--cmd', 'set swapfile undodir=. directory=. viewdir=. backupdir=. belloff= noshowcmd noruler'},
+          args_rm={'-n', '-i', '--cmd'}}
   end)
   after_each(function ()
-    session:close()
     os.remove(shada_file)
   end)
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -394,17 +394,16 @@ end
 --                removed, e.g. args_rm={'--cmd'} removes all cases of "--cmd"
 --                (and its value) from the default set.
 --    env:        Map: Defines the environment of the new session.
---    headless:   Boolean (default=true): Append --headless arg.
 --
 -- Example:
 --    clear('-e')
 --    clear{args={'-e'}, args_rm={'-i'}, env={TERM=term}}
 local function clear(...)
   local args = {unpack(nvim_argv)}
+  table.insert(args, '--headless')
   local new_args
   local env = nil
   local opts = select(1, ...)
-  local headless = true
   if type(opts) == 'table' then
     args = remove_args(args, opts.args_rm)
     if opts.env then
@@ -432,14 +431,8 @@ local function clear(...)
       end
     end
     new_args = opts.args or {}
-    if opts.headless == false then
-      headless = false
-    end
   else
     new_args = {...}
-  end
-  if headless then
-    table.insert(args, '--headless')
   end
   for _, arg in ipairs(new_args) do
     table.insert(args, arg)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -351,12 +351,13 @@ end
 
 -- Starts a new global Nvim session.
 -- Parameters are interpreted as startup args, OR a map with these keys:
---    args: Merged with the default `nvim_argv` set.
+--    args: Appended to the default `nvim_argv` set.
 --    env : Defines the environment of the new session.
+--    headless: Append --headless arg.
 --
 -- Example:
 --    clear('-e')
---    clear({args={'-e'}, env={TERM=term}})
+--    clear{args={'-e'}, env={TERM=term}}
 local function clear(...)
   local args = {unpack(nvim_argv)}
   local new_args

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -38,7 +38,7 @@ local nvim_prog = (
 local nvim_set  = 'set shortmess+=I background=light noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
                   ..' belloff= noshowcmd noruler nomore'
-local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N',
+local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE',
                    '--cmd', nvim_set, '--embed'}
 -- Directory containing nvim.
 local nvim_dir = nvim_prog:gsub("[/\\][^/\\]+$", "")
@@ -312,6 +312,43 @@ local function merge_args(...)
   return argv
 end
 
+--  Removes Nvim startup args from `args` matching items in `args_rm`.
+--
+--  "-u", "-i", "--cmd" are treated specially: their "values" are also removed.
+--  Example:
+--      args={'--headless', '-u', 'NONE'}
+--      args_rm={'--cmd', '-u'}
+--  Result:
+--      {'--headless'}
+--
+--  All cases are removed.
+--  Example:
+--      args={'--cmd', 'foo', '-N', '--cmd', 'bar'}
+--      args_rm={'--cmd', '-u'}
+--  Result:
+--      {'-N'}
+local function remove_args(args, args_rm)
+  local new_args = {}
+  local skip_following = {'-u', '-i', '-c', '--cmd', '-s', '--listen'}
+  if not args_rm or #args_rm == 0 then
+    return {unpack(args)}
+  end
+  for _, v in ipairs(args_rm) do
+    assert(type(v) == 'string')
+  end
+  local last = ''
+  for _, arg in ipairs(args) do
+    if table_contains(skip_following, last) then
+      last = ''
+    elseif table_contains(args_rm, arg) then
+      last = arg
+    else
+      table.insert(new_args, arg)
+    end
+  end
+  return new_args
+end
+
 local function spawn(argv, merge, env)
   local child_stream = ChildProcessStream.spawn(
       merge and merge_args(prepend_argv, argv) or argv,
@@ -350,14 +387,18 @@ local function retry(max, max_ms, fn)
 end
 
 -- Starts a new global Nvim session.
+--
 -- Parameters are interpreted as startup args, OR a map with these keys:
---    args: Appended to the default `nvim_argv` set.
---    env : Defines the environment of the new session.
---    headless: Append --headless arg.
+--    args:       List: Args appended to the default `nvim_argv` set.
+--    args_rm:    List: Args removed from the default set. All cases are
+--                removed, e.g. args_rm={'--cmd'} removes all cases of "--cmd"
+--                (and its value) from the default set.
+--    env:        Map: Defines the environment of the new session.
+--    headless:   Boolean (default=true): Append --headless arg.
 --
 -- Example:
 --    clear('-e')
---    clear{args={'-e'}, env={TERM=term}}
+--    clear{args={'-e'}, args_rm={'-i'}, env={TERM=term}}
 local function clear(...)
   local args = {unpack(nvim_argv)}
   local new_args
@@ -365,6 +406,7 @@ local function clear(...)
   local opts = select(1, ...)
   local headless = true
   if type(opts) == 'table' then
+    args = remove_args(args, opts.args_rm)
     if opts.env then
       local env_tbl = {}
       for k, v in pairs(opts.env) do
@@ -375,7 +417,8 @@ local function clear(...)
       for _, k in ipairs({
         'HOME',
         'ASAN_OPTIONS',
-        'LD_LIBRARY_PATH', 'PATH',
+        'LD_LIBRARY_PATH',
+        'PATH',
         'NVIM_LOG_FILE',
         'NVIM_RPLUGIN_MANIFEST',
       }) do

--- a/test/functional/legacy/074_global_var_in_viminfo_spec.lua
+++ b/test/functional/legacy/074_global_var_in_viminfo_spec.lua
@@ -2,9 +2,9 @@
 
 local helpers = require('test.functional.helpers')(after_each)
 local lfs = require('lfs')
-local clear, command, eq, neq, eval, wait, spawn =
+local clear, command, eq, neq, eval, wait =
   helpers.clear, helpers.command, helpers.eq, helpers.neq, helpers.eval,
-  helpers.wait, helpers.spawn
+  helpers.wait
 
 describe('storing global variables in ShaDa files', function()
   local tempname = 'Xtest-functional-legacy-074'
@@ -14,9 +14,7 @@ describe('storing global variables in ShaDa files', function()
   end)
 
   it('is working', function()
-    local nvim2 = spawn({helpers.nvim_prog, '-u', 'NONE',
-                                 '-i', 'Xviminfo', '--embed'})
-    helpers.set_session(nvim2)
+    clear{args_rm={'-i'}, args={'-i', 'Xviminfo'}}
 
     local test_dict = {foo = 1, bar = 0, longvarible = 1000}
     local test_list = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -15,9 +15,6 @@ local neq = helpers.neq
 local mkdir = helpers.mkdir
 local rmdir = helpers.rmdir
 local alter_slashes = helpers.alter_slashes
-local spawn = helpers.spawn
-local nvim_prog = helpers.nvim_prog
-local set_session = helpers.set_session
 
 describe('startup defaults', function()
   describe(':filetype', function()
@@ -164,26 +161,22 @@ describe('startup defaults', function()
   end)
 
   it("'shadafile' ('viminfofile')", function()
-    -- Cannot use clear() because we do not want "-i NONE".
-    local function clear_use_default_shada()
-      set_session(spawn({nvim_prog, '-u', 'NONE', '--embed', '--headless'},
-                         false,
-                         {XDG_DATA_HOME='Xtest-userdata',
-                          XDG_CONFIG_HOME='Xtest-userconfig'}))
-    end
-    clear_use_default_shada()
+    local env = {XDG_DATA_HOME='Xtest-userdata', XDG_CONFIG_HOME='Xtest-userconfig'}
+    clear{args={}, args_rm={'-i'}, env=env}
     -- Default 'shadafile' is empty.
     -- This means use the default location. :help shada-file-name
     eq('', meths.get_option('shadafile'))
     eq('', meths.get_option('viminfofile'))
     -- Check that shada data (such as v:oldfiles) is saved/restored.
-    command('edit foo')
+    command('edit Xtest-foo')
     command('write')
     local f = eval('fnamemodify(@%,":p")')
     assert(string.len(f) > 3)
     command('qall')
-    clear_use_default_shada()
+    clear{args={}, args_rm={'-i'}, env=env}
     eq({ f }, eval('v:oldfiles'))
+    os.remove('Xtest-foo')
+    rmdir('Xtest-userdata')
   end)
 
   it("'packpath'", function()

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -8,7 +8,7 @@ local clear = helpers.clear
 local function test_embed(ext_linegrid)
   local screen
   local function startup(...)
-    clear{headless=false, args={...}}
+    clear{args_rm={'--headless'}, args={...}}
 
     -- attach immediately after startup, for early UI
     screen = Screen.new(60, 8)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -529,7 +529,7 @@ describe('ui/ext_messages', function()
   local screen
 
   before_each(function()
-    clear{headless=false, args={"--cmd", "set shortmess-=I"}}
+    clear{args_rm={'--headless'}, args={"--cmd", "set shortmess-=I"}}
     screen = Screen.new(80, 24)
     screen:attach({rgb=true, ext_messages=true, ext_popupmenu=true})
     screen:set_default_attr_ids({

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -11,7 +11,7 @@ describe('ext_multigrid', function()
   local screen
 
   before_each(function()
-    clear{headless=false, args={'--cmd', 'set laststatus=2'}}
+    clear{args_rm={'--headless'}, args={'--cmd', 'set laststatus=2'}}
     screen = Screen.new(53,14)
     screen:attach({ext_multigrid=true})
     screen:set_default_attr_ids({

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -115,7 +115,8 @@ describe('ui receives option updates', function()
   end)
 
   local function startup_test(headless)
-    local expected = reset(nil,{headless=headless,args={'--cmd', 'set guifont=Comic\\ Sans\\ 12'}})
+    local expected = reset(nil, {args_rm=(headless and {} or {'--headless'}),
+                                 args={'--cmd', 'set guifont=Comic\\ Sans\\ 12'}})
     expected.guifont = "Comic Sans 12"
     screen:expect(function()
       eq(expected, screen.options)


### PR DESCRIPTION
- test 'shadafile' default (ref: 773bdd4, #9907)
- test: add new feature to `clear()` function: `args_rm` removes args from the default set