### PR TITLE
:ls : show "R", "F" for terminal-jobs

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -29,6 +29,7 @@
 #include "nvim/api/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/assert.h"
+#include "nvim/channel.h"
 #include "nvim/vim.h"
 #include "nvim/buffer.h"
 #include "nvim/charset.h"
@@ -2608,9 +2609,10 @@ void buflist_list(exarg_T *eap)
     const int changed_char = (buf->b_flags & BF_READERR)
       ? 'x'
       : (bufIsChanged(buf) ? '+' : ' ');
-    const int ro_char = !MODIFIABLE(buf)
-      ? '-'
-      : (buf->b_p_ro ? '=' : ' ');
+    int ro_char = !MODIFIABLE(buf) ? '-' : (buf->b_p_ro ? '=' : ' ');
+    if (buf->terminal) {
+      ro_char = channel_job_running((uint64_t)buf->b_p_channel) ? 'R' : 'F';
+    }
 
     msg_putchar('\n');
     len = vim_snprintf(

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -762,6 +762,14 @@ static void set_info_event(void **argv)
   channel_decref(chan);
 }
 
+bool channel_job_running(uint64_t id)
+{
+  Channel *chan = find_channel(id);
+  return (chan
+          && chan->streamtype == kChannelStreamProc
+          && !process_is_stopped(&chan->stream.proc));
+}
+
 Dictionary channel_info(uint64_t id)
 {
   Channel *chan = find_channel(id);

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -56,7 +56,8 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
 
 static inline bool process_is_stopped(Process *proc)
 {
-  return proc->stopped_time != 0;
+  bool exited = (proc->status >= 0);
+  return exited || (proc->stopped_time != 0);
 }
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/test/functional/ex_cmds/ls_spec.lua
+++ b/test/functional/ex_cmds/ls_spec.lua
@@ -1,0 +1,33 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
+local retry = helpers.retry
+
+describe(':ls', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('R, F for :terminal buffers', function()
+    command('edit foo')
+    command('set hidden')
+    command('terminal')
+    command('vsplit')
+    command('terminal')
+    feed('iexit<cr>')
+    retry(nil, 5000, function()
+      local ls_output = eval('execute("ls")')
+      -- Normal buffer.
+      eq('\n  1  h ', string.match(ls_output, '\n *1....'))
+      -- Terminal buffer [R]unning.
+      eq('\n  2 #aR', string.match(ls_output, '\n *2....'))
+      -- Terminal buffer [F]inished.
+      eq('\n  3 %aF', string.match(ls_output, '\n *3....'))
+    end)
+  end)
+
+end)
+


### PR DESCRIPTION
Followup https://github.com/neovim/neovim/pull/10349#discussion_r298347129 cc @janlazo .

---

This matches Vim behavior. From `:help :ls` :

    R    a terminal buffer with a running job
    F    a terminal buffer with a finished job
    ?    a terminal buffer without a job: `:terminal NONE`

TODO (future): implement `:terminal NONE` (or `:terminal ++none` ?).

ref #10349