### PR TITLE
[LSP] Fix separator drawing on hover (fixes #13006, #12998)

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -802,12 +802,13 @@ function M.fancy_floating_markdown(contents, opts)
   -- Insert blank line separator after code block
   local insert_separator = opts.separator
   if insert_separator == nil then insert_separator = true end
+  local separator_width = math.min(width, opts.wrap_at)
   if insert_separator then
     for i, h in ipairs(highlights) do
       h.start = h.start + i - 1
       h.finish = h.finish + i - 1
       if h.finish + 1 <= #stripped then
-        table.insert(stripped, h.finish + 1, string.rep("─", width))
+        table.insert(stripped, h.finish + 1, string.rep("─", separator_width))
         height = height + 1
       end
     end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -802,13 +802,12 @@ function M.fancy_floating_markdown(contents, opts)
   -- Insert blank line separator after code block
   local insert_separator = opts.separator
   if insert_separator == nil then insert_separator = true end
-  local separator_width = math.min(width, opts.wrap_at)
   if insert_separator then
     for i, h in ipairs(highlights) do
       h.start = h.start + i - 1
       h.finish = h.finish + i - 1
       if h.finish + 1 <= #stripped then
-        table.insert(stripped, h.finish + 1, string.rep("─", separator_width))
+        table.insert(stripped, h.finish + 1, string.rep("─", math.min(width, opts.wrap_at)))
         height = height + 1
       end
     end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -800,7 +800,8 @@ function M.fancy_floating_markdown(contents, opts)
   local width, height = M._make_floating_popup_size(stripped, opts)
 
   -- Insert blank line separator after code block
-  local insert_separator = opts.separator or true
+  local insert_separator = opts.separator
+  if insert_separator == nil then insert_separator = true end
   if insert_separator then
     for i, h in ipairs(highlights) do
       h.start = h.start + i - 1


### PR DESCRIPTION
* The previous conditional for inserting a separator in `lsp.util.fancy_floating_markdown` did not work if `opts.separator` was set to `false`; the default option `true` for an empty option is now set explicitly.
Fixes #13006 

* If the method signature was longer than than the window width and `max_width` was not set, then the separator was calculated based on the full width and wrapped as well. Now it is always terminated at `wrap_at` (which might be less than `max_width`).
Fixes #12998