### PR TITLE
[RDY] Fix splitting issue on gnu screen

### DIFF
--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -31,7 +31,10 @@ bool terminfo_is_term_family(const char *term, const char *family)
   return tlen >= flen
     && 0 == memcmp(term, family, flen)
     // Per commentary in terminfo, minus is the only valid suffix separator.
-    && ('\0' == term[flen] || '-' == term[flen]);
+    // The screen terminfo may have a terminal name like screen.xterm. By making
+    // the dot(.) a valid separator, such terminal names will also be the
+    // terminal family of the screen.
+    && ('\0' == term[flen] || '-' == term[flen] || '.' == term[flen]);
 }
 
 bool terminfo_is_bsd_console(const char *term)

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1631,6 +1631,11 @@ static void patch_terminfo_bugs(TUIData *data, const char *term,
     // per the screen manual; 2017-04 terminfo.src lacks these.
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b_");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x1b\\");
+    // Fix an issue where smglr is inherited by TERM=screen.xterm.
+    if (unibi_get_str(ut, unibi_set_lr_margin)) {
+      ILOG("Disabling smglr with TERM=screen.xterm for screen.");
+      unibi_set_str(ut, unibi_set_lr_margin, NULL);
+    }
   } else if (tmux) {
     unibi_set_if_empty(ut, unibi_to_status_line, "\x1b_");
     unibi_set_if_empty(ut, unibi_from_status_line, "\x1b\\");


### PR DESCRIPTION
gnu screen does not have `smglr`, but it inherits `smglr` from `TERM=screen.xterm` and splitting will cause drawing problems. So disable `smglr` as in #11132.