### PR TITLE
metatable for empty dict value

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -717,6 +717,16 @@ vim.NIL								    *vim.NIL*
 	is equivalent to a missing value: `{"foo", nil}` is the same as 
 	`{"foo"}`
 
+vim.empty_dict()					    *vim.empty_dict()*
+	Creates a special table which will be converted to an empty
+	dictionary when converting lua values to vimL or API types. The
+	table is empty, and this property is marked using a metatable. An
+	empty table `{}` without this metatable will default to convert to
+	an array/list.
+
+	Note: if numeric keys are added to the table, the metatable will be
+	ignored and the dict converted to a list/array anyway.
+
 vim.rpcnotify({channel}, {method}[, {args}...])		    *vim.rpcnotify()*
 	Sends {event} to {channel} via |RPC| and returns immediately.
 	If {channel} is 0, the event is broadcast to all channels.

--- a/runtime/lua/vim/inspect.lua
+++ b/runtime/lua/vim/inspect.lua
@@ -244,6 +244,11 @@ function Inspector:putTable(t)
 
     local nonSequentialKeys, nonSequentialKeysLength, sequenceLength = getNonSequentialKeys(t)
     local mt                = getmetatable(t)
+    if (vim and sequenceLength == 0 and nonSequentialKeysLength == 0
+        and mt == vim._empty_dict_mt) then
+      self:puts(tostring(t))
+      return
+    end
 
     self:puts('{')
     self:down(function()

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -275,9 +275,15 @@ function vim.tbl_flatten(t)
 end
 
 -- Determine whether a Lua table can be treated as an array.
+--
+-- An empty table `{}` will default to being treated as an array.
+-- Use `vim.emtpy_dict()` to create a table treated as an
+-- empty dict. Empty tables returned by `rpcrequest()` and
+-- `vim.fn` functions can be checked using this function
+-- whether they represent empty API arrays and vimL lists.
 ---
 --@params Table
---@returns true: A non-empty array, false: A non-empty table, nil: An empty table
+--@returns true: An array-like table, false: A dict-like or mixed table
 function vim.tbl_islist(t)
   if type(t) ~= 'table' then
     return false
@@ -296,7 +302,12 @@ function vim.tbl_islist(t)
   if count > 0 then
     return true
   else
-    return nil
+    -- TODO(bfredl): in the future, we will always be inside nvim
+    -- then this check can be deleted.
+    if vim._empty_dict_mt == nil then
+      return nil
+    end
+    return getmetatable(t) ~= vim._empty_dict_mt
   end
 end
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -324,6 +324,13 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   nlua_nil_ref = nlua_ref(lstate, -1);
   lua_setfield(lstate, -2, "NIL");
 
+  // vim._empty_dict_mt
+  lua_createtable(lstate, 0, 0);
+  lua_pushcfunction(lstate, &nlua_empty_dict_tostring);
+  lua_setfield(lstate, -2, "__tostring");
+  nlua_empty_dict_ref = nlua_ref(lstate, -1);
+  lua_setfield(lstate, -2, "_empty_dict_mt");
+
   // internal vim._treesitter... API
   nlua_add_treesitter(lstate);
 
@@ -662,6 +669,12 @@ check_err:
 static int nlua_nil_tostring(lua_State *lstate)
 {
   lua_pushstring(lstate, "vim.NIL");
+  return 1;
+}
+
+static int nlua_empty_dict_tostring(lua_State *lstate)
+{
+  lua_pushstring(lstate, "vim.empty_dict()");
   return 1;
 }
 

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -13,6 +13,7 @@
 void nlua_add_api_functions(lua_State *lstate) REAL_FATTR_NONNULL_ALL;
 
 EXTERN LuaRef nlua_nil_ref INIT(= LUA_NOREF);
+EXTERN LuaRef nlua_empty_dict_ref INIT(= LUA_NOREF);
 
 #define set_api_error(s, err) \
     do { \

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -243,6 +243,10 @@ function vim.schedule_wrap(cb)
   end)
 end
 
+function vim.empty_dict()
+  return setmetatable({}, vim._empty_dict_mt)
+end
+
 -- vim.fn.{func}(...)
 vim.fn = setmetatable({}, {
   __index = function(t, key)


### PR DESCRIPTION
Use a metatable on an empty table to represent "empty dict" apart from "empty list". This means if you already expected a dict, you don't need to bother with the special `[true]` and `[false]` keys, and just treat it as an empty table.

works:
```
aa = vim.fn.eval("{}")
bb = vim.fn.eval("[]")
print(vim.inspect(aa))
print(vim.inspect(bb))
next(aa) -- nil
next(bb) -- nil
vim.g.aa = aa
vim.g.bb = bb
```

TODO:

- [x] bikeshed printed representation. Currently `{<dict>}`.
- [ ] use it when reading `vim.g` et al (as it is a new interface)
- [x] support in `vim.tbl_islist()`