### PR TITLE
vim-patch:8.0.0858

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6985,6 +6985,7 @@ void save_file_ff(buf_T *buf)
 /// When "ignore_empty" is true don't consider a new, empty buffer to be
 /// changed.
 bool file_ff_differs(buf_T *buf, bool ignore_empty)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   // In a buffer that was never loaded the options are not valid.
   if (buf->b_flags & BF_NEVERLOADED) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2962,7 +2962,7 @@ static char_u *u_save_line(linenr_T lnum)
 ///
 /// @return true if the buffer has changed
 bool bufIsChanged(buf_T *buf)
-  FUNC_ATTR_WARN_UNUSED_RESULT
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return !bt_dontwrite(buf) && (buf->b_changed || file_ff_differs(buf, true));
 }
@@ -2979,15 +2979,12 @@ bool anyBufIsChanged(void)
   return false;
 }
 
-/// Check if the 'modified' flag is set, or 'ff' has changed (only need to
-/// check the first character, because it can only be "dos", "unix" or "mac").
-/// "nofile" and "scratch" type buffers are considered to always be unchanged.
-///
+/// @see bufIsChanged
 /// @return true if the current buffer has changed
 bool curbufIsChanged(void)
+  FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  return (!bt_dontwrite(curbuf)
-          && (curbuf->b_changed || file_ff_differs(curbuf, true)));
+  return bufIsChanged(curbuf);
 }
 
 /// Append the list of undo blocks to a newly allocated list


### PR DESCRIPTION
Noticed this while checking vim-patch:8.0.1382 because it targets the following code from vim-patch:8.0.0858 that was not ported to neovim.

```c
    int
bufIsChanged(buf_T *buf)
{
#ifdef FEAT_TERMINAL
    if (term_job_running(buf->b_term))
	return TRUE;
#endif
    return !bt_dontwrite(buf)
	&& (buf->b_changed || file_ff_differs(buf, TRUE));
}
```
