### PR TITLE
[RDY] PVS/V1001: Remove assignment to unused variable

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1531,10 +1531,10 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     end_line++;
   }
 
-  ns_id = extmark_set(buf, ns_id, 0,
-                      (int)line, (colnr_T)col_start,
-                      end_line, (colnr_T)col_end,
-                      decoration_hl(hl_id), kExtmarkNoUndo);
+  extmark_set(buf, ns_id, 0,
+              (int)line, (colnr_T)col_start,
+              end_line, (colnr_T)col_end,
+              decoration_hl(hl_id), kExtmarkNoUndo);
   return src_id;
 }
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1531,10 +1531,10 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     end_line++;
   }
 
-  extmark_set(buf, ns_id, 0,
-              (int)line, (colnr_T)col_start,
-              end_line, (colnr_T)col_end,
-              decoration_hl(hl_id), kExtmarkUndo);
+  ns_id = extmark_set(buf, ns_id, 0,
+                      (int)line, (colnr_T)col_start,
+                      end_line, (colnr_T)col_end,
+                      decoration_hl(hl_id), kExtmarkUndo);
   return src_id;
 }
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1531,11 +1531,11 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     end_line++;
   }
 
-  ns_id = extmark_set(buf, ns_id, 0,
-                      (int)line, (colnr_T)col_start,
-                      end_line, (colnr_T)col_end,
-                      decoration_hl(hl_id), kExtmarkUndo);
-  return (Integer)ns_id;
+  extmark_set(buf, ns_id, 0,
+              (int)line, (colnr_T)col_start,
+              end_line, (colnr_T)col_end,
+              decoration_hl(hl_id), kExtmarkUndo);
+  return src_id;
 }
 
 /// Clears namespaced objects (highlights, extmarks, virtual text) from

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1531,10 +1531,10 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     end_line++;
   }
 
-  ns_id = extmark_set(buf, ns_id, 0,
-                      (int)line, (colnr_T)col_start,
-                      end_line, (colnr_T)col_end,
-                      decoration_hl(hl_id), kExtmarkUndo);
+  extmark_set(buf, ns_id, 0,
+              (int)line, (colnr_T)col_start,
+              end_line, (colnr_T)col_end,
+              decoration_hl(hl_id), kExtmarkUndo);
   return src_id;
 }
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1535,7 +1535,7 @@ Integer nvim_buf_add_highlight(Buffer buffer,
                       (int)line, (colnr_T)col_start,
                       end_line, (colnr_T)col_end,
                       decoration_hl(hl_id), kExtmarkUndo);
-  return ns_id;
+  return (Integer)ns_id;
 }
 
 /// Clears namespaced objects (highlights, extmarks, virtual text) from

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1531,11 +1531,11 @@ Integer nvim_buf_add_highlight(Buffer buffer,
     end_line++;
   }
 
-  extmark_set(buf, ns_id, 0,
-              (int)line, (colnr_T)col_start,
-              end_line, (colnr_T)col_end,
-              decoration_hl(hl_id), kExtmarkUndo);
-  return src_id;
+  ns_id = extmark_set(buf, ns_id, 0,
+                      (int)line, (colnr_T)col_start,
+                      end_line, (colnr_T)col_end,
+                      decoration_hl(hl_id), kExtmarkUndo);
+  return ns_id;
 }
 
 /// Clears namespaced objects (highlights, extmarks, virtual text) from


### PR DESCRIPTION
Fixes PVS warning [V1001](https://www.viva64.com/en/w/v1001/).
Removes assignment to `ns_id` which is unused by the end of `nvim_buf_add_highlight()`.