### PR TITLE
man.vim: implement 'tagfunc'

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -420,10 +420,9 @@ function! man#init_pager() abort
 endfunction
 
 function! man#goto_tag(pattern, flags, info) abort
-  " currently no support for section completion
-  let sect = ""
+  let [sect, name] = man#extract_sect_and_name_ref(a:pattern)
 
-  let candidates = s:get_paths(sect, a:pattern)
+  let candidates = s:get_paths(sect, name)
 
   return map(candidates, {
   \  _, path -> {

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -360,14 +360,18 @@ function! man#complete(arg_lead, cmd_line, cursor_pos) abort
   return s:complete(sect, sect, name)
 endfunction
 
-function! s:complete(sect, psect, name) abort
+function! s:get_paths(sect, name) abort
   try
     let mandirs = join(split(s:system(['man', s:find_arg]), ':\|\n'), ',')
   catch
     call s:error(v:exception)
     return
   endtry
-  let pages = globpath(mandirs,'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
+  return globpath(mandirs,'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
+endfunction
+
+function! s:complete(sect, psect, name) abort
+  let pages = s:get_paths(a:sect, a:name)
   " We remove duplicates in case the same manpage in different languages was found.
   return uniq(sort(map(pages, 's:format_candidate(v:val, a:psect)'), 'i'))
 endfunction

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -150,6 +150,7 @@ endfunction
 function! s:put_page(page) abort
   setlocal modifiable
   setlocal noreadonly
+  setlocal noswapfile
   silent keepjumps %delete _
   silent put =a:page
   while getline(1) =~# '^\s*$'

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -66,7 +66,6 @@ function! man#open_page(count, count1, mods, ...) abort
 
   let [l:buf, l:save_tfu] = [bufnr(), &tagfunc]
   try
-    set eventignore+=BufReadCmd
     set tagfunc=man#goto_tag
     let l:target = l:name . '(' . l:sect . ')'
     if a:mods !~# 'tab' && s:find_man()
@@ -76,7 +75,6 @@ function! man#open_page(count, count1, mods, ...) abort
     endif
   finally
     call setbufvar(l:buf, '&tagfunc', l:save_tfu)
-    set eventignore-=BufReadCmd
   endtry
 
   let b:man_sect = sect

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -264,14 +264,6 @@ function! s:push_tag() abort
         \ }]
 endfunction
 
-function! man#pop_tag() abort
-  if !empty(s:tag_stack)
-    let tag = remove(s:tag_stack, -1)
-    execute 'silent' tag['buf'].'buffer'
-    call cursor(tag['lnum'], tag['col'])
-  endif
-endfunction
-
 " extracts the name and sect out of 'path/name.sect'
 function! s:extract_sect_and_name_path(path) abort
   let tail = fnamemodify(a:path, ':t')
@@ -408,6 +400,21 @@ function! man#init_pager() abort
   if -1 == match(bufname('%'), 'man:\/\/')  " Avoid duplicate buffers, E95.
     execute 'silent file man://'.tolower(fnameescape(ref))
   endif
+endfunction
+
+function! man#goto_tag(pattern, flags, info) abort
+  " currently no support for section completion
+  let sect = ""
+
+  let candidates = s:get_paths(sect, a:pattern)
+
+  return map(candidates, {
+  \  _, path -> {
+  \      'name': s:extract_sect_and_name_path(path)[1],
+  \      'filename': 'man://' . path,
+  \      'cmd': '1'
+  \    }
+  \  })
 endfunction
 
 call s:init()

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -381,14 +381,23 @@ function! man#init_pager() abort
 endfunction
 
 function! man#goto_tag(pattern, flags, info) abort
-  let [sect, name] = man#extract_sect_and_name_ref(a:pattern)
+  let [l:sect, l:name] = man#extract_sect_and_name_ref(a:pattern)
 
-  let candidates = s:get_paths(sect, name)
+  let l:paths = s:get_paths(l:sect, l:name)
+  let l:structured = []
 
-  return map(candidates, {
-  \  _, path -> {
-  \      'name': s:extract_sect_and_name_path(path)[1],
-  \      'filename': 'man://' . path,
+  for l:path in l:paths
+    let l:n = s:extract_sect_and_name_path(l:path)[1]
+    let l:structured += [{ 'name': l:n, 'path': l:path }]
+  endfor
+
+  " sort by relevance - exact matches first, then the previous order
+  call sort(l:structured, { a, b -> a.name ==? l:name ? -1 : b.name ==? l:name ? 1 : 0 })
+
+  return map(l:structured, {
+  \  _, entry -> {
+  \      'name': entry.name,
+  \      'filename': 'man://' . entry.path,
   \      'cmd': '1'
   \    }
   \  })

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -20,13 +20,13 @@ setlocal wrap breakindent linebreak
 setlocal nonumber norelativenumber
 setlocal foldcolumn=0 colorcolumn=0 nolist nofoldenable
 
+setlocal tagfunc=man#goto_tag
+
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> j          gj
   nnoremap <silent> <buffer> k          gk
   nnoremap <silent> <buffer> gO         :call man#show_toc()<CR>
-  nnoremap <silent> <buffer> <C-]>      :Man<CR>
   nnoremap <silent> <buffer> K          :Man<CR>
-  nnoremap <silent> <buffer> <C-T>      :call man#pop_tag()<CR>
   if 1 == bufnr('%') || s:pager
     nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
   else


### PR DESCRIPTION
This is a follow up PR to #11199, using `'tagfunc'` in `man.vim`, which gives us man page tag jump functionality for `<C-W><C-]>` and `<C-W>}`.