### PR TITLE
build: cmake: remove usage of old policy for CMP0059

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(nvim C)
 
-if(POLICY CMP0059)
-  # Needed for use of DEFINITIONS variable, which is used to collect the
-  # compilation flags for reporting in "nvim --version"
-  # https://github.com/neovim/neovim/pull/8558#issuecomment-398033140
-  cmake_policy(SET CMP0059 OLD)
-endif()
-
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -273,22 +266,23 @@ int main(void)
 
 if(MSVC)
   # XXX: /W4 gives too many warnings. #3241
-  add_definitions(/W3 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
+  add_compile_options(/W3)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   add_definitions(-DWIN32)
 else()
-  add_definitions(-Wall -Wextra -pedantic -Wno-unused-parameter
+  add_compile_options(-Wall -Wextra -pedantic -Wno-unused-parameter
     -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion
     -Wmissing-prototypes)
 
   check_c_compiler_flag(-Wimplicit-fallthrough HAS_WIMPLICIT_FALLTHROUGH_FLAG)
   if(HAS_WIMPLICIT_FALLTHROUGH_FLAG)
-    add_definitions(-Wimplicit-fallthrough)
+    add_compile_options(-Wimplicit-fallthrough)
   endif()
 
   # On FreeBSD 64 math.h uses unguarded C11 extension, which taints clang
   # 3.4.1 used there.
   if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" AND CMAKE_C_COMPILER_ID MATCHES "Clang")
-    add_definitions(-Wno-c11-extensions)
+    add_compile_options(-Wno-c11-extensions)
   endif()
 endif()
 
@@ -304,7 +298,7 @@ endif()
 # OpenBSD's GCC (4.2.1) doesn't have -Wvla
 check_c_compiler_flag(-Wvla HAS_WVLA_FLAG)
 if(HAS_WVLA_FLAG)
-  add_definitions(-Wvla)
+  add_compile_options(-Wvla)
 endif()
 
 if(UNIX)
@@ -313,15 +307,15 @@ if(UNIX)
   check_c_compiler_flag(-fstack-protector HAS_FSTACK_PROTECTOR_FLAG)
 
   if(HAS_FSTACK_PROTECTOR_STRONG_FLAG)
-    add_definitions(-fstack-protector-strong)
+    add_compile_options(-fstack-protector-strong)
   elseif(HAS_FSTACK_PROTECTOR_FLAG)
-    add_definitions(-fstack-protector --param ssp-buffer-size=4)
+    add_compile_options(-fstack-protector --param ssp-buffer-size=4)
   endif()
 endif()
 
 check_c_compiler_flag(-fdiagnostics-color=auto HAS_DIAG_COLOR_FLAG)
 if(HAS_DIAG_COLOR_FLAG)
-  add_definitions(-fdiagnostics-color=auto)
+  add_compile_options(-fdiagnostics-color=auto)
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
@@ -332,7 +326,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   # So we must disable -Warray-bounds globally for GCC (for kbtree.h, #7083).
   check_c_compiler_flag(-Wno-array-bounds HAS_NO_ARRAY_BOUNDS_FLAG)
   if(HAS_NO_ARRAY_BOUNDS_FLAG)
-    add_definitions(-Wno-array-bounds)
+    add_compile_options(-Wno-array-bounds)
   endif()
 endif()
 
@@ -340,10 +334,10 @@ option(TRAVIS_CI_BUILD "Travis/QuickBuild CI, extra flags will be set" OFF)
 
 if(TRAVIS_CI_BUILD)
   message(STATUS "Travis/QuickBuild CI build enabled")
-  add_definitions(-Werror)
+  add_compile_options(-Werror)
   if(DEFINED ENV{BUILD_32BIT})
     # Get some test coverage for unsigned char
-    add_definitions(-funsigned-char)
+    add_compile_options(-funsigned-char)
   endif()
 endif()
 

--- a/cmake/GetCompileFlags.cmake
+++ b/cmake/GetCompileFlags.cmake
@@ -1,6 +1,6 @@
 function(get_compile_flags _compile_flags)
   # Create template akin to CMAKE_C_COMPILE_OBJECT.
-  set(compile_flags "<CMAKE_C_COMPILER> <CFLAGS> <BUILD_TYPE_CFLAGS> <DEFINITIONS> <INCLUDES>")
+  set(compile_flags "<CMAKE_C_COMPILER> <CFLAGS> <BUILD_TYPE_CFLAGS> <COMPILE_OPTIONS> <COMPILE_DEFINITIONS> <INCLUDES>")
 
   # Get C compiler.
   string(REPLACE
@@ -9,13 +9,28 @@ function(get_compile_flags _compile_flags)
     compile_flags
     "${compile_flags}")
 
-  # Get flags set by add_definition().
-  get_directory_property(definitions
+  # Get flags set by add_definitions().
+  get_directory_property(compile_definitions
     DIRECTORY "src/nvim"
-    DEFINITIONS)
+    COMPILE_DEFINITIONS)
+  # NOTE: list(JOIN) requires CMake 3.12.
+  string(REPLACE ";" " -D" compile_definitions "${compile_definitions}")
+  string(CONCAT compile_definitions "-D" "${compile_definitions}")
   string(REPLACE
-    "<DEFINITIONS>"
-    "${definitions}"
+    "<COMPILE_DEFINITIONS>"
+    "${compile_definitions}"
+    compile_flags
+    "${compile_flags}")
+
+  # Get flags set by add_compile_options().
+  get_directory_property(compile_options
+    DIRECTORY "src/nvim"
+    COMPILE_OPTIONS)
+  # NOTE: list(JOIN) requires CMake 3.12.
+  string(REPLACE ";" " " compile_options "${compile_options}")
+  string(REPLACE
+    "<COMPILE_OPTIONS>"
+    "${compile_options}"
     compile_flags
     "${compile_flags}")
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -7,7 +7,7 @@ if(USE_GCOV)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
-  add_compile_definitions(USE_GCOV)
+  add_definitions(-DUSE_GCOV)
 endif()
 endif()
 

--- a/third-party/cmake/LibvtermCMakeLists.txt
+++ b/third-party/cmake/LibvtermCMakeLists.txt
@@ -5,9 +5,10 @@ include(GNUInstallDirs)
 find_package(Perl)
 
 if(MSVC)
-  add_definitions(/W3 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
+  add_compile_options(/W3)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
 else()
-  add_definitions(-Wall -std=c99)
+  add_compile_options(-Wall -std=c99)
 endif()
 
 # Generate includes from tables

--- a/third-party/cmake/libtermkeyCMakeLists.txt
+++ b/third-party/cmake/libtermkeyCMakeLists.txt
@@ -4,7 +4,7 @@ project(libtermkey)
 add_definitions(-D _CRT_SECURE_NO_WARNINGS)
 add_definitions(-DHAVE_UNIBILIUM)
 if(NOT MSVC)
-  add_definitions(-std=c99)
+  add_compile_options(-std=c99)
 endif()
 
 include_directories(${PROJECT_BINARY_DIR}/t)


### PR DESCRIPTION
Keeps using add_definitions for compatibility with older CMake.

Newer CMake (3.12) would have `add_compile_definitions`, but it is not
required, since `add_defitions` was meant to be used for
compile/preprocessor definitions initially anyway.

Ref: https://github.com/neovim/neovim/pull/4389
