### PR TITLE
tests: AppVeyor: fix test/functional/ex_cmds/arg_spec.lua

### DIFF
--- a/test/functional/ex_cmds/arg_spec.lua
+++ b/test/functional/ex_cmds/arg_spec.lua
@@ -22,7 +22,7 @@ describe(":argument", function()
 
       local bufname_after = funcs.bufname("%")
       local bufnr_after = funcs.bufnr("%")
-      eq("\n["..bufname_before.."] ", helpers.eval('execute("args")'))
+      eq("["..bufname_before.."]", helpers.eval('trim(execute("args"))'))
       ok(funcs.line('$') > 1)
       eq(bufname_before, bufname_after)
       eq(bufnr_before, bufnr_after)


### PR DESCRIPTION
For unknown reasons it does not have the trailing space in `:args`
output there anymore:

    [  FAILED  ] test/functional\ex_cmds\arg_spec.lua @ 11: :argument does not restart :terminal buffer
    test/functional\ex_cmds\arg_spec.lua:25: Expected objects to be the same.
    Passed in:
    (string) '
    [term://.//4552:C:\Windows\system32\cmd.exe]'
    Expected:
    (string) '
    [term://.//4552:C:\Windows\system32\cmd.exe] '
    stack traceback:
            test/functional\ex_cmds\arg_spec.lua:25: in function <test/functional\ex_cmds\arg_spec.lua:11>

The test is not about that though, and this can be made less strict by
using `trim()`.  The new test in `test_arglist.vim` for no trailing
newline is OK, and contains trailing spaces.  So this is likely due to
the length of it exceeding the column width already.

