### PR TITLE
checkhealth: ignore cpamn output that starts with !

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -708,10 +708,10 @@ function! s:check_perl() abort
   endif
   call health#report_info('Nvim perl host: '. host)
 
-  let latest_cpan_cmd = 'cpanm --info Neovim::Ext'
+  let latest_cpan_cmd = ['perl', '-W', '-MNeovim::Ext', '-e', 'print $Neovim::Ext::VERSION']
   let latest_cpan = s:system(latest_cpan_cmd)
   if s:shell_error || empty(latest_cpan)
-    call health#report_error('Failed to run: '. latest_cpan_cmd,
+    call health#report_error('Failed to run: '. string(latest_cpan_cmd),
           \ ["Make sure you're connected to the internet.",
           \  'Are you behind a firewall or proxy?'])
     return


### PR DESCRIPTION
'Neovim::Ext' module exposes '$Neovim::Ext::VERSION' constant
for checking the version in Perl.
Use that instead of cpanm to avoid 'sudo' warnings in Linux.

Close #11858

Oops. wrong change. I'll reopen later.