### PR TITLE
Improve schedule wrap docs

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -973,21 +973,21 @@ schedule_wrap({cb})                                      *vim.schedule_wrap()*
 
                 The user must call the returned function themselves if it is not
                 being used as an argument to a function that will call it for them,
-                such as `vim.fn_defer`.
+                such as |nvim_buf_attach()|.
 
-                Example: Using as an argument >
-
-                 local safe = vim.schedule_wrap(function()
-		   vim.api.nvim_command('echomsg "test"')
-                 end)
-                 vim.defer_fn(safe, 100)
-
-                Example: Using on it's own >
+                Example: using on its own >
 
                  local safe = vim.schedule_wrap(function()
                    vim.api.nvim_command('echomsg "test"')
                  end)
                  safe()
+                 
+                Example: using as an argument >
+
+                 local safe = vim.schedule_wrap(function()
+		   vim.api.nvim_command('echomsg "test"')
+                 end)
+                 vim.api.nvim_buf_attach(0, false, {on_lines=safe})
 		
                 Return: ~
                     function

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -988,6 +988,9 @@ schedule_wrap({cb})                                      *vim.schedule_wrap()*
 		   vim.api.nvim_command('echomsg "test"')
 		 end)
 		 safe()
+		
+		Return: ~
+		    function
 
                 See also: ~
                     |lua-loop-callbacks|

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -968,15 +968,31 @@ paste({lines}, {phase})                                          *vim.paste()*
                     |paste|
 
 schedule_wrap({cb})                                      *vim.schedule_wrap()*
-                Defers callback `cb` until the Nvim API is safe to call.
+                Wraps callback `cb` in a function which will defer the execution
+		of `cb` until the Nvim API is safe to call.
+
+		The user must call the returned function themselves if it is not
+		being used as an argument to a function that will call it for them,
+		such as `vim.fn_defer`.
+
+		Example: Using as an argument >
+
+		 local safe = vim.schedule_wrap(function()
+		   vim.api.nvim_command('echomsg "test"')
+		 end)
+		 vim.defer_fn(safe, 100)
+
+		Example: Using on it's own >
+
+		 local safe = vim.schedule_wrap(function()
+		   vim.api.nvim_command('echomsg "test"')
+		 end)
+		 safe()
 
                 See also: ~
                     |lua-loop-callbacks|
                     |vim.schedule()|
                     |vim.in_fast_event()|
-
-
-
 
 deep_equal({a}, {b})                                        *vim.deep_equal()*
                 TODO: Documentation

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -969,28 +969,28 @@ paste({lines}, {phase})                                          *vim.paste()*
 
 schedule_wrap({cb})                                      *vim.schedule_wrap()*
                 Wraps callback `cb` in a function which will defer the execution
-		of `cb` until the Nvim API is safe to call.
+                of `cb` until the Nvim API is safe to call.
 
-		The user must call the returned function themselves if it is not
-		being used as an argument to a function that will call it for them,
-		such as `vim.fn_defer`.
+                The user must call the returned function themselves if it is not
+                being used as an argument to a function that will call it for them,
+                such as `vim.fn_defer`.
 
-		Example: Using as an argument >
+                Example: Using as an argument >
 
-		 local safe = vim.schedule_wrap(function()
+                 local safe = vim.schedule_wrap(function()
 		   vim.api.nvim_command('echomsg "test"')
-		 end)
-		 vim.defer_fn(safe, 100)
+                 end)
+                 vim.defer_fn(safe, 100)
 
-		Example: Using on it's own >
+                Example: Using on it's own >
 
-		 local safe = vim.schedule_wrap(function()
-		   vim.api.nvim_command('echomsg "test"')
-		 end)
-		 safe()
+                 local safe = vim.schedule_wrap(function()
+                   vim.api.nvim_command('echomsg "test"')
+                 end)
+                 safe()
 		
-		Return: ~
-		    function
+                Return: ~
+                    function
 
                 See also: ~
                     |lua-loop-callbacks|


### PR DESCRIPTION
I didn't understand that `schedule_wrap`, returns a *function* that you have to call yourself.

The name does actually imply this, _if_ you know what wrap is supposed to mean, but it caused me a lot of confusion and I was on the edge of posting an issue complete with an example `init.vim` before it actually connected.

So I thought maybe the docs for `schedule_wrap` could be a bit more explicit in it's usage, since it's easy to skim the few examples in the docs and not realize the actual nature of it's usage.

English is not my primary tongue so I hope it has been written correctly.