### PR TITLE
vim-patch:8.1.2180: Error E303 is not useful when 'directory' is empty

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -556,7 +556,8 @@ allowed for the command that was used.
 Vim was not able to create a swap file.  You can still edit the file, but if
 Vim unexpectedly exits the changes will be lost.  And Vim may consume a lot of
 memory when editing a big file.  You may want to change the 'directory' option
-to avoid this error.  See |swap-file|.
+to avoid this error.  This error is not given when 'directory' is empty.  See
+|swap-file|.
 
 							*E140*  >
   Use ! to write partial buffer

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1978,7 +1978,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  possible.  If it is not possible in any directory, but last 
 	  directory listed in the option does not exist, it is created.
 	- Empty means that no swap file will be used (recovery is
-	  impossible!).
+	  impossible!) and no |E303| error will be given.
 	- A directory "." means to put the swap file in the same directory as
 	  the edited file.  On Unix, a dot is prepended to the file name, so
 	  it doesn't show in a directory listing.  On MS-Windows the "hidden"

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -523,9 +523,9 @@ void ml_open_file(buf_T *buf)
     }
   }
 
-  if (mfp->mf_fname == NULL) {          /* Failed! */
-    need_wait_return = TRUE;            /* call wait_return later */
-    ++no_wait_return;
+  if (*p_dir != NUL && mfp->mf_fname == NULL) {
+    need_wait_return = true;  // call wait_return later
+    no_wait_return++;
     (void)EMSG2(_(
             "E303: Unable to open swap file for \"%s\", recovery impossible"),
         buf_spname(buf) != NULL ? buf_spname(buf) : buf->b_fname);

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -14,6 +14,12 @@ func Test_recover_root_dir()
     set dir=/notexist/
   endif
   call assert_fails('split Xtest', 'E303:')
+
+  " No error with empty 'directory' setting.
+  set directory=
+  split XtestOK
+  close!
+
   set dir&
 endfunc
 


### PR DESCRIPTION
Problem:    Error E303 is not useful when 'directory' is empty.
Solution:   Skip the error message. (Daniel Hahler, vim/vim#5067)
https://github.com/vim/vim/commit/00e192becd50a38cb21a1bc3f86fcc7a21f8ee88