### PR TITLE
vim-patch:8.0.1750: crash when clearing loccation list in autocommand

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4980,9 +4980,6 @@ void ex_helpgrep(exarg_T *eap)
     }
   }
 
-  // Autocommands may change the list. Save it for later comparison
-  qf_info_T *save_qi = qi;
-
   regmatch.regprog = vim_regcomp(eap->arg, RE_MAGIC + RE_STRING);
   regmatch.rm_ic = FALSE;
   if (regmatch.regprog != NULL) {
@@ -5078,7 +5075,7 @@ void ex_helpgrep(exarg_T *eap)
   if (au_name != NULL) {
     apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
                    curbuf->b_fname, true, curbuf);
-    if (!new_qi && qi != save_qi && qf_find_buf(qi) == NULL) {
+    if (!new_qi && qi != &ql_info && qf_find_buf(qi) == NULL) {
       // autocommands made "qi" invalid
       return;
     }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2727,3 +2727,17 @@ func Test_empty_qfbuf()
   enew
   call delete('Xfile1')
 endfunc
+
+" The following test used to crash Vim
+func Test_lhelpgrep_autocmd()
+  lhelpgrep quickfix
+  autocmd QuickFixCmdPost * call setloclist(0, [], 'f')
+  lhelpgrep buffer
+  call assert_equal('help', &filetype)
+  call assert_equal(0, getloclist(0, {'nr' : '$'}).nr)
+  lhelpgrep tabpage
+  call assert_equal('help', &filetype)
+  call assert_equal(1, getloclist(0, {'nr' : '$'}).nr)
+  au! QuickFixCmdPost
+  new | only
+endfunc


### PR DESCRIPTION
Problem:    Crash when clearing loccation list in autocommand.
Solution:   Check if "qi" equals "ql_info". (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/3b9474b4ad4d85b5396f7f641b436f193dc9d486