### PR TITLE
lsp: definition callback can accept location object

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -112,11 +112,20 @@ local function location_callback(_, method, result)
     local _ = log.info() and log.info(method, 'No location found')
     return nil
   end
-  util.jump_to_location(result[1])
-  if #result > 1 then
-    util.set_qflist(util.locations_to_items(result))
-    api.nvim_command("copen")
-    api.nvim_command("wincmd p")
+
+  -- textDocument/definition can return Location or Location[]
+  -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition
+
+  if vim.tbl_islist(result) then
+    util.jump_to_location(result[1])
+
+    if #result > 1 then
+      util.set_qflist(util.locations_to_items(result))
+      api.nvim_command("copen")
+      api.nvim_command("wincmd p")
+    end
+  else
+    util.jump_to_location(result)
   end
 end
 


### PR DESCRIPTION
goto definition response can be Location object.
response types (Location | Location[] | LocationLink[] | null)

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition

[elixir-ls](https://github.com/elixir-lsp/elixir-ls) was returning object so I needed this