### PR TITLE
lsp: set buflisted when jumping to location

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -438,6 +438,7 @@ function M.jump_to_location(location)
 
   --- Jump to new location
   api.nvim_set_current_buf(bufnr)
+  api.nvim_buf_set_option(0, 'buflisted', true)
   local range = location.range or location.targetSelectionRange
   local row = range.start.line
   local col = range.start.character


### PR DESCRIPTION
Just giving some context, it's a bit annoying to jump to a location and the buffer I jumped to not be set as listed. So when I move to another buffer, that unlisted buffer disappears and I can't go back to it. Also, it glitches visualizing the buffer using tabline, since, for being unlisted, it doesn't get shown.

This commit simply sets the buffer we jump to as listed, so if I move out of it, it won't go away, and it also correctly appears in the tabline.