### PR TITLE
Use $VIM to specify system-global runtime directory

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -378,7 +378,7 @@ See also
 System-global
 .Nm
 configuration file.
-.It Pa /usr/local/share/nvim
+.It Pa $VIM/nvim
 System-global
 .Nm
 runtime directory.


### PR DESCRIPTION
Evidence: I tried modifying `/usr/local/share/nvim` on Debian 10 and it didn't work. It only worked when I modified `/usr/share/nvim`. In fact, when I checked the `$VIM`, it is exactly equal to `/usr/share/nvim`.