### PR TITLE
vim-patch: Update cfilter to 1.1

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -501,6 +501,29 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 <			Otherwise it works the same as `:ldo`.
 			{not in Vi}
 
+FILTERING A QUICKFIX OR LOCATION LIST:
+				    *cfilter-plugin* *:Cfilter* *:Lfilter*
+If you have too many entries in a quickfix list, you can use the cfilter
+plugin to reduce the number of entries.  Load the plugin with: >
+
+    packadd cfilter
+
+Then you can use the following commands to filter a quickfix/location list: >
+
+    :Cfilter[!] /{pat}/
+    :Lfilter[!] /{pat}/
+
+The |:Cfilter| command creates a new quickfix list from the entries matching
+{pat} in the current quickfix list. {pat} is a Vim |regular-expression|
+pattern. Both the file name and the text of the entries are matched against
+{pat}. If the optional ! is supplied, then the entries not matching {pat} are
+used. The pattern can be optionally enclosed using one of the following
+characters: ', ", /. If the pattern is empty, then the last used search
+pattern is used.
+
+The |:Lfilter| command does the same as |:Cfilter| but operates on the current
+location list.
+
 =============================================================================
 2. The error window					*quickfix-window*
 
@@ -1562,22 +1585,6 @@ changing the 'makeprg' option.  For example: >
 The backslashes before the pipe character are required to avoid it to be
 recognized as a command separator.  The backslash before each space is
 required for the set command.
-
-					    *cfilter-plugin* *:Cfilter* *:Lfilter*
-If you have too many matching messages, you can use the cfilter plugin to
-reduce the number of entries.  Load the plugin with: >
-   packadd cfilter
-
-Then you can use these command: >
-   :Cfilter[!] /{pat}/
-   :Lfilter[!] /{pat}/
-
-:Cfilter creates a new quickfix list from entries matching {pat} in the
-current quickfix list. Both the file name and the text of the entries are
-matched against {pat}. If ! is supplied, then entries not matching {pat} are
-used.
-
-:Lfilter does the same as :Cfilter but operates on the current location list.
 
 =============================================================================
 8. The directory stack				*quickfix-directory-stack*

--- a/runtime/pack/dist/opt/cfilter/plugin/cfilter.vim
+++ b/runtime/pack/dist/opt/cfilter/plugin/cfilter.vim
@@ -1,15 +1,17 @@
 " cfilter.vim: Plugin to filter entries from a quickfix/location list
-" Last Change: 	May 12, 2018
-" Maintainer: 	Yegappan Lakshmanan (yegappan AT yahoo DOT com)
-" Version:	1.0
+" Last Change: Aug 23, 2018
+" Maintainer: Yegappan Lakshmanan (yegappan AT yahoo DOT com)
+" Version: 1.1
 "
 " Commands to filter the quickfix list:
-"   :Cfilter[!] {pat}
+"   :Cfilter[!] /{pat}/
 "       Create a new quickfix list from entries matching {pat} in the current
 "       quickfix list. Both the file name and the text of the entries are
 "       matched against {pat}. If ! is supplied, then entries not matching
-"       {pat} are used.
-"   :Lfilter[!] {pat}
+"       {pat} are used. The pattern can be optionally enclosed using one of
+"       the following characters: ', ", /. If the pattern is empty, then the
+"       last used search pattern is used.
+"   :Lfilter[!] /{pat}/
 "       Same as :Cfilter but operates on the current location list.
 "
 if exists("loaded_cfilter")
@@ -17,7 +19,7 @@ if exists("loaded_cfilter")
 endif
 let loaded_cfilter = 1
 
-func s:Qf_filter(qf, pat, bang)
+func s:Qf_filter(qf, searchpat, bang)
     if a:qf
 	let Xgetlist = function('getqflist')
 	let Xsetlist = function('setqflist')
@@ -28,14 +30,31 @@ func s:Qf_filter(qf, pat, bang)
 	let cmd = ':Lfilter' . a:bang
     endif
 
-    if a:bang == '!'
-	let cond = 'v:val.text !~# a:pat && bufname(v:val.bufnr) !~# a:pat'
+    let firstchar = a:searchpat[0]
+    let lastchar = a:searchpat[-1:]
+    if firstchar == lastchar &&
+		\ (firstchar == '/' || firstchar == '"' || firstchar == "'")
+	let pat = a:searchpat[1:-2]
+	if pat == ''
+	    " Use the last search pattern
+	    let pat = @/
+	endif
     else
-	let cond = 'v:val.text =~# a:pat || bufname(v:val.bufnr) =~# a:pat'
+	let pat = a:searchpat
+    endif
+
+    if pat == ''
+	return
+    endif
+
+    if a:bang == '!'
+	let cond = 'v:val.text !~# pat && bufname(v:val.bufnr) !~# pat'
+    else
+	let cond = 'v:val.text =~# pat || bufname(v:val.bufnr) =~# pat'
     endif
 
     let items = filter(Xgetlist(), cond)
-    let title = cmd . ' ' . a:pat
+    let title = cmd . ' /' . pat . '/'
     call Xsetlist([], ' ', {'title' : title, 'items' : items})
 endfunc
 


### PR DESCRIPTION
Update `cfilter` from 1.0 to 1.1
Reference https://github.com/vim/vim/blob/master/runtime/pack/dist/opt/cfilter/plugin/cfilter.vim

Features added:
  - Regex
  - Last used search pattern

Hi @janlazo Could you take a look at this PR? Thank you.