### PR TITLE
vim-patch:8.0.1332: highlighting in quickfix window could be better

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2485,8 +2485,8 @@ void qf_list(exarg_T *eap)
   int         qfFileAttr;
   int         qfSepAttr;
   int         qfLineAttr;
-  int all = eap->forceit;               /* if not :cl!, only show
-                                                   recognised errors */
+  int         all = eap->forceit;     // if not :cl!, only show
+                                      // recognised errors
   qf_info_T   *qi = &ql_info;
 
   if (eap->cmdidx == CMD_llist) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -40,6 +40,7 @@
 #include "nvim/screen.h"
 #include "nvim/search.h"
 #include "nvim/strings.h"
+#include "nvim/syntax.h"
 #include "nvim/ui.h"
 #include "nvim/window.h"
 #include "nvim/os/os.h"
@@ -2481,6 +2482,9 @@ void qf_list(exarg_T *eap)
   int idx1 = 1;
   int idx2 = -1;
   char_u      *arg = eap->arg;
+  int         qfFileAttr;
+  int         qfSepAttr;
+  int         qfLineAttr;
   int all = eap->forceit;               /* if not :cl!, only show
                                                    recognised errors */
   qf_info_T   *qi = &ql_info;
@@ -2524,6 +2528,21 @@ void qf_list(exarg_T *eap)
 
   // Shorten all the file names, so that it is easy to read.
   shorten_fnames(false);
+
+  // Get the attributes for the different quickfix highlight items.  Note
+  // that this depends on syntax items defined in the qf.vim syntax file
+  qfFileAttr = syn_name2attr((char_u *)"qfFileName");
+  if (qfFileAttr == 0) {
+     qfFileAttr = HL_ATTR(HLF_D);
+  }
+  qfSepAttr = syn_name2attr((char_u *)"qfSeparator");
+  if (qfSepAttr == 0) {
+      qfSepAttr = HL_ATTR(HLF_D);
+  }
+  qfLineAttr = syn_name2attr((char_u *)"qfLineNr");
+  if (qfLineAttr == 0) {
+      qfLineAttr = HL_ATTR(HLF_N);
+  }
 
   if (qi->qf_lists[qi->qf_curlist].qf_nonevalid) {
     all = true;
@@ -2574,22 +2593,27 @@ void qf_list(exarg_T *eap)
       }
       msg_putchar('\n');
       msg_outtrans_attr(IObuff, i == qi->qf_lists[qi->qf_curlist].qf_index
-                        ? HL_ATTR(HLF_QFL) : HL_ATTR(HLF_D));
+                        ? HL_ATTR(HLF_QFL) : qfFileAttr);
+
+      if (qfp->qf_lnum != 0) {
+        msg_puts_attr(":", qfSepAttr);
+      }
       if (qfp->qf_lnum == 0) {
         IObuff[0] = NUL;
       } else if (qfp->qf_col == 0) {
-        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRIdLINENR, qfp->qf_lnum);
+        vim_snprintf((char *)IObuff, IOSIZE, "%" PRIdLINENR, qfp->qf_lnum);
       } else {
-        vim_snprintf((char *)IObuff, IOSIZE, ":%" PRIdLINENR " col %d",
+        vim_snprintf((char *)IObuff, IOSIZE, "%" PRIdLINENR " col %d",
                      qfp->qf_lnum, qfp->qf_col);
       }
-      vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s:",
+      vim_snprintf((char *)IObuff + STRLEN(IObuff), IOSIZE, "%s",
                    (char *)qf_types(qfp->qf_type, qfp->qf_nr));
-      msg_puts_attr((const char *)IObuff, HL_ATTR(HLF_N));
+      msg_puts_attr((const char *)IObuff, qfLineAttr);
+      msg_puts_attr(":", qfSepAttr);
       if (qfp->qf_pattern != NULL) {
         qf_fmt_text(qfp->qf_pattern, IObuff, IOSIZE);
-        xstrlcat((char *)IObuff, ":", IOSIZE);
         msg_puts((const char *)IObuff);
+        msg_puts_attr(":", qfSepAttr);
       }
       msg_puts(" ");
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7336,6 +7336,17 @@ int syn_name2id(const char_u *name)
   return i + 1;
 }
 
+/// Lookup a highlight group name and return its attributes.
+/// Return zero if not found.
+int syn_name2attr(char_u *name) {
+  int id = syn_name2id(name);
+
+  if (id != 0) {
+    return syn_id2attr(syn_get_final_id(id));
+  }
+  return 0;
+}
+
 /*
  * Return TRUE if highlight group "name" exists.
  */

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7338,7 +7338,8 @@ int syn_name2id(const char_u *name)
 
 /// Lookup a highlight group name and return its attributes.
 /// Return zero if not found.
-int syn_name2attr(char_u *name) {
+int syn_name2attr(char_u *name)
+{
   int id = syn_name2id(name);
 
   if (id != 0) {


### PR DESCRIPTION
Problem:    Highlighting in quickfix window could be better. (Axel Bender)
Solution:   Use the qfSeparator highlight item. (Yegappan Lakshmanan)
https://github.com/vim/vim/commit/93a32e2ec4b5a391c5006ca09f196e6510c8c2e9

This adds `syn_name2attr` already (from previous patch 8.0.1123,
vim/vim@1b9645de3).