### PR TITLE
tests: skip "API nvim_parse_expression" on MSVC_32

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1149,7 +1149,7 @@ describe('API', function()
       meths.set_option('isident', '')
     end)
 
-    local itp = it
+    local it_maybe_pending = it
     if (helpers.isCI('appveyor') and os.getenv('CONFIGURATION') == 'MSVC_32') then
       -- For "works with &opt" (flaky on MSVC_32), but not easy to skip alone.  #10241
       itp = pending

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1148,6 +1148,13 @@ describe('API', function()
     before_each(function()
       meths.set_option('isident', '')
     end)
+
+    local it
+    if (helpers.isCI('appveyor') and os.getenv('CONFIGURATION') == 'MSVC_32') then
+      -- 'works with &opt' is flaky on MSVC_32, but not easy to skip alone.  #10241
+      it = pending
+    end
+
     local function simplify_east_api_node(line, east_api_node)
       if east_api_node == NIL then
         return nil

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1151,7 +1151,7 @@ describe('API', function()
 
     local itp = it
     if (helpers.isCI('appveyor') and os.getenv('CONFIGURATION') == 'MSVC_32') then
-      -- 'works with &opt' is flaky on MSVC_32, but not easy to skip alone.  #10241
+      -- For "works with &opt" (flaky on MSVC_32), but not easy to skip alone.  #10241
       itp = pending
     end
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1352,7 +1352,7 @@ describe('API', function()
     end
     assert:set_parameter('TableFormatLevel', 1000000)
     require('test.unit.viml.expressions.parser_tests')(
-        itp, _check_parsing, hl, fmtn)
+        it_maybe_pending, _check_parsing, hl, fmtn)
   end)
 
   describe('nvim_list_uis', function()

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1149,10 +1149,10 @@ describe('API', function()
       meths.set_option('isident', '')
     end)
 
-    local it
+    local itp = it
     if (helpers.isCI('appveyor') and os.getenv('CONFIGURATION') == 'MSVC_32') then
       -- 'works with &opt' is flaky on MSVC_32, but not easy to skip alone.  #10241
-      it = pending
+      itp = pending
     end
 
     local function simplify_east_api_node(line, east_api_node)
@@ -1352,7 +1352,7 @@ describe('API', function()
     end
     assert:set_parameter('TableFormatLevel', 1000000)
     require('test.unit.viml.expressions.parser_tests')(
-        it, _check_parsing, hl, fmtn)
+        itp, _check_parsing, hl, fmtn)
   end)
 
   describe('nvim_list_uis', function()

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1152,7 +1152,7 @@ describe('API', function()
     local it_maybe_pending = it
     if (helpers.isCI('appveyor') and os.getenv('CONFIGURATION') == 'MSVC_32') then
       -- For "works with &opt" (flaky on MSVC_32), but not easy to skip alone.  #10241
-      itp = pending
+      it_maybe_pending = pending
     end
 
     local function simplify_east_api_node(line, east_api_node)


### PR DESCRIPTION
Only "API nvim_parse_expression works with &opt" is flaky, but easier to
skip all of "API nvim_parse_expression".

Ref: https://github.com/neovim/neovim/issues/10241