### PR TITLE
vim-patch:8.1.{2141,2419}

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1886,6 +1886,7 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
   // wait-return prompt later.  Needed when scrolling, resetting
   // need_wait_return after some prompt, and then outputting something
   // without scrolling
+  // Not needed when only using CR to move the cursor.
   bool overflow = false;
   if (ui_has(kUIMessages)) {
     int count = msg_ext_visible + (msg_ext_overwrite ? 0 : 1);
@@ -1897,7 +1898,7 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
     overflow = msg_scrolled != 0;
   }
 
-  if (overflow && !msg_scrolled_ign) {
+  if (overflow && !msg_scrolled_ign && strcmp(str, "\r") != 0) {
     need_wait_return = true;
   }
   msg_didany = true;  // remember that something was outputted

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2000,7 +2000,7 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr,
                               || (*s == TAB && msg_col <= 7)
                               || (utf_ptr2cells(s) > 1
                                   && msg_col <= 2))
-                           : (msg_col + t_col >= Columns - 1
+                           : ((*s != '\r' && msg_col + t_col >= Columns - 1)
                               || (*s == TAB
                                   && msg_col + t_col >= ((Columns - 1) & ~7))
                               || (utf_ptr2cells(s) > 1

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -185,6 +185,23 @@ func Test_scroll_CursorLineNr_update()
   call delete(filename)
 endfunc
 
+" check a long file name does not result in the hit-enter prompt
+func Test_edit_long_file_name()
+  CheckScreendump
+
+  let longName = 'x'->repeat(&columns)
+  call writefile([], longName)
+  let buf = RunVimInTerminal('-N -u NONE ' .. longName, #{rows: 8})
+
+  call VerifyScreenDump(buf, 'Test_long_file_name_1', {})
+
+  call term_sendkeys(buf, ":q\<cr>")
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete(longName)
+endfunc
+
 " Test for scrolling that modifies buffer during visual block
 func Test_visual_block_scroll()
   " See test/functional/legacy/visual_mode_spec.lua


### PR DESCRIPTION
Cherry-picked patch 8.1.2419 from https://github.com/neovim/neovim/pull/13027.

@Happy-Dude I can merge a separate PR with only patches 8.1.2141 and 8.1.2419 since you worked on them before me. There doesn't seem to be regressions since the tests pass.