### PR TITLE
Prevent LSP diagnostics callback from loading or leaving useless buffers

### DIFF
--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -76,6 +76,10 @@ end
 M['textDocument/publishDiagnostics'] = function(_, _, result)
   if not result then return end
   local uri = result.uri
+
+  -- prevent creating/loading bufers for empty diagnostics
+  if vim.tbl_isempty(result.diagnostics) then return end
+
   local bufnr = vim.uri_to_bufnr(uri)
   if not bufnr then
     err_message("LSP.publishDiagnostics: Couldn't find buffer for ", uri)
@@ -89,6 +93,8 @@ M['textDocument/publishDiagnostics'] = function(_, _, result)
   -- In particular, this stops a ton of spam when first starting a server for current
   -- unloaded buffers.
   if not api.nvim_buf_is_loaded(bufnr) then
+    -- since buffer was loaded by uri_to_bufnr, wipe it out to leave a clean buffer list
+    vim.cmd(string.format('%dbw!', bufnr))
     return
   end
 

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -74,11 +74,10 @@ end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_publishDiagnostics
 M['textDocument/publishDiagnostics'] = function(_, _, result)
-  if not result then return end
-  local uri = result.uri
-
   -- prevent creating/loading bufers for empty diagnostics
-  if vim.tbl_isempty(result.diagnostics) then return end
+  if not result or not result.diagnostics or vim.tbl_isempty(result.diagnostics) then return end
+
+  local uri = result.uri
 
   local bufnr = vim.uri_to_bufnr(uri)
   if not bufnr then


### PR DESCRIPTION
Prevents having a huge list of unlisted buffers when using LSP.

For example, when sumneko is configured with @tjdevries trick:

```
	                        runtime = { version = "LuaJIT", path = vim.split(package.path, ';'), },
				workspace = {
					library = {
						[vim.fn.expand("$VIMRUNTIME/lua")] = true,
						[vim.fn.expand("$VIMRUNTIME/lua/vim/lsp")] = true,
					}
				}
```

after opening a single lua file, you get:

![image](https://user-images.githubusercontent.com/125701/95061475-f01e2f00-06fb-11eb-924c-aab85011c2ac.png)

This PR prevents loading buffers when not needed (empty diagnostics) or when these are not loaded or valid