### PR TITLE
fix hang issue with recoverymode

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -291,6 +291,12 @@ int main(int argc, char **argv)
     fname = get_fname(&params, cwd);
   }
 
+  // Recovery mode without a file name: List swap files.
+  // In this case, no UI is needed.
+  if (recoverymode && fname == NULL) {
+    headless_mode = true;
+  }
+
   TIME_MSG("expanding arguments");
 
   if (params.diff_mode && params.window_count == -1)
@@ -978,7 +984,6 @@ static void command_line_scan(mparm_T *parmp)
         case 'r':    // "-r" recovery mode
         case 'L': {  // "-L" recovery mode
           recoverymode = 1;
-          headless_mode = true;
           break;
         }
         case 's': {


### PR DESCRIPTION
In the case of `recoverymode`, the `headlessmode` was true, causing the UI to hang without starting. Fix this problem by setting `headlessmode` to true for List swap files only.

fixes #12492.