### PR TITLE
defaults: remove _ from cpoptions

### DIFF
--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -132,7 +132,7 @@
                                 // cursor would not move
 #define CPO_CHANGEW     '_'     // "cw" special-case
 // default values for Vim and Vi
-#define CPO_VIM         "aABceFs_"
+#define CPO_VIM         "aABceFs"
 #define CPO_VI          "aAbBcCdDeEfFiIJKlLmMnoOpPqrRsStuvWxXyZ$!%+>;_"
 
 // characters for p_ww option:


### PR DESCRIPTION
'_' converts the mapping 'cw' into 'ce', e.g., ending the edit at the
end of the word without removing the following space.

to recover the previous behavior, add this to vimrc:
set cpoptions+=_

TODO:
- add to vim_diff.txt