### PR TITLE
PVS/V1049: fix numerous "DEFINE_FUNC_ATTRIBUTES" warnings

### DIFF
--- a/src/nvim/generators/gen_declarations.lua
+++ b/src/nvim/generators/gen_declarations.lua
@@ -207,9 +207,7 @@ preproc_f:close()
 
 
 local header = [[
-#ifndef DEFINE_FUNC_ATTRIBUTES
-# define DEFINE_FUNC_ATTRIBUTES
-#endif
+#define DEFINE_FUNC_ATTRIBUTES
 #include "nvim/func_attr.h"
 #undef DEFINE_FUNC_ATTRIBUTES
 ]]


### PR DESCRIPTION
PVS erroneously flags our DEFINE_FUNC_ATTRIBUTES guard:

https://neovim.io/doc/reports/pvs/PVS-studio.html.d/

> V1049 The 'DEFINE_FUNC_ATTRIBUTES' include guard is already defined in the 'lang.h.generated.h' header. The 'profile.h.generated.h' header  will be excluded from compilation.

To satisfy PVS, just remove the `#ifndef` check. It's not needed anyway: C allows to redundantly `#define` a macro.

https://gcc.gnu.org/onlinedocs/cpp/Undefining-and-Redefining-Macros.html

> if an identifier which is currently a macro is redefined, then the new
> definition must be effectively the same as the old one
> ...
> If a macro is redefined with a definition that is not effectively the
> same as the old one, the preprocessor issues a warning and changes the
> macro to use the new definition. If the new definition is effectively
> the same, the redefinition is silently ignored. This allows, for
> instance, two different headers to define a common macro. The
> preprocessor will only complain if the definitions do not match.