### PR TITLE
getdigits: introduce `strict`, `def` parameters

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5078,7 +5078,7 @@ chk_modeline(
         } else {
           e = s + 3;
         }
-        if (getdigits_safe(&e, &vers) != OK) {
+        if (!try_getdigits(&e, &vers)) {
           continue;
         }
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1017,7 +1017,7 @@ do_bufdel(
           }
           arg = p;
         } else
-          bnr = getdigits_int(&arg);
+          bnr = getdigits_int(&arg, false, 0);
       }
     }
     if (!got_int && do_current
@@ -3626,10 +3626,7 @@ int build_stl_str_hl(
 
     // The first digit group is the item's min width
     if (ascii_isdigit(*fmt_p)) {
-      minwid = getdigits_int(&fmt_p);
-      if (minwid < 0) {         // overflow
-        minwid = 0;
-      }
+      minwid = getdigits_int(&fmt_p, false, 0);
     }
 
     // User highlight groups override the min width field
@@ -3712,10 +3709,7 @@ int build_stl_str_hl(
     if (*fmt_p == '.') {
       fmt_p++;
       if (ascii_isdigit(*fmt_p)) {
-        maxwid = getdigits_int(&fmt_p);
-        if (maxwid <= 0) {              // overflow
-          maxwid = 50;
-        }
+        maxwid = getdigits_int(&fmt_p, false, 50);
       }
     }
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1016,8 +1016,9 @@ do_bufdel(
             break;
           }
           arg = p;
-        } else
+        } else {
           bnr = getdigits_int(&arg, false, 0);
+        }
       }
     }
     if (!got_int && do_current

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1323,7 +1323,7 @@ int open_line(
           if (*p == COM_RIGHT || *p == COM_LEFT) {
               c = *p++;
           } else if (ascii_isdigit(*p) || *p == '-') {
-              off = getdigits_int(&p);
+              off = getdigits_int(&p, true, 0);
           } else {
               p++;
           }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1601,18 +1601,18 @@ char_u* skiptowhite_esc(char_u *p) {
 ///                  It will be advanced past the read number.
 /// @param[out]  nr  Number read from the string.
 ///
-/// @return OK on success, FAIL on error/overflow
-int getdigits_safe(char_u **pp, intmax_t *nr)
+/// @return true on success, false on error/overflow
+bool try_getdigits(char_u **pp, intmax_t *nr)
 {
   errno = 0;
   *nr = strtoimax((char *)(*pp), (char **)pp, 10);
 
   if ((*nr == INTMAX_MIN || *nr == INTMAX_MAX)
       && errno == ERANGE) {
-    return FAIL;
+    return false;
   }
 
-  return OK;
+  return true;
 }
 
 /// Get a number from a string and skip over it.
@@ -1624,10 +1624,10 @@ int getdigits_safe(char_u **pp, intmax_t *nr)
 intmax_t getdigits(char_u **pp)
 {
   intmax_t number;
-  int ret = getdigits_safe(pp, &number);
+  int ok = try_getdigits(pp, &number);
 
-  (void)ret;  // Avoid "unused variable" warning in Release build
-  assert(ret == OK);
+  (void)ok;  // Avoid "unused variable" warning in Release build
+  assert(ok);
 
   return number;
 }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -166,7 +166,7 @@ int buf_init_chartab(buf_T *buf, int global)
       }
 
       if (ascii_isdigit(*p)) {
-        c = getdigits_int((char_u **)&p);
+        c = getdigits_int((char_u **)&p, true, 0);
       } else {
         c = mb_ptr2char_adv(&p);
       }
@@ -176,7 +176,7 @@ int buf_init_chartab(buf_T *buf, int global)
         ++p;
 
         if (ascii_isdigit(*p)) {
-          c2 = getdigits_int((char_u **)&p);
+          c2 = getdigits_int((char_u **)&p, true, 0);
         } else {
           c2 = mb_ptr2char_adv(&p);
         }
@@ -1595,7 +1595,7 @@ char_u* skiptowhite_esc(char_u *p) {
   return p;
 }
 
-/// Get a number from a string and skip over it, signalling overflows
+/// Gets a number from a string and skips over it, signalling overflow.
 ///
 /// @param[out]  pp  A pointer to a pointer to char_u.
 ///                  It will be advanced past the read number.
@@ -1606,48 +1606,58 @@ bool try_getdigits(char_u **pp, intmax_t *nr)
 {
   errno = 0;
   *nr = strtoimax((char *)(*pp), (char **)pp, 10);
-
-  if ((*nr == INTMAX_MIN || *nr == INTMAX_MAX)
-      && errno == ERANGE) {
+  if (errno == ERANGE && (*nr == INTMAX_MIN || *nr == INTMAX_MAX)) {
     return false;
   }
-
   return true;
 }
 
-/// Get a number from a string and skip over it.
+/// Gets a number from a string and skips over it.
 ///
-/// @param[out]  pp  A pointer to a pointer to char_u.
+/// @param[out]  pp  Pointer to a pointer to char_u.
 ///                  It will be advanced past the read number.
+/// @param strict    Abort on overflow.
+/// @param def       Default value, if parsing fails or overflow occurs.
 ///
-/// @return Number read from the string.
-intmax_t getdigits(char_u **pp)
+/// @return Number read from the string, or `def` on parse failure or overflow.
+intmax_t getdigits(char_u **pp, bool strict, intmax_t def)
 {
   intmax_t number;
   int ok = try_getdigits(pp, &number);
-
-  (void)ok;  // Avoid "unused variable" warning in Release build
-  assert(ok);
-
-  return number;
+  if (strict && !ok) {
+    abort();
+  }
+  return ok ? number : def;
 }
 
-/// Get an int number from a string. Like getdigits(), but restricted to `int`.
-int getdigits_int(char_u **pp)
+/// Gets an int number from a string.
+///
+/// @see getdigits
+int getdigits_int(char_u **pp, bool strict, int def)
 {
-  intmax_t number = getdigits(pp);
+  intmax_t number = getdigits(pp, strict, def);
 #if SIZEOF_INTMAX_T > SIZEOF_INT
-  assert(number >= INT_MIN && number <= INT_MAX);
+  if (strict) {
+    assert(number >= INT_MIN && number <= INT_MAX);
+  } else if (!(number >= INT_MIN && number <= INT_MAX)) {
+    return def;
+  }
 #endif
   return (int)number;
 }
 
-/// Get a long number from a string. Like getdigits(), but restricted to `long`.
-long getdigits_long(char_u **pp)
+/// Gets a long number from a string.
+///
+/// @see getdigits
+long getdigits_long(char_u **pp, bool strict, long def)
 {
-  intmax_t number = getdigits(pp);
+  intmax_t number = getdigits(pp, strict, def);
 #if SIZEOF_INTMAX_T > SIZEOF_LONG
-  assert(number >= LONG_MIN && number <= LONG_MAX);
+  if (strict) {
+    assert(number >= LONG_MIN && number <= LONG_MAX);
+  } else if (!(number >= LONG_MIN && number <= LONG_MAX)) {
+    return def;
+  }
 #endif
   return (long)number;
 }

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -176,15 +176,17 @@ char_u *parse_shape_opt(int what)
               p += len;
               if (!ascii_isdigit(*p))
                 return (char_u *)N_("E548: digit expected");
-              int n = getdigits_int(&p);
+              int n = getdigits_int(&p, false, 0);
               if (len == 3) {               /* "ver" or "hor" */
-                if (n == 0)
+                if (n == 0) {
                   return (char_u *)N_("E549: Illegal percentage");
+                }
                 if (round == 2) {
-                  if (TOLOWER_ASC(i) == 'v')
+                  if (TOLOWER_ASC(i) == 'v') {
                     shape_table[idx].shape = SHAPE_VER;
-                  else
+                  } else {
                     shape_table[idx].shape = SHAPE_HOR;
+                  }
                   shape_table[idx].percentage = n;
                 }
               } else if (round == 2) {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -177,7 +177,7 @@ char_u *parse_shape_opt(int what)
               if (!ascii_isdigit(*p))
                 return (char_u *)N_("E548: digit expected");
               int n = getdigits_int(&p, false, 0);
-              if (len == 3) {               /* "ver" or "hor" */
+              if (len == 3) {               // "ver" or "hor"
                 if (n == 0) {
                   return (char_u *)N_("E549: Illegal percentage");
                 }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2113,7 +2113,7 @@ int diffopt_changed(void)
       diff_flags_new |= DIFF_FILLER;
     } else if ((STRNCMP(p, "context:", 8) == 0) && ascii_isdigit(p[8])) {
       p += 8;
-      diff_context_new = getdigits_int(&p);
+      diff_context_new = getdigits_int(&p, false, diff_context_new);
     } else if (STRNCMP(p, "iblank", 6) == 0) {
       p += 6;
       diff_flags_new |= DIFF_IBLANK;
@@ -2137,7 +2137,7 @@ int diffopt_changed(void)
       diff_flags_new |= DIFF_VERTICAL;
     } else if ((STRNCMP(p, "foldcolumn:", 11) == 0) && ascii_isdigit(p[11])) {
       p += 11;
-      diff_foldcolumn_new = getdigits_int(&p);
+      diff_foldcolumn_new = getdigits_int(&p, false, diff_foldcolumn_new);
     } else if (STRNCMP(p, "hiddenoff", 9) == 0) {
       p += 9;
       diff_flags_new |= DIFF_HIDDEN_OFF;
@@ -3000,10 +3000,10 @@ static int parse_diff_ed(char_u     *line,
   // append: {first}a{first}[,{last}]
   // delete: {first}[,{last}]d{first}
   p = line;
-  f1 = getdigits(&p);
+  f1 = getdigits(&p, true, 0);
   if (*p == ',') {
     p++;
-    l1 = getdigits(&p);
+    l1 = getdigits(&p, true, 0);
   } else {
     l1 = f1;
   }
@@ -3011,10 +3011,10 @@ static int parse_diff_ed(char_u     *line,
     return FAIL;        // invalid diff format
   }
   difftype = *p++;
-  f2 = getdigits(&p);
+  f2 = getdigits(&p, true, 0);
   if (*p == ',') {
     p++;
-    l2 = getdigits(&p);
+    l2 = getdigits(&p, true, 0);
   } else {
     l2 = f2;
   }
@@ -3056,18 +3056,18 @@ static int parse_diff_unified(char_u        *line,
   // @@ -oldline,oldcount +newline,newcount @@
   p = line;
   if (*p++ == '@' && *p++ == '@' && *p++ == ' ' && *p++ == '-') {
-    oldline = getdigits(&p);
+    oldline = getdigits(&p, true, 0);
     if (*p == ',') {
       p++;
-      oldcount = getdigits(&p);
+      oldcount = getdigits(&p, true, 0);
     } else {
       oldcount = 1;
     }
     if (*p++ == ' ' && *p++ == '+') {
-      newline = getdigits(&p);
+      newline = getdigits(&p, true, 0);
       if (*p == ',') {
         p++;
-        newcount = getdigits(&p);
+        newcount = getdigits(&p, true, 0);
       } else {
         newcount = 1;
       }

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1618,7 +1618,7 @@ void putdigraph(char_u *str)
       EMSG(_(e_number_exp));
       return;
     }
-    int n = getdigits_int(&str);
+    int n = getdigits_int(&str, true, 0);
 
     // If the digraph already exists, replace the result.
     dp = (digr_T *)user_digraphs.ga_data;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2936,9 +2936,9 @@ void ex_lockvar(exarg_T *eap)
   char_u      *arg = eap->arg;
   int deep = 2;
 
-  if (eap->forceit)
+  if (eap->forceit) {
     deep = -1;
-  else if (ascii_isdigit(*arg)) {
+  } else if (ascii_isdigit(*arg)) {
     deep = getdigits_int(&arg, false, -1);
     arg = skipwhite(arg);
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2939,7 +2939,7 @@ void ex_lockvar(exarg_T *eap)
   if (eap->forceit)
     deep = -1;
   else if (ascii_isdigit(*arg)) {
-    deep = getdigits_int(&arg);
+    deep = getdigits_int(&arg, false, -1);
     arg = skipwhite(arg);
   }
 
@@ -15775,7 +15775,7 @@ static void f_setreg(typval_T *argvars, typval_T *rettv, FunPtr fptr)
           yank_type = kMTBlockWise;
           if (ascii_isdigit(stropt[1])) {
             stropt++;
-            block_len = getdigits_long((char_u **)&stropt) - 1;
+            block_len = getdigits_long((char_u **)&stropt, true, 0) - 1;
             stropt--;
           }
           break;

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -40,8 +40,8 @@ int socket_watcher_init(Loop *loop, SocketWatcher *watcher,
     char *port = host_end + 1;
     intmax_t iport;
 
-    int ret = getdigits_safe(&(char_u *){ (char_u *)port }, &iport);
-    if (ret == FAIL || iport < 0 || iport > UINT16_MAX) {
+    int ok = try_getdigits(&(char_u *){ (char_u *)port }, &iport);
+    if (!ok || iport < 0 || iport > UINT16_MAX) {
       ELOG("Invalid port: %s", port);
       return UV_EINVAL;
     }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -707,7 +707,7 @@ void ex_retab(exarg_T *eap)
   save_list = curwin->w_p_list;
   curwin->w_p_list = 0;             /* don't want list mode here */
 
-  new_ts = getdigits_int(&(eap->arg));
+  new_ts = getdigits_int(&(eap->arg), false, -1);
   if (new_ts < 0) {
     EMSG(_(e_positive));
     return;
@@ -3357,7 +3357,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
   // check for a trailing count
   cmd = skipwhite(cmd);
   if (ascii_isdigit(*cmd)) {
-    i = getdigits_long(&cmd);
+    i = getdigits_long(&cmd, true, 0);
     if (i <= 0 && !eap->skip && subflags.do_error) {
       EMSG(_(e_zerocount));
       return NULL;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -570,7 +570,7 @@ static int dbg_parsearg(char_u *arg, garray_T *gap)
   if (here) {
     bp->dbg_lnum = curwin->w_cursor.lnum;
   } else if (gap != &prof_ga && ascii_isdigit(*p)) {
-    bp->dbg_lnum = getdigits_long(&p);
+    bp->dbg_lnum = getdigits_long(&p, true, 0);
     p = skipwhite(p);
   } else {
     bp->dbg_lnum = 0;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2071,7 +2071,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
   if ((ea.argt & COUNT) && ascii_isdigit(*ea.arg)
       && (!(ea.argt & BUFNAME) || *(p = skipdigits(ea.arg)) == NUL
           || ascii_iswhite(*p))) {
-    n = getdigits_long(&ea.arg);
+    n = getdigits_long(&ea.arg, false, -1);
     ea.arg = skipwhite(ea.arg);
     if (n <= 0 && !ni && (ea.argt & ZEROR) == 0) {
       errormsg = (char_u *)_(e_zerocount);
@@ -3797,7 +3797,7 @@ static linenr_T get_address(exarg_T *eap,
 
     default:
       if (ascii_isdigit(*cmd))                    /* absolute line number */
-        lnum = getdigits_long(&cmd);
+        lnum = getdigits_long(&cmd, false, 0);
     }
 
     for (;; ) {
@@ -3832,14 +3832,16 @@ static linenr_T get_address(exarg_T *eap,
         }
       }
 
-      if (ascii_isdigit(*cmd))
-        i = '+';                        /* "number" is same as "+number" */
-      else
+      if (ascii_isdigit(*cmd)) {
+        i = '+';                        // "number" is same as "+number"
+      } else {
         i = *cmd++;
-      if (!ascii_isdigit(*cmd))           /* '+' is '+1', but '+0' is not '+1' */
+      }
+      if (!ascii_isdigit(*cmd)) {       // '+' is '+1', but '+0' is not '+1'
         n = 1;
-      else
-        n = getdigits(&cmd);
+      } else {
+        n = getdigits(&cmd, true, 0);
+      }
 
       if (addr_type == ADDR_TABS_RELATIVE) {
         EMSG(_(e_invrange));
@@ -4504,7 +4506,7 @@ static int get_tabpage_arg(exarg_T *eap)
     }
 
     p_save = p;
-    tab_number = getdigits(&p);
+    tab_number = getdigits(&p, false, tab_number);
 
     if (relative == 0) {
       if (STRCMP(p, "$") == 0) {
@@ -5179,7 +5181,7 @@ two_count:
           return FAIL;
         }
 
-        *def = getdigits_long(&p);
+        *def = getdigits_long(&p, true, 0);
         *argt |= (ZEROR | NOTADR);
 
         if (p != val + vallen || vallen == 0) {
@@ -5196,7 +5198,7 @@ invalid_count:
         if (*def >= 0)
           goto two_count;
 
-        *def = getdigits_long(&p);
+        *def = getdigits_long(&p, true, 0);
 
         if (p != val + vallen)
           goto invalid_count;
@@ -6832,8 +6834,7 @@ static void ex_tabnext(exarg_T *eap)
     if (eap->arg && *eap->arg != NUL) {
       char_u *p = eap->arg;
       char_u *p_save = p;
-
-      tab_number = getdigits(&p);
+      tab_number = getdigits(&p, false, 0);
       if (p == p_save || *p_save == '-' || *p_save == '+' || *p != NUL
           || tab_number == 0) {
         // No numbers as argument.
@@ -7472,18 +7473,16 @@ static void do_exmap(exarg_T *eap, int isabbrev)
  */
 static void ex_winsize(exarg_T *eap)
 {
-  int w, h;
-  char_u      *arg = eap->arg;
-  char_u      *p;
-
-  w = getdigits_int(&arg);
+  char_u *arg = eap->arg;
+  int w = getdigits_int(&arg, false, 10);
   arg = skipwhite(arg);
-  p = arg;
-  h = getdigits_int(&arg);
-  if (*p != NUL && *arg == NUL)
+  char_u *p = arg;
+  int h = getdigits_int(&arg, false, 10);
+  if (*p != NUL && *arg == NUL) {
     screen_resize(w, h);
-  else
+  } else {
     EMSG(_("E465: :winsize requires two number arguments"));
+  }
 }
 
 static void ex_wincmd(exarg_T *eap)
@@ -7745,7 +7744,7 @@ static void ex_later(exarg_T *eap)
   if (*p == NUL)
     count = 1;
   else if (isdigit(*p)) {
-    count = getdigits_long(&p);
+    count = getdigits_long(&p, false, 0);
     switch (*p) {
     case 's': ++p; sec = true; break;
     case 'm': ++p; sec = true; count *= 60; break;
@@ -8414,7 +8413,7 @@ static void ex_findpat(exarg_T *eap)
 
   n = 1;
   if (ascii_isdigit(*eap->arg)) { /* get count */
-    n = getdigits_long(&eap->arg);
+    n = getdigits_long(&eap->arg, false, 0);
     eap->arg = skipwhite(eap->arg);
   }
   if (*eap->arg == '/') {   /* Match regexp, not just whole words */
@@ -8660,13 +8659,13 @@ eval_vars (
       return NULL;
     }
   }
-  /*
-   * '#': Alternate file name
-   * '%': Current file name
-   *	    File name under the cursor
-   *	    File name for autocommand
-   *	and following modifiers
-   */
+  //
+  // '#': Alternate file name
+  // '%': Current file name
+  //        File name under the cursor
+  //        File name for autocommand
+  //    and following modifiers
+  //
   else {
     switch (spec_idx) {
     case SPEC_PERC:             /* '%': current file */
@@ -8692,7 +8691,7 @@ eval_vars (
       s = src + 1;
       if (*s == '<')                    /* "#<99" uses v:oldfiles */
         ++s;
-      i = getdigits_int(&s);
+      i = getdigits_int(&s, false, 0);
       if (s == src + 2 && src[1] == '-') {
         // just a minus sign, don't skip over it
         s--;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2064,10 +2064,10 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     }
   }
 
-  /*
-   * Check for a count.  When accepting a BUFNAME, don't use "123foo" as a
-   * count, it's a buffer name.
-   */
+  //
+  // Check for a count.  When accepting a BUFNAME, don't use "123foo" as a
+  // count, it's a buffer name.
+  ///
   if ((ea.argt & COUNT) && ascii_isdigit(*ea.arg)
       && (!(ea.argt & BUFNAME) || *(p = skipdigits(ea.arg)) == NUL
           || ascii_iswhite(*p))) {
@@ -3796,14 +3796,16 @@ static linenr_T get_address(exarg_T *eap,
       break;
 
     default:
-      if (ascii_isdigit(*cmd))                    /* absolute line number */
+      if (ascii_isdigit(*cmd)) {  // absolute line number
         lnum = getdigits_long(&cmd, false, 0);
+      }
     }
 
     for (;; ) {
       cmd = skipwhite(cmd);
-      if (*cmd != '-' && *cmd != '+' && !ascii_isdigit(*cmd))
+      if (*cmd != '-' && *cmd != '+' && !ascii_isdigit(*cmd)) {
         break;
+      }
 
       if (lnum == MAXLNUM) {
         switch (addr_type) {
@@ -7723,17 +7725,13 @@ static void ex_rundo(exarg_T *eap)
   u_read_undo((char *) eap->arg, hash, NULL);
 }
 
-/*
- * ":redo".
- */
+/// ":redo".
 static void ex_redo(exarg_T *eap)
 {
   u_redo(1);
 }
 
-/*
- * ":earlier" and ":later".
- */
+/// ":earlier" and ":later".
 static void ex_later(exarg_T *eap)
 {
   long count = 0;
@@ -7741,9 +7739,9 @@ static void ex_later(exarg_T *eap)
   bool file = false;
   char_u      *p = eap->arg;
 
-  if (*p == NUL)
+  if (*p == NUL) {
     count = 1;
-  else if (isdigit(*p)) {
+  } else if (isdigit(*p)) {
     count = getdigits_long(&p, false, 0);
     switch (*p) {
     case 's': ++p; sec = true; break;
@@ -7754,11 +7752,12 @@ static void ex_later(exarg_T *eap)
     }
   }
 
-  if (*p != NUL)
+  if (*p != NUL) {
     EMSG2(_(e_invarg2), eap->arg);
-  else
+  } else {
     undo_time(eap->cmdidx == CMD_earlier ? -count : count,
               sec, file, false);
+  }
 }
 
 /*
@@ -8412,23 +8411,24 @@ static void ex_findpat(exarg_T *eap)
   }
 
   n = 1;
-  if (ascii_isdigit(*eap->arg)) { /* get count */
+  if (ascii_isdigit(*eap->arg)) {  // get count
     n = getdigits_long(&eap->arg, false, 0);
     eap->arg = skipwhite(eap->arg);
   }
-  if (*eap->arg == '/') {   /* Match regexp, not just whole words */
-    whole = FALSE;
-    ++eap->arg;
+  if (*eap->arg == '/') {   // Match regexp, not just whole words
+    whole = false;
+    eap->arg++;
     p = skip_regexp(eap->arg, '/', p_magic, NULL);
     if (*p) {
       *p++ = NUL;
       p = skipwhite(p);
 
-      /* Check for trailing illegal characters */
-      if (!ends_excmd(*p))
+      // Check for trailing illegal characters.
+      if (!ends_excmd(*p)) {
         eap->errmsg = e_trailing;
-      else
+      } else {
         eap->nextcmd = check_nextcmd(p);
+      }
     }
   }
   if (!eap->skip)
@@ -8658,7 +8658,6 @@ eval_vars (
       *errormsg = (char_u *)"";
       return NULL;
     }
-  }
   //
   // '#': Alternate file name
   // '%': Current file name
@@ -8666,9 +8665,9 @@ eval_vars (
   //        File name for autocommand
   //    and following modifiers
   //
-  else {
+  } else {
     switch (spec_idx) {
-    case SPEC_PERC:             /* '%': current file */
+    case SPEC_PERC:             // '%': current file
       if (curbuf->b_fname == NULL) {
         result = (char_u *)"";
         valid = 0;                  // Must have ":p:h" to be valid
@@ -8689,8 +8688,9 @@ eval_vars (
         break;
       }
       s = src + 1;
-      if (*s == '<')                    /* "#<99" uses v:oldfiles */
-        ++s;
+      if (*s == '<') {                  // "#<99" uses v:oldfiles.
+        s++;
+      }
       i = getdigits_int(&s, false, 0);
       if (s == src + 2 && src[1] == '-') {
         // just a minus sign, don't skip over it

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -325,7 +325,7 @@ static char_u *parse_list_options(char_u *option_str, option_table_T *table,
         break;
       }
 
-      table[idx].number = getdigits_int(&p);
+      table[idx].number = getdigits_int(&p, false, 0);
     }
 
     table[idx].string = p;

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1675,25 +1675,27 @@ void parse_cino(buf_T *buf)
 
   for (p = buf->b_p_cino; *p; ) {
     l = p++;
-    if (*p == '-')
-      ++p;
-    char_u *digits_start = p;             /* remember where the digits start */
+    if (*p == '-') {
+      p++;
+    }
+    char_u *digits_start = p;   // remember where the digits start
     int n = getdigits_int(&p, true, 0);
     divider = 0;
-    if (*p == '.') {        /* ".5s" means a fraction */
+    if (*p == '.') {        // ".5s" means a fraction.
       fraction = atoi((char *)++p);
       while (ascii_isdigit(*p)) {
-        ++p;
-        if (divider)
+        p++;
+        if (divider) {
           divider *= 10;
-        else
+        } else {
           divider = 10;
+        }
       }
     }
-    if (*p == 's') {        /* "2s" means two times 'shiftwidth' */
-      if (p == digits_start)
-        n = sw;         /* just "s" is one 'shiftwidth' */
-      else {
+    if (*p == 's') {        // "2s" means two times 'shiftwidth'.
+      if (p == digits_start) {
+        n = sw;             // just "s" is one 'shiftwidth'.
+      } else {
         n *= sw;
         if (divider)
           n += (sw * fraction + divider / 2) / divider;
@@ -1910,15 +1912,15 @@ int get_c_indent(void)
       int what = 0;
 
       while (*p != NUL && *p != ':') {
-        if (*p == COM_START || *p == COM_END || *p == COM_MIDDLE)
+        if (*p == COM_START || *p == COM_END || *p == COM_MIDDLE) {
           what = *p++;
-        else if (*p == COM_LEFT || *p == COM_RIGHT)
+        } else if (*p == COM_LEFT || *p == COM_RIGHT) {
           align = *p++;
-        else if (ascii_isdigit(*p) || *p == '-') {
+        } else if (ascii_isdigit(*p) || *p == '-') {
           off = getdigits_int(&p, true, 0);
+        } else {
+          p++;
         }
-        else
-          ++p;
       }
 
       if (*p == ':')

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1678,7 +1678,7 @@ void parse_cino(buf_T *buf)
     if (*p == '-')
       ++p;
     char_u *digits_start = p;             /* remember where the digits start */
-    int n = getdigits_int(&p);
+    int n = getdigits_int(&p, true, 0);
     divider = 0;
     if (*p == '.') {        /* ".5s" means a fraction */
       fraction = atoi((char *)++p);
@@ -1915,7 +1915,7 @@ int get_c_indent(void)
         else if (*p == COM_LEFT || *p == COM_RIGHT)
           align = *p++;
         else if (ascii_isdigit(*p) || *p == '-') {
-          off = getdigits_int(&p);
+          off = getdigits_int(&p, true, 0);
         }
         else
           ++p;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -112,12 +112,14 @@ ex_menu(exarg_T *eap)
     }
   }
   if (ascii_iswhite(*p)) {
-    for (i = 0; i < MENUDEPTH && !ascii_iswhite(*arg); ++i) {
+    for (i = 0; i < MENUDEPTH && !ascii_iswhite(*arg); i++) {
       pri_tab[i] = getdigits_long(&arg, false, 0);
-      if (pri_tab[i] == 0)
+      if (pri_tab[i] == 0) {
         pri_tab[i] = 500;
-      if (*arg == '.')
-        ++arg;
+      }
+      if (*arg == '.') {
+        arg++;
+      }
     }
     arg = skipwhite(arg);
   } else if (eap->addr_count && eap->line2 != 0) {

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -113,7 +113,7 @@ ex_menu(exarg_T *eap)
   }
   if (ascii_iswhite(*p)) {
     for (i = 0; i < MENUDEPTH && !ascii_iswhite(*arg); ++i) {
-      pri_tab[i] = getdigits_long(&arg);
+      pri_tab[i] = getdigits_long(&arg, false, 0);
       if (pri_tab[i] == 0)
         pri_tab[i] = 500;
       if (*arg == '.')

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5714,7 +5714,7 @@ bool prepare_yankreg_from_object(yankreg_T *reg, String regtype, size_t lines)
       return false;
     }
     const char *p = regtype.data+1;
-    reg->y_width = getdigits_int((char_u **)&p)-1;
+    reg->y_width = getdigits_int((char_u **)&p, false, 1) - 1;
     if (regtype.size > (size_t)(p-regtype.data)) {
       return false;
     }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1585,7 +1585,7 @@ int do_set(
                */
               else if (varp == (char_u *)&p_bs
                        && ascii_isdigit(**(char_u **)varp)) {
-                i = getdigits_int((char_u **)varp);
+                i = getdigits_int((char_u **)varp, true, 0);
                 switch (i) {
                 case 0:
                   *(char_u **)varp = empty_option;
@@ -1613,7 +1613,7 @@ int do_set(
               else if (varp == (char_u *)&p_ww
                        && ascii_isdigit(*arg)) {
                 *errbuf = NUL;
-                i = getdigits_int(&arg);
+                i = getdigits_int(&arg, true, 0);
                 if (i & 1) {
                   STRCAT(errbuf, "b,");
                 }
@@ -3053,7 +3053,7 @@ ambw_end:
       if (*++s == '-') {        // ignore a '-'
         s++;
       }
-      wid = getdigits_int(&s);
+      wid = getdigits_int(&s, true, 0);
       if (wid && *s == '(' && (errmsg = check_stl_option(p_ruf)) == NULL) {
         ru_wid = wid;
       } else {
@@ -3440,7 +3440,7 @@ char_u *check_colorcolumn(win_T *wp)
       if (!ascii_isdigit(*s)) {
         return e_invarg;
       }
-      col = col * getdigits_int(&s);
+      col = col * getdigits_int(&s, true, 0);
       if (wp->w_buffer->b_p_tw == 0) {
         goto skip;          // 'textwidth' not set, skip this item
       }
@@ -3455,7 +3455,7 @@ char_u *check_colorcolumn(win_T *wp)
         goto skip;
       }
     } else if (ascii_isdigit(*s)) {
-      col = getdigits_int(&s);
+      col = getdigits_int(&s, true, 0);
     } else {
       return e_invarg;
     }
@@ -7109,12 +7109,12 @@ static bool briopt_check(win_T *wp)
         && ((p[6] == '-' && ascii_isdigit(p[7])) || ascii_isdigit(p[6])))
     {
       p += 6;
-      bri_shift = getdigits_int(&p);
+      bri_shift = getdigits_int(&p, true, 0);
     }
     else if (STRNCMP(p, "min:", 4) == 0 && ascii_isdigit(p[4]))
     {
       p += 4;
-      bri_min = getdigits_int(&p);
+      bri_min = getdigits_int(&p, true, 0);
     }
     else if (STRNCMP(p, "sbr", 3) == 0)
     {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3105,23 +3105,26 @@ static int read_limits(long *minval, long *maxval)
   long tmp;
 
   if (*regparse == '-') {
-    /* Starts with '-', so reverse the range later */
+    // Starts with '-', so reverse the range later.
     regparse++;
     reverse = TRUE;
   }
   first_char = regparse;
   *minval = getdigits_long(&regparse, false, 0);
-  if (*regparse == ',') {           /* There is a comma */
-    if (ascii_isdigit(*++regparse))
+  if (*regparse == ',') {           // There is a comma.
+    if (ascii_isdigit(*++regparse)) {
       *maxval = getdigits_long(&regparse, false, MAX_LIMIT);
-    else
+    } else {
       *maxval = MAX_LIMIT;
-  } else if (ascii_isdigit(*first_char))
-    *maxval = *minval;              /* It was \{n} or \{-n} */
-  else
-    *maxval = MAX_LIMIT;            /* It was \{} or \{-} */
-  if (*regparse == '\\')
-    regparse++;         /* Allow either \{...} or \{...\} */
+    }
+  } else if (ascii_isdigit(*first_char)) {
+    *maxval = *minval;              // It was \{n} or \{-n}
+  } else {
+    *maxval = MAX_LIMIT;            // It was \{} or \{-}
+  }
+  if (*regparse == '\\') {
+    regparse++;         // Allow either \{...} or \{...\}
+  }
   if (*regparse != '}') {
     sprintf((char *)IObuff, _("E554: Syntax error in %s{...}"),
         reg_magic == MAGIC_ALL ? "" : "\\");

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3110,10 +3110,10 @@ static int read_limits(long *minval, long *maxval)
     reverse = TRUE;
   }
   first_char = regparse;
-  *minval = getdigits_long(&regparse);
+  *minval = getdigits_long(&regparse, false, 0);
   if (*regparse == ',') {           /* There is a comma */
     if (ascii_isdigit(*++regparse))
-      *maxval = getdigits_long(&regparse);
+      *maxval = getdigits_long(&regparse, false, MAX_LIMIT);
     else
       *maxval = MAX_LIMIT;
   } else if (ascii_isdigit(*first_char))

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -1130,7 +1130,7 @@ static int parse_sign_cmd_args(
   // first arg could be placed sign id
   arg1 = arg;
   if (ascii_isdigit(*arg)) {
-    *signid = getdigits_int(&arg);
+    *signid = getdigits_int(&arg, true, 0);
     if (!ascii_iswhite(*arg) && *arg != NUL) {
       *signid = -1;
       arg = arg1;
@@ -1182,7 +1182,7 @@ static int parse_sign_cmd_args(
     } else if (STRNCMP(arg, "buffer=", 7) == 0) {
       arg += 7;
       filename = arg;
-      *buf = buflist_findnr(getdigits_int(&arg));
+      *buf = buflist_findnr(getdigits_int(&arg, true, 0));
       if (*skipwhite(arg) != NUL) {
         EMSG(_(e_trailing));
       }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2706,7 +2706,7 @@ int spell_check_sps(void)
     f = 0;
     if (ascii_isdigit(*buf)) {
       s = buf;
-      sps_limit = getdigits_int(&s);
+      sps_limit = getdigits_int(&s, true, 0);
       if (*s != NUL && !ascii_isdigit(*s))
         f = -1;
     } else if (STRCMP(buf, "best") == 0)

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2707,17 +2707,19 @@ int spell_check_sps(void)
     if (ascii_isdigit(*buf)) {
       s = buf;
       sps_limit = getdigits_int(&s, true, 0);
-      if (*s != NUL && !ascii_isdigit(*s))
+      if (*s != NUL && !ascii_isdigit(*s)) {
         f = -1;
-    } else if (STRCMP(buf, "best") == 0)
+      }
+    } else if (STRCMP(buf, "best") == 0) {
       f = SPS_BEST;
-    else if (STRCMP(buf, "fast") == 0)
+    } else if (STRCMP(buf, "fast") == 0) {
       f = SPS_FAST;
-    else if (STRCMP(buf, "double") == 0)
+    } else if (STRCMP(buf, "double") == 0) {
       f = SPS_DOUBLE;
-    else if (STRNCMP(buf, "expr:", 5) != 0
-             && STRNCMP(buf, "file:", 5) != 0)
+    } else if (STRNCMP(buf, "expr:", 5) != 0
+               && STRNCMP(buf, "file:", 5) != 0) {
       f = -1;
+    }
 
     if (f == -1 || (sps_flags != 0 && f != 0)) {
       sps_flags = SPS_BEST;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1834,23 +1834,29 @@ int spell_check_msm(void)
     return FAIL;
   // block count = (value * 1024) / SBLOCKSIZE (but avoid overflow)
   start = (getdigits_long(&p, true, 0) * 10) / (SBLOCKSIZE / 102);
-  if (*p != ',')
+  if (*p != ',') {
     return FAIL;
-  ++p;
-  if (!ascii_isdigit(*p))
+  }
+  p++;
+  if (!ascii_isdigit(*p)) {
     return FAIL;
+  }
   incr = (getdigits_long(&p, true, 0) * 102) / (SBLOCKSIZE / 10);
-  if (*p != ',')
+  if (*p != ',') {
     return FAIL;
-  ++p;
-  if (!ascii_isdigit(*p))
+  }
+  p++;
+  if (!ascii_isdigit(*p)) {
     return FAIL;
+  }
   added = getdigits_long(&p, true, 0) * 1024;
-  if (*p != NUL)
+  if (*p != NUL) {
     return FAIL;
+  }
 
-  if (start == 0 || incr == 0 || added == 0 || incr > start)
+  if (start == 0 || incr == 0 || added == 0 || incr > start) {
     return FAIL;
+  }
 
   compress_start = start;
   compress_inc = incr;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1833,19 +1833,19 @@ int spell_check_msm(void)
   if (!ascii_isdigit(*p))
     return FAIL;
   // block count = (value * 1024) / SBLOCKSIZE (but avoid overflow)
-  start = (getdigits_long(&p) * 10) / (SBLOCKSIZE / 102);
+  start = (getdigits_long(&p, true, 0) * 10) / (SBLOCKSIZE / 102);
   if (*p != ',')
     return FAIL;
   ++p;
   if (!ascii_isdigit(*p))
     return FAIL;
-  incr = (getdigits_long(&p) * 102) / (SBLOCKSIZE / 10);
+  incr = (getdigits_long(&p, true, 0) * 102) / (SBLOCKSIZE / 10);
   if (*p != ',')
     return FAIL;
   ++p;
   if (!ascii_isdigit(*p))
     return FAIL;
-  added = getdigits_long(&p) * 1024;
+  added = getdigits_long(&p, true, 0) * 1024;
   if (*p != NUL)
     return FAIL;
 
@@ -2787,7 +2787,7 @@ static unsigned get_affitem(int flagtype, char_u **pp)
       ++*pp;            // always advance, avoid getting stuck
       return 0;
     }
-    res = getdigits_int(pp);
+    res = getdigits_int(pp, true, 0);
   } else {
     res = mb_ptr2char_adv((const char_u **)pp);
     if (flagtype == AFT_LONG || (flagtype == AFT_CAPLONG
@@ -2906,7 +2906,7 @@ static bool flag_in_afflist(int flagtype, char_u *afflist, unsigned flag)
 
   case AFT_NUM:
     for (p = afflist; *p != NUL; ) {
-      int digits = getdigits_int(&p);
+      int digits = getdigits_int(&p, true, 0);
       assert(digits >= 0);
       n = (unsigned int)digits;
       if (n == flag)

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5048,10 +5048,10 @@ static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
         } else {                          /* yy=x+99 */
           end += 4;
           if (*end == '+') {
-            ++end;
+            end++;
             *p = getdigits_int(&end, true, 0);    // positive offset
           } else if (*end == '-')   {
-            ++end;
+            end++;
             *p = -getdigits_int(&end, true, 0);   // negative offset
           }
         }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5038,7 +5038,7 @@ static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
         ci->sp_off_flags |= (1 << idx);
         if (idx == SPO_LC_OFF) {            /* lc=99 */
           end += 3;
-          *p = getdigits_int(&end);
+          *p = getdigits_int(&end, true, 0);
 
           /* "lc=" offset automatically sets "ms=" offset */
           if (!(ci->sp_off_flags & (1 << SPO_MS_OFF))) {
@@ -5049,10 +5049,10 @@ static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
           end += 4;
           if (*end == '+') {
             ++end;
-            *p = getdigits_int(&end);                       /* positive offset */
+            *p = getdigits_int(&end, true, 0);    // positive offset
           } else if (*end == '-')   {
             ++end;
-            *p = -getdigits_int(&end);                      /* negative offset */
+            *p = -getdigits_int(&end, true, 0);   // negative offset
           }
         }
         if (*end != ',')
@@ -5118,7 +5118,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
         illegal = TRUE;
         break;
       }
-      n = getdigits_long(&arg_end);
+      n = getdigits_long(&arg_end, false, 0);
       if (!eap->skip) {
         if (key[4] == 'B')
           curwin->w_s->b_syn_sync_linebreaks = n;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5974,15 +5974,17 @@ file_name_in_line (
   if (file_lnum != NULL) {
     char_u *p;
 
-    /* Get the number after the file name and a separator character */
+    // Get the number after the file name and a separator character.
     p = ptr + len;
     p = skipwhite(p);
     if (*p != NUL) {
-      if (!isdigit(*p))
-        ++p;                        /* skip the separator */
+      if (!isdigit(*p)) {
+        p++;                        // skip the separator
+      }
       p = skipwhite(p);
-      if (isdigit(*p))
+      if (isdigit(*p)) {
         *file_lnum = getdigits_long(&p, false, 0);
+      }
     }
   }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5982,7 +5982,7 @@ file_name_in_line (
         ++p;                        /* skip the separator */
       p = skipwhite(p);
       if (isdigit(*p))
-        *file_lnum = getdigits_long(&p);
+        *file_lnum = getdigits_long(&p, false, 0);
     }
   }
 

--- a/test/functional/ex_cmds/excmd_spec.lua
+++ b/test/functional/ex_cmds/excmd_spec.lua
@@ -1,0 +1,32 @@
+local helpers = require("test.functional.helpers")(after_each)
+local command = helpers.command
+local eq = helpers.eq
+local clear = helpers.clear
+local pcall_err = helpers.pcall_err
+local assert_alive = helpers.assert_alive
+
+describe('Ex cmds', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('handle integer overflow from user-input #5555', function()
+    command(':9999999999999999999999999999999999999999')
+    command(':later 9999999999999999999999999999999999999999')
+    command(':echo expand("#<9999999999999999999999999999999999999999")')
+    command(':lockvar 9999999999999999999999999999999999999999')
+    command(':winsize 9999999999999999999999999999999999999999 9999999999999999999999999999999999999999')
+    eq('Vim(tabnext):E474: Invalid argument',
+      pcall_err(command, ':tabnext 9999999999999999999999999999999999999999'))
+    eq('Vim(Next):E939: Positive count required',
+      pcall_err(command, ':N 9999999999999999999999999999999999999999'))
+    eq('Vim(menu):E329: No menu "9999999999999999999999999999999999999999"',
+      pcall_err(command, ':menu 9999999999999999999999999999999999999999'))
+    eq('Vim(bdelete):E939: Positive count required',
+      pcall_err(command, ':bdelete 9999999999999999999999999999999999999999'))
+    eq('Vim(retab):E487: Argument must be positive',
+      pcall_err(command, ':retab 9999999999999999999999999999999999999999'))
+    assert_alive()
+  end)
+end)
+


### PR DESCRIPTION
Problem:
During a refactor long ago, we changed the `getdigits_*` familiy of functions to abort on overflow.  But this is often wrong, because many of these codepaths are handling user input.

Solution:
Decide at each call-site whether to use "strict" mode.

fix #5555