### PR TITLE
[WIP] vim-patch:8.0.1505: debugger can't break on a condition

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -804,6 +804,19 @@ DEFINING BREAKPOINTS
 <		Note that this only works for commands that are executed when
 		sourcing the file, not for a function defined in that file.
 
+:breaka[dd] expr {expression}
+		Sets a breakpoint, that will break whenever the {expression}
+		evaluates to a different value. Example: >
+			:breakadd expr g:lnum
+
+<		Will break, whenever the global variable lnum changes.
+		Note if you watch a |script-variable| this will break
+		when switching scripts, since the script variable is only
+		valid in the script where it has been defined and if that
+		script is called from several other scripts, this will stop
+		whenever that particular variable will become visible or
+		unaccessible again.
+
 The [lnum] is the line number of the breakpoint.  Vim will stop at or after
 this line.  When omitted line 1 is used.
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5442,8 +5442,7 @@ int typval_compare(
   exptype_T	 type,    /* operator */
   int		     type_is, /* TRUE for "is" and "isnot" */
   int		     ic,      /* ignore case */
-  int		     evaluate)
-) {
+  int		     evaluate) {
   int   i;
   varnumber_T n1, n2;
   if (evaluate) {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2024,29 +2024,7 @@ static void f_exists(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       n = au_exists(p + 1);
     }
   } else {  // Internal variable.
-    typval_T tv;
-
-    // get_name_len() takes care of expanding curly braces
-    const char *name = p;
-    char *tofree;
-    len = get_name_len((const char **)&p, &tofree, true, false);
-    if (len > 0) {
-      if (tofree != NULL) {
-        name = tofree;
-      }
-      n = (get_var_tv(name, len, &tv, NULL, false, true) == OK);
-      if (n) {
-        // Handle d.key, l[idx], f(expr).
-        n = (handle_subscript(&p, &tv, true, false) == OK);
-        if (n) {
-          tv_clear(&tv);
-        }
-      }
-    }
-    if (*p != NUL)
-      n = FALSE;
-
-    xfree(tofree);
+    n = var_exists(p);
   }
 
   rettv->vval.v_number = n;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1993,7 +1993,6 @@ static void f_exepath(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 static void f_exists(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   int n = false;
-  int len = 0;
 
   const char *p = tv_get_string(&argvars[0]);
   if (*p == '$') {  // Environment variable.

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -105,6 +105,22 @@ typedef enum {
   VAR_FIXED = 2,     ///< Locked forever.
 } VarLockStatus;
 
+/*
+ * types for expressions.
+ */
+typedef enum
+{
+    TYPE_UNKNOWN = 0
+    , TYPE_EQUAL	/* == */
+    , TYPE_NEQUAL	/* != */
+    , TYPE_GREATER	/* >  */
+    , TYPE_GEQUAL	/* >= */
+    , TYPE_SMALLER	/* <  */
+    , TYPE_SEQUAL	/* <= */
+    , TYPE_MATCH	/* =~ */
+    , TYPE_NOMATCH	/* !~ */
+} exptype_T;
+
 /// VimL variable types, for use in typval_T.v_type
 typedef enum {
   VAR_UNKNOWN = 0,  ///< Unknown (unspecified) value.

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2800,6 +2800,9 @@ void ex_call(exarg_T *eap)
       failed = true;
       break;
     }
+    if (has_watchexpr()) {
+      dbg_check_breakpoint(eap);
+    }
 
     // Handle a function returning a Funcref, Dictionary or List.
     if (handle_subscript((const char **)&arg, &rettv, true, true)

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -902,7 +902,7 @@ debuggy_find(
         debug_oldval = typval_tostring(bp->dbg_val);
         debug_newval = typval_tostring(NULL);
         xfree(bp->dbg_val);
-        bp->dbg_val = NUL;
+        bp->dbg_val = NULL;
         line = TRUE;
       }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -705,6 +705,13 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
       }
     }
 
+    /* Check for the next breakpoint after a watchexpression */
+    if (breakpoint != NULL && has_watchexpr())
+    {
+        *breakpoint = dbg_find_breakpoint(FALSE, fname, sourcing_lnum);
+        *dbg_tick = debug_tick;
+    }
+
     /*
      * When not inside any ":while" loop, clear remembered lines.
      */


### PR DESCRIPTION
Problem:    Debugger can't break on a condition. (Charles Campbell)
Solution:   Add ":breakadd expr". (Christian Brabandt, closes vim/vim#859)
https://github.com/vim/vim/commit/c6f9f739d32084923c3031cbf6f581f8c8bf7fd2