### PR TITLE
Lua: vim.fn_wrap

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -585,6 +585,51 @@ describe('lua stdlib', function()
 
     -- error handling
     eq({false, 'Vim:E714: List required'}, exec_lua([[return {pcall(vim.fn.add, "aa", "bb")}]]))
+
+    eq(
+      {false, 'error converting argument 2'},
+      exec_lua([[
+        return {
+          pcall(
+            function()
+              return vim.fn.timer_start(
+                2000,
+                function(...)
+                  return {...}
+                end
+              )
+          end)
+        }
+      ]])
+    )
+
+    -- NOTE: vim.wrap_fn, not vim.fn
+    eq(
+      {true, 1},
+      exec_lua([[
+        return {
+          pcall(
+            function()
+              -- Set the value to false
+              vim.g.test_wrap_fn_result = false
+
+              local result = vim.wrap_fn.timer_start(
+                0,
+                function(...)
+                  -- Timer will set the value new
+                  vim.g.test_wrap_fn_result = true
+                  return {...}
+                end
+              )
+
+              vim.cmd('sleep 100m')
+
+              return result
+          end)
+        }
+      ]])
+    )
+    eq(true, exec_lua([[return vim.g.test_wrap_fn_result]]))
   end)
 
   it('vim.rpcrequest and vim.rpcnotify', function()


### PR DESCRIPTION
This is a step 1 of implementing better Lua <-> VimL interop. In general, I've seen this question on gitter a lot:

> This `vim.fn.prompt_setcallback(buf, function(text) print(text) end)` doesn't work
> This `vim.fn.jobstart(...)` doesn't work

I'm proposing this as the first step in making this work. You can now use `vim.wrap_fn` to recursively transform your functions to pass between Lua & vim (so it handles functions being inside of tables and what not). It's obviously slower and somewhat of a hack as compared to `vim.fn`, but that's why it has a different name :)

I'm suggesting that we can merge this in at some point, and then as time goes on find a more elegant way to convert between Lua & Vim functions (it will probably be some table like this with garbage collection and what not, but that would have taken a lot more time) and then we just drop that in as a replacement for `vim.wrap_fn`. At some point, if it's performant enough and good, we can just do `vim.wrap_fn = vim.fn` and call it a day.

Anyway, tested it a bit myself life and it seems to work well and I added a test to show that the behavior is working and gives results that you'd expect (as in, actually calls the lua function).

Thanks!