### PR TITLE
tui: fix handling of bg response after suspend

### DIFF
--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -12,7 +12,7 @@ typedef struct term_input {
   // Phases: -1=all 0=disabled 1=first-chunk 2=continue 3=last-chunk
   int8_t paste;
   bool waiting;
-  bool waiting_for_bg_response;
+  int8_t waiting_for_bg_response;
   TermKey *tk;
 #if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
   TermKey_Terminfo_Getstr_Hook *tk_ti_hook_fn;  ///< libtermkey terminfo hook

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -296,7 +296,7 @@ static void terminfo_start(UI *ui)
   unibi_out(ui, unibi_keypad_xmit);
   unibi_out(ui, unibi_clear_screen);
   // Ask the terminal to send us the background color.
-  data->input.waiting_for_bg_response = true;
+  data->input.waiting_for_bg_response = 5;
   unibi_out_ext(ui, data->unibi_ext.get_bg);
   // Enable bracketed paste
   unibi_out_ext(ui, data->unibi_ext.enable_bracketed_paste);
@@ -366,11 +366,6 @@ static void tui_terminal_after_startup(UI *ui)
   // 2.3 bug(?) which caused slow drawing during startup.  #7649
   unibi_out_ext(ui, data->unibi_ext.enable_focus_reporting);
   flush_buf(ui);
-
-  if (data->input.waiting_for_bg_response) {
-    DLOG("did not get a response for terminal background query");
-    data->input.waiting_for_bg_response = false;
-  }
 }
 
 static void tui_terminal_stop(UI *ui)

--- a/test/unit/tui_spec.lua
+++ b/test/unit/tui_spec.lua
@@ -16,7 +16,7 @@ itp('handle_background_color', function()
   local events = globals.main_loop.thread_events
 
   -- Short-circuit when not waiting for response.
-  term_input.waiting_for_bg_response = false
+  term_input.waiting_for_bg_response = 0
   eq(false, handle_background_color(term_input))
 
   local capacity = 100
@@ -27,9 +27,9 @@ itp('handle_background_color', function()
     local term_response = '\027]11;'..colorspace..':'..color..'\007'
     rbuffer.rbuffer_write(rbuf, to_cstr(term_response), #term_response)
 
-    term_input.waiting_for_bg_response = true
+    term_input.waiting_for_bg_response = 1
     eq(true, handle_background_color(term_input))
-    eq(false, term_input.waiting_for_bg_response)
+    eq(0, term_input.waiting_for_bg_response)
     eq(1, multiqueue.multiqueue_size(events))
 
     local event = multiqueue.multiqueue_get(events)
@@ -101,10 +101,9 @@ itp('handle_background_color', function()
   local term_response = '\027]11;rgba:f/f/f/f'  -- missing '\007
   rbuffer.rbuffer_write(rbuf, to_cstr(term_response), #term_response)
 
-  term_input.waiting_for_bg_response = true
-  eq(true, term_input.waiting_for_bg_response)
+  term_input.waiting_for_bg_response = 1
   eq(false, handle_background_color(term_input))
-  eq(false, term_input.waiting_for_bg_response)
+  eq(0, term_input.waiting_for_bg_response)
 
   eq(0, multiqueue.multiqueue_size(events))
   eq(0, rbuf.size)
@@ -114,10 +113,9 @@ itp('handle_background_color', function()
   term_response = '123\027]11;rgba:f/f/f/f\007456'
   rbuffer.rbuffer_write(rbuf, to_cstr(term_response), #term_response)
 
-  term_input.waiting_for_bg_response = true
-  eq(true, term_input.waiting_for_bg_response)
+  term_input.waiting_for_bg_response = 3
   eq(false, handle_background_color(term_input))
-  eq(true, term_input.waiting_for_bg_response)
+  eq(2, term_input.waiting_for_bg_response)
 
   eq(0, multiqueue.multiqueue_size(events))
   eq(#term_response, rbuf.size)
@@ -128,10 +126,9 @@ itp('handle_background_color', function()
   term_response = '\027]11;rgba:f/f/f/f\007456'
   rbuffer.rbuffer_write(rbuf, to_cstr(term_response), #term_response)
 
-  term_input.waiting_for_bg_response = true
-  eq(true, term_input.waiting_for_bg_response)
+  term_input.waiting_for_bg_response = 1
   eq(true, handle_background_color(term_input))
-  eq(false, term_input.waiting_for_bg_response)
+  eq(0, term_input.waiting_for_bg_response)
 
   eq(1, multiqueue.multiqueue_size(events))
   eq(3, rbuf.size)


### PR DESCRIPTION
`tui_terminal_after_startup` gets called right after resuming from
suspending (via `Ctrl-z`) already (not delayed as with the startup
itself), and would set `waiting_for_bg_response` to false then directly.
This results in the terminal response not being processed then anymore,
and leaking into Neovim itself.

This changes it to try 5 times always, which means that it typically
would stop after a few characters of input from the user typically, e.g.
with tmux, which does not send a reply.

While it might be better to have something based on the time (e.g. only
wait for max 1s), this appears to be easier to do.

Fixes regression in 8a4ae3d.