### PR TITLE
Makefile: use `$TMPDIR` below `src/nvim/testdir`

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -11,7 +11,7 @@ ROOT := ../../..
 
 export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
-export TMPDIR := $(abspath ../../../Xtest-tmpdir)
+export TMPDIR := $(abspath Xtest-tmpdir)
 
 SCRIPTS_DEFAULT = \
 	test42.out             \


### PR DESCRIPTION
This makes it ignored/cleaned automatically.
It was made absolute in 8821579ba, but to the root back then.

Taken out of https://github.com/neovim/neovim/pull/10650, where it appears to cause issues on AppVeyor.