### PR TITLE
funding: Salt -> GitHub Sponsors & Open Collective [ci skip]

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-custom: https://salt.bountysource.com/teams/neovim
+github: neovim
+open_collective: neovim


### PR DESCRIPTION
We have a GitHub Sponsors page for the neovim organization now:

  - https://github.com/sponsors/neovim

It can be reached by clicking on the "Sponsor" button on the [organization page](https://github.com/neovim).

This commit replaces the link to Salt by the new GitHub Sponsors page.