### PR TITLE
Update SNAP and Fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,6 +193,7 @@ jobs:
         - LANG: C.UTF-8
         - SNAPCRAFT_ENABLE_SILENT_REPORT: y
         - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: y
+        - SNAPCRAFT_BUILD_ENVIRONMENT: lxd
       addons:
         snaps:
           - name: snapcraft
@@ -221,6 +222,7 @@ jobs:
       - LANG: C.UTF-8
       - SNAPCRAFT_ENABLE_SILENT_REPORT: y
       - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: y
+      - SNAPCRAFT_BUILD_ENVIRONMENT: lxd
   fast_finish: true
 
 before_install: ci/before_install.sh

--- a/ci/snap/install.sh
+++ b/ci/snap/install.sh
@@ -4,6 +4,7 @@ set -e
 set -o pipefail
 
 sudo apt update
+sudo usermod -aG lxd $USER
 sudo /snap/bin/lxd.migrate -yes
 sudo /snap/bin/lxd waitready
 sudo /snap/bin/lxd init --auto

--- a/ci/snap/script.sh
+++ b/ci/snap/script.sh
@@ -4,5 +4,5 @@ set -e
 set -o pipefail
 
 mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
-sudo snapcraft --use-lxd
+sg lxd -c snapcraft
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: nvim
-base: core18
+base: core20
 adopt-info: nvim
 summary: Vim-fork focused on extensibility and agility.
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,11 +52,13 @@ parts:
             - autoconf
             - automake
             - cmake
+            - gawk
             - g++
             - git
             - gettext
             - pkg-config
             - unzip
+            - wget
         prime:
             - -usr/share/man
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
           snapcraftctl set-version "${version_prefix}-${git_described}"
         plugin: make
         make-parameters:
-            - CMAKE_BUILD_TYPE=Release
+            - CMAKE_BUILD_TYPE=RelWithDebInfo
             - CMAKE_INSTALL_PREFIX=/usr
         override-build: |
             snapcraftctl build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,8 @@ parts:
         make-parameters:
             - CMAKE_BUILD_TYPE=RelWithDebInfo
             - CMAKE_INSTALL_PREFIX=/usr
+            - CMAKE_FLAGS=-DPREFER_LUA=ON
+            - DEPS_CMAKE_FLAGS="-DUSE_BUNDLED_LUA=ON -DUSE_BUNDLED_LUAJIT=OFF"
         override-build: |
             snapcraftctl build
             # Fix Desktop file


### PR DESCRIPTION
Fix SNAP builds on snapcraft.io/builds
Fix SNAP builds on Travis
Switch form luajit to lua to support arm64
Publish latest v0.4.4 to candidate in preparation to promote to stable.

Closes #12712, #11817, #11758