### PR TITLE
[WIP] build: Fix luv detection failure

### DIFF
--- a/cmake/FindLibLUV.cmake
+++ b/cmake/FindLibLUV.cmake
@@ -6,16 +6,26 @@
 
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBLUV QUIET luv)
+  # Inconsistently, the .pc file is libluv.pc.
+  pkg_check_modules(PC_LIBLUV QUIET libluv)
 endif()
 
 set(LIBLUV_DEFINITIONS ${PC_LIBLUV_CFLAGS_OTHER})
 
+# Remove cflags returned by pkg-config as it contains unnecessary trailing luv.
+if (PC_LIBLUV_INCLUDEDIR)
+  string(REGEX REPLACE "/luv/?$" "" PC_LIBLUV_INCLUDEDIR ${PC_LIBLUV_INCLUDEDIR})
+endif()
+if (PC_LIBLUV_INCLUDE_DIRS)
+  string(REGEX REPLACE "/luv/?$" "" PC_LIBLUV_INCLUDE_DIRS ${PC_LIBLUV_INCLUDE_DIRS})
+endif()
+
 find_path(LIBLUV_INCLUDE_DIR luv/luv.h
           PATHS ${PC_LIBLUV_INCLUDEDIR} ${PC_LIBLUV_INCLUDE_DIRS})
 
-# Explicitly look for luv.so. #10407
-list(APPEND LIBLUV_NAMES luv luv${CMAKE_SHARED_LIBRARY_SUFFIX})
+# Explicitly look for luv.so. #10407. Also, version 1.34.2-1 has a static
+# library named luv_a.a installed, so look for luv_a.
+list(APPEND LIBLUV_NAMES luv luv${CMAKE_SHARED_LIBRARY_SUFFIX} luv_a)
 
 find_library(LIBLUV_LIBRARY NAMES ${LIBLUV_NAMES}
   HINTS ${PC_LIBLUV_LIBDIR} ${PC_LIBLUV_LIBRARY_DIRS})


### PR DESCRIPTION
Fixes a problem that fails to detect the latest Luv.

- Correct an error in the `.pc` file name.
- Change to remove unwanted trailing luv in the `cflags` that returns by `pkg-config`.
- Change to find `luv_a` too.