### PR TITLE
LSP: fix omnifunc findstart

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -864,29 +864,15 @@ function lsp.omnifunc(findstart, base)
   else
     -- Then, perform standard completion request
     log.info("base ", base)
-    
+ 
     local pos = vim.api.nvim_win_get_cursor(0)
     local line = vim.api.nvim_get_current_line()
     local line_to_cursor = line:sub(1, pos[2])
     local _ = log.trace() and log.trace("omnifunc.line", pos, line)
-   
 
     -- Get the start postion of the current keyword 
     local textMatch = vim.fn.match(line_to_cursor, '\\k*$')
-
-    local params = {
-       textDocument = { uri = vim.uri_from_bufnr(bufnr); };
-       position = {
-         -- 0-indexed for both line and character
-         line = pos[1] - 1,
-         character = pos[2],
-        };
-       -- The completion context. This is only available if the client specifies
-       -- to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
-       -- context = nil or {
-       --  triggerKind = protocol.CompletionTriggerKind.Invoked;
-       --  triggerCharacter = nil or "";
-    };
+    local params = util.make_position_params()
 
     -- TODO handle timeout error differently? Like via an error?
     local client_responses = lsp.buf_request_sync(bufnr, 'textDocument/completion', params) or {}

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -863,7 +863,7 @@ function lsp.omnifunc(findstart, base)
   local line_to_cursor = line:sub(1, pos[2])
 
   if findstart == 1 then
-    local wordPos = vim.call("eval", string.format("match('%s', '\\k*$')", line_to_cursor))
+    local wordPos = vim.fn.match(line_to_cursor, '\\k*$')
     return wordPos
 
   else

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -844,6 +844,11 @@ function lsp.buf_notify(bufnr, method, params)
   end)
 end
 
+local line = nil;
+local pos = nil;
+local line_to_cursor = nil;
+local textMatch = nil;
+
 --- Function which can be called to generate omnifunc compatible completion.
 function lsp.omnifunc(findstart, base)
   local _ = log.debug() and log.debug("omnifunc.findstart", { findstart = findstart, base = base })
@@ -858,18 +863,31 @@ function lsp.omnifunc(findstart, base)
     end
   end
 
-  local line = vim.api.nvim_get_current_line()
-  local pos = vim.api.nvim_win_get_cursor(0)
-  local line_to_cursor = line:sub(1, pos[2])
 
   if findstart == 1 then
-    local wordPos = vim.fn.match(line_to_cursor, '\\k*$')
-    return wordPos
+
+    line = vim.api.nvim_get_current_line()
+    pos = vim.api.nvim_win_get_cursor(0)
+    line_to_cursor = line:sub(1, pos[2])
+    
+    textMatch = vim.fn.matchstrpos(line_to_cursor, '\\k*$')
+    return textMatch[2]
 
   else
     local _ = log.trace() and log.trace("omnifunc.line", pos, line)
-    local _ = log.trace() and log.trace("omnifunc.line_to_cursor", line_to_cursor)
-    local params = util.make_position_params()
+    local params = {
+       textDocument = { uri = vim.uri_from_bufnr(bufnr); };
+       position = {
+         -- 0-indexed for both line and character
+         line = pos[1] - 1,
+         character = pos[2],
+       };       
+       -- The completion context. This is only available if the client specifies
+       -- to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+       -- context = nil or {
+       --  triggerKind = protocol.CompletionTriggerKind.Invoked;
+       --  triggerCharacter = nil or "";
+    };
 
     -- TODO handle timeout error differently? Like via an error?
     local client_responses = lsp.buf_request_sync(bufnr, 'textDocument/completion', params) or {}

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -864,13 +864,13 @@ function lsp.omnifunc(findstart, base)
   else
     -- Then, perform standard completion request
     log.info("base ", base)
- 
+
     local pos = vim.api.nvim_win_get_cursor(0)
     local line = vim.api.nvim_get_current_line()
     local line_to_cursor = line:sub(1, pos[2])
     local _ = log.trace() and log.trace("omnifunc.line", pos, line)
 
-    -- Get the start postion of the current keyword 
+    -- Get the start postion of the current keyword
     local textMatch = vim.fn.match(line_to_cursor, '\\k*$')
     local params = util.make_position_params()
 
@@ -881,7 +881,7 @@ function lsp.omnifunc(findstart, base)
       -- TODO how to handle errors?
       if not response.error then
         local data = response.result
-        local completion_items = util.text_document_completion_list_to_complete_items(data or {}, line_to_cursor)
+        local completion_items = util.text_document_completion_list_to_complete_items(data or {})
         local _ = log.trace() and log.trace("omnifunc.completion_items", completion_items)
         vim.list_extend(matches, completion_items)
       end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -19,21 +19,6 @@ local function npcall(fn, ...)
   return ok_or_nil(pcall(fn, ...))
 end
 
---- Find the longest shared prefix between prefix and word.
--- e.g. remove_prefix("123tes", "testing") == "ting"
-local function remove_prefix(prefix, word)
-  local max_prefix_length = math.min(#prefix, #word)
-  local prefix_length = 0
-  for i = 1, max_prefix_length do
-    local current_line_suffix = prefix:sub(-i)
-    local word_prefix = word:sub(1, i)
-    if current_line_suffix == word_prefix then
-      prefix_length = i
-    end
-  end
-  return word:sub(prefix_length + 1)
-end
-
 -- TODO(ashkan) @performance this could do less copying.
 function M.set_lines(lines, A, B, new_lines)
   -- 0-indexing to 1-indexing
@@ -161,14 +146,10 @@ end
 --- Getting vim complete-items with incomplete flag.
 -- @params CompletionItem[], CompletionList or nil (https://microsoft.github.io/language-server-protocol/specification#textDocument_completion)
 -- @return { matches = complete-items table, incomplete = boolean  }
-function M.text_document_completion_list_to_complete_items(result, line_prefix)
+function M.text_document_completion_list_to_complete_items(result)
   local items = M.extract_completion_items(result)
   if vim.tbl_isempty(items) then
     return {}
-  end
-  -- Only initialize if we have some items.
-  if not line_prefix then
-    line_prefix = M.get_current_line_to_cursor()
   end
 
   local matches = {}

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -187,10 +187,8 @@ function M.text_document_completion_list_to_complete_items(result, line_prefix)
     end
 
     local word = completion_item.insertText or completion_item.label
-
-    -- Ref: `:h complete-items`
     table.insert(matches, {
-      word = remove_prefix(line_prefix, word),
+      word = word,
       abbr = completion_item.label,
       kind = protocol.CompletionItemKind[completion_item.kind] or '',
       menu = completion_item.detail or '',


### PR DESCRIPTION
Mentioned last week to @norcalli, but the current omnifunc for LSP doesn't properly try to find the correct position for the word being completed. Instead it would just return the current cursor position.

This PR fixes the behaviour.


![nvim-lsp-omni](https://user-images.githubusercontent.com/2835826/70265216-f0f6d500-1767-11ea-8b87-e46392d1376d.gif)
