### PR TITLE
pvs/V1037: suppress false positive

### DIFF
--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -382,7 +382,7 @@ static int _TYPVAL_ENCODE_CONVERT_ONE_VALUE(
     case VAR_SPECIAL: {
       switch (tv->vval.v_special) {
         case kSpecialVarNull: {
-          TYPVAL_ENCODE_CONV_NIL(tv);
+          TYPVAL_ENCODE_CONV_NIL(tv);  // -V1037
           break;
         }
         case kSpecialVarTrue:


### PR DESCRIPTION
pvs was signalling that these 2 branches are the same
```c
  case kSpecialVarNull: {
          TYPVAL_ENCODE_CONV_NIL(tv);
          break;
        }
        case kSpecialVarFalse: {
          TYPVAL_ENCODE_CONV_BOOL(tv, tv->vval.v_special == kSpecialVarTrue);
          break;
        }
```