### PR TITLE
Extmarks: allow to set extranges past final newline

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1393,15 +1393,17 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id,
   }
 
   if (col2 >= 0) {
-    if (line2 >= 0) {
-      len = STRLEN(ml_get_buf(buf, (linenr_T)line2+1, false));
+    if (line2 >= 0 && line2 < buf->b_ml.ml_line_count) {
+      len = STRLEN(ml_get_buf(buf, (linenr_T)line2 + 1, false));
+    } else if (line2 == buf->b_ml.ml_line_count) {
+      // We are trying to add an extmark past final newline
+      len = 0;
     } else {
       // reuse len from before
       line2 = (int)line;
     }
     if (col2 > (Integer)len) {
-      api_set_error(err, kErrorTypeValidation,
-                    "end_col value outside range");
+      api_set_error(err, kErrorTypeValidation, "end_col value outside range");
       goto error;
     }
   } else if (line2 >= 0) {

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -100,6 +100,15 @@ describe('API/extmarks', function()
     ns2 = request('nvim_create_namespace', "my-fancy-plugin2")
   end)
 
+  it("can end extranges past final newline using end_col = 0", function()
+    set_extmark(ns, marks[1], 0, 0, {
+      end_col = 0,
+      end_line = 1
+    })
+    eq("end_col value outside range",
+       pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = 1, end_line = 1 }))
+  end)
+
   it('adds, updates  and deletes marks', function()
     local rv = set_extmark(ns, marks[1], positions[1][1], positions[1][2])
     eq(marks[1], rv)


### PR DESCRIPTION
Turns https://github.com/neovim/neovim/issues/12867 into https://github.com/neovim/neovim/issues/12861.

This allows to end an extrange past the final newline (tree-sitter does that sometimes...)