### PR TITLE
ci: nvim-deps: use `cp -a`

### DIFF
--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -34,8 +34,8 @@ build_deps() {
     export CCACHE_RECACHE=1
   elif test -f "${CACHE_MARKER}" ; then
     echo "Using third-party dependencies from Travis cache (last update: $(_stat "${CACHE_MARKER}"))."
-    cp -r "${HOME}/.cache/nvim-deps"/. "${DEPS_BUILD_DIR}"
-    cp -r "${HOME}/.cache/nvim-deps-downloads"/. "${DEPS_DOWNLOAD_DIR}"
+    cp -a "${HOME}/.cache/nvim-deps"/. "${DEPS_BUILD_DIR}"
+    cp -a "${HOME}/.cache/nvim-deps-downloads"/. "${DEPS_DOWNLOAD_DIR}"
   fi
 
   # Even if we're using cached dependencies, run CMake and make to


### PR DESCRIPTION
Symlinks should be preserved.

Ref: https://github.com/neovim/neovim/pull/10319#issuecomment-505410132