### PR TITLE
Fixes json syntax for when you have a json encoded string as a value

### DIFF
--- a/runtime/syntax/json.vim
+++ b/runtime/syntax/json.vim
@@ -16,8 +16,19 @@ syntax match   jsonNoise           /\%(:\|,\)/
 
 " NOTE that for the concealing to work your conceallevel should be set to 2
 
+" Syntax: JSON Keywords
+" Separated into a match and region because a region by itself is always greedy
+syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
+if has('conceal')
+   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
+else
+   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
+endif
+
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
+" Needs to come after keywords or else a json encoded string will break the
+" syntax
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
 if has('conceal')
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
@@ -28,14 +39,6 @@ endif
 " Syntax: JSON does not allow strings with single quotes, unlike JavaScript.
 syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 
-" Syntax: JSON Keywords
-" Separated into a match and region because a region by itself is always greedy
-syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal')
-   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
-else
-   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
-endif
 
 " Syntax: Escape sequences
 syn match   jsonEscape    "\\["\\/bfnrt]" contained


### PR DESCRIPTION
Here is an example of some json that will cause the syntax to break:
```
{
  "item": [
    {
      "name": "some stuff",
      "item": [
        {
          "body": {
            "mode": "raw",
            "ode": "raw",
            "ra": "\"check\"",
            "raa": "\"check\":it\"out\"",
            "raw": "{\n   \"check\":\"one\",\n  \"nested\":{\"foo\":\"bar\"},\n   \"isThing\":true,\n   \"arr\":[\"one\"]\n}\n"
          }
        }
      ]
    }
  ]
}
```
I'm not sure what testing is needed here all I had to do was move the keywords to be defined before the string.