### PR TITLE
[RFC] win,fs.c: Fix is_executable_ext

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -24,6 +24,7 @@
 #include "nvim/message.h"
 #include "nvim/assert.h"
 #include "nvim/misc1.h"
+#include "nvim/option.h"
 #include "nvim/path.h"
 #include "nvim/strings.h"
 
@@ -312,8 +313,8 @@ static bool is_executable_ext(char *name, char_u **abspath)
   if (!pathext) {
     pathext = ".com;.exe;.bat;.cmd";
   }
-  for (const char *ext = pathext;
-       (ext == pathext || *(ext - 1)) && *ext; ext++) {
+  const char *ext = pathext;
+  while (*ext) {
     // If $PATHEXT itself contains dot:
     if (ext[0] == '.' && (ext[1] == '\0' || ext[1] == ENV_SEPCHAR)) {
       if (is_executable(name, abspath)) {
@@ -321,13 +322,17 @@ static bool is_executable_ext(char *name, char_u **abspath)
       }
       // Skip it.
       ext++;
+      if (*ext) {
+        ext++;
+      }
       continue;
     }
 
-    const char *ext_end = xstrchrnul(ext, ENV_SEPCHAR);
-    size_t ext_len = (size_t)(ext_end - ext);
+    const char *ext_end = ext;
+    size_t ext_len =
+      copy_option_part((char_u **)&ext_end, (char_u *)buf_end,
+                       sizeof(os_buf) - (size_t)(buf_end - os_buf), ENV_SEPSTR);
     if (ext_len != 0) {
-      STRLCPY(buf_end, ext, ext_len + 1);
       bool in_pathext = nameext_len == ext_len
         && 0 == mb_strnicmp((char_u *)nameext, (char_u *)ext, ext_len);
 

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -320,6 +320,9 @@ static bool is_executable_ext(char *name, char_u **abspath)
       }
       // Skip it.
       ext++;
+      if (*ext == NUL) {
+        break;
+      }
       continue;
     }
 
@@ -336,6 +339,9 @@ static bool is_executable_ext(char *name, char_u **abspath)
       }
     }
     ext = ext_end;
+    if (*ext == NUL) {
+      break;
+    }
   }
   return false;
 }

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -312,7 +312,7 @@ static bool is_executable_ext(char *name, char_u **abspath)
   if (!pathext) {
     pathext = ".com;.exe;.bat;.cmd";
   }
-  for (const char *ext = pathext; *ext; ext++) {
+  for (const char *ext = pathext; *(ext - 1) && *ext; ext++) {
     // If $PATHEXT itself contains dot:
     if (ext[0] == '.' && (ext[1] == '\0' || ext[1] == ENV_SEPCHAR)) {
       if (is_executable(name, abspath)) {
@@ -320,9 +320,6 @@ static bool is_executable_ext(char *name, char_u **abspath)
       }
       // Skip it.
       ext++;
-      if (*ext == NUL) {
-        break;
-      }
       continue;
     }
 
@@ -339,9 +336,6 @@ static bool is_executable_ext(char *name, char_u **abspath)
       }
     }
     ext = ext_end;
-    if (*ext == NUL) {
-      break;
-    }
   }
   return false;
 }

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -312,7 +312,8 @@ static bool is_executable_ext(char *name, char_u **abspath)
   if (!pathext) {
     pathext = ".com;.exe;.bat;.cmd";
   }
-  for (const char *ext = pathext; *(ext - 1) && *ext; ext++) {
+  for (const char *ext = pathext;
+       (ext == pathext || *(ext - 1)) && *ext; ext++) {
     // If $PATHEXT itself contains dot:
     if (ext[0] == '.' && (ext[1] == '\0' || ext[1] == ENV_SEPCHAR)) {
       if (is_executable(name, abspath)) {


### PR DESCRIPTION
Fix issue that increment expression is executable and pointer ext
pointing out of the buffer, if the pointer ext points to the terminating
NUL.