### PR TITLE
LSP/hover: Do not throw away contents if first line is empty

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -269,7 +269,7 @@ function M.convert_input_to_markdown_lines(input, contents)
       end
     end
   end
-  if contents[1] == '' or contents[1] == nil then
+  if (contents[1] == '' or contents[1] == nil) and #contents == 1 then
     return {}
   end
   return contents


### PR DESCRIPTION
haskell-ide-engine sends `hover` payloads as follows:

    {
      contents = {
        kind = "markdown",
        value = "\n```haskell\nfoo :: Either String (Integer, Text)\n```\n`foo` *local*"
      },
      range = {
        end = {
          character = 5,
          line = 57
        },
        start = {
          character = 2,
          line = 57
        }
      }
    }

`value` starts with `\n`. The logic in `convert_input_to_markdown_lines`
threw away the whole information.