### PR TITLE
ci: Travis: cache: use TRAVIS_BRANCH in env for each job  [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,47 +47,76 @@ env:
     - CCACHE_SLOPPINESS=time_macros,file_macro
     - CCACHE_BASEDIR="$TRAVIS_BUILD_DIR"
 
+anchors:
+  envs: &common-job-env
+    # Do not fall back to cache for "master" for PR on "release" branch:
+    # adds the target branch to the cache key.
+    FOR_TRAVIS_CACHE=$TRAVIS_BRANCH
+
 jobs:
   include:
     - stage: baseline
+      name: clang-asan
       os: linux
       compiler: clang-4.0
       # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
-      env: >
-        CLANG_SANITIZER=ASAN_UBSAN
-        CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
-        ASAN_SYMBOLIZE=asan_symbolize-4.0
-    - os: linux
+      env:
+        - CLANG_SANITIZER=ASAN_UBSAN
+        - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
+        - ASAN_SYMBOLIZE=asan_symbolize-4.0
+        - *common-job-env
+    - name: gcc-functionaltest-lua
+      os: linux
       compiler: gcc
-      env: >
-        FUNCTIONALTEST=functionaltest-lua
-        CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
-        DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
-    - os: linux
+      env:
+        - FUNCTIONALTEST=functionaltest-lua
+        - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
+        - DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
+        - *common-job-env
+    - name: gcc-32bit
+      os: linux
       # Travis creates a cache per compiler. Set a different value here to
       # store 32-bit dependencies in a separate cache.
       compiler: gcc
-      env: BUILD_32BIT=ON
+      env:
+        - BUILD_32BIT=ON
+        - *common-job-env
     - if: branch = master AND commit_message !~ /\[skip.lint\]/
+      name: lint
       os: linux
-      env: CI_TARGET=lint
+      env:
+        - CI_TARGET=lint
+        - *common-job-env
 
     - stage: second stage
+      name: "macOS: clang"
       os: osx
       compiler: clang
       osx_image: xcode10.2  # macOS 10.14
-    - os: osx
+      env:
+        - *common-job-env
+    - name: "macOS: gcc"
+      os: osx
       compiler: gcc
       osx_image: xcode10.2  # macOS 10.14
+      env:
+        - *common-job-env
 
-    - os: linux
+    - name: gcc-coverage
+      os: linux
       compiler: gcc
-      env: GCOV=gcov CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
-    - os: linux
+      env:
+        - GCOV=gcov
+        - CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
+        - *common-job-env
+    - name: clang-tsan
+      os: linux
       compiler: clang
-      env: CLANG_SANITIZER=TSAN
+      env:
+        - CLANG_SANITIZER=TSAN
+        - *common-job-env
   allow_failures:
-    - env: CLANG_SANITIZER=TSAN
+    - name: clang-tsan
   fast_finish: true
 
 before_install: ci/before_install.sh


### PR DESCRIPTION
This is meant to not fall back to using the cache for the "master"
target branch, for release pull requests (targeting not "master").

Simpler, but more verbose alternative to https://github.com/neovim/neovim/pull/10358.