### PR TITLE
ci: Travis: move gcc-functionaltest-lua to 2nd stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,14 +92,6 @@ jobs:
         - CLANG_SANITIZER=ASAN_UBSAN
         - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
         - *common-job-env
-    - name: gcc-functionaltest-lua
-      os: linux
-      compiler: gcc
-      env:
-        - FUNCTIONALTEST=functionaltest-lua
-        - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
-        - DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
-        - *common-job-env
     - name: gcc-coverage (gcc 9)
       os: linux
       compiler: gcc-9
@@ -129,7 +121,14 @@ jobs:
       osx_image: xcode10.2  # macOS 10.14
       env:
         - *common-job-env
-
+    - name: gcc-functionaltest-lua
+      os: linux
+      compiler: gcc
+      env:
+        - FUNCTIONALTEST=functionaltest-lua
+        - CMAKE_FLAGS="$CMAKE_FLAGS -DPREFER_LUA=ON"
+        - DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUAJIT=OFF"
+        - *common-job-env
     - name: gcc-32bit
       os: linux
       # Travis creates a cache per compiler. Set a different value here to
@@ -140,7 +139,6 @@ jobs:
         # Minimum required CMake.
         - CMAKE_URL=https://cmake.org/files/v2.8/cmake-2.8.12-Linux-i386.sh
         - *common-job-env
-
     - name: clang-tsan
       os: linux
       compiler: clang


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/pull/10673#issuecomment-517733843