### PR TITLE
pvs/V590 removing redundant condition

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1217,7 +1217,7 @@ int do_search(
           xfree(msgbuf);
           msgbuf = r;
           // move reversed text to beginning of buffer
-          while (*r != NUL && *r == ' ') {
+          while (*r == ' ') {
             r++;
           }
           size_t pat_len = msgbuf + STRLEN(msgbuf) - r;


### PR DESCRIPTION
Fixes PVS/590 
https://neovim.io/doc/reports/pvs/PVS-studio.html.d/sources/search.c_16.html#ln1220

Checking that `*r == ' '` is enough to make sure that it is not null byte. 