### PR TITLE
test behavior with regard to SIGPIPE with child processes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ if(BUSTED_PRG)
   endif()
 
   set(UNITTEST_PREREQS nvim-test unittest-headers)
-  set(FUNCTIONALTEST_PREREQS nvim printargs-test shell-test streams-test ${GENERATED_HELP_TAGS})
+  set(FUNCTIONALTEST_PREREQS nvim printargs-test shell-test streams-test sigtrap-test ${GENERATED_HELP_TAGS})
   if(NOT WIN32)
     list(APPEND FUNCTIONALTEST_PREREQS tty-test)
   endif()

--- a/test/functional/fixtures/CMakeLists.txt
+++ b/test/functional/fixtures/CMakeLists.txt
@@ -10,3 +10,6 @@ endif()
 
 add_executable(streams-test streams-test.c)
 target_link_libraries(streams-test ${LIBUV_LIBRARIES})
+
+add_executable(sigtrap-test sigtrap-test.c)
+target_link_libraries(sigtrap-test ${LIBUV_LIBRARIES})

--- a/test/functional/fixtures/sigtrap-test.c
+++ b/test/functional/fixtures/sigtrap-test.c
@@ -1,0 +1,20 @@
+/// Helper program to handle signal processing with jobs.
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+
+static void on_sigterm(int signum)
+{
+  fprintf(stdout, "got_sigterm\n");
+  fflush(stdout);
+}
+
+int main(int argc, char **argv)
+{
+  signal(SIGTERM, on_sigterm);
+  fprintf(stdout, "pid: %d\n", getpid());
+  fflush(stdout);
+  while (1) {
+    usleep(100000);
+  }
+}

--- a/test/functional/terminal/jobs_spec.lua
+++ b/test/functional/terminal/jobs_spec.lua
@@ -1,0 +1,36 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local nvim_dir = helpers.nvim_dir
+local child_session = require('test.functional.terminal.helpers')
+
+it('Job receives SIGHUP with output during exiting', function()
+  helpers.clear()
+  -- local screen = child_session.screen_setup(0, '["'..helpers.nvim_prog
+  --   ..'", "-u", "NONE", "-i", "NONE", "--cmd", "'..helpers.nvim_set..'"]')
+
+  -- TODO: move to helpers?
+  local nvim_child_argv = {
+    helpers.nvim_prog, '-u', 'NONE', '-i', 'NONE', '--cmd', helpers.nvim_set}
+  local cmd = '["'..table.concat(nvim_child_argv, '", "')..'"]'
+  local screen = child_session.screen_setup(0, cmd)
+  -- local screen = thelpers.screen_setup(0, cmd)
+
+  child_session.feed_data(string.format([[
+    :let g:started = 0
+    :let opts = {}
+    :let opts.on_stdout = {-> execute('let g:started = 1')}
+    :let opts.on_exit = {...-> execute('echom printf("exiting:%%d, status:%%d", v:exiting, a:2)', '')}
+    :call jobstart('%s', opts)
+    :while !g:started | sleep 10m | endwhile
+    :qa
+  ]], nvim_dir..'/sigtrap-test'))
+  screen:expect{grid=[[
+    exiting:0, status:141                             |
+    [Process exited 0]{1: }                               |
+                                                      |
+                                                      |
+                                                      |
+                                                      |
+    {3:-- TERMINAL --}                                    |
+  ]]}
+end)


### PR DESCRIPTION
1. test that shows that a job receives SIGPIPE when it outputs something after SIGTERM has been sent (but only during exiting nvim)

Appears to not clean the screen properly?

    Expected:
      |*exiting:0, status:141                             |
      |*[Process exited 0]{1: }                               |
      |*                                                  |
      |*                                                  |
      |*                                                  |
      |*                                                  |
      |{3:-- TERMINAL --}                                    |
    Actual:
      |*    :call jobstart('/home/daniel/Vcs/neovim/build/|
      |*bin/sigtrap-test', opts)                          |
      |*    :while !g:started | sleep 10m | endwhile      |
      |*    :qa                                           |
      |*  exiting:0, status:141                           |
      |*[Process exited 0]{1: }                               |
      |{3:-- TERMINAL --}                                    |