### PR TITLE
[WIP] Renames Window to NvimWindow

### DIFF
--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -79,7 +79,7 @@ typedef struct {
 } String;
 
 REMOTE_TYPE(Buffer);
-REMOTE_TYPE(Window);
+REMOTE_TYPE(NvimWindow);
 REMOTE_TYPE(Tabpage);
 
 typedef struct object Object;
@@ -107,7 +107,7 @@ typedef enum {
   kObjectTypeLuaRef,
   // EXT types, cannot be split or reordered, see #EXT_OBJECT_TYPE_SHIFT
   kObjectTypeBuffer,
-  kObjectTypeWindow,
+  kObjectTypeNvimWindow,
   kObjectTypeTabpage,
 } ObjectType;
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -637,7 +637,7 @@ buf_T *find_buffer_by_handle(Buffer buffer, Error *err)
   return rv;
 }
 
-win_T *find_window_by_handle(Window window, Error *err)
+win_T *find_window_by_handle(NvimWindow window, Error *err)
 {
   if (window == 0) {
     return curwin;
@@ -1080,7 +1080,7 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
       break;
 
     case kObjectTypeBuffer:
-    case kObjectTypeWindow:
+    case kObjectTypeNvimWindow:
     case kObjectTypeTabpage:
     case kObjectTypeInteger:
       STATIC_ASSERT(sizeof(obj.data.integer) <= sizeof(varnumber_T),
@@ -1181,7 +1181,7 @@ void api_free_object(Object value)
     case kObjectTypeInteger:
     case kObjectTypeFloat:
     case kObjectTypeBuffer:
-    case kObjectTypeWindow:
+    case kObjectTypeNvimWindow:
     case kObjectTypeTabpage:
       break;
 
@@ -1318,7 +1318,7 @@ static void init_type_metadata(Dictionary *metadata)
 
   Dictionary window_metadata = ARRAY_DICT_INIT;
   PUT(window_metadata, "id",
-      INTEGER_OBJ(kObjectTypeWindow - EXT_OBJECT_TYPE_SHIFT));
+      INTEGER_OBJ(kObjectTypeNvimWindow - EXT_OBJECT_TYPE_SHIFT));
   PUT(window_metadata, "prefix", STRING_OBJ(cstr_to_string("nvim_win_")));
 
   Dictionary tabpage_metadata = ARRAY_DICT_INIT;
@@ -1327,7 +1327,7 @@ static void init_type_metadata(Dictionary *metadata)
   PUT(tabpage_metadata, "prefix", STRING_OBJ(cstr_to_string("nvim_tabpage_")));
 
   PUT(types, "Buffer", DICTIONARY_OBJ(buffer_metadata));
-  PUT(types, "Window", DICTIONARY_OBJ(window_metadata));
+  PUT(types, "NvimWindow", DICTIONARY_OBJ(window_metadata));
   PUT(types, "Tabpage", DICTIONARY_OBJ(tabpage_metadata));
 
   PUT(*metadata, "types", DICTIONARY_OBJ(types));

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -32,8 +32,8 @@
     .type = kObjectTypeBuffer, \
     .data.integer = s })
 
-#define WINDOW_OBJ(s) ((Object) { \
-    .type = kObjectTypeWindow, \
+#define NVIMWINDOW_OBJ(s) ((Object) { \
+    .type = kObjectTypeNvimWindow, \
     .data.integer = s })
 
 #define TABPAGE_OBJ(s) ((Object) { \
@@ -81,7 +81,7 @@
 #define api_init_float
 #define api_init_string = STRING_INIT
 #define api_init_buffer
-#define api_init_window
+#define api_init_nvimwindow
 #define api_init_tabpage
 #define api_init_object = NIL
 #define api_init_array = ARRAY_DICT_INIT
@@ -91,7 +91,7 @@
 #define api_free_integer(value)
 #define api_free_float(value)
 #define api_free_buffer(value)
-#define api_free_window(value)
+#define api_free_nvimwindow(value)
 #define api_free_tabpage(value)
 
 /// Structure used for saving state for :try

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -17,7 +17,7 @@
 /// @param tabpage  Tabpage handle, or 0 for current tabpage
 /// @param[out] err Error details, if any
 /// @return List of windows in `tabpage`
-ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, Error *err)
+ArrayOf(NvimWindow) nvim_tabpage_list_wins(Tabpage tabpage, Error *err)
   FUNC_API_SINCE(1)
 {
   Array rv = ARRAY_DICT_INIT;
@@ -35,7 +35,7 @@ ArrayOf(Window) nvim_tabpage_list_wins(Tabpage tabpage, Error *err)
   size_t i = 0;
 
   FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
-    rv.items[i++] = WINDOW_OBJ(wp->handle);
+    rv.items[i++] = NVIMWINDOW_OBJ(wp->handle);
   }
 
   return rv;
@@ -144,10 +144,10 @@ Object tabpage_del_var(Tabpage tabpage, String name, Error *err)
 /// @param tabpage  Tabpage handle, or 0 for current tabpage
 /// @param[out] err Error details, if any
 /// @return Window handle
-Window nvim_tabpage_get_win(Tabpage tabpage, Error *err)
+NvimWindow nvim_tabpage_get_win(Tabpage tabpage, Error *err)
   FUNC_API_SINCE(1)
 {
-  Window rv = 0;
+  NvimWindow rv = 0;
   tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab || !valid_tabpage(tab)) {

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -100,13 +100,13 @@ void raw_line(Integer grid, Integer row, Integer startcol,
 void event(char *name, Array args, bool *args_consumed)
   FUNC_API_NOEXPORT;
 
-void win_pos(Integer grid, Window win, Integer startrow,
+void win_pos(Integer grid, NvimWindow win, Integer startrow,
              Integer startcol, Integer width, Integer height)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid,
+void win_float_pos(Integer grid, NvimWindow win, String anchor, Integer anchor_grid,
                    Float anchor_row, Float anchor_col, Boolean focusable)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void win_external_pos(Integer grid, Window win)
+void win_external_pos(Integer grid, NvimWindow win)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_hide(Integer grid)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -981,7 +981,7 @@ void nvim_set_current_buf(Buffer buffer, Error *err)
 /// Gets the current list of window handles.
 ///
 /// @return List of window handles
-ArrayOf(Window) nvim_list_wins(void)
+ArrayOf(NvimWindow) nvim_list_wins(void)
   FUNC_API_SINCE(1)
 {
   Array rv = ARRAY_DICT_INIT;
@@ -994,7 +994,7 @@ ArrayOf(Window) nvim_list_wins(void)
   size_t i = 0;
 
   FOR_ALL_TAB_WINDOWS(tp, wp) {
-    rv.items[i++] = WINDOW_OBJ(wp->handle);
+    rv.items[i++] = NVIMWINDOW_OBJ(wp->handle);
   }
 
   return rv;
@@ -1003,7 +1003,7 @@ ArrayOf(Window) nvim_list_wins(void)
 /// Gets the current window.
 ///
 /// @return Window handle
-Window nvim_get_current_win(void)
+NvimWindow nvim_get_current_win(void)
   FUNC_API_SINCE(1)
 {
   return curwin->handle;
@@ -1013,7 +1013,7 @@ Window nvim_get_current_win(void)
 ///
 /// @param window Window handle
 /// @param[out] err Error details, if any
-void nvim_set_current_win(Window window, Error *err)
+void nvim_set_current_win(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -1160,7 +1160,7 @@ fail:
 /// @param[out] err Error details, if any
 ///
 /// @return Window handle, or 0 on error
-Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config,
+NvimWindow nvim_open_win(Buffer buffer, Boolean enter, Dictionary config,
                      Error *err)
   FUNC_API_SINCE(6)
 {

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -25,7 +25,7 @@
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return Buffer handle
-Buffer nvim_win_get_buf(Window window, Error *err)
+Buffer nvim_win_get_buf(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -42,7 +42,7 @@ Buffer nvim_win_get_buf(Window window, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param buffer   Buffer handle
 /// @param[out] err Error details, if any
-void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
+void nvim_win_set_buf(NvimWindow window, Buffer buffer, Error *err)
   FUNC_API_SINCE(5)
 {
   win_T *win = find_window_by_handle(window, err), *save_curwin = curwin;
@@ -81,7 +81,7 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return (row, col) tuple
-ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
+ArrayOf(Integer, 2) nvim_win_get_cursor(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   Array rv = ARRAY_DICT_INIT;
@@ -100,7 +100,7 @@ ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param pos      (row, col) tuple representing the new position
 /// @param[out] err Error details, if any
-void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
+void nvim_win_set_cursor(NvimWindow window, ArrayOf(Integer, 2) pos, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -150,7 +150,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return Height as a count of rows
-Integer nvim_win_get_height(Window window, Error *err)
+Integer nvim_win_get_height(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -168,7 +168,7 @@ Integer nvim_win_get_height(Window window, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param height   Height as a count of rows
 /// @param[out] err Error details, if any
-void nvim_win_set_height(Window window, Integer height, Error *err)
+void nvim_win_set_height(NvimWindow window, Integer height, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -195,7 +195,7 @@ void nvim_win_set_height(Window window, Integer height, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return Width as a count of columns
-Integer nvim_win_get_width(Window window, Error *err)
+Integer nvim_win_get_width(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -213,7 +213,7 @@ Integer nvim_win_get_width(Window window, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param width    Width as a count of columns
 /// @param[out] err Error details, if any
-void nvim_win_set_width(Window window, Integer width, Error *err)
+void nvim_win_set_width(NvimWindow window, Integer width, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -241,7 +241,7 @@ void nvim_win_set_width(Window window, Integer width, Error *err)
 /// @param name     Variable name
 /// @param[out] err Error details, if any
 /// @return Variable value
-Object nvim_win_get_var(Window window, String name, Error *err)
+Object nvim_win_get_var(NvimWindow window, String name, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -259,7 +259,7 @@ Object nvim_win_get_var(Window window, String name, Error *err)
 /// @param name     Variable name
 /// @param value    Variable value
 /// @param[out] err Error details, if any
-void nvim_win_set_var(Window window, String name, Object value, Error *err)
+void nvim_win_set_var(NvimWindow window, String name, Object value, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -276,7 +276,7 @@ void nvim_win_set_var(Window window, String name, Object value, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param name     Variable name
 /// @param[out] err Error details, if any
-void nvim_win_del_var(Window window, String name, Error *err)
+void nvim_win_del_var(NvimWindow window, String name, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -300,7 +300,7 @@ void nvim_win_del_var(Window window, String name, Error *err)
 ///
 ///         @warning It may return nil if there was no previous value
 ///                  or if previous value was `v:null`.
-Object window_set_var(Window window, String name, Object value, Error *err)
+Object window_set_var(NvimWindow window, String name, Object value, Error *err)
 {
   win_T *win = find_window_by_handle(window, err);
 
@@ -319,7 +319,7 @@ Object window_set_var(Window window, String name, Object value, Error *err)
 /// @param name     variable name
 /// @param[out] err Error details, if any
 /// @return Old value
-Object window_del_var(Window window, String name, Error *err)
+Object window_del_var(NvimWindow window, String name, Error *err)
 {
   win_T *win = find_window_by_handle(window, err);
 
@@ -336,7 +336,7 @@ Object window_del_var(Window window, String name, Error *err)
 /// @param name     Option name
 /// @param[out] err Error details, if any
 /// @return Option value
-Object nvim_win_get_option(Window window, String name, Error *err)
+Object nvim_win_get_option(NvimWindow window, String name, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -356,7 +356,7 @@ Object nvim_win_get_option(Window window, String name, Error *err)
 /// @param name     Option name
 /// @param value    Option value
 /// @param[out] err Error details, if any
-void nvim_win_set_option(uint64_t channel_id, Window window,
+void nvim_win_set_option(uint64_t channel_id, NvimWindow window,
                          String name, Object value, Error *err)
   FUNC_API_SINCE(1)
 {
@@ -374,7 +374,7 @@ void nvim_win_set_option(uint64_t channel_id, Window window,
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return (row, col) tuple with the window position
-ArrayOf(Integer, 2) nvim_win_get_position(Window window, Error *err)
+ArrayOf(Integer, 2) nvim_win_get_position(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   Array rv = ARRAY_DICT_INIT;
@@ -393,7 +393,7 @@ ArrayOf(Integer, 2) nvim_win_get_position(Window window, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return Tabpage that contains the window
-Tabpage nvim_win_get_tabpage(Window window, Error *err)
+Tabpage nvim_win_get_tabpage(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   Tabpage rv = 0;
@@ -411,7 +411,7 @@ Tabpage nvim_win_get_tabpage(Window window, Error *err)
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return Window number
-Integer nvim_win_get_number(Window window, Error *err)
+Integer nvim_win_get_number(NvimWindow window, Error *err)
   FUNC_API_SINCE(1)
 {
   int rv = 0;
@@ -431,7 +431,7 @@ Integer nvim_win_get_number(Window window, Error *err)
 ///
 /// @param window Window handle, or 0 for current window
 /// @return true if the window is valid, false otherwise
-Boolean nvim_win_is_valid(Window window)
+Boolean nvim_win_is_valid(NvimWindow window)
   FUNC_API_SINCE(1)
 {
   Error stub = ERROR_INIT;
@@ -453,7 +453,7 @@ Boolean nvim_win_is_valid(Window window)
 /// @param      config  Map defining the window configuration,
 ///                     see |nvim_open_win()|
 /// @param[out] err     Error details, if any
-void nvim_win_set_config(Window window, Dictionary config, Error *err)
+void nvim_win_set_config(NvimWindow window, Dictionary config, Error *err)
   FUNC_API_SINCE(6)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -491,7 +491,7 @@ void nvim_win_set_config(Window window, Dictionary config, Error *err)
 /// @param      window Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return     Map defining the window configuration, see |nvim_open_win()|
-Dictionary nvim_win_get_config(Window window, Error *err)
+Dictionary nvim_win_get_config(NvimWindow window, Error *err)
   FUNC_API_SINCE(6)
 {
   Dictionary rv = ARRAY_DICT_INIT;
@@ -540,7 +540,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
 ///                 unwritten changes can be closed. The buffer will become
 ///                 hidden, even if 'hidden' is not set.
 /// @param[out] err Error details, if any
-void nvim_win_close(Window window, Boolean force, Error *err)
+void nvim_win_close(NvimWindow window, Boolean force, Error *err)
   FUNC_API_SINCE(6)
 {
   win_T *win = find_window_by_handle(window, err);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1033,7 +1033,7 @@ typedef enum {
 } WinStyle;
 
 typedef struct {
-  Window window;
+  NvimWindow window;
   lpos_T bufpos;
   int height, width;
   double row, col;

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -222,7 +222,7 @@ for i = 1, #functions do
       converted = 'arg_'..j
       local rt = real_type(param[1])
       if rt ~= 'Object' then
-        if rt:match('^Buffer$') or rt:match('^Window$') or rt:match('^Tabpage$') then
+        if rt:match('^Buffer$') or rt:match('^NvimWindow$') or rt:match('^Tabpage$') then
           -- Buffer, Window, and Tabpage have a specific type, but are stored in integer
           output:write('\n  if (args.items['..
             (j - 1)..'].type == kObjectType'..rt..' && args.items['..(j - 1)..'].data.integer >= 0) {')
@@ -231,7 +231,7 @@ for i = 1, #functions do
           output:write('\n  if (args.items['..(j - 1)..'].type == kObjectType'..rt..') {')
           output:write('\n    '..converted..' = args.items['..(j - 1)..'].data.'..attr_name(rt)..';')
         end
-        if rt:match('^Buffer$') or rt:match('^Window$') or rt:match('^Tabpage$') or rt:match('^Boolean$') then
+        if rt:match('^Buffer$') or rt:match('^NvimWindow$') or rt:match('^Tabpage$') or rt:match('^Boolean$') then
           -- accept nonnegative integers for Booleans, Buffers, Windows and Tabpages
           output:write('\n  } else if (args.items['..
             (j - 1)..'].type == kObjectTypeInteger && args.items['..(j - 1)..'].data.integer >= 0) {')

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -737,7 +737,7 @@ void nlua_push_##type(lua_State *lstate, const type item, bool special) \
 }
 
 GENERATE_INDEX_FUNCTION(Buffer)
-GENERATE_INDEX_FUNCTION(Window)
+GENERATE_INDEX_FUNCTION(NvimWindow)
 GENERATE_INDEX_FUNCTION(Tabpage)
 
 #undef GENERATE_INDEX_FUNCTION
@@ -779,7 +779,7 @@ void nlua_push_Object(lua_State *lstate, const Object obj, bool special)
       break; \
     }
     ADD_REMOTE_TYPE(Buffer)
-    ADD_REMOTE_TYPE(Window)
+    ADD_REMOTE_TYPE(NvimWindow)
     ADD_REMOTE_TYPE(Tabpage)
 #undef ADD_REMOTE_TYPE
   }
@@ -1233,7 +1233,7 @@ type nlua_pop_##type(lua_State *lstate, Error *err) \
 }
 
 GENERATE_INDEX_FUNCTION(Buffer)
-GENERATE_INDEX_FUNCTION(Window)
+GENERATE_INDEX_FUNCTION(NvimWindow)
 GENERATE_INDEX_FUNCTION(Tabpage)
 
 #undef GENERATE_INDEX_FUNCTION

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -66,7 +66,7 @@ void msgpack_rpc_helpers_init(void)
 }
 
 HANDLE_TYPE_CONVERSION_IMPL(Buffer, buffer)
-HANDLE_TYPE_CONVERSION_IMPL(Window, window)
+HANDLE_TYPE_CONVERSION_IMPL(NvimWindow, window)
 HANDLE_TYPE_CONVERSION_IMPL(Tabpage, tabpage)
 
 typedef struct {
@@ -236,8 +236,8 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
             ret = msgpack_rpc_to_buffer(cur.mobj, &cur.aobj->data.integer);
             break;
           }
-          case kObjectTypeWindow: {
-            cur.aobj->type = kObjectTypeWindow;
+          case kObjectTypeNvimWindow: {
+            cur.aobj->type = kObjectTypeNvimWindow;
             ret = msgpack_rpc_to_window(cur.mobj, &cur.aobj->data.integer);
             break;
           }
@@ -379,8 +379,8 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
   kv_push(stack, ((APIToMPObjectStackItem) { &result, false, 0 }));
   while (kv_size(stack)) {
     APIToMPObjectStackItem cur = kv_last(stack);
-    STATIC_ASSERT(kObjectTypeWindow == kObjectTypeBuffer + 1
-                  && kObjectTypeTabpage == kObjectTypeWindow + 1,
+    STATIC_ASSERT(kObjectTypeNvimWindow == kObjectTypeBuffer + 1
+                  && kObjectTypeTabpage == kObjectTypeNvimWindow + 1,
                   "Buffer, window and tabpage enum items are in order");
     switch (cur.aobj->type) {
       case kObjectTypeNil:
@@ -411,7 +411,7 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
         msgpack_rpc_from_buffer(cur.aobj->data.integer, res);
         break;
       }
-      case kObjectTypeWindow: {
+      case kObjectTypeNvimWindow: {
         msgpack_rpc_from_window(cur.aobj->data.integer, res);
         break;
       }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -883,7 +883,7 @@ bool parse_float_config(Dictionary config, FloatConfig *fconfig, bool reconf,
     } else if (!strcmp(key, "win")) {
       has_window = true;
       if (val.type != kObjectTypeInteger
-          && val.type != kObjectTypeWindow) {
+          && val.type != kObjectTypeNvimWindow) {
         api_set_error(err, kErrorTypeValidation,
                       "'win' key must be Integer or Window");
         return false;


### PR DESCRIPTION
## Background
I tried to compile a project with libnvim and wayland-client libraries and hit upon a roadblock since both projects implement a Window datastructure. To get around this I renamed Window to NvimWindow. I posted this to see if anyone else has run into this and see what the maintainers think. I still think just naming it Window is cleaner but wanted to get some second opinions.

## Work done
I've renamed all instances I've found to NvimWindow, however I haven't touched any documentation or tests yet. Wanted to get this out there to gauge the interest.