### PR TITLE
[WIP] vim-patch:8.0.1554: custom plugins loaded with --clean

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -90,6 +90,7 @@ argument.
 --clean		Equivalent to "-u NONE -i NONE":
 		- Skips initializations from files and environment variables.
 		- No 'shada' file is read or written.
+		- the home directory is excluded from 'runtimepath'
 
 							*--noplugin*
 --noplugin	Skip loading plugins.  Resets the 'loadplugins' option.

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -188,7 +188,7 @@ bool event_teardown(void)
 /// Performs early initialization.
 ///
 /// Needed for unit tests. Must be called after `time_init()`.
-static void early_init(mparm_T *paramp)
+void early_init(bool clean_arg)
 {
   env_init();
   fs_init();
@@ -222,7 +222,7 @@ static void early_init(mparm_T *paramp)
   // msg_outtrans_len_attr().
   // First find out the home directory, needed to expand "~" in options.
   init_homedir();               // find real value of $HOME
-  set_init_1(paramp->clean);
+  set_init_1(clean_arg);
   log_init();
   TIME_MSG("inits 1");
 
@@ -268,7 +268,7 @@ int main(int argc, char **argv)
 
   event_init();
 
-  early_init(&params);
+  early_init(&params.clean);
 
   // Check if we have an interactive window.
   check_and_set_isatty(&params);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -501,11 +501,11 @@ static inline char *add_dir(char *dest, const char *const dir,
 ///
 /// Windows: Uses "…/nvim-data" for kXDGDataHome to avoid storing
 /// configuration and data files in the same path. #4403
-static void set_runtimepath_default(void)
+static void set_runtimepath_default(bool clean_arg)
 {
   size_t rtp_size = 0;
   char *const data_home = stdpaths_get_xdg_var(kXDGDataHome);
-  char *const config_home = stdpaths_get_xdg_var(kXDGConfigHome);
+  char *const config_home = clean_arg ? NULL : stdpaths_get_xdg_var(kXDGConfigHome);
   char *const vimruntime = vim_getenv("VIMRUNTIME");
   char *const data_dirs = stdpaths_get_xdg_var(kXDGDataDirs);
   char *const config_dirs = stdpaths_get_xdg_var(kXDGConfigDirs);
@@ -590,8 +590,9 @@ static void set_runtimepath_default(void)
  * Initialize the options, first part.
  *
  * Called only once from main(), just after creating the first buffer.
+ * If "clean_arg" is TRUE Vim was started with --clean.
  */
-void set_init_1(void)
+void set_init_1(bool clean_arg)
 {
   int opt_idx;
 
@@ -734,7 +735,7 @@ void set_init_1(void)
                      true);
   // Set default for &runtimepath. All necessary expansions are performed in
   // this function.
-  set_runtimepath_default();
+  set_runtimepath_default(clean_arg);
 
   /*
    * Set all the options (except the terminal options) to their default


### PR DESCRIPTION
Problem:    Custom plugins loaded with --clean.
Solution:   Do not include the home directory in 'runtimepath'.
https://github.com/vim/vim/commit/072687032683b1994d25a114893d9a6f8bc36612

TODO:

- [ ] https://github.com/vim/vim/issues/5537