### PR TITLE
Add g:loaded_matchit check

### DIFF
--- a/runtime/plugin/matchit.vim
+++ b/runtime/plugin/matchit.vim
@@ -1,4 +1,4 @@
 " Nvim: load the matchit plugin by default.
-if stridx(&packpath, $VIMRUNTIME) >= 0
+if !exists("g:loaded_matchit") && stridx(&packpath, $VIMRUNTIME) >= 0
   packadd matchit
 endif


### PR DESCRIPTION
I have added `g:loaded_matchit` check to skip matchit loading like other default plugins.