### PR TITLE
pvs/V560 part of conditional expression is always true

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4500,7 +4500,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
         sp->ts_state = STATE_SWAP3;
         break;
       }
-      if (c2 != NUL && TRY_DEEPER(su, stack, depth, SCORE_SWAP)) {
+      if (TRY_DEEPER(su, stack, depth, SCORE_SWAP)) {
         go_deeper(stack, depth, SCORE_SWAP);
 #ifdef DEBUG_TRIEWALK
         snprintf(changename[depth], sizeof(changename[0]),


### PR DESCRIPTION
Fixes discovered by PVS issues [V560](https://www.viva64.com/en/w/v560/)

Inverse condition earlier leads to short-circuit of the loop