### PR TITLE
LSP: compute height of floating preview correctly for wrapped lines

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -615,12 +615,11 @@ function M.focusable_preview(unique_name, fn)
 end
 
 --- Trim empty lines from input and pad left and right with spaces
---- Defaults to left and right padding by 1 for backward compatibility
 --- 
 --@param contents table of lines to trim and pad
 --@param opts dictionary with optional fields
---             - pad_left  amount of columns to pad contents at left
---             - pad_right amount of columns to pad contents at right
+--             - pad_left  amount of columns to pad contents at left (default 1)
+--             - pad_right amount of columns to pad contents at right (default 1)
 --@return contents table of trimmed and padded lines
 function M._trim_and_pad(contents,opts)
   validate {
@@ -628,7 +627,6 @@ function M._trim_and_pad(contents,opts)
     opts = { opts, 't', true };
   }
   opts = opts or {}
-  -- Default padding of 1 for backwards compatibility
   left_padding = (" "):rep(opts.pad_left or 1)
   right_padding = (" "):rep(opts.pad_right or 1)
   contents = M.trim_empty_lines(contents)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -615,7 +615,7 @@ function M.focusable_preview(unique_name, fn)
 end
 
 --- Trim empty lines from input and pad left and right with spaces
---- 
+---
 --@param contents table of lines to trim and pad
 --@param opts dictionary with optional fields
 --             - pad_left  amount of columns to pad contents at left (default 1)
@@ -627,11 +627,11 @@ function M._trim_and_pad(contents, opts)
     opts = { opts, 't', true };
   }
   opts = opts or {}
-  left_padding = (" "):rep(opts.pad_left or 1)
-  right_padding = (" "):rep(opts.pad_right or 1)
+  local left_padding = (" "):rep(opts.pad_left or 1)
+  local right_padding = (" "):rep(opts.pad_right or 1)
   contents = M.trim_empty_lines(contents)
   for i, line in ipairs(contents) do
-    contents[i] = string.format('%s%s%s', right_padding, line:gsub("\r", ""), right_padding)
+    contents[i] = string.format('%s%s%s', left_padding, line:gsub("\r", ""), right_padding)
   end
   return contents
 end
@@ -694,7 +694,7 @@ function M.fancy_floating_markdown(contents, opts)
       end
     end
   end
-  -- Clean up and add padding 
+  -- Clean up and add padding
   stripped = M._trim_and_pad(stripped, opts)
 
   -- Compute size of float needed to show (wrapped) lines

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -752,14 +752,14 @@ function M._make_floating_popup_size(contents, opts)
     local wrap_at = opts.wrap_at
     if wrap_at and width > wrap_at then
       height = 0
-      if line_widths then
-        for i = 1, #contents do
-          height = height + math.ceil(line_widths[i]/wrap_at)
+      if vim.tbl_isempty(line_widths) then
+        for _, line in ipairs(contents) do
+          local line_width = vim.fn.strdisplaywidth(line)
+          height = height + math.ceil(line_width/wrap_at)
         end
       else
-        for i, line in ipairs(contents) do
-          line_width = vim.fn.strdisplaywidth(line)
-          height = height + math.ceil(line_width/wrap_at)
+        for i = 1, #contents do
+          height = height + math.ceil(line_widths[i]/wrap_at)
         end
       end
     end
@@ -795,7 +795,7 @@ function M.open_floating_preview(contents, filetype, opts)
   local width, height = M._make_floating_popup_size(contents, opts)
 
   -- Add right padding of 1
-  width = width + 1 
+  width = width + 1
 
   local floating_bufnr = api.nvim_create_buf(false, true)
   if filetype then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -621,7 +621,7 @@ end
 --             - pad_left  amount of columns to pad contents at left (default 1)
 --             - pad_right amount of columns to pad contents at right (default 1)
 --@return contents table of trimmed and padded lines
-function M._trim_and_pad(contents,opts)
+function M._trim_and_pad(contents, opts)
   validate {
     contents = { contents, 't' };
     opts = { opts, 't', true };

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -773,8 +773,9 @@ end
 --@param contents table of lines to show in window
 --@param filetype string of filetype to set for opened buffer
 --@param opts dictionary with optional fields
---             - height of floating window
---             - width  of floating window
+--             - height  of floating window
+--             - width   of floating window
+--             - wrap_at character to wrap at for computing height
 --@return bufnr,winnr buffer and window number of floating window or nil
 function M.open_floating_preview(contents, filetype, opts)
   validate {
@@ -791,7 +792,7 @@ function M.open_floating_preview(contents, filetype, opts)
   end
 
   -- Compute size of float needed to show (wrapped) lines
-  opts.wrap_at = (vim.wo["wrap"] and api.nvim_win_get_width(0))
+  opts.wrap_at = opts.wrap_at or (vim.wo["wrap"] and api.nvim_win_get_width(0))
   local width, height = M._make_floating_popup_size(contents, opts)
 
   -- Add right padding of 1

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -637,10 +637,6 @@ function M.fancy_floating_markdown(contents, opts)
   }
   opts = opts or {}
 
-  -- Default padding of 1 for backwards compatibility
-  local pad_left = opts.pad_left or 1
-  local pad_right = opts.pad_right or 1
-
   local stripped = {}
   local highlights = {}
   do
@@ -674,12 +670,12 @@ function M.fancy_floating_markdown(contents, opts)
       end
     end
   end
-  -- Clean input and add padding
-  for i, v in ipairs(stripped) do
-    v = v:gsub("\r", "")
-    if pad_left then v = (" "):rep(pad_left)..v end
-    if pad_right then v = v..(" "):rep(pad_right) end
-    stripped[i] = v
+  -- Clean up and add padding (default to 1 for backward compatibility)
+  left_padding = (" "):rep(opts.pad_left or 1)
+  right_padding = (" "):rep(opts.pad_right or 1)
+  stripped = M.trim_empty_lines(stripped)
+  for i, line in ipairs(stripped) do
+    stripped[i] = string.format('%s%s%s', right_padding, line:gsub("\r", ""), right_padding)
   end
 
   -- Compute size of float needed to show (wrapped) lines
@@ -808,17 +804,13 @@ function M.open_floating_preview(contents, filetype, opts)
   }
   opts = opts or {}
 
-  -- Default padding of 1 for backwards compatibility
-  local pad_left = opts.pad_left or 1
-  local pad_right = opts.pad_right or 1
-
   -- Clean up input: trim empty lines from the end, pad
+  -- Default padding of 1 for backwards compatibility
+  left_padding = (" "):rep(opts.pad_left or 1)
+  right_padding = (" "):rep(opts.pad_right or 1)
   contents = M.trim_empty_lines(contents)
   for i, line in ipairs(contents) do
-    line = line:gsub("\r", "")
-    if pad_left then line = (" "):rep(pad_left)..line end
-    if pad_right then line = line..(" "):rep(pad_right) end
-    contents[i] = line
+    contents[i] = string.format('%s%s%s', right_padding, line:gsub("\r", ""), right_padding)
   end
 
   -- Compute size of float needed to show (wrapped) lines

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -773,9 +773,11 @@ end
 --@param contents table of lines to show in window
 --@param filetype string of filetype to set for opened buffer
 --@param opts dictionary with optional fields
---             - height  of floating window
---             - width   of floating window
---             - wrap_at character to wrap at for computing height
+--             - height     of floating window
+--             - width     of floating window
+--             - wrap_at   character to wrap at for computing height
+--             - pad_left  amount of columns to pad contents at left
+--             - pad_right amount of columns to pad contents at right
 --@return bufnr,winnr buffer and window number of floating window or nil
 function M.open_floating_preview(contents, filetype, opts)
   validate {
@@ -785,18 +787,22 @@ function M.open_floating_preview(contents, filetype, opts)
   }
   opts = opts or {}
 
-  -- Clean up input: trim empty lines from the end
+  -- default padding of 1 for backwards compatibility
+  local pad_left = opts.pad_left or 1
+  local pad_right = opts.pad_right or 1
+
+  -- Clean up input: trim empty lines from the end, pad
   contents = M.trim_empty_lines(contents)
   for i, line in ipairs(contents) do
-    contents[i] = " "..line:gsub("\r", "") -- clean and left pad
+    line = line:gsub("\r", "")
+    if pad_left then line = (" "):rep(pad_left)..line end
+    if pad_right then line = line..(" "):rep(pad_right) end
+    contents[i] = line
   end
 
   -- Compute size of float needed to show (wrapped) lines
   opts.wrap_at = opts.wrap_at or (vim.wo["wrap"] and api.nvim_win_get_width(0))
   local width, height = M._make_floating_popup_size(contents, opts)
-
-  -- Add right padding of 1
-  width = width + 1
 
   local floating_bufnr = api.nvim_create_buf(false, true)
   if filetype then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1379,4 +1379,14 @@ describe('LSP', function()
       eq('å', exec_lua[[return vim.fn.expand('<cword>')]])
     end)
   end)
+
+  describe('lsp.util._make_floating_popup_size', function()
+    exec_lua [[ contents =
+    {"text tαxt txtα tex",
+    "text tααt tααt text",
+    "text tαxt tαxt"}
+    ]]
+    eq({19,3}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents)} ]])
+    eq({15,5}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents,{width = 15, wrap_at = 14})} ]])
+  end)
 end)


### PR DESCRIPTION
If the contents of a floating window opened by `open_floating_preview` inherit the wrapped setting of the parent window, the height was previously calculated according to the number of lines (before wrapping), leading to text being cut off. (This can occur with the `preview_location` function introduced in #12368 and the texlab server.)

We now check whether a) the `opts.height` field is not set, b) the parent window has `wrap` set, and c) the maximal width just calculated is larger than the (parent's) window width. In this case, it goes through the lines and counts them according to how many lines they'd take after wrapping. Otherwise, it reverts to the old behavior (take `opts.height` if that is passed, number of unwrapped lines otherwise).

**EDIT** This is now done in a separate function `make_floating_popup_size`. I've done some refactoring to a) make the padding `open_floating_preview` more consistent with `fancy_floating_markdown` (in particular, configurable, with the previous value of `1` as default for backward compatibility) and b) use `make_floating_popup_size` in `fancy_floating_markdown`. (That function could use a more massive refactor, though -- @norcalli?) As a bonus, `hover` now inherits the wrapping from the parent window, which is useful for texlab (and metals @ckipp01?)

This does not account for the `linebreak` option so will still cut off the preview for _very_ long lines or _very_ thin windows, but should be OK for the majority of cases (and improves on the status quo in any case).

I also added a docstring to the methods while I was at it (plus a test for `make_floating_popup_size`).