### PR TITLE
fix(highlight): compare rows vs columns in range highlight check

### DIFF
--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -14,7 +14,7 @@ function highlight.range(bufnr, ns, higroup, start, finish, rtype, inclusive)
   inclusive = inclusive or false
 
   -- sanity check
-  if start[2] < 0 or finish[2] < start[2] then return end
+  if start[2] < 0 or finish[1] < start[1] then return end
 
   local region = vim.region(bufnr, start, finish, rtype, inclusive)
   for linenr, cols in pairs(region) do


### PR DESCRIPTION
This fixes an issue with highlighting ranges. Take the following example.

```javascript
const myFn = () => {
  return 'cool';
}
```
If we want to highlight the arrow function (treesitter node, for example). `vim.highlight.range` would fail because the start end column is less than the start column. This should be comparing rows instead of columns.