### PR TITLE
viml/profile: revert gettimeofday()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16540,7 +16540,7 @@ static void f_reltimefloat(typval_T *argvars , typval_T *rettv, FunPtr fptr)
   rettv->v_type = VAR_FLOAT;
   rettv->vval.v_float = 0;
   if (list2proftime(&argvars[0], &tm) == OK) {
-    rettv->vval.v_float = ((float_T)tm) / 1000000;
+    rettv->vval.v_float = ((float_T)tm) / 1000000000;
   }
 }
 

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -31,27 +31,6 @@ void time_init(void)
   uv_cond_init(&delay_cond);
 }
 
-/// Gets the current time with microsecond (μs) precision.
-///
-/// Subject to system-clock quirks (drift, going backwards, skipping).
-/// But it is much faster than os_hrtime() on some systems. #10328
-///
-/// @see gettimeofday(2)
-///
-/// @return Current time in microseconds.
-int64_t os_utime(void)
-  FUNC_ATTR_WARN_UNUSED_RESULT
-{
-  uv_timeval64_t tm;
-  int e = uv_gettimeofday(&tm);
-  if (e != 0 || tm.tv_sec < 0 || tm.tv_usec < 0) {
-    return 0;
-  }
-  int64_t rv = tm.tv_sec * 1000 * 1000;  // s => μs
-  STRICT_ADD(rv, tm.tv_usec, &rv, int64_t);
-  return rv;
-}
-
 /// Gets a high-resolution (nanosecond), monotonically-increasing time relative
 /// to an arbitrary time in the past.
 ///


### PR DESCRIPTION
e2ce5ff9d616 was proven to be bogus, so revert it.

User observed TSC being disabled:

    $ dmesg | grep TSC
    [    0.002665] tsc: Detected 2592.000 MHz TSC
    [    0.594826] TSC deadline timer enabled
    [  163.591720] tsc: Marking TSC unstable due to clocksource watchdog
    [  163.591747] TSC found unstable after boot, most likely due to broken BIOS. Use 'tsc=unstable'.

https://github.com/neovim/neovim/issues/10328#issuecomment-507814528
> On Linx, uv_hrtime() is driven by vDSO, which just checks the
> TSC (Time Stamp Counter) register and applies some basic math.
> It probably shouldn't even register as kernel-space time since
> vDSO should avoid a context-switch.
>
> So, it seems like something is causing newer (buggy) kernel to switch
> to using the non-vDSO codepath (fallback to libc impl, which does
> a syscall). If called a lot, this might be slow.

close #10328
ref #10356
ref #10452