### PR TITLE
[WIP] test/old: pass  Test_recover_root_dir on Windows

### DIFF
--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -7,8 +7,10 @@ func Test_recover_root_dir()
   call assert_fails('recover', 'E305:')
   close!
 
-  if has('win32') || filewritable('/') == 2
+  if has('win32')
     " can write in / directory on MS-Windows
+    let &directory = 'F:\\'
+  elseif filewritable('/') == 2
     set dir=/notexist/
   endif
   call assert_fails('split Xtest', 'E303:')

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -6,6 +6,11 @@ func Test_recover_root_dir()
   set dir=/
   call assert_fails('recover', 'E305:')
   close!
+
+  if has('win32') || filewritable('/') == 2
+    " can write in / directory on MS-Windows
+    set dir=/notexist/
+  endif
   call assert_fails('split Xtest', 'E303:')
   set dir&
 endfunc


### PR DESCRIPTION
Close https://github.com/neovim/neovim/pull/10188

This risk breaking someone else `F:\\` drive but I don't have a better idea because of the CI. Othewise, just skip the test on the CI.