### PR TITLE
LSP: Prefer bufnr over filename in symbols_to_items

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -98,9 +98,10 @@ M['textDocument/references'] = function(_, _, result)
   api.nvim_command("wincmd p")
 end
 
-local symbol_callback = function(_, _, result, _, bufnr)
+local symbol_callback = function(_, _, result, _)
   if not result or vim.tbl_isempty(result) then return end
 
+  local bufnr = api.nvim_get_current_buf()
   util.set_qflist(util.symbols_to_items(result, bufnr))
   api.nvim_command("copen")
   api.nvim_command("wincmd p")

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -243,7 +243,7 @@ end
 -- Add boilerplate error validation and logging for all of these.
 for k, fn in pairs(M) do
   M[k] = function(err, method, params, client_id, bufnr)
-    local _ = log.debug() and log.debug('default_callback', method, { params = params, client_id = client_id, err = err, bufnr = bufnr })
+    log.debug('default_callback', method, { params = params, client_id = client_id, err = err, bufnr = bufnr })
     if err then
       error(tostring(err))
     end

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -98,10 +98,9 @@ M['textDocument/references'] = function(_, _, result)
   api.nvim_command("wincmd p")
 end
 
-local symbol_callback = function(_, _, result, _)
+local symbol_callback = function(_, _, result, _, bufnr)
   if not result or vim.tbl_isempty(result) then return end
 
-  local bufnr = api.nvim_get_current_buf()
   util.set_qflist(util.symbols_to_items(result, bufnr))
   api.nvim_command("copen")
   api.nvim_command("wincmd p")
@@ -243,12 +242,12 @@ end
 
 -- Add boilerplate error validation and logging for all of these.
 for k, fn in pairs(M) do
-  M[k] = function(err, method, params, client_id)
-    local _ = log.debug() and log.debug('default_callback', method, { params = params, client_id = client_id, err = err })
+  M[k] = function(err, method, params, client_id, bufnr)
+    local _ = log.debug() and log.debug('default_callback', method, { params = params, client_id = client_id, err = err, bufnr = bufnr })
     if err then
       error(tostring(err))
     end
-    return fn(err, method, params, client_id)
+    return fn(err, method, params, client_id, bufnr)
   end
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -979,7 +979,7 @@ function M.symbols_to_items(symbols, bufnr)
         local range = symbol.location.range
         local kind = M._get_symbol_kind_name(symbol.kind)
         table.insert(_items, {
-          filename = vim.uri_to_fname(symbol.location.uri),
+          bufnr = vim.uri_to_bufnr(symbol.location.uri),
           lnum = range.start.line + 1,
           col = range.start.character + 1,
           kind = kind,
@@ -988,8 +988,7 @@ function M.symbols_to_items(symbols, bufnr)
       elseif symbol.range then -- DocumentSymbole type
         local kind = M._get_symbol_kind_name(symbol.kind)
         table.insert(_items, {
-          -- bufnr = _bufnr,
-          filename = vim.api.nvim_buf_get_name(_bufnr),
+          bufnr = _bufnr,
           lnum = symbol.range.start.line + 1,
           col = symbol.range.start.character + 1,
           kind = kind,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -997,21 +997,18 @@ describe('LSP', function()
         local expected = {
           {
             col = 1,
-            filename = '',
             kind = 'File',
             lnum = 2,
             text = '[File] TestA'
           },
           {
             col = 1,
-            filename = '',
             kind = 'Module',
             lnum = 4,
             text = '[Module] TestB'
           },
           {
             col = 1,
-            filename = '',
             kind = 'Namespace',
             lnum = 6,
             text = '[Namespace] TestC'
@@ -1108,14 +1105,12 @@ describe('LSP', function()
         local expected = {
           {
             col = 1,
-            filename = '',
             kind = 'File',
             lnum = 2,
             text = '[File] TestA'
           },
           {
             col = 1,
-            filename = '',
             kind = 'Namespace',
             lnum = 6,
             text = '[Namespace] TestC'
@@ -1183,15 +1178,15 @@ describe('LSP', function()
     describe('convert SymbolInformation[] to items', function()
         local expected = {
           {
+            bufnr = 2,
             col = 1,
-            filename = 'test_a',
             kind = 'File',
             lnum = 2,
             text = '[File] TestA'
           },
           {
+            bufnr = 3,
             col = 1,
-            filename = 'test_b',
             kind = 'Module',
             lnum = 4,
             text = '[Module] TestB'


### PR DESCRIPTION
Language servers can return uri values which are not file uri's. Calling
`vim.uri_to_filename` mangles these uri's and makes them unusable.

See https://github.com/neovim/neovim/issues/12210 for more background.