### PR TITLE
[RDY] Fix invalid events with `o` `<CR>` and `autoindent`

### DIFF
--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -288,7 +288,8 @@ void buf_updates_send_splice(
     int old_row, colnr_T old_col, bcount_t old_byte,
     int new_row, colnr_T new_col, bcount_t new_byte)
 {
-  if (!buf_updates_active(buf)) {
+  if (!buf_updates_active(buf)
+      || (old_byte == 0 && new_byte == 0)) {
     return;
   }
 

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1677,6 +1677,9 @@ int open_line(
         truncate_spaces(saved_line);
       }
       ml_replace(curwin->w_cursor.lnum, saved_line, false);
+      extmark_splice_cols(
+          curbuf, (int)curwin->w_cursor.lnum,
+          0, curwin->w_cursor.col, (int)STRLEN(saved_line), kExtmarkUndo);
       saved_line = NULL;
       if (did_append) {
         changed_lines(curwin->w_cursor.lnum, curwin->w_cursor.col,

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -338,7 +338,6 @@ describe('lua: nvim_buf_attach on_bytes', function()
         }
         feed '<cr>'
         check_events {
-          { "test1", "bytes", 1, 4, 8, 0, 115, 0, 0, 0, 0, 0, 0 };
           { "test1", "bytes", 1, 5, 7, 0, 114, 0, 0, 0, 1, 0, 1 };
         }
     end)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -82,6 +82,17 @@ end
 function module.ok(res, msg, logfile)
   return dumplog(logfile, assert.is_true, res, msg)
 end
+
+-- TODO(bfredl): this should "failure" not "error" (issue with dumplog() )
+local function epicfail(state, arguments, _)
+  state.failure_message = arguments[1]
+  return false
+end
+assert:register("assertion", "epicfail", epicfail)
+function module.fail(msg, logfile)
+  return dumplog(logfile, assert.epicfail, msg)
+end
+
 function module.matches(pat, actual)
   if nil ~= string.match(actual, pat) then
     return true


### PR DESCRIPTION
@bfredl here my work so far.

The error occurs when hitting `o<CR>` on a previously indented line, with `autoindent` on. 