### PR TITLE
man.vim: fallback to a single path on empty glob

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -332,7 +332,7 @@ function! s:get_paths(sect, name, do_fallback) abort
   " callers must try-catch this, as some `man` implementations don't support `s:find_arg`
   try
     let mandirs = join(split(s:system(['man', s:find_arg]), ':\|\n'), ',')
-    let paths = globpath(mandirs,'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
+    let paths = globpath(mandirs, 'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
     if !empty(paths)
       return paths
     endif
@@ -341,10 +341,15 @@ function! s:get_paths(sect, name, do_fallback) abort
       throw v:exception
     endif
   endtry
-
   " Fallback to a single path, with the page we're trying to find.
-  let [l:sect, l:name, l:path] = s:verify_exists(a:sect, a:name)
-  return [l:path]
+  if a:do_fallback
+    try
+      let [l:sect, l:name, l:path] = s:verify_exists(a:sect, a:name)
+      return [l:path]
+    catch
+    endtry
+  endif
+  return []
 endfunction
 
 function! s:complete(sect, psect, name) abort

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -332,16 +332,19 @@ function! s:get_paths(sect, name, do_fallback) abort
   " callers must try-catch this, as some `man` implementations don't support `s:find_arg`
   try
     let mandirs = join(split(s:system(['man', s:find_arg]), ':\|\n'), ',')
-    return globpath(mandirs,'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
+    let paths = globpath(mandirs,'man?/'.a:name.'*.'.a:sect.'*', 0, 1)
+    if !empty(paths)
+      return paths
+    endif
   catch
     if !a:do_fallback
       throw v:exception
     endif
-
-    " fallback to a single path, with the page we're trying to find
-    let [l:sect, l:name, l:path] = s:verify_exists(a:sect, a:name)
-    return [l:path]
   endtry
+
+  " Fallback to a single path, with the page we're trying to find.
+  let [l:sect, l:name, l:path] = s:verify_exists(a:sect, a:name)
+  return [l:path]
 endfunction
 
 function! s:complete(sect, psect, name) abort


### PR DESCRIPTION
Currently, uppercase section names (for example in case of OpenGL manual pages) cannot be opened (with <kbd>K</kbd>), because they converted to lowercase. `glob()` finds nothing and returns an empty list. In these cases, falling back to `s:verify_exists()` seems a logical decision and also solves my particular issue.

(Maybe a better fix would be to glob for `...{section-number-only}*` and then do a case-insensitive filtering on the resulting files.)