### PR TITLE
 runtime: fix patch syntax/tex.vim

### DIFF
--- a/runtime/syntax/tex.vim
+++ b/runtime/syntax/tex.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:	TeX
 " Maintainer:	Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
-" Last Change:	Jun 07, 2020
-" Version:	118
+" Last Change:	Jun 29, 2020
+" Version:	119
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_TEX
 "
 " Notes: {{{1
@@ -147,6 +147,11 @@ if exists("g:tex_nospell") && g:tex_nospell
 else
  let s:tex_nospell = 0
 endif
+if exists("g:tex_matchcheck")
+ let s:tex_matchcheck= g:tex_matchcheck
+else
+ let s:tex_matchcheck= '[({[]'
+endif
 if exists("g:tex_excludematcher")
  let s:tex_excludematcher= g:tex_excludematcher
 else
@@ -205,27 +210,41 @@ if !exists("g:tex_no_math")
  endif
 endif
 
-" Try to flag {} and () mismatches: {{{1
+" Try to flag {}, [], and () mismatches: {{{1
 if s:tex_fast =~# 'm'
   if !s:tex_no_error
-   syn region texMatcher	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchGroup,texError
-   syn region texMatcher	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchGroup,texError,@NoSpell
-   syn region texMatcherNM	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchNMGroup,texError
-   syn region texMatcherNM	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchNMGroup,texError,@NoSpell
+   if s:tex_matchcheck =~ '{'
+    syn region texMatcher	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchGroup,texError
+    syn region texMatcherNM	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchNMGroup,texError
+   endif
+   if s:tex_matchcheck =~ '\['
+    syn region texMatcher	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchGroup,texError,@NoSpell
+    syn region texMatcherNM	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchNMGroup,texError,@NoSpell
+   endif
   else
-   syn region texMatcher	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchGroup
-   syn region texMatcher	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchGroup
-   syn region texMatcherNM	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchNMGroup
-   syn region texMatcherNM	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchNMGroup
+   if s:tex_matchcheck =~ '{'
+    syn region texMatcher	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchGroup
+    syn region texMatcherNM	matchgroup=Delimiter start="{" skip="\\\\\|\\[{}]"	end="}"			transparent contains=@texMatchNMGroup
+   endif
+   if s:tex_matchcheck =~ '\['
+    syn region texMatcher	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchGroup
+    syn region texMatcherNM	matchgroup=Delimiter start="\["				end="]"			transparent contains=@texMatchNMGroup
+   endif
   endif
-  if !s:tex_nospell
-   syn region texParen		start="("	end=")"								transparent contains=@texMatchGroup,@Spell
-  else
-   syn region texParen		start="("	end=")"								transparent contains=@texMatchGroup
+  if s:tex_matchcheck =~ '('
+   if !s:tex_nospell
+    syn region texParen		start="("	end=")"								transparent contains=@texMatchGroup,@Spell
+   else
+    syn region texParen		start="("	end=")"								transparent contains=@texMatchGroup
+   endif
   endif
 endif
 if !s:tex_no_error
- syn match  texError		"[}\])]"
+ if s:tex_matchcheck =~ '('
+  syn match  texError		"[}\]]"
+ else
+  syn match  texError		"[}\])]"
+ endif
 endif
 if s:tex_fast =~# 'M'
   if !exists("g:tex_no_math")
@@ -756,7 +775,7 @@ if has("conceal") && &enc == 'utf-8'
     \ ['ldots'		, '…'],
     \ ['le'		, '≤'],
     \ ['left|'		, '|'],
-    \ ['left\|'		, '‖'],
+    \ ['left\\|'	, '‖'],
     \ ['left('		, '('],
     \ ['left\['		, '['],
     \ ['left\\{'	, '{'],


### PR DESCRIPTION
Oh well,

alas the patches made in #12497 are not fully correct since a mistake in the original vim repositories.
I already informed the original maintainer Dr Chip.

However this might take a while, so here is my quick fix.