### PR TITLE
jobstop(): close channel before process_stop()

### DIFF
--- a/runtime/autoload/remote/host.vim
+++ b/runtime/autoload/remote/host.vim
@@ -147,7 +147,7 @@ function! s:RegistrationCommands(host) abort
         \ a:host, string(map(registered, "fnamemodify(v:val, ':t')")))
 
   " Delete the temporary host clone
-  call rpcstop(s:hosts[host_id].channel)
+  call jobstop(s:hosts[host_id].channel)
   call remove(s:hosts, host_id)
   call remove(s:plugins_for_host, host_id)
   return lines

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -44,6 +44,11 @@ Functions ~
 *jobclose()*		Obsolete name for |chanclose()|
 *jobsend()*		Obsolete name for |chansend()|
 *last_buffer_nr()*	Obsolete name for bufnr("$").
+*rpcstop()*		Deprecated. Instead use |jobstop()| to stop any job,
+			or chanclose(id, "rpc") to close RPC communication
+			without stopping the job. Use chanclose(id) to close
+			any socket.
+
 
 Modifiers ~
 *cpo-<*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6708,11 +6708,6 @@ rpcstart({prog}[, {argv}])					*rpcstart()*
 <		with >
 			:let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 
-rpcstop({channel})						*rpcstop()*
-		Deprecated. Instead use |jobstop()| to stop any job, and
-		chanclose(id, "rpc") to close RPC communication without
-		stopping the job. Use chanclose(id) to close any socket.
-
 screenattr({row}, {col})					*screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather
 		arbitrary number that can only be used to compare to the

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12227,8 +12227,16 @@ static void f_jobstop(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
+  const char *error = NULL;
+  if (data->is_rpc) {
+    // Ignore return code, but show error later.
+    (void)channel_close(data->id, kChannelPartRpc, &error);
+  }
   process_stop((Process *)&data->stream.proc);
   rettv->vval.v_number = 1;
+  if (error) {
+    EMSG(error);
+  }
 }
 
 // "jobwait(ids[, timeout])" function

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -198,7 +198,8 @@ for i = 1, #functions do
     output:write('Object handle_'..fn.name..'(uint64_t channel_id, Array args, Error *error)')
     output:write('\n{')
     output:write('\n#if MIN_LOG_LEVEL <= DEBUG_LOG_LEVEL')
-    output:write('\n  logmsg(DEBUG_LOG_LEVEL, "RPC: ", NULL, -1, true, "invoke '..fn.name..'");')
+    output:write('\n  logmsg(DEBUG_LOG_LEVEL, "RPC: ", NULL, -1, true, "ch %" PRIu64 ": invoke '
+                 ..fn.name..'", channel_id);')
     output:write('\n#endif')
     output:write('\n  Object ret = NIL;')
     -- Declare/initialize variables that will hold converted arguments


### PR DESCRIPTION
fix #9799

Helped-by: Björn Linse