### PR TITLE
vim-patch:8.1.{1000,1436}

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1422,8 +1422,8 @@ int vgetc(void)
 
       }
 
-      /* a keypad or special function key was not mapped, use it like
-       * its ASCII equivalent */
+      // a keypad or special function key was not mapped, use it like
+      // its ASCII equivalent
       switch (c) {
         case K_KPLUS:       c = '+'; break;
         case K_KMINUS:      c = '-'; break;
@@ -1475,25 +1475,25 @@ int vgetc(void)
         case K_XRIGHT:      c = K_RIGHT; break;
       }
 
-      /* For a multi-byte character get all the bytes and return the
-       * converted character.
-       * Note: This will loop until enough bytes are received!
-       */
-      if (has_mbyte && (n = MB_BYTE2LEN_CHECK(c)) > 1) {
+      // For a multi-byte character get all the bytes and return the
+      // converted character.
+      // Note: This will loop until enough bytes are received!
+      if ((n = MB_BYTE2LEN_CHECK(c)) > 1) {
         no_mapping++;
         buf[0] = (char_u)c;
         for (i = 1; i < n; i++) {
           buf[i] = (char_u)vgetorpeek(true);
           if (buf[i] == K_SPECIAL
               ) {
-            /* Must be a K_SPECIAL - KS_SPECIAL - KE_FILLER sequence,
-             * which represents a K_SPECIAL (0x80),
-             * or a CSI - KS_EXTRA - KE_CSI sequence, which represents
-             * a CSI (0x9B),
-             * of a K_SPECIAL - KS_EXTRA - KE_CSI, which is CSI too. */
-            c = vgetorpeek(TRUE);
-            if (vgetorpeek(TRUE) == (int)KE_CSI && c == KS_EXTRA)
+            // Must be a K_SPECIAL - KS_SPECIAL - KE_FILLER sequence,
+            // which represents a K_SPECIAL (0x80),
+            // or a CSI - KS_EXTRA - KE_CSI sequence, which represents
+            // a CSI (0x9B),
+            // of a K_SPECIAL - KS_EXTRA - KE_CSI, which is CSI too.
+            c = vgetorpeek(true);
+            if (vgetorpeek(true) == (int)KE_CSI && c == KS_EXTRA) {
               buf[i] = CSI;
+            }
           }
         }
         no_mapping--;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -983,13 +983,16 @@ do_execreg(
       EMSG(_(e_nolastcmd));
       return FAIL;
     }
-    XFREE_CLEAR(new_last_cmdline);      // don't keep the cmdline containing @:
+    // don't keep the cmdline containing @:
+    XFREE_CLEAR(new_last_cmdline);
     // Escape all control characters with a CTRL-V
     p = vim_strsave_escaped_ext(
         last_cmdline,
-        (char_u *)
-        "\001\002\003\004\005\006\007\010\011\012\013\014\015\016\017\020\021\022\023\024\025\026\027\030\031\032\033\034\035\036\037",
-        Ctrl_V, FALSE);
+        (char_u *)"\001\002\003\004\005\006\007"
+        "\010\011\012\013\014\015\016\017"
+        "\020\021\022\023\024\025\026\027"
+        "\030\031\032\033\034\035\036\037",
+        Ctrl_V, false);
     /* When in Visual mode "'<,'>" will be prepended to the command.
      * Remove it when it's already there. */
     if (VIsual_active && STRNCMP(p, "'<,'>", 5) == 0)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -993,18 +993,19 @@ do_execreg(
         "\020\021\022\023\024\025\026\027"
         "\030\031\032\033\034\035\036\037",
         Ctrl_V, false);
-    /* When in Visual mode "'<,'>" will be prepended to the command.
-     * Remove it when it's already there. */
-    if (VIsual_active && STRNCMP(p, "'<,'>", 5) == 0)
-      retval = put_in_typebuf(p + 5, TRUE, TRUE, silent);
-    else
-      retval = put_in_typebuf(p, TRUE, TRUE, silent);
+    // When in Visual mode "'<,'>" will be prepended to the command.
+    // Remove it when it's already there.
+    if (VIsual_active && STRNCMP(p, "'<,'>", 5) == 0) {
+      retval = put_in_typebuf(p + 5, true, true, silent);
+    } else {
+      retval = put_in_typebuf(p, true, true, silent);
+    }
     xfree(p);
   } else if (regname == '=') {
     p = get_expr_line();
     if (p == NULL)
       return FAIL;
-    retval = put_in_typebuf(p, TRUE, colon, silent);
+    retval = put_in_typebuf(p, true, colon, silent);
     xfree(p);
   } else if (regname == '.') {        /* use last inserted text */
     p = get_last_insert_save();
@@ -1012,7 +1013,7 @@ do_execreg(
       EMSG(_(e_noinstext));
       return FAIL;
     }
-    retval = put_in_typebuf(p, FALSE, colon, silent);
+    retval = put_in_typebuf(p, false, colon, silent);
     xfree(p);
   } else {
     yankreg_T *reg = get_yank_register(regname, YREG_PASTE);
@@ -1078,8 +1079,8 @@ static void put_reedit_in_typebuf(int silent)
  */
 static int put_in_typebuf(
     char_u *s,
-    int esc,
-    int colon,                  /* add ':' before the line */
+    bool esc,
+    bool colon,                 // add ':' before the line
     int silent
 )
 {

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -38,7 +38,7 @@ func Test_writefile_fails_conversion()
   endif
   " Without a backup file the write won't happen if there is a conversion
   " error.
-  set nobackup nowritebackup
+  set nobackup nowritebackup backupdir=. backupskip=
   new
   let contents = ["line one", "line two"]
   call writefile(contents, 'Xfile')
@@ -49,7 +49,7 @@ func Test_writefile_fails_conversion()
 
   call delete('Xfile')
   bwipe!
-  set backup& writebackup&
+  set backup& writebackup& backupdir&vim backupskip&vim
 endfunc
 
 func Test_writefile_fails_conversion2()
@@ -58,7 +58,7 @@ func Test_writefile_fails_conversion2()
   endif
   " With a backup file the write happens even if there is a conversion error,
   " but then the backup file must remain
-  set nobackup writebackup
+  set nobackup writebackup backupdir=. backupskip=
   let contents = ["line one", "line two"]
   call writefile(contents, 'Xfile_conversion_err')
   edit Xfile_conversion_err
@@ -71,6 +71,7 @@ func Test_writefile_fails_conversion2()
   call delete('Xfile_conversion_err')
   call delete('Xfile_conversion_err~')
   bwipe!
+  set backup& writebackup& backupdir&vim backupskip&vim
 endfunc
 
 func SetFlag(timer)


### PR DESCRIPTION
**vim-patch:8.1.1000: indenting is off**
Problem:    Indenting is off.
Solution:   Make indenting consistent and update comments. (Ozaki Kiichi, closes vim/vim#4079)
vim/vim@fd731b0

**vim-patch:8.1.1436: writefile test fails when run under /tmp**
Problem:    Writefile test fails when run under /tmp.
Solution:   Adjust 'backupskip. (Kenta Sato, closes vim/vim#4462)
vim/vim@c28cb5b