### PR TITLE
nvim_buf_set_text

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -651,7 +651,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust mapks if we managed to switch to a window that holds
+  // Only adjust marks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start,
               (linenr_T)(end - 1),
@@ -840,7 +840,7 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust mapks if we managed to switch to a window that holds
+  // Only adjust marks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start_row,
               (linenr_T)end_row,
@@ -856,7 +856,10 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   changed_lines((linenr_T)start_row, 0, (linenr_T)end_row, (long)extra, true);
 
-  // TODO: adjust cursor like an extmark ( i e it was inside last_part_len)
+  // adjust cursor like an extmark ( i e it was inside last_part_len)
+  if (curwin->w_cursor.lnum == end_row && curwin->w_cursor.col > end_col) {
+    curwin->w_cursor.col -= col_extent - (colnr_T)last_item.size;
+  }
   fix_cursor((linenr_T)start_row, (linenr_T)end_row, (linenr_T)extra);
 
 end:

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -672,6 +672,23 @@ end:
   try_end(err);
 }
 
+/// Sets (replaces) a range in the buffer.
+///
+/// Indexing is zero-based, end-exclusive.
+///
+/// To insert text at a given index, set `start` and `end` ranges to the same
+/// index. To delete a range, set `replacement` to an empty array.
+///
+/// Prefer nvim_buf_set_lines when modifying entire lines.
+///
+/// @param channel_id
+/// @param buffer           Buffer handle, or 0 for current buffer
+/// @param start_row        First line index
+/// @param start_column     Last column
+/// @param end_row          Last line index (exclusive)
+/// @param end_column       Last column
+/// @param replacement      Array of lines to use as replacement
+/// @param[out] err         Error details, if any
 void nvim_buf_set_text(uint64_t channel_id,
                        Buffer buffer,
                        Integer start_row,

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1509,9 +1509,20 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer id,
     return 0;
   }
 
-  if (opts.size > 0) {
-    api_set_error(err, kErrorTypeValidation, "opts dict isn't empty");
-    return 0;
+  bool right_gravity = true;
+  for (size_t i = 0; i < opts.size; i++) {
+    String k = opts.items[i].key;
+    Object *v = &opts.items[i].value;
+    if (strequal("right_gravity", k.data)) {
+      if (v->type != kObjectTypeBoolean) {
+        api_set_error(err, kErrorTypeValidation, "right_gravity is not a boolean");
+        return 0;
+      }
+      right_gravity = v->data.boolean;
+    } else {
+      api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
+      return 0;
+    }
   }
 
   size_t len = 0;
@@ -1538,7 +1549,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer id,
   }
 
   id_num = extmark_set(buf, (uint64_t)ns_id, id_num,
-                       (int)line, (colnr_T)col, kExtmarkUndo);
+                       (int)line, (colnr_T)col, kExtmarkUndo, right_gravity);
 
   return (Integer)id_num;
 }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -808,7 +808,6 @@ void nvim_buf_set_text(uint64_t channel_id,
     }
 
     // Same as with replacing, but we also need to free lines
-    xfree(lines[i]);
     lines[i] = NULL;
     extra++;
   }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3959,7 +3959,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
             extmark_splice(curbuf, lnum_start-1, start_col,
                            end.lnum-start.lnum, matchcols,
                            lnum-lnum_start, subcols, kExtmarkUndo);
-            }
+          }
         }
 
 

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -71,7 +71,7 @@ static ExtmarkNs *buf_ns_ref(buf_T *buf, uint64_t ns_id, bool put) {
 /// must not be used during iteration!
 /// @returns the mark id
 uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
-                     int row, colnr_T col, ExtmarkOp op)
+                     int row, colnr_T col, ExtmarkOp op, bool right_gravity)
 {
   ExtmarkNs *ns = buf_ns_ref(buf, ns_id, true);
   mtpos_t old_pos;
@@ -101,7 +101,7 @@ uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
     }
   }
 
-  mark = marktree_put(buf->b_marktree, row, col, true);
+  mark = marktree_put(buf->b_marktree, row, col, right_gravity);
 revised:
   map_put(uint64_t, ExtmarkItem)(buf->b_extmark_index, mark,
                                  (ExtmarkItem){ ns_id, id, 0,

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -392,6 +392,89 @@ describe('api/buf', function()
     end)
   end)
 
+  describe('nvim_buf_get_lines, nvim_buf_set_text', function()
+    local get_lines, set_text = curbufmeths.get_lines, curbufmeths.set_text
+    local line_count = curbufmeths.line_count
+
+    it('works', function()
+      insert([[
+      hello foo!
+      text
+      ]])
+
+      eq({'hello foo!'}, get_lines(0, 1, true))
+
+
+      -- can replace a single word
+      set_text(0, 6, 0, 9, {'world'})
+      eq({'hello world!', 'text'}, get_lines(0, 2, true))
+
+      -- can replace with multiple lines
+      local err = set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
+      eq({'hello foo', 'wo', 'more!', 'text'}, get_lines(0,  4, true))
+
+      -- will join multiple lines if needed
+      set_text(0, 6, 3, 4, {'bar'})
+      eq({'hello bar'}, get_lines(0,  1, true))
+    end)
+
+    it('updates the cursor position', function()
+      insert([[
+      hello world!
+      ]])
+
+      -- position the cursor on `!`
+      curwin('set_cursor', {1, 11})
+      -- replace 'world' with 'foo'
+      set_text(0, 6, 0, 11, {'foo'})
+      eq('hello foo!', curbuf_depr('get_line', 0))
+      -- cursor should be moved left by two columns (replacement is shorter by 2 chars)
+      eq({1, 9}, curwin('get_cursor'))
+    end)
+
+    it('can handle NULs', function()
+      set_text(0, 0, 0, 0, {'ab\0cd'})
+      eq('ab\0cd', curbuf_depr('get_line', 0))
+    end)
+
+    it('adjusts extmarks', function()
+      local ns = request('nvim_create_namespace', "my-fancy-plugin")
+      insert([[
+      foo bar
+      baz
+      ]])
+      local id1 = curbufmeths.set_extmark(ns, 0, 0, 1, {})
+      local id2 = curbufmeths.set_extmark(ns, 0, 0, 7, {})
+      local id3 = curbufmeths.set_extmark(ns, 0, 1, 1, {})
+      set_text(0, 4, 0, 7, {"q"})
+
+      -- TODO: if we set text at 0,3, what happens to the mark at 0,3
+
+      eq({'foo q', 'baz'}, get_lines(0, 2, true))
+      -- mark before replacement point is unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id1)
+      eq({0, 1}, rv)
+      -- mark gets shifted back because the replacement was shorter
+      rv = curbufmeths.get_extmark_by_id(ns, id2)
+      eq({0, 5}, rv)
+      -- mark on the next line is unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id3)
+      eq({1, 1}, rv)
+
+      -- replacing the text spanning two lines will adjust the mark on the next line
+      set_text(0, 3, 1, 3, {"qux"})
+      rv = curbufmeths.get_extmark_by_id(ns, id3)
+      eq({'fooqux', ''}, get_lines(0, 2, true))
+      eq({0, 6}, rv)
+      -- but mark before replacement point is still unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id1)
+      eq({0, 1}, rv)
+      -- and the mark in the middle was shifted to the end of the insertion
+      rv = curbufmeths.get_extmark_by_id(ns, id2)
+      eq({0, 6}, rv)
+    end)
+  end)
+
   describe('nvim_buf_get_offset', function()
     local get_offset = curbufmeths.get_offset
     it('works', function()


### PR DESCRIPTION
Refs #11833 

This should unblock snippet and multiple cursor implementations. The advantage over `set_lines` is that it retains marks in that range.

To decide: Do we want to allow negative indexing/out of bounds? I've allowed specifying a negative end_row as a way to mean "from start to last line", but I'd need to modify that to allow negative indexing on the columns as well. I think we can merge without this and potentially expand 