### PR TITLE
tests: fix Test_tagfiles: use Vim's 'tags' setting

### DIFF
--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -17,6 +17,8 @@ set listchars=eol:$
 set fillchars=vert:\|,fold:-
 set shortmess-=F
 set laststatus=1
+set tags=./tags,tags
+
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -635,7 +635,8 @@ func Test_OptionSet()
 
   " Cleanup
   au! OptionSet
-  for opt in ['nu', 'ai', 'acd', 'ar', 'bs', 'backup', 'cul', 'cp']
+  " set tags&
+  for opt in ['nu', 'ai', 'acd', 'ar', 'bs', 'backup', 'cul', 'cp', 'tags']
     exe printf(":set %s&vim", opt)
   endfor
   call test_override('starting', 0)

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -294,6 +294,7 @@ func Test_getcompletion()
   endfor
 
   call delete('Xtags')
+  set tags&
 
   call assert_fails('call getcompletion("", "burp")', 'E475:')
 endfunc

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -225,6 +225,7 @@ func Test_set_completion()
 
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
+  set tags&
   let &shellslash = shellslash
 endfunc
 

--- a/src/nvim/testdir/test_tagcase.vim
+++ b/src/nvim/testdir/test_tagcase.vim
@@ -44,6 +44,7 @@ func Test_tagcase()
   endfor
 
   call delete('Xtags')
+  set tags&
   set ic&
   setg tc&
   setl tc&

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -20,6 +20,7 @@ func Test_cancel_ptjump()
   call assert_equal(2, winnr('$'))
 
   call delete('Xtags')
+  set tags&
   quit
 endfunc
 
@@ -104,6 +105,7 @@ func Test_tagjump_switchbuf()
   enew | only
   call delete('Xfile1')
   call delete('Xtags')
+  set tags&
   set switchbuf&vim
 endfunc
 
@@ -424,7 +426,7 @@ func Test_tagnr_recall()
   tag
   call assert_equal(bufname('%'), 'Xtest.h')
 
-  set tag&
+  set tags&
   call delete('Xtags')
   bwipe Xtest.h
   bwipe Xtest.c
@@ -460,6 +462,7 @@ func Test_tag_line_toolong()
   endtry
   call assert_equal('Ignoring long line in tags file', split(execute('messages'), '\n')[-1])
   call delete('Xtags')
+  set tags&
   let &verbose = old_vbs
 endfunc
 

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -90,7 +90,8 @@ func Test_tagfiles()
 	\           fnamemodify(tf[0], ':p:gs?\\?/?'))
   helpclose
   call assert_equal(['Xtags1', 'Xtags2'], tagfiles())
-  set tags&
+  " Nvim: defaults to "./tags;,tags", which might cause false positives.
+  set tags=./tags,tags
   call assert_equal([], tagfiles())
 
   call delete('Xtags1')

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -16,6 +16,7 @@ func Test_taglist()
   call assert_equal(['BFoo', 'FFoo'], map(taglist("Foo", "Xbar"), {i, v -> v.name}))
 
   call delete('Xtags')
+  set tags&
   bwipe
 endfunc
 
@@ -36,6 +37,7 @@ func Test_taglist_native_etags()
 	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
 
   call delete('Xtags')
+  set tags&
 endfunc
 
 func Test_taglist_ctags_etags()
@@ -55,6 +57,7 @@ func Test_taglist_ctags_etags()
 	\ map(taglist('set_signals'), {i, v -> [v.name, v.cmd]}))
 
   call delete('Xtags')
+  set tags&
 endfunc
 
 func Test_tags_too_long()
@@ -73,6 +76,7 @@ func Test_tagsfile_without_trailing_newline()
   call assert_equal('Foo', tl[0].name)
 
   call delete('Xtags')
+  set tags&
 endfunc
 
 func Test_tagfiles()


### PR DESCRIPTION
Otherwise it might fail with an existing `tags` file upwards, e.g. in
neovim's source directory (which should be rather common).