### PR TITLE
vim-patch:8.0.1817,8.1.{840,842,844}

### DIFF
--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -260,9 +260,11 @@ func Test_getchar_zero()
     return
   endif
 
+  " Measure the elapsed time to avoid a hang when it fails.
+  let start = reltime()
   let id = timer_start(20, {id -> feedkeys('x', 'L')})
   let c = 0
-  while c == 0
+  while c == 0 && reltimefloat(reltime(start)) < 0.2
     let c = getchar(0)
     sleep 10m
   endwhile

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -254,13 +254,20 @@ func Test_peek_and_get_char()
 endfunc
 
 func Test_getchar_zero()
-  call timer_start(20, {id -> feedkeys('x', 'L')})
+  if has('win32')
+    " Console: no low-level input
+    " GUI: somehow doesn't work
+    return
+  endif
+
+  let id = timer_start(20, {id -> feedkeys('x', 'L')})
   let c = 0
   while c == 0
     let c = getchar(0)
     sleep 10m
   endwhile
   call assert_equal('x', nr2char(c))
+  call timer_stop(id)
 endfunc
 
 func Test_ex_mode()
@@ -268,7 +275,7 @@ func Test_ex_mode()
   func Foo(...)
 
   endfunc
-  let timer =  timer_start(40, function('g:Foo'), {'repeat':-1})
+  let timer = timer_start(40, function('g:Foo'), {'repeat':-1})
   " This used to throw error E749.
   exe "normal Qsleep 100m\rvi\r"
   call timer_stop(timer)

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -253,6 +253,16 @@ func Test_peek_and_get_char()
   call timer_stop(intr)
 endfunc
 
+func Test_getchar_zero()
+  call timer_start(20, {id -> feedkeys('x', 'L')})
+  let c = 0
+  while c == 0
+    let c = getchar(0)
+    sleep 10m
+  endwhile
+  call assert_equal('x', nr2char(c))
+endfunc
+
 func Test_ex_mode()
   " Function with an empty line.
   func Foo(...)


### PR DESCRIPTION
Timer changes in 8.0.1817 seem to be unnecessary for Neovim. Same behavior as Vim 8.2 nightly and v8.0.1817.

If the source code changes from 8.1.0840 are required, 8.1.0834 is a prequisite.