### PR TITLE
[RFC] vim-patch.sh improvements  [ci skip]

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -110,8 +110,12 @@ commit_message() {
 }
 
 find_git_remote() {
-  git remote -v \
-    | awk '$2 ~ /github.com[:\/]neovim\/neovim/ && $3 == "(fetch)" {print $1; exit}'
+  git_remote=$(git remote -v \
+    | awk '$2 ~ /github.com[:\/]neovim\/neovim/ && $3 == "(fetch)" {print $1; exit}')
+  if [[ -z "$git_remote" ]]; then
+    git_remote="origin"
+  fi
+  echo "$git_remote"
 }
 
 assign_commit_details() {

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -34,6 +34,11 @@ usage() {
   echo
   echo "    \$VIM_SOURCE_DIR controls where Vim sources are found"
   echo "    (default: '${VIM_SOURCE_DIR_DEFAULT}')"
+  echo
+  echo "Examples:"
+  echo
+  echo " - List missing patches for a given file (in the Vim source):"
+  echo "   $0 -l -- src/edit.c"
 }
 
 msg_ok() {


### PR DESCRIPTION
IDEAS:

- [ ] include (git commit) summary line with `-l`, and `-L` (?).  The latter is meant for external parsing, so should be handled with care, but the former updates Vim sources always.  Could be done later still - not that trivial.

- [ ] have a mode to report missing patches for a given file, which might be based on Vim (with optional ".vim-src" prefix) or Neovim.  This should be distinct, since it is non-trivial to e.g. adjust the path in `$@` when passing it to git-log.