### PR TITLE
Fix flaky test: tui_spec: increase timeout

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -939,7 +939,7 @@ describe('TUI FocusGained/FocusLost', function()
                                                         |
       gained                                            |
       {3:-- TERMINAL --}                                    |
-    ]], timeout=(3 * screen.timeout)}
+    ]], timeout=(4 * screen.timeout)}
 
     feed_data('\027[O')
     screen:expect([[


### PR DESCRIPTION
Meant to fix:

    [  ERROR   ] test/functional/terminal/tui_spec.lua @ 925: TUI FocusGained/FocusLost in terminal-mode
    test/functional/ui/screen.lua:587: Row 6 did not match.
    Expected:
      |{1:r}eady $                                           |
      |[Process exited 0]                                |
      |                                                  |
      |                                                  |
      |                                                  |
      |*gained                                            |
      |{3:-- TERMINAL --}                                    |
    Actual:
      |{1:r}eady $                                           |
      |[Process exited 0]                                |
      |                                                  |
      |                                                  |
      |                                                  |
      |*:terminal                                         |
      |{3:-- TERMINAL --}                                    |

    To print the expect() call that would assert the current screen state, use
    screen:snapshot_util(). In case of non-deterministic failures, use
    screen:redraw_debug() to show all intermediate screen states.

    stack traceback:
    	test/functional/ui/screen.lua:587: in function '_wait'
    	test/functional/ui/screen.lua:370: in function 'expect'
    	test/functional/terminal/tui_spec.lua:934: in function <test/functional/terminal/tui_spec.lua:925>

I've thought about adding this, but it might not be really relevant, and
slows down the tests a bit (and a warning "warning: Screen test
succeeded immediately" with another test):

```diff
diff --git i/test/functional/terminal/tui_spec.lua w/test/functional/terminal/tui_spec.lua
index ada073c4e..4bc2ab4e0 100644
--- i/test/functional/terminal/tui_spec.lua
+++ w/test/functional/terminal/tui_spec.lua
@@ -818,6 +818,11 @@ describe('TUI FocusGained/FocusLost', function()
       ..'", "-u", "NONE", "-i", "NONE", "--cmd", "set noswapfile noshowcmd noruler"]')
     feed_data(":autocmd FocusGained * echo 'gained'\n")
     feed_data(":autocmd FocusLost * echo 'lost'\n")
+    -- Wait for autocommand to be registered.
+    retry(nil, nil, function()
+      feed_data(":autocmd FocusLost\n")
+      screen:expect{any="         echo 'lost'"}
+    end)
     feed_data("\034\016")  -- CTRL-\ CTRL-N
   end)
```