### PR TITLE
[WIP] Fix wait() function

### DIFF
--- a/test/functional/eval/wait_spec.lua
+++ b/test/functional/eval/wait_spec.lua
@@ -58,11 +58,8 @@ describe('wait()', function()
     endfunction
     ]])
 
-    -- XXX: flaky (#11137)
-    helpers.retry(nil, nil, function()
-      nvim('set_var', 'counter', 0)
-      eq(-1, call('wait', 20, 'Count() >= 5', 99999))
-    end)
+    nvim('set_var', 'counter', 0)
+    eq(-1, call('wait', 20, 'Count() >= 5', 99999))
 
     nvim('set_var', 'counter', 0)
     eq(0, call('wait', 10000, 'Count() >= 5', 5))

--- a/test/functional/eval/wait_spec.lua
+++ b/test/functional/eval/wait_spec.lua
@@ -58,8 +58,13 @@ describe('wait()', function()
     endfunction
     ]])
 
+    -- Run a timer to make sure that the wait() function is not affected by
+    -- mail_loop.events.
+    command('let g:timer = timer_start(20, { t -> 0 }, {"repeat" : -1})')
     nvim('set_var', 'counter', 0)
-    eq(-1, call('wait', 20, 'Count() >= 5', 99999))
+    eq(-1, call('wait', 120, 'Count() >= 5', 99999))
+    eq(0, eval('g:counter'))
+    feed_command('call timer_stop(g:timer)')
 
     nvim('set_var', 'counter', 0)
     eq(0, call('wait', 10000, 'Count() >= 5', 5))


### PR DESCRIPTION
fixes #11137.

The `wait()` function evaluates the condition every time `main_loop.events` is processed, not every interval. In addition, the condition is evaluated once more for the first time. You can check this by following these steps:

```vim
nvim -u NORC
:function Count()
    let g:counter += 1
    return g:counter
endfunction
:let g:counter = 0
:let g:timer = timer_start(20, { t -> 0 }, {'repeat' : -1 })
:echo wait(120, Count() >= 5, 99999)  " expected -1, but got 0.
:call timer_stop(g:timer)
:let g:counter = 0
:echo  wait(120, Count() >= 5, 99999)
:echo g:counter  " expected 0, but got 1. 
```

Fix them with this PR.