### PR TITLE
cmake: fix usage of find_package_handle_standard_args

### DIFF
--- a/cmake/FindLibLUV.cmake
+++ b/cmake/FindLibLUV.cmake
@@ -26,7 +26,7 @@ set(LIBLUV_INCLUDE_DIRS ${LIBLUV_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBLUV_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(libluv DEFAULT_MSG
+find_package_handle_standard_args(LibLUV DEFAULT_MSG
   LIBLUV_LIBRARY LIBLUV_INCLUDE_DIR)
 
 mark_as_advanced(LIBLUV_INCLUDE_DIR LIBLUV_LIBRARY)

--- a/cmake/FindUnibilium.cmake
+++ b/cmake/FindUnibilium.cmake
@@ -41,7 +41,7 @@ set(UNIBILIUM_INCLUDE_DIRS ${UNIBILIUM_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set UNIBILIUM_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(unibilium DEFAULT_MSG
+find_package_handle_standard_args(Unibilium DEFAULT_MSG
   UNIBILIUM_LIBRARY UNIBILIUM_INCLUDE_DIR)
 
 mark_as_advanced(UNIBILIUM_INCLUDE_DIR UNIBILIUM_LIBRARY)


### PR DESCRIPTION
The package argument is case sensitive, which is important to handle
X_FIND_REQUIRED properly, i.e. error out early if it is not found:

    CMake Error at /usr/share/cmake-3.14/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
      Could NOT find Unibilium (missing: UNIBILIUM_LIBRARY UNIBILIUM_INCLUDE_DIR)

Otherwise it would continue until:

    CMake Error: The following variables are used in this project, but they
    are set to NOTFOUND.
    Please set them or make sure they are set and tested correctly in the
    CMake files:
    UNIBILIUM_INCLUDE_DIR (ADVANCED)

Quickly checked via `rg 'find_package_handle_standard|find_package.*REQUIRED' -I | sort`.

Ref: https://gitlab.kitware.com/cmake/cmake/issues/19413