### PR TITLE
vim-patch:1ebff3dc9

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7415,6 +7415,12 @@ void do_sleep(long msec)
     LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, (int)next, got_int);
     os_breakcheck();
   }
+
+  // If CTRL-C was typed to interrupt the sleep, drop the CTRL-C from the
+  // input buffer, otherwise a following call to input() fails.
+  if (got_int) {
+    (void)vpeekc();
+  }
 }
 
 static void do_exmap(exarg_T *eap, int isabbrev)


### PR DESCRIPTION
patch 8.1.0158: GUI: input() fails if CTRL-C was pressed before

Problem:    GUI: input() fails if CTRL-C was pressed before. (Michael Naumann)
Solution:   call vpeekc() to drop the CTRL-C from the input stream.
https://github.com/vim/vim/commit/1ebff3dc93b6d022ccfe0613c1d1ee2d62fc7935

I've though about putting it in `os_breakcheck` directly, but there is at least one place, which already calls `vpeekc()` after it.

Tested using:
```vim
try
  sleep 10
catch
endtry

echom 'input...'
echo input('?')
```