### PR TITLE
LSP/references: Add context to locations returned by server

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -33,7 +33,6 @@ M['textDocument/publishDiagnostics'] = function(_, _, result)
   util.buf_diagnostics_underline(bufnr, result.diagnostics)
   util.buf_diagnostics_virtual_text(bufnr, result.diagnostics)
   util.buf_diagnostics_signs(bufnr, result.diagnostics)
-  -- util.set_loclist(result.diagnostics)
   vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -797,7 +797,7 @@ function M.locations_to_items(locations)
   for _, d in ipairs(locations) do
     local start = d.range.start
     local fname = assert(vim.uri_to_fname(d.uri))
-    table.insert(grouped[fname], {start = start, msg= d.message })
+    table.insert(grouped[fname], {start = start})
   end
 
 
@@ -824,7 +824,7 @@ function M.locations_to_items(locations)
             filename = fname,
             lnum = row + 1,
             col = col + 1;
-            text = temp.msg or line;
+            text = line;
           })
         end
       end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -824,7 +824,7 @@ function M.locations_to_items(locations)
             filename = fname,
             lnum = row + 1,
             col = col + 1;
-            text = temp.msg;
+            text = temp.msg or line;
           })
         end
       end


### PR DESCRIPTION
This changes the `textDocument/references` callback to annotate the
locations returned by the server with the content present at the
locations range.

The quickfix list then looks as follows:

    cr8/insert_fake_data.py|17 col 32| from .misc import parse_table, parse_version
    cr8/insert_fake_data.py|43 col 15| version = parse_version(r['rows'][0][0])
    cr8/java_magic.py|8 col 22| from cr8.misc import parse_version
    cr8/java_magic.py|30 col 19| version = parse_version(fst)
    cr8/java_magic.py|33 col 16| return parse_version(version_str)

Instead of:

    cr8/insert_fake_data.py|17 col 32|
    cr8/insert_fake_data.py|43 col 15|
    cr8/java_magic.py|8 col 22|
    cr8/java_magic.py|30 col 19|
    cr8/java_magic.py|33 col 16|