### PR TITLE
[WIP] vim-patch:8.1.{1327,1347}

### DIFF
--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -648,16 +648,8 @@ endfunc
 
 func Test_split_noscroll()
   let so_save = &so
-  new
-  only
-
-  " Make sure windows can hold all content after split.
-  for i in range(1, 20)
-    wincmd +
-    redraw!
-  endfor
-
-  call setline (1, range(1, 8))
+  enew
+  call setline(1, range(1, 8))
   normal 100%
   split
 
@@ -672,12 +664,20 @@ func Test_split_noscroll()
   call assert_equal(1, info1.topline)
   call assert_equal(1, info2.topline)
 
-  " Restore original state.
-  for i in range(1, 20)
-    wincmd -
-    redraw!
-  endfor
+  " window that fits all lines by itself, but not when split: closing other
+  " window should restore fraction.
   only!
+  call setline(1, range(1, &lines - 10))
+  exe &lines / 4
+  let winid1 = win_getid()
+  let info1 = getwininfo(winid1)[0]
+  call assert_equal(1, info1.topline)
+  new
+  redraw
+  close
+  let info1 = getwininfo(winid1)[0]
+  call assert_equal(1, info1.topline)
+
   bwipe!
   let &so = so_save
 endfunc

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -646,6 +646,42 @@ func Test_relative_cursor_second_line_after_resize()
   let &so = so_save
 endfunc
 
+func Test_split_noscroll()
+  let so_save = &so
+  new
+  only
+
+  " Make sure windows can hold all content after split.
+  for i in range(1, 20)
+    wincmd +
+    redraw!
+  endfor
+
+  call setline (1, range(1, 8))
+  normal 100%
+  split
+
+  1wincmd w
+  let winid1 = win_getid()
+  let info1 = getwininfo(winid1)[0]
+
+  2wincmd w
+  let winid2 = win_getid()
+  let info2 = getwininfo(winid2)[0]
+
+  call assert_equal(1, info1.topline)
+  call assert_equal(1, info2.topline)
+
+  " Restore original state.
+  for i in range(1, 20)
+    wincmd -
+    redraw!
+  endfor
+  only!
+  bwipe!
+  let &so = so_save
+endfunc
+
 " Tests for the winnr() function
 func Test_winnr()
   only | tabonly

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5454,10 +5454,13 @@ void scroll_to_fraction(win_T *wp, int prev_height)
     int sline, line_size;
     int height = wp->w_height_inner;
 
-    // Don't change w_topline when height is zero.  Don't set w_topline when
-    // 'scrollbind' is set and this isn't the current window.
+  // Don't change w_topline in any of these cases:
+  // - window height is 0
+  // - 'scrollbind' is set and this isn't the current window
+  // - window height is sufficient to display the whole buffer
   if (height > 0
       && (!wp->w_p_scb || wp == curwin)
+      && (height < wp->w_buffer->b_ml.ml_line_count)
       ) {
     /*
      * Find a value for w_topline that shows the cursor at the same

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5457,10 +5457,11 @@ void scroll_to_fraction(win_T *wp, int prev_height)
   // Don't change w_topline in any of these cases:
   // - window height is 0
   // - 'scrollbind' is set and this isn't the current window
-  // - window height is sufficient to display the whole buffer
+  // - window height is sufficient to display the whole buffer and first line
+  //   is visible.
   if (height > 0
       && (!wp->w_p_scb || wp == curwin)
-      && (height < wp->w_buffer->b_ml.ml_line_count)
+      && (height < wp->w_buffer->b_ml.ml_line_count || wp->w_topline > 1)
       ) {
     /*
      * Find a value for w_topline that shows the cursor at the same


### PR DESCRIPTION
**vim-patch:8.1.1327: unnecessary scroll after horizontal split**
Problem:    Unnecessary scroll after horizontal split.
Solution:   Don't adjust to fraction if all the text fits in the window.
            (Martin Kunev, closes vim/vim#4367)
vim/vim@a9b2535

**vim-patch:8.1.1347: fractional scroll position not restored after closing window**
Problem:    Fractional scroll position not restored after closing window.
Solution:   Do restore fraction if topline is not one.
vim/vim@bd2d68c

This is missing some vim patches so I'll update the screen tests later.