### PR TITLE
improve error message to make it actionable

### DIFF
--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -250,7 +250,7 @@ for i = 1, #functions do
         end
         output:write('\n  } else {')
         output:write('\n    api_set_error(error, kErrorTypeException, \
-          "Wrong type for argument '..j..', expecting '..param[1]..'");')
+          "Wrong type for argument '..j..' when calling '..fn.name..', expecting '..param[1]..'");')
         output:write('\n    goto cleanup;')
         output:write('\n  }\n')
       else

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -57,7 +57,7 @@ describe('API: highlight',function()
     -- Test nil argument.
     err, emsg = pcall(meths.get_hl_by_id, { nil }, false)
     eq(false, err)
-    eq('Wrong type for argument 1, expecting Integer',
+    eq('Wrong type for argument 1 when calling nvim_get_hl_by_id, expecting Integer',
        string.match(emsg, 'Wrong.*'))
 
     -- Test 0 argument.
@@ -112,7 +112,7 @@ describe('API: highlight',function()
     -- Test nil argument.
     err, emsg = pcall(meths.get_hl_by_name , { nil }, false)
     eq(false, err)
-    eq('Wrong type for argument 1, expecting String',
+    eq('Wrong type for argument 1 when calling nvim_get_hl_by_name, expecting String',
        string.match(emsg, 'Wrong.*'))
 
     -- Test empty string argument.

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -751,7 +751,7 @@ describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()
   end
 
   it('rejects negative bufnr values', function()
-    eq('Wrong type for argument 1, expecting Buffer',
+    eq('Wrong type for argument 1 when calling nvim_buf_set_keymap, expecting Buffer',
       pcall_err(bufmeths.set_keymap, -1, '', 'lhs', 'rhs', {}))
   end)
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1350,7 +1350,7 @@ describe('API', function()
       eq({info=info}, meths.get_var("info_event"))
       eq({[1]=testinfo,[2]=stderr,[3]=info}, meths.list_chans())
 
-      eq("Vim:Error invoking 'nvim_set_current_buf' on channel 3 (amazing-cat):\nWrong type for argument 1, expecting Buffer",
+      eq("Vim:Error invoking 'nvim_set_current_buf' on channel 3 (amazing-cat):\nWrong type for argument 1 when calling nvim_set_current_buf, expecting Buffer",
          pcall_err(eval, 'rpcrequest(3, "nvim_set_current_buf", -1)'))
     end)
 
@@ -1512,7 +1512,7 @@ describe('API', function()
   it("does not leak memory on incorrect argument types", function()
     local status, err = pcall(nvim, 'set_current_dir',{'not', 'a', 'dir'})
     eq(false, status)
-    ok(err:match(': Wrong type for argument 1, expecting String') ~= nil)
+    ok(err:match(': Wrong type for argument 1 when calling set_current_dir, expecting String') ~= nil)
   end)
 
   describe('nvim_parse_expression', function()

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1512,7 +1512,7 @@ describe('API', function()
   it("does not leak memory on incorrect argument types", function()
     local status, err = pcall(nvim, 'set_current_dir',{'not', 'a', 'dir'})
     eq(false, status)
-    ok(err:match(': Wrong type for argument 1 when calling set_current_dir, expecting String') ~= nil)
+    ok(err:match(': Wrong type for argument 1 when calling nvim_set_current_dir, expecting String') ~= nil)
   end)
 
   describe('nvim_parse_expression', function()

--- a/test/functional/eval/api_functions_spec.lua
+++ b/test/functional/eval/api_functions_spec.lua
@@ -35,13 +35,13 @@ describe('eval-API', function()
     eq('Vim(call):E119: Not enough arguments for function: nvim_set_option', err)
 
     err = exc_exec('call nvim_buf_set_lines(1, 0, -1, [], ["list"])')
-    eq('Vim(call):E5555: API call: Wrong type for argument 4, expecting Boolean', err)
+    eq('Vim(call):E5555: API call: Wrong type for argument 4 when calling nvim_buf_set_lines, expecting Boolean', err)
 
     err = exc_exec('call nvim_buf_set_lines(0, 0, -1, v:true, "string")')
-    eq('Vim(call):E5555: API call: Wrong type for argument 5, expecting ArrayOf(String)', err)
+    eq('Vim(call):E5555: API call: Wrong type for argument 5 when calling nvim_buf_set_lines, expecting ArrayOf(String)', err)
 
     err = exc_exec('call nvim_buf_get_number("0")')
-    eq('Vim(call):E5555: API call: Wrong type for argument 1, expecting Buffer', err)
+    eq('Vim(call):E5555: API call: Wrong type for argument 1 when calling nvim_buf_get_number, expecting Buffer', err)
 
     err = exc_exec('call nvim_buf_line_count(17)')
     eq('Vim(call):E5555: API call: Invalid buffer id: 17', err)


### PR DESCRIPTION
Tiny improvement in error message that helped me debug:

```
Error executing vim.schedule lua callback: Vim:E5555: API call: Wrong type for argument 4, expecting String
```

The error is now showing:

```
Error executing vim.schedule lua callback: Vim:E5555: API call: Wrong type for argument 4 when calling nvim_buf_set_keymap, expecting String
```