### PR TITLE
tests: display logfile on error/failures only, fix TAP

### DIFF
--- a/test/busted/outputHandlers/TAP.lua
+++ b/test/busted/outputHandlers/TAP.lua
@@ -3,12 +3,16 @@
 local global_helpers = require('test.helpers')
 
 return function(options)
+  local busted = require 'busted'
   local handler = require 'busted.outputHandlers.TAP'(options)
 
-  handler.suiteEnd = function()
-    io.write(global_helpers.read_nvim_log())
-    return handler.suiteEnd()
+  local suiteEnd = function()
+    if #handler.failures > 0 or #handler.errors > 0 then
+      io.write(global_helpers.read_nvim_log())
+    end
+    return nil, true
   end
+  busted.subscribe({ 'suite', 'end' }, suiteEnd)
 
   return handler
 end

--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -196,7 +196,9 @@ return function(options)
     local tests = (testCount == 1 and 'test' or 'tests')
     local files = (fileCount == 1 and 'file' or 'files')
     io.write(globalTeardown)
-    io.write(global_helpers.read_nvim_log())
+    if errorCount > 0 or failureCount > 0 then
+      io.write(global_helpers.read_nvim_log())
+    end
     io.write(suiteEndString:format(testCount, tests, fileCount, files, elapsedTime_ms))
     io.write(getSummaryString())
     io.flush()


### PR DESCRIPTION
Overwriting of the default TAP handler's `suiteEnd` was not working as
expected.  This registers a new subscriber to "suite.end" instead.