### PR TITLE
[RDY] Fix indentkeys preceded by '!' indenting twice

### DIFF
--- a/test/functional/editor/mode_insert_spec.lua
+++ b/test/functional/editor/mode_insert_spec.lua
@@ -6,10 +6,18 @@ local expect = helpers.expect
 local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
+local curbuf_contents = helpers.curbuf_contents
 
 describe('insert-mode', function()
   before_each(function()
     clear()
+  end)
+
+  it('indents only once after "!" keys #12894', function()
+    command('let counter = []')
+    command('set indentexpr=len(add(counter,0))')
+    feed('i<C-F>x')
+    eq(' x', curbuf_contents())
   end)
 
   it('CTRL-@', function()


### PR DESCRIPTION
which is both unexpected and different from the Vim behaviour.

Indent was triggered once by the `'!'` check in `insert_execute()`, and inserting the char was correctly skipped, but then triggered again in `insert_check()` (provided that cindent was not being ignored after manual indentation, i.e. `can_cindent == true`).

While this is the smallest fix, another solution would be to remove `VimState#check` and instead move that to `*_enter()`/-`_execute()`, since the control flow is pretty unnecessarily convoluted as is. That would also have the benefit of differing less from the Vim source code.

This is the smallest thing, but I ran into it when making my [vim-haskell] plugin compatible with Neovim. To implement Tab-cycle indentation it piggybacks on `indentexpr` by setting a flag and using `i_CTRL_F`, instead of reimplementing setting of indent with `i_CTRL-\_CTRL-O` and having to ensure correct cursor placement and all that. It worked really well until, well, now.

Noticed too that the test `"API/auto indenting entire line works"` in `test/functional/api/extmark_spec.lua` fails without the `stop_arrow()` check, which is weird given its documentation, since no arrows keys are fed by the test.

[vim-haskell]: https://github.com/axelf4/vim-haskell