### PR TITLE
Update syntax json to be like in vim

### DIFF
--- a/runtime/syntax/json.vim
+++ b/runtime/syntax/json.vim
@@ -20,7 +20,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal')
+if has('conceal') && (!exists("g:vim_json_conceal") || g:vim_json_conceal==1)
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
 else
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
@@ -31,7 +31,7 @@ endif
 " Needs to come after keywords or else a json encoded string will break the
 " syntax
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-if has('conceal')
+if has('conceal') && (!exists("g:vim_json_conceal") || g:vim_json_conceal==1)
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained


### PR DESCRIPTION
This patch is based upon the patch present in vim, see 
https://github.com/vim/vim/commit/589edb340454e7f1b19358f129287a636d53d0e1#diff-446d78ef6820e890e59f83f0bce61d4a

I'm not sure about the vim patch related to this modification (as explained in https://github.com/neovim/neovim/wiki/Merging-patches-from-upstream-Vim).
The full patch 8.2.0705 (listed on the top of the page) seems not fully relevant in adding this option.

Let me know if this PR is not followings the rules of neovim, so I can edit it, or close it otherwise.
First contribution ; read the contributing file.