### PR TITLE
add pty_no_echo option

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -274,6 +274,7 @@ Channel *channel_job_start(char **argv, CallbackReader on_stdout,
                            CallbackReader on_stderr, Callback on_exit,
                            bool pty, bool rpc, bool detach, const char *cwd,
                            uint16_t pty_width, uint16_t pty_height,
+                           bool pty_echo,
                            char *term_name, varnumber_T *status_out)
 {
   assert(cwd == NULL || os_isdir_executable(cwd));
@@ -298,6 +299,9 @@ Channel *channel_job_start(char **argv, CallbackReader on_stdout,
     }
     if (pty_height > 0) {
       chan->stream.pty.height = pty_height;
+    }
+    if (!pty_echo) {
+      chan->stream.pty.echo = false;
     }
     if (term_name) {
       chan->stream.pty.term_name = term_name;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12164,6 +12164,7 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   bool detach = false;
   bool rpc = false;
   bool pty = false;
+  bool pty_echo = true;
   CallbackReader on_stdout = CALLBACK_READER_INIT,
                  on_stderr = CALLBACK_READER_INIT;
   Callback on_exit = CALLBACK_NONE;
@@ -12201,14 +12202,15 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   char *term_name = NULL;
 
   if (pty) {
+    pty_echo = !(tv_dict_get_number(job_opts, "pty_no_echo") != 0);
     width = (uint16_t)tv_dict_get_number(job_opts, "width");
     height = (uint16_t)tv_dict_get_number(job_opts, "height");
     term_name = tv_dict_get_string(job_opts, "TERM", true);
   }
 
   Channel *chan = channel_job_start(argv, on_stdout, on_stderr, on_exit, pty,
-                                    rpc, detach, cwd, width, height, term_name,
-                                    &rettv->vval.v_number);
+                                    rpc, detach, cwd, width, height, pty_echo,
+                                    term_name, &rettv->vval.v_number);
   if (chan) {
     channel_create_event(chan, NULL);
   }
@@ -14516,7 +14518,7 @@ static void f_rpcstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   Channel *chan = channel_job_start(argv, CALLBACK_READER_INIT,
                                     CALLBACK_READER_INIT, CALLBACK_NONE,
-                                    false, true, false, NULL, 0, 0, NULL,
+                                    false, true, false, NULL, 0, 0, true, NULL,
                                     &rettv->vval.v_number);
   if (chan) {
     channel_create_event(chan, NULL);
@@ -17828,6 +17830,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   Channel *chan = channel_job_start(argv, on_stdout, on_stderr, on_exit,
                                     true, false, false, cwd,
                                     term_width, curwin->w_height_inner,
+                                    true,
                                     xstrdup("xterm-256color"),
                                     &rettv->vval.v_number);
   if (rettv->vval.v_number <= 0) {

--- a/src/nvim/os/pty_process_unix.h
+++ b/src/nvim/os/pty_process_unix.h
@@ -11,6 +11,7 @@ typedef struct pty_process {
   uint16_t width, height;
   struct winsize winsize;
   int tty_fd;
+  bool echo;
 } PtyProcess;
 
 static inline PtyProcess pty_process_init(Loop *loop, void *data)
@@ -21,6 +22,7 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
   rv.width = 80;
   rv.height = 24;
   rv.tty_fd = -1;
+  rv.echo = true;
   return rv;
 }
 


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/issues/9107

Given the number of options there are already, `channel_job_start` should be passed a struct for those instead maybe?

Also this uses `pty_no_echo` mainly because `tv_dict_get_number` defaults to 0 for a non-existing entry - but it is also clearer.

However, also for `jobstart()` it might make sense to at least group `termios` settings?!