### PR TITLE
bytetrack: fix J with trailing whitespace

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3835,22 +3835,23 @@ int do_join(size_t count,
           && (!has_format_option(FO_MBYTE_JOIN2)
               || utf_ptr2char(curr) < 0x100 || endcurr1 < 0x100)
           ) {
-        /* don't add a space if the line is ending in a space */
-        if (endcurr1 == ' ')
+        // don't add a space if the line is ending in a space
+        if (endcurr1 == ' ') {
           endcurr1 = endcurr2;
-        else
-          ++spaces[t];
+        } else {
+          spaces[t]++;
+        }
         // Extra space when 'joinspaces' set and line ends in '.', '?', or '!'.
         if (p_js && (endcurr1 == '.' || endcurr1 == '?' || endcurr1 == '!')) {
-          ++spaces[t];
+          spaces[t]++;
         }
       }
     }
 
     if (t > 0 && curbuf_splice_pending == 0) {
-      colnr_T removed = (int)(curr- curr_start);
+      colnr_T removed = (int)(curr - curr_start);
       extmark_splice(curbuf, (int)curwin->w_cursor.lnum-1, sumsize,
-                     1, removed, removed + 1,
+                     1, removed, removed + 1,  // Newline
                      0, spaces[t], spaces[t],
                      kExtmarkUndo);
     }
@@ -3881,13 +3882,11 @@ int do_join(size_t count,
   cend = newp + sumsize;
   *cend = 0;
 
-  /*
-   * Move affected lines to the new long one.
-   *
-   * Move marks from each deleted line to the joined line, adjusting the
-   * column.  This is not Vi compatible, but Vi deletes the marks, thus that
-   * should not really be a problem.
-   */
+  // Move affected lines to the new long one.
+  //
+  // Move marks from each deleted line to the joined line, adjusting the
+  // column.  This is not Vi compatible, but Vi deletes the marks, thus that
+  // should not really be a problem.
 
   curbuf_splice_pending++;
 

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -365,9 +365,16 @@ describe('lua: nvim_buf_attach on_bytes', function()
         }
     end)
 
+    it('joining with indentation and trainling whitespace', function()
+        local check_events = setup_eventcheck(verify, {"foo  ", "    fooo indented"})
+        feed 'J'
+        check_events {
+          { "test1", "bytes", 1, 3, 0, 5, 5, 1, 4, 5, 0, 0, 0 };
+        }
+    end)
+
     it('opening lines', function()
         local check_events = setup_eventcheck(verify, origlines)
-        -- meths.buf_set_option(0, 'autoindent', true)
         feed 'Go'
         check_events {
           { "test1", "bytes", 1, 4, 7, 0, 114, 0, 0, 0, 1, 0, 1 };


### PR DESCRIPTION
Attempt to fix this issue we had for a while, when joining lines with trailing whitespace on the line where you hit `J`.