### PR TITLE
third-party: update libuv to v1.32.0

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -102,9 +102,6 @@ bool os_env_exists(const char *name)
   assert(r != UV_EINVAL);
   if (r != 0 && r != UV_ENOENT && r != UV_ENOBUFS) {
     ELOG("uv_os_getenv(%s) failed: %d %s", name, r, uv_err_name(r));
-#ifdef WIN32
-    return (r == UV_UNKNOWN);
-#endif
   }
   return (r == 0 || r == UV_ENOBUFS);
 }

--- a/test/functional/eval/environ_spec.lua
+++ b/test/functional/eval/environ_spec.lua
@@ -10,6 +10,7 @@ describe('environment variables', function()
     eq("", environ()['EMPTY_VAR'])
     eq(nil, environ()['DOES_NOT_EXIST'])
   end)
+
   it('exists() handles empty env variable', function()
     clear({env={EMPTY_VAR=""}})
     eq(1, exists('$EMPTY_VAR'))

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -2,3 +2,13 @@
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
 local helpers = require('test.functional.helpers')(nil)
+local iswin = helpers.iswin
+
+if iswin() then
+  local ffi = require('ffi')
+  ffi.cdef[[
+  typedef int errno_t;
+  errno_t _set_fmode(int mode);
+  ]]
+  ffi.C._set_fmode(0x8000)
+end

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -134,11 +134,12 @@ include(ExternalProject)
 
 if(WIN32)
   # "nvim" branch of https://github.com/neovim/libuv
-  set(LIBUV_URL https://github.com/neovim/libuv/archive/eeae18d085de25f138c23966f98a179f0fb609e7.tar.gz)
-  set(LIBUV_SHA256 c37d0b7cb1defe69ae8dbb4d712c0d7cf838d6539178e8bcf71c72579ab5b666)
+  set(LIBUV_URL https://github.com/neovim/libuv/archive/d5ff3004d26b9bb863b76247399a9c72a0ff184c.tar.gz)
+  set(LIBUV_SHA256 0f5dfd92269713ed275273966ed73578fc68db669c509b01210cd58c1cf6361d)
 else()
-  set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.30.0.tar.gz)
-  set(LIBUV_SHA256 44c8fdadf3b3f393006a4ac4ba144020673a3f9cd72bed1fbb2c366ebcf0d199)
+  # blueyed/nvim-fixes (for *BSD build fixes).
+  set(LIBUV_URL https://github.com/blueyed/libuv/archive/2af4cf2.tar.gz)
+  set(LIBUV_SHA256 SKIP)
 endif()
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0/msgpack-3.0.0.tar.gz)


### PR DESCRIPTION
Waiting for new release for OpenBSD build failure: https://github.com/libuv/libuv/pull/2458

TODO:

- [x] https://github.com/neovim/neovim/pull/10978#issuecomment-531104690