### PR TITLE
lsp: clear diagnostics_by_buf in buf_clear_diagnostics

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -926,6 +926,9 @@ do
 
     -- clear virtual text namespace
     api.nvim_buf_clear_namespace(bufnr, diagnostic_ns, 0, -1)
+
+    -- Clear local diagnostic cache of this buffer.
+    M.diagnostics_by_buf[bufnr] = nil
   end
 
   function M.get_severity_highlight_name(severity)


### PR DESCRIPTION
Normally, this is a no-op, as a call to `M.buf_clear_diagnostics()` is
nearly always followed by a call to
`M.buf_diagnostics_save_positions()`. The latter will overwrite the
`bufnr` entry in the `M.diagnostics_by_buf` table.

However, there are cases where not doing `M.diagnostics_by_buf[bufnr] =
nil` this produces strange results. A trimmed excerpt:

```lua
  function M.buf_diagnostics_save_positions(bufnr, diagnostics)
    -- ...
    if not diagnostics then return end -- What if diagnostics is indeed nil?
    -- ...
    M.diagnostics_by_buf[bufnr] = diagnostics
  end
```

In case of a nil `diagnostics` parameters, `M.diagnostics_by_buf` will
not be overwritten, and the old diagnostics will just stay there, but
the virtual text and signs wll have been cleared by
`M.buf_clear_diagnostics()`.

I believe I've observed this happening with a crashing language server.
See my comments on https://github.com/nvim-lua/diagnostic-nvim/issues/40
(which is actually a different issue from what I encountered, so I also
confuddled the issue).

cc @haorenW1025.