### PR TITLE
snap: still failing with "need manual review"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ jobs:
       env:
         - CLANG_SANITIZER=TSAN
         - *common-job-env
-    - if: type != pull_request
+    - if: true
       name: snap
       os: linux
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,6 +188,12 @@ jobs:
         script: ci/snap/deploy.sh
         on:
           branch: master
+  allow_failures:
+    - env:
+      - LC_ALL: C.UTF-8
+      - LANG: C.UTF-8
+      - SNAPCRAFT_ENABLE_SILENT_REPORT: y
+      - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: y
   fast_finish: true
 
 before_install: ci/before_install.sh

--- a/ci/snap/script.sh
+++ b/ci/snap/script.sh
@@ -5,4 +5,5 @@ set -o pipefail
 
 mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
 sudo snapcraft --use-lxd
+exit 1
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ description: |
  For lots more details, see the wiki!
 
 grade: stable  # must be 'stable' to release into candidate/stable channels
-confinement: classic
+confinement: devmode
 
 apps:
     nvim:


### PR DESCRIPTION
snap approved our November 30 build, and we added it to the "edge" channel. We had expected this to enable "auto approval" for `containment=classic`, but after re-enabling the CI job it still fails.