### PR TITLE
[RFC] Minor fix

### DIFF
--- a/src/nvim/os/tty.c
+++ b/src/nvim/os/tty.c
@@ -6,6 +6,7 @@
 //
 
 #include "nvim/os/os.h"
+#include "nvim/os/tty.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/tty.c.generated.h"

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -26,7 +26,7 @@ void tinput_init(TermInput *input, Loop *loop)
 {
   input->loop = loop;
   input->paste = 0;
-  input->in_fd = 0;
+  input->in_fd = STDIN_FILENO;
   input->waiting_for_bg_response = 0;
   input->key_buffer = rbuffer_new(KEY_BUFFER_SIZE);
   uv_mutex_init(&input->key_buffer_mutex);
@@ -36,7 +36,7 @@ void tinput_init(TermInput *input, Loop *loop)
   //    echo q | nvim -es
   //    ls *.md | xargs nvim
 #ifdef WIN32
-  if (!os_isatty(0)) {
+  if (!os_isatty(input->in_fd)) {
       const HANDLE conin_handle = CreateFile("CONIN$",
                                              GENERIC_READ | GENERIC_WRITE,
                                              FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -46,8 +46,8 @@ void tinput_init(TermInput *input, Loop *loop)
       assert(input->in_fd != -1);
   }
 #else
-  if (!os_isatty(0) && os_isatty(2)) {
-    input->in_fd = 2;
+  if (!os_isatty(input->in_fd) && os_isatty(STDERR_FILENO)) {
+    input->in_fd = STDERR_FILENO;
   }
 #endif
   input_global_fd_init(input->in_fd);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -220,7 +220,7 @@ static void terminfo_start(UI *ui)
   data->unibi_ext.reset_cursor_style = -1;
   data->unibi_ext.get_bg = -1;
   data->unibi_ext.set_underline_color = -1;
-  data->out_fd = 1;
+  data->out_fd = STDOUT_FILENO;
   data->out_isatty = os_isatty(data->out_fd);
 
   const char *term = os_getenv("TERM");


### PR DESCRIPTION
I don't think there's any real harm, but I think it's better to fix it because there is a warning.

https://ci.appveyor.com/project/neovim/neovim/branch/master/job/c8w3o0k5ti2j1o3m?fullLog=true#L5678

`main.c` uses preprocessor symbols, but `tui/{input.c, tui.c}` uses magic numbers. I think this should also be fixed.