### PR TITLE
Change to check the existence of vim_tempdir

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5292,7 +5292,8 @@ void vim_deltempdir(void)
 /// call to this function.
 char_u *vim_gettempdir(void)
 {
-  if (vim_tempdir == NULL) {
+  if (vim_tempdir == NULL || !os_isdir(vim_tempdir)) {
+    XFREE_CLEAR(vim_tempdir);
     vim_maketempdir();
   }
 


### PR DESCRIPTION
Since `vim_tempdir` cached on Windows may not exist, change it to check the existence. It is presumed to be removed by the antivirus software cleanup process.

Fixes #11250
Fixes #9833
Fixes #1432
Related: f50135a32e11c535e1dc3a8e9460c5b4e640ee86 stdpath("run")