### PR TITLE
[RFC] nvim_win_close should not be able to close cmdline-window

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#include "nvim/ascii.h"
+#include "nvim/globals.h"
 #include "nvim/api/window.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
@@ -17,7 +19,6 @@
 #include "nvim/window.h"
 #include "nvim/screen.h"
 #include "nvim/move.h"
-
 
 /// Gets the current buffer in a window
 ///
@@ -526,9 +527,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
   return rv;
 }
 
-/// Close a window.
-///
-/// This is equivalent to |:close| with count except that it takes a window id.
+/// Closes the window (like |:close| with a |window-ID|).
 ///
 /// @param window   Window handle
 /// @param force    Behave like `:close!` The last window of a buffer with
@@ -546,6 +545,10 @@ void nvim_win_close(Window window, Boolean force, Error *err)
 
   TryState tstate;
   try_enter(&tstate);
-  ex_win_close(force, win, tabpage == curtab ? NULL : tabpage);
+  if (cmdwin_type != 0 && win == curwin) {
+    cmdwin_result = Ctrl_C;
+  } else {
+    ex_win_close(force, win, tabpage == curtab ? NULL : tabpage);
+  }
   vim_ignored = try_leave(&tstate, err);
 }

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -322,5 +322,20 @@ describe('API/win', function()
       meths.win_close(oldwin,true)
       eq({newwin}, meths.list_wins())
     end)
+
+    it('in cmdline-window #9767', function()
+      command('split')
+      eq(2, #meths.list_wins())
+      -- Open cmdline-window.
+      feed('q:')
+      eq(3, #meths.list_wins())
+      eq(':', funcs.getcmdwintype())
+      -- Vim: not allowed to close other windows from cmdline-window.
+      expect_err('Invalid window id$', meths.win_close, 1, true)
+      -- Close cmdline-window.
+      meths.win_close(0,true)
+      eq(2, #meths.list_wins())
+      eq('', funcs.getcmdwintype())
+    end)
   end)
 end)


### PR DESCRIPTION
#9767 Corner case where `nvim_win_close(0, 1)` is called from cmdline-window, and leaves neovim and host terminal in an invalid state. 

**<h1>Expected Behavior</h1>**

- Call to the close window API function with the 'force' flag will have no effect from the embedded terminal (i.e. `:nvim_win_close` with the cmdline-window open)

- Call to the close window API function from the cmdline-window itself will close the window, without affecting the larger context or leaving nvim in an invalid state

- Call to the close window API function from the cmdline from the last open window will have no effect.

**<h1>Actual Behavior</h1>**

- nvim is always in a valid state

- Split windows can be closed, last window cannot

- Tested on macOS native terminal with bash and zsh, as well as iTerm2 with bash and zsh (will test more when I have access to desktop)