### PR TITLE
vim-patch:8.1.1738: testing lambda with timer is slow

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -278,7 +278,6 @@ let s:flaky_tests = [
       \ 'Test_terminal_redir_file()',
       \ 'Test_terminal_tmap()',
       \ 'Test_with_partial_callback()',
-      \ 'Test_lambda_with_timer()',
       \ ]
 
 " Pattern indicating a common flaky test failure.

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -23,30 +23,36 @@ function! Test_lambda_with_timer()
     return
   endif
 
-  source load.vim
-
   let s:n = 0
   let s:timer_id = 0
-  function! s:Foo()
-    "let n = 0
-    let s:timer_id = timer_start(50, {-> execute("let s:n += 1 | echo s:n", "")}, {"repeat": -1})
-  endfunction
+  func! s:Foo()
+    let s:timer_id = timer_start(10, {-> execute("let s:n += 1 | echo s:n", "")}, {"repeat": -1})
+  endfunc
 
   call s:Foo()
-  sleep 210m
+  " check timer works
+  for i in range(0, 10)
+    if s:n > 0
+      break
+    endif
+    sleep 10m
+  endfor
+
   " do not collect lambda
   call test_garbagecollect_now()
-  let m = LoadAdjust(s:n)
-  sleep 230m
+
+  " check timer still works
+  let m = s:n
+  for i in range(0, 10)
+    if s:n > m
+      break
+    endif
+    sleep 10m
+  endfor
+
   call timer_stop(s:timer_id)
-
-  let n = LoadAdjust(s:n)
-  let nine = LoadAdjust(9)
-
-  call assert_true(m > 1)
-  call assert_true(n > m + 1)
-  call assert_true(n < nine)
-endfunction
+  call assert_true(s:n > m)
+endfunc
 
 function! Test_lambda_with_partial()
   let l:Cb = function({... -> ['zero', a:1, a:2, a:3]}, ['one', 'two'])


### PR DESCRIPTION
vim-patch:8.1.1738: testing lambda with timer is slow

Problem:    Testing lambda with timer is slow.
Solution:   Do not test timer accuracy, only that it works. (Daniel Hahler,
            closes vim/vim#4723)
https://github.com/vim/vim/commit/9bc4dde45d45df732953491d0f2c3fd3b10a627e
