### PR TITLE
cmake: enable exporting symbols from static libs again

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -465,6 +465,7 @@ install_helper(TARGETS nvim)
 
 set_property(TARGET nvim APPEND PROPERTY
              INCLUDE_DIRECTORIES ${LUA_PREFERRED_INCLUDE_DIRS})
+set_property(TARGET nvim PROPERTY ENABLE_EXPORTS TRUE)
 
 if(ENABLE_LTO AND (POLICY CMP0069))
   include(CheckIPOSupported)


### PR DESCRIPTION
Reverts the effect of disabling CMP0065 in ac32426 (#11131) "build: get rid of warnings with `cmake --debug-output`".   `ENABLE_EXPORTS` is the non-deprecated way of achieving the same effect.

We need symbols from statically linked libraries to be exported. Otherwise cpath lua modules will not find liblua/libluajit symbols as needed.