### PR TITLE
Add tmux 3.2 options to syntax file

### DIFF
--- a/runtime/syntax/tmux.vim
+++ b/runtime/syntax/tmux.vim
@@ -63,22 +63,23 @@ endfor
 
 syn keyword tmuxOptions
 \ buffer-limit command-alias default-terminal escape-time exit-empty
-\ activity-action assume-paste-time base-index bell-action default-command
+\ activity-action assume-paste-time base-index bell-action
+\ copy-mode-match-style copy-mode-current-match-style default-command
 \ default-shell default-size destroy-unattached detach-on-destroy
 \ display-panes-active-colour display-panes-colour display-panes-time
 \ display-time exit-unattached focus-events history-file history-limit
 \ key-table lock-after-time lock-command message-command-style message-limit
 \ message-style mouse aggressive-resize allow-rename alternate-screen
-\ automatic-rename automatic-rename-format clock-mode-colour
-\ clock-mode-style main-pane-height main-pane-width mode-keys mode-style
-\ monitor-activity monitor-bell monitor-silence other-pane-height
-\ other-pane-width pane-active-border-style pane-base-index
-\ pane-border-format pane-border-status pane-border-style prefix prefix2
-\ remain-on-exit renumber-windows repeat-time set-clipboard set-titles
-\ set-titles-string silence-action status status-bg status-fg status-format
-\ status-interval status-justify status-keys status-left status-left-length
-\ status-left-style status-position status-right status-right-length
-\ status-right-style status-style synchronize-panes terminal-overrides
+\ automatic-rename automatic-rename-format clock-mode-colour clock-mode-style
+\ main-pane-height main-pane-width mode-keys mode-style monitor-activity
+\ monitor-bell monitor-silence other-pane-height other-pane-width
+\ pane-active-border-style pane-base-index pane-border-format
+\ pane-border-status pane-border-style prefix prefix2 remain-on-exit
+\ renumber-windows repeat-time set-clipboard set-titles set-titles-string
+\ silence-action status status-bg status-fg status-format status-interval
+\ status-justify status-keys status-left status-left-length status-left-style
+\ status-position status-right status-right-length status-right-style
+\ status-style synchronize-panes terminal-features terminal-overrides
 \ update-environment user-keys visual-activity visual-bell visual-silence
 \ window-active-style window-size window-status-activity-style
 \ window-status-bell-style window-status-current-format


### PR DESCRIPTION
This change adds `copy-mode-match-style`, `copy-mode-match-current-style`, and `terminal-features` to `syntax/tmux.vim`. These options were recently added to tmux-master and will be introduced with tmux 3.2. 

(The line width formatting makes the diff look a bit strange...)