### PR TITLE
[RDY] runtime: Add vim.lsp.get_client_by_name

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -72,8 +72,9 @@ the option in an |after-directory| ftplugin, e.g. "after/ftplugin/python.vim".
                                                            *lsp-core-api*
 These are the core api functions for working with clients. You will mainly be
 using |vim.lsp.start_client()| and |vim.lsp.buf_attach_client()| for operations
-and |vim.lsp.get_client_by_id()| to retrieve a client by its id after it has
-initialized (or {config.on_init}. see below)
+and |vim.lsp.get_client_by_id()| and |vim.lsp.get_client_by_name()| to retrieve
+a client by its id or name after it has initialized (or {config.on_init}. see
+below)
 
                                                         *vim.lsp.start_client()*
 
@@ -265,6 +266,11 @@ vim.lsp.get_client_by_id({client_id})
   Look up an active client by its id, returns nil if it is not yet initialized
   or is not a valid id. Returns |lsp-client|
 
+                                                  *vim.lsp.get_client_by_name()*
+vim.lsp.get_client_by_name({client_name})
+
+  Look up an active client by its name, returns nil if it is not yet initialized
+  or is not a valid name. Returns |lsp-client|
                                                          *vim.lsp.stop_client()*
 vim.lsp.stop_client({client_id}, [{force}])
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -697,6 +697,16 @@ function lsp.get_client_by_id(client_id)
   return active_clients[client_id]
 end
 
+-- Look up an active client by its name, returns nil if it is not yet initialized
+-- or is not a valid name.
+-- @param client_name string the client name.
+function lsp.get_client_by_name(client_name)
+  for _, client in pairs(active_clients) do
+    if client.name == client_name then return client end
+  end
+  return nil
+end
+
 -- Stop a client by its id, optionally with force.
 -- You can also use the `stop()` function on a client if you already have
 -- access to it.

--- a/test/functional/plugin/lsp/lsp_spec.lua
+++ b/test/functional/plugin/lsp/lsp_spec.lua
@@ -111,6 +111,7 @@ describe('Language Client API', function()
       exec_lua([=[
         lsp = require('vim.lsp')
         local test_name, fixture_filename = ...
+        TEST_NAME = test_name
         TEST_RPC_CLIENT_ID = lsp.start_client {
           cmd = {
             vim.api.nvim_get_vvar("progpath"), '-Es', '-u', 'NONE', '--headless',
@@ -118,6 +119,7 @@ describe('Language Client API', function()
             "-c", "luafile "..fixture_filename;
           };
           root_dir = vim.loop.cwd();
+          name = test_name;
         }
       ]=], test_name, lsp_test_rpc_server_file)
     end)
@@ -137,6 +139,7 @@ describe('Language Client API', function()
         end
         eq(1, exec_lua("return #lsp.get_active_clients()"))
         eq(false, exec_lua("return lsp.get_client_by_id(TEST_RPC_CLIENT_ID) == nil"))
+        eq(false, exec_lua("return lsp.get_client_by_name(TEST_NAME) == nil"))
         eq(false, exec_lua("return lsp.get_client_by_id(TEST_RPC_CLIENT_ID).is_stopped()"))
         exec_lua("return lsp.get_client_by_id(TEST_RPC_CLIENT_ID).stop()")
         eq(false, exec_lua("return lsp.get_client_by_id(TEST_RPC_CLIENT_ID).is_stopped()"))
@@ -147,6 +150,7 @@ describe('Language Client API', function()
           end
         end
         eq(true, exec_lua("return lsp.get_client_by_id(TEST_RPC_CLIENT_ID) == nil"))
+        eq(true, exec_lua("return lsp.get_client_by_name(TEST_NAME) == nil"))
       end)
     end)
   end)


### PR DESCRIPTION
Since the client name is more obvious than the client id for the user, add an API to get the lsp client by the client name.

I want use like this:
`:echo luaeval("vim.inspect(vim.lsp.get_client_by_name('gopls'))")`