### PR TITLE
restore old 'termencoding' behavior

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4742,13 +4742,6 @@ bool get_tty_option(char *name, char **value)
     return true;
   }
 
-  if (strequal(name, "tenc") || strequal(name, "termencoding")) {
-    if (value) {
-      *value = xstrdup("utf-8");
-    }
-    return true;
-  }
-
   if (strequal(name, "ttytype")) {
     if (value) {
       *value = p_ttytype ? xstrdup(p_ttytype) : xstrdup("nvim");

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2489,6 +2489,12 @@ return {
       defaults={if_true={vi=false}}
     },
     {
+      full_name='termencoding', abbreviation='tenc',
+      type='string', scope={'global'},
+      vi_def=true,
+      defaults={if_true={vi=""}}
+    },
+    {
       full_name='termguicolors', abbreviation='tgc',
       type='bool', scope={'global'},
       vi_def=false,

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -175,9 +175,7 @@ endfunc
 
 func Test_unicode()
   " this crashed Vim once
-  if &tenc != ''
-    throw "Skipped: 'termencoding' is not empty"
-  endif
+  throw "Skipped: nvim does not support changing 'encoding'"
 
   set encoding=utf32
   py3 print('hello')


### PR DESCRIPTION
The old implementation was removed without clear motivation. The "term option"
hackaround added in its place is neither shorter nor simpler. Let's not break things that are not broken. And when we do, we should restore the known _non-broken_ state.

The new behavior breaks even init.vim that expliticly check against it:

    if exists('&termencoding')
      set termencoding=utf-8
    endif

There was nothing wrong with the 0.4.x behavior. Empty &tenc has indicated that the &enc value should be used for all the history of Nvim. Ignoring setting the option is the expected behavior for Vim
versions that does not support the option (and Nvim is such a version)

