### PR TITLE
test: Eliminate expect_err

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -178,9 +178,20 @@ local function trim(s)
   return s:match('^%s*(.*%S)') or ''
 end
 
+--- Escapes magic chars in a Lua pattern string.
+---
+--@see https://github.com/rxi/lume
+--@param s  String to escape
+--@returns  %-escaped pattern string
+local function pesc(s)
+  assert(type(s) == 'string')
+  return s:gsub('[%(%)%.%%%+%-%*%?%[%]%^%$]', '%%%1')
+end
+
 local module = {
   deepcopy = deepcopy,
   gsplit = gsplit,
+  pesc = pesc,
   split = split,
   tbl_contains = tbl_contains,
   tbl_extend = tbl_extend,

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -13,7 +13,6 @@ local NIL = helpers.NIL
 local command = helpers.command
 local bufmeths = helpers.bufmeths
 local feed = helpers.feed
-local expect_err = helpers.expect_err
 local pcall_err = helpers.pcall_err
 
 describe('api/buf', function()
@@ -191,14 +190,14 @@ describe('api/buf', function()
 
     it('fails correctly when input is not valid', function()
       eq(1, curbufmeths.get_number())
-      expect_err([[String cannot contain newlines]],
-        bufmeths.set_lines, 1, 1, 2, false, {'b\na'})
+      eq([[String cannot contain newlines]],
+        pcall_err(bufmeths.set_lines, 1, 1, 2, false, {'b\na'}))
     end)
 
     it("fails if 'nomodifiable'", function()
       command('set nomodifiable')
-      expect_err([[Buffer is not 'modifiable']],
-        bufmeths.set_lines, 1, 1, 2, false, {'a','b'})
+      eq([[Buffer is not 'modifiable']],
+        pcall_err(bufmeths.set_lines, 1, 1, 2, false, {'a','b'}))
     end)
 
     it('has correct line_count when inserting and deleting', function()

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -10,11 +10,11 @@ local exc_exec = helpers.exc_exec
 local feed_command = helpers.feed_command
 local insert = helpers.insert
 local NIL = helpers.NIL
-local meth_pcall = helpers.meth_pcall
 local command = helpers.command
 local bufmeths = helpers.bufmeths
 local feed = helpers.feed
 local expect_err = helpers.expect_err
+local pcall_err = helpers.pcall_err
 
 describe('api/buf', function()
   before_each(clear)
@@ -191,11 +191,8 @@ describe('api/buf', function()
 
     it('fails correctly when input is not valid', function()
       eq(1, curbufmeths.get_number())
-      local err, emsg = pcall(bufmeths.set_lines, 1, 1, 2, false, {'b\na'})
-      eq(false, err)
-      local exp_emsg = 'String cannot contain newlines'
-      -- Expected {filename}:{lnum}: {exp_emsg}
-      eq(': ' .. exp_emsg, emsg:sub(-#exp_emsg - 2))
+      expect_err([[String cannot contain newlines]],
+        bufmeths.set_lines, 1, 1, 2, false, {'b\na'})
     end)
 
     it("fails if 'nomodifiable'", function()
@@ -407,8 +404,8 @@ describe('api/buf', function()
       eq(16, get_offset(3))
       eq(24, get_offset(4))
       eq(29, get_offset(5))
-      eq({false,'Index out of bounds'}, meth_pcall(get_offset, 6))
-      eq({false,'Index out of bounds'}, meth_pcall(get_offset, -1))
+      eq('Index out of bounds', pcall_err(get_offset, 6))
+      eq('Index out of bounds', pcall_err(get_offset, -1))
 
       curbufmeths.set_option('eol', false)
       curbufmeths.set_option('fixeol', false)
@@ -441,15 +438,15 @@ describe('api/buf', function()
       eq(1, funcs.exists('b:lua'))
       curbufmeths.del_var('lua')
       eq(0, funcs.exists('b:lua'))
-      eq({false, 'Key not found: lua'}, meth_pcall(curbufmeths.del_var, 'lua'))
+      eq( 'Key not found: lua', pcall_err(curbufmeths.del_var, 'lua'))
       curbufmeths.set_var('lua', 1)
       command('lockvar b:lua')
-      eq({false, 'Key is locked: lua'}, meth_pcall(curbufmeths.del_var, 'lua'))
-      eq({false, 'Key is locked: lua'}, meth_pcall(curbufmeths.set_var, 'lua', 1))
-      eq({false, 'Key is read-only: changedtick'},
-         meth_pcall(curbufmeths.del_var, 'changedtick'))
-      eq({false, 'Key is read-only: changedtick'},
-         meth_pcall(curbufmeths.set_var, 'changedtick', 1))
+      eq('Key is locked: lua', pcall_err(curbufmeths.del_var, 'lua'))
+      eq('Key is locked: lua', pcall_err(curbufmeths.set_var, 'lua', 1))
+      eq('Key is read-only: changedtick',
+         pcall_err(curbufmeths.del_var, 'changedtick'))
+      eq('Key is read-only: changedtick',
+         pcall_err(curbufmeths.set_var, 'changedtick', 1))
     end)
   end)
 

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -3,8 +3,8 @@ local clear = helpers.clear
 local eq, ok = helpers.eq, helpers.ok
 local buffer, command, eval, nvim, next_msg = helpers.buffer,
   helpers.command, helpers.eval, helpers.nvim, helpers.next_msg
-local expect_err = helpers.expect_err
 local nvim_prog = helpers.nvim_prog
+local pcall_err = helpers.pcall_err
 local sleep = helpers.sleep
 local write_file = helpers.write_file
 
@@ -760,7 +760,7 @@ describe('API: buffer events:', function()
   it('returns a proper error on nonempty options dict', function()
     clear()
     local b = editoriginal(false)
-    expect_err("unexpected key: builtin", buffer, 'attach', b, false, {builtin="asfd"})
+    eq("unexpected key: builtin", pcall_err(buffer, 'attach', b, false, {builtin="asfd"}))
   end)
 
   it('nvim_buf_attach returns response after delay #8634', function()

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -5,9 +5,9 @@ local clear = helpers.clear
 local command = helpers.command
 local curbufmeths = helpers.curbufmeths
 local eq = helpers.eq
-local expect_err = helpers.expect_err
 local meths = helpers.meths
 local source = helpers.source
+local pcall_err = helpers.pcall_err
 
 describe('nvim_get_commands', function()
   local cmd_dict  = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='echo "Hello World"', name='Hello', nargs='1', range=NIL, register=false, script_id=0, }
@@ -19,10 +19,10 @@ describe('nvim_get_commands', function()
   end)
 
   it('validates input', function()
-    expect_err('builtin=true not implemented', meths.get_commands,
-               {builtin=true})
-    expect_err('unexpected key: foo', meths.get_commands,
-               {foo='blah'})
+    eq('builtin=true not implemented', pcall_err(meths.get_commands,
+      {builtin=true}))
+    eq('unexpected key: foo', pcall_err(meths.get_commands,
+      {foo='blah'}))
   end)
 
   it('gets global user-defined commands', function()

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -5,11 +5,11 @@ local clear = helpers.clear
 local command = helpers.command
 local curbufmeths = helpers.curbufmeths
 local eq, neq = helpers.eq, helpers.neq
-local expect_err = helpers.expect_err
 local feed = helpers.feed
 local funcs = helpers.funcs
 local meths = helpers.meths
 local source = helpers.source
+local pcall_err = helpers.pcall_err
 
 local shallowcopy = helpers.shallowcopy
 local sleep = helpers.sleep
@@ -360,12 +360,9 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
 
   it('error on empty LHS', function()
     -- escape parentheses in lua string, else comparison fails erroneously
-    expect_err('Invalid %(empty%) LHS',
-               meths.set_keymap, '', '', 'rhs', {})
-    expect_err('Invalid %(empty%) LHS',
-               meths.set_keymap, '', '', '', {})
-
-    expect_err('Invalid %(empty%) LHS', meths.del_keymap, '', '')
+    eq('Invalid (empty) LHS', pcall_err(meths.set_keymap, '', '', 'rhs', {}))
+    eq('Invalid (empty) LHS', pcall_err(meths.set_keymap, '', '', '', {}))
+    eq('Invalid (empty) LHS', pcall_err(meths.del_keymap, '', ''))
   end)
 
   it('error if LHS longer than MAXMAPLEN', function()
@@ -385,10 +382,10 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
 
     -- 51 chars should produce an error
     lhs = lhs..'1'
-    expect_err('LHS exceeds maximum map length: '..lhs,
-               meths.set_keymap, '', lhs, 'rhs', {})
-    expect_err('LHS exceeds maximum map length: '..lhs,
-               meths.del_keymap, '', lhs)
+    eq('LHS exceeds maximum map length: '..lhs,
+      pcall_err(meths.set_keymap, '', lhs, 'rhs', {}))
+    eq('LHS exceeds maximum map length: '..lhs,
+      pcall_err(meths.del_keymap, '', lhs))
   end)
 
   it('does not throw errors when rhs is longer than MAXMAPLEN', function()
@@ -404,48 +401,48 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
   end)
 
   it('throws errors when given too-long mode shortnames', function()
-    expect_err('Shortname is too long: map',
-               meths.set_keymap, 'map', 'lhs', 'rhs', {})
+    eq('Shortname is too long: map',
+      pcall_err(meths.set_keymap, 'map', 'lhs', 'rhs', {}))
 
-    expect_err('Shortname is too long: vmap',
-               meths.set_keymap, 'vmap', 'lhs', 'rhs', {})
+    eq('Shortname is too long: vmap',
+      pcall_err(meths.set_keymap, 'vmap', 'lhs', 'rhs', {}))
 
-    expect_err('Shortname is too long: xnoremap',
-               meths.set_keymap, 'xnoremap', 'lhs', 'rhs', {})
+    eq('Shortname is too long: xnoremap',
+      pcall_err(meths.set_keymap, 'xnoremap', 'lhs', 'rhs', {}))
 
-    expect_err('Shortname is too long: map', meths.del_keymap, 'map', 'lhs')
-    expect_err('Shortname is too long: vmap', meths.del_keymap, 'vmap', 'lhs')
-    expect_err('Shortname is too long: xnoremap', meths.del_keymap, 'xnoremap', 'lhs')
+    eq('Shortname is too long: map', pcall_err(meths.del_keymap, 'map', 'lhs'))
+    eq('Shortname is too long: vmap', pcall_err(meths.del_keymap, 'vmap', 'lhs'))
+    eq('Shortname is too long: xnoremap', pcall_err(meths.del_keymap, 'xnoremap', 'lhs'))
   end)
 
   it('error on invalid mode shortname', function()
-    expect_err('Invalid mode shortname: " "',
-               meths.set_keymap, ' ', 'lhs', 'rhs', {})
-    expect_err('Invalid mode shortname: "m"',
-               meths.set_keymap, 'm', 'lhs', 'rhs', {})
-    expect_err('Invalid mode shortname: "?"',
-               meths.set_keymap, '?', 'lhs', 'rhs', {})
-    expect_err('Invalid mode shortname: "y"',
-               meths.set_keymap, 'y', 'lhs', 'rhs', {})
-    expect_err('Invalid mode shortname: "p"',
-               meths.set_keymap, 'p', 'lhs', 'rhs', {})
-    expect_err('Invalid mode shortname: "?"', meths.del_keymap, '?', 'lhs')
-    expect_err('Invalid mode shortname: "y"', meths.del_keymap, 'y', 'lhs')
-    expect_err('Invalid mode shortname: "p"', meths.del_keymap, 'p', 'lhs')
+    eq('Invalid mode shortname: " "',
+      pcall_err(meths.set_keymap, ' ', 'lhs', 'rhs', {}))
+    eq('Invalid mode shortname: "m"',
+      pcall_err(meths.set_keymap, 'm', 'lhs', 'rhs', {}))
+    eq('Invalid mode shortname: "?"',
+      pcall_err(meths.set_keymap, '?', 'lhs', 'rhs', {}))
+    eq('Invalid mode shortname: "y"',
+      pcall_err(meths.set_keymap, 'y', 'lhs', 'rhs', {}))
+    eq('Invalid mode shortname: "p"',
+      pcall_err(meths.set_keymap, 'p', 'lhs', 'rhs', {}))
+    eq('Invalid mode shortname: "?"', pcall_err(meths.del_keymap, '?', 'lhs'))
+    eq('Invalid mode shortname: "y"', pcall_err(meths.del_keymap, 'y', 'lhs'))
+    eq('Invalid mode shortname: "p"', pcall_err(meths.del_keymap, 'p', 'lhs'))
   end)
 
   it('error on invalid optnames', function()
-    expect_err('Invalid key: silentt',
-               meths.set_keymap, 'n', 'lhs', 'rhs', {silentt = true})
-    expect_err('Invalid key: sidd',
-               meths.set_keymap, 'n', 'lhs', 'rhs', {sidd = false})
-    expect_err('Invalid key: nowaiT',
-               meths.set_keymap, 'n', 'lhs', 'rhs', {nowaiT = false})
+    eq('Invalid key: silentt',
+      pcall_err(meths.set_keymap, 'n', 'lhs', 'rhs', {silentt = true}))
+    eq('Invalid key: sidd',
+      pcall_err(meths.set_keymap, 'n', 'lhs', 'rhs', {sidd = false}))
+    eq('Invalid key: nowaiT',
+      pcall_err(meths.set_keymap, 'n', 'lhs', 'rhs', {nowaiT = false}))
   end)
 
   it('error on <buffer> option key', function()
-    expect_err('Invalid key: buffer',
-               meths.set_keymap, 'n', 'lhs', 'rhs', {buffer = true})
+    eq('Invalid key: buffer',
+      pcall_err(meths.set_keymap, 'n', 'lhs', 'rhs', {buffer = true}))
   end)
 
   local optnames = {'nowait', 'silent', 'script', 'expr', 'unique'}
@@ -454,8 +451,8 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     it('throws an error when given non-boolean value for '..opt, function()
       local opts = {}
       opts[opt] = 2
-      expect_err('Gave non%-boolean value for an opt: '..opt,
-                 meths.set_keymap, 'n', 'lhs', 'rhs', opts)
+      eq('Gave non-boolean value for an opt: '..opt,
+        pcall_err(meths.set_keymap, 'n', 'lhs', 'rhs', opts))
     end)
   end
 
@@ -581,8 +578,8 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
 
   it('throws appropriate error messages when setting <unique> maps', function()
     meths.set_keymap('l', 'lhs', 'rhs', {})
-    expect_err('E227: mapping already exists for lhs',
-               meths.set_keymap, 'l', 'lhs', 'rhs', {unique = true})
+    eq('E227: mapping already exists for lhs',
+      pcall_err(meths.set_keymap, 'l', 'lhs', 'rhs', {unique = true}))
     -- different mapmode, no error should be thrown
     meths.set_keymap('t', 'lhs', 'rhs', {unique = true})
   end)
@@ -750,8 +747,8 @@ describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()
   end
 
   it('rejects negative bufnr values', function()
-    expect_err('Wrong type for argument 1, expecting Buffer',
-               bufmeths.set_keymap, -1, '', 'lhs', 'rhs', {})
+    eq('Wrong type for argument 1, expecting Buffer',
+      pcall_err(bufmeths.set_keymap, -1, '', 'lhs', 'rhs', {}))
   end)
 
   it('can set mappings active in the current buffer but not others', function()
@@ -800,8 +797,8 @@ describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()
   it("can't disable mappings given wrong buffer handle", function()
     local first, second = make_two_buffers(false)
     bufmeths.set_keymap(first, '', 'lhs', 'irhs<Esc>', {})
-    expect_err('E31: No such mapping',
-               bufmeths.del_keymap, second, '', 'lhs')
+    eq('E31: No such mapping',
+      pcall_err(bufmeths.del_keymap, second, '', 'lhs'))
 
     -- should still work
     switch_to_buf(first)

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -10,7 +10,7 @@ local ok = helpers.ok
 local meths = helpers.meths
 local spawn, merge_args = helpers.spawn, helpers.merge_args
 local set_session = helpers.set_session
-local meth_pcall = helpers.meth_pcall
+local pcall_err = helpers.pcall_err
 
 describe('server -> client', function()
   local cid
@@ -220,8 +220,8 @@ describe('server -> client', function()
     end)
 
     it('returns an error if the request failed', function()
-      eq({false, "Vim:Error invoking 'does-not-exist' on channel 3:\nInvalid method: does-not-exist" },
-         meth_pcall(eval, "rpcrequest(vim, 'does-not-exist')"))
+      eq("Vim:Error invoking 'does-not-exist' on channel 3:\nInvalid method: does-not-exist",
+         pcall_err(eval, "rpcrequest(vim, 'does-not-exist')"))
     end)
   end)
 

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -6,7 +6,7 @@ local curtabmeths = helpers.curtabmeths
 local funcs = helpers.funcs
 local request = helpers.request
 local NIL = helpers.NIL
-local meth_pcall = helpers.meth_pcall
+local pcall_err = helpers.pcall_err
 local command = helpers.command
 
 describe('api/tabpage', function()
@@ -34,11 +34,11 @@ describe('api/tabpage', function()
       eq(1, funcs.exists('t:lua'))
       curtabmeths.del_var('lua')
       eq(0, funcs.exists('t:lua'))
-      eq({false, 'Key not found: lua'}, meth_pcall(curtabmeths.del_var, 'lua'))
+      eq('Key not found: lua', pcall_err(curtabmeths.del_var, 'lua'))
       curtabmeths.set_var('lua', 1)
       command('lockvar t:lua')
-      eq({false, 'Key is locked: lua'}, meth_pcall(curtabmeths.del_var, 'lua'))
-      eq({false, 'Key is locked: lua'}, meth_pcall(curtabmeths.set_var, 'lua', 1))
+      eq('Key is locked: lua', pcall_err(curtabmeths.del_var, 'lua'))
+      eq('Key is locked: lua', pcall_err(curtabmeths.set_var, 'lua', 1))
     end)
 
     it('tabpage_set_var returns the old value', function()

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -3,9 +3,9 @@ local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
-local expect_err = helpers.expect_err
 local meths = helpers.meths
 local request = helpers.request
+local pcall_err = helpers.pcall_err
 
 describe('nvim_ui_attach()', function()
   before_each(function()
@@ -18,20 +18,20 @@ describe('nvim_ui_attach()', function()
     eq(999, eval('&columns'))
   end)
   it('invalid option returns error', function()
-    expect_err('No such UI option: foo',
-               meths.ui_attach, 80, 24, { foo={'foo'} })
+    eq('No such UI option: foo',
+      pcall_err(meths.ui_attach, 80, 24, { foo={'foo'} }))
   end)
   it('validates channel arg', function()
-    expect_err('UI not attached to channel: 1',
-               request, 'nvim_ui_try_resize', 40, 10)
-    expect_err('UI not attached to channel: 1',
-               request, 'nvim_ui_set_option', 'rgb', true)
-    expect_err('UI not attached to channel: 1',
-               request, 'nvim_ui_detach')
+    eq('UI not attached to channel: 1',
+      pcall_err(request, 'nvim_ui_try_resize', 40, 10))
+    eq('UI not attached to channel: 1',
+      pcall_err(request, 'nvim_ui_set_option', 'rgb', true))
+    eq('UI not attached to channel: 1',
+      pcall_err(request, 'nvim_ui_detach'))
 
     local screen = Screen.new()
     screen:attach({rgb=false})
-    expect_err('UI already attached to channel: 1',
-               request, 'nvim_ui_attach', 40, 10, { rgb=false })
+    eq('UI already attached to channel: 1',
+      pcall_err(request, 'nvim_ui_attach', 40, 10, { rgb=false }))
   end)
 end)

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -8,10 +8,10 @@ local curwinmeths = helpers.curwinmeths
 local funcs = helpers.funcs
 local request = helpers.request
 local NIL = helpers.NIL
-local meth_pcall = helpers.meth_pcall
 local meths = helpers.meths
 local command = helpers.command
 local expect_err = helpers.expect_err
+local pcall_err = helpers.pcall_err
 
 -- check if str is visible at the beginning of some line
 local function is_visible(str)
@@ -74,8 +74,7 @@ describe('API/win', function()
 
     it('does not leak memory when using invalid window ID with invalid pos',
     function()
-      eq({false, 'Invalid window id'},
-         meth_pcall(meths.win_set_cursor, 1, {"b\na"}))
+      eq('Invalid window id', pcall_err(meths.win_set_cursor, 1, {"b\na"}))
     end)
 
     it('updates the screen, and also when the window is unfocused', function()
@@ -185,11 +184,11 @@ describe('API/win', function()
       eq(1, funcs.exists('w:lua'))
       curwinmeths.del_var('lua')
       eq(0, funcs.exists('w:lua'))
-      eq({false, 'Key not found: lua'}, meth_pcall(curwinmeths.del_var, 'lua'))
+      eq('Key not found: lua', pcall_err(curwinmeths.del_var, 'lua'))
       curwinmeths.set_var('lua', 1)
       command('lockvar w:lua')
-      eq({false, 'Key is locked: lua'}, meth_pcall(curwinmeths.del_var, 'lua'))
-      eq({false, 'Key is locked: lua'}, meth_pcall(curwinmeths.set_var, 'lua', 1))
+      eq('Key is locked: lua', pcall_err(curwinmeths.del_var, 'lua'))
+      eq('Key is locked: lua', pcall_err(curwinmeths.set_var, 'lua', 1))
     end)
 
     it('window_set_var returns the old value', function()
@@ -222,7 +221,8 @@ describe('API/win', function()
       eq('', nvim('get_option', 'statusline'))
       command("set modified")
       command("enew") -- global-local: not preserved in new buffer
-      eq({false, "Failed to get value for option 'statusline'"}, meth_pcall(curwin, 'get_option', 'statusline'))
+      eq("Failed to get value for option 'statusline'",
+        pcall_err(curwin, 'get_option', 'statusline'))
       eq('', eval('&l:statusline')) -- confirm local value was not copied
     end)
   end)
@@ -317,8 +317,8 @@ describe('API/win', function()
       insert('text')
       command('new')
       local newwin = meths.get_current_win()
-      eq({false,"Vim:E37: No write since last change (add ! to override)"},
-         meth_pcall(meths.win_close, oldwin,false))
+      eq("Vim:E37: No write since last change (add ! to override)",
+         pcall_err(meths.win_close, oldwin,false))
       eq({newwin,oldwin}, meths.list_wins())
     end)
 

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -10,7 +10,6 @@ local request = helpers.request
 local NIL = helpers.NIL
 local meths = helpers.meths
 local command = helpers.command
-local expect_err = helpers.expect_err
 local pcall_err = helpers.pcall_err
 
 -- check if str is visible at the beginning of some line
@@ -56,8 +55,8 @@ describe('API/win', function()
     end)
 
     it('validates args', function()
-      expect_err('Invalid buffer id$', window, 'set_buf', nvim('get_current_win'), 23)
-      expect_err('Invalid window id$', window, 'set_buf', 23, nvim('get_current_buf'))
+      eq('Invalid buffer id', pcall_err(window, 'set_buf', nvim('get_current_win'), 23))
+      eq('Invalid window id', pcall_err(window, 'set_buf', 23, nvim('get_current_buf')))
     end)
   end)
 
@@ -340,7 +339,8 @@ describe('API/win', function()
       eq(3, #meths.list_wins())
       eq(':', funcs.getcmdwintype())
       -- Vim: not allowed to close other windows from cmdline-window.
-      expect_err('E11: Invalid in command%-line window; <CR> executes, CTRL%-C quits$', meths.win_close, oldwin, true)
+      eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
+        pcall_err(meths.win_close, oldwin, true))
       -- Close cmdline-window.
       meths.win_close(0,true)
       eq(2, #meths.list_wins())

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -7,7 +7,7 @@ local eval = helpers.eval
 local feed = helpers.feed
 local clear = helpers.clear
 local meths = helpers.meths
-local meth_pcall = helpers.meth_pcall
+local pcall_err = helpers.pcall_err
 local funcs = helpers.funcs
 local expect = helpers.expect
 local command = helpers.command
@@ -219,8 +219,8 @@ describe('autocmd', function()
     eq(7, eval('g:test'))
 
     -- API calls are blocked when aucmd_win is not in scope
-    eq({false, 'Vim(call):E5555: API call: Invalid window id'},
-       meth_pcall(command, "call nvim_set_current_win(g:winid)"))
+    eq('Vim(call):E5555: API call: Invalid window id',
+      pcall_err(command, "call nvim_set_current_win(g:winid)"))
 
     -- second time aucmd_win is needed, a different code path is invoked
     -- to reuse the same window, so check again
@@ -257,8 +257,8 @@ describe('autocmd', function()
     eq(0, eval('g:had_value'))
     eq(7, eval('g:test'))
 
-    eq({false, 'Vim(call):E5555: API call: Invalid window id'},
-       meth_pcall(command, "call nvim_set_current_win(g:winid)"))
+    eq('Vim(call):E5555: API call: Invalid window id',
+      pcall_err(command, "call nvim_set_current_win(g:winid)"))
   end)
 
   it(':doautocmd does not warn "No matching autocommands" #10689', function()

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -17,7 +17,7 @@ local pathroot = helpers.pathroot
 local nvim_set = helpers.nvim_set
 local expect_twostreams = helpers.expect_twostreams
 local expect_msg_seq = helpers.expect_msg_seq
-local expect_err = helpers.expect_err
+local pcall_err = helpers.pcall_err
 local Screen = require('test.functional.ui.screen')
 
 -- Kill process with given pid
@@ -122,8 +122,8 @@ describe('jobs', function()
     local dir = 'Xtest_not_executable_dir'
     mkdir(dir)
     funcs.setfperm(dir, 'rw-------')
-    expect_err('E475: Invalid argument: expected valid directory$', nvim,
-               'command', "call jobstart('pwd', {'cwd': '" .. dir .. "'})")
+    eq('Vim(call):E475: Invalid argument: expected valid directory',
+      pcall_err(nvim, 'command', "call jobstart('pwd', {'cwd': '"..dir.."'})"))
     rmdir(dir)
   end)
 

--- a/test/functional/eval/api_functions_spec.lua
+++ b/test/functional/eval/api_functions_spec.lua
@@ -4,7 +4,7 @@ local lfs = require('lfs')
 local neq, eq, command = helpers.neq, helpers.eq, helpers.command
 local clear, curbufmeths = helpers.clear, helpers.curbufmeths
 local exc_exec, expect, eval = helpers.exc_exec, helpers.expect, helpers.eval
-local insert, meth_pcall = helpers.insert, helpers.meth_pcall
+local insert, pcall_err = helpers.insert, helpers.pcall_err
 local meths = helpers.meths
 
 describe('eval-API', function()
@@ -148,8 +148,8 @@ describe('eval-API', function()
   end)
 
   it('cannot be called from sandbox', function()
-    eq({false, 'Vim(call):E48: Not allowed in sandbox'},
-       meth_pcall(command, "sandbox call nvim_input('ievil')"))
+    eq('Vim(call):E48: Not allowed in sandbox',
+       pcall_err(command, "sandbox call nvim_input('ievil')"))
     eq({''}, meths.buf_get_lines(0, 0, -1, true))
   end)
 end)

--- a/test/functional/eval/buf_functions_spec.lua
+++ b/test/functional/eval/buf_functions_spec.lua
@@ -15,7 +15,7 @@ local curwinmeths = helpers.curwinmeths
 local curtabmeths = helpers.curtabmeths
 local get_pathsep = helpers.get_pathsep
 local rmdir = helpers.rmdir
-local expect_err = helpers.expect_err
+local pcall_err = helpers.pcall_err
 
 local fname = 'Xtest-functional-eval-buf_functions'
 local fname2 = fname .. '.2'
@@ -297,8 +297,8 @@ describe('setbufvar() function', function()
     eq('Vim(call):E461: Illegal variable name: b:',
        exc_exec('call setbufvar(1, "", 0)'))
     eq(true, bufmeths.get_var(buf1, 'number'))
-    expect_err('Vim:E46: Cannot change read%-only variable "b:changedtick"',
-               funcs.setbufvar, 1, 'changedtick', true)
+    eq('Vim:E46: Cannot change read-only variable "b:changedtick"',
+      pcall_err(funcs.setbufvar, 1, 'changedtick', true))
     eq(2, funcs.getbufvar(1, 'changedtick'))
   end)
 end)

--- a/test/functional/eval/changedtick_spec.lua
+++ b/test/functional/eval/changedtick_spec.lua
@@ -9,7 +9,7 @@ local meths = helpers.meths
 local command = helpers.command
 local exc_exec = helpers.exc_exec
 local redir_exec = helpers.redir_exec
-local meth_pcall = helpers.meth_pcall
+local pcall_err = helpers.pcall_err
 local curbufmeths = helpers.curbufmeths
 
 before_each(clear)
@@ -64,8 +64,8 @@ describe('b:changedtick', function()
        redir_exec('let b:.changedtick = ' .. ctn))
     eq('\nE46: Cannot change read-only variable "d.changedtick"',
        redir_exec('let d.changedtick = ' .. ctn))
-    eq({false, 'Key is read-only: changedtick'},
-       meth_pcall(curbufmeths.set_var, 'changedtick', ctn))
+    eq('Key is read-only: changedtick',
+      pcall_err(curbufmeths.set_var, 'changedtick', ctn))
 
     eq('\nE795: Cannot delete variable b:changedtick',
        redir_exec('unlet b:changedtick'))
@@ -75,8 +75,8 @@ describe('b:changedtick', function()
        redir_exec('unlet b:["changedtick"]'))
     eq('\nE46: Cannot change read-only variable "d.changedtick"',
        redir_exec('unlet d.changedtick'))
-    eq({false, 'Key is read-only: changedtick'},
-       meth_pcall(curbufmeths.del_var, 'changedtick'))
+    eq('Key is read-only: changedtick',
+      pcall_err(curbufmeths.del_var, 'changedtick'))
     eq(ct, changedtick())
 
     eq('\nE46: Cannot change read-only variable "b:["changedtick"]"',

--- a/test/functional/eval/ctx_functions_spec.lua
+++ b/test/functional/eval/ctx_functions_spec.lua
@@ -5,7 +5,6 @@ local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
-local expect_err = helpers.expect_err
 local feed = helpers.feed
 local map = helpers.map
 local nvim = helpers.nvim
@@ -14,6 +13,7 @@ local redir_exec = helpers.redir_exec
 local source = helpers.source
 local trim = helpers.trim
 local write_file = helpers.write_file
+local pcall_err = helpers.pcall_err
 
 describe('context functions', function()
   local fname1 = 'Xtest-functional-eval-ctx1'
@@ -110,9 +110,9 @@ describe('context functions', function()
       nvim('del_var', 'one')
       nvim('del_var', 'Two')
       nvim('del_var', 'THREE')
-      expect_err('E121: Undefined variable: g:one', eval, 'g:one')
-      expect_err('E121: Undefined variable: g:Two', eval, 'g:Two')
-      expect_err('E121: Undefined variable: g:THREE', eval, 'g:THREE')
+      eq('Vim:E121: Undefined variable: g:one', pcall_err(eval, 'g:one'))
+      eq('Vim:E121: Undefined variable: g:Two', pcall_err(eval, 'g:Two'))
+      eq('Vim:E121: Undefined variable: g:THREE', pcall_err(eval, 'g:THREE'))
 
       call('ctxpop')
       eq({1, 2 ,3}, eval('[g:one, g:Two, g:THREE]'))
@@ -120,9 +120,9 @@ describe('context functions', function()
       nvim('del_var', 'one')
       nvim('del_var', 'Two')
       nvim('del_var', 'THREE')
-      expect_err('E121: Undefined variable: g:one', eval, 'g:one')
-      expect_err('E121: Undefined variable: g:Two', eval, 'g:Two')
-      expect_err('E121: Undefined variable: g:THREE', eval, 'g:THREE')
+      eq('Vim:E121: Undefined variable: g:one', pcall_err(eval, 'g:one'))
+      eq('Vim:E121: Undefined variable: g:Two', pcall_err(eval, 'g:Two'))
+      eq('Vim:E121: Undefined variable: g:THREE', pcall_err(eval, 'g:THREE'))
 
       call('ctxpop')
       eq({1, 2 ,3}, eval('[g:one, g:Two, g:THREE]'))
@@ -217,9 +217,9 @@ describe('context functions', function()
       command('delfunction Greet')
       command('delfunction GreetAll')
 
-      expect_err('Vim:E117: Unknown function: Greet', call, 'Greet', 'World')
-      expect_err('Vim:E117: Unknown function: Greet', call, 'GreetAll',
-                 'World', 'One', 'Two', 'Three')
+      eq('Vim:E117: Unknown function: Greet', pcall_err(call, 'Greet', 'World'))
+      eq('Vim:E117: Unknown function: GreetAll',
+        pcall_err(call, 'GreetAll', 'World', 'One', 'Two', 'Three'))
 
       call('ctxpop')
 
@@ -233,13 +233,13 @@ describe('context functions', function()
 
     it('errors out when context stack is empty', function()
       local err = 'Vim:Context stack is empty'
-      expect_err(err, call, 'ctxpop')
-      expect_err(err, call, 'ctxpop')
+      eq(err, pcall_err(call, 'ctxpop'))
+      eq(err, pcall_err(call, 'ctxpop'))
       call('ctxpush')
       call('ctxpush')
       call('ctxpop')
       call('ctxpop')
-      expect_err(err, call, 'ctxpop')
+      eq(err, pcall_err(call, 'ctxpop'))
     end)
   end)
 
@@ -263,11 +263,11 @@ describe('context functions', function()
 
   describe('ctxget()', function()
     it('errors out when index is out of bounds', function()
-      expect_err(outofbounds, call, 'ctxget')
+      eq(outofbounds, pcall_err(call, 'ctxget'))
       call('ctxpush')
-      expect_err(outofbounds, call, 'ctxget', 1)
+      eq(outofbounds, pcall_err(call, 'ctxget', 1))
       call('ctxpop')
-      expect_err(outofbounds, call, 'ctxget', 0)
+      eq(outofbounds, pcall_err(call, 'ctxget', 0))
     end)
 
     it('returns context dictionary at index in context stack', function()
@@ -370,11 +370,11 @@ describe('context functions', function()
 
   describe('ctxset()', function()
     it('errors out when index is out of bounds', function()
-      expect_err(outofbounds, call, 'ctxset', {dummy = 1})
+      eq(outofbounds, pcall_err(call, 'ctxset', {dummy = 1}))
       call('ctxpush')
-      expect_err(outofbounds, call, 'ctxset', {dummy = 1}, 1)
+      eq(outofbounds, pcall_err(call, 'ctxset', {dummy = 1}, 1))
       call('ctxpop')
-      expect_err(outofbounds, call, 'ctxset', {dummy = 1}, 0)
+      eq(outofbounds, pcall_err(call, 'ctxset', {dummy = 1}, 0))
     end)
 
     it('sets context dictionary at index in context stack', function()

--- a/test/functional/eval/match_functions_spec.lua
+++ b/test/functional/eval/match_functions_spec.lua
@@ -6,7 +6,7 @@ local clear = helpers.clear
 local funcs = helpers.funcs
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local expect_err = helpers.expect_err
+local pcall_err = helpers.pcall_err
 
 before_each(clear)
 
@@ -41,11 +41,11 @@ describe('setmatches()', function()
   end)
 
   it('fails with -1 if highlight group is not defined', function()
-    expect_err('E28: No such highlight group name: 1', funcs.setmatches,
-               {{group=1, pattern=2, id=3, priority=4}})
+    eq('Vim:E28: No such highlight group name: 1',
+      pcall_err(funcs.setmatches, {{group=1, pattern=2, id=3, priority=4}}))
     eq({}, funcs.getmatches())
-    expect_err('E28: No such highlight group name: 1', funcs.setmatches,
-               {{group=1, pos1={2}, pos2={6}, id=3, priority=4, conceal=5}})
+    eq('Vim:E28: No such highlight group name: 1',
+      pcall_err(funcs.setmatches, {{group=1, pos1={2}, pos2={6}, id=3, priority=4, conceal=5}}))
     eq({}, funcs.getmatches())
   end)
 end)

--- a/test/functional/eval/server_spec.lua
+++ b/test/functional/eval/server_spec.lua
@@ -5,7 +5,7 @@ local clear, funcs, meths = helpers.clear, helpers.funcs, helpers.meths
 local iswin = helpers.iswin
 local ok = helpers.ok
 local matches = helpers.matches
-local expect_err = helpers.expect_err
+local pcall_err = helpers.pcall_err
 
 local function clear_serverlist()
   for _, server in pairs(funcs.serverlist()) do
@@ -102,8 +102,8 @@ describe('server', function()
     eq(expected, funcs.serverlist())
     clear_serverlist()
 
-    expect_err('Failed to start server: invalid argument',
-               funcs.serverstart, '127.0.0.1:65536')  -- invalid port
+    eq('Vim:Failed to start server: invalid argument',
+      pcall_err(funcs.serverstart, '127.0.0.1:65536'))  -- invalid port
     eq({}, funcs.serverlist())
   end)
 

--- a/test/functional/eval/wait_spec.lua
+++ b/test/functional/eval/wait_spec.lua
@@ -4,12 +4,12 @@ local clear = helpers.clear
 local command = helpers.command
 local eval = helpers.eval
 local eq = helpers.eq
-local expect_err = helpers.expect_err
 local feed = helpers.feed
 local feed_command = helpers.feed_command
 local next_msg = helpers.next_msg
 local nvim = helpers.nvim
 local source = helpers.source
+local pcall_err = helpers.pcall_err
 
 before_each(function()
   clear()
@@ -66,13 +66,10 @@ describe('wait()', function()
     eq(5, nvim('get_var', 'counter'))
   end)
 
-  it('errors out on invalid timeout value', function()
-    expect_err('Invalid value for argument', call, 'wait', '', 1)
-  end)
-
-  it('errors out on invalid interval', function()
-    expect_err('Invalid value for argument', call, 'wait', 0, 1, -1)
-    expect_err('Invalid value for argument', call, 'wait', 0, 1, 0)
-    expect_err('Invalid value for argument', call, 'wait', 0, 1, '')
+  it('validates args', function()
+    eq('Vim:E475: Invalid value for argument 1', pcall_err(call, 'wait', '', 1))
+    eq('Vim:E475: Invalid value for argument 3', pcall_err(call, 'wait', 0, 1, -1))
+    eq('Vim:E475: Invalid value for argument 3', pcall_err(call, 'wait', 0, 1, 0))
+    eq('Vim:E475: Invalid value for argument 3', pcall_err(call, 'wait', 0, 1, ''))
   end)
 end)

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -5,7 +5,6 @@ local eq, eval, expect, source =
   helpers.eq, helpers.eval, helpers.expect, helpers.source
 local clear = helpers.clear
 local command = helpers.command
-local expect_err = helpers.expect_err
 local feed = helpers.feed
 local nvim_prog = helpers.nvim_prog
 local ok = helpers.ok
@@ -14,6 +13,7 @@ local set_session = helpers.set_session
 local spawn = helpers.spawn
 local nvim_async = helpers.nvim_async
 local expect_msg_seq = helpers.expect_msg_seq
+local pcall_err = helpers.pcall_err
 
 describe(':recover', function()
   before_each(clear)
@@ -21,11 +21,11 @@ describe(':recover', function()
   it('fails if given a non-existent swapfile', function()
     local swapname = 'bogus_swapfile'
     local swapname2 = 'bogus_swapfile.swp'
-    expect_err('E305: No swap file found for '..swapname,
-               command, 'recover '..swapname)  -- Should not segfault. #2117
+    eq('Vim(recover):E305: No swap file found for '..swapname,
+      pcall_err(command, 'recover '..swapname))  -- Should not segfault. #2117
     -- Also check filename ending with ".swp". #9504
-    expect_err('Vim%(recover%):E306: Cannot open '..swapname2,
-               command, 'recover '..swapname2)  -- Should not segfault. #2117
+    eq('Vim(recover):E306: Cannot open '..swapname2,
+      pcall_err(command, 'recover '..swapname2))  -- Should not segfault. #2117
     eq(2, eval('1+1'))  -- Still alive?
   end)
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -687,14 +687,6 @@ function module.skip_fragile(pending_fn, cond)
   return false
 end
 
-function module.meth_pcall(...)
-  local ret = {pcall(...)}
-  if type(ret[2]) == 'string' then
-    ret[2] = ret[2]:gsub('^[^:]+:%d+: ', '')
-  end
-  return ret
-end
-
 module.funcs = module.create_callindex(module.call)
 module.meths = module.create_callindex(module.nvim)
 module.uimeths = module.create_callindex(ui)

--- a/test/functional/lua/utility_functions_spec.lua
+++ b/test/functional/lua/utility_functions_spec.lua
@@ -7,12 +7,12 @@ local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
 local feed = helpers.feed
-local meth_pcall = helpers.meth_pcall
+local pcall_err = helpers.pcall_err
 local exec_lua = helpers.exec_lua
 
 before_each(clear)
 
-describe('lua function', function()
+describe('lua stdlib', function()
   -- İ: `tolower("İ")` is `i` which has length 1 while `İ` itself has
   --    length 2 (in bytes).
   -- Ⱥ: `tolower("Ⱥ")` is `ⱥ` which has length 2 while `Ⱥ` itself has
@@ -147,11 +147,11 @@ describe('lua function', function()
     eq({"yy","xx"}, exec_lua("return test_table"))
 
     -- type checked args
-    eq({false, 'Error executing lua: vim.schedule: expected function'},
-       meth_pcall(exec_lua, "vim.schedule('stringly')"))
+    eq('Error executing lua: vim.schedule: expected function',
+      pcall_err(exec_lua, "vim.schedule('stringly')"))
 
-    eq({false, 'Error executing lua: vim.schedule: expected function'},
-       meth_pcall(exec_lua, "vim.schedule()"))
+    eq('Error executing lua: vim.schedule: expected function',
+      pcall_err(exec_lua, "vim.schedule()"))
 
     exec_lua([[
       vim.schedule(function()
@@ -282,5 +282,10 @@ describe('lua function', function()
     ]])
 
     assert(is_dc)
+  end)
+
+  it('vim.pesc', function()
+    eq('foo%-bar', exec_lua([[return vim.pesc('foo-bar')]]))
+    eq('foo%%%-bar', exec_lua([[return vim.pesc(vim.pesc('foo-bar'))]]))
   end)
 end)

--- a/test/functional/normal/search_spec.lua
+++ b/test/functional/normal/search_spec.lua
@@ -1,16 +1,17 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local command = helpers.command
-local expect_err = helpers.expect_err
+local eq = helpers.eq
+local pcall_err = helpers.pcall_err
 
 describe('search (/)', function()
   before_each(clear)
 
   it('fails with huge column (%c) value #9930', function()
-    expect_err("Vim:E951: \\%% value too large",
-      command, "/\\v%18446744071562067968c")
-    expect_err("Vim:E951: \\%% value too large",
-      command, "/\\v%2147483648c")
+    eq([[Vim:E951: \% value too large]],
+      pcall_err(command, "/\\v%18446744071562067968c"))
+    eq([[Vim:E951: \% value too large]],
+      pcall_err(command, "/\\v%2147483648c"))
   end)
 end)
 

--- a/test/functional/provider/provider_spec.lua
+++ b/test/functional/provider/provider_spec.lua
@@ -2,7 +2,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, eval = helpers.clear, helpers.eval
 local command = helpers.command
-local expect_err = helpers.expect_err
+local eq = helpers.eq
+local pcall_err = helpers.pcall_err
 
 describe('providers', function()
   before_each(function()
@@ -13,14 +14,14 @@ describe('providers', function()
     command('set loadplugins')
     -- Using test-fixture with broken impl:
     -- test/functional/fixtures/autoload/provider/python.vim
-    expect_err('Vim:provider: python: missing required variable g:loaded_python_provider',
-      eval, "has('python')")
+    eq('Vim:provider: python: missing required variable g:loaded_python_provider',
+      pcall_err(eval, "has('python')"))
   end)
 
   it('with g:loaded_xx_provider, missing #Call()', function()
     -- Using test-fixture with broken impl:
     -- test/functional/fixtures/autoload/provider/ruby.vim
-    expect_err('Vim:provider: ruby: g:loaded_ruby_provider=2 but provider#ruby#Call is not defined',
-      eval, "has('ruby')")
+    eq('Vim:provider: ruby: g:loaded_ruby_provider=2 but provider#ruby#Call is not defined',
+      pcall_err(eval, "has('ruby')"))
   end)
 end)

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -2,18 +2,19 @@ local helpers = require('test.functional.helpers')(after_each)
 local eval, command, feed = helpers.eval, helpers.command, helpers.feed
 local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
 local expect, write_file = helpers.expect, helpers.write_file
-local expect_err = helpers.expect_err
 local feed_command = helpers.feed_command
 local source = helpers.source
 local missing_provider = helpers.missing_provider
+local matches = helpers.matches
+local pcall_err = helpers.pcall_err
 
 do
   clear()
   if missing_provider('python3') then
     it(':python3 reports E319 if provider is missing', function()
       local expected = [[Vim%(py3.*%):E319: No "python3" provider found.*]]
-      expect_err(expected, command, 'py3 print("foo")')
-      expect_err(expected, command, 'py3file foo')
+      matches(expected, pcall_err(command, 'py3 print("foo")'))
+      matches(expected, pcall_err(command, 'py3file foo'))
     end)
     pending('Python 3 (or the pynvim module) is broken/missing', function() end)
     return

--- a/test/functional/provider/python_spec.lua
+++ b/test/functional/provider/python_spec.lua
@@ -8,20 +8,21 @@ local funcs = helpers.funcs
 local meths = helpers.meths
 local insert = helpers.insert
 local expect = helpers.expect
-local expect_err = helpers.expect_err
 local command = helpers.command
 local exc_exec = helpers.exc_exec
 local write_file = helpers.write_file
 local curbufmeths = helpers.curbufmeths
 local missing_provider = helpers.missing_provider
+local matches = helpers.matches
+local pcall_err = helpers.pcall_err
 
 do
   clear()
   if missing_provider('python') then
     it(':python reports E319 if provider is missing', function()
       local expected = [[Vim%(py.*%):E319: No "python" provider found.*]]
-      expect_err(expected, command, 'py print("foo")')
-      expect_err(expected, command, 'pyfile foo')
+      matches(expected, pcall_err(command, 'py print("foo")'))
+      matches(expected, pcall_err(command, 'pyfile foo'))
     end)
     pending('Python 2 (or the pynvim module) is broken/missing', function() end)
     return

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -6,22 +6,23 @@ local curbufmeths = helpers.curbufmeths
 local eq = helpers.eq
 local eval = helpers.eval
 local expect = helpers.expect
-local expect_err = helpers.expect_err
 local feed = helpers.feed
 local feed_command = helpers.feed_command
 local funcs = helpers.funcs
 local insert = helpers.insert
 local meths = helpers.meths
 local missing_provider = helpers.missing_provider
+local matches = helpers.matches
 local write_file = helpers.write_file
+local pcall_err = helpers.pcall_err
 
 do
   clear()
   if missing_provider('ruby') then
     it(':ruby reports E319 if provider is missing', function()
       local expected = [[Vim%(ruby.*%):E319: No "ruby" provider found.*]]
-      expect_err(expected, command, 'ruby puts "foo"')
-      expect_err(expected, command, 'rubyfile foo')
+      matches(expected, pcall_err(command, 'ruby puts "foo"'))
+      matches(expected, pcall_err(command, 'rubyfile foo'))
     end)
     pending("Missing neovim RubyGem.", function() end)
     return

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -10,8 +10,8 @@ local wait = helpers.wait
 local retry = helpers.retry
 local curbufmeths = helpers.curbufmeths
 local nvim = helpers.nvim
-local expect_err = helpers.expect_err
 local feed_data = thelpers.feed_data
+local pcall_err = helpers.pcall_err
 
 describe(':terminal scrollback', function()
   local screen
@@ -455,8 +455,10 @@ describe("'scrollback' option", function()
   end)
 
   it('error if set to invalid value', function()
-    expect_err('E474:', command, 'set scrollback=-2')
-    expect_err('E474:', command, 'set scrollback=100001')
+    eq('Vim(set):E474: Invalid argument: scrollback=-2',
+      pcall_err(command, 'set scrollback=-2'))
+    eq('Vim(set):E474: Invalid argument: scrollback=100001',
+      pcall_err(command, 'set scrollback=100001'))
   end)
 
   it('defaults to -1 on normal buffers', function()

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -10,7 +10,7 @@ local meths = helpers.meths
 local curbufmeths = helpers.curbufmeths
 local funcs = helpers.funcs
 local run = helpers.run
-local meth_pcall = helpers.meth_pcall
+local pcall_err = helpers.pcall_err
 
 describe('floating windows', function()
   before_each(function()
@@ -636,26 +636,26 @@ describe('floating windows', function()
 
     it('API has proper error messages', function()
       local buf = meths.create_buf(false,false)
-      eq({false, "Invalid key 'bork'"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=2,bork=true}))
-      eq({false, "'win' key is only valid with relative='win'"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,win=0}))
-      eq({false, "Only one of 'relative' and 'external' must be used"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,external=true}))
-      eq({false, "Invalid value of 'relative' key"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='shell',row=0,col=0}))
-      eq({false, "Invalid value of 'anchor' key"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,anchor='bottom'}))
-      eq({false, "All of 'relative', 'row', and 'col' has to be specified at once"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=2,relative='editor'}))
-      eq({false, "'width' key must be a positive Integer"},
-         meth_pcall(meths.open_win,buf, false, {width=-1,height=2,relative='editor'}))
-      eq({false, "'height' key must be a positive Integer"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=-1,relative='editor'}))
-      eq({false, "'height' key must be a positive Integer"},
-         meth_pcall(meths.open_win,buf, false, {width=20,height=0,relative='editor'}))
-      eq({false, "Must specify 'width' and 'height'"},
-         meth_pcall(meths.open_win,buf, false, {relative='editor'}))
+      eq("Invalid key 'bork'",
+         pcall_err(meths.open_win,buf, false, {width=20,height=2,bork=true}))
+      eq("'win' key is only valid with relative='win'",
+         pcall_err(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,win=0}))
+      eq("Only one of 'relative' and 'external' must be used",
+         pcall_err(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,external=true}))
+      eq("Invalid value of 'relative' key",
+         pcall_err(meths.open_win,buf, false, {width=20,height=2,relative='shell',row=0,col=0}))
+      eq("Invalid value of 'anchor' key",
+         pcall_err(meths.open_win,buf, false, {width=20,height=2,relative='editor',row=0,col=0,anchor='bottom'}))
+      eq("All of 'relative', 'row', and 'col' has to be specified at once",
+         pcall_err(meths.open_win,buf, false, {width=20,height=2,relative='editor'}))
+      eq("'width' key must be a positive Integer",
+         pcall_err(meths.open_win,buf, false, {width=-1,height=2,relative='editor'}))
+      eq("'height' key must be a positive Integer",
+         pcall_err(meths.open_win,buf, false, {width=20,height=-1,relative='editor'}))
+      eq("'height' key must be a positive Integer",
+         pcall_err(meths.open_win,buf, false, {width=20,height=0,relative='editor'}))
+      eq("Must specify 'width' and 'height'",
+         pcall_err(meths.open_win,buf, false, {relative='editor'}))
     end)
 
     it('can be placed relative window or cursor', function()
@@ -4528,8 +4528,8 @@ describe('floating windows', function()
             {0:~                             }|
         ]], float_pos=expected_pos}
         else
-          eq({false, "UI doesn't support external windows"},
-             meth_pcall(meths.win_set_config, 0, {external=true, width=30, height=2}))
+          eq("UI doesn't support external windows",
+             pcall_err(meths.win_set_config, 0, {external=true, width=30, height=2}))
           return
         end
 
@@ -4844,8 +4844,8 @@ describe('floating windows', function()
             {0:~                                       }|
         ]], float_pos=expected_pos}
         else
-          eq({false, "UI doesn't support external windows"},
-             meth_pcall(meths.win_set_config, 0, {external=true, width=65, height=4}))
+          eq("UI doesn't support external windows",
+             pcall_err(meths.win_set_config, 0, {external=true, width=65, height=4}))
         end
 
         feed(":tabnext<cr>")

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -74,15 +74,14 @@ function module.matches(pat, actual)
   error(string.format('Pattern does not match.\nPattern:\n%s\nActual:\n%s', pat, actual))
 end
 
--- Expects an error matching Lua pattern `pat`.
---
-function module.expect_err(pat, fn, ...)
-  assert(type(fn) == 'function')
-  local fn_args = {...}
-  assert.error_matches(function() return fn(unpack(fn_args)) end, pat)
-end
-
 -- Invokes `fn` and returns the error string, or raises an error if `fn` succeeds.
+--
+-- Usage:
+--    -- Match exact string.
+--    eq('e', pcall_err(function(a, b) error('e') end, 'arg1', 'arg2'))
+--    -- Match Lua pattern.
+--    matches('e[or]+$', pcall_err(function(a, b) error('some error') end, 'arg1', 'arg2'))
+--
 function module.pcall_err(fn, ...)
   assert(type(fn) == 'function')
   local status, rv = pcall(fn, ...)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -73,12 +73,24 @@ function module.matches(pat, actual)
   end
   error(string.format('Pattern does not match.\nPattern:\n%s\nActual:\n%s', pat, actual))
 end
--- Expect an error matching pattern `pat`.
-function module.expect_err(pat, ...)
-  local fn = select(1, ...)
+
+-- Expects an error matching Lua pattern `pat`.
+--
+function module.expect_err(pat, fn, ...)
+  assert(type(fn) == 'function')
   local fn_args = {...}
-  table.remove(fn_args, 1)
   assert.error_matches(function() return fn(unpack(fn_args)) end, pat)
+end
+
+-- Invokes `fn` and returns the error string, or raises an error if `fn` succeeds.
+function module.pcall_err(fn, ...)
+  assert(type(fn) == 'function')
+  local status, rv = pcall(fn, ...)
+  if status == true then
+    error('expected failure, but got success')
+  end
+  local errmsg = tostring(rv):gsub('^[^:]+:%d+: ', '')
+  return errmsg
 end
 
 -- initial_path:  directory to recurse into


### PR DESCRIPTION
The test util lib ("helpers") is too big.  It has some redundant functions, and some general-purpose functions that should be moved to `vim.shared` (with tests + docs).

- ~~Eliminate `meth_pcall`~~ Rename to `pcall_err`.
- Eliminate `expect_err` in favor of `matches(..., pcall_err(...))`.
- Add `vim.pesc()` to treat a string as literal where a Lua pattern is expected.

I wonder if a better pattern would be if functions treated a `pat('...')` object as a Lua pattern and normal strings as literal.