### PR TITLE
Add sync variant of LSP formatting

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -58,6 +58,11 @@ Nvim provides the |vim.lsp.omnifunc| 'omnifunc' handler which allows
   " Use LSP omni-completion in Python files.
   autocmd Filetype python setlocal omnifunc=v:lua.vim.lsp.omnifunc
 
+If a function has a `*_sync` variant, it's primarily intended for being run
+automatically on file save.  E.g. code formatting: >
+
+  " Auto-format *.rs files prior to saving them
+  autocmd BufWritePre *.rs lua vim.lsp.buf.formatting_sync(nil, 1000)
 
 ================================================================================
 FAQ                                                     *lsp-faq*
@@ -766,6 +771,12 @@ document_symbol()                              *vim.lsp.buf.document_symbol()*
 
 formatting({options})                               *vim.lsp.buf.formatting()*
                 TODO: Documentation
+
+formatting_sync({options}, {timeout_ms})       *vim.lsp.buf.formatting_sync()*
+                Same as |vim.lsp.buf.formatting()| but synchronous.  Useful
+                for running on save, to make sure buffer is formatted prior
+                to being saved.  {timeout_ms} is passed on to
+                |vim.lsp.buf_request_sync()|.
 
 hover()                                                  *vim.lsp.buf.hover()*
                 TODO: Documentation

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -65,17 +65,16 @@ function M.completion(context)
 end
 
 function M.formatting(options)
-  validate { options = {options, 't', true} }
-  local sts = vim.bo.softtabstop;
-  options = vim.tbl_extend('keep', options or {}, {
-    tabSize = (sts > 0 and sts) or (sts < 0 and vim.bo.shiftwidth) or vim.bo.tabstop;
-    insertSpaces = vim.bo.expandtab;
-  })
-  local params = {
-    textDocument = { uri = vim.uri_from_bufnr(0) };
-    options = options;
-  }
+  local params = util.make_formatting_params(options)
   return request('textDocument/formatting', params)
+end
+
+function M.formatting_sync(options, timeout_ms)
+  local params = util.make_formatting_params(options)
+  local result = vim.lsp.buf_request_sync(0, "textDocument/formatting", params, timeout_ms)
+  if not result then return end
+  result = result[1].result
+  vim.lsp.util.apply_text_edits(result)
 end
 
 function M.range_formatting(options, start_pos, end_pos)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1259,6 +1259,30 @@ function M.make_text_document_params()
   return { uri = vim.uri_from_bufnr(0) }
 end
 
+--- Get visual width of tabstop.
+---
+--@see |softtabstop|
+--@param bufnr (optional, number): Buffer handle, defaults to current
+--@returns (number) tabstop visual width
+function M.get_effective_tabstop(bufnr)
+  validate { bufnr = {bufnr, 'n', true} }
+  local bo = bufnr and vim.bo[bufnr] or vim.bo
+  local sts = bo.softtabstop
+  return (sts > 0 and sts) or (sts < 0 and bo.shiftwidth) or bo.tabstop
+end
+
+function M.make_formatting_params(options)
+  validate { options = {options, 't', true} }
+  options = vim.tbl_extend('keep', options or {}, {
+    tabSize = M.get_effective_tabstop();
+    insertSpaces = vim.bo.expandtab;
+  })
+  return {
+    textDocument = { uri = vim.uri_from_bufnr(0) };
+    options = options;
+  }
+end
+
 -- @param buf buffer handle or 0 for current.
 -- @param row 0-indexed line
 -- @param col 0-indexed byte offset in line

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1424,4 +1424,19 @@ describe('LSP', function()
       eq({15,5}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents,{width = 15, wrap_at = 14})} ]])
     end)
   end)
+
+  describe('lsp.util.get_effective_tabstop', function()
+    local function test_tabstop(tabsize, softtabstop)
+      exec_lua(string.format([[
+        vim.api.nvim_buf_set_option(0, 'softtabstop', %d)
+        vim.api.nvim_buf_set_option(0, 'tabstop', 2)
+        vim.api.nvim_buf_set_option(0, 'shiftwidth', 3)
+      ]], softtabstop))
+      eq(tabsize, exec_lua('return vim.lsp.util.get_effective_tabstop()'))
+    end
+
+    it('with softtabstop = 1', function() test_tabstop(1, 1) end)
+    it('with softtabstop = 0', function() test_tabstop(2, 0) end)
+    it('with softtabstop = -1', function() test_tabstop(3, -1) end)
+  end)
 end)


### PR DESCRIPTION
The `textDocument/formatting` request is often run on file save, so a synchronous variant is desirable, otherwise the formatting is likely to complete *after* the save and [leave the buffer in a modified state](https://github.com/neovim/nvim-lsp/issues/115#issuecomment-582319317).

It remains to be seen whether it's best to add sync variants of LSP requests on a case by case basis as needed (as in this PR), or whether a more general solution can/should be put in place which would allow the user to run any request either synchronously or asynchronously. As tjdevries [suggested](https://github.com/neovim/nvim-lsp/issues/115#issuecomment-623582027), this might be a good place to discuss it :)

E.g. LanguageClient-neovim seems to have gone [the former, ad-hoc route](https://github.com/autozimu/LanguageClient-neovim/blob/18434f2cd9abc33498e705dfde70d80e19223d0f/autoload/LanguageClient.vim#L902-L907). If most LSP requests don't need a sync variant in practice (do they?), then worrying about a general solution is probably overkill.

Another LSP request which would probably benefit from a sync variant is `textDocument/codeAction`, e.g. for [organizing imports on save](https://github.com/neovim/nvim-lsp/issues/115). Note however that support for `textDocument/codeAction` has not been merged yet, cf. #11607.