### PR TITLE
screen.c: fix resize logic on floating window

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -505,7 +505,7 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
   }
 
   if (wp->w_floating) {
-    if (width != wp->w_width && height != wp->w_height) {
+    if (width != wp->w_width || height != wp->w_height) {
       wp->w_float_config.width = width;
       wp->w_float_config.height = height;
       win_config_float(wp, wp->w_float_config);


### PR DESCRIPTION
A small logic error I found. Also, should the values be `MAX(val, 0)` like the non-floating window logic does?