### PR TITLE
vim-patch:8.1.0572: stopping a job does not work properly on OpenBSD

### DIFF
--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -86,24 +86,16 @@ bool os_proc_tree_kill(int pid, int sig)
 }
 #else
 /// Kills process group where `pid` is the process group leader.
+/// TODO(vim): have an option to only kill the process, not the group?
 bool os_proc_tree_kill(int pid, int sig)
 {
   assert(sig == SIGTERM || sig == SIGKILL);
-  int pgid = getpgid(pid);
-  if (pgid > 0) {  // Ignore error. Never kill self (pid=0).
-    if (pgid == pid) {
-      ILOG("sending %s to process group: -%d",
-           sig == SIGTERM ? "SIGTERM" : "SIGKILL", pgid);
-      int rv = uv_kill(-pgid, sig);
-      return rv == 0;
-    } else {
-      // Should never happen, because process_spawn() did setsid() in the child.
-      ELOG("pgid %d != pid %d", pgid, pid);
-    }
-  } else {
-    ELOG("getpgid(%d) returned %d", pid, pgid);
+  if (pid == 0) {
+    // Never kill self (pid=0).
+    return false;
   }
-  return false;
+  ILOG("sending %s to PID %d", sig == SIGTERM ? "SIGTERM" : "SIGKILL", -pid);
+  return uv_kill(-pid, sig) == 0;
 }
 #endif
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -797,7 +797,7 @@ describe('jobs', function()
       eq(ppid, info.ppid)
     end
     -- Kill the root of the tree.
-    funcs.jobstop(j)
+    eq(1, funcs.jobstop(j))
     -- Assert that the children were killed.
     retry(nil, nil, function()
       for _, child_pid in ipairs(children) do


### PR DESCRIPTION
Problem:    Stopping a job does not work properly on OpenBSD.
Solution:   Do not use getpgid() to check the process group of the job
            processs ID, always pass the negative process ID to kill().
            (George Koehler, closes vim/vim#3656)
https://github.com/vim/vim/commit/76ab4fd61901090e6af3451ca6c5ca0fc370571f

Ref: https://github.com/neovim/neovim/issues/9704
Ref: https://github.com/neovim/neovim/issues/10182#issuecomment-514450069