### PR TITLE
log_init: call log_path_init

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -93,6 +93,7 @@ static bool log_path_init(void)
 void log_init(void)
 {
   uv_mutex_init(&mutex);
+  log_path_init();
 }
 
 void log_lock(void)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -144,7 +144,6 @@ static const char *err_extra_cmd =
 
 void event_init(void)
 {
-  log_init();
   loop_init(&main_loop, NULL);
   resize_events = multiqueue_new_child(main_loop.events);
 
@@ -220,6 +219,7 @@ void early_init(void)
   // First find out the home directory, needed to expand "~" in options.
   init_homedir();               // find real value of $HOME
   set_init_1();
+  log_init();
   TIME_MSG("inits 1");
 
   set_lang_var();               // set v:lang and v:ctype

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -224,9 +224,6 @@ describe('startup defaults', function()
         XDG_DATA_HOME=xdgdir,
         NVIM_LOG_FILE='',  -- Empty is invalid.
       }})
-      -- server_start() calls ELOG, which tickles log_path_init().
-      pcall(command, 'call serverstart(serverlist()[0])')
-
       eq(xdgdir..'/'..datasubdir..'/log', string.gsub(eval('$NVIM_LOG_FILE'), '\\', '/'))
     end)
     it('defaults to stdpath("data")/log if invalid', function()
@@ -235,9 +232,6 @@ describe('startup defaults', function()
         XDG_DATA_HOME=xdgdir,
         NVIM_LOG_FILE='.',  -- Any directory is invalid.
       }})
-      -- server_start() calls ELOG, which tickles log_path_init().
-      pcall(command, 'call serverstart(serverlist()[0])')
-
       eq(xdgdir..'/'..datasubdir..'/log', string.gsub(eval('$NVIM_LOG_FILE'), '\\', '/'))
     end)
     it('defaults to .nvimlog if stdpath("data") is invalid', function()
@@ -245,9 +239,6 @@ describe('startup defaults', function()
         XDG_DATA_HOME='Xtest-missing-xdg-dir',
         NVIM_LOG_FILE='.',  -- Any directory is invalid.
       }})
-      -- server_start() calls ELOG, which tickles log_path_init().
-      pcall(command, 'call serverstart(serverlist()[0])')
-
       eq('.nvimlog', eval('$NVIM_LOG_FILE'))
     end)
   end)


### PR DESCRIPTION
This has to be done after `init_homedir` for XDG default and `set_init_1` for
lookup from env, which could be done earlier likely (to help with
https://github.com/neovim/neovim/issues/10937), but this keeps it in
sync with Vim.

Fixes https://github.com/neovim/neovim/issues/11499.