### PR TITLE
LSP: Use buffer version instead of changedtick for edits

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -613,6 +613,8 @@ do
     if tbl_isempty(all_buffer_active_clients[bufnr] or {}) then
       return
     end
+
+    util.buf_versions[bufnr] = changedtick
     -- Lazy initialize these because clients may not even need them.
     local incremental_changes = once(function(client)
       local size_index = encoding_index[client.offset_encoding]

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -135,7 +135,7 @@ function M.apply_text_document_edit(text_document_edit)
   local text_document = text_document_edit.textDocument
   local bufnr = vim.uri_to_bufnr(text_document.uri)
   -- TODO(ashkan) check this is correct.
-  if api.nvim_buf_get_changedtick(bufnr) > text_document.version then
+  if (M.buf_versions[bufnr] or 0) > text_document.version then
     print("Buffer ", text_document.uri, " newer than edits.")
     return
   end
@@ -867,6 +867,8 @@ function M.character_offset(buf, row, col)
   end
   return str_utfindex(line, col)
 end
+
+M.buf_versions = {}
 
 return M
 -- vim:sw=2 ts=2 et


### PR DESCRIPTION
Currently, `changedtick` is used for the version of a buffer when applying `TextdocumentEdit`s. However, changes are only sent to the language server on line events, causing errors, like in neovim/nvim-lsp#134. This PR changes that behaviour by storing a buffer's version when sending a `textdocument/didChange` message to the server and retrieving it on receiving an edit