### PR TITLE
treesitter: add runtime queries feature

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -574,14 +574,25 @@ retained for the lifetime of a buffer but this is subject to change. A plugin
 should keep a reference to the parser object as long as it wants incremental
 updates.
 
-Required runtime files					*lua-treesitter-files*
+Parser files						*treesitter-parsers*
 
-Treesitter requires some files to work properly :
-	- Parsers : this is the `.so` files created whan compiling parsers,
-	  they are searched under the `parsers` subdirectory.
-	- Queries : these are `.scm` files that are "sourced" when
-	  `vim.treesitter.get_query(lang, type)` is called. They are searched under the
-	  `queries/{lang}` subdirectory.
+Parsers are the heart of tree-sitter. They are libraries that tree-sitter will
+search for in the `parsers` runtime directory.
+
+For a parser to be available for a given language, there must be a file named
+`{lang}.so` within the parser directory.
+
+Query files						*treesitter-query*
+
+Queries are objects that tree-sitter uses to extract informations. They are
+built from a `scheme`-like language, and treesitter parses them to build the
+object.
+
+Treesitter also searches for query files within the `queries` directory. For a
+given language, treesitter will search the queries in the `queries/{lang}`. A
+query file is a `scheme` file (ending with `.scm`).
+
+An example query can be found at |lua-treesitter-highlight|
 
 Parser methods						*lua-treesitter-parser*
 
@@ -602,9 +613,9 @@ shouldn't be done directly in the change callback anyway as they will be very
 frequent. Rather a plugin that does any kind of analysis on a tree should use
 a timer to throttle too frequent updates.
 
-tsparser:set_included_ranges(ranges)			*tsparser:set_included_ranges()*
+tsparser:set_included_ranges({ranges})			*tsparser:set_included_ranges()*
 	Changes the ranges the parser should consider. This is used for
-	language injection.  `ranges` should be of the form (all zero-based): >
+	language injection.  {ranges} should be of the form (all zero-based): >
 	{
 		{start_node, end_node},
 		...
@@ -626,15 +637,15 @@ tsnode:parent()						*tsnode:parent()*
 tsnode:child_count()					*tsnode:child_count()*
 	Get the node's number of children.
 
-tsnode:child(N)						*tsnode:child()*
-	Get the node's child at the given index, where zero represents the
+tsnode:child({index})						*tsnode:child()*
+	Get the node's child at the given {index}, where zero represents the
 	first child.
 
 tsnode:named_child_count()			*tsnode:named_child_count()*
 	Get the node's number of named children.
 
-tsnode:named_child(N)					*tsnode:named_child()*
-	Get the node's named child at the given index, where zero represents
+tsnode:named_child({index})					*tsnode:named_child()*
+	Get the node's named child at the given {index}, where zero represents
 	the first named child.
 
 tsnode:start()						*tsnode:start()*
@@ -670,12 +681,12 @@ tsnode:has_error()					*tsnode:has_error()*
 tsnode:sexpr()						*tsnode:sexpr()*
 	Get an S-expression representing the node as a string.
 
-tsnode:descendant_for_range(start_row, start_col, end_row, end_col)
+tsnode:descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})
 						*tsnode:descendant_for_range()*
 	Get the smallest node within this node that spans the given range of
 	(row, column) positions
 
-tsnode:named_descendant_for_range(start_row, start_col, end_row, end_col)
+tsnode:named_descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})
 					*tsnode:named_descendant_for_range()*
 	Get the smallest named node within this node that spans the given
 	range of (row, column) positions
@@ -686,23 +697,23 @@ Tree-sitter queries are supported, with some limitations. Currently, the only
 supported match predicate is `eq?` (both comparing a capture against a string
 and two captures against each other).
 
-vim.treesitter.parse_query(lang, query)
+vim.treesitter.parse_query({lang}, {query})
 						*vim.treesitter.parse_query()*
-	Parse the query as a string. (If the query is in a file, the caller
+	Parse {query} as a string. (If the query is in a file, the caller
         should read the contents into a string before calling).
 
-vim.treesitter.get_query(lang, query_name)
+vim.treesitter.get_query({lang}, {query_name})
 						*vim.treesitter.get_query()*
-	Get the runtime query named `query_name`. This internally calls
-	`parse_query`. This will "source" all the runtime and user defined
-	queries (see |lua-treesitter-files|).
+	Get the runtime query named {query_name}. This internally calls
+	|vim.treesitter.parse_query()|. This will "source" all the runtime and
+	user defined queries (see |lua-treesitter-files|).
 
-query:iter_captures(node, bufnr, start_row, end_row)
+query:iter_captures({node}, {bufnr}, {start_row}, {end_row})
 							*query:iter_captures()*
-	Iterate over all captures from all matches inside a `node`.
-	`bufnr` is needed if the query contains predicates, then the caller
+	Iterate over all captures from all matches inside {node}.
+	{bufnr} is needed if the query contains predicates, then the caller
 	must ensure to use a freshly parsed tree consistent with the current
-	text of the buffer. `start_row` and `end_row` can be used to limit
+	text of the buffer. {start_row} and {end_row} can be used to limit
 	matches inside a row range (this is typically used with root node
 	as the node, i e to get syntax highlight matches in the current
 	viewport)
@@ -719,7 +730,7 @@ query:iter_captures(node, bufnr, start_row, end_row)
 	  ... use the info here ...
 	end
 <
-query:iter_matches(node, bufnr, start_row, end_row)
+query:iter_matches({node}, {bufnr}, {start_row}, {end_row})
 							*query:iter_matches()*
 	Iterate over all matches within a node. The arguments are the same as
 	for |query:iter_captures()| but the iterated values are different:
@@ -762,9 +773,9 @@ buffer with this code: >
       ; ... more definitions
     ]]
 
-    highlighter = vim.treesitter.TSHighlighter.new(query, bufnr, lang)
-    -- alternatively, to use the current buffer and its filetype:
-    -- highlighter = vim.treesitter.TSHighlighter.new(query)
+    -- the query parameter is optionnal here, and if not provided, treesitter
+    -- will search for a highlights.scm query in the runtime files.
+    highlighter = vim.treesitter.TSHighlighter.new(bufnr, lang, query)
 
     -- Don't recreate the highlighter for the same buffer, instead
     -- modify the query like this:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -574,6 +574,15 @@ retained for the lifetime of a buffer but this is subject to change. A plugin
 should keep a reference to the parser object as long as it wants incremental
 updates.
 
+Required runtime files					*lua-treesitter-files*
+
+Treesitter requires some files to work properly :
+	- Parsers : this is the `.so` files created whan compiling parsers,
+	  they are searched under the `parsers` subdirectory.
+	- Queries : these are `.scm` files that are "sourced" when
+	  `vim.treesitter.get_query(lang, type)` is called. They are searched under the
+	  `queries/{lang}` subdirectory.
+
 Parser methods						*lua-treesitter-parser*
 
 tsparser:parse()					*tsparser:parse()*
@@ -678,9 +687,15 @@ supported match predicate is `eq?` (both comparing a capture against a string
 and two captures against each other).
 
 vim.treesitter.parse_query(lang, query)
-						*vim.treesitter.parse_query(()*
+						*vim.treesitter.parse_query()*
 	Parse the query as a string. (If the query is in a file, the caller
         should read the contents into a string before calling).
+
+vim.treesitter.get_query(lang, query_name)
+						*vim.treesitter.get_query()*
+	Get the runtime query named `query_name`. This internally calls
+	`parse_query`. This will "source" all the runtime and user defined
+	queries (see |lua-treesitter-files|).
 
 query:iter_captures(node, bufnr, start_row, end_row)
 							*query:iter_captures()*

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -10,6 +10,12 @@ local parsers = {}
 local Parser = {}
 Parser.__index = Parser
 
+--- Parses the buffer if needed and returns a tree.
+--
+-- Calling this will call the on_changedtree callbacks if the tree has changed.
+--
+-- @returns An up to date tree
+-- @returns If the tree changed with this call, the changed ranges
 function Parser:parse()
   if self.valid then
     return self.tree
@@ -40,6 +46,9 @@ function Parser:_on_lines(bufnr, changed_tick, start_row, old_stop_row, stop_row
   end
 end
 
+--- Sets the included ranges for the current parser
+--
+-- @param ranges A table of nodes that will be used as the ranges the parser should include.
 function Parser:set_included_ranges(ranges)
   self._parser:set_included_ranges(ranges)
   -- The buffer will need to be parsed again later
@@ -61,6 +70,13 @@ setmetatable(M, {
    end
  })
 
+--- Creates a new parser.
+--
+-- It is not recommended to use this, use vim.treesitter.get_parser() instead.
+--
+-- @param bufnr The buffer the parser will be tied to
+-- @param language The language of the parser.
+-- @param id The id the parser will have
 function M._create_parser(bufnr, language, id)
   lang.require_language(language)
   if bufnr == 0 then
@@ -91,6 +107,20 @@ function M._create_parser(bufnr, language, id)
   return self
 end
 
+--- Gets the parser for this bufnr / ft combination.
+--
+-- If needed this will create the parser.
+-- Unconditionnally attach the provided callback
+--
+-- @param bufnr The buffer the parser should be tied to
+-- @param ft The filetype of this parser
+-- @param buf_attach_cbs An `nvim_buf_attach`-like table argument with the following keys :
+--  `on_lines` : see `nvim_buf_attach`, but this will be called _after_ the parsers callback.
+--  `on_changedtree` : a callback that will be called everytime the tree has syntactical changes.
+--      it will only be passed one argument, that is a table of the ranges (as node ranges) that
+--      changed.
+--
+-- @returns The parser
 function M.get_parser(bufnr, ft, buf_attach_cbs)
   if bufnr == nil or bufnr == 0 then
     bufnr = a.nvim_get_current_buf()

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -55,12 +55,13 @@ function Parser:set_included_ranges(ranges)
   self.valid = false
 end
 
--- TODO(vigoux): not that great way to do it, but that __index method bothers me...
 local M = vim.tbl_extend("error", query, lang)
 
 setmetatable(M, {
   __index = function (t, k)
       if k == "TSHighlighter" then
+        a.nvim_err_writeln(
+          "Using vim.TSHighlighter is deprecated, please use vim.treesitter.highlighter instead.")
         t[k] = require'vim.treesitter.highlighter'
         return t[k]
       elseif k == "highlighter" then

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -1,4 +1,6 @@
 local a = vim.api
+local query = require'vim.treesitter.query'
+local lang = require'vim.treesitter.language'
 
 -- TODO(bfredl): currently we retain parsers for the lifetime of the buffer.
 -- Consider use weak references to release parser if all plugins are done with
@@ -44,55 +46,36 @@ function Parser:set_included_ranges(ranges)
   self.valid = false
 end
 
-local M = {
-  parse_query = vim._ts_parse_query,
-}
+-- TODO(vigoux): not that great way to do it, but that __index method bothers me...
+local M = vim.tbl_extend("error", query, lang)
 
 setmetatable(M, {
   __index = function (t, k)
       if k == "TSHighlighter" then
-        t[k] = require'vim.tshighlighter'
+        t[k] = require'vim.treesitter.highlighter'
+        return t[k]
+      elseif k == "highlighter" then
+        t[k] = require'vim.treesitter.highlighter'
         return t[k]
       end
    end
  })
 
-function M.require_language(lang, path)
-  if vim._ts_has_language(lang) then
-    return true
-  end
-  if path == nil then
-    local fname = 'parser/' .. lang .. '.*'
-    local paths = a.nvim_get_runtime_file(fname, false)
-    if #paths == 0 then
-      -- TODO(bfredl): help tag?
-      error("no parser for '"..lang.."' language")
-    end
-    path = paths[1]
-  end
-  vim._ts_add_language(path, lang)
-end
-
-function M.inspect_language(lang)
-  M.require_language(lang)
-  return vim._ts_inspect_language(lang)
-end
-
-function M.create_parser(bufnr, lang, id)
-  M.require_language(lang)
+function M._create_parser(bufnr, language, id)
+  lang.require_language(language)
   if bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
 
   vim.fn.bufload(bufnr)
 
-  local self = setmetatable({bufnr=bufnr, lang=lang, valid=false}, Parser)
-  self._parser = vim._create_ts_parser(lang)
+  local self = setmetatable({bufnr=bufnr, lang=language, valid=false}, Parser)
+  self._parser = vim._create_ts_parser(language)
   self.changedtree_cbs = {}
   self.lines_cbs = {}
   self:parse()
-    -- TODO(bfredl): use weakref to self, so that the parser is free'd is no plugin is
-    -- using it.
+  -- TODO(bfredl): use weakref to self, so that the parser is free'd is no plugin is
+  -- using it.
   local function lines_cb(_, ...)
     return self:_on_lines(...)
   end
@@ -118,7 +101,7 @@ function M.get_parser(bufnr, ft, buf_attach_cbs)
   local id = tostring(bufnr)..'_'..ft
 
   if parsers[id] == nil then
-    parsers[id] = M.create_parser(bufnr, ft, id)
+    parsers[id] = M._create_parser(bufnr, ft, id)
   end
 
   if buf_attach_cbs and buf_attach_cbs.on_changedtree then
@@ -130,131 +113,6 @@ function M.get_parser(bufnr, ft, buf_attach_cbs)
   end
 
   return parsers[id]
-end
-
--- query: pattern matching on trees
--- predicate matching is implemented in lua
-local Query = {}
-Query.__index = Query
-
-local magic_prefixes = {['\\v']=true, ['\\m']=true, ['\\M']=true, ['\\V']=true}
-local function check_magic(str)
-  if string.len(str) < 2 or magic_prefixes[string.sub(str,1,2)] then
-    return str
-  end
-  return '\\v'..str
-end
-
-function M.parse_query(lang, query)
-  M.require_language(lang)
-  local self = setmetatable({}, Query)
-  self.query = vim._ts_parse_query(lang, vim.fn.escape(query,'\\'))
-  self.info = self.query:inspect()
-  self.captures = self.info.captures
-  self.regexes = {}
-  for id,preds in pairs(self.info.patterns) do
-    local regexes = {}
-    for i, pred in ipairs(preds) do
-      if (pred[1] == "match?" and type(pred[2]) == "number"
-          and type(pred[3]) == "string") then
-        regexes[i] = vim.regex(check_magic(pred[3]))
-      end
-    end
-    if next(regexes) then
-      self.regexes[id] = regexes
-    end
-  end
-  return self
-end
-
-local function get_node_text(node, bufnr)
-  local start_row, start_col, end_row, end_col = node:range()
-  if start_row ~= end_row then
-    return nil
-  end
-  local line = a.nvim_buf_get_lines(bufnr, start_row, start_row+1, true)[1]
-  return string.sub(line, start_col+1, end_col)
-end
-
-function Query:match_preds(match, pattern, bufnr)
-  local preds = self.info.patterns[pattern]
-  if not preds then
-    return true
-  end
-  local regexes = self.regexes[pattern]
-  for i, pred in pairs(preds) do
-    -- Here we only want to return if a predicate DOES NOT match, and
-    -- continue on the other case. This way unknown predicates will not be considered,
-    -- which allows some testing and easier user extensibility (#12173).
-    -- Also, tree-sitter strips the leading # from predicates for us.
-    if pred[1] == "eq?" then
-      local node = match[pred[2]]
-      local node_text = get_node_text(node, bufnr)
-
-      local str
-      if type(pred[3]) == "string" then
-        -- (#eq? @aa "foo")
-        str = pred[3]
-      else
-        -- (#eq? @aa @bb)
-        str = get_node_text(match[pred[3]], bufnr)
-      end
-
-      if node_text ~= str or str == nil then
-        return false
-      end
-    elseif pred[1] == "match?" then
-      if not regexes or not regexes[i] then
-        return false
-      end
-      local node = match[pred[2]]
-      local start_row, start_col, end_row, end_col = node:range()
-      if start_row ~= end_row then
-        return false
-      end
-      if not regexes[i]:match_line(bufnr, start_row, start_col, end_col) then
-        return false
-      end
-    end
-  end
-  return true
-end
-
-function Query:iter_captures(node, bufnr, start, stop)
-  if bufnr == 0 then
-    bufnr = vim.api.nvim_get_current_buf()
-  end
-  local raw_iter = node:_rawquery(self.query,true,start,stop)
-  local function iter()
-    local capture, captured_node, match = raw_iter()
-    if match ~= nil then
-      local active = self:match_preds(match, match.pattern, bufnr)
-      match.active = active
-      if not active then
-        return iter() -- tail call: try next match
-      end
-    end
-    return capture, captured_node
-  end
-  return iter
-end
-
-function Query:iter_matches(node, bufnr, start, stop)
-  if bufnr == 0 then
-    bufnr = vim.api.nvim_get_current_buf()
-  end
-  local raw_iter = node:_rawquery(self.query,false,start,stop)
-  local function iter()
-    local pattern, match = raw_iter()
-    if match ~= nil then
-      local active = self:match_preds(match, pattern, bufnr)
-      if not active then
-        return iter() -- tail call: try next match
-      end
-    end
-    return pattern, match
-  end
-  return iter
 end
 
 return M

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -11,19 +11,52 @@ local ts_hs_ns = a.nvim_create_namespace("treesitter_hl")
 -- go through a few tree-sitter provided queries and decide
 -- on translations that makes the most sense.
 TSHighlighter.hl_map = {
-    keyword="Keyword",
-    string="String",
-    type="Type",
-    comment="Comment",
-    constant="Constant",
-    operator="Operator",
-    number="Number",
-    label="Label",
-    ["function"]="Function",
-    ["function.special"]="Function",
+    ["error"] = "Error",
+
+-- Miscs
+    ["comment"] = "Comment",
+    ["function.special"] = "Function",
+    ["punctuation.delimiter"] = "Delimiter",
+    ["punctuation.bracket"] = "Delimiter",
+    ["punctuation.special"] = "Delimiter",
+
+-- Constants
+    ["constant"] = "Constant",
+    ["constant.builtin"] = "Special",
+    ["constant.macro"] = "Define",
+    ["string"] = "String",
+    ["string.regex"] = "String",
+    ["string.escape"] = "SpecialChar",
+    ["character"] = "Character",
+    ["number"] = "Number",
+    ["boolean"] = "Boolean",
+    ["float"] = "Float",
+
+-- Functions
+    ["function"] = "Function",
+    ["function.builtin"] = "Special",
+    ["function.macro"] = "Macro",
+    ["parameter"] = "Identifier",
+    ["method"] = "Function",
+    ["field"] = "Identifier",
+    ["property"] = "Identifier",
+    ["constructor"] = "Special",
+
+-- Keywords
+    ["conditional"] = "Conditional",
+    ["repeat"] = "Repeat",
+    ["label"] = "Label",
+    ["operator"] = "Operator",
+    ["keyword"] = "Keyword",
+    ["exception"] = "Exception",
+
+    ["type"] = "Type",
+    ["type.builtin"] = "Type",
+    ["structure"] = "Structure",
+    ["include"] = "Include",
 }
 
-function TSHighlighter.new(query, bufnr, ft)
+function TSHighlighter.new(bufnr, ft, query)
   local self = setmetatable({}, TSHighlighter)
   self.parser = vim.treesitter.get_parser(
     bufnr,
@@ -75,7 +108,18 @@ end
 function TSHighlighter:set_query(query)
   if type(query) == "string" then
     query = vim.treesitter.parse_query(self.parser.lang, query)
+  elseif query == nil then
+    query = vim.treesitter.get_query(self.parser.lang, 'highlights')
+
+    if query == nil then
+      a.err_writeln("No highlights.scm query found for " .. self.parser.lang)
+
+      if query == nil then
+        query = vim.treesitter.parse_query(self.parser.lang, "")
+      end
+    end
   end
+
   self.query = query
 
   self.hl_cache = setmetatable({}, {

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -7,9 +7,6 @@ local ts_hs_ns = a.nvim_create_namespace("treesitter_hl")
 
 -- These are conventions defined by tree-sitter, though it
 -- needs to be user extensible also.
--- TODO(bfredl): this is very much incomplete, we will need to
--- go through a few tree-sitter provided queries and decide
--- on translations that makes the most sense.
 TSHighlighter.hl_map = {
     ["error"] = "Error",
 
@@ -112,11 +109,8 @@ function TSHighlighter:set_query(query)
     query = vim.treesitter.get_query(self.parser.lang, 'highlights')
 
     if query == nil then
-      a.err_writeln("No highlights.scm query found for " .. self.parser.lang)
-
-      if query == nil then
-        query = vim.treesitter.parse_query(self.parser.lang, "")
-      end
+      a.nvim_err_writeln("No highlights.scm query found for " .. self.parser.lang)
+      query = vim.treesitter.parse_query(self.parser.lang, "")
     end
   end
 

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -2,6 +2,12 @@ local a = vim.api
 
 local M = {}
 
+--- Asserts that the provided language is installed, and optionnaly provide a path for the parser
+--
+-- Parsers are searched in the `parser` runtime directory.
+--
+-- @param lang The language the parser should parse
+-- @param path Optionnal path the parser is located at
 function M.require_language(lang, path)
   if vim._ts_has_language(lang) then
     return true
@@ -11,13 +17,18 @@ function M.require_language(lang, path)
     local paths = a.nvim_get_runtime_file(fname, false)
     if #paths == 0 then
       -- TODO(bfredl): help tag?
-      error("no parser for '"..lang.."' language")
+      error("no parser for '"..lang.."' language, see :help treesitter-parsers")
     end
     path = paths[1]
   end
   vim._ts_add_language(path, lang)
 end
 
+--- Inspects the provided language.
+--
+-- Inspecting provides some useful informations on the language like node names, ...
+--
+-- @param lang The language.
 function M.inspect_language(lang)
   M.require_language(lang)
   return vim._ts_inspect_language(lang)

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -1,0 +1,26 @@
+local a = vim.api
+
+local M = {}
+
+function M.require_language(lang, path)
+  if vim._ts_has_language(lang) then
+    return true
+  end
+  if path == nil then
+    local fname = 'parser/' .. lang .. '.*'
+    local paths = a.nvim_get_runtime_file(fname, false)
+    if #paths == 0 then
+      -- TODO(bfredl): help tag?
+      error("no parser for '"..lang.."' language")
+    end
+    path = paths[1]
+  end
+  vim._ts_add_language(path, lang)
+end
+
+function M.inspect_language(lang)
+  M.require_language(lang)
+  return vim._ts_inspect_language(lang)
+end
+
+return M

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -19,6 +19,9 @@ function M.require_language(lang, path)
       -- TODO(bfredl): help tag?
       error("no parser for '"..lang.."' language, see :help treesitter-parsers")
     end
+    if #paths > 1 then
+      print("Warning: multiple parsers were found for :", lang)
+    end
     path = paths[1]
   end
   vim._ts_add_language(path, lang)

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1,0 +1,207 @@
+local a = vim.api
+local lang = require'vim.treesitter.language'
+
+-- query: pattern matching on trees
+-- predicate matching is implemented in lua
+local Query = {}
+Query.__index = Query
+
+local M = {}
+
+local magic_prefixes = {['\\v']=true, ['\\m']=true, ['\\M']=true, ['\\V']=true}
+local function check_magic(str)
+  if string.len(str) < 2 or magic_prefixes[string.sub(str, 1, 2)] then
+    return str
+  end
+  return '\\v'..str
+end
+
+-- Some treesitter grammars extend others.
+-- We can use that to import the queries of the base language
+local base_language_map = {
+  cpp = {'c'},
+  typescript = {'javascript'},
+  tsx = {'typescript', 'javascript'},
+}
+
+function M.base_language_add(language, base_language)
+  if not base_language_map[language] then
+    base_language_map[language] = {}
+  end
+
+  table.insert(base_language_map[language], base_language)
+end
+
+function M.base_language_get(language)
+  return base_language_map[language] or {}
+end
+
+function M.parse_query(language, query)
+  lang.require_language(language)
+  local self = setmetatable({}, Query)
+  self.query = vim._ts_parse_query(language, vim.fn.escape(query,'\\'))
+  self.info = self.query:inspect()
+  self.captures = self.info.captures
+  self.regexes = {}
+  for id, preds in pairs(self.info.patterns) do
+    local regexes = {}
+    for i, pred in ipairs(preds) do
+      if (pred[1] == "match?" and type(pred[2]) == "number"
+          and type(pred[3]) == "string") then
+        regexes[i] = vim.regex(check_magic(pred[3]))
+      end
+    end
+    if not vim.tbl_isempty(regexes) then
+      self.regexes[id] = regexes
+    end
+  end
+  return self
+end
+
+local function read_query_file(filename)
+  local contents = {}
+
+  vim.list_extend(contents, vim.fn.readfile(filename))
+
+  return table.concat(contents, '\n')
+end
+
+--- Gets a fully fledged query from runtime files
+-- @param lang the source language
+-- @param query_name the name of the query (without `.scm`)
+function M.get_query(language, query_name)
+  local query_string = ''
+  if vim.fn.filereadable(query_name) == 1 then
+    query_string = read_query_file(query_name)
+  else
+    local query_files = a.nvim_get_runtime_file(string.format('queries/%s/%s.scm', language, query_name), false)
+    -- First read the files defined for this exact language
+    if #query_files > 0 then
+      query_string = read_query_file(query_files[#query_files]) .. "\n" .. query_string
+    end
+
+    -- Prepend the base language queries this allows to extend the C query to match C++ use case.
+    for _, base_lang in ipairs(M.base_language_get(language)) do
+      local base_files = a.nvim_get_runtime_file(string.format('queries/%s/%s.scm', base_lang, query_name), false)
+      if base_files and #base_files > 0 then
+          query_string = read_query_file(base_files[#base_files]) .. "\n" .. query_string
+      end
+    end
+  end
+
+  -- Finaly parse the query
+  if #query_string > 0 then
+    return M.parse_query(language, query_string)
+  end
+end
+
+-- TODO(vigoux): support multiline nodes too
+local function get_node_text(node, bufnr)
+  local start_row, start_col, end_row, end_col = node:range()
+  if start_row ~= end_row then
+    return nil
+  end
+  local line = a.nvim_buf_get_lines(bufnr, start_row, start_row+1, true)[1]
+  return string.sub(line, start_col+1, end_col)
+end
+
+-- Predicate handler receive the following arguments
+-- (match, pattern, bufnr, regexes, index, predicate)
+local predicate_handlers = {
+  ["eq?"] = function(match, _, bufnr, _, _, predicate)
+      local node = match[predicate[2]]
+      local node_text = get_node_text(node, bufnr)
+
+      local str
+      if type(predicate[3]) == "string" then
+        -- (#eq? @aa "foo")
+        str = predicate[3]
+      else
+        -- (#eq? @aa @bb)
+        str = get_node_text(match[predicate[3]], bufnr)
+      end
+
+      if node_text ~= str or str == nil then
+        return false
+      end
+
+      return true
+  end,
+  ["match?"] = function(match, _, bufnr, regexes, index, predicate)
+      if not regexes or not regexes[index] then
+        return false
+      end
+      local node = match[predicate[2]]
+      local start_row, start_col, end_row, end_col = node:range()
+      if start_row ~= end_row then
+        return false
+      end
+      if not regexes[index]:match_line(bufnr, start_row, start_col, end_col) then
+        return false
+      end
+
+      return true
+  end,
+}
+
+function M.add_predicate(name, handler)
+  predicate_handlers[name] = handler
+end
+
+function Query:match_preds(match, pattern, bufnr)
+  local preds = self.info.patterns[pattern]
+  if not preds then
+    return true
+  end
+  local regexes = self.regexes[pattern]
+  for i, pred in pairs(preds) do
+    -- Here we only want to return if a predicate DOES NOT match, and
+    -- continue on the other case. This way unknown predicates will not be considered,
+    -- which allows some testing and easier user extensibility (#12173).
+    -- Also, tree-sitter strips the leading # from predicates for us.
+    if predicate_handlers[pred[1]] and
+      not predicate_handlers[pred[1]](match, pattern, bufnr, regexes, i, pred) then
+      return false
+    end
+  end
+  return true
+end
+
+function Query:iter_captures(node, bufnr, start, stop)
+  if bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+  local raw_iter = node:_rawquery(self.query, true, start, stop)
+  local function iter()
+    local capture, captured_node, match = raw_iter()
+    if match ~= nil then
+      local active = self:match_preds(match, match.pattern, bufnr)
+      match.active = active
+      if not active then
+        return iter() -- tail call: try next match
+      end
+    end
+    return capture, captured_node
+  end
+  return iter
+end
+
+function Query:iter_matches(node, bufnr, start, stop)
+  if bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+  local raw_iter = node:_rawquery(self.query, false, start, stop)
+  local function iter()
+    local pattern, match = raw_iter()
+    if match ~= nil then
+      local active = self:match_preds(match, pattern, bufnr)
+      if not active then
+        return iter() -- tail call: try next match
+      end
+    end
+    return pattern, match
+  end
+  return iter
+end
+
+return M

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -24,6 +24,10 @@ local base_language_map = {
   tsx = {'typescript', 'javascript'},
 }
 
+--- Register a language as using base_language as it's base.
+--
+-- @param language The language
+-- @param base_langue The language of which the queries will be used as a base.
 function M.base_language_add(language, base_language)
   if not base_language_map[language] then
     base_language_map[language] = {}
@@ -32,10 +36,21 @@ function M.base_language_add(language, base_language)
   table.insert(base_language_map[language], base_language)
 end
 
+--- Returns the base languages of a given language
+--
+-- @param language The language
+--
+-- @returns A table containing the languages @param language uses as it's base.
 function M.base_language_get(language)
   return base_language_map[language] or {}
 end
 
+--- Parses a query.
+--
+-- @param language The language
+-- @param query A string containing the query (s-expr syntax)
+--
+-- @returns The query
 function M.parse_query(language, query)
   lang.require_language(language)
   local self = setmetatable({}, Query)
@@ -67,8 +82,11 @@ local function read_query_file(filename)
 end
 
 --- Gets a fully fledged query from runtime files
--- @param lang the source language
--- @param query_name the name of the query (without `.scm`)
+--
+-- @param lang The source language
+-- @param query_name The name of the query (without `.scm`)
+--
+-- @returns The query
 function M.get_query(language, query_name)
   local query_string = ''
   if vim.fn.filereadable(query_name) == 1 then
@@ -167,6 +185,15 @@ function Query:match_preds(match, pattern, bufnr)
   return true
 end
 
+--- Iterates of the captures of self on a given range.
+--
+-- @param node The node under witch the search will occur
+-- @param buffer The source buffer to search
+-- @param start The starting line of the search
+-- @param stop The stoping line of the search (end-exclusive)
+--
+-- @returns The matching capture id
+-- @returns The captured node
 function Query:iter_captures(node, bufnr, start, stop)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
@@ -186,6 +213,15 @@ function Query:iter_captures(node, bufnr, start, stop)
   return iter
 end
 
+--- Iterates of the matches of self on a given range.
+--
+-- @param node The node under witch the search will occur
+-- @param buffer The source buffer to search
+-- @param start The starting line of the search
+-- @param stop The stoping line of the search (end-exclusive)
+--
+-- @returns The matching pattern id
+-- @returns The matching match
 function Query:iter_matches(node, bufnr, start, stop)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -1,0 +1,138 @@
+[
+  "const"
+  "default"
+  "enum"
+  "extern"
+  "inline"
+  "return"
+  "sizeof"
+  "static"
+  "struct"
+  "typedef"
+  "union"
+  "volatile"
+  "goto"
+] @keyword
+
+[
+  "while"
+  "for"
+  "do"
+  "continue"
+  "break"
+] @repeat
+
+[
+ "if"
+ "else"
+ "case"
+ "switch"
+] @conditional
+
+[
+  "#define"
+  "#if"
+  "#ifdef"
+  "#ifndef"
+  "#else"
+  "#elif"
+  "#endif"
+  "#include"
+  (preproc_directive)
+] @keyword
+
+[
+  "="
+
+  "-"
+  "*"
+  "/"
+  "+"
+
+  "~"
+  "|"
+  "&"
+  "<<"
+  ">>"
+
+  "->"
+
+  "<"
+  "<="
+  ">="
+  ">"
+  "=="
+  "!="
+
+  "!"
+  "&&"
+  "||"
+
+  "-="
+  "+="
+  "*="
+  "/="
+  "|="
+  "&="
+  "--"
+  "++"
+] @operator
+
+[
+ (true)
+ (false)
+] @boolean
+
+[ "." ";" ":" "," ] @punctuation.delimiter
+
+(conditional_expression [ "?" ":" ] @conditional)
+
+
+[ "(" ")" "[" "]" "{" "}"] @punctuation.bracket
+
+(string_literal) @string
+(system_lib_string) @string
+
+(null) @constant.builtin
+(number_literal) @number
+(char_literal) @number
+
+(call_expression
+  function: (identifier) @function)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @function))
+(function_declarator
+  declarator: (identifier) @function)
+(preproc_function_def
+  name: (identifier) @function.macro)
+(preproc_arg)  @function.macro
+; TODO (preproc_arg)  @embedded
+
+(field_identifier) @property
+(statement_identifier) @label
+
+[
+(type_identifier)
+(primitive_type)
+(sized_type_specifier)
+(type_descriptor)
+ ] @type
+
+(declaration type: [(identifier) (type_identifier)] @type)
+(cast_expression type: [(identifier) (type_identifier)] @type)
+(sizeof_expression value: (parenthesized_expression (identifier) @type))
+
+((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$"))
+
+(comment) @comment
+
+;; Parameters
+(parameter_declaration
+  declarator: (_) @parameter)
+
+(preproc_params
+  (identifier)) @parameter
+
+(ERROR) @error


### PR DESCRIPTION
Following https://github.com/neovim/neovim/issues/12619#issuecomment-656832733 I decided to upstream the `runtime query` feature from `nvim-treesitter`. This allows users to _source_ query files from a runtime path at `queries/{lang}`

I removed a bit of machinery from our implementation, but this allows two things :
 - User defined queries (located in the appropriate `.config` subdirs.
 - Base languages, that is, extending a given query using the queries of some base language (like `C++` using the `C` query).

This allows us to create runtime `.scm` files that are `sourced` by treesitter.

Also refactors a bit things to allow a bit more flexibility.

EDIT: Extra addition is out of the box treesitter highlighting of C (still opt in though), using a query defined in `nvim-treesitter`.