### PR TITLE
[RFC] Fix buf_signcols sorting breaks signlist structure

### DIFF
--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -233,8 +233,9 @@ static void insert_sign_by_lnum_prio(
 
   // keep signs sorted by lnum, priority and id: insert new sign at
   // the proper position in the list for this lnum.
-  while (prev != NULL && prev->lnum == lnum && (prev->priority < prio
-         || ( prev->priority == prio && prev->id <= id ))) {
+  while (prev != NULL && prev->lnum == lnum
+         && (prev->priority < prio
+             || (prev->priority == prio && prev->id <= id))) {
     prev = prev->prev;
   }
   if (prev == NULL) {

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -231,9 +231,10 @@ static void insert_sign_by_lnum_prio(
 {
   signlist_T  *sign;
 
-  // keep signs sorted by lnum and by priority: insert new sign at
+  // keep signs sorted by lnum, priority and id: insert new sign at
   // the proper position in the list for this lnum.
-  while (prev != NULL && prev->lnum == lnum && prev->priority <= prio) {
+  while (prev != NULL && prev->lnum == lnum && (prev->priority < prio
+         || ( prev->priority == prio && prev->id <= id ))) {
     prev = prev->prev;
   }
   if (prev == NULL) {


### PR DESCRIPTION
Sorting in buf_signcols has been removed, as signlist is already kept
sorted and it did not correctly update the double linked list.

Fixes #10078