### PR TITLE
build: require unibilium>=2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,10 +409,10 @@ option(FEAT_TUI "Enable the Terminal UI" ON)
 
 if(FEAT_TUI)
   find_package(Unibilium 2.0 REQUIRED)
-  include_directories(SYSTEM ${Unibilium_INCLUDE_DIRS})
+  include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
 
-  list(APPEND CMAKE_REQUIRED_INCLUDES "${Unibilium_INCLUDE_DIRS}")
-  list(APPEND CMAKE_REQUIRED_LIBRARIES "${Unibilium_LIBRARIES}")
+  list(APPEND CMAKE_REQUIRED_INCLUDES "${UNIBILIUM_INCLUDE_DIRS}")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "${UNIBILIUM_LIBRARIES}")
   check_c_source_compiles("
   #include <unibilium.h>
 
@@ -422,8 +422,8 @@ if(FEAT_TUI)
     return unibi_num_from_var(unibi_var_from_num(0));
   }
   " UNIBI_HAS_VAR_FROM)
-  list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${Unibilium_INCLUDE_DIRS}")
-  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${Unibilium_LIBRARIES}")
+  list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${UNIBILIUM_INCLUDE_DIRS}")
+  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${UNIBILIUM_LIBRARIES}")
   if(UNIBI_HAS_VAR_FROM)
     add_definitions(-DNVIM_UNIBI_HAS_VAR_FROM)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,11 +408,11 @@ endif()
 option(FEAT_TUI "Enable the Terminal UI" ON)
 
 if(FEAT_TUI)
-  find_package(Unibilium REQUIRED)
-  include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
+  find_package(Unibilium 2.0 REQUIRED)
+  include_directories(SYSTEM ${Unibilium_INCLUDE_DIRS})
 
-  list(APPEND CMAKE_REQUIRED_INCLUDES "${UNIBILIUM_INCLUDE_DIRS}")
-  list(APPEND CMAKE_REQUIRED_LIBRARIES "${UNIBILIUM_LIBRARIES}")
+  list(APPEND CMAKE_REQUIRED_INCLUDES "${Unibilium_INCLUDE_DIRS}")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "${Unibilium_LIBRARIES}")
   check_c_source_compiles("
   #include <unibilium.h>
 
@@ -422,8 +422,8 @@ if(FEAT_TUI)
     return unibi_num_from_var(unibi_var_from_num(0));
   }
   " UNIBI_HAS_VAR_FROM)
-  list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${UNIBILIUM_INCLUDE_DIRS}")
-  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${UNIBILIUM_LIBRARIES}")
+  list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${Unibilium_INCLUDE_DIRS}")
+  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${Unibilium_LIBRARIES}")
   if(UNIBI_HAS_VAR_FROM)
     add_definitions(-DNVIM_UNIBI_HAS_VAR_FROM)
   endif()

--- a/cmake/FindUnibilium.cmake
+++ b/cmake/FindUnibilium.cmake
@@ -1,12 +1,12 @@
 # - Try to find unibilium
 # Once done this will define
-#  Unibilium_FOUND - System has unibilium
-#  Unibilium_INCLUDE_DIRS - The unibilium include directories
-#  Unibilium_LIBRARIES - The libraries needed to use unibilium
+#  UNIBILIUM_FOUND - System has unibilium
+#  UNIBILIUM_INCLUDE_DIRS - The unibilium include directories
+#  UNIBILIUM_LIBRARIES - The libraries needed to use unibilium
 
 include(LibFindMacros)
 
-libfind_pkg_detect(Unibilium unibilium
+libfind_pkg_detect(UNIBILIUM unibilium
   FIND_PATH unibilium.h
   FIND_LIBRARY unibilium)
-libfind_process(Unibilium)
+libfind_process(UNIBILIUM)

--- a/cmake/FindUnibilium.cmake
+++ b/cmake/FindUnibilium.cmake
@@ -1,37 +1,12 @@
 # - Try to find unibilium
 # Once done this will define
-#  UNIBILIUM_FOUND - System has unibilium
-#  UNIBILIUM_INCLUDE_DIRS - The unibilium include directories
-#  UNIBILIUM_LIBRARIES - The libraries needed to use unibilium
+#  Unibilium_FOUND - System has unibilium
+#  Unibilium_INCLUDE_DIRS - The unibilium include directories
+#  Unibilium_LIBRARIES - The libraries needed to use unibilium
 
-find_package(PkgConfig)
-if (PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_UNIBILIUM QUIET unibilium)
-endif()
+include(LibFindMacros)
 
-set(UNIBILIUM_DEFINITIONS ${PC_UNIBILIUM_CFLAGS_OTHER})
-
-find_path(UNIBILIUM_INCLUDE_DIR unibilium.h
-          PATHS ${PC_UNIBILIUM_INCLUDEDIR} ${PC_UNIBILIUM_INCLUDE_DIRS})
-
-# If we're asked to use static linkage, add libunibilium.a as a preferred library name.
-if(UNIBILIUM_USE_STATIC)
-  list(APPEND UNIBILIUM_NAMES
-    "${CMAKE_STATIC_LIBRARY_PREFIX}unibilium${CMAKE_STATIC_LIBRARY_SUFFIX}")
-endif()
-
-list(APPEND UNIBILIUM_NAMES unibilium)
-
-find_library(UNIBILIUM_LIBRARY NAMES ${UNIBILIUM_NAMES}
-  HINTS ${PC_UNIBILIUM_LIBDIR} ${PC_UNIBILIUM_LIBRARY_DIRS})
-
-set(UNIBILIUM_LIBRARIES ${UNIBILIUM_LIBRARY})
-set(UNIBILIUM_INCLUDE_DIRS ${UNIBILIUM_INCLUDE_DIR})
-
-include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set UNIBILIUM_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(Unibilium DEFAULT_MSG
-  UNIBILIUM_LIBRARY UNIBILIUM_INCLUDE_DIR)
-
-mark_as_advanced(UNIBILIUM_INCLUDE_DIR UNIBILIUM_LIBRARY)
+libfind_pkg_detect(Unibilium unibilium
+  FIND_PATH unibilium.h
+  FIND_LIBRARY unibilium)
+libfind_process(Unibilium)


### PR DESCRIPTION
This also ports FindUnibilium to LibFindMacros, which was planned
anyway, and makes the version check easier.

With an older Unibilium our fallback code in `terminfo_from_builtin`
will not work (because it assumes the new data structures from 2.0.0 [1]),
and nvim would crash later because of `ut` being NUL.

1: https://github.com/neovim/unibilium/commit/42f3cdd284735bd827691c3d0bfae9472b22d5d5