### PR TITLE
fileio.c: eliminate set_file_time()

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -32,7 +32,6 @@ if(NOT HAVE_SYS_WAIT_H AND UNIX)
 endif()
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
 check_include_files(termios.h HAVE_TERMIOS_H)
-check_include_files(utime.h HAVE_UTIME_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
 
 # Functions
@@ -53,8 +52,6 @@ check_function_exists(setsid HAVE_SETSID)
 check_function_exists(sigaction HAVE_SIGACTION)
 check_function_exists(strcasecmp HAVE_STRCASECMP)
 check_function_exists(strncasecmp HAVE_STRNCASECMP)
-check_function_exists(utime HAVE_UTIME)
-check_function_exists(utimes HAVE_UTIMES)
 
 # Symbols
 check_symbol_exists(FD_CLOEXEC "fcntl.h" HAVE_FD_CLOEXEC)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -38,9 +38,6 @@
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H
 #cmakedefine HAVE_TERMIOS_H
-#cmakedefine HAVE_UTIME
-#cmakedefine HAVE_UTIME_H
-#cmakedefine HAVE_UTIMES
 #cmakedefine HAVE_WORKING_LIBINTL
 #cmakedefine HAVE_WSL
 #cmakedefine UNIX

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -746,6 +746,22 @@ bool os_path_exists(const char_u *path)
   return os_stat((char *)path, &statbuf) == kLibuvSuccess;
 }
 
+/// Sets file access and modification times.
+///
+/// @see POSIX utime(2)
+///
+/// @param path   File path.
+/// @param atime  Last access time.
+/// @param mtime  Last modification time.
+///
+/// @return 0 on success, or negative error code.
+int os_file_settime(const char *path, double atime, double mtime)
+{
+  int r;
+  RUN_UV_FS_FUNC(r, uv_fs_utime, path, atime, mtime, NULL);
+  return r;
+}
+
 /// Check if a file is readable.
 ///
 /// @return true if `name` is readable, otherwise false.


### PR DESCRIPTION
- Introduce os_file_settime(), remove cruft.
- ~~Set atime/mtime on Windows.~~ In Vim this is only done on Unix (perhaps because ACL covers it? #1200) 
    - Reverted, see https://github.com/neovim/neovim/pull/10357#issuecomment-507008233