### PR TITLE
tests: increase timeout with "timers doesn't mess up the cmdline"

### DIFF
--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -225,7 +225,7 @@ describe('timers', function()
       {0:~                                       }|
       {0:~                                       }|
       :good^                                   |
-    ]], intermediate=true, timeout=200}
+    ]], intermediate=true, timeout=1000}
 
     eq(1, eval('g:val'))
   end)


### PR DESCRIPTION
This might be required on (slower) CI.

    [ RUN      ] timers doesn't mess up the cmdline: ERR
    test/functional/ui/screen.lua:562: expected intermediate screen state before final screen state
    stack traceback:
            test/functional/ui/screen.lua:562: in function '_wait'
            test/functional/ui/screen.lua:366: in function 'expect'
            .../build/neovim/neovim/test/functional/eval/timer_spec.lua:221: in function <.../build/neovim/neovim/test/functional/eval/timer_spec.lua:199>

Ref: https://travis-ci.org/neovim/neovim/jobs/544974506#L3861