### PR TITLE
lsp: Fix show_line_diagnostics

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -706,6 +706,7 @@ do
       -- TODO(ashkan) make format configurable?
       local prefix = string.format("%d. ", i)
       local hiname = severity_highlights[diagnostic.severity]
+      assert(hiname, 'unknown severity: ' .. tostring(diagnostic.severity))
       local message_lines = split_lines(diagnostic.message)
       table.insert(lines, prefix..message_lines[1])
       table.insert(highlights, {#prefix + 1, hiname})

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -695,7 +695,7 @@ do
 
     local buffer_diagnostics = M.diagnostics_by_buf[bufnr]
     if not buffer_diagnostics then return end
-    local line_diagnostics = M.diagnostics_group_by_line(buffer_diagnostics[line])
+    local line_diagnostics = M.diagnostics_group_by_line(buffer_diagnostics)[line]
     if not line_diagnostics then return end
 
     for i, diagnostic in ipairs(line_diagnostics) do

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -864,8 +864,8 @@ describe('LSP', function()
   describe('lsp.util.show_line_diagnostics', function()
     it('creates floating window and returns popup bufnr and winnr if current line contains diagnostics', function()
       eq(3, exec_lua [[
-        BUFFER = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_lines(BUFFER, 0, -1, false, {
+        local buffer = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, {
           "testing";
           "123";
         })
@@ -879,8 +879,8 @@ describe('LSP', function()
             message = "Syntax error";
           },
         }
-        vim.api.nvim_win_set_buf(0, BUFFER)
-        vim.lsp.util.buf_diagnostics_save_positions(vim.fn.bufnr(BUFFER), diagnostics)
+        vim.api.nvim_win_set_buf(0, buffer)
+        vim.lsp.util.buf_diagnostics_save_positions(vim.fn.bufnr(buffer), diagnostics)
         local popup_bufnr, winnr = vim.lsp.util.show_line_diagnostics()
         return popup_bufnr
       ]])

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -862,7 +862,7 @@ describe('LSP', function()
     end)
   end)
   describe('lsp.util.show_line_diagnostics', function()
-    it('show_line_diagnotics shows diagnostics for current line', function()
+    it('creates floating window and returns popup bufnr and winnr if current line contains diagnostics', function()
       eq(3, exec_lua [[
         BUFFER = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_lines(BUFFER, 0, -1, false, {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -861,4 +861,29 @@ describe('LSP', function()
       ]])
     end)
   end)
+  describe('lsp.util.show_line_diagnostics', function()
+    it('show_line_diagnotics shows diagnostics for current line', function()
+      eq(3, exec_lua [[
+        BUFFER = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(BUFFER, 0, -1, false, {
+          "testing";
+          "123";
+        })
+        local diagnostics = {
+          {
+            range = {
+              start = { line = 0; character = 1; };
+              ["end"] = { line = 0; character = 3; };
+            };
+            severity = vim.lsp.protocol.DiagnosticSeverity.Error;
+            message = "Syntax error";
+          },
+        }
+        vim.api.nvim_win_set_buf(0, BUFFER)
+        vim.lsp.util.buf_diagnostics_save_positions(vim.fn.bufnr(BUFFER), diagnostics)
+        local popup_bufnr, winnr = vim.lsp.util.show_line_diagnostics()
+        return popup_bufnr
+      ]])
+    end)
+  end)
 end)


### PR DESCRIPTION
Messed this up in ef0398fe88e6cc74f33fb20519997774168d7832

The second commit adds a test for it, but it currently fails with

    neovim/runtime/lua/vim/lsp/util.lua:721: Expected lua string

utils.lua:721 contains:

    api.nvim_buf_add_highlight(popup_bufnr, -1, hiname, i-1, prefixlen, -1)

Any pointers how to resolve this or if there is a better way to test
this?