### PR TITLE
ci: Travis: move coverage job to first stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,31 +100,6 @@ jobs:
         - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
         - DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
         - *common-job-env
-    - name: gcc-32bit
-      os: linux
-      # Travis creates a cache per compiler. Set a different value here to
-      # store 32-bit dependencies in a separate cache.
-      compiler: gcc
-      env:
-        - BUILD_32BIT=ON
-        # Minimum required CMake.
-        - CMAKE_URL=https://cmake.org/files/v2.8/cmake-2.8.12-Linux-i386.sh
-        - *common-job-env
-    - if: branch = master AND commit_message !~ /\[skip.lint\]/
-      name: lint
-      os: linux
-      env:
-        - CI_TARGET=lint
-        - *common-job-env
-
-    - stage: second stage
-      name: "macOS: clang"
-      os: osx
-      compiler: clang
-      osx_image: xcode10.2  # macOS 10.14
-      env:
-        - *common-job-env
-
     - name: gcc-coverage (gcc 9)
       os: linux
       compiler: gcc-9
@@ -140,6 +115,31 @@ jobs:
           packages:
             - *common-apt-packages
             - gcc-9
+    - if: branch = master AND commit_message !~ /\[skip.lint\]/
+      name: lint
+      os: linux
+      env:
+        - CI_TARGET=lint
+        - *common-job-env
+
+    - stage: second stage
+      name: "macOS: clang"
+      os: osx
+      compiler: clang
+      osx_image: xcode10.2  # macOS 10.14
+      env:
+        - *common-job-env
+
+    - name: gcc-32bit
+      os: linux
+      # Travis creates a cache per compiler. Set a different value here to
+      # store 32-bit dependencies in a separate cache.
+      compiler: gcc
+      env:
+        - BUILD_32BIT=ON
+        # Minimum required CMake.
+        - CMAKE_URL=https://cmake.org/files/v2.8/cmake-2.8.12-Linux-i386.sh
+        - *common-job-env
 
     - name: clang-tsan
       os: linux


### PR DESCRIPTION
This swaps it with "gcc-32bit".
It is better to have the "coverage" job run than "gcc-32bit" in case of
flaky build failures - especially on master, since otherwise no base
coverage is available for future PRs.