### PR TITLE
[RDY] Fix incsearch highlighting disappearing when redrawing from timer

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -11,6 +11,7 @@
 #include "nvim/cursor.h"
 #include "nvim/diff.h"
 #include "nvim/edit.h"
+#include "nvim/ex_getln.h"
 #include "nvim/eval.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
@@ -120,8 +121,11 @@ void changed(void)
   }
   buf_inc_changedtick(curbuf);
 
-  // If a pattern is highlighted, the position may now be invalid.
-  highlight_match = false;
+  // If a pattern is highlighted, the position may now be invalid. Clear
+  // highlighting except when in incsearch.
+  if (highlight_match) {
+    highlight_match = is_incsearch_active();
+  }
 }
 
 /// Internal part of changed(), no user interaction.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -5781,10 +5781,9 @@ int get_cmdline_type(void)
   return p->cmdfirstc;
 }
 
-/*
- * Returns whether incsearch is active.
- */
-bool is_incsearch_active(void) {
+// Returns whether incsearch is active.
+bool is_incsearch_active(void)
+{
   if (!p_is) {
     return false;
   }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5719,12 +5719,20 @@ void grid_puts_line_flush(bool set_cursor)
  */
 static void start_search_hl(void)
 {
-  if (p_hls && !no_hlsearch) {
-    end_search_hl();  // just in case it wasn't called before
-    last_pat_prog(&search_hl.rm);
-    // Set the time limit to 'redrawtime'.
-    search_hl.tm = profile_setlimit(p_rdt);
+  if (!p_hls) {
+    return;
   }
+
+  if (is_incsearch_active()) {
+    set_no_hlsearch(false);
+  } else if (no_hlsearch) {
+    return;
+  }
+
+  end_search_hl();  // just in case it wasn't called before
+  last_pat_prog(&search_hl.rm);
+  // Set the time limit to 'redrawtime'.
+  search_hl.tm = profile_setlimit(p_rdt);
 }
 
 /*

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -510,12 +510,12 @@ void set_last_search_pat(const char_u *s, int idx, int magic, int setlast)
 void last_pat_prog(regmmatch_T *regmatch)
 {
   char_u *pat;
-  bool incsearch_active = is_incsearch_active();
+  bool should_show_incsearch = cmdwin_type == 0 && is_incsearch_active();
 
-  if (incsearch_active &&
+  if (should_show_incsearch &&
       highlight_match && incsearch_pattern != NULL) {
     pat = incsearch_pattern;
-  } else if (incsearch_active || spats[last_idx].pat == NULL) {
+  } else if (should_show_incsearch || spats[last_idx].pat == NULL) {
     regmatch->regprog = NULL;
     return;
   } else {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -336,7 +336,8 @@ void restore_last_search_pattern(void)
 }
 
 // Sets the current search pattern to the incsearch pattern.
-void save_incsearch_pattern(void) {
+void save_incsearch_pattern(void)
+{
   if (incsearch_pattern != NULL) {
     xfree(incsearch_pattern);
   }
@@ -347,7 +348,8 @@ void save_incsearch_pattern(void) {
   }
 }
 
-void clear_incsearch_pattern(void) {
+void clear_incsearch_pattern(void)
+{
   if (incsearch_pattern != NULL) {
     xfree(incsearch_pattern);
     incsearch_pattern = NULL;
@@ -512,8 +514,8 @@ void last_pat_prog(regmmatch_T *regmatch)
   char_u *pat;
   bool should_show_incsearch = cmdwin_type == 0 && is_incsearch_active();
 
-  if (should_show_incsearch &&
-      highlight_match && incsearch_pattern != NULL) {
+  if (should_show_incsearch
+      && highlight_match && incsearch_pattern != NULL) {
     pat = incsearch_pattern;
   } else if (should_show_incsearch || spats[last_idx].pat == NULL) {
     regmatch->regprog = NULL;
@@ -521,9 +523,9 @@ void last_pat_prog(regmmatch_T *regmatch)
   } else {
     pat = NULL;
   }
-  ++emsg_off;           /* So it doesn't beep if bad expr */
+  emsg_off++;           // So it doesn't beep if bad expr
   (void)search_regcomp(pat, 0, last_idx, SEARCH_KEEP, regmatch);
-  --emsg_off;
+  emsg_off--;
 }
 
 /// lowest level search function.


### PR DESCRIPTION
Redrawing from a timer clears temporary highlights when a floating window needs to be redrawn. Temporary highlights here refers to highlights applied when performing a `/` search when `incsearch` is active. This issue is not unique to floating windows, any action that would invalidate highlighting will have the same issue.

This PR only fixes the issue for the `Search` highlights, `IncSearch` needs a separate fix.

Minimal `init.vim`:
```vim
let s:height = 1
let s:win = nvim_open_win(0, 0,
      \ {'relative': 'editor', 'height': 1, 'width': 1, 'row': 0, 'col': 0})

function! Foo() abort
  let s:height = 3 - s:height
  call nvim_win_set_config(s:win, {'height': s:height})
  redraw
endfunction

autocmd CmdlineChanged * call timer_start(0, {-> Foo()})
```
Open a file and do a search to match something in the file. The search highlights will either flash temporarily on the screen or not be appear.

This is somewhat similar to https://github.com/vim/vim/issues/3694, but the redrawing mechanism between Vim and Neovim has diverged quite a bit. The gist behind both issues are the same - (some) temporary highlights are not preserved when redrawing from a timer.