### PR TITLE
[RDY] win: make UV_OVERLAPPED_PIPE optional

### DIFF
--- a/runtime/autoload/provider.vim
+++ b/runtime/autoload/provider.vim
@@ -3,8 +3,11 @@
 " Start the provider and perform a 'poll' request
 "
 " Returns a valid channel on success
-function! provider#Poll(argv, orig_name, log_env) abort
+function! provider#Poll(argv, orig_name, log_env, ...) abort
   let job = {'rpc': v:true, 'stderr_buffered': v:true}
+  if a:0
+    let job = extend(job, a:1)
+  endif
   try
     let channel_id = jobstart(a:argv, job)
     if channel_id > 0 && rpcrequest(channel_id, 'poll') ==# 'ok'

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -19,7 +19,7 @@ function! provider#pythonx#Require(host) abort
     call add(args, plugin.path)
   endfor
 
-  return provider#Poll(args, a:host.orig_name, '$NVIM_PYTHON_LOG_FILE')
+  return provider#Poll(args, a:host.orig_name, '$NVIM_PYTHON_LOG_FILE', {'overlapped': v:true})
 endfunction
 
 function! s:get_python_executable_from_host_var(major_version) abort

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5506,6 +5506,11 @@ jobstart({cmd}[, {opts}])				*jobstart()*
 			      stdout data.
 		  |on_stderr|:  (function) Callback invoked when the job emits
 			      stderr data.
+		  overlapped: (boolean) Set FILE_FLAG_OVERLAPPED for the
+			      standard input/output passed to the child process.
+			      Normally you do not need to set this.
+			      (Only available on MS-Windows, On other
+			      platforms, this option is silently ignored.)
 		  pty:	      (boolean) Connect the job to a new pseudo
 			      terminal, and its streams to the master file
 			      descriptor. Then  `on_stderr` is ignored,

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -301,7 +301,8 @@ static void close_cb(Stream *stream, void *data)
 /// @returns [allocated] channel
 Channel *channel_job_start(char **argv, CallbackReader on_stdout,
                            CallbackReader on_stderr, Callback on_exit,
-                           bool pty, bool rpc, bool detach, const char *cwd,
+                           bool pty, bool rpc, bool overlapped, bool detach,
+                           const char *cwd,
                            uint16_t pty_width, uint16_t pty_height,
                            char *term_name, char **env, varnumber_T *status_out)
 {
@@ -342,6 +343,7 @@ Channel *channel_job_start(char **argv, CallbackReader on_stdout,
   proc->detach = detach;
   proc->cwd = cwd;
   proc->env = env;
+  proc->overlapped = overlapped;
 
   char *cmd = xstrdup(proc->argv[0]);
   bool has_out, has_err;

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -52,7 +52,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   if (!proc->in.closed) {
     uvproc->uvstdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
 #ifdef WIN32
-    uvproc->uvstdio[0].flags |= UV_OVERLAPPED_PIPE;
+    uvproc->uvstdio[0].flags |= proc->overlapped ? UV_OVERLAPPED_PIPE : 0;
 #endif
     uvproc->uvstdio[0].data.stream = STRUCT_CAST(uv_stream_t,
                                                  &proc->in.uv.pipe);
@@ -61,8 +61,9 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   if (!proc->out.closed) {
     uvproc->uvstdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
 #ifdef WIN32
-    // pipe must be readable for IOCP to work.
-    uvproc->uvstdio[1].flags |= UV_READABLE_PIPE | UV_OVERLAPPED_PIPE;
+    // pipe must be readable for IOCP to work on Windows.
+    uvproc->uvstdio[1].flags |= proc->overlapped ?
+      (UV_READABLE_PIPE | UV_OVERLAPPED_PIPE) : 0;
 #endif
     uvproc->uvstdio[1].data.stream = STRUCT_CAST(uv_stream_t,
                                                  &proc->out.uv.pipe);

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -27,7 +27,7 @@ struct process {
   Stream in, out, err;
   process_exit_cb cb;
   internal_process_cb internal_exit_cb, internal_close_cb;
-  bool closed, detach;
+  bool closed, detach, overlapped;
   MultiQueue *events;
 };
 


### PR DESCRIPTION
When `UV_OVERLAPPED_PIPE` was used for the pipe passed to the child process, a problem occurred with the standard input of the .Net Framework application (#11809).
This was probably only needed for `rpc`. And so far, this setting has not caused any problems for applications that require `rpc`.

fixes #11809.