### PR TITLE
vim-patch:8.1.1365: source command doesn't check for the sandbox

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1234,7 +1234,7 @@ void restore_typeahead(tasave_T *tp)
 /*
  * Open a new script file for the ":source!" command.
  */
-void 
+void
 openscript (
     char_u *name,
     int directly                   /* when TRUE execute directly */
@@ -1244,6 +1244,13 @@ openscript (
     EMSG(_(e_nesting));
     return;
   }
+
+  // Disallow sourcing a file in the sandbox, the commands would be executed
+  // later, possibly outside of the sandbox.
+  if (check_secure()) {
+      return;
+  }
+
   if (ignore_script)
     /* Not reading from script, also don't open one.  Warning message? */
     return;

--- a/src/nvim/testdir/test_source.vim
+++ b/src/nvim/testdir/test_source.vim
@@ -1,0 +1,8 @@
+func Test_source_sandbox()
+  new
+  call writefile(["Ohello\<Esc>"], 'Xsourcehello')
+  source! Xsourcehello | echo
+  call assert_equal('hello', getline(1))
+  call assert_fails('sandbox source! Xsourcehello', 'E48:')
+  bwipe!
+endfunc


### PR DESCRIPTION
Problem:    Source command doesn't check for the sandbox. (Armin Razmjou)
Solution:   Check for the sandbox when sourcing a file.
https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040