### PR TITLE
ci: AppVeyor: fix upload of coverage for oldtest

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -137,8 +137,10 @@ if ($uploadToCodecov) {
 # Old tests
 # Add MSYS to path, required for e.g. `find` used in test scripts.
 # But would break functionaltests, where its `more` would be used then.
+$OldPath = $env:PATH
 $env:PATH = "C:\msys64\usr\bin;$env:PATH"
 & "C:\msys64\mingw$bits\bin\mingw32-make.exe" -C $(Convert-Path ..\src\nvim\testdir) VERBOSE=1
+$env:PATH = $OldPath
 
 if ($uploadToCodecov) {
   bash -l /c/projects/neovim/ci/common/submit_coverage.sh oldtest


### PR DESCRIPTION
This was not working due to having another `python` in the PATH then.

Ref: https://ci.appveyor.com/project/neovim/neovim/builds/26492761/job/dspm40v5l2v6gn40?fullLog=true#L15955