### PR TITLE
defaults: exclude "S" from 'shortmess'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5254,7 +5254,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function to get the effective shiftwidth value.
 
 						*'shortmess'* *'shm'*
-'shortmess' 'shm'	string	(Vim default "filnxtToOFS", Vi default: "S")
+'shortmess' 'shm'	string	(Vim default "filnxtToOF", Vi default: "S")
 			global
 	This option helps to avoid all the |hit-enter| prompts caused by file
 	messages, for example  with CTRL-G, and to avoid some other messages.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -51,7 +51,7 @@ the differences.
 - 'nrformats' defaults to "bin,hex"
 - 'ruler' is set by default
 - 'sessionoptions' doesn't include "options"
-- 'shortmess' sets "F" flag
+- 'shortmess' includes "F", excludes "S"
 - 'showcmd' is set by default
 - 'sidescroll' defaults to 1
 - 'smarttab' is set by default

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2134,7 +2134,7 @@ return {
       type='string', list='flags', scope={'global'},
       vim=true,
       varname='p_shm',
-      defaults={if_true={vi="S", vim="filnxtToOFS"}}
+      defaults={if_true={vi="S", vim="filnxtToOF"}}
     },
     {
       full_name='showbreak', abbreviation='sbr',

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -26,7 +26,7 @@ local nvim_prog = (
   or global_helpers.test_build_dir .. '/bin/nvim'
 )
 -- Default settings for the test session.
-local nvim_set  = 'set shortmess+=I background=light noswapfile noautoindent'
+local nvim_set  = 'set shortmess+=IS background=light noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
                   ..' belloff= noshowcmd noruler nomore'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE',


### PR DESCRIPTION
ref #6289

New feature from https://github.com/neovim/neovim/pull/10114 (thanks @chrisbra and @erw7 ). Still doesn't work for mappings in some cases, but is a good default anyway.

example of a mapping that doesn't show the search stats:

```
nnoremap n :<C-U>exe 'norm! n'<CR>
nnoremap N :<C-U>exe 'norm! N'<CR>
```