### PR TITLE
tests: let_spec: enable "multibyte env var to child process"

### DIFF
--- a/test/functional/eval/let_spec.lua
+++ b/test/functional/eval/let_spec.lua
@@ -59,10 +59,6 @@ describe(':let', function()
   end)
 
   it("multibyte env var to child process #8398 #9267",  function()
-    if (not helpers.iswin()) and helpers.isCI() then
-      -- Fails on non-Windows CI. Buffering/timing issue?
-      pending('fails on unix CI', function() end)
-    end
     local cmd_get_child_env = "let g:env_from_child = system(['"..nvim_dir.."/printenv-test', 'NVIM_TEST'])"
     command("let $NVIM_TEST = 'AìaB'")
     command(cmd_get_child_env)

--- a/test/functional/fixtures/printenv-test.c
+++ b/test/functional/fixtures/printenv-test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
                                  utf8_len,
                                  NULL,
                                  NULL);
-  fprintf(stderr, "%s", utf8_value);
+  fprintf(stdout, "%s", utf8_value);
   free(utf8_value);
 #else
   char *value = getenv(argv[1]);
@@ -52,8 +52,8 @@ int main(int argc, char **argv)
     fprintf(stderr, "env var not found: %s", argv[1]);
     return 1;
   }
-  // Print to stderr to avoid buffering.
-  fprintf(stderr, "%s", value);
+  fprintf(stdout, "%s", value);
 #endif
+  fflush(stdout);
   return 0;
 }


### PR DESCRIPTION
It passes on OpenBSD usually, but is flaky there: https://builds.sr.ht/~jmk/job/97195#task-test-586

I think we can fix and enable it in general.