### PR TITLE
oldtest: windows: revert setting shellslash individually

### DIFF
--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -24,10 +24,7 @@ func Test_cd_no_arg()
     call assert_equal(path, getcwd())
   else
     " Test that cd without argument echoes cwd on non-Unix systems.
-    let shellslash = &shellslash
-    set shellslash
     call assert_match(getcwd(), execute('cd'))
-    let &shellslash = shellslash
   endif
 endfunc
 

--- a/src/nvim/testdir/test_checkpath.vim
+++ b/src/nvim/testdir/test_checkpath.vim
@@ -2,8 +2,6 @@
 
 " Test for 'include' without \zs or \ze
 func Test_checkpath1()
-  let save_shellslash = &shellslash
-  set shellslash
   call mkdir("Xdir1/dir2", "p")
   call writefile(['#include    "bar.a"'], 'Xdir1/dir2/foo.a')
   call writefile(['#include    "baz.a"'], 'Xdir1/dir2/bar.a')
@@ -27,7 +25,6 @@ func Test_checkpath1()
   call delete("./Xbase.a")
   call delete("Xdir1", "rf")
   set path&
-  let &shellslash = save_shellslash
 endfunc
 
 func DotsToSlashes()
@@ -36,8 +33,6 @@ endfunc
 
 " Test for 'include' with \zs and \ze
 func Test_checkpath2()
-  let save_shellslash = &shellslash
-  set shellslash
   call mkdir("Xdir1/dir2", "p")
   call writefile(['%inc    /bar/'], 'Xdir1/dir2/foo.b')
   call writefile(['%inc    /baz/'], 'Xdir1/dir2/bar.b')
@@ -66,7 +61,6 @@ func Test_checkpath2()
   set path&
   set include&
   set includeexpr&
-  let &shellslash = save_shellslash
 endfunc
 
 func StripNewlineChar()
@@ -78,8 +72,6 @@ endfunc
 
 " Test for 'include' with \zs and no \ze
 func Test_checkpath3()
-  let save_shellslash = &shellslash
-  set shellslash
   call mkdir("Xdir1/dir2", "p")
   call writefile(['%inc    bar.c'], 'Xdir1/dir2/foo.c')
   call writefile(['%inc    baz.c'], 'Xdir1/dir2/bar.c')
@@ -109,5 +101,4 @@ func Test_checkpath3()
   set path&
   set include&
   set includeexpr&
-  let &shellslash = save_shellslash
 endfunc

--- a/src/nvim/testdir/test_find_complete.vim
+++ b/src/nvim/testdir/test_find_complete.vim
@@ -3,8 +3,6 @@
 " Do all the tests in a separate window to avoid E211 when we recursively
 " delete the Xfind directory during cleanup
 func Test_find_complete()
-  let shellslash = &shellslash
-  set shellslash
   set belloff=all
 
   " On windows a stale "Xfind" directory may exist, remove it so that
@@ -162,5 +160,4 @@ func Test_find_complete()
   exe 'cd ' . cwd
   call delete('Xfind', 'rf')
   set path&
-  let &shellslash = shellslash
 endfunc

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -976,8 +976,8 @@ func Test_balloon_show()
 endfunc
 
 func Test_shellescape()
-  let [save_shell, save_shellslash] = [&shell, &shellslash]
-  set shell=bash shellslash
+  let save_shell = &shell
+  set shell=bash
   call assert_equal("'text'", shellescape('text'))
   call assert_equal("'te\"xt'", shellescape('te"xt'))
   call assert_equal("'te'\\''xt'", shellescape("te'xt"))
@@ -991,13 +991,13 @@ func Test_shellescape()
 
   call assert_equal("'te\nxt'", shellescape("te\nxt"))
   call assert_equal("'te\\\nxt'", shellescape("te\nxt", 1))
-  set shell=tcsh shellslash
+  set shell=tcsh
   call assert_equal("'te\\!xt'", shellescape("te!xt"))
   call assert_equal("'te\\\\!xt'", shellescape("te!xt", 1))
   call assert_equal("'te\\\nxt'", shellescape("te\nxt"))
   call assert_equal("'te\\\\\nxt'", shellescape("te\nxt", 1))
 
-  let [&shell, &shellslash] = [save_shell, save_shellslash]
+  let &shell = save_shell
 endfunc
 
 func Test_redo_in_nested_functions()

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -210,8 +210,6 @@ func Test_set_completion()
   call assert_equal('"set fileencodings:ucs-bom,utf-8,default,latin1', @:)
 
   " Expand directories.
-  let shellslash = &shellslash
-  set shellslash
   call feedkeys(":set cdpath=./\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('./samples/ ', @:)
   call assert_notmatch('./small.vim ', @:)
@@ -223,7 +221,6 @@ func Test_set_completion()
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
   set tags&
-  let &shellslash = shellslash
 endfunc
 
 func Test_set_errors()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -139,8 +139,6 @@ func XlistTests(cchar)
 	      \ ' 5:50 col 25  55: one'], l)
 
   " Test for module names, one needs to explicitly set `'valid':v:true` so
-  let save_shellslash = &shellslash
-  set shellslash
   call g:Xsetlist([
         \ {'lnum':10,'col':5,'type':'W','module':'Data.Text','text':'ModuleWarning','nr':11,'valid':v:true},
         \ {'lnum':20,'col':10,'type':'W','module':'Data.Text','filename':'Data/Text.hs','text':'ModuleWarning','nr':22,'valid':v:true},
@@ -149,7 +147,6 @@ func XlistTests(cchar)
   call assert_equal([' 1 Data.Text:10 col 5 warning  11: ModuleWarning',
         \ ' 2 Data.Text:20 col 10 warning  22: ModuleWarning',
         \ ' 3 Data/Text.hs:30 col 15 warning  33: FileWarning'], l)
-  let &shellslash = save_shellslash
 
   " Error cases
   call assert_fails('Xlist abc', 'E488:')

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -86,11 +86,8 @@ func Test_statusline()
   call assert_match('^Xstatusline\s*$', s:get_statusline())
 
   " %F: Full path to the file in the buffer.
-  let shellslash = &shellslash
-  set shellslash
   set statusline=%F
   call assert_match('/testdir/Xstatusline\s*$', s:get_statusline())
-  let &shellslash = shellslash
 
   " %h: Help buffer flag, text is "[help]".
   " %H: Help buffer flag, text is ",HLP".

--- a/src/nvim/testdir/test_true_false.vim
+++ b/src/nvim/testdir/test_true_false.vim
@@ -57,9 +57,6 @@ endfunc
 
 " Test using TRUE or FALSE values for an argument.
 func Test_true_false_arg()
-  let shellslash = &shellslash
-  let wildignore = &wildignore
-  set shellslash
   call Try_arg_true_false('count(["a", "A"], "a", %v%)', 1, 2)
 
   set wildignore=*.swp
@@ -113,8 +110,6 @@ func Test_true_false_arg()
   let here_id = synID(1, 3, 0)
   call Try_arg_true_false('synID(1, 3, %v%)', here_id, brackets_id)
   bwipe!
-  let &wildignore = wildignore
-  let &shellslash = shellslash
 endfunc
 
 function Try_arg_non_zero(expr, false_val, true_val)

--- a/src/nvim/testdir/test_true_false.vim
+++ b/src/nvim/testdir/test_true_false.vim
@@ -134,8 +134,6 @@ func Test_non_zero_arg()
   " call test_settime(93784)
   " call Try_arg_non_zero("mode(%v%)", 'x', 'x!')
   " call test_settime(0)
-  let shellslash = &shellslash
-  set shellslash
 
   call Try_arg_non_zero("shellescape('foo%', %v%)", "'foo%'", "'foo\\%'")
 
@@ -154,6 +152,4 @@ func Test_non_zero_arg()
     let r = visualmode(v)
     call assert_equal('', r, 'result for ' . v . ' is not "" but ' . r)
   endfor
-
-  let &shellslash = shellslash
 endfunc


### PR DESCRIPTION
This reverts commit 6245b4873d5e24fade9aadadf32645bfb3ebfc31.

It should probably use try/finally for resetting it, but maybe is not
necessary at all.

Test_find_complete currently fails on AppVeyor [1].
Test_set_completion passes, but this brings it in line with Vim's
original test.

1: https://ci.appveyor.com/project/neovim/neovim/builds/25196915?fullLog=true#L22602