### PR TITLE
cmake/GetCompileFlags: include CMAKE_C_COMPILER_ARG1

### DIFF
--- a/cmake/GetCompileFlags.cmake
+++ b/cmake/GetCompileFlags.cmake
@@ -3,6 +3,13 @@ function(get_compile_flags _compile_flags)
   set(compile_flags "<CMAKE_C_COMPILER> <CFLAGS> <BUILD_TYPE_CFLAGS> <COMPILE_OPTIONS><COMPILE_DEFINITIONS> <INCLUDES>")
 
   # Get C compiler.
+  if(CMAKE_C_COMPILER_ARG1)
+    string(REPLACE
+      "<CMAKE_C_COMPILER>"
+      "<CMAKE_C_COMPILER> ${CMAKE_C_COMPILER_ARG1}"
+      compile_flags
+      "${compile_flags}")
+  endif()
   string(REPLACE
     "<CMAKE_C_COMPILER>"
     "${CMAKE_C_COMPILER}"


### PR DESCRIPTION
This is used internally (e.g. on Travis) for 32-bit builds (`-m32`).

Worked: https://travis-ci.org/neovim/neovim/jobs/589140720#L846