### PR TITLE
lsp: Remove snippet lies

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -639,8 +639,11 @@ function protocol.make_client_capabilities()
       completion = {
         dynamicRegistration = false;
         completionItem = {
+          -- Until we can actually expand snippet, move cursor and allow for true snippet experience,
+          -- this should be disabled out of the box.
+          -- However, users can turn this back on if they have a snippet plugin.
+          snippetSupport = false;
 
-          snippetSupport = true;
           commitCharactersSupport = false;
           preselectSupport = false;
           deprecatedSupport = false;


### PR DESCRIPTION
We don't actually support snippets in core in the way that users would
truly expect. So, by default, we will not say that builtin-lsp has
`snippetSupport`.

To re-enable, users can do the following:

First, get a capabilities dictionary with

`local capabilities = vim.lsp.protocol.make_client_capabilities()`

Then override

`capabilities.textDocument.completion.completionItem.snippetSupport = true`

and then pass those capabilties to the setup function.

```
nvim_lsp.server_name.setup {
  ...,
  capabilities = capabilities,
  ...,
}
```

See https://github.com/neovim/neovim/issues/12795