### PR TITLE
vim-patch:8.1.{1306,1312}

### DIFF
--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -78,9 +78,8 @@ then the PDB was built with the EXE.
 
 If you have Visual Studio, use that instead of the VC Toolkit and WinDbg.
 
-For other compilers, you should always use the corresponding debugger: TD for
-a Vim executable compiled with the Borland compiler; gdb (see above
-|debug-gcc|) for the Cygwin and MinGW compilers.
+For other compilers, you should always use the corresponding debugger: gdb
+(see above |debug-gcc|) for the Cygwin and MinGW compilers.
 
 
 								*debug-vs2005*

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1298,7 +1298,12 @@ void dialog_changed(buf_T *buf, bool checkall)
 {
   char_u buff[DIALOG_MSG_SIZE];
   int ret;
-  exarg_T ea;
+  // Init ea pseudo-structure, this is needed for the check_overwrite()
+  // function.
+  exarg_T ea = {
+    .append = false,
+    .forceit = false,
+  };
 
   dialog_msg(buff, _("Save changes to \"%s\"?"), buf->b_fname);
   if (checkall) {
@@ -1306,10 +1311,6 @@ void dialog_changed(buf_T *buf, bool checkall)
   } else {
     ret = vim_dialog_yesnocancel(VIM_QUESTION, NULL, buff, 1);
   }
-
-  // Init ea pseudo-structure, this is needed for the check_overwrite()
-  // function.
-  ea.append = ea.forceit = false;
 
   if (ret == VIM_YES) {
     if (buf->b_fname != NULL

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4260,10 +4260,10 @@ static void restore_start_dir(char_u *dirname_start)
   if (STRCMP(dirname_start, dirname_now) != 0) {
     /* If the directory has changed, change it back by building up an
      * appropriate ex command and executing it. */
-    exarg_T ea;
-
-    ea.arg = dirname_start;
-    ea.cmdidx = (curwin->w_localdir == NULL) ? CMD_cd : CMD_lcd;
+    exarg_T ea = {
+      .arg = dirname_start,
+      .cmdidx = (curwin->w_localdir == NULL) ? CMD_cd : CMD_lcd,
+    };
     ex_cd(&ea);
   }
   xfree(dirname_now);


### PR DESCRIPTION
**vim-patch:8.1.1306: Borland support is outdated and doesn't work**
Problem:    Borland support is outdated and doesn't work.
Solution:   Remove Borland support, there are other (free) compilers
            available. (Thomas Dziedzic, Ken Takata, closes vim/vim#4364)
vim/vim@eae1b91

**vim-patch:8.1.1312: Coverity warning for using uninitialized variable**
Problem:    Coverity warning for using uninitialized variable.
Solution:   Clear exarg_T.
vim/vim@4ca4153

I diverged from the patch to avoid memset. Tried `{ 0 }` to zero-initialize the struct but got `Wmissing-field-initializer` warning.