### PR TITLE
LSP: Enforce only one popup at a time.

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -181,28 +181,29 @@ M['textDocument/signatureHelp'] = function(_, method, result)
   end)
 end
 
--- M['textDocument/peekDefinition'] = function(_, method, result, _)
---   if not (result and result[1]) then return end
---   util.popup(method, function()
---     local loc = result[1]
---     local bufnr = vim.uri_to_bufnr(loc.uri) or error("not found: "..tostring(loc.uri))
---     local start = loc.range.start
---     local finish = loc.range["end"]
---     local winnr = util.open_floating_peek_preview(bufnr, start, finish)
---     local headbuf, headwin = util.open_floating_preview({"Peek:"}, nil, {
---       offset_y = -(finish.line - start.line + 1);
---       width = finish.character - start.character + 2;
---     })
---     api.nvim_buf_attach(headbuf, false, {
---       on_detach = function()
---         api.nvim_win_close(winnr, true)
---       end
---     })
---     -- TODO(ashkan) change highlight group?
---     api.nvim_buf_add_highlight(headbuf, -1, 'Keyword', 0, 0, -1)
---     return headbuf, headwin
---   end)
--- end
+M['textDocument/peekDefinition'] = function(_, method, result, _)
+  if not (result and result[1]) then return end
+  util.popup(method, function()
+    local loc = result[1]
+    local bufnr = vim.uri_to_bufnr(loc.uri) or error("not found: "..tostring(loc.uri))
+    local start = loc.range.start
+    local finish = loc.range["end"]
+    local winnr, width, height = util.open_floating_peek_preview(bufnr, start, finish)
+    local headbuf, headwin = util.open_floating_preview({"Peek:"}, nil, {
+      -- offset_y = -height;
+      width = math.max(width, 5),
+      height = height+1;
+    })
+    api.nvim_buf_attach(headbuf, false, {
+      on_detach = function()
+        api.nvim_win_close(winnr, true)
+      end
+    })
+    -- TODO(ashkan) change highlight group?
+    api.nvim_buf_add_highlight(headbuf, -1, 'Keyword', 0, 0, -1)
+    return headbuf, headwin
+  end)
+end
 
 local function log_message(_, _, result, client_id)
   local message_type = result.type

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -69,6 +69,7 @@ M['textDocument/completion'] = function(_, _, result)
 end
 
 M['textDocument/hover'] = function(_, method, result)
+  util.close_popups()
   util.focusable_float(method, function()
     if not (result and result.contents) then
       -- return { 'No information available' }
@@ -83,7 +84,7 @@ M['textDocument/hover'] = function(_, method, result)
     local bufnr, winnr = util.fancy_floating_markdown(markdown_lines, {
       pad_left = 1; pad_right = 1;
     })
-    util.close_preview_autocmd({"CursorMoved", "BufHidden", "InsertCharPre"}, winnr)
+    util.close_preview_autocmd({"CursorMovedI", "CursorMoved", "BufHidden", "InsertCharPre"}, winnr)
     return bufnr, winnr
   end)
 end
@@ -166,6 +167,7 @@ local function signature_help_to_preview_contents(input)
 end
 
 M['textDocument/signatureHelp'] = function(_, method, result)
+  util.close_popups()
   util.focusable_preview(method, function()
     if not (result and result.signatures and result.signatures[1]) then
       return { 'No signature available' }

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -326,7 +326,7 @@ function M.close_popups()
   end
 end
 
--- Close all popups which belong to us.
+-- Close a popup by its name.
 function M.close_popup_by_name(name)
   for _, v in popup_manager.iter() do
     if v.name == name then
@@ -639,7 +639,6 @@ do
 
   function M.buf_clear_diagnostics(bufnr)
     validate { bufnr = {bufnr, 'n', true} }
-    -- bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
     api.nvim_buf_clear_namespace(bufnr or 0, diagnostic_ns, 0, -1)
   end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -13,14 +13,6 @@ local function split_lines(value)
   return split(value, '\n', true)
 end
 
-local function ok_or_nil(status, ...)
-  if not status then return end
-  return ...
-end
-local function npcall(fn, ...)
-  return ok_or_nil(pcall(fn, ...))
-end
-
 function M.set_lines(lines, A, B, new_lines)
   -- 0-indexing to 1-indexing
   local i_0 = A[1] + 1
@@ -311,6 +303,7 @@ end
 local popup_manager = buffer_manager{
   buf_init = function(bufnr, value)
     local bo = vim.bo[bufnr]
+    -- luacheck: ignore
     bo.bufhidden = 'wipe'
     return value
   end;

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -576,6 +576,7 @@ function M.open_floating_peek_preview(bufnr, start, finish, opts)
     width = math.max(len, width)
   end
   local floating_winnr = api.nvim_open_win(bufnr, false, M.make_floating_popup_options(width, height, opts))
+  -- luacheck: ignore
   vim.wo[floating_winnr].wrap = false
   local col = start.character
   if col > 0 then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -314,6 +314,19 @@ local function find_window_by_var(name, value)
   end
 end
 
+-- Close all popups which belong to us.
+function M.close_popups()
+  -- Our popups are identified by windows which have a w: variable which uses
+  -- the callback method as the variable name.
+  for _, win in ipairs(api.nvim_list_wins()) do
+    for k in pairs(vim.lsp.callbacks) do
+      if npcall(api.nvim_win_get_var, win, k) then
+        api.nvim_win_close(win, true)
+      end
+    end
+  end
+end
+
 -- Check if a window with `unique_name` tagged is associated with the current
 -- buffer. If not, make a new preview.
 --
@@ -493,8 +506,8 @@ function M.open_floating_preview(contents, filetype, opts)
   end
   api.nvim_buf_set_lines(floating_bufnr, 0, -1, true, contents)
   api.nvim_buf_set_option(floating_bufnr, 'modifiable', false)
-  -- TODO make InsertCharPre disappearing optional?
-  api.nvim_command("autocmd CursorMoved,BufHidden,InsertCharPre <buffer> ++once lua pcall(vim.api.nvim_win_close, "..floating_winnr..", true)")
+
+  M.close_preview_autocmd({"CursorMoved","CursorMovedI","BufHidden","InsertCharPre"}, floating_winnr)
   return floating_bufnr, floating_winnr
 end
 

--- a/runtime/lua/vim/util/buffer_manager.lua
+++ b/runtime/lua/vim/util/buffer_manager.lua
@@ -34,6 +34,7 @@ local function buffer_manager(config)
     local buffer_lookup = lookup[bufnr]
     if not buffer_lookup then
       -- TODO(ashkan): pcall?
+      -- TODO(ashkan): use `true` as a default or throw error?
       buffer_lookup = config.buf_init(bufnr, ...) or error("Failed to setup buffer "..bufnr)
       lookup[bufnr] = buffer_lookup
       api.nvim_buf_attach(bufnr, false, {

--- a/runtime/lua/vim/util/buffer_manager.lua
+++ b/runtime/lua/vim/util/buffer_manager.lua
@@ -19,7 +19,7 @@ local function buffer_manager(config)
   }
   local lookup = {}
   local function on_detach(_, bufnr)
-    if config.on_detach then
+    if lookup[bufnr] then
       pcall(config.on_detach, bufnr, lookup[bufnr])
     end
     lookup[bufnr] = nil
@@ -27,10 +27,15 @@ local function buffer_manager(config)
 
   local R = {}
 
-  function R.attach(bufnr, ...)
+  local function resolve_bufnr(bufnr)
     if bufnr == 0 or bufnr == nil then
-      bufnr = api.nvim_get_current_buf()
+      return api.nvim_get_current_buf()
     end
+    return bufnr
+  end
+
+  function R.attach(bufnr, ...)
+    bufnr = resolve_bufnr(bufnr)
     local buffer_lookup = lookup[bufnr]
     if not buffer_lookup then
       -- TODO(ashkan): pcall?
@@ -54,7 +59,12 @@ local function buffer_manager(config)
   end
 
   function R.get(bufnr)
-    return lookup[bufnr]
+    return lookup[resolve_bufnr(bufnr)]
+  end
+
+  function R.set(bufnr, value)
+    assert(value ~= nil)
+    lookup[resolve_bufnr(bufnr)] = value
   end
 
   return R

--- a/runtime/lua/vim/util/buffer_manager.lua
+++ b/runtime/lua/vim/util/buffer_manager.lua
@@ -1,0 +1,62 @@
+local vim = vim
+local api = vim.api
+
+-- config = {
+--   buf_init(bufnr, ...) -> lookup_value: any
+--   on_detach(bufnr, lookup_value)
+--   on_lines
+--   on_changedtick
+--   utf_sizes
+-- }
+-- Returns: { attach(bufnr, ...), iter(), get(bufnr) }
+--
+-- Any arguments passed after bufnr to attach() are forwarded to buf_init()
+-- on_lines, on_changedtick, utf_sizes are forwarded to nvim_buf_attach
+local function buffer_manager(config)
+  vim.validate{
+    on_detach = {config.on_detach, 'f', true};
+    buf_init = {config.buf_init, 'f'};
+  }
+  local lookup = {}
+  local function on_detach(_, bufnr)
+    if config.on_detach then
+      pcall(config.on_detach, bufnr, lookup[bufnr])
+    end
+    lookup[bufnr] = nil
+  end
+
+  local R = {}
+
+  function R.attach(bufnr, ...)
+    if bufnr == 0 or bufnr == nil then
+      bufnr = api.nvim_get_current_buf()
+    end
+    local buffer_lookup = lookup[bufnr]
+    if not buffer_lookup then
+      -- TODO(ashkan): pcall?
+      buffer_lookup = config.buf_init(bufnr, ...) or error("Failed to setup buffer "..bufnr)
+      lookup[bufnr] = buffer_lookup
+      api.nvim_buf_attach(bufnr, false, {
+        on_detach = on_detach;
+
+        -- Forward any extra attachments from the config.
+        on_lines       = config.on_lines;
+        on_changedtick = config.on_changedtick;
+        utf_sizes      = config.utf_sizes;
+      })
+    end
+    return buffer_lookup, bufnr
+  end
+
+  function R.iter()
+    return pairs(lookup)
+  end
+
+  function R.get(bufnr)
+    return lookup[bufnr]
+  end
+
+  return R
+end
+
+return buffer_manager


### PR DESCRIPTION
At first I was fixing the hover popups ( #11395 #11508 ):
- Close other popups on creation.
- Close popup on CursorMovedI.

Then I decided I might as well try this new method which I believe can be shared
- Add buffer_manager and use it for popups.
- Use buffer_manager for diagnostics.

Also I'm hiding the peekDefinition stuff since it's not quite ready for prime time. I'm thinking of changing it to read the file from disk if the buffer isn't available. It also seems like it's not possible with either the api.txt or eval.txt methods to specify the viewport of a floating buffer. Specifically, I want to be able to specify the rectange of how to view a buffer based on its cursor positions.

Also, where should we be putting stuff `buffer_manager` for the future? I have it under `vim.util` right now, but that's obviously a bit generic. I think @bfredl mentioned something from treesitter that could also benefit from it and I know I use that pattern a lot in colorizer/lsp. If you guys like it, I'll do more replacements with it.

Here's some thoughts I had from the gitter:
```
Trying to figure out where to put it. We still haven't added too much stuff to the stdlib. I'm tempted to start a `vim.util` but I don't know if that's too generic
Future things we're going to add are things like path, but that's easy since `vim.path` makes sense
or would it be `vim.util.path`
Then there's luafun related stuff, so would that be `vim.util.iter`?
Also future data structures like a Trie
`vim.util.trie` or `vim.trie`
```