### PR TITLE
Revisit out_data_decide_throttle

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -405,8 +405,11 @@ static bool out_data_decide_throttle(size_t size)
     return false;
   } else if (!visit) {
     started = os_hrtime();
-  } else if (visit % 20 == 0) {
+  } else {
     uint64_t since = os_hrtime() - started;
+    if (since < (visit * 0.1L * NS_1_SECOND)) {
+      return true;
+    }
     if (since > (3 * NS_1_SECOND)) {
       received = visit = 0;
       return false;
@@ -415,12 +418,10 @@ static bool out_data_decide_throttle(size_t size)
 
   visit++;
   // Pulse "..." at the bottom of the screen.
-  size_t tick = (visit % 20 == 0)
-                ? 3  // Force all dots "..." on last visit.
-                : (visit % 4);
-  pulse_msg[0] = (tick == 0) ? ' ' : '.';
-  pulse_msg[1] = (tick == 0 || 1 == tick) ? ' ' : '.';
-  pulse_msg[2] = (tick == 0 || 1 == tick || 2 == tick) ? ' ' : '.';
+  size_t tick = visit % 4;
+  pulse_msg[0] = (tick > 0) ? '.' : ' ';
+  pulse_msg[1] = (tick > 1) ? '.' : ' ';
+  pulse_msg[2] = (tick > 2) ? '.' : ' ';
   if (visit == 1) {
     msg_putchar('\n');
   }

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -40,7 +40,6 @@ static void help(void)
   puts("      0: foo bar");
   puts("      ...");
   puts("      96: foo bar");
-  puts("  shell-test REP_NODELAY N {text}");
   puts("  shell-test INTERACT");
   puts("    Prints \"interact $ \" to stderr, and waits for \"exit\" input.");
 }
@@ -67,8 +66,7 @@ int main(int argc, char **argv)
       if (argc >= 3) {
         fprintf(stderr, "%s\n", argv[2]);
       }
-    } else if (strcmp(argv[1], "REP") == 0 ||
-               strcmp(argv[1], "REP_NODELAY") == 0) {
+    } else if (strcmp(argv[1], "REP") == 0) {
       if (argc != 4) {
         fprintf(stderr, "REP expects exactly 3 arguments\n");
         return 4;
@@ -78,15 +76,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "Invalid count: %s\n", argv[2]);
         return 4;
       }
-      if (strcmp(argv[1], "REP_NODELAY") == 0) {
-        for (int i = 0; i < count; i++) {
-          printf("%d: %s\n", i, argv[3]);
-          fflush(stdout);
-        }
-      } else {
-        for (int i = 0; i < count; i++) {
-          printf("%d: %s\n", i, argv[3]);
-          fflush(stdout);
+      for (int i = 0; i < count; i++) {
+        printf("%d: %s\n", i, argv[3]);
+        fflush(stdout);
+        if (i % 100 == 0) {
           usleep(1000);  // Wait 1 ms (simulate typical output).
         }
       }

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -50,7 +50,7 @@ describe("shell command :!", function()
   end)
 
   it("throttles shell-command output greater than ~10KB", function()
-    child_session.feed_data(":!"..nvim_dir.."/shell-test REP_NODELAY 30001 foo\n")
+    child_session.feed_data(":!"..nvim_dir.."/shell-test REP 30001 foo\n")
 
     -- If we observe any line starting with a dot, then throttling occurred.
     -- Avoid false failure on slow systems.


### PR DESCRIPTION
Pulse every 0.2s only, displaying first dot always ([1]).

This makes `:!yes` look much better (less busy) - although that might
have been intentional?!.

1: https://github.com/neovim/neovim/pull/10854#issuecomment-524858426