### PR TITLE
[RFC] Add support for the pum_getpos() API

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -607,6 +607,9 @@ CompleteChanged 					*CompleteChanged*
 
 				It is not allowed to change the text |textlock|.
 
+  				The size and position of the popup are also
+ 				available by calling |pum_getpos()|.
+
 							*CursorHold*
 CursorHold			When the user doesn't press a key for the time
 				specified with 'updatetime'.  Not re-triggered

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2280,6 +2280,7 @@ pathshorten({expr})		String	shorten directory names in a path
 pow({x}, {y})			Float	{x} to the power of {y}
 prevnonblank({lnum})		Number	line nr of non-blank line <= {lnum}
 printf({fmt}, {expr1}...)	String	format text
+pum_getpos()			Dict	position and size of pum if visible
 pumvisible()			Number	whether popup menu is visible
 pyeval({expr})			any	evaluate |Python| expression
 py3eval({expr})			any	evaluate |python3| expression
@@ -3119,6 +3120,9 @@ complete_info([{what}])
 		If the optional {what} list argument is supplied, then only
 		the items listed in {what} are returned.  Unsupported items in
 		{what} are silently ignored.
+
+		To get the position of the popup menu, see |pum_getpos()|. It's
+ 		also available in |v:event| during the |CompleteChanged| event.
 
 		Examples: >
 			" Get all items
@@ -6520,6 +6524,19 @@ printf({fmt}, {expr1} ...)				*printf()*
 		of "%" items.  If there are not sufficient or too many
 		arguments an error is given.  Up to 18 arguments can be used.
 
+
+pum_getpos()						*pum_getpos()*
+ 		If the popup menu (see |ins-completion-menu|) is not visible,
+ 		returns an empty |Dictionary|, otherwise, returns a
+ 		|Dictionary| with the following keys:
+ 			height		nr of items visible
+ 			width		screen cells
+ 			row		top screen row (0 first row)
+ 			col		leftmost screen column (0 first col)
+ 			size		total nr of items
+ 			scrollbar	|TRUE| if visible
+
+  		The values are the same as in |v:event| during |CompleteChanged|.
 
 pumvisible()						*pumvisible()*
 		Returns non-zero when the popup menu is visible, zero

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13972,9 +13972,7 @@ static void f_printf(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
-/*
- * "pum_getpos()" function
- */
+// "pum_getpos()" function
 static void f_pum_getpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   tv_dict_alloc_ret(rettv);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -13973,6 +13973,15 @@ static void f_printf(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 }
 
 /*
+ * "pum_getpos()" function
+ */
+static void f_pum_getpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  tv_dict_alloc_ret(rettv);
+  pum_set_event_info(rettv->vval.v_dict);
+}
+
+/*
  * "pumvisible()" function
  */
 static void f_pumvisible(typval_T *argvars, typval_T *rettv, FunPtr fptr)

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -243,6 +243,7 @@ return {
     pow={args=2},
     prevnonblank={args=1},
     printf={args=varargs(1)},
+    pum_getpos={},
     pumvisible={},
     py3eval={args=1},
     pyeval={args=1},

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -918,6 +918,20 @@ func Test_popup_complete_info_02()
   bwipe!
 endfunc
 
+func Test_popup_complete_info_no_pum()
+  new
+  call assert_false( pumvisible() )
+  let no_pum_info = complete_info()
+  let d = {
+        \   'mode': '',
+        \   'pum_visible': 0,
+        \   'items': [],
+        \   'selected': -1,
+        \  }
+  call assert_equal( d, complete_info() )
+  bwipe!
+endfunc
+
 func Test_CompleteChanged()
   new
   call setline(1, ['foo', 'bar', 'foobar', ''])
@@ -950,6 +964,34 @@ func Test_CompleteChanged()
   set complete& completeopt&
   delfunc! OnPumchange
   bw!
+endfunc
+
+function! GetPumPosition()
+  call assert_true( pumvisible() )
+  let g:pum_pos = pum_getpos()
+  return ''
+endfunction
+
+func Test_pum_getpos()
+  new
+  inoremap <buffer><F5> <C-R>=GetPumPosition()<CR>
+  setlocal completefunc=UserDefinedComplete
+
+   let d = {
+    \   'height':    5,
+    \   'width':     15,
+    \   'row':       1,
+    \   'col':       0,
+    \   'size':      5,
+    \   'scrollbar': v:false,
+    \ }
+  call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
+  call assert_equal(d, g:pum_pos)
+
+  call assert_false( pumvisible() )
+  call assert_equal( {}, pum_getpos() )
+  bw!
+  unlet g:pum_pos
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Per #11537, vim has added a `pum_getpos()` function that allows you to get the position of the popup menu. (This happened in vim/vim#4827.) This function is used by plugins like YouCompleteMe, so it's helpful to have support for it in Neovim as well. This PR is a straightforward port of vim's implementation to Neovim.

Although my impression is that new Neovim functions are generally added via Lua now, for this particular function it seems to me that using C makes sense. The function body is only two lines, since it's just a wrapper around an existing internal function that is already present in Neovim.

This is a first step towards supporting YouCompleteMe's fancier completion features in Neovim. Once this lands, I'd like to investigate adding a compatibility layer between Neovim's popup window API and vim's. I'll need some general advice on how to get started there; presumably that code should live in `runtime/lua`, but I'm not totally clear on how to expose Lua functions as builtin Neovim functions.