### PR TITLE
shell: improve displaying of pulse

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -423,10 +423,11 @@ static bool out_data_decide_throttle(size_t size)
   pulse_msg[1] = (tick > 1) ? '.' : ' ';
   pulse_msg[2] = (tick > 2) ? '.' : ' ';
   if (visit == 1) {
-    msg_putchar('\n');
+    msg_puts("[...]\n");
   }
   msg_putchar('\r');  // put cursor at start of line
   msg_puts(pulse_msg);
+  msg_putchar('\r');
   ui_flush();
   return true;
 }


### PR DESCRIPTION
- give clear message about output being throttled (visible in
  scrollback), instead of just an empty line
- only iterate over ".", "..", and "..." - this avoids having just an
  empty line there without any output for a while
- go to beginning of line after displaying the pulse, so that following
  output is displayed over it