### PR TITLE
[RFC] Rename CMAKE_EXTRA_FLAGS to CMAKE_FLAGS, use in build.ps1

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -20,7 +20,7 @@ sources:
 environment:
   SOURCEHUT: 1
   LANG: en_US.UTF-8
-  CMAKE_EXTRA_FLAGS: -DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3
+  CMAKE_FLAGS: -DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
 - build-deps: |
@@ -28,7 +28,7 @@ tasks:
     gmake deps
 - build: |
     cd neovim
-    gmake CMAKE_BUILD_TYPE=Release CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" nvim
+    gmake CMAKE_BUILD_TYPE=Release CMAKE_FLAGS="${CMAKE_FLAGS}" nvim
 - functionaltest: |
     cd neovim
     gmake functionaltest

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -19,7 +19,7 @@ sources:
 environment:
   SOURCEHUT: 1
   LC_CTYPE: en_US.UTF-8
-  CMAKE_EXTRA_FLAGS: -DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3
+  CMAKE_FLAGS: -DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
 - build-deps: |
@@ -32,7 +32,7 @@ tasks:
 - build: |
     mkdir neovim/build
     cd neovim/build
-    cmake -G Ninja $CMAKE_EXTRA_FLAGS ..
+    cmake -G Ninja $CMAKE_FLAGS ..
     cmake --build . --config Debug
     ./bin/nvim --version
 - functionaltest: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ and [AppVeyor].
       # To get a full backtrace:
       #   1. Rebuild with debug info.
       rm -rf nvim.core build
-      gmake CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3" nvim
+      gmake CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_FLAGS="-DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3" nvim
       #   2. Run the failing test to generate a new core file.
       TEST_FILE=test/functional/foo.lua gmake functionaltest
       lldb build/bin/nvim -c nvim.core

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,17 @@ all: nvim
 
 CMAKE_PRG ?= $(shell (command -v cmake3 || echo cmake))
 CMAKE_BUILD_TYPE ?= Debug
-CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
-# Extra CMake flags which extend the default set
-CMAKE_EXTRA_FLAGS ?=
+CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) $(CMAKE_FLAGS)
 
 # CMAKE_INSTALL_PREFIX
-#   - May be passed directly or as part of CMAKE_EXTRA_FLAGS.
+#   - May be passed directly or as part of CMAKE_FLAGS.
 #   - `checkprefix` target checks that it matches the CMake-cached value. #9615
-ifneq (,$(CMAKE_INSTALL_PREFIX)$(CMAKE_EXTRA_FLAGS))
-CMAKE_INSTALL_PREFIX := $(shell echo $(CMAKE_EXTRA_FLAGS) | 2>/dev/null \
+ifneq (,$(CMAKE_INSTALL_PREFIX)$(CMAKE_FLAGS))
+CMAKE_INSTALL_PREFIX := $(shell echo $(CMAKE_FLAGS) | 2>/dev/null \
     grep -o 'CMAKE_INSTALL_PREFIX=[^ ]\+' | cut -d '=' -f2)
 endif
 ifneq (,$(CMAKE_INSTALL_PREFIX))
-override CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
+override CMAKE_FLAGS += -DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX)
 
 checkprefix:
 	@if [ -f build/.ran-cmake ]; then \
@@ -93,7 +91,7 @@ cmake:
 	$(MAKE) build/.ran-cmake
 
 build/.ran-cmake: | deps
-	cd build && $(CMAKE_PRG) -G '$(BUILD_TYPE)' $(CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS) $(THIS_DIR)
+	cd build && $(CMAKE_PRG) -G '$(BUILD_TYPE)' $(CMAKE_FLAGS) $(THIS_DIR)
 	touch $@
 
 deps: | build/.ran-third-party-cmake

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -135,7 +135,7 @@ cd $buildDir
 # Build Neovim
 mkdir build
 cd build
-cmake -G $cmakeGenerator $(convertToCmakeArgs($nvimCmakeVars)) .. ; exitIfFailed
+cmake -G $cmakeGenerator $(convertToCmakeArgs($nvimCmakeVars)) $env:CMAKE_FLAGS .. ; exitIfFailed
 cmake --build . --config $cmakeBuildType -- $cmakeGeneratorArgs ; exitIfFailed
 .\bin\nvim --version ; exitIfFailed
 

--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -2,13 +2,13 @@
 # Individual entries must be uncommented to take effect.
 
 # By default, the installation prefix is '/usr/local'.
-# CMAKE_EXTRA_FLAGS += -DCMAKE_INSTALL_PREFIX=/usr/local/nvim-latest
+# CMAKE_FLAGS += -DCMAKE_INSTALL_PREFIX=/usr/local/nvim-latest
 
 # These CFLAGS can be used in addition to those specified in CMakeLists.txt:
-# CMAKE_EXTRA_FLAGS="-DCMAKE_C_FLAGS=-ftrapv -Wlogical-op"
+# CMAKE_FLAGS="-DCMAKE_C_FLAGS=-ftrapv -Wlogical-op"
 
 # To turn compiler warnings into errors:
-# CMAKE_EXTRA_FLAGS += "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -Werror"
+# CMAKE_FLAGS += "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -Werror"
 
 # Sets the build type; defaults to Debug. Valid values:
 #
@@ -29,11 +29,11 @@
 # link-time optimization (LTO)) is enabled by default, which causes the link
 # step to take a significant amout of time, which is relevant when building
 # often.  You can disable it explicitly:
-# CMAKE_EXTRA_FLAGS += -DENABLE_LTO=OFF
+# CMAKE_FLAGS += -DENABLE_LTO=OFF
 
 # Log levels: 0 (DEBUG), 1 (INFO), 2 (WARNING), 3 (ERROR)
 # Default is 1 (INFO) unless CMAKE_BUILD_TYPE is Release or RelWithDebInfo.
-# CMAKE_EXTRA_FLAGS += -DMIN_LOG_LEVEL=1
+# CMAKE_FLAGS += -DMIN_LOG_LEVEL=1
 
 # By default, nvim uses bundled versions of its required third-party
 # dependencies.

--- a/scripts/genappimage.sh
+++ b/scripts/genappimage.sh
@@ -25,7 +25,7 @@ APP_DIR="$APP.AppDir"
 ########################################################################
 
 # Build and install nvim into the AppImage
-make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=${APP_DIR}/usr -DCMAKE_INSTALL_MANDIR=man"
+make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=${APP_DIR}/usr -DCMAKE_INSTALL_MANDIR=man"
 make install
 
 ########################################################################

--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -303,7 +303,7 @@ create_compile_commands() {(
     (
       cd "$tgt"
 
-      make -j"$(get_jobs_num)" CMAKE_EXTRA_FLAGS=" -DCMAKE_INSTALL_PREFIX=$PWD/root -DCMAKE_BUILD_TYPE=Debug "
+      make -j"$(get_jobs_num)" CMAKE_FLAGS=" -DCMAKE_INSTALL_PREFIX=$PWD/root -DCMAKE_BUILD_TYPE=Debug "
     )
   fi
   find "$tgt/build/src/nvim/auto" -name '*.test-include.c' -delete

--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -29,7 +29,7 @@ alternate file (e.g. stderr) use `LOG_CALLSTACK_TO_FILE(FILE*)`.
 UI events are logged at DEBUG level (`DEBUG_LOG_LEVEL`).
 
     rm -rf build/
-    make CMAKE_EXTRA_FLAGS="-DMIN_LOG_LEVEL=0"
+    make CMAKE_FLAGS="-DMIN_LOG_LEVEL=0"
 
 Many log messages have a shared prefix, such as "UI" or "RPC". Use the shell to
 filter the log, e.g. at DEBUG level you might want to exclude UI messages:
@@ -50,9 +50,9 @@ Requires clang 3.4 or later, and `llvm-symbolizer` must be in `$PATH`:
 
 Build Nvim with sanitizer instrumentation (choose one):
 
-    CC=clang make CMAKE_EXTRA_FLAGS="-DCLANG_ASAN_UBSAN=ON"
-    CC=clang make CMAKE_EXTRA_FLAGS="-DCLANG_MSAN=ON"
-    CC=clang make CMAKE_EXTRA_FLAGS="-DCLANG_TSAN=ON"
+    CC=clang make CMAKE_FLAGS="-DCLANG_ASAN_UBSAN=ON"
+    CC=clang make CMAKE_FLAGS="-DCLANG_MSAN=ON"
+    CC=clang make CMAKE_FLAGS="-DCLANG_TSAN=ON"
 
 Create a directory to store logs:
 


### PR DESCRIPTION
This would at least help me on CI for my client library, since I need to debug everything windows-related on appveyor, and need to enable debug logging there.