### PR TITLE
Use HTTPS for downloading spell files

### DIFF
--- a/runtime/autoload/spellfile.vim
+++ b/runtime/autoload/spellfile.vim
@@ -1,13 +1,9 @@
 " Vim script to download a missing spell file
 
 if !exists('g:spellfile_URL')
-  " Prefer using http:// when netrw should be able to use it, since
-  " more firewalls let this through.
-  if executable("curl") || executable("wget") || executable("fetch")
-    let g:spellfile_URL = 'http://ftp.vim.org/pub/vim/runtime/spell'
-  else
-    let g:spellfile_URL = 'ftp://ftp.vim.org/pub/vim/runtime/spell'
-  endif
+  " Always use https:// because it's secure.  The certificate is for nluug.nl,
+  " thus we can't use the alias ftp.vim.org here.
+  let g:spellfile_URL = 'https://ftp.nluug.nl/pub/vim/runtime/spell'
 endif
 let s:spellfile_URL = ''    " Start with nothing so that s:donedict is reset.
 

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -617,11 +617,12 @@ ask you where to write the file (there must be a writable directory in
 'runtimepath' for this).
 
 The plugin has a default place where to look for spell files, on the Vim ftp
-server.  If you want to use another location or another protocol, set the
-g:spellfile_URL variable to the directory that holds the spell files.  The
-|netrw| plugin is used for getting the file, look there for the specific
-syntax of the URL.  Example: >
-	let g:spellfile_URL = 'http://ftp.vim.org/vim/runtime/spell'
+server.  The protocol used is SSL (https://) for security.  If you want to use
+another location or another protocol, set the g:spellfile_URL variable to the
+directory that holds the spell files.  You can use http:// or ftp://, but you
+are taking a security risk then.  The |netrw| plugin is used for getting the
+file, look there for the specific syntax of the URL.  Example: >
+	let g:spellfile_URL = 'https://ftp.nluug.nl/vim/runtime/spell'
 You may need to escape special characters.
 
 The plugin will only ask about downloading a language once.  If you want to


### PR DESCRIPTION
Closes #12877 

Reflects changes in Vim's runtime files, see [7ff78465](https://github.com/vim/vim/commit/7ff78465f7057a672a6de0d75d56286da253501b).

I did not update the entire file because Neovim contains custom fixes differing from Vim 8. Most of these differences are negligible, like variables prefixed with `l:` and different messages/comments. The other differences (error handling, XDG) don't affect the download process. Tested with different languages.