### PR TITLE
tree-sitter: error out when parsing fails

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -180,7 +180,7 @@ int tslua_add_language(lua_State *L)
       || lang_version > TREE_SITTER_LANGUAGE_VERSION) {
     return luaL_error(
         L,
-        "ABI version mismatch : expected %" PRIu32 ", found %" PRIu32,
+        "ABI version mismatch : expected %d, found %d",
         TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION, lang_version);
   }
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -176,7 +176,8 @@ int tslua_add_language(lua_State *L)
   }
 
   uint32_t lang_version = ts_language_version(lang);
-  if (lang_version < TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION) {
+  if (lang_version < TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION
+      || lang_version > TREE_SITTER_LANGUAGE_VERSION) {
     return luaL_error(
         L,
         "ABI version mismatch : expected %" PRIu32 ", found %" PRIu32,
@@ -246,7 +247,12 @@ int tslua_push_parser(lua_State *L)
   }
 
   TSParser *parser = ts_parser_new();
-  ts_parser_set_language(parser, lang);
+
+  if (!ts_parser_set_language(parser, lang)) {
+    ts_parser_delete(parser);
+    return luaL_error(L, "Failed to load language : %s", lang_name);
+  }
+
   TSLua_parser *p = lua_newuserdata(L, sizeof(TSLua_parser));  // [udata]
   p->parser = parser;
   p->tree = NULL;
@@ -342,7 +348,7 @@ static int parser_parse(lua_State *L)
     return 0;
   }
 
-  TSTree *new_tree;
+  TSTree *new_tree = NULL;
   size_t len;
   const char *str;
   long bufnr;
@@ -372,6 +378,12 @@ static int parser_parse(lua_State *L)
 
     default:
       return luaL_error(L, "invalid argument to parser:parse()");
+  }
+
+  // Sometimes parsing fails (timeout, or wrong parser ABI)
+  // In those case, just return an error.
+  if (!new_tree) {
+    return luaL_error(L, "An error occured when parsing.");
   }
 
   uint32_t n_ranges = 0;


### PR DESCRIPTION
This can happen when there is ABI mismatches, and removes the assumption
parsing alwasy succeeds (which is wrong).

cc @mfussenegger maybe this can help