### PR TITLE
mksession: use exists(':tcd'), not has('nvim')

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9181,7 +9181,7 @@ makeopens(
 
     // Take care of tab-local working directories if applicable
     if (tp->tp_localdir) {
-      if (fputs("if has('nvim') | tcd ", fd) < 0
+      if (fputs("if exists(':tcd') == 2 | tcd ", fd) < 0
           || ses_put_fname(fd, tp->tp_localdir, &ssop_flags) == FAIL
           || fputs(" | endif", fd) < 0
           || put_eol(fd) == FAIL) {


### PR DESCRIPTION
Since recent vim versions also support :tcd, check for the actual
availability of the command, rather than has('nvim').