### PR TITLE
doc: correct vim.types usage in lua-special-tbl

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -362,8 +362,8 @@ cases there is the following agreement:
      converted to a dictionary `{'a': 42}`: non-string keys are ignored.
      Without `vim.type_idx` key tables with keys not fitting in 1., 2. or 3.
      are errors.
-   - `{[vim.type_idx]=vim.types.list}` is converted to an empty list. As well
-     as `{[vim.type_idx]=vim.types.list, [42]=1}`: integral keys that do not
+   - `{[vim.type_idx]=vim.types.array}` is converted to an empty list. As well
+     as `{[vim.type_idx]=vim.types.array, [42]=1}`: integral keys that do not
      form a 1-step sequence from 1 to N are ignored, as well as all
      non-integral keys.
 


### PR DESCRIPTION
Hi there! I spotted a minor docs typo in `:h lua-special-tbl` and figured I'd submit a quick PR.

I actually think `vim.types.list` would make more sense, since that's the name of the viml type we want a given table to treat it as during interop, but that isn't currently what it's called in the API. Though it might be worth adding an `vim.types.list = vim.types.array` alias at some point and eventually phasing out `.array`, but I'll leave that up to you actual nvim developers :wink: