### PR TITLE
treesitter: check hl group exists before passing it in nvim_get_hl_id_by_name

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -98,7 +98,12 @@ function TSHighlighter:get_hl_from_capture(capture)
     return vim.split(name, '.', true)[1]
   else
     -- Default to false to avoid recomputing
-    return a.nvim_get_hl_id_by_name(TSHighlighter.hl_map[name])
+    local hl = TSHighlighter.hl_map[name]
+    if hl then
+      return a.nvim_get_hl_id_by_name(hl)
+    else
+      return 0
+    end
   end
 end
 

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -99,11 +99,7 @@ function TSHighlighter:get_hl_from_capture(capture)
   else
     -- Default to false to avoid recomputing
     local hl = TSHighlighter.hl_map[name]
-    if hl then
-      return a.nvim_get_hl_id_by_name(hl)
-    else
-      return 0
-    end
+    return hl and a.nvim_get_hl_id_by_name(hl) or 0
   end
 end
 


### PR DESCRIPTION
using neovim latest and nvim-treesitter latest.

Open a rust file (with some `derive` directive), try to save, you get :
`Overwrite existing file "....../main.rs"? (Y)es, [N]o:`

Try to format the file, or do some kind of changes (for instance on a derive directive, remove the last e and write it back), you'll get:
`Error executing lua callback: /usr/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:122: Expected lua string`

This is happening because in the highlights.scm file for rust, we use `@meta` which is not declared in the `TSHighlight.hl_map` dict, and going through the highlighter at some point it messes up stuff.

This PR checks the highlight group exists before calling `nvim_get_hl_id_by_name`. 
Maybe a warning should be added to inform a name is not defined in `hl_map` ?