### PR TITLE
vim-patch:8.1.0911: tag line with Ex command cannot have extra fields

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -537,7 +537,14 @@ only supported by new versions of ctags (such as Exuberant ctags).
 {term}		;" The two characters semicolon and double quote.  This is
 		interpreted by Vi as the start of a comment, which makes the
 		following be ignored.  This is for backwards compatibility
-		with Vi, it ignores the following fields.
+		with Vi, it ignores the following fields. Example:
+			APP	file	/^static int APP;$/;"	v
+		When {tagaddress} is not a line number or search pattern, then
+		{term} must be |;".  Here the bar ends the command (excluding
+		the bar) and ;" is used to have Vi ignore the rest of the
+		line.  Example:
+			APP	file.c	call cursor(3, 4)|;"	v
+			
 {field} ..	A list of optional fields.  Each field has the form:
 
 			<Tab>{fieldname}:{value}

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -79,20 +79,6 @@ func Test_tags_too_long()
   tags
 endfunc
 
-" For historical reasons we support a tags file where the last line is missing
-" the newline.
-func Test_tagsfile_without_trailing_newline()
-  call writefile(["Foo\tfoo\t1"], 'Xtags', 'b')
-  set tags=Xtags
-
-  let tl = taglist('.*')
-  call assert_equal(1, len(tl))
-  call assert_equal('Foo', tl[0].name)
-
-  call delete('Xtags')
-  set tags&
-endfunc
-
 func Test_tagfiles()
   call assert_equal([], tagfiles())
 
@@ -115,4 +101,18 @@ func Test_tagfiles()
   call delete('Xtags1')
   call delete('Xtags2')
   bd
+endfunc
+
+" For historical reasons we support a tags file where the last line is missing
+" the newline.
+func Test_tagsfile_without_trailing_newline()
+  call writefile(["Foo\tfoo\t1"], 'Xtags', 'b')
+  set tags=Xtags
+
+  let tl = taglist('.*')
+  call assert_equal(1, len(tl))
+  call assert_equal('Foo', tl[0].name)
+
+  call delete('Xtags')
+  set tags&
 endfunc

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -5,7 +5,9 @@ func Test_taglist()
 	\ "FFoo\tXfoo\t1",
 	\ "FBar\tXfoo\t2",
 	\ "BFoo\tXbar\t1",
-	\ "BBar\tXbar\t2"
+	\ "BBar\tXbar\t2",
+	\ "Kindly\tXbar\t3;\"\tv\tfile:",
+	\ "Command\tXbar\tcall cursor(3, 4)|;\"\td",
 	\ ], 'Xtags')
   set tags=Xtags
   split Xtext
@@ -14,6 +16,18 @@ func Test_taglist()
   call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xtext"), {i, v -> v.name}))
   call assert_equal(['FFoo', 'BFoo'], map(taglist("Foo", "Xfoo"), {i, v -> v.name}))
   call assert_equal(['BFoo', 'FFoo'], map(taglist("Foo", "Xbar"), {i, v -> v.name}))
+
+  let kind = taglist("Kindly")
+  call assert_equal(1, len(kind))
+  call assert_equal('v', kind[0]['kind'])
+  call assert_equal('3', kind[0]['cmd'])
+  call assert_equal(1, kind[0]['static'])
+  call assert_equal('Xbar', kind[0]['filename'])
+
+  let cmd = taglist("Command")
+  call assert_equal(1, len(cmd))
+  call assert_equal('d', cmd[0]['kind'])
+  call assert_equal('call cursor(3, 4)', cmd[0]['cmd'])
 
   call delete('Xtags')
   set tags&


### PR DESCRIPTION
Problem:    Tag line with Ex command cannot have extra fields.
Solution:   Recognize |;" as the end of the command. (closes vim/vim#2402)
https://github.com/vim/vim/commit/943e9639a9ecb08bdec78ae6695c917bca6210b9