### PR TITLE
[RDY] vim-patch:8.1.{265,271,273,274,275,277,278,279,280,281,282,284,286,291,295,296,320,321,339,351,392,399,552}

### DIFF
--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -169,6 +169,10 @@ struct exarg {
   LineGetter getline;           ///< Function used to get the next line
   void   *cookie;               ///< argument for getline()
   cstack_T *cstack;             ///< condition stack for ":if" etc.
+  long verbose_save;            ///< saved value of p_verbose
+  int save_msg_silent;          ///< saved value of msg_silent
+  int did_esilent;              ///< how many times emsg_silent was incremented
+  bool did_sandbox;             ///< when true did sandbox++
 };
 
 #define FORCE_BIN 1             // ":edit ++bin file"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2301,6 +2301,7 @@ static void free_cmdmod(void)
 
 
 // Parse the address range, if any, in "eap".
+// May set the last search pattern.
 // Return FAIL and set "errormsg" or return OK.
 int parse_cmd_address(exarg_T *eap, char_u **errormsg)
   FUNC_ATTR_NONNULL_ALL
@@ -3683,14 +3684,13 @@ char_u *skip_range(
   return (char_u *)cmd;
 }
 
-/*
- * get a single EX address
- *
- * Set ptr to the next character after the part that was interpreted.
- * Set ptr to NULL when an error is encountered.
- *
- * Return MAXLNUM when no Ex address was found.
- */
+// Get a single EX address
+//
+// Set ptr to the next character after the part that was interpreted.
+// Set ptr to NULL when an error is encountered.
+// This may set the last used search pattern.
+//
+// Return MAXLNUM when no Ex address was found.
 static linenr_T get_address(exarg_T *eap,
                             char_u **ptr,
                             int addr_type,  // flag: one of ADDR_LINES, ...

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -316,8 +316,8 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
             ea.line2 = 1;
             ea.cmd = ccline.cmdbuff;
             ea.addr_type = ADDR_LINES;
-            parse_cmd_address(&ea, &dummy);
             curwin->w_cursor = s->search_start;
+            parse_cmd_address(&ea, &dummy);
             if (ea.addr_count > 0) {
               search_first_line = ea.line1;
               search_last_line = ea.line2;
@@ -384,6 +384,9 @@ static void may_do_incsearch_highlighting(int firstc, long count,
     tm = profile_setlimit(500L);
     if (!p_hls) {
       search_flags += SEARCH_KEEP;
+    }
+    if (search_first_line != 0) {
+      search_flags += SEARCH_START;
     }
     c = ccline.cmdbuff[skiplen + patlen];
     ccline.cmdbuff[skiplen + patlen] = NUL;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -604,13 +604,19 @@ static void finish_incsearch_highlighting(int gotesc, incsearch_state_T *s,
     }
     restore_viewstate(&s->old_viewstate);
     highlight_match = false;
+
+    // by default search all lines
+    search_first_line = 0;
+    search_last_line = MAXLNUM;
+
+    p_magic = s->magic_save;
+
     validate_cursor();          // needed for TAB
     if (call_update_screen) {
       update_screen(SOME_VALID);
     } else {
       redraw_all_later(SOME_VALID);
     }
-    p_magic = s->magic_save;
   }
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -314,6 +314,7 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
             && (STRNCMP(cmd, "substitute", p - cmd) == 0
                 || STRNCMP(cmd, "smagic", p - cmd) == 0
                 || STRNCMP(cmd, "snomagic", MAX(p - cmd, 3)) == 0
+                || STRNCMP(cmd, "sort", p - cmd) == 0
                 || STRNCMP(cmd, "global", p - cmd) == 0
                 || STRNCMP(cmd, "vglobal", p - cmd) == 0)) {
           if (*cmd == 's' && cmd[1] == 'm') {
@@ -330,6 +331,17 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
               return false;
             }
           }
+
+          // For ":sort" skip over flags.
+          if (cmd[0] == 's' && cmd[1] == 'o') {
+            while (ASCII_ISALPHA(*(p = skipwhite(p)))) {
+              ++p;
+            }
+            if (*p == NUL) {
+              return false;
+            }
+          }
+
           p = skipwhite(p);
           delim = *p++;
           end = skip_regexp(p, delim, p_magic, NULL);
@@ -352,7 +364,7 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
                 search_first_line = ea.line1;
                 search_last_line = ea.line2;
               }
-            } else if (*cmd == 's') {
+            } else if (cmd[0] == 's' && cmd[1] != 'o') {
               // :s defaults to the current line
               search_first_line = curwin->w_cursor.lnum;
               search_last_line = curwin->w_cursor.lnum;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1348,6 +1348,8 @@ static int may_do_command_line_next_incsearch(int firstc, long count,
 
   if (firstc == ccline.cmdbuff[skiplen]) {
     pat = last_search_pattern();
+    skiplen = 0;
+    patlen = (int)STRLEN(pat);
   } else {
     pat = ccline.cmdbuff + skiplen;
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -299,6 +299,13 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
             && (STRNCMP(cmd, "substitute", p - cmd) == 0
                 || STRNCMP(cmd, "global", p - cmd) == 0
                 || STRNCMP(cmd, "vglobal", p - cmd) == 0)) {
+          // Check for "global!/".
+          if (*cmd == 'g' && *p == '!') {
+            p++;
+            if (*skipwhite(p) == NUL) {
+              return false;
+            }
+          }
           p = skipwhite(p);
           delim = *p++;
           end = skip_regexp(p, delim, p_magic, NULL);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -295,7 +295,10 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
       if (*cmd == 's' || *cmd == 'g' || *cmd == 'v') {
         // Skip over "substitute" to find the pattern separator.
         for (p = cmd; ASCII_ISALPHA(*p); p++) {}
-        if (*p != NUL) {
+        if (*p != NUL
+            && (STRNCMP(cmd, "substitute", p - cmd) == 0
+                || STRNCMP(cmd, "global", p - cmd) == 0
+                || STRNCMP(cmd, "vglobal", p - cmd) == 0)) {
           delim = *p++;
           end = skip_regexp(p, delim, p_magic, NULL);
           if (end > p) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -423,6 +423,7 @@ static void may_do_incsearch_highlighting(int firstc, long count,
   char_u use_last_pat;
 
   // Parsing range may already set the last search pattern.
+  // NOTE: must call restore_last_search_pattern() before returning!
   save_last_search_pattern();
 
   if (!do_incsearch_highlighting(firstc, s, &skiplen, &patlen)) {
@@ -566,6 +567,7 @@ static int may_add_char_to_search(int firstc, int *c, incsearch_state_T *s)
   int skiplen, patlen;
 
   // Parsing range may already set the last search pattern.
+  // NOTE: must call restore_last_search_pattern() before returning!
   save_last_search_pattern();
 
   // Add a character from under the cursor for 'incsearch'
@@ -573,6 +575,7 @@ static int may_add_char_to_search(int firstc, int *c, incsearch_state_T *s)
     restore_last_search_pattern();
     return FAIL;
   }
+  restore_last_search_pattern();
 
   if (s->did_incsearch) {
     curwin->w_cursor = s->match_end;
@@ -1445,6 +1448,7 @@ static int may_do_command_line_next_incsearch(int firstc, long count,
   int skiplen, patlen;
 
   // Parsing range may already set the last search pattern.
+  // NOTE: must call restore_last_search_pattern() before returning!
   save_last_search_pattern();
 
   if (!do_incsearch_highlighting(firstc, s, &skiplen, &patlen)) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -422,13 +422,18 @@ static void may_do_incsearch_highlighting(int firstc, long count,
   char_u next_char;
   char_u use_last_pat;
 
+  // Parsing range may already set the last search pattern.
+  save_last_search_pattern();
+
   if (!do_incsearch_highlighting(firstc, s, &skiplen, &patlen)) {
+    restore_last_search_pattern();
     finish_incsearch_highlighting(false, s, true);
     return;
   }
 
   // if there is a character waiting, search and redraw later
   if (char_avail()) {
+    restore_last_search_pattern();
     s->incsearch_postponed = true;
     return;
   }
@@ -442,7 +447,6 @@ static void may_do_incsearch_highlighting(int firstc, long count,
     curwin->w_cursor.lnum = search_first_line;
     curwin->w_cursor.col = 0;
   }
-  save_last_search_pattern();
   int i;
 
   // Use the previous pattern for ":s//".
@@ -556,8 +560,13 @@ static void may_do_incsearch_highlighting(int firstc, long count,
 static int may_add_char_to_search(int firstc, int *c, incsearch_state_T *s)
 {
   int skiplen, patlen;
+
+  // Parsing range may already set the last search pattern.
+  save_last_search_pattern();
+
   // Add a character from under the cursor for 'incsearch'
   if (!do_incsearch_highlighting(firstc, s, &skiplen, &patlen)) {
+    restore_last_search_pattern();
     return FAIL;
   }
 
@@ -1431,10 +1440,16 @@ static int may_do_command_line_next_incsearch(int firstc, long count,
                                               bool next_match)
 {
   int skiplen, patlen;
+
+  // Parsing range may already set the last search pattern.
+  save_last_search_pattern();
+
   if (!do_incsearch_highlighting(firstc, s, &skiplen, &patlen)) {
+    restore_last_search_pattern();
     return OK;
   }
   if (patlen == 0 && ccline.cmdbuff[skiplen] == NUL) {
+    restore_last_search_pattern();
     return FAIL;
   }
 
@@ -1454,8 +1469,6 @@ static int may_do_command_line_next_incsearch(int firstc, long count,
   } else {
     pat = ccline.cmdbuff + skiplen;
   }
-
-  save_last_search_pattern();
 
   if (next_match) {
     t = s->match_end;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -519,6 +519,17 @@ static void may_do_incsearch_highlighting(int firstc, long count,
   } else {
     end_pos = curwin->w_cursor;         // shutup gcc 4
   }
+  //
+  // Disable 'hlsearch' highlighting if the pattern matches
+  // everything. Avoids a flash when typing "foo\|".
+  if (!use_last_pat) {
+    next_char = ccline.cmdbuff[skiplen + patlen];
+    ccline.cmdbuff[skiplen + patlen] = NUL;
+    if (empty_pattern(ccline.cmdbuff)) {
+      set_no_hlsearch(true);
+    }
+    ccline.cmdbuff[skiplen + patlen] = next_char;
+  }
 
   validate_cursor();
   // May redraw the status line to show the cursor position.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -319,8 +319,14 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
             curwin->w_cursor = s->search_start;
             parse_cmd_address(&ea, &dummy);
             if (ea.addr_count > 0) {
-              search_first_line = ea.line1;
-              search_last_line = ea.line2;
+              // Allow for reverse match.
+              if (ea.line2 < ea.line1) {
+                search_first_line = ea.line2;
+                search_last_line = ea.line1;
+              } else {
+                search_first_line = ea.line1;
+                search_last_line = ea.line2;
+              }
             } else if (*cmd == 's') {
               // :s defaults to the current line
               search_first_line = curwin->w_cursor.lnum;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -295,10 +295,11 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
       if (*cmd == 's' || *cmd == 'g' || *cmd == 'v') {
         // Skip over "substitute" to find the pattern separator.
         for (p = cmd; ASCII_ISALPHA(*p); p++) {}
-        if (*p != NUL
+        if (*skipwhite(p) != NUL
             && (STRNCMP(cmd, "substitute", p - cmd) == 0
                 || STRNCMP(cmd, "global", p - cmd) == 0
                 || STRNCMP(cmd, "vglobal", p - cmd) == 0)) {
+          p = skipwhite(p);
           delim = *p++;
           end = skip_regexp(p, delim, p_magic, NULL);
           if (end > p || *end == delim) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -529,7 +529,8 @@ static void may_do_incsearch_highlighting(int firstc, long count,
   if (!use_last_pat) {
     next_char = ccline.cmdbuff[skiplen + patlen];
     ccline.cmdbuff[skiplen + patlen] = NUL;
-    if (empty_pattern(ccline.cmdbuff)) {
+    if (empty_pattern(ccline.cmdbuff) && !no_hlsearch) {
+      redraw_all_later(SOME_VALID);
       set_no_hlsearch(true);
     }
     ccline.cmdbuff[skiplen + patlen] = next_char;
@@ -624,10 +625,9 @@ static void finish_incsearch_highlighting(int gotesc, incsearch_state_T *s,
     p_magic = s->magic_save;
 
     validate_cursor();          // needed for TAB
+    redraw_all_later(SOME_VALID);
     if (call_update_screen) {
       update_screen(SOME_VALID);
-    } else {
-      redraw_all_later(SOME_VALID);
     }
   }
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -427,6 +427,7 @@ static void may_do_incsearch_highlighting(int firstc, long count,
         || curwin->w_cursor.lnum > search_last_line) {
       // match outside of address range
       i = 0;
+      curwin->w_cursor = s->search_start;
     }
 
     // if interrupted while searching, behave like it failed

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -391,7 +391,7 @@ static bool do_incsearch_highlighting(int firstc, incsearch_state_T *s,
   // parse the address range
   save_cursor = curwin->w_cursor;
   curwin->w_cursor = s->search_start;
-  parse_cmd_address(&ea, &dummy);
+  parse_cmd_address(&ea, &dummy, true);
   if (ea.addr_count > 0) {
     // Allow for reverse match.
     if (ea.line2 < ea.line1) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -353,9 +353,11 @@ EXTERN int t_colors INIT(= 256);                // int value of T_CCO
 // position.  Search_match_lines is the number of lines after the match (0 for
 // a match within one line), search_match_endcol the column number of the
 // character just after the match in the last line.
-EXTERN int highlight_match INIT(= false);       // show search match pos
-EXTERN linenr_T search_match_lines;             // lines of of matched string
-EXTERN colnr_T search_match_endcol;             // col nr of match end
+EXTERN bool highlight_match INIT(= false);         // show search match pos
+EXTERN linenr_T search_match_lines;                // lines of of matched string
+EXTERN colnr_T search_match_endcol;                // col nr of match end
+EXTERN linenr_T search_first_line INIT(= 0);       // for :{FIRST},{last}s/pat
+EXTERN linenr_T search_last_line INIT(= MAXLNUM);  // for :{first},{LAST}s/pat
 
 EXTERN int no_smartcase INIT(= false);          // don't use 'smartcase' once
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5918,6 +5918,12 @@ next_search_hl (
   long nmatched = 0;
   int save_called_emsg = called_emsg;
 
+  // for :{range}s/pat only highlight inside the range
+  if (lnum < search_first_line || lnum > search_last_line) {
+    shl->lnum = 0;
+    return;
+  }
+
   if (shl->lnum != 0) {
     // Check for three situations:
     // 1. If the "lnum" is below a previous match, start a new search.

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -99,6 +99,7 @@ static struct spat saved_spats[2];
 // copy of spats[RE_SEARCH], for keeping the search patterns while incremental
 // searching
 static struct spat  saved_last_search_spat;
+static int did_save_last_search_spat = 0;
 static int saved_last_idx = 0;
 static bool saved_no_hlsearch = false;
 
@@ -316,6 +317,12 @@ void free_search_patterns(void)
 /// cancelling incremental searching even if it's called inside user functions.
 void save_last_search_pattern(void)
 {
+  if (did_save_last_search_spat != 0) {
+    IEMSG("did_save_last_search_spat is not zero");
+  } else {
+    did_save_last_search_spat++;
+  }
+
   saved_last_search_spat = spats[RE_SEARCH];
   if (spats[RE_SEARCH].pat != NULL) {
     saved_last_search_spat.pat = vim_strsave(spats[RE_SEARCH].pat);
@@ -326,8 +333,15 @@ void save_last_search_pattern(void)
 
 void restore_last_search_pattern(void)
 {
+  if (did_save_last_search_spat != 1) {
+    IEMSG("did_save_last_search_spat is not one");
+    return;
+  }
+  did_save_last_search_spat--;
+
   xfree(spats[RE_SEARCH].pat);
   spats[RE_SEARCH] = saved_last_search_spat;
+  saved_last_search_spat.pat = NULL;
   set_vv_searchforward();
   last_idx = saved_last_idx;
   set_no_hlsearch(saved_no_hlsearch);

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -356,7 +356,7 @@ func Cmdline3_prep()
   set incsearch
 endfunc
 
-func Cmdline3_cleanup()
+func Incsearch_cleanup()
   throw 'skipped: Nvim does not support test_override()'
   set noincsearch
   call test_override("char_avail", 0)
@@ -374,7 +374,7 @@ func Test_search_cmdline3()
   call feedkeys("/the\<c-l>\<cr>", 'tx')
   call assert_equal('  2 the~e', getline('.'))
 
-  call Cmdline3_cleanup()
+  call Incsearch_cleanup()
 endfunc
 
 func Test_search_cmdline3s()
@@ -393,7 +393,7 @@ func Test_search_cmdline3s()
   call feedkeys(":%substitute/the\<c-l>/xxx\<cr>", 'tx')
   call assert_equal('  2 xxxe', getline('.'))
 
-  call Cmdline3_cleanup()
+  call Incsearch_cleanup()
 endfunc
 
 func Test_search_cmdline3g()
@@ -409,7 +409,7 @@ func Test_search_cmdline3g()
   call feedkeys(":global/the\<c-l>/d\<cr>", 'tx')
   call assert_equal('  3 the theother', getline(2))
 
-  call Cmdline3_cleanup()
+  call Incsearch_cleanup()
 endfunc
 
 func Test_search_cmdline3v()
@@ -427,7 +427,7 @@ func Test_search_cmdline3v()
   call assert_equal(1, line('$'))
   call assert_equal('  2 the~e', getline(1))
 
-  call Cmdline3_cleanup()
+  call Incsearch_cleanup()
 endfunc
 
 func Test_search_cmdline4()
@@ -680,6 +680,28 @@ func Test_incsearch_scrolling()
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
   call delete('Xscript')
+endfunc
+
+func Test_incsearch_substitute()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  call test_override("char_avail", 1)
+  new
+  set incsearch
+  for n in range(1, 10)
+    call setline(n, 'foo ' . n)
+  endfor
+  4
+  call feedkeys(":.,.+2s/foo\<BS>o\<BS>o/xxx\<cr>", 'tx')
+  call assert_equal('foo 3', getline(3))
+  call assert_equal('xxx 4', getline(4))
+  call assert_equal('xxx 5', getline(5))
+  call assert_equal('xxx 6', getline(6))
+  call assert_equal('foo 7', getline(7))
+
+  call Incsearch_cleanup()
 endfunc
 
 func Test_search_undefined_behaviour()

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -801,6 +801,44 @@ func Test_keep_last_search_pattern()
   set noincsearch
 endfunc
 
+func Test_word_under_cursor_after_match()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  new
+  call setline(1, 'foo bar')
+  set incsearch
+  call test_override("char_avail", 1)
+  try
+    call feedkeys("/foo\<C-R>\<C-W>\<CR>", 'ntx')
+  catch /E486:/
+  endtry
+  call assert_equal('foobar', @/)
+
+  bwipe!
+  call test_override("ALL", 0)
+  set noincsearch
+endfunc
+
+func Test_subst_word_under_cursor()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  new
+  call setline(1, ['int SomeLongName;', 'for (xxx = 1; xxx < len; ++xxx)'])
+  set incsearch
+  call test_override("char_avail", 1)
+  call feedkeys("/LongName\<CR>", 'ntx')
+  call feedkeys(":%s/xxx/\<C-R>\<C-W>/g\<CR>", 'ntx')
+  call assert_equal('for (SomeLongName = 1; SomeLongName < len; ++SomeLongName)', getline(2))
+
+  bwipe!
+  call test_override("ALL", 0)
+  set noincsearch
+endfunc
+
 func Test_incsearch_with_change()
   if !has('timers') || !exists('+incsearch') || !CanRunVimInTerminal()
     throw 'Skipped: cannot make screendumps and/or timers feature and/or incsearch option missing'

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -783,6 +783,24 @@ func Test_incsearch_vimgrep_dump()
   call delete('Xis_vimgrep_script')
 endfunc
 
+func Test_keep_last_search_pattern()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  new
+  call setline(1, ['foo', 'foo', 'foo'])
+  set incsearch
+  call test_override("char_avail", 1)
+  let @/ = 'bar'
+  call feedkeys(":/foo/s//\<Esc>", 'ntx')
+  call assert_equal('bar', @/)
+
+  bwipe!
+  call test_override("ALL", 0)
+  set noincsearch
+endfunc
+
 func Test_incsearch_with_change()
   if !has('timers') || !exists('+incsearch') || !CanRunVimInTerminal()
     throw 'Skipped: cannot make screendumps and/or timers feature and/or incsearch option missing'

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -408,6 +408,14 @@ func Test_search_cmdline3g()
   undo
   call feedkeys(":global/the\<c-l>/d\<cr>", 'tx')
   call assert_equal('  3 the theother', getline(2))
+  undo
+  call feedkeys(":g!/the\<c-l>/d\<cr>", 'tx')
+  call assert_equal(1, line('$'))
+  call assert_equal('  2 the~e', getline(1))
+  undo
+  call feedkeys(":global!/the\<c-l>/d\<cr>", 'tx')
+  call assert_equal(1, line('$'))
+  call assert_equal('  2 the~e', getline(1))
 
   call Incsearch_cleanup()
 endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -701,7 +701,7 @@ func Test_incsearch_substitute_dump()
 endfunc
 
 " Similar to Test_incsearch_substitute_dump() for :sort
-func Test_incsearch_ssort_dump()
+func Test_incsearch_sort_dump()
   if !exists('+incsearch')
     return
   endif
@@ -826,6 +826,41 @@ func Test_incsearch_scrolling()
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
   call delete('Xscript')
+endfunc
+
+func Test_incsearch_search_dump()
+  if !exists('+incsearch')
+    return
+  endif
+  if !CanRunVimInTerminal()
+    return
+  endif
+  call writefile([
+	\ 'set incsearch hlsearch scrolloff=0',
+	\ 'for n in range(1, 8)',
+	\ '  call setline(n, "foo " . n)',
+	\ 'endfor',
+	\ '3',
+	\ ], 'Xis_search_script')
+  let buf = RunVimInTerminal('-S Xis_search_script', {'rows': 9, 'cols': 70})
+  " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
+  " the 'ambiwidth' check.
+  sleep 100m
+
+  " Need to send one key at a time to force a redraw.
+  call term_sendkeys(buf, '/fo')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_search_01', {})
+  call term_sendkeys(buf, "\<Esc>")
+  sleep 100m
+
+  call term_sendkeys(buf, '/\v')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_search_02', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+  call delete('Xis_search_script')
 endfunc
 
 func Test_incsearch_substitute()

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -796,6 +796,10 @@ func Test_keep_last_search_pattern()
   call feedkeys(":/foo/s//\<Esc>", 'ntx')
   call assert_equal('bar', @/)
 
+  " no error message if pattern not found
+  call feedkeys(":/xyz/s//\<Esc>", 'ntx')
+  call assert_equal('bar', @/)
+
   bwipe!
   call test_override("ALL", 0)
   set noincsearch

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -639,7 +639,6 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, 'o')
   sleep 100m
   call term_sendkeys(buf, 'o')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_01', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -647,30 +646,25 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, "/foo\<CR>")
   sleep 100m
   call term_sendkeys(buf, ':.,.+2s//')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_02', {})
 
   " Deleting last slash should remove the match.
   call term_sendkeys(buf, "\<BS>")
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_03', {})
   call term_sendkeys(buf, "\<Esc>")
 
   " Reverse range is accepted
   call term_sendkeys(buf, ':5,2s/foo')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_04', {})
   call term_sendkeys(buf, "\<Esc>")
 
   " White space after the command is skipped
   call term_sendkeys(buf, ':2,3sub  /fo')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_05', {})
   call term_sendkeys(buf, "\<Esc>")
 
   " Command modifiers are skipped
   call term_sendkeys(buf, ':above below browse botr confirm keepmar keepalt keeppat keepjum filter xxx hide lockm leftabove noau noswap rightbel sandbox silent silent! $tab top unsil vert verbose 4,5s/fo.')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_06', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -678,13 +672,11 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, ":set cursorline\<CR>")
   call term_sendkeys(buf, 'G9G')
   call term_sendkeys(buf, ':9,11s/bar')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_07', {})
   call term_sendkeys(buf, "\<Esc>")
 
   " Cursorline highlighting at cursor when no match
   call term_sendkeys(buf, ':9,10s/bar')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_08', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -692,7 +684,6 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, '3G4G')
   call term_sendkeys(buf, ":nohlsearch\<CR>")
   call term_sendkeys(buf, ':6,7s/\v')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_09', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -704,6 +695,15 @@ func Test_incsearch_substitute_dump()
   sleep 100m
   call term_sendkeys(buf, "\<Esc>")
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_10', {})
+
+  call term_sendkeys(buf, ":split\<CR>")
+  call term_sendkeys(buf, ":let @/ = 'xyz'\<CR>")
+  call term_sendkeys(buf, ":%s/.")
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_11', {})
+  call term_sendkeys(buf, "\<BS>")
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_12', {})
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_13', {})
 
   call StopVimInTerminal(buf)
   call delete('Xis_subst_script')
@@ -728,7 +728,6 @@ func Test_incsearch_sort_dump()
 
   " Need to send one key at a time to force a redraw.
   call term_sendkeys(buf, ':sort ni u /on')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_sort_01', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -755,27 +754,22 @@ func Test_incsearch_vimgrep_dump()
 
   " Need to send one key at a time to force a redraw.
   call term_sendkeys(buf, ':vimgrep on')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_01', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call term_sendkeys(buf, ':vimg /on/ *.txt')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_02', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call term_sendkeys(buf, ':vimgrepadd "\<on')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_03', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call term_sendkeys(buf, ':lv "tha')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_04', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call term_sendkeys(buf, ':lvimgrepa "the" **/*.txt')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_05', {})
   call term_sendkeys(buf, "\<Esc>")
 
@@ -918,13 +912,11 @@ func Test_incsearch_search_dump()
 
   " Need to send one key at a time to force a redraw.
   call term_sendkeys(buf, '/fo')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_search_01', {})
   call term_sendkeys(buf, "\<Esc>")
   sleep 100m
 
   call term_sendkeys(buf, '/\v')
-  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_search_02', {})
   call term_sendkeys(buf, "\<Esc>")
 

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -392,6 +392,14 @@ func Test_search_cmdline3s()
   undo
   call feedkeys(":%substitute/the\<c-l>/xxx\<cr>", 'tx')
   call assert_equal('  2 xxxe', getline('.'))
+  undo
+  call feedkeys(":%smagic/the.e/xxx\<cr>", 'tx')
+  call assert_equal('  2 xxx', getline('.'))
+  undo
+  call assert_fails(":%snomagic/the.e/xxx\<cr>", 'E486')
+  "
+  call feedkeys(":%snomagic/the\\.e/xxx\<cr>", 'tx')
+  call assert_equal('  2 xxx', getline('.'))
 
   call Incsearch_cleanup()
 endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -696,6 +696,15 @@ func Test_incsearch_substitute_dump()
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_09', {})
   call term_sendkeys(buf, "\<Esc>")
 
+  call term_sendkeys(buf, ":set nocursorline\<CR>")
+
+  " All matches are highlighted for 'hlsearch' after the incsearch canceled
+  call term_sendkeys(buf, "1G*")
+  call term_sendkeys(buf, ":2,5s/foo")
+  sleep 100m
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_10', {})
+
   call StopVimInTerminal(buf)
   call delete('Xis_subst_script')
 endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -692,6 +692,33 @@ func Test_incsearch_substitute_dump()
   call delete('Xis_subst_script')
 endfunc
 
+" Similar to Test_incsearch_substitute_dump() for :sort
+func Test_incsearch_ssort_dump()
+  if !exists('+incsearch')
+    return
+  endif
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot make screendumps'
+  endif
+  call writefile([
+	\ 'set incsearch hlsearch scrolloff=0',
+	\ 'call setline(1, ["another one 2", "that one 3", "the one 1"])',
+	\ ], 'Xis_sort_script')
+  let buf = RunVimInTerminal('-S Xis_sort_script', {'rows': 9, 'cols': 70})
+  " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
+  " the 'ambiwidth' check.
+  sleep 100m
+
+  " Need to send one key at a time to force a redraw.
+  call term_sendkeys(buf, ':sort ni u /on')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_sort_01', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+  call delete('Xis_sort_script')
+endfunc
+
 func Test_incsearch_with_change()
   if !has('timers') || !exists('+incsearch') || !CanRunVimInTerminal()
     throw 'Skipped: cannot make screendumps and/or timers feature and/or incsearch option missing'

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -637,6 +637,12 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, "\<BS>")
   sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_03', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  " Reverse range is accepted
+  call term_sendkeys(buf, ':5,2s/foo')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_04', {})
 
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -659,6 +659,12 @@ func Test_incsearch_substitute_dump()
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_05', {})
   call term_sendkeys(buf, "\<Esc>")
 
+  " Command modifiers are skipped
+  call term_sendkeys(buf, ':above below browse botr confirm keepmar keepalt keeppat keepjum filter xxx hide lockm leftabove noau noswap rightbel sandbox silent silent! $tab top unsil vert verbose 4,5s/fo.')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_06', {})
+  call term_sendkeys(buf, "\<Esc>")
+
   call StopVimInTerminal(buf)
   call delete('Xis_subst_script')
 endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -367,6 +367,63 @@ func Test_search_cmdline3()
   bw!
 endfunc
 
+func Cmdline3_prep()
+  throw 'skipped: Nvim does not support test_override()'
+  " need to disable char_avail,
+  " so that expansion of commandline works
+  call test_override("char_avail", 1)
+  new
+  call setline(1, ['  1', '  2 the~e', '  3 the theother'])
+  set incsearch
+endfunc
+
+func Cmdline3_cleanup()
+  throw 'skipped: Nvim does not support test_override()'
+  set noincsearch
+  call test_override("char_avail", 0)
+  bw!
+endfunc
+
+func Test_search_cmdline3s()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  call Cmdline3_prep()
+  1
+  call feedkeys(":%s/the\<c-l>/xxx\<cr>", 'tx')
+  call assert_equal('  2 xxxe', getline('.'))
+
+  call Cmdline3_cleanup()
+endfunc
+
+func Test_search_cmdline3g()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  call Cmdline3_prep()
+  1
+  call feedkeys(":g/the\<c-l>/d\<cr>", 'tx')
+  call assert_equal('  3 the theother', getline(2))
+
+  call Cmdline3_cleanup()
+endfunc
+
+func Test_search_cmdline3v()
+  throw 'skipped: Nvim does not support test_override()'
+  if !exists('+incsearch')
+    return
+  endif
+  call Cmdline3_prep()
+  1
+  call feedkeys(":v/the\<c-l>/d\<cr>", 'tx')
+  call assert_equal(1, line('$'))
+  call assert_equal('  2 the~e', getline(1))
+
+  call Cmdline3_cleanup()
+endfunc
+
 func Test_search_cmdline4()
   " See test/functional/legacy/search_spec.lua
   throw 'skipped: Nvim does not support test_override()'

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -688,6 +688,14 @@ func Test_incsearch_substitute_dump()
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_08', {})
   call term_sendkeys(buf, "\<Esc>")
 
+  " Only \v handled as empty pattern, does not move cursor
+  call term_sendkeys(buf, '3G4G')
+  call term_sendkeys(buf, ":nohlsearch\<CR>")
+  call term_sendkeys(buf, ':6,7s/\v')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_09', {})
+  call term_sendkeys(buf, "\<Esc>")
+
   call StopVimInTerminal(buf)
   call delete('Xis_subst_script')
 endfunc

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -614,6 +614,7 @@ func Test_incsearch_substitute_dump()
   sleep 100m
 
   " Need to send one key at a time to force a redraw.
+  " Select three lines at the cursor with typed pattern.
   call term_sendkeys(buf, ':.,.+2s/')
   sleep 100m
   call term_sendkeys(buf, 'f')
@@ -621,7 +622,21 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, 'o')
   sleep 100m
   call term_sendkeys(buf, 'o')
+  sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_01', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  " Select three lines at the cursor using previous pattern.
+  call term_sendkeys(buf, "/foo\<CR>")
+  sleep 100m
+  call term_sendkeys(buf, ':.,.+2s//')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_02', {})
+
+  " Deleting last slash should remove the match.
+  call term_sendkeys(buf, "\<BS>")
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_03', {})
 
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -719,6 +719,53 @@ func Test_incsearch_ssort_dump()
   call delete('Xis_sort_script')
 endfunc
 
+" Similar to Test_incsearch_substitute_dump() for :vimgrep famiry
+func Test_incsearch_vimgrep_dump()
+  if !exists('+incsearch')
+    return
+  endif
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot make screendumps'
+  endif
+  call writefile([
+	\ 'set incsearch hlsearch scrolloff=0',
+	\ 'call setline(1, ["another one 2", "that one 3", "the one 1"])',
+	\ ], 'Xis_vimgrep_script')
+  let buf = RunVimInTerminal('-S Xis_vimgrep_script', {'rows': 9, 'cols': 70})
+  " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
+  " the 'ambiwidth' check.
+  sleep 100m
+
+  " Need to send one key at a time to force a redraw.
+  call term_sendkeys(buf, ':vimgrep on')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_01', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ':vimg /on/ *.txt')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_02', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ':vimgrepadd "\<on')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_03', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ':lv "tha')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_04', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ':lvimgrepa "the" **/*.txt')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_vimgrep_05', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+  call delete('Xis_vimgrep_script')
+endfunc
+
 func Test_incsearch_with_change()
   if !has('timers') || !exists('+incsearch') || !CanRunVimInTerminal()
     throw 'Skipped: cannot make screendumps and/or timers feature and/or incsearch option missing'

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -614,6 +614,7 @@ func Test_incsearch_substitute_dump()
 	\ 'for n in range(1, 10)',
 	\ '  call setline(n, "foo " . n)',
 	\ 'endfor',
+	\ 'call setline(11, "bar 11")',
 	\ '3',
 	\ ], 'Xis_subst_script')
   let buf = RunVimInTerminal('-S Xis_subst_script', {'rows': 9, 'cols': 70})
@@ -663,6 +664,20 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, ':above below browse botr confirm keepmar keepalt keeppat keepjum filter xxx hide lockm leftabove noau noswap rightbel sandbox silent silent! $tab top unsil vert verbose 4,5s/fo.')
   sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_06', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  " Cursorline highlighting at match
+  call term_sendkeys(buf, ":set cursorline\<CR>")
+  call term_sendkeys(buf, 'G9G')
+  call term_sendkeys(buf, ':9,11s/bar')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_07', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  " Cursorline highlighting at cursor when no match
+  call term_sendkeys(buf, ':9,10s/bar')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_08', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -643,8 +643,14 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, ':5,2s/foo')
   sleep 100m
   call VerifyScreenDump(buf, 'Test_incsearch_substitute_04', {})
-
   call term_sendkeys(buf, "\<Esc>")
+
+  " White space after the command is skipped
+  call term_sendkeys(buf, ':2,3sub  /fo')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_substitute_05', {})
+  call term_sendkeys(buf, "\<Esc>")
+
   call StopVimInTerminal(buf)
   call delete('Xis_subst_script')
 endfunc

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -21,6 +21,7 @@ describe('search cmdline', function()
       err = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
       more = { bold = true, foreground = Screen.colors.SeaGreen4 },
       tilde = { bold = true, foreground = Screen.colors.Blue1 },
+      hl = { background = Screen.colors.Yellow },
     })
   end)
 
@@ -569,5 +570,21 @@ describe('search cmdline', function()
         3 the third                           |
       ?the                                    |
     ]])
+  end)
+
+  it('incsearch works with :sort', function()
+    -- oldtest: Test_incsearch_sort_dump().
+    screen:try_resize(20, 4)
+    command('set incsearch hlsearch scrolloff=0')
+    funcs.setline(1, {'another one 2', 'that one 3', 'the one 1'})
+
+    feed(':sort ni u /on')
+    screen:expect([[
+      another {inc:on}e 2       |
+      that {hl:on}e 3          |
+      the {hl:on}e 1           |
+      :sort ni u /on^      |
+    ]])
+    feed('<esc>')
   end)
 end)

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -587,4 +587,56 @@ describe('search cmdline', function()
     ]])
     feed('<esc>')
   end)
+
+  it('incsearch works with :vimgrep family', function()
+    -- oldtest: Test_incsearch_vimgrep_dump().
+    screen:try_resize(30, 4)
+    command('set incsearch hlsearch scrolloff=0')
+    funcs.setline(1, {'another one 2', 'that one 3', 'the one 1'})
+
+    feed(':vimgrep on')
+    screen:expect([[
+      another {inc:on}e 2                 |
+      that {hl:on}e 3                    |
+      the {hl:on}e 1                     |
+      :vimgrep on^                   |
+    ]])
+    feed('<esc>')
+
+    feed(':vimg /on/ *.txt')
+    screen:expect([[
+      another {inc:on}e 2                 |
+      that {hl:on}e 3                    |
+      the {hl:on}e 1                     |
+      :vimg /on/ *.txt^              |
+    ]])
+    feed('<esc>')
+
+    feed(':vimgrepadd "\\<LT>on')
+    screen:expect([[
+      another {inc:on}e 2                 |
+      that {hl:on}e 3                    |
+      the {hl:on}e 1                     |
+      :vimgrepadd "\<on^             |
+    ]])
+    feed('<esc>')
+
+    feed(':lv "tha')
+    screen:expect([[
+      another one 2                 |
+      {inc:tha}t one 3                    |
+      the one 1                     |
+      :lv "tha^                      |
+    ]])
+    feed('<esc>')
+
+    feed(':lvimgrepa "the" **/*.txt')
+    screen:expect([[
+      ano{inc:the}r one 2                 |
+      that one 3                    |
+      {hl:the} one 1                     |
+      :lvimgrepa "the" **/*.txt^     |
+    ]])
+    feed('<esc>')
+  end)
 end)

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -162,7 +162,7 @@ describe(":substitute, 'inccommand' preserves", function()
       insert(default_text)
       feed_command("set inccommand=" .. case)
 
-      local delims = { '/', '#', ';', '%', ',', '@', '!', ''}
+      local delims = { '/', '#', ';', '%', ',', '@', '!' }
       for _,delim in pairs(delims) do
         feed_command("%s"..delim.."lines"..delim.."LINES"..delim.."g")
         expect([[


### PR DESCRIPTION
Hello, this is my first time porting patches. I made some changes from the original diff, notably:
1. Change incsearch state argument name from `is_state` to `s`
2. I'm reusing `command_line_next_incsearch` for `may_adjust_incsearch_highlighting`
3. `may_do_incsearch_highlighting` returns a value