### PR TITLE
Fix timezone format of LSP log (ISO 8601) [ci skip]

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -17,7 +17,7 @@ log.levels = {
 
 -- Default log level is warn.
 local current_log_level = log.levels.WARN
-local log_date_format = "%FT%H:%M:%SZ%z"
+local log_date_format = "%FT%H:%M:%S%z"
 
 do
   local path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"


### PR DESCRIPTION
The change is trivial:
```diff
-[ ERROR ] 2020-05-17T22:07:00Z+0900 ] …
+[ ERROR ] 2020-05-17T22:07:00+0900 ] …
```
