### PR TITLE
ci: fix build failure in Travis

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -22,7 +22,7 @@ if [[ "${TRAVIS_OS_NAME}" != osx ]] && command -v pyenv; then
   echo 'Setting Python versions via pyenv'
 
   # Prefer Python 2 over 3 (more conservative).
-  pyenv global 2.7.15:3.7
+  pyenv global 2.7.15:3.7.1
 
   echo 'Updated Python info:'
   (


### PR DESCRIPTION
Supposedly python 3.7 was dropped from the Travis image. We can do `pyenv install 3.7`, but if we don't have any problems with 3.7.1, I'd like to change it to 3.7.1.