### PR TITLE
lsp: clear references before highlighting new ones

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -211,6 +211,7 @@ end
 M['textDocument/documentHighlight'] = function(_, _, result, _)
   if not result then return end
   local bufnr = api.nvim_get_current_buf()
+  util.buf_clear_references(bufnr)
   util.buf_highlight_references(bufnr, result)
 end
 


### PR DESCRIPTION
Before highlighting the found references, clear the previous highlights.

Closes #12499.