### PR TITLE
Fix ignored LSP tests

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1380,13 +1380,21 @@ describe('LSP', function()
     end)
   end)
 
-  it('lsp.util._make_floating_popup_size', function()
-    exec_lua [[ contents =
-    {"text tαxt txtα tex",
-    "text tααt tααt text",
-    "text tαxt tαxt"}
-    ]]
-    eq({19,3}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents)} ]])
-    eq({15,5}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents,{width = 15, wrap_at = 14})} ]])
+  describe('lsp.util._make_floating_popup_size', function()
+    before_each(function()
+      exec_lua [[ contents =
+      {"text tαxt txtα tex",
+      "text tααt tααt text",
+      "text tαxt tαxt"}
+      ]]
+    end)
+
+    it('calculates size correctly', function()
+      eq({19,3}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents)} ]])
+    end)
+
+    it('calculates size correctly with wrapping', function()
+      eq({15,5}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents,{width = 15, wrap_at = 14})} ]])
+    end)
   end)
 end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1232,7 +1232,7 @@ describe('LSP', function()
         ]])
       end)
     end)
-    describe('convert SymbolInformation[] to items', function()
+    it('convert SymbolInformation[] to items', function()
         local expected = {
           {
             col = 1,
@@ -1296,11 +1296,11 @@ describe('LSP', function()
   end)
 
   describe('lsp.util._get_completion_item_kind_name', function()
-    describe('returns the name specified by protocol', function()
+    it('returns the name specified by protocol', function()
       eq("Text", exec_lua("return vim.lsp.util._get_completion_item_kind_name(1)"))
       eq("TypeParameter", exec_lua("return vim.lsp.util._get_completion_item_kind_name(25)"))
     end)
-    describe('returns the name not specified by protocol', function()
+    it('returns the name not specified by protocol', function()
       eq("Unknown", exec_lua("return vim.lsp.util._get_completion_item_kind_name(nil)"))
       eq("Unknown", exec_lua("return vim.lsp.util._get_completion_item_kind_name(vim.NIL)"))
       eq("Unknown", exec_lua("return vim.lsp.util._get_completion_item_kind_name(1000)"))
@@ -1308,11 +1308,11 @@ describe('LSP', function()
   end)
 
   describe('lsp.util._get_symbol_kind_name', function()
-    describe('returns the name specified by protocol', function()
+    it('returns the name specified by protocol', function()
       eq("File", exec_lua("return vim.lsp.util._get_symbol_kind_name(1)"))
       eq("TypeParameter", exec_lua("return vim.lsp.util._get_symbol_kind_name(26)"))
     end)
-    describe('returns the name not specified by protocol', function()
+    it('returns the name not specified by protocol', function()
       eq("Unknown", exec_lua("return vim.lsp.util._get_symbol_kind_name(nil)"))
       eq("Unknown", exec_lua("return vim.lsp.util._get_symbol_kind_name(vim.NIL)"))
       eq("Unknown", exec_lua("return vim.lsp.util._get_symbol_kind_name(1000)"))
@@ -1380,7 +1380,7 @@ describe('LSP', function()
     end)
   end)
 
-  describe('lsp.util._make_floating_popup_size', function()
+  it('lsp.util._make_floating_popup_size', function()
     exec_lua [[ contents =
     {"text tαxt txtα tex",
     "text tααt tααt text",


### PR DESCRIPTION
While working on e1d7ae7c5857038718167bfc1da6a0e809fdf4cb, I noticed that some of the tests in `test/functional/plugin/lsp_spec.lua` aren't being run because the leaves of the spec tree were `describe`s instead of `it`s. This PR makes sure these six additional tests are run. If they were disabled intentionally in this way, please ignore it.