### PR TITLE
ci: AppVeyor: branches: only: master  [skip travis]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,3 +40,6 @@ cache:
 artifacts:
 - path: build/Neovim.zip
 - path: build/bin/nvim.exe
+branches:
+  only:
+    - master


### PR DESCRIPTION
Only build PRs for master, and not other branches on the main repo, e.g.
when reverting via GitHub's UI.

Ref: https://www.appveyor.com/docs/branches/