### PR TITLE
build: luajit: do not disable jit

### DIFF
--- a/third-party/cmake/BuildLuajit.cmake
+++ b/third-party/cmake/BuildLuajit.cmake
@@ -41,7 +41,6 @@ else()
   set(AMD64_ABI "")
 endif()
 set(INSTALLCMD_UNIX ${MAKE_PRG} CFLAGS=-fPIC
-                                CFLAGS+=-DLUAJIT_DISABLE_JIT
                                 CFLAGS+=-DLUA_USE_APICHECK
                                 CFLAGS+=-DLUA_USE_ASSERT
                                 ${AMD64_ABI}
@@ -94,7 +93,6 @@ elseif(MINGW)
   endif()
   BuildLuaJit(BUILD_COMMAND ${LUAJIT_MAKE_PRG} CC=${DEPS_C_COMPILER}
                                 PREFIX=${DEPS_INSTALL_DIR}
-                                CFLAGS+=-DLUAJIT_DISABLE_JIT
                                 CFLAGS+=-DLUA_USE_APICHECK
                                 CFLAGS+=-DLUA_USE_ASSERT
                                 CCDEBUG+=-g


### PR DESCRIPTION
This was added in 4c92a0bac to help with debugging, but could also have been
just moved there instead of disabling it manually (which was done due to
issues on Travis with OSX).

Since the JIT is the main feature of luajit, we should not disable it,
especially not during compile time.

/cc @tarruda 