### PR TITLE
Experimental support for USDT Probes

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
 check_include_files(termios.h HAVE_TERMIOS_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
+check_include_files(sys/sdt.h HAVE_SYS_SDT_H)
 
 # Functions
 check_function_exists(fseeko HAVE_FSEEKO)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -33,6 +33,7 @@
 #cmakedefine HAVE_STRCASECMP
 #cmakedefine HAVE_STRINGS_H
 #cmakedefine HAVE_STRNCASECMP
+#cmakedefine HAVE_SYS_SDT_H
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H
 #cmakedefine HAVE_TERMIOS_H

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -40,6 +40,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/shell.h"
 #include "nvim/path.h"
+#include "nvim/probe.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"
 #include "nvim/screen.h"
@@ -5106,6 +5107,8 @@ static garray_T funcargs = GA_EMPTY_INIT_VALUE;
 /// @returns        true if some memory was freed.
 bool garbage_collect(bool testing)
 {
+  PROBE_EVAL_GC_ENTRY(testing);
+
   bool abort = false;
 #define ABORTING(func) abort = abort || func
 
@@ -5303,6 +5306,8 @@ bool garbage_collect(bool testing)
         "Not enough memory to set references, garbage collection aborted!"));
   }
 #undef ABORTING
+
+  PROBE_EVAL_GC_RETURN(did_free);
   return did_free;
 }
 
@@ -6305,6 +6310,8 @@ call_func(
   // be changed or deleted in the called function.
   name = vim_strnsave(funcname, len);
 
+  PROBE_EVAL_CALL_FUNC_ENTRY(name, len);
+
   fname = fname_trans_sid(name, fname_buf, &tofree, &error);
 
   *doesrange = false;
@@ -6450,6 +6457,8 @@ call_func(
       break;
     }
   }
+
+  PROBE_EVAL_CALL_FUNC_RETURN(funcname, len, ret);
 
   while (argv_clear > 0) {
     tv_clear(&argv[--argv_clear]);
@@ -11117,6 +11126,8 @@ void ex_function(exarg_T *eap)
   fp->uf_calls = 0;
   fp->uf_script_ctx = current_sctx;
   fp->uf_script_ctx.sc_lnum += sourcing_lnum_top;
+
+  PROBE_EVAL_DEFINE_FUNCTION(sourcing_name, &fp->uf_name);
 
   goto ret_free;
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -20,6 +20,7 @@
 #include "nvim/os/shell.h"
 #include "nvim/os/signal.h"
 #include "nvim/path.h"
+#include "nvim/probe.h"
 #include "nvim/types.h"
 #include "nvim/main.h"
 #include "nvim/vim.h"
@@ -640,6 +641,8 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
   int current_state = State;
   bool forward_output = true;
 
+  PROBE_OS_CALL_SHELL_ENTRY(cmd);
+
   // While the child is running, ignore terminating signals
   signal_reject_deadly();
 
@@ -680,6 +683,8 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
 
   State = current_state;
   signal_accept_deadly();
+
+  PROBE_OS_CALL_SHELL_RETURN(exitcode);
 
   return exitcode;
 }
@@ -722,6 +727,8 @@ static int do_os_system(char **argv,
                         bool silent,
                         bool forward_output)
 {
+  PROBE_OS_SYSTEM_ENTRY(argv, input, len);
+
   out_data_decide_throttle(0);  // Initialize throttle decider.
   out_data_ring(NULL, 0);       // Initialize output ring-buffer.
   bool has_input = (input != NULL && input[0] != '\0');
@@ -832,6 +839,8 @@ static int do_os_system(char **argv,
 
   assert(multiqueue_empty(events));
   multiqueue_free(events);
+
+  PROBE_OS_SYSTEM_RETURN(exitcode, output, nread);
 
   return exitcode;
 }

--- a/src/nvim/probe.h
+++ b/src/nvim/probe.h
@@ -1,0 +1,40 @@
+#ifndef NVIM_PROBE_H
+#define NVIM_PROBE_H
+
+#if defined(UNIT_TESTING)
+
+// TODO(zacharyl): Figure out how to pass these to unit tests
+#include <stdio.h>
+#define __PROBE(name, n, ...) fputs("PROBE" #n ": " #name "\n", stderr)
+
+#elif defined(HAVE_SYS_SDT_H)
+
+#include <sys/sdt.h>
+#define __PROBE(name, n, ...) STAP_PROBE##n(neovim, name, ##__VA_ARGS__)
+
+#else
+
+#define __PROBE(name, n, ...)
+
+#endif
+
+#define PROBE_EVAL_GC_ENTRY(testing) __PROBE(eval__gc__entry, 1, testing)
+#define PROBE_EVAL_GC_RETURN(did_free) __PROBE(eval__gc__return, 1, did_free)
+
+#define PROBE_EVAL_CALL_FUNC_ENTRY(funcname, len)                              \
+  __PROBE(eval__call_func__entry, 2, funcname, len)
+#define PROBE_EVAL_CALL_FUNC_RETURN(funcname, len, ret)                        \
+  __PROBE(eval__call_func__return, 3, funcname, len, ret)
+#define PROBE_EVAL_DEFINE_FUNCTION(script, funcname)                           \
+  __PROBE(eval__define_function, 2, script, funcname)
+
+#define PROBE_OS_CALL_SHELL_ENTRY(cmd) __PROBE(os__call_shell__entry, 1, cmd)
+#define PROBE_OS_CALL_SHELL_RETURN(exitcode)                                   \
+  __PROBE(os__call_shell__return, 1, exitcode)
+
+#define PROBE_OS_SYSTEM_ENTRY(argv, input, len)                                \
+  __PROBE(os__system__entry, 3, argv, input, len)
+#define PROBE_OS_SYSTEM_RETURN(ret, output, nread)                             \
+  __PROBE(os__system__return, 3, ret, output, nread)
+
+#endif  // NVIM_PROBE_H


### PR DESCRIPTION
This branch introduces support for USDT probes and a few example probes.
Support is enabled if sys/sdt.h is found. This header comes from glibc, if built with --enable-systemtap, or from systemtap.

I have been trying this out as a way to trace the causes of slow
operations in neovim. Often I've seen this caused by things like plugins
that access a network share, or attempt to write a large number of
files, etc.

This is useful for me, but I wanted to see if there is general interest
in adding support for this.

Here's a not-too-exciting example of tracing function entry and exits:

```
$ sudo /usr/share/bcc/tools/trace 'u:build/bin/nvim:eval__call_func__entry "-> %s", arg1' 'u:build/bin/nvim:eval__call_func__return "<- %s", arg1'
PID     TID     COMM            FUNC             -
119595  119595  nvim            eval__call_func__entry -> b'extend'
119595  119595  nvim            eval__call_func__entry -> b'jobstart'
119595  119595  nvim            eval__call_func__return <- b'exists'
119595  119595  nvim            eval__call_func__return <- b'win_getid'
119595  119595  nvim            eval__call_func__return <- b'winnr'
```

This is an example of a slightly more complicated example, using
bpftrace. It tracks vim functions that took a long time, and prints out
any files that were opened during that period. At the end, it prints
a histogram of function timing:

```
 #!/usr/bin/env bpftrace

BEGIN {
  @depth = -1;
}

tracepoint:sched:sched_process_fork /@pidmap[args->parent_pid]/ {
  @pidmap[args->child_pid] = 1;
}

tracepoint:sched:sched_process_exit /@pidmap[args->pid]/ {
  delete(@pidmap[args->pid]);
}

usdt:build/bin/nvim:neovim:eval__call_func__entry {
    @pidmap[pid] = 1;
    @depth++;
    @funcentry[@depth] = nsecs;
}

usdt:build/bin/nvim:neovim:eval__call_func__return {
    $func = str(arg0);
    $msecs = (nsecs - @funcentry[@depth]) / 1000000;

    @time_histo = hist($msecs);

    if ($msecs >= 1000) {
      printf("%u ms for %s\n", $msecs, $func);
      print(@files);
    }

    clear(@files);
    delete(@funcentry[@depth]);
    @depth--;
}

tracepoint:syscalls:sys_enter_open,
tracepoint:syscalls:sys_enter_openat {
  if (@pidmap[pid] == 1 && @depth >= 0) {
    @files[str(args->filename)] = count();
  }
}

END {
  clear(@depth);
}
```
```
$ sudo bpftrace funcslower.bt
1527 ms for Slower
@files[/usr/lib/libstdc++.so.6]: 2
@files[/etc/fish/config.fish]: 2
<snip>

^C
@time_histo:
[0]                71430 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1]                  346 |                                                    |
[2, 4)               208 |                                                    |
[4, 8)                91 |                                                    |
[8, 16)               22 |                                                    |
[16, 32)              85 |                                                    |
[32, 64)               7 |                                                    |
[64, 128)              0 |                                                    |
[128, 256)             0 |                                                    |
[256, 512)             6 |                                                    |
[512, 1K)              1 |                                                    |
[1K, 2K)               5 |                                                    |
```