### PR TITLE
ci: bump openbsd image 6.5 -> 6.7

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,17 +1,17 @@
 # sourcehut CI: https://builds.sr.ht/~jmk/neovim
 
-image: openbsd/6.5
+image: openbsd/6.7
 
 packages:
 - autoconf-2.69p2
 - automake-1.15.1
 - cmake
-- gettext-0.19.8.1p3
-- gettext-tools-0.19.8.1
+- gettext-runtime-0.20.1p1
+- gettext-tools-0.20.1p3
 - gmake
 - libtool
-- ninja-1.8.2p0
-- unzip-6.0p11
+- ninja-1.10.0
+- unzip-6.0p13
 
 sources:
 - https://github.com/neovim/neovim


### PR DESCRIPTION
seems like 6.5 is not supported anymore.

(cherry picked from commit c4888b2bdec3aa1c6febbcd8fbed89bd5e4c9b22)