### PR TITLE
terminfo_start: keep first flushing of ui buffer

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -312,6 +312,7 @@ static void terminfo_start(UI *ui)
     uv_pipe_init(&data->write_loop, &data->output_handle.pipe, 0);
     uv_pipe_open(&data->output_handle.pipe, data->out_fd);
   }
+  flush_buf(ui);
 }
 
 static void terminfo_stop(UI *ui)


### PR DESCRIPTION
Initially done in 3626d2107 (#11074, for #11062), it was reverted then
in 445f2f409 (#11083, which added flushing later).

But it is still required here to avoid the reporting of the background
response with urxvt/kitty (`nvim -u NONE -cq`).
Apparently I've tested this not enough with 445f2f409 (probably only within tmux).