### PR TITLE
vim-patch:8.1.{929,1535,1536,1604,1668,1935,2347},8.2.{351,752,1087,1804,1863}

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6936,7 +6936,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
 
     ptrdiff_t len = (ptrdiff_t)strlen(p);
-    if (len > 0 && after_pathsep(p, p + len)) {
+    if (len > 1 && after_pathsep(p, p + len)) {
       has_trailing_pathsep = true;
       p[len - 1] = NUL;  // The trailing slash breaks readlink().
     }

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -214,7 +214,7 @@ func Test_strftime()
   endif
 endfunc
 
-func Test_resolve()
+func Test_resolve_unix()
   if !has('unix')
     return
   endif
@@ -258,6 +258,8 @@ func Test_resolve()
   call assert_equal('Xlink2', resolve('Xlink1'))
   call assert_equal('./Xlink2', resolve('./Xlink1'))
   call delete('Xlink1')
+
+  call assert_equal('/', resolve('/'))
 endfunc
 
 func Test_simplify()


### PR DESCRIPTION
vim-patch:8.2.1804: resolve('/') returns an empty string

Problem:    resolve('/') returns an empty string.
Solution:   Don't remove single slash. (closes vim/vim#7074)
https://github.com/vim/vim/commit/50c4e9e08fb0981892e33afb9fe3751aa6df1fa4

Cherry-pick the test rename from Test_resolve() to Test_resolve_unix()
from patch 8.1.0894.

N/A patches for version.c:

vim-patch:8.1.0929: no error when requesting ConPTY but it's not available

Problem:    No error when requesting ConPTY but it's not available.
Solution:   Add an error message. (Hirohito Higashi, closes vim/vim#3967)
https://github.com/vim/vim/commit/5acd9872580a12ca1138275bf65d1cb9349e2a53

vim-patch:8.1.1535: popup select test fails on Mac

Problem:    Popup select test fails on Mac.
Solution:   Skip test if clipboard feature not available.
https://github.com/vim/vim/commit/650a63748c349bbb60adb912273e9bedd2b677c5

vim-patch:8.1.1536: popup select test still fails on Mac

Problem:    Popup select test still fails on Mac.
Solution:   Set 'clipboard' to "autoselect"
https://github.com/vim/vim/commit/1755ec4278ee6dccdbb8030fd5a4cf6054211f81

vim-patch:8.1.1604: popup window scroll test is flaky

Problem:    Popup window scroll test is flaky.
Solution:   Add a delay between scroll events.
https://github.com/vim/vim/commit/13b47c37a650ab6045680a9e5513ef6ad71ee93f

vim-patch:8.1.1668: popup window test is a bit flaky on some systems

Problem:    Popup window test is a bit flaky on some systems.
Solution:   Clear the command line. (Naruhiko Nishino, closes vim/vim#4656)
https://github.com/vim/vim/commit/8ccabf624ef4eb7ebe3e4d52449bc0bc545810f2

vim-patch:8.1.1935: test for text property popup window is flaky

Problem:    Test for text property popup window is flaky.
Solution:   Remove the undo message
https://github.com/vim/vim/commit/57441d6fa0ba44be8dc16d6469a8659afc2f3b81

vim-patch:8.1.2347: MacOS: build fails

Problem:    MacOS: build fails.
Solution:   Don't define _XOPEN_SOURCE for Mac.
https://github.com/vim/vim/commit/84f903326d44db9b75fc3a39d4866f636f9ad4cd

vim-patch:8.2.0351: terminal in popup test is still a bit flaky

Problem:    Terminal in popup test is still a bit flaky.
Solution:   Clear and redraw before opening the popup.
https://github.com/vim/vim/commit/3e919d2924c87eb8fee62603788fcc3ced2a0031

vim-patch:8.2.0752: terminal in popup window test is a bit flaky

Problem:    Terminal in popup window test is a bit flaky.
Solution:   Wait for shell job status to be "run".  Mark as flaky test.
https://github.com/vim/vim/commit/e06a28f5e30f439545ac125d54ffc4e6bd6daada

vim-patch:8.2.1087: possible memory leak when file expansion fails

Problem:    Possible memory leak when file expansion fails.
Solution:   Clear the grow array when returning FAIL.  Use an error message
            instead of an empty string.
https://github.com/vim/vim/commit/566cc8c72bb8036f015a435800f28ef9f6a9a3b6

vim-patch:8.2.1863: json code not sufficiently tested

Problem:    Json code not sufficiently tested.
Solution:   Add more test cases. (Dominique Pellé, closes vim/vim#7166)
https://github.com/vim/vim/commit/e3c65ce4e59143736bb2e0fba93c21283aa92a35