### PR TITLE
Windows: expand nested environment variables

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -305,13 +305,10 @@ void init_homedir(void)
   // variable, esp. "%USERPROFILE%".  Happens when $USERPROFILE isn't set
   // when $HOME is being set.
   if (var != NULL && *var == '%') {
-    char *p;
-    const char *exp;
-
-    p = strchr(var + 1, '%');
+    const char *p = strchr(var + 1, '%');
     if (p != NULL) {
       vim_snprintf(os_buf, (size_t)(p - var), "%s", var + 1);
-      exp = os_getenv(os_buf);
+      const char *exp = os_getenv(os_buf);
       if (exp != NULL && *exp != NUL
           && STRLEN(exp) + STRLEN(p) < MAXPATHL) {
         vim_snprintf(os_buf, MAXPATHL, "%s%s", exp, p + 1);
@@ -320,14 +317,11 @@ void init_homedir(void)
     }
   }
 
-  if (var != NULL && *var == NUL) {
-    // empty is same as not set
-    var = NULL;
-  }
-
   // Default home dir is C:/
   // Best assumption we can make in such a situation.
-  if (var == NULL) {
+  if (var == NULL
+      // Empty means "undefined"
+      || *var == NUL) {
     var = "C:/";
   }
 #endif

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -300,6 +300,36 @@ void init_homedir(void)
   if (var == NULL) {
     var = os_getenv("USERPROFILE");
   }
+
+  // Weird but true: $HOME may contain an indirect reference to another
+  // variable, esp. "%USERPROFILE%".  Happens when $USERPROFILE isn't set
+  // when $HOME is being set.
+  if (var != NULL && *var == '%') {
+    char *p;
+    const char *exp;
+
+    p = strchr(var + 1, '%');
+    if (p != NULL) {
+      vim_snprintf(os_buf, (size_t)(p - var), "%s", var + 1);
+      exp = os_getenv(os_buf);
+      if (exp != NULL && *exp != NUL
+          && STRLEN(exp) + STRLEN(p) < MAXPATHL) {
+        vim_snprintf(os_buf, MAXPATHL, "%s%s", exp, p + 1);
+        var = os_buf;
+      }
+    }
+  }
+
+  if (var != NULL && *var == NUL) {
+    // empty is same as not set
+    var = NULL;
+  }
+
+  // Default home dir is C:/
+  // Best assumption we can make in such a situation.
+  if (var == NULL) {
+    var = "C:/";
+  }
 #endif
 
   if (var != NULL) {
@@ -701,16 +731,16 @@ char *vim_getenv(const char *name)
   // init_path() should have been called before now.
   assert(get_vim_var_str(VV_PROGPATH)[0] != NUL);
 
-  const char *kos_env_path = os_getenv(name);
-  if (kos_env_path != NULL) {
-    return xstrdup(kos_env_path);
-  }
-
 #ifdef WIN32
   if (strcmp(name, "HOME") == 0) {
     return xstrdup(homedir);
   }
 #endif
+
+  const char *kos_env_path = os_getenv(name);
+  if (kos_env_path != NULL) {
+    return xstrdup(kos_env_path);
+  }
 
   bool vimruntime = (strcmp(name, "VIMRUNTIME") == 0);
   if (!vimruntime && strcmp(name, "VIM") != 0) {

--- a/src/nvim/testdir/test_windows_home.vim
+++ b/src/nvim/testdir/test_windows_home.vim
@@ -86,7 +86,7 @@ func Test_WindowsHome()
     let $HOME = '%USERPROFILE%\bar'
     let $HOMEDRIVE = 'unused'
     let $HOMEPATH = 'unused'
-    " call CheckHome('C:\foo\bar', '%USERPROFILE%\bar')
+    call CheckHome('C:\foo\bar', '%USERPROFILE%\bar')
 
     " Invalid $HOME is kept
     let $USERPROFILE = 'C:\foo'


### PR DESCRIPTION
Fixed an issue where  Test_WindowsHome() fails on oldtest.