### PR TITLE
vim-patch:8.0.1455,8.1.{2115,2361}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5166,6 +5166,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	It is allowed to give an argument to the command, e.g.  "csh -f".
 	See |option-backslash| about including spaces and backslashes.
 	Environment variables are expanded |:set_env|.
+
 	If the name of the shell contains a space, you might need to enclose
 	it in quotes.  Example: >
 		:set shell=\"c:\program\ files\unix\sh.exe\"\ -f

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1182,6 +1182,7 @@ static void do_filter(
   char_u      *cmd_buf;
   buf_T       *old_curbuf = curbuf;
   int shell_flags = 0;
+  const int stmp = p_stmp;
 
   if (*cmd == NUL)          /* no filter command */
     return;
@@ -1210,16 +1211,16 @@ static void do_filter(
   if (do_out)
     shell_flags |= kShellOptDoOut;
 
-  if (!do_in && do_out && !p_stmp) {
+  if (!do_in && do_out && !stmp) {
     // Use a pipe to fetch stdout of the command, do not use a temp file.
     shell_flags |= kShellOptRead;
     curwin->w_cursor.lnum = line2;
-  } else if (do_in && !do_out && !p_stmp) {
+  } else if (do_in && !do_out && !stmp) {
     // Use a pipe to write stdin of the command, do not use a temp file.
     shell_flags |= kShellOptWrite;
     curbuf->b_op_start.lnum = line1;
     curbuf->b_op_end.lnum = line2;
-  } else if (do_in && do_out && !p_stmp) {
+  } else if (do_in && do_out && !stmp) {
     // Use a pipe to write stdin and fetch stdout of the command, do not
     // use a temp file.
     shell_flags |= kShellOptRead | kShellOptWrite;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -652,7 +652,14 @@ void set_init_1(bool clean_arg)
   {
     const char *shell = os_getenv("SHELL");
     if (shell != NULL) {
-      set_string_default("sh", (char *) shell, false);
+      if (vim_strchr((const char_u *)shell, ' ') != NULL) {
+        const size_t len = strlen(shell) + 3;  // two quotes and a trailing NUL
+        char *const cmd = xmalloc(len);
+        snprintf(cmd, len, "\"%s\"", shell);
+        set_string_default("sh", cmd, true);
+      } else {
+        set_string_default("sh", (char *)shell, false);
+      }
     }
   }
 
@@ -987,10 +994,9 @@ static void set_string_default(const char *name, char *val, bool allocated)
       xfree(options[opt_idx].def_val[VI_DEFAULT]);
     }
 
-    options[opt_idx].def_val[VI_DEFAULT] = (char_u *) (
-        allocated
-        ? (char_u *) val
-        : (char_u *) xstrdup(val));
+    options[opt_idx].def_val[VI_DEFAULT] = allocated
+        ? (char_u *)val
+        : (char_u *)xstrdup(val);
     options[opt_idx].flags |= P_DEF_ALLOCED;
   }
 }

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -516,7 +516,7 @@ func Test_termguicolors()
   if !exists('+termguicolors')
     return
   endif
-  if has('vtp') && !has('vcon')
+  if has('vtp') && !has('vcon') && !has('gui_running')
     " Win32: 'guicolors' doesn't work without virtual console.
     call assert_fails('set termguicolors', 'E954:')
     return

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -581,6 +581,27 @@ func Test_read_stdin()
   call delete('Xtestout')
 endfunc
 
+func Test_set_shell()
+  let after =<< trim [CODE]
+    call writefile([&shell], "Xtestout")
+    quit!
+  [CODE]
+
+  if has('win32')
+    let $SHELL = 'C:\with space\cmd.exe'
+    let expected = '"C:\with space\cmd.exe"'
+  else
+    let $SHELL = '/bin/with space/sh'
+    let expected = '"/bin/with space/sh"'
+  endif
+
+  if RunVimPiped([], after, '', '')
+    let lines = readfile('Xtestout')
+    call assert_equal(expected, lines[0])
+  endif
+  call delete('Xtestout')
+endfunc
+
 func Test_progpath()
   " Tests normally run with "./vim" or "../vim", these must have been expanded
   " to a full path.


### PR DESCRIPTION
I don't understand why this patch necessary. The test doesn't check for regressions, especially for Windows shells.