### PR TITLE
test: shell-test.c: "REP" command: flush, wait 1ms

### DIFF
--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -150,6 +150,7 @@ describe('search highlighting', function()
     feed([[:terminal "]]..nvim_dir..[[/shell-test" REP 5000 foo<cr>]])
 
     feed(':file term<CR>')
+    feed('G')  -- Follow :terminal output.
     feed(':vnew<CR>')
     insert([[
       foo bar baz


### PR DESCRIPTION
Typically most shell output is the result of non-trivial work, so it
would not blast stdout instantaneously.  To more closely simulate that
typical scenario, change `shell-test REP` to wait 1 millisecond between
iterations.