### PR TITLE
build: Makefile: fix distclean  [ci skip]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,9 @@ clean:
 	$(MAKE) -C src/nvim/testdir clean
 	$(MAKE) -C runtime/doc clean
 
-distclean: clean
+distclean:
 	rm -rf $(DEPS_BUILD_DIR) build
+	$(MAKE) clean
 
 install: | nvim
 	+$(BUILD_CMD) -C build install


### PR DESCRIPTION
Do not run CMake in build before deleting it unnecessarily:

    % make distclean
    test -d build && ninja -C build clean || true
    ninja: Entering directory `build'
    [0/1] Re-running CMake...