### PR TITLE
[RFC] extmark: fix E315 in nvim_buf_set_extmark

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1191,7 +1191,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer id,
     api_set_error(err, kErrorTypeValidation, "line value outside range");
     return 0;
   } else if (line < buf->b_ml.ml_line_count) {
-    len = STRLEN(ml_get_buf(curbuf, (linenr_T)line+1, false));
+    len = STRLEN(ml_get_buf(buf, (linenr_T)line+1, false));
   }
 
   if (col == -1) {

--- a/test/functional/api/mark_extended_spec.lua
+++ b/test/functional/api/mark_extended_spec.lua
@@ -5,6 +5,7 @@ local request = helpers.request
 local eq = helpers.eq
 local ok = helpers.ok
 local curbufmeths = helpers.curbufmeths
+local bufmeths = helpers.bufmeths
 local pcall_err = helpers.pcall_err
 local insert = helpers.insert
 local feed = helpers.feed
@@ -1274,6 +1275,13 @@ describe('Extmarks buffer api', function()
     eq(true, curbufmeths.get_option('ro'))
     local id = set_extmark(ns, 0, 0, 2)
     eq({{id, 0, 2}}, get_extmarks(ns,0, -1))
+  end)
+
+  it('can set a mark to other buffer', function()
+    local buf = request('nvim_create_buf', 0, 1)
+    request('nvim_buf_set_lines', buf, 0, -1, 1, {"", ""})
+    local id = bufmeths.set_extmark(buf, ns, 0, 1, 0, {})
+    eq({{id, 1, 0}}, bufmeths.get_extmarks(buf, ns, 0, -1, {}))
   end)
 end)
 


### PR DESCRIPTION
Fix #11447

## a minimal script for reproduce

```vim
let s:bufnr = nvim_create_buf(v:false, v:true)

call nvim_buf_set_lines(s:bufnr, 0, -1, v:true, ['', ''])

let s:ns = nvim_create_namespace('myplugin')
call nvim_buf_set_extmark(s:bufnr, s:ns, 0, 1, 0, {})
```

## before

```
$ nvim -es -u NORC -c "source ~/setmark.vim" -c "call append(0, execute('message'))" -c "%print" -cq!
^@Error detected while processing /home/notomo/setmark.vim:^@line    4:^@E315: ml_get: invalid lnum: 2
```

## after

```
$ ./nvim -es -u NORC -c "source ~/setmark.vim" -c "call append(0, execute('message'))" -c "%print" -cq!

$
```
