### PR TITLE
vim-patch:8.1.1365: :source should check sandbox

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1244,6 +1244,13 @@ openscript (
     EMSG(_(e_nesting));
     return;
   }
+
+  // Disallow sourcing a file in the sandbox, the commands would be executed
+  // later, possibly outside of the sandbox.
+  if (check_secure()) {
+    return;
+  }
+
   if (ignore_script)
     /* Not reading from script, also don't open one.  Warning message? */
     return;


### PR DESCRIPTION
Problem:    Source command doesn't check for the sandbox. (Armin Razmjou)
Solution:   Check for the sandbox when sourcing a file.
https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040

ref #10052