### PR TITLE
Support tagstack for lsp location jump

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -322,16 +322,40 @@ end
 
 function M.jump_to_location(location)
   if location.uri == nil then return end
-  local bufnr = vim.uri_to_bufnr(location.uri)
   -- Save position in jumplist
   vim.cmd "normal! m'"
   -- TODO(ashkan) use tagfunc here to update tagstack.
-  api.nvim_set_current_buf(bufnr)
-  local row = location.range.start.line
-  local col = location.range.start.character
-  local line = api.nvim_buf_get_lines(0, row, row+1, true)[1]
-  col = vim.str_byteindex(line, col)
-  api.nvim_win_set_cursor(0, {row + 1, col})
+  local tag_temp_path = os.tmpname()
+  local jump_word = vim.fn.expand("<cword>")
+  local jump_fname = vim.uri_to_fname(location.uri)
+  local jump_row = location.range.start.line
+  local jump_col = location.range.start.character
+  local tag_file = io.open(tag_temp_path, "w")
+  local tag_file_content = string.format("%s\t%s\tcall cursor(%d, %d)",
+      jump_word,
+      jump_fname,
+      tonumber(jump_row)+1,
+      tonumber(jump_col)
+  )
+  tag_file:write(tag_file_content)
+  tag_file:close()
+
+  -- Store the original setting and set temporary new setting
+  local ori_tag_setting = vim.api.nvim_get_option("tags")
+  local ori_wildignore = vim.api.nvim_get_option("wildignore")
+  vim.api.nvim_set_option("tags", tag_temp_path)
+  vim.api.nvim_set_option("wildignore", "")
+
+  -- Jump to the new location
+  vim.cmd(string.format("tjump %s", jump_word))
+
+  -- Restore the orignal setting
+  vim.api.nvim_set_option("tags", ori_tag_setting)
+  vim.api.nvim_set_option("wildignore", ori_wildignore)
+
+  -- Remove the temp tag file
+  os.remove(tag_temp_path)
+
   return true
 end
 


### PR DESCRIPTION
Thanks for the amazing built-in lsp feature. I really love it.

The function to jump to the definition in lsp is very good but can not jump to the original location. The patch tries to provide a simple solution - add the destination to a temp tag file then jump.

Maybe it's not a good solution. I hope that the commit can provide some ideas to let someone add the function.

The code rewrites the code from https://github.com/davidhalter/jedi-vim/blob/686f39ac002ca31acd663ae8749982144484ff95/pythonx/jedi_vim.py#L387-L405