### PR TITLE
lsp: Fix "client has shut down" errors during initializing

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -488,8 +488,8 @@ get_active_clients()                            *vim.lsp.get_active_clients()*
                     Table of |vim.lsp.client| objects
 
 get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
-                Gets an active client by id, or nil if the id is invalid or
-                the client is not yet initialized.
+		Gets a client by id, or nil if the id is invalid.
+		The returned client may not yet be fully initialized.
 
                 Parameters: ~
                     {client_id}  client id number

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -397,9 +397,8 @@ end
 --@param trace:  "off" | "messages" | "verbose" | nil passed directly to the language
 --- server in the initialize request. Invalid/empty values will default to "off"
 ---
---@returns Client id. |vim.lsp.get_client_by_id()| Note: client is only
---- available after it has been initialized, which may happen after a small
---- delay (or never if there is an error). Use `on_init` to do any actions once
+--@returns Client id. |vim.lsp.get_client_by_id()| Note: client may not be
+--- fully initialized. Use `on_init` to do any actions once
 --- the client has been initialized.
 function lsp.start_client(config)
   local cleaned_config = validate_client_config(config)
@@ -910,14 +909,14 @@ function lsp.buf_is_attached(bufnr, client_id)
   return (all_buffer_active_clients[bufnr] or {})[client_id] == true
 end
 
---- Gets an active client by id, or nil if the id is invalid or the
---- client is not yet initialized.
----
+--- Gets a client by id, or nil if the id is invalid.
+--- The returned client may not yet be fully initialized.
+--
 --@param client_id client id number
 ---
 --@returns |vim.lsp.client| object, or nil
 function lsp.get_client_by_id(client_id)
-  return active_clients[client_id]
+  return active_clients[client_id] or uninitialized_clients[client_id]
 end
 
 --- Stops a client(s).


### PR DESCRIPTION
Language servers can already send log messages to the client while the
server is still being initialized.

This currently leads to "client has shut down" messages which are
confusing to the user as the server is properly starting.

To fix this, this changes the `get_client_by_id` method to also return a
client if it is still initializing.