### PR TITLE
paste: handle CR, CRLF

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -239,12 +239,13 @@ GUIs can paste by calling |nvim_paste()|.
 
 PASTE BEHAVIOR ~
 
-Paste always inserts text after the cursor.  In cmdline-mode only the first
-line is pasted, to avoid accidentally executing many commands.  Use the
-|cmdline-window| if you really want to paste multiple lines to the cmdline.
-
-When pasting a huge amount of text, screen updates are throttled and the
+Paste inserts text after the cursor.  Lines break at <NL>, <CR>, and <CR><NL>.
+When pasting a huge amount of text, screen-updates are throttled and the
 message area shows a "..." pulse.
+
+In cmdline-mode only the first line is pasted, to avoid accidentally executing
+many commands.  Use the |cmdline-window| if you really want to paste multiple
+lines to the cmdline.
 
 You can implement a custom paste handler by redefining |vim.paste()|.
 Example: >

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -745,19 +745,32 @@ String ga_take_string(garray_T *ga)
   return str;
 }
 
-/// Creates "readfile()-style" ArrayOf(String).
+/// Creates "readfile()-style" ArrayOf(String) from a binary string.
 ///
-/// - NUL bytes are replaced with NL (form-feed).
-/// - If last line ends with NL an extra empty list item is added.
-Array string_to_array(const String input)
+/// - Lines break at \n (NL/LF/line-feed).
+/// - NUL bytes are replaced with NL.
+/// - If the last byte is a linebreak an extra empty list item is added.
+///
+/// @param input  Binary string
+/// @param crlf  Also break lines at CR and CRLF.
+/// @return [allocated] String array
+Array string_to_array(const String input, bool crlf)
 {
   Array ret = ARRAY_DICT_INIT;
   for (size_t i = 0; i < input.size; i++) {
     const char *start = input.data + i;
-    const char *end = xmemscan(start, NL, input.size - i);
-    const size_t line_len = (size_t)(end - start);
+    const char *end = start;
+    size_t line_len = 0;
+    for (; line_len < input.size - i; line_len++) {
+      end = start + line_len;
+      if (*end == NL || (crlf && *end == CAR)) {
+        break;
+      }
+    }
     i += line_len;
-
+    if (crlf && *end == CAR && i + 1 < input.size && *(end + 1) == NL) {
+      i += 1;  // Advance past CRLF.
+    }
     String s = {
       .size = line_len,
       .data = xmemdupz(start, line_len),
@@ -766,8 +779,8 @@ Array string_to_array(const String input)
     ADD(ret, STRING_OBJ(s));
     // If line ends at end-of-buffer, add empty final item.
     // This is "readfile()-style", see also ":help channel-lines".
-    if (i + 1 == input.size && end[0] == NL) {
-      ADD(ret, STRING_OBJ(cchar_to_string(NUL)));
+    if (i + 1 == input.size && (*end == NL || (crlf && *end == CAR))) {
+      ADD(ret, STRING_OBJ(STRING_INIT));
     }
   }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1247,7 +1247,7 @@ Boolean nvim_paste(String data, Integer phase, Error *err)
     // Skip remaining chunks.  Report error only once per "stream".
     goto theend;
   }
-  Array lines = string_to_array(data);
+  Array lines = string_to_array(data, true);
   ADD(args, ARRAY_OBJ(lines));
   ADD(args, INTEGER_OBJ(phase));
   rv = nvim_execute_lua(STATIC_CSTR_AS_STRING("return vim.paste(...)"), args,

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -381,8 +381,7 @@ describe('API', function()
         line 2
         line 3
         ]])
-      -- Cursor follows the paste.
-      eq({0,4,1,0}, funcs.getpos('.'))
+      eq({0,4,1,0}, funcs.getpos('.'))  -- Cursor follows the paste.
       eq(false, nvim('get_option', 'paste'))
       command('%delete _')
       -- Without final "\n".
@@ -391,8 +390,38 @@ describe('API', function()
         line 1
         line 2
         line 3]])
-      -- Cursor follows the paste.
       eq({0,3,6,0}, funcs.getpos('.'))
+      command('%delete _')
+      -- CRLF #10872
+      nvim('paste', 'line 1\r\nline 2\r\nline 3\r\n', -1)
+      expect([[
+        line 1
+        line 2
+        line 3
+        ]])
+      eq({0,4,1,0}, funcs.getpos('.'))
+      command('%delete _')
+      -- CRLF without final "\n".
+      nvim('paste', 'line 1\r\nline 2\r\nline 3\r', -1)
+      expect([[
+        line 1
+        line 2
+        line 3
+        ]])
+      eq({0,4,1,0}, funcs.getpos('.'))
+      command('%delete _')
+      -- CRLF without final "\r\n".
+      nvim('paste', 'line 1\r\nline 2\r\nline 3', -1)
+      expect([[
+        line 1
+        line 2
+        line 3]])
+      eq({0,3,6,0}, funcs.getpos('.'))
+      command('%delete _')
+      -- Various other junk.
+      nvim('paste', 'line 1\r\n\r\rline 2\nline 3\rline 4\r', -1)
+      expect('line 1\n\n\nline 2\nline 3\nline 4\n')
+      eq({0,7,1,0}, funcs.getpos('.'))
       eq(false, nvim('get_option', 'paste'))
     end)
     it('vim.paste() failure', function()

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -455,6 +455,12 @@ local SUBTBL = {
   '\\030', '\\031',
 }
 
+-- Formats Lua value `v`.
+--
+-- TODO(justinmk): redundant with vim.inspect() ?
+--
+-- "Nice table formatting similar to screen:snapshot_util()".
+-- Commit: 520c0b91a528
 function module.format_luav(v, indent, opts)
   opts = opts or {}
   local linesep = '\n'
@@ -533,6 +539,9 @@ function module.format_luav(v, indent, opts)
   return ret
 end
 
+-- Like Python repr(), "{!r}".format(s)
+--
+-- Commit: 520c0b91a528
 function module.format_string(fmt, ...)
   local i = 0
   local args = {...}


### PR DESCRIPTION
fix #10872
ref #10223

todo:

- [x] break at CR by itself, this is what some terminals send to indicate EOL