### PR TITLE
[RFC] Fix crash when set rightleft on terminal

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4021,10 +4021,7 @@ win_line (
       if (wp->w_buffer->terminal) {
         // terminal buffers may need to highlight beyond the end of the
         // logical line
-        int n = 1;
-        if (wp->w_p_rl) {
-          n = -1;
-        }
+        int n = wp->w_p_rl ? -1 : 1;
         while (col >= 0 && col < grid->Columns) {
           schar_from_ascii(linebuf_char[off], ' ');
           linebuf_attr[off] = term_attrs[vcol];

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4021,10 +4021,16 @@ win_line (
       if (wp->w_buffer->terminal) {
         // terminal buffers may need to highlight beyond the end of the
         // logical line
-        while (col < grid->Columns) {
+        int n = 1;
+        if (wp->w_p_rl) {
+          n = -1;
+        }
+        while (col >= 0 && col < grid->Columns) {
           schar_from_ascii(linebuf_char[off], ' ');
-          linebuf_attr[off++] = term_attrs[vcol++];
-          col++;
+          linebuf_attr[off] = term_attrs[vcol];
+          off += n;
+          vcol += n;
+          col += n;
         }
       }
       grid_put_linebuf(grid, row, 0, col, grid->Columns, wp->w_p_rl, wp,

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -230,7 +230,6 @@ describe(':terminal buffer', function()
     local columns = eval('&columns')
     feed(string.rep('a', columns))
     command('set rightleft')
-    wait()
     screen:expect([[
                                                ydaer ytt|
       {1:a}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
@@ -240,7 +239,7 @@ describe(':terminal buffer', function()
                                                         |
       {3:-- TERMINAL --}                                    |
     ]])
-    feed_command('bdelete!')
+    command('bdelete!')
   end)
 end)
 

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -5,6 +5,7 @@ local wait = helpers.wait
 local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.source
 local eq, neq = helpers.eq, helpers.neq
 local write_file = helpers.write_file
+local command= helpers.command
 
 describe(':terminal buffer', function()
   local screen
@@ -223,6 +224,23 @@ describe(':terminal buffer', function()
       feed('y')
       neq('terminal', eval('&buftype'))
     end)
+  end)
+
+  it('it works with set rightleft #11438', function()
+    local columns = eval('&columns')
+    feed(string.rep('a', columns))
+    command('set rightleft')
+    wait()
+    screen:expect([[
+                                               ydaer ytt|
+      {1:a}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+                                                        |
+                                                        |
+                                                        |
+                                                        |
+      {3:-- TERMINAL --}                                    |
+    ]])
+    feed_command('bdelete!')
   end)
 end)
 


### PR DESCRIPTION
Fixes #11438.

Backtrace:
```
#0  schar_from_ascii ( p=0x801cc9e112c3 <error: Cannot access memory at address 0x801cc9e112c3>, c=32 ' ') at ../src/nvim/screen.c:5263
#1  0x00007f31460eccc5 in win_line (wp=wp@entry=0x7fffc9df6230, lnum=lnum@entry=11, startrow=startrow@entry=10, endrow=41, nochange=false, number_only=number_only@entry=false) at ../src/nvim/screen.c:4025
#2  0x00007f31460eed8e in win_update (wp=wp@entry=0x7fffc9df6230) at ../src/nvim/screen.c:1403
#3  0x00007f31460f011f in update_screen (type=<optimized out>) at ../src/nvim/screen.c:502
#4  0x00007f3146138ef4 in normal_redraw (s=s@entry=0x7fffd0a5f700) at ../src/nvim/normal.c:1247
#5  0x00007f314613b159 in normal_check (state=0x7fffd0a5f700) at ../src/nvim/normal.c:1324
#6  0x00007f31460accfe in state_enter (s=0x7fffd0a5f700) at ../src/nvim/state.c:28
#7  0x00007f3146143099 in normal_enter (cmdwin=<optimized out>, noexmode=<optimized out>) at ../src/nvim/normal.c:463
#8  0x00007f314618b541 in main (argc=<optimized out>, argv=<optimized out>) at ../src/nvim/main.c:580
```