### PR TITLE
lsp: even if contents before change is 0 byte, request to server

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -586,9 +586,7 @@ do
       old_utf16_size)
     local _ = log.debug() and log.debug("on_lines", bufnr, changedtick, firstline,
     lastline, new_lastline, old_byte_size, old_utf32_size, old_utf16_size, nvim_buf_get_lines(bufnr, firstline, new_lastline, true))
-    if old_byte_size == 0 then
-      return
-    end
+
     -- Don't do anything if there are no clients attached.
     if tbl_isempty(all_buffer_active_clients[bufnr] or {}) then
       return


### PR DESCRIPTION
fix: https://github.com/neovim/neovim/issues/12414

In the example issue, this is happening because rustfmt deleted all the contents in the buffer once and then did not send the result of the formatting to the server.