### PR TITLE
[RDY] ci: Travis: debug asan_symbolize

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -16,13 +16,16 @@ echo 'Python info:'
   pip3 --version
   pip2 --version
   pip --version
+
+  pyenv --version
   pyenv versions
 ) 2>&1 | sed 's/^/  /' || true
 
 # Use pyenv, but not for OSX on Travis, where it only has the "system" version.
 if [[ "${TRAVIS_OS_NAME}" != osx ]] && command -v pyenv; then
   echo 'Setting Python versions via pyenv'
-  # Prefer python2 as python for /usr/bin/asan_symbolize-4.0.
+
+  # Prefer Python 2 over 3 (more conservative).
   pyenv global 2.7.15:3.7
 
   echo 'Updated Python info:'

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -69,6 +69,7 @@ check_logs() {
   for log in $(find "${1}" -type f -name "${2}" -size +0); do
     cat "${log}"
     err=1
+    rm "${log}"
   done
   if test -n "${err}" ; then
     fail 'logs' E 'Runtime errors detected.'
@@ -81,7 +82,7 @@ valgrind_check() {
 
 asan_check() {
   if test "${CLANG_SANITIZER}" = "ASAN_UBSAN" ; then
-    check_logs "${1}" "*san.*" | asan_symbolize
+    check_logs "${1}" "*san.*"
   fi
 }
 


### PR DESCRIPTION
Via https://github.com/neovim/neovim/pull/10620#issuecomment-515714211:
```
+bin/nvim -u NONE -e -c :qall
[?1049h[22;0;0t[?1h=[H[2J]11;?[?2004h]112[2 q[H[?25h[?25l(B[m[H[2J]112[2 q]112[2 q[39B[?25h[?25l]112[2 q(B[m[?25h[?1l>[?1049l[23;0;0t[?2004l[?1004l[?25h+asan_check /home/travis/build/neovim/neovim/build/log
+test ASAN_UBSAN = ASAN_UBSAN
+asan_symbolize
+check_logs /home/travis/build/neovim/neovim/build/log '*san.*'
++find /home/travis/build/neovim/neovim/build/log -type f -name '*san.*'
+local err=
++find /home/travis/build/neovim/neovim/build/log -type f -name '*san.*' -size +0
+test -n ''
/opt/pyenv/libexec/pyenv: line 43: cd: asan_symbolize-3.8: Not a directory
```

Should probably just use llvm-symbolizer?!