### PR TITLE
Only use __has_include when it is defined

### DIFF
--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 
 #include "auto/config.h"
+#include "nvim/macros.h"
 
 #define DEBUG_LOG_LEVEL 0
 #define INFO_LOG_LEVEL 1
@@ -68,7 +69,7 @@
 # define LOG_CALLSTACK_TO_FILE(fp) log_callstack_to_file(fp, __func__, __LINE__)
 #endif
 
-#if defined(__has_include) && __has_include("sanitizer/asan_interface.h")
+#if NVIM_HAS_INCLUDE("sanitizer/asan_interface.h")
 # include "sanitizer/asan_interface.h"
 #endif
 

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -152,6 +152,12 @@
 #define STR_(x) #x
 #define STR(x) STR_(x)
 
+#ifndef __has_include
+# define NVIM_HAS_INCLUDE(x) 0
+#else
+# define NVIM_HAS_INCLUDE __has_include
+#endif
+
 #ifndef __has_attribute
 # define NVIM_HAS_ATTRIBUTE(x) 0
 #elif defined(__clang__) && __clang__ == 1 \


### PR DESCRIPTION
Per GCC's documentation:

> The __has_include operator by itself, without any operand or parentheses, acts as a predefined macro so that support for it can be tested in portable code. Thus, the recommended use of the operator is as follows:
>
>     #if defined __has_include
>     #  if __has_include (<stdatomic.h>)
>     #    include <stdatomic.h>
>     #  endif
>     #endif
>
> The first ‘#if’ test succeeds only when the operator is supported by the version of GCC (or another compiler) being used. Only when that test succeeds is it valid to use __has_include as a preprocessor operator.

This fixes the unstable PPA build:

```
[  0%] Generating auto/api/buffer.c.generated.h, ../../include/api/buffer.h.generated.h
In file included from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/garray.h:7:0,
                 from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/eval/typval.h:12,
                 from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/strings.h:9,
                 from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/keymap.h:4,
                 from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/vim.h:33,
                 from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/api/private/helpers.h:7,
                 from /<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/api/buffer.c:13:
/<<BUILDDIR>>/neovim-0.5.0+ubuntu2+git202009201403-9f704c88a-d569569c9/src/nvim/log.h:71:44: error: missing binary operator before token "("
 #if defined(__has_include) && __has_include("sanitizer/asan_interface.h")
                                            ^
make[5]: *** [src/nvim/auto/api/buffer.c.generated.h] Error 1
```