### PR TITLE
timer_spec: no timeout with "doesn't mess up the cmdline"

### DIFF
--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -209,7 +209,7 @@ describe('timers', function()
         let g:val = 1
       endfunc
     ]])
-    command("call timer_start(100,  'MyHandler', {'repeat': 1})")
+    command("call timer_start(10,  'MyHandler', {'repeat': 1})")
     feed(":good")
     screen:expect([[
                                               |
@@ -220,6 +220,12 @@ describe('timers', function()
       :good^                                   |
     ]])
 
+    -- Wait for timer to have finished / echoed.
+    retry(nil, nil, function()
+      eq(1, eval('g:val'))
+    end)
+
+    -- "evil" was not printed.
     screen:expect{grid=[[
                                               |
       {0:~                                       }|
@@ -227,9 +233,7 @@ describe('timers', function()
       {0:~                                       }|
       {0:~                                       }|
       :good^                                   |
-    ]], intermediate=true}
-
-    eq(1, eval('g:val'))
+    ]]}
   end)
 
 end)

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -203,17 +203,14 @@ describe('timers', function()
     screen:attach()
     screen:set_default_attr_ids( {[0] = {bold=true, foreground=255}} )
     source([[
-      let g:val = -1
+      let g:val = 0
       func! MyHandler(timer)
-        if g:val >= 0
-          let g:val = 1
-          echo "evil"
-          call timer_stop(a:timer)
-        endif
+        echo "evil"
+        let g:val = 1
       endfunc
     ]])
-    command("call timer_start(10,  'MyHandler', {'repeat': -1})")
-    feed(":let g:val = 1<cr>:good")
+    command("call timer_start(100,  'MyHandler', {'repeat': 1})")
+    feed(":good")
     screen:expect([[
                                               |
       {0:~                                       }|

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -227,7 +227,7 @@ describe('timers', function()
       {0:~                                       }|
       {0:~                                       }|
       :good^                                   |
-    ]], intermediate=true, timeout=1000}
+    ]], intermediate=true}
 
     eq(1, eval('g:val'))
   end)

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -233,7 +233,7 @@ describe('timers', function()
       {0:~                                       }|
       {0:~                                       }|
       :good^                                   |
-    ]]}
+    ]], intermediate=true}
   end)
 
 end)

--- a/test/functional/eval/timer_spec.lua
+++ b/test/functional/eval/timer_spec.lua
@@ -230,7 +230,7 @@ describe('timers', function()
       {0:~                                       }|
       {0:~                                       }|
       :good^                                   |
-    ]], intermediate=true, timeout=100}
+    ]], intermediate=true, timeout=load_adjust(200)}
 
     eq(1, eval('g:val'))
   end)


### PR DESCRIPTION
It was increased in dd21cd2a4 to avoid flakiness, but takes 1s then.

Not specifying a timeout argument makes it pass faster.

This is due to `1000` being used as minimal timeout when a timeout is passed: https://github.com/blueyed/neovim/blob/3518bb328b7b5e8394626764f03cb400b6068a8e/test/functional/ui/screen.lua#L495

Not really sure if that's a bug by itself, or just how it is used here.

/cc @bfredl 