### PR TITLE
[RDY] lsp: fix formatting_sync with multiple clients

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -138,8 +138,9 @@ end
 function M.formatting_sync(options, timeout_ms)
   local params = util.make_formatting_params(options)
   local result = vim.lsp.buf_request_sync(0, "textDocument/formatting", params, timeout_ms)
-  if not result then return end
-  result = result[1].result
+  if not result or vim.tbl_isempty(result) then return end
+  local _, formatting_result = next(result)
+  result = formatting_result.result
   if not result then return end
   vim.lsp.util.apply_text_edits(result)
 end


### PR DESCRIPTION
buf_request_sync returns a table indexed by the client id, so when
starting a second client on a separate buffer, result[1] will be nil.

Closes #13232.