### PR TITLE
doc/ui.txt(mode_info_set): mention colors should be swapped

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -161,7 +161,9 @@ the editor.
 	`cursor_shape`:	"block", "horizontal", "vertical"
 	`cell_percentage`: Cell % occupied by the cursor.
 	`blinkwait`, `blinkon`, `blinkoff`: See |cursor-blinking|.
-	`attr_id`:	Cursor attribute id (defined by `hl_attr_define`)
+	`attr_id`:	Cursor attribute id (defined by `hl_attr_define`).
+			When attr_id is 0, the background and foreground
+			colors should be swapped.
 	`attr_id_lm`:	Cursor attribute id for when 'langmap' is active.
 	`short_name`:	Mode code name, see 'guicursor'.
 	`name`:		Mode descriptive name.


### PR DESCRIPTION
When attr_id is 0, the cursor's colors should be swapped, otherwise the
cursor might be invisible.

Closes #12198.