### PR TITLE
vim-patch:8.0.0930: terminal buffers are stored in the viminfo file

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2366,7 +2366,7 @@ static inline bool ignore_buf(const buf_T *const buf,
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE
 {
   return (buf->b_ffname == NULL || !buf->b_p_bl || bt_quickfix(buf) \
-          || in_bufset(removable_bufs, buf));
+          || bt_terminal(buf) || in_bufset(removable_bufs, buf));
 }
 
 /// Get list of buffers to write to the shada file


### PR DESCRIPTION
Problem:    Terminal buffers are stored in the viminfo file while they can't
            be useful.
Solution:   Skip terminal buffers for file marks and buffer list
https://github.com/vim/vim/commit/e62780543f403186b27b210dd087dd8ba74159fc