### PR TITLE
[cscope] Only jump to qf item if there is exactly 1 match

### DIFF
--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -188,7 +188,6 @@ do_cscope_general(
   if (make_split) {
     if (!cmdp->cansplit) {
       (void)MSG_PUTS(_(
-
               "This cscope command does not support splitting the window.\n"));
       return;
     }

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1047,7 +1047,9 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
            */
           qi = (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
                ?  wp->w_llist_ref : wp->w_llist;
-        qf_jump(qi, 0, 0, forceit);
+        if(totmatches == 1) {
+          qf_jump(qi, 0, 0, forceit);
+        }
       }
     }
     os_remove((char *)tmp);

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -188,6 +188,7 @@ do_cscope_general(
   if (make_split) {
     if (!cmdp->cansplit) {
       (void)MSG_PUTS(_(
+
               "This cscope command does not support splitting the window.\n"));
       return;
     }
@@ -1047,7 +1048,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
            */
           qi = (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
                ?  wp->w_llist_ref : wp->w_llist;
-        if (totmatches == 1) {
+        if (cmdletter != 'g' || totmatches == 1) {
           qf_jump(qi, 0, 0, forceit);
         }
       }

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1047,7 +1047,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose,
            */
           qi = (bt_quickfix(wp->w_buffer) && wp->w_llist_ref != NULL)
                ?  wp->w_llist_ref : wp->w_llist;
-        if(totmatches == 1) {
+        if (totmatches == 1) {
           qf_jump(qi, 0, 0, forceit);
         }
       }


### PR DESCRIPTION
When performing `:cstag` or `:cscope find`, only jump to the first
quickfix item if there is exactly one result. Otherwise, wait for the
user to select a qf item before jumping. This is a lot more in line with
`:tag`.