### PR TITLE
env: use putenv_s for LC_ALL, LANG, etc.

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -138,17 +138,13 @@ int os_setenv(const char *name, const char *value, int overwrite)
   int r;
 #ifdef WIN32
   // libintl uses getenv() for LC_ALL/LANG/etc., so we must use _putenv_s().
-  // in libintl, so we must use _putenv_s().
   if (striequal(name, "LC_ALL") || striequal(name, "LANGUAGE")
       || striequal(name, "LANG") || striequal(name, "LC_MESSAGES")) {
     r = _putenv_s(name, value);  // NOLINT
     assert(r == 0);
-  } else {
-#endif
-  r = uv_os_setenv(name, value);
-#ifdef WIN32
   }
 #endif
+  r = uv_os_setenv(name, value);
   assert(r != UV_EINVAL);
   // Destroy the old map item. Do this AFTER uv_os_setenv(), because `value`
   // could be a previous os_getenv() result.

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -137,10 +137,10 @@ int os_setenv(const char *name, const char *value, int overwrite)
   uv_mutex_lock(&mutex);
   int r;
 #ifdef WIN32
-  // LC_ALL, LANG, LANGUAGE and LC_MESSAGES must be obtained using getenv()
+  // LC_ALL, LANGUAGE, LANG and LC_MESSAGES must be obtained using getenv()
   // in libintl, so we must use _putenv_s().
-  if (strcmp(name, "LC_ALL") == 0 || strcmp(name, "LANG") == 0
-      || strcmp(name, "LANGUAGE") == 0 || strcmp(name, "LC_MESSAGES") == 0) {
+  if (striequal(name, "LC_ALL") || striequal(name, "LANGUAGE")
+      || striequal(name, "LANG") || striequal(name, "LC_MESSAGES")) {
     r = _putenv_s(name, value);  // NOLINT
     assert(r == 0);
   } else {

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -137,7 +137,7 @@ int os_setenv(const char *name, const char *value, int overwrite)
   uv_mutex_lock(&mutex);
   int r;
 #ifdef WIN32
-  // LC_ALL, LANGUAGE, LANG and LC_MESSAGES must be obtained using getenv()
+  // libintl uses getenv() for LC_ALL/LANG/etc., so we must use _putenv_s().
   // in libintl, so we must use _putenv_s().
   if (striequal(name, "LC_ALL") || striequal(name, "LANGUAGE")
       || striequal(name, "LANG") || striequal(name, "LC_MESSAGES")) {


### PR DESCRIPTION
```
Problem:  ":lang messages en_US.UTF-8" no longer overrides the language
          detected from the environment (at startup).
Solution: In os_setenv, special-case "LC_ALL", "LANG", et al. to use
          putenv_s instead of uv_os_setenv.
```

fixes #11045