### PR TITLE
[release-0.4] backports

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -189,7 +189,7 @@ paste = (function()
     if mode == 'c' and not got_line1 then  -- cmdline-mode: paste only 1 line.
       got_line1 = (#lines > 1)
       vim.api.nvim_set_option('paste', true)  -- For nvim_input().
-      local line1, _ = string.gsub(lines[1], '[\r\n\012\027]', ' ')  -- Scrub.
+      local line1 = lines[1]:gsub('<', '<lt>'):gsub('[\r\n\012\027]', ' ')  -- Scrub.
       vim.api.nvim_input(line1)
       vim.api.nvim_set_option('paste', false)
     elseif mode ~= 'c' then  -- Else: discard remaining cmdline-mode chunks.

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -135,7 +135,16 @@ int os_setenv(const char *name, const char *value, int overwrite)
   }
 #endif
   uv_mutex_lock(&mutex);
-  int r = uv_os_setenv(name, value);
+  int r;
+#ifdef WIN32
+  // libintl uses getenv() for LC_ALL/LANG/etc., so we must use _putenv_s().
+  if (striequal(name, "LC_ALL") || striequal(name, "LANGUAGE")
+      || striequal(name, "LANG") || striequal(name, "LC_MESSAGES")) {
+    r = _putenv_s(name, value);  // NOLINT
+    assert(r == 0);
+  }
+#endif
+  r = uv_os_setenv(name, value);
   assert(r != UV_EINVAL);
   // Destroy the old map item. Do this AFTER uv_os_setenv(), because `value`
   // could be a previous os_getenv() result.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -871,7 +871,7 @@ static void win_update(win_T *wp)
         if (wp->w_lines[0].wl_lnum != wp->w_topline)
           i += diff_check_fill(wp, wp->w_lines[0].wl_lnum)
                - wp->w_old_topfill;
-        if (i < wp->w_grid.Rows - 2) {  // less than a screen off
+        if (i != 0 && i < wp->w_grid.Rows - 2) {  // less than a screen off
           // Try to insert the correct number of lines.
           // If not the last window, delete the lines at the bottom.
           // win_ins_lines may fail when the terminal can't do it.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4007,7 +4007,7 @@ win_line (
             break;
           }
 
-          ++vcol;
+          vcol += cells;
         }
       }
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -578,6 +578,23 @@ describe('TUI', function()
     ]])
   end)
 
+  it('paste: less-than sign in cmdline  #11088', function()
+    local expected = '<'
+    feed_data(':')
+    wait_for_mode('c')
+    -- "bracketed paste"
+    feed_data('\027[200~'..expected..'\027[201~')
+    screen:expect{grid=[[
+                                                        |
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {4:~                                                 }|
+      {5:[No Name]                                         }|
+      :<{1: }                                               |
+      {3:-- TERMINAL --}                                    |
+    ]]}
+  end)
+
   it('paste: big burst of input', function()
     feed_data(':set ruler\n')
     local t = {}

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -31,6 +31,9 @@ describe('Buffer highlighting', function()
       [14] = {background = Screen.colors.Gray90},
       [15] = {background = Screen.colors.Gray90, bold = true, foreground = Screen.colors.Brown},
       [16] = {foreground = Screen.colors.Magenta, background = Screen.colors.Gray90},
+      [17] = {foreground = Screen.colors.Magenta, background = Screen.colors.LightRed},
+      [18] = {background = Screen.colors.LightRed},
+      [19] = {foreground = Screen.colors.Blue1, background = Screen.colors.LightRed},
     })
   end)
 
@@ -515,6 +518,32 @@ describe('Buffer highlighting', function()
         {1:~                                       }|
                                                 |
       ]])
+    end)
+
+    it('works with color column', function()
+      eq(-1, set_virtual_text(-1, 3, {{"暗x事", "Comment"}}, {}))
+      screen:expect{grid=[[
+        ^1 + 2 {3:=}{2: 3}                               |
+        3 + {11:ERROR:} invalid syntax               |
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5|
+        , 5, 5, 5, 5, 5, 5,  Lorem ipsum dolor s|
+        x = 4 {12:暗x事}                             |
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]]}
+
+      command("set colorcolumn=9")
+      screen:expect{grid=[[
+        ^1 + 2 {3:=}{2: }{17:3}                               |
+        3 + {11:ERROR:} invalid syntax               |
+        5, 5, 5,{18: }5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5|
+        , 5, 5, 5, 5, 5, 5,  Lorem ipsum dolor s|
+        x = 4 {12:暗}{19:x}{12:事}                             |
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]]}
     end)
   end)
 

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -3,6 +3,8 @@ local Screen = require('test.functional.ui.screen')
 
 local feed = helpers.feed
 local clear = helpers.clear
+local command = helpers.command
+local insert = helpers.insert
 local write_file = helpers.write_file
 
 describe('Diff mode screen', function()
@@ -956,4 +958,76 @@ int main(int argc, char **argv)
       ]])
     end)
   end)
+end)
+
+it('win_update redraws lines properly', function()
+  local screen
+  clear()
+  screen = Screen.new(30, 10)
+  screen:attach()
+  screen:set_default_attr_ids({
+    [1] = {bold = true, foreground = Screen.colors.Blue1},
+    [2] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+    [3] = {background = Screen.colors.Red, foreground = Screen.colors.Grey100, special = Screen.colors.Yellow},
+    [4] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    [5] = {special = Screen.colors.Yellow},
+    [6] = {special = Screen.colors.Yellow, bold = true, foreground = Screen.colors.SeaGreen4},
+    [7] = {foreground = Screen.colors.Grey0, background = Screen.colors.Grey100},
+    [8] = {foreground = Screen.colors.Gray90, background = Screen.colors.Grey100},
+    [9] = {foreground = tonumber('0x00000c'), background = Screen.colors.Grey100},
+    [10] = {background = Screen.colors.Grey100, bold = true, foreground = tonumber('0xe5e5ff')},
+    [11] = {background = Screen.colors.Grey100, bold = true, foreground = tonumber('0x2b8452')},
+    [12] = {bold = true, reverse = true},
+    [13] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
+    [14] = {reverse = true},
+    [15] = {background = Screen.colors.LightBlue},
+    [16] = {background = Screen.colors.LightCyan1, bold = true, foreground = Screen.colors.Blue1},
+    [17] = {bold = true, background = Screen.colors.Red},
+    [18] = {background = Screen.colors.LightMagenta},
+  })
+
+  insert([[
+  1
+
+
+  2
+  1a
+  ]])
+  command("vnew")
+  insert([[
+  2
+  2a
+  2b
+  ]])
+  command("windo diffthis")
+  command("windo 1")
+  screen:expect{grid=[[
+    {13:  }{16:-------}{14:│}{13:  }{15:^1                 }|
+    {13:  }{16:-------}{14:│}{13:  }{15:                  }|
+    {13:  }{16:-------}{14:│}{13:  }{15:                  }|
+    {13:  }2      {14:│}{13:  }2                 |
+    {13:  }{17:2}{18:a     }{14:│}{13:  }{17:1}{18:a                }|
+    {13:  }{15:2b     }{14:│}{13:  }{16:------------------}|
+    {13:  }       {14:│}{13:  }                  |
+    {1:~        }{14:│}{1:~                   }|
+    {14:<me] [+]  }{12:[No Name] [+]       }|
+                                  |
+  ]]}
+  feed('<C-e>')
+  feed('<C-e>')
+  feed('<C-y>')
+  feed('<C-y>')
+  feed('<C-y>')
+  screen:expect{grid=[[
+    {13:  }{16:-------}{14:│}{13:  }{15:1                 }|
+    {13:  }{16:-------}{14:│}{13:  }{15:                  }|
+    {13:  }{16:-------}{14:│}{13:  }{15:^                  }|
+    {13:  }2      {14:│}{13:  }2                 |
+    {13:  }{17:2}{18:a     }{14:│}{13:  }{17:1}{18:a                }|
+    {13:  }{15:2b     }{14:│}{13:  }{16:------------------}|
+    {13:  }       {14:│}{13:  }                  |
+    {1:~        }{14:│}{1:~                   }|
+    {14:<me] [+]  }{12:[No Name] [+]       }|
+                                  |
+  ]]}
 end)


### PR DESCRIPTION
This adds the backports from the 0.4.3 milestone: https://github.com/neovim/neovim/milestone/22?closed=1

I've added a new label "maintenance:backported" to keep track of them.