### PR TITLE
[RDY] vim-patch:8.1.0888

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4183,7 +4183,7 @@ static int ins_compl_get_exp(pos_T *ini)
                 if (tmp_ptr - ptr >= IOSIZE - len) {
                   tmp_ptr = ptr + IOSIZE - len - 1;
                 }
-                snprintf((char *)(IObuff + len), tmp_ptr - ptr, "%s", ptr);
+                STRLCPY(IObuff + len, ptr, IOSIZE - len);
                 len += (int)(tmp_ptr - ptr);
                 flags |= CONT_S_IPOS;
               }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4183,7 +4183,7 @@ static int ins_compl_get_exp(pos_T *ini)
                 if (tmp_ptr - ptr >= IOSIZE - len) {
                   tmp_ptr = ptr + IOSIZE - len - 1;
                 }
-                STRNCPY(IObuff + len, ptr, tmp_ptr - ptr);
+                snprintf((char *)(IObuff + len), tmp_ptr - ptr, "%s", ptr);
                 len += (int)(tmp_ptr - ptr);
                 flags |= CONT_S_IPOS;
               }

--- a/src/nvim/testdir/test_let.vim
+++ b/src/nvim/testdir/test_let.vim
@@ -25,3 +25,118 @@ func Test_let()
   let s = "\na                     #1\nb                     #2"
   call assert_equal(s, out)
 endfunc
+
+func s:set_arg1(a) abort
+  let a:a = 1
+endfunction
+
+func s:set_arg2(a) abort
+  let a:b = 1
+endfunction
+
+func s:set_arg3(a) abort
+  let b = a:
+  let b['a'] = 1
+endfunction
+
+func s:set_arg4(a) abort
+  let b = a:
+  let b['a'] = 1
+endfunction
+
+func s:set_arg5(a) abort
+  let b = a:
+  let b['a'][0] = 1
+endfunction
+
+func s:set_arg6(a) abort
+  let a:a[0] = 1
+endfunction
+
+func s:set_arg7(a) abort
+  call extend(a:, {'a': 1})
+endfunction
+
+func s:set_arg8(a) abort
+  call extend(a:, {'b': 1})
+endfunction
+
+func s:set_arg9(a) abort
+  let a:['b'] = 1
+endfunction
+
+func s:set_arg10(a) abort
+  let b = a:
+  call extend(b, {'a': 1})
+endfunction
+
+func s:set_arg11(a) abort
+  let b = a:
+  call extend(b, {'b': 1})
+endfunction
+
+func s:set_arg12(a) abort
+  let b = a:
+  let b['b'] = 1
+endfunction
+
+func Test_let_arg_fail()
+  call assert_fails('call s:set_arg1(1)', 'E46:')
+  call assert_fails('call s:set_arg2(1)', 'E461:')
+  call assert_fails('call s:set_arg3(1)', 'E46:')
+  call assert_fails('call s:set_arg4(1)', 'E46:')
+  call assert_fails('call s:set_arg5(1)', 'E46:')
+  call s:set_arg6([0])
+  call assert_fails('call s:set_arg7(1)', 'E742:')
+  call assert_fails('call s:set_arg8(1)', 'E742:')
+  call assert_fails('call s:set_arg9(1)', 'E461:')
+  call assert_fails('call s:set_arg10(1)', 'E742:')
+  call assert_fails('call s:set_arg11(1)', 'E742:')
+  call assert_fails('call s:set_arg12(1)', 'E461:')
+endfunction
+
+func s:set_varg1(...) abort
+  let a:000 = []
+endfunction
+
+func s:set_varg2(...) abort
+  let a:000[0] = 1
+endfunction
+
+func s:set_varg3(...) abort
+  let a:000 += [1]
+endfunction
+
+func s:set_varg4(...) abort
+  call add(a:000, 1)
+endfunction
+
+func s:set_varg5(...) abort
+  let a:000[0][0] = 1
+endfunction
+
+func s:set_varg6(...) abort
+  let b = a:000
+  let b[0] = 1
+endfunction
+
+func s:set_varg7(...) abort
+  let b = a:000
+  call add(b, 1)
+endfunction
+
+func s:set_varg8(...) abort
+  let b = a:000
+  let b[0][0] = 1
+endfunction
+
+func Test_let_varg_fail()
+  call assert_fails('call s:set_varg1(1)', 'E46:')
+  call assert_fails('call s:set_varg2(1)', 'E742:')
+  call assert_fails('call s:set_varg3(1)', 'E46:')
+  call assert_fails('call s:set_varg4(1)', 'E742:')
+  call s:set_varg5([0])
+  call assert_fails('call s:set_varg6(1)', 'E742:')
+  call assert_fails('call s:set_varg7(1)', 'E742:')
+  call s:set_varg8([0])
+endfunction

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -500,17 +500,20 @@ endfunc
 
 " No remove() of write-protected scope-level variable
 func! Tfunc(this_is_a_long_parameter_name)
-  call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E795')
+  call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E742')
 endfun
 func Test_dict_scope_var_remove()
   call Tfunc('testval')
 endfunc
 
 " No extend() of write-protected scope-level variable
+func Test_dict_scope_var_extend()
+  call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
+endfunc
 func! Tfunc(this_is_a_long_parameter_name)
   call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
 endfunc
-func Test_dict_scope_var_extend()
+func Test_dict_scope_var_extend_overwrite()
   call Tfunc('testval')
 endfunc
 
@@ -698,4 +701,76 @@ func Test_listdict_extend()
 
   call assert_fails("call extend([1, 2], 1)", 'E712:')
   call assert_fails("call extend([1, 2], {})", 'E712:')
+endfunc
+
+func s:check_scope_dict(x, fixed)
+  func s:gen_cmd(cmd, x)
+    return substitute(a:cmd, '\<x\ze:', a:x, 'g')
+  endfunc
+
+  let cmd = s:gen_cmd('let x:foo = 1', a:x)
+  if a:fixed
+    call assert_fails(cmd, 'E461')
+  else
+    exe cmd
+    exe s:gen_cmd('call assert_equal(1, x:foo)', a:x)
+  endif
+
+  let cmd = s:gen_cmd('let x:["bar"] = 2', a:x)
+  if a:fixed
+    call assert_fails(cmd, 'E461')
+  else
+    exe cmd
+    exe s:gen_cmd('call assert_equal(2, x:bar)', a:x)
+  endif
+
+  let cmd = s:gen_cmd('call extend(x:, {"baz": 3})', a:x)
+  if a:fixed
+    call assert_fails(cmd, 'E742')
+  else
+    exe cmd
+    exe s:gen_cmd('call assert_equal(3, x:baz)', a:x)
+  endif
+
+  if a:fixed
+    if a:x ==# 'a'
+      call assert_fails('unlet a:x', 'E795')
+      call assert_fails('call remove(a:, "x")', 'E742')
+    elseif a:x ==# 'v'
+      call assert_fails('unlet v:count', 'E795')
+      call assert_fails('call remove(v:, "count")', 'E742')
+    endif
+  else
+    exe s:gen_cmd('unlet x:foo', a:x)
+    exe s:gen_cmd('unlet x:bar', a:x)
+    exe s:gen_cmd('call remove(x:, "baz")', a:x)
+  endif
+
+  delfunc s:gen_cmd
+endfunc
+
+func Test_scope_dict()
+  " Test for g:
+  call s:check_scope_dict('g', v:false)
+
+  " Test for s:
+  call s:check_scope_dict('s', v:false)
+
+  " Test for l:
+  call s:check_scope_dict('l', v:false)
+
+  " Test for a:
+  call s:check_scope_dict('a', v:true)
+
+  " Test for b:
+  call s:check_scope_dict('b', v:false)
+
+  " Test for w:
+  call s:check_scope_dict('w', v:false)
+
+  " Test for t:
+  call s:check_scope_dict('t', v:false)
+
+  " Test for v:
+  call s:check_scope_dict('v', v:true)
 endfunc

--- a/test/functional/legacy/055_list_and_dict_types_spec.lua
+++ b/test/functional/legacy/055_list_and_dict_types_spec.lua
@@ -666,7 +666,7 @@ describe('list and dictionary types', function()
       Vim(put):E741: 
       {'a': 99, 'b': 100}
       No remove() of write-protected scope-level variable:
-      Vim(put):E795: 
+      Vim(put):E742: 
       No extend() of write-protected scope-level variable:
       Vim(put):E742: 
       No :unlet of variable in locked scope:


### PR DESCRIPTION
#### vim-patch:8.1.0888: the a: dict is not immutable as documented

Problem:    The a: dict is not immutable as documented.
Solution:   Make the a:dict immutable, add a test. (Ozaki Kiichi, Yasuhiro
            Matsumoto, closes vim/vim#3929)
https://github.com/vim/vim/commit/31b816042fca879b11965ddd75287732563ba698