### PR TITLE
Input: Do not translate scroll keys into multiclicks

### DIFF
--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -244,8 +244,10 @@ static uint8_t check_multiclick(int code, int grid, int row, int col)
   static int orig_mouse_row = 0;
   static uint64_t orig_mouse_time = 0;  // time of previous mouse click
 
-  if (code == KE_LEFTRELEASE || code == KE_RIGHTRELEASE
-      || code == KE_MIDDLERELEASE) {
+  if (code == KE_LEFTRELEASE      || code == KE_RIGHTRELEASE
+      || code == KE_MIDDLERELEASE || code == KE_MOUSEDOWN
+      || code == KE_MOUSEUP       || code == KE_MOUSELEFT
+      || code == KE_MOUSERIGHT) {
     return 0;
   }
   uint64_t mouse_time = os_hrtime();    // time of current mouse click (ns)


### PR DESCRIPTION
**Motivation**
Neovim (and Vim) will transform multiple `<MouseKey>`'s into a single`<N-MouseKey>` if they are received within `'mousetime'` of each other. For example, `<LeftMouse><LeftMouse>` becomes `<2-LeftMouse>` (a double click). This transformation is also applied to `<ScrollKey>`'s, this is unintuitive and has some serious downsides. 

1. Mapping scroll keys does not work as users expect. They would have to map from `<ScrollKey>` to `<4-ScrollKey>` to get complete coverage.

2. Scrolling looks worse. Not redrawing the intermediate scroll steps makes scrolling look jittery. You can confirm this by doing `set mousetime=0` (thereby disabling all multiclicks) and noting that scrolling looks much smoother.