### PR TITLE
lua: cleanup naming conventions of executor functions

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -212,10 +212,10 @@ Boolean nvim_buf_attach(uint64_t channel_id,
 
 error:
   // TODO(bfredl): ASAN build should check that the ref table is empty?
-  executor_free_luaref(cb.on_lines);
-  executor_free_luaref(cb.on_bytes);
-  executor_free_luaref(cb.on_changedtick);
-  executor_free_luaref(cb.on_detach);
+  api_free_luaref(cb.on_lines);
+  api_free_luaref(cb.on_bytes);
+  api_free_luaref(cb.on_changedtick);
+  api_free_luaref(cb.on_detach);
   return false;
 }
 
@@ -247,10 +247,10 @@ Boolean nvim_buf_detach(uint64_t channel_id,
 static void buf_clear_luahl(buf_T *buf, bool force)
 {
   if (buf->b_luahl || force) {
-    executor_free_luaref(buf->b_luahl_start);
-    executor_free_luaref(buf->b_luahl_window);
-    executor_free_luaref(buf->b_luahl_line);
-    executor_free_luaref(buf->b_luahl_end);
+    api_free_luaref(buf->b_luahl_start);
+    api_free_luaref(buf->b_luahl_window);
+    api_free_luaref(buf->b_luahl_line);
+    api_free_luaref(buf->b_luahl_end);
   }
   buf->b_luahl_start = LUA_NOREF;
   buf->b_luahl_window = LUA_NOREF;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1198,7 +1198,7 @@ void api_free_object(Object value)
       break;
 
     case kObjectTypeLuaRef:
-      executor_free_luaref(value.data.luaref);
+      api_free_luaref(value.data.luaref);
       break;
 
     default:

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -475,7 +475,7 @@ Object nvim_execute_lua(String code, Array args, Error *err)
   FUNC_API_DEPRECATED_SINCE(7)
   FUNC_API_REMOTE_ONLY
 {
-  return executor_exec_lua_api(code, args, err);
+  return nlua_exec(code, args, err);
 }
 
 /// Execute Lua code. Parameters (if any) are available as `...` inside the
@@ -494,7 +494,7 @@ Object nvim_exec_lua(String code, Array args, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_REMOTE_ONLY
 {
-  return executor_exec_lua_api(code, args, err);
+  return nlua_exec(code, args, err);
 }
 
 /// Calls a VimL function.
@@ -2477,7 +2477,7 @@ Array nvim_get_proc_children(Integer pid, Error *err)
     Array a = ARRAY_DICT_INIT;
     ADD(a, INTEGER_OBJ(pid));
     String s = cstr_to_string("return vim._os_proc_children(select(1, ...))");
-    Object o = nvim_exec_lua(s, a, err);
+    Object o = nlua_exec(s, a, err);
     api_free_string(s);
     api_free_array(a);
     if (o.type == kObjectTypeArray) {
@@ -2523,7 +2523,7 @@ Object nvim_get_proc(Integer pid, Error *err)
   Array a = ARRAY_DICT_INIT;
   ADD(a, INTEGER_OBJ(pid));
   String s = cstr_to_string("return vim._os_proc_info(select(1, ...))");
-  Object o = nvim_exec_lua(s, a, err);
+  Object o = nlua_exec(s, a, err);
   api_free_string(s);
   api_free_array(a);
   if (o.type == kObjectTypeArray && o.data.array.size == 0) {

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -158,7 +158,7 @@ void buf_updates_unregister_all(buf_T *buf)
       args.items[0] = BUFFER_OBJ(buf->handle);
 
       textlock++;
-      executor_exec_lua_cb(cb.on_detach, "detach", args, false, NULL);
+      nlua_call_ref(cb.on_detach, "detach", args, false, NULL);
       textlock--;
     }
     free_update_callbacks(cb);
@@ -266,7 +266,7 @@ void buf_updates_send_changes(buf_T *buf,
         args.items[7] = INTEGER_OBJ((Integer)deleted_codeunits);
       }
       textlock++;
-      Object res = executor_exec_lua_cb(cb.on_lines, "lines", args, true, NULL);
+      Object res = nlua_call_ref(cb.on_lines, "lines", args, true, NULL);
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
@@ -317,7 +317,7 @@ void buf_updates_send_splice(
       args.items[10] = INTEGER_OBJ(new_byte);
 
       textlock++;
-      Object res = executor_exec_lua_cb(cb.on_bytes, "bytes", args, true, NULL);
+      Object res = nlua_call_ref(cb.on_bytes, "bytes", args, true, NULL);
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
@@ -352,8 +352,8 @@ void buf_updates_changedtick(buf_T *buf)
       args.items[1] = INTEGER_OBJ(buf_get_changedtick(buf));
 
       textlock++;
-      Object res = executor_exec_lua_cb(cb.on_changedtick, "changedtick",
-                                        args, true, NULL);
+      Object res = nlua_call_ref(cb.on_changedtick, "changedtick",
+                                 args, true, NULL);
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
@@ -387,6 +387,6 @@ void buf_updates_changedtick_single(buf_T *buf, uint64_t channel_id)
 
 static void free_update_callbacks(BufUpdateCallbacks cb)
 {
-  executor_free_luaref(cb.on_lines);
-  executor_free_luaref(cb.on_changedtick);
+  api_free_luaref(cb.on_lines);
+  api_free_luaref(cb.on_changedtick);
 }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5482,7 +5482,7 @@ static void f_luaeval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  executor_eval_lua(cstr_as_string((char *)str), &argvars[1], rettv);
+  nlua_typval_eval(cstr_as_string((char *)str), &argvars[1], rettv);
 }
 
 /*

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1395,8 +1395,7 @@ call_func(
     if (is_luafunc(partial)) {
       if (len > 0) {
         error = ERROR_NONE;
-        executor_call_lua((const char *)funcname, len,
-                          argvars, argcount, rettv);
+        nlua_typval_call((const char *)funcname, len, argvars, argcount, rettv);
       }
     } else if (!builtin_function((const char *)rfname, -1)) {
       // User defined function.

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -1249,6 +1249,13 @@ type_error:
   return ret;
 }
 
+LuaRef nlua_pop_LuaRef(lua_State *const lstate, Error *err)
+{
+  LuaRef rv = nlua_ref(lstate, -1);
+  lua_pop(lstate, 1);
+  return rv;
+}
+
 #define GENERATE_INDEX_FUNCTION(type) \
 type nlua_pop_##type(lua_State *lstate, Error *err) \
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT \

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -513,7 +513,7 @@ int update_screen(int type)
         FIXED_TEMP_ARRAY(args, 2);
         args.items[0] = BUFFER_OBJ(buf->handle);
         args.items[1] = INTEGER_OBJ(display_tick);
-        executor_exec_lua_cb(buf->b_luahl_start, "start", args, false, &err);
+        nlua_call_ref(buf->b_luahl_start, "start", args, false, &err);
         if (ERROR_SET(&err)) {
           ELOG("error in luahl start: %s", err.msg);
           api_clear_error(&err);
@@ -1251,7 +1251,7 @@ static void win_update(win_T *wp)
     args.items[3] = INTEGER_OBJ(knownmax);
     // TODO(bfredl): we could allow this callback to change mod_top, mod_bot.
     // For now the "start" callback is expected to use nvim__buf_redraw_range.
-    executor_exec_lua_cb(buf->b_luahl_window, "window", args, false, &err);
+    nlua_call_ref(buf->b_luahl_window, "window", args, false, &err);
     if (ERROR_SET(&err)) {
       ELOG("error in luahl window: %s", err.msg);
       api_clear_error(&err);
@@ -2356,8 +2356,7 @@ win_line (
         args.items[2] = INTEGER_OBJ(lnum-1);
         lua_attr_active = true;
         extra_check = true;
-        Object o = executor_exec_lua_cb(buf->b_luahl_line, "line",
-                                        args, true, &err);
+        Object o = nlua_call_ref(buf->b_luahl_line, "line", args, true, &err);
         lua_attr_active = false;
         if (o.type == kObjectTypeString) {
           // TODO(bfredl): this is a bit of a hack. A final API should use an

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -16,7 +16,7 @@ typedef uint32_t u8char_T;
 // Opaque handle used by API clients to refer to various objects in vim
 typedef int handle_T;
 
-// Opaque handle to a lua value. Must be free with `executor_free_luaref` when
+// Opaque handle to a lua value. Must be free with `api_free_luaref` when
 // not needed anymore! LUA_NOREF represents missing reference, i e to indicate
 // absent callback etc.
 typedef int LuaRef;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2119,13 +2119,13 @@ void list_in_columns(char_u **items, int size, int current)
 
 void list_lua_version(void)
 {
-  typval_T luaver_tv;
-  typval_T arg = { .v_type = VAR_UNKNOWN };  // No args.
-  char *luaver_expr = "((jit and jit.version) and jit.version or _VERSION)";
-  executor_eval_lua(cstr_as_string(luaver_expr), &arg, &luaver_tv);
-  assert(luaver_tv.v_type == VAR_STRING);
-  MSG(luaver_tv.vval.v_string);
-  xfree(luaver_tv.vval.v_string);
+  char *code = "return ((jit and jit.version) and jit.version or _VERSION)";
+  Error err = ERROR_INIT;
+  Object ret = nlua_exec(cstr_as_string(code), (Array)ARRAY_DICT_INIT, &err);
+  assert(!ERROR_SET(&err));
+  assert(ret.type == kObjectTypeString);
+  MSG(ret.data.string.data);
+  api_free_object(ret);
 }
 
 void list_version(void)


### PR DESCRIPTION
broken out of #12841 . The internal naming changes only, no new functionality.