### PR TITLE
Fix apply_text_edits for empty strings

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -129,12 +129,18 @@ function M.apply_text_edits(text_edits, bufnr)
       e.range["end"].character)
     start_line = math.min(e.range.start.line, start_line)
     finish_line = math.max(e.range["end"].line, finish_line)
+    local lines
+    if e.newText == '' then
+      lines = { '' }
+    else
+      lines = vim.split(e.newText, '\n', true)
+    end
     -- TODO(ashkan) sanity check ranges for overlap.
     table.insert(cleaned, {
       i = i;
       A = {start_row; start_col};
       B = {end_row; end_col};
-      lines = vim.split(e.newText, '\n', true);
+      lines = lines;
     })
   end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -810,6 +810,22 @@ describe('LSP', function()
         'å å ɧ 汉语 ↥ 🤦 🦄';
       }, buf_lines(1))
     end)
+    it('applies empty edits', function()
+      local edits = {
+        make_edit(0, 0, 0, 2, {""});
+        make_edit(1, 1, 1, 3, {""});
+        make_edit(4, 3, 4, 5, {""});
+        make_edit(4, 8, 4, 10, {""});
+      }
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      eq({
+        'rst line of text';
+        'Sond line of text';
+        'Third line of text';
+        'Fourth line of text';
+        'å ɧ 汉↥ 🤦 🦄';
+      }, buf_lines(1))
+    end)
     it('applies complex edits', function()
       local edits = {
         make_edit(0, 0, 0, 0, {"", "12"});


### PR DESCRIPTION
When an LSP server sends an edit where the newText is an empty string `""`, `vim.split` returned an empty table which caused an error.

I discovered this when running the `organizeImports` code action on a Go file using `gopls`. The case was that I had imported `fmt` and `sync` in a file but in the wrong order. `gopls` (and `goimports´) want `fmt` to come before `sync` in the import statement, and `gopls` sent back four edits:

1. Replace `sync` with empty string on the first line
2. Write `fmt` within the now empty `""` on the first line
3. Replace `fmt` on the second line with empty string
4. Write `sync` within the now empty `""` on the first line

Those edits failed in `vim.lsp.util.set_lines` and was caused by `vim.split` on an empty string returning an empty table.

There are other bugs here but this was the easiest to fix. I'll look at the others as well.