### PR TITLE
vim.uri: fix uri_to_fname

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -70,6 +70,7 @@ local function uri_from_bufnr(bufnr)
 end
 
 local function uri_to_fname(uri)
+  uri = uri_decode(uri)
   -- TODO improve this.
   if is_windows_file_uri(uri) then
     uri = uri:gsub('^file:///', '')
@@ -77,7 +78,7 @@ local function uri_to_fname(uri)
   else
     uri = uri:gsub('^file://', '')
   end
-  return uri_decode(uri)
+  return uri
 end
 
 -- Return or create a buffer for a uri.

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -85,6 +85,15 @@ describe('URI methods', function()
         eq('C:\\Foo\\Bar\\Baz.txt', exec_lua(test_case))
       end)
 
+      it('file path includes only ascii charactors with encoded colon character', function()
+        local test_case = [[
+        local uri = 'file:///C%3A/Foo/Bar/Baz.txt'
+        return vim.uri_to_fname(uri)
+        ]]
+
+        eq('C:\\Foo\\Bar\\Baz.txt', exec_lua(test_case))
+      end)
+
       it('file path including white space', function()
         local test_case = [[
         local uri = 'file:///C:/Foo%20/Bar/Baz.txt'


### PR DESCRIPTION
fix: #12056
If the colon of the drive letter of windows is URI encoded,
it doesn't match the expected pattern, so decode it first.