### PR TITLE
LSP diagnostic (conversation)

### DIFF
--- a/runtime/autoload/health/lsp.vim
+++ b/runtime/autoload/health/lsp.vim
@@ -1,0 +1,5 @@
+
+function! health#lsp#check() abort
+    lua require 'health/lsp'.check_health()
+endfunc
+

--- a/runtime/lua/health/lsp.lua
+++ b/runtime/lua/health/lsp.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+local report_error = vim.fn['health#report_error']
+local report_info = vim.fn['health#report_info']
+
+function M.check_health()
+
+	for key, client in pairs(vim.lsp.get_active_clients()) do
+		M.lsp_dump_active_client(client)
+	end
+end
+
+function M.lsp_dump_active_client(client)
+
+	local config = client.config
+	vim.fn["health#report_start"]('State of '..config.name)
+	report_info("Working directory: "..config.root_dir)
+
+end
+
+return M
+


### PR DESCRIPTION
quick and dirty push. Not sure if it should be a checkhealth, actually it may be best to have proper DebugLSP command and keep checkhealth just to show abnormal behavior. 
I just wanted to provide a starting point since neovim LSP is pretty good but what lacks for a release is:
- a(n easy) way to disable/enable LSP
- a diagnostic utility more approachable than `lua print(vim.inspect(vim.lsp.get_active_clients()))`