### PR TITLE
[RFC] vim-patch:8.1.0017: shell command completion has duplicates

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -232,6 +232,15 @@ func Test_getcompletion()
   let l = getcompletion('not', 'mapclear')
   call assert_equal([], l)
 
+  let l = getcompletion('.', 'shellcmd')
+  call assert_equal(['./', '../'], l[0:1])
+  call assert_equal(-1, match(l[2:], '^\.\.\?/$'))
+  let root = has('win32') ? 'C:\\' : '/'
+  let l = getcompletion(root, 'shellcmd')
+  let expected = map(filter(glob(root . '*', 0, 1),
+        \ 'isdirectory(v:val) || executable(v:val)'), 'isdirectory(v:val) ? v:val . ''/'' : v:val')
+  call assert_equal(expected, l)
+
   if has('cscope')
     let l = getcompletion('', 'cscope')
     let cmds = ['add', 'find', 'help', 'kill', 'reset', 'show']

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -282,8 +282,7 @@ func Test_getcompletion()
   call assert_equal([], l)
 
   " For others test if the name is recognized.
-  let names = ['buffer', 'environment', 'file_in_path',
-	\ 'mapping', 'shellcmd', 'tag', 'tag_listfiles', 'user']
+  let names = ['buffer', 'environment', 'file_in_path', 'mapping', 'tag', 'tag_listfiles', 'user']
   if has('cmdline_hist')
     call add(names, 'history')
   endif


### PR DESCRIPTION
**vim-patch:8.1.0017: shell command completion has duplicates**
Problem:    Shell command completion has duplicates. (Yegappan Lakshmanan)
Solution:   Use a hash table to avoid duplicates. (Ozaki Kiichi, closes vim/vim#539, closes vim/vim#2733)
https://github.com/vim/vim/commit/62fe66f251263715968442e237742d9d3dfd5fa1