### PR TITLE
gcov: use __gcov_flush instead of __gcov_dump

### DIFF
--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -22,11 +22,6 @@
 # include "event/process.c.generated.h"
 #endif
 
-/// Externally defined with gcov.
-#ifdef USE_GCOV
-void __gcov_dump(void);
-#endif
-
 // Time for a process to exit cleanly before we send KILL.
 // For PTY processes SIGTERM is sent first (in case SIGHUP was not enough).
 #define KILL_TIMEOUT_MS 2000
@@ -54,11 +49,6 @@ int process_spawn(Process *proc, bool in, bool out, bool err)
   } else {
     proc->err.closed = true;
   }
-
-#ifdef USE_GCOV
-  // Dump coverage data before forking, to avoid "Merge mismatch" errors.
-  __gcov_dump();
-#endif
 
   int status;
   switch (proc->type) {

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -36,6 +36,11 @@
 # include "os/pty_process_unix.c.generated.h"
 #endif
 
+/// Externally defined with gcov.
+#ifdef USE_GCOV
+void __gcov_flush(void);
+#endif
+
 /// termios saved at startup (for TUI) or initialized by pty_process_spawn().
 static struct termios termios_default;
 
@@ -58,6 +63,11 @@ int pty_process_spawn(PtyProcess *ptyproc)
     // TODO(jkeyes): We could pass NULL to forkpty() instead ...
     init_termios(&termios_default);
   }
+
+#ifdef USE_GCOV
+  // Flush coverage data before forking, to avoid "Merge mismatch" errors.
+  __gcov_flush();
+#endif
 
   int status = 0;  // zero or negative error code (libuv convention)
   Process *proc = (Process *)ptyproc;


### PR DESCRIPTION
This restores missing coverage again.

Move it to process_spawn in os/pty_process_unix.c, since it seems to
break printargs-test on Windows/AppVeyor otherwise (#10248).

Pulled out of https://github.com/neovim/neovim/pull/10248 - better to have restored coverage already, while still trying to figure out what's going on there.