### PR TITLE
Fix possible misplaced cursor after :map expr (Issue #12707)

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1977,6 +1977,8 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
           update_screen(0);
         }
 
+        // The mapping may do anything, but we expect it to take care of
+        // redrawing.  Do put the cursor back where it was.
         ui_cursor_goto(save_cursor_row, save_cursor_col);
       }
     } else {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1956,6 +1956,8 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
     if (mp->m_expr) {
       int save_vgetc_busy = vgetc_busy;
       const bool save_may_garbage_collect = may_garbage_collect;
+      int save_cursor_row = ui_current_row();
+      int save_cursor_col = ui_current_col();
 
       vgetc_busy = 0;
       may_garbage_collect = false;
@@ -1967,6 +1969,16 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
       map_str = eval_map_expr(mp, NUL);
       vgetc_busy = save_vgetc_busy;
       may_garbage_collect = save_may_garbage_collect;
+
+      if (State & CMDLINE) {
+        redrawcmdline();
+      } else {
+        if (must_redraw) {
+          update_screen(0);
+        }
+
+        ui_cursor_goto(save_cursor_row, save_cursor_col);
+      }
     } else {
       map_str = mp->m_str;
     }

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -1,6 +1,7 @@
 " Tests for mappings and abbreviations
 
 source shared.vim
+source check.vim
 
 func Test_abbreviation()
   " abbreviation with 0x80 should work
@@ -449,6 +450,36 @@ func Test_expr_map_gets_cursor()
   delfunc StoreColumn
   nunmap x
   nunmap !
+endfunc
+
+func Test_expr_map_restore_cursor()
+  CheckScreendump
+
+  let lines =<< trim END
+      call setline(1, ['one', 'two', 'three'])
+      2
+      set ls=2
+      hi! link StatusLine ErrorMsg
+      noremap <expr> <C-B> Func()
+      func Func()
+	  let g:on = !get(g:, 'on', 0)
+	  redraws
+	  return ''
+      endfunc
+      func Status()
+	  return get(g:, 'on', 0) ? '[on]' : ''
+      endfunc
+      set stl=%{Status()}
+  END
+  call writefile(lines, 'XtestExprMap')
+  let buf = RunVimInTerminal('-S XtestExprMap', #{rows: 10})
+  call term_wait(buf)
+  call term_sendkeys(buf, "\<C-B>")
+  call VerifyScreenDump(buf, 'Test_map_expr_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XtestExprMap')
 endfunc
 
 " Test for mapping errors

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require("test.functional.helpers")(after_each)
+local Screen = require('test.functional.ui.screen')
 
 local eq = helpers.eq
 local feed = helpers.feed
@@ -24,5 +25,134 @@ describe(':*map', function()
     command('imap <M-"> foo')
     feed('i-<M-">-')
     expect('-foo-')
+  end)
+end)
+
+describe(':*map <expr>', function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(20, 5)
+    screen:attach()
+  end)
+
+  it('cursor is restored after :map <expr>', function()
+    command(':map <expr> x input("> ")')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+                          |
+    ]])
+    feed('x')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      > ^                  |
+    ]])
+    feed('\n')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+      >                   |
+    ]])
+  end)
+
+  it('cursor is restored after :imap <expr>', function()
+    command(':imap <expr> x input("> ")')
+    feed('i')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+      -- INSERT --        |
+    ]])
+    feed('x')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      > ^                  |
+    ]])
+    feed('\n')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+      >                   |
+    ]])
+  end)
+
+  it('command line is restored after :cmap <expr>', function()
+    command(':cmap <expr> x input("> ")')
+    feed(':foo')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      :foo^                |
+    ]])
+    feed('x')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      > ^                  |
+    ]])
+    feed('\n')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      :foo^                |
+    ]])
+  end)
+
+  it('error in :cmap <expr> handled correctly', function()
+    screen:try_resize(40, 5)
+    command(':cmap <expr> x execute("throw 42")')
+    feed(':echo "foo')
+    screen:expect([[
+                                              |
+      ~                                       |
+      ~                                       |
+      ~                                       |
+      :echo "foo^                              |
+    ]])
+    feed('x')
+    screen:expect([[
+                                              |
+      :echo "foo                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      :echo "foo^                              |
+    ]])
+    feed('"')
+    screen:expect([[
+                                              |
+      :echo "foo                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      :echo "foo"^                             |
+    ]])
+    feed('\n')
+    screen:expect([[
+      :echo "foo                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      foo                                     |
+      Press ENTER or type command to continue^ |
+    ]])
   end)
 end)

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -410,7 +410,7 @@ describe('Command-line coloring', function()
   end)
   it('stops executing callback after a number of errors', function()
     set_color_cb('SplittedMultibyteStart')
-    start_prompt('let x = "«»«»«»«»«»"\n')
+    start_prompt('let x = "«»«»«»«»«»"')
     screen:expect([[
       {EOB:~                                       }|
       {EOB:~                                       }|
@@ -419,7 +419,7 @@ describe('Command-line coloring', function()
       :let x = "                              |
       {ERR:E5405: Chunk 0 start 10 splits multibyte}|
       {ERR: character}                              |
-      ^:let x = "«»«»«»«»«»"                   |
+      :let x = "«»«»«»«»«»"^                   |
     ]])
     feed('\n')
     screen:expect([[
@@ -432,6 +432,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
                                               |
     ]])
+    feed('\n')
     eq('let x = "«»«»«»«»«»"', meths.get_var('out'))
     local msg = '\nE5405: Chunk 0 start 10 splits multibyte character'
     eq(msg:rep(1), funcs.execute('messages'))
@@ -474,14 +475,14 @@ describe('Command-line coloring', function()
     ]])
     feed('\n')
     screen:expect([[
-                                              |
+      ^                                        |
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      ^:echo 42                                |
+      :echo 42                                |
     ]])
     feed('\n')
     eq('echo 42', meths.get_var('out'))


### PR DESCRIPTION
My attempt at tackling issue: https://github.com/neovim/neovim/issues/12707.

Fix corner case that occurs when both:
  1. Evaluating a mapped expression causes the cursor to move.
  2. The evaluated result does not resolve to a character.

When a mapping does not result in a character, the UI is flushed, and we go back to waiting for user input. When the cursor has moved, the UI is flushed in an incorrect state, this can be resolved with a simple call to setcursor().