### PR TITLE
vim-patch:8.1.1205: BufReadPre may move the cursor

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -999,6 +999,16 @@ typedef struct {
                                           .relative = 0, .external = false, \
                                           .focusable = true })
 
+// Structure to store last cursor position and topline.  Used by check_lnums()
+// and reset_lnums().
+typedef struct
+{
+  int w_topline_save;   // original topline value
+  int w_topline_corr;   // corrected topline value
+  pos_T w_cursor_save;  // original cursor position
+  pos_T w_cursor_corr;  // corrected cursor position
+} pos_save_T;
+
 /// Structure which contains all information that belongs to a window.
 ///
 /// All row numbers are relative to the start of the window, except w_winrow.
@@ -1091,17 +1101,18 @@ struct window_S {
   colnr_T w_skipcol;                /* starting column when a single line
                                        doesn't fit in the window */
 
-  /*
-   * Layout of the window in the screen.
-   * May need to add "msg_scrolled" to "w_winrow" in rare situations.
-   */
-  int w_winrow;                     /* first row of window in screen */
-  int w_height;                     /* number of rows in window, excluding
-                                       status/command line(s) */
-  int w_status_height;              /* number of status lines (0 or 1) */
-  int w_wincol;                     /* Leftmost column of window in screen. */
-  int w_width;                      /* Width of window, excluding separation. */
-  int w_vsep_width;                 /* Number of separator columns (0 or 1). */
+  //
+  // Layout of the window in the screen.
+  // May need to add "msg_scrolled" to "w_winrow" in rare situations.
+  //
+  int w_winrow;                     // first row of window in screen
+  int w_height;                     // number of rows in window, excluding
+                                    // status/command line(s)
+  int w_status_height;              // number of status lines (0 or 1)
+  int w_wincol;                     // Leftmost column of window in screen.
+  int w_width;                      // Width of window, excluding separation.
+  int w_vsep_width;                 // Number of separator columns (0 or 1).
+  pos_save_T w_save_cursor;         // backup of cursor pos and topline
 
   // inner size of window, which can be overridden by external UI
   int w_height_inner;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -7072,6 +7072,8 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
     do_cmdline(NULL, getnextac, (void *)&patcmd,
                DOCMD_NOWAIT|DOCMD_VERBOSE|DOCMD_REPEAT);
 
+    reset_lnums();  // restore cursor and topline, unless they were changed
+
     if (eap != NULL) {
       (void)set_cmdarg(NULL, save_cmdarg);
       set_vim_var_nr(VV_CMDBANG, save_cmdbang);


### PR DESCRIPTION
Problem:    A BufReadPre autocommand may cause the cursor to move.
Solution:   Restore the cursor position after executing the autocommand,
            unless the autocommand moved it. (Christian Brabandt,
            closes vim/vim#4302, closes vim/vim#4294)
https://github.com/vim/vim/commit/a68e59590905da9b4448ff1fcac929ad1a18da9e