### PR TITLE
vim-patch:8.1.{972,974}

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -528,6 +528,9 @@ wingotofile:
       cmdmod.tab = tabpage_index(curtab) + 1;
       nchar = xchar;
       goto wingotofile;
+    case 't':                       // CTRL-W gt: go to next tab page
+      goto_tabpage((int)Prenum);
+      break;
 
     case 'e':
       if (curwin->w_floating || !ui_has(kUIMultigrid)) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -85,10 +85,7 @@ do_window(
   size_t len;
   char cbuf[40];
 
-  if (Prenum == 0)
-    Prenum1 = 1;
-  else
-    Prenum1 = Prenum;
+  Prenum1 = Prenum == 0 ? 1 : Prenum;
 
 # define CHECK_CMDWIN \
   do { \
@@ -530,6 +527,10 @@ wingotofile:
       goto wingotofile;
     case 't':                       // CTRL-W gt: go to next tab page
       goto_tabpage((int)Prenum);
+      break;
+
+    case 'T':                       // CTRL-W gT: go to previous tab page
+      goto_tabpage(-(int)Prenum1);
       break;
 
     case 'e':

--- a/test/functional/normal/tabpage_spec.lua
+++ b/test/functional/normal/tabpage_spec.lua
@@ -1,0 +1,25 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local feed = helpers.feed
+local eval = helpers.eval
+
+describe('tabpage', function()
+  before_each(clear)
+
+  it('advances to the next page via <C-W>gt', function()
+    -- add some tabpages
+    command('tabnew')
+    command('tabnew')
+    command('tabnew')
+
+    eq(4, eval('tabpagenr()'))
+
+    feed('<C-W>gt')
+
+    eq(1, eval('tabpagenr()'))
+  end)
+end)
+

--- a/test/functional/normal/tabpage_spec.lua
+++ b/test/functional/normal/tabpage_spec.lua
@@ -21,5 +21,18 @@ describe('tabpage', function()
 
     eq(1, eval('tabpagenr()'))
   end)
+
+  it('retreats to the previous page via <C-W>gT', function()
+    -- add some tabpages
+    command('tabnew')
+    command('tabnew')
+    command('tabnew')
+
+    eq(4, eval('tabpagenr()'))
+
+    feed('<C-W>gT')
+
+    eq(3, eval('tabpagenr()'))
+  end)
 end)
 


### PR DESCRIPTION
Add the `<C-W>gt` and `<C-W>gT` aliases for `gt` and `gT` respectively.  

These were added for vim's `:terminal` but apply in normal mode and are [already documented](https://github.com/neovim/neovim/commit/41fe644124140c4a303de4a5a84e28efec918274) to be normal commands in neovim.