### PR TITLE
vim-patch:8.1.0193

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -896,3 +896,5 @@ func s:BufUnloaded()
   endfor
 endfunc
 
+let &cpo = s:keepcpo
+unlet s:keepcpo


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/8364 omitted a change to revert `&cpo` at the bottom of the file.