### PR TITLE
LSP: Add check for null version in VersionedTextDocumentIdentifier

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -159,7 +159,8 @@ end
 function M.apply_text_document_edit(text_document_edit)
   local text_document = text_document_edit.textDocument
   local bufnr = vim.uri_to_bufnr(text_document.uri)
-  if M.buf_versions[bufnr] > text_document.version then
+  -- `VersionedTextDocumentIdentifier`s version may be nil https://microsoft.github.io/language-server-protocol/specification#versionedTextDocumentIdentifier
+  if text_document.version ~= nil and M.buf_versions[bufnr] > text_document.version then
     print("Buffer ", text_document.uri, " newer than edits.")
     return
   end


### PR DESCRIPTION
According to the spec there is the possibility that when a `VersionedTextDocumentIdentifier` is used in a `TextEdit` the value may be null. Currently we don't check for this and always assume that it's set. So currently if a `TextEdit` comes in for a rename for example with the `version` set as `null`, it fails as we are comparing the bufnumber with nil.

https://microsoft.github.io/language-server-protocol/specification#versionedTextDocumentIdentifier