### PR TITLE
[WIP] Connect to --server (basis for --remote edit and remote TUI)

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2380,9 +2380,8 @@ Array nvim_get_proc_children(Integer pid, Error *err)
     DLOG("fallback to vim._os_proc_children()");
     Array a = ARRAY_DICT_INIT;
     ADD(a, INTEGER_OBJ(pid));
-    String s = cstr_to_string("return vim._os_proc_children(...)");
+    String s = STATIC_CSTR_AS_STRING("return vim._os_proc_children(...)");
     Object o = nvim_execute_lua(s, a, err);
-    api_free_string(s);
     api_free_array(a);
     if (o.type == kObjectTypeArray) {
       rvobj = o.data.array;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2380,7 +2380,7 @@ Array nvim_get_proc_children(Integer pid, Error *err)
     DLOG("fallback to vim._os_proc_children()");
     Array a = ARRAY_DICT_INIT;
     ADD(a, INTEGER_OBJ(pid));
-    String s = cstr_to_string("return vim._os_proc_children(select(1, ...))");
+    String s = cstr_to_string("return vim._os_proc_children(...)");
     Object o = nvim_execute_lua(s, a, err);
     api_free_string(s);
     api_free_array(a);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1033,6 +1033,9 @@ EXTERN char_u e_unsupportedoption[] INIT(= N_("E519: Option not supported"));
 EXTERN char_u e_fnametoolong[] INIT(= N_("E856: Filename too long"));
 EXTERN char_u e_float_as_string[] INIT(= N_("E806: using Float as a String"));
 
+EXTERN char_u e_noserver[] INIT(=N_(
+    "E247: couldn't connect to remote server: %s"));
+
 EXTERN char_u e_autocmd_err[] INIT(=N_(
     "E5500: autocmd has thrown an exception: %s"));
 EXTERN char_u e_cmdmap_err[] INIT(=N_(

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -253,6 +253,79 @@ local function fn_index(t, key)
 end
 local fn = setmetatable({}, {__index=fn_index})
 
+local function __rpcrequest(...)
+  return vim.api.nvim_call_function("rpcrequest", {...})
+end
+
+local function _cs_remote(rcid, args)
+
+  local f_silent = false
+  local f_wait = false
+  local f_tab = false
+  local should_exit = true
+  local command = 'edit '
+
+  local subcmd = string.sub(args[1],10)
+
+  if subcmd == '' then
+    -- no flags to set
+  elseif subcmd == 'tab' then
+    f_tab = true
+  elseif subcmd == 'silent' then
+    f_silent = true
+  elseif subcmd == 'wait' then
+    f_wait = true
+  elseif subcmd == 'wait-silent' then
+    f_wait = true
+    f_silent = true
+  elseif subcmd == 'tab-wait' then
+    f_tab = true
+    f_wait = true
+  elseif subcmd == 'tab-silent' then
+    f_tab = true
+    f_silent = true
+  elseif subcmd == 'tab-wait-silent' then
+    f_tab = true
+    f_wait = true
+    f_silent = true
+  elseif subcmd == 'send' then
+    __rpcrequest(rcid, 'nvim_input', args[2])
+    return { should_exit = should_exit, tabbed = f_tab, files = 0 }
+    -- should we show warning if --server doesn't exist in --send and --expr?
+  elseif subcmd == 'expr' then
+    local res = __rpcrequest(rcid, 'vim_eval', args[2])
+    print(res)
+    return { should_exit = should_exit, tabbed = f_tab, files = 0 }
+  else
+    print('--remote subcommand not found')
+  end
+
+  table.remove(args,1)
+
+  if not f_silent and rcid == 0 then
+    print('Remote server does not exist.')
+  end
+
+  if f_silent and rcid == 0 then
+    print('Remote server does not exist. starting new server')
+    should_exit = false
+  end
+
+  if f_tab then command = 'tabedit ' end
+
+  if rcid ~= 0 then
+    for _, key in ipairs(args) do
+      __rpcrequest(rcid, 'nvim_command', command .. key)
+    end
+  end
+
+  return {
+    should_exit = should_exit,
+    tabbed = f_tab,
+    files = table.getn(args)
+  }
+end
+
 local module = {
   _update_package_paths = _update_package_paths,
   _os_proc_children = _os_proc_children,
@@ -261,6 +334,7 @@ local module = {
   paste = paste,
   schedule_wrap = schedule_wrap,
   fn=fn,
+  _cs_remote = _cs_remote,
 }
 
 setmetatable(module, {

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -286,68 +286,19 @@ local function _cs_remote(rcid, args)
 
   local subcmd = string.sub(args[1],10)
 
-  if subcmd == '' then
-    -- no flags to set
-  elseif subcmd == 'tab' then
-    f_tab = true
-  elseif subcmd == 'silent' then
-    f_silent = true
-  elseif subcmd == 'wait' then
-    f_wait = true
-  elseif subcmd == 'wait-silent' then
-    f_wait = true
-    f_silent = true
-  elseif subcmd == 'tab-wait' then
-    f_tab = true
-    f_wait = true
-  elseif subcmd == 'tab-silent' then
-    f_tab = true
-    f_silent = true
-  elseif subcmd == 'tab-wait-silent' then
-    f_tab = true
-    f_wait = true
-    f_silent = true
-  elseif subcmd == 'send' then
+  if subcmd == 'send' then
     __rpcrequest(rcid, 'nvim_input', args[2])
-    return { should_exit = should_exit, tabbed = f_tab, files = 0 }
     -- should we show warning if --server doesn't exist in --send and --expr?
   elseif subcmd == 'expr' then
     local res = __rpcrequest(rcid, 'nvim_eval', args[2])
     print(res)
-    return {should_exit = true}
   elseif subcmd == 'lua' then
     local res = __rpcrequest( rcid, 'nvim_execute_lua', 'return vim._cs_remote_lua(...)', {args[2]})
     print(res)
-    return {should_exit = true}
   else
     print('--remote subcommand not found')
-    return {should_exit=true}
   end
-
-  table.remove(args,1)
-
-  if not f_silent and rcid == 0 then
-    print('Remote server does not exist.')
-  end
-
-  if f_silent and rcid == 0 then
-    print('Remote server does not exist. starting new server')
-    should_exit = false
-  end
-
-  if f_tab then command = 'tabedit ' end
-
-  if rcid ~= 0 then
-    for _, key in ipairs(args) do
-      __rpcrequest(rcid, 'nvim_command', command .. key)
-    end
-  end
-
-  return {
-    should_exit = should_exit,
-    tabbed = f_tab,
-    files = table.getn(args)
-  }
+  return {should_exit = true}
 end
 
 local module = {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -762,7 +762,7 @@ static uint64_t server_connect(char *server_addr)
   CallbackReader on_data = CALLBACK_READER_INIT;
   const char *error = NULL;
   bool is_tcp = strrchr(server_addr, ':') ? true : false;
-  // connected to channel
+
   uint64_t chan = channel_connect(is_tcp, server_addr, true, on_data, 50, &error);
   if (error) {
     EMSG2(e_noserver, error);
@@ -798,12 +798,12 @@ static bool remote_request(uint64_t chan, mparm_T *params, int remote_args,
   api_free_array(a);
 
 
-  if (o.type != kObjectTypeDictionary) {
-    EMSG("vim._cs_remote must return a dictionary");
-    goto free_return;
-  } else if (ERROR_SET(&err)) {
+  if (ERROR_SET(&err)) {
     EMSG2("vim._cs_remote: %s", err.msg);
     api_clear_error(&err);
+    goto free_return;
+  } else if (o.type != kObjectTypeDictionary) {
+    EMSG("vim._cs_remote must return a dictionary");
     goto free_return;
   }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -74,6 +74,7 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/handle.h"
 #include "nvim/api/private/dispatch.h"
+#include "nvim/lua/executor.h"
 #ifndef WIN32
 # include "nvim/os/pty_process_unix.h"
 #endif
@@ -115,6 +116,8 @@ typedef struct {
   int diff_mode;                        // start with 'diff' set
 
   char *listen_addr;                    // --listen {address}
+  int remote;                           // --remote[-subcmd] {file1} {file2}
+  char *server_addr;                    // --server {address}
 } mparm_T;
 
 // Values for edit_type.
@@ -279,6 +282,10 @@ int main(int argc, char **argv)
   }
 
   server_init(params.listen_addr);
+  if (params.remote) {
+    handle_remote_client(&params, params.remote,
+                         params.server_addr, argc, argv);
+  }
 
   if (GARGCOUNT > 0) {
     fname = get_fname(&params, cwd);
@@ -738,6 +745,67 @@ static bool edit_stdin(bool explicit, mparm_T *parmp)
   return explicit || implicit;
 }
 
+/// Handle remote subcommands
+static void handle_remote_client(mparm_T *params, int remote_args,
+                                 char *server_addr, int argc, char **argv)
+{
+    Object rvobj = OBJECT_INIT;
+    rvobj.data.dictionary = (Dictionary)ARRAY_DICT_INIT;
+    rvobj.type = kObjectTypeDictionary;
+    CallbackReader on_data = CALLBACK_READER_INIT;
+    const char *error = NULL;
+    uint64_t rc_id = server_addr == NULL ? 0 : channel_connect(false,
+                     server_addr, true, on_data, 50, &error);
+
+    Boolean should_exit = true;
+    Boolean tabbed;
+    int files;
+
+    int t_argc = remote_args;
+    Array args = ARRAY_DICT_INIT;
+    String arg_s;
+    for (; t_argc < argc; t_argc++) {
+      arg_s = cstr_to_string(argv[t_argc]);
+      ADD(args, STRING_OBJ(arg_s));
+    }
+
+    Error err = ERROR_INIT;
+    Array a = ARRAY_DICT_INIT;
+    ADD(a, INTEGER_OBJ((int)rc_id));
+    ADD(a, ARRAY_OBJ(args));
+    String s = cstr_to_string("return vim._cs_remote(...)");
+    Object o = executor_exec_lua_api(s, a, &err);
+    api_free_string(s);
+    api_free_array(a);
+
+    if (o.type == kObjectTypeDictionary) {
+      rvobj.data.dictionary = o.data.dictionary;
+    } else if (!ERROR_SET(&err)) {
+      api_set_error(&err, kErrorTypeException,
+                    "Function returned unexpected value");
+    }
+
+    for (size_t i = 0; i < rvobj.data.dictionary.size ; i++) {
+      if (strcmp(rvobj.data.dictionary.items[i].key.data, "tabbed") == 0) {
+        // should we check items[i].value.type here?
+        tabbed = rvobj.data.dictionary.items[i].value.data.boolean;
+      } else if (strcmp(rvobj.data.dictionary.items[i].key.data, "should_exit") == 0) {
+        should_exit = rvobj.data.dictionary.items[i].value.data.boolean;
+      } else if (strcmp(rvobj.data.dictionary.items[i].key.data, "files") == 0) {
+        files = (int)rvobj.data.dictionary.items[i].value.data.integer;
+      }
+    }
+
+    if (should_exit) {
+      mch_exit(0);
+    } else {
+      if (tabbed) {
+        params->window_count = files;
+        params->window_layout = WIN_TABS;
+      }
+    }
+}
+
 /// Scan the command line arguments.
 static void command_line_scan(mparm_T *parmp)
 {
@@ -793,6 +861,9 @@ static void command_line_scan(mparm_T *parmp)
           // "--version" give version message
           // "--noplugin[s]" skip plugins
           // "--cmd <cmd>" execute cmd before vimrc
+          // "--remote" open file on remote instance
+          // "--server" name of vim server to send to or name
+          // of server to become
           if (STRICMP(argv[0] + argv_idx, "help") == 0) {
             usage();
             mch_exit(0);
@@ -833,6 +904,11 @@ static void command_line_scan(mparm_T *parmp)
             // Do nothing: file args are always literal. #7679
           } else if (STRNICMP(argv[0] + argv_idx, "noplugin", 8) == 0) {
             p_lpl = false;
+          } else if (STRNICMP(argv[0] + argv_idx, "remote", 6) == 0) {
+            parmp->remote = parmp->argc - argc;
+          } else if (STRNICMP(argv[0] + argv_idx, "server", 6) == 0) {
+            want_argument = true;
+            argv_idx += 6;
           } else if (STRNICMP(argv[0] + argv_idx, "cmd", 3) == 0) {
             want_argument = true;
             argv_idx += 3;
@@ -1090,6 +1166,9 @@ static void command_line_scan(mparm_T *parmp)
             } else if (strequal(argv[-1], "--listen")) {
               // "--listen {address}"
               parmp->listen_addr = argv[0];
+            } else if (strequal(argv[-1], "--server")) {
+              // "--server {address}"
+              parmp->server_addr = argv[0];
             }
             // "--startuptime <file>" already handled
             break;
@@ -1257,6 +1336,8 @@ static void init_params(mparm_T *paramp, int argc, char **argv)
   paramp->use_debug_break_level = -1;
   paramp->window_count = -1;
   paramp->listen_addr = NULL;
+  paramp->server_addr = NULL;
+  paramp->remote = 0;
 }
 
 /// Initialize global startuptime file if "--startuptime" passed as an argument.
@@ -1999,6 +2080,8 @@ static void usage(void)
   mch_msg(_("  --headless            Don't start a user interface\n"));
   mch_msg(_("  --listen <address>    Serve RPC API from this address\n"));
   mch_msg(_("  --noplugin            Don't load plugins\n"));
+  mch_msg(_("  --remote[-subcommand] Execute commands remotey on a server\n"));
+  mch_msg(_("  --server <address>    Specify RPC server to send commands to\n"));
   mch_msg(_("  --startuptime <file>  Write startup timing messages to <file>\n"));
   mch_msg(_("\nSee \":help startup-options\" for all options.\n"));
 }

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -1,0 +1,60 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local neq = helpers.neq
+local funcs = helpers.funcs
+local nvim_prog_abs = helpers.nvim_prog_abs
+local merge_args = helpers.merge_args
+local spawn = helpers.spawn
+local set_session = helpers.set_session
+local expect = helpers.expect
+
+describe("remote --server client", function()
+  local server, client, address, pid
+  before_each(function()
+    local nvim_argv = merge_args(helpers.nvim_argv, {'--headless'})
+    server = spawn(nvim_argv)
+    set_session(server)
+    address = funcs.serverlist()[1]
+    pid = funcs.getpid()
+
+    client = spawn(nvim_argv)
+    set_session(client, true)
+    neq(funcs.getpid(), pid)
+  end)
+
+  it('--remote-expr', function()
+    eq(pid..'\r\n',
+       funcs.system({nvim_prog_abs(), '-u', 'NONE', '-i', 'NONE',
+                    '--server', address, '--remote-expr', 'getpid()'}))
+  end)
+
+  it('--remote-lua', function()
+    eq('{ "a", "", "b" }\r\n',
+       funcs.system({nvim_prog_abs(), '-u', 'NONE', '-i', 'NONE',
+                     '--server', address, '--remote-lua', 'vim.split("a::b", ":")'}))
+
+    eq('3\r\n',
+       funcs.system({nvim_prog_abs(), '-u', 'NONE', '-i', 'NONE',
+                     '--server', address, '--remote-lua', 'return 3'}))
+
+    eq("[string \"remote\"]:1: '=' expected near 'error'\r\n",
+       funcs.system({nvim_prog_abs(), '-u', 'NONE', '-i', 'NONE',
+                     '--server', address, '--remote-lua', 'syntax error'}))
+  end)
+
+  it('--remote-send', function()
+    eq('',
+       funcs.system({nvim_prog_abs(), '-u', 'NONE', '-i', 'NONE',
+                    '--server', address, '--remote-send', 'iwords'}))
+    set_session(server)
+    expect([[words]])
+    eq('i', funcs.mode())
+  end)
+
+  it('error handling', function()
+    -- TODO: wrong address
+    -- invalid subcommand
+  end)
+
+end)


### PR DESCRIPTION
Both clientserver #8326  and remote TUI #10071 requires connecting to a server address specified on the cmdline. This implements basic client support and a _subset_ of --remote commands ("send", "expr" and nvim specific "lua" subcommand). Both a complete --remote implementation (which will require a bit more arg parsing logic than #8326 has already done) and TUI attachment will be done upon this shared client code.