### PR TITLE
doc/manpage: Remove the extra nvim subdirectory

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -378,7 +378,7 @@ See also
 System-global
 .Nm
 configuration file.
-.It Pa $VIM/nvim
+.It Pa $VIM
 System-global
 .Nm
 runtime directory.


### PR DESCRIPTION
This is an amend to #11840. `$VIM` already includes `/nvim` subdirectory, i.e. `/usr/share/nvim` on Debian 10, and `/nix/store/gsqk6xgz8780xn99kji2h4bzq20imv87-neovim-unwrapped-0.4.3/share/nvim` on Nixos unstable.