### PR TITLE
vim-patch:8.0.{1335,1339,1744}

### DIFF
--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -155,3 +155,11 @@ func Test_writefile_autowrite_nowrite()
   bwipe!
   set noautowrite
 endfunc
+
+func Test_writefile_sync_dev_stdout()
+  if !has('unix')
+    return
+  endif
+  " Just check that this doesn't cause an error.
+  call writefile(['one'], '/dev/stdout')
+endfunc

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -162,7 +162,7 @@ func Test_writefile_sync_dev_stdout()
   endif
   if filewritable('/dev/stdout')
     " Just check that this doesn't cause an error.
-    call writefile(['one'], '/dev/stdout')
+    call writefile(['one'], '/dev/stdout', 's')
   else
     throw 'Skipped: /dev/stdout is not writable'
   endif

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -160,6 +160,10 @@ func Test_writefile_sync_dev_stdout()
   if !has('unix')
     return
   endif
-  " Just check that this doesn't cause an error.
-  call writefile(['one'], '/dev/stdout')
+  if filewritable('/dev/stdout')
+    " Just check that this doesn't cause an error.
+    call writefile(['one'], '/dev/stdout')
+  else
+    throw 'Skipped: /dev/stdout is not writable'
+  endif
 endfunc


### PR DESCRIPTION
Just adds a (more explicit) test basically.

The fix itself is N/A: Neovim ignores EINVAL already in `file_fsync`
(https://github.com/neovim/neovim/blob/93dc59b1149/src/nvim/os/fileio.c#L232)