### PR TITLE
clipboard: do not close stderr together with stdout (fixup #11617)

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -172,10 +172,9 @@ function! s:clipboard.set(lines, regtype, reg) abort
   if jobid > 0
     call jobsend(jobid, a:lines)
     call jobclose(jobid, 'stdin')
-    " xclip does not close stdout,stderr when receiving input via stdin
+    " xclip does not close stdout when receiving input via stdin
     if argv[0] ==# 'xclip'
       call jobclose(jobid, 'stdout')
-      call jobclose(jobid, 'stderr')
     endif
     let selection.owner = jobid
     let ret = 1


### PR DESCRIPTION
stderr is needed to get error messages in case of failure, and job handler expects it to be open.  