### PR TITLE
test/shada_spec: avoid exit_event race

### DIFF
--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -12,9 +12,7 @@ local shada_helpers = require('test.functional.shada.helpers')
 local get_shada_rw = shada_helpers.get_shada_rw
 
 local function reset(shada_file)
-  clear{ args={'-u', 'NORC',
-              '-i', shada_file or 'NONE',
-        }}
+  clear{ args={'-u', 'NORC', '-i', shada_file or 'NONE', }}
 end
 
 local mpack_eq = function(expected, mpack_result)
@@ -2143,7 +2141,7 @@ describe('plugin/shada.vim', function()
   local epoch = os.date('%Y-%m-%dT%H:%M:%S', 0)
   local eol = helpers.iswin() and '\r\n' or '\n'
   before_each(function()
-    reset()
+    -- Note: reset() is called explicitly in each test.
     os.remove(fname)
     os.remove(fname .. '.tst')
     os.remove(fname_tmp)
@@ -2159,272 +2157,263 @@ describe('plugin/shada.vim', function()
     mpack_eq(expected, mpack_result)
   end
 
-  describe('event BufReadCmd', function()
-    it('works', function()
-      wshada('\004\000\009\147\000\196\002ab\196\001a')
-      wshada_tmp('\004\000\009\147\000\196\002ab\196\001b')
-      nvim_command('edit ' .. fname)
-      eq({
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "a"',
-      }, nvim_eval('getline(1, "$")'))
-      eq(false, curbuf('get_option', 'modified'))
-      eq('shada', curbuf('get_option', 'filetype'))
-      nvim_command('edit ' .. fname_tmp)
-      eq({
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "b"',
-      }, nvim_eval('getline(1, "$")'))
-      eq(false, curbuf('get_option', 'modified'))
-      eq('shada', curbuf('get_option', 'filetype'))
-      eq('++opt not supported', exc_exec('edit ++enc=latin1 ' .. fname))
-      neq({
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "a"',
-      }, nvim_eval('getline(1, "$")'))
-      neq(true, curbuf('get_option', 'modified'))
-    end)
+  it('event BufReadCmd', function()
+    reset()
+    wshada('\004\000\009\147\000\196\002ab\196\001a')
+    wshada_tmp('\004\000\009\147\000\196\002ab\196\001b')
+    nvim_command('edit ' .. fname)
+    eq({
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "a"',
+    }, nvim_eval('getline(1, "$")'))
+    eq(false, curbuf('get_option', 'modified'))
+    eq('shada', curbuf('get_option', 'filetype'))
+    nvim_command('edit ' .. fname_tmp)
+    eq({
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "b"',
+    }, nvim_eval('getline(1, "$")'))
+    eq(false, curbuf('get_option', 'modified'))
+    eq('shada', curbuf('get_option', 'filetype'))
+    eq('++opt not supported', exc_exec('edit ++enc=latin1 ' .. fname))
+    neq({
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "a"',
+    }, nvim_eval('getline(1, "$")'))
+    neq(true, curbuf('get_option', 'modified'))
   end)
 
-  describe('event FileReadCmd', function()
-    it('works', function()
-      wshada('\004\000\009\147\000\196\002ab\196\001a')
-      wshada_tmp('\004\000\009\147\000\196\002ab\196\001b')
-      nvim_command('$read ' .. fname)
-      eq({
-        '',
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "a"',
-      }, nvim_eval('getline(1, "$")'))
-      eq(true, curbuf('get_option', 'modified'))
-      neq('shada', curbuf('get_option', 'filetype'))
-      nvim_command('1,$read ' .. fname_tmp)
-      eq({
-        '',
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "a"',
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "b"',
-      }, nvim_eval('getline(1, "$")'))
-      eq(true, curbuf('get_option', 'modified'))
-      neq('shada', curbuf('get_option', 'filetype'))
-      curbuf('set_option', 'modified', false)
-      eq('++opt not supported', exc_exec('$read ++enc=latin1 ' .. fname))
-      eq({
-        '',
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "a"',
-        'History entry with timestamp ' .. epoch .. ':',
-        '  @ Description_  Value',
-        '  - history type  CMD',
-        '  - contents      "ab"',
-        '  -               "b"',
-      }, nvim_eval('getline(1, "$")'))
-      neq(true, curbuf('get_option', 'modified'))
-    end)
+  it('event FileReadCmd', function()
+    reset()
+    wshada('\004\000\009\147\000\196\002ab\196\001a')
+    wshada_tmp('\004\000\009\147\000\196\002ab\196\001b')
+    nvim_command('$read ' .. fname)
+    eq({
+      '',
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "a"',
+    }, nvim_eval('getline(1, "$")'))
+    eq(true, curbuf('get_option', 'modified'))
+    neq('shada', curbuf('get_option', 'filetype'))
+    nvim_command('1,$read ' .. fname_tmp)
+    eq({
+      '',
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "a"',
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "b"',
+    }, nvim_eval('getline(1, "$")'))
+    eq(true, curbuf('get_option', 'modified'))
+    neq('shada', curbuf('get_option', 'filetype'))
+    curbuf('set_option', 'modified', false)
+    eq('++opt not supported', exc_exec('$read ++enc=latin1 ' .. fname))
+    eq({
+      '',
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "a"',
+      'History entry with timestamp ' .. epoch .. ':',
+      '  @ Description_  Value',
+      '  - history type  CMD',
+      '  - contents      "ab"',
+      '  -               "b"',
+    }, nvim_eval('getline(1, "$")'))
+    neq(true, curbuf('get_option', 'modified'))
   end)
 
-  describe('event BufWriteCmd', function()
-    it('works', function()
-      nvim('set_var', 'shada#add_own_header', 0)
-      curbuf('set_lines', 0, 1, true, {
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-      })
-      nvim_command('w ' .. fname .. '.tst')
-      nvim_command('w ' .. fname)
-      nvim_command('w ' .. fname_tmp)
-      eq('++opt not supported', exc_exec('w! ++enc=latin1 ' .. fname))
-      eq(table.concat({
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-      }, eol) .. eol, read_file(fname .. '.tst'))
-      shada_eq({{
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }, {
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }}, fname)
-      shada_eq({{
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }, {
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }}, fname_tmp)
-    end)
+  it('event BufWriteCmd', function()
+    reset()
+    nvim('set_var', 'shada#add_own_header', 0)
+    curbuf('set_lines', 0, 1, true, {
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+    })
+    nvim_command('w ' .. fname .. '.tst')
+    nvim_command('w ' .. fname)
+    nvim_command('w ' .. fname_tmp)
+    eq('++opt not supported', exc_exec('w! ++enc=latin1 ' .. fname))
+    eq(table.concat({
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+    }, eol) .. eol, read_file(fname .. '.tst'))
+    shada_eq({{
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }, {
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }}, fname)
+    shada_eq({{
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }, {
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }}, fname_tmp)
   end)
 
-  describe('event FileWriteCmd', function()
-    it('works', function()
-      nvim('set_var', 'shada#add_own_header', 0)
-      curbuf('set_lines', 0, 1, true, {
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-      })
-      nvim_command('1,3w ' .. fname .. '.tst')
-      nvim_command('1,3w ' .. fname)
-      nvim_command('1,3w ' .. fname_tmp)
-      eq('++opt not supported', exc_exec('1,3w! ++enc=latin1 ' .. fname))
-      eq(table.concat({
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-      }, eol) .. eol, read_file(fname .. '.tst'))
-      shada_eq({{
-        timestamp=0,
-        type=8,
-        value={n=('A'):byte()},
-      }}, fname)
-      shada_eq({{
-        timestamp=0,
-        type=8,
-        value={n=('A'):byte()},
-      }}, fname_tmp)
-    end)
+  it('event FileWriteCmd', function()
+    reset()
+    nvim('set_var', 'shada#add_own_header', 0)
+    curbuf('set_lines', 0, 1, true, {
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+    })
+    nvim_command('1,3w ' .. fname .. '.tst')
+    nvim_command('1,3w ' .. fname)
+    nvim_command('1,3w ' .. fname_tmp)
+    eq('++opt not supported', exc_exec('1,3w! ++enc=latin1 ' .. fname))
+    eq(table.concat({
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+    }, eol) .. eol, read_file(fname .. '.tst'))
+    shada_eq({{
+      timestamp=0,
+      type=8,
+      value={n=('A'):byte()},
+    }}, fname)
+    shada_eq({{
+      timestamp=0,
+      type=8,
+      value={n=('A'):byte()},
+    }}, fname_tmp)
   end)
 
-  describe('event FileAppendCmd', function()
-    it('works', function()
-      nvim('set_var', 'shada#add_own_header', 0)
-      curbuf('set_lines', 0, 1, true, {
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-      })
-      funcs.writefile({''}, fname .. '.tst', 'b')
-      funcs.writefile({''}, fname, 'b')
-      funcs.writefile({''}, fname_tmp, 'b')
-      nvim_command('1,3w >> ' .. fname .. '.tst')
-      nvim_command('1,3w >> ' .. fname)
-      nvim_command('1,3w >> ' .. fname_tmp)
-      nvim_command('w >> ' .. fname .. '.tst')
-      nvim_command('w >> ' .. fname)
-      nvim_command('w >> ' .. fname_tmp)
-      eq('++opt not supported', exc_exec('1,3w! ++enc=latin1 >> ' .. fname))
-      eq(table.concat({
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-        'Jump with timestamp ' .. epoch .. ':',
-        '  % Key________  Description  Value',
-        '  + n            name         \'A\'',
-        '  + f            file name    ["foo"]',
-        '  + l            line number  2',
-        '  + c            column       -200',
-      }, eol) .. eol, read_file(fname .. '.tst'))
-      shada_eq({{
-        timestamp=0,
-        type=8,
-        value={n=('A'):byte()},
-      }, {
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }, {
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }}, fname)
-      shada_eq({{
-        timestamp=0,
-        type=8,
-        value={n=('A'):byte()},
-      }, {
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }, {
-        timestamp=0,
-        type=8,
-        value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
-      }}, fname_tmp)
-    end)
+  it('event FileAppendCmd', function()
+    reset()
+    nvim('set_var', 'shada#add_own_header', 0)
+    curbuf('set_lines', 0, 1, true, {
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+    })
+    funcs.writefile({''}, fname .. '.tst', 'b')
+    funcs.writefile({''}, fname, 'b')
+    funcs.writefile({''}, fname_tmp, 'b')
+    nvim_command('1,3w >> ' .. fname .. '.tst')
+    nvim_command('1,3w >> ' .. fname)
+    nvim_command('1,3w >> ' .. fname_tmp)
+    nvim_command('w >> ' .. fname .. '.tst')
+    nvim_command('w >> ' .. fname)
+    nvim_command('w >> ' .. fname_tmp)
+    eq('++opt not supported', exc_exec('1,3w! ++enc=latin1 >> ' .. fname))
+    eq(table.concat({
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+      'Jump with timestamp ' .. epoch .. ':',
+      '  % Key________  Description  Value',
+      '  + n            name         \'A\'',
+      '  + f            file name    ["foo"]',
+      '  + l            line number  2',
+      '  + c            column       -200',
+    }, eol) .. eol, read_file(fname .. '.tst'))
+    shada_eq({{
+      timestamp=0,
+      type=8,
+      value={n=('A'):byte()},
+    }, {
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }, {
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }}, fname)
+    shada_eq({{
+      timestamp=0,
+      type=8,
+      value={n=('A'):byte()},
+    }, {
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }, {
+      timestamp=0,
+      type=8,
+      value={c=-200, f={'foo'}, l=2, n=('A'):byte()},
+    }}, fname_tmp)
   end)
 
-  describe('event SourceCmd', function()
-    before_each(function()
-      reset(fname)
-    end)
-    it('works', function()
-      wshada('\004\000\006\146\000\196\002ab')
-      wshada_tmp('\004\001\006\146\000\196\002bc')
-      eq(0, exc_exec('source ' .. fname))
-      eq(0, exc_exec('source ' .. fname_tmp))
-      eq('bc', funcs.histget(':', -1))
-      eq('ab', funcs.histget(':', -2))
-    end)
+  it('event SourceCmd', function()
+    reset(fname)
+    wshada('\004\000\006\146\000\196\002ab')
+    wshada_tmp('\004\001\006\146\000\196\002bc')
+    eq(0, exc_exec('source ' .. fname))
+    eq(0, exc_exec('source ' .. fname_tmp))
+    eq('bc', funcs.histget(':', -1))
+    eq('ab', funcs.histget(':', -2))
   end)
 end)
 


### PR DESCRIPTION
This was apparently fixed in https://github.com/neovim/neovim/pull/10850 , but then started failing again since  https://github.com/neovim/neovim/pull/10946 .

- Workaround (same as d4a0b6c): avoid doing `clear()` multiple times in quick succession by removing unnecessary `reset()` call in the test.
- Replace unnecessary nested describe() blocks with it() blocks.


ref: https://github.com/neovim/neovim/issues/8813#issuecomment-519450094

<details><summary>backtrace</summary><p>


```
[32m[2m[ RUN      ][0m[0m plugin/shada.vim event SourceCmd works: [2m83.62 ms[0m [1m[32mOK[0m[0m
==================== File /home/travis/build/neovim/neovim/build/log/ubsan.19545 ====================
= =================================================================
= ==19545==ERROR: AddressSanitizer: SEGV on unknown address 0x000001d8add0 (pc 0x000000455614 bp 0x000000000000 sp 0x7ffdcedf5f50 T0)
= ==19545==The signal is caused by a WRITE memory access.
=     #0 0x455613 in atomic_compare_exchange_strong<__sanitizer::atomic_uint8_t> /tmp/final/llvm.src/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_atomic_clang.h:81:10
=     #1 0x455613 in AtomicallySetQuarantineFlagIfAllocated /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_allocator.cc:554
=     #2 0x455613 in __asan::Allocator::Deallocate(void*, unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType) /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_allocator.cc:631
=     #3 0x4fbf0b in __interceptor_free /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:129:3
=     #4 0x10aacd4 in xfree /home/travis/build/neovim/neovim/build/../src/nvim/memory.c:119:3
=     #5 0x12eea48 in free_string_option /home/travis/build/neovim/neovim/build/../src/nvim/option.c:2296:5
=     #6 0x12edf6d in free_all_options /home/travis/build/neovim/neovim/build/../src/nvim/option.c:969:9
=     #7 0x10ad969 in free_all_mem /home/travis/build/neovim/neovim/build/../src/nvim/memory.c:650:3
=     #8 0x13a2dd5 in mch_exit /home/travis/build/neovim/neovim/build/../src/nvim/os_unix.c:102:3
=     #9 0x116c8bd in exit_event /home/travis/build/neovim/neovim/build/../src/nvim/msgpack_rpc/channel.c:557:5
=     #10 0xb43a7e in multiqueue_process_events /home/travis/build/neovim/neovim/build/../src/nvim/event/multiqueue.c:150:7
=     #11 0xb3ce67 in loop_poll_events /home/travis/build/neovim/neovim/build/../src/nvim/event/loop.c:70:3
=     #12 0x138ae13 in os_breakcheck /home/travis/build/neovim/neovim/build/../src/nvim/os/input.c:167:5
=     #13 0x1109e59 in line_breakcheck /home/travis/build/neovim/neovim/build/../src/nvim/misc1.c:1009:5
=     #14 0x152b314 in nfa_regmatch /home/travis/build/neovim/neovim/build/../src/nvim/regexp_nfa.c:6316:5
=     #15 0x150b9bb in nfa_regtry /home/travis/build/neovim/neovim/build/../src/nvim/regexp_nfa.c:6390:16
=     #16 0x15096f2 in nfa_regexec_both /home/travis/build/neovim/neovim/build/../src/nvim/regexp_nfa.c:6560:12
=     #17 0x14b7728 in nfa_regexec_nl /home/travis/build/neovim/neovim/build/../src/nvim/regexp_nfa.c:6706:10
=     #18 0x146ada7 in vim_regexec_string /home/travis/build/neovim/neovim/build/../src/nvim/regexp.c:7250:16
=     #19 0x146ba87 in vim_regexec_nl /home/travis/build/neovim/neovim/build/../src/nvim/regexp.c:7302:10
=     #20 0xa414d3 in find_some_match /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:13028:15
=     #21 0x9aa3a5 in f_matchstr /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:13306:3
=     #22 0x8e0b5d in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6525:11
=     #23 0x8f37b7 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6268:11
=     #24 0x9849c8 in eval7 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4371:15
=     #25 0x980ffa in eval6 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4081:7
=     #26 0x97eac5 in eval5 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3929:7
=     #27 0x97a2bb in eval4 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3665:7
=     #28 0x979753 in eval3 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3583:7
=     #29 0x978c03 in eval2 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3514:7
=     #30 0x8da348 in eval1 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3441:7
=     #31 0x8dab16 in eval1 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3480:9
=     #32 0x8d9772 in eval0 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3401:9
=     #33 0x8e4e10 in ex_let_const /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:1580:9
=     #34 0x8e52d6 in ex_let /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:1521:3
=     #35 0xc3e8c9 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2248:5
=     #36 0xc209d8 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:594:20
=     #37 0x913be2 in call_user_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:22917:3
=     #38 0x8e046a in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6510:11
=     #39 0x8f37b7 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6268:11
=     #40 0x9849c8 in eval7 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4371:15
=     #41 0x980ffa in eval6 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4081:7
=     #42 0x97eac5 in eval5 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3929:7
=     #43 0x97a2bb in eval4 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3665:7
=     #44 0x979753 in eval3 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3583:7
=     #45 0x978c03 in eval2 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3514:7
=     #46 0x8da348 in eval1 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3441:7
=     #47 0x8d9772 in eval0 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3401:9
=     #48 0x8e5ae3 in eval_for_line /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2653:7
=     #49 0xce3dc5 in ex_while /home/travis/build/neovim/neovim/build/../src/nvim/ex_eval.c:967:14
=     #50 0xc3e8c9 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2248:5
=     #51 0xc209d8 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:594:20
=     #52 0x913be2 in call_user_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:22917:3
=     #53 0x8e046a in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6510:11
=     #54 0x8f37b7 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6268:11
=     #55 0x9849c8 in eval7 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4371:15
=     #56 0x980ffa in eval6 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:4081:7
=     #57 0x97eac5 in eval5 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3929:7
=     #58 0x97a2bb in eval4 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3665:7
=     #59 0x979753 in eval3 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3583:7
=     #60 0x978c03 in eval2 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3514:7
=     #61 0x8da348 in eval1 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3441:7
=     #62 0x8d9772 in eval0 /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:3401:9
=     #63 0x8e4e10 in ex_let_const /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:1580:9
=     #64 0x8e52d6 in ex_let /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:1521:3
=     #65 0xc3e8c9 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2248:5
=     #66 0xc209d8 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:594:20
=     #67 0x913be2 in call_user_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:22917:3
=     #68 0x8e046a in call_func /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6510:11
=     #69 0x8f37b7 in get_func_tv /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:6268:11
=     #70 0x8ec6ae in ex_call /home/travis/build/neovim/neovim/build/../src/nvim/eval.c:2878:9
=     #71 0xc3e8c9 in do_one_cmd /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:2248:5
=     #72 0xc209d8 in do_cmdline /home/travis/build/neovim/neovim/build/../src/nvim/ex_docmd.c:594:20
=     #73 0xc06d98 in do_source /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:3233:3
=     #74 0xc018ee in source_callback /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2368:9
=     #75 0xc01145 in do_in_path /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2446:15
=     #76 0xc015ab in do_in_path_and_pp /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2490:12
=     #77 0xc018c1 in source_in_path /home/travis/build/neovim/neovim/build/../src/nvim/ex_cmds2.c:2538:10
=     #78 0xf8945e in load_plugins /home/travis/build/neovim/neovim/build/../src/nvim/main.c:1342:5
=     #79 0xf7b206 in main /home/travis/build/neovim/neovim/build/../src/nvim/main.c:384:3
=     #80 0x7f7b1a8c082f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
=     #81 0x454348 in _start (/home/travis/build/neovim/neovim/build/bin/nvim+0x454348)
= 
= AddressSanitizer can not provide additional info.
= SUMMARY: AddressSanitizer: SEGV /tmp/final/llvm.src/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_atomic_clang.h:81:10 in atomic_compare_exchange_strong<__sanitizer::atomic_uint8_t>
= ==19545==ABORTING
=====================================================================================================
test/helpers.lua:158: Found runtime errors in logfile(s): /home/travis/build/neovim/neovim/build/log/ubsan.19545

stack traceback:
	test/helpers.lua:158: in function 'check_logs'
	test/functional/helpers.lua:806: in function <test/functional/helpers.lua:802>
```
</p></details>
