### PR TITLE
Support for :perl, :perlfile, :perldo and perleval()

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -689,29 +689,31 @@ function! s:check_perl() abort
     return
   endif
 
-  if !executable('perl') || !executable('cpanm')
-    call health#report_warn(
-          \ '`perl` and `cpanm` must be in $PATH.',
-          \ ['Install Perl and cpanminus and verify that `perl` and `cpanm` commands work.'])
-    return
+  let [perl_exec, perl_errors] = provider#perl#Detect()
+  if empty(perl_exec)
+    if !empty(perl_errors)
+      call health#report_error('perl provider error:', perl_errors)
+	else
+      call health#report_warn('No usable perl executable found')
+    endif
+	return
   endif
 
-  call s:system(['perl', '-e', 'use v5.22'])
+  call health#report_info('perl executable: '. perl_exec)
+
+  " we cannot use cpanm that is on the path, as it may not be for the perl
+  " set with g:perl_host_prog
+  call s:system([perl_exec, '-W', '-MApp::cpanminus', '-e', ''])
   if s:shell_error
-    call health#report_warn('Perl version is too old, 5.22+ required')
-    " Skip further checks, they are nonsense if perl is too old.
-    return
+    return [perl_exec, '"App::cpanminus" module is not installed']
   endif
 
-  let host = provider#perl#Detect()
-  if empty(host)
-    call health#report_warn('Missing "Neovim::Ext" cpan module.',
-          \ ['Run in shell: cpanm Neovim::Ext'])
-    return
-  endif
-  call health#report_info('Nvim perl host: '. host)
+  let latest_cpan_cmd = [perl_exec,
+			  \ '-MApp::cpanminus::fatscript', '-e',
+			  \ 'my $app = App::cpanminus::script->new;
+			  \ $app->parse_options ("--info", "-q", "Neovim::Ext");
+			  \ exit $app->doit']
 
-  let latest_cpan_cmd = 'cpanm --info -q Neovim::Ext'
   let latest_cpan = s:system(latest_cpan_cmd)
   if s:shell_error || empty(latest_cpan)
     call health#report_error('Failed to run: '. latest_cpan_cmd,
@@ -735,7 +737,7 @@ function! s:check_perl() abort
     return
   endif
 
-  let current_cpan_cmd = [host, '-W', '-MNeovim::Ext', '-e', 'print $Neovim::Ext::VERSION']
+  let current_cpan_cmd = [perl_exec, '-W', '-MNeovim::Ext', '-e', 'print $Neovim::Ext::VERSION']
   let current_cpan = s:system(current_cpan_cmd)
   if s:shell_error
     call health#report_error('Failed to run: '. string(current_cpan_cmd),

--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -695,10 +695,10 @@ function! s:check_perl() abort
           \ ['Install Perl and cpanminus and verify that `perl` and `cpanm` commands work.'])
     return
   endif
-  let perl_v = get(split(s:system(['perl', '-W', '-e', 'print $^V']), "\n"), 0, '')
-  call health#report_info('Perl: '. perl_v)
+
+  call s:system(['perl', '-e', 'use v5.22'])
   if s:shell_error
-    call health#report_warn('Nvim perl host does not support '.perl_v)
+    call health#report_warn('Perl version is too old, 5.22+ required')
     " Skip further checks, they are nonsense if perl is too old.
     return
   endif

--- a/runtime/autoload/provider/perl.vim
+++ b/runtime/autoload/provider/perl.vim
@@ -11,6 +11,12 @@ function! provider#perl#Detect() abort
     return ''
   endif
 
+  " if perl is available, make sure we have 5.22+
+  call system([prog, '-e', 'use v5.22'])
+  if v:shell_error
+    return ''
+  endif
+
   " if perl is available, make sure the required module is available
   call system([prog, '-W', '-MNeovim::Ext', '-e', ''])
   return v:shell_error ? '' : prog

--- a/runtime/autoload/provider/perl.vim
+++ b/runtime/autoload/provider/perl.vim
@@ -46,7 +46,7 @@ function! provider#perl#Call(method, args) abort
 
   if !exists('s:host')
     try
-      let s:host = remote#host#Require('perl')
+      let s:host = remote#host#Require('legacy-perl-provider')
     catch
       let s:err = v:exception
       echohl WarningMsg
@@ -66,4 +66,9 @@ if g:loaded_perl_provider != 2
   let s:err = 'Cannot find perl or the required perl module'
 endif
 
-call remote#host#RegisterPlugin('perl-provider', 'perl', [])
+
+" The perl provider plugin will run in a separate instance of the perl
+" host.
+call remote#host#RegisterClone('legacy-perl-provider', 'perl')
+call remote#host#RegisterPlugin('legacy-perl-provider', 'ScriptHost.pm', [])
+

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -556,6 +556,7 @@ followed by another Vim command:
     :lfdo
     :make
     :normal
+    :perlfile
     :promptfind
     :promptrepl
     :pyfile

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2288,6 +2288,7 @@ nr2char({expr}[, {utf8}])	String	single char with ASCII/UTF8 value {expr}
 nvim_...({args}...)		any	call nvim |api| functions
 or({expr}, {expr})		Number  bitwise OR
 pathshorten({expr})		String	shorten directory names in a path
+perleval({expr})		any	evaluate |perl| expression
 pow({x}, {y})			Float	{x} to the power of {y}
 prevnonblank({lnum})		Number	line nr of non-blank line <= {lnum}
 printf({fmt}, {expr1}...)	String	format text
@@ -6422,6 +6423,21 @@ pathshorten({expr})					*pathshorten()*
 			:echo pathshorten('~/.config/nvim/autoload/file1.vim')
 <			~/.c/n/a/file1.vim ~
 		It doesn't matter if the path exists or not.
+
+perleval({expr})					*perleval()*
+		Evaluate |perl| expression {expr} and return its result
+		converted to Vim data structures.
+		Numbers and strings are returned as they are (strings are
+		copied though).
+		Lists are represented as Vim |List| type.
+		Dictionaries are represented as Vim |Dictionary| type,
+		non-string keys result in error.
+
+		Note: If you want an array or hash, {expr} must return a
+		reference to it.
+		Example: >
+			:echo perleval('[1 .. 4]')
+<			[1, 2, 3, 4]
 
 pow({x}, {y})						*pow()*
 		Return the power of {x} to the exponent {y} as a |Float|.

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -107,7 +107,162 @@ to the next.
 ==============================================================================
 2. The VIM module					*perl-vim*
 
-Note: Perl codes does not currently have access to the legacy "VIM" package.
+Perl code gets all of its access to Neovim via the "VIM" module.
+
+Overview >
+	print "Hello"				# displays a message
+	VIM::Msg("Hello")			# displays a message
+	VIM::SetOption("ai")			# sets a vim option
+	$nbuf = VIM::Buffers()			# returns the number of buffers
+	@buflist = VIM::Buffers()		# returns array of all buffers
+	$mybuf = (VIM::Buffers('a.c'))[0] 	# returns buffer object for 'a.c'
+	@winlist = VIM::Windows()		# returns array of all windows
+	$nwin = VIM::Windows()			# returns the number of windows
+	($success, $v) = VIM::Eval('&path')	# $v: option 'path', $success: 1
+	($success, $v) = VIM::Eval('&xyz')	# $v: '' and $success: 0
+	$v = VIM::Eval('expand("<cfile>")')	# expands <cfile>
+	$curwin->SetHeight(10)			# sets the window height
+	@pos = $curwin->Cursor()		# returns (row, col) array
+	@pos = (10, 10)
+	$curwin->Cursor(@pos)			# sets cursor to @pos
+	$curwin->Cursor(10,10)			# sets cursor to row 10 col 10
+	$mybuf = $curwin->Buffer()		# returns the buffer object for window
+	$curbuf->Name()				# returns buffer name
+	$curbuf->Number()			# returns buffer number
+	$curbuf->Count()			# returns the number of lines
+	$l = $curbuf->Get(10)			# returns line 10
+	@l = $curbuf->Get(1 .. 5)		# returns lines 1 through 5
+	$curbuf->Delete(10)			# deletes line 10
+	$curbuf->Delete(10, 20)			# delete lines 10 through 20
+	$curbuf->Append(10, "Line")		# appends a line
+	$curbuf->Append(10, "L1", "L2", "L3")	# appends 3 lines
+	@l = ("L1", "L2", "L3")
+	$curbuf->Append(10, @l)			# appends L1, L2 and L3
+	$curbuf->Set(10, "Line")		# replaces line 10
+	$curbuf->Set(10, "Line1", "Line2")	# replaces lines 10 and 11
+	$curbuf->Set(10, @l)			# replaces 3 lines
+
+Module Functions:
+
+							*perl-Msg*
+VIM::Msg({msg})
+			Displays the message {msg}.
+
+							*perl-SetOption*
+VIM::SetOption({arg})	Sets a vim option.  {arg} can be any argument that the
+			":set" command accepts.  Note that this means that no
+			spaces are allowed in the argument!  See |:set|.
+
+							*perl-Buffers*
+VIM::Buffers([{bn}...])	With no arguments, returns a list of all the buffers
+			in an array context or returns the number of buffers
+			in a scalar context.  For a list of buffer names or
+			numbers {bn}, returns a list of the buffers matching
+			{bn}, using the same rules as Vim's internal
+			|bufname()| function.
+			WARNING: the list becomes invalid when |:bwipe| is
+			used.
+
+							*perl-Windows*
+VIM::Windows([{wn}...])	With no arguments, returns a list of all the windows
+			in an array context or returns the number of windows
+			in a scalar context.  For a list of window numbers
+			{wn}, returns a list of the windows with those
+			numbers.
+			WARNING: the list becomes invalid when a window is
+			closed.
+
+							*perl-DoCommand*
+VIM::DoCommand({cmd})	Executes Ex command {cmd}.
+
+							*perl-Eval*
+VIM::Eval({expr})	Evaluates {expr} and returns (success, value) in list
+			context or just value in scalar context.
+			success=1 indicates that val contains the value of
+			{expr}; success=0 indicates a failure to evaluate
+			the expression.  '@x' returns the contents of register
+			x, '&x' returns the value of option x, 'x' returns the
+			value of internal |variables| x, and '$x' is equivalent
+			to perl's $ENV{x}.  All |functions| accessible from
+			the command-line are valid for {expr}.
+			A |List| is turned into a string by joining the items
+			and inserting line breaks.
+
+==============================================================================
+3. VIM::Buffer objects					*perl-buffer*
+
+Methods:
+
+							*perl-Buffer-Name*
+Name()		Returns the filename for the Buffer.
+
+							*perl-Buffer-Number*
+Number()	Returns the number of the Buffer.
+
+							*perl-Buffer-Count*
+Count()		Returns the number of lines in the Buffer.
+
+							*perl-Buffer-Get*
+Get({lnum}, {lnum}?, ...)
+			Returns a text string of line {lnum} in the Buffer
+			for each {lnum} specified.  An array can be passed
+			with a list of {lnum}'s specified.
+
+							*perl-Buffer-Delete*
+Delete({lnum}, {lnum}?)
+			Deletes line {lnum} in the Buffer.  With the second
+			{lnum}, deletes the range of lines from the first
+			{lnum} to the second {lnum}.
+
+							*perl-Buffer-Append*
+Append({lnum}, {line}, {line}?, ...)
+			Appends each {line} string after Buffer line {lnum}.
+			The list of {line}s can be an array.
+
+							*perl-Buffer-Set*
+Set({lnum}, {line}, {line}?, ...)
+			Replaces one or more Buffer lines with specified
+			{lines}s, starting at Buffer line {lnum}.  The list of
+			{line}s can be an array.  If the arguments are
+			invalid, replacement does not occur.
+
+==============================================================================
+4. VIM::Window objects					*perl-window*
+
+Methods:
+							*perl-Window-SetHeight*
+SetHeight({height})
+			Sets the Window height to {height}, within screen
+			limits.
+
+							*perl-Window-GetCursor*
+Cursor({row}?, {col}?)
+			With no arguments, returns a (row, col) array for the
+			current cursor position in the Window.  With {row} and
+			{col} arguments, sets the Window's cursor position to
+			{row} and {col}.  Note that {col} is numbered from 0,
+			Perl-fashion, and thus is one less than the value in
+			Vim's ruler.
+
+Buffer()						*perl-Window-Buffer*
+			Returns the Buffer object corresponding to the given
+			Window.
+
+==============================================================================
+5. Lexical variables					*perl-globals*
+
+There are multiple lexical variables.
+
+$curwin			The current Window object.
+$curbuf			The current Buffer object.
+$vim			A Neovim::Ext object.
+$nvim			The same as $nvim.
+$current		A Neovim::Ext::Current object.
+
+These are also available via the "main" package:
+
+$main::curwin		The current Window object.
+$main::curbuf		The current Buffer object.
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -1,0 +1,113 @@
+*if_perl.txt*   Nvim
+
+
+		  VIM REFERENCE MANUAL    by Jacques Germishuys
+
+The perl Interface to Vim				*if_perl* *perl*
+
+See |provider-perl| for more information.
+
+                                      Type |gO| to see the table of contents.
+
+==============================================================================
+1. Commands						*perl-commands*
+
+							*:perl*
+:[range]perl {stmt}
+			Execute perl statement {stmt}.  The current package is
+			"main".  A simple check if the `:perl` command is
+			working: >
+				:perl print "Hello"
+
+:[range]perl << [endmarker]
+{script}
+{endmarker}
+			Execute perl script {script}.  Useful for including
+			perl code in Vim scripts.  Requires perl, see
+			|script-here|.
+
+The {endmarker} below the {script} must NOT be preceded by any white space.
+
+If [endmarker] is omitted from after the "<<", a dot '.' must be used after
+{script}, like for the |:append| and |:insert| commands.
+
+Example: >
+	function! MyVimMethod()
+	perl << EOF
+	sub my_vim_method
+	{
+		print "Hello World!\n";
+	}
+	EOF
+	endfunction
+
+To see what version of perl you have: >
+
+	:perl print $^V
+<
+							*:perldo*
+:[range]perldo {cmd}	Execute perl command {cmd} for each line in the[range],
+			with $_ being set to the test of each line in turn,
+			without a trailing <EOL>. In addition to $_, $line and
+			$linenr is also set to the line content and line number
+			respectively. Setting $_ will change the text, but note
+			that it is not possible to add or delete lines using
+			this command.
+			The default for [range] is the whole file: "1,$".
+
+Examples:
+>
+	:perldo $_ = reverse($_);
+	:perldo $_ = "".$linenr." => $line";
+
+One can use `:perldo` in conjunction with `:perl` to filter a range using
+perl. For example: >
+
+	:perl << EOF
+	sub perl_vim_string_replace
+	{
+	    my $line = shift;
+	    my $needle = $vim->eval('@a');
+	    my $replacement = $vim->eval('@b');
+	    $line =~ s/$needle/$replacement/g;
+	    return $line;
+	}
+	EOF
+	:let @a='somevalue'
+	:let @b='newvalue'
+	:'<,'>perldo $_ = perl_vim_string_replace($_)
+<
+							*:perlfile*
+:[range]perlfile {file}
+			Execute the perl script in {file}.  The whole
+			argument is used as a single file name.
+
+Both of these commands do essentially the same thing - they execute a piece of
+perl code, with the "current range" set to the given line range.
+
+In the case of :perl, the code to execute is in the command-line.
+In the case of :perlfile, the code to execute is the contents of the given file.
+
+perl commands cannot be used in the |sandbox|.
+
+To pass arguments you need to set @ARGV explicitly.  Example: >
+
+	:perl @ARGV = ("foo", "bar");
+	:perlfile myscript.pl
+
+Here are some examples					*perl-examples*  >
+
+	:perl print "Hello"
+	:perl $current->line (uc ($current->line))
+	:perl my $str = $current->buffer->[42]; print "Set \$str to: $str"
+
+Note that changes (such as the "use" statements) persist from one command
+to the next.
+
+==============================================================================
+2. The VIM module					*perl-vim*
+
+Note: Perl codes does not currently have access to the legacy "VIM" package.
+
+==============================================================================
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1441,6 +1441,9 @@ tag		command		action ~
 |:packloadall|	:packl[oadall]	load all packages under 'packpath'
 |:pclose|	:pc[lose]	close preview window
 |:pedit|	:ped[it]	edit file in the preview window
+|:perl|		:perl		execute perl command
+|:perldo|	:perldo		execute perl command for each line
+|:perfile|	:perlfile	execute perl script file
 |:print|	:p[rint]	print lines
 |:profdel|	:profd[el]	stop profiling a function or script
 |:profile|	:prof[ile]	profiling functions and scripts

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -135,6 +135,7 @@ The Vim legacy |perl-vim| interface is also supported (which is itself
 implemented as a Nvim remote-plugin).
 https://github.com/jacquesg/p5-Neovim-Ext
 
+Note: Only perl versions from 5.22 onward are supported.
 
 PERL QUICKSTART~
 

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -129,7 +129,9 @@ To use the RVM "system" Ruby installation: >
 ==============================================================================
 Perl integration				*provider-perl*
 
-Nvim supports Perl |remote-plugin|s.
+Nvim supports Perl |remote-plugin|s on non-Windows platforms. Support for
+polling STDIN on Windows in lacking from all known event loop implementations
+currently.
 https://github.com/jacquesg/p5-Neovim-Ext
 
 

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -129,9 +129,10 @@ To use the RVM "system" Ruby installation: >
 ==============================================================================
 Perl integration				*provider-perl*
 
-Nvim supports Perl |remote-plugin|s on non-Windows platforms. Support for
-polling STDIN on Windows in lacking from all known event loop implementations
-currently.
+Nvim supports Perl |remote-plugin|s on Unix platforms. Support for polling STDIN
+on MS-Windows is currently lacking from all known event loop implementations.
+The Vim legacy |perl-vim| interface is also supported (which is itself
+implemented as a Nvim remote-plugin).
 https://github.com/jacquesg/p5-Neovim-Ext
 
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -407,7 +407,6 @@ Some legacy Vim features are not implemented:
 
 - |if_lua|: Nvim Lua API is not compatible with Vim's "if_lua"
 - *if_mzscheme*
-- *if_perl*
 - |if_py|: *python-bindeval* *python-Function* are not supported
 - *if_tcl*
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -256,6 +256,7 @@ return {
     py3eval={args=1},
     pyeval={args=1},
     pyxeval={args=1},
+    perleval={args=1},
     range={args={1, 3}},
     readdir={args={1, 2}},
     readfile={args={1, 3}},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6374,6 +6374,14 @@ static void f_pyxeval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
+///
+/// "perleval()" function
+///
+static void f_perleval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  script_host_eval("perl", argvars, rettv);
+}
+
 /*
  * "range()" function
  */

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1927,13 +1927,19 @@ return {
     command='perl',
     flags=bit.bor(RANGE, EXTRA, DFLALL, NEEDARG, SBOXOK, CMDWIN, RESTRICT),
     addr_type=ADDR_LINES,
-    func='ex_script_ni',
+    func='ex_perl',
   },
   {
     command='perldo',
     flags=bit.bor(RANGE, EXTRA, DFLALL, NEEDARG, CMDWIN, RESTRICT),
     addr_type=ADDR_LINES,
-    func='ex_ni',
+    func='ex_perldo',
+  },
+  {
+    command='perlfile',
+    flags=bit.bor(RANGE, FILE1, NEEDARG, CMDWIN, RESTRICT),
+    addr_type=ADDR_LINES,
+    func='ex_perlfile',
   },
   {
     command='pedit',

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -935,6 +935,21 @@ void ex_pydo3(exarg_T *eap)
   script_host_do_range("python3", eap);
 }
 
+void ex_perl(exarg_T *eap)
+{
+  script_host_execute("perl", eap);
+}
+
+void ex_perlfile(exarg_T *eap)
+{
+  script_host_execute_file("perl", eap);
+}
+
+void ex_perldo(exarg_T *eap)
+{
+  script_host_do_range("perl", eap);
+}
+
 // Command line expansion for :profile.
 static enum {
   PEXP_SUBCMD,          ///< expand :profile sub-commands

--- a/src/nvim/testdir/test_perl.vim
+++ b/src/nvim/testdir/test_perl.vim
@@ -1,0 +1,225 @@
+" Tests for Perl interface
+
+if !has('perl') || has('win32')
+  finish
+endif
+
+perl $SIG{__WARN__} = sub { die "Unexpected warnings from perl: @_" };
+
+func Test_change_buffer()
+  call setline(line('$'), ['1 line 1'])
+  perl VIM::DoCommand("normal /^1\n")
+  perl $curline = VIM::Eval("line('.')")
+  perl $curbuf->Set($curline, "1 changed line 1")
+  call assert_equal('1 changed line 1', getline('$'))
+endfunc
+
+func Test_evaluate_list()
+  call setline(line('$'), ['2 line 2'])
+  perl VIM::DoCommand("normal /^2\n")
+  perl $curline = VIM::Eval("line('.')")
+  let l = ["abc", "def"]
+  perl << EOF
+  $l = VIM::Eval("l");
+  $curbuf->Append($curline, $l);
+EOF
+endfunc
+
+funct Test_VIM_Blob()
+  call assert_equal('0z',         perleval('VIM::Blob("")'))
+  "call assert_equal('0z31326162', 'VIM::Blob("12ab")'->perleval())
+  call assert_equal('0z00010203', perleval('VIM::Blob("\x00\x01\x02\x03")'))
+  call assert_equal('0z8081FEFF', perleval('VIM::Blob("\x80\x81\xfe\xff")'))
+endfunc
+
+func Test_buffer_Delete()
+  new
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
+  perl $curbuf->Delete(7)
+  perl $curbuf->Delete(2, 5)
+  perl $curbuf->Delete(10)
+  call assert_equal(['a', 'f', 'h'],  getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_buffer_Append()
+  new
+  perl $curbuf->Append(1, '1')
+  perl $curbuf->Append(2, '2', '3', '4')
+  call assert_equal(['', '1', '2', '3', '4'], getline(1, '$'))
+  perl @l = ('5' ..'7')
+  perl $curbuf->Append(0, @l)
+  call assert_equal(['5', '6', '7', '', '1', '2', '3', '4'], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_buffer_Set()
+  new
+  call setline(1, ['1', '2', '3', '4', '5'])
+  perl $curbuf->Set(2, 'a', 'b', 'c')
+  perl $curbuf->Set(4, 'A', 'B', 'C')
+  call assert_equal(['1', 'a', 'b', 'A', 'B'], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_buffer_Get()
+  new
+  call setline(1, ['1', '2', '3', '4'])
+  call assert_equal('2:3', perleval('join(":", $curbuf->Get(2, 3))'))
+  bwipe!
+endfunc
+
+func Test_buffer_Count()
+  new
+  call setline(1, ['a', 'b', 'c'])
+  call assert_equal(3, perleval('$curbuf->Count()'))
+  bwipe!
+endfunc
+
+func Test_buffer_Name()
+  new
+  call assert_equal('', perleval('$curbuf->Name()'))
+  bwipe!
+  new Xfoo
+  call assert_equal('Xfoo', perleval('$curbuf->Name()'))
+  bwipe!
+endfunc
+
+func Test_buffer_Number()
+  call assert_equal(bufnr('%'), perleval('$curbuf->Number()'))
+endfunc
+
+func Test_window_Cursor()
+  new
+  call setline(1, ['line1', 'line2'])
+  perl $curwin->Cursor(2, 3)
+  call assert_equal('2:3', perleval('join(":", $curwin->Cursor())'))
+  " Col is numbered from 0 in Perl, and from 1 in Vim script.
+  call assert_equal([0, 2, 4, 0], getpos('.'))
+  bwipe!
+endfunc
+
+func Test_window_SetHeight()
+  new
+  perl $curwin->SetHeight(2)
+  call assert_equal(2, winheight(0))
+  bwipe!
+endfunc
+
+func Test_VIM_Windows()
+  new
+  " VIM::Windows() without argument in scalar and list context.
+  perl $winnr = VIM::Windows()
+  perl @winlist = VIM::Windows()
+  perl $curbuf->Append(0, $winnr, scalar(@winlist))
+  call assert_equal(['2', '2', ''], getline(1, '$'))
+
+  "" VIM::Windows() with window number argument.
+  perl (VIM::Windows(VIM::Eval('winnr()')))[0]->Buffer()->Set(1, 'bar')
+  call assert_equal('bar', getline(1))
+  bwipe!
+endfunc
+
+func Test_VIM_Buffers()
+  new Xbar
+  " VIM::Buffers() without argument in scalar and list context.
+  perl $nbuf = VIM::Buffers()
+  perl @buflist = VIM::Buffers()
+
+  " VIM::Buffers() with argument.
+  perl $curbuf = (VIM::Buffers('Xbar'))[0]
+  perl $curbuf->Append(0, $nbuf, scalar(@buflist))
+  call assert_equal(['2', '2', ''], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_perleval()
+  call assert_false(perleval('undef'))
+
+  "" scalar
+  call assert_equal(0, perleval('0'))
+  call assert_equal(2, perleval('2'))
+  call assert_equal(-2, perleval('-2'))
+  if has('float')
+    call assert_equal(2.5, perleval('2.5'))
+  else
+    call assert_equal(2, perleval('2.5'))
+  end
+
+  call assert_equal('abc', perleval('"abc"'))
+
+  "" ref
+  call assert_equal([], perleval('[]'))
+  call assert_equal(['word', 42, [42],{}], perleval('["word", 42, [42], {}]'))
+
+  call assert_equal({}, perleval('{}'))
+  call assert_equal({'foo': 'bar'}, perleval('{foo => "bar"}'))
+
+  perl our %h; our @a;
+  let a = perleval('[\%h, \%h, \@a, \@a]')
+  echo a
+  call assert_equal(a[0], a[1])
+  call assert_equal(a[2], a[3])
+  perl undef %h; undef @a;
+
+  call assert_equal('*VIM', perleval('"*VIM"'))
+endfunc
+
+func Test_perldo()
+  sp __TEST__
+  exe 'read ' g:testname
+  perldo s/perl/vieux_chameau/g
+  1
+  call assert_false(search('\Cperl'))
+  bw!
+
+  " Check deleting lines does not trigger ml_get error.
+  new
+  call setline(1, ['one', 'two', 'three'])
+  perldo VIM::DoCommand("%d_")
+  bwipe!
+
+  "" Check switching to another buffer does not trigger ml_get error.
+  new
+  let wincount = winnr('$')
+  call setline(1, ['one', 'two', 'three'])
+  perldo VIM::DoCommand("new")
+  call assert_equal(wincount + 1, winnr('$'))
+  bwipe!
+  bwipe!
+endfunc
+
+func Test_VIM_package()
+  perl VIM::DoCommand('let l:var = "foo"')
+  call assert_equal(l:var, 'foo')
+
+  set noet
+  perl VIM::SetOption('et')
+  call assert_true(&et)
+endfunc
+
+func Test_set_cursor()
+  " Check that setting the cursor position works.
+  new
+  call setline(1, ['first line', 'second line'])
+  normal gg
+  perldo $curwin->Cursor(1, 5)
+  call assert_equal([1, 6], [line('.'), col('.')])
+
+  " Check that movement after setting cursor position keeps current column.
+  normal j
+  call assert_equal([2, 6], [line('.'), col('.')])
+endfunc
+
+" Test for various heredoc syntax
+func Test_perl_heredoc()
+  perl << END
+VIM::DoCommand('let s = "A"')
+END
+  perl <<
+VIM::DoCommand('let s ..= "B"')
+.
+  call assert_equal('AB', s)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -768,9 +768,12 @@ function module.new_pipename()
 end
 
 function module.missing_provider(provider)
-  if provider == 'ruby' or provider == 'node' or provider == 'perl' then
+  if provider == 'ruby' or provider == 'node' then
     local prog = module.funcs['provider#' .. provider .. '#Detect']()
     return prog == '' and (provider .. ' not detected') or false
+  elseif provider == 'perl' then
+    local errors = module.funcs['provider#'..provider..'#Detect']()[2]
+    return errors ~= '' and errors or false
   elseif provider == 'python' or provider == 'python3' then
     local py_major_version = (provider == 'python3' and 3 or 2)
     local errors = module.funcs['provider#pythonx#Detect'](py_major_version)[2]


### PR DESCRIPTION
Initial support for ```:perl```, ```:perlfile```, ```:perldo``` and ```perleval()```. These have been implemented via the perl remote plugin infrastructure and requires [```Neovim::Ext```](https://metacpan.org/release/JACQUESG/Neovim-Ext-0.03) version 0.03 or greater.