### PR TITLE
vim-patch:8.2.0602: :unlet $VAR does not work properly

### DIFF
--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -233,6 +233,8 @@ typedef enum {
   kDictListItems,  ///< List dictionary contents: [keys, values].
 } DictListType;
 
+typedef int (*ex_unletlock_callback)(lval_T *, char_u *, exarg_T *, int);
+
 // Used for checking if local variables or arguments used in a lambda.
 extern bool *eval_lavars_used;
 

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1393,6 +1393,20 @@ func Test_compound_assignment_operators()
     let @/ = ''
 endfunc
 
+func Test_unlet_env()
+    let $TESTVAR = 'yes'
+    call assert_equal('yes', $TESTVAR)
+    call assert_fails('lockvar $TESTVAR', 'E940')
+    call assert_fails('unlockvar $TESTVAR', 'E940')
+    call assert_equal('yes', $TESTVAR)
+    if 0
+        unlet $TESTVAR
+    endif
+    call assert_equal('yes', $TESTVAR)
+    unlet $TESTVAR
+    call assert_equal('', $TESTVAR)
+endfunc
+
 func Test_funccall_garbage_collect()
     func Func(x, ...)
         call add(a:x, a:000)


### PR DESCRIPTION
Problem:    :unlet $VAR does not work properly.
Solution:   Make ":lockvar $VAR" fail.  Check the "skip" flag.
https://github.com/vim/vim/commit/7e0868efcf094f2cc59fa4e18af3a8dc7aedd64f

Would like some input on this patch; it's one of my first for neovim!

I decided to use a bit of [patch 8.2.0601](https://github.com/vim/vim/commit/d72c1bf0a6784afdc8d8ceab4a007cd76d5b81e1)'s callback-related stuff for `ex_unletlock()`; I'm unsure if that was a good idea as that patch mostly relates to Vim9. I can implement this patch without those changes if that's wanted instead.

Cheers!