### PR TITLE
Fix substitution creating empty undo blocks when nothing changed

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4154,6 +4154,11 @@ skip:
       print_line(curwin->w_cursor.lnum, subflags.do_number, subflags.do_list);
     }
   } else if (!global_busy) {
+    if (!preview) {
+      // Revert u_save_cursor();
+      u_undo_and_forget(1);
+    }
+
     if (got_int) {
       // interrupted
       EMSG(_(e_interr));

--- a/test/functional/legacy/080_substitute_spec.lua
+++ b/test/functional/legacy/080_substitute_spec.lua
@@ -159,4 +159,12 @@ describe(':substitue', function()
     feed('yyq')  -- For the dialog of the previous :s command.
     expect('XXx')
   end)
+
+  it('does not create empty undo block when substitution matches nothing', function()
+    insert('xxx')
+    feed_command('set magic&')
+    feed_command('%s/z//eg')
+    feed_command('undo')
+    expect('')
+  end)
 end)


### PR DESCRIPTION
This is what's creating the empty undo block https://github.com/neovim/neovim/blob/f8f41d088b2b7b503f638ce8930bedb32c0d32c5/src/nvim/ex_cmds.c#L3281-L3284

Countering that with `u_undo_and_forget(1);` seems to put us back in line with how Vim behaves, but I'm not sure if something else having to do with extended marks should be addressed instead.