### PR TITLE
tests: oldtests: mark Test_cursorhold_insert as flaky  [ci skip]

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -264,6 +264,7 @@ endif
 
 " Names of flaky tests.
 let s:flaky = [
+      \ 'Test_cursorhold_insert()',
       \ 'Test_exit_callback_interval()',
       \ 'Test_oneshot()',
       \ 'Test_out_cb()',


### PR DESCRIPTION
Fails often on CI (OSX), e.g.:

```
1 FAILED:
Found errors in Test_cursorhold_insert():
function RunTheTest[37]..Test_cursorhold_insert line 9: Expected 1 but got 0
```

> Compiler: clang Xcode: xcode10.1 C

The test could be adjusted to re-try the timer a few times, but I do not
think it's really worth it currently, and that the test should be marked
as flaky instead.

Code ref: https://github.com/blueyed/neovim/blob/ff3383bab6112d20a4f68c76ee36e40e22837c42/src/nvim/testdir/test_autocmd.vim#L36