### PR TITLE
Fix libvterm build for cmake 3.18.0

### DIFF
--- a/third-party/cmake/BuildLibvterm.cmake
+++ b/third-party/cmake/BuildLibvterm.cmake
@@ -27,7 +27,6 @@ function(BuildLibvterm)
       -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
     PATCH_COMMAND "${_libvterm_PATCH_COMMAND}"
-    CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND "${_libvterm_CONFIGURE_COMMAND}"
     BUILD_COMMAND "${_libvterm_BUILD_COMMAND}"


### PR DESCRIPTION
Fixes #12675 

The cmake file for libvterm had an empty `CONFIGURE_COMMAND ""`, which tells cmake to skip the configure step for this dependency (even though a later patch added another, actual, `CONFIGURE_COMMAND` two lines below). Evidently the recently released cmake 3.18.0 is pickier about this than previous versions, causing the build to fail. Removing this line makes the build successful again.

(Tested on macOS, cmake 3.18.0 and 3.17.3.)

**EDIT:** CI failure is due to a python3 version mismatch.