### PR TITLE
LSP: Set current name as default rename text

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -115,7 +115,7 @@ function M.rename(new_name)
   -- TODO(ashkan) use prepareRename
   -- * result: [`Range`](#range) \| `{ range: Range, placeholder: string }` \| `null` describing the range of the string to rename and optionally a placeholder text of the string content to be renamed. If `null` is returned then it is deemed that a 'textDocument/rename' request is not valid at the given position.
   local params = util.make_position_params()
-  new_name = new_name or npcall(vfn.input, "New Name: ")
+  new_name = new_name or npcall(vfn.input, "New Name: ", vfn.expand('<cword>'))
   if not (new_name and #new_name > 0) then return end
   params.newName = new_name
   request('textDocument/rename', params)


### PR DESCRIPTION
Since we don't know what the server considers to be a symbol, `cword` is the best bet in most cases.

Fixes https://github.com/neovim/neovim/issues/12534.