### PR TITLE
[WIP] terminal: fix string width issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,6 +434,25 @@ endif()
 find_package(LIBVTERM 0.1 REQUIRED)
 include_directories(SYSTEM ${LIBVTERM_INCLUDE_DIRS})
 
+list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBVTERM_INCLUDE_DIRS}")
+list(APPEND CMAKE_REQUIRED_LIBRARIES "${LIBVTERM_LIBRARIES}")
+check_c_source_compiles("
+#include <vterm.h>
+
+int
+main(void)
+{
+  vterm_set_user_unicode_width(NULL);
+  vterm_set_user_unicode_is_combining(NULL);
+  return 0;
+}
+" VTERM_HAS_USER_FUNC)
+list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${LIBVTERM_INCLUDE_DIRS}")
+list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${LIBVTERM_LIBRARIES}")
+if(VTERM_HAS_USER_FUNC)
+  add_definitions(-DNVIM_VTERM_HAS_USER_FUNC)
+endif()
+
 if(WIN32)
   find_package(Winpty 0.4.3 REQUIRED)
   include_directories(SYSTEM ${WINPTY_INCLUDE_DIRS})

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -458,6 +458,19 @@ static bool intable(const struct interval *table, size_t n_items, int c)
   return false;
 }
 
+#ifdef NVIM_VTERM_HAS_USER_FUNC
+///
+/// utf_char2cells() with different argument type for libvterm.
+///
+int utf_uint2cells(uint32_t c)
+{
+  if (c >= 0x100 && utf_iscomposing((int)c)) {
+    return 0;
+  }
+  return utf_char2cells((int)c);
+}
+#endif
+
 /// For UTF-8 character "c" return 2 for a double-width character, 1 for others.
 /// Returns 4 or 6 for an unprintable character.
 /// Is only correct for characters >= 0x80.
@@ -1018,6 +1031,16 @@ int utf_char2bytes(const int c, char_u *const buf)
     return 6;
   }
 }
+
+#ifdef NVIM_VTERM_HAS_USER_FUNC
+///
+/// utf_iscomposing() with different argument type for libvterm.
+///
+int utf_iscomposing_uint(uint32_t c)
+{
+  return utf_iscomposing((int)c);
+}
+#endif
 
 /*
  * Return true if "c" is a composing UTF-8 character.  This means it will be

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -161,6 +161,10 @@ void terminal_init(void)
   time_watcher_init(&main_loop, &refresh_timer, NULL);
   // refresh_timer_cb will redraw the screen which can call vimscript
   refresh_timer.events = multiqueue_new_child(main_loop.events);
+#ifdef NVIM_VTERM_HAS_USER_FUNC
+  vterm_set_user_unicode_width(utf_uint2cells);
+  vterm_set_user_unicode_is_combining(utf_iscomposing_uint);
+#endif
 }
 
 void terminal_teardown(void)

--- a/third-party/cmake/BuildLibvterm.cmake
+++ b/third-party/cmake/BuildLibvterm.cmake
@@ -38,7 +38,14 @@ if(WIN32)
     set(LIBVTERM_PATCH_COMMAND
     ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm init
       COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm apply --ignore-whitespace
-        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Remove-VLAs-for-MSVC.patch)
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Remove-VLAs-for-MSVC.patch
+      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm apply --ignore-whitespace
+      ${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Add-user-func.patch)
+  else()
+    set(LIBVTERM_PATCH_COMMAND
+    ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm init
+      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm apply --ignore-whitespace
+      ${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Add-user-func.patch)
   endif()
   set(LIBVTERM_CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibvtermCMakeLists.txt
@@ -60,6 +67,8 @@ else()
                                            LDFLAGS+=-static
                                            ${DEFAULT_MAKE_CFLAGS}
                                            install)
+  set(LIBVTERM_PATCH_COMMAND patch -d ${DEPS_BUILD_DIR}/src/libvterm -Np1 --input
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Add-user-func.patch)
 endif()
 
 BuildLibvterm(PATCH_COMMAND ${LIBVTERM_PATCH_COMMAND}

--- a/third-party/patches/libvterm-Add-user-func.patch
+++ b/third-party/patches/libvterm-Add-user-func.patch
@@ -1,0 +1,69 @@
+commit 89098a9a1daf4c1613af8ff843ea7ec6e5cb0c44
+Author: erw7 <erw7.github@gmail.com>
+Date:   Wed Apr 22 19:40:52 2020 +0900
+
+    Add user function
+    
+    Change user program functions to be available instead of
+    vterm_unicode_width() and vterm_unicode_is_combining().
+
+diff --git a/include/vterm.h b/include/vterm.h
+index 03c2f77..4b51e91 100644
+--- a/include/vterm.h
++++ b/include/vterm.h
+@@ -526,6 +526,12 @@ void vterm_copy_cells(VTermRect dest,
+                       void (*copycell)(VTermPos dest, VTermPos src, void *user),
+                       void *user);
+ 
++typedef int VTermUserUnicodeWidth(uint32_t codepoint);
++void vterm_set_user_unicode_width(VTermUserUnicodeWidth *func);
++
++typedef int VTermUserUnicodeIsCombining(uint32_t codepoint);
++void vterm_set_user_unicode_is_combining(VTermUserUnicodeIsCombining *func);
++
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/src/unicode.c b/src/unicode.c
+index 0d1b5ff..da0f4bc 100644
+--- a/src/unicode.c
++++ b/src/unicode.c
+@@ -67,6 +67,19 @@
+  * Latest version: http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
+  */
+ 
++static VTermUserUnicodeWidth *user_unicode_width = NULL;
++static VTermUserUnicodeIsCombining *user_unicode_is_combining = NULL;
++
++void vterm_set_user_unicode_width(VTermUserUnicodeWidth *func)
++{
++  user_unicode_width = func;
++}
++
++void vterm_set_user_unicode_is_combining(VTermUserUnicodeIsCombining *func)
++{
++  user_unicode_is_combining = func;
++}
++
+ struct interval {
+   int first;
+   int last;
+@@ -325,6 +338,9 @@ static const struct interval fullwidth[] = {
+ 
+ INTERNAL int vterm_unicode_width(uint32_t codepoint)
+ {
++  if (user_unicode_width) {
++    return user_unicode_width(codepoint);
++  }
+   if(bisearch(codepoint, fullwidth, sizeof(fullwidth) / sizeof(fullwidth[0]) - 1))
+     return 2;
+ 
+@@ -333,5 +349,8 @@ INTERNAL int vterm_unicode_width(uint32_t codepoint)
+ 
+ INTERNAL int vterm_unicode_is_combining(uint32_t codepoint)
+ {
++  if (user_unicode_is_combining) {
++    return user_unicode_is_combining(codepoint);
++  }
+   return bisearch(codepoint, combining, sizeof(combining) / sizeof(struct interval) - 1);
+ }


### PR DESCRIPTION
Change libvterm to use neovim functions instead of `vterm_unicode_width()` and `vterm_unicode_is_combining()`.

This is the change equivalent to v8.0.0985(https://github.com/vim/vim/commit/6d0826dfbba9880820d9ec221327e4250bbf6540) in vim.