### PR TITLE
coverage: use "cd" with gcovr

### DIFF
--- a/ci/common/submit_coverage.sh
+++ b/ci/common/submit_coverage.sh
@@ -21,7 +21,10 @@ if ! [ -f "$codecov_sh" ]; then
   python3 -m pip install --quiet --user gcovr
 fi
 
-python3 -m gcovr --branches --exclude-unreachable-branches --print-summary -j 2 --exclude '.*/auto/.*' --root build --delete -o coverage.xml --xml
+(
+  cd build
+  python3 -m gcovr --branches --exclude-unreachable-branches --print-summary -j 2 --exclude '.*/auto/.*' --root .. --delete -o ../coverage.xml --xml
+)
 
 # Upload to codecov.
 # -X gcov: disable gcov, done manually above.


### PR DESCRIPTION
This makes the invocation compatible for the upcoming gcovr 4.2 release,
and is the correct way of invoking it.

Ref: https://github.com/gcovr/gcovr/commit/a782972#commitcomment-34420728

TODO:

- [ ] check coverage diff carefully