### PR TITLE
[RFC] vim-patch:8.2.{0953,0955,0956,1678}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5672,6 +5672,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	up to the first character that is not an ASCII letter or number and
 	not a dash.  Also see |set-spc-auto|.
 
+						*'spelloptions'* *'spo'*
+'spelloptions' 'spo'	string	(default "")
+			local to buffer
+	A comma separated list of options for spell checking:
+	   camel	When a word is CamelCased, assume "Cased" is a
+			separate word: every upper-case character in a word
+			that comes after a lower case character indicates the
+			start of a new word.
 
 						*'spellsuggest'* *'sps'*
 'spellsuggest' 'sps'	string	(default "best")

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -187,6 +187,9 @@ When there is a line break right after a sentence the highlighting of the next
 line may be postponed.  Use |CTRL-L| when needed.  Also see |set-spc-auto| for
 how it can be set automatically when 'spelllang' is set.
 
+The 'spelloptions' option has a few more flags that influence the way spell
+checking works.
+
 Vim counts the number of times a good word is encountered.  This is used to
 sort the suggestions: words that have been seen before get a small bonus,
 words that have been seen often get a bigger bonus.  The COMMON item in the

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1941,6 +1941,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   vim_regfree(buf->b_s.b_cap_prog);
   buf->b_s.b_cap_prog = NULL;
   clear_string_option(&buf->b_s.b_p_spl);
+  clear_string_option(&buf->b_s.b_p_spo);
   clear_string_option(&buf->b_p_sua);
   clear_string_option(&buf->b_p_ft);
   clear_string_option(&buf->b_p_cink);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -451,6 +451,7 @@ typedef struct {
   regprog_T   *b_cap_prog;      // program for 'spellcapcheck'
   char_u      *b_p_spf;         // 'spellfile'
   char_u      *b_p_spl;         // 'spelllang'
+  char_u      *b_p_spo;         // 'spelloptions'
   int b_cjk;                    // all CJK letters as OK
   char_u b_syn_chartab[32];     // syntax iskeyword option
   char_u *b_syn_isk;            // iskeyword option

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -174,6 +174,7 @@ static char_u   *p_syn;
 static char_u   *p_spc;
 static char_u   *p_spf;
 static char_u   *p_spl;
+static char_u   *p_spo;
 static long p_ts;
 static long p_tw;
 static int p_udf;
@@ -2285,6 +2286,7 @@ void check_buf_options(buf_T *buf)
   check_string_option(&buf->b_s.b_p_spc);
   check_string_option(&buf->b_s.b_p_spf);
   check_string_option(&buf->b_s.b_p_spl);
+  check_string_option(&buf->b_s.b_p_spo);
   check_string_option(&buf->b_p_sua);
   check_string_option(&buf->b_p_cink);
   check_string_option(&buf->b_p_cino);
@@ -3090,6 +3092,10 @@ ambw_end:
   } else if (varp == &(curwin->w_s->b_p_spc)) {
     // When 'spellcapcheck' is set compile the regexp program.
     errmsg = compile_cap_prog(curwin->w_s);
+  } else if (varp == &(curwin->w_s->b_p_spo)) {  // 'spelloptions'
+    if (**varp != NUL && STRCMP("camel", *varp) != 0) {
+      errmsg = e_invarg;
+    }
   } else if (varp == &p_sps) {  // 'spellsuggest'
     if (spell_check_sps() != OK) {
       errmsg = e_invarg;
@@ -5896,6 +5902,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_SPC:    return (char_u *)&(curwin->w_s->b_p_spc);
   case PV_SPF:    return (char_u *)&(curwin->w_s->b_p_spf);
   case PV_SPL:    return (char_u *)&(curwin->w_s->b_p_spl);
+  case PV_SPO:    return (char_u *)&(curwin->w_s->b_p_spo);
   case PV_SW:     return (char_u *)&(curbuf->b_p_sw);
   case PV_TFU:    return (char_u *)&(curbuf->b_p_tfu);
   case PV_TS:     return (char_u *)&(curbuf->b_p_ts);
@@ -6175,6 +6182,7 @@ void buf_copy_options(buf_T *buf, int flags)
       (void)compile_cap_prog(&buf->b_s);
       buf->b_s.b_p_spf = vim_strsave(p_spf);
       buf->b_s.b_p_spl = vim_strsave(p_spl);
+      buf->b_s.b_p_spo = vim_strsave(p_spo);
       buf->b_p_inde = vim_strsave(p_inde);
       buf->b_p_indk = vim_strsave(p_indk);
       buf->b_p_fp = empty_option;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -787,6 +787,7 @@ enum {
   , BV_SPC
   , BV_SPF
   , BV_SPL
+  , BV_SPO
   , BV_STS
   , BV_SUA
   , BV_SW

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2320,6 +2320,16 @@ return {
       defaults={if_true={vi="best"}}
     },
     {
+      full_name='spelloptions', abbreviation='spo',
+      type='string', list='onecomma', scope={'buffer'},
+      deny_duplicates=true,
+      secure=true,
+      vi_def=true,
+      expand=true,
+      varname='p_spo',
+      defaults={if_true={vi="", vim=""}}
+    },
+    {
       full_name='splitbelow', abbreviation='sb',
       type='bool', scope={'global'},
       vi_def=true,

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -362,6 +362,8 @@ size_t spell_check(
   size_t wrongcaplen = 0;
   int lpi;
   bool count_word = docount;
+  bool use_camel_case = *wp->w_s->b_p_spo != NUL;
+  bool camel_case = false;
 
   // A word never starts at a space or a control character. Return quickly
   // then, skipping over the character.
@@ -394,9 +396,24 @@ size_t spell_check(
   mi.mi_word = ptr;
   mi.mi_fend = ptr;
   if (spell_iswordp(mi.mi_fend, wp)) {
+    int prev_upper;
+    int this_upper;
+
+    if (use_camel_case) {
+      c = PTR2CHAR(mi.mi_fend);
+      this_upper = SPELL_ISUPPER(c);
+    }
+
     do {
       MB_PTR_ADV(mi.mi_fend);
-    } while (*mi.mi_fend != NUL && spell_iswordp(mi.mi_fend, wp));
+      if (use_camel_case) {
+        prev_upper = this_upper;
+        c = PTR2CHAR(mi.mi_fend);
+        this_upper = SPELL_ISUPPER(c);
+        camel_case = !prev_upper && this_upper;
+      }
+    } while (*mi.mi_fend != NUL && spell_iswordp(mi.mi_fend, wp)
+             && !camel_case);
 
     if (capcol != NULL && *capcol == 0 && wp->w_s->b_cap_prog != NULL) {
       // Check word starting with capital letter.
@@ -427,6 +444,11 @@ size_t spell_check(
 
   (void)spell_casefold(ptr, (int)(mi.mi_fend - ptr), mi.mi_fword, MAXWLEN + 1);
   mi.mi_fwordlen = (int)STRLEN(mi.mi_fword);
+
+  if (camel_case) {
+    // introduce a fake word end space into the folded word.
+    mi.mi_fword[mi.mi_fwordlen - 1] = ' ';
+  }
 
   // The word is bad unless we recognize it.
   mi.mi_result = SP_BAD;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5588,9 +5588,11 @@ void ex_ownsyntax(exarg_T *eap)
     hash_init(&curwin->w_s->b_keywtab_ic);
     // TODO: Keep the spell checking as it was. NOLINT(readability/todo)
     curwin->w_p_spell = false;  // No spell checking
+    // make sure option values are "empty_option" instead of NULL
     clear_string_option(&curwin->w_s->b_p_spc);
     clear_string_option(&curwin->w_s->b_p_spf);
     clear_string_option(&curwin->w_s->b_p_spl);
+    clear_string_option(&curwin->w_s->b_p_spo);
     clear_string_option(&curwin->w_s->b_syn_isk);
   }
 

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -79,6 +79,11 @@ func Test_spellbadword()
   call assert_equal(['bycycle', 'bad'],  spellbadword('My bycycle.'))
   call assert_equal(['another', 'caps'], spellbadword('A sentence. another sentence'))
 
+  call assert_equal(['TheCamelWord', 'bad'], spellbadword('TheCamelWord asdf'))
+  set spelloptions=camel
+  call assert_equal(['asdf', 'bad'], spellbadword('TheCamelWord asdf'))
+  set spelloptions=
+
   set spelllang=en
   call assert_equal(['', ''],            spellbadword('centre'))
   call assert_equal(['', ''],            spellbadword('center'))

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -369,7 +369,11 @@ func Test_ownsyntax()
   call setline(1, '#define FOO')
   syntax on
   set filetype=c
+
   ownsyntax perl
+  " this should not crash
+  set
+
   call assert_equal('perlComment', synIDattr(synID(line('.'), col('.'), 1), 'name'))
   call assert_equal('c',    b:current_syntax)
   call assert_equal('perl', w:current_syntax)


### PR DESCRIPTION
Hopefully I did it right, this is following [this request](https://github.com/neovim/neovim/issues/12949).

#### vim-patch:8.2.0953: spell checking doesn't work for CamelCased words

Problem:    Spell checking doesn't work for CamelCased words.
Solution:   Add the "camel" value in the new option 'spelloptions'.
            (closes vim/vim#1235)
https://github.com/vim/vim/commit/362b44bd4aa87a2aef0f8fd5a28d68dd09a7d909


#### vim-patch:8.2.0955: build fails

Problem:    Build fails.
Solution:   Add missing struct change.
https://github.com/vim/vim/commit/215f49c4d720367be29f56168f363a0ee9eaf86b


#### vim-patch:8.2.0956: spell test fails

Problem:    Spell test fails.
Solution:   Add missing change the spell checking.
https://github.com/vim/vim/commit/e0ebeda4d8219a8955001b43ef7a9268452ef7f5

#### vim-patch:8.2.1678: crash when using ":set" after ":ownsyntax"

Problem:    Crash when using ":set" after ":ownsyntax".
Solution:   Make sure 'spelloptions' is not NULL. (closes vim/vim#6950)
vim/vim@d1f76af