### PR TITLE
[RFC] vim-patch:8.2.0629

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1075,8 +1075,8 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
       break;
 
     case kObjectTypeBoolean:
-      tv->v_type = VAR_SPECIAL;
-      tv->vval.v_special = obj.data.boolean? kSpecialVarTrue: kSpecialVarFalse;
+      tv->v_type = VAR_BOOL;
+      tv->vval.v_bool = obj.data.boolean? kBoolVarTrue: kBoolVarFalse;
       break;
 
     case kObjectTypeBuffer:

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1838,12 +1838,15 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
       int opt_type;
       long numval;
       char *stringval = NULL;
+      const char *s = NULL;
 
       const char c1 = *p;
       *p = NUL;
 
       varnumber_T n = tv_get_number(tv);
-      const char *s = tv_get_string_chk(tv);  // != NULL if number or string.
+      if (tv->v_type != VAR_BOOL && tv->v_type != VAR_SPECIAL) {
+        s = tv_get_string_chk(tv);  // != NULL if number or string.
+      }
       if (s != NULL && op != NULL && *op != '=') {
         opt_type = get_option_value(arg, &numval, (char_u **)&stringval,
                                     opt_flags);
@@ -1869,7 +1872,8 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
           }
         }
       }
-      if (s != NULL) {
+      if (s != NULL || tv->v_type == VAR_BOOL
+          || tv->v_type == VAR_SPECIAL) {
         set_option_value((const char *)arg, n, s, opt_flags);
         arg_end = (char_u *)p;
       }

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -795,9 +795,9 @@ json_decode_string_cycle_start:
         }
         p += 3;
         POP(((typval_T) {
-          .v_type = VAR_SPECIAL,
+          .v_type = VAR_BOOL,
           .v_lock = VAR_UNLOCKED,
-          .vval = { .v_special = kSpecialVarTrue },
+          .vval = { .v_bool = kBoolVarTrue },
         }), false);
         break;
       }
@@ -808,9 +808,9 @@ json_decode_string_cycle_start:
         }
         p += 4;
         POP(((typval_T) {
-          .v_type = VAR_SPECIAL,
+          .v_type = VAR_BOOL,
           .v_lock = VAR_UNLOCKED,
-          .vval = { .v_special = kSpecialVarFalse },
+          .vval = { .v_bool = kBoolVarFalse },
         }), false);
         break;
       }
@@ -954,10 +954,10 @@ int msgpack_to_vim(const msgpack_object mobj, typval_T *const rettv)
     }
     case MSGPACK_OBJECT_BOOLEAN: {
       *rettv = (typval_T) {
-        .v_type = VAR_SPECIAL,
+        .v_type = VAR_BOOL,
         .v_lock = VAR_UNLOCKED,
         .vval = {
-          .v_special = mobj.via.boolean ? kSpecialVarTrue : kSpecialVarFalse
+          .v_bool = mobj.via.boolean ? kBoolVarTrue : kBoolVarFalse
         },
       };
       break;

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -34,10 +34,13 @@
 #define utf_ptr2len(b) ((size_t)utf_ptr2len((char_u *)b))
 #define utf_char2len(b) ((size_t)utf_char2len(b))
 
+const char *const encode_bool_var_names[] = {
+  [kBoolVarTrue] = "true",
+  [kBoolVarFalse] = "false",
+};
+
 const char *const encode_special_var_names[] = {
   [kSpecialVarNull] = "null",
-  [kSpecialVarTrue] = "true",
-  [kSpecialVarFalse] = "false",
 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/eval/encode.h
+++ b/src/nvim/eval/encode.h
@@ -55,6 +55,7 @@ static inline ListReaderState encode_init_lrstate(const list_T *const list)
 }
 
 /// Array mapping values from SpecialVarValue enum to names
+extern const char *const encode_bool_var_names[];
 extern const char *const encode_special_var_names[];
 
 /// First codepoint in high surrogates block

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -28,11 +28,13 @@ int eexe_mod_op(typval_T *const tv1, const typval_T *const tv2,
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NO_SANITIZE_UNDEFINED
 {
   // Can't do anything with a Funcref, a Dict or special value on the right.
-  if (tv2->v_type != VAR_FUNC && tv2->v_type != VAR_DICT) {
+  if (tv2->v_type != VAR_FUNC && tv2->v_type != VAR_DICT
+      && tv2->v_type != VAR_BOOL && tv2->v_type != VAR_SPECIAL) {
     switch (tv1->v_type) {
       case VAR_DICT:
       case VAR_FUNC:
       case VAR_PARTIAL:
+      case VAR_BOOL:
       case VAR_SPECIAL: {
         break;
       }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -175,8 +175,8 @@ static int non_zero_arg(typval_T *argvars)
 {
   return ((argvars[0].v_type == VAR_NUMBER
            && argvars[0].vval.v_number != 0)
-          || (argvars[0].v_type == VAR_SPECIAL
-              && argvars[0].vval.v_special == kSpecialVarTrue)
+          || (argvars[0].v_type == VAR_BOOL
+              && argvars[0].vval.v_bool == kBoolVarTrue)
           || (argvars[0].v_type == VAR_STRING
               && argvars[0].vval.v_string != NULL
               && *argvars[0].vval.v_string != NUL));
@@ -1758,19 +1758,21 @@ static void f_empty(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       n = (tv_dict_len(argvars[0].vval.v_dict) == 0);
       break;
     }
-    case VAR_SPECIAL: {
-      // Using switch to get warning if SpecialVarValue receives more values.
-      switch (argvars[0].vval.v_special) {
-        case kSpecialVarTrue: {
+    case VAR_BOOL: {
+      switch (argvars[0].vval.v_bool) {
+        case kBoolVarTrue: {
           n = false;
           break;
         }
-        case kSpecialVarFalse:
-        case kSpecialVarNull: {
+        case kBoolVarFalse: {
           n = true;
           break;
         }
       }
+      break;
+    }
+    case VAR_SPECIAL: {
+      n = argvars[0].vval.v_special == kSpecialVarNull;
       break;
     }
     case VAR_UNKNOWN: {
@@ -5189,6 +5191,7 @@ static void f_len(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       break;
     }
     case VAR_UNKNOWN:
+    case VAR_BOOL:
     case VAR_SPECIAL:
     case VAR_FLOAT:
     case VAR_PARTIAL:
@@ -10808,20 +10811,8 @@ static void f_type(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     case VAR_LIST:   n = VAR_TYPE_LIST; break;
     case VAR_DICT:   n = VAR_TYPE_DICT; break;
     case VAR_FLOAT:  n = VAR_TYPE_FLOAT; break;
-    case VAR_SPECIAL: {
-      switch (argvars[0].vval.v_special) {
-        case kSpecialVarTrue:
-        case kSpecialVarFalse: {
-          n = VAR_TYPE_BOOL;
-          break;
-        }
-        case kSpecialVarNull: {
-          n = 7;
-          break;
-        }
-      }
-      break;
-    }
+    case VAR_BOOL:   n = VAR_TYPE_BOOL; break;
+    case VAR_SPECIAL:n = VAR_TYPE_SPECIAL; break;
     case VAR_UNKNOWN: {
       internal_error("f_type(UNKNOWN)");
       break;

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -91,10 +91,14 @@ typedef struct dict_watcher {
   bool busy;  // prevent recursion if the dict is changed in the callback
 } DictWatcher;
 
+/// Bool variable values
+typedef enum {
+  kBoolVarFalse,         ///< v:false
+  kBoolVarTrue,          ///< v:true
+} BoolVarValue;
+
 /// Special variable values
 typedef enum {
-  kSpecialVarFalse,  ///< v:false
-  kSpecialVarTrue,   ///< v:true
   kSpecialVarNull,   ///< v:null
 } SpecialVarValue;
 
@@ -114,6 +118,7 @@ typedef enum {
   VAR_LIST,         ///< List, .v_list is used.
   VAR_DICT,         ///< Dictionary, .v_dict is used.
   VAR_FLOAT,        ///< Floating-point value, .v_float is used.
+  VAR_BOOL,         ///< true, false
   VAR_SPECIAL,      ///< Special value (true, false, null), .v_special
                     ///< is used.
   VAR_PARTIAL,      ///< Partial, .v_partial is used.
@@ -125,6 +130,7 @@ typedef struct {
   VarLockStatus v_lock;  ///< Variable lock status.
   union typval_vval_union {
     varnumber_T v_number;  ///< Number, for VAR_NUMBER.
+    BoolVarValue v_bool;        ///< Bool value, for VAR_BOOL
     SpecialVarValue v_special;  ///< Special value, for VAR_SPECIAL.
     float_T v_float;  ///< Floating-point number, for VAR_FLOAT.
     char_u *v_string;  ///< String, for VAR_STRING and VAR_FUNC, can be NULL.

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -379,15 +379,20 @@ static int _TYPVAL_ENCODE_CONVERT_ONE_VALUE(
       TYPVAL_ENCODE_CONV_REAL_LIST_AFTER_START(tv, _mp_last(*mpstack));
       break;
     }
+    case VAR_BOOL: {
+      switch (tv->vval.v_bool) {
+        case kBoolVarTrue:
+        case kBoolVarFalse: {
+          TYPVAL_ENCODE_CONV_BOOL(tv, tv->vval.v_bool == kBoolVarTrue);
+          break;
+        }
+      }
+      break;
+    }
     case VAR_SPECIAL: {
       switch (tv->vval.v_special) {
         case kSpecialVarNull: {
           TYPVAL_ENCODE_CONV_NIL(tv);  // -V1037
-          break;
-        }
-        case kSpecialVarTrue:
-        case kSpecialVarFalse: {
-          TYPVAL_ENCODE_CONV_BOOL(tv, tv->vval.v_special == kSpecialVarTrue);
           break;
         }
       }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -432,8 +432,8 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     tv_dict_add_nr(dict, S_LEN("cmdlevel"), ccline.level);
     tv_dict_set_keys_readonly(dict);
     // not readonly:
-    tv_dict_add_special(dict, S_LEN("abort"),
-                        s->gotesc ? kSpecialVarTrue : kSpecialVarFalse);
+    tv_dict_add_bool(dict, S_LEN("abort"),
+                     s->gotesc ? kBoolVarTrue : kBoolVarFalse);
     try_enter(&tstate);
     apply_autocmds(EVENT_CMDLINELEAVE, (char_u *)firstcbuf, (char_u *)firstcbuf,
                    false, curbuf);

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -286,10 +286,10 @@ bool nlua_pop_typval(lua_State *lstate, typval_T *ret_tv)
         break;
       }
       case LUA_TBOOLEAN: {
-        cur.tv->v_type = VAR_SPECIAL;
-        cur.tv->vval.v_special = (lua_toboolean(lstate, -1)
-                                  ? kSpecialVarTrue
-                                  : kSpecialVarFalse);
+        cur.tv->v_type = VAR_BOOL;
+        cur.tv->vval.v_bool = (lua_toboolean(lstate, -1)
+                               ? kBoolVarTrue
+                               : kBoolVarFalse);
         break;
       }
       case LUA_TSTRING: {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2740,8 +2740,8 @@ static void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
   tv_dict_add_str(dict, S_LEN("regname"), buf);
 
   // Motion type: inclusive or exclusive.
-  tv_dict_add_special(dict, S_LEN("inclusive"),
-                      oap->inclusive ? kSpecialVarTrue : kSpecialVarFalse);
+  tv_dict_add_bool(dict, S_LEN("inclusive"),
+                   oap->inclusive ? kBoolVarTrue : kBoolVarFalse);
 
   // Kind of operation: yank, delete, change).
   buf[0] = (char)get_op_char(oap->op_type);
@@ -2749,8 +2749,8 @@ static void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
   tv_dict_add_str(dict, S_LEN("operator"), buf);
 
   // Selection type: visual or not.
-  tv_dict_add_special(dict, S_LEN("visual"),
-                      oap->is_VIsual ? kSpecialVarTrue : kSpecialVarFalse);
+  tv_dict_add_bool(dict, S_LEN("visual"),
+                   oap->is_VIsual ? kBoolVarTrue : kBoolVarFalse);
 
   tv_dict_set_keys_readonly(dict);
   textlock++;

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -923,6 +923,6 @@ void pum_set_event_info(dict_T *dict)
   tv_dict_add_float(dict, S_LEN("row"), r);
   tv_dict_add_float(dict, S_LEN("col"), c);
   tv_dict_add_nr(dict, S_LEN("size"), pum_size);
-  tv_dict_add_special(dict, S_LEN("scrollbar"),
-                      pum_scrollbar ? kSpecialVarTrue : kSpecialVarFalse);
+  tv_dict_add_bool(dict, S_LEN("scrollbar"),
+                   pum_scrollbar ? kBoolVarTrue : kBoolVarFalse);
 }

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -561,3 +561,18 @@ func Test_visualbell()
   set novisualbell
   set belloff=all
 endfunc
+
+" Test for setting option values using v:false and v:true
+func Test_opt_boolean()
+  set number&
+  set number
+  call assert_equal(1, &nu)
+  set nonu
+  call assert_equal(0, &nu)
+  let &nu = v:true
+  call assert_equal(1, &nu)
+  let &nu = v:false
+  call assert_equal(0, &nu)
+  set number&
+endfunc
+

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -101,6 +101,7 @@ typedef enum {
 #define VAR_TYPE_DICT       4
 #define VAR_TYPE_FLOAT      5
 #define VAR_TYPE_BOOL       6
+#define VAR_TYPE_SPECIAL    7
 
 
 // values for xp_context when doing command line completion

--- a/test/functional/eval/buf_functions_spec.lua
+++ b/test/functional/eval/buf_functions_spec.lua
@@ -31,10 +31,12 @@ for _, func in ipairs({'bufname(%s)', 'bufnr(%s)', 'bufwinnr(%s)',
     it('errors out when receives v:true/v:false/v:null', function()
       -- Not compatible with Vim: in Vim it always results in buffer not found
       -- without any error messages.
-      for _, var in ipairs({'v:true', 'v:false', 'v:null'}) do
-        eq('Vim(call):E5300: Expected a Number or a String',
+      for _, var in ipairs({'v:true', 'v:false'}) do
+        eq('Vim(call):E5299: Expected a Number or a String, Boolean found',
            exc_exec('call ' .. func:format(var)))
       end
+      eq('Vim(call):E5300: Expected a Number or a String',
+         exc_exec('call ' .. func:format('v:null')))
     end)
     it('errors out when receives invalid argument', function()
       eq('Vim(call):E745: Expected a Number or a String, List found',

--- a/test/functional/eval/sort_spec.lua
+++ b/test/functional/eval/sort_spec.lua
@@ -14,7 +14,7 @@ before_each(clear)
 
 describe('sort()', function()
   it('errors out when sorting special values', function()
-    eq('Vim(call):E907: Using a special value as a Float',
+    eq('Vim(call):E362: Using a boolean value as a Float',
        exc_exec('call sort([v:true, v:false], "f")'))
   end)
 
@@ -30,6 +30,7 @@ describe('sort()', function()
       errors[err] = true
     end
     eq({
+      ['E362: Using a boolean value as a Float']=true,
       ['E891: Using a Funcref as a Float']=true,
       ['E892: Using a String as a Float']=true,
       ['E893: Using a List as a Float']=true,

--- a/test/functional/eval/uniq_spec.lua
+++ b/test/functional/eval/uniq_spec.lua
@@ -11,7 +11,7 @@ before_each(clear)
 
 describe('uniq()', function()
   it('errors out when processing special values', function()
-    eq('Vim(call):E907: Using a special value as a Float',
+    eq('Vim(call):E362: Using a boolean value as a Float',
        exc_exec('call uniq([v:true, v:false], "f")'))
   end)
 

--- a/test/unit/eval/helpers.lua
+++ b/test/unit/eval/helpers.lua
@@ -136,11 +136,15 @@ local function typvalt2lua_tab_init()
     return
   end
   typvalt2lua_tab = {
+    [tonumber(eval.VAR_BOOL)] = function(t)
+      return ({
+        [tonumber(eval.kBoolVarFalse)] = false,
+        [tonumber(eval.kBoolVarTrue)] = true,
+      })[tonumber(t.vval.v_bool)]
+    end,
     [tonumber(eval.VAR_SPECIAL)] = function(t)
       return ({
-        [tonumber(eval.kSpecialVarFalse)] = false,
         [tonumber(eval.kSpecialVarNull)] = nil_value,
-        [tonumber(eval.kSpecialVarTrue)] = true,
       })[tonumber(t.vval.v_special)]
     end,
     [tonumber(eval.VAR_NUMBER)] = function(t)
@@ -349,8 +353,8 @@ lua2typvalt = function(l, processed)
       [null_list] = {'VAR_LIST', {v_list=ffi.cast('list_T*', nil)}},
       [null_dict] = {'VAR_DICT', {v_dict=ffi.cast('dict_T*', nil)}},
       [nil_value] = {'VAR_SPECIAL', {v_special=eval.kSpecialVarNull}},
-      [true] = {'VAR_SPECIAL', {v_special=eval.kSpecialVarTrue}},
-      [false] = {'VAR_SPECIAL', {v_special=eval.kSpecialVarFalse}},
+      [true] = {'VAR_BOOL', {v_bool=eval.kBoolVarTrue}},
+      [false] = {'VAR_BOOL', {v_bool=eval.kBoolVarFalse}},
     }
 
     for k, v in pairs(special_vals) do


### PR DESCRIPTION
#### vim-patch:8.2.0629: setting a boolean option to v:false does not work

Problem:    Setting a boolean option to v:false does not work.
Solution:   Do not use the string representation of the value. (Christian
            Brabandt, closes vim/vim#5974)
https://github.com/vim/vim/commit/65d032c779a43b767497e15e6a32d04a6a8fa65d

cc #12174 