### PR TITLE
tests: loop_spec: retry

### DIFF
--- a/test/functional/lua/loop_spec.lua
+++ b/test/functional/lua/loop_spec.lua
@@ -10,6 +10,7 @@ local eq = helpers.eq
 local eval = helpers.eval
 local matches = helpers.matches
 local exec_lua = helpers.exec_lua
+local retry = helpers.retry
 
 before_each(clear)
 
@@ -52,8 +53,10 @@ describe('vim.loop', function()
 
     eq(0, meths.get_var('coroutine_cnt'))
     exec_lua(code)
-    sleep(50)
-    eq(2, meths.get_var('coroutine_cnt'))
+    retry(2, nil, function()
+      sleep(50)
+      eq(2, meths.get_var('coroutine_cnt'))
+    end)
     eq(3, meths.get_var('coroutine_cnt_1'))
   end)
 


### PR DESCRIPTION
Flaky test (osx):

    [  FAILED  ] ...is/build/neovim/neovim/test/functional/lua/loop_spec.lua @ 23: vim.loop timer
    ...is/build/neovim/neovim/test/functional/lua/loop_spec.lua:56: Expected objects to be the same.
    Passed in:
    (number) 0
    Expected:
    (number) 2
    stack traceback:
            ...is/build/neovim/neovim/test/functional/lua/loop_spec.lua:56: in function <...is/build/neovim/neovim/test/functional/lua/loop_spec.lua:23>

It was bumped from sleeping for 20ms to 50ms in d33aaa0f5f already.