### PR TITLE
tests: fix "api nvim_get_proc_children returns child process ids"

### DIFF
--- a/test/functional/api/proc_spec.lua
+++ b/test/functional/api/proc_spec.lua
@@ -17,24 +17,28 @@ describe('api', function()
     it('returns child process ids', function()
       local this_pid = funcs.getpid()
 
+      -- Might be non-zero already (left-over from some other test?),
+      -- but this is not what is tested here.
+      local initial_childs = request('nvim_get_proc_children', this_pid)
+
       local job1 = funcs.jobstart(nvim_argv)
       retry(nil, nil, function()
-        eq(1, #request('nvim_get_proc_children', this_pid))
+        eq(#initial_childs + 1, #request('nvim_get_proc_children', this_pid))
       end)
 
       local job2 = funcs.jobstart(nvim_argv)
       retry(nil, nil, function()
-        eq(2, #request('nvim_get_proc_children', this_pid))
+        eq(#initial_childs + 2, #request('nvim_get_proc_children', this_pid))
       end)
 
       funcs.jobstop(job1)
       retry(nil, nil, function()
-        eq(1, #request('nvim_get_proc_children', this_pid))
+        eq(#initial_childs + 1, #request('nvim_get_proc_children', this_pid))
       end)
 
       funcs.jobstop(job2)
       retry(nil, nil, function()
-        eq(0, #request('nvim_get_proc_children', this_pid))
+        eq(#initial_childs, #request('nvim_get_proc_children', this_pid))
       end)
     end)
 


### PR DESCRIPTION
There might be an existing job already - maybe due to some other test,
but in this case there was only one failure in the test run.

```
[----------] Running tests from C:/projects/neovim/test/functional\api\proc_spec.lua
  [ RUN      ] api nvim_get_proc_children returns child process ids: ERR
  test\functional\helpers.lua:392:
  retry() attempts: 450
  C:/projects/neovim/test/functional\api\proc_spec.lua:22: Expected objects to be the same.
  Passed in:
  (number) 2
  Expected:
  (number) 1

  stack traceback:
  	test\functional\helpers.lua:392: in function 'retry'
  	C:/projects/neovim/test/functional\api\proc_spec.lua:21: in function <C:/projects/neovim/test/functional\api\proc_spec.lua:17>
```

https://ci.appveyor.com/project/neovim/neovim/builds/25461215/job/8ns204v6091iy9rs?fullLog=true#L2672