### PR TITLE
[RDY] ex_getln.c: fix compute_cmdrow() not resetting lines_left

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3483,6 +3483,7 @@ void compute_cmdrow(void)
     cmdline_row = wp->w_winrow + wp->w_height
                   + wp->w_status_height;
   }
+  lines_left = cmdline_row;
 }
 
 static void cursorcmd(void)

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2634,3 +2634,19 @@ it(':substitute with inccommand, timer-induced :redraw #9777', function()
     :%s/foo/ZZZ^                   |
   ]])
 end)
+
+it('long :%s/ with inccommand does not collapse cmdline', function()
+  local screen = Screen.new(10,5)
+  clear()
+  common_setup(screen)
+  command('set inccommand=nosplit')
+  feed(':%s/AAAAAAA', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A',
+    'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A')
+  screen:expect([[
+    {15:~           }|
+    {15:~           }|
+    :%s/AAAAAAAA|
+    AAAAAAAAAAAA|
+    AAAAAAA^     |
+  ]])
+end)


### PR DESCRIPTION
Before this commit, when `inccomand` was set to `nosplit`, multi-line
substitutions collapsed the command-line.

This happened because when ex_getln.c:cursorcmd() computed a msg_row, it
was given a cmdline_row one line too high. This happened because
message.c:msg_puts_display() was supposed to decrement cmdline_row but
didn't, because of the `msg_no_more && lines_left == 0` check placed
just before the decrementation part in msg_puts_display's while loop.

Every time msg_puts_display writes a line, it decreases `lines_left` (a
variable used to know how many lines are left for prompts). Since
redrawcommandline() did not reset lines_left between calls to
msg_puts_display, every time a character was pressed, `lines_left` was
decremented. This meant that once the user pressed COLUMNS+ROWS numbers
of characters, lines_left would reach 0 and prevent msg_row from being
decremented.

It makes sense to fix setting `lines_left` to `cmdline_row` in
`compute_cmdrow` ; after all, computing where the command line row
should be placed is equivalent to computing how many lines left of
output there are left.

Closes #8254.

Note: I tried to write a test but couldn't get it to fail. It was in inccommand_spec.lua and looked like this:
```lua
it('long :%s/ with inccomand does not collapse cmdline', function()
  local screen = Screen.new(10,5)
  clear()
  common_setup(screen)
  command('set inccommand=nosplit')
  feed(':%s/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
  screen:expect([[
    {15:~                             }|
    {15:~                             }|
    :%s/AAAAAAAAAAAAAAAAAAAAAAAAAA|
    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA|
    AAAAAAAA^                      |
  ]])
end)
```