### PR TITLE
contrib/local.mk.example: add example for -Werror  [ci skip]

### DIFF
--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -7,6 +7,9 @@
 # These CFLAGS can be used in addition to those specified in CMakeLists.txt:
 # CMAKE_EXTRA_FLAGS="-DCMAKE_C_FLAGS=-ftrapv -Wlogical-op"
 
+# To turn compiler warnings into errors:
+# CMAKE_EXTRA_FLAGS += "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -Werror"
+
 # Sets the build type; defaults to Debug. Valid values:
 #
 # - Debug:          Disables optimizations (-O0), enables debug information.


### PR DESCRIPTION
This simulates what Travis does (via https://github.com/blueyed/neovim/blob/0c3a92e2ef91ba723ca9e86ef5f9fa823eec325f/CMakeLists.txt#L343), and seems to be useful during development.