### PR TITLE
keymap: allow modifiers to multibyte chars, like <m-ä>

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -404,6 +404,9 @@ Mapping <kHome> will not work then.
 Note: If numlock is on, the |TUI| receives plain ASCII values, so
 mappings to <k0> - <k9> and <kPoint> will not work.
 
+Note: Nvim supports mapping multibyte chars with modifiers such as `<M-ä>`.
+Which combinations actually are usable depends on the terminal emulator or GUI.
+
 								*<>*
 Examples are often given in the <> notation.  Sometimes this is just to make
 clear what you need to type, but often it can be typed literally, e.g., with

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -604,7 +604,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
         // Anything accepted, like <C-?>.
         // <C-"> or <M-"> are not special in strings as " is
         // the string delimiter. With a backslash it works: <M-\">
-        if (end - bp > l && !(in_string && bp[1] == '"') && bp[2] == '>') {
+        if (end - bp > l && !(in_string && bp[1] == '"') && bp[l+1] == '>') {
           bp += l;
         } else if (end - bp > 2 && in_string && bp[1] == '\\'
                    && bp[2] == '"' && bp[3] == '>') {

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -103,6 +103,11 @@ describe('mappings', function()
     check_mapping('<kequal>','<kequal>')
     check_mapping('<KPEquals>','<kequal>')
   end)
+
+  it('support meta + multibyte char mapping', function()
+    add_mapping('<m-ä>', '<m-ä>')
+    check_mapping('<m-ä>', '<m-ä>')
+  end)
 end)
 
 describe('feeding large chunks of input with <Paste>', function()


### PR DESCRIPTION
Note: this might not work in most terminals, at least not without configuration. But we should allow it for GUI:s and the terminals that do.

It works with `xterm -xrm 'xterm*VT100.metaSendsEscape: true'` at least.