### PR TITLE
vim-patch:8.1.{865,1299}

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -678,8 +678,6 @@ static void win_update(win_T *wp)
       mod_bot = wp->w_redraw_bot + 1;
     else
       mod_bot = 0;
-    wp->w_redraw_top = 0;       /* reset for next time */
-    wp->w_redraw_bot = 0;
     if (buf->b_mod_set) {
       if (mod_top == 0 || mod_top > buf->b_mod_top) {
         mod_top = buf->b_mod_top;
@@ -776,6 +774,8 @@ static void win_update(win_T *wp)
     if (mod_top != 0 && buf->b_mod_xlines != 0 && wp->w_p_nu)
       mod_bot = MAXLNUM;
   }
+  wp->w_redraw_top = 0;  // reset for next time
+  wp->w_redraw_bot = 0;
 
   /*
    * When only displaying the lines at the top, set top_end.  Used when
@@ -2446,7 +2446,9 @@ win_line (
   }
 
   if (wp->w_p_list) {
-    if (curwin->w_p_lcs_chars.space || wp->w_p_lcs_chars.trail) {
+    if (curwin->w_p_lcs_chars.space
+        || wp->w_p_lcs_chars.trail
+        || wp->w_p_lcs_chars.nbsp) {
       extra_check = true;
     }
     // find start of trailing whitespace

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3995,8 +3995,10 @@ win_line (
       break;
     }
 
-    // line continues beyond line end
-    if (wp->w_p_lcs_chars.ext
+    // Show "extends" character from 'listchars' if beyond the line end and
+    // 'list' is set.
+    if (wp->w_p_lcs_chars.ext != NUL
+        && wp->w_p_list
         && !wp->w_p_wrap
         && filler_todo <= 0
         && (wp->w_p_rl ? col == 0 : col == grid->Columns - 1)

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -90,6 +90,26 @@ func Test_listchars()
 	      \ '.....h>-$',
 	      \ 'iii<<<<><<$', '$'], l)
 
+
+  " test nbsp
+  normal ggdG
+  set listchars=nbsp:X,trail:Y
+  set list
+  " Non-breaking space
+  let nbsp = nr2char(0xa0)
+  call append(0, [ ">".nbsp."<" ])
+
+  let expected = '>X< '
+
+  redraw!
+  call cursor(1, 1)
+  call assert_equal([expected], ScreenLines(1, virtcol('$')))
+
+  set listchars=nbsp:X
+  redraw!
+  call cursor(1, 1)
+  call assert_equal([expected], ScreenLines(1, virtcol('$')))
+
   enew!
   set listchars& ff&
 endfunc

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -110,6 +110,25 @@ func Test_listchars()
   call cursor(1, 1)
   call assert_equal([expected], ScreenLines(1, virtcol('$')))
 
+  " test extends
+  normal ggdG
+  set listchars=extends:Z
+  set nowrap
+  set nolist
+  call append(0, [ repeat('A', &columns + 1) ])
+
+  let expected = repeat('A', &columns)
+
+  redraw!
+  call cursor(1, 1)
+  call assert_equal([expected], ScreenLines(1, &columns))
+
+  set list
+  let expected = expected[:-2] . 'Z'
+  redraw!
+  call cursor(1, 1)
+  call assert_equal([expected], ScreenLines(1, &columns))
+
   enew!
   set listchars& ff&
 endfunc


### PR DESCRIPTION
**vim-patch:8.1.0865: when 'listchars' only contains "nbsp:X" it does not work**
Problem:    When 'listchars' only contains "nbsp:X" it does not work.
Solution:   Set extra_check when lcs_nbsp is set. (Ralf Schandl, closes vim/vim#3889)
vim/vim@895d966

**vim-patch:8.1.1299: "extends" from 'listchars' is used when 'list' is off**
Problem:    "extends" from 'listchars' is used when 'list' is off. (Hiroyuki Yoshinaga)
Solution:   Only use the "extends" character when 'list' is on. (Hirohito Higashi, closes vim/vim#4360)
vim/vim@a5c6a0b