### PR TITLE
vim-patch:8.1.{0252,0407,0469,0488,0532,1006,1030,1062,1098,1112,1256} cannot navigate through errors relative to the cursor (take 2)

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1163,11 +1163,13 @@ tag		command		action ~
 |:cNfile|	:cNf[ile]	go to last error in previous file
 |:cabbrev|	:ca[bbrev]	like ":abbreviate" but for Command-line mode
 |:cabclear|	:cabc[lear]	clear all abbreviations for Command-line mode
+|:cabove|	:cabo[ve]	go to error above current line
 |:caddbuffer|	:cad[dbuffer]	add errors from buffer
 |:caddexpr|	:cadde[xpr]	add errors from expr
 |:caddfile|	:caddf[ile]	add error message to current quickfix list
 |:call|		:cal[l]		call a function
 |:catch|	:cat[ch]	part of a :try command
+|:cbelow|	:cbe[low]	got to error below current line
 |:cbottom|	:cbo[ttom]	scroll to the bottom of the quickfix window
 |:cbuffer|	:cb[uffer]	parse error messages and jump to first error
 |:cc|		:cc		go to specific error
@@ -1324,12 +1326,14 @@ tag		command		action ~
 |:lNext|	:lN[ext]	go to previous entry in location list
 |:lNfile|	:lNf[ile]	go to last entry in previous file
 |:list|		:l[ist]		print lines
+|:labove|	:lab[ove]	go to location above current line
 |:laddexpr|	:lad[dexpr]	add locations from expr
 |:laddbuffer|	:laddb[uffer]	add locations from buffer
 |:laddfile|	:laddf[ile]	add locations to current location list
 |:last|		:la[st]		go to the last file in the argument list
 |:language|	:lan[guage]	set the language (locale)
 |:later|	:lat[er]	go to newer change, redo
+|:lbelow|	:lbe[low]	go to location below current line
 |:lbottom|	:lbo[ttom]	scroll to the bottom of the location window
 |:lbuffer|	:lb[uffer]	parse locations and jump to first location
 |:lcd|		:lc[d]		change directory locally

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -109,6 +109,36 @@ processing a quickfix or location list command, it will be aborted.
 			list for the current window is used instead of the
 			quickfix list.
 
+							*:cabo* *:cabove*
+:[count]cabo[ve]	Go to the [count] error above the current line in the
+			current buffer.  If [count] is omitted, then 1 is
+			used.  If there are no errors, then an error message
+			is displayed.  Assumes that the entries in a quickfix
+			list are sorted by their buffer number and line
+			number. If there are multiple errors on the same line,
+			then only the first entry is used.  If [count] exceeds
+			the number of entries above the current line, then the
+			first error in the file is selected.
+
+							*:lab* *:labove*
+:[count]lab[ove]	Same as ":cabove", except the location list for the
+			current window is used instead of the quickfix list.
+
+							*:cbe* *:cbelow*
+:[count]cbe[low]	Go to the [count] error below the current line in the
+			current buffer.  If [count] is omitted, then 1 is
+			used.  If there are no errors, then an error message
+			is displayed.  Assumes that the entries in a quickfix
+			list are sorted by their buffer number and line
+			number.  If there are multiple errors on the same
+			line, then only the first entry is used.  If [count]
+			exceeds the number of entries below the current line,
+			then the last error in the file is selected.
+
+							*:lbe* *:lbelow*
+:[count]lbe[low]	Same as ":cbelow", except the location list for the
+			current window is used instead of the quickfix list.
+
 							*:cnf* *:cnfile*
 :[count]cnf[ile][!]	Display the first error in the [count] next file in
 			the list that includes a file name.  If there are no

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -323,6 +323,12 @@ return {
     func='ex_abclear',
   },
   {
+    command='cabove',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
+  },
+  {
     command='caddbuffer',
     flags=bit.bor(RANGE, NOTADR, WORD1, TRLBAR),
     addr_type=ADDR_LINES,
@@ -357,6 +363,12 @@ return {
     flags=bit.bor(BANG, RANGE, NOTADR, WORD1, TRLBAR),
     addr_type=ADDR_LINES,
     func='ex_cbuffer',
+  },
+  {
+    command='cbelow',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
   },
   {
     command='cbottom',
@@ -1273,6 +1285,12 @@ return {
     func='ex_last',
   },
   {
+    command='labove',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
+  },
+  {
     command='language',
     flags=bit.bor(EXTRA, TRLBAR, CMDWIN),
     addr_type=ADDR_LINES,
@@ -1307,6 +1325,12 @@ return {
     flags=bit.bor(BANG, RANGE, NOTADR, WORD1, TRLBAR),
     addr_type=ADDR_LINES,
     func='ex_cbuffer',
+  },
+  {
+    command='lbelow',
+    flags=bit.bor(RANGE, TRLBAR),
+    addr_type=ADDR_OTHER ,
+    func='ex_cbelow',
   },
   {
     command='lbottom',

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -693,6 +693,8 @@ void free_all_mem(void)
 
   clear_hl_tables(false);
   list_free_log();
+
+  check_quickfix_busy();
 }
 
 #endif

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -382,7 +382,7 @@ static char_u * scanf_fmt_to_regpat(
 }
 
 // Analyze/parse an errorformat prefix.
-static char_u *efm_analyze_prefix(const char_u *efmp, efm_T *efminfo,
+static const char_u *efm_analyze_prefix(const char_u *efmp, efm_T *efminfo,
                                   char_u *errmsg, size_t errmsglen)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -1138,7 +1138,7 @@ qf_init_ext(
 error2:
   if (!adding) {
     // Error when creating a new list. Free the new list
-    qf_free(qi, qi->qf_curlist);
+    qf_free(&qi->qf_lists[qi->qf_curlist]);
     qi->qf_listcount--;
     if (qi->qf_curlist > 0) {
       qi->qf_curlist--;
@@ -1156,16 +1156,16 @@ qf_init_end:
 
 /// Set the title of the specified quickfix list. Frees the previous title.
 /// Prepends ':' to the title.
-static void qf_store_title(qf_info_T *qi, int qf_idx, const char_u *title)
+static void qf_store_title(qf_list_T *qfl, const char_u *title)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  XFREE_CLEAR(qi->qf_lists[qf_idx].qf_title);
+  XFREE_CLEAR(qfl->qf_title);
 
   if (title != NULL) {
     size_t len = STRLEN(title) + 1;
     char_u *p = xmallocz(len);
 
-    qi->qf_lists[qf_idx].qf_title = p;
+    qfl->qf_title = p;
     xstrlcpy((char *)p, (const char *)title, len + 1);
   }
 }
@@ -1193,22 +1193,24 @@ static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
   // If the current entry is not the last entry, delete entries beyond
   // the current entry.  This makes it possible to browse in a tree-like
   // way with ":grep'.
-  while (qi->qf_listcount > qi->qf_curlist + 1)
-    qf_free(qi, --qi->qf_listcount);
+  while (qi->qf_listcount > qi->qf_curlist + 1) {
+    qf_free(&qi->qf_lists[--qi->qf_listcount]);
+  }
 
   /*
    * When the stack is full, remove to oldest entry
    * Otherwise, add a new entry.
    */
   if (qi->qf_listcount == LISTCOUNT) {
-    qf_free(qi, 0);
-    for (i = 1; i < LISTCOUNT; ++i)
+    qf_free(&qi->qf_lists[0]);
+    for (i = 1; i < LISTCOUNT; i++) {
       qi->qf_lists[i - 1] = qi->qf_lists[i];
+    }
     qi->qf_curlist = LISTCOUNT - 1;
   } else
     qi->qf_curlist = qi->qf_listcount++;
   memset(&qi->qf_lists[qi->qf_curlist], 0, (size_t)(sizeof(qf_list_T)));
-  qf_store_title(qi, qi->qf_curlist, qf_title);
+  qf_store_title(&qi->qf_lists[qi->qf_curlist], qf_title);
   qi->qf_lists[qi->qf_curlist].qf_id = ++last_qf_id;
 }
 
@@ -1628,7 +1630,7 @@ static int qf_parse_multiline_pfx(qf_info_T *qi, int qf_idx, int idx,
   return QF_IGNORE_LINE;
 }
 
-/// Free a location list.
+/// Free a location list stack
 static void ll_free_all(qf_info_T **pqi)
 {
   int i;
@@ -1641,9 +1643,10 @@ static void ll_free_all(qf_info_T **pqi)
 
   qi->qf_refcount--;
   if (qi->qf_refcount < 1) {
-    /* No references to this location list */
-    for (i = 0; i < qi->qf_listcount; ++i)
-      qf_free(qi, i);
+    // No references to this location list
+    for (i = 0; i < qi->qf_listcount; i++) {
+      qf_free(&qi->qf_lists[i]);
+    }
     xfree(qi);
   }
 }
@@ -1658,10 +1661,12 @@ void qf_free_all(win_T *wp)
     /* location list */
     ll_free_all(&wp->w_llist);
     ll_free_all(&wp->w_llist_ref);
-  } else
-    /* quickfix list */
-    for (i = 0; i < qi->qf_listcount; ++i)
-      qf_free(qi, i);
+  } else {
+    // quickfix list
+    for (i = 0; i < qi->qf_listcount; i++) {
+      qf_free(&qi->qf_lists[i]);
+    }
+  }
 }
 
 /// Add an entry to the end of the list of errors.
@@ -1687,6 +1692,7 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
                         int col, char_u vis_col, char_u *pattern, int nr,
                         char_u type, char_u valid)
 {
+  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   qfline_T *qfp = xmalloc(sizeof(qfline_T));
   qfline_T **lastp;  // pointer to qf_last or NULL
 
@@ -1722,12 +1728,12 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
   qfp->qf_type = (char_u)type;
   qfp->qf_valid = valid;
 
-  lastp = &qi->qf_lists[qf_idx].qf_last;
+  lastp = &qfl->qf_last;
   if (qf_list_empty(qi, qf_idx)) {
     // first element in the list
-    qi->qf_lists[qf_idx].qf_start = qfp;
-    qi->qf_lists[qf_idx].qf_ptr = qfp;
-    qi->qf_lists[qf_idx].qf_index = 0;
+    qfl->qf_start = qfp;
+    qfl->qf_ptr = qfp;
+    qfl->qf_index = 0;
     qfp->qf_prev = NULL;
   } else {
     assert(*lastp);
@@ -1737,19 +1743,17 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
   qfp->qf_next = NULL;
   qfp->qf_cleared = false;
   *lastp = qfp;
-  qi->qf_lists[qf_idx].qf_count++;
-  if (qi->qf_lists[qf_idx].qf_index == 0 && qfp->qf_valid) {
+  qfl->qf_count++;
+  if (qfl->qf_index == 0 && qfp->qf_valid) {
     // first valid entry
-    qi->qf_lists[qf_idx].qf_index = qi->qf_lists[qf_idx].qf_count;
-    qi->qf_lists[qf_idx].qf_ptr = qfp;
+    qfl->qf_index = qfl->qf_count;
+    qfl->qf_ptr = qfp;
   }
 
   return OK;
 }
 
-/*
- * Allocate a new location list
- */
+// Allocate a new location list stack
 static qf_info_T *ll_new_list(void)
   FUNC_ATTR_NONNULL_RET
 {
@@ -1759,10 +1763,8 @@ static qf_info_T *ll_new_list(void)
   return qi;
 }
 
-/*
- * Return the location list for window 'wp'.
- * If not present, allocate a location list
- */
+// Return the location list stack for window 'wp'.
+// If not present, allocate a location list stack
 static qf_info_T *ll_get_or_alloc_list(win_T *wp)
 {
   if (IS_LL_WINDOW(wp))
@@ -1936,7 +1938,7 @@ static int qf_get_fnum(qf_info_T *qi, int qf_idx, char_u *directory,
     // directory change.
     if (!os_path_exists(ptr)) {
       xfree(ptr);
-      directory = qf_guess_filepath(qi, qf_idx, fname);
+      directory = qf_guess_filepath(&qi->qf_lists[qf_idx], fname);
       if (directory) {
         ptr = (char_u *)concat_fnames((char *)directory, (char *)fname, true);
       } else {
@@ -2084,12 +2086,11 @@ static void qf_clean_dir_stack(struct dir_stack_T **stackptr)
 //     x.c:9: Error
 // Then qf_push_dir thinks we are in ./aa/bb, but we are in ./bb.
 // qf_guess_filepath will return NULL.
-static char_u *qf_guess_filepath(qf_info_T *qi, int qf_idx, char_u *filename)
+static char_u *qf_guess_filepath(qf_list_T *qfl, char_u *filename)
 {
   struct dir_stack_T     *ds_ptr;
   struct dir_stack_T     *ds_tmp;
   char_u                 *fullname;
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
 
   // no dirs on the stack - there's nothing we can do
   if (qfl->qf_dir_stack == NULL) {
@@ -2147,13 +2148,10 @@ static bool qflist_valid(win_T *wp, unsigned int qf_id)
 /// This may invalidate the current quickfix entry.  This function checks
 /// whether an entry is still present in the quickfix list.
 /// Similar to location list.
-static bool is_qf_entry_present(qf_info_T *qi, qfline_T *qf_ptr)
+static bool is_qf_entry_present(qf_list_T *qfl, qfline_T *qf_ptr)
 {
-  qf_list_T *qfl;
   qfline_T *qfp;
   int i;
-
-  qfl = &qi->qf_lists[qi->qf_curlist];
 
   // Search for the entry in the current list
   for (i = 0, qfp = qfl->qf_start; i < qfl->qf_count; i++, qfp = qfp->qf_next) {
@@ -2171,20 +2169,19 @@ static bool is_qf_entry_present(qf_info_T *qi, qfline_T *qf_ptr)
 
 /// Get the next valid entry in the current quickfix/location list. The search
 /// starts from the current entry. Returns NULL on failure.
-static qfline_T *get_next_valid_entry(qf_info_T *qi, qfline_T *qf_ptr,
+static qfline_T *get_next_valid_entry(qf_list_T *qfl, qfline_T *qf_ptr,
                                       int *qf_index, int dir)
 {
   int idx = *qf_index;
   int old_qf_fnum = qf_ptr->qf_fnum;
 
   do {
-    if (idx == qi->qf_lists[qi->qf_curlist].qf_count
-        || qf_ptr->qf_next == NULL) {
+    if (idx == qfl->qf_count || qf_ptr->qf_next == NULL) {
       return NULL;
     }
     idx++;
     qf_ptr = qf_ptr->qf_next;
-  } while ((!qi->qf_lists[qi->qf_curlist].qf_nonevalid && !qf_ptr->qf_valid)
+  } while ((!qfl->qf_nonevalid && !qf_ptr->qf_valid)
            || (dir == FORWARD_FILE && qf_ptr->qf_fnum == old_qf_fnum));
 
   *qf_index = idx;
@@ -2193,7 +2190,7 @@ static qfline_T *get_next_valid_entry(qf_info_T *qi, qfline_T *qf_ptr,
 
 /// Get the previous valid entry in the current quickfix/location list. The
 /// search starts from the current entry. Returns NULL on failure.
-static qfline_T *get_prev_valid_entry(qf_info_T *qi, qfline_T *qf_ptr,
+static qfline_T *get_prev_valid_entry(qf_list_T *qfl, qfline_T *qf_ptr,
                                       int *qf_index, int dir)
 {
   int idx = *qf_index;
@@ -2205,7 +2202,7 @@ static qfline_T *get_prev_valid_entry(qf_info_T *qi, qfline_T *qf_ptr,
     }
     idx--;
     qf_ptr = qf_ptr->qf_prev;
-  } while ((!qi->qf_lists[qi->qf_curlist].qf_nonevalid && !qf_ptr->qf_valid)
+  } while ((!qfl->qf_nonevalid && !qf_ptr->qf_valid)
            || (dir == BACKWARD_FILE && qf_ptr->qf_fnum == old_qf_fnum));
 
   *qf_index = idx;
@@ -2216,7 +2213,7 @@ static qfline_T *get_prev_valid_entry(qf_info_T *qi, qfline_T *qf_ptr,
 /// the quickfix list.
 ///   dir == FORWARD or FORWARD_FILE: next valid entry
 ///   dir == BACKWARD or BACKWARD_FILE: previous valid entry
-static qfline_T *get_nth_valid_entry(qf_info_T *qi, int errornr,
+static qfline_T *get_nth_valid_entry(qf_list_T *qfl, int errornr,
                                      qfline_T *qf_ptr, int *qf_index, int dir)
 {
   qfline_T *prev_qf_ptr;
@@ -2229,9 +2226,9 @@ static qfline_T *get_nth_valid_entry(qf_info_T *qi, int errornr,
     prev_index = *qf_index;
 
     if (dir == FORWARD || dir == FORWARD_FILE) {
-      qf_ptr = get_next_valid_entry(qi, qf_ptr, qf_index, dir);
+      qf_ptr = get_next_valid_entry(qfl, qf_ptr, qf_index, dir);
     } else {
-      qf_ptr = get_prev_valid_entry(qi, qf_ptr, qf_index, dir);
+      qf_ptr = get_prev_valid_entry(qfl, qf_ptr, qf_index, dir);
     }
 
     if (qf_ptr == NULL) {
@@ -2251,7 +2248,7 @@ static qfline_T *get_nth_valid_entry(qf_info_T *qi, int errornr,
 }
 
 /// Get n'th (errornr) quickfix entry
-static qfline_T *get_nth_entry(qf_info_T *qi, int errornr, qfline_T *qf_ptr,
+static qfline_T *get_nth_entry(qf_list_T *qfl, int errornr, qfline_T *qf_ptr,
                                int *cur_qfidx)
 {
   int qf_idx = *cur_qfidx;
@@ -2264,7 +2261,7 @@ static qfline_T *get_nth_entry(qf_info_T *qi, int errornr, qfline_T *qf_ptr,
 
   // New error number is greater than the current error number
   while (errornr > qf_idx
-         && qf_idx < qi->qf_lists[qi->qf_curlist].qf_count
+         && qf_idx < qfl->qf_count
          && qf_ptr->qf_next != NULL) {
     qf_idx++;
     qf_ptr = qf_ptr->qf_next;
@@ -2535,6 +2532,7 @@ static int qf_jump_to_usable_window(int qf_fnum, int *opened_window)
 static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit,
                                win_T *oldwin, int *opened_window, int *abort)
 {
+  qf_list_T *qfl = &qi->qf_lists[qi->qf_curlist];
   int retval = OK;
 
   if (qf_ptr->qf_type == 1) {
@@ -2549,7 +2547,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit,
                        oldwin == curwin ? curwin : NULL);
     }
   } else {
-    unsigned save_qfid = qi->qf_lists[qi->qf_curlist].qf_id;
+    unsigned save_qfid = qfl->qf_id;
 
     retval = buflist_getfile(qf_ptr->qf_fnum, (linenr_T)1,
                              GETF_SETMARK | GETF_SWITCH, forceit);
@@ -2565,7 +2563,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit,
         EMSG(_(e_loc_list_changed));
         *abort = true;
       }
-    } else if (!is_qf_entry_present(qi, qf_ptr)) {
+    } else if (!is_qf_entry_present(qfl, qf_ptr)) {
       if (IS_QF_STACK(qi)) {
         EMSG(_("E925: Current quickfix was changed"));
       } else {
@@ -2660,6 +2658,7 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr,
 /// else go to entry "errornr"
 void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
 {
+  qf_list_T *qfl;
   qfline_T *qf_ptr;
   qfline_T *old_qf_ptr;
   int qf_index;
@@ -2682,26 +2681,29 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
     return;
   }
 
-  qf_ptr = qi->qf_lists[qi->qf_curlist].qf_ptr;
+  qfl = &qi->qf_lists[qi->qf_curlist];
+
+  qf_ptr = qfl->qf_ptr;
   old_qf_ptr = qf_ptr;
-  qf_index = qi->qf_lists[qi->qf_curlist].qf_index;
+  qf_index = qfl->qf_index;
   old_qf_index = qf_index;
   if (dir != 0) {   // next/prev valid entry
-    qf_ptr = get_nth_valid_entry(qi, errornr, qf_ptr, &qf_index, dir);
+    qf_ptr = get_nth_valid_entry(qfl, errornr, qf_ptr, &qf_index, dir);
     if (qf_ptr == NULL) {
       qf_ptr = old_qf_ptr;
       qf_index = old_qf_index;
       goto theend;  // The horror... the horror...
     }
   } else if (errornr != 0) {  // go to specified number
-    qf_ptr = get_nth_entry(qi, errornr, qf_ptr, &qf_index);
+    qf_ptr = get_nth_entry(qfl, errornr, qf_ptr, &qf_index);
   }
 
-  qi->qf_lists[qi->qf_curlist].qf_index = qf_index;
-  if (qf_win_pos_update(qi, old_qf_index))
-    /* No need to print the error message if it's visible in the error
-     * window */
-    print_message = FALSE;
+  qfl->qf_index = qf_index;
+  if (qf_win_pos_update(qi, old_qf_index)) {
+    // No need to print the error message if it's visible in the error
+    // window
+    print_message = false;
+  }
 
   // For ":helpgrep" find a help window or open one.
   if (qf_ptr->qf_type == 1 && (!bt_help(curwin->w_buffer) || cmdmod.tab != 0)) {
@@ -2770,8 +2772,8 @@ failed:
   }
 theend:
   if (qi != NULL) {
-    qi->qf_lists[qi->qf_curlist].qf_ptr = qf_ptr;
-    qi->qf_lists[qi->qf_curlist].qf_index = qf_index;
+    qfl->qf_ptr = qf_ptr;
+    qfl->qf_index = qf_index;
   }
   if (p_swb != old_swb && opened_window) {
     /* Restore old 'switchbuf' value, but not when an autocommand or
@@ -2792,7 +2794,9 @@ static int qfLineAttr;
 
 // Display information about a single entry from the quickfix/location list.
 // Used by ":clist/:llist" commands.
-static void qf_list_entry(qf_info_T *qi, qfline_T *qfp, int qf_idx)
+// 'cursel' will be set to TRUE for the currently selected entry in the
+// quickfix list.
+static void qf_list_entry(qfline_T *qfp, int qf_idx, int cursel)
 {
   char_u *fname;
   buf_T *buf;
@@ -2838,8 +2842,7 @@ static void qf_list_entry(qf_info_T *qi, qfline_T *qfp, int qf_idx)
   }
 
   msg_putchar('\n');
-  msg_outtrans_attr(IObuff, qf_idx == qi->qf_lists[qi->qf_curlist].qf_index
-                    ? HL_ATTR(HLF_QFL) : qfFileAttr);
+  msg_outtrans_attr(IObuff, cursel ? HL_ATTR(HLF_QFL) : qfFileAttr);
 
   if (qfp->qf_lnum != 0) {
     msg_puts_attr(":", qfSepAttr);
@@ -2879,7 +2882,8 @@ static void qf_list_entry(qf_info_T *qi, qfline_T *qfp, int qf_idx)
  */
 void qf_list(exarg_T *eap)
 {
-  qfline_T    *qfp;
+  qf_list_T *qfl;
+  qfline_T *qfp;
   int i;
   int idx1 = 1;
   int idx2 = -1;
@@ -2910,12 +2914,13 @@ void qf_list(exarg_T *eap)
     EMSG(_(e_trailing));
     return;
   }
+  qfl = &qi->qf_lists[qi->qf_curlist];
   if (plus) {
-    i = qi->qf_lists[qi->qf_curlist].qf_index;
+    i = qfl->qf_index;
     idx2 = i + idx1;
     idx1 = i;
   } else {
-    i = qi->qf_lists[qi->qf_curlist].qf_count;
+    i = qfl->qf_count;
     if (idx1 < 0) {
       idx1 = (-idx1 > i) ? 0 : idx1 + i + 1;
     }
@@ -2942,17 +2947,17 @@ void qf_list(exarg_T *eap)
       qfLineAttr = HL_ATTR(HLF_N);
   }
 
-  if (qi->qf_lists[qi->qf_curlist].qf_nonevalid) {
+  if (qfl->qf_nonevalid) {
     all = true;
   }
-  qfp = qi->qf_lists[qi->qf_curlist].qf_start;
-  for (i = 1; !got_int && i <= qi->qf_lists[qi->qf_curlist].qf_count; ) {
+  qfp = qfl->qf_start;
+  for (i = 1; !got_int && i <= qfl->qf_count; ) {
     if ((qfp->qf_valid || all) && idx1 <= i && i <= idx2) {
       if (got_int) {
         break;
       }
 
-      qf_list_entry(qi, qfp, i);
+      qf_list_entry(qfp, i, i == qfl->qf_index);
     }
 
     qfp = qfp->qf_next;
@@ -3078,12 +3083,11 @@ void qf_history(exarg_T *eap)
 
 /// Free all the entries in the error list "idx". Note that other information
 /// associated with the list like context and title are not freed.
-static void qf_free_items(qf_info_T *qi, int idx)
+static void qf_free_items(qf_list_T *qfl)
 {
   qfline_T    *qfp;
   qfline_T    *qfpnext;
   bool stop = false;
-  qf_list_T *qfl = &qi->qf_lists[idx];
 
   while (qfl->qf_count && qfl->qf_start != NULL) {
     qfp = qfl->qf_start;
@@ -3124,10 +3128,9 @@ static void qf_free_items(qf_info_T *qi, int idx)
 
 /// Free error list "idx". Frees all the entries in the quickfix list,
 /// associated context information and the title.
-static void qf_free(qf_info_T *qi, int idx)
+static void qf_free(qf_list_T *qfl)
 {
-  qf_list_T *qfl = &qi->qf_lists[idx];
-  qf_free_items(qi, idx);
+  qf_free_items(qfl);
 
   XFREE_CLEAR(qfl->qf_title);
   tv_free(qfl->qf_ctx);
@@ -3406,6 +3409,14 @@ static int qf_open_new_cwindow(const qf_info_T *qi, int height)
   return OK;
 }
 
+// Set "w:quickfix_title" if "qi" has a title.
+static void qf_set_title_var(qf_list_T *qfl)
+{
+  if (qfl->qf_title != NULL) {
+    set_internal_string_var((char_u *)"w:quickfix_title", qfl->qf_title);
+  }
+}
+
 /*
  * ":copen": open a window that shows the list of errors.
  * ":lopen": open a window that shows the location list.
@@ -3443,7 +3454,7 @@ void ex_copen(exarg_T *eap)
     }
   }
 
-  qf_set_title_var(qi);
+  qf_set_title_var(&qi->qf_lists[qi->qf_curlist]);
 
   // Fill the buffer with the quickfix list.
   qf_fill_buffer(qi, curbuf, NULL);
@@ -3541,7 +3552,7 @@ qf_win_pos_update (
 }
 
 /// Checks whether the given window is displaying the specified
-/// quickfix/location list buffer.
+/// quickfix/location stack.
 static int is_qf_win(const win_T *win, const qf_info_T *qi)
   FUNC_ATTR_NONNULL_ARG(2) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
@@ -3561,7 +3572,7 @@ static int is_qf_win(const win_T *win, const qf_info_T *qi)
   return false;
 }
 
-/// Find a window displaying the quickfix/location list 'qi'
+/// Find a window displaying the quickfix/location stack 'qi'
 /// Only searches in the current tabpage.
 static win_T *qf_find_win(const qf_info_T *qi)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
@@ -3599,7 +3610,7 @@ static void qf_update_win_titlevar(qf_info_T *qi)
   if ((win = qf_find_win(qi)) != NULL) {
     win_T *curwin_save = curwin;
     curwin = win;
-    qf_set_title_var(qi);
+    qf_set_title_var(&qi->qf_lists[qi->qf_curlist]);
     curwin = curwin_save;
   }
 }
@@ -3640,15 +3651,6 @@ static void qf_update_buffer(qf_info_T *qi, qfline_T *old_last)
     if ((win = qf_find_win(qi)) != NULL && old_line_count < win->w_botline) {
       redraw_buf_later(buf, NOT_VALID);
     }
-  }
-}
-
-// Set "w:quickfix_title" if "qi" has a title.
-static void qf_set_title_var(qf_info_T *qi)
-{
-  if (qi->qf_lists[qi->qf_curlist].qf_title != NULL) {
-      set_internal_string_var((char_u *)"w:quickfix_title",
-                              qi->qf_lists[qi->qf_curlist].qf_title);
   }
 }
 
@@ -4144,11 +4146,9 @@ int qf_get_cur_valid_idx(exarg_T *eap)
 /// Used by :cdo, :ldo, :cfdo and :lfdo commands.
 /// For :cdo and :ldo, returns the 'n'th valid error entry.
 /// For :cfdo and :lfdo, returns the 'n'th valid file entry.
-static size_t qf_get_nth_valid_entry(qf_info_T *qi, size_t n, bool fdo)
+static size_t qf_get_nth_valid_entry(qf_list_T *qfl, size_t n, int fdo)
   FUNC_ATTR_NONNULL_ALL
 {
-  qf_list_T *qfl = &qi->qf_lists[qi->qf_curlist];
-
   // Check if the list has valid errors.
   if (qfl->qf_count <= 0 || qfl->qf_nonevalid) {
     return 1;
@@ -4231,8 +4231,9 @@ void ex_cc(exarg_T *eap)
     } else {
       n = 1;
     }
-    size_t valid_entry = qf_get_nth_valid_entry(qi, n,
-      eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo);
+    size_t valid_entry = qf_get_nth_valid_entry(
+        &qi->qf_lists[qi->qf_curlist], n,
+        eap->cmdidx == CMD_cfdo || eap->cmdidx == CMD_lfdo);
     assert(valid_entry <= INT_MAX);
     errornr = (int)valid_entry;
   }
@@ -5065,7 +5066,7 @@ static int qf_get_list_from_lines(dict_T *what, dictitem_T *di, dict_T *retdict)
     if (qf_init_ext(qi, 0, NULL, NULL, &di->di_tv, errorformat,
                     true, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0) {
       (void)get_errorlist(qi, NULL, 0, l);
-      qf_free(qi, 0);
+      qf_free(&qi->qf_lists[0]);
     }
     xfree(qi);
 
@@ -5298,6 +5299,7 @@ static int qf_getprop_idx(qf_info_T *qi, int qf_idx, dict_T *retdict)
 int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 {
   qf_info_T *qi = &ql_info;
+  qf_list_T *qfl;
   dictitem_T *di = NULL;
   int status = OK;
   int qf_idx;
@@ -5321,6 +5323,8 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
     return qf_getprop_defaults(qi, flags, retdict);
   }
 
+  qfl = &qi->qf_lists[qf_idx];
+
   if (flags & QF_GETLIST_TITLE) {
     status = qf_getprop_title(qi, qf_idx, retdict);
   }
@@ -5337,18 +5341,18 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
     status = qf_getprop_ctx(qi, qf_idx, retdict);
   }
   if ((status == OK) && (flags & QF_GETLIST_ID)) {
-    status = tv_dict_add_nr(retdict, S_LEN("id"), qi->qf_lists[qf_idx].qf_id);
+    status = tv_dict_add_nr(retdict, S_LEN("id"), qfl->qf_id);
   }
   if ((status == OK) && (flags & QF_GETLIST_IDX)) {
     status = qf_getprop_idx(qi, qf_idx, retdict);
   }
   if ((status == OK) && (flags & QF_GETLIST_SIZE)) {
     status = tv_dict_add_nr(retdict, S_LEN("size"),
-                            qi->qf_lists[qf_idx].qf_count);
+                            qfl->qf_count);
   }
   if ((status == OK) && (flags & QF_GETLIST_TICK)) {
     status = tv_dict_add_nr(retdict, S_LEN("changedtick"),
-                            qi->qf_lists[qf_idx].qf_changedtick);
+                            qfl->qf_changedtick);
   }
   if ((status == OK) && (wp != NULL) && (flags & QF_GETLIST_FILEWINID)) {
     status = qf_getprop_filewinid(wp, qi, retdict);
@@ -5435,6 +5439,7 @@ static int qf_add_entry_from_dict(
 static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
                           char_u *title, int action)
 {
+  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   qfline_T *old_last = NULL;
   int retval = OK;
 
@@ -5442,12 +5447,13 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
     // make place for a new list
     qf_new_list(qi, title);
     qf_idx = qi->qf_curlist;
+    qfl = &qi->qf_lists[qf_idx];
   } else if (action == 'a' && !qf_list_empty(qi, qf_idx)) {
     // Adding to existing list, use last entry.
-    old_last = qi->qf_lists[qf_idx].qf_last;
+    old_last = qfl->qf_last;
   } else if (action == 'r') {
-    qf_free_items(qi, qf_idx);
-    qf_store_title(qi, qf_idx, title);
+    qf_free_items(qfl);
+    qf_store_title(qfl, title);
   }
 
   TV_LIST_ITER_CONST(list, li, {
@@ -5466,16 +5472,16 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
     }
   });
 
-  if (qi->qf_lists[qf_idx].qf_index == 0) {
+  if (qfl->qf_index == 0) {
     // no valid entry
-    qi->qf_lists[qf_idx].qf_nonevalid = true;
+    qfl->qf_nonevalid = true;
   } else {
-    qi->qf_lists[qf_idx].qf_nonevalid = false;
+    qfl->qf_nonevalid = false;
   }
   if (action != 'a') {
-    qi->qf_lists[qf_idx].qf_ptr = qi->qf_lists[qf_idx].qf_start;
+    qfl->qf_ptr = qfl->qf_start;
     if (!qf_list_empty(qi, qf_idx)) {
-      qi->qf_lists[qf_idx].qf_index = 1;
+      qfl->qf_index = 1;
     }
   }
 
@@ -5605,7 +5611,7 @@ static int qf_setprop_items_from_lines(
   }
 
   if (action == 'r') {
-    qf_free_items(qi, qf_idx);
+    qf_free_items(&qi->qf_lists[qf_idx]);
   }
   if (qf_init_ext(qi, qf_idx, NULL, NULL, &di->di_tv, errorformat,
                   false, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0) {
@@ -5616,13 +5622,13 @@ static int qf_setprop_items_from_lines(
 }
 
 // Set quickfix list context.
-static int qf_setprop_context(qf_info_T *qi, int qf_idx, dictitem_T *di)
+static int qf_setprop_context(qf_list_T *qfl, dictitem_T *di)
   FUNC_ATTR_NONNULL_ALL
 {
-  tv_free(qi->qf_lists[qf_idx].qf_ctx);
+  tv_free(qfl->qf_ctx);
   typval_T *ctx = xcalloc(1, sizeof(typval_T));
   tv_copy(&di->di_tv, ctx);
-  qi->qf_lists[qf_idx].qf_ctx = ctx;
+  qfl->qf_ctx = ctx;
 
   return OK;
 }
@@ -5658,7 +5664,7 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
     retval = qf_setprop_items_from_lines(qi, qf_idx, what, di, action);
   }
   if ((di = tv_dict_find(what, S_LEN("context"))) != NULL) {
-    retval = qf_setprop_context(qi, qf_idx, di);
+    retval = qf_setprop_context(&qi->qf_lists[qf_idx], di);
   }
 
   if (retval == OK) {
@@ -5668,7 +5674,8 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
   return retval;
 }
 
-// Find the non-location list window with the specified location list.
+// Find the non-location list window with the specified location list in the
+// current tabpage.
 static win_T * find_win_with_ll(qf_info_T *qi)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
@@ -5689,7 +5696,7 @@ static void qf_free_stack(win_T *wp, qf_info_T *qi)
   if (qfwin != NULL) {
     // If the quickfix/location list window is open, then clear it
     if (qi->qf_curlist < qi->qf_listcount) {
-      qf_free(qi, qi->qf_curlist);
+      qf_free(&qi->qf_lists[qi->qf_curlist]);
     }
     qf_update_buffer(qi, NULL);
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -215,7 +215,10 @@ typedef struct {
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "quickfix.c.generated.h"
 #endif
-/* Quickfix window check helper macro */
+
+static char_u *e_no_more_items = (char_u *)N_("E553: No more items");
+
+// Quickfix window check helper macro
 #define IS_QF_WINDOW(wp) (bt_quickfix(wp->w_buffer) && wp->w_llist_ref == NULL)
 /* Location list window check helper macro */
 #define IS_LL_WINDOW(wp) (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
@@ -896,6 +899,13 @@ static bool qf_list_empty(qf_list_T *qfl)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return qfl == NULL || qfl->qf_count <= 0;
+}
+
+// Returns TRUE if the specified quickfix/location list is not empty and
+// has valid entries.
+static int qf_list_has_valid_entries(qf_list_T *qfl)
+{
+  return !qf_list_empty(qfl) && !qfl->qf_nonevalid;
 }
 
 // Return a pointer to a list in the specified quickfix stack
@@ -2370,7 +2380,6 @@ static qfline_T *get_nth_valid_entry(qf_list_T *qfl, int errornr,
 {
   qfline_T *prev_qf_ptr;
   int prev_index;
-  static char_u *e_no_more_items = (char_u *)N_("E553: No more items");
   char_u *err = e_no_more_items;
 
   while (errornr--) {
@@ -4240,7 +4249,7 @@ int qf_get_cur_valid_idx(exarg_T *eap)
   qf_list_T *qfl = qf_get_curlist(qi);
 
   // Check if the list has valid errors.
-  if (qfl->qf_count <= 0 || qfl->qf_nonevalid) {
+  if (!qf_list_has_valid_entries(qfl)) {
     return 1;
   }
 
@@ -4279,7 +4288,7 @@ static size_t qf_get_nth_valid_entry(qf_list_T *qfl, size_t n, int fdo)
   FUNC_ATTR_NONNULL_ALL
 {
   // Check if the list has valid errors.
-  if (qfl->qf_count <= 0 || qfl->qf_nonevalid) {
+  if (!qf_list_has_valid_entries(qfl)) {
     return 1;
   }
 
@@ -4418,6 +4427,282 @@ void ex_cnext(exarg_T *eap)
 
   qf_jump(qi, dir, errornr, eap->forceit);
 }
+
+// Find the first entry in the quickfix list 'qfl' from buffer 'bnr'.
+// The index of the entry is stored in 'errornr'.
+// Returns NULL if an entry is not found.
+static qfline_T *qf_find_first_entry_in_buf(qf_list_T *qfl,
+                                            int bnr,
+                                            int *errornr)
+{
+  qfline_T *qfp = NULL;
+  int idx = 0;
+
+  // Find the first entry in this file
+  FOR_ALL_QFL_ITEMS(qfl, qfp, idx) {
+    if (qfp->qf_fnum == bnr) {
+      break;
+    }
+  }
+
+  *errornr = idx;
+  return qfp;
+}
+
+// Find the first quickfix entry on the same line as 'entry'. Updates 'errornr'
+// with the error number for the first entry. Assumes the entries are sorted in
+// the quickfix list by line number.
+static qfline_T * qf_find_first_entry_on_line(qfline_T *entry, int *errornr)
+{
+  while (!got_int
+         && entry->qf_prev != NULL
+         && entry->qf_fnum == entry->qf_prev->qf_fnum
+         && entry->qf_lnum == entry->qf_prev->qf_lnum) {
+    entry = entry->qf_prev;
+    (*errornr)--;
+  }
+
+  return entry;
+}
+
+// Find the last quickfix entry on the same line as 'entry'. Updates 'errornr'
+// with the error number for the last entry. Assumes the entries are sorted in
+// the quickfix list by line number.
+static qfline_T * qf_find_last_entry_on_line(qfline_T *entry, int *errornr)
+{
+  while (!got_int
+         && entry->qf_next != NULL
+         && entry->qf_fnum == entry->qf_next->qf_fnum
+         && entry->qf_lnum == entry->qf_next->qf_lnum) {
+    entry = entry->qf_next;
+    (*errornr)++;
+  }
+
+  return entry;
+}
+
+// Find the first quickfix entry below line 'lnum' in buffer 'bnr'.
+// 'qfp' points to the very first entry in the buffer and 'errornr' is the
+// index of the very first entry in the quickfix list.
+// Returns NULL if an entry is not found after 'lnum'.
+static qfline_T *qf_find_entry_on_next_line(int bnr,
+                                            linenr_T lnum,
+                                            qfline_T *qfp,
+                                            int *errornr)
+{
+  if (qfp->qf_lnum > lnum) {
+    // First entry is after line 'lnum'
+    return qfp;
+  }
+
+  // Find the entry just before or at the line 'lnum'
+  while (qfp->qf_next != NULL
+         && qfp->qf_next->qf_fnum == bnr
+         && qfp->qf_next->qf_lnum <= lnum) {
+    qfp = qfp->qf_next;
+    (*errornr)++;
+  }
+
+  if (qfp->qf_next == NULL || qfp->qf_next->qf_fnum != bnr) {
+    // No entries found after 'lnum'
+    return NULL;
+  }
+
+  // Use the entry just after line 'lnum'
+  qfp = qfp->qf_next;
+  (*errornr)++;
+
+  return qfp;
+}
+
+// Find the first quickfix entry before line 'lnum' in buffer 'bnr'.
+// 'qfp' points to the very first entry in the buffer and 'errornr' is the
+// index of the very first entry in the quickfix list.
+// Returns NULL if an entry is not found before 'lnum'.
+static qfline_T *qf_find_entry_on_prev_line(int bnr,
+                                            linenr_T lnum,
+                                            qfline_T *qfp,
+                                            int *errornr)
+{
+  // Find the entry just before the line 'lnum'
+  while (qfp->qf_next != NULL
+         && qfp->qf_next->qf_fnum == bnr
+         && qfp->qf_next->qf_lnum < lnum) {
+    qfp = qfp->qf_next;
+    (*errornr)++;
+  }
+
+  if (qfp->qf_lnum >= lnum) {  // entry is after 'lnum'
+    return NULL;
+  }
+
+  // If multiple entries are on the same line, then use the first entry
+  qfp = qf_find_first_entry_on_line(qfp, errornr);
+
+  return qfp;
+}
+
+// Find a quickfix entry in 'qfl' closest to line 'lnum' in buffer 'bnr' in
+// the direction 'dir'.
+static qfline_T *qf_find_closest_entry(qf_list_T *qfl,
+                                       int bnr,
+                                       linenr_T lnum,
+                                       int dir,
+                                       int *errornr)
+{
+  qfline_T *qfp;
+
+  *errornr = 0;
+
+  // Find the first entry in this file
+  qfp = qf_find_first_entry_in_buf(qfl, bnr, errornr);
+  if (qfp == NULL) {
+    return NULL;  // no entry in this file
+  }
+
+  if (dir == FORWARD) {
+    qfp = qf_find_entry_on_next_line(bnr, lnum, qfp, errornr);
+  } else {
+    qfp = qf_find_entry_on_prev_line(bnr, lnum, qfp, errornr);
+  }
+
+  return qfp;
+}
+
+// Get the nth quickfix entry below the specified entry treating multiple
+// entries on a single line as one. Searches forward in the list.
+static qfline_T *qf_get_nth_below_entry(qfline_T *entry,
+                                        int *errornr,
+                                        linenr_T n)
+{
+  while (n-- > 0 && !got_int) {
+    qfline_T *first_entry = entry;
+    int first_errornr = *errornr;
+
+    // Treat all the entries on the same line in this file as one
+    entry = qf_find_last_entry_on_line(entry, errornr);
+
+    if (entry->qf_next == NULL
+        || entry->qf_next->qf_fnum != entry->qf_fnum) {
+      // If multiple entries are on the same line, then use the first
+      // entry
+      entry = first_entry;
+      *errornr = first_errornr;
+      break;
+    }
+
+    entry = entry->qf_next;
+    (*errornr)++;
+  }
+
+  return entry;
+}
+
+// Get the nth quickfix entry above the specified entry treating multiple
+// entries on a single line as one. Searches backwards in the list.
+static qfline_T *qf_get_nth_above_entry(qfline_T *entry,
+                                        int *errornr,
+                                        linenr_T n)
+{
+  while (n-- > 0 && !got_int) {
+    if (entry->qf_prev == NULL
+        || entry->qf_prev->qf_fnum != entry->qf_fnum) {
+      break;
+    }
+
+    entry = entry->qf_prev;
+    (*errornr)--;
+
+    // If multiple entries are on the same line, then use the first entry
+    entry = qf_find_first_entry_on_line(entry, errornr);
+  }
+
+  return entry;
+}
+
+// Find the n'th quickfix entry adjacent to line 'lnum' in buffer 'bnr' in the
+// specified direction.
+// Returns the error number in the quickfix list or 0 if an entry is not found.
+static int qf_find_nth_adj_entry(qf_list_T *qfl,
+                                 int bnr,
+                                 linenr_T lnum,
+                                 linenr_T n,
+                                 int dir)
+{
+  qfline_T *adj_entry;
+  int errornr;
+
+  // Find an entry closest to the specified line
+  adj_entry = qf_find_closest_entry(qfl, bnr, lnum, dir, &errornr);
+  if (adj_entry == NULL) {
+    return 0;
+  }
+
+  if (--n > 0) {
+    // Go to the n'th entry in the current buffer
+    if (dir == FORWARD) {
+      adj_entry = qf_get_nth_below_entry(adj_entry, &errornr, n);
+    } else {
+      adj_entry = qf_get_nth_above_entry(adj_entry, &errornr, n);
+    }
+  }
+
+  return errornr;
+}
+
+// Jump to a quickfix entry in the current file nearest to the current line.
+// ":cabove", ":cbelow", ":labove" and ":lbelow" commands
+void ex_cbelow(exarg_T *eap)
+{
+  qf_info_T *qi;
+  qf_list_T *qfl;
+  int dir;
+  int buf_has_flag;
+  int errornr = 0;
+
+  if (eap->addr_count > 0 && eap->line2 <= 0) {
+    EMSG(_(e_invrange));
+    return;
+  }
+
+  // Check whether the current buffer has any quickfix entries
+  if (eap->cmdidx == CMD_cabove || eap->cmdidx == CMD_cbelow) {
+    buf_has_flag = BUF_HAS_QF_ENTRY;
+  } else {
+    buf_has_flag = BUF_HAS_LL_ENTRY;
+  }
+  if (!(curbuf->b_has_qf_entry & buf_has_flag)) {
+    EMSG(_(e_quickfix));
+    return;
+  }
+
+  if ((qi = qf_cmd_get_stack(eap, true)) == NULL) {
+    return;
+  }
+
+  qfl = qf_get_curlist(qi);
+  // check if the list has valid errors
+  if (!qf_list_has_valid_entries(qfl)) {
+    EMSG(_(e_quickfix));
+    return;
+  }
+
+  if (eap->cmdidx == CMD_cbelow || eap->cmdidx == CMD_lbelow) {
+    dir = FORWARD;
+  } else {
+    dir = BACKWARD;
+  }
+
+  errornr = qf_find_nth_adj_entry(qfl, curbuf->b_fnum, curwin->w_cursor.lnum,
+                                  eap->addr_count > 0 ? eap->line2 : 0, dir);
+
+  if (errornr > 0) {
+    qf_jump(qi, 0, errornr, false);
+  } else {
+    EMSG(_(e_no_more_items));
+  }
+}
+
 
 // Return the autocmd name for the :cfile Ex commands
 static char_u * cfile_get_auname(cmdidx_T cmdidx)

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -80,12 +80,13 @@ struct qfline_S {
 #define LISTCOUNT   10
 #define INVALID_QFIDX (-1)
 
-// Quickfix list type.
+/// Quickfix list type.
 typedef enum
 {
-  QFLT_QUICKFIX,  // Quickfix list - global list
-  QFLT_LOCATION,  // Location list - per window list
-  QFLT_INTERNAL   // Internal - Temporary list used by getqflist()/getloclist()
+  QFLT_QUICKFIX,  ///< Quickfix list - global list
+  QFLT_LOCATION,  ///< Location list - per window list
+  QFLT_INTERNAL   ///< Internal - Temporary list used by
+                  //   getqflist()/getloclist()
 } qfltype_T;
 
 /// Quickfix/Location list definition
@@ -164,8 +165,8 @@ struct efm_S {
   int conthere;                 /* %> used */
 };
 
-// List of location lists to be deleted.
-// Used to delay the deletion of locations lists by autocmds.
+/// List of location lists to be deleted.
+/// Used to delay the deletion of locations lists by autocmds.
 typedef struct qf_delq_S {
   struct qf_delq_S *next;
   qf_info_T *qi;
@@ -180,8 +181,8 @@ enum {
   QF_MULTISCAN = 5,
 };
 
-// State information used to parse lines and add entries to a quickfix/location
-// list.
+/// State information used to parse lines and add entries to a quickfix/location
+/// list.
 typedef struct {
   char_u *linebuf;
   size_t linelen;
@@ -255,8 +256,8 @@ static char *e_loc_list_changed = N_("E926: Current location list was changed");
 static int quickfix_busy = 0;
 static qf_delq_T *qf_delq_head = NULL;
 
-// Process the next line from a file/buffer/list/string and add it
-// to the quickfix list 'qfl'.
+/// Process the next line from a file/buffer/list/string and add it
+/// to the quickfix list 'qfl'.
 static int qf_init_process_nextline(qf_list_T *qfl,
                                     efm_T *fmt_first,
                                     qfstate_T *state,
@@ -341,10 +342,10 @@ static struct fmtpattern
   { 'o', ".\\+" }
 };
 
-// Convert an errorformat pattern to a regular expression pattern.
-// See fmt_pat definition above for the list of supported patterns.  The
-// pattern specifier is supplied in "efmpat".  The converted pattern is stored
-// in "regpat".  Returns a pointer to the location after the pattern.
+/// Convert an errorformat pattern to a regular expression pattern.
+/// See fmt_pat definition above for the list of supported patterns.  The
+/// pattern specifier is supplied in "efmpat".  The converted pattern is stored
+/// in "regpat".  Returns a pointer to the location after the pattern.
 static char_u * efmpat_to_regpat(
     const char_u *efmpat,
     char_u *regpat,
@@ -410,8 +411,8 @@ static char_u * efmpat_to_regpat(
   return regpat;
 }
 
-// Convert a scanf like format in 'errorformat' to a regular expression.
-// Returns a pointer to the location after the pattern.
+/// Convert a scanf like format in 'errorformat' to a regular expression.
+/// Returns a pointer to the location after the pattern.
 static char_u * scanf_fmt_to_regpat(
     const char_u **pefmp,
     const char_u *efm,
@@ -455,7 +456,7 @@ static char_u * scanf_fmt_to_regpat(
   return regpat;
 }
 
-// Analyze/parse an errorformat prefix.
+/// Analyze/parse an errorformat prefix.
 static const char_u *efm_analyze_prefix(const char_u *efmp, efm_T *efminfo,
                                         char_u *errmsg, size_t errmsglen)
   FUNC_ATTR_NONNULL_ALL
@@ -556,8 +557,8 @@ static void free_efm_list(efm_T **efm_first)
   fmt_start = NULL;
 }
 
-// Compute the size of the buffer used to convert a 'errorformat' pattern into
-// a regular expression pattern.
+/// Compute the size of the buffer used to convert a 'errorformat' pattern into
+/// a regular expression pattern.
 static size_t efm_regpat_bufsz(char_u *efm)
 {
   size_t sz;
@@ -575,7 +576,7 @@ static size_t efm_regpat_bufsz(char_u *efm)
   return sz;
 }
 
-// Return the length of a 'errorformat' option part (separated by ",").
+/// Return the length of a 'errorformat' option part (separated by ",").
 static int efm_option_part_len(char_u *efm)
 {
   int len;
@@ -589,9 +590,9 @@ static int efm_option_part_len(char_u *efm)
   return len;
 }
 
-// Parse the 'errorformat' option. Multiple parts in the 'errorformat' option
-// are parsed and converted to regular expressions. Returns information about
-// the parsed 'errorformat' option.
+/// Parse the 'errorformat' option. Multiple parts in the 'errorformat' option
+/// are parsed and converted to regular expressions. Returns information about
+/// the parsed 'errorformat' option.
 static efm_T * parse_efm_option(char_u *efm)
 {
   efm_T *fmt_ptr = NULL;
@@ -645,7 +646,7 @@ parse_efm_end:
   return fmt_first;
 }
 
-// Allocate more memory for the line buffer used for parsing lines.
+/// Allocate more memory for the line buffer used for parsing lines.
 static char_u *qf_grow_linebuf(qfstate_T *state, size_t newsz)
 {
   // If the line exceeds LINE_MAXLEN exclude the last
@@ -887,28 +888,28 @@ static int qf_get_nextline(qfstate_T *state)
   return QF_OK;
 }
 
-// Returns true if the specified quickfix/location stack is empty
+/// Returns true if the specified quickfix/location stack is empty
 static bool qf_stack_empty(const qf_info_T *qi)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return qi == NULL || qi->qf_listcount <= 0;
 }
 
-// Returns true if the specified quickfix/location list is empty.
+/// Returns true if the specified quickfix/location list is empty.
 static bool qf_list_empty(qf_list_T *qfl)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return qfl == NULL || qfl->qf_count <= 0;
 }
 
-// Returns TRUE if the specified quickfix/location list is not empty and
-// has valid entries.
-static int qf_list_has_valid_entries(qf_list_T *qfl)
+/// Returns true if the specified quickfix/location list is not empty and
+/// has valid entries.
+static bool qf_list_has_valid_entries(qf_list_T *qfl)
 {
   return !qf_list_empty(qfl) && !qfl->qf_nonevalid;
 }
 
-// Return a pointer to a list in the specified quickfix stack
+/// Return a pointer to a list in the specified quickfix stack
 static qf_list_T * qf_get_list(qf_info_T *qi, int idx)
 {
   return &qi->qf_lists[idx];
@@ -1241,15 +1242,15 @@ static char_u * qf_cmdtitle(char_u *cmd)
   return qftitle_str;
 }
 
-// Return a pointer to the current list in the specified quickfix stack
+/// Return a pointer to the current list in the specified quickfix stack
 static qf_list_T * qf_get_curlist(qf_info_T *qi)
 {
   return qf_get_list(qi, qi->qf_curlist);
 }
 
-// Prepare for adding a new quickfix list. If the current list is in the
-// middle of the stack, then all the following lists are freed and then
-// the new list is added.
+/// Prepare for adding a new quickfix list. If the current list is in the
+/// middle of the stack, then all the following lists are freed and then
+/// the new list is added.
 static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
 {
   int i;
@@ -1275,14 +1276,14 @@ static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
   } else
     qi->qf_curlist = qi->qf_listcount++;
   qfl = qf_get_curlist(qi);
-  memset(qfl, 0, (size_t)(sizeof(qf_list_T)));
+  memset(qfl, 0, sizeof(qf_list_T));
   qf_store_title(qfl, qf_title);
   qfl->qfl_type = qi->qfl_type;
   qfl->qf_id = ++last_qf_id;
 }
 
-// Parse the match for filename ('%f') pattern in regmatch.
-// Return the matched value in "fields->namebuf".
+/// Parse the match for filename ('%f') pattern in regmatch.
+/// Return the matched value in "fields->namebuf".
 static int qf_parse_fmt_f(regmatch_T *rmp,
                           int midx,
                           qffields_T *fields,
@@ -1310,8 +1311,8 @@ static int qf_parse_fmt_f(regmatch_T *rmp,
   return QF_OK;
 }
 
-// Parse the match for error number ('%n') pattern in regmatch.
-// Return the matched value in "fields->enr".
+/// Parse the match for error number ('%n') pattern in regmatch.
+/// Return the matched value in "fields->enr".
 static int qf_parse_fmt_n(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   if (rmp->startp[midx] == NULL) {
@@ -1321,8 +1322,8 @@ static int qf_parse_fmt_n(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// Parse the match for line number (%l') pattern in regmatch.
-// Return the matched value in "fields->lnum".
+/// Parse the match for line number (%l') pattern in regmatch.
+/// Return the matched value in "fields->lnum".
 static int qf_parse_fmt_l(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   if (rmp->startp[midx] == NULL) {
@@ -1332,8 +1333,8 @@ static int qf_parse_fmt_l(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// Parse the match for column number ('%c') pattern in regmatch.
-// Return the matched value in "fields->col".
+/// Parse the match for column number ('%c') pattern in regmatch.
+/// Return the matched value in "fields->col".
 static int qf_parse_fmt_c(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   if (rmp->startp[midx] == NULL) {
@@ -1343,8 +1344,8 @@ static int qf_parse_fmt_c(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// Parse the match for error type ('%t') pattern in regmatch.
-// Return the matched value in "fields->type".
+/// Parse the match for error type ('%t') pattern in regmatch.
+/// Return the matched value in "fields->type".
 static int qf_parse_fmt_t(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   if (rmp->startp[midx] == NULL) {
@@ -1354,8 +1355,8 @@ static int qf_parse_fmt_t(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// Parse the match for '%+' format pattern. The whole matching line is included
-// in the error string.  Return the matched line in "fields->errmsg".
+/// Parse the match for '%+' format pattern. The whole matching line is included
+/// in the error string.  Return the matched line in "fields->errmsg".
 static int qf_parse_fmt_plus(char_u *linebuf,
                              size_t linelen,
                              qffields_T *fields)
@@ -1369,8 +1370,8 @@ static int qf_parse_fmt_plus(char_u *linebuf,
   return QF_OK;
 }
 
-// Parse the match for error message ('%m') pattern in regmatch.
-// Return the matched value in "fields->errmsg".
+/// Parse the match for error message ('%m') pattern in regmatch.
+/// Return the matched value in "fields->errmsg".
 static int qf_parse_fmt_m(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   size_t len;
@@ -1388,8 +1389,8 @@ static int qf_parse_fmt_m(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// Parse the match for rest of a single-line file message ('%r') pattern.
-// Return the matched value in "tail".
+/// Parse the match for rest of a single-line file message ('%r') pattern.
+/// Return the matched value in "tail".
 static int qf_parse_fmt_r(regmatch_T *rmp, int midx, char_u **tail)
 {
   if (rmp->startp[midx] == NULL) {
@@ -1399,9 +1400,8 @@ static int qf_parse_fmt_r(regmatch_T *rmp, int midx, char_u **tail)
   return QF_OK;
 }
 
-
-// Parse the match for the pointer line ('%p') pattern in regmatch.
-// Return the matched value in "fields->col".
+/// Parse the match for the pointer line ('%p') pattern in regmatch.
+/// Return the matched value in "fields->col".
 static int qf_parse_fmt_p(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   char_u *match_ptr;
@@ -1423,9 +1423,8 @@ static int qf_parse_fmt_p(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-
-// Parse the match for the virtual column number ('%v') pattern in regmatch.
-// Return the matched value in "fields->col".
+/// Parse the match for the virtual column number ('%v') pattern in regmatch.
+/// Return the matched value in "fields->col".
 static int qf_parse_fmt_v(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   if (rmp->startp[midx] == NULL) {
@@ -1436,9 +1435,8 @@ static int qf_parse_fmt_v(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-
-// Parse the match for the search text ('%s') pattern in regmatch.
-// Return the matched value in "fields->pattern".
+/// Parse the match for the search text ('%s') pattern in regmatch.
+/// Return the matched value in "fields->pattern".
 static int qf_parse_fmt_s(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   size_t len;
@@ -1458,8 +1456,8 @@ static int qf_parse_fmt_s(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// Parse the match for the module ('%o') pattern in regmatch.
-// Return the matched value in "fields->module".
+/// Parse the match for the module ('%o') pattern in regmatch.
+/// Return the matched value in "fields->module".
 static int qf_parse_fmt_o(regmatch_T *rmp, int midx, qffields_T *fields)
 {
   size_t len;
@@ -1477,9 +1475,9 @@ static int qf_parse_fmt_o(regmatch_T *rmp, int midx, qffields_T *fields)
   return QF_OK;
 }
 
-// 'errorformat' format pattern parser functions.
-// The '%f' and '%r' formats are parsed differently from other formats.
-// See qf_parse_match() for details.
+/// 'errorformat' format pattern parser functions.
+/// The '%f' and '%r' formats are parsed differently from other formats.
+/// See qf_parse_match() for details.
 static int (*qf_parse_fmt[FMT_PATTERNS])(regmatch_T *, int, qffields_T *) = {
   NULL,
   qf_parse_fmt_n,
@@ -1696,7 +1694,7 @@ static int qf_parse_multiline_pfx(int idx, qf_list_T *qfl, qffields_T *fields)
   return QF_IGNORE_LINE;
 }
 
-// Queue location list stack delete request.
+/// Queue location list stack delete request.
 static void locstack_queue_delreq(qf_info_T *qi)
 {
   qf_delq_T *q;
@@ -1752,16 +1750,16 @@ void qf_free_all(win_T *wp)
   }
 }
 
-// Delay freeing of location list stacks when the quickfix code is running.
-// Used to avoid problems with autocmds freeing location list stacks when the
-// quickfix code is still referencing the stack.
-// Must always call decr_quickfix_busy() exactly once after this.
+/// Delay freeing of location list stacks when the quickfix code is running.
+/// Used to avoid problems with autocmds freeing location list stacks when the
+/// quickfix code is still referencing the stack.
+/// Must always call decr_quickfix_busy() exactly once after this.
 static void incr_quickfix_busy(void)
 {
     quickfix_busy++;
 }
 
-// Safe to free location list stacks. Process any delayed delete requests.
+/// Safe to free location list stacks. Process any delayed delete requests.
 static void decr_quickfix_busy(void)
 {
   quickfix_busy--;
@@ -1878,7 +1876,7 @@ static int qf_add_entry(qf_list_T *qfl, char_u *dir, char_u *fname,
   return QF_OK;
 }
 
-// Allocate a new quickfix/location list stack
+/// Allocate a new quickfix/location list stack
 static qf_info_T *qf_alloc_stack(qfltype_T qfltype)
   FUNC_ATTR_NONNULL_RET
 {
@@ -1889,8 +1887,8 @@ static qf_info_T *qf_alloc_stack(qfltype_T qfltype)
   return qi;
 }
 
-// Return the location list stack for window 'wp'.
-// If not present, allocate a location list stack
+/// Return the location list stack for window 'wp'.
+/// If not present, allocate a location list stack
 static qf_info_T *ll_get_or_alloc_list(win_T *wp)
 {
   if (IS_LL_WINDOW(wp))
@@ -1909,10 +1907,10 @@ static qf_info_T *ll_get_or_alloc_list(win_T *wp)
   return wp->w_llist;
 }
 
-// Get the quickfix/location list stack to use for the specified Ex command.
-// For a location list command, returns the stack for the current window.  If
-// the location list is not found, then returns NULL and prints an error
-// message if 'print_emsg' is TRUE.
+/// Get the quickfix/location list stack to use for the specified Ex command.
+/// For a location list command, returns the stack for the current window.  If
+/// the location list is not found, then returns NULL and prints an error
+/// message if 'print_emsg' is TRUE.
 static qf_info_T * qf_cmd_get_stack(exarg_T *eap, int print_emsg)
 {
   qf_info_T *qi = &ql_info;
@@ -1930,11 +1928,11 @@ static qf_info_T * qf_cmd_get_stack(exarg_T *eap, int print_emsg)
   return qi;
 }
 
-// Get the quickfix/location list stack to use for the specified Ex command.
-// For a location list command, returns the stack for the current window.
-// If the location list is not present, then allocates a new one.
-// Returns NULL if the allocation fails.  For a location list command, sets
-// 'pwinp' to curwin.
+/// Get the quickfix/location list stack to use for the specified Ex command.
+/// For a location list command, returns the stack for the current window.
+/// If the location list is not present, then allocates a new one.
+/// Returns NULL if the allocation fails.  For a location list command, sets
+/// 'pwinp' to curwin.
 static qf_info_T * qf_cmd_get_or_alloc_stack(exarg_T *eap, win_T **pwinp)
 {
   qf_info_T *qi = &ql_info;
@@ -1950,7 +1948,7 @@ static qf_info_T * qf_cmd_get_or_alloc_stack(exarg_T *eap, win_T **pwinp)
   return qi;
 }
 
-// Copy location list entries from 'from_qfl' to 'to_qfl'.
+/// Copy location list entries from 'from_qfl' to 'to_qfl'.
 static int copy_loclist_entries(const qf_list_T *from_qfl, qf_list_T *to_qfl)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -1989,7 +1987,7 @@ static int copy_loclist_entries(const qf_list_T *from_qfl, qf_list_T *to_qfl)
   return OK;
 }
 
-// Copy the specified location list 'from_qfl' to 'to_qfl'.
+/// Copy the specified location list 'from_qfl' to 'to_qfl'.
 static int copy_loclist(const qf_list_T *from_qfl, qf_list_T *to_qfl)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -2075,8 +2073,8 @@ void copy_loclist_stack(win_T *from, win_T *to)
   to->w_llist->qf_curlist = qi->qf_curlist;  // current list
 }
 
-// Get buffer number for file "directory/fname".
-// Also sets the b_has_qf_entry flag.
+/// Get buffer number for file "directory/fname".
+/// Also sets the b_has_qf_entry flag.
 static int qf_get_fnum(qf_list_T *qfl, char_u *directory, char_u *fname )
 {
   char_u *ptr = NULL;
@@ -2230,24 +2228,24 @@ static void qf_clean_dir_stack(struct dir_stack_T **stackptr)
   }
 }
 
-// Check in which directory of the directory stack the given file can be
-// found.
-// Returns a pointer to the directory name or NULL if not found.
-// Cleans up intermediate directory entries.
-//
-// TODO(vim): How to solve the following problem?
-// If we have this directory tree:
-//     ./
-//     ./aa
-//     ./aa/bb
-//     ./bb
-//     ./bb/x.c
-// and make says:
-//     making all in aa
-//     making all in bb
-//     x.c:9: Error
-// Then qf_push_dir thinks we are in ./aa/bb, but we are in ./bb.
-// qf_guess_filepath will return NULL.
+/// Check in which directory of the directory stack the given file can be
+/// found.
+/// Returns a pointer to the directory name or NULL if not found.
+/// Cleans up intermediate directory entries.
+///
+/// TODO(vim): How to solve the following problem?
+/// If we have this directory tree:
+///     ./
+///     ./aa
+///     ./aa/bb
+///     ./bb
+///     ./bb/x.c
+/// and make says:
+///     making all in aa
+///     making all in bb
+///     x.c:9: Error
+/// Then qf_push_dir thinks we are in ./aa/bb, but we are in ./bb.
+/// qf_guess_filepath will return NULL.
 static char_u *qf_guess_filepath(qf_list_T *qfl, char_u *filename)
 {
   struct dir_stack_T     *ds_ptr;
@@ -2444,7 +2442,7 @@ static win_T *qf_find_help_win(void)
   return NULL;
 }
 
-// Set the location list for the specified window to 'qi'.
+/// Set the location list for the specified window to 'qi'.
 static void win_set_loclist(win_T *wp, qf_info_T *qi)
 {
   wp->w_llist = qi;
@@ -2526,7 +2524,7 @@ static win_T *qf_find_win_with_normal_buf(void)
   return NULL;
 }
 
-// Go to a window in any tabpage containing the specified file.  Returns TRUE
+// Go to a window in any tabpage containing the specified file.  Returns true
 // if successfully jumped to the window. Otherwise returns FALSE.
 static bool qf_goto_tabwin_with_file(int fnum)
 {
@@ -2960,11 +2958,11 @@ static int qfFileAttr;
 static int qfSepAttr;
 static int qfLineAttr;
 
-// Display information about a single entry from the quickfix/location list.
-// Used by ":clist/:llist" commands.
-// 'cursel' will be set to TRUE for the currently selected entry in the
-// quickfix list.
-static void qf_list_entry(qfline_T *qfp, int qf_idx, int cursel)
+/// Display information about a single entry from the quickfix/location list.
+/// Used by ":clist/:llist" commands.
+/// 'cursel' will be set to true for the currently selected entry in the
+/// quickfix list.
+static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
 {
   char_u *fname;
   buf_T *buf;
@@ -3172,12 +3170,10 @@ static void qf_msg(qf_info_T *qi, int which, char *lead)
   msg(buf);
 }
 
-/*
- * ":colder [count]": Up in the quickfix stack.
- * ":cnewer [count]": Down in the quickfix stack.
- * ":lolder [count]": Up in the location list stack.
- * ":lnewer [count]": Down in the location list stack.
- */
+/// ":colder [count]": Up in the quickfix stack.
+/// ":cnewer [count]": Down in the quickfix stack.
+/// ":lolder [count]": Up in the location list stack.
+/// ":lnewer [count]": Down in the location list stack.
 void qf_age(exarg_T *eap)
 {
   qf_info_T *qi;
@@ -3553,7 +3549,7 @@ static int qf_open_new_cwindow(const qf_info_T *qi, int height)
   return OK;
 }
 
-// Set "w:quickfix_title" if "qi" has a title.
+/// Set "w:quickfix_title" if "qi" has a title.
 static void qf_set_title_var(qf_list_T *qfl)
 {
   if (qfl->qf_title != NULL) {
@@ -3561,10 +3557,8 @@ static void qf_set_title_var(qf_list_T *qfl)
   }
 }
 
-/*
- * ":copen": open a window that shows the list of errors.
- * ":lopen": open a window that shows the location list.
- */
+/// ":copen": open a window that shows the list of errors.
+/// ":lopen": open a window that shows the location list.
 void ex_copen(exarg_T *eap)
 {
   qf_info_T   *qi;
@@ -3634,7 +3628,7 @@ static void qf_win_goto(win_T *win, linenr_T lnum)
   curbuf = curwin->w_buffer;
 }
 
-// :cbottom/:lbottom command.
+/// :cbottom/:lbottom command.
 void ex_cbottom(exarg_T *eap)
 {
   qf_info_T *qi;
@@ -3867,11 +3861,11 @@ static int qf_buf_add_line(buf_T *buf, linenr_T lnum, const qfline_T *qfp,
   return OK;
 }
 
-// Fill current buffer with quickfix errors, replacing any previous contents.
-// curbuf must be the quickfix buffer!
-// If "old_last" is not NULL append the items after this one.
-// When "old_last" is NULL then "buf" must equal "curbuf"!  Because ml_delete()
-// is used and autocommands will be triggered.
+/// Fill current buffer with quickfix errors, replacing any previous contents.
+/// curbuf must be the quickfix buffer!
+/// If "old_last" is not NULL append the items after this one.
+/// When "old_last" is NULL then "buf" must equal "curbuf"!  Because ml_delete()
+/// is used and autocommands will be triggered.
 static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last)
   FUNC_ATTR_NONNULL_ARG(2)
 {
@@ -3966,11 +3960,11 @@ static int qf_id2nr(const qf_info_T *const qi, const unsigned qfid)
   return INVALID_QFIDX;
 }
 
-// If the current list is not "save_qfid" and we can find the list with that ID
-// then make it the current list.
-// This is used when autocommands may have changed the current list.
-// Returns OK if successfully restored the list. Returns FAIL if the list with
-// the specified identifier (save_qfid) is not found in the stack.
+/// If the current list is not "save_qfid" and we can find the list with that ID
+/// then make it the current list.
+/// This is used when autocommands may have changed the current list.
+/// Returns OK if successfully restored the list. Returns FAIL if the list with
+/// the specified identifier (save_qfid) is not found in the stack.
 static int qf_restore_list(qf_info_T *qi, unsigned save_qfid)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
@@ -4318,11 +4312,9 @@ static size_t qf_get_nth_valid_entry(qf_list_T *qfl, size_t n, int fdo)
   return i <= qfl->qf_count ? (size_t)i : 1;
 }
 
-/*
- * ":cc", ":crewind", ":cfirst" and ":clast".
- * ":ll", ":lrewind", ":lfirst" and ":llast".
- * ":cdo", ":ldo", ":cfdo" and ":lfdo".
- */
+/// ":cc", ":crewind", ":cfirst" and ":clast".
+/// ":ll", ":lrewind", ":lfirst" and ":llast".
+/// ":cdo", ":ldo", ":cfdo" and ":lfdo".
 void ex_cc(exarg_T *eap)
 {
   qf_info_T   *qi;
@@ -4373,11 +4365,9 @@ void ex_cc(exarg_T *eap)
   qf_jump(qi, 0, errornr, eap->forceit);
 }
 
-/*
- * ":cnext", ":cnfile", ":cNext" and ":cprevious".
- * ":lnext", ":lNext", ":lprevious", ":lnfile", ":lNfile" and ":lpfile".
- * ":cdo", ":ldo", ":cfdo" and ":lfdo".
- */
+/// ":cnext", ":cnfile", ":cNext" and ":cprevious".
+/// ":lnext", ":lNext", ":lprevious", ":lnfile", ":lNfile" and ":lpfile".
+/// ":cdo", ":ldo", ":cfdo" and ":lfdo".
 void ex_cnext(exarg_T *eap)
 {
   qf_info_T   *qi;
@@ -4428,9 +4418,9 @@ void ex_cnext(exarg_T *eap)
   qf_jump(qi, dir, errornr, eap->forceit);
 }
 
-// Find the first entry in the quickfix list 'qfl' from buffer 'bnr'.
-// The index of the entry is stored in 'errornr'.
-// Returns NULL if an entry is not found.
+/// Find the first entry in the quickfix list 'qfl' from buffer 'bnr'.
+/// The index of the entry is stored in 'errornr'.
+/// Returns NULL if an entry is not found.
 static qfline_T *qf_find_first_entry_in_buf(qf_list_T *qfl,
                                             int bnr,
                                             int *errornr)
@@ -4449,9 +4439,9 @@ static qfline_T *qf_find_first_entry_in_buf(qf_list_T *qfl,
   return qfp;
 }
 
-// Find the first quickfix entry on the same line as 'entry'. Updates 'errornr'
-// with the error number for the first entry. Assumes the entries are sorted in
-// the quickfix list by line number.
+/// Find the first quickfix entry on the same line as 'entry'. Updates 'errornr'
+/// with the error number for the first entry. Assumes the entries are sorted in
+/// the quickfix list by line number.
 static qfline_T * qf_find_first_entry_on_line(qfline_T *entry, int *errornr)
 {
   while (!got_int
@@ -4465,9 +4455,9 @@ static qfline_T * qf_find_first_entry_on_line(qfline_T *entry, int *errornr)
   return entry;
 }
 
-// Find the last quickfix entry on the same line as 'entry'. Updates 'errornr'
-// with the error number for the last entry. Assumes the entries are sorted in
-// the quickfix list by line number.
+/// Find the last quickfix entry on the same line as 'entry'. Updates 'errornr'
+/// with the error number for the last entry. Assumes the entries are sorted in
+/// the quickfix list by line number.
 static qfline_T * qf_find_last_entry_on_line(qfline_T *entry, int *errornr)
 {
   while (!got_int
@@ -4481,10 +4471,10 @@ static qfline_T * qf_find_last_entry_on_line(qfline_T *entry, int *errornr)
   return entry;
 }
 
-// Find the first quickfix entry below line 'lnum' in buffer 'bnr'.
-// 'qfp' points to the very first entry in the buffer and 'errornr' is the
-// index of the very first entry in the quickfix list.
-// Returns NULL if an entry is not found after 'lnum'.
+/// Find the first quickfix entry below line 'lnum' in buffer 'bnr'.
+/// 'qfp' points to the very first entry in the buffer and 'errornr' is the
+/// index of the very first entry in the quickfix list.
+/// Returns NULL if an entry is not found after 'lnum'.
 static qfline_T *qf_find_entry_on_next_line(int bnr,
                                             linenr_T lnum,
                                             qfline_T *qfp,
@@ -4515,10 +4505,10 @@ static qfline_T *qf_find_entry_on_next_line(int bnr,
   return qfp;
 }
 
-// Find the first quickfix entry before line 'lnum' in buffer 'bnr'.
-// 'qfp' points to the very first entry in the buffer and 'errornr' is the
-// index of the very first entry in the quickfix list.
-// Returns NULL if an entry is not found before 'lnum'.
+/// Find the first quickfix entry before line 'lnum' in buffer 'bnr'.
+/// 'qfp' points to the very first entry in the buffer and 'errornr' is the
+/// index of the very first entry in the quickfix list.
+/// Returns NULL if an entry is not found before 'lnum'.
 static qfline_T *qf_find_entry_on_prev_line(int bnr,
                                             linenr_T lnum,
                                             qfline_T *qfp,
@@ -4542,8 +4532,8 @@ static qfline_T *qf_find_entry_on_prev_line(int bnr,
   return qfp;
 }
 
-// Find a quickfix entry in 'qfl' closest to line 'lnum' in buffer 'bnr' in
-// the direction 'dir'.
+/// Find a quickfix entry in 'qfl' closest to line 'lnum' in buffer 'bnr' in
+/// the direction 'dir'.
 static qfline_T *qf_find_closest_entry(qf_list_T *qfl,
                                        int bnr,
                                        linenr_T lnum,
@@ -4569,8 +4559,8 @@ static qfline_T *qf_find_closest_entry(qf_list_T *qfl,
   return qfp;
 }
 
-// Get the nth quickfix entry below the specified entry treating multiple
-// entries on a single line as one. Searches forward in the list.
+/// Get the nth quickfix entry below the specified entry treating multiple
+/// entries on a single line as one. Searches forward in the list.
 static qfline_T *qf_get_nth_below_entry(qfline_T *entry,
                                         int *errornr,
                                         linenr_T n)
@@ -4598,8 +4588,8 @@ static qfline_T *qf_get_nth_below_entry(qfline_T *entry,
   return entry;
 }
 
-// Get the nth quickfix entry above the specified entry treating multiple
-// entries on a single line as one. Searches backwards in the list.
+/// Get the nth quickfix entry above the specified entry treating multiple
+/// entries on a single line as one. Searches backwards in the list.
 static qfline_T *qf_get_nth_above_entry(qfline_T *entry,
                                         int *errornr,
                                         linenr_T n)
@@ -4620,9 +4610,9 @@ static qfline_T *qf_get_nth_above_entry(qfline_T *entry,
   return entry;
 }
 
-// Find the n'th quickfix entry adjacent to line 'lnum' in buffer 'bnr' in the
-// specified direction.
-// Returns the error number in the quickfix list or 0 if an entry is not found.
+/// Find the n'th quickfix entry adjacent to line 'lnum' in buffer 'bnr' in the
+/// specified direction.
+/// Returns the error number in the quickfix list or 0 if an entry is not found.
 static int qf_find_nth_adj_entry(qf_list_T *qfl,
                                  int bnr,
                                  linenr_T lnum,
@@ -4650,8 +4640,8 @@ static int qf_find_nth_adj_entry(qf_list_T *qfl,
   return errornr;
 }
 
-// Jump to a quickfix entry in the current file nearest to the current line.
-// ":cabove", ":cbelow", ":labove" and ":lbelow" commands
+/// Jump to a quickfix entry in the current file nearest to the current line.
+/// ":cabove", ":cbelow", ":labove" and ":lbelow" commands
 void ex_cbelow(exarg_T *eap)
 {
   qf_info_T *qi;
@@ -4704,7 +4694,7 @@ void ex_cbelow(exarg_T *eap)
 }
 
 
-// Return the autocmd name for the :cfile Ex commands
+/// Return the autocmd name for the :cfile Ex commands
 static char_u * cfile_get_auname(cmdidx_T cmdidx)
 {
   switch (cmdidx) {
@@ -5367,8 +5357,8 @@ static void unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
   }
 }
 
-// Copy the specified quickfix entry items into a new dict and appened the dict
-// to 'list'.  Returns OK on success.
+/// Copy the specified quickfix entry items into a new dict and appened the dict
+/// to 'list'.  Returns OK on success.
 static int get_qfline_items(qfline_T *qfp, list_T *list)
 {
   char_u buf[2];
@@ -5794,8 +5784,8 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
   return status;
 }
 
-// Add a new quickfix entry to list at 'qf_idx' in the stack 'qi' from the
-// items in the dict 'd'.
+/// Add a new quickfix entry to list at 'qf_idx' in the stack 'qi' from the
+/// items in the dict 'd'.
 static int qf_add_entry_from_dict(
     qf_list_T *qfl,
     const dict_T *d,
@@ -5922,7 +5912,7 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
   return retval;
 }
 
-// Get the quickfix list index from 'nr' or 'id'
+/// Get the quickfix list index from 'nr' or 'id'
 static int qf_setprop_get_qfidx(
     const qf_info_T *qi,
     const dict_T *what,
@@ -6064,9 +6054,9 @@ static int qf_setprop_context(qf_list_T *qfl, dictitem_T *di)
   return OK;
 }
 
-// Set quickfix/location list properties (title, items, context).
-// Also used to add items from parsing a list of lines.
-// Used by the setqflist() and setloclist() Vim script functions.
+/// Set quickfix/location list properties (title, items, context).
+/// Also used to add items from parsing a list of lines.
+/// Used by the setqflist() and setloclist() Vim script functions.
 static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
                              char_u *title)
   FUNC_ATTR_NONNULL_ALL
@@ -6107,8 +6097,8 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
   return retval;
 }
 
-// Find the non-location list window with the specified location list stack in
-// the current tabpage.
+/// Find the non-location list window with the specified location list stack in
+/// the current tabpage.
 static win_T * find_win_with_ll(qf_info_T *qi)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
@@ -6247,7 +6237,7 @@ bool set_ref_in_quickfix(int copyID)
   return abort;
 }
 
-// Return the autocmd name for the :cbuffer Ex commands
+/// Return the autocmd name for the :cbuffer Ex commands
 static char_u * cbuffer_get_auname(cmdidx_T cmdidx)
 {
   switch (cmdidx) {
@@ -6261,8 +6251,8 @@ static char_u * cbuffer_get_auname(cmdidx_T cmdidx)
   }
 }
 
-// Process and validate the arguments passed to the :cbuffer, :caddbuffer,
-// :cgetbuffer, :lbuffer, :laddbuffer, :lgetbuffer Ex commands.
+/// Process and validate the arguments passed to the :cbuffer, :caddbuffer,
+/// :cgetbuffer, :lbuffer, :laddbuffer, :lgetbuffer Ex commands.
 static int cbuffer_process_args(exarg_T *eap,
                                 buf_T **bufp,
                                 linenr_T *line1,
@@ -6384,7 +6374,7 @@ void ex_cbuffer(exarg_T *eap)
   decr_quickfix_busy();
 }
 
-// Return the autocmd name for the :cexpr Ex commands.
+/// Return the autocmd name for the :cexpr Ex commands.
 static char_u * cexpr_get_auname(cmdidx_T cmdidx)
 {
   switch (cmdidx) {
@@ -6398,10 +6388,8 @@ static char_u * cexpr_get_auname(cmdidx_T cmdidx)
   }
 }
 
-/*
- * ":cexpr {expr}", ":cgetexpr {expr}", ":caddexpr {expr}" command.
- * ":lexpr {expr}", ":lgetexpr {expr}", ":laddexpr {expr}" command.
- */
+/// ":cexpr {expr}", ":cgetexpr {expr}", ":caddexpr {expr}" command.
+/// ":lexpr {expr}", ":lgetexpr {expr}", ":laddexpr {expr}" command.
 void ex_cexpr(exarg_T *eap)
 {
   qf_info_T *qi;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -80,6 +80,14 @@ struct qfline_S {
 #define LISTCOUNT   10
 #define INVALID_QFIDX (-1)
 
+// Quickfix list type.
+typedef enum
+{
+  QFLT_QUICKFIX,  // Quickfix list - global list
+  QFLT_LOCATION,  // Location list - per window list
+  QFLT_INTERNAL   // Internal - Temporary list used by getqflist()/getloclist()
+} qfltype_T;
+
 /// Quickfix/Location list definition
 ///
 /// Usually the list contains one or more entries. But an empty list can be
@@ -87,6 +95,7 @@ struct qfline_S {
 /// information and entries can be added later using setqflist()/setloclist().
 typedef struct qf_list_S {
   unsigned qf_id;               ///< Unique identifier for this list
+  qfltype_T   qfl_type;
   qfline_T    *qf_start;        ///< pointer to the first error
   qfline_T    *qf_last;         ///< pointer to the last error
   qfline_T    *qf_ptr;          ///< pointer to the current error
@@ -120,6 +129,7 @@ struct qf_info_S {
   int qf_listcount;                 /* current number of lists */
   int qf_curlist;                   /* current error list */
   qf_list_T qf_lists[LISTCOUNT];
+  qfltype_T qfl_type;  // type of list
 };
 
 static qf_info_T ql_info;         // global quickfix list
@@ -211,8 +221,10 @@ typedef struct {
 #define IS_LL_WINDOW(wp) (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
 
 // Quickfix and location list stack check helper macros
-#define IS_QF_STACK(qi)         (qi == &ql_info)
-#define IS_LL_STACK(qi)         (qi != &ql_info)
+#define IS_QF_STACK(qi)       (qi->qfl_type == QFLT_QUICKFIX)
+#define IS_LL_STACK(qi)       (qi->qfl_type == QFLT_LOCATION)
+#define IS_QF_LIST(qfl)       (qfl->qfl_type == QFLT_QUICKFIX)
+#define IS_LL_LIST(qfl)       (qfl->qfl_type == QFLT_LOCATION)
 
 //
 // Return location list for window 'wp'
@@ -1225,6 +1237,7 @@ static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
   qfl = &qi->qf_lists[qi->qf_curlist];
   memset(qfl, 0, (size_t)(sizeof(qf_list_T)));
   qf_store_title(qfl, qf_title);
+  qfl->qfl_type = qi->qfl_type;
   qfl->qf_id = ++last_qf_id;
 }
 
@@ -1777,7 +1790,7 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
     qfp->qf_fnum = bufnum;
     if (buf != NULL) {
       buf->b_has_qf_entry |=
-        IS_QF_STACK(qi) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
+        IS_QF_LIST(qfl) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
     }
   } else {
     qfp->qf_fnum = qf_get_fnum(qi, qf_idx, dir, fname);
@@ -1828,12 +1841,13 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
   return OK;
 }
 
-// Allocate a new location list stack
-static qf_info_T *ll_new_list(void)
+// Allocate a new quickfix/location list stack
+static qf_info_T *qf_alloc_stack(qfltype_T qfltype)
   FUNC_ATTR_NONNULL_RET
 {
   qf_info_T *qi = xcalloc(1, sizeof(qf_info_T));
   qi->qf_refcount++;
+  qi->qfl_type = qfltype;
 
   return qi;
 }
@@ -1852,8 +1866,9 @@ static qf_info_T *ll_get_or_alloc_list(win_T *wp)
    */
   ll_free_all(&wp->w_llist_ref);
 
-  if (wp->w_llist == NULL)
-    wp->w_llist = ll_new_list();            /* new location list */
+  if (wp->w_llist == NULL) {
+    wp->w_llist = qf_alloc_stack(QFLT_LOCATION);  // new location list
+  }
   return wp->w_llist;
 }
 
@@ -1908,6 +1923,7 @@ static int copy_loclist(const qf_list_T *from_qfl,
   FUNC_ATTR_NONNULL_ALL
 {
   // Some of the fields are populated by qf_add_entry()
+  to_qfl->qfl_type = from_qfl->qfl_type;
   to_qfl->qf_nonevalid = from_qfl->qf_nonevalid;
   to_qfl->qf_count = 0;
   to_qfl->qf_index = 0;
@@ -1969,7 +1985,7 @@ void copy_loclist_stack(win_T *from, win_T *to)
   }
 
   // allocate a new location list
-  to->w_llist = ll_new_list();
+  to->w_llist = qf_alloc_stack(QFLT_LOCATION);
 
   to->w_llist->qf_listcount = qi->qf_listcount;
 
@@ -2042,7 +2058,7 @@ static int qf_get_fnum(qf_info_T *qi, int qf_idx, char_u *directory,
     return 0;
   }
   buf->b_has_qf_entry =
-    IS_QF_STACK(qi) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
+    IS_QF_LIST(qfl) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
   return buf->b_fnum;
 }
 
@@ -2609,6 +2625,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit,
                                win_T *oldwin, int *opened_window, int *abort)
 {
   qf_list_T *qfl = &qi->qf_lists[qi->qf_curlist];
+  qfltype_T qfl_type = qfl->qfl_type;
   int retval = OK;
 
   if (qf_ptr->qf_type == 1) {
@@ -2628,7 +2645,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit,
     retval = buflist_getfile(qf_ptr->qf_fnum, (linenr_T)1,
                              GETF_SETMARK | GETF_SWITCH, forceit);
 
-    if (IS_LL_STACK(qi)) {
+    if (qfl_type == QFLT_LOCATION) {
       // Location list. Check whether the associated window is still
       // present and the list is still valid.
       if (!win_valid_any_tab(oldwin)) {
@@ -2640,7 +2657,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit,
         *abort = true;
       }
     } else if (!is_qf_entry_present(qfl, qf_ptr)) {
-      if (IS_QF_STACK(qi)) {
+      if (qfl_type == QFLT_QUICKFIX) {
         EMSG(_("E925: Current quickfix was changed"));
       } else {
         EMSG(_(e_loc_list_changed));
@@ -5165,7 +5182,7 @@ static int qf_get_list_from_lines(dict_T *what, dictitem_T *di, dict_T *retdict)
     }
 
     list_T *l = tv_list_alloc(kListLenMayKnow);
-    qf_info_T *const qi = ll_new_list();
+    qf_info_T *const qi = qf_alloc_stack(QFLT_INTERNAL);
 
     if (qf_init_ext(qi, 0, NULL, NULL, &di->di_tv, errorformat,
                     true, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0) {
@@ -5292,7 +5309,10 @@ static int qf_getprop_qfidx(qf_info_T *qi, dict_T *what)
 }
 
 /// Return default values for quickfix list properties in retdict.
-static int qf_getprop_defaults(qf_info_T *qi, int flags, dict_T *retdict)
+static int qf_getprop_defaults(qf_info_T *qi,
+                               int flags,
+                               int locstack,
+                               dict_T *retdict)
 {
   int status = OK;
 
@@ -5324,7 +5344,7 @@ static int qf_getprop_defaults(qf_info_T *qi, int flags, dict_T *retdict)
   if ((status == OK) && (flags & QF_GETLIST_TICK)) {
     status = tv_dict_add_nr(retdict, S_LEN("changedtick"), 0);
   }
-  if ((status == OK) && (qi != &ql_info) && (flags & QF_GETLIST_FILEWINID)) {
+  if ((status == OK) && locstack && (flags & QF_GETLIST_FILEWINID)) {
     status = tv_dict_add_nr(retdict, S_LEN("filewinid"), 0);
   }
 
@@ -5424,7 +5444,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 
   // List is not present or is empty
   if (qf_stack_empty(qi) || qf_idx == INVALID_QFIDX) {
-    return qf_getprop_defaults(qi, flags, retdict);
+    return qf_getprop_defaults(qi, flags, wp != NULL, retdict);
   }
 
   qfl = &qi->qf_lists[qf_idx];
@@ -5826,7 +5846,7 @@ static void qf_free_stack(win_T *wp, qf_info_T *qi)
   } else if (IS_LL_WINDOW(orig_wp)) {
     // If the location list window is open, then create a new empty location
     // list
-    qf_info_T *new_ll = ll_new_list();
+    qf_info_T *new_ll = qf_alloc_stack(QFLT_LOCATION);
 
     // first free the list reference in the location list window
     ll_free_all(&orig_wp->w_llist_ref);
@@ -6144,7 +6164,7 @@ static qf_info_T *hgr_get_ll(bool *new_ll)
   }
   if (qi == NULL) {
     // Allocate a new location list for help text matches
-    qi = ll_new_list();
+    qi = qf_alloc_stack(QFLT_LOCATION);
     *new_ll = true;
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -383,7 +383,7 @@ static char_u * scanf_fmt_to_regpat(
 
 // Analyze/parse an errorformat prefix.
 static const char_u *efm_analyze_prefix(const char_u *efmp, efm_T *efminfo,
-                                  char_u *errmsg, size_t errmsglen)
+                                        char_u *errmsg, size_t errmsglen)
   FUNC_ATTR_NONNULL_ALL
 {
   if (vim_strchr((char_u *)"+-", *efmp) != NULL) {
@@ -1138,7 +1138,7 @@ qf_init_ext(
 error2:
   if (!adding) {
     // Error when creating a new list. Free the new list
-    qf_free(&qi->qf_lists[qi->qf_curlist]);
+    qf_free(qfl);
     qi->qf_listcount--;
     if (qi->qf_curlist > 0) {
       qi->qf_curlist--;
@@ -1189,6 +1189,7 @@ static char_u * qf_cmdtitle(char_u *cmd)
 static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
 {
   int i;
+  qf_list_T *qfl;
 
   // If the current entry is not the last entry, delete entries beyond
   // the current entry.  This makes it possible to browse in a tree-like
@@ -1209,9 +1210,10 @@ static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
     qi->qf_curlist = LISTCOUNT - 1;
   } else
     qi->qf_curlist = qi->qf_listcount++;
-  memset(&qi->qf_lists[qi->qf_curlist], 0, (size_t)(sizeof(qf_list_T)));
-  qf_store_title(&qi->qf_lists[qi->qf_curlist], qf_title);
-  qi->qf_lists[qi->qf_curlist].qf_id = ++last_qf_id;
+  qfl = &qi->qf_lists[qi->qf_curlist];
+  memset(qfl, 0, (size_t)(sizeof(qf_list_T)));
+  qf_store_title(qfl, qf_title);
+  qfl->qf_id = ++last_qf_id;
 }
 
 // Parse the match for filename ('%f') pattern in regmatch.
@@ -1917,6 +1919,7 @@ void copy_loclist_stack(win_T *from, win_T *to)
 static int qf_get_fnum(qf_info_T *qi, int qf_idx, char_u *directory,
                        char_u *fname)
 {
+  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   char_u *ptr = NULL;
   char_u *bufname;
   buf_T *buf;
@@ -1938,7 +1941,7 @@ static int qf_get_fnum(qf_info_T *qi, int qf_idx, char_u *directory,
     // directory change.
     if (!os_path_exists(ptr)) {
       xfree(ptr);
-      directory = qf_guess_filepath(&qi->qf_lists[qf_idx], fname);
+      directory = qf_guess_filepath(qfl, fname);
       if (directory) {
         ptr = (char_u *)concat_fnames((char *)directory, (char *)fname, true);
       } else {
@@ -3268,6 +3271,7 @@ void qf_view_result(bool split)
 void ex_cwindow(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
+  qf_list_T   *qfl;
   win_T       *win;
 
   if (is_loclist_cmd(eap->cmdidx)) {
@@ -3275,6 +3279,8 @@ void ex_cwindow(exarg_T *eap)
     if (qi == NULL)
       return;
   }
+
+  qfl = &qi->qf_lists[qi->qf_curlist];
 
   /* Look for an existing quickfix window.  */
   win = qf_find_win(qi);
@@ -3285,7 +3291,7 @@ void ex_cwindow(exarg_T *eap)
    * it if we have errors; otherwise, leave it closed.
    */
   if (qf_stack_empty(qi)
-      || qi->qf_lists[qi->qf_curlist].qf_nonevalid
+      || qfl->qf_nonevalid
       || qf_list_empty(qi, qi->qf_curlist)) {
     if (win != NULL) {
       ex_cclose(eap);
@@ -3424,6 +3430,7 @@ static void qf_set_title_var(qf_list_T *qfl)
 void ex_copen(exarg_T *eap)
 {
   qf_info_T   *qi = &ql_info;
+  qf_list_T   *qfl;
   int height;
   int status = FAIL;
 
@@ -3454,12 +3461,13 @@ void ex_copen(exarg_T *eap)
     }
   }
 
-  qf_set_title_var(&qi->qf_lists[qi->qf_curlist]);
+  qfl = &qi->qf_lists[qi->qf_curlist];
+  qf_set_title_var(qfl);
 
   // Fill the buffer with the quickfix list.
   qf_fill_buffer(qi, curbuf, NULL);
 
-  curwin->w_cursor.lnum = qi->qf_lists[qi->qf_curlist].qf_index;
+  curwin->w_cursor.lnum = qfl->qf_index;
   curwin->w_cursor.col = 0;
   check_cursor();
   update_topline();             // scroll to show the line
@@ -3746,13 +3754,14 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
 
   // Check if there is anything to display
   if (!qf_stack_empty(qi)) {
+     qf_list_T *qfl = &qi->qf_lists[qi->qf_curlist];
      char_u dirname[MAXPATHL];
 
      *dirname = NUL;
 
     // Add one line for each error
     if (old_last == NULL) {
-      qfp = qi->qf_lists[qi->qf_curlist].qf_start;
+      qfp = qfl->qf_start;
       lnum = 0;
     } else {
       qfp = old_last->qf_next;
@@ -3801,9 +3810,9 @@ static void qf_fill_buffer(qf_info_T *qi, buf_T *buf, qfline_T *old_last)
   KeyTyped = old_KeyTyped;
 }
 
-static void qf_list_changed(qf_info_T *qi, int qf_idx)
+static void qf_list_changed(qf_list_T *qfl)
 {
-    qi->qf_lists[qf_idx].qf_changedtick++;
+    qfl->qf_changedtick++;
 }
 
 /// Return the quickfix/location list number with the given identifier.
@@ -3967,7 +3976,7 @@ void ex_make(exarg_T *eap)
     }
   }
   if (res >= 0) {
-    qf_list_changed(qi, qi->qf_curlist);
+    qf_list_changed(&qi->qf_lists[qi->qf_curlist]);
   }
   // Remember the current quickfix list identifier, so that we can
   // check for autocommands changing the current quickfix list.
@@ -4040,6 +4049,7 @@ size_t qf_get_size(exarg_T *eap)
   FUNC_ATTR_NONNULL_ALL
 {
   qf_info_T *qi = &ql_info;
+  qf_list_T *qfl;
   if (is_loclist_cmd(eap->cmdidx)) {
     // Location list.
     qi = GET_LOC_LIST(curwin);
@@ -4053,8 +4063,8 @@ size_t qf_get_size(exarg_T *eap)
   qfline_T *qfp;
   size_t i;
   assert(qi->qf_lists[qi->qf_curlist].qf_count >= 0);
-  for (i = 0, qfp = qi->qf_lists[qi->qf_curlist].qf_start;
-       i < (size_t)qi->qf_lists[qi->qf_curlist].qf_count && qfp != NULL;
+  qfl = &qi->qf_lists[qi->qf_curlist];
+  for (i = 0, qfp = qfl->qf_start; i < (size_t)qfl->qf_count && qfp != NULL;
        i++, qfp = qfp->qf_next) {
     if (!qfp->qf_valid) {
       continue;
@@ -4353,7 +4363,7 @@ void ex_cfile(exarg_T *eap)
     }
   }
   if (res >= 0) {
-    qf_list_changed(qi, qi->qf_curlist);
+    qf_list_changed(&qi->qf_lists[qi->qf_curlist]);
   }
   unsigned save_qfid = qi->qf_lists[qi->qf_curlist].qf_id;
   if (au_name != NULL) {
@@ -4564,6 +4574,7 @@ void ex_vimgrep(exarg_T *eap)
   char_u      *p;
   int fi;
   qf_info_T   *qi = &ql_info;
+  qf_list_T   *qfl;
   win_T *wp = NULL;
   buf_T       *buf;
   int duplicate_name = FALSE;
@@ -4741,10 +4752,11 @@ void ex_vimgrep(exarg_T *eap)
 
   FreeWild(fcount, fnames);
 
-  qi->qf_lists[qi->qf_curlist].qf_nonevalid = FALSE;
-  qi->qf_lists[qi->qf_curlist].qf_ptr = qi->qf_lists[qi->qf_curlist].qf_start;
-  qi->qf_lists[qi->qf_curlist].qf_index = 1;
-  qf_list_changed(qi, qi->qf_curlist);
+  qfl = &qi->qf_lists[qi->qf_curlist];
+  qfl->qf_nonevalid = false;
+  qfl->qf_ptr = qfl->qf_start;
+  qfl->qf_index = 1;
+  qf_list_changed(qfl);
 
   qf_update_buffer(qi, NULL);
 
@@ -5228,10 +5240,10 @@ static int qf_getprop_defaults(qf_info_T *qi, int flags, dict_T *retdict)
 }
 
 /// Return the quickfix list title as 'title' in retdict
-static int qf_getprop_title(qf_info_T *qi, int qf_idx, dict_T *retdict)
+static int qf_getprop_title(qf_list_T *qfl, dict_T *retdict)
 {
     return tv_dict_add_str(retdict, S_LEN("title"),
-                           (const char *)qi->qf_lists[qf_idx].qf_title);
+                           (const char *)qfl->qf_title);
 }
 
 // Returns the identifier of the window used to display files from a location
@@ -5264,13 +5276,13 @@ static int qf_getprop_items(qf_info_T *qi, int qf_idx, dict_T *retdict)
 }
 
 /// Return the quickfix list context (if any) as 'context' in retdict.
-static int qf_getprop_ctx(qf_info_T *qi, int qf_idx, dict_T *retdict)
+static int qf_getprop_ctx(qf_list_T *qfl, dict_T *retdict)
 {
   int status;
 
-  if (qi->qf_lists[qf_idx].qf_ctx != NULL) {
+  if (qfl->qf_ctx != NULL) {
     dictitem_T *di = tv_dict_item_alloc_len(S_LEN("context"));
-    tv_copy(qi->qf_lists[qf_idx].qf_ctx, &di->di_tv);
+    tv_copy(qfl->qf_ctx, &di->di_tv);
     status = tv_dict_add(retdict, di);
     if (status == FAIL) {
       tv_dict_item_free(di);
@@ -5282,15 +5294,15 @@ static int qf_getprop_ctx(qf_info_T *qi, int qf_idx, dict_T *retdict)
   return status;
 }
 
-/// Return the quickfix list index as 'idx' in retdict
+/// Return the current quickfix list index as 'idx' in retdict
 static int qf_getprop_idx(qf_info_T *qi, int qf_idx, dict_T *retdict)
 {
-  int idx = qi->qf_lists[qf_idx].qf_index;
+  int curidx = qi->qf_lists[qf_idx].qf_index;
   if (qf_list_empty(qi, qf_idx)) {
-    // For empty lists, qf_index is set to 1
-    idx = 0;
+    // For empty lists, current index is set to 0
+    curidx = 0;
   }
-  return tv_dict_add_nr(retdict, S_LEN("idx"), idx);
+  return tv_dict_add_nr(retdict, S_LEN("idx"), curidx);
 }
 
 /// Return quickfix/location list details (title) as a dictionary.
@@ -5302,7 +5314,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
   qf_list_T *qfl;
   dictitem_T *di = NULL;
   int status = OK;
-  int qf_idx;
+  int qf_idx = INVALID_QFIDX;
 
   if ((di = tv_dict_find(what, S_LEN("lines"))) != NULL) {
     return qf_get_list_from_lines(what, di, retdict);
@@ -5326,7 +5338,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
   qfl = &qi->qf_lists[qf_idx];
 
   if (flags & QF_GETLIST_TITLE) {
-    status = qf_getprop_title(qi, qf_idx, retdict);
+    status = qf_getprop_title(qfl, retdict);
   }
   if ((status == OK) && (flags & QF_GETLIST_NR)) {
     status = tv_dict_add_nr(retdict, S_LEN("nr"), qf_idx + 1);
@@ -5338,7 +5350,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
     status = qf_getprop_items(qi, qf_idx, retdict);
   }
   if ((status == OK) && (flags & QF_GETLIST_CONTEXT)) {
-    status = qf_getprop_ctx(qi, qf_idx, retdict);
+    status = qf_getprop_ctx(qfl, retdict);
   }
   if ((status == OK) && (flags & QF_GETLIST_ID)) {
     status = tv_dict_add_nr(retdict, S_LEN("id"), qfl->qf_id);
@@ -5551,13 +5563,13 @@ static int qf_setprop_title(qf_info_T *qi, int qf_idx, const dict_T *what,
                             const dictitem_T *di)
   FUNC_ATTR_NONNULL_ALL
 {
+  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   if (di->di_tv.v_type != VAR_STRING) {
     return FAIL;
   }
 
-  xfree(qi->qf_lists[qf_idx].qf_title);
-  qi->qf_lists[qf_idx].qf_title =
-    (char_u *)tv_dict_get_string(what, "title", true);
+  xfree(qfl->qf_title);
+  qfl->qf_title = (char_u *)tv_dict_get_string(what, "title", true);
   if (qf_idx == qi->qf_curlist) {
     qf_update_win_titlevar(qi);
   }
@@ -5640,6 +5652,7 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
                              char_u *title)
   FUNC_ATTR_NONNULL_ALL
 {
+  qf_list_T *qfl;
   dictitem_T *di;
   int  retval = FAIL;
   bool newlist = action == ' ' || qf_stack_empty(qi);
@@ -5654,6 +5667,7 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
     qf_idx = qi->qf_curlist;
   }
 
+  qfl = &qi->qf_lists[qf_idx];
   if ((di = tv_dict_find(what, S_LEN("title"))) != NULL) {
     retval = qf_setprop_title(qi, qf_idx, what, di);
   }
@@ -5664,18 +5678,18 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
     retval = qf_setprop_items_from_lines(qi, qf_idx, what, di, action);
   }
   if ((di = tv_dict_find(what, S_LEN("context"))) != NULL) {
-    retval = qf_setprop_context(&qi->qf_lists[qf_idx], di);
+    retval = qf_setprop_context(qfl, di);
   }
 
   if (retval == OK) {
-    qf_list_changed(qi, qf_idx);
+    qf_list_changed(qfl);
   }
 
   return retval;
 }
 
-// Find the non-location list window with the specified location list in the
-// current tabpage.
+// Find the non-location list window with the specified location list stack in
+// the current tabpage.
 static win_T * find_win_with_ll(qf_info_T *qi)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
@@ -5754,7 +5768,7 @@ int set_errorlist(win_T *wp, list_T *list, int action, char_u *title,
   } else {
     retval = qf_add_entries(qi, qi->qf_curlist, list, title, action);
     if (retval == OK) {
-      qf_list_changed(qi, qi->qf_curlist);
+      qf_list_changed(&qi->qf_lists[qi->qf_curlist]);
     }
   }
 
@@ -5889,7 +5903,7 @@ void ex_cbuffer(exarg_T *eap)
                              && eap->cmdidx != CMD_laddbuffer),
                             eap->line1, eap->line2, qf_title, NULL);
       if (res >= 0) {
-        qf_list_changed(qi, qi->qf_curlist);
+        qf_list_changed(&qi->qf_lists[qi->qf_curlist]);
       }
       // Remember the current quickfix list identifier, so that we can
       // check for autocommands changing the current quickfix list.
@@ -5971,7 +5985,7 @@ void ex_cexpr(exarg_T *eap)
                             (linenr_T)0, (linenr_T)0,
                             qf_cmdtitle(*eap->cmdlinep), NULL);
       if (res >= 0) {
-        qf_list_changed(qi, qi->qf_curlist);
+        qf_list_changed(&qi->qf_lists[qi->qf_curlist]);
       }
       // Remember the current quickfix list identifier, so that we can
       // check for autocommands changing the current quickfix list.
@@ -6171,10 +6185,12 @@ void ex_helpgrep(exarg_T *eap)
 
     vim_regfree(regmatch.regprog);
 
-    qi->qf_lists[qi->qf_curlist].qf_nonevalid = FALSE;
-    qi->qf_lists[qi->qf_curlist].qf_ptr =
-      qi->qf_lists[qi->qf_curlist].qf_start;
-    qi->qf_lists[qi->qf_curlist].qf_index = 1;
+    qf_list_T *qfl = &qi->qf_lists[qi->qf_curlist];
+    qfl->qf_nonevalid = false;
+    qfl->qf_ptr = qfl->qf_start;
+    qfl->qf_index = 1;
+    qf_list_changed(qfl);
+    qf_update_buffer(qi, NULL);
   }
 
   if (p_cpo == empty_option) {
@@ -6183,9 +6199,6 @@ void ex_helpgrep(exarg_T *eap)
     // Darn, some plugin changed the value.
     free_string_option(save_cpo);
   }
-
-  qf_list_changed(qi, qi->qf_curlist);
-  qf_update_buffer(qi, NULL);
 
   if (au_name != NULL) {
     apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -845,24 +845,26 @@ static bool qf_stack_empty(const qf_info_T *qi)
 }
 
 // Returns true if the specified quickfix/location list is empty.
-static bool qf_list_empty(const qf_info_T *qi, int qf_idx)
+static bool qf_list_empty(qf_list_T *qfl)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  if (qi == NULL || qf_idx < 0 || qf_idx >= LISTCOUNT) {
-    return true;
-  }
-  return qi->qf_lists[qf_idx].qf_count <= 0;
+  return qfl == NULL || qfl->qf_count <= 0;
+}
+
+// Return a pointer to a list in the specified quickfix stack
+static qf_list_T * qf_get_list(qf_info_T *qi, int idx)
+{
+  return &qi->qf_lists[idx];
 }
 
 /// Parse a line and get the quickfix fields.
 /// Return the QF_ status.
-static int qf_parse_line(qf_info_T *qi, int qf_idx, char_u *linebuf,
+static int qf_parse_line(qf_list_T *qfl, char_u *linebuf,
                          size_t linelen, efm_T *fmt_first, qffields_T *fields)
 {
   efm_T *fmt_ptr;
   int    idx = 0;
   char_u *tail = NULL;
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   int status;
 
 restofline:
@@ -918,7 +920,7 @@ restofline:
       qfl->qf_multiignore = false;  // reset continuation
     } else if (vim_strchr((char_u *)"CZ", idx) != NULL) {
       // continuation of multi-line msg
-      status = qf_parse_multiline_pfx(qi, qf_idx, idx, qfl, fields);
+      status = qf_parse_multiline_pfx(idx, qfl, fields);
       if (status != QF_OK) {
         return status;
       }
@@ -1064,12 +1066,12 @@ qf_init_ext(
   } else {
     // Adding to existing list, use last entry.
     adding = true;
-    if (!qf_list_empty(qi, qf_idx)) {
+    if (!qf_list_empty(qf_get_list(qi, qf_idx) )) {
       old_last = qi->qf_lists[qf_idx].qf_last;
     }
   }
 
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
+  qf_list_T *qfl = qf_get_list(qi, qf_idx);
 
   // Use the local value of 'errorformat' if it's set.
   if (errorformat == p_efm && tv == NULL && buf && *buf->b_p_efm != NUL) {
@@ -1113,7 +1115,7 @@ qf_init_ext(
       break;
     }
 
-    status = qf_parse_line(qi, qf_idx, state.linebuf, state.linelen,
+    status = qf_parse_line(qfl, state.linebuf, state.linelen,
                            fmt_first, &fields);
     if (status == QF_FAIL) {
       goto error2;
@@ -1122,8 +1124,7 @@ qf_init_ext(
       continue;
     }
 
-    if (qf_add_entry(qi,
-                     qf_idx,
+    if (qf_add_entry(qfl,
                      qfl->qf_directory,
                      (*fields.namebuf || qfl->qf_directory)
                      ? fields.namebuf : ((qfl->qf_currfile && fields.valid)
@@ -1210,7 +1211,7 @@ static char_u * qf_cmdtitle(char_u *cmd)
 // Return a pointer to the current list in the specified quickfix stack
 static qf_list_T * qf_get_curlist(qf_info_T *qi)
 {
-  return &qi->qf_lists[qi->qf_curlist];
+  return qf_get_list(qi, qi->qf_curlist);
 }
 
 // Prepare for adding a new quickfix list. If the current list is in the
@@ -1616,8 +1617,7 @@ static int qf_parse_line_nomatch(char_u *linebuf, size_t linelen,
 }
 
 /// Parse multi-line error format prefixes (%C and %Z)
-static int qf_parse_multiline_pfx(qf_info_T *qi, int qf_idx, int idx,
-                                  qf_list_T *qfl, qffields_T *fields)
+static int qf_parse_multiline_pfx(int idx, qf_list_T *qfl, qffields_T *fields)
 {
   if (!qfl->qf_multiignore) {
     qfline_T *qfprev = qfl->qf_last;
@@ -1648,7 +1648,7 @@ static int qf_parse_multiline_pfx(qf_info_T *qi, int qf_idx, int idx,
     }
     qfprev->qf_viscol = fields->use_viscol;
     if (!qfprev->qf_fnum) {
-      qfprev->qf_fnum = qf_get_fnum(qi, qf_idx, qfl->qf_directory,
+      qfprev->qf_fnum = qf_get_fnum(qfl, qfl->qf_directory,
                                     *fields->namebuf || qfl->qf_directory
                                     ? fields->namebuf
                                     : qfl->qf_currfile && fields->valid
@@ -1694,7 +1694,7 @@ static void ll_free_all(qf_info_T **pqi)
       locstack_queue_delreq(qi);
     } else {
       for (i = 0; i < qi->qf_listcount; i++) {
-        qf_free(&qi->qf_lists[i]);
+        qf_free(qf_get_list(qi, i));
       }
       xfree(qi);
     }
@@ -1714,7 +1714,7 @@ void qf_free_all(win_T *wp)
   } else {
     // quickfix list
     for (i = 0; i < qi->qf_listcount; i++) {
-      qf_free(&qi->qf_lists[i]);
+      qf_free(qf_get_list(qi, i));
     }
   }
 }
@@ -1765,8 +1765,7 @@ void check_quickfix_busy(void)
 
 /// Add an entry to the end of the list of errors.
 ///
-/// @param  qi       quickfix list
-/// @param  qf_idx   list index
+/// @param  qfl      quickfix list entry
 /// @param  dir      optional directory name
 /// @param  fname    file name or NULL
 /// @param  module   module name or NULL
@@ -1781,12 +1780,11 @@ void check_quickfix_busy(void)
 /// @param  valid    valid entry
 ///
 /// @returns OK or FAIL.
-static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
+static int qf_add_entry(qf_list_T *qfl, char_u *dir, char_u *fname,
                         char_u *module, int bufnum, char_u *mesg, long lnum,
                         int col, char_u vis_col, char_u *pattern, int nr,
                         char_u type, char_u valid)
 {
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   qfline_T *qfp = xmalloc(sizeof(qfline_T));
   qfline_T **lastp;  // pointer to qf_last or NULL
 
@@ -1799,7 +1797,7 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
         IS_QF_LIST(qfl) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
     }
   } else {
-    qfp->qf_fnum = qf_get_fnum(qi, qf_idx, dir, fname);
+    qfp->qf_fnum = qf_get_fnum(qfl, dir, fname);
   }
   qfp->qf_text = vim_strsave(mesg);
   qfp->qf_lnum = lnum;
@@ -1823,7 +1821,7 @@ static int qf_add_entry(qf_info_T *qi, int qf_idx, char_u *dir, char_u *fname,
   qfp->qf_valid = valid;
 
   lastp = &qfl->qf_last;
-  if (qf_list_empty(qi, qf_idx)) {
+  if (qf_list_empty(qfl)) {
     // first element in the list
     qfl->qf_start = qfp;
     qfl->qf_ptr = qfp;
@@ -1880,19 +1878,17 @@ static qf_info_T *ll_get_or_alloc_list(win_T *wp)
 
 // Copy location list entries from 'from_qfl' to 'to_qfl'.
 static int copy_loclist_entries(const qf_list_T *from_qfl,
-                                qf_list_T *to_qfl,
-                                qf_info_T *to_qi)
+                                qf_list_T *to_qfl)
   FUNC_ATTR_NONNULL_ALL
 {
   int i;
-  const qfline_T *from_qfp;
+  qfline_T *from_qfp;
 
   // copy all the location entries in this list
   for (i = 0, from_qfp = from_qfl->qf_start;
        i < from_qfl->qf_count && from_qfp != NULL;
        i++, from_qfp = from_qfp->qf_next) {
-    if (qf_add_entry(to_qi,
-                     to_qi->qf_curlist,
+    if (qf_add_entry(to_qfl,
                      NULL,
                      NULL,
                      from_qfp->qf_module,
@@ -1923,9 +1919,7 @@ static int copy_loclist_entries(const qf_list_T *from_qfl,
 }
 
 // Copy the specified location list 'from_qfl' to 'to_qfl'.
-static int copy_loclist(const qf_list_T *from_qfl,
-                        qf_list_T *to_qfl,
-                        qf_info_T *to_qi)
+static int copy_loclist(const qf_list_T *from_qfl, qf_list_T *to_qfl)
   FUNC_ATTR_NONNULL_ALL
 {
   // Some of the fields are populated by qf_add_entry()
@@ -1949,8 +1943,9 @@ static int copy_loclist(const qf_list_T *from_qfl,
   } else {
     to_qfl->qf_ctx = NULL;
   }
+
   if (from_qfl->qf_count) {
-    if (copy_loclist_entries(from_qfl, to_qfl, to_qi) == FAIL) {
+    if (copy_loclist_entries(from_qfl, to_qfl) == FAIL) {
       return FAIL;
     }
   }
@@ -1999,8 +1994,8 @@ void copy_loclist_stack(win_T *from, win_T *to)
   for (int idx = 0; idx < qi->qf_listcount; idx++) {
     to->w_llist->qf_curlist = idx;
 
-    if (copy_loclist(&qi->qf_lists[idx], &to->w_llist->qf_lists[idx],
-                     to->w_llist) == FAIL) {
+    if (copy_loclist(qf_get_list(qi, idx),
+                     qf_get_list(to->w_llist, idx)) == FAIL) {
       qf_free_all(to);
       return;
     }
@@ -2011,10 +2006,8 @@ void copy_loclist_stack(win_T *from, win_T *to)
 
 // Get buffer number for file "directory/fname".
 // Also sets the b_has_qf_entry flag.
-static int qf_get_fnum(qf_info_T *qi, int qf_idx, char_u *directory,
-                       char_u *fname)
+static int qf_get_fnum(qf_list_T *qfl, char_u *directory, char_u *fname )
 {
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
   char_u *ptr = NULL;
   char_u *bufname;
   buf_T *buf;
@@ -2534,7 +2527,7 @@ static void qf_goto_win_with_ll_file(win_T *use_win, int qf_fnum,
 
   // If the location list for the window is not set, then set it
   // to the location list from the location window
-  if (win->w_llist == NULL) {
+  if (win->w_llist == NULL && ll_ref != NULL) {
     // The new window should use the location list from the
     // location list window
     win_set_loclist(win, ll_ref);
@@ -2781,7 +2774,7 @@ void qf_jump(qf_info_T *qi, int dir, int errornr, int forceit)
   if (qi == NULL)
     qi = &ql_info;
 
-  if (qf_stack_empty(qi) || qf_list_empty(qi, qi->qf_curlist)) {
+  if (qf_stack_empty(qi) || qf_list_empty(qf_get_curlist(qi))) {
     EMSG(_(e_quickfix));
     return;
   }
@@ -3005,7 +2998,7 @@ void qf_list(exarg_T *eap)
     }
   }
 
-  if (qf_stack_empty(qi) || qf_list_empty(qi, qi->qf_curlist)) {
+  if (qf_stack_empty(qi) || qf_list_empty(qf_get_curlist(qi))) {
     EMSG(_(e_quickfix));
     return;
   }
@@ -3177,7 +3170,7 @@ void qf_history(exarg_T *eap)
   if (is_loclist_cmd(eap->cmdidx)) {
     qi = GET_LOC_LIST(curwin);
   }
-  if (qf_stack_empty(qi) || qf_list_empty(qi, qi->qf_curlist)) {
+  if (qf_stack_empty(qi) || qf_list_empty(qf_get_curlist(qi))) {
     MSG(_("No entries"));
   } else {
     for (i = 0; i < qi->qf_listcount; i++) {
@@ -3268,9 +3261,11 @@ bool qf_mark_adjust(win_T *wp, linenr_T line1, linenr_T line2, long amount,
   }
 
   for (idx = 0; idx < qi->qf_listcount; idx++) {
-    if (!qf_list_empty(qi, idx)) {
-      for (i = 0, qfp = qi->qf_lists[idx].qf_start;
-           i < qi->qf_lists[idx].qf_count && qfp != NULL;
+    qf_list_T *qfl = qf_get_list(qi, idx);
+
+    if (!qf_list_empty(qfl)) {
+      for (i = 0, qfp = qfl->qf_start;
+           i < qfl->qf_count && qfp != NULL;
            i++, qfp = qfp->qf_next) {
         if (qfp->qf_fnum == curbuf->b_fnum) {
           found_one = true;
@@ -3344,7 +3339,7 @@ void qf_view_result(bool split)
   if (IS_LL_WINDOW(curwin)) {
     qi = GET_LOC_LIST(curwin);
   }
-  if (qf_list_empty(qi, qi->qf_curlist)) {
+  if (qf_list_empty(qf_get_curlist(qi))) {
     EMSG(_(e_quickfix));
     return;
   }
@@ -3394,7 +3389,7 @@ void ex_cwindow(exarg_T *eap)
    */
   if (qf_stack_empty(qi)
       || qfl->qf_nonevalid
-      || qf_list_empty(qi, qi->qf_curlist)) {
+      || qf_list_empty(qf_get_curlist(qi))) {
     if (win != NULL) {
       ex_cclose(eap);
     }
@@ -3965,7 +3960,7 @@ static void qf_jump_first(qf_info_T *qi, unsigned save_qfid, int forceit)
     return;
   }
   // Autocommands might have cleared the list, check for that
-  if (!qf_list_empty(qi, qi->qf_curlist)) {
+  if (!qf_list_empty(qf_get_curlist(qi))) {
     qf_jump(qi, 0, 0, forceit);
   }
 }
@@ -4613,8 +4608,7 @@ static bool vgr_match_buflines(qf_info_T *qi, char_u *fname, buf_T *buf,
       // Pass the buffer number so that it gets used even for a
       // dummy buffer, unless duplicate_name is set, then the
       // buffer will be wiped out below.
-      if (qf_add_entry(qi,
-                       qi->qf_curlist,
+      if (qf_add_entry(qf_get_curlist(qi),
                        NULL,  // dir
                        fname,
                        NULL,
@@ -4893,7 +4887,7 @@ void ex_vimgrep(exarg_T *eap)
   }
 
   // Jump to first match.
-  if (!qf_list_empty(qi, qi->qf_curlist)) {
+  if (!qf_list_empty(qf_get_curlist(qi))) {
     if ((flags & VGR_NOJUMP) == 0) {
       vgr_jump_to_match(qi, eap->forceit, &redraw_for_dummy, first_match_buf,
                         target_dir);
@@ -5084,6 +5078,7 @@ static void unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
 int get_errorlist(const qf_info_T *qi_arg, win_T *wp, int qf_idx, list_T *list)
 {
   const qf_info_T *qi = qi_arg;
+  qf_list_T *qfl;
   char_u buf[2];
   qfline_T    *qfp;
   int i;
@@ -5103,13 +5098,17 @@ int get_errorlist(const qf_info_T *qi_arg, win_T *wp, int qf_idx, list_T *list)
     qf_idx = qi->qf_curlist;
   }
 
-  if (qf_idx >= qi->qf_listcount
-      || qf_list_empty(qi, qf_idx)) {
+  if (qf_idx >= qi->qf_listcount) {
     return FAIL;
   }
 
-  qfp = qi->qf_lists[qf_idx].qf_start;
-  for (i = 1; !got_int && i <= qi->qf_lists[qf_idx].qf_count; i++) {
+  qfl = qf_get_list(qi, qf_idx);
+  if (qf_list_empty(qfl)) {
+    return FAIL;
+  }
+
+  qfp = qfl->qf_start;
+  for (i = 1; !got_int && i <= qfl->qf_count; i++) {
     // Handle entries with a non-existing buffer number.
     bufnum = qfp->qf_fnum;
     if (bufnum != 0 && (buflist_findnr(bufnum) == NULL))
@@ -5418,10 +5417,10 @@ static int qf_getprop_ctx(qf_list_T *qfl, dict_T *retdict)
 }
 
 /// Return the current quickfix list index as 'idx' in retdict
-static int qf_getprop_idx(qf_info_T *qi, int qf_idx, dict_T *retdict)
+static int qf_getprop_idx(qf_list_T *qfl, dict_T *retdict)
 {
-  int curidx = qi->qf_lists[qf_idx].qf_index;
-  if (qf_list_empty(qi, qf_idx)) {
+  int curidx = qfl->qf_index;
+  if (qf_list_empty(qfl)) {
     // For empty lists, current index is set to 0
     curidx = 0;
   }
@@ -5458,7 +5457,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
     return qf_getprop_defaults(qi, flags, wp != NULL, retdict);
   }
 
-  qfl = &qi->qf_lists[qf_idx];
+  qfl = qf_get_list(qi, qf_idx);
 
   if (flags & QF_GETLIST_TITLE) {
     status = qf_getprop_title(qfl, retdict);
@@ -5479,7 +5478,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
     status = tv_dict_add_nr(retdict, S_LEN("id"), qfl->qf_id);
   }
   if ((status == OK) && (flags & QF_GETLIST_IDX)) {
-    status = qf_getprop_idx(qi, qf_idx, retdict);
+    status = qf_getprop_idx(qfl, retdict);
   }
   if ((status == OK) && (flags & QF_GETLIST_SIZE)) {
     status = tv_dict_add_nr(retdict, S_LEN("size"),
@@ -5499,8 +5498,7 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 // Add a new quickfix entry to list at 'qf_idx' in the stack 'qi' from the
 // items in the dict 'd'.
 static int qf_add_entry_from_dict(
-    qf_info_T *qi,
-    int qf_idx,
+    qf_list_T *qfl,
     const dict_T *d,
     bool first_entry)
   FUNC_ATTR_NONNULL_ALL
@@ -5546,17 +5544,16 @@ static int qf_add_entry_from_dict(
     valid = tv_dict_get_number(d, "valid");
   }
 
-  const int status = qf_add_entry(qi,
-                                  qf_idx,
-                                  NULL,  // dir
+  const int status = qf_add_entry(qfl,
+                                  NULL,      // dir
                                   (char_u *)filename,
                                   (char_u *)module,
                                   bufnum,
                                   (char_u *)text,
                                   lnum,
                                   col,
-                                  vcol,  // vis_col
-                                  (char_u *)pattern,  // search pattern
+                                  vcol,      // vis_col
+                                  (char_u *)pattern,   // search pattern
                                   nr,
                                   (char_u)(type == NULL ? NUL : *type),
                                   valid);
@@ -5574,7 +5571,7 @@ static int qf_add_entry_from_dict(
 static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
                           char_u *title, int action)
 {
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
+  qf_list_T *qfl = qf_get_list(qi, qf_idx);
   qfline_T *old_last = NULL;
   int retval = OK;
 
@@ -5582,8 +5579,8 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
     // make place for a new list
     qf_new_list(qi, title);
     qf_idx = qi->qf_curlist;
-    qfl = &qi->qf_lists[qf_idx];
-  } else if (action == 'a' && !qf_list_empty(qi, qf_idx)) {
+    qfl = qf_get_list(qi, qf_idx);
+  } else if (action == 'a' && !qf_list_empty(qfl)) {
     // Adding to existing list, use last entry.
     old_last = qfl->qf_last;
   } else if (action == 'r') {
@@ -5601,7 +5598,7 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
       continue;
     }
 
-    retval = qf_add_entry_from_dict(qi, qf_idx, d, li == tv_list_first(list));
+    retval = qf_add_entry_from_dict(qfl, d, li == tv_list_first(list));
     if (retval == FAIL) {
       break;
     }
@@ -5615,7 +5612,7 @@ static int qf_add_entries(qf_info_T *qi, int qf_idx, list_T *list,
   }
   if (action != 'a') {
     qfl->qf_ptr = qfl->qf_start;
-    if (!qf_list_empty(qi, qf_idx)) {
+    if (!qf_list_empty(qfl)) {
       qfl->qf_index = 1;
     }
   }
@@ -5686,7 +5683,7 @@ static int qf_setprop_title(qf_info_T *qi, int qf_idx, const dict_T *what,
                             const dictitem_T *di)
   FUNC_ATTR_NONNULL_ALL
 {
-  qf_list_T *qfl = &qi->qf_lists[qf_idx];
+  qf_list_T *qfl = qf_get_list(qi, qf_idx);
   if (di->di_tv.v_type != VAR_STRING) {
     return FAIL;
   }
@@ -5790,7 +5787,7 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
     qf_idx = qi->qf_curlist;
   }
 
-  qfl = &qi->qf_lists[qf_idx];
+  qfl = qf_get_list(qi, qf_idx);
   if ((di = tv_dict_find(what, S_LEN("title"))) != NULL) {
     retval = qf_setprop_title(qi, qf_idx, what, di);
   }
@@ -6205,8 +6202,7 @@ static void hgr_search_file(
         line[--l] = NUL;
       }
 
-      if (qf_add_entry(qi,
-                       qi->qf_curlist,
+      if (qf_add_entry(qf_get_curlist(qi),
                        NULL,   // dir
                        fname,
                        NULL,
@@ -6356,7 +6352,7 @@ void ex_helpgrep(exarg_T *eap)
   }
 
   // Jump to first match.
-  if (!qf_list_empty(qi, qi->qf_curlist)) {
+  if (!qf_list_empty(qf_get_curlist(qi))) {
     qf_jump(qi, 0, 0, false);
   } else {
     EMSG2(_(e_nomatch2), eap->arg);

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -163,6 +163,12 @@ endfunc
 func XageTests(cchar)
   call s:setup_commands(a:cchar)
 
+  if a:cchar == 'l'
+    " No location list for the current window
+    call assert_fails('lolder', 'E776:')
+    call assert_fails('lnewer', 'E776:')
+  endif
+
   let list = [{'bufnr': bufnr('%'), 'lnum': 1}]
   call g:Xsetlist(list)
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1045,8 +1045,8 @@ func Test_efm2()
   set efm=%f:%s
   cexpr 'Xtestfile:Line search text'
   let l = getqflist()
-  call assert_equal(l[0].pattern, '^\VLine search text\$')
-  call assert_equal(l[0].lnum, 0)
+  call assert_equal('^\VLine search text\$', l[0].pattern)
+  call assert_equal(0, l[0].lnum)
 
   let l = split(execute('clist', ''), "\n")
   call assert_equal([' 1 Xtestfile:^\VLine search text\$:  '], l)

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -540,6 +540,8 @@ func s:test_xhelpgrep(cchar)
 
   " Search for non existing help string
   call assert_fails('Xhelpgrep a1b2c3', 'E480:')
+  " Invalid regular expression
+  call assert_fails('Xhelpgrep \@<!', 'E480:')
 endfunc
 
 func Test_helpgrep()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3339,7 +3339,28 @@ func Test_lexpr_crash()
   augroup QF_Test
     au!
   augroup END
+
   enew | only
+  augroup QF_Test
+    au!
+    au BufNew * call setloclist(0, [], 'f')
+  augroup END
+  lexpr 'x:1:x'
+  augroup QF_Test
+    au!
+  augroup END
+
+  enew | only
+  lexpr ''
+  lopen
+  augroup QF_Test
+    au!
+    au FileType * call setloclist(0, [], 'f')
+  augroup END
+  lexpr ''
+  augroup QF_Test
+    au!
+  augroup END
 endfunc
 
 " The following test used to crash Vim


### PR DESCRIPTION
Brings over the :cabove, :cbelow, :labove and :lbelow commands introduced in Vim 8.1.1256 (vim/vim#4316).

This is a second attempt at the following PR that grew stale and closed: https://github.com/neovim/neovim/pull/11119