### PR TITLE
Backport build fixes for gcc-10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,11 @@ if(UNIX)
   endif()
 endif()
 
+check_c_compiler_flag(-fno-common HAVE_FNO_COMMON)
+if (HAVE_FNO_COMMON)
+  add_compile_options(-fno-common)
+endif()
+
 check_c_compiler_flag(-fdiagnostics-color=auto HAS_DIAG_COLOR_FLAG)
 if(HAS_DIAG_COLOR_FLAG)
   if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -15,7 +15,6 @@
 #include "nvim/ascii.h"
 
 static bool did_stdio = false;
-PMap(uint64_t) *channels = NULL;
 
 /// next free id for a job or rpc channel
 /// 1 is reserved for stdio channel

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -85,7 +85,7 @@ struct Channel {
   bool callback_scheduled;
 };
 
-EXTERN PMap(uint64_t) *channels;
+EXTERN PMap(uint64_t) *channels INIT(= NULL);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "channel.h.generated.h"

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -33,7 +33,7 @@ typedef double float_T;
 enum { DO_NOT_FREE_CNT = (INT_MAX / 2) };
 
 /// Additional values for tv_list_alloc() len argument
-enum {
+enum ListLenSpecials {
   /// List length is not known in advance
   ///
   /// To be used when there is neither a way to know how many elements will be
@@ -49,7 +49,7 @@ enum {
   ///
   /// To be used when it looks impractical to determine list length.
   kListLenMayKnow = -3,
-} ListLenSpecials;
+};
 
 /// Maximal possible value of varnumber_T variable
 #define VARNUMBER_MAX INT64_MAX

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -10,12 +10,12 @@
 /// Values for "noremap" argument of ins_typebuf()
 ///
 /// Also used for map->m_noremap and menu->noremap[].
-enum {
+enum RemapValues {
   REMAP_YES = 0,  ///< Allow remapping.
   REMAP_NONE = -1,  ///< No remapping.
   REMAP_SCRIPT = -2,  ///< Remap script-local mappings only.
   REMAP_SKIP = -3,  ///< No remapping for first char.
-} RemapValues;
+};
 
 // Argument for flush_buffers().
 typedef enum {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -10,6 +10,7 @@
 #include <msgpack.h>
 
 #include "nvim/ascii.h"
+#include "nvim/channel.h"
 #include "nvim/vim.h"
 #include "nvim/main.h"
 #include "nvim/aucmd.h"

--- a/src/nvim/msgpack_rpc/channel.h
+++ b/src/nvim/msgpack_rpc/channel.h
@@ -15,7 +15,7 @@
 /// HACK: os/input.c drains this queue immediately before blocking for input.
 ///       Events on this queue are async-safe, but they need the resolved state
 ///       of os_inchar(), so they are processed "just-in-time".
-MultiQueue *ch_before_blocking_events;
+EXTERN MultiQueue *ch_before_blocking_events INIT(= NULL);
 
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/viml/parser/expressions.h
+++ b/src/nvim/viml/parser/expressions.h
@@ -326,7 +326,7 @@ struct expr_ast_node {
   } data;
 };
 
-enum {
+enum ExprParserFlags {
   /// Allow multiple expressions in a row: e.g. for :echo
   ///
   /// Parser will still parse only one of them though.
@@ -345,7 +345,7 @@ enum {
   //     viml_expressions_parser.c, nvim_parse_expression() flags parsing
   //     alongside with its documentation and flag sets in check_parsing()
   //     function in expressions parser functional and unit tests.
-} ExprParserFlags;
+};
 
 /// AST error definition
 typedef struct {


### PR DESCRIPTION
Use `-fno-common` when available and fix the issues it caught.

Original PR: https://github.com/neovim/neovim/pull/11890