### PR TITLE
doc: direct runtime updates straight to vim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ Pull requests (PRs)
 
 - To avoid duplicate work, create a `[WIP]` pull request as soon as possible.
 - Your PR must include **test coverage.** See [test/README.md][run-tests].
+- Runtimes fixes should follow [Vim conventions][vim-contribute-runtime] first,
+  and then backported.
 - Avoid cosmetic changes to unrelated files in the same commit.
 - Use a [feature branch][git-feature-branch] instead of the master branch.
 - Use a **rebase workflow** for small PRs.
@@ -234,3 +236,4 @@ as context, use the `-W` argument as well.
 [Clang report]: https://neovim.io/doc/reports/clang/
 [complexity:low]: https://github.com/neovim/neovim/issues?q=is%3Aopen+is%3Aissue+label%3Acomplexity%3Alow
 [master error list]: https://raw.githubusercontent.com/neovim/doc/gh-pages/reports/clint/errors.json
+[vim-contribute-runtime]: https://github.com/vim/vim/blob/master/CONTRIBUTING.md#syntax-indent-and-other-runtime-files


### PR DESCRIPTION
this often happens and it would be nice to redirect the misdirected
contributors to some official statement.