### PR TITLE
multigrid: fixes

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -292,6 +292,8 @@ numerical highlight ids to the actual attributes.
 	`bold`:		bold text.
 	`underline`:	underlined text. The line has `special` color.
 	`undercurl`:	undercurled text. The curl has `special` color.
+	`blend`:	Blend level (0-100). Could be used by UIs to support
+			blending floating windows to the background.
 
 	For absent color keys the default color should be used. Don't store
 	the default value in the table, rather a sentinel value, so that

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -100,7 +100,7 @@ void raw_line(Integer grid, Integer row, Integer startcol,
 void event(char *name, Array args, bool *args_consumed)
   FUNC_API_NOEXPORT;
 
-void win_pos(Integer grid, Integer win, Integer startrow,
+void win_pos(Integer grid, Window win, Integer startrow,
              Integer startcol, Integer width, Integer height)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid,

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -233,6 +233,7 @@ int hl_get_underline(void)
           .rgb_fg_color = -1,
           .rgb_bg_color = -1,
           .rgb_sp_color = -1,
+          .hl_blend = -1,
       },
       .kind = kHlUI,
       .id1 = 0,
@@ -427,6 +428,8 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
   cattrs.rgb_bg_color = rgb_blend(ratio, battrs.rgb_bg_color,
                                   fattrs.rgb_bg_color);
 
+  cattrs.hl_blend = -1;  // blend property was consumed
+
   HlKind kind = *through ? kHlBlendThrough : kHlBlend;
   id = get_attr_entry((HlEntry){ .attr = cattrs, .kind = kind,
                                  .id1 = back_attr, .id2 = front_attr });
@@ -612,6 +615,10 @@ Dictionary hlattrs2dict(HlAttrs ae, bool use_rgb)
     if (cterm_normal_bg_color != ae.cterm_bg_color) {
       PUT(hl, "background", INTEGER_OBJ(ae.cterm_bg_color - 1));
     }
+  }
+
+  if (ae.hl_blend > -1) {
+      PUT(hl, "blend", INTEGER_OBJ(ae.hl_blend));
   }
 
   return hl;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -662,6 +662,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
         .rgb_fg_color = vt_fg,
         .rgb_bg_color = vt_bg,
         .rgb_sp_color = -1,
+        .hl_blend = -1,
       });
     }
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -4144,14 +4144,14 @@ describe('floating windows', function()
             [4:----------------------------------------]|
             [4:----------------------------------------]|
             :tabnew                                 |
-          ## grid 2
+          ## grid 2 (hidden)
             x                                       |
             {0:~                                       }|
             {0:~                                       }|
             {0:~                                       }|
             {0:~                                       }|
             {0:~                                       }|
-          ## grid 3
+          ## grid 3 (hidden)
             {1:y                   }|
             {2:~                   }|
           ## grid 4
@@ -4193,7 +4193,7 @@ describe('floating windows', function()
           ## grid 3
             {1:y                   }|
             {2:~                   }|
-          ## grid 4
+          ## grid 4 (hidden)
                                                     |
             {0:~                                       }|
             {0:~                                       }|
@@ -4223,13 +4223,13 @@ describe('floating windows', function()
             [4:----------------------------------------]|
             [4:----------------------------------------]|
             :tabnext                                |
-          ## grid 2
+          ## grid 2 (hidden)
             x                                       |
             {0:~                                       }|
             {0:~                                       }|
             {0:~                                       }|
             {0:~                                       }|
-          ## grid 3
+          ## grid 3 (hidden)
             {1:y                   }|
             {2:~                   }|
           ## grid 4
@@ -4267,7 +4267,7 @@ describe('floating windows', function()
             [4:----------------------------------------]|
             [4:----------------------------------------]|
             :tabnew                                 |
-          ## grid 2
+          ## grid 2 (hidden)
             x                                       |
             {0:~                                       }|
             {0:~                                       }|
@@ -4313,7 +4313,7 @@ describe('floating windows', function()
             {0:~                                                                }|
             {0:~                                                                }|
             {0:~                                                                }|
-          ## grid 4
+          ## grid 4 (hidden)
                                                     |
             {0:~                                       }|
             {0:~                                       }|
@@ -4333,7 +4333,7 @@ describe('floating windows', function()
             [4:----------------------------------------]|
             [4:----------------------------------------]|
             :tabnext                                |
-          ## grid 2
+          ## grid 2 (hidden)
             x                                       |
             {0:~                                       }|
             {0:~                                       }|

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -4365,7 +4365,11 @@ describe('floating windows', function()
         [5] = {foreground = tonumber('0x990000'), background = tonumber('0xfff1ff')},
         [6] = {foreground = tonumber('0x332533'), background = tonumber('0xfff1ff')},
         [7] = {background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0x0000d8')},
-        [8] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1}
+        [8] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1},
+        [9] = {background = Screen.colors.LightMagenta, blend=30},
+        [10] = {foreground = Screen.colors.Red, background = Screen.colors.LightMagenta, blend=0},
+        [11] = {foreground = Screen.colors.Red, background = Screen.colors.LightMagenta, blend=80},
+        [12] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1, blend=30},
       })
       insert([[
         Lorem ipsum dolor sit amet, consectetur
@@ -4445,9 +4449,9 @@ describe('floating windows', function()
           qui officia deserunt mollit anim id est           |
           laborum^.                                          |
         ## grid 4
-          {1:test           }|
-          {1:               }|
-          {1:popup    text  }|
+          {9:test           }|
+          {9:               }|
+          {9:popup    text  }|
         ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}, unchanged=true}
       else
         screen:expect([[
@@ -4487,9 +4491,9 @@ describe('floating windows', function()
           qui officia deserunt mollit anim id est           |
           laborum^.                                          |
         ## grid 4
-          {1:test           }|
-          {1:               }|
-          {4:popup    text}{1:  }|
+          {9:test           }|
+          {9:               }|
+          {10:popup    text}{9:  }|
         ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}}
       else
         screen:expect([[
@@ -4497,7 +4501,7 @@ describe('floating windows', function()
           exercitation ullamco laboris nisi ut aliquip ex   |
           ea co{2:test}{3:o consequat}. Duis aute irure dolor in    |
           repre{3:henderit in vol}uptate velit esse cillum      |
-          dolor{4:popup    text}{3:ul}la pariatur. Excepteur sint   |
+          dolor{10:popup    text}{3:ul}la pariatur. Excepteur sint   |
           occaecat cupidatat non proident, sunt in culpa    |
           qui officia deserunt mollit anim id est           |
           laborum^.                                          |
@@ -4528,9 +4532,9 @@ describe('floating windows', function()
           qui officia deserunt mollit anim id est           |
           laborum^.                                          |
         ## grid 4
-          {1:test           }|
-          {1:               }|
-          {4:popup    text}{1:  }|
+          {9:test           }|
+          {9:               }|
+          {11:popup    text}{9:  }|
         ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}, unchanged=true}
       else
         screen:expect([[
@@ -4570,9 +4574,9 @@ describe('floating windows', function()
           qui officia deserunt mollit anim id est           |
           laborum^.                                          |
         ## grid 4
-          {4:popup    text}{1:  }|
-          {8:~              }|
-          {8:~              }|
+          {11:popup    text}{9:  }|
+          {12:~              }|
+          {12:~              }|
         ]], float_pos={[4] = {{id = 1002}, "NW", 1, 2, 5, true}}}
       else
         meths.input_mouse('wheel', 'down', '', 0, 4, 7)
@@ -4672,7 +4676,7 @@ describe('floating windows', function()
         [2] = {foreground = Screen.colors.Grey0, background = tonumber('0xffcfff')},
         [3] = {bold = true, foreground = Screen.colors.Blue1},
         [4] = {background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0xb282ff')},
-        [5] = {background = Screen.colors.LightMagenta},
+        [5] = {background = Screen.colors.LightMagenta, blend=30},
       })
       if multigrid then
         screen:expect{grid=[[

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -1206,7 +1206,7 @@ describe('ext_multigrid', function()
     ]])
   end)
 
-  it('handles switich tabs', function()
+  it('handles switch tabs', function()
     command('vsp')
     screen:expect([[
     ## grid 1
@@ -1271,7 +1271,7 @@ describe('ext_multigrid', function()
       [4:-----------------------------------------------------]|
       {11:[No Name]                                            }|
                                                            |
-    ## grid 2
+    ## grid 2 (hidden)
                                 |
       {1:~                         }|
       {1:~                         }|
@@ -1284,7 +1284,7 @@ describe('ext_multigrid', function()
       {1:~                         }|
       {1:~                         }|
       {1:~                         }|
-    ## grid 3
+    ## grid 3 (hidden)
                                 |
       {1:~                         }|
       {1:~                         }|
@@ -1328,7 +1328,7 @@ describe('ext_multigrid', function()
       [4:-----------------------------------------------------]|
       {12:[No Name]                                            }|
                                                            |
-    ## grid 2
+    ## grid 2 (hidden)
                                 |
       {1:~                         }|
       {1:~                         }|
@@ -1341,7 +1341,7 @@ describe('ext_multigrid', function()
       {1:~                         }|
       {1:~                         }|
       {1:~                         }|
-    ## grid 3
+    ## grid 3 (hidden)
                                 |
       {1:~                         }|
       {1:~                         }|
@@ -1409,13 +1409,13 @@ describe('ext_multigrid', function()
       {1:~                         }|
       {1:~                         }|
       {1:~                         }|
-    ## grid 4
+    ## grid 4 (hidden)
                                                            |
       {1:~                                                    }|
       {1:~                                                    }|
       {1:~                                                    }|
       {1:~                                                    }|
-    ## grid 5
+    ## grid 5 (hidden)
                                                            |
       {1:~                                                    }|
       {1:~                                                    }|
@@ -1440,7 +1440,7 @@ describe('ext_multigrid', function()
       [4:-----------------------------------------------------]|
       {12:[No Name]                                            }|
                                                            |
-    ## grid 2
+    ## grid 2 (hidden)
                                 |
       {1:~                         }|
       {1:~                         }|
@@ -1452,7 +1452,7 @@ describe('ext_multigrid', function()
       {1:~                         }|
       {1:~                         }|
       {1:~                         }|
-    ## grid 3
+    ## grid 3 (hidden)
                                 |
       {1:~                         }|
       {1:~                         }|

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -76,7 +76,7 @@ describe('ext_multigrid', function()
 
   it('positions windows correctly', function()
     command('vsplit')
-    screen:expect([[
+    screen:expect{grid=[[
     ## grid 1
       [3:--------------------------]{12:│}[2:--------------------------]|
       [3:--------------------------]{12:│}[2:--------------------------]|
@@ -118,15 +118,15 @@ describe('ext_multigrid', function()
       {1:~                         }|
       {1:~                         }|
       {1:~                         }|
-    ]], nil, nil, function()
+    ]], condition=function()
       eq({
-        [2] = { win = 1000, startrow = 0, startcol = 27, width = 26, height = 12 },
-        [3] = { win = 1001, startrow = 0, startcol =  0, width = 26, height = 12 }
+        [2] = { win = {id=1000}, startrow = 0, startcol = 27, width = 26, height = 12 },
+        [3] = { win = {id=1001}, startrow = 0, startcol =  0, width = 26, height = 12 }
       }, screen.win_position)
-    end)
+    end}
     command('wincmd l')
     command('split')
-    screen:expect([[
+    screen:expect{grid=[[
     ## grid 1
       [3:--------------------------]{12:│}[4:--------------------------]|
       [3:--------------------------]{12:│}[4:--------------------------]|
@@ -168,16 +168,16 @@ describe('ext_multigrid', function()
       {1:~                         }|
       {1:~                         }|
       {1:~                         }|
-    ]], nil, nil, function()
+    ]], condition=function()
       eq({
-        [2] = { win = 1000, startrow = 7, startcol = 27, width = 26, height =  5 },
-        [3] = { win = 1001, startrow = 0, startcol =  0, width = 26, height = 12 },
-        [4] = { win = 1002, startrow = 0, startcol = 27, width = 26, height =  6 }
+        [2] = { win = {id=1000}, startrow = 7, startcol = 27, width = 26, height =  5 },
+        [3] = { win = {id=1001}, startrow = 0, startcol =  0, width = 26, height = 12 },
+        [4] = { win = {id=1002}, startrow = 0, startcol = 27, width = 26, height =  6 }
       }, screen.win_position)
-    end)
+    end}
     command('wincmd h')
     command('q')
-    screen:expect([[
+    screen:expect{grid=[[
     ## grid 1
       [4:-----------------------------------------------------]|
       [4:-----------------------------------------------------]|
@@ -206,12 +206,12 @@ describe('ext_multigrid', function()
       {1:~                                                    }|
       {1:~                                                    }|
       {1:~                                                    }|
-    ]], nil, nil, function()
+    ]], condition=function()
       eq({
-        [2] = { win = 1000, startrow = 7, startcol = 0, width = 53, height =  5 },
-        [4] = { win = 1002, startrow = 0, startcol = 0, width = 53, height =  6 }
+        [2] = { win = {id=1000}, startrow = 7, startcol = 0, width = 53, height =  5 },
+        [4] = { win = {id=1002}, startrow = 0, startcol = 0, width = 53, height =  6 }
       }, screen.win_position)
-    end)
+    end}
   end)
 
   describe('split', function ()

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1644,6 +1644,7 @@ describe('builtin popupmenu', function()
       [42] = {foreground = tonumber('0x0c0c0c'), background = tonumber('0xe5a8e5')},
       [43] = {background = tonumber('0x7f5d7f'), bold = true, foreground = tonumber('0x3f3f3f')},
       [44] = {foreground = tonumber('0x3f3f3f'), background = tonumber('0x7f5d7f')},
+      [45] = {background = Screen.colors.WebGray, blend=0},
     })
     command('syntax on')
     command('set mouse=a')
@@ -1761,7 +1762,7 @@ describe('builtin popupmenu', function()
       Lorem ipsum d{1:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla incididunt^                                          |
-      incidid{22: incididunt     }{27: }d{1:ol}ore magna aliqua.                |
+      incidid{45: incididunt     }{27: }d{1:ol}ore magna aliqua.                |
       Ut enim{28: }{29:ut}{28: minim veniam}{25:,} quis nostrud                       |
       exercit{28:a}{29:labore}{28:llamco la}{25:b}oris nisi ut aliquip ex             |
       {2:[No Nam}{30:e}{43:et}{30:[+]          }{32: }{2:                                    }|

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1496,7 +1496,7 @@ function Screen:_equal_attrs(a, b)
        a.underline == b.underline and a.undercurl == b.undercurl and
        a.italic == b.italic and a.reverse == b.reverse and
        a.foreground == b.foreground and a.background == b.background and
-       a.special == b.special
+       a.special == b.special and a.blend == b.blend
 end
 
 function Screen:_equal_info(a, b)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1212,7 +1212,11 @@ function Screen:render(headers, attr_state, preview)
   local rv = {}
   for igrid,grid in pairs(self._grids) do
     if headers then
-      table.insert(rv, "## grid "..igrid)
+      local suffix = ""
+      if igrid > 1 and self.win_position[igrid] == nil and self.float_pos[igrid] == nil then
+        suffix = " (hidden)"
+      end
+      table.insert(rv, "## grid "..igrid..suffix)
     end
     for i = 1, grid.height do
       local cursor = self._cursor.grid == igrid and self._cursor.row == i

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -316,9 +316,10 @@ local ext_keys = {
 -- cmdline_block:  Expected ext_cmdline block (for function definitions)
 -- wildmenu_items: Expected items for ext_wildmenu
 -- wildmenu_pos:   Expected position for ext_wildmenu
-function Screen:expect(expected, attr_ids, attr_ignore)
+function Screen:expect(expected, attr_ids, attr_ignore, ...)
   local grid, condition = nil, nil
   local expected_rows = {}
+  assert(next({...}) == nil, "invalid args to expect()")
   if type(expected) == "table" then
     assert(not (attr_ids ~= nil or attr_ignore ~= nil))
     local is_key = {grid=true, attr_ids=true, attr_ignore=true, condition=true,


### PR DESCRIPTION
- `win_pos` had inconsistent window type compared to `win_float_pos`. Also tests were broken.
- Tests for `win_hide` were incomplete
- Blending information missing from UI protocol. Add `blend` key to `hl_attr_define`, so that multigrid UI:s can support `winblend`.
