### PR TITLE
shada: initialize jumplist before search pattern

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2705,6 +2705,11 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer,
     } while (var_iter != NULL);
   }
 
+  // Initialize jump list
+  setpcmark();
+  cleanup_jumplist(curwin, false);
+  wms->jumps_size = shada_init_jumps(wms->jumps, &removable_bufs);
+
   const bool search_highlighted = !(no_hlsearch
                                     || find_shada_parameter('h') != NULL);
   const bool search_last_used = search_was_last_used();
@@ -2735,11 +2740,6 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer,
       }
     };
   }
-
-  // Initialize jump list
-  setpcmark();
-  cleanup_jumplist(curwin, false);
-  wms->jumps_size = shada_init_jumps(wms->jumps, &removable_bufs);
 
   // Initialize global marks
   if (dump_global_marks) {

--- a/test/functional/shada/history_spec.lua
+++ b/test/functional/shada/history_spec.lua
@@ -224,4 +224,17 @@ describe('ShaDa support code', function()
     eq('', funcs.histget('/', -1))
   end)
 
+  it('does not crash when dumping last search pattern (#10945)', function()
+    nvim_command('edit Xtest-functional-shada-history_spec')
+    -- Save jump list
+    nvim_command('wshada')
+    -- Wipe out buffer list (jump list entry gets removed)
+    nvim_command('%bwipeout')
+    -- Restore jump list
+    nvim_command('rshada')
+    nvim_command('silent! /pat/')
+    nvim_command('au BufNew * echo')
+    nvim_command('wshada')
+  end)
+
 end)


### PR DESCRIPTION
Since 8b8ecf4, the shada module loads files in the jumplist to properly
clear duplicates. This can trigger some autocommands, which in turn
saves and restores search and substitute patterns, freeing the previous
strings in "spats" which are held in "wms" as well (heap-use-after-free).
To avoid this, initialize the jumplist in "wms" before search patterns.

Fixes https://github.com/neovim/neovim/issues/10945 ?