### PR TITLE
vim-patch:8.2.1850

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -598,7 +598,9 @@ list_missing_previous_vimpatches_for_patch() {
 
   local -a missing_unique
   while IFS= read -r line; do
-    missing_unique+=("$line")
+    local commit="${line%%:*}"
+    local stat="$(git -C "${VIM_SOURCE_DIR}" show --format= --shortstat "${commit}")"
+    missing_unique+=("$(printf '%s\n  %s' "$line" "$stat")")
   done < <(printf '%s\n' "${missing_list[@]}" | sort -u)
 
   msg_err "$(printf '%d missing previous Vim patches:' ${#missing_unique[@]})"

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -597,9 +597,10 @@ list_missing_previous_vimpatches_for_patch() {
   set -u
 
   local -a missing_unique
+  local stat
   while IFS= read -r line; do
     local commit="${line%%:*}"
-    local stat="$(git -C "${VIM_SOURCE_DIR}" show --format= --shortstat "${commit}")"
+    stat="$(git -C "${VIM_SOURCE_DIR}" show --format= --shortstat "${commit}")"
     missing_unique+=("$(printf '%s\n  %s' "$line" "$stat")")
   done < <(printf '%s\n' "${missing_list[@]}" | sort -u)
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7668,7 +7668,7 @@ static int searchpair_cmn(typval_T *argvars, pos_T *match_pos)
   }
 
   retval = do_searchpair(
-      (char_u *)spat, (char_u *)mpat, (char_u *)epat, dir, skip,
+      spat, mpat, epat, dir, skip,
       flags, match_pos, lnum_stop, time_limit);
 
 theend:
@@ -7712,9 +7712,9 @@ static void f_searchpairpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  */
 long
 do_searchpair(
-    char_u *spat,          // start pattern
-    char_u *mpat,          // middle pattern
-    char_u *epat,          // end pattern
+    const char *spat,      // start pattern
+    const char *mpat,      // middle pattern
+    const char *epat,      // end pattern
     int dir,               // BACKWARD or FORWARD
     const typval_T *skip,  // skip expression
     int flags,             // SP_SETPCMARK and other SP_ values
@@ -7722,6 +7722,7 @@ do_searchpair(
     linenr_T lnum_stop,    // stop at this line if not zero
     long time_limit        // stop after this many msec
 )
+  FUNC_ATTR_NONNULL_ARG(1, 2, 3)
 {
   char_u      *save_cpo;
   char_u      *pat, *pat2 = NULL, *pat3 = NULL;
@@ -7736,8 +7737,6 @@ do_searchpair(
   bool use_skip = false;
   int options = SEARCH_KEEP;
   proftime_T tm;
-  size_t pat2_len;
-  size_t pat3_len;
 
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   save_cpo = p_cpo;
@@ -7748,9 +7747,9 @@ do_searchpair(
 
   // Make two search patterns: start/end (pat2, for in nested pairs) and
   // start/middle/end (pat3, for the top pair).
-  pat2_len = STRLEN(spat) + STRLEN(epat) + 17;
+  const size_t pat2_len = strlen(spat) + strlen(epat) + 17;
   pat2 = xmalloc(pat2_len);
-  pat3_len = STRLEN(spat) + STRLEN(mpat) + STRLEN(epat) + 25;
+  const size_t pat3_len = strlen(spat) + strlen(mpat) + strlen(epat) + 25;
   pat3 = xmalloc(pat3_len);
   snprintf((char *)pat2, pat2_len, "\\m\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat);
   if (*mpat == NUL) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3436,7 +3436,6 @@ current_tagblock(
   pos_T start_pos;
   pos_T end_pos;
   pos_T old_start, old_end;
-  char_u      *spat, *epat;
   char_u      *p;
   char_u      *cp;
   int len;
@@ -3490,9 +3489,9 @@ again:
    */
   for (long n = 0; n < count; n++) {
     if (do_searchpair(
-        (char_u *)"<[^ \t>/!]\\+\\%(\\_s\\_[^>]\\{-}[^/]>\\|$\\|\\_s\\=>\\)",
-        (char_u *)"",
-        (char_u *)"</[^>]*>", BACKWARD, NULL, 0,
+        "<[^ \t>/!]\\+\\%(\\_s\\_[^>]\\{-}[^/]>\\|$\\|\\_s\\=>\\)",
+        "",
+        "</[^>]*>", BACKWARD, NULL, 0,
         NULL, (linenr_T)0, 0L) <= 0) {
       curwin->w_cursor = old_pos;
       goto theend;
@@ -3514,12 +3513,15 @@ again:
     curwin->w_cursor = old_pos;
     goto theend;
   }
-  spat = xmalloc(len + 31);
-  epat = xmalloc(len + 9);
-  sprintf((char *)spat, "<%.*s\\>\\%%(\\s\\_[^>]\\{-}[^/]>\\|>\\)\\c", len, p);
-  sprintf((char *)epat, "</%.*s>\\c", len, p);
+  const size_t spat_len = len + 39;
+  char *const spat = xmalloc(spat_len);
+  const size_t epat_len = len + 9;
+  char *const epat = xmalloc(epat_len);
+  snprintf(spat, spat_len,
+           "<%.*s\\>\\%%(\\_s\\_[^>]\\{-}\\_[^/]>\\|\\_s\\?>\\)\\c", len, p);
+  snprintf(epat, epat_len, "</%.*s>\\c", len, p);
 
-  const int r = do_searchpair(spat, (char_u *)"", epat, FORWARD, NULL,
+  const int r = do_searchpair(spat, "", epat, FORWARD, NULL,
                               0, NULL, (linenr_T)0, 0L);
 
   xfree(spat);

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -152,6 +152,36 @@ func Test_string_html_objects()
   normal! dit
   call assert_equal('-<b></b>', getline('.'))
 
+  " copy the tag block from leading indentation before the start tag
+  let t = "    <b>\ntext\n</b>"
+  $put =t
+  normal! 2kvaty
+  call assert_equal("<b>\ntext\n</b>", @")
+
+  " copy the tag block from the end tag
+  let t = "<title>\nwelcome\n</title>"
+  $put =t
+  normal! $vaty
+  call assert_equal("<title>\nwelcome\n</title>", @")
+
+  " copy the outer tag block from a tag without an end tag
+  let t = "<html>\n<title>welcome\n</html>"
+  $put =t
+  normal! k$vaty
+  call assert_equal("<html>\n<title>welcome\n</html>", @")
+
+  " nested tag that has < in a different line from >
+  let t = "<div><div\n></div></div>"
+  $put =t
+  normal! k0vaty
+  call assert_equal("<div><div\n></div></div>", @")
+
+  " nested tag with attribute that has < in a different line from >
+  let t = "<div><div\nattr=\"attr\"\n></div></div>"
+  $put =t
+  normal! 2k0vaty
+  call assert_equal("<div><div\nattr=\"attr\"\n></div></div>", @")
+
   set quoteescape&
   enew!
 endfunc


### PR DESCRIPTION
vim-patch:8.2.1850: "vat" does not select tags correctly over line break

Problem:    "vat" does not select tags correctly over line break.
Solution:   Adjust the search pattern. (Aufar Gilbran, closes vim/vim#7136)
https://github.com/vim/vim/commit/a604ccc959c3bff88d3d5bc3c965819fc326d239

Use 'const char*' for spat,mpat,epat params of do_searchpair()
to reduce (char_u *) casts.