### PR TITLE
LSP: add optional vertical padding, maximal size to floats

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -637,12 +637,12 @@ function M._trim_and_pad(contents, opts)
   end
   if opts.pad_top then
     for _ = 1, opts.pad_top do
-      table.insert(contents,1,"")
+      table.insert(contents, 1, "")
     end
   end
   if opts.pad_bottom then
     for _ = 1, opts.pad_bottom do
-      table.insert(contents,"")
+      table.insert(contents, "")
     end
   end
   return contents

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -662,6 +662,8 @@ end
 --             - height    of floating window
 --             - width     of floating window
 --             - wrap_at   character to wrap at for computing height
+--             - max_width  maximal width of floating window
+--             - max_height maximal height of floating window
 --             - pad_left   number of columns to pad contents at left
 --             - pad_right  number of columns to pad contents at right
 --             - pad_top    number of lines to pad contents at top
@@ -776,6 +778,8 @@ end
 --             - height  of floating window
 --             - width   of floating window
 --             - wrap_at character to wrap at for computing height
+--             - max_width  maximal width of floating window
+--             - max_height maximal height of floating window
 --@return width,height size of float
 function M._make_floating_popup_size(contents, opts)
   validate {
@@ -786,6 +790,9 @@ function M._make_floating_popup_size(contents, opts)
 
   local width = opts.width
   local height = opts.height
+  local wrap_at = opts.wrap_at
+  local max_width = opts.max_width
+  local max_height = opts.max_height
   local line_widths = {}
 
   if not width then
@@ -796,11 +803,14 @@ function M._make_floating_popup_size(contents, opts)
       width = math.max(line_widths[i], width)
     end
   end
+  if max_width then
+    width = math.min(width, max_width)
+    wrap_at = math.min(wrap_at, max_width)
+  end
 
   if not height then
     height = #contents
-    local wrap_at = opts.wrap_at
-    if wrap_at and width > wrap_at then
+    if wrap_at and width >= wrap_at then
       height = 0
       if vim.tbl_isempty(line_widths) then
         for _, line in ipairs(contents) do
@@ -814,6 +824,9 @@ function M._make_floating_popup_size(contents, opts)
       end
     end
   end
+  if max_height then
+    height = math.min(height, max_height)
+  end
 
   return width, height
 end
@@ -826,6 +839,8 @@ end
 --             - height    of floating window
 --             - width     of floating window
 --             - wrap_at   character to wrap at for computing height
+--             - max_width  maximal width of floating window
+--             - max_height maximal height of floating window
 --             - pad_left   number of columns to pad contents at left
 --             - pad_right  number of columns to pad contents at right
 --             - pad_top    number of lines to pad contents at top

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -618,8 +618,10 @@ end
 ---
 --@param contents table of lines to trim and pad
 --@param opts dictionary with optional fields
---             - pad_left  amount of columns to pad contents at left (default 1)
---             - pad_right amount of columns to pad contents at right (default 1)
+--             - pad_left   number of columns to pad contents at left (default 1)
+--             - pad_right  number of columns to pad contents at right (default 1)
+--             - pad_top    number of lines to pad contents at top (default 0)
+--             - pad_bottom number of lines to pad contents at bottom (default 0)
 --@return contents table of trimmed and padded lines
 function M._trim_and_pad(contents, opts)
   validate {
@@ -632,6 +634,16 @@ function M._trim_and_pad(contents, opts)
   contents = M.trim_empty_lines(contents)
   for i, line in ipairs(contents) do
     contents[i] = string.format('%s%s%s', left_padding, line:gsub("\r", ""), right_padding)
+  end
+  if opts.pad_top then
+    for _ = 1, opts.pad_top do
+      table.insert(contents,1,"")
+    end
+  end
+  if opts.pad_bottom then
+    for _ = 1, opts.pad_bottom do
+      table.insert(contents,"")
+    end
   end
   return contents
 end
@@ -650,8 +662,10 @@ end
 --             - height    of floating window
 --             - width     of floating window
 --             - wrap_at   character to wrap at for computing height
---             - pad_left  amount of columns to pad contents at left
---             - pad_right amount of columns to pad contents at right
+--             - pad_left   number of columns to pad contents at left
+--             - pad_right  number of columns to pad contents at right
+--             - pad_top    number of lines to pad contents at top
+--             - pad_bottom number of lines to pad contents at bottom
 --             - separator insert separator after code block
 --@return width,height size of float
 function M.fancy_floating_markdown(contents, opts)
@@ -795,7 +809,7 @@ function M._make_floating_popup_size(contents, opts)
         end
       else
         for i = 1, #contents do
-          height = height + math.ceil(line_widths[i]/wrap_at)
+          height = height + math.max(1,math.ceil(line_widths[i]/wrap_at))
         end
       end
     end
@@ -812,8 +826,10 @@ end
 --             - height    of floating window
 --             - width     of floating window
 --             - wrap_at   character to wrap at for computing height
---             - pad_left  amount of columns to pad contents at left
---             - pad_right amount of columns to pad contents at right
+--             - pad_left   number of columns to pad contents at left
+--             - pad_right  number of columns to pad contents at right
+--             - pad_top    number of lines to pad contents at top
+--             - pad_bottom number of lines to pad contents at bottom
 --@return bufnr,winnr buffer and window number of floating window or nil
 function M.open_floating_preview(contents, filetype, opts)
   validate {

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -819,7 +819,7 @@ function M._make_floating_popup_size(contents, opts)
         end
       else
         for i = 1, #contents do
-          height = height + math.max(1,math.ceil(line_widths[i]/wrap_at))
+          height = height + math.max(1, math.ceil(line_widths[i]/wrap_at))
         end
       end
     end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -805,7 +805,7 @@ function M._make_floating_popup_size(contents, opts)
   end
   if max_width then
     width = math.min(width, max_width)
-    wrap_at = math.min(wrap_at, max_width)
+    wrap_at = math.min(wrap_at or max_width, max_width)
   end
 
   if not height then


### PR DESCRIPTION
As requested in #12441, this allows adding vertical padding to floating windows (defaulting for none to preserve current behavior) as well as `max_width` and `max_height` options. You can use this globally for hover by, e.g., putting the following (lua code) in you `init.vim`:
```lua
vim.lsp.callbacks['textDocument/hover'] = function(_, method, result)
  util.focusable_float(method, function()
    if not (result and result.contents) then
      -- return { 'No information available' }
      return
    end
    local markdown_lines = util.convert_input_to_markdown_lines(result.contents)
    markdown_lines = util.trim_empty_lines(markdown_lines)
    if vim.tbl_isempty(markdown_lines) then
      -- return { 'No information available' }
      return
    end
    local bufnr, winnr = util.fancy_floating_markdown(markdown_lines, {
      pad_left = 1; pad_right = 1;
      pad_top = 1; pad_bottom = 1; -- add this line for vertical padding
      max_width = 80; -- add this line to set the maximal width of hover float
    })
    util.close_preview_autocmd({"CursorMoved", "BufHidden", "InsertCharPre"}, winnr)
    return bufnr, winnr
  end)
end
```

(There's an additional fix to the `_make_floatin_popup_size` function that makes sure that empty lines are counted properly for the purposes of computing the height.)