### PR TITLE
bufhl: use extmark column adjustment for bufhl

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5599,11 +5599,7 @@ insertchar (
     do_digraph(-1);                     /* clear digraphs */
     do_digraph(buf[i-1]);               /* may be the start of a digraph */
     buf[i] = NUL;
-    colnr_T col_start = curwin->w_cursor.col;
     ins_str(buf);
-    extmark_col_adjust(curbuf, curwin->w_cursor.lnum,
-                       (colnr_T)(col_start + 1), 0,
-                       (long)STRLEN(buf), kExtmarkUndo);
     if (flags & INSCHAR_CTRLV) {
       redo_literal(*buf);
       i = 1;
@@ -5614,9 +5610,6 @@ insertchar (
   } else {
     int cc;
 
-    extmark_col_adjust(curbuf, curwin->w_cursor.lnum,
-                       (colnr_T)(curwin->w_cursor.col + 1), 0,
-                       1, kExtmarkUndo);
     if ((cc = utf_char2len(c)) > 1) {
       char_u buf[MB_MAXBYTES + 1];
 
@@ -8506,14 +8499,6 @@ static bool ins_tab(void)
   }
 
   temp -= get_nolist_virtcol() % temp;
-
-  // Move extmarks
-  extmark_col_adjust(curbuf,
-                     curwin->w_cursor.lnum,
-                     curwin->w_cursor.col,
-                     0,
-                     temp,
-                     kExtmarkUndo);
 
   /*
    * Insert the first space with ins_char().	It will delete one char in

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5599,9 +5599,10 @@ insertchar (
     do_digraph(-1);                     /* clear digraphs */
     do_digraph(buf[i-1]);               /* may be the start of a digraph */
     buf[i] = NUL;
+    colnr_T col_start = curwin->w_cursor.col;
     ins_str(buf);
     extmark_col_adjust(curbuf, curwin->w_cursor.lnum,
-                       (colnr_T)(curwin->w_cursor.col + 1), 0,
+                       (colnr_T)(col_start + 1), 0,
                        (long)STRLEN(buf), kExtmarkUndo);
     if (flags & INSCHAR_CTRLV) {
       redo_literal(*buf);

--- a/src/nvim/mark_extended.c
+++ b/src/nvim/mark_extended.c
@@ -910,6 +910,9 @@ void extmark_col_adjust(buf_T *buf, linenr_T lnum,
   bool marks_moved =  extmark_col_adjust_impl(buf, lnum, mincol, lnum_amount,
                                               false, col_amount);
 
+  marks_moved |= bufhl_mark_col_adjust(buf, lnum, mincol,
+                                       lnum_amount, col_amount);
+
   if (undo == kExtmarkUndo && marks_moved) {
     u_extmark_col_adjust(buf, lnum, mincol, lnum_amount, col_amount);
   }
@@ -938,6 +941,7 @@ void extmark_col_adjust_delete(buf_T *buf, linenr_T lnum,
   marks_moved = extmark_col_adjust_impl(buf, lnum, mincol, 0,
                                         true, (long)endcol);
 
+  marks_moved |= bufhl_mark_col_adjust(buf, lnum, endcol, 0, mincol-(endcol+1));
   // Deletes at the end of the line have different behaviour than the normal
   // case when deleted.
   // Cleanup any marks that are floating beyond the end of line.

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1644,8 +1644,6 @@ int op_delete(oparg_T *oap)
       curwin->w_cursor.col = 0;
       (void)del_bytes((colnr_T)n, !virtual_op,
                       oap->op_type == OP_DELETE && !oap->is_VIsual);
-      extmark_col_adjust(curbuf, curwin->w_cursor.lnum,
-                         (colnr_T)0, 0L, (long)-n, kExtmarkUndo);
       curwin->w_cursor = curpos;  // restore curwin->w_cursor
       (void)do_join(2, false, false, false, false);
     }
@@ -1685,7 +1683,6 @@ setmarks:
     if (oap->is_VIsual == false) {
       endcol = MAX(endcol - 1, mincol);
     }
-    extmark_col_adjust_delete(curbuf, lnum, mincol, endcol, kExtmarkUndo, 0);
   }
   return OK;
 }
@@ -2279,7 +2276,7 @@ void op_insert(oparg_T *oap, long count1)
   colnr_T col = oap->start.col;
   for (linenr_T lnum = oap->start.lnum; lnum <= oap->end.lnum; lnum++) {
     extmark_col_adjust(curbuf, lnum, col, 0, 1, kExtmarkUndo);
-    }
+  }
 }
 
 /*
@@ -4279,14 +4276,14 @@ format_lines(
         if (next_leader_len > 0) {
           (void)del_bytes(next_leader_len, false, false);
           mark_col_adjust(curwin->w_cursor.lnum, (colnr_T)0, 0L,
-                          (long)-next_leader_len, 0, kExtmarkUndo);
+                          (long)-next_leader_len, 0, kExtmarkNOOP);
         } else if (second_indent > 0) {   // the "leader" for FO_Q_SECOND
           int indent = (int)getwhitecols_curline();
 
           if (indent > 0) {
-            (void)del_bytes(indent, FALSE, FALSE);
+            (void)del_bytes(indent, false, false);
             mark_col_adjust(curwin->w_cursor.lnum,
-                            (colnr_T)0, 0L, (long)-indent, 0, kExtmarkUndo);
+                            (colnr_T)0, 0L, (long)-indent, 0, kExtmarkNOOP);
           }
         }
         curwin->w_cursor.lnum--;
@@ -4949,23 +4946,6 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
   curbuf->b_op_end = endpos;
   if (curbuf->b_op_end.col > 0) {
     curbuf->b_op_end.col--;
-  }
-
-  // if buf1 wasn't allocated, only a singe ASCII char was changed in-place.
-  if (did_change && buf1 != NULL) {
-    extmark_col_adjust_delete(curbuf,
-                              pos->lnum,
-                              startpos.col + 2,
-                              endpos.col + 1 + length,
-                              kExtmarkUndo,
-                              0);
-    long col_amount = (long)STRLEN(buf1);
-    extmark_col_adjust(curbuf,
-                       pos->lnum,
-                       startpos.col + 1,
-                       0,
-                       col_amount,
-                       kExtmarkUndo);
   }
 
 theend:

--- a/test/functional/api/mark_extended_spec.lua
+++ b/test/functional/api/mark_extended_spec.lua
@@ -475,6 +475,13 @@ describe('Extmarks buffer api', function()
     check_undo_redo(ns, marks[2], 0, 3, 1, 2)
   end)
 
+  it('deleting right before a mark works #extmarks', function()
+    -- op_delete in ops.c
+    set_extmark(ns, marks[1], 0, 2)
+    feed('0lx')
+    check_undo_redo(ns, marks[1], 0, 2, 0, 1)
+  end)
+
   it('deleting on a mark works #extmarks', function()
     -- op_delete in ops.c
     set_extmark(ns, marks[1], 0, 2)

--- a/test/functional/api/mark_extended_spec.lua
+++ b/test/functional/api/mark_extended_spec.lua
@@ -422,7 +422,7 @@ describe('Extmarks buffer api', function()
     set_extmark(ns, marks[1], 1, 2)
     -- Insert a fullwidth (two col) tilde, NICE
     feed('0i～<esc>')
-    check_undo_redo(ns, marks[1], 1, 2, 1, 3)
+    check_undo_redo(ns, marks[1], 1, 2, 1, 5)
   end)
 
   it('marks move with blockwise inserts #extmarks', function()

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -241,7 +241,7 @@ describe('Buffer highlighting', function()
         {1:~                                       }|
         {1:~                                       }|
         {1:~                                       }|
-        1 change; before #2  0 seconds ago      |
+        1 change; before #2  {MATCH:.*}|
       ]]}
 
       -- change/insert in the middle
@@ -278,7 +278,7 @@ describe('Buffer highlighting', function()
         {1:~                                       }|
         {1:~                                       }|
         {1:~                                       }|
-        1 change; before #4  0 seconds ago      |
+        1 change; before #4  {MATCH:.*}|
       ]]}
 
       feed('u')
@@ -290,7 +290,7 @@ describe('Buffer highlighting', function()
         {1:~                                       }|
         {1:~                                       }|
         {1:~                                       }|
-        1 change; before #3  0 seconds ago      |
+        1 change; before #3  {MATCH:.*}|
       ]]}
       end)
 
@@ -317,7 +317,7 @@ describe('Buffer highlighting', function()
         {1:~                                       }|
         {1:~                                       }|
         {1:~                                       }|
-        1 more line; before #2  0 seconds ago   |
+        1 more line; before #2  {MATCH:.*}|
       ]]}
     end)
 
@@ -357,7 +357,7 @@ describe('Buffer highlighting', function()
         {9:from }{8:diff}{7:erent} sources                  |
         {1:~                                       }|
         {1:~                                       }|
-        1 line less; before #3  0 seconds ago   |
+        1 line less; before #3  {MATCH:.*}|
       ]]}
 
       feed('<esc>u')
@@ -369,7 +369,7 @@ describe('Buffer highlighting', function()
         {1:~                                       }|
         {1:~                                       }|
         {1:~                                       }|
-        1 line less; before #2  0 seconds ago   |
+        1 line less; before #2  {MATCH:.*}|
       ]]}
     end)
   end)

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -217,6 +217,161 @@ describe('Buffer highlighting', function()
                                                 |
       ]])
     end)
+
+    it('and adjusting columns', function()
+      -- insert before
+      feed('ggiquite <esc>')
+      screen:expect{grid=[[
+        quite^ a {5:longer} example                  |
+        in {6:order} to {7:de}{5:monstr}{7:ate}                 |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]]}
+
+      feed('u')
+      screen:expect{grid=[[
+        ^a {5:longer} example                        |
+        in {6:order} to {7:de}{5:monstr}{7:ate}                 |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        1 change; before #2  0 seconds ago      |
+      ]]}
+
+      -- change/insert in the middle
+      feed('+fesAAAA')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:ordAAAA^r} to {7:de}{5:monstr}{7:ate}              |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {7:-- INSERT --}                            |
+      ]]}
+
+      feed('<esc>tdD')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:ordAAAAr} t^o                          |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]]}
+
+      feed('u')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:ordAAAAr} to^ demonstrate              |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        1 change; before #4  0 seconds ago      |
+      ]]}
+
+      feed('u')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:ord^er} to demonstrate                 |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        1 change; before #3  0 seconds ago      |
+      ]]}
+      end)
+
+    it('and joining lines', function()
+      feed('ggJJJ')
+      screen:expect{grid=[[
+        a {5:longer} example in {6:order} to {7:de}{5:monstr}{7:ate}|
+        {7: combin}{8:ing hi}{7:ghlights^ }{8:from diff}{7:erent sou}|
+        {7:rces}                                    |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]]}
+
+      -- TODO(bfredl): perhaps better undo
+      feed('uuu')
+      screen:expect{grid=[[
+        ^a longer example                        |
+        in order to demonstrate                 |
+        combining highlights                    |
+        from different sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        1 more line; before #2  0 seconds ago   |
+      ]]}
+    end)
+
+    it('and splitting lines', function()
+      feed('2Gtti<cr>')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:order}                                |
+        ^ to {7:de}{5:monstr}{7:ate}                         |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {7:-- INSERT --}                            |
+      ]]}
+
+      -- TODO(bfredl): keep both "parts" after split, requires proper extmark ranges
+      feed('<esc>tsi<cr>')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:order}                                |
+         to {7:de}{5:mo}                                |
+        ^nstrate                                 |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {7:-- INSERT --}                            |
+      ]]}
+
+      -- TODO(bfredl): perhaps better undo
+      feed('<esc>u')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in {6:order}                                |
+         to demo{7:^nstrat}{8:e}                         |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        1 line less; before #3  0 seconds ago   |
+      ]]}
+
+      feed('<esc>u')
+      screen:expect{grid=[[
+        a {5:longer} example                        |
+        in order^ to demonstrate                 |
+        {7:combin}{8:ing}{9: hi}ghlights                    |
+        {9:from }{8:diff}{7:erent} sources                  |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        1 line less; before #2  0 seconds ago   |
+      ]]}
+    end)
   end)
 
   it('prioritizes latest added highlight', function()


### PR DESCRIPTION
Note: this is not the final integration of bufhl feature into extmark. But quickly getting something working for column adjustment seems worth it. It allows for quick debugging of col adjust
issues (except for undo, which is only partially supported until final integration)

bufhl should soon be made apart of the extmark tree, so that "start" adjustment just works automatically. But "stop" will still need some trickery, until extended marks natively support ranges (hopefully sooner than forever).