### PR TITLE
RFC/WIP: v:maxechospace

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -395,6 +395,7 @@ static struct vimvar {
   VV(VV_OP,             "operator",         VAR_STRING, VV_RO),
   VV(VV_SEARCHFORWARD,  "searchforward",    VAR_NUMBER, 0),
   VV(VV_HLSEARCH,       "hlsearch",         VAR_NUMBER, 0),
+  VV(VV_MAXECHOSPACE,   "maxechospace",     VAR_NUMBER, 0),
   VV(VV_OLDFILES,       "oldfiles",         VAR_LIST, 0),
   VV(VV_WINDOWID,       "windowid",         VAR_NUMBER, VV_RO_SBX),
   VV(VV_PROGPATH,       "progpath",         VAR_STRING, VV_RO),
@@ -621,6 +622,7 @@ void eval_init(void)
   set_vim_var_nr(VV_STDERR,   CHAN_STDERR);
   set_vim_var_nr(VV_SEARCHFORWARD, 1L);
   set_vim_var_nr(VV_HLSEARCH, 1L);
+  set_vim_var_nr(VV_MAXECHOSPACE, sc_col);
   set_vim_var_nr(VV_COUNT1, 1);
   set_vim_var_nr(VV_TYPE_NUMBER, VAR_TYPE_NUMBER);
   set_vim_var_nr(VV_TYPE_STRING, VAR_TYPE_STRING);

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -91,6 +91,7 @@ typedef enum {
     VV_OP,
     VV_SEARCHFORWARD,
     VV_HLSEARCH,
+    VV_MAXECHOSPACE,
     VV_OLDFILES,
     VV_WINDOWID,
     VV_PROGPATH,

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5456,6 +5456,7 @@ void comp_col(void)
   if (ru_col <= 0) {
     ru_col = 1;
   }
+  set_vim_var_nr(VV_MAXECHOSPACE, sc_col - 1);  // -1 for newline being added
 }
 
 // Unset local option value, similar to ":set opt<".


### PR DESCRIPTION
Allows for:
```vim
let toolong = repeat("a", &columns * 2)
echom printf(printf('%%.%ds', v:maxechospace-3).'...', toolong)
```
(avoiding wait-enter prompt)

TODO:

- [ ] doc
- [ ] include space for 'showcmd' (10 cellse)?
      (could be done (mostly at least) by adjusting
      [msg_check](https://github.com/neovim/neovim/blob/3223dedfc/src/nvim/message.c#L2803-L2812))

Ref: https://github.com/vim/vim/issues/4732