### PR TITLE
lsp: Expose all diagnostics

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1032,6 +1032,12 @@ get({bufnr}, {client_id})                           *vim.lsp.diagnostic.get()*
                                  diagnostics. Else, return just the
                                  diagnostics associated with the client_id.
 
+get_all()                                       *vim.lsp.diagnostic.get_all()*
+                Get all diagnostics for all clients
+
+                Return: ~
+                    Diagnostic[]
+
                                               *vim.lsp.diagnostic.get_count()*
 get_count({bufnr}, {severity}, {client_id})
                 Get the counts for a particular severity

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -305,6 +305,20 @@ end
 -- }}}
 -- Diagnostic Retrieval {{{
 
+
+--- Get all diagnostics for all clients
+---
+---@return Diagnostic[]
+function M.get_all()
+  local all_diagnostics = {}
+  for _, buf_diagnostics in pairs(diagnostic_cache) do
+    for _, client_diagnostics in pairs(buf_diagnostics) do
+      vim.list_extend(all_diagnostics, client_diagnostics)
+    end
+  end
+  return all_diagnostics
+end
+
 --- Return associated diagnostics for bufnr
 ---
 ---@param bufnr number

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -990,10 +990,6 @@ function M.display(diagnostics, bufnr, client_id, config)
     update_in_insert = false,
   }, config)
 
-  if diagnostics == nil then
-    diagnostics = M.get(bufnr, client_id)
-  end
-
   -- TODO(tjdevries): Consider how we can make this a "standardized" kind of thing for |lsp-handlers|.
   --    It seems like we would probably want to do this more often as we expose more of them.
   --    It provides a very nice functional interface for people to override configuration.
@@ -1031,7 +1027,7 @@ function M.display(diagnostics, bufnr, client_id, config)
 
   M.clear(bufnr, client_id)
 
-  diagnostics = diagnostics or diagnostic_cache[bufnr][client_id]
+  diagnostics = diagnostics or M.get(bufnr, client_id)
 
   if not diagnostics or vim.tbl_isempty(diagnostics) then
     return

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -67,6 +67,22 @@ describe('vim.lsp.diagnostic', function()
 
   describe('vim.lsp.diagnostic', function()
     describe('handle_publish_diagnostics', function()
+      it('should be able to retrieve diagnostics from all buffers and clients', function()
+        eq(3, exec_lua [[
+          vim.lsp.diagnostic.save(
+            {
+              make_error('Diagnostic #1', 1, 1, 1, 1),
+              make_error('Diagnostic #2', 2, 1, 2, 1),
+            }, 0, 1
+          )
+          vim.lsp.diagnostic.save(
+            {
+              make_error('Diagnostic #3', 3, 1, 3, 1),
+            }, 1, 2
+          )
+          return #vim.lsp.diagnostic.get_all()
+        ]])
+      end)
       it('should be able to save and count a single client error', function()
         eq(1, exec_lua [[
           vim.lsp.diagnostic.save(


### PR DESCRIPTION
Before the changes in #12655 it was possible to retrieve all diagnostics 
via `vim.lsp.util.diagnostics_by_buf`.

This adds a `diagnostic.get_all()` to enable users to retrieve all 
diagnostics again.

Use cases for that could include loading all diagnostics into the quickfix
list, or to build an enhanced goto_next that can move across buffers.
With compiled languages it is common to move from one compile error to the next.


---


Note sure if a new method is the best option, or if `get` should be extended
somehow instead. Happy to adjust it.