### PR TITLE
screen: fixes for `set display-=msgsep`

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -154,8 +154,8 @@ void msg_grid_validate(void)
 {
   grid_assign_handle(&msg_grid);
   bool should_alloc = msg_dothrottle();
-  if (msg_grid.Rows != Rows || msg_grid.Columns != Columns
-      || (should_alloc && !msg_grid.chars)) {
+  if (should_alloc && (msg_grid.Rows != Rows || msg_grid.Columns != Columns
+                       || !msg_grid.chars)) {
     // TODO(bfredl): eventually should be set to "invalid". I e all callers
     // will use the grid including clear to EOS if necessary.
     grid_alloc(&msg_grid, Rows, Columns, false, true);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -404,7 +404,7 @@ int update_screen(int type)
     default_grid.valid = true;
   }
 
-  if (type == NOT_VALID && msg_dothrottle()) {
+  if (type == NOT_VALID && (msg_dothrottle() || msg_grid.chars)) {
     grid_fill(&default_grid, Rows-p_ch, Rows, 0, Columns, ' ', ' ', 0);
   }
 
@@ -7288,9 +7288,9 @@ void screen_resize(int width, int height)
         }
       }
     }
+    ui_flush();
   }
-  ui_flush();
-  --busy;
+  busy--;
 }
 
 /// Check if the new Nvim application "shell" dimensions are valid.

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -81,6 +81,20 @@ local function test_embed(ext_linegrid)
       eq(Screen.colors.Green, screen.default_colors.rgb_bg)
     end}
   end)
+
+  it("set display-=msgsep before first redraw", function()
+    startup('--cmd', 'set display-=msgsep')
+    screen:expect{grid=[[
+      ^                                                            |
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+                                                                  |
+    ]]}
+  end)
 end
 
 describe('--embed UI on startup (ext_linegrid=true)', function() test_embed(true) end)


### PR DESCRIPTION
Currently `nvim -u NORC --cmd "set display-=msgsep"` will still allocate the message grid and remove it just afterwards. While inefficient, we must make sure `update_screen()` re-validates the `default_grid` completely when this happens.

Something weird happens to the cursor when `ext_linegrid=false` only, need to investigate.
