### PR TITLE
cmake/RunTests.cmake: fail tests with output on stderr

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -66,7 +66,11 @@ execute_process(
 file(GLOB RM_FILES ${BUILD_DIR}/Xtest_*)
 file(REMOVE_RECURSE ${RM_FILES})
 
-if(NOT res EQUAL 0)
+if(res EQUAL 0)
+  if(NOT "${err}" STREQUAL "")
+    message(FATAL_ERROR "Tests passed, but there is output on stderr:\n${err}")
+  endif()
+else()
   message(STATUS "Tests exited non-zero: ${res}")
   if("${err}" STREQUAL "")
     message(STATUS "No output to stderr.")


### PR DESCRIPTION
This should at least gets displayed always, since it will contain output
from sanitizers for example.