### PR TITLE
vim-patch:8.1.1491: when skipping over code a function call may cause trouble

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4284,7 +4284,7 @@ static int eval7(
         // Stop the expression evaluation when immediately
         // aborting on error, or when an interrupt occurred or
         // an exception was thrown but not caught.
-        if (aborting()) {
+        if (evaluate && aborting()) {
           if (ret == OK) {
             tv_clear(rettv);
           }

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -99,3 +99,12 @@ func Test_let_errmsg()
   call assert_fails('let v:errmsg = []', 'E730:')
   let v:errmsg = ''
 endfunc
+
+" Test fix for issue #4507
+func Test_skip_after_throw()
+  try
+    throw 'something'
+    let x = wincol() || &ts
+  catch /something/
+  endtry
+endfunc


### PR DESCRIPTION
Problem:    When skipping over code after an exception was thrown expression
            evaluation is aborted after a function call. (Ingo Karkat)
Solution:   Do not fail if not executing the expression. (closes vim/vim#4507)
https://github.com/vim/vim/commit/606407384144df73a6154aca1d77e071fe1b7651