### PR TITLE
pvs/V512: memcpy call will lead to overflow/underflow

### DIFF
--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -359,7 +359,7 @@ static void compose_line(Integer row, Integer startcol, Integer endcol,
                                                  attrbuf[i+1], &thru);
         }
         if (thru) {
-          memcpy(linebuf[i], bg_line[i], (size_t)width * sizeof(linebuf[i]));
+          memcpy(linebuf + i, bg_line + i, (size_t)width * sizeof(linebuf[i]));
         }
       }
     }


### PR DESCRIPTION
Fixes PVS issue [V512](https://www.viva64.com/en/w/v512/)
problem:  @bfredl : pvs thinks the type of the pointed at item is too small.

solution: refactored address calculation.