### PR TITLE
Fix redraw regression with w_p_cole in visual mode

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -108,14 +108,14 @@ void reset_cursorline(void)
 void redraw_for_cursorline(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  if ((wp->w_p_rnu || win_cursorline_standout(wp) || VIsual_active)
+  if ((wp->w_p_rnu || win_cursorline_standout(wp))
       && (wp->w_valid & VALID_CROW) == 0
       && !pum_visible()) {
     if (wp->w_p_rnu) {
       // win_line() will redraw the number column only.
       redraw_win_later(wp, VALID);
     }
-    if (win_cursorline_standout(wp) || VIsual_active) {
+    if (win_cursorline_standout(wp)) {
       if (wp->w_redr_type <= VALID && wp->w_last_cursorline != 0) {
         // "w_last_cursorline" may be outdated, worst case we redraw
         // too much.  This is optimized for moving the cursor around in

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -108,14 +108,14 @@ void reset_cursorline(void)
 void redraw_for_cursorline(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  if ((wp->w_p_rnu || win_cursorline_standout(wp))
+  if ((wp->w_p_rnu || win_cursorline_standout(wp) || VIsual_active)
       && (wp->w_valid & VALID_CROW) == 0
       && !pum_visible()) {
     if (wp->w_p_rnu) {
       // win_line() will redraw the number column only.
       redraw_win_later(wp, VALID);
     }
-    if (win_cursorline_standout(wp)) {
+    if (win_cursorline_standout(wp) || VIsual_active) {
       if (wp->w_redr_type <= VALID && wp->w_last_cursorline != 0) {
         // "w_last_cursorline" may be outdated, worst case we redraw
         // too much.  This is optimized for moving the cursor around in

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -581,7 +581,8 @@ void conceal_check_cursor_line(void)
 bool win_cursorline_standout(const win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  return wp->w_p_cul || (wp->w_p_cole > 0 && !conceal_cursor_line(wp));
+  return wp->w_p_cul
+    || (wp->w_p_cole > 0 && (VIsual_active || !conceal_cursor_line(wp)));
 }
 
 /*

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -17,6 +17,7 @@ describe('Screen', function()
       [3] = {reverse = true},
       [4] = {bold = true},
       [5] = {background = Screen.colors.Yellow},
+      [6] = {background = Screen.colors.LightGrey},
     } )
   end)
 
@@ -822,6 +823,51 @@ describe('Screen', function()
                                                                |
         ]])
       end)
+    end)
+
+    it('redraws properly with concealcursor in visual mode', function()
+      command('set concealcursor=v conceallevel=2')
+
+      feed('10Ofoo barf bar barf eggs<esc>')
+      feed(':3<cr>o    a<Esc>ggV')
+      screen:expect{grid=[[
+        ^f{6:oo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+            a                                                |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        {4:-- VISUAL LINE --}                                    |
+      ]]}
+      feed('jjjjjjjjjjjjjjj')
+      screen:expect{grid=[[
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        ^f{6:oo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {4:-- VISUAL LINE --}                                    |
+      ]]}
+      feed('kkkkkkkkkkkkkkk')
+      screen:expect{grid=[[
+        ^f{6:oo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+            a                                                |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        {4:-- VISUAL LINE --}                                    |
+      ]]}
     end)
   end)
 end)


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/11024, regressed in 23c71d51.

Taken out of https://github.com/neovim/neovim/pull/11101.

This could use a separate state/flag (like before 23c71d5182) [1], but
should hopefully not make a difference performance-wise?!
(it might however check at least if it is not the same line there?)

1: https://github.com/neovim/neovim/commit/23c71d5182a5e717c3a1852d9d3c90e81b4735fd#diff-8c3658f9d8b5f84bfb51b708fd7b9760L1249-R1244

redraw_for_cursorline: check for VIsual_active

See https://github.com/neovim/neovim/pull/11101#discussion_r329345383 for what could be done here.