### PR TITLE
vim-patch:8.0.1109: timer causes error on exit from Ex mode

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17921,6 +17921,7 @@ static void timer_due_cb(TimeWatcher *tw, void *data)
   argv[0].vval.v_number = timer->timer_id;
   typval_T rettv = TV_INITIAL_VALUE;
   called_emsg = false;
+  int save_ex_pressedreturn = get_pressedreturn();
 
   callback_call(&timer->callback, 1, argv, &rettv);
 
@@ -17933,6 +17934,7 @@ static void timer_due_cb(TimeWatcher *tw, void *data)
   }
   did_emsg = save_did_emsg;
   called_emsg = save_called_emsg;
+  set_pressedreturn(save_ex_pressedreturn);
 
   if (timer->emsg_count >= 3) {
     timer_stop(timer);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -10064,6 +10064,16 @@ static void ex_folddo(exarg_T *eap)
   ml_clearmarked();      // clear rest of the marks
 }
 
+int get_pressedreturn(void)
+{
+    return ex_pressedreturn;
+}
+
+void set_pressedreturn(int val)
+{
+     ex_pressedreturn = val;
+}
+
 static void ex_terminal(exarg_T *eap)
 {
   char ex_cmd[1024];

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -252,4 +252,15 @@ func Test_peek_and_get_char()
   call timer_stop(intr)
 endfunc
 
+func Test_ex_mode()
+  " Function with an empty line.
+  func Foo(...)
+
+  endfunc
+  let timer =  timer_start(40, function('g:Foo'), {'repeat':-1})
+  " This used to throw error E749.
+  exe "normal Qsleep 100m\rvi\r"
+  call timer_stop(timer)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Timer causes error on exit from Ex mode. (xtal8)
Solution:   save and restore the ex_pressedreturn flag. (Christian Brabandt,
            closes vim/vim#2079)
https://github.com/vim/vim/commit/f5291f301e9322545f0621b2157e93050d1d4fb3