### PR TITLE
vim-patch:8.1.{1319,1563,1591},8.2.{42,499}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -736,7 +736,7 @@ int eval_expr_typval(const typval_T *expr, typval_T *argv,
     if (s == NULL || *s == NUL) {
       return FAIL;
     }
-    if (call_func(s, (int)STRLEN(s), rettv, argc, argv, NULL,
+    if (call_func(s, -1, rettv, argc, argv, NULL,
                   0L, 0L, &dummy, true, NULL, NULL) == FAIL) {
       return FAIL;
     }
@@ -746,7 +746,7 @@ int eval_expr_typval(const typval_T *expr, typval_T *argv,
     if (s == NULL || *s == NUL) {
       return FAIL;
     }
-    if (call_func(s, (int)STRLEN(s), rettv, argc, argv, NULL,
+    if (call_func(s, -1, rettv, argc, argv, NULL,
                   0L, 0L, &dummy, true, partial, NULL) == FAIL) {
       return FAIL;
     }
@@ -7270,7 +7270,7 @@ bool callback_call(Callback *const callback, const int argcount_in,
   }
 
   int dummy;
-  return call_func(name, (int)STRLEN(name), rettv, argcount_in, argvars_in,
+  return call_func(name, -1, rettv, argcount_in, argvars_in,
                    NULL, curwin->w_cursor.lnum, curwin->w_cursor.lnum, &dummy,
                    true, partial, NULL);
 }
@@ -8492,7 +8492,7 @@ handle_subscript(
       } else {
         s = (char_u *)"";
       }
-      ret = get_func_tv(s, lua ? slen : (int)STRLEN(s), rettv, (char_u **)arg,
+      ret = get_func_tv(s, lua ? slen : -1, rettv, (char_u **)arg,
                         curwin->w_cursor.lnum, curwin->w_cursor.lnum,
                         &len, evaluate, pt, selfdict);
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9174,7 +9174,7 @@ static int item_compare2(const void *s1, const void *s2, bool keep_zero)
 
   rettv.v_type = VAR_UNKNOWN;  // tv_clear() uses this
   res = call_func((const char_u *)func_name,
-                  (int)STRLEN(func_name),
+                  -1,
                   &rettv, 2, argv, NULL, 0L, 0L, &dummy, true,
                   partial, sortinfo->item_compare_selfdict);
   tv_clear(&argv[0]);

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -367,7 +367,7 @@ void emsg_funcname(char *ermsg, const char_u *name)
 int
 get_func_tv(
     const char_u *name,     // name of the function
-    int len,                // length of "name"
+    int len,                // length of "name" or -1 to use strlen()
     typval_T *rettv,
     char_u **arg,           // argument, pointing to the '('
     linenr_T firstline,     // first line of range
@@ -1291,7 +1291,7 @@ int func_call(char_u *name, typval_T *args, partial_T *partial,
     tv_copy(TV_LIST_ITEM_TV(item), &argv[argc++]);
   });
 
-  r = call_func(name, (int)STRLEN(name), rettv, argc, argv, NULL,
+  r = call_func(name, -1, rettv, argc, argv, NULL,
                 curwin->w_cursor.lnum, curwin->w_cursor.lnum,
                 &dummy, true, partial, selfdict);
 
@@ -1316,7 +1316,7 @@ func_call_skip_call:
 int
 call_func(
     const char_u *funcname,         // name of the function
-    int len,                        // length of "name"
+    int len,                        // length of "name" or -1 to use strlen()
     typval_T *rettv,                // [out] value goes here
     int argcount_in,                // number of "argvars"
     typval_T *argvars_in,           // vars for arguments, must have "argcount"
@@ -1350,6 +1350,9 @@ call_func(
 
   // Make a copy of the name, if it comes from a funcref variable it could
   // be changed or deleted in the called function.
+  if (len <= 0) {
+    len = (int)STRLEN(funcname);
+  }
   name = vim_strnsave(funcname, len);
 
   fname = fname_trans_sid(name, fname_buf, &tofree, &error);
@@ -2853,7 +2856,7 @@ void ex_call(exarg_T *eap)
       curwin->w_cursor.coladd = 0;
     }
     arg = startarg;
-    if (get_func_tv(name, (int)STRLEN(name), &rettv, &arg,
+    if (get_func_tv(name, -1, &rettv, &arg,
                     eap->line1, eap->line2, &doesrange,
                     true, partial, fudi.fd_dict) == FAIL) {
       failed = true;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3347,9 +3347,13 @@ bool set_ref_in_previous_funccal(int copyID)
 {
   bool abort = false;
 
-  for (funccall_T *fc = previous_funccal; fc != NULL; fc = fc->caller) {
-    abort = abort || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID + 1, NULL);
-    abort = abort || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID + 1, NULL);
+  for (funccall_T *fc = previous_funccal; !abort && fc != NULL;
+       fc = fc->caller) {
+    fc->fc_copyID = copyID + 1;
+    abort = abort
+      || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID + 1, NULL)
+      || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID + 1, NULL)
+      || set_ref_in_list(&fc->l_varlist, copyID + 1, NULL);
   }
   return abort;
 }
@@ -3360,9 +3364,11 @@ static bool set_ref_in_funccal(funccall_T *fc, int copyID)
 
   if (fc->fc_copyID != copyID) {
     fc->fc_copyID = copyID;
-    abort = abort || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL);
-    abort = abort || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL);
-    abort = abort || set_ref_in_func(NULL, fc->func, copyID);
+    abort = abort
+      || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL)
+      || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL)
+      || set_ref_in_list(&fc->l_varlist, copyID, NULL)
+      || set_ref_in_func(NULL, fc->func, copyID);
   }
   return abort;
 }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3413,12 +3413,13 @@ bool set_ref_in_call_stack(int copyID)
 {
   bool abort = false;
 
-  for (funccall_T *fc = current_funccal; fc != NULL; fc = fc->caller) {
+  for (funccall_T *fc = current_funccal; !abort && fc != NULL;
+       fc = fc->caller) {
     abort = abort || set_ref_in_funccal(fc, copyID);
   }
 
   // Also go through the funccal_stack.
-  for (funccal_entry_T *entry = funccal_stack; entry != NULL;
+  for (funccal_entry_T *entry = funccal_stack; !abort && entry != NULL;
        entry = entry->next) {
     for (funccall_T *fc = entry->top_funccal; !abort && fc != NULL;
          fc = fc->caller) {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -821,17 +821,12 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars,
   current_funccal = fc;
   fc->func = fp;
   fc->rettv = rettv;
-  rettv->vval.v_number = 0;
-  fc->linenr = 0;
-  fc->returned = FALSE;
   fc->level = ex_nesting_level;
   // Check if this function has a breakpoint.
   fc->breakpoint = dbg_find_breakpoint(false, fp->uf_name, (linenr_T)0);
   fc->dbg_tick = debug_tick;
 
   // Set up fields for closure.
-  fc->fc_refcount = 0;
-  fc->fc_copyID = 0;
   ga_init(&fc->fc_funcs, sizeof(ufunc_T *), 1);
   func_ptr_ref(fp);
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2044,14 +2044,19 @@ static int vgetorpeek(bool advance)
              */
             if (mp->m_expr) {
               int save_vgetc_busy = vgetc_busy;
+              const bool save_may_garbage_collect = may_garbage_collect;
 
               vgetc_busy = 0;
+              may_garbage_collect = false;
+
               save_m_keys = vim_strsave(mp->m_keys);
               save_m_str = vim_strsave(mp->m_str);
               s = eval_map_expr(save_m_str, NUL);
               vgetc_busy = save_vgetc_busy;
-            } else
+              may_garbage_collect = save_may_garbage_collect;
+            } else {
               s = mp->m_str;
+            }
 
             /*
              * Insert the 'to' part in the typebuf.tb_buf.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2483,7 +2483,7 @@ do_mouse (
           typval_T rettv;
           int doesrange;
           (void)call_func((char_u *)tab_page_click_defs[mouse_col].func,
-                          (int)strlen(tab_page_click_defs[mouse_col].func),
+                          -1,
                           &rettv, ARRAY_SIZE(argv), argv, NULL,
                           curwin->w_cursor.lnum, curwin->w_cursor.lnum,
                           &doesrange, true, NULL, NULL);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6708,14 +6708,14 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest,
         argv[0].vval.v_list = &matchList.sl_list;
         if (expr->v_type == VAR_FUNC) {
           s = expr->vval.v_string;
-          call_func(s, (int)STRLEN(s), &rettv, 1, argv,
+          call_func(s, -1, &rettv, 1, argv,
                     fill_submatch_list, 0L, 0L, &dummy,
                     true, NULL, NULL);
         } else if (expr->v_type == VAR_PARTIAL) {
           partial_T *partial = expr->vval.v_partial;
 
           s = partial_name(partial);
-          call_func(s, (int)STRLEN(s), &rettv, 1, argv,
+          call_func(s, -1, &rettv, 1, argv,
                     fill_submatch_list, 0L, 0L, &dummy,
                     true, partial, NULL);
         }

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -181,7 +181,7 @@ function! Test_lambda_scope()
   let l:D = s:NewCounter2()
 
   call assert_equal(1, l:C())
-  call assert_fails(':call l:D()', 'E15:') " E121: then E15:
+  call assert_fails(':call l:D()', 'E121:')
   call assert_equal(2, l:C())
 endfunction
 

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1409,6 +1409,17 @@ func Test_compound_assignment_operators()
     let @/ = ''
 endfunc
 
+func! Test_funccall_garbage_collect()
+    func Func(x, ...)
+        call add(a:x, a:000)
+    endfunc
+    call Func([], [])
+    " Must not crash cause by invalid freeing
+    call test_garbagecollect_now()
+    call assert_true(v:true)
+    delfunc Func
+endfunc
+
 func Test_function_defined_line()
     if has('gui_running')
         " Can't catch the output of gvim.

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1409,7 +1409,7 @@ func Test_compound_assignment_operators()
     let @/ = ''
 endfunc
 
-func! Test_funccall_garbage_collect()
+func Test_funccall_garbage_collect()
     func Func(x, ...)
         call add(a:x, a:000)
     endfunc


### PR DESCRIPTION
Cherry-picked patch 8.1.1563 from https://github.com/neovim/neovim/pull/12377

~~Patch 8.1.1319 fails a `v:lua` test for some reason.~~ It is checked further down the code for `call_func` so `len` should be reassigned so that `strlen` does not run twice.