### PR TITLE
LSP: Add tests & use nvim_buf_get_lines in locations_to_items

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1101,11 +1101,7 @@ function M.locations_to_items(locations)
     local rows = grouped[uri]
     table.sort(rows, position_sort)
     local bufnr = vim.uri_to_bufnr(uri)
-    if not api.nvim_buf_is_loaded(bufnr) then
-      vim.fn.bufload(bufnr)
-    else
-      vim.cmd("checktime")
-    end
+    vim.fn.bufload(bufnr)
     local filename = vim.uri_to_fname(uri)
     for _, temp in ipairs(rows) do
       local pos = temp.start

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1104,13 +1104,14 @@ function M.locations_to_items(locations)
     if not api.nvim_buf_is_loaded(bufnr) then
       vim.fn.bufload(bufnr)
     end
+    local filename = vim.uri_to_fname(uri)
     for _, temp in ipairs(rows) do
       local pos = temp.start
       local row = pos.line
-      local line = (api.nvim_buf_get_lines(bufnr, row, row + 1, true) or {""})[1]
+      local line = (api.nvim_buf_get_lines(bufnr, row, row + 1, false) or {""})[1]
       local col = M.character_offset(bufnr, row, pos.character)
       table.insert(items, {
-        filename = vim.uri_to_fname(uri),
+        filename = filename,
         lnum = row + 1,
         col = col + 1;
         text = line;

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1103,6 +1103,8 @@ function M.locations_to_items(locations)
     local bufnr = vim.uri_to_bufnr(uri)
     if not api.nvim_buf_is_loaded(bufnr) then
       vim.fn.bufload(bufnr)
+    else
+      vim.cmd("checktime")
     end
     local filename = vim.uri_to_fname(uri)
     for _, temp in ipairs(rows) do

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1099,34 +1099,22 @@ function M.locations_to_items(locations)
   -- TODO(ashkan) I wish we could do this lazily.
   for _, uri in ipairs(keys) do
     local rows = grouped[uri]
-
     table.sort(rows, position_sort)
-    local i = 0
     local bufnr = vim.uri_to_bufnr(uri)
     if not api.nvim_buf_is_loaded(bufnr) then
       vim.fn.bufload(bufnr)
     end
-    local lines = api.nvim_buf_get_lines(bufnr, 0, -1, true)
-    for _, line in ipairs(lines) do
-      for _, temp in ipairs(rows) do
-        local pos = temp.start
-        local row = pos.line
-        if i == row then
-          local col
-          if pos.character > #line then
-            col = #line
-          else
-            col = vim.str_byteindex(line, pos.character)
-          end
-          table.insert(items, {
-            filename = vim.uri_to_fname(uri),
-            lnum = row + 1,
-            col = col + 1;
-            text = line;
-          })
-        end
-      end
-      i = i + 1
+    for _, temp in ipairs(rows) do
+      local pos = temp.start
+      local row = pos.line
+      local line = (api.nvim_buf_get_lines(bufnr, row, row + 1, true) or {""})[1]
+      local col = M.character_offset(bufnr, row, pos.character)
+      table.insert(items, {
+        filename = vim.uri_to_fname(uri),
+        lnum = row + 1,
+        col = col + 1;
+        text = line;
+      })
     end
   end
   return items

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1070,6 +1070,72 @@ describe('LSP', function()
       ]])
     end)
   end)
+  describe('lsp.util.locations_to_items', function()
+    it('Convert Location[] to items', function()
+      local expected = {
+        {
+          filename = '',
+          lnum = 1,
+          col = 3,
+          text = 'testing'
+        },
+      }
+      local actual = exec_lua [[
+        local buffer = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_name(buffer, 'dummy')
+        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, {
+          "testing";
+          "123";
+        })
+        local locations = {
+          {
+            uri = vim.uri_from_bufnr(buffer),
+            range = {
+              start = { line = 0, character = 2 },
+              ['end'] = { line = 0, character = 3 },
+            }
+          },
+        }
+        return vim.lsp.util.locations_to_items(locations)
+      ]]
+      actual[1].filename = ''
+      eq(expected, actual)
+    end)
+    it('Convert LocationLink[] to items', function()
+      local expected = {
+        {
+          filename = '',
+          lnum = 1,
+          col = 3,
+          text = 'testing'
+        },
+      }
+      local actual = exec_lua [[
+        local buffer = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_name(buffer, 'dummy')
+        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, {
+          "testing";
+          "123";
+        })
+        local locations = {
+          {
+            targetUri = vim.uri_from_bufnr(buffer),
+            targetRange = {
+              start = { line = 0, character = 2 },
+              ['end'] = { line = 0, character = 3 },
+            },
+            targetSelectionRange = {
+              start = { line = 0, character = 2 },
+              ['end'] = { line = 0, character = 3 },
+            }
+          },
+        }
+        return vim.lsp.util.locations_to_items(locations)
+      ]]
+      actual[1].filename = ''
+      eq(expected, actual)
+    end)
+  end)
   describe('lsp.util.symbols_to_items', function()
     describe('convert DocumentSymbol[] to items', function()
       it('DocumentSymbol has children', function()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1074,22 +1074,19 @@ describe('LSP', function()
     it('Convert Location[] to items', function()
       local expected = {
         {
-          filename = '',
+          filename = 'fake/uri',
           lnum = 1,
           col = 3,
           text = 'testing'
         },
       }
       local actual = exec_lua [[
-        local buffer = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_name(buffer, 'dummy')
-        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, {
-          "testing";
-          "123";
-        })
+        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local lines = {"testing", "123"}
+        vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, lines)
         local locations = {
           {
-            uri = vim.uri_from_bufnr(buffer),
+            uri = 'file://fake/uri',
             range = {
               start = { line = 0, character = 2 },
               ['end'] = { line = 0, character = 3 },
@@ -1098,28 +1095,24 @@ describe('LSP', function()
         }
         return vim.lsp.util.locations_to_items(locations)
       ]]
-      actual[1].filename = ''
       eq(expected, actual)
     end)
     it('Convert LocationLink[] to items', function()
       local expected = {
         {
-          filename = '',
+          filename = 'fake/uri',
           lnum = 1,
           col = 3,
           text = 'testing'
         },
       }
       local actual = exec_lua [[
-        local buffer = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_name(buffer, 'dummy')
-        vim.api.nvim_buf_set_lines(buffer, 0, -1, false, {
-          "testing";
-          "123";
-        })
+        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local lines = {"testing", "123"}
+        vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, lines)
         local locations = {
           {
-            targetUri = vim.uri_from_bufnr(buffer),
+            targetUri = vim.uri_from_bufnr(bufnr),
             targetRange = {
               start = { line = 0, character = 2 },
               ['end'] = { line = 0, character = 3 },
@@ -1132,7 +1125,6 @@ describe('LSP', function()
         }
         return vim.lsp.util.locations_to_items(locations)
       ]]
-      actual[1].filename = ''
       eq(expected, actual)
     end)
   end)


### PR DESCRIPTION
This is to add support for cases where the server returns a URI in the
locations that does not have a file scheme but needs to be loaded via a
BufReadCmd event.

I first wanted to split adding a test into a separate commit, but the use of
`io.lines` would have required to write the test against a real file on the
filesystem (I think?). So I did both adding tests and changing the
implementation at once.

This relates to https://github.com/neovim/neovim/issues/12210 and I think it is
the last part that wasn't working.