### PR TITLE
vim-patch:8.0.1563

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2114,8 +2114,8 @@ gettabwinvar({tabnr}, {winnr}, {name} [, {def}])
 				any	{name} in {winnr} in tab page {tabnr}
 getwininfo([{winid}])		List	list of windows
 getwinpos([{timeout}])		List	X and Y coord in pixels of the Vim window
-getwinposx()			Number	X coord in pixels of GUI Vim window
-getwinposy()			Number	Y coord in pixels of GUI Vim window
+getwinposx()			Number	X coord in pixels of Vim window
+getwinposy()			Number	Y coord in pixels of Vim window
 getwinvar({nr}, {varname} [, {def}])
 				any	variable {varname} in window {nr}
 glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])
@@ -4549,6 +4549,13 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])		*gettabwinvar()*
 <
 		To obtain all window-local variables use: >
 			gettabwinvar({tabnr}, {winnr}, '&')
+
+getwinpos([{timeout}])					*getwinpos()*
+		The result is a list with two numbers, the result of
+		getwinposx() and getwinposy() combined: 
+			[x-pos, y-pos]
+		{timeout} can be used to specify how long to wait in msec for
+		a response from the terminal.  When omitted 100 msec is used.
 
 							*getwinposx()*
 getwinposx()	The result is a Number, which is the X coordinate in pixels of

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10474,6 +10474,14 @@ static void f_win_screenpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   tv_list_append_number(rettv->vval.v_list, wp == NULL ? 0 : wp->w_wincol + 1);
 }
 
+// "getwinpos({timeout})" function
+static void f_getwinpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  tv_list_alloc_ret(rettv, 2);
+  tv_list_append_number(rettv->vval.v_list, -1);
+  tv_list_append_number(rettv->vval.v_list, -1);
+}
+
 /*
  * "getwinposx()" function
  */

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -143,6 +143,7 @@ return {
     gettabvar={args={2, 3}},
     gettabwinvar={args={3, 4}},
     getwininfo={args={0, 1}},
+    getwinpos={args={0, 1}},
     getwinposx={},
     getwinposy={},
     getwinvar={args={2, 3}},


### PR DESCRIPTION
**vim-patch:8.0.1563: timeout of getwinposx() can be too short**

Problem:    Timeout of getwinposx() can be too short. (lilydjwg)
Solution:   Add getwinpos(). (closes vim/vim#2689)
https://github.com/vim/vim/commit/3f54fd319f6641b4bed478bcc90cdb39ede68e31

GUI test for this is in vim-patch:8.0.1840 (N/A, merged).