### PR TITLE
lsp: when applying text edits, set buflisted on buffers

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -119,6 +119,7 @@ function M.apply_text_edits(text_edits, bufnr)
   if not api.nvim_buf_is_loaded(bufnr) then
     vim.fn.bufload(bufnr)
   end
+  api.nvim_buf_set_option(bufnr, 'buflisted', true)
   local start_line, finish_line = math.huge, -1
   local cleaned = {}
   for i, e in ipairs(text_edits) do


### PR DESCRIPTION
The client creates buffers on the fly to be able to apply text edits on
files that weren't previously open, which is great, but it uses the
bufadd() function, which creates unlisted buffers and can lead to a
weird experience in the text editor. Setting the buffer to buflisted
fixes this.

Closes #12488.