### PR TITLE
third-party: upgrade libvterm to v0.1.3

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -162,8 +162,8 @@ set(UNIBILIUM_SHA256 29815283c654277ef77a3adcc8840db79ddbb20a0f0b0c8f648bd8cd49a
 set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz)
 set(LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600)
 
-set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/e23b82f58cdedcb190f2433557a355a29c583be7.tar.gz)
-set(LIBVTERM_SHA256 09f31d4d40f6a4efda50ad84e2ad39c47f44c207bb61edd0026f8122339aef93)
+set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/65dbda3ed214f036ee799d18b2e693a833a0e591.tar.gz)
+set(LIBVTERM_SHA256 95d3c7e86336fbd40dfd7a0aa0a795320bb71bc957ea995ea0e549c96d20db3a)
 
 set(LUV_VERSION 1.30.1-1)
 set(LUV_URL https://github.com/luvit/luv/archive/${LUV_VERSION}.tar.gz)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -162,8 +162,8 @@ set(UNIBILIUM_SHA256 29815283c654277ef77a3adcc8840db79ddbb20a0f0b0c8f648bd8cd49a
 set(LIBTERMKEY_URL http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz)
 set(LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600)
 
-set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/7c72294d84ce20da4c27362dbd7fa4b08cfc91da.tar.gz)
-set(LIBVTERM_SHA256 f30c4d43e0c6db3e0912daf7188d98fbf6ee88f97589d72f6f304e5db48826a8)
+set(LIBVTERM_URL https://github.com/neovim/libvterm/archive/e23b82f58cdedcb190f2433557a355a29c583be7.tar.gz)
+set(LIBVTERM_SHA256 09f31d4d40f6a4efda50ad84e2ad39c47f44c207bb61edd0026f8122339aef93)
 
 set(LUV_VERSION 1.30.1-1)
 set(LUV_URL https://github.com/luvit/luv/archive/${LUV_VERSION}.tar.gz)


### PR DESCRIPTION
Using https://github.com/neovim/libvterm/commit/e23b82f58cdedcb190f2433557a355a29c583be7.