### PR TITLE
[WIP] Add a create_logger(filename) function to lsp/log.lua

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -1,13 +1,8 @@
 -- Logger for language client plugin.
 
-local log = {}
+local loggers = {}
 
--- Log level dictionary with reverse lookup as well.
---
--- Can be used to lookup the number from the name or the name from the number.
--- Levels by name: 'trace', 'debug', 'info', 'warn', 'error'
--- Level numbers begin with 'trace' at 0
-log.levels = {
+local raw_levels = {
   TRACE = 0;
   DEBUG = 1;
   INFO  = 2;
@@ -15,27 +10,56 @@ log.levels = {
   ERROR = 4;
 }
 
--- Default log level is warn.
-local current_log_level = log.levels.WARN
+-- Log level dictionary with reverse lookup as well.
+--
+-- Can be used to lookup the number from the name or the name from the number.
+-- Levels by name: 'trace', 'debug', 'info', 'warn', 'error'
+-- Level numbers begin with 'trace' at 0
+local levels = vim.deepcopy(raw_levels)
+vim.tbl_add_reverse_lookup(levels)
+
 local log_date_format = "%FT%H:%M:%SZ%z"
 
-do
+
+local function create_logger(filename)
+  local logger = loggers[filename]
+  if logger then
+    return logger
+  end
+  logger = {}
+  loggers[filename] = logger
+
   local path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
   local function path_join(...)
     return table.concat(vim.tbl_flatten{...}, path_sep)
   end
-  local logfilename = path_join(vim.fn.stdpath('data'), 'vim-lsp.log')
 
-  --- Return the log filename.
-  function log.get_filename()
+  local logfilename = path_join(vim.fn.stdpath('data'), filename)
+  local current_log_level = levels.WARN
+
+  function logger.get_filename()
     return logfilename
+  end
+
+  function logger.set_level(level)
+    if type(level) == 'string' then
+      current_log_level = assert(levels[level:upper()], string.format("Invalid log level: %q", level))
+    else
+      assert(type(level) == 'number', "level must be a number or string")
+      assert(levels[level], string.format("Invalid log level: %d", level))
+      current_log_level = level
+    end
   end
 
   vim.fn.mkdir(vim.fn.stdpath('data'), "p")
   local logfile = assert(io.open(logfilename, "a+"))
-  for level, levelnr in pairs(log.levels) do
-    -- Also export the log level on the root object.
-    log[level] = levelnr
+
+  function logger.close()
+    loggers[filename] = nil
+    logfile:close()
+  end
+
+  for level, levelnr in pairs(raw_levels) do
     -- Set the lowercase name as the main use function.
     -- If called without arguments, it will check whether the log level is
     -- greater than or equal to this one. When called with arguments, it will
@@ -47,7 +71,7 @@ do
     -- ```
     --
     -- This way you can avoid string allocations if the log level isn't high enough.
-    log[level:lower()] = function(...)
+    logger[level:lower()] = function(...)
       local argc = select("#", ...)
       if levelnr < current_log_level then return false end
       if argc == 0 then return true end
@@ -59,7 +83,7 @@ do
         if arg == nil then
           table.insert(parts, "nil")
         else
-          table.insert(parts, vim.inspect(arg, {newline=''}))
+          table.insert(parts, vim.inspect(arg))
         end
       end
       logfile:write(table.concat(parts, '\t'), "\n")
@@ -68,27 +92,23 @@ do
   end
   -- Add some space to make it easier to distinguish different neovim runs.
   logfile:write("\n")
+  return logger
 end
 
--- This is put here on purpose after the loop above so that it doesn't
--- interfere with iterating the levels
-vim.tbl_add_reverse_lookup(log.levels)
 
-function log.set_level(level)
-  if type(level) == 'string' then
-    current_log_level = assert(log.levels[level:upper()], string.format("Invalid log level: %q", level))
-  else
-    assert(type(level) == 'number', "level must be a number or string")
-    assert(log.levels[level], string.format("Invalid log level: %d", level))
-    current_log_level = level
-  end
+-- Emulate the interface `log.lua` had before the addition of `create_logger`
+local lsp_logger = create_logger('vim-lsp.log')
+lsp_logger.create_logger = create_logger
+for level, levelnr in pairs(levels) do
+  lsp_logger[level] = levelnr
 end
 
 -- Return whether the level is sufficient for logging.
 -- @param level number log level
-function log.should_log(level)
-  return level >= current_log_level
+function lsp_logger.should_log(level)
+  return level >= lsp_logger.current_log_level
 end
 
-return log
+
+return lsp_logger
 -- vim:sw=2 ts=2 et


### PR DESCRIPTION
The motivation is to be able to use the log functions in plugins without
having it log into the `vim-lsp.log` file.

To keep the interface of `log` as it was before. Importing the `log`
module will still result in a logger that is targeting `vim-lsp.log`,
but it additionally contains a `create_logger(filename)` function that
can be used to create different loggers.

E.g.:

    local log = require('vim.lsp.log')
    log.warn('This logs to vim-lsp.log')

    local mylogger = log.create_logger('myplugin.log')
    mylogger.warn('This logs to myplugin.log')

See https://github.com/mfussenegger/nvim-dap/commit/328fdd9a129f3fdb4d662d03dbdfaf3859b809c7 where this could be used