### PR TITLE
LSP: Do not block window on error messages (window/logMessage)

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -204,12 +204,8 @@ local function log_message(_, _, result, client_id)
   if not client then
     err_message("LSP[", client_name, "] client has shut down after sending the message")
   end
-  if message_type == protocol.MessageType.Error then
-    err_message("LSP[", client_name, "] ", message)
-  else
-    local message_type_name = protocol.MessageType[message_type]
-    api.nvim_out_write(string.format("LSP[%s][%s] %s\n", client_name, message_type_name, message))
-  end
+  local message_type_name = protocol.MessageType[message_type]
+  api.nvim_out_write(string.format("LSP[%s][%s] %s\n", client_name, message_type_name, message))
   return result
 end
 


### PR DESCRIPTION
Fixes https://github.com/neovim/nvim-lsp/issues/127

Same could also happen with haskell-ide-engine, where messages as
follows were sent:

```
"window/showMessage"
{
  client_id = 1,
  params = {
    message = '"cannot satisfy -package-id junittui-0.1.0.0-AmJpwWxXMEHEoylTJC167n\\n    (use -v for more informatio n)"',
    type = 1
  }
}
```