### PR TITLE
os_can_exe: do not require "./" or "../" with relative paths

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8465,10 +8465,7 @@ static void f_executable(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const char *name = tv_get_string(&argvars[0]);
 
   // Check in $PATH and also check directly if there is a directory name
-  rettv->vval.v_number = (
-      os_can_exe(name, NULL, true)
-      || (gettail_dir(name) != name
-          && os_can_exe(name, NULL, false)));
+  rettv->vval.v_number = os_can_exe(name, NULL, true);
 }
 
 typedef struct {

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -242,23 +242,12 @@ int os_exepath(char *buffer, size_t *size)
 bool os_can_exe(const char *name, char **abspath, bool use_path)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  bool no_path = !use_path || path_is_absolute((char_u *)name);
-  // If the filename is "qualified" (relative or absolute) do not check $PATH.
-#ifdef WIN32
-  no_path |= (name[0] == '.'
-              && ((name[1] == '/' || name[1] == '\\')
-                  || (name[1] == '.' && (name[2] == '/' || name[2] == '\\'))));
-#else
-  no_path |= (name[0] == '.'
-              && (name[1] == '/' || (name[1] == '.' && name[2] == '/')));
-#endif
-
-  if (no_path) {
+  if (!use_path || gettail_dir(name) != name) {
 #ifdef WIN32
     if (is_executable_ext(name, abspath)) {
 #else
     // Must have path separator, cannot execute files in the current directory.
-    if (gettail_dir(name) != name
+    if ((use_path || gettail_dir(name) != name)
         && is_executable(name, abspath)) {
 #endif
       return true;

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -887,6 +887,14 @@ func Test_Executable()
   elseif has('unix')
     call assert_equal(1, executable('cat'))
     call assert_equal(0, executable('nodogshere'))
+
+    " get "cat" path and remove the leading /
+    let catcmd = exepath('cat')[1:]
+    new
+    lcd /
+    call assert_equal(1, executable(catcmd))
+    call assert_equal('/' .. catcmd, exepath(catcmd))
+    bwipe
   endif
 endfunc
 


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/10554.

The original code is very old already - but I cannot see a reason why "./" / "../" should be required.

A more recent change was meant for Windows in https://github.com/neovim/neovim/commit/519b93d236ad2e9d35fe294acb020d93debf79a2.

TODO:
- [x] test

Ok, it's actually an issue in Vim also (`mch_can_exe`): https://github.com/vim/vim/blob/acf7544cf62227972eeb063d6d9ecddaa5682a73/src/os_unix.c#L3098-L3108
It's just that Vim does not use it for when starting a job.
Filed https://github.com/vim/vim/issues/4710.