### PR TITLE
third-party: fix warning with (un)bundled libtermkey/unibilium

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -191,6 +191,9 @@ endif()
 
 if(USE_BUNDLED_LIBTERMKEY)
   include(BuildLibtermkey)
+  if(USE_BUNDLED_UNIBILIUM)
+    add_dependencies(libtermkey unibilium)
+  endif()
 endif()
 
 if(USE_BUNDLED_LIBVTERM)

--- a/third-party/cmake/BuildLibtermkey.cmake
+++ b/third-party/cmake/BuildLibtermkey.cmake
@@ -53,4 +53,3 @@ ExternalProject_Add(libtermkey
 endif()
 
 list(APPEND THIRD_PARTY_DEPS libtermkey)
-add_dependencies(libtermkey unibilium)


### PR DESCRIPTION
Fixes warning with:

> cmake -S third-party -B .deps -DUSE_BUNDLED=OFF -DUSE_BUNDLED_UNIBILIUM=0 -DUSE_BUNDLED_LIBTERMKEY=1
> The dependency target "unibilium" of target "libtermkey" does not exist.