### PR TITLE
scripts/vim-patch.sh: lazy update Vim source

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -482,16 +482,12 @@ show_vimpatches() {
   done
 
   printf "\nInstructions:
-  To port one of the above patches to Neovim, execute this script with the patch revision as argument and follow the instructions.
-
-  Examples: '%s -p 7.4.487'
-            '%s -p 1e8ebf870720e7b671f98f22d653009826304c4f'
-            (There is also '-P' for more automation.)
+  To port one of the above patches to Neovim, execute this script with the patch revision as argument and follow the instructions, e.g.
+  '%s -p v8.0.1234', or '%s -P v8.0.1234'
 
   NOTE: Please port the _oldest_ patch if you possibly can.
-        Out-of-order patches increase the possibility of bugs.
         You can use '%s -l path/to/file' to see what patches are missing for a file.
-" "${BASENAME}" "${BASENAME}" "${BASENAME}"
+" "${BASENAME}" "${BASENAME}"
 }
 
 review_commit() {

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -85,13 +85,11 @@ clean_files() {
 get_vim_sources() {
   require_executable git
 
-  local update=$1
-
   if [[ ! -d ${VIM_SOURCE_DIR} ]]; then
     echo "Cloning Vim into: ${VIM_SOURCE_DIR}"
     git clone https://github.com/vim/vim.git "${VIM_SOURCE_DIR}"
     cd "${VIM_SOURCE_DIR}"
-  elif [[ "$update" == 1 ]]; then
+  elif [[ "${1-}" == update ]]; then
     cd "${VIM_SOURCE_DIR}"
     if ! [ -d ".git" ] \
         && ! [ "$(git rev-parse --show-toplevel)" = "${VIM_SOURCE_DIR}" ]; then
@@ -153,7 +151,7 @@ assign_commit_details() {
   local get_vim_commit_cmd="git -C ${VIM_SOURCE_DIR} log -1 --format=%H ${vim_commit_ref} --"
   vim_commit=$($get_vim_commit_cmd 2>&1) || {
     # Update Vim sources.
-    get_vim_sources 1
+    get_vim_sources update
     vim_commit=$($get_vim_commit_cmd 2>&1) || {
       >&2 msg_err "Couldn't find Vim revision '${vim_commit_ref}': git error: ${vim_commit}."
       exit 3
@@ -216,7 +214,7 @@ preprocess_patch() {
 }
 
 get_vimpatch() {
-  get_vim_sources 0
+  get_vim_sources
 
   assign_commit_details "${1}"
 
@@ -465,7 +463,7 @@ list_missing_vimpatches() {
 # Prints a human-formatted list of Vim commits, with instructional messages.
 # Passes "$@" onto list_missing_vimpatches (args for git-log).
 show_vimpatches() {
-  get_vim_sources 1
+  get_vim_sources update
   printf "Vim patches missing from Neovim:\n"
 
   local -A runtime_commits
@@ -559,7 +557,7 @@ review_pr() {
   require_executable nvim
   require_executable jq
 
-  get_vim_sources 0
+  get_vim_sources
 
   local pr="${1}"
   echo
@@ -628,7 +626,7 @@ while getopts "hlLMVp:P:g:r:s" opt; do
       exit 0
       ;;
     V)
-      get_vim_sources 1
+      get_vim_sources update
       exit 0
       ;;
     *)


### PR DESCRIPTION
Mainly inspired via https://github.com/neovim/neovim/pull/11182, but I've thought that `-l` should still update it always for now.  (With #11182 you can use `-L --format='%H %s'` then yourself for now.)