### PR TITLE
[RDY] Correct command

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1265,7 +1265,7 @@ exist, the next-higher scope in the hierarchy applies.
 			other tabs and windows is not changed.
 
 							*:tcd-*
-:tcd[!] -		Change to the previous current directory (before the
+:tc[d][!] -		Change to the previous current directory (before the
 			previous ":tcd {path}" command).
 
 							*:tch* *:tchdir*
@@ -1280,7 +1280,7 @@ exist, the next-higher scope in the hierarchy applies.
 :lch[dir][!]		Same as |:lcd|.
 
 							*:lcd-* 
-:lcd[!] -		Change to the previous current directory (before the
+:lc[d][!] -		Change to the previous current directory (before the
 			previous ":lcd {path}" command).
 
 							*:pw* *:pwd* *E187*


### PR DESCRIPTION
The `:lcd -` command, and `:tcd -` which returns to a previous directory, can be done with `:lc -` and `:tc -` respectively. 

Basically, the d is optional, so I updated the documentation to indicate this in the traditional format.