### PR TITLE
TUI: do not use nvim_get_option in tui thread

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2587,6 +2587,7 @@ return {
       type='bool', scope={'global'},
       vi_def=true,
       vim=true,
+      redraw={'ui_option'},
       varname='p_ttimeout',
       defaults={if_true={vi=true}}
     },
@@ -2594,6 +2595,7 @@ return {
       full_name='ttimeoutlen', abbreviation='ttm',
       type='number', scope={'global'},
       vi_def=true,
+      redraw={'ui_option'},
       varname='p_ttm',
       defaults={if_true={vi=50}}
     },

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -12,7 +12,9 @@ typedef struct term_input {
   // Phases: -1=all 0=disabled 1=first-chunk 2=continue 3=last-chunk
   int8_t paste;
   bool waiting;
+  bool ttimeout;
   int8_t waiting_for_bg_response;
+  long ttimeoutlen;
   TermKey *tk;
 #if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
   TermKey_Terminfo_Getstr_Hook *tk_ti_hook_fn;  ///< libtermkey terminfo hook

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1292,6 +1292,12 @@ static void tui_option_set(UI *ui, String name, Object value)
     data->print_attr_id = -1;
     invalidate(ui, 0, data->grid.height, 0, data->grid.width);
   }
+  if (strequal(name.data, "ttimeout")) {
+    data->input.ttimeout = value.data.boolean;
+  }
+  if (strequal(name.data, "ttimeoutlen")) {
+    data->input.ttimeoutlen = (long)value.data.integer;
+  }
 }
 
 static void tui_raw_line(UI *ui, Integer g, Integer linerow, Integer startcol,

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -20,6 +20,8 @@ describe('UI receives option updates', function()
       pumblend=0,
       showtabline=1,
       termguicolors=false,
+      ttimeout=true,
+      ttimeoutlen=50,
       ext_cmdline=false,
       ext_popupmenu=false,
       ext_tabline=false,
@@ -104,6 +106,18 @@ describe('UI receives option updates', function()
 
     command("set linespace=-11")
     expected.linespace = -11
+    screen:expect(function()
+      eq(expected, screen.options)
+    end)
+
+    command("set nottimeout")
+    expected.ttimeout = false
+    screen:expect(function()
+      eq(expected, screen.options)
+    end)
+
+    command("set ttimeoutlen=100")
+    expected.ttimeoutlen = 100
     screen:expect(function()
       eq(expected, screen.options)
     end)


### PR DESCRIPTION
Since `nvim_get_option` is executed on the tui thread as a C function instead of msgpack-rpc, it accesses global variables that may change on the main thread.