### PR TITLE
Remove non-existing flag usage from pvs-studio-analyzer

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -369,7 +369,6 @@ run_analysis() {(
     analyze \
       --threads "$(get_jobs_num)" \
       --output-file PVS-studio.log \
-      --verbose \
       --file build/compile_commands.json \
       --sourcetree-root . || true
 


### PR DESCRIPTION
It looks like `verbose` flag was removed from `pvs-studio-analyzer`, which causes the following error 
when `scripts/pvscheck.sh` is run:

```
Flag could not be matched: verbose
Compiler commands monitoring and analyzer tool.
Copyright (c) 2008-2019 OOO "Program Verification Systems"

PVS-Studio is a static code analyzer and SAST (static application security
testing) tool that is available for C and C++ desktop and embedded development,
C# and Java under Windows, Linux and macOS.

Usage: pvs-studio-analyzer analyze [-l <FILE>] [-j <N>] [-i] [-o <FILE>]
                           [-c <FILE>] [-s <FILE>] [-q] [-f <FILE>]
                           [-C <COMPILER_NAME...>] [-E <VAR=VALUE>] [-e <DIR>]
                           [-a <MODE>] [-r <DIR>] [-d] [--preprocessor <NAME>]
                           [--platform <NAME>]

Launch PVS-Studio for your project

Options:

    -l [FILE], --lic-file [FILE]
        PVS-Studio license file
    -j [N], --threads [N]
        Allow N PVS-Studio analyzers at once
        Default: 1
    -i, --incremental
        Use incremental analysis
    -o [FILE], --output-file [FILE]
        Place the analyzer's report into FILE
    -c [FILE], --cfg [FILE]
        Run PVS using config FILE
    -s [FILE], --suppress-file [FILE]
        Path to suppress file
        Default: suppress_base.json
    -q, --quiet
        Analysis progress is not displayed
    -f [FILE], --file [FILE]
        Use trace output or compile commands database FILE
        Default: 'compile_commands.json', 'strace_out'
    -C [COMPILER_NAME...], --compiler [COMPILER_NAME...]
        Filter compiler commands by compiler name
    -E [VAR=VALUE], --env [VAR=VALUE]
        Modify environment for preprocessor
    -e [DIR], --exclude-path [DIR]
        Directory whose files are not necessary to check
    -a [MODE], --analysis-mode [MODE]
        MODE defines the type of warnings:
        1 - 64-bit errors;
        2 - reserved;
        4 - General Analysis;
        8 - Micro-optimizations;
        16 - Customers Specific Requests;
        32 - MISRA.
        Modes can be combined by adding the values
        Default: 4
    -r [DIR], --sourcetree-root [DIR]
        Replace absolute paths in report with relative paths
    -d, --disableLicenseExpirationCheck
        Sets return code back to 0 if license will expire soon
    --preprocessor [NAME]
        Preprocessor (gcc or clang)
        Default: <auto-detected>
    --platform [NAME]
        Platform (linux64, linux32)
        Default: linux64
```

Removing non-existent flag fixes the problem and `scripts/pvscheck.sh` generates report as expected.