### PR TITLE
vim-patch:8.1.{1005,1041,1049,1052,1053,1086,1394}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5171,18 +5171,21 @@ chk_modeline(
 
 // Return true if "buf" is a help buffer.
 bool bt_help(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && buf->b_help;
 }
 
 // Return true if "buf" is the quickfix buffer.
 bool bt_quickfix(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && buf->b_p_bt[0] == 'q';
 }
 
 // Return true if "buf" is a terminal buffer.
 bool bt_terminal(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && buf->b_p_bt[0] == 't';
 }
@@ -5190,6 +5193,7 @@ bool bt_terminal(const buf_T *const buf)
 // Return true if "buf" is a "nofile", "acwrite" or "terminal" buffer.
 // This means the buffer name is not a file name.
 bool bt_nofile(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
                          || buf->b_p_bt[0] == 'a' || buf->terminal);
@@ -5197,11 +5201,13 @@ bool bt_nofile(const buf_T *const buf)
 
 // Return true if "buf" is a "nowrite", "nofile" or "terminal" buffer.
 bool bt_dontwrite(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && (buf->b_p_bt[0] == 'n' || buf->terminal);
 }
 
 bool bt_dontwrite_msg(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (bt_dontwrite(buf)) {
     EMSG(_("E382: Cannot write, 'buftype' option is set"));

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6761,8 +6761,9 @@ void ex_splitview(exarg_T *eap)
     if (*eap->arg != NUL
         ) {
       RESET_BINDING(curwin);
-    } else
-      do_check_scrollbind(FALSE);
+    } else {
+      do_check_scrollbind(false);
+    }
     do_exedit(eap, old_curwin);
   }
 

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -127,7 +127,11 @@
 # define MB_CHAR2LEN(c)     mb_char2len(c)
 # define PTR2CHAR(p)        utf_ptr2char(p)
 
-# define RESET_BINDING(wp)  (wp)->w_p_scb = FALSE; (wp)->w_p_crb = FALSE
+# define RESET_BINDING(wp) \
+  do { \
+    (wp)->w_p_scb = false; \
+    (wp)->w_p_crb = false; \
+  } while (0)
 
 /// Calculate the length of a C array
 ///

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1245,12 +1245,12 @@ static void botline_forw(lineoff_T *lp)
   } else {
     ++lp->lnum;
     lp->fill = 0;
-    if (lp->lnum > curbuf->b_ml.ml_line_count)
+    if (lp->lnum > curbuf->b_ml.ml_line_count) {
       lp->height = MAXCOL;
-    else if (hasFolding(lp->lnum, NULL, &lp->lnum))
-      /* Add a closed fold */
+    } else if (hasFolding(lp->lnum, NULL, &lp->lnum)) {
+      // Add a closed fold
       lp->height = 1;
-    else {
+    } else {
       lp->height = plines_nofill(lp->lnum);
     }
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7465,8 +7465,12 @@ static void nv_esc(cmdarg_T *cap)
         && cmdwin_type == 0
         && !VIsual_active
         && no_reason) {
-      MSG(_("Type  :qa!  and press <Enter> to abandon all changes"
-            " and exit Nvim"));
+      if (anyBufIsChanged()) {
+        MSG(_("Type  :qa!  and press <Enter> to abandon all changes"
+              " and exit Nvim"));
+      } else {
+        MSG(_("Type  :qa  and press <Enter> to exit Nvim"));
+      }
     }
 
     /* Don't reset "restart_edit" when 'insertmode' is set, it won't be

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2519,9 +2519,9 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
         endcol = (colnr_T)STRLEN(p);
       if (startcol > endcol
           || is_oneChar
-          )
+          ) {
         bd.textlen = 0;
-      else {
+      } else {
         bd.textlen = endcol - startcol + oap->inclusive;
       }
       bd.textstart = p + startcol;

--- a/src/nvim/testdir/test_arabic.vim
+++ b/src/nvim/testdir/test_arabic.vim
@@ -524,54 +524,6 @@ func Test_shape_final()
   bwipe!
 endfunc
 
-func Test_shape_final_to_medial()
-  new
-  set arabicshape
-
-  " Shaping arabic {testchar} arabic   Tests chg_c_f2m().
-  " This does not test much...
-  " pair[0] = testchar,  pair[1] = current-result
-  for pair in [[s:a_f_YEH_HAMZA, s:a_f_BEH],
-	\[s:a_f_WAW_HAMZA, s:a_s_BEH],
-	\[s:a_f_ALEF, s:a_s_BEH],
-	\[s:a_f_TEH_MARBUTA, s:a_s_BEH],
-	\[s:a_f_DAL, s:a_s_BEH],
-	\[s:a_f_THAL, s:a_s_BEH],
-	\[s:a_f_REH, s:a_s_BEH],
-	\[s:a_f_ZAIN, s:a_s_BEH],
-	\[s:a_f_WAW, s:a_s_BEH],
-	\[s:a_f_ALEF_MAKSURA, s:a_s_BEH],
-	\[s:a_f_BEH, s:a_f_BEH],
-	\[s:a_f_TEH, s:a_f_BEH],
-	\[s:a_f_THEH, s:a_f_BEH],
-	\[s:a_f_JEEM, s:a_f_BEH],
-	\[s:a_f_HAH, s:a_f_BEH],
-	\[s:a_f_KHAH, s:a_f_BEH],
-	\[s:a_f_SEEN, s:a_f_BEH],
-	\[s:a_f_SHEEN, s:a_f_BEH],
-	\[s:a_f_SAD, s:a_f_BEH],
-	\[s:a_f_DAD, s:a_f_BEH],
-	\[s:a_f_TAH, s:a_f_BEH],
-	\[s:a_f_ZAH, s:a_f_BEH],
-	\[s:a_f_AIN, s:a_f_BEH],
-	\[s:a_f_GHAIN, s:a_f_BEH],
-	\[s:a_f_FEH, s:a_f_BEH],
-	\[s:a_f_QAF, s:a_f_BEH],
-	\[s:a_f_KAF, s:a_f_BEH],
-	\[s:a_f_LAM, s:a_f_BEH],
-	\[s:a_f_MEEM, s:a_f_BEH],
-	\[s:a_f_NOON, s:a_f_BEH],
-	\[s:a_f_HEH, s:a_f_BEH],
-	\[s:a_f_YEH, s:a_f_BEH],
-	\ ]
-    call setline(1, ' ' . s:a_BEH . pair[0])
-    call assert_equal([' ' . pair[1] . pair[0]], ScreenLines(1, 3))
-  endfor
-
-  set arabicshape&
-  bwipe!
-endfunc
-
 func Test_shape_combination_final()
   new
   set arabicshape

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2552,6 +2552,21 @@ func Test_delete_until_paragraph()
   bwipe!
 endfunc
 
+func Test_message_when_using_ctrl_c()
+  " Make sure no buffers are changed.
+  %bwipe!
+
+  exe "normal \<C-C>"
+  call assert_match("Type  :qa  and press <Enter> to exit Nvim", Screenline(&lines))
+
+  new
+  cal setline(1, 'hi!')
+  exe "normal \<C-C>"
+  call assert_match("Type  :qa!  and press <Enter> to abandon all changes and exit Nvim", Screenline(&lines))
+
+  bwipe!
+endfunc
+
 " Test for '[m', ']m', '[M' and ']M'
 " Jumping to beginning and end of methods in Java-like languages
 func Test_java_motion()

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -79,6 +79,6 @@ func Test_recording_esc_sequence()
   call assert_equal(['Quirk', 'Test', 'Quirk', 'Test'], getline(1, 4))
   bwipe!
   if exists('save_F2')
-    let t_F2 = save_F2
+    let &t_F2 = save_F2
   endif
 endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -68,12 +68,17 @@ endfunc
 " characters as an escape sequence.
 func Test_recording_esc_sequence()
   new
-  let save_F2 = &t_F2
+  try
+    let save_F2 = &t_F2
+  catch
+  endtry
   let t_F2 = "\<Esc>OQ"
   call feedkeys("qqiTest\<Esc>", "xt")
   call feedkeys("OQuirk\<Esc>q", "xt")
   call feedkeys("Go\<Esc>@q", "xt")
   call assert_equal(['Quirk', 'Test', 'Quirk', 'Test'], getline(1, 4))
   bwipe!
-  let t_F2 = save_F2
+  if exists('save_F2')
+    let t_F2 = save_F2
+  endif
 endfunc

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2961,8 +2961,21 @@ static char_u *u_save_line(linenr_T lnum)
 ///
 /// @return true if the buffer has changed
 bool bufIsChanged(buf_T *buf)
+  FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return !bt_dontwrite(buf) && (buf->b_changed || file_ff_differs(buf, true));
+}
+
+// Return true if any buffer has changes.  Also buffers that are not written.
+bool anyBufIsChanged(void)
+  FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  FOR_ALL_BUFFERS(buf) {
+    if (bufIsChanged(buf)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /// Check if the 'modified' flag is set, or 'ff' has changed (only need to

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -275,7 +275,7 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        Type  :qa!  and press <E...all changes and exit Nvim |
+        Type  :qa  and press <Enter> to exit Nvim            |
       ]])
     end)
   end)
@@ -481,7 +481,7 @@ describe('systemlist()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-        Type  :qa!  and press <E...all changes and exit Nvim |
+        Type  :qa  and press <Enter> to exit Nvim            |
       ]])
     end)
   end)

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -494,7 +494,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      Type  :qa!  and pr...nges and exit Nvim |
+      Type  :qa  and pre...nter> to exit Nvim |
     ]])
   end)
   it('works fine with NUL, NL, CR', function()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -631,7 +631,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|
       {1:~                        }|
     ]], messages={{
-      content = {{ "Type  :qa!  and press <Enter> to abandon all changes and exit Nvim" }},
+      content = {{ "Type  :qa  and press <Enter> to exit Nvim" }},
       kind = ""}
     }}
 
@@ -678,7 +678,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|
     ]], messages={
       {kind="echomsg", content={{"howdy"}}},
-      {kind="", content={{"Type  :qa!  and press <Enter> to abandon all changes and exit Nvim"}}},
+      {kind="", content={{"Type  :qa  and press <Enter> to exit Nvim"}}},
       {kind="echoerr", content={{"bork", 2}}},
       {kind="emsg", content={{"E117: Unknown function: nosuchfunction", 2}}}
     }}


### PR DESCRIPTION
8.1.1041 deletes a test, disabled in 8.1.1038.

~~`test/functional/ui/messages_spec.lua` fails but I don't know how to fix it.~~ Fixed.