### PR TITLE
Makefile: CMAKE_INSTALL_PREFIX: skip parsing CMAKE_EXTRA_FLAGS if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,9 @@ CMAKE_EXTRA_FLAGS ?=
 # CMAKE_INSTALL_PREFIX
 #   - May be passed directly or as part of CMAKE_EXTRA_FLAGS.
 #   - `checkprefix` target checks that it matches the CMake-cached value. #9615
-ifneq (,$(CMAKE_INSTALL_PREFIX))
-ifneq (,$(CMAKE_EXTRA_FLAGS))
+ifneq (,$(CMAKE_INSTALL_PREFIX)$(CMAKE_EXTRA_FLAGS))
 CMAKE_INSTALL_PREFIX := $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
-endif
 endif
 ifneq (,$(CMAKE_INSTALL_PREFIX))
 CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,14 @@ CMAKE_EXTRA_FLAGS ?=
 # CMAKE_INSTALL_PREFIX
 #   - May be passed directly or as part of CMAKE_EXTRA_FLAGS.
 #   - `checkprefix` target checks that it matches the CMake-cached value. #9615
+ifneq (,$(CMAKE_INSTALL_PREFIX))
 ifneq (,$(CMAKE_EXTRA_FLAGS))
 CMAKE_INSTALL_PREFIX ?= $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
 endif
+endif
 ifneq (,$(CMAKE_INSTALL_PREFIX))
-  CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
+CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
 
 checkprefix:
 	@if [ -f build/.ran-cmake ]; then \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CMAKE_EXTRA_FLAGS ?=
 #   - `checkprefix` target checks that it matches the CMake-cached value. #9615
 ifneq (,$(CMAKE_INSTALL_PREFIX))
 ifneq (,$(CMAKE_EXTRA_FLAGS))
-CMAKE_INSTALL_PREFIX ?= $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
+CMAKE_INSTALL_PREFIX := $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
 endif
 endif


### PR DESCRIPTION
Fixes:

>  Recursive variable 'CMAKE_EXTRA_FLAGS' references itself (eventually).  Stop.

This will not use it with the following, when CMAKE_INSTALL_PREFIX is
defined in local.mk already, which is fair:

> make install CMAKE_EXTRA_FLAGS+="-DCMAKE_INSTALL_PREFIX=/tmp/foo"

Ref: https://github.com/neovim/neovim/pull/10348