### PR TITLE
getchar: Handle incomplete <Paste> in typeahead buffer

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1936,7 +1936,8 @@ static int vgetorpeek(int advance)
           }
 
           if ((mp == NULL || max_mlen >= mp_match_len)
-              && keylen != KEYLEN_PART_MAP) {
+              && keylen != KEYLEN_PART_MAP
+              && !(keylen == KEYLEN_PART_KEY && c1 == ui_toggle[0])) {
             // No matching mapping found or found a non-matching mapping that
             // matches at least what the matching mapping matched
             keylen = 0;

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -182,6 +182,21 @@ describe('TUI', function()
     ]])
   end)
 
+  it('handles pasting a specific amount of text', function()
+    -- Need extra time for this test, specially in ASAN.
+    screen.timeout = 60000
+    feed_data('i\027[200~'..string.rep('z', 64)..'\027[201~')
+    screen:expect([[
+      zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz|
+      zzzzzzzzzzzzzz{1: }                                   |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name] [+]                                     }|
+      {3:-- INSERT --}                                      |
+      {3:-- TERMINAL --}                                    |
+    ]])
+  end)
+
   it('can handle arbitrarily long bursts of input', function()
     -- Need extra time for this test, specially in ASAN.
     screen.timeout = 60000


### PR DESCRIPTION
`<Paste>` is a 3-byte sequence and the beginning one or two bytes can appear at
the very end of the typeahead buffer. When this happens, we were exiting from
`vgetorpeek()` instead of reading more characters to see the complete sequence.

I think this should fix #7994 -- at least partially. Before this change, when I
paste exactly 64 characters into a freshly booted instance, I get what I pasted
plus the literal text `<Paste>` at the end. Nvim also stays in nopaste mode.
The attached test case fails in this manner without the code change.

Fix #7994