### PR TITLE
[WIP] vim-patch:8.0.0338: :recover test fails on MS-Windows

### DIFF
--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -7,7 +7,7 @@ func Test_recover_root_dir()
   call assert_fails('recover', 'E305:')
   close!
 
-  if has('win32')
+  if has('win32') || filewritable('/') == 2
     " can write in / directory on MS-Windows
     set dir=/notexist/
   endif

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -6,6 +6,11 @@ func Test_recover_root_dir()
   set dir=/
   call assert_fails('recover', 'E305:')
   close!
+
+  if has('win32')
+    " can write in / directory on MS-Windows
+    set dir=/notexist/
+  endif
   call assert_fails('split Xtest', 'E303:')
   set dir&
 endfunc


### PR DESCRIPTION
Includes:

> vim-patch:8.0.0600: test_recover fails on some systems