### PR TITLE
vim-patch:8.2.1252

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -632,6 +632,7 @@ void ex_marks(exarg_T *eap)
   char_u      *arg = eap->arg;
   int i;
   char_u      *name;
+  pos_T       *posp, *startp, *endp;
 
   if (arg != NULL && *arg == NUL)
     arg = NULL;
@@ -657,8 +658,18 @@ void ex_marks(exarg_T *eap)
   show_one_mark(']', arg, &curbuf->b_op_end, NULL, true);
   show_one_mark('^', arg, &curbuf->b_last_insert.mark, NULL, true);
   show_one_mark('.', arg, &curbuf->b_last_change.mark, NULL, true);
-  show_one_mark('<', arg, &curbuf->b_visual.vi_start, NULL, true);
-  show_one_mark('>', arg, &curbuf->b_visual.vi_end, NULL, true);
+
+  // Show the marks as where they will jump to.
+  startp = &curbuf->b_visual.vi_start;
+  endp = &curbuf->b_visual.vi_end;
+  if ((lt(*startp, *endp) || endp->lnum == 0) && startp->lnum != 0) {
+    posp = startp;
+  } else {
+    posp = endp;
+  }
+  show_one_mark('<', arg, posp, NULL, true);
+  show_one_mark('>', arg, posp == startp ? endp : startp, NULL, true);
+
   show_one_mark(-1, arg, NULL, NULL, false);
 }
 

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -94,33 +94,43 @@ func Test_marks_cmd()
   new Xtwo
   call setline(1, ['ccc', 'ddd'])
   norm! $mcGmD
+  exe "norm! GVgg\<Esc>G"
   w!
 
   b Xone
   let a = split(execute('marks'), "\n")
   call assert_equal(9, len(a))
-  call assert_equal('mark line  col file/text', a[0])
-  call assert_equal(" '      2    0 bbb", a[1])
-  call assert_equal(' a      1    0 aaa', a[2])
-  call assert_equal(' B      2    2 bbb', a[3])
-  call assert_equal(' D      2    0 Xtwo', a[4])
-  call assert_equal(' "      1    0 aaa', a[5])
-  call assert_equal(' [      1    0 aaa', a[6])
-  call assert_equal(' ]      2    0 bbb', a[7])
-  call assert_equal(' .      2    0 bbb', a[8])
+  call assert_equal(['mark line  col file/text',
+        \ " '      2    0 bbb",
+        \ ' a      1    0 aaa',
+        \ ' B      2    2 bbb',
+        \ ' D      2    0 Xtwo',
+        \ ' "      1    0 aaa',
+        \ ' [      1    0 aaa',
+        \ ' ]      2    0 bbb',
+        \ ' .      2    0 bbb'], a)
 
   b Xtwo
   let a = split(execute('marks'), "\n")
-  call assert_equal(9, len(a))
-  call assert_equal('mark line  col file/text', a[0])
-  call assert_equal(" '      1    0 ccc", a[1])
-  call assert_equal(' c      1    2 ccc', a[2])
-  call assert_equal(' B      2    2 Xone', a[3])
-  call assert_equal(' D      2    0 ddd', a[4])
-  call assert_equal(' "      2    0 ddd', a[5])
-  call assert_equal(' [      1    0 ccc', a[6])
-  call assert_equal(' ]      2    0 ddd', a[7])
-  call assert_equal(' .      2    0 ddd', a[8])
+  call assert_equal(11, len(a))
+  call assert_equal(['mark line  col file/text',
+        \ " '      1    0 ccc",
+        \ ' c      1    2 ccc',
+        \ ' B      2    2 Xone',
+        \ ' D      2    0 ddd',
+        \ ' "      2    0 ddd',
+        \ ' [      1    0 ccc',
+        \ ' ]      2    0 ddd',
+        \ ' .      2    0 ddd',
+        \ ' <      1    0 ccc',
+        \ ' >      2    0 ddd'], a)
+  norm! Gdd
+  w!
+  let a = split(execute('marks <>'), "\n")
+  call assert_equal(3, len(a))
+  call assert_equal(['mark line  col file/text',
+        \ ' <      1    0 ccc',
+        \ ' >      2    0 -invalid-'], a)
 
   b Xone
   delmarks aB


### PR DESCRIPTION
Problem:    ":marks" may show '< and '> mixed up.
Solution:   Show the mark position as where '< and '> would jump.
https://github.com/vim/vim/commit/54c3fcd852f9d986f81547429e850b3364f058d6