### PR TITLE
highlight: show "hi Group" message correctly when not using the screen

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7211,6 +7211,7 @@ static bool syn_list_header(const bool did_header, const int outlen,
 {
   int endcol = 19;
   bool newline = true;
+  bool adjust = true;
 
   if (!did_header) {
     msg_putchar('\n');
@@ -7219,6 +7220,9 @@ static bool syn_list_header(const bool did_header, const int outlen,
     }
     msg_outtrans(HL_TABLE()[id - 1].sg_name);
     endcol = 15;
+  } else if (ui_has(kUIMessages) || msg_silent) {
+    msg_putchar(' ');
+    adjust = false;
   } else if (msg_col + outlen + 1 >= Columns)   {
     msg_putchar('\n');
     if (got_int) {
@@ -7230,12 +7234,14 @@ static bool syn_list_header(const bool did_header, const int outlen,
     }
   }
 
-  if (msg_col >= endcol)        /* output at least one space */
-    endcol = msg_col + 1;
-  if (Columns <= endcol)        /* avoid hang for tiny window */
-    endcol = Columns - 1;
+  if (adjust) {
+    if (msg_col >= endcol) {
+      // output at least one space
+      endcol = msg_col + 1;
+    }
 
-  msg_advance(endcol);
+    msg_advance(endcol);
+  }
 
   /* Show "xxx" with the attributes. */
   if (!did_header) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -5,6 +5,7 @@ local eval = helpers.eval
 local eq = helpers.eq
 local command = helpers.command
 local set_method_error = helpers.set_method_error
+local meths = helpers.meths
 
 
 describe('ui/ext_messages', function()
@@ -329,6 +330,22 @@ describe('ui/ext_messages', function()
       {1:~                        }|
     ]], messages={
       {content = {{"/line        [2/2]"}}, kind = "search_count"}
+    }}
+  end)
+
+  it(':hi Group output', function()
+    feed(':hi ErrorMsg<cr>')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={
+      {content = {{"\nErrorMsg      " }, {"xxx", 2}, {" "},
+                  {"ctermfg=", 5 }, { "15 " }, { "ctermbg=", 5 }, { "1 " },
+                  {"guifg=", 5 }, { "White " }, { "guibg=", 5 }, { "Red" }},
+       kind = ""}
     }}
   end)
 
@@ -786,6 +803,7 @@ describe('ui/builtin messages', function()
       [2] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [3] = {bold = true, reverse = true},
       [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+      [5] = {foreground = Screen.colors.Blue1},
     })
   end)
 
@@ -805,6 +823,38 @@ describe('ui/builtin messages', function()
         set_method_error("complete\nerror\n\nmessage")
       end
     end}
+  end)
+
+  it(':hi Group output', function()
+    screen:try_resize(70,7)
+    feed(':hi ErrorMsg<cr>')
+    screen:expect([[
+                                                                            |
+      {1:~                                                                     }|
+      {1:~                                                                     }|
+      {3:                                                                      }|
+      :hi ErrorMsg                                                          |
+      ErrorMsg       {2:xxx} {5:ctermfg=}15 {5:ctermbg=}1 {5:guifg=}White {5:guibg=}Red         |
+      {4:Press ENTER or type command to continue}^                               |
+    ]])
+
+    feed('<cr>')
+    screen:try_resize(30,7)
+    feed(':hi ErrorMsg<cr>')
+    screen:expect([[
+      :hi ErrorMsg                  |
+      ErrorMsg       {2:xxx} {5:ctermfg=}15 |
+                         {5:ctermbg=}1  |
+                         {5:guifg=}White|
+                         {5:guibg=}Red  |
+      {4:Press ENTER or type command to}|
+      {4: continue}^                     |
+    ]])
+    feed('<cr>')
+
+    -- screen size doesn't affect internal output #10285
+    eq('ErrorMsg       xxx ctermfg=15 ctermbg=1 guifg=White guibg=Red',
+       meths.command_output("hi ErrorMsg"))
   end)
 end)
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1194,6 +1194,10 @@ function Screen:render(headers, attr_state, preview)
   return rv
 end
 
+local remove_all_metatables = function(item, path)
+  if path[#path] ~= inspect.METATABLE then return item end
+end
+
 function Screen:print_snapshot(attrs, ignore)
   attrs = attrs or self._default_attr_ids
   if ignore == nil then
@@ -1247,8 +1251,8 @@ function Screen:print_snapshot(attrs, ignore)
   io.stdout:write( "]]"..attrstr)
   for _, k in ipairs(ext_keys) do
     if ext_state[k] ~= nil then
-      -- TODO(bfredl): improve formating, remove ext metatables
-      io.stdout:write(", "..k.."="..inspect(ext_state[k]))
+      -- TODO(bfredl): improve formatting
+      io.stdout:write(", "..k.."="..inspect(ext_state[k],{process=remove_all_metatables}))
     end
   end
   print((keys and "}" or ")").."\n")


### PR DESCRIPTION
ext_message doesn't set `msg_col`, so add a space and let client deal with wrapping. When using silent redirect show the unwrapped message form.

fixes #10285 