### PR TITLE
vim-patch:8.1.013{0,1}

### DIFF
--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -260,6 +260,7 @@ struct ufunc {
   garray_T     uf_args;          ///< arguments
   garray_T     uf_lines;         ///< function lines
   int          uf_profiling;     ///< true when func is being profiled
+  int          uf_prof_initialized;
   // Profiling the function as a whole.
   int          uf_tm_count;      ///< nr of calls
   proftime_T   uf_tm_total;      ///< time spent in function + children

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -5,6 +5,8 @@ endif
 
 func Test_profile_func()
   let lines = [
+    \ 'profile start Xprofile_func.log',
+    \ 'profile func Foo*"',
     \ "func! Foo1()",
     \ "endfunc",
     \ "func! Foo2()",
@@ -33,9 +35,7 @@ func Test_profile_func()
 
   call writefile(lines, 'Xprofile_func.vim')
   call system(v:progpath
-    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
-    \ . ' -c "profile start Xprofile_func.log"'
-    \ . ' -c "profile func Foo*"'
+    \ . ' -es --clean'
     \ . ' -c "so Xprofile_func.vim"'
     \ . ' -c "qall!"')
   call assert_equal(0, v:shell_error)
@@ -97,7 +97,7 @@ func Test_profile_file()
 
   call writefile(lines, 'Xprofile_file.vim')
   call system(v:progpath
-    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
+    \ . ' -es --clean'
     \ . ' -c "profile start Xprofile_file.log"'
     \ . ' -c "profile file Xprofile_file.vim"'
     \ . ' -c "so Xprofile_file.vim"'
@@ -152,17 +152,17 @@ func Test_profile_file_with_cont()
   let lines = readfile('Xprofile_file.log')
   call assert_equal(11, len(lines))
 
-  call assert_match('^SCRIPT .*Xprofile_file.vim$',                   lines[0])
-  call assert_equal('Sourced 1 time',                                lines[1])
-  call assert_match('^Total time:\s\+\d\+\.\d\+$',                    lines[2])
-  call assert_match('^ Self time:\s\+\d\+\.\d\+$',                    lines[3])
-  call assert_equal('',                                               lines[4])
-  call assert_equal('count  total (s)   self (s)',                    lines[5])
-  call assert_match('    1              0.\d\+ echo "hello',          lines[6])
-  call assert_equal('                              \ world"',         lines[7])
-  call assert_match('    1              0.\d\+ echo "foo ',           lines[8])
-  call assert_equal('                              \bar"',            lines[9])
-  call assert_equal('',                                               lines[10])
+  call assert_match('^SCRIPT .*Xprofile_file.vim$',           lines[0])
+  call assert_equal('Sourced 1 time',                         lines[1])
+  call assert_match('^Total time:\s\+\d\+\.\d\+$',            lines[2])
+  call assert_match('^ Self time:\s\+\d\+\.\d\+$',            lines[3])
+  call assert_equal('',                                       lines[4])
+  call assert_equal('count  total (s)   self (s)',            lines[5])
+  call assert_match('    1              0.\d\+ echo "hello',  lines[6])
+  call assert_equal('                              \ world"', lines[7])
+  call assert_match('    1              0.\d\+ echo "foo ',   lines[8])
+  call assert_equal('                              \bar"',    lines[9])
+  call assert_equal('',                                       lines[10])
 
   call delete('Xprofile_file.vim')
   call delete('Xprofile_file.log')
@@ -218,6 +218,76 @@ func Test_profile_truncate_mbyte()
   call assert_match("\u5052$", getline(lnum + 3))
   call assert_match('^\s*\\ \]$', getline(lnum + 4))
   bwipe!
+
+  call delete('Xprofile_file.vim')
+  call delete('Xprofile_file.log')
+endfunc
+
+func Test_profdel_func()
+  let lines = [
+    \  'profile start Xprofile_file.log',
+    \  'func! Foo1()',
+    \  'endfunc',
+    \  'func! Foo2()',
+    \  'endfunc',
+    \  'func! Foo3()',
+    \  'endfunc',
+    \  '',
+    \  'profile func Foo1',
+    \  'profile func Foo2',
+    \  'call Foo1()',
+    \  'call Foo2()',
+    \  '',
+    \  'profile func Foo3',
+    \  'profdel func Foo2',
+    \  'profdel func Foo3',
+    \  'call Foo1()',
+    \  'call Foo2()',
+    \  'call Foo3()' ]
+  call writefile(lines, 'Xprofile_file.vim')
+  call system(v:progpath . ' -es --clean -c "so Xprofile_file.vim" -c q')
+  call assert_equal(0, v:shell_error)
+
+  let lines = readfile('Xprofile_file.log')
+  call assert_equal(24, len(lines))
+
+  " Check that:
+  " - Foo1() is called twice (profdel not invoked)
+  " - Foo2() is called once (profdel invoked after it was called)
+  " - Foo3() is not called (profdel invoked before it was called)
+  call assert_equal('FUNCTION  Foo1()',               lines[0])
+  call assert_equal('Called 2 times',                 lines[1])
+  call assert_equal('FUNCTION  Foo2()',               lines[7])
+  call assert_equal('Called 1 time',                  lines[8])
+  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME', lines[14])
+  call assert_equal('FUNCTIONS SORTED ON SELF TIME',  lines[19])
+
+  call delete('Xprofile_file.vim')
+  call delete('Xprofile_file.log')
+endfunc
+
+func Test_profdel_star()
+  " Foo() is invoked once before and once after 'profdel *'.
+  " So profiling should report it only once.
+  let lines = [
+    \  'profile start Xprofile_file.log',
+    \  'func! Foo()',
+    \  'endfunc',
+    \  'profile func Foo',
+    \  'call Foo()',
+    \  'profdel *',
+    \  'call Foo()' ]
+  call writefile(lines, 'Xprofile_file.vim')
+  call system(v:progpath . ' -es --clean -c "so Xprofile_file.vim" -c q')
+  call assert_equal(0, v:shell_error)
+
+  let lines = readfile('Xprofile_file.log')
+  call assert_equal(15, len(lines))
+
+  call assert_equal('FUNCTION  Foo()',                lines[0])
+  call assert_equal('Called 1 time',                  lines[1])
+  call assert_equal('FUNCTIONS SORTED ON TOTAL TIME', lines[7])
+  call assert_equal('FUNCTIONS SORTED ON SELF TIME',  lines[11])
 
   call delete('Xprofile_file.vim')
   call delete('Xprofile_file.log')


### PR DESCRIPTION
patch 8.1.0131: :profdel is not tested

Problem:    :profdel is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3123)
https://github.com/vim/vim/commit/1fbfe7c48cb711f5a6deae535b3ec3bfe7952ce9