### PR TITLE
reltimefloat(): allow negative result #10521

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13843,11 +13843,7 @@ static void f_reltime(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   tv_list_append_number(rettv->vval.v_list, u.split.low);
 }
 
-/// f_reltimestr - return a string that represents the value of {time}
-///
-/// @return The string representation of the argument, the format is the
-///         number of seconds followed by a dot, followed by the number
-///         of microseconds.
+/// "reltimestr()" function
 static void f_reltimestr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -16578,9 +16574,7 @@ static void f_uniq(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   do_sort_uniq(argvars, rettv, false);
 }
 
-//
 // "reltimefloat()" function
-//
 static void f_reltimefloat(typval_T *argvars , typval_T *rettv, FunPtr fptr)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -16589,7 +16583,7 @@ static void f_reltimefloat(typval_T *argvars , typval_T *rettv, FunPtr fptr)
   rettv->v_type = VAR_FLOAT;
   rettv->vval.v_float = 0;
   if (list2proftime(&argvars[0], &tm) == OK) {
-    rettv->vval.v_float = ((float_T)tm) / 1000000000;
+    rettv->vval.v_float = (float_T)profile_signed(tm) / 1000000000.0;
   }
 }
 

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -169,7 +169,7 @@ bool profile_equal(proftime_T tm1, proftime_T tm2) FUNC_ATTR_CONST
   return tm1 == tm2;
 }
 
-/// Converts a proftime_T value `tm` to a signed integer.
+/// Converts time duration `tm` (`profile_sub` result) to a signed integer.
 ///
 /// @return signed representation of the given time value
 int64_t profile_signed(proftime_T tm)

--- a/test/functional/eval/reltime_spec.lua
+++ b/test/functional/eval/reltime_spec.lua
@@ -6,7 +6,7 @@ local reltime, reltimestr, reltimefloat = funcs.reltime, funcs.reltimestr, funcs
 describe('reltimestr(), reltimefloat()', function()
   before_each(clear)
 
-  it('Checks', function()
+  it('acceptance', function()
     local now = reltime()
     command('sleep 10m')
     local later = reltime()
@@ -31,20 +31,23 @@ describe('reltimestr(), reltimefloat()', function()
     -- original vim test for < 0.1, but easily fails on travis
     ok(nil ~= string.match(reltimestr(differs), "0%."))
     ok(reltimefloat(differs) < 1.0)
-
   end)
 
-  it('reltime() allows negative result #10452', function()
+  it('(start - end) returns negative #10452', function()
     local older_time = reltime()
     command('sleep 1m')
     local newer_time = reltime()
 
     -- Start/end swapped: should be something like -0.002123.
-    local rv = tonumber(reltimestr(reltime(newer_time, older_time)))
-    ok(rv < 0 and rv > -10)
+    local tm_s = tonumber(reltimestr(reltime(newer_time, older_time)))
+    local tm_f = reltimefloat(reltime(newer_time, older_time))
+    ok(tm_s < 0 and tm_s > -10)
+    ok(tm_f < 0 and tm_f > -10)
 
     -- Not swapped: should be something like 0.002123.
-    rv = tonumber(reltimestr(reltime(older_time, newer_time)))
-    ok(rv > 0 and rv < 10)
+    tm_s = tonumber(reltimestr(reltime(older_time, newer_time)))
+    tm_f = reltimefloat(reltime(older_time, newer_time))
+    ok(tm_s > 0 and tm_s < 10)
+    ok(tm_f > 0 and tm_f < 10)
   end)
 end)


### PR DESCRIPTION
For "backwards" duration, reltimefloat() should return negative value like its counterpart reltimestr().

ref bab24a88ab48
ref 06af88cd72ea
ref #10521
fix #10452