### PR TITLE
checkhealth: skip python checks if intentionally disabled

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -276,7 +276,11 @@ function! s:check_python(version) abort
   let python_multiple = []
 
   if exists(loaded_var) && !exists('*provider#'.pyname.'#Call')
-    call health#report_info('Disabled ('.loaded_var.'='.eval(loaded_var).').  This might be due to some previous error.')
+    let v = eval(loaded_var)
+    call health#report_info('Disabled ('.loaded_var.'='.v.').'.(0 is v ? '' : '  This might be due to some previous error.'))
+    if 0 is v
+      return
+    endif
   endif
 
   let [pyenv, pyenv_root] = s:check_for_pyenv()


### PR DESCRIPTION
Suppress message when `g:loaded_python(3)_provider` is set.

fix #11040
