### PR TITLE
man.vim: Remove q mapping when not in MANPAGER mode

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -402,6 +402,13 @@ function! s:format_candidate(path, psect) abort
 endfunction
 
 function! man#init_pager() abort
+  if exists('b:man_pager')
+    " Already inited, occurs as init_pager is called in syntax/man.vim
+    " and ftplugin/man.vim
+    return
+  endif
+  let b:man_pager = 1
+
   " https://github.com/neovim/neovim/issues/6828
   let og_modifiable = &modifiable
   setlocal modifiable
@@ -425,6 +432,12 @@ function! man#init_pager() abort
   endif
 
   let &l:modifiable = og_modifiable
+endfunction
+
+" We're in pager mode if at some point init_pager was ran
+" or !exists('b:man_sect').
+function! man#is_pager() abort
+  return exists('b:man_pager') || !exists('b:man_sect')
 endfunction
 
 function! man#goto_tag(pattern, flags, info) abort

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -6,9 +6,7 @@ if exists('b:did_ftplugin') || &filetype !=# 'man'
 endif
 let b:did_ftplugin = 1
 
-let s:pager = !exists('b:man_sect')
-
-if s:pager
+if man#is_pager()
   call man#init_pager()
 endif
 
@@ -27,10 +25,9 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> j          gj
   nnoremap <silent> <buffer> k          gk
   nnoremap <silent> <buffer> gO         :call man#show_toc()<CR>
-  if s:pager
+
+  if man#is_pager()
     nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
-  else
-    nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c
   endif
 endif
 

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -27,7 +27,7 @@ if &filetype != 'man'
   finish
 endif
 
-if !exists('b:man_sect')
+if man#is_pager()
   call man#init_pager()
 endif
 

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -12,6 +12,7 @@ describe(':Man', function()
       command('syntax on')
       command('set filetype=man')
       command('syntax off')  -- Ignore syntax groups
+      command('unlet! b:man_pager') -- Allow man#init_pager to rerun
       screen = Screen.new(52, 5)
       screen:set_default_attr_ids({
         b = { bold = true },


### PR DESCRIPTION
Closes #12409