### PR TITLE
TUI: block signals on suspend (avoid kernel panic #8075)

### DIFF
--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -50,22 +50,13 @@ void signal_init(void)
   signal_watcher_init(&main_loop, &shup, NULL);
   signal_watcher_init(&main_loop, &squit, NULL);
   signal_watcher_init(&main_loop, &sterm, NULL);
-#ifdef SIGPIPE
-  signal_watcher_start(&spipe, on_signal, SIGPIPE);
-#endif
-  signal_watcher_start(&shup, on_signal, SIGHUP);
-#ifdef SIGQUIT
-  signal_watcher_start(&squit, on_signal, SIGQUIT);
-#endif
-  signal_watcher_start(&sterm, on_signal, SIGTERM);
 #ifdef SIGPWR
   signal_watcher_init(&main_loop, &spwr, NULL);
-  signal_watcher_start(&spwr, on_signal, SIGPWR);
 #endif
 #ifdef SIGUSR1
   signal_watcher_init(&main_loop, &susr1, NULL);
-  signal_watcher_start(&susr1, on_signal, SIGUSR1);
 #endif
+  signal_start();
 }
 
 void signal_teardown(void)
@@ -83,11 +74,33 @@ void signal_teardown(void)
 #endif
 }
 
+void signal_start(void)
+{
+#ifdef SIGPIPE
+  signal_watcher_start(&spipe, on_signal, SIGPIPE);
+#endif
+  signal_watcher_start(&shup, on_signal, SIGHUP);
+#ifdef SIGQUIT
+  signal_watcher_start(&squit, on_signal, SIGQUIT);
+#endif
+  signal_watcher_start(&sterm, on_signal, SIGTERM);
+#ifdef SIGPWR
+  signal_watcher_start(&spwr, on_signal, SIGPWR);
+#endif
+#ifdef SIGUSR1
+  signal_watcher_start(&susr1, on_signal, SIGUSR1);
+#endif
+}
+
 void signal_stop(void)
 {
+#ifdef SIGPIPE
   signal_watcher_stop(&spipe);
+#endif
   signal_watcher_stop(&shup);
+#ifdef SIGQUIT
   signal_watcher_stop(&squit);
+#endif
   signal_watcher_stop(&sterm);
 #ifdef SIGPWR
   signal_watcher_stop(&spwr);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -31,6 +31,7 @@
 #include "nvim/event/signal.h"
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
+#include "nvim/os/signal.h"
 #include "nvim/os/tty.h"
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
@@ -1239,7 +1240,9 @@ static void suspend_event(void **argv)
   tui_terminal_stop(ui);
   data->cont_received = false;
   stream_set_blocking(input_global_fd(), true);   // normalize stream (#2598)
+  signal_stop();
   kill(0, SIGTSTP);
+  signal_start();
   while (!data->cont_received) {
     // poll the event loop until SIGCONT is received
     loop_poll_events(data->loop, -1);


### PR DESCRIPTION
This is only temporary, but it seems that kernel panic was occurring when sending signals to race when suspending, so I created a PR to fix it. https://github.com/neovim/neovim/issues/8075

I tried on macOS 10.14.5（18F132）
Terminal.app, iTerm2 (Build 3.3.9), bash 5.0, bash 3.2, zsh 5.7.1 