### PR TITLE
vim-patch:8.1.1587: redraw problem when sign icons in the number column

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4095,8 +4095,20 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
       curbuf->b_p_iminsert = B_IMODE_NONE;
       curbuf->b_p_imsearch = B_IMODE_USE_INSERT;
     }
+  } else if (((int *)varp == &curwin->w_p_nu
+              || (int *)varp == &curwin->w_p_rnu)
+             && (*curwin->w_p_scl == 'n' && *(curwin->w_p_scl + 1) == 'u')
+             && curbuf->b_signlist != NULL) {
+    // If the 'number' or 'relativenumber' options are modified and
+    // 'signcolumn' is set to 'number', then clear the screen for a full
+    // refresh. Otherwise the sign icons are not displayed properly in the
+    // number column.  If the 'number' option is set and only the
+    // 'relativenumber' option is toggled, then don't refresh the screen
+    // (optimization).
+    if (!(curwin->w_p_nu && ((int *)varp == &curwin->w_p_rnu))) {
+      redraw_all_later(CLEAR);
+    }
   }
-
 
   /*
    * End of handling side effects for bool options.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2223,7 +2223,7 @@ return {
       type='string', scope={'window'},
       vi_def=true,
       alloced=true,
-      redraw={'current_window'},
+      redraw={'everything'},
       defaults={if_true={vi="auto"}}
     },
     {


### PR DESCRIPTION
Problem:    Redraw problem when sign icons in the number column.
Solution:   Clear and redraw when changing related options.  Right aligh the
            sign icon in the GUI. (Yegappan Lakshmanan, closes vim/vim#4578)
https://github.com/vim/vim/commit/2b044ffb5ada77e6fa89779d6532ea9fae3fe029

vim-patch:8.1.1910: redrawing too much when toggling 'relativenumber'

Problem:    Redrawing too much when toggling 'relativenumber'.
Solution:   Only clear when 'signcolumn' is set to "number". (Yegappan
            Lakshmanan, closes vim/vim#4852)
https://github.com/vim/vim/commit/448262176b382c63bd2faa9a1354670a4eede36b