### PR TITLE
buffer_updates: set `deleted_bytes` correctly when hitting `~`

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1876,8 +1876,10 @@ errorret:
     buf->b_ml.ml_line_lnum = lnum;
     buf->b_ml.ml_flags &= ~ML_LINE_DIRTY;
   }
-  if (will_change)
+  if (will_change) {
     buf->b_ml.ml_flags |= (ML_LOCKED_DIRTY | ML_LOCKED_POS);
+    ml_add_deleted_len_buf(buf, buf->b_ml.ml_line_ptr, -1);
+  }
 
   return buf->b_ml.ml_line_ptr;
 }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2447,14 +2447,14 @@ int ml_replace_buf(buf_T *buf, linenr_T lnum, char_u *line, bool copy)
   if (buf->b_ml.ml_line_lnum != lnum) {  // other line buffered
     ml_flush_line(buf);  // flush it
   } else if (buf->b_ml.ml_flags & ML_LINE_DIRTY) {  // same line allocated
-    ml_add_deleted_len(buf->b_ml.ml_line_ptr, -1);
+    ml_add_deleted_len_buf(buf, buf->b_ml.ml_line_ptr, -1);
     readlen = false;  // already added the length
 
     xfree(buf->b_ml.ml_line_ptr);  // free it
   }
 
   if (readlen && kv_size(buf->update_callbacks)) {
-    ml_add_deleted_len(ml_get_buf(buf, lnum, false), -1);
+    ml_add_deleted_len_buf(buf, ml_get_buf(buf, lnum, false), -1);
   }
 
   buf->b_ml.ml_line_ptr = line;
@@ -2541,7 +2541,7 @@ static int ml_delete_int(buf_T *buf, linenr_T lnum, bool message)
   // Line should always have an NL char internally (represented as NUL),
   // even if 'noeol' is set.
   assert(line_size >= 1);
-  ml_add_deleted_len((char_u *)dp + line_start, line_size-1);
+  ml_add_deleted_len_buf(buf, (char_u *)dp + line_start, line_size-1);
 
   /*
    * special case: If there is only one line in the data block it becomes empty.

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -360,6 +360,52 @@ static int nlua_schedule(lua_State *const lstate)
       {8:}}                                                                |
                                                                        |
     ]]}
+
+    feed("gg$")
+    feed("~")
+    screen:expect{grid=[[
+      {2:/// Schedule Lua callback on main loop's event queu^E}             |
+      {3:static} {3:int} nlua_schedule({3:lua_State} *{3:const} lstate)                |
+      {                                                                |
+      {2:/*}                                                               |
+      {2:  if (lua_type(lstate, 1) != LUA_TFUNCTION}                       |
+      {2:      || lstate != lstate) {}                                     |
+      {2:    lua_pushliteral(lstate, "vim.schedule: expected function");}  |
+      {2:    return lua_error(lstate);}                                    |
+      {2:*/}                                                               |
+        }                                                              |
+                                                                       |
+        {7:LuaRef} cb = nlua_ref(lstate, {5:1});                               |
+                                                                       |
+        multiqueue_put(main_loop.events, nlua_schedule_event,          |
+                       {5:1}, ({3:void} *)({3:ptrdiff_t})cb);                      |
+        {4:return} {5:0};                                                      |
+      {8:}}                                                                |
+                                                                       |
+    ]]}
+
+
+    feed("re")
+    screen:expect{grid=[[
+      {2:/// Schedule Lua callback on main loop's event queu^e}             |
+      {3:static} {3:int} nlua_schedule({3:lua_State} *{3:const} lstate)                |
+      {                                                                |
+      {2:/*}                                                               |
+      {2:  if (lua_type(lstate, 1) != LUA_TFUNCTION}                       |
+      {2:      || lstate != lstate) {}                                     |
+      {2:    lua_pushliteral(lstate, "vim.schedule: expected function");}  |
+      {2:    return lua_error(lstate);}                                    |
+      {2:*/}                                                               |
+        }                                                              |
+                                                                       |
+        {7:LuaRef} cb = nlua_ref(lstate, {5:1});                               |
+                                                                       |
+        multiqueue_put(main_loop.events, nlua_schedule_event,          |
+                       {5:1}, ({3:void} *)({3:ptrdiff_t})cb);                      |
+        {4:return} {5:0};                                                      |
+      {8:}}                                                                |
+                                                                       |
+    ]]}
   end)
 
   it('inspects language', function()


### PR DESCRIPTION
This PR fixes #12645 
The problem was the `deleted_bytes` of `buf_t` not getting updated in the `pbytes` function, causing every feature relying on this to send wrong buffer updates (and by the same occasion making the treesitter tree out of sync).