### PR TITLE
build: match WSL2 kernel name

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -12,7 +12,7 @@ check_type_size("size_t" SIZEOF_SIZE_T)
 check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("void *" SIZEOF_VOID_PTR)
 
-if (CMAKE_HOST_SYSTEM_VERSION MATCHES ".*-Microsoft")
+if (CMAKE_HOST_SYSTEM_VERSION MATCHES ".*-(Microsoft|microsoft-standard)")
   # Windows Subsystem for Linux
   set(HAVE_WSL 1)
 endif()


### PR DESCRIPTION
The kernel name in WSL1 is of this format
`4.4.0-19041-Microsoft`
while the following is used in WSL2:
`4.19.104-microsoft-standard`.
See https://github.com/microsoft/WSL2-Linux-Kernel/blob/master/Microsoft/config-wsl#L22.

Match both formats, so that `has("wsl")` is working as intended.