### PR TITLE
[RDY] runtime/termdebug.vim: implement opening terminal vertically

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -564,8 +564,7 @@ let s:evalFromBalloonExprResult = ''
 func s:HandleEvaluate(msg)
   let value = substitute(a:msg, '.*value="\(.*\)"', '\1', '')
   let value = substitute(value, '\\"', '"', 'g')
-  let value = substitute(value, '
-', '\1', '')
+  let value = substitute(value, '', '\1', '')
   if s:evalFromBalloonExpr
     if s:evalFromBalloonExprResult == ''
       let s:evalFromBalloonExprResult = s:evalexpr . ': ' . value

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -119,10 +119,14 @@ func s:StartDebug_internal(dict)
   let s:startsigncolumn = &signcolumn
 
   let s:save_columns = 0
+  let s:allleft = 0
   if exists('g:termdebug_wide')
     if &columns < g:termdebug_wide
       let s:save_columns = &columns
       let &columns = g:termdebug_wide
+      " If we make the Vim window wider, use the whole left halve for the debug
+      " windows.
+      let s:allleft = 1
     endif
     let s:vertical = 1
   else
@@ -157,6 +161,9 @@ func s:StartDebug_term(dict)
     " Assuming the source code window will get a signcolumn, use two more
     " columns for that, thus one less for the terminal window.
     exe (&columns / 2 - 1) . "wincmd |"
+    if s:allleft
+      " use the whole left column
+      wincmd H
   endif
 
   " Create a hidden terminal window to communicate with gdb
@@ -557,7 +564,8 @@ let s:evalFromBalloonExprResult = ''
 func s:HandleEvaluate(msg)
   let value = substitute(a:msg, '.*value="\(.*\)"', '\1', '')
   let value = substitute(value, '\\"', '"', 'g')
-  let value = substitute(value, '', '\1', '')
+  let value = substitute(value, '
+', '\1', '')
   if s:evalFromBalloonExpr
     if s:evalFromBalloonExprResult == ''
       let s:evalFromBalloonExprResult = s:evalexpr . ': ' . value

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -140,7 +140,7 @@ endfunc
 
 func s:StartDebug_term(dict)
   " Open a terminal window without a job, to run the debugged program in.
-  execute 'new'
+  execute s:vertical ? 'vnew' : 'new'
   let s:pty_job_id = termopen('tail -f /dev/null;#gdb program')
   if s:pty_job_id == 0
     echoerr 'invalid argument (or job table is full) while opening terminal window'

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -164,6 +164,7 @@ func s:StartDebug_term(dict)
     if s:allleft
       " use the whole left column
       wincmd H
+    endif
   endif
 
   " Create a hidden terminal window to communicate with gdb


### PR DESCRIPTION
All of the code was already there, including a necessary flag. This commit just adds a conditional call to `vnew` if the flag is set.

This change was suggested by @justinmk.