### PR TITLE
tests: runnvim.vim: do not call jobstop()

### DIFF
--- a/src/nvim/testdir/runnvim.vim
+++ b/src/nvim/testdir/runnvim.vim
@@ -20,7 +20,7 @@ function Main()
   let results = jobwait([job], 5 * 60 * 1000)
   " TODO(ZyX-I): Get colors
   let screen = getline(1, '$')
-  bwipeout!
+  bwipeout!  " kills the job always.
   let stringified_events = map(s:logger.d_events,
         \'v:val[0] . ": " . ' .
         \'join(map(v:val[1], '.
@@ -43,9 +43,6 @@ function Main()
         \])
   write
   if results[0] != 0
-    if results[0] != -1
-      call jobstop(job)
-    endif
     cquit
   else
     qall


### PR DESCRIPTION
It should be done for timeouts only (-1, not != -1), but the job is
stopped via `:bwipeout!` already also in that case.