### PR TITLE
Change uri_to_fname to not convert non-file URIs

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -76,6 +76,10 @@ local function uri_from_bufnr(bufnr)
 end
 
 local function uri_to_fname(uri)
+  local scheme = assert(uri:match("^([a-z]+)://.*"), 'Uri must contain a scheme: ' .. uri)
+  if scheme ~= 'file' then
+    return uri
+  end
   uri = uri_decode(uri)
   -- TODO improve this.
   if is_windows_file_uri(uri) then

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -65,9 +65,11 @@ local function uri_from_fname(path)
   return table.concat(uri_parts)
 end
 
+local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*)://.*'
+
 local function uri_from_bufnr(bufnr)
   local fname = vim.api.nvim_buf_get_name(bufnr)
-  local scheme = fname:match("^([a-z]+)://.*")
+  local scheme = fname:match(URI_SCHEME_PATTERN)
   if scheme then
     return fname
   else
@@ -76,7 +78,7 @@ local function uri_from_bufnr(bufnr)
 end
 
 local function uri_to_fname(uri)
-  local scheme = assert(uri:match("^([a-z]+)://.*"), 'Uri must contain a scheme: ' .. uri)
+  local scheme = assert(uri:match(URI_SCHEME_PATTERN), 'URI must contain a scheme: ' .. uri)
   if scheme ~= 'file' then
     return uri
   end
@@ -93,7 +95,7 @@ end
 
 -- Return or create a buffer for a uri.
 local function uri_to_bufnr(uri)
-  local scheme = assert(uri:match("^([a-z]+)://.*"), 'Uri must contain a scheme: ' .. uri)
+  local scheme = assert(uri:match(URI_SCHEME_PATTERN), 'URI must contain a scheme: ' .. uri)
   if scheme == 'file' then
     return vim.fn.bufadd(uri_to_fname(uri))
   else

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -112,6 +112,7 @@ describe('URI methods', function()
         eq('C:\\xy\\åäö\\ɧ\\汉语\\↥\\🤦\\🦄\\å\\بِيَّ.txt', exec_lua(test_case))
       end)
     end)
+
     describe('decode non-file uri', function()
       it('uri_to_fname returns non-file uri unchanged', function()
         eq('jdt://content/%5C/', exec_lua [[
@@ -119,6 +120,15 @@ describe('URI methods', function()
         ]])
       end)
     end)
+
+    describe('decode uri without scheme', function()
+      it('fails because uri must have a scheme', function()
+        eq(false, exec_lua [[
+          return pcall(vim.uri_to_fname, 'not_an_uri.txt')
+        ]])
+      end)
+    end)
+
   end)
 
   describe('uri to bufnr', function()

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -113,16 +113,22 @@ describe('URI methods', function()
       end)
     end)
 
-    describe('decode non-file uri', function()
-      it('uri_to_fname returns non-file uri unchanged', function()
-        eq('jdt://content/%5C/', exec_lua [[
-          return vim.uri_to_fname('jdt://content/%5C/')
+    describe('decode non-file URI', function()
+      it('uri_to_fname returns non-file URI unchanged', function()
+        eq('jdt1.23+x-z://content/%5C/', exec_lua [[
+          return vim.uri_to_fname('jdt1.23+x-z://content/%5C/')
+        ]])
+      end)
+
+      it('uri_to_fname returns non-file upper-case scheme URI unchanged', function()
+        eq('JDT://content/%5C/', exec_lua [[
+          return vim.uri_to_fname('JDT://content/%5C/')
         ]])
       end)
     end)
 
-    describe('decode uri without scheme', function()
-      it('fails because uri must have a scheme', function()
+    describe('decode URI without scheme', function()
+      it('fails because URI must have a scheme', function()
         eq(false, exec_lua [[
           return pcall(vim.uri_to_fname, 'not_an_uri.txt')
         ]])

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -112,6 +112,13 @@ describe('URI methods', function()
         eq('C:\\xy\\åäö\\ɧ\\汉语\\↥\\🤦\\🦄\\å\\بِيَّ.txt', exec_lua(test_case))
       end)
     end)
+    describe('decode non-file uri', function()
+      it('uri_to_fname returns non-file uri unchanged', function()
+        eq('jdt://content/%5C/', exec_lua [[
+          return vim.uri_to_fname('jdt://content/%5C/')
+        ]])
+      end)
+    end)
   end)
 
   describe('uri to bufnr', function()


### PR DESCRIPTION
A URI with a scheme other than file doesn't have a local file path.

This is an alternative to https://github.com/neovim/neovim/pull/12264 and
relates to https://github.com/neovim/neovim/issues/12210