### PR TITLE
tests: executable_spec: keep assertion

### DIFF
--- a/test/functional/eval/executable_spec.lua
+++ b/test/functional/eval/executable_spec.lua
@@ -29,6 +29,8 @@ describe('executable()', function()
     local is_executable = call('executable', sibling_exe)
     if iswin() and is_executable ~= expected then
       pending('XXX: sometimes fails on AppVeyor')
+    else
+      eq(expected, is_executable)
     end
   end)
 


### PR DESCRIPTION
It was moved to become pending in 18127f64c, but the assertion should be
kept.

Ref: https://github.com/neovim/neovim/pull/6038/files#r99477887