### PR TITLE
Check got_int in msg_multiline_attr with ex_echo

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -20903,7 +20903,7 @@ void ex_echo(exarg_T *eap)
       char *tofree = encode_tv2echo(&rettv, NULL);
       if (*tofree != NUL) {
         msg_ext_set_kind("echo");
-        msg_multiline_attr(tofree, echo_attr);
+        msg_multiline_attr(tofree, echo_attr, true);
       }
       xfree(tofree);
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -222,12 +222,12 @@ int msg_attr(const char *s, const int attr)
 }
 
 /// similar to msg_outtrans_attr, but support newlines and tabs.
-void msg_multiline_attr(const char *s, int attr)
+void msg_multiline_attr(const char *s, int attr, bool check_int)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *next_spec = s;
 
-  while (next_spec != NULL && !got_int) {
+  while (next_spec != NULL && (!check_int || !got_int)) {
     next_spec = strpbrk(s, "\t\n\r");
 
     if (next_spec != NULL) {
@@ -306,7 +306,7 @@ bool msg_attr_keep(char_u *s, int attr, bool keep, bool multiline)
     s = buf;
 
   if (multiline) {
-    msg_multiline_attr((char *)s, attr);
+    msg_multiline_attr((char *)s, attr, false);
   } else {
     msg_outtrans_attr(s, attr);
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -227,7 +227,7 @@ void msg_multiline_attr(const char *s, int attr)
 {
   const char *next_spec = s;
 
-  while (next_spec != NULL) {
+  while (next_spec != NULL && !got_int) {
     next_spec = strpbrk(s, "\t\n\r");
 
     if (next_spec != NULL) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1052,3 +1052,37 @@ describe('ui/msg_puts_printf', function()
     os.execute('cmake -E remove_directory '..test_build_dir..'/share')
   end)
 end)
+
+describe('pager', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(25, 5)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    })
+  end)
+
+  it('can be quit', function()
+    command("set more")
+    feed(':echon join(map(range(0, &lines*2), "v:val"), "\\n")<cr>')
+    screen:expect{grid=[[
+      0                        |
+      1                        |
+      2                        |
+      3                        |
+      {4:-- More --}^               |
+    ]]}
+    feed('q')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+                               |
+    ]]}
+  end)
+end)

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -951,6 +951,46 @@ local function screen_tests(linegrid)
                                                            |
     ]])
   end)
+
+  describe('more prompt', function()
+    it('can be quit', function()
+      command("set more")
+      feed(':echon join(map(range(0, &lines*2), "v:val"), "\\n")<cr>')
+      screen:expect{grid=[[
+        0                                                    |
+        1                                                    |
+        2                                                    |
+        3                                                    |
+        4                                                    |
+        5                                                    |
+        6                                                    |
+        7                                                    |
+        8                                                    |
+        9                                                    |
+        10                                                   |
+        11                                                   |
+        12                                                   |
+        {7:-- More --}^                                           |
+      ]]}
+      feed('q')
+      screen:expect{grid=[[
+        ^                                                     |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]]}
+    end)
+  end)
 end
 
 describe("Screen (char-based)", function()

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -951,46 +951,6 @@ local function screen_tests(linegrid)
                                                            |
     ]])
   end)
-
-  describe('more prompt', function()
-    it('can be quit', function()
-      command("set more")
-      feed(':echon join(map(range(0, &lines*2), "v:val"), "\\n")<cr>')
-      screen:expect{grid=[[
-        0                                                    |
-        1                                                    |
-        2                                                    |
-        3                                                    |
-        4                                                    |
-        5                                                    |
-        6                                                    |
-        7                                                    |
-        8                                                    |
-        9                                                    |
-        10                                                   |
-        11                                                   |
-        12                                                   |
-        {7:-- More --}^                                           |
-      ]]}
-      feed('q')
-      screen:expect{grid=[[
-        ^                                                     |
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-        {0:~                                                    }|
-                                                             |
-      ]]}
-    end)
-  end)
 end
 
 describe("Screen (char-based)", function()


### PR DESCRIPTION
Fixes quitting the pager using `q`.

Fixes https://github.com/neovim/neovim/issues/10923.