### PR TITLE
terminfo_start: flush buffer

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -312,6 +312,7 @@ static void terminfo_start(UI *ui)
     uv_pipe_init(&data->write_loop, &data->output_handle.pipe, 0);
     uv_pipe_open(&data->output_handle.pipe, data->out_fd);
   }
+  flush_buf(ui);
 }
 
 static void terminfo_stop(UI *ui)


### PR DESCRIPTION
This is in line with `terminfo_stop`, which also flushes the buffer
after disabling things.

This ensures Neovim gets the response to the terminal background query
before exiting (`nvim -u NONE -cq` with e.g. urxvt or kitty).

With kitty this causes some "flickering", likely since the alternate
screen is being setup with `nvim -u NONE -cq`, whereas it would not be
processed otherwise before quitting (as with the background query).

Fixes https://github.com/neovim/neovim/issues/11062.