### PR TITLE
vim-patch:8.2.1552,8.2.1553,8.2.1560

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -346,7 +346,8 @@ submit_pr() {
   local patches
   # Extract just the "vim-patch:X.Y.ZZZZ" or "vim-patch:sha" portion of each log
   patches=("$(git log --grep=vim-patch --reverse --format='%s' "${git_remote}"/master..HEAD | sed 's/: .*//')")
-  patches=("${patches[@]//vim-patch:}") # Remove 'vim-patch:' prefix for each item in array.
+  # shellcheck disable=SC2206
+  patches=(${patches[@]//vim-patch:}) # Remove 'vim-patch:' prefix for each item in array.
   local pr_title="${patches[*]}" # Create space-separated string from array.
   pr_title="${pr_title// /,}" # Replace spaces with commas.
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -577,10 +577,11 @@ void foldCreate(win_T *wp, linenr_T start, linenr_T end)
     i = 0;
   } else {
     for (;;) {
-      if (!foldFind(gap, start_rel, &fp))
+      if (!foldFind(gap, start_rel, &fp)) {
         break;
+      }
       if (fp->fd_top + fp->fd_len > end_rel) {
-        /* New fold is completely inside this fold: Go one level deeper. */
+        // New fold is completely inside this fold: Go one level deeper.
         gap = &fp->fd_nested;
         start_rel -= fp->fd_top;
         end_rel -= fp->fd_top;
@@ -594,8 +595,8 @@ void foldCreate(win_T *wp, linenr_T start, linenr_T end)
         }
         level++;
       } else {
-        /* This fold and new fold overlap: Insert here and move some folds
-         * inside the new fold. */
+        // This fold and new fold overlap: Insert here and move some folds
+        // inside the new fold.
         break;
       }
     }
@@ -1064,14 +1065,14 @@ void cloneFoldGrowArray(garray_T *from, garray_T *to)
  * the first fold below it (careful: it can be beyond the end of the array!).
  * Returns FALSE when there is no fold that contains "lnum".
  */
-static int foldFind(const garray_T *gap, linenr_T lnum, fold_T **fpp)
+static bool foldFind(const garray_T *gap, linenr_T lnum, fold_T **fpp)
 {
   linenr_T low, high;
   fold_T      *fp;
 
   if (gap->ga_len == 0) {
     *fpp = NULL;
-    return FALSE;
+    return false;
   }
 
   /*
@@ -1097,7 +1098,7 @@ static int foldFind(const garray_T *gap, linenr_T lnum, fold_T **fpp)
     }
   }
   *fpp = fp + low;
-  return FALSE;
+  return false;
 }
 
 /* foldLevelWin() {{{2 */
@@ -1231,9 +1232,10 @@ setManualFoldWin(
   gap = &wp->w_folds;
   for (;; ) {
     if (!foldFind(gap, lnum, &fp)) {
-      /* If there is a following fold, continue there next time. */
-      if (fp != NULL && fp < (fold_T *)gap->ga_data + gap->ga_len)
+      // If there is a following fold, continue there next time.
+      if (fp != NULL && fp < (fold_T *)gap->ga_data + gap->ga_len) {
         next = fp->fd_top + off;
+      }
       break;
     }
 
@@ -2280,14 +2282,15 @@ static linenr_T foldUpdateIEMSRecurse(
         /* Find an existing fold to re-use.  Preferably one that
          * includes startlnum, otherwise one that ends just before
          * startlnum or starts after it. */
-        if (gap->ga_len > 0 && (foldFind(gap, startlnum, &fp)
-            || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
-                && fp->fd_top <= firstlnum)
-            || foldFind(gap, firstlnum - concat, &fp)
-            || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
-                && ((lvl < level && fp->fd_top < flp->lnum)
-                    || (lvl >= level
-                        && fp->fd_top <= flp->lnum_save))))) {
+        if (gap->ga_len > 0
+            && (foldFind(gap, startlnum, &fp)
+                || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
+                    && fp->fd_top <= firstlnum)
+                || foldFind(gap, firstlnum - concat, &fp)
+                || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
+                    && ((lvl < level && fp->fd_top < flp->lnum)
+                        || (lvl >= level
+                            && fp->fd_top <= flp->lnum_save))))) {
           if (fp->fd_top + fp->fd_len + concat > firstlnum) {
             /* Use existing fold for the new fold.  If it starts
              * before where we started looking, extend it.  If it
@@ -2578,9 +2581,10 @@ static void foldInsert(garray_T *gap, int i)
   ga_grow(gap, 1);
 
   fp = (fold_T *)gap->ga_data + i;
-  if (gap->ga_len > 0 && i < gap->ga_len)
+  if (gap->ga_len > 0 && i < gap->ga_len) {
     memmove(fp + 1, fp, sizeof(fold_T) * (size_t)(gap->ga_len - i));
-  ++gap->ga_len;
+  }
+  gap->ga_len++;
   ga_init(&fp->fd_nested, (int)sizeof(fold_T), 10);
 }
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -788,13 +788,15 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
     return;
   }
 
-  // Mark all folds from top to bot as maybe-small.
-  fold_T *fp;
-  (void)foldFind(&wp->w_folds, top, &fp);
-  while (fp < (fold_T *)wp->w_folds.ga_data + wp->w_folds.ga_len
-         && fp->fd_top < bot) {
-    fp->fd_small = kNone;
-    fp++;
+  if (wp->w_folds.ga_len > 0) {
+    // Mark all folds from top to bot as maybe-small.
+    fold_T *fp;
+    (void)foldFind(&wp->w_folds, top, &fp);
+    while (fp < (fold_T *)wp->w_folds.ga_data + wp->w_folds.ga_len
+           && fp->fd_top < bot) {
+      fp->fd_small = kNone;
+      fp++;
+    }
   }
 
   if (foldmethodIsIndent(wp)
@@ -1062,6 +1064,11 @@ static int foldFind(const garray_T *gap, linenr_T lnum, fold_T **fpp)
 {
   linenr_T low, high;
   fold_T      *fp;
+
+  if (gap->ga_len == 0) {
+    *fpp = NULL;
+    return FALSE;
+  }
 
   /*
    * Perform a binary search.
@@ -2269,14 +2276,14 @@ static linenr_T foldUpdateIEMSRecurse(
         /* Find an existing fold to re-use.  Preferably one that
          * includes startlnum, otherwise one that ends just before
          * startlnum or starts after it. */
-        if (foldFind(gap, startlnum, &fp)
+        if (gap->ga_len > 0 && (foldFind(gap, startlnum, &fp)
             || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
                 && fp->fd_top <= firstlnum)
             || foldFind(gap, firstlnum - concat, &fp)
             || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
                 && ((lvl < level && fp->fd_top < flp->lnum)
                     || (lvl >= level
-                        && fp->fd_top <= flp->lnum_save)))) {
+                        && fp->fd_top <= flp->lnum_save))))) {
           if (fp->fd_top + fp->fd_len + concat > firstlnum) {
             /* Use existing fold for the new fold.  If it starts
              * before where we started looking, extend it.  If it
@@ -2367,7 +2374,11 @@ static linenr_T foldUpdateIEMSRecurse(
         } else {
           /* Insert new fold.  Careful: ga_data may be NULL and it
            * may change! */
-          i = (int)(fp - (fold_T *)gap->ga_data);
+          if (gap->ga_len == 0) {
+            i = 0;
+          } else {
+            i = (int)(fp - (fold_T *)gap->ga_data);
+          }
           foldInsert(gap, i);
           fp = (fold_T *)gap->ga_data + i;
           /* The new fold continues until bot, unless we find the
@@ -2563,7 +2574,7 @@ static void foldInsert(garray_T *gap, int i)
   ga_grow(gap, 1);
 
   fp = (fold_T *)gap->ga_data + i;
-  if (i < gap->ga_len)
+  if (gap->ga_len > 0 && i < gap->ga_len)
     memmove(fp + 1, fp, sizeof(fold_T) * (size_t)(gap->ga_len - i));
   ++gap->ga_len;
   ga_init(&fp->fd_nested, (int)sizeof(fold_T), 10);
@@ -2645,7 +2656,7 @@ static void foldRemove(
     return;             // nothing to do
   }
 
-  for (;; ) {
+  while (gap->ga_len > 0) {
     // Find fold that includes top or a following one.
     if (foldFind(gap, top, &fp) && fp->fd_top < top) {
       // 2: or 3: need to delete nested folds

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -5663,6 +5663,9 @@ check_suggestions (
   int len;
   hlf_T attr;
 
+  if (gap->ga_len == 0) {
+    return;
+  }
   stp = &SUG(*gap, 0);
   for (int i = gap->ga_len - 1; i >= 0; --i) {
     // Need to append what follows to check for "the the".


### PR DESCRIPTION
#### vim-patch:8.2.1552: warnings from asan with clang-11

Problem:    Warnings from asan with clang-11. (James McCoy)
Solution:   Avoid using a NULL pointer. (issue vim/vim#6811)
https://github.com/vim/vim/commit/64f37d309025a65210dbc33823ec9ec5d547775f


#### vim-patch:8.2.1553: crash in edit test

Problem:    Crash in edit test.
Solution:   Avoid using invalid pointer.
https://github.com/vim/vim/commit/2c93c685e3334c50d9a748ad699df727a4501b08


#### vim-patch:8.2.1560: using NULL pointers in some code

Problem:    Using NULL pointers in some code. (James McCoy)
Solution:   Avoid adding to a NULL pointer.  Use byte as unsigned.
https://github.com/vim/vim/commit/9c2b06637b32742cac11bfd66b1a4e84583c6c2e

The changes to eval.c (skip_expr_concatenate) and vim9compile.c aren't
included since they're specific to vim9script support.