### PR TITLE
vim-patch:8.0.{10{39,53,55},1274}: cannot change a line in not current buffer

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2286,6 +2286,9 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout}]]])
 server2client({clientid}, {string})
 				Number	send reply string
 serverlist()			String	get a list of available servers
+setbufline( {expr}, {lnum}, {line})
+				Number	set line {lnum} to {line} in buffer
+					{expr}
 setbufvar({expr}, {varname}, {val})	set {varname} in buffer {expr} to {val}
 setcharsearch({dict})		Dict	set character search from {dict}
 setcmdpos({pos})		Number	set cursor position in command-line
@@ -6997,6 +7000,19 @@ serverstop({address})					*serverstop()*
 		If |v:servername| is stopped it is set to the next available
 		address returned by |serverlist()|.
 
+setbufline({expr}, {lnum}, {text})			*setbufline()*
+		Set line {lnum} to {text} in buffer {expr}.  To insert
+		lines use |append()|.
+
+		For the use of {expr}, see |bufname()| above.
+
+		{lnum} is used like with |setline()|.
+		This works like |setline()| for the specified buffer.
+		On success 0 is returned, on failure 1 is returned.
+
+		If {expr} is not a valid buffer or {lnum} is not valid, an
+		error message is given.
+
 setbufvar({expr}, {varname}, {val})			*setbufvar()*
 		Set option or local variable {varname} in buffer {expr} to
 		{val}.
@@ -7064,13 +7080,19 @@ setfperm({fname}, {mode})				*setfperm()* *chmod*
 
 setline({lnum}, {text})					*setline()*
 		Set line {lnum} of the current buffer to {text}.  To insert
-		lines use |append()|.
+		lines use |append()|. To set lines in another buffer use
+		|setbufline()|.
+
 		{lnum} is used like with |getline()|.
 		When {lnum} is just below the last line the {text} will be
 		added as a new line.
+
 		If this succeeds, 0 is returned.  If this fails (most likely
-		because {lnum} is invalid) 1 is returned.  Example: >
+		because {lnum} is invalid) 1 is returned.
+
+		Example: >
 			:call setline(5, strftime("%c"))
+
 <		When {text} is a |List| then line {lnum} and following lines
 		will be set to the items in the list.  Example: >
 			:call setline(5, ['aaa', 'bbb', 'ccc'])

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14854,7 +14854,10 @@ static void set_buffer_lines(buf_T *buf, linenr_T lnum, typval_T *lines,
   buf_T       *curbuf_save;
   int         is_curbuf = buf == curbuf;
 
-  if (buf == NULL || buf->b_ml.ml_mfp == NULL || lnum < 1) {
+  // When using the current buffer ml_mfp will be set if needed.  Useful when
+  // setline() is used on startup.  For other buffers the buffer must be
+  // loaded.
+  if (buf == NULL || (!is_curbuf && buf->b_ml.ml_mfp == NULL) || lnum < 1) {
     rettv->vval.v_number = 1;  // FAIL
     return;
   }

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -263,6 +263,7 @@ return {
     serverlist={},
     serverstart={args={0, 1}},
     serverstop={args=1},
+    setbufline={args=3},
     setbufvar={args=3},
     setcharsearch={args=1},
     setcmdpos={args=1},

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -190,12 +190,18 @@ func s:feedkeys(timer)
 endfunc
 
 " Get the command to run Vim, with -u NONE and --headless arguments.
+" If there is an argument use it instead of "NONE".
 " Returns an empty string on error.
-func GetVimCommand()
+func GetVimCommand(...)
+  if a:0 == 0
+    let name = 'NONE'
+  else
+    let name = a:1
+  endif
   let cmd = v:progpath
-  let cmd = substitute(cmd, '-u \f\+', '-u NONE', '')
-  if cmd !~ '-u NONE'
-    let cmd = cmd . ' -u NONE'
+  let cmd = substitute(cmd, '-u \f\+', '-u ' . name, '')
+  if cmd !~ '-u '. name
+    let cmd = cmd . ' -u ' . name
   endif
   let cmd .= ' --headless -i NONE'
   let cmd = substitute(cmd, 'VIMRUNTIME=.*VIMRUNTIME;', '', '')

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -27,6 +27,32 @@ func Test_setbufline_getbufline()
   exe "bwipe! " . b
 endfunc
 
+func Test_setbufline_getbufline_fold()
+  split Xtest
+  setlocal foldmethod=expr foldexpr=0
+  let b = bufnr('%')
+  new
+  call assert_equal(0, setbufline(b, 1, ['foo', 'bar']))
+  call assert_equal(['foo'], getbufline(b, 1))
+  call assert_equal(['bar'], getbufline(b, 2))
+  call assert_equal(['foo', 'bar'], getbufline(b, 1, 2))
+  exe "bwipe!" b
+  bwipe!
+endfunc
+
+func Test_setbufline_getbufline_fold_tab()
+  split Xtest
+  setlocal foldmethod=expr foldexpr=0
+  let b = bufnr('%')
+  tab new
+  call assert_equal(0, setbufline(b, 1, ['foo', 'bar']))
+  call assert_equal(['foo'], getbufline(b, 1))
+  call assert_equal(['bar'], getbufline(b, 2))
+  call assert_equal(['foo', 'bar'], getbufline(b, 1, 2))
+  exe "bwipe!" b
+  bwipe!
+endfunc
+
 func Test_setline_startup()
   let cmd = GetVimCommand('Xscript')
   if cmd == ''

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -1,0 +1,26 @@
+" Tests for setbufline() and getbufline()
+
+func Test_setbufline_getbufline()
+  new
+  let b = bufnr('%')
+  hide
+  call assert_equal(0, setbufline(b, 1, ['foo', 'bar']))
+  call assert_equal(['foo'], getbufline(b, 1))
+  call assert_equal(['bar'], getbufline(b, 2))
+  call assert_equal(['foo', 'bar'], getbufline(b, 1, 2))
+  exe "bd!" b
+  call assert_equal([], getbufline(b, 1, 2))
+
+  split Xtest
+  call setline(1, ['a', 'b', 'c'])
+  let b = bufnr('%')
+  wincmd w
+  call assert_equal(1, setbufline(b, 5, ['x']))
+  call assert_equal(1, setbufline(1234, 1, ['x']))
+  call assert_equal(0, setbufline(b, 4, ['d', 'e']))
+  call assert_equal(['c'], getbufline(b, 3))
+  call assert_equal(['d'], getbufline(b, 4))
+  call assert_equal(['e'], getbufline(b, 5))
+  call assert_equal([], getbufline(b, 6))
+  exe "bwipe! " . b
+endfunc

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -1,5 +1,7 @@
 " Tests for setbufline() and getbufline()
 
+source shared.vim
+
 func Test_setbufline_getbufline()
   new
   let b = bufnr('%')
@@ -23,4 +25,17 @@ func Test_setbufline_getbufline()
   call assert_equal(['e'], getbufline(b, 5))
   call assert_equal([], getbufline(b, 6))
   exe "bwipe! " . b
+endfunc
+
+func Test_setline_startup()
+  let cmd = GetVimCommand('Xscript')
+  if cmd == ''
+    return
+  endif
+  call writefile(['call setline(1, "Hello")', 'w Xtest', 'q!'], 'Xscript')
+  call system(cmd)
+  call assert_equal(['Hello'], readfile('Xtest'))
+
+  call delete('Xscript')
+  call delete('Xtest')
 endfunc

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -32,7 +32,7 @@ func Test_setline_startup()
   if cmd == ''
     return
   endif
-  call writefile(['call setline(1, "Hello")', 'w Xtest', 'q!'], 'Xscript')
+  call writefile(['call setline(1, "Hello")', 'silent w Xtest', 'q!'], 'Xscript')
   call system(cmd)
   call assert_equal(['Hello'], readfile('Xtest'))
 


### PR DESCRIPTION
Problem:    Cannot change a line in a buffer other than the current one.
Solution:   Add setbufline(). (Yasuhiro Matsumoto, Ozaki Kiichi, closes vim/vim#1953)
https://github.com/vim/vim/commit/b31cf2bb0be95d106bd8eef93cc07550591c1d0d