### PR TITLE
tests: fix Test_tagfiles: use Vim's 'tags'

### DIFF
--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -80,6 +80,8 @@ func Test_tags_too_long()
 endfunc
 
 func Test_tagfiles()
+  " Nvim: different default for 'tags'.
+  set tags=./tags,tags
   call assert_equal([], tagfiles())
 
   call writefile(["FFoo\tXfoo\t1"], 'Xtags1')


### PR DESCRIPTION
When run via `test_alot.vim` `Test_tagfiles` gets run after `set tags&`,
and might therefore pick up "tags" from Neovim's source directory.

This patch makes it use Vim's default always (which is different from
Neovim's).