### PR TITLE
[WIP] vim-patch:8.0.{858,953,1382,1525}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1641,9 +1641,10 @@ void no_write_message(void)
   EMSG(_("E37: No write since last change (add ! to override)"));
 }
 
-void no_write_message_nobang(void)
+void no_write_message_nobang(const buf_T *const buf)
+  FUNC_ATTR_NONNULL_ALL
 {
-  if (channel_job_running((uint64_t)curbuf->b_p_channel)) {
+  if (channel_job_running((uint64_t)buf->b_p_channel)) {
     EMSG(_("E948: Job still running"));
   } else {
     EMSG(_("E37: No write since last change"));

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1643,7 +1643,11 @@ void no_write_message(void)
 
 void no_write_message_nobang(void)
 {
-  EMSG(_("E37: No write since last change"));
+  if (channel_job_running((uint64_t)curbuf->b_p_channel)) {
+    EMSG(_("E948: Job still running"));
+  } else {
+    EMSG(_("E37: No write since last change"));
+  }
 }
 
 //

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1952,7 +1952,10 @@ void do_wqall(exarg_T *eap)
   }
 
   FOR_ALL_BUFFERS(buf) {
-    if (!bufIsChanged(buf) || bt_dontwrite(buf)) {
+    if (exiting && channel_job_running((uint64_t)buf->b_p_channel)) {
+      no_write_message_nobang(buf);
+      error++;
+    } else if (!bufIsChanged(buf) || bt_dontwrite(buf)) {
       continue;
     }
     /*

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1388,7 +1388,7 @@ do_shell(
       && !autocmd_busy
       && msg_silent == 0)
     FOR_ALL_BUFFERS(buf) {
-      if (bufIsChanged(buf)) {
+      if (bufIsChangedNotTerm(buf)) {
         MSG_PUTS(_("[No write since last change]\n"));
         break;
       }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1281,7 +1281,7 @@ bool check_changed(buf_T *buf, int flags)
     if (flags & CCGD_EXCMD) {
       no_write_message();
     } else {
-      no_write_message_nobang();
+      no_write_message_nobang(curbuf);
     }
     return true;
   }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1487,8 +1487,10 @@ bool check_changed_any(bool hidden, bool unload)
       msg_col = 0;
       msg_didout = false;
     }
-    if (EMSG2(_("E162: No write since last change for buffer \"%s\""),
-              buf_spname(buf) != NULL ? buf_spname(buf) : buf->b_fname)) {
+    if (channel_job_running((uint64_t)buf->b_p_channel)
+        ? EMSG2(_("E947: Job still running in buffer \"%s\""), buf->b_fname)
+        : EMSG2(_("E162: No write since last change for buffer \"%s\""),
+                buf_spname(buf) != NULL ? buf_spname(buf) : buf->b_fname)) {
       save = no_wait_return;
       no_wait_return = false;
       wait_return(false);

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2971,6 +2971,9 @@ static char_u *u_save_line(linenr_T lnum)
 bool bufIsChanged(buf_T *buf)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
+  if (channel_job_running((uint64_t)buf->b_p_channel)) {
+    return true;
+  }
   // In a "prompt" buffer we do respect 'modified', so that we can control
   // closing the window by setting or resetting that option.
   return  (!bt_dontwrite(buf) || bt_prompt(buf))

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2964,6 +2964,7 @@ static char_u *u_save_line(linenr_T lnum)
 /// Check if the 'modified' flag is set, or 'ff' has changed (only need to
 /// check the first character, because it can only be "dos", "unix" or "mac").
 /// "nofile" and "scratch" type buffers are considered to always be unchanged.
+/// Also considers a buffer changed when a terminal window contains a running
 ///
 /// @param buf The buffer to check
 ///
@@ -2974,6 +2975,13 @@ bool bufIsChanged(buf_T *buf)
   if (channel_job_running((uint64_t)buf->b_p_channel)) {
     return true;
   }
+  return bufIsChangedNotTerm(buf);
+}
+
+// Like bufIsChanged() but ignoring a terminal window.
+bool bufIsChangedNotTerm(buf_T *buf)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+{
   // In a "prompt" buffer we do respect 'modified', so that we can control
   // closing the window by setting or resetting that option.
   return  (!bt_dontwrite(buf) || bt_prompt(buf))

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -6,6 +6,7 @@ local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.s
 local eq, neq = helpers.eq, helpers.neq
 local write_file = helpers.write_file
 local command= helpers.command
+local exc_exec = helpers.exc_exec
 
 describe(':terminal buffer', function()
   local screen
@@ -240,6 +241,10 @@ describe(':terminal buffer', function()
       {3:-- TERMINAL --}                                    |
     ]])
     command('bdelete!')
+  end)
+
+  it('handles wqall', function()
+    eq('Vim(wqall):E948: Job still running', exc_exec('wqall'))
   end)
 end)
 


### PR DESCRIPTION
Decoupled from https://github.com/neovim/neovim/pull/11997 to focus on the new behavior of `:wqall` in the terminal.