### PR TITLE
vim-patch:8.0.1704: 'backupskip' default doesn't work for Mac

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -874,7 +874,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Use 'backupdir' to put the backup in a different directory.
 
 						*'backupskip'* *'bsk'*
-'backupskip' 'bsk'	string	(default: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
+'backupskip' 'bsk'	string	(default: "$TMPDIR/*,$TMP/*,$TEMP/*"
+				 Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
+				 Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
 			global
 	A list of file patterns.  When one of the patterns matches with the
 	name of the file which is written, no backup file is created.  Both

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -626,7 +626,11 @@ void set_init_1(void)
       char *p;
 # ifdef UNIX
       if (*names[n] == NUL) {
+#  ifdef __APPLE__
+        p = "/private/tmp";
+#  else
         p = "/tmp";
+#  endif
         mustfree = false;
       } else
 # endif

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -180,6 +180,15 @@ func Test_thesaurus()
   call Check_dir_option('thesaurus')
 endfun
 
+func Test_complete()
+  " Trailing single backslash used to cause invalid memory access.
+  set complete=s\
+  new
+  call feedkeys("i\<C-N>\<Esc>", 'xt')
+  bwipe!
+  set complete&
+endfun
+
 func Test_set_completion()
   call feedkeys(":set di\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set dictionary diff diffexpr diffopt digraph directory display', @:)
@@ -305,14 +314,23 @@ func Test_set_ttytype()
   endif
 endfunc
 
-func Test_complete()
-  " Trailing single backslash used to cause invalid memory access.
-  set complete=s\
-  new
-  call feedkeys("i\<C-N>\<Esc>", 'xt')
-  bwipe!
-  set complete&
-endfun
+func Test_set_all()
+  set tw=75
+  set iskeyword=a-z,A-Z
+  set nosplitbelow
+  let out = execute('set all')
+  call assert_match('textwidth=75', out)
+  call assert_match('iskeyword=a-z,A-Z', out)
+  call assert_match('nosplitbelow', out)
+  set tw& iskeyword& splitbelow&
+endfunc
+
+func Test_set_values()
+  " The file is only generated when running "make test" in the src directory.
+  if filereadable('opt_test.vim')
+    source opt_test.vim
+  endif
+endfunc
 
 func ResetIndentexpr()
   set indentexpr=
@@ -393,24 +411,6 @@ func Test_shortmess_F()
   call assert_match('bar', execute('file'))
   set shortmess&
   bwipe
-endfunc
-
-func Test_set_all()
-  set tw=75
-  set iskeyword=a-z,A-Z
-  set nosplitbelow
-  let out = execute('set all')
-  call assert_match('textwidth=75', out)
-  call assert_match('iskeyword=a-z,A-Z', out)
-  call assert_match('nosplitbelow', out)
-  set tw& iskeyword& splitbelow&
-endfunc
-
-func Test_set_values()
-  " The file is only generated when running "make test" in the src directory.
-  if filereadable('opt_test.vim')
-    source opt_test.vim
-  endif
 endfunc
 
 func Test_shortmess_F2()

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -345,6 +345,22 @@ func Test_set_indentexpr()
   bwipe!
 endfunc
 
+func Test_backupskip()
+  if has("mac")
+    call assert_match('/private/tmp/\*', &bsk)
+  elseif has("unix")
+    call assert_match('/tmp/\*', &bsk)
+  endif
+
+  let bskvalue = substitute(&bsk, '\\', '/', 'g')
+  for var in  ['$TEMPDIR', '$TMP', '$TEMP']
+    if exists(var)
+      let varvalue = substitute(expand(var), '\\', '/', 'g')
+      call assert_match(varvalue . '.\*', bskvalue)
+    endif
+  endfor
+endfunc
+
 func Test_copy_winopt()
   set hidden
 


### PR DESCRIPTION
Also aligns tests from two previous patched to the ones in upstream.