### PR TITLE
ci: Travis: move handling of GCOV_ERROR_FILE to after_script  [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,7 @@ install:        ci/install.sh
 before_script:  ci/before_script.sh
 script:         ci/script.sh
 before_cache:   ci/before_cache.sh
+after_script:   ci/after_script.sh
 
 addons:
   apt:

--- a/ci/after_script.sh
+++ b/ci/after_script.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -x
+
+if [[ -n "${GCOV_ERROR_FILE}" ]]; then
+  ls -l "${GCOV_ERROR_FILE}" || true
+  if [[ -s "${GCOV_ERROR_FILE}" ]]; then
+    echo '=== Unexpected gcov errors: ==='
+    cat "${GCOV_ERROR_FILE}"
+    exit 1
+  fi
+fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,9 +11,3 @@ if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
 else
   ci/run_${CI_TARGET}.sh
 fi
-
-if [[ -s "${GCOV_ERROR_FILE}" ]]; then
-  echo '=== Unexpected gcov errors: ==='
-  cat "${GCOV_ERROR_FILE}"
-  exit 1
-fi


### PR DESCRIPTION
Still unclear why it gets not used (always at least), but this should
help with finding out about it (since it gets run / checked always now).

Ref: https://github.com/neovim/neovim/issues/10332