### PR TITLE
Check for bash version in vim-patch.sh

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -6,8 +6,8 @@ set -u
 set -p
 
 # Ensure that the user has a bash that supports -A
-if [ "${BASH_VERSINFO[0]}" -lt 4  ]; then
-  echo "Update your bash version to one that supports -A syntax (>3)"
+if [[ "${BASH_VERSINFO[0]}" -lt 4  ]]; then
+  echo "This script requires bash version 3 or later (you have ${BASH_VERSION})." >&2
   exit 1
 fi
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -5,6 +5,12 @@ set -u
 # Use privileged mode, which e.g. skips using CDPATH.
 set -p
 
+# Ensure that the user has a bash that supports -A
+if [ "${BASH_VERSINFO[0]}" -lt 4  ]; then
+  echo "Update your bash version to one that supports -A syntax (>3)"
+  exit 1
+fi
+
 readonly NVIM_SOURCE_DIR="${NVIM_SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 readonly VIM_SOURCE_DIR_DEFAULT="${NVIM_SOURCE_DIR}/.vim-src"
 readonly VIM_SOURCE_DIR="${VIM_SOURCE_DIR:-${VIM_SOURCE_DIR_DEFAULT}}"


### PR DESCRIPTION
Because of licensing reasons apple is not going to upgrade their installed bash version anytime soon. Checking for an unsupported version and informing the user about the need to update their bash is probably the easiest workaround we can do. Could also compromise and make the script be compatible with antique bash, but that doesn't sound necessary.

I'd gladly also add this warning to any other scripts / to a wrapper script if there's other places in the neovim build / contribution chain where a bash version check could be useful. Any pointers about this?

Fixes  #12069 
