### PR TITLE
tests: output_spec: use shell-test REP_NODELAY

### DIFF
--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -40,6 +40,7 @@ static void help(void)
   puts("      0: foo bar");
   puts("      ...");
   puts("      96: foo bar");
+  puts("  shell-test REP_NODELAY N {text}");
   puts("  shell-test INTERACT");
   puts("    Prints \"interact $ \" to stderr, and waits for \"exit\" input.");
 }
@@ -66,7 +67,8 @@ int main(int argc, char **argv)
       if (argc >= 3) {
         fprintf(stderr, "%s\n", argv[2]);
       }
-    } else if (strcmp(argv[1], "REP") == 0) {
+    } else if (strcmp(argv[1], "REP") == 0 ||
+               strcmp(argv[1], "REP_NODELAY") == 0) {
       if (argc != 4) {
         fprintf(stderr, "REP expects exactly 3 arguments\n");
         return 4;
@@ -76,10 +78,17 @@ int main(int argc, char **argv)
         fprintf(stderr, "Invalid count: %s\n", argv[2]);
         return 4;
       }
-      for (int i = 0; i < count; i++) {
-        printf("%d: %s\n", i, argv[3]);
-        fflush(stdout);
-        usleep(1000);  // Wait 1 ms (simulate typical output).
+      if (strcmp(argv[1], "REP_NODELAY") == 0) {
+        for (int i = 0; i < count; i++) {
+          printf("%d: %s\n", i, argv[3]);
+          fflush(stdout);
+        }
+      } else {
+        for (int i = 0; i < count; i++) {
+          printf("%d: %s\n", i, argv[3]);
+          fflush(stdout);
+          usleep(1000);  // Wait 1 ms (simulate typical output).
+        }
       }
     } else if (strcmp(argv[1], "UTF-8") == 0) {
       // test split-up UTF-8 sequence

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -51,12 +51,7 @@ describe("shell command :!", function()
   end)
 
   it("throttles shell-command output greater than ~10KB", function()
-    if helpers.skip_fragile(pending,
-        (helpers.isCI('travis') and helpers.os_name() == 'osx')) then
-      return
-    end
-    child_session.feed_data(
-      ":!for i in $(seq 2 30000); do echo XXXXXXXXXX $i; done\n")
+    child_session.feed_data(":!"..nvim_dir.."/shell-test REP_NODELAY 30001 foo\n")
 
     -- If we observe any line starting with a dot, then throttling occurred.
     -- Avoid false failure on slow systems.
@@ -65,10 +60,10 @@ describe("shell command :!", function()
     -- Final chunk of output should always be displayed, never skipped.
     -- (Throttling is non-deterministic, this test is merely a sanity check.)
     screen:expect([[
-      XXXXXXXXXX 29997                                  |
-      XXXXXXXXXX 29998                                  |
-      XXXXXXXXXX 29999                                  |
-      XXXXXXXXXX 30000                                  |
+      29997: foo                                        |
+      29998: foo                                        |
+      29999: foo                                        |
+      30000: foo                                        |
                                                         |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |


### PR DESCRIPTION
Fix flaky "shell command :! throttles shell-command output greater than ~10KB:":

    [ RUN      ] shell command :! throttles shell-command output greater than ~10KB:
    warning: Screen changes were received after the expected state. This indicates
    indeterminism in the test. Try adding screen:expect(...) (or wait()) between
    asynchronous (feed(), nvim_input()) and synchronous API calls.
      - Use screen:redraw_debug() to investigate; it may find relevant intermediate
        states that should be added to the test to make it more robust.
      - If the purpose of the test is to assert state after some user input sent
        with feed(), adding screen:expect() before the feed() will help to ensure
        the input is sent when Nvim is in a predictable state. This is preferable
        to wait(), for being closer to real user interaction.
      - wait() can trigger redraws and consequently generate more indeterminism.
        Try removing wait().

    ERR
    test/functional/ui/screen.lua:579: Failed to match any screen lines.
    Expected (anywhere): "
    %."
    Actual:
      |XXXXXXXXXX 591                                    |
      |XXXXXXXXXX 592                                    |
      |XXXXXXXXXX 593                                    |
      |XXXXXXXXXX 594                                    |
      |                                                  |
      |                                                  |
      |{3:-- TERMINAL --}                                    |
    stack traceback:
            test/functional/ui/screen.lua:579: in function '_wait'
            test/functional/ui/screen.lua:367: in function 'expect'
            test/functional/ui/output_spec.lua:63: in function <test/functional/ui/output_spec.lua:53>

Log: https://travis-ci.org/neovim/neovim/jobs/569082705#L5355
(gcc-functionaltest-lua)

Ref: 2fbe28bc0
Ref: #9721 (4f5e37812) - mentions that "Travis macOS is not fast enough to run this test reliably", but hopefully shell-test is.