### PR TITLE
vim-patch:8.1.2315: not always using the right window when jumping to an error

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6014,6 +6014,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   vsplit	Just like "split" but split vertically.
 	   newtab	Like "split", but open a new tab page.  Overrules
 			"split" when both are present.
+	   uselast	If included, jump to the previously used window when
+			jumping to errors with |quickfix| commands.
 
 						*'synmaxcol'* *'smc'*
 'synmaxcol' 'smc'	number	(default 3000)

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -612,13 +612,14 @@ EXTERN char_u   *p_swb;         // 'switchbuf'
 EXTERN unsigned swb_flags;
 #ifdef IN_OPTION_C
 static char *(p_swb_values[]) =
-  { "useopen", "usetab", "split", "newtab", "vsplit", NULL };
+  { "useopen", "usetab", "split", "newtab", "vsplit", "uselast", NULL };
 #endif
 #define SWB_USEOPEN             0x001
 #define SWB_USETAB              0x002
 #define SWB_SPLIT               0x004
 #define SWB_NEWTAB              0x008
 #define SWB_VSPLIT              0x010
+#define SWB_USELAST             0x020
 EXTERN int p_tbs;               ///< 'tagbsearch'
 EXTERN char_u *p_tc;            ///< 'tagcase'
 EXTERN unsigned tc_flags;       ///< flags from 'tagcase'

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2595,8 +2595,11 @@ static void qf_goto_win_with_qfl_file(int qf_fnum)
 
     if (IS_QF_WINDOW(win)) {
       // Didn't find it, go to the window before the quickfix
-      // window.
-      if (altwin != NULL) {
+      // window, unless 'switchbuf' contains 'uselast': in this case we
+      // try to jump to the previously used window first.
+      if ((swb_flags & SWB_USELAST) && win_valid(prevwin)) {
+        win = prevwin;
+      } else if (altwin != NULL) {
         win = altwin;
       } else if (curwin->w_prev != NULL) {
         win = curwin->w_prev;

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1642,6 +1642,14 @@ func Test_switchbuf()
   call assert_equal(3, tabpagenr('$'))
   tabfirst | enew | tabonly | only
 
+  set switchbuf=uselast
+  split
+  let last_winid = win_getid()
+  copen
+  exe "normal 1G\<CR>"
+  call assert_equal(last_winid, win_getid())
+  enew | only
+
   set switchbuf=
   edit Xqftestfile1
   let file1_winid = win_getid()


### PR DESCRIPTION
Problem:    Not always using the right window when jumping to an error.
Solution:   Add the "uselast" flag in 'switchbuf'. (closes vim/vim#1652)
https://github.com/vim/vim/commit/539aa6b25eaea91dfd1a175cd053c0f259fa2e58