### PR TITLE
[WIP] vim-patch:8.0.0825

### DIFF
--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -87,6 +87,7 @@ typedef enum {
   , HLF_CUL         // 'cursorline'
   , HLF_MC          // 'colorcolumn'
   , HLF_QFL         // selected quickfix line
+  , HLF_ST          // status lines of terminal windows
   , HLF_0           // Whitespace
   , HLF_INACTIVE    // NormalNC: Normal text in non-current windows
   , HLF_MSGSEP      // message separator line
@@ -140,6 +141,7 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_CUL] = "CursorLine",
   [HLF_MC] = "ColorColumn",
   [HLF_QFL] = "QuickFixLine",
+  [HLF_ST] = "StatusLineTerm",
   [HLF_0] = "Whitespace",
   [HLF_INACTIVE] = "NormalNC",
   [HLF_MSGSEP] = "MsgSeparator",

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -263,7 +263,7 @@ typedef struct vimoption {
   "B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel," \
   "x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill," \
   "!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine," \
-  "0:Whitespace,I:NormalNC"
+  "$:StatusLineTerm,0:Whitespace,I:NormalNC"
 
 /*
  * options[] is initialized here.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6831,7 +6831,14 @@ static int fillchar_status(int *attr, win_T *wp)
 {
   int fill;
   bool is_curwin = (wp == curwin);
-  if (is_curwin) {
+  if (bt_terminal(wp->w_buffer)) {
+    *attr = win_hl_attr(wp, HLF_ST);
+    if (is_curwin) {
+      fill = wp->w_p_fcs_chars.stl;
+    } else {
+      fill = wp->w_p_fcs_chars.stlnc;
+    }
+  } else if (is_curwin) {
     *attr = win_hl_attr(wp, HLF_S);
     fill = wp->w_p_fcs_chars.stl;
   } else {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5957,6 +5957,8 @@ static const char *highlight_init_both[] = {
   "PmenuSbar    ctermbg=Grey guibg=Grey",
   "StatusLine   cterm=reverse,bold gui=reverse,bold",
   "StatusLineNC cterm=reverse gui=reverse",
+  "StatusLineTerm term=reverse cterm=reverse ctermFg=DarkGreen "
+      "gui=reverse guifg=DarkGreen",
   "TabLineFill  cterm=reverse gui=reverse",
   "TabLineSel   cterm=bold gui=bold",
   "TermCursor   cterm=reverse gui=reverse",


### PR DESCRIPTION
**vim-patch:8.0.0825: not easy to see that a window is a terminal window**
Problem:    Not easy to see that a window is a terminal window.
Solution:   Add StatusLineTerm highlighting.
https://github.com/vim/vim/commit/3633cf5201e914cc802fd2f813fa87bc959ffaec

WIP until `StatusLineTermNC` is included and works.