### PR TITLE
vim-patch:8.0.0970: passing invalid highlight id

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7546,7 +7546,7 @@ void highlight_changed(void)
    */
   ga_grow(&highlight_ga, 10);
   hlcnt = highlight_ga.ga_len;
-  if (id_S == 0) {  /* Make sure id_S is always valid to simplify code below */
+  if (id_S == -1) {  // Make sure id_S is always valid to simplify code below
     memset(&HL_TABLE()[hlcnt + 9], 0, sizeof(struct hl_group));
     id_S = hlcnt + 10;
   }


### PR DESCRIPTION
Problem:    if there is no StatusLine highlighting and there is StatusLineNC
            or StatusLineTermNC highlighting then an invalid highlight id is
            passed to combine_stl_hlt(). (Coverity)
Solution:   Check id_S to be -1 instead of zero.
https://github.com/vim/vim/commit/d6a7b3e6bbb8f87507de68d86cf70eab806aab3a