### PR TITLE
Implement saving full paths for 'backupdir'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -843,6 +843,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  name, precede it with a backslash.
 	- To include a comma in a directory name precede it with a backslash.
 	- A directory name may end in an '/'.
+ 	- For Unix and Win32, if a directory ends in two path separators "//"
+ 	  (Unix, Win32) or "\\" (Win32), the swap file name will be built from
+ 	  the complete path to the file with all path separators substituted
+ 	  to percent '%' signs. This will ensure file name uniqueness in the
+ 	  preserve directory.
+ 	  On Win32, when a separating comma is following, you must use "//",
+ 	  since "\\" will include the comma in the file name. In general, it
+ 	  is recommended to use '//', instead of '\\'.
 	- Environment variables are expanded |:set_env|.
 	- Careful with '\' characters, type one before a space, type two to
 	  get one in the option (see |option-backslash|), for example: >
@@ -1987,11 +1995,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  put the swap file relative to where the edited file is.  The leading
 	  "." is replaced with the path name of the edited file.
 	- For Unix and Win32, if a directory ends in two path separators "//"
-	  or "\\", the swap file name will be built from the complete path to
-	  the file with all path separators substituted to percent '%' signs.
-	  This will ensure file name uniqueness in the preserve directory.
+ 	  (Unix, Win32) or "\\" (Win32), the swap file name will be built from
+ 	  the complete path to the file with all path separators substituted
+ 	  to percent '%' signs. This will ensure file name uniqueness in the
+ 	  preserve directory.
 	  On Win32, when a separating comma is following, you must use "//",
-	  since "\\" will include the comma in the file name.
+	  since "\\" will include the comma in the file name. In general, it
+	  is recommended to use '//', instead of '\\'.
 	- Spaces after the comma are ignored, other spaces are considered part
 	  of the directory name.  To have a space at the start of a directory
 	  name, precede it with a backslash.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2650,6 +2650,7 @@ buf_write(
    */
   if (!(append && *p_pm == NUL) && !filtering && perm >= 0 && dobackup) {
     FileInfo file_info;
+    const bool kNoPrependDot = false;
 
     if ((bkc & BKC_YES) || append) {       /* "yes" */
       backup_copy = TRUE;
@@ -2737,7 +2738,15 @@ buf_write(
       int some_error = false;
       char_u      *dirp;
       char_u      *rootname;
+      char_u      *p;
+      char_u      *copybuf;
 
+      copybuf = verbose_try_malloc(BUFSIZE + 1);
+      if (copybuf == NULL) {
+        // out of memory
+        some_error = TRUE;
+        goto nobackup;
+      }
       /*
        * Try to make the backup in each directory in the 'bdir' option.
        *
@@ -2755,8 +2764,19 @@ buf_write(
         /*
          * Isolate one directory name, using an entry in 'bdir'.
          */
-        (void)copy_option_part(&dirp, IObuff, IOSIZE, ",");
-        rootname = get_file_in_dir(fname, IObuff);
+        (void)copy_option_part(&dirp, copybuf, BUFSIZE, ",");
+        p = copybuf + STRLEN(copybuf);
+        if (after_pathsep((char *)copybuf, (char *)p) && p[-1] == p[-2]) {
+          // Ends with '//', Use Full path
+          if ((p = (char_u *)make_percent_swname((char *)copybuf,
+                                                 (char *)fname)) != NULL) {
+            backup = (char_u *)modname((char *)p,
+                                       (char *)backup_ext,
+                                       kNoPrependDot);
+          }
+        }
+
+        rootname = get_file_in_dir(fname, copybuf);
         if (rootname == NULL) {
           some_error = TRUE;                /* out of memory */
           goto nobackup;
@@ -2767,7 +2787,12 @@ buf_write(
           /*
            * Make backup file name.
            */
-          backup = (char_u *)modname((char *)rootname, (char *)backup_ext, FALSE);
+          if (backup == NULL) {
+            backup = (char_u *)modname((char *)rootname,
+                                       (char *)backup_ext,
+                                       kNoPrependDot);
+          }
+
           if (backup == NULL) {
             xfree(rootname);
             some_error = TRUE;                          /* out of memory */
@@ -2853,6 +2878,8 @@ buf_write(
       }
 
 nobackup:
+      xfree(copybuf);
+
       if (backup == NULL && errmsg == NULL) {
         SET_ERRMSG(_(
             "E509: Cannot create backup file (add ! to override)"));
@@ -2893,12 +2920,27 @@ nobackup:
          * Isolate one directory name and make the backup file name.
          */
         (void)copy_option_part(&dirp, IObuff, IOSIZE, ",");
-        rootname = get_file_in_dir(fname, IObuff);
-        if (rootname == NULL)
-          backup = NULL;
-        else {
-          backup = (char_u *)modname((char *)rootname, (char *)backup_ext, FALSE);
-          xfree(rootname);
+        p = IObuff + STRLEN(IObuff);
+        if (after_pathsep((char *)IObuff, (char *)p) && p[-1] == p[-2]) {
+          // Ends with '//', Use Full path
+          if ((p = (char_u *)make_percent_swname((char *)IObuff,
+                                                 (char *)fname)) != NULL) {
+            backup = (char_u *)modname((char *)p,
+                                       (char *)backup_ext,
+                                       kNoPrependDot);
+          }
+        }
+
+        if (backup == NULL) {
+          rootname = get_file_in_dir(fname, IObuff);
+          if (rootname == NULL) {
+            backup = NULL;
+          } else {
+            backup = (char_u *)modname((char *)rootname,
+                                       (char *)backup_ext,
+                                       kNoPrependDot);
+            xfree(rootname);
+          }
         }
 
         if (backup != NULL) {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2739,14 +2739,7 @@ buf_write(
       char_u      *dirp;
       char_u      *rootname;
       char_u      *p;
-      char_u      *copybuf;
 
-      copybuf = verbose_try_malloc(BUFSIZE + 1);
-      if (copybuf == NULL) {
-        // out of memory
-        some_error = TRUE;
-        goto nobackup;
-      }
       /*
        * Try to make the backup in each directory in the 'bdir' option.
        *
@@ -2764,11 +2757,11 @@ buf_write(
         /*
          * Isolate one directory name, using an entry in 'bdir'.
          */
-        (void)copy_option_part(&dirp, copybuf, BUFSIZE, ",");
-        p = copybuf + STRLEN(copybuf);
-        if (after_pathsep((char *)copybuf, (char *)p) && p[-1] == p[-2]) {
+        (void)copy_option_part(&dirp, IObuff, IOSIZE, ",");
+        p = IObuff + STRLEN(IObuff);
+        if (after_pathsep((char *)IObuff, (char *)p) && p[-1] == p[-2]) {
           // Ends with '//', Use Full path
-          if ((p = (char_u *)make_percent_swname((char *)copybuf,
+          if ((p = (char_u *)make_percent_swname((char *)IObuff,
                                                  (char *)fname)) != NULL) {
             backup = (char_u *)modname((char *)p,
                                        (char *)backup_ext,
@@ -2776,7 +2769,7 @@ buf_write(
           }
         }
 
-        rootname = get_file_in_dir(fname, copybuf);
+        rootname = get_file_in_dir(fname, IObuff);
         if (rootname == NULL) {
           some_error = TRUE;                /* out of memory */
           goto nobackup;
@@ -2878,8 +2871,6 @@ buf_write(
       }
 
 nobackup:
-      xfree(copybuf);
-
       if (backup == NULL && errmsg == NULL) {
         SET_ERRMSG(_(
             "E509: Cannot create backup file (add ! to override)"));

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1437,7 +1437,7 @@ recover_names (
  * Append the full path to name with path separators made into percent
  * signs, to dir. An unnamed buffer is handled as "" (<currentdir>/"")
  */
-static char *make_percent_swname(const char *dir, char *name)
+char *make_percent_swname(const char *dir, char *name)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   char *d = NULL;


### PR DESCRIPTION
The original patch seems to have been a bit lost:
https://github.com/neovim/neovim/commit/bd551cb6f523e9d82e3641cb85ee501167cc4dc7

I've just merged this with the current master.