### PR TITLE
Declare ListLenSpecials and RemapValues as typedefs not enum instances

### DIFF
--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -33,7 +33,7 @@ typedef double float_T;
 enum { DO_NOT_FREE_CNT = (INT_MAX / 2) };
 
 /// Additional values for tv_list_alloc() len argument
-enum {
+typedef enum {
   /// List length is not known in advance
   ///
   /// To be used when there is neither a way to know how many elements will be

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -10,7 +10,7 @@
 /// Values for "noremap" argument of ins_typebuf()
 ///
 /// Also used for map->m_noremap and menu->noremap[].
-enum {
+typedef enum {
   REMAP_YES = 0,  ///< Allow remapping.
   REMAP_NONE = -1,  ///< No remapping.
   REMAP_SCRIPT = -2,  ///< Remap script-local mappings only.


### PR DESCRIPTION
GCC 10 is, by default, strict about properly using extern for variable declarations in header files.  These two enums were incorrectly being declared as instances instead of typedefs causing the build to fail with errors like:

    /usr/bin/ld: src/nvim/CMakeFiles/nvim.dir/spell.c.o (symbol from plugin): in function `spelltab':
    (.text+0x0): multiple definition of `RemapValues'; src/nvim/CMakeFiles/nvim.dir/auto/msgpack_lua_c_bindings.generated.c.o (symbol from plugin):(.text+0x0): first defined here
    /usr/bin/ld: src/nvim/CMakeFiles/nvim.dir/spell.c.o (symbol from plugin): in function `spelltab':
    (.text+0x0): multiple definition of `ListLenSpecials'; src/nvim/CMakeFiles/nvim.dir/auto/msgpack_lua_c_bindings.generated.c.o (symbol from plugin):(.text+0x0): first defined here