### PR TITLE
vim-patch:8.1.{560,1204,1206}

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1136,9 +1136,10 @@ scripts.
 
 :com[mand]						*:com* *:command*
 			List all user-defined commands.  When listing commands,
-			the characters in the first two columns are
+			the characters in the first columns are:
 			    !	Command has the -bang attribute
 			    "	Command has the -register attribute
+			    |   Command has the -bar attribute
 			    b	Command is local to current buffer
 			(see below for details on attributes)
 			The list can be filtered on command name with
@@ -1342,14 +1343,15 @@ It is possible that the special characters in the range like `.`, `$` or `%`
 which by default correspond to the current line, last line and the whole
 buffer, relate to arguments, (loaded) buffers, windows or tab pages.
 
-Possible values are:
-	-addr=lines		Range of lines (this is the default)
-	-addr=arguments		Range for arguments
-	-addr=buffers		Range for buffers (also not loaded buffers)
-	-addr=loaded_buffers	Range for loaded buffers
-	-addr=windows		Range for windows
-	-addr=tabs		Range for tab pages
-	-addr=other		other kind of range
+Possible values are (second column is the short name used in listing):
+    -addr=lines		  	Range of lines (this is the default)
+    -addr=arguments	  arg	Range for arguments
+    -addr=buffers	  buf	Range for buffers (also not loaded buffers)
+    -addr=loaded_buffers  load	Range for loaded buffers
+    -addr=windows	  win	Range for windows
+    -addr=tabs		  tab	Range for tab pages
+    -addr=quickfix	  qf	Range for quickfix entries
+    -addr=other		  ?	other kind of range
 
 
 Special cases ~

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2400,6 +2400,7 @@ int parse_cmd_address(exarg_T *eap, char_u **errormsg, bool silent)
             }
             break;
           case ADDR_TABS_RELATIVE:
+          case ADDR_OTHER:
             *errormsg = (char_u *)_(e_invrange);
             return FAIL;
           case ADDR_ARGUMENTS:
@@ -5066,6 +5067,7 @@ static struct {
   { ADDR_BUFFERS, "buffers" },
   { ADDR_WINDOWS, "windows" },
   { ADDR_QUICKFIX, "quickfix" },
+  { ADDR_OTHER, "other" },
   { -1, NULL }
 };
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5058,17 +5058,18 @@ fail:
 static struct {
   int expand;
   char *name;
+  char *shortname;
 } addr_type_complete[] =
 {
-  { ADDR_ARGUMENTS, "arguments" },
-  { ADDR_LINES, "lines" },
-  { ADDR_LOADED_BUFFERS, "loaded_buffers" },
-  { ADDR_TABS, "tabs" },
-  { ADDR_BUFFERS, "buffers" },
-  { ADDR_WINDOWS, "windows" },
-  { ADDR_QUICKFIX, "quickfix" },
-  { ADDR_OTHER, "other" },
-  { -1, NULL }
+  { ADDR_ARGUMENTS, "arguments", "arg" },
+  { ADDR_LINES, "lines", "line" },
+  { ADDR_LOADED_BUFFERS, "loaded_buffers", "load" },
+  { ADDR_TABS, "tabs", "tab" },
+  { ADDR_BUFFERS, "buffers", "buf" },
+  { ADDR_WINDOWS, "windows", "win" },
+  { ADDR_QUICKFIX, "quickfix", "qf" },
+  { ADDR_OTHER, "other", "?" },
+  { -1, NULL, NULL }
 };
 
 /*
@@ -5153,7 +5154,7 @@ static void uc_list(char_u *name, size_t name_len)
       // Put out the title first time
       if (!found) {
         MSG_PUTS_TITLE(_("\n    Name              Args Address "
-                         "Complete   Definition"));
+                         "Complete    Definition"));
       }
       found = true;
       msg_putchar('\n');
@@ -5239,13 +5240,13 @@ static void uc_list(char_u *name, size_t name_len)
 
       do {
         IObuff[len++] = ' ';
-      } while (len < 9 - over);
+      } while (len < 8 - over);
 
       // Address Type
       for (j = 0; addr_type_complete[j].expand != -1; j++) {
         if (addr_type_complete[j].expand != ADDR_LINES
             && addr_type_complete[j].expand == cmd->uc_addr_type) {
-          STRCPY(IObuff + len, addr_type_complete[j].name);
+          STRCPY(IObuff + len, addr_type_complete[j].shortname);
           len += (int)STRLEN(IObuff + len);
           break;
         }
@@ -5264,13 +5265,13 @@ static void uc_list(char_u *name, size_t name_len)
 
       do {
         IObuff[len++] = ' ';
-      } while (len < 24 - over);
+      } while (len < 25 - over);
 
       IObuff[len] = '\0';
       msg_outtrans(IObuff);
 
       msg_outtrans_special(cmd->uc_rep, false,
-                           name_len == 0 ? Columns - 46 : 0);
+                           name_len == 0 ? Columns - 47 : 0);
       if (p_verbose > 0) {
         last_set_msg(cmd->uc_script_ctx);
       }

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -398,3 +398,143 @@ func Test_addr_all()
 
   delcommand DoSomething
 endfunc
+
+func Test_command_list()
+  command! DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0                        :",
+        \           execute('command DoCmd'))
+
+  " Test with various -range= and -count= argument values.
+  command! -range DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .                   :",
+        \           execute('command DoCmd'))
+  command! -range=% DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    %                   :",
+        \           execute('command! DoCmd'))
+  command! -range=2 DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    2                   :",
+        \           execute('command DoCmd'))
+  command! -count=2 DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    2c                  :",
+        \           execute('command DoCmd'))
+
+  " Test with various -addr= argument values.
+  command! -addr=lines DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .                   :",
+        \           execute('command DoCmd'))
+  command! -addr=arguments DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .  arg              :",
+        \           execute('command DoCmd'))
+  command! -addr=buffers DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .  buf              :",
+        \           execute('command DoCmd'))
+  command! -addr=loaded_buffers DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .  load             :",
+        \           execute('command DoCmd'))
+  command! -addr=windows DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .  win              :",
+        \           execute('command DoCmd'))
+  command! -addr=tabs DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .  tab              :",
+        \           execute('command DoCmd'))
+  command! -addr=other DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0    .  ?                :",
+        \           execute('command DoCmd'))
+
+  " Test with various -complete= argument values (non-exhaustive list)
+  command! -complete=arglist DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0            arglist     :",
+        \           execute('command DoCmd'))
+  command! -complete=augroup DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0            augroup     :",
+        \           execute('command DoCmd'))
+  command! -complete=custom,CustomComplete DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0            custom      :",
+        \           execute('command DoCmd'))
+  command! -complete=customlist,CustomComplete DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0            customlist  :",
+        \           execute('command DoCmd'))
+
+  " Test with various -narg= argument values.
+  command! -nargs=0 DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0                        :",
+        \           execute('command DoCmd'))
+  command! -nargs=1 DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             1                        :",
+        \           execute('command DoCmd'))
+  command! -nargs=* DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             *                        :",
+        \           execute('command DoCmd'))
+  command! -nargs=? DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             ?                        :",
+        \           execute('command DoCmd'))
+  command! -nargs=+ DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             +                        :",
+        \           execute('command DoCmd'))
+
+  " Test with other arguments.
+  command! -bang DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n!   DoCmd             0                        :",
+        \           execute('command DoCmd'))
+  command! -bar DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n|   DoCmd             0                        :",
+        \           execute('command DoCmd'))
+  command! -register DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n\"   DoCmd             0                        :",
+        \           execute('command DoCmd'))
+  command! -buffer DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\nb   DoCmd             0                        :"
+        \        .. "\n\"   DoCmd             0                        :",
+        \           execute('command DoCmd'))
+  comclear
+
+  " Test with many args.
+  command! -bang -bar -register -buffer -nargs=+ -complete=environment -addr=windows -count=3 DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n!\"b|DoCmd             +    3c win  environment :",
+        \           execute('command DoCmd'))
+  comclear
+
+  " Test with special characters in command definition.
+  command! DoCmd :<cr><tab><c-d>
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             0                        :<CR><Tab><C-D>",
+        \           execute('command DoCmd'))
+
+  " Test output in verbose mode.
+  command! DoCmd :
+  call assert_match("^\n"
+        \        .. "    Name              Args Address Complete    Definition\n"
+        \        .. "    DoCmd             0                        :\n"
+        \        .. "\tLast set from .*/test_usercommands.vim line \\d\\+$",
+        \           execute('verbose command DoCmd'))
+
+  comclear
+  call assert_equal("\nNo user-defined commands found", execute(':command Xxx'))
+  call assert_equal("\nNo user-defined commands found", execute('command'))
+endfunc

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -342,6 +342,7 @@ func Test_use_execute_in_completion()
 endfunc
 
 func Test_addr_all()
+  throw 'skipped: requires patch v8.1.0341 to pass'
   command! -addr=lines DoSomething let g:a1 = <line1> | let g:a2 = <line2>
   %DoSomething
   call assert_equal(1, g:a1)

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -276,7 +276,7 @@ func Test_CmdCompletion()
   call assert_equal('"com -nargs=* + 0 1 ?', @:)
 
   call feedkeys(":com -addr=\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"com -addr=arguments buffers lines loaded_buffers quickfix tabs windows', @:)
+  call assert_equal('"com -addr=arguments buffers lines loaded_buffers other quickfix tabs windows', @:)
 
   call feedkeys(":com -complete=co\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -complete=color command compiler', @:)
@@ -339,4 +339,62 @@ func Test_use_execute_in_completion()
   call feedkeys(":DoExec \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoExec hi', @:)
   delcommand DoExec
+endfunc
+
+func Test_addr_all()
+  command! -addr=lines DoSomething let g:a1 = <line1> | let g:a2 = <line2>
+  %DoSomething
+  call assert_equal(1, g:a1)
+  call assert_equal(line('$'), g:a2)
+
+  command! -addr=arguments DoSomething let g:a1 = <line1> | let g:a2 = <line2>
+  args one two three
+  %DoSomething
+  call assert_equal(1, g:a1)
+  call assert_equal(3, g:a2)
+
+  command! -addr=buffers DoSomething let g:a1 = <line1> | let g:a2 = <line2>
+  %DoSomething
+  for low in range(1, bufnr('$'))
+    if buflisted(low)
+      break
+    endif
+  endfor
+  call assert_equal(low, g:a1)
+  call assert_equal(bufnr('$'), g:a2)
+
+  command! -addr=loaded_buffers DoSomething let g:a1 = <line1> | let g:a2 = <line2>
+  %DoSomething
+  for low in range(1, bufnr('$'))
+    if bufloaded(low)
+      break
+    endif
+  endfor
+  call assert_equal(low, g:a1)
+  for up in range(bufnr('$'), 1, -1)
+    if bufloaded(up)
+      break
+    endif
+  endfor
+  call assert_equal(up, g:a2)
+
+  command! -addr=windows DoSomething  let g:a1 = <line1> | let g:a2 = <line2>
+  new
+  %DoSomething
+  call assert_equal(1, g:a1)
+  call assert_equal(winnr('$'), g:a2)
+  bwipe
+
+  command! -addr=tabs DoSomething  let g:a1 = <line1> | let g:a2 = <line2>
+  tabnew
+  %DoSomething
+  call assert_equal(1, g:a1)
+  call assert_equal(len(gettabinfo()), g:a2)
+  bwipe
+
+  command! -addr=other DoSomething echo 'nothing'
+  DoSomething
+  call assert_fails('%DoSomething')
+
+  delcommand DoSomething
 endfunc


### PR DESCRIPTION
```
$ ./scripts/vim-patch.sh -l -- src/testdir/test_usercommands.vim
Updating Vim sources: /home/jan/repo/git/neovim/.vim-src
Already up-to-date.
✔ Updated Vim sources.
Vim patches missing from Neovim:
  • v8.1.1241: Ex command info contains confusing information
```

~~Patch 8.1.0341 is not a full port because it requires v8.0.x patches.~~ Patch v8.1.0341 should be a full port to not fail `test_autocmd.vim` tests so it cannot be included in this PR. Patch v8.1.1241 requires patch v8.1.1210 so it will be ported in a separate PR.