### PR TITLE
LSP/completion: add textEdit support

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -161,7 +161,7 @@ end
 -- So we exclude completion candidates whose prefix does not match.
 local function remove_unmatch_completion_items(items, prefix)
   return vim.tbl_filter(function(item)
-    local word = item.insertText or item.label
+    local word = (item.textEdit and item.textEdit.newText) or item.insertText or item.label
     return vim.startswith(word, prefix)
   end, items)
 end
@@ -193,7 +193,7 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       end
     end
 
-    local word = completion_item.insertText or completion_item.label
+    local word = (completion_item.textEdit and completion_item.textEdit.newText) or completion_item.insertText or completion_item.label
     table.insert(matches, {
       word = word,
       abbr = completion_item.label,

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -157,11 +157,23 @@ local function sort_completion_items(items)
   end
 end
 
+-- Returns text that should be inserted when selecting completion item. The precedence is as follows:
+-- textEdit.newText > insertText > label
+-- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
+local function get_completion_word(item)
+  if item.textEdit ~= nil and item.textEdit.newText ~= nil then
+    return item.textEdit.newText
+  elseif item.insertText ~= nil then
+    return item.insertText
+  end
+  return item.label
+end
+
 -- Some lanuguage servers return complementary candidates whose prefixes do not match are also returned.
 -- So we exclude completion candidates whose prefix does not match.
 local function remove_unmatch_completion_items(items, prefix)
   return vim.tbl_filter(function(item)
-    local word = (item.textEdit and item.textEdit.newText) or item.insertText or item.label
+    local word = get_completion_word(item)
     return vim.startswith(word, prefix)
   end, items)
 end
@@ -193,7 +205,7 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       end
     end
 
-    local word = (completion_item.textEdit and completion_item.textEdit.newText) or completion_item.insertText or completion_item.label
+    local word = get_completion_word(completion_item)
     table.insert(matches, {
       word = word,
       abbr = completion_item.label,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -813,3 +813,35 @@ describe('LSP', function()
     end)
   end)
 end)
+
+describe('LSP', function()
+  describe('completion_list_to_complete_items', function()
+    it('should choose right completion option ', function ()
+      local prefix = 'foo'
+      local completion_list = {
+        -- resolves into label
+        { label='foobar' },
+        { label='foobar', textEdit={} },
+        -- resolves into insertText
+        { label='foocar', insertText='foobar' },
+        { label='foocar', insertText='foobar', textEdit={} },
+        -- resolves into textEdit.newText
+        { label='foocar', insertText='foodar', textEdit={newText='foobar'} },
+        { label='foocar', textEdit={newText='foobar'} }
+      }
+      local completion_list_items = {items=completion_list}
+      local expected = {
+        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+      }
+
+      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
+      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
+      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+    end)
+  end)
+end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -812,11 +812,12 @@ describe('LSP', function()
       }, buf_lines(1))
     end)
   end)
-end)
 
-describe('LSP', function()
   describe('completion_list_to_complete_items', function()
-    it('should choose right completion option ', function ()
+    -- Completion option precedence:
+    -- textEdit.newText > insertText > label
+    -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
+    it('should choose right completion option', function ()
       local prefix = 'foo'
       local completion_list = {
         -- resolves into label


### PR DESCRIPTION
According to lsp specification, value of insertText should be ignored if textEdit is provided.