### PR TITLE
messages: echo "line1\r\nline2" should not clear line1

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -21242,6 +21242,7 @@ void ex_echo(exarg_T *eap)
   char_u      *arg = eap->arg;
   typval_T rettv;
   bool atstart = true;
+  bool need_clear = true;
   const int did_emsg_before = did_emsg;
 
   if (eap->skip)
@@ -21284,7 +21285,7 @@ void ex_echo(exarg_T *eap)
       char *tofree = encode_tv2echo(&rettv, NULL);
       if (*tofree != NUL) {
         msg_ext_set_kind("echo");
-        msg_multiline_attr(tofree, echo_attr, true);
+        msg_multiline_attr(tofree, echo_attr, true, &need_clear);
       }
       xfree(tofree);
     }
@@ -21297,7 +21298,9 @@ void ex_echo(exarg_T *eap)
     emsg_skip--;
   } else {
     // remove text that may still be there from the command
-    msg_clr_eos();
+    if (need_clear) {
+      msg_clr_eos();
+    }
     if (eap->cmdidx == CMD_echo) {
       msg_end();
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -228,7 +228,8 @@ int msg_attr(const char *s, const int attr)
 }
 
 /// similar to msg_outtrans_attr, but support newlines and tabs.
-void msg_multiline_attr(const char *s, int attr, bool check_int)
+void msg_multiline_attr(const char *s, int attr,
+                        bool check_int, bool *need_clear)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *next_spec = s;
@@ -243,8 +244,9 @@ void msg_multiline_attr(const char *s, int attr, bool check_int)
       // Printing all char that are before the char found by strpbrk
       msg_outtrans_len_attr((const char_u *)s, next_spec - s, attr);
 
-      if (*next_spec != TAB) {
+      if (*next_spec != TAB && *need_clear) {
         msg_clr_eos();
+        *need_clear = false;
       }
       msg_putchar_attr((uint8_t)(*next_spec), attr);
       s = next_spec + 1;
@@ -256,6 +258,7 @@ void msg_multiline_attr(const char *s, int attr, bool check_int)
   if (*s != NUL) {
     msg_outtrans_attr((char_u *)s, attr);
   }
+  return;
 }
 
 
@@ -314,12 +317,15 @@ bool msg_attr_keep(char_u *s, int attr, bool keep, bool multiline)
   if (buf != NULL)
     s = buf;
 
+  bool need_clear = true;
   if (multiline) {
-    msg_multiline_attr((char *)s, attr, false);
+    msg_multiline_attr((char *)s, attr, false, &need_clear);
   } else {
     msg_outtrans_attr(s, attr);
   }
-  msg_clr_eos();
+  if (need_clear) {
+    msg_clr_eos();
+  }
   retval = msg_end();
 
   if (keep && retval && vim_strsize(s) < (int)(Rows - cmdline_row - 1)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -938,6 +938,30 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
       {7:                                          0,0-1 100%        }|
     ]]}
   end)
+
+  it('supports echo with CRLF line separators', function()
+    feed(':echo "line 1\\r\\nline 2"<cr>')
+    screen:expect{grid=[[
+                                                                  |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {3:                                                            }|
+      line 1                                                      |
+      line 2                                                      |
+      {4:Press ENTER or type command to continue}^                     |
+    ]]}
+
+    feed('<cr>:echo "abc\\rz"<cr>')
+    screen:expect{grid=[[
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      zbc                                                         |
+    ]]}
+  end)
 end)
 
 describe('ui/ext_messages', function()


### PR DESCRIPTION
Fixes #11722 by using the same logic as vim (only first CR or LF needs a clear of command text).

Needs a test. Will check if it breaks any existing tests first.