### PR TITLE
Fix capitalization of event names in output of getcompletion()

### DIFF
--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -21,9 +21,9 @@ return {
     'BufWritePre',            -- before writing a buffer
     'ChanInfo',               -- info was received about channel
     'ChanOpen',               -- channel was opened
-    'CmdLineChanged',         -- command line was modified
-    'CmdLineEnter',           -- after entering cmdline mode
-    'CmdLineLeave',           -- before leaving cmdline mode
+    'CmdlineChanged',         -- command line was modified
+    'CmdlineEnter',           -- after entering cmdline mode
+    'CmdlineLeave',           -- before leaving cmdline mode
     'CmdUndefined',           -- command undefined
     'CmdWinEnter',            -- after entering the cmdline window
     'CmdWinLeave',            -- before leaving the cmdline window


### PR DESCRIPTION
The names of the events `CmdlineChanged`, `CmdlineEnter`, `CmdlineLeave` are capitalized in an inconsistent way in the output of `getcompletion()`:

    :echo getcompletion('cmdl', 'event')
    ['CmdLineChanged', 'CmdLineEnter', 'CmdLineLeave']
         ^                 ^               ^

To be consistent with Vim and the help (e.g. `:h CmdlineChanged`), the output should be:

    ['CmdlineChanged', 'CmdlineEnter', 'CmdlineLeave']
         ^                 ^               ^

I know it's a minor issue, but it caused a plugin I use to behave unexpectedly:

    call filter(my_events, {_,v -> index(getcompletion('', 'event'), v) >= 0})

I fixed it by ignoring the case during the comparison:

    call filter(my_events, {_,v -> index(getcompletion('', 'event'), v, 0, 1) >= 0})
                                                                           ^

I still thought it was worth being reported/changed.
