### PR TITLE
doc: fix vim.api.nvim_buf_attach callback arguments [ci skip]

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1612,6 +1612,7 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                     {opts}         Optional parameters.
                                    • on_lines: Lua callback invoked on change.
                                      Return`true`to detach. Args:
+                                     • the string "lines"
                                      • buffer handle
                                      • b:changedtick
                                      • first line that changed (zero-indexed)
@@ -1626,11 +1627,13 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                                    • on_changedtick: Lua callback invoked on
                                      changedtick increment without text
                                      change. Args:
+                                     • the string "changedtick"
                                      • buffer handle
                                      • b:changedtick
 
                                    • on_detach: Lua callback invoked on
                                      detach. Args:
+                                     • the string "detach"
                                      • buffer handle
 
                                    • utf_sizes: include UTF-32 and UTF-16 size

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -126,6 +126,7 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
 /// @param  opts  Optional parameters.
 ///             - on_lines: Lua callback invoked on change.
 ///               Return `true` to detach. Args:
+///               - the string "lines"
 ///               - buffer handle
 ///               - b:changedtick
 ///               - first line that changed (zero-indexed)
@@ -136,9 +137,11 @@ String buffer_get_line(Buffer buffer, Integer index, Error *err)
 ///               - deleted_codeunits (if `utf_sizes` is true)
 ///             - on_changedtick: Lua callback invoked on changedtick
 ///               increment without text change. Args:
+///               - the string "changedtick"
 ///               - buffer handle
 ///               - b:changedtick
 ///             - on_detach: Lua callback invoked on detach. Args:
+///               - the string "detach"
 ///               - buffer handle
 ///             - utf_sizes: include UTF-32 and UTF-16 size of the replaced
 ///               region, as args to `on_lines`.


### PR DESCRIPTION
resolve: #12340

related commit https://github.com/neovim/neovim/commit/9ef16a1628722958b6e14fe9274006e50ed6682d

(We should also update `runtime/doc/api.txt`. But now, `gen_vimdoc.py` don't work latest Doxgen.)