### PR TITLE
v:lua and better error messages for vimL->lua

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1737,6 +1737,10 @@ v:lnum		Line number for the 'foldexpr' |fold-expr|, 'formatexpr' and
 		expressions is being evaluated.  Read-only when in the
 		|sandbox|.
 
+						*v:lua* *lua-variable*
+v:lua		Prefix for calling lua functions from expressions.
+		See |v:lua-call| for more information.
+
 					*v:mouse_win* *mouse_win-variable*
 v:mouse_win	Window number for a mouse click obtained with |getchar()|.
 		First window has number 1, like with |winnr()|.  The value is

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -327,6 +327,38 @@ Return value is also always converted. When converting,
 |msgpack-special-dict|s are treated specially.
 
 ==============================================================================
+v:lua function calls						*v:lua-call*
+
+The special prefix `v:lua` can be used in vimL expressions to call lua
+functions which are global or nested inside global tables. The expression
+`v:lua.func(arg1, arg2)` is equivalent to executing the lua code
+`return func(...)` where the args have been converted to lua values. In addition
+`v:lua.somemod.func(args)` will work like `return somemod.func(...)` .
+
+`v:lua` can also be used in function options like 'omnifunc'. As an
+example, consider the following lua implementation of an omnifunc: >
+
+    function mymod.omnifunc(findstart, base)
+      if findstart == 1 then
+        return 0
+      else
+        return {'stuff', 'steam', 'strange things'}
+      end
+    end
+    vim.api.nvim_buf_set_option(0, 'omnifunc', 'v:lua.mymod.omnifunc')
+
+A limitation is that the plugin module ("mymod" in this case) must
+be made available as a global.
+
+Note: `v:lua` without a call is not allowed in a vimL expression. Funcrefs
+to lua functions cannot be created. The following are errors: >
+
+    let g:Myvar = v:lua.myfunc
+    call SomeFunc(v:lua.mycallback)
+    let g:foo = v:lua
+    let g:foo = v:['lua']
+
+==============================================================================
 Lua standard modules					*lua-stdlib*
 
 The Nvim Lua "standard library" (stdlib) is the `vim` module, which exposes

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -117,6 +117,7 @@ typedef enum {
     VV_TYPE_BOOL,
     VV_ECHOSPACE,
     VV_EXITING,
+    VV_LUA,
 } VimVarIndex;
 
 /// All recognized msgpack types

--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -155,41 +155,41 @@ describe('luaeval(vim.api.…)', function()
 
   it('errors out correctly when working with API', function()
     -- Conversion errors
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Cannot convert given lua type',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Cannot convert given lua type',
        exc_exec([[call luaeval("vim.api.nvim__id(vim.api.nvim__id)")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Cannot convert given lua table',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Cannot convert given lua table',
        exc_exec([[call luaeval("vim.api.nvim__id({1, foo=42})")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Cannot convert given lua type',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Cannot convert given lua type',
        exc_exec([[call luaeval("vim.api.nvim__id({42, vim.api.nvim__id})")]]))
     -- Errors in number of arguments
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected 1 argument',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 1 argument',
        exc_exec([[call luaeval("vim.api.nvim__id()")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected 1 argument',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 1 argument',
        exc_exec([[call luaeval("vim.api.nvim__id(1, 2)")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected 2 arguments',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 2 arguments',
        exc_exec([[call luaeval("vim.api.nvim_set_var(1, 2, 3)")]]))
     -- Error in argument types
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected lua string',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua string',
        exc_exec([[call luaeval("vim.api.nvim_set_var(1, 2)")]]))
 
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected lua number',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua number',
        exc_exec([[call luaeval("vim.api.nvim_buf_get_lines(0, 'test', 1, false)")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Number is not integral',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Number is not integral',
        exc_exec([[call luaeval("vim.api.nvim_buf_get_lines(0, 1.5, 1, false)")]]))
 
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected lua table',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
        exc_exec([[call luaeval("vim.api.nvim__id_float('test')")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Unexpected type',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
        exc_exec([[call luaeval("vim.api.nvim__id_float({[vim.type_idx]=vim.types.dictionary})")]]))
 
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected lua table',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
        exc_exec([[call luaeval("vim.api.nvim__id_array(1)")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Unexpected type',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
        exc_exec([[call luaeval("vim.api.nvim__id_array({[vim.type_idx]=vim.types.dictionary})")]]))
 
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Expected lua table',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
        exc_exec([[call luaeval("vim.api.nvim__id_dictionary(1)")]]))
-    eq('Vim(call):E5108: Error while calling lua chunk for luaeval(): [string "<VimL compiled string>"]:1: Unexpected type',
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
        exc_exec([[call luaeval("vim.api.nvim__id_dictionary({[vim.type_idx]=vim.types.array})")]]))
     -- TODO: check for errors with Tabpage argument
     -- TODO: check for errors with Window argument

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -13,6 +13,7 @@ local source = helpers.source
 local dedent = helpers.dedent
 local command = helpers.command
 local exc_exec = helpers.exc_exec
+local pcall_err = helpers.pcall_err
 local write_file = helpers.write_file
 local redir_exec = helpers.redir_exec
 local curbufmeths = helpers.curbufmeths
@@ -42,16 +43,16 @@ describe(':lua command', function()
     eq({'', 'ETTS', 'TTSE', 'STTE'}, curbufmeths.get_lines(0, 100, false))
   end)
   it('throws catchable errors', function()
-    eq([[Vim(lua):E5104: Error while creating lua chunk: [string "<VimL compiled string>"]:1: unexpected symbol near ')']],
-       exc_exec('lua ()'))
-    eq([[Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: TEST]],
+    eq([[Vim(lua):E5107: Error loading lua [string ":lua"]:1: unexpected symbol near ')']],
+       pcall_err(command, 'lua ()'))
+    eq([[Vim(lua):E5108: Error executing lua [string ":lua"]:1: TEST]],
        exc_exec('lua error("TEST")'))
-    eq([[Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: Invalid buffer id]],
+    eq([[Vim(lua):E5108: Error executing lua [string ":lua"]:1: Invalid buffer id]],
        exc_exec('lua vim.api.nvim_buf_set_lines(-10, 1, 1, false, {"TEST"})'))
     eq({''}, curbufmeths.get_lines(0, 100, false))
   end)
   it('works with NULL errors', function()
-    eq([=[Vim(lua):E5105: Error while calling lua chunk: [NULL]]=],
+    eq([=[Vim(lua):E5108: Error executing lua [NULL]]=],
        exc_exec('lua error(nil)'))
   end)
   it('accepts embedded NLs without heredoc', function()
@@ -74,7 +75,7 @@ describe(':lua command', function()
   it('works with long strings', function()
     local s = ('x'):rep(100500)
 
-    eq('\nE5104: Error while creating lua chunk: [string "<VimL compiled string>"]:1: unfinished string near \'<eof>\'', redir_exec(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s})'):format(s)))
+    eq('\nE5107: Error loading lua [string ":lua"]:1: unfinished string near \'<eof>\'', redir_exec(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s})'):format(s)))
     eq({''}, curbufmeths.get_lines(0, -1, false))
 
     eq('', redir_exec(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s"})'):format(s)))
@@ -82,7 +83,7 @@ describe(':lua command', function()
   end)
 
   it('can show multiline error messages', function()
-    local screen = Screen.new(50,10)
+    local screen = Screen.new(40,10)
     screen:attach()
     screen:set_default_attr_ids({
       [1] = {bold = true, foreground = Screen.colors.Blue1},
@@ -92,51 +93,51 @@ describe(':lua command', function()
     })
 
     feed(':lua error("fail\\nmuch error\\nsuch details")<cr>')
-    screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      {3:E5105: Error while calling lua chunk: [string "<Vi}|
-      {3:mL compiled string>"]:1: fail}                     |
-      {3:much error}                                        |
-      {3:such details}                                      |
-      {4:Press ENTER or type command to continue}^           |
-    ]])
+    screen:expect{grid=[[
+                                              |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {2:                                        }|
+      {3:E5108: Error executing lua [string ":lua}|
+      {3:"]:1: fail}                              |
+      {3:much error}                              |
+      {3:such details}                            |
+      {4:Press ENTER or type command to continue}^ |
+    ]]}
     feed('<cr>')
-    screen:expect([[
-      ^                                                  |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-                                                        |
-    ]])
-    eq('E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
+    screen:expect{grid=[[
+      ^                                        |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]]}
+    eq('E5108: Error executing lua [string ":lua"]:1: fail\nmuch error\nsuch details', eval('v:errmsg'))
 
     local status, err = pcall(command,'lua error("some error\\nin a\\nAPI command")')
-    local expected = 'Vim(lua):E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: some error\nin a\nAPI command'
+    local expected = 'Vim(lua):E5108: Error executing lua [string ":lua"]:1: some error\nin a\nAPI command'
     eq(false, status)
     eq(expected, string.sub(err, -string.len(expected)))
 
     feed(':messages<cr>')
-    screen:expect([[
-                                                        |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {2:                                                  }|
-      {3:E5105: Error while calling lua chunk: [string "<Vi}|
-      {3:mL compiled string>"]:1: fail}                     |
-      {3:much error}                                        |
-      {3:such details}                                      |
-      {4:Press ENTER or type command to continue}^           |
-    ]])
+    screen:expect{grid=[[
+                                              |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {2:                                        }|
+      {3:E5108: Error executing lua [string ":lua}|
+      {3:"]:1: fail}                              |
+      {3:much error}                              |
+      {3:such details}                            |
+      {4:Press ENTER or type command to continue}^ |
+    ]]}
   end)
 end)
 
@@ -167,13 +168,13 @@ describe(':luado command', function()
     eq({''}, curbufmeths.get_lines(0, -1, false))
   end)
   it('fails on errors', function()
-    eq([[Vim(luado):E5109: Error while creating lua chunk: [string "<VimL compiled string>"]:1: unexpected symbol near ')']],
+    eq([[Vim(luado):E5109: Error loading lua: [string ":luado"]:1: unexpected symbol near ')']],
        exc_exec('luado ()'))
-    eq([[Vim(luado):E5111: Error while calling lua function: [string "<VimL compiled string>"]:1: attempt to perform arithmetic on global 'liness' (a nil value)]],
+    eq([[Vim(luado):E5111: Error calling lua: [string ":luado"]:1: attempt to perform arithmetic on global 'liness' (a nil value)]],
        exc_exec('luado return liness + 1'))
   end)
   it('works with NULL errors', function()
-    eq([=[Vim(luado):E5111: Error while calling lua function: [NULL]]=],
+    eq([=[Vim(luado):E5111: Error calling lua: [NULL]]=],
        exc_exec('luado error(nil)'))
   end)
   it('fails in sandbox when needed', function()
@@ -185,7 +186,7 @@ describe(':luado command', function()
   it('works with long strings', function()
     local s = ('x'):rep(100500)
 
-    eq('\nE5109: Error while creating lua chunk: [string "<VimL compiled string>"]:1: unfinished string near \'<eof>\'', redir_exec(('luado return "%s'):format(s)))
+    eq('\nE5109: Error loading lua: [string ":luado"]:1: unfinished string near \'<eof>\'', redir_exec(('luado return "%s'):format(s)))
     eq({''}, curbufmeths.get_lines(0, -1, false))
 
     eq('', redir_exec(('luado return "%s"'):format(s)))

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -54,11 +54,12 @@ describe('print', function()
       v_tblout = setmetatable({}, meta_tblout)
     ]])
     eq('', redir_exec('luafile ' .. fname))
-    eq('\nE5105: Error while calling lua chunk: E5114: Error while converting print argument #2: [NULL]',
+    -- TODO(bfredl): these look weird, print() should not use "E5114:" style errors..
+    eq('\nE5108: Error executing lua E5114: Error while converting print argument #2: [NULL]',
        redir_exec('lua print("foo", v_nilerr, "bar")'))
-    eq('\nE5105: Error while calling lua chunk: E5114: Error while converting print argument #2: Xtest-functional-lua-overrides-luafile:2: abc',
+    eq('\nE5108: Error executing lua E5114: Error while converting print argument #2: Xtest-functional-lua-overrides-luafile:2: abc',
        redir_exec('lua print("foo", v_abcerr, "bar")'))
-    eq('\nE5105: Error while calling lua chunk: E5114: Error while converting print argument #2: <Unknown error: lua_tolstring returned NULL for tostring result>',
+    eq('\nE5108: Error executing lua E5114: Error while converting print argument #2: <Unknown error: lua_tolstring returned NULL for tostring result>',
        redir_exec('lua print("foo", v_tblout, "bar")'))
   end)
   it('prints strings with NULs and NLs correctly', function()
@@ -156,7 +157,8 @@ describe('debug.debug', function()
       lua_debug> ^                                          |
     ]])
     feed('<C-c>')
-    screen:expect([[
+    screen:expect{grid=[[
+      {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -167,11 +169,10 @@ describe('debug.debug', function()
       lua_debug> print("TEST")                             |
       TEST                                                 |
                                                            |
-      {E:E5105: Error while calling lua chunk: [string "<VimL }|
-      {E:compiled string>"]:5: attempt to perform arithmetic o}|
-      {E:n local 'a' (a nil value)}                            |
+      {E:E5108: Error executing lua [string ":lua"]:5: attempt}|
+      {E: to perform arithmetic on local 'a' (a nil value)}    |
       Interrupt: {cr:Press ENTER or type command to continue}^   |
-    ]])
+    ]]}
     feed('<C-l>:lua Test()\n')
     screen:expect([[
       {0:~                                                    }|
@@ -190,7 +191,8 @@ describe('debug.debug', function()
       lua_debug> ^                                          |
     ]])
     feed('\n')
-    screen:expect([[
+    screen:expect{grid=[[
+      {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -201,11 +203,10 @@ describe('debug.debug', function()
       {0:~                                                    }|
       nil                                                  |
       lua_debug>                                           |
-      {E:E5105: Error while calling lua chunk: [string "<VimL }|
-      {E:compiled string>"]:5: attempt to perform arithmetic o}|
-      {E:n local 'a' (a nil value)}                            |
+      {E:E5108: Error executing lua [string ":lua"]:5: attempt}|
+      {E: to perform arithmetic on local 'a' (a nil value)}    |
       {cr:Press ENTER or type command to continue}^              |
-    ]])
+    ]]}
   end)
 
   it("can be safely exited with 'cont'", function()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -747,7 +747,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|
       {1:~                        }|
     ]], messages={{
-        content = {{'E5105: Error while calling lua chunk: [string "<VimL compiled string>"]:1: such\nmultiline\nerror', 2}},
+        content = {{'E5108: Error executing lua [string ":lua"]:1: such\nmultiline\nerror', 2}},
         kind = "lua_error"
      }}}
   end)
@@ -1146,97 +1146,96 @@ aliquip ex ea commodo consequat.]])
   it('handles wrapped lines with line scroll', function()
     feed(':lua error(_G.x)<cr>')
     screen:expect{grid=[[
-      {2:E5105: Error while calling lua chun}|
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:E5108: Error executing lua [string }|
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
+      {2:a aliqua.}                          |
       {4:-- More --}^                         |
     ]]}
 
     feed('j')
     screen:expect{grid=[[
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
       {2:a aliqua.}                          |
+      {2:Ut enim ad minim veniam, quis nostr}|
       {4:-- More --}^                         |
     ]]}
 
     feed('k')
     screen:expect{grid=[[
-      {2:E5105: Error while calling lua chun}|
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:E5108: Error executing lua [string }|
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
+      {2:a aliqua.}                          |
       {4:-- More --}^                         |
     ]]}
 
     feed('j')
     screen:expect{grid=[[
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
       {2:a aliqua.}                          |
+      {2:Ut enim ad minim veniam, quis nostr}|
       {4:-- More --}^                         |
     ]]}
-
   end)
 
   it('handles wrapped lines with page scroll', function()
     feed(':lua error(_G.x)<cr>')
     screen:expect{grid=[[
-      {2:E5105: Error while calling lua chun}|
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:E5108: Error executing lua [string }|
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
+      {2:a aliqua.}                          |
       {4:-- More --}^                         |
     ]]}
     feed('d')
     screen:expect{grid=[[
-      {2:adipisicing elit, sed do eiusmod te}|
-      {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
       {2:a aliqua.}                          |
       {2:Ut enim ad minim veniam, quis nostr}|
       {2:ud xercitation}                     |
       {2:ullamco laboris nisi ut}            |
-      {4:-- More --}^                         |
+      {2:aliquip ex ea commodo consequat.}   |
+      {4:Press ENTER or type command to cont}|
+      {4:inue}^                               |
     ]]}
     feed('u')
     screen:expect{grid=[[
-      {2:E5105: Error while calling lua chun}|
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:E5108: Error executing lua [string }|
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
+      {2:a aliqua.}                          |
       {4:-- More --}^                         |
     ]]}
     feed('d')
     screen:expect{grid=[[
-      {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
       {2:a aliqua.}                          |
       {2:Ut enim ad minim veniam, quis nostr}|
       {2:ud xercitation}                     |
       {2:ullamco laboris nisi ut}            |
+      {2:aliquip ex ea commodo consequat.}   |
       {4:-- More --}^                         |
     ]]}
   end)
@@ -1246,49 +1245,49 @@ aliquip ex ea commodo consequat.]])
 
     feed(':lua error(_G.x)<cr>')
     screen:expect{grid=[[
-      {3:E5105: Error while calling lua chun}|
-      {3:k: [string "<VimL compiled string>"}|
-      {3:]:1: Lorem ipsum dolor sit amet, co}|
-      {3:nsectetur}{5:                          }|
+      {3:E5108: Error executing lua [string }|
+      {3:":lua"]:1: Lorem ipsum dolor sit am}|
+      {3:et, consectetur}{5:                    }|
       {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
+      {3:a aliqua.}{5:                          }|
       {6:-- More --}{5:^                         }|
     ]]}
 
     feed('j')
     screen:expect{grid=[[
-      {3:k: [string "<VimL compiled string>"}|
-      {3:]:1: Lorem ipsum dolor sit amet, co}|
-      {3:nsectetur}{5:                          }|
+      {3:":lua"]:1: Lorem ipsum dolor sit am}|
+      {3:et, consectetur}{5:                    }|
       {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
       {3:a aliqua.}{5:                          }|
+      {3:Ut enim ad minim veniam, quis nostr}|
       {6:-- More --}{5:^                         }|
     ]]}
 
     feed('k')
     screen:expect{grid=[[
-      {3:E5105: Error while calling lua chun}|
-      {3:k: [string "<VimL compiled string>"}|
-      {3:]:1: Lorem ipsum dolor sit amet, co}|
-      {3:nsectetur}{5:                          }|
+      {3:E5108: Error executing lua [string }|
+      {3:":lua"]:1: Lorem ipsum dolor sit am}|
+      {3:et, consectetur}{5:                    }|
       {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
+      {3:a aliqua.}{5:                          }|
       {6:-- More --}{5:^                         }|
     ]]}
 
     feed('j')
     screen:expect{grid=[[
-      {3:k: [string "<VimL compiled string>"}|
-      {3:]:1: Lorem ipsum dolor sit amet, co}|
-      {3:nsectetur}{5:                          }|
+      {3:":lua"]:1: Lorem ipsum dolor sit am}|
+      {3:et, consectetur}{5:                    }|
       {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
       {3:a aliqua.}{5:                          }|
+      {3:Ut enim ad minim veniam, quis nostr}|
       {6:-- More --}{5:^                         }|
     ]]}
   end)
@@ -1297,46 +1296,46 @@ aliquip ex ea commodo consequat.]])
     command("hi MsgArea guisp=Yellow")
     feed(':lua error(_G.x)<cr>')
     screen:expect{grid=[[
-      {3:E5105: Error while calling lua chun}|
-      {3:k: [string "<VimL compiled string>"}|
-      {3:]:1: Lorem ipsum dolor sit amet, co}|
-      {3:nsectetur}{5:                          }|
+      {3:E5108: Error executing lua [string }|
+      {3:":lua"]:1: Lorem ipsum dolor sit am}|
+      {3:et, consectetur}{5:                    }|
       {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
+      {3:a aliqua.}{5:                          }|
       {6:-- More --}{5:^                         }|
     ]]}
     feed('d')
     screen:expect{grid=[[
-      {3:adipisicing elit, sed do eiusmod te}|
-      {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
       {3:a aliqua.}{5:                          }|
       {3:Ut enim ad minim veniam, quis nostr}|
       {3:ud xercitation}{5:                     }|
       {3:ullamco laboris nisi ut}{5:            }|
-      {6:-- More --}{5:^                         }|
+      {3:aliquip ex ea commodo consequat.}{5:   }|
+      {6:Press ENTER or type command to cont}|
+      {6:inue}{5:^                               }|
     ]]}
     feed('u')
     screen:expect{grid=[[
-      {3:E5105: Error while calling lua chun}|
-      {3:k: [string "<VimL compiled string>"}|
-      {3:]:1: Lorem ipsum dolor sit amet, co}|
-      {3:nsectetur}{5:                          }|
+      {3:E5108: Error executing lua [string }|
+      {3:":lua"]:1: Lorem ipsum dolor sit am}|
+      {3:et, consectetur}{5:                    }|
       {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
+      {3:a aliqua.}{5:                          }|
       {6:-- More --}{5:^                         }|
     ]]}
     feed('d')
     screen:expect{grid=[[
-      {3:adipisicing elit, sed do eiusmod te}|
       {3:mpor}{5:                               }|
       {3:incididunt ut labore et dolore magn}|
       {3:a aliqua.}{5:                          }|
       {3:Ut enim ad minim veniam, quis nostr}|
       {3:ud xercitation}{5:                     }|
       {3:ullamco laboris nisi ut}{5:            }|
+      {3:aliquip ex ea commodo consequat.}{5:   }|
       {6:-- More --}{5:^                         }|
     ]]}
   end)
@@ -1473,23 +1472,23 @@ aliquip ex ea commodo consequat.]])
   it('can be resized', function()
     feed(':lua error(_G.x)<cr>')
     screen:expect{grid=[[
-      {2:E5105: Error while calling lua chun}|
-      {2:k: [string "<VimL compiled string>"}|
-      {2:]:1: Lorem ipsum dolor sit amet, co}|
-      {2:nsectetur}                          |
+      {2:E5108: Error executing lua [string }|
+      {2:":lua"]:1: Lorem ipsum dolor sit am}|
+      {2:et, consectetur}                    |
       {2:adipisicing elit, sed do eiusmod te}|
       {2:mpor}                               |
       {2:incididunt ut labore et dolore magn}|
+      {2:a aliqua.}                          |
       {4:-- More --}^                         |
     ]]}
 
     -- responds to resize, but text is not reflown
     screen:try_resize(45, 5)
     screen:expect{grid=[[
-      {2:nsectetur}                                    |
       {2:adipisicing elit, sed do eiusmod te}          |
       {2:mpor}                                         |
       {2:incididunt ut labore et dolore magn}          |
+      {2:a aliqua.}                                    |
       {4:-- More --}^                                   |
     ]]}
 
@@ -1497,14 +1496,14 @@ aliquip ex ea commodo consequat.]])
     -- text is not reflown; existing lines get cut
     screen:try_resize(30, 12)
     screen:expect{grid=[[
-      {2:E5105: Error while calling lua}|
-      {2:k: [string "<VimL compiled str}|
-      {2:]:1: Lorem ipsum dolor sit ame}|
-      {2:nsectetur}                     |
+      {2:E5108: Error executing lua [st}|
+      {2:":lua"]:1: Lorem ipsum dolor s}|
+      {2:et, consectetur}               |
       {2:adipisicing elit, sed do eiusm}|
       {2:mpore}                         |
       {2:incididunt ut labore et dolore}|
-      {2: magn}                         |
+      {2:a aliqua.}                     |
+                                    |
                                     |
                                     |
                                     |
@@ -1515,18 +1514,18 @@ aliquip ex ea commodo consequat.]])
     -- wrapped at the new screen size.
     feed('<cr>')
     screen:expect{grid=[[
-      {2:k: [string "<VimL compiled str}|
-      {2:]:1: Lorem ipsum dolor sit ame}|
-      {2:nsectetur}                     |
+      {2:et, consectetur}               |
       {2:adipisicing elit, sed do eiusm}|
       {2:mpore}                         |
       {2:incididunt ut labore et dolore}|
-      {2: magna aliqua.}                |
+      {2:a aliqua.}                     |
       {2:Ut enim ad minim veniam, quis }|
       {2:nostrud xercitation}           |
       {2:ullamco laboris nisi ut}       |
       {2:aliquip ex ea commodo consequa}|
-      {4:-- More --}^                    |
+      {2:t.}                            |
+      {4:Press ENTER or type command to}|
+      {4: continue}^                     |
     ]]}
 
     feed('q')


### PR DESCRIPTION
Works:

    " useless test, but can has roundtrip
    :echo v:lua.vim.fn.sin(1)

Also works:

    function superop(kind)
      print(kind)
    end
    -- note:  only '*func' option is demo'd here, later on we should have
    -- vim.map_operator("<plug>(whatever)", superop) 
    vim.api.nvim_command("set opfunc=v:lua.superop")
    vim.api.nvim_command("map <leader>w g@")

~~Notoriously does not work (will fix tomorrow maybe):~~ works now

    :call v:lua.func()

On purpose does not work:

    " not a value, we don't want to commit to store LuaRef in typvals for now
    :echo v:lua.vim.fn.sin 

ref #6723 #11306 etc

