### PR TITLE
[release-0.4] f_getenv/setenv: Access v_special when v_type is VAR_SPECIAL

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8492,7 +8492,7 @@ static void f_getenv(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   if (p == NULL) {
     rettv->v_type = VAR_SPECIAL;
-    rettv->vval.v_number = kSpecialVarNull;
+    rettv->vval.v_special = kSpecialVarNull;
     return;
   }
   rettv->vval.v_string = p;
@@ -15441,7 +15441,7 @@ static void f_setenv(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const char *name = tv_get_string_buf(&argvars[0], namebuf);
 
   if (argvars[1].v_type == VAR_SPECIAL
-      && argvars[1].vval.v_number == kSpecialVarNull) {
+      && argvars[1].vval.v_special == kSpecialVarNull) {
     os_unsetenv(name);
   } else {
     os_setenv(name, tv_get_string_buf(&argvars[1], valbuf), 1);


### PR DESCRIPTION
Multiple Debian builds were failing these tests:

    Failures:
    	From test_environ.vim:
    	Found errors in Test_external_env():
    	function RunTheTest[37]..Test_external_env line 16: Expected '' but got 'FOO=null\n'
    	Found errors in Test_getenv():
    	function RunTheTest[37]..Test_getenv line 2: Expected v:null but got v:false
    	Found errors in Test_setenv():
    	function RunTheTest[37]..Test_setenv line 5: Expected v:null but got 'null'

This is because nvim has a separate tag (`v_special`) in `typval_T` for
special variables, whereas vim re-uses the `v_number` tag.

On little-endian architectures, using the incorrect tag is not an issue
because the byte representation is the same.  However, on big-endian
systems this caused the `v_number == kSpecialVarNull` checks to fail,
and the non-special code to execute.