### PR TITLE
WIP Fix #11349 - Backups failing for symlink files

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2855,6 +2855,7 @@ buf_write(
               != 0) {
             SET_ERRMSG(_("E506: Can't write to backup file "
                          "(add ! to override)"));
+            continue;
           }
 
 #ifdef UNIX
@@ -2865,6 +2866,7 @@ buf_write(
 #ifdef HAVE_ACL
           mch_set_acl(backup, acl);
 #endif
+          SET_ERRMSG(NULL);
           break;
         }
       }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2855,6 +2855,7 @@ buf_write(
               != 0) {
             SET_ERRMSG(_("E506: Can't write to backup file "
                          "(add ! to override)"));
+            backup = NULL;
             continue;
           }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2855,6 +2855,7 @@ buf_write(
               != 0) {
             SET_ERRMSG(_("E506: Can't write to backup file "
                          "(add ! to override)"));
+            XFREE_CLEAR(backup);
             backup = NULL;
             continue;
           }

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -129,14 +129,6 @@ describe('fileio', function()
     feed('Abar<esc>')
     command('write')
 
-    local final_contents = initial_content .. 'bar'
-
-    local file_contents = trim(read_file('Xtest_startup_file1'))
-    eq(final_contents, file_contents)
-
-    local orig_contents = trim(read_file('Xtest_startup_file2'))
-    eq(final_contents, orig_contents)
-
     local backup_raw = read_file('Xtest_startup_file2~')
     neq(nil, backup_raw, "Expected backup file to exist but did not")
     eq(initial_content, trim(backup_raw), 'Expected backup to contain original contents')
@@ -156,14 +148,6 @@ describe('fileio', function()
     command('edit Xtest_startup_file2')
     feed('Abar<esc>')
     command('write')
-
-    local final_contents = initial_content .. 'bar'
-
-    local file_contents = trim(read_file('Xtest_startup_file1'))
-    eq(final_contents, file_contents)
-
-    local orig_contents = trim(read_file('Xtest_startup_file2'))
-    eq(final_contents, orig_contents)
 
     local backup_raw = read_file('Xtest_startup_swapdir/Xtest_startup_file2~')
     neq(nil, backup_raw, "Expected backup file to exist but did not")

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -1,10 +1,11 @@
 local lfs = require('lfs')
+local global_helpers = require('test.helpers')
 local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
-local neq = helpers.neq
+local neq = global_helpers.neq
 local feed = helpers.feed
 local funcs = helpers.funcs
 local nvim_prog = helpers.nvim_prog

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -121,15 +121,26 @@ describe('fileio', function()
     clear()
 
     local initial_content = 'foo'
+    local backup_dir = 'Xtest_backupdir'
+    local sep = helpers.get_pathsep()
+    local link_file_name = 'Xtest_startup_file2'
+    local backup_file_name = link_file_name .. '~'
+
     write_file('Xtest_startup_file1', initial_content, false)
-    lfs.link('Xtest_startup_file1', 'Xtest_startup_file2', true)
+    lfs.link('Xtest_startup_file1', link_file_name, true)
     command('set backup')
     command('set backupcopy=yes')
-    command('edit Xtest_startup_file2')
+    command('edit ' .. link_file_name)
     feed('Abar<esc>')
     command('write')
 
-    local backup_raw = read_file('Xtest_startup_file2~')
+    -- only for testing Windows
+    command('edit Xtest_startup_file1')
+    feed('Ibaz<esc>')
+    command('write')
+
+    local backup_raw = read_file(backup_file_name)
+    eq('x', {currentdir(), lfs.symlinkattributes(link_file_name), backup_file_name, helpers.funcs.glob('./*')})
     neq(nil, backup_raw, "Expected backup file to exist but did not")
     eq(initial_content, trim(backup_raw), 'Expected backup to contain original contents')
   end)
@@ -139,17 +150,28 @@ describe('fileio', function()
     clear()
 
     local initial_content = 'foo'
+    local backup_dir = 'Xtest_backupdir'
+    local sep = helpers.get_pathsep()
+    local link_file_name = 'Xtest_startup_file2'
+    local backup_file_name = backup_dir .. sep .. link_file_name .. '~'
+
     write_file('Xtest_startup_file1', initial_content, false)
-    lfs.link('Xtest_startup_file1', 'Xtest_startup_file2', true)
-    lfs.mkdir('Xtest_startup_swapdir')
+    lfs.link('Xtest_startup_file1', link_file_name, true)
+    mkdir('Xtest_backupdir')
     command('set backup')
     command('set backupcopy=yes')
-    command('set backupdir=.__this_does_not_exist__,Xtest_startup_swapdir')
-    command('edit Xtest_startup_file2')
+    command('set backupdir=.__this_does_not_exist__,' .. backup_dir)
+    command('edit ' .. link_file_name)
     feed('Abar<esc>')
     command('write')
 
-    local backup_raw = read_file('Xtest_startup_swapdir/Xtest_startup_file2~')
+    -- only for testing Windows
+    command('edit Xtest_startup_file1')
+    feed('Ibaz<esc>')
+    command('write')
+
+    local backup_raw = read_file(backup_file_name)
+    eq('x', {currentdir(), lfs.symlinkattributes(link_file_name), backup_file_name, helpers.funcs.glob(backup_dir .. '/*')})
     neq(nil, backup_raw, "Expected backup file to exist but did not")
     eq(initial_content, trim(backup_raw), 'Expected backup to contain original contents')
   end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -15,6 +15,7 @@ local check_cores = global_helpers.check_cores
 local check_logs = global_helpers.check_logs
 local dedent = global_helpers.dedent
 local eq = global_helpers.eq
+local neq = global_helpers.neq
 local filter = global_helpers.filter
 local is_os = global_helpers.is_os
 local map = global_helpers.map

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -15,7 +15,6 @@ local check_cores = global_helpers.check_cores
 local check_logs = global_helpers.check_logs
 local dedent = global_helpers.dedent
 local eq = global_helpers.eq
-local neq = global_helpers.neq
 local filter = global_helpers.filter
 local is_os = global_helpers.is_os
 local map = global_helpers.map


### PR DESCRIPTION
Fixes #11349 

### Problem
Prior to #9709, we only when down the copy route if we could open the file, otherwise we would cycle through the backupdir options until/if we could. After that PR, we moved where the `break` was and if the first encountered backupdir + backup file option can't be written we fail and break out of the backupdir loop.

### Solution

Continue through the loop of backupdir options (still recording the error message if we can't copy), then clear out error messages if we finally succeed