### PR TITLE
LSP: Add function for formatexpr in lsp.util

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1235,4 +1235,16 @@ trim_empty_lines({lines})                    *vim.lsp.util.trim_empty_lines()*
 try_trim_markdown_code_blocks({lines})
                 TODO: Documentation
 
+validate_lsp_position({pos})            *vim.lsp.util.validate_lsp_position()*
+                TODO: Documentation
+
+                                            *vim.lsp.util.format_formatexpr()*
+format_formatexpr()
+                To use a LSP server with |gq|,
+                set |formatexpr| to this function globally:
+                `set formatexpr = v:lua.vim.lsp.util.format_formatexpr()`
+                or using autocmd
+                `autocmd FileType c setlocal formatexpr=v:lua.vim.lsp.util.format_formatexpr()`
+
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1238,13 +1238,19 @@ try_trim_markdown_code_blocks({lines})
 validate_lsp_position({pos})            *vim.lsp.util.validate_lsp_position()*
                 TODO: Documentation
 
-                                            *vim.lsp.util.format_formatexpr()*
-format_formatexpr()
+                                                   *vim.lsp.util.formatexpr()*
+formatexpr({start_line}, {end_line}, {timeout_ms})
+                Formats linewise, runs sync
+
                 To use a LSP server with |gq|,
                 set |formatexpr| to this function globally:
-                `set formatexpr = v:lua.vim.lsp.util.format_formatexpr()`
-                or using autocmd
-                `autocmd FileType c setlocal formatexpr=v:lua.vim.lsp.util.format_formatexpr()`
+                `set formatexpr = v:lua.vim.lsp.util.formatexpr()`
+                or using autocmd:
+                `autocmd FileType c setlocal formatexpr=v:lua.vim.lsp.util.formatexpr()`
 
+                Parameters: ~
+                    {start_line} (optional) 1-indexed
+                    {end_line}   (optional) 1-indexed
+                    {timeout_ms} (optional) passed to |buf_request_sync|
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1353,6 +1353,23 @@ function M.character_offset(buf, row, col)
   return str_utfindex(line, col)
 end
 
+function M.format_formatexpr()
+ -- only reformat on explicit gq command
+ -- `formatexpr` is also called when exceding
+ -- `textwidth` in insert mode
+ if vim.fn.mode() == 'i' or vim.fn.mode() == 'R' then
+    -- fall back to Vims internal reformatting
+    return 1
+ end
+ local start_line = vim.v.lnum
+ local end_line = start_line + vim.v.count - 1
+ if start_line > 0 and end_line > 0 then
+   vim.lsp.buf.range_formatting({}, {start_line, 0}, {end_line, 0})
+ end
+ -- do not run internal formatter.
+ return 0
+end
+
 M.buf_versions = {}
 
 return M


### PR DESCRIPTION
Adds a function in lua.lsp.util that can
be set as `formatexpr` for use with `gq`

Adresses https://github.com/neovim/neovim/issues/12528
@tjdevries any thoughts or pointers?