### PR TITLE
vim-patch:8.1.2096: too many #ifdefs

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5479,10 +5479,10 @@ insertchar (
   if (c == NUL)             /* only formatting was wanted */
     return;
 
-  /* Check whether this character should end a comment. */
+  // Check whether this character should end a comment.
   if (did_ai && c == end_comment_pending) {
     char_u  *line;
-    char_u lead_end[COM_MAX_LEN];           /* end-comment string */
+    char_u lead_end[COM_MAX_LEN];  // end-comment string
     int middle_len, end_len;
     int i;
 
@@ -5490,39 +5490,40 @@ insertchar (
      * Need to remove existing (middle) comment leader and insert end
      * comment leader.  First, check what comment leader we can find.
      */
-    i = get_leader_len(line = get_cursor_line_ptr(), &p, FALSE, TRUE);
-    if (i > 0 && vim_strchr(p, COM_MIDDLE) != NULL) {   /* Just checking */
-      /* Skip middle-comment string */
-      while (*p && p[-1] != ':')        /* find end of middle flags */
-        ++p;
+    i = get_leader_len(line = get_cursor_line_ptr(), &p, false, true);
+    if (i > 0 && vim_strchr(p, COM_MIDDLE) != NULL) {  // Just checking
+      // Skip middle-comment string
+      while (*p && p[-1] != ':') {  // find end of middle flags
+        p++;
+      }
       middle_len = copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
-      /* Don't count trailing white space for middle_len */
-      while (middle_len > 0 && ascii_iswhite(lead_end[middle_len - 1]))
-        --middle_len;
+      // Don't count trailing white space for middle_len
+      while (middle_len > 0 && ascii_iswhite(lead_end[middle_len - 1])) {
+        middle_len--;
+      }
 
-      /* Find the end-comment string */
-      while (*p && p[-1] != ':')        /* find end of end flags */
-        ++p;
+      // Find the end-comment string
+      while (*p && p[-1] != ':') {  // find end of end flags
+        p++;
+      }
       end_len = copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
 
-      /* Skip white space before the cursor */
+      // Skip white space before the cursor
       i = curwin->w_cursor.col;
       while (--i >= 0 && ascii_iswhite(line[i]))
         ;
       i++;
 
-      /* Skip to before the middle leader */
+      // Skip to before the middle leader
       i -= middle_len;
 
-      /* Check some expected things before we go on */
+      // Check some expected things before we go on
       if (i >= 0 && lead_end[end_len - 1] == end_comment_pending) {
-        /* Backspace over all the stuff we want to replace */
+        // Backspace over all the stuff we want to replace
         backspace_until_column(i);
 
-        /*
-         * Insert the end-comment string, except for the last
-         * character, which will get inserted as normal later.
-         */
+        // Insert the end-comment string, except for the last
+        // character, which will get inserted as normal later.
         ins_bytes_len(lead_end, end_len - 1);
       }
     }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -792,8 +792,6 @@ int prompt_for_number(int *mouse_used)
       cmdline_row = msg_row - 1;
     }
     need_wait_return = false;
-    msg_didany = false;
-    msg_didout = false;
   } else {
     cmdline_row = save_cmdline_row;
   }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -270,20 +270,21 @@ void shift_line(
     int left,
     int round,
     int amount,
-    int call_changed_bytes         /* call changed_bytes() */
+    int call_changed_bytes  // call changed_bytes()
 )
 {
   int count;
   int i, j;
   int p_sw = get_sw_value(curbuf);
 
-  count = get_indent();         /* get current indent */
+  count = get_indent();  // get current indent
 
-  if (round) {                  /* round off indent */
-    i = count / p_sw;           /* number of p_sw rounded down */
-    j = count % p_sw;           /* extra spaces */
-    if (j && left)              /* first remove extra spaces */
-      --amount;
+  if (round) {  // round off indent
+    i = count / p_sw;  // number of p_sw rounded down
+    j = count % p_sw;  // extra spaces
+    if (j && left) {  // first remove extra spaces
+      amount--;
+    }
     if (left) {
       i -= amount;
       if (i < 0)
@@ -291,7 +292,7 @@ void shift_line(
     } else
       i += amount;
     count = i * p_sw;
-  } else {            /* original vi indent */
+  } else {  // original vi indent
     if (left) {
       count -= p_sw * amount;
       if (count < 0)
@@ -300,11 +301,12 @@ void shift_line(
       count += p_sw * amount;
   }
 
-  /* Set new indent */
-  if (State & VREPLACE_FLAG)
-    change_indent(INDENT_SET, count, FALSE, NUL, call_changed_bytes);
-  else
+  // Set new indent
+  if (State & VREPLACE_FLAG) {
+    change_indent(INDENT_SET, count, false, NUL, call_changed_bytes);
+  } else {
     (void)set_indent(count, call_changed_bytes ? SIN_CHANGED : 0);
+  }
 }
 
 /*
@@ -4281,15 +4283,13 @@ int paragraph_start(linenr_T lnum)
     return TRUE;                /* after empty line */
 
   do_comments = has_format_option(FO_Q_COMS);
-  if (fmt_check_par(lnum - 1
-          , &leader_len, &leader_flags, do_comments
-          ))
-    return TRUE;                /* after non-paragraph line */
+  if (fmt_check_par(lnum - 1, &leader_len, &leader_flags, do_comments)) {
+    return true;  // after non-paragraph line
+  }
 
-  if (fmt_check_par(lnum
-          , &next_leader_len, &next_leader_flags, do_comments
-          ))
-    return TRUE;                /* "lnum" is not a paragraph line */
+  if (fmt_check_par(lnum, &next_leader_len, &next_leader_flags, do_comments)) {
+    return true;  // "lnum" is not a paragraph line
+  }
 
   if (has_format_option(FO_WHITE_PAR) && !ends_in_white(lnum - 1))
     return TRUE;                /* missing trailing space in previous line. */


### PR DESCRIPTION
Problem:    Too many #ifdefs.
Solution:   Graduate FEAT_COMMENTS.
https://github.com/vim/vim/commit/8c96af9c05bfcac2d5ae081e098d4863db561511

Fixes https://github.com/vim/vim/issues/4972.