### PR TITLE
[RDY] ex_getln.c: fix <S-Tab> not triggering Pmenu when wildoptions=pum

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1021,9 +1021,11 @@ static int command_line_execute(VimState *state, int key)
 
   // <S-Tab> goes to last match, in a clumsy way
   if (s->c == K_S_TAB && KeyTyped) {
-    if (nextwild(&s->xpc, WILD_EXPAND_KEEP, 0, s->firstc != '@') == OK
-        && nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@') == OK
-        && nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@') == OK) {
+    if (nextwild(&s->xpc, WILD_EXPAND_KEEP, 0, s->firstc != '@') == OK) {
+      showmatches(&s->xpc, p_wmnu
+                  && ((wim_flags[s->wim_index] & WIM_LIST) == 0));
+      nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@');
+      nextwild(&s->xpc, WILD_PREV, 0, s->firstc != '@');
       return command_line_changed(s);
     }
   }

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -574,6 +574,22 @@ describe('ui/ext_popupmenu', function()
     ]])
     feed('<esc>')
 
+    -- #10042: make sure shift-tab also triggers the pum
+    feed(':sign <S-tab>')
+    screen:expect{grid=[[
+                                      |
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      :sign unplace^                   |
+    ]], popupmenu={items=wild_expected, pos=5, anchor={1, 9, 6}}}
+    feed('<esc>')
+
     -- check positioning with multibyte char in pattern
     command("e långfile1")
     command("sp långfile2")
@@ -594,6 +610,7 @@ describe('ui/ext_popupmenu', function()
       items = {{"långfile1", "", "", "" }, {"långfile2", "", "", ""}},
       pos = 0,
     }}
+
   end)
 end)
 


### PR DESCRIPTION
Some of the logic that was present for `<Tab>` was missing from `<S-Tab>`.

Closes https://github.com/neovim/neovim/issues/10042.