### PR TITLE
lsp: do not assert even if the code does not exist in ErrorCodes

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -140,14 +140,23 @@ local function format_rpc_error(err)
   validate {
     err = { err, 't' };
   }
-  local code_name = assert(protocol.ErrorCodes[err.code], "err.code is invalid")
-  local message_parts = {"RPC", code_name}
+
+  -- There is ErrorCodes in the LSP specification,
+  -- but in ResponseError.code it is not used and the actual type is number.
+  local code
+  if protocol.ErrorCodes[err.code] then
+    code = string.format("code_name = %s,", protocol.ErrorCodes[err.code])
+  else
+    code = string.format("code_name = unknown, code = %s,", err.code)
+  end
+
+  local message_parts = {"RPC[Error]", code}
   if err.message then
-    table.insert(message_parts, "message = ")
+    table.insert(message_parts, "message =")
     table.insert(message_parts, string.format("%q", err.message))
   end
   if err.data then
-    table.insert(message_parts, "data = ")
+    table.insert(message_parts, "data =")
     table.insert(message_parts, vim.inspect(err.data))
   end
   return table.concat(message_parts, ' ')


### PR DESCRIPTION
There is ErrorCodes in the LSP specification, but in ResponseError.code
it is not used and the actual type is number.
Some language servers response original error cods and this is valid spec.
So we shouldn't assert even if the code does not exist in ErrorCodes.

ref: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage

### before
#### the code does not exist in ErrorCodes
![2020_03_05_1139-1583375952_](https://user-images.githubusercontent.com/4556097/75942922-05697b80-5ed7-11ea-8173-7954d4c8c8e1.png)

#### the code does exist in ErrorCodes
![2020_03_05_1139-1583375978_](https://user-images.githubusercontent.com/4556097/75942925-07333f00-5ed7-11ea-9481-55e56a3d54dd.png)

### after
#### the code does not exist in ErrorCodes
![2020_03_05_1146-1583376369_](https://user-images.githubusercontent.com/4556097/75942934-0dc1b680-5ed7-11ea-99e8-b85e9b9640d2.png)

#### the code does exist in ErrorCodes
![2020_03_05_1145-1583376346_](https://user-images.githubusercontent.com/4556097/75942930-0bf7f300-5ed7-11ea-923c-6df7097809c8.png)

