### PR TITLE
[RFC] lsp: factor out highlight_range

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1042,14 +1042,6 @@ get_current_line_to_cursor()
 get_severity_highlight_name({severity})
                 TODO: Documentation
 
-                                              *vim.lsp.util.highlight_range()*
-highlight_range({bufnr}, {ns}, {hiname}, {start}, {finish})
-                TODO: Documentation
-
-                                             *vim.lsp.util.highlight_region()*
-highlight_region({ft}, {start}, {finish})
-                TODO: Documentation
-
 jump_to_location({location})                 *vim.lsp.util.jump_to_location()*
                 TODO: Documentation
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -713,6 +713,16 @@ vim.highlight.on_yank([{higroup}, {timeout}, {event}])
         in milliseconds ({timeout}, default `500`), and the event structure 
         that is fired ({event}, default `vim.v.event`).
 
+
+vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
+                                                       *vim.highlight.range()*
+        Highlights the range between {start} and {finish} (tuples of {line,col})
+        in buffer {bufnr} with the highlight group {higroup} using the namespace
+        {ns}. Optional arguments are the type of range (characterwise, linewise,
+        or blockwise, see |setreg|; default to characterwise) and whether the
+        range is inclusive (default false).
+
+
 ------------------------------------------------------------------------------
 VIM.REGEX							*lua-regex*
 

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -2,12 +2,34 @@ local api = vim.api
 
 local highlight = {}
 
+--- Highlight range between two positions
+---
+--@param bufnr number of buffer to apply highlighting to
+--@param ns namespace to add highlight to
+--@param higroup highlight group to use for highlighting
+--@param rtype type of range (:help setreg, default charwise)
+--@param inclusive boolean indicating whether the range is end-inclusive (default false)
+function highlight.range(bufnr, ns, higroup, start, finish, rtype, inclusive)
+  rtype = rtype or 'v'
+  inclusive = inclusive or false
+
+  -- sanity check
+  if start[2] < 0 or finish[2] < start[2] then return end
+
+  local region = vim.region(bufnr, start, finish, rtype, inclusive)
+  for linenr, cols in pairs(region) do
+    api.nvim_buf_add_highlight(bufnr, ns, higroup, linenr, cols[1], cols[2])
+  end
+
+end
+
 --- Highlight the yanked region
---
+---
 --- use from init.vim via
 ---   au TextYankPost * lua require'vim.highlight'.on_yank()
 --- customize highlight group and timeout via
 ---   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 500)
+---
 -- @param higroup highlight group for yanked region
 -- @param timeout time in ms before highlight is cleared
 -- @param event event structure
@@ -27,10 +49,7 @@ function highlight.on_yank(higroup, timeout, event)
   pos1 = {pos1[2] - 1, pos1[3] - 1 + pos1[4]}
   pos2 = {pos2[2] - 1, pos2[3] - 1 + pos2[4]}
 
-  local region = vim.region(bufnr, pos1, pos2, event.regtype, event.inclusive)
-  for linenr, cols in pairs(region) do
-    api.nvim_buf_add_highlight(bufnr, yank_ns, higroup, linenr, cols[1], cols[2])
-  end
+  highlight.range(bufnr, yank_ns, higroup, pos1, pos2, event.regtype, event.inclusive)
 
   vim.defer_fn(
     function() api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1) end,


### PR DESCRIPTION
This PR moves the `highlight_range` function from `lsp/util.lua` to `highlight.lua` and refactors it to make use of the `vim.region()` function introduced in #12279 

This should make function using `highlight_range` non-ASCII safe.

Marking this RFC because I can't test the highlight function for LSP locally; in particular, I don't know if `inclusive=true` or `false` is the correct, backward-compatible, default.

@tjdevries @h-michael @haorenW1025