### PR TITLE
build: FindLibLUV: use PkgConfig

### DIFF
--- a/cmake/FindLibLUV.cmake
+++ b/cmake/FindLibLUV.cmake
@@ -4,9 +4,15 @@
 #  LIBLUV_INCLUDE_DIRS - The libluv include directories
 #  LIBLUV_LIBRARIES - The libraries needed to use libluv
 
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_LIBTERMKEY QUIET luv)
+endif()
+
+set(LIBLUV_DEFINITIONS ${PC_LIBLUV_CFLAGS_OTHER})
+
 find_path(LIBLUV_INCLUDE_DIR luv/luv.h
-          PATHS ${PC_LIBLUV_INCLUDEDIR} ${PC_LIBLUV_INCLUDE_DIRS}
-          ${LIMIT_SEARCH})
+          PATHS ${PC_LIBLUV_INCLUDEDIR} ${PC_LIBLUV_INCLUDE_DIRS})
 
 # If we're asked to use static linkage, add libluv.a as a preferred library name.
 if(LIBLUV_USE_STATIC)
@@ -17,8 +23,7 @@ endif()
 list(APPEND LIBLUV_NAMES luv)
 
 find_library(LIBLUV_LIBRARY NAMES ${LIBLUV_NAMES}
-  HINTS ${PC_LIBLUV_LIBDIR} ${PC_LIBLUV_LIBRARY_DIRS}
-  ${LIMIT_SEARCH})
+  HINTS ${PC_LIBLUV_LIBDIR} ${PC_LIBLUV_LIBRARY_DIRS})
 
 set(LIBLUV_LIBRARIES ${LIBLUV_LIBRARY})
 set(LIBLUV_INCLUDE_DIRS ${LIBLUV_INCLUDE_DIR})

--- a/cmake/FindLibLUV.cmake
+++ b/cmake/FindLibLUV.cmake
@@ -6,7 +6,7 @@
 
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBTERMKEY QUIET luv)
+  pkg_check_modules(PC_LIBLUV QUIET luv)
 endif()
 
 set(LIBLUV_DEFINITIONS ${PC_LIBLUV_CFLAGS_OTHER})


### PR DESCRIPTION
Apparently forgotten in c83926cd0.

- Also LIMIT_SEARCH was never used.
- Also add LIBLUV_DEFINITIONS, as used with other Find modules.