### PR TITLE
ci: AppVeyor: do not install unibilium system-wide  [skip travis]

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -50,7 +50,7 @@ if ($compiler -eq 'MINGW') {
   # in MSYS2, but we cannot build inside the MSYS2 shell.
   $cmakeGenerator = 'Ninja'
   $cmakeGeneratorArgs = '-v'
-  $mingwPackages = @('ninja', 'cmake', 'perl', 'diffutils', 'unibilium').ForEach({
+  $mingwPackages = @('ninja', 'cmake', 'perl', 'diffutils').ForEach({
     "mingw-w64-$arch-$_"
   })
 


### PR DESCRIPTION
Initially added in 685ca180f, but gets built via third-party anyway.