### PR TITLE
Extend LSP callback for references to open qf

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -50,6 +50,8 @@ end
 M['textDocument/references'] = function(_, _, result)
   if not result then return end
   util.set_qflist(util.locations_to_items(result))
+  api.nvim_command("copen")
+  api.nvim_command("wincmd p")
 end
 
 M['textDocument/documentSymbol'] = function(_, _, result, _, bufnr)


### PR DESCRIPTION
Closes: #12170

Behaves exactly like for document symbols now.