### PR TITLE
pvs/V1019: Compound assignment is used inside condition

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3439,7 +3439,7 @@ void ex_display(exarg_T *eap)
           MSG_PUTS_ATTR("^J", attr);
           n -= 2;
         }
-        for (p = yb->y_array[j]; *p && (n -= ptr2cells(p)) >= 0; ++p) {
+        for (p = yb->y_array[j]; *p && (n -= ptr2cells(p)) >= 0; p++) {  // -V1019
           clen = (*mb_ptr2len)(p);
           msg_outtrans_len(p, clen);
           p += clen - 1;


### PR DESCRIPTION
Fixing PVS Issue [V1019](https://www.viva64.com/en/w/v1019/)

For improving code readability don't use compound assignments
inside condition