### PR TITLE
[RFC] Fix is_executable_in_path() on Windows

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -364,7 +364,7 @@ static bool is_executable_in_path(const char_u *name, char_u **abspath)
 #ifdef WIN32
   // Prepend ".;" to $PATH.
   size_t pathlen = strlen(path_env);
-  char *path = memcpy(xmallocz(pathlen + 3), "." ENV_SEPSTR, 2);
+  char *path = memcpy(xmallocz(pathlen + 2), "." ENV_SEPSTR, 2);
   memcpy(path + 2, path_env, pathlen);
 #else
   char *path = xstrdup(path_env);

--- a/test/functional/eval/executable_spec.lua
+++ b/test/functional/eval/executable_spec.lua
@@ -24,12 +24,7 @@ describe('executable()', function()
       eq('arg1=lemon;arg2=sky;arg3=tree;',
          call('system', sibling_exe..' lemon sky tree'))
     end
-    local is_executable = call('executable', sibling_exe)
-    if iswin() and is_executable ~= expected then
-      pending('XXX: sometimes fails on AppVeyor')
-    else
-      eq(expected, is_executable)
-    end
+    eq(expected, call('executable', sibling_exe))
   end)
 
   describe('exec-bit', function()


### PR DESCRIPTION
Fix the problem that 1 byte extra memory was allocated in `is_executable_in_path()`.