### PR TITLE
[release-0.4] backports

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -578,10 +578,13 @@ void conceal_check_cursor_line(void)
 ///
 /// If true, both old and new cursorline will need
 /// need to be redrawn when moving cursor within windows.
+/// TODO(bfredl): VIsual_active shouldn't be needed, but is used to fix a glitch
+///               caused by scrolling.
 bool win_cursorline_standout(const win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  return wp->w_p_cul || (wp->w_p_cole > 0 && !conceal_cursor_line(wp));
+  return wp->w_p_cul
+    || (wp->w_p_cole > 0 && (VIsual_active || !conceal_cursor_line(wp)));
 }
 
 /*

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -93,7 +93,7 @@ typedef struct {
   int out_fd;
   bool scroll_region_is_full_screen;
   bool can_change_scroll_region;
-  bool can_set_lr_margin;
+  bool can_set_lr_margin;  // smglr
   bool can_set_left_right_margin;
   bool can_scroll;
   bool can_erase_chars;
@@ -1598,6 +1598,12 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
       unibi_set_if_empty(ut, unibi_set_lr_margin, "\x1b[%i%p1%d;%p2%ds");
       unibi_set_if_empty(ut, unibi_set_left_margin_parm, "\x1b[%i%p1%ds");
       unibi_set_if_empty(ut, unibi_set_right_margin_parm, "\x1b[%i;%p2%ds");
+    } else {
+      // Fix things advertised via TERM=xterm, for non-xterm.
+      if (unibi_get_str(ut, unibi_set_lr_margin)) {
+        ILOG("Disabling smglr with TERM=xterm for non-xterm.");
+        unibi_set_str(ut, unibi_set_lr_margin, NULL);
+      }
     }
 
 #ifdef WIN32

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -17,6 +17,7 @@ describe('Screen', function()
       [3] = {reverse = true},
       [4] = {bold = true},
       [5] = {background = Screen.colors.Yellow},
+      [6] = {background = Screen.colors.LightGrey},
     } )
   end)
 
@@ -822,6 +823,51 @@ describe('Screen', function()
                                                                |
         ]])
       end)
+    end)
+
+    it('redraws properly with concealcursor in visual mode', function()
+      command('set concealcursor=v conceallevel=2')
+
+      feed('10Ofoo barf bar barf eggs<esc>')
+      feed(':3<cr>o    a<Esc>ggV')
+      screen:expect{grid=[[
+        ^f{6:oo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+            a                                                |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        {4:-- VISUAL LINE --}                                    |
+      ]]}
+      feed(string.rep('j', 15))
+      screen:expect{grid=[[
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {6:foo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        ^f{6:oo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        {4:-- VISUAL LINE --}                                    |
+      ]]}
+      feed(string.rep('k', 15))
+      screen:expect{grid=[[
+        ^f{6:oo }{1:b}{6: bar }{1:b}{6: eggs}                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+            a                                                |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |
+        {4:-- VISUAL LINE --}                                    |
+      ]]}
     end)
   end)
 end)


### PR DESCRIPTION
The two remaining ones: https://github.com/neovim/neovim/pulls?q=is%3Apr+milestone%3A0.4.3+is%3Aclosed+-label%3Amaintenance%3Abackported

Should we maybe push those to the release-0.4 branch directly?