### PR TITLE
oldtest: support for running by filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,11 @@ else
 	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" \
 	  $(patsubst %.vim,%,$(patsubst %.res,%,$(TEST_FILE))) SCRIPTS= $(MAKEOVERRIDES)
 endif
-# Build oldtest by specifying the .vim filename.
+# Build oldtest by specifying the relative .vim filename.
 .PHONY: phony_force
 src/nvim/testdir/%.vim: phony_force
-	$(MAKE) oldtest NEW_TESTS=$(patsubst src/nvim/testdir/%.vim,%,$@)
+	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" \
+	  $(patsubst src/nvim/testdir/%.vim,%,$@) SCRIPTS= $(MAKEOVERRIDES)
 
 build/runtime/doc/tags helptags: | nvim
 	+$(BUILD_CMD) -C build runtime/doc/tags

--- a/Makefile
+++ b/Makefile
@@ -120,13 +120,12 @@ ifeq ($(strip $(TEST_FILE)),)
 	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" $(MAKEOVERRIDES)
 else
 	@# Handle TEST_FILE=test_foo{,.res,.vim}.
-	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" $(MAKEOVERRIDES) SCRIPTS= $(patsubst %.vim,%,$(patsubst %.res,%,$(TEST_FILE)))
+	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" SCRIPTS= $(MAKEOVERRIDES) $(patsubst %.vim,%,$(patsubst %.res,%,$(TEST_FILE)))
 endif
 # Build oldtest by specifying the relative .vim filename.
 .PHONY: phony_force
 src/nvim/testdir/%.vim: phony_force
-	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" \
-	  $(patsubst src/nvim/testdir/%.vim,%,$@) SCRIPTS= $(MAKEOVERRIDES)
+	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" SCRIPTS= $(MAKEOVERRIDES) $(patsubst src/nvim/testdir/%.vim,%,$@)
 
 build/runtime/doc/tags helptags: | nvim
 	+$(BUILD_CMD) -C build runtime/doc/tags

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,7 @@ ifeq ($(strip $(TEST_FILE)),)
 	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" $(MAKEOVERRIDES)
 else
 	@# Handle TEST_FILE=test_foo{,.res,.vim}.
-	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" \
-	  $(patsubst %.vim,%,$(patsubst %.res,%,$(TEST_FILE))) SCRIPTS= $(MAKEOVERRIDES)
+	+$(SINGLE_MAKE) -C src/nvim/testdir NVIM_PRG="$(realpath build/bin/nvim)" $(MAKEOVERRIDES) SCRIPTS= $(patsubst %.vim,%,$(patsubst %.res,%,$(TEST_FILE)))
 endif
 # Build oldtest by specifying the relative .vim filename.
 .PHONY: phony_force

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -49,8 +49,8 @@ NEW_TESTS_IGNORE := \
   test_listlbr \
   test_largefile \
 
-NEW_TESTS ?= $(sort $(filter-out $(NEW_TESTS_ALOT) $(NEW_TESTS_IN_ALOT) $(NEW_TESTS_IGNORE),$(basename $(notdir $(wildcard test_*.vim))))) $(NEW_TESTS_ALOT)
-NEW_TESTS_RES ?= $(addsuffix .res,$(NEW_TESTS))
+NEW_TESTS := $(sort $(basename $(notdir $(wildcard test_*.vim))))
+NEW_TESTS_RES := $(addsuffix .res,$(filter-out $(NEW_TESTS_ALOT) $(NEW_TESTS_IN_ALOT) $(NEW_TESTS_IGNORE),$(NEW_TESTS)) $(NEW_TESTS_ALOT))
 
 
 ifdef VALGRIND_GDB

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -34,21 +34,22 @@ SCRIPTS ?= $(SCRIPTS_DEFAULT)
 
 # Tests using runtest.vim.
 NEW_TESTS_ALOT := test_alot_utf8 test_alot
-NEW_TESTS_IN_ALOT := $(shell sed '/^source/ s/^source //;s/\.vim$$//' test_alot*.vim)
+NEW_TESTS_IN_ALOT := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' $(addsuffix .vim,$(NEW_TESTS_ALOT)))
+NEW_TESTS_IN_ALOT_LATIN := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' test_alot_latin.vim)
 # Ignored tests.
 # test_alot_latin: Nvim does not allow setting encoding.
 # test_autochdir: ported to Lua, but kept for easier merging.
 # test_eval_func: used as include in old-style test (test_eval.in).
 # test_listlbr: Nvim does not allow setting encoding.
 # test_largefile: uses too much resources to run on CI.
-NEW_TESTS_IGNORE := $(NEW_TESTS_IN_ALOT) $(NEW_TESTS_ALOT) \
-  test_alot_latin \
+NEW_TESTS_IGNORE := \
+  test_alot_latin $(NEW_TESTS_IN_ALOT_LATIN) \
   test_autochdir \
   test_eval_func \
   test_listlbr \
   test_largefile \
 
-NEW_TESTS ?= $(sort $(filter-out $(NEW_TESTS_IGNORE),$(basename $(notdir $(wildcard test_*.vim))))) $(NEW_TESTS_ALOT)
+NEW_TESTS ?= $(sort $(filter-out $(NEW_TESTS_ALOT) $(NEW_TESTS_IN_ALOT) $(NEW_TESTS_IGNORE),$(basename $(notdir $(wildcard test_*.vim))))) $(NEW_TESTS_ALOT)
 NEW_TESTS_RES ?= $(addsuffix .res,$(NEW_TESTS))
 
 
@@ -114,7 +115,7 @@ fixff:
 	  dotest.in
 
 # Execute an individual new style test, e.g.:
-# make test_largefile
+# 	make test_largefile
 $(NEW_TESTS):
 	rm -f $@.res test.log messages
 	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile $@.res

--- a/test/README.md
+++ b/test/README.md
@@ -77,7 +77,11 @@ To run all legacy Vim tests:
 
     make oldtest
 
-To run a *single* legacy test file:
+To run a *single* legacy test file you can use either:
+
+    make oldtest TEST_FILE=test_syntax.vim
+
+or:
 
     make src/nvim/testdir/test_syntax.vim
 

--- a/test/README.md
+++ b/test/README.md
@@ -77,11 +77,10 @@ To run all legacy Vim tests:
 
     make oldtest
 
-To run a *single* legacy test set `TEST_FILE`, for example:
+To run a *single* legacy test file:
 
-    TEST_FILE=test_syntax.res make oldtest
+    make src/nvim/testdir/test_syntax.vim
 
-- The `.res` extension (instead of `.vim`) is required.
 - Specify only the test file name, not the full path.
 
 


### PR DESCRIPTION
Follow-up to 8969efca8 (vim-patch:8.1.0723)

NOTE: This changes the main entrypoint for running single oldtest files
to not use/require the ".res" extension anymore.  But it is handled for
B/C.

Adds a phony rule to run oldtest by filename.

testdir/Makefile: only keep files in NEW_TESTS_IN_ALOT

Taken out of https://github.com/neovim/neovim/pull/10650.