### PR TITLE
third-party: use CXX only for BuildGperf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,7 +138,6 @@ addons:
       - clang-4.0
       - cmake
       - cscope
-      - g++-multilib
       - gcc-multilib
       - gdb
       - gperf

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is not meant to be included by the top-level.
 cmake_minimum_required (VERSION 2.8.12)
-project(NVIM_DEPS)
+project(NVIM_DEPS C)
 
 # Needed for: check_c_compiler_flag()
 include(CheckCCompilerFlag)

--- a/third-party/cmake/BuildGperf.cmake
+++ b/third-party/cmake/BuildGperf.cmake
@@ -2,6 +2,7 @@
 # cross compiling we still want to build for the HOST system, whenever
 # writing a recipe that is meant for cross-compile, use the HOSTDEPS_* variables
 # instead of DEPS_* - check the main CMakeLists.txt for a list.
+project(NVIM_DEPS_GPERF C CXX)
 
 # BuildGperf(CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
 # Reusable function to build Gperf, wraps ExternalProject_Add.

--- a/third-party/cmake/BuildGperf.cmake
+++ b/third-party/cmake/BuildGperf.cmake
@@ -2,7 +2,7 @@
 # cross compiling we still want to build for the HOST system, whenever
 # writing a recipe that is meant for cross-compile, use the HOSTDEPS_* variables
 # instead of DEPS_* - check the main CMakeLists.txt for a list.
-project(NVIM_DEPS_GPERF C CXX)
+enable_language(CXX)
 
 # BuildGperf(CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
 # Reusable function to build Gperf, wraps ExternalProject_Add.


### PR DESCRIPTION
This allows to build deps without g++ when not using the bundled gperf.

> make deps DEPS_CMAKE_FLAGS='-DUSE_BUNDLED_GPERF=0'