### PR TITLE
Fix shift change callbacks reading bad cursor

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -221,8 +221,6 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
     ++curwin->w_cursor.lnum;
   }
 
-  changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
-
   if (oap->motion_type == kMTBlockWise) {
     curwin->w_cursor.lnum = oap->start.lnum;
     curwin->w_cursor.col = block_col;
@@ -264,6 +262,8 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
   curbuf->b_op_end.col = (colnr_T)STRLEN(ml_get(oap->end.lnum));
   if (curbuf->b_op_end.col > 0)
     --curbuf->b_op_end.col;
+
+  changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
 }
 
 // Shift the current line one shiftwidth left (if left != 0) or right

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -260,8 +260,9 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
   curbuf->b_op_start = oap->start;
   curbuf->b_op_end.lnum = oap->end.lnum;
   curbuf->b_op_end.col = (colnr_T)STRLEN(ml_get(oap->end.lnum));
-  if (curbuf->b_op_end.col > 0)
-    --curbuf->b_op_end.col;
+  if (curbuf->b_op_end.col > 0) {
+    curbuf->b_op_end.col--;
+  }
 
   changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
 }

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -1,9 +1,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq, ok = helpers.eq, helpers.ok
-local buffer, command, meths, eval, nvim, next_msg, exec_lua = helpers.buffer,
-	helpers.command, helpers.meths, helpers.eval, helpers.nvim, helpers.next_msg,
-	helpers.exec_lua
+local buffer, command, eval, nvim, next_msg = helpers.buffer,
+  helpers.command, helpers.eval, helpers.nvim, helpers.next_msg
 local nvim_prog = helpers.nvim_prog
 local pcall_err = helpers.pcall_err
 local sleep = helpers.sleep
@@ -860,20 +859,6 @@ describe('API: buffer events:', function()
     local s = string.rep('\nxyz', 30)
     sendkeys(s)
     assert_match_somewhere(expected_lines, buffer_lines)
-  end)
-
-  it('has valid cursor position while shifting', function()
-	  clear()
-	  local b = open(false, {'line1'})
-	  exec_lua([[
-	  vim.api.nvim_buf_attach(vim.api.nvim_get_current_buf(), false, {
-		  on_lines = function()
-			  vim.api.nvim_set_var('listener_cursor_line', vim.api.nvim_win_get_cursor(0)[1])
-		  end,
-		  })
-	  ]])
-	  sendkeys('>>')
-	  eq(1, meths.get_var('listener_cursor_line'))
   end)
 
 end)

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -1,8 +1,9 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq, ok = helpers.eq, helpers.ok
-local buffer, command, eval, nvim, next_msg = helpers.buffer,
-  helpers.command, helpers.eval, helpers.nvim, helpers.next_msg
+local buffer, command, meths, eval, nvim, next_msg, exec_lua = helpers.buffer,
+	helpers.command, helpers.meths, helpers.eval, helpers.nvim, helpers.next_msg,
+	helpers.exec_lua
 local nvim_prog = helpers.nvim_prog
 local pcall_err = helpers.pcall_err
 local sleep = helpers.sleep
@@ -859,6 +860,20 @@ describe('API: buffer events:', function()
     local s = string.rep('\nxyz', 30)
     sendkeys(s)
     assert_match_somewhere(expected_lines, buffer_lines)
+  end)
+
+  it('has valid cursor position while shifting', function()
+	  clear()
+	  local b = open(false, {'line1'})
+	  exec_lua([[
+	  vim.api.nvim_buf_attach(vim.api.nvim_get_current_buf(), false, {
+		  on_lines = function()
+			  vim.api.nvim_set_var('listener_cursor_line', vim.api.nvim_win_get_cursor(0)[1])
+		  end,
+		  })
+	  ]])
+	  sendkeys('>>')
+	  eq(1, meths.get_var('listener_cursor_line'))
   end)
 
 end)

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -203,4 +203,17 @@ describe('lua: buffer event callbacks', function()
         { "test1", "lines", 1, tick+1, 5, 6, 5, 27, 20, 20 }}, exec_lua("return get_events(...)" ))
   end)
 
+  it('has valid cursor position while shifting', function()
+    meths.buf_set_lines(0, 0, -1, true, {'line1'})
+    exec_lua([[
+      vim.api.nvim_buf_attach(0, false, {
+        on_lines = function()
+          vim.api.nvim_set_var('listener_cursor_line', vim.api.nvim_win_get_cursor(0)[1])
+        end,
+      })
+    ]])
+    feed('>>')
+    eq(1, meths.get_var('listener_cursor_line'))
+  end)
+
 end)


### PR DESCRIPTION
Sloppy code inherited from Vim caused user scripts to be able to observe the cursor line in an invalid intermediary state, due to Neovim change callbacks being unbuffered unlike Vim listeners.

Manifested in Vimscript executed from the callback possibly erroring when `:call`:ing any function, due to the implicit range `curwin->w_cursor.lnum,curwin->w_cursor.lnum` failing validation.

Fixed by deferring the call to `changed_lines()` until after `curwin->w_cursor.lnum` gets its correct value.

Maybe `nvim_call_function()` should be made to perform the same assertions on range validity that `:call` does, to make catching similar errors easier in the future. Possible that other cases of this exist.