### PR TITLE
build: fix handling of install prefix with CMAKE_EXTRA_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CMAKE_INSTALL_PREFIX := $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
 endif
 ifneq (,$(CMAKE_INSTALL_PREFIX))
-CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
+override CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
 
 checkprefix:
 	@if [ -f build/.ran-cmake ]; then \


### PR DESCRIPTION
Append `CMAKE_INSTALL_PREFIX` to any given `CMAKE_EXTRA_FLAGS` always.

Regressed in 5031e3298.

Fixes https://github.com/neovim/neovim/issues/10524.