### PR TITLE
screen.lua: remove screen:_on_event

### DIFF
--- a/test/functional/example_spec.lua
+++ b/test/functional/example_spec.lua
@@ -3,7 +3,10 @@
 
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
-local clear, feed = helpers.clear, helpers.feed
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local feed = helpers.feed
 
 describe('example', function()
   local screen
@@ -32,5 +35,38 @@ describe('example', function()
       {0:~                   }|
                           |
     ]])
+  end)
+
+  it('override UI event-handler', function()
+    -- Example: override the "tabline_update" UI event handler.
+    --
+    -- screen.lua defines default handlers for UI events, but tests
+    -- may sometimes want to override a handler.
+
+    -- The UI must declare that it wants to handle the UI events.
+    -- For this example, we enable `ext_tabline`:
+    screen:detach()
+    screen = Screen.new(25, 5)
+    screen:attach({rgb=true, ext_tabline=true})
+
+    -- From ":help ui" we find that `tabline_update` receives `curtab` and
+    -- `tabs` objects. So we declare the UI handler like this:
+    local event_tabs, event_curtab
+    function screen:_handle_tabline_update(curtab, tabs)
+      event_curtab, event_tabs = curtab, tabs
+    end
+
+    -- Create a tabpage...
+    command('tabedit foo')
+
+    -- Use screen:expect{condition=…} to check the result.
+    screen:expect{condition=function()
+      eq({ id = 2 }, event_curtab)
+      eq({
+          {tab = { id = 1 }, name = '[No Name]'},
+          {tab = { id = 2 }, name = 'foo'},
+        },
+        event_tabs)
+    end}
   end)
 end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -606,17 +606,12 @@ function Screen:_redraw(updates)
     for i = 2, #update do
       local handler_name = '_handle_'..method
       local handler = self[handler_name]
-      if handler ~= nil then
-        local status, res = pcall(handler, self, unpack(update[i]))
-        if not status then
-          error(handler_name..' failed'
-            ..'\n  payload: '..inspect(update)
-            ..'\n  error:   '..tostring(res))
-        end
-      else
-        assert(self._on_event,
-          "Add Screen:"..handler_name.." or call Screen:set_on_event_handler")
-        self._on_event(method, update[i])
+      assert(handler ~= nil, "missing handler: Screen:"..handler_name)
+      local status, res = pcall(handler, self, unpack(update[i]))
+      if not status then
+        error(handler_name..' failed'
+          ..'\n  payload: '..inspect(update)
+          ..'\n  error:   '..tostring(res))
       end
     end
     if k == #updates and method == "flush" then
@@ -624,10 +619,6 @@ function Screen:_redraw(updates)
     end
   end
   return did_flush
-end
-
-function Screen:set_on_event_handler(callback)
-  self._on_event = callback
 end
 
 function Screen:_handle_resize(width, height)

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -10,11 +10,9 @@ describe('ui/ext_tabline', function()
     clear()
     screen = Screen.new(25, 5)
     screen:attach({rgb=true, ext_tabline=true})
-    screen:set_on_event_handler(function(name, data)
-      if name == "tabline_update" then
-        event_curtab, event_tabs = unpack(data)
-      end
-    end)
+    function screen:_handle_tabline_update(curtab, tabs)
+      event_curtab, event_tabs = curtab, tabs
+    end
   end)
 
   it('publishes UI events', function()


### PR DESCRIPTION
Tests can redefine the handlers, so we don't need this extra hook. (Though maybe it is/was useful for debugging?)