### PR TITLE
vim-patch:8.0.{876,1144},8.1.0133

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1346,6 +1346,15 @@ void slash_adjust(char_u *p)
   if (path_with_url((const char *)p)) {
     return;
   }
+
+  if (*p == '`') {
+    // don't replace backslash in backtick quoted strings
+    const size_t len = STRLEN(p);
+    if (len > 2 && *(p + len - 1) == '`') {
+      return;
+    }
+  }
+
   while (*p) {
     if (*p == (char_u)psepcN) {
       *p = (char_u)psepc;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -430,7 +430,11 @@ static efm_T * parse_efm_option(char_u *efm)
   for (int round = FMT_PATTERNS - 1; round >= 0; ) {
     i += STRLEN(fmt_pat[round--].pattern);
   }
+#ifdef BACKSLASH_IN_FILENAME
+  i += 12;  // "%f" can become twelve chars longer (see efm_to_regpat)
+#else
   i += 2;   // "%f" can become two chars longer
+#endif
   char_u *fmtstr = xmalloc(i);
 
   while (efm[0] != NUL) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2044,9 +2044,10 @@ get_tagfname (
           return FAIL;  // avoid duplicate file names
         }
       }
-    } else
-      STRLCPY(buf, ((char_u **)(tag_fnames.ga_data))[
-            tnp->tn_hf_idx++], MAXPATHL);
+    } else {
+      STRLCPY(buf, ((char_u **)(tag_fnames.ga_data))[tnp->tn_hf_idx++],
+              MAXPATHL);
+    }
     return OK;
   }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1970,7 +1970,13 @@ static garray_T tag_fnames = GA_EMPTY_INIT_VALUE;
  */
 static void found_tagfile_cb(char_u *fname, void *cookie)
 {
-  GA_APPEND(char_u *, &tag_fnames, vim_strsave(fname));
+  char_u *const tag_fname = vim_strsave(fname);
+
+#ifdef BACKSLASH_IN_FILENAME
+    slash_adjust(tag_fname);
+#endif
+  simplify_filename(tag_fname);
+  GA_APPEND(char_u *, &tag_fnames, tag_fname);
 }
 
 #if defined(EXITFREE)
@@ -2028,6 +2034,16 @@ get_tagfname (
       ++tnp->tn_hf_idx;
       STRCPY(buf, p_hf);
       STRCPY(path_tail(buf), "tags");
+#ifdef BACKSLASH_IN_FILENAME
+      slash_adjust(buf);
+#endif
+      simplify_filename(buf);
+
+      for (int i = 0; i < tag_fnames.ga_len; i++) {
+        if (STRCMP(buf, ((char_u **)(tag_fnames.ga_data))[i]) == 0) {
+          return FAIL;  // avoid duplicate file names
+        }
+      }
     } else
       STRLCPY(buf, ((char_u **)(tag_fnames.ga_data))[
             tnp->tn_hf_idx++], MAXPATHL);

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -1,4 +1,4 @@
-" test 'taglist' function and :tags command
+" test taglist(), tagfiles() functions and :tags command
 
 func Test_taglist()
   call writefile([
@@ -73,4 +73,27 @@ func Test_tagsfile_without_trailing_newline()
   call assert_equal('Foo', tl[0].name)
 
   call delete('Xtags')
+endfunc
+
+func Test_tagfiles()
+  call assert_equal([], tagfiles())
+
+  call writefile(["FFoo\tXfoo\t1"], 'Xtags1')
+  call writefile(["FBar\tXbar\t1"], 'Xtags2')
+  set tags=Xtags1,Xtags2
+  call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
+
+  help
+  let tf = tagfiles()
+  call assert_equal(1, len(tf))
+  call assert_equal(fnamemodify(expand('$VIMRUNTIME/doc/tags'), ':p:gs?\\?/?'),
+	\           fnamemodify(tf[0], ':p:gs?\\?/?'))
+  helpclose
+  call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
+  set tags&
+  call assert_equal([], tagfiles())
+
+  call delete('Xtags1')
+  call delete('Xtags2')
+  bd
 endfunc


### PR DESCRIPTION
**vim-patch:8.0.0876: backslashes and wildcards in backticks don't work**
Problem:    MS-Windows: Backslashes and wildcards in backticks don't work.
Solution:   Do not handle backslashes inside backticks in the wrong place.
            (Yasuhiro Matsumoto, closes vim/vim#1942)
vim/vim@39d21e3

**vim-patch:8.0.1144: using wrong #ifdef for computing length**
Problem:    Using wrong #ifdef for computing length.
Solution:   use BACKSLASH_IN_FILENAME instead of COLON_IN_FILENAME. (Yasuhiro
            Matsomoto, closes vim/vim#2153)
vim/vim@0b05e49

**vim-patch:8.1.0133: tagfiles() can have duplicate entries**
Problem:    tagfiles() can have duplicate entries.
Solution:   Simplify the filename to make checking for duplicates work better.
            Add a test. (Dominique Pelle, closes vim/vim#2979)
vim/vim@46577b5