### PR TITLE
[RDY]vim-patch:8.0.1038: strike-through text not supported

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8396,6 +8396,7 @@ synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
 		"standout"	"1" if standout
 		"underline"	"1" if underlined
 		"undercurl"	"1" if undercurled
+		"strikethrough"	"1" if struckthrough
 
 		Example (echoes the color of the syntax item under the
 		cursor): >

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4720,6 +4720,7 @@ the same syntax file on all UIs.
 
 					*bold* *underline* *undercurl*
 					*inverse* *italic* *standout*
+					*strikethrough*
 cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 	attr-list is a comma separated list (without spaces) of the
 	following items (in any order):
@@ -4730,6 +4731,7 @@ cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 		inverse		same as reverse
 		italic
 		standout
+		strikethrough
 		NONE		no attributes used (used to reset it)
 
 	Note that "bold" can be used here and by using a bold font.  They

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -290,6 +290,7 @@ numerical highlight ids to the actual attributes.
 			switched.
 	`italic`:	italic text.
 	`bold`:		bold text.
+	`strikethrough`:  struckthrough text.
 	`underline`:	underlined text. The line has `special` color.
 	`undercurl`:	undercurled text. The curl has `special` color.
 	`blend`:	Blend level (0-100). Could be used by UIs to support
@@ -447,6 +448,7 @@ is not active. New UIs should implement |ui-linegrid| instead.
 			switched.
 	`italic`:	italic text.
 	`bold`:		bold text.
+	`strikethrough`:  struckthrough text.
 	`underline`:	underlined text. The line has `special` color.
 	`undercurl`:	undercurled text. The curl has `special` color.
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -17593,6 +17593,9 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     case 's': {
       if (TOLOWER_ASC(what[1]) == 'p') {  // sp[#]
         p = highlight_color(id, what, modec);
+      } else if (TOLOWER_ASC(what[1]) == 't'
+                 && TOLOWER_ASC(what[2]) == 'r') {  // strikethrough
+        p = highlight_has_attr(id, HL_STRIKETHROUGH, modec);
       } else {  // standout
         p = highlight_has_attr(id, HL_STANDOUT, modec);
       }

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -598,6 +598,10 @@ Dictionary hlattrs2dict(HlAttrs ae, bool use_rgb)
     PUT(hl, "reverse", BOOLEAN_OBJ(true));
   }
 
+  if (mask & HL_STRIKETHROUGH) {
+    PUT(hl, "strikethrough", BOOLEAN_OBJ(true));
+  }
+
   if (use_rgb) {
     if (ae.rgb_fg_color != -1) {
       PUT(hl, "foreground", INTEGER_OBJ(ae.rgb_fg_color));

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -11,12 +11,13 @@ typedef int32_t RgbValue;
 ///
 /// sign bit should not be used here, as it identifies invalid highlight
 typedef enum {
-  HL_INVERSE     = 0x01,
-  HL_BOLD        = 0x02,
-  HL_ITALIC      = 0x04,
-  HL_UNDERLINE   = 0x08,
-  HL_UNDERCURL   = 0x10,
-  HL_STANDOUT    = 0x20,
+  HL_INVERSE         = 0x01,
+  HL_BOLD            = 0x02,
+  HL_ITALIC          = 0x04,
+  HL_UNDERLINE       = 0x08,
+  HL_UNDERCURL       = 0x10,
+  HL_STANDOUT        = 0x20,
+  HL_STRIKETHROUGH   = 0x40,
 } HlAttrFlags;
 
 /// Stores a complete highlighting entry, including colors and attributes

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -115,11 +115,11 @@ static int include_link = 0;    /* when 2 include "nvim/link" and "clear" */
 /// The "term", "cterm" and "gui" arguments can be any combination of the
 /// following names, separated by commas (but no spaces!).
 static char *(hl_name_table[]) =
-{"bold", "standout", "underline", "undercurl",
- "italic", "reverse", "inverse", "NONE"};
+{ "bold", "standout", "underline", "undercurl",
+  "italic", "reverse", "inverse", "strikethrough", "NONE" };
 static int hl_attr_table[] =
-{HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE,
- HL_INVERSE, 0};
+{ HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE,
+  HL_INVERSE, HL_STRIKETHROUGH, 0 };
 
 // The patterns that are being searched for are stored in a syn_pattern.
 // A match item consists of one pattern.

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -605,7 +605,8 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
     int hl_attrs = (cell.attrs.bold ? HL_BOLD : 0)
                  | (cell.attrs.italic ? HL_ITALIC : 0)
                  | (cell.attrs.reverse ? HL_INVERSE : 0)
-                 | (cell.attrs.underline ? HL_UNDERLINE : 0);
+                 | (cell.attrs.underline ? HL_UNDERLINE : 0)
+                 | (cell.attrs.strike ? HL_STRIKETHROUGH: 0);
 
     int attr_id = 0;
 

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -25,6 +25,7 @@ describe('API: highlight',function()
     reverse = true,
     undercurl = true,
     underline = true,
+    strikethrough = true,
   }
 
   before_each(function()
@@ -46,7 +47,7 @@ describe('API: highlight',function()
     eq('Invalid highlight id: 30000', string.match(emsg, 'Invalid.*'))
 
     -- Test all highlight properties.
-    command('hi NewHighlight gui=underline,bold,undercurl,italic,reverse')
+    command('hi NewHighlight gui=underline,bold,undercurl,italic,reverse,strikethrough')
     eq(expected_rgb2, nvim("get_hl_by_id", hl_id, true))
 
     -- Test nil argument.

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -29,6 +29,7 @@ local function set_bg(num) feed_termcode('[48;5;'..num..'m') end
 local function set_bold() feed_termcode('[1m') end
 local function set_italic() feed_termcode('[3m') end
 local function set_underline() feed_termcode('[4m') end
+local function set_strikethrough() feed_termcode('[9m') end
 local function clear_attrs() feed_termcode('[0;10m') end
 -- mouse
 local function enable_mouse() feed_termcode('[?1002h') end
@@ -113,6 +114,7 @@ return {
   set_bold = set_bold,
   set_italic = set_italic,
   set_underline = set_underline,
+  set_strikethrough = set_strikethrough,
   clear_attrs = clear_attrs,
   enable_mouse = enable_mouse,
   disable_mouse = disable_mouse,

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -18,7 +18,7 @@ describe(':terminal highlight', function()
       [1] = {foreground = 45},
       [2] = {background = 46},
       [3] = {foreground = 45, background = 46},
-      [4] = {bold = true, italic = true, underline = true},
+      [4] = {bold = true, italic = true, underline = true, strikethrough = true},
       [5] = {bold = true},
       [6] = {foreground = 12},
       [7] = {bold = true, reverse = true},
@@ -108,10 +108,11 @@ describe(':terminal highlight', function()
     thelpers.set_fg(45)
     thelpers.set_bg(46)
   end)
-  descr('bold, italics and underline', 4, function()
+  descr('bold, italics, underline and strikethrough', 4, function()
     thelpers.set_bold()
     thelpers.set_italic()
     thelpers.set_underline()
+    thelpers.set_strikethrough()
   end)
 end)
 
@@ -215,7 +216,7 @@ describe('synIDattr()', function()
     screen = Screen.new(50, 7)
     command('highlight Normal ctermfg=252 guifg=#ff0000 guibg=Black')
     -- Salmon #fa8072 Maroon #800000
-    command('highlight Keyword ctermfg=79 guifg=Salmon guisp=Maroon')
+    command('highlight Keyword ctermfg=79 guifg=Salmon guisp=Maroon cterm=strikethrough gui=strikethrough')
   end)
 
   it('returns cterm-color if RGB-capable UI is _not_ attached', function()
@@ -254,6 +255,12 @@ describe('synIDattr()', function()
     screen:attach({rgb=false})
     eq('252', eval('synIDattr(hlID("Normal"), "fg")'))
     eq('79', eval('synIDattr(hlID("Keyword"), "fg")'))
+  end)
+
+  it('returns "1" if group has "strikethrough" attribute', function()
+    eq('', eval('synIDattr(hlID("Normal"), "strikethrough")'))
+    eq('1', eval('synIDattr(hlID("Keyword"), "strikethrough")'))
+    eq('1', eval('synIDattr(hlID("Keyword"), "strikethrough", "gui")'))
   end)
 end)
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -412,6 +412,32 @@ describe('highlight', function()
     ]])
   end)
 
+  it('strikethrough', function()
+    screen:detach()
+    screen = Screen.new(25,6)
+    screen:attach()
+    feed_command('syntax on')
+    feed_command('syn keyword TmpKeyword foo')
+    feed_command('hi! Awesome cterm=strikethrough gui=strikethrough')
+    feed_command('hi link TmpKeyword Awesome')
+    insert([[
+      foo
+      foo bar
+      foobarfoobar
+      ]])
+    screen:expect([[
+      {1:foo}                      |
+      {1:foo} bar                  |
+      foobarfoobar             |
+      ^                         |
+      {2:~                        }|
+                               |
+    ]],{
+      [1] = {strikethrough = true},
+      [2] = {bold = true, foreground = Screen.colors.Blue1},
+    })
+  end)
+
   it('guisp (special/undercurl)', function()
     feed_command('syntax on')
     feed_command('syn keyword TmpKeyword neovim')

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1509,7 +1509,8 @@ function Screen:_equal_attrs(a, b)
        a.underline == b.underline and a.undercurl == b.undercurl and
        a.italic == b.italic and a.reverse == b.reverse and
        a.foreground == b.foreground and a.background == b.background and
-       a.special == b.special and a.blend == b.blend
+       a.special == b.special and a.blend == b.blend and
+       a.strikethrough == b.strikethrough
 end
 
 function Screen:_equal_info(a, b)


### PR DESCRIPTION
Problem:    Strike-through text not supported.
Solution:   Add support for the "strikethrough" attribute. (Christian
	         Brabandt, Ken Takata)
https://github.com/vim/vim/commit/cf4b00c856ef714482d8d060332ac9a4d74e6b88

fix #3436