### PR TITLE
[WIP]vim-patch:8.0.0902: cannot specify directory or environment for a job

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -273,7 +273,7 @@ static void close_cb(Stream *stream, void *data)
 Channel *channel_job_start(char **argv, CallbackReader on_stdout,
                            CallbackReader on_stderr, Callback on_exit,
                            bool pty, bool rpc, bool detach, const char *cwd,
-                           uint16_t pty_width, uint16_t pty_height,
+                           dict_T *env, uint16_t pty_width, uint16_t pty_height,
                            char *term_name, varnumber_T *status_out)
 {
   assert(cwd == NULL || os_isdir_executable(cwd));
@@ -312,6 +312,7 @@ Channel *channel_job_start(char **argv, CallbackReader on_stdout,
   proc->events = chan->events;
   proc->detach = detach;
   proc->cwd = cwd;
+  proc->env = env;
 
   char *cmd = xstrdup(proc->argv[0]);
   bool has_out, has_err;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12349,6 +12349,7 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
                  on_stderr = CALLBACK_READER_INIT;
   Callback on_exit = CALLBACK_NONE;
   char *cwd = NULL;
+  dict_T *env = NULL;
   if (argvars[1].v_type == VAR_DICT) {
     job_opts = argvars[1].vval.v_dict;
 
@@ -12372,6 +12373,8 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       }
     }
 
+    env = (dict_T*)tv_dict_find(job_opts, "env", -1);
+
     if (!common_job_callbacks(job_opts, &on_stdout, &on_stderr, &on_exit)) {
       shell_free_argv(argv);
       return;
@@ -12388,8 +12391,8 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   Channel *chan = channel_job_start(argv, on_stdout, on_stderr, on_exit, pty,
-                                    rpc, detach, cwd, width, height, term_name,
-                                    &rettv->vval.v_number);
+                                    rpc, detach, cwd, env, width, height,
+                                    term_name, &rettv->vval.v_number);
   if (chan) {
     channel_create_event(chan, NULL);
   }
@@ -14679,7 +14682,7 @@ static void f_rpcstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   Channel *chan = channel_job_start(argv, CALLBACK_READER_INIT,
                                     CALLBACK_READER_INIT, CALLBACK_NONE,
-                                    false, true, false, NULL, 0, 0, NULL,
+                                    false, true, false, NULL, NULL, 0, 0, NULL,
                                     &rettv->vval.v_number);
   if (chan) {
     channel_create_event(chan, NULL);
@@ -18008,6 +18011,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   Callback on_exit = CALLBACK_NONE;
   dict_T *job_opts = NULL;
   const char *cwd = ".";
+  dict_T *env = NULL;
   if (argvars[1].v_type == VAR_DICT) {
     job_opts = argvars[1].vval.v_dict;
 
@@ -18022,6 +18026,8 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       }
     }
 
+    env = (dict_T*)tv_dict_find(job_opts, "env", -1);
+
     if (!common_job_callbacks(job_opts, &on_stdout, &on_stderr, &on_exit)) {
       shell_free_argv(argv);
       return;
@@ -18030,7 +18036,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   uint16_t term_width = MAX(0, curwin->w_width_inner - win_col_off(curwin));
   Channel *chan = channel_job_start(argv, on_stdout, on_stderr, on_exit,
-                                    true, false, false, cwd,
+                                    true, false, false, cwd, env,
                                     term_width, curwin->w_height_inner,
                                     xstrdup("xterm-256color"),
                                     &rettv->vval.v_number);

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -1,6 +1,7 @@
 #ifndef NVIM_EVENT_PROCESS_H
 #define NVIM_EVENT_PROCESS_H
 
+#include "nvim/eval/typval.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/rstream.h"
 #include "nvim/event/wstream.h"
@@ -22,6 +23,7 @@ struct process {
   uint8_t exit_signal;  // Signal used when killing (on Windows).
   uint64_t stopped_time;  // process_stop() timestamp
   const char *cwd;
+  dict_T *env;
   char **argv;
   Stream in, out, err;
   process_exit_cb cb;


### PR DESCRIPTION
Problem:    Cannot specify directory or environment for a job.
Solution:   Add the "cwd" and "env" arguments to job options. (Yasuhiro
            Matsumoto, closes vim/vim#1160)
https://github.com/vim/vim/commit/05aafed54b50b602315ae55d83a7d089804cecb0