### PR TITLE
ci: codecov: do not use flags  [ci skip]

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -122,7 +122,7 @@ Set-PSDebug -Strict -Trace 1
 
 
 if ($uploadToCodecov) {
-  C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) -c -F functionaltest || echo 'codecov upload failed.'"
+  C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) -c || echo 'codecov upload failed.'"
 }
 
 # Old tests
@@ -130,7 +130,7 @@ $env:PATH = "C:\msys64\usr\bin;$env:PATH"
 & "C:\msys64\mingw$bits\bin\mingw32-make.exe" -C $(Convert-Path ..\src\nvim\testdir) VERBOSE=1
 
 if ($uploadToCodecov) {
-  C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) -c -F oldtest || echo 'codecov upload failed.'"
+  C:\msys64\usr\bin\bash -lc "cd /c/projects/neovim; bash <(curl -s https://codecov.io/bash) -c || echo 'codecov upload failed.'"
 }
 
 # Build artifacts

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -4,7 +4,7 @@
 submit_coverage() {
   if [ -n "${GCOV}" ]; then
     if curl --fail --output codecov.bash --silent https://codecov.io/bash; then
-      bash codecov.bash -c -F "$1" || echo "codecov upload failed."
+      bash codecov.bash -c || echo "codecov upload failed."
       rm -f codecov.bash
     fi
   fi


### PR DESCRIPTION
Using flags results in timeouts on their end when viewing reports, and
is a known issue since months already.

Flags are only relevant with codecov's comments, which we are not using currently anyway.

Example for a timing out URL: https://codecov.io/gh/neovim/neovim/pull/10186

I had to do this with other projects before, e.g. pytest, and support on Slack confirmed that this is a known issue.

This is included in https://github.com/neovim/neovim/pull/10201 already, but it is still work in progress, and codecov not being helpful / available for coverage status/changes makes it harder there.