### PR TITLE
man.vim: Improve ft=man keyword definition

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -151,6 +151,8 @@ function! s:put_page(page) abort
   setlocal modifiable
   setlocal noreadonly
   setlocal noswapfile
+  " git-ls-files(1) is all one keyword/tag-target
+  setlocal iskeyword+=(,)
   silent keepjumps %delete _
   silent put =a:page
   while getline(1) =~# '^\s*$'


### PR DESCRIPTION
This addresses a minor quality problem with the recent `'tagfunc'` changes for `man.vim` (see https://github.com/neovim/neovim/pull/11280#discussion_r348342357). Currently, with the cursor on a parenthese, hitting `K` will jump us to the man page of the next mentioned entry, instead of the one to which the parenthese (or section number) belongs.

```
pcrepattern(3), terminfo(5), glob(7), regex(7).
       e.g. ^        e.g. ^
```

Adding the parentheses to `'iskeyword'` means we correctly handle these cases too.