### PR TITLE
deps: LDFLAGS=-static

### DIFF
--- a/third-party/cmake/BuildLibtermkey.cmake
+++ b/third-party/cmake/BuildLibtermkey.cmake
@@ -48,6 +48,7 @@ ExternalProject_Add(libtermkey
                               PREFIX=${DEPS_INSTALL_DIR}
                               PKG_CONFIG_PATH=${DEPS_LIB_DIR}/pkgconfig
                               CFLAGS=-fPIC
+                              LDFLAGS+=-static
                               ${DEFAULT_MAKE_CFLAGS}
                               install)
 endif()

--- a/third-party/cmake/BuildLibvterm.cmake
+++ b/third-party/cmake/BuildLibvterm.cmake
@@ -58,6 +58,7 @@ else()
   set(LIBVTERM_INSTALL_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
                                            PREFIX=${DEPS_INSTALL_DIR}
                                            CFLAGS=-fPIC
+                                           LDFLAGS+=-static
                                            ${DEFAULT_MAKE_CFLAGS}
                                            install)
 endif()

--- a/third-party/cmake/BuildUnibilium.cmake
+++ b/third-party/cmake/BuildUnibilium.cmake
@@ -40,6 +40,7 @@ else()
     BUILD_COMMAND ${MAKE_PRG} CC=${DEPS_C_COMPILER}
                               PREFIX=${DEPS_INSTALL_DIR}
                               CFLAGS=-fPIC
+                              LDFLAGS+=-static
     INSTALL_COMMAND ${MAKE_PRG} PREFIX=${DEPS_INSTALL_DIR} install)
 endif()
 


### PR DESCRIPTION
For some reason `libvterm.a` is not built for IRC user `_DanN_`.

This might fix it there.

I wonder if it is disabled to be done by default there.

The following output might be relevant:
```
% libtool --version
% libtool --features
% libtool --config | grep -v '^#' | grep -v '^$'
```

Interesting:

- `_DanN` had `old_library=''` in `.deps/usr/lib/libvterm.la`, while I have `old_library='libvterm.a'` there.  The comment for it says "# The name of the static archive.".

Output from `make -C .deps/build/src/libvterm CC=/usr/local/bin/cc PREFIX=/path/to/deps/.deps/usr CFLAGS=-fPIC CFLAGS+=-Og CFLAGS+=-g install VERBOSE=1` from him: https://pastebin.com/raw/L4tbeCHK
Does not mention `libvterm.a` therein, as for me.

TODO:

- use (new) DEFAULT_MAKE_LDFLAGS to use this with all Makefile-based deps?