### PR TITLE
[WIP] screen: fix line propagation during screen update

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -898,12 +898,7 @@ static void win_update(win_T *wp)
        || type == INVERTED || type == INVERTED_ALL)
       && !wp->w_botfill && !wp->w_old_botfill
       ) {
-    if (mod_top != 0 && wp->w_topline == mod_top) {
-      /*
-       * w_topline is the first changed line, the scrolling will be done
-       * further down.
-       */
-    } else if (wp->w_lines[0].wl_valid
+    if (wp->w_lines[0].wl_valid
                && (wp->w_topline < wp->w_lines[0].wl_lnum
                    || (wp->w_topline == wp->w_lines[0].wl_lnum
                        && wp->w_topfill > wp->w_old_topfill)


### PR DESCRIPTION
After scrolling down using CTRL+D, one win_update() is called and the
following happens in order:

  1) Propagate the line informations that is not above the wp->w_topline
     entries upwards.

  2) Calculate the range of lines affected by the scroll.

  3) Updates wl_lnum of affected lines.

In some cases, win_update() starts with buf->b_mod_set set to true. One
example where this can happen is when the scroll results in the cursor
pointing to a parentheses/bracket. The scroll generates a CursorMoved
event that gets applied by matchparen autocommand, which will result in
a call to match_add() and set buf->b_mod_set to true.

When buf->b_mod_set is set to true, the first step of the usual
win_update() on scroll does not happen because another conditional
branch might be chosen (see the deleted conditional). This results in
stale wl_lnum for lines above wp->w_topline.

The calculation done on the second step requires the wp->w_topline to be
found. However, if the propagation step does not happen, the line that
correponds to wp->w_topline will be situated are the line with higher
index than the reality.

Fixes: #12285