### PR TITLE
vim-patch:8.0.1518,8.1.{2,804}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -20082,9 +20082,15 @@ static void set_var(const char *name, const size_t name_len, typval_T *const tv,
     // prevent changing the type.
     if (ht == &vimvarht) {
       if (v->di_tv.v_type == VAR_STRING) {
-        xfree(v->di_tv.vval.v_string);
+        XFREE_CLEAR(v->di_tv.vval.v_string);
         if (copy || tv->v_type != VAR_STRING) {
-          v->di_tv.vval.v_string = (char_u *)xstrdup(tv_get_string(tv));
+          const char *const val = tv_get_string(tv);
+
+          // Careful: when assigning to v:errmsg and tv_get_string()
+          // causes an error message the variable will alrady be set.
+          if (v->di_tv.vval.v_string == NULL) {
+            v->di_tv.vval.v_string = (char_u *)xstrdup(val);
+          }
         } else {
           // Take over the string to avoid an extra alloc/free.
           v->di_tv.vval.v_string = tv->vval.v_string;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2217,11 +2217,19 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     ea.arg = skipwhite(p);
   }
 
-  /*
-   * 7. Switch on command name.
-   *
-   * The "ea" structure holds the arguments that can be used.
-   */
+  // The :try command saves the emsg_silent flag, reset it here when
+  // ":silent! try" was used, it should only apply to :try itself.
+  if (ea.cmdidx == CMD_try && did_esilent > 0) {
+    emsg_silent -= did_esilent;
+    if (emsg_silent < 0) {
+      emsg_silent = 0;
+    }
+    did_esilent = 0;
+  }
+
+  // 7. Execute the command.
+  //
+  // The "ea" structure holds the arguments that can be used.
   ea.cmdlinep = cmdlinep;
   ea.getline = fgetline;
   ea.cookie = cookie;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6595,6 +6595,9 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
+  const int save_msg_row = msg_row;
+  const int save_msg_col = msg_col;
+
   msg_ext_ui_flush();
   msg_pos_mode();
   if (reg_recording != 0) {
@@ -6602,6 +6605,9 @@ void clearmode(void)
   }
   msg_clr_eos();
   msg_ext_flush_showmode();
+
+  msg_col = save_msg_col;
+  msg_row = save_msg_row;
 }
 
 static void recording_mode(int attr)

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -78,3 +78,17 @@ func Test_string_concatenation()
   let a..=b
   call assert_equal('ab', a)
 endfunc
+
+func Test_nocatch_restore_silent_emsg()
+  silent! try
+    throw 1
+  catch
+  endtry
+  echoerr 'wrong'
+  let c1 = nr2char(screenchar(&lines, 1))
+  let c2 = nr2char(screenchar(&lines, 2))
+  let c3 = nr2char(screenchar(&lines, 3))
+  let c4 = nr2char(screenchar(&lines, 4))
+  let c5 = nr2char(screenchar(&lines, 5))
+  call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
+endfunc

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -92,3 +92,10 @@ func Test_nocatch_restore_silent_emsg()
   let c5 = nr2char(screenchar(&lines, 5))
   call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
 endfunc
+
+func Test_let_errmsg()
+  call assert_fails('let v:errmsg = []', 'E730:')
+  let v:errmsg = ''
+  call assert_fails('let v:errmsg = []', 'E730:')
+  let v:errmsg = ''
+endfunc

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -39,6 +39,27 @@ function Test_messages()
   endtry
 endfunction
 
+ " Patch 7.4.1696 defined the "clearmode()" command for clearing the mode
+" indicator (e.g., "-- INSERT --") when ":stopinsert" is invoked.  Message
+" output could then be disturbed when 'cmdheight' was greater than one.
+" This test ensures that the bugfix for this issue remains in place.
+function! Test_stopinsert_does_not_break_message_output()
+  set cmdheight=2
+  redraw!
+
+   stopinsert | echo 'test echo'
+  call assert_equal(116, screenchar(&lines - 1, 1))
+  call assert_equal(32, screenchar(&lines, 1))
+  redraw!
+
+   stopinsert | echomsg 'test echomsg'
+  call assert_equal(116, screenchar(&lines - 1, 1))
+  call assert_equal(32, screenchar(&lines, 1))
+  redraw!
+
+   set cmdheight&
+endfunction
+
 func Test_message_completion()
   call feedkeys(":message \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"message clear', @:)


### PR DESCRIPTION
**vim-patch:8.0.1518: error messages suppressed after ":silent! try"**
Problem:    Error messages suppressed after ":silent! try". (Ben Reilly)
Solution:   Restore emsg_silent before executing :try. (closes vim/vim#2531)
https://github.com/vim/vim/commit/2be57331524e93da52a0663f4a334d21c05123bb

**vim-patch:8.1.0002: :stopinsert changes the message position**
Problem:    :stopinsert changes the message position.
Solution:   Save and restore msg_col and msg_row in clearmode(). (Jason
            Franklin)
vim/vim@2abad54

**vim-patch:8.1.0804: crash when setting v:errmsg to empty list**
Problem:    Crash when setting v:errmsg to empty list. (Jaon Franklin)
Solution:   Separate getting value and assigning result.
vim/vim@4b9e91f

Revisit https://github.com/neovim/neovim/pull/8951 and https://github.com/neovim/neovim/pull/9111 after https://github.com/neovim/neovim/pull/9338