### PR TITLE
lsp: remove popup No signature available.

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -239,7 +239,7 @@ M['textDocument/signatureHelp'] = function(_, method, result)
   if vim.tbl_isempty(lines) then
     return
   end
-  util.focusable_preview(method, function()    
+  util.focusable_preview(method, function()
     return lines, util.try_trim_markdown_code_blocks(lines)
   end)
 end

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -229,16 +229,17 @@ M['textDocument/implementation'] = location_callback
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
 M['textDocument/signatureHelp'] = function(_, method, result)
-  util.focusable_preview(method, function()
-    if not (result and result.signatures and result.signatures[1]) then
-      return { 'No signature available' }
-    end
-    -- TODO show popup when signatures is empty?
-    local lines = util.convert_signature_help_to_markdown_lines(result)
-    lines = util.trim_empty_lines(lines)
-    if vim.tbl_isempty(lines) then
-      return { 'No signature available' }
-    end
+  -- When use `autocmd ComleteDone` to call signatureHelp callback
+  -- If the completion item doesn't have signatures It will make noise
+  if not (result and result.signatures and result.signatures[1]) then
+    return
+  end
+  local lines = util.convert_signature_help_to_markdown_lines(result)
+  lines = util.trim_empty_lines(lines)
+  if vim.tbl_isempty(lines) then
+    return
+  end
+  util.focusable_preview(method, function()    
     return lines, util.try_trim_markdown_code_blocks(lines)
   end)
 end

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -232,11 +232,13 @@ M['textDocument/signatureHelp'] = function(_, method, result)
   -- When use `autocmd ComleteDone` to call signatureHelp callback
   -- If the completion item doesn't have signatures It will make noise
   if not (result and result.signatures and result.signatures[1]) then
+    print('No signature help available')
     return
   end
   local lines = util.convert_signature_help_to_markdown_lines(result)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
+    print('No signature help available')
     return
   end
   util.focusable_preview(method, function()

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -229,8 +229,8 @@ M['textDocument/implementation'] = location_callback
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
 M['textDocument/signatureHelp'] = function(_, method, result)
-  -- When use `autocmd ComleteDone` to call signatureHelp callback
-  -- If the completion item doesn't have signatures It will make noise
+  -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp callback
+  -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
     print('No signature help available')
     return


### PR DESCRIPTION
@tjdevries  If no signatures. we shouldn't popup No signature available ..It will make noise when use
` api.nvim_command("autocmd CompleteDone <buffer> lua vim.lsp.buf.signature_help()")`