### PR TITLE
lua: fix behavior when split empty string

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -79,7 +79,7 @@ function vim.gsplit(s, sep, plain)
   end
 
   return function()
-    if done or s == '' then
+    if done or (s == '' and sep == '') then
       return
     end
     if sep == '' then

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -244,6 +244,7 @@ describe('lua stdlib', function()
       { "axaby", "ab?", false, { '', 'x', 'y' } },
       { "f v2v v3v w2w ", "([vw])2%1", false, { 'f ', ' v3v ', ' ' } },
       { "", "", false, {} },
+      { "", "a", false, { '' } },
       { "x*yz*oo*l", "*", true, { 'x', 'yz', 'oo', 'l' } },
     }
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -800,13 +800,14 @@ describe('LSP', function()
         make_edit(0, 0, 0, 0, {"123"});
         make_edit(1, 0, 1, 1, {"2"});
         make_edit(2, 0, 2, 2, {"3"});
+        make_edit(3, 2, 3, 4, {""});
       }
       exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
       eq({
         '123First line of text';
         '2econd line of text';
         '3ird line of text';
-        'Fourth line of text';
+        'Foth line of text';
         'å å ɧ 汉语 ↥ 🤦 🦄';
       }, buf_lines(1))
     end)


### PR DESCRIPTION
this pr will fix the behaivior vim.split.
ref: https://github.com/neovim/neovim/pull/12420#issuecomment-638044627

## before

```lua
vim.split("", "\n") == {}
```

## after 

```lua
vim.split("", "\n") == { '' }
```

