### PR TITLE
add regex support in treesitter queries

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -693,6 +693,35 @@ identical identifiers, highlighting both as |hl-WarningMsg|: >
      (eq? @WarningMsg.left @WarningMsg.right))
 
 ------------------------------------------------------------------------------
+VIM.REGEX							*lua-regex*
+
+Vim regexes can be used directly from lua. Currently they only allow
+matching within a single line.
+
+vim.regex({re})						*vim.regex()*
+
+        Parse the regex {re} and return a regex object. 'magic' and
+        'ignorecase' options are ignored, lua regexes always defaults to magic
+        and ignoring case.  The behavior can be changed with flags in
+        the beginning of the string |/magic|.
+
+Regex objects support the following methods:
+
+regex:match_str({str})					*regex:match_str()*
+        Match the string against the regex. If the string should match the
+        regex precisely, surround the regex with `^` and `$`.
+        If the was a match, the byte indices for the beginning and end of
+        the match is returned. When there is no match, `nil` is returned.
+        As any integer is truth-y, `regex:match()` can be directly used
+        as a condition in an if-statement.
+
+regex:match_line({bufnr}, {line_idx}[, {start}, {end}])	*regex:match_line()*
+        Match line {line_idx} (zero-based) in buffer {bufnr}. If {start} and
+        {end} are supplied, match only this byte index range. Otherwise see
+        |regex:match_str()|. If {start} is used, then the returned byte
+        indices will be relative {start}.
+
+------------------------------------------------------------------------------
 VIM							*lua-builtin*
 
 vim.api.{func}({...})					*vim.api*

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -113,12 +113,33 @@ end
 local Query = {}
 Query.__index = Query
 
+local magic_prefixes = {['\\v']=true, ['\\m']=true, ['\\M']=true, ['\\V']=true}
+local function check_magic(str)
+  if string.len(str) < 2 or magic_prefixes[string.sub(str,1,2)] then
+    return str
+  end
+  return '\\v'..str
+end
+
 function M.parse_query(lang, query)
   M.require_language(lang)
   local self = setmetatable({}, Query)
   self.query = vim._ts_parse_query(lang, query)
   self.info = self.query:inspect()
   self.captures = self.info.captures
+  self.regexes = {}
+  for id,preds in pairs(self.info.patterns) do
+    local regexes = {}
+    for i, pred in ipairs(preds) do
+      if (pred[1] == "match?" and type(pred[2]) == "number"
+          and type(pred[3]) == "string") then
+        regexes[i] = vim.regex(check_magic(pred[3]))
+      end
+    end
+    if next(regexes) then
+      self.regexes[id] = regexes
+    end
+  end
   return self
 end
 
@@ -131,8 +152,13 @@ local function get_node_text(node, bufnr)
   return string.sub(line, start_col+1, end_col)
 end
 
-local function match_preds(match, preds, bufnr)
-  for _, pred in pairs(preds) do
+function Query:match_preds(match, pattern, bufnr)
+  local preds = self.info.patterns[pattern]
+  if not preds then
+    return true
+  end
+  local regexes = self.regexes[pattern]
+  for i, pred in pairs(preds) do
     if pred[1] == "eq?" then
       local node = match[pred[2]]
       local node_text = get_node_text(node, bufnr)
@@ -149,6 +175,16 @@ local function match_preds(match, preds, bufnr)
       if node_text ~= str or str == nil then
         return false
       end
+    elseif pred[1] == "match?" then
+      if not regexes or not regexes[i] then
+        return false
+      end
+      local node = match[pred[2]]
+      local start_row, start_col, end_row, end_col = node:range()
+      if start_row ~= end_row then
+        return false
+      end
+      return regexes[i]:match_line(bufnr, start_row, start_col, end_col)
     else
       return false
     end
@@ -164,8 +200,7 @@ function Query:iter_captures(node, bufnr, start, stop)
   local function iter()
     local capture, captured_node, match = raw_iter()
     if match ~= nil then
-      local preds = self.info.patterns[match.pattern]
-      local active = match_preds(match, preds, bufnr)
+      local active = self:match_preds(match, match.pattern, bufnr)
       match.active = active
       if not active then
         return iter() -- tail call: try next match
@@ -184,8 +219,7 @@ function Query:iter_matches(node, bufnr, start, stop)
   local function iter()
     local pattern, match = raw_iter()
     if match ~= nil then
-      local preds = self.info.patterns[pattern]
-      local active = (not preds) or match_preds(match, preds, bufnr)
+      local active = self:match_preds(match, pattern, bufnr)
       if not active then
         return iter() -- tail call: try next match
       end

--- a/runtime/lua/vim/tshighlighter.lua
+++ b/runtime/lua/vim/tshighlighter.lua
@@ -69,6 +69,8 @@ function TSHighlighter:set_query(query)
     end
     self.id_map[i] = hl
   end
+
+    a.nvim__buf_redraw_range(self.buf, 0, a.nvim_buf_line_count(self.buf))
 end
 
 function TSHighlighter:on_change(changes)

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -93,10 +93,7 @@ static PMap(cstr_t) *langs;
 static void build_meta(lua_State *L, const char *tname, const luaL_Reg *meta)
 {
   if (luaL_newmetatable(L, tname)) {  // [meta]
-    for (size_t i = 0; meta[i].name != NULL; i++) {
-      lua_pushcfunction(L, meta[i].func);  // [meta, func]
-      lua_setfield(L, -2, meta[i].name);  // [meta]
-    }
+    luaL_register(L, NULL, meta);
 
     lua_pushvalue(L, -1);  // [meta, meta]
     lua_setfield(L, -2, "__index");  // [meta]

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -245,6 +245,11 @@ static int nlua_schedule(lua_State *const lstate)
 (primitive_type) @type
 (sized_type_specifier) @type
 
+; defaults to very magic syntax, for best compatibility
+((identifier) @Identifier (match? @Identifier "^l(u)a_"))
+; still support \M etc prefixes
+((identifier) @Constant (match? @Constant "\M^\[A-Z_]\+$"))
+
 ((binary_expression left: (identifier) @WarningMsg.left right: (identifier) @WarningMsg.right) (eq? @WarningMsg.left @WarningMsg.right))
 
 (comment) @comment
@@ -263,7 +268,7 @@ static int nlua_schedule(lua_State *const lstate)
       [8] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [9] = {foreground = Screen.colors.Magenta, background = Screen.colors.Red},
       [10] = {foreground = Screen.colors.Red, background = Screen.colors.Red},
-
+      [11] = {foreground = Screen.colors.Cyan4},
     })
 
     insert(hl_text)
@@ -297,10 +302,10 @@ static int nlua_schedule(lua_State *const lstate)
       {2:/// Schedule Lua callback on main loop's event queue}             |
       {3:static} {3:int} nlua_schedule(lua_State *{3:const} lstate)                |
       {                                                                |
-        {4:if} (lua_type(lstate, {5:1}) != LUA_TFUNCTION                       |
+        {4:if} ({11:lua_type}(lstate, {5:1}) != {5:LUA_TFUNCTION}                       |
             || {6:lstate} != {6:lstate}) {                                     |
-          lua_pushliteral(lstate, {5:"vim.schedule: expected function"});  |
-          {4:return} lua_error(lstate);                                    |
+          {11:lua_pushliteral}(lstate, {5:"vim.schedule: expected function"});  |
+          {4:return} {11:lua_error}(lstate);                                    |
         }                                                              |
                                                                        |
         {7:LuaRef} cb = nlua_ref(lstate, {5:1});                               |
@@ -319,10 +324,10 @@ static int nlua_schedule(lua_State *const lstate)
       {2:/// Schedule Lua callback on main loop's event queue}             |
       {3:static} {3:int} nlua_schedule(lua_State *{3:const} lstate)                |
       {                                                                |
-        {4:if} (lua_type(lstate, {5:1}) != LUA_TFUNCTION                       |
+        {4:if} ({11:lua_type}(lstate, {5:1}) != {5:LUA_TFUNCTION}                       |
             || {6:lstate} != {6:lstate}) {                                     |
-          lua_pushliteral(lstate, {5:"vim.schedule: expected function"});  |
-          {4:return} lua_error(lstate);                                    |
+          {11:lua_pushliteral}(lstate, {5:"vim.schedule: expected function"});  |
+          {4:return} {11:lua_error}(lstate);                                    |
       {8:*^/}                                                               |
         }                                                              |
                                                                        |

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -844,4 +844,22 @@ describe('lua stdlib', function()
     eq('2', funcs.luaeval "BUF")
     eq(2, funcs.luaeval "#vim.api.nvim_list_bufs()")
   end)
+
+  it('vim.regex', function()
+    exec_lua [[
+      re1 = vim.regex"ab\\+c"
+      vim.cmd "set nomagic ignorecase"
+      re2 = vim.regex"xYz"
+    ]]
+    eq({}, exec_lua[[return {re1:match_str("x ac")}]])
+    eq({3,7}, exec_lua[[return {re1:match_str("ac abbc")}]])
+
+    meths.buf_set_lines(0, 0, -1, true, {"yy", "abc abbc"})
+    eq({}, exec_lua[[return {re1:match_line(0, 0)}]])
+    eq({0,3}, exec_lua[[return {re1:match_line(0, 1)}]])
+    eq({3,7}, exec_lua[[return {re1:match_line(0, 1, 1)}]])
+    eq({3,7}, exec_lua[[return {re1:match_line(0, 1, 1, 8)}]])
+    eq({}, exec_lua[[return {re1:match_line(0, 1, 1, 7)}]])
+    eq({0,3}, exec_lua[[return {re1:match_line(0, 1, 0, 7)}]])
+  end)
 end)


### PR DESCRIPTION
 Support `(match? @capture "^regex$")` predicates in tree-sitter queries, as stated in https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries. Default to "very magic" to be mostly compatible with standard tree-sitter queries, though we could allow override to standard magic/nomagic.

ref #11724 .