### PR TITLE
[RDY] fillchars: fix display on closed fold

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2123,11 +2123,11 @@ fill_foldcolumn(
 
   if (closed) {
     if (symbol != 0) {
-      // rollback length
+      // rollback previous write
       char_counter -= len;
+      memset(&p[char_counter], ' ', len);
     }
-    symbol = wp->w_p_fcs_chars.foldclosed;
-    len = utf_char2bytes(symbol, &p[char_counter]);
+    len = utf_char2bytes(wp->w_p_fcs_chars.foldclosed, &p[char_counter]);
     char_counter += len;
   }
 


### PR DESCRIPTION
The rollback of the last written symbol was not thorough, hence
confusing the code later on and causing a buggy display.

To reproduce, use `set fillchars+=foldopen:▾,foldsep:│` and close a
fold. Foldcolumn should display a glitch.