### PR TITLE
scripts/vim-patch.sh: improve performance

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -384,6 +384,11 @@ list_missing_vimpatches() {
     tokens[$token]=1
   done
 
+  # Create an associative array mapping commits to tags.
+  eval "declare -A commit_tags=(
+    $(git -C "${VIM_SOURCE_DIR}" for-each-ref refs/tags --format '[%(objectname)]=%(refname:lstrip=2)' --shell)
+  )"
+
   # Get missing Vim commits
   for vim_commit in $(list_vim_commits); do
     # Check for vim-patch:<commit_hash> (usually runtime updates).
@@ -392,7 +397,8 @@ list_missing_vimpatches() {
       continue
     fi
 
-    if vim_tag="$(git -C "${VIM_SOURCE_DIR}" describe --tags --exact-match "${vim_commit}" 2>/dev/null)"; then
+    vim_tag="${commit_tags[$vim_commit]-}"
+    if [[ -n "$vim_tag" ]]; then
       # Check for vim-patch:<tag> (not commit hash).
       patch_number="vim-patch:${vim_tag:1}" # "v7.4.0001" => "7.4.0001"
       if [[ "${tokens[$patch_number]-}" ]]; then

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -378,15 +378,19 @@ list_vimpatch_numbers() {
 list_missing_vimpatches() {
   local token vim_commit vim_tag patch_number
   declare -A tokens
+  declare -A vim_commit_tags
 
   # Find all "vim-patch:xxx" tokens in the Nvim git log.
   for token in $(list_vimpatch_tokens); do
     tokens[$token]=1
   done
 
-  # Create an associative array mapping commits to tags.
-  eval "declare -A commit_tags=(
-    $(git -C "${VIM_SOURCE_DIR}" for-each-ref refs/tags --format '[%(objectname)]=%(refname:lstrip=2)' --shell)
+  # Create an associative array mapping Vim commits to tags.
+  eval "declare -A vim_commit_tags=(
+    $(git -C "${VIM_SOURCE_DIR}" for-each-ref refs/tags \
+      --format '[%(objectname)]=%(refname:lstrip=2)' \
+      --sort='-*authordate' \
+      --shell)
   )"
 
   # Get missing Vim commits
@@ -397,7 +401,7 @@ list_missing_vimpatches() {
       continue
     fi
 
-    vim_tag="${commit_tags[$vim_commit]-}"
+    vim_tag="${vim_commit_tags[$vim_commit]-}"
     if [[ -n "$vim_tag" ]]; then
       # Check for vim-patch:<tag> (not commit hash).
       patch_number="vim-patch:${vim_tag:1}" # "v7.4.0001" => "7.4.0001"


### PR DESCRIPTION
`vim-patch.sh -L`: down to ~0.5s from ~85s.
`vim-patch.sh -l`: down to ~6s from ~90s.

    % diff old new:
    193c193
    <   • v8.0.1366
    ---
    >   • v8.0.1367
    354d353
    <   • v8.0.1738

This is due to duplicate tags for Vim commits
(https://github.com/vim/vim/issues/4510):

  - vim/vim@1ad022a9b: tagged as v8.0.1367, v8.0.1366
  - vim/vim@5d69da462: tagged as v8.0.1739, v8.0.1738