### PR TITLE
ci: Travis: simplify 32bit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ env:
                    -DDEPS_PREFIX=$DEPS_BUILD_DIR/usr
                    -DMIN_LOG_LEVEL=3"
     - DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_GPERF=OFF"
-    # Additional CMake flags for 32-bit builds.
-    - CMAKE_FLAGS_32BIT="-DCMAKE_SYSTEM_LIBRARY_PATH=/lib32:/usr/lib32:/usr/local/lib32
-                         -DCMAKE_IGNORE_PATH=/lib:/usr/lib:/usr/local/lib
-                         -DCMAKE_TOOLCHAIN_FILE=$TRAVIS_BUILD_DIR/cmake/i386-linux-gnu.toolchain.cmake"
     # Environment variables for Clang sanitizers.
     - ASAN_OPTIONS="detect_leaks=1:check_initialization_order=1:log_path=$LOG_DIR/asan"
     - TSAN_OPTIONS="log_path=$LOG_DIR/tsan"
@@ -136,6 +132,8 @@ jobs:
       compiler: gcc
       env:
         - BUILD_32BIT=ON
+        - CMAKE_FLAGS="$CMAKE_FLAGS -m32 -DCMAKE_TOOLCHAIN_FILE=$TRAVIS_BUILD_DIR/cmake/i386-linux-gnu.toolchain.cmake"
+        - DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -m32 -DCMAKE_TOOLCHAIN_FILE=$TRAVIS_BUILD_DIR/cmake/i386-linux-gnu.toolchain.cmake"
         # Minimum required CMake.
         - CMAKE_URL=https://cmake.org/files/v2.8/cmake-2.8.12-Linux-i386.sh
         - *common-job-env

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -18,9 +18,6 @@ build_make() {
 }
 
 build_deps() {
-  if test "${BUILD_32BIT}" = ON ; then
-    DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} ${CMAKE_FLAGS_32BIT}"
-  fi
   if test "${FUNCTIONALTEST}" = "functionaltest-lua" \
      || test "${CLANG_SANITIZER}" = "ASAN_UBSAN" ; then
     DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} -DUSE_BUNDLED_LUA=ON"
@@ -52,9 +49,6 @@ build_deps() {
 prepare_build() {
   if test -n "${CLANG_SANITIZER}" ; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCLANG_${CLANG_SANITIZER}=ON"
-  fi
-  if test "${BUILD_32BIT}" = ON ; then
-    CMAKE_FLAGS="${CMAKE_FLAGS} ${CMAKE_FLAGS_32BIT}"
   fi
 
   mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
- `CMAKE_SYSTEM_LIBRARY_PATH` should not be used, and is a
  semicolon-separated list anyway [1].

1: https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_LIBRARY_PATH.html