### PR TITLE
tests: unit: NVIM_TEST_TRACE_LEVEL: default to 0

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -315,11 +315,12 @@ Number; !must be defined to function properly):
 - `NVIM_TEST_RUN_TESTTEST` (U) (1): allows running
   `test/unit/testtest_spec.lua` used to check how testing infrastructure works.
 
-- `NVIM_TEST_TRACE_LEVEL` (U) (N): specifies unit tests tracing level: `0`
-  disables tracing (the fastest, but you get no data if tests crash and there
-  was no core dump generated), `1` or empty/undefined leaves only C function
-  cals and returns in the trace (faster then recording everything), `2` records
-  all function calls, returns and lua source lines exuecuted.
+- `NVIM_TEST_TRACE_LEVEL` (U) (N): specifies unit tests tracing level:
+  - `0` disables tracing (the fastest, but you get no data if tests crash and
+    there no core dump was generated),
+  - `1` leaves only C function calls and returns in the trace (faster than
+    recording everything),
+  - `2` records all function calls, returns and executed Lua source lines.
 
 - `NVIM_TEST_TRACE_ON_ERROR` (U) (1): makes unit tests yield trace on error in
   addition to regular error message.

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -545,7 +545,7 @@ local tracehelp = dedent([[
 local function child_sethook(wr)
   local trace_level = os.getenv('NVIM_TEST_TRACE_LEVEL')
   if not trace_level or trace_level == '' then
-    trace_level = 1
+    trace_level = 0
   else
     trace_level = tonumber(trace_level)
   end
@@ -708,7 +708,7 @@ local function check_child_err(rd)
     local eres = sc.read(rd, 2)
     if eres ~= '$\n' then
       if #trace == 0 then
-        err = '\nTest crashed, no trace available\n'
+        err = '\nTest crashed, no trace available (check NVIM_TEST_TRACE_LEVEL)\n'
       else
         err = '\nTest crashed, trace:\n' .. tracehelp
         for i = 1, #trace do


### PR DESCRIPTION
Traces are not useful normally (unless debugging/fixing tests), but only add
overhead.  Disable them by default.

Improves `make unittest` from 2:40m to 0:50m for me.