### PR TITLE
pvs/V547: expression is always true/false

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -16064,9 +16064,6 @@ static void f_sign_jump(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     sign_group = NULL;  // global sign group
   } else {
     sign_group = xstrdup(sign_group_chk);
-    if (sign_group == NULL) {
-      return;
-    }
   }
 
   // Buffer to place the sign
@@ -16115,9 +16112,6 @@ static void f_sign_place(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     group = NULL;  // global sign group
   } else {
     group = vim_strsave((const char_u *)group_chk);
-    if (group == NULL) {
-      return;
-    }
   }
 
   // Sign name
@@ -16210,9 +16204,6 @@ static void f_sign_unplace(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     group = NULL;  // global sign group
   } else {
     group = vim_strsave((const char_u *)group_chk);
-    if (group == NULL) {
-      return;
-    }
   }
 
   if (argvars[1].v_type != VAR_UNKNOWN) {

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1793,17 +1793,14 @@ void ex_args(exarg_T *eap)
     // ":args": list arguments.
     if (ARGCOUNT > 0) {
       char_u **items = xmalloc(sizeof(char_u *) * (size_t)ARGCOUNT);
-
-      if (items != NULL) {
-        // Overwrite the command, for a short list there is no scrolling
-        // required and no wait_return().
-        gotocmdline(true);
-        for (int i = 0; i < ARGCOUNT; i++) {
-          items[i] = alist_name(&ARGLIST[i]);
-        }
-        list_in_columns(items, ARGCOUNT, curwin->w_arg_idx);
-        xfree(items);
+      // Overwrite the command, for a short list there is no scrolling
+      // required and no wait_return().
+      gotocmdline(true);
+      for (int i = 0; i < ARGCOUNT; i++) {
+        items[i] = alist_name(&ARGLIST[i]);
       }
+      list_in_columns(items, ARGCOUNT, curwin->w_arg_idx);
+      xfree(items);
     }
   } else if (eap->cmdidx == CMD_arglocal) {
     garray_T        *gap = &curwin->w_alist->al_ga;

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -253,11 +253,7 @@ char_u * sign_typenr2name(int typenr)
 /// Return information about a sign in a Dict
 dict_T * sign_get_info(signlist_T *sign)
 {
-  dict_T  *d;
-
-  if ((d = tv_dict_alloc()) == NULL) {
-    return NULL;
-  }
+  dict_T  *d = tv_dict_alloc();
   tv_dict_add_nr(d,  S_LEN("id"), sign->id);
   tv_dict_add_str(d, S_LEN("group"), ((sign->group == NULL)
                                       ? (char *)""


### PR DESCRIPTION
Fixes PVS issue [V547](https://www.viva64.com/en/w/v547/)

Explanation: 

Functions marked with `FUNC_ATTR_NONNULL_RET` do not return `NULL`
Redundant checks are removed