### PR TITLE
tests: tui_spec: fix waiting for terminal to be ready

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -924,7 +924,15 @@ describe('TUI FocusGained/FocusLost', function()
 
     feed_data(':terminal\n')
     -- Wait for terminal to be ready.
-    screen:expect{any='-- TERMINAL --'}
+    screen:expect{grid=[[
+      {1:r}eady $                                           |
+      [Process exited 0]                                |
+                                                        |
+                                                        |
+                                                        |
+      :terminal                                         |
+      {3:-- TERMINAL --}                                    |
+    ]]}
 
     feed_data('\027[I')
     screen:expect{grid=[[


### PR DESCRIPTION
The screen would have '-- TERMINAL --' already initially.

Related to flakiness of "TUI FocusGained/FocusLost in terminal-mode".