### PR TITLE
funcs: Fix a memory leak in f_expand

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2063,8 +2063,10 @@ static void f_expand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       if (result != NULL) {
         tv_list_append_string(rettv->vval.v_list, (const char *)result, -1);
       }
-    } else
+      XFREE_CLEAR(result);
+    } else {
       rettv->vval.v_string = result;
+    }
   } else {
     // When the optional second argument is non-zero, don't remove matches
     // for 'wildignore' and don't put matches for 'suffixes' at the end.


### PR DESCRIPTION
```
:echo expand('%', v:false, v:true)

==423== 28 bytes in 1 blocks are definitely lost in loss record 124 of 420
==423==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==423==    by 0x2AD09C: try_malloc (memory.c:71)
==423==    by 0x2AD0B8: xmalloc (memory.c:105)
==423==    by 0x2AE05D: xmallocz (memory.c:182)
==423==    by 0x1F7CF4: vim_strnsave (strings.c:68)
==423==    by 0x318813: eval_vars (ex_docmd.c:8885)
==423==    by 0x34F5FC: f_expand (funcs.c:2058)
==423==    by 0x36D023: call_func (eval.c:6419)
==423==    by 0x370C28: get_func_tv.lto_priv.707 (eval.c:6150)
==423==    by 0x372748: eval7 (eval.c:4326)
==423==    by 0x37291A: eval6 (eval.c:4036)
==423==    by 0x372BF6: eval5 (eval.c:3884)
```

Related: https://github.com/vim/vim/commit/8617348e2110c2c8387ea448a6258f1effa8d249. Before porting 8.1.2107, we need to port the method. Therefore, I created a PR that solved only this problem for the time being. The release here seems to have been completely leaky compared to vim in the first place.