### PR TITLE
defaults: wildoptions=pum,tagfile

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6653,17 +6653,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	More info here: |cmdline-completion|.
 
 						*'wildoptions'* *'wop'*
-'wildoptions' 'wop'	string	(default "")
+'wildoptions' 'wop'	string	(default "pum,tagfile")
 			global
-	A list of words that change how command line completion is done.
+	List of words that change how |cmdline-completion| is done.
+	  pum		Display the completion matches using the popupmenu
+			in the same style as the |ins-completion-menu|.
 	  tagfile	When using CTRL-D to list matching tags, the kind of
 			tag and the file of the tag is listed.	Only one match
 			is displayed per line.  Often used tag kinds are:
 				d	#define
 				f	function
-	  pum		Display the completion matches using the popupmenu
-			in the same style as the |ins-completion-menu|.
-	Also see |cmdline-completion|.
 
 						*'winaltkeys'* *'wak'*
 'winaltkeys' 'wak'	string	(default "menu")

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -26,13 +26,14 @@ the differences.
 - Syntax highlighting is enabled by default
 - ":filetype plugin indent on" is enabled by default
 
-- 'autoindent' is set by default
-- 'autoread' is set by default
-- 'background' always defaults to "dark"
+- 'autoindent' is enabled
+- 'autoread' is enabled
+- 'background' defaults to "dark" (unless set automatically by the terminal/UI)
 - 'backspace' defaults to "indent,eol,start"
 - 'backupdir' defaults to .,~/.local/share/nvim/backup (|xdg|)
 - 'belloff' defaults to "all"
-- 'complete' doesn't include "i"
+- 'compatible' is always disabled
+- 'complete' excludes "i"
 - 'cscopeverbose' is enabled
 - 'directory' defaults to ~/.local/share/nvim/swap// (|xdg|), auto-created
 - 'display' defaults to "lastline,msgsep"
@@ -41,27 +42,27 @@ the differences.
 - 'formatoptions' defaults to "tcqj"
 - 'fsync' is disabled
 - 'history' defaults to 10000 (the maximum)
-- 'hlsearch' is set by default
-- 'incsearch' is set by default
-- 'langnoremap' is enabled by default
-- 'langremap' is disabled by default
+- 'hlsearch' is enabled
+- 'incsearch' is enabled
+- 'langnoremap' is enabled
+- 'langremap' is disabled
 - 'laststatus' defaults to 2 (statusline is always shown)
 - 'listchars' defaults to "tab:> ,trail:-,nbsp:+"
-- 'nocompatible' is always set
 - 'nrformats' defaults to "bin,hex"
-- 'ruler' is set by default
-- 'sessionoptions' doesn't include "options"
+- 'ruler' is enabled
+- 'sessionoptions' excludes "options"
 - 'shortmess' includes "F", excludes "S"
-- 'showcmd' is set by default
+- 'showcmd' is enabled
 - 'sidescroll' defaults to 1
-- 'smarttab' is set by default
+- 'smarttab' is enabled
 - 'tabpagemax' defaults to 50
 - 'tags' defaults to "./tags;,tags"
 - 'ttimeoutlen' defaults to 50
 - 'ttyfast' is always set
 - 'undodir' defaults to ~/.local/share/nvim/undo (|xdg|), auto-created
 - 'viminfo' includes "!"
-- 'wildmenu' is set by default
+- 'wildmenu' is enabled
+- 'wildoptions' defaults to "pum,tagfile"
 
 ==============================================================================
 3. New Features						       *nvim-features*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2177,10 +2177,8 @@ static char_u *option_expand(int opt_idx, char_u *val)
   return NameBuff;
 }
 
-/*
- * After setting various option values: recompute variables that depend on
- * option values.
- */
+// After setting various option values: recompute variables that depend on
+// option values.
 static void didset_options(void)
 {
   // initialize the table for 'iskeyword' et.al.
@@ -2195,6 +2193,7 @@ static void didset_options(void)
   (void)opt_strings_flags(p_dy, p_dy_values, &dy_flags, true);
   (void)opt_strings_flags(p_tc, p_tc_values, &tc_flags, false);
   (void)opt_strings_flags(p_ve, p_ve_values, &ve_flags, true);
+  (void)opt_strings_flags(p_wop, p_wop_values, &wop_flags, true);
   (void)spell_check_msm();
   (void)spell_check_sps();
   (void)compile_cap_prog(curwin->w_s);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2752,7 +2752,7 @@ return {
       deny_duplicates=true,
       vi_def=true,
       varname='p_wop',
-      defaults={if_true={vi=""}}
+      defaults={if_true={vi='', vim='pum,tagfile'}}
     },
     {
       full_name='winaltkeys', abbreviation='wak',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2750,7 +2750,7 @@ return {
       full_name='wildoptions', abbreviation='wop',
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
+      vim=true,
       varname='p_wop',
       defaults={if_true={vi='', vim='pum,tagfile'}}
     },

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -7,17 +7,18 @@ endif
 let s:did_load = 1
 
 " Align Nvim defaults to Vim.
-set sidescroll=0
-set directory^=.
-set undodir^=.
 set backspace=
-set nrformats+=octal
-set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
-set listchars=eol:$
+set directory^=.
 set fillchars=vert:\|,fold:-
-set shortmess-=F
 set laststatus=1
+set listchars=eol:$
+set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
+set nrformats+=octal
+set shortmess-=F
+set sidescroll=0
 set tags=./tags,tags
+set undodir^=.
+set wildoptions=
 
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -28,7 +28,7 @@ local nvim_prog = (
 -- Default settings for the test session.
 local nvim_set  = 'set shortmess+=IS background=light noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
-                  ..' belloff= wildoptions= noshowcmd noruler nomore'
+                  ..' belloff= wildoptions-=pum noshowcmd noruler nomore'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE',
                    '--cmd', nvim_set, '--embed'}
 -- Directory containing nvim.

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -28,7 +28,7 @@ local nvim_prog = (
 -- Default settings for the test session.
 local nvim_set  = 'set shortmess+=IS background=light noswapfile noautoindent'
                   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
-                  ..' belloff= noshowcmd noruler nomore'
+                  ..' belloff= wildoptions= noshowcmd noruler nomore'
 local nvim_argv = {nvim_prog, '-u', 'NONE', '-i', 'NONE',
                    '--cmd', nvim_set, '--embed'}
 -- Directory containing nvim.


### PR DESCRIPTION
ref #6289

- `wildoptions+=pum` is glorious and I've been using it for months without issues.
- `wildoptions+=tagfile` is likely not well-known but worth enabling.
    - Vertical layout is easier to scan.
    -  Associated file is useful.
    - If `:tag foo<c-d>` has more matches than the height of your screen, you probably have too many matches...

P.S.: `options.c` is truly atrocious. 🤢 