### PR TITLE
tests: tui_spec.lua: wait_for_mode with "TUI paste: exactly 64 bytes"

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -603,6 +603,7 @@ describe('TUI', function()
     wait_for_mode('i')
     -- "bracketed paste"
     feed_data('\027[200~'..expected..'\027[201~')
+    wait_for_mode('i')  -- Ensure input is processed in order (#11110).
     feed_data(' end')
     expected = expected..' end'
     screen:expect([[


### PR DESCRIPTION
Maybe fixes https://github.com/neovim/neovim/issues/11110.

Suggested in https://github.com/neovim/neovim/issues/11110#issuecomment-536160249.