### PR TITLE
viml/profile: fix missing fixes when merging vim-patch:8.1.0130

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1045,9 +1045,10 @@ static void profile_reset(void)
         uf->uf_tm_self      = profile_zero();
         uf->uf_tm_children  = profile_zero();
 
-        XFREE_CLEAR(uf->uf_tml_count);
-        XFREE_CLEAR(uf->uf_tml_total);
-        XFREE_CLEAR(uf->uf_tml_self);
+        for (int i = 0; i < uf->uf_lines.ga_len; i++) {
+          uf->uf_tml_count[i] = 0;
+          uf->uf_tml_total[i] = uf->uf_tml_self[i] = 0;
+        }
 
         uf->uf_tml_start    = profile_zero();
         uf->uf_tml_children = profile_zero();

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1038,7 +1038,7 @@ static void profile_reset(void)
     if (!HASHITEM_EMPTY(hi)) {
       n--;
       ufunc_T *uf = HI2UF(hi);
-      if (uf->uf_profiling) {
+      if (uf->uf_prof_initialized) {
         uf->uf_profiling    = 0;
         uf->uf_tm_count     = 0;
         uf->uf_tm_total     = profile_zero();

--- a/test/functional/ex_cmds/profile_spec.lua
+++ b/test/functional/ex_cmds/profile_spec.lua
@@ -6,6 +6,9 @@ local eval     = helpers.eval
 local command  = helpers.command
 local eq, neq  = helpers.eq, helpers.neq
 local tempfile = helpers.tmpname()
+local source   = helpers.source
+local matches  = helpers.matches
+local read_file = helpers.read_file
 
 -- tmpname() also creates the file on POSIX systems. Remove it again.
 -- We just need the name, ignoring any race conditions.
@@ -32,20 +35,67 @@ describe(':profile', function()
     end
   end)
 
-  it('dump', function()
-    eq(0, eval('v:profiling'))
-    command('profile start ' .. tempfile)
-    eq(1, eval('v:profiling'))
-    assert_file_exists_not(tempfile)
-    command('profile dump')
-    assert_file_exists(tempfile)
+  describe('dump', function()
+    it('works', function()
+      eq(0, eval('v:profiling'))
+      command('profile start ' .. tempfile)
+      eq(1, eval('v:profiling'))
+      assert_file_exists_not(tempfile)
+      command('profile dump')
+      assert_file_exists(tempfile)
+    end)
+
+    it('not resetting the profile', function()
+      source([[
+        function! Test()
+        endfunction
+      ]])
+      command('profile start ' .. tempfile)
+      assert_file_exists_not(tempfile)
+      command('profile func Test')
+      command('call Test()')
+      command('profile dump')
+      assert_file_exists(tempfile)
+      local profile = read_file(tempfile)
+      matches('Called 1 time', profile)
+      command('call Test()')
+      command('profile dump')
+      assert_file_exists(tempfile)
+      profile = read_file(tempfile)
+      matches('Called 2 time', profile)
+      command('profile stop')
+    end)
   end)
 
-  it('stop', function()
-    command('profile start ' .. tempfile)
-    assert_file_exists_not(tempfile)
-    command('profile stop')
-    assert_file_exists(tempfile)
-    eq(0, eval('v:profiling'))
+  describe('stop', function()
+    it('works', function()
+      command('profile start ' .. tempfile)
+      assert_file_exists_not(tempfile)
+      command('profile stop')
+      assert_file_exists(tempfile)
+      eq(0, eval('v:profiling'))
+    end)
+
+    it('resetting the profile', function()
+      source([[
+        function! Test()
+        endfunction
+      ]])
+      command('profile start ' .. tempfile)
+      assert_file_exists_not(tempfile)
+      command('profile func Test')
+      command('call Test()')
+      command('profile stop')
+      assert_file_exists(tempfile)
+      local profile = read_file(tempfile)
+      matches('Called 1 time', profile)
+      command('profile start ' .. tempfile)
+      command('profile func Test')
+      command('call Test()')
+      command('profile stop')
+      assert_file_exists(tempfile)
+      profile = read_file(tempfile)
+      matches('Called 1 time', profile)
+    end)
   end)
 end)


### PR DESCRIPTION
fixes #12255.

This should be fine, but I couldn't figure out what path to follow to cause `SIGSEGV` by looking at `call_use_func()`.

Added: This will also fix the following problems.

### Steps to reproduce using `nvim -u NORC`

```
nvim -u NORC
:function Test()
:endfunction
:profile start log1
:profile func Test
:call Test()
:profile stop
:profile start log2
:profile func Test
:call Test()
:profile stop
```

### Actual behaviour

#### log1
```
FUNCTION Test()
Called 1 times
...
```

#### log2
```
FUNCTION Test()
Called 2 times
...
```

### Expected behaviour

#### log1
```
FUNCTION Test()
Called 1 times
...
```

#### log2
```
FUNCTION Test()
Called 1 times
...
```
