### PR TITLE
[RDY]vim-patch:8.0.1564,8.1.{917,1895,2018,2335},8.2.{89,491,873,892,905}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5835,6 +5835,7 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		  "rhs"	     The {rhs} of the mapping as typed.
 		  "silent"   1 for a |:map-silent| mapping, else 0.
 		  "noremap"  1 if the {rhs} of the mapping is not remappable.
+		  "script"   1 if mapping was defined with <script>.
 		  "expr"     1 for an expression mapping (|:map-<expr>|).
 		  "buffer"   1 for a buffer local mapping (|:map-local|).
 		  "mode"     Modes for which the mapping is defined. In

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -883,11 +883,12 @@ au BufNewFile,BufRead *.ll			setf lifelines
 " Lilo: Linux loader
 au BufNewFile,BufRead lilo.conf			setf lilo
 
-" Lisp (*.el = ELisp, *.cl = Common Lisp, *.jl = librep Lisp)
+" Lisp (*.el = ELisp, *.cl = Common Lisp)
+" *.jl was removed, it's also used for Julia, better skip than guess wrong.
 if has("fname_case")
-  au BufNewFile,BufRead *.lsp,*.lisp,*.el,*.cl,*.jl,*.L,.emacs,.sawfishrc setf lisp
+  au BufNewFile,BufRead *.lsp,*.lisp,*.el,*.cl,*.L,.emacs,.sawfishrc setf lisp
 else
-  au BufNewFile,BufRead *.lsp,*.lisp,*.el,*.cl,*.jl,.emacs,.sawfishrc setf lisp
+  au BufNewFile,BufRead *.lsp,*.lisp,*.el,*.cl,.emacs,.sawfishrc setf lisp
 endif
 
 " SBCL implementation of Common Lisp

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -186,14 +186,17 @@ int open_buffer(
       }
     }
 
-    /*
-     * if there is no memfile at all, exit
-     * This is OK, since there are no changes to lose.
-     */
+    // If there is no memfile at all, exit.
+    // This is OK, since there are no changes to lose.
     if (curbuf == NULL) {
       EMSG(_("E82: Cannot allocate any buffer, exiting..."));
+
+      // Don't try to do any saving, with "curbuf" NULL almost nothing
+      // will work.
+      v_dying = 2;
       getout(2);
     }
+
     EMSG(_("E83: Cannot allocate buffer, using other one..."));
     enter_buffer(curbuf);
     if (old_tw != curbuf->b_p_tw) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6754,6 +6754,7 @@ void mapblock_fill_dict(dict_T *const dict,
   }
   tv_dict_add_allocated_str(dict, S_LEN("lhs"), lhs);
   tv_dict_add_nr(dict, S_LEN("noremap"), noremap_value);
+  tv_dict_add_nr(dict, S_LEN("script"), mp->m_noremap == REMAP_SCRIPT ? 1 : 0);
   tv_dict_add_nr(dict, S_LEN("expr"),  mp->m_expr ? 1 : 0);
   tv_dict_add_nr(dict, S_LEN("silent"), mp->m_silent ? 1 : 0);
   tv_dict_add_nr(dict, S_LEN("sid"), (varnumber_T)mp->m_script_ctx.sc_sid);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6120,7 +6120,7 @@ void common_function(typval_T *argvars, typval_T *rettv,
         if (tv_list_len(list) == 0) {
           arg_idx = 0;
         } else if (tv_list_len(list) > MAX_FUNC_ARGS) {
-          emsg_funcname((char *)e_toomanyarg, name);
+          emsg_funcname((char *)e_toomanyarg, s);
           xfree(name);
           goto theend;
         }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -170,6 +170,7 @@ int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
   garray_T   newargs = GA_EMPTY_INIT_VALUE;
   garray_T   *pnewargs;
   ufunc_T    *fp = NULL;
+  partial_T *pt = NULL;
   int        varargs;
   int        ret;
   char_u     *start = skipwhite(*arg + 1);
@@ -219,7 +220,6 @@ int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
     int len, flags = 0;
     char_u *p;
     char_u name[20];
-    partial_T *pt;
     garray_T newlines;
 
     lambda_no++;
@@ -274,6 +274,7 @@ int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
 errret:
   ga_clear_strings(&newargs);
   xfree(fp);
+  xfree(pt);
   eval_lavars_used = old_eval_lavars;
   return FAIL;
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -5361,12 +5361,12 @@ void globpath(char_u *path, char_u *file, garray_T *ga, int expand_options)
 
         // Concatenate new results to previous ones.
         ga_grow(ga, num_p);
+        // take over the pointers and put them in "ga"
         for (int i = 0; i < num_p; i++) {
-          ((char_u **)ga->ga_data)[ga->ga_len] = vim_strsave(p[i]);
+          ((char_u **)ga->ga_data)[ga->ga_len] = p[i];
           ga->ga_len++;
         }
-
-        FreeWild(num_p, p);
+        xfree(p);
       }
     }
   }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -203,7 +203,7 @@ EXTERN int msg_nowait INIT(= false);        // don't wait for this msg
 EXTERN int emsg_off INIT(= 0);              // don't display errors for now,
                                             // unless 'debug' is set.
 EXTERN int info_message INIT(= false);      // printing informative message
-EXTERN int msg_hist_off INIT(= false);      // don't add messages to history
+EXTERN bool msg_hist_off INIT(= false);     // don't add messages to history
 EXTERN int need_clr_eos INIT(= false);      // need to clear text before
                                             // displaying a message.
 EXTERN int emsg_skip INIT(= 0);             // don't display errors for

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -478,6 +478,8 @@ EXTERN int sc_col;              // column for shown command
 EXTERN int starting INIT(= NO_SCREEN);
 // true when planning to exit. Might keep running if there is a changed buffer.
 EXTERN bool exiting INIT(= false);
+// internal value of v:dying
+EXTERN int v_dying INIT(= 0);
 // is stdin a terminal?
 EXTERN int stdin_isatty INIT(= true);
 // is stdout a terminal?

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -621,7 +621,7 @@ void getout(int exitval)
   /* Optionally print hashtable efficiency. */
   hash_debug_results();
 
-  if (get_vim_var_nr(VV_DYING) <= 1) {
+  if (v_dying <= 1) {
     const tabpage_T *next_tp;
 
     // Trigger BufWinLeave for all windows, but only once per buffer.
@@ -670,8 +670,9 @@ void getout(int exitval)
     shada_write_file(NULL, false);
   }
 
-  if (get_vim_var_nr(VV_DYING) <= 1)
-    apply_autocmds(EVENT_VIMLEAVE, NULL, NULL, FALSE, curbuf);
+  if (v_dying <= 1) {
+    apply_autocmds(EVENT_VIMLEAVE, NULL, NULL, false, curbuf);
+  }
 
   profile_dump();
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -306,11 +306,6 @@ bool msg_attr_keep(char_u *s, int attr, bool keep, bool multiline)
     add_msg_hist((const char *)s, -1, attr, multiline);
   }
 
-  /* When displaying keep_msg, don't let msg_start() free it, caller must do
-   * that. */
-  if (s == keep_msg)
-    keep_msg = NULL;
-
   /* Truncate the message if needed. */
   msg_start();
   buf = msg_strtrunc(s, FALSE);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -621,6 +621,8 @@ static void normal_redraw_mode_message(NormalState *s)
     update_screen(0);
     // now reset it, otherwise it's put in the history again
     keep_msg = kmsg;
+
+    kmsg = vim_strsave(keep_msg);
     msg_attr((const char *)kmsg, keep_msg_attr);
     xfree(kmsg);
   }
@@ -1265,10 +1267,15 @@ static void normal_redraw(NormalState *s)
   // Display message after redraw. If an external message is still visible,
   // it contains the kept message already.
   if (keep_msg != NULL && !msg_ext_is_visible()) {
-    // msg_attr_keep() will set keep_msg to NULL, must free the string here.
-    // Don't reset keep_msg, msg_attr_keep() uses it to check for duplicates.
-    char *p = (char *)keep_msg;
-    msg_attr(p, keep_msg_attr);
+    char_u *const p = vim_strsave(keep_msg);
+
+    // msg_start() will set keep_msg to NULL, make a copy
+    // first.  Don't reset keep_msg, msg_attr_keep() uses it to
+    // check for duplicates.  Never put this message in
+    // history.
+    msg_hist_off = true;
+    msg_attr((const char *)p, keep_msg_attr);
+    msg_hist_off = false;
     xfree(p);
   }
 

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -157,6 +157,7 @@ static void deadly_signal(int signum)
 {
   // Set the v:dying variable.
   set_vim_var_nr(VV_DYING, 1);
+  v_dying = 1;
 
   WLOG("got signal %d (%s)", signum, signal_name(signum));
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -249,6 +249,7 @@ static char_u e_nul_found[] = N_(
 static char_u e_misplaced[] = N_("E866: (NFA regexp) Misplaced %c");
 static char_u e_ill_char_class[] = N_(
     "E877: (NFA regexp) Invalid character class: %" PRId64);
+static char_u e_value_too_large[] = N_("E951: \\% value too large");
 
 /* Since the out pointers in the list are always
  * uninitialized, we use the pointers themselves
@@ -1499,7 +1500,8 @@ static int nfa_regatom(void)
         c = getchr();
       while (ascii_isdigit(c)) {
         if (n > (INT32_MAX - (c - '0')) / 10) {
-          EMSG(_("E951: \\% value too large"));
+          // overflow.
+          EMSG(_(e_value_too_large));
           return FAIL;
         }
         n = n * 10 + (c - '0');
@@ -1526,7 +1528,7 @@ static int nfa_regatom(void)
           limit = INT32_MAX / MB_MAXBYTES;
         }
         if (n >= limit) {
-          EMSG(_("E951: \\% value too large"));
+          EMSG(_(e_value_too_large));
           return FAIL;
         }
         EMIT((int)n);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7444,6 +7444,8 @@ static int syn_add_group(char_u *name)
     return 0;
   }
 
+  char_u *const name_up = vim_strsave_up(name);
+
   // Append another syntax_highlight entry.
   struct hl_group* hlgp = GA_APPEND_VIA_PTR(struct hl_group, &highlight_ga);
   memset(hlgp, 0, sizeof(*hlgp));
@@ -7452,7 +7454,7 @@ static int syn_add_group(char_u *name)
   hlgp->sg_rgb_fg = -1;
   hlgp->sg_rgb_sp = -1;
   hlgp->sg_blend = -1;
-  hlgp->sg_name_u = vim_strsave_up(name);
+  hlgp->sg_name_u = name_up;
 
   return highlight_ga.ga_len;               /* ID is index plus one */
 }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -692,6 +692,22 @@ func Test_getcmdwin_autocmd()
   augroup END
 endfunc
 
+" Test error: "E135: *Filter* Autocommands must not change current buffer"
+func Test_cmd_bang_E135()
+  new
+  call setline(1, ['a', 'b', 'c', 'd'])
+  augroup test_cmd_filter_E135
+    au!
+    autocmd FilterReadPost * help
+  augroup END
+  call assert_fails('2,3!echo "x"', 'E135:')
+
+  augroup test_cmd_filter_E135
+    au!
+  augroup END
+  %bwipe!
+endfunc
+
 func Test_verbosefile()
   set verbosefile=Xlog
   echomsg 'foo'

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -252,7 +252,7 @@ let s:filename_checks = {
     \ 'lilo': ['lilo.conf'],
     \ 'limits': ['/etc/limits', '/etc/anylimits.conf', '/etc/anylimits.d/file.conf'],
     \ 'liquid': ['file.liquid'],
-    \ 'lisp': ['sbclrc', '.sbclrc'],
+    \ 'lisp': ['file.lsp', 'file.lisp', 'file.el', 'file.cl', '.emacs', '.sawfishrc', 'sbclrc', '.sbclrc'],
     \ 'lite': ['file.lite', 'file.lt'],
     \ 'litestep': ['/LiteStep/any/file.rc'],
     \ 'loginaccess': ['/etc/login.access'],

--- a/src/nvim/testdir/test_ga.vim
+++ b/src/nvim/testdir/test_ga.vim
@@ -24,6 +24,7 @@ func Test_ga_command()
   " Test a few multi-bytes characters.
   call assert_equal("\n<é> 233, Hex 00e9, Oct 351, Digr e'",    Do_ga('é'))
   call assert_equal("\n<ẻ> 7867, Hex 1ebb, Oct 17273, Digr e2", Do_ga('ẻ'))
+  call assert_equal("\n<\U00012345> 74565, Hex 00012345, Octal 221505", Do_ga("\U00012345"))
 
   " Test with combining characters.
   call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401", Do_ga("e\u0301"))

--- a/src/nvim/testdir/test_maparg.vim
+++ b/src/nvim/testdir/test_maparg.vim
@@ -15,23 +15,23 @@ function Test_maparg()
   map foo<C-V> is<F4>foo
   vnoremap <script> <buffer> <expr> <silent> bar isbar
   call assert_equal("is<F4>foo", maparg('foo<C-V>'))
-  call assert_equal({'silent': 0, 'noremap': 0, 'lhs': 'foo<C-V>',
+  call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo<C-V>',
         \ 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1,
         \ 'rhs': 'is<F4>foo', 'buffer': 0},
         \ maparg('foo<C-V>', '', 0, 1))
-  call assert_equal({'silent': 1, 'noremap': 1, 'lhs': 'bar', 'mode': 'v',
+  call assert_equal({'silent': 1, 'noremap': 1, 'script': 1, 'lhs': 'bar', 'mode': 'v',
         \ 'nowait': 0, 'expr': 1, 'sid': sid, 'lnum': lnum + 2,
         \ 'rhs': 'isbar', 'buffer': 1},
         \ maparg('bar', '', 0, 1))
   let lnum = expand('<sflnum>')
   map <buffer> <nowait> foo bar
-  call assert_equal({'silent': 0, 'noremap': 0, 'lhs': 'foo', 'mode': ' ',
+  call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo', 'mode': ' ',
         \ 'nowait': 1, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'bar',
         \ 'buffer': 1},
         \ maparg('foo', '', 0, 1))
   let lnum = expand('<sflnum>')
   tmap baz foo
-  call assert_equal({'silent': 0, 'noremap': 0, 'lhs': 'baz', 'mode': 't',
+  call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'baz', 'mode': 't',
         \ 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'foo',
         \ 'buffer': 0},
         \ maparg('baz', 't', 0, 1))

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -21,6 +21,7 @@ describe('nvim_get_keymap', function()
   local foo_bar_string = 'nnoremap foo bar'
   local foo_bar_map_table = {
     lhs='foo',
+    script=0,
     silent=0,
     rhs='bar',
     expr=0,
@@ -245,6 +246,7 @@ describe('nvim_get_keymap', function()
 
   it('works correctly despite various &cpo settings', function()
     local cpo_table = {
+      script=0,
       silent=0,
       expr=0,
       sid=0,
@@ -302,6 +304,7 @@ describe('nvim_get_keymap', function()
       lhs='|   |',
       rhs='|    |',
       mode='n',
+      script=0,
       silent=0,
       expr=0,
       sid=0,
@@ -343,6 +346,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     to_return.noremap = not opts.noremap and 0 or 1
     to_return.lhs = lhs
     to_return.rhs = rhs
+    to_return.script = 0
     to_return.silent = not opts.silent and 0 or 1
     to_return.nowait = not opts.nowait and 0 or 1
     to_return.expr = not opts.expr and 0 or 1

--- a/test/functional/eval/map_functions_spec.lua
+++ b/test/functional/eval/map_functions_spec.lua
@@ -13,6 +13,7 @@ describe('maparg()', function()
 
   local foo_bar_map_table = {
       lhs='foo',
+      script=0,
       silent=0,
       rhs='bar',
       expr=0,
@@ -147,6 +148,7 @@ describe('maparg()', function()
         mode = 'n',
         noremap = 1,
         nowait = 0,
+        script=0,
         sid = 0,
         silent = 0,
         lnum = 0,

--- a/test/functional/legacy/075_maparg_spec.lua
+++ b/test/functional/legacy/075_maparg_spec.lua
@@ -49,9 +49,9 @@ describe('maparg()', function()
     -- Assert buffer contents.
     expect([[
       is<F4>foo
-      {'lnum': 0, 'silent': 0, 'noremap': 0, 'lhs': 'foo<C-V>', 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': 0, 'rhs': 'is<F4>foo', 'buffer': 0}
-      {'lnum': 0, 'silent': 1, 'noremap': 1, 'lhs': 'bar', 'mode': 'v', 'nowait': 0, 'expr': 1, 'sid': 0, 'rhs': 'isbar', 'buffer': 1}
-      {'lnum': 0, 'silent': 0, 'noremap': 0, 'lhs': 'foo', 'mode': ' ', 'nowait': 1, 'expr': 0, 'sid': 0, 'rhs': 'bar', 'buffer': 1}
+      {'lnum': 0, 'script': 0, 'silent': 0, 'noremap': 0, 'lhs': 'foo<C-V>', 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': 0, 'rhs': 'is<F4>foo', 'buffer': 0}
+      {'lnum': 0, 'script': 1, 'silent': 1, 'noremap': 1, 'lhs': 'bar', 'mode': 'v', 'nowait': 0, 'expr': 1, 'sid': 0, 'rhs': 'isbar', 'buffer': 1}
+      {'lnum': 0, 'script': 0, 'silent': 0, 'noremap': 0, 'lhs': 'foo', 'mode': ' ', 'nowait': 1, 'expr': 0, 'sid': 0, 'rhs': 'bar', 'buffer': 1}
       xrx
       yRy
       abcd]])


### PR DESCRIPTION
vim-patch:8.1.0917 adds a useless `xfree`. It is N/A if later patches do not add code to `get_lambda_tv` to handle non-allocation errors.

I could add vim-patch:8.1.1895 here but it is missing `v_dying` from vim-patch:8.0.1564. I thought that was N/A because most of that patch is deleting `#ifdef` for `+autocmd`.