### PR TITLE
LUA: add options to highlight.on_yank

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -711,16 +711,16 @@ VIM.HIGHLIGHT                  				*lua-highlight*
 Nvim includes a function for highlighting a selection on yank (see for example
 https://github.com/machakann/vim-highlightedyank). To enable it, add
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank()
+ au TextYankPost * silent! vim.highlight.on_yank()
 <
 to your `init.vim`. You can customize the highlight group and the duration of
 the highlight via
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank {higroup="IncSearch", timeout=250}
+ au TextYankPost * silent! vim.highlight.on_yank {higroup="IncSearch", timeout=250}
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank {on_visual=false}
+ au TextYankPost * silent! vim.highlight.on_yank {on_visual=false}
 <
 
 vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -716,11 +716,11 @@ https://github.com/machakann/vim-highlightedyank). To enable it, add
 to your `init.vim`. You can customize the highlight group and the duration of
 the highlight via
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank({higroup="IncSearch", timeout=250})
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank {higroup="IncSearch", timeout=250}
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank({visual=false})
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank {visual=false}
 <
 
 vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -716,21 +716,20 @@ https://github.com/machakann/vim-highlightedyank). To enable it, add
 to your `init.vim`. You can customize the highlight group and the duration of
 the highlight via
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 250)
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank({higroup="IncSearch", timeout=250})
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 250, {visual=false})
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank({visual=false})
 <
 
-vim.highlight.on_yank([{higroup}, {timeout}, {opts}]) 
-                                                    *vim.highlight.on_yank()*
-        Highlights the yanked text. Optional arguments are the highlight group
-        to use ({higroup}, default `"IncSearch"`), the duration of highlighting
-        in milliseconds ({timeout}, default `250`), and a dict with options 
-        controlling the when to highlight ({opts}, containing the fields {visual}
-        (boolean, default `true`), {macro} (boolean, default `false`), and {event}
-        (struct, default `vim.v.event`).
+vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
+        Highlights the yanked text. The fields of the optional dict {opts}
+        control the highlight: the highlight group to use ({higroup}, default
+        `"IncSearch"`), the duration of highlighting in milliseconds
+        ({timeout}, default `250`), whether to highlight a visual selection 
+        ({visual}, default `true`), whether to highlight when executing a macro
+        ({macro}, default `false`), and the {event} (struct, default `vim.v.event`).
 
 vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
                                                        *vim.highlight.range()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -720,16 +720,17 @@ the highlight via
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank {visual=false}
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank {on_visual=false}
 <
 
 vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
         Highlights the yanked text. The fields of the optional dict {opts}
         control the highlight: the highlight group to use ({higroup}, default
         `"IncSearch"`), the duration of highlighting in milliseconds
-        ({timeout}, default `250`), whether to highlight a visual selection 
-        ({visual}, default `true`), whether to highlight when executing a macro
-        ({macro}, default `false`), and the {event} (struct, default `vim.v.event`).
+        ({timeout}, default `250`), whether to highlight a visual selection
+        ({on_visual}, default `true`), whether to highlight when executing a
+        macro ({on_macro}, default `false`), and the {event} (struct, default
+        `vim.v.event`).
 
 vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
                                                        *vim.highlight.range()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -716,7 +716,7 @@ https://github.com/machakann/vim-highlightedyank). To enable it, add
 to your `init.vim`. You can customize the highlight group and the duration of
 the highlight via
 >
- au TextYankPost * silent! lua vim.highlight.on_yank {higroup="IncSearch", timeout=250}
+ au TextYankPost * silent! lua vim.highlight.on_yank {higroup="IncSearch", timeout=150}
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
@@ -727,7 +727,7 @@ vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
         Highlights the yanked text. The fields of the optional dict {opts}
         control the highlight:
           - {higroup} highlight group for yanked region (default `"IncSearch"`)
-          - {timeout} time in ms before highlight is cleared (default `250`)
+          - {timeout} time in ms before highlight is cleared (default `150`)
           - {on_macro} highlight when executing macro (default `false`)
           - {on_visual} highlight when yanking visual selection (default `true`)
           - {event} event structure (default `vim.v.event`)

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -716,18 +716,18 @@ https://github.com/machakann/vim-highlightedyank). To enable it, add
 to your `init.vim`. You can customize the highlight group and the duration of
 the highlight via
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 500)
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 250)
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
- au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 500, {visual=false})
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 250, {visual=false})
 <
 
 vim.highlight.on_yank([{higroup}, {timeout}, {opts}]) 
                                                     *vim.highlight.on_yank()*
         Highlights the yanked text. Optional arguments are the highlight group
         to use ({higroup}, default `"IncSearch"`), the duration of highlighting
-        in milliseconds ({timeout}, default `500`), and a dict with options 
+        in milliseconds ({timeout}, default `250`), and a dict with options 
         controlling the when to highlight ({opts}, containing the fields {visual}
         (boolean, default `true`), {macro} (boolean, default `false`), and {event}
         (struct, default `vim.v.event`).

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -711,26 +711,26 @@ VIM.HIGHLIGHT                  				*lua-highlight*
 Nvim includes a function for highlighting a selection on yank (see for example
 https://github.com/machakann/vim-highlightedyank). To enable it, add
 >
- au TextYankPost * silent! vim.highlight.on_yank()
+ au TextYankPost * silent! lua vim.highlight.on_yank()
 <
 to your `init.vim`. You can customize the highlight group and the duration of
 the highlight via
 >
- au TextYankPost * silent! vim.highlight.on_yank {higroup="IncSearch", timeout=250}
+ au TextYankPost * silent! lua vim.highlight.on_yank {higroup="IncSearch", timeout=250}
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
- au TextYankPost * silent! vim.highlight.on_yank {on_visual=false}
+ au TextYankPost * silent! lua vim.highlight.on_yank {on_visual=false}
 <
 
 vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
         Highlights the yanked text. The fields of the optional dict {opts}
-        control the highlight: the highlight group to use ({higroup}, default
-        `"IncSearch"`), the duration of highlighting in milliseconds
-        ({timeout}, default `250`), whether to highlight a visual selection
-        ({on_visual}, default `true`), whether to highlight when executing a
-        macro ({on_macro}, default `false`), and the {event} (struct, default
-        `vim.v.event`).
+        control the highlight:
+          - {higroup} highlight group for yanked region (default `"IncSearch"`)
+          - {timeout} time in ms before highlight is cleared (default `250`)
+          - {on_macro} highlight when executing macro (default `false`)
+          - {on_visual} highlight when yanking visual selection (default `true`)
+          - {event} event structure (default `vim.v.event`)
 
 vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
                                                        *vim.highlight.range()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -720,16 +720,17 @@ the highlight via
 <
 If you want to exclude visual selections from highlighting on yank, use
 >
-au TextYankPost * silent! lua return (not vim.v.event.visual) and require'vim.highlight'.on_yank()
+ au TextYankPost * silent! lua require'vim.highlight'.on_yank("IncSearch", 500, {visual=false})
 <
 
-vim.highlight.on_yank([{higroup}, {timeout}, {event}]) 
+vim.highlight.on_yank([{higroup}, {timeout}, {opts}]) 
                                                     *vim.highlight.on_yank()*
         Highlights the yanked text. Optional arguments are the highlight group
         to use ({higroup}, default `"IncSearch"`), the duration of highlighting
-        in milliseconds ({timeout}, default `500`), and the event structure 
-        that is fired ({event}, default `vim.v.event`).
-
+        in milliseconds ({timeout}, default `500`), and a dict with options 
+        controlling the when to highlight ({opts}, containing the fields {visual}
+        (boolean, default `true`), {macro} (boolean, default `false`), and {event}
+        (struct, default `vim.v.event`).
 
 vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
                                                        *vim.highlight.range()*
@@ -738,7 +739,6 @@ vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclu
         {ns}. Optional arguments are the type of range (characterwise, linewise,
         or blockwise, see |setreg|; default to characterwise) and whether the
         range is inclusive (default false).
-
 
 ------------------------------------------------------------------------------
 VIM.REGEX							*lua-regex*

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -28,17 +28,19 @@ end
 --- use from init.vim via
 ---   au TextYankPost * lua require'vim.highlight'.on_yank()
 --- customize highlight group and timeout via
----   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 250)
+---   au TextYankPost * lua require'vim.highlight'.on_yank({higroup="IncSearch", timeout=250})
 --- customize conditions (do not highlight a visual selection) via
----   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 250, {visual=false})
+---   au TextYankPost * lua require'vim.highlight'.on_yank({visual=false})
 ---
 -- @param higroup highlight group for yanked region
 -- @param timeout time in ms before highlight is cleared
--- @param opts dictionary with options controlling when to highlight:
---              - macro (bool) when executing macro (default false)
---              - visual (bool) when yanking visual selection (default true)
+-- @param opts dictionary with options controlling the highlight:
+--              - higroup highlight group for yanked region
+--              - timeout time in ms before highlight is cleared
+--              - macro (bool) highlight when executing macro (default false)
+--              - visual (bool) highlight when yanking visual selection (default true)
 --              - event  (struct) event structure (default vim.v.event)
-function highlight.on_yank(higroup, timeout, opts)
+function highlight.on_yank(opts)
   opts = opts or {}
   local event = opts.event or vim.v.event
   local macro = opts.macro or false
@@ -48,8 +50,8 @@ function highlight.on_yank(higroup, timeout, opts)
   if event.operator ~= 'y' or event.regtype == '' then return end
   if (not visual) and event.visual then return end
 
-  higroup = higroup or "IncSearch"
-  timeout = timeout or 250
+  local higroup = opts.higroup or "IncSearch"
+  local timeout = opts.timeout or 250
 
   local bufnr = api.nvim_get_current_buf()
   local yank_ns = api.nvim_create_namespace('')

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -57,7 +57,7 @@ function highlight.on_yank(opts)
   local timeout = opts.timeout or 150
 
   local bufnr = api.nvim_get_current_buf()
-  local yank_ns = api.nvim_create_namespace('')
+  local yank_ns = api.nvim_create_namespace('hlyank')
   api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
 
   local pos1 = vim.fn.getpos("'[")

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -29,13 +29,25 @@ end
 ---   au TextYankPost * lua require'vim.highlight'.on_yank()
 --- customize highlight group and timeout via
 ---   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 500)
+--- customize conditions (do not highlight a visual selection) via
+---   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 500, {visual=false})
 ---
 -- @param higroup highlight group for yanked region
 -- @param timeout time in ms before highlight is cleared
--- @param event event structure
-function highlight.on_yank(higroup, timeout, event)
-  event = event or vim.v.event
+-- @param opts dictionary with options controlling when to highlight:
+--              - macro (bool) when executing macro (default false)
+--              - visual (bool) when yanking visual selection (default true)
+--              - event  (struct) event structure (default vim.v.event)
+function highlight.on_yank(higroup, timeout, opts)
+  opts = opts or {}
+  local event = opts.event or vim.v.event
+  local macro = opts.macro or false
+  local visual = (opts.visual ~= false)
+
+  if (not macro) and vim.fn.reg_executing() ~= '' then return end
   if event.operator ~= 'y' or event.regtype == '' then return end
+  if (not visual) and event.visual then return end
+
   higroup = higroup or "IncSearch"
   timeout = timeout or 500
 

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -26,11 +26,11 @@ end
 --- Highlight the yanked region
 ---
 --- use from init.vim via
----   au TextYankPost * lua require'vim.highlight'.on_yank()
+---   au TextYankPost * lua vim.highlight.on_yank()
 --- customize highlight group and timeout via
----   au TextYankPost * lua require'vim.highlight'.on_yank {higroup="IncSearch", timeout=250}
+---   au TextYankPost * lua vim.highlight.on_yank {higroup="IncSearch", timeout=250}
 --- customize conditions (do not highlight a visual selection) via
----   au TextYankPost * lua require'vim.highlight'.on_yank {visual=false}
+---   au TextYankPost * lua vim.highlight.on_yank {visual=false}
 ---
 -- @param higroup highlight group for yanked region
 -- @param timeout time in ms before highlight is cleared

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -28,9 +28,9 @@ end
 --- use from init.vim via
 ---   au TextYankPost * lua require'vim.highlight'.on_yank()
 --- customize highlight group and timeout via
----   au TextYankPost * lua require'vim.highlight'.on_yank({higroup="IncSearch", timeout=250})
+---   au TextYankPost * lua require'vim.highlight'.on_yank {higroup="IncSearch", timeout=250}
 --- customize conditions (do not highlight a visual selection) via
----   au TextYankPost * lua require'vim.highlight'.on_yank({visual=false})
+---   au TextYankPost * lua require'vim.highlight'.on_yank {visual=false}
 ---
 -- @param higroup highlight group for yanked region
 -- @param timeout time in ms before highlight is cleared

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -29,17 +29,15 @@ end
 ---   au TextYankPost * lua vim.highlight.on_yank()
 --- customize highlight group and timeout via
 ---   au TextYankPost * lua vim.highlight.on_yank {higroup="IncSearch", timeout=250}
---- customize conditions (do not highlight a visual selection) via
----   au TextYankPost * lua vim.highlight.on_yank {visual=false}
+--- customize conditions (here: do not highlight a visual selection) via
+---   au TextYankPost * lua vim.highlight.on_yank {on_visual=false}
 ---
--- @param higroup highlight group for yanked region
--- @param timeout time in ms before highlight is cleared
 -- @param opts dictionary with options controlling the highlight:
---              - higroup highlight group for yanked region
---              - timeout time in ms before highlight is cleared
---              - on_macro (bool) highlight when executing macro (default false)
---              - on_visual (bool) highlight when yanking visual selection (default true)
---              - event  (struct) event structure (default vim.v.event)
+--              - higroup   highlight group for yanked region (default "IncSearch")
+--              - timeout   time in ms before highlight is cleared (default 250)
+--              - on_macro  highlight when executing macro (default false)
+--              - on_visual highlight when yanking visual selection (default true)
+--              - event     event structure (default vim.v.event)
 function highlight.on_yank(opts)
   opts = opts or {}
   local event = opts.event or vim.v.event

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -23,6 +23,7 @@ function highlight.range(bufnr, ns, higroup, start, finish, rtype, inclusive)
 
 end
 
+local yank_ns = api.nvim_create_namespace('hlyank')
 --- Highlight the yanked region
 ---
 --- use from init.vim via
@@ -57,7 +58,6 @@ function highlight.on_yank(opts)
   local timeout = opts.timeout or 150
 
   local bufnr = api.nvim_get_current_buf()
-  local yank_ns = api.nvim_create_namespace('hlyank')
   api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
 
   local pos1 = vim.fn.getpos("'[")

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -37,18 +37,18 @@ end
 -- @param opts dictionary with options controlling the highlight:
 --              - higroup highlight group for yanked region
 --              - timeout time in ms before highlight is cleared
---              - macro (bool) highlight when executing macro (default false)
---              - visual (bool) highlight when yanking visual selection (default true)
+--              - on_macro (bool) highlight when executing macro (default false)
+--              - on_visual (bool) highlight when yanking visual selection (default true)
 --              - event  (struct) event structure (default vim.v.event)
 function highlight.on_yank(opts)
   opts = opts or {}
   local event = opts.event or vim.v.event
-  local macro = opts.macro or false
-  local visual = (opts.visual ~= false)
+  local on_macro = opts.on_macro or false
+  local on_visual = (opts.on_visual ~= false)
 
-  if (not macro) and vim.fn.reg_executing() ~= '' then return end
+  if (not on_macro) and vim.fn.reg_executing() ~= '' then return end
   if event.operator ~= 'y' or event.regtype == '' then return end
-  if (not visual) and event.visual then return end
+  if (not on_visual) and event.visual then return end
 
   local higroup = opts.higroup or "IncSearch"
   local timeout = opts.timeout or 250

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -28,9 +28,9 @@ end
 --- use from init.vim via
 ---   au TextYankPost * lua require'vim.highlight'.on_yank()
 --- customize highlight group and timeout via
----   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 500)
+---   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 250)
 --- customize conditions (do not highlight a visual selection) via
----   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 500, {visual=false})
+---   au TextYankPost * lua require'vim.highlight'.on_yank("IncSearch", 250, {visual=false})
 ---
 -- @param higroup highlight group for yanked region
 -- @param timeout time in ms before highlight is cleared
@@ -49,7 +49,7 @@ function highlight.on_yank(higroup, timeout, opts)
   if (not visual) and event.visual then return end
 
   higroup = higroup or "IncSearch"
-  timeout = timeout or 500
+  timeout = timeout or 250
 
   local bufnr = api.nvim_get_current_buf()
   local yank_ns = api.nvim_create_namespace('')

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -28,13 +28,13 @@ end
 --- use from init.vim via
 ---   au TextYankPost * lua vim.highlight.on_yank()
 --- customize highlight group and timeout via
----   au TextYankPost * lua vim.highlight.on_yank {higroup="IncSearch", timeout=250}
+---   au TextYankPost * lua vim.highlight.on_yank {higroup="IncSearch", timeout=150}
 --- customize conditions (here: do not highlight a visual selection) via
 ---   au TextYankPost * lua vim.highlight.on_yank {on_visual=false}
 ---
 -- @param opts dictionary with options controlling the highlight:
 --              - higroup   highlight group for yanked region (default "IncSearch")
---              - timeout   time in ms before highlight is cleared (default 250)
+--              - timeout   time in ms before highlight is cleared (default 150)
 --              - on_macro  highlight when executing macro (default false)
 --              - on_visual highlight when yanking visual selection (default true)
 --              - event     event structure (default vim.v.event)
@@ -54,7 +54,7 @@ function highlight.on_yank(opts)
   if (not on_visual) and event.visual then return end
 
   local higroup = opts.higroup or "IncSearch"
-  local timeout = opts.timeout or 250
+  local timeout = opts.timeout or 150
 
   local bufnr = api.nvim_get_current_buf()
   local yank_ns = api.nvim_create_namespace('')

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -39,6 +39,11 @@ end
 --              - on_visual highlight when yanking visual selection (default true)
 --              - event     event structure (default vim.v.event)
 function highlight.on_yank(opts)
+  vim.validate {
+    opts = { opts,
+    function(t) if t == nil then return true else return type(t) == 'table' end end,
+    'a table or nil to configure options (see `:h highlight.on_yank`)',
+  }}
   opts = opts or {}
   local event = opts.event or vim.v.event
   local on_macro = opts.on_macro or false

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -288,6 +288,9 @@ local function __index(t, key)
   elseif key == 'lsp' then
     t.lsp = require('vim.lsp')
     return t.lsp
+  elseif key == 'highlight' then
+    t.highlight = require('vim.highlight')
+    return t.highlight
   end
 end
 


### PR DESCRIPTION
closes #12540 (thanks to @kdheepak for the suggestion and for digging up the correct variable to check for this!)

This PR adds an (optional) dictionary argument to the `vim.highlight.on_yank()` function that contains options controlling the highlight:
1. `on_macro` (default false) specifies whether to highlight when executing a macro
2. `on_visual` (default true) specifies whether to highlight when yanking a visual selection (replacing the previously documented approach)
3. `event` (default `vim.v.event`)

The rationale for including the latter (which used to be an optional positional argument) is that a) I still don't see a practical use case for _not_ using `vim.v.event` and hence b) think it shouldn't take up a positional argument (otherwise we'd either have to always specify it when setting options or moving the position of the argument, which would be needlessly breaking).

In a similar vein, I'd actually prefer to move `timeout` and `higroup` into the dictionary as well (in effect, making all arguments keyword arguments) to allow overriding one without having to specify the other, but that would also be a breaking change.  

**EDIT:** All options are now dictionary fields. In addition, `vim.highlight` is now exposed, i.e., you'd do

```viml
au TextYankPost * lua vim.highlight.on_yank {higroup="IncSearch", timeout=250, on_visual=false}
```

While I was at it, I've reduced the default timeout after using this a while and seeing others prefer a shorter timeout, too. Let me know if I should drop that commit.

@tjdevries 