### PR TITLE
help: sort help tag completions by name

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2052,23 +2052,15 @@ parse_line:
           // Store the info we need later, which depends on the kind of
           // tags we are dealing with.
           if (help_only) {
-# define ML_EXTRA 3
-            // Append the help-heuristic number after the tagname, for
-            // sorting it later.  The heuristic is ignored for
-            // detecting duplicates.
-            // The format is {tagname}@{lang}NUL{heuristic}NUL
+            // The format is {tagname}@{lang}
             *tagp.tagname_end = NUL;
             len = (int)(tagp.tagname_end - tagp.tagname);
-            mfp = xmalloc(sizeof(char_u) + len + 10 + ML_EXTRA + 1);
+            mfp = xmalloc(len + 1 + sizeof(help_lang));
 
             p = mfp;
             STRCPY(p, tagp.tagname);
             p[len] = '@';
             STRCPY(p + len + 1, help_lang);
-            snprintf((char *)p + len + 1 + ML_EXTRA, 10, "%06d",
-                     help_heuristic(tagp.tagname,
-                                    match_re ? matchoff : 0, !match_no_ic)
-                     + help_pri);
 
             *tagp.tagname_end = TAB;
           } else if (name_only)   {


### PR DESCRIPTION
When using help tag completion (`:h :syn-<tab>`), the matches looks unordered.
Especially when using wildoptions+=pum.

Actually, the result is sorted, but using a fancy (arbitrary) algorithm that
calculates a score for each tag name and and hides it in memory. Afterwards the
matches are sorted by these scores.

This commit removes the fancy algorithm and simply sorts tags by name.

---

I put this up here for discussion. Maybe it's just personal preference, but I don't see any advantage of the fancy algorithm over just sorting by name. If anything, it's what I would expect to be honest. Why showing the user matches in an order that's impossible for him to understand?

Here's how the current algorithm prioritizes matches: https://github.com/neovim/neovim/blob/f7aeac7263c792e1503f9169abed20b6f5b9da99/src/nvim/ex_cmds.c#L4714-L4720

The old tests are failing now, but I want to wait for more opinions before dealing with that.