### PR TITLE
lsp: fix call hierarchies

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -328,14 +328,12 @@ local make_call_hierarchy_handler = function(direction)
     local items = {}
     for _, call_hierarchy_call in pairs(result) do
       local call_hierarchy_item = call_hierarchy_call[direction]
-      for _, range in pairs(call_hierarchy_call.fromRanges) do
-        table.insert(items, {
-          filename = assert(vim.uri_to_fname(call_hierarchy_item.uri)),
-          text = call_hierarchy_item.name,
-          lnum = range.start.line + 1,
-          col = range.start.character + 1,
-        })
-      end
+      table.insert(items, {
+        filename = assert(vim.uri_to_fname(call_hierarchy_item.uri)),
+        text = call_hierarchy_item.name,
+        lnum = call_hierarchy_item.selectionRange.start.line + 1,
+        col = call_hierarchy_item.selectionRange.start.character + 1,
+      })
     end
     util.set_qflist(items)
     api.nvim_command("copen")

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1652,8 +1652,8 @@ describe('LSP', function()
 
       local expected = { {
         bufnr = 2,
-        col = 5,
-        lnum = 4,
+        col = 4,
+        lnum = 1,
         module = "",
         nr = 0,
         pattern = "",
@@ -1724,8 +1724,8 @@ describe('LSP', function()
 
       local expected = { {
         bufnr = 2,
-        col = 5,
-        lnum = 4,
+        col = 4,
+        lnum = 3,
         module = "",
         nr = 0,
         pattern = "",


### PR DESCRIPTION
Jump to function definitions rather than call sites, which also fixes
incorrect quickfix entries when working across multiple files.