### PR TITLE
provider: do not incorrectly prefer python2 when python3 is working

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13640,10 +13640,6 @@ static void f_pumvisible(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  */
 static void f_pyeval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (p_pyx == 0) {
-      p_pyx = 2;
-  }
-
   script_host_eval("python", argvars, rettv);
 }
 
@@ -13652,10 +13648,6 @@ static void f_pyeval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  */
 static void f_py3eval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (p_pyx == 0) {
-      p_pyx = 3;
-  }
-
   script_host_eval("python3", argvars, rettv);
 }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2830,9 +2830,9 @@ void ex_options(exarg_T *eap)
 void init_pyxversion(void)
 {
   if (p_pyx == 0) {
-    if (!eval_has_provider("python3")) {
+    if (eval_has_provider("python3")) {
       p_pyx = 3;
-    } else if (!eval_has_provider("python")) {
+    } else if (eval_has_provider("python")) {
       p_pyx = 2;
     }
   }

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -91,6 +91,7 @@ describe('python3 provider', function()
   end)
 
   it('pyxeval #10758', function()
+    eq(0, eval([[&pyxversion]]))
     eq(3, eval([[pyxeval('sys.version_info[:3][0]')]]))
     eq(3, eval([[&pyxversion]]))
   end)

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -90,6 +90,11 @@ describe('python3 provider', function()
     eq({1, 2, {['key'] = 'val'}}, eval([[py3eval('[1, 2, {"key": "val"}]')]]))
   end)
 
+  it('pyxeval #10758', function()
+    eq(3, eval([[pyxeval('sys.version_info[:3][0]')]]))
+    eq(3, eval([[&pyxversion]]))
+  end)
+
   it('RPC call to expand("<afile>") during BufDelete #5245 #5617', function()
     source([=[
       python3 << EOF


### PR DESCRIPTION
fixes #10758.

Not sure if we tested the incorrect behaviour, or if there are no tests.