### PR TITLE
[RFC] buf_attach: fix buffer updates with setline()

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -362,8 +362,7 @@ void changed_bytes(linenr_T lnum, colnr_T col)
 /// insert/delete bytes at column
 ///
 /// Like changed_bytes() but also adjust extmark for "new" bytes.
-/// When "new" is negative text was deleted.
-static void inserted_bytes(linenr_T lnum, colnr_T col, int old, int new)
+void inserted_bytes(linenr_T lnum, colnr_T col, int old, int new)
 {
   if (curbuf_splice_pending == 0) {
     extmark_splice_cols(curbuf, (int)lnum-1, col, old, new, kExtmarkUndo);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6962,9 +6962,10 @@ void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append,
 
     if (!append && lnum <= curbuf->b_ml.ml_line_count) {
       // Existing line, replace it.
+      int old_len = (int)STRLEN(ml_get(lnum));
       if (u_savesub(lnum) == OK
           && ml_replace(lnum, (char_u *)line, true) == OK) {
-        changed_bytes(lnum, 0);
+        inserted_bytes(lnum, 0, old_len, STRLEN(line));
         if (is_curbuf && lnum == curwin->w_cursor.lnum) {
           check_cursor_col();
         }


### PR DESCRIPTION
A concrete example for how do debug and fix "bytetrack" errors. change `check_events` assert to just whatever events neovim happen to be sending (in this particuar case: nothing). The verify logic will tell you if the final state is self-inconsistent, so this test is failing now even if the events are "correct".