### PR TITLE
Fix crash with nested TermClose

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -331,7 +331,10 @@ void terminal_close(Terminal *term, char *msg)
   }
 
   if (buf) {
+    aco_save_T aco;
+    aucmd_prepbuf(&aco, buf);
     apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
+    aucmd_restbuf(&aco);
   }
 }
 


### PR DESCRIPTION
I'm new to this code, so I'm not sure this is the right approach.  It does seem to prevent the segfaults I was running into.

-------------------------

Once we are about to close a buffer because it is not curbuf, lock
curbuf and restore it after close in case an autocommand tries to
either:

  - Delete curbuf
  - Change curbuf to the buffer we are closing

Ref: #10386