### PR TITLE
Revert "Downgrade to clang-4.0 to avoid false-positive warnings from clang"  [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
     - ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1:log_path=$LOG_DIR/asan"
     - TSAN_OPTIONS="log_path=$LOG_DIR/tsan"
     - UBSAN_OPTIONS="print_stacktrace=1 log_path=$LOG_DIR/ubsan"
-    - ASAN_SYMBOLIZE=asan_symbolize
     # Environment variables for Valgrind.
     - VALGRIND_LOG="$LOG_DIR/valgrind-%p.log"
     # If this file exists, the cache is valid (compile was successful).
@@ -62,7 +61,7 @@ addons:
       - autoconf
       - automake
       - build-essential
-      - clang-4.0
+      - clang
       - cmake
       - cscope
       - gcc-multilib
@@ -88,12 +87,11 @@ jobs:
     - stage: baseline
       name: clang-asan
       os: linux
-      compiler: clang-4.0
+      compiler: clang
       # Use Lua so that ASAN can test our embedded Lua support. 8fec4d53d0f6
       env:
         - CLANG_SANITIZER=ASAN_UBSAN
         - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
-        - ASAN_SYMBOLIZE=asan_symbolize-4.0
         - *common-job-env
     - name: gcc-functionaltest-lua
       os: linux

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -81,7 +81,7 @@ valgrind_check() {
 
 asan_check() {
   if test "${CLANG_SANITIZER}" = "ASAN_UBSAN" ; then
-    check_logs "${1}" "*san.*" | $ASAN_SYMBOLIZE
+    check_logs "${1}" "*san.*" | asan_symbolize
   fi
 }
 


### PR DESCRIPTION
This reverts commit 2cbac719c3eba8ea5826e16912126d70222911ed.