### PR TITLE
deps: update to libuv v1.29.1

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -124,11 +124,12 @@ endif()
 include(ExternalProject)
 
 if(WIN32)
-  set(LIBUV_URL https://github.com/neovim/libuv/archive/327f762644ccb964715cb99d08db0f1df43f651e.tar.gz)
-  set(LIBUV_SHA256 76e4ac06c7c74aeb471342c7f2d4a054af51ff054d399fac9f26e8fd5821dc92)
+  # "nvim" branch of https://github.com/neovim/libuv
+  set(LIBUV_URL https://github.com/neovim/libuv/archive/0ac136359903c70ab1db1838c3ad06da6fa5b912.tar.gz)
+  set(LIBUV_SHA256 600badb81e39578ddfc8f3636f78dd308ea0915e5bf1ee56e6cdfa314d3c463f)
 else()
-  set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.26.0.tar.gz)
-  set(LIBUV_SHA256 e414cf74615b7dae768f0f5667092f1d4975f5067c087bcbe0641e241ebe4693)
+  set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.29.1.tar.gz)
+  set(LIBUV_SHA256 bdde1140087ce97080ea323c3598553ece00a24ae63ac568be78bef3e97f3e25)
 endif()
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0/msgpack-3.0.0.tar.gz)


### PR DESCRIPTION
Fixes #10101
See also neovim/libuv@0ac1363

Notable changes since v1.26.0:

- v1.27.0
  - linux: use statx() to obtain file birth time
- v1.28.0
  - unix,win: add uv_gettimeofday()
  - unix,win: add uv_fs_{open,read,close}dir()
  - unix: fix uv_interface_addresses()
  - fs: remove macOS-specific copyfile(3) fixes #10101
  - unix: suppress EINTR/EINPROGRESS in uv_fs_close()
- v1.29.0
  - unix: fix race condition in uv_async_send()
  - linux: use O_CLOEXEC instead of EPOLL_CLOEXEC
  - linux: read free/total memory from /proc/meminfo
  - unix: don't assert on UV_PROCESS_WINDOWS_* flags
  - unix,win: add uv_get_constrained_memory()
- v1.29.1
  - linux: fix sscanf() overflows reading from /proc