### PR TITLE
Makefile: only use pattern rules with BUILD_TYPE=Ninja  [ci skip]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,14 @@ appimage-%:
 
 lint: check-single-includes clint lualint pylint
 
+# Generic pattern rules, allowing for `make build/bin/nvim` etc.
+# Does not work with "Unix Makefiles".
+ifeq ($(BUILD_TYPE),Ninja)
 build/%:
 	$(BUILD_CMD) -C build $(patsubst build/%,%,$@)
 
 $(DEPS_BUILD_DIR)/%:
 	$(BUILD_CMD) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
+endif
 
 .PHONY: test lualint pylint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage checkprefix


### PR DESCRIPTION
While not doing any harm with "Unix Makefiles", they do not work there
as-is.  Therefore just do not use them then.

Followup to #10366 (7f6ff829a).