### PR TITLE
BufModifiedSet event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -253,6 +253,9 @@ BufLeave			Before leaving to another buffer.  Also when
 				new current window is not for the same buffer.
 
 				Not used for ":qa" or ":q" when exiting Vim.
+							*BufModifiedSet*
+BufModifiedSet			After the `'modified'` value of a buffer has
+				been changed.
 							*BufNew*
 BufNew				Just after creating a new buffer.  Also used
 				just after a buffer has been renamed.  When

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -7,6 +7,7 @@ return {
     'BufFilePre',             -- before renaming a buffer
     'BufHidden',              -- just after buffer becomes hidden
     'BufLeave',               -- before leaving a buffer
+    'BufModified',            -- after the 'modified' state of a buffer changes
     'BufNew',                 -- after creating any buffer
     'BufNewFile',             -- when creating a buffer for a new file
     'BufReadCmd',             -- read buffer using command
@@ -124,6 +125,7 @@ return {
   -- List of nvim-specific events or aliases for the purpose of generating
   -- syntax file
   nvim_specific = {
+    BufModified=true,
     DirChanged=true,
     Signal=true,
     TabClosed=true,

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -7,7 +7,7 @@ return {
     'BufFilePre',             -- before renaming a buffer
     'BufHidden',              -- just after buffer becomes hidden
     'BufLeave',               -- before leaving a buffer
-    'BufModified',            -- after the 'modified' state of a buffer changes
+    'BufModifiedSet',         -- after the 'modified' state of a buffer changes
     'BufNew',                 -- after creating any buffer
     'BufNewFile',             -- when creating a buffer for a new file
     'BufReadCmd',             -- read buffer using command
@@ -125,7 +125,7 @@ return {
   -- List of nvim-specific events or aliases for the purpose of generating
   -- syntax file
   nvim_specific = {
-    BufModified=true,
+    BufModifiedSet=true,
     DirChanged=true,
     Signal=true,
     TabClosed=true,

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -541,8 +541,9 @@ struct file_buffer {
 
   int b_changed;                // 'modified': Set to true if something in the
                                 // file has been changed and not written out.
-  bool b_changed_notified;      // if the BufModified autocmd has been triggered
-                                // since the last time b_changed was modified
+  bool b_changed_invalid;       // Set if BufModified autocmd has not been
+                                // triggered since the last time b_changed was
+                                // modified.
 
   /// Change-identifier incremented for each change, including undo.
   ///

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -541,6 +541,8 @@ struct file_buffer {
 
   int b_changed;                // 'modified': Set to true if something in the
                                 // file has been changed and not written out.
+  bool b_changed_notified;      // if the BufModified autocmd has been triggered
+                                // since the last time b_changed was modified
 
   /// Change-identifier incremented for each change, including undo.
   ///

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -129,6 +129,7 @@ void changed(void)
 void changed_internal(void)
 {
   curbuf->b_changed = true;
+  curbuf->b_changed_notified = false;
   ml_setflags(curbuf);
   check_status(curbuf);
   redraw_tabline = true;
@@ -502,6 +503,7 @@ void unchanged(buf_T *buf, int ff, bool always_inc_changedtick)
 {
   if (buf->b_changed || (ff && file_ff_differs(buf, false))) {
     buf->b_changed = false;
+    buf->b_changed_notified = false;
     ml_setflags(buf);
     if (ff) {
       save_file_ff(buf);

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -129,7 +129,7 @@ void changed(void)
 void changed_internal(void)
 {
   curbuf->b_changed = true;
-  curbuf->b_changed_notified = false;
+  curbuf->b_changed_invalid = true;
   ml_setflags(curbuf);
   check_status(curbuf);
   redraw_tabline = true;
@@ -503,7 +503,7 @@ void unchanged(buf_T *buf, int ff, bool always_inc_changedtick)
 {
   if (buf->b_changed || (ff && file_ff_differs(buf, false))) {
     buf->b_changed = false;
-    buf->b_changed_notified = false;
+    buf->b_changed_invalid = true;
     ml_setflags(buf);
     if (ff) {
       save_file_ff(buf);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1488,12 +1488,12 @@ static void ins_redraw(
     do_autocmd_winscrolled(curwin);
   }
 
-  // Trigger BufModified if b_changed_notified is false.
+  // Trigger BufModified if b_changed_invalid is set.
   if (ready && has_event(EVENT_BUFMODIFIEDSET)
-      && curbuf->b_changed_notified == false
+      && curbuf->b_changed_invalid == true
       && !pum_visible()) {
     apply_autocmds(EVENT_BUFMODIFIEDSET, NULL, NULL, false, curbuf);
-    curbuf->b_changed_notified = true;
+    curbuf->b_changed_invalid = false;
   }
 
   if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1489,10 +1489,10 @@ static void ins_redraw(
   }
 
   // Trigger BufModified if b_changed_notified is false.
-  if (ready && has_event(EVENT_BUFMODIFIED)
+  if (ready && has_event(EVENT_BUFMODIFIEDSET)
       && curbuf->b_changed_notified == false
       && !pum_visible()) {
-    apply_autocmds(EVENT_BUFMODIFIED, NULL, NULL, false, curbuf);
+    apply_autocmds(EVENT_BUFMODIFIEDSET, NULL, NULL, false, curbuf);
     curbuf->b_changed_notified = true;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1488,6 +1488,14 @@ static void ins_redraw(
     do_autocmd_winscrolled(curwin);
   }
 
+  // Trigger BufModified if b_changed_notified is false.
+  if (ready && has_event(EVENT_BUFMODIFIED)
+      && curbuf->b_changed_notified == false
+      && !pum_visible()) {
+    apply_autocmds(EVENT_BUFMODIFIED, NULL, NULL, false, curbuf);
+    curbuf->b_changed_notified = true;
+  }
+
   if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)
       && conceal_cursor_moved) {
     redrawWinline(curwin, curwin->w_cursor.lnum);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1233,9 +1233,9 @@ static void normal_check_buffer_modified(NormalState *s)
 {
   // Trigger BufModified if b_modified changed
   if (!finish_op && has_event(EVENT_BUFMODIFIEDSET)
-      && curbuf->b_changed_notified == false) {
+      && curbuf->b_changed_invalid == true) {
     apply_autocmds(EVENT_BUFMODIFIEDSET, NULL, NULL, false, curbuf);
-    curbuf->b_changed_notified = true;
+    curbuf->b_changed_invalid = false;
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1232,9 +1232,9 @@ static void normal_check_text_changed(NormalState *s)
 static void normal_check_buffer_modified(NormalState *s)
 {
   // Trigger BufModified if b_modified changed
-  if (!finish_op && has_event(EVENT_BUFMODIFIED)
+  if (!finish_op && has_event(EVENT_BUFMODIFIEDSET)
       && curbuf->b_changed_notified == false) {
-    apply_autocmds(EVENT_BUFMODIFIED, NULL, NULL, false, curbuf);
+    apply_autocmds(EVENT_BUFMODIFIEDSET, NULL, NULL, false, curbuf);
     curbuf->b_changed_notified = true;
   }
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1229,6 +1229,16 @@ static void normal_check_text_changed(NormalState *s)
   }
 }
 
+static void normal_check_buffer_modified(NormalState *s)
+{
+  // Trigger BufModified if b_modified changed
+  if (!finish_op && has_event(EVENT_BUFMODIFIED)
+      && curbuf->b_changed_notified == false) {
+    apply_autocmds(EVENT_BUFMODIFIED, NULL, NULL, false, curbuf);
+    curbuf->b_changed_notified = true;
+  }
+}
+
 static void normal_check_folds(NormalState *s)
 {
   // Include a closed fold completely in the Visual area.
@@ -1336,6 +1346,7 @@ static int normal_check(VimState *state)
     normal_check_cursor_moved(s);
     normal_check_text_changed(s);
     normal_check_window_scrolled(s);
+    normal_check_buffer_modified(s);
 
     // Updating diffs from changed() does not always work properly,
     // esp. updating folds.  Do an update just before redrawing if

--- a/test/functional/autocmd/bufmodifiedset_spec.lua
+++ b/test/functional/autocmd/bufmodifiedset_spec.lua
@@ -1,0 +1,20 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local eq = helpers.eq
+local eval = helpers.eval
+local source = helpers.source
+
+describe('BufModified', function()
+  before_each(clear)
+
+  it('is triggered when modified and un-modified', function()
+    source([[
+    let g:modified = 0
+    autocmd BufModifiedSet * let g:modified += 1
+    execute "normal! aa\<Esc>"
+    execute "normal! u"
+    ]])
+    eq(2, eval('g:modified'))
+  end)
+end)

--- a/test/functional/autocmd/bufmodifiedset_spec.lua
+++ b/test/functional/autocmd/bufmodifiedset_spec.lua
@@ -4,6 +4,7 @@ local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
 local source = helpers.source
+local request = helpers.request
 
 describe('BufModified', function()
   before_each(clear)
@@ -12,9 +13,9 @@ describe('BufModified', function()
     source([[
     let g:modified = 0
     autocmd BufModifiedSet * let g:modified += 1
-    execute "normal! aa\<Esc>"
-    execute "normal! u"
     ]])
+    request("nvim_command", [[normal! aa\<Esc>]])
+    request("nvim_command", [[normal! u]])
     eq(2, eval('g:modified'))
   end)
 end)

--- a/test/functional/autocmd/bufmodifiedset_spec.lua
+++ b/test/functional/autocmd/bufmodifiedset_spec.lua
@@ -15,6 +15,7 @@ describe('BufModified', function()
     autocmd BufModifiedSet * let g:modified += 1
     ]])
     request("nvim_command", [[normal! aa\<Esc>]])
+    eq(1, eval('g:modified'))
     request("nvim_command", [[normal! u]])
     eq(2, eval('g:modified'))
   end)


### PR DESCRIPTION
POC implementation, comments welcome on the viability of the PR.

TBD:
 - As per comment in `get_option_value()`: `// Special case: 'modified' is b_changed, but we also want to consider it set when 'ff' or 'fenc' changed.`. We might want to extend the logic here to fulfill that behavior.
 - Event when non-current buffer is modified
