### PR TITLE
tests: unit.helpers: provide string with write errors

### DIFF
--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -456,8 +456,8 @@ else
         if bytes_written == -1 then
           local err = ffi.errno(0)
           if err ~= ffi.C.kPOSIXErrnoEINTR then
-            assert(false, ("write() error: %u: %s"):format(
-                err, ffi.string(ffi.C.strerror(err))))
+            assert(false, ("write() error: %u: %s ('%s')"):format(
+                err, ffi.string(ffi.C.strerror(err)), s))
           end
         elseif bytes_written == 0 then
           break


### PR DESCRIPTION
This might help to have more information in case of errors, like
mentioned in https://github.com/neovim/neovim/commit/eec529cf9e.