### PR TITLE
clang/"Argument with 'nonnull' attribute passed null"

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4374,6 +4374,12 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol,
 
   screen_adjust_grid(&grid, &row, &coloff);
 
+  // Safety check. Avoids clang warnings down the call stack.
+  if (grid->chars == NULL || row >= grid->Rows || col >= grid->Columns) {
+    DLOG("invalid state, skipped");
+    return;
+  }
+
   off_from = 0;
   off_to = grid->line_offset[row] + coloff;
   max_off_from = linebuf_size;


### PR DESCRIPTION
**Problem:**  
In screen.c `grid_char_needs_redraw` clang warns that `grid->chars` could be `NULL`
https://neovim.io/doc/reports/clang/report-55252e.html#EndPath

**Solution:** 
Suggested by @bfredl. 
Add explicit check `grid->chars != NULL` in `grid_put_linebuf` similar to `grid_puts_len`