### PR TITLE
general-purpose modal win; implement interactive :! using modal terminal

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -542,9 +542,9 @@ void nvim_win_close(Window window, Boolean force, Error *err)
     return;
   }
 
-  if (cmdwin_type != 0) {
+  if (modal_active()) {
     if (win == curwin) {
-      cmdwin_result = Ctrl_C;
+      modal_result = Ctrl_C;
     } else {
       api_set_error(err, kErrorTypeException, "%s", _(e_cmdwin));
     }

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -626,8 +626,8 @@ static void channel_process_exit_cb(Process *proc, int status, void *data)
 {
   Channel *chan = data;
   if (chan->term) {
-    char msg[sizeof("\r\n[Process exited ]") + NUMBUFLEN];
-    snprintf(msg, sizeof msg, "\r\n[Process exited %d]", proc->status);
+    char msg[sizeof("\r\nexit status . Press ENTER to continue.") + NUMBUFLEN];
+    snprintf(msg, sizeof msg, "\r\nExit status %d. Press ENTER to continue.", proc->status);
     terminal_close(chan->term, msg);
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -808,9 +808,10 @@ static int insert_handle_key(InsertState *s)
     FALLTHROUGH;
 
   case Ctrl_C:        // End input mode
-    if (s->c == Ctrl_C && cmdwin_type != 0) {
+    // TODO: also for modal() ??
+    if (s->c == Ctrl_C && cmdwin_active()) {
       // Close the cmdline window. */
-      cmdwin_result = K_IGNORE;
+      modal_result = K_IGNORE;
       got_int = false;         // don't stop executing autocommands et al
       s->nomove = true;
       return 0;  // exit insert mode
@@ -1136,9 +1137,10 @@ check_pum:
       }
       break;
     }
-    if (cmdwin_type != 0) {
+    // TODO: also for modal()?
+    if (cmdwin_active()) {
       // Execute the command in the cmdline window.
-      cmdwin_result = CAR;
+      modal_result = CAR;
       return 0;
     }
     if (!ins_eol(s->c) && !p_im) {
@@ -3589,8 +3591,8 @@ static bool ins_compl_prep(int c)
       }
 
       // Avoid the popup menu remains displayed when leaving the
-      // command line window.
-      if (c == Ctrl_C && cmdwin_type != 0) {
+      // modal window.
+      if (c == Ctrl_C && modal_active()) {
         update_screen(0);
       }
 
@@ -6108,7 +6110,7 @@ comp_textwidth (
     /* The width is the window width minus 'wrapmargin' minus all the
      * things that add to the margin. */
     textwidth = curwin->w_width_inner - curbuf->b_p_wm;
-    if (cmdwin_type != 0) {
+    if (cmdwin_active()) {
       textwidth -= 1;
     }
     textwidth -= curwin->w_p_fdc;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10081,7 +10081,7 @@ static void f_getcmdwintype(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
   rettv->vval.v_string = xmallocz(1);
-  rettv->vval.v_string[0] = cmdwin_type;
+  rettv->vval.v_string[0] = cmdwin_active() ? cmdwin_firstc : 0;
 }
 
 // "getcompletion()" function

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1689,12 +1689,6 @@ return {
     func='ex_mkrc',
   },
   {
-    command='modal',
-    flags=bit.bor(BANG, FILES, CMDWIN),
-    addr_type=ADDR_LINES,
-    func='ex_modal',
-  },
-  {
     command='mode',
     flags=bit.bor(WORD1, TRLBAR, CMDWIN),
     addr_type=ADDR_LINES,
@@ -3215,6 +3209,13 @@ return {
   {
     command='!',
     enum='CMD_bang',
+    flags=bit.bor(RANGE, WHOLEFOLD, BANG, FILES, CMDWIN),
+    addr_type=ADDR_LINES,
+    func='ex_modal',
+  },
+  {
+    command='oldbang',
+    enum='CMD_oldbang',
     flags=bit.bor(RANGE, WHOLEFOLD, BANG, FILES, CMDWIN),
     addr_type=ADDR_LINES,
     func='ex_bang',

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1689,6 +1689,12 @@ return {
     func='ex_mkrc',
   },
   {
+    command='modal',
+    flags=bit.bor(BANG, FILES, CMDWIN),
+    addr_type=ADDR_LINES,
+    func='ex_modal',
+  },
+  {
     command='mode',
     flags=bit.bor(WORD1, TRLBAR, CMDWIN),
     addr_type=ADDR_LINES,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6052,8 +6052,8 @@ static bool before_quit_autocmds(win_T *wp, bool quit_all, int forceit)
 // ":{nr}quit": quit window {nr}
 static void ex_quit(exarg_T *eap)
 {
-  if (cmdwin_type != 0) {
-    cmdwin_result = Ctrl_C;
+  if (modal_active()) {
+    modal_result = Ctrl_C;
     return;
   }
   /* Don't quit while editing the command line. */
@@ -6125,11 +6125,12 @@ static void ex_cquit(exarg_T *eap)
  */
 static void ex_quit_all(exarg_T *eap)
 {
-  if (cmdwin_type != 0) {
+  if (modal_active()) {
+    // FIXME: this is weird
     if (eap->forceit) {
-      cmdwin_result = K_XF1;            // open_cmdwin() takes care of this
+      modal_result = K_XF1;            // open_cmdwin() takes care of this
     } else {
-      cmdwin_result = K_XF2;
+      modal_result = K_XF2;
     }
     return;
   }
@@ -6158,8 +6159,8 @@ static void ex_close(exarg_T *eap)
 {
   win_T *win = NULL;
   int winnr = 0;
-  if (cmdwin_type != 0) {
-    cmdwin_result = Ctrl_C;
+  if (modal_active()) {
+    modal_result = Ctrl_C;
   } else if (!text_locked() && !curbuf_locked()) {
     if (eap->addr_count == 0) {
       ex_win_close(eap->forceit, curwin, NULL);
@@ -6238,8 +6239,9 @@ static void ex_tabclose(exarg_T *eap)
 {
   tabpage_T   *tp;
 
-  if (cmdwin_type != 0)
-    cmdwin_result = K_IGNORE;
+  // why no Ctrl-C???
+  if (modal_active())
+    modal_result = K_IGNORE;
   else if (first_tabpage->tp_next == NULL)
     EMSG(_("E784: Cannot close last tab page"));
   else {
@@ -6263,8 +6265,8 @@ static void ex_tabclose(exarg_T *eap)
 /// ":tabonly": close all tab pages except the current one
 static void ex_tabonly(exarg_T *eap)
 {
-  if (cmdwin_type != 0) {
-    cmdwin_result = K_IGNORE;
+  if (modal_active()) {
+    modal_result = K_IGNORE;
   } else if (first_tabpage->tp_next == NULL) {
       MSG(_("Already only one tab page"));
   } else {
@@ -6434,8 +6436,8 @@ static void ex_stop(exarg_T *eap)
 // ":exit", ":xit" and ":wq": Write file and quite the current window.
 static void ex_exit(exarg_T *eap)
 {
-  if (cmdwin_type != 0) {
-    cmdwin_result = Ctrl_C;
+  if (modal_active()) {
+    modal_result = Ctrl_C;
     return;
   }
   /* Don't quit while editing the command line. */

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -10126,6 +10126,33 @@ static void ex_terminal(exarg_T *eap)
   do_cmdline_cmd(ex_cmd);
 }
 
+// modal terminal window 
+
+static exarg_T *modal_eap = NULL;
+void ex_modal(exarg_T *eap)
+{
+  // TODO: this is ugly. We should be able to launch the pty first
+  // and only if that worked, open the modal window
+  modal_eap = eap;
+
+  FloatConfig fconfig = FLOAT_CONFIG_INIT;
+  fconfig.width = Columns;
+  fconfig.height = Rows/2;
+  fconfig.row = Rows - fconfig.height-1;
+  fconfig.style = kWinStyleMinimal;
+  do_modal(kModalTerminal, &fconfig);
+}
+
+void modal_terminal_init(void)
+{
+  ex_terminal(modal_eap);
+  modal_eap = NULL;
+
+  // terminal mode.
+  stuffReadbuff("i");
+}
+
+// }}}
 /// Checks if `cmd` is "previewable" (i.e. supported by 'inccommand').
 ///
 /// @param[in] cmd Commandline to check. May start with a range or modifier.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6169,10 +6169,6 @@ void cmdwin_finish(void) {
   set_bufref(&cmdwin_bufref, curbuf);
 }
 
-bool is_cmdwin(win_T *wp) {
-  return cmdwin_active() && curwin == wp;
-}
-
 /// Get script string
 ///
 /// Used for commands which accept either `:command script` or

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2208,7 +2208,7 @@ static int vgetorpeek(int advance)
           if (p_im && (State & INSERT))
             c = Ctrl_L;
           else if ((State & CMDLINE)
-                   || (cmdwin_type > 0 && tc == ESC)
+                   || (cmdwin_active() && tc == ESC)
                    )
             c = Ctrl_C;
           else

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -844,9 +844,22 @@ EXTERN char_u   *globaldir INIT(= NULL);
 EXTERN int km_stopsel INIT(= FALSE);
 EXTERN int km_startsel INIT(= FALSE);
 
+typedef enum {
+  kModalNone = 0,  ///< no modal window active
+  kModalCmdwin,    ///< cmdline window
+  kModalTerminal,  ///< modal terminal (:!)
+  KModalUser       ///< window for modal()
+} ModalType;
+
 EXTERN int cedit_key INIT(= -1);     ///< key value of 'cedit' option
-EXTERN int cmdwin_type INIT(= 0);    ///< type of cmdline window or 0
-EXTERN int cmdwin_result INIT(= 0);  ///< result of cmdline window or 0
+
+//EXTERN bool modal_active INIT(= 0); ///< modal window is active
+#define modal_active() (modal_type != kModalNone)
+#define cmdwin_active() (modal_type == kModalCmdwin)
+EXTERN ModalType modal_type INIT(= 0);  ///< type of modal window.
+EXTERN int modal_result INIT(= 0);  ///< result of modal window or 0
+
+EXTERN int cmdwin_firstc INIT(= 0);  //< type of cmdline window 
 EXTERN int cmdwin_level INIT(= 0);   ///< cmdline recursion level
 
 EXTERN char_u no_lines_msg[] INIT(= N_("--No lines in buffer--"));

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -166,14 +166,13 @@ retnomove:
                 && !on_sep_line
                 && (wp->w_p_rl
                     ? col < wp->w_width_inner - wp->w_p_fdc
-                    : col >= wp->w_p_fdc + (cmdwin_type == 0 && wp == curwin
-                                            ? 0 : 1))
+                    : col >= wp->w_p_fdc + (is_cmdwin(wp) ? 1 : 0))
                 && (flags & MOUSE_MAY_STOP_VIS)))) {
       end_visual_mode();
       redraw_curbuf_later(INVERTED);            // delete the inversion
     }
-    if (cmdwin_type != 0 && wp != curwin) {
-      // A click outside the command-line window: Use modeless
+    if (modal_active() && wp != curwin) {
+      // A click outside the modal window: Use modeless
       // selection if possible.  Allow dragging the status lines.
       on_sep_line = 0;
       row = 0;
@@ -306,7 +305,7 @@ retnomove:
 
   // Check for position outside of the fold column.
   if (curwin->w_p_rl ? col < curwin->w_width_inner - curwin->w_p_fdc :
-      col >= curwin->w_p_fdc + (cmdwin_type == 0 ? 0 : 1)) {
+      col >= curwin->w_p_fdc + (cmdwin_active() ? 1 : 0)) {
     mouse_char = ' ';
   }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -689,7 +689,7 @@ void validate_cursor_col(void)
 int win_col_off(win_T *wp)
 {
   return ((wp->w_p_nu || wp->w_p_rnu) ? number_width(wp) + 1 : 0)
-         + (cmdwin_type == 0 || wp != curwin ? 0 : 1)
+         + (is_cmdwin(wp) ? 1 : 0)
          + (int)wp->w_p_fdc
          + (win_signcol_count(wp) * win_signcol_width(wp));
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -70,7 +70,7 @@ typedef struct normal_state {
   bool need_flushbuf;
   bool set_prevcount;
   bool previous_got_int;             // `got_int` was true
-  bool cmdwin;                       // command-line window normal mode
+  bool modal;                        // command-line window normal mode
   bool noexmode;                     // true if the normal mode was pushed from
                                      // ex mode(:global or :visual for example)
   bool toplevel;                     // top-level normal mode
@@ -447,19 +447,21 @@ static int find_command(int cmdchar)
 // Normal state entry point. This is called on:
 //
 // - Startup, In this case the function never returns.
-// - The command-line window is opened(`q:`). Returns when `cmdwin_result` != 0.
+// - Modal window is opened (cmdline window `q:`, :! window, etc).
+//   Returns when `modal_result` != 0.
 // - The :visual command is called from :global in ex mode, `:global/PAT/visual`
 //   for example. Returns when re-entering ex mode(because ex mode recursion is
 //   not allowed)
 //
 // This used to be called main_loop on main.c
-void normal_enter(bool cmdwin, bool noexmode)
+void normal_enter(bool modal, bool noexmode)
 {
   NormalState state;
   normal_state_init(&state);
-  state.cmdwin = cmdwin;
+  state.modal = modal; // TODO: rename!!
   state.noexmode = noexmode;
-  state.toplevel = (!cmdwin || cmdwin_result == 0) && !noexmode;
+  // TODO: this looks borked, why not toplevel = !modal ??
+  state.toplevel = (!modal || modal_result == 0) && !noexmode;
   state_enter(&state.state);
 }
 
@@ -1339,7 +1341,7 @@ static int normal_check(VimState *state)
   // Dict internally somewhere.
   // "may_garbage_collect" is reset in vgetc() which is invoked through
   // do_exmode() and normal_cmd().
-  may_garbage_collect = !s->cmdwin && !s->noexmode;
+  may_garbage_collect = !s->modal && !s->noexmode;
 
   // Update w_curswant if w_set_curswant has been set.
   // Postponed until here to avoid computing w_virtcol too often.
@@ -1353,8 +1355,8 @@ static int normal_check(VimState *state)
     return -1;
   }
 
-  if (s->cmdwin && cmdwin_result != 0) {
-    // command-line window and cmdwin_result is set
+  if (s->modal && modal_result != 0) {
+    // modal window and modal_result is set
     return 0;
   }
 
@@ -2377,7 +2379,7 @@ do_mouse (
 
     /* click in a tab selects that tab page */
     if (is_click
-        && cmdwin_type == 0
+        && !modal_active()
         && mouse_col < Columns) {
       in_tab_line = true;
       c1 = tab_page_click_defs[mouse_col].tabnr;
@@ -5240,8 +5242,9 @@ static void nv_down(cmdarg_T *cap)
     qf_view_result(false);
   } else {
     // In the cmdline window a <CR> executes the command.
-    if (cmdwin_type != 0 && cap->cmdchar == CAR) {
-      cmdwin_result = CAR;
+    // TODO: opt-in for user modal() ?
+    if (cmdwin_active() && cap->cmdchar == CAR) {
+      modal_result = CAR;
     } else {
       cap->oap->motion_type = kMTLineWise;
       if (cursor_down(cap->count1, cap->oap->op_type == OP_NOP) == false) {
@@ -7436,8 +7439,8 @@ static void nv_normal(cmdarg_T *cap)
     if (restart_edit != 0 && mode_displayed)
       clear_cmdline = true;                     /* unshow mode later */
     restart_edit = 0;
-    if (cmdwin_type != 0)
-      cmdwin_result = Ctrl_C;
+    if (modal_active())
+      modal_result = Ctrl_C;
     if (VIsual_active) {
       end_visual_mode();                /* stop Visual */
       redraw_curbuf_later(INVERTED);
@@ -7465,7 +7468,7 @@ static void nv_esc(cmdarg_T *cap)
 
   if (cap->arg) {               /* true for CTRL-C */
     if (restart_edit == 0
-        && cmdwin_type == 0
+        && !modal_active()
         && !VIsual_active
         && no_reason) {
       if (anyBufIsChanged()) {
@@ -7480,8 +7483,9 @@ static void nv_esc(cmdarg_T *cap)
      * set again below when halfway through a mapping. */
     if (!p_im)
       restart_edit = 0;
-    if (cmdwin_type != 0) {
-      cmdwin_result = K_IGNORE;
+    // TODO: also for user modal() ?
+    if (cmdwin_active()) {
+      modal_result = K_IGNORE;
       got_int = false;          /* don't stop executing autocommands et al. */
       return;
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6441,7 +6441,7 @@ int showmode(void)
   msg_ext_ui_flush();
 
   do_mode = ((p_smd && msg_silent == 0)
-             && ((State & TERM_FOCUS)
+             && (((State & TERM_FOCUS) && !modal_active())
                  || (State & INSERT)
                  || restart_edit
                  || VIsual_active));

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1719,7 +1719,7 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
   int off;
 
   /* Build the fold line:
-   * 1. Add the cmdwin_type for the command-line window
+   * 1. Add the cmdwin_firstc for the command-line window
    * 2. Add the 'foldcolumn'
    * 3. Add the 'number' or 'relativenumber' column
    * 4. Compose the text
@@ -1730,11 +1730,11 @@ static void fold_line(win_T *wp, long fold_count, foldinfo_T *foldinfo, linenr_T
   off = 0;
 
   /*
-   * 1. Add the cmdwin_type for the command-line window
+   * 1. Add the cmdwin_firstc for the command-line window
    * Ignores 'rightleft', this window is never right-left.
    */
-  if (cmdwin_type != 0 && wp == curwin) {
-    schar_from_ascii(linebuf_char[off], cmdwin_type);
+  if (is_cmdwin(wp)) {
+    schar_from_ascii(linebuf_char[off], cmdwin_firstc);
     linebuf_attr[off] = win_hl_attr(wp, HLF_AT);
     col++;
   }
@@ -2678,10 +2678,10 @@ win_line (
     if (draw_state != WL_LINE) {
       if (draw_state == WL_CMDLINE - 1 && n_extra == 0) {
         draw_state = WL_CMDLINE;
-        if (cmdwin_type != 0 && wp == curwin) {
+        if (is_cmdwin(wp)) {
           /* Draw the cmdline character. */
           n_extra = 1;
-          c_extra = cmdwin_type;
+          c_extra = cmdwin_firstc;
           c_final = NUL;
           char_attr = win_hl_attr(wp, HLF_AT);
         }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -61,6 +61,7 @@
 #include "nvim/screen.h"
 #include "nvim/keymap.h"
 #include "nvim/edit.h"
+#include "nvim/ex_cmds_defs.h"
 #include "nvim/mouse.h"
 #include "nvim/memline.h"
 #include "nvim/map.h"
@@ -425,7 +426,9 @@ void terminal_enter(void)
   if (s->close) {
     bool wipe = s->term->buf_handle != 0;
     s->term->opts.close_cb(s->term->opts.data);
-    if (wipe) {
+    if (modal_active()) {
+      modal_result = true;
+    } else if (wipe) {
       do_cmdline_cmd("bwipeout!");
     }
   }
@@ -1359,5 +1362,4 @@ static char *get_config_string(char *key)
 }
 
 // }}}
-
 // vim: foldmethod=marker

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -92,7 +92,7 @@ do_window (
 
 # define CHECK_CMDWIN \
   do { \
-    if (cmdwin_type != 0) { \
+    if (modal_active()) { \
       EMSG(_(e_cmdwin)); \
       return; \
     } \
@@ -6784,4 +6784,143 @@ win_T *lastwin_nofloating(void) {
     res = res->w_prev;
   }
   return res;
+}
+
+int do_modal(ModalType type, bool use_float) {
+  bufref_T            old_curbuf;
+  win_T               *old_curwin = curwin;
+  win_T               *wp;
+  int i;
+  linenr_T lnum;
+  garray_T winsizes;
+  char_u typestr[2];
+  int save_restart_edit = restart_edit;
+  int save_State = State;
+  int save_exmode = exmode_active;
+  int save_cmdmsg_rl = cmdmsg_rl;
+
+  if (modal_active()) {
+    abort();
+  }
+
+  set_bufref(&old_curbuf, curbuf);
+
+  /* Save current window sizes. */
+  win_size_save(&winsizes);
+
+  /* Don't execute autocommands while creating the window. */
+  block_autocmds();
+
+  // When using completion in Insert mode with <C-R>=<C-F> one can open the
+  // command line window, but we don't want the popup menu then.
+  pum_undisplay(true);
+
+  // don't use a new tab page
+  cmdmod.tab = 0;
+  cmdmod.noswapfile = 1;
+
+  // Create modal window
+  if (use_float) {
+    abort();
+  } else if (win_split((int)p_cwh, WSP_BOT) == FAIL) {
+    beep_flush();
+    unblock_autocmds();
+    return K_IGNORE;
+  }
+  unblock_autocmds();
+
+  if (type == kModalCmdwin) {
+    cmdwin_init();
+  } else {
+    abort();
+  }
+
+  redraw_later(SOME_VALID);
+
+  // Save the command line info, can be used recursively.
+  void *saved_cmdline = save_cmdline_alloc();
+
+  /* No Ex mode here! */
+  exmode_active = 0;
+
+  State = NORMAL;
+  setmouse();
+
+  if (type == kModalCmdwin) {
+    // Trigger CmdwinEnter autocommands.
+    typestr[0] = (char_u)cmdwin_firstc;
+    typestr[1] = NUL;
+    apply_autocmds(EVENT_CMDWINENTER, typestr, typestr, FALSE, curbuf);
+    if (restart_edit != 0)        /* autocmd with ":startinsert" */
+      stuffcharReadbuff(K_NOP);
+  }
+
+  modal_type = type;
+
+  i = RedrawingDisabled;
+  RedrawingDisabled = 0;
+  int save_count = save_batch_count();
+
+  /*
+   * Call the main loop until <CR> or CTRL-C is typed.
+   */
+  modal_result = 0;
+  normal_enter(true, false);
+
+  RedrawingDisabled = i;
+  restore_batch_count(save_count);
+
+  const bool save_KeyTyped = KeyTyped;
+
+  if (type == kModalCmdwin) {
+    /* Trigger CmdwinLeave autocommands. */
+    apply_autocmds(EVENT_CMDWINLEAVE, typestr, typestr, FALSE, curbuf);
+  }
+
+  /* Restore KeyTyped in case it is modified by autocommands */
+  KeyTyped = save_KeyTyped;
+
+  // Restore the command line info.
+  restore_cmdline_alloc(saved_cmdline);
+  modal_type = kModalNone;
+
+  exmode_active = save_exmode;
+
+  /* Safety check: The old window or buffer was deleted: It's a bug when
+   * this happens! */
+  if (!win_valid(old_curwin) || !bufref_valid(&old_curbuf)) {
+    modal_result = Ctrl_C;
+    EMSG(_("E199: Active window or buffer deleted"));
+  } else {
+    if (type == kModalCmdwin) {
+      cmdwin_finish();
+    } else {
+      abort();
+    }
+
+    /* Don't execute autocommands while deleting the window. */
+    block_autocmds();
+    // Avoid command-line window first character being concealed
+    curwin->w_p_cole = 0;
+    wp = curwin;
+    win_goto(old_curwin);
+    win_close(wp, true);
+
+
+    if (!use_float) {
+      /* Restore window sizes. */
+      win_size_restore(&winsizes);
+    }
+
+    unblock_autocmds();
+  }
+
+  ga_clear(&winsizes);
+  restart_edit = save_restart_edit;
+  cmdmsg_rl = save_cmdmsg_rl;
+
+  State = save_State;
+  setmouse();
+
+  return modal_result;
 }


### PR DESCRIPTION
Generalize `cmdline_win` into a general-purpose modal window abstraction.
Use this to reimplement interactive `:!` using a modal terminal window.

Note: currently this hardcoded using a floating window which covers half of the screen height. It would be useful to dynamically expand to the area that is actually used by the command.

![Screenshot from 2019-08-24 22-25-51](https://user-images.githubusercontent.com/1363104/63642351-38c48580-c6be-11e9-9a35-613c262a4e67.png)

