### PR TITLE
lsp: set InitializeParams.rootPath value

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -452,7 +452,7 @@ function lsp.start_client(config)
       -- The rootPath of the workspace. Is null if no folder is open.
       --
       -- @deprecated in favour of rootUri.
-      rootPath = nil;
+      rootPath = config.root_dir;
       -- The rootUri of the workspace. Is null if no folder is open. If both
       -- `rootPath` and `rootUri` are set `rootUri` wins.
       rootUri = vim.uri_from_fname(config.root_dir);


### PR DESCRIPTION
InitializeParams.rootPath is deprecated now. But some language servers still use it.

ex) vue-language-server
https://github.com/vuejs/vetur/blob/988bdb7db0cc8391b414dfcab076147656db83e2/server/src/services/vls.ts#L90-L92
