### PR TITLE
Increase max number of items in the statusline

### DIFF
--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -259,7 +259,7 @@ enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
 #define PERROR(msg) (void) emsgf("%s: %s", msg, strerror(errno))
 
 #define SHOWCMD_COLS 10                 // columns needed by shown command
-#define STL_MAX_ITEM 80                 // max nr of %<flag> in statusline
+#define STL_MAX_ITEM 300                // max nr of %<flag> in statusline
 
 #include "nvim/path.h"
 

--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -212,7 +212,7 @@ describe('buffer functions', function()
 
   describe('build_stl_str_hl', function()
     local buffer_byte_size = 100
-    local STL_MAX_ITEM = 80
+    local STL_MAX_ITEM = 300
     local output_buffer = ''
 
     -- This function builds the statusline


### PR DESCRIPTION
Vim throws `E541` when there are too many items in the tabline or statusline, which happens often when using tabline or statusline plugins. This PR increase the number of items from 80 to 300. I have chosen 300 because it seems like a fine number to me, isn't exagerated in terms of memory, and will probably satisfy the needs of everyone. Also because I want to stop seing that error therefore an arbitrary number is better than the current *status quo*.

Fixes #7459

Example: https://github.com/itchyny/lightline.vim/issues/220