### PR TITLE
lua: laundry list (crashes and additions)

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -400,7 +400,8 @@ is safe to execute API methods. >
     end))
 
 A subset of the API is available in direct luv callbacks ("fast" callbacks),
-most notably |nvim_get_mode()| and |nvim_input()|.
+most notably |nvim_get_mode()| and |nvim_input()|.  It is possible to
+check whether code is running in this context using |vim.in_fast_event()|.
 
 
 Example: repeating timer
@@ -461,6 +462,14 @@ vim.stricmp({a}, {b})					*vim.stricmp()*
 vim.schedule({callback})				*vim.schedule()*
         Schedules {callback} to be invoked soon by the main event-loop. Useful
         to avoid |textlock| or other temporary restrictions.
+
+vim.in_fast_event()					*vim.in_fast_event()*
+        Returns true if the code is executing as part of a "fast" event
+        handler, where most of the API is disabled. These are low-level event
+        such as luv callbacks |lua-loop-callbacks|, which can be invoked at
+        any time nvim polls for input. When this returns `false` most API
+        functions are callable, but can be subjected to other restrictions,
+        such as |textlock|.
 
 vim.type_idx						*vim.type_idx*
 	Type index for use in |lua-special-tbl|.  Specifying one of the 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -323,6 +323,42 @@ void executor_exec_lua(const String str, typval_T *const ret_tv)
   nlua_pop_typval(lstate, ret_tv);
 }
 
+static void nlua_print_event(void **argv)
+{
+  char *str = argv[0];
+  const size_t len = (size_t)(intptr_t)argv[1]-1;  // exclude final NUL
+
+  for (size_t i = 0; i < len;) {
+    const size_t start = i;
+    while (i < len) {
+      switch (str[i]) {
+        case NUL: {
+          str[i] = NL;
+          i++;
+          continue;
+        }
+        case NL: {
+          // TODO(bfredl): use proper multiline msg? Probably should implement
+          // print() in lua in terms of nvim_message(), when it is available.
+          str[i] = NUL;
+          i++;
+          break;
+        }
+        default: {
+          i++;
+          continue;
+        }
+      }
+      break;
+    }
+    msg((char_u *)str + start);
+  }
+  if (len && str[len - 1] == NUL) {  // Last was newline
+    msg((char_u *)"");
+  }
+  xfree(str);
+}
+
 /// Print as a Vim message
 ///
 /// @param  lstate  Lua interpreter state.
@@ -362,47 +398,24 @@ static int nlua_print(lua_State *const lstate)
     lua_pop(lstate, 1);
   }
 #undef PRINT_ERROR
-  lua_pop(lstate, nargs + 1);
   ga_append(&msg_ga, NUL);
-  {
-    const size_t len = (size_t)msg_ga.ga_len - 1;
-    char *const str = (char *)msg_ga.ga_data;
 
-    for (size_t i = 0; i < len;) {
-      const size_t start = i;
-      while (i < len) {
-        switch (str[i]) {
-          case NUL: {
-            str[i] = NL;
-            i++;
-            continue;
-          }
-          case NL: {
-            str[i] = NUL;
-            i++;
-            break;
-          }
-          default: {
-            i++;
-            continue;
-          }
-        }
-        break;
-      }
-      msg((char_u *)str + start);
-    }
-    if (len && str[len - 1] == NUL) {  // Last was newline
-      msg((char_u *)"");
-    }
+  if (in_fast_callback) {
+    multiqueue_put(main_loop.events, nlua_print_event,
+                   2, msg_ga.ga_data, msg_ga.ga_len);
+  } else {
+    nlua_print_event((void *[]){ msg_ga.ga_data,
+                                 (void *)(intptr_t)msg_ga.ga_len });
   }
-  ga_clear(&msg_ga);
   return 0;
+
 nlua_print_error:
-  emsgf(_("E5114: Error while converting print argument #%i: %.*s"),
-        curargidx, (int)errmsg_len, errmsg);
   ga_clear(&msg_ga);
-  lua_pop(lstate, lua_gettop(lstate));
-  return 0;
+  const char *fmt = _("E5114: Error while converting print argument #%i: %.*s");
+  size_t len = (size_t)vim_snprintf((char *)IObuff, IOSIZE, fmt, curargidx,
+                                    (int)errmsg_len, errmsg);
+  lua_pushlstring(lstate, (char *)IObuff, len);
+  return lua_error(lstate);
 }
 
 /// debug.debug: interaction with user while debugging.

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -223,6 +223,9 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   // schedule
   lua_pushcfunction(lstate, &nlua_schedule);
   lua_setfield(lstate, -2, "schedule");
+  // in_fast_event
+  lua_pushcfunction(lstate, &nlua_in_fast_event);
+  lua_setfield(lstate, -2, "in_fast_event");
 
   // vim.loop
   luv_set_loop(lstate, &main_loop.uv);
@@ -455,6 +458,12 @@ int nlua_debug(lua_State *lstate)
     tv_clear(&input);
   }
   return 0;
+}
+
+int nlua_in_fast_event(lua_State *lstate)
+{
+  lua_pushboolean(lstate, in_fast_callback > 0);
+  return 1;
 }
 
 #ifdef WIN32

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -449,11 +449,10 @@ int nlua_debug(lua_State *lstate)
     if (luaL_loadbuffer(lstate, (const char *)input.vval.v_string,
                         STRLEN(input.vval.v_string), "=(debug command)")) {
       nlua_error(lstate, _("E5115: Error while loading debug string: %.*s"));
-    }
-    tv_clear(&input);
-    if (lua_pcall(lstate, 0, 0, 0)) {
+    } else if (lua_pcall(lstate, 0, 0, 0)) {
       nlua_error(lstate, _("E5116: Error while calling debug string: %.*s"));
     }
+    tv_clear(&input);
   }
   return 0;
 }

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -207,6 +207,81 @@ describe('debug.debug', function()
       {cr:Press ENTER or type command to continue}^              |
     ]])
   end)
+
+  it("can be safely exited with 'cont'", function()
+    feed('<cr>')
+    feed(':lua debug.debug() print("x")<cr>')
+    screen:expect{grid=[[
+                                                           |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      lua_debug> ^                                          |
+    ]]}
+
+    feed("conttt<cr>") -- misspelled cont; invalid syntax
+    screen:expect{grid=[[
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      lua_debug> conttt                                    |
+      {E:E5115: Error while loading debug string: (debug comma}|
+      {E:nd):1: '=' expected near '<eof>'}                     |
+      lua_debug> ^                                          |
+    ]]}
+
+    feed("cont<cr>") -- exactly "cont", exit now
+    screen:expect{grid=[[
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      lua_debug> conttt                                    |
+      {E:E5115: Error while loading debug string: (debug comma}|
+      {E:nd):1: '=' expected near '<eof>'}                     |
+      lua_debug> cont                                      |
+      x                                                    |
+      {cr:Press ENTER or type command to continue}^              |
+    ]]}
+
+    feed('<cr>')
+    screen:expect{grid=[[
+      ^                                                     |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+                                                           |
+    ]]}
+  end)
 end)
 
 describe('package.path/package.cpath', function()


### PR DESCRIPTION
Some lua fixes and additions:

- Make `print()` formally safe with luv callbacks. it mostly works already, but I have seen crashes with it (cannot reproduce for the moment). The implementation is a bit _ad-hoc_, but I think it makes sense: `print()` is mostly for debugging or one-off messages, so "print now if possible otherwise later" should be fine. We can reimplement it in terms of a better `vim.api.nvim_message` later (which uses proper formatting, a child queue to never reorder messages, etc)

- Fix a crash with `debug.debug()`

- Add a function `vim.in_immediate_event` to detect if a function is called from an immediate luv callback. This is can be done already with some `pcall(vim.api.nvim_...)` trickery, but it is good if there is a standard efficient idiom.