### PR TITLE
vim-patch:8.1.1173: suspend test has duplicated lines

### DIFF
--- a/src/nvim/testdir/test_suspend.vim
+++ b/src/nvim/testdir/test_suspend.vim
@@ -2,6 +2,20 @@
 
 source shared.vim
 
+func CheckSuspended(buf, fileExists)
+  call WaitForAssert({-> assert_match('[$#] $', term_getline(a:buf, '.'))})
+
+  if a:fileExists
+    call assert_equal(['foo'], readfile('Xfoo'))
+  else
+    " Without 'autowrite', buffer should not be written.
+    call assert_equal(0, filereadable('Xfoo'))
+  endif
+
+  call term_sendkeys(a:buf, "fg\<CR>\<C-L>")
+  call WaitForAssert({-> assert_equal('  1 foo', term_getline(a:buf, '.'))})
+endfunc
+
 func Test_suspend()
   if !has('terminal') || !executable('/bin/sh')
     return
@@ -26,13 +40,7 @@ func Test_suspend()
         \             "\<C-Z>"]
     " Suspend and wait for shell prompt.
     call term_sendkeys(buf, suspend_cmd)
-    call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
-
-    " Without 'autowrite', buffer should not be written.
-    call assert_equal(0, filereadable('Xfoo'))
-
-    call term_sendkeys(buf, "fg\<CR>")
-    call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+    call CheckSuspended(buf, 0)
   endfor
 
   " Test that :suspend! with 'autowrite' writes content of buffers if modified.
@@ -40,10 +48,7 @@ func Test_suspend()
   call assert_equal(0, filereadable('Xfoo'))
   call term_sendkeys(buf, ":suspend\<CR>")
   " Wait for shell prompt.
-  call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
-  call assert_equal(['foo'], readfile('Xfoo'))
-  call term_sendkeys(buf, "fg\<CR>")
-  call WaitForAssert({-> assert_equal('  1 foo', term_getline(buf, '.'))})
+  call CheckSuspended(buf, 1)
 
   " Quit gracefully to dump coverage information.
   call term_sendkeys(buf, ":qall!\<CR>")


### PR DESCRIPTION
Problem:    Suspend test has duplicated lines.
Solution:   Use a function.
https://github.com/vim/vim/commit/a8356bc1734195d130c6eeaf4858356ae3a3f722