### PR TITLE
LSP: Handle rpc RequestCancelled specifically.

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -378,8 +378,7 @@ local function create_and_start_client(cmd, cmd_args, handlers, extra_spawn_para
       decoded.error = convert_NIL(decoded.error)
       decoded.result = convert_NIL(decoded.result)
 
-      -- For RequestCancelled, we want to ignore the handlers since this is an
-      -- RPC internal handling code and we shouldn't report this to users.
+      -- Do not surface RequestCancelled to users, it is RPC-internal.
       if decoded.error
         and decoded.error.code == protocol.ErrorCodes.RequestCancelled then
         local _ = log.debug() and log.debug("Received cancellation ack", decoded)

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -1,3 +1,4 @@
+local vim = vim
 local uv = vim.loop
 local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
@@ -376,6 +377,23 @@ local function create_and_start_client(cmd, cmd_args, handlers, extra_spawn_para
       -- Server Result
       decoded.error = convert_NIL(decoded.error)
       decoded.result = convert_NIL(decoded.result)
+
+      -- For RequestCancelled, we want to ignore the handlers since this is an
+      -- RPC internal handling code and we shouldn't report this to users.
+      if decoded.error
+        and decoded.error.code == protocol.ErrorCodes.RequestCancelled then
+        local _ = log.debug() and log.debug("Received cancellation ack", decoded)
+        local result_id = tonumber(decoded.id)
+        -- Clear any callback since this is cancelled now.
+        -- This is safe to do assuming that these conditions hold:
+        -- - The server will not send a result callback after this cancellation.
+        -- - If the server sent this cancellation ACK after sending the result, the user of this RPC
+        -- client will ignore the result themselves.
+        if result_id then
+          message_callbacks[result_id] = nil
+        end
+        return
+      end
 
       -- We sent a number, so we expect a number.
       local result_id = tonumber(decoded.id)


### PR DESCRIPTION
This was creating extra noise in errors that we should've been handling
internally.

Fixes #11515