### PR TITLE
[nvim-lsp] Handle ContentModified the same way as RequestCancelled

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -496,8 +496,7 @@ local function start(cmd, cmd_args, handlers, extra_spawn_params)
       decoded.result = convert_NIL(decoded.result)
 
       -- Do not surface RequestCancelled or ContentModified to users, it is RPC-internal.
-      if decoded.error and (decoded.error.code == protocol.ErrorCodes.RequestCancelled
-        or decoded.error.code == protocol.ErrorCodes.ContentModified) then
+      if decoded.error then
         if decoded.error.code == protocol.ErrorCodes.RequestCancelled then
           local _ = log.debug() and log.debug("Received cancellation ack", decoded)
         elseif decoded.error.code == protocol.ErrorCodes.ContentModified then

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -495,10 +495,15 @@ local function start(cmd, cmd_args, handlers, extra_spawn_params)
       decoded.error = convert_NIL(decoded.error)
       decoded.result = convert_NIL(decoded.result)
 
-      -- Do not surface RequestCancelled to users, it is RPC-internal.
-      if decoded.error
-        and decoded.error.code == protocol.ErrorCodes.RequestCancelled then
-        local _ = log.debug() and log.debug("Received cancellation ack", decoded)
+      -- Do not surface RequestCancelled or ContentModified to users, it is RPC-internal.
+      if decoded.error and (decoded.error.code == protocol.ErrorCodes.RequestCancelled
+        or decoded.error.code == protocol.ErrorCodes.ContentModified) then
+        if decoded.error.code == protocol.ErrorCodes.RequestCancelled then
+          local _ = log.debug() and log.debug("Received cancellation ack", decoded)
+        end
+        else if decoded.error.code == protocol.ErrorCodes.ContentModified then
+          local _ = log.debug() and log.debug("Received content modified ack", decoded)
+        end
         local result_id = tonumber(decoded.id)
         -- Clear any callback since this is cancelled now.
         -- This is safe to do assuming that these conditions hold:

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -500,8 +500,7 @@ local function start(cmd, cmd_args, handlers, extra_spawn_params)
         or decoded.error.code == protocol.ErrorCodes.ContentModified) then
         if decoded.error.code == protocol.ErrorCodes.RequestCancelled then
           local _ = log.debug() and log.debug("Received cancellation ack", decoded)
-        end
-        else if decoded.error.code == protocol.ErrorCodes.ContentModified then
+        elseif decoded.error.code == protocol.ErrorCodes.ContentModified then
           local _ = log.debug() and log.debug("Received content modified ack", decoded)
         end
         local result_id = tonumber(decoded.id)


### PR DESCRIPTION
Last night I was getting errors like the one below using nvim-lsp and clangd:
![](https://i.imgur.com/qiOU8SZ.png)

I investigated and it seems that nvim
should handle the "ContentModified" error in the same way as the "RequestCancelled" error, or atleast not show it to the end user.

From the LSP spec:
`If a server detects a state change that invalidates the result of a request in execution the server can error these requests with ContentModified. If clients receive a ContentModified error, it generally should not show it in the UI for the end-user. Clients can resend the request if appropriate.`

I've gone ahead and modified `rpc.lua` to handle the "ContentModified" error in the same way as the "RequestCancelled" error.