### PR TITLE
lsp: do not process diagnostics for unloaded buffers

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -72,6 +72,17 @@ M['textDocument/publishDiagnostics'] = function(_, _, result)
     err_message("LSP.publishDiagnostics: Couldn't find buffer for ", uri)
     return
   end
+
+  -- Unloaded buffers should not handle diagnostics.
+  --    When the buffer is loaded, we'll call on_attach, which sends textDocument/didOpen.
+  --    This should trigger another publish of the diagnostics.
+  --
+  -- In particular, this stops a ton of spam when first starting a server for current
+  -- unloaded buffers.
+  if not api.nvim_buf_is_loaded(bufnr) then
+    return
+  end
+
   util.buf_clear_diagnostics(bufnr)
 
   -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic


### PR DESCRIPTION
This seems to work and doesn't prevent diagnostics getting loaded for the current buffer.

This prevents diagnostics from being run for all possible buffers (which means loading all possible buffers) on startup.

cc @clason 