### PR TITLE
vim-patch:8.1.1484: some tests are slow

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -678,11 +678,12 @@ void eval_clear(void)
     xfree(SCRIPT_SV(i));
   ga_clear(&ga_scripts);
 
+  // functions need to be freed before gargabe collecting, otherwise local
+  // variables might be freed twice.
+  free_all_functions();
+
   // unreferenced lists and dicts
   (void)garbage_collect(false);
-
-  // functions
-  free_all_functions();
 }
 
 #endif

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -166,9 +166,7 @@ nolog:
 RUN_VIMTEST = $(TOOL) $(NVIM_PRG) -u unix.vim
 
 newtests: newtestssilent
-	@/bin/sh -c "if test -f messages && grep -q 'FAILED' messages; then \
-	                 cat messages && cat test.log;                      \
-	             fi"
+	@/bin/sh -c "if test -f messages && grep -q 'SKIPPED\|FAILED' messages; then cat messages; fi"
 
 newtestssilent: $(NEW_TESTS)
 

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -44,6 +44,10 @@ if &lines < 24 || &columns < 80
   qa!
 endif
 
+if has('reltime')
+  let s:start_time = reltime()
+endif
+
 " Common with all tests on all systems.
 source setup.vim
 
@@ -105,6 +109,9 @@ endfunc
 
 func RunTheTest(test)
   echo 'Executing ' . a:test
+  if has('reltime')
+    let func_start = reltime()
+  endif
 
   " Avoid stopping at the "hit enter" prompt
   set nomore
@@ -129,7 +136,11 @@ func RunTheTest(test)
     endtry
   endif
 
-  call add(s:messages, 'Executing ' . a:test)
+  let message = 'Executed ' . a:test
+  if has('reltime')
+    let message ..= ' in ' .. reltimestr(reltime(func_start)) .. ' seconds'
+  endif
+  call add(s:messages, message)
   let s:done += 1
 
   if a:test =~ 'Test_nocatch_'
@@ -234,6 +245,9 @@ func FinishTesting()
     let message = 'NO tests executed'
   else
     let message = 'Executed ' . s:done . (s:done > 1 ? ' tests' : ' test')
+  endif
+  if has('reltime')
+    let message ..= ' in ' .. reltimestr(reltime(s:start_time)) .. ' seconds'
   endif
   echo message
   call add(s:messages, message)


### PR DESCRIPTION
vim-patch:8.1.1484: some tests are slow

Problem:    Some tests are slow.
Solution:   Add timing to the test messages.  Fix double free when quitting in
            VimLeavePre autocmd.
https://github.com/vim/vim/commit/75ee544f99ca66be8105570c6309d95435ad30d1

TODO:

- [ ] v8.1.1485 ?!