### PR TITLE
vim-patch:8.1.1003: playing back recorded key sequence mistakes key code

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2342,6 +2342,17 @@ static int vgetorpeek(int advance)
     }
   }
 
+  if (timedout && c == ESC) {
+    char_u nop_buf[3];
+
+    // When recording there will be no timeout.  Add a <Nop> after the ESC
+    // to avoid that it forms a key code with following characters.
+    nop_buf[0] = K_SPECIAL;
+    nop_buf[1] = KS_EXTRA;
+    nop_buf[2] = KE_NOP;
+    gotchars(nop_buf, 3);
+  }
+
   --vgetc_busy;
 
   return c;

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -63,3 +63,17 @@ func Test_display_registers()
 
     bwipe!
 endfunc
+
+" Check that replaying a typed sequence does not use an Esc and following
+" characters as an escape sequence.
+func Test_recording_esc_sequence()
+  new
+  let save_F2 = &t_F2
+  let t_F2 = "\<Esc>OQ"
+  call feedkeys("qqiTest\<Esc>", "xt")
+  call feedkeys("OQuirk\<Esc>q", "xt")
+  call feedkeys("Go\<Esc>@q", "xt")
+  call assert_equal(['Quirk', 'Test', 'Quirk', 'Test'], getline(1, 4))
+  bwipe!
+  let t_F2 = save_F2
+endfunc


### PR DESCRIPTION
Problem:    Playing back recorded key sequence mistakes key code.
Solution:   Insert a <Nop> after the <Esc>. (closes vim/vim#4068)
https://github.com/vim/vim/commit/6edbbd8114320089c0e603e033775d9dd34cb10a