### PR TITLE
vim-patch:8.2.0861

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2174,6 +2174,7 @@ getjumplist([{winnr} [, {tabnr}]])
 getline({lnum})			String	line {lnum} of current buffer
 getline({lnum}, {end})		List	lines {lnum} to {end} of current buffer
 getloclist({nr} [, {what}])	List	list of location list items
+getmarklist([{expr}])		List	list of global/local marks
 getmatches([{win}])		List	list of current matches
 getpid()			Number	process ID of Vim
 getpos({expr})			List	position of cursor, mark, etc.
@@ -4635,6 +4636,24 @@ getloclist({nr},[, {what}])				*getloclist()*
 		window used to display files from the location list. This
 		field is applicable only when called from a location list
 		window.
+
+getmarklist([{expr}]					*getmarklist()*
+		Without the {expr} argument returns a |List| with information
+		about all the global marks. |mark|
+
+		If the optional {expr} argument is specified, returns the
+		local marks defined in buffer {expr}.  For the use of {expr},
+		see |bufname()|.
+
+		Each item in the retuned List is a |Dict| with the following:
+		    name - name of the mark prefixed by "'"
+		    pos - a |List| with the position of the mark:
+				[bufnum, lnum, col, off]
+			  Refer to |getpos()| for more information.
+		    file - file name
+
+		Refer to |getpos()| for getting information about a specific
+		mark.
 
 getmatches([{win}])					*getmatches()*
 		Returns a |List| with all matches previously defined for the

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -723,6 +723,7 @@ Cursor and mark position:		*cursor-functions* *mark-functions*
 	getcurpos()		get position of the cursor
 	getpos()		get position of cursor, mark, etc.
 	setpos()		set position of cursor, mark, etc.
+	getmarklist()		list of global/local marks
 	byte2line()		get line number at a specific byte count
 	line2byte()		byte count at a specific line
 	diff_filler()		get the number of filler lines above a line

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -150,6 +150,7 @@ return {
     getjumplist={args={0, 2}},
     getline={args={1, 2}},
     getloclist={args={1, 2}},
+    getmarklist={args={0, 1}},
     getmatches={args={0, 1}},
     getpid={},
     getpos={args=1},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3509,6 +3509,29 @@ static void f_getloclist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   get_qf_loc_list(false, wp, &argvars[1], rettv);
 }
 
+
+/// "getmarklist()" function
+static void f_getmarklist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  buf_T *buf = NULL;
+
+  if (tv_list_alloc_ret(rettv, kListLenMayKnow) == NULL) {
+    return;
+  }
+
+  if (argvars[0].v_type == VAR_UNKNOWN) {
+    get_global_marks(rettv->vval.v_list);
+    return;
+  }
+
+  buf = tv_get_buf(&argvars[0], false);
+  if (buf == NULL) {
+    return;
+  }
+
+  get_buf_local_marks(buf, rettv->vval.v_list);
+}
+
 /*
  * "getmatches()" function
  */

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3513,7 +3513,6 @@ static void f_getloclist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "getmarklist()" function
 static void f_getmarklist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-
   tv_list_alloc_ret(rettv, kListLenMayKnow);
 
   if (argvars[0].v_type == VAR_UNKNOWN) {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3513,18 +3513,15 @@ static void f_getloclist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "getmarklist()" function
 static void f_getmarklist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  buf_T *buf = NULL;
 
-  if (tv_list_alloc_ret(rettv, kListLenMayKnow) == NULL) {
-    return;
-  }
+  tv_list_alloc_ret(rettv, kListLenMayKnow);
 
   if (argvars[0].v_type == VAR_UNKNOWN) {
     get_global_marks(rettv->vval.v_list);
     return;
   }
 
-  buf = tv_get_buf(&argvars[0], false);
+  buf_T *buf = tv_get_buf(&argvars[0], false);
   if (buf == NULL) {
     return;
   }

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1557,23 +1557,14 @@ void mark_mb_adjustpos(buf_T *buf, pos_T *lp)
 // Add information about mark 'mname' to list 'l'
 static int add_mark(list_T *l, char *mname, pos_T *pos, int bufnr, char *fname)
 {
-  dict_T *d;
-  list_T *lpos;
-
   if (pos->lnum <= 0) {
     return OK;
   }
 
-  d = tv_dict_alloc();
-  if (d == NULL) {
-    return FAIL;
-  }
+  dict_T *d = tv_dict_alloc();
   tv_list_append_dict(l, d);
 
-  lpos = tv_list_alloc(kListLenMayKnow);
-  if (lpos == NULL) {
-    return FAIL;
-  }
+  list_T *lpos = tv_list_alloc(kListLenMayKnow);
 
   tv_list_append_number(lpos, bufnr);
   tv_list_append_number(lpos, pos->lnum);

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1552,3 +1552,92 @@ void mark_mb_adjustpos(buf_T *buf, pos_T *lp)
     }
   }
 }
+
+
+// Add information about mark 'mname' to list 'l'
+static int add_mark(list_T *l, char *mname, pos_T *pos, int bufnr, char *fname)
+{
+  dict_T *d;
+  list_T *lpos;
+
+  if (pos->lnum <= 0) {
+    return OK;
+  }
+
+  d = tv_dict_alloc();
+  if (d == NULL) {
+    return FAIL;
+  }
+  tv_list_append_dict(l, d);
+
+  lpos = tv_list_alloc(kListLenMayKnow);
+  if (lpos == NULL) {
+    return FAIL;
+  }
+
+  tv_list_append_number(lpos, bufnr);
+  tv_list_append_number(lpos, pos->lnum);
+  tv_list_append_number(lpos, pos->col);
+  tv_list_append_number(lpos, pos->coladd);
+
+  if (tv_dict_add_str(d, S_LEN("mark"), mname) == FAIL
+      || tv_dict_add_list(d, S_LEN("pos"), lpos) == FAIL
+      || (fname != NULL && tv_dict_add_str(d, S_LEN("file"), fname) == FAIL)) {
+    return FAIL;
+  }
+
+  return OK;
+}
+
+
+/// Get information about marks local to a buffer.
+///
+/// @param[in] buf  Buffer to get the marks from
+/// @param[out] l   List to store marks
+void get_buf_local_marks(buf_T *buf, list_T *l)
+{
+  char mname[3] = "' ";
+
+  // Marks 'a' to 'z'
+  for (int i = 0; i < NMARKS; i++) {
+    mname[1] = (char)('a' + i);
+    add_mark(l, mname, &buf->b_namedm[i].mark, buf->b_fnum, NULL);
+  }
+
+  // Mark '' is a window local mark and not a buffer local mark
+  add_mark(l, (char *)"''", &curwin->w_pcmark, curbuf->b_fnum, NULL);
+
+  add_mark(l, (char *)"'\"", &buf->b_last_cursor.mark, buf->b_fnum, NULL);
+  add_mark(l, (char *)"'[", &buf->b_op_start, buf->b_fnum, NULL);
+  add_mark(l, (char *)"']", &buf->b_op_end, buf->b_fnum, NULL);
+  add_mark(l, (char *)"'^", &buf->b_last_insert.mark, buf->b_fnum, NULL);
+  add_mark(l, (char *)"'.", &buf->b_last_change.mark, buf->b_fnum, NULL);
+  add_mark(l, (char *)"'<", &buf->b_visual.vi_start, buf->b_fnum, NULL);
+  add_mark(l, (char *)"'>", &buf->b_visual.vi_end, buf->b_fnum, NULL);
+}
+
+/// Get information about global marks ('A' to 'Z' and '0' to '9')
+///
+/// @param[out] l  List to store global marks
+void get_global_marks(list_T *l)
+{
+  char mname[3] = "' ";
+  char *name;
+
+  // Marks 'A' to 'Z' and '0' to '9'
+  for (int i = 0; i < NMARKS + EXTRA_MARKS; i++) {
+    if (namedfm[i].fmark.fnum != 0) {
+      name = (char *)buflist_nr2name(namedfm[i].fmark.fnum, true, true);
+    } else {
+      name = (char *)namedfm[i].fname;
+    }
+    if (name != NULL) {
+      mname[1] = i >= NMARKS ? (char)(i - NMARKS + '0') : (char)(i + 'A');
+
+      add_mark(l, mname, &namedfm[i].fmark.mark, namedfm[i].fmark.fnum, name);
+      if (namedfm[i].fmark.fnum != 0) {
+        xfree(name);
+      }
+    }
+  }
+}

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -201,3 +201,28 @@ func Test_mark_error()
   call assert_fails('mark xx', 'E488:')
   call assert_fails('mark _', 'E191:')
 endfunc
+
+" Test for the getmarklist() function
+func Test_getmarklist()
+  new
+  " global marks
+  delmarks A-Z 0-9 \" ^.[]
+  call assert_equal([], getmarklist())
+  call setline(1, ['one', 'two', 'three'])
+  mark A
+  call cursor(3, 5)
+  normal mN
+  call assert_equal([{'file' : '', 'mark' : "'A", 'pos' : [bufnr(), 1, 0, 0]},
+        \ {'file' : '', 'mark' : "'N", 'pos' : [bufnr(), 3, 4, 0]}],
+        \ getmarklist())
+  " buffer local marks
+  delmarks!
+  call assert_equal([{'mark' : "''", 'pos' : [bufnr(), 1, 0, 0]},
+        \ {'mark' : "'\"", 'pos' : [bufnr(), 1, 0, 0]}], getmarklist(bufnr()))
+  call cursor(2, 2)
+  normal mr
+  call assert_equal({'mark' : "'r", 'pos' : [bufnr(), 2, 1, 0]},
+        \ getmarklist(bufnr())[0])
+  call assert_equal([], getmarklist({}))
+  close!
+endfunc


### PR DESCRIPTION
~Currently the added test fails due this assertion:~

```vim
call assert_equal({'mark' : "'r", 'pos' : [bufnr(), 2, 1, 0]},
        \ getmarklist(bufnr())[0])
```

~I will into what's causing this later.~
I've fixed the issue. Tests should succeed.

A question regarding style: How much can/should I deviate from the original patch to fit nvim's style guide (e.g. meaningful variable names, etc.)?