### PR TITLE
fix crash on :!tmux split, redraw after resize in pager

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9941,9 +9941,7 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if (argvars[0].v_type == VAR_UNKNOWN) {
       // getchar(): blocking wait.
       if (!(char_avail() || using_script() || input_available())) {
-        input_enable_events();
-        (void)os_inchar(NULL, 0, -1, 0);
-        input_disable_events();
+        (void)os_inchar(NULL, 0, -1, 0, main_loop.events);
         if (!multiqueue_empty(main_loop.events)) {
           multiqueue_process_events(main_loop.events);
           continue;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5673,7 +5673,6 @@ void ex_substitute(exarg_T *eap)
   }
 
   block_autocmds();           // Disable events during command preview.
-  input_disable_events();
 
   char_u *save_eap = eap->arg;
   garray_T save_view;
@@ -5716,7 +5715,6 @@ void ex_substitute(exarg_T *eap)
   restore_search_patterns();
   win_size_restore(&save_view);
   ga_clear(&save_view);
-  input_enable_events();
   unblock_autocmds();
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5099,10 +5099,10 @@ static void uc_list(char_u *name, size_t name_len)
       if (p_verbose > 0) {
         last_set_msg(cmd->uc_script_ctx);
       }
-      ui_flush();
-      os_breakcheck();
-      if (got_int)
+      line_breakcheck();
+      if (got_int) {
         break;
+      }
     }
     if (gap == &ucmds || i < gap->ga_len)
       break;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1532,8 +1532,9 @@ int safe_vgetc(void)
   int c;
 
   c = vgetc();
-  if (c == NUL)
-    c = get_keystroke();
+  if (c == NUL) {
+    c = get_keystroke(NULL);
+  }
   return c;
 }
 
@@ -2447,9 +2448,10 @@ int inchar(
       char_u dum[DUM_LEN + 1];
 
       for (;; ) {
-        len = os_inchar(dum, DUM_LEN, 0L, 0);
-        if (len == 0 || (len == 1 && dum[0] == 3))
+        len = os_inchar(dum, DUM_LEN, 0L, 0, NULL);
+        if (len == 0 || (len == 1 && dum[0] == 3)) {
           break;
+        }
       }
       return retesc;
     }
@@ -2460,7 +2462,7 @@ int inchar(
 
     // Fill up to a third of the buffer, because each character may be
     // tripled below.
-    len = os_inchar(buf, maxlen / 3, (int)wait_time, tb_change_cnt);
+    len = os_inchar(buf, maxlen / 3, (int)wait_time, tb_change_cnt, NULL);
   }
 
   // If the typebuf was changed further down, it is like nothing was added by

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -57,9 +57,8 @@ struct map_arguments {
 };
 typedef struct map_arguments MapArguments;
 
-#define KEYLEN_PART_KEY -1      /* keylen value for incomplete key-code */
-#define KEYLEN_PART_MAP -2      /* keylen value for incomplete mapping */
-#define KEYLEN_REMOVED  9999    /* keylen value for removed sequence */
+#define KEYLEN_PART_KEY -1  // keylen value for incomplete key-code
+#define KEYLEN_PART_MAP -2  // keylen value for incomplete mapping
 
 /// Maximum number of streams to read script from
 enum { NSCRIPT = 15 };

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -144,6 +144,8 @@ void event_init(void)
 {
   log_init();
   loop_init(&main_loop, NULL);
+  resize_events = multiqueue_new_child(main_loop.events);
+
   // early msgpack-rpc initialization
   msgpack_rpc_init_method_table();
   msgpack_rpc_helpers_init();

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2587,8 +2587,10 @@ static int do_more_prompt(int typed_char)
     if (used_typed_char != NUL) {
       c = used_typed_char;              /* was typed at hit-enter prompt */
       used_typed_char = NUL;
-    } else
-      c = get_keystroke();
+    } else {
+      c = get_keystroke(resize_events);
+      multiqueue_process_events(resize_events);
+    }
 
 
     toscroll = 0;
@@ -3307,8 +3309,8 @@ do_dialog (
   hotkeys = msg_show_console_dialog(message, buttons, dfltbutton);
 
   for (;; ) {
-    /* Get a typed character directly from the user. */
-    c = get_keystroke();
+    // Get a typed character directly from the user.
+    c = get_keystroke(NULL);
     switch (c) {
     case CAR:                 /* User accepts default option */
     case NL:

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2556,6 +2556,7 @@ static int do_more_prompt(int typed_char)
   int c;
   int retval = FALSE;
   int toscroll;
+  bool to_redraw = false;
   msgchunk_T  *mp_last = NULL;
   msgchunk_T  *mp;
   int i;
@@ -2589,7 +2590,6 @@ static int do_more_prompt(int typed_char)
       used_typed_char = NUL;
     } else {
       c = get_keystroke(resize_events);
-      multiqueue_process_events(resize_events);
     }
 
 
@@ -2663,31 +2663,44 @@ static int do_more_prompt(int typed_char)
       lines_left = Rows - 1;
       break;
 
+    case K_EVENT:
+      // only resize_events are processed here
+      // Attempt to redraw the screen. sb_text doesn't support reflow
+      // so this only really works for vertical resize.
+      multiqueue_process_events(resize_events);
+      to_redraw = true;
+      break;
+
     default:                    /* no valid response */
       msg_moremsg(TRUE);
       continue;
     }
 
-    if (toscroll != 0) {
-      if (toscroll < 0) {
-        /* go to start of last line */
-        if (mp_last == NULL)
+    // code assumes we only do one at a time
+    assert((toscroll == 0) || !to_redraw);
+
+    if (toscroll != 0 || to_redraw) {
+      if (toscroll < 0 || to_redraw) {
+        // go to start of last line
+        if (mp_last == NULL) {
           mp = msg_sb_start(last_msgchunk);
-        else if (mp_last->sb_prev != NULL)
+        } else if (mp_last->sb_prev != NULL) {
           mp = msg_sb_start(mp_last->sb_prev);
-        else
+        } else {
           mp = NULL;
+        }
 
         /* go to start of line at top of the screen */
         for (i = 0; i < Rows - 2 && mp != NULL && mp->sb_prev != NULL;
              ++i)
           mp = msg_sb_start(mp->sb_prev);
 
-        if (mp != NULL && mp->sb_prev != NULL) {
-          /* Find line to be displayed at top. */
-          for (i = 0; i > toscroll; --i) {
-            if (mp == NULL || mp->sb_prev == NULL)
+        if (mp != NULL && (mp->sb_prev != NULL || to_redraw)) {
+          // Find line to be displayed at top
+          for (i = 0; i > toscroll; i--) {
+            if (mp == NULL || mp->sb_prev == NULL) {
               break;
+            }
             mp = msg_sb_start(mp->sb_prev);
             if (mp_last == NULL)
               mp_last = msg_sb_start(last_msgchunk);
@@ -2695,7 +2708,7 @@ static int do_more_prompt(int typed_char)
               mp_last = msg_sb_start(mp_last->sb_prev);
           }
 
-          if (toscroll == -1) {
+          if (toscroll == -1 && !to_redraw) {
             grid_ins_lines(&msg_grid_adj, 0, 1, Rows, 0, Columns);
             grid_fill(&msg_grid_adj, 0, 1, 0, Columns, ' ', ' ',
                       HL_ATTR(HLF_MSG));
@@ -2711,6 +2724,7 @@ static int do_more_prompt(int typed_char)
               mp = disp_sb_line(i, mp);
               ++msg_scrolled;
             }
+            to_redraw = false;
           }
           toscroll = 0;
         }

--- a/src/nvim/os/input.h
+++ b/src/nvim/os/input.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 
 #include "nvim/api/private/defs.h"
+#include "nvim/event/multiqueue.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/input.h.generated.h"

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -46,14 +46,12 @@ getkey:
       // Event was made available after the last multiqueue_process_events call
       key = K_EVENT;
     } else {
-      input_enable_events();
       // Flush screen updates before blocking
       ui_flush();
       // Call `os_inchar` directly to block for events or user input without
       // consuming anything from `input_buffer`(os/input.c) or calling the
       // mapping engine.
-      (void)os_inchar(NULL, 0, -1, 0);
-      input_disable_events();
+      (void)os_inchar(NULL, 0, -1, 0, main_loop.events);
       // If an event was put into the queue, we send K_EVENT directly.
       key = !multiqueue_empty(main_loop.events)
             ? K_EVENT

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -174,7 +174,7 @@ void ui_refresh(void)
   }
 
   if (updating_screen) {
-    ui_schedule_refresh();
+    deferred_refresh_event(NULL);
     return;
   }
 
@@ -228,11 +228,11 @@ static void ui_refresh_event(void **argv)
 
 void ui_schedule_refresh(void)
 {
-  // TODO(bfredl): "fast" is not optimal. UI should be refreshed only at
-  // deferred processing plus a few more blocked-on-input situtions like
-  // wait_return(), but not any os_breakcheck(). Alternatively make this
-  // defered and make wait_return() process deferred events already.
-  loop_schedule_fast(&main_loop, event_create(ui_refresh_event, 0));
+  loop_schedule_fast(&main_loop, event_create(deferred_refresh_event, 0));
+}
+static void deferred_refresh_event(void **argv)
+{
+  multiqueue_put(resize_events, ui_refresh_event, 0);
 }
 
 void ui_default_colors_set(void)

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -66,4 +66,7 @@ struct ui_t {
 # include "ui.h.generated.h"
 # include "ui_events_call.h.generated.h"
 #endif
+
+
+EXTERN MultiQueue *resize_events;
 #endif  // NVIM_UI_H

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -689,6 +689,7 @@ end
 
 module.funcs = module.create_callindex(module.call)
 module.meths = module.create_callindex(module.nvim)
+module.async_meths = module.create_callindex(module.nvim_async)
 module.uimeths = module.create_callindex(ui)
 module.bufmeths = module.create_callindex(module.buffer)
 module.winmeths = module.create_callindex(module.window)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -122,10 +122,10 @@ describe('TUI', function()
 
     screen:try_resize(50,5)
     screen:expect{grid=[[
-      {8:FAIL 1}                                            |
-      {8:FAIL 2}                                            |
       {8:FAIL 3}                                            |
-      {10:-- More -- SPACE/d/j: screen/page/line down, b/u/}{12:k}|
+      {8:FAIL 4}                                            |
+      {8:FAIL 5}                                            |
+      {10:-- More --}{1: }                                       |
       {3:-- TERMINAL --}                                    |
     ]]}
 
@@ -144,12 +144,12 @@ describe('TUI', function()
                     )                                   |
       {8:Error detected while processing function ManyErr:} |
       {11:line    2:}                                        |
-      {10:-- More --}                                        |
-      {10:                                                  }|
-      {10:                                                  }|
-      {10:                                                  }|
-      {10:                                                  }|
-      {10:-- More -- SPACE/d/j: screen/page/line down, b/u/}{12:k}|
+      {8:FAIL 0}                                            |
+      {8:FAIL 1}                                            |
+      {8:FAIL 2}                                            |
+      {8:FAIL 3}                                            |
+      {8:FAIL 4}                                            |
+      {10:-- More --}{1: }                                       |
       {3:-- TERMINAL --}                                    |
     ]]}
 


### PR DESCRIPTION
Only handle resize at safe points. This is a bit tricky, we want to handle resize at "deferred" points, but also at some more occasions like the pager, but not in every `os_breakcheck()`. Solution: allow waiting for input together with any (child) queue, and not just hardcoded `main_loop.events`

Beyond fixing the crash we could:
 - [x] actually redraw the pager after resize (neither nvim 0.3.8 nor vim 8 does this, so the screen is messed up until you have scrolled an entire page). 
 - [x] also enable pager resize from remote UI