### PR TITLE
[RDY] Fix multiple <C-D> showing statusline on previous completion list

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -656,10 +656,13 @@ static int command_line_execute(VimState *state, int key)
         redrawcmd();
         save_p_ls = -1;
         wild_menu_showing = 0;
-      } else {
+      // don't redraw statusline if WM_LIST is showing
+      } else if (wild_menu_showing != WM_LIST) {
         win_redraw_last_status(topframe);
         wild_menu_showing = 0;  // must be before redraw_statuslines #8385
         redraw_statuslines();
+      } else {
+        wild_menu_showing = 0;
       }
       KeyTyped = skt;
       if (ccline.input_fn) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -705,11 +705,8 @@ describe('ui/ext_messages', function()
   end)
 
   it('wildmode=list', function()
-    local default_attr = screen:get_default_attr_ids()
-    screen:detach()
-    screen = Screen.new(25, 7)
-    screen:attach({rgb=true, ext_messages=true})
-    screen:set_default_attr_ids(default_attr)
+    screen:try_resize(25, 7)
+    screen:set_option('ext_popupmenu', false)
 
     command('set wildmenu wildmode=list')
     feed(':set wildm<tab>')

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -15,9 +15,6 @@ describe("'wildmenu'", function()
     screen = Screen.new(25, 5)
     screen:attach()
   end)
-  after_each(function()
-    screen:detach()
-  end)
 
   -- expect the screen stayed unchanged some time after first seen success
   local function expect_stay_unchanged(args)
@@ -170,9 +167,7 @@ describe("'wildmenu'", function()
 
   it('wildmode=list,full and display+=msgsep interaction #10092', function()
     -- Need more than 5 rows, else tabline is covered and will be redrawn.
-    screen:detach()
-    screen = Screen.new(25, 7)
-    screen:attach()
+    screen:try_resize(25, 7)
 
     command('set display+=msgsep')
     command('set wildmenu wildmode=list,full')
@@ -211,9 +206,7 @@ describe("'wildmenu'", function()
 
   it('wildmode=list,full and display-=msgsep interaction', function()
     -- Need more than 5 rows, else tabline is covered and will be redrawn.
-    screen:detach()
-    screen = Screen.new(25, 7)
-    screen:attach()
+    screen:try_resize(25, 7)
 
     command('set display-=msgsep')
     command('set wildmenu wildmode=list,full')
@@ -250,6 +243,8 @@ describe("'wildmenu'", function()
   end)
 
   it('multiple <C-D> renders correctly', function()
+    screen:try_resize(25, 7)
+
     command('set laststatus=2')
     command('set display+=msgsep')
     feed(':set wildm')
@@ -358,10 +353,6 @@ describe('ui/ext_wildmenu', function()
     clear()
     screen = Screen.new(25, 5)
     screen:attach({rgb=true, ext_wildmenu=true})
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it('works with :sign <tab>', function()

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -248,6 +248,42 @@ describe("'wildmenu'", function()
                                |
     ]])
   end)
+
+  it('multiple <C-D> renders correctly', function()
+    command('set laststatus=2')
+    command('set display+=msgsep')
+    feed(':set wildm')
+    feed('<c-d>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+                               |
+      :set wildm               |
+      wildmenu  wildmode       |
+      :set wildm^               |
+    ]])
+    feed('<c-d>')
+    screen:expect([[
+                               |
+                               |
+      :set wildm               |
+      wildmenu  wildmode       |
+      :set wildm               |
+      wildmenu  wildmode       |
+      :set wildm^               |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      [No Name]                |
+                               |
+    ]])
+  end)
 end)
 
 describe('command line completion', function()


### PR DESCRIPTION
Repro:
```vim
nvim -u NORC
:co<c-d><c-d>
```

The statusline gets redrawn on the last line of the completion list. Subsequent `<C-D>` will render more statuslines.