### PR TITLE
Propagate visual selection information to TextYankPost

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -844,6 +844,7 @@ TextYankPost			Just after a |yank| or |deleting| command, but not
 				    regcontents
 				    regname
 				    regtype
+				    visual
 				The `inclusive` flag combined with the |'[|
 				and |']| marks can be used to calculate the
 				precise region of the operation.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1591,6 +1591,8 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 					operation.
 			regtype		Type of register as returned by
 					|getregtype()|.
+			visual		Selection is visual (as opposed to,
+					e.g., via motion).	
 			completed_item    Current selected complete item on
 					|CompleteChanged|, Is `{}` when no complete
 					item selected.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -705,6 +705,10 @@ the highlight via
 >
  au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 500)
 <
+If you want to exclude visual selections from highlighting on yank, use
+>
+au TextYankPost * silent! lua return (not vim.v.event.visual) and require'vim.highlight'.on_yank()
+<
 
 vim.highlight.on_yank([{higroup}, {timeout}, {event}]) 
                                                     *vim.highlight.on_yank()*

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2748,6 +2748,10 @@ static void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
   buf[1] = NUL;
   tv_dict_add_str(dict, S_LEN("operator"), buf);
 
+  // Selection type: visual or not.
+  tv_dict_add_special(dict, S_LEN("visual"),
+                      oap->is_VIsual ? kSpecialVarTrue : kSpecialVarFalse);
+
   tv_dict_set_keys_readonly(dict);
   textlock++;
   apply_autocmds(EVENT_TEXTYANKPOST, NULL, NULL, false, curbuf);

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1246,23 +1246,23 @@ func Test_TextYankPost()
 
   norm "ayiw
   call assert_equal(
-    \{'regcontents': ['foo'], 'inclusive': v:true, 'regname': 'a', 'operator': 'y', 'regtype': 'v'},
+    \{'regcontents': ['foo'], 'inclusive': v:true, 'regname': 'a', 'operator': 'y', 'visual': v:false, 'regtype': 'v'},
     \g:event)
   norm y_
   call assert_equal(
-    \{'regcontents': ['foo'], 'inclusive': v:false, 'regname': '',  'operator': 'y', 'regtype': 'V'},
+    \{'regcontents': ['foo'], 'inclusive': v:false, 'regname': '',  'operator': 'y', 'visual': v:false, 'regtype': 'V'},
     \g:event)
   call feedkeys("\<C-V>y", 'x')
   call assert_equal(
-    \{'regcontents': ['f'], 'inclusive': v:true, 'regname': '',  'operator': 'y', 'regtype': "\x161"},
+    \{'regcontents': ['f'], 'inclusive': v:true, 'regname': '',  'operator': 'y', 'visual': v:true, 'regtype': "\x161"},
     \g:event)
   norm "xciwbar
   call assert_equal(
-    \{'regcontents': ['foo'], 'inclusive': v:true, 'regname': 'x', 'operator': 'c', 'regtype': 'v'},
+    \{'regcontents': ['foo'], 'inclusive': v:true, 'regname': 'x', 'operator': 'c', 'visual': v:false, 'regtype': 'v'},
     \g:event)
   norm "bdiw
   call assert_equal(
-    \{'regcontents': ['bar'], 'inclusive': v:true, 'regname': 'b', 'operator': 'd', 'regtype': 'v'},
+    \{'regcontents': ['bar'], 'inclusive': v:true, 'regname': 'b', 'operator': 'd', 'visual': v:false, 'regtype': 'v'},
     \g:event)
 
   call assert_equal({}, v:event)

--- a/test/functional/autocmd/textyankpost_spec.lua
+++ b/test/functional/autocmd/textyankpost_spec.lua
@@ -27,7 +27,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo\nbar' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
     eq(1, eval('g:count'))
 
@@ -40,7 +41,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'baz ' },
       regname = '',
-      regtype = 'v'
+      regtype = 'v',
+      visual = false
     }, eval('g:event'))
     eq(2, eval('g:count'))
 
@@ -50,7 +52,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo', 'baz' },
       regname = '',
-      regtype = "\0223" -- ^V + block width
+      regtype = "\0223", -- ^V + block width
+      visual = true
     }, eval('g:event'))
     eq(3, eval('g:count'))
   end)
@@ -62,7 +65,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo\nbar' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
 
     command('set debug=msg')
@@ -92,7 +96,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo\nbar' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
     eq(1, eval('g:count'))
     eq({ 'foo\nbar' }, funcs.getreg('+',1,1))
@@ -105,7 +110,8 @@ describe('TextYankPost', function()
       operator = 'd',
       regcontents = { 'foo' },
       regname = '',
-      regtype = 'v'
+      regtype = 'v',
+      visual = false
     }, eval('g:event'))
     eq(1, eval('g:count'))
 
@@ -115,7 +121,8 @@ describe('TextYankPost', function()
       operator = 'd',
       regcontents = { '\nbar' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
     eq(2, eval('g:count'))
 
@@ -125,7 +132,8 @@ describe('TextYankPost', function()
       operator = 'c',
       regcontents = { 'baz' },
       regname = '',
-      regtype = 'v'
+      regtype = 'v',
+      visual = false
     }, eval('g:event'))
     eq(3, eval('g:count'))
   end)
@@ -153,7 +161,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'bar' },
       regname = 'b',
-      regtype = 'v'
+      regtype = 'v',
+      visual = false
     }, eval('g:event'))
 
     feed('"*yy')
@@ -162,7 +171,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo\nbar' },
       regname = '*',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
 
     command("set clipboard=unnamed")
@@ -174,7 +184,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo\nbar' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
 
     feed('"*yy')
@@ -183,7 +194,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'foo\nbar' },
       regname = '*',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
   end)
 
@@ -194,7 +206,8 @@ describe('TextYankPost', function()
       operator = 'd',
       regcontents = { 'foo\nbar' },
       regname = '+',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
     eq(1, eval('g:count'))
 
@@ -204,7 +217,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'baz text' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
     eq(2, eval('g:count'))
 
@@ -214,7 +228,8 @@ describe('TextYankPost', function()
       operator = 'y',
       regcontents = { 'baz ' },
       regname = '',
-      regtype = 'v'
+      regtype = 'v',
+      visual = false
     }, eval('g:event'))
     eq(3, eval('g:count'))
 
@@ -224,7 +239,8 @@ describe('TextYankPost', function()
       operator = 'd',
       regcontents = { 'baz text' },
       regname = '',
-      regtype = 'V'
+      regtype = 'V',
+      visual = false
     }, eval('g:event'))
     eq(4, eval('g:count'))
   end)


### PR DESCRIPTION
This PR propagates the `is_VIsual` boolean from `oparg_T` to the `v:event` struct filled by the TextYankPost autocommand (see #12381).

This is useful for, e.g., not highlighting the yanked text from visual selections (which already provide visual feedback) as requested on [Reddit](https://www.reddit.com/r/neovim/comments/gofplz/neovim_has_added_the_ability_to_highlight_yanked/); use it via
```vim
au TextYankPost * silent! lua return (not vim.v.event.visual) and require'vim.highlight'.on_yank()
```

@tjdevries 

**EDIT** adapted tests, including one with visual selection, which pass locally