### PR TITLE
Fix aucmd_win issues: crashes and redrawing errors.

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3418,8 +3418,8 @@ void win_alloc_aucmd_win(void)
 {
   Error err = ERROR_INIT;
   FloatConfig fconfig = FLOAT_CONFIG_INIT;
-  fconfig.width = 20;
-  fconfig.height = 20;
+  fconfig.width = Columns;
+  fconfig.height = 5;
   fconfig.focusable = false;
   aucmd_win = win_new_float(NULL, fconfig, &err);
   aucmd_win->w_buffer->b_nwindows--;


### PR DESCRIPTION
```
function! Doit()
  let g:x = nvim_get_current_win()
  redraw!
  echo getchar()
endfunction

enew
call setline(1,"bb")
autocmd User <buffer> call Doit()
enew
doautoall User

" without the last line the screen is messed up
" and with this line nvim master will crash
"call nvim_set_current_win(g:x)
```