### PR TITLE
ci: AppVeyor: skip MSVC_32 for non-PR builds  [skip travis]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,17 @@ configuration:
 init:
 - ps: |
     # Pull requests: skip some build configurations to save time.
-    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
-      $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
-      Exit-AppVeyorBuild
-    }
-    # Non-PRs: skip MSVC_32 run for PRs already.
-    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_32)$') {
-      $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
-      Exit-AppVeyorBuild
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
+      if ($env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
+        $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
+        Exit-AppVeyorBuild
+      }
+    } else {
+      # Non-PRs: skip MSVC_32 run for PRs already.
+      if ($env:CONFIGURATION -match '^(MSVC_32)$') {
+        $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
+        Exit-AppVeyorBuild
+      }
     }
 # RDP
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,11 @@ init:
       $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
       Exit-AppVeyorBuild
     }
+    # Non-PRs: skip MSVC_32 run for PRs already.
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_32)$') {
+      $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
+      Exit-AppVeyorBuild
+    }
 # RDP
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 matrix:


### PR DESCRIPTION
It was run for the PR already, and we can save the ~25min it takes with
merged PRs then - given that there is only one parallel job on AppVeyor
this should help to reduce the queue size.