### PR TITLE
doc: small fixes for nvim_open_win()

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1027,7 +1027,7 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
 ///      - "editor" the global editor grid
 ///      - "win"    a window. Use `win` to specify a window id,
 ///                 or the current window will be used by default.
-///      "cursor" the cursor position in current window.
+///      - "cursor" the cursor position in current window.
 ///   - `win`: When using relative='win', window id of the window where the
 ///       position is defined.
 ///   - `anchor`: The corner of the float that the row,col position defines:


### PR DESCRIPTION
I found small mistakes in doc for `nvim_open_win()`. This patch fixes them

- `"cursor"` value of `relative` config did not have its section
- Some lines exceeded max columns (78 chars)

EDIT: Removed one redundant space by force push