### PR TITLE
Fix test/busted/outputHandlers/TAP.lua

### DIFF
--- a/test/busted/outputHandlers/TAP.lua
+++ b/test/busted/outputHandlers/TAP.lua
@@ -3,12 +3,14 @@
 local global_helpers = require('test.helpers')
 
 return function(options)
+  local busted = require 'busted'
   local handler = require 'busted.outputHandlers.TAP'(options)
 
-  handler.suiteEnd = function()
+  local suiteEnd = function()
     io.write(global_helpers.read_nvim_log())
-    return handler.suiteEnd()
+    return nil, true
   end
+  busted.subscribe({ 'suite', 'end' }, suiteEnd)
 
   return handler
 end


### PR DESCRIPTION
Extending the original TAP handler was not working as expected.
This adds a new function for displaying the log.

Ref: https://github.com/neovim/neovim/pull/10876