### PR TITLE
ci: Travis: ccache: use CCACHE_HASHDIR  [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ env:
     - CCACHE_COMPRESS=1
     - CCACHE_SLOPPINESS=time_macros,file_macro
     - CCACHE_BASEDIR="$TRAVIS_BUILD_DIR"
+    # Default since 3.3, but Travis (Xenial) has 3.2.4.
+    - CCACHE_HASHDIR=1
 
 anchors:
   envs: &common-job-env


### PR DESCRIPTION
This is the default since ccache 3.3, but Travis has 3.2.4.

This fixes compiler warnings from macros with later clang/gcc.

Unblocks https://github.com/neovim/neovim/pull/10480, and
https://github.com/neovim/neovim/pull/10487.

Using `CCACHE_HASHDIR=1` fixes ccache v3.2.4, but `CCACHE_NOHASHDIR=1` does not break v3.7.1.  The real issue/fix appears to be https://github.com/ccache/ccache/commit/284e3a0c66193639171ff2a6ec4ff00a4a90dea9, and using the hashdir option seems to only work around this.

Ref: https://github.com/ccache/ccache/commit/6d9cb3dfdd9