### PR TITLE
tree-sitter: Put base languages first in queries

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -38,9 +38,8 @@ end
 
 local function get_query_files(lang, query_name, is_included)
   local lang_files = filtered_runtime_queries(lang, query_name)
-  local query_files = lang_files
 
-  if #query_files == 0 then return {} end
+  if #lang_files == 0 then return {} end
 
   local base_langs = {}
 
@@ -51,7 +50,7 @@ local function get_query_files(lang, query_name, is_included)
   -- {language} ::= {lang} | ({lang})
   local MODELINE_FORMAT = "^;+%s*inherits%s*:?%s*([a-z_,()]+)%s*$"
 
-  for _, file in ipairs(query_files) do
+  for _, file in ipairs(lang_files) do
     local modeline = vim.fn.readfile(file, "", 1)
 
     if #modeline == 1 then
@@ -73,10 +72,12 @@ local function get_query_files(lang, query_name, is_included)
     end
   end
 
+  local query_files = {}
   for _, base_lang in ipairs(base_langs) do
     local base_files = get_query_files(base_lang, query_name, true)
     vim.list_extend(query_files, base_files)
   end
+  vim.list_extend(query_files, lang_files)
 
   return query_files
 end


### PR DESCRIPTION
This reverts the handling of base languages to the old way how
nvim-treesitter handled them. When a language extends a base language
it usually wants to be able to overwrite queries.

So base language queries should be put before the queries of the current language.

Related: https://github.com/nvim-treesitter/nvim-treesitter/issues/633
