### PR TITLE
[WIP] ci: AppVeyor: remove MINGW_64-gcov

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,19 +9,15 @@ configuration:
 - MSVC_32
 - MINGW_64
 - MINGW_32
-- MINGW_64-gcov
 init:
 - ps: |
     # Pull requests: skip some build configurations to save time.
-    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32|MINGW_64-gcov)$') {
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
       $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
       Exit-AppVeyorBuild
     }
 # RDP
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-matrix:
-  allow_failures:
-    - configuration: MINGW_64-gcov
 install: []
 before_build:
 - ps: Install-Product node 8


### PR DESCRIPTION
There appears to be no locking support on Windows.

This results in a) incomplete results in general, and more impotantly b) those
errors being spilled into test results, e.g.:

    [  FAILED  ] C:/projects/neovim/test/functional\core\main_spec.lua @ 97: Command-line option -s errors out when trying to use nonexistent file with -s
    C:/projects/neovim/test/functional\core\main_spec.lua:98: Expected objects to be the same.
    Passed in:
    (string) 'Cannot open for reading: "Xtest-functional-core-main-s.nonexistent": no such file or directory
    profiling:C:\projects\neovim\build/src/nvim/CMakeFiles/nvim.dir/buffer.c.gcda:Data file mismatch - some data files may have been concurrently updated without locking support
    '
    Expected:
    (string) 'Cannot open for reading: "Xtest-functional-core-main-s.nonexistent": no such file or directory
    '

    stack traceback:
            C:/projects/neovim/test/functional\core\main_spec.lua:98: in function <C:/projects/neovim/test/functional\core\main_spec.lua:97>

Therefore it does not make sense to have a always-failing job.

Just for reference, the locking appears to have been reworked for gcc
9.1 [1], so might could be tried later again.

1: https://github.com/gcc-mirror/gcc/commit/56621355b

-

Followup to 9a9d9a187, where it was ignored.
