### PR TITLE
vim-patch:8.1.{1812,2024,2239,2242,2247,2249,2253},8.2.{354,603,609,665,1570,1790,1792,1801}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2497,8 +2497,12 @@ int do_ecmd(
       new_name = NULL;
     }
     set_bufref(&bufref, buf);
-    if (p_ur < 0 || curbuf->b_ml.ml_line_count <= p_ur) {
-      // Save all the text, so that the reload can be undone.
+
+    // If the buffer was used before, store the current contents so that
+    // the reload can be undone.  Do not do this if the (empty) buffer is
+    // being re-used for another file.
+    if (!(curbuf->b_flags & BF_NEVERLOADED)
+        && (p_ur < 0 || curbuf->b_ml.ml_line_count <= p_ur)) {
       // Sync first so that this is a separate undo-able action.
       u_sync(false);
       if (u_savecommon(0, curbuf->b_ml.ml_line_count + 1, 0, true)

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -25,6 +25,14 @@ func CheckFunction(name)
   endif
 endfunc
 
+" Command to check for the presence of python.  Argument should have been
+" obtained with PythonProg()
+func CheckPython(name)
+  if a:name == ''
+    throw 'Skipped: python command not available'
+  endif
+endfunc
+
 " Command to check for running on MS-Windows
 command CheckMSWindows call CheckMSWindows()
 func CheckMSWindows()

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -392,6 +392,26 @@ func Test_rundo_errors()
   call delete('Xundofile')
 endfunc
 
+func Test_undofile_next()
+  set undofile
+  new Xfoo.txt
+  execute "norm ix\<c-g>uy\<c-g>uz\<Esc>"
+  write
+  bwipe
+
+  next Xfoo.txt
+  call assert_equal('xyz', getline(1))
+  silent undo
+  call assert_equal('xy', getline(1))
+  silent undo
+  call assert_equal('x', getline(1))
+  bwipe!
+
+  call delete('Xfoo.txt')
+  call delete('.Xfoo.txt.un~')
+  set undofile&
+endfunc
+
 " Test for undo working properly when executing commands from a register.
 " Also test this in an empty buffer.
 func Test_cmd_in_reg_undo()

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -380,7 +380,7 @@ func Test_undofile_truncated()
   endfor
 
   bwipe!
-"  call delete('Xundofile')
+  call delete('Xundofile')
 endfunc
 
 func Test_rundo_errors()

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -364,6 +364,25 @@ func Test_wundo_errors()
   bwipe!
 endfunc
 
+" Check that reading a truncted undo file doesn't hang.
+func Test_undofile_truncated()
+  throw 'skipped: TODO: '
+  new
+  call setline(1, 'hello')
+  set ul=100
+  wundo Xundofile
+  let contents = readfile('Xundofile', 'B')
+
+  " try several sizes
+  for size in range(20, 500, 33)
+    call writefile(contents[0:size], 'Xundofile')
+    call assert_fails('rundo Xundofile', 'E825:')
+  endfor
+
+  bwipe!
+"  call delete('Xundofile')
+endfunc
+
 func Test_rundo_errors()
   call assert_fails('rundo XfileDoesNotExist', 'E822:')
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -878,7 +878,12 @@ static u_header_T *unserialize_uhp(bufinfo_T *bi,
   for (;; ) {
     int len = undo_read_byte(bi);
 
-    if (len == 0 || len == EOF) {
+    if (len == EOF) {
+      corruption_error("truncated", file_name);
+      u_free_uhp(uhp);
+      return NULL;
+    }
+    if (len == 0) {
       break;
     }
     int what = undo_read_byte(bi);


### PR DESCRIPTION
vim-patch:8.2.0665: wrongly assuming Python executable is called "python"

Problem:    Wrongly assuming Python executable is called "python".
Solution:   Use detected python command. (Ken Takata, closes vim/vim#6016)
            Also use CheckFunction if possible.
https://github.com/vim/vim/commit/a161cb5dddd6d374899e46fde834ce9ba5c80c0b

CheckPython() is used only in test_terminal.vim as of patch 8.2.1794.
test_terminal.vim is no-opt in Neovim.
I ported it only for merging Vim patches.

N/A patches for version.c:

vim-patch:8.2.0354: Python 3.9 does not define _Py_DEC_REFTOTAL

Problem:    Python 3.9 does not define _Py_DEC_REFTOTAL. (Zdenek Dohnal)
Solution:   Remove it, it was only for debugging.
https://github.com/vim/vim/commit/a65bb53514a1af1ec0dc5c4831dfaef69f139a48

vim-patch:8.2.0603: configure does not detect moonjit

Problem:    Configure does not detect moonjit.
Solution:   Add check for moonjit. (Shlomi Fish, closes vim/vim#5947)
https://github.com/vim/vim/commit/f49e5640821d8ef752fb50d99edcf40bb62a4d4d

vim-patch:8.2.0609: configure does not detect moonjit correctly

Problem:    Configure does not detect moonjit correctly.
Solution:   Double the brackets. (Ozaki Kiichi)
https://github.com/vim/vim/commit/ad4dc83389931a0354c3691b42f99a5bb98c766f

vim-patch:8.2.1570: configure check for dirfd() does not work on HPUX

Problem:    Configure check for dirfd() does not work on HPUX. (Michael Osipov)
Solution:   Use AC_TRY_LINK instead of AC_TRY_COMPILE. (closes vim/vim#6838)
https://github.com/vim/vim/commit/9d8bfae50fdaf5f5ec6307c60ebd1fad0927c6be

vim-patch:8.2.1790: MS-Windows with Python: crash when executed from Vifm

Problem:    MS-Windows with Python: crash when executed from Vifm.
Solution:   Use NUL instead of CONIN. (Ken Takata, closes vim/vim#7061, closes vim/vim#7053)
https://github.com/vim/vim/commit/794771cfd83af2a0d1926bed301e784447e7290b

vim-patch:8.2.1792: Configure does not recognize Racket 6.1+

Problem:    Configure does not recognize Racket 6.1+.
Solution:   Add a check for "rktio". (closes vim/vim#7062)
https://github.com/vim/vim/commit/588d241d44fc25ad4c5a635ee4fdeafdfcee0fde