### PR TITLE
LSP: add preview_location util function

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1053,6 +1053,9 @@ highlight_region({ft}, {start}, {finish})
 jump_to_location({location})                 *vim.lsp.util.jump_to_location()*
                 TODO: Documentation
 
+preview_location({location})                 *vim.lsp.util.preview_location()*
+                TODO: Documentation
+
 locations_to_items({locations})            *vim.lsp.util.locations_to_items()*
                 TODO: Documentation
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -481,7 +481,15 @@ function M.jump_to_location(location)
   return true
 end
 
--- Show a LocationLink or Location in a floating windows
+--- Preview a location in a floating windows
+---
+--- behavior depends on type of location:
+---   - for Location, range is shown (e.g., function definition)
+---   - for LocationLink, targetRange is shown (e.g., body of function definition)
+---   - for an array of either, the first element is shown
+---
+--@param location Location, LocationLink, or array thereof
+--@return bufnr,winnr buffer and window number of floating window
 function M.preview_location(location)
   -- location may be LocationLink or Location (more useful for the former)
   local uri = location.targetUri or location.uri
@@ -493,7 +501,7 @@ function M.preview_location(location)
   local range = location.targetRange or location.range
   local contents = api.nvim_buf_get_lines(bufnr, range.start.line, range["end"].line+1, false)
   local filetype = api.nvim_buf_get_option(bufnr, 'filetype')
-  M.open_floating_preview(contents, filetype)
+  return M.open_floating_preview(contents, filetype)
 end
 
 local function find_window_by_var(name, value)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -481,6 +481,21 @@ function M.jump_to_location(location)
   return true
 end
 
+-- Show a LocationLink or Location in a floating windows
+function M.preview_location(location)
+  -- location may be LocationLink or Location (more useful for the former)
+  local uri = location.targetUri or location.uri
+  if uri == nil then return end
+  local bufnr = vim.uri_to_bufnr(uri)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    vim.fn.bufload(bufnr)
+  end
+  local range = location.targetRange or location.range
+  local contents = api.nvim_buf_get_lines(bufnr, range.start.line, range["end"].line+1, false)
+  local filetype = api.nvim_buf_get_option(bufnr, 'filetype')
+  M.open_floating_preview(contents, filetype)
+end
+
 local function find_window_by_var(name, value)
   for _, win in ipairs(api.nvim_list_wins()) do
     if npcall(api.nvim_win_get_var, win, name) == value then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -489,7 +489,7 @@ end
 ---   - for an array of either, the first element is shown
 ---
 --@param location Location, LocationLink, or array thereof
---@return bufnr,winnr buffer and window number of floating window
+--@return bufnr,winnr buffer and window number of floating window or nil
 function M.preview_location(location)
   -- location may be LocationLink or Location (more useful for the former)
   local uri = location.targetUri or location.uri

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -486,9 +486,8 @@ end
 --- behavior depends on type of location:
 ---   - for Location, range is shown (e.g., function definition)
 ---   - for LocationLink, targetRange is shown (e.g., body of function definition)
----   - for an array of either, the first element is shown
 ---
---@param location Location, LocationLink, or array thereof
+--@param location a single Location or LocationLink
 --@return bufnr,winnr buffer and window number of floating window or nil
 function M.preview_location(location)
   -- location may be LocationLink or Location (more useful for the former)


### PR DESCRIPTION
This PR (split off from #12232) adds a utility function to util.lua that takes a `Location` or `LocationLink` and shows the contents in a floating buffer. This can be useful, e.g., for implementing a `Peek Definition` function (as provided by VS Code an vim-lsp) for servers that support `LocationLink`, where the preview can show the body of a function definition. (If the server only supports `Location`, this would show a "poor man's signature help".)

To use it, put the following lua code in your `init.vim`
```lua
local function preview_location_callback(_, method, result)
  if result == nil or vim.tbl_isempty(result) then
    vim.lsp.log.info(method, 'No location found')
    return nil
  end
  if vim.tbl_islist(result) then
    vim.lsp.util.preview_location(result[1])
  else
    vim.lsp.util.preview_location(result)
  end
end

function peek_definition()
  local params = vim.lsp.util.make_position_params()
  return vim.lsp.buf_request(0, 'textDocument/definition', params, preview_location_callback)
end
```
and call `lua peek_definition()` on a valid symbol.

@tjdevries 