### PR TITLE
vim-patch:8.1.1854: now another timer test is flaky

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -288,6 +288,7 @@ let s:flaky_tests = [
       \ 'Test_reltime()',
       \ 'Test_repeat_many()',
       \ 'Test_repeat_three()',
+      \ 'Test_stop_all_in_callback()',
       \ 'Test_terminal_composing_unicode()',
       \ 'Test_terminal_redir_file()',
       \ 'Test_terminal_tmap()',


### PR DESCRIPTION
Missing 8.1.1855.