### PR TITLE
[RFC] nv_next: do not re-do search unnecessarily

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4116,7 +4116,7 @@ static int ins_compl_get_exp(pos_T *ini)
                                      compl_direction,
                                      compl_pattern, 1L,
                                      SEARCH_KEEP + SEARCH_NFMSG,
-                                     RE_LAST, (linenr_T)0, NULL, NULL);
+                                     RE_LAST, (linenr_T)0, NULL, NULL, NULL);
         }
         msg_silent--;
         if (!compl_started || set_match_pos) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14634,7 +14634,8 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 
   pos = save_cursor = curwin->w_cursor;
   subpatnum = searchit(curwin, curbuf, &pos, NULL, dir, (char_u *)pat, 1,
-                       options, RE_SEARCH, (linenr_T)lnum_stop, &tm, NULL, NULL);
+                       options, RE_SEARCH, (linenr_T)lnum_stop, &tm, NULL,
+                       NULL);
   if (subpatnum != FAIL) {
     if (flags & SP_SUBPAT)
       retval = subpatnum;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -14634,7 +14634,7 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 
   pos = save_cursor = curwin->w_cursor;
   subpatnum = searchit(curwin, curbuf, &pos, NULL, dir, (char_u *)pat, 1,
-                       options, RE_SEARCH, (linenr_T)lnum_stop, &tm, NULL);
+                       options, RE_SEARCH, (linenr_T)lnum_stop, &tm, NULL, NULL);
   if (subpatnum != FAIL) {
     if (flags & SP_SUBPAT)
       retval = subpatnum;
@@ -15207,7 +15207,7 @@ do_searchpair(
   pat = pat3;
   for (;; ) {
     n = searchit(curwin, curbuf, &pos, NULL, dir, pat, 1L,
-                 options, RE_SEARCH, lnum_stop, &tm, NULL);
+                 options, RE_SEARCH, lnum_stop, &tm, NULL, NULL);
     if (n == FAIL || (firstpos.lnum != 0 && equalpos(pos, firstpos))) {
       // didn't find it or found the first match again: FAIL
       break;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3751,7 +3751,7 @@ static linenr_T get_address(exarg_T *eap,
         }
         searchcmdlen = 0;
         if (!do_search(NULL, c, cmd, 1L,
-                       SEARCH_HIS | SEARCH_MSG, NULL, NULL)) {
+                       SEARCH_HIS | SEARCH_MSG, NULL, NULL, NULL)) {
           curwin->w_cursor = pos;
           cmd = NULL;
           goto error;
@@ -3789,7 +3789,7 @@ static linenr_T get_address(exarg_T *eap,
         if (searchit(curwin, curbuf, &pos, NULL,
                      *cmd == '?' ? BACKWARD : FORWARD,
                      (char_u *)"", 1L, SEARCH_MSG,
-                     i, (linenr_T)0, NULL, NULL) != FAIL) {
+                     i, (linenr_T)0, NULL, NULL, NULL) != FAIL) {
           lnum = pos.lnum;
         } else {
           cmd = NULL;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1075,7 +1075,7 @@ static void command_line_next_incsearch(CommandLineState *s, bool next_match)
   int found = searchit(curwin, curbuf, &t, NULL,
                        next_match ? FORWARD : BACKWARD,
                        pat, s->count, search_flags,
-                       RE_SEARCH, 0, NULL, NULL);
+                       RE_SEARCH, 0, NULL, NULL, NULL);
   emsg_off--;
   ui_busy_stop();
   if (found) {
@@ -1845,7 +1845,7 @@ static int command_line_changed(CommandLineState *s)
         search_flags += SEARCH_KEEP;
       }
       i = do_search(NULL, s->firstc, ccline.cmdbuff, s->count,
-                    search_flags, &tm, NULL);
+                    search_flags, &tm, NULL, NULL);
       emsg_off--;
       // if interrupted while searching, behave like it failed
       if (got_int) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5396,7 +5396,8 @@ static int normal_search(
   curwin->w_set_curswant = true;
 
   i = do_search(cap->oap, dir, pat, cap->count1,
-                opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, NULL, NULL, wrapped);
+                opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, NULL, NULL,
+                wrapped);
   if (i == 0) {
     clearop(cap->oap);
   } else {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3794,7 +3794,7 @@ find_decl (
     valid = false;
     (void)valid;  // Avoid "dead assignment" warning.
     t = searchit(curwin, curbuf, &curwin->w_cursor, NULL, FORWARD,
-                 pat, 1L, searchflags, RE_LAST, (linenr_T)0, NULL, NULL);
+                 pat, 1L, searchflags, RE_LAST, (linenr_T)0, NULL, NULL, NULL);
     if (curwin->w_cursor.lnum >= old_pos.lnum) {
       t = false;         // match after start is failure too
     }
@@ -4927,7 +4927,7 @@ static void nv_ident(cmdarg_T *cap)
     /* put pattern in search history */
     init_history();
     add_to_history(HIST_SEARCH, (char_u *)buf, true, NUL);
-    (void)normal_search(cap, cmdchar == '*' ? '/' : '?', (char_u *)buf, 0);
+    (void)normal_search(cap, cmdchar == '*' ? '/' : '?', (char_u *)buf, 0, NULL);
   } else {
     do_cmdline_cmd(buf);
   }
@@ -5352,7 +5352,7 @@ static void nv_search(cmdarg_T *cap)
 
   (void)normal_search(cap, cap->cmdchar, cap->searchbuf,
                       (cap->arg || !equalpos(save_cursor, curwin->w_cursor))
-                      ? 0 : SEARCH_MARK);
+                      ? 0 : SEARCH_MARK, NULL);
 }
 
 /*
@@ -5362,14 +5362,15 @@ static void nv_search(cmdarg_T *cap)
 static void nv_next(cmdarg_T *cap)
 {
   pos_T old = curwin->w_cursor;
-  int i = normal_search(cap, 0, NULL, SEARCH_MARK | cap->arg);
+  int wrapped = 0;
+  int i = normal_search(cap, 0, NULL, SEARCH_MARK | cap->arg, &wrapped);
 
-  if (i == 1 && equalpos(old, curwin->w_cursor)) {
+  if (i == 1 && !wrapped && equalpos(old, curwin->w_cursor)) {
     // Avoid getting stuck on the current cursor position, which can happen when
     // an offset is given and the cursor is on the last char in the buffer:
     // Repeat with count + 1.
     cap->count1 += 1;
-    (void)normal_search(cap, 0, NULL, SEARCH_MARK | cap->arg);
+    (void)normal_search(cap, 0, NULL, SEARCH_MARK | cap->arg, NULL);
     cap->count1 -= 1;
   }
 }
@@ -5383,7 +5384,8 @@ static int normal_search(
     cmdarg_T *cap,
     int dir,
     char_u *pat,
-    int opt                        /* extra flags for do_search() */
+    int opt,                        /* extra flags for do_search() */
+    int *wrapped
 )
 {
   int i;
@@ -5394,7 +5396,7 @@ static int normal_search(
   curwin->w_set_curswant = true;
 
   i = do_search(cap->oap, dir, pat, cap->count1,
-                opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, NULL, NULL);
+                opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, NULL, NULL, wrapped);
   if (i == 0) {
     clearop(cap->oap);
   } else {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4927,7 +4927,8 @@ static void nv_ident(cmdarg_T *cap)
     /* put pattern in search history */
     init_history();
     add_to_history(HIST_SEARCH, (char_u *)buf, true, NUL);
-    (void)normal_search(cap, cmdchar == '*' ? '/' : '?', (char_u *)buf, 0, NULL);
+    (void)normal_search(cap, cmdchar == '*' ? '/' : '?', (char_u *)buf, 0,
+                        NULL);
   } else {
     do_cmdline_cmd(buf);
   }
@@ -5384,7 +5385,7 @@ static int normal_search(
     cmdarg_T *cap,
     int dir,
     char_u *pat,
-    int opt,                        /* extra flags for do_search() */
+    int opt,  // extra flags for do_search()
     int *wrapped
 )
 {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2417,7 +2417,8 @@ static void qf_jump_goto_line(linenr_T qf_lnum, int qf_col, char_u qf_viscol,
     // Move the cursor to the first line in the buffer
     pos_T save_cursor = curwin->w_cursor;
     curwin->w_cursor.lnum = 0;
-    if (!do_search(NULL, '/', qf_pattern, (long)1, SEARCH_KEEP, NULL, NULL, NULL)) {
+    if (!do_search(NULL, '/', qf_pattern, (long)1, SEARCH_KEEP, NULL, NULL,
+                   NULL)) {
       curwin->w_cursor = save_cursor;
     }
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2417,7 +2417,7 @@ static void qf_jump_goto_line(linenr_T qf_lnum, int qf_col, char_u qf_viscol,
     // Move the cursor to the first line in the buffer
     pos_T save_cursor = curwin->w_cursor;
     curwin->w_cursor.lnum = 0;
-    if (!do_search(NULL, '/', qf_pattern, (long)1, SEARCH_KEEP, NULL, NULL)) {
+    if (!do_search(NULL, '/', qf_pattern, (long)1, SEARCH_KEEP, NULL, NULL, NULL)) {
       curwin->w_cursor = save_cursor;
     }
   }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1332,6 +1332,7 @@ int do_search(
         && !(cmd_silent + msg_silent)
         && c != FAIL
         && !shortmess(SHM_SEARCHCOUNT)
+        && (!wrapped || shortmess(SHM_SEARCH))
         && msgbuf != NULL) {
       search_stat(dirc, &pos, wrapped, msgbuf, (count != 1 || has_offset));
     }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1060,8 +1060,6 @@ int do_search(
    * Repeat the search when pattern followed by ';', e.g. "/foo/;?bar".
    */
   for (;; ) {
-    bool show_top_bot_msg = false;
-
     searchstr = pat;
     dircp = NULL;
     /* use previous pattern */
@@ -1282,12 +1280,6 @@ int do_search(
       *dircp = dirc;  // restore second '/' or '?' for normal_cmd()
     }
 
-    if (!shortmess(SHM_SEARCH)
-        && ((dirc == '/' && lt(pos, curwin->w_cursor))
-            || (dirc == '?' && lt(curwin->w_cursor, pos)))) {
-      show_top_bot_msg = true;
-    }
-
     if (c == FAIL) {
       retval = 0;
       goto end_do_search;
@@ -1341,8 +1333,7 @@ int do_search(
         && c != FAIL
         && !shortmess(SHM_SEARCHCOUNT)
         && msgbuf != NULL) {
-      search_stat(dirc, &pos, show_top_bot_msg, msgbuf,
-                  (count != 1 || has_offset));
+      search_stat(dirc, &pos, wrapped, msgbuf, (count != 1 || has_offset));
     }
 
     // The search command can be followed by a ';' to do another search.

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3031,7 +3031,7 @@ void ex_spellrepall(exarg_T *eap)
   sub_nlines = 0;
   curwin->w_cursor.lnum = 0;
   while (!got_int) {
-    if (do_search(NULL, '/', frompat, 1L, SEARCH_KEEP, NULL, NULL) == 0
+    if (do_search(NULL, '/', frompat, 1L, SEARCH_KEEP, NULL, NULL, NULL) == 0
         || u_save_cursor() == FAIL) {
       break;
     }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2487,7 +2487,7 @@ static int jumpto_tag(
       save_lnum = curwin->w_cursor.lnum;
       curwin->w_cursor.lnum = 0;        /* start search before first line */
       if (do_search(NULL, pbuf[0], pbuf + 1, (long)1,
-                    search_options, NULL, NULL)) {
+                    search_options, NULL, NULL, NULL)) {
         retval = OK;
       } else {
         int found = 1;
@@ -2498,7 +2498,7 @@ static int jumpto_tag(
          */
         p_ic = TRUE;
         if (!do_search(NULL, pbuf[0], pbuf + 1, (long)1,
-                       search_options, NULL, NULL)) {
+                       search_options, NULL, NULL, NULL)) {
           // Failed to find pattern, take a guess: "^func  ("
           found = 2;
           (void)test_for_static(&tagp);
@@ -2506,12 +2506,12 @@ static int jumpto_tag(
           *tagp.tagname_end = NUL;
           snprintf((char *)pbuf, LSIZE, "^%s\\s\\*(", tagp.tagname);
           if (!do_search(NULL, '/', pbuf, (long)1,
-                         search_options, NULL, NULL)) {
+                         search_options, NULL, NULL, NULL)) {
             // Guess again: "^char * \<func  ("
             snprintf((char *)pbuf, LSIZE, "^\\[#a-zA-Z_]\\.\\*\\<%s\\s\\*(",
                      tagp.tagname);
             if (!do_search(NULL, '/', pbuf, (long)1,
-                           search_options, NULL, NULL)) {
+                           search_options, NULL, NULL, NULL)) {
               found = 0;
             }
           }

--- a/test/functional/normal/search_spec.lua
+++ b/test/functional/normal/search_spec.lua
@@ -48,13 +48,11 @@ it('nv_next does not unnecessarily re-search (n/N)', function()
     {2:~                                       }|
     {2:~                                       }|
     {2:~                                       }|
-    /bar                           [1/1] W  |
+    {3:search hit BOTTOM, continuing at TOP}    |
   ]]}
 
   -- Check that normal_search was not called again in nv_next by checking for a
   -- single bot_top_msg (would be 3 otherwise).
-  eq(helpers.dedent([[
-    search hit BOTTOM, continuing at TOP
-    /bar                           [1/1] W]]),
+  eq('search hit BOTTOM, continuing at TOP',
     eval('trim(execute(":messages"))'))
 end)

--- a/test/functional/normal/search_spec.lua
+++ b/test/functional/normal/search_spec.lua
@@ -2,6 +2,8 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
+local eval = helpers.eval
+local feed = helpers.feed
 local pcall_err = helpers.pcall_err
 
 describe('search (/)', function()
@@ -15,3 +17,14 @@ describe('search (/)', function()
   end)
 end)
 
+it('nv_next does not unnecessarily re-search (n/N)', function()
+  clear()
+
+  helpers.insert('foobar')
+  feed('gg0/bar<cr>')
+  eq('', eval('trim(execute(":messages"))'))
+  feed('n')
+  -- Check that normal_search was not called again by checking for a single
+  -- message (would be 3 otherwise).
+  eq('search hit BOTTOM, continuing at TOP', eval('trim(execute(":messages"))'))
+end)


### PR DESCRIPTION
Uses a new "wrapped" flag to skip the additional search when the
position was not changed (but 'wrapscan' wrapped around).

This makes it necessary to change a lot of places to pass this through.
Given that it is similar to tm/timed_out being passed around already, it
might make sense to use a single struct/mask here to be passed around
instead, allowing for easier changes in the future.

Ref/via: https://github.com/neovim/neovim/issues/11243#issuecomment-542949801