### PR TITLE
LSP - open possible fold when jump to location

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -403,6 +403,7 @@ function M.jump_to_location(location)
   local line = api.nvim_buf_get_lines(0, row, row+1, true)[1]
   col = vim.str_byteindex(line, col)
   api.nvim_win_set_cursor(0, {row + 1, col})
+  api.nvim_command("silent! .foldopen")
   return true
 end
 


### PR DESCRIPTION
When jumping to a location provided by a language server request, the target line can be hidden in a fold. Therefore it is useful to always attempt to open a possible fold at this location.