### PR TITLE
Backupdir default

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -824,7 +824,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	again not rename the file.
 
 						*'backupdir'* *'bdir'*
-'backupdir' 'bdir'	string	(default ".,$XDG_DATA_HOME/nvim/backup")
+'backupdir' 'bdir'	string	(default ".,$XDG_DATA_HOME/nvim/backup//")
 			global
 	List of directories for the backup file, separated with commas.
 	- The backup file will be created in the first directory in the list
@@ -6421,7 +6421,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'ttyfast' 'tf'		Removed. |vim-differences|
 
 						*'undodir'* *'udir'* *E5003*
-'undodir' 'udir'	string	(default "$XDG_DATA_HOME/nvim/undo")
+'undodir' 'udir'	string	(default "$XDG_DATA_HOME/nvim/undo//")
 			global
 	List of directory names for undo files, separated with commas.
 	See |'backupdir'| for details of the format.
@@ -6546,7 +6546,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	displayed when 'verbosefile' is set.
 
 						*'viewdir'* *'vdir'*
-'viewdir' 'vdir'	string	(default: "$XDG_DATA_HOME/nvim/view")
+'viewdir' 'vdir'	string	(default: "$XDG_DATA_HOME/nvim/view//")
 			global
 	Name of the directory where to store files for |:mkview|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -30,7 +30,7 @@ the differences.
 - 'autoread' is enabled
 - 'background' defaults to "dark" (unless set automatically by the terminal/UI)
 - 'backspace' defaults to "indent,eol,start"
-- 'backupdir' defaults to .,~/.local/share/nvim/backup (|xdg|)
+- 'backupdir' defaults to .,~/.local/share/nvim/backup// (|xdg|)
 - 'belloff' defaults to "all"
 - 'compatible' is always disabled
 - 'complete' excludes "i"
@@ -61,7 +61,7 @@ the differences.
 - 'ttimeoutlen' defaults to 50
 - 'ttyfast' is always set
 - 'viewoptions' includes "unix,slash"
-- 'undodir' defaults to ~/.local/share/nvim/undo (|xdg|), auto-created
+- 'undodir' defaults to ~/.local/share/nvim/undo// (|xdg|), auto-created
 - 'viminfo' includes "!"
 - 'wildmenu' is enabled
 - 'wildoptions' defaults to "pum,tagfile"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2805,6 +2805,17 @@ buf_write(
          * Isolate one directory name, using an entry in 'bdir'.
          */
         (void)copy_option_part(&dirp, IObuff, IOSIZE, ",");
+        if (!os_isdir(IObuff)) {
+          int ret;
+          char *failed_dir;
+          if ((ret = os_mkdir_recurse((char *)IObuff, 0755, &failed_dir))
+              != 0) {
+            EMSG3(_("E303: Unable to create directory \"%s\" for backup file, "
+                    "recovery impossible: %s"),
+                  failed_dir, os_strerror(ret));
+            xfree(failed_dir);
+          }
+        }
         p = IObuff + STRLEN(IObuff);
         if (after_pathsep((char *)IObuff, (char *)p) && p[-1] == p[-2]) {
           // Ends with '//', Use Full path

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -759,17 +759,17 @@ void set_init_1(bool clean_arg)
 #endif
                      false);
 
-  char *backupdir = stdpaths_user_data_subpath("backup", 0, true);
+  char *backupdir = stdpaths_user_data_subpath("backup", 2, true);
   const size_t backupdir_len = strlen(backupdir);
   backupdir = xrealloc(backupdir, backupdir_len + 3);
   memmove(backupdir + 2, backupdir, backupdir_len + 1);
   memmove(backupdir, ".,", 2);
-  set_string_default("viewdir", stdpaths_user_data_subpath("view", 0, true),
-                     true);
   set_string_default("backupdir", backupdir, true);
+  set_string_default("viewdir", stdpaths_user_data_subpath("view", 2, true),
+                     true);
   set_string_default("directory", stdpaths_user_data_subpath("swap", 2, true),
                      true);
-  set_string_default("undodir", stdpaths_user_data_subpath("undo", 0, true),
+  set_string_default("undodir", stdpaths_user_data_subpath("undo", 2, true),
                      true);
   // Set default for &runtimepath. All necessary expansions are performed in
   // this function.

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -361,11 +361,11 @@ describe('XDG-based defaults', function()
           .. ',' .. ('/a'):rep(2048) .. '/nvim/after'
           .. ',' .. ('/x'):rep(4096) .. '/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,' .. ('/X'):rep(4096) .. '/nvim/backup',
+      eq('.,' .. ('/X'):rep(4096) .. '/nvim/backup//',
          meths.get_option('backupdir'))
       eq(('/X'):rep(4096) .. '/nvim/swap//', meths.get_option('directory'))
-      eq(('/X'):rep(4096) .. '/nvim/undo', meths.get_option('undodir'))
-      eq(('/X'):rep(4096) .. '/nvim/view', meths.get_option('viewdir'))
+      eq(('/X'):rep(4096) .. '/nvim/undo//', meths.get_option('undodir'))
+      eq(('/X'):rep(4096) .. '/nvim/view//', meths.get_option('viewdir'))
     end)
   end)
 
@@ -408,10 +408,10 @@ describe('XDG-based defaults', function()
           .. ',$XDG_DATA_DIRS/nvim/after'
           .. ',$XDG_DATA_HOME/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,$XDG_CONFIG_HOME/nvim/backup', meths.get_option('backupdir'))
+      eq('.,$XDG_CONFIG_HOME/nvim/backup//', meths.get_option('backupdir'))
       eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
-      eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
-      eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
+      eq('$XDG_CONFIG_HOME/nvim/undo//', meths.get_option('undodir'))
+      eq('$XDG_CONFIG_HOME/nvim/view//', meths.get_option('viewdir'))
       meths.command('set all&')
       eq(('$XDG_DATA_HOME/nvim'
           .. ',$XDG_DATA_DIRS/nvim'
@@ -424,10 +424,10 @@ describe('XDG-based defaults', function()
           .. ',$XDG_DATA_DIRS/nvim/after'
           .. ',$XDG_DATA_HOME/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,$XDG_CONFIG_HOME/nvim/backup', meths.get_option('backupdir'))
+      eq('.,$XDG_CONFIG_HOME/nvim/backup//', meths.get_option('backupdir'))
       eq('$XDG_CONFIG_HOME/nvim/swap//', meths.get_option('directory'))
-      eq('$XDG_CONFIG_HOME/nvim/undo', meths.get_option('undodir'))
-      eq('$XDG_CONFIG_HOME/nvim/view', meths.get_option('viewdir'))
+      eq('$XDG_CONFIG_HOME/nvim/undo//', meths.get_option('undodir'))
+      eq('$XDG_CONFIG_HOME/nvim/view//', meths.get_option('viewdir'))
     end)
   end)
 
@@ -478,10 +478,10 @@ describe('XDG-based defaults', function()
           .. ',\\,-\\,-\\,/nvim/after'
           .. ',\\, \\, \\,/nvim/after'
       ), meths.get_option('runtimepath'))
-      eq('.,\\,=\\,=\\,/nvim/backup', meths.get_option('backupdir'))
+      eq('.,\\,=\\,=\\,/nvim/backup//', meths.get_option('backupdir'))
       eq('\\,=\\,=\\,/nvim/swap//', meths.get_option('directory'))
-      eq('\\,=\\,=\\,/nvim/undo', meths.get_option('undodir'))
-      eq('\\,=\\,=\\,/nvim/view', meths.get_option('viewdir'))
+      eq('\\,=\\,=\\,/nvim/undo//', meths.get_option('undodir'))
+      eq('\\,=\\,=\\,/nvim/view//', meths.get_option('viewdir'))
     end)
   end)
 end)


### PR DESCRIPTION
Fix for #11860

Changed the default options for 'backupdir', 'undodir' and 'viewdir' to have trailing "//". Also removed the '.' from the default from 'backupdir' and it is now autocreated if needed. Modified documentation and tests accordingly.