### PR TITLE
build: use main cmake modules with third-party

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -6,7 +6,7 @@ project(NVIM_DEPS)
 include(CheckCCompilerFlag)
 
 # Point CMake at any custom modules we may ship
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${PROJECT_SOURCE_DIR}/../cmake")
 
 # In Windows/MSVC CMAKE_BUILD_TYPE changes the paths/linking of the build
 # recipes (libuv, msgpack), make sure it is set

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -59,7 +59,6 @@ if(UNIX OR (MINGW AND CMAKE_CROSSCOMPILING))
     list(APPEND LUAROCKS_OPTS
       --with-lua=${HOSTDEPS_INSTALL_DIR})
   else()
-    list(APPEND CMAKE_MODULE_PATH "../cmake")
     find_package(LuaJit)
     if(LUAJIT_FOUND)
       list(APPEND LUAROCKS_OPTS


### PR DESCRIPTION
This is meant to make it possible to use `find_package(LuaJit)` etc with
the third-party CMake project in general.

Followup to https://github.com/neovim/neovim/pull/10297/files#r296439576.