### PR TITLE
lsp: add client.resolved_capabilities.rename

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -912,6 +912,7 @@ function protocol.resolve_capabilities(server_capabilities)
   general_properties.workspace_symbol = server_capabilities.workspaceSymbolProvider or false
   general_properties.document_formatting = server_capabilities.documentFormattingProvider or false
   general_properties.document_range_formatting = server_capabilities.documentRangeFormattingProvider or false
+  general_properties.rename = server_capabilities.renameProvider or false
 
   if server_capabilities.codeActionProvider == nil then
     general_properties.code_action = false


### PR DESCRIPTION
This allows users to query whether the server supports it later on.

renameProvider can be either a boolean or RenameOptions, but the latter is only returned when the client supports prepareRename, which isn't the case currently with neovim. Should I add a note to the code or something like that?