### PR TITLE
Fixup workspace symbol capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -688,7 +688,9 @@ function protocol.make_client_capabilities()
         };
         hierarchicalDocumentSymbolSupport = true;
       };
-      workspaceSymbol = {
+    };
+    workspace = {
+      symbol = {
         dynamicRegistration = false;
         symbolKind = {
           valueSet = (function()
@@ -702,7 +704,6 @@ function protocol.make_client_capabilities()
         hierarchicalWorkspaceSymbolSupport = true;
       };
     };
-    workspace = nil;
     experimental = nil;
   }
 end


### PR DESCRIPTION
correct nesting of capabilities dict for `workspaceSymbol` (see https://github.com/neovim/neovim/pull/12224#discussion_r418992886)