### PR TITLE
[RDY] vim-patch:8.2.1793: not consistently giving the "is a directory" warning

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -73,3 +73,19 @@ func CheckNotGui()
     throw 'Skipped: only works in the terminal'
   endif
 endfunc
+
+" Command to check that the current language is English
+command CheckEnglish call CheckEnglish()
+func CheckEnglish()
+  if v:lang != "C" && v:lang !~ '^[Ee]n'
+      throw 'Skipped: only works in English language environment'
+  endif
+endfunc
+
+" Command to check for NOT running on MS-Windows
+command CheckNotMSWindows call CheckNotMSWindows()
+func CheckNotMSWindows()
+  if has('win32')
+    throw 'Skipped: does not work on MS-Windows'
+  endif
+endfunc

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1534,3 +1534,30 @@ func Test_edit_noesckeys()
   bwipe!
   " set esckeys
 endfunc
+
+" Test for editing a directory
+" Todo: "is a directory" message is not displayed in Windows.
+func Test_edit_is_a_directory()
+  CheckEnglish
+  CheckNotMSWindows
+  let dirname = getcwd() . "/Xdir"
+  call mkdir(dirname, 'p')
+
+  new
+  redir => msg
+  exe 'edit' dirname
+  redir END
+  call assert_match("is a directory$", split(msg, "\n")[0])
+  bwipe!
+
+  let dirname .= '/'
+
+  new
+  redir => msg
+  exe 'edit' dirname
+  redir END
+  call assert_match("is a directory$", split(msg, "\n")[0])
+  bwipe!
+
+  call delete(dirname, 'rf')
+endfunc


### PR DESCRIPTION
Problem:    Not consistently giving the "is a directory" warning.
Solution:   Adjust check for illegal file name and directory. (Yasuhiro
            Matsumoto, closes vim/vim#7067)
https://github.com/vim/vim/commit/c8fe645c198e2ca55c4e3446efbbdb9b995c63ce