### PR TITLE
cmdline: wildmenumode() should be true with wildoptions+=pum

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -18845,8 +18845,9 @@ static void f_visualmode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  */
 static void f_wildmenumode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (wild_menu_showing)
+  if (wild_menu_showing || ((State & CMDLINE) && pum_visible())) {
     rettv->vval.v_number = 1;
+  }
 }
 
 /// "win_findbuf()" function

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -516,6 +516,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                               }|
       :sign ^                          |
     ]])
+    eq(0, funcs.wildmenumode())
 
     feed('<tab>')
     screen:expect{grid=[[
@@ -530,6 +531,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                               }|
       :sign define^                    |
     ]], popupmenu={items=wild_expected, pos=0, anchor={1, 9, 6}}}
+    eq(1, funcs.wildmenumode())
 
     feed('<left>')
     screen:expect{grid=[[
@@ -589,6 +591,7 @@ describe('ui/ext_popupmenu', function()
       :sign unplace^                   |
     ]], popupmenu={items=wild_expected, pos=5, anchor={1, 9, 6}}}
     feed('<esc>')
+    eq(0, funcs.wildmenumode())
 
     -- check positioning with multibyte char in pattern
     command("e långfile1")


### PR DESCRIPTION
otherwise mappings with `<exp> mildmenumode() ? "..." : "..."` doesn't work.