### PR TITLE
vim-patch:8.0.1845: various comment updates needed, missing white space

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -416,6 +416,10 @@ a previous version <Esc> was used).  In the pattern standard wildcards '*' and
 '?' are accepted when matching file names.  '*' matches any string, '?'
 matches exactly one character.
 
+When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
+ending up back to what was typed.  If the first match is not what you wanted,
+you can use <S-Tab> or CTRL-P to go straight back to what you typed.
+
 The 'wildignorecase' option can be set to ignore case in filenames.
 
 The 'wildmenu' option can be set to show the matches just above the command

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1825,8 +1825,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	contain a list of words.  This can be one word per line, or several
 	words per line, separated by non-keyword characters (white space is
 	preferred).  Maximum line length is 510 bytes.
-	When this option is empty, or an entry "spell" is present, spell
-	checking is enabled the currently active spelling is used. |spell|
+
+	When this option is empty or an entry "spell" is present, and spell
+	checking is enabled, words in the word lists for the currently active
+	'spelllang' are used. See |spell|.
+
 	To include a comma in a file name precede it with a backslash.  Spaces
 	after a comma are ignored, otherwise spaces are included in the file
 	name.  See |option-backslash| about using backslashes.

--- a/runtime/indent/php.vim
+++ b/runtime/indent/php.vim
@@ -12,7 +12,7 @@
 "	A fully commented version of this file is available on github
 "
 "
-"  If you find a bug, please open a ticket on github.org
+"  If you find a bug, please open a ticket on github.com
 "  ( https://github.com/2072/PHP-Indenting-for-VIm/issues ) with an example of
 "  code that breaks the algorithm.
 "

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -261,7 +261,7 @@ syn keyword phpStatement return break continue exit goto yield contained
 syn keyword phpKeyword var const contained
 
 " Type
-syn keyword phpType bool boolean int integer real double float string array object NULL callable iterable contained
+syn keyword phpType void bool boolean int integer real double float string array object NULL callable iterable contained
 
 " Structure
 syn keyword phpStructure namespace extends implements instanceof parent self contained

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3642,7 +3642,9 @@ int ExpandMappings(regmatch_T *regmatch, int *num_file, char_u ***file)
 
 /*
  * Check for an abbreviation.
- * Cursor is at ptr[col]. When inserting, mincol is where insert started.
+ * Cursor is at ptr[col].
+ * When inserting, mincol is where insert started.
+ * For the command line, mincol is what is to be skipped over.
  * "c" is the character typed before check_abbr was called.  It may have
  * ABBR_OFF added to avoid prepending a CTRL-V to it.
  *

--- a/src/nvim/testdir/test_cscope.vim
+++ b/src/nvim/testdir/test_cscope.vim
@@ -36,7 +36,7 @@ func Test_cscopeWithCscopeConnections()
 
     " Test 1: Find this C-Symbol
     for cmd in ['cs find s main', 'cs find 0 main']
-      let a=execute(cmd)
+      let a = execute(cmd)
       " Test 1.1 test where it moves the cursor
       call assert_equal('main(void)', getline('.'))
       " Test 1.2 test the output of the :cs command
@@ -51,21 +51,21 @@ func Test_cscopeWithCscopeConnections()
 
     " Test 3: Find functions called by this function
     for cmd in ['cs find d test_mf_hash', 'cs find 2 test_mf_hash']
-      let a=execute(cmd)
+      let a = execute(cmd)
       call assert_match('\n(1 of 42): <<mf_hash_init>> mf_hash_init(&ht);', a)
       call assert_equal('    mf_hash_init(&ht);', getline('.'))
     endfor
 
     " Test 4: Find functions calling this function
     for cmd in ['cs find c test_mf_hash', 'cs find 3 test_mf_hash']
-      let a=execute(cmd)
+      let a = execute(cmd)
       call assert_match('\n(1 of 1): <<main>> test_mf_hash();', a)
       call assert_equal('    test_mf_hash();', getline('.'))
     endfor
 
     " Test 5: Find this text string
     for cmd in ['cs find t Bram', 'cs find 4 Bram']
-      let a=execute(cmd)
+      let a = execute(cmd)
       call assert_match('(1 of 1): <<<unknown>>>  \* VIM - Vi IMproved^Iby Bram Moolenaar', a)
       call assert_equal(' * VIM - Vi IMproved	by Bram Moolenaar', getline('.'))
     endfor
@@ -73,7 +73,7 @@ func Test_cscopeWithCscopeConnections()
     " Test 6: Find this egrep pattern
     " test all matches returned by cscope
     for cmd in ['cs find e ^\#includ.', 'cs find 6 ^\#includ.']
-      let a=execute(cmd)
+      let a = execute(cmd)
       call assert_match('\n(1 of 3): <<<unknown>>> #include <assert.h>', a)
       call assert_equal('#include <assert.h>', getline('.'))
       cnext
@@ -84,7 +84,7 @@ func Test_cscopeWithCscopeConnections()
     endfor
 
     " Test 7: Find the same egrep pattern using lcscope this time.
-    let a=execute('lcs find e ^\#includ.')
+    let a = execute('lcs find e ^\#includ.')
     call assert_match('\n(1 of 3): <<<unknown>>> #include <assert.h>', a)
     call assert_equal('#include <assert.h>', getline('.'))
     lnext
@@ -96,7 +96,7 @@ func Test_cscopeWithCscopeConnections()
     " Test 8: Find this file
     for cmd in ['cs find f Xmemfile_test.c', 'cs find 7 Xmemfile_test.c']
       enew
-      let a=execute(cmd)
+      let a = execute(cmd)
       call assert_true(a =~ '"Xmemfile_test.c" \d\+L, \d\+C')
       call assert_equal('Xmemfile_test.c', @%)
     endfor
@@ -104,7 +104,7 @@ func Test_cscopeWithCscopeConnections()
     " Test 9: Find files #including this file
     for cmd in ['cs find i assert.h', 'cs find 8 assert.h']
       enew
-      let a=execute(cmd)
+      let a = execute(cmd)
       let alines = split(a, '\n', 1)
       call assert_equal('', alines[0])
       call assert_true(alines[1] =~ '"Xmemfile_test.c" \d\+L, \d\+C')
@@ -118,11 +118,11 @@ func Test_cscopeWithCscopeConnections()
     " Test 11: Find places where this symbol is assigned a value
     " this needs a cscope >= 15.8
     " unfortunately, Travis has cscope version 15.7
-    let cscope_version=systemlist('cscope --version')[0]
-    let cs_version=str2float(matchstr(cscope_version, '\d\+\(\.\d\+\)\?'))
+    let cscope_version = systemlist('cscope --version')[0]
+    let cs_version = str2float(matchstr(cscope_version, '\d\+\(\.\d\+\)\?'))
     if cs_version >= 15.8
       for cmd in ['cs find a item', 'cs find 9 item']
-        let a=execute(cmd)
+        let a = execute(cmd)
         call assert_equal(['', '(1 of 4): <<test_mf_hash>> item = (mf_hashitem_T *)lalloc_clear(sizeof(mf_hashtab_T), FALSE);'], split(a, '\n', 1))
         call assert_equal('	item = (mf_hashitem_T *)lalloc_clear(sizeof(mf_hashtab_T), FALSE);', getline('.'))
         cnext
@@ -135,18 +135,18 @@ func Test_cscopeWithCscopeConnections()
     endif
 
     " Test 12: leading whitespace is not removed for cscope find text
-    let a=execute('cscope find t     test_mf_hash')
+    let a = execute('cscope find t     test_mf_hash')
     call assert_equal(['', '(1 of 1): <<<unknown>>>     test_mf_hash();'], split(a, '\n', 1))
     call assert_equal('    test_mf_hash();', getline('.'))
 
     " Test 13: test with scscope
-    let a=execute('scs find t Bram')
+    let a = execute('scs find t Bram')
     call assert_match('(1 of 1): <<<unknown>>>  \* VIM - Vi IMproved^Iby Bram Moolenaar', a)
     call assert_equal(' * VIM - Vi IMproved	by Bram Moolenaar', getline('.'))
 
     " Test 14: cscope help
     for cmd in ['cs', 'cs help', 'cs xxx']
-      let a=execute(cmd)
+      let a = execute(cmd)
       call assert_match('^cscope commands:\n', a)
       call assert_match('\nadd  :', a)
       call assert_match('\nfind :', a)
@@ -155,25 +155,25 @@ func Test_cscopeWithCscopeConnections()
       call assert_match('\nreset: Reinit all connections', a)
       call assert_match('\nshow : Show connections', a)
     endfor
-    let a=execute('scscope help')
+    let a = execute('scscope help')
     call assert_match('This cscope command does not support splitting the window\.', a)
 
     " Test 15: reset connections
-    let a=execute('cscope reset')
+    let a = execute('cscope reset')
     call assert_match('\nAdded cscope database.*Xcscope.out (#0)', a)
     call assert_match('\nAll cscope databases reset', a)
 
     " Test 16: cscope show
-    let a=execute('cscope show')
+    let a = execute('cscope show')
     call assert_match('\n 0 \d\+.*Xcscope.out\s*<none>', a)
 
     " Test 17: cstag and 'csto' option
     set csto=0
-    let a=execute('cstag TEST_COUNT')
+    let a = execute('cstag TEST_COUNT')
     call assert_match('(1 of 1): <<TEST_COUNT>> #define TEST_COUNT 50000', a)
     call assert_equal('#define TEST_COUNT 50000', getline('.'))
     set csto=1
-    let a=execute('cstag index_to_key')
+    let a = execute('cstag index_to_key')
     call assert_match('(1 of 1): <<index_to_key>> #define index_to_key(i) ((i) ^ 15167)', a)
     call assert_equal('#define index_to_key(i) ((i) ^ 15167)', getline('.'))
     call assert_fails('cstag xxx', 'E257:')
@@ -183,10 +183,10 @@ func Test_cscopeWithCscopeConnections()
     set nocst
     call assert_fails('tag TEST_COUNT', 'E426:')
     set cst
-    let a=execute('tag TEST_COUNT')
+    let a = execute('tag TEST_COUNT')
     call assert_match('(1 of 1): <<TEST_COUNT>> #define TEST_COUNT 50000', a)
     call assert_equal('#define TEST_COUNT 50000', getline('.'))
-    let a=execute('tags')
+    let a = execute('tags')
     call assert_match('1  1 TEST_COUNT\s\+\d\+\s\+#define index_to_key', a)
 
     " Test 19: this should trigger call to cs_print_tags()
@@ -198,17 +198,17 @@ func Test_cscopeWithCscopeConnections()
     call assert_fails('cscope kill 2', 'E261:')
     call assert_fails('cscope kill xxx', 'E261:')
 
-    let a=execute('cscope kill 0')
+    let a = execute('cscope kill 0')
     call assert_match('cscope connection 0 closed', a)
 
     cscope add Xcscope.out
-    let a=execute('cscope kill Xcscope.out')
+    let a = execute('cscope kill Xcscope.out')
     call assert_match('cscope connection Xcscope.out closed', a)
 
     cscope add Xcscope.out .
-    let a=execute('cscope kill -1')
+    let a = execute('cscope kill -1')
     call assert_match('cscope connection .*Xcscope.out closed', a)
-    let a=execute('cscope kill -1')
+    let a = execute('cscope kill -1')
     call assert_equal('', a)
 
     " Test 21: 'csprg' option
@@ -220,7 +220,7 @@ func Test_cscopeWithCscopeConnections()
     " Test 22: multiple cscope connections
     cscope add Xcscope.out
     cscope add Xcscope2.out . -C
-    let a=execute('cscope show')
+    let a = execute('cscope show')
     call assert_match('\n 0 \d\+.*Xcscope.out\s*<none>', a)
     call assert_match('\n 1 \d\+.*Xcscope2.out\s*\.', a)
 
@@ -294,7 +294,7 @@ func Test_withoutCscopeConnection()
   call assert_equal(cscope_connection(), 0)
 
   call assert_fails('cscope find s main', 'E567:')
-  let a=execute('cscope show')
+  let a = execute('cscope show')
   call assert_match('no cscope connections', a)
 endfunc
 


### PR DESCRIPTION
Problem:    Various comment updates needed, missing white space.
Solution:   Update comments, add white space.
https://github.com/vim/vim/commit/259f26ac2d41ecfb28b82c651b2bfc1edc7c3e29

Ignored (partly) applied patch for src/nvim/po/it.po.