### PR TITLE
stdpaths_get_xdg_var: consider empty env vars

### DIFF
--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -68,6 +68,10 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
   if (env_val == NULL && xdg_defaults_env_vars[idx] != NULL) {
     env_val = os_getenv(xdg_defaults_env_vars[idx]);
   }
+#else
+  if (env_val == NULL && os_env_exists(env)) {
+    env_val = "";
+  }
 #endif
 
   char *ret = NULL;


### PR DESCRIPTION
Without this "sysinit uses VIM if XDG_CONFIG_DIRS unset" fails with an
existing `/etc/xdg/nvim/sysinit.vim` file, because `XDG_CONFIG_DIRS=` is
not considered, but the default ("/etc/xdg") used then.

TODO:

- [ ] explicit test?!