### PR TITLE
vim-patch:8.1.{2031,2421}

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -560,6 +560,7 @@ list_missing_previous_vimpatches_for_patch() {
     local -a missing_vim_patches=()
     _set_missing_vimpatches 1 -- "${fname}"
 
+    set +u  # Avoid "unbound variable" with bash < 4.4 below.
     local missing_vim_commit_info="${missing_vim_patches[0]}"
     if [[ -z "${missing_vim_commit_info}" ]]; then
       printf -- "-\n"
@@ -572,6 +573,7 @@ list_missing_previous_vimpatches_for_patch() {
         printf -- "-\n"
       fi
     fi
+    set -u
   done
 
   set +u  # Avoid "unbound variable" with bash < 4.4 below.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3868,6 +3868,7 @@ win_line (
       }
       wp->w_wrow = row;
       did_wcol = true;
+      curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
     }
 
     // Don't override visual selection highlighting.

--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -1,5 +1,5 @@
 " Test for python 2 commands.
-" TODO: move tests from test87.in here.
+" TODO: move tests from test86.in here.
 
 if !has('python')
   finish

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -1,5 +1,5 @@
 " Test for python 3 commands.
-" TODO: move tests from test88.in here.
+" TODO: move tests from test87.in here.
 
 if !has('python3')
   finish


### PR DESCRIPTION
'test_conceal.vim' requires +conceal and +terminal so it is N/A.