### PR TITLE
tests: test_arglist.vim: align with Vim  [ci skip]

### DIFF
--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -167,15 +167,6 @@ func Test_argument()
   call assert_fails('argument', 'E163:')
 endfunc
 
-func Test_args_with_quote()
-  " Only on Unix can a file name include a double quote.
-  if has('unix')
-    args \"foobar
-    call assert_equal('"foobar', argv(0))
-    %argdelete
-  endif
-endfunc
-
 func Test_list_arguments()
   " Clean the argument list
   arga a | %argd
@@ -202,6 +193,15 @@ func Test_list_arguments()
   call assert_match(aarg . '\n\[' . barg . ']\n' . carg . '\n' . darg, trim(result))
 
   %argdelete
+endfunc
+
+func Test_args_with_quote()
+  " Only on Unix can a file name include a double quote.
+  if has('unix')
+    args \"foobar
+    call assert_equal('"foobar', argv(0))
+    %argdelete
+  endif
 endfunc
 
 " Test for 0argadd and 0argedit


### PR DESCRIPTION
This just moves the test to where it is in Vim.