### PR TITLE
build: dependencies: specify minimum libvterm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,7 @@ if(FEAT_TUI)
   include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
 endif()
 
-find_package(LIBVTERM REQUIRED)
+find_package(LIBVTERM 0.1 REQUIRED)
 include_directories(SYSTEM ${LIBVTERM_INCLUDE_DIRS})
 
 if(WIN32)


### PR DESCRIPTION
libvterm now advertises a version number, so we can specify the minimum required version.  And this is necessary because there were breaking changes in its API.

**Note:** local builds might need after this change:

    make distclean

