### PR TITLE
CI/OpenBSD: run old tests

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -33,5 +33,6 @@ tasks:
     ./bin/nvim --version
 - test: |
     export LC_CTYPE=en_US.UTF-8
-    cd neovim/build
-    cmake --build . --config Debug --target oldtest
+    cd neovim
+    # oldtests
+    gmake -C src/nvim/testdir NVIM_PRG=`pwd`/build/bin/nvim

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -33,6 +33,5 @@ tasks:
     ./bin/nvim --version
 - test: |
     export LC_CTYPE=en_US.UTF-8
-    cd neovim
-    # oldtests
-    gmake -C src/nvim/testdir NVIM_PRG=`pwd`/build/bin/nvim
+    cd neovim/build
+    cmake --build . --config Debug --target oldtest

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -34,5 +34,4 @@ tasks:
 - test: |
     export LC_CTYPE=en_US.UTF-8
     cd neovim
-    # oldtests
-    gmake -C src/nvim/testdir NVIM_PRG=`pwd`/build/bin/nvim
+    cmake --build . --config Debug --target oldtest

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -31,3 +31,8 @@ tasks:
     cmake -G Ninja ..
     cmake --build . --config Debug
     ./bin/nvim --version
+- test: |
+    export LC_CTYPE=en_US.UTF-8
+    cd neovim
+    # oldtests
+    gmake -C src/nvim/testdir NVIM_PRG=`pwd`/build/bin/nvim

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -34,4 +34,5 @@ tasks:
 - test: |
     export LC_CTYPE=en_US.UTF-8
     cd neovim
-    cmake --build . --config Debug --target oldtest
+    # oldtests
+    gmake -C src/nvim/testdir NVIM_PRG=`pwd`/build/bin/nvim

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1170,6 +1170,8 @@ func Test_libcall_libcallnr()
     else
       let libc = '/usr/lib/libc.so'
     endif
+  elseif system('uname -s') =~ 'OpenBSD'
+    let libc = 'libc.so'
   else
     " On Unix, libc.so can be in various places.
     " Interestingly, using an empty string for the 1st argument of libcall


### PR DESCRIPTION
This should enable oldtests for the sourcehut config.

FAO @justinmk 

On my OpenBSD-current machine, the oldtests currently fail like this:
```
From test_registers.vim:
Found errors in Test_display_registers():
function RunTheTest[37]..Test_display_registers line 12: Expected '\n--- Registers ---\n""   a\n"0   ba\n"1   b\n"a   b\n"q   ^Jfunction Test_yank_shows_register()^Jfunction Test_recording_esc_sequenc\n"-   a\nclipboard: error: No protocol specified\n".   8\n":   ls\n"%   file2\n"#   file1\n"/   bar\n"=   2*4' but got '\n--- Registers ---\n""   a\n"0   ba\n"1   b\n"a   b\n"q   ^Jfunction Test_yank_shows_register()^Jfunction Test_recording_esc_sequenc\n"-   a\n".   8\n":   ls\n"%   file2\n"#   file1\n"/   bar\n"=   2*4'

From test_alot.vim:
Found errors in Test_libcall_libcallnr():
Caught exception in Test_libcall_libcallnr(): Vim(call):dlerror = "File not found" @ function RunTheTest[37]..Test_libcall_libcallnr, line 30
TEST FAILURE
```

There's already a bug for this failure: #10420

Let's see if the same happens for OpenBSD-6.5...