### PR TITLE
tests: add/sync Test_undojoin_redo from Vim

### DIFF
--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -238,7 +238,17 @@ func Test_undojoin()
   call assert_equal(['aaaa', 'bbbb', 'cccc'], getline(2, '$'))
   call feedkeys("u", 'xt')
   call assert_equal(['aaaa'], getline(2, '$'))
-  close!
+  bwipe!
+endfunc
+
+func Test_undojoin_redo()
+  new
+  call setline(1, ['first line', 'second line'])
+  call feedkeys("ixx\<Esc>", 'xt')
+  call feedkeys(":undojoin | redo\<CR>", 'xt')
+  call assert_equal('xxfirst line', getline(1))
+  call assert_equal('second line', getline(2))
+  bwipe!
 endfunc
 
 " undojoin not allowed after undo


### PR DESCRIPTION
This was not added in e0e482589 with Vim patch 8.0.0205.