### PR TITLE
api/lua: add {byte_count} parameter to line region change event

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -200,17 +200,23 @@ User reloads the buffer with ":edit", emits: >
   nvim_buf_detach_event[{buf}]
 
                                                         *api-buffer-updates-lua*
-In-process lua plugins can also recieve buffer updates, in the form of lua
+In-process lua plugins can also receive buffer updates, in the form of lua
 callbacks. These callbacks are called frequently in various contexts, buffer
 contents or window layout should not be changed inside these |textlock|.
 |vim.schedule| can be used to defer these operations to the main loop, where
 they are allowed.
 
 |nvim_buf_attach| will take keyword args for the callbacks. "on_lines" will
-receive parameters ("lines", {buf}, {changedtick}, {firstline}, {lastline}, {new_lastline}).
-Unlike remote channels the text contents are not passed. The new text can be
-accessed inside the callback as
-`vim.api.nvim_buf_get_lines(buf, firstline, new_lastline, true)`
+receive parameters ("lines", {buf}, {changedtick}, {firstline}, {lastline},
+{new_lastline}, {old_bytecount}).
+Unlike remote channel events the text contents are not passed. The new text can
+be accessed inside the callback as
+
+    `vim.api.nvim_buf_get_lines(buf, firstline, new_lastline, true)`
+
+{old_bytecount} is the total size of the replaced region {firstline} to
+{lastline} in bytes, including the final newline after {lastline}.
+
 "on_changedtick" is invoked when |b:changedtick| was incremented but no text
 was changed. The parameters recieved are ("changedtick", {buf}, {changedtick}).
 

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -208,14 +208,17 @@ they are allowed.
 
 |nvim_buf_attach| will take keyword args for the callbacks. "on_lines" will
 receive parameters ("lines", {buf}, {changedtick}, {firstline}, {lastline},
-{new_lastline}, {old_bytecount}).
+{new_lastline}, {old_byte_size}[, {old_utf32_size}, {old_utf16_size}]).
 Unlike remote channel events the text contents are not passed. The new text can
 be accessed inside the callback as
 
     `vim.api.nvim_buf_get_lines(buf, firstline, new_lastline, true)`
 
-{old_bytecount} is the total size of the replaced region {firstline} to
-{lastline} in bytes, including the final newline after {lastline}.
+{old_byte_size} is the total size of the replaced region {firstline} to
+{lastline} in bytes, including the final newline after {lastline}. if
+`utf_sizes` is set to true in |nvim_buf_attach()| keyword args, then the
+UTF-32 and UTF-16 sizes of the deleted region is also passed as additional
+arguments {old_utf32_size} and {old_utf16_size}.
 
 "on_changedtick" is invoked when |b:changedtick| was incremented but no text
 was changed. The parameters recieved are ("changedtick", {buf}, {changedtick}).

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1176,6 +1176,29 @@ free_exit:
   return 0;
 }
 
+Dictionary nvim__buf_stats(Buffer buffer, Error *err)
+{
+  Dictionary rv = ARRAY_DICT_INIT;
+
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+  if (!buf) {
+    return rv;
+  }
+
+  // Number of times the cached line was flushed.
+  // This should generally not increase while editing the same
+  // line in the same mode.
+  PUT(rv, "flush_count", INTEGER_OBJ(buf->flush_count));
+  // lnum of current line
+  PUT(rv, "current_lnum", INTEGER_OBJ(buf->b_ml.ml_line_lnum));
+  // whether the line has unflushed changes.
+  PUT(rv, "line_dirty", BOOLEAN_OBJ(buf->b_ml.ml_flags & ML_LINE_DIRTY));
+  // NB: this should be zero at any time API functions are called,
+  // this exists to debug issues
+  PUT(rv, "dirty_bytes", INTEGER_OBJ((Integer)buf->deleted_bytes));
+  return rv;
+}
+
 // Check if deleting lines made the cursor position invalid.
 // Changed lines from `lo` to `hi`; added `extra` lines (negative if deleted).
 static void fix_cursor(linenr_T lo, linenr_T hi, linenr_T extra)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -807,6 +807,9 @@ struct file_buffer {
   kvec_t(uint64_t) update_channels;
   kvec_t(BufUpdateCallbacks) update_callbacks;
 
+  size_t deleted_bytes;
+  int flush_count;
+
   int b_diff_failed;    // internal diff failed for this buffer
 };
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -459,8 +459,9 @@ typedef struct {
   LuaRef on_lines;
   LuaRef on_changedtick;
   LuaRef on_detach;
+  bool utf_sizes;
 } BufUpdateCallbacks;
-#define BUF_UPDATE_CALLBACKS_INIT { LUA_NOREF, LUA_NOREF, LUA_NOREF }
+#define BUF_UPDATE_CALLBACKS_INIT { LUA_NOREF, LUA_NOREF, LUA_NOREF, false }
 
 #define BUF_HAS_QF_ENTRY 1
 #define BUF_HAS_LL_ENTRY 2
@@ -802,12 +803,24 @@ struct file_buffer {
 
   kvec_t(BufhlLine *) b_bufhl_move_space;  // temporary space for highlights
 
-  // array of channelids which have asked to receive updates for this
+  // array of channel_id:s which have asked to receive updates for this
   // buffer.
   kvec_t(uint64_t) update_channels;
+  // array of lua callbacks for buffer updates.
   kvec_t(BufUpdateCallbacks) update_callbacks;
 
+  // whether an update callback has requested codepoint size of deleted regions.
+  bool update_need_codepoints;
+
+  // Measurements of the deleted or replaced region since the last update
+  // event. Some consumers of buffer changes need to know the byte size (like
+  // tree-sitter) or the corresponding UTF-32/UTF-16 size (like LSP) of the
+  // deleted text.
   size_t deleted_bytes;
+  size_t deleted_codepoints;
+  size_t deleted_codeunits;
+
+  // The number for times the current line has been flushed in the memline.
   int flush_count;
 
   int b_diff_failed;    // internal diff failed for this buffer

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -26,6 +26,9 @@ bool buf_updates_register(buf_T *buf, uint64_t channel_id,
 
   if (channel_id == LUA_INTERNAL_CALL) {
     kv_push(buf->update_callbacks, cb);
+    if (cb.utf_sizes) {
+      buf->update_need_codepoints = true;
+    }
     return true;
   }
 
@@ -169,7 +172,9 @@ void buf_updates_send_changes(buf_T *buf,
                               int64_t num_removed,
                               bool send_tick)
 {
-  size_t deleted_bytes = ml_flush_deleted_bytes(buf);
+  size_t deleted_codepoints, deleted_codeunits;
+  size_t deleted_bytes = ml_flush_deleted_bytes(buf, &deleted_codepoints,
+                                                &deleted_codeunits);
 
   if (!buf_updates_active(buf)) {
     return;
@@ -233,8 +238,8 @@ void buf_updates_send_changes(buf_T *buf,
     bool keep = true;
     if (cb.on_lines != LUA_NOREF) {
       Array args = ARRAY_DICT_INIT;
-      Object items[6];
-      args.size = 6;
+      Object items[8];
+      args.size = 6;  // may be increased to 8 below
       args.items = items;
 
       // the first argument is always the buffer handle
@@ -254,6 +259,11 @@ void buf_updates_send_changes(buf_T *buf,
 
       // byte count of previous contents
       args.items[5] = INTEGER_OBJ((Integer)deleted_bytes);
+      if (cb.utf_sizes) {
+        args.size = 8;
+        args.items[6] = INTEGER_OBJ((Integer)deleted_codepoints);
+        args.items[7] = INTEGER_OBJ((Integer)deleted_codeunits);
+      }
       textlock++;
       Object res = executor_exec_lua_cb(cb.on_lines, "lines", args, true);
       textlock--;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1756,6 +1756,8 @@ failed:
       linecnt--;
     }
     curbuf->deleted_bytes = 0;
+    curbuf->deleted_codepoints = 0;
+    curbuf->deleted_codeunits = 0;
     linecnt = curbuf->b_ml.ml_line_count - linecnt;
     if (filesize == 0)
       linecnt = 0;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1755,6 +1755,7 @@ failed:
       ml_delete(curbuf->b_ml.ml_line_count, false);
       linecnt--;
     }
+    curbuf->deleted_bytes = 0;
     linecnt = curbuf->b_ml.ml_line_count - linecnt;
     if (filesize == 0)
       linecnt = 0;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -627,6 +627,8 @@ EXTERN pos_T Insstart_orig;
 EXTERN int orig_line_count INIT(= 0);       /* Line count when "gR" started */
 EXTERN int vr_lines_changed INIT(= 0);      /* #Lines changed by "gR" so far */
 
+// increase around internal delete/replace
+EXTERN int inhibit_delete_count INIT(= 0);
 
 /*
  * These flags are set based upon 'fileencoding'.

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1685,6 +1685,7 @@ int del_bytes(colnr_T count, bool fixpos_arg, bool use_delcombine)
   bool was_alloced = ml_line_alloced();     // check if oldp was allocated
   char_u *newp;
   if (was_alloced) {
+    curbuf->deleted_bytes += (size_t)oldlen+1;
     newp = oldp;                            // use same allocated memory
   } else {                                  // need to allocate a new line
     newp = xmalloc((size_t)(oldlen + 1 - count));

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -780,6 +780,7 @@ open_line (
     did_append = FALSE;
   }
 
+  inhibit_delete_count++;
   if (newindent
       || did_si
       ) {
@@ -821,6 +822,7 @@ open_line (
       did_si = false;
     }
   }
+  inhibit_delete_count--;
 
   /*
    * In REPLACE mode, for each character in the extra leader, there must be
@@ -1685,7 +1687,7 @@ int del_bytes(colnr_T count, bool fixpos_arg, bool use_delcombine)
   bool was_alloced = ml_line_alloced();     // check if oldp was allocated
   char_u *newp;
   if (was_alloced) {
-    curbuf->deleted_bytes += (size_t)oldlen+1;
+    ml_add_deleted_len(curbuf->b_ml.ml_line_ptr, oldlen);
     newp = oldp;                            // use same allocated memory
   } else {                                  // need to allocate a new line
     newp = xmalloc((size_t)(oldlen + 1 - count));

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -5,6 +5,8 @@ local command = helpers.command
 local meths = helpers.meths
 local clear = helpers.clear
 local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+local feed = helpers.feed
 
 local origlines = {"original line 1",
                    "original line 2",
@@ -16,7 +18,7 @@ local origlines = {"original line 1",
 describe('lua: buffer event callbacks', function()
   before_each(function()
     clear()
-    meths.execute_lua([[
+    exec_lua([[
       local events = {}
 
       function test_register(bufnr, id, changedtick)
@@ -38,55 +40,101 @@ describe('lua: buffer event callbacks', function()
         events = {}
         return ret_events
       end
-    ]], {})
+    ]])
   end)
 
-  it('works', function()
+
+  -- verifying the sizes with nvim_buf_get_offset is nice (checks we cannot
+  -- assert the wrong thing), but masks errors with unflushed lines (as
+  -- nvim_buf_get_offset forces a flush of the memline). To be safe run the
+  -- test both ways.
+  local function check(verify)
+    local lastsize
     meths.buf_set_lines(0, 0, -1, true, origlines)
-    meths.execute_lua("return test_register(...)", {0, "test1"})
+    if verify then
+      lastsize = meths.buf_get_offset(0, meths.buf_line_count(0))
+    end
+    exec_lua("return test_register(...)", 0, "test1")
     local tick = meths.buf_get_changedtick(0)
+
+    local verify_name = "test1"
+    local function check_events(expected)
+      local events = exec_lua("return get_events(...)" )
+      eq(expected, events)
+      if verify then
+        for _, event in ipairs(events) do
+          if event[1] == verify_name and event[2] == "lines" then
+            local startline, endline = event[5], event[7]
+            local newrange = meths.buf_get_offset(0, endline) - meths.buf_get_offset(0, startline)
+            local newsize = meths.buf_get_offset(0, meths.buf_line_count(0))
+            local oldrange = newrange + lastsize - newsize
+            eq(oldrange, event[8])
+            lastsize = newsize
+          end
+        end
+      end
+    end
 
     command('normal! GyyggP')
     tick = tick + 1
-    eq({{ "test1", "lines", 1, tick, 0, 0, 1 }},
-       meths.execute_lua("return get_events(...)", {}))
+    check_events({{ "test1", "lines", 1, tick, 0, 0, 1, 0}})
 
     meths.buf_set_lines(0, 3, 5, true, {"changed line"})
     tick = tick + 1
-    eq({{ "test1", "lines", 1, tick, 3, 5, 4 }},
-       meths.execute_lua("return get_events(...)", {}))
+    check_events({{ "test1", "lines", 1, tick, 3, 5, 4, 32 }})
 
-    meths.execute_lua("return test_register(...)", {0, "test2", true})
+    exec_lua("return test_register(...)", 0, "test2", true)
     tick = tick + 1
     command('undo')
 
     -- plugins can opt in to receive changedtick events, or choose
     -- to only recieve actual changes.
-    eq({{ "test1", "lines", 1, tick, 3, 4, 5 },
-        { "test2", "lines", 1, tick, 3, 4, 5 },
-        { "test2", "changedtick", 1, tick+1 } },
-       meths.execute_lua("return get_events(...)", {}))
+    check_events({{ "test1", "lines", 1, tick, 3, 4, 5, 13 },
+        { "test2", "lines", 1, tick, 3, 4, 5, 13 },
+        { "test2", "changedtick", 1, tick+1 } })
     tick = tick + 1
 
     -- simulate next callback returning true
-    meths.execute_lua("test_unreg = 'test1'", {})
+    exec_lua("test_unreg = 'test1'")
 
     meths.buf_set_lines(0, 6, 7, true, {"x1","x2","x3"})
     tick = tick + 1
 
     -- plugins can opt in to receive changedtick events, or choose
     -- to only recieve actual changes.
-    eq({{ "test1", "lines", 1, tick, 6, 7, 9 },
-        { "test2", "lines", 1, tick, 6, 7, 9 }},
-       meths.execute_lua("return get_events(...)", {}))
+    check_events({{ "test1", "lines", 1, tick, 6, 7, 9, 16 },
+        { "test2", "lines", 1, tick, 6, 7, 9, 16 }})
+
+    verify_name = "test2"
 
     meths.buf_set_lines(0, 1, 1, true, {"added"})
     tick = tick + 1
-    eq({{ "test2", "lines", 1, tick, 1, 1, 2 }},
-       meths.execute_lua("return get_events(...)", {}))
+    check_events({{ "test2", "lines", 1, tick, 1, 1, 2, 0 }})
+
+    feed('wix')
+    tick = tick + 1
+    check_events({{ "test2", "lines", 1, tick, 4, 5, 5, 16 }})
+
+    -- check hot path for multiple insert
+    feed('yz')
+    tick = tick + 1
+    check_events({{ "test2", "lines", 1, tick, 4, 5, 5, 17 }})
+
+    feed('<bs>')
+    tick = tick + 1
+    check_events({{ "test2", "lines", 1, tick, 4, 5, 5, 19 }})
+
+    feed('<esc>')
 
     command('bwipe!')
-    eq({{ "test2", "detach", 1 }},
-       meths.execute_lua("return get_events(...)", {}))
+    check_events({{ "test2", "detach", 1 }})
+   end
+
+  it('works', function()
+    check(false)
+  end)
+
+  it('works with verify', function()
+    check(true)
   end)
 end)


### PR DESCRIPTION
It would simplify tree-sitter integration #10124 if we could get the size of the deleted region in bytes.

A possible extension could be to also calculate the UTF-16 codeunits which would be needed to implement efficient deltas for LSP (without extra double buffering). Though we could wait a bit to see if https://github.com/microsoft/language-server-protocol/issues/376 is ever going to be resolved (but I wouldn't bet on it). But they would probably use UTF-32 codepoints then instead, which is not so different (we can easily calculate both in the same loop).

`nvim__buf_locked` can probably be removed before merging, I mostly used it for debugging missing counts and extra flushes etc.