### PR TITLE
treesitter: check bufloaded before parsing

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -75,6 +75,9 @@ function M.create_parser(bufnr, lang, id)
   if bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
+
+  vim.fn.bufload(bufnr)
+
   local self = setmetatable({bufnr=bufnr, lang=lang, valid=false}, Parser)
   self._parser = vim._create_ts_parser(lang)
   self.change_cbs = {}

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -307,11 +307,13 @@ static int parser_parse_buf(lua_State *L)
   }
 
   long bufnr = lua_tointeger(L, 2);
-  void *payload = handle_get_buffer(bufnr);
-  if (!payload) {
+  buf_T *buf = handle_get_buffer(bufnr);
+
+  if (!buf) {
     return luaL_error(L, "invalid buffer handle: %d", bufnr);
   }
-  TSInput input = { payload, input_cb, TSInputEncodingUTF8 };
+
+  TSInput input = { (void *)buf, input_cb, TSInputEncodingUTF8 };
   TSTree *new_tree = ts_parser_parse(p->parser, p->tree, input);
 
   uint32_t n_ranges = 0;


### PR DESCRIPTION
Attempts to fix #12550. The thing is just asserting that the buffer is actually loaded when trying to parse it, and error out if the buffer is not loaded.
I would like to test it, but I don't really know how I can call `vim.fn.bufload` within a test (that is, the path I should choose to open a given file).
I don't know whether this fix is great or not, but at least it reinforces our confidence in the fact that the tree and the actual buffer content match.