### PR TITLE
tests: assert:set_parameter('TableFormatLevel', 100)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -249,11 +249,6 @@ the file).
 Configuration
 =============
 
-busted (luassert) by default does not print the full result of deeply-nested
-tables. But sometimes it's useful while debugging a test.
-
-    assert:set_parameter('TableFormatLevel', 1000000)
-
 Test behaviour is affected by environment variables. Currently supported 
 (Functional, Unit, Benchmarks) (when Defined; when set to _1_; when defined, 
 treated as Integer; when defined, treated as String; when defined, treated as 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1568,7 +1568,6 @@ describe('API', function()
         return ('%s(%s)%s'):format(typ, args, rest)
       end
     end
-    assert:set_parameter('TableFormatLevel', 1000000)
     require('test.unit.viml.expressions.parser_tests')(
         it_maybe_pending, _check_parsing, hl, fmtn)
   end)

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -1360,8 +1360,6 @@ describe('autoload/shada.vim', function()
       nvim_command('unlet g:__actual')
     end
 
-    assert:set_parameter('TableFormatLevel', 100)
-
     it('works with multiple items', function()
       strings2sd_eq({{
         type=11, timestamp=0, data={

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -6,6 +6,8 @@ local lfs = require('lfs')
 local relpath = require('pl.path').relpath
 local Paths = require('test.config.paths')
 
+assert:set_parameter('TableFormatLevel', 100)
+
 local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
 local function shell_quote(str)
   if string.find(str, quote_me) or str == '' then

--- a/test/unit/viml/expressions/parser_spec.lua
+++ b/test/unit/viml/expressions/parser_spec.lua
@@ -451,10 +451,6 @@ local function phl2lua(pstate)
   return ret
 end
 
-child_call_once(function()
-  assert:set_parameter('TableFormatLevel', 1000000)
-end)
-
 describe('Expressions parser', function()
   local function _check_parsing(opts, str, exp_ast, exp_highlighting_fs,
                                 nz_flags_exps)


### PR DESCRIPTION
luassert uses 3 by default, which is often not enough.

Instead of documenting how to increase it, let's use a more fitting
(sane) default of 100 levels.

Ref: https://github.com/neovim/neovim/commit/afef973262bea3fe1563dc0571bb4168ac0914aa#diff-c30ff793110b0960f76bb3854af6f5a8R252-R255 (added the docs)