### PR TITLE
Add python3.9 to autoload/provider/pythonx.vim

### DIFF
--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -29,7 +29,7 @@ endfunction
 function! s:get_python_candidates(major_version) abort
   return {
         \ 2: ['python2', 'python2.7', 'python2.6', 'python'],
-        \ 3: ['python3', 'python3.8', 'python3.7', 'python3.6', 'python3.5',
+        \ 3: ['python3', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'python3.5',
         \     'python3.4', 'python3.3', 'python']
         \ }[a:major_version]
 endfunction


### PR DESCRIPTION
3.9's scheduled for beta release today.
https://www.python.org/dev/peps/pep-0596/