### PR TITLE
UIEnter/UILeave: expose client name as <afile>

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -811,7 +811,7 @@ UIEnter				After a UI connects via |nvim_ui_attach()|,
 				    name    (client name per |nvim_set_client_info()|)
 				<afile> (|autocmd-pattern|) is the
 				|nvim_set_client_info()| name provided by
-				conforming clients, or "unknown".
+				conforming clients, or "?".
 							*UILeave*
 UILeave				After a UI disconnects from Nvim.
 				Sets these |v:event| keys:
@@ -819,7 +819,7 @@ UILeave				After a UI disconnects from Nvim.
 				    name    (client name per |nvim_set_client_info()|)
 				<afile> (|autocmd-pattern|) is the
 				|nvim_set_client_info()| name provided by
-				conforming clients, or "unknown".
+				conforming clients, or "?".
 							*InsertChange*
 InsertChange			When typing <Insert> while in Insert or
 				Replace mode.  The |v:insertmode| variable

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -512,15 +512,11 @@ BufWritePost			After writing the whole buffer to a file
 ChanInfo			State of channel changed, for instance the
 				client of a RPC channel described itself.
 				Sets these |v:event| keys:
-				    info
-				See |nvim_get_chan_info()| for the format of
-				the info Dictionary.
+				    info    (fields described at |nvim_get_chan_info()|)
 							*ChanOpen*
 ChanOpen			Just after a channel was opened.
 				Sets these |v:event| keys:
-				    info
-				See |nvim_get_chan_info()| for the format of
-				the info Dictionary.
+				    info    (fields described at |nvim_get_chan_info()|)
 							*CmdUndefined*
 CmdUndefined			When a user command is used but it isn't
 				defined.  Useful for defining a command only
@@ -809,14 +805,21 @@ FuncUndefined			When a user function is used but it isn't
 				See |autoload-functions|.
 							*UIEnter*
 UIEnter				After a UI connects via |nvim_ui_attach()|,
-				after VimEnter.  Can be used for GUI-specific
-				configuration.
+				after VimEnter.  Useful for GUI setup.
 				Sets these |v:event| keys:
 				    chan
+				    name    (client name per |nvim_set_client_info()|)
+				<afile> (|autocmd-pattern|) is the
+				|nvim_set_client_info()| name provided by
+				conforming clients, or "unknown".
 							*UILeave*
 UILeave				After a UI disconnects from Nvim.
 				Sets these |v:event| keys:
 				    chan
+				    name    (client name per |nvim_set_client_info()|)
+				<afile> (|autocmd-pattern|) is the
+				|nvim_set_client_info()| name provided by
+				conforming clients, or "unknown".
 							*InsertChange*
 InsertChange			When typing <Insert> while in Insert or
 				Replace mode.  The |v:insertmode| variable

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1572,9 +1572,16 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 			chan		|channel-id| or 0 for "internal".
 			cmdlevel	Level of cmdline.
 			cmdtype		Type of cmdline, |cmdline-char|.
+			col  	 	Col count of popup menu on |CompleteChanged|,
+					relative to screen.
+			completed_item	Dictionary of selected item info on
+					|CompleteChanged|, or empty dict if
+					not selected.
 			cwd		Current working directory.
+			height 		Height of popup menu on |CompleteChanged|
 			inclusive	Motion is |inclusive|, else exclusive.
-			scope		Event-specific scope name.
+			info		Dictionary of context-specific info.
+			name		Name string.
 			operator	Current |operator|.  Also set for Ex
 					commands (unlike |v:operator|). For
 					example if |TextYankPost| is triggered
@@ -1587,19 +1594,14 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 					operation.
 			regtype		Type of register as returned by
 					|getregtype()|.
-			completed_item    Current selected complete item on
-					|CompleteChanged|, Is `{}` when no complete
-					item selected.
-			height 		Height of popup menu on |CompleteChanged|
-			width   	width of popup menu on |CompleteChanged|
 			row  	 	Row count of popup menu on |CompleteChanged|,
 					relative to screen.
-			col  	 	Col count of popup menu on |CompleteChanged|,
-					relative to screen.
-			size 		Total number of completion items on
-					|CompleteChanged|.
+			scope		Event-specific scope name.
 			scrollbar 	Is |v:true| if popup menu have scrollbar, or
 					|v:false| if not.
+			size 		Total number of completion items on
+					|CompleteChanged|.
+			width   	width of popup menu on |CompleteChanged|
 
 					*v:exception* *exception-variable*
 v:exception	The value of the exception most recently caught and not

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -12,11 +12,18 @@ Nvim Graphical User Interface				*gui* *GUI*
 Starting the GUI				*gui-start* *E229* *E233*
 
 				*ginit.vim* *gui-init* *gvimrc* *$MYGVIMRC*
-For GUI-specific configuration Nvim provides the |UIEnter| event.  This
-happens after other |initialization|s, like reading your vimrc file.
+When a UI starts ("attaches") the |UIEnter| event is raised, so it can be used
+for UI-specific configuration.  This happens after other |initialization|s,
+like reading your vimrc file.
 
-Example: this sets "g:gui" to the value of the UI's "rgb" field:    >
-	:autocmd UIEnter * let g:gui = filter(nvim_list_uis(),{k,v-> v.chan==v:event.chan})[0].rgb
+Example: Configure the "firenvim" UI. >
+    func! SetupFirenvim() abort
+      set guifont=Monaco:h10
+    endf
+    autocmd UIEnter firenvim call SetupFirenvim()
+<
+Example: Get UI info from |nvim_list_uis()| by channel id. >
+    autocmd UIEnter * let g:gui = filter(nvim_list_uis(),{k,v-> v.chan==v:event.chan})[0].rgb
 <
 
 						*:winp* *:winpos* *E188*

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1655,6 +1655,11 @@ void nvim_set_client_info(uint64_t channel_id, String name,
                           Error *err)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_ONLY
 {
+  if (name.size == 0) {
+    api_set_error(err, kErrorTypeValidation, "Invalid (empty) name");
+    return;
+  }
+
   Dictionary info = ARRAY_DICT_INIT;
   PUT(info, "name", copy_object(STRING_OBJ(name)));
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1696,9 +1696,8 @@ void nvim_set_client_info(uint64_t channel_id, String name,
 ///                 still be present to indicate a pty is used. This is
 ///                 currently the case when using winpty on windows.
 ///    -  "buffer"  buffer with connected |terminal| instance (optional)
-///    -  "client"  information about the client on the other end of the
-///                 RPC channel, if it has added it using
-///                 |nvim_set_client_info()|. (optional)
+///    -  "client"  information describing the client, if it was provided
+///                 (by a call to |nvim_set_client_info()|).
 ///
 Dictionary nvim_get_chan_info(Integer chan, Error *err)
   FUNC_API_SINCE(4)

--- a/src/nvim/aucmd.c
+++ b/src/nvim/aucmd.c
@@ -27,12 +27,12 @@ void do_autocmd_uienter(uint64_t chanid, bool attached)
   Channel *chan = find_channel(chanid);
   const char *client_name = (chan && chanid > 0)
     ? rpc_client_name(chan)
-    : (chanid > 0 ? "unknown" : "nvim-tui");
+    : (chanid > 0 ? "?" : "nvim-tui");
 
   dict_T *dict = get_vim_var_dict(VV_EVENT);
   assert(chanid < VARNUMBER_MAX);
   tv_dict_add_str(dict, S_LEN("name"),
-                  client_name ? client_name : "unknown");
+                  client_name ? client_name : "?");
   tv_dict_add_nr(dict, S_LEN("chan"), (varnumber_T)chanid);
   tv_dict_set_keys_readonly(dict);
   apply_autocmds(attached ? EVENT_UIENTER : EVENT_UILEAVE,

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
+local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
 local meths = helpers.meths
@@ -41,18 +42,29 @@ it('autocmds UIEnter/UILeave', function()
     args_rm={'--headless'},
     args={
       '--cmd', 'let g:evs = []',
-      '--cmd', 'autocmd UIEnter * :call add(g:evs, "UIEnter") | let g:uienter_ev = deepcopy(v:event)',
-      '--cmd', 'autocmd UILeave * :call add(g:evs, "UILeave") | let g:uileave_ev = deepcopy(v:event)',
+      '--cmd', 'autocmd UIEnter * :call add(g:evs, "UIEnter-".expand("<afile>")) | let g:uienter_ev = deepcopy(v:event)',
+      '--cmd', 'autocmd UILeave * :call add(g:evs, "UILeave-".expand("<afile>")) | let g:uileave_ev = deepcopy(v:event)',
+      '--cmd', 'autocmd UIEnter testui :call add(g:evs, "UIEnter-matches-pattern")',
+      '--cmd', 'autocmd UILeave testui :call add(g:evs, "UILeave-matches-pattern")',
+      '--cmd', 'autocmd UIEnter bogus :call add(g:evs, "UIEnter-does-NOT-match")',
+      '--cmd', 'autocmd UILeave bogus :call add(g:evs, "UILeave-does-NOT-match")',
       '--cmd', 'autocmd VimEnter * :call add(g:evs, "VimEnter")',
     }}
+  meths.set_client_info("testui",
+                        {},
+                        'ui',
+                        {do_stuff={n_args={2,3}}},
+                        {license= 'Apache2'})
   local screen = Screen.new()
   screen:attach()
-  eq({chan=1}, eval('g:uienter_ev'))
+  eq({chan=1, name='testui'}, eval('g:uienter_ev'))
   screen:detach()
-  eq({chan=1}, eval('g:uileave_ev'))
+  eq({chan=1, name='testui'}, eval('g:uileave_ev'))
   eq({
     'VimEnter',
-    'UIEnter',
-    'UILeave',
+    'UIEnter-testui',
+    'UIEnter-matches-pattern',
+    'UILeave-testui',
+    'UILeave-matches-pattern',
   }, eval('g:evs'))
 end)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1119,7 +1119,7 @@ describe('API', function()
     end)
   end)
 
-  describe('nvim_list_chans and nvim_get_chan_info', function()
+  describe('nvim_list_chans, nvim_get_chan_info', function()
     before_each(function()
       command('autocmd ChanOpen * let g:opened_event = copy(v:event)')
       command('autocmd ChanInfo * let g:info_event = copy(v:event)')
@@ -1141,6 +1141,11 @@ describe('API', function()
       eq({}, meths.get_chan_info(-1))
       -- more preallocated numbers might be added, try something high
       eq({}, meths.get_chan_info(10))
+    end)
+
+    it('validates args', function()
+      eq('Invalid (empty) name',
+        pcall_err(meths.set_client_info, '', {}, 'ui', {}, {}))
     end)
 
     it('works for stdio channel', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -787,8 +787,8 @@ describe('TUI UIEnter/UILeave', function()
       '["'..nvim_prog..'", "-u", "NONE", "-i", "NONE"'
       ..[[, "--cmd", "set noswapfile noshowcmd noruler"]]
       ..[[, "--cmd", "let g:evs = []"]]
-      ..[[, "--cmd", "autocmd UIEnter  * :call add(g:evs, 'UIEnter')"]]
-      ..[[, "--cmd", "autocmd UILeave  * :call add(g:evs, 'UILeave')"]]
+      ..[[, "--cmd", "autocmd UIEnter  * :call add(g:evs, 'UIEnter-'.expand('<afile>'))"]]
+      ..[[, "--cmd", "autocmd UILeave  * :call add(g:evs, 'UILeave-'.expand('<afile>'))"]]
       ..[[, "--cmd", "autocmd VimEnter * :call add(g:evs, 'VimEnter')"]]
       ..']'
     )
@@ -799,7 +799,7 @@ describe('TUI UIEnter/UILeave', function()
       {4:~                                                 }|
       {4:~                                                 }|
       {5:[No Name]                                         }|
-      ['VimEnter', 'UIEnter']                           |
+      ['VimEnter', 'UIEnter-nvim-tui']                  |
       {3:-- TERMINAL --}                                    |
     ]]}
   end)


### PR DESCRIPTION
Problem:  Not easy to perform setup for specific clients.
Solution: Expose the client.name field set by nvim_set_client_info().

- Expose client.name as autocmd-pattern (`<afile>`).
- Expose client.name as `v:event.name`.

Before:

    :autocmd UIEnter * let g:gui = filter(nvim_list_uis(),{k,v-> v.chan==v:event.chan})[0].rgb

After:

    :autocmd UIEnter firenvim ...
    " or
    :autocmd UIEnter * if expand('<afile>') == 'firenvim' | ... | endif