### PR TITLE
vim-patch:8.1.0543

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1524,9 +1524,9 @@ void scroll_cursor_bot(int min_scroll, int set_topbot)
       /* Count screen lines that are below the window. */
       scrolled += loff.height;
       if (loff.lnum == curwin->w_botline
-          && boff.fill == 0
-          )
+          && loff.fill == 0) {
         scrolled -= curwin->w_empty_rows;
+      }
     }
 
     if (boff.lnum < curbuf->b_ml.ml_line_count) {


### PR DESCRIPTION
***vim-patch:8.1.0543: Coverity warns for leaking memory and using wrong struct**
Problem:    Coverity warns for leaking memory and using wrong struct.
Solution:   Free pointer when allocation fails. Change "boff" to "loff".
            (closes vim/vim#3634)
https://github.com/vim/vim/commit/4e303c8ba8dcd0566a1ad7c82ff18eb016eea335