### PR TITLE
[RFC] Add exclusive control of environment variables

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -44,6 +44,16 @@ void env_init(void)
   uv_mutex_init(&mutex);
 }
 
+void os_env_var_lock(void)
+{
+  uv_mutex_lock(&mutex);
+}
+
+void os_env_var_unlock(void)
+{
+  uv_mutex_unlock(&mutex);
+}
+
 /// Like getenv(), but returns NULL if the variable is empty.
 /// @see os_env_exists
 const char *os_getenv(const char *name)

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -234,7 +234,9 @@ static void terminfo_start(UI *ui)
   // Set up unibilium/terminfo.
   char *termname = NULL;
   if (term) {
+    os_env_var_lock();
     data->ut = unibi_from_term(term);
+    os_env_var_unlock();
     if (data->ut) {
       termname = xstrdup(term);
     }


### PR DESCRIPTION
`unibi_from_term()` internally calls `getenv()`, which can cause problems if `os_getenv()`, `os_setenv()`, `os_unsetenv()` is called on the main thread. In this PR, exclusive control is added so that the problem does not occur.