### PR TITLE
vim-patch:8.1.0212: preferred cursor column not set in interfaces

### DIFF
--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -26,6 +26,20 @@ func Test_pydo()
   endif
 endfunc
 
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  py import vim
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  pydo vim.current.window.cursor = (1, 5)
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
+endfunc
+
 func Test_vim_function()
   " Check creating vim.Function object
   py import vim

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -1,4 +1,4 @@
-" Test for python 2 commands.
+" Test for python 3 commands.
 " TODO: move tests from test88.in here.
 
 if !has('python3')
@@ -24,6 +24,20 @@ func Test_py3do()
     bwipe!
     bwipe!
   endif
+endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  py3 import vim
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  py3do vim.current.window.cursor = (1, 5)
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
 endfunc
 
 func Test_vim_function()


### PR DESCRIPTION
Problem:    Preferred cursor column not set in interfaces.
Solution:   Set w_set_curswant when setting the cursor. (David Hotham,
            closes vim/vim#3060)
https://github.com/vim/vim/commit/53901442f37a59e5495165f91db5574c0b43ab04

No code changes appear to be required for Neovim.
`test_python2.vim` / `test_python3.vim` does not appear to run currently on CI (https://github.com/neovim/neovim/pull/10269), but verified this locally.