### PR TITLE
[RFC] Wildmenu support C-E and C-Y as popupmenu

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6689,6 +6689,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	While the menu is active these keys have special meanings:
 
 	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
+	<CTRL-Y>	- Accet the currenty selected match and stop
+                          completion.
+	<CTRL-E>	- End completion, back to original typed text.
 	<Down>		- in filename/menu name completion: move into a
 			  subdirectory or submenu.
 	<CR>		- in menu completion, when the cursor is just after a

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6688,10 +6688,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	While the menu is active these keys have special meanings:
 
+	CTRL-Y		- accept the currently selected match and stop
+			  completion.
+	CTRL-E		- end completion, go back to what was there before
+			  selecting a match.
 	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
-	<CTRL-Y>	- Accet the currenty selected match and stop
-                          completion.
-	<CTRL-E>	- End completion, back to original typed text.
 	<Down>		- in filename/menu name completion: move into a
 			  subdirectory or submenu.
 	<CR>		- in menu completion, when the cursor is just after a

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -621,6 +621,16 @@ static int command_line_execute(VimState *state, int key)
       s->c = Ctrl_N;
     }
   }
+  if (compl_match_array || s->did_wild_list) {
+    if (s->c == Ctrl_E) {
+      s->res = nextwild(&s->xpc, WILD_CANCEL, WILD_NO_BEEP,
+                        s->firstc != '@');
+    } else if (s->c == Ctrl_Y) {
+      s->res = nextwild(&s->xpc, WILD_APPLY, WILD_NO_BEEP,
+                        s->firstc != '@');
+      s->c = Ctrl_E;
+    }
+  }
 
   // Hitting CR after "emenu Name.": complete submenu
   if (s->xpc.xp_context == EXPAND_MENUNAMES && p_wmnu
@@ -3788,6 +3798,12 @@ ExpandOne (
       return NULL;
   }
 
+  if (mode == WILD_CANCEL) {
+    ss = vim_strsave(orig_save);
+  } else if (mode == WILD_APPLY) {
+    ss =  vim_strsave(findex == -1 ? orig_save : xp->xp_files[findex]);
+  }
+
   /* free old names */
   if (xp->xp_numfiles != -1 && mode != WILD_ALL && mode != WILD_LONGEST) {
     FreeWild(xp->xp_numfiles, xp->xp_files);
@@ -3799,7 +3815,7 @@ ExpandOne (
   if (mode == WILD_FREE)        /* only release file name */
     return NULL;
 
-  if (xp->xp_numfiles == -1) {
+  if (xp->xp_numfiles == -1 && mode != WILD_APPLY && mode != WILD_CANCEL) {
     xfree(orig_save);
     orig_save = orig;
     orig_saved = TRUE;

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -16,6 +16,8 @@
 #define WILD_ALL                6
 #define WILD_LONGEST            7
 #define WILD_ALL_KEEP           8
+#define WILD_CANCEL             9
+#define WILD_APPLY              10
 
 #define WILD_LIST_NOTFOUND      0x01
 #define WILD_HOME_REPLACE       0x02

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -16,6 +16,44 @@ describe("'wildmenu'", function()
     screen:attach()
   end)
 
+  it('C-E to cancel wildmenu completion restore original input', function()
+    feed(':sign <tab>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      define  jump  list  >    |
+      :sign define^             |
+    ]])
+    feed('<C-E>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      ~                        |
+      :sign ^                   |
+    ]])
+  end)
+
+  it('C-Y to apply selection and end wildmenu completion', function()
+    feed(':sign <tab>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      define  jump  list  >    |
+      :sign define^             |
+    ]])
+    feed('<tab><C-Y>')
+    screen:expect([[
+                               |
+      ~                        |
+      ~                        |
+      ~                        |
+      :sign jump^               |
+    ]])
+  end)
+
   it(':sign <tab> shows wildmenu completions', function()
     command('set wildmenu wildmode=full')
     feed(':sign <tab>')


### PR DESCRIPTION
From #10693, add `cancel` and `apply` operations for the wildmenu in ex mode.

- [x] Implement operations
- [x] Add functional tests