### PR TITLE
compositor: handle invalid screen positions after resize gracefully

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4375,7 +4375,7 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol,
   screen_adjust_grid(&grid, &row, &coloff);
 
   // Safety check. Avoids clang warnings down the call stack.
-  if (grid->chars == NULL || row >= grid->Rows || col >= grid->Columns) {
+  if (grid->chars == NULL || row >= grid->Rows || coloff >= grid->Columns) {
     DLOG("invalid state, skipped");
     return;
   }


### PR DESCRIPTION
The screen resize logic needs to be refactored to be simpler and more deterministic. Until then, we need to handle attempts to draw outside of the screen size gracefully, just like the old vim code did.

fixes #9989