### PR TITLE
api: make try_end clean-up afer an exception properly. 

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -125,6 +125,7 @@ bool try_end(Error *err)
 
   // Set by emsg(), affects aborting().  See also enter_cleanup().
   did_emsg = false;
+  force_abort = false;
 
   if (got_int) {
     if (current_exception) {


### PR DESCRIPTION
Otherwise `force_abort` will cause an emsg() higher on the stack
to be converted to an exception, even though it is outside any
try/catch.

Fixes #10809
