### PR TITLE
vim.validate(): include stacktrace in message

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -514,20 +514,20 @@ do
       local optional = (true == spec[3])
 
       if type(t) == 'string' then
-        local translated_type_name = type_names[t]
-        if not translated_type_name then
+        local t_name = type_names[t]
+        if not t_name then
           return false, string.format('invalid type name: %s', t)
         end
 
-        if (not optional or val ~= nil) and not _is_type(val, translated_type_name) then
-          return false, string.format("%s: expected %s, got %s", param_name, translated_type_name, type(val))
+        if (not optional or val ~= nil) and not _is_type(val, t_name) then
+          return false, string.format("%s: expected %s, got %s", param_name, t_name, type(val))
         end
       elseif vim.is_callable(t) then
         -- Check user-provided validation function.
         local valid, optional_message = t(val)
         if not valid then
           local error_message = string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), val)
-          if not (optional_message == nil) then
+          if optional_message ~= nil then
             error_message = error_message .. string.format(". Info: %s", optional_message)
           end
 

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -477,48 +477,77 @@ end
 ---          2. (arg_value, fn, msg)
 ---             - arg_value: argument value
 ---             - fn: any function accepting one argument, returns true if and
----               only if the argument is valid
+---               only if the argument is valid. Can optionally return an additional
+---               informative error message as the second returned value.
 ---             - msg: (optional) error string if validation fails
 function vim.validate(opt) end  -- luacheck: no unused
-vim.validate = (function()
+
+do
   local type_names = {
-    t='table', s='string', n='number', b='boolean', f='function', c='callable',
-    ['table']='table', ['string']='string', ['number']='number',
-    ['boolean']='boolean', ['function']='function', ['callable']='callable',
-    ['nil']='nil', ['thread']='thread', ['userdata']='userdata',
+    ['table']    = 'table',    t = 'table',
+    ['string']   = 'string',   s = 'string',
+    ['number']   = 'number',   n = 'number',
+    ['boolean']  = 'boolean',  b = 'boolean',
+    ['function'] = 'function', f = 'function',
+    ['callable'] = 'callable', c = 'callable',
+    ['nil']      = 'nil',
+    ['thread']   = 'thread',
+    ['userdata'] = 'userdata',
   }
-  local function _type_name(t)
-    local tname = type_names[t]
-    if tname == nil then
-      error(string.format('invalid type name: %s', tostring(t)))
-    end
-    return tname
-  end
+
   local function _is_type(val, t)
     return t == 'callable' and vim.is_callable(val) or type(val) == t
   end
 
-  return function(opt)
-    assert(type(opt) == 'table', string.format('opt: expected table, got %s', type(opt)))
+  local function is_valid(opt)
+    if type(opt) ~= 'table' then
+      return false, string.format('opt: expected table, got %s', type(opt))
+    end
+
     for param_name, spec in pairs(opt) do
-      assert(type(spec) == 'table', string.format('%s: expected table, got %s', param_name, type(spec)))
+      if type(spec) ~= 'table' then
+        return false, string.format('opt[%s]: expected table, got %s', param_name, type(spec))
+      end
 
       local val = spec[1]   -- Argument value.
       local t = spec[2]     -- Type name, or callable.
       local optional = (true == spec[3])
 
-      if not vim.is_callable(t) then  -- Check type name.
-        if (not optional or val ~= nil) and not _is_type(val, _type_name(t)) then
-          error(string.format("%s: expected %s, got %s", param_name, _type_name(t), type(val)))
+      if type(t) == 'string' then
+        local translated_type_name = type_names[t]
+        if not translated_type_name then
+          return false, string.format('invalid type name: %s', t)
         end
-      elseif not t(val) then  -- Check user-provided validation function.
-        error(string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), val))
+
+        if (not optional or val ~= nil) and not _is_type(val, translated_type_name) then
+          return false, string.format("%s: expected %s, got %s", param_name, translated_type_name, type(val))
+        end
+      elseif vim.is_callable(t) then
+        -- Check user-provided validation function.
+        local valid, optional_message = t(val)
+        if not valid then
+          local error_message = string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), val)
+          if not (optional_message == nil) then
+            error_message = error_message .. string.format(". Info: %s", optional_message)
+          end
+
+          return false, error_message
+        end
+      else
+        return false, string.format("invalid type name: %s", tostring(t))
       end
     end
-    return true
-  end
-end)()
 
+    return true, nil
+  end
+
+  function vim.validate(opt)
+    local ok, err_msg = is_valid(opt)
+    if not ok then
+      error(debug.traceback(err_msg, 2), 2)
+    end
+  end
+end
 --- Returns true if object `f` can be called as a function.
 ---
 --@param f Any object

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -449,19 +449,19 @@ describe('API', function()
     end)
 
     it('reports errors', function()
-      eq([[Error loading lua: [string "<nvim>"]:1: '=' expected near '+']],
+      eq([[Error loading lua: [string "<nvim>"]:0: '=' expected near '+']],
         pcall_err(meths.exec_lua, 'a+*b', {}))
 
-      eq([[Error loading lua: [string "<nvim>"]:1: unexpected symbol near '1']],
+      eq([[Error loading lua: [string "<nvim>"]:0: unexpected symbol near '1']],
         pcall_err(meths.exec_lua, '1+2', {}))
 
-      eq([[Error loading lua: [string "<nvim>"]:1: unexpected symbol]],
+      eq([[Error loading lua: [string "<nvim>"]:0: unexpected symbol]],
         pcall_err(meths.exec_lua, 'aa=bb\0', {}))
 
-      eq([[Error executing lua: [string "<nvim>"]:1: attempt to call global 'bork' (a nil value)]],
+      eq([[Error executing lua: [string "<nvim>"]:0: attempt to call global 'bork' (a nil value)]],
         pcall_err(meths.exec_lua, 'bork()', {}))
 
-      eq('Error executing lua: [string "<nvim>"]:1: did\nthe\nfail',
+      eq('Error executing lua: [string "<nvim>"]:0: did\nthe\nfail',
         pcall_err(meths.exec_lua, 'error("did\\nthe\\nfail")', {}))
     end)
 
@@ -605,7 +605,7 @@ describe('API', function()
     end)
     it('vim.paste() failure', function()
       nvim('exec_lua', 'vim.paste = (function(lines, phase) error("fake fail") end)', {})
-      eq([[Error executing lua: [string "<nvim>"]:1: fake fail]],
+      eq([[Error executing lua: [string "<nvim>"]:0: fake fail]],
         pcall_err(request, 'nvim_paste', 'line 1\nline 2\nline 3', false, 1))
     end)
   end)

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -43,7 +43,7 @@ describe(':lua command', function()
     eq({'', 'ETTS', 'TTSE', 'STTE'}, curbufmeths.get_lines(0, 100, false))
   end)
   it('throws catchable errors', function()
-    eq([[Vim(lua):E5107: Error loading lua [string ":lua"]:1: unexpected symbol near ')']],
+    eq([[Vim(lua):E5107: Error loading lua [string ":lua"]:0: unexpected symbol near ')']],
        pcall_err(command, 'lua ()'))
     eq([[Vim(lua):E5108: Error executing lua [string ":lua"]:1: TEST]],
        exc_exec('lua error("TEST")'))

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -477,14 +477,14 @@ describe('v:lua', function()
     eq(NIL, eval('v:lua.mymod.noisy("eval")'))
     eq("hey eval", meths.get_current_line())
 
-    eq("Vim:E5108: Error executing lua [string \"<nvim>\"]:10: attempt to call global 'nonexistent' (a nil value)",
+    eq("Vim:E5108: Error executing lua [string \"<nvim>\"]:0: attempt to call global 'nonexistent' (a nil value)",
        pcall_err(eval, 'v:lua.mymod.crashy()'))
   end)
 
   it('works in :call', function()
     command(":call v:lua.mymod.noisy('command')")
     eq("hey command", meths.get_current_line())
-    eq("Vim(call):E5108: Error executing lua [string \"<nvim>\"]:10: attempt to call global 'nonexistent' (a nil value)",
+    eq("Vim(call):E5108: Error executing lua [string \"<nvim>\"]:0: attempt to call global 'nonexistent' (a nil value)",
        pcall_err(command, 'call v:lua.mymod.crashy()'))
   end)
 

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -15,14 +15,14 @@ before_each(clear)
 describe('treesitter API', function()
   -- error tests not requiring a parser library
   it('handles missing language', function()
-    eq("Error executing lua: .../language.lua: no parser for 'borklang' language, see :help treesitter-parsers",
+    eq("Error executing lua: .../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.get_parser(0, 'borklang')"))
 
     -- actual message depends on platform
     matches("Error executing lua: Failed to load parser: uv_dlopen: .+",
        pcall_err(exec_lua, "parser = vim.treesitter.require_language('borklang', 'borkbork.so')"))
 
-    eq("Error executing lua: .../language.lua: no parser for 'borklang' language, see :help treesitter-parsers",
+    eq("Error executing lua: .../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.inspect_language('borklang')"))
   end)
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6,7 +6,6 @@ local buf_lines = helpers.buf_lines
 local dedent = helpers.dedent
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
-local contains = helpers.contains
 local pcall_err = helpers.pcall_err
 local pesc = helpers.pesc
 local insert = helpers.insert
@@ -748,8 +747,16 @@ describe('LSP', function()
     end)
 
     it('should invalid cmd argument', function()
-      contains('cmd: expected list, got nvim', pcall_err(_cmd_parts, "nvim"))
-      contains('cmd argument: expected string, got number', pcall_err(_cmd_parts, {"nvim", 1}))
+      eq(dedent([[
+          Error executing lua: .../lsp.lua:0: cmd: expected list, got nvim
+          stack traceback:
+              .../lsp.lua:0: in function .../lsp.lua:0>]]),
+        pcall_err(_cmd_parts, 'nvim'))
+      eq(dedent([[
+          Error executing lua: .../lsp.lua:0: cmd argument: expected string, got number
+          stack traceback:
+              .../lsp.lua:0: in function .../lsp.lua:0>]]),
+        pcall_err(_cmd_parts, {'nvim', 1}))
     end)
   end)
 end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6,6 +6,7 @@ local buf_lines = helpers.buf_lines
 local dedent = helpers.dedent
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
+local contains = helpers.contains
 local pcall_err = helpers.pcall_err
 local pesc = helpers.pesc
 local insert = helpers.insert
@@ -747,8 +748,8 @@ describe('LSP', function()
     end)
 
     it('should invalid cmd argument', function()
-      eq('Error executing lua: .../shared.lua: cmd: expected list, got nvim', pcall_err(_cmd_parts, "nvim"))
-      eq('Error executing lua: .../shared.lua: cmd argument: expected string, got number', pcall_err(_cmd_parts, {"nvim", 1}))
+      contains('cmd: expected list, got nvim', pcall_err(_cmd_parts, "nvim"))
+      contains('cmd argument: expected string, got number', pcall_err(_cmd_parts, {"nvim", 1}))
     end)
   end)
 end)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -59,7 +59,7 @@ describe('floatwin', function()
   end)
 
   it('closed immediately by autocmd #11383', function()
-    eq('Error executing lua: [string "<nvim>"]:4: Window was closed immediately',
+    eq('Error executing lua: [string "<nvim>"]:0: Window was closed immediately',
       pcall_err(exec_lua, [[
         local a = vim.api
         local function crashes(contents)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -99,6 +99,9 @@ function module.matches(pat, actual)
   end
   error(string.format('Pattern does not match.\nPattern:\n%s\nActual:\n%s', pat, actual))
 end
+function module.contains(pat, actual)
+  return module.matches(".*" .. pat .. ".*", actual)
+end
 
 --- Asserts that `pat` matches one or more lines in the tail of $NVIM_LOG_FILE.
 ---

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -99,9 +99,6 @@ function module.matches(pat, actual)
   end
   error(string.format('Pattern does not match.\nPattern:\n%s\nActual:\n%s', pat, actual))
 end
-function module.contains(pat, actual)
-  return module.matches(".*" .. pat .. ".*", actual)
-end
 
 --- Asserts that `pat` matches one or more lines in the tail of $NVIM_LOG_FILE.
 ---
@@ -119,8 +116,12 @@ function module.assert_log(pat, logfile)
     pat, nrlines, logfile, logtail))
 end
 
--- Invokes `fn` and returns the error string (may truncate full paths), or
--- raises an error if `fn` succeeds.
+-- Invokes `fn` and returns the error string (with truncated paths), or raises
+-- an error if `fn` succeeds.
+--
+-- Replaces line/column numbers with zero:
+--     shared.lua:0: in function 'gsplit'
+--     shared.lua:0: in function <shared.lua:0>'
 --
 -- Usage:
 --    -- Match exact string.
@@ -128,27 +129,34 @@ end
 --    -- Match Lua pattern.
 --    matches('e[or]+$', pcall_err(function(a, b) error('some error') end, 'arg1', 'arg2'))
 --
-function module.pcall_err(fn, ...)
+function module.pcall_err_withfile(fn, ...)
   assert(type(fn) == 'function')
   local status, rv = pcall(fn, ...)
   if status == true then
     error('expected failure, but got success')
   end
-  -- From this:
-  --    /home/foo/neovim/runtime/lua/vim/shared.lua:186: Expected string, got number
-  -- to this:
-  --     Expected string, got number
-  local errmsg = tostring(rv):gsub('^[^:]+:%d+: ', '')
-  -- From this:
-  --    Error executing lua: /very/long/foo.lua:186: Expected string, got number
-  -- to this:
-  --    Error executing lua: .../foo.lua:186: Expected string, got number
-  errmsg = errmsg:gsub([[lua: [a-zA-Z]?:?[^:]-[/\]([^:/\]+):%d+: ]], 'lua: .../%1: ')
-  -- Compiled modules will not have a path and will just be a name like
-  -- shared.lua:186, so strip the number.
-  errmsg = errmsg:gsub([[lua: ([^:/\ ]+):%d+: ]], 'lua: .../%1: ')
-  --                          ^ Windows drive-letter (C:)
+  -- From:
+  --    C:/long/path/foo.lua:186: Expected string, got number
+  -- to:
+  --    .../foo.lua:0: Expected string, got number
+  local errmsg = tostring(rv):gsub('[^%s]-[/\\]([^%s:/\\]+):%d+', '.../%1:0')
+  -- Scrub numbers in paths/stacktraces:
+  --    shared.lua:0: in function 'gsplit'
+  --    shared.lua:0: in function <shared.lua:0>'
+  errmsg = errmsg:gsub('([^%s]):%d+', '%1:0')
+  -- Scrub tab chars:
+  errmsg = errmsg:gsub('\t', '    ')
+  -- In Lua 5.1, we sometimes get a "(tail call): ?" on the last line.
+  --    We remove this so that the tests are not lua dependent.
+  errmsg = errmsg:gsub('%s*%(tail call%): %?', '')
+
   return errmsg
+end
+
+function module.pcall_err(fn, ...)
+  local errmsg = module.pcall_err_withfile(fn, ...)
+
+  return errmsg:gsub('.../helpers.lua:0: ', '')
 end
 
 -- initial_path:  directory to recurse into


### PR DESCRIPTION
### No longer exactly old PR.

Now just makes `vim.validate` show a traceback. Doesn't change behavior (still raises error).

This way there are no cryptic messages with no context about who passed the wrong parameters.

Result:

```lua
local function z(val)
  vim.validate { val = { val, 'string' } }
end

local function y(val)
  z(val)
end

local function x(val)
  y(val)
end

x(5)
```

```
Error detected while processing function <SNR>12_save_and_exec:                                                                             
line    6:                                                                                                                                  
E5113: Error while calling lua chunk: /home/tj/test/vim_validate.lua:3: val: expected string, got number                                    
stack traceback:                                                                                                                            
        /home/tj/test/vim_validate.lua:3: in function 'z'                                                                                   
        /home/tj/test/vim_validate.lua:7: in function 'y'                                                                                   
        /home/tj/test/vim_validate.lua:11: in function 'x'                                                                                  
        /home/tj/test/vim_validate.lua:14: in main chunk
```