### PR TITLE
[RFC] vim-patch:8.0.{755,1146,1164}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3361,7 +3361,6 @@ int build_stl_str_hl(
   char_u      *usefmt = fmt;
   const int save_must_redraw = must_redraw;
   const int save_redr_type = curwin->w_redr_type;
-  const int save_highlight_shcnaged = need_highlight_changed;
 
   // When the format starts with "%!" then evaluate it as an expression and
   // use the result as the actual format string.
@@ -4425,12 +4424,12 @@ int build_stl_str_hl(
     cur_tab_rec->def.func = NULL;
   }
 
-  // We do not want redrawing a stausline, ruler, title, etc. to trigger
-  // another redraw, it may cause an endless loop.  This happens when a
-  // statusline changes a highlight group.
-  must_redraw = save_must_redraw;
-  curwin->w_redr_type = save_redr_type;
-  need_highlight_changed = save_highlight_shcnaged;
+  // When inside update_screen we do not want redrawing a stausline, ruler,
+  // title, etc. to trigger another redraw, it may cause an endless loop.
+  if (updating_screen) {
+    must_redraw = save_must_redraw;
+    curwin->w_redr_type = save_redr_type;
+  }
 
   return width;
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6829,7 +6829,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           }
 
           xfree(HL_TABLE()[idx].sg_rgb_fg_name);
-          if (strcmp(arg, "NONE")) {
+          if (strcmp(arg, "NONE") != 0) {
             HL_TABLE()[idx].sg_rgb_fg_name = (char_u *)xstrdup((char *)arg);
             HL_TABLE()[idx].sg_rgb_fg = name_to_color((const char_u *)arg);
           } else {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6823,18 +6823,22 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           }
         }
       } else if (strcmp(key, "GUIFG") == 0)   {
+        char_u **const namep = &HL_TABLE()[idx].sg_rgb_fg_name;
+
         if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
           if (!init) {
             HL_TABLE()[idx].sg_set |= SG_GUI;
           }
 
-          xfree(HL_TABLE()[idx].sg_rgb_fg_name);
-          if (strcmp(arg, "NONE") != 0) {
-            HL_TABLE()[idx].sg_rgb_fg_name = (char_u *)xstrdup((char *)arg);
-            HL_TABLE()[idx].sg_rgb_fg = name_to_color((const char_u *)arg);
-          } else {
-            HL_TABLE()[idx].sg_rgb_fg_name = NULL;
-            HL_TABLE()[idx].sg_rgb_fg = -1;
+          if (*namep == NULL || STRCMP(*namep, arg) != 0) {
+            xfree(*namep);
+            if (strcmp(arg, "NONE") != 0) {
+              *namep = (char_u *)xstrdup(arg);
+              HL_TABLE()[idx].sg_rgb_fg = name_to_color((char_u *)arg);
+            } else {
+              *namep = NULL;
+              HL_TABLE()[idx].sg_rgb_fg = -1;
+            }
           }
         }
 
@@ -6842,18 +6846,22 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           normal_fg = HL_TABLE()[idx].sg_rgb_fg;
         }
       } else if (STRCMP(key, "GUIBG") == 0)   {
+        char_u **const namep = &HL_TABLE()[idx].sg_rgb_bg_name;
+
         if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
           if (!init) {
             HL_TABLE()[idx].sg_set |= SG_GUI;
           }
 
-          xfree(HL_TABLE()[idx].sg_rgb_bg_name);
-          if (STRCMP(arg, "NONE") != 0) {
-            HL_TABLE()[idx].sg_rgb_bg_name = (char_u *)xstrdup((char *)arg);
-            HL_TABLE()[idx].sg_rgb_bg = name_to_color((const char_u *)arg);
-          } else {
-            HL_TABLE()[idx].sg_rgb_bg_name = NULL;
-            HL_TABLE()[idx].sg_rgb_bg = -1;
+          if (*namep == NULL || STRCMP(*namep, arg) != 0) {
+            xfree(*namep);
+            if (STRCMP(arg, "NONE") != 0) {
+              *namep = (char_u *)xstrdup(arg);
+              HL_TABLE()[idx].sg_rgb_bg = name_to_color((char_u *)arg);
+            } else {
+              *namep = NULL;
+              HL_TABLE()[idx].sg_rgb_bg = -1;
+            }
           }
         }
 
@@ -6861,18 +6869,22 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           normal_bg = HL_TABLE()[idx].sg_rgb_bg;
         }
       } else if (strcmp(key, "GUISP") == 0)   {
+        char_u **const namep = &HL_TABLE()[idx].sg_rgb_sp_name;
+
         if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
           if (!init) {
             HL_TABLE()[idx].sg_set |= SG_GUI;
           }
 
-          xfree(HL_TABLE()[idx].sg_rgb_sp_name);
-          if (strcmp(arg, "NONE") != 0) {
-            HL_TABLE()[idx].sg_rgb_sp_name = (char_u *)xstrdup((char *)arg);
-            HL_TABLE()[idx].sg_rgb_sp = name_to_color((const char_u *)arg);
-          } else {
-            HL_TABLE()[idx].sg_rgb_sp_name = NULL;
-            HL_TABLE()[idx].sg_rgb_sp = -1;
+          if (*namep == NULL || STRCMP(*namep, arg) != 0) {
+            xfree(*namep);
+            if (strcmp(arg, "NONE") != 0) {
+              *namep = (char_u *)xstrdup(arg);
+              HL_TABLE()[idx].sg_rgb_sp = name_to_color((char_u *)arg);
+            } else {
+              *namep = NULL;
+              HL_TABLE()[idx].sg_rgb_sp = -1;
+            }
           }
         }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6467,6 +6467,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   int id;
   int idx;
   struct hl_group item_before;
+  bool did_change = false;
   bool dodefault = false;
   bool doclear = false;
   bool dolink = false;
@@ -6839,6 +6840,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
               *namep = NULL;
               HL_TABLE()[idx].sg_rgb_fg = -1;
             }
+            did_change = true;
           }
         }
 
@@ -6862,6 +6864,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
               *namep = NULL;
               HL_TABLE()[idx].sg_rgb_bg = -1;
             }
+            did_change = true;
           }
         }
 
@@ -6885,6 +6888,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
               *namep = NULL;
               HL_TABLE()[idx].sg_rgb_sp = -1;
             }
+            did_change = true;
           }
         }
 
@@ -6946,9 +6950,15 @@ void do_highlight(const char *line, const bool forceit, const bool init)
 
   // Only call highlight_changed() once, after a sequence of highlight
   // commands, and only if an attribute actually changed
-  if (memcmp(&HL_TABLE()[idx], &item_before, sizeof(item_before)) != 0
+  if ((did_change
+       || memcmp(&HL_TABLE()[idx], &item_before, sizeof(item_before)) != 0)
       && !did_highlight_changed) {
-    redraw_all_later(NOT_VALID);
+    // Do not trigger a redraw when highlighting is changed while
+    // redrawing.  This may happen when evaluating 'statusline' changes the
+    // StatusLine group.
+    if (!updating_screen) {
+      redraw_all_later(NOT_VALID);
+    }
     need_highlight_changed = true;
   }
 }


### PR DESCRIPTION
~~I omitted changes for gui code. Seems applicable for termguicolors but I don't know what to do.~~

8.0.0755 was marked N/A but it has a relevant `syntax.c` change to match the other `GUI*` color checks.