### PR TITLE
Makefile: revisit/improve checkprefix handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ checkprefix:
 	@if [ -f build/.ran-cmake ]; then \
 	  cached_prefix=$(shell $(CMAKE_PRG) -L -N build | 2>/dev/null grep 'CMAKE_INSTALL_PREFIX' | cut -d '=' -f2); \
 	  if ! [ "$(CMAKE_INSTALL_PREFIX)" = "$$cached_prefix" ]; then \
-	    echo "Re-running CMake for changed CMAKE_INSTALL_PREFIX."; \
+	    printf "CMAKE_INSTALL_PREFIX '$(CMAKE_INSTALL_PREFIX)' does not match cached value '%s' - re-running CMake.\n" "$$cached_prefix"; \
 	    $(RM) build/.ran-cmake; \
 	  fi \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ checkprefix:
 	@if [ -f build/.ran-cmake ]; then \
 	  cached_prefix=$(shell $(CMAKE_PRG) -L -N build | 2>/dev/null grep 'CMAKE_INSTALL_PREFIX' | cut -d '=' -f2); \
 	  if ! [ "$(CMAKE_INSTALL_PREFIX)" = "$$cached_prefix" ]; then \
-			echo "Re-running CMake for changed CMAKE_INSTALL_PREFIX."; \
+	    echo "Re-running CMake for changed CMAKE_INSTALL_PREFIX."; \
 	    $(RM) build/.ran-cmake; \
 	  fi \
 	fi
@@ -161,7 +161,7 @@ distclean:
 	rm -rf $(DEPS_BUILD_DIR) build
 	$(MAKE) clean
 
-install: checkprefix build/.ran-cmake nvim
+install: checkprefix nvim
 	+$(BUILD_CMD) -C build install
 
 clint: build/.ran-cmake

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ CMAKE_EXTRA_FLAGS ?=
 # CMAKE_INSTALL_PREFIX
 #   - May be passed directly or as part of CMAKE_EXTRA_FLAGS.
 #   - `checkprefix` target checks that it matches the CMake-cached value. #9615
-ifeq (,$(CMAKE_EXTRA_FLAGS))
-CMAKE_INSTALL_PREFIX ?=
-else
+ifneq (,$(CMAKE_EXTRA_FLAGS))
 CMAKE_INSTALL_PREFIX ?= $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
 endif

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ checkprefix:
 	@if [ -f build/.ran-cmake ]; then \
 	  cached_prefix=$(shell $(CMAKE_PRG) -L -N build | 2>/dev/null grep 'CMAKE_INSTALL_PREFIX' | cut -d '=' -f2); \
 	  if ! [ "$(CMAKE_INSTALL_PREFIX)" = "$$cached_prefix" ]; then \
-	    printf "CMAKE_INSTALL_PREFIX '$(CMAKE_INSTALL_PREFIX)' does not match cached value '%s' - re-running CMake.\n" "$$cached_prefix"; \
+	    printf "Re-running CMake: CMAKE_INSTALL_PREFIX '$(CMAKE_INSTALL_PREFIX)' does not match cached value '%s'.\n" "$$cached_prefix"; \
 	    $(RM) build/.ran-cmake; \
 	  fi \
 	fi


### PR DESCRIPTION
Main improvement: do not error out, but re-run CMake in case
CMAKE_INSTALL_PREFIX changed, and only check it for "install".

- only look at CMAKE_EXTRA_FLAGS via shell if not empty
- add CMAKE_INSTALL_PREFIX to CMAKE_EXTRA_FLAGS (not CMAKE_FLAGS), to
  override it being set in CMAKE_EXTRA_FLAGS from local.mk
- use an empty "checkprefix" target if CMAKE_INSTALL_PREFIX is not
  provided
- skip checking of cached value without build/.ran-cmake; it will be run
  then anyway
- only use it with "install" target; it is only relevant there
- do not error, but re-run CMake (by removing the stamp file)

Ref: https://github.com/neovim/neovim/issues/9615
Ref: https://github.com/neovim/neovim/pull/9621

TEST: `make USE_BUNDLED=0 install CMAKE_INSTALL_PREFIX=/tmp/neovim`