### PR TITLE
ci: Travis: single osx job  [ci skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,12 +125,6 @@ jobs:
       osx_image: xcode10.2  # macOS 10.14
       env:
         - *common-job-env
-    - name: "macOS: gcc"
-      os: osx
-      compiler: gcc
-      osx_image: xcode10.2  # macOS 10.14
-      env:
-        - *common-job-env
 
     - name: gcc-coverage (gcc 9)
       os: linux


### PR DESCRIPTION
The "osx" jobs are the slowest ones, and often still flaky.

I think it is good enough to have a single one there (since they only use
different compilers).
This should improve build times in general (with multiple running
builds, since we're using less jobs per build), and also make flaky job
failures less likely.