### PR TITLE
context: shada_encode_regs(): init WriteMergerState

### DIFF
--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -60,9 +60,9 @@ Enable the sanitizer(s) via these environment variables:
 
     # Change to detect_leaks=1 to detect memory leaks (slower).
     export ASAN_OPTIONS="detect_leaks=0:log_path=$HOME/logs/asan"
-    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-5.0/bin/llvm-symbolizer
+    export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 
-    export MSAN_SYMBOLIZER_PATH=/usr/lib/llvm-5.0/bin/llvm-symbolizer
+    export MSAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
     export TSAN_OPTIONS="external_symbolizer_path=/usr/lib/llvm-5.0/bin/llvm-symbolizer log_path=${HOME}/logs/tsan"
 
 Logs will be written to `${HOME}/logs/*san.PID`.


### PR DESCRIPTION
got this running vim_spec.lua in a loop with ASAN enabled:

```
../src/nvim/shada.c:1773:13: runtime error: load of value 224, which is not a valid value for type 'bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/nvim/shada.c:1773:13 in
```

- Maybe `cur_entry{.data.reg.is_unnamed}` is not fully initialized in `shada_read()`? Maybe the init logic in `open_shada_sbuf_for_reading` needs to be revisited. Or `sd_sbuf_reader_skip_read` ...
- ~~could be a bug from #4700~~


Adding an explicit check just before the ASAN failed line, allows inspecting with gdb:

```c
 │1772        case kSDItemRegister: {                                                                                                      │
 │1773          if (*((uint8_t *)(void *)&entry.data.reg.is_unnamed) != 1                                                                      │
 │1774              && *((uint8_t *)(void *)&entry.data.reg.is_unnamed) != 0) {                                                                │
>│1775            abort();                                                                                                                 │
 |1776          }                                                                                                                          
```


```
(gdb) p entry.data.reg
+p entry.data.reg
$5 = {name = 49 '1', type = kMTLineWise, contents = 0x60200000c250, is_unnamed = true, contents_size = 1, width = 0, additional_data = 0x0}
(gdb) p *((uint8_t *)(&entry.data.reg.is_unnamed))
+p *((uint8_t *)(&entry.data.reg.is_unnamed))
$1 = 32 ' '
```

seems that garbage is being written (overrun?) to `is_unnamed` , or else it wasn't set somehow.