### PR TITLE
allow pass through of :terminal palette colors with termguicolors

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -611,6 +611,14 @@ Dictionary hlattrs2dict(HlAttrs ae, bool use_rgb)
   }
 
   if (use_rgb) {
+    if (mask & HL_FG_INDEXED) {
+      PUT(hl, "fg_indexed", BOOLEAN_OBJ(true));
+    }
+
+    if (mask & HL_BG_INDEXED) {
+      PUT(hl, "bg_indexed", BOOLEAN_OBJ(true));
+    }
+
     if (ae.rgb_fg_color != -1) {
       PUT(hl, "foreground", INTEGER_OBJ(ae.rgb_fg_color));
     }

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -321,18 +321,26 @@ int hl_combine_attr(int char_attr, int prim_attr)
 
   if (spell_aep.cterm_fg_color > 0) {
     new_en.cterm_fg_color = spell_aep.cterm_fg_color;
+    new_en.rgb_ae_attr &= ((~HL_FG_INDEXED)
+                           | (spell_aep.rgb_ae_attr & HL_FG_INDEXED));
   }
 
   if (spell_aep.cterm_bg_color > 0) {
     new_en.cterm_bg_color = spell_aep.cterm_bg_color;
+    new_en.rgb_ae_attr &= ((~HL_BG_INDEXED)
+                           | (spell_aep.rgb_ae_attr & HL_BG_INDEXED));
   }
 
   if (spell_aep.rgb_fg_color >= 0) {
     new_en.rgb_fg_color = spell_aep.rgb_fg_color;
+    new_en.rgb_ae_attr &= ((~HL_FG_INDEXED)
+                           | (spell_aep.rgb_ae_attr & HL_FG_INDEXED));
   }
 
   if (spell_aep.rgb_bg_color >= 0) {
     new_en.rgb_bg_color = spell_aep.rgb_bg_color;
+    new_en.rgb_ae_attr &= ((~HL_BG_INDEXED)
+                           | (spell_aep.rgb_ae_attr & HL_BG_INDEXED));
   }
 
   if (spell_aep.rgb_sp_color >= 0) {
@@ -422,6 +430,7 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
     cattrs.cterm_bg_color = fattrs.cterm_bg_color;
     cattrs.cterm_fg_color = cterm_blend(ratio, battrs.cterm_fg_color,
                                         fattrs.cterm_bg_color);
+    cattrs.rgb_ae_attr &= ~(HL_FG_INDEXED | HL_BG_INDEXED);
   } else {
     cattrs = fattrs;
     if (ratio >= 50) {
@@ -435,6 +444,8 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
     } else {
       cattrs.rgb_sp_color = -1;
     }
+
+    cattrs.rgb_ae_attr &= ~HL_BG_INDEXED;
   }
   cattrs.rgb_bg_color = rgb_blend(ratio, battrs.rgb_bg_color,
                                   fattrs.rgb_bg_color);

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -19,6 +19,8 @@ typedef enum {
   HL_STANDOUT        = 0x20,
   HL_STRIKETHROUGH   = 0x40,
   HL_NOCOMBINE       = 0x80,
+  HL_BG_INDEXED    = 0x0100,
+  HL_FG_INDEXED    = 0x0200,
 } HlAttrFlags;
 
 /// Stores a complete highlighting entry, including colors and attributes

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -138,6 +138,8 @@ struct terminal {
   int pressed_button;               // which mouse button is pressed
   bool pending_resize;              // pending width/height
 
+  bool color_set[16];
+
   size_t refcount;                  // reference count
 };
 
@@ -241,6 +243,7 @@ Terminal *terminal_open(TerminalOptions opts)
                         (uint8_t)((color_val >> 8) & 0xFF),
                         (uint8_t)((color_val >> 0) & 0xFF));
         vterm_state_set_palette_color(state, i, &color);
+        rv->color_set[i] = true;
       }
     }
   }
@@ -604,13 +607,16 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
     int vt_fg_idx = ((!fg_default && fg_indexed) ? cell.fg.indexed.idx + 1 : 0);
     int vt_bg_idx = ((!bg_default && bg_indexed) ? cell.bg.indexed.idx + 1 : 0);
 
+    bool fg_set = vt_fg_idx && vt_fg_idx <= 16 && term->color_set[vt_fg_idx-1];
+    bool bg_set = vt_bg_idx && vt_bg_idx <= 16 && term->color_set[vt_bg_idx-1];
+
     int hl_attrs = (cell.attrs.bold ? HL_BOLD : 0)
                  | (cell.attrs.italic ? HL_ITALIC : 0)
                  | (cell.attrs.reverse ? HL_INVERSE : 0)
                  | (cell.attrs.underline ? HL_UNDERLINE : 0)
-                 | (cell.attrs.strike ? HL_STRIKETHROUGH: 0);
-                 | (fg_indexed ? HL_FG_INDEXED : 0)
-                 | (bg_indexed ? HL_BG_INDEXED : 0);
+                 | (cell.attrs.strike ? HL_STRIKETHROUGH: 0)
+                 | ((fg_indexed && !fg_set) ? HL_FG_INDEXED : 0)
+                 | ((bg_indexed && !bg_set) ? HL_BG_INDEXED : 0);
 
     int attr_id = 0;
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -598,16 +598,19 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr,
     int vt_fg = fg_default ? -1 : get_rgb(state, cell.fg);
     int vt_bg = bg_default ? -1 : get_rgb(state, cell.bg);
 
-    int vt_fg_idx = ((!fg_default && VTERM_COLOR_IS_INDEXED(&cell.fg))
-                     ? cell.fg.indexed.idx + 1 : 0);
-    int vt_bg_idx = ((!bg_default && VTERM_COLOR_IS_INDEXED(&cell.bg))
-                     ? cell.bg.indexed.idx + 1 : 0);
+    bool fg_indexed = VTERM_COLOR_IS_INDEXED(&cell.fg);
+    bool bg_indexed = VTERM_COLOR_IS_INDEXED(&cell.bg);
+
+    int vt_fg_idx = ((!fg_default && fg_indexed) ? cell.fg.indexed.idx + 1 : 0);
+    int vt_bg_idx = ((!bg_default && bg_indexed) ? cell.bg.indexed.idx + 1 : 0);
 
     int hl_attrs = (cell.attrs.bold ? HL_BOLD : 0)
                  | (cell.attrs.italic ? HL_ITALIC : 0)
                  | (cell.attrs.reverse ? HL_INVERSE : 0)
                  | (cell.attrs.underline ? HL_UNDERLINE : 0)
                  | (cell.attrs.strike ? HL_STRIKETHROUGH: 0);
+                 | (fg_indexed ? HL_FG_INDEXED : 0)
+                 | (bg_indexed ? HL_BG_INDEXED : 0);
 
     int attr_id = 0;
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -515,20 +515,8 @@ static void update_attrs(UI *ui, int attr_id)
   }
   data->print_attr_id = attr_id;
   HlAttrs attrs = kv_A(data->attrs, (size_t)attr_id);
-
-  int fg = ui->rgb ? attrs.rgb_fg_color : (attrs.cterm_fg_color - 1);
-  if (fg == -1) {
-    fg = ui->rgb ? data->clear_attrs.rgb_fg_color
-                 : (data->clear_attrs.cterm_fg_color - 1);
-  }
-
-  int bg = ui->rgb ? attrs.rgb_bg_color : (attrs.cterm_bg_color - 1);
-  if (bg == -1) {
-    bg = ui->rgb ? data->clear_attrs.rgb_bg_color
-                 : (data->clear_attrs.cterm_bg_color - 1);
-  }
-
   int attr = ui->rgb ? attrs.rgb_ae_attr : attrs.cterm_ae_attr;
+
   bool bold = attr & HL_BOLD;
   bool italic = attr & HL_ITALIC;
   bool reverse = attr & HL_INVERSE;
@@ -596,7 +584,10 @@ static void update_attrs(UI *ui, int attr_id)
         unibi_out_ext(ui, data->unibi_ext.set_underline_color);
     }
   }
+
+  int fg, bg;
   if (ui->rgb) {
+    fg = (attrs.rgb_fg_color != -1) ? attrs.rgb_fg_color : data->clear_attrs.rgb_fg_color;
     if (fg != -1) {
       UNIBI_SET_NUM_VAR(data->params[0], (fg >> 16) & 0xff);  // red
       UNIBI_SET_NUM_VAR(data->params[1], (fg >> 8) & 0xff);   // green
@@ -604,6 +595,7 @@ static void update_attrs(UI *ui, int attr_id)
       unibi_out_ext(ui, data->unibi_ext.set_rgb_foreground);
     }
 
+    bg = (attrs.rgb_bg_color != -1) ? attrs.rgb_bg_color : data->clear_attrs.rgb_bg_color;
     if (bg != -1) {
       UNIBI_SET_NUM_VAR(data->params[0], (bg >> 16) & 0xff);  // red
       UNIBI_SET_NUM_VAR(data->params[1], (bg >> 8) & 0xff);   // green
@@ -611,11 +603,13 @@ static void update_attrs(UI *ui, int attr_id)
       unibi_out_ext(ui, data->unibi_ext.set_rgb_background);
     }
   } else {
+    fg = attrs.cterm_fg_color ? attrs.cterm_fg_color - 1 : (data->clear_attrs.cterm_fg_color - 1);
     if (fg != -1) {
       UNIBI_SET_NUM_VAR(data->params[0], fg);
       unibi_out(ui, unibi_set_a_foreground);
     }
 
+    bg = attrs.cterm_bg_color ? attrs.cterm_bg_color - 1 : (data->clear_attrs.cterm_bg_color - 1);
     if (bg != -1) {
       UNIBI_SET_NUM_VAR(data->params[0], bg);
       unibi_out(ui, unibi_set_a_background);

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -67,7 +67,7 @@ describe('Command-line option', function()
                                                 |
                                                 |
       ]], {
-        [1] = {foreground = 4210943},
+        [1] = {foreground = tonumber('0x4040ff'), fg_indexed=true},
         [2] = {bold = true, reverse = true}
       })
       feed('i:cq<CR>')

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -121,13 +121,12 @@ it(':terminal highlight has lower precedence than editor #9964', function()
   local screen = Screen.new(30, 4)
   screen:set_default_attr_ids({
     -- "Normal" highlight emitted by the child nvim process.
-    N_child = {foreground = tonumber('0x4040ff'), background = tonumber('0xffff40')},
-    -- "Search" highlight emitted by the child nvim process.
-    S_child = {background = tonumber('0xffff40'), italic = true, foreground = tonumber('0x4040ff')},
+    N_child = {foreground = tonumber('0x4040ff'), background = tonumber('0xffff40'), fg_indexed=true, bg_indexed=true},
     -- "Search" highlight in the parent nvim process.
     S = {background = Screen.colors.Green, italic = true, foreground = Screen.colors.Red},
     -- "Question" highlight in the parent nvim process.
-    Q = {background = tonumber('0xffff40'), bold = true, foreground = Screen.colors.SeaGreen4},
+    -- note: bg is indexed as it comes from the (cterm) child, while fg isn't as it comes from (rgb) parent
+    Q = {background = tonumber('0xffff40'), bold = true, foreground = Screen.colors.SeaGreen4, bg_indexed=true},
   })
   screen:attach({rgb=true})
   -- Child nvim process in :terminal (with cterm colors).
@@ -160,6 +159,54 @@ it(':terminal highlight has lower precedence than editor #9964', function()
   ]])
 end)
 
+describe(':terminal highlight forwarding', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(50, 7)
+    screen:set_rgb_cterm(true)
+    screen:set_default_attr_ids({
+      [1] = {{reverse = true}, {reverse = true}},
+      [2] = {{bold = true}, {bold = true}},
+      [3] = {{fg_indexed = true, foreground = tonumber('0xe0e000')}, {foreground = 3}},
+      [4] = {{foreground = tonumber('0xff8000')}, {}},
+    })
+    screen:attach()
+    command('enew | call termopen(["'..nvim_dir..'/tty-test"])')
+    feed('i')
+    screen:expect([[
+      tty ready                                         |
+      {1: }                                                 |
+                                                        |
+                                                        |
+                                                        |
+                                                        |
+      {2:-- TERMINAL --}                                    |
+    ]])
+  end)
+
+  it('will handle cterm and rgb attributes', function()
+    if helpers.pending_win32(pending) then return end
+    thelpers.set_fg(3)
+    thelpers.feed_data('text')
+    thelpers.feed_termcode('[38:2:255:128:0m')
+    thelpers.feed_data('color')
+    thelpers.clear_attrs()
+    thelpers.feed_data('text')
+    screen:expect{grid=[[
+      tty ready                                         |
+      {3:text}{4:color}text{1: }                                    |
+                                                        |
+                                                        |
+                                                        |
+                                                        |
+      {2:-- TERMINAL --}                                    |
+    ]]}
+  end)
+end)
+
+
 describe(':terminal highlight with custom palette', function()
   local screen
 
@@ -167,7 +214,7 @@ describe(':terminal highlight with custom palette', function()
     clear()
     screen = Screen.new(50, 7)
     screen:set_default_attr_ids({
-      [1] = {foreground = tonumber('0x123456')},
+      [1] = {foreground = tonumber('0x123456')}, -- no fg_indexed when overriden
       [2] = {foreground = 12},
       [3] = {bold = true, reverse = true},
       [5] = {background = 11},

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -181,11 +181,11 @@ describe('ext_hlstate detailed highlights', function()
   it("work with :terminal", function()
     screen:set_default_attr_ids({
       [1] = {{}, {{hi_name = "TermCursorNC", ui_name = "TermCursorNC", kind = "ui"}}},
-      [2] = {{foreground = 52479}, {{kind = "term"}}},
-      [3] = {{bold = true, foreground = 52479}, {{kind = "term"}}},
-      [4] = {{foreground = 52479}, {2, 1}},
-      [5] = {{foreground = 4259839}, {{kind = "term"}}},
-      [6] = {{foreground = 4259839}, {5, 1}},
+      [2] = {{foreground = tonumber('0x00ccff'), fg_indexed=true}, {{kind = "term"}}},
+      [3] = {{bold = true, foreground = tonumber('0x00ccff'), fg_indexed=true}, {{kind = "term"}}},
+      [4] = {{foreground = tonumber('0x00ccff'), fg_indexed=true}, {2, 1}},
+      [5] = {{foreground = tonumber('0x40ffff'), fg_indexed=true}, {{kind = "term"}}},
+      [6] = {{foreground = tonumber('0x40ffff'), fg_indexed=true}, {5, 1}},
       [7] = {{}, {{hi_name = "MsgArea", ui_name = "MsgArea", kind = "ui"}}},
     })
     command('enew | call termopen(["'..nvim_dir..'/tty-test"])')

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1362,6 +1362,7 @@ function Screen:linegrid_check_attrs(attrs)
       if self._rgb_cterm then
         attr_rgb, attr_cterm, info = unpack(v)
         attr = {attr_rgb, attr_cterm}
+        info = info or {}
       elseif self._options.ext_hlstate then
         attr, info = unpack(v)
       else
@@ -1400,11 +1401,12 @@ end
 function Screen:_pprint_hlitem(item)
     -- print(inspect(item))
     local multi = self._rgb_cterm or self._options.ext_hlstate
-    local attrdict = "{"..self:_pprint_attrs(multi and item[1] or item).."}"
+    local cterm = (not self._rgb_cterm and not self._options.rgb)
+    local attrdict = "{"..self:_pprint_attrs(multi and item[1] or item, cterm).."}"
     local attrdict2, hlinfo
     local descdict = ""
     if self._rgb_cterm then
-      attrdict2 = ", {"..self:_pprint_attrs(item[2]).."}"
+      attrdict2 = ", {"..self:_pprint_attrs(item[2], true).."}"
       hlinfo = item[3]
     else
       attrdict2 = ""
@@ -1433,13 +1435,15 @@ function Screen:_pprint_hlinfo(states)
 end
 
 
-function Screen:_pprint_attrs(attrs)
+function Screen:_pprint_attrs(attrs, cterm)
     local items = {}
     for f, v in pairs(attrs) do
       local desc = tostring(v)
       if f == "foreground" or f == "background" or f == "special" then
         if Screen.colornames[v] ~= nil then
           desc = "Screen.colors."..Screen.colornames[v]
+        elseif cterm then
+          desc = tostring(v)
         else
           desc = string.format("tonumber('0x%06x')",v)
         end

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1515,7 +1515,8 @@ function Screen:_equal_attrs(a, b)
        a.italic == b.italic and a.reverse == b.reverse and
        a.foreground == b.foreground and a.background == b.background and
        a.special == b.special and a.blend == b.blend and
-       a.strikethrough == b.strikethrough
+       a.strikethrough == b.strikethrough and
+       a.fg_indexed == b.fg_indexed and a.bg_indexed == b.bg_indexed
 end
 
 function Screen:_equal_info(a, b)


### PR DESCRIPTION
Possible followup of #9494 

When running inside an RGB terminal, we could still allow palette colors inside a `:terminal` instance to be rendered by the enclosing terminal, to match the users chosen scheme for palette colors (mostly relevant for <16 colors probably). This PR currently hardcodes the behavior for a simple demo, but it could also be an UI option/flag.

Note: the `ext_hlstate` protocol extension already contains the necessary information, adding two auxiliary attributes just makes for a simple TUI implementation without needing to parse the full hlstate stack of attribute groups.

Probably been discussed in various github and gitter threads, too lazy to find and link them all now...