### PR TITLE
tests: fix "system() … prints verbose information"

### DIFF
--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -203,13 +203,12 @@ describe('system()', function()
     end)
 
     it('prints verbose information', function()
+      nvim('set_option', 'shell', 'fake_shell')
+      nvim('set_option', 'shellcmdflag', 'cmdflag')
+
       screen:try_resize(72, 14)
       feed(':4verbose echo system("echo hi")<cr>')
-      if iswin() then
-        screen:expect{any=[[Executing command: "'cmd.exe' '/s' '/c' '"echo hi"'"]]}
-      else
-        screen:expect{any=[[Executing command: "'/[^']*sh' '%-c' 'echo hi'"]]}
-      end
+      screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' 'echo hi'"]]}
       feed('<cr>')
     end)
 

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -208,7 +208,11 @@ describe('system()', function()
 
       screen:try_resize(72, 14)
       feed(':4verbose echo system("echo hi")<cr>')
-      screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' 'echo hi'"]]}
+      if iswin() then
+        screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' '"echo hi"'"]]}
+      else
+        screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' 'echo hi'"]]}
+      end
       feed('<cr>')
     end)
 


### PR DESCRIPTION
It would previously fail with `set shell=sh` (no slash).

For the test itself we can just use a non-existing (fake) shell, because
it is only about the verbose output.

Ref: https://github.com/neovim/neovim/issues/9330