### PR TITLE
Update the differences with Vim

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -113,7 +113,6 @@ Working intuitively and consistently is a major goal of Nvim.
 Usability details have been improved where the benefit outweighs any
 backwards-compatibility cost. Some examples:
 
-- |K| in help documents can be used like |CTRL-]|.
 - Directories for 'directory' and 'undodir' are auto-created.
 - Terminal features such as 'guicursor' are enabled where possible.
 
@@ -147,19 +146,15 @@ Command-line highlighting:
 Commands:
   |:autocmd| accepts the `++once` flag
   |:checkhealth|
-  |:cquit| can use [count] to set the exit code
   |:drop| is always available
   |:Man| is available by default, with many improvements such as completion
   |:sign-define| accepts a `numhl` argument, to highlight the line number
-  |:tchdir| tab-local |current-directory|
 
 Events:
-  |DirChanged|
   |Signal|
   |TabNewEntered|
   |TermClose|
   |TermOpen|
-  |TextYankPost|
   |UIEnter|
   |UILeave|
   |VimResume|
@@ -173,7 +168,6 @@ Functions:
   |msgpackdump()|, |msgpackparse()| provide msgpack de/serialization
   |stdpath()|
   |system()|, |systemlist()| can run {cmd} directly (without 'shell')
-  |tabpagenr()| "#" argument
 
 Highlight groups:
   |highlight-blend| controls blend level for a highlight group
@@ -182,7 +176,6 @@ Highlight groups:
   |hl-NormalNC| highlights non-current windows
   |hl-MsgArea| highlights messages/cmdline area
   |hl-MsgSeparator| highlights separator for scrolled messages
-  |hl-QuickFixLine|
   |hl-Substitute|
   |hl-TermCursor|
   |hl-TermCursorNC|
@@ -198,7 +191,6 @@ Input/Mappings:
   ALT behaves like <Esc> if not mapped. |i_ALT| |v_ALT| |c_ALT|
 
 Normal commands:
-  |g<Tab>| goes to the last-accessed tabpage.
   |gO| shows a filetype-defined "outline" of the current buffer.
 
 Options:
@@ -223,7 +215,6 @@ Signs:
   Signs are removed if the associated line is deleted.
 
 Variables:
-  |v:event|
   |v:exiting|
   |v:progpath| is always absolute ("full")
   |v:windowid| is always available (for use by external UIs)


### PR DESCRIPTION
:cquit can use count to set the exit code
    patch 8.2.0095: cannot specify exit code for :cquit

:tchdir tab-local current-directory
    patch 8.1.1218: cannot set a directory for a tab page

Autocmd Events:
    - DirChanged
	patch 8.0.1459: cannot handle change of directory
    - TextYankPost
	patch 8.0.1394: cannot intercept a yank command

tabpagenr() "#" argument
g<Tab> goes to the last-accessed tabpage.
    patch 8.2.1401: cannot jump to the last used tabpage

hl-QuickFixLine
    patch 8.0.0641: cannot set a separate highlighting for the quickfix line

v:event
    patch 8.0.1394: cannot intercept a yank command

K in help documents can be used like CTRL-].
    This is added as part of a runtime update.
    https://github.com/vim/vim/commit/4c05fa08c9739e307ddc88ac91ba6d208f1fd68e

