### PR TITLE
Make neovim building even with libuv 1.18.0

### DIFF
--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -17,7 +17,7 @@
 #endif
 
 // For compatbility with libuv < 1.19.0 (tested on 1.18.0)
-#ifndef uv_stream_get_write_queue_size
+#if UV_VERSION_MINOR < 19
 #define uv_stream_get_write_queue_size(stream) stream->write_queue_size
 #endif
 

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -16,6 +16,11 @@
 # include "event/stream.c.generated.h"
 #endif
 
+// For compatbility with libuv < 1.19.0 (tested on 1.18.0)
+#ifndef uv_stream_get_write_queue_size
+#define uv_stream_get_write_queue_size(stream) stream->write_queue_size
+#endif
+
 /// Sets the stream associated with `fd` to "blocking" mode.
 ///
 /// @return `0` on success, or libuv error code on failure.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -62,6 +62,11 @@
 #define BUFSIZE         8192    /* size of normal write buffer */
 #define SMBUFSIZE       256     /* size of emergency write buffer */
 
+// For compatibility with libuv < 1.20.0 (tested on 1.18.0)
+#ifndef UV_FS_COPYFILE_FICLONE
+#define UV_FS_COPYFILE_FICLONE 0
+#endif
+
 //
 // The autocommands are stored in a list for each event.
 // Autocommands for the same pattern, that are consecutive, are joined


### PR DESCRIPTION
(found for example on openSUSE/Leap 15)

I am not sure you care much about older systems, but this seems like a minimal pain for neovim building even on openSUSE/Leap 15 with libuv 1.18.0. More, I would like this to be here in case anybody needs it.