### PR TITLE
vim-patch:7.4.2213: runtime parts with EndOfBuffer port

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -95,7 +95,7 @@ A List, Dictionary or Float is not a Number or String, thus evaluate to FALSE.
 List, Dictionary and Funcref types are not automatically converted.
 
 							*E805* *E806* *E808*
-When mixing Number and Float the Number is converted to Float.	Otherwise
+When mixing Number and Float the Number is converted to Float.  Otherwise
 there is no automatic conversion of Float.  You can use str2float() for String
 to Float, printf() for Float to String and float2nr() for Float to Number.
 
@@ -104,13 +104,14 @@ When expecting a Float a Number can also be used, but nothing else.
 
 					*no-type-checking*
 You will not get an error if you try to change the type of a variable.
-	
+
+
 1.2 Function references ~
 					*Funcref* *E695* *E718*
-A Funcref variable is obtained with the |function()| function or created with
-the lambda expression |expr-lambda|. It can be used in an expression in the
-place of a function name, before the parenthesis around the arguments, to
-invoke the function it refers to.  Example: >
+A Funcref variable is obtained with the |function()| function, the |funcref()|
+function or created with the lambda expression |expr-lambda|.  It can be used
+in an expression in the place of a function name, before the parenthesis
+around the arguments, to invoke the function it refers to.  Example: >
 
 	:let Fn = function("MyFunc")
 	:echo Fn()
@@ -142,8 +143,8 @@ arguments: >
 								*Partial*
 A Funcref optionally binds a Dictionary and/or arguments.  This is also called
 a Partial.  This is created by passing the Dictionary and/or arguments to
-function().  When calling the function the Dictionary and/or arguments will be
-passed to the function.  Example: >
+function() or funcref().  When calling the function the Dictionary and/or
+arguments will be passed to the function.  Example: >
 
 	let Cb = function('Callback', ['foo'], myDict)
 	call Cb()
@@ -177,7 +178,7 @@ Here "self" will be "myDict", because it was bound explicitly.
 1.3 Lists ~
 						*list* *List* *Lists* *E686*
 A List is an ordered sequence of items.  An item can be of any type.  Items
-can be accessed by their index number.	Items can be added and removed at any
+can be accessed by their index number.  Items can be added and removed at any
 position in the sequence.
 
 
@@ -188,7 +189,7 @@ Examples: >
 	:let mylist = [1, two, 3, "four"]
 	:let emptylist = []
 
-An item can be any expression.	Using a List for an item creates a
+An item can be any expression.  Using a List for an item creates a
 List of Lists: >
 	:let nestlist = [[11, 12], [21, 22], [31, 32]]
 
@@ -247,7 +248,7 @@ length minus one is used: >
 	:echo mylist[2:8]		" result: [2, 3]
 
 NOTE: mylist[s:e] means using the variable "s:e" as index.  Watch out for
-using a single letter variable before the ":".	Insert a space when needed:
+using a single letter variable before the ":".  Insert a space when needed:
 mylist[s : e].
 
 
@@ -376,7 +377,7 @@ This works like: >
 If all you want to do is modify each item in the list then the |map()|
 function will be a simpler method than a for loop.
 
-Just like the |:let| command, |:for| also accepts a list of variables.	This
+Just like the |:let| command, |:for| also accepts a list of variables.  This
 requires the argument to be a list of lists. >
 	:for [lnum, col] in [[1, 3], [2, 8], [3, 0]]
 	:   call Doit(lnum, col)
@@ -433,11 +434,11 @@ only appear once.  Examples: >
 <							*E713* *E716* *E717*
 A key is always a String.  You can use a Number, it will be converted to a
 String automatically.  Thus the String '4' and the number 4 will find the same
-entry.	Note that the String '04' and the Number 04 are different, since the
+entry.  Note that the String '04' and the Number 04 are different, since the
 Number will be converted to the String '4'.  The empty string can be used as a
 key.
 
-A value can be any expression.	Using a Dictionary for a value creates a
+A value can be any expression.  Using a Dictionary for a value creates a
 nested Dictionary: >
 	:let nestdict = {1: {11: 'a', 12: 'b'}, 2: {21: 'c'}}
 
@@ -464,7 +465,7 @@ key lookup can be repeated: >
 
 Dictionary to List conversion ~
 
-You may want to loop over the entries in a dictionary.	For this you need to
+You may want to loop over the entries in a dictionary.  For this you need to
 turn the Dictionary into a List and pass it to |:for|.
 
 Most often you want to loop over the keys, using the |keys()| function: >
@@ -531,7 +532,7 @@ This removes all entries from "dict" with a value not matching 'x'.
 Dictionary function ~
 				*Dictionary-function* *self* *E725* *E862*
 When a function is defined with the "dict" attribute it can be used in a
-special way with a dictionary.	Example: >
+special way with a dictionary.  Example: >
 	:function Mylen() dict
 	:   return len(self.data)
 	:endfunction
@@ -555,7 +556,7 @@ assigned to a Dictionary in this way: >
 	:echo mydict.len()
 
 The function will then get a number and the value of dict.len is a |Funcref|
-that references this function.	The function can only be used through a
+that references this function.  The function can only be used through a
 |Funcref|.  It will automatically be deleted when there is no |Funcref|
 remaining that refers to it.
 
@@ -815,10 +816,10 @@ values are different: >
 "is#"/"isnot#" and "is?"/"isnot?" can be used to match and ignore case.
 
 When comparing a String with a Number, the String is converted to a Number,
-and the comparison is done on Numbers. This means that: >
+and the comparison is done on Numbers.  This means that: >
 	echo 0 == 'x'
 	1
-because 'x' converted to a Number is zero. However: >
+because 'x' converted to a Number is zero.  However: >
 	echo [0] == ['x']
 	0
 Inside a List or Dictionary this conversion is not used.
@@ -914,7 +915,7 @@ For '+' the number is unchanged.
 
 A String will be converted to a Number first.
 
-These three can be repeated and mixed.	Examples:
+These three can be repeated and mixed.  Examples:
 	!-1	    == 0
 	!!8	    == 1
 	--9	    == 9
@@ -948,7 +949,7 @@ compatibility).  Use [-1:] to get the last byte.
 
 If expr8 is a |List| then it results the item at index expr1.  See |list-index|
 for possible index values.  If the index is out of range this results in an
-error.	Example: >
+error.  Example: >
 	:let item = mylist[-1]		" get last item
 
 Generally, if a |List| index is equal to or higher than the length of the
@@ -980,7 +981,7 @@ Examples: >
 <
 							*slice*
 If expr8 is a |List| this results in a new |List| with the items indicated by
-the indexes expr1a and expr1b.	This works like with a String, as explained
+the indexes expr1a and expr1b.  This works like with a String, as explained
 just above. Also see |sublist| below.  Examples: >
 	:let l = mylist[:3]		" first four items
 	:let l = mylist[4:4]		" List with one item
@@ -1040,7 +1041,7 @@ Floating point numbers can be written in two forms:
 contain digits.
 [-+] means there is an optional plus or minus sign.
 {exp} is the exponent, power of 10.
-Only a decimal point is accepted, not a comma.	No matter what the current
+Only a decimal point is accepted, not a comma.  No matter what the current
 locale is.
 
 Examples:
@@ -1129,11 +1130,11 @@ literal-string						*literal-string* *E115*
 
 Note that single quotes are used.
 
-This string is taken as it is.	No backslashes are removed or have a special
+This string is taken as it is.  No backslashes are removed or have a special
 meaning.  The only exception is that two quotes stand for one quote.
 
 Single quoted strings are useful for patterns, so that backslashes do not need
-to be doubled.	These two commands are equivalent: >
+to be doubled.  These two commands are equivalent: >
 	if a =~ "\\s*"
 	if a =~ '\s*'
 
@@ -1159,7 +1160,7 @@ register						*expr-register* *@r*
 
 The result is the contents of the named register, as a single string.
 Newlines are inserted where required.  To get the contents of the unnamed
-register use @" or @@.	See |registers| for an explanation of the available
+register use @" or @@.  See |registers| for an explanation of the available
 registers.
 
 When using the '=' register you get the expression itself, not what it
@@ -1321,7 +1322,7 @@ It is deleted when the tab page is closed.
 
 						*global-variable* *g:var* *g:*
 Inside functions global variables are accessed with "g:".  Omitting this will
-access a variable local to a function.	But "g:" can also be used in any other
+access a variable local to a function.  But "g:" can also be used in any other
 place if you like.
 
 						*local-variable* *l:var* *l:*
@@ -1463,7 +1464,7 @@ v:cmdarg	This variable is used for two purposes:
 		   set before an autocommand event for a file read/write
 		   command is triggered.  There is a leading space to make it
 		   possible to append this variable directly after the
-		   read/write command.	Note: The "+cmd" argument isn't
+		   read/write command.  Note: The "+cmd" argument isn't
 		   included here, because it will be executed anyway.
 		2. When printing a PostScript file with ":hardcopy" this is
 		   the argument for the ":hardcopy" command.  This can be used
@@ -1483,7 +1484,7 @@ v:completed_item
 
 					*v:count* *count-variable*
 v:count		The count given for the last Normal mode command.  Can be used
-		to get the count before a mapping.  Read-only.	Example: >
+		to get the count before a mapping.  Read-only.  Example: >
 	:map _x :<C-U>echo "the count is " . v:count<CR>
 <		Note: The <C-U> is required to remove the line range that you
 		get when typing ':' after a count.
@@ -1505,7 +1506,7 @@ v:ctype		The current locale setting for characters of the runtime
 		See |multi-lang|.
 
 					*v:dying* *dying-variable*
-v:dying		Normally zero.	When a deadly signal is caught it's set to
+v:dying		Normally zero.  When a deadly signal is caught it's set to
 		one.  When multiple signals are caught the number increases.
 		Can be used in an autocommand to check if Vim didn't
 		terminate normally. {only works on Unix}
@@ -1638,7 +1639,7 @@ v:fname_out	The name of the output file.  Only valid while
 			'diffexpr'	output of diff
 			'patchexpr'	resulting patched file
 		(*) When doing conversion for a write command (e.g., ":w
-		file") it will be equal to v:fname_in.	When doing conversion
+		file") it will be equal to v:fname_in.  When doing conversion
 		for a read command (e.g., ":e file") it will be a temporary
 		file and different from v:fname_in.
 
@@ -1787,7 +1788,7 @@ v:prevcount	The count given for the last but one Normal mode command.
 <		Read-only.
 
 					*v:profiling* *profiling-variable*
-v:profiling	Normally zero.	Set to one after using ":profile start".
+v:profiling	Normally zero.  Set to one after using ":profile start".
 		See |profiling|.
 
 					*v:progname* *progname-variable*
@@ -1867,14 +1868,14 @@ v:swapchoice	|SwapExists| autocommands can set this to the selected choice
 			'd'	Delete swapfile
 			'q'	Quit
 			'a'	Abort
-		The value should be a single-character string.	An empty value
+		The value should be a single-character string.  An empty value
 		results in the user being asked, as would happen when there is
 		no SwapExists autocommand.  The default is empty.
 
 					*v:swapcommand* *swapcommand-variable*
 v:swapcommand	Normal mode command to be executed after a file has been
 		opened.  Can be used for a |SwapExists| autocommand to have
-		another Vim open the file and jump to the right place.	For
+		another Vim open the file and jump to the right place.  For
 		example, when jumping to a tag the value is ":tag tagname\r".
 		For ":edit +cmd file" the value is ":cmd\r".
 
@@ -1917,7 +1918,7 @@ v:this_session	Full filename of the last loaded or saved session file.
 
 					*v:throwpoint* *throwpoint-variable*
 v:throwpoint	The point where the exception most recently caught and not
-		finished was thrown.  Not set when commands are typed.	See
+		finished was thrown.  Not set when commands are typed.  See
 		also |v:exception| and |throw-variables|.
 		Example: >
 	:try
@@ -1935,7 +1936,7 @@ v:true		Special value used to put "true" in JSON and msgpack.  See
 		|expr7| when used with numeric operators). Read-only.
 
 						*v:val* *val-variable*
-v:val		Value of the current item of a |List| or |Dictionary|.	Only
+v:val		Value of the current item of a |List| or |Dictionary|.  Only
 		valid while evaluating the expression used with |map()| and
 		|filter()|.  Read-only.
 
@@ -2478,7 +2479,7 @@ append({lnum}, {text})					*append()*
 		the current buffer.
 		{lnum} can be zero to insert a line before the first one.
 		Returns 1 for failure ({lnum} out of range or out of memory),
-		0 for success.	Example: >
+		0 for success.  Example: >
 			:let failed = append(line('$'), "# THE END")
 			:let failed = append(0, ["Chapter 1", "the beginning"])
 <
@@ -2736,7 +2737,7 @@ bufname({expr})						*bufname()*
 		If {expr} is a Number, that buffer number's name is given.
 		Number zero is the alternate buffer for the current window.
 		If {expr} is a String, it is used as a |file-pattern| to match
-		with the buffer names.	This is always done like 'magic' is
+		with the buffer names.  This is always done like 'magic' is
 		set and 'cpoptions' is empty.  When there is more than one
 		match an empty string is returned.
 		"" or "%" can be used for the current buffer, "#" for the
@@ -2786,7 +2787,7 @@ bufwinid({expr})					*bufwinid()*
 bufwinnr({expr})					*bufwinnr()*
 		The result is a Number, which is the number of the first
 		window associated with buffer {expr}.  For the use of {expr},
-		see |bufname()| above.	If buffer {expr} doesn't exist or
+		see |bufname()| above.  If buffer {expr} doesn't exist or
 		there is no such window, -1 is returned.  Example: >
 
 	echo "A window containing buffer 1 is " . (bufwinnr(1))
@@ -2943,7 +2944,7 @@ col({expr})	The result is a Number, which is the byte index of the column
 			col("$")		length of cursor line plus one
 			col("'t")		column of mark t
 			col("'" . markname)	column of mark markname
-<		The first column is 1.	0 is returned for an error.
+<		The first column is 1.  0 is returned for an error.
 		For an uppercase mark the column may actually be in another
 		buffer.
 		For the cursor position, when 'virtualedit' is active, the
@@ -2990,7 +2991,7 @@ complete_add({expr})				*complete_add()*
 		Returns 0 for failure (empty string or out of memory),
 		1 when the match was added, 2 when the match was already in
 		the list.
-		See |complete-functions| for an explanation of {expr}.	It is
+		See |complete-functions| for an explanation of {expr}.  It is
 		the same as one item in the list that 'omnifunc' would return.
 
 complete_check()				*complete_check()*
@@ -3097,19 +3098,20 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])
    :endif
 <		In a GUI dialog, buttons are used.  The layout of the buttons
 		depends on the 'v' flag in 'guioptions'.  If it is included,
-		the buttons are always put vertically.	Otherwise,  confirm()
+		the buttons are always put vertically.  Otherwise,  confirm()
 		tries to put the buttons in one horizontal line.  If they
 		don't fit, a vertical layout is used anyway.  For some systems
 		the horizontal layout is always used.
 
 							*copy()*
-copy({expr})	Make a copy of {expr}.	For Numbers and Strings this isn't
+copy({expr})	Make a copy of {expr}.  For Numbers and Strings this isn't
 		different from using {expr} directly.
 		When {expr} is a |List| a shallow copy is created.  This means
 		that the original |List| can be changed without changing the
 		copy, and vice versa.  But the items are identical, thus
-		changing an item changes the contents of both |Lists|.	Also
-		see |deepcopy()|.
+		changing an item changes the contents of both |Lists|.
+		A |Dictionary| is copied in a similar way as a |List|.
+		Also see |deepcopy()|.
 
 cos({expr})						*cos()*
 		Return the cosine of {expr}, measured in radians, as a |Float|.
@@ -3217,7 +3219,7 @@ cursor({list})
 
 
 deepcopy({expr}[, {noref}])				*deepcopy()* *E698*
-		Make a copy of {expr}.	For Numbers and Strings this isn't
+		Make a copy of {expr}.  For Numbers and Strings this isn't
 		different from using {expr} directly.
 		When {expr} is a |List| a full copy is created.  This means
 		that the original |List| can be changed without changing the
@@ -3374,10 +3376,10 @@ executable({expr})					*executable()*
 		searchpath for programs.		*PATHEXT*
 		On Windows the ".exe", ".bat", etc. can
 		optionally be included.  Then the extensions in $PATHEXT are
-		tried.	Thus if "foo.exe" does not exist, "foo.exe.bat" can be
-		found.	If $PATHEXT is not set then ".exe;.com;.bat;.cmd" is
+		tried.  Thus if "foo.exe" does not exist, "foo.exe.bat" can be
+		found.  If $PATHEXT is not set then ".exe;.com;.bat;.cmd" is
 		used.  A dot by itself can be used in $PATHEXT to try using
-		the name without an extension.	When 'shell' looks like a
+		the name without an extension.  When 'shell' looks like a
 		Unix shell, then the name is also tried without adding an
 		extension.
 		On Windows it only checks if the file exists and
@@ -3440,7 +3442,7 @@ exists({expr})	The result is a Number, which is |TRUE| if {expr} is
 					|user-functions|). Also works for a
 					variable that is a Funcref.
 			varname		internal variable (see
-					|internal-variables|).	Also works
+					|internal-variables|).  Also works
 					for |curly-braces-names|, |Dictionary|
 					entries, |List| items, etc.  Beware
 					that evaluating an index may cause an
@@ -3525,7 +3527,7 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 		Otherwise the result is a String and when there are several
 		matches, they are separated by <NL> characters.
 
-		If the expansion fails, the result is an empty string.	A name
+		If the expansion fails, the result is an empty string.  A name
 		for a non-existing file is not included, unless {expr} does
 		not start with '%', '#' or '<', see below.
 
@@ -3589,7 +3591,7 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 		slow, because a shell may be used to do the expansion.  See
 		|expr-env-expand|.
 		The expanded variable is still handled like a list of file
-		names.	When an environment variable cannot be expanded, it is
+		names.  When an environment variable cannot be expanded, it is
 		left unchanged.  Thus ":echo expand('$FOOBAR')" results in
 		"$FOOBAR".
 
@@ -3612,7 +3614,7 @@ extend({expr1}, {expr2} [, {expr3}])			*extend()*
 		items copied is equal to the original length of the List.
 		E.g., when {expr3} is 1 you get N new copies of the first item
 		(where N is the original length of the List).
-		Use |add()| to concatenate one item to a list.	To concatenate
+		Use |add()| to concatenate one item to a list.  To concatenate
 		two lists into a new list use the + operator: >
 			:let newlist = [1, 2, 3] + [4, 5]
 <
@@ -3812,7 +3814,7 @@ fmod({expr1}, {expr2})					*fmod()*
 
 
 fnameescape({string})					*fnameescape()*
-		Escape {string} for use as file name command argument.	All
+		Escape {string} for use as file name command argument.  All
 		characters that have a special meaning, such as '%' and '|'
 		are escaped with a backslash.
 		For most systems the characters escaped are
@@ -3849,7 +3851,7 @@ foldclosedend({lnum})					*foldclosedend()*
 
 foldlevel({lnum})					*foldlevel()*
 		The result is a Number, which is the foldlevel of line {lnum}
-		in the current buffer.	For nested folds the deepest level is
+		in the current buffer.  For nested folds the deepest level is
 		returned.  If there is no fold at line {lnum}, zero is
 		returned.  It doesn't matter if the folds are open or closed.
 		When used while updating folds (from 'foldexpr') -1 is
@@ -3864,7 +3866,7 @@ foldtext()	Returns a String, to be displayed for a closed fold.  This is
 		|v:foldstart|, |v:foldend| and |v:folddashes| variables.
 		The returned string looks like this: >
 			+-- 45 lines: abcdef
-<		The number of leading dashes depends on the foldlevel. The
+<		The number of leading dashes depends on the foldlevel.  The
 		"45" is the number of lines in the fold.  "abcdef" is the text
 		in the first non-blank line of the fold.  Leading white space,
 		"//" or "/*" and the text from the 'foldmarker' and
@@ -3883,7 +3885,7 @@ foldtextresult({lnum})					*foldtextresult()*
 		Useful when exporting folded text, e.g., to HTML.
 
 							*foreground()*
-foreground()	Move the Vim window to the foreground.	Useful when sent from
+foreground()	Move the Vim window to the foreground.  Useful when sent from
 		a client to a Vim server. |remote_send()|
 		On Win32 systems this might not work, the OS does not always
 		allow a window to bring itself to the foreground.  Use
@@ -4185,7 +4187,7 @@ getcharmod()						*getcharmod()*
 			96	mouse quadruple click (== 32 + 64)
 			128	command (Macintosh only)
 		Only the modifiers that have not been included in the
-		character itself are obtained.	Thus Shift-a results in "A"
+		character itself are obtained.  Thus Shift-a results in "A"
 		without a modifier.
 
 getcharsearch()						*getcharsearch()*
@@ -4709,7 +4711,7 @@ getwinposx()	The result is a Number, which is the X coordinate in pixels of
 
 							*getwinposy()*
 getwinposy()	The result is a Number, which is the Y coordinate in pixels of
-		the top of the GUI Vim window.	The result will be -1 if the
+		the top of the GUI Vim window.  The result will be -1 if the
 		information is not available.
 		The value can be used with `:winpos`.
 
@@ -4776,7 +4778,7 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])		*glob()*
 			:let tagfiles = glob("`find . -name tags -print`")
 			:let &tags = substitute(tagfiles, "\n", ",", "g")
 <		The result of the program inside the backticks should be one
-		item per line.	Spaces inside an item are allowed.
+		item per line.  Spaces inside an item are allowed.
 
 		See |expand()| for expanding special Vim variables.  See
 		|system()| for getting the raw output of an external command.
@@ -4791,7 +4793,7 @@ glob2regpat({expr})					 *glob2regpat()*
 <		When {expr} is an empty string the result is "^$", match an
 		empty string.
 		Note that the result depends on the system.  On MS-Windows
-		a backslash usually means a patch separator.
+		a backslash usually means a path separator.
 
 								*globpath()*
 globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])
@@ -4913,7 +4915,7 @@ hasmapto({what} [, {mode} [, {abbr}]])			*hasmapto()*
 		When {mode} is omitted, "nvo" is used.
 
 		This function is useful to check if a mapping already exists
-		to a function in a Vim script.	Example: >
+		to a function in a Vim script.  Example: >
 			:if !hasmapto('\ABCdoit')
 			:   map <Leader>d \ABCdoit
 			:endif
@@ -5008,7 +5010,7 @@ hlID({name})	The result is a Number, which is the ID of the highlight group
 		with name {name}.  When the highlight group doesn't exist,
 		zero is returned.
 		This can be used to retrieve information about the highlight
-		group.	For example, to get the background color of the
+		group.  For example, to get the background color of the
 		"Comment" group: >
 	:echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 
@@ -5078,7 +5080,7 @@ input({opts})
 
 		The highlighting set with |:echohl| is used for the prompt.
 		The input is entered just like a command-line, with the same
-		editing commands and mappings.	There is a separate history
+		editing commands and mappings.  There is a separate history
 		for lines typed for input().
 		Example: >
 			:if input("Coffee or beer? ") == "beer"
@@ -5092,9 +5094,9 @@ input({opts})
 
 <		The optional {completion} argument specifies the type of
 		completion supported for the input.  Without it completion is
-		not performed.	The supported completion types are the same as
+		not performed.  The supported completion types are the same as
 		that can be supplied to a user-defined command using the
-		"-complete=" argument.	Refer to |:command-completion| for
+		"-complete=" argument.  Refer to |:command-completion| for
 		more information.  Example: >
 			let fname = input("File: ", "", "file")
 
@@ -5174,12 +5176,12 @@ inputlist({textlist})					*inputlist()*
 		displayed, one string per line.  The user will be prompted to
 		enter a number, which is returned.
 		The user can also select an item by clicking on it with the
-		mouse.	For the first string 0 is returned.  When clicking
+		mouse.  For the first string 0 is returned.  When clicking
 		above the first item a negative number is returned.  When
 		clicking on the prompt one more than the length of {textlist}
 		is returned.
 		Make sure {textlist} has less than 'lines' entries, otherwise
-		it won't work.	It's a good idea to put the entry number at
+		it won't work.  It's a good idea to put the entry number at
 		the start of the string.  And put a prompt in the first item.
 		Example: >
 			let color = inputlist(['Select color:', '1. red',
@@ -5213,7 +5215,7 @@ inputsecret({prompt} [, {text}])			*inputsecret()*
 insert({list}, {item} [, {idx}])			*insert()*
 		Insert {item} at the start of |List| {list}.
 		If {idx} is specified insert {item} before the item with index
-		{idx}.	If {idx} is zero it goes before the first item, just
+		{idx}.  If {idx} is zero it goes before the first item, just
 		like omitting {idx}.  A negative {idx} is also possible, see
 		|list-index|.  -1 inserts just before the last item.
 		Returns the resulting |List|.  Examples: >
@@ -5696,7 +5698,7 @@ match({expr}, {pat} [, {start} [, {count}]])			*match()*
 		first item where {pat} matches.  Each item is used as a
 		String, |Lists| and |Dictionaries| are used as echoed.
 
-		Otherwise, {expr} is used as a String.	The result is a
+		Otherwise, {expr} is used as a String.  The result is a
 		Number, which gives the index (byte offset) in {expr} where
 		{pat} matches.
 
@@ -5709,7 +5711,7 @@ match({expr}, {pat} [, {start} [, {count}]])			*match()*
 			:echo match([1, 'x'], '\a')	" results in 1
 <		See |string-match| for how {pat} is used.
 								*strpbrk()*
-		Vim doesn't have a strpbrk() function.	But you can do: >
+		Vim doesn't have a strpbrk() function.  But you can do: >
 			:let sepidx = match(line, '[.,;: \t]')
 <								*strcasestr()*
 		Vim doesn't have a strcasestr() function.  But you can add
@@ -5746,7 +5748,7 @@ match({expr}, {pat} [, {start} [, {count}]])			*match()*
 
 		See |pattern| for the patterns that are accepted.
 		The 'ignorecase' option is used to set the ignore-caseness of
-		the pattern.  'smartcase' is NOT used.	The matching is always
+		the pattern.  'smartcase' is NOT used.  The matching is always
 		done like 'magic' is set and 'cpoptions' is empty.
 
 				*matchadd()* *E798* *E799* *E801* *E957*
@@ -5762,7 +5764,7 @@ matchadd({group}, {pattern}[, {priority}[, {id} [, {dict}]]])
 		concealed.
 
 		The optional {priority} argument assigns a priority to the
-		match.	A match with a high priority will have its
+		match.  A match with a high priority will have its
 		highlighting overrule that of a match with a lower priority.
 		A priority is specified as an integer (negative numbers are no
 		exception).  If the {priority} argument is not specified, the
@@ -5801,7 +5803,7 @@ matchadd({group}, {pattern}[, {priority}[, {id} [, {dict}]]])
 			:call matchdelete(m)
 
 <		A list of matches defined by |matchadd()| and |:match| are
-		available from |getmatches()|.	All matches can be deleted in
+		available from |getmatches()|.  All matches can be deleted in
 		one operation by |clearmatches()|.
 
 							*matchaddpos()*
@@ -5989,7 +5991,7 @@ mkdir({name} [, {path} [, {prot}]])
 		necessary.  Otherwise it must be "".
 		If {prot} is given it is used to set the protection bits of
 		the new directory.  The default is 0755 (rwxr-xr-x: r/w for
-		the user readable for others).	Use 0700 to make it unreadable
+		the user readable for others).  Use 0700 to make it unreadable
 		for others.
 
 		{prot} is applied for all parts of {name}.  Thus if you create
@@ -6270,7 +6272,7 @@ printf({fmt}, {expr1} ...)				*printf()*
 			      number produced by a signed conversion (d).
 
 		    +	      A sign must always be placed before a number
-			      produced by a signed conversion.	A + overrides
+			      produced by a signed conversion.  A + overrides
 			      a space if both are used.
 
 		field-width
@@ -6296,7 +6298,7 @@ printf({fmt}, {expr1} ...)				*printf()*
 
 		A field width or precision, or both, may be indicated by an
 		asterisk '*' instead of a digit string.  In this case, a
-		Number argument supplies the field width or precision.	A
+		Number argument supplies the field width or precision.  A
 		negative field width is treated as a left adjustment flag
 		followed by a positive field width; a negative precision is
 		treated as though it were missing.  Example: >
@@ -6530,7 +6532,7 @@ reltimestr({time})				*reltimestr()*
 
 							*remote_expr()* *E449*
 remote_expr({server}, {string} [, {idvar} [, {timeout}]])
-		Send the {string} to {server}.	The string is sent as an
+		Send the {string} to {server}.  The string is sent as an
 		expression and the result is returned after evaluation.
 		The result must be a String or a |List|.  A |List| is turned
 		into a String by joining the items with a line break in
@@ -6572,7 +6574,7 @@ remote_foreground({server})				*remote_foreground()*
 remote_peek({serverid} [, {retvar}])		*remote_peek()*
 		Returns a positive number if there are available strings
 		from {serverid}.  Copies any reply string into the variable
-		{retvar} if specified.	{retvar} must be a string with the
+		{retvar} if specified.  {retvar} must be a string with the
 		name of a variable.
 		Returns zero if none are available.
 		Returns -1 if something is wrong.
@@ -6595,7 +6597,7 @@ remote_read({serverid}, [{timeout}])			*remote_read()*
 <
 							*remote_send()* *E241*
 remote_send({server}, {string} [, {idvar}])
-		Send the {string} to {server}.	The string is sent as input
+		Send the {string} to {server}.  The string is sent as input
 		keys and the function returns immediately.  At the Vim server
 		the keys are not mapped |:map|.
 		If {idvar} is present, it is taken as the name of a variable
@@ -6654,7 +6656,7 @@ repeat({expr}, {count})					*repeat()*
 			:let separator = repeat('-', 80)
 <		When {count} is zero or negative the result is empty.
 		When {expr} is a |List| the result is {expr} concatenated
-		{count} times.	Example: >
+		{count} times.  Example: >
 			:let longlist = repeat(['a', 'b'], 3)
 <		Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 
@@ -6673,7 +6675,7 @@ resolve({filename})					*resolve()* *E655*
 		path name) and also keeps a trailing path separator.
 
 							*reverse()*
-reverse({list})	Reverse the order of items in {list} in-place.	Returns
+reverse({list})	Reverse the order of items in {list} in-place.  Returns
 		{list}.
 		If you want a list to remain unmodified make a copy first: >
 			:let revlist = reverse(copy(mylist))
@@ -6787,7 +6789,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout}]]])	*search()*
 		A zero value is equal to not giving the argument.
 
 		When the {timeout} argument is given the search stops when
-		more than this many milliseconds have passed.	Thus when
+		more than this many milliseconds have passed.  Thus when
 		{timeout} is 500 the search stops after half a second.
 		The value must not be negative.  A zero value is like not
 		giving the argument.
@@ -6906,7 +6908,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip}
 <		When starting at the "if 2", with the cursor on the "i", and
 		searching forwards, the "endif 2" is found.  When starting on
 		the character just before the "if 2", the "endif 1" will be
-		found.	That's because the "if 2" will be found first, and
+		found.  That's because the "if 2" will be found first, and
 		then this is considered to be a nested if/endif from "if 2" to
 		"endif 2".
 		When searching backwards and {end} is more than one character,
@@ -7064,7 +7066,7 @@ setcharsearch({dict})					*setcharsearch()*
 
 setcmdpos({pos})					*setcmdpos()*
 		Set the cursor position in the command line to byte position
-		{pos}.	The first position is 1.
+		{pos}.  The first position is 1.
 		Use |getcmdpos()| to obtain the current position.
 		Only works while editing the command line, thus you must use
 		|c_CTRL-\_e|, |c_CTRL-R_=| or |c_CTRL-R_CTRL-R| with '='.  For
@@ -7119,7 +7121,7 @@ setline({lnum}, {text})					*setline()*
 
 <		Note: The '[ and '] marks are not set.
 
-setloclist({nr}, {list} [, {action}[, {what}]])		*setloclist()*
+setloclist({nr}, {list}[, {action}[, {what}]])		*setloclist()*
 		Create or replace or add to the location list for window {nr}.
 		{nr} can be the window number or the |window-ID|.
 		When {nr} is zero the current window is used.
@@ -8173,7 +8175,7 @@ substitute({expr}, {pat}, {sub}, {flags})		*substitute()*
 
 		A "~" in {sub} is not replaced with the previous {sub}.
 		Note that some codes in {sub} have a special meaning
-		|sub-replace-special|.	For example, to replace something with
+		|sub-replace-special|.  For example, to replace something with
 		"\n" (two characters), use "\\\\n" or '\\n'.
 
 		When {pat} does not match in {expr}, {expr} is returned
@@ -8194,9 +8196,9 @@ substitute({expr}, {pat}, {sub}, {flags})		*substitute()*
 		optional argument.  Example: >
 		   :echo substitute(s, '%\(\x\x\)', SubNr, 'g')
 <		The optional argument is a list which contains the whole
-		matched string and up to nine submatches,like what
-		|submatch()| returns. Example: >
-		   :echo substitute(s, '\(\x\x\)', {m -> '0x' . m[1]}, 'g')
+		matched string and up to nine submatches, like what
+		|submatch()| returns.  Example: >
+		   :echo substitute(s, '%\(\x\x\)', {m -> '0x' . m[1]}, 'g')
 
 swapinfo({fname})					*swapinfo()*
 		The result is a dictionary, which holds information about the
@@ -8236,7 +8238,7 @@ synID({lnum}, {col}, {trans})				*synID()*
 		zero.
 
 		When {trans} is |TRUE|, transparent items are reduced to the
-		item that they reveal.	This is useful when wanting to know
+		item that they reveal.  This is useful when wanting to know
 		the effective color.  When {trans} is |FALSE|, the transparent
 		item is returned.  This is useful when wanting to know which
 		syntax item is effective (e.g. inside parens).
@@ -8252,7 +8254,7 @@ synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
 		syntax ID {synID}.  This can be used to obtain information
 		about a syntax item.
 		{mode} can be "gui", "cterm" or "term", to get the attributes
-		for that mode.	When {mode} is omitted, or an invalid value is
+		for that mode.  When {mode} is omitted, or an invalid value is
 		used, the attributes for the currently active highlighting are
 		used (GUI, cterm or term).
 		Use synIDtrans() to follow linked highlight groups.
@@ -8481,7 +8483,7 @@ taglist({expr} [, {filename}])				*taglist()*
 
 tempname()					*tempname()* *temp-file-name*
 		The result is a String, which is the name of a file that
-		doesn't exist.	It can be used for a temporary file.  Example: >
+		doesn't exist.  It can be used for a temporary file.  Example: >
 			:let tmpfile = tempname()
 			:exe "redir > " . tmpfile
 <		For Unix, the file will be in a private directory |tempfile|.
@@ -8739,7 +8741,7 @@ uniq({list} [, {func} [, {dict}]])			*uniq()* *E882*
 		each item.  For the use of {func} and {dict} see |sort()|.
 
 values({dict})						*values()*
-		Return a |List| with all the values of {dict}.	The |List| is
+		Return a |List| with all the values of {dict}.  The |List| is
 		in arbitrary order.
 
 
@@ -8775,7 +8777,7 @@ virtcol({expr})						*virtcol()*
   virtcol(".")	   with text "foo^Lbar", with cursor on the "^L", returns 5
   virtcol("$")	   with text "foo^Lbar", returns 9
   virtcol("'t")    with text "	  there", with 't at 'h', returns 6
-<		The first column is 1.	0 is returned for an error.
+<		The first column is 1.  0 is returned for an error.
 		A more advanced example that echoes the maximum length of
 		all lines: >
 		    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
@@ -8902,7 +8904,7 @@ winlayout([{tabnr}])					*winlayout()*
 <
 							*winline()*
 winline()	The result is a Number, which is the screen line of the cursor
-		in the window.	This is counting screen lines from the top of
+		in the window.  This is counting screen lines from the top of
 		the window.  The first line is one.
 		If the cursor was moved the view on the file will be updated
 		first, this may cause a scroll.
@@ -9145,9 +9147,9 @@ See |:verbose-cmd| for more information.
 			{name} can also be a |Dictionary| entry that is a
 			|Funcref|: >
 				:function dict.init(arg)
-<			"dict" must be an existing dictionary.	The entry
+<			"dict" must be an existing dictionary.  The entry
 			"init" is added if it didn't exist yet.  Otherwise [!]
-			is required to overwrite an existing function.	The
+			is required to overwrite an existing function.  The
 			result is a |Funcref| to a numbered function.  The
 			function can only be used with a |Funcref| and will be
 			deleted if there are no more references to it.
@@ -9176,7 +9178,7 @@ See |:verbose-cmd| for more information.
 			abort as soon as an error is detected.
 								*:func-dict*
 			When the [dict] argument is added, the function must
-			be invoked through an entry in a |Dictionary|.	The
+			be invoked through an entry in a |Dictionary|.  The
 			local variable "self" will then be set to the
 			dictionary.  See |Dictionary-function|.
 						*:func-closure* *E932*
@@ -9255,7 +9257,7 @@ See |:verbose-cmd| for more information.
 			returns at the outermost ":endtry".
 
 						*function-argument* *a:var*
-An argument can be defined by giving its name.	In the function this can then
+An argument can be defined by giving its name.  In the function this can then
 be used as "a:name" ("a:" for argument).
 					*a:0* *a:1* *a:000* *E740* *...*
 Up to 20 arguments can be given, separated by commas.  After the named
@@ -9326,7 +9328,7 @@ This function can then be called with: >
 		itself, the function is executed for each line in the range,
 		with the cursor in the first column of that line.  The cursor
 		is left at the last line (possibly moved by the last function
-		call).	The arguments are re-evaluated for each line.  Thus
+		call).  The arguments are re-evaluated for each line.  Thus
 		this works:
 						*function-range-example*  >
 	:function Mynumber(arg)
@@ -9371,7 +9373,7 @@ This is introduced in the user manual, section |41.14|.
 
 The autocommand is useful if you have a plugin that is a long Vim script file.
 You can define the autocommand and quickly quit the script with |:finish|.
-That makes Vim startup faster.	The autocommand should then load the same file
+That makes Vim startup faster.  The autocommand should then load the same file
 again, setting a variable to skip the |:finish| command.
 
 Use the FuncUndefined autocommand event with a pattern that matches the
@@ -9450,7 +9452,7 @@ name.  So in the above example, if the variable "adjective" was set to
 "adjective" was set to "quiet", then it would be to "my_quiet_variable".
 
 One application for this is to create a set of variables governed by an option
-value.	For example, the statement >
+value.  For example, the statement >
 	echo my_{&background}_message
 
 would output the contents of "my_dark_message" or "my_light_message" depending
@@ -9496,7 +9498,7 @@ This does NOT work: >
 			must be a valid index in that list.  For nested list
 			the index can be repeated.
 			This cannot be used to add an item to a |List|.
-			This cannot be used to set a byte in a String.	You
+			This cannot be used to set a byte in a String.  You
 			can do that like this: >
 				:let var = var[0:2] . 'X' . var[4:]
 <
@@ -9545,7 +9547,7 @@ This does NOT work: >
 			that would match everywhere.
 
 :let @{reg-name} .= {expr1}
-			Append {expr1} to register {reg-name}.	If the
+			Append {expr1} to register {reg-name}.  If the
 			register was empty it's like setting it to {expr1}.
 
 :let &{option-name} = {expr1}			*:let-option* *:let-&*
@@ -9621,7 +9623,7 @@ This does NOT work: >
 			|List| item.
 
 								*E121*
-:let {var-name}	..	List the value of variable {var-name}.	Multiple
+:let {var-name}	..	List the value of variable {var-name}.  Multiple
 			variable names may be given.  Special names recognized
 			here:				*E738*
 			  g:	global variables
@@ -9803,7 +9805,7 @@ This does NOT work: >
 				:for item in copy(mylist)
 <			When not making a copy, Vim stores a reference to the
 			next item in the list, before executing the commands
-			with the current item.	Thus the current item can be
+			with the current item.  Thus the current item can be
 			removed without effect.  Removing any later item means
 			it will not be found.  Thus the following example
 			works (an inefficient way to make a list empty): >
@@ -10022,7 +10024,7 @@ This does NOT work: >
 			message in the |message-history|.  When used in a
 			script or function the line number will be added.
 			Spaces are placed between the arguments as with the
-			:echo command.	When used inside a try conditional,
+			:echo command.  When used inside a try conditional,
 			the message is raised as an error exception instead
 			(see |try-echoerr|).
 			Example: >
@@ -10151,14 +10153,14 @@ the finally clause.  It is resumed at the ":endtry", so that commands after
 the ":endtry" are not executed and the exception might be caught elsewhere,
 see |try-nesting|.
    When during execution of a catch clause another exception is thrown, the
-remaining lines in that catch clause are not executed.	The new exception is
+remaining lines in that catch clause are not executed.  The new exception is
 not matched against the patterns in any of the ":catch" commands of the same
 try conditional and none of its catch clauses is taken.  If there is, however,
 a finally clause, it is executed, and the exception pends during its
 execution.  The commands following the ":endtry" are not executed.  The new
 exception might, however, be caught elsewhere, see |try-nesting|.
    When during execution of the finally clause (if present) an exception is
-thrown, the remaining lines in the finally clause are skipped.	If the finally
+thrown, the remaining lines in the finally clause are skipped.  If the finally
 clause has been taken because of an exception from the try block or one of the
 catch clauses, the original (pending) exception is discarded.  The commands
 following the ":endtry" are not executed, and the exception from the finally
@@ -10192,7 +10194,7 @@ catch an exception thrown in its try block or throws a new exception from one
 of its catch clauses or its finally clause, the outer try conditional is
 checked according to the rules above.  If the inner try conditional is in the
 try block of the outer try conditional, its catch clauses are checked, but
-otherwise only the finally clause is executed.	It does not matter for
+otherwise only the finally clause is executed.  It does not matter for
 nesting, whether the inner try conditional is directly contained in the outer
 one, or whether the outer one sources a script or calls a function containing
 the inner try conditional.
@@ -10255,7 +10257,7 @@ executed. >
 however displays "in Bar" and throws 4711.
 
 Any other command that takes an expression as argument might also be
-abandoned by an (uncaught) exception during the expression evaluation.	The
+abandoned by an (uncaught) exception during the expression evaluation.  The
 exception is then propagated to the caller of the command.
    Example: >
 
@@ -10439,13 +10441,13 @@ CLEANUP CODE						*try-finally*
 
 Scripts often change global settings and restore them at their end.  If the
 user however interrupts the script by pressing CTRL-C, the settings remain in
-an inconsistent state.	The same may happen to you in the development phase of
+an inconsistent state.  The same may happen to you in the development phase of
 a script when an error occurs or you explicitly throw an exception without
 catching it.  You can solve these problems by using a try conditional with
 a finally clause for restoring the settings.  Its execution is guaranteed on
 normal control flow, on error, on an explicit ":throw", and on interrupt.
 (Note that errors and interrupts from inside the try conditional are converted
-to exceptions.	When not caught, they terminate the script after the finally
+to exceptions.  When not caught, they terminate the script after the finally
 clause has been executed.)
 Example: >
 
@@ -10503,7 +10505,7 @@ This displays "first", "cleanup", "second", "cleanup", and "end". >
 	:echo Foo() "returned by Foo"
 
 This displays "cleanup" and "4711 returned by Foo".  You don't need to add an
-extra ":return" in the finally clause.	(Above all, this would override the
+extra ":return" in the finally clause.  (Above all, this would override the
 return value.)
 
 							*except-from-finally*
@@ -10547,7 +10549,7 @@ or >
 	Vim:{errmsg}
 
 {cmdname} is the name of the command that failed; the second form is used when
-the command name is not known.	{errmsg} is the error message usually produced
+the command name is not known.  {errmsg} is the error message usually produced
 when the error occurs outside try conditionals.  It always begins with
 a capital "E", followed by a two or three-digit error number, a colon, and
 a space.
@@ -10652,7 +10654,7 @@ This works also when a try conditional is active.
 CATCHING INTERRUPTS					*catch-interrupt*
 
 When there are active try conditionals, an interrupt (CTRL-C) is converted to
-the exception "Vim:Interrupt".	You can catch it like every exception.	The
+the exception "Vim:Interrupt".  You can catch it like every exception.  The
 script is not terminated, then.
    Example: >
 
@@ -10686,7 +10688,7 @@ script is not terminated, then.
 	:endwhile
 
 You can interrupt a task here by pressing CTRL-C; the script then asks for
-a new command.	If you press CTRL-C at the prompt, the script is terminated.
+a new command.  If you press CTRL-C at the prompt, the script is terminated.
 
 For testing what happens when CTRL-C would be pressed on a specific line in
 your script, use the debug mode and execute the |>quit| or |>interrupt|
@@ -10843,7 +10845,7 @@ For some commands, the normal action can be replaced by a sequence of
 autocommands.  Exceptions from that sequence will be catchable by the caller
 of the command.
    Example:  For the ":write" command, the caller cannot know whether the file
-had actually been written when the exception occurred.	You need to tell it in
+had actually been written when the exception occurred.  You need to tell it in
 some way. >
 
 	:if !exists("cnt")
@@ -10991,8 +10993,8 @@ or ":endif".  On the other hand, errors should be catchable as exceptions
 
 This problem has been solved by converting errors to exceptions and using
 immediate abortion (if not suppressed by ":silent!") only when a try
-conditional is active.	This is no restriction since an (error) exception can
-be caught only from an active try conditional.	If you want an immediate
+conditional is active.  This is no restriction since an (error) exception can
+be caught only from an active try conditional.  If you want an immediate
 termination without catching the error, just use a try conditional without
 catch clause.  (You can cause cleanup code being executed before termination
 by specifying a finally clause.)
@@ -11007,8 +11009,8 @@ conditional of a new script, you might change the control flow of the existing
 script on error.  You get the immediate abortion on error and can catch the
 error in the new script.  If however the sourced script suppresses error
 messages by using the ":silent!" command (checking for errors by testing
-|v:errmsg| if appropriate), its execution path is not changed.	The error is
-not converted to an exception.	(See |:silent|.)  So the only remaining cause
+|v:errmsg| if appropriate), its execution path is not changed.  The error is
+not converted to an exception.  (See |:silent|.)  So the only remaining cause
 where this happens is for scripts that don't care about errors and produce
 error messages.  You probably won't want to use such code from your new
 scripts.


### PR DESCRIPTION
Problem:    Cannot highlight the "~" lines at the end of a window differently.
Solution:   Add the EndOfBuffer highlighting. (Marco Hinz, James McCoy)
https://github.com/vim/vim/commit/58b853460add42098ab08017df9e030fb14fd34b

Includes minor doc parts from 7.4.1304 for runtime/doc/eval.txt.