### PR TITLE
build: LibUV: required version: 1.28.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ endif()
 include_directories("${PROJECT_BINARY_DIR}/config")
 include_directories("${PROJECT_SOURCE_DIR}/src")
 
-find_package(LibUV REQUIRED)  # minimum version: v1.12
+find_package(LibUV 1.28.0 REQUIRED)
 include_directories(SYSTEM ${LIBUV_INCLUDE_DIRS})
 
 find_package(Msgpack 1.0.0 REQUIRED)


### PR DESCRIPTION
For uv_gettimeofday.

Ref: https://github.com/neovim/neovim/pull/10453#issuecomment-509583170