### PR TITLE
Allow signs to be 0 width

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5438,7 +5438,9 @@ int buf_signcols(buf_T *buf)
             curline = sign->lnum;
             linesum = 0;
           }
-          linesum++;
+          if (sign->has_text_or_icon) {
+            linesum++;
+          }
         }
         if (linesum > buf->b_signcols_max) {
           buf->b_signcols_max = linesum;

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -1,6 +1,7 @@
 #ifndef NVIM_SIGN_DEFS_H
 #define NVIM_SIGN_DEFS_H
 
+#include <stdbool.h>
 #include "nvim/pos.h"
 #include "nvim/types.h"
 
@@ -22,13 +23,14 @@ typedef struct signlist signlist_T;
 
 struct signlist
 {
-    int id;              // unique identifier for each placed sign
-    linenr_T lnum;       // line number which has this sign
-    int typenr;          // typenr of sign
-    signgroup_T *group;  // sign group
-    int priority;        // priority for highlighting
-    signlist_T *next;    // next signlist entry
-    signlist_T *prev;    // previous entry -- for easy reordering
+    int id;                 // unique identifier for each placed sign
+    linenr_T lnum;          // line number which has this sign
+    int typenr;             // typenr of sign
+    bool has_text_or_icon;  // has text or icon
+    signgroup_T *group;     // sign group
+    int priority;           // priority for highlighting
+    signlist_T *next;       // next signlist entry
+    signlist_T *prev;       // previous entry -- for easy reordering
 };
 
 // Default sign priority for highlighting

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -133,9 +133,9 @@ func Test_sign()
   call assert_fails("sign define Sign4 text=a\e linehl=Comment", 'E239:')
   call assert_fails("sign define Sign4 text=\ea linehl=Comment", 'E239:')
 
-  " Only 1 or 2 character text is allowed
+  " Only 0, 1 or 2 character text is allowed
   call assert_fails("sign define Sign4 text=abc linehl=Comment", 'E239:')
-  call assert_fails("sign define Sign4 text= linehl=Comment", 'E239:')
+  " call assert_fails("sign define Sign4 text= linehl=Comment", 'E239:')
   call assert_fails("sign define Sign4 text=\\ ab  linehl=Comment", 'E239:')
 
   " define sign with whitespace
@@ -317,7 +317,7 @@ func Test_sign_invalid_commands()
   call assert_fails('sign jump 1 name=', 'E474:')
   call assert_fails('sign jump 1 name=Sign1', 'E474:')
   call assert_fails('sign jump 1 line=100', '474:')
-  call assert_fails('sign define Sign2 text=', 'E239:')
+  " call assert_fails('sign define Sign2 text=', 'E239:')
   " Non-numeric identifier for :sign place
   call assert_fails("sign place abc line=3 name=Sign1 buffer=" . bufnr(''),
 								\ 'E474:')
@@ -412,7 +412,7 @@ func Test_sign_funcs()
 
   " Tests for invalid arguments to sign_define()
   call assert_fails('call sign_define("sign4", {"text" : "===>"})', 'E239:')
-  call assert_fails('call sign_define("sign5", {"text" : ""})', 'E239:')
+  " call assert_fails('call sign_define("sign5", {"text" : ""})', 'E239:')
   call assert_fails('call sign_define([])', 'E730:')
   call assert_fails('call sign_define("sign6", [])', 'E715:')
 

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -76,6 +76,28 @@ describe('Signs', function()
       ]])
     end)
 
+    it('allows signs with no text', function()
+      feed('ia<cr>b<cr><esc>')
+      command('sign define piet1 text= texthl=Search')
+      command('sign place 1 line=1 name=piet1 buffer=1')
+      screen:expect([[
+        a                                                    |
+        b                                                    |
+        ^                                                     |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+    end)
+
     it('can be called right after :split', function()
       feed('ia<cr>b<cr>c<cr><esc>gg')
       -- This used to cause a crash due to :sign using a special redraw
@@ -242,6 +264,50 @@ describe('Signs', function()
         {0:~                                                    }|
                                                              |
       ]]}
+    end)
+
+    it('ignores signs with no icon and text when calculting the signcolumn width', function()
+      feed('ia<cr>b<cr>c<cr><esc>')
+      command('set number')
+      command('set signcolumn=auto:2')
+      command('sign define pietSearch text=>> texthl=Search')
+      command('sign define pietError text= texthl=Error')
+      command('sign place 2 line=1 name=pietError buffer=1')
+      -- no signcolumn with only empty sign
+      screen:expect([[
+        {6:  1 }a                                                |
+        {6:  2 }b                                                |
+        {6:  3 }c                                                |
+        {6:  4 }^                                                 |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      -- single column with 1 sign with text and one sign without
+      command('sign place 1 line=1 name=pietSearch buffer=1')
+      screen:expect([[
+        {1:>>}{6:  1 }a                                              |
+        {2:  }{6:  2 }b                                              |
+        {2:  }{6:  3 }c                                              |
+        {2:  }{6:  ^4 }                                               |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
     end)
 
     it('can have 32bit sign IDs', function()


### PR DESCRIPTION
Currently, signs need to be 1 or 2 cell wide.
This PR would allow them to be 0, and don't display the signcolumn for
those signs. So you can use only `linehl` or `numhl` for _some_ signs. 

![Screen Capture_select-area_20201114104128](https://user-images.githubusercontent.com/12900252/99136229-29d14680-2667-11eb-9d47-48718b744c98.png)

![Screen Capture_select-area_20201114104209](https://user-images.githubusercontent.com/12900252/99136319-8cc2dd80-2667-11eb-9eac-9f9660fe25cd.png)

What do you think about the idea?
Code probably needs cleanup + tests etc.