### PR TITLE
Fix #12449: textDocumentSync.save can be boolean

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -897,7 +897,8 @@ function protocol.resolve_capabilities(server_capabilities)
         text_document_will_save = ifnil(textDocumentSync.willSave, false);
         text_document_will_save_wait_until = ifnil(textDocumentSync.willSaveWaitUntil, false);
         text_document_save = ifnil(textDocumentSync.save, false);
-        text_document_save_include_text = ifnil(textDocumentSync.save and textDocumentSync.save.includeText, false);
+        text_document_save_include_text = ifnil(type(textDocumentSync.save) == 'table'
+                                                and textDocumentSync.save.includeText, false);
       }
     else
       return nil, string.format("Invalid type for textDocumentSync: %q", type(textDocumentSync))


### PR DESCRIPTION
Fix #12449: textDocumentSync.save can be boolean instead of a table. In this case, we assume text_document_save_include_text == false

https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#textDocument_didSave