### PR TITLE
vim-patch:8.0.1236

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11241,6 +11241,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "mac",
     "macunix",
     "osx",
+    "osxdarwin",
 #endif
     "menu",
     "mksession",

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -109,7 +109,7 @@
 // MB_COPY_CHAR(f, t): copy one char from "f" to "t" and advance the pointers.
 // PTR2CHAR(): get character from pointer.
 
-// Get the length of the character p points to
+// Get the length of the character p points to, including composing chars.
 # define MB_PTR2LEN(p)          mb_ptr2len(p)
 // Advance multi-byte pointer, skip over composing chars.
 # define MB_PTR_ADV(p)      (p += mb_ptr2len((char_u *)p))


### PR DESCRIPTION
Stopped reading the patch midway. Mostly `#ifdef` changes that don't apply to neovim since `mac` and `macunix` are treated the same.

How flaky is the mac build now?