### PR TITLE
Fix pythonx current working directory path removing

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -202,7 +202,8 @@ function! s:version_info(python) abort
 
   let nvim_path = s:trim(s:system([
         \ a:python, '-c',
-        \ 'import sys; sys.path.remove(""); ' .
+        \ 'import sys; ' .
+        \ 'sys.path = list(filter(lambda x: x != "", sys.path)); ' .
         \ 'import neovim; print(neovim.__file__)']))
   if s:shell_error || empty(nvim_path)
     return [python_version, 'unable to load neovim Python module', pypi_version,

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -10,7 +10,8 @@ function! provider#pythonx#Require(host) abort
 
   " Python host arguments
   let prog = (ver == '2' ?  provider#python#Prog() : provider#python3#Prog())
-  let args = [prog, '-c', 'import sys; sys.path.remove(""); import neovim; neovim.start_host()']
+  let args = [prog, '-c', 'import sys; sys.path = list(filter(lambda x: x != "", sys.path)); import neovim; neovim.start_host()']
+
 
   " Collect registered Python plugins into args
   let python_plugins = remote#host#PluginsForHost(a:host.name)
@@ -66,7 +67,7 @@ endfunction
 function! s:import_module(prog, module) abort
   let prog_version = system([a:prog, '-c' , printf(
         \ 'import sys; ' .
-        \ 'sys.path.remove(""); ' .
+        \ 'sys.path = list(filter(lambda x: x != "", sys.path)); ' .
         \ 'sys.stdout.write(str(sys.version_info[0]) + "." + str(sys.version_info[1])); ' .
         \ 'import pkgutil; ' .
         \ 'exit(2*int(pkgutil.get_loader("%s") is None))',


### PR DESCRIPTION
Fix to use `filter()` function instead of `remove()`, to avoid `ValueError` when `sys.path` doesn't contain empty string element. This fixes #11293.