### PR TITLE
doc: update 'cpoptions' default value

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1486,7 +1486,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See 'preserveindent'.
 
 						*'cpoptions'* *'cpo'* *cpo*
-'cpoptions' 'cpo'	string	(Vim default: "aABceFs",
+'cpoptions' 'cpo'	string	(Vim default: "aABceFs_",
 				 Vi default: all flags)
 			global
 	A sequence of single character flags.  When a character is present


### PR DESCRIPTION
Since version 0.2, the `_` compatibility option is turned on by default.

Cf. https://github.com/neovim/neovim/blob/b0196586debd55b9b8be62966084eee12bf0e4ad/src/nvim/option_defs.h#L135