### PR TITLE
lsp: Add ability to subscribe to handlers

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1220,9 +1220,23 @@ end
 --- Function to manage overriding defaults for LSP handlers.
 --@param handler (function) See |lsp-handler|
 --@param override_config (table) Table containing the keys to override behavior of the {handler}
-function lsp.with(handler, override_config)
+function lsp.with(handler, override_config, subscriptions)
+  subscriptions = subscriptions or {}
+
   return function(err, method, params, client_id, bufnr, config)
-    return handler(err, method, params, client_id, bufnr, vim.tbl_deep_extend("force", config or {}, override_config))
+    config = vim.tbl_deep_extend("force", config or {}, override_config)
+
+    if subscriptions.pre then
+      subscriptions.pre(err, method, params, client_id, bufnr, config)
+    end
+
+    local result = handler(err, method, params, client_id, bufnr, )
+
+    if subscriptions.post then
+      subscriptions.post(err, method, params, client_id, bufnr, config)
+    end
+
+    return result
   end
 end
 


### PR DESCRIPTION
This is an idea I had.

You can now "subscribe" to "handlers".

@bfredl @mfussenegger @glepnir (or others) thoughts on this idea? I will add tests and docs if we think it's a good idea.

This makes it so we don't have to add autocmds for EVER possible combination and reduces the need for tons of documentation for every lsp handler.