### PR TITLE
vim-patch:8.1.{475,800,868,1007,1027,1031,1033,1037,1058,1435,1484,1485}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -442,7 +442,8 @@ void eval_clear(void)
   // unreferenced lists and dicts
   (void)garbage_collect(false);
 
-  // functions
+  // functions need to be freed before gargabe collecting, otherwise local
+  // variables might be freed twice.
   free_all_functions();
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -439,12 +439,12 @@ void eval_clear(void)
     xfree(SCRIPT_SV(i));
   ga_clear(&ga_scripts);
 
-  // unreferenced lists and dicts
-  (void)garbage_collect(false);
-
   // functions need to be freed before gargabe collecting, otherwise local
   // variables might be freed twice.
   free_all_functions();
+
+  // unreferenced lists and dicts
+  (void)garbage_collect(false);
 }
 
 #endif

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -439,12 +439,11 @@ void eval_clear(void)
     xfree(SCRIPT_SV(i));
   ga_clear(&ga_scripts);
 
-  // functions need to be freed before gargabe collecting, otherwise local
-  // variables might be freed twice.
-  free_all_functions();
-
   // unreferenced lists and dicts
   (void)garbage_collect(false);
+
+  // functions not garbage collected
+  free_all_functions();
 }
 
 #endif

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5026,7 +5026,7 @@ bool garbage_collect(bool testing)
 
     // 3. Check if any funccal can be freed now.
     //    This may call us back recursively.
-    did_free = did_free || free_unref_funccal(copyID, testing);
+    did_free = free_unref_funccal(copyID, testing) || did_free;
   } else if (p_verbose > 0) {
     verb_msg(_(
         "Not enough memory to set references, garbage collection aborted!"));

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7219,7 +7219,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   uint8_t *save_sourcing_name, *save_autocmd_fname, *save_autocmd_match;
   linenr_T save_sourcing_lnum;
   int save_autocmd_bufnr;
-  void *save_funccalp;
+  funccal_entry_T funccal_entry;
 
   if (l_provider_call_nesting) {
     // If this is called from a provider function, restore the scope
@@ -7230,7 +7230,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     save_autocmd_fname = autocmd_fname;
     save_autocmd_match = autocmd_match;
     save_autocmd_bufnr = autocmd_bufnr;
-    save_funccalp = save_funccal();
+    save_funccal(&funccal_entry);
 
     current_sctx = provider_caller_scope.script_ctx;
     sourcing_name = provider_caller_scope.sourcing_name;
@@ -7238,7 +7238,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     autocmd_fname = provider_caller_scope.autocmd_fname;
     autocmd_match = provider_caller_scope.autocmd_match;
     autocmd_bufnr = provider_caller_scope.autocmd_bufnr;
-    restore_funccal(provider_caller_scope.funccalp);
+    set_current_funccal((funccall_T *)(provider_caller_scope.funccalp));
   }
 
 
@@ -7256,7 +7256,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     autocmd_fname = save_autocmd_fname;
     autocmd_match = save_autocmd_match;
     autocmd_bufnr = save_autocmd_bufnr;
-    restore_funccal(save_funccalp);
+    restore_funccal();
   }
 
   if (ERROR_SET(&err)) {

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -607,7 +607,7 @@ _convert_one_value_regular_dict: {}
                                              kMPConvDict);
       TYPVAL_ENCODE_CONV_DICT_START(tv, tv->vval.v_dict,
                                     tv->vval.v_dict->dv_hashtab.ht_used);
-      assert(saved_copyID != copyID && saved_copyID != copyID - 1);
+      assert(saved_copyID != copyID);
       _mp_push(*mpstack, ((MPConvStackVal) {
         .tv = tv,
         .type = kMPConvDict,

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3356,9 +3356,18 @@ bool set_ref_in_call_stack(int copyID)
   bool abort = false;
 
   for (funccall_T *fc = current_funccal; fc != NULL; fc = fc->caller) {
-    abort = abort || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL);
-    abort = abort || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL);
+    abort = abort || set_ref_in_funccal(fc, copyID);
   }
+
+  // Also go through the funccal_stack.
+  for (funccal_entry_T *entry = funccal_stack; entry != NULL;
+       entry = entry->next) {
+    for (funccall_T *fc = entry->top_funccal; !abort && fc != NULL;
+         fc = fc->caller) {
+      abort = abort || set_ref_in_funccal(fc, copyID);
+    }
+  }
+
   return abort;
 }
 

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -11,6 +11,12 @@ typedef struct {
   dictitem_T  *fd_di;  ///< Dictionary item used.
 } funcdict_T;
 
+typedef struct funccal_entry funccal_entry_T;
+struct funccal_entry {
+  void *top_funccal;
+  funccal_entry_T *next;
+};
+
 /// errors for when calling a function
 typedef enum {
   ERROR_UNKNOWN = 0,

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3106,7 +3106,6 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   int retval = FAIL;
   static scid_T last_current_SID = 0;
   static int last_current_SID_seq = 0;
-  void                    *save_funccalp;
   int save_debug_break_level = debug_break_level;
   scriptitem_T            *si = NULL;
   proftime_T wait_start;
@@ -3227,7 +3226,8 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
 
   // Don't use local function variables, if called from a function.
   // Also starts profiling timer for nested script.
-  save_funccalp = save_funccal();
+  funccal_entry_T funccalp_entry;
+  save_funccal(&funccalp_entry);
 
   // Check if this script was sourced before to finds its SID.
   // If it's new, generate a new SID.
@@ -3352,7 +3352,7 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   }
 
   current_sctx = save_current_sctx;
-  restore_funccal(save_funccalp);
+  restore_funccal();
   if (l_do_profiling == PROF_YES) {
     prof_child_exit(&wait_start);    // leaving a child now
   }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -6736,7 +6736,6 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   static int nesting = 0;
   AutoPatCmd patcmd;
   AutoPat     *ap;
-  void        *save_funccalp;
   char_u      *save_cmdarg;
   long save_cmdbang;
   static int filechangeshell_busy = FALSE;
@@ -6926,8 +6925,9 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   if (do_profiling == PROF_YES)
     prof_child_enter(&wait_time);     /* doesn't count for the caller itself */
 
-  /* Don't use local function variables, if called from a function */
-  save_funccalp = save_funccal();
+  // Don't use local function variables, if called from a function.
+  funccal_entry_T funccal_entry;
+  save_funccal(&funccal_entry);
 
   /*
    * When starting to execute autocommands, save the search patterns.
@@ -7016,9 +7016,10 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   autocmd_bufnr = save_autocmd_bufnr;
   autocmd_match = save_autocmd_match;
   current_sctx = save_current_sctx;
-  restore_funccal(save_funccalp);
-  if (do_profiling == PROF_YES)
+  restore_funccal();
+  if (do_profiling == PROF_YES) {
     prof_child_exit(&wait_time);
+  }
   KeyTyped = save_KeyTyped;
   xfree(fname);
   xfree(sfname);

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -44,6 +44,10 @@ if &lines < 24 || &columns < 80
   qa!
 endif
 
+if has('reltime')
+  let s:start_time = reltime()
+endif
+
 " Common with all tests on all systems.
 source setup.vim
 
@@ -100,6 +104,9 @@ endfunc
 
 func RunTheTest(test)
   echo 'Executing ' . a:test
+  if has('reltime')
+    let func_start = reltime()
+  endif
 
   " Avoid stopping at the "hit enter" prompt
   set nomore
@@ -124,7 +131,11 @@ func RunTheTest(test)
     endtry
   endif
 
-  call add(s:messages, 'Executing ' . a:test)
+  let message = 'Executed ' . a:test
+  if has('reltime')
+    let message ..= ' in ' .. reltimestr(reltime(func_start)) .. ' seconds'
+  endif
+  call add(s:messages, message)
   let s:done += 1
 
   if a:test =~ 'Test_nocatch_'
@@ -229,6 +240,9 @@ func FinishTesting()
     let message = 'NO tests executed'
   else
     let message = 'Executed ' . s:done . (s:done > 1 ? ' tests' : ' test')
+  endif
+  if has('reltime')
+    let message ..= ' in ' .. reltimestr(reltime(s:start_time)) .. ' seconds'
   endif
   echo message
   call add(s:messages, message)

--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -143,8 +143,10 @@ describe('memory usage', function()
       feed_command('so '..fname)
     end
     local last = monitor_memory_usage(pid)
+    -- The usage may be a bit less than the last value
+    local lower = before.last * 8 / 10
     check_result({before=before, after=after, last=last},
-                 pcall(ok, before.last < last.last))
+                 pcall(ok, lower < last.last))
     check_result({before=before, after=after, last=last},
                  pcall(ok, last.last < after.max + (after.last - before.last)))
   end)

--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -1,0 +1,151 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local eval = helpers.eval
+local eq = helpers.eq
+local feed_command = helpers.feed_command
+local iswin = helpers.iswin
+local retry = helpers.retry
+local ok = helpers.ok
+local source = helpers.source
+
+local monitor_memory_usage = {
+  memory_usage = function(self)
+    local handle
+    if iswin() then
+      handle = io.popen('wmic process where processid=' ..self.pid..' get WorkingSetSize')
+    else
+      handle = io.popen('ps -o rss= -p '..self.pid)
+    end
+    return tonumber(handle:read('*a'):match('%d+'))
+  end,
+  op = function(self)
+    retry(nil, 10000, function()
+      local val = self.memory_usage(self)
+      if self.min > val then
+        self.min = val
+      elseif self.max < val then
+        self.max = val
+      end
+      table.insert(self.hist, val)
+      ok(#self.hist > 20)
+      local result = {}
+      for key,value in ipairs(self.hist) do
+        if value ~= self.hist[key + 1] then
+          table.insert(result, value)
+        end
+      end
+      table.remove(self.hist, 1)
+      self.last = self.hist[#self.hist]
+      eq(#result, 1)
+    end)
+  end,
+  dump = function(self)
+    return 'max: '..self.max ..', last: '..self.last
+  end,
+  monitor_memory_usage = function(self, pid)
+    local obj = {
+      pid = pid,
+      min = 0,
+      max = 0,
+      last = 0,
+      hist = {},
+    }
+    setmetatable(obj, { __index = self })
+    obj:op()
+    return obj
+  end
+}
+setmetatable(monitor_memory_usage,
+{__call = function(self, pid)
+  return monitor_memory_usage.monitor_memory_usage(self, pid)
+end})
+
+describe('memory usage', function()
+  local function check_result(tbl, status, result)
+    if not status then
+      print('')
+      for key, val in pairs(tbl) do
+        print(key, val:dump())
+      end
+      error(result)
+    end
+  end
+
+  local function isasan()
+    local version = eval('execute("version")')
+    return version:match('-fsanitize=[a-z,]*address')
+  end
+
+  before_each(clear)
+
+  --[[
+  Case: if a local variable captures a:000, funccall object will be free
+  just after it finishes.
+  ]]--
+  it('function capture vargs', function()
+    if isasan() then
+      pending('ASAN build is difficult to estimate memory usage')
+    end
+    if iswin() and eval("executable('wmic')")  == 0 then
+      pending('missing "wmic" command')
+    elseif eval("executable('ps')")  == 0 then
+      pending('missing "ps" command')
+    end
+
+    local pid = eval('getpid()')
+    local before = monitor_memory_usage(pid)
+    source([[
+      func s:f(...)
+        let x = a:000
+      endfunc
+      for _ in range(10000)
+        call s:f(0)
+      endfor
+    ]])
+    local after = monitor_memory_usage(pid)
+    -- Estimate the limit of max usage as 2x initial usage.
+    check_result({before=before, after=after}, pcall(ok, before.last < after.max))
+    check_result({before=before, after=after}, pcall(ok, before.last * 2 > after.max))
+    -- In this case, garbase collecting is not needed.
+    check_result({before=before, after=after}, pcall(eq, after.last, after.max))
+  end)
+
+  --[[
+  Case: if a local variable captures l: dict, funccall object will not be
+  free until garbage collector runs, but after that memory usage doesn't
+  increase so much even when rerun Xtest.vim since system memory caches.
+  ]]--
+  it('function capture lvars', function()
+    if isasan() then
+      pending('ASAN build is difficult to estimate memory usage')
+    end
+    if iswin() and eval("executable('wmic')")  == 0 then
+      pending('missing "wmic" command')
+    elseif eval("executable('ps')")  == 0 then
+      pending('missing "ps" command')
+    end
+
+    local pid = eval('getpid()')
+    local before = monitor_memory_usage(pid)
+    local fname = source([[
+      if !exists('s:defined_func')
+        func s:f()
+          let x = l:
+        endfunc
+      endif
+      let s:defined_func = 1
+      for _ in range(10000)
+        call s:f()
+      endfor
+    ]])
+    local after = monitor_memory_usage(pid)
+    for _ = 1, 3 do
+      feed_command('so '..fname)
+    end
+    local last = monitor_memory_usage(pid)
+    check_result({before=before, after=after, last=last},
+                 pcall(ok, before.last < last.last))
+    check_result({before=before, after=after, last=last},
+                 pcall(ok, last.last < after.max + (after.last - before.last)))
+  end)
+end)

--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -101,11 +101,13 @@ describe('memory usage', function()
     ]])
     local after = monitor_memory_usage(pid)
     -- Estimate the limit of max usage as 2x initial usage.
-    check_result({before=before, after=after}, pcall(ok, before.last < after.max))
-    check_result({before=before, after=after}, pcall(ok, before.last * 2 > after.max))
+    -- The lower limit can fluctuate a bit, use 98%.
+    check_result({before=before, after=after},
+                 pcall(ok, before.last * 98 / 100 < after.max))
+    check_result({before=before, after=after},
+                 pcall(ok, before.last * 2 > after.max))
     -- In this case, garbage collecting is not needed.
-    -- The value might fluctuate
-    -- a bit, allow for 3% tolerance.
+    -- The value might fluctuate a bit, allow for 3% tolerance.
     local lower = after.last * 97 / 100
     local upper = after.last * 103 / 100
     check_result({before=before, after=after}, pcall(ok, lower < after.max))

--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -146,9 +146,9 @@ describe('memory usage', function()
     end
     local last = monitor_memory_usage(pid)
     -- The usage may be a bit less than the last value, use 80%.
-    -- Allow for 1% tolerance at the upper limit.
+    -- Allow for 3% tolerance at the upper limit.
     local lower = before.last * 8 / 10
-    local upper = (after.max + (after.last - before.last)) * 101 / 100
+    local upper = (after.max + (after.last - before.last)) * 103 / 100
     check_result({before=before, after=after, last=last},
                  pcall(ok, lower < last.last))
     check_result({before=before, after=after, last=last},

--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -101,15 +101,16 @@ describe('memory usage', function()
     ]])
     local after = monitor_memory_usage(pid)
     -- Estimate the limit of max usage as 2x initial usage.
-    -- The lower limit can fluctuate a bit, use 98%.
+    -- The lower limit can fluctuate a bit, use 97%.
     check_result({before=before, after=after},
-                 pcall(ok, before.last * 98 / 100 < after.max))
+                 pcall(ok, before.last * 97 / 100 < after.max))
     check_result({before=before, after=after},
                  pcall(ok, before.last * 2 > after.max))
     -- In this case, garbage collecting is not needed.
-    -- The value might fluctuate a bit, allow for 3% tolerance.
+    -- The value might fluctuate a bit, allow for 3% tolerance below and 5% above.
+    -- Based on various test runs.
     local lower = after.last * 97 / 100
-    local upper = after.last * 103 / 100
+    local upper = after.last * 105 / 100
     check_result({before=before, after=after}, pcall(ok, lower < after.max))
     check_result({before=before, after=after}, pcall(ok, after.max < upper))
   end)

--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -146,9 +146,10 @@ describe('memory usage', function()
     end
     local last = monitor_memory_usage(pid)
     -- The usage may be a bit less than the last value, use 80%.
-    -- Allow for 3% tolerance at the upper limit.
+    -- Allow for 20% tolerance at the upper limit. That's very permissive, but
+    -- otherwise the test fails sometimes.
     local lower = before.last * 8 / 10
-    local upper = (after.max + (after.last - before.last)) * 103 / 100
+    local upper = (after.max + (after.last - before.last)) * 12 / 10
     check_result({before=before, after=after, last=last},
                  pcall(ok, lower < last.last))
     check_result({before=before, after=after, last=last},


### PR DESCRIPTION
- [x] vim-patch:8.1.1485
- [x] vim-patch:8.1.1536
- [ ] ~vim-patch:8.1.1575~
- [ ] ~vim-patch:8.1.1583~

**vim-patch:8.1.0475: memory not freed on exit when quit in autocmd**
Problem:    Memory not freed on exit when quit in autocmd.
Solution:   Remember funccal stack when executing autocmd.
https://github.com/vim/vim/commit/27e80c885bcb5c5cf6a6462d71d6c81b06ba2451

**vim-patch:8.1.0800: may use a lot of memory when a function refers itself**
Problem:    May use a lot of memory when a function creates a cyclic reference.
Solution:   After saving a funccal many times, invoke the garbage collector. (closes vim/vim#3835)
vim/vim@4456ab5

**vim-patch:8.1.0868: crash if triggering garbage collector after a function call**
Problem:    Crash if triggering garbage collector after a function call. (Michael Henry)
Solution:   Don't call the garbage collector right away, do it later. (closes vim/vim#3894)
vim/vim@889da2f

**vim-patch:8.1.1007: using closure may consume a lot of memory**
Problem:    Using closure may consume a lot of memory.
Solution:   unreference items that are no longer needed. Add a test. (Ozaki Kiichi, closes vim/vim#3961)
vim/vim@209b8e3

**vim-patch:8.1.1027: memory usage test sometimes fails**
Problem:    Memory usage test sometimes fails.
Solution:   Use 80% of before.last as the lower limit. (Christian Brabandt)
vim/vim@08cda65

**vim-patch:8.1.1031: memory usage test may still fail**
Problem:    Memory usage test may still fail.
Solution:   Drop the unused min value. (Christian Brabandt)
vim/vim@f7e47af

**vim-patch:8.1.1033: memory usage test may still fail on some systems**
Problem:    Memory usage test may still fail on some systems. (Elimar Riesebieter)
Solution:   Increase tolerance from 1% to 3%.

**vim-patch:8.1.1037: memory usage test may still fail on some systems**
Problem:    Memory usage test may still fail on some systems.
Solution:   Increase tolerance from 3% to 20%.
vim/vim@6b6f7aa

**vim-patch:8.1.1058: memory usage test may still fail on some systems**
Problem:    Memory usage test may still fail on some systems.
Solution:   Use 98% of the lower limit. (Christian Brabandt)
vim/vim@3a731ee

**vim-patch:8.1.1435: memory usage test is a bit too flaky**
Problem:    Memory usage test is a bit too flaky.
Solution:   Adjust the tolerances a bit. (Christian Brabandt)
vim/vim@5d508dd

**vim-patch:8.1.1484: some tests are slow**
Problem:    Some tests are slow.
Solution:   Add timing to the test messages.  Fix double free when quitting in VimLeavePre autocmd.
vim/vim@75ee544

**vim-patch:8.1.1485: double free when garbage_collect() is used in autocommand**
Problem:    Double free when garbage_collect() is used in autocommand.
Solution:   Have garbage collection also set the copyID in funccal_stack.
vim/vim@c07f67a