### PR TITLE
vim-patch.sh: multiline printf -> heredoc

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -501,13 +501,15 @@ show_vimpatches() {
     fi
   done
 
-  printf "\nInstructions:
+  cat << EOF
+
+Instructions:
   To port one of the above patches to Neovim, execute this script with the patch revision as argument and follow the instructions, e.g.
-  '%s -p v8.0.1234', or '%s -P v8.0.1234'
+  '${BASENAME} -p v8.0.1234', or '${BASENAME} -P v8.0.1234'
 
   NOTE: Please port the _oldest_ patch if you possibly can.
-        You can use '%s -l path/to/file' to see what patches are missing for a file.
-" "${BASENAME}" "${BASENAME}" "${BASENAME}"
+        You can use '${BASENAME} -l path/to/file' to see what patches are missing for a file.
+EOF
 }
 
 review_commit() {


### PR DESCRIPTION
The following script is cut out from vim-patch.sh:

```sh
#!/usr/bin/env bash

BASENAME=vim-patch.sh

printf "\nInstructions:
To port one of the above patches to Neovim, execute this script with the patch revision as argument and follow the instructions, e.g.
'%s -p v8.0.1234', or '%s -P v8.0.1234'

NOTE: Please port the _oldest_ patch if you possibly can.
      You can use '%s -l path/to/file' to see what patches are missing for a file.
" "${BASENAME}" "${BASENAME}" "${BASENAME}"
```

The code itself should be correct, but shellcheck 0.7.0 says:

```
In /tmp/test.sh line 5:
  printf "\nInstructions:
         ^-- SC2183: This format string has 2 variables, but is passed 3 arguments.
```

We also had a problem before that a `%s` was added, but the accompanying
argument to printf was forgotten. 

Using a heredoc is less error-prone, since we insert variables directly and shellcheck 0.7.0 succeeds in parsing it.