### PR TITLE
[RFC] vim-patch:8.1.0053 first argument of 'completefunc' has inconsistent type

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3694,7 +3694,7 @@ expand_by_function (
   curbuf_save = curbuf;
 
   // Call a function, which returns a list or dict.
-  if (call_vim_function(funcname, 2, args, false, &rettv) == OK) {
+  if (call_vim_function(funcname, 2, args, &rettv, false) == OK) {
     switch (rettv.v_type) {
     case VAR_LIST:
       matchlist = rettv.vval.v_list;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3682,14 +3682,19 @@ expand_by_function (
     return;
 
   // Call 'completefunc' to obtain the list of matches.
-  const char_u *const args[2] = { (char_u *)"0", base };
+  typval_T args[3];
+  args[0].v_type = VAR_NUMBER;
+  args[1].v_type = VAR_STRING;
+  args[2].v_type = VAR_UNKNOWN;
+  args[0].vval.v_number = 0;
+  args[1].vval.v_string = base != NULL ? base : (char_u *)"";
 
   pos = curwin->w_cursor;
   curwin_save = curwin;
   curbuf_save = curbuf;
 
-  /* Call a function, which returns a list or dict. */
-  if (call_vim_function(funcname, 2, args, FALSE, FALSE, &rettv) == OK) {
+  // Call a function, which returns a list or dict.
+  if (call_vim_function(funcname, 2, args, false, &rettv) == OK) {
     switch (rettv.v_type) {
     case VAR_LIST:
       matchlist = rettv.vval.v_list;
@@ -4892,7 +4897,13 @@ static int ins_complete(int c, bool enable_pum)
         return FAIL;
       }
 
-      const char_u *const args[2] = { (char_u *)"1", NULL };
+      typval_T args[3];
+      args[0].v_type = VAR_NUMBER;
+      args[1].v_type = VAR_STRING;
+      args[2].v_type = VAR_UNKNOWN;
+      args[0].vval.v_number = 1;
+      args[1].vval.v_string = (char_u *)"";
+
       pos = curwin->w_cursor;
       curwin_save = curwin;
       curbuf_save = curbuf;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1275,7 +1275,7 @@ int get_spellword(list_T *const list, const char **ret_word)
 
 
 // Call some vim script function and return the result in "*rettv".
-// Uses argv[argc-1] for the function arguments. argv[argc]
+// Uses argv[0] to argv[argc-1] for the function arguments. argv[argc]
 // should have type VAR_UNKNOWN.
 //
 // Return OK or FAIL.
@@ -1283,8 +1283,8 @@ int call_vim_function(
     const char_u *func,
     int argc,
     typval_T *argv,
-    int safe,                       // use the sandbox
-    typval_T *rettv
+    typval_T *rettv,
+    bool safe                       // use the sandbox
 )
 {
   int doesrange;
@@ -1325,7 +1325,7 @@ varnumber_T call_func_retnr(char_u *func, int argc,
   typval_T rettv;
   varnumber_T retval;
 
-  if (call_vim_function(func, argc, argv, safe, &rettv) == FAIL) {
+  if (call_vim_function(func, argc, argv, &rettv, safe) == FAIL) {
     return -1;
   }
   retval = tv_get_number_chk(&rettv, NULL);
@@ -1348,7 +1348,7 @@ char *call_func_retstr(const char *const func, int argc,
 {
   typval_T rettv;
   // All arguments are passed as strings, no conversion to number.
-  if (call_vim_function((const char_u *)func, argc, argv, safe, &rettv)
+  if (call_vim_function((const char_u *)func, argc, argv, &rettv, safe)
       == FAIL) {
     return NULL;
   }
@@ -1372,7 +1372,7 @@ void *call_func_retlist(char_u *func, int argc, typval_T *argv,
   typval_T rettv;
 
   // All arguments are passed as strings, no conversion to number.
-  if (call_vim_function(func, argc, argv, safe, &rettv) == FAIL) {
+  if (call_vim_function(func, argc, argv, &rettv, safe) == FAIL) {
     return NULL;
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -200,7 +200,7 @@ static Array cmdline_block = ARRAY_DICT_INIT;
  */
 typedef void *(*user_expand_func_T)(const char_u *,
                                     int,
-                                    const char_u * const *,
+                                    typval_T *,
                                     bool);
 
 static histentry_T *(history[HIST_COUNT]) = {NULL, NULL, NULL, NULL, NULL};
@@ -5051,8 +5051,8 @@ static void * call_user_expand_func(user_expand_func_T user_expand_func,
                                     expand_T *xp, int *num_file, char_u ***file)
 {
   char_u keep = 0;
-  char_u num[50];
-  char_u      *args[3];
+  typval_T args[4];
+  char_u *pat = NULL;
   int save_current_SID = current_SID;
   void        *ret;
   struct cmdline_info save_ccline;
@@ -5067,10 +5067,14 @@ static void * call_user_expand_func(user_expand_func_T user_expand_func,
     ccline.cmdbuff[ccline.cmdlen] = 0;
   }
 
-  args[0] = vim_strnsave(xp->xp_pattern, xp->xp_pattern_len);
-  args[1] = xp->xp_line;
-  sprintf((char *)num, "%d", xp->xp_col);
-  args[2] = num;
+  pat = vim_strnsave(xp->xp_pattern, xp->xp_pattern_len);
+  args[0].v_type = VAR_STRING;
+  args[1].v_type = VAR_STRING;
+  args[2].v_type = VAR_NUMBER;
+  args[3].v_type = VAR_UNKNOWN;
+  args[0].vval.v_string = pat;
+  args[1].vval.v_string = xp->xp_line;
+  args[2].vval.v_number = xp->xp_col;
 
   /* Save the cmdline, we don't know what the function may do. */
   save_ccline = ccline;
@@ -5080,7 +5084,7 @@ static void * call_user_expand_func(user_expand_func_T user_expand_func,
 
   ret = user_expand_func(xp->xp_arg,
                          3,
-                         (const char_u * const *)args,
+                         args,
                          false);
 
   ccline = save_ccline;
@@ -5088,7 +5092,7 @@ static void * call_user_expand_func(user_expand_func_T user_expand_func,
   if (ccline.cmdbuff != NULL)
     ccline.cmdbuff[ccline.cmdlen] = keep;
 
-  xfree(args[0]);
+  xfree(pat);
   return ret;
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2096,13 +2096,15 @@ static void op_function(oparg_T *oap)
       decl(&curbuf->b_op_end);
     }
 
-    const char_u *const argv[1] = {
-      (const char_u *)(((const char *const[]) {
+    typval_T argv[2];
+    argv[0].v_type = VAR_STRING;
+    argv[1].v_type = VAR_UNKNOWN;
+    argv[0].vval.v_string =
+      (char_u *)(((const char *const[]) {
         [kMTBlockWise] = "block",
         [kMTLineWise] = "line",
         [kMTCharWise] = "char",
-      })[oap->motion_type]),
-    };
+      })[oap->motion_type]);
 
     // Reset virtual_op so that 'virtualedit' can be changed in the
     // function.

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -250,6 +250,31 @@ func Test_omni_dash()
   set omnifunc=
 endfunc
 
+func Test_completefunc_args()
+  let s:args = []
+  func! CompleteFunc(findstart, base)
+    let s:args += [[a:findstart, empty(a:base)]]
+  endfunc
+  new
+
+  set completefunc=CompleteFunc
+  call feedkeys("i\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([1, 1], s:args[0])
+  call assert_equal(0, s:args[1][0])
+  set completefunc=
+
+  let s:args = []
+  set omnifunc=CompleteFunc
+  call feedkeys("i\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([1, 1], s:args[0])
+  call assert_equal(0, s:args[1][0])
+  set omnifunc=
+
+  bwipe!
+  unlet s:args
+  delfunc CompleteFunc
+endfunc
+
 " Check that when using feedkeys() typeahead does not interrupt searching for
 " completions.
 func Test_compl_feedkeys()


### PR DESCRIPTION
Problem:    The first argument given to 'completefunc' can be Number or
            String, depending on the value.
Solution:   Avoid guessing the type of an argument, use typval_T in the
            callers of call_vim_function(). (Ozaki Kiichi)
vim/vim#2993