### PR TITLE
tests: busted: do not use "--lua"

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -44,7 +44,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{TMPDIR})
 set(ENV{SYSTEM_NAME} ${SYSTEM_NAME})
 execute_process(
   COMMAND ${BUSTED_PRG} -v -o ${BUSTED_OUTPUT_TYPE}
-    --lua=${LUA_PRG} --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
+    --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua
     --lpath=${WORKING_DIR}/runtime/lua/?.lua
     --lpath=?.lua


### PR DESCRIPTION
The feature is very rudimentary [1], and causes problems when not using
bundled deps, where it might then fail to find `busted.runner` due to
this.

E.g. with "-DUSE_BUNDLED=OFF -DUSE_BUNDLED_LUAROCKS=ON":
`.deps/usr/bin/busted` contains `exec '/usr/bin/luajit' -e …`, i.e. it
run luajit with adjusted lpath etc.
But using `--lua /usr/bin/luajit` then causes this `busted` wrapper to
be replaced with just `/usr/bin/luajit`, i.e. it is missing the adjusted
lpath then.

1: https://github.com/Olivine-Labs/busted/commit/9eb6c9cf93bc558a2398c822b896990e48bd69fd