### PR TITLE
shed biking: it's always extmarks, never marks extended

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -26,7 +26,7 @@
 #include "nvim/map_defs.h"
 #include "nvim/map.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/fileio.h"
 #include "nvim/move.h"
 #include "nvim/syntax.h"

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -24,7 +24,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/map_defs.h"
 #include "nvim/map.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/version.h"

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -40,7 +40,7 @@
 #include "nvim/ops.h"
 #include "nvim/option.h"
 #include "nvim/state.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/syntax.h"
 #include "nvim/getchar.h"
 #include "nvim/os/input.h"

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -53,7 +53,7 @@
 #include "nvim/indent_c.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -17,7 +17,7 @@
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/memline.h"
 #include "nvim/misc1.h"
 #include "nvim/move.h"

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -28,7 +28,7 @@
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
 #include "nvim/main.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -40,7 +40,7 @@
 #include "nvim/buffer_updates.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/message.h"

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -32,7 +32,7 @@
 #include "nvim/api/vim.h"
 #include "nvim/vim.h"
 #include "nvim/charset.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/buffer_updates.h"
 #include "nvim/memline.h"
 #include "nvim/pos.h"
@@ -45,7 +45,7 @@
 #include "nvim/highlight.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mark_extended.c.generated.h"
+# include "extmark.c.generated.h"
 #endif
 
 static ExtmarkNs *buf_ns_ref(buf_T *buf, uint64_t ns_id, bool put) {

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -1,8 +1,8 @@
-#ifndef NVIM_MARK_EXTENDED_H
-#define NVIM_MARK_EXTENDED_H
+#ifndef NVIM_EXTMARK_H
+#define NVIM_EXTMARK_H
 
 #include "nvim/buffer_defs.h"
-#include "nvim/mark_extended_defs.h"
+#include "nvim/extmark_defs.h"
 #include "nvim/marktree.h"
 
 EXTERN int extmark_splice_pending INIT(= 0);
@@ -87,7 +87,7 @@ typedef struct {
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mark_extended.h.generated.h"
+# include "extmark.h.generated.h"
 #endif
 
-#endif  // NVIM_MARK_EXTENDED_H
+#endif  // NVIM_EXTMARK_H

--- a/src/nvim/extmark_defs.h
+++ b/src/nvim/extmark_defs.h
@@ -1,5 +1,5 @@
-#ifndef NVIM_MARK_EXTENDED_DEFS_H
-#define NVIM_MARK_EXTENDED_DEFS_H
+#ifndef NVIM_EXTMARK_DEFS_H
+#define NVIM_EXTMARK_DEFS_H
 
 #include "nvim/pos.h"  // for colnr_T
 #include "nvim/lib/kvec.h"
@@ -34,4 +34,4 @@ typedef enum {
   kExtmarkUndoNoRedo,  // Operation should be undoable, but not redoable
 } ExtmarkOp;
 
-#endif  // NVIM_MARK_EXTENDED_DEFS_H
+#endif  // NVIM_EXTMARK_DEFS_H

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -22,7 +22,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/indent.h"
 #include "nvim/buffer_updates.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -13,7 +13,7 @@
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/misc1.h"

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "nvim/map_defs.h"
-#include "nvim/mark_extended_defs.h"
+#include "nvim/extmark_defs.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/dispatch.h"
 #include "nvim/highlight_defs.h"

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -20,7 +20,7 @@
 #include "nvim/ex_cmds.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -6,7 +6,7 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/func_attr.h"
 #include "nvim/mark_defs.h"
-#include "nvim/mark_extended_defs.h"
+#include "nvim/extmark_defs.h"
 #include "nvim/memory.h"
 #include "nvim/pos.h"
 #include "nvim/os/time.h"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -31,7 +31,7 @@
 #include "nvim/indent.h"
 #include "nvim/log.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -87,7 +87,7 @@
 #include "nvim/highlight.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -93,7 +93,7 @@
 #include "nvim/buffer_updates.h"
 #include "nvim/pos.h"  // MAXLNUM
 #include "nvim/mark.h"
-#include "nvim/mark_extended.h"
+#include "nvim/extmark.h"
 #include "nvim/memline.h"
 #include "nvim/message.h"
 #include "nvim/misc1.h"

--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -4,7 +4,7 @@
 #include <time.h>  // for time_t
 
 #include "nvim/pos.h"
-#include "nvim/mark_extended_defs.h"
+#include "nvim/extmark_defs.h"
 #include "nvim/mark_defs.h"
 
 typedef struct u_header u_header_T;

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -548,7 +548,6 @@ describe('API/extmarks', function()
   end)
 
   it('deleting marks at end of line works', function()
-    -- mark_extended.c/extmark_col_adjust_delete
     set_extmark(ns, marks[1], 0, 4)
     feed('$x')
     check_undo_redo(ns, marks[1], 0, 4, 0, 4)


### PR DESCRIPTION
Having both the terms "extmarks" and "mark_extended" seems superfluous. Let's fix this before doing more changes (which will follow very soon, hopefully).