### PR TITLE
vim-patch:8.1.2226,8.2.{1772,1774,1775,1776}

### DIFF
--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3473,6 +3473,18 @@ func Test_shorten_fname()
   " Displaying the quickfix list should simplify the file path
   silent! clist
   call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
+  " Add a few entries for the same file with different paths and check whether
+  " the buffer name is shortened
+  %bwipe
+  call setqflist([], 'f')
+  call setqflist([{'filename' : 'test_quickfix.vim', 'lnum' : 10},
+        \ {'filename' : '../testdir/test_quickfix.vim', 'lnum' : 20},
+        \ {'filename' : fname, 'lnum' : 30}], ' ')
+  copen
+  call assert_equal(['test_quickfix.vim|10| ',
+        \ 'test_quickfix.vim|20| ',
+        \ 'test_quickfix.vim|30| '], getline(1, '$'))
+  cclose
 endfunc
 
 " Quickfix title tests


### PR DESCRIPTION
vim-patch:8.2.1775: MS-Windows: adding a long quickfix list is slow

Problem:    MS-Windows: adding a long quickfix list is slow.
Solution:   Shorten the buffer name only for the first entry. (Yegappan
            Lakshmanan, closes vim/vim#7039, closes vim/vim#7033)
https://github.com/vim/vim/commit/8ec92c977976d9e9225183e36a80e6b0cdbf1f51

N/A patches for version.c:

vim-patch:8.1.2226: cannot use system copy/paste in non-xterm terminals

Problem:    Cannot use system copy/paste in non-xterm terminals.
Solution:   Instead of setting 'mouse' to "a" set it to "nvi" in defaults.vim.
https://github.com/vim/vim/commit/5b418992cf254137fde2a14d7066fbea5afddb28

vim-patch:8.2.1772: cannot use CTRL-W <Down> to move out of a terminal window

Problem:    Cannot use CTRL-W <Down> to move out of a terminal window.
Solution:   Use special_to_buf() instead of mb_char2bytes(). (closes vim/vim#7045)
https://github.com/vim/vim/commit/f43e7ac4eee22dbb26fc069ec9a3d1598ec8dfe9

vim-patch:8.2.1774: GTK: hang when forced to exit

Problem:    GTK: hang when forced to exit.
Solution:   Do not clean up "mainwin" when really_exiting is set.
            (Zdenek Dohnal, closes vim/vim#7042)
https://github.com/vim/vim/commit/32fbc4f247a31e35ade0939542e11aa033a2554f

vim-patch:8.2.1776: filetype.vim may be loaded twice

Problem:    Filetype.vim may be loaded twice.
Solution:   Do "syntax on" after "filetype on". (Adam Stankiewicz,
            closes vim/vim#7049)
https://github.com/vim/vim/commit/17bb4d4607a95e13e913519af106f1bf8b26c178