### PR TITLE
clipboard: fix stripping newline in wl-paste

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -84,9 +84,9 @@ function! provider#clipboard#Executable() abort
     return 'pbcopy'
   elseif exists('$WAYLAND_DISPLAY') && executable('wl-copy') && executable('wl-paste')
     let s:copy['+'] = 'wl-copy --foreground --type text/plain'
-    let s:paste['+'] = 'wl-paste --no-newline'
+    let s:paste['+'] = 'wl-paste'
     let s:copy['*'] = 'wl-copy --foreground --primary --type text/plain'
-    let s:paste['*'] = 'wl-paste --no-newline --primary'
+    let s:paste['*'] = 'wl-paste --primary'
     return 'wl-copy'
   elseif exists('$DISPLAY') && executable('xclip')
     let s:copy['+'] = 'xclip -quiet -i -selection clipboard'


### PR DESCRIPTION
When using wayland with wl-copy/wl-paste, pasting would strip newlines
from the copied text, resulting in pasted entries being inserted within
the current line rather than after it.

e.g. starting with:
```
hello
world
```

and pressing `dd` on hello:
```
world
```

and pressing `p` without moving the cursor would paste within the line:
```
wohellorld
```

instead of after:
```
world
hello
```