### PR TITLE
vim-patch:8.1.1913: not easy to compute the space on the command line

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1529,6 +1529,13 @@ v:dying		Normally zero.  When a deadly signal is caught it's set to
 					*v:exiting* *exiting-variable*
 v:exiting	Exit code, or |v:null| if not exiting. |VimLeave|
 
+					*v:echospace* *echospace-variable*
+v:echospace	Number of screen cells that can be used for an `:echo` message
+		in the last screen line before causing the |hit-enter-prompt|.
+		Depends on 'showcmd', 'ruler' and 'columns'.  You need to
+		check 'cmdheight' for whether there are full-width lines
+		available above the last line.
+
 					*v:errmsg* *errmsg-variable*
 v:errmsg	Last given error message.
 		Modifiable (can be set).

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -419,6 +419,7 @@ static struct vimvar {
   VV(VV_TYPE_DICT,      "t_dict",           VAR_NUMBER, VV_RO),
   VV(VV_TYPE_FLOAT,     "t_float",          VAR_NUMBER, VV_RO),
   VV(VV_TYPE_BOOL,      "t_bool",           VAR_NUMBER, VV_RO),
+  VV(VV_ECHOSPACE,      "echospace",        VAR_NUMBER, VV_RO),
   VV(VV_EXITING,        "exiting",          VAR_NUMBER, VV_RO),
 };
 #undef VV
@@ -634,6 +635,8 @@ void eval_init(void)
   set_vim_var_special(VV_TRUE, kSpecialVarTrue);
   set_vim_var_special(VV_NULL, kSpecialVarNull);
   set_vim_var_special(VV_EXITING, kSpecialVarNull);
+
+  set_vim_var_nr(VV_ECHOSPACE,    sc_col - 1);
 
   set_reg_var(0);  // default for v:register is not 0 but '"'
 }

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -115,6 +115,7 @@ typedef enum {
     VV_TYPE_DICT,
     VV_TYPE_FLOAT,
     VV_TYPE_BOOL,
+    VV_ECHOSPACE,
     VV_EXITING,
 } VimVarIndex;
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5456,6 +5456,7 @@ void comp_col(void)
   if (ru_col <= 0) {
     ru_col = 1;
   }
+  set_vim_var_nr(VV_ECHOSPACE, sc_col - 1);
 }
 
 // Unset local option value, similar to ":set opt<".

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -64,3 +64,20 @@ func Test_message_completion()
   call feedkeys(":message \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"message clear', @:)
 endfunc
+
+func Test_echospace()
+  set noruler noshowcmd laststatus=1
+  call assert_equal(&columns - 1, v:echospace)
+  split
+  call assert_equal(&columns - 1, v:echospace)
+  set ruler
+  call assert_equal(&columns - 1, v:echospace)
+  close
+  call assert_equal(&columns - 19, v:echospace)
+  set showcmd noruler
+  call assert_equal(&columns - 12, v:echospace)
+  set showcmd ruler
+  call assert_equal(&columns - 29, v:echospace)
+
+  set ruler& showcmd&
+endfunc


### PR DESCRIPTION
Problem:    Not easy to compute the space on the command line.
Solution:   Add v:echospace. (Daniel Hahler, closes vim/vim#4732)
https://github.com/vim/vim/commit/37f4cbd46f5a6f2dd3a48d5fa4324dce37e4bd6c