### PR TITLE
vim-patch:8.2.{6,1002,1871}

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3171,7 +3171,7 @@ complete_info([{what}])
 <
 						*confirm()*
 confirm({msg} [, {choices} [, {default} [, {type}]]])
-		confirm() offers the user a dialog, from which a choice can be
+		Confirm() offers the user a dialog, from which a choice can be
 		made.  It returns the number of the choice.  For the first
 		choice this is 1.
 
@@ -4640,16 +4640,10 @@ getloclist({nr},[, {what}])				*getloclist()*
 		If the optional {what} dictionary argument is supplied, then
 		returns the items listed in {what} as a dictionary. Refer to
 		|getqflist()| for the supported items in {what}.
-
-		In addition to the items supported by |getqflist()| in {what},
-		the following item is supported by |getloclist()|:
-
-			filewinid 	id of the window used to display files
-					from the location list. This field is
-					applicable only when called from a
-					location list window. See
-					|location-list-file-window| for more
-					details.
+		If {what} contains 'filewinid', then returns the id of the
+		window used to display files from the location list. This
+		field is applicable only when called from a location list
+		window. See |location-list-file-window| for more details.
 
 getmatches([{win}])					*getmatches()*
 		Returns a |List| with all matches previously defined for the
@@ -4751,9 +4745,6 @@ getqflist([{what}])					*getqflist()*
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and "$" means
 				the last quickfix list
-			qfbufnr number of the buffer displayed in the quickfix
-				window. Returns 0 if the quickfix buffer is
-				not present. See |quickfix-buffer|.
 			size	number of entries in the quickfix list
 			title	get the list title |quickfix-title|
 			winid	get the quickfix |window-ID|
@@ -4782,8 +4773,6 @@ getqflist([{what}])					*getqflist()*
 			items	quickfix list entries. If not present, set to
 				an empty list.
 			nr	quickfix list number. If not present, set to 0
-			qfbufnr	number of the buffer displayed in the quickfix
-				window. If not present, set to 0.
 			size	number of entries in the quickfix list. If not
 				present, set to 0.
 			title	quickfix list title text. If not present, set
@@ -10397,14 +10386,14 @@ text...
 			commands are skipped.
 			When {pattern} is omitted all errors are caught.
 			Examples: >
-		:catch /^Vim:Interrupt$/	 " catch interrupts (CTRL-C)
-		:catch /^Vim\%((\a\+)\)\=:E/	 " catch all Vim errors
-		:catch /^Vim\%((\a\+)\)\=:/	 " catch errors and interrupts
-		:catch /^Vim(write):/		 " catch all errors in :write
-		:catch /^Vim\%((\a\+)\)\=:E123:/ " catch error E123
-		:catch /my-exception/		 " catch user exception
-		:catch /.*/			 " catch everything
-		:catch				 " same as /.*/
+		:catch /^Vim:Interrupt$/	" catch interrupts (CTRL-C)
+		:catch /^Vim\%((\a\+)\)\=:E/	" catch all Vim errors
+		:catch /^Vim\%((\a\+)\)\=:/	" catch errors and interrupts
+		:catch /^Vim(write):/		" catch all errors in :write
+		:catch /^Vim\%((\a\+)\)\=:E123/	" catch error E123
+		:catch /my-exception/		" catch user exception
+		:catch /.*/			" catch everything
+		:catch				" same as /.*/
 <
 			Another character can be used instead of / around the
 			{pattern}, so long as it does not have a special

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -540,7 +540,6 @@ location list.
 			second quickfix window.  If [height] is given the
 			existing window will be resized to it.
 
-							*quickfix-buffer*
 			The window will contain a special buffer, with
 			'buftype' equal to "quickfix".  Don't change this!
 			The window will have the w:quickfix_title variable set
@@ -549,11 +548,7 @@ location list.
 			status line if the value of 'statusline' is adjusted
 			properly. Whenever this buffer is modified by a
 			quickfix command or function, the |b:changedtick|
-			variable is incremented.  You can get the number of
-			this buffer using the getqflist() and getloclist()
-			functions by passing the 'qfbufnr' item. For a
-			location list, this buffer is wiped out when the
-			location list is removed.
+			variable is incremented.
 
 							*:lop* *:lopen*
 :lop[en] [height]	Open a window to show the location list for the
@@ -719,17 +714,11 @@ using these functions are below:
     " get the quickfix list window id
     :echo getqflist({'winid' : 0}).winid
 
-    " get the quickfix list window buffer number
-    :echo getqflist({'qfbufnr' : 0}).qfbufnr
-
     " get the context of the current location list
     :echo getloclist(0, {'context' : 0}).context
 
     " get the location list window id of the third window
     :echo getloclist(3, {'winid' : 0}).winid
-
-    " get the location list window buffer number of the third window
-    :echo getloclist(3, {'qfbufnr' : 0}).qfbufnr
 
     " get the file window id of a location list window (winnr: 4)
     :echo getloclist(4, {'filewinid' : 0}).filewinid

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5397,12 +5397,16 @@ bool buf_hide(const buf_T *const buf)
 char_u *buf_spname(buf_T *buf)
 {
   if (bt_quickfix(buf)) {
-    // Differentiate between the quickfix and location list buffers using
-    // the buffer number stored in the global quickfix stack.
-    if (buf->b_fnum == qf_stack_get_bufnr()) {
+    win_T *win;
+    tabpage_T *tp;
+
+    // For location list window, w_llist_ref points to the location list.
+    // For quickfix window, w_llist_ref is NULL.
+    if (find_win_for_buf(buf, &win, &tp) && win->w_llist_ref != NULL) {
+      return (char_u *)_(msg_loclist);
+    } else {
       return (char_u *)_(msg_qflist);
     }
-    return (char_u *)_(msg_loclist);
   }
   // There is no _file_ when 'buftype' is "nofile", b_sfname
   // contains the name as specified by the user.

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5596,8 +5596,7 @@ enum {
   QF_GETLIST_SIZE = 0x80,
   QF_GETLIST_TICK = 0x100,
   QF_GETLIST_FILEWINID = 0x200,
-  QF_GETLIST_QFBUFNR = 0x400,
-  QF_GETLIST_ALL = 0x7FF,
+  QF_GETLIST_ALL = 0x3FF,
 };
 
 /// Parse text from 'di' and return the quickfix list items.
@@ -5652,15 +5651,6 @@ static int qf_winid(qf_info_T *qi)
   return 0;
 }
 
-// Returns the number of the buffer displayed in the quickfix/location list
-// window. If there is no buffer associated with the list, then returns 0.
-static int qf_getprop_qfbufnr(const qf_info_T *qi, dict_T *retdict)
-  FUNC_ATTR_NONNULL_ARG(2)
-{
-  return tv_dict_add_nr(retdict, S_LEN("qfbufnr"),
-                        (qi == NULL) ? 0 : qi->qf_bufnr);
-}
-
 /// Convert the keys in 'what' to quickfix list property flags.
 static int qf_getprop_keys2flags(const dict_T *what, bool loclist)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
@@ -5703,9 +5693,6 @@ static int qf_getprop_keys2flags(const dict_T *what, bool loclist)
   }
   if (loclist && tv_dict_find(what, S_LEN("filewinid")) != NULL) {
     flags |= QF_GETLIST_FILEWINID;
-  }
-  if (tv_dict_find(what, S_LEN("qfbufnr")) != NULL) {
-    flags |= QF_GETLIST_QFBUFNR;
   }
 
   return flags;
@@ -5797,9 +5784,6 @@ static int qf_getprop_defaults(qf_info_T *qi,
   }
   if ((status == OK) && locstack && (flags & QF_GETLIST_FILEWINID)) {
     status = tv_dict_add_nr(retdict, S_LEN("filewinid"), 0);
-  }
-  if ((status == OK) && (flags & QF_GETLIST_QFBUFNR)) {
-    status = qf_getprop_qfbufnr(qi, retdict);
   }
 
   return status;
@@ -5934,9 +5918,6 @@ int qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
   }
   if ((status == OK) && (wp != NULL) && (flags & QF_GETLIST_FILEWINID)) {
     status = qf_getprop_filewinid(wp, qi, retdict);
-  }
-  if ((status == OK) && (flags & QF_GETLIST_QFBUFNR)) {
-    status = qf_getprop_qfbufnr(qi, retdict);
   }
 
   return status;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1669,8 +1669,8 @@ static int qf_parse_multiline_pfx(int idx, qf_list_T *qfl, qffields_T *fields)
     }
     if (!qfprev->qf_col) {
       qfprev->qf_col = fields->col;
+      qfprev->qf_viscol = fields->use_viscol;
     }
-    qfprev->qf_viscol = fields->use_viscol;
     if (!qfprev->qf_fnum) {
       qfprev->qf_fnum = qf_get_fnum(qfl, qfl->qf_directory,
                                     *fields->namebuf || qfl->qf_directory

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -73,7 +73,6 @@ struct qfline_S {
 // There is a stack of error lists.
 #define LISTCOUNT   10
 #define INVALID_QFIDX (-1)
-#define INVALID_QFBUFNR (0)
 
 /// Quickfix list type.
 typedef enum
@@ -124,7 +123,6 @@ struct qf_info_S {
   int qf_curlist;                   // current error list
   qf_list_T qf_lists[LISTCOUNT];
   qfltype_T qfl_type;  // type of list
-  int qf_bufnr;                     // quickfix window buffer number
 };
 
 static qf_info_T ql_info;         // global quickfix list
@@ -1698,28 +1696,6 @@ static void locstack_queue_delreq(qf_info_T *qi)
   qf_delq_head = q;
 }
 
-// Return the global quickfix stack window buffer number.
-int qf_stack_get_bufnr(void)
-{
-  return ql_info.qf_bufnr;
-}
-
-// Wipe the quickfix window buffer (if present) for the specified
-// quickfix/location list.
-static void wipe_qf_buffer(qf_info_T *qi)
-  FUNC_ATTR_NONNULL_ALL
-{
-  if (qi->qf_bufnr != INVALID_QFBUFNR) {
-    buf_T *const qfbuf = buflist_findnr(qi->qf_bufnr);
-    if (qfbuf != NULL && qfbuf->b_nwindows == 0) {
-      // If the quickfix buffer is not loaded in any window, then
-      // wipe the buffer.
-      close_buffer(NULL, qfbuf, DOBUF_WIPE, false);
-      qi->qf_bufnr = INVALID_QFBUFNR;
-    }
-  }
-}
-
 /// Free a location list stack
 static void ll_free_all(qf_info_T **pqi)
 {
@@ -1739,9 +1715,6 @@ static void ll_free_all(qf_info_T **pqi)
     if (quickfix_busy > 0) {
       locstack_queue_delreq(qi);
     } else {
-      // If the quickfix window buffer is loaded, then wipe it
-      wipe_qf_buffer(qi);
-
       for (i = 0; i < qi->qf_listcount; i++) {
         qf_free(qf_get_list(qi, i));
       }
@@ -1901,7 +1874,6 @@ static qf_info_T *qf_alloc_stack(qfltype_T qfltype)
   qf_info_T *qi = xcalloc(1, sizeof(qf_info_T));
   qi->qf_refcount++;
   qi->qfl_type = qfltype;
-  qi->qf_bufnr = INVALID_QFBUFNR;
 
   return qi;
 }
@@ -2538,8 +2510,7 @@ static int jump_to_help_window(qf_info_T *qi, bool newwin, int *opened_window)
   return OK;
 }
 
-// Find a non-quickfix window in the current tabpage using the given location
-// list stack.
+// Find a non-quickfix window using the given location list.
 // Returns NULL if a matching window is not found.
 static win_T *qf_find_win_with_loclist(const qf_info_T *ll)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
@@ -3589,7 +3560,7 @@ static void qf_set_cwindow_options(void)
   // switch off 'swapfile'
   set_option_value("swf", 0L, NULL, OPT_LOCAL);
   set_option_value("bt", 0L, "quickfix", OPT_LOCAL);
-  set_option_value("bh", 0L, "hide", OPT_LOCAL);
+  set_option_value("bh", 0L, "wipe", OPT_LOCAL);
   RESET_BINDING(curwin);
   curwin->w_p_diff = false;
   set_option_value("fdm", 0L, "manual", OPT_LOCAL);
@@ -3642,9 +3613,6 @@ static int qf_open_new_cwindow(qf_info_T *qi, int height)
   } else {
     // Create a new quickfix buffer
     (void)do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, oldwin);
-
-    // save the number of the new buffer
-    qi->qf_bufnr = curbuf->b_fnum;
   }
 
   // Set the options for the quickfix buffer/window (if not already done)
@@ -3843,15 +3811,6 @@ static win_T *qf_find_win(const qf_info_T *qi)
 static buf_T *qf_find_buf(qf_info_T *qi)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  if (qi->qf_bufnr != INVALID_QFBUFNR) {
-    buf_T *const qfbuf = buflist_findnr(qi->qf_bufnr);
-    if (qfbuf != NULL) {
-      return qfbuf;
-    }
-    // buffer is no longer present
-    qi->qf_bufnr = INVALID_QFBUFNR;
-  }
-
   FOR_ALL_TAB_WINDOWS(tp, win) {
     if (is_qf_win(win, qi)) {
       return win->w_buffer;
@@ -6296,6 +6255,20 @@ static int qf_set_properties(qf_info_T *qi, const dict_T *what, int action,
   return retval;
 }
 
+/// Find the non-location list window with the specified location list stack in
+/// the current tabpage.
+static win_T *find_win_with_ll(const qf_info_T *qi)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if ((wp->w_llist == qi) && !bt_quickfix(wp->w_buffer)) {
+      return wp;
+    }
+  }
+
+  return NULL;
+}
+
 // Free the entire quickfix/location list stack.
 // If the quickfix/location list window is open, then clear it.
 static void qf_free_stack(win_T *wp, qf_info_T *qi)
@@ -6310,10 +6283,12 @@ static void qf_free_stack(win_T *wp, qf_info_T *qi)
     qf_update_buffer(qi, NULL);
   }
 
+  win_T *llwin = NULL;
+  win_T *orig_wp = wp;
   if (wp != NULL && IS_LL_WINDOW(wp)) {
     // If in the location list window, then use the non-location list
     // window with this location list (if present)
-    win_T *const llwin = qf_find_win_with_loclist(qi);
+    llwin = find_win_with_ll(qi);
     if (llwin != NULL) {
       wp = llwin;
     }
@@ -6324,17 +6299,16 @@ static void qf_free_stack(win_T *wp, qf_info_T *qi)
     // quickfix list
     qi->qf_curlist = 0;
     qi->qf_listcount = 0;
-  } else if (qfwin != NULL) {
+  } else if (IS_LL_WINDOW(orig_wp)) {
     // If the location list window is open, then create a new empty location
     // list
     qf_info_T *new_ll = qf_alloc_stack(QFLT_LOCATION);
-    new_ll->qf_bufnr = qfwin->w_buffer->b_fnum;
 
     // first free the list reference in the location list window
-    ll_free_all(&qfwin->w_llist_ref);
+    ll_free_all(&orig_wp->w_llist_ref);
 
-    qfwin->w_llist_ref = new_ll;
-    if (wp != qfwin) {
+    orig_wp->w_llist_ref = new_ll;
+    if (llwin != NULL) {
       win_set_loclist(wp, new_ll);
     }
   }

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -189,7 +189,7 @@ endfunc
 func Test_edit_long_file_name()
   CheckScreendump
 
-  let longName = 'x'->repeat(&columns)
+  let longName = 'x'->repeat(min([&columns, 255]))
   call writefile([], longName)
   let buf = RunVimInTerminal('-N -u NONE ' .. longName, #{rows: 8})
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -4064,6 +4064,21 @@ func Test_viscol()
   cnext
   call assert_equal([16, 25], [col('.'), virtcol('.')])
 
+  " Use screen column number with a multi-line error message
+  enew
+  call writefile(["à test"], 'Xfile1')
+  set efm=%E===\ %f\ ===,%C%l:%v,%Z%m
+  cexpr ["=== Xfile1 ===", "1:3", "errormsg"]
+  call assert_equal('Xfile1', @%)
+  call assert_equal([0, 1, 4, 0], getpos('.'))
+
+  " Repeat previous test with byte offset %c: ensure that fix to issue #7145
+  " does not break this
+  set efm=%E===\ %f\ ===,%C%l:%c,%Z%m
+  cexpr ["=== Xfile1 ===", "1:3", "errormsg"]
+  call assert_equal('Xfile1', @%)
+  call assert_equal([0, 1, 3, 0], getpos('.'))
+
   enew | only
   set efm&
   call delete('Xfile1')

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -4151,6 +4151,7 @@ func Xqfbuf_test(cchar)
 endfunc
 
 func Test_qfbuf()
+  throw 'skipped: enable after porting patch 8.1.0877'
   call Xqfbuf_test('c')
   call Xqfbuf_test('l')
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3254,21 +3254,19 @@ func Xgetlist_empty_tests(cchar)
   call assert_equal(0, g:Xgetlist({'changedtick' : 0}).changedtick)
   if a:cchar == 'c'
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0,
-		  \ 'items' : [], 'nr' : 0, 'size' : 0, 'qfbufnr' : 0,
+		  \ 'items' : [], 'nr' : 0, 'size' : 0,
 		  \ 'title' : '', 'winid' : 0, 'changedtick': 0},
 		  \ g:Xgetlist({'all' : 0}))
   else
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0,
 		\ 'items' : [], 'nr' : 0, 'size' : 0, 'title' : '',
-		\ 'winid' : 0, 'changedtick': 0, 'filewinid' : 0,
-		\ 'qfbufnr' : 0},
+		\ 'winid' : 0, 'changedtick': 0, 'filewinid' : 0},
 		\ g:Xgetlist({'all' : 0}))
   endif
 
   " Quickfix window with empty stack
   silent! Xopen
   let qfwinid = (a:cchar == 'c') ? win_getid() : 0
-  let qfbufnr = (a:cchar == 'c') ? bufnr('') : 0
   call assert_equal(qfwinid, g:Xgetlist({'winid' : 0}).winid)
   Xclose
 
@@ -3300,12 +3298,11 @@ func Xgetlist_empty_tests(cchar)
   if a:cchar == 'c'
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'qfbufnr' : qfbufnr,
 		\ 'changedtick' : 0}, g:Xgetlist({'id' : qfid, 'all' : 0}))
   else
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'changedtick' : 0, 'filewinid' : 0, 'qfbufnr' : 0},
+		\ 'changedtick' : 0, 'filewinid' : 0},
 		\ g:Xgetlist({'id' : qfid, 'all' : 0}))
   endif
 
@@ -3322,12 +3319,11 @@ func Xgetlist_empty_tests(cchar)
   if a:cchar == 'c'
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'changedtick' : 0, 'qfbufnr' : qfbufnr},
-		\ g:Xgetlist({'nr' : 5, 'all' : 0}))
+		\ 'changedtick' : 0}, g:Xgetlist({'nr' : 5, 'all' : 0}))
   else
     call assert_equal({'context' : '', 'id' : 0, 'idx' : 0, 'items' : [],
 		\ 'nr' : 0, 'size' : 0, 'title' : '', 'winid' : 0,
-		\ 'changedtick' : 0, 'filewinid' : 0, 'qfbufnr' : 0},
+		\ 'changedtick' : 0, 'filewinid' : 0},
 		\ g:Xgetlist({'nr' : 5, 'all' : 0}))
   endif
 endfunc
@@ -4096,7 +4092,6 @@ func Xqfbuf_test(cchar)
   Xclose
   " Even after the quickfix window is closed, the buffer should be loaded
   call assert_true(bufloaded(qfbnum))
-  call assert_true(qfbnum, g:Xgetlist({'qfbufnr' : 0}).qfbufnr)
   Xopen
   " Buffer should be reused when opening the window again
   call assert_equal(qfbnum, bufnr(''))
@@ -4115,7 +4110,7 @@ func Xqfbuf_test(cchar)
     close
     " When the location list window is closed, the buffer name should not
     " change to 'Quickfix List'
-    call assert_match(qfbnum . 'u h-  "\[Location List]"', execute('ls!'))
+    call assert_match(qfbnum . '  h-  "\[Location List]"', execute('ls'))
     call assert_true(bufloaded(qfbnum))
 
     " After deleting a location list buffer using ":bdelete", opening the
@@ -4132,7 +4127,6 @@ func Xqfbuf_test(cchar)
     " removed
     call setloclist(0, [], 'f')
     call assert_false(bufexists(qfbnum))
-    call assert_equal(0, getloclist(0, {'qfbufnr' : 0}).qfbufnr)
 
     " When the location list is freed with the location list window open, the
     " location list buffer should not be lost. It should be reused when the

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2582,10 +2582,6 @@ int win_close(win_T *win, bool free_buf)
   if (win->w_buffer != NULL) {
     reset_synblock(win);
   }
-  // When the quickfix/location list window is closed, unlist the buffer.
-  if (win->w_buffer != NULL && bt_quickfix(win->w_buffer)) {
-    win->w_buffer->b_p_bl = false;
-  }
 
   /*
    * Close the link to the buffer.


### PR DESCRIPTION
Revert patches 8.1.0877 and 8.1.1015 from https://github.com/neovim/neovim/pull/13083.

`./scripts/vim-patch.sh` treats them as merged patches though. Problem with naive automation :disappointed: 