### PR TITLE
doc: contrib/local.mk.example: include ENABLE_LTO  [ci skip]

### DIFF
--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -25,6 +25,12 @@
 #
 # CMAKE_BUILD_TYPE := Debug
 
+# With non-Debug builds interprocedural optimization (IPO) (which includes
+# link-time optimization (LTO)) is enabled by default, which causes the link
+# step to take a significant amout of time, which is relevant when building
+# often.  You can disable it explicitly:
+# CMAKE_EXTRA_FLAGS += -DENABLE_LTO=OFF
+
 # Log levels: 0 (DEBUG), 1 (INFO), 2 (WARNING), 3 (ERROR)
 # Default is 1 (INFO) unless CMAKE_BUILD_TYPE is Release or RelWithDebInfo.
 # CMAKE_EXTRA_FLAGS += -DMIN_LOG_LEVEL=1


### PR DESCRIPTION
Using it takes 30+ additional seconds for me with a ccache-enabled build
(43s vs. 12s).

1. While it certainly makes sense to use DEBUG during development,
bisecting etc, it should be made clearer what causes this.

2. It could also have a CMake status message maybe?

3. While at it, it could also have a section for/about
   `CMAKE_C_FLAGS_DEBUG` / `CMAKE_C_FLAGS_X` maybe with it?

4. Should/could be added to the wiki also, but I think it needs to be
   more visible from the source / build process itself.