### PR TITLE
Add Linux ASAN/lint CI via GitHub Actions

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -20,7 +20,7 @@ sources:
 environment:
   SOURCEHUT: 1
   LANG: en_US.UTF-8
-  CMAKE_EXTRA_FLAGS: -DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3
+  CMAKE_EXTRA_FLAGS: -DCI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
 - build-deps: |

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -19,7 +19,7 @@ sources:
 environment:
   SOURCEHUT: 1
   LC_CTYPE: en_US.UTF-8
-  CMAKE_EXTRA_FLAGS: -DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3
+  CMAKE_EXTRA_FLAGS: -DCI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
 - build-deps: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,8 +69,10 @@ jobs:
         env:
           cache-name: asan-deps
         with:
-          path: env.CACHE_NVIM_DEPS_DIR
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.base_ref }}
+          path: |
+            ${{ env.CACHE_NVIM_DEPS_DIR }}
+            ~/.ccache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles(format('{0}/**', env.CACHE_NVIM_DEPS_DIR)) }}-${{ github.base_ref }}
 
       - name: Build third-party
         run: ./ci/before_script.sh
@@ -119,8 +121,10 @@ jobs:
         env:
           cache-name: lint-deps
         with:
-          path: env.CACHE_NVIM_DEPS_DIR
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.base_ref }}
+          path: |
+            ${{ env.CACHE_NVIM_DEPS_DIR }}
+            ~/.ccache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles(format('{0}/**', env.CACHE_NVIM_DEPS_DIR)) }}-${{ github.base_ref }}
 
       - name: Build third-party
         run: ./ci/before_script.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,77 @@
+name: Linux CI
+on: [push, pull_request]
+env:
+  # Set "false" to force rebuild of third-party dependencies.
+  CACHE_ENABLE: true
+  DEPS_CMAKE_FLAGS: "-DUSE_BUNDLED_GPERF=OFF"
+  # default target name for functional tests
+  FUNCTIONALTEST: functionaltest
+  CI_TARGET: tests
+  # Environment variables for ccache
+  CCACHE_COMPRESS: 1
+  CCACHE_SLOPPINESS: "time_macros,file_macro"
+  # Default since 3.3; required with newer gcc/clang.
+  CCACHE_CPP2: 1
+
+jobs:
+  ASAN:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang-11
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup commom environment variables
+        run: |
+          echo "CI_BUILD_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "BUILD_DIR=$GITHUB_WORKSPACE/build" >> $GITHUB_ENV
+          echo "DEPS_BUILD_DIR=$HOME/nvim-deps" >> $GITHUB_ENV
+          echo "INSTALL_PREFIX=$HOME/nvim-install" >> $GITHUB_ENV
+          echo "LOG_DIR=$GITHUB_WORKSPACE/build/log" >> $GITHUB_ENV
+          echo "NVIM_LOG_FILE=$GITHUB_WORKSPACE/build/.nvimlog" >> $GITHUB_ENV
+          echo "CMAKE_FLAGS=-DCI_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=$HOME/nvim-install -DBUSTED_OUTPUT_TYPE=nvim -DDEPS_PREFIX=$HOME/nvim-deps/usr -DMIN_LOG_LEVEL=3" >> $GITHUB_ENV
+          echo "ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan" >> $GITHUB_ENV
+          echo "TSAN_OPTIONS=log_path=$GITHUB_WORKSPACE/build/log/tsan" >> $GITHUB_ENV
+          echo "UBSAN_OPTIONS=print_stacktrace=1 log_path=$GITHUB_WORKSPACE/build/log/ubsan" >> $GITHUB_ENV
+          echo "VALGRIND_LOG=$GITHUB_WORKSPACE/build/log/valgrind-%p.log" >> $GITHUB_ENV
+          echo "CACHE_NVIM_DEPS_DIR=$HOME/.cache/nvim-deps" >> $GITHUB_ENV
+          echo "CACHE_MARKER=$HOME/.cache/nvim-deps/.ci_cache_marker" >> $GITHUB_ENV
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Setup clang repository
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
+
+      - name: Install apt packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake build-essential ccache cmake cpanminus cscope gcc-multilib gdb gettext gperf language-pack-tr libtool-bin locales ninja-build pkg-config python python-pip python-setuptools python3 python3-pip python3-setuptools unzip valgrind xclip
+
+      - name: Install new clang
+        run: sudo apt-get install -y clang-11
+
+      - name: Set ASAN env vars
+        run: |
+          echo "CLANG_SANITIZER=ASAN_UBSAN" >> $GITHUB_ENV
+          echo "CMAKE_FLAGS=-DCI_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=$HOME/nvim-install -DBUSTED_OUTPUT_TYPE=nvim -DDEPS_PREFIX=$HOME/nvim-deps/usr -DMIN_LOG_LEVEL=3 -DPREFER_LUA=ON" >> $GITHUB_ENV
+          echo "SYMBOLIZER=asan_symbolize-11" >> $GITHUB_ENV
+
+      - name: Setup interpreter packages
+        run: |
+          ./ci/before_install.sh
+          ./ci/install.sh
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: asan-deps
+        with:
+          path: env.CACHE_NVIM_DEPS_DIR
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.base_ref }}
+
+      - name: Build third-party
+        run: ./ci/before_script.sh
+
+      - name: Build and test
+        run: ./ci/script.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,6 +80,10 @@ jobs:
       - name: Build and test
         run: ./ci/script.sh
 
+      - name: Cache dependencies
+        if: ${{ success() }}
+        run: ./ci/before_cache.sh
+
   lint:
     runs-on: ubuntu-latest
     env:
@@ -131,3 +135,7 @@ jobs:
 
       - name: Build and test
         run: ./ci/script.sh
+
+      - name: Cache dependencies
+        if: ${{ success() }}
+        run: ./ci/before_cache.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Setup commom environment variables
         run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
           echo "CI_BUILD_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "BUILD_DIR=$GITHUB_WORKSPACE/build" >> $GITHUB_ENV
           echo "DEPS_BUILD_DIR=$HOME/nvim-deps" >> $GITHUB_ENV
@@ -85,6 +87,8 @@ jobs:
 
       - name: Setup commom environment variables
         run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
           echo "CI_BUILD_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "BUILD_DIR=$GITHUB_WORKSPACE/build" >> $GITHUB_ENV
           echo "DEPS_BUILD_DIR=$HOME/nvim-deps" >> $GITHUB_ENV

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -72,7 +72,7 @@ jobs:
           path: |
             ${{ env.CACHE_NVIM_DEPS_DIR }}
             ~/.ccache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles(format('{0}/**', env.CACHE_NVIM_DEPS_DIR)) }}-${{ github.base_ref }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
 
       - name: Build third-party
         run: ./ci/before_script.sh
@@ -128,7 +128,7 @@ jobs:
           path: |
             ${{ env.CACHE_NVIM_DEPS_DIR }}
             ~/.ccache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles(format('{0}/**', env.CACHE_NVIM_DEPS_DIR)) }}-${{ github.base_ref }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
 
       - name: Build third-party
         run: ./ci/before_script.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,3 +75,51 @@ jobs:
 
       - name: Build and test
         run: ./ci/script.sh
+
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      CI_TARGET: lint
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup commom environment variables
+        run: |
+          echo "CI_BUILD_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "BUILD_DIR=$GITHUB_WORKSPACE/build" >> $GITHUB_ENV
+          echo "DEPS_BUILD_DIR=$HOME/nvim-deps" >> $GITHUB_ENV
+          echo "INSTALL_PREFIX=$HOME/nvim-install" >> $GITHUB_ENV
+          echo "LOG_DIR=$GITHUB_WORKSPACE/build/log" >> $GITHUB_ENV
+          echo "NVIM_LOG_FILE=$GITHUB_WORKSPACE/build/.nvimlog" >> $GITHUB_ENV
+          echo "CMAKE_FLAGS=-DCI_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=$HOME/nvim-install -DBUSTED_OUTPUT_TYPE=nvim -DDEPS_PREFIX=$HOME/nvim-deps/usr -DMIN_LOG_LEVEL=3" >> $GITHUB_ENV
+          echo "ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan" >> $GITHUB_ENV
+          echo "TSAN_OPTIONS=log_path=$GITHUB_WORKSPACE/build/log/tsan" >> $GITHUB_ENV
+          echo "UBSAN_OPTIONS=print_stacktrace=1 log_path=$GITHUB_WORKSPACE/build/log/ubsan" >> $GITHUB_ENV
+          echo "VALGRIND_LOG=$GITHUB_WORKSPACE/build/log/valgrind-%p.log" >> $GITHUB_ENV
+          echo "CACHE_NVIM_DEPS_DIR=$HOME/.cache/nvim-deps" >> $GITHUB_ENV
+          echo "CACHE_MARKER=$HOME/.cache/nvim-deps/.ci_cache_marker" >> $GITHUB_ENV
+          echo "CCACHE_BASEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Install apt packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake build-essential ccache cmake gcc-multilib gettext gperf libtool-bin locales ninja-build pkg-config python3 python3-pip python3-setuptools unzip
+
+      - name: Setup interpreter packages
+        run: |
+          ./ci/before_install.sh
+          ./ci/install.sh
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: lint-deps
+        with:
+          path: env.CACHE_NVIM_DEPS_DIR
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.base_ref }}
+
+      - name: Build third-party
+        run: ./ci/before_script.sh
+
+      - name: Build and test
+        run: ./ci/script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     # Nvim log file.
     - NVIM_LOG_FILE="$BUILD_DIR/.nvimlog"
     # Default CMake flags.
-    - CMAKE_FLAGS="-DTRAVIS_CI_BUILD=ON
+    - CMAKE_FLAGS="-DCI_BUILD=ON
                    -DCMAKE_BUILD_TYPE=Debug
                    -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX
                    -DBUSTED_OUTPUT_TYPE=nvim

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
     - VALGRIND_LOG="$LOG_DIR/valgrind-%p.log"
     - CACHE_NVIM_DEPS_DIR="$HOME/.cache/nvim-deps"
     # If this file exists, the cache is valid (compile was successful).
-    - CACHE_MARKER="$CACHE_NVIM_DEPS_DIR/.travis_cache_marker"
+    - CACHE_MARKER="$CACHE_NVIM_DEPS_DIR/.ci_cache_marker"
     # default target name for functional tests
     - FUNCTIONALTEST=functionaltest
     - CI_TARGET=tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,10 +322,10 @@ if(HAS_DIAG_COLOR_FLAG)
   endif()
 endif()
 
-option(TRAVIS_CI_BUILD "Travis/sourcehut CI, extra flags will be set" OFF)
+option(CI_BUILD "CI, extra flags will be set" OFF)
 
-if(TRAVIS_CI_BUILD)
-  message(STATUS "Travis/sourcehut CI build enabled")
+if(CI_BUILD)
+  message(STATUS "CI build enabled")
   add_compile_options(-Werror)
   if(DEFINED ENV{BUILD_32BIT})
     # Get some test coverage for unsigned char

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ and [AppVeyor].
       # To get a full backtrace:
       #   1. Rebuild with debug info.
       rm -rf nvim.core build
-      gmake CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DTRAVIS_CI_BUILD=ON -DMIN_LOG_LEVEL=3" nvim
+      gmake CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DCI_BUILD=ON -DMIN_LOG_LEVEL=3" nvim
       #   2. Run the failing test to generate a new core file.
       TEST_FILE=test/functional/foo.lua gmake functionaltest
       lldb build/bin/nvim -c nvim.core

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [Chat](https://gitter.im/neovim/neovim) |
 [Twitter](https://twitter.com/Neovim)
 
-[![Travis build status](https://travis-ci.org/neovim/neovim.svg?branch=master)](https://travis-ci.org/neovim/neovim)
+[![Linux CI](https://github.com/neovim/neovim/workflows/Linux%20CI/badge.svg)](https://github.com/neovim/neovim/actions?query=workflow%3A%22Linux+CI%22)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/urdqjrik5u521fac/branch/master?svg=true)](https://ci.appveyor.com/project/neovim/neovim/branch/master)
 [![Codecov coverage](https://img.shields.io/codecov/c/github/neovim/neovim.svg)](https://codecov.io/gh/neovim/neovim)
 [![Coverity Scan analysis](https://scan.coverity.com/projects/2227/badge.svg)](https://scan.coverity.com/projects/2227)

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -3,10 +3,6 @@
 set -e
 set -o pipefail
 
-if [[ "${CI_TARGET}" == lint ]]; then
-  exit
-fi
-
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common/build.sh"
 

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -29,7 +29,7 @@ build_deps() {
   if test "${CACHE_ENABLE}" = "false" ; then
     export CCACHE_RECACHE=1
   elif test -f "${CACHE_MARKER}" ; then
-    echo "Using third-party dependencies from Travis cache (last update: $(_stat "${CACHE_MARKER}"))."
+    echo "Using third-party dependencies from cache (last update: $(_stat "${CACHE_MARKER}"))."
     cp -a "${CACHE_NVIM_DEPS_DIR}"/. "${DEPS_BUILD_DIR}"
   fi
 

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -37,13 +37,13 @@ build_deps() {
   # update CMake configuration and update to newer deps versions.
   cd "${DEPS_BUILD_DIR}"
   echo "Configuring with '${DEPS_CMAKE_FLAGS}'."
-  CC= cmake -G Ninja ${DEPS_CMAKE_FLAGS} "${TRAVIS_BUILD_DIR}/third-party/"
+  CC= cmake -G Ninja ${DEPS_CMAKE_FLAGS} "${CI_BUILD_DIR}/third-party/"
 
   if ! top_make; then
     exit 1
   fi
 
-  cd "${TRAVIS_BUILD_DIR}"
+  cd "${CI_BUILD_DIR}"
 }
 
 prepare_build() {
@@ -54,7 +54,7 @@ prepare_build() {
   mkdir -p "${BUILD_DIR}"
   cd "${BUILD_DIR}"
   echo "Configuring with '${CMAKE_FLAGS} $@'."
-  cmake -G Ninja ${CMAKE_FLAGS} "$@" "${TRAVIS_BUILD_DIR}"
+  cmake -G Ninja ${CMAKE_FLAGS} "$@" "${CI_BUILD_DIR}"
 }
 
 build_nvim() {
@@ -84,5 +84,5 @@ build_nvim() {
   fi
   check_sanitizer "${LOG_DIR}"
 
-  cd "${TRAVIS_BUILD_DIR}"
+  cd "${CI_BUILD_DIR}"
 }

--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -13,16 +13,33 @@ FAIL_SUMMARY_FILE="$BUILD_DIR/.test_errors"
 
 ANSI_CLEAR="\033[0K"
 
-travis_fold() {
-  local action="$1"
-  local name="$2"
-  name="$(echo -n "$name" | tr '\n\0' '--' | sed 's/[^A-Za-z0-9]\{1,\}/-/g')"
-  name="$(echo -n "$name" | sed 's/-$//')"
-  echo -en "travis_fold:${action}:${name}\r${ANSI_CLEAR}"
-}
-
-if test "$TRAVIS" != "true" ; then
-  travis_fold() {
+if test "$TRAVIS" = "true"; then
+  ci_fold() {
+    local action="$1"
+    local name="$2"
+    name="$(echo -n "$name" | tr '\n\0' '--' | sed 's/[^A-Za-z0-9]\{1,\}/-/g')"
+    name="$(echo -n "$name" | sed 's/-$//')"
+    echo -en "travis_fold:${action}:${name}\r${ANSI_CLEAR}"
+  }
+elif test "$GITHUB_ACTIONS" = "true"; then
+  ci_fold() {
+    local action="$1"
+    local name="$2"
+    name="$(echo -n "$name" | tr '\n\0' '--' | sed 's/[^A-Za-z0-9]\{1,\}/-/g')"
+    name="$(echo -n "$name" | sed 's/-$//')"
+    case "$action" in
+      start)
+        echo "::group::${name}"
+        ;;
+      end)
+        echo "::endgroup::"
+        ;;
+      *)
+        :;;
+    esac
+  }
+else
+  ci_fold() {
     return 0
   }
 fi
@@ -33,7 +50,7 @@ enter_suite() {
   rm -f "${END_MARKER}"
   local suite_name="$1"
   export NVIM_TEST_CURRENT_SUITE="${NVIM_TEST_CURRENT_SUITE}/$suite_name"
-  travis_fold start "${NVIM_TEST_CURRENT_SUITE}"
+  ci_fold start "${NVIM_TEST_CURRENT_SUITE}"
   set -x
 }
 
@@ -43,7 +60,7 @@ exit_suite() {
     echo "Suite ${NVIM_TEST_CURRENT_SUITE} failed, summary:"
     echo "${FAIL_SUMMARY}"
   else
-    travis_fold end "${NVIM_TEST_CURRENT_SUITE}"
+    ci_fold end "${NVIM_TEST_CURRENT_SUITE}"
   fi
   export NVIM_TEST_CURRENT_SUITE="${NVIM_TEST_CURRENT_SUITE%/*}"
   if test "$1" != "--continue" ; then

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -19,7 +19,7 @@ echo "Install neovim module for Python 2."
 CC=cc python2 -m pip -q install --user --upgrade pynvim
 
 echo "Install neovim RubyGem."
-gem install --no-document --pre neovim
+gem install --no-document --user-install --pre neovim
 
 echo "Install neovim npm package"
 source ~/.nvm/nvm.sh

--- a/ci/snap/script.sh
+++ b/ci/snap/script.sh
@@ -3,6 +3,6 @@
 set -e
 set -o pipefail
 
-mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
+mkdir -p "$CI_BUILD_DIR/snaps-cache"
 sg lxd -c snapcraft
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -617,14 +617,14 @@ if(CLANG_ASAN_UBSAN)
   message(STATUS "Enabling Clang address sanitizer and undefined behavior sanitizer for nvim.")
   check_c_compiler_flag(-fno-sanitize-recover=all SANITIZE_RECOVER_ALL)
   if(SANITIZE_RECOVER_ALL)
-    if(TRAVIS_CI_BUILD)
+    if(CI_BUILD)
       # Try to recover from all sanitize issues so we get reports about all failures
       set(SANITIZE_RECOVER -fsanitize-recover=all)     # Clang 3.6+
     else()
       set(SANITIZE_RECOVER -fno-sanitize-recover=all)  # Clang 3.6+
     endif()
   else()
-    if(TRAVIS_CI_BUILD)
+    if(CI_BUILD)
       # Try to recover from all sanitize issues so we get reports about all failures
       set(SANITIZE_RECOVER -fsanitize-recover)         # Clang 3.5-
     else()

--- a/src/nvim/testdir/runnvim.sh
+++ b/src/nvim/testdir/runnvim.sh
@@ -66,7 +66,7 @@ main() {(
     fi
   fi
   if test "$FAILED" = 1 ; then
-    travis_fold start "$NVIM_TEST_CURRENT_SUITE/$test_name"
+    ci_fold start "$NVIM_TEST_CURRENT_SUITE/$test_name"
   fi
   valgrind_check .
   if test -n "$LOG_DIR" ; then
@@ -78,7 +78,7 @@ main() {(
   fi
   rm -f "$tlog"
   if test "$FAILED" = 1 ; then
-    travis_fold end "$NVIM_TEST_CURRENT_SUITE/$test_name"
+    ci_fold end "$NVIM_TEST_CURRENT_SUITE/$test_name"
   fi
   if test "$FAILED" = 1 ; then
     echo "Test $test_name failed, see output above and summary for more details" >> test.log

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -348,6 +348,10 @@ describe('TUI', function()
   end)
 
   it('paste: terminal mode', function()
+    if os.getenv('GITHUB_ACTIONS') ~= nil then
+        pending("tty-test complains about not owning the terminal -- actions/runner#241")
+        return
+    end
     feed_data(':set statusline=^^^^^^^\n')
     feed_data(':terminal '..nvim_dir..'/tty-test\n')
     feed_data('i')
@@ -776,6 +780,10 @@ describe('TUI', function()
   end)
 
   it('forwards :term palette colors with termguicolors', function()
+    if os.getenv('GITHUB_ACTIONS') ~= nil then
+        pending("tty-test complains about not owning the terminal -- actions/runner#241")
+        return
+    end
     screen:set_rgb_cterm(true)
     screen:set_default_attr_ids({
       [1] = {{reverse = true}, {reverse = true}},


### PR DESCRIPTION
This generalizes much of the CI code (mainly in naming) and adds a new GitHub actions workflow for Linux builds.  Currently only the ASAN and lint jobs from Travis have been implemented, but that should be a good starting point.