### PR TITLE
Fix shada typo in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Features
   JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket, Ruby, Rust
 - Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
 - Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)
-- [Shared data (shada)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances
+- [Shared data (ShaDa)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances
 - [XDG base directories](https://github.com/neovim/neovim/pull/3470) support
 - Compatible with most Vim plugins, including Ruby and Python plugins
 

--- a/man/nvim.1
+++ b/man/nvim.1
@@ -197,7 +197,7 @@ If
 .Ar shada
 is
 .Cm NONE ,
-do not read or write a ShaDa file.
+do not read or write a shada file.
 .Ic ":help shada"
 .It Fl -noplugin
 Skip loading plugins.
@@ -348,7 +348,7 @@ Defaults to
 Like
 .Ev XDG_CONFIG_HOME ,
 but used to store data not generally edited by the user,
-namely swap, backup, and ShaDa files.
+namely swap, backup, and shada files.
 Defaults to
 .Pa ~/.local/share .
 :help xdg

--- a/man/nvim.1
+++ b/man/nvim.1
@@ -188,23 +188,23 @@ is
 .Cm NONE ,
 loading plugins is also skipped.
 .Ic ":help initialization"
-.It Fl i Ar shada
+.It Fl i Ar ShaDa
 Use
-.Ar shada
+.Ar ShaDa
 instead of the default
 .Pa ~/.local/share/nvim/shada/main.shada .
 If
-.Ar shada
+.Ar ShaDa
 is
 .Cm NONE ,
-do not read or write a shada file.
+do not read or write a ShaDa file.
 .Ic ":help shada"
 .It Fl -noplugin
 Skip loading plugins.
 Implied by
 .Cm -u NONE .
 .It Fl -clean
-Skip loading plugins and shada (viminfo) file.
+Skip loading plugins and ShaDa (viminfo) file.
 .It Fl o Ns Op Ar N
 Open
 .Ar N
@@ -348,7 +348,7 @@ Defaults to
 Like
 .Ev XDG_CONFIG_HOME ,
 but used to store data not generally edited by the user,
-namely swap, backup, and shada files.
+namely swap, backup, and ShaDa files.
 Defaults to
 .Pa ~/.local/share .
 :help xdg

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -44,7 +44,7 @@ function! s:check_config() abort
   let shadafile = (empty(&shadafile) || &shadafile ==# 'NONE') ? stdpath('data').'/shada/main.shada' : &shadafile
   if !empty(shadafile) && (!filereadable(shadafile) || !filewritable(shadafile))
     let ok = v:false
-    call health#report_error('shada file is not '.(filereadable(shadafile) ? 'writeable' : 'readable').":\n".shadafile)
+    call health#report_error('ShaDa file is not '.(filereadable(shadafile) ? 'writeable' : 'readable').":\n".shadafile)
   endif
 
   if ok

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -287,8 +287,8 @@ Name			triggered by ~
 |TermResponse|		after the terminal response to t_RV is received
 |QuitPre|		when using `:quit`, before deciding whether to exit
 |ExitPre|		when using a command that may make Vim exit
-|VimLeavePre|		before exiting Nvim, before writing the shada file
-|VimLeave|		before exiting Nvim, after writing the shada file
+|VimLeavePre|		before exiting Nvim, before writing the ShaDa file
+|VimLeave|		before exiting Nvim, after writing the ShaDa file
 |VimResume|		after Nvim is resumed
 |VimSuspend|		before Nvim is suspended
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -588,7 +588,7 @@ function.
 
 When the '!' flag is included in the 'shada' option, global variables that
 start with an uppercase letter, and don't contain a lowercase letter, are
-stored in the shada file |shada-file|.
+stored in the ShaDa file |shada-file|.
 
 When the 'sessionoptions' option contains "global", global variables that
 start with an uppercase letter and contain at least one lowercase letter are

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -818,7 +818,7 @@ for a moment.  When the 'shada' option is not empty, uppercase marks are
 kept in the .shada file.  See |shada-file-marks|.
 
 Numbered marks '0 to '9 are quite different.  They can not be set directly.
-They are only present when using a shada file |shada-file|.  Basically '0
+They are only present when using a ShaDa file |shada-file|.  Basically '0
 is the location of the cursor when you last exited Vim, '1 the last but one
 time, etc.  Use the "r" flag in 'shada' to specify files for which no
 Numbered mark should be stored.  See |shada-file-marks|.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -795,7 +795,7 @@ struct file_buffer {
 
   Terminal *terminal;           // Terminal instance associated with the buffer
 
-  dict_T *additional_data;      // Additional data from shada file if any.
+  dict_T *additional_data;      // Additional data from ShaDa file if any.
 
   int b_mapped_ctrl_c;          // modes where CTRL-C is mapped
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1099,7 +1099,7 @@ static void command_line_scan(mparm_T *parmp)
             break;
           }
 
-          case 'i': {  // "-i {shada}" use for shada
+          case 'i': {  // "-i {shada}" use for ShaDa
             set_option_value("shadafile", 0L, argv[0], 0);
             break;
           }
@@ -1976,7 +1976,7 @@ static void usage(void)
   mch_msg(_("  -e, -E                Ex mode\n"));
   mch_msg(_("  -es, -Es              Silent (batch) mode\n"));
   mch_msg(_("  -h, --help            Print this help message\n"));
-  mch_msg(_("  -i <shada>            Use this shada file\n"));
+  mch_msg(_("  -i <shada>            Use this ShaDa file\n"));
   mch_msg(_("  -m                    Modifications (writing files) not allowed\n"));
   mch_msg(_("  -M                    Modifications in text not allowed\n"));
   mch_msg(_("  -n                    No swap file, use memory only\n"));

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -45,7 +45,7 @@
  * If a named file mark's fnum is non-zero, it is for an existing buffer,
  * otherwise it is from .shada and namedfm[n].fname is the file name.
  * There are marks 'A - 'Z (set by user) and '0 to '9 (set when writing
- * shada).
+ * ShaDa).
  */
 
 /// Global marks (marks with file number or name)

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -3185,8 +3185,8 @@ msgstr "  -es, -Es              Мовчазний (пакетний) режим
 msgid "  -h, --help            Print this help message\n"
 msgstr "  -h, --help            Надрукувати це повідомлення\n"
 
-msgid "  -i <shada>            Use this shada file\n"
-msgstr "  -i <shada>            Вжити цей файл shada\n"
+msgid "  -i <shada>            Use this ShaDa file\n"
+msgstr "  -i <shada>            Вжити цей файл ShaDa\n"
 
 msgid "  -m                    Modifications (writing files) not allowed\n"
 msgstr "  -m                    Зміни (запис файлів) не дозволено\n"

--- a/test/functional/ex_cmds/oldfiles_spec.lua
+++ b/test/functional/ex_cmds/oldfiles_spec.lua
@@ -10,7 +10,7 @@ local eval = helpers.eval
 local shada_file = 'Xtest.shada'
 
 local function _clear()
-  clear{args={'-i', shada_file, -- Need shada for these tests.
+  clear{args={'-i', shada_file, -- Need ShaDa for these tests.
               '--cmd', 'set noswapfile undodir=. directory=. viewdir=. backupdir=. belloff= noshowcmd noruler'},
         args_rm={'-i', '--cmd'}}
 end

--- a/test/functional/ex_cmds/wviminfo_spec.lua
+++ b/test/functional/ex_cmds/wviminfo_spec.lua
@@ -19,7 +19,7 @@ describe(':wshada', function()
     os.remove(shada_file)
   end)
 
-  it('creates a shada file', function()
+  it('creates a ShaDa file', function()
     -- file should _not_ exist
     eq(nil, lfs.attributes(shada_file))
     command('wsh! '..shada_file)
@@ -39,12 +39,12 @@ describe(':wshada', function()
 
     command('wsh! '..shada_file)
 
-    -- File should have been overwritten with a shada file.
+    -- File should have been overwritten with a ShaDa file.
     local fp = io.open(shada_file, 'r')
     local char1 = fp:read(1)
     fp:close()
     -- ShaDa file starts with a “header” entry
     assert(char1:byte() == 0x01,
-      shada_file..' should be a shada file')
+      shada_file..' should be a ShaDa file')
   end)
 end)

--- a/test/functional/legacy/074_global_var_in_viminfo_spec.lua
+++ b/test/functional/legacy/074_global_var_in_viminfo_spec.lua
@@ -28,7 +28,7 @@ describe('storing global variables in ShaDa files', function()
     command('set shada+=!')
     command('let MY_GLOBAL_DICT={\'foo\': 1, \'bar\': 0, \'longvarible\': 1000}')
     -- Store a really long list. Initially this was testing line wrapping in
-    -- viminfo, but shada files has no line wrapping, no matter how long the
+    -- viminfo, but ShaDa files has no line wrapping, no matter how long the
     -- list is.
     command('let MY_GLOBAL_LIST=range(1, 100)')
 
@@ -38,7 +38,7 @@ describe('storing global variables in ShaDa files', function()
     command('wsh! ' .. tempname)
     wait()
 
-    -- Assert that the shada file exists.
+    -- Assert that the ShaDa file exists.
     neq(nil, lfs.attributes(tempname))
     command('unlet MY_GLOBAL_DICT')
     command('unlet MY_GLOBAL_LIST')

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -168,7 +168,7 @@ describe('startup defaults', function()
     -- This means use the default location. :help shada-file-name
     eq('', meths.get_option('shadafile'))
     eq('', meths.get_option('viminfofile'))
-    -- Check that shada data (such as v:oldfiles) is saved/restored.
+    -- Check that ShaDa data (such as v:oldfiles) is saved/restored.
     command('edit Xtest-foo')
     command('write')
     local f = eval('fnamemodify(@%,":p")')

--- a/test/functional/shada/buffers_spec.lua
+++ b/test/functional/shada/buffers_spec.lua
@@ -1,4 +1,4 @@
--- shada buffer list saving/reading support
+-- ShaDa buffer list saving/reading support
 local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, eq, curbufmeths =
   helpers.command, helpers.funcs, helpers.eq, helpers.curbufmeths
@@ -6,7 +6,7 @@ local nvim_command, funcs, eq, curbufmeths =
 local shada_helpers = require('test.functional.shada.helpers')
 local reset, clear = shada_helpers.reset, shada_helpers.clear
 
-describe('shada support code', function()
+describe('ShaDa support code', function()
   local testfilename = 'Xtestfile-functional-shada-buffers'
   local testfilename_2 = 'Xtestfile-functional-shada-buffers-2'
   after_each(clear)

--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -49,7 +49,7 @@ describe('ShaDa support code', function()
     eq(2, nvim_current_line())
   end)
 
-  it('does not dump global mark with `f0` in shada', function()
+  it('does not dump global mark with `f0` in ShaDa', function()
     nvim_command('set shada+=f0')
     nvim_command('edit ' .. testfilename)
     nvim_command('mark A')
@@ -61,7 +61,7 @@ describe('ShaDa support code', function()
     eq('Vim(normal):E20: Mark not set', exc_exec('normal! `A'))
   end)
 
-  it('does read back global mark even with `\'0` and `f0` in shada', function()
+  it('does read back global mark even with `\'0` and `f0` in ShaDa', function()
     nvim_command('edit ' .. testfilename)
     nvim_command('mark A')
     nvim_command('2')
@@ -224,7 +224,7 @@ describe('ShaDa support code', function()
         '--embed',  -- no --embed
       },
       args={
-        '-i', meths.get_var('tmpname'),  -- Use same shada file as parent.
+        '-i', meths.get_var('tmpname'),  -- Use same ShaDa file as parent.
         '--cmd', 'silent edit '..non_existent_testfilename,
         '-c', 'qall'},
     }
@@ -240,7 +240,7 @@ describe('ShaDa support code', function()
         '--embed',  -- no --embed
       },
       args={
-        '-i', meths.get_var('tmpname'),  -- Use same shada file as parent.
+        '-i', meths.get_var('tmpname'),  -- Use same ShaDa file as parent.
         '-c', 'silent edit '..non_existent_testfilename,
         '-c', 'autocmd VimEnter * qall'},
     }


### PR DESCRIPTION
Need use ShaDa instead shada. See the link below for a [discussion](https://github.com/neovim/neovim/pull/11161) of this issue. 