### PR TITLE
Fix rule of `build/.ran-third-party-cmake`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,6 @@ ifeq ($(call filter-true,$(USE_BUNDLED)),)
 	+$(BUILD_CMD) -C $(DEPS_BUILD_DIR)
 endif
 
-build/.ran-third-party-cmake::
-	mkdir -p build
-	touch $@
-
 ifeq ($(call filter-true,$(USE_BUNDLED)),)
 $(DEPS_BUILD_DIR):
 	mkdir -p "$@"
@@ -113,6 +109,9 @@ build/.ran-third-party-cmake:: $(DEPS_BUILD_DIR)
 		$(CMAKE_PRG) -G '$(BUILD_TYPE)' $(BUNDLED_CMAKE_FLAG) $(BUNDLED_LUA_CMAKE_FLAG) \
 		$(DEPS_CMAKE_FLAGS) $(THIS_DIR)/third-party
 endif
+build/.ran-third-party-cmake::
+	mkdir -p build
+	touch $@
 
 # TODO: cmake 3.2+ add_custom_target() has a USES_TERMINAL flag.
 oldtest: | nvim helptags


### PR DESCRIPTION
In order that `$(DEPS_BUILD_DIR)/Makefile` exists under parallel make