### PR TITLE
API: introduce Context

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -21,6 +21,7 @@
 #include "nvim/lua/executor.h"
 #include "nvim/vim.h"
 #include "nvim/buffer.h"
+#include "nvim/context.h"
 #include "nvim/file_search.h"
 #include "nvim/highlight.h"
 #include "nvim/window.h"
@@ -1250,6 +1251,25 @@ Dictionary nvim_get_color_map(void)
   return colors;
 }
 
+/// Gets a map of the current editor state.
+///
+/// @param kinds  Context kinds ("reg", "pos", …) to gather, or NIL for all.
+///
+/// @return map of global context
+Dictionary nvim_get_context(Array kinds)
+  FUNC_API_SINCE(6)
+{
+  Context ctx = {
+    .pos = {
+      .lnum = 0,
+      .col = 0,
+      .coladd = 0,
+    },
+    .reg = NULL,
+  };
+  ctx_save(&ctx, kCtxAll);
+  return ctx_to_dict(&ctx);
+}
 
 /// Gets the current mode. |mode()|
 /// "blocking" is true if Nvim is waiting for input.

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -1,0 +1,190 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+// Context: snapshot of the entire editor state as one big object/map:
+//    - editor state (cf. shada.c): registers, variables, ...
+//    - [not implemented] cursor position
+//    - [not implemented] VimL variables (g:, ...?)
+//    - [not implemented] tracking edits (mark_ext.c)
+//    - [not implemented] options?
+
+#include "nvim/os/os.h"
+#include "nvim/api/private/helpers.h"
+#include "nvim/context.h"
+#include "nvim/fileio.h"
+#include "nvim/vim.h"
+#include "nvim/main.h"
+#include "nvim/ops.h"
+#include "nvim/ui.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "context.c.generated.h"
+#endif
+
+int kCtxAll = (kCtxReg | kCtxVimscript | kCtxOptions);
+
+// typedef struct {
+//   char name;
+//   MotionType type;
+//   char **contents;
+//   bool is_unnamed;
+//   size_t contents_size;
+//   size_t width;
+//   dict_T *additional_data;
+// } Reg;
+
+Context last_ctx = {
+  .pos = {
+    .lnum = 0,
+    .col = 0,
+    .coladd = 0,
+  },
+  .reg = NULL,
+};
+
+/// Saves the editor state to a context.
+///
+/// If `context` is NULL, saves to a default internal store.
+/// Use `flags` to select particular types of context.
+///
+/// @param  ctx    Save to this context, or to default store if NULL.
+/// @param  flags  Flags, see ContextTypeFlags enum.
+void ctx_save(Context *ctx, const int flags)
+{
+  if (flags & kCtxReg) {
+    ctx_save_reg(ctx);
+  }
+  // TODO(justinmk)
+  // if (flags & kCtxVimscript) {
+  // }
+  // if (flags & kCtxOptions) {
+  // }
+  // ...
+}
+
+/// Restores the editor state from a context.
+///
+/// If `context` is NULL, restores from the default internal store.
+/// Use `flags` to select particular types of context.
+///
+/// @param  ctx    Save to this context, or to default store if NULL.
+/// @param  flags  Flags, see ContextTypeFlags enum.
+void ctx_restore(Context *ctx, const int flags)
+{
+  if (flags & kCtxReg) {
+    ctx_restore_reg(ctx);
+  }
+  // TODO(justinmk)
+  // if (flags & kCtxVimscript) {
+  // }
+  // if (flags & kCtxOptions) {
+  // }
+  // ...
+}
+
+/// Saves the global registers to a context. If `context` is NULL, saves to
+/// a default internal store.
+///
+/// @param  ctx    Save to this context, or to default store if NULL.
+void ctx_save_reg(Context *ctx)
+{
+  if (ctx == NULL) {
+    ctx = &last_ctx;
+  }
+  if (ctx->reg == NULL) {
+    ctx->reg = xmalloc(NUM_REGISTERS * sizeof(*ctx->reg));
+  }
+  const void *reg_iter = NULL;
+  do {
+    yankreg_T reg;
+    char name = NUL;
+    bool is_unnamed = false;
+    reg_iter = op_global_reg_iter(reg_iter, &name, &reg, &is_unnamed);
+    if (name == NUL) {
+      // TODO(justinmk): when does this happen?
+      break;
+    }
+    ctx->reg[op_reg_index(name)] = copy_register(name);
+  } while (reg_iter != NULL);
+}
+
+/// Restores the global registers from a context.
+///
+/// If `context` is NULL, restores from the default internal store.
+///
+/// @param  ctx   Restore from this context, or from default store if NULL.
+void ctx_restore_reg(Context *ctx)
+{
+  if (ctx == NULL) {
+    ctx = &last_ctx;
+  }
+  assert(ctx->reg != NULL);
+  const void *reg_iter = NULL;
+  // Abuse op_global_reg_iter() because we don't store the register name.
+  // This requires `ctx->reg` to be stored in the same order.
+  do {
+    yankreg_T reg;
+    char name = NUL;
+    bool is_unnamed = false;
+    reg_iter = op_global_reg_iter(reg_iter, &name, &reg, &is_unnamed);
+    if (name == NUL) {
+      // TODO(justinmk): when does this happen?
+      break;
+    }
+
+    yankreg_T *saved_reg = ctx->reg[op_reg_index(name)];
+    if (!op_reg_set(name, *saved_reg, is_unnamed)) {
+      abort();  // failed somehow?
+      // xfree(saved_reg);
+    }
+  } while (reg_iter != NULL);
+}
+
+Dictionary ctx_to_dict(Context *ctx)
+  FUNC_ATTR_NONNULL_ALL
+{
+  assert(ctx != NULL);
+  Dictionary rv = ARRAY_DICT_INIT;
+
+  Dictionary pos_dict = ARRAY_DICT_INIT;
+  PUT(pos_dict, "lnum", INTEGER_OBJ(ctx->pos.lnum));
+  PUT(pos_dict, "col", INTEGER_OBJ(ctx->pos.col));
+  PUT(pos_dict, "coladd", INTEGER_OBJ(ctx->pos.coladd));
+  PUT(rv, "pos", DICTIONARY_OBJ(pos_dict));
+
+  Dictionary regs_dict = ARRAY_DICT_INIT;
+  // PUT(rv, "reg", DICTIONARY_OBJ(pos_dict));
+  // Convert registers.
+  const void *reg_iter = NULL;
+
+  // Abuse op_global_reg_iter() because we don't store the register name.
+  // This requires `ctx->reg` to be stored in the same order.
+  do {
+    yankreg_T reg;
+    char name[2] = { 0 };
+    bool is_un = false;
+    // reg_iter = op_register_iter(reg_iter, *(ctx->reg), &name, &reg,
+    // yankreg_T *saved_reg = ctx->reg[op_reg_index(name)];
+    reg_iter = op_global_reg_iter(reg_iter, &name[0], &reg, &is_un);
+    if (name[0] == NUL) {
+      break;
+    }
+
+    reg = *ctx->reg[op_reg_index(name[0])];
+    Dictionary reg_dict = ARRAY_DICT_INIT;
+
+    // lines
+    Array lines = ARRAY_DICT_INIT;
+    for (size_t i = 0; i < reg.y_size; i++) {
+      // TODO: can we avoid the copy here?
+      ADD(lines, STRING_OBJ(cstr_to_string((char *)reg.y_array[i])));
+    }
+    PUT(reg_dict, "lines", ARRAY_OBJ(lines));
+    PUT(regs_dict, name, DICTIONARY_OBJ(reg_dict));
+  } while (reg_iter != NULL);
+
+
+  PUT(rv, "reg", DICTIONARY_OBJ(regs_dict));
+
+  return rv;
+}

--- a/src/nvim/context.h
+++ b/src/nvim/context.h
@@ -1,0 +1,26 @@
+#ifndef NVIM_CONTEXT_H
+#define NVIM_CONTEXT_H
+
+#include "nvim/ops.h"
+
+typedef struct {
+  pos_T  pos;         ///< Current cursor position.
+  int mode;           ///< NORMAL, INSERT, …
+  bufref_T buf;       ///< Current buffer.
+  win_T *win;         ///< Current window.
+  yankreg_T **reg;    ///< Registers.
+} Context;
+typedef kvec_t(Context) ContextVec;
+
+typedef enum {
+  kCtxReg = 1,        ///< Registers
+  kCtxVimscript = 2,  ///< VimL variables: v:, g:, s:, …
+  kCtxOptions = 4,    ///< Editor options
+} ContextTypeFlags;
+extern int kCtxAll;
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "context.h.generated.h"
+#endif
+
+#endif  // NVIM_CONTEXT_H

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5250,7 +5250,7 @@ bool garbage_collect(bool testing)
       yankreg_T reg;
       char name = NUL;
       bool is_unnamed = false;
-      reg_iter = op_register_iter(reg_iter, &name, &reg, &is_unnamed);
+      reg_iter = op_global_reg_iter(reg_iter, &name, &reg, &is_unnamed);
       if (name != NUL) {
         ABORTING(set_ref_dict)(reg.additional_data, copyID);
       }
@@ -15563,7 +15563,7 @@ free_lstval:
 
   if (set_unnamed) {
     // Discard the result. We already handle the error case.
-    if (op_register_set_previous(regname)) { }
+    if (op_reg_set_previous(regname)) { }
   }
 }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5884,33 +5884,45 @@ static inline bool reg_empty(const yankreg_T *const reg)
               && *(reg->y_array[0]) == NUL));
 }
 
-/// Iterate over registerrs
+/// Iterate over global registers.
+///
+/// @see op_register_iter
+const void *op_global_reg_iter(const void *const iter, char *const name,
+                               yankreg_T *const reg, bool *is_unnamed)
+  FUNC_ATTR_NONNULL_ARG(2, 3, 4) FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return op_reg_iter(iter, y_regs, name, reg, is_unnamed);
+}
+
+/// Iterate over registers `regs`.
 ///
 /// @param[in]   iter      Iterator. Pass NULL to start iteration.
+/// @param[in]   regs      Registers list to be iterated.
 /// @param[out]  name      Register name.
 /// @param[out]  reg       Register contents.
 ///
-/// @return Pointer that needs to be passed to next `op_register_iter` call or
+/// @return Pointer that must be passed to next `op_register_iter` call or
 ///         NULL if iteration is over.
-const void *op_register_iter(const void *const iter, char *const name,
-                             yankreg_T *const reg, bool *is_unnamed)
-  FUNC_ATTR_NONNULL_ARG(2, 3) FUNC_ATTR_WARN_UNUSED_RESULT
+const void *op_reg_iter(const void *const iter, const yankreg_T *const regs,
+                        char *const name, yankreg_T *const reg,
+                        bool *is_unnamed)
+  FUNC_ATTR_NONNULL_ARG(3, 4, 5) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   *name = NUL;
   const yankreg_T *iter_reg = (iter == NULL
-                               ? &(y_regs[0])
+                               ? &(regs[0])
                                : (const yankreg_T *const) iter);
-  while (iter_reg - &(y_regs[0]) < NUM_SAVED_REGISTERS && reg_empty(iter_reg)) {
+  while (iter_reg - &(regs[0]) < NUM_SAVED_REGISTERS && reg_empty(iter_reg)) {
     iter_reg++;
   }
-  if (iter_reg - &(y_regs[0]) == NUM_SAVED_REGISTERS || reg_empty(iter_reg)) {
+  if (iter_reg - &(regs[0]) == NUM_SAVED_REGISTERS || reg_empty(iter_reg)) {
     return NULL;
   }
-  int iter_off = (int)(iter_reg - &(y_regs[0]));
+  int iter_off = (int)(iter_reg - &(regs[0]));
   *name = (char)get_register_name(iter_off);
   *reg = *iter_reg;
   *is_unnamed = (iter_reg == y_previous);
-  while (++iter_reg - &(y_regs[0]) < NUM_SAVED_REGISTERS) {
+  while (++iter_reg - &(regs[0]) < NUM_SAVED_REGISTERS) {
     if (!reg_empty(iter_reg)) {
       return (void *) iter_reg;
     }
@@ -5919,7 +5931,7 @@ const void *op_register_iter(const void *const iter, char *const name,
 }
 
 /// Get a number of non-empty registers
-size_t op_register_amount(void)
+size_t op_reg_amount(void)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   size_t ret = 0;
@@ -5938,7 +5950,7 @@ size_t op_register_amount(void)
 /// @param[in]  is_unnamed  Whether to set the unnamed regiseter to reg
 ///
 /// @return true on success, false on failure.
-bool op_register_set(const char name, const yankreg_T reg, bool is_unnamed)
+bool op_reg_set(const char name, const yankreg_T reg, bool is_unnamed)
 {
   int i = op_reg_index(name);
   if (i == -1) {
@@ -5958,7 +5970,7 @@ bool op_register_set(const char name, const yankreg_T reg, bool is_unnamed)
 /// @param[in]  name  Register name.
 ///
 /// @return Pointer to the register contents or NULL.
-const yankreg_T *op_register_get(const char name)
+const yankreg_T *op_reg_get(const char name)
 {
   int i = op_reg_index(name);
   if (i == -1) {
@@ -5972,7 +5984,7 @@ const yankreg_T *op_register_get(const char name)
 /// @param[in]  name  Register name.
 ///
 /// @return true on success, false on failure.
-bool op_register_set_previous(const char name)
+bool op_reg_set_previous(const char name)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   int i = op_reg_index(name);

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1328,13 +1328,13 @@ static void shada_read(ShaDaReadDef *const sd_reader, const int flags)
           break;
         }
         if (!force) {
-          const yankreg_T *const reg = op_register_get(cur_entry.data.reg.name);
+          const yankreg_T *const reg = op_reg_get(cur_entry.data.reg.name);
           if (reg == NULL || reg->timestamp >= cur_entry.timestamp) {
             shada_free_shada_entry(&cur_entry);
             break;
           }
         }
-        if (!op_register_set(cur_entry.data.reg.name, (yankreg_T) {
+        if (!op_reg_set(cur_entry.data.reg.name, (yankreg_T) {
           .y_array = (char_u **)cur_entry.data.reg.contents,
           .y_size = cur_entry.data.reg.contents_size,
           .y_type = cur_entry.data.reg.type,
@@ -2496,7 +2496,7 @@ static inline void shada_initialize_registers(WriteMergerState *const wms,
     yankreg_T reg;
     char name = NUL;
     bool is_unnamed = false;
-    reg_iter = op_register_iter(reg_iter, &name, &reg, &is_unnamed);
+    reg_iter = op_global_reg_iter(reg_iter, &name, &reg, &is_unnamed);
     if (name == NUL) {
       break;
     }

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -671,6 +671,39 @@ describe('API', function()
     end)
   end)
 
+  describe('nvim_get_context', function()
+    it('gets editor state', function()
+      eq({
+          pos = {
+            col = 0,
+            coladd = 0,
+            lnum = 0 },
+          reg = {},
+         },
+         nvim('get_context', {nil}))
+
+      -- Set some registers.
+      feed('ifoo bar<esc>yy')
+      feed('"ayiw')
+      -- eq('x', require('inspect')(nvim('get_context')))
+      eq({
+          pos = {
+            col = 0,
+            coladd = 0,
+            lnum = 0 },
+          reg = {
+            ['0'] = {
+              lines = { "foo bar" },
+            },
+            a = {
+              lines = { "bar" },
+            },
+          },
+         },
+         nvim('get_context', {nil}))
+    end)
+  end)
+
   describe('nvim_replace_termcodes', function()
     it('escapes K_SPECIAL as K_SPECIAL KS_SPECIAL KE_FILLER', function()
       eq('\128\254X', helpers.nvim('replace_termcodes', '\128', true, true, true))


### PR DESCRIPTION
This introduces the "context" concept. Currently that just means "big ball of values gathered from the nether regions of the application and crammed into a map". Basically a `Context` struct which is marshaled to a `Dictionary` for API/VimL/etc.

Useful for:

-  p2p #1180 
- multiproc #9943 
- multicursor (which is where this patch came from)
- future?: similar to Python `with ...:` , execute code with temporary side-effects (such as changes to user options).

Still needed:

- Currently this only implements save/restore of registers. Not implemented yet:
    - `g:` (could be implemented in Lua)
    - marks
    - quickfix stuff
    - ...
- Maybe introducing a new "Context" concept is not necessary, instead evolve `shada.c`? 
    - Explore: `shada_write` does much of what we need for "Context", but it's somewhat coupled to writing a file and building a `msgpack_packer`. If we could decouple the file-writing logic and just return the `msgpack_packer`, we could work with that msgpack object instead of writing a bunch of logic that is potentially redundant with the guts of `shada_write`.
- `nvim_load_context` to "import" a context (dual of `nvim_get_context`)
- fix memory leaks (I made no effort here yet)

cc @abdelhakeem