### PR TITLE
[WIP] unittests: fail test if process had non-zero exit status

### DIFF
--- a/test/unit/memory_spec.lua
+++ b/test/unit/memory_spec.lua
@@ -33,6 +33,8 @@ describe('xstrlcat()', function()
     eq('ABCיהZdefgiיהZ',  test_xstrlcat('ABCיהZ', 'defgiיהZ',  4096))
     eq('b',  test_xstrlcat('',  'b', 4096))
     eq('a',  test_xstrlcat('a', '',  4096))
+    os.exit(3)
+    cimp.xstrlcat(nil,nil,3) -- fake it to see it
   end)
 
   itp('concatenates overlapping strings', function()


### PR DESCRIPTION
broken out of #11563. I noticed while working on it that crashes are silently ignored in unittests, at least locally. 

Will test with CI that it fails as expected with signals and non-zero exit().