### PR TITLE
viml/profile: revert proftime_T to unsigned type

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13830,7 +13830,7 @@ static void f_reltimestr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
   if (list2proftime(&argvars[0], &tm) == OK) {
-    rettv->vval.v_string = (char_u *) xstrdup(profile_msg(tm));
+    rettv->vval.v_string = (char_u *)xstrdup(profile_msg(tm));
   }
 }
 

--- a/src/nvim/profile.h
+++ b/src/nvim/profile.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <time.h>
 
-typedef int64_t proftime_T;
+typedef uint64_t proftime_T;
 
 #define TIME_MSG(s) do { \
     if (time_fd != NULL) time_msg(s, NULL); \

--- a/test/functional/eval/reltime_spec.lua
+++ b/test/functional/eval/reltime_spec.lua
@@ -38,9 +38,13 @@ describe('reltimestr(), reltimefloat()', function()
     local older_time = reltime()
     command('sleep 1m')
     local newer_time = reltime()
-    -- Should be something like -0.002123.
+
+    -- Start/end swapped: should be something like -0.002123.
     local rv = tonumber(reltimestr(reltime(newer_time, older_time)))
-    ok(rv < 0)
-    ok(rv > -10)
+    ok(rv < 0 and rv > -10)
+
+    -- Not swapped: should be something like 0.002123.
+    rv = tonumber(reltimestr(reltime(older_time, newer_time)))
+    ok(rv > 0 and rv < 10)
   end)
 end)


### PR DESCRIPTION
- reltimestr(): Produce negative value by comparing the unsigned  proftime_T value to INT64_MAX.

https://github.com/neovim/neovim/issues/10452#issuecomment-511155132
1. The interfaces of nearly all platforms return uint64_t. INT64_MAX is   only half of that.
2. Low-level interfaces like this typically define that there is no   fixed starting point. The only guarantees are that it's (a)   monotonically increasing at a rate that (b) matches real time.

ref 06af88cd72ea
fix #10452

cc @aktau 