### PR TITLE
[WIP] Internal Metatable to make `vim.g` act the way we expect

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -852,28 +852,31 @@ void nvim__set_var_from_keys(ArrayOf(Object) keys, Object value, Error *err)
   for (size_t i = 0; i < keys.size - 1; i++) {
     Object item = keys.items[i];
     if (item.type == kObjectTypeString) {
-      ILOG("SETTING: %s", item.data.string.data);
-      dictitem_T *const di = tv_dict_find(&d, item.data.string.data, (ptrdiff_t)item.data.string.size);
+      dictitem_T *const di = tv_dict_find(
+          &d,
+          item.data.string.data,
+          (ptrdiff_t)item.data.string.size);
+
       if (di->di_tv.v_type == VAR_DICT) {
         ILOG("IS DICT: %s", item.data.string.data);
         d = *(di->di_tv.vval.v_dict);
-        ILOG("IS DICT: %s", item.data.string.data);
       } else {
-        api_set_error(err, kErrorTypeValidation, "Invalid type");
+        api_set_error(err, kErrorTypeValidation, "Invalid type for setting dict");
         return;
       }
     } else {
-      api_set_error(err, kErrorTypeValidation, "Invalid type");
+      api_set_error(err, kErrorTypeValidation, "Invalid type for key");
       return;
     }
   }
 
+  String dict_key = keys.items[keys.size - 1].data.string;
+
   ILOG("DONE");
-  ILOG("SIZE: %s", keys.items[keys.size].data.string.data);
-  ILOG("SIZE - 1: %s", keys.items[keys.size - 1].data.string.data);
+  ILOG("SIZE - 1: %s", dict_key.data);
   dict_set_var(
       &d,
-      keys.items[keys.size - 1].data.string,
+      dict_key,
       value, false, false, err);
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -817,6 +817,66 @@ Object nvim_get_var(String name, Error *err)
   return dict_get_value(&globvardict, name, err);
 }
 
+/// Gets a global (g:) variable from a nested set of keys.
+Object nvim__get_var_from_keys(ArrayOf(Object) keys, Error *err)
+  FUNC_API_SINCE(7)
+{
+  dict_T d = globvardict;
+
+  for (size_t i = 0; i < keys.size - 1; i++) {
+    Object item = keys.items[i];
+    if (item.type == kObjectTypeString) {
+      dictitem_T *const di = tv_dict_find(&d, item.data.string.data, (ptrdiff_t)item.data.string.size);
+      if (di->di_tv.v_type == VAR_DICT) {
+        d = *(di->di_tv.vval.v_dict);
+      } else {
+        api_set_error(err, kErrorTypeValidation, "Invalid type");
+        goto err;
+      }
+    } else {
+      api_set_error(err, kErrorTypeValidation, "Invalid type");
+      goto err;
+    }
+  }
+
+  return dict_get_value(&d, keys.items[keys.size].data.string, err);
+
+err:
+  return (Object) OBJECT_INIT;
+}
+
+void nvim__set_var_from_keys(ArrayOf(Object) keys, Object value, Error *err)
+  FUNC_API_SINCE(7)
+{
+  dict_T d = globvardict;
+  for (size_t i = 0; i < keys.size - 1; i++) {
+    Object item = keys.items[i];
+    if (item.type == kObjectTypeString) {
+      ILOG("SETTING: %s", item.data.string.data);
+      dictitem_T *const di = tv_dict_find(&d, item.data.string.data, (ptrdiff_t)item.data.string.size);
+      if (di->di_tv.v_type == VAR_DICT) {
+        ILOG("IS DICT: %s", item.data.string.data);
+        d = *(di->di_tv.vval.v_dict);
+        ILOG("IS DICT: %s", item.data.string.data);
+      } else {
+        api_set_error(err, kErrorTypeValidation, "Invalid type");
+        return;
+      }
+    } else {
+      api_set_error(err, kErrorTypeValidation, "Invalid type");
+      return;
+    }
+  }
+
+  ILOG("DONE");
+  ILOG("SIZE: %s", keys.items[keys.size].data.string.data);
+  ILOG("SIZE - 1: %s", keys.items[keys.size - 1].data.string.data);
+  dict_set_var(
+      &d,
+      keys.items[keys.size - 1].data.string,
+      value, false, false, err);
+}
+
 /// Sets a global (g:) variable.
 ///
 /// @param name     Variable name

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -314,6 +314,21 @@ bool nlua_pop_typval(lua_State *lstate, typval_T *ret_tv)
         break;
       }
       case LUA_TTABLE: {
+        // get metatable
+        // get __vim_serialize
+        // if __vim_serialize, then return nlua_pop_typval(__seralialize(table))
+        if (lua_getmetatable(lstate, -1)) {
+          ILOG("This has metatable");
+          lua_getfield(lstate, -1, "__vim_serialize");
+          if (lua_isfunction(lstate, -1)) {
+            ILOG("This has __vim_serialize");
+            lua_pop(lstate, -2);
+            lua_pcall(lstate, 1, 1, 0);
+          }
+        } else {
+          ILOG("No metatable");
+        }
+
         const LuaTableProps table_props = nlua_traverse_table(lstate);
 
         for (size_t i = 0; i < kv_size(stack); i++) {

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -365,9 +365,14 @@ do
       end,
 
       __newindex = function(_, k, v)
+        rawset(proxy, k, v)
         return a.nvim__set_var_from_keys({s, k}, v)
         -- rawset(proxy, k, v)
         -- a.nvim_set_var(s, proxy)
+      end,
+
+      __vim_serialize = function(_)
+        return proxy
       end
     }
   end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -866,22 +866,43 @@ describe('lua stdlib', function()
     eq(false, exec_lua("return vim.is_callable({})"))
   end)
 
-  it('vim.g', function()
-    exec_lua [[
-    vim.api.nvim_set_var("testing", "hi")
-    vim.api.nvim_set_var("other", 123)
-    vim.api.nvim_set_var("to_delete", {hello="world"})
-    ]]
+  describe('vim.g', function()
+    it('should handle direct gets and sets', function()
+      exec_lua [[
+      vim.api.nvim_set_var("testing", "hi")
+      vim.api.nvim_set_var("other", 123)
+      vim.api.nvim_set_var("to_delete", {hello="world"})
+      ]]
 
-    eq('hi', funcs.luaeval "vim.g.testing")
-    eq(123, funcs.luaeval "vim.g.other")
-    eq(NIL, funcs.luaeval "vim.g.nonexistant")
+      eq('hi', funcs.luaeval "vim.g.testing")
+      eq(123, funcs.luaeval "vim.g.other")
+      eq(NIL, funcs.luaeval "vim.g.nonexistant")
 
-    eq({hello="world"}, funcs.luaeval "vim.g.to_delete")
-    exec_lua [[
-    vim.g.to_delete = nil
-    ]]
-    eq(NIL, funcs.luaeval "vim.g.to_delete")
+      eq({hello="world"}, funcs.luaeval "vim.g.to_delete")
+      exec_lua [[
+      vim.g.to_delete = nil
+      ]]
+      eq(NIL, funcs.luaeval "vim.g.to_delete")
+    end)
+
+    it('should handle updating dictionary types', function()
+      eq({a = true, b = false}, exec_lua [[
+        vim.g.x = {}
+        vim.g.x.a = true
+        vim.g.x.b = false
+
+        return vim.g.x
+      ]])
+    end)
+
+    it('should handle updating list types', function()
+      eq({"a", "b"}, exec_lua [[
+        vim.g.x = {"a"}
+
+        table.insert(vim.g.x, "b")
+        return vim.g.x
+      ]])
+    end)
   end)
 
   it('vim.b', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -885,25 +885,22 @@ describe('lua stdlib', function()
       eq(NIL, funcs.luaeval "vim.g.to_delete")
     end)
 
+    it('should return an index from a dictionary', function()
+      eq(true, exec_lua [[
+        vim.g.test = { a = true }
+        return vim.g.test.a
+      ]])
+    end)
+
     it('should handle updating dictionary types', function()
       eq({a = true, b = true}, exec_lua [[
         vim.g.x = {a = true}
         vim.g.x.b = false
         vim.g.x.b = true
+        vim.g.x.c = true
 
-        return {
-          a = vim.g.x.a,
-          b = vim.g.x.b,
-        }
+        return vim.g.x
       ]])
-
-      local t = vim.g.y 
-      t.foo = 7
-      t.bar = false
-
-      assert(t ~= {})
-      assert(vim.g.y.bar == false)
-
     end)
 
     it('should handle updating list types', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -886,13 +886,24 @@ describe('lua stdlib', function()
     end)
 
     it('should handle updating dictionary types', function()
-      eq({a = true, b = false}, exec_lua [[
-        vim.g.x = {}
-        vim.g.x.a = true
+      eq({a = true, b = true}, exec_lua [[
+        vim.g.x = {a = true}
         vim.g.x.b = false
+        vim.g.x.b = true
 
-        return vim.g.x
+        return {
+          a = vim.g.x.a,
+          b = vim.g.x.b,
+        }
       ]])
+
+      local t = vim.g.y 
+      t.foo = 7
+      t.bar = false
+
+      assert(t ~= {})
+      assert(vim.g.y.bar == false)
+
     end)
 
     it('should handle updating list types', function()


### PR DESCRIPTION
TODO, info on this PR

----

Hey, @norcalli 

What do you think about adding a metamethod for `__vim_serialize` on tables, that basically allows a table or userdata or whatever to define a custom function that returns some "normal" lua object that can be converted into vimscript stuff.

I have been playing around with this and I can't think of any way to do this otherwise. Interested in your thoughts about that.