### PR TITLE
lsp: Cleanup of lsp log output

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -761,8 +761,12 @@ do
   text_document_did_change_handler = function(_, bufnr, changedtick,
       firstline, lastline, new_lastline, old_byte_size, old_utf32_size,
       old_utf16_size)
-    local _ = log.debug() and log.debug("on_lines", bufnr, changedtick, firstline,
-    lastline, new_lastline, old_byte_size, old_utf32_size, old_utf16_size, nvim_buf_get_lines(bufnr, firstline, new_lastline, true))
+
+    local _ = log.debug() and log.debug(
+      string.format("on_lines bufnr: %s, changedtick: %s, firstline: %s, lastline: %s, new_lastline: %s, old_byte_size: %s, old_utf32_size: %s, old_utf16_size: %s",
+      bufnr, changedtick, firstline, lastline, new_lastline, old_byte_size, old_utf32_size, old_utf16_size),
+      nvim_buf_get_lines(bufnr, firstline, new_lastline, true)
+    )
 
     -- Don't do anything if there are no clients attached.
     if tbl_isempty(all_buffer_active_clients[bufnr] or {}) then

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -376,7 +376,6 @@ local function start(cmd, cmd_args, handlers, extra_spawn_params)
   --@param params (table): Parameters for the invoked LSP method
   --@returns (bool) `true` if notification could be sent, `false` if not
   local function notify(method, params)
-    local _ = log.debug() and log.debug("rpc.notify", method, params)
     return encode_and_send {
       jsonrpc = "2.0";
       method = method;


### PR DESCRIPTION
- Since "rpc.send.payload" outputs the log with almost the same contents, delete the output.
- Unless we look at the code every time, we will not know what the log value is, so add the key name.
