### PR TITLE
api: add nvim_win_get_id

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1968,6 +1968,15 @@ nvim_win_get_number({window})                          *nvim_win_get_number()*
                 Return: ~
                     Window number
 
+nvim_win_get_id({window})                                  *nvim_win_get_id()*
+                Gets the window ID
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+
+                Return: ~
+                    Window ID
+
 nvim_win_is_valid({window})                              *nvim_win_is_valid()*
                 Checks if a window is valid
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -427,6 +427,23 @@ Integer nvim_win_get_number(Window window, Error *err)
   return rv;
 }
 
+/// Gets the window ID
+///
+/// @param window   Window handle, or 0 for current window
+/// @param[out] err Error details, if any
+/// @return Window ID
+Integer nvim_win_get_id(Window window, Error *err)
+  FUNC_API_SINCE(1)
+{
+  int rv = 0;
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return rv;
+  }
+  return win->handle;
+}
+
 /// Checks if a window is valid
 ///
 /// @param window Window handle, or 0 for current window


### PR DESCRIPTION
Initially done for pynvim, before I've noticed that it has ".handle" already, which reflects the ID.

Still useful in general I assume, e.g. for Lua, isn't it?