### PR TITLE
API: nvim_buf_set_text

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -362,22 +362,9 @@ void nvim_buf_set_lines(uint64_t channel_id,
     return;
   }
 
-  for (size_t i = 0; i < replacement.size; i++) {
-    if (replacement.items[i].type != kObjectTypeString) {
-      api_set_error(err,
-                    kErrorTypeValidation,
-                    "All items in the replacement array must be strings");
-      return;
-    }
-    // Disallow newlines in the middle of the line.
-    if (channel_id != VIML_INTERNAL_CALL) {
-      const String l = replacement.items[i].data.string;
-      if (memchr(l.data, NL, l.size)) {
-        api_set_error(err, kErrorTypeValidation,
-                      "String cannot contain newlines");
-        return;
-      }
-    }
+  bool disallow_nl = (channel_id != VIML_INTERNAL_CALL);
+  if (!check_string_array(replacement, disallow_nl, err)) {
+    return;
   }
 
   size_t new_len = replacement.size;
@@ -466,7 +453,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust marks if we managed to switch to a window that holds
+  // Only adjust mapks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start,
               (linenr_T)(end - 1),
@@ -483,6 +470,173 @@ end:
   }
 
   xfree(lines);
+  aucmd_restbuf(&aco);
+  try_end(err);
+}
+
+void nvim_buf_set_text(uint64_t channel_id,
+                       Buffer buffer,
+                       Integer start_row,
+                       Integer start_col,
+                       Integer end_row,
+                       Integer end_col,
+                       ArrayOf(String) replacement,
+                       Error *err)
+  FUNC_API_SINCE(7)
+{
+  // TODO: treat [] as [''] for convenience
+  assert(replacement.size > 0);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+  if (!buf) {
+    return;
+  }
+  size_t new_len = replacement.size;
+
+  // TODO: do the nl-for-NUL dance as well?
+  bool disallow_nl = (channel_id != VIML_INTERNAL_CALL);
+  if (!check_string_array(replacement, disallow_nl, err)) {
+    return;
+  }
+
+  // TODO: check range is ordered and everything!
+  // start_row, end_row within buffer len (except add text past the end?)
+  char *str_at_start = (char *)ml_get_buf(buf, start_row+1, false);
+  if (start_col < 0 || (size_t)start_col > strlen(str_at_start)) {
+    api_set_error(err, kErrorTypeValidation, "start_col out of bounds");
+    return;
+  }
+
+  char *str_at_end = (char *)ml_get_buf(buf, end_row+1, false);
+  size_t len_at_end = strlen(str_at_end);
+  if (end_col < 0 || (size_t)end_col > len_at_end) {
+    api_set_error(err, kErrorTypeValidation, "end_col out of bounds");
+    return;
+  }
+
+  String first_item = replacement.items[0].data.string;
+  String last_item = replacement.items[replacement.size-1].data.string;
+  size_t firstlen = (size_t)start_col+first_item.size;
+  size_t last_part_len = strlen(str_at_end) - (size_t)end_col;
+  if (replacement.size == 1) {
+    firstlen += last_part_len;
+  }
+  char *first = xmallocz(firstlen), *last = NULL;
+  memcpy(first, str_at_start, (size_t)start_col);
+  memcpy(first+start_col, first_item.data, first_item.size);
+  if (replacement.size == 1) {
+    memcpy(first+start_col+first_item.size, str_at_end+end_col, last_part_len);
+  } else {
+    last = xmallocz(last_item.size+last_part_len);
+    memcpy(last, last_item.data, last_item.size);
+    memcpy(last+last_item.size, str_at_end+end_col, last_part_len);
+  }
+
+  char **lines = (new_len != 0) ? xcalloc(new_len, sizeof(char *)) : NULL;
+  lines[0] = first;
+  for (size_t i = 1; i < new_len-1; i++) {
+    lines[i] = replacement.items[i].data.string.data;
+  }
+  if (replacement.size > 1) {
+    lines[replacement.size-1] = last;
+  }
+
+  try_start();
+  aco_save_T aco;
+  aucmd_prepbuf(&aco, (buf_T *)buf);
+
+  if (!MODIFIABLE(buf)) {
+    api_set_error(err, kErrorTypeException, "Buffer is not 'modifiable'");
+    goto end;
+  }
+
+  // TODO: dubbel KOLLA KOLLA indexen här
+  if (u_save((linenr_T)start_row, (linenr_T)end_row+2) == FAIL) {
+    api_set_error(err, kErrorTypeException, "Failed to save undo information");
+    goto end;
+  }
+
+
+  ptrdiff_t extra = 0;  // lines added to text, can be negative
+  size_t old_len = (size_t)(end_row-start_row+1);
+
+  // If the size of the range is reducing (ie, new_len < old_len) we
+  // need to delete some old_len. We do this at the start, by
+  // repeatedly deleting line "start".
+  size_t to_delete = (new_len < old_len) ? (size_t)(old_len - new_len) : 0;
+  for (size_t i = 0; i < to_delete; i++) {
+    if (ml_delete((linenr_T)start_row+1, false) == FAIL) {
+      api_set_error(err, kErrorTypeException, "Failed to delete line");
+      goto end;
+    }
+  }
+
+  if (to_delete > 0) {
+    extra -= (ptrdiff_t)to_delete;
+  }
+
+  // For as long as possible, replace the existing old_len with the
+  // new old_len. This is a more efficient operation, as it requires
+  // less memory allocation and freeing.
+  size_t to_replace = old_len < new_len ? old_len : new_len;
+  for (size_t i = 0; i < to_replace; i++) {
+    int64_t lnum = start_row + 1 + (int64_t)i;
+
+    if (lnum >= MAXLNUM) {
+      api_set_error(err, kErrorTypeValidation, "Index value is too high");
+      goto end;
+    }
+
+    if (ml_replace((linenr_T)lnum, (char_u *)lines[i], false) == FAIL) {
+      api_set_error(err, kErrorTypeException, "Failed to replace line");
+      goto end;
+    }
+    // Mark lines that haven't been passed to the buffer as they need
+    // to be freed later
+    lines[i] = NULL;
+  }
+
+  // Now we may need to insert the remaining new old_len
+  for (size_t i = to_replace; i < new_len; i++) {
+    int64_t lnum = start_row + (int64_t)i;
+
+    if (lnum >= MAXLNUM) {
+      api_set_error(err, kErrorTypeValidation, "Index value is too high");
+      goto end;
+    }
+
+    if (ml_append((linenr_T)lnum, (char_u *)lines[i], 0, false) == FAIL) {
+      api_set_error(err, kErrorTypeException, "Failed to insert line");
+      goto end;
+    }
+
+    // Same as with replacing, but we also need to free lines
+    xfree(lines[i]);
+    lines[i] = NULL;
+    extra++;
+  }
+
+  // Adjust marks. Invalidate any which lie in the
+  // changed range, and move any in the remainder of the buffer.
+  // Only adjust mapks if we managed to switch to a window that holds
+  // the buffer, otherwise line numbers will be invalid.
+  mark_adjust((linenr_T)start_row,
+              (linenr_T)end_row,
+              MAXLNUM,
+              (long)extra,
+              kExtmarkNOOP);
+
+  colnr_T col_extent = (colnr_T)(end_col
+                                 - ((end_row > start_col) ? start_col : 0));
+  extmark_splice(buf, (int)start_row, (colnr_T)start_col,
+                 (int)(end_row-start_row), col_extent,
+                 (int)new_len-1, (colnr_T)last_item.size, kExtmarkUndo);
+
+  changed_lines((linenr_T)start_row+1, 0, (linenr_T)end_row+1, (long)extra, true);
+
+  // TODO: adjust cursor like an extmark ( i e it was inside last_part_len)
+  fix_cursor((linenr_T)start_row+1, (linenr_T)end_row+1, (linenr_T)extra);
+
+end:
   aucmd_restbuf(&aco);
   try_end(err);
 }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -560,6 +560,23 @@ void extmark_adjust(buf_T *buf,
                       new_row, 0, new_byte, undo);
 }
 
+// Adjust extmarks following a text edit.
+//
+// @param buf
+// @param start_row   Start row of the region to be changed
+// @param start_col   Start col of the region to be changed
+// @param old_row     End row of the region to be changed.
+//                      Encoded as an offset to start_row.
+// @param old_col     End col of the region to be changed. Encodes
+//                      an offset from start_col if old_row = 0; otherwise,
+//                      encodes the end column of the old region.
+// @param old_byte    Byte extent of the region to be changed.
+// @param new_row     Row offset of the new region.
+// @param new_col     Col offset of the new region. Encodes an offset from
+//                      start_col if new_row = 0; otherwise, encodes
+//                      the end column of the new region.
+// @param new_byte    Byte extent of the new region.
+// @param undo
 void extmark_splice(buf_T *buf,
                     int start_row, colnr_T start_col,
                     int old_row, colnr_T old_col, bcount_t old_byte,

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -392,6 +392,89 @@ describe('api/buf', function()
     end)
   end)
 
+  describe('nvim_buf_get_lines, nvim_buf_set_text', function()
+    local get_lines, set_text = curbufmeths.get_lines, curbufmeths.set_text
+    local line_count = curbufmeths.line_count
+
+    it('works', function()
+      insert([[
+      hello foo!
+      text
+      ]])
+
+      eq({'hello foo!'}, get_lines(0, 1, true))
+
+
+      -- can replace a single word
+      set_text(0, 6, 0, 9, {'world'})
+      eq({'hello world!', 'text'}, get_lines(0, 2, true))
+
+      -- can replace with multiple lines
+      local err = set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
+      eq({'hello foo', 'wo', 'more!', 'text'}, get_lines(0,  4, true))
+
+      -- will join multiple lines if needed
+      set_text(0, 6, 3, 4, {'bar'})
+      eq({'hello bar'}, get_lines(0,  1, true))
+    end)
+
+    it('updates the cursor position', function()
+      insert([[
+      hello world!
+      ]])
+
+      -- position the cursor on `!`
+      curwin('set_cursor', {1, 11})
+      -- replace 'world' with 'foo'
+      set_text(0, 6, 0, 11, {'foo'})
+      eq('hello foo!', curbuf_depr('get_line', 0))
+      -- cursor should be moved left by two columns (replacement is shorter by 2 chars)
+      eq({1, 9}, curwin('get_cursor'))
+    end)
+
+    it('can handle NULs', function()
+      set_text(0, 0, 0, 0, {'ab\0cd'})
+      eq('ab\0cd', curbuf_depr('get_line', 0))
+    end)
+
+    it('adjusts extmarks', function()
+      local ns = request('nvim_create_namespace', "my-fancy-plugin")
+      insert([[
+      foo bar
+      baz
+      ]])
+      local id1 = curbufmeths.set_extmark(ns, 0, 0, 1, {})
+      local id2 = curbufmeths.set_extmark(ns, 0, 0, 7, {})
+      local id3 = curbufmeths.set_extmark(ns, 0, 1, 1, {})
+      set_text(0, 4, 0, 7, {"q"})
+
+      -- TODO: if we set text at 0,3, what happens to the mark at 0,3
+
+      eq({'foo q', 'baz'}, get_lines(0, 2, true))
+      -- mark before replacement point is unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id1)
+      eq({0, 1}, rv)
+      -- mark gets shifted back because the replacement was shorter
+      rv = curbufmeths.get_extmark_by_id(ns, id2)
+      eq({0, 5}, rv)
+      -- mark on the next line is unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id3)
+      eq({1, 1}, rv)
+
+      -- replacing the text spanning two lines will adjust the mark on the next line
+      set_text(0, 3, 1, 3, {"qux"})
+      rv = curbufmeths.get_extmark_by_id(ns, id3)
+      eq({'fooqux', ''}, get_lines(0, 2, true))
+      eq({0, 6}, rv)
+      -- but mark before replacement point is still unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id1)
+      eq({0, 1}, rv)
+      -- and the mark in the middle was shifted to the end of the insertion
+      rv = curbufmeths.get_extmark_by_id(ns, id2)
+      eq({0, 6}, rv)
+    end)
+  end)
+
   describe('nvim_buf_get_offset', function()
     local get_offset = curbufmeths.get_offset
     it('works', function()

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -394,7 +394,6 @@ describe('api/buf', function()
 
   describe('nvim_buf_get_lines, nvim_buf_set_text', function()
     local get_lines, set_text = curbufmeths.get_lines, curbufmeths.set_text
-    local line_count = curbufmeths.line_count
 
     it('works', function()
       insert([[
@@ -418,7 +417,7 @@ describe('api/buf', function()
       eq({'hello world!', 'text'}, get_lines(0, 2, true))
 
       -- can replace with multiple lines
-      local err = set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
+      set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
       eq({'hello foo', 'wo', 'more!', 'text'}, get_lines(0,  4, true))
 
       -- will join multiple lines if needed
@@ -426,25 +425,10 @@ describe('api/buf', function()
       eq({'hello bar'}, get_lines(0,  1, true))
     end)
 
-    pending('can handle multibyte characters', function()
-        insert([[
-        hellØ world!
-        ]])
-
-        eq({'hellØ world!'}, get_lines(0, 1, true))
-
-        -- inserting multibyte
-        set_text(0, 11, 0, 11, {'Ø'})
-        eq({'hellØ worldØ!'}, get_lines(0, 1, true))
-
-        -- deleting multibyte
-        set_text(0, 0, 0, 6, {''})
-        eq({'worldØ!'}, get_lines(0, 1, true))
-    end)
-
     it('works with undo', function()
         insert([[
         hello world!
+        foo bar
         ]])
 
         -- setting text
@@ -459,6 +443,11 @@ describe('api/buf', function()
 
         -- inserting newlines
         set_text(0, 0, 0, 0, {'hello', 'mr '})
+        feed('u')
+        eq({'hello world!'}, get_lines(0, 1, true))
+
+        -- deleting newlines
+        set_text(0, 0, 1, 4, {'hello'})
         feed('u')
         eq({'hello world!'}, get_lines(0, 1, true))
     end)
@@ -493,30 +482,36 @@ describe('api/buf', function()
       local id3 = curbufmeths.set_extmark(ns, 1, 1, {})
       set_text(0, 4, 0, 7, {"q"})
 
-      -- TODO: if we set text at 0,3, what happens to the mark at 0,3
-
       eq({'foo q', 'baz'}, get_lines(0, 2, true))
       -- mark before replacement point is unaffected
-      rv = curbufmeths.get_extmark_by_id(ns, id1, {})
-      eq({0, 1}, rv)
+      eq({0, 1}, curbufmeths.get_extmark_by_id(ns, id1, {}))
       -- mark gets shifted back because the replacement was shorter
-      rv = curbufmeths.get_extmark_by_id(ns, id2, {})
-      eq({0, 5}, rv)
+      eq({0, 5}, curbufmeths.get_extmark_by_id(ns, id2, {}))
       -- mark on the next line is unaffected
-      rv = curbufmeths.get_extmark_by_id(ns, id3, {})
-      eq({1, 1}, rv)
+      eq({1, 1}, curbufmeths.get_extmark_by_id(ns, id3, {}))
 
       -- replacing the text spanning two lines will adjust the mark on the next line
       set_text(0, 3, 1, 3, {"qux"})
-      rv = curbufmeths.get_extmark_by_id(ns, id3, {})
       eq({'fooqux', ''}, get_lines(0, 2, true))
-      eq({0, 6}, rv)
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id3, {}))
       -- but mark before replacement point is still unaffected
-      rv = curbufmeths.get_extmark_by_id(ns, id1, {})
-      eq({0, 1}, rv)
+      eq({0, 1}, curbufmeths.get_extmark_by_id(ns, id1, {}))
       -- and the mark in the middle was shifted to the end of the insertion
-      rv = curbufmeths.get_extmark_by_id(ns, id2, {})
-      eq({0, 6}, rv)
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id2, {}))
+
+      -- marks should be put back into the same place after undoing
+      set_text(0, 0, 0, 2, {''})
+      feed('u')
+      eq({0, 1}, curbufmeths.get_extmark_by_id(ns, id1, {}))
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id2, {}))
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id3, {}))
+
+	  -- marks should be shifted over by the correct number of bytes for multibyte
+	  -- chars
+	  set_text(0, 0, 0, 0, {'Ø'})
+	  eq({0, 3}, curbufmeths.get_extmark_by_id(ns, id1, {}))
+	  eq({0, 8}, curbufmeths.get_extmark_by_id(ns, id2, {}))
+	  eq({0, 8}, curbufmeths.get_extmark_by_id(ns, id3, {}))
     end)
   end)
 


### PR DESCRIPTION
Sketch on an API function that allows you to change an arbitrary charwise region, both joining and splitting lines if needed, and fully preserve extmarks.

NB: stream of consciousness draft. Half of the code is the same as set_lines, I will try to merge them. Perhaps `set_text` can take a `mode` flag so it covers both usecases (perhaps even block mode, but block semantics are messy and intricate. Could shell out to ops.c for that, i e fake delete/put)