### PR TITLE
LSP: enable using different highlighting rules for LSP signs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -163,13 +163,21 @@ name: >
 LSP HIGHLIGHT                                                    *lsp-highlight*
 
                                                         *hl-LspDiagnosticsError*
-LspDiagnosticsError       used for "Error" diagnostic virtual text
+LspDiagnosticsError          used for "Error" diagnostic virtual text
+                                                    *hl-LspDiagnosticsErrorSign*
+LspDiagnosticsErrorSign      used for "Error" diagnostic signs in sign column
                                                       *hl-LspDiagnosticsWarning*
-LspDiagnosticsWarning     used for "Warning" diagnostic virtual text
+LspDiagnosticsWarning        used for "Warning" diagnostic virtual text
+                                                  *hl-LspDiagnosticsWarningSign*
+LspDiagnosticsWarningSign    used for "Warning" diagnostic signs in sign column
                                                   *hl-LspDiagnosticsInformation*
-LspDiagnosticInformation  used for "Information" diagnostic virtual text
+LspDiagnosticInformation     used for "Information" diagnostic virtual text
+                                              *hl-LspDiagnosticsInformationSign*
+LspDiagnosticInformationSign used for "Information" signs in sign column
                                                          *hl-LspDiagnosticsHint*
-LspDiagnosticHint         used for "Hint" diagnostic virtual text
+LspDiagnosticHint            used for "Hint" diagnostic virtual text
+                                                     *hl-LspDiagnosticsHintSign*
+LspDiagnosticHintSign        used for "Hint" diagnostic signs in sign column
                                                            *hl-LspReferenceText*
 LspReferenceText          used for highlighting "text" references
                                                            *hl-LspReferenceRead*

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1024,10 +1024,10 @@ do
       vim.fn.sign_define(name, properties)
     end
   end
-  define_default_sign('LspDiagnosticsErrorSign', {text='E', texthl='LspDiagnosticsError', linehl='', numhl=''})
-  define_default_sign('LspDiagnosticsWarningSign', {text='W', texthl='LspDiagnosticsWarning', linehl='', numhl=''})
-  define_default_sign('LspDiagnosticsInformationSign', {text='I', texthl='LspDiagnosticsInformation', linehl='', numhl=''})
-  define_default_sign('LspDiagnosticsHintSign', {text='H', texthl='LspDiagnosticsHint', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsErrorSign', {text='E', texthl='LspDiagnosticsErrorSign', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsWarningSign', {text='W', texthl='LspDiagnosticsWarningSign', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsInformationSign', {text='I', texthl='LspDiagnosticsInformationSign', linehl='', numhl=''})
+  define_default_sign('LspDiagnosticsHintSign', {text='H', texthl='LspDiagnosticsHintSign', linehl='', numhl=''})
 end
 
 return lsp

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -672,6 +672,7 @@ do
       table.insert(cmd_parts, k.."="..v)
     end
     api.nvim_command(table.concat(cmd_parts, ' '))
+    api.nvim_command('highlight link ' .. highlight_name .. 'Sign ' .. highlight_name)
     severity_highlights[severity] = highlight_name
   end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -754,14 +754,18 @@ describe('LSP', function()
 
   it('highlight groups', function()
     eq({'LspDiagnosticsError',
+        'LspDiagnosticsErrorSign',
         'LspDiagnosticsHint',
+        'LspDiagnosticsHintSign',
         'LspDiagnosticsInformation',
+        'LspDiagnosticsInformationSign',
         'LspDiagnosticsUnderline',
         'LspDiagnosticsUnderlineError',
         'LspDiagnosticsUnderlineHint',
         'LspDiagnosticsUnderlineInformation',
         'LspDiagnosticsUnderlineWarning',
         'LspDiagnosticsWarning',
+        'LspDiagnosticsWarningSign',
       },
       exec_lua([[require'vim.lsp'; return vim.fn.getcompletion('Lsp', 'highlight')]]))
   end)


### PR DESCRIPTION
This commit creates 4 new highlight groups:
- LspDiagnosticsErrorSign
- LspDiagnosticsWarningSign
- LspDiagnosticsInformationSign
- LspDiagnosticsHintSign

These highlight groups are linked to their corresponding LspDiagnostics
highlight groups by default.

This lets users choose a different color for their sign columns and
virtualtext warnings.