### PR TITLE
ex_echo: fix check for got_int

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -233,7 +233,10 @@ void msg_multiline_attr(const char *s, int attr, bool check_int)
 {
   const char *next_spec = s;
 
-  while (next_spec != NULL && (!check_int || !got_int)) {
+  while (next_spec != NULL) {
+    if (check_int && got_int) {
+      return;
+    }
     next_spec = strpbrk(s, "\t\n\r");
 
     if (next_spec != NULL) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1125,7 +1125,7 @@ aliquip ex ea commodo consequat.]])
 
   it('can be quit', function()
     screen:try_resize(25,5)
-    feed(':echon join(map(range(0, &lines*2), "v:val"), "\\n")<cr>')
+    feed(':echon join(map(range(0, &lines*10), "v:val"), "\\n")<cr>')
     screen:expect{grid=[[
       0                        |
       1                        |


### PR DESCRIPTION
It needs to return to not output any remaining parts.

Followup to https://github.com/neovim/neovim/pull/10926
Ref: https://github.com/neovim/neovim/issues/10923