### PR TITLE
WIP: testdir/runtest.vim: use shellslash (like Vim)

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -64,7 +64,7 @@ set nomore
 lang mess C
 
 " Always use forward slashes.
-" set shellslash
+set shellslash
 
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1

--- a/src/nvim/testdir/unix.vim
+++ b/src/nvim/testdir/unix.vim
@@ -5,7 +5,6 @@ set shell=sh
 if has('win32')
   set shellcmdflag=-c shellxquote= shellxescape= shellquote=
   let &shellredir = '>%s 2>&1'
-  set shellslash
 endif
 
 " Don't depend on system locale, always use utf-8


### PR DESCRIPTION
Working towards fixing tests on Windows, bringing them more in line with Vim (https://github.com/neovim/neovim/pull/10189#issuecomment-501296559).