### PR TITLE
[WIP] support v:lua in prompt_setcallback and similar

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8142,6 +8142,15 @@ bool callback_call(Callback *const callback, const int argcount_in,
     case kCallbackFuncref:
       name = callback->data.funcref;
       partial = NULL;
+      if (STRLEN(name) >= 6 && !memcmp(name, "v:lua.", 6)) {
+        name += 6;
+        int len = check_luafunc_name((const char *)name, false);
+        if (len == 0) {
+          EMSG2(e_invexpr2, "v:lua");
+          return false;
+        }
+        partial = vvlua_partial;
+      }
       break;
 
     case kCallbackPartial:


### PR DESCRIPTION
I could almost prototype prompt buffer in luadev with `set buftype=prompt` and `call prompt_setcallback(bufnr(), "v:lua.luadev.exec")` (and `call prompt_setprompt(bufnr(), "lua> ")` ) but `v:lua` doesn't work with `callback_from_typval` + `callback_call` yet. so fix that.