### PR TITLE
LSP: Add workspace.applyEdit client capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -703,6 +703,7 @@ function protocol.make_client_capabilities()
         };
         hierarchicalWorkspaceSymbolSupport = true;
       };
+      applyEdit = true;
     };
     experimental = nil;
   }


### PR DESCRIPTION
applyEdit is already supported by the built-in client.

(Background: After https://github.com/neovim/neovim/commit/55b62a937c27715f7e6c299ae312c38edf08fa74 got merged I removed my custom callback https://github.com/mfussenegger/dotfiles/commit/30260b623f80412d997ec573a67fd9fe7de78747 including custom capabilities and noticed that some commands I had stopped working properly (e.g "organizeImports" in eclipse.jdt.ls. The server doesn't send a separate applyEdit request to the client if the capability is not set) 