### PR TITLE
Send buffer linecount in win_viewport

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -594,11 +594,12 @@ tabs.
 	When |ext_messages| is active, no message grid is used, and this event
 	will not be sent.
 
-["win_viewport", grid, win, topline, botline, curline, curcol]
+["win_viewport", grid, win, topline, botline, curline, curcol, linecount]
 	Indicates the range of buffer text displayed in the window, as well
 	as the cursor position in the buffer. All positions are zero-based.
 	`botline` is set to one more than the line count of the buffer, if
-	there are filler lines past the end.
+	there are filler lines past the end. linecount tells the amount of
+	lines in the buffer.
 
 ==============================================================================
 Popupmenu Events						 *ui-popupmenu*

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -116,7 +116,8 @@ void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
   FUNC_API_SINCE(6) FUNC_API_BRIDGE_IMPL FUNC_API_COMPOSITOR_IMPL;
 
 void win_viewport(Integer grid, Window win, Integer topline,
-                  Integer botline, Integer curline, Integer curcol)
+                  Integer botline, Integer curline, Integer curcol,
+                  Integer lines)
   FUNC_API_SINCE(7) FUNC_API_REMOTE_ONLY;
 
 void popupmenu_show(Array items, Integer selected,

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -783,8 +783,13 @@ void ui_ext_win_viewport(win_T *wp)
       // interact with incomplete final line? Diff filler lines?
       botline = wp->w_buffer->b_ml.ml_line_count;
     }
+    int linecount = botline;
+    if (wp->w_buffer != NULL) {
+      linecount = wp->w_buffer->b_ml.ml_line_count;
+    }
     ui_call_win_viewport(wp->w_grid.handle, wp->handle, wp->w_topline-1,
-                         botline, wp->w_cursor.lnum-1, wp->w_cursor.col);
+                         botline, wp->w_cursor.lnum-1, wp->w_cursor.col,
+                         linecount);
     wp->w_viewport_invalid = false;
   }
 }


### PR DESCRIPTION
Currently, if GUIs want to implement scrollbars they'll have to query
the max line count of the current buffer for each window they want to
display the scrollbar for. Instead of requiring GUIs to do extra work to
get that one number, send it in the win_viewport event where all the
other related info is also send.

Ref #11748

Now, I'm not completely sure if the linecount param fits to the viewport event at all - what viewport "is" is quite well known and (buffer) linecount has nothing to do with it. I was just playing around with scrollbars for gnvim and threw this together to avoid extra IO round trip with `line('$')`. Opinions?