### PR TITLE
vim-patch:8.1.2222: Update indent/typescript.vim

### DIFF
--- a/runtime/indent/typescript.vim
+++ b/runtime/indent/typescript.vim
@@ -442,7 +442,7 @@ let &cpo = s:cpo_save
 unlet s:cpo_save
 
 function! Fixedgq(lnum, count)
-    let l:tw = &tw ? &tw : 80;
+    let l:tw = &tw ? &tw : 80
 
     let l:count = a:count
     let l:first_char = indent(a:lnum) + 1


### PR DESCRIPTION
Remove trailing `;` from the Fixedgq function.

Typescript conventionally ends expressions with a semicolon; however, Vimscript does not. As a result, using <kbd>gq</kbd> in a typescript file will raise an error instead of reformatting a text object.

This commit fixes it.