### PR TITLE
fix: don't redefine LspDiagnostics signs if they're already defined

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -960,12 +960,12 @@ buf_diagnostics_virtual_text({bufnr}, {diagnostics})
                                  *vim.lsp.util.buf_diagnostics_signs()*
 buf_diagnostics_signs({bufnr}, {diagnostics})
                 Place signs for each diagnostic in the sign column.
-                Sign characters can be customized with the following options:
+                Sign characters can be customized with the following commands:
 >
-let g:LspDiagnosticsErrorSign = 'E'
-let g:LspDiagnosticsWarningSign = 'W'
-let g:LspDiagnosticsInformationSign = 'I'
-let g:LspDiagnosticsHintSign = 'H'
+sign define LspDiagnosticsErrorSign text=E texthl=LspDiagnosticsError linehl= numhl=
+sign define LspDiagnosticsWarningSign text=W texthl=LspDiagnosticsWarning linehl= numhl=
+sign define LspDiagnosticsInformationSign text=I texthl=LspDiagnosticsInformation linehl= numhl=
+sign define LspDiagnosticsHintSign text=H texthl=LspDiagnosticsHint linehl= numhl=
 <
 
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1015,5 +1015,21 @@ function lsp.get_log_path()
   return log.get_filename()
 end
 
+local function define_default_sign(name, properties)
+  if not vim.fn.sign_getdefined(name) then
+    vim.fn.sign_define(name, properties)
+  end
+end
+
+-- Define the LspDiagnostics signs if they're not defined already.
+local function define_default_lsp_diagnostics_signs()
+  define_default_sign('LspDiagnosticsErrorSign', {text='E', texthl='LspDiagnosticsError', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsWarningSign', {text='W', texthl='LspDiagnosticsWarning', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsInformationSign', {text='I', texthl='LspDiagnosticsInformation', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsHintSign', {text='H', texthl='LspDiagnosticsHint', linehl='', numhl=''})
+end
+
+define_default_lsp_diagnostics_signs()
+
 return lsp
 -- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -820,6 +820,7 @@ do
       api.nvim_buf_set_virtual_text(bufnr, diagnostic_ns, line, virt_texts, {})
     end
   end
+
   function M.buf_diagnostics_count(kind)
     local bufnr = vim.api.nvim_get_current_buf()
     local buffer_line_diagnostics = all_buffer_diagnostics[bufnr]
@@ -832,19 +833,16 @@ do
     end
     return count
   end
-  function M.buf_diagnostics_signs(bufnr, diagnostics)
-    vim.fn.sign_define('LspDiagnosticsErrorSign', {text=vim.g['LspDiagnosticsErrorSign'] or 'E', texthl='LspDiagnosticsError', linehl='', numhl=''})
-    vim.fn.sign_define('LspDiagnosticsWarningSign', {text=vim.g['LspDiagnosticsWarningSign'] or 'W', texthl='LspDiagnosticsWarning', linehl='', numhl=''})
-    vim.fn.sign_define('LspDiagnosticsInformationSign', {text=vim.g['LspDiagnosticsInformationSign'] or 'I', texthl='LspDiagnosticsInformation', linehl='', numhl=''})
-    vim.fn.sign_define('LspDiagnosticsHintSign', {text=vim.g['LspDiagnosticsHintSign'] or 'H', texthl='LspDiagnosticsHint', linehl='', numhl=''})
 
+  local diagnostic_severity_map = {
+    [protocol.DiagnosticSeverity.Error] = "LspDiagnosticsErrorSign";
+    [protocol.DiagnosticSeverity.Warning] = "LspDiagnosticsWarningSign";
+    [protocol.DiagnosticSeverity.Information] = "LspDiagnosticsInformationSign";
+    [protocol.DiagnosticSeverity.Hint] = "LspDiagnosticsHintSign";
+  }
+
+  function M.buf_diagnostics_signs(bufnr, diagnostics)
     for _, diagnostic in ipairs(diagnostics) do
-      local diagnostic_severity_map = {
-        [protocol.DiagnosticSeverity.Error] = "LspDiagnosticsErrorSign";
-        [protocol.DiagnosticSeverity.Warning] = "LspDiagnosticsWarningSign";
-        [protocol.DiagnosticSeverity.Information] = "LspDiagnosticsInformationSign";
-        [protocol.DiagnosticSeverity.Hint] = "LspDiagnosticsHintSign";
-      }
       vim.fn.sign_place(0, sign_ns, diagnostic_severity_map[diagnostic.severity], bufnr, {lnum=(diagnostic.range.start.line+1)})
     end
   end


### PR DESCRIPTION
Should fix #12162.