### PR TITLE
screen: disable redrawing inside VimResized

### DIFF
--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1152,6 +1152,50 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
+  it('behaves correcty with VimResized autocmd', function()
+    feed('isome long prefix before the ')
+    command("set completeopt+=noinsert,noselect")
+    command("autocmd VimResized * redraw!")
+    command("set linebreak")
+    funcs.complete(29, {'word', 'choice', 'text', 'thing'})
+    screen:expect([[
+      some long prefix before the ^    |
+      {1:~                        }{n: word  }|
+      {1:~                        }{n: choice}|
+      {1:~                        }{n: text  }|
+      {1:~                        }{n: thing }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {2:-- INSERT --}                    |
+    ]])
+
+    screen:try_resize(16,10)
+    screen:expect([[
+      some long       |
+      prefix before   |
+      the ^            |
+      {1:~  }{n: word        }|
+      {1:~  }{n: choice      }|
+      {1:~  }{n: text        }|
+      {1:~  }{n: thing       }|
+      {1:~               }|
+      {1:~               }|
+      {2:-- INSERT --}    |
+    ]])
+  end)
+
   it('works with rightleft window', function()
     command("set rl")
     feed('isome rightleft ')


### PR DESCRIPTION
Fixes #10002

While it doesn't crash anymore, master is still very glitchy with popupmenu (try completing on the end of a wrapped line and resize). I will see if I can make a test.