### PR TITLE
Handle 'cscopetag' in :Man

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -398,6 +398,11 @@ function! man#goto_tag(pattern, flags, info) abort
   " sort by relevance - exact matches first, then the previous order
   call sort(l:structured, { a, b -> a.name ==? l:name ? -1 : b.name ==? l:name ? 1 : 0 })
 
+  if &cscopetag
+    " return only a single entry so we work well with :cstag (#11675)
+    let l:structured = l:structured[:0]
+  endif
+
   return map(l:structured, {
   \  _, entry -> {
   \      'name': entry.name,


### PR DESCRIPTION
Fix #11675.

The old `:Man` implementation (82d3ceb) would take either the word under the cursor, or the argument passed in, and load that up as a man page.

Since we now (25bb1b5) go through `tagfunc` and look for all relevant man-pages, if your system has several (i.e. the same name, but in different sections), we return several, giving the user an option instead of picking exactly what the user's given us (using `man_default_sects` as a default section, if one wasn't given here).

This works well for most tag commands, except `:tjump`, which will fail if there's multiple tags to choose from. This just happens to be what the cscope code uses (it actually attempts to prompt the user, but this fails).

This commit works around that specificity of the cscope implementation, seeing as Nvim is moving towards LSP support.