### PR TITLE
Add terminal filtering and `lastused` to `:ls` (vim-patch:8.0.1651)

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4164,6 +4164,9 @@ getbufinfo([{dict}])
 			changed		TRUE if the buffer is modified.
 			changedtick	number of changes made to the buffer.
 			hidden		TRUE if the buffer is hidden.
+			lastused	timestamp in seconds, like
+					|localtime()|, when the buffer was
+					last used.
 			listed		TRUE if the buffer is listed.
 			lnum		current line number in buffer.
 			linecount	number of lines in the buffer (only

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6742,6 +6742,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			complete first match.
 	"list:longest"	When more than one match, list all matches and
 			complete till longest common string.
+	"list:lastused" When more than one buffer matches, sort buffers
+			by time last used (other than the current buffer).
 	When there is only a single match, it is fully completed in all cases.
 
 	Examples: >

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1023,6 +1023,7 @@ list of buffers. |unlisted-buffer|
 			#	alternate buffer
 			R	terminal buffers with a running job
 			F	terminal buffers with a finished job
+			t	show time last used and sort buffers
 		Combining flags means they are "and"ed together, e.g.:
 			h+	hidden buffers which are modified
 			a+	active buffers which are modified

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1021,6 +1021,8 @@ list of buffers. |unlisted-buffer|
 			x	buffers with a read error
 			%	current buffer
 			#	alternate buffer
+			R	terminal buffers with a running job
+			F	terminal buffers with a finished job
 		Combining flags means they are "and"ed together, e.g.:
 			h+	hidden buffers which are modified
 			a+	active buffers which are modified

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1618,6 +1618,7 @@ void enter_buffer(buf_T *buf)
   if (!curbuf->b_help && curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL) {
     (void)did_set_spelllang(curwin);
   }
+  curbuf->b_last_used = time(NULL);
 
   redraw_later(NOT_VALID);
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2600,6 +2600,9 @@ void buflist_list(exarg_T *eap)
   int i;
 
   for (buf = firstbuf; buf != NULL && !got_int; buf = buf->b_next) {
+    const bool is_terminal = buf->terminal;
+    const bool job_running = buf->terminal && terminal_running(buf->terminal);
+
     // skip unspecified buffers
     if ((!buf->b_p_bl && !eap->forceit && !strchr((char *)eap->arg, 'u'))
         || (strchr((char *)eap->arg, 'u') && buf->b_p_bl)
@@ -2609,6 +2612,8 @@ void buflist_list(exarg_T *eap)
             && (buf->b_ml.ml_mfp == NULL || buf->b_nwindows == 0))
         || (strchr((char *)eap->arg, 'h')
             && (buf->b_ml.ml_mfp == NULL || buf->b_nwindows != 0))
+        || (strchr((char *)eap->arg, 'R') && (!is_terminal || !job_running))
+        || (strchr((char *)eap->arg, 'F') && (!is_terminal || job_running))
         || (strchr((char *)eap->arg, '-') && buf->b_p_ma)
         || (strchr((char *)eap->arg, '=') && !buf->b_p_ro)
         || (strchr((char *)eap->arg, 'x') && !(buf->b_flags & BF_READERR))

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -543,6 +543,8 @@ struct file_buffer {
   long b_mtime_read;            // last change time when reading
   uint64_t b_orig_size;         // size of original file in bytes
   int b_orig_mode;              // mode of original file
+  time_t b_last_used;           // time when the buffer was last used; used
+                                // for viminfo
 
   fmark_T b_namedm[NMARKS];     // current named marks (mark.c)
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7241,6 +7241,8 @@ dict_T *get_buffer_info(buf_T *buf)
     tv_dict_add_list(dict, S_LEN("signs"), get_buffer_signs(buf));
   }
 
+  tv_dict_add_nr(dict, S_LEN("lastused"), buf->b_last_used);
+
   return dict;
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2670,6 +2670,8 @@ int do_ecmd(
     msg_scrolled_ign = FALSE;
   }
 
+  curbuf->b_last_used = time(NULL);
+
   if (command != NULL)
     do_cmdline(command, NULL, NULL, DOCMD_VERBOSE);
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -947,6 +947,10 @@ static int command_line_execute(VimState *state, int key)
   // - wildcard expansion is only done when the 'wildchar' key is really
   //   typed, not when it comes from a macro
   if ((s->c == p_wc && !s->gotesc && KeyTyped) || s->c == p_wcm) {
+    int options = WILD_NO_BEEP;
+    if (wim_flags[s->wim_index] & WIM_BUFLASTUSED) {
+      options |= WILD_BUFLASTUSED;
+    }
     if (s->xpc.xp_numfiles > 0) {       // typed p_wc at least twice
       // if 'wildmode' contains "list" may still need to list
       if (s->xpc.xp_numfiles > 1
@@ -960,11 +964,11 @@ static int command_line_execute(VimState *state, int key)
       }
 
       if (wim_flags[s->wim_index] & WIM_LONGEST) {
-        s->res = nextwild(&s->xpc, WILD_LONGEST, WILD_NO_BEEP,
-            s->firstc != '@');
+        s->res = nextwild(&s->xpc, WILD_LONGEST, options,
+                          s->firstc != '@');
       } else if (wim_flags[s->wim_index] & WIM_FULL) {
-        s->res = nextwild(&s->xpc, WILD_NEXT, WILD_NO_BEEP,
-            s->firstc != '@');
+        s->res = nextwild(&s->xpc, WILD_NEXT, options,
+                          s->firstc != '@');
       } else {
         s->res = OK;                 // don't insert 'wildchar' now
       }
@@ -975,11 +979,11 @@ static int command_line_execute(VimState *state, int key)
       // if 'wildmode' first contains "longest", get longest
       // common part
       if (wim_flags[0] & WIM_LONGEST) {
-        s->res = nextwild(&s->xpc, WILD_LONGEST, WILD_NO_BEEP,
-            s->firstc != '@');
+        s->res = nextwild(&s->xpc, WILD_LONGEST, options,
+                          s->firstc != '@');
       } else {
-        s->res = nextwild(&s->xpc, WILD_EXPAND_KEEP, WILD_NO_BEEP,
-            s->firstc != '@');
+        s->res = nextwild(&s->xpc, WILD_EXPAND_KEEP, options,
+                          s->firstc != '@');
       }
 
       // if interrupted while completing, behave like it failed
@@ -1016,11 +1020,11 @@ static int command_line_execute(VimState *state, int key)
           s->did_wild_list = true;
 
           if (wim_flags[s->wim_index] & WIM_LONGEST) {
-            nextwild(&s->xpc, WILD_LONGEST, WILD_NO_BEEP,
-                s->firstc != '@');
+            nextwild(&s->xpc, WILD_LONGEST, options,
+                     s->firstc != '@');
           } else if (wim_flags[s->wim_index] & WIM_FULL) {
-            nextwild(&s->xpc, WILD_NEXT, WILD_NO_BEEP,
-                s->firstc != '@');
+            nextwild(&s->xpc, WILD_NEXT, options,
+                     s->firstc != '@');
           }
         } else {
           vim_beep(BO_WILD);

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -31,6 +31,7 @@
 #define WILD_ALLLINKS           0x200
 #define WILD_IGNORE_COMPLETESLASH   0x400
 #define WILD_NOERROR            0x800  // sets EW_NOERROR
+#define WILD_BUFLASTUSED        0x1000
 
 /// Present history tables
 typedef enum {

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1162,3 +1162,26 @@ int goto_im(void)
 {
   return p_im && stuff_empty() && typebuf_typed();
 }
+
+/// Put the timestamp of an undo header in "buf[buflen]" in a nice format.
+void add_time(char_u *buf, size_t buflen, time_t tt)
+{
+  struct tm curtime;
+
+  if (time(NULL) - tt >= 100) {
+    os_localtime_r(&tt, &curtime);
+    if (time(NULL) - tt < (60L * 60L * 12L)) {
+      // within 12 hours
+      (void)strftime((char *)buf, buflen, "%H:%M:%S", &curtime);
+    } else {
+      // longer ago
+      (void)strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", &curtime);
+    }
+  } else {
+    int64_t seconds = time(NULL) - tt;
+    vim_snprintf((char *)buf, buflen,
+                 NGETTEXT("%" PRId64 " second ago",
+                          "%" PRId64 " seconds ago", (uint32_t)seconds),
+                 seconds);
+  }
+}

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1260,6 +1260,8 @@ static void normal_redraw(NormalState *s)
     maketitle();
   }
 
+  curbuf->b_last_used = time(NULL);
+
   // Display message after redraw. If an external message is still visible,
   // it contains the kept message already.
   if (keep_msg != NULL && !msg_ext_is_visible()) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7083,6 +7083,8 @@ static int check_opt_wim(void)
       new_wim_flags[idx] |= WIM_FULL;
     } else if (i == 4 && STRNCMP(p, "list", 4) == 0) {
       new_wim_flags[idx] |= WIM_LIST;
+    } else if (i == 8 && STRNCMP(p, "lastused", 8) == 0) {
+      new_wim_flags[idx] |= WIM_BUFLASTUSED;
     } else {
       return FAIL;
     }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -277,6 +277,7 @@ enum {
 #define WIM_FULL        1
 #define WIM_LONGEST     2
 #define WIM_LIST        4
+#define WIM_BUFLASTUSED 8
 
 // arguments for can_bs()
 #define BS_INDENT       'i'     // "Indent"

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -650,6 +650,11 @@ Buffer terminal_buf(const Terminal *term)
   return term->buf_handle;
 }
 
+bool terminal_running(const Terminal *term)
+{
+  return !term->closed;
+}
+
 // }}}
 // libvterm callbacks {{{
 

--- a/src/nvim/testdir/test_bufwintabinfo.vim
+++ b/src/nvim/testdir/test_bufwintabinfo.vim
@@ -149,3 +149,10 @@ func Test_getbufinfo_lines()
   edit Xfoo
   bw!
 endfunc
+
+function Test_getbufinfo_lastused()
+  new Xfoo
+  let info = getbufinfo('Xfoo')[0]
+  call assert_equal(has_key(info, 'lastused'), 1)
+  call assert_equal(type(info.lastused), type(0))
+endfunc

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -755,3 +755,49 @@ func Test_cmdwin_feedkeys()
   " This should not generate E488
   call feedkeys("q:\<CR>", 'x')
 endfunc
+
+func Test_buffers_lastused()
+  " check that buffers are sorted by time when wildmode has lastused
+  edit bufc " oldest
+
+  sleep 1200m
+  enew
+  edit bufa " middle
+
+  sleep 1200m
+  enew
+  edit bufb " newest
+
+  enew
+
+  call assert_equal(['bufc', 'bufa', 'bufb'],
+	\ getcompletion('', 'buffer'))
+
+  let save_wildmode = &wildmode
+  set wildmode=full:lastused
+
+  let cap = "\<c-r>=execute('let X=getcmdline()')\<cr>"
+  call feedkeys(":b \<tab>" .. cap .. "\<esc>", 'xt')
+  call assert_equal('b bufb', X)
+  call feedkeys(":b \<tab>\<tab>" .. cap .. "\<esc>", 'xt')
+  call assert_equal('b bufa', X)
+  call feedkeys(":b \<tab>\<tab>\<tab>" .. cap .. "\<esc>", 'xt')
+  call assert_equal('b bufc', X)
+  enew
+
+  sleep 1200m
+  edit other
+  call feedkeys(":b \<tab>" .. cap .. "\<esc>", 'xt')
+  call assert_equal('b bufb', X)
+  call feedkeys(":b \<tab>\<tab>" .. cap .. "\<esc>", 'xt')
+  call assert_equal('b bufa', X)
+  call feedkeys(":b \<tab>\<tab>\<tab>" .. cap .. "\<esc>", 'xt')
+  call assert_equal('b bufc', X)
+  enew
+
+  let &wildmode = save_wildmode
+
+  bwipeout bufa
+  bwipeout bufb
+  bwipeout bufc
+endfunc

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -8,3 +8,35 @@ func Test_ex_delete()
   .dl
   call assert_equal(['a', 'c'], getline(1, 2))
 endfunc
+
+func Test_buffers_lastused()
+  edit bufc " oldest
+
+  sleep 1200m
+  edit bufa " middle
+
+  sleep 1200m
+  edit bufb " newest
+
+  enew
+
+  let ls = split(execute('buffers t', 'silent!'), '\n')
+  let bufs = []
+  for line in ls
+    let bufs += [split(line, '"\s*')[1:2]]
+  endfor
+
+  let names = []
+  for buf in bufs
+    if buf[0] !=# '[No Name]'
+      let names += [buf[0]]
+    endif
+  endfor
+
+  call assert_equal(['bufb', 'bufa', 'bufc'], names)
+  call assert_match('[0-2] seconds ago', bufs[1][1])
+
+  bwipeout bufa
+  bwipeout bufb
+  bwipeout bufc
+endfunc

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2441,10 +2441,11 @@ static void u_undo_end(
     uhp = curbuf->b_u_newhead;
   }
 
-  if (uhp == NULL)
+  if (uhp == NULL) {
     *msgbuf = NUL;
-  else
-    u_add_time(msgbuf, sizeof(msgbuf), uhp->uh_time);
+  } else {
+    add_time(msgbuf, sizeof(msgbuf), uhp->uh_time);
+  }
 
   {
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
@@ -2509,8 +2510,8 @@ void ex_undolist(exarg_T *eap)
         && uhp->uh_walk != mark) {
       vim_snprintf((char *)IObuff, IOSIZE, "%6ld %7d  ",
                    uhp->uh_seq, changes);
-      u_add_time(IObuff + STRLEN(IObuff), IOSIZE - STRLEN(IObuff),
-          uhp->uh_time);
+      add_time(IObuff + STRLEN(IObuff), IOSIZE - STRLEN(IObuff),
+               uhp->uh_time);
       if (uhp->uh_save_nr > 0) {
         while (STRLEN(IObuff) < 33)
           STRCAT(IObuff, " ");
@@ -2571,30 +2572,6 @@ void ex_undolist(exarg_T *eap)
     msg_end();
 
     ga_clear_strings(&ga);
-  }
-}
-
-/*
- * Put the timestamp of an undo header in "buf[buflen]" in a nice format.
- */
-static void u_add_time(char_u *buf, size_t buflen, time_t tt)
-{
-  struct tm curtime;
-
-  if (time(NULL) - tt >= 100) {
-    os_localtime_r(&tt, &curtime);
-    if (time(NULL) - tt < (60L * 60L * 12L))
-      /* within 12 hours */
-      (void)strftime((char *)buf, buflen, "%H:%M:%S", &curtime);
-    else
-      /* longer ago */
-      (void)strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", &curtime);
-  } else {
-    int64_t seconds = time(NULL) - tt;
-    vim_snprintf((char *)buf, buflen,
-                 NGETTEXT("%" PRId64 " second ago",
-                          "%" PRId64 " seconds ago", (uint32_t)seconds),
-                 seconds);
   }
 }
 

--- a/test/functional/ex_cmds/ls_spec.lua
+++ b/test/functional/ex_cmds/ls_spec.lua
@@ -31,6 +31,18 @@ describe(':ls', function()
       -- Terminal buffer [F]inished.
       eq('\n  3 %aF', string.match(ls_output, '\n *3....'))
     end)
+
+    retry(nil, 5000, function()
+      local ls_output = eval('execute("ls R")')
+      -- Just the [R]unning terminal buffer.
+      eq('\n  2 #aR ', string.match(ls_output, '^\n *2 ... '))
+    end)
+
+    retry(nil, 5000, function()
+      local ls_output = eval('execute("ls F")')
+      -- Just the [F]inished terminal buffer.
+      eq('\n  3 %aF ', string.match(ls_output, '^\n *3 ... '))
+    end)
   end)
 
 end)


### PR DESCRIPTION
This was originally going to just be vim-patch `8.0.1651` (`cannot filter :ls output for terminal buffers`), however I spotted the last-used feature and decided to include it (patches `7.4.1988` & `8.1.2225`).

`7.4.1988` - this is a viminfo change, most of which is irrelevant. The patch has just been brought across / mentioned in spirit as it's the commit where I feel the creation and updating `b_last_used` still belong.

#### vim-patch:7.4.1988

Problem:    When updating viminfo with file marks there is no time order.
Solution:   Remember the time when a buffer was last used, store marks for
            the most recently used buffers.
https://github.com/vim/vim/commit/ab9c89b68dcbdb3fbda8c5a50dd90caca64f1bfd

#### vim-patch:8.0.1651: cannot filter :ls output for terminal buffers

Problem:    Cannot filter :ls output for terminal buffers.
Solution:   Add flags for terminal buffers. (Marcin Szamotulski, closes vim/vim#2751)
https://github.com/vim/vim/commit/0751f51a5b428805a8c1e9fe529693d032bec991

#### vim-patch:8.1.2225: the "last used" info of a buffer is under used

Problem:    The "last used" info of a buffer is under used.
Solution:   Add "lastused" to getbufinfo(). List buffers sorted by last-used
            field. (Andi Massimino, closes vim/vim#4722)
https://github.com/vim/vim/commit/52410575be50d5c40bbe6380159df48cfc382ceb