### PR TITLE
tests: include `timer_start` with duration

### DIFF
--- a/src/nvim/testdir/load.vim
+++ b/src/nvim/testdir/load.vim
@@ -6,8 +6,8 @@ function! s:load_factor() abort
 
   for _ in range(5)
     let g:val = 0
-    call timer_start(timeout, {-> nvim_set_var('val', 1)})
     let start = reltime()
+    call timer_start(timeout, {-> nvim_set_var('val', 1)})
     while 1
       sleep 10m
       if g:val == 1


### PR DESCRIPTION
This should not make much of a difference, but increases the timeout
when `load_factor` is used slightly.