### PR TITLE
paste: reset 'paste' option immediately

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -188,8 +188,9 @@ paste = (function()
     if mode == 'c' and not got_line1 then  -- cmdline-mode: paste only 1 line.
       got_line1 = (#lines > 1)
       vim.api.nvim_set_option('paste', true)  -- For nvim_input().
-      local line1, _ = string.gsub(lines[1], '[\r\n\012\027]', ' ')
-      vim.api.nvim_input(line1)  -- Scrub "\r".
+      local line1, _ = string.gsub(lines[1], '[\r\n\012\027]', ' ')  -- Scrub.
+      vim.api.nvim_input(line1)
+      vim.api.nvim_set_option('paste', false)
     elseif mode == 'i' or mode == 'R' then
       vim.api.nvim_put(lines, 'c', false, true)
     else
@@ -206,7 +207,6 @@ paste = (function()
     if phase == -1 or phase == 3 then
       vim.api.nvim_command('redraw')
       vim.api.nvim_command('echo ""')
-      vim.api.nvim_set_option('paste', false)
     end
     return true  -- Paste will not continue if not returning `true`.
   end

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -505,7 +505,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|
       {5:                                                  }|
-      {8:paste: Error executing lua: vim.lua:196: Vim:E21: }|
+      {8:paste: Error executing lua: vim.lua:197: Vim:E21: }|
       {8:Cannot make changes, 'modifiable' is off}          |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |


### PR DESCRIPTION
- Workaround #10966: 'paste' option is not always reset.
- In any case there's not much reason to wait until phase=3, because  pasting in cmdline-mode skips lines after the first line (thus the  `:set paste .. :set nopaste` dance happens only ~once).