### PR TITLE
vim-patch.sh: include --shortstat with -m

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -587,7 +587,9 @@ list_missing_previous_vimpatches_for_patch() {
 
   local -a missing_unique
   while IFS= read -r line; do
-    missing_unique+=("$line")
+    local commit="${line%%:*}"
+    local stat="$(git -C "${VIM_SOURCE_DIR}" show --format= --shortstat "${commit}")"
+    missing_unique+=("$(printf '%s\n  %s' "$line" "$stat")")
   done < <(printf '%s\n' "${missing_list[@]}" | sort -u)
 
   msg_err "$(printf '%d missing previous Vim patches:' ${#missing_unique[@]})"


### PR DESCRIPTION
Example output:
```
% scripts/vim-patch.sh -m v8.1.0744
=== getting missing patches for 5 files ===
[1/5] src/if_perl.xs: v8.0.1123: cannot define a toolbar for a window
[2/5] src/if_py_both.h: v8.1.0735: cannot handle binary data
[3/5] src/integration.c: -
[4/5] src/option.c: v8.0.1455: if $SHELL contains a space then 'shell' is incorrect
[5/5] src/version.c: v8.0.1119: quitting a split terminal window kills the job
✘ 4 missing previous Vim patches:
 - v8.0.1119: quitting a split terminal window kills the job
   3 files changed, 39 insertions(+), 20 deletions(-)
 - v8.0.1123: cannot define a toolbar for a window
   20 files changed, 679 insertions(+), 238 deletions(-)
 - v8.0.1455: if $SHELL contains a space then 'shell' is incorrect
   4 files changed, 40 insertions(+), 6 deletions(-)
 - v8.1.0735: cannot handle binary data
   27 files changed, 1357 insertions(+), 117 deletions(-)
```