### PR TITLE
provider: document `*_host_prog` ordering issues

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -58,12 +58,14 @@ If you run into problems, uninstall _both_ then install "pynvim" again: >
 PYTHON PROVIDER CONFIGURATION ~
 						*g:python_host_prog*
 Command to start Python 2 (executable, not directory). Setting this makes
-startup faster. Useful for working with virtualenvs.  >
+startup faster. Useful for working with virtualenvs. Must be set before any
+check for has("python2").  >
     let g:python_host_prog  = '/path/to/python'
 <
 						*g:python3_host_prog*
 Command to start Python 3 (executable, not directory). Setting this makes
-startup faster. Useful for working with virtualenvs.  >
+startup faster. Useful for working with virtualenvs. Must be set before any
+check for has("python3").  >
     let g:python3_host_prog = '/path/to/python3'
 <
 						*g:loaded_python_provider*


### PR DESCRIPTION
Any uses of `has("python3")` will cause the `g:loaded_python3_provider`
variable to be set if the system path does not have a Python with Neovim
support. Subsequent assignments to `g:python3_host_program` will
therefore not cause the provider to be activated.

wchargin-branch: docs-host-prog-order