### PR TITLE
LSP - Remove obsolete peek definition method

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -752,9 +752,6 @@ npcall({fn}, {...})                                     *vim.lsp.buf.npcall()*
 ok_or_nil({status}, {...})                           *vim.lsp.buf.ok_or_nil()*
                 TODO: Documentation
 
-peek_definition()                              *vim.lsp.buf.peek_definition()*
-                TODO: Documentation
-
                                               *vim.lsp.buf.range_formatting()*
 range_formatting({options}, {start_pos}, {end_pos})
                 TODO: Documentation
@@ -1031,10 +1028,6 @@ npcall({fn}, {...})                                    *vim.lsp.util.npcall()*
                 TODO: Documentation
 
 ok_or_nil({status}, {...})                          *vim.lsp.util.ok_or_nil()*
-                TODO: Documentation
-
-                                   *vim.lsp.util.open_floating_peek_preview()*
-open_floating_peek_preview({bufnr}, {start}, {finish}, {opts})
                 TODO: Documentation
 
                                         *vim.lsp.util.open_floating_preview()*

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -32,12 +32,6 @@ function M.hover()
   request('textDocument/hover', params)
 end
 
-function M.peek_definition()
-  local params = util.make_position_params()
-  request('textDocument/peekDefinition', params)
-end
-
-
 function M.declaration()
   local params = util.make_position_params()
   request('textDocument/declaration', params)

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -149,21 +149,6 @@ M['textDocument/signatureHelp'] = function(_, method, result)
   end)
 end
 
-M['textDocument/peekDefinition'] = function(_, _, result, _)
-  if not (result and result[1]) then return end
-  local loc = result[1]
-  local bufnr = vim.uri_to_bufnr(loc.uri) or error("not found: "..tostring(loc.uri))
-  local start = loc.range.start
-  local finish = loc.range["end"]
-  util.open_floating_peek_preview(bufnr, start, finish, { offset_x = 1 })
-  local headbuf = util.open_floating_preview({"Peek:"}, nil, {
-    offset_y = -(finish.line - start.line);
-    width = finish.character - start.character + 2;
-  })
-  -- TODO(ashkan) change highlight group?
-  api.nvim_buf_add_highlight(headbuf, -1, 'Keyword', 0, -1)
-end
-
 M['textDocument/documentHighlight'] = function(_, _, result, _)
   if not result then return end
   local bufnr = api.nvim_get_current_buf()

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -597,31 +597,6 @@ function M.open_floating_preview(contents, filetype, opts)
   return floating_bufnr, floating_winnr
 end
 
-local function validate_lsp_position(pos)
-  validate { pos = {pos, 't'} }
-  validate {
-    line = {pos.line, 'n'};
-    character = {pos.character, 'n'};
-  }
-  return true
-end
-
-function M.open_floating_peek_preview(bufnr, start, finish, opts)
-  validate {
-    bufnr = {bufnr, 'n'};
-    start = {start, validate_lsp_position, 'valid start Position'};
-    finish = {finish, validate_lsp_position, 'valid finish Position'};
-    opts = { opts, 't', true };
-  }
-  local width = math.max(finish.character - start.character + 1, 1)
-  local height = math.max(finish.line - start.line + 1, 1)
-  local floating_winnr = api.nvim_open_win(bufnr, false, M.make_floating_popup_options(width, height, opts))
-  api.nvim_win_set_cursor(floating_winnr, {start.line+1, start.character})
-  api.nvim_command("autocmd CursorMoved * ++once lua pcall(vim.api.nvim_win_close, "..floating_winnr..", true)")
-  return floating_winnr
-end
-
-
 local function highlight_range(bufnr, ns, hiname, start, finish)
   if start[1] == finish[1] then
     -- TODO care about encoding here since this is in byte index?


### PR DESCRIPTION
The method with the name 'textDocument/peekDefinition' is not part of the [official language server protocol specification](https://microsoft.github.io/language-server-protocol/specification.html). No language server implementation can/will support this. Thereby all related code and documentation as been removed.

See also issue #12166 and PR #12169