### PR TITLE
gen_vimdoc.py: fix :help formatting, reduce mpack formatting

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -479,6 +479,215 @@ created for extmark changes.
 ==============================================================================
 Global Functions                                                  *api-global*
 
+nvim__id({obj})                                                   *nvim__id()*
+                Returns object given as argument.
+
+                This API function is used for testing. One should not rely on
+                its presence in plugins.
+
+                Parameters: ~
+                    {obj}  Object to return.
+
+                Return: ~
+                    its argument.
+
+nvim__id_array({arr})                                       *nvim__id_array()*
+                Returns array given as argument.
+
+                This API function is used for testing. One should not rely on
+                its presence in plugins.
+
+                Parameters: ~
+                    {arr}  Array to return.
+
+                Return: ~
+                    its argument.
+
+nvim__id_dictionary({dct})                             *nvim__id_dictionary()*
+                Returns dictionary given as argument.
+
+                This API function is used for testing. One should not rely on
+                its presence in plugins.
+
+                Parameters: ~
+                    {dct}  Dictionary to return.
+
+                Return: ~
+                    its argument.
+
+nvim__id_float({flt})                                       *nvim__id_float()*
+                Returns floating-point value given as argument.
+
+                This API function is used for testing. One should not rely on
+                its presence in plugins.
+
+                Parameters: ~
+                    {flt}  Value to return.
+
+                Return: ~
+                    its argument.
+
+nvim__inspect_cell({grid}, {row}, {col})                *nvim__inspect_cell()*
+                TODO: Documentation
+
+nvim__put_attr({id}, {c0}, {c1})                            *nvim__put_attr()*
+                Set attrs in nvim__buf_set_lua_hl callbacks
+
+                TODO(bfredl): This is rather pedestrian. The final interface
+                should probably be derived from a reformed bufhl/virttext
+                interface with full support for multi-line ranges etc
+
+nvim__stats()                                                  *nvim__stats()*
+                Gets internal stats.
+
+                Return: ~
+                    Map of various internal stats.
+
+nvim_call_atomic({calls})                                 *nvim_call_atomic()*
+                Calls many API methods atomically.
+
+                This has two main usages:
+                1. To perform several requests from an async context
+                   atomically, i.e. without interleaving redraws, RPC requests
+                   from other clients, or user interactions (however API
+                   methods may trigger autocommands or event processing which
+                   have such side-effects, e.g. |:sleep| may wake timers).
+                2. To minimize RPC overhead (roundtrips) of a sequence of many
+                   requests.
+
+                Parameters: ~
+                    {calls}  an array of calls, where each call is described
+                             by an array with two elements: the request name,
+                             and an array of arguments.
+
+                Return: ~
+                    Array of two elements. The first is an array of return
+                    values. The second is NIL if all calls succeeded. If a
+                    call resulted in an error, it is a three-element array
+                    with the zero-based index of the call which resulted in an
+                    error, the error type and the error message. If an error
+                    occurred, the values from all preceding calls will still
+                    be returned.
+
+nvim_call_dict_function({dict}, {fn}, {args})      *nvim_call_dict_function()*
+                Calls a VimL |Dictionary-function| with the given arguments.
+
+                On execution error: fails with VimL error, does not update
+                v:errmsg.
+
+                Parameters: ~
+                    {dict}  Dictionary, or String evaluating to a VimL |self|
+                            dict
+                    {fn}    Name of the function defined on the VimL dict
+                    {args}  Function arguments packed in an Array
+
+                Return: ~
+                    Result of the function call
+
+nvim_call_function({fn}, {args})                        *nvim_call_function()*
+                Calls a VimL function with the given arguments.
+
+                On execution error: fails with VimL error, does not update
+                v:errmsg.
+
+                Parameters: ~
+                    {fn}    Function to call
+                    {args}  Function arguments packed in an Array
+
+                Return: ~
+                    Result of the function call
+
+nvim_command({command})                                       *nvim_command()*
+                Executes an ex-command.
+
+                On execution error: fails with VimL error, does not update
+                v:errmsg.
+
+                Parameters: ~
+                    {command}  Ex-command string
+
+                See also: ~
+                    |nvim_exec()|
+
+nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
+                Creates a new, empty, unnamed buffer.
+
+                Parameters: ~
+                    {listed}   Sets 'buflisted'
+                    {scratch}  Creates a "throwaway" |scratch-buffer| for
+                               temporary work (always 'nomodified')
+
+                Return: ~
+                    Buffer handle, or 0 on error
+
+                See also: ~
+                    buf_open_scratch
+
+nvim_create_namespace({name})                        *nvim_create_namespace()*
+                Creates a new namespace, or gets an existing one.
+
+                Namespaces are used for buffer highlights and virtual text,
+                see |nvim_buf_add_highlight()| and
+                |nvim_buf_set_virtual_text()|.
+
+                Namespaces can be named or anonymous. If `name` matches an
+                existing namespace, the associated id is returned. If `name`
+                is an empty string a new, anonymous namespace is created.
+
+                Parameters: ~
+                    {name}  Namespace name or empty string
+
+                Return: ~
+                    Namespace id
+
+nvim_del_current_line()                              *nvim_del_current_line()*
+                Deletes the current line.
+
+nvim_del_keymap({mode}, {lhs})                             *nvim_del_keymap()*
+                Unmaps a global |mapping| for the given mode.
+
+                To unmap a buffer-local mapping, use |nvim_buf_del_keymap()|.
+
+                See also: ~
+                    |nvim_set_keymap()|
+
+nvim_del_var({name})                                          *nvim_del_var()*
+                Removes a global (g:) variable.
+
+                Parameters: ~
+                    {name}  Variable name
+
+nvim_err_write({str})                                       *nvim_err_write()*
+                Writes a message to the Vim error buffer. Does not append
+                "\n", the message is buffered (won't display) until a linefeed
+                is written.
+
+                Parameters: ~
+                    {str}  Message
+
+nvim_err_writeln({str})                                   *nvim_err_writeln()*
+                Writes a message to the Vim error buffer. Appends "\n", so the
+                buffer is flushed (and displayed).
+
+                Parameters: ~
+                    {str}  Message
+
+                See also: ~
+                    nvim_err_write()
+
+nvim_eval({expr})                                                *nvim_eval()*
+                Evaluates a VimL |expression|. Dictionaries and Lists are
+                recursively expanded.
+
+                On execution error: fails with VimL error, does not update
+                v:errmsg.
+
+                Parameters: ~
+                    {expr}  VimL expression string
+
+                Return: ~
+                    Evaluation result or expanded object
+
 nvim_exec({src}, {output})                                       *nvim_exec()*
                 Executes Vimscript (multiline block of Ex-commands), like
                 anonymous |:source|.
@@ -502,48 +711,19 @@ nvim_exec({src}, {output})                                       *nvim_exec()*
                     |execute()|
                     |nvim_command()|
 
-nvim_command({command})                                       *nvim_command()*
-                Executes an ex-command.
+nvim_exec_lua({code}, {args})                                *nvim_exec_lua()*
+                Execute Lua code. Parameters (if any) are available as `...`
+                inside the chunk. The chunk can return a value.
 
-                On execution error: fails with VimL error, does not update
-                v:errmsg.
-
-                Parameters: ~
-                    {command}  Ex-command string
-
-                See also: ~
-                    |nvim_exec()|
-
-nvim_get_hl_by_name({name}, {rgb})                     *nvim_get_hl_by_name()*
-                Gets a highlight definition by name.
+                Only statements are executed. To evaluate an expression,
+                prefix it with `return` : return my_function(...)
 
                 Parameters: ~
-                    {name}  Highlight group name
-                    {rgb}   Export RGB colors
+                    {code}  Lua code to execute
+                    {args}  Arguments to the code
 
                 Return: ~
-                    Highlight definition map
-
-                See also: ~
-                    nvim_get_hl_by_id
-
-nvim_get_hl_by_id({hl_id}, {rgb})                        *nvim_get_hl_by_id()*
-                Gets a highlight definition by id. |hlID()|
-
-                Parameters: ~
-                    {hl_id}  Highlight id as returned by |hlID()|
-                    {rgb}    Export RGB colors
-
-                Return: ~
-                    Highlight definition map
-
-                See also: ~
-                    nvim_get_hl_by_name
-
-nvim_get_hl_id_by_name({name})                      *nvim_get_hl_id_by_name()*
-                Gets a highlight group by name
-
-                similar to |hlID()|, but allocates a new ID if not present.
+                    Return value of Lua code if present or NIL.
 
 nvim_feedkeys({keys}, {mode}, {escape_csi})                  *nvim_feedkeys()*
                 Sends input-keys to Nvim, subject to various quirks controlled
@@ -561,6 +741,214 @@ nvim_feedkeys({keys}, {mode}, {escape_csi})                  *nvim_feedkeys()*
                 See also: ~
                     feedkeys()
                     vim_strsave_escape_csi
+
+nvim_get_api_info()                                      *nvim_get_api_info()*
+                Returns a 2-tuple (Array), where item 0 is the current channel
+                id and item 1 is the |api-metadata| map (Dictionary).
+
+                Return: ~
+                    2-tuple [{channel-id}, {api-metadata}]
+
+                Attributes: ~
+                    {fast}
+
+nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
+                Get information about a channel.
+
+                Return: ~
+                    Dictionary describing a channel, with these keys:
+                    • "stream" the stream underlying the channel
+                      • "stdio" stdin and stdout of this Nvim instance
+                      • "stderr" stderr of this Nvim instance
+                      • "socket" TCP/IP socket or named pipe
+                      • "job" job with communication over its stdio
+
+                    • "mode" how data received on the channel is interpreted
+                      • "bytes" send and receive raw bytes
+                      • "terminal" a |terminal| instance interprets ASCII
+                        sequences
+                      • "rpc" |RPC| communication on the channel is active
+
+                    • "pty" Name of pseudoterminal, if one is used (optional).
+                      On a POSIX system, this will be a device path like
+                      /dev/pts/1. Even if the name is unknown, the key will
+                      still be present to indicate a pty is used. This is
+                      currently the case when using winpty on windows.
+                    • "buffer" buffer with connected |terminal| instance
+                      (optional)
+                    • "client" information about the client on the other end
+                      of the RPC channel, if it has added it using
+                      |nvim_set_client_info()|. (optional)
+
+nvim_get_color_by_name({name})                      *nvim_get_color_by_name()*
+                Returns the 24-bit RGB value of a |nvim_get_color_map()| color
+                name or "#rrggbb" hexadecimal string.
+
+                Example: >
+                    :echo nvim_get_color_by_name("Pink")
+                    :echo nvim_get_color_by_name("#cbcbcb")
+<
+
+                Parameters: ~
+                    {name}  Color name or "#rrggbb" string
+
+                Return: ~
+                    24-bit RGB value, or -1 for invalid argument.
+
+nvim_get_color_map()                                    *nvim_get_color_map()*
+                Returns a map of color names and RGB values.
+
+                Keys are color names (e.g. "Aqua") and values are 24-bit RGB
+                color values (e.g. 65535).
+
+                Return: ~
+                    Map of color names and RGB values.
+
+nvim_get_commands({opts})                                *nvim_get_commands()*
+                Gets a map of global (non-buffer-local) Ex commands.
+
+                Currently only |user-commands| are supported, not builtin Ex
+                commands.
+
+                Parameters: ~
+                    {opts}  Optional parameters. Currently only supports
+                            {"builtin":false}
+
+                Return: ~
+                    Map of maps describing commands.
+
+nvim_get_context({opts})                                  *nvim_get_context()*
+                Gets a map of the current editor state.
+
+                Parameters: ~
+                    {opts}  Optional parameters.
+                            • types: List of |context-types| ("regs", "jumps",
+                              "bufs", "gvars", …) to gather, or empty for
+                              "all".
+
+                Return: ~
+                    map of global |context|.
+
+nvim_get_current_buf()                                *nvim_get_current_buf()*
+                Gets the current buffer.
+
+                Return: ~
+                    Buffer handle
+
+nvim_get_current_line()                              *nvim_get_current_line()*
+                Gets the current line.
+
+                Return: ~
+                    Current line string
+
+nvim_get_current_tabpage()                        *nvim_get_current_tabpage()*
+                Gets the current tabpage.
+
+                Return: ~
+                    Tabpage handle
+
+nvim_get_current_win()                                *nvim_get_current_win()*
+                Gets the current window.
+
+                Return: ~
+                    Window handle
+
+nvim_get_hl_by_id({hl_id}, {rgb})                        *nvim_get_hl_by_id()*
+                Gets a highlight definition by id. |hlID()|
+
+                Parameters: ~
+                    {hl_id}  Highlight id as returned by |hlID()|
+                    {rgb}    Export RGB colors
+
+                Return: ~
+                    Highlight definition map
+
+                See also: ~
+                    nvim_get_hl_by_name
+
+nvim_get_hl_by_name({name}, {rgb})                     *nvim_get_hl_by_name()*
+                Gets a highlight definition by name.
+
+                Parameters: ~
+                    {name}  Highlight group name
+                    {rgb}   Export RGB colors
+
+                Return: ~
+                    Highlight definition map
+
+                See also: ~
+                    nvim_get_hl_by_id
+
+nvim_get_hl_id_by_name({name})                      *nvim_get_hl_id_by_name()*
+                Gets a highlight group by name
+
+                similar to |hlID()|, but allocates a new ID if not present.
+
+nvim_get_keymap({mode})                                    *nvim_get_keymap()*
+                Gets a list of global (non-buffer-local) |mapping|
+                definitions.
+
+                Parameters: ~
+                    {mode}  Mode short-name ("n", "i", "v", ...)
+
+                Return: ~
+                    Array of maparg()-like dictionaries describing mappings.
+                    The "buffer" key is always zero.
+
+nvim_get_mode()                                              *nvim_get_mode()*
+                Gets the current mode. |mode()| "blocking" is true if Nvim is
+                waiting for input.
+
+                Return: ~
+                    Dictionary { "mode": String, "blocking": Boolean }
+
+                Attributes: ~
+                    {fast}
+
+nvim_get_namespaces()                                  *nvim_get_namespaces()*
+                Gets existing, non-anonymous namespaces.
+
+                Return: ~
+                    dict that maps from names to namespace ids.
+
+nvim_get_option({name})                                    *nvim_get_option()*
+                Gets an option value string.
+
+                Parameters: ~
+                    {name}  Option name
+
+                Return: ~
+                    Option value (global)
+
+nvim_get_proc({pid})                                         *nvim_get_proc()*
+                Gets info describing process `pid` .
+
+                Return: ~
+                    Map of process properties, or NIL if process not found.
+
+nvim_get_proc_children({pid})                       *nvim_get_proc_children()*
+                Gets the immediate children of process `pid` .
+
+                Return: ~
+                    Array of child process ids, empty if process not found.
+
+nvim_get_var({name})                                          *nvim_get_var()*
+                Gets a global (g:) variable.
+
+                Parameters: ~
+                    {name}  Variable name
+
+                Return: ~
+                    Variable value
+
+nvim_get_vvar({name})                                        *nvim_get_vvar()*
+                Gets a v: variable.
+
+                Parameters: ~
+                    {name}  Variable name
+
+                Return: ~
+                    Variable value
 
 nvim_input({keys})                                              *nvim_input()*
                 Queues raw user-input. Unlike |nvim_feedkeys()|, this uses a
@@ -623,195 +1011,6 @@ nvim_input_mouse({button}, {action}, {modifier}, {grid}, {row}, {col})
                     {col}       Mouse column-position (zero-based, like redraw
                                 events)
 
-                                                    *nvim_replace_termcodes()*
-nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})
-                Replaces terminal codes and |keycodes| (<CR>, <Esc>, ...) in a
-                string with the internal representation.
-
-                Parameters: ~
-                    {str}        String to be converted.
-                    {from_part}  Legacy Vim parameter. Usually true.
-                    {do_lt}      Also translate <lt>. Ignored if `special` is
-                                 false.
-                    {special}    Replace |keycodes|, e.g. <CR> becomes a "\n"
-                                 char.
-
-                See also: ~
-                    replace_termcodes
-                    cpoptions
-
-nvim_eval({expr})                                                *nvim_eval()*
-                Evaluates a VimL |expression|. Dictionaries and Lists are
-                recursively expanded.
-
-                On execution error: fails with VimL error, does not update
-                v:errmsg.
-
-                Parameters: ~
-                    {expr}  VimL expression string
-
-                Return: ~
-                    Evaluation result or expanded object
-
-nvim_exec_lua({code}, {args})                                *nvim_exec_lua()*
-                Execute Lua code. Parameters (if any) are available as `...`
-                inside the chunk. The chunk can return a value.
-
-                Only statements are executed. To evaluate an expression,
-                prefix it with `return` : return my_function(...)
-
-                Parameters: ~
-                    {code}  Lua code to execute
-                    {args}  Arguments to the code
-
-                Return: ~
-                    Return value of Lua code if present or NIL.
-
-nvim_call_function({fn}, {args})                        *nvim_call_function()*
-                Calls a VimL function with the given arguments.
-
-                On execution error: fails with VimL error, does not update
-                v:errmsg.
-
-                Parameters: ~
-                    {fn}    Function to call
-                    {args}  Function arguments packed in an Array
-
-                Return: ~
-                    Result of the function call
-
-nvim_call_dict_function({dict}, {fn}, {args})      *nvim_call_dict_function()*
-                Calls a VimL |Dictionary-function| with the given arguments.
-
-                On execution error: fails with VimL error, does not update
-                v:errmsg.
-
-                Parameters: ~
-                    {dict}  Dictionary, or String evaluating to a VimL |self|
-                            dict
-                    {fn}    Name of the function defined on the VimL dict
-                    {args}  Function arguments packed in an Array
-
-                Return: ~
-                    Result of the function call
-
-nvim_strwidth({text})                                        *nvim_strwidth()*
-                Calculates the number of display cells occupied by `text` .
-                <Tab> counts as one cell.
-
-                Parameters: ~
-                    {text}  Some text
-
-                Return: ~
-                    Number of cells
-
-nvim_list_runtime_paths()                          *nvim_list_runtime_paths()*
-                Gets the paths contained in 'runtimepath'.
-
-                Return: ~
-                    List of paths
-
-nvim_set_current_dir({dir})                           *nvim_set_current_dir()*
-                Changes the global working directory.
-
-                Parameters: ~
-                    {dir}  Directory path
-
-nvim_get_current_line()                              *nvim_get_current_line()*
-                Gets the current line.
-
-                Return: ~
-                    Current line string
-
-nvim_set_current_line({line})                        *nvim_set_current_line()*
-                Sets the current line.
-
-                Parameters: ~
-                    {line}  Line contents
-
-nvim_del_current_line()                              *nvim_del_current_line()*
-                Deletes the current line.
-
-nvim_get_var({name})                                          *nvim_get_var()*
-                Gets a global (g:) variable.
-
-                Parameters: ~
-                    {name}  Variable name
-
-                Return: ~
-                    Variable value
-
-nvim_set_var({name}, {value})                                 *nvim_set_var()*
-                Sets a global (g:) variable.
-
-                Parameters: ~
-                    {name}   Variable name
-                    {value}  Variable value
-
-nvim_del_var({name})                                          *nvim_del_var()*
-                Removes a global (g:) variable.
-
-                Parameters: ~
-                    {name}  Variable name
-
-nvim_get_vvar({name})                                        *nvim_get_vvar()*
-                Gets a v: variable.
-
-                Parameters: ~
-                    {name}  Variable name
-
-                Return: ~
-                    Variable value
-
-nvim_set_vvar({name}, {value})                               *nvim_set_vvar()*
-                Sets a v: variable, if it is not readonly.
-
-                Parameters: ~
-                    {name}   Variable name
-                    {value}  Variable value
-
-nvim_get_option({name})                                    *nvim_get_option()*
-                Gets an option value string.
-
-                Parameters: ~
-                    {name}  Option name
-
-                Return: ~
-                    Option value (global)
-
-nvim_set_option({name}, {value})                           *nvim_set_option()*
-                Sets an option value.
-
-                Parameters: ~
-                    {name}   Option name
-                    {value}  New option value
-
-nvim_out_write({str})                                       *nvim_out_write()*
-                Writes a message to the Vim output buffer. Does not append
-                "\n", the message is buffered (won't display) until a linefeed
-                is written.
-
-                Parameters: ~
-                    {str}  Message
-
-nvim_err_write({str})                                       *nvim_err_write()*
-                Writes a message to the Vim error buffer. Does not append
-                "\n", the message is buffered (won't display) until a linefeed
-                is written.
-
-                Parameters: ~
-                    {str}  Message
-
-nvim_err_writeln({str})                                   *nvim_err_writeln()*
-                Writes a message to the Vim error buffer. Appends "\n", so the
-                buffer is flushed (and displayed).
-
-                Parameters: ~
-                    {str}  Message
-
-                See also: ~
-                    nvim_err_write()
-
 nvim_list_bufs()                                            *nvim_list_bufs()*
                 Gets the current list of buffer handles
 
@@ -821,17 +1020,36 @@ nvim_list_bufs()                                            *nvim_list_bufs()*
                 Return: ~
                     List of buffer handles
 
-nvim_get_current_buf()                                *nvim_get_current_buf()*
-                Gets the current buffer.
+nvim_list_chans()                                          *nvim_list_chans()*
+                Get information about all open channels.
 
                 Return: ~
-                    Buffer handle
+                    Array of Dictionaries, each describing a channel with the
+                    format specified at |nvim_get_chan_info()|.
 
-nvim_set_current_buf({buffer})                        *nvim_set_current_buf()*
-                Sets the current buffer.
+nvim_list_runtime_paths()                          *nvim_list_runtime_paths()*
+                Gets the paths contained in 'runtimepath'.
 
-                Parameters: ~
-                    {buffer}  Buffer handle
+                Return: ~
+                    List of paths
+
+nvim_list_tabpages()                                    *nvim_list_tabpages()*
+                Gets the current list of tabpage handles.
+
+                Return: ~
+                    List of tabpage handles
+
+nvim_list_uis()                                              *nvim_list_uis()*
+                Gets a list of dictionaries representing attached UIs.
+
+                Return: ~
+                    Array of UI dictionaries, each with these keys:
+                    • "height" Requested height of the UI
+                    • "width" Requested width of the UI
+                    • "rgb" true if the UI uses RGB colors (false implies
+                      |cterm-colors|)
+                    • "ext_..." Requested UI extensions, see |ui-option|
+                    • "chan" Channel id of remote UI (not present for TUI)
 
 nvim_list_wins()                                            *nvim_list_wins()*
                 Gets the current list of window handles.
@@ -839,31 +1057,11 @@ nvim_list_wins()                                            *nvim_list_wins()*
                 Return: ~
                     List of window handles
 
-nvim_get_current_win()                                *nvim_get_current_win()*
-                Gets the current window.
-
-                Return: ~
-                    Window handle
-
-nvim_set_current_win({window})                        *nvim_set_current_win()*
-                Sets the current window.
+nvim_load_context({dict})                                *nvim_load_context()*
+                Sets the current editor state from the given |context| map.
 
                 Parameters: ~
-                    {window}  Window handle
-
-nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
-                Creates a new, empty, unnamed buffer.
-
-                Parameters: ~
-                    {listed}   Sets 'buflisted'
-                    {scratch}  Creates a "throwaway" |scratch-buffer| for
-                               temporary work (always 'nomodified')
-
-                Return: ~
-                    Buffer handle, or 0 on error
-
-                See also: ~
-                    buf_open_scratch
+                    {dict}  |Context| map.
 
 nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                 Open a new window.
@@ -916,7 +1114,7 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                                 • "cursor" Cursor position in current window.
 
                               • `win` : |window-ID| for relative="win".
-                              •  `anchor` : Decides which corner of the float to place
+                              • `anchor`: Decides which corner of the float to place
                                 at (row,col):
                                 • "NW" northwest (default)
                                 • "NE" northeast
@@ -946,7 +1144,7 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                                 an external top-level window. Currently
                                 accepts no other positioning configuration
                                 together with this.
-                              •  `style` : Configure the appearance of the window.
+                              • `style`: Configure the appearance of the window.
                                 Currently only takes one non-empty value:
                                 • "minimal" Nvim will display the window with
                                   many UI options disabled. This is useful
@@ -964,352 +1162,13 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                 Return: ~
                     Window handle, or 0 on error
 
-nvim_list_tabpages()                                    *nvim_list_tabpages()*
-                Gets the current list of tabpage handles.
-
-                Return: ~
-                    List of tabpage handles
-
-nvim_get_current_tabpage()                        *nvim_get_current_tabpage()*
-                Gets the current tabpage.
-
-                Return: ~
-                    Tabpage handle
-
-nvim_set_current_tabpage({tabpage})               *nvim_set_current_tabpage()*
-                Sets the current tabpage.
+nvim_out_write({str})                                       *nvim_out_write()*
+                Writes a message to the Vim output buffer. Does not append
+                "\n", the message is buffered (won't display) until a linefeed
+                is written.
 
                 Parameters: ~
-                    {tabpage}  Tabpage handle
-
-nvim_create_namespace({name})                        *nvim_create_namespace()*
-                Creates a new namespace, or gets an existing one.
-
-                Namespaces are used for buffer highlights and virtual text,
-                see |nvim_buf_add_highlight()| and
-                |nvim_buf_set_virtual_text()|.
-
-                Namespaces can be named or anonymous. If `name` matches an
-                existing namespace, the associated id is returned. If `name`
-                is an empty string a new, anonymous namespace is created.
-
-                Parameters: ~
-                    {name}  Namespace name or empty string
-
-                Return: ~
-                    Namespace id
-
-nvim_get_namespaces()                                  *nvim_get_namespaces()*
-                Gets existing, non-anonymous namespaces.
-
-                Return: ~
-                    dict that maps from names to namespace ids.
-
-nvim_paste({data}, {crlf}, {phase})                             *nvim_paste()*
-                Pastes at cursor, in any mode.
-
-                Invokes the `vim.paste` handler, which handles each mode
-                appropriately. Sets redo/undo. Faster than |nvim_input()|.
-                Lines break at LF ("\n").
-
-                Errors ('nomodifiable', `vim.paste()` failure, …) are
-                reflected in `err` but do not affect the return value (which
-                is strictly decided by `vim.paste()` ). On error, subsequent
-                calls are ignored ("drained") until the next paste is
-                initiated (phase 1 or -1).
-
-                Parameters: ~
-                    {data}   Multiline input. May be binary (containing NUL
-                             bytes).
-                    {crlf}   Also break lines at CR and CRLF.
-                    {phase}  -1: paste in a single call (i.e. without
-                             streaming). To "stream" a paste, call `nvim_paste` sequentially with these `phase` values:
-                             • 1: starts the paste (exactly once)
-                             • 2: continues the paste (zero or more times)
-                             • 3: ends the paste (exactly once)
-
-                Return: ~
-
-                    • true: Client may continue pasting.
-                    • false: Client must cancel the paste.
-
-nvim_put({lines}, {type}, {after}, {follow})                      *nvim_put()*
-                Puts text at cursor, in any mode.
-
-                Compare |:put| and |p| which are always linewise.
-
-                Parameters: ~
-                    {lines}   |readfile()|-style list of lines.
-                              |channel-lines|
-                    {type}    Edit behavior: any |getregtype()| result, or:
-                              • "b" |blockwise-visual| mode (may include
-                                width, e.g. "b3")
-                              • "c" |charwise| mode
-                              • "l" |linewise| mode
-                              • "" guess by contents, see |setreg()|
-                    {after}   Insert after cursor (like |p|), or before (like
-                              |P|).
-                    {follow}  Place cursor at end of inserted text.
-
-nvim_subscribe({event})                                     *nvim_subscribe()*
-                Subscribes to event broadcasts.
-
-                Parameters: ~
-                    {event}  Event type string
-
-nvim_unsubscribe({event})                                 *nvim_unsubscribe()*
-                Unsubscribes to event broadcasts.
-
-                Parameters: ~
-                    {event}  Event type string
-
-nvim_get_color_by_name({name})                      *nvim_get_color_by_name()*
-                Returns the 24-bit RGB value of a |nvim_get_color_map()| color
-                name or "#rrggbb" hexadecimal string.
-
-                Example: >
-                    :echo nvim_get_color_by_name("Pink")
-                    :echo nvim_get_color_by_name("#cbcbcb")
-<
-
-                Parameters: ~
-                    {name}  Color name or "#rrggbb" string
-
-                Return: ~
-                    24-bit RGB value, or -1 for invalid argument.
-
-nvim_get_color_map()                                    *nvim_get_color_map()*
-                Returns a map of color names and RGB values.
-
-                Keys are color names (e.g. "Aqua") and values are 24-bit RGB
-                color values (e.g. 65535).
-
-                Return: ~
-                    Map of color names and RGB values.
-
-nvim_get_context({opts})                                  *nvim_get_context()*
-                Gets a map of the current editor state.
-
-                Parameters: ~
-                    {opts}  Optional parameters.
-                            • types: List of |context-types| ("regs", "jumps",
-                              "bufs", "gvars", …) to gather, or empty for
-                              "all".
-
-                Return: ~
-                    map of global |context|.
-
-nvim_load_context({dict})                                *nvim_load_context()*
-                Sets the current editor state from the given |context| map.
-
-                Parameters: ~
-                    {dict}  |Context| map.
-
-nvim_get_mode()                                              *nvim_get_mode()*
-                Gets the current mode. |mode()| "blocking" is true if Nvim is
-                waiting for input.
-
-                Return: ~
-                    Dictionary { "mode": String, "blocking": Boolean }
-
-                Attributes: ~
-                    {fast}
-
-nvim_get_keymap({mode})                                    *nvim_get_keymap()*
-                Gets a list of global (non-buffer-local) |mapping|
-                definitions.
-
-                Parameters: ~
-                    {mode}  Mode short-name ("n", "i", "v", ...)
-
-                Return: ~
-                    Array of maparg()-like dictionaries describing mappings.
-                    The "buffer" key is always zero.
-
-nvim_set_keymap({mode}, {lhs}, {rhs}, {opts})              *nvim_set_keymap()*
-                Sets a global |mapping| for the given mode.
-
-                To set a buffer-local mapping, use |nvim_buf_set_keymap()|.
-
-                Unlike |:map|, leading/trailing whitespace is accepted as part
-                of the {lhs} or {rhs}. Empty {rhs} is |<Nop>|. |keycodes| are
-                replaced as usual.
-
-                Example: >
-                    call nvim_set_keymap('n', ' <NL>', '', {'nowait': v:true})
-<
-
-                is equivalent to: >
-                    nmap <nowait> <Space><NL> <Nop>
-<
-
-                Parameters: ~
-                    {mode}  Mode short-name (map command prefix: "n", "i",
-                            "v", "x", …) or "!" for |:map!|, or empty string
-                            for |:map|.
-                    {lhs}   Left-hand-side |{lhs}| of the mapping.
-                    {rhs}   Right-hand-side |{rhs}| of the mapping.
-                    {opts}  Optional parameters map. Accepts all
-                            |:map-arguments| as keys excluding |<buffer>| but
-                            including |noremap|. Values are Booleans. Unknown
-                            key is an error.
-
-nvim_del_keymap({mode}, {lhs})                             *nvim_del_keymap()*
-                Unmaps a global |mapping| for the given mode.
-
-                To unmap a buffer-local mapping, use |nvim_buf_del_keymap()|.
-
-                See also: ~
-                    |nvim_set_keymap()|
-
-nvim_get_commands({opts})                                *nvim_get_commands()*
-                Gets a map of global (non-buffer-local) Ex commands.
-
-                Currently only |user-commands| are supported, not builtin Ex
-                commands.
-
-                Parameters: ~
-                    {opts}  Optional parameters. Currently only supports
-                            {"builtin":false}
-
-                Return: ~
-                    Map of maps describing commands.
-
-nvim_get_api_info()                                      *nvim_get_api_info()*
-                Returns a 2-tuple (Array), where item 0 is the current channel
-                id and item 1 is the |api-metadata| map (Dictionary).
-
-                Return: ~
-                    2-tuple [{channel-id}, {api-metadata}]
-
-                Attributes: ~
-                    {fast}
-
-                                                      *nvim_set_client_info()*
-nvim_set_client_info({name}, {version}, {type}, {methods},
-                     {attributes})
-                Self-identifies the client.
-
-                The client/plugin/application should call this after
-                connecting, to provide hints about its identity and purpose,
-                for debugging and orchestration.
-
-                Can be called more than once; the caller should merge old info
-                if appropriate. Example: library first identifies the channel,
-                then a plugin using that library later identifies itself.
-
-                Note:
-                    "Something is better than nothing". You don't need to
-                    include all the fields.
-
-                Parameters: ~
-                    {name}        Short name for the connected client
-                    {version}     Dictionary describing the version, with
-                                  these (optional) keys:
-                                  • "major" major version (defaults to 0 if
-                                    not set, for no release yet)
-                                  • "minor" minor version
-                                  • "patch" patch number
-                                  • "prerelease" string describing a
-                                    prerelease, like "dev" or "beta1"
-                                  • "commit" hash or similar identifier of
-                                    commit
-                    {type}        Must be one of the following values. Client
-                                  libraries should default to "remote" unless
-                                  overridden by the user.
-                                  • "remote" remote client connected to Nvim.
-                                  • "ui" gui frontend
-                                  • "embedder" application using Nvim as a
-                                    component (for example, IDE/editor
-                                    implementing a vim mode).
-                                  • "host" plugin host, typically started by
-                                    nvim
-                                  • "plugin" single plugin, started by nvim
-                    {methods}     Builtin methods in the client. For a host,
-                                  this does not include plugin methods which
-                                  will be discovered later. The key should be
-                                  the method name, the values are dicts with
-                                  these (optional) keys (more keys may be
-                                  added in future versions of Nvim, thus
-                                  unknown keys are ignored. Clients must only
-                                  use keys defined in this or later versions
-                                  of Nvim):
-                                  • "async" if true, send as a notification.
-                                    If false or unspecified, use a blocking
-                                    request
-                                  • "nargs" Number of arguments. Could be a
-                                    single integer or an array of two
-                                    integers, minimum and maximum inclusive.
-                    {attributes}  Arbitrary string:string map of informal
-                                  client properties. Suggested keys:
-                                  • "website": Client homepage URL (e.g.
-                                    GitHub repository)
-                                  • "license": License description ("Apache
-                                    2", "GPLv3", "MIT", …)
-                                  • "logo": URI or path to image, preferably
-                                    small logo or icon. .png or .svg format is
-                                    preferred.
-
-nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
-                Get information about a channel.
-
-                Return: ~
-                    Dictionary describing a channel, with these keys:
-                    • "stream" the stream underlying the channel
-                      • "stdio" stdin and stdout of this Nvim instance
-                      • "stderr" stderr of this Nvim instance
-                      • "socket" TCP/IP socket or named pipe
-                      • "job" job with communication over its stdio
-
-                    • "mode" how data received on the channel is interpreted
-                      • "bytes" send and receive raw bytes
-                      • "terminal" a |terminal| instance interprets ASCII
-                        sequences
-                      • "rpc" |RPC| communication on the channel is active
-
-                    • "pty" Name of pseudoterminal, if one is used (optional).
-                      On a POSIX system, this will be a device path like
-                      /dev/pts/1. Even if the name is unknown, the key will
-                      still be present to indicate a pty is used. This is
-                      currently the case when using winpty on windows.
-                    • "buffer" buffer with connected |terminal| instance
-                      (optional)
-                    • "client" information about the client on the other end
-                      of the RPC channel, if it has added it using
-                      |nvim_set_client_info()|. (optional)
-
-nvim_list_chans()                                          *nvim_list_chans()*
-                Get information about all open channels.
-
-                Return: ~
-                    Array of Dictionaries, each describing a channel with the
-                    format specified at |nvim_get_chan_info()|.
-
-nvim_call_atomic({calls})                                 *nvim_call_atomic()*
-                Calls many API methods atomically.
-
-                This has two main usages:
-                1. To perform several requests from an async context
-                   atomically, i.e. without interleaving redraws, RPC requests
-                   from other clients, or user interactions (however API
-                   methods may trigger autocommands or event processing which
-                   have such side-effects, e.g. |:sleep| may wake timers).
-                2. To minimize RPC overhead (roundtrips) of a sequence of many
-                   requests.
-
-                Parameters: ~
-                    {calls}  an array of calls, where each call is described
-                             by an array with two elements: the request name,
-                             and an array of arguments.
-
-                Return: ~
-                    Array of two elements. The first is an array of return
-                    values. The second is NIL if all calls succeeded. If a
-                    call resulted in an error, it is a three-element array
-                    with the zero-based index of the call which resulted in an
-                    error, the error type and the error message. If an error
-                    occurred, the values from all preceding calls will still
-                    be returned.
+                    {str}  Message
 
                                                      *nvim_parse_expression()*
 nvim_parse_expression({expr}, {flags}, {highlight})
@@ -1408,83 +1267,68 @@ nvim_parse_expression({expr}, {flags}, {highlight})
                       • "svalue": String, value for "SingleQuotedString" and
                         "DoubleQuotedString" nodes.
 
-nvim__id({obj})                                                   *nvim__id()*
-                Returns object given as argument.
+nvim_paste({data}, {crlf}, {phase})                             *nvim_paste()*
+                Pastes at cursor, in any mode.
 
-                This API function is used for testing. One should not rely on
-                its presence in plugins.
+                Invokes the `vim.paste` handler, which handles each mode
+                appropriately. Sets redo/undo. Faster than |nvim_input()|.
+                Lines break at LF ("\n").
 
-                Parameters: ~
-                    {obj}  Object to return.
-
-                Return: ~
-                    its argument.
-
-nvim__id_array({arr})                                       *nvim__id_array()*
-                Returns array given as argument.
-
-                This API function is used for testing. One should not rely on
-                its presence in plugins.
+                Errors ('nomodifiable', `vim.paste()` failure, …) are
+                reflected in `err` but do not affect the return value (which
+                is strictly decided by `vim.paste()` ). On error, subsequent
+                calls are ignored ("drained") until the next paste is
+                initiated (phase 1 or -1).
 
                 Parameters: ~
-                    {arr}  Array to return.
+                    {data}   Multiline input. May be binary (containing NUL
+                             bytes).
+                    {crlf}   Also break lines at CR and CRLF.
+                    {phase}  -1: paste in a single call (i.e. without
+                             streaming). To "stream" a paste, call `nvim_paste` sequentially with these `phase` values:
+                             • 1: starts the paste (exactly once)
+                             • 2: continues the paste (zero or more times)
+                             • 3: ends the paste (exactly once)
 
                 Return: ~
-                    its argument.
 
-nvim__id_dictionary({dct})                             *nvim__id_dictionary()*
-                Returns dictionary given as argument.
+                    • true: Client may continue pasting.
+                    • false: Client must cancel the paste.
 
-                This API function is used for testing. One should not rely on
-                its presence in plugins.
+nvim_put({lines}, {type}, {after}, {follow})                      *nvim_put()*
+                Puts text at cursor, in any mode.
+
+                Compare |:put| and |p| which are always linewise.
 
                 Parameters: ~
-                    {dct}  Dictionary to return.
+                    {lines}   |readfile()|-style list of lines.
+                              |channel-lines|
+                    {type}    Edit behavior: any |getregtype()| result, or:
+                              • "b" |blockwise-visual| mode (may include
+                                width, e.g. "b3")
+                              • "c" |charwise| mode
+                              • "l" |linewise| mode
+                              • "" guess by contents, see |setreg()|
+                    {after}   Insert after cursor (like |p|), or before (like
+                              |P|).
+                    {follow}  Place cursor at end of inserted text.
 
-                Return: ~
-                    its argument.
-
-nvim__id_float({flt})                                       *nvim__id_float()*
-                Returns floating-point value given as argument.
-
-                This API function is used for testing. One should not rely on
-                its presence in plugins.
+                                                    *nvim_replace_termcodes()*
+nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})
+                Replaces terminal codes and |keycodes| (<CR>, <Esc>, ...) in a
+                string with the internal representation.
 
                 Parameters: ~
-                    {flt}  Value to return.
+                    {str}        String to be converted.
+                    {from_part}  Legacy Vim parameter. Usually true.
+                    {do_lt}      Also translate <lt>. Ignored if `special` is
+                                 false.
+                    {special}    Replace |keycodes|, e.g. <CR> becomes a "\n"
+                                 char.
 
-                Return: ~
-                    its argument.
-
-nvim__stats()                                                  *nvim__stats()*
-                Gets internal stats.
-
-                Return: ~
-                    Map of various internal stats.
-
-nvim_list_uis()                                              *nvim_list_uis()*
-                Gets a list of dictionaries representing attached UIs.
-
-                Return: ~
-                    Array of UI dictionaries, each with these keys:
-                    • "height" Requested height of the UI
-                    • "width" Requested width of the UI
-                    • "rgb" true if the UI uses RGB colors (false implies
-                      |cterm-colors|)
-                    • "ext_..." Requested UI extensions, see |ui-option|
-                    • "chan" Channel id of remote UI (not present for TUI)
-
-nvim_get_proc_children({pid})                       *nvim_get_proc_children()*
-                Gets the immediate children of process `pid` .
-
-                Return: ~
-                    Array of child process ids, empty if process not found.
-
-nvim_get_proc({pid})                                         *nvim_get_proc()*
-                Gets info describing process `pid` .
-
-                Return: ~
-                    Map of process properties, or NIL if process not found.
+                See also: ~
+                    replace_termcodes
+                    cpoptions
 
                                                 *nvim_select_popupmenu_item()*
 nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
@@ -1506,15 +1350,171 @@ nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
                               Implies `insert` .
                     {opts}    Optional parameters. Reserved for future use.
 
-nvim__inspect_cell({grid}, {row}, {col})                *nvim__inspect_cell()*
-                TODO: Documentation
+                                                      *nvim_set_client_info()*
+nvim_set_client_info({name}, {version}, {type}, {methods},
+                     {attributes})
+                Self-identifies the client.
 
-nvim__put_attr({id}, {c0}, {c1})                            *nvim__put_attr()*
-                Set attrs in nvim__buf_set_lua_hl callbacks
+                The client/plugin/application should call this after
+                connecting, to provide hints about its identity and purpose,
+                for debugging and orchestration.
 
-                TODO(bfredl): This is rather pedestrian. The final interface
-                should probably be derived from a reformed bufhl/virttext
-                interface with full support for multi-line ranges etc
+                Can be called more than once; the caller should merge old info
+                if appropriate. Example: library first identifies the channel,
+                then a plugin using that library later identifies itself.
+
+                Note:
+                    "Something is better than nothing". You don't need to
+                    include all the fields.
+
+                Parameters: ~
+                    {name}        Short name for the connected client
+                    {version}     Dictionary describing the version, with
+                                  these (optional) keys:
+                                  • "major" major version (defaults to 0 if
+                                    not set, for no release yet)
+                                  • "minor" minor version
+                                  • "patch" patch number
+                                  • "prerelease" string describing a
+                                    prerelease, like "dev" or "beta1"
+                                  • "commit" hash or similar identifier of
+                                    commit
+                    {type}        Must be one of the following values. Client
+                                  libraries should default to "remote" unless
+                                  overridden by the user.
+                                  • "remote" remote client connected to Nvim.
+                                  • "ui" gui frontend
+                                  • "embedder" application using Nvim as a
+                                    component (for example, IDE/editor
+                                    implementing a vim mode).
+                                  • "host" plugin host, typically started by
+                                    nvim
+                                  • "plugin" single plugin, started by nvim
+                    {methods}     Builtin methods in the client. For a host,
+                                  this does not include plugin methods which
+                                  will be discovered later. The key should be
+                                  the method name, the values are dicts with
+                                  these (optional) keys (more keys may be
+                                  added in future versions of Nvim, thus
+                                  unknown keys are ignored. Clients must only
+                                  use keys defined in this or later versions
+                                  of Nvim):
+                                  • "async" if true, send as a notification.
+                                    If false or unspecified, use a blocking
+                                    request
+                                  • "nargs" Number of arguments. Could be a
+                                    single integer or an array of two
+                                    integers, minimum and maximum inclusive.
+                    {attributes}  Arbitrary string:string map of informal
+                                  client properties. Suggested keys:
+                                  • "website": Client homepage URL (e.g.
+                                    GitHub repository)
+                                  • "license": License description ("Apache
+                                    2", "GPLv3", "MIT", …)
+                                  • "logo": URI or path to image, preferably
+                                    small logo or icon. .png or .svg format is
+                                    preferred.
+
+nvim_set_current_buf({buffer})                        *nvim_set_current_buf()*
+                Sets the current buffer.
+
+                Parameters: ~
+                    {buffer}  Buffer handle
+
+nvim_set_current_dir({dir})                           *nvim_set_current_dir()*
+                Changes the global working directory.
+
+                Parameters: ~
+                    {dir}  Directory path
+
+nvim_set_current_line({line})                        *nvim_set_current_line()*
+                Sets the current line.
+
+                Parameters: ~
+                    {line}  Line contents
+
+nvim_set_current_tabpage({tabpage})               *nvim_set_current_tabpage()*
+                Sets the current tabpage.
+
+                Parameters: ~
+                    {tabpage}  Tabpage handle
+
+nvim_set_current_win({window})                        *nvim_set_current_win()*
+                Sets the current window.
+
+                Parameters: ~
+                    {window}  Window handle
+
+nvim_set_keymap({mode}, {lhs}, {rhs}, {opts})              *nvim_set_keymap()*
+                Sets a global |mapping| for the given mode.
+
+                To set a buffer-local mapping, use |nvim_buf_set_keymap()|.
+
+                Unlike |:map|, leading/trailing whitespace is accepted as part
+                of the {lhs} or {rhs}. Empty {rhs} is |<Nop>|. |keycodes| are
+                replaced as usual.
+
+                Example: >
+                    call nvim_set_keymap('n', ' <NL>', '', {'nowait': v:true})
+<
+
+                is equivalent to: >
+                    nmap <nowait> <Space><NL> <Nop>
+<
+
+                Parameters: ~
+                    {mode}  Mode short-name (map command prefix: "n", "i",
+                            "v", "x", …) or "!" for |:map!|, or empty string
+                            for |:map|.
+                    {lhs}   Left-hand-side |{lhs}| of the mapping.
+                    {rhs}   Right-hand-side |{rhs}| of the mapping.
+                    {opts}  Optional parameters map. Accepts all
+                            |:map-arguments| as keys excluding |<buffer>| but
+                            including |noremap|. Values are Booleans. Unknown
+                            key is an error.
+
+nvim_set_option({name}, {value})                           *nvim_set_option()*
+                Sets an option value.
+
+                Parameters: ~
+                    {name}   Option name
+                    {value}  New option value
+
+nvim_set_var({name}, {value})                                 *nvim_set_var()*
+                Sets a global (g:) variable.
+
+                Parameters: ~
+                    {name}   Variable name
+                    {value}  Variable value
+
+nvim_set_vvar({name}, {value})                               *nvim_set_vvar()*
+                Sets a v: variable, if it is not readonly.
+
+                Parameters: ~
+                    {name}   Variable name
+                    {value}  Variable value
+
+nvim_strwidth({text})                                        *nvim_strwidth()*
+                Calculates the number of display cells occupied by `text` .
+                <Tab> counts as one cell.
+
+                Parameters: ~
+                    {text}  Some text
+
+                Return: ~
+                    Number of cells
+
+nvim_subscribe({event})                                     *nvim_subscribe()*
+                Subscribes to event broadcasts.
+
+                Parameters: ~
+                    {event}  Event type string
+
+nvim_unsubscribe({event})                                 *nvim_unsubscribe()*
+                Unsubscribes to event broadcasts.
+
+                Parameters: ~
+                    {event}  Event type string
 
 
 ==============================================================================
@@ -1533,14 +1533,65 @@ affected.
 You can use |nvim_buf_is_loaded()| or |nvim_buf_line_count()|
 to check whether a buffer is loaded.
 
-nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
-                Gets the buffer line count
+                                                    *nvim__buf_redraw_range()*
+nvim__buf_redraw_range({buffer}, {first}, {last})
+                TODO: Documentation
+
+nvim__buf_set_luahl({buffer}, {opts})                  *nvim__buf_set_luahl()*
+                Unstabilized interface for defining syntax hl in lua.
+
+                This is not yet safe for general use, lua callbacks will need
+                to be restricted, like textlock and probably other stuff.
+
+                The API on_line/nvim__put_attr is quite raw and not intended
+                to be the final shape. Ideally this should operate on chunks
+                larger than a single line to reduce interpreter overhead, and
+                generate annotation objects (bufhl/virttext) on the fly but
+                using the same representation.
+
+nvim__buf_stats({buffer})                                  *nvim__buf_stats()*
+                TODO: Documentation
+
+                                                    *nvim_buf_add_highlight()*
+nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line},
+                       {col_start}, {col_end})
+                Adds a highlight to buffer.
+
+                Useful for plugins that dynamically generate highlights to a
+                buffer (like a semantic highlighter or linter). The function
+                adds a single highlight to a buffer. Unlike |matchaddpos()|
+                highlights follow changes to line numbering (as lines are
+                inserted/removed above the highlighted line), like signs and
+                marks do.
+
+                Namespaces are used for batch deletion/updating of a set of
+                highlights. To create a namespace, use |nvim_create_namespace|
+                which returns a namespace id. Pass it in to this function as
+                `ns_id` to add highlights to the namespace. All highlights in
+                the same namespace can then be cleared with single call to
+                |nvim_buf_clear_namespace|. If the highlight never will be
+                deleted by an API call, pass `ns_id = -1` .
+
+                As a shorthand, `ns_id = 0` can be used to create a new
+                namespace for the highlight, the allocated id is then
+                returned. If `hl_group` is the empty string no highlight is
+                added, but a new `ns_id` is still returned. This is supported
+                for backwards compatibility, new code should use
+                |nvim_create_namespace| to create a new empty namespace.
 
                 Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
+                    {buffer}     Buffer handle, or 0 for current buffer
+                    {ns_id}      namespace to use or -1 for ungrouped
+                                 highlight
+                    {hl_group}   Name of the highlight group to use
+                    {line}       Line to highlight (zero-indexed)
+                    {col_start}  Start of (byte-indexed) column range to
+                                 highlight
+                    {col_end}    End of (byte-indexed) column range to
+                                 highlight, or -1 to highlight to end of line
 
                 Return: ~
-                    Line count, or 0 for unloaded buffer. |api-buffer|
+                    The ns_id that was used
 
 nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                 Activates buffer-update events on a channel, or as Lua
@@ -1563,7 +1614,7 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                                    callbacks.
                     {opts}         Optional parameters.
                                    • on_lines: Lua callback invoked on change.
-                                     Return `true` to detach. Args:
+                                     Return`true`to detach. Args:
                                      • buffer handle
                                      • b:changedtick
                                      • first line that changed (zero-indexed)
@@ -1597,6 +1648,49 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                     |nvim_buf_detach()|
                     |api-buffer-updates-lua|
 
+                                                  *nvim_buf_clear_namespace()*
+nvim_buf_clear_namespace({buffer}, {ns_id}, {line_start}, {line_end})
+                Clears namespaced objects (highlights, extmarks, virtual text)
+                from a region.
+
+                Lines are 0-indexed. |api-indexing| To clear the namespace in
+                the entire buffer, specify line_start=0 and line_end=-1.
+
+                Parameters: ~
+                    {buffer}      Buffer handle, or 0 for current buffer
+                    {ns_id}       Namespace to clear, or -1 to clear all
+                                  namespaces.
+                    {line_start}  Start of range of lines to clear
+                    {line_end}    End of range of lines to clear (exclusive)
+                                  or -1 to clear to end of buffer.
+
+nvim_buf_del_extmark({buffer}, {ns_id}, {id})         *nvim_buf_del_extmark()*
+                Removes an extmark.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {ns_id}   Namespace id from |nvim_create_namespace()|
+                    {id}      Extmark id
+
+                Return: ~
+                    true if the extmark was found, else false
+
+nvim_buf_del_keymap({buffer}, {mode}, {lhs})           *nvim_buf_del_keymap()*
+                Unmaps a buffer-local |mapping| for the given mode.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+
+                See also: ~
+                    |nvim_del_keymap()|
+
+nvim_buf_del_var({buffer}, {name})                        *nvim_buf_del_var()*
+                Removes a buffer-scoped (b:) variable
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Variable name
+
 nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
                 Deactivates buffer-update events on the channel.
 
@@ -1611,97 +1705,6 @@ nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
                     |nvim_buf_attach()|
                     |api-lua-detach| for detaching Lua callbacks
 
-nvim__buf_set_luahl({buffer}, {opts})                  *nvim__buf_set_luahl()*
-                Unstabilized interface for defining syntax hl in lua.
-
-                This is not yet safe for general use, lua callbacks will need
-                to be restricted, like textlock and probably other stuff.
-
-                The API on_line/nvim__put_attr is quite raw and not intended
-                to be the final shape. Ideally this should operate on chunks
-                larger than a single line to reduce interpreter overhead, and
-                generate annotation objects (bufhl/virttext) on the fly but
-                using the same representation.
-
-                                                    *nvim__buf_redraw_range()*
-nvim__buf_redraw_range({buffer}, {first}, {last})
-                TODO: Documentation
-
-                                                        *nvim_buf_get_lines()*
-nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
-                Gets a line-range from the buffer.
-
-                Indexing is zero-based, end-exclusive. Negative indices are
-                interpreted as length+1+index: -1 refers to the index past the
-                end. So to get the last element use start=-2 and end=-1.
-
-                Out-of-bounds indices are clamped to the nearest valid value,
-                unless `strict_indexing` is set.
-
-                Parameters: ~
-                    {buffer}           Buffer handle, or 0 for current buffer
-                    {start}            First line index
-                    {end}              Last line index (exclusive)
-                    {strict_indexing}  Whether out-of-bounds should be an
-                                       error.
-
-                Return: ~
-                    Array of lines, or empty array for unloaded buffer.
-
-                                                        *nvim_buf_set_lines()*
-nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing},
-                   {replacement})
-                Sets (replaces) a line-range in the buffer.
-
-                Indexing is zero-based, end-exclusive. Negative indices are
-                interpreted as length+1+index: -1 refers to the index past the
-                end. So to change or delete the last element use start=-2 and
-                end=-1.
-
-                To insert lines at a given index, set `start` and `end` to the
-                same index. To delete a range of lines, set `replacement` to
-                an empty array.
-
-                Out-of-bounds indices are clamped to the nearest valid value,
-                unless `strict_indexing` is set.
-
-                Parameters: ~
-                    {buffer}           Buffer handle, or 0 for current buffer
-                    {start}            First line index
-                    {end}              Last line index (exclusive)
-                    {strict_indexing}  Whether out-of-bounds should be an
-                                       error.
-                    {replacement}      Array of lines to use as replacement
-
-nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
-                Returns the byte offset of a line (0-indexed). |api-indexing|
-
-                Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is
-                one byte. 'fileformat' and 'fileencoding' are ignored. The
-                line index just after the last line gives the total byte-count
-                of the buffer. A final EOL byte is counted if it would be
-                written, see 'eol'.
-
-                Unlike |line2byte()|, throws error for out-of-bounds indexing.
-                Returns -1 for unloaded buffer.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {index}   Line index
-
-                Return: ~
-                    Integer byte offset, or -1 for unloaded buffer.
-
-nvim_buf_get_var({buffer}, {name})                        *nvim_buf_get_var()*
-                Gets a buffer-scoped (b:) variable.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Variable name
-
-                Return: ~
-                    Variable value
-
 nvim_buf_get_changedtick({buffer})                *nvim_buf_get_changedtick()*
                 Gets a changed tick of a buffer
 
@@ -1710,36 +1713,6 @@ nvim_buf_get_changedtick({buffer})                *nvim_buf_get_changedtick()*
 
                 Return: ~
                     `b:changedtick` value.
-
-nvim_buf_get_keymap({buffer}, {mode})                  *nvim_buf_get_keymap()*
-                Gets a list of buffer-local |mapping| definitions.
-
-                Parameters: ~
-                    {mode}    Mode short-name ("n", "i", "v", ...)
-                    {buffer}  Buffer handle, or 0 for current buffer
-
-                Return: ~
-                    Array of maparg()-like dictionaries describing mappings.
-                    The "buffer" key holds the associated buffer handle.
-
-                                                       *nvim_buf_set_keymap()*
-nvim_buf_set_keymap({buffer}, {mode}, {lhs}, {rhs}, {opts})
-                Sets a buffer-local |mapping| for the given mode.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-
-                See also: ~
-                    |nvim_set_keymap()|
-
-nvim_buf_del_keymap({buffer}, {mode}, {lhs})           *nvim_buf_del_keymap()*
-                Unmaps a buffer-local |mapping| for the given mode.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-
-                See also: ~
-                    |nvim_del_keymap()|
 
 nvim_buf_get_commands({buffer}, {opts})              *nvim_buf_get_commands()*
                 Gets a map of buffer-local |user-commands|.
@@ -1750,92 +1723,6 @@ nvim_buf_get_commands({buffer}, {opts})              *nvim_buf_get_commands()*
 
                 Return: ~
                     Map of maps describing commands.
-
-nvim_buf_set_var({buffer}, {name}, {value})               *nvim_buf_set_var()*
-                Sets a buffer-scoped (b:) variable
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Variable name
-                    {value}   Variable value
-
-nvim_buf_del_var({buffer}, {name})                        *nvim_buf_del_var()*
-                Removes a buffer-scoped (b:) variable
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Variable name
-
-nvim_buf_get_option({buffer}, {name})                  *nvim_buf_get_option()*
-                Gets a buffer option value
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Option name
-
-                Return: ~
-                    Option value
-
-nvim_buf_set_option({buffer}, {name}, {value})         *nvim_buf_set_option()*
-                Sets a buffer option value. Passing 'nil' as value deletes the
-                option (only works if there's a global fallback)
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Option name
-                    {value}   Option value
-
-nvim_buf_get_name({buffer})                              *nvim_buf_get_name()*
-                Gets the full file name for the buffer
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-
-                Return: ~
-                    Buffer name
-
-nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
-                Sets the full file name for a buffer
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Buffer name
-
-nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
-                Checks if a buffer is valid and loaded. See |api-buffer| for
-                more info about unloaded buffers.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-
-                Return: ~
-                    true if the buffer is valid and loaded, false otherwise.
-
-nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
-                Checks if a buffer is valid.
-
-                Note:
-                    Even if a buffer is valid it may have been unloaded. See
-                    |api-buffer| for more info about unloaded buffers.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-
-                Return: ~
-                    true if the buffer is valid, false otherwise.
-
-nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
-                Return a tuple (row,col) representing the position of the
-                named mark.
-
-                Marks are (1,0)-indexed. |api-indexing|
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {name}    Mark name
-
-                Return: ~
-                    (row, col) tuple
 
                                                 *nvim_buf_get_extmark_by_id()*
 nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id})
@@ -1898,6 +1785,152 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
                     List of [extmark_id, row, col] tuples in "traversal
                     order".
 
+nvim_buf_get_keymap({buffer}, {mode})                  *nvim_buf_get_keymap()*
+                Gets a list of buffer-local |mapping| definitions.
+
+                Parameters: ~
+                    {mode}    Mode short-name ("n", "i", "v", ...)
+                    {buffer}  Buffer handle, or 0 for current buffer
+
+                Return: ~
+                    Array of maparg()-like dictionaries describing mappings.
+                    The "buffer" key holds the associated buffer handle.
+
+                                                        *nvim_buf_get_lines()*
+nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
+                Gets a line-range from the buffer.
+
+                Indexing is zero-based, end-exclusive. Negative indices are
+                interpreted as length+1+index: -1 refers to the index past the
+                end. So to get the last element use start=-2 and end=-1.
+
+                Out-of-bounds indices are clamped to the nearest valid value,
+                unless `strict_indexing` is set.
+
+                Parameters: ~
+                    {buffer}           Buffer handle, or 0 for current buffer
+                    {start}            First line index
+                    {end}              Last line index (exclusive)
+                    {strict_indexing}  Whether out-of-bounds should be an
+                                       error.
+
+                Return: ~
+                    Array of lines, or empty array for unloaded buffer.
+
+nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
+                Return a tuple (row,col) representing the position of the
+                named mark.
+
+                Marks are (1,0)-indexed. |api-indexing|
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Mark name
+
+                Return: ~
+                    (row, col) tuple
+
+nvim_buf_get_name({buffer})                              *nvim_buf_get_name()*
+                Gets the full file name for the buffer
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+
+                Return: ~
+                    Buffer name
+
+nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
+                Returns the byte offset of a line (0-indexed). |api-indexing|
+
+                Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is
+                one byte. 'fileformat' and 'fileencoding' are ignored. The
+                line index just after the last line gives the total byte-count
+                of the buffer. A final EOL byte is counted if it would be
+                written, see 'eol'.
+
+                Unlike |line2byte()|, throws error for out-of-bounds indexing.
+                Returns -1 for unloaded buffer.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {index}   Line index
+
+                Return: ~
+                    Integer byte offset, or -1 for unloaded buffer.
+
+nvim_buf_get_option({buffer}, {name})                  *nvim_buf_get_option()*
+                Gets a buffer option value
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Option name
+
+                Return: ~
+                    Option value
+
+nvim_buf_get_var({buffer}, {name})                        *nvim_buf_get_var()*
+                Gets a buffer-scoped (b:) variable.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Variable name
+
+                Return: ~
+                    Variable value
+
+nvim_buf_get_virtual_text({buffer}, {lnum})      *nvim_buf_get_virtual_text()*
+                Get the virtual text (annotation) for a buffer line.
+
+                The virtual text is returned as list of lists, whereas the
+                inner lists have either one or two elements. The first element
+                is the actual text, the optional second element is the
+                highlight group.
+
+                The format is exactly the same as given to
+                nvim_buf_set_virtual_text().
+
+                If there is no virtual text associated with the given line, an
+                empty list is returned.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {line}    Line to get the virtual text from (zero-indexed)
+
+                Return: ~
+                    List of virtual text chunks
+
+nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
+                Checks if a buffer is valid and loaded. See |api-buffer| for
+                more info about unloaded buffers.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+
+                Return: ~
+                    true if the buffer is valid and loaded, false otherwise.
+
+nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
+                Checks if a buffer is valid.
+
+                Note:
+                    Even if a buffer is valid it may have been unloaded. See
+                    |api-buffer| for more info about unloaded buffers.
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+
+                Return: ~
+                    true if the buffer is valid, false otherwise.
+
+nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
+                Gets the buffer line count
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+
+                Return: ~
+                    Line count, or 0 for unloaded buffer. |api-buffer|
+
                                                       *nvim_buf_set_extmark()*
 nvim_buf_set_extmark({buffer}, {ns_id}, {id}, {line}, {col}, {opts})
                 Creates or updates an extmark.
@@ -1919,73 +1952,64 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {id}, {line}, {col}, {opts})
                 Return: ~
                     Id of the created/updated extmark
 
-nvim_buf_del_extmark({buffer}, {ns_id}, {id})         *nvim_buf_del_extmark()*
-                Removes an extmark.
+                                                       *nvim_buf_set_keymap()*
+nvim_buf_set_keymap({buffer}, {mode}, {lhs}, {rhs}, {opts})
+                Sets a buffer-local |mapping| for the given mode.
 
                 Parameters: ~
                     {buffer}  Buffer handle, or 0 for current buffer
-                    {ns_id}   Namespace id from |nvim_create_namespace()|
-                    {id}      Extmark id
 
-                Return: ~
-                    true if the extmark was found, else false
+                See also: ~
+                    |nvim_set_keymap()|
 
-                                                    *nvim_buf_add_highlight()*
-nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line},
-                       {col_start}, {col_end})
-                Adds a highlight to buffer.
+                                                        *nvim_buf_set_lines()*
+nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing},
+                   {replacement})
+                Sets (replaces) a line-range in the buffer.
 
-                Useful for plugins that dynamically generate highlights to a
-                buffer (like a semantic highlighter or linter). The function
-                adds a single highlight to a buffer. Unlike |matchaddpos()|
-                highlights follow changes to line numbering (as lines are
-                inserted/removed above the highlighted line), like signs and
-                marks do.
+                Indexing is zero-based, end-exclusive. Negative indices are
+                interpreted as length+1+index: -1 refers to the index past the
+                end. So to change or delete the last element use start=-2 and
+                end=-1.
 
-                Namespaces are used for batch deletion/updating of a set of
-                highlights. To create a namespace, use |nvim_create_namespace|
-                which returns a namespace id. Pass it in to this function as
-                `ns_id` to add highlights to the namespace. All highlights in
-                the same namespace can then be cleared with single call to
-                |nvim_buf_clear_namespace|. If the highlight never will be
-                deleted by an API call, pass `ns_id = -1` .
+                To insert lines at a given index, set `start` and `end` to the
+                same index. To delete a range of lines, set `replacement` to
+                an empty array.
 
-                As a shorthand, `ns_id = 0` can be used to create a new
-                namespace for the highlight, the allocated id is then
-                returned. If `hl_group` is the empty string no highlight is
-                added, but a new `ns_id` is still returned. This is supported
-                for backwards compatibility, new code should use
-                |nvim_create_namespace| to create a new empty namespace.
+                Out-of-bounds indices are clamped to the nearest valid value,
+                unless `strict_indexing` is set.
 
                 Parameters: ~
-                    {buffer}     Buffer handle, or 0 for current buffer
-                    {ns_id}      namespace to use or -1 for ungrouped
-                                 highlight
-                    {hl_group}   Name of the highlight group to use
-                    {line}       Line to highlight (zero-indexed)
-                    {col_start}  Start of (byte-indexed) column range to
-                                 highlight
-                    {col_end}    End of (byte-indexed) column range to
-                                 highlight, or -1 to highlight to end of line
+                    {buffer}           Buffer handle, or 0 for current buffer
+                    {start}            First line index
+                    {end}              Last line index (exclusive)
+                    {strict_indexing}  Whether out-of-bounds should be an
+                                       error.
+                    {replacement}      Array of lines to use as replacement
 
-                Return: ~
-                    The ns_id that was used
-
-                                                  *nvim_buf_clear_namespace()*
-nvim_buf_clear_namespace({buffer}, {ns_id}, {line_start}, {line_end})
-                Clears namespaced objects (highlights, extmarks, virtual text)
-                from a region.
-
-                Lines are 0-indexed. |api-indexing| To clear the namespace in
-                the entire buffer, specify line_start=0 and line_end=-1.
+nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
+                Sets the full file name for a buffer
 
                 Parameters: ~
-                    {buffer}      Buffer handle, or 0 for current buffer
-                    {ns_id}       Namespace to clear, or -1 to clear all
-                                  namespaces.
-                    {line_start}  Start of range of lines to clear
-                    {line_end}    End of range of lines to clear (exclusive)
-                                  or -1 to clear to end of buffer.
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Buffer name
+
+nvim_buf_set_option({buffer}, {name}, {value})         *nvim_buf_set_option()*
+                Sets a buffer option value. Passing 'nil' as value deletes the
+                option (only works if there's a global fallback)
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Option name
+                    {value}   Option value
+
+nvim_buf_set_var({buffer}, {name}, {value})               *nvim_buf_set_var()*
+                Sets a buffer-scoped (b:) variable
+
+                Parameters: ~
+                    {buffer}  Buffer handle, or 0 for current buffer
+                    {name}    Variable name
+                    {value}   Variable value
 
                                                  *nvim_buf_set_virtual_text()*
 nvim_buf_set_virtual_text({buffer}, {ns_id}, {line}, {chunks}, {opts})
@@ -2025,33 +2049,26 @@ nvim_buf_set_virtual_text({buffer}, {ns_id}, {line}, {chunks}, {opts})
                 Return: ~
                     The ns_id that was used
 
-nvim_buf_get_virtual_text({buffer}, {lnum})      *nvim_buf_get_virtual_text()*
-                Get the virtual text (annotation) for a buffer line.
-
-                The virtual text is returned as list of lists, whereas the
-                inner lists have either one or two elements. The first element
-                is the actual text, the optional second element is the
-                highlight group.
-
-                The format is exactly the same as given to
-                nvim_buf_set_virtual_text().
-
-                If there is no virtual text associated with the given line, an
-                empty list is returned.
-
-                Parameters: ~
-                    {buffer}  Buffer handle, or 0 for current buffer
-                    {line}    Line to get the virtual text from (zero-indexed)
-
-                Return: ~
-                    List of virtual text chunks
-
-nvim__buf_stats({buffer})                                  *nvim__buf_stats()*
-                TODO: Documentation
-
 
 ==============================================================================
 Window Functions                                                  *api-window*
+
+nvim_win_close({window}, {force})                           *nvim_win_close()*
+                Closes the window (like |:close| with a |window-ID|).
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {force}   Behave like `:close!` The last window of a
+                              buffer with unwritten changes can be closed. The
+                              buffer will become hidden, even if 'hidden' is
+                              not set.
+
+nvim_win_del_var({window}, {name})                        *nvim_win_del_var()*
+                Removes a window-scoped (w:) variable
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {name}    Variable name
 
 nvim_win_get_buf({window})                                *nvim_win_get_buf()*
                 Gets the current buffer in a window
@@ -2062,12 +2079,19 @@ nvim_win_get_buf({window})                                *nvim_win_get_buf()*
                 Return: ~
                     Buffer handle
 
-nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
-                Sets the current buffer in a window, without side-effects
+nvim_win_get_config({window})                          *nvim_win_get_config()*
+                Gets window configuration.
+
+                The returned value may be given to |nvim_open_win()|.
+
+                `relative` is empty for normal windows.
 
                 Parameters: ~
                     {window}  Window handle, or 0 for current window
-                    {buffer}  Buffer handle
+
+                Return: ~
+                    Map defining the window configuration, see
+                    |nvim_open_win()|
 
 nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
                 Gets the (1,0)-indexed cursor position in the window.
@@ -2079,14 +2103,6 @@ nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
                 Return: ~
                     (row, col) tuple
 
-nvim_win_set_cursor({window}, {pos})                   *nvim_win_set_cursor()*
-                Sets the (1,0)-indexed cursor position in the window.
-                |api-indexing|
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {pos}     (row, col) tuple representing the new position
-
 nvim_win_get_height({window})                          *nvim_win_get_height()*
                 Gets the window height
 
@@ -2096,55 +2112,14 @@ nvim_win_get_height({window})                          *nvim_win_get_height()*
                 Return: ~
                     Height as a count of rows
 
-nvim_win_set_height({window}, {height})                *nvim_win_set_height()*
-                Sets the window height. This will only succeed if the screen
-                is split horizontally.
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {height}  Height as a count of rows
-
-nvim_win_get_width({window})                            *nvim_win_get_width()*
-                Gets the window width
+nvim_win_get_number({window})                          *nvim_win_get_number()*
+                Gets the window number
 
                 Parameters: ~
                     {window}  Window handle, or 0 for current window
 
                 Return: ~
-                    Width as a count of columns
-
-nvim_win_set_width({window}, {width})                   *nvim_win_set_width()*
-                Sets the window width. This will only succeed if the screen is
-                split vertically.
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {width}   Width as a count of columns
-
-nvim_win_get_var({window}, {name})                        *nvim_win_get_var()*
-                Gets a window-scoped (w:) variable
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {name}    Variable name
-
-                Return: ~
-                    Variable value
-
-nvim_win_set_var({window}, {name}, {value})               *nvim_win_set_var()*
-                Sets a window-scoped (w:) variable
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {name}    Variable name
-                    {value}   Variable value
-
-nvim_win_del_var({window}, {name})                        *nvim_win_del_var()*
-                Removes a window-scoped (w:) variable
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {name}    Variable name
+                    Window number
 
 nvim_win_get_option({window}, {name})                  *nvim_win_get_option()*
                 Gets a window option value
@@ -2155,15 +2130,6 @@ nvim_win_get_option({window}, {name})                  *nvim_win_get_option()*
 
                 Return: ~
                     Option value
-
-nvim_win_set_option({window}, {name}, {value})         *nvim_win_set_option()*
-                Sets a window option value. Passing 'nil' as value deletes the
-                option(only works if there's a global fallback)
-
-                Parameters: ~
-                    {window}  Window handle, or 0 for current window
-                    {name}    Option name
-                    {value}   Option value
 
 nvim_win_get_position({window})                      *nvim_win_get_position()*
                 Gets the window position in display cells. First position is
@@ -2184,14 +2150,24 @@ nvim_win_get_tabpage({window})                        *nvim_win_get_tabpage()*
                 Return: ~
                     Tabpage that contains the window
 
-nvim_win_get_number({window})                          *nvim_win_get_number()*
-                Gets the window number
+nvim_win_get_var({window}, {name})                        *nvim_win_get_var()*
+                Gets a window-scoped (w:) variable
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {name}    Variable name
+
+                Return: ~
+                    Variable value
+
+nvim_win_get_width({window})                            *nvim_win_get_width()*
+                Gets the window width
 
                 Parameters: ~
                     {window}  Window handle, or 0 for current window
 
                 Return: ~
-                    Window number
+                    Width as a count of columns
 
 nvim_win_is_valid({window})                              *nvim_win_is_valid()*
                 Checks if a window is valid
@@ -2201,6 +2177,13 @@ nvim_win_is_valid({window})                              *nvim_win_is_valid()*
 
                 Return: ~
                     true if the window is valid, false otherwise
+
+nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
+                Sets the current buffer in a window, without side-effects
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {buffer}  Buffer handle
 
 nvim_win_set_config({window}, {config})                *nvim_win_set_config()*
                 Configures window layout. Currently only for floating and
@@ -2219,42 +2202,66 @@ nvim_win_set_config({window}, {config})                *nvim_win_set_config()*
                 See also: ~
                     |nvim_open_win()|
 
-nvim_win_get_config({window})                          *nvim_win_get_config()*
-                Gets window configuration.
-
-                The returned value may be given to |nvim_open_win()|.
-
-                `relative` is empty for normal windows.
+nvim_win_set_cursor({window}, {pos})                   *nvim_win_set_cursor()*
+                Sets the (1,0)-indexed cursor position in the window.
+                |api-indexing|
 
                 Parameters: ~
                     {window}  Window handle, or 0 for current window
+                    {pos}     (row, col) tuple representing the new position
 
-                Return: ~
-                    Map defining the window configuration, see
-                    |nvim_open_win()|
-
-nvim_win_close({window}, {force})                           *nvim_win_close()*
-                Closes the window (like |:close| with a |window-ID|).
+nvim_win_set_height({window}, {height})                *nvim_win_set_height()*
+                Sets the window height. This will only succeed if the screen
+                is split horizontally.
 
                 Parameters: ~
                     {window}  Window handle, or 0 for current window
-                    {force}   Behave like `:close!` The last window of a
-                              buffer with unwritten changes can be closed. The
-                              buffer will become hidden, even if 'hidden' is
-                              not set.
+                    {height}  Height as a count of rows
+
+nvim_win_set_option({window}, {name}, {value})         *nvim_win_set_option()*
+                Sets a window option value. Passing 'nil' as value deletes the
+                option(only works if there's a global fallback)
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {name}    Option name
+                    {value}   Option value
+
+nvim_win_set_var({window}, {name}, {value})               *nvim_win_set_var()*
+                Sets a window-scoped (w:) variable
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {name}    Variable name
+                    {value}   Variable value
+
+nvim_win_set_width({window}, {width})                   *nvim_win_set_width()*
+                Sets the window width. This will only succeed if the screen is
+                split vertically.
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {width}   Width as a count of columns
 
 
 ==============================================================================
 Tabpage Functions                                                *api-tabpage*
 
-nvim_tabpage_list_wins({tabpage})                   *nvim_tabpage_list_wins()*
-                Gets the windows in a tabpage
+nvim_tabpage_del_var({tabpage}, {name})               *nvim_tabpage_del_var()*
+                Removes a tab-scoped (t:) variable
+
+                Parameters: ~
+                    {tabpage}  Tabpage handle, or 0 for current tabpage
+                    {name}     Variable name
+
+nvim_tabpage_get_number({tabpage})                 *nvim_tabpage_get_number()*
+                Gets the tabpage number
 
                 Parameters: ~
                     {tabpage}  Tabpage handle, or 0 for current tabpage
 
                 Return: ~
-                    List of windows in `tabpage`
+                    Tabpage number
 
 nvim_tabpage_get_var({tabpage}, {name})               *nvim_tabpage_get_var()*
                 Gets a tab-scoped (t:) variable
@@ -2266,21 +2273,6 @@ nvim_tabpage_get_var({tabpage}, {name})               *nvim_tabpage_get_var()*
                 Return: ~
                     Variable value
 
-nvim_tabpage_set_var({tabpage}, {name}, {value})      *nvim_tabpage_set_var()*
-                Sets a tab-scoped (t:) variable
-
-                Parameters: ~
-                    {tabpage}  Tabpage handle, or 0 for current tabpage
-                    {name}     Variable name
-                    {value}    Variable value
-
-nvim_tabpage_del_var({tabpage}, {name})               *nvim_tabpage_del_var()*
-                Removes a tab-scoped (t:) variable
-
-                Parameters: ~
-                    {tabpage}  Tabpage handle, or 0 for current tabpage
-                    {name}     Variable name
-
 nvim_tabpage_get_win({tabpage})                       *nvim_tabpage_get_win()*
                 Gets the current window in a tabpage
 
@@ -2290,15 +2282,6 @@ nvim_tabpage_get_win({tabpage})                       *nvim_tabpage_get_win()*
                 Return: ~
                     Window handle
 
-nvim_tabpage_get_number({tabpage})                 *nvim_tabpage_get_number()*
-                Gets the tabpage number
-
-                Parameters: ~
-                    {tabpage}  Tabpage handle, or 0 for current tabpage
-
-                Return: ~
-                    Tabpage number
-
 nvim_tabpage_is_valid({tabpage})                     *nvim_tabpage_is_valid()*
                 Checks if a tabpage is valid
 
@@ -2307,6 +2290,23 @@ nvim_tabpage_is_valid({tabpage})                     *nvim_tabpage_is_valid()*
 
                 Return: ~
                     true if the tabpage is valid, false otherwise
+
+nvim_tabpage_list_wins({tabpage})                   *nvim_tabpage_list_wins()*
+                Gets the windows in a tabpage
+
+                Parameters: ~
+                    {tabpage}  Tabpage handle, or 0 for current tabpage
+
+                Return: ~
+                    List of windows in `tabpage`
+
+nvim_tabpage_set_var({tabpage}, {name}, {value})      *nvim_tabpage_set_var()*
+                Sets a tab-scoped (t:) variable
+
+                Parameters: ~
+                    {tabpage}  Tabpage handle, or 0 for current tabpage
+                    {name}     Variable name
+                    {value}    Variable value
 
 
 ==============================================================================
@@ -2335,10 +2335,17 @@ nvim_ui_detach()                                            *nvim_ui_detach()*
 
                 Removes the client from the list of UIs. |nvim_list_uis()|
 
-nvim_ui_try_resize({width}, {height})                   *nvim_ui_try_resize()*
-                TODO: Documentation
+nvim_ui_pum_set_height({height})                    *nvim_ui_pum_set_height()*
+                Tells Nvim the number of elements displaying in the popumenu,
+                to decide <PageUp> and <PageDown> movement.
+
+                Parameters: ~
+                    {height}  Popupmenu height, must be greater than zero.
 
 nvim_ui_set_option({name}, {value})                     *nvim_ui_set_option()*
+                TODO: Documentation
+
+nvim_ui_try_resize({width}, {height})                   *nvim_ui_try_resize()*
                 TODO: Documentation
 
                                                    *nvim_ui_try_resize_grid()*
@@ -2353,12 +2360,5 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
                     {grid}    The handle of the grid to be changed.
                     {width}   The new requested width.
                     {height}  The new requested height.
-
-nvim_ui_pum_set_height({height})                    *nvim_ui_pum_set_height()*
-                Tells Nvim the number of elements displaying in the popumenu,
-                to decide <PageUp> and <PageDown> movement.
-
-                Parameters: ~
-                    {height}  Popupmenu height, must be greater than zero.
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -540,6 +540,11 @@ nvim_get_hl_by_id({hl_id}, {rgb})                        *nvim_get_hl_by_id()*
                 See also: ~
                     nvim_get_hl_by_name
 
+nvim_get_hl_id_by_name({name})                      *nvim_get_hl_id_by_name()*
+                Gets a highlight group by name
+
+                similar to |hlID()|, but allocates a new ID if not present.
+
 nvim_feedkeys({keys}, {mode}, {escape_csi})                  *nvim_feedkeys()*
                 Sends input-keys to Nvim, subject to various quirks controlled
                 by `mode` flags. This is a blocking call, unlike
@@ -903,7 +908,7 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                     {buffer}  Buffer to display, or 0 for current buffer
                     {enter}   Enter the window (make it the current window)
                     {config}  Map defining the window configuration. Keys:
-                              •  `relative` : Sets the window layout to "floating", placed
+                              • `relative`: Sets the window layout to "floating", placed
                                 at (row,col) coordinates relative to:
                                 • "editor" The global editor grid
                                 • "win" Window given by the `win` field, or
@@ -1504,6 +1509,13 @@ nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
 nvim__inspect_cell({grid}, {row}, {col})                *nvim__inspect_cell()*
                 TODO: Documentation
 
+nvim__put_attr({id}, {c0}, {c1})                            *nvim__put_attr()*
+                Set attrs in nvim__buf_set_lua_hl callbacks
+
+                TODO(bfredl): This is rather pedestrian. The final interface
+                should probably be derived from a reformed bufhl/virttext
+                interface with full support for multi-line ranges etc
+
 
 ==============================================================================
 Buffer Functions                                                  *api-buffer*
@@ -1598,6 +1610,22 @@ nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
                 See also: ~
                     |nvim_buf_attach()|
                     |api-lua-detach| for detaching Lua callbacks
+
+nvim__buf_set_luahl({buffer}, {opts})                  *nvim__buf_set_luahl()*
+                Unstabilized interface for defining syntax hl in lua.
+
+                This is not yet safe for general use, lua callbacks will need
+                to be restricted, like textlock and probably other stuff.
+
+                The API on_line/nvim__put_attr is quite raw and not intended
+                to be the final shape. Ideally this should operate on chunks
+                larger than a single line to reduce interpreter overhead, and
+                generate annotation objects (bufhl/virttext) on the fly but
+                using the same representation.
+
+                                                    *nvim__buf_redraw_range()*
+nvim__buf_redraw_range({buffer}, {first}, {last})
+                TODO: Documentation
 
                                                         *nvim_buf_get_lines()*
 nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -861,6 +861,9 @@ schedule_wrap({cb})                                      *vim.schedule_wrap()*
 
 
 
+deep_equal({a}, {b})                                        *vim.deep_equal()*
+                TODO: Documentation
+
 deepcopy({orig})                                              *vim.deepcopy()*
                 Returns a deep copy of the given object. Non-table objects are
                 copied as in a typical Lua assignment, whereas table objects
@@ -889,6 +892,45 @@ gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
                     https://www.lua.org/pil/20.2.html
                     http://lua-users.org/wiki/StringLibraryTutorial
 
+is_callable({f})                                           *vim.is_callable()*
+                Returns true if object `f` can be called as a function.
+
+                Parameters: ~
+                    {f}  Any object
+
+                Return: ~
+                    true if `f` is callable, else false
+
+list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
+                Extends a list-like table with the values of another list-like
+                table.
+
+                NOTE: This mutates dst!
+
+                Parameters: ~
+                    {dst}     list which will be modified and appended to.
+                    {src}     list from which values will be inserted.
+                    {start}   Start index on src. defaults to 1
+                    {finish}  Final index on src. defaults to #src
+
+                Return: ~
+                    dst
+
+                See also: ~
+                    |vim.tbl_extend()|
+
+pesc({s})                                                         *vim.pesc()*
+                Escapes magic chars in a Lua pattern string.
+
+                Parameters: ~
+                    {s}  String to escape
+
+                Return: ~
+                    %-escaped pattern string
+
+                See also: ~
+                    https://github.com/rxi/lume
+
 split({s}, {sep}, {plain})                                       *vim.split()*
                 Splits a string at each instance of a separator.
 
@@ -909,6 +951,62 @@ split({s}, {sep}, {plain})                                       *vim.split()*
 
                 See also: ~
                     |vim.gsplit()|
+
+tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
+                Add the reverse lookup values to an existing table. For
+                example: `tbl_add_reverse_lookup { A = 1 } == { [1] = 'A', A =
+                1 }`
+
+                Parameters: ~
+                    {o}  table The table to add the reverse to.
+
+tbl_contains({t}, {value})                                *vim.tbl_contains()*
+                Checks if a list-like (vector) table contains `value` .
+
+                Parameters: ~
+                    {t}      Table to check
+                    {value}  Value to compare
+
+                Return: ~
+                    true if `t` contains `value`
+
+tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
+                Merges two or more map-like tables.
+
+                Parameters: ~
+                    {behavior}  Decides what to do if a key is found in more
+                                than one map:
+                                • "error": raise an error
+                                • "keep": use value from the leftmost map
+                                • "force": use value from the rightmost map
+                    {...}       Two or more map-like tables.
+
+                See also: ~
+                    |extend()|
+
+tbl_flatten({t})                                           *vim.tbl_flatten()*
+                Creates a copy of a list-like table such that any nested
+                tables are "unrolled" and appended to the result.
+
+                Parameters: ~
+                    {t}  List-like table
+
+                Return: ~
+                    Flattened copy of the given list-like table.
+
+                See also: ~
+                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
+
+tbl_isempty({t})                                           *vim.tbl_isempty()*
+                See also: ~
+                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua@paramt Table to check
+
+tbl_islist({t})                                             *vim.tbl_islist()*
+                Table
+
+                Return: ~
+                    true: A non-empty array, false: A non-empty table, nil: An
+                    empty table
 
 tbl_keys({t})                                                 *vim.tbl_keys()*
                 Return a list of all keys used in a table. However, the order
@@ -933,83 +1031,6 @@ tbl_values({t})                                             *vim.tbl_values()*
                 Return: ~
                     list of values
 
-tbl_contains({t}, {value})                                *vim.tbl_contains()*
-                Checks if a list-like (vector) table contains `value` .
-
-                Parameters: ~
-                    {t}      Table to check
-                    {value}  Value to compare
-
-                Return: ~
-                    true if `t` contains `value`
-
-tbl_isempty({t})                                           *vim.tbl_isempty()*
-                See also: ~
-                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua@paramt Table to check
-
-tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
-                Merges two or more map-like tables.
-
-                Parameters: ~
-                    {behavior}  Decides what to do if a key is found in more
-                                than one map:
-                                • "error": raise an error
-                                • "keep": use value from the leftmost map
-                                • "force": use value from the rightmost map
-                    {...}       Two or more map-like tables.
-
-                See also: ~
-                    |extend()|
-
-deep_equal({a}, {b})                                        *vim.deep_equal()*
-                TODO: Documentation
-
-tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
-                Add the reverse lookup values to an existing table. For
-                example: `tbl_add_reverse_lookup { A = 1 } == { [1] = 'A', A =
-                1 }`
-
-                Parameters: ~
-                    {o}  table The table to add the reverse to.
-
-list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
-                Extends a list-like table with the values of another list-like
-                table.
-
-                NOTE: This mutates dst!
-
-                Parameters: ~
-                    {dst}     list which will be modified and appended to.
-                    {src}     list from which values will be inserted.
-                    {start}   Start index on src. defaults to 1
-                    {finish}  Final index on src. defaults to #src
-
-                Return: ~
-                    dst
-
-                See also: ~
-                    |vim.tbl_extend()|
-
-tbl_flatten({t})                                           *vim.tbl_flatten()*
-                Creates a copy of a list-like table such that any nested
-                tables are "unrolled" and appended to the result.
-
-                Parameters: ~
-                    {t}  List-like table
-
-                Return: ~
-                    Flattened copy of the given list-like table.
-
-                See also: ~
-                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
-
-tbl_islist({t})                                             *vim.tbl_islist()*
-                Table
-
-                Return: ~
-                    true: A non-empty array, false: A non-empty table, nil: An
-                    empty table
-
 trim({s})                                                         *vim.trim()*
                 Trim whitespace (Lua pattern "%s") from both sides of a
                 string.
@@ -1022,18 +1043,6 @@ trim({s})                                                         *vim.trim()*
 
                 See also: ~
                     https://www.lua.org/pil/20.2.html
-
-pesc({s})                                                         *vim.pesc()*
-                Escapes magic chars in a Lua pattern string.
-
-                Parameters: ~
-                    {s}  String to escape
-
-                Return: ~
-                    %-escaped pattern string
-
-                See also: ~
-                    https://github.com/rxi/lume
 
 validate({opt})                                               *vim.validate()*
                 Validates a parameter specification (types and values).
@@ -1084,14 +1093,5 @@ validate({opt})                                               *vim.validate()*
                                 valid
                               • msg: (optional) error string if validation
                                 fails
-
-is_callable({f})                                           *vim.is_callable()*
-                Returns true if object `f` can be called as a function.
-
-                Parameters: ~
-                    {f}  Any object
-
-                Return: ~
-                    true if `f` is callable, else false
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -145,7 +145,7 @@ def debug_this(cond, o):
         except Exception:
             pass
     if ((callable(cond) and cond())
-            or (not callable(cond) and cond == True)
+            or (not callable(cond) and cond)
             or (not callable(cond) and cond in o)):
         raise RuntimeError('xxx: {}\n{}'.format(name, o))
 
@@ -312,8 +312,8 @@ def update_params_map(parent, ret_map, width=62):
         desc = ''
         desc_node = get_child(node, 'parameterdescription')
         if desc_node:
-            desc = fmt_node_as_vimhelp(desc_node, width=width,
-                                  indent=(' ' * max_name_len))
+            desc = fmt_node_as_vimhelp(
+                    desc_node, width=width, indent=(' ' * max_name_len))
             ret_map[name] = desc
     return ret_map
 
@@ -321,8 +321,10 @@ def update_params_map(parent, ret_map, width=62):
 def render_node(n, text, prefix='', indent='', width=62):
     """Renders a node as Vim help text, recursively traversing all descendants."""
     global fmt_vimhelp
+
     def ind(s):
         return s if fmt_vimhelp else ''
+
     text = ''
     # space_preceding = (len(text) > 0 and ' ' == text[-1][-1])
     # text += (int(not space_preceding) * ' ')
@@ -666,6 +668,8 @@ def extract_from_xml(filename, mode, width):
 
         xrefs.clear()
 
+    fns = collections.OrderedDict(sorted(fns.items()))
+    deprecated_fns = collections.OrderedDict(sorted(deprecated_fns.items()))
     return (fns, deprecated_fns)
 
 
@@ -864,6 +868,7 @@ def main(config):
         with open(doc_file, 'ab') as fp:
             fp.write(docs.encode('utf8'))
 
+        fn_map_full = collections.OrderedDict(sorted(fn_map_full.items()))
         with open(mpack_file, 'wb') as fp:
             fp.write(msgpack.packb(fn_map_full, use_bin_type=True))
 

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Generates Nvim help docs from C/Lua docstrings, using Doxygen.
+"""Generates Nvim :help docs from C/Lua docstrings, using Doxygen.
 
 Also generates *.mpack files. To inspect the *.mpack structure:
 
-    :new | put=json_encode(msgpackparse(readfile('runtime/doc/api.mpack')))
+    :new | put=v:lua.vim.inspect(msgpackparse(readfile('runtime/doc/api.mpack')))
+
 
 Flow:
-    gen_docs
+    main
       extract_from_xml
-        fmt_node_as_vimhelp
-          fmt_params_map_as_vimhelp
-            render_node
-          para_as_map
-            render_node
+        fmt_node_as_vimhelp   \
+          para_as_map          } recursive
+            update_params_map /
+              render_node
 
 This would be easier using lxml and XSLT, but:
 
@@ -58,6 +58,7 @@ DEBUG = ('DEBUG' in os.environ)
 INCLUDE_C_DECL = ('INCLUDE_C_DECL' in os.environ)
 INCLUDE_DEPRECATED = ('INCLUDE_DEPRECATED' in os.environ)
 
+fmt_vimhelp = False  # HACK
 text_width = 78
 script_path = os.path.abspath(__file__)
 base_dir = os.path.dirname(os.path.dirname(script_path))
@@ -144,6 +145,7 @@ def debug_this(cond, o):
         except Exception:
             pass
     if ((callable(cond) and cond())
+            or (not callable(cond) and cond == True)
             or (not callable(cond) and cond in o)):
         raise RuntimeError('xxx: {}\n{}'.format(name, o))
 
@@ -156,18 +158,25 @@ def find_first(parent, name):
     return sub[0]
 
 
-def get_children(parent, name):
-    """Yield matching child nodes within parent."""
+def iter_children(parent, name):
+    """Yields matching child nodes within parent."""
     for child in parent.childNodes:
         if child.nodeType == child.ELEMENT_NODE and child.nodeName == name:
             yield child
 
 
 def get_child(parent, name):
-    """Get the first matching child node."""
-    for child in get_children(parent, name):
+    """Gets the first matching child node."""
+    for child in iter_children(parent, name):
         return child
     return None
+
+
+def self_or_child(n):
+    """Gets the first child node, or self."""
+    if len(n.childNodes) == 0:
+        return n
+    return n.childNodes[0]
 
 
 def clean_text(text):
@@ -190,18 +199,21 @@ def is_blank(text):
     return '' == clean_lines(text)
 
 
-def get_text(parent, preformatted=False):
-    """Combine all text in a node."""
-    if parent.nodeType == parent.TEXT_NODE:
-        return parent.data
-
-    out = ''
-    for node in parent.childNodes:
+def get_text(n, preformatted=False):
+    """Recursively concatenates all text in a node tree."""
+    text = ''
+    if n.nodeType == n.TEXT_NODE:
+        return n.data
+    if n.nodeName == 'computeroutput':
+        for node in n.childNodes:
+            text += get_text(node)
+        return '`{}` '.format(text)
+    for node in n.childNodes:
         if node.nodeType == node.TEXT_NODE:
-            out += node.data if preformatted else clean_text(node.data)
+            text += node.data if preformatted else clean_text(node.data)
         elif node.nodeType == node.ELEMENT_NODE:
-            out += ' ' + get_text(node, preformatted)
-    return out
+            text += ' ' + get_text(node, preformatted)
+    return text
 
 
 # Gets the length of the last line in `text`, excluding newline ("\n") char.
@@ -221,6 +233,8 @@ def len_lastline_withoutindent(text, indent):
 
 # Returns True if node `n` contains only inline (not block-level) elements.
 def is_inline(n):
+    # if len(n.childNodes) == 0:
+    #     return n.nodeType == n.TEXT_NODE or n.nodeName == 'computeroutput'
     for c in n.childNodes:
         if c.nodeType != c.TEXT_NODE and c.nodeName != 'computeroutput':
             return False
@@ -271,11 +285,17 @@ def doc_wrap(text, prefix='', width=70, func=False, indent=None):
     return result
 
 
+def max_name(names):
+    if len(names) == 0:
+        return 0
+    return max(len(name) for name in names)
+
+
 def update_params_map(parent, ret_map, width=62):
     """Updates `ret_map` with name:desc key-value pairs extracted
     from Doxygen XML node `parent`.
     """
-    params = []
+    params = collections.OrderedDict()
     for node in parent.childNodes:
         if node.nodeType == node.TEXT_NODE:
             continue
@@ -285,48 +305,34 @@ def update_params_map(parent, ret_map, width=62):
         name = get_text(name_node)
         if name in param_exclude:
             continue
-        params.append((name.strip(), node))
+        params[name.strip()] = node
+    max_name_len = max_name(params.keys()) + 8
     # `ret_map` is a name:desc map.
-    for name, node in params:
+    for name, node in params.items():
         desc = ''
         desc_node = get_child(node, 'parameterdescription')
         if desc_node:
-            desc = fmt_node_as_vimhelp(desc_node, width=width, indent=(" " * len(name)))
+            desc = fmt_node_as_vimhelp(desc_node, width=width,
+                                  indent=(' ' * max_name_len))
             ret_map[name] = desc
     return ret_map
 
 
-def fmt_params_map_as_vimhelp(m, width=62):
-    """Renders a params map as Vim :help text."""
-    max_name_len = 0
-    for name, desc in m.items():
-        max_name_len = max(max_name_len, len(name) + 4)
-    out = ''
-    for name, desc in m.items():
-        name = '    {}'.format('{{{}}}'.format(name).ljust(max_name_len))
-        out += '{}{}\n'.format(name, desc)
-    return out.rstrip()
-
-
 def render_node(n, text, prefix='', indent='', width=62):
     """Renders a node as Vim help text, recursively traversing all descendants."""
+    global fmt_vimhelp
+    def ind(s):
+        return s if fmt_vimhelp else ''
     text = ''
     # space_preceding = (len(text) > 0 and ' ' == text[-1][-1])
     # text += (int(not space_preceding) * ' ')
 
-    if n.nodeType == n.TEXT_NODE:
-        # `prefix` is NOT sent to doc_wrap, it was already handled by now.
-        text += doc_wrap(n.data, indent=indent, width=width)
-    elif n.nodeName == 'computeroutput':
-        text += ' `{}` '.format(get_text(n))
-    elif n.nodeName == 'preformatted':
+    if n.nodeName == 'preformatted':
         o = get_text(n, preformatted=True)
         ensure_nl = '' if o[-1] == '\n' else '\n'
-        text += ' >{}{}\n<'.format(ensure_nl, o)
+        text += '>{}{}\n<'.format(ensure_nl, o)
     elif is_inline(n):
-        for c in n.childNodes:
-            text += render_node(c, text)
-        text = doc_wrap(text, indent=indent, width=width)
+        text = doc_wrap(get_text(n), indent=indent, width=width)
     elif n.nodeName == 'verbatim':
         # TODO: currently we don't use this. The "[verbatim]" hint is there as
         # a reminder that we must decide how to format this if we do use it.
@@ -341,8 +347,6 @@ def render_node(n, text, prefix='', indent='', width=62):
     elif n.nodeName in ('para', 'heading'):
         for c in n.childNodes:
             text += render_node(c, text, indent=indent, width=width)
-        if is_inline(n):
-            text = doc_wrap(text, indent=indent, width=width)
     elif n.nodeName == 'itemizedlist':
         for c in n.childNodes:
             text += '{}\n'.format(render_node(c, text, prefix='• ',
@@ -368,7 +372,7 @@ def render_node(n, text, prefix='', indent='', width=62):
         text += '\n'
     elif (n.nodeName == 'simplesect'
             and n.getAttribute('kind') in ('return', 'see')):
-        text += '    '
+        text += ind('    ')
         for c in n.childNodes:
             text += render_node(c, text, indent='    ', width=width)
     else:
@@ -395,11 +399,6 @@ def para_as_map(parent, indent='', width=62):
         'xrefs': []
     }
 
-    if is_inline(parent):
-        chunks["text"] = clean_lines(
-            doc_wrap(render_node(parent, ""), indent=indent, width=width).strip()
-        )
-
     # Ordered dict of ordered lists.
     groups = collections.OrderedDict([
         ('params', []),
@@ -413,27 +412,39 @@ def para_as_map(parent, indent='', width=62):
     text = ''
     kind = ''
     last = ''
-    for child in parent.childNodes:
-        if child.nodeName == 'parameterlist':
-            groups['params'].append(child)
-        elif child.nodeName == 'xrefsect':
-            groups['xrefs'].append(child)
-        elif child.nodeName == 'simplesect':
-            last = kind
-            kind = child.getAttribute('kind')
-            if kind == 'return' or (kind == 'note' and last == 'return'):
-                groups['return'].append(child)
-            elif kind == 'see':
-                groups['seealso'].append(child)
-            elif kind in ('note', 'warning'):
-                text += render_node(child, text, indent=indent, width=width)
+    if is_inline(parent):
+        # Flatten inline text from a tree of non-block nodes.
+        text = doc_wrap(render_node(parent, ""), indent=indent, width=width)
+    else:
+        prev = None  # Previous node
+        for child in parent.childNodes:
+            if child.nodeName == 'parameterlist':
+                groups['params'].append(child)
+            elif child.nodeName == 'xrefsect':
+                groups['xrefs'].append(child)
+            elif child.nodeName == 'simplesect':
+                last = kind
+                kind = child.getAttribute('kind')
+                if kind == 'return' or (kind == 'note' and last == 'return'):
+                    groups['return'].append(child)
+                elif kind == 'see':
+                    groups['seealso'].append(child)
+                elif kind in ('note', 'warning'):
+                    text += render_node(child, text, indent=indent, width=width)
+                else:
+                    raise RuntimeError('unhandled simplesect: {}\n{}'.format(
+                        child.nodeName, child.toprettyxml(indent='  ', newl='\n')))
             else:
-                raise RuntimeError('unhandled simplesect: {}\n{}'.format(
-                    child.nodeName, child.toprettyxml(indent='  ', newl='\n')))
-        else:
-            text += render_node(child, text, indent=indent, width=width)
+                if (prev is not None
+                        and is_inline(self_or_child(prev))
+                        and is_inline(self_or_child(child))
+                        and '' != get_text(self_or_child(child)).strip()
+                        and ' ' != text[-1]):
+                    text += ' '
+                text += render_node(child, text, indent=indent, width=width)
+                prev = child
 
-    chunks['text'] = text
+    chunks['text'] += text
 
     # Generate map from the gathered items.
     if len(groups['params']) > 0:
@@ -441,7 +452,7 @@ def para_as_map(parent, indent='', width=62):
             update_params_map(child, ret_map=chunks['params'], width=width)
     for child in groups['return']:
         chunks['return'].append(render_node(
-            child, '', indent=indent, width=width).lstrip())
+            child, '', indent=indent, width=width))
     for child in groups['seealso']:
         chunks['seealso'].append(render_node(
             child, '', indent=indent, width=width))
@@ -463,20 +474,30 @@ def fmt_node_as_vimhelp(parent, width=62, indent=''):
     NB: Blank lines in a docstring manifest as <para> tags.
     """
     rendered_blocks = []
+
+    def fmt_param_doc(m):
+        """Renders a params map as Vim :help text."""
+        max_name_len = max_name(m.keys()) + 4
+        out = ''
+        for name, desc in m.items():
+            name = '    {}'.format('{{{}}}'.format(name).ljust(max_name_len))
+            out += '{}{}\n'.format(name, desc)
+        return out.rstrip()
+
+    def has_nonexcluded_params(m):
+        """Returns true if any of the given params has at least
+        one non-excluded item."""
+        if fmt_param_doc(m) != '':
+            return True
+
     for child in parent.childNodes:
         para = para_as_map(child, indent, width)
-
-        def has_nonexcluded_params(m):
-            """Returns true if any of the given params has at least
-            one non-excluded item."""
-            if fmt_params_map_as_vimhelp(m) != '':
-                return True
 
         # Generate text from the gathered items.
         chunks = [para['text']]
         if len(para['params']) > 0 and has_nonexcluded_params(para['params']):
             chunks.append('\nParameters: ~')
-            chunks.append(fmt_params_map_as_vimhelp(para['params'], width=width))
+            chunks.append(fmt_param_doc(para['params']))
         if len(para['return']) > 0:
             chunks.append('\nReturn: ~')
             for s in para['return']:
@@ -493,20 +514,21 @@ def fmt_node_as_vimhelp(parent, width=62, indent=''):
     return clean_lines('\n'.join(rendered_blocks).strip())
 
 
-def extract_from_xml(filename, mode, fmt_vimhelp):
+def extract_from_xml(filename, mode, width):
     """Extracts Doxygen info as maps without formatting the text.
 
     Returns two maps:
       1. Functions
       2. Deprecated functions
 
-    The `fmt_vimhelp` parameter controls some special cases for use by
+    The `fmt_vimhelp` global controls some special cases for use by
     fmt_doxygen_xml_as_vimhelp(). (TODO: ugly :)
     """
     global xrefs
+    global fmt_vimhelp
     xrefs.clear()
-    functions = {}  # Map of func_name:docstring.
-    deprecated_functions = {}  # Map of func_name:docstring.
+    fns = {}  # Map of func_name:docstring.
+    deprecated_fns = {}  # Map of func_name:docstring.
 
     dom = minidom.parse(filename)
     compoundname = get_text(dom.getElementsByTagName('compoundname')[0])
@@ -553,7 +575,7 @@ def extract_from_xml(filename, mode, fmt_vimhelp):
         params = []
         type_length = 0
 
-        for param in get_children(member, 'param'):
+        for param in iter_children(member, 'param'):
             param_type = get_text(get_child(param, 'type')).strip()
             param_name = ''
             declname = get_child(param, 'declname')
@@ -590,15 +612,15 @@ def extract_from_xml(filename, mode, fmt_vimhelp):
                                      '    ')
 
             # Minimum 8 chars between signature and vimtag
-            lhs = (text_width - 8) - len(prefix)
+            lhs = (width - 8) - len(prefix)
 
             if len(prefix) + len(suffix) > lhs:
-                signature = vimtag.rjust(text_width) + '\n'
-                signature += doc_wrap(suffix, width=text_width-8, prefix=prefix,
+                signature = vimtag.rjust(width) + '\n'
+                signature += doc_wrap(suffix, width=width-8, prefix=prefix,
                                       func=True)
             else:
                 signature = prefix + suffix
-                signature += vimtag.rjust(text_width - len(signature))
+                signature += vimtag.rjust(width - len(signature))
 
         paras = []
         desc = find_first(member, 'detaileddescription')
@@ -638,25 +660,27 @@ def extract_from_xml(filename, mode, fmt_vimhelp):
             fn['c_decl'] = c_decl
 
         if 'Deprecated' in str(xrefs):
-            deprecated_functions[name] = fn
+            deprecated_fns[name] = fn
         elif name.startswith(CONFIG[mode]['func_name_prefix']):
-            functions[name] = fn
+            fns[name] = fn
 
         xrefs.clear()
 
-    return (functions, deprecated_functions)
+    return (fns, deprecated_fns)
 
 
 def fmt_doxygen_xml_as_vimhelp(filename, mode):
-    """Formats functions from doxygen XML into Vim :help format.
+    """Entrypoint for generating Vim :help from from Doxygen XML.
 
-    Returns two strings:
-      1. Functions in Vim :help format
-      2. Deprecated functions (handled by caller, or ignored)
+    Returns 3 items:
+      1. Vim help text for functions found in `filename`.
+      2. Vim help text for deprecated functions.
     """
-    functions = {}  # Map of func_name:docstring.
-    deprecated_functions = {}  # Map of func_name:docstring.
-    fns, deprecated_fns = extract_from_xml(filename, mode, True)
+    global fmt_vimhelp
+    fmt_vimhelp = True
+    fns_txt = {}  # Map of func_name:vim-help-text.
+    deprecated_fns_txt = {}  # Map of func_name:vim-help-text.
+    fns, _ = extract_from_xml(filename, mode, width=text_width)
 
     for name, fn in fns.items():
         # Generate Vim :help for parameters.
@@ -685,15 +709,15 @@ def fmt_doxygen_xml_as_vimhelp(filename, mode):
         func_doc = re.sub(r'^\s+([<>])$', r'\1', func_doc, flags=re.M)
 
         if 'Deprecated' in xrefs:
-            deprecated_functions.append(func_doc)
+            deprecated_fns_txt[name] = func_doc
         elif name.startswith(CONFIG[mode]['func_name_prefix']):
-            functions[name] = func_doc
+            fns_txt[name] = func_doc
 
         xrefs.clear()
 
-    return ('\n\n'.join(list(functions.values())),
-            '\n\n'.join(deprecated_fns),
-            functions)
+    fmt_vimhelp = False
+    return ('\n\n'.join(list(fns_txt.values())),
+            '\n\n'.join(list(deprecated_fns_txt.values())))
 
 
 def delete_lines_below(filename, tokenstr):
@@ -710,14 +734,15 @@ def delete_lines_below(filename, tokenstr):
         fp.writelines(lines[0:i])
 
 
-def gen_docs(config):
-    """Generate formatted Vim :help docs and unformatted *.mpack files for use
-    by API clients.
+def main(config):
+    """Generates:
+
+    1. Vim :help docs
+    2. *.mpack files for use by API clients
 
     Doxygen is called and configured through stdin.
     """
     for mode in CONFIG:
-        functions = {}  # Map of func_name:docstring.
         mpack_file = os.path.join(
             base_dir, 'runtime', 'doc',
             CONFIG[mode]['filename'].replace('.txt', '.mpack'))
@@ -766,14 +791,13 @@ def gen_docs(config):
 
             filename = get_text(find_first(compound, 'name'))
             if filename.endswith('.c') or filename.endswith('.lua'):
+                # Extract unformatted (*.mpack).
                 fn_map, _ = extract_from_xml(os.path.join(base, '{}.xml'.format(
-                    compound.getAttribute('refid'))), mode, False)
-
-                functions_text, deprecated_text, fns = fmt_doxygen_xml_as_vimhelp(
+                    compound.getAttribute('refid'))), mode, width=9999)
+                # Extract formatted (:help).
+                functions_text, deprecated_text = fmt_doxygen_xml_as_vimhelp(
                     os.path.join(base, '{}.xml'.format(
                                  compound.getAttribute('refid'))), mode)
-                # Collect functions from all modules (for the current `mode`).
-                functions = {**functions, **fns}
 
                 if not functions_text and not deprecated_text:
                     continue
@@ -900,6 +924,6 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         filter_source(sys.argv[1])
     else:
-        gen_docs(Doxyfile)
+        main(Doxyfile)
 
 # vim: set ft=python ts=4 sw=4 tw=79 et :

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -637,7 +637,7 @@ def extract_from_xml(filename, mode, fmt_vimhelp):
         if INCLUDE_C_DECL:
             fn['c_decl'] = c_decl
 
-        if 'Deprecated' in xrefs:
+        if 'Deprecated' in str(xrefs):
             deprecated_functions[name] = fn
         elif name.startswith(CONFIG[mode]['func_name_prefix']):
             functions[name] = fn

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -457,6 +457,7 @@ Object nvim_eval(String expr, Error *err)
 }
 
 /// @deprecated Use nvim_exec_lua() instead.
+/// @see nvim_exec_lua
 Object nvim_execute_lua(String code, Array args, Error *err)
   FUNC_API_SINCE(3)
   FUNC_API_DEPRECATED_SINCE(7)


### PR DESCRIPTION
- fix `:help` formatting
- reduce `*.mpack` formatting
- sort functions by name (per-module in `:help`, and globally in `*.mpack`)


With this PR the regressions from https://github.com/neovim/neovim/pull/11396 are mostly fixed. Needs further improvements of course, especially handling of backticks (Doxygen `<computeroutput>` nodes).

Also simplified the logic/codeflow somewhat, but there's a lot more work to do there.