### PR TITLE
tui:cursor_goto(): remove dead code

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -704,14 +704,6 @@ static void cursor_goto(UI *ui, int row, int col)
     // even less expensive than using BSes or CUB.
     unibi_out(ui, unibi_carriage_return);
     ugrid_goto(grid, grid->row, 0);
-  } else if (col > grid->col) {
-      int n = col - grid->col;
-      if (n <= (row == grid->row ? 4 : 2)
-          && cheap_to_print(ui, grid->row, grid->col, n)) {
-        UGRID_FOREACH_CELL(grid, grid->row, grid->col, col, {
-          print_cell(ui, cell);
-        });
-      }
   }
   if (row == grid->row) {
     if (col < grid->col


### PR DESCRIPTION
fix #9918
ref dbc25f5a87cf3bcfe1caac1eb1ff8b3a6978a415

Before 7ede14d191b1 the UGRID_FOREACH_CELL loop was never entered,
because it expanded to an always-false condition.
From build/src/nvim/auto/tui/tui.i:

    do {
      UCell *row_cells = (grid)->cells[grid->row];
      for (int col = grid->col; col < col; col++) {
        UCell *cell = row_cells + col;
        (void)(cell);
        {
          print_cell(ui, cell);
        };
      }
    } while (0);

After 7ede14d191b1 issue #9918 was reported.

    $ ./build/bin/nvim -Nu NONE +'colo evening'
    :h<tab>  " causes cursor to change colors

Since the code was dead before 7ede14d191b1, just remove it.