### PR TITLE
Require at least version 0.1 of libvterm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,7 @@ if(FEAT_TUI)
   include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
 endif()
 
-find_package(LIBVTERM REQUIRED)
+find_package(LIBVTERM 0.1 REQUIRED)
 include_directories(SYSTEM ${LIBVTERM_INCLUDE_DIRS})
 
 if(WIN32)


### PR DESCRIPTION
Since 7bb858c39cac9b9af321fc90470c91d2e31ed96e, libvterm >= 0.1 is required.  Although the API/ABI isn't fully stabilized yet, we're not going to use an exact version match, since that's likely to be too restrictive.