### PR TITLE
Invalidate grid on allocation when in ext_multigrid

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6211,7 +6211,7 @@ void win_grid_alloc(win_T *wp)
       || grid->Rows != rows
       || grid->Columns != cols) {
     if (want_allocation) {
-      grid_alloc(grid, rows, cols, wp->w_grid.valid, wp->w_grid.valid);
+      grid_alloc(grid, rows, cols, wp->w_grid.valid, false);
       grid->valid = true;
     } else {
       // Single grid mode, all rendering will be redirected to default_grid.


### PR DESCRIPTION
When in ext_multigrid mode, after a window gets resized neovim wont
currently send all the needed events fill the window's blank space and
thus' UIs will have invalid grid state.

Some old discussions about this topic can be found here on gitter's archives: https://gitter.im/neovim/neovim/archives/2019/08/15