### PR TITLE
system(), jobstart(): raise error on non-executable

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -51,6 +51,9 @@ function! provider#node#Detect() abort
   if exists('g:node_host_prog')
     return expand(g:node_host_prog)
   endif
+  if !executable('node')
+    return ''
+  endif
   if !s:is_minimum_version(v:null, 6, 0)
     return ''
   endif

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12542,6 +12542,9 @@ static char **tv_to_argv(typval_T *cmd_tv, const char **cmd, bool *executable)
   char *exe_resolved = NULL;
   if (!arg0 || !os_can_exe(arg0, &exe_resolved, true)) {
     if (arg0 && executable) {
+      char buf[IOSIZE];
+      snprintf(buf, sizeof(buf), "'%s' is not executable", arg0);
+      EMSG3(_(e_invargNval), "cmd", buf);
       *executable = false;
     }
     return NULL;

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -185,11 +185,10 @@ describe('jobs', function()
       return eval([[jobstart('')]])
     end
     local executable_jobid = new_job()
-    local nonexecutable_jobid = eval("jobstart(['"..(iswin()
-      and './test/functional/fixtures'
-      or  './test/functional/fixtures/non_executable.txt').."'])")
-    eq(-1, nonexecutable_jobid)
-    -- Should _not_ throw an error.
+
+    local exe = iswin() and './test/functional/fixtures' or './test/functional/fixtures/non_executable.txt'
+    eq("Vim:E475: Invalid value for argument cmd: '"..exe.."' is not executable",
+      pcall_err(eval, "jobstart(['"..exe.."'])"))
     eq("", eval("v:errmsg"))
     -- Non-executable job should not increment the job ids. #5465
     eq(executable_jobid + 1, new_job())

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -8,6 +8,7 @@ local command = helpers.command
 local exc_exec = helpers.exc_exec
 local iswin = helpers.iswin
 local os_kill = helpers.os_kill
+local pcall_err = helpers.pcall_err
 
 local Screen = require('test.functional.ui.screen')
 
@@ -32,8 +33,9 @@ describe('system()', function()
       return nvim_dir..'/printargs-test' .. (iswin() and '.exe' or '')
     end
 
-    it('sets v:shell_error if cmd[0] is not executable', function()
-      call('system', { 'this-should-not-exist' })
+    it('throws error if cmd[0] is not executable', function()
+      eq("Vim:E475: Invalid value for argument cmd: 'this-should-not-exist' is not executable",
+        pcall_err(call, 'system', { 'this-should-not-exist' }))
       eq(-1, eval('v:shell_error'))
     end)
 
@@ -48,7 +50,8 @@ describe('system()', function()
       eq(0, eval('v:shell_error'))
 
       -- Provoke a non-zero v:shell_error.
-      call('system', { 'this-should-not-exist' })
+      eq("Vim:E475: Invalid value for argument cmd: 'this-should-not-exist' is not executable",
+        pcall_err(call, 'system', { 'this-should-not-exist' }))
       local old_val = eval('v:shell_error')
       eq(-1, old_val)
 

--- a/test/functional/provider/nodejs_spec.lua
+++ b/test/functional/provider/nodejs_spec.lua
@@ -8,8 +8,9 @@ local retry = helpers.retry
 
 do
   clear()
-  if missing_provider('node') then
-    pending("Missing nodejs host, or nodejs version is too old.", function()end)
+  local reason = missing_provider('node')
+  if reason then
+    pending(string.format("Missing nodejs host, or nodejs version is too old (%s)", reason), function() end)
     return
   end
 end

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -10,13 +10,14 @@ local pcall_err = helpers.pcall_err
 
 do
   clear()
-  if missing_provider('python3') then
+  local reason = missing_provider('python3')
+  if reason then
     it(':python3 reports E319 if provider is missing', function()
       local expected = [[Vim%(py3.*%):E319: No "python3" provider found.*]]
       matches(expected, pcall_err(command, 'py3 print("foo")'))
       matches(expected, pcall_err(command, 'py3file foo'))
     end)
-    pending('Python 3 (or the pynvim module) is broken/missing', function() end)
+    pending(string.format('Python 3 (or the pynvim module) is broken/missing (%s)', reason), function() end)
     return
   end
 end

--- a/test/functional/provider/python_spec.lua
+++ b/test/functional/provider/python_spec.lua
@@ -18,13 +18,14 @@ local pcall_err = helpers.pcall_err
 
 do
   clear()
-  if missing_provider('python') then
+  local reason = missing_provider('python')
+  if reason then
     it(':python reports E319 if provider is missing', function()
       local expected = [[Vim%(py.*%):E319: No "python" provider found.*]]
       matches(expected, pcall_err(command, 'py print("foo")'))
       matches(expected, pcall_err(command, 'pyfile foo'))
     end)
-    pending('Python 2 (or the pynvim module) is broken/missing', function() end)
+    pending(string.format('Python 2 (or the pynvim module) is broken/missing (%s)', reason), function() end)
     return
   end
 end

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -18,13 +18,14 @@ local pcall_err = helpers.pcall_err
 
 do
   clear()
-  if missing_provider('ruby') then
+  local reason = missing_provider('ruby')
+  if reason then
     it(':ruby reports E319 if provider is missing', function()
       local expected = [[Vim%(ruby.*%):E319: No "ruby" provider found.*]]
       matches(expected, pcall_err(command, 'ruby puts "foo"'))
       matches(expected, pcall_err(command, 'rubyfile foo'))
     end)
-    pending("Missing neovim RubyGem.", function() end)
+    pending(string.format('Missing neovim RubyGem (%s)', reason), function() end)
     return
   end
 end


### PR DESCRIPTION
Callers always assume that emsg was emitted:

- https://github.com/neovim/neovim/blob/57fbf288202153b04f069f7335450e4eaa1e8551/src/nvim/eval.c#L12509
- https://github.com/neovim/neovim/blob/57fbf288202153b04f069f7335450e4eaa1e8551/src/nvim/eval.c#L17923
- https://github.com/neovim/neovim/blob/57fbf288202153b04f069f7335450e4eaa1e8551/src/nvim/eval.c#L18202

Via https://github.com/neovim/neovim/pull/11233.

TODO:

- [x] tests