### PR TITLE
vim-patch:8.1.1947: when executing one test the report doesn't show it

### DIFF
--- a/src/nvim/testdir/summarize.vim
+++ b/src/nvim/testdir/summarize.vim
@@ -21,9 +21,9 @@ if 1
 
   try
     " This uses the :s command to just fetch and process the output of the
-    " tests, it doesn't acutally replace anything.
+    " tests, it doesn't actually replace anything.
     " And it uses "silent" to avoid reporting the number of matches.
-    silent %s/^Executed\s\+\zs\d\+\ze\s\+tests/\=Count(submatch(0),'executed')/egn
+    silent %s/^Executed\s\+\zs\d\+\ze\s\+tests\?/\=Count(submatch(0),'executed')/egn
     silent %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
     silent %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
 


### PR DESCRIPTION
Problem:    When executing one test the report doesn't show it.
Solution:   Adjust the regexp. (Daniel Hahler, closes vim/vim#4879)
https://github.com/vim/vim/commit/60b1bcfe92da1d7b8f894c91192f3a76e8aec391