### PR TITLE
vim-patch:8.0.1708,8.1.{369,794,1242}

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -432,6 +432,16 @@ flag when defining the function, it is not relevant when executing it. >
    .
    :endfunction
    :set cpo-=C
+<
+					*line-continuation-comment*
+To add a comment in between the lines start with '\" '.  Notice the space
+after the double quote.  Example: >
+	let array = [
+		"\ first entry comment
+		\ 'first',
+		"\ second entry comment
+		\ 'second',
+		\ ]
 
 Rationale:
 	Most programs work with a trailing backslash to indicate line
@@ -439,6 +449,14 @@ Rationale:
 	For example for this Vi mapping: >
 		:map xx  asdf\
 <	Therefore the unusual leading backslash is used.
+
+	Starting a comment in a continuation line results in all following
+	continuation lines to be part of the comment.  Since it was like this
+	for a long time, when making it possible to add a comment halfway a
+	sequence of continuation lines, it was not possible to use \", since
+	that was a valid continuation line.  Using '"\ ' comes closest, even
+	though it may look a bit weird.  Requiring the space after the
+	backslash is to make it very unlikely this is a normal comment line.
 
 ==============================================================================
 5. Using Vim packages					*packages*

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -10,7 +10,7 @@ endif
 let b:did_indent = 1
 
 setlocal indentexpr=GetVimIndent()
-setlocal indentkeys+==end,=else,=cat,=fina,=END,0\\
+setlocal indentkeys+==end,=else,=cat,=fina,=END,0\\,0=\"\\\ 
 
 let b:undo_indent = "setl indentkeys< indentexpr<"
 
@@ -31,15 +31,17 @@ function GetVimIndent()
   endtry
 endfunc
 
+let s:lineContPat = '^\s*\(\\\|"\\ \)'
+
 function GetVimIndentIntern()
   " Find a non-blank line above the current line.
   let lnum = prevnonblank(v:lnum - 1)
 
-  " If the current line doesn't start with '\' and below a line that starts
-  " with '\', use the indent of the line above it.
+  " If the current line doesn't start with '\' or '"\ ' and below a line that
+  " starts with '\' or '"\ ', use the indent of the line above it.
   let cur_text = getline(v:lnum)
-  if cur_text !~ '^\s*\\'
-    while lnum > 0 && getline(lnum) =~ '^\s*\\'
+  if cur_text !~ s:lineContPat
+    while lnum > 0 && getline(lnum) =~ s:lineContPat
       let lnum = lnum - 1
     endwhile
   endif
@@ -51,10 +53,10 @@ function GetVimIndentIntern()
   let prev_text = getline(lnum)
 
   " Add a 'shiftwidth' after :if, :while, :try, :catch, :finally, :function
-  " and :else.  Add it three times for a line that starts with '\' after
-  " a line that doesn't (or g:vim_indent_cont if it exists).
+  " and :else.  Add it three times for a line that starts with '\' or '"\ '
+  " after a line that doesn't (or g:vim_indent_cont if it exists).
   let ind = indent(lnum)
-  if cur_text =~ '^\s*\\' && v:lnum > 1 && prev_text !~ '^\s*\\'
+  if cur_text =~ s:lineContPat && v:lnum > 1 && prev_text !~ s:lineContPat
     if exists("g:vim_indent_cont")
       let ind = ind + g:vim_indent_cont
     else

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12880,33 +12880,36 @@ static void f_mkdir(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   char buf[NUMBUFLEN];
   const char *const dir = tv_get_string_buf(&argvars[0], buf);
   if (*dir == NUL) {
-    rettv->vval.v_number = FAIL;
-  } else {
-    if (*path_tail((char_u *)dir) == NUL) {
-      // Remove trailing slashes.
-      *path_tail_with_sep((char_u *)dir) = NUL;
-    }
-
-    if (argvars[1].v_type != VAR_UNKNOWN) {
-      if (argvars[2].v_type != VAR_UNKNOWN) {
-        prot = tv_get_number_chk(&argvars[2], NULL);
-      }
-      if (prot != -1 && strcmp(tv_get_string(&argvars[1]), "p") == 0) {
-        char *failed_dir;
-        int ret = os_mkdir_recurse(dir, prot, &failed_dir);
-        if (ret != 0) {
-          EMSG3(_(e_mkdir), failed_dir, os_strerror(ret));
-          xfree(failed_dir);
-          rettv->vval.v_number = FAIL;
-          return;
-        } else {
-          rettv->vval.v_number = OK;
-          return;
-        }
-      }
-    }
-    rettv->vval.v_number = prot == -1 ? FAIL : vim_mkdir_emsg(dir, prot);
+    return;
   }
+
+  if (*path_tail((char_u *)dir) == NUL) {
+    // Remove trailing slashes.
+    *path_tail_with_sep((char_u *)dir) = NUL;
+  }
+
+  if (argvars[1].v_type != VAR_UNKNOWN) {
+    if (argvars[2].v_type != VAR_UNKNOWN) {
+      prot = tv_get_number_chk(&argvars[2], NULL);
+      if (prot == -1) {
+        return;
+      }
+    }
+    if (strcmp(tv_get_string(&argvars[1]), "p") == 0) {
+      char *failed_dir;
+      int ret = os_mkdir_recurse(dir, prot, &failed_dir);
+      if (ret != 0) {
+        EMSG3(_(e_mkdir), failed_dir, os_strerror(ret));
+        xfree(failed_dir);
+        rettv->vval.v_number = FAIL;
+        return;
+      } else {
+        rettv->vval.v_number = OK;
+        return;
+      }
+    }
+  }
+  rettv->vval.v_number = vim_mkdir_emsg(dir, prot);
 }
 
 /// "mode()" function

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4506,7 +4506,7 @@ static int get_tabpage_arg(exarg_T *eap)
     } else {
       tab_number = eap->line2;
       if (!unaccept_arg0 && *skipwhite(*eap->cmdlinep) == '-') {
-        --tab_number;
+        tab_number--;
         if (tab_number < unaccept_arg0) {
           eap->errmsg = e_invarg;
         }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4505,7 +4505,7 @@ static int get_tabpage_arg(exarg_T *eap)
       tab_number = 0;
     } else {
       tab_number = eap->line2;
-      if (!unaccept_arg0 && **eap->cmdlinep == '-') {
+      if (!unaccept_arg0 && *skipwhite(*eap->cmdlinep) == '-') {
         --tab_number;
         if (tab_number < unaccept_arg0) {
           eap->errmsg = e_invarg;

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -38,3 +38,14 @@ func Test_mkdir_p()
   call delete('Xfile')
   call delete('Xmkdir', 'rf')
 endfunc
+
+func Test_line_continuation()
+  let array = [5,
+	"\ ignore this
+	\ 6,
+	"\ more to ignore
+	"\ more moreto ignore
+	\ ]
+	"\ and some more
+  call assert_equal([5, 6], array)
+endfunc

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -21,3 +21,20 @@ func Test_E963()
   call assert_fails("let v:oldfiles=''", 'E963:')
   call assert_equal(v_o, v:oldfiles)
 endfunc
+
+func Test_mkdir_p()
+  call mkdir('Xmkdir/nested', 'p')
+  call assert_true(isdirectory('Xmkdir/nested'))
+  try
+    " Trying to make existing directories doesn't error
+    call mkdir('Xmkdir', 'p')
+    call mkdir('Xmkdir/nested', 'p')
+  catch /E739:/
+    call assert_report('mkdir(..., "p") failed for an existing directory')
+  endtry
+  " 'p' doesn't suppress real errors
+  call writefile([], 'Xfile')
+  call assert_fails('call mkdir("Xfile", "p")', 'E739')
+  call delete('Xfile')
+  call delete('Xmkdir', 'rf')
+endfunc

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -105,6 +105,14 @@ function Test_tabpage()
   call assert_equal(4, tabpagenr())
   7tabmove 5
   call assert_equal(5, tabpagenr())
+  -tabmove
+  call assert_equal(4, tabpagenr())
+  +tabmove
+  call assert_equal(5, tabpagenr())
+  -2tabmove
+  call assert_equal(3, tabpagenr())
+  +3tabmove
+  call assert_equal(6, tabpagenr())
 
   " The following are a no-op
   norm! 2gt

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -1,5 +1,6 @@
 " Tests for tabpage
 
+" source screendump.vim
 
 function Test_tabpage()
   bw!
@@ -553,6 +554,29 @@ func Test_tabs()
 
   1tabonly!
   bw!
+endfunc
+
+func Test_tabpage_cmdheight()
+  if !CanRunVimInTerminal()
+    throw 'Skipped: only works with terminal'
+  endif
+  call writefile([
+        \ 'set laststatus=2',
+        \ 'set cmdheight=2',
+        \ 'tabnew',
+        \ 'set cmdheight=3',
+        \ 'tabnext',
+        \ 'redraw!',
+        \ 'echo "hello\nthere"',
+        \ 'tabnext',
+        \ 'redraw',
+	\ ], 'XTest_tabpage_cmdheight')
+  " Check that cursor line is concealed
+  let buf = RunVimInTerminal('-S XTest_tabpage_cmdheight', {'statusoff': 3})
+  call VerifyScreenDump(buf, 'Test_tabpage_cmdheight', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XTest_conceal')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3793,6 +3793,9 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, int trigger_enter_au
    * the frames for that.  When the Vim window was resized need to update
    * frame sizes too.  Use the stored value of p_ch, so that it can be
    * different for each tab page. */
+  if (p_ch != curtab->tp_ch_used) {
+    clear_cmdline = true;
+  }
   p_ch = curtab->tp_ch_used;
   if (curtab->tp_old_Rows != Rows || (old_off != firstwin->w_winrow
                                       ))


### PR DESCRIPTION
**vim-patch:8.0.1708: mkdir with 'p' flag fails on existing directory**
Problem:    Mkdir with 'p' flag fails on existing directory, which is
            different from the mkdir shell command.
Solution:   Don't fail if the directory already exists. (James McCoy,
            closes vim/vim#2775)
vim/vim@78a16b0

**vim-patch:8.1.0369: continuation lines cannot contain comments**
Problem:    Continuation lines cannot contain comments.
Solution:   Support using "\ .
vim/vim@67f8ab8

**vim-patch:8.1.0794: white space before " -Ntabmove" causes problems**
Problem:    White space before " -Ntabmove" causes problems.
Solution:   Skip whitespace. (Ozaki Kiichi, closes vim/vim#3841)
vim/vim@82a1246

**vim-patch:8.1.1242: no cmdline redraw when tabpages have different 'cmdheight'**

Problem:    No cmdline redraw when tabpages have different 'cmdheight'.
Solution:   redraw the command line when 'cmdheight' changes when switching
            tabpages. (closes vim/vim#4321)
vim/vim@0fef0ae