### PR TITLE
[RFC] fix: flaky 'jobstop() kills entire process tree #6530'

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -777,9 +777,9 @@ describe('jobs', function()
     retry(nil, nil, function()
       children = meths.get_proc_children(ppid)
       if iswin() then
-        -- On Windows there is conhost.exe always,
-        -- and e.g. vctip.exe might appear.  #10783
-        ok(#children >= 4 and #children <= 5)
+        -- On Windows conhost.exe may exist, and
+        -- e.g. vctip.exe might appear.  #10783
+        ok(#children >= 3 and #children <= 5)
       else
         eq(3, #children)
       end

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -776,7 +776,13 @@ describe('jobs', function()
     local children
     retry(nil, nil, function()
       children = meths.get_proc_children(ppid)
-      eq((iswin() and 4 or 3), #children)
+      if iswin() then
+        -- On Windows there is conhost.exe always,
+        -- and e.g. vctip.exe might appear.  #10783
+        ok(#children >= 4 and #children <= 5)
+      else
+        eq(3, #children)
+      end
     end)
     -- Assert that nvim_get_proc() sees the children.
     for _, child_pid in ipairs(children) do


### PR DESCRIPTION
Debug flaky 'jobstop() kills entire process tree #6530'.

fix https://github.com/neovim/neovim/issues/10762
