### PR TITLE
screen.c: fix buffer overflow due to folding

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2822,6 +2822,16 @@ win_line (
       n_extra = wp->w_p_rl ? (col + 1) : (grid->Columns - col);
     }
 
+    if (draw_state == WL_LINE
+        && foldinfo.fi_level != 0
+        && foldinfo.fi_lines > 0
+        && col >= grid->Columns
+        && n_extra != 0
+        && row == startrow) {
+      // Truncate the folding.
+      n_extra = 0;
+    }
+
     if (draw_state == WL_LINE && (area_highlighting || has_spell)) {
       // handle Visual or match highlighting in this line
       if (vcol == fromcol

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -6,6 +6,8 @@ local feed_command = helpers.feed_command
 local insert = helpers.insert
 local funcs = helpers.funcs
 local meths = helpers.meths
+local source = helpers.source
+local assert_alive = helpers.assert_alive
 
 describe("folded lines", function()
   local screen
@@ -356,5 +358,27 @@ describe("folded lines", function()
     {1:~                                            }|
                                                  |
     ]]}
+  end)
+
+  it('does not crash when foldtext is longer than columns #12988', function()
+    source([[
+      function! MyFoldText() abort
+        return repeat('-', &columns + 100)
+      endfunction
+    ]])
+    command('set foldtext=MyFoldText()')
+    feed("i<cr><esc>")
+    feed("vkzf")
+    screen:expect{grid=[[
+    {5:^---------------------------------------------}|
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+    {1:~                                            }|
+                                                 |
+    ]]}
+    assert_alive()
   end)
 end)


### PR DESCRIPTION
fixes #12988.

- [ ] ~Correct handling of multi-byte characters.~
- [x] Write test.