### PR TITLE
docs: Add hint for :help vim.lsp.buf for new users

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -39,7 +39,7 @@ To check LSP clients attached to the current buffer:  >
                                                         *lsp-config*
 Inline diagnostics are enabled automatically, e.g. syntax errors will be
 annotated in the buffer.  But you probably want to use other features like
-go-to-definition, hover, etc. See `:help vim.lsp.buf`. Example config: >
+go-to-definition, hover, etc. See |vim.lsp.buf|. Example config: >
 
   nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
   nnoremap <silent> <c-]> <cmd>lua vim.lsp.buf.definition()<CR>

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -39,7 +39,7 @@ To check LSP clients attached to the current buffer:  >
                                                         *lsp-config*
 Inline diagnostics are enabled automatically, e.g. syntax errors will be
 annotated in the buffer.  But you probably want to use other features like
-go-to-definition, hover, etc.  Example config: >
+go-to-definition, hover, etc. See `:help vim.lsp.buf`. Example config: >
 
   nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
   nnoremap <silent> <c-]> <cmd>lua vim.lsp.buf.definition()<CR>

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -39,9 +39,10 @@ To check LSP clients attached to the current buffer:  >
                                                         *lsp-config*
 Inline diagnostics are enabled automatically, e.g. syntax errors will be
 annotated in the buffer.  But you probably want to use other features like
-go-to-definition, hover, etc. See |vim.lsp.buf|. Example config: >
+go-to-definition, hover, etc. Full list of features in |vim.lsp.buf|. 
 
-  nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
+Example config: >
+
   nnoremap <silent> <c-]> <cmd>lua vim.lsp.buf.definition()<CR>
   nnoremap <silent> K     <cmd>lua vim.lsp.buf.hover()<CR>
   nnoremap <silent> gD    <cmd>lua vim.lsp.buf.implementation()<CR>
@@ -50,6 +51,9 @@ go-to-definition, hover, etc. See |vim.lsp.buf|. Example config: >
   nnoremap <silent> gr    <cmd>lua vim.lsp.buf.references()<CR>
   nnoremap <silent> g0    <cmd>lua vim.lsp.buf.document_symbol()<CR>
   nnoremap <silent> gW    <cmd>lua vim.lsp.buf.workspace_symbol()<CR>
+  nnoremap <silent> gd    <cmd>lua vim.lsp.buf.declaration()<CR>
+
+Note: Language servers may have limited support for these features.
 
 Nvim provides the |vim.lsp.omnifunc| 'omnifunc' handler which allows
 |i_CTRL-X_CTRL-O| to consume LSP completion. Example config (note the use of


### PR DESCRIPTION
Adds a small hint for new users to show the full LSP API. 

In the keymap example it can mislead people of the scope of the API and adding this hint allows them to see the full API that's available. Notably `vim.lsp.buf.code_action` and `vim.lsp.buf.rename` are not listed but can be helpful. 