### PR TITLE
vim-patch:8.0.1179: Test_popup_and_window_resize() does not always pass

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -269,7 +269,6 @@ let s:flaky_tests = [
       \ 'Test_oneshot()',
       \ 'Test_out_cb()',
       \ 'Test_paused()',
-      \ 'Test_popup_and_window_resize()',
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -196,22 +196,40 @@ func s:feedkeys(timer)
   call feedkeys('x', 'nt')
 endfunc
 
+" Get $VIMPROG to run Vim executable.
+" The Makefile writes it as the first line in the "vimcmd" file.
+" Nvim: uses $NVIM_TEST_ARG0.
+func GetVimProg()
+  if empty($NVIM_TEST_ARG0)
+    " Assume the script was sourced instead of running "make".
+    return '../../../build/bin/nvim'
+  endif
+  return $NVIM_TEST_ARG0
+endfunc
+
 " Get the command to run Vim, with -u NONE and --headless arguments.
 " If there is an argument use it instead of "NONE".
-" Returns an empty string on error.
 func GetVimCommand(...)
   if a:0 == 0
     let name = 'NONE'
   else
     let name = a:1
   endif
-  let cmd = v:progpath
+  let cmd = GetVimProg()
   let cmd = substitute(cmd, '-u \f\+', '-u ' . name, '')
   if cmd !~ '-u '. name
     let cmd = cmd . ' -u ' . name
   endif
   let cmd .= ' --headless -i NONE'
   let cmd = substitute(cmd, 'VIMRUNTIME=.*VIMRUNTIME;', '', '')
+  return cmd
+endfunc
+
+" Get the command to run Vim, with --clean.
+func GetVimCommandClean()
+  let cmd = GetVimCommand()
+  let cmd = substitute(cmd, '-u NONE', '--clean', '')
+  let cmd = substitute(cmd, '--headless', '', '')
   return cmd
 endfunc
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -669,10 +669,10 @@ func Test_popup_and_window_resize()
   if h < 15
     return
   endif
-  let g:buf = term_start([$NVIM_PRG, '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
-  call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>G")
-  call term_sendkeys(g:buf, "i\<c-x>")
+  let g:buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': h / 3})
+  call term_sendkeys(g:buf, (h / 3 - 1)."o\<esc>")
   call term_wait(g:buf, 200)
+  call term_sendkeys(g:buf, "Gi\<c-x>")
   call term_sendkeys(g:buf, "\<c-v>")
   call term_wait(g:buf, 100)
   " popup first entry "!" must be at the top

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -470,7 +470,7 @@ func Test_bg_detection()
   hi Normal ctermbg=NONE
 endfunc
 
-fun Test_synstack_synIDtrans()
+func Test_synstack_synIDtrans()
   new
   setfiletype c
   syntax on
@@ -493,6 +493,39 @@ fun Test_synstack_synIDtrans()
   syn clear
   bw!
 endfunc
+
+" Check highlighting for a small piece of C code with a screen dump.
+func Test_syntax_c()
+  if !has('terminal')
+    return
+  endif
+  call writefile([
+	\ '/* comment line at the top */',
+	\ '  int',
+	\ 'main(int argc, char **argv)// another comment',
+	\ '{',
+	\ '#if 0',
+	\ '   int   not_used;',
+	\ '#else',
+	\ '   int   used;',
+	\ '#endif',
+	\ '   printf("Just an example piece of C code\n");',
+	\ '   return 0x0ff;',
+	\ '}',
+	\ '   static void',
+	\ 'myFunction(const double count, struct nothing, long there) {',
+	\ '  // 123: nothing to read here',
+	\ '  for (int i = 0; i < count; ++i) {',
+	\ '    break;',
+	\ '  }',
+	\ '}',
+	\ ], 'Xtest.c')
+  let buf = RunVimInTerminal('Xtest.c', {})
+  call VerifyScreenDump(buf, 'Test_syntax_c_01')
+  call StopVimInTerminal(buf)
+
+  call delete('Xtest.c')
+endfun
 
 " Using \z() in a region with NFA failing should not crash.
 func Test_syn_wrong_z_one()


### PR DESCRIPTION
Problem:    Test_popup_and_window_resize() does not always pass.
Solution:   Do not use $VIMPROG, pass the Vim executable in the vimcmd file.
            (Ozaki Kiichi, closes vim/vim#2186)
https://github.com/vim/vim/commit/631820536e4084e01bf990f9314ec385b60b21d7

NOTE: Does not add `GetVimProg()`, but keeps/syncs existing usages of it
in tests (which obviously are all skipped, mostly because of
`!has('terminal')`).  Likely to be replaced with `v:progpath` in Vim [1], or
at least that would/should be used with Neovim then probably.

1: https://github.com/vim/vim/pull/4806