### PR TITLE
main: early_init before event_init

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -209,6 +209,8 @@ void early_init(void)
   alist_init(&global_alist);    // Init the argument list to empty.
   global_alist.id = 0;
 
+  event_init();
+
   // Set the default values for the options.
   // NOTE: Non-latin1 translated messages are working only after this,
   // because this is where "has_mbyte" will be set, which is used by
@@ -258,8 +260,6 @@ int main(int argc, char **argv)
   init_startuptime(&params);
 
   early_init();
-
-  event_init();
 
   // Check if we have an interactive window.
   check_and_set_isatty(&params);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -257,9 +257,9 @@ int main(int argc, char **argv)
 
   init_startuptime(&params);
 
-  event_init();
-
   early_init();
+
+  event_init();
 
   // Check if we have an interactive window.
   check_and_set_isatty(&params);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -733,6 +733,9 @@ const void *vim_env_iter_rev(const char delim,
 /// @return [allocated] Expanded environment variable, or NULL
 char *vim_getenv(const char *name)
 {
+  // init_path() should have been called before now.
+  assert(get_vim_var_str(VV_PROGPATH)[0] != NUL);
+
 #ifdef WIN32
   if (strcmp(name, "HOME") == 0) {
     return xstrdup(homedir);
@@ -764,12 +767,6 @@ char *vim_getenv(const char *name)
         vim_path = xstrdup(kos_env_path);
       }
     }
-  }
-
-  // init_path() has been called typically before, but allow for logging to
-  // be used before already (not storing computed paths then).
-  if (get_vim_var_str(VV_PROGPATH)[0] == NUL) {
-    return NULL;
   }
 
   // When expanding $VIM or $VIMRUNTIME fails, try using:

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -733,9 +733,6 @@ const void *vim_env_iter_rev(const char delim,
 /// @return [allocated] Expanded environment variable, or NULL
 char *vim_getenv(const char *name)
 {
-  // init_path() should have been called before now.
-  assert(get_vim_var_str(VV_PROGPATH)[0] != NUL);
-
 #ifdef WIN32
   if (strcmp(name, "HOME") == 0) {
     return xstrdup(homedir);
@@ -767,6 +764,12 @@ char *vim_getenv(const char *name)
         vim_path = xstrdup(kos_env_path);
       }
     }
+  }
+
+  // init_path() has been called typically before, but allow for logging to
+  // be used before already (not storing computed paths then).
+  if (get_vim_var_str(VV_PROGPATH)[0] == NUL) {
+    return NULL;
   }
 
   // When expanding $VIM or $VIMRUNTIME fails, try using:


### PR DESCRIPTION
Allow for early logging.

Fixes https://github.com/neovim/neovim/issues/10937