### PR TITLE
termdebug: disable line numbers in floats

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -687,7 +687,7 @@ function! s:OpenHoverPreview(lines, filetype) abort
             \   'height': height,
             \ })
       call nvim_win_set_option(float_win_id, 'relativenumber', v:false)
-      call nvim_win_set_option(float_win_id, 'signcolumn', 'no')
+      call nvim_win_set_option(float_win_id, 'number', v:false)
       call nvim_win_set_option(float_win_id, 'signcolumn', 'no')
       if a:filetype isnot v:null
         call nvim_win_set_option(float_win_id, 'filetype', a:filetype)

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -685,10 +685,9 @@ function! s:OpenHoverPreview(lines, filetype) abort
             \   'col': col,
             \   'width': width,
             \   'height': height,
+            \   'style': 'minimal',
             \ })
-      call nvim_win_set_option(float_win_id, 'relativenumber', v:false)
-      call nvim_win_set_option(float_win_id, 'number', v:false)
-      call nvim_win_set_option(float_win_id, 'signcolumn', 'no')
+
       if a:filetype isnot v:null
         call nvim_win_set_option(float_win_id, 'filetype', a:filetype)
       endif


### PR DESCRIPTION
I noticed that line numbers weren't hidden in the floating window of this plugin (which also meant the variable is cut off, as the number column isn't considered when calculating the width of the float). 

When looking at the code, it seems like there was an erroneous duplication of disabling `signcolumn`, and `nonumber` was indeed missed when porting the original implementation to Neovim.