### PR TITLE
build: use -fdiagnostics-color=always with Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,11 @@ endif()
 
 check_c_compiler_flag(-fdiagnostics-color=auto HAS_DIAG_COLOR_FLAG)
 if(HAS_DIAG_COLOR_FLAG)
-  add_compile_options(-fdiagnostics-color=auto)
+  if(CMAKE_GENERATOR MATCHES "Ninja")
+    add_compile_options(-fdiagnostics-color=always)
+  else()
+    add_compile_options(-fdiagnostics-color=auto)
+  endif()
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
"auto" does not work, since Ninja does not appear as a TTY to gcc/clang,
but handles stripping escape codes itself when output is not to a TTY.

Ref: https://github.com/ninja-build/ninja/blob/ca041d88f4d6/src/build.cc#L158-L169