### PR TITLE
Revert "tests: executable_spec: enable pending test"

### DIFF
--- a/test/functional/eval/executable_spec.lua
+++ b/test/functional/eval/executable_spec.lua
@@ -24,7 +24,12 @@ describe('executable()', function()
       eq('arg1=lemon;arg2=sky;arg3=tree;',
          call('system', sibling_exe..' lemon sky tree'))
     end
-    eq(expected, call('executable', sibling_exe))
+    local is_executable = call('executable', sibling_exe)
+    if iswin() and is_executable ~= expected then
+      pending('XXX: sometimes fails on AppVeyor')
+    else
+      eq(expected, is_executable)
+    end
   end)
 
   describe('exec-bit', function()


### PR DESCRIPTION
Reverts neovim/neovim#10443

It is still flaky.