### PR TITLE
RFC: Mirror vim's terminal-to-job json api

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4539,6 +4539,20 @@ skip_cmd_arg (
   return p;
 }
 
+int populate_bad_opt(exarg_T *eap, char_u *argvalue)
+{
+  if (STRICMP(argvalue, "keep") == 0)
+    eap->bad_char = BAD_KEEP;
+  else if (STRICMP(argvalue, "drop") == 0)
+    eap->bad_char = BAD_DROP;
+  else if (MB_BYTE2LEN(*argvalue) == 1 && argvalue[1] == NUL)
+    eap->bad_char = *argvalue;
+  else
+    return FAIL;
+
+  return OK;
+}
+
 /*
  * Get "++opt=arg" argument.
  * Return FAIL or OK.
@@ -4607,13 +4621,7 @@ static int getargopt(exarg_T *eap)
     /* Check ++bad= argument.  Must be a single-byte character, "keep" or
      * "drop". */
     p = eap->cmd + bad_char_idx;
-    if (STRICMP(p, "keep") == 0)
-      eap->bad_char = BAD_KEEP;
-    else if (STRICMP(p, "drop") == 0)
-      eap->bad_char = BAD_DROP;
-    else if (MB_BYTE2LEN(*p) == 1 && p[1] == NUL)
-      eap->bad_char = *p;
-    else
+    if (populate_bad_opt(eap, p) == FAIL)
       return FAIL;
   }
 

--- a/test/functional/terminal/osc_spec.lua
+++ b/test/functional/terminal/osc_spec.lua
@@ -48,6 +48,48 @@ describe('osc handling', function()
 
         os.remove(fname)
       end)
+
+      it('handles missing argument', function()
+        local screen = Screen.new(25, 10)
+        screen:attach()
+
+        local osc = '\x1b]51;["drop"]\a'
+        emit_osc(osc)
+
+        screen:expect([[
+          ^ $                       |
+          [Process exited 0]       |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+        ]])
+      end)
+    end)
+
+    it('handles empty list', function()
+      local screen = Screen.new(25, 10)
+      screen:attach()
+
+      local osc = '\x1b]51;[]\a'
+      emit_osc(osc)
+
+      screen:expect([[
+        ^ $                       |
+        [Process exited 0]       |
+                                 |
+                                 |
+                                 |
+                                 |
+                                 |
+                                 |
+                                 |
+        E474: Invalid argument   |
+      ]])
     end)
   end)
 end)

--- a/test/functional/terminal/osc_spec.lua
+++ b/test/functional/terminal/osc_spec.lua
@@ -69,6 +69,27 @@ describe('osc handling', function()
                                    |
         ]])
       end)
+
+      it('handles encoding arguments (TODO)', function()
+        local screen = Screen.new(25, 10)
+        screen:attach()
+
+        local osc = '\x1b]51;["drop"]\a' -- TODO
+        emit_osc(osc)
+
+        screen:expect([[
+          ^ $                       |
+          [Process exited 0]       |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+                                   |
+        ]])
+      end)
     end)
 
     it('handles empty list', function()

--- a/test/functional/terminal/osc_spec.lua
+++ b/test/functional/terminal/osc_spec.lua
@@ -1,0 +1,53 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+
+local nvim_dir = helpers.nvim_dir
+local command = helpers.command
+local clear = helpers.clear
+local eq = helpers.eq
+local feed = helpers.feed
+local meths = helpers.meths
+local write_file = helpers.write_file
+
+describe('osc handling', function()
+  function emit_osc(osc)
+    command("term " .. osc)
+  end
+
+  before_each(function()
+    clear()
+
+    meths.set_option('shell', nvim_dir .. '/shell-test')
+    meths.set_option('shellcmdflag', '-t')
+  end)
+
+  describe('osc-51', function()
+    describe('containing a drop command', function()
+      it('opens the specified file in a split', function()
+        local fname = 'drop_target'
+        write_file(fname, 'drop target contents', false)
+
+        local screen = Screen.new(25, 10)
+        screen:attach()
+
+        local osc = '\x1b]51;["drop", "' .. fname .. '"]\a'
+        emit_osc(osc)
+
+        screen:expect([[
+          ^drop target contents     |
+          ~                        |
+          ~                        |
+          ~                        |
+          drop_target              |
+           $                       |
+          [Process exited 0]       |
+                                   |
+          <drop", "drop_target"]^G |
+                                   |
+        ]])
+
+        os.remove(fname)
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
Vim allows programs running within a terminal to emit an escape code which will cause vim to either call a function or start editing a file (`:h terminal-api`).

I've done a little bit of work on this, but before doing any more, I wanted to ask - is a vim terminal feature like this desired? And seeing as vim's terminal and neovim's terminal implementations are pretty different, is this the right thing to do? Or should we attempt to cherry-pick the vim patches regardless - [8.0.1641], [8.0.1660], [8.1.1629] and [8.1.2080] ?

[8.0.1641]: https://github.com/vim/vim/commit/8fbaeb195d9298c3a2a80300b5f96f1adddd2f59
[8.0.1660]: https://github.com/vim/vim/commit/333b80acf3a44e462456e6d5730e47ffa449c83d
[8.1.1629]: https://github.com/vim/vim/commit/6bf2c6264b5ebbe4981751840c5a8b69da08e744
[8.1.2080]: https://github.com/vim/vim/commit/d2842ea60bd608b7f9ec93c77d3f36a8e3bf5fe9
