### PR TITLE
ci: fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ addons:
       - valgrind
       - xclip
   homebrew:
-    update: true
+    update: false
     packages:
       - ccache
       - ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
                          -DCMAKE_TOOLCHAIN_FILE=$TRAVIS_BUILD_DIR/cmake/i386-linux-gnu.toolchain.cmake"
     # Environment variables for Clang sanitizers.
     - ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1:log_path=$LOG_DIR/asan"
-    - TSAN_OPTIONS="log_path=$LOG_DIR/tsan"
+    - TSAN_OPTIONS="log_path=$LOG_DIR/tsan:suppressions=$TRAVIS_BUILD_DIR/src/.tsan-suppressions"
     - UBSAN_OPTIONS="print_stacktrace=1 log_path=$LOG_DIR/ubsan"
     # Environment variables for Valgrind.
     - VALGRIND_LOG="$LOG_DIR/valgrind-%p.log"

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -84,7 +84,7 @@ build_nvim() {
   fi
 
   # Invoke nvim to trigger *San early.
-  if ! (bin/nvim --version && bin/nvim -u NONE -e -cq | cat -A) ; then
+  if ! (bin/nvim --version && bin/nvim -u NONE -e -cq | cat -vet) ; then
     check_sanitizer "${LOG_DIR}"
     exit 1
   fi

--- a/src/.tsan-suppressions
+++ b/src/.tsan-suppressions
@@ -1,0 +1,2 @@
+# Ref: https://github.com/neovim/neovim/pull/10591#issuecomment-521248233
+race:starting

--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -63,7 +63,7 @@ Enable the sanitizer(s) via these environment variables:
     export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 
     export MSAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
-    export TSAN_OPTIONS="external_symbolizer_path=/usr/lib/llvm-5.0/bin/llvm-symbolizer log_path=${HOME}/logs/tsan"
+    export TSAN_OPTIONS="log_path=${HOME}/logs/tsan:suppressions=${NVIM_PATH}/src/.tsan-suppressions"
 
 Logs will be written to `${HOME}/logs/*san.PID`.
 


### PR DESCRIPTION
It is disabled by default, and the docs mention that it slows builds
down [1].  It took 165s in https://travis-ci.org/neovim/neovim/jobs/572000615.

1: https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos