### PR TITLE
tests/functional: expect_msg_seq: use load_adjust

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -165,11 +165,12 @@ function module.expect_msg_seq(...)
     end
     return string.format('%s\n%s\n%s', err1, string.rep('=', 78), err2)
   end
+  local msg_timeout = module.load_adjust(10000)  -- Big timeout for ASAN/valgrind.
   for anum = 1, #seqs do
     local expected_seq = seqs[anum]
     -- Collect enough messages to compare the next expected sequence.
     while #actual_seq < #expected_seq do
-      local msg = module.next_msg(10000)  -- Big timeout for ASAN/valgrind.
+      local msg = module.next_msg(msg_timeout)
       local msg_type = msg and msg[2] or nil
       if msg == nil then
         error(cat_err(final_error,
@@ -762,14 +763,14 @@ function module.alter_slashes(obj)
   end
 end
 
-
-local load_factor = nil
+local load_factor = 1
+if global_helpers.isCI() then
+  -- Compute load factor only once (but outside of any tests).
+  module.clear()
+  module.request('nvim_command', 'source src/nvim/testdir/load.vim')
+  load_factor = module.request('nvim_eval', 'g:test_load_factor')
+end
 function module.load_adjust(num)
-  if load_factor == nil then  -- Compute load factor only once.
-    module.clear()
-    module.request('nvim_command', 'source src/nvim/testdir/load.vim')
-    load_factor = module.request('nvim_eval', 'g:test_load_factor')
-  end
   return math.ceil(num * load_factor)
 end
 


### PR DESCRIPTION
Regardless of the comment "Big timeout for ASAN/valgrind" it would use
10s by default already.
This changes it to use `load_adjust`, which itself is only computed on
CI now, and outside of any tests - since it has side effects when being
used the first time!

The failure seen on AppVeyor:

    [ RUN      ] jobs can get the pid value using getpid: ERR
    test\functional\helpers.lua:167:
    ==============================================================================
    got 0 messages (ignored 0), expected 1
    stack traceback:
            test\functional\helpers.lua:167: in function 'expect_msg_seq'
            test/functional\core\job_spec.lua:288: in function <test/functional\core\job_spec.lua:281>

Log: https://ci.appveyor.com/project/neovim/neovim/builds/26537324/job/y1io66fbx399q7h6?fullLog=true#L6554