### PR TITLE
[RFC] vim-patch:8.1.1932: ml_get errors after using append()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -15217,8 +15217,14 @@ static void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append,
 
   if (added > 0) {
     appended_lines_mark(append_lnum, added);
+
+    // Only adjust the cursor for buffers other than the current, unless it
+    // is the current window. For curbuf and other windows it has been done
+    // in mark_adjust_internal().
     FOR_ALL_TAB_WINDOWS(tp, wp) {
-      if (wp->w_buffer == buf && wp->w_cursor.lnum > append_lnum) {
+      if (wp->w_buffer == buf
+          && (wp->w_buffer != curbuf || wp == curwin)
+          && wp->w_cursor.lnum > append_lnum) {
         wp->w_cursor.lnum += added;
       }
     }

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -592,6 +592,15 @@ func Test_mode()
   set complete&
 endfunc
 
+func Test_append()
+  enew!
+  split
+  call append(0, ["foo"])
+  split
+  only
+  undo
+endfunc
+
 func Test_getbufvar()
   let bnr = bufnr('%')
   let b:var_num = '1234'


### PR DESCRIPTION
```
Problem:  Ml_get errors after using append(). (Alex Genco)
Solution: Do not update the cursor twice.
```

https://github.com/vim/vim/commit/d20070274c47668560e02db184e1f8e456c3c326