### PR TITLE
Fix PVS-Studio analysis

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -346,7 +346,7 @@ patch_sources() {(
   if test "$only_build" != "--only-build" ; then
     find \
       src/nvim test/functional/fixtures test/unit/fixtures \
-      -name '*.c' \
+      \( -name '*.c' -a '!' -path '*xdiff*' \) \
       -exec /bin/sh -c "$sh_script" - '{}' \;
   fi
 
@@ -373,6 +373,7 @@ run_analysis() {(
     analyze \
       --lic-file PVS-Studio.lic \
       --threads "$(get_jobs_num)" \
+      --exclude-path src/nvim/xdiff \
       --output-file PVS-studio.log \
       --file build/compile_commands.json \
       --sourcetree-root . || true

--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -363,10 +363,15 @@ run_analysis() {(
 
   cd "$tgt"
 
+  if [ ! -r PVS-Studio.lic ]; then
+    pvs-studio-analyzer credentials -o PVS-Studio.lic 'PVS-Studio Free' 'FREE-FREE-FREE-FREE'
+  fi
+
   # pvs-studio-analyzer exits with a non-zero exit code when there are detected
   # errors, so ignore its return
   pvs-studio-analyzer \
     analyze \
+      --lic-file PVS-Studio.lic \
       --threads "$(get_jobs_num)" \
       --output-file PVS-studio.log \
       --file build/compile_commands.json \

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -1,7 +1,6 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-//
-//
+
 #include "nvim/vim.h"
 #include "nvim/extmark.h"
 #include "nvim/decoration.h"

--- a/test/functional/fixtures/streams-test.c
+++ b/test/functional/fixtures/streams-test.c
@@ -1,3 +1,6 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
 /// Helper program to exit and keep stdout open (like "xclip -i -loops 1").
 #include <stdio.h>
 


### PR DESCRIPTION
* License file is required since release 7.10, so create it as part of analysis.
* Exclude xdiff from analysis since that's 3rd party code
* Add the PVS-Studio comment to new files