### PR TITLE
anchor float to buffer position

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2297,6 +2297,7 @@ rpcrequest({channel}, {method}[, {args}...])
 screenattr({row}, {col})	Number	attribute at screen position
 screenchar({row}, {col})	Number	character at screen position
 screencol()			Number	current cursor column
+screenpos({winid}, {lnum}, {col}) Dict	screen row and col of a text character
 screenrow()			Number	current cursor row
 search({pattern} [, {flags} [, {stopline} [, {timeout}]]])
 				Number	search for {pattern}
@@ -6794,7 +6795,25 @@ screencol()							*screencol()*
 		the following mappings: >
 			nnoremap <expr> GG ":echom ".screencol()."\n"
 			nnoremap <silent> GG :echom screencol()<CR>
+			noremap GG <Cmd>echom screencol()<Cr>
 <
+screenpos({winid}, {lnum}, {col})				*screenpos()*
+		The result is a Dict with the screen position of the text
+		character in window {winid} at buffer line {lnum} and column
+		{col}.  {col} is a one-based byte index.
+		The Dict has these members:
+			row	screen row
+			col	first screen column
+			endcol	last screen column
+			curscol	cursor screen column
+		If the specified position is not visible, all values are zero.
+		The "endcol" value differs from "col" when the character
+		occupies more than one screen cell.  E.g. for a Tab "col" can
+		be 1 and "endcol" can be 8.
+		The "curscol" value is where the cursor would be placed.  For
+		a Tab it would be the same as "endcol", while for a double
+		width character it would be the same as "col".
+
 screenrow()							*screenrow()*
 		The result is a Number, which is the current screen row of the
 		cursor.  The top line has number one.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1059,6 +1059,12 @@ fail:
 ///      - "SE" south-east
 ///   - `height`: window height (in character cells). Minimum of 1.
 ///   - `width`: window width (in character cells). Minimum of 1.
+///   - 'bufpos': position float relative text inside the window `win` (only
+///               when relative="win"). Takes a tuple of [line, column] where
+///               both are zero-index. Note: `row` and `col` if present, still
+///               applies relative this positio. By default `row=1` and `col=0`
+///               is used (with default NW anchor), to make the float
+///               behave like a tooltip under the buffer text.
 ///   - `row`: row position. Screen cell height are used as unit. Can be
 ///       floating point.
 ///   - `col`: column position. Screen cell width is used as unit. Can be

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -503,25 +503,33 @@ Dictionary nvim_win_get_config(Window window, Error *err)
     return rv;
   }
 
-  PUT(rv, "focusable", BOOLEAN_OBJ(wp->w_float_config.focusable));
-  PUT(rv, "external", BOOLEAN_OBJ(wp->w_float_config.external));
+  FloatConfig *config = &wp->w_float_config;
+
+  PUT(rv, "focusable", BOOLEAN_OBJ(config->focusable));
+  PUT(rv, "external", BOOLEAN_OBJ(config->external));
 
   if (wp->w_floating) {
-    PUT(rv, "width", INTEGER_OBJ(wp->w_float_config.width));
-    PUT(rv, "height", INTEGER_OBJ(wp->w_float_config.height));
-    if (!wp->w_float_config.external) {
-      if (wp->w_float_config.relative == kFloatRelativeWindow) {
-        PUT(rv, "win", INTEGER_OBJ(wp->w_float_config.window));
+    PUT(rv, "width", INTEGER_OBJ(config->width));
+    PUT(rv, "height", INTEGER_OBJ(config->height));
+    if (!config->external) {
+      if (config->relative == kFloatRelativeWindow) {
+        PUT(rv, "win", INTEGER_OBJ(config->window));
+        if (config->bufpos.lnum >= 0) {
+          Array pos = ARRAY_DICT_INIT;
+          ADD(pos, INTEGER_OBJ(config->bufpos.lnum));
+          ADD(pos, INTEGER_OBJ(config->bufpos.col));
+          PUT(rv, "bufpos", ARRAY_OBJ(pos));
+        }
       }
       PUT(rv, "anchor", STRING_OBJ(cstr_to_string(
-          float_anchor_str[wp->w_float_config.anchor])));
-      PUT(rv, "row", FLOAT_OBJ(wp->w_float_config.row));
-      PUT(rv, "col", FLOAT_OBJ(wp->w_float_config.col));
+          float_anchor_str[config->anchor])));
+      PUT(rv, "row", FLOAT_OBJ(config->row));
+      PUT(rv, "col", FLOAT_OBJ(config->col));
     }
   }
 
-  const char *rel = (wp->w_floating && !wp->w_float_config.external
-                     ? float_relative_str[wp->w_float_config.relative] : "");
+  const char *rel = (wp->w_floating && !config->external
+                     ? float_relative_str[config->relative] : "");
   PUT(rv, "relative", STRING_OBJ(cstr_to_string(rel)));
 
   return rv;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1006,7 +1006,7 @@ typedef enum {
   kFloatRelativeCursor = 2,
 } FloatRelative;
 
-EXTERN const char *const float_relative_str[] INIT(= { "editor", "window",
+EXTERN const char *const float_relative_str[] INIT(= { "editor", "win",
                                                        "cursor" });
 
 typedef enum {
@@ -1016,6 +1016,7 @@ typedef enum {
 
 typedef struct {
   Window window;
+  lpos_T bufpos;
   int height, width;
   double row, col;
   FloatAnchor anchor;
@@ -1026,6 +1027,7 @@ typedef struct {
 } FloatConfig;
 
 #define FLOAT_CONFIG_INIT ((FloatConfig){ .height = 0, .width = 0, \
+                                          .bufpos = { -1, 0 }, \
                                           .row = 0, .col = 0, .anchor = 0, \
                                           .relative = 0, .external = false, \
                                           .focusable = true, \

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14781,6 +14781,32 @@ static void f_screencol(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->vval.v_number = ui_current_col() + 1;
 }
 
+/// "screenpos({winid}, {lnum}, {col})" function
+static void f_screenpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  pos_T pos;
+  int row = 0;
+  int scol = 0, ccol = 0, ecol = 0;
+
+  tv_dict_alloc_ret(rettv);
+  dict_T *dict = rettv->vval.v_dict;
+
+  win_T *wp = find_win_by_nr_or_id(&argvars[0]);
+  if (wp == NULL) {
+    return;
+  }
+
+  pos.lnum = tv_get_number(&argvars[1]);
+  pos.col = tv_get_number(&argvars[2]) - 1;
+  pos.coladd = 0;
+  textpos2screenpos(wp, &pos, &row, &scol, &ccol, &ecol, false);
+
+  tv_dict_add_nr(dict, S_LEN("row"), row);
+  tv_dict_add_nr(dict, S_LEN("col"), scol);
+  tv_dict_add_nr(dict, S_LEN("curscol"), ccol);
+  tv_dict_add_nr(dict, S_LEN("endcol"), ecol);
+}
+
 /*
  * "screenrow()" function
  */

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -266,6 +266,7 @@ return {
     screenattr={args=2},
     screenchar={args=2},
     screencol={},
+    screenpos={args=3},
     screenrow={},
     search={args={1, 4}},
     searchdecl={args={1, 3}},

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -64,3 +64,31 @@ func Test_curswant_with_cursorline()
   call assert_equal(6, winsaveview().curswant)
   quit!
 endfunc
+
+func Test_screenpos()
+  rightbelow new
+  rightbelow 20vsplit
+  call setline(1, ["\tsome text", "long wrapping line here", "next line"])
+  redraw
+  let winid = win_getid()
+  let [winrow, wincol] = win_screenpos(winid)
+  call assert_equal({'row': winrow,
+    \ 'col': wincol + 0,
+    \ 'curscol': wincol + 7,
+    \ 'endcol': wincol + 7}, screenpos(winid, 1, 1))
+  call assert_equal({'row': winrow,
+    \ 'col': wincol + 13,
+    \ 'curscol': wincol + 13,
+    \ 'endcol': wincol + 13}, screenpos(winid, 1, 7))
+  call assert_equal({'row': winrow + 2,
+    \ 'col': wincol + 1,
+    \ 'curscol': wincol + 1,
+    \ 'endcol': wincol + 1}, screenpos(winid, 2, 22))
+  setlocal number
+  call assert_equal({'row': winrow + 3,
+    \ 'col': wincol + 9,
+    \ 'curscol': wincol + 9,
+    \ 'endcol': wincol + 9}, screenpos(winid, 2, 22))
+  close
+  bwipe!
+endfunc

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -963,6 +963,335 @@ describe('floating windows', function()
       end
     end)
 
+    it('can be placed relative text in a window', function()
+      screen:try_resize(30,5)
+      local firstwin = meths.get_current_win().id
+      meths.buf_set_lines(0, 0, -1, true, {'just some', 'example text that is wider than the window', '', '', 'more text'})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [3:------------------------------]|
+        ## grid 2
+          ^just some                     |
+          example text that is wider tha|
+          n the window                  |
+                                        |
+        ## grid 3
+                                        |
+        ]]}
+      else
+        screen:expect{grid=[[
+          ^just some                     |
+          example text that is wider tha|
+          n the window                  |
+                                        |
+                                        |
+        ]]}
+      end
+
+      local buf = meths.create_buf(false,false)
+      meths.buf_set_lines(buf, 0, -1, true, {'some info!'})
+
+      local win = meths.open_win(buf, false, {relative='win', width=12, height=1, bufpos={1,32}})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [3:------------------------------]|
+        ## grid 2
+          ^just some                     |
+          example text that is wider tha|
+          n the window                  |
+                                        |
+        ## grid 3
+                                        |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "NW", 2, 3, 2, true }
+        }}
+      else
+        screen:expect{grid=[[
+          ^just some                     |
+          example text that is wider tha|
+          n the window                  |
+            {1:some info!  }                |
+                                        |
+        ]]}
+      end
+      eq({relative='win', width=12, height=1, bufpos={1,32}, anchor='NW',
+          external=false, col=0, row=1, win=firstwin, focusable=true}, meths.win_get_config(win))
+
+      feed('<c-e>')
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [2:------------------------------]|
+          [3:------------------------------]|
+        ## grid 2
+          ^example text that is wider tha|
+          n the window                  |
+                                        |
+                                        |
+        ## grid 3
+                                        |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "NW", 2, 2, 2, true }
+        }}
+      else
+        screen:expect{grid=[[
+          ^example text that is wider tha|
+          n the window                  |
+            {1:some info!  }                |
+                                        |
+                                        |
+        ]]}
+      end
+
+
+      screen:try_resize(45,5)
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          ^example text that is wider than the window   |
+                                                       |
+                                                       |
+          more text                                    |
+        ## grid 3
+                                                       |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "NW", 2, 1, 32, true }
+        }}
+      else
+        -- note: appears misalinged due to cursor
+        screen:expect{grid=[[
+          ^example text that is wider than the window   |
+                                          {1:some info!  } |
+                                                       |
+          more text                                    |
+                                                       |
+        ]]}
+      end
+
+      screen:try_resize(25,10)
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [3:-------------------------]|
+        ## grid 2
+          ^example text that is wide|
+          r than the window        |
+                                   |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+        ## grid 3
+                                   |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "NW", 2, 2, 7, true }
+        }}
+      else
+        screen:expect{grid=[[
+          ^example text that is wide|
+          r than the window        |
+                 {1:some info!  }      |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+                                   |
+        ]]}
+      end
+
+      meths.win_set_config(win, {relative='win', bufpos={1,32}, anchor='SW'})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [3:-------------------------]|
+        ## grid 2
+          ^example text that is wide|
+          r than the window        |
+                                   |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+        ## grid 3
+                                   |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "SW", 2, 1, 7, true }
+        }}
+      else
+        screen:expect{grid=[[
+          ^example{1:some info!  }s wide|
+          r than the window        |
+                                   |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+                                   |
+        ]]}
+      end
+
+      meths.win_set_config(win, {relative='win', bufpos={1,32}, anchor='NW', col=-2})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [3:-------------------------]|
+        ## grid 2
+          ^example text that is wide|
+          r than the window        |
+                                   |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+        ## grid 3
+                                   |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "NW", 2, 2, 5, true }
+        }}
+      else
+        screen:expect{grid=[[
+          ^example text that is wide|
+          r than the window        |
+               {1:some info!  }        |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+                                   |
+        ]]}
+      end
+
+      meths.win_set_config(win, {relative='win', bufpos={1,32}, row=2})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [2:-------------------------]|
+          [3:-------------------------]|
+        ## grid 2
+          ^example text that is wide|
+          r than the window        |
+                                   |
+                                   |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+        ## grid 3
+                                   |
+        ## grid 5
+          {1:some info!  }|
+        ]], float_pos={
+          [5] = { {
+              id = 1002
+            }, "NW", 2, 3, 7, true }
+        }}
+      else
+        screen:expect{grid=[[
+          ^example text that is wide|
+          r than the window        |
+                                   |
+                 {1:some info!  }      |
+          more text                |
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+          {0:~                        }|
+                                   |
+        ]]}
+      end
+    end)
+
     it('validates cursor even when window is not entered', function()
       screen:try_resize(30,5)
       command("set nowrap")


### PR DESCRIPTION
This was what I originally had in mind for `anchor="win"` but I never got around to it, because position logic in `move.c` seemed too entangled to the cursor. But this recent vim patch https://github.com/vim/vim/commit/b3d17a20d243f65bcfe23de08b7afd948c5132c2 revelaed what is needed to properly calculate the screen position from any buffer position. (probably we should merge screenpos() here also, then we can mark the patch as included, as the rest is NA/replaced by the functionality added here).

Adds a `'bufpos': [lnum, col]` argument to the `win` relative mode of `nvim_open_win()`, which is useful to anchor the float at a given text position in the window. Note: one still has to pass i e `row=1, col=0` to make it appear right under the text rather than cover the text. Probably we want to add an additional "pum-like" anchor mode, where the float automatically will be placed just below by default, but above if it doesn't fit below.

