### PR TITLE
[RDY] test: Fix problem of breaking user's viminfo

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -101,6 +101,9 @@ test1.out: $(NVIM_PRG)
 $(SCRIPTS): $(NVIM_PRG) test1.out
 
 NO_PLUGINS = --noplugin --headless
+# In vim, if the -u command line option is specified, compatible is turned on
+# and viminfo is not read. Unlike vim, neovim reads viminfo and requires the
+# -i command line option.
 NO_INITS = -U NONE -i viminfo $(NO_PLUGINS)
 
 # TODO: find a way to avoid changing the distributed files.

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -101,7 +101,7 @@ test1.out: $(NVIM_PRG)
 $(SCRIPTS): $(NVIM_PRG) test1.out
 
 NO_PLUGINS = --noplugin --headless
-NO_INITS = -U NONE $(NO_PLUGINS)
+NO_INITS = -U NONE -i viminfo $(NO_PLUGINS)
 
 # TODO: find a way to avoid changing the distributed files.
 fixff:

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -104,13 +104,13 @@ NO_PLUGINS = --noplugin --headless
 # In vim, if the -u command line option is specified, compatible is turned on
 # and viminfo is not read. Unlike vim, neovim reads viminfo and requires the
 # -i command line option.
-NO_INITS = -U NONE -i viminfo $(NO_PLUGINS)
+NO_INITS = -U NONE -i NONE $(NO_PLUGINS)
 
 # TODO: find a way to avoid changing the distributed files.
 fixff:
-	-$(NVIM_PRG) -u unix.vim $(NO_INITS) "+argdo set ff=dos|upd" +q \
+	-$(NVIM_PRG) $(NO_INITS) -u unix.vim "+argdo set ff=dos|upd" +q \
 	  *.in *.ok
-	-$(NVIM_PRG) -u unix.vim $(NO_INITS) "+argdo set ff=dos|upd" +q \
+	-$(NVIM_PRG) $(NO_INITS) -u unix.vim "+argdo set ff=dos|upd" +q \
 	  dotest.in
 
 RM_ON_RUN   := test.out X* viminfo


### PR DESCRIPTION
`vim` turns on `compatible` as a side effect of using the `-u` command line option. As a result, `viminfo` is not used. But that is not the case with `neovim`. `neovim` requires the `-i` command line option to avoid breaking user's `viminfo`.