### PR TITLE
[RFC] lsp: remove buffer version on buffer_detach

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -198,6 +198,7 @@ local function text_document_did_open_handler(bufnr, client)
     }
   }
   client.notify('textDocument/didOpen', params)
+  util.buf_versions[bufnr] = params.textDocument.version
 end
 
 --- LSP client object.
@@ -722,6 +723,7 @@ function lsp.buf_attach_client(bufnr, client_id)
             client.notify('textDocument/didClose', params)
           end
         end)
+        util.buf_versions[bufnr] = nil
         all_buffer_active_clients[bufnr] = nil
       end;
       -- TODO if we know all of the potential clients ahead of time, then we

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -134,8 +134,7 @@ end
 function M.apply_text_document_edit(text_document_edit)
   local text_document = text_document_edit.textDocument
   local bufnr = vim.uri_to_bufnr(text_document.uri)
-  -- TODO(ashkan) check this is correct.
-  if (M.buf_versions[bufnr] or 0) > text_document.version then
+  if M.buf_versions[bufnr] > text_document.version then
     print("Buffer ", text_document.uri, " newer than edits.")
     return
   end


### PR DESCRIPTION
fix: https://github.com/neovim/nvim-lsp/issues/134
When we save the buffer, the buffer is detached and attached again.
So the client also needs to remove the buffer version once.

@bfredl 
When we save the buffer, the buffer is detached and attached again.
Is this behavior itself the intended behavior?

@urandom Would you try this? cc: @Jesse-Bakker 