### PR TITLE
[release-0.4] vim-patch:8.2.0235

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3532,6 +3532,12 @@ int build_stl_str_hl(
         if (n == curitem && group_start_userhl == group_end_userhl) {
           out_p = t;
           group_len = 0;
+          // do not use the highlighting from the removed group
+          for (n = groupitems[groupdepth] + 1; n < curitem; n++) {
+            if (items[n].type == Highlight) {
+              items[n].type = Empty;
+            }
+          }
         }
       }
 

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -347,3 +347,24 @@ func Test_statusline()
   set laststatus&
   set splitbelow&
 endfunc
+
+func Test_statusline_removed_group()
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot make screendumps'
+  endif
+
+  let lines =<< trim END
+    scriptencoding utf-8
+    set laststatus=2
+    let &statusline = '%#StatColorHi2#%(✓%#StatColorHi2#%) Q≡'
+  END
+  call writefile(lines, 'XTest_statusline')
+
+  let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 10, 'cols': 50})
+  call term_wait(buf, 100)
+  call VerifyScreenDump(buf, 'Test_statusline_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XTest_statusline')
+endfunc

--- a/test/functional/ui/multibyte_spec.lua
+++ b/test/functional/ui/multibyte_spec.lua
@@ -127,6 +127,10 @@ describe('multibyte rendering: statusline', function()
   before_each(function()
     clear()
     screen = Screen.new(40, 4)
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {bold = true, reverse = true},
+    })
     screen:attach()
     command('set laststatus=2')
   end)
@@ -139,8 +143,8 @@ describe('multibyte rendering: statusline', function()
     command('set statusline=你好')
     screen:expect([[
     ^                                        |
-    ~                                       |
-    你好                                    |
+    {1:~                                       }|
+    {2:你好                                    }|
                                             |
     ]])
   end)
@@ -148,8 +152,8 @@ describe('multibyte rendering: statusline', function()
     command('set statusline=abc')
     screen:expect([[
     ^                                        |
-    ~                                       |
-    abc                                     |
+    {1:~                                       }|
+    {2:abc                                     }|
                                             |
     ]])
   end)
@@ -157,8 +161,8 @@ describe('multibyte rendering: statusline', function()
     command('set statusline=')
     screen:expect([[
     ^                                        |
-    ~                                       |
-    <9f>                                    |
+    {1:~                                       }|
+    {2:<9f>                                    }|
                                             |
     ]])
   end)
@@ -167,8 +171,8 @@ describe('multibyte rendering: statusline', function()
     -- o + U+1DF0 + U+20EF + U+0338 + U+20D0 + U+20E7 + U+20DD
     screen:expect([[
     ^                                        |
-    ~                                       |
-    o̸⃯ᷰ⃐⃧⃝                                       |
+    {1:~                                       }|
+    {2:o̸⃯ᷰ⃐⃧⃝                                       }|
                                             |
     ]])
   end)
@@ -177,9 +181,19 @@ describe('multibyte rendering: statusline', function()
     -- U+9F + U+1DF0 + U+20EF + U+0338 + U+20D0 + U+20E7 + U+20DD
     screen:expect([[
     ^                                        |
-    ~                                       |
-    <9f><1df0><20ef><0338><20d0><20e7><20dd>|
+    {1:~                                       }|
+    {2:<9f><1df0><20ef><0338><20d0><20e7><20dd>}|
                                             |
     ]])
+  end)
+
+  it('hidden group %( %) does not cause invalid unicode', function()
+    command("let &statusline = '%#StatColorHi2#%(✓%#StatColorHi2#%) Q≡'")
+    screen:expect{grid=[[
+      ^                                        |
+      {1:~                                       }|
+      {2: Q≡                                     }|
+                                              |
+    ]]}
   end)
 end)


### PR DESCRIPTION
Backport of #11836 

The glitch existed since before, but escalated to an assertion error on 0.4.x

Problem:    Draw error when an empty group is removed from 'statusline'.
Solution:   Do not use highlighting from a removed group.
https://github.com/vim/vim/commit/dbe5d361feb65137099644329cf0ecfd4a945a14