### PR TITLE
LSP: Force space indentation while formatting when Nvim wants mixed

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1274,9 +1274,18 @@ end
 
 function M.make_formatting_params(options)
   validate { options = {options, 't', true} }
+  local bo = vim.bo
+  local ets = M.get_effective_tabstop()
   options = vim.tbl_extend('keep', options or {}, {
-    tabSize = M.get_effective_tabstop();
-    insertSpaces = vim.bo.expandtab;
+    tabSize = ets;
+    -- If softtabstop is non-zero and tabstop is not equal to the effective
+    -- tabstop, then the user has configured Nvim so that it will indent using
+    -- a mix of tabs and spaces. There's no way to request such mixed
+    -- indentation in the LSP protocol, so the next best thing is to override
+    -- expandtab and indent using spaces in this case, which is at least
+    -- visually consistent with the user's settings and can be fixed with
+    -- :retab!.
+    insertSpaces = bo.softtabstop ~= 0 and bo.tabstop ~= ets or bo.expandtab;
   })
   return {
     textDocument = { uri = vim.uri_from_bufnr(0) };


### PR DESCRIPTION
This picks up on a discussion started in #12252, see https://github.com/neovim/neovim/pull/12252#issuecomment-641980630 for details and an example if this seems too abstract.

The gist is that if `softtabstop` is non-zero and `tabstop` is not equal to the effective tabstop, then the user has configured Nvim so that it will indent using a mix of tabs and spaces. There's no way to request such mixed indentation in LSP (or is there? if so, see below), so the next best thing is to override `expandtab` and indent using spaces in this case, which is at least visually consistent with the user's settings and can be fixed with `:retab!`.

If there actually *is* a way to request mixed indentation in LSP, then the formatting params should of course use that instead :)