### PR TITLE
lsp: Fix cursor position after text edit applying

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -166,11 +166,12 @@ function M.apply_text_edits(text_edits, bufnr)
     local end_index, suffix, _
     lines, _, end_index, _, suffix = M.set_lines(lines, A, B, e.lines)
 
-    if e.B[1] <= curpos[1] then
-      if e.B[1] == curpos[1] and e.B[2] <= curpos[2] then
-        curpos[2] = (#(lines[end_index] or '') - #(suffix or '')) + (curpos[2] - e.B[2])
-      end
+    if e.B[1] < curpos[1] then
       curpos[1] = curpos[1] + (lines_len - range_len)
+      curpos_fixed = true
+    elseif e.B[1] == curpos[1] and e.B[1] == curpos[1] and e.B[2] <= curpos[2] then
+      curpos[1] = curpos[1] + (lines_len - range_len)
+      curpos[2] = (#(lines[end_index] or '') - #(suffix or '')) + (curpos[2] - e.B[2])
       curpos_fixed = true
     end
   end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -153,7 +153,7 @@ function M.apply_text_edits(text_edits, bufnr)
     table.insert(lines, '')
   end
 
-  -- store current cursor pos
+  -- store current cursor position (when target buffer is not current one, it will be ignore)
   local curpos_fixed = false
   local cursor_position = M.make_position_param()
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -45,6 +45,9 @@ local function npcall(fn, ...)
   return ok_or_nil(pcall(fn, ...))
 end
 
+--- Apply TextEdit for lines variable
+-- Returns a tuple of (modified_lines, modified_start_line_idx, modified_end_line_idx, old_start_line_prefix, old_end_line_suffix)
+-- The line_idx is 1-based
 function M.set_lines(lines, A, B, new_lines)
   -- 0-indexing to 1-indexing
   local i_0 = A[1] + 1
@@ -75,6 +78,7 @@ function M.set_lines(lines, A, B, new_lines)
   if #prefix > 0 then
     lines[i_0] = prefix..lines[i_0]
   end
+  -- (modified_lines, modified_start_line_idx, modified_end_line_idx, old_start_line_prefix, old_end_line_suffix)
   return lines, i_0, (i_0 + #new_lines - 1), prefix, suffix
 end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -870,6 +870,21 @@ describe('LSP', function()
       }, buf_lines(1))
       eq({ 2, 18 }, winmeths.get_cursor(0))
     end)
+    it('does not fix cursor position when edits end pos is same line but edits col after cursor col', function()
+      local edits = {
+        make_edit(2, 11, 2, 11, {"", ""})
+      }
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      eq({
+        'First line of text',
+        'Second line of text',
+        'Third| line',
+        ' of text',
+        'Fourth line of text',
+        'å å ɧ 汉语 ↥ 🤦 🦄'
+      }, buf_lines(1))
+      eq({ 3, 5 }, winmeths.get_cursor(0))
+    end)
     it('applies complex edits', function()
       local edits = {
         make_edit(0, 0, 0, 0, {"3", "foo"});


### PR DESCRIPTION
This PR aims to improve cursor position after text edits.

For example, rust-analyzer returns CompletionItem that depends on this behavior.

```rust
use std::fs::File;

fn main() {
    let file = File::open("Cargo.toml").unwrap();
    file
        .box| // | is cursor
}
```

In this case, the expected completion confirmation behavior is below.

```rust
use std::fs::File;

fn main() {
    let file = File::open("Cargo.toml").unwrap();
    Box:new(file)| // | is cursor
}
```

<details>
<summary>CompletionItem structure at this time</summary>

```json5
{
	'label': 'box',
	'insertTextFormat': 2,
	'deprecated': v: false,
	'additionalTextEdits': [{
		'range': {
			'end': {
				'character': 9,
				'line': 5
			},
			'start': {
				'character': 4,
				'line': 4
			}
		},
		'newText': ''
	}],
	'filterText': 'box',
	'textEdit': {
		'range': {
			'end': {
				'character': 9,
				'line': 5
			},
			'start': {
				'character': 9,
				'line': 5
			}
		},
		'newText': 'Box::new(file)'
	},
	'detail': 'Box::new(expr)'
}
```

</details>

<hr>

This means we should do the below on CompleteDone.

#### Remove inserted `v:completed_item.word` (because it will be insert by `textEdit`).

<details>
<summary>buffer at this time</summary>

```rust
use std::fs::File;

fn main() {
    let file = File::open("Cargo.toml").unwrap();
    file
        .| // | is cursor
}
```

</details>

#### Apply additionalTextEdits and fix cursor position.

<details>
<summary>buffer at this time</summary>

```rust
use std::fs::File;

fn main() {
    let file = File::open("Cargo.toml").unwrap();
    | // | is cursor
}
```

</details>

#### Apply TextEdit on a new cursor position.

<details>
<summary>buffer at this time</summary>

```rust
use std::fs::File;

fn main() {
    let file = File::open("Cargo.toml").unwrap();
    Box::new(file)| // | is cursor
}
```

</details>


Currently, nvim has no support `CompleteDone` behavior so this improvement has not big effect in the context of nvim itself maybe.

But I think it will be useful for some LSP related plugins authors (e.g. [nvim-lua/completion-nvim](https://github.com/nvim-lua/completion-nvim) etc)
