### PR TITLE
vim-patch:8.1.2168: heredoc assignment not skipped in if block

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1675,10 +1675,12 @@ static void ex_let_const(exarg_T *eap, const bool is_const)
     list_T *l = heredoc_get(eap, expr + 3);
     if (l != NULL) {
       tv_list_set_ret(&rettv, l);
-      op[0] = '=';
-      op[1] = NUL;
-      (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count,
-                        is_const, op);
+      if (!eap->skip) {
+        op[0] = '=';
+        op[1] = NUL;
+        (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count,
+                          is_const, op);
+      }
       tv_clear(&rettv);
     }
   } else {

--- a/src/nvim/testdir/test_let.vim
+++ b/src/nvim/testdir/test_let.vim
@@ -276,4 +276,12 @@ E
   app
   END
   call assert_equal(['something', 'app'], var1)
+
+  let check = []
+  if 0
+     let check =<< trim END
+       from heredoc
+     END
+  endif
+  call assert_equal([], check)
 endfunc


### PR DESCRIPTION
```
Problem:    Heredoc assignment not skipped in if block.
Solution:   Check if "skip" is set.
```

https://github.com/vim/vim/commit/b1ba9abcb385b0a5355788a7eefef78ec68d2f65

Fixes https://github.com/neovim/neovim/issues/11264