### PR TITLE
[LSP] Add complete support for `CodeActionKind`s to capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -632,7 +632,7 @@ function protocol.make_client_capabilities()
 
         codeActionLiteralSupport = {
           codeActionKind = {
-            valueSet = {};
+            valueSet = vim.tbl_values(protocol.CodeActionKind);
           };
         };
       };
@@ -940,11 +940,9 @@ function protocol.resolve_capabilities(server_capabilities)
 
   if server_capabilities.codeActionProvider == nil then
     general_properties.code_action = false
-  elseif type(server_capabilities.codeActionProvider) == 'boolean' then
+  elseif type(server_capabilities.codeActionProvider) == 'boolean'
+    or type(server_capabilities.codeActionProvider) == 'table' then
     general_properties.code_action = server_capabilities.codeActionProvider
-  elseif type(server_capabilities.codeActionProvider) == 'table' then
-    -- TODO(ashkan) support CodeActionKind
-    general_properties.code_action = false
   else
     error("The server sent invalid codeActionProvider")
   end


### PR DESCRIPTION
The LSP spec is unclear about what exactly specifying support for `CodeActionKind`s means. We support applying all kinds in the spec equivalently and some servers (including dartls) won't send code actions if support for the relevant kinds is not explicitly stated in the client capabilities. Therefore, this PR makes that support explicit.

Also, as we support all `CodeActionKind`s, we should also mark the server as supporting code actions when it specifies code action kinds. This is also done in this PR.

Fixes #13057 