### PR TITLE
Document indexing behavior of nvim_win_get_cursor

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -14,7 +14,9 @@ Applications can also embed libnvim to work with the C API directly.
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
-API Types							   *api-types*
+API Definitions                                                *api-definitions*
+
+                                                                     *api-types*
 
 The Nvim C API defines custom types for all function parameters. Some are just
 typedefs around C99 standard types, others are Nvim-defined data structures.
@@ -33,6 +35,27 @@ discriminated as separate types in an Object:
   Buffer				-> enum value kObjectTypeBuffer
   Window				-> enum value kObjectTypeWindow
   Tabpage				-> enum value kObjectTypeTabpage
+
+                                                                  *api-indexing*
+
+Most of the API uses 0-based indices, and ranges are end-exclusive. For the
+end of a range, -1 denotes the last line/column.
+
+This is the case for the following functions/events:
+
+    |nvim_buf_lines_event|
+    |nvim_buf_get_lines()|
+    |nvim_buf_set_lines(),|
+    |nvim_buf_add_highlight()|
+    |nvim_buf_clear_namespace()|
+    |nvim_buf_get_offset()|
+
+For historical reasons, the following functions exhibit "mark-like" behavior,
+i.e. lines are 1-indexed, columns are 0-indexed.
+
+    |nvim_buf_get_mark()|
+    |nvim_win_get_cursor()|
+    |nvim_win_set_cursor()|
 
 ==============================================================================
 API metadata							 *api-metadata*

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -489,10 +489,11 @@ end:
 
 /// Returns the byte offset for a line.
 ///
-/// Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is one byte.
-/// 'fileformat' and 'fileencoding' are ignored. The line index just after the
-/// last line gives the total byte-count of the buffer. A final EOL byte is
-/// counted if it would be written, see 'eol'.
+/// Line indices are 0-based, see |api-indexing|. Line 1 (index=0) has offset
+/// 0. UTF-8 bytes are counted. EOL is one byte. 'fileformat' and
+/// 'fileencoding' are ignored. The line index just after the last line gives
+/// the total byte-count of the buffer. A final EOL byte is counted if it would
+/// be written, see 'eol'.
 ///
 /// Unlike |line2byte()|, throws error for out-of-bounds indexing.
 /// Returns -1 for unloaded buffer.
@@ -879,7 +880,8 @@ void buffer_insert(Buffer buffer,
   nvim_buf_set_lines(0, buffer, lnum, lnum, true, lines, err);
 }
 
-/// Return a tuple (row,col) representing the position of the named mark
+/// Return a tuple (row,col) representing the position of the named mark,
+/// indices are (1, 0)-based, see also |api-indexing|.
 ///
 /// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Mark name
@@ -993,8 +995,9 @@ Integer nvim_buf_add_highlight(Buffer buffer,
 
 /// Clears namespaced objects, highlights and virtual text, from a line range
 ///
-/// To clear the namespace in the entire buffer, pass in 0 and -1 to
-/// line_start and line_end respectively.
+/// Line indices are 0-based, see also |api-indexing|. To clear the namespace
+/// in the entire buffer, pass in 0 and -1 to line_start and line_end
+/// respectively.
 ///
 /// @param buffer     Buffer handle, or 0 for current buffer
 /// @param ns_id      Namespace to clear, or -1 to clear all namespaces.

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -74,9 +74,8 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
   restore_win(save_curwin, save_curtab, false);
 }
 
-/// Gets the cursor position in the window. Rows are 1-indexed, while columns
-/// are 0-indexed (which is consistent with |marks|).
-///
+/// Gets the cursor position in the window. Indices are (1, 0)-based, see also
+/// |api-indexing|.
 /// @param window   Window handle
 /// @param[out] err Error details, if any
 /// @return (row, col) tuple
@@ -94,7 +93,8 @@ ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
   return rv;
 }
 
-/// Sets the cursor position in the window
+/// Sets the cursor position in the window. Indices are (1, 0)-based, see also
+/// |api-indexing|.
 ///
 /// @param window   Window handle
 /// @param pos      (row, col) tuple representing the new position

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -74,7 +74,8 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
   restore_win(save_curwin, save_curtab, false);
 }
 
-/// Gets the cursor position in the window
+/// Gets the cursor position in the window. Rows are 1-indexed, while columns
+/// are 0-indexed (which is consistent with |marks|).
 ///
 /// @param window   Window handle
 /// @param[out] err Error details, if any


### PR DESCRIPTION
I stumbled over this, so I figured I'd document it.

@justinmk suggested a table of indexing behavior in api.txt. I'd do it, but let me point out the functions that would be mentioned:

- Functions where lines/columns are 0-indexed, and ranges are end-exclusive:
  - nvim_buf_lines_event[{buf}, {changedtick}, **{firstline}, {lastline}**, {linedata}, {more}]
  - nvim_buf_get_lines({buffer}, **{start}, {end}**, {strict_indexing})
  - nvim_buf_set_lines({buffer}, **{start}, {end}**, {strict_indexing},
  - nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, **{line},{col_start}, {col_end}**)
  - nvim_buf_clear_namespace({buffer}, {ns_id}, **{line_start}, {line_end}**)
  - nvim_buf_get_offset({buffer}, **{index}**)
- Functions that exhibit "mark-like" behavior (lines 1-indexed, columns 0-indexed)
  - nvim_buf_get_mark({buffer}, {name})                     
  - nvim_win_get_cursor({window})                     
  - nvim_win_set_cursor({window}, {pos})                  

Should I put that into a table? Most of it is documented in the function docs themselves (I'd recheck if we don't do the table), and there's just 2 types of behavior, "api-like" and "mark-like". I'd suggest we just add a small paragraph with a sentence, rather than a table.
