### PR TITLE
lsp: Fix parameter markdown rendering for signature help

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -505,13 +505,13 @@ function M.convert_signature_help_to_markdown_lines(signature_help)
   if signature.documentation then
     M.convert_input_to_markdown_lines(signature.documentation, contents)
   end
-  if signature_help.parameters then
+  if signature.parameters and #signature.parameters > 0 then
     local active_parameter = signature_help.activeParameter or 0
     -- If the activeParameter is not inside the valid range, then clip it.
-    if active_parameter >= #signature_help.parameters then
+    if active_parameter >= #signature.parameters then
       active_parameter = 0
     end
-    local parameter = signature.parameters and signature.parameters[active_parameter]
+    local parameter = signature.parameters[active_parameter + 1]
     if parameter then
       --[=[
       --Represents a parameter of a callable-signature. A parameter can
@@ -532,8 +532,8 @@ function M.convert_signature_help_to_markdown_lines(signature_help)
       }
       --]=]
       -- TODO highlight parameter
-      if parameter.documentation then
-        M.convert_input_help_to_markdown_lines(parameter.documentation, contents)
+      if parameter.documentation and parameter.documentation ~= vim.NIL then
+        M.convert_input_to_markdown_lines(parameter.documentation, contents)
       end
     end
   end


### PR DESCRIPTION
This PR fixed some issues imported by #11950 

As the [specification](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_signatureHelp)

```typescript
/**
 * Signature help represents the signature of something
 * callable. There can be multiple signature but only one
 * active and only one active parameter.
 */
interface SignatureHelp {
	/**
	 * One or more signatures.
	 */
	signatures: SignatureInformation[];

	/**
	 * The active signature. If omitted or the value lies outside the
	 * range of `signatures` the value defaults to zero or is ignored if
	 * `signatures.length === 0`. Whenever possible implementors should
	 * make an active decision about the active signature and shouldn't
	 * rely on a default value.
	 * In future version of the protocol this property might become
	 * mandatory to better express this.
	 */
	activeSignature?: number;

	/**
	 * The active parameter of the active signature. If omitted or the value
	 * lies outside the range of `signatures[activeSignature].parameters`
	 * defaults to 0 if the active signature has parameters. If
	 * the active signature has no parameters it is ignored.
	 * In future version of the protocol this property might become
	 * mandatory to better express the active parameter if the
	 * active signature does have any.
	 */
	activeParameter?: number;
}

/**
 * Represents the signature of something callable. A signature
 * can have a label, like a function-name, a doc-comment, and
 * a set of parameters.
 */
interface SignatureInformation {
	/**
	 * The label of this signature. Will be shown in
	 * the UI.
	 */
	label: string;

	/**
	 * The human-readable doc-comment of this signature. Will be shown
	 * in the UI but can be omitted.
	 */
	documentation?: string | MarkupContent;

	/**
	 * The parameters of this signature.
	 */
	parameters?: ParameterInformation[];
}

/**
 * Represents a parameter of a callable-signature. A parameter can
 * have a label and a doc-comment.
 */
interface ParameterInformation {

	/**
	 * The label of this parameter information.
	 *
	 * Either a string or an inclusive start and exclusive end offsets within its containing
	 * signature label. (see SignatureInformation.label). The offsets are based on a UTF-16
	 * string representation as `Position` and `Range` does.
	 *
	 * *Note*: a label of type string should be a substring of its containing signature label.
	 * Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
	 */
	label: string | [number, number];

	/**
	 * The human-readable doc-comment of this parameter. Will be shown
	 * in the UI but can be omitted.
	 */
	documentation?: string | MarkupContent;
}
```

* `parameters` is a field of `SignatureInformation`, not of `SignatureHelp`
* `activeParameter` is 0-indexed