### PR TITLE
server_requests_spec: use Lua path/cpath from tests

### DIFF
--- a/test/functional/api/rpc_fixture.lua
+++ b/test/functional/api/rpc_fixture.lua
@@ -1,12 +1,8 @@
-local deps_prefix = (os.getenv('DEPS_PREFIX') and os.getenv('DEPS_PREFIX')
-                     or './.deps/usr')
-
-package.path = deps_prefix .. '/share/lua/5.1/?.lua;' ..
-               deps_prefix .. '/share/lua/5.1/?/init.lua;' ..
-               package.path
-
-package.cpath = deps_prefix .. '/lib/lua/5.1/?.so;' ..
-                package.cpath
+--- RPC server fixture.
+--
+-- Lua's paths are passed as arguments to reflect the path in the test itself.
+package.path = arg[1]
+package.cpath = arg[2]
 
 local mpack = require('mpack')
 local StdioStream = require('nvim.stdio_stream')

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -241,10 +241,14 @@ describe('server -> client', function()
         \ 'rpc': v:true
         \ }
       ]])
-      meths.set_var("args", {helpers.test_lua_prg,
-                             'test/functional/api/rpc_fixture.lua'})
+      meths.set_var("args", {
+        helpers.test_lua_prg,
+        'test/functional/api/rpc_fixture.lua',
+        package.path,
+        package.cpath,
+      })
       jobid = eval("jobstart(g:args, g:job_opts)")
-      neq(0, 'jobid')
+      neq(0, jobid)
     end)
 
     after_each(function()
@@ -254,7 +258,11 @@ describe('server -> client', function()
     if helpers.pending_win32(pending) then return end
 
     it('rpc and text stderr can be combined', function()
-      eq("ok",funcs.rpcrequest(jobid, "poll"))
+      local status, rv = pcall(funcs.rpcrequest, jobid, 'poll')
+      if not status then
+        error(string.format('missing nvim Lua module? (%s)', rv))
+      end
+      eq('ok', rv)
       funcs.rpcnotify(jobid, "ping")
       eq({'notification', 'pong', {}}, next_msg())
       eq("done!",funcs.rpcrequest(jobid, "write_stderr", "fluff\n"))


### PR DESCRIPTION
This helps with diagnosing a test failure due to the "nvim" Lua module
not being available (e.g. when using the system luajit, but not having
activated Luarocks for it).

Previously it would fail with:
```
[  ERROR   ] 1 error, listed below:
[  ERROR   ] test/functional/api/server_requests_spec.lua @ 257: server -> client jobstart() rpc and text stderr can be combined
test/functional/helpers.lua:106: Vim:Error invoking 'poll' on channel 3:
ch 3 was closed by the client

stack traceback:
        test/functional/helpers.lua:106: in function 'rpcrequest'
        test/functional/api/server_requests_spec.lua:258: in function <test/functional/api/server_requests_spec.lua:257>
```

Now:
```
[  ERROR   ] test/functional/api/server_requests_spec.lua @ 230: server -> client jobstart() before_each
test/functional/helpers.lua:403:
retry() attempts: 50
test/functional/helpers.lua:106: Vim:E121: Undefined variable: g:rpc_session_started

stack traceback:
        test/functional/helpers.lua:403: in function 'retry'
        test/functional/api/server_requests_spec.lua:248: in function <test/functional/api/server_requests_spec.lua:230>
```