### PR TITLE
jobstart(), system(): use $PATHEXT-resolved exe

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8466,9 +8466,9 @@ static void f_executable(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   // Check in $PATH and also check directly if there is a directory name
   rettv->vval.v_number = (
-      os_can_exe((const char_u *)name, NULL, true)
+      os_can_exe(name, NULL, true)
       || (gettail_dir(name) != name
-          && os_can_exe((const char_u *)name, NULL, false)));
+          && os_can_exe(name, NULL, false)));
 }
 
 typedef struct {
@@ -8573,12 +8573,12 @@ static void f_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 static void f_exepath(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   const char *arg = tv_get_string(&argvars[0]);
-  char_u *path = NULL;
+  char *path = NULL;
 
-  (void)os_can_exe((const char_u *)arg, &path, true);
+  (void)os_can_exe(arg, &path, true);
 
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = path;
+  rettv->vval.v_string = (char_u *)path;
 }
 
 /// Find a window: When using a Window ID in any tab page, when using a number
@@ -12109,8 +12109,8 @@ static char **tv_to_argv(typval_T *cmd_tv, const char **cmd, bool *executable)
   }
 
   const char *arg0 = tv_get_string_chk(TV_LIST_ITEM_TV(tv_list_first(argl)));
-  char_u *exe_resolved = NULL;
-  if (!arg0 || !os_can_exe((const char_u *)arg0, &exe_resolved, true)) {
+  char *exe_resolved = NULL;
+  if (!arg0 || !os_can_exe(arg0, &exe_resolved, true)) {
     if (arg0 && executable) {
       *executable = false;
     }

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -230,7 +230,7 @@ int os_exepath(char *buffer, size_t *size)
 /// Checks if the file `name` is executable.
 ///
 /// @param[in]  name     Filename to check.
-/// @param[out] abspath  Returns resolved executable path, if not NULL.
+/// @param[out,allocated] abspath  Returns resolved exe path, if not NULL.
 /// @param[in] use_path  Also search $PATH.
 ///
 /// @return true if `name` is executable and
@@ -271,6 +271,9 @@ bool os_can_exe(const char_u *name, char_u **abspath, bool use_path)
 }
 
 /// Returns true if `name` is an executable file.
+///
+/// @param[in]            name     Filename to check.
+/// @param[out,allocated] abspath  Returns full exe path, if not NULL.
 static bool is_executable(const char *name, char_u **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -239,10 +239,10 @@ int os_exepath(char *buffer, size_t *size)
 ///   - is absolute.
 ///
 /// @return `false` otherwise.
-bool os_can_exe(const char_u *name, char_u **abspath, bool use_path)
+bool os_can_exe(const char *name, char **abspath, bool use_path)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  bool no_path = !use_path || path_is_absolute(name);
+  bool no_path = !use_path || path_is_absolute((char_u *)name);
   // If the filename is "qualified" (relative or absolute) do not check $PATH.
 #ifdef WIN32
   no_path |= (name[0] == '.'
@@ -255,11 +255,11 @@ bool os_can_exe(const char_u *name, char_u **abspath, bool use_path)
 
   if (no_path) {
 #ifdef WIN32
-    if (is_executable_ext((char *)name, abspath)) {
+    if (is_executable_ext(name, abspath)) {
 #else
     // Must have path separator, cannot execute files in the current directory.
-    if ((const char_u *)gettail_dir((const char *)name) != name
-        && is_executable((char *)name, abspath)) {
+    if (gettail_dir(name) != name
+        && is_executable(name, abspath)) {
 #endif
       return true;
     } else {
@@ -274,10 +274,10 @@ bool os_can_exe(const char_u *name, char_u **abspath, bool use_path)
 ///
 /// @param[in]            name     Filename to check.
 /// @param[out,allocated] abspath  Returns full exe path, if not NULL.
-static bool is_executable(const char *name, char_u **abspath)
+static bool is_executable(const char *name, char **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  int32_t mode = os_getperm((const char *)name);
+  int32_t mode = os_getperm(name);
 
   if (mode < 0) {
     return false;
@@ -295,7 +295,7 @@ static bool is_executable(const char *name, char_u **abspath)
   const bool ok = (r == 0);
 #endif
   if (ok && abspath != NULL) {
-    *abspath = save_abs_path((char_u *)name);
+    *abspath = save_abs_path(name);
   }
   return ok;
 }
@@ -304,7 +304,7 @@ static bool is_executable(const char *name, char_u **abspath)
 /// Checks if file `name` is executable under any of these conditions:
 /// - extension is in $PATHEXT and `name` is executable
 /// - result of any $PATHEXT extension appended to `name` is executable
-static bool is_executable_ext(char *name, char_u **abspath)
+static bool is_executable_ext(char *name, char **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   const bool is_unix_shell = strstr((char *)path_tail(p_sh), "sh") != NULL;
@@ -356,7 +356,7 @@ static bool is_executable_ext(char *name, char_u **abspath)
 /// @param[out] abspath  Returns resolved executable path, if not NULL.
 ///
 /// @return `true` if `name` is an executable inside `$PATH`.
-static bool is_executable_in_path(const char_u *name, char_u **abspath)
+static bool is_executable_in_path(const char *name, char **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   const char *path_env = os_getenv("PATH");
@@ -373,7 +373,7 @@ static bool is_executable_in_path(const char_u *name, char_u **abspath)
   char *path = xstrdup(path_env);
 #endif
 
-  size_t buf_len = STRLEN(name) + strlen(path) + 2;
+  size_t buf_len = strlen(name) + strlen(path) + 2;
   char *buf = xmalloc(buf_len);
 
   // Walk through all entries in $PATH to check if "name" exists there and
@@ -385,7 +385,7 @@ static bool is_executable_in_path(const char_u *name, char_u **abspath)
 
     // Combine the $PATH segment with `name`.
     STRLCPY(buf, p, e - p + 1);
-    append_path(buf, (char *)name, buf_len);
+    append_path(buf, name, buf_len);
 
 #ifdef WIN32
     if (is_executable_ext(buf, abspath)) {

--- a/src/nvim/os_unix.c
+++ b/src/nvim/os_unix.c
@@ -535,7 +535,7 @@ int mch_expand_wildcards(int num_pat, char_u **pat, int *num_file,
 
     // Skip files that are not executable if we check for that.
     if (!dir && (flags & EW_EXEC)
-        && !os_can_exe((*file)[i], NULL, !(flags & EW_SHELLCMD))) {
+        && !os_can_exe((char *)(*file)[i], NULL, !(flags & EW_SHELLCMD))) {
       continue;
     }
 

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -453,13 +453,13 @@ char *FullName_save(const char *fname, bool force)
 /// Saves the absolute path.
 /// @param name An absolute or relative path.
 /// @return The absolute path of `name`.
-char_u *save_abs_path(const char_u *name)
+char *save_abs_path(const char *name)
   FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
-  if (!path_is_absolute(name)) {
-    return (char_u *)FullName_save((char *)name, true);
+  if (!path_is_absolute((char_u *)name)) {
+    return FullName_save(name, true);
   }
-  return vim_strsave((char_u *) name);
+  return (char *)vim_strsave((char_u *)name);
 }
 
 /// Checks if a path has a wildcard character including '~', unless at the end.
@@ -1401,7 +1401,7 @@ void addfile(
   // If the file isn't executable, may not add it.  Do accept directories.
   // When invoked from expand_shellcmd() do not use $PATH.
   if (!isdir && (flags & EW_EXEC)
-      && !os_can_exe(f, NULL, !(flags & EW_SHELLCMD))) {
+      && !os_can_exe((char *)f, NULL, !(flags & EW_SHELLCMD))) {
     return;
   }
 
@@ -2306,7 +2306,7 @@ void path_guess_exepath(const char *argv0, char *buf, size_t bufsize)
       xstrlcpy((char *)NameBuff, dir, dir_len + 1);
       xstrlcat((char *)NameBuff, PATHSEPSTR, sizeof(NameBuff));
       xstrlcat((char *)NameBuff, argv0, sizeof(NameBuff));
-      if (os_can_exe(NameBuff, NULL, false)) {
+      if (os_can_exe((char *)NameBuff, NULL, false)) {
         xstrlcpy(buf, (char *)NameBuff, bufsize);
         return;
       }

--- a/test/functional/eval/executable_spec.lua
+++ b/test/functional/eval/executable_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq, clear, call, iswin, write_file, command =
   helpers.eq, helpers.clear, helpers.call, helpers.iswin, helpers.write_file,
   helpers.command
+local eval = helpers.eval
 
 describe('executable()', function()
   before_each(clear)
@@ -95,10 +96,16 @@ describe('executable() (Windows)', function()
     eq(0, call('executable', '.\\test_executable_zzz'))
   end)
 
+  it('system([…]), jobstart([…]) use $PATHEXT #9569', function()
+    -- Invoking `cmdscript` should find/execute `cmdscript.cmd`.
+    eq('much success\n', call('system', {'test/functional/fixtures/cmdscript'}))
+    assert(0 < call('jobstart', {'test/functional/fixtures/cmdscript'}))
+  end)
+
   it('full path with extension', function()
     -- Some executable we can expect in the test env.
     local exe = 'printargs-test'
-    local exedir = helpers.eval("fnamemodify(v:progpath, ':h')")
+    local exedir = eval("fnamemodify(v:progpath, ':h')")
     local exepath = exedir..'/'..exe..'.exe'
     eq(1, call('executable', exepath))
     eq('arg1=lemon;arg2=sky;arg3=tree;',
@@ -108,7 +115,7 @@ describe('executable() (Windows)', function()
   it('full path without extension', function()
     -- Some executable we can expect in the test env.
     local exe = 'printargs-test'
-    local exedir = helpers.eval("fnamemodify(v:progpath, ':h')")
+    local exedir = eval("fnamemodify(v:progpath, ':h')")
     local exepath = exedir..'/'..exe
     eq('arg1=lemon;arg2=sky;arg3=tree;',
        call('system', exepath..' lemon sky tree'))

--- a/test/functional/fixtures/cmdscript.cmd
+++ b/test/functional/fixtures/cmdscript.cmd
@@ -1,0 +1,2 @@
+@echo off
+echo much success


### PR DESCRIPTION
Windows: In order for `jobstart(['foo'])`, `system(['foo'])` to find `foo.cmd`, we must replace "foo" with "foo.cmd" before sending `argv` to `process_spawn()`.

Rationale: `jobstart([…])`, `system([…])` "executable" semantics should be consistent with the VimL `executable()` function.

fix #9569
related: #10554