### PR TITLE
option: restore termencoding (readonly)

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4737,6 +4737,13 @@ bool get_tty_option(char *name, char **value)
     return true;
   }
 
+  if (strequal(name, "tenc") || strequal(name, "termencoding")) {
+    if (value) {
+      *value = xstrdup("utf-8");
+    }
+    return true;
+  }
+
   if (strequal(name, "ttytype")) {
     if (value) {
       *value = p_ttytype ? xstrdup(p_ttytype) : xstrdup("nvim");

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -174,7 +174,6 @@ func Test_Catch_Exception_Message()
 endfunc
 
 func Test_unicode()
-  throw 'skipped: Nvim does not support "termencoding" option and only supports "utf-8" for "encoding" option'
   " this crashed Vim once
   if &tenc != ''
     throw "Skipped: 'termencoding' is not empty"


### PR DESCRIPTION
'termencoding' option was removed in abaabd1d03fd723630f6addeadee9928faa4cdde
but some plugins check its value.