### PR TITLE
[RFC] provider/python: add python3.8 executable

### DIFF
--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -29,8 +29,8 @@ endfunction
 function! s:get_python_candidates(major_version) abort
   return {
         \ 2: ['python2', 'python2.7', 'python2.6', 'python'],
-        \ 3: ['python3', 'python3.7', 'python3.6', 'python3.5', 'python3.4', 'python3.3',
-        \     'python']
+        \ 3: ['python3', 'python3.8', 'python3.7', 'python3.6', 'python3.5',
+        \     'python3.4', 'python3.3', 'python']
         \ }[a:major_version]
 endfunction
 


### PR DESCRIPTION
Python 3.8 was released 2019-10-14:

  https://www.python.org/dev/peps/pep-0569