### PR TITLE
:doautocmd : Never show "No matching autocommands"

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1087,14 +1087,12 @@ TextChangedP			After a change was made to the text in the
 				popup menu is visible.  Otherwise the same as
 				TextChanged.
 							*User*
-User				Never executed automatically.  To be used for
-				autocommands that are only executed with
-				":doautocmd".
-				Note that when `:doautocmd User MyEvent` is
-				used while there are no matching autocommands,
-				you will get an error.  If you don't want
-				that, define a dummy autocommand yourself.
-							*UserGettingBored*
+User				Not executed automatically.  Use |:doautocmd|
+				to trigger this, typically for "custom events"
+				in a plugin.  Example: >
+				    :autocmd User MyPlugin echom 'got MyPlugin event'
+				    :doautocmd User MyPlugin
+<							*UserGettingBored*
 UserGettingBored		When the user presses the same key 42 times.
 				Just kidding! :-)
 							*VimEnter*
@@ -1389,18 +1387,17 @@ option will not cause any commands to be executed.
 			When the [group] argument is not given, Vim executes
 			the autocommands for all groups.  When the [group]
 			argument is included, Vim executes only the matching
-			autocommands for that group.  Note: if you use an
-			undefined group name, Vim gives you an error message.
+			autocommands for that group.  Undefined group is an
+			error.
 							*<nomodeline>*
 			After applying the autocommands the modelines are
 			processed, so that their settings overrule the
-			settings from autocommands, like what happens when
-			editing a file. This is skipped when the <nomodeline>
-			argument is present. You probably want to use
-			<nomodeline> for events that are not used when loading
-			a buffer, such as |User|.
-			Processing modelines is also skipped when no
-			matching autocommands were executed.
+			settings from autocommands when editing a file. This
+			is skipped if <nomodeline> is specified. You probably
+			want to use <nomodeline> for events not used when
+			loading a buffer, such as |User|.
+			Modelines are also skipped when no matching
+			autocommands were executed.
 
 						*:doautoa* *:doautoall*
 :doautoa[ll] [<nomodeline>] [group] {event} [fname]

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -310,6 +310,9 @@ other arguments if used).
 
 |input()| and |inputdialog()| support user-defined cmdline highlighting.
 
+Commands:
+  |:doautocmd| does not warn about "No matching autocommands".
+
 Highlight groups:
   |hl-ColorColumn|, |hl-CursorColumn| are lower priority than most other
   groups

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4614,7 +4614,7 @@ static void ex_doautocmd(exarg_T *eap)
   int call_do_modelines = check_nomodeline(&arg);
   bool did_aucmd;
 
-  (void)do_doautocmd(arg, true, &did_aucmd);
+  (void)do_doautocmd(arg, false, &did_aucmd);
   // Only when there is no <nomodeline>.
   if (call_do_modelines && did_aucmd) {
     do_modelines(0);

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -260,4 +260,26 @@ describe('autocmd', function()
     eq({false, 'Vim(call):E5555: API call: Invalid window id'},
        meth_pcall(command, "call nvim_set_current_win(g:winid)"))
   end)
+
+  it(':doautocmd does not warn "No matching autocommands" #10689', function()
+    local screen = Screen.new(32, 3)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+    })
+
+    feed(':doautocmd User Foo<cr>')
+    screen:expect{grid=[[
+      ^                                |
+      {1:~                               }|
+      :doautocmd User Foo             |
+    ]]}
+    feed(':autocmd! SessionLoadPost<cr>')
+    feed(':doautocmd SessionLoadPost<cr>')
+    screen:expect{grid=[[
+      ^                                |
+      {1:~                               }|
+      :doautocmd SessionLoadPost      |
+    ]]}
+  end)
 end)


### PR DESCRIPTION
The message is useless, it doesn't even mention the event name.

vim_dev discussion:
https://groups.google.com/forum/#!msg/vim_dev/RTbq58TMq9w/Xr4rSoUTCgAJ

ref: https://github.com/vim/vim/issues/4300

- [x] add a test
- [ ] ~~show only at some 'verbose' level?~~ But the message is useless, so skip this.