### PR TITLE
encoding: UTF-32 Assertion Failure

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1401,6 +1401,12 @@ retry:
               u8c += (unsigned)(*--p) << 16;
               u8c += (unsigned)(*--p) << 24;
             }
+
+            // Replace characters over INT_MAX
+            // with Unicode replacement character
+            if (u8c > INT_MAX) {
+              u8c = 0xfffd;
+            }
           } else {        /* UTF-8 */
             if (*--p < 0x80)
               u8c = *p;


### PR DESCRIPTION
A fix for #11877. Replaced characters over INT_MAX with U+FFFD, as proposed in the discussion.

Behaviour is now identical to that of `vim -u DEFAULTS`.

**Test coverage:**

```
[==========] 655 tests from 33 test files ran. (38134.31 ms total)
[  PASSED  ] 655 tests.
```

**Linter:**

```
Total: 0 warnings / 0 errors in 414 files
```