### PR TITLE
fix(treesitter): account for no main query file

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -25,7 +25,7 @@ local function filter_files(file_list)
     end
   end
 
-  return { main, unpack(after) }
+  return main and { main, unpack(after) } or after
 end
 
 local function runtime_query_path(lang, query_name)


### PR DESCRIPTION
Fixes the issue where there is no main query file but one defined by a plugin in the `/after` folder. If main is `nil` then the table can not be iterated with `ipairs` when iterating over that list.