### PR TITLE
Fix screenchar() problem in headless mode

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1806,8 +1806,13 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
   // different, e.g. for Win32 console) or we just don't know where the
   // cursor is.
   if (msg_use_printf()) {
+    int saved_msg_col = msg_col;
     msg_puts_printf(str, len);
-  } else {
+    if (headless_mode) {
+      msg_col = saved_msg_col;
+    }
+  }
+  if (!msg_use_printf() || headless_mode) {
     msg_puts_display((const char_u *)str, len, attr, false);
   }
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1812,7 +1812,7 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
       msg_col = saved_msg_col;
     }
   }
-  if (!msg_use_printf() || headless_mode) {
+  if (!msg_use_printf() || (headless_mode && default_grid.chars)) {
     msg_puts_display((const char_u *)str, len, attr, false);
   }
 }


### PR DESCRIPTION
In the case of the headless mode, `screenchar()` does not operate normally
because it is not output to the internal screen. Change output to `stderr`
and internal screen to fix it.

ref #9338