### PR TITLE
vim-patch:8.1.{1829,1956,2234},8.2.1944

### DIFF
--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -291,6 +291,9 @@ func GetVimCommandClean()
   let cmd = substitute(cmd, '-u NONE', '--clean', '')
   let cmd = substitute(cmd, '--headless', '', '')
 
+  " Force using utf-8, Vim may pick up something else from the environment.
+  " let cmd ..= ' --cmd "set enc=utf8" '
+
   " Optionally run Vim under valgrind
   " let cmd = 'valgrind --tool=memcheck --leak-check=yes --num-callers=25 --log-file=valgrind ' . cmd
 

--- a/src/nvim/testdir/test_windows_home.vim
+++ b/src/nvim/testdir/test_windows_home.vim
@@ -1,8 +1,7 @@
 " Test for $HOME on Windows.
 
-if !has('win32')
-  finish
-endif
+source check.vim
+CheckMSWindows
 
 let s:env = {}
 


### PR DESCRIPTION
vim-patch:8.1.1829: difference in screenshots

Problem:    Difference in screenshots.
Solution:   Update screenshots.  Change checks in a few more tests.
            (closes vim/vim#4789)
https://github.com/vim/vim/commit/39de6413c8b7bae882bed3dba636f6d52d793087

vim-patch:8.1.1956: screenshot tests may use a different encoding

Problem:    Screenshot tests may use a different encoding. (Dominique Pelle)
Solution:   Always set 'encoding' to "utf-8" when running Vim in a terminal.
            (closes vim/vim#4884)
vim/vim@0fdddee

N/A patches for version.c:

vim-patch:8.1.2234: get_short_pathname() fails depending on encoding

Problem:    get_short_pathname() fails depending on encoding.
Solution:   Use the wide version of the library function. (closes vim/vim#5129)
https://github.com/vim/vim/commit/3f39697b73f661d6900c7cf5430d967a129660d7

vim-patch:8.2.1944: Netbeans test is flaky

Problem:    Netbeans test is flaky.
Solution:   Add a short delay. (Yegappan Lakshmanan, closes vim/vim#7246)
https://github.com/vim/vim/commit/6fd3a4ba2320c4a95f02daef5f2ac76d3105d013