### PR TITLE
api/lua: make nvim_execute_lua use native lua floats, not special tables

### DIFF
--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -441,7 +441,7 @@ local function process_function(fn)
     end
     write_shifted_output(output, string.format([[
     const %s ret = %s(%s);
-    nlua_push_%s(lstate, ret);
+    nlua_push_%s(lstate, ret, true);
     api_free_%s(ret);
   %s
   %s

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -562,7 +562,7 @@ Object executor_exec_lua_api(const String str, const Array args, Error *err)
   }
 
   for (size_t i = 0; i < args.size; i++) {
-    nlua_push_Object(lstate, args.items[i]);
+    nlua_push_Object(lstate, args.items[i], false);
   }
 
   if (lua_pcall(lstate, (int)args.size, 1, 0)) {
@@ -583,7 +583,7 @@ Object executor_exec_lua_cb(LuaRef ref, const char *name, Array args,
   nlua_pushref(lstate, ref);
   lua_pushstring(lstate, name);
   for (size_t i = 0; i < args.size; i++) {
-    nlua_push_Object(lstate, args.items[i]);
+    nlua_push_Object(lstate, args.items[i], false);
   }
 
   if (lua_pcall(lstate, (int)args.size+1, retval ? 1 : 0, 0)) {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -339,6 +339,15 @@ describe('API', function()
                  "did\nthe\nfail"},
          meth_pcall(meths.execute_lua, 'error("did\\nthe\\nfail")', {}))
     end)
+
+    it('uses native float values', function()
+      eq(2.5, meths.execute_lua("return select(1, ...)", {2.5}))
+      eq("2.5", meths.execute_lua("return vim.inspect(...)", {2.5}))
+
+      -- "special" float values are still accepted as return values.
+      eq(2.5, meths.execute_lua("return vim.api.nvim_eval('2.5')", {}))
+      eq("{\n  [false] = 2.5,\n  [true] = 3\n}", meths.execute_lua("return vim.inspect(vim.api.nvim_eval('2.5'))", {}))
+    end)
   end)
 
   describe('nvim_input', function()


### PR DESCRIPTION
Rationale: the purpose of nvim_execute_lua is to simply call lua code with lua values. If a lua function expects a floating point value, it should be enough to specify a float as argument to nvim_execute_lua. The existing behavior was a mistake, because I didn't know `nlua_push_Object` had special behavior when implementing `nvim_execute_lua`.

However, make sure to preserve the existing roundtripping behavior of API values when using `vim.api` functions. This is covered by existing `lua/api_spec.lua` tests.