### PR TITLE
vim-patch:8.1.0830: test leaves directory behind on MS-Windows

### DIFF
--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -98,6 +98,9 @@ func Test_missing_dir()
   split bar/x.txt
   only
 
+  " Delete the buffer so that swap file is removed before we try to delete the
+  " directory.  That fails on MS-Windows.
+  %bdelete!
   set directory&
   call delete('Xswapdir', 'rf')
 endfunc


### PR DESCRIPTION
Problem:    Test leaves directory behind on MS-Windows.
Solution:   Close buffer before deleting directory.
https://github.com/vim/vim/commit/e3d065454408a103c39308651dd7793f0bf55ba6