### PR TITLE
bundle: clean binary dir when downloading

### DIFF
--- a/third-party/cmake/BuildLuv.cmake
+++ b/third-party/cmake/BuildLuv.cmake
@@ -42,7 +42,9 @@ function(BuildLuv)
       -DDOWNLOAD_DIR=${DEPS_DOWNLOAD_DIR}/luv
       -DURL=${LUV_URL}
       -DEXPECTED_SHA256=${LUV_SHA256}
-      -DTARGET=luv
+      -DTARGET=luv-static
+      # The source is shared with BuildLuarocks (with USE_BUNDLED_LUV).
+      -DSRC_DIR=${DEPS_BUILD_DIR}/src/luv
       -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
     PATCH_COMMAND "${_luv_PATCH_COMMAND}"

--- a/third-party/cmake/DownloadAndExtractFile.cmake
+++ b/third-party/cmake/DownloadAndExtractFile.cmake
@@ -18,7 +18,10 @@ if(NOT DEFINED TARGET)
   message(FATAL_ERROR "TARGET must be defined.")
 endif()
 
-set(SRC_DIR ${PREFIX}/src/${TARGET})
+if(NOT DEFINED SRC_DIR)
+  set(SRC_DIR ${PREFIX}/src/${TARGET})
+endif()
+set(BINARY_DIR ${PREFIX}/src/${TARGET}-build)
 
 # Check whether the source has been downloaded. If true, skip it.
 # Useful for external downloads like homebrew.
@@ -153,6 +156,13 @@ message(STATUS "extracting... [rename]")
 file(REMOVE_RECURSE ${SRC_DIR})
 get_filename_component(contents ${contents} ABSOLUTE)
 file(RENAME ${contents} ${SRC_DIR})
+
+# Remove any existing BINARY_DIR, to force a new build.
+# Without this a necessary output (e.g. libluv.a) might not be updated/installed.
+#
+message(STATUS "extracting... [clean binary dir]")
+file(REMOVE_RECURSE ${BINARY_DIR})
+file(MAKE_DIRECTORY ${BINARY_DIR})
 
 # Clean up:
 #


### PR DESCRIPTION
This is required to (re)build e.g. libluv when the version changes (which triggers a new download).

With `make deps`, changing the `LUV_URL`/`LUV_SHA256`, and `make deps` again:

Before:

> Up-to-date: /home/daniel/Vcs/neovim/.deps/usr/lib/libluv.a

After:

> Installing: /home/daniel/Vcs/neovim/.deps/usr/lib/libluv.a 

See with https://github.com/neovim/neovim/pull/10358 - where .deps contained libluv 1.29, the merge updates it to 1.30, but then it failed to link because `libluv.a` is considered to be up-to-date (after downloading the new version).

Note that header files get installed, since they have the original time stamp, but `libluv.a` is being generated (does not use the timestamp from the archive here, but needs to get rebuild).

It could be argued that the build system of the included project should catch/handle this, but it seems to be good practice to clean the binary / build dir with a new download to start from scratch.

Ref: https://gitlab.kitware.com/cmake/cmake/issues/19452