### PR TITLE
[RFC] vim-patch:8.1.{729,732}

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -955,6 +955,12 @@ ShellFilterPost			After executing a shell command with
 							*SourcePre*
 SourcePre			Before sourcing a Vim script. |:source|
 				<afile> is the name of the file being sourced.
+							*SourcePost*
+SourcePost			After sourcing a Vim script. |:source|
+				<afile> is the name of the file being sourced.
+				Not triggered when sourcing was interrupted.
+				Also triggered after a SourceCmd autocommand
+				was triggered.
 							*SourceCmd*
 SourceCmd			When sourcing a Vim script. |:source|
 				<afile> is the name of the file being sourced.

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -77,6 +77,7 @@ return {
     'Signal',                 -- after nvim process received a signal
     'SourceCmd',              -- sourcing a Vim script using command
     'SourcePre',              -- before sourcing a Vim script
+    'SourcePost',             -- after sourcing a Vim script
     'SpellFileMissing',       -- spell file missing
     'StdinReadPost',          -- after reading from stdin
     'StdinReadPre',           -- before reading from stdin

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3186,7 +3186,7 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
     }
     si = &SCRIPT_ITEM(current_SID);
     si->sn_name = fname_exp;
-    fname_exp = NULL;
+    fname_exp = vim_strsave(si->sn_name);  // used for autocmd
     if (file_id_ok) {
       si->file_id_valid = true;
       si->file_id = file_id;
@@ -3288,7 +3288,7 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   convert_setup(&cookie.conv, NULL, NULL);
 
   if (trigger_source_post) {
-    apply_autocmds(EVENT_SOURCEPOST, si->sn_name, si->sn_name, false, curbuf);
+    apply_autocmds(EVENT_SOURCEPOST, fname_exp, fname_exp, false, curbuf);
   }
 
 theend:

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3039,6 +3039,7 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   int save_debug_break_level = debug_break_level;
   scriptitem_T            *si = NULL;
   proftime_T wait_start;
+  bool trigger_source_post = false;
 
   p = expand_env_save(fname);
   if (p == NULL) {
@@ -3059,6 +3060,10 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
       && apply_autocmds(EVENT_SOURCECMD, fname_exp, fname_exp,
                         false, curbuf)) {
     retval = aborting() ? FAIL : OK;
+    if (retval == OK) {
+      // Apply SourcePost autocommands.
+      apply_autocmds(EVENT_SOURCEPOST, fname_exp, fname_exp, false, curbuf);
+    }
     goto theend;
   }
 
@@ -3261,6 +3266,10 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
     time_pop(rel_time);
   }
 
+  if (!got_int) {
+    trigger_source_post = true;
+  }
+
   // After a "finish" in debug mode, need to break at first command of next
   // sourced file.
   if (save_debug_break_level > ex_nesting_level
@@ -3277,6 +3286,10 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   xfree(cookie.nextline);
   xfree(firstline);
   convert_setup(&cookie.conv, NULL, NULL);
+
+  if (trigger_source_post) {
+    apply_autocmds(EVENT_SOURCEPOST, si->sn_name, si->sn_name, false, curbuf);
+  }
 
 theend:
   xfree(fname_exp);

--- a/src/nvim/testdir/test_source.vim
+++ b/src/nvim/testdir/test_source.vim
@@ -8,3 +8,40 @@ func Test_source_sandbox()
   call assert_fails('sandbox source! Xsourcehello', 'E48:')
   bwipe!
 endfunc
+
+func Test_source_autocmd()
+  call writefile([
+	\ 'let did_source = 1',
+	\ ], 'Xsourced')
+  au SourcePre *source* let did_source_pre = 1
+  au SourcePost *source* let did_source_post = 1
+
+  source Xsourced
+
+  call assert_equal(g:did_source, 1)
+  call assert_equal(g:did_source_pre, 1)
+  call assert_equal(g:did_source_post, 1)
+
+  call delete('Xsourced')
+  au! SourcePre
+  au! SourcePost
+  unlet g:did_source
+  unlet g:did_source_pre
+  unlet g:did_source_post
+endfunc
+
+func Test_source_cmd()
+  au SourceCmd *source* let did_source = expand('<afile>')
+  au SourcePre *source* let did_source_pre = 2
+  au SourcePost *source* let did_source_post = 2
+
+  source Xsourced
+
+  call assert_equal(g:did_source, 'Xsourced')
+  call assert_false(exists('g:did_source_pre'))
+  call assert_equal(g:did_source_post, 2)
+
+  au! SourceCmd
+  au! SourcePre
+  au! SourcePost
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0729: there is a SourcePre autocommand event but not a SourcePost**
Problem:    There is a SourcePre autocommand event but not a SourcePost.
Solution:   Add the SourcePost autocommand event. (closes vim/vim#3739)
vim/vim@2b61852

Leaving this WIP until patches for ~~VIM_CLEAR~~ and sourcing files are merged.