### PR TITLE
ci/travis: Enable ipv6

### DIFF
--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -10,6 +10,12 @@ fi
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common/build.sh"
 
+# Enable ipv6 on Travis. ref: a39c8b7ce30d
+if ! test "${TRAVIS_OS_NAME}" = osx ; then
+  echo "before_script.sh: enable ipv6"
+  sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0
+fi
+
 # Test some of the configuration variables.
 if [[ -n "${GCOV}" ]] && [[ ! $(type -P "${GCOV}") ]]; then
   echo "\$GCOV: '${GCOV}' is not executable."

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -86,12 +86,3 @@ build_nvim() {
 
   cd "${TRAVIS_BUILD_DIR}"
 }
-
-macos_rvm_dance() {
-  # neovim-ruby gem requires a ruby newer than the macOS default.
-  source ~/.rvm/scripts/rvm
-  rvm get stable --auto-dotfiles
-  rvm reload
-  rvm use 2.2.5
-  rvm use
-}


### PR DESCRIPTION
ref: a39c8b7ce30ddeed4329c28c42b1b699103dccab
ref: https://github.com/vim/vim/commit/bfe13ccc58ccb96f243a58309800410db1ccb52c

seems to work.

before:

```
RUN server -> client connecting to another (peer) nvim via ipv6 address: 42.27 ms SKIP
...
SKIPPED test/functional/api/server_requests_spec.lua server -> client connecting to another (peer) nvim via ipv6 address
test/functional/api/server_requests_spec.lua:331: no ipv6 stack
```

after:

    RUN server -> client connecting to another (peer) nvim via ipv6 address: 153.26 ms OK

