### PR TITLE
inccommand: fix issues with modifiers, prompting

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5566,12 +5566,7 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
   linenr_T highest_num_line = 0;
   int col_width = 0;
 
-  // if we fail to split the window, we don't want to modify orig_buf
-  bool split_success = false;
-
   if (split && win_split((int)p_cwh, WSP_BOT) != FAIL) {
-    split_success = true;
-
     buf_open_scratch(preview_buf ? bufnr : 0, "[Preview]");
     buf_clear();
     preview_buf = curbuf;
@@ -5589,6 +5584,9 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
       highest_num_line = kv_last(lines.subresults).end.lnum;
       col_width = log10(highest_num_line) + 1 + 3;
     }
+  } else {
+    // if we fail to split the window, we don't want to modify the preview buffer
+    preview_buf = NULL;
   }
 
   char *str = NULL;  // construct the line to show in here
@@ -5601,7 +5599,7 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
   for (size_t matchidx = 0; matchidx < lines.subresults.size; matchidx++) {
     SubResult match = lines.subresults.items[matchidx];
 
-    if (split_success && preview_buf) {
+    if (preview_buf) {
       lpos_T p_start = { 0, match.start.col };  // match starts here in preview
       lpos_T p_end   = { 0, match.end.col };    // ... and ends here
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5563,7 +5563,12 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
   linenr_T highest_num_line = 0;
   int col_width = 0;
 
+  // if we fail to split the window, we don't want to modify orig_buf
+  bool split_success = false;
+
   if (split && win_split((int)p_cwh, WSP_BOT) != FAIL) {
+    split_success = true;
+
     buf_open_scratch(preview_buf ? bufnr : 0, "[Preview]");
     buf_clear();
     preview_buf = curbuf;
@@ -5593,7 +5598,7 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
   for (size_t matchidx = 0; matchidx < lines.subresults.size; matchidx++) {
     SubResult match = lines.subresults.items[matchidx];
 
-    if (split && preview_buf) {
+    if (split_success && preview_buf) {
       lpos_T p_start = { 0, match.start.col };  // match starts here in preview
       lpos_T p_end   = { 0, match.end.col };    // ... and ends here
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5535,9 +5535,7 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
 
   // We keep a special-purpose buffer around, but don't assume it exists.
   buf_T *preview_buf = bufnr ? buflist_findnr(bufnr) : 0;
-  // disable :leftabove/botright modifiers
-  // (especially ones that conflict with our win_split() call below)
-  cmdmod.split = 0;
+  cmdmod.split = 0;               // disable :leftabove/botright modifiers
   cmdmod.tab = 0;                 // disable :tab modifier
   cmdmod.noswapfile = true;       // disable swap for preview buffer
   // disable file info message

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5535,6 +5535,9 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
 
   // We keep a special-purpose buffer around, but don't assume it exists.
   buf_T *preview_buf = bufnr ? buflist_findnr(bufnr) : 0;
+  // disable :leftabove/botright modifiers
+  // (especially ones that conflict with our win_split() call below)
+  cmdmod.split = 0;
   cmdmod.tab = 0;                 // disable :tab modifier
   cmdmod.noswapfile = true;       // disable swap for preview buffer
   // disable file info message

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -10216,10 +10216,13 @@ bool cmd_can_preview(char_u *cmd)
     return false;
   }
 
+  // Ignore additional colons at the start...
+  cmd = skip_colon_white(cmd, true);
+
   // Ignore any leading modifiers (:keeppatterns, :verbose, etc.)
   for (int len = modifier_len(cmd); len != 0; len = modifier_len(cmd)) {
     cmd += len;
-    cmd = skipwhite(cmd);
+    cmd = skip_colon_white(cmd, true);
   }
 
   exarg_T ea;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1201,6 +1201,19 @@ static void get_wincmd_addr_type(char_u *arg, exarg_T *eap)
   }
 }
 
+static char_u *skip_colon_white(const char_u *p, bool skipleadingwhite)
+{
+  if (skipleadingwhite) {
+    p = skipwhite(p);
+  }
+
+  while (*p == ':') {
+    p = skipwhite(p + 1);
+  }
+
+  return (char_u *)p;
+}
+
 /*
  * Execute one Ex command.
  *
@@ -1705,9 +1718,7 @@ static char_u * do_one_cmd(char_u **cmdlinep,
   /*
    * Skip ':' and any white space
    */
-  ea.cmd = skipwhite(ea.cmd);
-  while (*ea.cmd == ':')
-    ea.cmd = skipwhite(ea.cmd + 1);
+  ea.cmd = skip_colon_white(ea.cmd, true);
 
   /*
    * If we got a line, but no command, then go to the line.
@@ -3580,9 +3591,8 @@ char_u *skip_range(
       ++cmd;
   }
 
-  /* Skip ":" and white space. */
-  while (*cmd == ':')
-    cmd = skipwhite(cmd + 1);
+  // Skip ":" and white space.
+  cmd = skip_colon_white(cmd, false);
 
   return (char_u *)cmd;
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1201,6 +1201,10 @@ static void get_wincmd_addr_type(char_u *arg, exarg_T *eap)
   }
 }
 
+/// Skip colons and trailing whitespace, returning a pointer to the first
+/// non-colon, non-whitespace character.
+//
+/// @param skipleadingwhite Skip leading whitespace too
 static char_u *skip_colon_white(const char_u *p, bool skipleadingwhite)
 {
   if (skipleadingwhite) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1927,7 +1927,9 @@ static int command_line_changed(CommandLineState *s)
     //       - Immediately undo the effects.
     State |= CMDPREVIEW;
     emsg_silent++;  // Block error reporting as the command may be incomplete
+    msg_silent++;   // Block messages, namely ones that prompt
     do_cmdline(ccline.cmdbuff, NULL, NULL, DOCMD_KEEPLINE|DOCMD_NOWAIT);
+    msg_silent--;   // Unblock messages
     emsg_silent--;  // Unblock error reporting
 
     // Restore the window "view".

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -88,7 +88,7 @@ local function common_setup(screen, inccommand, text)
     })
   end
 
-  command("set inccommand=" .. (inccommand and inccommand or ""))
+  command("set inccommand=" .. (inccommand or ""))
 
   if text then
     insert(text)

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -95,7 +95,7 @@ local function common_setup(screen, inccommand, text)
   end
 end
 
-describe(":substitute, inccommand=split", function()
+describe(":substitute, inccommand=split interactivity", function()
   before_each(function()
     clear()
     common_setup(nil, "split", default_text)
@@ -784,6 +784,52 @@ describe(":substitute, inccommand=split", function()
     -- leading colons
     feed(':::%s/tw/to')
     screen:expect{any=[[{12:to}o lines]]}
+    feed('<Esc>')
+    screen:expect{any=[[two lines]]}
+  end)
+
+  it("ignores new-window modifiers when splitting the preview window", function()
+    -- one modifier
+    feed(':topleft %s/tw/to')
+    screen:expect([[
+      Inc substitution on           |
+      {12:to}o lines                     |
+      Inc substitution on           |
+      {12:to}o lines                     |
+                                    |
+      {11:[No Name] [+]                 }|
+      |2| {12:to}o lines                 |
+      |4| {12:to}o lines                 |
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {10:[Preview]                     }|
+      :topleft %s/tw/to^             |
+    ]])
+    feed('<Esc>')
+    screen:expect{any=[[two lines]]}
+
+    -- multiple modifiers
+    feed(':topleft vert %s/tw/to')
+    screen:expect([[
+      Inc substitution on           |
+      {12:to}o lines                     |
+      Inc substitution on           |
+      {12:to}o lines                     |
+                                    |
+      {11:[No Name] [+]                 }|
+      |2| {12:to}o lines                 |
+      |4| {12:to}o lines                 |
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {10:[Preview]                     }|
+      :topleft vert %s/tw/to^        |
+    ]])
     feed('<Esc>')
     screen:expect{any=[[two lines]]}
   end)

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2582,6 +2582,49 @@ describe(":substitute", function()
       :%s/some\(thing\)\@!/every/^   |
     ]])
   end)
+
+  it("doesn't prompt to swap cmd range", function()
+    screen = Screen.new(50, 8) -- wide to avoid hit-enter prompt
+    common_setup(screen, "split", default_text)
+    feed(':2,1s/tw/MO/g')
+
+    -- substitution preview should have been made, without prompting
+    screen:expect([[
+      {12:MO}o lines                                         |
+      {11:[No Name] [+]                                     }|
+      |2| {12:MO}o lines                                     |
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {10:[Preview]                                         }|
+      :2,1s/tw/MO/g^                                     |
+    ]])
+
+    -- but should be prompted on hitting enter
+    feed('<CR>')
+    screen:expect([[
+      {12:MO}o lines                                         |
+      {11:[No Name] [+]                                     }|
+      |2| {12:MO}o lines                                     |
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {10:[Preview]                                         }|
+      {13:Backwards range given, OK to swap (y/n)?}^          |
+    ]])
+
+    feed('y')
+    screen:expect([[
+      Inc substitution on                               |
+      ^MOo lines                                         |
+                                                        |
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {15:~                                                 }|
+      {13:Backwards range given, OK to swap (y/n)?}y         |
+    ]])
+  end)
 end)
 
 it(':substitute with inccommand during :terminal activity', function()

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -779,6 +779,13 @@ describe(":substitute, inccommand=split", function()
       {15:~                             }|
       :silent tabedit %s/tw/to^      |
     ]])
+    feed('<Esc>')
+
+    -- leading colons
+    feed(':::%s/tw/to')
+    screen:expect{any=[[{12:to}o lines]]}
+    feed('<Esc>')
+    screen:expect{any=[[two lines]]}
   end)
 
   it('shows split window when typing the pattern', function()


### PR DESCRIPTION
This fixes a few problems with `'inccommand'`

### `:topleft` buffer corruption
With `inccommand=split`, prefixing a substitute command with `:to[pleft]` would prevent a preview split from opening, causing what would appear to be random modifications to the original buffer as the command line changes.

The window split wouldn't open because `:topleft` would conflict with `WSP_BOT` in the `win_split()` call for the preview window. This then meant we would apply the substitutions thinking we were in the preview buffer, but they would accidentally end up applied over the original buffer.

`:vert[ical]`,  would also reposition the preview window - this was purely cosmetic, however it would lead to a very thin, difficult to read preview window, so I've prevented this too.

### Interaction interrupted by prompt
With a non-empty `'inccommand'`, anything causing a prompt (e.g. `:5,2s/...` --> `Backwards range given, OK to swap (y/n)?`) would interrupt the interactive process with this prompt on every keypress.

### Leading colons
Leading colons prevented interactive completion, e.g. `::%s/...`
