### PR TITLE
tests: messages_spec: enable/fix "ui/msg_puts_printf"

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -29,9 +29,12 @@ tasks:
 - build: |
     cd neovim
     gmake CMAKE_BUILD_TYPE=Release CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" nvim
-- test: |
+- test-functionaltest: |
     cd neovim
-    gmake unittest functionaltest
+    gmake functionaltest
+- test-unittest: |
+    cd neovim
+    gmake unittest
 
 # Unfortunately, oldtest is tanking hard on sourcehut's FreeBSD instance
 # and not producing any logs as a result. So don't do this task for now.

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1073,8 +1073,9 @@ describe('ui/msg_puts_printf', function()
     os.execute('cmake -E make_directory '..locale_dir)
     os.execute('cmake -E copy '..test_build_dir..'/src/nvim/po/ja.mo '..locale_dir..'/nvim.mo')
 
+    eq('ja_JP.UTF-8', eval('$LANG'))
     local lang = eval('execute("lang messages")')
-    eq(lang, '\n現在の messages 言語: "ja_JP.UTF-8"')
+    eq('\n現在の messages 言語: "ja_JP.UTF-8"', lang)
 
     cmd = cmd..'"'..nvim_prog..'" -u NONE -i NONE -Es -V1'
     command([[call termopen(']]..cmd..[[')]])

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1052,6 +1052,9 @@ describe('ui/msg_puts_printf', function()
     local cmd = ''
     local locale_dir = test_build_dir..'/share/locale/ja/LC_MESSAGES'
 
+    os.execute('cmake -E make_directory '..locale_dir)
+    os.execute('cmake -E copy '..test_build_dir..'/src/nvim/po/ja.mo '..locale_dir..'/nvim.mo')
+
     clear({env={LANG='ja_JP.UTF-8'}})
     screen = Screen.new(80, 5)
     screen:attach()
@@ -1069,9 +1072,6 @@ describe('ui/msg_puts_printf', function()
         return
       end
     end
-
-    os.execute('cmake -E make_directory '..locale_dir)
-    os.execute('cmake -E copy '..test_build_dir..'/src/nvim/po/ja.mo '..locale_dir..'/nvim.mo')
 
     eq('ja_JP.UTF-8', eval('$LANG'))
     local lang = eval('execute("lang messages")')

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1067,10 +1067,6 @@ describe('ui/msg_puts_printf', function()
       if (exc_exec('lang ja_JP.UTF-8') ~= 0) then
         pending('Locale ja_JP.UTF-8 not supported', function() end)
         return
-      elseif helpers.isCI() then
-        -- Fails non--Windows CI. Message catalog direcotry issue?
-        pending('fails on unix CI', function() end)
-        return
       end
     end
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1053,7 +1053,7 @@ describe('ui/msg_puts_printf', function()
     local locale_dir = test_build_dir..'/share/locale/ja/LC_MESSAGES'
 
     clear({env={LANG='ja_JP.UTF-8'}})
-    screen = Screen.new(25, 5)
+    screen = Screen.new(80, 5)
     screen:attach()
 
     if iswin() then
@@ -1073,15 +1073,18 @@ describe('ui/msg_puts_printf', function()
     os.execute('cmake -E make_directory '..locale_dir)
     os.execute('cmake -E copy '..test_build_dir..'/src/nvim/po/ja.mo '..locale_dir..'/nvim.mo')
 
+    local lang = eval('execute("lang messages")')
+    eq(lang, '\n現在の messages 言語: "ja_JP.UTF-8"')
+
     cmd = cmd..'"'..nvim_prog..'" -u NONE -i NONE -Es -V1'
     command([[call termopen(']]..cmd..[[')]])
-    screen:expect([[
-    ^Exモードに入ります. ノー |
-    マルモードに戻るには"visu|
-    al"と入力してください.   |
-    :                        |
-                             |
-    ]])
+    screen:expect{grid=[[
+      ^Exモードに入ります. ノーマルモードに戻るには"visual"と入力してください.         |
+      :                                                                               |
+      [Process exited 0]                                                              |
+                                                                                      |
+                                                                                      |
+    ]]}
 
     os.execute('cmake -E remove_directory '..test_build_dir..'/share')
   end)


### PR DESCRIPTION
This works on OpenBSD apparently on Sourcehut.  Let's enable/fix it for
all.

Ref: https://github.com/neovim/neovim/pull/10098