### PR TITLE
LSP: Support LocationLink

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -644,6 +644,18 @@ function protocol.make_client_capabilities()
         -- TODO(tjdevries): Implement this
         contextSupport = false;
       };
+      declaration = {
+        linkSupport = true;
+      };
+      definition = {
+        linkSupport = true;
+      };
+      implementation = {
+        linkSupport = true;
+      };
+      typeDefinition = {
+        linkSupport = true;
+      };
       hover = {
         dynamicRegistration = false;
         contentFormat = { protocol.MarkupKind.Markdown; protocol.MarkupKind.PlainText };

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -424,8 +424,10 @@ function M.make_floating_popup_options(width, height, opts)
 end
 
 function M.jump_to_location(location)
-  if location.uri == nil then return end
-  local bufnr = vim.uri_to_bufnr(location.uri)
+  -- location may be Location or LocationLink
+  local uri = location.uri or location.targetUri
+  if uri == nil then return end
+  local bufnr = vim.uri_to_bufnr(uri)
   -- Save position in jumplist
   vim.cmd "normal! m'"
 
@@ -436,8 +438,9 @@ function M.jump_to_location(location)
 
   --- Jump to new location
   api.nvim_set_current_buf(bufnr)
-  local row = location.range.start.line
-  local col = location.range.start.character
+  local range = location.range or location.targetSelectionRange
+  local row = range.start.line
+  local col = range.start.character
   local line = api.nvim_buf_get_lines(0, row, row+1, true)[1]
   col = vim.str_byteindex(line, col)
   api.nvim_win_set_cursor(0, {row + 1, col})
@@ -876,9 +879,11 @@ function M.locations_to_items(locations)
     end;
   })
   for _, d in ipairs(locations) do
-    local start = d.range.start
-    local fname = assert(vim.uri_to_fname(d.uri))
-    table.insert(grouped[fname], {start = start})
+    -- locations may be Location or LocationLink
+    local uri = d.uri or d.targetUri
+    local fname = assert(vim.uri_to_fname(uri))
+    local range = d.range or d.targetSelectionRange
+    table.insert(grouped[fname], {start = range.start})
   end
 
 


### PR DESCRIPTION
addresses first part of #12218 

Servers may respond to `textDocument/definition` (and similar) requests with either a `Location` or a `LocationLink` (or an array of them). Unfortunately, the names of the default fields in these are different, so `jump_to_location` and `locations_to_items` need to check for either name. (`symbol` requests can only return `Location`s, so `symbols_to_items` doesn't need to be changed).

Also announce the support for `LocationLink` in the client capabilities.

(Tested with texlab.)