### PR TITLE
win/os_env_exists(): workaround libuv bug

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -102,6 +102,9 @@ bool os_env_exists(const char *name)
   assert(r != UV_EINVAL);
   if (r != 0 && r != UV_ENOENT && r != UV_ENOBUFS) {
     ELOG("uv_os_getenv(%s) failed: %d %s", name, r, uv_err_name(r));
+#ifdef WIN32
+    return (r == UV_UNKNOWN);
+#endif
   }
   return (r == 0 || r == UV_ENOBUFS);
 }

--- a/test/functional/eval/environ_spec.lua
+++ b/test/functional/eval/environ_spec.lua
@@ -3,7 +3,6 @@ local clear = helpers.clear
 local eq = helpers.eq
 local environ = helpers.funcs.environ
 local exists = helpers.funcs.exists
-local iswin = helpers.iswin
 
 describe('environment variables', function()
   it('environ() handles empty env variable', function()
@@ -12,8 +11,8 @@ describe('environment variables', function()
     eq(nil, environ()['DOES_NOT_EXIST'])
   end)
   it('exists() handles empty env variable', function()
-    clear({env={EMPTY_VAR=""}})  -- Windows treats this as "undefined".
-    eq((iswin() and 0 or 1), exists('$EMPTY_VAR'))
+    clear({env={EMPTY_VAR=""}})
+    eq(1, exists('$EMPTY_VAR'))
     eq(0, exists('$DOES_NOT_EXIST'))
   end)
 end)


### PR DESCRIPTION
os_env_exists() fails on MSVC build:

    os_env_exists:104: uv_os_getenv(EMPTY_VAR) failed: -4094 UNKNOWN

- Revert 396a3945c4eba733b3a99a7ded217af83a400791
- HACK: Windows: return `true` if `uv_os_getenv()` returns UV_UNKNOWN, until  https://github.com/libuv/libuv/issues/2413 is resolved

ref https://github.com/neovim/neovim/commit/396a3945c4eba733b3a99a7ded217af83a400791#r34642361