### PR TITLE
Document extmark indexing

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -456,8 +456,8 @@ extmark index on a line is 1 larger than the character index: >
      0 1 2 3 4 5  <-- character positions (0-based)
     0 1 2 3 4 5 6 <-- extmark positions (0-based)
 
-Note that extmarks have "right gravity": If you place the cursor directly on
-an extmark position and enter some text, the extmark gets pushed rightward. >
+Note that extmarks have "forward gravity": If you place the cursor directly on
+an extmark position and enter some text, the extmark gets pushed forward. >
 
      f o o|b a r  <-- line (| = cursor)
           3       <-- extmark
@@ -467,9 +467,9 @@ an extmark position and enter some text, the extmark gets pushed rightward. >
      f o o z|b a r  <-- line (| = cursor)
             4       <-- extmark
 
-If your extmark is on the last possible index of a line (`7` in the
-above "foozbar" example) and you enter a newline at that point, the extmark is
-pushed to the next line: >
+If your extmark is on the last possible index of a line (7 in the above
+"foozbar" example) and you enter a newline at that point, the extmark will
+accordingly be pushed to the next line: >
 
      f o o z b a r|  <-- line (| = cursor)
                   7  <-- extmark

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -447,6 +447,41 @@ in the buffer. They could be used to represent cursors, folds, misspelled
 words, and anything else that needs to track a logical location in the buffer
 over time.
 
+Extmarks use |api-indexing|, and you can think of them as cursor positions.
+For example, an extmark at position 1 exists between the first and second
+character on a line, similar to a bar cursor. For that reason, the maximum
+extmark index on a line is 1 larger than the character index: >
+
+     f o o b a r  <-- line contents (with spaces for illustration purposes)
+     0 1 2 3 4 5  <-- character positions (0-based)
+    0 1 2 3 4 5 6 <-- extmark positions (0-based)
+
+Note that extmarks have "right gravity": If you place the cursor directly on
+an extmark position and enter some text, the extmark gets pushed rightward. >
+
+     f o o|b a r  <-- line (| = cursor)
+          3       <-- extmark
+
+     (Now add "z" at cursor position):
+
+     f o o z|b a r  <-- line (| = cursor)
+            4       <-- extmark
+
+If your extmark is on the last possible index of a line (`7` in the
+above "foozbar" example) and you enter a newline at that point, the extmark is
+pushed to the next line: >
+
+     f o o z b a r|  <-- line (| = cursor)
+                  7  <-- extmark
+
+     (Now add <cr> at cursor position):
+
+     f o o z b a r  <-- first line
+                    <-- extmarks (none present)
+     |              <-- second line (| = cursor)
+     0              <-- new extmark position
+
+
 Example:
 
 We will set an extmark at the first row and third column. |api-indexing| is

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -127,6 +127,10 @@ Special types (msgpack EXT) ~
 Most of the API uses 0-based indices, and ranges are end-exclusive. For the
 end of a range, -1 denotes the last line/column.
 
+Exception: the following API functions use 0-based, end-inclusive indexing:
+
+    |nvim_buf_get_extmarks()|
+
 Exception: the following API functions use "mark-like" indexing (1-based
 lines, 0-based columns):
 
@@ -733,14 +737,9 @@ nvim_feedkeys({keys}, {mode}, {escape_csi})                  *nvim_feedkeys()*
                 |nvim_input()|.
 
                 On execution error: does not fail, but updates v:errmsg.
-
-                If you need to input sequences like <C-o> use nvim_replace_termcodes
-                to replace the termcodes and then pass the resulting string to
-                nvim_feedkeys. You'll also want to enable escape_csi.
-
                 Example: >
-		    :let key = nvim_replace_termcodes("<C-o>", v:true, v:false, v:true)
-		    :call nvim_feedkeys(key, 'n', v:true)
+                    :let key = nvim_replace_termcodes("<C-o>", v:true, v:false, v:true)
+                    :call nvim_feedkeys(key, 'n', v:true)
 <
 
                 Parameters: ~
@@ -1766,7 +1765,7 @@ nvim_buf_get_commands({buffer}, {opts})              *nvim_buf_get_commands()*
 
                                                 *nvim_buf_get_extmark_by_id()*
 nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id})
-                Returns position for a given extmark id
+                Returns 0-indexed position for a given extmark id
 
                 Parameters: ~
                     {buffer}  Buffer handle, or 0 for current buffer
@@ -1774,7 +1773,8 @@ nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id})
                     {id}      Extmark id
 
                 Return: ~
-                    (row, col) tuple or empty list () if extmark id was absent
+                    0-indexed (row, col) tuple or empty list () if extmark id
+                    was absent
 
                                                      *nvim_buf_get_extmarks()*
 nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
@@ -1814,10 +1814,12 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
                 Parameters: ~
                     {buffer}  Buffer handle, or 0 for current buffer
                     {ns_id}   Namespace id from |nvim_create_namespace()|
-                    {start}   Start of range, given as (row, col) or valid
-                              extmark id (whose position defines the bound)
-                    {end}     End of range, given as (row, col) or valid
-                              extmark id (whose position defines the bound)
+                    {start}   Start of range, given as 0-indexed (row, col) or
+                              valid extmark id (whose position defines the
+                              bound)
+                    {end}     End of range (inclusive), given as 0-indexed
+                              (row, col) or valid extmark id (whose position
+                              defines the bound)
                     {opts}    Optional parameters. Keys:
                               • limit: Maximum number of marks to return
 
@@ -1982,12 +1984,14 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {id}, {line}, {col}, {opts})
                 of existing and unused ids itself. (Useful over RPC, to avoid
                 waiting for the return value.)
 
+                Uses |api-indexing|.
+
                 Parameters: ~
                     {buffer}  Buffer handle, or 0 for current buffer
                     {ns_id}   Namespace id from |nvim_create_namespace()|
                     {id}      Extmark id, or 0 to create new
-                    {line}    Line number where to place the mark
-                    {col}     Column where to place the mark
+                    {line}    0-indexed line number where to place the mark
+                    {col}     0-indexed column where to place the mark
                     {opts}    Optional parameters. Currently not used.
 
                 Return: ~

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1108,13 +1108,14 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
   return rv;
 }
 
-/// Returns position for a given extmark id
+/// Returns 0-indexed position for a given extmark id
 ///
 /// @param buffer  Buffer handle, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
 /// @param id  Extmark id
 /// @param[out] err   Error details, if any
-/// @return (row, col) tuple or empty list () if extmark id was absent
+/// @return 0-indexed (row, col) tuple or empty list () if extmark id was
+/// absent
 ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
                                             Integer id, Error *err)
   FUNC_API_SINCE(7)
@@ -1175,10 +1176,10 @@ ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
 ///
 /// @param buffer  Buffer handle, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
-/// @param start  Start of range, given as (row, col) or valid extmark id
-///               (whose position defines the bound)
-/// @param end  End of range, given as (row, col) or valid extmark id
-///             (whose position defines the bound)
+/// @param start  Start of range, given as 0-indexed (row, col) or valid
+///               extmark id (whose position defines the bound)
+/// @param end  End of range (inclusive), given as 0-indexed (row, col) or
+///             valid extmark id (whose position defines the bound)
 /// @param opts  Optional parameters. Keys:
 ///          - limit:  Maximum number of marks to return
 /// @param[out] err   Error details, if any
@@ -1266,11 +1267,13 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start,
 /// id, but the caller must then keep track of existing and unused ids itself.
 /// (Useful over RPC, to avoid waiting for the return value.)
 ///
+/// Uses |api-indexing|.
+///
 /// @param buffer  Buffer handle, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
 /// @param id  Extmark id, or 0 to create new
-/// @param line  Line number where to place the mark
-/// @param col  Column where to place the mark
+/// @param line  0-indexed line number where to place the mark
+/// @param col  0-indexed column where to place the mark
 /// @param opts  Optional parameters. Currently not used.
 /// @param[out]  err   Error details, if any
 /// @return Id of the created/updated extmark


### PR DESCRIPTION
Extmarks mostly use api-indexing, except for `nvim_buf_get_extmarks()`, which uses api-indexing with inclusive ranges.