### PR TITLE
[RFC] clang/"null pointer dereference"

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3689,7 +3689,7 @@ expand_by_function(
   typval_T rettv;
   const int save_State = State;
 
-  assert(curbuf != NULL && curbuf->b_p_cfu != NULL && curbuf->b_p_ofu != NULL);
+  assert(curbuf != NULL);
   funcname = (type == CTRL_X_FUNCTION) ? curbuf->b_p_cfu : curbuf->b_p_ofu;
   if (*funcname == NUL) {
     return;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3672,28 +3672,28 @@ static buf_T *ins_compl_next_buf(buf_T *buf, int flag)
 }
 
 
-/*
- * Execute user defined complete function 'completefunc' or 'omnifunc', and
- * get matches in "matches".
- */
+// Execute user defined complete function 'completefunc' or 'omnifunc', and
+// get matches in "matches".
 static void
-expand_by_function (
-    int type,                   /* CTRL_X_OMNI or CTRL_X_FUNCTION */
+expand_by_function(
+    int type,                   // CTRL_X_OMNI or CTRL_X_FUNCTION
     char_u *base
 )
 {
-  list_T      *matchlist = NULL;
-  dict_T      *matchdict = NULL;
-  char_u      *funcname;
+  list_T *matchlist = NULL;
+  dict_T *matchdict = NULL;
+  char_u *funcname;
   pos_T pos;
-  win_T       *curwin_save;
-  buf_T       *curbuf_save;
+  win_T *curwin_save;
+  buf_T *curbuf_save;
   typval_T rettv;
   const int save_State = State;
 
+  assert(curbuf != NULL && curbuf->b_p_cfu != NULL && curbuf->b_p_ofu != NULL);
   funcname = (type == CTRL_X_FUNCTION) ? curbuf->b_p_cfu : curbuf->b_p_ofu;
-  if (*funcname == NUL)
+  if (*funcname == NUL) {
     return;
+  }
 
   // Call 'completefunc' to obtain the list of matches.
   typval_T args[3];


### PR DESCRIPTION
Fixes 2 clang warnings
https://neovim.io/doc/reports/clang/report-18c19f.html#EndPath
https://neovim.io/doc/reports/clang/report-651d2c.html#EndPath

According to @justinmk 
> can just be an assert; curbuf can never be null.

Added asserts to make sure curbuf and it its fields are not NULL