### PR TITLE
vim-patch:8.1.{2030,2063},8.2.{864,1086,1938}

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -566,9 +566,15 @@ The examples below assume a 'shiftwidth' of 4.
 	      with "#" does not work.
 
 
+	PN    When N is non-zero recognize C pragmas, and indent them like any
+	      other code; does not concern other preprocessor directives.
+	      When N is zero (default): don't recognize C pragmas, treating
+	      them like every other preprocessor directive.
+
+
 The defaults, spelled out in full, are:
 	cinoptions=>s,e0,n0,f0,{0,}0,^0,L-1,:s,=s,l0,b0,gs,hs,N0,E0,ps,ts,is,+s,
-			c3,C0,/0,(2s,us,U0,w0,W0,k0,m0,j0,J0,)20,*70,#0
+			c3,C0,/0,(2s,us,U0,w0,W0,k0,m0,j0,J0,)20,*70,#0,P0
 
 Vim puts a line in column 1 if:
 - It starts with '#' (preprocessor directives), if 'cinkeys' contains '#0'.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -795,6 +795,7 @@ struct file_buffer {
   int b_ind_cpp_namespace;
   int b_ind_if_for_while;
   int b_ind_cpp_extern_c;
+  int b_ind_pragma;
 
   linenr_T b_no_eol_lnum;       /* non-zero lnum when last line of next binary
                                  * write should not have an end-of-line */

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1676,6 +1676,9 @@ void parse_cino(buf_T *buf)
   // Handle C++ extern "C" or "C++"
   buf->b_ind_cpp_extern_c = 0;
 
+  // Handle C #pragma directives
+  buf->b_ind_pragma = 0;
+
   for (p = buf->b_p_cino; *p; ) {
     l = p++;
     if (*p == '-') {
@@ -1747,6 +1750,7 @@ void parse_cino(buf_T *buf)
     case 'N': buf->b_ind_cpp_namespace = n; break;
     case 'k': buf->b_ind_if_for_while = n; break;
     case 'E': buf->b_ind_cpp_extern_c = n; break;
+    case 'P': buf->b_ind_pragma = n; break;
     }
     if (*p == ',')
       ++p;
@@ -1858,12 +1862,14 @@ int get_c_indent(void)
     goto laterend;
   }
 
-  /*
-   * #defines and so on always go at the left when included in 'cinkeys'.
-   */
+  // #defines and so on go at the left when included in 'cinkeys',
+  // exluding pragmas when customized in 'cinoptions'
   if (*theline == '#' && (*linecopy == '#' || in_cinkeys('#', ' ', true))) {
-    amount = curbuf->b_ind_hash_comment;
-    goto theend;
+    const char_u *const directive = skipwhite(theline + 1);
+    if (curbuf->b_ind_pragma == 0 || STRNCMP(directive, "pragma", 6) != 0) {
+      amount = curbuf->b_ind_hash_comment;
+      goto theend;
+    }
   }
 
   /*

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -127,4 +127,40 @@ func Test_cindent_case()
   bwipe!
 endfunc
 
+func Test_cindent_pragma()
+  new
+  setl cindent ts=4 sw=4
+  setl cino=Ps
+
+  let code =<< trim [CODE]
+  {
+  #pragma omp parallel
+  {
+  #pragma omp task
+  foo();
+  # pragma omp taskwait
+  }
+  }
+  [CODE]
+
+  call append(0, code)
+  normal gg
+  normal =G
+
+  let expected =<< trim [CODE]
+  {
+	#pragma omp parallel
+	{
+		#pragma omp task
+		foo();
+		# pragma omp taskwait
+	}
+  }
+
+  [CODE]
+
+  call assert_equal(expected, getline(1, '$'))
+  enew! | close
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
vim-patch:8.2.0864: pragmas are indented all the way to the left

Problem:    Pragmas are indented all the way to the left.
Solution:   Add an option to indent progmas like normal code. (Max Rumpf,
            closes vim/vim#5468)
https://github.com/vim/vim/commit/d881b516da0184052d2f9d33c3f72c5c014316bd

vim-patch:8.2.1086: possibly using freed memory when text properties used
    
Problem:    Possibly using freed memory when text properties used when changing indent of a line.
Solution:   Compute the offset before calling ml_replace().
https://github.com/vim/vim/commit/cf30643ae607ae1a97b50e19c622dc8303723fa2

N/A patches for version.c:

vim-patch:8.1.2030: tests fail when build with normal features and terminal

Problem:    Tests fail when build with normal features and terminal.
            (Dominique Pelle)
Solution:   Disable tests that won't work. (closes vim/vim#4932)
https://github.com/vim/vim/commit/997d42427eaab889058eb047e08d55de9e4a968a

vim-patch:8.1.2063: some tests fail when +balloon_eval_term is missing

Problem:    Some tests fail when +balloon_eval_term is missing but
            _balloon_eval is present. (Dominique Pelle)
Solution:   Check the right feature in the test. (closes vim/vim#4962)
https://github.com/vim/vim/commit/1e82a784ace6d2c4dce594dd6156bcb0028bba9e

vim-patch:8.2.1938: wiping out a terminal buffer makes some tests fail

Problem:    Wiping out a terminal buffer makes some tests fail.
Solution:   Do not wipe out the terminal buffer unless wanted.
https://github.com/vim/vim/commit/a46765a79745ff27b4a44659fb8389519c961977