### PR TITLE
vim-patch:8.1.0817

### DIFF
--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -7,6 +7,7 @@ source test_cd.vim
 source test_changedtick.vim
 source test_compiler.vim
 source test_cursor_func.vim
+source test_ex_equal.vim
 source test_ex_undo.vim
 source test_ex_z.vim
 source test_execute_func.vim

--- a/src/nvim/testdir/test_ex_equal.vim
+++ b/src/nvim/testdir/test_ex_equal.vim
@@ -1,0 +1,32 @@
+" Test Ex := command.
+
+func Test_ex_equal()
+  new
+  call setline(1, ["foo\tbar", "bar\tfoo"])
+
+  let a = execute('=')
+  call assert_equal("\n2", a)
+
+  let a = execute('=#')
+  call assert_equal("\n2\n  1 foo     bar", a)
+
+  let a = execute('=l')
+  call assert_equal("\n2\nfoo^Ibar$", a)
+
+  let a = execute('=p')
+  call assert_equal("\n2\nfoo     bar", a)
+
+  let a = execute('=l#')
+  call assert_equal("\n2\n  1 foo^Ibar$", a)
+
+  let a = execute('=p#')
+  call assert_equal("\n2\n  1 foo     bar", a)
+
+  let a = execute('.=')
+  call assert_equal("\n1", a)
+
+  call assert_fails('3=', 'E16:')
+  call assert_fails('=x', 'E488:')
+
+  bwipe!
+endfunc


### PR DESCRIPTION
**vim-patch:8.1.0817: ":=" command is not tested**

Problem:    ":=" command is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3859)
https://github.com/vim/vim/commit/99531a7604ce89ba82f41cdb519669abb61f3df0