### PR TITLE
tests: ex_terminal_spec: retry ":terminal (with fake shell)"

### DIFF
--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -245,12 +245,14 @@ describe(':terminal (with fake shell)', function()
   it('works with gf', function()
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell([[echo "scripts/shadacat.py"]])
+    retry(nil, 4 * screen.timeout, function()
     screen:expect([[
       ^ready $ echo "scripts/shadacat.py"                |
                                                         |
       [Process exited 0]                                |
       :terminal echo "scripts/shadacat.py"              |
     ]])
+    end)
     feed([[<C-\><C-N>]])
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
     feed([[ggf"lgf]])


### PR DESCRIPTION
Flaky failure (Travis CI, macOS)

    [ RUN      ] :terminal (with fake shell) works with gf: 10518.41 ms FAIL
    test/functional/terminal/ex_terminal_spec.lua:248: Row 1 did not match.
    Expected:
      |*^ready $ echo "scripts/shadacat.py"                |
      |*                                                  |
      |*[Process exited 0]                                |
      |:terminal echo "scripts/shadacat.py"              |
    Actual:
      |*^                                                  |
      |*[Process exited 0]                                |
      |*                                                  |
      |:terminal echo "scripts/shadacat.py"              |
    To print the expect() call that would assert the current screen state, use
    screen:snapshot_util(). In case of non-deterministic failures, use
    screen:redraw_debug() to show all intermediate screen states.
    stack traceback:
            test/functional/ui/screen.lua:579: in function '_wait'
            test/functional/ui/screen.lua:361: in function 'expect'
            test/functional/terminal/ex_terminal_spec.lua:248: in function <test/functional/terminal/ex_terminal_spec.lua:245>

Similar fix as with https://github.com/neovim/neovim/pull/10401.