### PR TITLE
Fix shada write error on exit, vim-patch:8.2.0920

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2676,6 +2676,13 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer,
       if (name == NULL) {
         break;
       }
+      switch (vartv.v_type) {
+        case VAR_FUNC:
+        case VAR_PARTIAL:
+          continue;
+        default:
+          break;
+      }
       typval_T tgttv;
       tv_copy(&vartv, &tgttv);
       ShaDaWriteResult spe_ret;

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2679,7 +2679,30 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer,
       switch (vartv.v_type) {
         case VAR_FUNC:
         case VAR_PARTIAL:
+          tv_clear(&vartv);
           continue;
+        case VAR_DICT:
+          {
+            dict_T *di = vartv.vval.v_dict;
+            int copyID = get_copyID();
+            if (!set_ref_in_ht(&di->dv_hashtab, copyID, NULL)
+                && copyID == di->dv_copyID) {
+              tv_clear(&vartv);
+              continue;
+            }
+            break;
+          }
+        case VAR_LIST:
+          {
+            list_T *l = vartv.vval.v_list;
+            int copyID = get_copyID();
+            if (!set_ref_in_list(l, copyID, NULL)
+                && copyID == l->lv_copyID) {
+              tv_clear(&vartv);
+              continue;
+            }
+            break;
+          }
         default:
           break;
       }

--- a/test/functional/shada/errors_spec.lua
+++ b/test/functional/shada/errors_spec.lua
@@ -1,7 +1,7 @@
 -- ShaDa errors handling support
 local helpers = require('test.functional.helpers')(after_each)
-local nvim_command, eq, exc_exec, redir_exec =
-  helpers.command, helpers.eq, helpers.exc_exec, helpers.redir_exec
+local nvim_command, eq, exc_exec =
+  helpers.command, helpers.eq, helpers.exc_exec
 
 local shada_helpers = require('test.functional.shada.helpers')
 local reset, clear, get_shada_rw =
@@ -492,15 +492,6 @@ $
     eq('Vim(rshada):E576: Error while reading ShaDa file: last entry specified that it occupies 47 bytes, but file ended earlier', exc_exec(sdrcmd()))
     eq('Vim(wshada):E576: Error while reading ShaDa file: last entry specified that it occupies 47 bytes, but file ended earlier', exc_exec('wshada ' .. shada_fname))
     eq(0, exc_exec('wshada! ' .. shada_fname))
-  end)
-
-  it('errors when a self-referencing list is stored in a variable', function()
-    nvim_command('let L = []')
-    nvim_command('call add(L, L)')
-    nvim_command('set shada+=!')
-    eq('\nE5005: Unable to dump variable g:L: container references itself in index 0'
-       .. '\nE574: Failed to write variable L',
-       redir_exec('wshada'))
   end)
 
   it('errors with too large items', function()

--- a/test/functional/shada/errors_spec.lua
+++ b/test/functional/shada/errors_spec.lua
@@ -494,14 +494,6 @@ $
     eq(0, exc_exec('wshada! ' .. shada_fname))
   end)
 
-  it('errors when a funcref is stored in a variable', function()
-    nvim_command('let F = function("tr")')
-    nvim_command('set shada+=!')
-    eq('\nE5004: Error while dumping variable g:F, itself: attempt to dump function reference'
-       .. '\nE574: Failed to write variable F',
-       redir_exec('wshada'))
-  end)
-
   it('errors when a self-referencing list is stored in a variable', function()
     nvim_command('let L = []')
     nvim_command('call add(L, L)')

--- a/test/functional/shada/variables_spec.lua
+++ b/test/functional/shada/variables_spec.lua
@@ -1,7 +1,7 @@
 -- ShaDa variables saving/reading support
 local helpers = require('test.functional.helpers')(after_each)
-local meths, funcs, nvim_command, eq, exc_exec =
-  helpers.meths, helpers.funcs, helpers.command, helpers.eq, helpers.exc_exec
+local meths, funcs, nvim_command, eq =
+  helpers.meths, helpers.funcs, helpers.command, helpers.eq
 
 local shada_helpers = require('test.functional.shada.helpers')
 local reset, clear = shada_helpers.reset, shada_helpers.clear
@@ -145,16 +145,15 @@ describe('ShaDa support code', function()
     eq('10', meths.get_var('U'))
   end)
 
-  it('errors and writes when a self-referencing list is stored in a variable',
+  it('ignore when a self-referencing list is stored in a variable',
   function()
     meths.set_var('L', {})
     nvim_command('call add(L, L)')
     meths.set_var('U', '10')
     nvim_command('set shada+=!')
-    eq('Vim(wshada):E5005: Unable to dump variable g:L: container references itself in index 0',
-       exc_exec('wshada'))
-    meths.set_option('shada', '')
-    reset('set shada+=!')
+    nvim_command('wshada')
+    reset()
+    nvim_command('rshada')
     eq('10', meths.get_var('U'))
   end)
 end)

--- a/test/functional/shada/variables_spec.lua
+++ b/test/functional/shada/variables_spec.lua
@@ -121,15 +121,27 @@ describe('ShaDa support code', function()
        meths.get_var('NESTEDVAR'))
   end)
 
-  it('errors and writes when a funcref is stored in a variable',
+  it('ignore when a funcref is stored in a variable',
   function()
     nvim_command('let F = function("tr")')
     meths.set_var('U', '10')
     nvim_command('set shada+=!')
-    eq('Vim(wshada):E5004: Error while dumping variable g:F, itself: attempt to dump function reference',
-       exc_exec('wshada'))
-    meths.set_option('shada', '')
-    reset('set shada+=!')
+    nvim_command('wshada')
+    reset()
+    nvim_command('set shada+=!')
+    nvim_command('rshada')
+    eq('10', meths.get_var('U'))
+  end)
+
+  it('ignore when a partial is stored in a variable',
+  function()
+    nvim_command('let P = { -> 1 }')
+    meths.set_var('U', '10')
+    nvim_command('set shada+=!')
+    nvim_command('wshada')
+    reset()
+    nvim_command('set shada+=!')
+    nvim_command('rshada')
     eq('10', meths.get_var('U'))
   end)
 


### PR DESCRIPTION
```vim
nvim -u NORC
:func! Test() abort
:endfunc
:let F1 = function('Test')
:let F2  = funcref('Test')
:let P = { -> 1}
:wshada
E5004: Error while dumping variable g:F1, itself: attempt to dump function reference
E574: Failed to write variable F1
E5004: Error while dumping variable g:P, itself: attempt to dump function reference
E574: Failed to write variable P
E5004: Error while dumping variable g:F2, itself: attempt to dump function reference
E574: Failed to write variable F2
```

```vim
nvim -u NORC
:let L = []
:let D = { 'list' : L }
:call add(L, D)
:wshada
E5005: Unable to dump variable g:L: container references itself in index 0, key 'list'
E574: Failed to write variable L
E5005: Unable to dump variable g:D: container references itself in key 'list', index 0
E574: Failed to write variable D
```