### PR TITLE
[RDY] Add buffer information to tabline_update

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -631,11 +631,13 @@ Tabline Events							   *ui-tabline*
 
 Activated by the `ext_tabline` |ui-option|.
 
-["tabline_update", curtab, tabs]
+["tabline_update", curtab, tabs, curbuf, buffers]
 	Tabline was updated. UIs should present this data in a custom tabline
-	widget.
-	curtab:	  Current Tabpage
-	tabs:	  List of Dicts [{ "tab": Tabpage, "name": String }, ...]
+	widget. Note: options `curbuf` + `buffers` were added in API7.
+	curtab:   Current Tabpage
+	tabs:     List of Dicts [{ "tab": Tabpage, "name": String }, ...]
+	curbuf:   Current buffer handle.
+	buffers:  List of Dicts [{ "buffer": buffer handle, "name": String}, ...]
 
 ==============================================================================
 Cmdline Events							   *ui-cmdline*

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -130,7 +130,8 @@ void popupmenu_hide(void)
 void popupmenu_select(Integer selected)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
-void tabline_update(Tabpage current, Array tabs)
+void tabline_update(Tabpage current, Array tabs,
+                    Buffer current_buffer, Array buffers)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
 void cmdline_show(Array content, Integer pos, String firstc, String prompt,

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7211,7 +7211,24 @@ void ui_ext_tabline_update(void)
 
     ADD(tabs, DICTIONARY_OBJ(tab_info));
   }
-  ui_call_tabline_update(curtab->handle, tabs);
+
+  Array buffers = ARRAY_DICT_INIT;
+  FOR_ALL_BUFFERS(buf) {
+    // Do not include unlisted buffers
+    if (!buf->b_p_bl) {
+      continue;
+    }
+
+    Dictionary buffer_info = ARRAY_DICT_INIT;
+    PUT(buffer_info, "buffer", BUFFER_OBJ(buf->handle));
+
+    get_trans_bufname(buf);
+    PUT(buffer_info, "name", STRING_OBJ(cstr_to_string((char *)NameBuff)));
+
+    ADD(buffers, DICTIONARY_OBJ(buffer_info));
+  }
+
+  ui_call_tabline_update(curtab->handle, tabs, curbuf->handle, buffers);
 }
 
 /*

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -4,14 +4,17 @@ local clear, command, eq = helpers.clear, helpers.command, helpers.eq
 
 describe('ui/ext_tabline', function()
   local screen
-  local event_tabs, event_curtab
+  local event_tabs, event_curtab, event_curbuf, event_buffers
 
   before_each(function()
     clear()
     screen = Screen.new(25, 5)
     screen:attach({rgb=true, ext_tabline=true})
-    function screen:_handle_tabline_update(curtab, tabs)
-      event_curtab, event_tabs = curtab, tabs
+    function screen:_handle_tabline_update(curtab, tabs, curbuf, buffers)
+      event_curtab = curtab
+      event_tabs = tabs
+      event_curbuf = curbuf
+      event_buffers = buffers
     end
   end)
 
@@ -43,6 +46,40 @@ describe('ui/ext_tabline', function()
     ]], condition=function()
       eq({ id = 1 }, event_curtab)
       eq(expected_tabs, event_tabs)
+    end}
+  end)
+
+  it('buffer UI events', function()
+    local expected_buffers_initial= {
+      {buffer = { id = 1 }, name = '[No Name]'},
+    }
+
+    screen:expect{grid=[[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+                               |
+    ]], condition=function()
+      eq({ id = 1}, event_curbuf)
+      eq(expected_buffers_initial, event_buffers)
+    end}
+
+    command("badd another-buffer")
+    command("bnext")
+
+    local expected_buffers = {
+      {buffer = { id = 2 }, name = 'another-buffer'},
+    }
+    screen:expect{grid=[[
+      ^                         |
+      ~                        |
+      ~                        |
+      ~                        |
+                               |
+    ]], condition=function()
+      eq({ id = 2 }, event_curbuf)
+      eq(expected_buffers, event_buffers)
     end}
   end)
 end)


### PR DESCRIPTION
I have noticed many users disable `ext_tabline` because it does not behave as they expect. I would like send buffer and tab information in `tabline_update` events. This would allow GUIs to provide feature parity with tabline plugins and give users with the behavior they expect.

With `ext_tabline` alone, I cannot write a GUI equivalent to `vim-airline`:
![image](https://user-images.githubusercontent.com/11207308/84558799-676e2400-ad03-11ea-9da7-9b43cb24440f.png)

This is a proof of concept for `neovim-qt` displaying buffers and tabs:
![neovim-qt with GUI buffers and tabs](https://user-images.githubusercontent.com/11207308/84558842-d3508c80-ad03-11ea-88b5-ee0cdcc311cf.png)
![neovim-qt with buffers as GUI tabs](https://user-images.githubusercontent.com/11207308/84558981-0d6e5e00-ad05-11ea-8869-03ca016e3c3f.png)

https://github.com/jgehrig/neovim-qt/commit/d9f2ca172f12b888e2a28fcc331b1bc24e0fa694

I imagine I could hack this information out of the Neovim API, or perhaps leverage `ext_multigrid` to accomplish similar behavior. However, I think there is value in such a minimal and backwards compatible expansion to the existing `tabline_update` API.

If anyone is open to this change, I can address any feedback and get a corresponding consumer merged into `neovim-qt`.