### PR TITLE
vim-patch:8.1.0769: :stop is covered in two tests

### DIFF
--- a/src/nvim/testdir/test_suspend.vim
+++ b/src/nvim/testdir/test_suspend.vim
@@ -45,7 +45,11 @@ func Test_suspend()
   call term_sendkeys(buf, "fg\<CR>")
   call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
 
+  " Quit gracefully to dump coverage information.
+  call term_sendkeys(buf, ":qall!\<CR>")
+  call term_wait(buf)
+  call Stop_shell_in_terminal(buf)
+
   exe buf . 'bwipe!'
   call delete('Xfoo')
-  set autowrite&
 endfunc


### PR DESCRIPTION
Problem:    :stop is covered in two tests.
Solution:   Remove Test_stop_in_terminal().  Make other test exit Vim cleanly.
            (Ozaki Kiichi, closes vim/vim#3814)
https://github.com/vim/vim/commit/3020ccb113d397ddf474001dc00a1916ad7abdee