### PR TITLE
Remove docs for unused function (PR #12719)

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1123,10 +1123,6 @@ focusable_preview({unique_name}, {fn})
 get_completion_word({item})               *vim.lsp.util.get_completion_word()*
                 TODO: Documentation
 
-                                   *vim.lsp.util.get_current_line_to_cursor()*
-get_current_line_to_cursor()
-                TODO: Documentation
-
 get_effective_tabstop({bufnr})          *vim.lsp.util.get_effective_tabstop()*
                 Get visual width of tabstop.
 


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/12719 missed removing the docs for
`vim.lsp.util.get_current_line_to_cursor()`. This fixes that.