### PR TITLE
vim-patch:8.2.1947: crash when using "zj" without folds

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -888,6 +888,9 @@ int foldMoveTo(
     // that moves the cursor is used.
     linenr_T lnum_off = 0;
     garray_T *gap = &curwin->w_folds;
+    if (gap->ga_len == 0) {
+      break;
+    }
     bool use_level = false;
     bool maybe_small = false;
     linenr_T lnum_found = curwin->w_cursor.lnum;

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -795,3 +795,14 @@ func Test_fold_delete_first_line()
   bwipe!
   set foldmethod&
 endfunc
+
+" this was crashing
+func Test_move_no_folds()
+  new
+  fold
+  setlocal fdm=expr
+  normal zj
+  bwipe!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Crash when using "zj" without folds. (Sean Dewar)
Solution:   Check for at least one fold. (closes vim/vim#7245)
https://github.com/vim/vim/commit/c136a3528b7ebb825c3863d701af44f023381181