### PR TITLE
tests: tui_spec: improve "TUI paste: exactly 64 bytes"

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -566,7 +566,6 @@ describe('TUI', function()
     feed_data('\027[200~'..expected..'\027[201~')
     feed_data(' end')
     expected = expected..' end'
-    expect_child_buf_lines({expected})
     screen:expect([[
       zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz|
       zzzzzzzzzzzzzz end{1: }                               |
@@ -576,6 +575,7 @@ describe('TUI', function()
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
     ]])
+    expect_child_buf_lines({expected})
   end)
 
   it('paste: big burst of input', function()


### PR DESCRIPTION
Doing the screen test first might give insights about a possible
(flaky?) failure, where it looks like "feed_data" is processed out of
order:

    [  ERROR   ] test/functional/terminal/tui_spec.lua @ 561: TUI paste: exactly 64 bytes #10311
    test/functional/helpers.lua:388:
    retry() attempts: 490
    test/functional/terminal/tui_spec.lua:66: Expected objects to be the same.
    Passed in:
    (table: 0x44042de8) {
     *[1] = ' endzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' }
    Expected:
    (table: 0x41d6e568) {
     *[1] = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz end' }
    stack traceback:
            test/functional/helpers.lua:388: in function 'retry'
            test/functional/terminal/tui_spec.lua:63: in function 'expect_child_buf_lines'
            test/functional/terminal/tui_spec.lua:569: in function <test/functional/terminal/tui_spec.lua:561>

Ref: https://github.com/neovim/neovim/pull/11083#issuecomment-534375201
Build log: https://travis-ci.org/neovim/neovim/jobs/588749739#L5597