### PR TITLE
basic support for USDT systemtap probes

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
 check_include_files(termios.h HAVE_TERMIOS_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
+check_include_files(sys/sdt.h HAVE_SYS_SDT_H)
 
 # Functions
 check_function_exists(fseeko HAVE_FSEEKO)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -33,6 +33,7 @@
 #cmakedefine HAVE_STRCASECMP
 #cmakedefine HAVE_STRINGS_H
 #cmakedefine HAVE_STRNCASECMP
+#cmakedefine HAVE_SYS_SDT_H
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H
 #cmakedefine HAVE_TERMIOS_H

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -7,6 +7,16 @@
 #include "auto/config.h"
 #include "nvim/macros.h"
 
+// USDT probes. Example invokation:
+//     NVIM_PROBE(nvim_foo_bar, 1, string.data);
+#if defined(HAVE_SYS_SDT_H)
+#include <sys/sdt.h> // NOLINT
+#define NVIM_PROBE(name, n, ...) STAP_PROBE##n(neovim, name, __VA_ARGS__)
+#else
+#define NVIM_PROBE(name, n, ...)
+#endif
+
+
 #define DEBUG_LOG_LEVEL 0
 #define INFO_LOG_LEVEL 1
 #define WARN_LOG_LEVEL 2


### PR DESCRIPTION
reduced version of #12036 . Just adds the include check and a conditional macro. Then `NVIM_PROBE` can be added inside debugging PR:s, for now.