### PR TITLE
Update stripdecls.py

### DIFF
--- a/scripts/stripdecls.py
+++ b/scripts/stripdecls.py
@@ -18,8 +18,6 @@ Strip = namedtuple('Strip', 'start_line start_column end_line end_column')
 
 
 def main(progname, cfname, only_static, move_all):
-  only_static = False
-
   cfname = os.path.abspath(os.path.normpath(cfname))
 
   hfname1 = os.path.splitext(cfname)[0] + os.extsep + 'h'


### PR DESCRIPTION
This commit removes the `only_static = False` which overwritten the argument passed to stripdecls.py main function making the:
```python
    if only_static and next(child.get_tokens()).spelling == 'static':
      continue
```
branch to be never taken.

As a result passing a `--static` argument to stripdecls.py had no effect.