### PR TITLE
Patch FindLua to support locating Lua 5.4

### DIFF
--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -42,7 +42,7 @@ unset(_lua_append_versions)
 
 # this is a function only to have all the variables inside go away automatically
 function(_lua_set_version_vars)
-    set(LUA_VERSIONS5 5.3 5.2 5.1 5.0)
+    set(LUA_VERSIONS5 5.4 5.3 5.2 5.1 5.0)
 
     if (Lua_FIND_VERSION_EXACT)
         if (Lua_FIND_VERSION_COUNT GREATER 1)


### PR DESCRIPTION
Lua 5.4 is out, and will be shipped with Fedora 33.

Since there are architectures where LuaJIT is not available, being able
to compile against Lua 5.4 is needed to get Neovim to build for this
release.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neovim/neovim/12820)
<!-- Reviewable:end -->
