### PR TITLE
tests: fix/improve "jobwait returns -1 when timed out"

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -707,11 +707,10 @@ describe('jobs', function()
       it('will return -1 if the wait timed out', function()
         source([[
         call rpcnotify(g:channel, 'wait', jobwait([
-        \  jobstart('exit 4'),
         \  jobstart((has('win32') ? 'Start-Sleep 10' : 'sleep 10').'; exit 5'),
-        \  ], has('win32') ? 6000 : 100))
+        \  ], 100))
         ]])
-        eq({'notification', 'wait', {{4, -1}}}, next_msg())
+        eq({'notification', 'wait', {{-1}}}, next_msg())
       end)
 
       it('can pass 0 to check if a job exists', function()


### PR DESCRIPTION
There was a longer timeout for Windows already, but unlike stated in
51d42917f it is not a worst-case, but gets waited for always.

The test is only about "-1" on timeout, so reduce it to this.

Fixes:

    16:33:19,309 INFO  - not ok 627 - jobs jobwait with timeout argument will return -1 if the wait timed out
    16:33:19,309 INFO  - # test/functional/core/job_spec.lua @ 707
    16:33:19,309 INFO  - # Failure message: test/functional/core/job_spec.lua:714: Expected objects to be the same.
    16:33:19,309 INFO  - # Passed in:
    16:33:19,309 INFO  - # (table: 0x0db1a3f0) {
    16:33:19,309 INFO  - #   [1] = 'notification'
    16:33:19,309 INFO  - #   [2] = 'wait'
    16:33:19,309 INFO  - #  *[3] = {
    16:33:19,309 INFO  - #    *[1] = {
    16:33:19,309 INFO  - #      *[1] = -1
    16:33:19,309 INFO  - #       [2] = -1 } } }
    16:33:19,309 INFO  - # Expected:
    16:33:19,309 INFO  - # (table: 0x0db1a480) {
    16:33:19,309 INFO  - #   [1] = 'notification'
    16:33:19,309 INFO  - #   [2] = 'wait'
    16:33:19,309 INFO  - #  *[3] = {
    16:33:19,309 INFO  - #    *[1] = {
    16:33:19,309 INFO  - #      *[1] = 4
    16:33:19,309 INFO  - #       [2] = -1 } } }
    16:33:19,309 INFO  - # stack traceback:
    16:33:19,309 INFO  - # 	test/functional/core/job_spec.lua:714: in function <test/functional/core/job_spec.lua:707>

Log: http://neovim-qb.szakmeister.net/build/24312