### PR TITLE
[WIP] lsp: in case of error display message

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -294,7 +294,7 @@ M['window/logMessage'] = function(_, _, result, client_id)
   local client = vim.lsp.get_client_by_id(client_id)
   local client_name = client and client.name or string.format("id=%d", client_id)
   if not client then
-    err_message("LSP[", client_name, "] client has shut down after sending the message")
+    err_message("LSP[", client_name, "] client has shut down after sending the message. Result:\n", message)
   end
   if message_type == protocol.MessageType.Error then
     log.error(message)


### PR DESCRIPTION
I am running haskell-language-server and on startup I get
`LSP[id=1] client has shut down after sending the message`.
Not only does it seem the client keeps working since I receive notification status but the message also doesn't say why the client shuts down. 
I think we should unconditionnaly print the message (if it exists). In my case, I had to go through the logs to see a misconfiguration in the LSP server: printing the message in the TUI is more user-friendly 