### PR TITLE
[RDY] Fix macOS Catalina dependencies build

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -101,6 +101,7 @@ set(DEPS_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
 
 if(CMAKE_OSX_SYSROOT)
   set(DEPS_C_COMPILER "${DEPS_C_COMPILER} -isysroot${CMAKE_OSX_SYSROOT}")
+  set(DEPS_CXX_COMPILER "${DEPS_CXX_COMPILER} -isysroot${CMAKE_OSX_SYSROOT}")
 endif()
 
 # Cross compiling: use these for dependencies built for the


### PR DESCRIPTION
`Catalina` no longer supports system compatibility headers, so `sysroot` has to be explicitly specified.
When building dependencies it was propagated to C, but not to C++ compiler, which was causing Gperf build failures. 