### PR TITLE
deps: update libtermkey to 0.22

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -159,8 +159,8 @@ set(LUAROCKS_SHA256 9eb3d0738fd02ad8bf39bcedccac4e83e9b5fff2bcca247c3584b925b207
 set(UNIBILIUM_URL https://github.com/neovim/unibilium/archive/92d929f.tar.gz)
 set(UNIBILIUM_SHA256 29815283c654277ef77a3adcc8840db79ddbb20a0f0b0c8f648bd8cd49a02e4b)
 
-set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.21.1.tar.gz)
-set(LIBTERMKEY_SHA256 cecbf737f35d18f433c8d7864f63c0f878af41f8bd0255a3ebb16010dc044d5f)
+set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz)
+set(LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600)
 
 set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/7c72294d84ce20da4c27362dbd7fa4b08cfc91da.tar.gz)
 set(LIBVTERM_SHA256 f30c4d43e0c6db3e0912daf7188d98fbf6ee88f97589d72f6f304e5db48826a8)


### PR DESCRIPTION
functionaltests fail on nixos. It has libtermkey using 0.22 so I just want to check if that's the reason for this crash
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f4a020e8040 in lookup_next () from /nix/store/v5235zay4kndr7qsbsahv7269dl0mi3x-libtermkey-0.22/lib/libtermkey.so.1
[Current thread is 1 (Thread 0x7f4a01c85700 (LWP 6782))]
+(gdb) bt
#0  0x00007f4a020e8040 in lookup_next () from /nix/store/v5235zay4kndr7qsbsahv7269dl0mi3x-libtermkey-0.22/lib/libtermkey.so.1
#1  0x00007f4a020e80ec in peekkey () from /nix/store/v5235zay4kndr7qsbsahv7269dl0mi3x-libtermkey-0.22/lib/libtermkey.so.1
#2  0x00007f4a020e4930 in peekkey () from /nix/store/v5235zay4kndr7qsbsahv7269dl0mi3x-libtermkey-0.22/lib/libtermkey.so.1
#3  0x00007f4a020e52b5 in termkey_getkey ()
   from /nix/store/v5235zay4kndr7qsbsahv7269dl0mi3x-libtermkey-0.22/lib/libtermkey.so.1
#4  0x00000000006c4c91 in tk_getkey (tk=0x7f49fc012ed0, key=0x7f4a01c81200, force=false)
    at /home/teto/neovim/src/nvim/tui/input.c:286
#5  0x00000000006c4df6 in tk_getkeys (input=0x7f49fc010e88, force=false) at /home/teto/neovim/src/nvim/tui/input.c:311
#6  0x00000000006c5ba3 in tinput_read_cb (stream=0x7f49fc010f68, buf=0x7f49fc013670, count_=12, data=0x7f49fc010e88, eof=false)
    at /home/teto/neovim/src/nvim/tui/input.c:576
#7  0x00000000004de7f6 in read_event (argv=0x7f4a01c813a0) at /home/teto/neovim/src/nvim/event/rstream.c:194
#8  0x00000000004de91e in invoke_read_cb (stream=0x7f49fc010f68, count=12, eof=false)
    at /home/teto/neovim/src/nvim/event/rstream.c:207
#9  0x00000000004de577 in read_cb (uvstream=0x7f49fc010f70, cnt=12, buf=0x7f4a01c81490)
    at /home/teto/neovim/src/nvim/event/rstream.c:135
#10 0x00007f4a021722c7 in uv.read () from /nix/store/7y86qx423pqmyk5v1ik2fdah9n3d1bqs-libuv-1.33.1/lib/libuv.so.1
#11 0x00007f4a02172e28 in uv.stream_io () from /nix/store/7y86qx423pqmyk5v1ik2fdah9n3d1bqs-libuv-1.33.1/lib/libuv.so.1
#12 0x00007f4a02178238 in uv.io_poll () from /nix/store/7y86qx423pqmyk5v1ik2fdah9n3d1bqs-libuv-1.33.1/lib/libuv.so.1
#13 0x00007f4a02168675 in uv_run () from /nix/store/7y86qx423pqmyk5v1ik2fdah9n3d1bqs-libuv-1.33.1/lib/libuv.so.1
#14 0x00000000004da9a3 in loop_poll_events (loop=0x7f4a01c848e0, ms=20) at /home/teto/neovim/src/nvim/event/loop.c:62
#15 0x00000000006c882b in tui_main (bridge=0x9c1990, ui=0x9c1870) at /home/teto/neovim/src/nvim/tui/tui.c:434
#16 0x00000000006d5b01 in ui_thread_run (data=0x9c1990) at /home/teto/neovim/src/nvim/ui_bridge.c:104
#17 0x00007f4a0212fef7 in start_thread () from /nix/store/qb6k4hp7gk331x9fydw0w7qj4dv09bwz-glibc-2.27/lib/libpthread.so.0
#18 0x00007f4a01df022f in clone () from /nix/store/qb6k4hp7gk331x9fydw0w7qj4dv09bwz-glibc-2.27/lib/libc.so.6
```