### PR TITLE
refactor: introduce XFREE_CLEAR()

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -809,8 +809,7 @@ free_buffer_stuff(
   bufhl_clear_all(buf);                // delete any highligts
   map_clear_int(buf, MAP_ALL_MODES, true, false);    // clear local mappings
   map_clear_int(buf, MAP_ALL_MODES, true, true);     // clear local abbrevs
-  xfree(buf->b_start_fenc);
-  buf->b_start_fenc = NULL;
+  XFREE_CLEAR(buf->b_start_fenc);
 
   buf_updates_unregister_all(buf);
 }
@@ -1756,10 +1755,8 @@ buf_T * buflist_new(char_u *ffname, char_u *sfname, linenr_T lnum, int flags)
   buf->b_wininfo = xcalloc(1, sizeof(wininfo_T));
 
   if (ffname != NULL && (buf->b_ffname == NULL || buf->b_sfname == NULL)) {
-    xfree(buf->b_ffname);
-    buf->b_ffname = NULL;
-    xfree(buf->b_sfname);
-    buf->b_sfname = NULL;
+    XFREE_CLEAR(buf->b_ffname);
+    XFREE_CLEAR(buf->b_sfname);
     if (buf != curbuf) {
       free_buffer(buf);
     }
@@ -2665,10 +2662,8 @@ setfname(
 
   if (ffname == NULL || *ffname == NUL) {
     // Removing the name.
-    xfree(buf->b_ffname);
-    xfree(buf->b_sfname);
-    buf->b_ffname = NULL;
-    buf->b_sfname = NULL;
+    XFREE_CLEAR(buf->b_ffname);
+    XFREE_CLEAR(buf->b_sfname);
   } else {
     fname_expand(buf, &ffname, &sfname);    // will allocate ffname
     if (ffname == NULL) {                   // out of memory
@@ -3791,8 +3786,7 @@ int build_stl_str_hl(
       if (str != NULL && *str != 0) {
         if (*skipdigits(str) == NUL) {
           num = atoi((char *)str);
-          xfree(str);
-          str = NULL;
+          XFREE_CLEAR(str);
           itemisflag = false;
         }
       }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -662,8 +662,7 @@ static void diff_redraw(int dofold)
 static void clear_diffin(diffin_T *din)
 {
   if (din->din_fname == NULL) {
-    xfree(din->din_mmfile.ptr);
-    din->din_mmfile.ptr = NULL;
+    XFREE_CLEAR(din->din_mmfile.ptr);
   } else {
     os_remove((char *)din->din_fname);
   }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2522,8 +2522,7 @@ static void ins_compl_del_pum(void)
 {
   if (compl_match_array != NULL) {
     pum_undisplay(false);
-    xfree(compl_match_array);
-    compl_match_array = NULL;
+    XFREE_CLEAR(compl_match_array);
   }
 }
 
@@ -2592,8 +2591,7 @@ void ins_compl_show_pum(void)
      * not use "compl_leader" as prefix filter.
      */
     if (ins_compl_need_restart()){
-      xfree(compl_leader);
-      compl_leader = NULL;
+      XFREE_CLEAR(compl_leader);
     }
     if (compl_leader != NULL)
       lead_len = (int)STRLEN(compl_leader);
@@ -2960,10 +2958,8 @@ static void ins_compl_free(void)
   compl_T *match;
   int i;
 
-  xfree(compl_pattern);
-  compl_pattern = NULL;
-  xfree(compl_leader);
-  compl_leader = NULL;
+  XFREE_CLEAR(compl_pattern);
+  XFREE_CLEAR(compl_leader);
 
   if (compl_first_match == NULL)
     return;
@@ -2993,13 +2989,10 @@ static void ins_compl_clear(void)
   compl_cont_status = 0;
   compl_started = FALSE;
   compl_matches = 0;
-  xfree(compl_pattern);
-  compl_pattern = NULL;
-  xfree(compl_leader);
-  compl_leader = NULL;
+  XFREE_CLEAR(compl_pattern);
+  XFREE_CLEAR(compl_leader);
   edit_submode_extra = NULL;
-  xfree(compl_orig_text);
-  compl_orig_text = NULL;
+  XFREE_CLEAR(compl_orig_text);
   compl_enter_selects = FALSE;
   // clear v:completed_item
   set_vim_var_dict(VV_COMPLETED_ITEM, tv_dict_alloc());
@@ -4960,10 +4953,8 @@ static int ins_complete(int c, bool enable_pum)
     compl_orig_text = vim_strnsave(line + compl_col, compl_length);
     if (ins_compl_add(compl_orig_text, -1, p_ic, NULL, NULL, false, 0,
                       ORIGINAL_TEXT, false, false) != OK) {
-      xfree(compl_pattern);
-      compl_pattern = NULL;
-      xfree(compl_orig_text);
-      compl_orig_text = NULL;
+      XFREE_CLEAR(compl_pattern);
+      XFREE_CLEAR(compl_orig_text);
       return FAIL;
     }
 
@@ -6310,10 +6301,8 @@ void set_last_insert(int c)
 #if defined(EXITFREE)
 void free_last_insert(void)
 {
-  xfree(last_insert);
-  last_insert = NULL;
-  xfree(compl_orig_text);
-  compl_orig_text = NULL;
+  XFREE_CLEAR(last_insert);
+  XFREE_CLEAR(compl_orig_text);
 }
 
 #endif
@@ -6840,8 +6829,7 @@ static void mb_replace_pop_ins(int cc)
  */
 static void replace_flush(void)
 {
-  xfree(replace_stack);
-  replace_stack = NULL;
+  XFREE_CLEAR(replace_stack);
   replace_stack_len = 0;
   replace_stack_nr = 0;
 }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2586,15 +2586,16 @@ void ins_compl_show_pum(void)
     // Need to build the popup menu list.
     compl_match_arraysize = 0;
     compl = compl_first_match;
-    /*
-     * If it's user complete function and refresh_always,
-     * not use "compl_leader" as prefix filter.
-     */
-    if (ins_compl_need_restart()){
+    //
+    // If it's user complete function and refresh_always,
+    // do not use "compl_leader" as prefix filter.
+    //
+    if (ins_compl_need_restart()) {
       XFREE_CLEAR(compl_leader);
     }
-    if (compl_leader != NULL)
+    if (compl_leader != NULL) {
       lead_len = (int)STRLEN(compl_leader);
+    }
     do {
       if ((compl->cp_flags & ORIGINAL_TEXT) == 0
           && (compl_leader == NULL
@@ -2993,7 +2994,7 @@ static void ins_compl_clear(void)
   XFREE_CLEAR(compl_leader);
   edit_submode_extra = NULL;
   XFREE_CLEAR(compl_orig_text);
-  compl_enter_selects = FALSE;
+  compl_enter_selects = false;
   // clear v:completed_item
   set_vim_var_dict(VV_COMPLETED_ITEM, tv_dict_alloc());
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -622,8 +622,7 @@ void eval_clear(void)
   for (size_t i = 0; i < ARRAY_SIZE(vimvars); i++) {
     p = &vimvars[i];
     if (p->vv_di.di_tv.v_type == VAR_STRING) {
-      xfree(p->vv_str);
-      p->vv_str = NULL;
+      XFREE_CLEAR(p->vv_str);
     } else if (p->vv_di.di_tv.v_type == VAR_LIST) {
       tv_list_unref(p->vv_list);
       p->vv_list = NULL;
@@ -842,15 +841,12 @@ void var_redir_stop(void)
       clear_lval(redir_lval);
     }
 
-    /* free the collected output */
-    xfree(redir_ga.ga_data);
-    redir_ga.ga_data = NULL;
+    // free the collected output
+    XFREE_CLEAR(redir_ga.ga_data);
 
-    xfree(redir_lval);
-    redir_lval = NULL;
+    XFREE_CLEAR(redir_lval);
   }
-  xfree(redir_varname);
-  redir_varname = NULL;
+  XFREE_CLEAR(redir_varname);
 }
 
 int eval_charconvert(const char *const enc_from, const char *const enc_to,
@@ -3201,8 +3197,7 @@ char_u *get_user_var_name(expand_T *xp, int idx)
     return cat_prefix_varname('v', (char_u *)vimvars[vidx++].vv_name);
   }
 
-  xfree(varnamebuf);
-  varnamebuf = NULL;
+  XFREE_CLEAR(varnamebuf);
   varnamebuflen = 0;
   return NULL;
 }
@@ -5942,8 +5937,7 @@ static int get_env_tv(char_u **arg, typval_T *rettv, int evaluate)
       // Next try expanding things like $VIM and ${HOME}.
       string = expand_env_save(name - 1);
       if (string != NULL && *string == '$') {
-        xfree(string);
-        string = NULL;
+        XFREE_CLEAR(string);
       }
     }
     name[len] = cc;
@@ -13815,8 +13809,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       if (*q != NUL) {
         STRMOVE(remain, q - 1);
       } else {
-        xfree(remain);
-        remain = NULL;
+        XFREE_CLEAR(remain);
       }
     }
 
@@ -20391,8 +20384,7 @@ void ex_function(exarg_T *eap)
       /* between ":append" and "." and between ":python <<EOF" and "EOF"
        * don't check for ":endfunc". */
       if (STRCMP(theline, skip_until) == 0) {
-        xfree(skip_until);
-        skip_until = NULL;
+        XFREE_CLEAR(skip_until);
       }
     } else {
       /* skip ':' and blanks*/
@@ -20550,8 +20542,7 @@ void ex_function(exarg_T *eap)
         // redefine existing function
         ga_clear_strings(&(fp->uf_args));
         ga_clear_strings(&(fp->uf_lines));
-        xfree(name);
-        name = NULL;
+        XFREE_CLEAR(name);
       }
     }
   } else {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4058,7 +4058,7 @@ skip:
       }
 
       if (did_sub) {
-        ++sub_nlines;
+        sub_nlines++;
       }
       xfree(new_start);              // for when substitute was cancelled
       XFREE_CLEAR(sub_firstline);    // free the copy of the original line

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3526,8 +3526,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
           lnum += regmatch.startpos[0].lnum;
           sub_firstlnum += regmatch.startpos[0].lnum;
           nmatch -= regmatch.startpos[0].lnum;
-          xfree(sub_firstline);
-          sub_firstline = NULL;
+          XFREE_CLEAR(sub_firstline);
         }
 
         // Now we're at the line where the pattern match starts
@@ -4058,11 +4057,11 @@ skip:
         line_breakcheck();
       }
 
-      if (did_sub)
+      if (did_sub) {
         ++sub_nlines;
-      xfree(new_start);              /* for when substitute was cancelled */
-      xfree(sub_firstline);          /* free the copy of the original line */
-      sub_firstline = NULL;
+      }
+      xfree(new_start);              // for when substitute was cancelled
+      XFREE_CLEAR(sub_firstline);    // free the copy of the original line
     }
 
     line_breakcheck();
@@ -5077,9 +5076,8 @@ void fix_help_buffer(void)
                 }
                 if (fnamecmp(e1, ".txt") != 0
                     && fnamecmp(e1, fname + 4) != 0) {
-                  /* Not .txt and not .abx, remove it. */
-                  xfree(fnames[i1]);
-                  fnames[i1] = NULL;
+                  // Not .txt and not .abx, remove it.
+                  XFREE_CLEAR(fnames[i1]);
                   continue;
                 }
                 if (e1 - f1 != e2 - f2
@@ -5088,9 +5086,8 @@ void fix_help_buffer(void)
                 }
                 if (fnamecmp(e1, ".txt") == 0
                     && fnamecmp(e2, fname + 4) == 0) {
-                  /* use .abx instead of .txt */
-                  xfree(fnames[i1]);
-                  fnames[i1] = NULL;
+                  // use .abx instead of .txt
+                  XFREE_CLEAR(fnames[i1]);
                 }
               }
             }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1040,12 +1040,9 @@ static void profile_reset(void)
         uf->uf_tm_self      = profile_zero();
         uf->uf_tm_children  = profile_zero();
 
-        xfree(uf->uf_tml_count);
-        xfree(uf->uf_tml_total);
-        xfree(uf->uf_tml_self);
-        uf->uf_tml_count    = NULL;
-        uf->uf_tml_total    = NULL;
-        uf->uf_tml_self     = NULL;
+        XFREE_CLEAR(uf->uf_tml_count);
+        XFREE_CLEAR(uf->uf_tml_total);
+        XFREE_CLEAR(uf->uf_tml_self);
 
         uf->uf_tml_start    = profile_zero();
         uf->uf_tml_children = profile_zero();
@@ -1056,8 +1053,7 @@ static void profile_reset(void)
     }
   }
 
-  xfree(profile_fname);
-  profile_fname = NULL;
+  XFREE_CLEAR(profile_fname);
 }
 
 /// Start profiling a script.
@@ -4003,8 +3999,7 @@ void free_locales(void)
     for (i = 0; locales[i] != NULL; i++) {
       xfree(locales[i]);
     }
-    xfree(locales);
-    locales = NULL;
+    XFREE_CLEAR(locales);
   }
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -431,8 +431,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
     if (cstack.cs_looplevel > 0 && current_line < lines_ga.ga_len) {
       /* Each '|' separated command is stored separately in lines_ga, to
        * be able to jump to it.  Don't use next_cmdline now. */
-      xfree(cmdline_copy);
-      cmdline_copy = NULL;
+      XFREE_CLEAR(cmdline_copy);
 
       /* Check if a function has returned or, unless it has an unclosed
        * try conditional, aborted. */
@@ -606,12 +605,11 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
       current_line = cmd_loop_cookie.current_line;
 
     if (next_cmdline == NULL) {
-      xfree(cmdline_copy);
-      cmdline_copy = NULL;
-      /*
-       * If the command was typed, remember it for the ':' register.
-       * Do this AFTER executing the command to make :@: work.
-       */
+      XFREE_CLEAR(cmdline_copy);
+      //
+      // If the command was typed, remember it for the ':' register.
+      // Do this AFTER executing the command to make :@: work.
+      //
       if (getline_equal(fgetline, cookie, getexline)
           && new_last_cmdline != NULL) {
         xfree(last_cmdline);
@@ -4842,10 +4840,8 @@ static int uc_add_command(char_u *name, size_t name_len, char_u *rep,
         goto fail;
       }
 
-      xfree(cmd->uc_rep);
-      cmd->uc_rep = NULL;
-      xfree(cmd->uc_compl_arg);
-      cmd->uc_compl_arg = NULL;
+      XFREE_CLEAR(cmd->uc_rep);
+      XFREE_CLEAR(cmd->uc_compl_arg);
       break;
     }
 
@@ -7232,11 +7228,8 @@ static char_u   *prev_dir = NULL;
 #if defined(EXITFREE)
 void free_cd_dir(void)
 {
-  xfree(prev_dir);
-  prev_dir = NULL;
-
-  xfree(globaldir);
-  globaldir = NULL;
+  XFREE_CLEAR(prev_dir);
+  XFREE_CLEAR(globaldir);
 }
 
 #endif
@@ -7247,13 +7240,11 @@ void free_cd_dir(void)
 void post_chdir(CdScope scope, bool trigger_dirchanged)
 {
   // Always overwrite the window-local CWD.
-  xfree(curwin->w_localdir);
-  curwin->w_localdir = NULL;
+  XFREE_CLEAR(curwin->w_localdir);
 
   // Overwrite the tab-local CWD for :cd, :tcd.
   if (scope >= kCdScopeTab) {
-    xfree(curtab->tp_localdir);
-    curtab->tp_localdir = NULL;
+    XFREE_CLEAR(curtab->tp_localdir);
   }
 
   if (scope < kCdScopeGlobal) {
@@ -7270,8 +7261,7 @@ void post_chdir(CdScope scope, bool trigger_dirchanged)
   switch (scope) {
   case kCdScopeGlobal:
     // We are now in the global directory, no need to remember its name.
-    xfree(globaldir);
-    globaldir = NULL;
+    XFREE_CLEAR(globaldir);
     break;
   case kCdScopeTab:
     curtab->tp_localdir = (char_u *)xstrdup(cwd);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -592,8 +592,7 @@ static int command_line_execute(VimState *state, int key)
       && s->c != K_KPAGEDOWN && s->c != K_KPAGEUP
       && s->c != K_LEFT && s->c != K_RIGHT
       && (s->xpc.xp_numfiles > 0 || (s->c != Ctrl_P && s->c != Ctrl_N))) {
-    xfree(s->lookfor);
-    s->lookfor = NULL;
+    XFREE_CLEAR(s->lookfor);
   }
 
   // When there are matching completions to select <S-Tab> works like
@@ -626,8 +625,7 @@ static int command_line_execute(VimState *state, int key)
       && s->c != Ctrl_L) {
     if (compl_match_array) {
       pum_undisplay(true);
-      xfree(compl_match_array);
-      compl_match_array = NULL;
+      XFREE_CLEAR(compl_match_array);
     }
     if (s->xpc.xp_numfiles != -1) {
       (void)ExpandOne(&s->xpc, NULL, NULL, 0, WILD_FREE);
@@ -1260,8 +1258,7 @@ static int command_line_handle_key(CommandLineState *s)
         return command_line_not_changed(s);
       }
 
-      xfree(ccline.cmdbuff);               // no commandline to return
-      ccline.cmdbuff = NULL;
+      XFREE_CLEAR(ccline.cmdbuff);        // no commandline to return
       if (!cmd_silent && !ui_has(kUICmdline)) {
         if (cmdmsg_rl) {
           msg_col = Columns;
@@ -1978,8 +1975,7 @@ static int command_line_changed(CommandLineState *s)
 /// Abandon the command line.
 static void abandon_cmdline(void)
 {
-  xfree(ccline.cmdbuff);
-  ccline.cmdbuff = NULL;
+  XFREE_CLEAR(ccline.cmdbuff);
   if (msg_scrolled == 0) {
     compute_cmdrow();
   }
@@ -2630,8 +2626,7 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
 
   if (colored_ccline->cmdbuff == NULL || *colored_ccline->cmdbuff == NUL) {
     // Nothing to do, exiting.
-    xfree(ccline_colors->cmdbuff);
-    ccline_colors->cmdbuff = NULL;
+    XFREE_CLEAR(ccline_colors->cmdbuff);
     return ret;
   }
 
@@ -3650,8 +3645,7 @@ nextwild (
         }
       }
       if ((int)STRLEN(p2) < j) {
-        xfree(p2);
-        p2 = NULL;
+        XFREE_CLEAR(p2);
       }
     }
   }
@@ -3785,8 +3779,7 @@ ExpandOne (
   if (xp->xp_numfiles != -1 && mode != WILD_ALL && mode != WILD_LONGEST) {
     FreeWild(xp->xp_numfiles, xp->xp_files);
     xp->xp_numfiles = -1;
-    xfree(orig_save);
-    orig_save = NULL;
+    XFREE_CLEAR(orig_save);
   }
   findex = 0;
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -885,8 +885,7 @@ retry:
     }
     if (tmpname != NULL) {
       os_remove((char *)tmpname);  // delete converted file
-      xfree(tmpname);
-      tmpname = NULL;
+      XFREE_CLEAR(tmpname);
     }
   }
 
@@ -1884,8 +1883,7 @@ failed:
 
       msg_add_lines(c, (long)linecnt, filesize);
 
-      xfree(keep_msg);
-      keep_msg = NULL;
+      XFREE_CLEAR(keep_msg);
       p = NULL;
       msg_scrolled_ign = TRUE;
 
@@ -2171,8 +2169,7 @@ readfile_charconvert (
     MSG(errmsg);
     if (tmpname != NULL) {
       os_remove((char *)tmpname);  // delete converted file
-      xfree(tmpname);
-      tmpname = NULL;
+      XFREE_CLEAR(tmpname);
     }
   }
 
@@ -2828,14 +2825,13 @@ buf_write (
            */
           if (os_fileinfo((char *)backup, &file_info_new)) {
             if (os_fileinfo_id_equal(&file_info_new, &file_info_old)) {
-              /*
-               * Backup file is same as original file.
-               * May happen when modname() gave the same file back (e.g. silly
-               * link). If we don't check here, we either ruin the file when
-               * copying or erase it after writing.
-               */
-              xfree(backup);
-              backup = NULL;                    /* no backup file to delete */
+              //
+              // Backup file is same as original file.
+              // May happen when modname() gave the same file back (e.g. silly
+              // link). If we don't check here, we either ruin the file when
+              // copying or erase it after writing.
+              //
+              XFREE_CLEAR(backup);              // no backup file to delete
             } else if (!p_bk) {
               /*
                * We are not going to keep the backup file, so don't
@@ -2853,8 +2849,7 @@ buf_write (
               }
               /* They all exist??? Must be something wrong. */
               if (*wp == 'a') {
-                xfree(backup);
-                backup = NULL;
+                XFREE_CLEAR(backup);
               }
             }
           }
@@ -2969,8 +2964,7 @@ nobackup:
             }
             // They all exist??? Must be something wrong!
             if (*p == 'a') {
-              xfree(backup);
-              backup = NULL;
+              XFREE_CLEAR(backup);
             }
           }
         }
@@ -2988,8 +2982,7 @@ nobackup:
           if (vim_rename(fname, backup) == 0)
             break;
 
-          xfree(backup);             /* don't do the rename below */
-          backup = NULL;
+          XFREE_CLEAR(backup);             // don't do the rename below
         }
       }
       if (backup == NULL && !forceit) {
@@ -3585,8 +3578,7 @@ restore_backup:
         EMSG(_("E205: Patchmode: can't save original file"));
       } else if (!os_path_exists((char_u *)org)) {
         vim_rename(backup, (char_u *)org);
-        xfree(backup);                   /* don't delete the file */
-        backup = NULL;
+        XFREE_CLEAR(backup);                   // don't delete the file
 #ifdef UNIX
         set_file_time((char_u *)org,
                       file_info_old.stat.st_atim.tv_sec,
@@ -4313,8 +4305,7 @@ void shorten_buf_fname(buf_T *buf, char_u *dirname, int force)
       && (force
           || buf->b_sfname == NULL
           || path_is_absolute(buf->b_sfname))) {
-    xfree(buf->b_sfname);
-    buf->b_sfname = NULL;
+    XFREE_CLEAR(buf->b_sfname);
     p = path_shorten_fname(buf->b_ffname, dirname);
     if (p != NULL) {
       buf->b_sfname = vim_strsave(p);
@@ -5352,8 +5343,7 @@ void vim_deltempdir(void)
     // remove the trailing path separator
     path_tail(vim_tempdir)[-1] = NUL;
     delete_recursive((const char *)vim_tempdir);
-    xfree(vim_tempdir);
-    vim_tempdir = NULL;
+    XFREE_CLEAR(vim_tempdir);
   }
 }
 
@@ -5512,8 +5502,7 @@ static void show_autocmd(AutoPat *ap, event_T event)
 // Mark an autocommand handler for deletion.
 static void au_remove_pat(AutoPat *ap)
 {
-  xfree(ap->pat);
-  ap->pat = NULL;
+  XFREE_CLEAR(ap->pat);
   ap->buflocal_nr = -1;
   au_need_clean = true;
 }
@@ -5522,8 +5511,7 @@ static void au_remove_pat(AutoPat *ap)
 static void au_remove_cmds(AutoPat *ap)
 {
   for (AutoCmd *ac = ap->cmds; ac != NULL; ac = ac->next) {
-    xfree(ac->cmd);
-    ac->cmd = NULL;
+    XFREE_CLEAR(ac->cmd);
   }
   au_need_clean = true;
 }
@@ -5531,8 +5519,7 @@ static void au_remove_cmds(AutoPat *ap)
 // Delete one command from an autocmd pattern.
 static void au_del_cmd(AutoCmd *ac)
 {
-  xfree(ac->cmd);
-  ac->cmd = NULL;
+  XFREE_CLEAR(ac->cmd);
   au_need_clean = true;
 }
 
@@ -6504,8 +6491,7 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
 
     /* Make sure w_localdir and globaldir are NULL to avoid a chdir() in
      * win_enter_ext(). */
-    xfree(aucmd_win->w_localdir);
-    aucmd_win->w_localdir = NULL;
+    XFREE_CLEAR(aucmd_win->w_localdir);
     aco->globaldir = globaldir;
     globaldir = NULL;
 
@@ -7128,8 +7114,7 @@ auto_next_pat (
   AutoCmd     *cp;
   char        *s;
 
-  xfree(sourcing_name);
-  sourcing_name = NULL;
+  XFREE_CLEAR(sourcing_name);
 
   for (ap = apc->curpat; ap != NULL && !got_int; ap = ap->next) {
     apc->curpat = NULL;
@@ -7737,12 +7722,12 @@ char_u * file_pat_to_reg_pat(
     reg_pat[i++] = '$';
   reg_pat[i] = NUL;
   if (nested != 0) {
-    if (nested < 0)
+    if (nested < 0) {
       EMSG(_("E219: Missing {."));
-    else
+    } else {
       EMSG(_("E220: Missing }."));
-    xfree(reg_pat);
-    reg_pat = NULL;
+    }
+    XFREE_CLEAR(reg_pat);
   }
   return reg_pat;
 }

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -1942,8 +1942,7 @@ void mch_print_cleanup(void)
     prt_file_error = FALSE;
   }
   if (prt_ps_file_name != NULL) {
-    xfree(prt_ps_file_name);
-    prt_ps_file_name = NULL;
+    XFREE_CLEAR(prt_ps_file_name);
   }
 }
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1530,7 +1530,7 @@ static void cs_fill_results(char *tagstr, size_t totmatches, int *nummatches_a,
   }   /* for all cscope connections */
 
   if (totsofar == 0) {
-    /* No matches, free the arrays and return NULL in "*matches_p". */
+    // No matches, free the arrays and return NULL in "*matches_p".
     XFREE_CLEAR(matches);
     XFREE_CLEAR(cntxts);
   }

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1531,10 +1531,8 @@ static void cs_fill_results(char *tagstr, size_t totmatches, int *nummatches_a,
 
   if (totsofar == 0) {
     /* No matches, free the arrays and return NULL in "*matches_p". */
-    xfree(matches);
-    matches = NULL;
-    xfree(cntxts);
-    cntxts = NULL;
+    XFREE_CLEAR(matches);
+    XFREE_CLEAR(cntxts);
   }
   *matched = totsofar;
   *matches_p = matches;

--- a/src/nvim/lib/kbtree.h
+++ b/src/nvim/lib/kbtree.h
@@ -72,7 +72,7 @@
 			*top++ = (b)->root;											\
 			while (top != stack) {										\
 				x = *--top;												\
-				if (x->is_internal == 0) { xfree(x); continue; }			\
+				if (x->is_internal == 0) { XFREE_CLEAR(x); continue; }			\
 				for (i = 0; i <= x->n; ++i)								\
 					if (__KB_PTR(b, x)[i]) {							\
 						if (top - stack == (int)max) {		        	\
@@ -82,10 +82,10 @@
 						}												\
 						*top++ = __KB_PTR(b, x)[i];						\
 					}													\
-				xfree(x);												\
+				XFREE_CLEAR(x);												\
 			}															\
 		}																\
-		xfree(stack);											\
+		XFREE_CLEAR(stack);											\
 	} while (0)
 
 #define __KB_GET_AUX1(name, key_t, kbnode_t, __cmp)								\
@@ -253,7 +253,7 @@
 				memmove(&__KB_KEY(key_t, x)[i], &__KB_KEY(key_t, x)[i + 1], (unsigned int)(x->n - i - 1) * sizeof(key_t)); \
 				memmove(&__KB_PTR(b, x)[i + 1], &__KB_PTR(b, x)[i + 2], (unsigned int)(x->n - i - 1) * sizeof(void*)); \
 				--x->n;													\
-				xfree(z);												\
+				XFREE_CLEAR(z);												\
 				return __kb_delp_aux_##name(b, y, k, s);				\
 			}															\
 		}																\
@@ -281,7 +281,7 @@
 				memmove(&__KB_KEY(key_t, x)[i - 1], &__KB_KEY(key_t, x)[i], (unsigned int)(x->n - i) * sizeof(key_t)); \
 				memmove(&__KB_PTR(b, x)[i], &__KB_PTR(b, x)[i + 1], (unsigned int)(x->n - i) * sizeof(void*)); \
 				--x->n;													\
-				xfree(xp);												\
+				XFREE_CLEAR(xp);												\
 				xp = y;													\
 			} else if (i < x->n && (y = __KB_PTR(b, x)[i + 1])->n == T - 1) { \
 				__KB_KEY(key_t, xp)[xp->n++] = __KB_KEY(key_t, x)[i];	\
@@ -291,7 +291,7 @@
 				memmove(&__KB_KEY(key_t, x)[i], &__KB_KEY(key_t, x)[i + 1], (unsigned int)(x->n - i - 1) * sizeof(key_t)); \
 				memmove(&__KB_PTR(b, x)[i + 1], &__KB_PTR(b, x)[i + 2], (unsigned int)(x->n - i - 1) * sizeof(void*)); \
 				--x->n;													\
-				xfree(y);												\
+				XFREE_CLEAR(y);												\
 			}															\
 		}																\
 		return __kb_delp_aux_##name(b, xp, k, s);						\
@@ -306,7 +306,7 @@
 			--b->n_nodes;												\
 			x = b->root;												\
 			b->root = __KB_PTR(b, x)[0];								\
-			xfree(x);													\
+			XFREE_CLEAR(x);													\
 		}																\
 		return ret;														\
 	}																	\

--- a/src/nvim/lib/khash.h
+++ b/src/nvim/lib/khash.h
@@ -181,7 +181,7 @@ typedef khint_t khiter_t;
 #define krealloc(P,Z) xrealloc(P,Z)
 #endif
 #ifndef kfree
-#define kfree(P) xfree(P)
+#define kfree(P) XFREE_CLEAR(P)
 #endif
 
 #define __ac_HASH_UPPER 0.77

--- a/src/nvim/lib/klist.h
+++ b/src/nvim/lib/klist.h
@@ -46,9 +46,9 @@
     static inline void kmp_destroy_##name(kmp_##name##_t *mp) { \
         size_t k; \
         for (k = 0; k < mp->n; k++) { \
-            kmpfree_f(mp->buf[k]); xfree(mp->buf[k]); \
+            kmpfree_f(mp->buf[k]); XFREE_CLEAR(mp->buf[k]); \
         } \
-        xfree(mp->buf); xfree(mp); \
+        XFREE_CLEAR(mp->buf); XFREE_CLEAR(mp); \
     } \
     static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) { \
         mp->cnt++; \
@@ -100,7 +100,7 @@
         } \
         kmp_free(name, kl->mp, p); \
         kmp_destroy(name, kl->mp); \
-        xfree(kl); \
+        XFREE_CLEAR(kl); \
     } \
     static inline void kl_push_##name(kl_##name##_t *kl, kltype_t d) { \
         kl1_##name *q, *p = kmp_alloc(name, kl->mp); \

--- a/src/nvim/lib/kvec.h
+++ b/src/nvim/lib/kvec.h
@@ -58,7 +58,11 @@
     }
 
 #define kv_init(v) ((v).size = (v).capacity = 0, (v).items = 0)
-#define kv_destroy(v) XFREE_CLEAR((v).items)
+#define kv_destroy(v) \
+    do { \
+      xfree((v).items); \
+      kv_init(v); \
+    } while (0)
 #define kv_A(v, i) ((v).items[(i)])
 #define kv_pop(v) ((v).items[--(v).size])
 #define kv_size(v) ((v).size)
@@ -88,7 +92,7 @@
       } \
       (v1).size = (v0).size; \
       memcpy((v1).items, (v0).items, sizeof((v1).items[0]) * (v0).size); \
-    } while (0) \
+    } while (0)
 
 #define kv_pushp(v) \
     ((((v).size == (v).capacity) ? (kv_resize_full(v), 0) : 0), \

--- a/src/nvim/lib/kvec.h
+++ b/src/nvim/lib/kvec.h
@@ -58,7 +58,7 @@
     }
 
 #define kv_init(v) ((v).size = (v).capacity = 0, (v).items = 0)
-#define kv_destroy(v) xfree((v).items)
+#define kv_destroy(v) XFREE_CLEAR((v).items)
 #define kv_A(v, i) ((v).items[(i)])
 #define kv_pop(v) ((v).items[--(v).size])
 #define kv_size(v) ((v).size)
@@ -138,7 +138,7 @@ static inline void *_memcpy_free(void *const restrict dest,
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET FUNC_ATTR_ALWAYS_INLINE
 {
   memcpy(dest, src, size);
-  xfree(src);
+  XFREE_CLEAR(src);
   return dest;
 }
 
@@ -201,7 +201,7 @@ static inline void *_memcpy_free(void *const restrict dest,
 #define kvi_destroy(v) \
     do { \
       if ((v).items != (v).init_array) { \
-        xfree((v).items); \
+        XFREE_CLEAR((v).items); \
       } \
     } while (0)
 

--- a/src/nvim/lib/ringbuf.h
+++ b/src/nvim/lib/ringbuf.h
@@ -136,14 +136,14 @@ static inline void funcprefix##_rb_free(TypeName##RingBuffer *const rb) \
   RINGBUF_FORALL(rb, RBType, rbitem) { \
     rbfree(rbitem); \
   } \
-  xfree(rb->buf); \
+  XFREE_CLEAR(rb->buf); \
 } \
 \
 static inline void funcprefix##_rb_dealloc(TypeName##RingBuffer *const rb) \
   REAL_FATTR_UNUSED; \
 static inline void funcprefix##_rb_dealloc(TypeName##RingBuffer *const rb) \
 { \
-  xfree(rb->buf); \
+  XFREE_CLEAR(rb->buf); \
 } \
 \
 static inline void funcprefix##_rb_push(TypeName##RingBuffer *const rb, \

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -523,8 +523,7 @@ static void fmarks_check_one(xfmark_T *fm, char_u *name, buf_T *buf)
       && fm->fname != NULL
       && fnamecmp(name, fm->fname) == 0) {
     fm->fmark.fnum = buf->b_fnum;
-    xfree(fm->fname);
-    fm->fname = NULL;
+    XFREE_CLEAR(fm->fname);
   }
 }
 
@@ -752,8 +751,7 @@ void ex_delmarks(exarg_T *eap)
               n = i - 'A';
             }
             namedfm[n].fmark.mark.lnum = 0;
-            xfree(namedfm[n].fname);
-            namedfm[n].fname = NULL;
+            XFREE_CLEAR(namedfm[n].fname);
           }
         }
       } else

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1421,8 +1421,7 @@ int utf16_to_utf8(const wchar_t *strw, char **str)
                                  NULL,
                                  NULL);
   if (utf8_len == 0) {
-    xfree(*str);
-    *str = NULL;
+    XFREE_CLEAR(*str);
     return GetLastError();
   }
   (*str)[utf8_len] = '\0';
@@ -2119,9 +2118,8 @@ static char_u *iconv_string(const vimconv_T *const vcp, char_u *str,
       from += l;
       fromlen -= l;
     } else if (ICONV_ERRNO != ICONV_E2BIG) {
-      /* conversion failed */
-      xfree(result);
-      result = NULL;
+      // conversion failed
+      XFREE_CLEAR(result);
       break;
     }
     /* Not enough room or skipping illegal sequence. */

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -719,10 +719,8 @@ blocknr_T mf_trans_del(memfile_T *mfp, blocknr_T old_nr)
 /// Frees mf_fname and mf_ffname.
 void mf_free_fnames(memfile_T *mfp)
 {
-  xfree(mfp->mf_fname);
-  xfree(mfp->mf_ffname);
-  mfp->mf_fname = NULL;
-  mfp->mf_ffname = NULL;
+  XFREE_CLEAR(mfp->mf_fname);
+  XFREE_CLEAR(mfp->mf_ffname);
 }
 
 /// Set the simple file name and the full file name of memfile's swapfile, out

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3340,9 +3340,10 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
                                (char_u *)dir_name);
 
   for (;; ) {
-    if (fname == NULL)          /* must be out of memory */
+    if (fname == NULL) {        // must be out of memory
       break;
-    if ((n = strlen(fname)) == 0) {        /* safety check */
+    }
+    if ((n = strlen(fname)) == 0) {        // safety check
       XFREE_CLEAR(fname);
       break;
     }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -563,8 +563,7 @@ void ml_close(buf_T *buf, int del_file)
   if (buf->b_ml.ml_line_lnum != 0 && (buf->b_ml.ml_flags & ML_LINE_DIRTY))
     xfree(buf->b_ml.ml_line_ptr);
   xfree(buf->b_ml.ml_stack);
-  xfree(buf->b_ml.ml_chunksize);
-  buf->b_ml.ml_chunksize = NULL;
+  XFREE_CLEAR(buf->b_ml.ml_chunksize);
   buf->b_ml.ml_mfp = NULL;
 
   /* Reset the "recovered" flag, give the ATTENTION prompt the next time
@@ -3344,8 +3343,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
     if (fname == NULL)          /* must be out of memory */
       break;
     if ((n = strlen(fname)) == 0) {        /* safety check */
-      xfree(fname);
-      fname = NULL;
+      XFREE_CLEAR(fname);
       break;
     }
     // check if the swapfile already exists
@@ -3541,8 +3539,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname,
     if (fname[n - 1] == 'a') {          /* ".s?a" */
       if (fname[n - 2] == 'a') {        /* ".saa": tried enough, give up */
         EMSG(_("E326: Too many swap files found"));
-        xfree(fname);
-        fname = NULL;
+        XFREE_CLEAR(fname);
         break;
       }
       --fname[n - 2];                   /* ".svz", ".suz", etc. */

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -110,6 +110,8 @@ void *xmalloc(size_t size)
 }
 
 /// free() wrapper that delegates to the backing memory manager
+///
+/// @note Use XFREE_CLEAR() instead, if possible.
 void xfree(void *ptr)
 {
   free(ptr);

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -40,4 +40,15 @@ extern bool entered_free_all_mem;
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "memory.h.generated.h"
 #endif
+
+#define XFREE_CLEAR(ptr) \
+  do { \
+    /* Take the address to avoid double evaluation. #1375 */ \
+    void **ptr_ = (void **)&(ptr); \
+    xfree(*ptr_); \
+    /* coverity[dead-store] */ \
+    *ptr_ = NULL; \
+    (void)(*ptr_); \
+  } while (0)
+
 #endif  // NVIM_MEMORY_H

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -388,8 +388,7 @@ add_menu_path(
     menup = &menu->children;
     parent = menu;
     name = next_name;
-    xfree(dname);
-    dname = NULL;
+    XFREE_CLEAR(dname);
     if (pri_tab[pri_idx + 1] != -1) {
       pri_idx++;
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2997,7 +2997,7 @@ void give_warning(char_u *message, bool hl) FUNC_ATTR_NONNULL_ARG(1)
   /* Don't want a hit-enter prompt here. */
   ++no_wait_return;
 
-  set_vim_var_string(VV_WARNINGMSG, (char *) message, -1);
+  set_vim_var_string(VV_WARNINGMSG, (char *)message, -1);
   XFREE_CLEAR(keep_msg);
   if (hl) {
     keep_msg_attr = HL_ATTR(HLF_W);

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -420,8 +420,7 @@ static char_u   *last_sourcing_name = NULL;
  */
 void reset_last_sourcing(void)
 {
-  xfree(last_sourcing_name);
-  last_sourcing_name = NULL;
+  XFREE_CLEAR(last_sourcing_name);
   last_sourcing_lnum = 0;
 }
 
@@ -1117,8 +1116,7 @@ void wait_return(int redraw)
   reset_last_sourcing();
   if (keep_msg != NULL && vim_strsize(keep_msg) >=
       (Rows - cmdline_row - 1) * Columns + sc_col) {
-    xfree(keep_msg);
-    keep_msg = NULL;                /* don't redisplay message, it's too long */
+    XFREE_CLEAR(keep_msg);          // don't redisplay message, it's too long
   }
 
   if (tmpState == SETWSIZE) {       /* got resize event while in vgetc() */
@@ -1188,8 +1186,7 @@ void msg_start(void)
   int did_return = FALSE;
 
   if (!msg_silent) {
-    xfree(keep_msg);
-    keep_msg = NULL;                    /* don't display old message now */
+    XFREE_CLEAR(keep_msg);              // don't display old message now
   }
 
   if (need_clr_eos) {
@@ -3001,8 +2998,7 @@ void give_warning(char_u *message, bool hl) FUNC_ATTR_NONNULL_ARG(1)
   ++no_wait_return;
 
   set_vim_var_string(VV_WARNINGMSG, (char *) message, -1);
-  xfree(keep_msg);
-  keep_msg = NULL;
+  XFREE_CLEAR(keep_msg);
   if (hl) {
     keep_msg_attr = HL_ATTR(HLF_W);
   } else {

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -2828,8 +2828,7 @@ char_u *get_cmd_output(char_u *cmd, char_u *infile, ShellOpts flags,
   os_remove((char *)tempname);
   if (i != len) {
     EMSG2(_(e_notread), tempname);
-    xfree(buffer);
-    buffer = NULL;
+    XFREE_CLEAR(buffer);
   } else if (ret_len == NULL) {
     /* Change NUL into SOH, otherwise the string is truncated. */
     for (i = 0; i < len; ++i)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1467,8 +1467,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
         } else {
           AppendToRedobuffLit(repeat_cmdline, -1);
           AppendToRedobuff(NL_STR);
-          xfree(repeat_cmdline);
-          repeat_cmdline = NULL;
+          XFREE_CLEAR(repeat_cmdline);
         }
       }
     }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -983,9 +983,8 @@ do_execreg(
       EMSG(_(e_nolastcmd));
       return FAIL;
     }
-    xfree(new_last_cmdline);     /* don't keep the cmdline containing @: */
-    new_last_cmdline = NULL;
-    /* Escape all control characters with a CTRL-V */
+    XFREE_CLEAR(new_last_cmdline);      // don't keep the cmdline containing @:
+    // Escape all control characters with a CTRL-V
     p = vim_strsave_escaped_ext(
         last_cmdline,
         (char_u *)
@@ -2348,8 +2347,7 @@ void free_register(yankreg_T *reg)
     for (size_t i = reg->y_size; i-- > 0;) {  // from y_size - 1 to 0 included
       xfree(reg->y_array[i]);
     }
-    xfree(reg->y_array);
-    reg->y_array = NULL;
+    XFREE_CLEAR(reg->y_array);
   }
 }
 

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -553,8 +553,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
   *num_file = j;
 
   if (*num_file == 0) {     // rejected all entries
-    xfree(*file);
-    *file = NULL;
+    XFREE_CLEAR(*file);
     goto notfound;
   }
 

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2088,8 +2088,7 @@ int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files,
 
   // Free empty array of matches
   if (*num_files == 0) {
-    xfree(*files);
-    *files = NULL;
+    XFREE_CLEAR(*files);
     return FAIL;
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -848,8 +848,7 @@ qf_init_ext(
   int status;
 
   // Do not used the cached buffer, it may have been wiped out.
-  xfree(qf_last_bufname);
-  qf_last_bufname = NULL;
+  XFREE_CLEAR(qf_last_bufname);
 
   memset(&state, 0, sizeof(state));
   memset(&fields, 0, sizeof(fields));
@@ -894,8 +893,7 @@ qf_init_ext(
   // parsed values.
   if (last_efm == NULL || (STRCMP(last_efm, efm) != 0)) {
     // free the previously parsed data
-    xfree(last_efm);
-    last_efm = NULL;
+    XFREE_CLEAR(last_efm);
     free_efm_list(&fmt_first);
 
     // parse the current 'efm'
@@ -1019,8 +1017,7 @@ qf_init_end:
 /// Prepends ':' to the title.
 static void qf_store_title(qf_info_T *qi, int qf_idx, char_u *title)
 {
-  xfree(qi->qf_lists[qf_idx].qf_title);
-  qi->qf_lists[qf_idx].qf_title = NULL;
+  XFREE_CLEAR(qi->qf_lists[qf_idx].qf_title);
 
   if (title != NULL) {
     size_t len = STRLEN(title) + 1;
@@ -2754,8 +2751,7 @@ static void qf_free(qf_info_T *qi, int idx)
   qf_list_T *qfl = &qi->qf_lists[idx];
   qf_free_items(qi, idx);
 
-  xfree(qfl->qf_title);
-  qfl->qf_title = NULL;
+  XFREE_CLEAR(qfl->qf_title);
   tv_free(qfl->qf_ctx);
   qfl->qf_ctx = NULL;
   qfl->qf_id = 0;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3550,8 +3550,7 @@ theend:
   /* Free "reg_tofree" when it's a bit big.
    * Free regstack and backpos if they are bigger than their initial size. */
   if (reg_tofreelen > 400) {
-    xfree(reg_tofree);
-    reg_tofree = NULL;
+    XFREE_CLEAR(reg_tofree);
   }
   if (regstack.ga_maxlen > REGSTACK_INITIAL)
     ga_clear(&regstack);
@@ -6618,8 +6617,7 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest,
       if (eval_result != NULL) {
         STRCPY(dest, eval_result);
         dst += STRLEN(eval_result);
-        xfree(eval_result);
-        eval_result = NULL;
+        XFREE_CLEAR(eval_result);
       }
     } else {
       int prev_can_f_submatch = can_f_submatch;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6594,8 +6594,7 @@ out:
   return (regprog_T *)prog;
 
 fail:
-  xfree(prog);
-  prog = NULL;
+  XFREE_CLEAR(prog);
 #ifdef REGEXP_DEBUG
   nfa_postfix_dump(expr, FAIL);
 #endif

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3135,8 +3135,7 @@ win_line (
       int c0;
 
       if (p_extra_free != NULL) {
-        xfree(p_extra_free);
-        p_extra_free = NULL;
+        XFREE_CLEAR(p_extra_free);
       }
 
       // Get a character from the line itself.

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4291,7 +4291,7 @@ find_pattern_in_path(
               }
             }
             XFREE_CLEAR(new_fname);
-            already_searched = TRUE;
+            already_searched = true;
             break;
           }
         }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4290,8 +4290,7 @@ find_pattern_in_path(
                 prev_fname = NULL;
               }
             }
-            xfree(new_fname);
-            new_fname = NULL;
+            XFREE_CLEAR(new_fname);
             already_searched = TRUE;
             break;
           }

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1358,8 +1358,7 @@ static void shada_read(ShaDaReadDef *const sd_reader, const int flags)
       case kSDItemGlobalMark: {
         buf_T *buf = find_buffer(&fname_bufs, cur_entry.data.filemark.fname);
         if (buf != NULL) {
-          xfree(cur_entry.data.filemark.fname);
-          cur_entry.data.filemark.fname = NULL;
+          XFREE_CLEAR(cur_entry.data.filemark.fname);
         }
         xfmark_T fm = (xfmark_T) {
           .fname = (char_u *) (buf == NULL

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1708,19 +1708,13 @@ void slang_clear(slang_T *lp)
 {
   garray_T    *gap;
 
-  xfree(lp->sl_fbyts);
-  lp->sl_fbyts = NULL;
-  xfree(lp->sl_kbyts);
-  lp->sl_kbyts = NULL;
-  xfree(lp->sl_pbyts);
-  lp->sl_pbyts = NULL;
+  XFREE_CLEAR(lp->sl_fbyts);
+  XFREE_CLEAR(lp->sl_kbyts);
+  XFREE_CLEAR(lp->sl_pbyts);
 
-  xfree(lp->sl_fidxs);
-  lp->sl_fidxs = NULL;
-  xfree(lp->sl_kidxs);
-  lp->sl_kidxs = NULL;
-  xfree(lp->sl_pidxs);
-  lp->sl_pidxs = NULL;
+  XFREE_CLEAR(lp->sl_fidxs);
+  XFREE_CLEAR(lp->sl_kidxs);
+  XFREE_CLEAR(lp->sl_pidxs);
 
   GA_DEEP_CLEAR(&lp->sl_rep, fromto_T, free_fromto);
   GA_DEEP_CLEAR(&lp->sl_repsal, fromto_T, free_fromto);
@@ -1738,26 +1732,17 @@ void slang_clear(slang_T *lp)
     vim_regfree(lp->sl_prefprog[i]);
   }
   lp->sl_prefixcnt = 0;
-  xfree(lp->sl_prefprog);
-  lp->sl_prefprog = NULL;
-
-  xfree(lp->sl_info);
-  lp->sl_info = NULL;
-
-  xfree(lp->sl_midword);
-  lp->sl_midword = NULL;
+  XFREE_CLEAR(lp->sl_prefprog);
+  XFREE_CLEAR(lp->sl_info);
+  XFREE_CLEAR(lp->sl_midword);
 
   vim_regfree(lp->sl_compprog);
-  xfree(lp->sl_comprules);
-  xfree(lp->sl_compstartflags);
-  xfree(lp->sl_compallflags);
   lp->sl_compprog = NULL;
-  lp->sl_comprules = NULL;
-  lp->sl_compstartflags = NULL;
-  lp->sl_compallflags = NULL;
+  XFREE_CLEAR(lp->sl_comprules);
+  XFREE_CLEAR(lp->sl_compstartflags);
+  XFREE_CLEAR(lp->sl_compallflags);
 
-  xfree(lp->sl_syllable);
-  lp->sl_syllable = NULL;
+  XFREE_CLEAR(lp->sl_syllable);
   ga_clear(&lp->sl_syl_items);
 
   ga_clear_strings(&lp->sl_comppat);
@@ -1779,10 +1764,8 @@ void slang_clear(slang_T *lp)
 // Clear the info from the .sug file in "lp".
 void slang_clear_sug(slang_T *lp)
 {
-  xfree(lp->sl_sbyts);
-  lp->sl_sbyts = NULL;
-  xfree(lp->sl_sidxs);
-  lp->sl_sidxs = NULL;
+  XFREE_CLEAR(lp->sl_sbyts);
+  XFREE_CLEAR(lp->sl_sidxs);
   close_spellbuf(lp->sl_sugbuf);
   lp->sl_sugbuf = NULL;
   lp->sl_sugloaded = false;
@@ -2255,8 +2238,7 @@ theend:
 static void clear_midword(win_T *wp)
 {
   memset(wp->w_s->b_spell_ismw, 0, 256);
-  xfree(wp->w_s->b_spell_ismw_mb);
-  wp->w_s->b_spell_ismw_mb = NULL;
+  XFREE_CLEAR(wp->w_s->b_spell_ismw_mb);
 }
 
 // Use the "sl_midword" field of language "lp" for buffer "buf".
@@ -2415,8 +2397,7 @@ void spell_delete_wordlist(void)
     os_remove((char *)int_wordlist);
     int_wordlist_spl(fname);
     os_remove((char *)fname);
-    xfree(int_wordlist);
-    int_wordlist = NULL;
+    XFREE_CLEAR(int_wordlist);
   }
 }
 
@@ -2438,10 +2419,8 @@ void spell_free_all(void)
 
   spell_delete_wordlist();
 
-  xfree(repl_to);
-  repl_to = NULL;
-  xfree(repl_from);
-  repl_from = NULL;
+  XFREE_CLEAR(repl_to);
+  XFREE_CLEAR(repl_from);
 }
 
 // Clear all spelling tables and reload them.
@@ -2838,10 +2817,8 @@ void spell_suggest(int count)
       smsg(_("Sorry, only %" PRId64 " suggestions"),
            (int64_t)sug.su_ga.ga_len);
   } else {
-    xfree(repl_from);
-    repl_from = NULL;
-    xfree(repl_to);
-    repl_to = NULL;
+    XFREE_CLEAR(repl_from);
+    XFREE_CLEAR(repl_to);
 
     // When 'rightleft' is set the list is drawn right-left.
     cmdmsg_rl = curwin->w_p_rl;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1446,8 +1446,7 @@ static int read_compound(FILE *fd, slang_T *slang, int len)
     // Copy flag to "sl_comprules", unless we run into a wildcard.
     if (crp != NULL) {
       if (c == '?' || c == '+' || c == '*') {
-        xfree(slang->sl_comprules);
-        slang->sl_comprules = NULL;
+        XFREE_CLEAR(slang->sl_comprules);
         crp = NULL;
       } else
         *crp++ = c;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -992,10 +992,10 @@ static void syn_stack_free_block(synblock_T *block)
   synstate_T  *p;
 
   if (block->b_sst_array != NULL) {
-    for (p = block->b_sst_first; p != NULL; p = p->sst_next)
+    for (p = block->b_sst_first; p != NULL; p = p->sst_next) {
       clear_syn_state(p);
-    xfree(block->b_sst_array);
-    block->b_sst_array = NULL;
+    }
+    XFREE_CLEAR(block->b_sst_array);
     block->b_sst_len = 0;
   }
 }
@@ -3186,8 +3186,7 @@ void syntax_clear(synblock_T *block)
 
   vim_regfree(block->b_syn_linecont_prog);
   block->b_syn_linecont_prog = NULL;
-  xfree(block->b_syn_linecont_pat);
-  block->b_syn_linecont_pat = NULL;
+  XFREE_CLEAR(block->b_syn_linecont_pat);
   block->b_syn_folditems = 0;
   clear_string_option(&block->b_syn_isk);
 
@@ -3230,8 +3229,7 @@ static void syntax_sync_clear(void)
 
   vim_regfree(curwin->w_s->b_syn_linecont_prog);
   curwin->w_s->b_syn_linecont_prog = NULL;
-  xfree(curwin->w_s->b_syn_linecont_pat);
-  curwin->w_s->b_syn_linecont_pat = NULL;
+  XFREE_CLEAR(curwin->w_s->b_syn_linecont_pat);
   clear_string_option(&curwin->w_s->b_syn_isk);
 
   syn_stack_free_all(curwin->w_s);              /* Need to recompute all syntax. */
@@ -3331,8 +3329,7 @@ static void syn_cmd_clear(exarg_T *eap, int syncing)
           // and make it empty.
           int scl_id = id - SYNID_CLUSTER;
 
-          xfree(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
-          SYN_CLSTR(curwin->w_s)[scl_id].scl_list = NULL;
+          XFREE_CLEAR(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
         }
       } else {
         id = syn_namen2id(arg, (int)(arg_end - arg));
@@ -5160,8 +5157,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
         syn_clear_time(&curwin->w_s->b_syn_linecont_time);
 
         if (curwin->w_s->b_syn_linecont_prog == NULL) {
-          xfree(curwin->w_s->b_syn_linecont_pat);
-          curwin->w_s->b_syn_linecont_pat = NULL;
+          XFREE_CLEAR(curwin->w_s->b_syn_linecont_pat);
           finished = TRUE;
           break;
         }
@@ -6993,12 +6989,9 @@ static void highlight_clear(int idx)
   HL_TABLE()[idx].sg_rgb_fg = -1;
   HL_TABLE()[idx].sg_rgb_bg = -1;
   HL_TABLE()[idx].sg_rgb_sp = -1;
-  xfree(HL_TABLE()[idx].sg_rgb_fg_name);
-  HL_TABLE()[idx].sg_rgb_fg_name = NULL;
-  xfree(HL_TABLE()[idx].sg_rgb_bg_name);
-  HL_TABLE()[idx].sg_rgb_bg_name = NULL;
-  xfree(HL_TABLE()[idx].sg_rgb_sp_name);
-  HL_TABLE()[idx].sg_rgb_sp_name = NULL;
+  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_fg_name);
+  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_bg_name);
+  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_sp_name);
   // Clear the script ID only when there is no link, since that is not
   // cleared.
   if (HL_TABLE()[idx].sg_link == 0) {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5158,7 +5158,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
 
         if (curwin->w_s->b_syn_linecont_prog == NULL) {
           XFREE_CLEAR(curwin->w_s->b_syn_linecont_pat);
-          finished = TRUE;
+          finished = true;
           break;
         }
       }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -923,8 +923,7 @@ end_do_tag:
  */
 void tag_freematch(void)
 {
-  xfree(tagmatchname);
-  tagmatchname = NULL;
+  XFREE_CLEAR(tagmatchname);
 }
 
 static void taglen_advance(int l)
@@ -1987,8 +1986,7 @@ void free_tag_stuff(void)
   tag_freematch();
 
   if (ptag_entry.tagname) {
-    xfree(ptag_entry.tagname);
-    ptag_entry.tagname = NULL;
+    XFREE_CLEAR(ptag_entry.tagname);
   }
 }
 

--- a/src/nvim/ugrid.c
+++ b/src/nvim/ugrid.c
@@ -95,8 +95,7 @@ static void destroy_cells(UGrid *grid)
     for (int i = 0; i < grid->height; i++) {
       xfree(grid->cells[i]);
     }
-    xfree(grid->cells);
-    grid->cells = NULL;
+    XFREE_CLEAR(grid->cells);
   }
 }
 

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -92,10 +92,8 @@ void ui_comp_detach(UI *ui)
 {
   composed_uis--;
   if (composed_uis == 0) {
-    xfree(linebuf);
-    xfree(attrbuf);
-    linebuf = NULL;
-    attrbuf = NULL;
+    XFREE_CLEAR(linebuf);
+    XFREE_CLEAR(attrbuf);
     bufsize = 0;
   }
   ui->composed = false;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -714,8 +714,7 @@ char *u_get_undo_file_name(const char *const buf_ffname, const bool reading)
         && (!reading || os_path_exists((char_u *)undo_file_name))) {
       break;
     }
-    xfree(undo_file_name);
-    undo_file_name = NULL;
+    XFREE_CLEAR(undo_file_name);
   }
 
   xfree(munged_name);
@@ -2887,8 +2886,7 @@ void u_saveline(linenr_T lnum)
 void u_clearline(void)
 {
   if (curbuf->b_u_line_ptr != NULL) {
-    xfree(curbuf->b_u_line_ptr);
-    curbuf->b_u_line_ptr = NULL;
+    XFREE_CLEAR(curbuf->b_u_line_ptr);
     curbuf->b_u_line_lnum = 0;
   }
 }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -558,8 +558,7 @@ win_T *win_new_float(win_T *wp, FloatConfig fconfig, Error *err)
     }
     int dir;
     winframe_remove(wp, &dir, NULL);
-    xfree(wp->w_frame);
-    wp->w_frame = NULL;
+    XFREE_CLEAR(wp->w_frame);
     (void)win_comp_pos();  // recompute window positions
     win_remove(wp, NULL);
     win_append(lastwin_nofloating(), wp);
@@ -4297,8 +4296,7 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
         do_autocmd_dirchanged((char *)globaldir, kCdScopeGlobal);
       }
     }
-    xfree(globaldir);
-    globaldir = NULL;
+    XFREE_CLEAR(globaldir);
     shorten_fnames(TRUE);
   }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4297,7 +4297,7 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
       }
     }
     XFREE_CLEAR(globaldir);
-    shorten_fnames(TRUE);
+    shorten_fnames(true);
   }
 
   if (trigger_new_autocmds) {

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -148,10 +148,10 @@ describe('autocmd', function()
        funcs.execute('autocmd Tabnew'))
   end)
 
-  it('window works', function()
-    -- Nvim uses a special window to execute certain actions for an invisible buffer,
-    -- internally called autcmd_win and mentioned in the docs at :help E813
-    -- Do some safety checks for redrawing and api accesses to this window.
+  it('internal `aucmd_win` window', function()
+    -- Nvim uses a special internal window `aucmd_win` to execute certain
+    -- actions for an invisible buffer (:help E813).
+    -- Check redrawing and API accesses to this window.
 
     local screen = Screen.new(50, 10)
     screen:attach()


### PR DESCRIPTION
ref #1375

-  ~~rename `xfree` to `xfree_` (so that other PRs are forced to update upon merging to master)~~ 
-  ~~introduce `xfree`  macro (from @ZyX-I in #1375)~~
-  ~~rename `xfree` macro to `XFREE`~~

## Conclusion:

- see https://github.com/neovim/neovim/pull/10046#issuecomment-494572846
- introduce `XFREE_CLEAR()` and use it selectively