### PR TITLE
inccommand: plugin support: cmd_can_preview for user commands

### DIFF
--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -63,6 +63,7 @@
 #define MODIFY       0x200000   // forbidden in non-'modifiable' buffer
 #define EXFLAGS      0x400000   // allow flags after count in argument
 #define RESTRICT     0x800000L  // forbidden in restricted mode
+#define LIVE        0x1000000L  // allow live preview
 #define FILES (XFILE | EXTRA)   // multiple extra files allowed
 #define WORD1 (EXTRA | NOSPC)   // one extra word allowed
 #define FILE1 (FILES | NOSPC)   // 1 file allowed, defaults to current file

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5417,6 +5417,8 @@ invalid_count:
       if (addr_type_arg != ADDR_LINES) {
         *argt |= (ZEROR | NOTADR);
       }
+    } else if (STRNICMP(attr, "live", attrlen) == 0) {
+        *argt |= LIVE;
     } else {
       char_u ch = attr[len];
       attr[len] = '\0';
@@ -9413,6 +9415,13 @@ bool cmd_can_preview(char_u *cmd)
       }
       break;
     default:
+      // Cmd is is user command, check if live flag is set
+      if((ea.argt & LIVE)) {
+          // Only preview once the pattern delimiter has been typed
+          if(*end && !ASCII_ISALNUM(*end)) {
+              return true;
+          }
+      }
       break;
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1933,7 +1933,13 @@ static int command_line_changed(CommandLineState *s)
     State |= CMDPREVIEW;
     emsg_silent++;  // Block error reporting as the command may be incomplete
     msg_silent++;   // Block messages, namely ones that prompt
+
+    String cmdpreviewkey = cstr_to_string("cmdpreview");
+    Error temp;
+    dict_set_var(&globvardict, cmdpreviewkey, BOOLEAN_OBJ(true), false, false, &temp);
     do_cmdline(ccline.cmdbuff, NULL, NULL, DOCMD_KEEPLINE|DOCMD_NOWAIT);
+    dict_set_var(&globvardict, cmdpreviewkey, NIL, true, false, &temp);
+
     msg_silent--;   // Unblock messages
     emsg_silent--;  // Unblock error reporting
 


### PR DESCRIPTION
Added support for user commands in `cmd_can_preview`. All the commands which will be declared using this syntax `command -nargs=* -live ....` will fire up when `command_line_changed` gets called. The parameter `-live` in `command` does the whole work.

A plugin can access the CMDPREVIEW flag from `g:cmdpreview` and based on that call its own functions conditionally.

This is also referenced in #7370 as the 3rd checklist item. I need help in understanding how the live preview works, especially the part to undo the changes without screen update in a live preview.

There also other work for the live preview which includes support for global command, you can check that here #11958 .