### PR TITLE
TUI: support setting cursor color in tmux

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1903,7 +1903,7 @@ static void augment_terminfo(TUIData *data, const char *term,
     // would use a tmux control sequence and an extra if(screen) test.
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(
         ut, NULL, TMUX_WRAP(tmux, "\033]Pl%p1%06x\033\\"));
-  } else if ((xterm || rxvt || alacritty)
+  } else if ((xterm || rxvt || tmux || alacritty)
              && (vte_version == 0 || vte_version >= 3900)) {
     // Supported in urxvt, newer VTE.
     data->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(


### PR DESCRIPTION
This enables setting the cursor color in tmux.

tmux has support for setting the cursor color, and is able to translate the sequence as necessary for its host terminal.

It seems Neovim originally implicitly supported cursor coloring in tmux (and many other terminals) by assuming a default cursor color sequence. This was dropped here: https://github.com/neovim/neovim/commit/3d8e0594e495c42dbdf3871ef3c3023e128f748c#diff-3ac88981a139ac0eee448a6bd19c7569R2012

There's currently a wrapper for sequence passthrough around setting the cursor color for iTerm specifically (introduced in https://github.com/neovim/neovim/pull/6588/commits/c1d3bcc1842d7ca4edb514ef162696afd910f532). I'm not sure whether the same wrapper would be desired for other terminals that are not tmux, so I left that unchanged. However, with this explicit wrapping, I'm not sure whether the lack of cursor color support for tmux is on purpose. Perhaps this change could introduce issues with non-conforming terminals connecting to the tmux session.

tmux terminfo:

```shell
$ echo $TERM
tmux-256color

$ infocmp -x | grep Cs
        Cs=\E]12;%p1%s\007, E0=\E(B, E3=\E[3J,

$ infocmp -x | grep Cr
        tbc=\E[3g, tsl=\E]0;, vpa=\E[%i%p1%dd, Cr=\E]112\007,
```