### PR TITLE
Fix PVS Violations With Msg Formatting

### DIFF
--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -798,7 +798,7 @@ static inline bool tv_get_float_chk(const typval_T *const tv,
     *ret_f = (float_T)tv->vval.v_number;
     return true;
   }
-  emsgf(_("E808: Number or Float required"));
+  emsgf("%s", _("E808: Number or Float required"));
   return false;
 }
 

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -625,7 +625,7 @@ spell_load_file (
   switch (scms_ret) {
     case SP_FORMERROR:
     case SP_TRUNCERROR: {
-      emsgf(_("E757: This does not look like a spell file"));
+      emsgf("%s", _("E757: This does not look like a spell file"));
       goto endFAIL;
     }
     case SP_OTHERERROR: {
@@ -2654,8 +2654,9 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
   }
 
   if (compsylmax != 0) {
-    if (syllable == NULL)
-      smsg(_("COMPOUNDSYLMAX used without SYLLABLE"));
+    if (syllable == NULL) {
+      smsg("%s", _("COMPOUNDSYLMAX used without SYLLABLE"));
+    }
     aff_check_number(spin->si_compsylmax, compsylmax, "COMPOUNDSYLMAX");
     spin->si_compsylmax = compsylmax;
   }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -625,7 +625,7 @@ spell_load_file (
   switch (scms_ret) {
     case SP_FORMERROR:
     case SP_TRUNCERROR: {
-      emsgf(_("E757: This does not look like a spell file"));
+      emsgf("%s", _("E757: This does not look like a spell file"));
       goto endFAIL;
     }
     case SP_OTHERERROR: {
@@ -2655,7 +2655,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
 
   if (compsylmax != 0) {
     if (syllable == NULL)
-      smsg(_("COMPOUNDSYLMAX used without SYLLABLE"));
+      smsg("%s", _("COMPOUNDSYLMAX used without SYLLABLE"));
     aff_check_number(spin->si_compsylmax, compsylmax, "COMPOUNDSYLMAX");
     spin->si_compsylmax = compsylmax;
   }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1057,7 +1057,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf,
     if (file_name == NULL) {
       if (p_verbose > 0) {
         verbose_enter();
-        smsg(_("Cannot write undo file in any directory in 'undodir'"));
+        smsg("%s", _("Cannot write undo file in any directory in 'undodir'"));
         verbose_leave();
       }
       return;


### PR DESCRIPTION
Fixing violations with regard to formatting the message in emsgf and
smsg.

https://neovim.io/doc/reports/pvs/PVS-studio.html.d/sources/spellfile.c_23.html#ln628
https://neovim.io/doc/reports/pvs/PVS-studio.html.d/sources/buffer.c_4.html#ln1118
https://neovim.io/doc/reports/pvs/PVS-studio.html.d/sources/undo.c_25.html#ln1060