### PR TITLE
Fix / improve Python virtualenv check messages

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -537,8 +537,8 @@ function! s:check_virtualenv() abort
     call add(errors, 'no Python executables found in the virtualenv '.bin_dir.' directory.')
   endif
 
+  let msg = '$VIRTUAL_ENV is set to: '.$VIRTUAL_ENV
   if len(errors)
-    let msg = '$VIRTUAL_ENV is set to: '.$VIRTUAL_ENV
     if len(venv_bins)
       let msg .= "\nAnd its ".bin_dir.' directory contains: '
         \.join(map(venv_bins, "fnamemodify(v:val, ':t')"), ', ')
@@ -551,7 +551,10 @@ function! s:check_virtualenv() abort
     let msg .= "\nSo invoking Python may lead to unexpected results."
     call health#report_warn(msg, keys(hints))
   else
-    call health#report_ok('$VIRTUAL_ENV provides :python, :python3, et al.')
+    call health#report_info(msg)
+    call health#report_info('Python version: '
+      \.system('python -c "import platform, sys; sys.stdout.write(platform.python_version())"'))
+    call health#report_ok('$VIRTUAL_ENV provides :!python.')
   endif
 endfunction
 


### PR DESCRIPTION
I noticed a typo was introduced prior to merging a PR of mine back in February (#11781):

- the  OK message for the Python virtualenv health check currently says `'$VIRTUAL_ENV provides :python, :python3, et al.'`
- but that's not true, `:python` and `:python3` are Neovim's Python 2/3 *providers* (i.e. Python environments which have the `neovim` module installed), whereas the virtualenv check just checks whether a virtualenv is activated and whether the virtualenv's Python is the first `python` on the path in Neovim and subshells (the `neovim` module is not involved in any way)
- to preserve the brevity of the original message, I suggest changing it to `$VIRTUAL_ENV provides :!python.`, but I'm obviously open to alternatives

Along the way, I also thought it might be good to provide a little bit more info even when the virtualenv check succeeds, concerning which virtualenv and Python version have actually been detected, as these may differ from what the user expects and the information might help them troubleshoot. Though that's up for debate of course :)