### PR TITLE
doc: nvim_win_get_cursor()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2140,7 +2140,7 @@ nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
                     {window}  Window handle, or 0 for current window
 
                 Return: ~
-                    (row, col) tuple
+                    (row, byte-offset) tuple
 
 nvim_win_get_height({window})                          *nvim_win_get_height()*
                 Gets the window height

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -80,7 +80,7 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
 ///
 /// @param window   Window handle, or 0 for current window
 /// @param[out] err Error details, if any
-/// @return (row, col) tuple
+/// @return (row, byte-offset) tuple
 ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
   FUNC_API_SINCE(1)
 {


### PR DESCRIPTION
Fix #12973 . Documentation has been updated for nvim_win_get_cursor function.
Now states the return value will be byte offset from the buffer instead of column 
position. Doxygen comment has been updated in the C file and vimdoc has been
regenerated.