### PR TITLE
Accept modifiers in rust.vim's expand/emit commands

### DIFF
--- a/runtime/autoload/rust.vim
+++ b/runtime/autoload/rust.vim
@@ -80,17 +80,17 @@ endfunction
 
 " Expand {{{1
 
-function! rust#Expand(bang, args)
+function! rust#Expand(bang, args, mods)
 	let args = s:ShellTokenize(a:args)
 	if a:bang && !empty(l:args)
 		let pretty = remove(l:args, 0)
 	else
 		let pretty = "expanded"
 	endif
-	call s:WithPath(function("s:Expand"), pretty, args)
+	call s:WithPath(function("s:Expand", [a:mods]), pretty, args)
 endfunction
 
-function! s:Expand(dict, pretty, args)
+function! s:Expand(mods, dict, pretty, args)
 	try
 		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
@@ -108,7 +108,7 @@ function! s:Expand(dict, pretty, args)
 			echo output
 			echohl None
 		else
-			new
+			exe a:mods "new"
 			silent put =output
 			1
 			d
@@ -149,12 +149,12 @@ endfunction
 
 " Emit {{{1
 
-function! rust#Emit(type, args)
+function! rust#Emit(type, args, mods)
 	let args = s:ShellTokenize(a:args)
-	call s:WithPath(function("s:Emit"), a:type, args)
+	call s:WithPath(function("s:Emit", [a:mods]), a:type, args)
 endfunction
 
-function! s:Emit(dict, type, args)
+function! s:Emit(mods, dict, type, args)
 	try
 		let output_path = a:dict.tmpdir.'/output'
 
@@ -170,7 +170,7 @@ function! s:Emit(dict, type, args)
 			echohl None
 		endif
 		if !v:shell_error
-			new
+			exe a:mods "new"
 			exe 'silent keepalt read' fnameescape(output_path)
 			1
 			d

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -117,13 +117,13 @@ onoremap <silent> <buffer> ]] :call rust#Jump('o', 'Forward')<CR>
 command! -nargs=* -complete=file -bang -buffer RustRun call rust#Run(<bang>0, <q-args>)
 
 " See |:RustExpand| for docs
-command! -nargs=* -complete=customlist,rust#CompleteExpand -bang -buffer RustExpand call rust#Expand(<bang>0, <q-args>)
+command! -nargs=* -complete=customlist,rust#CompleteExpand -bang -buffer RustExpand call rust#Expand(<bang>0, <q-args>, <q-mods>)
 
 " See |:RustEmitIr| for docs
-command! -nargs=* -buffer RustEmitIr call rust#Emit("llvm-ir", <q-args>)
+command! -nargs=* -buffer RustEmitIr call rust#Emit("llvm-ir", <q-args>, <q-mods>)
 
 " See |:RustEmitAsm| for docs
-command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>)
+command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>, <q-mods>)
 
 " See |:RustPlay| for docs
 command! -range=% RustPlay :call rust#Play(<count>, <line1>, <line2>, <f-args>)

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
 " Maintainer:   Kevin Ballard <kevin@sb.org>
 " Last Change:  June 08, 2016
-" For bugs, patches and license go to https://github.com/rust-lang/rust.vim 
+" For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
 	finish


### PR DESCRIPTION
This enables commands like `:vertical RustEmitAsm` to split the new window vertically, and so on.