### PR TITLE
[RFC] vim-patch:8.1.{1352,1353}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10830,6 +10830,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 #ifdef __APPLE__
     "mac",
     "macunix",
+    "osx",
 #endif
     "menu",
     "mksession",

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17669,7 +17669,7 @@ static void f_undofile(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     // If there is no file name there will be no undo file.
     rettv->vval.v_string = NULL;
   } else {
-    char *ffname = FullName_save(fname, false);
+    char *ffname = FullName_save(fname, true);
 
     if (ffname != NULL) {
       rettv->vval.v_string = (char_u *)u_get_undo_file_name(ffname, false);

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -389,6 +389,11 @@ funct Test_undofile()
   " Test undofile() with 'undodir' set to a non-existing directory.
   " call assert_equal('', undofile('Xundofoo'))
 
+  if isdirectory('/tmp')
+    set undodir=/tmp
+    call assert_equal('/tmp/%tmp%file', undofile('///tmp/file'))
+  endif
+
   set undodir&
 endfunc
 

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -391,7 +391,11 @@ funct Test_undofile()
 
   if isdirectory('/tmp')
     set undodir=/tmp
-    call assert_equal('/tmp/%tmp%file', undofile('///tmp/file'))
+    if has('osx')
+      call assert_equal('/tmp/%private%tmp%file', undofile('///tmp/file'))
+    else
+      call assert_equal('/tmp/%tmp%file', undofile('///tmp/file'))
+    endif
   endif
 
   set undodir&


### PR DESCRIPTION
#### vim-patch:8.1.1352: undofile() reports wrong name

Problem:    Undofile() reports wrong name. (Francisco Giordano)
Solution:   Clean up the name before changing path separators. (closes vim/vim#4392,
            closes vim/vim#4394)
https://github.com/vim/vim/commit/e9ebc9a91cac357fd4888f4b71fdff7d97b41160

#### vim-patch:8.1.1353: undo test fails on Mac

Problem:    Undo test fails on Mac.
Solution:   Expect "private" on the Mac.
https://github.com/vim/vim/commit/2b39d806f04c1a474b6d689a7970253850d4adb8

Fixes #10030.