### PR TITLE
netrw.vim: `gx` ignore terminal buffers

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -5460,6 +5460,11 @@ fun! netrw#CheckIfRemote(...)
   else
    let curfile= expand("%")
   endif
+
+  " Ignore terminal buffers
+  if &buftype ==# 'terminal'
+    return 0
+  endif
 "  call Decho("curfile<".curfile.">")
   if curfile =~ '^\a\{3,}://'
 "   call Dret("netrw#CheckIfRemote 1")


### PR DESCRIPTION
netrw thinks it's a remote file due the name of a terminal buffer (term://),
but a terminal buffer isn't a file.

Fixes https://github.com/neovim/neovim/issues/4612#issuecomment-600321171