### PR TITLE
provider#pythonx: resolve/expand exe from host var

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -286,7 +286,7 @@ function! s:check_python(version) abort
     let python_exe = pyname
   endif
 
-  " No Python executable could `import neovim`.
+  " No Python executable could `import neovim`, or host_prog_var was used.
   if !empty(pythonx_errors)
     call health#report_error('Python provider error:', pythonx_errors)
 

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -43,7 +43,7 @@ function! provider#pythonx#DetectByModule(module, major_version) abort
   let python_exe = s:get_python_executable_from_host_var(a:major_version)
 
   if !empty(python_exe)
-    return [python_exe, '']
+    return [exepath(expand(python_exe)), '']
   endif
 
   let candidates = s:get_python_candidates(a:major_version)


### PR DESCRIPTION
This reverts part of ade88fe4c [1].

This is required for `let g:python3_host_prog = 'python'` etc, where it
should get picked up from PATH.

Without this it would show:

```
  - INFO: pyenv: Path: /home/user/.pyenv/libexec/pyenv
  - INFO: pyenv: Root: /home/user/.pyenv
  - INFO: Using: g:python3_host_prog = "python"
  - ERROR: "python" was not found.
  - INFO: Executable: Not found
  - ERROR: Detected pip upgrade failure: Python executable can import "pynvim" but not "neovim": python
    - ADVICE:
      - Use that Python version to reinstall "pynvim" and optionally "neovim".
          pip3 uninstall pynvim neovim
          pip3 install pynvim
          pip3 install neovim  # only if needed by third-party software
```

Note that it additionally causes a weird error
("Detected pip upgrade failure"), due to `s:check_bin` emptying
`python_exe` (because the non-absolute file not being readable), and
`provider#pythonx#DetectByModule('pynvim', a:version)` from 75593e6fce
then just getting the value from the host var again (without actual
checks).
This is implicitly fixed via this patch now (because it is skipped), but
could need some improvement in this regard probably.

With this patch it resolves it (for a virtualenv where pynvim is not
made available intentionally):
```
  - INFO: pyenv: Path: /home/daniel/.pyenv/libexec/pyenv
  - INFO: pyenv: Root: /home/daniel/.pyenv
  - INFO: Using: g:python3_host_prog = "python"
  - WARNING: $VIRTUAL_ENV exists but appears to be inactive. This could lead to unexpected results.
    - ADVICE:
      - If you are using Zsh, see: http://vi.stackexchange.com/a/7654
  - INFO: Executable: /home/daniel/.pyenv/shims/tmp-system-deoplete.nvim-f205aF/python
  - ERROR: Command error (job=11, exit code 1): `'/home/daniel/.pyenv/shims/tmp-system-deoplete.nvim-f205aF/python' -c 'import sys; sys.path.remove(""); import neovim; print(neovim.__file__)'` (in '/home/daniel/.dotfiles/vim/plugged/deoplete.nvim')
    Output: Traceback (most recent call last):  File "<string>", line 1, in <module>ModuleNotFoundError: No module named 'neovim'
    Stderr: Traceback (most recent call last):  File "<string>", line 1, in <module>ModuleNotFoundError: No module named 'neovim'
  - INFO: Python version: 3.7.4
  - INFO: pynvim version: unable to load neovim Python module
  - ERROR: pynvim is not installed.
    Error: unable to load neovim Python module
    - ADVICE:
      - Run in shell: pip3 install pynvim

```

Note: this appears to display the error twice via "Output:" and
"Stderr:".

1: https://github.com/neovim/neovim/pull/8784