### PR TITLE
fix lsp get diagnositcs

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -757,7 +757,7 @@ do
     local lines = {"Diagnostics:"}
     local highlights = {{0, "Bold"}}
     local line_diagnostics = M.get_line_diagnostics()
-    if not next(line_diagnostics) then return end
+    if vim.tbl_isempty(line_diagnostics) then return end
 
     for i, diagnostic in ipairs(line_diagnostics) do
     -- for i, mark in ipairs(marks) do

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -757,7 +757,7 @@ do
     local lines = {"Diagnostics:"}
     local highlights = {{0, "Bold"}}
     local line_diagnostics = M.get_line_diagnostics()
-    if not line_diagnostics then return end
+    if not next(line_diagnostics) then return end
 
     for i, diagnostic in ipairs(line_diagnostics) do
     -- for i, mark in ipairs(marks) do


### PR DESCRIPTION
Seems like this snuck in with #11607, but when utilizing some functions in utils so show diagnostics on cursorHold, even if there is not diagnostic, a floating window will but shown with an empty "Diagnostic" text.


```
  vim.api.nvim_command [[autocmd CursorHold  <buffer> lua vim.lsp.util.show_line_diagnostics()]]
```


This should clean up the check for the diagnostics.