### PR TITLE
runtime: use yarn in checkhealth

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -564,7 +564,10 @@ function! s:check_node() abort
   endif
   call health#report_info('Neovim node.js host: '. host)
 
-  let latest_npm_cmd = has('win32') ? 'cmd /c npm info neovim --json' : 'npm info neovim --json'
+  let manager = executable('npm') ? 'npm' : 'yarn'
+  let latest_npm_cmd = has('win32') ?
+        \ 'cmd /c '. manager .' info neovim --json' :
+        \ manager .' info neovim --json'
   let latest_npm = s:system(split(latest_npm_cmd))
   if s:shell_error || empty(latest_npm)
     call health#report_error('Failed to run: '. latest_npm_cmd,
@@ -593,7 +596,8 @@ function! s:check_node() abort
     call health#report_warn(
           \ printf('Package "neovim" is out-of-date. Installed: %s, latest: %s',
           \ current_npm, latest_npm),
-          \ ['Run in shell: npm install -g neovim'])
+          \ ['Run in shell: npm install -g neovim',
+          \  'Run in shell (if you use yarn): yarn global add neovim'])
   else
     call health#report_ok('Latest "neovim" npm/yarn package is installed: '. current_npm)
   endif


### PR DESCRIPTION
This PR fixes #10489.

#### Before:

```
## Node.js provider (optional)
  - INFO: Node.js: v11.15.0
  - INFO: Neovim node.js host: /home/johan/.config/yarn/global//node_modules/neovim/bin/cli.js
  - ERROR: Command error (job=-1): `npm info neovim --json` (in '/home/johan')
  - ERROR: Failed to run: npm info neovim --json
    - ADVICE:
      - Make sure you're connected to the internet.
      - Are you behind a firewall or proxy?
```

#### After:

```
## Node.js provider (optional)
  - INFO: Node.js: v11.15.0
  - INFO: Neovim node.js host: /home/johan/.config/yarn/global//node_modules/neovim/bin/cli.js
  - OK: Latest "neovim" npm/yarn package is installed: 4.5.0
```