### PR TITLE
Set filetype html for Vue.js files.

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -701,6 +701,9 @@ au BufNewFile,BufRead *.t.html			setf tilde
 " HTML (.shtml and .stm for server side)
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
 
+" Vue.js Single File Components work as HTML.
+au BufNewFile,BufRead *.vue			setf html
+
 " HTML with Ruby - eRuby
 au BufNewFile,BufRead *.erb,*.rhtml		setf eruby
 


### PR DESCRIPTION
Identify Vue.js Single File Component source files by their .vue
filename extension and set the filetype to html. They're a mixture
of html templates, css, and javascript. The html syntax highlighting
works well enough.