### PR TITLE
support search_count in ext_messages and fix msg_advance() crash

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -706,6 +706,7 @@ events, which the UI must handle.
 		"rpc_error"	Error response from |rpcrequest()|
 		"return_prompt"	|press-enter| prompt after a multiple messages
 		"quickfix"	Quickfix navigation message
+		"search_count"	Search count message ("S" flag of 'shortmess')
 		"wmsg"		Warning ("search hit BOTTOM", |W10|, …)
 	    New kinds may be added in the future; clients should treat unknown
 	    kinds as the empty kind.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -116,6 +116,7 @@ static const char *msg_ext_kind = NULL;
 static Array msg_ext_chunks = ARRAY_DICT_INIT;
 static garray_T msg_ext_last_chunk = GA_INIT(sizeof(char), 40);
 static sattr_T msg_ext_last_attr = -1;
+static size_t msg_ext_cur_len = 0;
 
 static bool msg_ext_overwrite = false;  ///< will overwrite last message
 static int msg_ext_visible = 0;  ///< number of messages currently visible
@@ -1877,8 +1878,9 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr,
       msg_ext_last_attr = attr;
     }
     // Concat pieces with the same highlight
-    ga_concat_len(&msg_ext_last_chunk, (char *)str,
-                  strnlen((char *)str, maxlen));  // -V781
+    size_t len = strnlen((char *)str, maxlen);
+    ga_concat_len(&msg_ext_last_chunk, (char *)str, len);  // -V781
+    msg_ext_cur_len += len;
     return;
   }
 
@@ -2770,6 +2772,7 @@ void msg_ext_ui_flush(void)
     }
     msg_ext_kind = NULL;
     msg_ext_chunks = (Array)ARRAY_DICT_INIT;
+    msg_ext_cur_len = 0;
     msg_ext_overwrite = false;
   }
 }
@@ -2782,6 +2785,7 @@ void msg_ext_flush_showmode(void)
     msg_ext_emit_chunk();
     ui_call_msg_showmode(msg_ext_chunks);
     msg_ext_chunks = (Array)ARRAY_DICT_INIT;
+    msg_ext_cur_len = 0;
   }
 }
 
@@ -3046,6 +3050,14 @@ void msg_advance(int col)
 {
   if (msg_silent != 0) {        /* nothing to advance to */
     msg_col = col;              /* for redirection, may fill it up later */
+    return;
+  }
+  if (ui_has(kUIMessages)) {
+    // TODO(bfredl): use byte count as a basic proxy.
+    // later on we might add proper support for formatted messages.
+    while (msg_ext_cur_len < (size_t)col) {
+      msg_putchar(' ');
+    }
     return;
   }
   if (col >= Columns)           /* not enough room */

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3018,7 +3018,10 @@ void give_warning(char_u *message, bool hl) FUNC_ATTR_NONNULL_ARG(1)
   } else {
     keep_msg_attr = 0;
   }
-  msg_ext_set_kind("wmsg");
+
+  if (msg_ext_kind == NULL) {
+    msg_ext_set_kind("wmsg");
+  }
 
   if (msg_attr((const char *)message, keep_msg_attr) && msg_scrolled == 0) {
     set_keep_msg(message, keep_msg_attr);

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1168,7 +1168,9 @@ int do_search(
         // search stat.  Use all the space available, so that the
         // search state is right aligned.  If there is not enough space
         // msg_strtrunc() will shorten in the middle.
-        if (msg_scrolled != 0) {
+        if (ui_has(kUIMessages)) {
+          len = 0;  // adjusted below
+        } else if (msg_scrolled != 0) {
           // Use all the columns.
           len = (int)(Rows - msg_row) * Columns - 1;
         } else {
@@ -4328,6 +4330,7 @@ static void search_stat(int dirc, pos_T *pos,
 
       // keep the message even after redraw, but don't put in history
       msg_hist_off = true;
+      msg_ext_set_kind("search_count");
       give_warning(msgbuf, false);
       msg_hist_off = false;
     }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -21,6 +21,8 @@ describe('ui/ext_messages', function()
       [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
       [5] = {foreground = Screen.colors.Blue1},
       [6] = {bold = true, reverse = true},
+      [7] = {background = Screen.colors.Yellow},
+      [8] = {foreground = Screen.colors.Red},
     })
   end)
   after_each(function()
@@ -300,6 +302,33 @@ describe('ui/ext_messages', function()
       {kind="echoerr", content={{"fail", 2}}},
       {kind="echoerr", content={{"extrafail", 2}}},
       {kind="echoerr", content={{"problem", 2}}}
+    }}
+  end)
+
+  it('shortmess-=S', function()
+    command('set shortmess-=S')
+    feed('iline 1\nline 2<esc>')
+
+    feed('/line<cr>')
+    screen:expect{grid=[[
+      {7:^line} 1                   |
+      {7:line} 2                   |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={
+      {content = {{"/line      [1/2] W"}}, kind = "search_count"}
+    }}
+
+    feed('n')
+    screen:expect{grid=[[
+      {7:line} 1                   |
+      {7:^line} 2                   |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={
+      {content = {{"/line        [2/2]"}}, kind = "search_count"}
     }}
   end)
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -332,6 +332,22 @@ describe('ui/ext_messages', function()
     }}
   end)
 
+  it("doesn't crash with column adjustment #10069", function()
+    feed(':let [x,y] = [1,2]<cr>')
+    feed(':let x y<cr>')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={
+      {content = {{ "x                     #1" }}, kind = ""},
+      {content = {{ "y                     #2" }}, kind = ""},
+      {content = {{ "Press ENTER or type command to continue", 4 }}, kind = "return_prompt"}
+    }}
+  end)
+
   it('&showmode', function()
     command('imap <f2> <cmd>echomsg "stuff"<cr>')
     feed('i')


### PR DESCRIPTION
Currently `ext_messages` crashes with the new `set shortmess-=S` search count feature.

An issue is that vim wants to right-justify a part of the message, and we don't yet have any convention how to do that in `ext_message`. An option could be to use literal `\t` tab chars to indicate multiple horizontal parts. Then UIs who want to special case `search_count` can split by `\t` (including properly displaying a pattern that ends by a space, something the TUI doesn't show), but other UI:s are expected to do something reasonable.