### PR TITLE
[RDY] Correct log levels

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -12,10 +12,10 @@ local log = {}
 -- Level numbers begin with 'trace' at 0
 log.levels = {
   TRACE = 0;
-  DEBUG = 1;
-  INFO  = 2;
-  WARN  = 3;
-  ERROR = 4;
+  ERROR = 1;
+  WARN  = 2;
+  INFO  = 3;
+  DEBUG = 4;
 }
 
 -- Default log level is warn.


### PR DESCRIPTION
The log levels declared in the log module were inconsistent with the
MessageType object declared in the protocol module.

This surfaced as the inability to correctly log when using the
nvim-lspconfig package.

This change synchronizes the two logging levels so that the semantics
match, but does not make the naming consistent, as that would result in
a bigger change.