### PR TITLE
tests: use vim.inspect

### DIFF
--- a/test/functional/ex_cmds/menu_spec.lua
+++ b/test/functional/ex_cmds/menu_spec.lua
@@ -83,7 +83,7 @@ describe('menu_get', function()
   it("path='', modes='a'", function()
     local m = funcs.menu_get("","a");
     -- HINT: To print the expected table and regenerate the tests:
-    -- print(require('inspect')(m))
+    -- print(require('vim.inspect')(m))
     local expected = {
       {
         shortcut = "T",

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -81,7 +81,7 @@ local dedent = helpers.dedent
 local get_session = helpers.get_session
 local create_callindex = helpers.create_callindex
 
-local inspect = require('inspect')
+local inspect = require('vim.inspect')
 
 local function isempty(v)
   return type(v) == 'table' and next(v) == nil
@@ -492,7 +492,7 @@ function Screen:_wait(check, flags)
       end
     elseif success_seen and #args > 0 then
       failure_after_success = true
-      --print(require('inspect')(args))
+      --print(require('vim.inspect')(args))
     end
 
     return true
@@ -577,7 +577,7 @@ function Screen:_redraw(updates)
   local did_flush = false
   for k, update in ipairs(updates) do
     -- print('--')
-    -- print(require('inspect')(update))
+    -- print(require('vim.inspect')(update))
     local method = update[1]
     for i = 2, #update do
       local handler_name = '_handle_'..method
@@ -1339,7 +1339,7 @@ end
 
 
 function Screen:_pprint_hlstate(item)
-    --print(require('inspect')(item))
+    --print(require('vim.inspect')(item))
     local attrdict = "{"..self:_pprint_attrs(item[1]).."}, "
     local attrdict2, hlinfo
     if self._hlstate_cterm then

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -492,7 +492,7 @@ function Screen:_wait(check, flags)
       end
     elseif success_seen and #args > 0 then
       failure_after_success = true
-      --print(require('vim.inspect')(args))
+      -- print(inspect(args))
     end
 
     return true
@@ -576,8 +576,7 @@ end
 function Screen:_redraw(updates)
   local did_flush = false
   for k, update in ipairs(updates) do
-    -- print('--')
-    -- print(require('vim.inspect')(update))
+    -- print('--', inspect(update))
     local method = update[1]
     for i = 2, #update do
       local handler_name = '_handle_'..method
@@ -1339,7 +1338,7 @@ end
 
 
 function Screen:_pprint_hlstate(item)
-    --print(require('vim.inspect')(item))
+    -- print(inspect(item))
     local attrdict = "{"..self:_pprint_attrs(item[1]).."}, "
     local attrdict2, hlinfo
     if self._hlstate_cterm then

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -129,20 +129,12 @@ add_custom_command(OUTPUT ${ROCKS_DIR}/lpeg
 add_custom_target(lpeg DEPENDS ${ROCKS_DIR}/lpeg)
 list(APPEND THIRD_PARTY_DEPS lpeg)
 
-# inspect
-add_custom_command(OUTPUT ${ROCKS_DIR}/inspect
-  COMMAND ${LUAROCKS_BINARY}
-  ARGS build inspect 3.1.1-0 ${LUAROCKS_BUILDARGS}
-  DEPENDS lpeg)
-add_custom_target(inspect DEPENDS ${ROCKS_DIR}/inspect)
-list(APPEND THIRD_PARTY_DEPS inspect)
-
 if((NOT USE_BUNDLED_LUAJIT) AND USE_BUNDLED_LUA)
   # luabitop
   add_custom_command(OUTPUT ${ROCKS_DIR}/luabitop
     COMMAND ${LUAROCKS_BINARY}
     ARGS build luabitop 1.0.2-3 ${LUAROCKS_BUILDARGS}
-    DEPENDS inspect)
+    DEPENDS lpeg)
   add_custom_target(luabitop DEPENDS ${ROCKS_DIR}/luabitop)
   list(APPEND THIRD_PARTY_DEPS luabitop)
 endif()
@@ -151,7 +143,7 @@ if(USE_BUNDLED_BUSTED)
   if((NOT USE_BUNDLED_LUAJIT) AND USE_BUNDLED_LUA)
     set(PENLIGHT_DEPENDS luabitop)
   else()
-    set(PENLIGHT_DEPENDS inspect)
+    set(PENLIGHT_DEPENDS lpeg)
   endif()
 
   # penlight


### PR DESCRIPTION
The inspect modules is vendored as `vim.inspect`, and therefore it makes
sense to use this in tests also.

Ref: https://github.com/neovim/neovim/issues/6580
Ref: https://github.com/neovim/neovim/commit/bb3aa824b