### PR TITLE
lsp: transmit "\n" after last line when 'eol' is set

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -23,7 +23,6 @@ local lsp = {
   -- format_rpc_error = lsp_rpc.format_rpc_error;
 }
 
--- TODO consider whether 'eol' or 'fixeol' should change the nvim_buf_get_lines that send.
 -- TODO improve handling of scratch buffers with LSP attached.
 
 local function resolve_bufnr(bufnr)
@@ -175,6 +174,14 @@ local function validate_client_config(config)
   }
 end
 
+local function buf_get_full_text(bufnr)
+  local text = table.concat(nvim_buf_get_lines(bufnr, 0, -1, true), '\n')
+  if nvim_buf_get_option(bufnr, 'eol') then
+    text = text .. '\n'
+  end
+  return text
+end
+
 local function text_document_did_open_handler(bufnr, client)
   if not client.resolved_capabilities.text_document_open_close then
     return
@@ -188,7 +195,7 @@ local function text_document_did_open_handler(bufnr, client)
       uri = vim.uri_from_bufnr(bufnr);
       -- TODO make sure our filetypes are compatible with languageId names.
       languageId = nvim_buf_get_option(bufnr, 'filetype');
-      text = table.concat(nvim_buf_get_lines(bufnr, 0, -1, false), '\n');
+      text = buf_get_full_text(bufnr);
     }
   }
   client.notify('textDocument/didOpen', params)
@@ -551,7 +558,7 @@ do
     end)
     local full_changes = once(function()
       return {
-        text = table.concat(nvim_buf_get_lines(bufnr, 0, -1, false), "\n");
+        text = buf_get_full_text(bufnr);
       };
     end)
     local uri = vim.uri_from_bufnr(bufnr)

--- a/test/functional/fixtures/lsp-test-rpc-server.lua
+++ b/test/functional/fixtures/lsp-test-rpc-server.lua
@@ -170,7 +170,7 @@ function tests.basic_check_buffer_open()
       expect_notification('textDocument/didOpen', {
         textDocument = {
           languageId = "";
-          text = table.concat({"testing"; "123"}, "\n");
+          text = table.concat({"testing"; "123"}, "\n") .. '\n';
           uri = "file://";
           version = 0;
         };
@@ -197,7 +197,7 @@ function tests.basic_check_buffer_open_and_change()
       expect_notification('textDocument/didOpen', {
         textDocument = {
           languageId = "";
-          text = table.concat({"testing"; "123"}, "\n");
+          text = table.concat({"testing"; "123"}, "\n") .. '\n';
           uri = "file://";
           version = 0;
         };
@@ -208,7 +208,7 @@ function tests.basic_check_buffer_open_and_change()
           version = 3;
         };
         contentChanges = {
-          { text = table.concat({"testing"; "boop"}, "\n"); };
+          { text = table.concat({"testing"; "boop"}, "\n") .. '\n'; };
         }
       })
       expect_notification("finish")
@@ -217,7 +217,7 @@ function tests.basic_check_buffer_open_and_change()
   }
 end
 
-function tests.basic_check_buffer_open_and_change_multi()
+function tests.basic_check_buffer_open_and_change_noeol()
   skeleton {
     on_init = function(params)
       local expected_capabilities = protocol.make_client_capabilities()
@@ -244,7 +244,42 @@ function tests.basic_check_buffer_open_and_change_multi()
           version = 3;
         };
         contentChanges = {
-          { text = table.concat({"testing"; "321"}, "\n"); };
+          { text = table.concat({"testing"; "boop"}, "\n"); };
+        }
+      })
+      expect_notification("finish")
+      notify('finish')
+    end;
+  }
+end
+function tests.basic_check_buffer_open_and_change_multi()
+  skeleton {
+    on_init = function(params)
+      local expected_capabilities = protocol.make_client_capabilities()
+      assert_eq(params.capabilities, expected_capabilities)
+      return {
+        capabilities = {
+          textDocumentSync = protocol.TextDocumentSyncKind.Full;
+        }
+      }
+    end;
+    body = function()
+      notify('start')
+      expect_notification('textDocument/didOpen', {
+        textDocument = {
+          languageId = "";
+          text = table.concat({"testing"; "123"}, "\n") .. '\n';
+          uri = "file://";
+          version = 0;
+        };
+      })
+      expect_notification('textDocument/didChange', {
+        textDocument = {
+          uri = "file://";
+          version = 3;
+        };
+        contentChanges = {
+          { text = table.concat({"testing"; "321"}, "\n") .. '\n'; };
         }
       })
       expect_notification('textDocument/didChange', {
@@ -253,7 +288,7 @@ function tests.basic_check_buffer_open_and_change_multi()
           version = 4;
         };
         contentChanges = {
-          { text = table.concat({"testing"; "boop"}, "\n"); };
+          { text = table.concat({"testing"; "boop"}, "\n") .. '\n'; };
         }
       })
       expect_notification("finish")
@@ -278,7 +313,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
       expect_notification('textDocument/didOpen', {
         textDocument = {
           languageId = "";
-          text = table.concat({"testing"; "123"}, "\n");
+          text = table.concat({"testing"; "123"}, "\n") .. '\n';
           uri = "file://";
           version = 0;
         };
@@ -289,7 +324,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
           version = 3;
         };
         contentChanges = {
-          { text = table.concat({"testing"; "321"}, "\n"); };
+          { text = table.concat({"testing"; "321"}, "\n") .. '\n'; };
         }
       })
       expect_notification('textDocument/didChange', {
@@ -298,7 +333,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
           version = 4;
         };
         contentChanges = {
-          { text = table.concat({"testing"; "boop"}, "\n"); };
+          { text = table.concat({"testing"; "boop"}, "\n") .. '\n'; };
         }
       })
       expect_notification('textDocument/didClose', {
@@ -328,7 +363,7 @@ function tests.basic_check_buffer_open_and_change_incremental()
       expect_notification('textDocument/didOpen', {
         textDocument = {
           languageId = "";
-          text = table.concat({"testing"; "123"}, "\n");
+          text = table.concat({"testing"; "123"}, "\n") .. '\n';
           uri = "file://";
           version = 0;
         };


### PR DESCRIPTION
Otherwise some servers like clangd will emit spurious "no newline at end of file" warnings.

I think this doesn't conflict/overlap with anything in #11430 