### PR TITLE
lua: minimal UTF-16 support needed for LSP

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -459,6 +459,24 @@ vim.stricmp({a}, {b})					*vim.stricmp()*
         are equal, {a} is greater than {b} or {a} is lesser than {b},
         respectively.
 
+vim.str_utfindex({str}[, {index}])			*vim.str_utfindex()*
+        Convert byte index to UTF-32 and UTF-16 indicies. If {index} is not
+        supplied, the length of the string is used. All indicies are zero-based.
+        Returns two values: the UTF-32 and UTF-16 indicies respectively.
+
+        Embedded NUL bytes are treated as terminating the string. Invalid
+        UTF-8 bytes, and embedded surrogates are counted as one code
+        point each. An {index} in the middle of a UTF-8 sequence is rounded
+        upwards to the end of that sequence.
+
+vim.str_byteindex({str}, {index}[, {use_utf16}])	*vim.str_byteindex()*
+        Convert UTF-32 or UTF-16 {index} to byte index. If {use_utf16} is not
+        supplied, it defaults to false (use UTF-32). Returns the byte index.
+
+        Invalid UTF-8 and NUL is treated like by |vim.str_byteindex()|. An {index}
+        in the middle of a UTF-16 sequence is rounded upwards to the end of that
+        sequence.
+
 vim.schedule({callback})				*vim.schedule()*
         Schedules {callback} to be invoked soon by the main event-loop. Useful
         to avoid |textlock| or other temporary restrictions.


### PR DESCRIPTION
As we all know and appreciate LSP protocol is assuming UTF-16 encoded texts for its character positions and ranges.

While we do not need to interact with UTF-16 text directly, we will need to manipulate positions _as if_ the buffer was UTF-16 encoded. As far as my understanding of the protocol, this reduces into three cases:

- `didChange` event. We need to supply the UTF-16 length of the changed text. Implemented in #10513 
- nvim request to server, like `hover`. We need to convert the internal byte index to a UTF-16 index. Use `vim.str_utfindex`
- server reply/event to nvim, like diagnostics. We need to convert UTF-16 positions back to byte indicies. Use `vim.str_byteindex`

While the first does zero-copy measurements on the internal memline, the later two functions operate on arbitrary (copied) strings. I expect these cases to be a lot less hot than the first one (every internal change of buffer text). Though we could still add `nvim_buf_get_utf_index` for convenience, if not only for efficiency.

Note: this is fully compatible with a later revision using UTF-32 instead. https://github.com/microsoft/language-server-protocol/issues/376. Or for use with an unrelated UTF-32 based protocol.