### PR TITLE
runtime: fix remote plugin command fails at some case

### DIFF
--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -24,7 +24,7 @@ function! remote#define#CommandOnHost(host, method, sync, name, opts)
   endif
 
   if has_key(a:opts, 'nargs')
-    call add(forward_args, ' <args>')
+    call add(forward_args, ' " . <q-args> . "')
   endif
 
   exe s:GetCommandPrefix(a:name, a:opts)

--- a/test/functional/provider/define_spec.lua
+++ b/test/functional/provider/define_spec.lua
@@ -92,12 +92,12 @@ local function command_specs_for(fn, sync, first_arg_factory, init)
       it('with nargs/double-quote', function()
         call(fn, args..', {"nargs": "*"}')
         local function on_setup()
-          command('RpcCommand "arg"')
+          command('RpcCommand "arg1" "arg2" "arg3"')
         end
 
         local function handler(method, arguments)
           eq('test-handler', method)
-          eq({'"arg"'}, arguments[1])
+          eq({'"arg1"', '"arg2"', '"arg3"'}, arguments[1])
           return ''
         end
 

--- a/test/functional/provider/define_spec.lua
+++ b/test/functional/provider/define_spec.lua
@@ -89,6 +89,21 @@ local function command_specs_for(fn, sync, first_arg_factory, init)
         runx(sync, handler, on_setup)
       end)
 
+      it('with nargs/double-quote', function()
+        call(fn, args..', {"nargs": "*"}')
+        local function on_setup()
+          command('RpcCommand "arg"')
+        end
+
+        local function handler(method, arguments)
+          eq('test-handler', method)
+          eq({'"arg"'}, arguments[1])
+          return ''
+        end
+
+        runx(sync, handler, on_setup)
+      end)
+
       it('with range', function()
         call(fn,args..', {"range": ""}')
         local function on_setup()


### PR DESCRIPTION
Change `<args>` to `<q-args>` because passing a double quote broke the argument.

fixes #12410