### PR TITLE
test/wildmode_spec: fix flaky test

### DIFF
--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -1,6 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
-local shallowcopy = helpers.shallowcopy
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
 local iswin = helpers.iswin
 local funcs = helpers.funcs
@@ -81,13 +80,19 @@ describe("'wildmenu'", function()
     feed([[:sign <Tab>]])   -- Invoke wildmenu.
     -- NB: in earlier versions terminal output was redrawn during cmdline mode.
     -- For now just assert that the screen remains unchanged.
-    screen:expect{any='define  jump  list  >    '}
+    screen:expect{any='define  jump  list  >    |\n:sign define^             |'}
     screen:expect_unchanged()
 
     -- cmdline CTRL-D display should also be preserved.
     feed([[<C-U>]])
     feed([[sign <C-D>]])   -- Invoke cmdline CTRL-D.
-    screen:expect{any='define    place          '}
+    screen:expect{grid=[[
+      :sign                    |
+      define    place          |
+      jump      undefine       |
+      list      unplace        |
+      :sign ^                   |
+    ]]}
     screen:expect_unchanged()
 
     -- Exiting cmdline should show the buffer.

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -17,14 +17,6 @@ describe("'wildmenu'", function()
     screen:attach()
   end)
 
-  -- expect the screen stayed unchanged some time after first seen success
-  local function expect_stay_unchanged(args)
-    screen:expect(args)
-    args = shallowcopy(args)
-    args.unchanged = true
-    screen:expect(args)
-  end
-
   it(':sign <tab> shows wildmenu completions', function()
     command('set wildmenu wildmode=full')
     feed(':sign <tab>')
@@ -89,24 +81,14 @@ describe("'wildmenu'", function()
     feed([[:sign <Tab>]])   -- Invoke wildmenu.
     -- NB: in earlier versions terminal output was redrawn during cmdline mode.
     -- For now just assert that the screen remains unchanged.
-    expect_stay_unchanged{grid=[[
-                               |
-                               |
-                               |
-      define  jump  list  >    |
-      :sign define^             |
-    ]]}
+    screen:expect{any='define  jump  list  >    '}
+    screen:expect_unchanged()
 
     -- cmdline CTRL-D display should also be preserved.
     feed([[<C-U>]])
     feed([[sign <C-D>]])   -- Invoke cmdline CTRL-D.
-    expect_stay_unchanged{grid=[[
-      :sign                    |
-      define    place          |
-      jump      undefine       |
-      list      unplace        |
-      :sign ^                   |
-    ]]}
+    screen:expect{any='define    place          '}
+    screen:expect_unchanged()
 
     -- Exiting cmdline should show the buffer.
     feed([[<C-\><C-N>]])
@@ -118,13 +100,14 @@ describe("'wildmenu'", function()
     command([[call timer_start(10, {->execute('redrawstatus')}, {'repeat':-1})]])
     feed([[<C-\><C-N>]])
     feed([[:sign <Tab>]])   -- Invoke wildmenu.
-    expect_stay_unchanged{grid=[[
+    screen:expect{grid=[[
                                |
       ~                        |
       ~                        |
       define  jump  list  >    |
       :sign define^             |
     ]]}
+    screen:expect_unchanged()
   end)
 
   it('with laststatus=0, :vsplit, :term #2255', function()
@@ -152,7 +135,8 @@ describe("'wildmenu'", function()
     feed([[:<Tab>]])      -- Invoke wildmenu.
     -- Check only the last 2 lines, because the shell output is
     -- system-dependent.
-    expect_stay_unchanged{any='!  #  &  <  =  >  @  >   |\n:!^'}
+    screen:expect{any='!  #  &  <  =  >  @  >   |\n:!^'}
+    screen:expect_unchanged()
   end)
 
   it('wildmode=list,full and display+=msgsep interaction #10092', function()


### PR DESCRIPTION
a00eb23c27da fixed one race, but not this one:

    [  ERROR   ] test/functional/ui/wildmode_spec.lua @ 84: 'wildmenu' is preserved during :terminal activity
    test/functional/ui/screen.lua:587: Row 1 did not match.
    Expected:
      |*                         |
      |                         |
      |                         |
      |define  jump  list  >    |
      |:sign define^             |
    Actual:
      |*0: !terminal_output!     |
      |                         |
      |                         |
      |define  jump  list  >    |
      |:sign define^             |
    To print the expect() call that would assert the current screen state, use
    screen:snapshot_util(). In case of non-deterministic failures, use
    screen:redraw_debug() to show all intermediate screen states.
    stack traceback:
            test/functional/ui/screen.lua:587: in function '_wait'
            test/functional/ui/screen.lua:370: in function 'expect'
            test/functional/ui/wildmode_spec.lua:22: in function 'expect_stay_unchanged'
            test/functional/ui/wildmode_spec.lua:92: in function <test/functional/ui/wildmode_spec.lua:84>