### PR TITLE
floats: fix 'winblend' on top of doublewidth chars.

### DIFF
--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -36,6 +36,7 @@ typedef struct attr_entry {
   .rgb_sp_color = -1, \
   .cterm_fg_color = 0, \
   .cterm_bg_color = 0, \
+  .hl_blend = -1, \
 }
 
 /// Values for index in highlight_attr[].

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -344,11 +344,22 @@ static void compose_line(Integer row, Integer startcol, Integer endcol,
 
     // 'pumblend' and 'winblend'
     if (grid->blending) {
-      for (int i = col-(int)startcol; i < until-startcol; i++) {
-        bool thru = strequal((char *)linebuf[i], " ");  // negative space
+      int width;
+      for (int i = col-(int)startcol; i < until-startcol; i += width) {
+        width = 1;
+        // negative space
+        bool thru = strequal((char *)linebuf[i], " ") && bg_line[i][0] != NUL;
+        if (i+1 < endcol-startcol && bg_line[i+1][0] == NUL) {
+          width = 2;
+          thru &= strequal((char *)linebuf[i+1], " ");
+        }
         attrbuf[i] = (sattr_T)hl_blend_attrs(bg_attrs[i], attrbuf[i], &thru);
+        if (width == 2) {
+          attrbuf[i+1] = (sattr_T)hl_blend_attrs(bg_attrs[i+1],
+                                                 attrbuf[i+1], &thru);
+        }
         if (thru) {
-          memcpy(linebuf[i], bg_line[i], sizeof(linebuf[i]));
+          memcpy(linebuf[i], bg_line[i], (size_t)width * sizeof(linebuf[i]));
         }
       }
     }

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -4659,6 +4659,96 @@ describe('floating windows', function()
                                                   |
         ]])
       end
+
+      -- The interaction between 'winblend' and doublewidth chars in the background
+      -- does not look very good. But check no chars get incorrectly placed
+      -- at least. Also check invisible EndOfBuffer region blends correctly.
+      meths.buf_set_lines(buf, 0, -1, true, {" x x  x   xx", "  x x  x   x"})
+      win = meths.open_win(buf, false, {relative='editor', width=12, height=3, row=0, col=11, style='minimal'})
+      meths.win_set_option(win, 'winblend', 30)
+      screen:set_default_attr_ids({
+        [1] = {foreground = tonumber('0xb282b2'), background = tonumber('0xffcfff')},
+        [2] = {foreground = Screen.colors.Grey0, background = tonumber('0xffcfff')},
+        [3] = {bold = true, foreground = Screen.colors.Blue1},
+        [4] = {background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0xb282ff')},
+        [5] = {background = Screen.colors.LightMagenta},
+      })
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+                                                  |
+        ## grid 2
+          # TODO: 测试字典信息的准确性            |
+          # FIXME: 测试字典信息的准确^性           |
+          {3:~                                       }|
+          {3:~                                       }|
+          {3:~                                       }|
+          {3:~                                       }|
+        ## grid 5
+          {5: x x  x   xx}|
+          {5:  x x  x   x}|
+          {5:            }|
+        ]], float_pos={
+          [5] = { {
+              id = 1003
+            }, "NW", 1, 0, 11, true }
+        }}
+      else
+        screen:expect([[
+          # TODO: 测 {2: x x  x}{1:息}{2: xx} 确性            |
+          # FIXME: 测{1:试}{2:x x  x}{1:息}{2: x}准确^性           |
+          {3:~          }{4:            }{3:                 }|
+          {3:~                                       }|
+          {3:~                                       }|
+          {3:~                                       }|
+                                                  |
+        ]])
+      end
+
+      meths.win_set_config(win, {relative='editor', row=0, col=12})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+                                                  |
+        ## grid 2
+          # TODO: 测试字典信息的准确性            |
+          # FIXME: 测试字典信息的准确^性           |
+          {3:~                                       }|
+          {3:~                                       }|
+          {3:~                                       }|
+          {3:~                                       }|
+        ## grid 5
+          {5: x x  x   xx}|
+          {5:  x x  x   x}|
+          {5:            }|
+        ]], float_pos={
+          [5] = { {
+              id = 1003
+            }, "NW", 1, 0, 12, true }
+        }}
+      else
+        screen:expect([[
+          # TODO: 测试{2: x x}{1:信}{2:x }{1:的}{2:xx}确性            |
+          # FIXME: 测 {2:  x x}{1:信}{2:x }{1:的}{2:x} 确^性           |
+          {3:~           }{4:            }{3:                }|
+          {3:~                                       }|
+          {3:~                                       }|
+          {3:~                                       }|
+                                                  |
+        ]])
+      end
     end)
   end
 


### PR DESCRIPTION
The interaction between 'winblend' and doublewidth chars in the background does not look very good. But check no chars get incorrectly placed at least. Fixes #10469

Also check that hidden `EndOfBuffer` region (from style="minimal") blends correctly.