### PR TITLE
termdebug.vim: Reset evalFromBalloonExprResult

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -583,6 +583,7 @@ func s:HandleEvaluate(msg)
     endif
     let s:evalFromBalloonExprResult = split(s:evalFromBalloonExprResult, '\\n')
     call s:OpenHoverPreview(s:evalFromBalloonExprResult, v:null)
+    let s:evalFromBalloonExprResult = ''
   else
     echomsg '"' . s:evalexpr . '": ' . value
   endif


### PR DESCRIPTION
The value is used again in case of a pointer and it will cause errors then.

It will result in an error saying you cannot compare a List with a String for this line:
```viml
if s:evalFromBalloonExprResult == ''
```