### PR TITLE
vim-patch:8.1.1877,8.2.{268,1874,1875,1877,1878,1881,1883}

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -700,9 +700,14 @@ InsertEnter			Just before starting Insert mode.  Also for
 				The cursor is restored afterwards.  If you do
 				not want that set |v:char| to a non-empty
 				string.
+							*InsertLeavePre*
+InsertLeavePre			Just before leaving Insert mode.  Also when
+				using CTRL-O |i_CTRL-O|.  Be caseful not to
+				change mode or use `:normal`, it will likely
+				cause trouble.
 							*InsertLeave*
-InsertLeave			When leaving Insert mode.  Also when using
-				CTRL-O |i_CTRL-O|.  But not for |i_CTRL-C|.
+InsertLeave			Just after leaving Insert mode.  Also when
+				using CTRL-O |i_CTRL-O|.  But not for |i_CTRL-C|.
 							*MenuPopup*
 MenuPopup			Just before showing the popup menu (under the
 				right mouse button).  Useful for adjusting the

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -65,7 +65,8 @@ return {
     'InsertChange',           -- when changing Insert/Replace mode
     'InsertCharPre',          -- before inserting a char
     'InsertEnter',            -- when entering Insert mode
-    'InsertLeave',            -- when leaving Insert mode
+    'InsertLeave',            -- just after leaving Insert mode
+    'InsertLeavePre',         -- just before leaving Insert mode
     'MenuPopup',              -- just before popup menu is displayed
     'OptionSet',              -- after setting any option
     'QuickFixCmdPost',        -- after :make, :grep etc.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7691,6 +7691,10 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
     undisplay_dollar();
   }
 
+  if (cmdchar != 'r' && cmdchar != 'v') {
+    ins_apply_autocmds(EVENT_INSERTLEAVEPRE);
+  }
+
   // When an autoindent was removed, curswant stays after the
   // indent
   if (restart_edit == NUL && (colnr_T)temp == curwin->w_cursor.col) {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2920,8 +2920,10 @@ void ex_call(exarg_T *eap)
   if (!failed || eap->cstack->cs_trylevel > 0) {
     // Check for trailing illegal characters and a following command.
     if (!ends_excmd(*arg)) {
-      emsg_severe = true;
-      EMSG(_(e_trailing));
+      if (!failed) {
+        emsg_severe = true;
+        EMSG(_(e_trailing));
+      }
     } else {
       eap->nextcmd = check_nextcmd(arg);
     }

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1441,31 +1441,40 @@ endfunc
 
 func Test_edit_InsertLeave()
   new
+  au InsertLeavePre * let g:did_au_pre = 1
   au InsertLeave * let g:did_au = 1
+  let g:did_au_pre = 0
   let g:did_au = 0
   call feedkeys("afoo\<Esc>", 'tx')
+  call assert_equal(1, g:did_au_pre)
   call assert_equal(1, g:did_au)
   call assert_equal('foo', getline(1))
 
+  let g:did_au_pre = 0
   let g:did_au = 0
   call feedkeys("Sbar\<C-C>", 'tx')
+  call assert_equal(1, g:did_au_pre)
   call assert_equal(0, g:did_au)
   call assert_equal('bar', getline(1))
 
   inoremap x xx<Esc>
+  let g:did_au_pre = 0
   let g:did_au = 0
   call feedkeys("Saax", 'tx')
+  call assert_equal(1, g:did_au_pre)
   call assert_equal(1, g:did_au)
   call assert_equal('aaxx', getline(1))
 
   inoremap x xx<C-C>
+  let g:did_au_pre = 0
   let g:did_au = 0
   call feedkeys("Sbbx", 'tx')
+  call assert_equal(1, g:did_au_pre)
   call assert_equal(0, g:did_au)
   call assert_equal('bbxx', getline(1))
 
   bwipe!
-  au! InsertLeave
+  au! InsertLeave InsertLeavePre
   iunmap x
 endfunc
 


### PR DESCRIPTION
vim-patch:8.2.0268: trycatch test fails

Problem:    Trycatch test fails.
Solution:   When calling function fails only check for following command, do
            not give another error.
https://github.com/vim/vim/commit/40d9da2a4395025169ebaf53a63618adfa737e96