### PR TITLE
LSP: check for vim.NIL in buf.lua

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -79,7 +79,7 @@ end
 function M.formatting_sync(options, timeout_ms)
   local params = util.make_formatting_params(options)
   local result = vim.lsp.buf_request_sync(0, "textDocument/formatting", params, timeout_ms)
-  if not result then return end
+  if result ~= vim.NIL then return end
   result = result[1].result
   vim.lsp.util.apply_text_edits(result)
 end


### PR DESCRIPTION
Hi! I have been getting "attempt to index nil value" errors associated with the given line while checking out the nvim LSP client. After viewing #12191, it looks like the issue is that we want to check for vim.NIL instead of just nil. After making this change my issues disappear locally. I'm not sure what exactly causes this issue other than knowing that on reloading my .vimrc and writing a file causes the error consistently.