### PR TITLE
vim-patch:8.0.0914: highlight attributes are always combined

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4720,18 +4720,19 @@ the same syntax file on all UIs.
 
 					*bold* *underline* *undercurl*
 					*inverse* *italic* *standout*
-					*strikethrough*
+					*nocombine* *strikethrough*
 cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 	attr-list is a comma separated list (without spaces) of the
 	following items (in any order):
 		bold
 		underline
 		undercurl	curly underline
+		strikethrough
 		reverse
 		inverse		same as reverse
 		italic
 		standout
-		strikethrough
+		nocombine	override attributes instead of combining them
 		NONE		no attributes used (used to reset it)
 
 	Note that "bold" can be used here and by using a bold font.  They

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -308,8 +308,16 @@ int hl_combine_attr(int char_attr, int prim_attr)
   // start with low-priority attribute, and override colors if present below.
   HlAttrs new_en = char_aep;
 
-  new_en.cterm_ae_attr |= spell_aep.cterm_ae_attr;
-  new_en.rgb_ae_attr |= spell_aep.rgb_ae_attr;
+  if (spell_aep.cterm_ae_attr & HL_NOCOMBINE) {
+    new_en.cterm_ae_attr = spell_aep.cterm_ae_attr;
+  } else {
+    new_en.cterm_ae_attr |= spell_aep.cterm_ae_attr;
+  }
+  if (spell_aep.rgb_ae_attr & HL_NOCOMBINE) {
+    new_en.rgb_ae_attr = spell_aep.rgb_ae_attr;
+  } else {
+    new_en.rgb_ae_attr |= spell_aep.rgb_ae_attr;
+  }
 
   if (spell_aep.cterm_fg_color > 0) {
     new_en.cterm_fg_color = spell_aep.cterm_fg_color;

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -18,6 +18,7 @@ typedef enum {
   HL_UNDERCURL       = 0x10,
   HL_STANDOUT        = 0x20,
   HL_STRIKETHROUGH   = 0x40,
+  HL_NOCOMBINE       = 0x80,
 } HlAttrFlags;
 
 /// Stores a complete highlighting entry, including colors and attributes

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -116,10 +116,10 @@ static int include_link = 0;    /* when 2 include "nvim/link" and "clear" */
 /// following names, separated by commas (but no spaces!).
 static char *(hl_name_table[]) =
 { "bold", "standout", "underline", "undercurl",
-  "italic", "reverse", "inverse", "strikethrough", "NONE" };
+  "italic", "reverse", "inverse", "strikethrough", "nocombine", "NONE" };
 static int hl_attr_table[] =
 { HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE,
-  HL_INVERSE, HL_STRIKETHROUGH, 0 };
+  HL_INVERSE, HL_STRIKETHROUGH, HL_NOCOMBINE, 0 };
 
 // The patterns that are being searched for are stored in a syn_pattern.
 // A match item consists of one pattern.

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -441,6 +441,13 @@ describe('highlight', function()
   it('nocombine', function()
     screen:detach()
     screen = Screen.new(25,6)
+    screen:set_default_attr_ids{
+      [1] = {foreground = Screen.colors.SlateBlue, underline = true},
+      [2] = {bold = true, foreground = Screen.colors.Blue1},
+      [3] = {underline = true, reverse = true, foreground = Screen.colors.SlateBlue},
+      [4] = {background = Screen.colors.Yellow, reverse = true, foreground = Screen.colors.SlateBlue},
+      [5] = {foreground = Screen.colors.Red},
+    }
     screen:attach()
     feed_command('syntax on')
     feed_command('hi! Underlined cterm=underline gui=underline')
@@ -457,39 +464,26 @@ describe('highlight', function()
       {2:~                        }|
       {2:~                        }|
                                |
-    ]], attr_ids={
-      [1] = {foreground = Screen.colors.SlateBlue, underline = true},
-      [2] = {bold = true, foreground = Screen.colors.Blue1},
-    }}
+    ]]}
 
     feed('/foo')
     screen:expect{grid=[[
-      {1:foo}{2:bar}                   |
-      {3:foo}{2:bar}                   |
+      {3:foo}{1:bar}                   |
+      {4:foo}{1:bar}                   |
                                |
-      {4:~                        }|
-      {4:~                        }|
+      {2:~                        }|
+      {2:~                        }|
       /foo^                     |
-    ]], attr_ids={
-      [1] = {underline = true, reverse = true, foreground = Screen.colors.SlateBlue},
-      [2] = {foreground = Screen.colors.SlateBlue, underline = true},
-      [3] = {background = Screen.colors.Yellow, reverse = true, foreground = Screen.colors.SlateBlue},
-      [4] = {bold = true, foreground = Screen.colors.Blue1},
-    }}
+    ]]}
     feed('\n')
     screen:expect{grid=[[
-      {1:^foo}{2:bar}                   |
-      {1:foo}{2:bar}                   |
+      {4:^foo}{1:bar}                   |
+      {4:foo}{1:bar}                   |
                                |
-      {3:~                        }|
-      {3:~                        }|
-      {4:search hit...uing at TOP} |
-    ]], attr_ids={
-      [1] = {background = Screen.colors.Yellow, reverse = true, foreground = Screen.colors.SlateBlue},
-      [2] = {foreground = Screen.colors.SlateBlue, underline = true},
-      [3] = {bold = true, foreground = Screen.colors.Blue1},
-      [4] = {foreground = Screen.colors.Red},
-    }}
+      {2:~                        }|
+      {2:~                        }|
+      {5:search hit...uing at TOP} |
+    ]]}
   end)
 
   it('guisp (special/undercurl)', function()

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -438,6 +438,46 @@ describe('highlight', function()
     })
   end)
 
+  it('nocombine', function()
+    screen:detach()
+    screen = Screen.new(25,6)
+    screen:attach()
+    feed_command('syntax on')
+    feed_command('hi! Underlined cterm=underline gui=underline')
+    feed_command('syn keyword Underlined foobar')
+    feed_command('hi Search cterm=inverse,nocombine gui=inverse,nocombine')
+    insert([[
+      foobar
+      foobar
+      ]])
+    screen:expect{grid=[[
+      {1:foobar}                   |
+      {1:foobar}                   |
+      ^                         |
+      {2:~                        }|
+      {2:~                        }|
+                               |
+    ]], attr_ids={
+      [1] = {foreground = Screen.colors.SlateBlue, underline = true},
+      [2] = {bold = true, foreground = Screen.colors.Blue1},
+    }}
+
+    feed('/foo')
+    screen:expect{grid=[[
+      {1:foo}{2:bar}                   |
+      {3:foo}{2:bar}                   |
+                               |
+      {4:~                        }|
+      {4:~                        }|
+      /foo^                     |
+    ]], attr_ids={
+      [1] = {underline = true, reverse = true, foreground = Screen.colors.SlateBlue},
+      [2] = {foreground = Screen.colors.SlateBlue, underline = true},
+      [3] = {background = Screen.colors.Yellow, reverse = true, foreground = Screen.colors.SlateBlue},
+      [4] = {bold = true, foreground = Screen.colors.Blue1},
+    }}
+  end)
+
   it('guisp (special/undercurl)', function()
     feed_command('syntax on')
     feed_command('syn keyword TmpKeyword neovim')

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -476,6 +476,20 @@ describe('highlight', function()
       [3] = {background = Screen.colors.Yellow, reverse = true, foreground = Screen.colors.SlateBlue},
       [4] = {bold = true, foreground = Screen.colors.Blue1},
     }}
+    feed('\n')
+    screen:expect{grid=[[
+      {1:^foo}{2:bar}                   |
+      {1:foo}{2:bar}                   |
+                               |
+      {3:~                        }|
+      {3:~                        }|
+      {4:search hit...uing at TOP} |
+    ]], attr_ids={
+      [1] = {background = Screen.colors.Yellow, reverse = true, foreground = Screen.colors.SlateBlue},
+      [2] = {foreground = Screen.colors.SlateBlue, underline = true},
+      [3] = {bold = true, foreground = Screen.colors.Blue1},
+      [4] = {foreground = Screen.colors.Red},
+    }}
   end)
 
   it('guisp (special/undercurl)', function()


### PR DESCRIPTION
Problem:    Highlight attributes are always combined.
Solution:   Add the 'nocombine' value to replace attributes instead of
            combining them. (scauligi, closes vim/vim#1963)
https://github.com/vim/vim/commit/0cd2a94a4030f6bd12eaec44db92db108e33c913