### PR TITLE
[RDY] man.vim: Simplify man#init to reduce load time

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -7,22 +7,10 @@ let s:loaded_man = 1
 
 let s:find_arg = '-w'
 let s:localfile_arg = v:true  " Always use -l if possible. #6683
-let s:section_arg = '-s'
+let s:section_arg = '-S'
 
-function! s:init_section_flag()
-  call system(['env', 'MANPAGER=cat', 'man', s:section_arg, '1', 'man'])
-  if v:shell_error
-    let s:section_arg = '-S'
-  endif
-endfunction
-
-function! s:init() abort
-  call s:init_section_flag()
-  " TODO(nhooyr): Does `man -l` on SunOS list searched directories?
+function! man#init() abort
   try
-    if !has('win32') && $OSTYPE !~? 'cygwin\|linux' && system('uname -s') =~? 'SunOS' && system('uname -r') =~# '^5'
-      let s:find_arg = '-l'
-    endif
     " Check for -l support.
     call s:get_page(s:get_path('', 'man'))
   catch /E145:/
@@ -139,7 +127,7 @@ function! s:get_page(path) abort
   " Disable hard-wrap by using a big $MANWIDTH (max 1000 on some systems #9065).
   " Soft-wrap: ftplugin/man.vim sets wrap/breakindent/….
   " Hard-wrap: driven by `man`.
-  let manwidth = !get(g:,'man_hardwrap', 1) ? 999 : (empty($MANWIDTH) ? winwidth(0) : $MANWIDTH)
+  let manwidth = !get(g:, 'man_hardwrap', 1) ? 999 : (empty($MANWIDTH) ? winwidth(0) : $MANWIDTH)
   " Force MANPAGER=cat to ensure Vim is not recursively invoked (by man-db).
   " http://comments.gmane.org/gmane.editors.vim.devel/29085
   " Set MAN_KEEP_FORMATTING so Debian man doesn't discard backspaces.
@@ -418,4 +406,4 @@ function! man#goto_tag(pattern, flags, info) abort
   \  })
 endfunction
 
-call s:init()
+call man#init()


### PR DESCRIPTION
I removed the SunOS stuff since no one uses SunOS and I've never tested
it on there.

I removed the section_flag init as we can just use -S instead of -s
and -S is used by every implementation as far as I know.

This brings man#init's time from 50-70ms to 20ms for me.

Updates #12318
Related #6766
Related #6815

Perhaps we can make it 0 if we find a way to avoid checking for
the -l flag.