### PR TITLE
channel: refactor events, prevent recursive invocation of callbacks

### DIFF
--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -42,13 +42,16 @@ typedef struct {
   Callback cb;
   dict_T *self;
   garray_T buffer;
+  bool eof;
   bool buffered;
+  const char *type;
 } CallbackReader;
 
 #define CALLBACK_READER_INIT ((CallbackReader){ .cb = CALLBACK_NONE, \
                                                 .self = NULL, \
                                                 .buffer = GA_EMPTY_INIT_VALUE, \
-                                                .buffered = false })
+                                                .buffered = false, \
+                                                .type = NULL })
 static inline bool callback_reader_set(CallbackReader reader)
 {
   return reader.cb.type != kCallbackNone || reader.self;
@@ -73,9 +76,13 @@ struct Channel {
   RpcState rpc;
   Terminal *term;
 
-  CallbackReader on_stdout;
+  CallbackReader on_data;
   CallbackReader on_stderr;
   Callback on_exit;
+  int exit_status;
+
+  bool callback_busy;
+  bool callback_scheduled;
 };
 
 EXTERN PMap(uint64_t) *channels;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5165,7 +5165,7 @@ bool garbage_collect(bool testing)
   {
     Channel *data;
     map_foreach_value(channels, data, {
-      set_ref_in_callback_reader(&data->on_stdout, copyID, NULL, NULL);
+      set_ref_in_callback_reader(&data->on_data, copyID, NULL, NULL);
       set_ref_in_callback_reader(&data->on_stderr, copyID, NULL, NULL);
       set_ref_in_callback(&data->on_exit, copyID, NULL, NULL);
     })


### PR DESCRIPTION
Attempt of refactoring the channel event logic. Eliminate allocated event state and instead keep all state in `Channel` struct. Without recursion, callback logic should be a finite state machine. So we "just" need to to the right thing at every event in each state.

Note: `jobwait()` (as used by the relevant test) _removes_ the waited channels from the main queue (one can argue it shouldn't), so I had to change the test to reproduce the issue on master.