### PR TITLE
[RDY] fix gcov merge mismatch, part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ jobs:
       env:
         - GCOV=gcov
         - CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
+        - GCOV_ERROR_FILE="/tmp/libgcov-errors.log"
         - *common-job-env
     - name: clang-tsan
       os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,8 @@ after_build:
     if (Test-Path $env:GCOV_ERROR_FILE) {
       Get-Content $env:GCOV_ERROR_FILE -Head 10
       Get-Content $env:GCOV_ERROR_FILE -Tail 10
+    } else {
+      write-host "no GCOV_ERROR_FILE"
     }
 cache:
 - C:\projects\nvim-deps -> third-party\**

--- a/ci/common/submit_coverage.sh
+++ b/ci/common/submit_coverage.sh
@@ -25,6 +25,7 @@ python3 -m gcovr --branches --exclude-unreachable-branches --print-summary -j 2 
 
 # Upload to codecov.
 # -X gcov: disable gcov, done manually above.
+# -X fix: disable fixing of reports (not necessary, rather slow)
 # -Z: exit non-zero on failure
 # -F: flag(s)
 # NOTE: ignoring flags for now, since this causes timeouts on codecov.io then,
@@ -32,7 +33,7 @@ python3 -m gcovr --branches --exclude-unreachable-branches --print-summary -j 2 
 # Flags must match pattern ^[\w\,]+$ ("," as separator).
 codecov_flags="$(uname -s),${1}"
 codecov_flags=$(echo "$codecov_flags" | sed 's/[^,_a-zA-Z0-9]/_/g')
-if ! "$codecov_sh" -f coverage.xml -X gcov -Z -F "${codecov_flags}"; then
+if ! "$codecov_sh" -f coverage.xml -X gcov -X fix -Z -F "${codecov_flags}"; then
   echo "codecov upload failed."
 fi
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,3 +11,9 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
 else
   ci/run_${CI_TARGET}.sh
 fi
+
+if [[ -s "${GCOV_ERROR_FILE}" ]]; then
+  echo '=== Unexpected gcov errors: ==='
+  cat "${GCOV_ERROR_FILE}"
+  exit 1
+fi

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -26,6 +26,11 @@
 // For PTY processes SIGTERM is sent first (in case SIGHUP was not enough).
 #define KILL_TIMEOUT_MS 2000
 
+/// Externally defined with gcov.
+#ifdef USE_GCOV
+void __gcov_flush(void);
+#endif
+
 static bool process_is_tearing_down = false;
 
 /// @returns zero on success, or negative error code
@@ -49,6 +54,11 @@ int process_spawn(Process *proc, bool in, bool out, bool err)
   } else {
     proc->err.closed = true;
   }
+
+#ifdef USE_GCOV
+  // Flush coverage data before forking, to avoid "Merge mismatch" errors.
+  __gcov_flush();
+#endif
 
   int status;
   switch (proc->type) {

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -36,11 +36,6 @@
 # include "os/pty_process_unix.c.generated.h"
 #endif
 
-/// Externally defined with gcov.
-#ifdef USE_GCOV
-void __gcov_flush(void);
-#endif
-
 /// termios saved at startup (for TUI) or initialized by pty_process_spawn().
 static struct termios termios_default;
 
@@ -63,11 +58,6 @@ int pty_process_spawn(PtyProcess *ptyproc)
     // TODO(jkeyes): We could pass NULL to forkpty() instead ...
     init_termios(&termios_default);
   }
-
-#ifdef USE_GCOV
-  // Flush coverage data before forking, to avoid "Merge mismatch" errors.
-  __gcov_flush();
-#endif
 
   int status = 0;  // zero or negative error code (libuv convention)
   Process *proc = (Process *)ptyproc;

--- a/test/functional/eval/executable_spec.lua
+++ b/test/functional/eval/executable_spec.lua
@@ -21,8 +21,6 @@ describe('executable()', function()
     -- Windows: siblings are in Nvim's "pseudo-$PATH".
     local expected = iswin() and 1 or 0
     if iswin() then
-      -- $PATH on AppVeyor CI might be oversized, redefine it to a minimal one.
-      clear({env={PATH=[[C:\Windows\system32;C:\Windows]]}})
       eq('arg1=lemon;arg2=sky;arg3=tree;',
          call('system', sibling_exe..' lemon sky tree'))
     end


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/issues/10332

Seen failures on Travis again: https://travis-ci.org/neovim/neovim/jobs/553494382, https://api.travis-ci.org/v3/job/553494382/log.txt.

Looks like `system()` also needs special treatment, and Windows probably, too.

### merge-mismatch errors

#### AppVeyor

- Pairs of:

> [00:16:02] profiling:C:\projects\neovim\build/src/nvim/CMakeFiles/nvim.dir/buffer.c.gcda:Data file mismatch - some data files may have been concurrently updated without locking support
[00:16:02] profiling:C:\projects\neovim\build/src/nvim/CMakeFiles/nvim.dir/eval/encode.c.gcda:Merge mismatch for function 7

#### Travis (from another build without this PR)

> profiling:/home/travis/build/neovim/neovim/build/src/nvim/CMakeFiles/nvim.dir/menu.c.gcda:Merge mismatch for function 23


TODO:

- [x] Travis: fail build on (gcov) errors (via error file), but use allow-failure then eventually (although I'd rather not).  But it needs to be clear from looking at jobs that this is due to (unexpected) gcov processing.

- [ ] update gcovr (`python3 -m pip install git+https://github.com/gcovr/gcovr.git` - several fixes/improvements there, worth trying)

- [x] codecov: skip fixing adjustments: rather slow (>10s on AppVeyor), and should not be necessary.  Do this after stable coverage.