### PR TITLE
Use libnvim as OUTPUT_NAME for libnvim

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -573,7 +573,6 @@ set_target_properties(
   libnvim
   PROPERTIES
     POSITION_INDEPENDENT_CODE ON
-    OUTPUT_NAME nvim
 )
 set_property(
   TARGET libnvim


### PR DESCRIPTION
libnvim's OUTPUT_NAME was nvim, which caused the cmake Ninja generator
to generate two build rules for the library, which produced a warning
about incorrect builds.

Fixes #12115.