### PR TITLE
treesitter: allow to list supported predicates

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -782,6 +782,11 @@ vim.treesitter.query.add_predicate({name}, {handler})
 This adds a predicate with the name {name} to be used in queries.
 {handler} should be a function whose signature will be : >
 	handler(match, pattern, bufnr, predicate)
+<
+					*vim.treesitter.query.list_predicates()*
+vim.treesitter.query.list_predicates()
+
+This lists the currently available predicates to use in queries.
 
 Treesitter syntax highlighting (WIP)			*lua-treesitter-highlight*
 

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -127,6 +127,11 @@ function M.add_predicate(name, handler, force)
   predicate_handlers[name] = handler
 end
 
+--- Returns the list of currently supported predicates
+function M.list_predicates()
+  return vim.tbl_keys(predicate_handlers)
+end
+
 function Query:match_preds(match, pattern, bufnr)
   local preds = self.info.patterns[pattern]
   if not preds then

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -312,6 +312,18 @@ void ui_refresh(void)
     ]], custom_query)
 
     eq({{0, 4, 0, 8}}, res)
+
+    local res_list = exec_lua[[
+    local query = require'vim.treesitter.query'
+
+    local list = query.list_predicates()
+
+    table.sort(list)
+
+    return list
+    ]]
+
+    eq({ 'contains?', 'eq?', 'is-main?', 'match?', 'vim-match?' }, res_list)
   end)
 
   it('supports highlighting', function()


### PR DESCRIPTION
This would be useful to know for completion purposes.
I will use it for sure in `architext.nvim`.