### PR TITLE
Fix "precedes" listchar behavior in wrap mode

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3698,8 +3698,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			off and the line continues beyond the right of the
 			screen.
 							*lcs-precedes*
-	  precedes:c	Character to show in the first column, when there is
-			text preceding the character visible in the first column.
+	  precedes:c	Character to show in the first visible column of the
+			physical line, when there is text preceding the
+			character visible in the first column.
 							*lcs-conceal*
 	  conceal:c	Character to show in place of concealed text, when
 			'conceallevel' is set to 1.  A space when omitted.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3698,9 +3698,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			off and the line continues beyond the right of the
 			screen.
 							*lcs-precedes*
-	  precedes:c	Character to show in the first column, when 'wrap'
-			is off and there is text preceding the character
-			visible in the first column.
+	  precedes:c	Character to show in the first column, when there is
+			text preceding the character visible in the first column.
 							*lcs-conceal*
 	  conceal:c	Character to show in place of concealed text, when
 			'conceallevel' is set to 1.  A space when omitted.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3763,7 +3763,7 @@ win_line (
      */
     if (lcs_prec_todo != NUL
         && wp->w_p_list
-        && (wp->w_p_wrap ? wp->w_skipcol > 0 : wp->w_leftcol > 0)
+        && (wp->w_p_wrap ? (wp->w_skipcol > 0 && row == 0) : wp->w_leftcol > 0)
         && filler_todo <= 0
         && draw_state > WL_NR
         && c != NUL) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3756,11 +3756,9 @@ win_line (
       char_attr = hl_combine_attr(char_attr, extra_attr);
     }
 
-    /*
-     * Handle the case where we are in column 0 but not on the first
-     * character of the line and the user wants us to show us a
-     * special character (via 'listchars' option "precedes:<char>".
-     */
+    // Handle the case where we are in column 0 but not on the first
+    // character of the line and the user wants us to show us a
+    // special character (via 'listchars' option "precedes:<char>".
     if (lcs_prec_todo != NUL
         && wp->w_p_list
         && (wp->w_p_wrap ? (wp->w_skipcol > 0 && row == 0) : wp->w_leftcol > 0)

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -69,3 +69,58 @@ func! Test_display_foldtext_mbyte()
   set foldtext& fillchars& foldmethod& fdc&
   bw!
 endfunc
+
+func Test_display_listchars_precedes()
+  call NewWindow(10, 10)
+  " Need a physical line that wraps over the complete
+  " window size
+  call append(0, repeat('aaa aaa aa ', 10))
+  call append(1, repeat(['bbb bbb bbb bbb'], 2))
+  " remove blank trailing line
+  $d
+  set list nowrap
+  call cursor(1, 1)
+  " move to end of line and scroll 2 characters back
+  norm! $2zh
+  let lines=ScreenLines([1,4], winwidth(0)+1)
+  let expect = [
+        \ " aaa aa $ |",
+        \ "$         |",
+        \ "$         |",
+        \ "~         |",
+        \ ]
+  call assert_equal(expect, lines)
+  set list listchars+=precedes:< nowrap
+  call cursor(1, 1)
+  " move to end of line and scroll 2 characters back
+  norm! $2zh
+  let lines = ScreenLines([1,4], winwidth(0)+1)
+  let expect = [
+        \ "<aaa aa $ |",
+        \ "<         |",
+        \ "<         |",
+        \ "~         |",
+        \ ]
+  call assert_equal(expect, lines)
+  set wrap
+  call cursor(1, 1)
+  " the complete line should be displayed in the window
+  norm! $
+
+  let lines = ScreenLines([1,10], winwidth(0)+1)
+  let expect = [
+        \ "<aaa aaa a|",
+        \ "a aaa aaa |",
+        \ "aa aaa aaa|",
+        \ " aa aaa aa|",
+        \ "a aa aaa a|",
+        \ "aa aa aaa |",
+        \ "aaa aa aaa|",
+        \ " aaa aa aa|",
+        \ "a aaa aa a|",
+        \ "aa aaa aa |",
+        \ ]
+  call assert_equal(expect, lines)
+  set list& listchars& wrap&
+  bw!
+endfunc

--- a/src/nvim/testdir/view_util.vim
+++ b/src/nvim/testdir/view_util.vim
@@ -42,6 +42,7 @@ endfunction
 function! NewWindow(height, width) abort
   exe a:height . 'new'
   exe a:width . 'vsp'
+  set winfixwidth winfixheight
   redraw!
 endfunction
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -657,6 +657,30 @@ describe("'listchars' highlight", function()
     ]])
   end)
 
+  it("'listchar' with wrap", function()
+    screen:set_default_attr_ids({
+      [0] = {bold=true, foreground=Screen.colors.Blue},
+    })
+    feed_command('set wrap')
+    feed_command('set listchars=eol:¬,precedes:< list')
+    feed('90ia<esc>')
+    screen:expect([[
+      {0:<}aaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaa^a{0:¬}         |
+                          |
+    ]])
+    feed('0')
+    screen:expect([[
+      ^aaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaa|
+                          |
+    ]])
+  end)
+
   it("'listchar' in visual mode", function()
     screen:set_default_attr_ids({
       [1] = {background=Screen.colors.Grey90},


### PR DESCRIPTION
Previously, the "precedes" character would be rendered on every row
when w_skipcol > 0 (i.e., when viewing a single line longer than the
entire screen), instead of just on the first row. Make sure to only
render it on the first row in this case.

Add a test for this behavior.

Fix documentation for the "precedes" character, which erroneously
stated that it was only active when wrap mode was off.