### PR TITLE
vim-patch:8.2.1757: Mac: default locale is lacking the encoding

### DIFF
--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -43,14 +43,20 @@ void lang_init(void)
       }
     }
 
+    char buf[50] = { 0 };
+    bool set_lang;
     if (lang_region) {
-      os_setenv("LANG", lang_region, true);
+      set_lang = true;
+      xstrlcpy(buf, lang_region, sizeof(buf));
     } else {
-      char buf[20] = { 0 };
-      if (CFStringGetCString(cf_lang_region, buf, 20,
-                             kCFStringEncodingUTF8)) {
-        os_setenv("LANG", buf, true);
+      set_lang = CFStringGetCString(cf_lang_region, buf, 40,
+                                    kCFStringEncodingUTF8);
+    }
+    if (set_lang) {
+      if (strcasestr(buf, "utf-8") == NULL) {
+        xstrlcat(buf, ".UTF-8", sizeof(buf));
       }
+      os_setenv("LANG", buf, true);
     }
     CFRelease(cf_lang_region);
 # ifdef HAVE_LOCALE_H

--- a/src/nvim/testdir/test_environ.vim
+++ b/src/nvim/testdir/test_environ.vim
@@ -1,4 +1,8 @@
+" Test for environment variables.
+
 scriptencoding utf-8
+
+source check.vim
 
 func Test_environ()
   unlet! $TESTENV
@@ -42,3 +46,24 @@ func Test_external_env()
   endif
   call assert_equal('', result)
 endfunc
+
+func Test_mac_locale()
+  CheckFeature osxdarwin
+
+  " If $LANG is not set then the system locale will be used.
+  " Run Vim after unsetting all the locale environmental vars, and capture the
+  " output of :lang.
+  let lang_results = system("unset LANG; unset LC_MESSAGES; " ..
+            \ shellescape(v:progpath) ..
+            \ " --clean -esX -c 'redir @a' -c 'lang' -c 'put a' -c 'print' -c 'qa!' ")
+
+  " Check that:
+  " 1. The locale is the form of <locale>.UTF-8.
+  " 2. Check that fourth item (LC_NUMERIC) is properly set to "C".
+  " Example match: "en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8"
+  call assert_match('"\([a-zA-Z_]\+\.UTF-8/\)\{3}C\(/[a-zA-Z_]\+\.UTF-8\)\{2}"',
+        \ lang_results,
+        \ "Default locale should have UTF-8 encoding set, and LC_NUMERIC set to 'C'")
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
vim-patch:8.2.1757: Mac: default locale is lacking the encoding

Problem:    Mac: default locale is lacking the encoding.
Solution:   Add ".UTF-8 to the locale. (Yee Cheng Chin, closes vim/vim#7022)
https://github.com/vim/vim/commit/a5fe91e6dc610bc823bc3201e2c88179989b13fb

Cherry-pick test_environ.vim changes from patch 8.2.1432.