### PR TITLE
gen_ex_cmds: simplify writes to defsfile

### DIFF
--- a/src/nvim/generators/gen_ex_cmds.lua
+++ b/src/nvim/generators/gen_ex_cmds.lua
@@ -24,8 +24,6 @@ local defsfile = io.open(defsfname, 'w')
 
 local defs = require('ex_cmds')
 
-local first = true
-
 local byte_a = string.byte('a')
 local byte_z = string.byte('z')
 local a_to_z = byte_z - byte_a + 1
@@ -41,8 +39,7 @@ static const uint16_t cmdidxs1[%u] = {
 -- fit in a byte.
 local cmdidxs2_out = string.format([[
 static const char_u cmdidxs2[%u][%u] = {
-/*             a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p   q   r   s   t   u   v   w   x   y   z */
-
+  /*           a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p   q   r   s   t   u   v   w   x   y   z */
 ]], a_to_z, a_to_z)
 
 enumfile:write([[
@@ -50,21 +47,14 @@ typedef enum CMD_index {
 ]])
 defsfile:write(string.format([[
 static const int command_count = %u;
-]], #defs))
-defsfile:write(string.format([[
 static CommandDefinition cmdnames[%u] = {
-]], #defs))
+]], #defs, #defs))
 local cmds, cmdidxs1, cmdidxs2 = {}, {}, {}
 for _, cmd in ipairs(defs) do
   local enumname = cmd.enum or ('CMD_' .. cmd.command)
   local byte_cmd = cmd.command:sub(1, 1):byte()
   if byte_a <= byte_cmd and byte_cmd <= byte_z then
     table.insert(cmds, cmd.command)
-  end
-  if first then
-    first = false
-  else
-    defsfile:write(',\n')
   end
   enumfile:write('  ' .. enumname .. ',\n')
   defsfile:write(string.format([[
@@ -73,7 +63,8 @@ for _, cmd in ipairs(defs) do
     .cmd_func = (ex_func_T)&%s,
     .cmd_argt = %uL,
     .cmd_addr_type = %i
-  }]], enumname, cmd.command, cmd.func, cmd.flags, cmd.addr_type))
+  },
+]], enumname, cmd.command, cmd.func, cmd.flags, cmd.addr_type))
 end
 for i = #cmds, 1, -1 do
   local cmd = cmds[i]
@@ -104,15 +95,14 @@ for i = byte_a, byte_z do
   end
   cmdidxs2_out = cmdidxs2_out .. ' },\n'
 end
-defsfile:write([[
-
-};
-]])
 enumfile:write([[
   CMD_SIZE,
   CMD_USER = -1,
   CMD_USER_BUF = -2
 } cmdidx_T;
 ]])
-defsfile:write(cmdidxs1_out .. '};\n')
-defsfile:write(cmdidxs2_out .. '};\n')
+defsfile:write(string.format([[
+};
+%s};
+%s};
+]], cmdidxs1_out, cmdidxs2_out))


### PR DESCRIPTION
defsfile:write() is executed multiple times to append strings.
Some of these can be combined into a format string, wrapped in [[]].
It is easier to read and insert strings via "%s".

defsfile now has a trailing comma for "cmdnames" array
but it does not break the build.