### PR TITLE
vim-patch:8.1.1852: timers test is flaky

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -286,6 +286,7 @@ let s:flaky_tests = [
       \ 'Test_quoteplus()',
       \ 'Test_quotestar()',
       \ 'Test_reltime()',
+      \ 'Test_repeat_many()',
       \ 'Test_repeat_three()',
       \ 'Test_terminal_composing_unicode()',
       \ 'Test_terminal_redir_file()',

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -48,7 +48,7 @@ func Test_repeat_many()
   endif
   sleep 200m
   call timer_stop(timer)
-  call assert_inrange((has('mac') ? 1 : 2), LoadAdjust(4), g:val)
+  call assert_inrange((has('mac') ? 1 : 2), LoadAdjust(5), g:val)
 endfunc
 
 func Test_with_partial_callback()


### PR DESCRIPTION
Problem:    Timers test is flaky.
Solution:   Accept a larger count.  Add test to list of flaky tests.
https://github.com/vim/vim/commit/7e6feb9eeb095ec424430ff4332c77f70372ce62