### PR TITLE
treesitter: unknown predicates always match

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -160,7 +160,7 @@ function Query:match_preds(match, pattern, bufnr)
   local regexes = self.regexes[pattern]
   for i, pred in pairs(preds) do
     -- Here we only want to return if a predicate DOES NOT match, and
-    -- continue on the other case. This way unknown predicates will not be considered, 
+    -- continue on the other case. This way unknown predicates will not be considered,
     -- which allows some testing and easier user extensibility (#12173).
     if pred[1] == "eq?" then
       local node = match[pred[2]]

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -159,6 +159,9 @@ function Query:match_preds(match, pattern, bufnr)
   end
   local regexes = self.regexes[pattern]
   for i, pred in pairs(preds) do
+    -- Here we only want to return if a predicate DOES NOT match, and
+    -- continue on the other case. This way unknown predicates will not be considered, 
+    -- which allows some testing and easier user extensibility (#12173).
     if pred[1] == "eq?" then
       local node = match[pred[2]]
       local node_text = get_node_text(node, bufnr)
@@ -184,9 +187,9 @@ function Query:match_preds(match, pattern, bufnr)
       if start_row ~= end_row then
         return false
       end
-      return regexes[i]:match_line(bufnr, start_row, start_col, end_col)
-    else
-      return false
+      if not regexes[i]:match_line(bufnr, start_row, start_col, end_col) then
+        return false
+      end
     end
   end
   return true


### PR DESCRIPTION
This PR changes slightly the behaviour of treesitter integration so that unknown predicates always match.
This allows for plugins like `nvim-treesitter` to add and test predicates before doing PRs so that they are included here.

Also change the behaviour of the `match?` to not return unconditionnaly.