### PR TITLE
[RFC/WIP] tests: busted: nvim handler: display durations always

### DIFF
--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -227,8 +227,19 @@ return function(options)
     return nil, true
   end
 
-  handler.testEnd = function(element, _parent, status, _debug)
+  local function write_status(element, string)
     local elapsedTime_ms = getElapsedTime(element)
+
+    -- XXX: not clear what that check is for.  Done in accc7a0b6.
+    -- Might be for "nan" - but `tonumber('nan') == tonumber('nan')`.
+    if elapsedTime_ms == elapsedTime_ms then
+      string = timeString:format(elapsedTime_ms) .. ' ' .. string
+    end
+    io.write(string)
+    io.flush()
+  end
+
+  handler.testEnd = function(element, _parent, status, _debug)
     local string
 
     fileTestCount = fileTestCount + 1
@@ -241,45 +252,21 @@ return function(options)
       string = skippedString
     elseif status == 'failure' then
       failureCount = failureCount + 1
-      string = nil
+      string = failureString .. failureDescription(handler.failures[#handler.failures])
     elseif status == 'error' then
       errorCount = errorCount + 1
-      string = nil
+      string = errorString .. failureDescription(handler.errors[#handler.errors])
+    else
+      string = "unexpected test status! ("..status..")"
     end
+    write_status(element, string)
 
-    if string ~= nil then
-      if elapsedTime_ms == elapsedTime_ms then
-        string = timeString:format(elapsedTime_ms) .. ' ' .. string
-      end
-      io.write(string)
-      io.flush()
-    end
-
-    return nil, true
-  end
-
-  handler.testFailure = function(_element, _parent, _message, _debug)
-    io.write(failureString)
-    io.flush()
-
-    io.write(failureDescription(handler.failures[#handler.failures]))
-    io.flush()
-    return nil, true
-  end
-
-  handler.testError = function(_element, _parent, _message, _debug)
-    io.write(errorString)
-    io.flush()
-
-    io.write(failureDescription(handler.errors[#handler.errors]))
-    io.flush()
     return nil, true
   end
 
   handler.error = function(element, _parent, _message, _debug)
     if element.descriptor ~= 'it' then
-      io.write(failureDescription(handler.errors[#handler.errors]))
-      io.flush()
+      write_status(element, failureDescription(handler.errors[#handler.errors]))
       errorCount = errorCount + 1
     end
 
@@ -293,8 +280,6 @@ return function(options)
   busted.subscribe({ 'file', 'end' }, handler.fileEnd)
   busted.subscribe({ 'test', 'start' }, handler.testStart, { predicate = handler.cancelOnPending })
   busted.subscribe({ 'test', 'end' }, handler.testEnd, { predicate = handler.cancelOnPending })
-  busted.subscribe({ 'failure', 'it' }, handler.testFailure)
-  busted.subscribe({ 'error', 'it' }, handler.testError)
   busted.subscribe({ 'failure' }, handler.error)
   busted.subscribe({ 'error' }, handler.error)
 

--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -228,14 +228,7 @@ return function(options)
   end
 
   local function write_status(element, string)
-    local elapsedTime_ms = getElapsedTime(element)
-
-    -- XXX: not clear what that check is for.  Done in accc7a0b6.
-    -- Might be for "nan" - but `tonumber('nan') == tonumber('nan')`.
-    if elapsedTime_ms == elapsedTime_ms then
-      string = timeString:format(elapsedTime_ms) .. ' ' .. string
-    end
-    io.write(string)
+    io.write(timeString:format(getElapsedTime(element)) .. ' ' .. string)
     io.flush()
   end
 


### PR DESCRIPTION
This shows them also with test failures/errors, where it is useful to
see how long the test took (for flaky failures running into timeout).