### PR TITLE
third-party: DownloadAndExtractFile.cmake: retry with status_code=7

### DIFF
--- a/third-party/cmake/DownloadAndExtractFile.cmake
+++ b/third-party/cmake/DownloadAndExtractFile.cmake
@@ -76,7 +76,8 @@ list(GET status 1 status_string)
 if(NOT status_code EQUAL 0)
   # Retry on certain errors, e.g. CURLE_COULDNT_RESOLVE_HOST, which is often
   # seen with libtermkey (www.leonerd.org.uk).
-  if(status_code EQUAL 6)  # "Couldn't resolve host name"
+  if((status_code EQUAL 6)  # "Couldn't resolve host name"
+    OR (status_code EQUAL 7))  # "Couldn't connect to server"
     message(STATUS "warning: retrying '${URL}' (${status_string}, status ${status_code})")
     execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 10)
     file(DOWNLOAD ${URL} ${file}


### PR DESCRIPTION
Retry downloads with "Couldn't connect to server" errors.

Ref: https://lgtm.com/projects/g/neovim/neovim/logs/rev/pr-ca2f193a91f02881deb637f18694818bda49a7ed/lang:cpp/stage:Build%20master_026ba804d173c41ab99ee270c93f7975c1d6d713

```
[2019-12-20 10:54:47] [build] FAILED: build/src/libtermkey-stamp/libtermkey-download 
[2019-12-20 10:54:47] [build] cd /opt/src/.deps/build/downloads/libtermkey && /usr/bin/cmake -DPREFIX=/opt/src/.deps/build -DDOWNLOAD_DIR=/opt/src/.deps/build/downloads/libtermkey -DURL=http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz -DEXPECTED_SHA256=6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600 -DTARGET=libtermkey -DUSE_EXISTING_SRC_DIR=OFF -P /opt/src/third-party/cmake/DownloadAndExtractFile.cmake && /usr/bin/cmake -E touch /opt/src/.deps/build/src/libtermkey-stamp/libtermkey-download
[2019-12-20 10:54:47] [build] -- file: /opt/src/.deps/build/downloads/libtermkey/libtermkey-0.22.tar.gz
[2019-12-20 10:54:47] [build] -- downloading...
[2019-12-20 10:54:47] [build]      src='http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz'
[2019-12-20 10:54:47] [build]      dst='/opt/src/.deps/build/downloads/libtermkey/libtermkey-0.22.tar.gz'
[2019-12-20 10:54:47] [build]      timeout='none'
[2019-12-20 10:54:47] [build] CMake Error at /opt/src/third-party/cmake/DownloadAndExtractFile.cmake:91 (message):
[2019-12-20 10:54:47] [build]   error: downloading
[2019-12-20 10:54:47] [build]   'http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz' failed
[2019-12-20 10:54:47] [build]     status_code: 7
[2019-12-20 10:54:47] [build]     status_string: "Couldn't connect to server"
[2019-12-20 10:54:47] [build]     log:   Trying 2a03:b0c0:0:1010::3b7:b001...
[2019-12-20 10:54:47] [build]   TCP_NODELAY set
[2019-12-20 10:54:47] [build]   Immediate connect fail for 2a03:b0c0:0:1010::3b7:b001: Cannot assign
[2019-12-20 10:54:47] [build]   requested address
[2019-12-20 10:54:47] [build]   Closing connection 0
```