### PR TITLE
build: cmake: GetCompileFlags: include CMAKE_C_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,10 +533,7 @@ install_helper(
 #
 
 add_subdirectory(src/nvim)
-# Read compilation flags from src/nvim, used in config subdirectory below.
-include(GetCompileFlags)
-get_compile_flags(NVIM_VERSION_CFLAGS)
-
+get_directory_property(NVIM_VERSION_CFLAGS DIRECTORY src/nvim DEFINITION NVIM_VERSION_CFLAGS)
 add_subdirectory(test/includes)
 add_subdirectory(config)
 add_subdirectory(test/functional/fixtures)  # compile test programs

--- a/cmake/GetCompileFlags.cmake
+++ b/cmake/GetCompileFlags.cmake
@@ -10,9 +10,7 @@ function(get_compile_flags _compile_flags)
     "${compile_flags}")
 
   # Get flags set by add_definitions().
-  get_directory_property(compile_definitions
-    DIRECTORY "src/nvim"
-    COMPILE_DEFINITIONS)
+  get_property(compile_definitions DIRECTORY PROPERTY COMPILE_DEFINITIONS)
   get_target_property(compile_definitions_target nvim COMPILE_DEFINITIONS)
   if(compile_definitions_target)
     list(APPEND compile_definitions ${compile_definitions_target})
@@ -30,9 +28,7 @@ function(get_compile_flags _compile_flags)
     "${compile_flags}")
 
   # Get flags set by add_compile_options().
-  get_directory_property(compile_options
-    DIRECTORY "src/nvim"
-    COMPILE_OPTIONS)
+  get_property(compile_options DIRECTORY PROPERTY COMPILE_OPTIONS)
   get_target_property(compile_options_target nvim COMPILE_OPTIONS)
   if(compile_options_target)
     list(APPEND compile_options ${compile_options_target})
@@ -62,9 +58,7 @@ function(get_compile_flags _compile_flags)
     "${compile_flags}")
 
   # Get include directories.
-  get_directory_property(include_directories_list
-    DIRECTORY "src/nvim"
-    INCLUDE_DIRECTORIES)
+  get_property(include_directories_list DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
   list(REMOVE_DUPLICATES include_directories_list)
   foreach(include_directory ${include_directories_list})
     set(include_directories "${include_directories} -I${include_directory}")

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -678,3 +678,6 @@ add_custom_target(generated-sources DEPENDS
 )
 
 add_subdirectory(po)
+
+include(GetCompileFlags)
+get_compile_flags(NVIM_VERSION_CFLAGS)


### PR DESCRIPTION
Calls `GetCompileFlags` from `src/nvim` directory, to include
`--coverage` (and any others).