### PR TITLE
vim-patch:8.2.{1165,1942}

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -450,7 +450,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 
   // skip line number and fold column in front of the line
   col -= win_col_off(win);
-  if (col < 0) {
+  if (col <= 0) {
     col = 0;
   }
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3602,6 +3602,10 @@ func Test_lhelpgrep_autocmd()
     au BufEnter * call setqflist([], 'f')
   augroup END
   call assert_fails('helpgrep quickfix', 'E925:')
+  " run the test with a help window already open
+  help
+  wincmd w
+  call assert_fails('helpgrep quickfix', 'E925:')
   augroup QF_Test
     au! BufEnter
   augroup END

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -3,7 +3,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
 local eq = helpers.eq
-local neq = helpers.neq
 local NIL = helpers.NIL
 local feed = helpers.feed
 local clear = helpers.clear
@@ -13,7 +12,6 @@ local iswin = helpers.iswin
 local command = helpers.command
 local write_file = helpers.write_file
 local redir_exec = helpers.redir_exec
-local alter_slashes = helpers.alter_slashes
 local exec_lua = helpers.exec_lua
 
 local screen


### PR DESCRIPTION
Included a fixup commit for https://github.com/neovim/neovim/pull/13119 so that `make lint` passes.