### PR TITLE
[RFC] remove DYNAMIC_ICONV

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -20,7 +20,6 @@ endif()
 check_symbol_exists(_NSGetEnviron crt_externs.h HAVE__NSGETENVIRON)
 
 # Headers
-check_include_files(iconv.h HAVE_ICONV_H)
 check_include_files(langinfo.h HAVE_LANGINFO_H)
 check_include_files(locale.h HAVE_LOCALE_H)
 check_include_files(pwd.h HAVE_PWD_H)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -22,7 +22,6 @@
 #cmakedefine HAVE_GETPWNAM
 #cmakedefine HAVE_GETPWUID
 #cmakedefine HAVE_ICONV
-#cmakedefine HAVE_ICONV_H
 #cmakedefine HAVE_LANGINFO_H
 #cmakedefine HAVE_LOCALE_H
 #cmakedefine HAVE_NL_LANGINFO_CODESET

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11259,7 +11259,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "fork",
 #endif
     "gettext",
-#if defined(HAVE_ICONV_H) && defined(USE_ICONV)
+#if defined(HAVE_ICONV)
     "iconv",
 #endif
     "insert_expand",
@@ -11372,10 +11372,6 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       n = stdout_isatty;
     } else if (STRICMP(name, "multi_byte_encoding") == 0) {
       n = has_mbyte != 0;
-#if defined(USE_ICONV) && defined(DYNAMIC_ICONV)
-    } else if (STRICMP(name, "iconv") == 0) {
-      n = iconv_enabled(false);
-#endif
     } else if (STRICMP(name, "syntax_items") == 0) {
       n = syntax_present(curwin);
 #ifdef UNIX

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -163,22 +163,22 @@ typedef struct AutoPatCmd {
  * Structure to pass arguments from buf_write() to buf_write_bytes().
  */
 struct bw_info {
-  int bw_fd;                    /* file descriptor */
-  char_u      *bw_buf;          /* buffer with data to be written */
-  int bw_len;                   /* length of data */
+  int bw_fd;                     // file descriptor
+  char_u      *bw_buf;           // buffer with data to be written
+  int bw_len;                    // length of data
 #ifdef HAS_BW_FLAGS
-  int bw_flags;                 /* FIO_ flags */
+  int bw_flags;                  // FIO_ flags
 #endif
-  char_u bw_rest[CONV_RESTLEN];        /* not converted bytes */
-  int bw_restlen;               /* nr of bytes in bw_rest[] */
-  int bw_first;                 /* first write call */
-  char_u      *bw_conv_buf;     /* buffer for writing converted chars */
-  int bw_conv_buflen;           /* size of bw_conv_buf */
-  int bw_conv_error;            /* set for conversion error */
-  linenr_T bw_conv_error_lnum;       /* first line with error or zero */
-  linenr_T bw_start_lnum;       /* line number at start of buffer */
-# ifdef USE_ICONV
-  iconv_t bw_iconv_fd;          /* descriptor for iconv() or -1 */
+  char_u bw_rest[CONV_RESTLEN];  // not converted bytes
+  int bw_restlen;                // nr of bytes in bw_rest[]
+  int bw_first;                  // first write call
+  char_u      *bw_conv_buf;      // buffer for writing converted chars
+  int bw_conv_buflen;            // size of bw_conv_buf
+  int bw_conv_error;             // set for conversion error
+  linenr_T bw_conv_error_lnum;   // first line with error or zero
+  linenr_T bw_start_lnum;        // line number at start of buffer
+# ifdef HAVE_ICONV
+  iconv_t bw_iconv_fd;           // descriptor for iconv() or -1
 # endif
 };
 
@@ -327,10 +327,10 @@ readfile(
   char_u      *fenc_next = NULL;        // next item in 'fencs' or NULL
   bool advance_fenc = false;
   long real_size = 0;
-# ifdef USE_ICONV
-  iconv_t iconv_fd = (iconv_t)-1;       /* descriptor for iconv() or -1 */
-  int did_iconv = FALSE;                /* TRUE when iconv() failed and trying
-                                           'charconvert' next */
+# ifdef HAVE_ICONV
+  iconv_t iconv_fd = (iconv_t)-1;       // descriptor for iconv() or -1
+  int did_iconv = false;                // TRUE when iconv() failed and trying
+                                        // 'charconvert' next
 # endif
   int converted = FALSE;                /* TRUE if conversion done */
   int notconverted = FALSE;             /* TRUE if conversion wanted but it
@@ -841,7 +841,7 @@ retry:
       fileformat = EOL_UNKNOWN;                 /* detect from file */
   }
 
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
   if (iconv_fd != (iconv_t)-1) {
     /* aborted conversion with iconv(), close the descriptor */
     iconv_close(iconv_fd);
@@ -908,15 +908,14 @@ retry:
 
 
 
-# ifdef USE_ICONV
-    /*
-     * Try using iconv() if we can't convert internally.
-     */
+# ifdef HAVE_ICONV
+    // Try using iconv() if we can't convert internally.
     if (fio_flags == 0
         && !did_iconv
-        )
+        ) {
       iconv_fd = (iconv_t)my_iconv_open(
           enc_utf8 ? (char_u *)"utf-8" : p_enc, fenc);
+    }
 # endif
 
     /*
@@ -925,12 +924,12 @@ retry:
      */
     if (fio_flags == 0 && !read_stdin && !read_buffer && *p_ccv != NUL
         && !read_fifo
-#  ifdef USE_ICONV
+#  ifdef HAVE_ICONV
         && iconv_fd == (iconv_t)-1
 #  endif
         ) {
-#  ifdef USE_ICONV
-      did_iconv = FALSE;
+#  ifdef HAVE_ICONV
+      did_iconv = false;
 #  endif
       /* Skip conversion when it's already done (retry for wrong
        * "fileformat"). */
@@ -950,7 +949,7 @@ retry:
       }
     } else {
       if (fio_flags == 0
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
           && iconv_fd == (iconv_t)-1
 # endif
           ) {
@@ -1023,20 +1022,23 @@ retry:
          * ucs-4 to utf-8: 4 bytes become up to 6 bytes, size must be
          * multiple of 4 */
         real_size = (int)size;
-# ifdef USE_ICONV
-        if (iconv_fd != (iconv_t)-1)
+# ifdef HAVE_ICONV
+        if (iconv_fd != (iconv_t)-1) {
           size = size / ICONV_MULT;
-        else
+        } else {
 # endif
-        if (fio_flags & FIO_LATIN1)
+        if (fio_flags & FIO_LATIN1) {
           size = size / 2;
-        else if (fio_flags & (FIO_UCS2 | FIO_UTF16))
+        } else if (fio_flags & (FIO_UCS2 | FIO_UTF16)) {
           size = (size * 2 / 3) & ~1;
-        else if (fio_flags & FIO_UCS4)
+        } else if (fio_flags & FIO_UCS4) {
           size = (size * 2 / 3) & ~3;
-        else if (fio_flags == FIO_UCSBOM)
-          size = size / ICONV_MULT;             /* worst case */
-
+        } else if (fio_flags == FIO_UCSBOM) {
+          size = size / ICONV_MULT;  // worst case
+        }
+# ifdef HAVE_ICONV
+        }
+# endif
         if (conv_restlen > 0) {
           // Insert unconverted bytes from previous line.
           memmove(ptr, conv_rest, conv_restlen);  // -V614
@@ -1112,7 +1114,7 @@ retry:
 
             /* When we did a conversion report an error. */
             if (fio_flags != 0
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
                 || iconv_fd != (iconv_t)-1
 # endif
                 ) {
@@ -1135,7 +1137,7 @@ retry:
                * leave the UTF8 checking code to do it, as it
                * works slightly differently. */
               if (bad_char_behavior != BAD_KEEP && (fio_flags != 0
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
                                                     || iconv_fd != (iconv_t)-1
 # endif
                                                     )) {
@@ -1144,8 +1146,8 @@ retry:
                   --conv_restlen;
                 }
               }
-              fio_flags = 0;                    /* don't convert this */
-# ifdef USE_ICONV
+              fio_flags = 0;  // don't convert this
+# ifdef HAVE_ICONV
               if (iconv_fd != (iconv_t)-1) {
                 iconv_close(iconv_fd);
                 iconv_fd = (iconv_t)-1;
@@ -1216,7 +1218,7 @@ retry:
       if (size <= 0)
         break;
 
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
       if (iconv_fd != (iconv_t)-1) {
         /*
          * Attempt conversion of the read bytes to 'encoding' using
@@ -1474,10 +1476,11 @@ retry:
                * file is more likely than a conversion error. */
               if (can_retry && !incomplete_tail)
                 break;
-# ifdef USE_ICONV
-              /* When we did a conversion report an error. */
-              if (iconv_fd != (iconv_t)-1 && conv_error == 0)
+# ifdef HAVE_ICONV
+              // When we did a conversion report an error.
+              if (iconv_fd != (iconv_t)-1 && conv_error == 0) {
                 conv_error = readfile_linenr(linecnt, ptr, p);
+              }
 # endif
               /* Remember the first linenr with an illegal byte */
               if (conv_error == 0 && illegal_byte == 0)
@@ -1497,15 +1500,18 @@ retry:
         if (p < ptr + size && !incomplete_tail) {
           /* Detected a UTF-8 error. */
 rewind_retry:
-          /* Retry reading with another conversion. */
-# ifdef USE_ICONV
-          if (*p_ccv != NUL && iconv_fd != (iconv_t)-1)
-            /* iconv() failed, try 'charconvert' */
-            did_iconv = TRUE;
-          else
+          // Retry reading with another conversion.
+# ifdef HAVE_ICONV
+          if (*p_ccv != NUL && iconv_fd != (iconv_t)-1) {
+            // iconv() failed, try 'charconvert'
+            did_iconv = true;
+          } else {
 # endif
           // use next item from 'fileencodings'
           advance_fenc = true;
+# ifdef HAVE_ICONV
+          }
+# endif
           file_rewind = true;
           goto retry;
         }
@@ -1710,7 +1716,7 @@ failed:
   }
   if (fenc_alloced)
     xfree(fenc);
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
   if (iconv_fd != (iconv_t)-1) {
     iconv_close(iconv_fd);
 #  ifndef __clang_analyzer__
@@ -2291,7 +2297,7 @@ buf_write(
   write_info.bw_conv_error = FALSE;
   write_info.bw_conv_error_lnum = 0;
   write_info.bw_restlen = 0;
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
   write_info.bw_iconv_fd = (iconv_t)-1;
 # endif
 
@@ -3012,7 +3018,7 @@ nobackup:
 
 
   if (converted && wb_flags == 0) {
-#  ifdef USE_ICONV
+#  ifdef HAVE_ICONV
     // Use iconv() conversion when conversion is needed and it's not done
     // internally.
     write_info.bw_iconv_fd = (iconv_t)my_iconv_open(fenc,
@@ -3042,7 +3048,7 @@ nobackup:
     }
   }
   if (converted && wb_flags == 0
-#  ifdef USE_ICONV
+#  ifdef HAVE_ICONV
       && write_info.bw_iconv_fd == (iconv_t)-1
 #  endif
       && wfname == fname
@@ -3570,7 +3576,7 @@ nofail:
     xfree(buffer);
   xfree(fenc_tofree);
   xfree(write_info.bw_conv_buf);
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
   if (write_info.bw_iconv_fd != (iconv_t)-1) {
     iconv_close(write_info.bw_iconv_fd);
     write_info.bw_iconv_fd = (iconv_t)-1;
@@ -3945,7 +3951,7 @@ static int buf_write_bytes(struct bw_info *ip)
       }
     }
 
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
     if (ip->bw_iconv_fd != (iconv_t)-1) {
       const char  *from;
       size_t fromlen;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -653,16 +653,6 @@ EXTERN int vr_lines_changed INIT(= 0);      /* #Lines changed by "gR" so far */
 /// Encoding used when 'fencs' is set to "default"
 EXTERN char_u *fenc_default INIT(= NULL);
 
-# if defined(USE_ICONV) && defined(DYNAMIC_ICONV)
-/* Pointers to functions and variables to be loaded at runtime */
-EXTERN size_t (*iconv)(iconv_t cd, const char **inbuf, size_t *inbytesleft,
-                       char **outbuf, size_t *outbytesleft);
-EXTERN iconv_t (*iconv_open)(const char *tocode, const char *fromcode);
-EXTERN int (*iconv_close)(iconv_t cd);
-EXTERN int (*iconvctl)(iconv_t cd, int request, void *argument);
-EXTERN int* (*iconv_errno)(void);
-# endif
-
 /// "State" is the main state of Vim.
 /// There are other variables that modify the state:
 ///    Visual_mode:    When State is NORMAL or INSERT.

--- a/src/nvim/iconv.h
+++ b/src/nvim/iconv.h
@@ -1,52 +1,20 @@
 #ifndef NVIM_ICONV_H
 #define NVIM_ICONV_H
 
-// iconv can be linked at compile-time as well as loaded at runtime. In the
-// latter case, some function pointers need to be initialized after loading
-// the library (see `iconv_enabled()` in mbyte.c). These function pointers
-// are stored in globals.h. Since globals.h includes iconv.h to get the
-// definition of USE_ICONV, we can't include it from iconv.h. One way to
-// solve this conundrum would be perhaps to let cmake decide the value of
-// USE_ICONV, or to put the USE_ICONV definition in config.h.in directly. As
-// it stands, globals.h needs to be included alongside iconv.h.
-
 #include "auto/config.h"
 
-// Use iconv() when it's available, either by linking to the library at
-// compile time or by loading it at runtime.
-#if (defined(HAVE_ICONV_H) && defined(HAVE_ICONV)) || defined(DYNAMIC_ICONV)
-# define USE_ICONV
-#endif
-
-// If we don't have the actual iconv header files present but USE_ICONV was
-// defined, we provide a type shim (pull in errno.h and define iconv_t).
-// This enables us to still load and use iconv dynamically at runtime.
-#ifdef USE_ICONV
+#ifdef HAVE_ICONV
 #  include <errno.h>
-#  ifdef HAVE_ICONV_H
-#    include <iconv.h>
-#  else
-typedef void *iconv_t;
-#  endif
-#endif
+#  include <iconv.h>
 
 // define some missing constants if necessary
-# ifdef USE_ICONV
 #  ifndef EILSEQ
 #   define EILSEQ 123
 #  endif
-#  ifdef DYNAMIC_ICONV
-// on win32 iconv.dll is dynamically loaded
-#   define ICONV_ERRNO (*iconv_errno())
-#   define ICONV_E2BIG  7
-#   define ICONV_EINVAL 22
-#   define ICONV_EILSEQ 42
-#  else
-#   define ICONV_ERRNO errno
-#   define ICONV_E2BIG  E2BIG
-#   define ICONV_EINVAL EINVAL
-#   define ICONV_EILSEQ EILSEQ
-#  endif
-# endif
+#  define ICONV_ERRNO errno
+#  define ICONV_E2BIG  E2BIG
+#  define ICONV_EINVAL EINVAL
+#  define ICONV_EILSEQ EILSEQ
+#endif
 
 #endif  // NVIM_ICONV_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -664,9 +664,6 @@ void getout(int exitval)
     ui_call_set_title(cstr_as_string((char *)p_titleold));
   }
 
-#if defined(USE_ICONV) && defined(DYNAMIC_ICONV)
-  iconv_end();
-#endif
   cs_end();
   if (garbage_collect_at_exit) {
     garbage_collect(false);

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -63,7 +63,7 @@ typedef enum {
 typedef struct {
   int vc_type;  ///< Zero or more ConvFlags.
   int vc_factor;  ///< Maximal expansion factor.
-# ifdef USE_ICONV
+# ifdef HAVE_ICONV
   iconv_t vc_fd;  ///< Value for CONV_ICONV.
 # endif
   bool vc_fail;  ///< What to do with invalid characters: if true, fail,

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -52,12 +52,8 @@ static char *features[] = {
 "-acl",
 #endif
 
-#if (defined(HAVE_ICONV_H) && defined(USE_ICONV)) || defined(DYNAMIC_ICONV)
-# ifdef DYNAMIC_ICONV
-"+iconv/dyn",
-# else
+#if defined(HAVE_ICONV)
 "+iconv",
-# endif
 #else
 "-iconv",
 #endif


### PR DESCRIPTION
`DYNAIMC_ICONV` is no longer defined by https://github.com/neovim/neovim/commit/d87e5d70163addaa4ab140425c8bf875ea3b747f. Therefore, I think that the code related to `DYNAMIC_ICONV` can be removed.

related: https://github.com/neovim/neovim/issues/3457