### PR TITLE
ci: RunTests: ensure that the logfile gets displayed

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -1,6 +1,11 @@
 # Set LC_ALL to meet expectations of some locale-sensitive tests.
 set(ENV{LC_ALL} "en_US.UTF-8")
 
+if(POLICY CMP0012)
+  # Handle CI=true, without dev warnings.
+  cmake_policy(SET CMP0012 NEW)
+endif()
+
 set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
 set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
 set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -62,6 +62,20 @@ file(GLOB RM_FILES ${BUILD_DIR}/Xtest_*)
 file(REMOVE_RECURSE ${RM_FILES})
 
 if(NOT res EQUAL 0)
-  message(STATUS "Output to stderr:\n${err}")
+  message(STATUS "Tests exited non-zero: ${res}")
+  if("${err}" STREQUAL "")
+    message(STATUS "No output to stderr.")
+  else()
+    message(STATUS "Output to stderr:\n${err}")
+  endif()
+
+  # Dump the logfile on CI (if not displayed and moved already).
+  if($ENV{CI})
+    if(EXISTS $ENV{NVIM_LOG_FILE} AND NOT EXISTS $ENV{NVIM_LOG_FILE}.displayed)
+      file(READ $ENV{NVIM_LOG_FILE} out)
+      message(STATUS "$NVIM_LOG_FILE: $ENV{NVIM_LOG_FILE}\n${out}")
+    endif()
+  endif()
+
   message(FATAL_ERROR "${TEST_TYPE} tests failed with error: ${res}")
 endif()

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -682,7 +682,7 @@ function module.isCI()
 end
 
 -- Gets the contents of $NVIM_LOG_FILE for printing to the build log.
--- Also removes the file, if the current environment looks like CI.
+-- Also moves the file to "${NVIM_LOG_FILE}.displayed" on CI environments.
 function module.read_nvim_log()
   local logfile = os.getenv('NVIM_LOG_FILE') or '.nvimlog'
   local is_ci = module.isCI()
@@ -696,7 +696,7 @@ function module.read_nvim_log()
   end
   log = log..('-'):rep(78)..'\n'
   if is_ci then
-    os.remove(logfile)
+    os.rename(logfile, logfile .. '.displayed')
   end
   return log
 end


### PR DESCRIPTION
This is meant to help with test failures where e.g. `busted` itself might
crash or get killed.

Ref: https://github.com/neovim/neovim/issues/10182#issuecomment-514450069