### PR TITLE
API: Context: "opts" param, et al.

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1027,13 +1027,14 @@ nvim_get_color_map()                                    *nvim_get_color_map()*
                 Return: ~
                     Map of color names and RGB values.
 
-nvim_get_context({types})                                 *nvim_get_context()*
+nvim_get_context({opts})                                  *nvim_get_context()*
                 Gets a map of the current editor state.
 
                 Parameters: ~
-                    {types}  Context types ("regs", "jumps", "buflist",
-                             "gvars", ...) to gather, or NIL for all (see
-                             |context-types|).
+                    {opts}  Optional parameters.
+                            • types: List of |context-types| ("regs", "jumps",
+                              "bufs", "gvars", …) to gather, or empty for
+                              "all".
 
                 Return: ~
                     map of global |context|.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -1003,14 +1003,14 @@ like the current |jumplist|, values of |registers|, and more, described below.
 The following Context items are supported:
 	"jumps"		|jumplist|
 	"regs"		|registers|
-	"buflist"	|buffer-list|
+	"bufs"		|buffer-list|
 	"gvars"		|global-variable|s
 	"sfuncs"	|script-local| functions
 	"funcs"		global and |script-local| functions
 
 							*context-dict*
 Context objects are dictionaries with the following key-value pairs:
-- "jumps", "regs", "buflist", "gvars":
+- "jumps", "regs", "bufs", "gvars":
       |readfile()|-style |List| representation of corresponding msgpack
       objects (see |msgpackdump()| and |msgpackparse()|).
 - "funcs" (includes |script-local| functions as well):

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1419,7 +1419,7 @@ Dictionary nvim_get_color_map(void)
 /// Gets a map of the current editor state.
 ///
 /// @param opts  Optional parameters.
-///               - types:  List of |context-types| ("regs", "jumps", "buflist",
+///               - types:  List of |context-types| ("regs", "jumps", "bufs",
 ///                 "gvars", …) to gather, or empty for "all".
 /// @param[out]  err  Error details, if any
 ///
@@ -1453,8 +1453,8 @@ Dictionary nvim_get_context(Dictionary opts, Error *err)
           int_types |= kCtxRegs;
         } else if (strequal(s, "jumps")) {
           int_types |= kCtxJumps;
-        } else if (strequal(s, "buflist")) {
-          int_types |= kCtxBuflist;
+        } else if (strequal(s, "bufs")) {
+          int_types |= kCtxBufs;
         } else if (strequal(s, "gvars")) {
           int_types |= kCtxGVars;
         } else if (strequal(s, "sfuncs")) {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1418,32 +1418,52 @@ Dictionary nvim_get_color_map(void)
 
 /// Gets a map of the current editor state.
 ///
-/// @param  types  Context types ("regs", "jumps", "buflist", "gvars", ...)
-///                to gather, or NIL for all (see |context-types|).
+/// @param opts  Optional parameters.
+///               - types:  List of |context-types| ("regs", "jumps", "buflist",
+///                 "gvars", …) to gather, or empty for "all".
+/// @param[out]  err  Error details, if any
 ///
 /// @return map of global |context|.
-Dictionary nvim_get_context(Array types)
+Dictionary nvim_get_context(Dictionary opts, Error *err)
   FUNC_API_SINCE(6)
 {
-  int int_types = 0;
-  if (types.size == 1 && types.items[0].type == kObjectTypeNil) {
-    int_types = kCtxAll;
-  } else {
+  Array types = ARRAY_DICT_INIT;
+  for (size_t i = 0; i < opts.size; i++) {
+    String k = opts.items[i].key;
+    Object v = opts.items[i].value;
+    if (strequal("types", k.data)) {
+      if (v.type != kObjectTypeArray) {
+        api_set_error(err, kErrorTypeValidation, "invalid value for key: %s",
+                      k.data);
+        return (Dictionary)ARRAY_DICT_INIT;
+      }
+      types = v.data.array;
+    } else {
+      api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
+      return (Dictionary)ARRAY_DICT_INIT;
+    }
+  }
+
+  int int_types = types.size > 0 ? 0 : kCtxAll;
+  if (types.size > 0) {
     for (size_t i = 0; i < types.size; i++) {
       if (types.items[i].type == kObjectTypeString) {
-        const char *const current = types.items[i].data.string.data;
-        if (strequal(current, "regs")) {
+        const char *const s = types.items[i].data.string.data;
+        if (strequal(s, "regs")) {
           int_types |= kCtxRegs;
-        } else if (strequal(current, "jumps")) {
+        } else if (strequal(s, "jumps")) {
           int_types |= kCtxJumps;
-        } else if (strequal(current, "buflist")) {
+        } else if (strequal(s, "buflist")) {
           int_types |= kCtxBuflist;
-        } else if (strequal(current, "gvars")) {
+        } else if (strequal(s, "gvars")) {
           int_types |= kCtxGVars;
-        } else if (strequal(current, "sfuncs")) {
+        } else if (strequal(s, "sfuncs")) {
           int_types |= kCtxSFuncs;
-        } else if (strequal(current, "funcs")) {
+        } else if (strequal(s, "funcs")) {
           int_types |= kCtxFuncs;
+        } else {
+          api_set_error(err, kErrorTypeValidation, "unexpected type: %s", s);
+          return (Dictionary)ARRAY_DICT_INIT;
         }
       }
     }

--- a/src/nvim/context.h
+++ b/src/nvim/context.h
@@ -8,7 +8,7 @@
 typedef struct {
   msgpack_sbuffer regs;     ///< Registers.
   msgpack_sbuffer jumps;    ///< Jumplist.
-  msgpack_sbuffer buflist;  ///< Buffer list.
+  msgpack_sbuffer bufs;     ///< Buffer list.
   msgpack_sbuffer gvars;    ///< Global variables.
   Array funcs;              ///< Functions.
 } Context;
@@ -23,7 +23,7 @@ typedef kvec_t(Context) ContextVec;
 #define CONTEXT_INIT (Context) { \
   .regs = MSGPACK_SBUFFER_INIT, \
   .jumps = MSGPACK_SBUFFER_INIT, \
-  .buflist = MSGPACK_SBUFFER_INIT, \
+  .bufs = MSGPACK_SBUFFER_INIT, \
   .gvars = MSGPACK_SBUFFER_INIT, \
   .funcs = ARRAY_DICT_INIT, \
 }
@@ -31,7 +31,7 @@ typedef kvec_t(Context) ContextVec;
 typedef enum {
   kCtxRegs = 1,       ///< Registers
   kCtxJumps = 2,      ///< Jumplist
-  kCtxBuflist = 4,    ///< Buffer list
+  kCtxBufs = 4,       ///< Buffer list
   kCtxGVars = 8,      ///< Global variables
   kCtxSFuncs = 16,    ///< Script functions
   kCtxFuncs = 32,     ///< Functions

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8002,8 +8002,8 @@ static void f_ctxpush(typval_T *argvars, typval_T *rettv, FunPtr fptr)
           types |= kCtxRegs;
         } else if (strequal((char *)tv_li->vval.v_string, "jumps")) {
           types |= kCtxJumps;
-        } else if (strequal((char *)tv_li->vval.v_string, "buflist")) {
-          types |= kCtxBuflist;
+        } else if (strequal((char *)tv_li->vval.v_string, "bufs")) {
+          types |= kCtxBufs;
         } else if (strequal((char *)tv_li->vval.v_string, "gvars")) {
           types |= kCtxGVars;
         } else if (strequal((char *)tv_li->vval.v_string, "sfuncs")) {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -903,7 +903,7 @@ describe('API', function()
         pcall_err(nvim, 'get_context', {types={'jumps', 'zub', 'zam',}}))
     end)
     it('returns map of current editor state', function()
-      local opts = {types={'regs', 'jumps', 'buflist', 'gvars'}}
+      local opts = {types={'regs', 'jumps', 'bufs', 'gvars'}}
       eq({}, parse_context(nvim('get_context', {})))
 
       feed('i1<cr>2<cr>3<c-[>ddddddqahjklquuu')
@@ -929,7 +929,7 @@ describe('API', function()
           { k, v -> k != "l" || v != 1 })'), '!empty(v:val.f)')
         ]]):gsub('\n', '')),
 
-        ['buflist'] = eval([[
+        ['bufs'] = eval([[
         filter(map(getbufinfo(), '{ "f": v:val.name }'), '!empty(v:val.f)')
         ]]),
 
@@ -944,7 +944,7 @@ describe('API', function()
 
   describe('nvim_load_context', function()
     it('sets current editor state to given context dictionary', function()
-      local opts = {types={'regs', 'jumps', 'buflist', 'gvars'}}
+      local opts = {types={'regs', 'jumps', 'bufs', 'gvars'}}
       eq({}, parse_context(nvim('get_context', opts)))
 
       nvim('set_var', 'one', 1)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -894,9 +894,17 @@ describe('API', function()
   end)
 
   describe('nvim_get_context', function()
-    it('returns context dictionary of current editor state', function()
-      local ctx_items = {'regs', 'jumps', 'buflist', 'gvars'}
-      eq({}, parse_context(nvim('get_context', ctx_items)))
+    it('validates args', function()
+      eq('unexpected key: blah',
+        pcall_err(nvim, 'get_context', {blah={}}))
+      eq('invalid value for key: types',
+        pcall_err(nvim, 'get_context', {types=42}))
+      eq('unexpected type: zub',
+        pcall_err(nvim, 'get_context', {types={'jumps', 'zub', 'zam',}}))
+    end)
+    it('returns map of current editor state', function()
+      local opts = {types={'regs', 'jumps', 'buflist', 'gvars'}}
+      eq({}, parse_context(nvim('get_context', {})))
 
       feed('i1<cr>2<cr>3<c-[>ddddddqahjklquuu')
       feed('gg')
@@ -928,19 +936,21 @@ describe('API', function()
         ['gvars'] = {{'one', 1}, {'Two', 2}, {'THREE', 3}},
       }
 
-      eq(expected_ctx, parse_context(nvim('get_context', ctx_items)))
+      eq(expected_ctx, parse_context(nvim('get_context', opts)))
+      eq(expected_ctx, parse_context(nvim('get_context', {})))
+      eq(expected_ctx, parse_context(nvim('get_context', {types={}})))
     end)
   end)
 
   describe('nvim_load_context', function()
     it('sets current editor state to given context dictionary', function()
-      local ctx_items = {'regs', 'jumps', 'buflist', 'gvars'}
-      eq({}, parse_context(nvim('get_context', ctx_items)))
+      local opts = {types={'regs', 'jumps', 'buflist', 'gvars'}}
+      eq({}, parse_context(nvim('get_context', opts)))
 
       nvim('set_var', 'one', 1)
       nvim('set_var', 'Two', 2)
       nvim('set_var', 'THREE', 3)
-      local ctx = nvim('get_context', ctx_items)
+      local ctx = nvim('get_context', opts)
       nvim('set_var', 'one', 'a')
       nvim('set_var', 'Two', 'b')
       nvim('set_var', 'THREE', 'c')

--- a/test/functional/eval/ctx_functions_spec.lua
+++ b/test/functional/eval/ctx_functions_spec.lua
@@ -82,21 +82,21 @@ describe('context functions', function()
       command('edit '..fname1)
       command('edit '..fname2)
       command('edit TEST')
-      local buflist = call('map', call('getbufinfo'), 'v:val.name')
+      local bufs = call('map', call('getbufinfo'), 'v:val.name')
       call('ctxpush')
-      call('ctxpush', {'buflist'})
+      call('ctxpush', {'bufs'})
 
       command('%bwipeout')
       eq({''}, call('map', call('getbufinfo'), 'v:val.name'))
 
       call('ctxpop')
-      eq({'', unpack(buflist)}, call('map', call('getbufinfo'), 'v:val.name'))
+      eq({'', unpack(bufs)}, call('map', call('getbufinfo'), 'v:val.name'))
 
       command('%bwipeout')
       eq({''}, call('map', call('getbufinfo'), 'v:val.name'))
 
       call('ctxpop')
-      eq({'', unpack(buflist)}, call('map', call('getbufinfo'), 'v:val.name'))
+      eq({'', unpack(bufs)}, call('map', call('getbufinfo'), 'v:val.name'))
     end)
 
     it('saves and restores global variables properly', function()
@@ -297,8 +297,8 @@ describe('context functions', function()
         ]]):gsub('\n', ''))
       }
 
-      local with_buflist = {
-        ['buflist'] = eval([[
+      local with_bufs = {
+        ['bufs'] = eval([[
         filter(map(getbufinfo(), '{ "f": v:val.name }'), '!empty(v:val.f)')
         ]])
       }
@@ -310,7 +310,7 @@ describe('context functions', function()
       local with_all = {
         ['regs'] = with_regs['regs'],
         ['jumps'] = with_jumps['jumps'],
-        ['buflist'] = with_buflist['buflist'],
+        ['bufs'] = with_bufs['bufs'],
         ['gvars'] = with_gvars['gvars'],
       }
 
@@ -323,16 +323,16 @@ describe('context functions', function()
       eq(with_gvars, parse_context(call('ctxget', 0)))
       eq(with_all, parse_context(call('ctxget', 1)))
 
-      call('ctxpush', {'buflist'})
-      eq(with_buflist, parse_context(call('ctxget')))
-      eq(with_buflist, parse_context(call('ctxget', 0)))
+      call('ctxpush', {'bufs'})
+      eq(with_bufs, parse_context(call('ctxget')))
+      eq(with_bufs, parse_context(call('ctxget', 0)))
       eq(with_gvars, parse_context(call('ctxget', 1)))
       eq(with_all, parse_context(call('ctxget', 2)))
 
       call('ctxpush', {'jumps'})
       eq(with_jumps, parse_context(call('ctxget')))
       eq(with_jumps, parse_context(call('ctxget', 0)))
-      eq(with_buflist, parse_context(call('ctxget', 1)))
+      eq(with_bufs, parse_context(call('ctxget', 1)))
       eq(with_gvars, parse_context(call('ctxget', 2)))
       eq(with_all, parse_context(call('ctxget', 3)))
 
@@ -340,20 +340,20 @@ describe('context functions', function()
       eq(with_regs, parse_context(call('ctxget')))
       eq(with_regs, parse_context(call('ctxget', 0)))
       eq(with_jumps, parse_context(call('ctxget', 1)))
-      eq(with_buflist, parse_context(call('ctxget', 2)))
+      eq(with_bufs, parse_context(call('ctxget', 2)))
       eq(with_gvars, parse_context(call('ctxget', 3)))
       eq(with_all, parse_context(call('ctxget', 4)))
 
       call('ctxpop')
       eq(with_jumps, parse_context(call('ctxget')))
       eq(with_jumps, parse_context(call('ctxget', 0)))
-      eq(with_buflist, parse_context(call('ctxget', 1)))
+      eq(with_bufs, parse_context(call('ctxget', 1)))
       eq(with_gvars, parse_context(call('ctxget', 2)))
       eq(with_all, parse_context(call('ctxget', 3)))
 
       call('ctxpop')
-      eq(with_buflist, parse_context(call('ctxget')))
-      eq(with_buflist, parse_context(call('ctxget', 0)))
+      eq(with_bufs, parse_context(call('ctxget')))
+      eq(with_bufs, parse_context(call('ctxget', 0)))
       eq(with_gvars, parse_context(call('ctxget', 1)))
       eq(with_all, parse_context(call('ctxget', 2)))
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -777,12 +777,12 @@ end
 
 function module.parse_context(ctx)
   local parsed = {}
-  for _, item in ipairs({'regs', 'jumps', 'buflist', 'gvars'}) do
+  for _, item in ipairs({'regs', 'jumps', 'bufs', 'gvars'}) do
     parsed[item] = filter(function(v)
       return type(v) == 'table'
     end, module.call('msgpackparse', ctx[item]))
   end
-  parsed['buflist'] = parsed['buflist'][1]
+  parsed['bufs'] = parsed['bufs'][1]
   return map(function(v)
     if #v == 0 then
       return nil


### PR DESCRIPTION
- Since the `types`  parameter was already non-primitive, make it an `opts` map instead of just a list, in case we want to extend it later.
- Rename "buflist" => "bufs". Given the other type names "jumps", "vars", etc., the name "buflist"
is somewhat unintuitive. (@abdelhakeem sorry, this is a bit of churn)