### PR TITLE
[LSP] fix lsp.buf.formatting_sync() null response

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -101,6 +101,7 @@ function M.formatting_sync(options, timeout_ms)
   local result = vim.lsp.buf_request_sync(0, "textDocument/formatting", params, timeout_ms)
   if not result then return end
   result = result[1].result
+  if not result then return end
   vim.lsp.util.apply_text_edits(result)
 end
 


### PR DESCRIPTION
according to spec, `result` field of response can be null: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting

when an lsp responds null, vim throws an error about expecting a table for `next()`