### PR TITLE
tests: fix/improve Screen:expect_unchanged

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -453,10 +453,9 @@ function Screen:expect_unchanged(waittime_ms, ignore_attrs, request_cb)
   self:sleep(0, request_cb)
   local kwargs = self:get_snapshot(nil, ignore_attrs)
 
-  -- Wait for potential changes.
-  self:sleep(waittime_ms, request_cb)
+  -- Check that screen state does not change.
   kwargs.unchanged = true
-  -- Check that screen state did not change.
+  kwargs.timeout = waittime_ms
   self:expect(kwargs)
 end
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -450,8 +450,9 @@ end
 function Screen:expect_unchanged(waittime_ms, ignore_attrs, request_cb)
   waittime_ms = waittime_ms and waittime_ms or 100
   -- Collect the current screen state.
-  self:sleep(waittime_ms, request_cb)
+  self:sleep(0, request_cb)
   local kwargs = self:get_snapshot(nil, ignore_attrs)
+
   -- Wait for potential changes.
   self:sleep(waittime_ms, request_cb)
   kwargs.unchanged = true

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -158,6 +158,7 @@ describe('search highlighting', function()
       bar foo baz
     ]])
     feed('/foo')
+    helpers.wait()
     screen:expect_unchanged()
   end)
 


### PR DESCRIPTION
Do not wait before collecting initial state.

Ref: https://github.com/neovim/neovim/pull/10550#issuecomment-513670205