### PR TITLE
tests/refactor: make screen.ui use "linegrid" representation internally

### DIFF
--- a/test/functional/api/menu_spec.lua
+++ b/test/functional/api/menu_spec.lua
@@ -15,10 +15,6 @@ describe("update_menu notification", function()
     screen:attach()
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   local function expect_sent(expected)
     screen:expect{condition=function()
       if screen.update_menu ~= expected then

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -963,9 +963,6 @@ describe("pty process teardown", function()
                                     |
     ]])
   end)
-  after_each(function()
-    screen:detach()
-  end)
 
   it("does not prevent/delay exit. #4798 #4900", function()
     if helpers.pending_win32(pending) then return end

--- a/test/functional/eval/api_functions_spec.lua
+++ b/test/functional/eval/api_functions_spec.lua
@@ -144,7 +144,6 @@ describe('eval-API', function()
       {5:~                                       }|
                                               |
     ]])
-    screen:detach()
   end)
 
   it('cannot be called from sandbox', function()

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -121,10 +121,6 @@ describe('system()', function()
       screen:attach()
     end)
 
-    after_each(function()
-      screen:detach()
-    end)
-
     if iswin() then
       local function test_more()
         eq('root = true', eval([[get(split(system('"more" ".editorconfig"'), "\n"), 0, '')]]))

--- a/test/functional/ex_cmds/drop_spec.lua
+++ b/test/functional/ex_cmds/drop_spec.lua
@@ -19,10 +19,6 @@ describe(":drop", function()
     command("set laststatus=2 shortmess-=F")
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it("works like :e when called with only one window open", function()
     feed_command("drop tmp1.vim")
     screen:expect([[

--- a/test/functional/ex_cmds/highlight_spec.lua
+++ b/test/functional/ex_cmds/highlight_spec.lua
@@ -13,10 +13,6 @@ describe(':highlight', function()
     screen:attach()
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it('invalid color name', function()
     eq('Vim(highlight):E421: Color name or number not recognized: ctermfg=#181818',
        exc_exec("highlight normal ctermfg=#181818"))

--- a/test/functional/legacy/045_folding_spec.lua
+++ b/test/functional/legacy/045_folding_spec.lua
@@ -14,9 +14,6 @@ describe('folding', function()
     screen = Screen.new(20, 8)
     screen:attach()
   end)
-  after_each(function()
-    screen:detach()
-  end)
 
   it('creation, opening, moving (to the end) and closing', function()
     insert([[

--- a/test/functional/legacy/063_match_and_matchadd_spec.lua
+++ b/test/functional/legacy/063_match_and_matchadd_spec.lua
@@ -14,6 +14,10 @@ describe('063: Test for ":match", "matchadd()" and related functions', function(
   it('is working', function()
     local screen = Screen.new(40, 5)
     screen:attach()
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+      [1] = {background = Screen.colors.Red},
+    })
 
     -- Check that "matcharg()" returns the correct group and pattern if a match
     -- is defined.
@@ -126,22 +130,22 @@ describe('063: Test for ":match", "matchadd()" and related functions', function(
     command("call matchaddpos('MyGroup1', [[1, 5], [1, 8, 3]], 10, 3)")
     screen:expect([[
       abcd{1:e}fg{1:hij}klmnop^q                       |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
                                               |
-    ]], {[1] = {background = Screen.colors.Red}}, {{bold = true, foreground = Screen.colors.Blue}})
+    ]])
 
     command("call clearmatches()")
     command("call setline(1, 'abcdΣabcdef')")
     command("call matchaddpos('MyGroup1', [[1, 4, 2], [1, 9, 2]])")
     screen:expect([[
       abc{1:dΣ}ab{1:cd}e^f                             |
-      ~                                       |
-      ~                                       |
-      ~                                       |
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
                                               |
-    ]],{[1] = {background = Screen.colors.Red}}, {{bold = true, foreground = Screen.colors.Blue}})
+    ]])
   end)
 end)
 

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -17,7 +17,10 @@ describe('search cmdline', function()
     screen = Screen.new(20, 3)
     screen:attach()
     screen:set_default_attr_ids({
-      inc = {reverse = true}
+      inc = {reverse = true},
+      err = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
+      more = { bold = true, foreground = Screen.colors.SeaGreen4 },
+      tilde = { bold = true, foreground = Screen.colors.Blue1 },
     })
   end)
 
@@ -404,12 +407,7 @@ describe('search cmdline', function()
   end)
 
   it('keeps the view after deleting a char from the search', function()
-    screen:detach()
-    screen = Screen.new(20, 6)
-    screen:attach()
-    screen:set_default_attr_ids({
-      inc = {reverse = true},
-    })
+    screen:try_resize(20, 6)
     tenlines()
 
     feed('/foo')
@@ -445,14 +443,7 @@ describe('search cmdline', function()
   end)
 
   it('restores original view after failed search', function()
-    screen:detach()
-    screen = Screen.new(40, 3)
-    screen:attach()
-    screen:set_default_attr_ids({
-      inc = {reverse = true},
-      err = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
-      more = { bold = true, foreground = Screen.colors.SeaGreen4 },
-    })
+    screen:try_resize(40, 3)
     tenlines()
     feed('0')
     feed('/foo')
@@ -481,15 +472,7 @@ describe('search cmdline', function()
 
   it("CTRL-G with 'incsearch' and ? goes in the right direction", function()
     -- oldtest: Test_search_cmdline4().
-    screen:detach()
-    screen = Screen.new(40, 4)
-    screen:attach()
-    screen:set_default_attr_ids({
-      inc = {reverse = true},
-      err = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
-      more = { bold = true, foreground = Screen.colors.SeaGreen4 },
-      tilde = { bold = true, foreground = Screen.colors.Blue1 },
-    })
+    screen:try_resize(40, 4)
     command('enew!')
     funcs.setline(1, {'  1 the first', '  2 the second', '  3 the third'})
     command('set laststatus=0 shortmess+=s')

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -408,10 +408,7 @@ describe('search cmdline', function()
     screen = Screen.new(20, 6)
     screen:attach()
     screen:set_default_attr_ids({
-      inc = {reverse = true}
-    })
-    screen:set_default_attr_ignore({
-      {bold=true, reverse=true}, {bold=true, foreground=Screen.colors.Blue1}
+      inc = {reverse = true},
     })
     tenlines()
 

--- a/test/functional/options/chars_spec.lua
+++ b/test/functional/options/chars_spec.lua
@@ -16,10 +16,6 @@ describe("'fillchars'", function()
     screen:attach()
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   local function shouldfail(val,errval)
     errval = errval or val
     eq('Vim(set):E474: Invalid argument: fillchars='..errval,
@@ -98,10 +94,6 @@ describe("'listchars'", function()
     clear()
     screen = Screen.new(50, 5)
     screen:attach()
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it('is local to window', function()

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -116,8 +116,6 @@ describe('health.vim', function()
       screen:set_default_attr_ids({
         Ok = { foreground = Screen.colors.Grey3, background = 6291200 },
         Error = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
-      })
-      screen:set_default_attr_ignore({
         Heading = { bold=true, foreground=Screen.colors.Magenta },
         Heading2 = { foreground = Screen.colors.SlateBlue },
         Bar = { foreground=Screen.colors.Purple },
@@ -126,18 +124,18 @@ describe('health.vim', function()
       command("checkhealth foo success1")
       command("1tabclose")
       command("set laststatus=0")
-      screen:expect([[
+      screen:expect{grid=[[
         ^                                                                        |
-        health#foo#check                                                        |
-        ========================================================================|
-          - {Error:ERROR:} No healthcheck found for "foo" plugin.                       |
+        {Heading:health#foo#check}                                                        |
+        {Bar:========================================================================}|
+        {Bullet:  -} {Error:ERROR:} No healthcheck found for "foo" plugin.                       |
                                                                                 |
-        health#success1#check                                                   |
-        ========================================================================|
-        ## report 1                                                             |
-          - {Ok:OK:} everything is fine                                              |
+        {Heading:health#success1#check}                                                   |
+        {Bar:========================================================================}|
+        {Heading2:##}{Heading: report 1}                                                             |
+        {Bullet:  -} {Ok:OK:} everything is fine                                              |
                                                                                 |
-      ]])
+      ]]}
     end)
 
     it("gracefully handles invalid healthcheck", function()

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -19,10 +19,8 @@ describe(':Man', function()
         u = { underline = true },
         bi = { bold = true, italic = true },
         biu = { bold = true, italic = true, underline = true },
-      })
-      screen:set_default_attr_ignore({
-        { foreground = Screen.colors.Blue }, -- control chars
-        { bold = true, foreground = Screen.colors.Blue } -- empty line '~'s
+        c = { foreground = Screen.colors.Blue }, -- control chars
+        eob = { bold = true, foreground = Screen.colors.Blue } -- empty line '~'s
       })
       screen:attach()
     end)
@@ -36,21 +34,21 @@ describe(':Man', function()
         ithis i<C-v><C-h>is<C-v><C-h>s a<C-v><C-h>a test
         with _<C-v><C-h>o_<C-v><C-h>v_<C-v><C-h>e_<C-v><C-h>r_<C-v><C-h>s_<C-v><C-h>t_<C-v><C-h>r_<C-v><C-h>u_<C-v><C-h>c_<C-v><C-h>k text<ESC>]])
 
-      screen:expect([[
-      this i^His^Hs a^Ha test                             |
-      with _^Ho_^Hv_^He_^Hr_^Hs_^Ht_^Hr_^Hu_^Hc_^Hk tex^t  |
-      ~                                                   |
-      ~                                                   |
-                                                          |
-      ]])
+      screen:expect{grid=[[
+        this i{c:^H}is{c:^H}s a{c:^H}a test                             |
+        with _{c:^H}o_{c:^H}v_{c:^H}e_{c:^H}r_{c:^H}s_{c:^H}t_{c:^H}r_{c:^H}u_{c:^H}c_{c:^H}k tex^t  |
+        {eob:~                                                   }|
+        {eob:~                                                   }|
+                                                            |
+      ]]}
 
       eval('man#init_pager()')
 
       screen:expect([[
       ^this {b:is} {b:a} test                                      |
       with {u:overstruck} text                                |
-      ~                                                   |
-      ~                                                   |
+      {eob:~                                                   }|
+      {eob:~                                                   }|
                                                           |
       ]])
     end)
@@ -60,21 +58,21 @@ describe(':Man', function()
         ithis <C-v><ESC>[1mis <C-v><ESC>[3ma <C-v><ESC>[4mtest<C-v><ESC>[0m
         <C-v><ESC>[4mwith<C-v><ESC>[24m <C-v><ESC>[4mescaped<C-v><ESC>[24m <C-v><ESC>[4mtext<C-v><ESC>[24m<ESC>]])
 
-      screen:expect([=[
-      this ^[[1mis ^[[3ma ^[[4mtest^[[0m                  |
-      ^[[4mwith^[[24m ^[[4mescaped^[[24m ^[[4mtext^[[24^m  |
-      ~                                                   |
-      ~                                                   |
-                                                          |
-      ]=])
+      screen:expect{grid=[=[
+        this {c:^[}[1mis {c:^[}[3ma {c:^[}[4mtest{c:^[}[0m                  |
+        {c:^[}[4mwith{c:^[}[24m {c:^[}[4mescaped{c:^[}[24m {c:^[}[4mtext{c:^[}[24^m  |
+        {eob:~                                                   }|
+        {eob:~                                                   }|
+                                                            |
+      ]=]}
 
       eval('man#init_pager()')
 
       screen:expect([[
       ^this {b:is }{bi:a }{biu:test}                                      |
       {u:with} {u:escaped} {u:text}                                   |
-      ~                                                   |
-      ~                                                   |
+      {eob:~                                                   }|
+      {eob:~                                                   }|
                                                           |
       ]])
     end)
@@ -88,8 +86,8 @@ describe(':Man', function()
       screen:expect([[
       ^this {b:is} {b:あ} test                                     |
       with {u:överstrũck} te{i:xt¶}                               |
-      ~                                                   |
-      ~                                                   |
+      {eob:~                                                   }|
+      {eob:~                                                   }|
                                                           |
       ]])
     end)
@@ -105,7 +103,7 @@ describe(':Man', function()
       {b:^_begins}                                             |
       {b:mid_dle}                                             |
       {u:mid_dle}                                             |
-      ~                                                   |
+      {eob:~                                                   }|
                                                           |
       ]])
     end)
@@ -121,7 +119,7 @@ describe(':Man', function()
       ^· {b:·}                                                 |
       {b:·}                                                   |
       {b:·} double                                            |
-      ~                                                   |
+      {eob:~                                                   }|
                                                           |
       ]])
     end)

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -25,10 +25,6 @@ describe(':Man', function()
       screen:attach()
     end)
 
-    after_each(function()
-      screen:detach()
-    end)
-
     it('clears backspaces from text and adds highlights', function()
       rawfeed([[
         ithis i<C-v><C-h>is<C-v><C-h>s a<C-v><C-h>a test

--- a/test/functional/provider/clipboard_spec.lua
+++ b/test/functional/provider/clipboard_spec.lua
@@ -88,6 +88,11 @@ describe('clipboard', function()
   before_each(function()
     clear()
     screen = Screen.new(72, 4)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+      [1] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [2] = {bold = true, foreground = Screen.colors.SeaGreen4},
+    })
     screen:attach()
     command("set display-=msgsep")
   end)
@@ -103,22 +108,22 @@ describe('clipboard', function()
     feed_command('redir @+> | :silent echo system("cat CONTRIBUTING.md") | redir END')
     screen:expect([[
       ^                                                                        |
-      ~                                                                       |
-      ~                                                                       |
+      {0:~                                                                       }|
+      {0:~                                                                       }|
       clipboard: No provider. Try ":checkhealth" or ":h clipboard".           |
-    ]], nil, {{bold = true, foreground = Screen.colors.Blue}})
+    ]])
   end)
 
   it('`:redir @+>|bogus_cmd|redir END` + invalid g:clipboard must not recurse #7184',
   function()
     command("let g:clipboard = 'bogus'")
     feed_command('redir @+> | bogus_cmd | redir END')
-    screen:expect([[
-      ~                                                                       |
+    screen:expect{grid=[[
+      {0:~                                                                       }|
       clipboard: No provider. Try ":checkhealth" or ":h clipboard".           |
-      E492: Not an editor command: bogus_cmd | redir END                      |
-      Press ENTER or type command to continue^                                 |
-    ]], nil, {{bold = true, foreground = Screen.colors.Blue}})
+      {1:E492: Not an editor command: bogus_cmd | redir END}                      |
+      {2:Press ENTER or type command to continue}^                                 |
+    ]]}
   end)
 
   it('invalid g:clipboard shows hint if :redir is not active', function()
@@ -131,10 +136,10 @@ describe('clipboard', function()
     feed_command('let @+="foo"')
     screen:expect([[
       ^                                                                        |
-      ~                                                                       |
-      ~                                                                       |
+      {0:~                                                                       }|
+      {0:~                                                                       }|
       clipboard: No provider. Try ":checkhealth" or ":h clipboard".           |
-    ]], nil, {{bold = true, foreground = Screen.colors.Blue}})
+    ]])
   end)
 
   it('valid g:clipboard', function()
@@ -266,13 +271,17 @@ describe('clipboard (with fake clipboard.vim)', function()
   function()
     local screen = Screen.new(72, 4)
     screen:attach()
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+      [1] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+    })
     feed_command('redir @+> | bogus_cmd | redir END')
     screen:expect([[
       ^                                                                        |
-      ~                                                                       |
-      ~                                                                       |
-      E492: Not an editor command: bogus_cmd | redir END                      |
-    ]], nil, {{bold = true, foreground = Screen.colors.Blue}})
+      {0:~                                                                       }|
+      {0:~                                                                       }|
+      {1:E492: Not an editor command: bogus_cmd | redir END}                      |
+    ]])
   end)
 
   it('has independent "* and unnamed registers by default', function()
@@ -637,6 +646,9 @@ describe('clipboard (with fake clipboard.vim)', function()
     feed_command('set mouse=a')
 
     local screen = Screen.new(30, 5)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+    })
     screen:attach()
     insert([[
       the source
@@ -646,10 +658,10 @@ describe('clipboard (with fake clipboard.vim)', function()
     screen:expect([[
       the ^source                    |
       a target                      |
-      ~                             |
-      ~                             |
+      {0:~                             }|
+      {0:~                             }|
                                     |
-    ]], nil, {{bold = true, foreground = Screen.colors.Blue}})
+    ]])
 
     feed('<MiddleMouse><0,1>')
     expect([[

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -208,18 +208,18 @@ describe(':terminal buffer', function()
       feed_command('terminal')
       feed('<c-\\><c-n>')
       feed_command('confirm bdelete')
-      screen:expect{any='Close "term://', attr_ignore=true}
+      screen:expect{any='Close "term://'}
     end)
 
     it('with &confirm', function()
       feed_command('terminal')
       feed('<c-\\><c-n>')
       feed_command('bdelete')
-      screen:expect{any='E89', attr_ignore=true}
+      screen:expect{any='E89'}
       feed('<cr>')
       eq('terminal', eval('&buftype'))
       feed_command('set confirm | bdelete')
-      screen:expect{any='Close "term://', attr_ignore=true}
+      screen:expect{any='Close "term://'}
       feed('y')
       neq('terminal', eval('&buftype'))
     end)

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -52,7 +52,7 @@ local function screen_setup(extra_rows, command, cols, opts)
     [3] = {bold = true},
     [4] = {foreground = 12},
     [5] = {bold = true, reverse = true},
-    [6] = {background = 11},
+    -- 6 was a duplicate item
     [7] = {foreground = 130},
     [8] = {foreground = 15, background = 1}, -- error message
     [9] = {foreground = 4},

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -31,10 +31,6 @@ describe(':terminal mouse', function()
     ]])
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   describe('when the terminal has focus', function()
     it('will exit focus on mouse-scroll', function()
       eq('t', eval('mode()'))

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -21,10 +21,6 @@ describe(':terminal scrollback', function()
     screen = thelpers.screen_setup(nil, nil, 30)
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   describe('when the limit is exceeded', function()
     before_each(function()
       local lines = {}
@@ -406,8 +402,6 @@ describe("'scrollback' option", function()
     feed_data(nvim_dir..'/shell-test REP 31 line'..(iswin() and '\r' or '\n'))
     screen:expect{any='30: line                      '}
     retry(nil, nil, function() expect_lines(7) end)
-
-    screen:detach()
   end)
 
   it('deletes lines (only) if necessary', function()
@@ -464,8 +458,6 @@ describe("'scrollback' option", function()
     -- Verify off-screen state
     eq((iswin() and '36: line' or '35: line'), eval("getline(line('w0') - 1)"))
     eq((iswin() and '27: line' or '26: line'), eval("getline(line('w0') - 10)"))
-
-    screen:detach()
   end)
 
   it('defaults to 10000 in :terminal buffers', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -45,10 +45,6 @@ describe('TUI', function()
     child_session = helpers.connect(child_server)
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   -- Wait for mode in the child Nvim (avoid "typeahead race" #10826).
   local function wait_for_mode(mode)
     retry(nil, nil, function()

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -37,10 +37,6 @@ describe('Buffer highlighting', function()
     })
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   local add_highlight = curbufmeths.add_highlight
   local clear_namespace = curbufmeths.clear_namespace
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -25,10 +25,6 @@ local function test_cmdline(linegrid)
     screen = new_screen({rgb=true, ext_cmdline=true, ext_linegrid=linegrid})
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it('works', function()
     feed(':')
     screen:expect{grid=[[
@@ -802,10 +798,6 @@ describe('cmdline redraw', function()
   before_each(function()
     clear()
     screen = new_screen({rgb=true})
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it('with timer', function()

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -13,10 +13,6 @@ describe('ui/cursor', function()
     screen:attach()
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it("'guicursor' is published as a UI event", function()
     local expected_mode_info = {
       [1] = {

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -24,10 +24,6 @@ describe("folded lines", function()
     })
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it("work with more than one signcolumn", function()
     command("set signcolumn=yes:9")
     feed("i<cr><esc>")

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -35,7 +35,6 @@ describe('highlight: `:syntax manual`', function()
   end)
 
   after_each(function()
-    screen:detach()
     os.remove('Xtest-functional-ui-highlight.tmp.vim')
   end)
 
@@ -95,10 +94,6 @@ describe('highlight defaults', function()
     screen = Screen.new()
     screen:attach()
     command("set display-=msgsep")
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it('window status bar', function()
@@ -346,17 +341,10 @@ describe('highlight defaults', function()
 end)
 
 describe('highlight', function()
-  local screen
-
-  before_each(function()
-    clear()
-    screen = Screen.new(25,10)
-    screen:attach()
-  end)
+  before_each(clear)
 
   it('visual', function()
-    screen:detach()
-    screen = Screen.new(20,4)
+    local screen = Screen.new(20,4)
     screen:attach()
     screen:set_default_attr_ids({
       [1] = {background = Screen.colors.LightGrey},
@@ -389,8 +377,7 @@ describe('highlight', function()
   end)
 
   it('cterm=standout gui=standout', function()
-    screen:detach()
-    screen = Screen.new(20,5)
+    local screen = Screen.new(20,5)
     screen:attach()
     screen:set_default_attr_ids({
         [1] = {bold = true, foreground = Screen.colors.Blue1},
@@ -413,8 +400,7 @@ describe('highlight', function()
   end)
 
   it('strikethrough', function()
-    screen:detach()
-    screen = Screen.new(25,6)
+    local screen = Screen.new(25,6)
     screen:attach()
     feed_command('syntax on')
     feed_command('syn keyword TmpKeyword foo')
@@ -439,8 +425,7 @@ describe('highlight', function()
   end)
 
   it('nocombine', function()
-    screen:detach()
-    screen = Screen.new(25,6)
+    local screen = Screen.new(25,6)
     screen:set_default_attr_ids{
       [1] = {foreground = Screen.colors.SlateBlue, underline = true},
       [2] = {bold = true, foreground = Screen.colors.Blue1},
@@ -487,6 +472,8 @@ describe('highlight', function()
   end)
 
   it('guisp (special/undercurl)', function()
+    local screen = Screen.new(25,10)
+    screen:attach()
     feed_command('syntax on')
     feed_command('syn keyword TmpKeyword neovim')
     feed_command('syn keyword TmpKeyword1 special')
@@ -540,10 +527,6 @@ describe("'listchars' highlight", function()
     clear()
     screen = Screen.new(20,5)
     screen:attach()
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it("'cursorline' and 'cursorcolumn'", function()

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -259,7 +259,7 @@ describe('ext_hlstate detailed highlights', function()
 
   it("can use independent cterm and rgb colors", function()
     -- tell test module to save all attributes (doesn't change nvim options)
-    screen:set_hlstate_cterm(true)
+    screen:set_rgb_cterm(true)
 
     screen:set_default_attr_ids({
         [1] = {{bold = true, foreground = Screen.colors.Blue1}, {foreground = 12}, {{hi_name = "NonText", ui_name = "EndOfBuffer", kind = "ui"}}},

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -556,7 +556,6 @@ describe(":substitute, 'inccommand' preserves undo", function()
         ]])
       end
     end
-    screen:detach()
   end)
 
   it('with undolevels=2', function()
@@ -647,7 +646,6 @@ describe(":substitute, 'inccommand' preserves undo", function()
           Already ...t change |
         ]])
       end
-      screen:detach()
     end
   end)
 
@@ -713,7 +711,6 @@ describe(":substitute, 'inccommand' preserves undo", function()
         Already ...t change |
       ]])
     end
-    screen:detach()
   end)
 
 end)
@@ -724,10 +721,6 @@ describe(":substitute, inccommand=split", function()
   before_each(function()
     clear()
     common_setup(screen, "split", default_text .. default_text)
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it("preserves 'modified' buffer flag", function()
@@ -1241,10 +1234,6 @@ describe("inccommand=nosplit", function()
     common_setup(screen, "nosplit", default_text .. default_text)
   end)
 
-  after_each(function()
-    if screen then screen:detach() end
-  end)
-
   it("works with :smagic, :snomagic", function()
     feed_command("set hlsearch")
     insert("Line *.3.* here")
@@ -1718,10 +1707,6 @@ describe("'inccommand' split windows", function()
     screen = Screen.new(40,30)
     common_setup(screen, "split", default_text)
   end
-
-  after_each(function()
-    screen:detach()
-  end)
 
   it('work after more splits', function()
     refresh()

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -40,10 +40,6 @@ describe('ui/mouse/input', function()
     ]])
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it('single left click moves cursor', function()
     feed('<LeftMouse><2,1>')
     screen:expect([[

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -26,6 +26,8 @@ describe('ui/mouse/input', function()
       },
       [4] = {reverse = true},
       [5] = {bold = true, reverse = true},
+      [6] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+      [7] = {bold = true, foreground = Screen.colors.SeaGreen4},
     })
     command("set display-=msgsep")
     feed('itesting<cr>mouse<cr>support and selection<esc>')
@@ -620,12 +622,12 @@ describe('ui/mouse/input', function()
     meths.set_option('tags', './non-existent-tags-file')
     feed('<C-LeftMouse><0,0>')
     screen:expect([[
-      E433: No tags file       |
-      E426: tag not found: test|
-      ing                      |
-      Press ENTER or type comma|
-      nd to continue^           |
-    ]],nil,true)
+      {6:E433: No tags file}       |
+      {6:E426: tag not found: test}|
+      {6:ing}                      |
+      {7:Press ENTER or type comma}|
+      {7:nd to continue}^           |
+    ]])
     feed('<cr>')
   end)
 

--- a/test/functional/ui/multibyte_spec.lua
+++ b/test/functional/ui/multibyte_spec.lua
@@ -21,10 +21,6 @@ describe("multibyte rendering", function()
     })
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it("works with composed char at start of line", function()
     insert([[
       ̊
@@ -129,10 +125,6 @@ describe('multibyte rendering: statusline', function()
     screen = Screen.new(40, 4)
     screen:attach()
     command('set laststatus=2')
-  end)
-
-  after_each(function()
-    screen:detach()
   end)
 
   it('last char shows (multibyte)', function()

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -37,10 +37,6 @@ describe('ext_multigrid', function()
     })
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it('default initial screen', function()
     screen:expect{grid=[[
     ## grid 1

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -40,10 +40,6 @@ describe('ui receives option updates', function()
     return defaults
   end
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it("for defaults", function()
     local expected = reset()
     screen:expect(function()

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -31,7 +31,6 @@ describe("shell command :!", function()
 
   after_each(function()
     child_session.feed_data("\3") -- Ctrl-C
-    screen:detach()
   end)
 
   it("displays output without LF/EOF. #4646 #4569 #3772", function()

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -66,7 +66,6 @@
 --      [1] = {reverse = true, bold = true},
 --      [2] = {reverse = true}
 --    })
---    screen:set_default_attr_ignore( {{}, {bold=true, foreground=NonText}} )
 --
 -- To help write screen tests, see Screen:snapshot_util().
 -- To debug screen tests, see Screen:redraw_debug().
@@ -169,7 +168,6 @@ function Screen.new(width, height)
     ruler = {},
     hl_groups = {},
     _default_attr_ids = nil,
-    _default_attr_ignore = nil,
     _mouse_enabled = true,
     _attrs = {},
     _hl_info = {[0]={}},
@@ -200,10 +198,6 @@ end
 
 function Screen:get_default_attr_ids()
   return deepcopy(self._default_attr_ids)
-end
-
-function Screen:set_default_attr_ignore(attr_ignore)
-  self._default_attr_ignore = attr_ignore
 end
 
 function Screen:set_rgb_cterm(val)
@@ -361,7 +355,7 @@ function Screen:expect(expected, attr_ids, attr_ignore, ...)
   end
   local attr_state = {
       ids = attr_ids or self._default_attr_ids,
-      ignore = attr_ignore or self._default_attr_ignore,
+      ignore = attr_ignore
   }
   if self._options.ext_linegrid then
     attr_state.id_to_index = self:linegrid_check_attrs(attr_state.ids or {})
@@ -1478,6 +1472,8 @@ function Screen:_get_attr_id(attr_state, attrs, hl_id)
       return nil
     elseif id ~= nil then
       return id
+    elseif attr_state.ignore == true then
+      return nil
     end
     if attr_state.mutable then
       id = self:_insert_hl_id(attr_state, hl_id)

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -26,10 +26,6 @@ describe('Signs', function()
     } )
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   describe(':sign place', function()
     it('allows signs with combining characters', function()
       feed('ia<cr>b<cr><esc>')

--- a/test/functional/ui/spell_spec.lua
+++ b/test/functional/ui/spell_spec.lua
@@ -20,10 +20,6 @@ describe("'spell'", function()
     })
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it('joins long lines #7937', function()
     feed_command('set spell')
     insert([[

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -22,10 +22,6 @@ describe('Screen', function()
     } )
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   describe("match and conceal", function()
 
     before_each(function()

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -17,10 +17,6 @@ describe('ui/ext_tabline', function()
     end)
   end)
 
-  after_each(function()
-    screen:detach()
-  end)
-
   it('publishes UI events', function()
     command("tabedit another-tab")
 


### PR DESCRIPTION
#8221 took a short-cut when implementing the tests: screen.lua would translate the linegrid highlight ids back into the old per-cell attribute description.

Apart from cleaning up technical debt, this enables to check both rgb and cterm colors in the same expect(), which previously was needlessly restricted to ext_hlstate tests only. This will be needed for #10994 tests, but I though it would make sense to test this separately against master. It should cause no functional change, unless some tests does some thing weird, like terminal/helpers.lua which contained a duplicated highlight description.