### PR TITLE
checkhealth: allow 'sudo install' of 'Neovim::Ext'

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -710,13 +710,27 @@ function! s:check_perl() abort
 
   let latest_cpan_cmd = 'cpanm --info -q Neovim::Ext'
   let latest_cpan = s:system(latest_cpan_cmd)
-  if s:shell_error || empty(latest_cpan) || latest_cpan[0] ==# '!'
+  if s:shell_error || empty(latest_cpan)
     call health#report_error('Failed to run: '. latest_cpan_cmd,
           \ ["Make sure you're connected to the internet.",
           \  'Are you behind a firewall or proxy?'])
     return
+  elseif latest_cpan[0] ==# '!'
+    let cpanm_errs = split(latest_cpan, '!')
+    if cpanm_errs[0] =~# "Can't write to "
+      call health#report_warn(cpanm_errs[0], cpanm_errs[1:-2])
+      " Last line is the package info
+      let latest_cpan = cpanm_errs[-1]
+    else
+      call health#report_error('Unknown warning from command: ' . latest_cpan_cmd, cpanm_errs)
+      return
+    endif
   endif
   let latest_cpan = matchstr(latest_cpan, '\(\.\?\d\)\+')
+  if empty(latest_cpan)
+    call health#report_error('Cannot parse version number from cpanm output: ' . latest_cpan)
+    return
+  endif
 
   let current_cpan_cmd = [host, '-W', '-MNeovim::Ext', '-e', 'print $Neovim::Ext::VERSION']
   let current_cpan = s:system(current_cpan_cmd)


### PR DESCRIPTION
cpanm cannot look for Perl modules from root directories
without sudo so it creates '\~/perl5/' and look for Perl modules in there.
Whether this directory existed before running cpanm or not,
cpanm returns a warning to advice the user to setup local::lib
in order to use modules in '\~/perl5/' and exits with error code 0.
Each line in the warning always starts with '!'.

Display this warning to the user.
Continue parsing the version number if the warning can be ignored
because lines that are not prefixed with '!' are valid output.

Fix https://github.com/neovim/neovim/issues/11858

cc @bertilow