### PR TITLE
doc/lsp: start_client config cmd must be a list

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -543,7 +543,8 @@ start_client({config})                                *vim.lsp.start_client()*
                     {root_dir}         (required, string) Directory where the
                                        LSP server will base its rootUri on
                                        initialization.
-                    {cmd}              (required, list) Base command that
+                    {cmd}              (required, list treated like
+                                       |jobstart()|) Base command that
                                        initiates the LSP client.
                     {cmd_cwd}          (string, default=|getcwd()|) Directory
                                        to launch the `cmd` process. Not

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -543,8 +543,7 @@ start_client({config})                                *vim.lsp.start_client()*
                     {root_dir}         (required, string) Directory where the
                                        LSP server will base its rootUri on
                                        initialization.
-                    {cmd}              (required, string or list treated like
-                                       |jobstart()|) Base command that
+                    {cmd}              (required, list) Base command that
                                        initiates the LSP client.
                     {cmd_cwd}          (string, default=|getcwd()|) Directory
                                        to launch the `cmd` process. Not


### PR DESCRIPTION
After the merge of https://github.com/neovim/neovim/pull/11847 cmd can
no longer be a string but must be a list.