### PR TITLE
docs: Use nvim-lspconfig plugin in lsp docs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -23,9 +23,9 @@ QUICKSTART                                              *lsp-quickstart*
 Nvim provides a LSP client, but the servers are provided by third parties.
 Follow these steps to get LSP features:
 
-  1. Install the nvim-lsp plugin.  It provides common configuration for
+  1. Install the nvim-lspconfig plugin.  It provides common configuration for
      various servers so you can get started quickly.
-     https://github.com/neovim/nvim-lsp
+     https://github.com/neovim/nvim-lspconfig
   2. Install a language server.  Try ":LspInstall <tab>" or use your system
      package manager to install the relevant language server:
      https://microsoft.github.io/language-server-protocol/implementors/servers/

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -30,7 +30,7 @@ Follow these steps to get LSP features:
      package manager to install the relevant language server:
      https://microsoft.github.io/language-server-protocol/implementors/servers/
   3. Add `nvim_lsp.xx.setup{…}` to your vimrc, where "xx" is the name of the
-     relevant config.  See the nvim-lsp README for details.
+     relevant config.  See the nvim-lspconfig README for details.
 
 To check LSP clients attached to the current buffer:  >
 


### PR DESCRIPTION
Update documentation to use the renamed nvim-lspconfig. 

Noted on #12823 