### PR TITLE
[RFC] vim-patch:8.1.2233

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1423,6 +1423,10 @@ PREDEFINED VIM VARIABLES			*vim-variable* *v:var* *v:*
 								*E963*
 Some variables can be set by the user, but the type cannot be changed.
 
+					*v:argv* *argv-variable*
+v:argv		The command line arguments Vim was invoked with.  This is a
+		list of strings.  The first item is the Vim command.
+
 					*v:beval_col* *beval_col-variable*
 v:beval_col	The number of the column, over which the mouse pointer is.
 		This is the byte index in the |v:beval_lnum| line.
@@ -2600,6 +2604,7 @@ argv([{nr} [, {winid}])
 		the whole |arglist| is returned.
 
 		The {winid} argument specifies the window ID, see |argc()|.
+		For the Vim command line arguments see |v:argv|.
 
 assert_beeps({cmd})					*assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -230,6 +230,7 @@ static struct vimvar {
   VV(VV_ECHOSPACE,      "echospace",        VAR_NUMBER, VV_RO),
   VV(VV_EXITING,        "exiting",          VAR_NUMBER, VV_RO),
   VV(VV_LUA,            "lua",              VAR_PARTIAL, VV_RO),
+  VV(VV_ARGV,           "argv",             VAR_LIST, VV_RO),
 };
 #undef VV
 
@@ -8106,6 +8107,23 @@ void set_vim_var_dict(const VimVarIndex idx, dict_T *const val)
     // Set readonly
     tv_dict_set_keys_readonly(val);
   }
+}
+
+/// Set the v:argv list.
+void set_argv_var(char **argv, int argc)
+{
+  list_T *l = tv_list_alloc(argc);
+  int i;
+
+  if (l == NULL) {
+    getout(1);
+  }
+  tv_list_set_lock(l, VAR_FIXED);
+  for (i = 0; i < argc; i++) {
+    tv_list_append_string(l, (const char *const)argv[i], -1);
+    TV_LIST_ITEM_TV(tv_list_last(l))->v_lock = VAR_FIXED;
+  }
+  set_vim_var_list(VV_ARGV, l);
 }
 
 /*

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -159,6 +159,7 @@ typedef enum {
     VV_ECHOSPACE,
     VV_EXITING,
     VV_LUA,
+    VV_ARGV,
 } VimVarIndex;
 
 /// All recognized msgpack types

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -269,6 +269,8 @@ int main(int argc, char **argv)
 
   early_init();
 
+  set_argv_var(argv, argc);  // set v:argv
+
   // Check if we have an interactive window.
   check_and_set_isatty(&params);
 

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -584,3 +584,12 @@ func Test_start_with_tabs()
   " clean up
   call StopVimInTerminal(buf)
 endfunc
+
+func Test_v_argv()
+  let out = system(GetVimCommand() . ' -es -V1 -X arg1 --cmd "echo v:argv" --cmd q')
+  let list = split(out, "', '")
+  call assert_match('vim', list[0])
+  let idx = index(list, 'arg1')
+  call assert_true(idx > 2)
+  call assert_equal(['arg1', '--cmd', 'echo v:argv', '--cmd', 'q'']'], list[idx:])
+endfunc

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -295,6 +295,14 @@ describe('startup', function()
       })
     )
   end)
+
+  it("get command line arguments from v:argv", function()
+    local out = funcs.system({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--headless',
+                               '--cmd', nvim_set,
+                               '-c', [[echo v:argv[-1:] len(v:argv) > 1]],
+                               '+q' })
+    eq('[\'+q\'] 1', out)
+  end)
 end)
 
 describe('sysinit', function()


### PR DESCRIPTION
#### vim-patch:8.1.2233: cannot get the Vim command line arguments

Problem:    Cannot get the Vim command line arguments.
Solution:   Add v:argv. (Dmitri Vereshchagin, closes vim/vim#1322)
https://github.com/vim/vim/commit/69bf634858a2a75f2984e42b1e4017bc529a040a