### PR TITLE
test/functional: retry/Screen: failure instead of error

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -1,4 +1,5 @@
 require('coxpcall')
+local busted = require('busted')
 local luv = require('luv')
 local lfs = require('lfs')
 local mpack = require('mpack')
@@ -14,7 +15,6 @@ local check_cores = global_helpers.check_cores
 local check_logs = global_helpers.check_logs
 local dedent = global_helpers.dedent
 local eq = global_helpers.eq
-local fail = global_helpers.fail
 local filter = global_helpers.filter
 local is_os = global_helpers.is_os
 local map = global_helpers.map
@@ -386,7 +386,7 @@ function module.retry(max, max_ms, fn)
     end
     luv.update_time()  -- Update cached value of luv.now() (libuv: uv_now()).
     if (max and tries >= max) or (luv.now() - start_time > timeout) then
-      fail(string.format("stopping after %d retry() attempts.\n%s", tries, tostring(result)), 2)
+      busted.fail(string.format("stopping after %d retry() attempts.\n%s", tries, tostring(result)), 2)
     end
     tries = tries + 1
     luv.sleep(20)  -- Avoid hot loop...

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -386,7 +386,7 @@ function module.retry(max, max_ms, fn)
     end
     luv.update_time()  -- Update cached value of luv.now() (libuv: uv_now()).
     if (max and tries >= max) or (luv.now() - start_time > timeout) then
-      busted.fail(string.format("stopping after %d retry() attempts.\n%s", tries, tostring(result)), 2)
+      busted.fail(string.format("retry() attempts: %d\n%s", tries, tostring(result)), 2)
     end
     tries = tries + 1
     luv.sleep(20)  -- Avoid hot loop...

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -14,6 +14,7 @@ local check_cores = global_helpers.check_cores
 local check_logs = global_helpers.check_logs
 local dedent = global_helpers.dedent
 local eq = global_helpers.eq
+local fail = global_helpers.fail
 local filter = global_helpers.filter
 local is_os = global_helpers.is_os
 local map = global_helpers.map
@@ -385,7 +386,7 @@ function module.retry(max, max_ms, fn)
     end
     luv.update_time()  -- Update cached value of luv.now() (libuv: uv_now()).
     if (max and tries >= max) or (luv.now() - start_time > timeout) then
-      error("\nretry() attempts: "..tostring(tries).."\n"..tostring(result))
+      fail(string.format("stopping after %d retry() attempts.\n%s", tries, tostring(result)), 2)
     end
     tries = tries + 1
     luv.sleep(20)  -- Avoid hot loop...

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -72,12 +72,12 @@
 -- To debug screen tests, see Screen:redraw_debug().
 
 local helpers = require('test.functional.helpers')(nil)
+local busted = require('busted')
 local deepcopy = helpers.deepcopy
 local shallowcopy = helpers.shallowcopy
 local concat_tables = helpers.concat_tables
 local request, run_session = helpers.request, helpers.run_session
 local eq = helpers.eq
-local fail = helpers.fail
 local dedent = helpers.dedent
 local get_session = helpers.get_session
 local create_callindex = helpers.create_callindex
@@ -585,7 +585,7 @@ asynchronous (feed(), nvim_input()) and synchronous API calls.
 
 
   if err then
-    fail(err, 3)
+    busted.fail(err, 3)
   elseif did_warn then
     local tb = debug.traceback()
     local index = string.find(tb, '\n%s*%[C]')

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -77,6 +77,7 @@ local shallowcopy = helpers.shallowcopy
 local concat_tables = helpers.concat_tables
 local request, run_session = helpers.request, helpers.run_session
 local eq = helpers.eq
+local fail = helpers.fail
 local dedent = helpers.dedent
 local get_session = helpers.get_session
 local create_callindex = helpers.create_callindex
@@ -584,7 +585,7 @@ asynchronous (feed(), nvim_input()) and synchronous API calls.
 
 
   if err then
-    assert(false, err)
+    fail(err, 3)
   elseif did_warn then
     local tb = debug.traceback()
     local index = string.find(tb, '\n%s*%[C]')

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -5,6 +5,7 @@ local luv = require('luv')
 local lfs = require('lfs')
 local relpath = require('pl.path').relpath
 local Paths = require('test.config.paths')
+local busted = require('busted')
 
 assert:set_parameter('TableFormatLevel', 100)
 
@@ -19,6 +20,7 @@ end
 
 local module = {
   REMOVE_THIS = {},
+  fail = busted.fail,
 }
 
 function module.argss_to_cmd(...)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -5,7 +5,6 @@ local luv = require('luv')
 local lfs = require('lfs')
 local relpath = require('pl.path').relpath
 local Paths = require('test.config.paths')
-local busted = require('busted')
 
 assert:set_parameter('TableFormatLevel', 100)
 
@@ -20,7 +19,6 @@ end
 
 local module = {
   REMOVE_THIS = {},
-  fail = busted.fail,
 }
 
 function module.argss_to_cmd(...)


### PR DESCRIPTION
- Running out of retries, or unexpected screen state should make the
  test FAIL, not ERROR.
- Uses levels to report the location of the caller.
- Improve message with retry-failure (formatting).

Before:

    [ RUN      ] test: 103.53 ms ERR
    test/functional/helpers.lua:388:
    retry() attempts: 1
    test/functional/ui/screen.lua:587: Row 1 did not match.
    Expected:
      |*X^                         |
      |{0:~                        }|
      |{0:~                        }|
      |                         |
    Actual:
      |*^                         |
      |{0:~                        }|
      |{0:~                        }|
      |                         |

    To print the expect() call that would assert the current screen state, use
    screen:snapshot_util(). In case of non-deterministic failures, use
    screen:redraw_debug() to show all intermediate screen states.

    stack traceback:
            test/functional/helpers.lua:388: in function 'retry'
            test/functional/test_spec.lua:24: in function <test/functional/test_spec.lua:23>

After:

    [ RUN      ] test: 105.22 ms FAIL
    test/functional/test_spec.lua:24: stopping after 1 retry() attempts.
    test/functional/test_spec.lua:25: Row 1 did not match.
    Expected:
      |*X^                         |
      |{0:~                        }|
      |{0:~                        }|
      |                         |
    Actual:
      |*^                         |
      |{0:~                        }|
      |{0:~                        }|
      |                         |

    To print the expect() call that would assert the current screen state, use
    screen:snapshot_util(). In case of non-deterministic failures, use
    screen:redraw_debug() to show all intermediate screen states.

    stack traceback:
            test/functional/helpers.lua:389: in function 'retry'
                test/functional/test_spec.lua:24: in function <test/functional/test_spec.lua:23>
