### PR TITLE
[RFC] Fix f_jobstop() return value

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5502,6 +5502,9 @@ jobstop({id})						*jobstop()*
 		(if any) will be invoked.
 		See |job-control|.
 
+		Returns 1 for valid job id, 0 for invalid id, including jobs have
+		exited or stopped.
+
 jobwait({jobs}[, {timeout}])				*jobwait()*
 		Waits for jobs and their |on_exit| handlers to complete.
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -12706,7 +12706,7 @@ static void f_jobstop(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  Channel *data = find_job(argvars[0].vval.v_number, true);
+  Channel *data = find_job(argvars[0].vval.v_number, false);
   if (!data) {
     return;
   }

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -306,16 +306,16 @@ describe('jobs', function()
     end))
   end)
 
-  it('disallows jobsend/stop on a non-existent job', function()
+  it('disallows jobsend on a non-existent job', function()
     eq(false, pcall(eval, "jobsend(-1, 'lol')"))
-    eq(false, pcall(eval, "jobstop(-1)"))
+    eq(0, eval('jobstop(-1)'))
   end)
 
-  it('disallows jobstop twice on the same job', function()
+  it('jobstop twice on the stopped or exited job return 0', function()
     nvim('command', "let j = jobstart(['cat', '-'], g:job_opts)")
     neq(0, eval('j'))
-    eq(true, pcall(eval, "jobstop(j)"))
-    eq(false, pcall(eval, "jobstop(j)"))
+    eq(1, eval("jobstop(j)"))
+    eq(0, eval("jobstop(j)"))
   end)
 
   it('will not leak memory if we leave a job running', function()
@@ -917,6 +917,13 @@ describe('jobs', function()
         eq(NIL, meths.get_proc(child_pid))
       end
     end)
+  end)
+
+  it('jobstop on same id before stopped', function()
+    nvim('command', 'let j = jobstart(["cat", "-"], g:job_opts)')
+    neq(0, eval('j'))
+
+    eq({1, 0}, eval('[jobstop(j), jobstop(j)]'))
   end)
 
   describe('running tty-test program', function()


### PR DESCRIPTION
Return 0 when the job is already stopped, exited or even the id is invalid and 1 stand for the valid job and has not been stopped.

But I don't know how to create the test case that when the job is still in the job table but the process is exited or stopped.

Refs: #10943 #10984 