### PR TITLE
TUI: defer nvim_paste event properly

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1283,8 +1283,6 @@ theend:
   api_free_array(args);
   if (cancel || phase == -1 || phase == 3) {  // End of paste-stream.
     draining = false;
-    // XXX: Tickle main loop to ensure cursor is updated.
-    loop_schedule_deferred(&main_loop, event_create(loop_dummy_event, 0));
   }
 
   return !cancel;

--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -71,7 +71,7 @@ bool loop_poll_events(Loop *loop, int ms)
   return timeout_expired;
 }
 
-/// Schedules an event from another thread.
+/// Schedules a fast event from another thread.
 ///
 /// @note Event is queued into `fast_events`, which is processed outside of the
 ///       primary `events` queue by loop_poll_events(). For `main_loop`, that
@@ -79,7 +79,7 @@ bool loop_poll_events(Loop *loop, int ms)
 ///       (VimState.execute), so redraw and other side-effects are likely to be
 ///       skipped.
 /// @see loop_schedule_deferred
-void loop_schedule(Loop *loop, Event event)
+void loop_schedule_fast(Loop *loop, Event event)
 {
   uv_mutex_lock(&loop->mutex);
   multiqueue_put_event(loop->thread_events, event);
@@ -87,15 +87,15 @@ void loop_schedule(Loop *loop, Event event)
   uv_mutex_unlock(&loop->mutex);
 }
 
-/// Schedules an event from another thread. Unlike loop_schedule(), the event
-/// is forwarded to `Loop.events`, instead of being processed immediately.
+/// Schedules an event from another thread. Unlike loop_schedule_fast(), the
+/// event is forwarded to `Loop.events`, instead of being processed immediately.
 ///
-/// @see loop_schedule
+/// @see loop_schedule_fast
 void loop_schedule_deferred(Loop *loop, Event event)
 {
   Event *eventp = xmalloc(sizeof(*eventp));
   *eventp = event;
-  loop_schedule(loop, event_create(loop_deferred_event, 2, loop, eventp));
+  loop_schedule_fast(loop, event_create(loop_deferred_event, 2, loop, eventp));
 }
 static void loop_deferred_event(void **argv)
 {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -269,7 +269,9 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 #endif
 
   // vim
-  if (luaL_dostring(lstate, (char *)&vim_module[0])) {
+  const char *code = (char *)&vim_module[0];
+  if (luaL_loadbuffer(lstate, code, strlen(code), "@vim.lua")
+      || lua_pcall(lstate, 0, LUA_MULTRET, 0)) {
     nlua_error(lstate, _("E5106: Error while creating vim module: %.*s"));
     return 1;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -753,7 +753,7 @@ void msg_schedule_emsgf(const char *const fmt, ...)
   va_end(ap);
 
   char *s = xstrdup((char *)IObuff);
-  loop_schedule(&main_loop, event_create(msg_emsgf_event, 1, s));
+  multiqueue_put(main_loop.events, msg_emsgf_event, 1, s);
 }
 
 /*

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -164,7 +164,7 @@ static void tinput_flush(TermInput *input, bool wait_until_empty)
   size_t drain_boundary = wait_until_empty ? 0 : 0xff;
   do {
     uv_mutex_lock(&input->key_buffer_mutex);
-    loop_schedule(&main_loop, event_create(tinput_wait_enqueue, 1, input));
+    loop_schedule_fast(&main_loop, event_create(tinput_wait_enqueue, 1, input));
     input->waiting = true;
     while (input->waiting) {
       uv_cond_wait(&input->key_buffer_cond, &input->key_buffer_mutex);
@@ -522,7 +522,7 @@ static void tinput_read_cb(Stream *stream, RBuffer *buf, size_t count_,
   TermInput *input = data;
 
   if (eof) {
-    loop_schedule(&main_loop, event_create(tinput_done_event, 0));
+    loop_schedule_fast(&main_loop, event_create(tinput_done_event, 0));
     return;
   }
 

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -106,17 +106,15 @@ static void tinput_wait_enqueue(void **argv)
   RBUFFER_UNTIL_EMPTY(input->key_buffer, buf, len) {
     const String keys = { .data = buf, .size = len };
     if (input->paste) {
-      Error err = ERROR_INIT;
-      // Paste phase: "continue" (unless handler canceled).
-      input->paste = !nvim_paste(keys, true, input->paste, &err)
-        ? 0 : (1 == input->paste ? 2 : input->paste);
+      String copy = copy_string(keys);
+      multiqueue_put(main_loop.events, tinput_paste_event, 3,
+                     copy.data, copy.size, (intptr_t)input->paste);
+      if (input->paste == 1) {
+        // Paste phase: "continue"
+        input->paste = 2;
+      }
       rbuffer_consumed(input->key_buffer, len);
       rbuffer_reset(input->key_buffer);
-      if (ERROR_SET(&err)) {
-        // TODO(justinmk): emsgf() does not display, why?
-        msg_printf_attr(HL_ATTR(HLF_E)|MSG_HIST, "paste: %s", err.msg);
-        api_clear_error(&err);
-      }
     } else {
       const size_t consumed = input_enqueue(keys);
       if (consumed) {
@@ -132,6 +130,33 @@ static void tinput_wait_enqueue(void **argv)
   input->waiting = false;
   uv_cond_signal(&input->key_buffer_cond);
   uv_mutex_unlock(&input->key_buffer_mutex);
+}
+
+static void tinput_paste_event(void **argv)
+{
+  static bool canceled = false;
+
+  String keys = { .data = argv[0], .size = (size_t)argv[1] };
+  intptr_t phase = (intptr_t)argv[2];
+
+  if (phase == -1 || phase == 1) {
+    canceled = false;
+  }
+
+  Error err = ERROR_INIT;
+  if (!canceled) {
+    if (!nvim_paste(keys, true, phase, &err)) {
+      // paste failed, ingore further segments of the same paste
+      canceled = true;
+    }
+  }
+
+  if (ERROR_SET(&err)) {
+    emsgf("paste: %s", err.msg);
+    api_clear_error(&err);
+  }
+
+  api_free_string(keys);
 }
 
 static void tinput_flush(TermInput *input, bool wait_until_empty)

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -134,23 +134,11 @@ static void tinput_wait_enqueue(void **argv)
 
 static void tinput_paste_event(void **argv)
 {
-  static bool canceled = false;
-
   String keys = { .data = argv[0], .size = (size_t)argv[1] };
   intptr_t phase = (intptr_t)argv[2];
 
-  if (phase == -1 || phase == 1) {
-    canceled = false;
-  }
-
   Error err = ERROR_INIT;
-  if (!canceled) {
-    if (!nvim_paste(keys, true, phase, &err)) {
-      // paste failed, ingore further segments of the same paste
-      canceled = true;
-    }
-  }
-
+  nvim_paste(keys, true, phase, &err);
   if (ERROR_SET(&err)) {
     emsgf("paste: %s", err.msg);
     api_clear_error(&err);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -454,7 +454,7 @@ static void tui_scheduler(Event event, void *d)
 {
   UI *ui = d;
   TUIData *data = ui->data;
-  loop_schedule(data->loop, event);  // `tui_loop` local to tui_main().
+  loop_schedule_fast(data->loop, event);  // `tui_loop` local to tui_main().
 }
 
 #ifdef UNIX

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -228,7 +228,11 @@ static void ui_refresh_event(void **argv)
 
 void ui_schedule_refresh(void)
 {
-  loop_schedule(&main_loop, event_create(ui_refresh_event, 0));
+  // TODO(bfredl): "fast" is not optimal. UI should be refreshed only at
+  // deferred processing plus a few more blocked-on-input situtions like
+  // wait_return(), but not any os_breakcheck(). Alternatively make this
+  // defered and make wait_return() process deferred events already.
+  loop_schedule_fast(&main_loop, event_create(ui_refresh_event, 0));
 }
 
 void ui_default_colors_set(void)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -518,6 +518,35 @@ describe('API', function()
         line 3]])
       eq({0,3,6,0}, funcs.getpos('.'))
     end)
+
+    it('allows block width', function()
+      -- behave consistently with setreg(); support "\022{NUM}" return by getregtype()
+      meths.put({'line 1','line 2','line 3'}, 'l', false, false)
+      expect([[
+        line 1
+        line 2
+        line 3
+        ]])
+
+      -- larger width create spaces
+      meths.put({'a', 'bc'}, 'b3', false, false)
+      expect([[
+        a  line 1
+        bc line 2
+        line 3
+        ]])
+      -- smaller width is ignored
+      meths.put({'xxx', 'yyy'}, '\0221', false, true)
+      expect([[
+        xxxa  line 1
+        yyybc line 2
+        line 3
+        ]])
+      eq({false, "Invalid type: 'bx'"},
+         meth_pcall(meths.put, {'xxx', 'yyy'}, 'bx', false, true))
+      eq({false, "Invalid type: 'b3x'"},
+         meth_pcall(meths.put, {'xxx', 'yyy'}, 'b3x', false, true))
+    end)
   end)
 
   describe('nvim_strwidth', function()


### PR DESCRIPTION
Otherwise cursor and redraw code for normal and insert mode will not run. The "tickle" workaround was used for this instead, and can now be removed.

Also if the user attempted paste while nvim was blocked for input, then `nvim_paste` could be run inside any `os_breakcheck`. This could be dangerous.

Additionally, if `nvim_paste` caused a wait-return prompt then the TUI would dead-lock. Release the mutex lock while `nvim_paste` at the expense of an extra copy (copy will be needed anyway with #10071 )

The builtin `vim.lua` got the module name `[string "-- Nvim-Lua stdlib: the vim module (:help l..."]` in error messages. Fix it to something reasonable.