### PR TITLE
Fix LSP completion when applying a `TextEdit` with `newText`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -277,11 +277,9 @@ local function get_completion_word(item, prefix)
   if item.textEdit ~= nil and item.textEdit.newText ~= nil then
     local start_range = item.textEdit.range["start"]
     local end_range = item.textEdit.range["end"]
-    local newText = ""
+    local newText = item.textEdit.newText
     if start_range.line == end_range.line and start_range.character == end_range.character then
-      newText = prefix .. item.textEdit.newText
-    else
-      newText = item.textEdit.newText
+      newText = prefix .. newText
     end
     if protocol.InsertTextFormat[item.insertTextFormat] == "PlainText" then
       return newText

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -273,12 +273,20 @@ end
 -- Returns text that should be inserted when selecting completion item. The precedence is as follows:
 -- textEdit.newText > insertText > label
 -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
-local function get_completion_word(item)
+local function get_completion_word(item, prefix)
   if item.textEdit ~= nil and item.textEdit.newText ~= nil then
-    if protocol.InsertTextFormat[item.insertTextFormat] == "PlainText" then
-      return item.textEdit.newText
+    local start_range = item.textEdit.range["start"]
+    local end_range = item.textEdit.range["end"]
+    local newText = ""
+    if start_range.line == end_range.line and start_range.character == end_range.character then
+      newText = prefix .. item.textEdit.newText
     else
-      return M.parse_snippet(item.textEdit.newText)
+      newText = item.textEdit.newText
+    end
+    if protocol.InsertTextFormat[item.insertTextFormat] == "PlainText" then
+      return newText
+    else
+      return M.parse_snippet(newText)
     end
   elseif item.insertText ~= nil then
     if protocol.InsertTextFormat[item.insertTextFormat] == "PlainText" then
@@ -294,7 +302,7 @@ end
 -- So we exclude completion candidates whose prefix does not match.
 local function remove_unmatch_completion_items(items, prefix)
   return vim.tbl_filter(function(item)
-    local word = get_completion_word(item)
+    local word = get_completion_word(item, prefix)
     return vim.startswith(word, prefix)
   end, items)
 end
@@ -333,7 +341,7 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       end
     end
 
-    local word = get_completion_word(completion_item)
+    local word = get_completion_word(completion_item, prefix)
     table.insert(matches, {
       word = word,
       abbr = completion_item.label,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1021,10 +1021,10 @@ describe('LSP', function()
       local prefix = 'foo'
       local completion_list = {
         -- resolves into label
-        { label='foobar' },
-        { label='foobar', textEdit={} },
+        { label = 'foobar' },
+        { label = 'foobar', textEdit = {} },
       }
-      local completion_list_items = {items=completion_list}
+      local completion_list_items = { items = completion_list }
       local expected = {
         create_compl_item { abbr = 'foobar', word = 'foobar', label = 'foobar' },
         create_compl_item { abbr = 'foobar', word = 'foobar', label = 'foobar', textEdit = {} },
@@ -1041,10 +1041,10 @@ describe('LSP', function()
         { label = 'foocar', insertText = 'foobar' },
         { label = 'foocar', insertText = 'foobar', textEdit = {} },
       }
-      local completion_list_items = {items=completion_list}
+      local completion_list_items = { items = completion_list }
       local expected = {
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText = 'foobar' },
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foobar', textEdit={} },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label = 'foocar', insertText = 'foobar' },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label = 'foocar', insertText = 'foobar', textEdit = {} },
       }
 
       eq(expected, get_completion_list(completion_list, prefix))
@@ -1067,11 +1067,11 @@ describe('LSP', function()
         { label = 'foocar', insertText = 'foodar', textEdit = { newText = 'foobar', range = replaceTextRange } },
         { label = 'foocar', textEdit = { newText = 'bar', range = insertTextRange } },
       }
-      local completion_list_items = {items=completion_list}
+      local completion_list_items = {items = completion_list}
       local expected = {
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit = { newText = 'bar', range = insertTextRange } },
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit = {newText = 'foobar', range = replaceTextRange } },
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', textEdit = { newText = 'bar', range = insertTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label = 'foocar', insertText = 'foodar', textEdit = { newText = 'bar', range = insertTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label = 'foocar', insertText = 'foodar', textEdit = {newText = 'foobar', range = replaceTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label = 'foocar', textEdit = { newText = 'bar', range = insertTextRange } },
       }
 
       eq(expected, get_completion_list(completion_list, prefix))
@@ -1089,7 +1089,7 @@ describe('LSP', function()
         { label = 'foocar', insertText = 'foodar', textEdit = { newText = 'bar(${1:place holder}, ${2:more ...holder{\\}})', range = insertTextRange } },
         { label = 'foocar', insertText = 'foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit = {} },
       }
-      local completion_list_items = {items=completion_list}
+      local completion_list_items = { items = completion_list }
       local expected = {
         create_compl_item { abbr = 'foocar', word = 'foobar(place holder, more ...holder{})', label = 'foocar', insertText = 'foodar', textEdit = { newText = 'bar(${1:place holder}, ${2:more ...holder{\\}})', range = insertTextRange } },
         create_compl_item { abbr = 'foocar', word = 'foodar(var1 typ1, var2 *typ2) {}', label = 'foocar', insertText = 'foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit = {} },
@@ -1120,7 +1120,7 @@ describe('LSP', function()
         -- plain text
         { label = 'foocar', insertText = 'foodar(${1:var1})', insertTextFormat = 1, textEdit = {} },
       }
-      local completion_list_items = {items=completion_list}
+      local completion_list_items = {items = completion_list}
       local expected = {
         create_compl_item { abbr = 'foocar', word = 'foodar(${1:var1})', label = 'foocar', insertText = 'foodar(${1:var1})', insertTextFormat = 1, textEdit = {} },
       }

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -987,6 +987,30 @@ describe('LSP', function()
     end)
   end)
   describe('completion_list_to_complete_items', function()
+    local function create_compl_item(opt)
+        return {
+          abbr = opt.abbr,
+          dup = opt.dup or 1,
+          empty = opt.empty or 1,
+          icase = opt.icase or 1,
+          info = opt.info or ' ',
+          kind = opt.kind or 'Unknown',
+          menu = opt.menu or '',
+          word = opt.word,
+          user_data = {
+            nvim = {
+              lsp = {
+                completion_item = {
+                  label = opt.label,
+                  insertText = opt.insertText,
+                  insertTextFormat = opt.insertTextFormat,
+                  textEdit = opt.textEdit,
+                }
+              }
+            }
+          },
+        }
+    end
     -- Completion option precedence:
     -- textEdit.newText > insertText > label
     -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
@@ -999,8 +1023,8 @@ describe('LSP', function()
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label = 'foobar' } } } } },
-        { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foobar', textEdit={} } } }  } },
+        create_compl_item { abbr = 'foobar', word = 'foobar', label = 'foobar' },
+        create_compl_item { abbr = 'foobar', word = 'foobar', label = 'foobar', textEdit = {} },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
@@ -1016,8 +1040,8 @@ describe('LSP', function()
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foobar' } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foobar', textEdit={} } } } } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText = 'foobar' },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foobar', textEdit={} },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
@@ -1036,15 +1060,15 @@ describe('LSP', function()
       }
       local completion_list = {
         -- resolves into textEdit.newText
-        { label='foocar', insertText='foodar', textEdit={newText='bar', range=insertTextRange} },
-        { label='foocar', insertText='foodar', textEdit={newText='foobar', range=replaceTextRange} },
-        { label='foocar', textEdit={newText='bar', range=insertTextRange} },
+        { label='foocar', insertText='foodar', textEdit = { newText='bar', range=insertTextRange } },
+        { label='foocar', insertText='foodar', textEdit = { newText='foobar', range=replaceTextRange } },
+        { label='foocar', textEdit = { newText = 'bar', range = insertTextRange } },
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='bar', range=insertTextRange} } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='foobar', range=replaceTextRange} } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', textEdit={newText='bar', range=insertTextRange} } } } } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit= { newText = 'bar', range=insertTextRange} },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit = {newText = 'foobar', range = replaceTextRange} },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', textEdit = { newText = 'bar', range=insertTextRange } },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
@@ -1064,8 +1088,8 @@ describe('LSP', function()
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar(place holder, more ...holder{})', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='bar(${1:place holder}, ${2:more ...holder{\\}})', range=insertTextRange} } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foodar(var1 typ1, var2 *typ2) {}', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit={} } } } } },
+        create_compl_item { abbr = 'foocar', word = 'foobar(place holder, more ...holder{})', label = 'foocar', insertText = 'foodar', textEdit = { newText = 'bar(${1:place holder}, ${2:more ...holder{\\}})', range = insertTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foodar(var1 typ1, var2 *typ2) {}', label = 'foocar', insertText = 'foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit = {} },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
@@ -1080,7 +1104,7 @@ describe('LSP', function()
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foodar(var1 typ2,typ3 tail) {}', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit={} } } } } },
+        create_compl_item { abbr = 'foocar', word = 'foodar(var1 typ2,typ3 tail) {}', label = 'foocar', insertText = 'foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit = {} },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
@@ -1095,7 +1119,7 @@ describe('LSP', function()
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foodar(${1:var1})', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar(${1:var1})', insertTextFormat=1, textEdit={} } } } } },
+        create_compl_item { abbr = 'foocar', word = 'foodar(${1:var1})', label = 'foocar', insertText = 'foodar(${1:var1})', insertTextFormat = 1, textEdit = {} },
       }
 
       eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1141,7 +1141,7 @@ describe('LSP', function()
             detail = "(function)",
             documentation = {
               kind = "markdown",
-              value = "```lua\nfunction ipairs(t: table)\n  -> iterator: any\n  2. t: table\n  3. i: integer(0)\n```\n----------------\n```lua\nfor i, v in ipairs(t) do\n    body\nend\n```\n\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-ipairs)\n"
+              value = "shortened for brevity"
             },
             insertTextFormat = 2,
             kind = 3,
@@ -1163,12 +1163,12 @@ describe('LSP', function()
           }, {
             data = {
               offset = 37101,
-              uri = "file:///Users/USER/local/nvim/share/nvim/runtime/lua/vim/lsp/util.lua"
+              uri = "shortened for brevity"
             },
             detail = "(function)",
             documentation = {
               kind = "markdown",
-              value = "```lua\nfunction pairs(t: table)\n  -> @next: any\n  2. t: table\n  3. nil\n```\n----------------\n```lua\nfor k, v in pairs(t) do\n    body\nend\n```\n\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-pairs)\n"
+              value = "shortened for brevity"
             },
             insertTextFormat = 2,
             kind = 3,
@@ -1195,7 +1195,7 @@ describe('LSP', function()
             detail = "(function)",
             documentation = {
               kind = "markdown",
-              value = "```lua\nfunction print(...)\n```\nReceives any number of arguments and prints their values to stdout.\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-print)\n"
+              value = "shortened for brevity"
             },
             insertTextFormat = 2,
             kind = 3,
@@ -1223,7 +1223,7 @@ describe('LSP', function()
           dup = 1,
           empty = 1,
           icase = 1,
-          info = "```lua\nfunction print(...)\n```\nReceives any number of arguments and prints their values to stdout.\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-print)\n",
+          info = "shortened for brevity",
           kind = "Function",
           menu = "(function)",
           user_data = {
@@ -1237,7 +1237,7 @@ describe('LSP', function()
                   detail = "(function)",
                   documentation = {
                     kind = "markdown",
-                    value = "```lua\nfunction print(...)\n```\nReceives any number of arguments and prints their values to stdout.\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-print)\n"
+                    value = "shortened for brevity"
                   },
                   insertTextFormat = 2,
                   kind = 3,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1038,8 +1038,8 @@ describe('LSP', function()
       local prefix = 'foo'
       local completion_list = {
         -- resolves into insertText
-        { label='foocar', insertText='foobar' },
-        { label='foocar', insertText='foobar', textEdit={} },
+        { label = 'foocar', insertText = 'foobar' },
+        { label = 'foocar', insertText = 'foobar', textEdit = {} },
       }
       local completion_list_items = {items=completion_list}
       local expected = {
@@ -1063,15 +1063,15 @@ describe('LSP', function()
       }
       local completion_list = {
         -- resolves into textEdit.newText
-        { label='foocar', insertText='foodar', textEdit = { newText='bar', range=insertTextRange } },
-        { label='foocar', insertText='foodar', textEdit = { newText='foobar', range=replaceTextRange } },
-        { label='foocar', textEdit = { newText = 'bar', range = insertTextRange } },
+        { label = 'foocar', insertText = 'foodar', textEdit = { newText = 'bar', range = insertTextRange } },
+        { label = 'foocar', insertText = 'foodar', textEdit = { newText = 'foobar', range = replaceTextRange } },
+        { label = 'foocar', textEdit = { newText = 'bar', range = insertTextRange } },
       }
       local completion_list_items = {items=completion_list}
       local expected = {
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit= { newText = 'bar', range=insertTextRange} },
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit = {newText = 'foobar', range = replaceTextRange} },
-        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', textEdit = { newText = 'bar', range=insertTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit = { newText = 'bar', range = insertTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foodar', textEdit = {newText = 'foobar', range = replaceTextRange } },
+        create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', textEdit = { newText = 'bar', range = insertTextRange } },
       }
 
       eq(expected, get_completion_list(completion_list, prefix))
@@ -1086,8 +1086,8 @@ describe('LSP', function()
       }
       local completion_list = {
         -- real-world snippet text
-        { label='foocar', insertText='foodar', textEdit={newText='bar(${1:place holder}, ${2:more ...holder{\\}})', range=insertTextRange} },
-        { label='foocar', insertText='foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit={} },
+        { label = 'foocar', insertText = 'foodar', textEdit = { newText = 'bar(${1:place holder}, ${2:more ...holder{\\}})', range = insertTextRange } },
+        { label = 'foocar', insertText = 'foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit = {} },
       }
       local completion_list_items = {items=completion_list}
       local expected = {
@@ -1103,9 +1103,9 @@ describe('LSP', function()
       local prefix = 'foo'
       local completion_list = {
         -- nested snippet tokens
-        { label='foocar', insertText='foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit={} },
+        { label = 'foocar', insertText = 'foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit = {} },
       }
-      local completion_list_items = {items=completion_list}
+      local completion_list_items = { items = completion_list }
       local expected = {
         create_compl_item { abbr = 'foocar', word = 'foodar(var1 typ2,typ3 tail) {}', label = 'foocar', insertText = 'foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit = {} },
       }
@@ -1118,7 +1118,7 @@ describe('LSP', function()
       local prefix = 'foo'
       local completion_list = {
         -- plain text
-        { label='foocar', insertText='foodar(${1:var1})', insertTextFormat=1, textEdit={} },
+        { label = 'foocar', insertText = 'foodar(${1:var1})', insertTextFormat = 1, textEdit = {} },
       }
       local completion_list_items = {items=completion_list}
       local expected = {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -992,6 +992,12 @@ describe('LSP', function()
     -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
     it('should choose right completion option', function ()
       local prefix = 'foo'
+      local insertTextRange = {}
+      insertTextRange["start"] = { line = 5, character = 23 }
+      insertTextRange["end"] = { line = 5, character = 23 }
+      local replaceTextRange = {}
+      replaceTextRange["start"] = { line = 5, character = 21 }
+      replaceTextRange["end"] = { line = 5, character = 23 }
       local completion_list = {
         -- resolves into label
         { label='foobar' },
@@ -1000,10 +1006,11 @@ describe('LSP', function()
         { label='foocar', insertText='foobar' },
         { label='foocar', insertText='foobar', textEdit={} },
         -- resolves into textEdit.newText
-        { label='foocar', insertText='foodar', textEdit={newText='foobar'} },
-        { label='foocar', textEdit={newText='foobar'} },
+        { label='foocar', insertText='foodar', textEdit={newText='bar', range=insertTextRange} },
+        { label='foocar', insertText='foodar', textEdit={newText='foobar', range=replaceTextRange} },
+        { label='foocar', textEdit={newText='bar', range=insertTextRange} },
         -- real-world snippet text
-        { label='foocar', insertText='foodar', textEdit={newText='foobar(${1:place holder}, ${2:more ...holder{\\}})'} },
+        { label='foocar', insertText='foodar', textEdit={newText='bar(${1:place holder}, ${2:more ...holder{\\}})', range=insertTextRange} },
         { label='foocar', insertText='foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit={} },
         -- nested snippet tokens
         { label='foocar', insertText='foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit={} },
@@ -1016,9 +1023,10 @@ describe('LSP', function()
         { abbr = 'foobar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foobar', textEdit={} } } }  } },
         { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foobar' } } } } },
         { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foobar', textEdit={} } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='foobar'} } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', textEdit={newText='foobar'} } } } } },
-        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar(place holder, more ...holder{})', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='foobar(${1:place holder}, ${2:more ...holder{\\}})'} } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='bar', range=insertTextRange} } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='foobar', range=replaceTextRange} } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar', user_data = { nvim = { lsp = { completion_item = { label='foocar', textEdit={newText='bar', range=insertTextRange} } } } } },
+        { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foobar(place holder, more ...holder{})', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar', textEdit={newText='bar(${1:place holder}, ${2:more ...holder{\\}})', range=insertTextRange} } } } } },
         { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foodar(var1 typ1, var2 *typ2) {}', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit={} } } } } },
         { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foodar(var1 typ2,typ3 tail) {}', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit={} } } } } },
         { abbr = 'foocar', dup = 1, empty = 1, icase = 1, info = ' ', kind = 'Unknown', menu = '', word = 'foodar(${1:var1})', user_data = { nvim = { lsp = { completion_item = { label='foocar', insertText='foodar(${1:var1})', insertTextFormat=1, textEdit={} } } } } },

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1129,6 +1129,142 @@ describe('LSP', function()
       eq(expected, get_completion_list(completion_list_items, prefix))
       eq({}, get_completion_list({}, prefix))
     end)
+    describe('completion_list_to_complete_items for lua lsp', function()
+      it("completion for 'pri'", function ()
+      local result = {
+        isIncomplete = true,
+        items = { {
+            data = {
+              offset = 0,
+              uri = ""
+            },
+            detail = "(function)",
+            documentation = {
+              kind = "markdown",
+              value = "```lua\nfunction ipairs(t: table)\n  -> iterator: any\n  2. t: table\n  3. i: integer(0)\n```\n----------------\n```lua\nfor i, v in ipairs(t) do\n    body\nend\n```\n\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-ipairs)\n"
+            },
+            insertTextFormat = 2,
+            kind = 3,
+            label = "ipairs",
+            sortText = "0001",
+            textEdit = {
+              newText = "ipairs",
+              range = {
+                [ "end" ] = {
+                  character = 3,
+                  line = 0
+                },
+                [ "start" ] = {
+                  character = 0,
+                  line = 0
+                }
+              }
+            }
+          }, {
+            data = {
+              offset = 37101,
+              uri = "file:///Users/USER/local/nvim/share/nvim/runtime/lua/vim/lsp/util.lua"
+            },
+            detail = "(function)",
+            documentation = {
+              kind = "markdown",
+              value = "```lua\nfunction pairs(t: table)\n  -> @next: any\n  2. t: table\n  3. nil\n```\n----------------\n```lua\nfor k, v in pairs(t) do\n    body\nend\n```\n\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-pairs)\n"
+            },
+            insertTextFormat = 2,
+            kind = 3,
+            label = "pairs",
+            sortText = "0002",
+            textEdit = {
+              newText = "pairs",
+              range = {
+                [ "end" ] = {
+                  character = 3,
+                  line = 0
+                },
+                [ "start" ] = {
+                  character = 0,
+                  line = 0
+                }
+              }
+            }
+          }, {
+            data = {
+              offset = 0,
+              uri = ""
+            },
+            detail = "(function)",
+            documentation = {
+              kind = "markdown",
+              value = "```lua\nfunction print(...)\n```\nReceives any number of arguments and prints their values to stdout.\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-print)\n"
+            },
+            insertTextFormat = 2,
+            kind = 3,
+            label = "print",
+            sortText = "0003",
+            textEdit = {
+              newText = "print",
+              range = {
+                [ "end" ] = {
+                  character = 3,
+                  line = 0
+                },
+                [ "start" ] = {
+                  character = 0,
+                  line = 0
+                }
+              }
+            }
+          },
+        }
+      }
+      local prefix = "pri"
+      local matches = { {
+          abbr = "print",
+          dup = 1,
+          empty = 1,
+          icase = 1,
+          info = "```lua\nfunction print(...)\n```\nReceives any number of arguments and prints their values to stdout.\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-print)\n",
+          kind = "Function",
+          menu = "(function)",
+          user_data = {
+            nvim = {
+              lsp = {
+                completion_item = {
+                  data = {
+                    offset = 0,
+                    uri = ""
+                  },
+                  detail = "(function)",
+                  documentation = {
+                    kind = "markdown",
+                    value = "```lua\nfunction print(...)\n```\nReceives any number of arguments and prints their values to stdout.\n```lua\n\n```\n[View documents](http://www.lua.org/manual/5.3/manual.html#pdf-print)\n"
+                  },
+                  insertTextFormat = 2,
+                  kind = 3,
+                  label = "print",
+                  sortText = "0003",
+                  textEdit = {
+                    newText = "print",
+                    range = {
+                      [ "end" ] = {
+                        character = 3,
+                        line = 0
+                      },
+                      [ "start" ] = {
+                        character = 0,
+                        line = 0
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          word = "print"
+        } }
+        eq(matches, get_completion_list(result, prefix))
+      end)
+    end)
   end)
   describe('buf_diagnostics_save_positions', function()
     it('stores the diagnostics in diagnostics_by_buf', function ()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1011,6 +1011,9 @@ describe('LSP', function()
           },
         }
     end
+    local function get_completion_list(completion_list, prefix)
+      return exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix)
+    end
     -- Completion option precedence:
     -- textEdit.newText > insertText > label
     -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
@@ -1027,9 +1030,9 @@ describe('LSP', function()
         create_compl_item { abbr = 'foobar', word = 'foobar', label = 'foobar', textEdit = {} },
       }
 
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
-      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+      eq(expected, get_completion_list(completion_list, prefix))
+      eq(expected, get_completion_list(completion_list_items, prefix))
+      eq({}, get_completion_list({}, prefix))
     end)
     it('should choose right completion option for insertText', function ()
       local prefix = 'foo'
@@ -1044,9 +1047,9 @@ describe('LSP', function()
         create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', insertText='foobar', textEdit={} },
       }
 
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
-      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+      eq(expected, get_completion_list(completion_list, prefix))
+      eq(expected, get_completion_list(completion_list_items, prefix))
+      eq({}, get_completion_list({}, prefix))
     end)
     it('should choose right completion option for textEdit.newText', function ()
       local prefix = 'foo'
@@ -1071,9 +1074,9 @@ describe('LSP', function()
         create_compl_item { abbr = 'foocar', word = 'foobar', label='foocar', textEdit = { newText = 'bar', range=insertTextRange } },
       }
 
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
-      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+      eq(expected, get_completion_list(completion_list, prefix))
+      eq(expected, get_completion_list(completion_list_items, prefix))
+      eq({}, get_completion_list({}, prefix))
     end)
     it('should choose right completion option for snippet', function ()
       local prefix = 'foo'
@@ -1092,9 +1095,9 @@ describe('LSP', function()
         create_compl_item { abbr = 'foocar', word = 'foodar(var1 typ1, var2 *typ2) {}', label = 'foocar', insertText = 'foodar(${1:var1} typ1, ${2:var2} *typ2) {$0\\}', textEdit = {} },
       }
 
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
-      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+      eq(expected, get_completion_list(completion_list, prefix))
+      eq(expected, get_completion_list(completion_list_items, prefix))
+      eq({}, get_completion_list({}, prefix))
     end)
     it('should choose right completion option snippet tokens', function ()
       local prefix = 'foo'
@@ -1107,9 +1110,9 @@ describe('LSP', function()
         create_compl_item { abbr = 'foocar', word = 'foodar(var1 typ2,typ3 tail) {}', label = 'foocar', insertText = 'foodar(${1:var1 ${2|typ2,typ3|} ${3:tail}}) {$0\\}', textEdit = {} },
       }
 
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
-      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+      eq(expected, get_completion_list(completion_list, prefix))
+      eq(expected, get_completion_list(completion_list_items, prefix))
+      eq({}, get_completion_list({}, prefix))
     end)
     it('should choose right completion option for plain text', function ()
       local prefix = 'foo'
@@ -1122,9 +1125,9 @@ describe('LSP', function()
         create_compl_item { abbr = 'foocar', word = 'foodar(${1:var1})', label = 'foocar', insertText = 'foodar(${1:var1})', insertTextFormat = 1, textEdit = {} },
       }
 
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list, prefix))
-      eq(expected, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], completion_list_items, prefix))
-      eq({}, exec_lua([[return vim.lsp.util.text_document_completion_list_to_complete_items(...)]], {}, prefix))
+      eq(expected, get_completion_list(completion_list, prefix))
+      eq(expected, get_completion_list(completion_list_items, prefix))
+      eq({}, get_completion_list({}, prefix))
     end)
   end)
   describe('buf_diagnostics_save_positions', function()


### PR DESCRIPTION
The language server specification says that `newText` is the text to be inserted when `start === end`.

````
A textual edit applicable to a text document.

```typescript
interface TextEdit {
	/**
	 * The range of the text document to be manipulated. To insert
	 * text into a document create a range where start === end.
	 */
	range: Range;
	/**
	 * The string to be inserted. For delete operations use an
	 * empty string.
	 */
	newText: string;
}
```
````

See https://github.com/microsoft/language-server-protocol/blob/ba5483e93d888e22ab38dce258b2471e30005726/_specifications/specification-3-16.md#L499-L517 for reference.

In the current implementation, `item.textEdit.newText` is returned. See the following lines:

https://github.com/neovim/neovim/blob/48ac77a14c65c18f1f4cd4ac8e657c645e9ca101/runtime/lua/vim/lsp/util.lua#L279

According to the specification, if I'm trying to complete `pri` and a language server may return a `TextEdit` with `newText` for it like `ntln`, and then in the current implementation the completion word returned here is set to `ntln` instead of `println`.

This PR fixes the issue.

cc @haorenW1025

Related issues and PRs:

- https://github.com/nvim-lua/completion-nvim/pull/125
- https://github.com/Shougo/deoplete-lsp/issues/24
- https://github.com/Shougo/deoplete-lsp/pull/25
