### PR TITLE
cmdline: remove invalid cmdline_show event when aborting mapping

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1978,6 +1978,7 @@ static int command_line_changed(CommandLineState *s)
 static void abandon_cmdline(void)
 {
   XFREE_CLEAR(ccline.cmdbuff);
+  ccline.redraw_state = kCmdRedrawNone;
   if (msg_scrolled == 0) {
     compute_cmdrow();
   }

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -761,7 +761,41 @@ local function test_cmdline(linegrid)
     }}, wildmenu_items=expected, wildmenu_pos=0}
   end)
 
+  it("doesn't send invalid events when aborting mapping #10000", function()
+    command('cnoremap ab c')
+
+    feed(':xa')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+                               |
+    ]], cmdline={{
+      content = { { "x" } },
+      firstc = ":",
+      pos = 1,
+      special = { "a", false }
+    }}}
+
+    -- This used to send an invalid event where pos where larger than the total
+    -- lenght of content. Checked in _handle_cmdline_show.
+    feed('<esc>')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+                               |
+    ]])
+  end)
+
 end
+
+-- the representation of cmdline and cmdline_block contents changed with ext_linegrid
+-- (which uses indexed highlights) so make sure to test both
+describe('ui/ext_cmdline', function() test_cmdline(true) end)
+describe('ui/ext_cmdline (legacy highlights)', function() test_cmdline(false) end)
 
 describe('cmdline redraw', function()
   local screen
@@ -813,8 +847,3 @@ describe('cmdline redraw', function()
     ]], unchanged=true}
   end)
 end)
-
--- the representation of cmdline and cmdline_block contents changed with ext_linegrid
--- (which uses indexed highlights) so make sure to test both
-describe('ui/ext_cmdline', function() test_cmdline(true) end)
-describe('ui/ext_cmdline (legacy highlights)', function() test_cmdline(false) end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -946,6 +946,14 @@ function Screen:_handle_cmdline_show(content, pos, firstc, prompt, indent, level
   if firstc == '' then firstc = nil end
   if prompt == '' then prompt = nil end
   if indent == 0 then indent = nil end
+
+  -- check position is valid #10000
+  local len = 0
+  for _, chunk in ipairs(content) do
+    len = len + string.len(chunk[2])
+  end
+  assert(pos <= len)
+
   self.cmdline[level] = {content=content, pos=pos, firstc=firstc,
                          prompt=prompt, indent=indent}
 end


### PR DESCRIPTION
fixes #10000.