### PR TITLE
vim-patch:8.1.0268: file type checking has too many #ifdef

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -220,13 +220,8 @@ int open_buffer(
     int perm;
 
     perm = os_getperm((const char *)curbuf->b_ffname);
-    if (perm >= 0 && (0
-# ifdef S_ISFIFO
-                      || S_ISFIFO(perm)
-# endif
-# ifdef S_ISSOCK
+    if (perm >= 0 && (0 || S_ISFIFO(perm)
                       || S_ISSOCK(perm)
-# endif
 # ifdef OPEN_CHR_FILES
                       || (S_ISCHR(perm)
                           && is_dev_fd_file(curbuf->b_ffname))

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3398,63 +3398,23 @@ static void f_getftype(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   FileInfo file_info;
   if (os_fileinfo_link(fname, &file_info)) {
     uint64_t mode = file_info.stat.st_mode;
-#ifdef S_ISREG
-    if (S_ISREG(mode))
+    if (S_ISREG(mode)) {
       t = "file";
-    else if (S_ISDIR(mode))
+    } else if (S_ISDIR(mode)) {
       t = "dir";
-# ifdef S_ISLNK
-    else if (S_ISLNK(mode))
+    } else if (S_ISLNK(mode)) {
       t = "link";
-# endif
-# ifdef S_ISBLK
-    else if (S_ISBLK(mode))
+    } else if (S_ISBLK(mode)) {
       t = "bdev";
-# endif
-# ifdef S_ISCHR
-    else if (S_ISCHR(mode))
+    } else if (S_ISCHR(mode)) {
       t = "cdev";
-# endif
-# ifdef S_ISFIFO
-    else if (S_ISFIFO(mode))
+    } else if (S_ISFIFO(mode)) {
       t = "fifo";
-# endif
-# ifdef S_ISSOCK
-    else if (S_ISSOCK(mode))
+    } else if (S_ISSOCK(mode)) {
       t = "socket";
-# endif
-    else
-      t = "other";
-#else
-# ifdef S_IFMT
-    switch (mode & S_IFMT) {
-    case S_IFREG: t = "file"; break;
-    case S_IFDIR: t = "dir"; break;
-#  ifdef S_IFLNK
-    case S_IFLNK: t = "link"; break;
-#  endif
-#  ifdef S_IFBLK
-    case S_IFBLK: t = "bdev"; break;
-#  endif
-#  ifdef S_IFCHR
-    case S_IFCHR: t = "cdev"; break;
-#  endif
-#  ifdef S_IFIFO
-    case S_IFIFO: t = "fifo"; break;
-#  endif
-#  ifdef S_IFSOCK
-    case S_IFSOCK: t = "socket"; break;
-#  endif
-    default: t = "other";
-    }
-# else
-    if (os_isdir((const char_u *)fname)) {
-      t = "dir";
     } else {
-      t = "file";
+      t = "other";
     }
-# endif
-#endif
     type = vim_strsave((char_u *)t);
   }
   rettv->vval.v_string = type;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -473,12 +473,8 @@ readfile(
     // On Unix it is possible to read a directory, so we have to
     // check for it before os_open().
     if (perm >= 0 && !S_ISREG(perm)                 // not a regular file ...
-# ifdef S_ISFIFO
         && !S_ISFIFO(perm)                          // ... or fifo
-# endif
-# ifdef S_ISSOCK
         && !S_ISSOCK(perm)                          // ... or socket
-# endif
 # ifdef OPEN_CHR_FILES
         && !(S_ISCHR(perm) && is_dev_fd_file(fname))
         // ... or a character special file named /dev/fd/<n>
@@ -1840,25 +1836,14 @@ failed:
       c = false;
 
 #ifdef UNIX
-# ifdef S_ISFIFO
-      if (S_ISFIFO(perm)) {                         /* fifo or socket */
-        STRCAT(IObuff, _("[fifo/socket]"));
-        c = TRUE;
-      }
-# else
-#  ifdef S_IFIFO
-      if ((perm & S_IFMT) == S_IFIFO) {             /* fifo */
+      if (S_ISFIFO(perm)) {             // fifo
         STRCAT(IObuff, _("[fifo]"));
         c = TRUE;
       }
-#  endif
-#  ifdef S_IFSOCK
-      if ((perm & S_IFMT) == S_IFSOCK) {            /* or socket */
+      if (S_ISSOCK(perm)) {            // or socket
         STRCAT(IObuff, _("[socket]"));
         c = TRUE;
       }
-#  endif
-# endif
 # ifdef OPEN_CHR_FILES
       if (S_ISCHR(perm)) {                          /* or character special */
         STRCAT(IObuff, _("[character special]"));

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -459,7 +459,7 @@ staterr:
 
   int i;
   // if filename is a directory, append the cscope database name to it
-  if ((file_info.stat.st_mode & S_IFMT) == S_IFDIR) {
+  if (S_ISDIR(file_info.stat.st_mode)) {
     fname2 = (char *)xmalloc(strlen(CSCOPE_DBFILE) + strlen(fname) + 2);
 
     while (fname[strlen(fname)-1] == '/'

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -44,4 +44,55 @@
 # define os_strtok strtok_r
 #endif
 
+// stat macros
+#ifndef S_ISDIR
+# ifdef S_IFDIR
+#  define S_ISDIR(m)    (((m) & S_IFMT) == S_IFDIR)
+# else
+#  define S_ISDIR(m)    0
+# endif
+#endif
+#ifndef S_ISREG
+# ifdef S_IFREG
+#  define S_ISREG(m)    (((m) & S_IFMT) == S_IFREG)
+# else
+#  define S_ISREG(m)    0
+# endif
+#endif
+#ifndef S_ISBLK
+# ifdef S_IFBLK
+#  define S_ISBLK(m)    (((m) & S_IFMT) == S_IFBLK)
+# else
+#  define S_ISBLK(m)    0
+# endif
+#endif
+#ifndef S_ISSOCK
+# ifdef S_IFSOCK
+#  define S_ISSOCK(m)   (((m) & S_IFMT) == S_IFSOCK)
+# else
+#  define S_ISSOCK(m)   0
+# endif
+#endif
+#ifndef S_ISFIFO
+# ifdef S_IFIFO
+#  define S_ISFIFO(m)   (((m) & S_IFMT) == S_IFIFO)
+# else
+#  define S_ISFIFO(m)   0
+# endif
+#endif
+#ifndef S_ISCHR
+# ifdef S_IFCHR
+#  define S_ISCHR(m)    (((m) & S_IFMT) == S_IFCHR)
+# else
+#  define S_ISCHR(m)    0
+# endif
+#endif
+#ifndef S_ISLNK
+# ifdef S_IFLNK
+#  define S_ISLNK(m)    (((m) & S_IFMT) == S_IFLNK)
+# else
+#  define S_ISLNK(m)    0
+# endif
+#endif
+
 #endif  // NVIM_OS_OS_DEFS_H

--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -74,28 +74,6 @@ typedef int mode_t;
 # define O_NOFOLLOW 0
 #endif
 
-#if !defined(S_ISDIR) && defined(S_IFDIR)
-# define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
-#endif
-#if !defined(S_ISREG) && defined(S_IFREG)
-# define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
-#endif
-#if !defined(S_ISLNK) && defined(S_IFLNK)
-# define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
-#endif
-#if !defined(S_ISBLK) && defined(S_IFBLK)
-# define S_ISBLK(m) (((m) & S_IFMT) == S_IFBLK)
-#endif
-#if !defined(S_ISSOCK) && defined(S_IFSOCK)
-# define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
-#endif
-#if !defined(S_ISFIFO) && defined(S_IFIFO)
-# define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
-#endif
-#if !defined(S_ISCHR) && defined(S_IFCHR)
-# define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
-#endif
-
 #ifndef STDIN_FILENO
 # define STDIN_FILENO 0
 #endif

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -316,7 +316,8 @@ enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
 #define LOWEST_WIN_ID 1000
 
 // BSD is supposed to cover FreeBSD and similar systems.
-#if (defined(BSD) || defined(__FreeBSD_kernel__)) && defined(S_ISCHR)
+#if (defined(BSD) || defined(__FreeBSD_kernel__)) \
+    && (defined(S_ISCHR) || defined(S_IFCHR))
 # define OPEN_CHR_FILES
 #endif
 


### PR DESCRIPTION
Problem:    File type checking has too many #ifdef.
Solution:   Always define the S_IF macros. (Ken Takata, closes vim/vim#3306)
https://github.com/vim/vim/commit/d569bb029983cff947dce704e6f830276204c13f