### PR TITLE
[RDY] clang/"null pointer dereference": ex_cmds.c

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5230,10 +5230,8 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
     return;
   }
 
-  /*
-   * If using the "++t" argument or generating tags for "$VIMRUNTIME/doc"
-   * add the "help-tags" tag.
-   */
+  // If using the "++t" argument or generating tags for "$VIMRUNTIME/doc"
+  // add the "help-tags" tag.
   ga_init(&ga, (int)sizeof(char_u *), 100);
   if (add_help_tags
       || path_full_compare((char_u *)"$VIMRUNTIME/doc",
@@ -5243,9 +5241,7 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
     GA_APPEND(char_u *, &ga, s);
   }
 
-  /*
-   * Go over all the files and extract the tags.
-   */
+  // Go over all the files and extract the tags.
   for (int fi = 0; fi < filecount && !got_int; fi++) {
     FILE *const fd = os_fopen((char *)files[fi], "r");
     if (fd == NULL) {
@@ -5285,21 +5281,19 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
         }
         firstline = false;
       }
-      p1 = vim_strchr(IObuff, '*');             /* find first '*' */
+      p1 = vim_strchr(IObuff, '*');                        // find first '*'
       while (p1 != NULL) {
         p2 = (char_u *)strchr((const char *)p1 + 1, '*');  // Find second '*'.
-        if (p2 != NULL && p2 > p1 + 1) {  // Skip "*" and "**".
+        if (p2 != NULL && p2 > p1 + 1) {                   // Skip "*" and "**".
           for (s = p1 + 1; s < p2; s++) {
             if (*s == ' ' || *s == '\t' || *s == '|') {
               break;
             }
           }
 
-          /*
-           * Only accept a *tag* when it consists of valid
-           * characters, there is white space before it and is
-           * followed by a white character or end-of-line.
-           */
+          // Only accept a *tag* when it consists of valid
+          // characters, there is white space before it and is
+          // followed by a white character or end-of-line.
           if (s == p2
               && (p1 == IObuff || p1[-1] == ' ' || p1[-1] == '\t')
               && (vim_strchr((char_u *)" \t\n\r", s[1]) != NULL
@@ -5310,7 +5304,7 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
             GA_APPEND(char_u *, &ga, s);
             sprintf((char *)s, "%s\t%s", p1, fname);
 
-            /* find next '*' */
+            // find next '*'
             p2 = vim_strchr(p2 + 1, '*');
           }
         }
@@ -5325,15 +5319,11 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
   FreeWild(filecount, files);
 
   if (!got_int && ga.ga_data != NULL) {
-    /*
-     * Sort the tags.
-     */
+    // Sort the tags.
     sort_strings((char_u **)ga.ga_data, ga.ga_len);
 
-    /*
-     * Check for duplicates.
-     */
-    for (int i = 1; i < ga.ga_len; ++i) {
+    // Check for duplicates.
+    for (int i = 1; i < ga.ga_len; i++) {
       p1 = ((char_u **)ga.ga_data)[i - 1];
       p2 = ((char_u **)ga.ga_data)[i];
       while (*p1 == *p2) {
@@ -5355,31 +5345,31 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
       fprintf(fd_tags, "!_TAG_FILE_ENCODING\tutf-8\t//\n");
     }
 
-    /*
-     * Write the tags into the file.
-     */
-    for (int i = 0; i < ga.ga_len; ++i) {
+    // Write the tags into the file.
+    for (int i = 0; i < ga.ga_len; i++) {
       s = ((char_u **)ga.ga_data)[i];
-      if (STRNCMP(s, "help-tags\t", 10) == 0)
-        /* help-tags entry was added in formatted form */
+      if (STRNCMP(s, "help-tags\t", 10) == 0) {
+        // help-tags entry was added in formatted form
         fputs((char *)s, fd_tags);
-      else {
-        fprintf(fd_tags, "%s\t/*", s);
-        for (p1 = s; *p1 != '\t'; ++p1) {
-          /* insert backslash before '\\' and '/' */
-          if (*p1 == '\\' || *p1 == '/')
+      } else {
+        fprintf(fd_tags, "%s\t/" "*", s);
+        for (p1 = s; *p1 != '\t'; p1++) {
+          // insert backslash before '\\' and '/'
+          if (*p1 == '\\' || *p1 == '/') {
             putc('\\', fd_tags);
+          }
           putc(*p1, fd_tags);
         }
         fprintf(fd_tags, "*\n");
       }
     }
   }
-  if (mix)
-    got_int = FALSE;        /* continue with other languages */
+  if (mix) {
+    got_int = false;        // continue with other languages
+  }
 
   GA_DEEP_CLEAR_PTR(&ga);
-  fclose(fd_tags);          /* there is no check for an error... */
+  fclose(fd_tags);          // there is no check for an error...
 }
 
 /// Generate tags in one help directory, taking care of translations.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5324,13 +5324,11 @@ static void helptags_one(char_u *const dir, const char_u *const ext,
 
   FreeWild(filecount, files);
 
-  if (!got_int) {
+  if (!got_int && ga.ga_data != NULL) {
     /*
      * Sort the tags.
      */
-    if (ga.ga_data != NULL) {
-      sort_strings((char_u **)ga.ga_data, ga.ga_len);
-    }
+    sort_strings((char_u **)ga.ga_data, ga.ga_len);
 
     /*
      * Check for duplicates.


### PR DESCRIPTION
[clang report](https://neovim.io/doc/reports/clang/report-cbc443.html#EndPath)

**Problem:**
Based on the structure of the code clang suggests `ga.ga_data` could be `NULL` while `ga.ga_len > 0`, which will lead to null pointer deref.  

**Suggested solution:**
Slightly change the condition so that the code that clang complains on (true branch) is never executed when `ga_data == NULL`