### PR TITLE
TUI: do not use "starting" global mutated by main thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
                          -DCMAKE_TOOLCHAIN_FILE=$TRAVIS_BUILD_DIR/cmake/i386-linux-gnu.toolchain.cmake"
     # Environment variables for Clang sanitizers.
     - ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1:log_path=$LOG_DIR/asan"
-    - TSAN_OPTIONS="log_path=$LOG_DIR/tsan:suppressions=$TRAVIS_BUILD_DIR/src/.tsan-suppressions"
+    - TSAN_OPTIONS="log_path=$LOG_DIR/tsan"
     - UBSAN_OPTIONS="print_stacktrace=1 log_path=$LOG_DIR/ubsan"
     # Environment variables for Valgrind.
     - VALGRIND_LOG="$LOG_DIR/valgrind-%p.log"

--- a/src/.tsan-suppressions
+++ b/src/.tsan-suppressions
@@ -1,2 +1,0 @@
-# Ref: https://github.com/neovim/neovim/pull/10591#issuecomment-521248233
-race:starting

--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -63,7 +63,7 @@ Enable the sanitizer(s) via these environment variables:
     export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 
     export MSAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
-    export TSAN_OPTIONS="log_path=${HOME}/logs/tsan:suppressions=${NVIM_PATH}/src/.tsan-suppressions"
+    export TSAN_OPTIONS="log_path=${HOME}/logs/tsan"
 
 Logs will be written to `${HOME}/logs/*san.PID`.
 


### PR DESCRIPTION
Problem: TUI is accessing `starting` global set by main thread without synchronization
Solution: Use `mode_changed` which is first sent when startup is done.

Ref https://github.com/neovim/neovim/pull/10591#issuecomment-521295678