### PR TITLE
eval/api: don't allow the API to be called in the sandbox

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6669,6 +6669,10 @@ static void float_op_wrapper(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
 static void api_wrapper(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
+  if (check_restricted() || check_secure()) {
+    return;
+  }
+
   ApiDispatchWrapper fn = (ApiDispatchWrapper)fptr;
 
   Array args = ARRAY_DICT_INIT;

--- a/test/functional/eval/api_functions_spec.lua
+++ b/test/functional/eval/api_functions_spec.lua
@@ -4,7 +4,8 @@ local lfs = require('lfs')
 local neq, eq, command = helpers.neq, helpers.eq, helpers.command
 local clear, curbufmeths = helpers.clear, helpers.curbufmeths
 local exc_exec, expect, eval = helpers.exc_exec, helpers.expect, helpers.eval
-local insert = helpers.insert
+local insert, meth_pcall = helpers.insert, helpers.meth_pcall
+local meths = helpers.meths
 
 describe('eval-API', function()
   before_each(clear)
@@ -144,5 +145,11 @@ describe('eval-API', function()
                                               |
     ]])
     screen:detach()
+  end)
+
+  it('cannot be called from sandbox', function()
+    eq({false, 'Vim(call):E48: Not allowed in sandbox'},
+       meth_pcall(command, "sandbox call nvim_input('ievil')"))
+    eq({''}, meths.buf_get_lines(0, 0, -1, true))
   end)
 end)


### PR DESCRIPTION
Identifying and maintaining a "secure" subset of the API would be too much busywork. So just disable the entire thing.

Ref https://github.com/neovim/neovim/issues/10130#issuecomment-499440088