### PR TITLE
jumplist: alleviate *, # command regression

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1240,7 +1240,12 @@ void cleanup_jumplist(win_T *wp, bool checktail)
       && wp->w_jumplistidx == wp->w_jumplistlen) {
     const xfmark_T *fm_last = &wp->w_jumplist[wp->w_jumplistlen - 1];
     if (fm_last->fmark.fnum == curbuf->b_fnum
-        && fm_last->fmark.mark.lnum == wp->w_cursor.lnum) {
+        && fm_last->fmark.mark.lnum == wp->w_cursor.lnum
+        && fm_last->fmark.mark.col == wp->w_cursor.col) {
+        // If the * or # command doesn't move the cursor, this block
+        // erroneously erases the newly created jumplist entry. More generally,
+        // the answer to "did the cursor move?" is insufficient to determine
+        // whether erasing entries is really safe. neovim/neovim#9874
       xfree(fm_last->fname);
       wp->w_jumplistlen--;
       wp->w_jumplistidx--;


### PR DESCRIPTION
This is a partial resolution to #9874. It improves the situation but I believe it
reveals that the approach in #9805 is too naive.

---

Commit 35362495c ("jumplist: avoid extra tail entry #9805", 2019-04-02)
introduced a regression where, when the * or # command leaves the cursor
in the same line, the jumplist entry is erroneously erased. In addition
to interactive use, this breaks mappings like

    nnoremap * *<C-O>

The cursor remains in the same line when

1. the cursor is outside of a word boundary;
2. the searched-for word occurs next time in the same line; or
3. the searched-for word is unique.

Only erase the jumplist entry when both the cursor line and column
position are unchanged. This still leaves case #3 confusingly broken but
hopefully it's enough to salvage interactive use -- why "jump back" when
the cursor doesn't move? -- even if it turns out to be insufficient for
aforementioned mapping.

The slightly more clumsy alternative mapping of

    nnoremap * *``

doesn't help: `` updates the jumplist, too, so unique keywords move the
cursor to the position before the * command instead of staying in place.
If that command is used on a unique keyword after being used on a
non-unique keyword, that position is the "next match of the searched-for
word" from the previous usage.
