### PR TITLE
build: third-party: enable CXX language earlier

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -2,10 +2,6 @@
 cmake_minimum_required (VERSION 2.8.12)
 project(NVIM_DEPS C)
 
-if(USE_BUNDLED_GPERF)
-  enable_language(CXX)
-endif()
-
 # Needed for: check_c_compiler_flag()
 include(CheckCCompilerFlag)
 
@@ -99,6 +95,10 @@ if(CMAKE_C_COMPILER_ARG1)
   set(DEPS_C_COMPILER "${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}")
 else()
   set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
+endif()
+
+if(USE_BUNDLED_GPERF)
+  enable_language(CXX)
 endif()
 
 if(CMAKE_CXX_COMPILER)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -2,6 +2,10 @@
 cmake_minimum_required (VERSION 2.8.12)
 project(NVIM_DEPS C)
 
+if(USE_BUNDLED_GPERF)
+  enable_language(CXX)
+endif()
+
 # Needed for: check_c_compiler_flag()
 include(CheckCCompilerFlag)
 
@@ -97,11 +101,15 @@ else()
   set(DEPS_C_COMPILER "${CMAKE_C_COMPILER}")
 endif()
 
-set(DEPS_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
+if(CMAKE_CXX_COMPILER)
+  set(DEPS_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
+endif()
 
 if(CMAKE_OSX_SYSROOT)
   set(DEPS_C_COMPILER "${DEPS_C_COMPILER} -isysroot${CMAKE_OSX_SYSROOT}")
-  set(DEPS_CXX_COMPILER "${DEPS_CXX_COMPILER} -isysroot${CMAKE_OSX_SYSROOT}")
+  if(DEPS_CXX_COMPILER)
+    set(DEPS_CXX_COMPILER "${DEPS_CXX_COMPILER} -isysroot${CMAKE_OSX_SYSROOT}")
+  endif()
 endif()
 
 # Cross compiling: use these for dependencies built for the

--- a/third-party/cmake/BuildGperf.cmake
+++ b/third-party/cmake/BuildGperf.cmake
@@ -2,7 +2,6 @@
 # cross compiling we still want to build for the HOST system, whenever
 # writing a recipe that is meant for cross-compile, use the HOSTDEPS_* variables
 # instead of DEPS_* - check the main CMakeLists.txt for a list.
-enable_language(CXX)
 
 # BuildGperf(CONFIGURE_COMMAND ... BUILD_COMMAND ... INSTALL_COMMAND ...)
 # Reusable function to build Gperf, wraps ExternalProject_Add.


### PR DESCRIPTION
This is required for `CMAKE_CXX_COMPILER` to be set already, not only
after including third-party/cmake/BuildGperf.cmake.

Closes https://github.com/neovim/neovim/pull/10860.