### PR TITLE
[RFC] build: use CFLAGS=-Werror with Lua nvim-client

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -203,7 +203,7 @@ if(USE_BUNDLED_BUSTED)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build nvim-client 0.2.0-1 ${LUAROCKS_BUILDARGS}
+    ARGS build nvim-client 0.2.0-1 ${LUAROCKS_BUILDARGS} CFLAGS=-Werror
     DEPENDS luv)
   add_custom_target(nvim-client
     DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)


### PR DESCRIPTION
Helps to catch issues when Lua 5.2+ is used for building it.

Ref: https://github.com/neovim/lua-client/pull/43

Should be likely be used via a (hidden) setting, and maybe only enabled on CI then by default?
(similar to https://github.com/blueyed/neovim/blob/7da318603a9db110fac720c5cce72b09509c8143/CMakeLists.txt#L339-L348)