### PR TITLE
Suppress copyright notice on every cl.exe invocation

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -220,7 +220,7 @@ set(gen_cflags ${gen_cflags} ${C_FLAGS_${build_type}_ARRAY} ${C_FLAGS_ARRAY})
 
 function(get_preproc_output varname iname)
   if(MSVC)
-    set(${varname} /P /Fi${iname} PARENT_SCOPE)
+    set(${varname} /P /Fi${iname} /nologo PARENT_SCOPE)
   else()
     set(${varname} -E -o ${iname} PARENT_SCOPE)
   endif()


### PR DESCRIPTION
## Problem

When building with cl.exe (Visual Studio's compiler), a copyright notice was displayed for each file, polluting the build output with useless and redundant information. This occurs regardless of the build system (Ninja or Visual Studio).

Here is a sample of the output:

```
main.c
Generating auto/map.c.generated.h, ../../include/map.h.generated.h
Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28315 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

map.c
Generating auto/mark.c.generated.h, ../../include/mark.h.generated.h
Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28315 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

mark.c
Generating auto/marktree.c.generated.h, ../../include/marktree.h.generated.h
Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28315 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.
```

## Solution

Suppress the copyright banner by setting the [`/nologo`](https://docs.microsoft.com/en-us/cpp/build/reference/nologo-suppress-startup-banner-c-cpp) cl.exe flag.

Result excerpt:

```
main.c
Generating auto/map.c.generated.h, ../../include/map.h.generated.h
map.c
Generating auto/mark.c.generated.h, ../../include/mark.h.generated.h
mark.c
Generating auto/marktree.c.generated.h, ../../include/marktree.h.generated.h
```

Tested on Windows 10 with VS2019 64-bit build environment using Ninja and default cmake generators (`-G Ninja` and no `-G` option).

These changes disable the vast majority of logo banners, though some in the third-party build are still present.