### PR TITLE
vim-patch:8.1.1962: leaking memory when using tagfunc()

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4568,8 +4568,10 @@ win_free (
 
   xfree(wp->w_lines);
 
-  for (i = 0; i < wp->w_tagstacklen; ++i)
+  for (i = 0; i < wp->w_tagstacklen; i++) {
     xfree(wp->w_tagstack[i].tagname);
+    xfree(wp->w_tagstack[i].user_data);
+  }
 
   xfree(wp->w_localdir);
 


### PR DESCRIPTION
Problem:    Leaking memory when using tagfunc().
Solution:   Free the user_data. (Dominique Pelle, closes vim/vim#4886)
https://github.com/vim/vim/commit/55008aad50601cae079037fda8fb434cde70c0f4