### PR TITLE
treesitter: fix some highlight issues

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -134,12 +134,9 @@ function TSHighlighter:on_changedtree(changes)
   self.root = self.parser.tree:root()
 
   for _, ch in ipairs(changes or {}) do
-    -- Try to be as exact as possible
-    local changed_node = self.root:descendant_for_range(ch[1], ch[2], ch[3], ch[4])
+    a.nvim_buf_clear_namespace(self.buf, ts_hs_ns, ch[1], ch[3] + 1)
 
-    a.nvim_buf_clear_namespace(self.buf, ts_hs_ns, ch[1], ch[3])
-
-    for capture, node in self.query:iter_captures(changed_node, self.buf, ch[1], ch[3] + 1) do
+    for capture, node in self.query:iter_captures(self.root, self.buf, ch[1], ch[3] + 1) do
       local start_row, start_col, end_row, end_col = node:range()
       local hl = self.hl_cache[capture]
       if hl then

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -445,6 +445,28 @@ static int nlua_schedule(lua_State *const lstate)
                                                                        |
     ]]}
 
+    feed("5Goc<esc>dd")
+    screen:expect{grid=[[
+      {2:/// Schedule Lua callback on main loop's event queue}             |
+      {3:static} {3:int} {11:nlua_schedule}({3:lua_State} *{3:const} lstate)                |
+      {                                                                |
+        {4:if} ({11:lua_type}(lstate, {5:1}) != {5:LUA_TFUNCTION}                       |
+            || {6:lstate} != {6:lstate}) {                                     |
+          {11:^lua_pushliteral}(lstate, {5:"vim.schedule: expected function"});  |
+          {4:return} {11:lua_error}(lstate);                                    |
+        }                                                              |
+                                                                       |
+        {7:LuaRef} cb = {11:nlua_ref}(lstate, {5:1});                               |
+                                                                       |
+        multiqueue_put(main_loop.events, {11:nlua_schedule_event},          |
+                       {5:1}, ({3:void} *)({3:ptrdiff_t})cb);                      |
+        {4:return} {5:0};                                                      |
+      }                                                                |
+      {1:~                                                                }|
+      {1:~                                                                }|
+                                                                       |
+    ]]}
+
     feed('7Go*/<esc>')
     screen:expect{grid=[[
       {2:/// Schedule Lua callback on main loop's event queue}             |


### PR DESCRIPTION
Sorry for the tiny PR, but this fixes some highlighting issues we had in treesitter.

This is a revert of what I thought was an optimization, but was just a mistake.