### PR TITLE
API: nvim_exec: fix script-scope

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -114,6 +114,15 @@ describe('API', function()
       nvim('exec','autocmd BufAdd * :let x1 = "Hello"', false)
       nvim('command', 'new foo')
       eq('Hello', request('nvim_eval', 'g:x1'))
+
+      -- Script scope (s:)
+      eq('ahoy! script-scoped varrrrr', nvim('exec', [[
+          let s:pirate = 'script-scoped varrrrr'
+          func! s:avast_ye_hades(s) abort
+            return s.' '.s:pirate
+          endf
+          echo <sid>avast_ye_hades('ahoy!')
+        ]], true))
     end)
 
     it('non-ASCII input', function()


### PR DESCRIPTION
- handle script-scope (`s:`, `<SID>`) variables and functions

TODO:

- Does `nvim_exec` need other options, e.g. the "silent" flag from
  `execute()`?
- If nvim_exec is done in a script, the "Last set by" field should not
  be "anonymous". Also for the traceback script name and line number.

Example:

    foo.vim:

        call nvim_exec('set wrap',v:true)

    :source foo.vim
    :verbose set wrap?