### PR TITLE
Show that statusline is local to buffer

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5783,7 +5783,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 			   *'statusline'* *'stl'* *E540* *E542*
 'statusline' 'stl'	string	(default empty)
-			global or local to window |global-local|
+			global or local to buffer |global-local|
 	When nonempty, this option determines the content of the status line.
 	Also see |status-line|.
 


### PR DESCRIPTION
When you `setlocal statusline=hi`, the options is actually local to the _buffer_. This can be seen by opening another buffer in the same window or the same buffer in another window. But the help says it's local to the _window_. So I fixed that.