### PR TITLE
terminal: absolute CWD in term:// URI

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -321,7 +321,7 @@ function vim.trim(s)
   return s:match('^%s*(.*%S)') or ''
 end
 
---- Escapes magic chars in a Lua pattern string.
+--- Escapes magic chars in a Lua pattern.
 ---
 --@see https://github.com/rxi/lume
 --@param s  String to escape

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -234,7 +234,8 @@ get_vimpatch() {
   msg_ok "Saved patch to '${NVIM_SOURCE_DIR}/${patch_file}'."
 }
 
-# shellcheck disable=SC2015  # "Note that A && B || C is not if-then-else."
+# shellcheck disable=SC2015
+# ^ "Note that A && B || C is not if-then-else."
 stage_patch() {
   get_vimpatch "$1"
   local try_apply="${2:-}"
@@ -305,7 +306,8 @@ git_hub_pr() {
   git hub pull new -m "$1"
 }
 
-# shellcheck disable=SC2015  # "Note that A && B || C is not if-then-else."
+# shellcheck disable=SC2015
+# ^ "Note that A && B || C is not if-then-else."
 submit_pr() {
   require_executable git
   local push_first

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -339,8 +339,8 @@ int main(int argc, char **argv)
                  "matchstr(expand(\"<amatch>\"), "
                  "'\\c\\m" PROTO "\\%(.\\{-}//\\%(\\d\\+:\\)\\?\\)\\?\\zs.*'), "
                  // capture the working directory
-                 "{'cwd': get(matchlist(expand(\"<amatch>\"), "
-                 "'\\c\\m" PROTO "\\(.\\{-}\\)//'), 1, '')})"
+                 "{'cwd': expand(get(matchlist(expand(\"<amatch>\"), "
+                 "'\\c\\m" PROTO "\\(.\\{-}\\)//'), 1, ''))})"
                  "|endif");
   do_cmdline_cmd("augroup END");
 #undef PROTO

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -6,6 +6,8 @@ local command = helpers.command
 local get_pathsep = helpers.get_pathsep
 local eq = helpers.eq
 local funcs = helpers.funcs
+local matches = helpers.matches
+local pesc = helpers.pesc
 local rmdir = helpers.rmdir
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
@@ -48,7 +50,7 @@ describe(':mksession', function()
     eq(cwd_dir .. get_pathsep() .. tab_dir, funcs.getcwd())
   end)
 
-  it('restores buffers when using tab-local working directories', function()
+  it('restores buffers with tab-local CWD', function()
     local tmpfile_base = file_prefix .. '-tmpfile'
     local cwd_dir = funcs.getcwd()
     local session_path = cwd_dir .. get_pathsep() .. session_file
@@ -69,5 +71,24 @@ describe(':mksession', function()
     eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '1', funcs.expand('%:p'))
     command('tabnext 2')
     eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', funcs.expand('%:p'))
+  end)
+
+  it('restores CWD for :terminal buffers #11288', function()
+    local cwd_dir = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
+    local session_path = cwd_dir..get_pathsep()..session_file
+
+    command('cd '..tab_dir)
+    command('terminal echo $PWD')
+    command('cd '..cwd_dir)
+    command('mksession '..session_path)
+    command('qall!')
+
+    -- Create a new test instance of Nvim.
+    clear()
+    command('silent source '..session_path)
+
+    local expected_cwd = cwd_dir..get_pathsep()..tab_dir
+    matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
+    command('qall!')
   end)
 end)

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -5,9 +5,12 @@ local curbufmeths = helpers.curbufmeths
 local curwinmeths = helpers.curwinmeths
 local nvim_dir = helpers.nvim_dir
 local command = helpers.command
+local funcs = helpers.funcs
 local meths = helpers.meths
 local clear = helpers.clear
 local eq = helpers.eq
+local matches = helpers.matches
+local pesc = helpers.pesc
 
 describe(':edit term://*', function()
   local get_screen = function(columns, lines)
@@ -28,7 +31,8 @@ describe(':edit term://*', function()
     command('edit term://')
     local termopen_runs = meths.get_var('termopen_runs')
     eq(1, #termopen_runs)
-    eq(termopen_runs[1], termopen_runs[1]:match('^term://.//%d+:$'))
+    local cwd = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
+    matches('^term://'..pesc(cwd)..'//%d+:$', termopen_runs[1])
   end)
 
   it("runs TermOpen early enough to set buffer-local 'scrollback'", function()


### PR DESCRIPTION
Fixes #11288

This PR fixes terminal buffer `cwd` restoration from a session by making sure to write the full, absolute path to the `cwd` of any terminal buffer to its `fname`.

~~I haven't fixed tests yet since I'm not sure if this is the right approach from a design perspective. I noticed that the `setfname` procedure does some work to expand the path name to an absolute path for non-terminal buffers (using the procedure `fname_expand`, which it turn calls `fix_fname`), so maybe that's the right place for this change to go instead? It's a little bit awkward for it to go there, though, since it'd have to parse apart the `term://` string to get the `cwd`, then get the absolute path of that `cwd`, and construct a new `term://` string. It's doable, though.~~

~~Anyway, I could use some help in figuring out where to put this logic. Then I'm happy to implement the changes and fix up all the tests.~~