### PR TITLE
treesitter: avoid escaping complete query strings

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -17,7 +17,7 @@ local M = {}
 function M.parse_query(lang, query)
   language.require_language(lang)
   local self = setmetatable({}, Query)
-  self.query = vim._ts_parse_query(lang, vim.fn.escape(query,'\\'))
+  self.query = vim._ts_parse_query(lang, query)
   self.info = self.query:inspect()
   self.captures = self.info.captures
   return self
@@ -82,7 +82,7 @@ local predicate_handlers = {
 
     local compiled_vim_regexes = setmetatable({}, {
       __index = function(t, pattern)
-        local res = vim.regex(check_magic(pattern))
+        local res = vim.regex(check_magic(vim.fn.escape(pattern, '\\')))
         rawset(t, pattern, res)
         return res
       end

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -198,6 +198,35 @@ void ui_refresh(void)
     }, res)
   end)
 
+  it('allow loading query with escaped quotes and capture them with `match?` and `vim-match?`', function()
+    if not check_parser() then return end
+
+    insert('char* astring = "Hello World!";')
+
+    local res = exec_lua([[
+      cquery = vim.treesitter.parse_query("c", '((_) @quote (vim-match? @quote "^\\"$")) ((_) @quote (match? @quote "^\\"$"))')
+      parser = vim.treesitter.get_parser(0, "c")
+      tree = parser:parse()
+      res = {}
+      for pattern, match in cquery:iter_matches(tree:root(), 0, 0, 1) do
+        -- can't transmit node over RPC. just check the name and range
+        local mrepr = {}
+        for cid,node in pairs(match) do
+          table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+        end
+        table.insert(res, {pattern, mrepr})
+      end
+      return res
+    ]])
+
+    eq({
+      { 1, { { "quote", '"', 0, 16, 0, 17 } } },
+      { 2, { { "quote", '"', 0, 16, 0, 17 } } },
+      { 1, { { "quote", '"', 0, 29, 0, 30 } } },
+      { 2, { { "quote", '"', 0, 29, 0, 30 } } },
+    }, res)
+  end)
+
   it('allows to add predicates', function()
     insert([[
     int main(void) {


### PR DESCRIPTION
Escape only for vim-match?

Fixes #12595

TODO:

 - [x] test for escaping `"`
 - [x] test for lua regexes behaving normally without unexpected doubling of `\\`