### PR TITLE
Fix typo in treesitter docs: parser directory is `parser` not `parsers`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -577,7 +577,7 @@ updates.
 Parser files						*treesitter-parsers*
 
 Parsers are the heart of tree-sitter. They are libraries that tree-sitter will
-search for in the `parsers` runtime directory.
+search for in the `parser` runtime directory.
 
 For a parser to be available for a given language, there must be a file named
 `{lang}.so` within the parser directory.


### PR DESCRIPTION
https://github.com/neovim/neovim/blob/7ba28b1aedcb88ef5643b32dc4a6bf92ac090fed/runtime/lua/vim/treesitter/language.lua#L16