### PR TITLE
Add vim.cmd as a basic interface for nvim_command

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -288,7 +288,7 @@ do
         if s == nil then
           return nvim_command(k)
         end
-        return nvim_command(table.concat({k, s}, ' '))
+        return nvim_command(k.." "..s)
       end
     end;
   })

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -277,11 +277,13 @@ setmetatable(vim, {
   __index = __index
 })
 
+-- An easier alias for commands.
+vim.cmd = vim.api.nvim_command
+
+-- These are the vim.env/v/g/o/bo/wo variable magic accessors.
 do
   local a = vim.api
   local validate = vim.validate
-  -- An easier alias for commands.
-  vim.cmd = a.nvim_command
   local function make_meta_accessor(get, set, del)
     validate {
       get = {get, 'f'};

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -279,10 +279,9 @@ setmetatable(vim, {
 
 do
   local a = vim.api
-  local nvim_command = a.nvim_command
   local validate = vim.validate
   -- An easier alias for commands.
-  vim.cmd = nvim_command
+  vim.cmd = a.nvim_command
   local function make_meta_accessor(get, set, del)
     validate {
       get = {get, 'f'};

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -279,7 +279,19 @@ setmetatable(vim, {
 
 do
   local a = vim.api
+  local nvim_command = a.nvim_command
   local validate = vim.validate
+  vim.cmd = setmetatable({}, {
+    __index = function(_, k)
+      return function(s)
+        validate { cmd = {s, 's', true} }
+        if s == nil then
+          return nvim_command(k)
+        end
+        return nvim_command(table.concat({k, s}, ' '))
+      end
+    end;
+  })
   local function make_meta_accessor(get, set, del)
     validate {
       get = {get, 'f'};

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -281,17 +281,8 @@ do
   local a = vim.api
   local nvim_command = a.nvim_command
   local validate = vim.validate
-  vim.cmd = setmetatable({}, {
-    __index = function(_, k)
-      return function(s)
-        validate { cmd = {s, 's', true} }
-        if s == nil then
-          return nvim_command(k)
-        end
-        return nvim_command(k.." "..s)
-      end
-    end;
-  })
+  -- An easier alias for commands.
+  vim.cmd = nvim_command
   local function make_meta_accessor(get, set, del)
     validate {
       get = {get, 'f'};

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -609,8 +609,8 @@ describe('lua stdlib', function()
 
   it('vim.cmd', function()
     exec_lua [[
-		vim.cmd.autocmd("BufNew * ++once lua BUF = vim.fn.expand('<abuf>')")
-		vim.cmd.new()
+    vim.cmd.autocmd("BufNew * ++once lua BUF = vim.fn.expand('<abuf>')")
+    vim.cmd.new()
     ]]
     eq('2', funcs.luaeval "BUF")
     eq(2, funcs.luaeval "#vim.api.nvim_list_bufs()")

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -609,8 +609,8 @@ describe('lua stdlib', function()
 
   it('vim.cmd', function()
     exec_lua [[
-    vim.cmd.autocmd("BufNew * ++once lua BUF = vim.fn.expand('<abuf>')")
-    vim.cmd.new()
+    vim.cmd "autocmd BufNew * ++once lua BUF = vim.fn.expand('<abuf>')"
+    vim.cmd "new"
     ]]
     eq('2', funcs.luaeval "BUF")
     eq(2, funcs.luaeval "#vim.api.nvim_list_bufs()")

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -606,4 +606,13 @@ describe('lua stdlib', function()
     ]]
     eq(0, funcs.luaeval "vim.wo.cole")
   end)
+
+  it('vim.cmd', function()
+    exec_lua [[
+		vim.cmd.autocmd("BufNew * ++once lua BUF = vim.fn.expand('<abuf>')")
+		vim.cmd.new()
+    ]]
+    eq('2', funcs.luaeval "BUF")
+    eq(2, funcs.luaeval "#vim.api.nvim_list_bufs()")
+  end)
 end)


### PR DESCRIPTION
I decided not to save `f` on vim.cmd (caching) to avoid noise on `vim.cmd`.