### PR TITLE
lsp: Add health check including a sample of error diagnostics

### DIFF
--- a/runtime/autoload/health/lsp.vim
+++ b/runtime/autoload/health/lsp.vim
@@ -1,0 +1,5 @@
+
+function! health#lsp#check() abort
+    lua require 'health/lsp'.check_health()
+endfunc
+

--- a/runtime/lua/health/lsp.lua
+++ b/runtime/lua/health/lsp.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+local report_error = vim.fn['health#report_error']
+local report_info = vim.fn['health#report_info']
+
+function M.check_health()
+
+	for key, client in pairs(vim.lsp.get_active_clients()) do
+		M.lsp_dump_active_client(client)
+	end
+end
+
+function M.lsp_dump_active_client(client)
+
+	local config = client.config
+	vim.fn["health#report_start"]('State of '..config.name)
+	report_info("Working directory: "..config.root_dir)
+
+end
+
+return M
+

--- a/runtime/lua/health/lsp.lua
+++ b/runtime/lua/health/lsp.lua
@@ -1,21 +1,46 @@
+local protocol = vim.lsp.protocol
 local M = {}
 
 local report_error = vim.fn['health#report_error']
 local report_info = vim.fn['health#report_info']
+local report_ok = vim.fn['health#report_ok']
 
-function M.check_health()
 
-	for key, client in pairs(vim.lsp.get_active_clients()) do
-		M.lsp_dump_active_client(client)
-	end
+local function lsp_dump_active_client(client)
+  local config = client.config
+  vim.fn["health#report_start"]('State of ' .. config.name)
+  report_info("Working directory: " .. config.root_dir)
+  local i = 0
+  for buf, diagnostics in pairs(vim.lsp.util.diagnostics_by_buf) do
+    for _, diagnostic in pairs(diagnostics) do
+      if diagnostic.severity == protocol.DiagnosticSeverity.Error then
+        i = i + 1
+        local fname = vim.fn.fnamemodify(
+          vim.uri_to_fname(vim.uri_from_bufnr(buf)),
+          ':.'
+        )
+        report_error(fname .. ': ' .. diagnostic.message)
+        if i > 10 then
+          return
+        end
+      end
+    end
+  end
+
+  if client.notify('window/progress', {}) then
+    report_ok('Language servers reported no errors via diagnostics')
+  else
+    report_error(
+      'Language servers reported no errors via diagnostics, but has shutdown or is malfunctioning.')
+  end
 end
 
-function M.lsp_dump_active_client(client)
-
-	local config = client.config
-	vim.fn["health#report_start"]('State of '..config.name)
-	report_info("Working directory: "..config.root_dir)
-
+function M.check_health()
+  local clients = vim.lsp.get_active_clients()
+  report_info(#clients .. ' active clients')
+  for _, client in pairs(clients) do
+    lsp_dump_active_client(client)
+  end
 end
 
 return M


### PR DESCRIPTION
Continuation of https://github.com/neovim/neovim/pull/12578

I'm also not sure if the checkhealth is the best option for this.

Maybe an additional command in `vim.lsp.buf` to load all error diagnostics into
the quickfix list would be a better option to discover important errors?