### PR TITLE
vim-patch:8.1.2083: multi-byte chars do not work properly with "%.*S" in printf()

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -953,11 +953,17 @@ int vim_vsnprintf_typval(
                                       - mb_string2cells((char_u *)str_arg));
                 }
                 if (precision) {
-                  const char *p1 = str_arg;
-                  for (size_t i = 0; i < precision && *p1; i++) {
-                    p1 += mb_ptr2len((const char_u *)p1);
+                  char_u  *p1;
+                  size_t  i = 0;
+
+                  for (p1 = (char_u *)str_arg; *p1;
+                       p1 += mb_ptr2len(p1)) {
+                    i += (size_t)utf_ptr2cells(p1);
+                    if (i > precision) {
+                      break;
+                    }
                   }
-                  str_arg_l = precision = (size_t)(p1 - str_arg);
+                  str_arg_l = precision = (size_t)(p1 - (char_u *)str_arg);
                 }
               }
               break;

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -279,6 +279,9 @@ function Test_printf_misc()
   call assert_equal('abc ', printf('%-4s', 'abc'))
   call assert_equal('abc ', printf('%-4S', 'abc'))
 
+  call assert_equal('🐍', printf('%.2S', '🐍🐍'))
+  call assert_equal('', printf('%.1S', '🐍🐍'))
+
   call assert_equal('1%', printf('%d%%', 1))
 endfunc
 


### PR DESCRIPTION
Problem:    Multi-byte chars do not work properly with "%.*S" in printf().
Solution:   Use mb_ptr2cells(). Daniel Hahler, closes vim/vim#4989)
https://github.com/vim/vim/commit/ce0fac28977af31f1dec411d3535b4de2c3169b3