### PR TITLE
Add support for multi-client diagnostics for a single buffer

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -928,19 +928,24 @@ apply_text_edits({text_edits}, {bufnr})
 apply_workspace_edit({workspace_edit})
                 TODO: Documentation
 
-                                         *vim.lsp.util.diagnostics_by_buf*
-diagnostics_by_buf
-                A table containing diagnostics grouped by buf.
+                                         *vim.lsp.util.buf_get_diagnostics()*
+buf_get_diagnostics({bufnr}, {client_id})
+                Returns a table containing diagnostics for bufnr and client_id.
 
-                {<bufnr>: {diagnostics}}
+                Parameters: ~
+                    {bufnr}      (number) Buffer handle, or 0 for current
+                    {client_id}  (number, optional) Client id
 
-		{diagnostics} is an array of diagnostics.
+                With no client_id, returns diagnostics across all clients for
+                the buffer.
+
+                {diagnostics} is an array of diagnostics.
 
                 By default this is populated by the
                 `textDocument/publishDiagnostics` callback via
                 |vim.lsp.util.buf_diagnostics_save_positions|.
 
-                It contains entries for active buffers. Once a buffer is
+                It returns entries for active buffers. Once a buffer is
                 detached the entries for it are discarded.
 
 buf_clear_diagnostics({bufnr})          *vim.lsp.util.buf_clear_diagnostics()*

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -20,7 +20,7 @@ M['workspace/applyEdit'] = function(_, _, workspace_edit)
   util.apply_workspace_edit(workspace_edit.edit)
 end
 
-M['textDocument/publishDiagnostics'] = function(_, _, result)
+M['textDocument/publishDiagnostics'] = function(_, _, result, client_id)
   if not result then return end
   local uri = result.uri
   local bufnr = vim.uri_to_bufnr(uri)
@@ -40,10 +40,13 @@ M['textDocument/publishDiagnostics'] = function(_, _, result)
     end
   end
 
-  util.buf_diagnostics_save_positions(bufnr, result.diagnostics)
-  util.buf_diagnostics_underline(bufnr, result.diagnostics)
-  util.buf_diagnostics_virtual_text(bufnr, result.diagnostics)
-  util.buf_diagnostics_signs(bufnr, result.diagnostics)
+  util.buf_diagnostics_save_positions(bufnr, client_id, result.diagnostics)
+
+  -- Get all diagnostics across clients and redraw
+  local buf_diagnostics = util.buf_get_diagnostics(bufnr)
+  util.buf_diagnostics_underline(bufnr, buf_diagnostics)
+  util.buf_diagnostics_virtual_text(bufnr, buf_diagnostics)
+  util.buf_diagnostics_signs(bufnr, buf_diagnostics)
   vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
 end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -984,6 +984,46 @@ describe('LSP', function()
         return vim.lsp.util.buf_get_diagnostics(0)
       ]])
     end)
+    it('returns diagnostics for a single client', function()
+      local client_A_diagnostics = {
+        { range = {}; message = "diag1" },
+        { range = {}; message = "diag2" },
+      }
+      local client_B_diagnostics = {
+        { range = {}; message = "diag3" },
+        { range = {}; message = "diag4" },
+      }
+      exec_lua([[
+        vim.lsp.util.buf_diagnostics_save_positions(...)]], 0, 1, client_A_diagnostics)
+      exec_lua([[
+        vim.lsp.util.buf_diagnostics_save_positions(...)]], 0, 2, client_B_diagnostics)
+
+      eq(client_B_diagnostics, exec_lua [[
+        return vim.lsp.util.buf_get_diagnostics(0, 2)
+      ]])
+    end)
+    it('returns updated diagnostics for a single client', function()
+      local client_A_diagnostics = {
+        { range = {}; message = "diag1" },
+        { range = {}; message = "diag2" },
+      }
+      local client_B_diagnostics = {
+        { range = {}; message = "diag3" },
+        { range = {}; message = "diag4" },
+      }
+      exec_lua([[
+        vim.lsp.util.buf_diagnostics_save_positions(...)]], 0, 1, client_A_diagnostics)
+      exec_lua([[
+        vim.lsp.util.buf_diagnostics_save_positions(...)]], 0, 2, client_B_diagnostics)
+
+      -- No more error for client A
+      exec_lua([[
+        vim.lsp.util.buf_diagnostics_save_positions(...)]], 0, 1, {})
+
+      eq(client_B_diagnostics, exec_lua [[
+        return vim.lsp.util.buf_get_diagnostics(0, 2)
+      ]])
+    end)
   end)
   describe('lsp.util.show_line_diagnostics', function()
     it('creates floating window and returns popup bufnr and winnr if current line contains diagnostics', function()


### PR DESCRIPTION
Instead of storing and clearing diagnostics per buffer only, now store
per client as well. When a client republishes diagnostics, we can
replace only the diagnostics it owns and redraw without clearing
unrelated diagnostics (sent by other clients).

<hr />

Full disclosure, I'm not familiar with Lua and even less so with Nvim internals, so it's possible I did something stupid. Any feedback welcome.

This is a breaking change because the diagnostics table was exposed and documented. I could save to two tables (one per buffer only, one per buffer and client) but it feels error prone.