### PR TITLE
[RFC] vim-patch:8.1.1759

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3304,6 +3304,8 @@ char *map_mode_to_chars(int mode)
       ga_append(&mapmode, 'n');                         /* :nmap */
     if (mode & OP_PENDING)
       ga_append(&mapmode, 'o');                         /* :omap */
+    if (mode & TERM_FOCUS)
+      ga_append(&mapmode, 't');                         /* :tmap */
     if ((mode & (VISUAL + SELECTMODE)) == VISUAL + SELECTMODE)
       ga_append(&mapmode, 'v');                         /* :vmap */
     else {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3288,31 +3288,36 @@ char *map_mode_to_chars(int mode)
 
   ga_init(&mapmode, 1, 7);
 
-  if ((mode & (INSERT + CMDLINE)) == INSERT + CMDLINE)
-    ga_append(&mapmode, '!');                           /* :map! */
-  else if (mode & INSERT)
-    ga_append(&mapmode, 'i');                           /* :imap */
-  else if (mode & LANGMAP)
-    ga_append(&mapmode, 'l');                           /* :lmap */
-  else if (mode & CMDLINE)
-    ga_append(&mapmode, 'c');                           /* :cmap */
-  else if ((mode & (NORMAL + VISUAL + SELECTMODE + OP_PENDING))
-           == NORMAL + VISUAL + SELECTMODE + OP_PENDING)
-    ga_append(&mapmode, ' ');                           /* :map */
-  else {
-    if (mode & NORMAL)
-      ga_append(&mapmode, 'n');                         /* :nmap */
-    if (mode & OP_PENDING)
-      ga_append(&mapmode, 'o');                         /* :omap */
-    if (mode & TERM_FOCUS)
-      ga_append(&mapmode, 't');                         /* :tmap */
-    if ((mode & (VISUAL + SELECTMODE)) == VISUAL + SELECTMODE)
-      ga_append(&mapmode, 'v');                         /* :vmap */
-    else {
-      if (mode & VISUAL)
-        ga_append(&mapmode, 'x');                       /* :xmap */
-      if (mode & SELECTMODE)
-        ga_append(&mapmode, 's');                       /* :smap */
+  if ((mode & (INSERT + CMDLINE)) == INSERT + CMDLINE) {
+    ga_append(&mapmode, '!');                           // :map!
+  } else if (mode & INSERT) {
+    ga_append(&mapmode, 'i');                           // :imap
+  } else if (mode & LANGMAP) {
+    ga_append(&mapmode, 'l');                           // :lmap
+  } else if (mode & CMDLINE) {
+    ga_append(&mapmode, 'c');                           // :cmap
+  } else if ((mode & (NORMAL + VISUAL + SELECTMODE + OP_PENDING))
+             == NORMAL + VISUAL + SELECTMODE + OP_PENDING) {
+    ga_append(&mapmode, ' ');                           // :map
+  } else {
+    if (mode & NORMAL) {
+      ga_append(&mapmode, 'n');                         // :nmap
+    }
+    if (mode & OP_PENDING) {
+      ga_append(&mapmode, 'o');                         // :omap
+    }
+    if (mode & TERM_FOCUS) {
+      ga_append(&mapmode, 't');                         // :tmap
+    }
+    if ((mode & (VISUAL + SELECTMODE)) == VISUAL + SELECTMODE) {
+      ga_append(&mapmode, 'v');                         // :vmap
+    } else {
+      if (mode & VISUAL) {
+        ga_append(&mapmode, 'x');                       // :xmap
+      }
+      if (mode & SELECTMODE) {
+        ga_append(&mapmode, 's');                       // :smap
+      }
     }
   }
 

--- a/src/nvim/testdir/test_maparg.vim
+++ b/src/nvim/testdir/test_maparg.vim
@@ -27,6 +27,10 @@ function Test_maparg()
   call assert_equal({'silent': 0, 'noremap': 0, 'lhs': 'foo', 'mode': ' ',
         \ 'nowait': 1, 'expr': 0, 'sid': sid, 'rhs': 'bar', 'buffer': 1},
         \ maparg('foo', '', 0, 1))
+  tmap baz foo
+  call assert_equal({'silent': 0, 'noremap': 0, 'lhs': 'baz', 'mode': 't',
+        \ 'nowait': 0, 'expr': 0, 'sid': sid, 'rhs': 'foo', 'buffer': 0},
+        \ maparg('baz', 't', 0, 1))
 
   map abc x<char-114>x
   call assert_equal("xrx", maparg('abc'))

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -346,11 +346,6 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     to_return.sid = not opts.sid and 0 or opts.sid
     to_return.buffer = not opts.buffer and 0 or opts.buffer
 
-    -- mode 't' doesn't print when calling maparg
-    if mode == 't' then
-      to_return.mode = ''
-    end
-
     return to_return
   end
 


### PR DESCRIPTION
#### vim-patch:8.1.1759: no mode char for terminal mapping from maparg()

Problem:    No mode char for terminal mapping from maparg().
Solution:   Check for TERMINAL mode. (closes vim/vim#4735)
https://github.com/vim/vim/commit/14371ed69778107654e39268d0d90982e53ad6e0