### PR TITLE
runtime: make :TOhtml plugin work with missing &vts option

### DIFF
--- a/runtime/autoload/tohtml.vim
+++ b/runtime/autoload/tohtml.vim
@@ -779,7 +779,7 @@ func! tohtml#GetUserSettings() "{{{
     if user_settings.no_pre == 0
       call tohtml#GetOption(user_settings,
 	    \ 'expand_tabs',
-	    \ &expandtab || &ts != 8 || &vts != '' || user_settings.number_lines ||
+	    \ &expandtab || &ts != 8 || (exists("+vts") && &vts != '') || user_settings.number_lines ||
 	    \   (user_settings.dynamic_folds && !user_settings.no_foldcolumn))
     else
       let user_settings.expand_tabs = 1

--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -1570,7 +1570,7 @@ while s:lnum <= s:end
 	if s:settings.expand_tabs
 	  let s:offset = 0
 	  let s:idx = stridx(s:expandedtab, "\t")
-	  let s:tablist = split(&vts,',')
+	  let s:tablist = exists("+vts") ? split(&vts,',') : []
 	  if empty(s:tablist)
 	    let s:tablist = [ &ts ]
 	  endif


### PR DESCRIPTION
Hotfix for 0.4

This should be reverted when `&vts` is added or at least stubbed out https://github.com/neovim/neovim/issues/10831#issuecomment-528601761