### PR TITLE
[WIP] Native clipboard support

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -16,8 +16,8 @@ if(WIN32)
   # tell MinGW compiler to enable wmain
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation")
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework CoreFoundation")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework AppKit")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework AppKit")
 endif()
 
 set(TOUCHES_DIR ${PROJECT_BINARY_DIR}/touches)
@@ -114,6 +114,10 @@ foreach(subdir
   list(APPEND NVIM_SOURCES ${sources})
   list(APPEND NVIM_HEADERS ${headers})
 endforeach()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  list(APPEND NVIM_SOURCES ${PROJECT_SOURCE_DIR}/src/nvim/os/clipboard_macos.m)
+endif()
 
 file(GLOB UNIT_TEST_FIXTURES ${PROJECT_SOURCE_DIR}/test/unit/fixtures/*.c)
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -16,7 +16,7 @@ if(WIN32)
   # tell MinGW compiler to enable wmain
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework AppKit")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework AppKit")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework AppKit")
 endif()
 

--- a/src/nvim/os/clipboard.h
+++ b/src/nvim/os/clipboard.h
@@ -1,0 +1,42 @@
+#ifndef NVIM_OS_CLIPBOARD_H
+#define NVIM_OS_CLIPBOARD_H
+
+#include <stddef.h>
+
+#include "nvim/normal.h"
+#include "nvim/types.h"
+
+#ifdef __APPLE__
+#define CLIPBOARD_NATIVE
+#endif
+
+/// Return value of clipboard_get
+typedef struct {
+  char_u *text;       ///< UTF-8 encoded text
+  size_t length;      ///< Length of text in bytes
+  MotionType regtype; ///< The register type
+} ClipboardData;
+
+/// clipboard_init - Intialize the clipboard subsystem.
+void clipboard_init(void);
+
+/// clipboard_get - Get the system clipboard.
+///
+/// @param[out] data Out data parameter. Contains the clipboard data on success.
+///                  Untouched if an error occurrs. Note: Text is allocated on
+///                  the heap. The caller takes ownership of this pointer and
+///                  should free it when done.
+///
+/// @returns true on success, false if an error occurred.
+bool clipboard_get(ClipboardData *data);
+
+/// clipboard_set - Set the system clipboard.
+///
+/// @param regname The register name ('*' or '+')
+/// @param regtype The register type
+/// @param lines Pointer to an array of line pointers
+/// @param numlines The number of lines in lines array
+void clipboard_set(char regname, MotionType regtype,
+                   char_u **lines, size_t numlines);
+
+#endif // NVIM_OS_CLIPBOARD_H

--- a/src/nvim/os/clipboard_macos.m
+++ b/src/nvim/os/clipboard_macos.m
@@ -86,7 +86,7 @@ bool clipboard_get(ClipboardData *data)
     if ([available isEqual:NVimPasteboardType]) {
       // This should be an array with two objects:
       //   1. Motion type (NSNumber)
-	    //   2. Text (NSString)
+      //   2. Text (NSString)
       //
       // If this is not the case we fall back on using NSPasteboardTypeString.
       NSArray *plist = [pasteboard propertyListForType:NVimPasteboardType];

--- a/src/nvim/os/clipboard_macos.m
+++ b/src/nvim/os/clipboard_macos.m
@@ -1,0 +1,158 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+#import <AppKit/NSPasteboard.h>
+
+#include "nvim/types.h"
+#include "nvim/memory.h"
+
+// HACK: We need to avoid including nvim/normal.h because it transitively
+//       includes nvim/api/private/defs.h which defines a Boolean type.
+//       Unfortunately Apple's system headers define an incompatible Boolean
+//       type with the same spelling. Instead of including nvim/normal.h, we
+//       will duplicate the required definitions here. This shouldn't be too
+//       much of a maintenance burden as the MotionType enum is stable.
+typedef enum {
+  kMTCharWise = 0,
+  kMTLineWise = 1,
+  kMTBlockWise = 2,
+  kMTUnknown = -1
+} MotionType;
+
+// We also need to duplicate the definitions in nvim/os/clipboard.h.
+// Note: These should remain in sync!
+typedef struct {
+  char_u *text;
+  size_t length;
+  MotionType regtype;
+} ClipboardData;
+
+bool clipboard_get(ClipboardData *data);
+
+void clipboard_set(char regname, MotionType regtype,
+                   char_u **lines, size_t numlines);
+
+// This constant is shared with Vim to preserve copying and pasting
+// compatibility. Do not change!
+static NSString * const NVimPasteboardType = @"VimPboardType";
+
+static inline void clear_clipboard_data(ClipboardData *data) {
+  data->text = NULL;
+  data->length = 0;
+  data->regtype = kMTUnknown;
+}
+
+static bool set_clipboard_data(ClipboardData *data,
+                               int regtype, NSString *string)
+{
+  if (regtype != kMTCharWise &&
+      regtype != kMTLineWise &&
+      regtype != kMTBlockWise) {
+    regtype = kMTUnknown;
+  }
+
+  size_t length = [string lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+
+  if (!length) {
+    clear_clipboard_data(data);
+    return true;
+  }
+
+  char_u *text = xmalloc(length + 1);
+  BOOL converted = [string getCString:(char*)text
+                            maxLength:length + 1
+                             encoding:NSUTF8StringEncoding];
+
+  if (!converted) {
+    xfree(text);
+    return false;
+  }
+  
+  data->text = text;
+  data->length = length;
+  data->regtype = regtype;
+
+  return true;
+}
+
+bool clipboard_get(ClipboardData *data)
+{
+  @autoreleasepool {
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    NSArray *supportedTypes = @[NVimPasteboardType, NSPasteboardTypeString];
+
+    NSString *available = [pasteboard availableTypeFromArray:supportedTypes];
+
+    if ([available isEqual:NVimPasteboardType]) {
+      // This should be an array with two objects:
+      //   1. Motion type (NSNumber)
+	    //   2. Text (NSString)
+      //
+      // If this is not the case we fall back on using NSPasteboardTypeString.
+      NSArray *plist = [pasteboard propertyListForType:NVimPasteboardType];
+
+      if ([plist isKindOfClass:[NSArray class]] && [plist count] == 2 &&
+          [plist[0] isKindOfClass:[NSNumber class]] &&
+          [plist[1] isKindOfClass:[NSString class]]) {
+        return set_clipboard_data(data, [plist[0] intValue], plist[1]);
+      }
+    }
+
+    NSString *string = [pasteboard stringForType:NSPasteboardTypeString];
+
+    if (!string) {
+      clear_clipboard_data(data);
+      return true;
+    }
+
+    NSMutableString *mstring = [string mutableCopy];
+    NSRange range = NSMakeRange(0, [string length]);
+
+    // Replace unrecognized end-of-line sequences with \x0a (line feed)
+    NSUInteger replaced = [mstring replaceOccurrencesOfString:@"\x0d\x0a"
+                                                   withString:@"\x0a"
+                                                      options:0
+                                                        range:range];
+
+    if (replaced == 0) {
+      [mstring replaceOccurrencesOfString:@"\x0d"
+                               withString:@"\x0a"
+                                  options:0
+                                    range:range];
+    }
+
+    return set_clipboard_data(data, kMTUnknown, mstring);
+  }
+}
+
+void clipboard_set(char regname, MotionType regtype,
+                   char_u **lines, size_t numlines)
+{
+  @autoreleasepool {
+    // Unused on MacOS. No selection / clipboard distinction.
+    (void)regname;
+    
+    NSMutableString *string =
+      [[NSMutableString alloc] initWithCapacity:numlines * 80];
+    
+    for (size_t i=0; i<numlines; ++i) {
+      NSString *line = [NSString stringWithUTF8String:(const char*)lines[i]];
+      [string appendString:line];
+      [string appendString:@"\n"];
+    }
+    
+    // Remove the trailing new line character in character wise yanks
+    if (regtype == kMTCharWise) {
+      [string deleteCharactersInRange:NSMakeRange([string length] - 1,1)];
+    }
+    
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    NSArray *supportedTypes = @[NVimPasteboardType, NSPasteboardTypeString];
+    NSArray *plist = @[[NSNumber numberWithInt:regtype], string];
+
+    [pasteboard declareTypes:supportedTypes owner:nil];
+    [pasteboard setPropertyList:plist forType:NVimPasteboardType];
+    [pasteboard setString:string forType:NSPasteboardTypeString];
+  }
+}
+


### PR DESCRIPTION
# Problem:

The current provider based clipboard integration, while being very flexible, has a few major disadvantages:
  1. It's slow. Creating processes is slow (especially on Windows and MacOS).
  2. Block pasting does not work correctly out of the box.
  3. It's yet another finicky configuration point.

# Proposal:

A simple clipboard API that is implemented for Windows, MacOS, X11, and Wayland. The proposed API consists of three functions:

1. Init -  Called early in the startup process, allows the clipboard subsystem an opportunity to initialize. This may not be needed on some platforms, in which case it's a no-op.

2. Get - Blocking synchronous access to the system clipboard. Returns a string and a register type. Internally, we use `str_to_register` to set the appropriate register.

3. Set - Sets the system clipboard. This is done in a way that preserves the register type for other Neovim and Vim processes (required for block pasting to work correctly).

The spellings and prototypes for each function are up for discussion. Feedback appreciated.

 **Project Layout:**
`os/clipboard.h` - API definitions.
`os/clipboard_macos.m` - Implementation for MacOS.
`os/clipboard_win.c` - Implementation for Windows.
`os/clipbaord_unix.c` - Implementation for X11 and Wayland.

We use the build system to conditionally compile each platforms implementation. A special note for Unix: One of Neovim's goals is to have single build for each platform, to support this we can include both an X11 and Wayland implementation on Linux.

This pull request includes an initial draft of the proposed API in `os/clipbaord.h` and an implementation for MacOS in `os/clipboard_macos.m`. Block pasting works across processes and is compatible with Vim (closing https://github.com/neovim/neovim/issues/1822).

The next easiest platform to get up and running is Windows, we can implement the clipboard API fairly easily using the win32 API. Linux will be more challenging, but it's doable.

Once we have basic clipboard support working across the platforms, we can look into reviving `clipboard=autoselect`.
