### PR TITLE
clang/"Null passed as a nonnull parameter" supressed

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4242,6 +4242,7 @@ static void search_stat(int dirc, pos_T *pos,
     // STRNICMP ignores case, but we should not ignore case.
     // Unfortunately, there is no STRNICMP function.
     if (!(chgtick == buf_get_changedtick(curbuf)
+          && lastpat != NULL  // supress clang/NULL passed as nonnull parameter
           && STRNICMP(lastpat, spats[last_idx].pat, STRLEN(lastpat)) == 0
           && STRLEN(lastpat) == STRLEN(spats[last_idx].pat)
           && equalpos(lastpos, curwin->w_cursor)


### PR DESCRIPTION
bfredl: condition should never be true when `lastpat == NULL`
Added additional guard condition to suppress clang warning