### PR TITLE
api_set_error: include expression with "Failed to evaluate expression"

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -443,7 +443,8 @@ Object nvim_eval(String expr, Error *err)
   if (!try_end(err)) {
     if (ok == FAIL) {
       // Should never happen, try_end() should get the error. #8371
-      api_set_error(err, kErrorTypeException, "Failed to evaluate expression");
+      api_set_error(err, kErrorTypeException,
+                    "Failed to evaluate expression: '%.*s'", 256, expr.data);
     } else {
       rv = vim_to_object(&rettv);
     }


### PR DESCRIPTION
(not included in #11712 since it needs more investigation likely)

This appears to get triggered via https://github.com/neovim/neovim/blob/1fcae97573c6796fcd26fc0c11edc28919e3d0f3/src/nvim/window.c#L4509, for when `curwin_invalid` is true.

I've a more complicated setup to trigger it (jedi-vim's goto, which triggers `cwindow` (and `0cc` right after (a bug there to be fixed)), and [semshi](https://github.com/numirias/semshi) listening to `CursorMoved` events (via a Python plugin):

```
INFO  2020-01-14T08:02:21.899 1284530 win_enter_ext:4501: curbuf=1 curwin_invalid=0

==> /tmp/nvim_python_py3_rplugin <==
2020-01-14 08:02:21,902 [INFO @ async_session.py:_on_notification:107] 1284543 - received notification: b'…/vim/plugged/semshi/rplugin/python3/semshi:function:SemshiCursorMoved', [[50, 51]]

==> /tmp/ll1 <==
event_cursor_moved: args=[50, 51] handler=<BufferHandler(1)>

==> /home/user/.local/share/nvim/log <==
INFO  2020-01-14T08:02:21.933 1284530 win_enter_ext:4501: curbuf=1 curwin_invalid=1
INFO  2020-01-14T08:02:21.933 1284530 win_enter_ext:4501: curbuf=1 curwin_invalid=0

==> /tmp/nvim_python_py3_rplugin <==
2020-01-14 08:02:21,935 [INFO @ session.py:request:101] 1284543 - 'Received error: [0, b"Failed to evaluate expression: bufnr('%')"]

==> /tmp/ll1 <==
event_buf_enter: args=[1, 39, 53]

==> /tmp/nvim_python_py3_rplugin <==
2020-01-14 08:02:21,935 [WARNING @ session.py:handler:200] 1284543 - error response from request 'b'…/vim/plugged/semshi/rplugin/python3/semshi:function:SemshiBufEnter' [[1, 39, 53]]': Traceback (most recent call last):
  File "…/Vcs/pynvim/pynvim/plugin/host.py", line 101, in _wrap_function
    return fn(*args)
  File "…/vim/plugged/semshi/rplugin/python3/semshi/plugin.py", line 80, in event_buf_enter
    buf = self._vim.eval("bufnr('%')")
  File "…/Vcs/pynvim/pynvim/api/nvim.py", line 293, in eval
    return self.request('nvim_eval', string, **kwargs)
  File "…/Vcs/pynvim/pynvim/api/nvim.py", line 182, in request
    res = self._session.request(name, *args, **kwargs)
  File "…/Vcs/pynvim/pynvim/msgpack_rpc/session.py", line 102, in request
    raise self.error_wrapper(err)
pynvim.api.common.NvimError: Failed to evaluate expression: bufnr('%')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "…/Vcs/pynvim/pynvim/msgpack_rpc/session.py", line 195, in handler
    rv = self._request_cb(name, args)
  File "…/Vcs/pynvim/pynvim/api/nvim.py", line 210, in filter_request_cb
    result = request_cb(name, args)
  File "…/Vcs/pynvim/pynvim/plugin/host.py", line 124, in _on_request
    rv = handler(*args)
  File "…/Vcs/pynvim/pynvim/plugin/host.py", line 105, in _wrap_function
    raise ErrorResponse(
pynvim.msgpack_rpc.session.ErrorResponse: error caught in request handler '…/vim/plugged/semshi/rplugin/python3/semshi:function:SemshiBufEnter [[1, 39, 53]]': pynvim.api.common.NvimError: Failed to evaluate expression: bufnr('%')
Traceback (most recent call last):
  File "…/vim/plugged/semshi/rplugin/python3/semshi/plugin.py", line 80, in event_buf_enter
    buf = self._vim.eval("bufnr('%')")
  File "…/Vcs/pynvim/pynvim/api/nvim.py", line 293, in eval
    return self.request('nvim_eval', string, **kwargs)
  File "…/Vcs/pynvim/pynvim/api/nvim.py", line 182, in request
    res = self._session.request(name, *args, **kwargs)
  File "…/Vcs/pynvim/pynvim/msgpack_rpc/session.py", line 102, in request
    raise self.error_wrapper(err)
pynvim.api.common.NvimError: Failed to evaluate expression: bufnr('%')
```

NOTE: eval'ing `winnr()` is also invalid, but e.g. `42` works.