### PR TITLE
vim-patch:8.1.{1325,1345,1348,1349}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3819,7 +3819,6 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
         if (!preview || has_second_delim) {
           if (subflags.do_count) {
             // prevent accidentally changing the buffer by a function
-            save_ma = curbuf->b_p_ma;
             curbuf->b_p_ma = false;
             sandbox++;
           }
@@ -3832,13 +3831,9 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
                                     sub, sub_firstline, false, p_magic, true);
           // If getting the substitute string caused an error, don't do
           // the replacement.
-          if (aborting()) {
-            goto skip;
-          }
-
           // Don't keep flags set by a recursive call
           subflags = subflags_save;
-          if (subflags.do_count) {
+          if (aborting() || subflags.do_count) {
             curbuf->b_p_ma = save_ma;
             if (sandbox > 0) {
               sandbox--;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3693,9 +3693,11 @@ restore_backup:
   /*
    * Remove the backup unless 'backup' option is set
    */
-  if (!p_bk && backup != NULL && os_remove((char *)backup) != 0)
+  if (!p_bk && backup != NULL
+      && !write_info.bw_conv_error
+      && os_remove((char *)backup) != 0) {
     EMSG(_("E207: Can't delete backup file"));
-
+  }
 
   goto nofail;
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -72,7 +72,31 @@ if has('timers')
     au! CursorHoldI
     set updatetime&
   endfunc
-endif
+
+  func Test_OptionSet_modeline()
+    throw 'skipped: Nvim does not support test_override()'
+    call test_override('starting', 1)
+    au! OptionSet
+    augroup set_tabstop
+      au OptionSet tabstop call timer_start(1, {-> execute("echo 'Handler called'", "")})
+    augroup END
+    call writefile(['vim: set ts=7 sw=5 :', 'something'], 'XoptionsetModeline')
+    set modeline
+    let v:errmsg = ''
+    call assert_fails('split XoptionsetModeline', 'E12:')
+    call assert_equal(7, &ts)
+    call assert_equal('', v:errmsg)
+
+    augroup set_tabstop
+      au!
+    augroup END
+    bwipe!
+    set ts&
+    call delete('XoptionsetModeline')
+    call test_override('starting', 0)
+  endfunc
+
+endif "has('timers')
 
 func Test_bufunload()
   augroup test_bufunload_group
@@ -675,29 +699,6 @@ func Test_OptionSet_diffmode_close()
   au! OptionSet
   call test_override('starting', 0)
   "delfunc! AutoCommandOptionSet
-endfunc
-
-func Test_OptionSet_modeline()
-  throw 'skipped: Nvim does not support test_override()'
-  call test_override('starting', 1)
-  au! OptionSet
-  augroup set_tabstop
-    au OptionSet tabstop call timer_start(1, {-> execute("echo 'Handler called'", "")})
-  augroup END
-  call writefile(['vim: set ts=7 sw=5 :', 'something'], 'XoptionsetModeline')
-  set modeline
-  let v:errmsg = ''
-  call assert_fails('split XoptionsetModeline', 'E12:')
-  call assert_equal(7, &ts)
-  call assert_equal('', v:errmsg)
-
-  augroup set_tabstop
-    au!
-  augroup END
-  bwipe!
-  set ts&
-  call delete('XoptionsetModeline')
-  call test_override('starting', 0)
 endfunc
 
 " Test for Bufleave autocommand that deletes the buffer we are about to edit.

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1385,9 +1385,26 @@ func Test_edit_complete_very_long_name()
     return
   endtry
 
-  " Try to get the Vim window position before setting 'columns'.
+  " Try to get the Vim window position before setting 'columns', so that we can
+  " move the window back to where it was.
   let winposx = getwinposx()
   let winposy = getwinposy()
+
+  if winposx >= 0 && winposy >= 0 && !has('gui_running')
+    " We did get the window position, but xterm may report the wrong numbers.
+    " Move the window to the reported position and compute any offset.
+    exe 'winpos ' . winposx . ' ' . winposy
+    sleep 100m
+    let x = getwinposx()
+    if x >= 0
+      let winposx += winposx - x
+    endif
+    let y = getwinposy()
+    if y >= 0
+      let winposy += winposy - y
+    endif
+  endif
+
   let save_columns = &columns
   " Need at least about 1100 columns to reproduce the problem.
   set columns=2000

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -639,6 +639,17 @@ func Test_nocatch_sub_failure_handling()
   call assert_equal(1, error_caught)
   call assert_equal(['1 aaa', '2 aaa', '3 aaa'], getline(1, 3))
 
+  " Same, but using "n" flag so that "sandbox" gets set
+  call setline(1, ['1 aaa', '2 aaa', '3 aaa'])
+  let error_caught = 0
+  try
+    %s/aaa/\=Foo()/gn
+  catch
+    let error_caught = 1
+  endtry
+  call assert_equal(1, error_caught)
+  call assert_equal(['1 aaa', '2 aaa', '3 aaa'], getline(1, 3))
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
**vim-patch:8.1.1325: cannot build with +eval but without +channel and +timers**
Problem:    Cannot build with +eval but without +channel and +timers. (John
            Marriott)
Solution:   Adjust #ifdef for get_callback().
vim/vim@97b0075

**vim-patch:8.1.1345: stuck in sandbox with ":s/../\=Function/gn"**
Problem:    Stuck in sandbox with ":s/../\=Function/gn".
Solution:   Don't skip over code to restore sandbox. (Christian Brabandt)
vim/vim@6349e94

**im-patch:8.1.1348: running tests may cause the window to move**
Problem:    Running tests may cause the window to move.
Solution:   Correct the reported window position for the offset with the
            position after ":winpos".  Works around an xterm bug.
vim/vim@f8191c5

**vim-patch:8.1.1349: if writing runs into conversion error backup file is deleted**
Problem:    If writing runs into a conversion error the backup file is
            deleted. (Arseny Nasokin)
Solution:   Don't delete the backup file is the file was overwritten and a
            conversion error occurred. (Christian Brabandt, closes vim/vim#4387)
vim/vim@cf0bfd9