### PR TITLE
pvs/V781 fix

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1878,8 +1878,8 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr,
       msg_ext_last_attr = attr;
     }
     // Concat pieces with the same highlight
-    size_t len = strnlen((char *)str, maxlen);
-    ga_concat_len(&msg_ext_last_chunk, (char *)str, len);  // -V781
+    size_t len = strnlen((char *)str, maxlen);             // -V781
+    ga_concat_len(&msg_ext_last_chunk, (char *)str, len);
     msg_ext_cur_len += len;
     return;
   }


### PR DESCRIPTION
Fixing incorrectly placed comment that was supposed to suppress false positive on V781

https://neovim.io/doc/reports/pvs/PVS-studio.html.d/sources/message.c_7.html#ln1881