### PR TITLE
vim-patch:8.1.2055: not easy to jump to function line from profile

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -22259,7 +22259,7 @@ void func_dump_profile(FILE *fd)
               .channel_id = 0,
           };
           char_u *p = get_scriptname(last_set, &should_free);
-          fprintf(fd, "    Defined: %s line %" PRIdLINENR "\n",
+          fprintf(fd, "    Defined: %s:%" PRIdLINENR "\n",
                   p, fp->uf_script_ctx.sc_lnum);
           if (should_free) {
             xfree(p);

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -54,7 +54,7 @@ func Test_profile_func()
   call assert_equal(30, len(lines))
 
   call assert_equal('FUNCTION  Foo1()',                            lines[0])
-  call assert_match('Defined:.*Xprofile_func.vim',                 lines[1])
+  call assert_match('Defined:.*Xprofile_func.vim:3',               lines[1])
   call assert_equal('Called 2 times',                              lines[2])
   call assert_match('^Total time:\s\+\d\+\.\d\+$',                 lines[3])
   call assert_match('^ Self time:\s\+\d\+\.\d\+$',                 lines[4])


### PR DESCRIPTION
Problem:    Not easy to jump to function line from profile.
Solution:   Use "file:99" instead of "file line 99" so that "gf" works.
            (Daniel Hahler, closes vim/vim#4951)
https://github.com/vim/vim/commit/181d4f58cc421f2e6d3b16333d4cb70d35ad1342