### PR TITLE
floatwin: show error if window is closed immediately

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1096,6 +1096,10 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dictionary config,
   if (enter) {
     win_enter(wp, false);
   }
+  if (!win_valid(wp)) {
+    api_set_error(err, kErrorTypeException, "Window was closed immediately");
+    return 0;
+  }
   if (buffer > 0) {
     nvim_win_set_buf(wp->handle, buffer, err);
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4372,9 +4372,10 @@ static void win_goto_hor(bool left, long count)
   }
 }
 
-/*
- * Make window "wp" the current window.
- */
+/// Make window `wp` the current window.
+///
+/// @warning Autocmds may close the window immediately, so caller must check
+///          win_valid(wp).
 void win_enter(win_T *wp, bool undo_sync)
 {
   win_enter_ext(wp, undo_sync, false, false, true, true);

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -52,10 +52,10 @@ describe('UI receives option updates', function()
     local evs = {}
     screen = Screen.new(20,5)
     -- Override mouse_on/mouse_off handlers.
-    function screen._handle_mouse_on()
+    function screen:_handle_mouse_on()
       table.insert(evs, 'mouse_on')
     end
-    function screen._handle_mouse_off()
+    function screen:_handle_mouse_off()
       table.insert(evs, 'mouse_off')
     end
     screen:attach()


### PR DESCRIPTION
Autocmds may close window while it is being entered, then win_set_minimal_style(wp) operates on an invalid pointer.

We could silently ignore this instead, but it is unlikely to be intentional, so it is more useful to show an error.

fix #11383