### PR TITLE
[RFC] Port of the termdebug.vim plugin to neovim terminal feature (Part 2).

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -328,9 +328,9 @@ To change the name of the gdb command, set the "termdebugger" variable before
 invoking `:Termdebug`: >
 	let termdebugger = "mygdb"
 
-To use neovim floating windows for previewing variable evaluation, set the
+To not use neovim floating windows for previewing variable evaluation, set the
 `g:termdebug_useFloatingHover` variable like this: >
-	let g:termdebug_useFloatingHover = 1
+	let g:termdebug_useFloatingHover = 0
 
 If you are a mouse person, you can also define a mapping using your right
 click to one of the terminal command like evaluate the variable under the

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -685,7 +685,7 @@ function! s:OpenHoverPreview(lines, filetype) abort
 
       execute 'noswapfile edit!' bufname
 
-      setlocal winhl=Normal:CursorLine
+      setlocal winhl=Normal:NormalFloat
       setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no
 
       if a:filetype isnot v:null

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -593,7 +593,7 @@ function! s:CloseFloatingHoverOnCursorMove(win_id, opened) abort
     " was really moved
     return
   endif
-  autocmd! termdebug-close-hover
+  autocmd! nvim_termdebug_close_hover
   let winnr = win_id2win(a:win_id)
   if winnr == 0
     return
@@ -605,7 +605,7 @@ function! s:CloseFloatingHoverOnBufEnter(win_id, bufnr) abort
     let winnr = win_id2win(a:win_id)
     if winnr == 0
         " Float window was already closed
-        autocmd! termdebug-close-hover
+        autocmd! nvim_termdebug_close_hover
         return
     endif
     if winnr == winnr()
@@ -616,7 +616,7 @@ function! s:CloseFloatingHoverOnBufEnter(win_id, bufnr) abort
         " When current buffer opened hover window, it's not another buffer. Skipped
         return
     endif
-    autocmd! termdebug-close-hover
+    autocmd! nvim_termdebug_close_hover
     call nvim_win_close(a:win_id, v:true)
   endfunction
 
@@ -632,14 +632,10 @@ function! s:OpenHoverPreview(lines, filetype) abort
     if use_float_win
       let pos = getpos('.')
 
-      " Calculate width and height and give margin to lines
+      " Calculate width and height
       let width = 0
       for index in range(len(lines))
         let line = lines[index]
-        if line !=# ''
-          " Give a left margin
-          let line = ' ' . line
-        endif
         let lw = strdisplaywidth(line)
         if lw > width
           let width = lw
@@ -647,9 +643,6 @@ function! s:OpenHoverPreview(lines, filetype) abort
         let lines[index] = line
       endfor
 
-      " Give margin
-      let width += 1
-      let lines = [''] + lines + ['']
       let height = len(lines)
 
       " Calculate anchor
@@ -698,7 +691,7 @@ function! s:OpenHoverPreview(lines, filetype) abort
       " hover window automatically when cursor is moved.
       let call_after_move = printf('<SID>CloseFloatingHoverOnCursorMove(%d, %s)', float_win_id, string(pos))
       let call_on_bufenter = printf('<SID>CloseFloatingHoverOnBufEnter(%d, %d)', float_win_id, bufnr)
-      augroup termdebug-close-hover
+      augroup nvim_termdebug_close_hover
         execute 'autocmd CursorMoved,CursorMovedI,InsertEnter <buffer> call ' . call_after_move
         execute 'autocmd BufEnter * call ' . call_on_bufenter
       augroup END

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -579,7 +579,7 @@ func s:HandleEvaluate(msg)
 endfunc
 
 function! s:ShouldUseFloatWindow() abort
-  if exists('*nvim_open_win') && exists('g:termdebug_useFloatingHover') && (g:termdebug_useFloatingHover == 1)
+  if exists('*nvim_open_win') && (get(g:, 'termdebug_useFloatingHover', 1) == 1)
     return v:true
   else
     return v:false

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -630,8 +630,6 @@ function! s:OpenHoverPreview(lines, filetype) abort
 
     let use_float_win = s:ShouldUseFloatWindow()
     if use_float_win
-      let bufname = nvim_create_buf(v:false, v:true)
-      call nvim_buf_set_lines(bufname, 0, -1, v:true, lines)
       let pos = getpos('.')
 
       " Calculate width and height and give margin to lines
@@ -674,7 +672,11 @@ function! s:OpenHoverPreview(lines, filetype) abort
         let col = 1
       endif
 
-      let float_win_id = nvim_open_win(bufnr, v:true, {
+      let buf = nvim_create_buf(v:false, v:true)
+      call nvim_buf_set_lines(buf, 0, -1, v:true, lines)
+      " using v:true for second argument of nvim_open_win make the floating
+      " window disappear
+      let float_win_id = nvim_open_win(buf, v:false, {
             \   'relative': 'cursor',
             \   'anchor': vert . hor,
             \   'row': row,
@@ -682,9 +684,6 @@ function! s:OpenHoverPreview(lines, filetype) abort
             \   'width': width,
             \   'height': height,
             \ })
-
-      execute 'noswapfile edit!' bufname
-
       setlocal winhl=Normal:NormalFloat
       setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no
 
@@ -692,10 +691,8 @@ function! s:OpenHoverPreview(lines, filetype) abort
         let &filetype = a:filetype
       endif
 
-      call setline(1, lines)
+      " cannot use nvim_win_set_option for these options
       setlocal nomodified nomodifiable
-
-      wincmd p
 
       " Unlike preview window, :pclose does not close window. Instead, close
       " hover window automatically when cursor is moved.

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -684,11 +684,11 @@ function! s:OpenHoverPreview(lines, filetype) abort
             \   'width': width,
             \   'height': height,
             \ })
-      setlocal winhl=Normal:NormalFloat
-      setlocal buftype=nofile nobuflisted bufhidden=wipe nonumber norelativenumber signcolumn=no
-
+      call nvim_win_set_option(float_win_id, 'relativenumber', v:false)
+      call nvim_win_set_option(float_win_id, 'signcolumn', 'no')
+      call nvim_win_set_option(float_win_id, 'signcolumn', 'no')
       if a:filetype isnot v:null
-        let &filetype = a:filetype
+        call nvim_win_set_option(float_win_id, 'filetype', a:filetype)
       endif
 
       " cannot use nvim_win_set_option for these options

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -691,8 +691,8 @@ function! s:OpenHoverPreview(lines, filetype) abort
         call nvim_win_set_option(float_win_id, 'filetype', a:filetype)
       endif
 
-      " cannot use nvim_win_set_option for these options
-      setlocal nomodified nomodifiable
+      call nvim_buf_set_option(buf, 'modified', v:false)
+      call nvim_buf_set_option(buf, 'modifiable', v:false)
 
       " Unlike preview window, :pclose does not close window. Instead, close
       " hover window automatically when cursor is moved.


### PR DESCRIPTION
The last commit of the previous pr #8364 broke the floating window feature, so this pr mainly fixed that.
Also, fix up review comments of last pr:

* [X] Use `NormalFloat` instead of `CursorLine`
* [X] Use `nvim_win_close` to close the floating window.