### PR TITLE
fix(input): resolve isolated (non-ALT/META) mappings

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1000,6 +1000,18 @@ void ins_char_typebuf(int c)
     buf[3] = NUL;
   } else {
     buf[utf_char2bytes(c, buf)] = NUL;
+    char_u *p = buf;
+    while (*p) {
+      if ((uint8_t)(*p) == CSI || (uint8_t)(*p) == K_SPECIAL) {
+        bool is_csi = (uint8_t)(*p) == CSI;
+        memmove(p + 3, p + 1, STRLEN(p + 1) + 1);
+        *p++ = K_SPECIAL;
+        *p++ = is_csi ? KS_EXTRA : KS_SPECIAL;
+        *p++ = is_csi ? KE_CSI : KE_FILLER;
+      } else {
+        p++;
+      }
+    }
   }
   (void)ins_typebuf(buf, KeyNoremap, 0, !KeyTyped, cmd_silent);
 }
@@ -1573,9 +1585,9 @@ int vgetc(void)
       if (!no_mapping && KeyTyped
           && (mod_mask == MOD_MASK_ALT || mod_mask == MOD_MASK_META)) {
         mod_mask = 0;
-        stuffcharReadbuff(c);
-        u_sync(false);
-        c = ESC;
+        ins_char_typebuf(c);
+        ins_char_typebuf(ESC);
+        continue;
       }
 
       break;

--- a/test/functional/editor/meta_key_spec.lua
+++ b/test/functional/editor/meta_key_spec.lua
@@ -11,15 +11,20 @@ describe('meta-keys #8226 #13042', function()
   end)
 
   it('ALT/META, normal-mode', function()
-    -- Unmapped ALT-chords behave as ESC+c
+    -- Unmapped ALT-chord behaves as ESC+c.
     insert('hello')
     feed('0<A-x><M-x>')
     expect('llo')
+    -- Unmapped ALT-chord resolves isolated (non-ALT) ESC mapping. #13086 #15869
+    command('nnoremap <ESC> A<lt>ESC><Esc>')
+    command('nnoremap ; A;<Esc>')
+    feed('<A-;><M-;>')
+    expect('llo<ESC>;<ESC>;')
     -- Mapped ALT-chord behaves as mapped.
     command('nnoremap <M-l> Ameta-l<Esc>')
     command('nnoremap <A-j> Aalt-j<Esc>')
     feed('<A-j><M-l>')
-    expect('lloalt-jmeta-l')
+    expect('llo<ESC>;<ESC>;alt-jmeta-l')
   end)
 
   it('ALT/META, visual-mode', function()
@@ -27,11 +32,15 @@ describe('meta-keys #8226 #13042', function()
     insert('peaches')
     feed('viw<A-x>viw<M-x>')
     expect('peach')
+    -- Unmapped ALT-chord resolves isolated (non-ALT) ESC mapping. #13086 #15869
+    command('vnoremap <ESC> A<lt>ESC>')
+    feed('viw<A-;><ESC>viw<M-;><ESC>')
+    expect('peach<ESC>;<ESC>;')
     -- Mapped ALT-chord behaves as mapped.
     command('vnoremap <M-l> Ameta-l<Esc>')
     command('vnoremap <A-j> Aalt-j<Esc>')
     feed('viw<A-j>viw<M-l>')
-    expect('peachalt-jmeta-l')
+    expect('peach<ESC>;<ESC>;alt-jmeta-l')
   end)
 
   it('ALT/META insert-mode', function()


### PR DESCRIPTION
Keys modified by Alt/Meta are now treated as ESC+c when not mapped by #13042. However, the mapping between ESC and c itself was not resolved. This behavior is especially confusing for the TUI. This will change it to resolve these mappings.

fixes #13086
fixes #15869