### PR TITLE
vim-patch:8.1.{1465,1467}

### DIFF
--- a/src/nvim/testdir/samples/memfile_test.c
+++ b/src/nvim/testdir/samples/memfile_test.c
@@ -70,7 +70,7 @@ test_mf_hash(void)
 	assert(mf_hash_find(&ht, key) == NULL);
 
 	/* allocate and add new item */
-	item = (mf_hashitem_T *)lalloc_clear(sizeof(mf_hashtab_T), FALSE);
+	item = (mf_hashitem_T *)lalloc_clear(sizeof(*item), FALSE);
 	assert(item != NULL);
 	item->mhi_key = key;
 	mf_hash_add_item(&ht, item);

--- a/src/nvim/testdir/test_cscope.vim
+++ b/src/nvim/testdir/test_cscope.vim
@@ -123,8 +123,8 @@ func Test_cscopeWithCscopeConnections()
     if cs_version >= 15.8
       for cmd in ['cs find a item', 'cs find 9 item']
         let a = execute(cmd)
-        call assert_equal(['', '(1 of 4): <<test_mf_hash>> item = (mf_hashitem_T *)lalloc_clear(sizeof(mf_hashtab_T), FALSE);'], split(a, '\n', 1))
-        call assert_equal('	item = (mf_hashitem_T *)lalloc_clear(sizeof(mf_hashtab_T), FALSE);', getline('.'))
+        call assert_equal(['', '(1 of 4): <<test_mf_hash>> item = (mf_hashitem_T *)lalloc_clear(sizeof(*item), FALSE);'], split(a, '\n', 1))
+        call assert_equal('	item = (mf_hashitem_T *)lalloc_clear(sizeof(*item), FALSE);', getline('.'))
         cnext
         call assert_equal('	item = mf_hash_find(&ht, key);', getline('.'))
         cnext


### PR DESCRIPTION
Diverged from the patch to avoid similar `sizeof(type)` errors.