### PR TITLE
Dump gcov coverage in process_spawn

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -7,6 +7,7 @@ if(USE_GCOV)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+  add_compile_definitions(USE_GCOV)
 endif()
 endif()
 

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -22,6 +22,11 @@
 # include "event/process.c.generated.h"
 #endif
 
+/// Externally defined with gcov.
+#ifdef USE_GCOV
+void __gcov_dump(void);
+#endif
+
 // Time for a process to exit cleanly before we send KILL.
 // For PTY processes SIGTERM is sent first (in case SIGHUP was not enough).
 #define KILL_TIMEOUT_MS 2000
@@ -49,6 +54,11 @@ int process_spawn(Process *proc, bool in, bool out, bool err)
   } else {
     proc->err.closed = true;
   }
+
+#ifdef USE_GCOV
+  // Dump coverage data before forking, to avoid "Merge mismatch" errors.
+  __gcov_dump();
+#endif
 
   int status;
   switch (proc->type) {


### PR DESCRIPTION
This fixes / prevents "Merge mismatch" errors via gcov.

Fixes https://github.com/neovim/neovim/pull/3926#issuecomment-502343527.

NOTE: not available on OSX builds?!

> Undefined symbols for architecture x86_64:
  "___gcov_dump", referenced from:
      _process_spawn in process.c.o
ld: symbol(s) not found for architecture x86_64

https://travis-ci.org/neovim/neovim/jobs/546088317#L1648

Might be required in `pty_process_spawn` (`pty_process_unix.c`) only really.
There it made a difference when put before the `signal(SIGHUP, SIG_DFL);` then - but might run into some 2s timeout then, likely related to / via `loop_close` then.