### PR TITLE
win/TUI: Use virtual terminal input if available

### DIFF
--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -11,6 +11,9 @@
 #include "nvim/rbuffer.h"
 #include "nvim/macros.h"
 #include "nvim/event/stream.h"
+#ifdef WIN32
+# include "nvim/os/os_win_console.h"
+#endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "event/stream.c.generated.h"
@@ -19,10 +22,6 @@
 // For compatbility with libuv < 1.19.0 (tested on 1.18.0)
 #if UV_VERSION_MINOR < 19
 #define uv_stream_get_write_queue_size(stream) stream->write_queue_size
-#endif
-
-#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
-# define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
 #endif
 
 /// Sets the stream associated with `fd` to "blocking" mode.

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -21,6 +21,10 @@
 #define uv_stream_get_write_queue_size(stream) stream->write_queue_size
 #endif
 
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+# define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+#endif
+
 /// Sets the stream associated with `fd` to "blocking" mode.
 ///
 /// @return `0` on success, or libuv error code on failure.
@@ -62,6 +66,11 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream)
       if (type == UV_TTY) {
         uv_tty_init(&loop->uv, &stream->uv.tty, fd, 0);
         uv_tty_set_mode(&stream->uv.tty, UV_TTY_MODE_RAW);
+        DWORD dwMode;
+        if (GetConsoleMode(stream->uv.tty.handle, &dwMode)) {
+          dwMode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+          SetConsoleMode(stream->uv.tty.handle, dwMode);
+        }
         stream->uvstream = STRUCT_CAST(uv_stream_t, &stream->uv.tty);
       } else {
 #endif

--- a/src/nvim/os/os_win_console.h
+++ b/src/nvim/os/os_win_console.h
@@ -5,4 +5,8 @@
 # include "os/os_win_console.h.generated.h"
 #endif
 
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+# define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+#endif
+
 #endif  // NVIM_OS_OS_WIN_CONSOLE_H

--- a/src/nvim/os/tty.c
+++ b/src/nvim/os/tty.c
@@ -28,7 +28,7 @@ void os_tty_guess_term(const char **term, int out_fd)
   if (winpty) {
     // Force TERM=win32con when running in winpty.
     *term = "win32con";
-    uv_set_vterm_state(UV_UNSUPPORTED);
+    uv_tty_set_vterm_state(UV_TTY_UNSUPPORTED);
     return;
   }
 
@@ -55,7 +55,7 @@ void os_tty_guess_term(const char **term, int out_fd)
   }
 
   if (conemu_ansi) {
-    uv_set_vterm_state(UV_SUPPORTED);
+    uv_tty_set_vterm_state(UV_TTY_SUPPORTED);
   }
 }
 #endif

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -135,12 +135,11 @@ include(ExternalProject)
 
 if(WIN32)
   # "nvim" branch of https://github.com/neovim/libuv
-  set(LIBUV_URL https://github.com/neovim/libuv/archive/d5ff3004d26b9bb863b76247399a9c72a0ff184c.tar.gz)
-  set(LIBUV_SHA256 0f5dfd92269713ed275273966ed73578fc68db669c509b01210cd58c1cf6361d)
+  set(LIBUV_URL https://github.com/neovim/libuv/archive/b899d12b0d56d217f31222da83f8c398355b69ef.tar.gz)
+  set(LIBUV_SHA256 eb7e37b824887e1b31a4e31d1d9bad4c03d8b98532d9cce5f67a3b70495a4b2a)
 else()
-  # blueyed/nvim-fixes (for *BSD build fixes).
-  set(LIBUV_URL https://github.com/blueyed/libuv/archive/2af4cf2.tar.gz)
-  set(LIBUV_SHA256 SKIP)
+  set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.34.2.tar.gz)
+  set(LIBUV_SHA256 0d9d38558b45c006c1ea4e8529bae64caf8becda570295ea74e3696362aeb7f2)
 endif()
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0/msgpack-3.0.0.tar.gz)


### PR DESCRIPTION
fixes #9514.

The following issues are also fixed on Windows where virtual terminal input is available.

- #8435(may be).
- #11773.
