### PR TITLE
tests: shell-test: add INTERACT mode

### DIFF
--- a/test/functional/ex_cmds/ls_spec.lua
+++ b/test/functional/ex_cmds/ls_spec.lua
@@ -4,6 +4,8 @@ local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
 local feed = helpers.feed
+local nvim = helpers.nvim
+local nvim_dir = helpers.nvim_dir
 local retry = helpers.retry
 
 describe(':ls', function()
@@ -12,6 +14,8 @@ describe(':ls', function()
   end)
 
   it('R, F for :terminal buffers', function()
+    nvim('set_option', 'shell', string.format('"%s" INTERACT', nvim_dir..'/shell-test'))
+
     command('edit foo')
     command('set hidden')
     command('terminal')

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -40,6 +40,8 @@ static void help(void)
   puts("      ...");
   puts("      96: test");
   puts("    will be printed because byte `a' is equal to 97.");
+  puts("  shell-test INTERACT");
+  puts("    Prints \"interact $ \" to stderr, and waits for \"exit\" input.");
 }
 
 int main(int argc, char **argv)
@@ -89,8 +91,31 @@ int main(int argc, char **argv)
 
       printf("3: \xc3\xa5\xcc"); wait();
       printf("\xb2\n"); wait();
+    } else if (strcmp(argv[1], "INTERACT") == 0) {
+      char input[256];
+      char cmd[100];
+      int arg;
+      int input_argc;
+
+      while (1) {
+        fprintf(stderr, "interact $ ");
+
+        if (fgets(input, sizeof(input), stdin) == NULL) {
+          break;  // EOF
+        }
+
+        input_argc = sscanf(input, "%s %d", cmd, &arg);
+        if(1 == input_argc) {
+          arg = 0;
+        }
+        if (strcmp(cmd, "exit") == 0) {
+            return arg;
+        } else {
+          fprintf(stderr, "command not found: %s\n", cmd);
+        }
+      }
     } else {
-      fprintf(stderr, "Unknown first argument\n");
+      fprintf(stderr, "Unknown first argument: %s\n", argv[1]);
       return 3;
     }
     return 0;


### PR DESCRIPTION
Use it to improve ls_spec: it should not use the user's real shell for
performance and other reasons.

Using "shellcmdflag=INTERACT" and just ":terminal" does not use it, but
is likely worth having it as a default then (for 'shell' and
'shellcmdflag') - so that it behaves like a real shell, while not having
to care about $HOME / &shell?!