### PR TITLE
Fix case where active_signature == vim.NIL

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -492,7 +492,10 @@ function M.convert_signature_help_to_markdown_lines(signature_help)
   --=== 0`. Whenever possible implementors should make an active decision about
   --the active signature and shouldn't rely on a default value.
   local contents = {}
-  local active_signature = signature_help.activeSignature or 0
+  local active_signature = signature_help.activeSignature
+  if active_signature == vim.NIL or active_signature == nil then
+    active_signature = 0
+  end
   -- If the activeSignature is not inside the valid range, then clip it.
   if active_signature >= #signature_help.signatures then
     active_signature = 0


### PR DESCRIPTION
I was experiencing this error using the pyright language server on a python file upon triggering the signature.

```
if __name__ == "__main__":
    import pdb
    pdb.set_trace(
```
```
Error executing vim.schedule lua callback: ...m-nightly-master/share/nvim/runtime/lua/vim/lsp/util.lua:497: attempt to compare number with userdata
```

Adding this check short circuits the comparison of active_signature (vim.NIL) with #signature_help.signatures (int)