### PR TITLE
test: is_os()

### DIFF
--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -180,7 +180,7 @@ describe('server -> client', function()
   end)
 
   describe('recursive (child) nvim client', function()
-    if helpers.isCI('travis') and helpers.os_name() == 'osx' then
+    if helpers.isCI('travis') and helpers.is_os('mac') then
       -- XXX: Hangs Travis macOS since e9061117a5b8f195c3f26a5cb94e18ddd7752d86.
       pending("[Hangs on Travis macOS. #5002]", function() end)
       return
@@ -339,7 +339,7 @@ describe('server -> client', function()
 
   describe('connecting to its own pipe address', function()
     it('does not deadlock', function()
-      if not helpers.isCI('travis') and helpers.os_name() == 'osx' then
+      if not helpers.isCI('travis') and helpers.is_os('mac') then
         -- It does, in fact, deadlock on QuickBuild. #6851
         pending("deadlocks on QuickBuild", function() end)
         return

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -11,7 +11,7 @@ local iswin = helpers.iswin
 local meth_pcall = helpers.meth_pcall
 local meths = helpers.meths
 local ok, nvim_async, feed = helpers.ok, helpers.nvim_async, helpers.feed
-local os_name = helpers.os_name
+local is_os = helpers.is_os
 local parse_context = helpers.parse_context
 local request = helpers.request
 local source = helpers.source
@@ -83,7 +83,7 @@ describe('API', function()
       nvim('command', 'w')
       local f = io.open(fname)
       ok(f ~= nil)
-      if os_name() == 'windows' then
+      if is_os('win') then
         eq('testing\r\napi\r\n', f:read('*a'))
       else
         eq('testing\napi\n', f:read('*a'))

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -7,7 +7,7 @@ local sleep = helpers.sleep
 local spawn, nvim_argv = helpers.spawn, helpers.nvim_argv
 local set_session = helpers.set_session
 local nvim_prog = helpers.nvim_prog
-local os_name = helpers.os_name
+local is_os = helpers.is_os
 local retry = helpers.retry
 local expect_twostreams = helpers.expect_twostreams
 
@@ -140,7 +140,7 @@ describe('channels', function()
     command("call chansend(id, 'incomplet\004')")
 
     local is_bsd = not not string.find(uname(), 'bsd')
-    local bsdlike = is_bsd or (os_name() == "osx")
+    local bsdlike = is_bsd or is_os('mac')
     local extra = bsdlike and "^D\008\008" or ""
     expect_twoline(id, "stdout",
                    "incomplet"..extra, "[1, ['incomplet'], 'stdin']", true)

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -206,7 +206,7 @@ describe('jobs', function()
 
   it("will not buffer data if it doesn't end in newlines", function()
     if helpers.isCI('travis') and os.getenv('CC') == 'gcc-4.9'
-      and helpers.os_name() == "osx" then
+      and helpers.is_os('mac') then
       -- XXX: Hangs Travis macOS since e9061117a5b8f195c3f26a5cb94e18ddd7752d86.
       pending("[Hangs on Travis macOS. #5002]", function() end)
       return

--- a/test/functional/legacy/file_perm_spec.lua
+++ b/test/functional/legacy/file_perm_spec.lua
@@ -21,7 +21,7 @@ describe('Test getting and setting file permissions', function()
     eq(9, call('len', call('getfperm', tempfile)))
 
     eq(1, call('setfperm', tempfile, 'rwx------'))
-    if helpers.os_name() == 'windows' then
+    if helpers.is_os('win') then
       eq('rw-rw-rw-', call('getfperm', tempfile))
     else
       eq('rwx------', call('getfperm', tempfile))

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -190,6 +190,15 @@ module.uname = (function()
   end)
 end)()
 
+function module.is_os(s)
+  if not (s == 'win' or s == 'mac' or s == 'unix') then
+    error('unknown platform: '..tostring(s))
+  end
+  return ((s == 'win' and module.iswin())
+    or (s == 'mac' and module.uname() == 'darwin')
+    or (s == 'unix'))
+end
+
 local function tmpdir_get()
   return os.getenv('TMPDIR') and os.getenv('TMPDIR') or os.getenv('TEMP')
 end


### PR DESCRIPTION
- Move os_name() up to "global helpers".
- Rename it to is_os().
- Make it depend on uname() instead of a running Nvim instance.