### PR TITLE
lsp/completion: Expose completion_item under completed_items.user_data + vim-patch:8.2.0084

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1083,7 +1083,8 @@ items:
 	empty		when non-zero this match will be added even when it is
 			an empty string
 	user_data 	custom data which is associated with the item and
-			available in |v:completed_item|
+			available in |v:completed_item|; it can be any type;
+			defaults to an empty string
 
 All of these except "icase", "equal", "dup" and "empty" must be a string.  If
 an item does not meet these requirements then an error message is given and

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -240,6 +240,13 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       icase = 1,
       dup = 1,
       empty = 1,
+      user_data = {
+        nvim = {
+          lsp = {
+            completion_item = completion_item
+          }
+        }
+      },
     })
   end
 

--- a/src/nvim/edit.h
+++ b/src/nvim/edit.h
@@ -10,8 +10,7 @@
 #define CPT_MENU        1   // "menu"
 #define CPT_KIND        2   // "kind"
 #define CPT_INFO        3   // "info"
-#define CPT_USER_DATA   4   // "user data"
-#define CPT_COUNT       5   // Number of entries
+#define CPT_COUNT       4   // Number of entries
 
 // values for cp_flags
 typedef enum {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1429,6 +1429,23 @@ dictitem_T *tv_dict_find(const dict_T *const d, const char *const key,
   return TV_DICT_HI2DI(hi);
 }
 
+/// Get a typval item from a dictionary and copy it into "rettv".
+///
+/// @param[in]  d  Dictionary to check.
+/// @param[in]  key  Dictionary key.
+/// @param[in]  rettv  Return value.
+/// @return OK in case of success or FAIL if nothing was found.
+int tv_dict_get_tv(dict_T *d, const char *const key, typval_T *rettv)
+{
+  dictitem_T *const di = tv_dict_find(d, key, -1);
+  if (di == NULL) {
+    return FAIL;
+  }
+
+  tv_copy(&di->di_tv, rettv);
+  return OK;
+}
+
 /// Get a number item from a dictionary
 ///
 /// Returns 0 if the entry does not exist.
@@ -1584,6 +1601,26 @@ int tv_dict_add_list(dict_T *const d, const char *const key,
   if (tv_dict_add(d, item) == FAIL) {
     tv_dict_item_free(item);
     return FAIL;
+  }
+  return OK;
+}
+
+/// Add a typval entry to dictionary.
+///
+/// @param[out]  d  Dictionary to add entry to.
+/// @param[in]  key  Key to add.
+/// @param[in]  key_len  Key length.
+///
+/// @return FAIL if out of memory or key already exists.
+int tv_dict_add_tv(dict_T *d, const char *key, const size_t key_len,
+                   typval_T *tv)
+{
+  dictitem_T *const item = tv_dict_item_alloc_len(key, key_len);
+
+  tv_copy(tv, &item->di_tv);
+  if (tv_dict_add(d, item) == FAIL) {
+      tv_dict_item_free(item);
+      return FAIL;
   }
   return OK;
 }

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -120,7 +120,7 @@ function! s:CompleteDone_CompleteFuncDict( findstart, base )
               \ 'menu': 'extra text',
               \ 'info': 'words are cool',
               \ 'kind': 'W',
-              \ 'user_data': 'test'
+              \ 'user_data': ['one', 'two']
             \ }
           \ ]
         \ }
@@ -136,7 +136,7 @@ func s:CompleteDone_CheckCompletedItemDict(pre)
   call assert_equal( 'extra text',     v:completed_item[ 'menu' ] )
   call assert_equal( 'words are cool', v:completed_item[ 'info' ] )
   call assert_equal( 'W',              v:completed_item[ 'kind' ] )
-  call assert_equal( 'test',           v:completed_item[ 'user_data' ] )
+  call assert_equal( ['one', 'two'],   v:completed_item[ 'user_data' ] )
 
   if a:pre
     call assert_equal('function', complete_info().mode)
@@ -170,7 +170,7 @@ func Test_CompleteDoneDict()
   execute "normal a\<C-X>\<C-U>\<C-Y>"
   set completefunc&
 
-  call assert_equal('test', v:completed_item[ 'user_data' ])
+  call assert_equal(['one', 'two'], v:completed_item[ 'user_data' ])
   call assert_true(s:called_completedone)
 
   let s:called_completedone = 0

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -832,12 +832,12 @@ describe('LSP', function()
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
-        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar'},
+        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label = 'foobar' } } } } },
+        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foobar', textEdit={} } } }  } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foobar' } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foobar', textEdit={} } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='foobar'} } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = '', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', textEdit={newText='foobar'} } } } } },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))


### PR DESCRIPTION
As per discussion in #11949 

- ports over patch 8.2.0084 to allow user_data to contain any value type. This way we can pass through LSP snippet data without the performance hit of json_encode/decode.

- Exposes completion_item, scoped under `nvim.lsp`.

https://github.com/vim/vim/issues/5412

