### PR TITLE
third-party: download: retry

### DIFF
--- a/third-party/cmake/DownloadAndExtractFile.cmake
+++ b/third-party/cmake/DownloadAndExtractFile.cmake
@@ -77,7 +77,7 @@ if(NOT status_code EQUAL 0)
   # Retry on certain errors, e.g. CURLE_COULDNT_RESOLVE_HOST, which is often
   # seen with libtermkey (www.leonerd.org.uk).
   if(status_code EQUAL 6)  # "Couldn't resolve host name"
-    message(STATUS "error: downloading '${URL}' failed (${status_string}, status ${status_code}) - retrying in 10s...")
+    message(STATUS "warning: retrying '${URL}' (${status_string}, status ${status_code})")
     execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 10)
     file(DOWNLOAD ${URL} ${file}
       ${timeout_args}

--- a/third-party/cmake/DownloadAndExtractFile.cmake
+++ b/third-party/cmake/DownloadAndExtractFile.cmake
@@ -74,11 +74,26 @@ list(GET status 0 status_code)
 list(GET status 1 status_string)
 
 if(NOT status_code EQUAL 0)
-  message(FATAL_ERROR "error: downloading '${URL}' failed
+  # Retry on certain errors, e.g. CURLE_COULDNT_RESOLVE_HOST, which is often
+  # seen with libtermkey (www.leonerd.org.uk).
+  if(status_code EQUAL 6)  # "Couldn't resolve host name"
+    message(STATUS "error: downloading '${URL}' failed (${status_string}, status ${status_code}) - retrying in 10s...")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 10)
+    file(DOWNLOAD ${URL} ${file}
+      ${timeout_args}
+      ${hash_args}
+      STATUS status
+      LOG log)
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
+  endif()
+  if(NOT status_code EQUAL 0)
+    message(FATAL_ERROR "error: downloading '${URL}' failed
   status_code: ${status_code}
   status_string: ${status_string}
   log: ${log}
 ")
+  endif()
 endif()
 
 set(NULL_SHA256 "0000000000000000000000000000000000000000000000000000000000000000")


### PR DESCRIPTION
This is meant to handle the common case of failing to download
libtermkey:

    FAILED: cd /home/travis/build/neovim/neovim/deps-downloads/libtermkey && /usr/local/cmake-3.12.4/bin/cmake -DPREFIX=/home/travis/nvim-deps/build -DDOWNLOAD_DIR=/home/travis/build/neovim/neovim/deps-downloads/libtermkey -DURL=http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.21.1.tar.gz -DEXPECTED_SHA256=cecbf737f35d18f433c8d7864f63c0f878af41f8bd0255a3ebb16010dc044d5f -DTARGET=libtermkey -DUSE_EXISTING_SRC_DIR=OFF -P /home/travis/build/neovim/neovim/third-party/cmake/DownloadAndExtractFile.cmake && /usr/local/cmake-3.12.4/bin/cmake -E touch /home/travis/nvim-deps/build/src/libtermkey-stamp/libtermkey-download
    -- file: /home/travis/build/neovim/neovim/deps-downloads/libtermkey/libtermkey-0.21.1.tar.gz
    -- downloading...
         src='http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.21.1.tar.gz'
         dst='/home/travis/build/neovim/neovim/deps-downloads/libtermkey/libtermkey-0.21.1.tar.gz'
         timeout='none'
    CMake Error at /home/travis/build/neovim/neovim/third-party/cmake/DownloadAndExtractFile.cmake:77 (message):
      error: downloading
      'http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.21.1.tar.gz' failed
        status_code: 6
        status_string: "Couldn't resolve host name"
        log: Curl_ipv4_resolve_r failed for www.leonerd.org.uk
      Couldn't resolve host 'www.leonerd.org.uk'
      Closing connection 0

For reference: the error codes are coming from curl: https://gitlab.kitware.com/cmake/cmake/blob/156f4c2f80a5aa603d71a24ba78441961bfcfd7d/Utilities/cmcurl/include/curl/curl.h#L477