### PR TITLE
extmark: do not crash in read-only buffer

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2409,7 +2409,6 @@ int inchar(
     did_outofmem_msg = FALSE;       /* display out of memory message (again) */
     did_swapwrite_msg = FALSE;      /* display swap file write error again */
   }
-  undo_off = FALSE;                 /* restart undo now */
 
   // Get a character from a script file if there is one.
   // If interrupted: Stop reading script files, close them all.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -768,7 +768,6 @@ EXTERN int did_outofmem_msg INIT(= false);
 // set after out of memory msg
 EXTERN int did_swapwrite_msg INIT(= false);
 // set after swap write error msg
-EXTERN int undo_off INIT(= false);          // undo switched off for now
 EXTERN int global_busy INIT(= 0);           // set when :global is executing
 EXTERN int listcmd_busy INIT(= false);      // set when :argdo, :windo or
                                             // :bufdo is executing

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -243,7 +243,7 @@ int u_save(linenr_T top, linenr_T bot)
  */
 int u_savesub(linenr_T lnum)
 {
-  return u_savecommon(lnum - 1, lnum + 1, lnum + 1, FALSE);
+  return u_savecommon(lnum - 1, lnum + 1, lnum + 1, false);
 }
 
 /*
@@ -254,7 +254,7 @@ int u_savesub(linenr_T lnum)
  */
 int u_inssub(linenr_T lnum)
 {
-  return u_savecommon(lnum - 1, lnum, lnum + 1, FALSE);
+  return u_savecommon(lnum - 1, lnum, lnum + 1, false);
 }
 
 /*
@@ -3043,8 +3043,14 @@ u_header_T *u_force_get_undo_header(buf_T *buf)
   }
   // Create the first undo header for the buffer
   if (!uhp) {
-    // TODO(timeyyy): there would be a better way to do this!
-    u_save_cursor();
+    // Undo is normally invoked in change code, which already has swapped
+    // curbuf.
+    buf_T *save_curbuf = curbuf;
+    curbuf = buf;
+    // Args are tricky: this means replace empty range by empty range..
+    u_savecommon(0, 1, 1, true);
+    curbuf = save_curbuf;
+
     uhp = buf->b_u_curhead;
     if (!uhp) {
       uhp = buf->b_u_newhead;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -225,9 +225,6 @@ int u_save_cursor(void)
  */
 int u_save(linenr_T top, linenr_T bot)
 {
-  if (undo_off)
-    return OK;
-
   if (top >= bot || bot > (curbuf->b_ml.ml_line_count + 1)) {
     return FAIL;        /* rely on caller to do error messages */
   }
@@ -246,9 +243,6 @@ int u_save(linenr_T top, linenr_T bot)
  */
 int u_savesub(linenr_T lnum)
 {
-  if (undo_off)
-    return OK;
-
   return u_savecommon(lnum - 1, lnum + 1, lnum + 1, FALSE);
 }
 
@@ -260,9 +254,6 @@ int u_savesub(linenr_T lnum)
  */
 int u_inssub(linenr_T lnum)
 {
-  if (undo_off)
-    return OK;
-
   return u_savecommon(lnum - 1, lnum, lnum + 1, FALSE);
 }
 
@@ -275,9 +266,6 @@ int u_inssub(linenr_T lnum)
  */
 int u_savedel(linenr_T lnum, long nlines)
 {
-  if (undo_off)
-    return OK;
-
   return u_savecommon(lnum - 1, lnum + nlines,
       nlines == curbuf->b_ml.ml_line_count ? 2 : lnum, FALSE);
 }
@@ -2924,9 +2912,6 @@ void u_undoline(void)
 {
   colnr_T t;
   char_u  *oldp;
-
-  if (undo_off)
-    return;
 
   if (curbuf->b_u_line_ptr == NULL
       || curbuf->b_u_line_lnum > curbuf->b_ml.ml_line_count) {

--- a/test/functional/api/mark_extended_spec.lua
+++ b/test/functional/api/mark_extended_spec.lua
@@ -1262,6 +1262,12 @@ describe('Extmarks buffer api', function()
     check_undo_redo(ns, marks[1], 3, 4, 2, 6)
   end)
 
+  it('in read-only buffer', function()
+    command("view! runtime/doc/help.txt")
+    eq(true, curbufmeths.get_option('ro'))
+    local id = set_extmark(ns, 0, 0, 2)
+    eq({{id, 0, 2}}, get_extmarks(ns,0, -1))
+  end)
 end)
 
 describe('Extmarks buffer api with many marks', function()


### PR DESCRIPTION
fixes https://github.com/neovim/neovim/issues/11377#issuecomment-554284457