### PR TITLE
[RFC] vim-patch:8.1.{613,1046,1249}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5116,7 +5116,7 @@ chk_modeline(
       save_SID = current_SID;
       current_SID = SID_MODELINE;
       // Make sure no risky things are executed as a side effect.
-      secure++;
+      secure = 1;
 
       retval = do_set(s, OPT_MODELINE | OPT_LOCAL | flags);
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5112,6 +5112,7 @@ chk_modeline(
     *e = NUL;                         // truncate the set command
 
     if (*s != NUL) {                  // skip over an empty "::"
+      const int secure_save = secure;
       save_SID = current_SID;
       current_SID = SID_MODELINE;
       // Make sure no risky things are executed as a side effect.
@@ -5119,7 +5120,7 @@ chk_modeline(
 
       retval = do_set(s, OPT_MODELINE | OPT_LOCAL | flags);
 
-      secure--;
+      secure = secure_save;
       current_SID = save_SID;
       if (retval == FAIL) {                   // stop if error found
         break;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1840,11 +1840,10 @@ int do_set(
               // effects in secure mode.  Also when the value was
               // set with the P_INSECURE flag and is not
               // completely replaced.
-              if (secure
+              if ((opt_flags & OPT_MODELINE)
                   || sandbox != 0
-                  || (opt_flags & OPT_MODELINE)
                   || (!value_is_replaced && (*p & P_INSECURE))) {
-                secure++;
+                secure = 1;
               }
 
               // Handle side effects, and set the global value

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1833,7 +1833,7 @@ int do_set(
 
             {
               uint32_t *p = insecure_flag(opt_idx, opt_flags);
-              int did_inc_secure = false;
+              const int secure_saved = secure;
 
               // When an option is set in the sandbox, from a
               // modeline or in secure mode, then deal with side
@@ -1844,23 +1844,20 @@ int do_set(
                   || sandbox != 0
                   || (opt_flags & OPT_MODELINE)
                   || (!value_is_replaced && (*p & P_INSECURE))) {
-                  did_inc_secure = true;
-                  secure++;
+                secure++;
               }
 
-              // Handle side effects, and set the global value for
-              // ":set" on local options. Note: when setting 'syntax'
-              // or 'filetype' autocommands may be triggered that can
-              // cause havoc.
+              // Handle side effects, and set the global value
+              // for ":set" on local options. Note: when setting
+              // 'syntax' or 'filetype' autocommands may be
+              // triggered that can cause havoc.
               errmsg = did_set_string_option(opt_idx, (char_u **)varp,
                                              new_value_alloced, oldval,
                                              errbuf, sizeof(errbuf),
                                              opt_flags, &value_checked);
 
-              if (did_inc_secure) {
-                secure--;
-              }
-          }
+              secure = secure_saved;
+            }
 
             if (errmsg == NULL) {
               if (!starting) {

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -4968,13 +4968,15 @@ static int nfa_did_time_out(void)
 ///
 /// When "nfa_endp" is not NULL it is a required end-of-match position.
 ///
-/// Return TRUE if there is a match, FALSE otherwise.
+/// Return TRUE if there is a match, FALSE if there is no match,
+/// NFA_TOO_EXPENSIVE if we end up with too many states.
 /// When there is a match "submatch" contains the positions.
+///
 /// Note: Caller must ensure that: start != NULL.
 static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
                         regsubs_T *submatch, regsubs_T *m)
 {
-  int result;
+  int result = false;
   int flag = 0;
   bool go_to_nextline = false;
   nfa_thread_T *t;

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -677,6 +677,29 @@ func Test_OptionSet_diffmode_close()
   "delfunc! AutoCommandOptionSet
 endfunc
 
+func Test_OptionSet_modeline()
+  throw 'skipped: Nvim does not support test_override()'
+  call test_override('starting', 1)
+  au! OptionSet
+  augroup set_tabstop
+    au OptionSet tabstop call timer_start(1, {-> execute("echo 'Handler called'", "")})
+  augroup END
+  call writefile(['vim: set ts=7 sw=5 :', 'something'], 'XoptionsetModeline')
+  set modeline
+  let v:errmsg = ''
+  call assert_fails('split XoptionsetModeline', 'E12:')
+  call assert_equal(7, &ts)
+  call assert_equal('', v:errmsg)
+
+  augroup set_tabstop
+    au!
+  augroup END
+  bwipe!
+  set ts&
+  call delete('XoptionsetModeline')
+  call test_override('starting', 0)
+endfunc
+
 " Test for Bufleave autocommand that deletes the buffer we are about to edit.
 func Test_BufleaveWithDelete()
   new | edit Xfile1

--- a/src/nvim/testdir/test_findfile.vim
+++ b/src/nvim/testdir/test_findfile.vim
@@ -133,6 +133,7 @@ func Test_finddir()
   let save_shellslash = &shellslash
   let save_dir = getcwd()
   set path=,,
+  set shellslash
   call CreateFiles()
   cd Xdir1
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -82,7 +82,6 @@ fun! Test_normal00_optrans()
 endfunc
 
 func! Test_normal01_keymodel()
-  throw "skipped: Nvim regression: 'keymodel'"
   call Setup_NewWindow()
   " Test 1: depending on 'keymodel' <s-down> does something different
   50


### PR DESCRIPTION
**vim-patch:8.1.0613: when executing an insecure function the secure flag is stuck**
Problem:    When executing an insecure function the secure flag is stuck.
            (Gabriel Barta)
Solution:   Restore "secure" instead of decrementing it. (closes vim/vim#3705)
vim/vim@48f377a

**vim-patch:8.1.1046: the "secure" variable is used inconsistently**
Problem:    the "secure" variable is used inconsistently. (Justin M. Keyes)
Solution:   Set it to one instead of incrementing.
vim/vim@82b033e

**vim-patch:8.1.1249: compiler warning for uninitialized variable**
Problem:    Compiler warning for uninitialized variable.
Solution:   Initialize it. (Christian Brabandt)
vim/vim@c6b1cc9