### PR TITLE
vim-patch:8.1.1660: assert_fails() does not fail inside try/catch

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7097,10 +7097,14 @@ static void f_assert_fails(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   const char *const cmd = tv_get_string_chk(&argvars[0]);
   garray_T    ga;
+  int         save_trylevel = trylevel;
 
+  // trylevel must be zero for a ":throw" command to be considered failed
+  trylevel = 0;
   called_emsg = false;
   suppress_errthrow = true;
   emsg_silent = true;
+
   do_cmdline_cmd(cmd);
   if (!called_emsg) {
     prepare_assert_error(&ga);
@@ -7122,6 +7126,7 @@ static void f_assert_fails(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
   }
 
+  trylevel = save_trylevel;
   called_emsg = false;
   suppress_errthrow = false;
   emsg_silent = false;

--- a/src/nvim/testdir/test_assert.vim
+++ b/src/nvim/testdir/test_assert.vim
@@ -1,5 +1,11 @@
 " Test that the methods used for testing work.
 
+func Test_assert_fails_in_try_block()
+  try
+    call assert_equal(0, assert_fails('throw "error"'))
+  endtry
+endfunc
+
 " Must be last.
 func Test_zz_quit_detected()
   " Verify that if a test function ends Vim the test script detects this.


### PR DESCRIPTION
Problem:    Assert_fails() does not fail inside try/catch.
Solution:   Set trylevel to zero. (Ozaki Kiichi, closes vim/vim#4639)
https://github.com/vim/vim/commit/7780e5c1c5485a979ab6e3914a43e17912e213a8