### PR TITLE
vim-patch:8.2.0629: setting a boolean option to v:false does not work

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1834,12 +1834,15 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
       int opt_type;
       long numval;
       char *stringval = NULL;
+      const char *s = NULL;
 
       const char c1 = *p;
       *p = NUL;
 
       varnumber_T n = tv_get_number(tv);
-      const char *s = tv_get_string_chk(tv);  // != NULL if number or string.
+      // avoid setting a string option to the text "v:false" or similar.
+      if (tv->v_type != VAR_SPECIAL)
+        s = tv_get_string_chk(tv);  // != NULL if number or string.
       if (s != NULL && op != NULL && *op != '=') {
         opt_type = get_option_value(arg, &numval, (char_u **)&stringval,
                                     opt_flags);
@@ -1865,7 +1868,7 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
           }
         }
       }
-      if (s != NULL) {
+      if (s != NULL || tv->v_type == VAR_SPECIAL) {
         set_option_value((const char *)arg, n, s, opt_flags);
         arg_end = (char_u *)p;
       }

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -554,3 +554,17 @@ func Test_visualbell()
   set novisualbell
   set belloff=all
 endfunc
+
+" Test for setting option values using v:false and v:true
+func Test_opt_boolean()
+  set number&
+  set number
+  call assert_equal(1, &nu)
+  set nonu
+  call assert_equal(0, &nu)
+  let &nu = v:true
+  call assert_equal(1, &nu)
+  let &nu = v:false
+  call assert_equal(0, &nu)
+  set number&
+endfunc


### PR DESCRIPTION
Problem:    Setting a boolean option to v:false does not work.
Solution:   Do not use the string representation of the value. (Christian
            Brabandt, closes vim/vim#5974)
https://github.com/vim/vim/commit/65d032c779a43b767497e15e6a32d04a6a8fa65d