### PR TITLE
vim-patch:8.1.1363

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2826,6 +2826,9 @@ void ex_packadd(exarg_T *eap)
 void ex_options(exarg_T *eap)
 {
   vim_setenv("OPTWIN_CMD", cmdmod.tab ? "tab" : "");
+  vim_setenv("OPTWIN_CMD",
+             cmdmod.tab ? "tab" :
+             (cmdmod.split & WSP_VERT) ? "vert" : "");
   cmd_source((char_u *)SYS_OPTWIN_FILE, NULL);
 }
 

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -51,6 +51,32 @@ function! Test_options()
   endtry
   call assert_equal('ok', caught)
 
+  " Check if the option-window is opened horizontally.
+  wincmd j
+  call assert_notequal('option-window', bufname(''))
+  wincmd k
+  call assert_equal('option-window', bufname(''))
+  " close option-window
+  close
+
+  " Open the option-window vertically.
+  vert options
+  " Check if the option-window is opened vertically.
+  wincmd l
+  call assert_notequal('option-window', bufname(''))
+  wincmd h
+  call assert_equal('option-window', bufname(''))
+  " close option-window
+  close
+
+  " Open the option-window in a new tab.
+  tab options
+  " Check if the option-window is opened in a tab.
+  normal gT
+  call assert_notequal('option-window', bufname(''))
+  normal gt
+  call assert_equal('option-window', bufname(''))
+
   " close option-window
   close
 endfunction


### PR DESCRIPTION
**vim-patch:8.1.1363: ":vert options" does not make a vertical split**

Problem:    ":vert options" does not make a vertical split.
Solution:   Pass the right modifiers in $OPTWIN_CMD. (Ken Takata,
            closes vim/vim#4401)
https://github.com/vim/vim/commit/e0b5949a3b28be9940bb8a46b2579e960100b83b