### PR TITLE
[RDY] Opts.wrap_at is sometimes a bool, ensure it falls back to a valid num…

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -807,7 +807,7 @@ function M.fancy_floating_markdown(contents, opts)
       h.start = h.start + i - 1
       h.finish = h.finish + i - 1
       if h.finish + 1 <= #stripped then
-        table.insert(stripped, h.finish + 1, string.rep("─", math.min(width, opts.wrap_at)))
+        table.insert(stripped, h.finish + 1, string.rep("─", math.min(width, opts.wrap_at or width)))
         height = height + 1
       end
     end


### PR DESCRIPTION
…ber in the call to math.min

I'm running the nightly builds, this issue has occurred starting a few days ago.
:version
NVIM v0.5.0-728-gf6ac37560 

I've traced it back to being introduced by this change:
https://github.com/neovim/neovim/commit/e5d98d85693245fec811307e5a2ccfdea3a350cd

The value of opts.wrap_at is unfortunately either a bool (when vim.wo['wrap'] == false or a number when true. This fact is handled inside the call to _make_floating_popup_size when it's utilized there, however in the recent change to better handle wrapping of the section separator, it enables a call to math.min with a second argument being the bool.

Explicitly, I get the following failure when pulling up diagnostics without wrap enabled:
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/util.lua:810: bad argument #2 to 'min' (number expected, got boolean) 

This patch fixes the issue by providing a valid fallback value when wrap is not enabled.