### PR TITLE
lsp: change log name to "lsp.log" from "vim-lsp.log"

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -24,7 +24,7 @@ do
   local function path_join(...)
     return table.concat(vim.tbl_flatten{...}, path_sep)
   end
-  local logfilename = path_join(vim.fn.stdpath('data'), 'vim-lsp.log')
+  local logfilename = path_join(vim.fn.stdpath('data'), 'lsp.log')
 
   --- Return the log filename.
   function log.get_filename()


### PR DESCRIPTION
It's confusing because vim-lsp already has the same name as the plugin name that predates this built-in lsp.
Also, since "vim.fn.stdpath" is used, adding the prefix "nvim-" is redundant, so just "lsp.log" will suffice.