### PR TITLE
treesitter: use lua-match? instead of match?

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -756,14 +756,15 @@ Here is a list of built-in predicates :
 			((node1) @left (node2) @right (#eq? @left @right))
 <
 	`match?`					*ts-predicate-match?*
-		This will match if the provived lua regex matches the text
+	`vim-match?`					*ts-predicate-vim-match?*
+		This will match if the provived vim regex matches the text
 		corresponding to a node : >
 			((idenfitier) @constant (#match? @constant "^[A-Z_]+$"))
 <		Note: the `^` and `$` anchors will respectively match the
 			start and end of the node's text.
 
-	`vim-match?`					*ts-predicate-vim-match?*
-		This will match the same way than |match?| but using vim
+	`lua-match?`					*ts-predicate-lua-match?*
+		This will match the same way than |match?| but using lua
 		regexes.
 	
 	`contains?`					*ts-predicate-contains?*

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -135,8 +135,8 @@ function M.list_predicates()
   return vim.tbl_keys(predicate_handlers)
 end
 
-local function xor(a, b)
-  return (a or b) and not (a and b)
+local function xor(x, y)
+  return (x or y) and not (x and y)
 end
 
 function Query:match_preds(match, pattern, bufnr)

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -60,7 +60,7 @@ local predicate_handlers = {
       return true
   end,
 
-  ["match?"] = function(match, _, bufnr, predicate)
+  ["lua-match?"] = function(match, _, bufnr, predicate)
       local node = match[predicate[2]]
       local regex = predicate[3]
       local start_row, _, end_row, _ = node:range()
@@ -71,7 +71,7 @@ local predicate_handlers = {
       return string.find(M.get_node_text(node, bufnr), regex)
   end,
 
-  ["vim-match?"] = (function()
+  ["match?"] = (function()
     local magic_prefixes = {['\\v']=true, ['\\m']=true, ['\\M']=true, ['\\V']=true}
     local function check_magic(str)
       if string.len(str) < 2 or magic_prefixes[string.sub(str,1,2)] then
@@ -113,6 +113,9 @@ local predicate_handlers = {
     return false
   end
 }
+
+-- As we provide lua-match? also expose vim-match?
+predicate_handlers["vim-match?"] = predicate_handlers["match?"]
 
 --- Adds a new predicates to be used in queries
 --

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -250,13 +250,13 @@ void ui_refresh(void)
     }, res)
   end)
 
-  it('allow loading query with escaped quotes and capture them with `match?` and `vim-match?`', function()
+  it('allow loading query with escaped quotes and capture them with `lua-match?` and `vim-match?`', function()
     if not check_parser() then return end
 
     insert('char* astring = "Hello World!";')
 
     local res = exec_lua([[
-      cquery = vim.treesitter.parse_query("c", '((_) @quote (vim-match? @quote "^\\"$")) ((_) @quote (match? @quote "^\\"$"))')
+      cquery = vim.treesitter.parse_query("c", '((_) @quote (vim-match? @quote "^\\"$")) ((_) @quote (lua-match? @quote "^\\"$"))')
       parser = vim.treesitter.get_parser(0, "c")
       tree = parser:parse()
       res = {}
@@ -373,7 +373,7 @@ static int nlua_schedule(lua_State *const lstate)
 
 ; Use lua regexes
 ((identifier) @Identifier (#contains? @Identifier "lua_"))
-((identifier) @Constant (#match? @Constant "^[A-Z_]+$"))
+((identifier) @Constant (#lua-match? @Constant "^[A-Z_]+$"))
 ((identifier) @Normal (#vim-match? @Constant "^lstate$"))
 
 ((binary_expression left: (identifier) @WarningMsg.left right: (identifier) @WarningMsg.right) (#eq? @WarningMsg.left @WarningMsg.right))

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -323,7 +323,7 @@ void ui_refresh(void)
     return list
     ]]
 
-    eq({ 'contains?', 'eq?', 'is-main?', 'match?', 'vim-match?' }, res_list)
+    eq({ 'contains?', 'eq?', 'is-main?', 'lua-match?', 'match?', 'vim-match?' }, res_list)
   end)
 
   it('supports highlighting', function()


### PR DESCRIPTION
Following [this comment](https://github.com/neovim/neovim/pull/12739#issuecomment-681139014), this PR reverts the switch to using lua for the default `match?` predicate, to use the vim implementation.

The lua-based `match?` predicate is accessible through `lua-match?`.
We still expose `vim-match?` to avoid confusion, and to be clear.

We also fire an error when a predicate has no handlers.

And also do a drive-by simplification of `Query:match_preds`.