### PR TITLE
ci: codecov: use defaults for project/patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,13 +15,8 @@ coverage:
   range: "70...100"
 
   status:
-    project:
-      default:
-        threshold: 1
-    patch:
-      default:
-        threshold: 1
-        only_pulls: true
+    project: yes
+    patch: yes
     changes: no
 
 comment: off


### PR DESCRIPTION
Inspired by "status" missing in https://github.com/neovim/neovim/pull/10584.