### PR TITLE
set comments and commentstring for .asm files

### DIFF
--- a/runtime/ftplugin/asm.vim
+++ b/runtime/ftplugin/asm.vim
@@ -1,0 +1,11 @@
+" Vim filetype plugin file
+" Language:	asm
+" Maintainer:	Colin Caine <cmcaine at the common googlemail domain>
+" Last Changed: 23 May 2020
+
+if exists("b:did_ftplugin") | finish | endif
+
+setl comments=";"
+setl commentstring=;%s
+
+let b:did_ftplugin = 1


### PR DESCRIPTION
Useful with tpope's commentary plugin.

This might be controversial because asm has a bunch of different dialects and `;` is only a comment in some of them. This is also true of the current default of `/* */`, but I think `;` is right more of the time (used in nasm x86, the official ARM assemblers, MASM, etc.).