### PR TITLE
Make sure msg_clear is sent after confirm message

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -505,12 +505,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
 
   if (ui_has(kUICmdline)) {
     ui_call_cmdline_hide(ccline.level);
-    if (msg_ext_is_visible()) {
-      msg_ext_did_cmdline = true;
-      if (must_redraw < VALID) {
-        must_redraw = VALID;
-      }
-    }
+    msg_ext_clear_later();
   }
 
   cmdline_level--;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -926,6 +926,10 @@ void ex_messages(void *const eap_p)
  */
 void msg_end_prompt(void)
 {
+  if (must_redraw < VALID) {
+    must_redraw = VALID;
+  }
+  msg_ext_did_cmdline = TRUE;
   need_wait_return = FALSE;
   emsg_on_display = FALSE;
   cmdline_row = msg_row;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -927,8 +927,8 @@ void ex_messages(void *const eap_p)
 void msg_end_prompt(void)
 {
   msg_ext_clear_later();
-  need_wait_return = FALSE;
-  emsg_on_display = FALSE;
+  need_wait_return = false;
+  emsg_on_display = false;
   cmdline_row = msg_row;
   msg_col = 0;
   msg_clr_eos();

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -926,10 +926,7 @@ void ex_messages(void *const eap_p)
  */
 void msg_end_prompt(void)
 {
-  if (must_redraw < VALID) {
-    must_redraw = VALID;
-  }
-  msg_ext_did_cmdline = TRUE;
+  msg_ext_clear_later();
   need_wait_return = FALSE;
   emsg_on_display = FALSE;
   cmdline_row = msg_row;
@@ -2795,12 +2792,22 @@ void msg_ext_clear(bool force)
   msg_ext_keep_after_cmdline = false;
 }
 
-void msg_ext_check_prompt(void)
+void msg_ext_clear_later(void)
 {
-  // Redraw after cmdline is expected to clear messages.
-  if (msg_ext_did_cmdline) {
+  if (msg_ext_is_visible()) {
+    msg_ext_need_clear = true;
+    if (must_redraw < VALID) {
+      must_redraw = VALID;
+    }
+  }
+}
+
+void msg_ext_check_clear(void)
+{
+  // Redraw after cmdline or prompt is expected to clear messages.
+  if (msg_ext_need_clear) {
     msg_ext_clear(true);
-    msg_ext_did_cmdline = false;
+    msg_ext_need_clear = false;
   }
 }
 

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -88,7 +88,7 @@ extern MessageHistoryEntry *first_msg_hist;
 /// Last message
 extern MessageHistoryEntry *last_msg_hist;
 
-EXTERN bool msg_ext_did_cmdline INIT(= false);
+EXTERN bool msg_ext_need_clear INIT(= false);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "message.h.generated.h"

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -369,7 +369,7 @@ void update_screen(int type)
     ui_comp_set_screen_valid(false);
   }
   win_ui_flush_positions();
-  msg_ext_check_prompt();
+  msg_ext_check_clear();
 
   /* reset cmdline_row now (may have been changed temporarily) */
   compute_cmdrow();

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -27,6 +27,30 @@ describe('ui/ext_messages', function()
     os.remove('Xtest')
   end)
 
+  it('msg_clear follows msg_show kind of confirm', function()
+    feed('iline 1<esc>')
+    feed(':call confirm("test")<cr>')
+    screen:expect{grid=[[
+      line ^1                   |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={ {
+      content = {{"\ntest\n[O]k: ", 4}},
+      kind = 'confirm',
+    }}}
+
+    feed('<cr>')
+    screen:expect{grid=[[
+      line ^1                   |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]]}
+  end)
+
   it('msg_show kind=confirm,confirm_sub,emsg,wmsg,quickfix', function()
     feed('iline 1\nline 2<esc>')
 


### PR DESCRIPTION
`msg_clear` isn't always send after a `msg_show` with kind confirm. This PR fixes that.

With the help of @bfredl and @justinmk.