### PR TITLE
clang bug: Dead assignment `ns_id`

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1420,10 +1420,10 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     end_line++;
   }
 
-  ns_id = extmark_add_decoration(buf, ns_id, hlg_id,
-                                 (int)line, (colnr_T)col_start,
-                                 end_line, (colnr_T)col_end,
-                                 VIRTTEXT_EMPTY);
+  extmark_add_decoration(buf, ns_id, hlg_id,
+                         (int)line, (colnr_T)col_start,
+                         end_line, (colnr_T)col_end,
+                         VIRTTEXT_EMPTY);
   return src_id;
 }
 


### PR DESCRIPTION
Remove a dead assignment of the `ns_id` variable in the
`src/nvim/api/buffer.c` file.

Refer: https://neovim.io/doc/reports/clang/report-f279da.html#EndPath