### PR TITLE
[WIP][LSP] check for vim.NIL and add apply_text_document_edit tests

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -160,7 +160,7 @@ function M.apply_text_document_edit(text_document_edit)
   local text_document = text_document_edit.textDocument
   local bufnr = vim.uri_to_bufnr(text_document.uri)
   -- `VersionedTextDocumentIdentifier`s version may be nil https://microsoft.github.io/language-server-protocol/specification#versionedTextDocumentIdentifier
-  if text_document.version ~= nil and M.buf_versions[bufnr] > text_document.version then
+  if text_document.version ~= vim.NIL and M.buf_versions[bufnr] > text_document.version then
     print("Buffer ", text_document.uri, " newer than edits.")
     return
   end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -817,6 +817,62 @@ describe('LSP', function()
     end)
   end)
 
+  describe('apply_text_document_edit', function()
+    before_each(function()
+      insert(dedent([[
+        First line of text
+        Second line of text]]))
+    end)
+    it('correctly goes ahead with the edit when all is normal', function()
+      local text_document_edit = {
+        edits = {
+          make_edit(0, 0, 0, 0, "hi")
+        },
+        textDocument = {
+          uri = "file://fake/uri";
+          version = 5
+        }
+      }
+      exec_lua('vim.lsp.util.apply_text_document_edit(...)', text_document_edit, 1)
+      eq({
+        'hiline of text';
+        'Second line of text';
+      }, buf_lines(1))
+    end)
+    it('correctly goes ahead with the edit whe the version is nil', function()
+      local text_document_edit = {
+        edits = {
+          make_edit(0, 0, 0, 0, "hi")
+        },
+        textDocument = {
+          uri = "file://fake/uri";
+          version = vim.NIL
+        }
+      }
+      exec_lua('vim.lsp.util.apply_text_document_edit(...)', text_document_edit, 1)
+      eq({
+        'hiline of text';
+        'Second line of text';
+      }, buf_lines(1))
+    end)
+    it('skips the edit if the version of the edit is behind the local buffer ', function()
+      local text_document_edit = {
+        edits = {
+          make_edit(0, 0, 0, 0, "hi")
+        },
+        textDocument = {
+          uri = "file://fake/uri";
+          version = 1
+        }
+      }
+      exec_lua('vim.lsp.util.apply_text_document_edit(...)', text_document_edit, 1)
+      eq({
+        'First line of text';
+        'Second line of text';
+      }, buf_lines(1))
+    end)
+  end)
+
   describe('completion_list_to_complete_items', function()
     -- Completion option precedence:
     -- textEdit.newText > insertText > label


### PR DESCRIPTION
This pr is a follow-up to https://github.com/neovim/neovim/pull/12185 where I checked for `nil` in `apply_text_document_edit` when the check should have been for `vim.NIL`. I've changed that and added in some tests per @teto's request. However, I'm stuck a bit on the tests. I'll explain in a comment below.