### PR TITLE
[release-0.4] test: delete duplicate highlight group

### DIFF
--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -52,7 +52,7 @@ local function screen_setup(extra_rows, command, cols, opts)
     [3] = {bold = true},
     [4] = {foreground = 12},
     [5] = {bold = true, reverse = true},
-    [6] = {background = 11},
+    -- 6 was a duplicate item
     [7] = {foreground = 130},
     [8] = {foreground = 15, background = 1}, -- error message
     [9] = {foreground = 4},


### PR DESCRIPTION
Depending on the lua version, 6 might get used instead of 2 here, which causes test failures in upstream builds. This was fixed as part of #11206 on master.