### PR TITLE
[RFC] Fix error message of update_version_stamp.lua on Windows

### DIFF
--- a/scripts/update_version_stamp.lua
+++ b/scripts/update_version_stamp.lua
@@ -13,6 +13,10 @@ local function die(msg)
   os.exit(0)
 end
 
+local function iswin()
+  return package.config:sub(1,1) == '\\'
+end
+
 if #arg ~= 2 then
   die(string.format("Expected two args, got %d", #arg))
 end
@@ -20,7 +24,8 @@ end
 local versiondeffile = arg[1]
 local prefix = arg[2]
 
-local described = io.popen('git describe --first-parent --dirty 2>/dev/null'):read('*l')
+local dev_null = iswin() and 'NUL' or '/dev/null'
+local described = io.popen('git describe --first-parent --dirty 2>'..dev_null):read('*l')
 if not described then
   described = io.popen('git describe --first-parent --tags --always --dirty'):read('*l')
 end


### PR DESCRIPTION
`/dev/null` does not exist on Windows.. Therefore, the following error message is displayed. This PR will fix it.

https://ci.appveyor.com/project/neovim/neovim/branch/master/job/u70wsks8c8hxre01?fullLog=true#L443