### PR TITLE
lua: add vim.fn.{func} for direct access to vimL function

### DIFF
--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -588,6 +588,22 @@ vim.schedule({callback})				*vim.schedule()*
         Schedules {callback} to be invoked soon by the main event-loop. Useful
         to avoid |textlock| or other temporary restrictions.
 
+vim.fn.{func}({...})
+        Call vimL function {func} with arguments. {func} can be both builtin
+        functions and user functions. To call autoload functions, use the
+        syntax `vim.fn['some#function']({...})`
+
+        Note: unlike vim.api.|nvim_call_function| this converts values directly
+        between vimL values and lua values. If the vimL function returns a
+        float, it will be representeted directly as a lua number. Both empty
+        lists and dictonaries will be represented by an empty table.
+
+        Note: vim.fn keys are generated on demand. So `pairs(vim.fn)`
+        does NOT work to enumerate all functions.
+
+vim.call({func}, {...})
+        Call vim script function {func}. Equivalent to `vim.fn[func]({...})`
+
 vim.type_idx						*vim.type_idx*
 	Type index for use in |lua-special-tbl|.  Specifying one of the 
 	values from |vim.types| allows typing the empty table (it is 

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -242,6 +242,17 @@ local function __index(t, key)
   end
 end
 
+
+-- vim.fn.{func}(...)
+local function fn_index(t, key)
+  local function func(...)
+    return vim.call(key, ...)
+  end
+  t[key] = func
+  return func
+end
+local fn = setmetatable({}, {__index=fn_index})
+
 local module = {
   _update_package_paths = _update_package_paths,
   _os_proc_children = _os_proc_children,
@@ -249,6 +260,7 @@ local module = {
   _system = _system,
   paste = paste,
   schedule_wrap = schedule_wrap,
+  fn=fn,
 }
 
 setmetatable(module, {


### PR DESCRIPTION
Add a direct implementation of calling a vimL function from lua.

This fixes some typing issues due to the indirect conversion via the API. float values are preserved as such, fixes https://github.com/neovim/neovim/issues/9389, as well as empty dicts/arrays (ideally these should be distinguishable by a metatable, which is the canonical way of creating table "subtypes" and far less intrusive than `{[true] = 7, [false] = 3}` thing). I might revisit this and other typing issues (such as a dedicated `vim.NIL` value as `nil` doesn't always work) in a following `vim.rpcrequest` PR (which is my next lua addition, for a full "rpc client lib" in lua code).

Also add convenient lua interface as `vim.funcs.fname(...)`. The name `funcs` is fully bikeshedable. @norcalli has also suggested a similar interface as part of his "stdlib" work but instead `nvim.fn.xx`, though it would be `vim.fn` here if we use it. In fact perhaps this should be the _only_ public interface, and `vim.call` instead be `vim._call` implementation detail.