### PR TITLE
vim-patch:8.1.{837,1180,1194,1203,1207,1209}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10117,7 +10117,7 @@ static void f_getmatches(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       // match added with matchaddpos()
       for (i = 0; i < MAXPOSMATCH; i++) {
         llpos_T   *llpos;
-        char buf[6];
+        char buf[30];  // use 30 to avoid compiler warning
 
         llpos = &cur->pos.pos[i];
         if (llpos->lnum == 0) {
@@ -14946,7 +14946,7 @@ static void f_setmatches(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
       // match from matchaddpos()
       for (i = 1; i < 9; i++) {
-        char buf[5];
+        char buf[30];  // use 30 to avoid compiler warning
         snprintf(buf, sizeof(buf), "pos%d", i);
         dictitem_T *const pos_di = tv_dict_find(d, buf, -1);
         if (pos_di != NULL) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3935,7 +3935,7 @@ static int eval6(char_u **arg, typval_T *rettv, int evaluate, int want_string)
   int op;
   varnumber_T n1, n2;
   bool use_float = false;
-  float_T f1 = 0, f2;
+  float_T f1 = 0, f2 = 0;
   bool error = false;
 
   /*

--- a/src/nvim/regexp_defs.h
+++ b/src/nvim/regexp_defs.h
@@ -94,10 +94,8 @@ typedef struct {
   char_u program[1];                    /* actually longer.. */
 } bt_regprog_T;
 
-/*
- * Structure representing a NFA state.
- * A NFA state may have no outgoing edge, when it is a NFA_MATCH state.
- */
+// Structure representing a NFA state.
+// An NFA state may have no outgoing edge, when it is a NFA_MATCH state.
 typedef struct nfa_state nfa_state_T;
 struct nfa_state {
   int c;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7460,7 +7460,7 @@ void highlight_attr_set_all(void)
 void highlight_changed(void)
 {
   int id;
-  char_u userhl[10];
+  char_u userhl[30];  // use 30 to avoid compiler warning
   int id_SNC = -1;
   int id_S = -1;
   int hlcnt;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1832,9 +1832,9 @@ parse_line:
             // Don't add identical matches.
             // Add all cscope tags, because they are all listed.
             // "mfp" is used as a hash key, there is a NUL byte to end
-            // the part matters for comparing, more bytes may follow
-            // after it.  E.g. help tags store the priority after the
-            // NUL.
+            // the part that matters for comparing, more bytes may
+            // follow after it.  E.g. help tags store the priority
+            // after the NUL.
             if (use_cscope) {
               hash++;
             } else {

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -164,5 +164,6 @@ newtestssilent: $(NEW_TESTS)
 
 %.res: %.vim .gdbinit
 	@echo "[OLDTEST] Running" $*
+	@rm -rf $*.failed test.ok $(RM_ON_RUN)
 	@mkdir -p $(TMPDIR)
 	@/bin/sh runnvim.sh $(ROOT) $(NVIM_PRG) $* $(RUN_VIMTEST) -u NONE -S runtest.vim $*.vim

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1401,3 +1401,205 @@ func Test_autocmd_once()
 
   call assert_fails('au WinNew * ++once ++once echo bad', 'E983:')
 endfunc
+
+" Tests for the following autocommands:
+" - FileWritePre	writing a compressed file
+" - FileReadPost	reading a compressed file
+" - BufNewFile		reading a file template
+" - BufReadPre		decompressing the file to be read
+" - FilterReadPre	substituting characters in the temp file
+" - FilterReadPost	substituting characters after filtering
+" - FileReadPre		set options for decompression
+" - FileReadPost	decompress the file
+func Test_ReadWrite_Autocmds()
+  " Run this test only on Unix-like systems and if gzip is available
+  if !has('unix') || !executable("gzip")
+    return
+  endif
+
+  " Make $GZIP empty, "-v" would cause trouble.
+  let $GZIP = ""
+
+  " Use a FileChangedShell autocommand to avoid a prompt for 'Xtestfile.gz'
+  " being modified outside of Vim (noticed on Solaris).
+  au FileChangedShell * echo 'caught FileChangedShell'
+
+  " Test for the FileReadPost, FileWritePre and FileWritePost autocmds
+  augroup Test1
+    au!
+    au FileWritePre    *.gz   '[,']!gzip
+    au FileWritePost   *.gz   undo
+    au FileReadPost    *.gz   '[,']!gzip -d
+  augroup END
+
+  new
+  set bin
+  call append(0, [
+	      \ 'line 2	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 3	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 4	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 5	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 6	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 7	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 8	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 9	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 10 Abcdefghijklmnopqrstuvwxyz'
+	      \ ])
+  1,9write! Xtestfile.gz
+  enew! | close
+
+  new
+  " Read and decompress the testfile
+  0read Xtestfile.gz
+  call assert_equal([
+	      \ 'line 2	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 3	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 4	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 5	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 6	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 7	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 8	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 9	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 10 Abcdefghijklmnopqrstuvwxyz'
+	      \ ], getline(1, 9))
+  enew! | close
+
+  augroup Test1
+    au!
+  augroup END
+
+  " Test for the FileAppendPre and FileAppendPost autocmds
+  augroup Test2
+    au!
+    au BufNewFile      *.c    read Xtest.c
+    au FileAppendPre   *.out  '[,']s/new/NEW/
+    au FileAppendPost  *.out  !cat Xtest.c >> test.out
+  augroup END
+
+  call writefile(['/*', ' * Here is a new .c file', ' */'], 'Xtest.c')
+  new foo.c			" should load Xtest.c
+  call assert_equal(['/*', ' * Here is a new .c file', ' */'], getline(2, 4))
+  w! >> test.out		" append it to the output file
+
+  let contents = readfile('test.out')
+  call assert_equal(' * Here is a NEW .c file', contents[2])
+  call assert_equal(' * Here is a new .c file', contents[5])
+
+  call delete('test.out')
+  enew! | close
+  augroup Test2
+    au!
+  augroup END
+
+  " Test for the BufReadPre and BufReadPost autocmds
+  augroup Test3
+    au!
+    " setup autocommands to decompress before reading and re-compress
+    " afterwards
+    au BufReadPre  *.gz  exe '!gzip -d ' . shellescape(expand("<afile>"))
+    au BufReadPre  *.gz  call rename(expand("<afile>:r"), expand("<afile>"))
+    au BufReadPost *.gz  call rename(expand("<afile>"), expand("<afile>:r"))
+    au BufReadPost *.gz  exe '!gzip ' . shellescape(expand("<afile>:r"))
+  augroup END
+
+  e! Xtestfile.gz		" Edit compressed file
+  call assert_equal([
+	      \ 'line 2	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 3	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 4	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 5	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 6	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 7	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 8	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 9	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 10 Abcdefghijklmnopqrstuvwxyz'
+	      \ ], getline(1, 9))
+
+  w! >> test.out		" Append it to the output file
+
+  augroup Test3
+    au!
+  augroup END
+
+  " Test for the FilterReadPre and FilterReadPost autocmds.
+  set shelltemp			" need temp files here
+  augroup Test4
+    au!
+    au FilterReadPre   *.out  call rename(expand("<afile>"), expand("<afile>") . ".t")
+    au FilterReadPre   *.out  exe 'silent !sed s/e/E/ ' . shellescape(expand("<afile>")) . ".t >" . shellescape(expand("<afile>"))
+    au FilterReadPre   *.out  exe 'silent !rm ' . shellescape(expand("<afile>")) . '.t'
+    au FilterReadPost  *.out  '[,']s/x/X/g
+  augroup END
+
+  e! test.out			" Edit the output file
+  1,$!cat
+  call assert_equal([
+	      \ 'linE 2	AbcdefghijklmnopqrstuvwXyz',
+	      \ 'linE 3	XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+	      \ 'linE 4	AbcdefghijklmnopqrstuvwXyz',
+	      \ 'linE 5	XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+	      \ 'linE 6	AbcdefghijklmnopqrstuvwXyz',
+	      \ 'linE 7	XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+	      \ 'linE 8	AbcdefghijklmnopqrstuvwXyz',
+	      \ 'linE 9	XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+	      \ 'linE 10 AbcdefghijklmnopqrstuvwXyz'
+	      \ ], getline(1, 9))
+  call assert_equal([
+	      \ 'line 2	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 3	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 4	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 5	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 6	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 7	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 8	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 9	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 10 Abcdefghijklmnopqrstuvwxyz'
+	      \ ], readfile('test.out'))
+
+  augroup Test4
+    au!
+  augroup END
+  set shelltemp&vim
+
+  " Test for the FileReadPre and FileReadPost autocmds.
+  augroup Test5
+    au!
+    au FileReadPre *.gz exe 'silent !gzip -d ' . shellescape(expand("<afile>"))
+    au FileReadPre *.gz call rename(expand("<afile>:r"), expand("<afile>"))
+    au FileReadPost *.gz '[,']s/l/L/
+  augroup END
+
+  new
+  0r Xtestfile.gz		" Read compressed file
+  call assert_equal([
+	      \ 'Line 2	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'Line 3	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'Line 4	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'Line 5	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'Line 6	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'Line 7	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'Line 8	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'Line 9	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'Line 10 Abcdefghijklmnopqrstuvwxyz'
+	      \ ], getline(1, 9))
+  call assert_equal([
+	      \ 'line 2	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 3	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 4	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 5	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 6	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 7	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 8	Abcdefghijklmnopqrstuvwxyz',
+	      \ 'line 9	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+	      \ 'line 10 Abcdefghijklmnopqrstuvwxyz'
+	      \ ], readfile('Xtestfile.gz'))
+
+  augroup Test5
+    au!
+  augroup END
+
+  au! FileChangedShell
+  call delete('Xtestfile.gz')
+  call delete('Xtest.c')
+  call delete('test.out')
+endfunc

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1469,7 +1469,6 @@ func Test_ReadWrite_Autocmds()
   augroup END
 
   " Test for the FileAppendPre and FileAppendPost autocmds
-  call delete('test.out')
   augroup Test2
     au!
     au BufNewFile      *.c    read Xtest.c

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1469,6 +1469,7 @@ func Test_ReadWrite_Autocmds()
   augroup END
 
   " Test for the FileAppendPre and FileAppendPost autocmds
+  call delete('test.out')
   augroup Test2
     au!
     au BufNewFile      *.c    read Xtest.c

--- a/src/nvim/testdir/test_debugger.vim
+++ b/src/nvim/testdir/test_debugger.vim
@@ -1,0 +1,232 @@
+" Tests for the Vim script debug commands
+
+source shared.vim
+" source screendump.vim
+
+" Run a Vim debugger command
+" If the expected output argument is supplied, then check for it.
+func RunDbgCmd(buf, cmd, ...)
+  call term_sendkeys(a:buf, a:cmd . "\r")
+  call term_wait(a:buf)
+
+  if a:0 != 0
+    " Verify the expected output
+    let lnum = 20 - len(a:1)
+    for l in a:1
+      call WaitForAssert({-> assert_equal(l, term_getline(a:buf, lnum))})
+      let lnum += 1
+    endfor
+  endif
+endfunc
+
+" Debugger tests
+func Test_Debugger()
+  if !CanRunVimInTerminal()
+    return
+  endif
+
+  " Create a Vim script with some functions
+  call writefile([
+	      \ 'func Foo()',
+	      \ '  let var1 = 1',
+	      \ '  let var2 = Bar(var1) + 9',
+	      \ '  return var2',
+	      \ 'endfunc',
+	      \ 'func Bar(var)',
+	      \ '  let var1 = 2 + a:var',
+	      \ '  let var2 = Bazz(var1) + 4',
+	      \ '  return var2',
+	      \ 'endfunc',
+	      \ 'func Bazz(var)',
+	      \ '  let var1 = 3 + a:var',
+	      \ '  let var3 = "another var"',
+	      \ '  let var3 = "value2"',
+	      \ '  let var3 = "value3"',
+	      \ '  return var1',
+	      \ 'endfunc'], 'Xtest.vim')
+
+  " Start Vim in a terminal
+  let buf = RunVimInTerminal('-S Xtest.vim', {})
+
+  " Start the Vim debugger
+  call RunDbgCmd(buf, ':debug echo Foo()')
+
+  " Create a few stack frames by stepping through functions
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+
+  " check backtrace
+  call RunDbgCmd(buf, 'backtrace', [
+	      \ '  2 function Foo[2]',
+	      \ '  1 Bar[2]',
+	      \ '->0 Bazz',
+	      \ 'line 2: let var3 = "another var"'])
+
+  " Check variables in different stack frames
+  call RunDbgCmd(buf, 'echo var1', ['6'])
+
+  call RunDbgCmd(buf, 'up')
+  call RunDbgCmd(buf, 'back', [
+	      \ '  2 function Foo[2]',
+	      \ '->1 Bar[2]',
+	      \ '  0 Bazz',
+	      \ 'line 2: let var3 = "another var"'])
+  call RunDbgCmd(buf, 'echo var1', ['3'])
+
+  call RunDbgCmd(buf, 'u')
+  call RunDbgCmd(buf, 'bt', [
+	      \ '->2 function Foo[2]',
+	      \ '  1 Bar[2]',
+	      \ '  0 Bazz',
+	      \ 'line 2: let var3 = "another var"'])
+  call RunDbgCmd(buf, 'echo var1', ['1'])
+
+  " Undefined variables
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'frame 2')
+  call RunDbgCmd(buf, 'echo var3', [
+	\ 'Error detected while processing function Foo[2]..Bar[2]..Bazz:',
+	\ 'line    3:',
+	\ 'E121: Undefined variable: var3'])
+
+  " var3 is defined in this level with some other value
+  call RunDbgCmd(buf, 'fr 0')
+  call RunDbgCmd(buf, 'echo var3', ['another var'])
+
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'step', [
+	      \ 'function Foo[2]..Bar',
+	      \ 'line 3: End of function'])
+  call RunDbgCmd(buf, 'up')
+
+  " Undefined var2
+  call RunDbgCmd(buf, 'echo var2', [
+	      \ 'Error detected while processing function Foo[2]..Bar:',
+	      \ 'line    3:',
+	      \ 'E121: Undefined variable: var2'])
+
+  " Var2 is defined with 10
+  call RunDbgCmd(buf, 'down')
+  call RunDbgCmd(buf, 'echo var2', ['10'])
+
+  " Backtrace movements
+  call RunDbgCmd(buf, 'b', [
+	      \ '  1 function Foo[2]',
+	      \ '->0 Bar',
+	      \ 'line 3: End of function'])
+
+  " next command cannot go down, we are on bottom
+  call RunDbgCmd(buf, 'down', ['frame is zero'])
+  call RunDbgCmd(buf, 'up')
+
+  " next command cannot go up, we are on top
+  call RunDbgCmd(buf, 'up', ['frame at highest level: 1'])
+  call RunDbgCmd(buf, 'where', [
+	      \ '->1 function Foo[2]',
+	      \ '  0 Bar',
+	      \ 'line 3: End of function'])
+
+  " fil is not frame or finish, it is file
+  call RunDbgCmd(buf, 'fil', ['"[No Name]" --No lines in buffer--'])
+
+  " relative backtrace movement
+  call RunDbgCmd(buf, 'fr -1')
+  call RunDbgCmd(buf, 'frame', [
+	      \ '  1 function Foo[2]',
+	      \ '->0 Bar',
+	      \ 'line 3: End of function'])
+
+  call RunDbgCmd(buf, 'fr +1')
+  call RunDbgCmd(buf, 'fram', [
+	      \ '->1 function Foo[2]',
+	      \ '  0 Bar',
+	      \ 'line 3: End of function'])
+
+  " go beyond limits does not crash
+  call RunDbgCmd(buf, 'fr 100', ['frame at highest level: 1'])
+  call RunDbgCmd(buf, 'fra', [
+	      \ '->1 function Foo[2]',
+	      \ '  0 Bar',
+	      \ 'line 3: End of function'])
+
+  call RunDbgCmd(buf, 'frame -40', ['frame is zero'])
+  call RunDbgCmd(buf, 'fram', [
+	      \ '  1 function Foo[2]',
+	      \ '->0 Bar',
+	      \ 'line 3: End of function'])
+
+  " final result 19
+  call RunDbgCmd(buf, 'cont', ['19'])
+
+  " breakpoints tests
+
+  " Start a debug session, so that reading the last line from the terminal
+  " works properly.
+  call RunDbgCmd(buf, ':debug echo Foo()')
+
+  " No breakpoints
+  call RunDbgCmd(buf, 'breakl', ['No breakpoints defined'])
+
+  " Place some breakpoints
+  call RunDbgCmd(buf, 'breaka func Bar')
+  call RunDbgCmd(buf, 'breaklis', ['  1  func Bar  line 1'])
+  call RunDbgCmd(buf, 'breakadd func 3 Bazz')
+  call RunDbgCmd(buf, 'breaklist', ['  1  func Bar  line 1',
+	      \ '  2  func Bazz  line 3'])
+
+  " Check whether the breakpoints are hit
+  call RunDbgCmd(buf, 'cont', [
+	      \ 'Breakpoint in "Bar" line 1',
+	      \ 'function Foo[2]..Bar',
+	      \ 'line 1: let var1 = 2 + a:var'])
+  call RunDbgCmd(buf, 'cont', [
+	      \ 'Breakpoint in "Bazz" line 3',
+	      \ 'function Foo[2]..Bar[2]..Bazz',
+	      \ 'line 3: let var3 = "value2"'])
+
+  " Delete the breakpoints
+  call RunDbgCmd(buf, 'breakd 1')
+  call RunDbgCmd(buf, 'breakli', ['  2  func Bazz  line 3'])
+  call RunDbgCmd(buf, 'breakdel func 3 Bazz')
+  call RunDbgCmd(buf, 'breakl', ['No breakpoints defined'])
+
+  call RunDbgCmd(buf, 'cont')
+
+  " Make sure the breakpoints are removed
+  call RunDbgCmd(buf, ':echo Foo()', ['19'])
+
+  " Delete a non-existing breakpoint
+  call RunDbgCmd(buf, ':breakdel 2', ['E161: Breakpoint not found: 2'])
+
+  " Expression breakpoint
+  call RunDbgCmd(buf, ':breakadd func 2 Bazz')
+  call RunDbgCmd(buf, ':echo Bazz(1)')
+  call RunDbgCmd(buf, 'step')
+  call RunDbgCmd(buf, 'breaka expr var3')
+  call RunDbgCmd(buf, 'breakl', ['  4  expr var3'])
+  call RunDbgCmd(buf, 'cont', ['Breakpoint in "Bazz" line 4',
+	      \ 'Oldval = "''another var''"',
+	      \ 'Newval = "''value2''"',
+	      \ 'function Bazz',
+	      \ 'line 4: let var3 = "value3"'])
+
+  call RunDbgCmd(buf, 'breakdel *')
+  call RunDbgCmd(buf, 'breakl', ['No breakpoints defined'])
+
+  " finish the current function
+  call RunDbgCmd(buf, 'finish', [
+	      \ 'function Bazz',
+	      \ 'line 5: End of function'])
+  call RunDbgCmd(buf, 'cont')
+
+  call StopVimInTerminal(buf)
+
+  call delete('Xtest.vim')
+endfunc

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -4,6 +4,8 @@ if !has('multi_byte')
   finish
 endif
 
+source shared.vim
+
 func Test_abbreviation()
   " abbreviation with 0x80 should work
   inoreab чкпр   vim
@@ -173,6 +175,9 @@ func Test_abbr_after_line_join()
 endfunc
 
 func Test_map_timeout()
+  if !has('timers')
+    return
+  endif
   nnoremap aaaa :let got_aaaa = 1<CR>
   nnoremap bb :let got_bb = 1<CR>
   nmap b aaa
@@ -182,7 +187,7 @@ func Test_map_timeout()
     call feedkeys("\<Esc>", "t")
   endfunc
   set timeout timeoutlen=200
-  call timer_start(300, 'ExitInsert')
+  let timer = timer_start(300, 'ExitInsert')
   " After the 'b' Vim waits for another character to see if it matches 'bb'.
   " When it times out it is expanded to "aaa", but there is no wait for
   " "aaaa".  Can't check that reliably though.
@@ -197,6 +202,39 @@ func Test_map_timeout()
   nunmap b
   set timeoutlen&
   delfunc ExitInsert
+  call timer_stop(timer)
+endfunc
+
+func Test_map_timeout_with_timer_interrupt()
+  if !has('job') || !has('timers')
+    return
+  endif
+
+  " Confirm the timer invoked in exit_cb of the job doesn't disturb mapped key
+  " sequence.
+  new
+  let g:val = 0
+  nnoremap \12 :let g:val = 1<CR>
+  nnoremap \123 :let g:val = 2<CR>
+  set timeout timeoutlen=1000
+
+  func ExitCb(job, status)
+    let g:timer = timer_start(1, {_ -> feedkeys("3\<Esc>", 't')})
+  endfunc
+
+  call job_start([&shell, &shellcmdflag, 'echo'], {'exit_cb': 'ExitCb'})
+  call feedkeys('\12', 'xt!')
+  call assert_equal(2, g:val)
+
+  bwipe!
+  nunmap \12
+  nunmap \123
+  set timeoutlen&
+  call WaitFor({-> exists('g:timer')})
+  call timer_stop(g:timer)
+  unlet g:timer
+  unlet g:val
+  delfunc ExitCb
 endfunc
 
 func Test_cabbr_visual_mode()

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1818,7 +1818,7 @@ void undo_time(long step, bool sec, bool file, bool absolute)
   u_header_T      *uhp = NULL;
   u_header_T      *last;
   int mark;
-  int nomark;
+  int nomark = 0;  // shut up compiler
   int round;
   bool dosec = sec;
   bool dofile = file;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3847,7 +3847,7 @@ static void tabpage_check_windows(tabpage_T *old_curtab)
  */
 void goto_tabpage(int n)
 {
-  tabpage_T   *tp;
+  tabpage_T   *tp = NULL;  // shut up compiler
   tabpage_T   *ttp;
   int i;
 


### PR DESCRIPTION
**vim-patch:8.1.0837: timer interrupting cursorhold and mapping not tested**

Problem:    Timer interrupting cursorhold and mapping not tested.
Solution:   Add tests with timers. (Ozaki Kiichi, closes vim/vim#3871)
https://github.com/vim/vim/commit/26d982185e21398738a9c688429c0a1840d7c9c3

**vim-patch:8.1.1180: Vim script debugger tests are old style**
Problem:    Vim script debugger tests are old style.
Solution:   Turn into new style tests. (Yegappan Lakshmanan, closes vim/vim#4259)
vim/vim@113bf06

**vim-patch:8.1.1194: typos and small problems in source files**
Problem:    Typos and small problems in source files.
Solution:   Small fixes.
vim/vim@ad3ec76

**vim-patch:8.1.1203: some autocmd tests are old style**
Problem:    Some autocmd tests are old style.
Solution:   Turn the tests into new style. (Yegappan Lakshmanan, closes vim/vim#4295)
vim/vim@69ea587
18fddad

**vim-patch:8.1.1207: some compilers give warning messages**
Problem:    Some compilers give warning messages.
Solution:   Initialize variables, change printf() argument. (Christian Brabandt, closes vim/vim#4305)
vim/vim@1f3601e

**vim-patch:8.1.1209: clever compiler warns for buffer being too small**
Problem:    Clever compiler warns for buffer being too small.
Solution:   Make the buffer bigger (even though it's not really needed).
vim/vim@5431589