### PR TITLE
highlight: expose builtin highlight groups using hl_group_set event

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -316,6 +316,14 @@ numerical highlight ids to the actual attributes.
 	`info` is an empty array by default, and will be used by the
 	|ui-hlstate| extension explained below.
 
+["hl_group_set", name, hl_id]
+	The bulitin highlight group `name` was set to use the attributes `hl_id`
+	defined by a previous `hl_attr_define` call. This event is not needed
+	to render the grids which use attribute ids directly, but is useful
+	for an UI who want to render its own elements with consistent
+	highlighting. For instance an UI using |ui-popupmenu| events, might
+	use the |hl-Pmenu| family of builtin highlights.
+
 							    *ui-event-grid_line*
 ["grid_line", grid, row, col_start, cells]
 	Redraw a continuous part of a `row` on a `grid`, starting at the column

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -123,6 +123,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   ui->mode_change = remote_ui_mode_change;
   ui->grid_scroll = remote_ui_grid_scroll;
   ui->hl_attr_define = remote_ui_hl_attr_define;
+  ui->hl_group_set = remote_ui_hl_group_set;
   ui->raw_line = remote_ui_raw_line;
   ui->bell = remote_ui_bell;
   ui->visual_bell = remote_ui_visual_bell;

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -73,6 +73,8 @@ void default_colors_set(Integer rgb_fg, Integer rgb_bg, Integer rgb_sp,
 void hl_attr_define(Integer id, HlAttrs rgb_attrs, HlAttrs cterm_attrs,
                     Array info)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_BRIDGE_IMPL;
+void hl_group_set(String name, Integer id)
+  FUNC_API_SINCE(6) FUNC_API_BRIDGE_IMPL;
 void grid_resize(Integer grid, Integer width, Integer height)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_COMPOSITOR_IMPL;
 void grid_clear(Integer grid)

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -150,6 +150,7 @@ EXTERN const char *hlf_names[] INIT(= {
 
 
 EXTERN int highlight_attr[HLF_COUNT];       // Highl. attr for each context.
+EXTERN int highlight_attr_last[HLF_COUNT];  // copy for detecting changed groups
 EXTERN int highlight_user[9];                   // User[1-9] attributes
 EXTERN int highlight_stlnc[9];                  // On top of user
 EXTERN int cterm_normal_fg_color INIT(= 0);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -14,6 +14,7 @@
 
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
+#include "nvim/api/private/helpers.h"
 #include "nvim/syntax.h"
 #include "nvim/charset.h"
 #include "nvim/cursor_shape.h"
@@ -7500,6 +7501,12 @@ void highlight_changed(void)
 
     highlight_attr[hlf] = hl_get_ui_attr(hlf, final_id,
                                          hlf == (int)HLF_INACTIVE);
+
+    if (highlight_attr[hlf] != highlight_attr_last[hlf]) {
+      ui_call_hl_group_set(cstr_as_string((char *)hlf_names[hlf]),
+                           highlight_attr[hlf]);
+      highlight_attr_last[hlf] = highlight_attr[hlf];
+    }
   }
 
   /* Setup the user highlights

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -311,6 +311,38 @@ describe('highlight defaults', function()
       [1] = {foreground=Screen.colors.Blue},
     })
   end)
+
+  it('are sent to UIs', function()
+    screen:try_resize(53, 4)
+    screen:set_default_attr_ids({
+      [0] = {},
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {bold = true, reverse = true},
+      [3] = {italic=true}
+    })
+    screen:expect{grid=[[
+      ^                                                     |
+      {1:~                                                    }|
+      {1:~                                                    }|
+                                                           |
+    ]], hl_groups={EndOfBuffer=1, MsgSeparator=2}}
+
+    command('highlight EndOfBuffer gui=italic')
+    screen:expect{grid=[[
+      ^                                                     |
+      {3:~                                                    }|
+      {3:~                                                    }|
+                                                           |
+    ]], hl_groups={EndOfBuffer=3, MsgSeparator=2}}
+
+    command('highlight clear EndOfBuffer')
+    screen:expect{grid=[[
+      ^                                                     |
+      ~                                                    |
+      ~                                                    |
+                                                           |
+    ]], hl_groups={EndOfBuffer=0, MsgSeparator=2}}
+  end)
 end)
 
 describe('highlight', function()


### PR DESCRIPTION
Expose the definitions of builtin highlight groups by name. This is useful i e for `ext_popupmenu` to use `Pmenu*` highlights (currently UI:s are using various hacks, which are not always reliable).

I will also use this for #10400, as multigrid UI:s will then be responsible for drawing `MsgSeparator` themselves (though they are free of course to draw it in their own style).

ref #9421