### PR TITLE
screen: showcmd should never move the cursor

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3386,8 +3386,8 @@ bool add_to_showcmd(int c)
 
 void add_to_showcmd_c(int c)
 {
-  if (!add_to_showcmd(c))
-    setcursor();
+  add_to_showcmd(c);
+  setcursor();
 }
 
 /*
@@ -3448,18 +3448,18 @@ static void display_showcmd(void)
     return;
   }
 
+  int showcmd_row = (int)Rows - 1;
+  grid_puts_line_start(&default_grid, showcmd_row);
+
   if (!showcmd_is_clear) {
-    grid_puts(&default_grid, showcmd_buf, (int)Rows - 1, sc_col, 0);
+    grid_puts(&default_grid, showcmd_buf, showcmd_row, sc_col, 0);
   }
 
-  /*
-   * clear the rest of an old message by outputting up to SHOWCMD_COLS
-   * spaces
-   */
-  grid_puts(&default_grid, (char_u *)"          " + len, (int)Rows - 1,
+  // clear the rest of an old message by outputting up to SHOWCMD_COLS spaces
+  grid_puts(&default_grid, (char_u *)"          " + len, showcmd_row,
             sc_col + len, 0);
 
-  setcursor();              /* put cursor back where it belongs */
+  grid_puts_line_flush(false);
 }
 
 /*

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -412,7 +412,7 @@ void pum_redraw(void)
     idx = i + pum_first;
     attr = (idx == pum_selected) ? attr_select : attr_norm;
 
-    screen_puts_line_start(row);
+    grid_puts_line_start(&pum_grid, row);
 
     // prepend a space if there is room
     if (extra_space) {
@@ -564,7 +564,7 @@ void pum_redraw(void)
                      ? attr_thumb : attr_scroll);
       }
     }
-    grid_puts_line_flush(&pum_grid, false);
+    grid_puts_line_flush(false);
     row++;
   }
 }


### PR DESCRIPTION
Also restore the symmetry between `grid_puts_line_start` and
`grid_puts_line_flush`.

Ref #10219 and https://github.com/vhakulinen/gnvim/issues/53