### PR TITLE
[WIP] vim-patch:8.1.0829: when 'hidden' is set session creates extra buffers

### DIFF
--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -107,6 +107,29 @@ func Test_mksession()
   let &wrap = wrap_save
 endfunc
 
+func Test_mksession_buffer_count()
+  set hidden
+
+  " Edit exactly three files in the current session.
+  %bwipe!
+  e Xfoo | tabe Xbar | tabe Xbaz
+  tabdo write
+  mksession! Xtest_mks.out
+
+  " Verify that loading the session does not create additional buffers.
+  %bwipe!
+  source Xtest_mks.out
+  call assert_equal(3, len(getbufinfo()))
+
+  " Clean up.
+  call delete('Xfoo')
+  call delete('Xbar')
+  call delete('Xbaz')
+  call delete('Xtest_mks.out')
+  %bwipe!
+  set hidden&
+endfunc
+
 func Test_mksession_winheight()
   new
   set winheight=10


### PR DESCRIPTION
Problem:    When 'hidden' is set session creates extra buffers.
Solution:   Move :badd commands to the end. (Jason Franklin)
https://github.com/vim/vim/commit/d39e275b57493f9e25e1b62f84810571eee30cf4