### PR TITLE
paste: fix normal-mode paste by different approach

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -239,7 +239,7 @@ GUIs can paste by calling |nvim_paste()|.
 
 PASTE BEHAVIOR ~
 
-Paste inserts text before the cursor.  Lines break at <NL>, <CR> and <CR><NL>.
+Paste inserts text after the cursor.  Lines break at <NL>, <CR>, and <CR><NL>.
 When pasting a huge amount of text, screen-updates are throttled and the
 message area shows a "..." pulse.
 

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -191,8 +191,14 @@ paste = (function()
       local line1, _ = string.gsub(lines[1], '[\r\n\012\027]', ' ')  -- Scrub.
       vim.api.nvim_input(line1)
       vim.api.nvim_set_option('paste', false)
-    elseif mode ~= 'c' then
-      vim.api.nvim_put(lines, 'c', false, true)
+    elseif mode ~= 'c' then  -- Else: discard remaining cmdline-mode chunks.
+      if phase < 2 and mode ~= 'i' and mode ~= 'R' then
+        vim.api.nvim_put(lines, 'c', true, true)
+        -- XXX: Normal-mode: workaround bad cursor-placement after first chunk.
+        vim.api.nvim_command('normal! a')
+      else
+        vim.api.nvim_put(lines, 'c', false, true)
+      end
     end
     if phase ~= -1 and (now - tdots >= 100) then
       local dots = ('.'):rep(tick % 4)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -319,7 +319,7 @@ describe('TUI', function()
       {1:x}                                                 |
       {4:~                                                 }|
       {5:[No Name] [+]                   3,1            All}|
-      :set ruler                                        |
+                                                        |
       {3:-- TERMINAL --}                                    |
     ]]
     local expected_attr = {
@@ -485,9 +485,9 @@ describe('TUI', function()
     feed_data('\n')  -- <CR>
     screen:expect{grid=[[
       foo                                               |
-      typed input..line A                               |
+      typed input...line A                              |
       line B                                            |
-      {1:.}                                                 |
+      {1: }                                                 |
       {5:[No Name] [+]                                     }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -512,7 +512,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|
       {5:                                                  }|
-      {8:paste: Error executing lua: vim.lua:195: Vim:E21: }|
+      {8:paste: Error executing lua: vim.lua:196: Vim:E21: }|
       {8:Cannot make changes, 'modifiable' is off}          |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |


### PR DESCRIPTION
Instead of a9e2bae (insert-before-cursor) force insert-mode after the first paste-chunk.

NB: Dot-repeat needs to match the original action.  Since a9e2bae changed paste to insert-before-cursor, dot-repeat must also. But that makes dot-repeat unpleasant/unusual.