### PR TITLE
quickfix.c: Fix vimgrep regression

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4775,10 +4775,10 @@ static void vgr_display_fname(char_u *fname)
 static buf_T *vgr_load_dummy_buf(char_u *fname, char_u *dirname_start,
                                  char_u *dirname_now)
 {
-  char_u *save_ei = NULL;
-
   // Don't do Filetype autocommands to avoid loading syntax and
   // indent scripts, a great speed improvement.
+  char_u *save_ei = au_event_disable(",Filetype");
+
   long save_mls = p_mls;
   p_mls = 0;
 


### PR DESCRIPTION
Fix ex_vimgrep to properly ignore filetype when running vimgrep.
This restores vimgrep to behaviour before function refactoring.

~~fix #11856~~ Fix #9842

Simple fix caused by a slight regression from refactoring of ex_vimgrep, the au_event_disable wasn't moved from the original function. The fix has been moved below the comment about a speed improvement as this is what causes the speed improvement, it was not relevant to the save_mls or p_mls variables.