### PR TITLE
Create ftplugin/crontab.vim

### DIFF
--- a/runtime/ftplugin/crontab.vim
+++ b/runtime/ftplugin/crontab.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#\ %s


### PR DESCRIPTION
This has always bugged me, and was/is an issue in vim too.

A syntax file for crontabs exists, but not an ftplugin, meaning NeoVim highlights comments correctly but cannot create them.