### PR TITLE
lua: fix infinite loop on vim.split

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -79,7 +79,7 @@ function vim.gsplit(s, sep, plain)
   end
 
   return function()
-    if done then
+    if done or s == '' then
       return
     end
     if sep == '' then

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -243,6 +243,7 @@ describe('lua stdlib', function()
       { "here be dragons", " ", false, { "here", "be", "dragons"} },
       { "axaby", "ab?", false, { '', 'x', 'y' } },
       { "f v2v v3v w2w ", "([vw])2%1", false, { 'f ', ' v3v ', ' ' } },
+      { "", "", false, {} },
       { "x*yz*oo*l", "*", true, { 'x', 'yz', 'oo', 'l' } },
     }
 


### PR DESCRIPTION
`:lua vim.split("", "")` causes infinite loop.
`:lua vim.gsplit("", "")` is the same as well.

This pr will fix it.
