### PR TITLE
nvim_get_hl_by_id: omit hl instead of returning -1

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -642,11 +642,11 @@ Dictionary hlattrs2dict(HlAttrs ae, bool use_rgb)
       PUT(hl, "special", INTEGER_OBJ(ae.rgb_sp_color));
     }
   } else {
-    if (cterm_normal_fg_color != ae.cterm_fg_color) {
+    if (cterm_normal_fg_color != ae.cterm_fg_color && ae.cterm_fg_color != 0) {
       PUT(hl, "foreground", INTEGER_OBJ(ae.cterm_fg_color - 1));
     }
 
-    if (cterm_normal_bg_color != ae.cterm_bg_color) {
+    if (cterm_normal_bg_color != ae.cterm_bg_color && ae.cterm_bg_color != 0) {
       PUT(hl, "background", INTEGER_OBJ(ae.cterm_bg_color - 1));
     }
   }

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -70,6 +70,22 @@ describe('API: highlight',function()
     eq(false, err)
     eq('Invalid highlight id: -1',
        string.match(emsg, 'Invalid.*'))
+
+    -- Test highlight group without ctermbg value.
+    command('hi Normal ctermfg=red ctermbg=yellow')
+    command('hi NewConstant ctermfg=green guifg=white guibg=blue')
+    hl_id = eval("hlID('NewConstant')")
+    eq({foreground = 10,}, meths.get_hl_by_id(hl_id, false))
+
+    -- Test highlight group without ctermfg value.
+    command('hi clear NewConstant')
+    command('hi NewConstant ctermbg=Magenta guifg=white guibg=blue')
+    eq({background = 13,}, meths.get_hl_by_id(hl_id, false))
+
+    -- Test highlight group with ctermfg and ctermbg values.
+    command('hi clear NewConstant')
+    command('hi NewConstant ctermfg=green ctermbg=Magenta guifg=white guibg=blue')
+    eq({foreground = 10, background = 13,}, meths.get_hl_by_id(hl_id, false))
   end)
 
   it("nvim_get_hl_by_name", function()


### PR DESCRIPTION
When Normal highlight group with values of ctermfg and ctermbg, but the other highlight group lacks of value of ctermfg or ctermbg, nvim_get_hl_by_id(hl_id, v:false) return -1
https://github.com/neovim/neovim/issues/11680