### PR TITLE
termdebug.vim: Remove mentions s:InstallWinbar

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -442,7 +442,7 @@ func s:InstallCommands()
   command Gdb call win_gotoid(s:gdbwin)
   command Program call win_gotoid(s:ptywin)
   command Source call s:GotoSourcewinOrCreateIt()
-  command Winbar call s:InstallWinbar()
+  " command Winbar call s:InstallWinbar()
 
   " TODO: can the K mapping be restored?
   nnoremap K :Evaluate<CR>
@@ -450,7 +450,7 @@ func s:InstallCommands()
   let &cpo = save_cpo
 endfunc
 
-let s:winbar_winids = []
+" let s:winbar_winids = []
 
 " Delete installed debugger commands in the current window.
 func s:DeleteCommands()
@@ -467,7 +467,7 @@ func s:DeleteCommands()
   delcommand Gdb
   delcommand Program
   delcommand Source
-  delcommand Winbar
+  " delcommand Winbar
 
   nunmap K
 
@@ -733,7 +733,7 @@ func s:GotoSourcewinOrCreateIt()
   if !win_gotoid(s:sourcewin)
     new
     let s:sourcewin = win_getid(winnr())
-    call s:InstallWinbar()
+    " call s:InstallWinbar()
   endif
 endfunc
 
@@ -764,7 +764,7 @@ func s:HandleCursor(msg)
           " TODO: find existing window
           exe 'split ' . fnameescape(fname)
           let s:sourcewin = win_getid(winnr())
-          call s:InstallWinbar()
+          " call s:InstallWinbar()
         else
           exe 'edit ' . fnameescape(fname)
         endif


### PR DESCRIPTION
This function is not implemented in neovim and causes errors saying so
when hitting these codepaths