### PR TITLE
vim-patch:8.2.1762: when a timer uses :stopinsert completion isn't stopped

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -649,6 +649,17 @@ static int insert_execute(VimState *state, int key)
   InsertState *s = (InsertState *)state;
   s->c = key;
 
+  // Insert mode ended, possibly from a callback.
+  if (stop_insert_mode) {
+    if (key != K_IGNORE && key != K_NOP)
+      vungetc(s->c);
+    s->count = 0;
+    s->nomove = true;
+    s->c = ESC;
+    ins_compl_prep(s->c);
+    insert_handle_key(s);
+  }
+
   // Don't want K_EVENT with cursorhold for the second key, e.g., after CTRL-V.
   if (key != K_EVENT) {
     did_cursorhold = true;

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -338,3 +338,25 @@ func Test_compl_in_cmdwin()
   delcom GetInput
   set wildmenu& wildchar&
 endfunc
+
+func Test_pum_stopped_by_timer()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['hello', 'hullo', 'heeee', ''])
+    func StartCompl()
+      call timer_start(100, { -> execute('stopinsert') })
+      call feedkeys("Gah\<C-N>")
+    endfunc
+  END
+
+  call writefile(lines, 'Xpumscript')
+  let buf = RunVimInTerminal('-S Xpumscript', #{rows: 12})
+  call term_sendkeys(buf, ":call StartCompl()\<CR>")
+  call TermWait(buf, 200)
+  call term_sendkeys(buf, "k")
+  call VerifyScreenDump(buf, 'Test_pum_stopped_by_timer', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xpumscript')
+endfunc


### PR DESCRIPTION
> Problem:    When a timer uses :stopinsert Insert mode completion isn't
>             stopped. (Stanley Chan)
> Solution:   Call ins_compl_prep(ESC).
> https://github.com/vim/vim/commit/d0e1b7103c14eb0d175c6b245b4b6ed93a204da9

First vim-patch PR to the project! Fixes bug https://github.com/neovim/neovim/issues/12976 and obsoletes @tjdevries's PR https://github.com/neovim/neovim/pull/12977

I am unsure what to do with the `src/testdir/dumps/Test_pum_stopped_by_timer.dump` file.

**NOTE**: https://github.com/vim/vim/issues/7035 mention additional patches that I am unsure we need in neovim:

* https://github.com/vim/vim/commit/ad9ec5e79916d206fd7677b77e36485c47ae534f
* https://github.com/vim/vim/commit/4537bcc88956f86267c25edf8008e0dbde598652

If these are necessary, I will make the changes accordingly 👍

Pinging @janlazo , @erw7 for review.