### PR TITLE
vim-patch:8.1.1748: :args output is not aligned

### DIFF
--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -150,6 +150,25 @@ func Test_argument()
 
   let &hidden = save_hidden
 
+  let save_columns = &columns
+  let &columns = 79
+  exe 'args ' .. join(range(1, 81))
+  call assert_equal(join([
+        \ '',
+        \ '[1] 6   11  16  21  26  31  36  41  46  51  56  61  66  71  76  81  ',
+        \ '2   7   12  17  22  27  32  37  42  47  52  57  62  67  72  77  ',
+        \ '3   8   13  18  23  28  33  38  43  48  53  58  63  68  73  78  ',
+        \ '4   9   14  19  24  29  34  39  44  49  54  59  64  69  74  79  ',
+        \ '5   10  15  20  25  30  35  40  45  50  55  60  65  70  75  80  ',
+        \ ], "\n"),
+        \ execute('args'))
+
+  " No trailing newline with one item per row.
+  let long_arg = repeat('X', 81)
+  exe 'args ' .. long_arg
+  call assert_equal("\n[".long_arg.']', execute('args'))
+  let &columns = save_columns
+
   " Setting argument list should fail when the current buffer has unsaved
   " changes
   %argd

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2038,6 +2038,9 @@ static void version_msg(char *s)
 static void list_features(void)
 {
   list_in_columns((char_u **)features, -1, -1);
+  if (msg_col > 0) {
+    msg_putchar('\n');
+  }
   MSG_PUTS("See \":help feature-compile\"\n\n");
 }
 
@@ -2065,7 +2068,7 @@ void list_in_columns(char_u **items, int size, int current)
     // Not enough screen columns - show one per line
     for (i = 0; i < item_count; i++) {
       version_msg_wrap(items[i], i == current);
-      if (msg_col > 0) {
+      if (msg_col > 0 && i < item_count - 1) {
         msg_putchar('\n');
       }
     }
@@ -2099,6 +2102,14 @@ void list_in_columns(char_u **items, int size, int current)
         while (msg_col % width) {
           msg_putchar(' ');
         }
+      }
+    } else {
+      // this row is out of items, thus at the end of the row
+      if (msg_col > 0) {
+        if (cur_row < nrow) {
+          msg_putchar('\n');
+        }
+        cur_row++;
       }
     }
   }


### PR DESCRIPTION
Problem:    :args output is not aligned.
Solution:   Output a line break after the last item in a row.
https://github.com/vim/vim/commit/74da39373c90fcb390068903b5bbb93ce7ac16fa

vim-patch:8.1.1750: depending on the terminal width :version may miss a line break

Problem:    Depending on the terminal width :version may miss a line break.
Solution:   Add a line break when needed.
https://github.com/vim/vim/commit/8a5c29aee978345132ad7f318b8a84633c33905c

vim-patch:8.1.1760: extra line break for wrapping output of :args

Problem:    Extra line break for wrapping output of :args.
Solution:   Avoid the extra line break. (Daniel Hahler, closes vim/vim#4737)
https://github.com/vim/vim/commit/9800bfe0fc7596e8fee97172139f0777bac639fb