### PR TITLE
Add v:event flag on DirChanged signaling switching window

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -515,6 +515,8 @@ DirChanged			After the |current-directory| was changed.
 				Sets these |v:event| keys:
 				    cwd:   current working directory
 				    scope: "global", "tab", "window"
+				    changed_window: v:true if we fired the event
+				                    switching window (or tab)
 				Non-recursive (event cannot trigger itself).
 							*FileAppendCmd*
 FileAppendCmd			Before appending to a file.  Should do the

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1614,6 +1614,8 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 					|CompleteChanged|.
 			scrollbar 	Is |v:true| if popup menu have scrollbar, or
 					|v:false| if not.
+			changed_window 	Is |v:true| if the the event fired
+					while changing window (or tab) on |DirChanged|.
 
 					*v:exception* *exception-variable*
 v:exception	The value of the exception most recently caught and not

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7503,7 +7503,7 @@ void post_chdir(CdScope scope, bool trigger_dirchanged)
   shorten_fnames(true);
 
   if (trigger_dirchanged) {
-    do_autocmd_dirchanged(cwd, scope);
+    do_autocmd_dirchanged(cwd, scope, false);
   }
 }
 

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1565,7 +1565,7 @@ theend:
   return file_name;
 }
 
-void do_autocmd_dirchanged(char *new_dir, CdScope scope)
+void do_autocmd_dirchanged(char *new_dir, CdScope scope, bool changed_window)
 {
   static bool recursive = false;
 
@@ -1601,6 +1601,7 @@ void do_autocmd_dirchanged(char *new_dir, CdScope scope)
 
   tv_dict_add_str(dict, S_LEN("scope"), buf);  // -V614
   tv_dict_add_str(dict, S_LEN("cwd"),   new_dir);
+  tv_dict_add_bool(dict, S_LEN("changed_window"), changed_window);
   tv_dict_set_keys_readonly(dict);
 
   apply_autocmds(EVENT_DIRCHANGED, (char_u *)buf, (char_u *)new_dir, false,
@@ -1633,7 +1634,7 @@ int vim_chdirfile(char_u *fname)
   slash_adjust((char_u *)dir);
 #endif
   if (!strequal(dir, (char *)NameBuff)) {
-    do_autocmd_dirchanged(dir, kCdScopeWindow);
+    do_autocmd_dirchanged(dir, kCdScopeWindow, false);
   }
 
   return OK;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4558,7 +4558,7 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
     if (os_chdir(new_dir) == 0) {
       if (!p_acd && !strequal(new_dir, cwd)) {
         do_autocmd_dirchanged(new_dir, curwin->w_localdir
-                              ? kCdScopeWindow : kCdScopeTab);
+                              ? kCdScopeWindow : kCdScopeTab, true);
       }
       shorten_fnames(true);
     }
@@ -4567,7 +4567,7 @@ static void win_enter_ext(win_T *wp, bool undo_sync, int curwin_invalid,
     // directory: Change to the global directory.
     if (os_chdir((char *)globaldir) == 0) {
       if (!p_acd && !strequal((char *)globaldir, cwd)) {
-        do_autocmd_dirchanged((char *)globaldir, kCdScopeGlobal);
+        do_autocmd_dirchanged((char *)globaldir, kCdScopeGlobal, true);
       }
     }
     XFREE_CLEAR(globaldir);


### PR DESCRIPTION
I was initially looking to help out porting vim patches and saw the few 8.0.x remaining. I looked at the DirChanged vim patch that was marked still as not ported even if the event was in Neovim first and found #9909 as the only thing before marking the patch as N/A and since it was tagged as complexity low I gave it a try.

Still some question and request for comments:

- I really didn't know how to name the additional field for `v:event`, so suggestions are more than welcome.
- I sketched the additional documentation but I'm not sure if it is comprehensive enough and if I missed pages from vim help to update.
- It is still not clear the process of updating `version.c`


Closes #9909