### PR TITLE
vim-patch:8.0.1660,8.1.{43,786,1201,2129,2131,2187,2223,2259},8.2.{241,267}

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -1773,7 +1773,7 @@ def CheckSpacingForFunctionCall(filename, line, linenum, error):
             fncall = match.group(1)
             break
 
-    # Except in if/for/while/switch, there should never be space
+    # Except in if/for/while/switch/case, there should never be space
     # immediately inside parens (eg "f( 3, 4 )").  We make an exception
     # for nested parens ( (a+b) + c ).  Likewise, there should never be
     # a space before a ( when it's a function argument.  I assume it's a
@@ -1787,7 +1787,7 @@ def CheckSpacingForFunctionCall(filename, line, linenum, error):
     # Note that we assume the contents of [] to be short enough that
     # they'll never need to wrap.
     if (  # Ignore control structures.
-            not Search(r'\b(if|for|while|switch|return|sizeof)\b', fncall) and
+            not Search(r'\b(if|for|while|switch|case|return|sizeof)\b', fncall) and
             # Ignore pointers/references to functions.
             not Search(r' \([^)]+\)\([^)]*(\)|,$)', fncall) and
             # Ignore pointers/references to arrays.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2852,7 +2852,8 @@ void ex_call(exarg_T *eap)
     }
   }
 
-  if (!failed) {
+  // When inside :try we need to check for following "| catch".
+  if (!failed || eap->cstack->cs_trylevel > 0) {
     // Check for trailing illegal characters and a following command.
     if (!ends_excmd(*arg)) {
       emsg_severe = TRUE;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9151,10 +9151,7 @@ char_u *v_throwpoint(char_u *oldval)
  */
 char_u *set_cmdarg(exarg_T *eap, char_u *oldarg)
 {
-  char_u      *oldval;
-  char_u      *newval;
-
-  oldval = vimvars[VV_CMDARG].vv_str;
+  char_u *oldval = vimvars[VV_CMDARG].vv_str;
   if (eap == NULL) {
     xfree(oldval);
     vimvars[VV_CMDARG].vv_str = oldarg;
@@ -9170,14 +9167,18 @@ char_u *set_cmdarg(exarg_T *eap, char_u *oldarg)
   if (eap->read_edit)
     len += 7;
 
-  if (eap->force_ff != 0)
-    len += STRLEN(eap->cmd + eap->force_ff) + 6;
-  if (eap->force_enc != 0)
+  if (eap->force_ff != 0) {
+    len += 10;  // " ++ff=unix"
+  }
+  if (eap->force_enc != 0) {
     len += STRLEN(eap->cmd + eap->force_enc) + 7;
-  if (eap->bad_char != 0)
-    len += 7 + 4;      /* " ++bad=" + "keep" or "drop" */
+  }
+  if (eap->bad_char != 0) {
+    len += 7 + 4;  // " ++bad=" + "keep" or "drop"
+  }
 
-  newval = xmalloc(len + 1);
+  const size_t newval_len = len + 1;
+  char_u *newval = xmalloc(newval_len);
 
   if (eap->force_bin == FORCE_BIN)
     sprintf((char *)newval, " ++bin");
@@ -9189,18 +9190,23 @@ char_u *set_cmdarg(exarg_T *eap, char_u *oldarg)
   if (eap->read_edit)
     STRCAT(newval, " ++edit");
 
-  if (eap->force_ff != 0)
-    sprintf((char *)newval + STRLEN(newval), " ++ff=%s",
-        eap->cmd + eap->force_ff);
-  if (eap->force_enc != 0)
-    sprintf((char *)newval + STRLEN(newval), " ++enc=%s",
-        eap->cmd + eap->force_enc);
-  if (eap->bad_char == BAD_KEEP)
+  if (eap->force_ff != 0) {
+    snprintf((char *)newval + STRLEN(newval), newval_len, " ++ff=%s",
+             eap->force_ff == 'u' ? "unix" :
+             eap->force_ff == 'd' ? "dos" : "mac");
+  }
+  if (eap->force_enc != 0) {
+    snprintf((char *)newval + STRLEN(newval), newval_len, " ++enc=%s",
+             eap->cmd + eap->force_enc);
+  }
+  if (eap->bad_char == BAD_KEEP) {
     STRCPY(newval + STRLEN(newval), " ++bad=keep");
-  else if (eap->bad_char == BAD_DROP)
+  } else if (eap->bad_char == BAD_DROP) {
     STRCPY(newval + STRLEN(newval), " ++bad=drop");
-  else if (eap->bad_char != 0)
-    sprintf((char *)newval + STRLEN(newval), " ++bad=%c", eap->bad_char);
+  } else if (eap->bad_char != 0) {
+    snprintf((char *)newval + STRLEN(newval), newval_len, " ++bad=%c",
+             eap->bad_char);
+  }
   vimvars[VV_CMDARG].vv_str = newval;
   return oldval;
 }

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -160,7 +160,7 @@ struct exarg {
   int regname;                  ///< register name (NUL if none)
   int force_bin;                ///< 0, FORCE_BIN or FORCE_NOBIN
   int read_edit;                ///< ++edit argument
-  int force_ff;                 ///< ++ff= argument (index in cmd[])
+  int force_ff;                 ///< ++ff= argument (first char of argument)
   int force_enc;                ///< ++enc= argument (index in cmd[])
   int bad_char;                 ///< BAD_KEEP, BAD_DROP or replacement byte
   int useridx;                  ///< user command index

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4547,8 +4547,10 @@ int get_bad_opt(const char_u *p, exarg_T *eap)
     eap->bad_char = BAD_DROP;
   } else if (MB_BYTE2LEN(*p) == 1 && p[1] == NUL) {
     eap->bad_char = *p;
+  } else {
+    return FAIL;
   }
-  return FAIL;
+  return OK;
 }
 
 /*

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4373,7 +4373,7 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
 
     if (has_wildcards) {
       expand_T xpc;
-      int options = WILD_LIST_NOTFOUND|WILD_ADD_SLASH;
+      int options = WILD_LIST_NOTFOUND | WILD_NOERROR | WILD_ADD_SLASH;
 
       ExpandInit(&xpc);
       xpc.xp_context = EXPAND_FILES;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4693,6 +4693,9 @@ ExpandFromContext (
     flags |= EW_KEEPALL;
   if (options & WILD_SILENT)
     flags |= EW_SILENT;
+  if (options & WILD_NOERROR) {
+    flags |= EW_NOERROR;
+  }
   if (options & WILD_ALLLINKS) {
     flags |= EW_ALLLINKS;
   }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2032,14 +2032,16 @@ readfile_linenr(
  * Fill "*eap" to force the 'fileencoding', 'fileformat' and 'binary to be
  * equal to the buffer "buf".  Used for calling readfile().
  */
-void prep_exarg(exarg_T *eap, buf_T *buf)
+void prep_exarg(exarg_T *eap, const buf_T *buf)
+  FUNC_ATTR_NONNULL_ALL
 {
-  eap->cmd = xmalloc(STRLEN(buf->b_p_ff) + STRLEN(buf->b_p_fenc) + 15);
+  const size_t cmd_len = 15 + STRLEN(buf->b_p_fenc);
+  eap->cmd = xmalloc(cmd_len);
 
-  sprintf((char *)eap->cmd, "e ++ff=%s ++enc=%s", buf->b_p_ff, buf->b_p_fenc);
-  eap->force_enc = 14 + (int)STRLEN(buf->b_p_ff);
+  snprintf((char *)eap->cmd, cmd_len, "e ++enc=%s", buf->b_p_fenc);
+  eap->force_enc = 8;
   eap->bad_char = buf->b_bad_char;
-  eap->force_ff = 7;
+  eap->force_ff = *buf->b_p_ff;
 
   eap->force_bin = buf->b_p_bin ? FORCE_BIN : FORCE_NOBIN;
   eap->read_edit = FALSE;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3361,7 +3361,7 @@ showmap (
     msg_putchar(' ');
 
   // Display the LHS.  Get length of what we write.
-  len = (size_t)msg_outtrans_special(mp->m_keys, true);
+  len = (size_t)msg_outtrans_special(mp->m_keys, true, 0);
   do {
     msg_putchar(' ');                   /* padd with blanks */
     ++len;
@@ -3389,7 +3389,7 @@ showmap (
     // as typeahead.
     char_u *s = vim_strsave(mp->m_str);
     vim_unescape_csi(s);
-    msg_outtrans_special(s, FALSE);
+    msg_outtrans_special(s, false, 0);
     xfree(s);
   }
   if (p_verbose > 0) {

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1863,7 +1863,10 @@ errorret:
         // Avoid giving this message for a recursive call, may happen
         // when the GUI redraws part of the text.
         recursive++;
-        IEMSGN(_("E316: ml_get: cannot find line %" PRId64), lnum);
+        get_trans_bufname(buf);
+        shorten_dir(NameBuff);
+        iemsgf(_("E316: ml_get: cannot find line %" PRId64 " in buffer %d %s"),
+               lnum, buf->b_fnum, NameBuff);
         recursive--;
       }
       goto errorret;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -868,7 +868,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
         if (*menu->strings[bit] == NUL) {
           msg_puts_attr("<Nop>", HL_ATTR(HLF_8));
         } else {
-          msg_outtrans_special(menu->strings[bit], false);
+          msg_outtrans_special(menu->strings[bit], false, 0);
         }
       }
   } else {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1521,7 +1521,8 @@ void msg_make(char_u *arg)
 /// the character/string -- webb
 int msg_outtrans_special(
     const char_u *strstart,
-    int from               ///< true for LHS of a mapping
+    bool from,              ///< true for LHS of a mapping
+    int maxlen              ///< screen columns, 0 for unlimeted
 )
 {
   if (strstart == NULL) {
@@ -1541,6 +1542,9 @@ int msg_outtrans_special(
       string = str2special((const char **)&str, from, false);
     }
     const int len = vim_strsize((char_u *)string);
+    if (maxlen > 0 && retval + len >= maxlen) {
+      break;
+    }
     // Highlight special keys
     msg_puts_attr(string, (len > 1
                            && (*mb_ptr2len)((char_u *)string) <= 1

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7294,12 +7294,13 @@ int get_fileformat(buf_T *buf)
 /// argument.
 ///
 /// @param eap  can be NULL!
-int get_fileformat_force(buf_T *buf, exarg_T *eap)
+int get_fileformat_force(const buf_T *buf, const exarg_T *eap)
+  FUNC_ATTR_NONNULL_ARG(1)
 {
   int c;
 
   if (eap != NULL && eap->force_ff != 0) {
-    c = eap->cmd[eap->force_ff];
+    c = eap->force_ff;
   } else {
     if ((eap != NULL && eap->force_bin != 0)
         ? (eap->force_bin == FORCE_BIN) : buf->b_p_bin) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3845,7 +3845,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last)
      *dirname = NUL;
 
     // Add one line for each error
-    if (old_last == NULL) {
+    if (old_last == NULL || old_last->qf_next == NULL) {
       qfp = qfl->qf_start;
       lnum = 0;
     } else {

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -86,7 +86,7 @@ nongui: nolog $(FIXFF) $(SCRIPTS) newtests report
 	@echo 'set $$_exitcode = -1\nrun\nif $$_exitcode != -1\n  quit\nend' > .gdbinit
 
 report:
-	$(RUN_VIMTEST) $(NO_INITS) -u NONE -S summarize.vim messages
+	$(NVIM_PRG) -u NONE $(NO_INITS) -S summarize.vim messages
 	@echo
 	@echo 'Test results:'
 	@cat test_result.log

--- a/src/nvim/testdir/test49.vim
+++ b/src/nvim/testdir/test49.vim
@@ -1,6 +1,6 @@
 " Vim script language tests
 " Author:	Servatius Brandt <Servatius.Brandt@fujitsu-siemens.com>
-" Last Change:	2019 May 24
+" Last Change:	2019 Oct 08
 
 "-------------------------------------------------------------------------------
 " Test environment							    {{{1
@@ -456,7 +456,7 @@ function! ExtraVim(...)
     " messing up the user's viminfo file.
     let redirect = a:0 ?
 	\ " -c 'au VimLeave * redir END' -c 'redir\\! >" . a:1 . "'" : ""
-    exec "!echo '" . debug_quits . "q' | $NVIM_PRG -u NONE -N -es" . redirect .
+    exec "!echo '" . debug_quits . "q' | " .. v:progpath .. " -u NONE -N -es" . redirect .
 	\ " -c 'debuggreedy|set viminfo+=nviminfo'" .
 	\ " -c 'let ExtraVimBegin = " . extra_begin . "'" .
 	\ " -c 'let ExtraVimResult = \"" . resultfile . "\"'" . breakpoints .

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -39,9 +39,9 @@ endfunc
 
 func Test_compiler_without_arg()
   let a=split(execute('compiler'))
-  call assert_match('^.*runtime/compiler/ant.vim$',   a[0])
-  call assert_match('^.*runtime/compiler/bcc.vim$',   a[1])
-  call assert_match('^.*runtime/compiler/xmlwf.vim$', a[-1])
+  call assert_match($VIMRUNTIME .. '/compiler/ant.vim$',   a[0])
+  call assert_match($VIMRUNTIME .. '/compiler/bcc.vim$',   a[1])
+  call assert_match($VIMRUNTIME .. '/compiler/xmlwf.vim$', a[-1])
 endfunc
 
 func Test_compiler_completion()

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -38,10 +38,11 @@ func Test_compiler()
 endfunc
 
 func Test_compiler_without_arg()
-  let a=split(execute('compiler'))
-  call assert_match($VIMRUNTIME .. '/compiler/ant.vim$',   a[0])
-  call assert_match($VIMRUNTIME .. '/compiler/bcc.vim$',   a[1])
-  call assert_match($VIMRUNTIME .. '/compiler/xmlwf.vim$', a[-1])
+  let runtime = substitute($VIMRUNTIME, '\\', '/', 'g')
+  let a = split(execute('compiler'))
+  call assert_match(runtime .. '/compiler/ant.vim$',   a[0])
+  call assert_match(runtime .. '/compiler/bcc.vim$',   a[1])
+  call assert_match(runtime .. '/compiler/xmlwf.vim$', a[-1])
 endfunc
 
 func Test_compiler_completion()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1510,6 +1510,13 @@ func Test_setqflist_invalid_nr()
   call setqflist([], ' ', {'nr' : $XXX_DOES_NOT_EXIST})
 endfunc
 
+func Test_setqflist_user_sets_buftype()
+  call setqflist([{'text': 'foo'}, {'text': 'bar'}])
+  set buftype=quickfix
+  call setqflist([], 'a')
+  enew
+endfunc
+
 func Test_quickfix_set_list_with_act()
   call XquickfixSetListWithAct('c')
   call XquickfixSetListWithAct('l')

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -132,18 +132,18 @@ func Test_spellinfo()
   new
 
   set enc=latin1 spell spelllang=en
-  call assert_match("^\nfile: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: " .. $VIMRUNTIME .. "/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set enc=cp1250 spell spelllang=en
-  call assert_match("^\nfile: .*/runtime/spell/en.ascii.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: " .. $VIMRUNTIME .. "/spell/en.ascii.spl\n$", execute('spellinfo'))
 
   set enc=utf-8 spell spelllang=en
-  call assert_match("^\nfile: .*/runtime/spell/en.utf-8.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: " .. $VIMRUNTIME .. "/spell/en.utf-8.spl\n$", execute('spellinfo'))
 
   set enc=latin1 spell spelllang=en_us,en_nz
   call assert_match("^\n" .
-                 \  "file: .*/runtime/spell/en.latin1.spl\n" .
-                 \  "file: .*/runtime/spell/en.latin1.spl\n$", execute('spellinfo'))
+                 \  "file: " .. $VIMRUNTIME .. "/spell/en.latin1.spl\n" .
+                 \  "file: " .. $VIMRUNTIME .. "/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set spell spelllang=
   call assert_fails('spellinfo', 'E756:')

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -130,20 +130,21 @@ endfunc
 func Test_spellinfo()
   throw 'skipped: Nvim does not support enc=latin1'
   new
+  let runtime = substitute($VIMRUNTIME, '\\', '/', 'g')
 
   set enc=latin1 spell spelllang=en
-  call assert_match("^\nfile: " .. $VIMRUNTIME .. "/spell/en.latin1.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: " .. runtime .. "/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set enc=cp1250 spell spelllang=en
-  call assert_match("^\nfile: " .. $VIMRUNTIME .. "/spell/en.ascii.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: " .. runtime .. "/spell/en.ascii.spl\n$", execute('spellinfo'))
 
   set enc=utf-8 spell spelllang=en
-  call assert_match("^\nfile: " .. $VIMRUNTIME .. "/spell/en.utf-8.spl\n$", execute('spellinfo'))
+  call assert_match("^\nfile: " .. runtime .. "/spell/en.utf-8.spl\n$", execute('spellinfo'))
 
   set enc=latin1 spell spelllang=en_us,en_nz
   call assert_match("^\n" .
-                 \  "file: " .. $VIMRUNTIME .. "/spell/en.latin1.spl\n" .
-                 \  "file: " .. $VIMRUNTIME .. "/spell/en.latin1.spl\n$", execute('spellinfo'))
+                 \  "file: " .. runtime .. "/spell/en.latin1.spl\n" .
+                 \  "file: " .. runtime .. "/spell/en.latin1.spl\n$", execute('spellinfo'))
 
   set spell spelllang=
   call assert_fails('spellinfo', 'E756:')

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -94,3 +94,7 @@ func Test_user_func()
   unlet g:retval g:counter
   enew!
 endfunc
+
+func Test_failed_call_in_try()
+  try | call UnknownFunc() | catch | endtry
+endfunc

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -1,4 +1,4 @@
-" Tests for the writefile() function.
+" Tests for the writefile() function and some :write commands.
 
 func Test_writefile()
   let f = tempname()
@@ -14,6 +14,11 @@ func Test_writefile()
   call assert_equal("morning", l[3])
   call assert_equal("vimmers", l[4])
   call delete(f)
+endfunc
+
+func Test_writefile_ignore_regexp_error()
+  write Xt[z-a]est.txt
+  call delete('Xt[z-a]est.txt')
 endfunc
 
 func Test_writefile_fails_gently()

--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -187,7 +187,7 @@ void terminfo_info_msg(const unibi_term *const ut)
       msg_printf_attr(0, "  %-25s %-10s = ", unibi_name_str(i),
                       unibi_short_name_str(i));
       // Most of these strings will contain escape sequences.
-      msg_outtrans_special((char_u *)s, false);
+      msg_outtrans_special((char_u *)s, false, 0);
       msg_putchar('\n');
     }
   }
@@ -214,7 +214,7 @@ void terminfo_info_msg(const unibi_term *const ut)
     msg_puts("Extended string capabilities:\n");
     for (size_t i = 0; i < unibi_count_ext_str(ut); i++) {
       msg_printf_attr(0, "  %-25s = ", unibi_get_ext_str_name(ut, i));
-      msg_outtrans_special((char_u *)unibi_get_ext_str(ut, i), false);
+      msg_outtrans_special((char_u *)unibi_get_ext_str(ut, i), false, 0);
       msg_putchar('\n');
     }
   }


### PR DESCRIPTION
~~Continue https://github.com/neovim/neovim/pull/10606 for patch 8.1.{341,430}.~~ 8.1.0341 needs 8.0.x buffer patches.

patch 8.1.1201 should be merged with patches 8.1.{1204,1206} but patch 8.1.1206 needs patches 8.1.{341,560}.

patch 8.0.1660 is for Vim terminal but I did not update `:drop` for Neovim terminal.