### PR TITLE
lsp/completion: Show duplicates in completion popup

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -201,7 +201,7 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       menu = completion_item.detail or '',
       info = info,
       icase = 1,
-      dup = 0,
+      dup = 1,
       empty = 1,
     })
   end


### PR DESCRIPTION
Allow duplicates so that in languages with overloaded functions it will
show all signatures.

E.g. instead of having a single (last one wins)

    add(int index, String element)

It shows all signatures:

    add(String e) : boolean
    add(int index, String element) : void