### PR TITLE
treesitter: runtime queries

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -56,7 +56,7 @@ TSHighlighter.hl_map = {
     ["include"] = "Include",
 }
 
-function TSHighlighter.new(query, bufnr, ft)
+function TSHighlighter.new(bufnr, ft, query)
   if bufnr == nil or bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end

--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -1,0 +1,151 @@
+(identifier) @variable
+
+[
+  "const"
+  "default"
+  "enum"
+  "extern"
+  "inline"
+  "return"
+  "sizeof"
+  "static"
+  "struct"
+  "typedef"
+  "union"
+  "volatile"
+  "goto"
+] @keyword
+
+[
+  "while"
+  "for"
+  "do"
+  "continue"
+  "break"
+] @repeat
+
+[
+ "if"
+ "else"
+ "case"
+ "switch"
+] @conditional
+
+"#define" @constant.macro
+[
+  "#if"
+  "#ifdef"
+  "#ifndef"
+  "#else"
+  "#elif"
+  "#endif"
+  (preproc_directive)
+] @keyword
+
+"#include" @include
+
+[
+  "="
+
+  "-"
+  "*"
+  "/"
+  "+"
+  "%"
+
+  "~"
+  "|"
+  "&"
+  "^"
+  "<<"
+  ">>"
+
+  "->"
+
+  "<"
+  "<="
+  ">="
+  ">"
+  "=="
+  "!="
+
+  "!"
+  "&&"
+  "||"
+
+  "-="
+  "+="
+  "*="
+  "/="
+  "%="
+  "|="
+  "&="
+  "^="
+  "--"
+  "++"
+] @operator
+
+[
+ (true)
+ (false)
+] @boolean
+
+[ "." ";" ":" "," ] @punctuation.delimiter
+
+(conditional_expression [ "?" ":" ] @conditional)
+
+
+[ "(" ")" "[" "]" "{" "}"] @punctuation.bracket
+
+(string_literal) @string
+(system_lib_string) @string
+
+(null) @constant.builtin
+(number_literal) @number
+(char_literal) @number
+
+(call_expression
+  function: (identifier) @function)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @function))
+(function_declarator
+  declarator: (identifier) @function)
+(preproc_function_def
+  name: (identifier) @function.macro)
+[
+ (preproc_arg)
+ (preproc_defined)
+]  @function.macro
+; TODO (preproc_arg)  @embedded
+
+(field_identifier) @property
+(statement_identifier) @label
+
+[
+(type_identifier)
+(primitive_type)
+(sized_type_specifier)
+(type_descriptor)
+ ] @type
+
+(declaration type: [(identifier) (type_identifier)] @type)
+(cast_expression type: [(identifier) (type_identifier)] @type)
+(sizeof_expression value: (parenthesized_expression (identifier) @type))
+
+((identifier) @constant
+ (#match? @constant "^[A-Z][A-Z0-9_]+$"))
+
+(comment) @comment
+
+;; Parameters
+(parameter_declaration
+  declarator: (identifier) @parameter)
+
+(parameter_declaration
+  declarator: (pointer_declarator) @parameter)
+
+(preproc_params
+  (identifier)) @parameter
+
+(ERROR) @error

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -25,7 +25,6 @@ describe('treesitter API', function()
     eq("Error executing lua: .../language.lua: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.inspect_language('borklang')"))
   end)
-
 end)
 
 describe('treesitter API with C parser', function()
@@ -185,6 +184,16 @@ void ui_refresh(void)
     (primitive_type) @type
     (field_expression argument: (identifier) @fieldarg)
   ]]
+
+  it("supports runtime queries", function()
+    if not check_parser() then return end
+
+    local ret = exec_lua [[
+      return require"vim.treesitter.query".get_query("c", "highlights").captures[1]
+    ]]
+
+    eq('variable', ret)
+  end)
 
   it('support query and iter by capture', function()
     if not check_parser() then return end
@@ -422,7 +431,7 @@ static int nlua_schedule(lua_State *const lstate)
     exec_lua([[
       local highlighter = vim.treesitter.highlighter
       local query = ...
-      test_hl = highlighter.new(query, 0, "c")
+      test_hl = highlighter.new(0, "c", query)
     ]], hl_query)
     screen:expect{grid=[[
       {2:/// Schedule Lua callback on main loop's event queue}             |


### PR DESCRIPTION
Runtime queries just work like ftplugins, that is:

- Queries in the `after` directory are sourced _after_ the "base" query
- Otherwise, the last define query takes precedence.

Queries can be found in the `queries` directory.

This is a replacement for #12639, and this is directly upstreamed from `nvim-treesitter`.
Also upstream the C runtime query, so that we can nearly have out of the box highlighting for C.

cc original commenters : @teto @tjdevries @bfredl 

Next step will be at #12953, to enable true language injection, using the LanguageTree structure.