### PR TITLE
nvim-qt does not support using '_' in place of spaces.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2844,12 +2844,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		      Normally you would use "cDEFAULT".
 
 	  Use a ':' to separate the options.
-	- A '_' can be used in the place of a space, so you don't need to use
-	  backslashes to escape the spaces.
-	- Examples: >
-	    :set guifont=courier_new:h12:w5:b:cRUSSIAN
-	    :set guifont=Andale_Mono:h7.5:w4.5
-<
 
 					*'guifontset'* *'gfs'*
 					*E250* *E252* *E234* *E597* *E598*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -466,6 +466,7 @@ Options:
   *'ed'* *'edcompatible'* *'noed'* *'noedcompatible'*
   'encoding' ("utf-8" is always used)
   'esckeys'
+  'guifont' '_' cannot be used in place of a space
   'guioptions' "t" flag was removed
   *'guipty'* (Nvim uses pipes and PTYs consistently on all platforms.)
   'highlight' (Names of builtin |highlight-groups| cannot be changed.)


### PR DESCRIPTION
## Problem

nvim-qt does not support using '_' in place of spaces like gvim does.

## Solution

Document differences.

## Alternatives Considered

1. nvim removes spaces when `set guifont` is called. The problem with this approach is that fonts with underscores in the name would have to be escaped.
2. nvim-qt removes spaces when `set guifont` is called. The problem with this approach (like 1) is that fonts with underscores in the name would have to be escaped. Also, every other nvim host application would have to implement the logic as well, making it harder for all versions to behave consistently.


