### PR TITLE
[WIP] win,terminal: Change to use conpty.dll if available

### DIFF
--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -126,7 +126,7 @@ conpty_t *os_conpty_init(char **in_name, char **out_name,
     | PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE;
 
   sa.nLength = sizeof(sa);
-  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-in-%d-%d",
+  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-in-%"PRIx64"-%d",
            os_get_pid(), count);
   *in_name = xstrdup(buf);
   if ((in_read = CreateNamedPipeA(
@@ -141,7 +141,7 @@ conpty_t *os_conpty_init(char **in_name, char **out_name,
     emsg = "create input pipe failed";
     goto failed;
   }
-  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-out-%d-%d",
+  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-out-%"PRIx64"-%d",
            os_get_pid(), count);
   *out_name = xstrdup(buf);
   if ((out_write = CreateNamedPipeA(


### PR DESCRIPTION
With the development of Windows Terminal, it appears that the PseudoConsole APIs and conhosts will be provided as a framework package independent of the OS. This pull request is the first attempt to use the results in neovim.

microsoft/terminal#1130

As the package is not yet available, you will need to build `conpty.dll` and `OpenConsole.exe` yourself using the steps below.

```
git clone https://github.com/microsoft/terminal
cd terminal
git submodule update --init --recursive
msbuild OpenConsole.sln -target:Conhost\Host_EXE -property:Configuration=Release -property:platform=x64
msbuild OpenConsole.sln -target:Conhost\winconpty_DLL -property:Configuration=Release -property:platform=x64
copy bin\x64\Release\OpenConsole.exe %NEOVIM_WIN_DIR%\bin
copy bin\x64\Release\conpty.dll %NEOVIM_WIN_DIR%\bin

```

`%NEOVIM_WIN_DIR%` is the directory where neovim is extracted. `x64` should be changed to suit the architecture.

By using this, the terminal window of neovim will work the same way as Windows Terminal. For example, the mouse works in WSL's tmux, neovim, etc. The handling of emojis will also be improved (Ref: #12123).