### PR TITLE
fix(win): remove UB in win_findbuf

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6986,7 +6986,7 @@ void win_findbuf(typval_T *argvars, list_T *list)
   int bufnr = tv_get_number(&argvars[0]);
 
   FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (wp->w_buffer->b_fnum == bufnr) {
+    if (!wp->w_closing && wp->w_buffer->b_fnum == bufnr) {
       tv_list_append_number(list, wp->handle);
     }
   }

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -216,4 +216,23 @@ describe('lua: buffer event callbacks', function()
     eq(1, meths.get_var('listener_cursor_line'))
   end)
 
+  it('does not SEGFAULT when calling win_findbuf in on_detach', function()
+
+    exec_lua[[
+      local buf = vim.api.nvim_create_buf(false, false)
+
+      vim.cmd"split"
+      vim.api.nvim_win_set_buf(0, buf)
+
+      vim.api.nvim_buf_attach(buf, false, {
+        on_detach = function(_, buf)
+          vim.fn.win_findbuf(buf)
+        end
+      })
+    ]]
+
+    command("q!")
+    helpers.assert_alive()
+  end)
+
 end)


### PR DESCRIPTION
This UB happened to me as a `SEGFAULT` when using `nvim-treesitter/playground`, just adding the check fixes it.

I am not sure of the fix though, maybe the problem is worse than what I think.

cc @teto

Repro for now is (maybe  @steelsojka can help ?):

1. Install `nvim-treesitter/playground`
2. Open a buffer and it's playground
3. Focus the playgrounds window
4. Hit `ZQ`
5. `SEGFAULT`

**EDIT**: Simpler repro steps below