### PR TITLE
lsp: add workspace/symbol

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -49,6 +49,7 @@ go-to-definition, hover, etc.  Example config: >
   nnoremap <silent> 1gD   <cmd>lua vim.lsp.buf.type_definition()<CR>
   nnoremap <silent> gr    <cmd>lua vim.lsp.buf.references()<CR>
   nnoremap <silent> g0    <cmd>lua vim.lsp.buf.document_symbol()<CR>
+  nnoremap <silent> gW    <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
 
 Nvim provides the |vim.lsp.omnifunc| 'omnifunc' handler which allows
 |i_CTRL-X_CTRL-O| to consume LSP completion. Example config (note the use of
@@ -782,6 +783,13 @@ signature_help()                                *vim.lsp.buf.signature_help()*
 
 type_definition()                              *vim.lsp.buf.type_definition()*
                 TODO: Documentation
+
+workspace_symbol({query})                     *vim.lsp.buf.workspace_symbol()*
+                Lists all symbols in the current workspace in the quickfix
+                window. The list is filtered against the optional argument 
+                {query}; if the argument is omitted from the call, the user 
+                is prompted to enter a string on the command line. An empty
+                string means no filtering is done. 
 
 
 ==============================================================================

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -533,6 +533,7 @@ function lsp.start_client(config)
       or (not client.resolved_capabilities.goto_definition and method == 'textDocument/definition')
       or (not client.resolved_capabilities.implementation and method == 'textDocument/implementation')
       or (not client.resolved_capabilities.document_symbol and method == 'textDocument/documentSymbol')
+      or (not client.resolved_capabilities.workspace_symbol and method == 'textDocument/workspaceSymbol')
     then
       callback(unsupported_method(method), method, nil, client_id, bufnr)
       return

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -137,6 +137,12 @@ function M.document_symbol()
   request('textDocument/documentSymbol', params)
 end
 
+function M.workspace_symbol(query)
+  query = query or npcall(vfn.input, "Query: ")
+  local params = {query = query}
+  request('workspace/symbol', params)
+end
+
 --- Send request to server to resolve document highlights for the
 --- current text document position. This request can be associated
 --- to key mapping or to events such as `CursorHold`, eg:

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -62,6 +62,14 @@ M['textDocument/documentSymbol'] = function(_, _, result, _, bufnr)
   api.nvim_command("wincmd p")
 end
 
+M['workspace/symbol'] = function(_, _, result, _, bufnr)
+  if not result or vim.tbl_isempty(result) then return end
+
+  util.set_qflist(util.symbols_to_items(result, bufnr))
+  api.nvim_command("copen")
+  api.nvim_command("wincmd p")
+end
+
 M['textDocument/rename'] = function(_, _, result)
   if not result then return end
   util.apply_workspace_edit(result)

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -54,21 +54,15 @@ M['textDocument/references'] = function(_, _, result)
   api.nvim_command("wincmd p")
 end
 
-M['textDocument/documentSymbol'] = function(_, _, result, _, bufnr)
+local symbol_callback = function(_, _, result, _, bufnr)
   if not result or vim.tbl_isempty(result) then return end
 
   util.set_qflist(util.symbols_to_items(result, bufnr))
   api.nvim_command("copen")
   api.nvim_command("wincmd p")
 end
-
-M['workspace/symbol'] = function(_, _, result, _, bufnr)
-  if not result or vim.tbl_isempty(result) then return end
-
-  util.set_qflist(util.symbols_to_items(result, bufnr))
-  api.nvim_command("copen")
-  api.nvim_command("wincmd p")
-end
+M['textDocument/documentSymbol'] = symbol_callback
+M['workspace/symbol'] = symbol_callback
 
 M['textDocument/rename'] = function(_, _, result)
   if not result then return end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -676,6 +676,19 @@ function protocol.make_client_capabilities()
         };
         hierarchicalDocumentSymbolSupport = true;
       };
+      workspaceSymbol = {
+        dynamicRegistration = false;
+        symbolKind = {
+          valueSet = (function()
+            local res = {}
+            for k in pairs(protocol.SymbolKind) do
+              if type(k) == 'number' then table.insert(res, k) end
+            end
+            return res
+          end)();
+        };
+        hierarchicalWorkspaceSymbolSupport = false;
+      };
     };
     workspace = nil;
     experimental = nil;

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -687,7 +687,7 @@ function protocol.make_client_capabilities()
             return res
           end)();
         };
-        hierarchicalWorkspaceSymbolSupport = false;
+        hierarchicalWorkspaceSymbolSupport = true;
       };
     };
     workspace = nil;


### PR DESCRIPTION
Adds the `workspace/symbol` method (by ~~stealing~~ following the pattern from `textDocument/DocumentSymbol` and `textDocument/rename`).

I've set `hierarchicalWorkspaceSymbolSupport = false` for now since there seems to be a bug in `_symbols_to_items` for hierarchical symbols.

(Tested with texlab server only)