### PR TITLE
tests: Screen:expect: support "{MATCH:…}"

### DIFF
--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -449,7 +449,7 @@ describe("'scrollback' option", function()
         38: line                      |
         39: line                      |
         40: line                      |
-        {IGNORE}|
+        {MATCH:.*}|
         {3:-- TERMINAL --}                |
       ]]}
     end

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -578,7 +578,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|
       {5:                                                  }|
-      {8:paste: Error executing lua: vim.lua:214: Vim:E21: }|
+      {MATCH:paste: Error executing lua: vim.lua:%d+: Vim:E21: }|
       {8:Cannot make changes, 'modifiable' is off}          |
       {10:Press ENTER or type command to continue}{1: }          |
       {3:-- TERMINAL --}                                    |

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -122,7 +122,7 @@ describe('ui/ext_messages', function()
     feed('G$x')
     screen:expect{grid=[[
         line 1                   |
-        {IGNORE}|
+        {MATCH:.*}|
         {1:~                        }|
         {1:~                        }|
         {1:~                        }|
@@ -966,7 +966,7 @@ describe('ui/ext_messages', function()
       {1:~                                                                               }|
       {1:~                                                                               }|
       {1:~                                                                               }|
-      {IGNORE}|
+      {MATCH:.*}|
       {1:~                                                                               }|
       {1:~                 }Nvim is open source and freely distributable{1:                  }|
       {1:~                           }https://neovim.io/#chat{1:                             }|
@@ -976,8 +976,8 @@ describe('ui/ext_messages', function()
       {1:~                }type  :q{5:<Enter>}               to exit         {1:                 }|
       {1:~                }type  :help{5:<Enter>}            for help        {1:                 }|
       {1:~                                                                               }|
-      {IGNORE}|
-      {IGNORE}|
+      {MATCH:.*}|
+      {MATCH:.*}|
       {1:~                                                                               }|
       {1:~                                                                               }|
       {1:~                                                                               }|
@@ -1022,7 +1022,7 @@ describe('ui/ext_messages', function()
                                                                                       |
                                                                                       |
                                                                                       |
-      {IGNORE}|
+      {MATCH:.*}|
                                                                                       |
                         Nvim is open source and freely distributable                  |
                                   https://neovim.io/#chat                             |
@@ -1032,8 +1032,8 @@ describe('ui/ext_messages', function()
                        type  :q{5:<Enter>}               to exit                          |
                        type  :help{5:<Enter>}            for help                         |
                                                                                       |
-      {IGNORE}|
-      {IGNORE}|
+      {MATCH:.*}|
+      {MATCH:.*}|
                                                                                       |
                                                                                       |
                                                                                       |

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -269,7 +269,7 @@ local ext_keys = {
 -- grid:        Expected screen state (string). Each line represents a screen
 --              row. Last character of each row (typically "|") is stripped.
 --              Common indentation is stripped.
---              Lines containing only "{IGNORE}|" are skipped.
+--              "{MATCH:x}|" lines are matched against Lua pattern `x`.
 -- attr_ids:    Expected text attributes. Screen rows are transformed according
 --              to this table, as follows: each substring S composed of
 --              characters having the same attributes will be substituted by
@@ -390,18 +390,16 @@ function Screen:expect(expected, attr_ids, ...)
         err_msg = "Expected screen height " .. #expected_rows
         .. ' differs from actual height ' .. #actual_rows .. '.'
       end
-      for i = 1, #expected_rows do
-        msg_expected_rows[i] = expected_rows[i]
-        if expected_rows[i] ~= actual_rows[i] and expected_rows[i] ~= "{IGNORE}|" then
-          local m = expected_rows[i]:match('{MATCH:(.*)}')
-          if not m or not actual_rows[i]:match(m) then
-            msg_expected_rows[i] = '*' .. msg_expected_rows[i]
-            if i <= #actual_rows then
-              actual_rows[i] = '*' .. actual_rows[i]
-            end
-            if err_msg == nil then
-              err_msg = 'Row ' .. tostring(i) .. ' did not match.'
-            end
+      for i, row in ipairs(expected_rows) do
+        msg_expected_rows[i] = row
+        local m = (row ~= actual_rows[i] and row:match('{MATCH:(.*)}') or nil)
+        if row ~= actual_rows[i] and (not m or not actual_rows[i]:match(m)) then
+          msg_expected_rows[i] = '*' .. msg_expected_rows[i]
+          if i <= #actual_rows then
+            actual_rows[i] = '*' .. actual_rows[i]
+          end
+          if err_msg == nil then
+            err_msg = 'Row ' .. tostring(i) .. ' did not match.'
           end
         end
       end

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -391,14 +391,17 @@ function Screen:expect(expected, attr_ids, ...)
         .. ' differs from actual height ' .. #actual_rows .. '.'
       end
       for i = 1, #expected_rows do
-         msg_expected_rows[i] = expected_rows[i]
+        msg_expected_rows[i] = expected_rows[i]
         if expected_rows[i] ~= actual_rows[i] and expected_rows[i] ~= "{IGNORE}|" then
-          msg_expected_rows[i] = '*' .. msg_expected_rows[i]
-          if i <= #actual_rows then
-            actual_rows[i] = '*' .. actual_rows[i]
-          end
-          if err_msg == nil then
-            err_msg = 'Row ' .. tostring(i) .. ' did not match.'
+          local m = expected_rows[i]:match('{MATCH:(.*)}')
+          if not m or not actual_rows[i]:match(m) then
+            msg_expected_rows[i] = '*' .. msg_expected_rows[i]
+            if i <= #actual_rows then
+              actual_rows[i] = '*' .. actual_rows[i]
+            end
+            if err_msg == nil then
+              err_msg = 'Row ' .. tostring(i) .. ' did not match.'
+            end
           end
         end
       end


### PR DESCRIPTION
Initially done for https://github.com/neovim/neovim/pull/10978 (to match varying number of cols/rows) - but likely not useful there anymore.

Since I've missed this before it might be good to have it.
Though I cannot remember a use case where this could be used directly already.  Hints?