### PR TITLE
build: fix check_c_compiler_flag for -Wno-…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,8 +329,8 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
   # 2. But _Pragma("...ignored") is broken (unresolved) in GCC 5+:
   #    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66099
   # So we must disable -Warray-bounds globally for GCC (for kbtree.h, #7083).
-  check_c_compiler_flag(-Wno-array-bounds HAS_NO_ARRAY_BOUNDS_FLAG)
-  if(HAS_NO_ARRAY_BOUNDS_FLAG)
+  check_c_compiler_flag(-Warray-bounds HAS_WARRAY_BOUNDS)
+  if(HAS_WARRAY_BOUNDS)
     add_compile_options(-Wno-array-bounds)
   endif()
 endif()

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -164,8 +164,8 @@ if(NOT MSVC)
   set_source_files_properties(
     ${CONV_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion")
   # gperf generates ANSI-C with incorrect linkage, ignore it.
-  check_c_compiler_flag(-Wno-static-in-inline HAS_WNO_STATIC_IN_INLINE_FLAG)
-  if(HAS_WNO_STATIC_IN_INLINE_FLAG)
+  check_c_compiler_flag(-Wstatic-in-inline HAS_WSTATIC_IN_INLINE)
+  if(HAS_WSTATIC_IN_INLINE)
     set_source_files_properties(
       eval.c PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-static-in-inline -Wno-conversion")
   else()


### PR DESCRIPTION
`check_c_compiler_flag(-Wno-doesnotexist …)` is successful always,
apparently for all "no-" prefixes.

Therefore check for the flag itself (without "no-" prefix).

I am seeing a warning if the source fails to compile:

> cc1: warning: unrecognized command line option ‘-Wno-meh’

Which is turned into an error with `-Werror`:

> cc1: error: unrecognized command line option ‘-Wno-meh’ [-Werror]

But when it compiles successfully, there is no warning/error.

gcc (GCC) 9.1.0.