### PR TITLE
lsp: Support text edit on inactive buffer

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -88,9 +88,8 @@ function M.apply_text_edits(text_edits, bufnr)
   -- Reverse sort the orders so we can apply them without interfering with
   -- eachother. Also add i as a sort key to mimic a stable sort.
   table.sort(cleaned, edit_sort_key)
-  local current_bufnr = api.nvim_get_current_buf()
   if not api.nvim_buf_is_loaded(bufnr) then
-    api.nvim_set_current_buf(bufnr)
+    vim.fn.bufload(bufnr)
   end
   local lines = api.nvim_buf_get_lines(bufnr, start_line, finish_line + 1, false)
   local fix_eol = api.nvim_buf_get_option(bufnr, 'fixeol')
@@ -109,9 +108,6 @@ function M.apply_text_edits(text_edits, bufnr)
     table.remove(lines)
   end
   api.nvim_buf_set_lines(bufnr, start_line, finish_line + 1, false, lines)
-  if bufnr ~= current_bufnr then
-    api.nvim_set_current_buf(current_bufnr)
-  end
 end
 
 -- local valid_windows_path_characters = "[^<>:\"/\\|?*]"

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -88,6 +88,10 @@ function M.apply_text_edits(text_edits, bufnr)
   -- Reverse sort the orders so we can apply them without interfering with
   -- eachother. Also add i as a sort key to mimic a stable sort.
   table.sort(cleaned, edit_sort_key)
+  local current_bufnr = api.nvim_get_current_buf()
+  if not api.nvim_buf_is_loaded(bufnr) then
+    api.nvim_set_current_buf(bufnr)
+  end
   local lines = api.nvim_buf_get_lines(bufnr, start_line, finish_line + 1, false)
   local fix_eol = api.nvim_buf_get_option(bufnr, 'fixeol')
   local set_eol = fix_eol and api.nvim_buf_line_count(bufnr) <= finish_line + 1
@@ -105,6 +109,9 @@ function M.apply_text_edits(text_edits, bufnr)
     table.remove(lines)
   end
   api.nvim_buf_set_lines(bufnr, start_line, finish_line + 1, false, lines)
+  if bufnr ~= current_bufnr then
+    api.nvim_set_current_buf(current_bufnr)
+  end
 end
 
 -- local valid_windows_path_characters = "[^<>:\"/\\|?*]"


### PR DESCRIPTION
Using `vim.lsp.buf.rename()` can result in receiving a TextEdit that
affects a file for which there is no active buffer.

In that case `api.nvim_buf_get_lines(...)` returned an empty result,
leading to an error.

Closes https://github.com/neovim/neovim/issues/11790