### PR TITLE
build: LibLUV: update required version  [ci skip]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,7 +379,7 @@ include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 find_package(Msgpack 1.0.0 REQUIRED)
 include_directories(SYSTEM ${MSGPACK_INCLUDE_DIRS})
 
-find_package(LibLUV 1.29.1 REQUIRED)
+find_package(LibLUV 1.30.0 REQUIRED)
 include_directories(SYSTEM ${LIBLUV_INCLUDE_DIRS})
 
 # Note: The test lib requires LuaJIT; it will be skipped if LuaJIT is missing.


### PR DESCRIPTION
Required after d33aaa0f5.

Does not really make a difference, since the VERSION is not handled with
our FindLibLUV (due to missing pkg-config information
(https://github.com/luvit/luv/issues/354)).