### PR TITLE
pvs/V1026: possible overflow in a loop

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1424,6 +1424,7 @@ retry:
             }
           }
           assert(u8c <= INT_MAX);
+          // produce UTF-8
           dest -= utf_char2len((int)u8c);
           (void)utf_char2bytes((int)u8c, dest);
         }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1423,30 +1423,32 @@ retry:
               }
             }
           }
-          if (enc_utf8) {               /* produce UTF-8 */
+          if (enc_utf8) {               // produce UTF-8
             dest -= utf_char2len(u8c);
             assert(u8c <= INT_MAX);
             (void)utf_char2bytes((int)u8c, dest);
-          } else {                    /* produce Latin1 */
-            --dest;
+          } else {                    // produce Latin1
+            dest--;
             if (u8c >= 0x100) {
-              /* character doesn't fit in latin1, retry with
-               * another fenc when possible, otherwise just
-               * report the error. */
-              if (can_retry)
+              // character doesn't fit in latin1, retry with
+              // another fenc when possible, otherwise just
+              // report the error.
+              if (can_retry) {
                 goto rewind_retry;
-              if (conv_error == 0)
+              }
+              if (conv_error == 0) {
                 conv_error = readfile_linenr(linecnt, ptr, p);
-              if (bad_char_behavior == BAD_DROP)
-                ++dest;
-              else if (bad_char_behavior == BAD_KEEP) {
+              }
+              if (bad_char_behavior == BAD_DROP) {
+                dest++;
+              } else if (bad_char_behavior == BAD_KEEP) {
                 assert(u8c <= UCHAR_MAX);
                 *dest = (char_u)u8c;
-              }
-              else if (eap != NULL && eap->bad_char != 0)
+              } else if (eap != NULL && eap->bad_char != 0) {
                 *dest = bad_char_behavior;
-              else
+              } else {
                 *dest = 0xBF;
+              }
             } else {
               assert(u8c <= UCHAR_MAX);
               *dest = (char_u)u8c;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1275,7 +1275,7 @@ retry:
 # endif
 
       if (fio_flags != 0) {
-        int u8c;
+        unsigned int u8c;
         char_u  *dest;
         char_u  *tail = NULL;
 
@@ -1425,7 +1425,8 @@ retry:
           }
           if (enc_utf8) {               /* produce UTF-8 */
             dest -= utf_char2len(u8c);
-            (void)utf_char2bytes(u8c, dest);
+            assert(u8c <= INT_MAX);
+            (void)utf_char2bytes((int)u8c, dest);
           } else {                    /* produce Latin1 */
             --dest;
             if (u8c >= 0x100) {
@@ -1438,14 +1439,18 @@ retry:
                 conv_error = readfile_linenr(linecnt, ptr, p);
               if (bad_char_behavior == BAD_DROP)
                 ++dest;
-              else if (bad_char_behavior == BAD_KEEP)
-                *dest = u8c;
+              else if (bad_char_behavior == BAD_KEEP) {
+                assert(u8c <= UCHAR_MAX);
+                *dest = (char_u)u8c;
+              }
               else if (eap != NULL && eap->bad_char != 0)
                 *dest = bad_char_behavior;
               else
                 *dest = 0xBF;
-            } else
-              *dest = u8c;
+            } else {
+              assert(u8c <= UCHAR_MAX);
+              *dest = (char_u)u8c;
+            }
           }
         }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -289,7 +289,7 @@ readfile (
   int wasempty;                         /* buffer was empty before reading */
   colnr_T len;
   long size = 0;
-  char_u      *p = NULL;
+  uint8_t      *p = NULL;
   off_T filesize = 0;
   int skip_read = false;
   context_sha256_T sha_ctx;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -258,7 +258,7 @@ static AutoPat *last_autopat[NUM_EVENTS] = {
  *
  * return FAIL for failure, NOTDONE for directory (failure), or OK
  */
-int 
+int
 readfile (
     char_u *fname,
     char_u *sfname,
@@ -289,7 +289,7 @@ readfile (
   int wasempty;                         /* buffer was empty before reading */
   colnr_T len;
   long size = 0;
-  uint8_t      *p = NULL;
+  uint8_t *p = NULL;
   off_T filesize = 0;
   int skip_read = false;
   context_sha256_T sha_ctx;
@@ -1423,37 +1423,9 @@ retry:
               }
             }
           }
-          if (enc_utf8) {               // produce UTF-8
-            dest -= utf_char2len(u8c);
-            assert(u8c <= INT_MAX);
-            (void)utf_char2bytes((int)u8c, dest);
-          } else {                    // produce Latin1
-            dest--;
-            if (u8c >= 0x100) {
-              // character doesn't fit in latin1, retry with
-              // another fenc when possible, otherwise just
-              // report the error.
-              if (can_retry) {
-                goto rewind_retry;
-              }
-              if (conv_error == 0) {
-                conv_error = readfile_linenr(linecnt, ptr, p);
-              }
-              if (bad_char_behavior == BAD_DROP) {
-                dest++;
-              } else if (bad_char_behavior == BAD_KEEP) {
-                assert(u8c <= UCHAR_MAX);
-                *dest = (char_u)u8c;
-              } else if (eap != NULL && eap->bad_char != 0) {
-                *dest = bad_char_behavior;
-              } else {
-                *dest = 0xBF;
-              }
-            } else {
-              assert(u8c <= UCHAR_MAX);
-              *dest = (char_u)u8c;
-            }
-          }
+          assert(u8c <= INT_MAX);
+          dest -= utf_char2len((int)u8c);
+          (void)utf_char2bytes((int)u8c, dest);
         }
 
         /* move the linerest to before the converted characters */
@@ -1730,7 +1702,7 @@ failed:
     // Remember the current file format.
     save_file_ff(curbuf);
     // If editing a new file: set 'fenc' for the current buffer.
-    // Also for ":read ++edit file". 
+    // Also for ":read ++edit file".
     set_string_option_direct((char_u *)"fenc", -1, fenc,
         OPT_FREE | OPT_LOCAL, 0);
   }
@@ -2029,7 +2001,7 @@ bool is_dev_fd_file(char_u *fname)
  * line number where we are now.
  * Used for error messages that include a line number.
  */
-static linenr_T 
+static linenr_T
 readfile_linenr (
     linenr_T linecnt,               /* line count before reading more bytes */
     char_u *p,                 /* start of more bytes read */
@@ -2213,7 +2185,7 @@ static void check_marks_read(void)
  *
  * return FAIL for failure, OK otherwise
  */
-int 
+int
 buf_write (
     buf_T *buf,
     char_u *fname,
@@ -4722,7 +4694,7 @@ static int already_warned = FALSE;
  * Returns TRUE if some message was written (screen should be redrawn and
  * cursor positioned).
  */
-int 
+int
 check_timestamps (
     int focus                      /* called for GUI focus event */
 )
@@ -4826,7 +4798,7 @@ static int move_lines(buf_T *frombuf, buf_T *tobuf)
  * return 2 if a message has been displayed.
  * return 0 otherwise.
  */
-int 
+int
 buf_check_timestamp (
     buf_T *buf,
     int focus               /* called for GUI focus event */
@@ -6279,7 +6251,7 @@ static int do_autocmd_event(event_T event, char_u *pat, bool once, int nested,
  * Implementation of ":doautocmd [group] event [fname]".
  * Return OK for success, FAIL for failure;
  */
-int 
+int
 do_doautocmd (
     char_u *arg,
     int do_msg,  // give message for no matching autocmds?
@@ -7067,7 +7039,7 @@ void unblock_autocmds(void)
 /*
  * Find next autocommand pattern that matches.
  */
-static void 
+static void
 auto_next_pat (
     AutoPatCmd *apc,
     int stop_at_last                   /* stop when 'last' flag is set */

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -259,7 +259,7 @@ static AutoPat *last_autopat[NUM_EVENTS] = {
  * return FAIL for failure, NOTDONE for directory (failure), or OK
  */
 int
-readfile (
+readfile(
     char_u *fname,
     char_u *sfname,
     linenr_T from,
@@ -1428,7 +1428,7 @@ retry:
           (void)utf_char2bytes((int)u8c, dest);
         }
 
-        /* move the linerest to before the converted characters */
+        // move the linerest to before the converted characters
         line_start = dest - linerest;
         memmove(line_start, buffer, (size_t)linerest);
         size = (long)((ptr + real_size) - dest);
@@ -1436,18 +1436,19 @@ retry:
       } else if (enc_utf8 && !curbuf->b_p_bin) {
         int incomplete_tail = FALSE;
 
-        /* Reading UTF-8: Check if the bytes are valid UTF-8. */
-        for (p = ptr;; ++p) {
+        // Reading UTF-8: Check if the bytes are valid UTF-8.
+        for (p = ptr;; p++) {
           int todo = (int)((ptr + size) - p);
           int l;
 
-          if (todo <= 0)
+          if (todo <= 0) {
             break;
+          }
           if (*p >= 0x80) {
-            /* A length of 1 means it's an illegal byte.  Accept
-             * an incomplete character at the end though, the next
-             * read() will get the next bytes, we'll check it
-             * then. */
+            // A length of 1 means it's an illegal byte.  Accept
+            // an incomplete character at the end though, the next
+            // read() will get the next bytes, we'll check it
+            // then.
             l = utf_ptr2len_len(p, todo);
             if (l > todo && !incomplete_tail) {
               /* Avoid retrying with a different encoding when
@@ -2002,10 +2003,10 @@ bool is_dev_fd_file(char_u *fname)
  * Used for error messages that include a line number.
  */
 static linenr_T
-readfile_linenr (
-    linenr_T linecnt,               /* line count before reading more bytes */
-    char_u *p,                 /* start of more bytes read */
-    char_u *endp              /* end of more bytes read */
+readfile_linenr(
+    linenr_T linecnt,         // line count before reading more bytes
+    char_u *p,                // start of more bytes read
+    char_u *endp              // end of more bytes read
 )
 {
   char_u      *s;
@@ -2186,7 +2187,7 @@ static void check_marks_read(void)
  * return FAIL for failure, OK otherwise
  */
 int
-buf_write (
+buf_write(
     buf_T *buf,
     char_u *fname,
     char_u *sfname,
@@ -4686,17 +4687,15 @@ int vim_rename(const char_u *from, const char_u *to)
 
 static int already_warned = FALSE;
 
-/*
- * Check if any not hidden buffer has been changed.
- * Postpone the check if there are characters in the stuff buffer, a global
- * command is being executed, a mapping is being executed or an autocommand is
- * busy.
- * Returns TRUE if some message was written (screen should be redrawn and
- * cursor positioned).
- */
+// Check if any not hidden buffer has been changed.
+// Postpone the check if there are characters in the stuff buffer, a global
+// command is being executed, a mapping is being executed or an autocommand is
+// busy.
+// Returns TRUE if some message was written (screen should be redrawn and
+// cursor positioned).
 int
-check_timestamps (
-    int focus                      /* called for GUI focus event */
+check_timestamps(
+    int focus                      // called for GUI focus event
 )
 {
   int didit = 0;
@@ -4799,7 +4798,7 @@ static int move_lines(buf_T *frombuf, buf_T *tobuf)
  * return 0 otherwise.
  */
 int
-buf_check_timestamp (
+buf_check_timestamp(
     buf_T *buf,
     int focus               /* called for GUI focus event */
 )
@@ -6247,12 +6246,10 @@ static int do_autocmd_event(event_T event, char_u *pat, bool once, int nested,
   return OK;
 }
 
-/*
- * Implementation of ":doautocmd [group] event [fname]".
- * Return OK for success, FAIL for failure;
- */
+// Implementation of ":doautocmd [group] event [fname]".
+// Return OK for success, FAIL for failure;
 int
-do_doautocmd (
+do_doautocmd(
     char_u *arg,
     int do_msg,  // give message for no matching autocmds?
     bool *did_something
@@ -7036,11 +7033,9 @@ void unblock_autocmds(void)
     apply_autocmds(EVENT_TERMRESPONSE, NULL, NULL, FALSE, curbuf);
 }
 
-/*
- * Find next autocommand pattern that matches.
- */
+// Find next autocommand pattern that matches.
 static void
-auto_next_pat (
+auto_next_pat(
     AutoPatCmd *apc,
     int stop_at_last                   /* stop when 'last' flag is set */
 )


### PR DESCRIPTION
There are multiple occurrences where `unsigned int` result being assigned to a signed `int`
On lines: 
* [fileio.c:1393-1395](https://github.com/neovim/neovim/blob/master/src/nvim/fileio.c#L1393-L1395)
* [fileio.c:1400-1401](https://github.com/neovim/neovim/blob/master/src/nvim/fileio.c#L1400-L1401)


Causing PVS warning [V1026](https://www.viva64.com/en/w/v1026/)
This PR fixes this by declaring variable as unsigned