### PR TITLE
vim-patch:8.1.2023: no test for synIDattr() returning "strikethrough"

### DIFF
--- a/src/nvim/testdir/test_syn_attr.vim
+++ b/src/nvim/testdir/test_syn_attr.vim
@@ -9,11 +9,14 @@ func Test_missing_attr()
   hi Mine cterm=standout gui=undercurl
   call assert_equal('1', synIDattr(hlID("Mine"), "standout", 'cterm'))
   call assert_equal('1', synIDattr(hlID("Mine"), "undercurl", 'gui'))
+  hi Mine gui=strikethrough
+  call assert_equal('1', synIDattr(hlID("Mine"), "strikethrough", 'gui'))
   hi Mine cterm=NONE gui=NONE
   call assert_equal('', synIDattr(hlID("Mine"), "italic", 'cterm'))
   call assert_equal('', synIDattr(hlID("Mine"), "inverse", 'cterm'))
   call assert_equal('', synIDattr(hlID("Mine"), "standout", 'cterm'))
   call assert_equal('', synIDattr(hlID("Mine"), "undercurl", 'gui'))
+  call assert_equal('', synIDattr(hlID("Mine"), "strikethrough", 'gui'))
 
   if has('gui')
     let fontname = getfontname()


### PR DESCRIPTION
Problem:    No test for synIDattr() returning "strikethrough".
Solution:   Extend the synIDattr() test. (Jaskaran Singh, closes vim/vim#4929)
https://github.com/vim/vim/commit/dcb2b9cb085288d2a2e4cc31abc591ade04e782e