### PR TITLE
vim-patch:8.1.2017: cannot execute commands after closing the cmdline window

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -559,16 +559,14 @@ CmdlineLeave			Before leaving the command-line (including
 							*CmdwinEnter*
 CmdwinEnter			After entering the command-line window.
 				Useful for setting options specifically for
-				this special type of window.  This is
-				triggered _instead_ of BufEnter and WinEnter.
+				this special type of window.
 				<afile> is set to a single character,
 				indicating the type of command-line.
 				|cmdwin-char|
 							*CmdwinLeave*
 CmdwinLeave			Before leaving the command-line window.
 				Useful to clean up any global setting done
-				with CmdwinEnter.  This is triggered _instead_
-				of BufLeave and WinLeave.
+				with CmdwinEnter.
 				<afile> is set to a single character,
 				indicating the type of command-line.
 				|cmdwin-char|

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1122,11 +1122,9 @@ edited as described in |cmdwin-char|.
 
 AUTOCOMMANDS
 
-Two autocommand events are used: |CmdwinEnter| and |CmdwinLeave|.  Since this
-window is of a special type, the WinEnter, WinLeave, BufEnter and BufLeave
-events are not triggered.  You can use the Cmdwin events to do settings
-specifically for the command-line window.  Be careful not to cause side
-effects!
+Two autocommand events are used: |CmdwinEnter| and |CmdwinLeave|.  You can use
+the Cmdwin events to do settings specifically for the command-line window.
+Be careful not to cause side effects!
 Example: >
 	:au CmdwinEnter :  let b:cpt_save = &cpt | set cpt=.
 	:au CmdwinLeave :  let &cpt = b:cpt_save

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6078,11 +6078,8 @@ static int open_cmdwin(void)
 
   set_bufref(&old_curbuf, curbuf);
 
-  /* Save current window sizes. */
+  // Save current window sizes.
   win_size_save(&winsizes);
-
-  /* Don't execute autocommands while creating the window. */
-  block_autocmds();
 
   // When using completion in Insert mode with <C-R>=<C-F> one can open the
   // command line window, but we don't want the popup menu then.
@@ -6092,10 +6089,9 @@ static int open_cmdwin(void)
   cmdmod.tab = 0;
   cmdmod.noswapfile = 1;
 
-  /* Create a window for the command-line buffer. */
+  // Create a window for the command-line buffer.
   if (win_split((int)p_cwh, WSP_BOT) == FAIL) {
     beep_flush();
-    unblock_autocmds();
     return K_IGNORE;
   }
   cmdwin_type = get_cmdline_type();
@@ -6110,13 +6106,11 @@ static int open_cmdwin(void)
   curbuf->b_p_ma = true;
   curwin->w_p_fen = false;
 
-  // Do execute autocommands for setting the filetype (load syntax).
-  unblock_autocmds();
-  // But don't allow switching to another buffer.
+  // Don't allow switching to another buffer.
   curbuf_lock++;
 
-  /* Showing the prompt may have set need_wait_return, reset it. */
-  need_wait_return = FALSE;
+  // Showing the prompt may have set need_wait_return, reset it.
+  need_wait_return = false;
 
   const int histtype = hist_char2type(cmdwin_type);
   if (histtype == HIST_CMD || histtype == HIST_DEBUG) {
@@ -6128,11 +6122,11 @@ static int open_cmdwin(void)
   }
   curbuf_lock--;
 
-  /* Reset 'textwidth' after setting 'filetype' (the Vim filetype plugin
-   * sets 'textwidth' to 78). */
+  // Reset 'textwidth' after setting 'filetype' (the Vim filetype plugin
+  // sets 'textwidth' to 78).
   curbuf->b_p_tw = 0;
 
-  /* Fill the buffer with the history. */
+  // Fill the buffer with the history.
   init_history();
   if (hislen > 0 && histtype != HIST_INVALID) {
     i = hisidx[histtype];
@@ -6173,9 +6167,10 @@ static int open_cmdwin(void)
   // Trigger CmdwinEnter autocommands.
   typestr[0] = (char_u)cmdwin_type;
   typestr[1] = NUL;
-  apply_autocmds(EVENT_CMDWINENTER, typestr, typestr, FALSE, curbuf);
-  if (restart_edit != 0)        /* autocmd with ":startinsert" */
+  apply_autocmds(EVENT_CMDWINENTER, typestr, typestr, false, curbuf);
+  if (restart_edit != 0) {  // autocmd with ":startinsert"
     stuffcharReadbuff(K_NOP);
+  }
 
   i = RedrawingDisabled;
   RedrawingDisabled = 0;
@@ -6192,10 +6187,10 @@ static int open_cmdwin(void)
 
   const bool save_KeyTyped = KeyTyped;
 
-  /* Trigger CmdwinLeave autocommands. */
-  apply_autocmds(EVENT_CMDWINLEAVE, typestr, typestr, FALSE, curbuf);
+  // Trigger CmdwinLeave autocommands.
+  apply_autocmds(EVENT_CMDWINLEAVE, typestr, typestr, false, curbuf);
 
-  /* Restore KeyTyped in case it is modified by autocommands */
+  // Restore KeyTyped in case it is modified by autocommands
   KeyTyped = save_KeyTyped;
 
   // Restore the command line info.
@@ -6254,9 +6249,7 @@ static int open_cmdwin(void)
       }
     }
 
-    /* Don't execute autocommands while deleting the window. */
-    block_autocmds();
-    // Avoid command-line window first character being concealed
+    // Avoid command-line window first character being concealed.
     curwin->w_p_cole = 0;
     wp = curwin;
     set_bufref(&bufref, curbuf);
@@ -6269,10 +6262,8 @@ static int open_cmdwin(void)
       close_buffer(NULL, bufref.br_buf, DOBUF_WIPE, false);
     }
 
-    /* Restore window sizes. */
+    // Restore window sizes.
     win_size_restore(&winsizes);
-
-    unblock_autocmds();
   }
 
   ga_clear(&winsizes);

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -619,6 +619,8 @@ func Check_cmdline(cmdtype)
   return ''
 endfunc
 
+set cpo&
+
 func Test_getcmdtype()
   call feedkeys(":MyCmd a\<C-R>=Check_cmdline(':')\<CR>\<Esc>", "xt")
 
@@ -657,6 +659,37 @@ func Test_getcmdwintype()
   call assert_equal(':', a)
 
   call assert_equal('', getcmdwintype())
+endfunc
+
+func Test_getcmdwin_autocmd()
+  let s:seq = []
+  augroup CmdWin
+  au WinEnter * call add(s:seq, 'WinEnter ' .. win_getid())
+  au WinLeave * call add(s:seq, 'WinLeave ' .. win_getid())
+  au BufEnter * call add(s:seq, 'BufEnter ' .. bufnr())
+  au BufLeave * call add(s:seq, 'BufLeave ' .. bufnr())
+  au CmdWinEnter * call add(s:seq, 'CmdWinEnter ' .. win_getid())
+  au CmdWinLeave * call add(s:seq, 'CmdWinLeave ' .. win_getid())
+
+  let org_winid = win_getid()
+  let org_bufnr = bufnr()
+  call feedkeys("q::let a = getcmdwintype()\<CR>:let s:cmd_winid = win_getid()\<CR>:let s:cmd_bufnr = bufnr()\<CR>:q\<CR>", 'x!')
+  call assert_equal(':', a)
+  call assert_equal([
+	\ 'WinLeave ' .. org_winid,
+	\ 'WinEnter ' .. s:cmd_winid,
+	\ 'BufLeave ' .. org_bufnr,
+	\ 'BufEnter ' .. s:cmd_bufnr,
+	\ 'CmdWinEnter ' .. s:cmd_winid,
+	\ 'CmdWinLeave ' .. s:cmd_winid,
+	\ 'BufLeave ' .. s:cmd_bufnr,
+	\ 'WinLeave ' .. s:cmd_winid,
+	\ 'WinEnter ' .. org_winid,
+	\ 'BufEnter ' .. org_bufnr,
+	\ ], s:seq)
+
+  au!
+  augroup END
 endfunc
 
 func Test_verbosefile()
@@ -717,5 +750,3 @@ func Test_cmdline_overstrike()
 
   let &encoding = encoding_save
 endfunc
-
-set cpo&


### PR DESCRIPTION
Problem:    Cannot execute commands after closing the cmdline window.
Solution:   Also trigger BufEnter and WinEnter. (closes vim/vim#4762)
https://github.com/vim/vim/commit/96e38a86a710fb6daec4550ac1667f019dc3a40e

Fixes https://github.com/neovim/neovim/issues/11279.