### PR TITLE
LSP: provide "peek definition" function

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -15,6 +15,7 @@ local lsp = {
   protocol = protocol;
   callbacks = default_callbacks;
   buf = require'vim.lsp.buf';
+  extensions = require'vim.lsp.extensions';
   util = util;
   -- Allow raw RPC access.
   rpc = lsp_rpc;

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -52,33 +52,33 @@ function M.implementation()
   request('textDocument/implementation', params)
 end
 
-local function peek_location_callback(_, method, result)
+local function preview_location_callback(_, method, result)
   if result == nil or vim.tbl_isempty(result) then
     local _ = log.info() and log.info(method, 'No location found')
     return nil
   end
   if vim.tbl_islist(result) then
-    util.peek_location(result[1])
+    util.preview_location(result[1])
   else
-    util.peek_location(result)
+    util.preview_location(result)
   end
 end
 
 function M.peek_definition()
   local params = util.make_position_params()
-  request('textDocument/definition', params, peek_location_callback)
+  request('textDocument/definition', params, preview_location_callback)
 end
 function M.peek_declaration()
   local params = util.make_position_params()
-  request('textDocument/declaration', params, peek_location_callback)
+  request('textDocument/declaration', params, preview_location_callback)
 end
 function M.peek_implementation()
   local params = util.make_position_params()
-  request('textDocument/implementation', params, peek_location_callback)
+  request('textDocument/implementation', params, preview_location_callback)
 end
 function M.peek_typeDefinition()
   local params = util.make_position_params()
-  request('textDocument/typeDefinition', params, peek_location_callback)
+  request('textDocument/typeDefinition', params, preview_location_callback)
 end
 
 function M.signature_help()

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -3,7 +3,6 @@ local validate = vim.validate
 local api = vim.api
 local vfn = vim.fn
 local util = require 'vim.lsp.util'
-local log = require 'vim.lsp.log'
 local list_extend = vim.list_extend
 
 local M = {}
@@ -51,35 +50,6 @@ end
 function M.implementation()
   local params = util.make_position_params()
   request('textDocument/implementation', params)
-end
-
-local function preview_location_callback(_, method, result)
-  if result == nil or vim.tbl_isempty(result) then
-    local _ = log.info() and log.info(method, 'No location found')
-    return nil
-  end
-  if vim.tbl_islist(result) then
-    util.preview_location(result[1])
-  else
-    util.preview_location(result)
-  end
-end
-
-function M.peek_definition()
-  local params = util.make_position_params()
-  request('textDocument/definition', params, preview_location_callback)
-end
-function M.peek_declaration()
-  local params = util.make_position_params()
-  request('textDocument/declaration', params, preview_location_callback)
-end
-function M.peek_implementation()
-  local params = util.make_position_params()
-  request('textDocument/implementation', params, preview_location_callback)
-end
-function M.peek_typeDefinition()
-  local params = util.make_position_params()
-  request('textDocument/typeDefinition', params, preview_location_callback)
 end
 
 function M.signature_help()

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -52,6 +52,35 @@ function M.implementation()
   request('textDocument/implementation', params)
 end
 
+local function peek_location_callback(_, method, result)
+  if result == nil or vim.tbl_isempty(result) then
+    local _ = log.info() and log.info(method, 'No location found')
+    return nil
+  end
+  if vim.tbl_islist(result) then
+    util.peek_location(result[1])
+  else
+    util.peek_location(result)
+  end
+end
+
+function M.peek_definition()
+  local params = util.make_position_params()
+  request('textDocument/definition', params, peek_location_callback)
+end
+function M.peek_declaration()
+  local params = util.make_position_params()
+  request('textDocument/declaration', params, peek_location_callback)
+end
+function M.peek_implementation()
+  local params = util.make_position_params()
+  request('textDocument/implementation', params, peek_location_callback)
+end
+function M.peek_typeDefinition()
+  local params = util.make_position_params()
+  request('textDocument/typeDefinition', params, peek_location_callback)
+end
+
 function M.signature_help()
   local params = util.make_position_params()
   request('textDocument/signatureHelp', params)

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -3,6 +3,7 @@ local validate = vim.validate
 local api = vim.api
 local vfn = vim.fn
 local util = require 'vim.lsp.util'
+local log = require 'vim.lsp.log'
 local list_extend = vim.list_extend
 
 local M = {}

--- a/runtime/lua/vim/lsp/extensions.lua
+++ b/runtime/lua/vim/lsp/extensions.lua
@@ -6,20 +6,11 @@ local buf = require 'vim.lsp.buf'
 
 local M = {}
 
--- copied from buf.lua
-local function request(method, params, callback)
-  validate {
-    method = {method, 's'};
-    callback = {callback, 'f', true};
-  }
-  return vim.lsp.buf_request(0, method, params, callback)
-end
-
 -- callback to preview a location in a floating window instead
 -- of jumping to it
 local function preview_location_callback(_, method, result)
   if result == nil or vim.tbl_isempty(result) then
-    local _ = log.info() and log.info(method, 'No location found')
+    log.info(method, 'No location found')
     return nil
   end
   if vim.tbl_islist(result) then
@@ -29,21 +20,28 @@ local function preview_location_callback(_, method, result)
   end
 end
 
+local function peek_request(method, params)
+  validate {
+    method = {method, 's'};
+  }
+  return vim.lsp.buf_request(0, method, params, preview_location_callback)
+end
+
 function M.peek_definition()
   local params = util.make_position_params()
-  request('textDocument/definition', params, preview_location_callback)
+  peek_request('textDocument/definition', params)
 end
 function M.peek_declaration()
   local params = util.make_position_params()
-  request('textDocument/declaration', params, preview_location_callback)
+  peek_request('textDocument/declaration', params)
 end
 function M.peek_implementation()
   local params = util.make_position_params()
-  request('textDocument/implementation', params, preview_location_callback)
+  peek_request('textDocument/implementation', params)
 end
 function M.peek_typeDefinition()
   local params = util.make_position_params()
-  request('textDocument/typeDefinition', params, preview_location_callback)
+  peek_request('textDocument/typeDefinition', params)
 end
 
 return M

--- a/runtime/lua/vim/lsp/extensions.lua
+++ b/runtime/lua/vim/lsp/extensions.lua
@@ -1,0 +1,50 @@
+local vim = vim
+local validate = vim.validate
+local log = require 'vim.lsp.log'
+local util = require 'vim.lsp.util'
+local buf = require 'vim.lsp.buf'
+
+local M = {}
+
+-- copied from buf.lua
+local function request(method, params, callback)
+  validate {
+    method = {method, 's'};
+    callback = {callback, 'f', true};
+  }
+  return vim.lsp.buf_request(0, method, params, callback)
+end
+
+-- callback to preview a location in a floating window instead
+-- of jumping to it
+local function preview_location_callback(_, method, result)
+  if result == nil or vim.tbl_isempty(result) then
+    local _ = log.info() and log.info(method, 'No location found')
+    return nil
+  end
+  if vim.tbl_islist(result) then
+    util.preview_location(result[1])
+  else
+    util.preview_location(result)
+  end
+end
+
+function M.peek_definition()
+  local params = util.make_position_params()
+  request('textDocument/definition', params, preview_location_callback)
+end
+function M.peek_declaration()
+  local params = util.make_position_params()
+  request('textDocument/declaration', params, preview_location_callback)
+end
+function M.peek_implementation()
+  local params = util.make_position_params()
+  request('textDocument/implementation', params, preview_location_callback)
+end
+function M.peek_typeDefinition()
+  local params = util.make_position_params()
+  request('textDocument/typeDefinition', params, preview_location_callback)
+end
+
+return M
+-- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -445,18 +445,17 @@ function M.jump_to_location(location)
 end
 
 function M.peek_location(location)
-  local uri = location.uri or location.targetUri
+  -- location may be LocationLink or Location (more useful for the former)
+  local uri = location.targetUri or location.uri
   if uri == nil then return end
   local bufnr = vim.uri_to_bufnr(uri)
   if not api.nvim_buf_is_loaded(bufnr) then
     vim.fn.bufload(bufnr)
   end
-  -- location may be LocationLink or Location
-  local uri = location.targetUri or location.uri
   local range = location.targetRange or location.range
   local contents = api.nvim_buf_get_lines(bufnr, range.start.line, range["end"].line+1, false)
   local filetype = api.nvim_buf_get_option(bufnr, 'filetype')
-  local popup_bufnr, winnr = M.open_floating_preview(contents, filetype)
+  M.open_floating_preview(contents, filetype)
 end
 
 local function find_window_by_var(name, value)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -444,7 +444,8 @@ function M.jump_to_location(location)
   return true
 end
 
-function M.peek_location(location)
+-- Show a LocationLink or Location in a floating windows
+function M.preview_location(location)
   -- location may be LocationLink or Location (more useful for the former)
   local uri = location.targetUri or location.uri
   if uri == nil then return end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -444,6 +444,21 @@ function M.jump_to_location(location)
   return true
 end
 
+function M.peek_location(location)
+  local uri = location.uri or location.targetUri
+  if uri == nil then return end
+  local bufnr = vim.uri_to_bufnr(uri)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    vim.fn.bufload(bufnr)
+  end
+  -- location may be LocationLink or Location
+  local uri = location.targetUri or location.uri
+  local range = location.targetRange or location.range
+  local contents = api.nvim_buf_get_lines(bufnr, range.start.line, range["end"].line+1, false)
+  local filetype = api.nvim_buf_get_option(bufnr, 'filetype')
+  local popup_bufnr, winnr = M.open_floating_preview(contents, filetype)
+end
+
 local function find_window_by_var(name, value)
   for _, win in ipairs(api.nvim_list_wins()) do
     if npcall(api.nvim_win_get_var, win, name) == value then


### PR DESCRIPTION
addresses second part of #12218 

1. adds a utility function to `util.lua` that takes a `Location(Link)` and shows the contents in a floating buffer

2. adds a callback (based on that for `textDocument/definition`) to ~~`buf.lua`~~ **the new `extensions.lua`** that takes the result of a request, does some verification, and calls the above-mentioned utility function. (Thematically, it would fit better in `callbacks.lua`, but since that is not imported so far, I left it here.)

3. adds a `peek_definition()` (and `declaration`, `implementation`, and `typeDefinition` to **`extensions.lua`** that make `textDocument/definition` (etc.) request with the above callback instead of the default one. 

I'd be happy about comments and suggestions, in particular about the use of the floating buffer.
I will add documentation when this is deemed ready to merge.

Note that this PR requires #12231 to be useful, otherwise you only see the line with the symbol instead of the full definition. (Tested, again, with texlab; call with `require'vim/lsp/extensions'.peek_definition()`)