### PR TITLE
build: move pylint to Makefile, optional with "make lint"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,15 +668,6 @@ else()
     COMMENT "lualint: LUACHECK_PRG not defined")
 endif()
 
-if(FLAKE8_PRG)
-  add_custom_target(pylint
-    COMMAND ${FLAKE8_PRG} contrib/ scripts/ src/ test/
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-else()
-  add_custom_target(pylint false
-    COMMENT "flake8: FLAKE8_PRG not defined")
-endif()
-
 set(CPACK_PACKAGE_NAME "Neovim")
 set(CPACK_PACKAGE_VENDOR "neovim.io")
 set(CPACK_PACKAGE_VERSION ${NVIM_VERSION_MEDIUM})

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ functionaltest-lua: | nvim
 lualint: | build/.ran-cmake deps
 	$(BUILD_CMD) -C build lualint
 
-pylint: | build/.ran-cmake deps
-	$(BUILD_CMD) -C build pylint
+pylint:
+	flake8 contrib/ scripts/ src/ test/
 
 unittest: | nvim
 	+$(BUILD_CMD) -C build unittest
@@ -182,7 +182,11 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-lint: check-single-includes clint lualint pylint
+lint: check-single-includes clint lualint
+	@# Run pylint only if flake8 is installed.
+	@command -v flake8 \
+		&& { $(MAKE) pylint; exit $?; } \
+		|| echo "SKIP: pylint (flake8 not found)"
 
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".


### PR DESCRIPTION
This avoids errors when using "make lint", but "flake8" is not
available.  We do not want to install it then via third-party.
On CI "make pylint" is used explicitly.