### PR TITLE
vim-patch:7.4.1407,8.1.1111

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2189,6 +2189,8 @@ insert({list}, {item} [, {idx}])
 				List	insert {item} in {list} [before {idx}]
 invert({expr})			Number  bitwise invert
 isdirectory({directory})	Number	|TRUE| if {directory} is a directory
+isinf({expr})			Number	determine if {expr} is infinity value
+					(positive or negative)
 islocked({expr})		Number	|TRUE| if {expr} is locked
 isnan({expr})			Number	|TRUE| if {expr} is NaN
 id({expr})			String	identifier of the container
@@ -5284,6 +5286,14 @@ isdirectory({directory})				*isdirectory()*
 		with the name {directory} exists.  If {directory} doesn't
 		exist, or isn't a directory, the result is |FALSE|.  {directory}
 		is any expression, which is used as a String.
+
+isinf({expr})						*isinf()*
+		Return 1 if {expr} is a positive infinity, or -1 a negative
+		infinity, otherwise 0. >
+			:echo isinf(1.0 / 0.0)
+<			1 >
+			:echo isinf(-1.0 / 0.0)
+<			-1
 
 islocked({expr})					*islocked()* *E786*
 		The result is a Number, which is |TRUE| when {expr} is the

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2190,6 +2190,7 @@ insert({list}, {item} [, {idx}])
 invert({expr})			Number  bitwise invert
 isdirectory({directory})	Number	|TRUE| if {directory} is a directory
 islocked({expr})		Number	|TRUE| if {expr} is locked
+isnan({expr})			Number	|TRUE| if {expr} is NaN
 id({expr})			String	identifier of the container
 items({dict})			List	key-value pairs in {dict}
 jobpid({id})			Number	Returns pid of a job.
@@ -5319,6 +5320,10 @@ items({dict})						*items()*
 		entry and the value of this entry.  The |List| is in arbitrary
 		order.
 
+isnan({expr})						*isnan()*
+		Return |TRUE| if {expr} is a float with value NaN. >
+			echo isnan(0.0 / 0.0)
+<			1
 
 jobpid({job})						*jobpid()*
 		Return the PID (process id) of |job-id| {job}.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -47,6 +47,7 @@
 #include "nvim/indent_c.h"
 #include "nvim/indent.h"
 #include "nvim/mark.h"
+#include "nvim/math.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
@@ -12028,6 +12029,12 @@ static void f_islocked(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   clear_lval(&lv);
 }
 
+// "isnan()" function
+static void f_isnan(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  rettv->vval.v_number = argvars[0].v_type == VAR_FLOAT
+    && xisnan(argvars[0].vval.v_float);
+}
 
 /// Turn a dictionary into a list
 ///

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11276,7 +11276,6 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 #endif
     "tablineat",
     "tag_binary",
-    "tag_old_static",
     "termguicolors",
     "termresponse",
     "textobjects",
@@ -12027,6 +12026,15 @@ static void f_islocked(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   clear_lval(&lv);
+}
+
+// "isinf()" function
+static void f_isinf(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  if (argvars[0].v_type == VAR_FLOAT
+      && xisinf(argvars[0].vval.v_float)) {
+    rettv->vval.v_number = argvars[0].vval.v_float > 0.0 ? 1 : -1;
+  }
 }
 
 // "isnan()" function

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -189,6 +189,7 @@ return {
     insert={args={2, 3}},
     invert={args=1},
     isdirectory={args=1},
+    isinf={args=1},
     islocked={args=1},
     isnan={args=1},
     id={args=1},

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -190,6 +190,7 @@ return {
     invert={args=1},
     isdirectory={args=1},
     islocked={args=1},
+    isnan={args=1},
     id={args=1},
     items={args=1},
     jobclose={args={1, 2}, func="f_chanclose"},

--- a/src/nvim/testdir/test_float_func.vim
+++ b/src/nvim/testdir/test_float_func.vim
@@ -288,13 +288,24 @@ func Test_trunc()
   call assert_fails("call trunc('')", 'E808:')
 endfunc
 
+func Test_isinf()
+  call assert_equal(1, isinf(1.0/0.0))
+  call assert_equal(-1, isinf(-1.0/0.0))
+  call assert_false(isinf(1.0))
+  call assert_false(isinf(0.0/0.0))
+  call assert_false(isinf('a'))
+  call assert_false(isinf([]))
+  call assert_false(isinf({}))
+endfunc
+
 func Test_isnan()
-  call assert_equal(0, isnan(1.0))
-  call assert_equal(1, isnan(0.0/0.0))
-  call assert_equal(0, isnan(1.0/0.0))
-  call assert_equal(0, isnan('a'))
-  call assert_equal(0, isnan([]))
-  call assert_equal(0, isnan({}))
+  call assert_true(isnan(0.0/0.0))
+  call assert_false(isnan(1.0))
+  call assert_false(isnan(1.0/0.0))
+  call assert_false(isnan(-1.0/0.0))
+  call assert_false(isnan('a'))
+  call assert_false(isnan([]))
+  call assert_false(isnan({}))
 endfunc
 
 " This was converted from test65

--- a/src/nvim/testdir/test_float_func.vim
+++ b/src/nvim/testdir/test_float_func.vim
@@ -289,7 +289,6 @@ func Test_trunc()
 endfunc
 
 func Test_isnan()
-  throw 'skipped: Nvim does not support isnan()'
   call assert_equal(0, isnan(1.0))
   call assert_equal(1, isnan(0.0/0.0))
   call assert_equal(0, isnan(1.0/0.0))


### PR DESCRIPTION
Why is vim-patch:7.4.1407 marked N/A in https://github.com/neovim/neovim/pull/4301? Noticed this while checking https://github.com/lifepillar/vim-colortemplate/blob/master/autoload/colortemplate.vim.