### PR TITLE
eval: fix assertion failure in garbage collection

### DIFF
--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -364,7 +364,7 @@ static int _TYPVAL_ENCODE_CONVERT_ONE_VALUE(
       _TYPVAL_ENCODE_DO_CHECK_SELF_REFERENCE(tv->vval.v_list, lv_copyID, copyID,
                                              kMPConvList);
       TYPVAL_ENCODE_CONV_LIST_START(tv, tv_list_len(tv->vval.v_list));
-      assert(saved_copyID != copyID && saved_copyID != copyID - 1);
+      assert(saved_copyID != copyID);
       _mp_push(*mpstack, ((MPConvStackVal) {
         .type = kMPConvList,
         .tv = tv,

--- a/test/functional/eval/let_spec.lua
+++ b/test/functional/eval/let_spec.lua
@@ -75,4 +75,19 @@ describe(':let', function()
     command(cmd_get_child_env)
     eq(eval('$NVIM_TEST'), eval('g:env_from_child'))
   end)
+
+  it("release of list assigned to l: variable does not trigger assertion #12387, #12430", function()
+    source([[
+      func! s:f()
+        let l:x = [1]
+        let g:x = l:
+      endfunc
+      for _ in range(2)
+        call s:f()
+      endfor
+      call garbagecollect()
+      call feedkeys('i', 't')
+    ]])
+    eq(1, eval('1'))
+  end)
 end)


### PR DESCRIPTION
fixes #12387, #12430

Lists with `CopyID+1` linked only from `previous_funccal` may be removed in the garbage collection. Therefore, the terms of the assertions are not correct. This can be confirmed by the following (The `l:x` with `CopyID+1` of the first function call needs to be removed by garbage collection):

```vim
func! s:f()
  let l:x = [1]
  let g:x = l:
endfunc

for _ in range(2)
  call s:f()
endfor
call garbagecollect()
```