### PR TITLE
test: Fix failing test in case of special .bashrc

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -93,6 +93,7 @@ describe('jobs', function()
         {'notification', 'stdout', {0, {'hello world %VAR%', ''}}}
       })
     else
+      nvim('command', "set shell=/bin/sh")
       nvim('command', [[call jobstart('echo $TOTO $VAR', g:job_opts)]])
       expect_msg_seq({
         {'notification', 'stdout', {0, {'hello world', ''}}}


### PR DESCRIPTION
The test of "replace environment" in the test module of
`test/functional/core/job_spec.lua` failed in case the bashrc file of
the user running the test has special actions in it (such actions were
printing to the screen from inside this file, or changing the bash mode
to be vi).

In order to fix this problem, the test now sets the shell to be
`/bin/sh` before running the command. Setting the shell to be `/bin/sh`
causes the running shell to run without the configuration of the user,
and so the test passes even in case of special .bashrc.
This change was done only for platforms other than Windows since it is
not relevant in windows.

The fix was applied to the specific test, even though it is possible
that related issues will arise in other tests. It seems like a big
overhead to make the fix work on all the possible tests, and it does not
worth this cost.

Fixes #12695