### PR TITLE
paste: fix various bugs

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -239,7 +239,7 @@ GUIs can paste by calling |nvim_paste()|.
 
 PASTE BEHAVIOR ~
 
-Paste inserts text after the cursor.  Lines break at <NL>, <CR>, and <CR><NL>.
+Paste inserts text before the cursor.  Lines break at <NL>, <CR> and <CR><NL>.
 When pasting a huge amount of text, screen-updates are throttled and the
 message area shows a "..." pulse.
 

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -192,7 +192,7 @@ paste = (function()
       vim.api.nvim_input(line1)
       vim.api.nvim_set_option('paste', false)
     elseif mode ~= 'c' then
-      vim.api.nvim_put(lines, 'c', (mode ~= 'i' and mode ~= 'R'), true)
+      vim.api.nvim_put(lines, 'c', false, true)
     end
     if phase ~= -1 and (now - tdots >= 100) then
       local dots = ('.'):rep(tick % 4)

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -203,8 +203,7 @@ paste = (function()
       vim.api.nvim_command(('echo "%s"'):format(dots))
     end
     if phase == -1 or phase == 3 then
-      vim.api.nvim_command('redraw')
-      vim.api.nvim_command('echo ""')
+      vim.api.nvim_command('redraw'..(tick > 1 and '|echo ""' or ''))
     end
     return true  -- Paste will not continue if not returning `true`.
   end

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -191,10 +191,8 @@ paste = (function()
       local line1, _ = string.gsub(lines[1], '[\r\n\012\027]', ' ')  -- Scrub.
       vim.api.nvim_input(line1)
       vim.api.nvim_set_option('paste', false)
-    elseif mode == 'i' or mode == 'R' then
-      vim.api.nvim_put(lines, 'c', false, true)
-    else
-      vim.api.nvim_put(lines, 'c', true, true)
+    elseif mode ~= 'c' then
+      vim.api.nvim_put(lines, 'c', (mode ~= 'i' and mode ~= 'R'), true)
     end
     if phase ~= -1 and (now - tdots >= 100) then
       local dots = ('.'):rep(tick % 4)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -319,7 +319,7 @@ describe('TUI', function()
       {1:x}                                                 |
       {4:~                                                 }|
       {5:[No Name] [+]                   3,1            All}|
-                                                        |
+      :set ruler                                        |
       {3:-- TERMINAL --}                                    |
     ]]
     local expected_attr = {
@@ -353,7 +353,11 @@ describe('TUI', function()
     expect_child_buf_lines({''})
     -- CRLF input
     feed_data('\027[200~'..table.concat(expected_lf,'\r\n')..'\027[201~')
-    screen:expect{grid=expected_grid1, attr_ids=expected_attr}
+    screen:expect{
+      grid=expected_grid1:gsub(
+        ':set ruler *',
+        '3 fewer lines; before #1  0 seconds ago           '),
+      attr_ids=expected_attr}
     expect_child_buf_lines(expected_crlf)
   end)
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -485,9 +485,9 @@ describe('TUI', function()
     feed_data('\n')  -- <CR>
     screen:expect{grid=[[
       foo                                               |
-      typed input...line A                              |
+      typed input..line A                               |
       line B                                            |
-      {1: }                                                 |
+      {1:.}                                                 |
       {5:[No Name] [+]                                     }|
                                                         |
       {3:-- TERMINAL --}                                    |

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -363,7 +363,10 @@ describe('TUI', function()
     feed_data('\027[D')   -- <Left> to place cursor between quotes.
     wait_for_mode('c')
     -- "bracketed paste"
-    feed_data('\027[200~line 1\nline 2\n\027[201~')
+    feed_data('\027[200~line 1\nline 2\n')
+    wait_for_mode('c')
+    feed_data('line 3\nline 4\n\027[201~')
+    wait_for_mode('c')
     screen:expect{grid=[[
       foo                                               |
                                                         |
@@ -505,7 +508,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|
       {5:                                                  }|
-      {8:paste: Error executing lua: vim.lua:197: Vim:E21: }|
+      {8:paste: Error executing lua: vim.lua:195: Vim:E21: }|
       {8:Cannot make changes, 'modifiable' is off}          |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |


### PR DESCRIPTION
- Cmdline: discard all chunks after first line
- Do not clear msg area for small pastes.
- Insert text _before_ cursor instead of _after_.