### PR TITLE
BuildLuarocks.cmake: use ROCKS_DIR

### DIFF
--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -107,44 +107,41 @@ if(USE_BUNDLED_LUAJIT)
 elseif(USE_BUNDLED_LUA)
   add_dependencies(luarocks lua)
 endif()
+set(ROCKS_DIR ${HOSTDEPS_LIB_DIR}/luarocks/rocks)
 
 # DEPENDS on the previous module, because Luarocks breaks if parallel.
-add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/mpack
+add_custom_command(OUTPUT ${ROCKS_DIR}/mpack
   COMMAND ${LUAROCKS_BINARY}
   ARGS build mpack 1.0.8-0 ${LUAROCKS_BUILDARGS}
   DEPENDS luarocks)
-add_custom_target(mpack
-  DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/mpack)
+add_custom_target(mpack DEPENDS ${ROCKS_DIR}/mpack)
 list(APPEND THIRD_PARTY_DEPS mpack)
 
 # DEPENDS on the previous module, because Luarocks breaks if parallel.
-add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lpeg
+add_custom_command(OUTPUT ${ROCKS_DIR}/lpeg
   COMMAND ${LUAROCKS_BINARY}
   ARGS build lpeg 1.0.2-1 ${LUAROCKS_BUILDARGS}
   DEPENDS mpack)
-add_custom_target(lpeg
-  DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/lpeg)
+add_custom_target(lpeg DEPENDS ${ROCKS_DIR}/lpeg)
 
 list(APPEND THIRD_PARTY_DEPS lpeg)
 
 # DEPENDS on the previous module, because Luarocks breaks if parallel.
-add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/inspect
+add_custom_command(OUTPUT ${ROCKS_DIR}/inspect
   COMMAND ${LUAROCKS_BINARY}
   ARGS build inspect 3.1.1-0 ${LUAROCKS_BUILDARGS}
   DEPENDS lpeg)
-add_custom_target(inspect
-  DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/inspect)
+add_custom_target(inspect DEPENDS ${ROCKS_DIR}/inspect)
 
 list(APPEND THIRD_PARTY_DEPS inspect)
 
 if((NOT USE_BUNDLED_LUAJIT) AND USE_BUNDLED_LUA)
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
-  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luabitop
+  add_custom_command(OUTPUT ${ROCKS_DIR}/luabitop
     COMMAND ${LUAROCKS_BINARY}
     ARGS build luabitop 1.0.2-3 ${LUAROCKS_BUILDARGS}
     DEPENDS inspect)
-  add_custom_target(luabitop
-    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luabitop)
+  add_custom_target(luabitop DEPENDS ${ROCKS_DIR}/luabitop)
 
   list(APPEND THIRD_PARTY_DEPS luabitop)
 endif()
@@ -157,12 +154,11 @@ if(USE_BUNDLED_BUSTED)
   endif()
 
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
-  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight
+  add_custom_command(OUTPUT ${ROCKS_DIR}/penlight
     COMMAND ${LUAROCKS_BINARY}
     ARGS build penlight 1.5.4-1 ${LUAROCKS_BUILDARGS}
     DEPENDS ${PENLIGHT_DEPENDS})
-  add_custom_target(penlight
-    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/penlight)
+  add_custom_target(penlight DEPENDS ${ROCKS_DIR}/penlight)
 
   if(WIN32)
     set(BUSTED_EXE "${HOSTDEPS_BIN_DIR}/busted.bat")
@@ -176,16 +172,14 @@ if(USE_BUNDLED_BUSTED)
     COMMAND ${LUAROCKS_BINARY}
     ARGS build busted 2.0.rc13-0 ${LUAROCKS_BUILDARGS}
     DEPENDS penlight)
-  add_custom_target(busted
-    DEPENDS ${BUSTED_EXE})
+  add_custom_target(busted DEPENDS ${BUSTED_EXE})
 
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   add_custom_command(OUTPUT ${LUACHECK_EXE}
     COMMAND ${LUAROCKS_BINARY}
     ARGS build luacheck 0.23.0-1 ${LUAROCKS_BUILDARGS}
     DEPENDS busted)
-  add_custom_target(luacheck
-    DEPENDS ${LUACHECK_EXE})
+  add_custom_target(luacheck DEPENDS ${LUACHECK_EXE})
 
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
   set(LUV_DEPS luacheck)
@@ -199,27 +193,25 @@ if(USE_BUNDLED_BUSTED)
       list(APPEND LUV_ARGS LIBUV_DIR=${HOSTDEPS_INSTALL_DIR})
     endif()
     SET(LUV_PRIVATE_ARGS LUA_COMPAT53_INCDIR=${DEPS_BUILD_DIR}/src/lua-compat-5.3)
-    add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luv
+    add_custom_command(OUTPUT ${ROCKS_DIR}/luv
       COMMAND ${LUAROCKS_BINARY}
       ARGS make ${LUAROCKS_BUILDARGS} ${LUV_ARGS} ${LUV_PRIVATE_ARGS}
       WORKING_DIRECTORY ${DEPS_BUILD_DIR}/src/luv
       DEPENDS ${LUV_DEPS})
   else()
-    add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luv
+    add_custom_command(OUTPUT ${ROCKS_DIR}/luv
       COMMAND ${LUAROCKS_BINARY}
       ARGS build luv ${LUV_VERSION} ${LUAROCKS_BUILDARGS}
       DEPENDS ${LUV_DEPS})
   endif()
-  add_custom_target(luv
-    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/luv)
+  add_custom_target(luv DEPENDS ${ROCKS_DIR}/luv)
 
   # DEPENDS on the previous module, because Luarocks breaks if parallel.
-  add_custom_command(OUTPUT ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client
+  add_custom_command(OUTPUT ${ROCKS_DIR}/nvim-client
     COMMAND ${LUAROCKS_BINARY}
     ARGS build nvim-client 0.2.0-1 ${LUAROCKS_BUILDARGS}
     DEPENDS luv)
-  add_custom_target(nvim-client
-    DEPENDS ${HOSTDEPS_LIB_DIR}/luarocks/rocks/nvim-client)
+  add_custom_target(nvim-client DEPENDS ${ROCKS_DIR}/nvim-client)
 
   list(APPEND THIRD_PARTY_DEPS busted luacheck nvim-client)
 endif()


### PR DESCRIPTION
With LuaRocks 3 it will include the version, and this will make the
upgrade easier then.
It also makes sense to factor this out in general for clarity already.

Pulled out of https://github.com/neovim/neovim/pull/10292.