### PR TITLE
vim-patch:8.2.{952,1885,1887}

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -450,6 +450,9 @@ Eval:
   *js_decode()*
   *v:none* (used by Vim to represent JavaScript "undefined"); use |v:null| instead.
 
+Events:
+  *SigUSR1* Use |Signal| to detect `SIGUSR1` signal instead.
+
 Highlight groups:
   *hl-StatusLineTerm* *hl-StatusLineTermNC* are unnecessary because Nvim
     supports 'winhighlight' window-local highlights.

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1897,4 +1897,17 @@ func Test_autocmd_FileReadCmd()
   delfunc ReadFileCmd
 endfunc
 
+" Tests for SigUSR1 autocmd event, which is only available on posix systems.
+func Test_autocmd_sigusr1()
+  CheckUnix
+
+  let g:sigusr1_passed = 0
+  au Signal SIGUSR1 let g:sigusr1_passed = 1
+  call system('/bin/kill -s usr1 ' . getpid())
+  call WaitForAssert({-> assert_true(g:sigusr1_passed)})
+
+  au! Signal
+  unlet g:sigusr1_passed
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -532,6 +532,7 @@ let s:filename_case_checks = {
     \ }
 
 func CheckItems(checks)
+  set noswapfile
   for [ft, names] in items(a:checks)
     for i in range(0, len(names) - 1)
       new
@@ -548,6 +549,7 @@ func CheckItems(checks)
       bwipe!
     endfor
   endfor
+  set swapfile&
 endfunc
 
 func Test_filetype_detection()


### PR DESCRIPTION
Neovim has `Signal` event which catches `SIGUSR1` signal. I ported only the test because it passes on my machine after fixing the autocmd to check `Signal`, not `SigUSR1`.