### PR TITLE
[RDY] lua: vim.deepcopy and vim.tbl_extend use empty_dict() instead of {} for empty_dict()

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -21,7 +21,7 @@ vim.deepcopy = (function()
     table = function(orig)
       local copy = {}
 
-      if getmetatable(orig) == vim._empty_dict_mt then
+      if vim._empty_dict_mt ~= nil and getmetatable(orig) == vim._empty_dict_mt then
         copy = vim.empty_dict()
       end
 
@@ -174,9 +174,19 @@ function vim.tbl_extend(behavior, ...)
   if (behavior ~= 'error' and behavior ~= 'keep' and behavior ~= 'force') then
     error('invalid "behavior": '..tostring(behavior))
   end
+
+  if select('#', ...) < 2 then
+    error('wrong number of arguments (given '..tostring(1 + select('#', ...))..', expected at least 3)')
+  end
+
   local ret = {}
+  if vim._empty_dict_mt ~= nil and getmetatable(select(1, ...)) == vim._empty_dict_mt then
+    ret = vim.empty_dict()
+  end
+
   for i = 1, select('#', ...) do
     local tbl = select(i, ...)
+    vim.validate{["after the second argument"] = {tbl,'t'}}
     if tbl then
       for k, v in pairs(tbl) do
         if behavior ~= 'force' and ret[k] ~= nil then

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -20,6 +20,11 @@ vim.deepcopy = (function()
   local deepcopy_funcs = {
     table = function(orig)
       local copy = {}
+
+      if getmetatable(orig) == vim._empty_dict_mt then
+        copy = vim.empty_dict()
+      end
+
       for k, v in pairs(orig) do
         copy[vim.deepcopy(k)] = vim.deepcopy(v)
       end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -322,6 +322,48 @@ describe('lua stdlib', function()
     ]])
 
     assert(is_dc)
+
+    local is_empty_list = exec_lua([[
+      local a = {}
+      local b = vim.deepcopy(a)
+
+      local count = 0
+      for _ in pairs(b) do count = count + 1 end
+
+      return getmetatable(b) ~= vim._empty_dict_mt
+        and count == 0
+        and tostring(a) ~= tostring(b)
+    ]])
+
+    assert(is_empty_list)
+
+    local is_empty_dic = exec_lua([[
+      local a = vim.empty_dict()
+      local b = vim.deepcopy(a)
+
+      local count = 0
+      for _ in pairs(b) do count = count + 1 end
+
+      return getmetatable(b) == vim._empty_dict_mt
+        and count == 0
+    ]])
+
+    assert(is_empty_dic)
+
+    local include_empty_dic = exec_lua([[
+      local a = {x = vim.empty_dict(), y = {}}
+      local b = vim.deepcopy(a)
+
+      local count = 0
+      for _ in pairs(b) do count = count + 1 end
+
+      return getmetatable(b.x) == vim._empty_dict_mt
+        and getmetatable(b.y) ~= vim._empty_dict_mt
+        and count == 2
+        and tostring(a) ~= tostring(b)
+    ]])
+
+    assert(include_empty_dic)
   end)
 
   it('vim.pesc', function()


### PR DESCRIPTION
fix: https://github.com/neovim/nvim-lsp/issues/94

cc: @justinmk 