### PR TITLE
blending of floating windows

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4513,6 +4513,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
 	transparent background. Values between 0-30 are typically most useful.
 
+	It is possible to override the level for individual highlights within
+	the popupmenu using |highlight-blend|. For instance, to enable
+	transparency but force the current selected element to be fully opaque: >
+
+		:set pumblend=15
+		:hi PmenuSel blend=0
+<
 	UI-dependent. Works best with RGB colors. 'termguicolors'
 
 						*'pyxversion'* *'pyx'*
@@ -6692,6 +6699,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If the menu is disabled by excluding 'm' from 'guioptions', the ALT
 	key is never used for the menu.
 	This option is not used for <F10>; on Win32.
+
+						*'winblend'* *'winbl'*
+'winblend' 'winbl'		number	(default 0)
+			local to window
+	Enables pseudo-transparency for a floating window. Valid values are in
+	the range of 0 for fully opaque window (disabled) to 100 for fully
+	transparent background. Values between 0-30 are typically most useful.
+
+	UI-dependent. Works best with RGB colors. 'termguicolors'
 
 						*'window'* *'wi'*
 'window' 'wi'		number  (default screen height - 1)

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4879,6 +4879,11 @@ guisp={color-name}					*highlight-guisp*
 	All values are hexadecimal, range from "00" to "ff".  Examples: >
   :highlight Comment guifg=#11f0c3 guibg=#ff00ff
 <
+blend={integer}					*highlight-blend*
+	Override the blend level for a highlight group within the popupmenu
+	or floating windows. Only takes effect if 'pumblend' or 'winblend'
+	is set for the menu or window. See the help at the respective option.
+
 					*highlight-groups* *highlight-default*
 These are the builtin highlighting groups.  Note that the highlighting depends
 on the value of 'background'.  You can see the current settings with the

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -252,6 +252,8 @@ typedef struct {
 # define w_p_fcs w_onebuf_opt.wo_fcs    // 'fillchars'
   char_u *wo_lcs;
 # define w_p_lcs w_onebuf_opt.wo_lcs    // 'listchars'
+  long wo_winbl;
+# define w_p_winbl w_onebuf_opt.wo_winbl  // 'winblend'
 
   LastSet wo_scriptID[WV_COUNT];        // SIDs for window-local options
 # define w_p_scriptID w_onebuf_opt.wo_scriptID

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -756,9 +756,11 @@ EXTERN bool KeyTyped;                    // true if user typed current char
 EXTERN int KeyStuffed;                   // TRUE if current char from stuffbuf
 EXTERN int maptick INIT(= 0);            // tick for each non-mapped char
 
-EXTERN int must_redraw INIT(= 0);           /* type of redraw necessary */
-EXTERN int skip_redraw INIT(= FALSE);       /* skip redraw once */
-EXTERN int do_redraw INIT(= FALSE);         /* extra redraw once */
+EXTERN int must_redraw INIT(= 0);           // type of redraw necessary
+EXTERN bool skip_redraw INIT(= false);      // skip redraw once
+EXTERN bool do_redraw INIT(= false);        // extra redraw once
+EXTERN bool must_redraw_pum INIT(= false);  // redraw pum. NB: must_redraw
+                                            // should also be set.
 
 EXTERN int need_highlight_changed INIT(= true);
 

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -54,6 +54,9 @@ typedef struct {
   int row_offset;
   int col_offset;
 
+  // whether the compositor should blend the grid with the background grid
+  bool blending;
+
   // state owned by the compositor.
   int comp_row;
   int comp_col;
@@ -61,7 +64,7 @@ typedef struct {
   bool comp_disabled;
 } ScreenGrid;
 
-#define SCREEN_GRID_INIT { 0, NULL, NULL, NULL, NULL, 0, 0, false, 0, 0, 0, \
-                           0, 0,  false }
+#define SCREEN_GRID_INIT { 0, NULL, NULL, NULL, NULL, 0, 0, false, 0, 0, \
+                           false, 0, 0, 0,  false }
 
 #endif  // NVIM_GRID_DEFS_H

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -25,6 +25,7 @@ typedef struct attr_entry {
   int16_t rgb_ae_attr, cterm_ae_attr;  ///< HlAttrFlags
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
+  int hl_blend;
 } HlAttrs;
 
 #define HLATTRS_INIT (HlAttrs) { \

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -816,6 +816,7 @@ enum {
   , WV_WINHL
   , WV_FCS
   , WV_LCS
+  , WV_WINBL
   , WV_COUNT        // must be the last one
 };
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2762,6 +2762,13 @@ return {
       defaults={if_true={vi="menu"}}
     },
     {
+      full_name='winblend', abbreviation='winbl',
+      type='number', scope={'window'},
+      vi_def=true,
+      redraw={'current_window'},
+      defaults={if_true={vi=0}}
+    },
+    {
       full_name='winhighlight', abbreviation='winhl',
       type='string', scope={'window'},
       vi_def=true,

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -376,6 +376,7 @@ void pum_redraw(void)
                                 pum_height, grid_width, false, true);
   bool invalid_grid = moved || pum_invalid;
   pum_invalid = false;
+  must_redraw_pum = false;
 
   if (!pum_grid.chars
       || pum_grid.Rows != pum_height || pum_grid.Columns != grid_width) {
@@ -790,6 +791,7 @@ void pum_undisplay(bool immediate)
 {
   pum_is_visible = false;
   pum_array = NULL;
+  must_redraw_pum = false;
 
   if (immediate) {
     pum_check_clear();

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -482,13 +482,13 @@ void update_screen(int type)
   }
 
   end_search_hl();
+
   // May need to redraw the popup menu.
-  if (pum_drawn() && redraw_popupmenu) {
+  if (pum_drawn() && must_redraw_pum) {
     pum_redraw();
   }
 
   send_grid_resize = false;
-  redraw_popupmenu = false;
 
   /* Reset b_mod_set flags.  Going through all windows is probably faster
    * than going through all buffers (there could be many buffers). */

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -330,10 +330,10 @@ static void compose_line(Integer row, Integer startcol, Integer endcol,
     memcpy(attrbuf+(col-startcol), grid->attrs+off, n * sizeof(*attrbuf));
 
     // 'pumblend'
-    if (grid == &pum_grid && p_pb) {
+    if (grid->blending) {
       for (int i = col-(int)startcol; i < until-startcol; i++) {
         bool thru = strequal((char *)linebuf[i], " ");  // negative space
-        attrbuf[i] = (sattr_T)hl_blend_attrs(bg_attrs[i], attrbuf[i], thru);
+        attrbuf[i] = (sattr_T)hl_blend_attrs(bg_attrs[i], attrbuf[i], &thru);
         if (thru) {
           memcpy(linebuf[i], bg_line[i], sizeof(linebuf[i]));
         }
@@ -419,7 +419,7 @@ static void ui_comp_raw_line(UI *ui, Integer grid, Integer row,
   assert(clearcol <= default_grid.Columns);
   if (flags & kLineFlagInvalid
       || kv_size(layers) > curgrid->comp_index+1
-      || (p_pb && curgrid == &pum_grid)) {
+      || curgrid->blending) {
     compose_line(row, startcol, clearcol, flags);
   } else {
     ui_composed_call_raw_line(1, row, startcol, endcol, clearcol, clearattr,

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -3764,6 +3764,196 @@ describe('floating windows', function()
         end
       end)
     end)
+
+    it("'winblend' option", function()
+      screen:try_resize(50,9)
+      screen:set_default_attr_ids({
+        [1] = {background = Screen.colors.LightMagenta},
+        [2] = {foreground = Screen.colors.Grey0, background = tonumber('0xffcfff')},
+        [3] = {foreground = tonumber('0xb282b2'), background = tonumber('0xffcfff')},
+        [4] = {foreground = Screen.colors.Red, background = Screen.colors.LightMagenta},
+        [5] = {foreground = tonumber('0x990000'), background = tonumber('0xfff1ff')},
+        [6] = {foreground = tonumber('0x332533'), background = tonumber('0xfff1ff')},
+      })
+      insert([[
+        Lorem ipsum dolor sit amet, consectetur
+        adipisicing elit, sed do eiusmod tempor
+        incididunt ut labore et dolore magna aliqua.
+        Ut enim ad minim veniam, quis nostrud
+        exercitation ullamco laboris nisi ut aliquip ex
+        ea commodo consequat. Duis aute irure dolor in
+        reprehenderit in voluptate velit esse cillum
+        dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa
+        qui officia deserunt mollit anim id est
+        laborum.]])
+      local buf = meths.create_buf(false,false)
+      meths.buf_set_lines(buf, 0, -1, true, {"test", "", "popup    text"})
+      local win = meths.open_win(buf, false, {relative='editor', width=15, height=3, row=2, col=5})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+                                                            |
+        ## grid 2
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea commodo consequat. Duis aute irure dolor in    |
+          reprehenderit in voluptate velit esse cillum      |
+          dolore eu fugiat nulla pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+        ## grid 4
+          {1:test           }|
+          {1:               }|
+          {1:popup    text  }|
+        ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}}
+      else
+        screen:expect([[
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea co{1:test           }. Duis aute irure dolor in    |
+          repre{1:               }uptate velit esse cillum      |
+          dolor{1:popup    text  }la pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+                                                            |
+        ]])
+      end
+
+      meths.win_set_option(win, "winblend", 30)
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+                                                            |
+        ## grid 2
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea commodo consequat. Duis aute irure dolor in    |
+          reprehenderit in voluptate velit esse cillum      |
+          dolore eu fugiat nulla pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+        ## grid 4
+          {1:test           }|
+          {1:               }|
+          {1:popup    text  }|
+        ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}, unchanged=true}
+      else
+        screen:expect([[
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea co{2:test}{3:o consequat}. Duis aute irure dolor in    |
+          repre{3:henderit in vol}uptate velit esse cillum      |
+          dolor{2:popup}{3:fugi}{2:text}{3:ul}la pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+                                                            |
+        ]])
+      end
+
+      command('hi SpecialRegion guifg=Red blend=0')
+      meths.buf_add_highlight(buf, -1, "SpecialRegion", 2, 0, -1)
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+                                                            |
+        ## grid 2
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea commodo consequat. Duis aute irure dolor in    |
+          reprehenderit in voluptate velit esse cillum      |
+          dolore eu fugiat nulla pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+        ## grid 4
+          {1:test           }|
+          {1:               }|
+          {4:popup    text}{1:  }|
+        ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}}
+      else
+        screen:expect([[
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea co{2:test}{3:o consequat}. Duis aute irure dolor in    |
+          repre{3:henderit in vol}uptate velit esse cillum      |
+          dolor{4:popup    text}{3:ul}la pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+                                                            |
+        ]])
+      end
+
+      command('hi SpecialRegion guifg=Red blend=80')
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+          [2:--------------------------------------------------]|
+                                                            |
+        ## grid 2
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea commodo consequat. Duis aute irure dolor in    |
+          reprehenderit in voluptate velit esse cillum      |
+          dolore eu fugiat nulla pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+        ## grid 4
+          {1:test           }|
+          {1:               }|
+          {4:popup    text}{1:  }|
+        ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}, unchanged=true}
+      else
+        screen:expect([[
+          Ut enim ad minim veniam, quis nostrud             |
+          exercitation ullamco laboris nisi ut aliquip ex   |
+          ea co{2:test}{3:o consequat}. Duis aute irure dolor in    |
+          repre{3:henderit in vol}uptate velit esse cillum      |
+          dolor{5:popup}{6:fugi}{5:text}{3:ul}la pariatur. Excepteur sint   |
+          occaecat cupidatat non proident, sunt in culpa    |
+          qui officia deserunt mollit anim id est           |
+          laborum^.                                          |
+                                                            |
+        ]])
+      end
+    end)
   end
 
   describe('with ext_multigrid', function()

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1662,6 +1662,26 @@ describe('builtin popupmenu', function()
       {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
     ]])
 
+    -- can disable blending for indiviual attribute. For instance current
+    -- selected item. (also tests that `hi Pmenu*` take immediate effect)
+    command('hi PMenuSel blend=0')
+    screen:expect([[
+      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      adipisicing elit, sed do eiusmod tempor                     |
+      bla bla incididunt^                                          |
+      incidid{22: incididunt     }{27: }d{1:ol}ore magna aliqua.                |
+      Ut enim{28: }{29:ut}{28: minim veniam}{25:,} quis nostrud                       |
+      exercit{28:a}{29:labore}{28:llamco la}{25:b}oris nisi ut aliquip ex             |
+      {2:[No Nam}{30:e}{43:et}{30:[+]          }{32: }{2:                                    }|
+      incidid{28:u}{29:dol}{41:or}{29:e}{28:labore et}{25: }d{1:ol}ore magna aliqua.                |
+      Ut enim{28: }{29:magna}{28:nim veniam}{25:,} quis nostrud                       |
+      exercit{28:a}{29:aliqua}{28:llamco la}{25:b}oris nisi {4:ut} aliquip ex             |
+      ea comm{28:o}{29:Ut}{28: consequat. D}{25:u}is a{4:ut}e irure d{1:ol}or in              |
+      reprehe{28:n}{29:enim}{28:t in v}{34:ol}{28:upt}{25:a}te v{3:el}it esse cillum                |
+      {5:[No Nam}{38:e}{44:ad}{38:[+]          }{40: }{5:                                    }|
+      {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
+    ]])
+
     feed('<c-e>')
     screen:expect([[
       Lorem ipsum d{1:ol}or sit amet, consectetur                     |


### PR DESCRIPTION
From the useless eyecandy department.

```
let x = nvim_open_win(0, v:true, {'relative': 'editor', 'row': 4, 'col': 4, 'width': 30, 'height': 3})
set floatblend=20 " window local option
 ```

Blending can additionally be overriden per highlight group (inside a float). This works:

```
hi PmenuSel blend=0
```

To disable blending of current item when `pumblend` is otherwise active.