### PR TITLE
update_version_stamp: redirect stderr on first try, --first-parent

### DIFF
--- a/scripts/update_version_stamp.lua
+++ b/scripts/update_version_stamp.lua
@@ -20,9 +20,9 @@ end
 local versiondeffile = arg[1]
 local prefix = arg[2]
 
-local described = io.popen('git describe --dirty'):read('*l')
+local described = io.popen('git describe --first-parent --dirty 2>/dev/null'):read('*l')
 if not described then
-  described = io.popen('git describe --tags --always --dirty'):read('*l')
+  described = io.popen('git describe --first-parent --tags --always --dirty'):read('*l')
 end
 if not described then
   io.open(versiondeffile, 'w'):write('\n')


### PR DESCRIPTION
Avoid noise during builds:

> fatal: No annotated tags can describe '417449f468c4ba186954f6295b3338fb55ee7b4a'.
> However, there were unannotated tags: try --tags.

This might be useful in general, but is expected to not happen - and
falling back is OK then.  The fallback command would still display
errors then.

It also uses `--first-parent`, which is important for when a release
branch gets merged back.