### PR TITLE
CI/AppVeyor: revert "skip MSVC_32 for non-PR" [skip travis]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,17 +14,9 @@ configuration:
 init:
 - ps: |
     # Pull requests: skip some build configurations to save time.
-    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
-      if ($env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
-        $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
-        Exit-AppVeyorBuild
-      }
-    } else {
-      # Non-PRs: skip MSVC_32 run for PRs already.
-      if ($env:CONFIGURATION -match '^(MSVC_32)$') {
-        $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
-        Exit-AppVeyorBuild
-      }
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and $env:CONFIGURATION -match '^(MSVC_64|MINGW_32)$') {
+      $env:APPVEYOR_CACHE_SKIP_SAVE = "true"
+      Exit-AppVeyorBuild
     }
 # RDP
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
Reverts neovim/neovim#10786

The nightly release job is failing:
https://travis-ci.org/neovim/bot-ci/builds/569687794

- We need the MSVC artifact on master so that our nightly job can publish it.
- Saving time on master is low-priority because most CI activity is from PRs.