### PR TITLE
LSP: Make applyEdit return a response

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -17,7 +17,11 @@ M['workspace/applyEdit'] = function(_, _, workspace_edit)
   if workspace_edit.label then
     print("Workspace edit", workspace_edit.label)
   end
-  util.apply_workspace_edit(workspace_edit.edit)
+  local status, result = pcall(util.apply_workspace_edit, workspace_edit.edit)
+  return {
+    applied = status;
+    failureReason = result;
+  }
 end
 
 M['textDocument/publishDiagnostics'] = function(_, _, result)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -914,7 +914,21 @@ describe('LSP', function()
       }, buf_lines(target_bufnr))
     end)
   end)
-
+  describe('workspace_apply_edit', function()
+    it('workspace/applyEdit returns ApplyWorkspaceEditResponse', function()
+      local expected = {
+        applied = true;
+        failureReason = nil;
+      }
+      eq(expected, exec_lua [[
+        local apply_edit = {
+          label = nil;
+          edit = {};
+        }
+        return vim.lsp.callbacks['workspace/applyEdit'](nil, nil, apply_edit)
+      ]])
+    end)
+  end)
   describe('completion_list_to_complete_items', function()
     -- Completion option precedence:
     -- textEdit.newText > insertText > label


### PR DESCRIPTION
According to the specification workspace/applyEdit needs to respond with
a `ApplyWorkspaceEditResponse`

See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit

This is a subset of https://github.com/neovim/neovim/pull/11607