### PR TITLE
Refactor Python provider detection and health checks

### DIFF
--- a/runtime/autoload/provider/python3.vim
+++ b/runtime/autoload/provider/python3.vim
@@ -7,11 +7,15 @@
 if exists('g:loaded_python3_provider')
   finish
 endif
-let [s:prog, s:err] = provider#pythonx#Detect(3)
+let [s:prog, s:ver, s:err] = provider#pythonx#Detect(3)
 let g:loaded_python3_provider = empty(s:prog) ? 1 : 2
 
 function! provider#python3#Prog() abort
   return s:prog
+endfunction
+
+function! provider#python3#Version() abort
+  return s:ver
 endfunction
 
 function! provider#python3#Error() abort
@@ -24,7 +28,7 @@ call remote#host#RegisterClone('legacy-python3-provider', 'python3')
 call remote#host#RegisterPlugin('legacy-python3-provider', 'script_host.py', [])
 
 function! provider#python3#Call(method, args) abort
-  if s:err != ''
+  if !empty(s:err)
     return
   endif
   if !exists('s:host')

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -4,6 +4,7 @@ if exists('s:loaded_pythonx_provider')
 endif
 
 let s:loaded_pythonx_provider = 1
+let s:min_version = '3.7'
 
 function! provider#pythonx#Require(host) abort
   " Python host arguments
@@ -20,43 +21,84 @@ function! provider#pythonx#Require(host) abort
   return provider#Poll(args, a:host.orig_name, '$NVIM_PYTHON_LOG_FILE', {'overlapped': v:true})
 endfunction
 
-function! s:get_python_executable_from_host_var(major_version) abort
-  return expand(get(g:, 'python'.(a:major_version == 3 ? '3' : execute("throw 'unsupported'")).'_host_prog', ''), v:true)
+" Turn a path with a host-specific directory separator into Vim's
+" comma-separated format.
+function! s:to_comma_separated_path(path) abort
+  if has('win32')
+    let path_sep = ';'
+    " remove backslashes at the end of path items, they would turn into \, and
+    " escape the , which globpath() expects as path separator
+    let path = substitute(a:path, '\\\+;', ';', 'g')
+  else
+    let path_sep = ':'
+    let path = a:path
+  endif
+
+  " escape existing commas, so that they remain part of the individual paths
+  let path = substitute(path, ',', '\\,', 'g')
+
+  " deduplicate path items, otherwise globpath() returns even more duplicate
+  " matches for some reason
+  let already_seen = {}
+  let path_list = []
+  for item in split(path, path_sep)
+    if !has_key(already_seen, item)
+      let already_seen[item] = v:true
+      call add(path_list, item)
+    endif
+  endfor
+
+  return join(path_list, ',')
 endfunction
 
-function! s:get_python_candidates(major_version) abort
-  return {
-        \ 3: ['python3', 'python3.10', 'python3.9', 'python3.8', 'python3.7', 'python']
-        \ }[a:major_version]
+" Returns a list of all Python executables found on path. a:convert specifies
+" whether the path to search needs to be converted from a host-specific
+" separator to the comma-separated format expected by globpath().
+function! provider#pythonx#GetPythonCandidates(major_version, path, convert) abort
+  let path = a:convert ? s:to_comma_separated_path(a:path) : a:path
+  let starts_with_python = globpath(path, 'python*', v:true, v:true)
+  let ext_pat = has('win32') ? '(\\.exe)?' : ''
+  let matches_version = printf('v:val =~# "\\v[\\/]python(%d(\\.[0-9]+)?)?%s$"', a:major_version, ext_pat)
+  return filter(starts_with_python, matches_version)
 endfunction
 
-" Returns [path_to_python_executable, error_message]
+" Returns [path_to_python_executable, python_version, error_messages]
 function! provider#pythonx#Detect(major_version) abort
   return provider#pythonx#DetectByModule('neovim', a:major_version)
 endfunction
 
-" Returns [path_to_python_executable, error_message]
+" Returns [path_to_python_executable, python_version, error_messages]
 function! provider#pythonx#DetectByModule(module, major_version) abort
-  let python_exe = s:get_python_executable_from_host_var(a:major_version)
-
-  if !empty(python_exe)
-    return [exepath(expand(python_exe, v:true)), '']
-  endif
-
-  let candidates = s:get_python_candidates(a:major_version)
+  let host_prog = 'python'.(a:major_version == 3 ? '3' : '').'_host_prog'
+  let python_exe = get(g:, host_prog, '')
   let errors = []
 
+  if !empty(python_exe)
+    let candidates = [exepath(expand(python_exe, v:true))]
+    call add(errors, 'The g:'.host_prog.' you set cannot be used.')
+  else
+    let candidates = provider#pythonx#GetPythonCandidates(a:major_version, $PATH, v:true)
+  endif
+
+  if empty(candidates)
+    call add(errors, 'No candidates for a Python '.a:major_version.' executable found on $PATH.')
+  endif
+
   for exe in candidates
-    let [result, error] = provider#pythonx#CheckForModule(exe, a:module, a:major_version)
+    let [result, python_version, error] = provider#pythonx#CheckForModule(exe, a:module, a:major_version)
     if result
-      return [exe, error]
+      " If result, then discard any errors: for one thing, if one of the
+      " candidates works, let's not add potentially confusing noise to health
+      " reports. For another, some code might rely on the absence of errors as
+      " a signal that everything went well (e.g. Nvim's own test suite does).
+      return [exe, python_version, []]
     endif
     " Accumulate errors in case we don't find any suitable Python executable.
     call add(errors, error)
   endfor
 
   " No suitable Python executable found.
-  return ['', 'Could not load Python '.a:major_version.":\n".join(errors, "\n")]
+  return ['', '', errors]
 endfunction
 
 " Returns array: [prog_exitcode, prog_version]
@@ -64,50 +106,41 @@ function! s:import_module(prog, module) abort
   let prog_version = system([a:prog, '-c' , printf(
         \ 'import sys; ' .
         \ 'sys.path = [p for p in sys.path if p != ""]; ' .
-        \ 'sys.stdout.write(str(sys.version_info[0]) + "." + str(sys.version_info[1])); ' .
+        \ 'sys.stdout.write(".".join(str(x) for x in sys.version_info[:3])); ' .
         \ 'import pkgutil; ' .
-        \ 'exit(2*int(pkgutil.get_loader("%s") is None))',
+        \ 'sys.exit(2*int(pkgutil.get_loader("%s") is None))',
         \ a:module)])
   return [v:shell_error, prog_version]
 endfunction
 
-" Returns array: [was_success, error_message]
-function! provider#pythonx#CheckForModule(prog, module, major_version) abort
-  let prog_path = exepath(a:prog)
-  if prog_path ==# ''
-    return [0, a:prog . ' not found in search path or not executable.']
-  endif
+function! s:satisfies_version(target, ref_major, ref_minimum) abort
+  return a:target =~# '^' . a:ref_major . '\(\.\|$\)'
+        \ && luaeval('vim.version_cmp(_A[1], _A[2]) >= 0', [a:target, a:ref_minimum])
+endfunction
 
-  let min_version = '3.7'
+" Returns array: [was_success, python_version, error_message]
+function! provider#pythonx#CheckForModule(prog_path, module, major_version) abort
 
   " Try to load module, and output Python version.
   " Exit codes:
   "   0  module can be loaded.
   "   2  module cannot be loaded.
   "   Otherwise something else went wrong (e.g. 1 or 127).
-  let [prog_exitcode, prog_version] = s:import_module(a:prog, a:module)
+  let [prog_exitcode, prog_version] = s:import_module(a:prog_path, a:module)
 
-  if prog_exitcode == 2 || prog_exitcode == 0
-    " Check version only for expected return codes.
-    if prog_version !~ '^' . a:major_version
-      return [0, prog_path . ' is Python ' . prog_version . ' and cannot provide Python '
-            \ . a:major_version . '.']
-    elseif prog_version =~ '^' . a:major_version && str2nr(prog_version[2:]) < str2nr(min_version[2:])
-      return [0, prog_path . ' is Python ' . prog_version . ' and cannot provide Python >= '
-            \ . min_version . '.']
-    endif
+  " Check version only for expected return codes.
+  if (prog_exitcode == 2 || prog_exitcode == 0) && !s:satisfies_version(prog_version, a:major_version, s:min_version)
+    return [0, '', a:prog_path . ' is Python ' . prog_version . ' and cannot provide Python '
+          \ . a:major_version . ' >= ' . s:min_version . '.']
   endif
 
   if prog_exitcode == 2
-    return [0, prog_path.' does not have the "' . a:module . '" module.']
-  elseif prog_exitcode == 127
-    " This can happen with pyenv's shims.
-    return [0, prog_path . ' does not exist: ' . prog_version]
+    return [0, '', a:prog_path.' does not have the "' . a:module . '" module.']
   elseif prog_exitcode
-    return [0, 'Checking ' . prog_path . ' caused an unknown error. '
-          \ . '(' . prog_exitcode . ', output: ' . prog_version . ')'
-          \ . ' Report this at https://github.com/neovim/neovim']
+    return [0, '', 'Checking ' . a:prog_path . ' exited with error code ' . prog_exitcode . '. '
+          \ . 'If running the same executable from the command line works fine, report this at '
+          \ . "https://github.com/neovim/neovim. This was the output:\n\n" . prog_version . "\n"]
   endif
 
-  return [1, '']
+  return [1, prog_version, '']
 endfunction

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1970,6 +1970,37 @@ validate({opt})                                               *vim.validate()*
                     returned value.
                   • msg: (optional) error string if validation fails
 
+version_cmp({ver1}, {ver2}, {strict})                      *vim.version_cmp()*
+    Compare two version strings.
+
+    Parameters: ~
+      • {ver1}    (string) Version string 1
+      • {ver2}    (string) Version string 2
+      • {strict}  (boolean|nil) If `true`, semver strings are expected;
+                  otherwise, just dotted numbers, possibly with junk at the
+                  end
+
+    Return: ~
+        (number) 1 if `ver1` is greater, -1 if it's smaller, 0 otherwise
+        (table) Parsed `ver1`
+        (table) Parsed `ver2`
+
+    See also: ~
+        |vim.version_parse()|
+
+version_parse({ver}, {strict})                           *vim.version_parse()*
+    Parse a version string into a table.
+
+    Parameters: ~
+      • {ver}     (string) Version string
+      • {strict}  (boolean|nil) If `true`, a semver string is expected;
+                  otherwise, just dotted numbers, possibly with junk at the
+                  end
+
+    Return: ~
+        (table) Table with keys `major`, `minor`, `patch`, `pre` and `build`
+        if `strict`, otherwise with numerical indices
+
 
 ==============================================================================
 Lua module: uri                                                      *lua-uri*

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -873,7 +873,7 @@ function module.missing_provider(provider)
     return e ~= '' and e or false
   elseif provider == 'python' or provider == 'python3' then
     local py_major_version = (provider == 'python3' and 3 or 2)
-    local e = module.funcs['provider#pythonx#Detect'](py_major_version)[2]
+    local e = table.concat(module.funcs['provider#pythonx#Detect'](py_major_version)[3], "\n")
     return e ~= '' and e or false
   else
     assert(false, 'Unknown provider: '..provider)


### PR DESCRIPTION
This is a follow-up on #11781, where I noted that [`s:check_python` may be unnecessarily complicated](https://github.com/neovim/neovim/pull/11781#issuecomment-579313377) (see https://github.com/neovim/neovim/issues/11753#issuecomment-578715584 for details) and asked whether there'd be interest in simplifying it. @justinmk said [yes, "as long as it results in a net reduction of code, and not a lot of indirection"](https://github.com/neovim/neovim/pull/11781#issuecomment-581191973).

Looking at the diff stats, the elephant in the room is that I actually ended up adding more code than I removed, but this is primarily because I ended up implementing reusable version comparison, including unit tests (see below). Hopefully adding tested code is less of a problem :) And if maintainers decide it should be removed, the PR will turn into a net reduction.

I realize there are quite a lot of code changes here and I'm obviously very open to feedback and dialing down on some of these ideas. I just thought they would be easier to discuss if I actually made the changes, rather than suggest / theorize about them. Please don't take this as an outsider stomping all over the codebase and lacking respect; take this as a conversation starter :)

### Demo and motivation

The main goal was to remove existing gnarliness and branching in Python provider detection and health checks, which currently leads to both false positives and false negatives.

Say you have the following setup:

```console
$ python3 -m venv venv
$ source venv/bin/activate
(venv) $ pip install pynvim
(venv) $ nvim -u NORC +'let g:python_host_prog = "python3" | checkhealth provider'
```

Installing `pynvim` inside the virtualenv simulates suboptimal setup for Python 3; setting the Python 2 host prog to `python3` simulates having an interpreter which doesn't satisfy version requirements.

Currently, this is the health check output:

![image](https://user-images.githubusercontent.com/2734517/83871946-520c5f00-a731-11ea-95ec-9c44e181b0ce.png)

The Python 2 provider gets set to a Python 3 interpreter (which can presumably break things) and just a warning is issued; the virtualenv problem slips by undetected (even though there is currently an error message for this type of situation, it just doesn't get triggered correctly).

With this PR, the health check would look something like this:

![image](https://user-images.githubusercontent.com/2734517/83871710-d6aaad80-a730-11ea-8107-984c24e1a95d.png)

Trying to set a Python 3 interpreter as the Python 2 provider becomes a hard error; the virtualenv problem is reported on.

### High-level overview

`provider/pythonx`:

- shouldn't have a hardcoded list of Python executable names as possible candidates, it's a maintenance burden because new versions have to be added as they're released, and until they are, the provider will fail to detect them, which is inconvenient for early adopters of new Python releases who are on stable Neovim
- it should instead consider all viable candidates found on the `$PATH`, i.e. *not* just the first one: if the first `python3` found on the `$PATH` can't `import neovim`, it makes sense to try the remaining ones as well
- it should also return the full path to the provider interpreter (if one is successfully found) as well as its version, since it already has to determine them anyway

Then, `s:check_python` in `health/provider`:

- can entirely avoid having to figure out the full path to the provider interpreter on its own, which is error-prone and previously involved logic which didn't quite match that in `provider/pythonx`
- it can also avoid having to figure out the Python version (which is not that error-prone, but why do it twice)
- it can instead just focus on presenting correct troubleshooting messages

Additionally:

- I don't think Neovim should make a special effort to troubleshoot `pyenv`. It's hard to keep diagnostics in sync with a third-party tool. All that matters is getting a working Python binary (of the correct version); if `pyenv` shims get in the way, it's *their* job to fail with informative output, which they generally do, and Neovim makes sure the user sees it, which should be enough.
- I noticed some broken ad-hoc version comparisons while refactoring (using either vanilla string comparison or float/int conversions), so I decided to add a slightly more robust and reusable version comparison function to `lua-stdlib` and use that instead.

  When I was part way through implementing it, I noticed that a `s:version_cmp` function was used for this purpose in other places. I still saw benefit in having a public, more feature complete function with unit tests for this purpose, so I went ahead and finished it, and replaced `s:version_cmp` with it. This is very much up for debate though, of course.

I'm happy to discuss all of this further, either in this main thread or in threads attached to particular pieces of code.