### PR TITLE
vim-patch:8.1.{0807,0813}

### DIFF
--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -239,6 +239,10 @@ func Test_mkview_no_file_name()
 endfunc
 
 func Test_mksession_quote_in_filename()
+  if !has('unix')
+    " only Unix can handle this weird filename
+    return
+  endif
   let v:errmsg = ''
   let filename = has('win32') ? 'x''y' : 'x''y"z'
   %bwipe!


### PR DESCRIPTION
- vim-patch:8.1.0807: session test fails on MS-Windows
- vim-patch:8.1.0813: FileChangedShell not sufficiently tested