### PR TITLE
pvs/V1028 cast operands, not the result ops.c:2605

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2602,8 +2602,9 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
 
 static void yank_copy_line(yankreg_T *reg, struct block_def *bd, size_t y_idx)
 {
-  char_u *pnew = xmallocz((size_t)(bd->startspaces + bd->endspaces
-                                   + bd->textlen));
+  int size = bd->startspaces + bd->endspaces + bd->textlen;
+  assert(size >= 0);
+  char_u *pnew = xmallocz((size_t)size);
   reg->y_array[y_idx] = pnew;
   memset(pnew, ' ', (size_t)bd->startspaces);
   pnew += bd->startspaces;


### PR DESCRIPTION
Fixing instances of V1028 from PVS report labeled as level high, one at a time

As per @justinmk request here https://github.com/neovim/neovim/pull/10478
