### PR TITLE
vim-patch:8.1.0950: using :python sets 'pyxversion' even when not executed

### DIFF
--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -53,6 +53,14 @@ func Test_vim_function()
   delfunc s:foo
 endfunc
 
+func Test_skipped_python_command_does_not_affect_pyxversion()
+  set pyxversion=0
+  if 0
+    python import vim
+  endif
+  call assert_equal(0, &pyxversion)  " This assertion would have failed with Vim 8.0.0251. (pyxversion was introduced in 8.0.0251.)
+endfunc
+
 func _SetUpHiddenBuffer()
   py import vim
   new

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -53,6 +53,14 @@ func Test_vim_function()
   delfunc s:foo
 endfunc
 
+func Test_skipped_python3_command_does_not_affect_pyxversion()
+  set pyxversion=0
+  if 0
+    python3 import vim
+  endif
+  call assert_equal(0, &pyxversion)  " This assertion would have failed with Vim 8.0.0251. (pyxversion was introduced in 8.0.0251.)
+endfunc
+
 func _SetUpHiddenBuffer()
   py3 import vim
   new


### PR DESCRIPTION
Problem:    Using :python sets 'pyxversion' even when not executed.
Solution:   Check the "skip" flag. (Shane Harper, closes vim/vim#3995)
https://github.com/vim/vim/commit/14816ad6e58336773443f5ee2e4aa9e384af65d2

No code changes appear to be required for Neovim.
test_python2.vim / test_python3.vim does not appear to run currently on CI (#10269), but verified this locally.