### PR TITLE
[Bugfix] Continue parsing (and handling) msgpack RPCs even if a response is handled

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -262,11 +262,9 @@ static void parse_msgpack(Channel *channel)
         call_set_error(channel, buf, ERROR_LOG_LEVEL);
       }
       msgpack_unpacked_destroy(&unpacked);
-      // Bail out from this event loop iteration
-      return;
+    } else {
+      handle_request(channel, &unpacked.data);
     }
-
-    handle_request(channel, &unpacked.data);
   }
 
   if (result == MSGPACK_UNPACK_NOMEM_ERROR) {


### PR DESCRIPTION
Bailing out of this loop seems to cause #12722: an issue where if an RPC response and request are sent in quick succession, a race condition is triggered and the request hangs. This change fixes the behaviour described in that issue.

[This comment](https://github.com/neovim/neovim/blob/master/src/nvim/msgpack_rpc/channel.c#L247) above the while loop in `parse_msgpack` indicates that neovim should be processing all messages that can be read off the RPC connection within that function. This change makes the code consistent with that convention.