### PR TITLE
provider: align retval of foo#Detect() functions

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -573,7 +573,7 @@ function! s:check_ruby() abort
   endif
   call health#report_info('Ruby: '. s:system('ruby -v'))
 
-  let host = provider#ruby#Detect()
+  let [host, err] = provider#ruby#Detect()
   if empty(host)
     call health#report_warn('`neovim-ruby-host` not found.',
           \ ['Run `gem install neovim` to ensure the neovim RubyGem is installed.',
@@ -636,7 +636,7 @@ function! s:check_node() abort
     call health#report_warn('node.js on this system does not support --inspect-brk so $NVIM_NODE_HOST_DEBUG is ignored.')
   endif
 
-  let host = provider#node#Detect()
+  let [host, err] = provider#node#Detect()
   if empty(host)
     call health#report_warn('Missing "neovim" npm (or yarn) package.',
           \ ['Run in shell: npm install -g neovim',

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -5,7 +5,8 @@ endif
 let g:loaded_ruby_provider = 1
 
 function! provider#ruby#Detect() abort
-  return s:prog
+  let e = empty(s:prog) ? 'missing ruby or ruby-host' : ''
+  return [s:prog, e]
 endfunction
 
 function! provider#ruby#Prog() abort

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -768,18 +768,15 @@ function module.new_pipename()
 end
 
 function module.missing_provider(provider)
-  if provider == 'ruby' or provider == 'node' then
-    local prog = module.funcs['provider#' .. provider .. '#Detect']()
-    return prog == '' and (provider .. ' not detected') or false
-  elseif provider == 'perl' then
-    local errors = module.funcs['provider#'..provider..'#Detect']()[2]
-    return errors ~= '' and errors or false
+  if provider == 'ruby' or provider == 'node' or provider == 'perl' then
+    local e = module.funcs['provider#'..provider..'#Detect']()[2]
+    return e ~= '' and e or false
   elseif provider == 'python' or provider == 'python3' then
     local py_major_version = (provider == 'python3' and 3 or 2)
-    local errors = module.funcs['provider#pythonx#Detect'](py_major_version)[2]
-    return errors ~= '' and errors or false
+    local e = module.funcs['provider#pythonx#Detect'](py_major_version)[2]
+    return e ~= '' and e or false
   else
-    assert(false, 'Unknown provider: ' .. provider)
+    assert(false, 'Unknown provider: '..provider)
   end
 end
 


### PR DESCRIPTION
ruby#Detect() and node#Detect() don't return a [prog, err] pair which means callers have to special case.