### PR TITLE
docs: Align help docs to match using tab

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -137,7 +137,7 @@ Special issues ~
 
 Programming language support ~
 |indent.txt|	automatic indenting for C and other languages
-|lsp.txt|         Language Server Protocol (LSP)
+|lsp.txt|	Language Server Protocol (LSP)
 |syntax.txt|	syntax highlighting
 |filetype.txt|	settings done specifically for a type of file
 |quickfix.txt|	commands for a quick edit-compile-fix cycle


### PR DESCRIPTION
This fixes alignment of the Language Server Protocol section to use tab instead of spaces, to be consistent. 