### PR TITLE
lsp: use vim.tbl_isempty for check sigh for diagnostics presence

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1017,21 +1017,18 @@ function lsp.get_log_path()
   return log.get_filename()
 end
 
-local function define_default_sign(name, properties)
-  if not vim.fn.sign_getdefined(name) then
-    vim.fn.sign_define(name, properties)
-  end
-end
-
 -- Define the LspDiagnostics signs if they're not defined already.
-local function define_default_lsp_diagnostics_signs()
+do
+  local function define_default_sign(name, properties)
+    if vim.tbl_isempty(vim.fn.sign_getdefined(name)) then
+      vim.fn.sign_define(name, properties)
+    end
+  end
   define_default_sign('LspDiagnosticsErrorSign', {text='E', texthl='LspDiagnosticsError', linehl='', numhl=''})
   define_default_sign('LspDiagnosticsWarningSign', {text='W', texthl='LspDiagnosticsWarning', linehl='', numhl=''})
   define_default_sign('LspDiagnosticsInformationSign', {text='I', texthl='LspDiagnosticsInformation', linehl='', numhl=''})
   define_default_sign('LspDiagnosticsHintSign', {text='H', texthl='LspDiagnosticsHint', linehl='', numhl=''})
 end
-
-define_default_lsp_diagnostics_signs()
 
 return lsp
 -- vim:sw=2 ts=2 et

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8489,6 +8489,7 @@ static void f_sign_define(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   xfree(linehl);
   xfree(text);
   xfree(texthl);
+  xfree(numhl);
 }
 
 /// "sign_getdefined()" function


### PR DESCRIPTION
ref: #12164
If we `vim.fn.sign_getdefined("sign name")`, it returns array.
So if the sign is not defined, it returns `{}`.