### PR TITLE
tests: fix retry with "TUI FocusGained/FocusLost in terminal-mode"

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -850,7 +850,7 @@ describe('TUI FocusGained/FocusLost', function()
     feed_data(':set shell='..nvim_dir..'/shell-test\n')
     feed_data(':set noshowmode laststatus=0\n')
 
-    retry(2, 3 * screen.timeout, function()
+    retry(3, nil, function()
       feed_data(':terminal\n')
       screen:sleep(1)
       feed_data('\027[I')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -851,7 +851,9 @@ describe('TUI FocusGained/FocusLost', function()
     feed_data(':set noshowmode laststatus=0\n')
 
     feed_data(':terminal\n')
-    screen:sleep(1)
+    -- Wait for terminal to be ready.
+    screen:expect{any='-- TERMINAL --'}
+
     feed_data('\027[I')
     screen:expect{grid=[[
       {1:r}eady $                                           |

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -853,7 +853,7 @@ describe('TUI FocusGained/FocusLost', function()
     feed_data(':terminal\n')
     screen:sleep(1)
     feed_data('\027[I')
-    screen:expect({grid=[[
+    screen:expect{grid=[[
       {1:r}eady $                                           |
       [Process exited 0]                                |
                                                         |
@@ -861,7 +861,7 @@ describe('TUI FocusGained/FocusLost', function()
                                                         |
       gained                                            |
       {3:-- TERMINAL --}                                    |
-    ]], timeout=(3 * screen.timeout)})
+    ]], timeout=(3 * screen.timeout)}
 
     feed_data('\027[O')
     screen:expect([[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -850,34 +850,29 @@ describe('TUI FocusGained/FocusLost', function()
     feed_data(':set shell='..nvim_dir..'/shell-test\n')
     feed_data(':set noshowmode laststatus=0\n')
 
-    retry(3, nil, function()
-      feed_data(':terminal\n')
-      screen:sleep(1)
-      feed_data('\027[I')
-      screen:expect([[
-        {1:r}eady $                                           |
-        [Process exited 0]                                |
-                                                          |
-                                                          |
-                                                          |
-        gained                                            |
-        {3:-- TERMINAL --}                                    |
-      ]])
-      feed_data('\027[O')
-      screen:expect([[
-        {1:r}eady $                                           |
-        [Process exited 0]                                |
-                                                          |
-                                                          |
-                                                          |
-        lost                                              |
-        {3:-- TERMINAL --}                                    |
-      ]])
+    feed_data(':terminal\n')
+    screen:sleep(1)
+    feed_data('\027[I')
+    screen:expect({grid=[[
+      {1:r}eady $                                           |
+      [Process exited 0]                                |
+                                                        |
+                                                        |
+                                                        |
+      gained                                            |
+      {3:-- TERMINAL --}                                    |
+    ]], timeout=(3 * screen.timeout)})
 
-      -- If retry is needed...
-      feed_data("\034\016")  -- CTRL-\ CTRL-N
-      feed_data(':bwipeout!\n')
-    end)
+    feed_data('\027[O')
+    screen:expect([[
+      {1:r}eady $                                           |
+      [Process exited 0]                                |
+                                                        |
+                                                        |
+                                                        |
+      lost                                              |
+      {3:-- TERMINAL --}                                    |
+    ]])
   end)
 
   it('in press-enter prompt', function()


### PR DESCRIPTION
Always retry (increased to 3 just because), not limited by timeout.

Failure seen on quickbuild (note the "retry() attempts: 1"):

    09:41:07,627  INFO  - # test/functional/terminal/tui_spec.lua @ 437: TUI FocusGained/FocusLost in terminal-mode
    09:41:07,627  INFO  - not ok 2976 - TUI FocusGained/FocusLost in terminal-mode
    09:41:07,627  INFO  - # test/functional/terminal/tui_spec.lua @ 437
    09:41:07,627  INFO  - # Failure message: ./test/functional/helpers.lua:403:
    09:41:07,627  INFO  - # retry() attempts: 1
    09:41:07,627  INFO  - # ./test/functional/ui/screen.lua:579: Row 1 did not match.
    09:41:07,627  INFO  - # Expected:
    09:41:07,627  INFO  - # |*{1:r}eady $ |
    09:41:07,627  INFO  - # |[Process exited 0] |
    09:41:07,627  INFO  - # | |
    09:41:07,627  INFO  - # | |
    09:41:07,627  INFO  - # | |
    09:41:07,627  INFO  - # |gained |
    09:41:07,628  INFO  - # |{3:-- TERMINAL --} |
    09:41:07,628  INFO  - # Actual:
    09:41:07,628  INFO  - # |*{1: } |
    09:41:07,628  INFO  - # |{4:~ }|
    09:41:07,628  INFO  - # |{4:~ }|
    09:41:07,628  INFO  - # |{4:~ }|
    09:41:07,628  INFO  - # |{5:[No Name] }|
    09:41:07,628  INFO  - # | |
    09:41:07,628  INFO  - # |{3:-- TERMINAL --} |
    09:41:07,628  INFO  - #
    09:41:07,628  INFO  - # To print the expect() call that would assert the current screen state, use
    09:41:07,628  INFO  - # screen:snapshot_util(). In case of non-deterministic failures, use
    09:41:07,628  INFO  - # screen:redraw_debug() to show all intermediate screen states.
    09:41:07,628  INFO  - # stack traceback:
    09:41:07,628  INFO  - #     ./test/functional/helpers.lua:403: in function 'retry'
    09:41:07,628  INFO  - #     test/functional/terminal/tui_spec.lua:441: in function <test/functional/terminal/tui_spec.lua:437>