### PR TITLE
tests: "timers can be stopped from the handler": check state before

### DIFF
--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -162,8 +162,8 @@ describe('timers', function()
         endif
       endfunc
     ]])
+    eq(0, eval("g:val"))
     command("call timer_start(10, 'MyHandler', {'repeat': -1})")
-    eq(0,eval("g:val"))
     retry(nil, nil, function()
       eq(3, eval("g:val"))
     end)


### PR DESCRIPTION
Check g:val before starting timer.  Otherwise the timeout of 10ms might
be triggered already before the check:

    18:57:37,600 INFO  - not ok 1172 - timers can be stopped from the handler
    18:57:37,600 INFO  - # test/functional/eval/timer_spec.lua @ 154
    18:57:37,600 INFO  - # Failure message: test/functional/eval/timer_spec.lua:166: Expected objects to be the same.
    18:57:37,600 INFO  - # Passed in:
    18:57:37,600 INFO  - # (number) 1
    18:57:37,600 INFO  - # Expected:
    18:57:37,600 INFO  - # (number) 0
    18:57:37,600 INFO  - # stack traceback:
    18:57:37,600 INFO  - # 	test/functional/eval/timer_spec.lua:166: in function <test/functional/eval/timer_spec.lua:154>

Log: http://neovim-qb.szakmeister.net/build/24318