### PR TITLE
[WIP] Add float ex commands

### DIFF
--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -208,6 +208,7 @@ struct expand {
 typedef struct {
   int split;                   ///< flags for win_split()
   int tab;                     ///< > 0 when ":tab" was used
+  bool floating;               ///< true ":float" was used
   bool browse;                 ///< true to invoke file dialog
   bool confirm;                ///< true to invoke yes/no dialog
   bool hide;                   ///< true when ":hide" was used

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5845,6 +5845,7 @@ uc_check_code(
     static mod_entry_T mod_entries[] = {
       { &cmdmod.browse, "browse" },
       { &cmdmod.confirm, "confirm" },
+      { &cmdmod.floating, "float" },
       { &cmdmod.hide, "hide" },
       { &cmdmod.keepalt, "keepalt" },
       { &cmdmod.keepjumps, "keepjumps" },

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1039,6 +1039,8 @@ bool parse_float_config(Dictionary config, FloatConfig *fconfig, bool reconf,
  */
 int win_split(int size, int flags)
 {
+  // TODO(float-ex): Add :float handling here
+
   /* When the ":tab" modifier was used open a new tab page instead. */
   if (may_open_tabpage() == OK)
     return OK;


### PR DESCRIPTION
Resolves #9663

This PR aims to add a `:float` modifier for floating windows, analogous to `:tab`, `:vert` and friends, with user-configurable settings (e.g. vertical and horizontal padding).

Also, I'd like to implement some way of hiding/unhiding floating windows, so workflows that use persistent terminals in floating windows are supported, but I don't know how that should work if there are multiple floating windows. Maybe as a stack?