### PR TITLE
Check for nil before checking for empty table

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -19,7 +19,7 @@ M['workspace/executeCommand'] = function(err, _)
 end
 
 M['textDocument/codeAction'] = function(_, _, actions)
-  if vim.tbl_isempty(actions) then
+  if actions == nil or vim.tbl_isempty(actions) then
     print("No code actions available")
     return
   end


### PR DESCRIPTION
At least the `gopls` language server seems to return nil/null if no code
actions are available. Currently this results in an error:

> Error executing vim.schedule lua callback: shared.lua:199: Expected table, got nil