### PR TITLE
[WIP] Fix segfault from null access on win_close.

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6382,6 +6382,10 @@ ex_win_close(
   int need_hide;
   buf_T       *buf = win->w_buffer;
 
+  if (!buf) {
+    win_close(win, false);
+    return;
+  }
   need_hide = (bufIsChanged(buf) && buf->b_nwindows <= 1);
   if (need_hide && !buf_hide(buf) && !forceit) {
     if ((p_confirm || cmdmod.confirm) && p_write) {


### PR DESCRIPTION
From trying to do some work on the LSP hover, I encountered a segfault and it was due to a null access.

This may not be the best fix, but it is a fix. It seems that `w_buffer` can be null if the buffer is deleted (in this case it was a `bufhidden=wipe`) before the window is closed.

[backtrace](https://gist.github.com/90f12fe3f19754d07fe06c4222273e15)

There's probably some other locations that may benefit from being checked for a similar condition.