### PR TITLE
[RDY] mouse.c: can click on multibyte foldopen/foldclose

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -109,12 +109,12 @@ retnomove:
   if (flags & MOUSE_SETPOS)
     goto retnomove;                             // ugly goto...
 
-  // Remember the character under the mouse, it might be a '-' or '+' in the
-  // fold column. NB: only works for ASCII chars!
+  // Remember the character under the mouse, might be one of foldclose or
+  // foldopen fillchars in the fold column.
   if (row >= 0 && row < Rows && col >= 0 && col <= Columns
       && default_grid.chars != NULL) {
-    mouse_char = default_grid.chars[default_grid.line_offset[row]
-                                    + (unsigned)col][0];
+     mouse_char = utf_ptr2char(default_grid.chars[default_grid.line_offset[row]
+                                                  + (unsigned)col]);
   } else {
     mouse_char = ' ';
   }

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -96,8 +96,20 @@ describe("folded lines", function()
       {1:                                            ~}|
       :set rightleft                               |
     ]]}
-  end)
 
+    feed_command("set norightleft")
+    meths.input_mouse('left', 'press', '', 0, 0, 1)
+    screen:expect{grid=[[
+    {7:▾▸}{5:^+---  5 lines: aa··························}|
+    {7:│ }ff                                         |
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+    :set norightleft                             |
+    ]]}
+  end)
 
   it("works with multibyte text", function()
     -- Currently the only allowed value of 'maxcombine'


### PR DESCRIPTION
would previously only work with ascii fillchars.

Added a test.