### PR TITLE
[RFC] Add mapping to navigate by header for markdown filetypes

### DIFF
--- a/runtime/ftplugin/markdown.vim
+++ b/runtime/ftplugin/markdown.vim
@@ -13,6 +13,10 @@ setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=>\ %s
 setlocal formatoptions+=tcqln formatoptions-=r formatoptions-=o
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+\\\|^\\[^\\ze[^\\]]\\+\\]:
 
+let s:headers = '^#\{1,5}\s*[a-z]'
+execute 'nnoremap <buffer> <silent> [[ ?' . s:headers . '?<CR>:nohls<CR>'
+execute 'nnoremap <buffer> <silent> ]] /' . s:headers . '/<CR>:nohls<CR>'
+
 if exists('b:undo_ftplugin')
   let b:undo_ftplugin .= "|setl cms< com< fo< flp<"
 else


### PR DESCRIPTION
In a similar vein to [ftplugin/php.vim](https://github.com/neovim/neovim/blob/master/runtime/ftplugin/php.vim) this adds a mapping for `]]`/`[[` to go to the next markdown header (specified with `#`). I've omitted the `====` and `----` style headers as they only cover `h1` and `h2` tags.