### PR TITLE
lsp: Fix default sign definition

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1018,7 +1018,7 @@ function lsp.get_log_path()
 end
 
 local function define_default_sign(name, properties)
-  if not vim.fn.sign_getdefined(name) then
+  if #vim.fn.sign_getdefined(name) == 0 then
     vim.fn.sign_define(name, properties)
   end
 end


### PR DESCRIPTION
`sign_getdefined` returns an empty table if the sign doesn't exist, not
`nil`

Without the proper definition the user gets a error message each time a new diagnostic is received.