### PR TITLE
[WIP] Add vim.create_command for defining commands that callback Lua directly

### DIFF
--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -62,6 +62,7 @@
                                  * curbuf_lock is set */
 #define MODIFY       0x200000   /* forbidden in non-'modifiable' buffer */
 #define EXFLAGS      0x400000   /* allow flags after count in argument */
+#define EX_LUA_CB    0x800000   /* the command is defined by a lua callback */
 #define FILES   (XFILE | EXTRA) /* multiple extra files allowed */
 #define WORD1   (EXTRA | NOSPC) /* one extra word allowed */
 #define FILE1   (FILES | NOSPC) /* 1 file allowed, defaults to current file */

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5463,7 +5463,8 @@ void define_lua_command(const char *name,
   /* else if (*val == '+') */
   /*   *argt |= (EXTRA | NEEDARG); */
   // TODO(ashkan): flags?
-  uc_add_command((char_u*)name, name_len, (char_u*)"", EX_LUA_CB|BANG|EXTRA, -1, 0, EXPAND_NOTHING, (char_u*)"",
+  uc_add_command((char_u *)name, name_len, (char_u *)"",
+                 EX_LUA_CB | BANG | EXTRA, -1, 0, EXPAND_NOTHING, (char_u *)"",
                  ADDR_LINES, force, callback);
 }
 
@@ -5928,8 +5929,8 @@ static void do_ucmd(exarg_T *eap)
     if (eap->forceit == 1) {
       lua_pushliteral(L, "bang");
       lua_pushboolean(L, eap->forceit == 1);
+      lua_rawset(L, -3);
     }
-    lua_rawset(L, -3);
     lua_pcall(L, 2, 0, 0);
     return;
   }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1031,18 +1031,18 @@ static void nlua_add_treesitter(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_setfield(lstate, -2, "_ts_parse_query");
 }
 
-static int nlua_create_ex_command(lua_State* L) FUNC_API_SINCE(8)
+static int nlua_create_ex_command(lua_State *L) FUNC_API_SINCE(8)
 {
   luaL_checktype(L, 2, LUA_TFUNCTION);
-  // luaL_checktype(L, 2, LUA_TBOOLEAN);
+  if (!(lua_isnone(L, 3) || lua_isnil(L, 3))) {
+    luaL_checktype(L, 3, LUA_TBOOLEAN);
+  }
   size_t name_len;
-  const char* name = luaL_checklstring(L, 1, &name_len);
-  // bool force = lua_toboolean(L, 2);
-  bool force = true;
+  const char *name = luaL_checklstring(L, 1, &name_len);
   LuaRef callback = nlua_ref(L, 2);
-  const char* name_copy = xmalloc(name_len);
-  memcpy((void*)name_copy, name, name_len);
+  bool force = lua_toboolean(L, 3);
+  const char *name_copy = xmalloc(name_len);
+  memcpy((void *)name_copy, name, name_len);
   define_lua_command(name_copy, name_len, force, callback);
   return 0;
 }
-


### PR DESCRIPTION
Functioning example of `vim.create_command(name, callback, force, options)` which allows you to define an ex command which is backed by a Lua callback.

`callback(arg: string, options: table)` is the current signature, where `arg` is the argument passed to the command directly without any kind of tokenization or further parsing. The options are things like whether `bang` was specified or a range or whatnot.

`options` in the original will be things like `bang` or `range`, etc.

The only things to bikeshed are the exact design and I have to read more on the existing ucmd interface and all of the options available, because it's quite thick.

I think that passing the `eap->arg` as-is to the callback isn't a bad idea as compared to supporting options like `<f-args>` or `<q-args>` because the expectation should be that achieving those things from Lua should be doable and ergonomic. We already have `vim.split` and `vim.gsplit` which makes it possible to tokenize the argument as you please.

TODO:
- [ ] Validate the command name as being user only
- [ ] Add support for buffer local commands
- [ ] Finish definitions of all other options.
- [ ] Add tests
- [ ] Add printing representation for the commands which display commands.