### PR TITLE
doc: Use gender-neutral pronouns in the docs.

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -3175,8 +3175,8 @@ window, then the one window will be horizontally split (by default).
 If there's more than one window, the previous window will be re-used on
 the selected file/directory.  If the previous window's associated buffer
 has been modified, and there's only one window with that buffer, then
-the user will be asked if s/he wishes to save the buffer first (yes,
-no, or cancel).
+the user will be asked if they wish to save the buffer first (yes, no, or
+cancel).
 
 Related Actions |netrw-cr| |netrw-o| |netrw-t| |netrw-v|
 Associated setting variables:

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -56,7 +56,7 @@ Disadvantages:
   directories (although Vim tries to avoid that by comparing the path name).
   This will result in bogus ATTENTION warning messages.
 - When you use your home directory, and somebody else tries to edit the same
-  file, he will not see your swap file and will not get the ATTENTION warning
+  file, they will not see your swap file and will not get the ATTENTION warning
   message.
 
 If you want to put swap files in a fixed place, put a command resembling the

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -591,8 +591,8 @@ Creating Vim packages					*package-create*
 This assumes you write one or more plugins that you distribute as a package.
 
 If you have two unrelated plugins you would use two packages, so that Vim
-users can chose what they include or not.  Or you can decide to use one
-package with optional plugins, and tell the user to add the ones he wants with
+users can choose what they include or not.  Or you can decide to use one
+package with optional plugins, and tell the user to add the ones they want with
 `:packadd`.
 
 Decide how you want to distribute the package.  You can create an archive or

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -591,8 +591,8 @@ Creating Vim packages					*package-create*
 This assumes you write one or more plugins that you distribute as a package.
 
 If you have two unrelated plugins you would use two packages, so that Vim
-users can chose what they include or not.  Or you can decide to use one
-package with optional plugins, and tell the user to add the ones he wants with
+users can choose what they include or not.  Or you can decide to use one
+package with optional plugins, and tell the user to add the ones they want with
 `:packadd`.
 
 Decide how you want to distribute the package.  You can create an archive or
@@ -628,9 +628,9 @@ You could add this packadd command in one of your plugins, to be executed when
 the optional plugin is needed.
 
 Run the `:helptags` command to generate the doc/tags file.  Including this
-generated file in the package means that the user can drop the package in his
-pack directory and the help command works right away.  Don't forget to re-run
-the command after changing the plugin help: >
+generated file in the package means that the user can drop the package in
+their pack directory and the help command works right away.  Don't forget to
+re-run the command after changing the plugin help: >
 	:helptags path/start/foobar/doc
 	:helptags path/opt/fooextra/doc
 

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1407,7 +1407,7 @@ are spelling mistakes this may not be quite right.
 Common words can be specified with the COMMON item.  This will give better
 suggestions when editing a short file.  Example:
 
-	COMMON  the of to and a in is it you that he was for on are ~
+	COMMON  the of to and a in is it you that he she they was for on are ~
 
 The words must be separated by white space, up to 25 per line.
 When multiple regions are specified in a ":mkspell" command the common words

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1905,7 +1905,7 @@ LEX						*lex.vim* *ft-lex-syntax*
 Lex uses brute-force synchronizing as the "^%%$" section delimiter
 gives no clue as to what section follows.  Consequently, the value for >
 	:syn sync minlines=300
-may be changed by the user if s/he is experiencing synchronization
+may be changed by the user if they are experiencing synchronization
 difficulties (such as may happen with large lex files).
 
 
@@ -2936,11 +2936,11 @@ variables in your vimrc:
 
 <   (dash users should use posix)
 
-If there's no "#! ..." line, and the user hasn't availed himself/herself of a
-default sh.vim syntax setting as just shown, then syntax/sh.vim will assume
-the Bourne shell syntax.  No need to quote RFCs or market penetration
-statistics in error reports, please -- just select the default version of the
-sh your system uses and install the associated "let..." in your <.vimrc>.
+If there's no "#! ..." line, and the user hasn't availed themself of a default
+sh.vim syntax setting as just shown, then syntax/sh.vim will assume the Bourne
+shell syntax.  No need to quote RFCs or market penetration statistics in error
+reports, please -- just select the default version of the sh your system uses
+and install the associated "let..." in your <.vimrc>.
 
 The syntax/sh.vim file provides several levels of syntax-based folding: >
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -194,7 +194,7 @@ The name for a highlight or syntax group must consist of ASCII letters, digits
 and the underscore.  As a regexp: "[a-zA-Z0-9_]*".  However, Vim does not give
 an error when using other characters.
 
-To be able to allow each user to pick his favorite set of colors, there must
+To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.
 These are the suggested group names (if syntax highlighting works properly
 you can see the actual color, except for "Ignore"):
@@ -1905,7 +1905,7 @@ LEX						*lex.vim* *ft-lex-syntax*
 Lex uses brute-force synchronizing as the "^%%$" section delimiter
 gives no clue as to what section follows.  Consequently, the value for >
 	:syn sync minlines=300
-may be changed by the user if s/he is experiencing synchronization
+may be changed by the user if they are experiencing synchronization
 difficulties (such as may happen with large lex files).
 
 
@@ -2936,11 +2936,11 @@ variables in your vimrc:
 
 <   (dash users should use posix)
 
-If there's no "#! ..." line, and the user hasn't availed himself/herself of a
-default sh.vim syntax setting as just shown, then syntax/sh.vim will assume
-the Bourne shell syntax.  No need to quote RFCs or market penetration
-statistics in error reports, please -- just select the default version of the
-sh your system uses and install the associated "let..." in your <.vimrc>.
+If there's no "#! ..." line, and the user hasn't availed themself of a default
+sh.vim syntax setting as just shown, then syntax/sh.vim will assume the Bourne
+shell syntax.  No need to quote RFCs or market penetration statistics in error
+reports, please -- just select the default version of the sh your system uses
+and install the associated "let..." in your <.vimrc>.
 
 The syntax/sh.vim file provides several levels of syntax-based folding: >
 
@@ -4417,7 +4417,7 @@ two different ways:
 	  (e.g., "syntax/pod.vim") the file is searched for in 'runtimepath'.
 	  All matching files are loaded.  Using a relative path is
 	  recommended, because it allows a user to replace the included file
-	  with his own version, without replacing the file that does the ":syn
+	  with their own version, without replacing the file that does the ":syn
 	  include".
 
 						*E847*

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -370,8 +370,8 @@ displaying the line.  The text in the file remains unchanged.
 	|letter generation program for a b|
 	|ank.  They wanted to send out a s|
 	|pecial, personalized letter to th|
-	|eir richest 1000 customers.  Unfo|
-	|rtunately for the programmer, he |
+	|eir richest 1000 customers.  Lame|
+	|ntably for the programmer, they  |
 	+---------------------------------+
 After: >
 
@@ -384,7 +384,7 @@ it looks like this:
 	|bank.  They wanted to send out a |
 	|special, personalized letter to  |
 	|their richest 1000 customers.    |
-	|Unfortunately for the programmer,|
+	|Lamentably for the programmer,   |
 	+---------------------------------+
 
 Related options:

--- a/runtime/doc/usr_28.txt
+++ b/runtime/doc/usr_28.txt
@@ -342,8 +342,8 @@ by a ">" before the line.  To fold these quotes use this: >
 
 You can try it out on this text:
 
-> quoted text he wrote
-> quoted text he wrote
+> quoted text they wrote
+> quoted text they wrote
 > > double quoted text I wrote
 > > double quoted text I wrote
 

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -335,7 +335,7 @@ Now when you type >
 Vim echoes "Hello World".  However, if you add a double quote, it won't work.
 For example: >
 
-	:Say he said "hello"
+	:Say they said "hello"
 
 To get special characters turned into a string, properly escaped to use as an
 expression, use "<q-args>": >
@@ -344,7 +344,7 @@ expression, use "<q-args>": >
 
 Now the above ":Say" command will result in this to be executed: >
 
-	:echo "he said \"hello\""
+	:echo "they said \"hello\""
 
 The <f-args> keyword contains the same information as the <args> keyword,
 except in a format suitable for use as function call arguments.  For example:

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1851,7 +1851,7 @@ NOT LOADING
 
 It's possible that a user doesn't always want to load this plugin.  Or the
 system administrator has dropped it in the system-wide plugin directory, but a
-user has his own plugin he wants to use.  Then the user must have a chance to
+user has their own plugin they want to use.  Then the user must have a chance to
 disable loading this specific plugin.  This will make it possible: >
 
   6	if exists("g:loaded_typecorr")
@@ -1884,7 +1884,7 @@ item can be used: >
 
 The "<Plug>TypecorrAdd" thing will do the work, more about that further on.
 
-The user can set the "mapleader" variable to the key sequence that he wants
+The user can set the "mapleader" variable to the key sequence that they want
 this mapping to start with.  Thus if the user has done: >
 
 	let mapleader = "_"
@@ -1895,7 +1895,7 @@ will be used, which is a backslash.  Then a map for "\a" will be defined.
 Note that <unique> is used, this will cause an error message if the mapping
 already happened to exist. |:map-<unique>|
 
-But what if the user wants to define his own key sequence?  We can allow that
+But what if the user wants to define their own key sequence?  We can allow that
 with this mechanism: >
 
  21	if !hasmapto('<Plug>TypecorrAdd')
@@ -1904,7 +1904,7 @@ with this mechanism: >
 
 This checks if a mapping to "<Plug>TypecorrAdd" already exists, and only
 defines the mapping from "<Leader>a" if it doesn't.  The user then has a
-chance of putting this in his vimrc file: >
+chance of putting this in their vimrc file: >
 
 	map ,c  <Plug>TypecorrAdd
 
@@ -2009,7 +2009,7 @@ Now let's add a user command to add a correction: >
 The user command is defined only if no command with the same name already
 exists.  Otherwise we would get an error here.  Overriding the existing user
 command with ":command!" is not a good idea, this would probably make the user
-wonder why the command he defined himself doesn't work.  |:command|
+wonder why the command they defined themself doesn't work.  |:command|
 
 
 SCRIPT VARIABLES
@@ -2261,7 +2261,7 @@ An example of how to define functionality in a filetype plugin: >
 |hasmapto()| is used to check if the user has already defined a map to
 <Plug>JavaImport.  If not, then the filetype plugin defines the default
 mapping.  This starts with |<LocalLeader>|, which allows the user to select
-the key(s) he wants filetype plugin mappings to start with.  The default is a
+the key(s) they want filetype plugin mappings to start with.  The default is a
 backslash.
 "<unique>" is used to give an error message if the mapping already exists or
 overlaps with an existing mapping.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1851,7 +1851,7 @@ NOT LOADING
 
 It's possible that a user doesn't always want to load this plugin.  Or the
 system administrator has dropped it in the system-wide plugin directory, but a
-user has his own plugin he wants to use.  Then the user must have a chance to
+user has their own plugin they want to use.  Then the user must have a chance to
 disable loading this specific plugin.  This will make it possible: >
 
   6	if exists("g:loaded_typecorr")
@@ -1884,7 +1884,7 @@ item can be used: >
 
 The "<Plug>TypecorrAdd" thing will do the work, more about that further on.
 
-The user can set the "mapleader" variable to the key sequence that he wants
+The user can set the "mapleader" variable to the key sequence that they want
 this mapping to start with.  Thus if the user has done: >
 
 	let mapleader = "_"
@@ -2009,7 +2009,7 @@ Now let's add a user command to add a correction: >
 The user command is defined only if no command with the same name already
 exists.  Otherwise we would get an error here.  Overriding the existing user
 command with ":command!" is not a good idea, this would probably make the user
-wonder why the command he defined himself doesn't work.  |:command|
+wonder why the command they defined themself doesn't work.  |:command|
 
 
 SCRIPT VARIABLES
@@ -2261,7 +2261,7 @@ An example of how to define functionality in a filetype plugin: >
 |hasmapto()| is used to check if the user has already defined a map to
 <Plug>JavaImport.  If not, then the filetype plugin defines the default
 mapping.  This starts with |<LocalLeader>|, which allows the user to select
-the key(s) he wants filetype plugin mappings to start with.  The default is a
+the key(s) they want filetype plugin mappings to start with.  The default is a
 backslash.
 "<unique>" is used to give an error message if the mapping already exists or
 overlaps with an existing mapping.

--- a/runtime/doc/usr_42.txt
+++ b/runtime/doc/usr_42.txt
@@ -210,7 +210,7 @@ argument: >
 
 Don't use "<silent>" too often.  It is not needed for short commands.  If you
 make a menu for someone else, being able the see the executed command will
-give him a hint about what he could have typed, instead of using the mouse.
+give them a hint about what they could have typed, instead of using the mouse.
 
 
 LISTING MENUS

--- a/runtime/tutor/tutor.tutor
+++ b/runtime/tutor/tutor.tutor
@@ -216,7 +216,7 @@ starting with "$".
 ## INTERACTIVE ELEMENTS *interactive*
 
 As visible in this very document, vim-tutor-mode includes some interactive
-elements to provide feedback to the user about his progress. If the text in
+elements to provide feedback to the user about their progress. If the text in
 these elements satisfies some set condition, a ✓ sign will appear in the gutter
 to the left. Otherwise, a ✗ sign is displayed.
 


### PR DESCRIPTION
This pull request replaces gendered pronouns in the documentation with gender-neutral pronouns. I've followed the  [Google developer documentation style guide](https://developers.google.com/style/pronouns) on how to write gender-neutral technical documentation, and to find instances of gendered language in the documentation, I've been running the following commands:
```
rg '\bhe\b' runtime/doc
rg '\bhim\b' runtime/doc
rg '\bhis\b' runtime/doc
rg '\bhimself\b' runtime/doc
rg '\bshe\b' runtime/doc
rg '\bher\b' runtime/doc
rg '\bhers\b' runtime/doc
rg '\bherself\b' runtime/doc
```