### PR TITLE
API: nvim_create_buf: unset 'modeline' on scratch-buffer

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1037,7 +1037,7 @@ void nvim_set_current_win(Window window, Error *err)
 ///
 /// @param listed Sets 'buflisted'
 /// @param scratch Creates a "throwaway" |scratch-buffer| for temporary work
-///                (always 'nomodified')
+///                (always 'nomodified'). Also sets 'nomodeline' on the buffer.
 /// @param[out] err Error details, if any
 /// @return Buffer handle, or 0 on error
 ///
@@ -1067,9 +1067,10 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
   if (scratch) {
     aco_save_T aco;
     aucmd_prepbuf(&aco, buf);
-    set_option_value("bh", 0L, "hide", OPT_LOCAL);
-    set_option_value("bt", 0L, "nofile", OPT_LOCAL);
-    set_option_value("swf", 0L, NULL, OPT_LOCAL);
+    set_option_value("bufhidden", 0L, "hide", OPT_LOCAL);
+    set_option_value("buftype", 0L, "nofile", OPT_LOCAL);
+    set_option_value("swapfile", 0L, NULL, OPT_LOCAL);
+    set_option_value("modeline", 0L, NULL, OPT_LOCAL);  // 'nomodeline'
     aucmd_restbuf(&aco);
   }
   return buf->b_fnum;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1808,7 +1808,7 @@ describe('API', function()
       eq({id=1}, meths.get_current_buf())
     end)
 
-    it("doesn't cause BufEnter or BufWinEnter autocmds", function()
+    it("does not trigger BufEnter, BufWinEnter", function()
       command("let g:fired = v:false")
       command("au BufEnter,BufWinEnter * let g:fired = v:true")
 
@@ -1818,7 +1818,7 @@ describe('API', function()
       eq(false, eval('g:fired'))
     end)
 
-    it('|scratch-buffer|', function()
+    it('scratch-buffer', function()
       eq({id=2}, meths.create_buf(false, true))
       eq({id=3}, meths.create_buf(true, true))
       eq({id=4}, meths.create_buf(true, true))
@@ -1845,6 +1845,7 @@ describe('API', function()
         eq('nofile', meths.buf_get_option(b, 'buftype'))
         eq('hide', meths.buf_get_option(b, 'bufhidden'))
         eq(false, meths.buf_get_option(b, 'swapfile'))
+        eq(false, meths.buf_get_option(b, 'modeline'))
       end
 
       --
@@ -1860,8 +1861,9 @@ describe('API', function()
       eq('nofile', meths.buf_get_option(edited_buf, 'buftype'))
       eq('hide', meths.buf_get_option(edited_buf, 'bufhidden'))
       eq(false, meths.buf_get_option(edited_buf, 'swapfile'))
+      eq(false, meths.buf_get_option(edited_buf, 'modeline'))
 
-      -- scratch buffer can be wiped without error
+      -- Scratch buffer can be wiped without error.
       command('bwipe')
       screen:expect([[
         ^                    |


### PR DESCRIPTION
Although 'nomodeline' is not strictly part of the definition of a "scratch-buffer" it is obviously the right default.