### PR TITLE
lua/executor.c: use TRY_WRAP

### DIFF
--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -102,6 +102,20 @@ typedef struct {
   int did_emsg;
 } TryState;
 
+// `msg_list` controls the collection of abort-causing non-exception errors,
+// which would otherwise be ignored.  This pattern is from do_cmdline().
+//
+// TODO(bfredl): prepare error-handling at "top level" (nv_event).
+#define TRY_WRAP(code) \
+  do { \
+    struct msglist **saved_msg_list = msg_list; \
+    struct msglist *private_msg_list; \
+    msg_list = &private_msg_list; \
+    private_msg_list = NULL; \
+    code \
+    msg_list = saved_msg_list;  /* Restore the exception context. */ \
+  } while (0)
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/helpers.h.generated.h"
 #endif

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -53,20 +53,6 @@
 # include "api/vim.c.generated.h"
 #endif
 
-// `msg_list` controls the collection of abort-causing non-exception errors,
-// which would otherwise be ignored.  This pattern is from do_cmdline().
-//
-// TODO(bfredl): prepare error-handling at "top level" (nv_event).
-#define TRY_WRAP(code) \
-  do { \
-    struct msglist **saved_msg_list = msg_list; \
-    struct msglist *private_msg_list; \
-    msg_list = &private_msg_list; \
-    private_msg_list = NULL; \
-    code \
-    msg_list = saved_msg_list;  /* Restore the exception context. */ \
-  } while (0)
-
 void api_vim_init(void)
   FUNC_API_NOEXPORT
 {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -563,11 +563,8 @@ int nlua_call(lua_State *lstate)
     }
   }
 
+  TRY_WRAP({
   // TODO(bfredl): this should be simplified in error handling refactor
-  struct msglist **saved_msg_list = msg_list;
-  struct msglist *private_msg_list = NULL;
-  msg_list = &private_msg_list;
-
   force_abort = false;
   suppress_errthrow = false;
   current_exception = NULL;
@@ -577,7 +574,7 @@ int nlua_call(lua_State *lstate)
   typval_T rettv;
   int dummy;
   // call_func() retval is deceptive, ignore it.  Instead we set `msg_list`
-  // (see above) to capture abort-causing non-exception errors.
+  // (TRY_WRAP) to capture abort-causing non-exception errors.
   (void)call_func(name, (int)name_len, &rettv, nargs,
                   vim_args, NULL, curwin->w_cursor.lnum, curwin->w_cursor.lnum,
                   &dummy, true, NULL, NULL);
@@ -585,8 +582,7 @@ int nlua_call(lua_State *lstate)
     nlua_push_typval(lstate, &rettv, false);
   }
   tv_clear(&rettv);
-
-  msg_list = saved_msg_list;
+  });
 
 free_vim_args:
   while (i > 0) {


### PR DESCRIPTION
Minor cleanup. Easier to grep for TRY_WRAP cases / avoids an extra TODO.