### PR TITLE
vim-patch:8.2.1754

### DIFF
--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -329,3 +329,17 @@ func RunVimPiped(before, after, arguments, pipecmd)
   endif
   return 1
 endfunc
+
+" Get all messages but drop the maintainer entry.
+func GetMessages()
+  redir => result
+  redraw | messages
+  redir END
+  let msg_list = split(result, "\n")
+  " if msg_list->len() > 0 && msg_list[0] =~ 'Messages maintainer:'
+  "   return msg_list[1:]
+  " endif
+  return msg_list
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -118,6 +118,43 @@ foobar/?
   set spell&
 endfunc
 
+func Test_spelllang_inv_region()
+  set spell spelllang=en_xx
+  let messages = GetMessages()
+  call assert_equal('Warning: region xx not supported', messages[-1])
+  set spell& spelllang&
+endfunc
+
+func Test_compl_with_CTRL_X_CTRL_K_using_spell()
+  " When spell checking is enabled and 'dictionary' is empty,
+  " CTRL-X CTRL-K in insert mode completes using the spelling dictionary.
+  new
+  set spell spelllang=en dictionary=
+
+  set ignorecase
+  call feedkeys("Senglis\<c-x>\<c-k>\<esc>", 'tnx')
+  call assert_equal(['English'], getline(1, '$'))
+  call feedkeys("SEnglis\<c-x>\<c-k>\<esc>", 'tnx')
+  call assert_equal(['English'], getline(1, '$'))
+
+  set noignorecase
+  call feedkeys("Senglis\<c-x>\<c-k>\<esc>", 'tnx')
+  call assert_equal(['englis'], getline(1, '$'))
+  call feedkeys("SEnglis\<c-x>\<c-k>\<esc>", 'tnx')
+  call assert_equal(['English'], getline(1, '$'))
+
+  set spelllang=en_us
+  call feedkeys("Stheat\<c-x>\<c-k>\<esc>", 'tnx')
+  call assert_equal(['theater'], getline(1, '$'))
+  set spelllang=en_gb
+  call feedkeys("Stheat\<c-x>\<c-k>\<esc>", 'tnx')
+  " FIXME: commented out, expected theatre bug got theater. See issue #7025.
+  " call assert_equal(['theatre'], getline(1, '$'))
+
+  bwipe!
+  set spell& spelllang& dictionary& ignorecase&
+endfunc
+
 func Test_spellreall()
   new
   set spell


### PR DESCRIPTION
Problem:    Completion with spell checking not tested.
Solution:   Add a test case. (Dominique Pellé, closes vim/vim#7024)
https://github.com/vim/vim/commit/8c7ad3631af570f68b2da2658cf966a9a19cb6c4

Cherry-pick GetMessages() from patch 8.2.0666.
Comment out the code that checks for "Messages maintainer:" line
because Neovim's ":messages" command does not output it
and patches for the "methods" feature (ie. foo->bar) are not ported yet.

https://github.com/neovim/neovim/pull/5160