### PR TITLE
tests: fix flaky "terminal (with fake shell) with not arguments …"

### DIFF
--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -137,7 +137,7 @@ describe(':terminal (with fake shell)', function()
 
   it('with no argument, acts like termopen()', function()
     terminal_with_fake_shell()
-    retry(3, 4 * screen.timeout, function()
+    retry(nil, 4 * screen.timeout, function()
     screen:expect([[
       ^ready $                                           |
       [Process exited 0]                                |


### PR DESCRIPTION
`retry()` would only try it three times (waiting for 20ms in between),
despite the large timeout.

Fixes https://github.com/neovim/neovim/issues/10265.

Followup to 618cfe03f.