### PR TITLE
TUI: can make the cursor transparent

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -149,6 +149,8 @@ Nvim will adjust the shape of the cursor from a block to a line when in insert
 mode (or as specified by the 'guicursor' option), on terminals that support
 it.  It uses the same |terminfo| extensions that were pioneered by tmux for
 this: "Ss" and "Se".
+Similarly, if you set the cursor highlight group with blend=100, Nvim hides
+the cursor through the "cvvis" and "civis" extensions.
 
 If your terminfo definition is missing them, then Nvim will decide whether to
 add them to your terminfo definition, by looking at $TERM and other

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -294,7 +294,8 @@ numerical highlight ids to the actual attributes.
 	`underline`:	underlined text. The line has `special` color.
 	`undercurl`:	undercurled text. The curl has `special` color.
 	`blend`:	Blend level (0-100). Could be used by UIs to support
-			blending floating windows to the background.
+			blending floating windows to the background or to
+			signal a transparent cursor.
 
 	For absent color keys the default color should be used. Don't store
 	the default value in the table, rather a sentinel value, so that

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -245,6 +245,25 @@ describe('ui/cursor', function()
       eq('normal', screen.mode)
     end)
 
+    -- update the highlight again to hide cursor
+    helpers.command('hi Cursor blend=100')
+
+    for _, m in ipairs(expected_mode_info) do
+      if m.hl_id then
+          m.attr = {background = Screen.colors.Red, blend = 100}
+      end
+    end
+    screen:expect{grid=[[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+      test                     |
+    ]], condition=function()
+      eq(expected_mode_info, screen._mode_info)
+    end
+    }
+
     -- Another cursor style.
     meths.set_option('guicursor', 'n-v-c:ver35-blinkwait171-blinkoff172-blinkon173'
       ..',ve:hor35,o:ver50,i-ci:block,r-cr:hor90,sm:ver42')


### PR DESCRIPTION
makes the cursor transparent when setting the cursor highlight blend to 100.

I've been testing with `nvim -u test.vim` in kitty
```
" snd hl group is for language mappings
set guicursor=n-v-c:block-blinkon250-Cursor/lCursor
" ve = visual exclusive
set guicursor+=ve:ver35-Cursor,
" operator-pending mode
set guicursor+=o:hor50-Cursor
" ci => command insert mode
set guicursor+=i-ci:ver25-blinkon250-CursorTransparent/lCursor
set guicursor+=r-cr:hor20-Cursor/lCursor

set termguicolors

highl CursorTransparent ctermfg=16 ctermbg=253 guifg=#000000 guibg=#00FF00 gui=strikethrough blend=100
highl Cursor ctermfg=16 ctermbg=253 guifg=#000000 guibg=#00FF00

```

seems like the codes for invisible cursor is overriden by neovim for the linux terminal but if we control unibilium, maybe we can move the fix over there.