### PR TITLE
fixes for pager glitches and crashes

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2217,37 +2217,36 @@ void msg_scroll_up(bool may_throttle)
 /// we get throttling "for free" using standard redraw_win_later code paths.
 void msg_scroll_flush(void)
 {
-  if (!msg_grid.throttled) {
-    return;
-  }
-  msg_grid.throttled = false;
-  int pos_delta = msg_grid_pos_at_flush - msg_grid_pos;
-  assert(pos_delta >= 0);
-  int delta = MIN(msg_scrolled - msg_scrolled_at_flush, msg_grid.Rows);
+  if (msg_grid.throttled) {
+    msg_grid.throttled = false;
+    int pos_delta = msg_grid_pos_at_flush - msg_grid_pos;
+    assert(pos_delta >= 0);
+    int delta = MIN(msg_scrolled - msg_scrolled_at_flush, msg_grid.Rows);
 
-  if (pos_delta > 0) {
-    ui_ext_msg_set_pos(msg_grid_pos, true);
-    msg_grid_pos_at_flush = msg_grid_pos;
-  }
+    if (pos_delta > 0) {
+      ui_ext_msg_set_pos(msg_grid_pos, true);
+    }
 
-  int to_scroll = delta-pos_delta-msg_grid_scroll_discount;
-  assert(to_scroll >= 0);
+    int to_scroll = delta-pos_delta-msg_grid_scroll_discount;
+    assert(to_scroll >= 0);
 
-  // TODO(bfredl): msg_grid_pos should be 0 already when starting scrolling
-  // but this sometimes fails in "headless" message printing.
-  if (to_scroll > 0 && msg_grid_pos == 0) {
-    ui_call_grid_scroll(msg_grid.handle, 0, Rows, 0, Columns, to_scroll, 0);
-  }
+    // TODO(bfredl): msg_grid_pos should be 0 already when starting scrolling
+    // but this sometimes fails in "headless" message printing.
+    if (to_scroll > 0 && msg_grid_pos == 0) {
+      ui_call_grid_scroll(msg_grid.handle, 0, Rows, 0, Columns, to_scroll, 0);
+    }
 
-  for (int i = MAX(Rows-MAX(delta, 1), 0); i < Rows; i++) {
-    int row = i-msg_grid_pos;
-    assert(row >= 0);
-    ui_line(&msg_grid, row, 0, msg_grid.dirty_col[row], msg_grid.Columns,
-            HL_ATTR(HLF_MSG), false);
-    msg_grid.dirty_col[row] = 0;
+    for (int i = MAX(Rows-MAX(delta, 1), 0); i < Rows; i++) {
+      int row = i-msg_grid_pos;
+      assert(row >= 0);
+      ui_line(&msg_grid, row, 0, msg_grid.dirty_col[row], msg_grid.Columns,
+              HL_ATTR(HLF_MSG), false);
+      msg_grid.dirty_col[row] = 0;
+    }
   }
   msg_scrolled_at_flush = msg_scrolled;
   msg_grid_scroll_discount = 0;
+  msg_grid_pos_at_flush = msg_grid_pos;
 }
 
 void msg_reset_scroll(void)

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2725,6 +2725,8 @@ static int do_more_prompt(int typed_char)
           // scroll up, display line at bottom
           msg_scroll_up(true);
           inc_msg_scrolled();
+          grid_fill(&msg_grid_adj, Rows-2, Rows-1, 0, Columns, ' ', ' ',
+                    HL_ATTR(HLF_MSG));
           mp_last = disp_sb_line(Rows - 2, mp_last);
           toscroll--;
         }
@@ -2746,7 +2748,8 @@ static int do_more_prompt(int typed_char)
   }
 
   // clear the --more-- message
-  grid_fill(&msg_grid_adj, Rows - 1, Rows, 0, Columns, ' ', ' ', 0);
+  grid_fill(&msg_grid_adj, Rows - 1, Rows, 0, Columns, ' ', ' ',
+            HL_ATTR(HLF_MSG));
   redraw_cmdline = true;
   clear_cmdline = false;
   mode_displayed = false;
@@ -2820,7 +2823,7 @@ void msg_moremsg(int full)
   int attr;
   char_u      *s = (char_u *)_("-- More --");
 
-  attr = HL_ATTR(HLF_M);
+  attr = hl_combine_attr(HL_ATTR(HLF_MSG), HL_ATTR(HLF_M));
   grid_puts(&msg_grid_adj, s, Rows - 1, 0, attr);
   if (full) {
     grid_puts(&msg_grid_adj, (char_u *)

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2465,10 +2465,6 @@ static msgchunk_T *disp_sb_line(int row, msgchunk_T *smp)
     mp = mp->sb_next;
   }
 
-  if (msg_col < Columns) {
-    grid_fill(&msg_grid_adj, row, row+1, msg_col, Columns, ' ', ' ',
-              HL_ATTR(HLF_MSG));
-  }
   return mp->sb_next;
 }
 
@@ -2700,12 +2696,16 @@ static int do_more_prompt(int typed_char)
 
           if (toscroll == -1) {
             grid_ins_lines(&msg_grid_adj, 0, 1, Rows, 0, Columns);
+            grid_fill(&msg_grid_adj, 0, 1, 0, Columns, ' ', ' ',
+                      HL_ATTR(HLF_MSG));
             // display line at top
             (void)disp_sb_line(0, mp);
           } else {
             // redisplay all lines
             // TODO(bfredl): this case is not optimized (though only concerns
             // event fragmentization, not unnecessary scroll events).
+            grid_fill(&msg_grid_adj, 0, Rows, 0, Columns, ' ', ' ',
+                      HL_ATTR(HLF_MSG));
             for (i = 0; mp != NULL && i < Rows - 1; i++) {
               mp = disp_sb_line(i, mp);
               ++msg_scrolled;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -518,9 +518,10 @@ EXTERN long p_pyx;              // 'pyxversion'
 EXTERN char_u *p_rdb;           // 'redrawdebug'
 EXTERN unsigned rdb_flags;
 # ifdef IN_OPTION_C
-static char *(p_rdb_values[]) = { "compositor", NULL };
+static char *(p_rdb_values[]) = { "compositor", "nothrottle", NULL };
 # endif
 # define RDB_COMPOSITOR         0x001
+# define RDB_NOTHROTTLE         0x002
 
 EXTERN long p_rdt;              // 'redrawtime'
 EXTERN int p_remap;             // 'remap'

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -404,7 +404,9 @@ int update_screen(int type)
     default_grid.valid = true;
   }
 
-  if (type == NOT_VALID && (msg_dothrottle() || msg_grid.chars)) {
+  // After disabling msgsep the grid might not have been deallocated yet,
+  // hence we also need to check msg_grid.chars
+  if (type == NOT_VALID && (msg_use_grid() || msg_grid.chars)) {
     grid_fill(&default_grid, Rows-p_ch, Rows, 0, Columns, ' ', ' ', 0);
   }
 
@@ -6250,7 +6252,7 @@ void screenclear(void)
   msg_scrolled = 0;  // can't scroll back
   msg_didany = false;
   msg_didout = false;
-  if (HL_ATTR(HLF_MSG) > 0 && msg_dothrottle() && msg_grid.chars) {
+  if (HL_ATTR(HLF_MSG) > 0 && msg_use_grid() && msg_grid.chars) {
     grid_invalidate(&msg_grid);
     msg_grid_validate();
     msg_grid_invalid = false;

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -132,7 +132,7 @@ describe('TUI', function()
     -- TODO(bfredl): messes up the output (just like vim does).
     feed_data('g')
     screen:expect{grid=[[
-      {8:FAIL 1}        )                                   |
+                    )                                   |
       {8:Error detected while processing function ManyErr:} |
       {11:line    2:}                                        |
       {10:-- More --}{1: }                                       |
@@ -141,7 +141,7 @@ describe('TUI', function()
 
     screen:try_resize(50,10)
     screen:expect{grid=[[
-      {8:FAIL 1}        )                                   |
+                    )                                   |
       {8:Error detected while processing function ManyErr:} |
       {11:line    2:}                                        |
       {10:-- More --}                                        |

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -859,7 +859,7 @@ function Screen:_handle_grid_scroll(g, top, bot, left, right, rows, cols)
 
   -- clear invalid rows
   for i = stop + step, stop + rows, step do
-    self:_clear_row_section(grid, i, left, right)
+    self:_clear_row_section(grid, i, left, right, true)
   end
 end
 
@@ -1065,10 +1065,10 @@ function Screen:_clear_block(grid, top, bot, left, right)
   end
 end
 
-function Screen:_clear_row_section(grid, rownum, startcol, stopcol)
+function Screen:_clear_row_section(grid, rownum, startcol, stopcol, invalid)
   local row = grid.rows[rownum]
   for i = startcol, stopcol do
-    row[i].text = ' '
+    row[i].text = (invalid and '�' or ' ')
     row[i].attrs = self._clear_attrs
   end
 end


### PR DESCRIPTION
- overlong scollback lines were cut at newline https://github.com/neovim/neovim/issues/10262#issuecomment-527000040
- MsgArea highlightning was missing to EOL after `j` https://github.com/neovim/neovim/issues/10262#issuecomment-526980592
- crash in `:echon` output ( likely other `msg_multiline` output ) https://github.com/neovim/neovim/issues/10924

TODO:

- crash after resize in `!tmux split`