### PR TITLE
u_check: dont assume curbuf

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7885,16 +7885,16 @@ static void ex_wundo(exarg_T *eap)
 {
   char_u hash[UNDO_HASH_SIZE];
 
-  u_compute_hash(hash);
-  u_write_undo((char *) eap->arg, eap->forceit, curbuf, hash);
+  u_compute_hash(curbuf, hash);
+  u_write_undo((char *)eap->arg, eap->forceit, curbuf, hash);
 }
 
 static void ex_rundo(exarg_T *eap)
 {
   char_u hash[UNDO_HASH_SIZE];
 
-  u_compute_hash(hash);
-  u_read_undo((char *) eap->arg, hash, NULL);
+  u_compute_hash(curbuf, hash);
+  u_read_undo((char *)eap->arg, hash, NULL);
 }
 
 /// ":redo".

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5087,13 +5087,10 @@ buf_check_timestamp(
     buf_reload(buf, orig_mode);
     if (buf->b_p_udf && buf->b_ffname != NULL) {
       char_u hash[UNDO_HASH_SIZE];
-      buf_T           *save_curbuf = curbuf;
 
-      /* Any existing undo file is unusable, write it now. */
-      curbuf = buf;
-      u_compute_hash(hash);
-      u_write_undo(NULL, FALSE, buf, hash);
-      curbuf = save_curbuf;
+      // Any existing undo file is unusable, write it now.
+      u_compute_hash(buf, hash);
+      u_write_undo(NULL, false, buf, hash);
     }
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3988,7 +3988,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
         if ((curbuf == save_curbuf
              || (opt_flags & OPT_GLOBAL) || opt_flags == 0)
             && !curbufIsChanged() && curbuf->b_ml.ml_mfp != NULL) {
-          u_compute_hash(hash);
+          u_compute_hash(bp, hash);
           u_read_undo(NULL, hash, curbuf->b_fname);
         }
       }

--- a/test/unit/undo_spec.lua
+++ b/test/unit/undo_spec.lua
@@ -38,7 +38,7 @@ child_call_once(function()
   --
   -- compute a hash for this undofile
   buffer_hash = ffi.new('char_u[32]')
-  undo.u_compute_hash(buffer_hash)
+  undo.u_compute_hash(buf, buffer_hash)
 end)
 
 


### PR DESCRIPTION
I am annoyed by the save_curbuf occurences https://github.com/neovim/neovim/compare/master...teto:u_check?expand=1#diff-06179475004b616c3697322734f2644bL5090