### PR TITLE
build: luarocks: fall back to luajit

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -61,6 +61,15 @@ if(UNIX OR (MINGW AND CMAKE_CROSSCOMPILING))
   elseif(USE_BUNDLED_LUA)
     list(APPEND LUAROCKS_OPTS
       --with-lua=${HOSTDEPS_INSTALL_DIR})
+  else()
+    list(APPEND CMAKE_MODULE_PATH "../cmake")
+    find_package(LuaJit)
+    if(LUAJIT_FOUND)
+      list(APPEND LUAROCKS_OPTS
+        --lua-version=5.1
+        --with-lua-include=${LUAJIT_INCLUDE_DIRS}
+        --lua-suffix=jit)
+    endif()
   endif()
 
   BuildLuarocks(


### PR DESCRIPTION
This regressed in 204ec6337.

Currently it would detect/use lua5.3 from the system, but in general
luajit is / should be preferred.

Noticed this due to nvim-client failing to build with Lua 5.3
(https://github.com/neovim/lua-client/pull/43).