### PR TITLE
option.c: Update default directories to use trailing "//"

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -751,7 +751,7 @@ void set_init_1(void)
 #endif
                      false);
 
-  char *backupdir = stdpaths_user_data_subpath("backup", 0, true);
+  char *backupdir = stdpaths_user_data_subpath("backup", 2, true);
   const size_t backupdir_len = strlen(backupdir);
   backupdir = xrealloc(backupdir, backupdir_len + 3);
   memmove(backupdir + 2, backupdir, backupdir_len + 1);
@@ -761,7 +761,7 @@ void set_init_1(void)
   set_string_default("backupdir", backupdir, true);
   set_string_default("directory", stdpaths_user_data_subpath("swap", 2, true),
                      true);
-  set_string_default("undodir", stdpaths_user_data_subpath("undo", 0, true),
+  set_string_default("undodir", stdpaths_user_data_subpath("undo", 2, true),
                      true);
   // Set default for &runtimepath. All necessary expansions are performed in
   // this function.

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -361,10 +361,10 @@ describe('XDG-based defaults', function()
           .. ',' .. ('/a'):rep(2048) .. '/nvim/after'
           .. ',' .. ('/x'):rep(4096) .. '/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,' .. ('/X'):rep(4096) .. '/nvim/backup',
+      eq('.,' .. ('/X'):rep(4096) .. '/nvim/backup//',
          meths.get_option('backupdir'))
       eq(('/X'):rep(4096) .. '/nvim/swap//', meths.get_option('directory'))
-      eq(('/X'):rep(4096) .. '/nvim/undo', meths.get_option('undodir'))
+      eq(('/X'):rep(4096) .. '/nvim/undo//', meths.get_option('undodir'))
       eq(('/X'):rep(4096) .. '/nvim/view', meths.get_option('viewdir'))
     end)
   end)
@@ -408,9 +408,9 @@ describe('XDG-based defaults', function()
           .. ',$XDG_DATA_DIRS/nvim/after'
           .. ',$XDG_DATA_HOME/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,$XDG_CONFIG_HOME/nvim/backup', meths.get_option('backupdir'))
+      eq('.,$XDG_CONFIG_HOME/nvim/backup//', meths.get_option('backupdir'))
       eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
-      eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
+      eq('$XDG_CONFIG_HOME/nvim/undo//', meths.get_option('undodir'))
       eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
       meths.command('set all&')
       eq(('$XDG_DATA_HOME/nvim'
@@ -424,9 +424,9 @@ describe('XDG-based defaults', function()
           .. ',$XDG_DATA_DIRS/nvim/after'
           .. ',$XDG_DATA_HOME/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,$XDG_CONFIG_HOME/nvim/backup', meths.get_option('backupdir'))
+      eq('.,$XDG_CONFIG_HOME/nvim/backup//', meths.get_option('backupdir'))
       eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
-      eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
+      eq('$XDG_CONFIG_HOME/nvim/undo//', meths.get_option('undodir'))
       eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
     end)
   end)
@@ -478,9 +478,9 @@ describe('XDG-based defaults', function()
           .. ',\\,-\\,-\\,/nvim/after'
           .. ',\\, \\, \\,/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,\\,=\\,=\\,/nvim/backup', meths.get_option('backupdir'))
+      eq('.,\\,=\\,=\\,/nvim/backup//', meths.get_option('backupdir'))
       eq('\\,=\\,=\\,/nvim/swap//', meths.get_option('directory'))
-      eq('\\,=\\,=\\,/nvim/undo', meths.get_option('undodir'))
+      eq('\\,=\\,=\\,/nvim/undo//', meths.get_option('undodir'))
       eq('\\,=\\,=\\,/nvim/view', meths.get_option('viewdir'))
     end)
   end)


### PR DESCRIPTION
Addresses issue #11860. I've updated tests accordingly to be in line with the newly expected backupdir and undodir defaults.

Do note that this doesn't address the issue of potentially dropping the '.' path in front of the backupdir.

Also unsure whether the runtime/doc/vim_diff.txt file should be updated to reflect these changes - would it be appropriate to specify that backup & undo now have the trailing '//' and are auto-created?