### PR TITLE
[RFC] vim-patch:8.1.{1965,1970,1980,1992},8.2.0840

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1198,7 +1198,7 @@ int do_search(
         // msg_strtrunc() will shorten in the middle.
         if (ui_has(kUIMessages)) {
           len = 0;  // adjusted below
-        } else if (msg_scrolled != 0 || cmd_silent) {
+        } else if (msg_scrolled != 0 && !cmd_silent) {
           // Use all the columns.
           len = (Rows - msg_row) * Columns - 1;
         } else {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1370,7 +1370,10 @@ int do_search(
         && !shortmess(SHM_SEARCHCOUNT)
         && msgbuf != NULL) {
       search_stat(dirc, &pos, show_top_bot_msg, msgbuf,
-                  (count != 1 || has_offset));
+                  (count != 1
+                   || has_offset
+                   || (!(fdo_flags & FDO_SEARCH)
+                       && hasFolding(curwin->w_cursor.lnum, NULL, NULL))));
     }
 
     // The search command can be followed by a ';' to do another search.

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4359,7 +4359,9 @@ static void search_stat(int dirc, pos_T *pos,
 
       len = STRLEN(t);
       if (show_top_bot_msg && len + 2 < SEARCH_STAT_BUF_LEN) {
-        STRCPY(t + len, " W");
+        memmove(t + 2, t, len);
+        t[0] = 'W';
+        t[1] = ' ';
         len += 2;
       }
 

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -186,6 +186,35 @@ func Test_search_stat()
   bwipe!
 endfunc
 
+func Test_search_stat_foldopen()
+  CheckScreendump
+
+  let lines =<< trim END
+    set shortmess-=S
+    setl foldenable foldmethod=indent foldopen-=search
+    call append(0, ['if', "\tfoo", "\tfoo", 'endif'])
+    let @/ = 'foo'
+    call cursor(1,1)
+    norm n
+  END
+  call writefile(lines, 'Xsearchstat1')
+
+  let buf = RunVimInTerminal('-S Xsearchstat1', #{rows: 10})
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstat_3', {})
+
+  call term_sendkeys(buf, "n")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstat_3', {})
+
+  call term_sendkeys(buf, "n")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstat_3', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xsearchstat1')
+endfunc
+
 func! Test_search_stat_screendump()
   CheckScreendump
 

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -43,7 +43,7 @@ func Test_search_stat()
   call assert_match(pat .. stat, g:a)
   call cursor(line('$'), 1)
   let g:a = execute(':unsilent :norm! n')
-  let stat = '\[1/>99\] W'
+  let stat = 'W \[1/>99\]'
   call assert_match(pat .. stat, g:a)
 
   " Many matches
@@ -53,7 +53,7 @@ func Test_search_stat()
   call assert_match(pat .. stat, g:a)
   call cursor(1, 1)
   let g:a = execute(':unsilent :norm! N')
-  let stat = '\[>99/>99\] W'
+  let stat = 'W \[>99/>99\]'
   call assert_match(pat .. stat, g:a)
 
   " right-left
@@ -85,7 +85,7 @@ func Test_search_stat()
     call cursor('$',1)
     let pat = 'raboof/\s\+'
     let g:a = execute(':unsilent :norm! n')
-    let stat = '\[20/1\]'
+    let stat = 'W \[20/1\]'
     call assert_match(pat .. stat, g:a)
     call assert_match('search hit BOTTOM, continuing at TOP', g:a)
     set norl
@@ -96,10 +96,10 @@ func Test_search_stat()
   let @/ = 'foobar'
   let pat = '?foobar\s\+'
   let g:a = execute(':unsilent :norm! N')
-  let stat = '\[20/20\]'
+  let stat = 'W \[20/20\]'
   call assert_match(pat .. stat, g:a)
   call assert_match('search hit TOP, continuing at BOTTOM', g:a)
-  call assert_match('\[20/20\] W', Screenline(&lines))
+  call assert_match('W \[20/20\]', Screenline(&lines))
 
   " normal, no match
   call cursor(1,1)

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -162,8 +162,29 @@ func! Test_search_stat()
   let stat = '\[1/2\]'
   call assert_notmatch(pat .. stat, g:a)
 
-  " close the window
+  " normal, n comes from a silent mapping
+  " First test a normal mapping, then a silent mapping
+  call cursor(1,1)
+  nnoremap n n
+  let @/ = 'find this'
+  let pat = '/find this\s\+'
+  let g:a = execute(':unsilent :norm n')
+  let g:b = split(g:a, "\n")[-1]
+  let stat = '\[1/2\]'
+  call assert_match(pat .. stat, g:b)
+  nnoremap <silent> n n
+  call cursor(1,1)
+  let g:a = execute(':unsilent :norm n')
+  let g:b = split(g:a, "\n")[-1]
+  let stat = '\[1/2\]'
+  call assert_notmatch(pat .. stat, g:b)
+  call assert_match(stat, g:b)
+  unmap n
+
+  " Clean up
   set shortmess+=S
+
+  " close the window
   bwipe!
 endfunc
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -323,7 +323,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|
       {1:~                        }|
     ]], messages={
-      {content = {{"/line      [1/2] W"}}, kind = "search_count"}
+      {content = {{"/line      W [1/2]"}}, kind = "search_count"}
     }}
 
     feed('n')


### PR DESCRIPTION
#### vim-patch:8.1.1965: search count message is not displayed when using a mapping

Problem:    The search count message is not displayed when using a mapping.
            (Gary Johnson)
Solution:   Ignore cmd_silent for showing the search count. (Christian
            Brabandt)
https://github.com/vim/vim/commit/359ad1a6f92d0d3b4b942ea003fb02dc57bbfc9e


#### vim-patch:8.1.1970: search stat space wrong, no test for 8.1.1965

Problem:    Search stat space wrong, no test for 8.1.1965.
Solution:   Fix check for cmd_silent.  Add a test. (Christian Brabandt)
https://github.com/vim/vim/commit/19e8ac72e9c17b894a9c74cb8f70feb33567033c


#### vim-patch:8.1.1980: fix for search stat not tested

Problem:    Fix for search stat not tested.
Solution:   Add a screenshot test. (Christian Brabandt)
https://github.com/vim/vim/commit/0f63ed33fdd12d8220f7bc7ff91095e7ceed9985


#### vim-patch:8.1.1992: the search stat moves when wrapping at the end of the buffer

Problem:    The search stat moves when wrapping at the end of the buffer.
Solution:   Put the "W" in front instead of at the end.
https://github.com/vim/vim/commit/16b58ae9f36e9675c34d942f5d5f8c8a7914dbc4


#### vim-patch:8.2.0840: search match count wrong when only match is in fold

Problem:    Search match count wrong when only match is in fold.
Solution:   Update search stats when in a closed fold. (Christian Brabandt,
            closes vim/vim#6160, closes vim/vim#6152)
https://github.com/vim/vim/commit/6cb0726215519fe94103803e4aa77a355384bcf2