### PR TITLE
[RFC] option.c: static string arr to store errmsg

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2489,7 +2489,7 @@ static char *set_string_option(const int opt_idx, const char *const value,
   if (options[opt_idx].var == NULL) {  // don't set hidden option
     return NULL;
   }
-
+  static char_u errbuf[80];
   char *const s = xstrdup(value);
   char **const varp = (char **)get_varp_scope(
       &(options[opt_idx]),
@@ -2506,7 +2506,7 @@ static char *set_string_option(const int opt_idx, const char *const value,
   int value_checked = false;
   char *const r = (char *)did_set_string_option(
       opt_idx, (char_u **)varp, (int)true, (char_u *)oldval,
-      NULL, 0, opt_flags, &value_checked);
+      errbuf, sizeof(errbuf), opt_flags, &value_checked);
   if (r == NULL) {
     did_set_option(opt_idx, opt_flags, true, value_checked);
   }


### PR DESCRIPTION
The err msg should set at [did_set_string_option()](https://github.com/neovim/neovim/blob/aa4557920696c45335f42f03e7b23b7038b5864e/src/nvim/option.c#L3375), but the caller(set_string_option()) didn't give a proper errbuf to store error msg.

Using a static char_u array to store the error msg temporarily as check_stl_option() does.
