### PR TITLE
vim-patch:8.0.{1208,1220},8.1.{1171,1373}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3485,9 +3485,10 @@ int build_stl_str_hl(
         int group_start_userhl = 0;
         int group_end_userhl = 0;
         int n;
-        for (n = 0; n < groupitems[groupdepth]; n++) {
+        for (n = groupitems[groupdepth] - 1; n >= 0; n--) {
           if (items[n].type == Highlight) {
-            group_start_userhl = items[n].minwid;
+            group_start_userhl = group_end_userhl = items[n].minwid;
+            break;
           }
         }
         for (n = groupitems[groupdepth] + 1; n < curitem; n++) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3480,15 +3480,25 @@ int build_stl_str_hl(
       //       Otherwise there would be no reason to do this step.
       if (curitem > groupitems[groupdepth] + 1
           && items[groupitems[groupdepth]].minwid == 0) {
-        bool has_normal_items = false;
-        for (long n = groupitems[groupdepth] + 1; n < curitem; n++) {
-          if (items[n].type == Normal || items[n].type == Highlight) {
-            has_normal_items = true;
-            break;
+        // remove group if all items are empty and highlight group
+        // doesn't change
+        int group_start_userhl = 0;
+        int group_end_userhl = 0;
+        int n;
+        for (n = 0; n < groupitems[groupdepth]; n++) {
+          if (items[n].type == Highlight) {
+            group_start_userhl = items[n].minwid;
           }
         }
-
-        if (!has_normal_items) {
+        for (n = groupitems[groupdepth] + 1; n < curitem; n++) {
+          if (items[n].type == Normal) {
+            break;
+          }
+          if (items[n].type == Highlight) {
+            group_end_userhl = items[n].minwid;
+          }
+        }
+        if (n == curitem && group_start_userhl == group_end_userhl) {
           out_p = t;
           group_len = 0;
         }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5633,11 +5633,8 @@ static void nv_brackets(cmdarg_T *cap)
       if ((fdo_flags & FDO_BLOCK) && KeyTyped && cap->oap->op_type == OP_NOP)
         foldOpenCursor();
     }
-  }
-  /*
-   * "[p", "[P", "]P" and "]p": put with indent adjustment
-   */
-  else if (cap->nchar == 'p' || cap->nchar == 'P') {
+  } else if (cap->nchar == 'p' || cap->nchar == 'P') {
+    // "[p", "[P", "]P" and "]p": put with indent adjustment
     nv_put_opt(cap, true);
   }
   /*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5638,44 +5638,7 @@ static void nv_brackets(cmdarg_T *cap)
    * "[p", "[P", "]P" and "]p": put with indent adjustment
    */
   else if (cap->nchar == 'p' || cap->nchar == 'P') {
-    if (!checkclearop(cap->oap)) {
-      int dir = (cap->cmdchar == ']' && cap->nchar == 'p') ? FORWARD : BACKWARD;
-      int regname = cap->oap->regname;
-      int was_visual = VIsual_active;
-      linenr_T line_count = curbuf->b_ml.ml_line_count;
-      pos_T start, end;
-
-      if (VIsual_active) {
-        start = ltoreq(VIsual, curwin->w_cursor) ? VIsual : curwin->w_cursor;
-        end = equalpos(start, VIsual) ? curwin->w_cursor : VIsual;
-        curwin->w_cursor = (dir == BACKWARD ? start : end);
-      }
-      prep_redo_cmd(cap);
-      do_put(regname, NULL, dir, cap->count1, PUT_FIXINDENT);
-      if (was_visual) {
-        VIsual = start;
-        curwin->w_cursor = end;
-        if (dir == BACKWARD) {
-          /* adjust lines */
-          VIsual.lnum += curbuf->b_ml.ml_line_count - line_count;
-          curwin->w_cursor.lnum += curbuf->b_ml.ml_line_count - line_count;
-        }
-
-        VIsual_active = true;
-        if (VIsual_mode == 'V') {
-          /* delete visually selected lines */
-          cap->cmdchar = 'd';
-          cap->nchar = NUL;
-          cap->oap->regname = regname;
-          nv_operator(cap);
-          do_pending_operator(cap, 0, false);
-        }
-        if (VIsual_active) {
-          end_visual_mode();
-          redraw_later(SOME_VALID);
-        }
-      }
-    }
+    nv_put_opt(cap, true);
   }
   /*
    * "['", "[`", "]'" and "]`": jump to next mark
@@ -7799,6 +7762,13 @@ static void nv_join(cmdarg_T *cap)
  */
 static void nv_put(cmdarg_T *cap)
 {
+  nv_put_opt(cap, false);
+}
+
+// "P", "gP", "p" and "gp" commands.
+// "fix_indent" is true for "[p", "[P", "]p" and "]P".
+static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
+{
   int regname = 0;
   yankreg_T *savereg = NULL;
   bool empty = false;
@@ -7815,9 +7785,15 @@ static void nv_put(cmdarg_T *cap)
     } else
       clearopbeep(cap->oap);
   } else {
-    dir = (cap->cmdchar == 'P'
-           || (cap->cmdchar == 'g' && cap->nchar == 'P'))
-          ? BACKWARD : FORWARD;
+    if (fix_indent) {
+      dir = (cap->cmdchar == ']' && cap->nchar == 'p')
+        ? FORWARD : BACKWARD;
+      flags |= PUT_FIXINDENT;
+    } else {
+      dir = (cap->cmdchar == 'P'
+             || (cap->cmdchar == 'g' && cap->nchar == 'P'))
+        ? BACKWARD : FORWARD;
+    }
     prep_redo_cmd(cap);
     if (cap->cmdchar == 'g')
       flags |= PUT_CURSEND;

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -104,3 +104,15 @@ func Test_put_p_errmsg_nodup()
   delfunction Capture_p_error
   bwipeout!
 endfunc
+
+func Test_put_p_indent_visual()
+  new
+  call setline(1, ['select this text', 'select that text'])
+  " yank "that" from the second line
+  normal 2Gwvey
+  " select "this" in the first line and put
+  normal k0wve[p
+  call assert_equal('select that text', getline(1))
+  call assert_equal('select that text', getline(2))
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -62,23 +62,23 @@ func Test_statusline()
   only
   set laststatus=2
   set splitbelow
-  call setline(1, range(1, 200))
+  call setline(1, range(1, 10000))
 
   " %b: Value of character under cursor.
   " %B: As above, in hexadecimal.
-  call cursor(180, 2)
+  call cursor(9000, 1)
   set statusline=%b,%B
-  call assert_match('^56,38\s*$', s:get_statusline())
+  call assert_match('^57,39\s*$', s:get_statusline())
 
   " %o: Byte number in file of byte under cursor, first byte is 1.
   " %O: As above, in hexadecimal.
   set statusline=%o,%O
   set fileformat=dos
-  call assert_match('^789,315\s*$', s:get_statusline())
+  call assert_match('^52888,CE98\s*$', s:get_statusline())
   set fileformat=mac
-  call assert_match('^610,262\s*$', s:get_statusline())
+  call assert_match('^43889,AB71\s*$', s:get_statusline())
   set fileformat=unix
-  call assert_match('^610,262\s*$', s:get_statusline())
+  call assert_match('^43889,AB71\s*$', s:get_statusline())
   set fileformat&
 
   " %f: Path to the file in the buffer, as typed or relative to current dir.
@@ -112,7 +112,7 @@ func Test_statusline()
   " %L: Number of line in buffer.
   " %c: Column number.
   set statusline=%l/%L,%c
-  call assert_match('^180/200,2\s*$', s:get_statusline())
+  call assert_match('^9000/10000,1\s*$', s:get_statusline())
 
   " %m: Modified flag, text is "[+]", "[-]" if 'modifiable' is off.
   " %M: Modified flag, text is ",+" or ",-".
@@ -136,7 +136,7 @@ func Test_statusline()
   call assert_match('^0,Top\s*$', s:get_statusline())
   norm G
   call assert_match('^100,Bot\s*$', s:get_statusline())
-  180
+  9000
   " Don't check the exact percentage as it depends on the window size
   call assert_match('^90,\(Top\|Bot\|\d\+%\)\s*$', s:get_statusline())
 
@@ -165,7 +165,7 @@ func Test_statusline()
 
   " %v: Virtual column number.
   " %V: Virtual column number as -{num}. Not displayed if equal to 'c'.
-  call cursor(180, 2)
+  call cursor(9000, 2)
   set statusline=%v,%V
   call assert_match('^2,\s*$', s:get_statusline())
   set virtualedit=all
@@ -195,20 +195,26 @@ func Test_statusline()
 
   " Test min/max width, leading zeroes, left/right justify.
   set statusline=%04B
-  call cursor(180, 2)
-  call assert_match('^0038\s*$', s:get_statusline())
+  call cursor(9000, 1)
+  call assert_match('^0039\s*$', s:get_statusline())
   set statusline=#%4B#
-  call assert_match('^#  38#\s*$', s:get_statusline())
+  call assert_match('^#  39#\s*$', s:get_statusline())
   set statusline=#%-4B#
-  call assert_match('^#38  #\s*$', s:get_statusline())
+  call assert_match('^#39  #\s*$', s:get_statusline())
   set statusline=%.6f
   call assert_match('^<sline\s*$', s:get_statusline())
 
   " %<: Where to truncate.
-  exe 'set statusline=a%<b' . repeat('c', 1000) . 'd'
-  call assert_match('^a<c*d$', s:get_statusline())
-  exe 'set statusline=a' . repeat('b', 1000) . '%<c'
-  call assert_match('^ab*>$', s:get_statusline())
+  " First check with when %< should not truncate with many columns
+  exe 'set statusline=a%<b' . repeat('c', &columns - 3) . 'd'
+  call assert_match('^abc\+d$', s:get_statusline())
+  exe 'set statusline=a' . repeat('b', &columns - 2) . '%<c'
+  call assert_match('^ab\+c$', s:get_statusline())
+  " Then check when %< should truncate when there with too few columns.
+  exe 'set statusline=a%<b' . repeat('c', &columns - 2) . 'd'
+  call assert_match('^a<c\+d$', s:get_statusline())
+  exe 'set statusline=a' . repeat('b', &columns - 1) . '%<c'
+  call assert_match('^ab\+>$', s:get_statusline())
 
   "%{: Evaluate expression between '%{' and '}' and substitute result.
   syntax on

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -312,6 +312,12 @@ func Test_statusline()
   call assert_equal(sa1, sa3)
   call assert_equal(sa1, sa4)
 
+  let g:a = ''
+  set statusline=%#Error#{%(\ %{g:a}\ %)}
+  call assert_match('^{}\s*$', s:get_statusline())
+  let g:a = 'X'
+  call assert_match('^{ X }\s*$', s:get_statusline())
+
   " %%: a percent sign.
   set statusline=10%%
   call assert_match('^10%\s*$', s:get_statusline())

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -5,7 +5,6 @@
 "   %N
 "   %T
 "   %X
-"   %*
 
 source view_util.vim
 
@@ -248,6 +247,70 @@ func Test_statusline()
   let sa3=screenattr(&lines - 1, 3)
   call assert_equal(sa1, sa3)
   call assert_notequal(sa1, sa2)
+
+  " An empty group that contains highlight changes
+  let g:a = ''
+  set statusline=ab%(cd%1*%{g:a}%*%)de
+  call assert_match('^abde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 4)
+  call assert_equal(sa1, sa2)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 5)
+  let sa3=screenattr(&lines - 1, 7)
+  call assert_equal(sa1, sa3)
+  call assert_notequal(sa1, sa2)
+
+  let g:a = ''
+  set statusline=ab%1*%(cd%*%{g:a}%1*%)de
+  call assert_match('^abde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 4)
+  call assert_notequal(sa1, sa2)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 3)
+  let sa3=screenattr(&lines - 1, 5)
+  let sa4=screenattr(&lines - 1, 7)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa1, sa3)
+  call assert_equal(sa2, sa4)
+
+  " An empty group that contains highlight changes and doesn't reset them
+  let g:a = ''
+  set statusline=ab%(cd%1*%{g:a}%)de
+  call assert_match('^abcdde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 5)
+  call assert_notequal(sa1, sa2)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 5)
+  let sa3=screenattr(&lines - 1, 7)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa2, sa3)
+
+  let g:a = ''
+  set statusline=ab%1*%(cd%*%{g:a}%)de
+  call assert_match('^abcdde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 3)
+  let sa3=screenattr(&lines - 1, 5)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa1, sa3)
+  let g:a = 'X'
+  call assert_match('^abcdXde\s*$', s:get_statusline())
+  let sa1=screenattr(&lines - 1, 1)
+  let sa2=screenattr(&lines - 1, 3)
+  let sa3=screenattr(&lines - 1, 5)
+  let sa4=screenattr(&lines - 1, 7)
+  call assert_notequal(sa1, sa2)
+  call assert_equal(sa1, sa3)
+  call assert_equal(sa1, sa4)
 
   " %%: a percent sign.
   set statusline=10%%


### PR DESCRIPTION
**vim-patch:8.0.1208: 'statusline' drops empty group with highlight change**
Problem:    'statusline' drops empty group with highlight change.
Solution:   Do not drop an empty group if it changes highlighting. (Marius Gedminas, closes vim/vim#2228)
vim/vim@6b89dbb

**vim-patch:8.0.1220: skipping empty statusline groups is not correct**
Problem:    Skipping empty statusline groups is not correct.
Solution:   Also set group_end_userhl. (itchyny)
vim/vim@235dddf

**vim-patch:8.1.1171: statusline test could fail in large terminal**
Problem:    Statusline test could fail in large terminal.
Solution:   Make the test work on a huge terminal. (Dominique Pelle,
            closes vim/vim#4255)
vim/vim@316c167

**vim-patch:8.1.1373: "[p" in Visual mode puts in wrong line**
Problem:    "[p" in Visual mode puts in wrong line.
Solution:   Call nv_put() instead of duplicating the functionality.
            (closes vim/vim#4408)
vim/vim@0ab190c