### PR TITLE
defaults: sessionoptions+=unix,slash

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -77,7 +77,9 @@ Options ~
 *'fe'*			'fenc'+'enc' before Vim 6.0; no longer used.
 *'highlight'* *'hl'*	Names of builtin |highlight-groups| cannot be changed.
 *'langnoremap'*		Deprecated alias to 'nolangremap'.
+'sessionoptions'	Flags "unix", "slash" are ignored and always enabled.
 *'vi'*
+'viewoptions'		Flags "unix", "slash" are ignored and always enabled.
 *'viminfo'*		Deprecated alias to 'shada' option.
 *'viminfofile'*		Deprecated alias to 'shadafile' option.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5028,22 +5028,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 			will become the current directory (useful with
 			projects accessed over a network from different
 			systems)
-	   slash	backslashes in file names replaced with forward
-			slashes
 	   tabpages	all tab pages; without this only the current tab page
 			is restored, so that you can make a session for each
 			tab page separately
 	   terminal	include terminal windows where the command can be
 			restored
-	   unix		with Unix end-of-line format (single <NL>), even when
-			on Windows or DOS
 	   winpos	position of the whole Vim window
 	   winsize	window sizes
+	   slash	|deprecated| Always enabled. Uses "/" in filenames.
+	   unix		|deprecated| Always enabled. Uses "\n" line endings.
 
-	Don't include both "curdir" and "sesdir".
-	When neither "curdir" nor "sesdir" is included, file names are stored
-	with absolute paths.
-	"slash" and "unix" are always enabled.
+	Don't include both "curdir" and "sesdir". When neither is included
+	filenames are stored as absolute paths.
 
 				*'shada'* *'sd'* *E526* *E527* *E528*
 'shada' 'sd'		string	(Vim default for
@@ -6569,14 +6565,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   options	options and mappings local to a window or buffer (not
 			global values for local options)
 	   localoptions same as "options"
-	   slash	backslashes in file names replaced with forward
-			slashes
-	   unix		with Unix end-of-line format (single <NL>), even when
-			on Windows or DOS
-
-	"slash" and "unix" are useful on Windows when sharing view files
-	with Unix.  The Unix version of Vim cannot source dos format scripts,
-	but the Windows version of Vim can source unix format scripts.
+	   slash	|deprecated| Always enabled. Uses "/" in filenames.
+	   unix		|deprecated| Always enabled. Uses "\n" line endings.
 
 					    *'virtualedit'* *'ve'*
 'virtualedit' 've'	string	(default "")

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -50,7 +50,7 @@ the differences.
 - 'listchars' defaults to "tab:> ,trail:-,nbsp:+"
 - 'nrformats' defaults to "bin,hex"
 - 'ruler' is enabled
-- 'sessionoptions' enables "slash,unix", excludes "options"
+- 'sessionoptions' includes "unix,slash", excludes "options"
 - 'shortmess' includes "F", excludes "S"
 - 'showcmd' is enabled
 - 'sidescroll' defaults to 1
@@ -60,6 +60,7 @@ the differences.
 - 'tags' defaults to "./tags;,tags"
 - 'ttimeoutlen' defaults to 50
 - 'ttyfast' is always set
+- 'viewoptions' includes "unix,slash"
 - 'undodir' defaults to ~/.local/share/nvim/undo (|xdg|), auto-created
 - 'viminfo' includes "!"
 - 'wildmenu' is enabled

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -493,7 +493,8 @@ static int put_view(
 
 /// Writes commands for restoring the current buffers, for :mksession.
 ///
-/// Legacy 'sessionoptions' flags SSOP_UNIX, SSOP_SLASH are always enabled.
+/// Legacy 'sessionoptions'/'viewoptions' flags SSOP_UNIX, SSOP_SLASH are
+/// always enabled.
 ///
 /// @param dirnow  Current directory name
 /// @param fd  File descriptor to write to
@@ -822,9 +823,9 @@ void ex_loadview(exarg_T *eap)
 
 /// ":mkexrc", ":mkvimrc", ":mkview", ":mksession".
 ///
-/// Legacy 'sessionoptions' flags SSOP_UNIX, SSOP_SLASH are always enabled.
-///   - SSOP_UNIX: line-endings are always LF
-///   - SSOP_SLASH: filenames are always written with "/" slash
+/// Legacy 'sessionoptions'/'viewoptions' flags are always enabled:
+///   - SSOP_UNIX: line-endings are LF
+///   - SSOP_SLASH: filenames are written with "/" slash
 void ex_mkrc(exarg_T *eap)
 {
   FILE        *fd;


### PR DESCRIPTION
Since 1c3ca4f18fdc, 2c1d12d0beda, #7836, the "unix" and "slash" behavior
of 'sessionoptions'/'viewoptions' is always enabled, and the flags are
just ignored. There is no reason for that behavior to be configurable.

Cherry-picked from https://github.com/neovim/neovim/pull/11708. Forgot about this when I committed https://github.com/neovim/neovim/pull/12713/commits/273ad7d66fd27a5bd80501576de7fd6b7ed90aa3.
cc @justinmk  @teto