### PR TITLE
LSP: implement documentHighlight

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -77,21 +77,6 @@ FAQ                                                     *lsp-faq*
   "after/ftplugin/python.vim".
 
 ================================================================================
-LSP HIGHLIGHT                                           *lsp-highlight*
-
-When LSP is activated these highlight groups are defined:
-
-  LspDiagnosticsError
-  LspDiagnosticsHint
-  LspDiagnosticsInformation
-  LspDiagnosticsUnderline
-  LspDiagnosticsUnderlineError
-  LspDiagnosticsUnderlineHint
-  LspDiagnosticsUnderlineInformation
-  LspDiagnosticsUnderlineWarning
-  LspDiagnosticsWarning
-
-================================================================================
 LSP API                                                 *lsp-api*
 
 The `vim.lsp` Lua module is a framework for building LSP plugins.
@@ -184,8 +169,6 @@ LspDiagnosticsWarning     used for "Warning" diagnostic virtual text
 LspDiagnosticInformation  used for "Information" diagnostic virtual text
                                                          *hl-LspDiagnosticsHint*
 LspDiagnosticHint         used for "Hint" diagnostic virtual text
-                                                    *hl-LspDiagnosticsUnderline*
-LspDiagnosticsUnderline   used for text with diagnostic information
                                                            *hl-LspReferenceText*
 LspReferenceText          used for highlighting "text" references
                                                            *hl-LspReferenceRead*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -174,7 +174,7 @@ name: >
   vim.lsp.protocol.TextDocumentSyncKind[1] == "Full"
 
 ================================================================================
-LSP Highlight groups                                      *lsp-highlight-groups*
+LSP HIGHLIGHT GROUPS                                      *lsp-highlight-groups*
 
                                                         *hl-LspDiagnosticsError*
 LspDiagnosticsError       used for 'Error' diagnostic virtual text

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -179,19 +179,19 @@ LSP HIGHLIGHT GROUPS                                      *lsp-highlight-groups*
                                                         *hl-LspDiagnosticsError*
 LspDiagnosticsError       used for "Error" diagnostic virtual text
                                                       *hl-LspDiagnosticsWarning*
-LspDiagnosticsWarning     used for 'Warning' diagnostic virtual text
+LspDiagnosticsWarning     used for "Warning" diagnostic virtual text
                                                   *hl-LspDiagnosticsInformation*
-LspDiagnosticInformation  used for 'Information' diagnostic virtual text
+LspDiagnosticInformation  used for "Information" diagnostic virtual text
                                                          *hl-LspDiagnosticsHint*
-LspDiagnosticHint         used for 'Hint' diagnostic virtual text
+LspDiagnosticHint         used for "Hint" diagnostic virtual text
                                                     *hl-LspDiagnosticsUnderline*
 LspDiagnosticsUnderline   used for text with diagnostic information
                                                            *hl-LspReferenceText*
-LspReferenceText          used for highlighting 'text' references
+LspReferenceText          used for highlighting "text" references
                                                            *hl-LspReferenceRead*
-LspReferenceRead          used for highlighting 'read' references
+LspReferenceRead          used for highlighting "read" references
                                                           *hl-LspReferenceWrite*
-LspReferenceWrite         used for highlighting 'write' references
+LspReferenceWrite         used for highlighting "write" references
 
 
 ================================================================================
@@ -742,15 +742,7 @@ definition()                                        *vim.lsp.buf.definition()*
                 TODO: Documentation
 
 document_highlight()                        *vim.lsp.buf.document_highlight()*
-                Send request to server to resolve document highlights for the 
-                current text document position. This request can be associated
-                to key mapping or to events such as `CursorHold`, eg:
->
-vim.api.nvim_command [[autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()]]
-vim.api.nvim_command [[autocmd CursorHoldI <buffer> lua vim.lsp.buf.document_highlight()]]
-vim.api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.util.buf_clear_references()]]
-<
-
+                TODO: Documentation
 
 formatting({options})                               *vim.lsp.buf.formatting()*
                 TODO: Documentation

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -741,6 +741,17 @@ declaration()                                      *vim.lsp.buf.declaration()*
 definition()                                        *vim.lsp.buf.definition()*
                 TODO: Documentation
 
+document_highlight()                        *vim.lsp.buf.document_highlight()*
+                Send request to server to resolve document highlights for the 
+                current text document position. This request can be associated
+                to key mapping or to events such as `CursorHold`, eg:
+>
+vim.api.nvim_command [[autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()]]
+vim.api.nvim_command [[autocmd CursorHoldI <buffer> lua vim.lsp.buf.document_highlight()]]
+vim.api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.util.buf_clear_references()]]
+<
+
+
 formatting({options})                               *vim.lsp.buf.formatting()*
                 TODO: Documentation
 
@@ -916,6 +927,9 @@ apply_workspace_edit({workspace_edit})
                 TODO: Documentation
 
 buf_clear_diagnostics({bufnr})          *vim.lsp.util.buf_clear_diagnostics()*
+                TODO: Documentation
+
+buf_clear_references({bufnr})            *vim.lsp.util.buf_clear_references()*
                 TODO: Documentation
 
                                *vim.lsp.util.buf_diagnostics_save_positions()*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -174,6 +174,27 @@ name: >
   vim.lsp.protocol.TextDocumentSyncKind[1] == "Full"
 
 ================================================================================
+LSP Highlight groups                                      *lsp-highlight-groups*
+
+                                                        *hl-LspDiagnosticsError*
+LspDiagnosticsError       used for 'Error' diagnostic virtual text
+                                                      *hl-LspDiagnosticsWarning*
+LspDiagnosticsWarning     used for 'Warning' diagnostic virtual text
+                                                  *hl-LspDiagnosticsInformation*
+LspDiagnosticInformation  used for 'Information' diagnostic virtual text
+                                                         *hl-LspDiagnosticsHint*
+LspDiagnosticHint         used for 'Hint' diagnostic virtual text
+                                                    *hl-LspDiagnosticsUnderline*
+LspDiagnosticsUnderline   used for text with diagnostic information
+                                                           *hl-LspReferenceText*
+LspReferenceText          used for highlighting 'text' references
+                                                           *hl-LspReferenceRead*
+LspReferenceRead          used for highlighting 'read' references
+                                                          *hl-LspReferenceWrite*
+LspReferenceWrite         used for highlighting 'write' references
+
+
+================================================================================
 LSP EXAMPLE                                            *lsp-extension-example*
 
 This example is for plugin authors or users who want a lot of control. If you

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -177,7 +177,7 @@ name: >
 LSP HIGHLIGHT GROUPS                                      *lsp-highlight-groups*
 
                                                         *hl-LspDiagnosticsError*
-LspDiagnosticsError       used for 'Error' diagnostic virtual text
+LspDiagnosticsError       used for "Error" diagnostic virtual text
                                                       *hl-LspDiagnosticsWarning*
 LspDiagnosticsWarning     used for 'Warning' diagnostic virtual text
                                                   *hl-LspDiagnosticsInformation*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -159,7 +159,7 @@ name: >
   vim.lsp.protocol.TextDocumentSyncKind[1] == "Full"
 
 ================================================================================
-LSP HIGHLIGHT GROUPS                                      *lsp-highlight-groups*
+LSP HIGHLIGHT                                                    *lsp-highlight*
 
                                                         *hl-LspDiagnosticsError*
 LspDiagnosticsError       used for "Error" diagnostic virtual text

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -134,5 +134,10 @@ function M.references(context)
   request('textDocument/references', params)
 end
 
+function M.document_highlight(context)
+  local params = util.make_position_params()
+  request('textDocument/documentHighlight', params)
+end
+
 return M
 -- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -134,9 +134,22 @@ function M.references(context)
   request('textDocument/references', params)
 end
 
-function M.document_highlight(context)
+--- Send request to server to resolve document highlights for the 
+--- current text document position. This request can be associated
+--- to key mapping or to events such as `CursorHold`, eg:
+---
+--- <pre>
+--- vim.api.nvim_command [[autocmd CursorHold  <buffer> lua vim.lsp.buf.document_highlight()]]
+--- vim.api.nvim_command [[autocmd CursorHoldI <buffer> lua vim.lsp.buf.document_highlight()]]
+--- vim.api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()]]
+--- </pre>
+function M.document_highlight()
   local params = util.make_position_params()
   request('textDocument/documentHighlight', params)
+end
+
+function M.clear_references()
+  util.buf_clear_references()
 end
 
 return M

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -134,7 +134,7 @@ function M.references(context)
   request('textDocument/references', params)
 end
 
---- Send request to server to resolve document highlights for the 
+--- Send request to server to resolve document highlights for the
 --- current text document position. This request can be associated
 --- to key mapping or to events such as `CursorHold`, eg:
 ---

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -199,17 +199,7 @@ end
 M['textDocument/documentHighlight'] = function(_, _, result, _)
   if not result then return end
   local bufnr = api.nvim_get_current_buf()
-  for _, reference in ipairs(result) do
-    local start_pos = {reference["range"]["start"]["line"], reference["range"]["start"]["character"]}
-    local end_pos = {reference["range"]["end"]["line"], reference["range"]["end"]["character"]}
-    if reference["kind"] == protocol.DocumentHighlightKind.Text then
-      util.highlight_range(bufnr, util.reference_ns, "LspReferenceText", start_pos, end_pos)
-    elseif reference["kind"] == protocol.DocumentHighlightKind.Read then
-      util.highlight_range(bufnr, util.reference_ns, "LspReferenceRead", start_pos, end_pos)
-    elseif reference["kind"] == protocol.DocumentHighlightKind.Write then
-      util.highlight_range(bufnr, util.reference_ns, "LspReferenceWrite", start_pos, end_pos)
-    end
-  end
+  util.buf_highlight_references(bufnr, result)
 end
 
 local function log_message(_, _, result, client_id)

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -196,6 +196,25 @@ M['textDocument/peekDefinition'] = function(_, _, result, _)
   api.nvim_buf_add_highlight(headbuf, -1, 'Keyword', 0, -1)
 end
 
+M['textDocument/documentHighlight'] = function(_, _, result, _)
+  if not result then return end
+  local bufnr = api.nvim_get_current_buf()
+  for _, reference in ipairs(result) do
+    local start_pos = {reference["range"]["start"]["line"], reference["range"]["start"]["character"]}
+    local end_pos = {reference["range"]["end"]["line"], reference["range"]["end"]["character"]}
+    if reference["kind"] == 1 then
+      -- text
+      util.highlight_range(bufnr, util.reference_ns, "LspReferenceText", start_pos, end_pos)
+    elseif reference["kind"] == 2 then
+      -- read
+      util.highlight_range(bufnr, util.reference_ns, "LspReferenceRead", start_pos, end_pos)
+    elseif reference["kind"] == 3 then
+      -- write 
+      util.highlight_range(bufnr, util.reference_ns, "LspReferenceWrite", start_pos, end_pos)
+    end
+  end
+end
+
 local function log_message(_, _, result, client_id)
   local message_type = result.type
   local message = result.message

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -202,14 +202,11 @@ M['textDocument/documentHighlight'] = function(_, _, result, _)
   for _, reference in ipairs(result) do
     local start_pos = {reference["range"]["start"]["line"], reference["range"]["start"]["character"]}
     local end_pos = {reference["range"]["end"]["line"], reference["range"]["end"]["character"]}
-    if reference["kind"] == 1 then
-      -- text
+    if reference["kind"] == protocol.DocumentHighlightKind.Text then
       util.highlight_range(bufnr, util.reference_ns, "LspReferenceText", start_pos, end_pos)
-    elseif reference["kind"] == 2 then
-      -- read
+    elseif reference["kind"] == protocol.DocumentHighlightKind.Read then
       util.highlight_range(bufnr, util.reference_ns, "LspReferenceRead", start_pos, end_pos)
-    elseif reference["kind"] == 3 then
-      -- write 
+    elseif reference["kind"] == protocol.DocumentHighlightKind.Write then
       util.highlight_range(bufnr, util.reference_ns, "LspReferenceWrite", start_pos, end_pos)
     end
   end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -569,7 +569,7 @@ do
   local all_buffer_diagnostics = {}
 
   local diagnostic_ns = api.nvim_create_namespace("vim_lsp_diagnostics")
-  M.reference_ns = api.nvim_create_namespace("vim_lsp_references")
+  local reference_ns = api.nvim_create_namespace("vim_lsp_references")
 
   local underline_highlight_name = "LspDiagnosticsUnderline"
   vim.cmd(string.format("highlight default %s gui=underline cterm=underline", underline_highlight_name))
@@ -603,14 +603,7 @@ do
 
   function M.buf_clear_diagnostics(bufnr)
     validate { bufnr = {bufnr, 'n', true} }
-    bufnr = api.nvim_get_current_buf() or bufnr
     api.nvim_buf_clear_namespace(bufnr, diagnostic_ns, 0, -1)
-  end
-
-  function M.buf_clear_references(bufnr)
-    validate { bufnr = {bufnr, 'n', true} }
-    bufnr = api.nvim_get_current_buf() or bufnr
-    api.nvim_buf_clear_namespace(bufnr, M.reference_ns, 0, -1)
   end
 
   function M.get_severity_highlight_name(severity)
@@ -690,7 +683,6 @@ do
     end
   end
 
-
   function M.buf_diagnostics_underline(bufnr, diagnostics)
     for _, diagnostic in ipairs(diagnostics) do
       local start = diagnostic.range["start"]
@@ -709,6 +701,26 @@ do
         {start.line, start.character},
         {finish.line, finish.character}
       )
+    end
+  end
+
+  function M.buf_clear_references(bufnr)
+    validate { bufnr = {bufnr, 'n', true} }
+    api.nvim_buf_clear_namespace(bufnr, reference_ns, 0, -1)
+  end
+
+  function M.buf_highlight_references(bufnr, references)
+    validate { bufnr = {bufnr, 'n', true} }
+    for _, reference in ipairs(references) do
+      local start_pos = {reference["range"]["start"]["line"], reference["range"]["start"]["character"]}
+      local end_pos = {reference["range"]["end"]["line"], reference["range"]["end"]["character"]}
+      if reference["kind"] == protocol.DocumentHighlightKind.Text then
+        highlight_range(bufnr, reference_ns, "LspReferenceText", start_pos, end_pos)
+      elseif reference["kind"] == protocol.DocumentHighlightKind.Read then
+        highlight_range(bufnr, reference_ns, "LspReferenceRead", start_pos, end_pos)
+      elseif reference["kind"] == protocol.DocumentHighlightKind.Write then
+        highlight_range(bufnr, reference_ns, "LspReferenceWrite", start_pos, end_pos)
+      end
     end
   end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -552,7 +552,7 @@ function M.open_floating_peek_preview(bufnr, start, finish, opts)
 end
 
 
-function M.highlight_range(bufnr, ns, hiname, start, finish)
+function highlight_range(bufnr, ns, hiname, start, finish)
   if start[1] == finish[1] then
     -- TODO care about encoding here since this is in byte index?
     api.nvim_buf_add_highlight(bufnr, ns, hiname, start[1], start[2], finish[2])

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -552,7 +552,7 @@ function M.open_floating_peek_preview(bufnr, start, finish, opts)
 end
 
 
-local function highlight_range(bufnr, ns, hiname, start, finish)
+function M.highlight_range(bufnr, ns, hiname, start, finish)
   if start[1] == finish[1] then
     -- TODO care about encoding here since this is in byte index?
     api.nvim_buf_add_highlight(bufnr, ns, hiname, start[1], start[2], finish[2])
@@ -569,6 +569,7 @@ do
   local all_buffer_diagnostics = {}
 
   local diagnostic_ns = api.nvim_create_namespace("vim_lsp_diagnostics")
+  M.reference_ns = api.nvim_create_namespace("vim_lsp_references")
 
   local underline_highlight_name = "LspDiagnosticsUnderline"
   vim.cmd(string.format("highlight default %s gui=underline cterm=underline", underline_highlight_name))
@@ -604,6 +605,12 @@ do
     validate { bufnr = {bufnr, 'n', true} }
     bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
     api.nvim_buf_clear_namespace(bufnr, diagnostic_ns, 0, -1)
+  end
+
+  function M.buf_clear_references(bufnr)
+    validate { bufnr = {bufnr, 'n', true} }
+    bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
+    api.nvim_buf_clear_namespace(bufnr, M.reference_ns, 0, -1)
   end
 
   function M.get_severity_highlight_name(severity)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -552,7 +552,7 @@ function M.open_floating_peek_preview(bufnr, start, finish, opts)
 end
 
 
-function highlight_range(bufnr, ns, hiname, start, finish)
+local function highlight_range(bufnr, ns, hiname, start, finish)
   if start[1] == finish[1] then
     -- TODO care about encoding here since this is in byte index?
     api.nvim_buf_add_highlight(bufnr, ns, hiname, start[1], start[2], finish[2])

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -606,12 +606,6 @@ do
     api.nvim_buf_clear_namespace(bufnr, diagnostic_ns, 0, -1)
   end
 
-  function M.buf_clear_references(bufnr)
-    validate { bufnr = {bufnr, 'n', true} }
-    bufnr = api.nvim_get_current_buf() or bufnr
-    api.nvim_buf_clear_namespace(bufnr, M.reference_ns, 0, -1)
-  end
-
   function M.get_severity_highlight_name(severity)
     return severity_highlights[severity]
   end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -552,7 +552,7 @@ function M.open_floating_peek_preview(bufnr, start, finish, opts)
 end
 
 
-local function highlight_range(bufnr, ns, hiname, start, finish)
+function M.highlight_range(bufnr, ns, hiname, start, finish)
   if start[1] == finish[1] then
     -- TODO care about encoding here since this is in byte index?
     api.nvim_buf_add_highlight(bufnr, ns, hiname, start[1], start[2], finish[2])
@@ -604,6 +604,12 @@ do
   function M.buf_clear_diagnostics(bufnr)
     validate { bufnr = {bufnr, 'n', true} }
     api.nvim_buf_clear_namespace(bufnr, diagnostic_ns, 0, -1)
+  end
+
+  function M.buf_clear_references(bufnr)
+    validate { bufnr = {bufnr, 'n', true} }
+    bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
+    api.nvim_buf_clear_namespace(bufnr, M.reference_ns, 0, -1)
   end
 
   function M.get_severity_highlight_name(severity)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -552,7 +552,7 @@ function M.open_floating_peek_preview(bufnr, start, finish, opts)
 end
 
 
-function highlight_range(bufnr, ns, hiname, start, finish)
+local function highlight_range(bufnr, ns, hiname, start, finish)
   if start[1] == finish[1] then
     -- TODO care about encoding here since this is in byte index?
     api.nvim_buf_add_highlight(bufnr, ns, hiname, start[1], start[2], finish[2])
@@ -714,13 +714,12 @@ do
     for _, reference in ipairs(references) do
       local start_pos = {reference["range"]["start"]["line"], reference["range"]["start"]["character"]}
       local end_pos = {reference["range"]["end"]["line"], reference["range"]["end"]["character"]}
-      if reference["kind"] == protocol.DocumentHighlightKind.Text then
-        highlight_range(bufnr, reference_ns, "LspReferenceText", start_pos, end_pos)
-      elseif reference["kind"] == protocol.DocumentHighlightKind.Read then
-        highlight_range(bufnr, reference_ns, "LspReferenceRead", start_pos, end_pos)
-      elseif reference["kind"] == protocol.DocumentHighlightKind.Write then
-        highlight_range(bufnr, reference_ns, "LspReferenceWrite", start_pos, end_pos)
-      end
+      local document_highlight_kind = {
+        [protocol.DocumentHighlightKind.Text] = "LspReferenceText";
+        [protocol.DocumentHighlightKind.Read] = "LspReferenceRead";
+        [protocol.DocumentHighlightKind.Write] = "LspReferenceWrite";
+      }
+      highlight_range(bufnr, reference_ns, document_highlight_kind[reference["kind"]], start_pos, end_pos)
     end
   end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -608,7 +608,7 @@ do
 
   function M.buf_clear_references(bufnr)
     validate { bufnr = {bufnr, 'n', true} }
-    bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
+    bufnr = api.nvim_get_current_buf() or bufnr
     api.nvim_buf_clear_namespace(bufnr, M.reference_ns, 0, -1)
   end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -603,13 +603,13 @@ do
 
   function M.buf_clear_diagnostics(bufnr)
     validate { bufnr = {bufnr, 'n', true} }
-    bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
+    bufnr = api.nvim_get_current_buf() or bufnr
     api.nvim_buf_clear_namespace(bufnr, diagnostic_ns, 0, -1)
   end
 
   function M.buf_clear_references(bufnr)
     validate { bufnr = {bufnr, 'n', true} }
-    bufnr = bufnr == 0 and api.nvim_get_current_buf() or bufnr
+    bufnr = api.nvim_get_current_buf() or bufnr
     api.nvim_buf_clear_namespace(bufnr, M.reference_ns, 0, -1)
   end
 


### PR DESCRIPTION
This PR implements the functions required for users to enable document highlight support, but is left to users to enable it. For example, in my case I use CursorHold to trigger the highlighting:

```
    vim.api.nvim_command [[autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()]]
    vim.api.nvim_command [[autocmd CursorHoldI <buffer> lua vim.lsp.buf.document_highlight()]]
    vim.api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.util.buf_clear_references()]]
```


