### PR TITLE
[RFC] Fix wildmode not respecting the popup menu

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -941,8 +941,10 @@ static int command_line_execute(VimState *state, int key)
       // if 'wildmode' contains "list" may still need to list
       if (s->xpc.xp_numfiles > 1
           && !s->did_wild_list
-          && (wim_flags[s->wim_index] & WIM_LIST)) {
-        (void)showmatches(&s->xpc, false);
+          && ((wim_flags[s->wim_index] & WIM_LIST)
+              || (p_wmnu && (wim_flags[s->wim_index] & WIM_FULL) != 0))) {
+        (void)showmatches(&s->xpc, p_wmnu
+                          && ((wim_flags[s->wim_index] & WIM_LIST) == 0));
         redrawcmd();
         s->did_wild_list = true;
       }

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -640,7 +640,7 @@ describe('builtin popupmenu', function()
     })
   end)
 
-  it('works with preview-window above', function()
+  it('with preview-window above', function()
     feed(':ped<CR><c-w>4+')
     feed('iaa bb cc dd ee ff gg hh ii jj<cr>')
     feed('<c-x><c-n>')
@@ -668,7 +668,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with preview-window below', function()
+  it('with preview-window below', function()
     feed(':ped<CR><c-w>4+<c-w>r')
     feed('iaa bb cc dd ee ff gg hh ii jj<cr>')
     feed('<c-x><c-n>')
@@ -696,7 +696,7 @@ describe('builtin popupmenu', function()
       ]])
   end)
 
-  it('works with preview-window above and tall and inverted', function()
+  it('with preview-window above and tall and inverted', function()
     feed(':ped<CR><c-w>8+')
     feed('iaa<cr>bb<cr>cc<cr>dd<cr>ee<cr>')
     feed('ff<cr>gg<cr>hh<cr>ii<cr>jj<cr>')
@@ -726,7 +726,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with preview-window above and short and inverted', function()
+  it('with preview-window above and short and inverted', function()
     feed(':ped<CR><c-w>4+')
     feed('iaa<cr>bb<cr>cc<cr>dd<cr>ee<cr>')
     feed('ff<cr>gg<cr>hh<cr>ii<cr>jj<cr>')
@@ -755,7 +755,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with preview-window below and inverted', function()
+  it('with preview-window below and inverted', function()
     feed(':ped<CR><c-w>4+<c-w>r')
     feed('iaa<cr>bb<cr>cc<cr>dd<cr>ee<cr>')
     feed('ff<cr>gg<cr>hh<cr>ii<cr>jj<cr>')
@@ -784,7 +784,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with vsplits', function()
+  it('with vsplits', function()
     insert('aaa aab aac\n')
     feed(':vsplit<cr>')
     screen:expect([[
@@ -859,7 +859,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with split and scroll', function()
+  it('with split and scroll', function()
     screen:try_resize(60,14)
     command("split")
     command("set completeopt+=noinsert")
@@ -1293,7 +1293,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('behaves correcty with VimResized autocmd', function()
+  it('with VimResized autocmd', function()
     feed('isome long prefix before the ')
     command("set completeopt+=noinsert,noselect")
     command("autocmd VimResized * redraw!")
@@ -1337,7 +1337,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with rightleft window', function()
+  it('with rightleft window', function()
     command("set rl")
     feed('isome rightleft ')
     screen:expect([[
@@ -1437,7 +1437,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with multiline messages', function()
+  it('with multiline messages', function()
     screen:try_resize(40,8)
     feed('ixx<cr>')
     command('imap <f2> <cmd>echoerr "very"\\|echoerr "much"\\|echoerr "error"<cr>')
@@ -1514,7 +1514,7 @@ describe('builtin popupmenu', function()
     ]], unchanged=true}
   end)
 
-  it('works with kind, menu and abbr attributes', function()
+  it('with kind, menu and abbr attributes', function()
     screen:try_resize(40,8)
     feed('ixx ')
     funcs.complete(4, {{word='wordey', kind= 'x', menu='extrainfo'}, 'thing', {word='secret', abbr='sneaky', menu='bar'}})
@@ -1566,7 +1566,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with wildoptions=pum', function()
+  it('wildoptions=pum', function()
     screen:try_resize(32,10)
     command('set wildmenu')
     command('set wildoptions=pum')
@@ -1738,7 +1738,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('works with wildoptions=pum with scrolled mesages ', function()
+  it('wildoptions=pum with scrolled mesages ', function()
     screen:try_resize(40,10)
     command('set wildmenu')
     command('set wildoptions=pum')
@@ -1784,6 +1784,39 @@ describe('builtin popupmenu', function()
       {6:error}                                   |
       :sign defined^                           |
     ]]}
+  end)
+
+  it('wildoptions=pum and wildmode=longest,full #11622', function()
+    screen:try_resize(30,8)
+    command('set wildmenu')
+    command('set wildoptions=pum')
+    command('set wildmode=longest,full')
+
+    feed(':sign u<tab>')
+    screen:expect{grid=[[
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :sign un^                      |
+    ]]}
+    eq(0, funcs.wildmenumode())
+
+    feed('<tab>')
+    screen:expect{grid=[[
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~    }{s: undefine       }{1:         }|
+      {1:~    }{n: unplace        }{1:         }|
+      :sign undefine^                |
+    ]]}
+    eq(1, funcs.wildmenumode())
   end)
 
   it("'pumblend' RGB-color", function()

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -221,6 +221,106 @@ describe("'wildmenu'", function()
     ]])
   end)
 
+  it('wildmode=longest,list', function()
+    -- Need more than 5 rows, else tabline is covered and will be redrawn.
+    screen:try_resize(25, 7)
+
+    command('set wildmenu wildmode=longest,list')
+
+    -- give wildmode-longest something to expand to
+    feed(':sign u<tab>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      :sign un^                 |
+    ]])
+    feed('<tab>') -- trigger wildmode list
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+                               |
+      :sign un                 |
+      undefine  unplace        |
+      :sign un^                 |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+                               |
+    ]])
+
+    -- give wildmode-longest something it cannot expand, use list
+    feed(':sign un<tab>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+                               |
+      :sign un                 |
+      undefine  unplace        |
+      :sign un^                 |
+    ]])
+    feed('<tab>')
+    screen:expect_unchanged()
+    feed('<Esc>')
+    screen:expect([[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+                               |
+    ]])
+  end)
+
+  it('wildmode=list,longest', function()
+    -- Need more than 5 rows, else tabline is covered and will be redrawn.
+    screen:try_resize(25, 7)
+
+    command('set wildmenu wildmode=list,longest')
+    feed(':sign u<tab>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+                               |
+      :sign u                  |
+      undefine  unplace        |
+      :sign u^                  |
+    ]])
+    feed('<tab>') -- trigger wildmode longest
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+                               |
+      :sign u                  |
+      undefine  unplace        |
+      :sign un^                 |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+      ~                        |
+                               |
+    ]])
+  end)
+
   it('multiple <C-D> renders correctly', function()
     screen:try_resize(25, 7)
 


### PR DESCRIPTION
Fixes #11622 

In the case where
- wildmode=longest,full
- wildmenu is enabled (default)
- popupmenu is enabled in wildoptions (default)

neovim now displays the popup wildmenu when the wildchar is pressed twice.

This is accomplished by calling showmatches(&s->xpc, true) on the second press of wildchar. The logic this PR uses to accomplish this is a copy of the logic used on the first press of wildchar (which can be found slightly below this PR's change).