### PR TITLE
buf_updates: fix wrong updates on linewise change

### DIFF
--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -68,6 +68,10 @@
 # define LOG_CALLSTACK_TO_FILE(fp) log_callstack_to_file(fp, __func__, __LINE__)
 #endif
 
+#if defined(__has_include) && __has_include("sanitizer/asan_interface.h")
+# include "sanitizer/asan_interface.h"
+#endif
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "log.h.generated.h"
 #endif

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1544,15 +1544,19 @@ int op_delete(oparg_T *oap)
     oap->line_count = 0;  // no lines deleted
   } else if (oap->motion_type == kMTLineWise) {
     if (oap->op_type == OP_CHANGE) {
-      /* Delete the lines except the first one.  Temporarily move the
-       * cursor to the next line.  Save the current line number, if the
-       * last line is deleted it may be changed.
-       */
+      // Delete the lines except the first one.  Temporarily move the
+      // cursor to the next line.  Save the current line number, if the
+      // last line is deleted it may be changed.
+
       if (oap->line_count > 1) {
         lnum = curwin->w_cursor.lnum;
         ++curwin->w_cursor.lnum;
         del_lines(oap->line_count - 1, TRUE);
         curwin->w_cursor.lnum = lnum;
+
+        extmark_adjust(curbuf, curwin->w_cursor.lnum,
+                       curwin->w_cursor.lnum + oap->line_count - 1,
+                       MAXLNUM, 0, kExtmarkUndo);
       }
       if (u_save_cursor() == FAIL)
         return FAIL;
@@ -1561,9 +1565,16 @@ int op_delete(oparg_T *oap)
         did_ai = true;                      // delete the indent when ESC hit
         ai_col = curwin->w_cursor.col;
       } else
-        beginline(0);                       /* cursor in column 0 */
-      truncate_line(FALSE);         /* delete the rest of the line */
-                                    /* leave cursor past last char in line */
+        beginline(0);                       // cursor in column 0
+
+      int old_len = (int)STRLEN(ml_get(curwin->w_cursor.lnum));
+      truncate_line(FALSE);         // delete the rest of the line
+
+      extmark_splice_cols(curbuf,
+                          (int)curwin->w_cursor.lnum, curwin->w_cursor.col,
+                          old_len - curwin->w_cursor.col, 0, kExtmarkUndo);
+
+                                    // leave cursor past last char in line
       if (oap->line_count > 1)
         u_clearline();              /* "U" command not possible after "2cc" */
     } else {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1560,19 +1560,21 @@ int op_delete(oparg_T *oap)
         beginline(BL_WHITE);                // cursor on first non-white
         did_ai = true;                      // delete the indent when ESC hit
         ai_col = curwin->w_cursor.col;
-      } else
+      } else {
         beginline(0);                       // cursor in column 0
+      }
 
       int old_len = (int)STRLEN(ml_get(curwin->w_cursor.lnum));
-      truncate_line(FALSE);         // delete the rest of the line
+      truncate_line(false);         // delete the rest of the line
 
       extmark_splice_cols(curbuf,
                           (int)curwin->w_cursor.lnum-1, curwin->w_cursor.col,
                           old_len - curwin->w_cursor.col, 0, kExtmarkUndo);
 
                                     // leave cursor past last char in line
-      if (oap->line_count > 1)
-        u_clearline();              /* "U" command not possible after "2cc" */
+      if (oap->line_count > 1) {
+        u_clearline();              // "U" command not possible after "2cc"
+      }
     } else {
       del_lines(oap->line_count, TRUE);
       beginline(BL_WHITE | BL_FIX);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1553,10 +1553,6 @@ int op_delete(oparg_T *oap)
         ++curwin->w_cursor.lnum;
         del_lines(oap->line_count - 1, TRUE);
         curwin->w_cursor.lnum = lnum;
-
-        extmark_adjust(curbuf, curwin->w_cursor.lnum,
-                       curwin->w_cursor.lnum + oap->line_count - 1,
-                       MAXLNUM, 0, kExtmarkUndo);
       }
       if (u_save_cursor() == FAIL)
         return FAIL;
@@ -1571,7 +1567,7 @@ int op_delete(oparg_T *oap)
       truncate_line(FALSE);         // delete the rest of the line
 
       extmark_splice_cols(curbuf,
-                          (int)curwin->w_cursor.lnum, curwin->w_cursor.col,
+                          (int)curwin->w_cursor.lnum-1, curwin->w_cursor.col,
                           old_len - curwin->w_cursor.col, 0, kExtmarkUndo);
 
                                     // leave cursor past last char in line

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -427,7 +427,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
       feed "cc"
       check_events {
-        { "test1", "bytes", 1, 4, 1, 0, 1, 0, 15, 15, 0, 0, 0 };
+        { "test1", "bytes", 1, 4, 0, 0, 0, 0, 15, 15, 0, 0, 0 };
       }
 
       feed "<ESC>"
@@ -436,7 +436,6 @@ describe('lua: nvim_buf_attach on_bytes', function()
       feed "c3j"
       check_events {
         { "test1", "bytes", 1, 4, 1, 0, 1, 3, 0, 48, 0, 0, 0 };
-        { "test1", "bytes", 1, 5, 0, 0, 0, 4, 0, 0, 4, 0, 51 };
       }
     end)
   end

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -289,6 +289,12 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
       if verify then
         for _, event in ipairs(events) do
+          for _, elem in ipairs(event) do
+            if type(elem) == "number" and elem < 0 then
+              fail(string.format("Received event has negative values"))
+            end
+          end
+
           if event[1] == verify_name and event[2] == "bytes" then
             local _, _, _, _, _, _, start_byte, _, _, old_byte, _, _, new_byte = unpack(event)
             local before = string.sub(shadowbytes, 1, start_byte)
@@ -409,6 +415,24 @@ describe('lua: nvim_buf_attach on_bytes', function()
       feed 'ia'
       check_events {
         { "test1", "bytes", 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 1 };
+      }
+    end)
+
+    it("changing lines", function()
+      local check_events = setup_eventcheck(verify, origlines)
+
+      feed "cc"
+      check_events {
+        { "test1", "bytes", 1, 4, 1, 0, 1, 0, 15, 15, 0, 0, 0 };
+      }
+
+      feed "<ESC>"
+      check_events {}
+
+      feed "c3j"
+      check_events {
+        { "test1", "bytes", 1, 4, 1, 0, 1, 3, 0, 48, 0, 0, 0 };
+        { "test1", "bytes", 1, 5, 0, 0, 0, 4, 0, 0, 4, 0, 51 };
       }
     end)
   end


### PR DESCRIPTION
This fixes some issues with bytetrack and linewise change.

Also, I may attempt to fix an issue with how we verify cinsistency for byte-level updates, as this
is an example of wrong verification.

cc @bfredl
