### PR TITLE
ci: coverage for Lua (without Windows, using luacov)

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,19 @@
+-- Configuration file for LuaCov
+
+local source = require("lfs").currentdir()
+
+local function pesc(s)
+  assert(type(s) == 'string', s)
+  return s:gsub('[%(%)%.%%%+%-%*%?%[%]%^%$]', '%%%1')
+end
+
+return {
+  include = {
+    -- Absolute paths (starting with source dir, not hidden (i.e. .deps)).
+    pesc(source) .. "[/\\][^.].+",
+    -- Relative (non-hidden) paths.
+    '^[^/\\.]',
+  },
+}
+
+-- vim: ft=lua tw=80 sw=2 et

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,8 @@ jobs:
         - GCOV=gcov-9
         - CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_GCOV=ON"
         - GCOV_ERROR_FILE="/tmp/libgcov-errors.log"
+        - USE_LUACOV=1
+        - BUSTED_ARGS="--coverage"
         - *common-job-env
       addons:
         apt:

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -35,5 +35,10 @@ fi
 # Compile dependencies.
 build_deps
 
+# Install luacov for Lua coverage.
+if [[ "$USE_LUACOV" == 1 ]]; then
+  "${DEPS_BUILD_DIR}/usr/bin/luarocks" install luacov
+fi
+
 rm -rf "${LOG_DIR}"
 mkdir -p "${LOG_DIR}"

--- a/ci/common/submit_coverage.sh
+++ b/ci/common/submit_coverage.sh
@@ -43,3 +43,11 @@ fi
 # Cleanup always, especially collected data.
 find . \( -name '*.gcov' -o -name '*.gcda' \) -ls -delete | wc -l
 rm -f coverage.xml
+
+# Upload Lua coverage  (generated manually on AppVeyor/Windows).
+if [ "$USE_LUACOV" = 1 ] && [ "$1" != "oldtest" ]; then
+  if ! "$codecov_sh" -f luacov.report.out -X gcov -X fix -Z -F "lua,${codecov_flags}"; then
+    echo "codecov upload failed."
+  fi
+  rm luacov.stats.out
+fi


### PR DESCRIPTION
Pulled out of https://github.com/neovim/neovim/pull/10426.
Windows is not working there (likely a Codecov issue), and it is good to have a base for when adding it.