### PR TITLE
man.vim: Add - to 'iskeyword'

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -16,6 +16,7 @@ setlocal noswapfile buftype=nofile bufhidden=hide
 setlocal nomodified readonly nomodifiable
 setlocal noexpandtab tabstop=8 softtabstop=8 shiftwidth=8
 setlocal wrap breakindent linebreak
+setlocal iskeyword+=-
 
 setlocal nonumber norelativenumber
 setlocal foldcolumn=0 colorcolumn=0 nolist nofoldenable


### PR DESCRIPTION
Pressing K on manpages with - in their name will now work.

I noticed this the manpages of https://github.com/cli/cli