### PR TITLE
findoption_len: treat viminfo/viminfofile as aliases

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4643,6 +4643,15 @@ int findoption_len(const char *const arg, const size_t len)
   }
   if (s == NULL) {
     opt_idx = -1;
+  } else {
+    // Nvim: handle option aliases.
+    if (STRNCMP(options[opt_idx].fullname, "viminfo", 7) == 0) {
+      if (STRLEN(options[opt_idx].fullname) == 7) {
+        return findoption_len("shada", 5);
+      }
+      assert(STRCMP(options[opt_idx].fullname, "viminfofile") == 0);
+      return findoption_len("shadafile", 9);
+    }
   }
   return opt_idx;
 }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2659,21 +2659,14 @@ return {
       defaults={if_true={vi="folds,options,cursor,curdir"}}
     },
     {
+      -- Alias for "shada".
       full_name='viminfo', abbreviation='vi',
-      type='string', list='onecomma', scope={'global'},
-      deny_duplicates=true,
-      secure=true,
-      varname='p_shada',
-      defaults={if_true={vi="", vim="!,'100,<50,s10,h"}}
+      type='string', scope={'global'}, nodefault=true,
     },
     {
+      -- Alias for "shadafile".
       full_name='viminfofile', abbreviation='vif',
-      type='string', list='onecomma', scope={'global'},
-      deny_duplicates=true,
-      vi_def=true,
-      secure=true,
-      varname='p_shadafile',
-      defaults={if_true={vi=""}}
+      type='string', scope={'global'}, nodefault=true,
     },
     {
       full_name='virtualedit', abbreviation='ve',

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -267,4 +267,46 @@ func Test_mksession_quote_in_filename()
   call delete('Xtest_mks_quoted.out')
 endfunc
 
+func s:ClearMappings()
+  mapclear
+  omapclear
+  mapclear!
+  lmapclear
+  tmapclear
+endfunc
+
+func Test_mkvimrc()
+  let entries = [
+        \ ['', 'nothing', '<Nop>'],
+        \ ['n', 'normal', 'NORMAL'],
+        \ ['v', 'visual', 'VISUAL'],
+        \ ['s', 'select', 'SELECT'],
+        \ ['x', 'visualonly', 'VISUALONLY'],
+        \ ['o', 'operator', 'OPERATOR'],
+        \ ['i', 'insert', 'INSERT'],
+        \ ['l', 'lang', 'LANG'],
+        \ ['c', 'command', 'COMMAND'],
+        \ ['t', 'terminal', 'TERMINAL'],
+        \ ]
+  for entry in entries
+    exe entry[0] .. 'map ' .. entry[1] .. ' ' .. entry[2]
+  endfor
+
+  mkvimrc Xtestvimrc
+
+  call s:ClearMappings()
+  for entry in entries
+    call assert_equal('', maparg(entry[1], entry[0]))
+  endfor
+
+  source Xtestvimrc
+
+  for entry in entries
+    call assert_equal(entry[2], maparg(entry[1], entry[0]))
+  endfor
+
+  call s:ClearMappings()
+  call delete('Xtestvimrc')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -178,6 +178,12 @@ describe('startup defaults', function()
     eq({ f }, eval('v:oldfiles'))
     os.remove('Xtest-foo')
     rmdir('Xtest-userdata')
+
+    -- Handles viminfo/viminfofile as alias for shada/shadafile.
+    eq('\n  shadafile=', eval('execute("set shadafile?")'))
+    eq('\n  shadafile=', eval('execute("set viminfofile?")'))
+    eq("\n  shada=!,'100,<50,s10,h", eval('execute("set shada?")'))
+    eq("\n  shada=!,'100,<50,s10,h", eval('execute("set viminfo?")'))
   end)
 
   it("'packpath'", function()


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/pull/10672#issuecomment-524716824

Will display "shadafile=" for `set viminfofile?` - which might be good actually?