### PR TITLE
vim-patch:7.4.1732,8.1.{0535,1922}

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -490,7 +490,8 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1,
   }
 
   if (tp == curtab) {
-    diff_redraw(true);
+    // Don't redraw right away, this updates the diffs, which can be slow.
+    need_diff_redraw = true;
 
     // Need to recompute the scroll binding, may remove or add filler
     // lines (e.g., when adding lines above w_topline). But it's slow when
@@ -634,8 +635,9 @@ static int diff_check_sanity(tabpage_T *tp, diff_T *dp)
 /// Mark all diff buffers in the current tab page for redraw.
 ///
 /// @param dofold Also recompute the folds
-static void diff_redraw(int dofold)
+void diff_redraw(int dofold)
 {
+  need_diff_redraw = false;
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (!wp->w_p_diff) {
       continue;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1305,9 +1305,11 @@ normalchar:
 static void insert_do_complete(InsertState *s)
 {
   compl_busy = true;
+  disable_fold_update++;  // don't redraw folds here
   if (ins_complete(s->c, true) == FAIL) {
     compl_cont_status = 0;
   }
+  disable_fold_update--;
   compl_busy = false;
 }
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -771,6 +771,10 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
     return;
   }
 
+  if (disable_fold_update > 0) {
+    return;
+  }
+
   // Mark all folds from top to bot as maybe-small.
   fold_T *fp;
   (void)foldFind(&wp->w_folds, top, &fp);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -775,6 +775,11 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
     return;
   }
 
+  if (need_diff_redraw) {
+    // will update later
+    return;
+  }
+
   // Mark all folds from top to bot as maybe-small.
   fold_T *fp;
   (void)foldFind(&wp->w_folds, top, &fp);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -839,6 +839,8 @@ extern char_u *compiled_sys;
  * directory is not a local directory, globaldir is NULL. */
 EXTERN char_u   *globaldir INIT(= NULL);
 
+EXTERN int disable_fold_update INIT(= 0);
+
 /* Whether 'keymodel' contains "stopsel" and "startsel". */
 EXTERN int km_stopsel INIT(= FALSE);
 EXTERN int km_startsel INIT(= FALSE);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -741,11 +741,12 @@ EXTERN bool KeyTyped;                    // true if user typed current char
 EXTERN int KeyStuffed;                   // TRUE if current char from stuffbuf
 EXTERN int maptick INIT(= 0);            // tick for each non-mapped char
 
-EXTERN int must_redraw INIT(= 0);           // type of redraw necessary
-EXTERN bool skip_redraw INIT(= false);      // skip redraw once
-EXTERN bool do_redraw INIT(= false);        // extra redraw once
-EXTERN bool must_redraw_pum INIT(= false);  // redraw pum. NB: must_redraw
-                                            // should also be set.
+EXTERN int must_redraw INIT(= 0);              // type of redraw necessary
+EXTERN bool skip_redraw INIT(= false);         // skip redraw once
+EXTERN bool do_redraw INIT(= false);           // extra redraw once
+EXTERN bool need_diff_redraw INIT(= false);    // need to call diff_redraw()
+EXTERN bool must_redraw_pum INIT(= false);     // redraw pum. NB: must_redraw
+                                               // should also be set.
 
 EXTERN int need_highlight_changed INIT(= true);
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -286,6 +286,11 @@ int update_screen(int type)
     return FAIL;
   }
 
+  // May have postposed updated diffs.
+  if (need_diff_redraw) {
+    diff_redraw(true);
+  }
+
   if (must_redraw) {
     if (type < must_redraw)         /* use maximal type */
       type = must_redraw;


### PR DESCRIPTION
**vim-patch:7.4.1732**

```
Problem:    Folds may close when using autocomplete. (Anmol Sethi)
Solution:   Increment/decrement disable_fold. (Christian Brabandt)
```

https://github.com/vim/vim/commit/429fcfbf9a9275367fe9441a50a3dcd773497d84

**vim-patch:8.1.0535: increment/decrement might get interrupted by updating folds**

```
Problem:    Increment/decrement might get interrupted by updating folds.
Solution:   Disable fold updating for a moment. (Christian Brabandt)
```

https://github.com/vim/vim/commit/6b731886ca94d66b9bdedfb7e603af44a6400399

**vim-patch:8.1.1922: in diff mode global operations can be very slow**

```
Problem:    In diff mode global operations can be very slow.
Solution:   Do not call diff_redraw() many times, call it once when redrawing.
            And also don't update folds multiple times.
```

https://github.com/vim/vim/commit/4f57eefe1e84b5a90e08474092ea6fc8825ad5c9