### PR TITLE
Remove man.vim's K mapping (to :Man)

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -26,7 +26,6 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> j          gj
   nnoremap <silent> <buffer> k          gk
   nnoremap <silent> <buffer> gO         :call man#show_toc()<CR>
-  nnoremap <silent> <buffer> K          :Man<CR>
   if 1 == bufnr('%') || s:pager
     nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
   else


### PR DESCRIPTION
A follow-up to #11457 - this mapping is no longer necessary.

(`'keywordprg'` defaults to `:Man` in [options.lua])

[options.lua]: https://github.com/neovim/neovim/blob/49a40f425d88cbbac09fdf442c22f725bffc2249/src/nvim/options.lua#L1329