### PR TITLE
Fix build failure

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -706,7 +706,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
 
     case VTERM_PROP_TITLE: {
       buf_T *buf = handle_get_buffer(term->buf_handle);
-      buf_set_term_title(buf, val->string);
+      buf_set_term_title(buf, (char*)((val->string).str));
       break;
     }
 


### PR DESCRIPTION
Not 100% sure why this doesn't happen when running 'make',
but it does so eventually when invoking 'cmake' directly.
The compiler options are likely different.

The error is:

src/nvim/terminal.c: In function 'term_settermprop':
src/nvim/terminal.c:709:34: error: incompatible type for argument 2 of 'buf_set_term_title'
  709 |       buf_set_term_title(buf, val->string);
      |                               ~~~^~~~~~~~
      |                                  |
      |                                  VTermStringFragment {aka struct <anonymous>}
nvim/terminal.c:680:50: note: expected 'char *' but argument is of type 'VTermStringFragment' {aka 'struct <anonymous>'}
  680 | static void buf_set_term_title(buf_T *buf, char *title)