### PR TITLE
lsp: remove vim.NIL from processing

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -42,13 +42,28 @@ local function is_dir(filename)
 end
 
 local NIL = vim.NIL
+
+--@private
+local recursive_convert_NIL
+recursive_convert_NIL = function(v, tbl_processed)
+  if v == NIL then
+    return nil
+  elseif not tbl_processed[v] and type(v) == 'table' then
+    tbl_processed[v] = true
+    return vim.tbl_map(function(x)
+      return recursive_convert_NIL(x, tbl_processed)
+    end, v)
+  end
+
+  return v
+end
+
 --@private
 --- Returns its argument, but converts `vim.NIL` to Lua `nil`.
 --@param v (any) Argument
 --@returns (any)
 local function convert_NIL(v)
-  if v == NIL then return nil end
-  return v
+  return recursive_convert_NIL(v, {})
 end
 
 --@private

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -214,13 +214,16 @@ end
 function M.apply_text_document_edit(text_document_edit)
   local text_document = text_document_edit.textDocument
   local bufnr = vim.uri_to_bufnr(text_document.uri)
-  if text_document.version then
-    -- `VersionedTextDocumentIdentifier`s version may be null https://microsoft.github.io/language-server-protocol/specification#versionedTextDocumentIdentifier
-    if text_document.version ~= vim.NIL and M.buf_versions[bufnr] ~= nil and M.buf_versions[bufnr] > text_document.version then
-      print("Buffer ", text_document.uri, " newer than edits.")
-      return
-    end
+
+  -- `VersionedTextDocumentIdentifier`s version may be null
+  --  https://microsoft.github.io/language-server-protocol/specification#versionedTextDocumentIdentifier
+  if text_document.version
+      and M.buf_versions[bufnr]
+      and M.buf_versions[bufnr] > text_document.version then
+    print("Buffer ", text_document.uri, " newer than edits.")
+    return
   end
+
   M.apply_text_edits(text_document_edit.edits, bufnr)
 end
 
@@ -492,10 +495,7 @@ function M.convert_signature_help_to_markdown_lines(signature_help)
   --=== 0`. Whenever possible implementors should make an active decision about
   --the active signature and shouldn't rely on a default value.
   local contents = {}
-  local active_signature = signature_help.activeSignature
-  if active_signature == vim.NIL or active_signature == nil then
-    active_signature = 0
-  end
+  local active_signature = signature_help.activeSignature or 0
   -- If the activeSignature is not inside the valid range, then clip it.
   if active_signature >= #signature_help.signatures then
     active_signature = 0
@@ -535,7 +535,7 @@ function M.convert_signature_help_to_markdown_lines(signature_help)
       }
       --]=]
       -- TODO highlight parameter
-      if parameter.documentation and parameter.documentation ~= vim.NIL then
+      if parameter.documentation then
         M.convert_input_to_markdown_lines(parameter.documentation, contents)
       end
     end


### PR DESCRIPTION
I think from seeing several PRs like: 

https://github.com/neovim/neovim/pull/13001

and others, we really don't want `vim.NIL` to show up.

I think we could _optionally_ not decode vim.NIL, but it seems that we were already thinking we removed all the nils, but just didn't think about doing it for table's values.... I'm not 100% sure though.

If Lua had a way to do `__bool`, then we could leave `vim.NIL` in, but it's too hard to check every time for it for `falsey` values. I think it causes way more bugs than features.

@mfussenegger what do you think?