### PR TITLE
eval_call_provider(): add a discard option for cases where the return value is not of interest

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -103,8 +103,10 @@ Examples:
 The provider framework invokes VimL from C.  It is composed of two functions
 in eval.c:
 
-- eval_call_provider(name, method, arguments): calls provider#{name}#Call
-  with the method and arguments.
+- eval_call_provider(name, method, arguments, discard): calls
+  provider#{name}#Call with the method and arguments. If discard is true, any
+  value returned by the provider will be discarded and and empty value be
+  returned.
 - eval_has_provider(name): Checks the `g:loaded_{name}_provider` variable
   which must be set to 2 by the provider script to indicate that it is
   "enabled and working". Called by |has()| to check if features are available.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10387,7 +10387,7 @@ void script_host_eval(char *name, typval_T *argvars, typval_T *rettv)
 }
 
 /// @param discard  Clears the value returned by the provider and returns
-//                  an empty typval_T.
+///                 an empty typval_T.
 typval_T eval_call_provider(char *provider, char *method, list_T *arguments,
                             bool discard)
 {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10383,10 +10383,13 @@ void script_host_eval(char *name, typval_T *argvars, typval_T *rettv)
 
   list_T *args = tv_list_alloc(1);
   tv_list_append_string(args, (const char *)argvars[0].vval.v_string, -1);
-  *rettv = eval_call_provider(name, "eval", args);
+  *rettv = eval_call_provider(name, "eval", args, false);
 }
 
-typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
+/// @param discard  Clears the value returned by the provider and returns
+//                  an empty typval_T.
+typval_T eval_call_provider(char *provider, char *method, list_T *arguments,
+                            bool discard)
 {
   if (!eval_has_provider(provider)) {
     emsgf("E319: No \"%s\" provider found. Run \":checkhealth provider\"",
@@ -10444,6 +10447,10 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments)
   provider_caller_scope = saved_provider_caller_scope;
   provider_call_nesting--;
   assert(provider_call_nesting >= 0);
+
+  if (discard) {
+    tv_clear(&rettv);
+  }
 
   return rettv;
 }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -4157,7 +4157,7 @@ static void script_host_execute(char *name, exarg_T *eap)
     tv_list_append_number(args, (int)eap->line1);
     tv_list_append_number(args, (int)eap->line2);
 
-    (void)eval_call_provider(name, "execute", args);
+    (void)eval_call_provider(name, "execute", args, true);
   }
 }
 
@@ -4172,7 +4172,7 @@ static void script_host_execute_file(char *name, exarg_T *eap)
   // current range
   tv_list_append_number(args, (int)eap->line1);
   tv_list_append_number(args, (int)eap->line2);
-  (void)eval_call_provider(name, "execute_file", args);
+  (void)eval_call_provider(name, "execute_file", args, true);
 }
 
 static void script_host_do_range(char *name, exarg_T *eap)
@@ -4181,7 +4181,7 @@ static void script_host_do_range(char *name, exarg_T *eap)
   tv_list_append_number(args, (int)eap->line1);
   tv_list_append_number(args, (int)eap->line2);
   tv_list_append_string(args, (const char *)eap->arg, -1);
-  (void)eval_call_provider(name, "do_range", args);
+  (void)eval_call_provider(name, "do_range", args, true);
 }
 
 /// ":drop"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5919,7 +5919,7 @@ static bool get_clipboard(int name, yankreg_T **target, bool quiet)
   const char regname = (char)name;
   tv_list_append_string(args, &regname, 1);
 
-  typval_T result = eval_call_provider("clipboard", "get", args);
+  typval_T result = eval_call_provider("clipboard", "get", args, false);
 
   if (result.v_type != VAR_LIST) {
     if (result.v_type == VAR_NUMBER && result.vval.v_number == 0) {
@@ -6067,7 +6067,7 @@ static void set_clipboard(int name, yankreg_T *reg)
   tv_list_append_string(args, &regtype, 1);  // -V614
   tv_list_append_string(args, ((char[]) { (char)name }), 1);
 
-  (void)eval_call_provider("clipboard", "set", args);
+  (void)eval_call_provider("clipboard", "set", args, true);
 }
 
 /// Avoid slow things (clipboard) during batch operations (while/for-loops).


### PR DESCRIPTION
Picked up in #12809, if a remote provider sends back a return value we are not interested in, we leak due to a missing call to ```tv_clear```.