### PR TITLE
eval: wait(): always spin up dummy-timer

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8920,23 +8920,20 @@ visualmode([expr])						*visualmode()*
 		the old value is returned.  See |non-zero-arg|.
 
 wait({timeout}, {condition}[, {interval}])			*wait()*
-		Wait until {condition} is satisfied, where {condition} is a
-		|Funcref| or a |string| containing an expression.
+		Waits until {condition} evaluates to |TRUE|, where {condition}
+		is a |Funcref| or |string| containing an expression.
 
-		{timeout} is the maximum number of milliseconds to wait,
-        -1 means forever.
+		{timeout} is the maximum waiting time in milliseconds, -1
+		means forever.
 
-		By default, the condition is evaluated on user and internal
-		events. If {interval} is given, the condition is evaluated
-		every {interval} milliseconds in addition. This can be useful
-		to guarantee that the function returns when the condition is
-		satisfied even if the editor is idle.
+		Condition is evaluated on user events, internal events, and
+		every {interval} milliseconds (default: 200).
 
-		Returns one of the following:
-			*  0 if the condition was satisfied before the timeout
-			* -1 if the timeout was exceeded
-			* -2 if the function was interrupted
-			* -3 if an error occurred
+		Returns a status integer:
+			0 if the condition was satisfied before timeout
+			-1 if the timeout was exceeded
+			-2 if the function was interrupted (by |CTRL-C|)
+			-3 if an error occurred
 
 wildmenumode()					*wildmenumode()*
 		Returns |TRUE| when the wildmenu is active and |FALSE|

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10910,31 +10910,24 @@ static void f_wait(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     EMSG2(_(e_invargval), "1");
     return;
   }
-
-  int timeout = argvars[0].vval.v_number;
-  typval_T expr = argvars[1];
-
-  int interval = -1;
-  typval_T *tv_interval = &argvars[2];
-
-  TimeWatcher *tw = NULL;
-
-  if (tv_interval->v_type == VAR_NUMBER) {
-    interval = tv_interval->vval.v_number;
-    if (interval <= 0) {
-      EMSG2(_(e_invargval), "3");
-      return;
-    }
-    // Start dummy timer
-    tw = xmalloc(sizeof(TimeWatcher));
-    time_watcher_init(&main_loop, tw, NULL);
-    tw->events = main_loop.events;
-    tw->blockable = true;
-    time_watcher_start(tw, dummy_timer_due_cb, interval, interval);
-  } else if (tv_interval->v_type != VAR_UNKNOWN) {
+  if ((argvars[2].v_type != VAR_NUMBER && argvars[2].v_type != VAR_UNKNOWN)
+      || (argvars[2].v_type == VAR_NUMBER && argvars[2].vval.v_number <= 0)) {
     EMSG2(_(e_invargval), "3");
     return;
   }
+
+  int timeout = argvars[0].vval.v_number;
+  typval_T expr = argvars[1];
+  int interval = argvars[2].v_type == VAR_NUMBER
+    ? argvars[2].vval.v_number
+    : 200;  // Default.
+  TimeWatcher *tw = xmalloc(sizeof(TimeWatcher));
+
+  // Start dummy timer.
+  time_watcher_init(&main_loop, tw, NULL);
+  tw->events = main_loop.events;
+  tw->blockable = true;
+  time_watcher_start(tw, dummy_timer_due_cb, interval, interval);
 
   typval_T argv = TV_INITIAL_VALUE;
   typval_T exprval = TV_INITIAL_VALUE;
@@ -10960,10 +10953,8 @@ static void f_wait(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   called_emsg = save_called_emsg;
 
   // Stop dummy timer
-  if (tw) {
-    time_watcher_stop(tw);
-    time_watcher_close(tw, dummy_timer_close_cb);
-  }
+  time_watcher_stop(tw);
+  time_watcher_close(tw, dummy_timer_close_cb);
 }
 
 // "win_screenpos()" function

--- a/test/functional/eval/wait_spec.lua
+++ b/test/functional/eval/wait_spec.lua
@@ -59,10 +59,10 @@ describe('wait()', function()
     ]])
 
     nvim('set_var', 'counter', 0)
-    eq(-1, call('wait', 20, 'Count() >= 5'))
+    eq(-1, call('wait', 20, 'Count() >= 5', 99999))
 
     nvim('set_var', 'counter', 0)
-    eq(0, call('wait', 1000, 'Count() >= 5', 5))
+    eq(0, call('wait', 10000, 'Count() >= 5', 5))
     eq(5, nvim('get_var', 'counter'))
   end)
 


### PR DESCRIPTION
This avoids getting "stuck".  If user actually _wants_ to get stuck forever, they could use `:sleep` or specify a really big `interval`.