### PR TITLE
lsp/completion: add user_data for completed_items

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -3,24 +3,7 @@ local uv = vim.loop
 local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
 local validate, schedule, schedule_wrap = vim.validate, vim.schedule, vim.schedule_wrap
-
--- TODO replace with a better implementation.
-local function json_encode(data)
-  local status, result = pcall(vim.fn.json_encode, data)
-  if status then
-    return result
-  else
-    return nil, result
-  end
-end
-local function json_decode(data)
-  local status, result = pcall(vim.fn.json_decode, data)
-  if status then
-    return result
-  else
-    return nil, result
-  end
-end
+local util = require('vim.lsp.util')
 
 local function is_dir(filename)
   local stat = vim.loop.fs_stat(filename)
@@ -259,7 +242,7 @@ local function create_and_start_client(cmd, cmd_args, handlers, extra_spawn_para
     if handle:is_closing() then return false end
     -- TODO(ashkan) remove this once we have a Lua json_encode
     schedule(function()
-      local encoded = assert(json_encode(payload))
+      local encoded = assert(util.json_encode(payload))
       stdin:write(format_message_with_content_length(encoded))
     end)
     return true
@@ -330,7 +313,7 @@ local function create_and_start_client(cmd, cmd_args, handlers, extra_spawn_para
   -- them with an error then, perhaps.
 
   local function handle_body(body)
-    local decoded, err = json_decode(body)
+    local decoded, err = util.json_decode(body)
     if not decoded then
       on_error(client_errors.INVALID_SERVER_JSON, err)
       return

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -203,6 +203,11 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       icase = 1,
       dup = 1,
       empty = 1,
+      user_data = M.json_encode({
+        lsp = {
+          completion_item = completion_item
+        }
+      }),
     })
   end
 
@@ -866,6 +871,25 @@ function M.character_offset(buf, row, col)
     return str_utfindex(line)
   end
   return str_utfindex(line, col)
+end
+
+-- TODO replace with a better implementation.
+function M.json_encode(data)
+  local status, result = pcall(vim.fn.json_encode, data)
+  if status then
+    return result
+  else
+    return nil, result
+  end
+end
+
+function M.json_decode(data)
+  local status, result = pcall(vim.fn.json_decode, data)
+  if status then
+    return result
+  else
+    return nil, result
+  end
 end
 
 return M


### PR DESCRIPTION
Currently, the nvim built-in LSP support does not include `user_data` in `v:completed_item`.

So the nvim built-in LSP support can't integrate to any snippet plugin (e.g. ultisnips, neosnippet, vsnip).

This PR aims to be able to support any snippet plugin.

--- Updated

This PR makes it possible to behavior like below (it uses vim-vsnip x vim-vsnip-integ but can use ultisnips etc if someone creates integration).

This screencasts is demo of snippet expansion.
![nvim-lsp-omnifunc-snippet](https://user-images.githubusercontent.com/629908/75540857-39b8e400-5a60-11ea-9a7e-cc3f65828648.gif)
