### PR TITLE
vim-patch:8.1.1056: no eval function for Ruby 

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -116,7 +116,7 @@ if (-not $NoTests) {
   python3 -c "import pynvim; print(str(pynvim))" ; exitIfFailed
 
   $env:PATH = "C:\Ruby24\bin;$env:PATH"
-  gem.cmd install neovim
+  gem.cmd install --pre neovim
   Get-Command -CommandType Application neovim-ruby-host.bat
 
   npm.cmd install -g neovim

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -19,7 +19,7 @@ echo "Install neovim module for Python 2."
 CC=cc python2 -m pip -q install --user --upgrade pynvim
 
 echo "Install neovim RubyGem."
-gem install --no-document --version ">= 0.8.0" neovim
+gem install --no-document --pre neovim
 
 echo "Install neovim npm package"
 source ~/.nvm/nvm.sh

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2336,6 +2336,7 @@ repeat({expr}, {count})		String	repeat {expr} {count} times
 resolve({filename})		String	get filename a shortcut points to
 reverse({list})			List	reverse {list} in-place
 round({expr})			Float	round off {expr}
+rubyeval({expr})		any	evaluate |Ruby| expression
 rpcnotify({channel}, {event}[, {args}...])
 				Sends an |RPC| notification to {channel}
 rpcrequest({channel}, {method}[, {args}...])
@@ -7069,6 +7070,17 @@ rpcstart({prog}[, {argv}])					*rpcstart()*
 			:let id = rpcstart('prog', ['arg1', 'arg2'])
 <		with >
 			:let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+
+rubyeval({expr})					*rubyeval()*
+		Evaluate Ruby expression {expr} and return its result
+		converted to Vim data structures.
+		Numbers, floats and strings are returned as they are (strings
+		are copied though).
+		Arrays are represented as Vim |List| type.
+		Hashes are represented as Vim |Dictionary| type.
+		Other objects are represented as strings resulted from their
+		"Object#to_s" method.
+		{only available when compiled with the |+ruby| feature}
 
 screenattr({row}, {col})					*screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -185,4 +185,13 @@ $curwin		The current window object.
 $curbuf		The current buffer object.
 
 ==============================================================================
+6. rubyeval() Vim function				*ruby-rubyeval*
+
+To facilitate bi-directional interface, you can use |rubyeval()| function to
+evaluate Ruby expressions and pass their values to Vim script.
+
+The Ruby value "true", "false" and "nil" are converted to v:true, v:false and
+v:null, respectively.
+
+==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -275,6 +275,7 @@ return {
     rpcrequest={args=varargs(2)},
     rpcstart={args={1, 2}},
     rpcstop={args=1},
+    rubyeval={args=1},
     screenattr={args=2},
     screenchar={args=2},
     screencol={},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6381,6 +6381,12 @@ static void f_perleval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   script_host_eval("perl", argvars, rettv);
 }
 
+// "rubyeval()" function
+static void f_rubyeval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  script_host_eval("ruby", argvars, rettv);
+}
+
 /*
  * "range()" function
  */

--- a/src/nvim/testdir/test_ruby.vim
+++ b/src/nvim/testdir/test_ruby.vim
@@ -4,13 +4,6 @@ if !has('ruby')
   finish
 end
 
-" Helper function as there is no builtin rubyeval() function similar
-" to perleval, luaevel() or pyeval().
-func RubyEval(ruby_expr)
-  let s = split(execute('ruby print ' . a:ruby_expr), "\n")
-  return (len(s) == 0) ? '' : s[-1]
-endfunc
-
 func Test_ruby_change_buffer()
   call setline(line('$'), ['1 line 1'])
   ruby Vim.command("normal /^1\n")
@@ -50,12 +43,12 @@ func Test_set_cursor()
   normal gg
   rubydo $curwin.cursor = [1, 5]
   call assert_equal([1, 6], [line('.'), col('.')])
-  call assert_equal('[1, 5]', RubyEval('$curwin.cursor'))
+  call assert_equal([1, 5], rubyeval('$curwin.cursor'))
 
   " Check that movement after setting cursor position keeps current column.
   normal j
   call assert_equal([2, 6], [line('.'), col('.')])
-  call assert_equal('[2, 5]', RubyEval('$curwin.cursor'))
+  call assert_equal([2, 5], rubyeval('$curwin.cursor'))
 
   " call assert_fails('ruby $curwin.cursor = [1]',
   "      \           'ArgumentError: array length must be 2')
@@ -66,25 +59,25 @@ endfunc
 func Test_buffer_count()
   new
   call setline(1, ['one', 'two', 'three'])
-  call assert_equal('3', RubyEval('$curbuf.count'))
-  call assert_equal('3', RubyEval('$curbuf.length'))
+  call assert_equal(3, rubyeval('$curbuf.count'))
+  call assert_equal(3, rubyeval('$curbuf.length'))
   bwipe!
 endfunc
 
 " Test buffer.name (buffer name)
 func Test_buffer_name()
   new Xfoo
-  call assert_equal(expand('%:p'), RubyEval('$curbuf.name'))
+  call assert_equal(expand('%:p'), rubyeval('$curbuf.name'))
   bwipe
-  call assert_equal('', RubyEval('$curbuf.name'))
+  call assert_equal('',     rubyeval('$curbuf.name'))
 endfunc
 
 " Test buffer.number (number of the buffer).
 func Test_buffer_number()
   new
-  call assert_equal(string(bufnr('%')), RubyEval('$curbuf.number'))
+  call assert_equal(bufnr('%'), rubyeval('$curbuf.number'))
   new
-  call assert_equal(string(bufnr('%')), RubyEval('$curbuf.number'))
+  call assert_equal(bufnr('%'), rubyeval('$curbuf.number'))
 
   %bwipe
 endfunc
@@ -128,7 +121,7 @@ func Test_buffer_line()
   new
   call setline(1, ['one', 'two', 'three'])
   2
-  call assert_equal('two', RubyEval('$curbuf.line'))
+  call assert_equal('two', rubyeval('$curbuf.line'))
 
   ruby $curbuf.line = 'TWO'
   call assert_equal(['one', 'TWO', 'three'], getline(1, '$'))
@@ -141,7 +134,7 @@ func Test_buffer_line_number()
   new
   call setline(1, ['one', 'two', 'three'])
   2
-  call assert_equal('2', RubyEval('$curbuf.line_number'))
+  call assert_equal(2, rubyeval('$curbuf.line_number'))
 
   bwipe!
 endfunc
@@ -149,8 +142,8 @@ endfunc
 func Test_buffer_get()
   new
   call setline(1, ['one', 'two'])
-  call assert_equal('one', RubyEval('$curbuf[1]'))
-  call assert_equal('two', RubyEval('$curbuf[2]'))
+  call assert_equal('one', rubyeval('$curbuf[1]'))
+  call assert_equal('two', rubyeval('$curbuf[2]'))
 
   " call assert_fails('ruby $curbuf[0]',
   "     \           'IndexError: line number 0 out of range')
@@ -184,7 +177,7 @@ func Test_window_height()
   call assert_equal(2, winheight(0))
 
   " Test getting window height
-  call assert_equal('2', RubyEval('$curwin.height'))
+  call assert_equal(2, rubyeval('$curwin.height'))
 
   bwipe
 endfunc
@@ -198,7 +191,7 @@ func Test_window_width()
   call assert_equal(2, winwidth(0))
 
   " Test getting window width
-  call assert_equal('2', RubyEval('$curwin.width'))
+  call assert_equal(2, rubyeval('$curwin.width'))
 
   bwipe
 endfunc
@@ -213,10 +206,10 @@ func Test_window_buffer()
   ruby $b1 = $curwin.buffer
   ruby $w1 = $curwin
 
-  " call assert_equal(RubyEval('$b1'), RubyEval('$w1.buffer'))
-  " call assert_equal(RubyEval('$b2'), RubyEval('$w2.buffer'))
-  call assert_equal(string(bufnr('Xfoo1')), RubyEval('$w1.buffer.number'))
-  call assert_equal(string(bufnr('Xfoo2')), RubyEval('$w2.buffer.number'))
+  " call assert_equal(rubyeval('$b1'), rubyeval('$w1.buffer'))
+  " call assert_equal(rubyeval('$b2'), rubyeval('$w2.buffer'))
+  call assert_equal(bufnr('Xfoo1'), rubyeval('$w1.buffer.number'))
+  call assert_equal(bufnr('Xfoo2'), rubyeval('$w2.buffer.number'))
 
   ruby $b1, $w1, $b2, $w2 = nil
   %bwipe
@@ -224,8 +217,8 @@ endfunc
 
 " Test Vim::Window.current (get current window object)
 func Test_Vim_window_current()
-  let cw = RubyEval('$curwin')
-  " call assert_equal(cw, RubyEval('Vim::Window.current'))
+  let cw = rubyeval('$curwin.to_s')
+  " call assert_equal(cw, rubyeval('Vim::Window.current'))
   call assert_match('^#<Neovim::Window:0x\x\+>$', cw)
 endfunc
 
@@ -234,27 +227,27 @@ func Test_Vim_window_count()
   new Xfoo1
   new Xfoo2
   split
-  call assert_equal('4', RubyEval('Vim::Window.count'))
+  call assert_equal(4, rubyeval('Vim::Window.count'))
   %bwipe
-  call assert_equal('1', RubyEval('Vim::Window.count'))
+  call assert_equal(1, rubyeval('Vim::Window.count'))
 endfunc
 
 " Test Vim::Window[n] (get window object of window n)
 func Test_Vim_window_get()
   new Xfoo1
   new Xfoo2
-  call assert_match('Xfoo2$', RubyEval('Vim::Window[0].buffer.name'))
+  call assert_match('Xfoo2$', rubyeval('Vim::Window[0].buffer.name'))
   wincmd j
-  call assert_match('Xfoo1$', RubyEval('Vim::Window[1].buffer.name'))
+  call assert_match('Xfoo1$', rubyeval('Vim::Window[1].buffer.name'))
   wincmd j
-  call assert_equal('',       RubyEval('Vim::Window[2].buffer.name'))
+  call assert_equal('',       rubyeval('Vim::Window[2].buffer.name'))
   %bwipe
 endfunc
 
 " Test Vim::Buffer.current (return the buffer object of current buffer)
 func Test_Vim_buffer_current()
-  let cb = RubyEval('$curbuf')
-  " call assert_equal(cb, RubyEval('Vim::Buffer.current'))
+  let cb = rubyeval('$curbuf.to_s')
+  " call assert_equal(cb, rubyeval('Vim::Buffer.current'))
   call assert_match('^#<Neovim::Buffer:0x\x\+>$', cb)
 endfunc
 
@@ -262,9 +255,9 @@ endfunc
 func Test_Vim_buffer_count()
   new Xfoo1
   new Xfoo2
-  call assert_equal('3', RubyEval('Vim::Buffer.count'))
+  call assert_equal(3, rubyeval('Vim::Buffer.count'))
   %bwipe
-  call assert_equal('1', RubyEval('Vim::Buffer.count'))
+  call assert_equal(1, rubyeval('Vim::Buffer.count'))
 endfunc
 
 " Test Vim::buffer[n] (return the buffer object of buffer number n)
@@ -273,9 +266,9 @@ func Test_Vim_buffer_get()
   new Xfoo2
 
   " Index of Vim::Buffer[n] goes from 0 to the number of buffers.
-  call assert_equal('',       RubyEval('Vim::Buffer[0].name'))
-  call assert_match('Xfoo1$', RubyEval('Vim::Buffer[1].name'))
-  call assert_match('Xfoo2$', RubyEval('Vim::Buffer[2].name'))
+  call assert_equal('',       rubyeval('Vim::Buffer[0].name'))
+  call assert_match('Xfoo1$', rubyeval('Vim::Buffer[1].name'))
+  call assert_match('Xfoo2$', rubyeval('Vim::Buffer[2].name'))
   call assert_fails('ruby print Vim::Buffer[3].name',
         \           "NoMethodError: undefined method `name' for nil:NilClass")
   %bwipe
@@ -301,33 +294,33 @@ func Test_Vim_set_option()
 endfunc
 
 func Test_Vim_evaluate()
-  call assert_equal('123',      RubyEval('Vim::evaluate("123")'))
+  call assert_equal(123,        rubyeval('Vim::evaluate("123")'))
   " Vim::evaluate("123").class gives Integer or Fixnum depending
   " on versions of Ruby.
-  call assert_match('^Integer\|Fixnum$', RubyEval('Vim::evaluate("123").class'))
+  call assert_match('^Integer\|Fixnum$', rubyeval('Vim::evaluate("123").class'))
 
-  call assert_equal('1.23',     RubyEval('Vim::evaluate("1.23")'))
-  call assert_equal('Float',    RubyEval('Vim::evaluate("1.23").class'))
+  call assert_equal(1.23,       rubyeval('Vim::evaluate("1.23")'))
+  call assert_equal('Float',    rubyeval('Vim::evaluate("1.23").class'))
 
-  call assert_equal('foo',      RubyEval('Vim::evaluate("\"foo\"")'))
-  call assert_equal('String',   RubyEval('Vim::evaluate("\"foo\"").class'))
+  call assert_equal('foo',      rubyeval('Vim::evaluate("\"foo\"")'))
+  call assert_equal('String',   rubyeval('Vim::evaluate("\"foo\"").class'))
 
-  call assert_equal('[1, 2]',   RubyEval('Vim::evaluate("[1, 2]")'))
-  call assert_equal('Array',    RubyEval('Vim::evaluate("[1, 2]").class'))
+  call assert_equal([1, 2],     rubyeval('Vim::evaluate("[1, 2]")'))
+  call assert_equal('Array',    rubyeval('Vim::evaluate("[1, 2]").class'))
 
-  call assert_equal('{"1"=>2}', RubyEval('Vim::evaluate("{1:2}")'))
-  call assert_equal('Hash',     RubyEval('Vim::evaluate("{1:2}").class'))
+  call assert_equal({'1': 2},   rubyeval('Vim::evaluate("{1:2}")'))
+  call assert_equal('Hash',     rubyeval('Vim::evaluate("{1:2}").class'))
 
-  call assert_equal('',         RubyEval('Vim::evaluate("v:null")'))
-  call assert_equal('NilClass', RubyEval('Vim::evaluate("v:null").class'))
+  call assert_equal(v:null,     rubyeval('Vim::evaluate("v:null")'))
+  call assert_equal('NilClass', rubyeval('Vim::evaluate("v:null").class'))
 
-  " call assert_equal('',         RubyEval('Vim::evaluate("v:none")'))
-  " call assert_equal('NilClass', RubyEval('Vim::evaluate("v:none").class'))
+  " call assert_equal(v:null,     rubyeval('Vim::evaluate("v:none")'))
+  " call assert_equal('NilClass', rubyeval('Vim::evaluate("v:none").class'))
 
-  call assert_equal('true',      RubyEval('Vim::evaluate("v:true")'))
-  call assert_equal('TrueClass', RubyEval('Vim::evaluate("v:true").class'))
-  call assert_equal('false',     RubyEval('Vim::evaluate("v:false")'))
-  call assert_equal('FalseClass',RubyEval('Vim::evaluate("v:false").class'))
+  call assert_equal(v:true,      rubyeval('Vim::evaluate("v:true")'))
+  call assert_equal('TrueClass', rubyeval('Vim::evaluate("v:true").class'))
+  call assert_equal(v:false,     rubyeval('Vim::evaluate("v:false")'))
+  call assert_equal('FalseClass',rubyeval('Vim::evaluate("v:false").class'))
 endfunc
 
 func Test_Vim_evaluate_list()
@@ -361,9 +354,22 @@ func Test_Vim_message()
 endfunc
 
 func Test_print()
-  ruby print "Hello World!"
-  let messages = split(execute('message'), "\n")
-  call assert_equal('Hello World!', messages[-1])
+  func RubyPrint(expr)
+    return trim(execute('ruby print ' . a:expr))
+  endfunc
+
+  call assert_equal('123', RubyPrint('123'))
+  call assert_equal('1.23', RubyPrint('1.23'))
+  call assert_equal('Hello World!', RubyPrint('"Hello World!"'))
+  call assert_equal('[1, 2]', RubyPrint('[1, 2]'))
+  call assert_equal('{"k1"=>"v1", "k2"=>"v2"}', RubyPrint('({"k1" => "v1", "k2" => "v2"})'))
+  call assert_equal('true', RubyPrint('true'))
+  call assert_equal('false', RubyPrint('false'))
+  call assert_equal('', RubyPrint('nil'))
+  call assert_match('Vim', RubyPrint('Vim'))
+  call assert_match('Module', RubyPrint('Vim.class'))
+
+  delfunc RubyPrint
 endfunc
 
 func Test_p()
@@ -373,13 +379,13 @@ func Test_p()
 
   " Check return values of p method
 
-  call assert_equal('123', RubyEval('p(123)'))
-  call assert_equal('[1, 2, 3]', RubyEval('p(1, 2, 3)'))
+  call assert_equal(123, rubyeval('p(123)'))
+  call assert_equal([1, 2, 3], rubyeval('p(1, 2, 3)'))
 
   " Avoid the "message maintainer" line.
   let $LANG = ''
   messages clear
-  call assert_equal('true', RubyEval('p() == nil'))
+  call assert_equal(v:true, rubyeval('p() == nil'))
 
   let messages = split(execute('message'), "\n")
   call assert_equal(0, len(messages))

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -5,6 +5,7 @@ local command = helpers.command
 local curbufmeths = helpers.curbufmeths
 local eq = helpers.eq
 local eval = helpers.eval
+local exc_exec = helpers.exc_exec
 local expect = helpers.expect
 local feed = helpers.feed
 local feed_command = helpers.feed_command
@@ -107,5 +108,26 @@ describe('ruby provider', function()
     command([=[autocmd BufDelete * ruby VIM::evaluate('expand("<afile>")')]=])
     feed_command('help help')
     eq(2, eval('1+1'))  -- Still alive?
+  end)
+end)
+
+describe('rubyeval()', function()
+  it('evaluates ruby objects', function()
+    eq({1, 2, {['key'] = 'val'}}, funcs.rubyeval('[1, 2, {key: "val"}]'))
+  end)
+
+  it('returns nil for empty strings', function()
+    eq(helpers.NIL, funcs.rubyeval(''))
+  end)
+
+  it('errors out when given non-string', function()
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(10)'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(v:_null_dict)'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(v:_null_list)'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(0.0)'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(function("tr"))'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(v:true)'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(v:false)'))
+    eq('Vim(call):E474: Invalid argument', exc_exec('call rubyeval(v:null)'))
   end)
 end)


### PR DESCRIPTION
This parallels https://github.com/vim/vim/commit/e99be0e6d28fad96efd2b2be23fa38e7559e80e1

We have a bit of a chicken/egg problem here, because this requires the `ruby_eval` RPC from https://github.com/neovim/neovim-ruby/pull/69, which in turn requires the `:rubyeval()` function from nvim for its acceptance tests.