### PR TITLE
vim-patch:8.1.{95,103,221,269,975,978,1403,1569,1856,1983,2014,2365,2406},8.2.{573,616,710,957,1020,1036,1038,1743,1842,1843}

### DIFF
--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -136,7 +136,7 @@ self[{n}]	Returns the buffer object for the number {n}.  The first number
 
 Methods:
 
-name		Returns the name of the buffer.
+name		Returns the full name of the buffer.
 number		Returns the number of the buffer.
 count		Returns the number of lines.
 length		Returns the number of lines.
@@ -172,6 +172,7 @@ height = {n}	Sets the window height to {n}.
 width		Returns the width of the window.
 width = {n}	Sets the window width to {n}.
 cursor		Returns a [row, col] array for the cursor position.
+		First line number is 1 and first column number is 0.
 cursor = [{row}, {col}]
 		Sets the cursor position to {row} and {col}.
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6929,8 +6929,9 @@ void ex_splitview(exarg_T *eap)
 {
   win_T       *old_curwin = curwin;
   char_u      *fname = NULL;
-
-
+  const bool use_tab = eap->cmdidx == CMD_tabedit
+    || eap->cmdidx == CMD_tabfind
+    || eap->cmdidx == CMD_tabnew;
 
   /* A ":split" in the quickfix window works like ":new".  Don't want two
    * quickfix windows.  But it's OK when doing ":tab split". */
@@ -6952,9 +6953,7 @@ void ex_splitview(exarg_T *eap)
   /*
    * Either open new tab page or split the window.
    */
-  if (eap->cmdidx == CMD_tabedit
-      || eap->cmdidx == CMD_tabfind
-      || eap->cmdidx == CMD_tabnew) {
+  if (use_tab) {
     if (win_new_tabpage(cmdmod.tab != 0 ? cmdmod.tab : eap->addr_count == 0
                         ? 0 : (int)eap->line2 + 1, eap->arg) != FAIL) {
       do_exedit(eap, old_curwin);

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -396,8 +396,7 @@ size_t spell_check(
   mi.mi_word = ptr;
   mi.mi_fend = ptr;
   if (spell_iswordp(mi.mi_fend, wp)) {
-    int prev_upper;
-    int this_upper;
+    bool this_upper = false;  // init for gcc
 
     if (use_camel_case) {
       c = PTR2CHAR(mi.mi_fend);
@@ -407,7 +406,7 @@ size_t spell_check(
     do {
       MB_PTR_ADV(mi.mi_fend);
       if (use_camel_case) {
-        prev_upper = this_upper;
+        const bool prev_upper = this_upper;
         c = PTR2CHAR(mi.mi_fend);
         this_upper = SPELL_ISUPPER(c);
         camel_case = !prev_upper && this_upper;

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -56,6 +56,9 @@ endfunc
 
 " Run "cmd".  Returns the job if using a job.
 func RunCommand(cmd)
+  " Running an external command can occasionally be slow or fail.
+  let g:test_is_flaky = 1
+
   let job = 0
   if has('job')
     let job = job_start(a:cmd, {"stoponexit": "hup"})

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -13,7 +13,6 @@ source test_ex_undo.vim
 source test_ex_z.vim
 source test_execute_func.vim
 source test_expand_func.vim
-source test_expr.vim
 source test_feedkeys.vim
 source test_filter_cmd.vim
 source test_filter_map.vim
@@ -50,6 +49,7 @@ source test_tagjump.vim
 source test_taglist.vim
 source test_true_false.vim
 source test_unlet.vim
+source test_version.vim
 source test_virtualedit.vim
 source test_window_cmd.vim
 source test_wnext.vim

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1559,3 +1559,23 @@ func Test_edit_is_a_directory()
 
   call delete(dirname, 'rf')
 endfunc
+
+func Test_edit_browse()
+  " in the GUI this opens a file picker, we only test the terminal behavior
+  CheckNotGui
+
+  " ":browse xxx" checks for the FileExplorer augroup and assumes editing "."
+  " works then.
+  augroup FileExplorer
+    au!
+  augroup END
+
+  " When the USE_FNAME_CASE is defined this used to cause a crash.
+  browse enew
+  bwipe!
+
+  browse split
+  bwipe!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_ruby.vim
+++ b/src/nvim/testdir/test_ruby.vim
@@ -4,42 +4,18 @@ if !has('ruby')
   finish
 end
 
+" Helper function as there is no builtin rubyeval() function similar
+" to perleval, luaevel() or pyeval().
+func RubyEval(ruby_expr)
+  let s = split(execute('ruby print ' . a:ruby_expr), "\n")
+  return (len(s) == 0) ? '' : s[-1]
+endfunc
+
 func Test_ruby_change_buffer()
   call setline(line('$'), ['1 line 1'])
   ruby Vim.command("normal /^1\n")
   ruby $curbuf.line = "1 changed line 1"
   call assert_equal('1 changed line 1', getline('$'))
-endfunc
-
-func Test_ruby_evaluate_list()
-  throw 'skipped: TODO: '
-  call setline(line('$'), ['2 line 2'])
-  ruby Vim.command("normal /^2\n")
-  let l = ["abc", "def"]
-  ruby << EOF
-  curline = $curbuf.line_number
-  l = Vim.evaluate("l");
-  $curbuf.append(curline, l.join("\n"))
-EOF
-  normal j
-  .rubydo $_ = $_.gsub(/\n/, '/')
-  call assert_equal('abc/def', getline('$'))
-endfunc
-
-func Test_ruby_evaluate_dict()
-  let d = {'a': 'foo', 'b': 123}
-  redir => l:out
-  ruby d = Vim.evaluate("d"); print d
-  redir END
-  call assert_equal(['{"a"=>"foo", "b"=>123}'], split(l:out, "\n"))
-endfunc
-
-func Test_ruby_evaluate_special_var()
-  let l = [v:true, v:false, v:null]
-  redir => l:out
-  ruby d = Vim.evaluate("l"); print d
-  redir END
-  call assert_equal(['[true, false, nil]'], split(l:out, "\n"))
 endfunc
 
 func Test_rubydo()
@@ -56,8 +32,7 @@ func Test_rubydo()
   call setline(1, ['one', 'two', 'three'])
   rubydo Vim.command("new")
   call assert_equal(wincount + 1, winnr('$'))
-  bwipe!
-  bwipe!
+  %bwipe!
 endfunc
 
 func Test_rubyfile()
@@ -75,8 +50,324 @@ func Test_set_cursor()
   normal gg
   rubydo $curwin.cursor = [1, 5]
   call assert_equal([1, 6], [line('.'), col('.')])
+  call assert_equal('[1, 5]', RubyEval('$curwin.cursor'))
 
   " Check that movement after setting cursor position keeps current column.
   normal j
   call assert_equal([2, 6], [line('.'), col('.')])
+  call assert_equal('[2, 5]', RubyEval('$curwin.cursor'))
+
+  " call assert_fails('ruby $curwin.cursor = [1]',
+  "      \           'ArgumentError: array length must be 2')
+  bwipe!
+endfunc
+
+" Test buffer.count and buffer.length (number of lines in buffer)
+func Test_buffer_count()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  call assert_equal('3', RubyEval('$curbuf.count'))
+  call assert_equal('3', RubyEval('$curbuf.length'))
+  bwipe!
+endfunc
+
+" Test buffer.name (buffer name)
+func Test_buffer_name()
+  new Xfoo
+  call assert_equal(expand('%:p'), RubyEval('$curbuf.name'))
+  bwipe
+  call assert_equal('', RubyEval('$curbuf.name'))
+endfunc
+
+" Test buffer.number (number of the buffer).
+func Test_buffer_number()
+  new
+  call assert_equal(string(bufnr('%')), RubyEval('$curbuf.number'))
+  new
+  call assert_equal(string(bufnr('%')), RubyEval('$curbuf.number'))
+
+  %bwipe
+endfunc
+
+" Test buffer.delete({n}) (delete line {n})
+func Test_buffer_delete()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  ruby $curbuf.delete(2)
+  call assert_equal(['one', 'three'], getline(1, '$'))
+
+  " call assert_fails('ruby $curbuf.delete(0)', 'IndexError: line number 0 out of range')
+  " call assert_fails('ruby $curbuf.delete(3)', 'IndexError: line number 3 out of range')
+  call assert_fails('ruby $curbuf.delete(3)', 'RuntimeError: Index out of bounds')
+
+  bwipe!
+endfunc
+
+" Test buffer.append({str}, str) (append line {str} after line {n})
+func Test_buffer_append()
+  new
+  ruby $curbuf.append(0, 'one')
+  ruby $curbuf.append(1, 'three')
+  ruby $curbuf.append(1, 'two')
+  ruby $curbuf.append(4, 'four')
+
+  call assert_equal(['one', 'two', 'three', '', 'four'], getline(1, '$'))
+
+  " call assert_fails('ruby $curbuf.append(-1, "x")',
+  "    \           'IndexError: line number -1 out of range')
+  call assert_fails('ruby $curbuf.append(-1, "x")',
+       \           'ArgumentError: Index out of bounds')
+  call assert_fails('ruby $curbuf.append(6, "x")',
+       \           'RuntimeError: Index out of bounds')
+
+  bwipe!
+endfunc
+
+" Test buffer.line (get or set the current line)
+func Test_buffer_line()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  2
+  call assert_equal('two', RubyEval('$curbuf.line'))
+
+  ruby $curbuf.line = 'TWO'
+  call assert_equal(['one', 'TWO', 'three'], getline(1, '$'))
+
+  bwipe!
+endfunc
+
+" Test buffer.line_number (get current line number)
+func Test_buffer_line_number()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  2
+  call assert_equal('2', RubyEval('$curbuf.line_number'))
+
+  bwipe!
+endfunc
+
+func Test_buffer_get()
+  new
+  call setline(1, ['one', 'two'])
+  call assert_equal('one', RubyEval('$curbuf[1]'))
+  call assert_equal('two', RubyEval('$curbuf[2]'))
+
+  " call assert_fails('ruby $curbuf[0]',
+  "     \           'IndexError: line number 0 out of range')
+  call assert_fails('ruby $curbuf[3]',
+       \           'RuntimeError: Index out of bounds')
+
+  bwipe!
+endfunc
+
+func Test_buffer_set()
+  new
+  call setline(1, ['one', 'two'])
+  ruby $curbuf[2] = 'TWO'
+  ruby $curbuf[1] = 'ONE'
+
+  " call assert_fails('ruby $curbuf[0] = "ZERO"',
+  "      \           'IndexError: line number 0 out of range')
+  " call assert_fails('ruby $curbuf[3] = "THREE"',
+  "      \           'IndexError: line number 3 out of range')
+  call assert_fails('ruby $curbuf[3] = "THREE"',
+        \           'RuntimeError: Index out of bounds')
+  bwipe!
+endfunc
+
+" Test window.width (get or set window height).
+func Test_window_height()
+  new
+
+  " Test setting window height
+  ruby $curwin.height = 2
+  call assert_equal(2, winheight(0))
+
+  " Test getting window height
+  call assert_equal('2', RubyEval('$curwin.height'))
+
+  bwipe
+endfunc
+
+" Test window.width (get or set window width).
+func Test_window_width()
+  vnew
+
+  " Test setting window width
+  ruby $curwin.width = 2
+  call assert_equal(2, winwidth(0))
+
+  " Test getting window width
+  call assert_equal('2', RubyEval('$curwin.width'))
+
+  bwipe
+endfunc
+
+" Test window.buffer (get buffer object of a window object).
+func Test_window_buffer()
+  new Xfoo1
+  new Xfoo2
+  ruby $b2 = $curwin.buffer
+  ruby $w2 = $curwin
+  wincmd j
+  ruby $b1 = $curwin.buffer
+  ruby $w1 = $curwin
+
+  " call assert_equal(RubyEval('$b1'), RubyEval('$w1.buffer'))
+  " call assert_equal(RubyEval('$b2'), RubyEval('$w2.buffer'))
+  call assert_equal(string(bufnr('Xfoo1')), RubyEval('$w1.buffer.number'))
+  call assert_equal(string(bufnr('Xfoo2')), RubyEval('$w2.buffer.number'))
+
+  ruby $b1, $w1, $b2, $w2 = nil
+  %bwipe
+endfunc
+
+" Test Vim::Window.current (get current window object)
+func Test_Vim_window_current()
+  let cw = RubyEval('$curwin')
+  " call assert_equal(cw, RubyEval('Vim::Window.current'))
+  call assert_match('^#<Neovim::Window:0x\x\+>$', cw)
+endfunc
+
+" Test Vim::Window.count (number of windows)
+func Test_Vim_window_count()
+  new Xfoo1
+  new Xfoo2
+  split
+  call assert_equal('4', RubyEval('Vim::Window.count'))
+  %bwipe
+  call assert_equal('1', RubyEval('Vim::Window.count'))
+endfunc
+
+" Test Vim::Window[n] (get window object of window n)
+func Test_Vim_window_get()
+  new Xfoo1
+  new Xfoo2
+  call assert_match('Xfoo2$', RubyEval('Vim::Window[0].buffer.name'))
+  wincmd j
+  call assert_match('Xfoo1$', RubyEval('Vim::Window[1].buffer.name'))
+  wincmd j
+  call assert_equal('',       RubyEval('Vim::Window[2].buffer.name'))
+  %bwipe
+endfunc
+
+" Test Vim::Buffer.current (return the buffer object of current buffer)
+func Test_Vim_buffer_current()
+  let cb = RubyEval('$curbuf')
+  " call assert_equal(cb, RubyEval('Vim::Buffer.current'))
+  call assert_match('^#<Neovim::Buffer:0x\x\+>$', cb)
+endfunc
+
+" Test Vim::Buffer:.count (return the number of buffers)
+func Test_Vim_buffer_count()
+  new Xfoo1
+  new Xfoo2
+  call assert_equal('3', RubyEval('Vim::Buffer.count'))
+  %bwipe
+  call assert_equal('1', RubyEval('Vim::Buffer.count'))
+endfunc
+
+" Test Vim::buffer[n] (return the buffer object of buffer number n)
+func Test_Vim_buffer_get()
+  new Xfoo1
+  new Xfoo2
+
+  " Index of Vim::Buffer[n] goes from 0 to the number of buffers.
+  call assert_equal('',       RubyEval('Vim::Buffer[0].name'))
+  call assert_match('Xfoo1$', RubyEval('Vim::Buffer[1].name'))
+  call assert_match('Xfoo2$', RubyEval('Vim::Buffer[2].name'))
+  call assert_fails('ruby print Vim::Buffer[3].name',
+        \           "NoMethodError: undefined method `name' for nil:NilClass")
+  %bwipe
+endfunc
+
+" Test Vim::command({cmd}) (execute a Ex command))
+" Test Vim::command({cmd})
+func Test_Vim_command()
+  new
+  call setline(1, ['one', 'two', 'three', 'four'])
+  ruby Vim::command('2,3d')
+  call assert_equal(['one', 'four'], getline(1, '$'))
+  bwipe!
+endfunc
+
+" Test Vim::set_option (set a vim option)
+func Test_Vim_set_option()
+  call assert_equal(0, &number)
+  ruby Vim::set_option('number')
+  call assert_equal(1, &number)
+  ruby Vim::set_option('nonumber')
+  call assert_equal(0, &number)
+endfunc
+
+func Test_Vim_evaluate()
+  call assert_equal('123',      RubyEval('Vim::evaluate("123")'))
+  " Vim::evaluate("123").class gives Integer or Fixnum depending
+  " on versions of Ruby.
+  call assert_match('^Integer\|Fixnum$', RubyEval('Vim::evaluate("123").class'))
+
+  call assert_equal('1.23',     RubyEval('Vim::evaluate("1.23")'))
+  call assert_equal('Float',    RubyEval('Vim::evaluate("1.23").class'))
+
+  call assert_equal('foo',      RubyEval('Vim::evaluate("\"foo\"")'))
+  call assert_equal('String',   RubyEval('Vim::evaluate("\"foo\"").class'))
+
+  call assert_equal('[1, 2]',   RubyEval('Vim::evaluate("[1, 2]")'))
+  call assert_equal('Array',    RubyEval('Vim::evaluate("[1, 2]").class'))
+
+  call assert_equal('{"1"=>2}', RubyEval('Vim::evaluate("{1:2}")'))
+  call assert_equal('Hash',     RubyEval('Vim::evaluate("{1:2}").class'))
+
+  call assert_equal('',         RubyEval('Vim::evaluate("v:null")'))
+  call assert_equal('NilClass', RubyEval('Vim::evaluate("v:null").class'))
+
+  " call assert_equal('',         RubyEval('Vim::evaluate("v:none")'))
+  " call assert_equal('NilClass', RubyEval('Vim::evaluate("v:none").class'))
+
+  call assert_equal('true',      RubyEval('Vim::evaluate("v:true")'))
+  call assert_equal('TrueClass', RubyEval('Vim::evaluate("v:true").class'))
+  call assert_equal('false',     RubyEval('Vim::evaluate("v:false")'))
+  call assert_equal('FalseClass',RubyEval('Vim::evaluate("v:false").class'))
+endfunc
+
+func Test_Vim_evaluate_list()
+  call setline(line('$'), ['2 line 2'])
+  ruby Vim.command("normal /^2\n")
+  let l = ["abc", "def"]
+  ruby << EOF
+  curline = $curbuf.line_number
+  l = Vim.evaluate("l");
+  $curbuf.append(curline, l.join("|"))
+EOF
+  normal j
+  .rubydo $_ = $_.gsub(/\|/, '/')
+  call assert_equal('abc/def', getline('$'))
+endfunc
+
+func Test_Vim_evaluate_dict()
+  let d = {'a': 'foo', 'b': 123}
+  redir => l:out
+  ruby d = Vim.evaluate("d"); print d
+  redir END
+  call assert_equal(['{"a"=>"foo", "b"=>123}'], split(l:out, "\n"))
+endfunc
+
+" Test Vim::message({msg}) (display message {msg})
+func Test_Vim_message()
+  throw 'skipped: TODO: '
+  ruby Vim::message('A message')
+  let messages = split(execute('message'), "\n")
+  call assert_equal('A message', messages[-1])
+endfunc
+
+func Test_print()
+  ruby print "Hello World!"
+  let messages = split(execute('message'), "\n")
+  call assert_equal('Hello World!', messages[-1])
+endfunc
+
+func Test_p()
+  ruby p 'Just a test'
+  let messages = split(execute('message'), "\n")
+  call assert_equal('"Just a test"', messages[-1])
 endfunc

--- a/src/nvim/testdir/test_ruby.vim
+++ b/src/nvim/testdir/test_ruby.vim
@@ -370,4 +370,17 @@ func Test_p()
   ruby p 'Just a test'
   let messages = split(execute('message'), "\n")
   call assert_equal('"Just a test"', messages[-1])
+
+  " Check return values of p method
+
+  call assert_equal('123', RubyEval('p(123)'))
+  call assert_equal('[1, 2, 3]', RubyEval('p(1, 2, 3)'))
+
+  " Avoid the "message maintainer" line.
+  let $LANG = ''
+  messages clear
+  call assert_equal('true', RubyEval('p() == nil'))
+
+  let messages = split(execute('message'), "\n")
+  call assert_equal(0, len(messages))
 endfunc

--- a/src/nvim/testdir/test_version.vim
+++ b/src/nvim/testdir/test_version.vim
@@ -1,0 +1,12 @@
+" Test :version Ex command
+
+func Test_version()
+  " version should always return the same string.
+  let v1 = execute('version')
+  let v2 = execute('version')
+  call assert_equal(v1, v2)
+
+  call assert_match("^\n\nNVIM v[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+.*", v1)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The review request is only for the `:version` patches because c6aa71605fac6fba19241f1ed11e706efeb26088 is incompatible with patch 8.1.0103. Patch 8.1.0103 makes the version string translatable because the version includes the text `compiled`.

I added `test_popupwin.vim` as a source of N/A patches in  https://github.com/neovim/neovim/wiki/Merging-patches-from-upstream-Vim#types-of-not-applicable-vim-patches.

I commented out some assertions for the perl and ruby tests. Some seem to depend on (undocumented) implementation details.