### PR TITLE
[RFC] Fix crash on unprotected lua errors

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -987,7 +987,7 @@ int typval_exec_lua_callable(
   PUSH_ALL_TYPVALS(lstate, argvars, argcount, false);
 
   if (lua_pcall(lstate, argcount + offset, 1, 0)) {
-    luaL_error(lstate, "nlua_CFunction_func_call failed.");
+    nlua_print(lstate);
     return ERROR_OTHER;
   }
 

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -255,6 +255,18 @@ describe('luaeval()', function()
     ]])
   end)
 
+  it('can handle functions with errors', function()
+    eq(true, exec_lua [[
+      vim.fn.timer_start(10, function()
+        error("dead function")
+      end)
+
+      vim.wait(1000, function() return false end)
+
+      return true
+    ]])
+  end)
+
   it('should handle passing functions around', function()
     command [[
       function VimCanCallLuaCallbacks(Concat, Cb)


### PR DESCRIPTION
Can be reproduced with a script like this:

-- in some lua file
vim.fn.timer_start(10, function() error("uh....") end)

-- will cause neovim to crash with the following error.
PANIC: unprotected error in call to Lua API
        (nlua_CFunction_func_call failed.)

After this, it will instead print the error message
from the top of the stack, like so.

tmp/error_nvim.lua:10: uh...

Also added an example test. Previously this test
caused the embedded nvim to panic.