### PR TITLE
doc: Lua.txt formatting

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -935,10 +935,8 @@ vim.env                                                              *vim.env*
             vim.env.FOO = 'bar'
             print(vim.env.TERM)
 <
-
-                                                             *lua-vim-options*
-From Lua you can work with editor |options| by reading and setting items in
-these Lua tables:
+From Lua you can work with editor |options| by               *lua-vim-options*
+reading and setting items in these Lua tables:
 
 vim.o                                                                  *vim.o*
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1,15 +1,15 @@
 *lua.txt*    Nvim
 
 
-			    NVIM REFERENCE MANUAL
+                            NVIM REFERENCE MANUAL
 
 
-Lua engine						*lua* *Lua*
+Lua engine                                                *lua* *Lua*
 
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
-INTRODUCTION						*lua-intro*
+INTRODUCTION                                                *lua-intro*
 
 The Lua 5.1 language is builtin and always available.  Try this command to get
 an idea of what lurks beneath: >
@@ -30,7 +30,7 @@ finds and loads Lua modules.  The conventions are similar to VimL plugins,
 with some extra features.  See |lua-require-example| for a walkthrough.
 
 ==============================================================================
-IMPORTING LUA MODULES					*lua-require*
+IMPORTING LUA MODULES                                        *lua-require*
 
                                                         *lua-package-path*
 Nvim automatically adjusts `package.path` and `package.cpath` according to
@@ -156,7 +156,7 @@ function without any parentheses. This is most often used to approximate
 
 
 ------------------------------------------------------------------------------
-LUA PLUGIN EXAMPLE					*lua-require-example*
+LUA PLUGIN EXAMPLE                                        *lua-require-example*
 
 The following example plugin adds a command `:MakeCharBlob` which transforms 
 current buffer into a long `unsigned char` array.  Lua contains transformation 
@@ -233,7 +233,7 @@ lua/charblob.lua: >
     }
 
 ==============================================================================
-COMMANDS						*lua-commands*
+COMMANDS                                                *lua-commands*
 
 These commands execute a Lua chunk from either the command line (:lua, :luado)
 or a file (:luafile) on the given line [range]. As always in Lua, each chunk
@@ -297,10 +297,10 @@ arguments separated by " " (space) instead of "\t" (tab).
                             :luado if bp:match(line) then return "-->\t" .. line end
 <
 
-							*:luafile*
+                                                        *:luafile*
 :[range]luafile {file}
-			Execute Lua script in {file}.
-			The whole argument is used as a single file name.
+                        Execute Lua script in {file}.
+                        The whole argument is used as a single file name.
 
                         Examples:
                         >
@@ -309,7 +309,7 @@ arguments separated by " " (space) instead of "\t" (tab).
 <
 
 ==============================================================================
-luaeval()						*lua-eval* *luaeval()*
+luaeval()                                                *lua-eval* *luaeval()*
 
 The (dual) equivalent of "vim.eval" for passing Lua values to Nvim is
 "luaeval". "luaeval" takes an expression string and an optional argument used 
@@ -347,7 +347,7 @@ cases there is the following agreement:
 3. Table with string keys, at least one of which contains NUL byte, is also 
    considered to be a dictionary, but this time it is converted to 
    a |msgpack-special-map|.
-							*lua-special-tbl*
+                                                        *lua-special-tbl*
 4. Table with `vim.type_idx` key may be a dictionary, a list or floating-point 
    value:
    - `{[vim.type_idx]=vim.types.float, [vim.val_idx]=1}` is converted to 
@@ -378,7 +378,7 @@ Return value is also always converted. When converting,
 |msgpack-special-dict|s are treated specially.
 
 ==============================================================================
-Vimscript v:lua interface				*v:lua-call*
+Vimscript v:lua interface                                *v:lua-call*
 
 From Vimscript the special `v:lua` prefix can be used to call Lua functions
 which are global or accessible from global tables. The expression >
@@ -414,7 +414,7 @@ Note: `v:lua` without a call is not allowed in a Vimscript expression:
 
 
 ==============================================================================
-Lua standard modules					*lua-stdlib*
+Lua standard modules                                        *lua-stdlib*
 
 The Nvim Lua "standard library" (stdlib) is the `vim` module, which exposes
 various functions and sub-modules.  It is always loaded, thus require("vim")
@@ -448,7 +448,7 @@ Note that underscore-prefixed functions (e.g. "_os_proc_children") are
 internal/private and must not be used by plugins.
 
 ------------------------------------------------------------------------------
-VIM.LOOP						*lua-loop* *vim.loop*
+VIM.LOOP                                                *lua-loop* *vim.loop*
 
 `vim.loop` exposes all features of the Nvim event-loop.  This is a low-level
 API that provides functionality for networking, filesystem, and process
@@ -459,7 +459,7 @@ management.  Try this command to see available functions: >
 Reference: https://github.com/luvit/luv/blob/master/docs.md
 Examples:  https://github.com/luvit/luv/tree/master/examples
 
-						*E5560* *lua-loop-callbacks*
+                                                *E5560* *lua-loop-callbacks*
 It is an error to directly invoke `vim.api` functions (except |api-fast|) in
 `vim.loop` callbacks.  For example, this is an error: >
 
@@ -495,7 +495,7 @@ Example: repeating timer
     print('sleeping');
 
 
-Example: File-change detection				*watch-file*
+Example: File-change detection                                *watch-file*
     1. Save this code to a file.
     2. Execute it with ":luafile %".
     3. Use ":Watch %" to watch any file.
@@ -521,7 +521,7 @@ Example: File-change detection				*watch-file*
       "command! -nargs=1 Watch call luaeval('watch_file(_A)', expand('<args>'))")
 
 
-Example: TCP echo-server				*tcp-server*
+Example: TCP echo-server                                *tcp-server*
     1. Save this code to a file.
     2. Execute it with ":luafile %".
     3. Note the port number.
@@ -551,7 +551,7 @@ Example: TCP echo-server				*tcp-server*
     print('TCP echo-server listening on port: '..server:getsockname().port)
 
 ------------------------------------------------------------------------------
-VIM.HIGHLIGHT                  				*lua-highlight*
+VIM.HIGHLIGHT                                                  *lua-highlight*
 
 Nvim includes a function for highlighting a selection on yank (see for example
 https://github.com/machakann/vim-highlightedyank). To enable it, add
@@ -586,12 +586,12 @@ vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclu
         range is inclusive (default false).
 
 ------------------------------------------------------------------------------
-VIM.REGEX							*lua-regex*
+VIM.REGEX                                                        *lua-regex*
 
 Vim regexes can be used directly from lua. Currently they only allow
 matching within a single line.
 
-vim.regex({re})						*vim.regex()*
+vim.regex({re})                                                *vim.regex()*
 
         Parse the regex {re} and return a regex object. 'magic' and
         'ignorecase' options are ignored, lua regexes always defaults to magic
@@ -600,7 +600,7 @@ vim.regex({re})						*vim.regex()*
 
 Regex objects support the following methods:
 
-regex:match_str({str})					*regex:match_str()*
+regex:match_str({str})                                        *regex:match_str()*
         Match the string against the regex. If the string should match the
         regex precisely, surround the regex with `^` and `$`.
         If the was a match, the byte indices for the beginning and end of
@@ -608,43 +608,43 @@ regex:match_str({str})					*regex:match_str()*
         As any integer is truth-y, `regex:match()` can be directly used
         as a condition in an if-statement.
 
-regex:match_line({bufnr}, {line_idx}[, {start}, {end}])	*regex:match_line()*
+regex:match_line({bufnr}, {line_idx}[, {start}, {end}])        *regex:match_line()*
         Match line {line_idx} (zero-based) in buffer {bufnr}. If {start} and
         {end} are supplied, match only this byte index range. Otherwise see
         |regex:match_str()|. If {start} is used, then the returned byte
         indices will be relative {start}.
 
 ------------------------------------------------------------------------------
-VIM							*lua-builtin*
+VIM                                                        *lua-builtin*
 
-vim.api.{func}({...})					*vim.api*
+vim.api.{func}({...})                                        *vim.api*
         Invokes Nvim |API| function {func} with arguments {...}.
         Example: call the "nvim_get_current_line()" API function: >
             print(tostring(vim.api.nvim_get_current_line()))
 
-vim.in_fast_event()					*vim.in_fast_event()*
+vim.in_fast_event()                                        *vim.in_fast_event()*
         Returns true if the code is executing as part of a "fast" event
         handler, where most of the API is disabled. These are low-level events
         (e.g. |lua-loop-callbacks|) which can be invoked whenever Nvim polls
         for input.  When this is `false` most API functions are callable (but
         may be subject to other restrictions such as |textlock|).
 
-vim.NIL								    *vim.NIL*
-	Special value used to represent NIL in msgpack-rpc and |v:null| in
-	vimL interaction, and similar cases. Lua `nil` cannot be used as
-	part of a lua table representing a Dictionary or Array, as it
-	is equivalent to a missing value: `{"foo", nil}` is the same as 
-	`{"foo"}`
+vim.NIL                                                                    *vim.NIL*
+        Special value used to represent NIL in msgpack-rpc and |v:null| in
+        vimL interaction, and similar cases. Lua `nil` cannot be used as
+        part of a lua table representing a Dictionary or Array, as it
+        is equivalent to a missing value: `{"foo", nil}` is the same as 
+        `{"foo"}`
 
-vim.empty_dict()					    *vim.empty_dict()*
-	Creates a special table which will be converted to an empty
-	dictionary when converting lua values to vimL or API types. The
-	table is empty, and this property is marked using a metatable. An
-	empty table `{}` without this metatable will default to convert to
-	an array/list.
+vim.empty_dict()                                            *vim.empty_dict()*
+        Creates a special table which will be converted to an empty
+        dictionary when converting lua values to vimL or API types. The
+        table is empty, and this property is marked using a metatable. An
+        empty table `{}` without this metatable will default to convert to
+        an array/list.
 
-	Note: if numeric keys are added to the table, the metatable will be
-	ignored and the dict converted to a list/array anyway.
+        Note: if numeric keys are added to the table, the metatable will be
+        ignored and the dict converted to a list/array anyway.
 
 vim.region({bufnr}, {pos1}, {pos2}, {type}, {inclusive})       *vim.region()*
         Converts a selection specified by the buffer ({bufnr}), starting
@@ -682,25 +682,25 @@ vim.register_keystroke_callback({fn}, {ns_id})
 
         NOTE: {fn} will *NOT* be cleared from |nvim_buf_clear_namespace()|
 
-vim.rpcnotify({channel}, {method}[, {args}...])		    *vim.rpcnotify()*
-	Sends {event} to {channel} via |RPC| and returns immediately.
-	If {channel} is 0, the event is broadcast to all channels.
+vim.rpcnotify({channel}, {method}[, {args}...])                    *vim.rpcnotify()*
+        Sends {event} to {channel} via |RPC| and returns immediately.
+        If {channel} is 0, the event is broadcast to all channels.
 
-	This function also works in a fast callback |lua-loop-callbacks|.
+        This function also works in a fast callback |lua-loop-callbacks|.
 
-vim.rpcrequest({channel}, {method}[, {args}...])	    *vim.rpcrequest()*
-	Sends a request to {channel} to invoke {method} via
-	|RPC| and blocks until a response is received.
+vim.rpcrequest({channel}, {method}[, {args}...])            *vim.rpcrequest()*
+        Sends a request to {channel} to invoke {method} via
+        |RPC| and blocks until a response is received.
 
-	Note: NIL values as part of the return value is represented as
-	|vim.NIL| special value
+        Note: NIL values as part of the return value is represented as
+        |vim.NIL| special value
 
-vim.stricmp({a}, {b})					*vim.stricmp()*
+vim.stricmp({a}, {b})                                        *vim.stricmp()*
         Compares strings case-insensitively.  Returns 0, 1 or -1 if strings
         are equal, {a} is greater than {b} or {a} is lesser than {b},
         respectively.
 
-vim.str_utfindex({str}[, {index}])			*vim.str_utfindex()*
+vim.str_utfindex({str}[, {index}])                        *vim.str_utfindex()*
         Convert byte index to UTF-32 and UTF-16 indicies. If {index} is not
         supplied, the length of the string is used. All indicies are zero-based.
         Returns two values: the UTF-32 and UTF-16 indicies respectively.
@@ -710,7 +710,7 @@ vim.str_utfindex({str}[, {index}])			*vim.str_utfindex()*
         point each. An {index} in the middle of a UTF-8 sequence is rounded
         upwards to the end of that sequence.
 
-vim.str_byteindex({str}, {index}[, {use_utf16}])	*vim.str_byteindex()*
+vim.str_byteindex({str}, {index}[, {use_utf16}])        *vim.str_byteindex()*
         Convert UTF-32 or UTF-16 {index} to byte index. If {use_utf16} is not
         supplied, it defaults to false (use UTF-32). Returns the byte index.
 
@@ -718,7 +718,7 @@ vim.str_byteindex({str}, {index}[, {use_utf16}])	*vim.str_byteindex()*
         in the middle of a UTF-16 sequence is rounded upwards to the end of that
         sequence.
 
-vim.schedule({callback})				*vim.schedule()*
+vim.schedule({callback})                                *vim.schedule()*
         Schedules {callback} to be invoked soon by the main event-loop. Useful
         to avoid |textlock| or other temporary restrictions.
 
@@ -788,40 +788,40 @@ vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
     end
 <
 
-vim.type_idx						*vim.type_idx*
-	Type index for use in |lua-special-tbl|.  Specifying one of the 
-	values from |vim.types| allows typing the empty table (it is 
-	unclear whether empty Lua table represents empty list or empty array) 
-	and forcing integral numbers to be |Float|.  See |lua-special-tbl| for 
-	more details.
+vim.type_idx                                                *vim.type_idx*
+        Type index for use in |lua-special-tbl|.  Specifying one of the 
+        values from |vim.types| allows typing the empty table (it is 
+        unclear whether empty Lua table represents empty list or empty array) 
+        and forcing integral numbers to be |Float|.  See |lua-special-tbl| for 
+        more details.
 
-vim.val_idx						*vim.val_idx*
-	Value index for tables representing |Float|s.  A table representing 
-	floating-point value 1.0 looks like this: >
+vim.val_idx                                                *vim.val_idx*
+        Value index for tables representing |Float|s.  A table representing 
+        floating-point value 1.0 looks like this: >
             {
               [vim.type_idx] = vim.types.float,
               [vim.val_idx] = 1.0,
             }
-<	See also |vim.type_idx| and |lua-special-tbl|.
+<        See also |vim.type_idx| and |lua-special-tbl|.
 
-vim.types						*vim.types*
-	Table with possible values for |vim.type_idx|.  Contains two sets 
-	of key-value pairs: first maps possible values for |vim.type_idx| 
-	to human-readable strings, second maps human-readable type names to 
-	values for |vim.type_idx|.  Currently contains pairs for `float`, 
-	`array` and `dictionary` types.
+vim.types                                                *vim.types*
+        Table with possible values for |vim.type_idx|.  Contains two sets 
+        of key-value pairs: first maps possible values for |vim.type_idx| 
+        to human-readable strings, second maps human-readable type names to 
+        values for |vim.type_idx|.  Currently contains pairs for `float`, 
+        `array` and `dictionary` types.
 
-	Note: one must expect that values corresponding to `vim.types.float`, 
-	`vim.types.array` and `vim.types.dictionary` fall under only two 
-	following assumptions:
-	1. Value may serve both as a key and as a value in a table.  Given the 
-	   properties of Lua tables this basically means “value is not `nil`”.
-	2. For each value in `vim.types` table `vim.types[vim.types[value]]` 
-	   is the same as `value`.
-	No other restrictions are put on types, and it is not guaranteed that 
-	values corresponding to `vim.types.float`, `vim.types.array` and 
-	`vim.types.dictionary` will not change or that `vim.types` table will 
-	only contain values for these three types.
+        Note: one must expect that values corresponding to `vim.types.float`, 
+        `vim.types.array` and `vim.types.dictionary` fall under only two 
+        following assumptions:
+        1. Value may serve both as a key and as a value in a table.  Given the 
+           properties of Lua tables this basically means “value is not `nil`”.
+        2. For each value in `vim.types` table `vim.types[vim.types[value]]` 
+           is the same as `value`.
+        No other restrictions are put on types, and it is not guaranteed that 
+        values corresponding to `vim.types.float`, `vim.types.array` and 
+        `vim.types.dictionary` will not change or that `vim.types` table will 
+        only contain values for these three types.
 
 ------------------------------------------------------------------------------
 LUA-VIMSCRIPT BRIDGE                                    *lua-vimscript*
@@ -829,7 +829,7 @@ LUA-VIMSCRIPT BRIDGE                                    *lua-vimscript*
 Nvim Lua provides an interface to Vimscript variables and functions, and
 editor commands and options.
 
-vim.call({func}, {...})					*vim.call()*
+vim.call({func}, {...})                                        *vim.call()*
         Invokes |vim-function| or |user-function| {func} with arguments {...}.
         See also |vim.fn|.
         Equivalent to: >
@@ -841,7 +841,7 @@ vim.cmd({cmd})                                          *vim.cmd()*
         Example: >
             vim.cmd('echo 42')
 
-vim.fn.{func}({...})					*vim.fn*
+vim.fn.{func}({...})                                        *vim.fn*
         Invokes |vim-function| or |user-function| {func} with arguments {...}.
         To call autoload functions, use the syntax: >
             vim.fn['some#function']({...})
@@ -1086,7 +1086,7 @@ split({s}, {sep}, {plain})                                       *vim.split()*
                     |vim.gsplit()|
 
 startswith({s}, {prefix})                                   *vim.startswith()*
-                Tests if `s` starts with `prefix` .
+                Tests if `s` starts with `prefix`.
 
                 Parameters: ~
                     {s}       (string) a string
@@ -1103,7 +1103,7 @@ tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
                     {o}  table The table to add the reverse to.
 
 tbl_contains({t}, {value})                                *vim.tbl_contains()*
-                Checks if a list-like (vector) table contains `value` .
+                Checks if a list-like (vector) table contains `value`.
 
                 Parameters: ~
                     {t}      Table to check
@@ -1113,9 +1113,8 @@ tbl_contains({t}, {value})                                *vim.tbl_contains()*
                     true if `t` contains `value`
 
 tbl_count({t})                                               *vim.tbl_count()*
-                Counts the number of non-nil values in table `t` .
+                Counts the number of non-nil values in table `t`.
 >
-
     vim.tbl_count({ a=1, b=2 }) => 2
     vim.tbl_count({ 1, 2 }) => 2
 <

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -572,6 +572,7 @@ If you want to exclude visual selections from highlighting on yank, use
 <
 
 vim.highlight.on_yank({opts})                        *vim.highlight.on_yank()*
+
         Highlights the yanked text. The fields of the optional dict {opts}
         control the highlight:
           - {higroup} highlight group for yanked region
@@ -613,6 +614,7 @@ vim.regex({re})                                                  *vim.regex()*
 Regex objects support the following methods:
 
 regex:match_str({str})                                     *regex:match_str()*
+
         Match the string against the regex. If the string should match the
         regex precisely, surround the regex with `^` and `$`.
         If the was a match, the byte indices for the beginning and end of
@@ -621,6 +623,7 @@ regex:match_str({str})                                     *regex:match_str()*
         as a condition in an if-statement.
 
 regex:match_line({bufnr}, {line_idx}[, {start}, {end}])   *regex:match_line()*
+
         Match line {line_idx} (zero-based) in buffer {bufnr}. If {start} and
         {end} are supplied, match only this byte index range. Otherwise see
         |regex:match_str()|. If {start} is used, then the returned byte
@@ -630,11 +633,13 @@ regex:match_line({bufnr}, {line_idx}[, {start}, {end}])   *regex:match_line()*
 VIM                                                              *lua-builtin*
 
 vim.api.{func}({...})                                                *vim.api*
+
         Invokes Nvim |API| function {func} with arguments {...}.
         Example: call the "nvim_get_current_line()" API function: >
             print(tostring(vim.api.nvim_get_current_line()))
 
 vim.in_fast_event()                                      *vim.in_fast_event()*
+
         Returns true if the code is executing as part of a "fast" event
         handler, where most of the API is disabled. These are low-level events
         (e.g. |lua-loop-callbacks|) which can be invoked whenever Nvim polls
@@ -642,6 +647,7 @@ vim.in_fast_event()                                      *vim.in_fast_event()*
         may be subject to other restrictions such as |textlock|).
 
 vim.NIL                                                              *vim.NIL*
+
         Special value used to represent NIL in msgpack-rpc and |v:null| in
         vimL interaction, and similar cases. Lua `nil` cannot be used as
         part of a lua table representing a Dictionary or Array, as it
@@ -649,6 +655,7 @@ vim.NIL                                                              *vim.NIL*
         `{"foo"}`
 
 vim.empty_dict()                                            *vim.empty_dict()*
+
         Creates a special table which will be converted to an empty
         dictionary when converting lua values to vimL or API types. The
         table is empty, and this property is marked using a metatable. An
@@ -659,6 +666,7 @@ vim.empty_dict()                                            *vim.empty_dict()*
         ignored and the dict converted to a list/array anyway.
 
 vim.region({bufnr}, {pos1}, {pos2}, {type}, {inclusive})        *vim.region()*
+
         Converts a selection specified by the buffer ({bufnr}), starting
         position ({pos1}, a zero-indexed pair `{line1,column1}`), ending
         position ({pos2}, same format as {pos1}), the type of the register
@@ -668,6 +676,7 @@ vim.region({bufnr}, {pos1}, {pos2}, {type}, {inclusive})        *vim.region()*
 
                                            *vim.register_keystroke_callback()*
 vim.register_keystroke_callback({fn}, {ns_id})
+
         Register a lua {fn} with an {ns_id} to be run after every keystroke.
 
         Parameters: ~
@@ -695,12 +704,14 @@ vim.register_keystroke_callback({fn}, {ns_id})
         NOTE: {fn} will *NOT* be cleared from |nvim_buf_clear_namespace()|
 
 vim.rpcnotify({channel}, {method}[, {args}...])              *vim.rpcnotify()*
+
         Sends {event} to {channel} via |RPC| and returns immediately.
         If {channel} is 0, the event is broadcast to all channels.
 
         This function also works in a fast callback |lua-loop-callbacks|.
 
 vim.rpcrequest({channel}, {method}[, {args}...])            *vim.rpcrequest()*
+
         Sends a request to {channel} to invoke {method} via
         |RPC| and blocks until a response is received.
 
@@ -708,11 +719,13 @@ vim.rpcrequest({channel}, {method}[, {args}...])            *vim.rpcrequest()*
         |vim.NIL| special value
 
 vim.stricmp({a}, {b})                                          *vim.stricmp()*
+
         Compares strings case-insensitively.  Returns 0, 1 or -1 if strings
         are equal, {a} is greater than {b} or {a} is lesser than {b},
         respectively.
 
 vim.str_utfindex({str}[, {index}])                        *vim.str_utfindex()*
+
         Convert byte index to UTF-32 and UTF-16 indicies. If {index} is not
         supplied, the length of the string is used. All indicies are zero-based.
         Returns two values: the UTF-32 and UTF-16 indicies respectively.
@@ -723,6 +736,7 @@ vim.str_utfindex({str}[, {index}])                        *vim.str_utfindex()*
         upwards to the end of that sequence.
 
 vim.str_byteindex({str}, {index}[, {use_utf16}])         *vim.str_byteindex()*
+
         Convert UTF-32 or UTF-16 {index} to byte index. If {use_utf16} is not
         supplied, it defaults to false (use UTF-32). Returns the byte index.
 
@@ -731,11 +745,13 @@ vim.str_byteindex({str}, {index}[, {use_utf16}])         *vim.str_byteindex()*
         sequence.
 
 vim.schedule({callback})                                      *vim.schedule()*
+
         Schedules {callback} to be invoked soon by the main event-loop. Useful
         to avoid |textlock| or other temporary restrictions.
 
 
 vim.defer_fn({fn}, {timeout})                                   *vim.defer_fn*
+
     Defers calling {fn} until {timeout} ms passes.  Use to do a one-shot timer
     that calls {fn}.
 
@@ -750,6 +766,7 @@ vim.defer_fn({fn}, {timeout})                                   *vim.defer_fn*
         |vim.loop|.new_timer() object
 
 vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
+
         Wait for {time} in milliseconds until {callback} returns `true`.
 
         Executes {callback} immediately and at approximately {interval}
@@ -798,9 +815,9 @@ vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
     if vim.wait(10000, function() return vim.g.timer_result end) then
       print('Only waiting a little bit of time!')
     end
-<
 
 vim.type_idx                                                    *vim.type_idx*
+
         Type index for use in |lua-special-tbl|.  Specifying one of the 
         values from |vim.types| allows typing the empty table (it is 
         unclear whether empty Lua table represents empty list or empty array) 
@@ -808,6 +825,7 @@ vim.type_idx                                                    *vim.type_idx*
         more details.
 
 vim.val_idx                                                      *vim.val_idx*
+
         Value index for tables representing |Float|s.  A table representing 
         floating-point value 1.0 looks like this: >
             {
@@ -817,6 +835,7 @@ vim.val_idx                                                      *vim.val_idx*
 <        See also |vim.type_idx| and |lua-special-tbl|.
 
 vim.types                                                          *vim.types*
+
         Table with possible values for |vim.type_idx|.  Contains two sets 
         of key-value pairs: first maps possible values for |vim.type_idx| 
         to human-readable strings, second maps human-readable type names to 
@@ -842,18 +861,21 @@ Nvim Lua provides an interface to Vimscript variables and functions, and
 editor commands and options.
 
 vim.call({func}, {...})                                           *vim.call()*
+
         Invokes |vim-function| or |user-function| {func} with arguments {...}.
         See also |vim.fn|.
         Equivalent to: >
             vim.fn[func]({...})
 
 vim.cmd({cmd})                                                     *vim.cmd()*
+
         Invokes an Ex command (the ":" commands, Vimscript statements).
         See also |ex-cmd-index|.
         Example: >
             vim.cmd('echo 42')
 
 vim.fn.{func}({...})                                                  *vim.fn*
+
         Invokes |vim-function| or |user-function| {func} with arguments {...}.
         To call autoload functions, use the syntax: >
             vim.fn['some#function']({...})
@@ -883,26 +905,32 @@ Example: >
     vim.g.foo = nil   -- Delete (:unlet) the Vimscript variable.
 
 vim.g                                                                  *vim.g*
+
         Global (|g:|) editor variables.
         Key with no value returns `nil`.
 
 vim.b                                                                  *vim.b*
+
         Buffer-scoped (|b:|) variables for the current buffer.
         Invalid or unset key returns `nil`.
 
 vim.w                                                                  *vim.w*
+
         Window-scoped (|w:|) variables for the current window.
         Invalid or unset key returns `nil`.
 
 vim.t                                                                  *vim.t*
+
         Tabpage-scoped (|t:|) variables for the current tabpage.
         Invalid or unset key returns `nil`.
 
 vim.v                                                                  *vim.v*
+
         |v:| variables.
         Invalid or unset key returns `nil`.
 
 vim.env                                                              *vim.env*
+
         Environment variables defined in the editor session.
         See |expand-env| and |:let-environment| for the Vimscript behavior.
         Invalid or unset key returns `nil`.
@@ -916,18 +944,21 @@ From Lua you can work with editor |options| by reading and setting items in
 these Lua tables:
 
 vim.o                                                                  *vim.o*
+
         Get or set editor options, like |:set|. Invalid key is an error.
         Example: >
             vim.o.cmdheight = 4
             print(vim.o.columns)
 
 vim.bo                                                                *vim.bo*
+
         Get or set buffer-scoped |local-options|. Invalid key is an error.
         Example: >
             vim.bo.buflisted = true
             print(vim.bo.comments)
 
 vim.wo                                                                *vim.wo*
+
         Get or set window-scoped |local-options|. Invalid key is an error.
         Example: >
             vim.wo.cursorcolumn = true
@@ -938,6 +969,7 @@ vim.wo                                                                *vim.wo*
 Lua module: vim                                                      *lua-vim*
 
 inspect({object}, {options})                                   *vim.inspect()*
+
                 Return a human-readable representation of the given object.
 
                 See also: ~
@@ -945,9 +977,11 @@ inspect({object}, {options})                                   *vim.inspect()*
                     https://github.com/mpeterv/vinspect
 
 make_meta_accessor({get}, {set}, {del})             *vim.make_meta_accessor()*
+
                 TODO: Documentation
 
 paste({lines}, {phase})                                          *vim.paste()*
+
                 Paste handler, invoked by |nvim_paste()| when a conforming UI
                 (such as the |TUI|) pastes text into the editor.
 
@@ -980,6 +1014,7 @@ paste({lines}, {phase})                                          *vim.paste()*
                     |paste|
 
 schedule_wrap({cb})                                      *vim.schedule_wrap()*
+
                 Defers callback `cb` until the Nvim API is safe to call.
 
                 See also: ~
@@ -991,9 +1026,11 @@ schedule_wrap({cb})                                      *vim.schedule_wrap()*
 
 
 deep_equal({a}, {b})                                        *vim.deep_equal()*
+
                 TODO: Documentation
 
 deepcopy({orig})                                              *vim.deepcopy()*
+
                 Returns a deep copy of the given object. Non-table objects are
                 copied as in a typical Lua assignment, whereas table objects
                 are copied recursively. Functions are naively copied, so
@@ -1008,6 +1045,7 @@ deepcopy({orig})                                              *vim.deepcopy()*
                     New table of copied keys and (nested) values.
 
 endswith({s}, {suffix})                                       *vim.endswith()*
+
                 Tests if `s` ends with `suffix` .
 
                 Parameters: ~
@@ -1018,6 +1056,7 @@ endswith({s}, {suffix})                                       *vim.endswith()*
                     (boolean) true if `suffix` is a suffix of s
 
 gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
+
                 Splits a string at each instance of a separator.
 
                 Parameters: ~
@@ -1035,6 +1074,7 @@ gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
                     http://lua-users.org/wiki/StringLibraryTutorial
 
 is_callable({f})                                           *vim.is_callable()*
+
                 Returns true if object `f` can be called as a function.
 
                 Parameters: ~
@@ -1044,9 +1084,11 @@ is_callable({f})                                           *vim.is_callable()*
                     true if `f` is callable, else false
 
 is_valid({opt})                                               *vim.is_valid()*
+
                 TODO: Documentation
 
 list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
+
                 Extends a list-like table with the values of another list-like
                 table.
 
@@ -1065,6 +1107,7 @@ list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
                     |vim.tbl_extend()|
 
 pesc({s})                                                         *vim.pesc()*
+
                 Escapes magic chars in a Lua pattern.
 
                 Parameters: ~
@@ -1077,6 +1120,7 @@ pesc({s})                                                         *vim.pesc()*
                     https://github.com/rxi/lume
 
 split({s}, {sep}, {plain})                                       *vim.split()*
+
                 Splits a string at each instance of a separator.
 
                 Examples: >
@@ -1098,6 +1142,7 @@ split({s}, {sep}, {plain})                                       *vim.split()*
                     |vim.gsplit()|
 
 startswith({s}, {prefix})                                   *vim.startswith()*
+
                 Tests if `s` starts with `prefix`.
 
                 Parameters: ~
@@ -1108,6 +1153,7 @@ startswith({s}, {prefix})                                   *vim.startswith()*
                     (boolean) true if `prefix` is a prefix of s
 
 tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
+
                 Add the reverse lookup values to an existing table. For
                 example: tbl_add_reverse_lookup { A = 1 } == { [1] = 'A , A = 1 }`
 
@@ -1115,6 +1161,7 @@ tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
                     {o}  table The table to add the reverse to.
 
 tbl_contains({t}, {value})                                *vim.tbl_contains()*
+
                 Checks if a list-like (vector) table contains `value`.
 
                 Parameters: ~
@@ -1125,6 +1172,7 @@ tbl_contains({t}, {value})                                *vim.tbl_contains()*
                     true if `t` contains `value`
 
 tbl_count({t})                                               *vim.tbl_count()*
+
                 Counts the number of non-nil values in table `t`.
 >
     vim.tbl_count({ a=1, b=2 }) => 2
@@ -1141,6 +1189,7 @@ tbl_count({t})                                               *vim.tbl_count()*
                     https://github.com/Tieske/Penlight/blob/master/lua/pl/tablex.lua
 
 tbl_deep_extend({behavior}, {...})                     *vim.tbl_deep_extend()*
+
                 Merges recursively two or more map-like tables.
 
                 Parameters: ~
@@ -1155,6 +1204,7 @@ tbl_deep_extend({behavior}, {...})                     *vim.tbl_deep_extend()*
                     |tbl_extend()|
 
 tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
+
                 Merges two or more map-like tables.
 
                 Parameters: ~
@@ -1169,6 +1219,7 @@ tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
                     |extend()|
 
 tbl_filter({func}, {t})                                     *vim.tbl_filter()*
+
                 Filter a table using a predicate function
 
                 Parameters: ~
@@ -1176,6 +1227,7 @@ tbl_filter({func}, {t})                                     *vim.tbl_filter()*
                     {t}     table
 
 tbl_flatten({t})                                           *vim.tbl_flatten()*
+
                 Creates a copy of a list-like table such that any nested
                 tables are "unrolled" and appended to the result.
 
@@ -1189,6 +1241,7 @@ tbl_flatten({t})                                           *vim.tbl_flatten()*
                     Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_isempty({t})                                           *vim.tbl_isempty()*
+
                 Checks if a table is empty.
 
                 Parameters: ~
@@ -1198,6 +1251,7 @@ tbl_isempty({t})                                           *vim.tbl_isempty()*
                     https://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_islist({t})                                             *vim.tbl_islist()*
+
                 Tests if a Lua table can be treated as an array.
 
                 Empty table `{}` is assumed to be an array, unless it was
@@ -1212,6 +1266,7 @@ tbl_islist({t})                                             *vim.tbl_islist()*
                     `true` if array-like table, else `false` .
 
 tbl_keys({t})                                                 *vim.tbl_keys()*
+
                 Return a list of all keys used in a table. However, the order
                 of the return table of keys is not guaranteed.
 
@@ -1225,6 +1280,7 @@ tbl_keys({t})                                                 *vim.tbl_keys()*
                     Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_map({func}, {t})                                           *vim.tbl_map()*
+
                 Apply a function to all values of a table.
 
                 Parameters: ~
@@ -1232,6 +1288,7 @@ tbl_map({func}, {t})                                           *vim.tbl_map()*
                     {t}     table
 
 tbl_values({t})                                             *vim.tbl_values()*
+
                 Return a list of all values used in a table. However, the
                 order of the return table of values is not guaranteed.
 
@@ -1242,6 +1299,7 @@ tbl_values({t})                                             *vim.tbl_values()*
                     list of values
 
 trim({s})                                                         *vim.trim()*
+
                 Trim whitespace (Lua pattern "%s") from both sides of a
                 string.
 
@@ -1255,6 +1313,7 @@ trim({s})                                                         *vim.trim()*
                     https://www.lua.org/pil/20.2.html
 
 validate({opt})                                               *vim.validate()*
+
                 Validates a parameter specification (types and values).
 
                 Usage example: >
@@ -1311,6 +1370,7 @@ validate({opt})                                               *vim.validate()*
 Lua module: uri                                                      *lua-uri*
 
 uri_from_bufnr({bufnr})                                 *vim.uri_from_bufnr()*
+
                 Get a URI from a bufnr
 
                 Parameters: ~
@@ -1320,6 +1380,7 @@ uri_from_bufnr({bufnr})                                 *vim.uri_from_bufnr()*
                     URI
 
 uri_from_fname({path})                                  *vim.uri_from_fname()*
+
                 Get a URI from a file path.
 
                 Parameters: ~
@@ -1329,6 +1390,7 @@ uri_from_fname({path})                                  *vim.uri_from_fname()*
                     URI
 
 uri_to_bufnr({uri})                                       *vim.uri_to_bufnr()*
+
                 Return or create a buffer for a uri.
 
                 Parameters: ~
@@ -1341,6 +1403,7 @@ uri_to_bufnr({uri})                                       *vim.uri_to_bufnr()*
                     Creates buffer but does not load it
 
 uri_to_fname({uri})                                       *vim.uri_to_fname()*
+
                 Get a filename from a URI
 
                 Parameters: ~

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -264,8 +264,7 @@ arguments separated by " " (space) instead of "\t" (tab).
                         can omit [endmarker] after the "<<" and use a dot "."
                         after {script} (similar to |:append|, |:insert|).
 
-                        Example:
-                        >
+                        Example: >
                             function! CurrentLineInfo()
                             lua << EOF
                             local linenr, curline, formatstr
@@ -290,8 +289,7 @@ arguments separated by " " (space) instead of "\t" (tab).
                         that becomes the text of the corresponding buffer
                         line. Default [range] is the whole file: "1,$".
 
-                        Examples:
-                        >
+                        Examples: >
                             :luado return string.format("%s\t%d", line:reverse(), #line)
 
                             :lua require"lpeg"
@@ -305,8 +303,7 @@ arguments separated by " " (space) instead of "\t" (tab).
                         Execute Lua script in {file}.
                         The whole argument is used as a single file name.
 
-                        Examples:
-                        >
+                        Examples: >
                             :luafile script.lua
                             :luafile %
 <

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -520,8 +520,8 @@ Example: File-change detection                                    *watch-file*
       w:start(fullpath, {}, vim.schedule_wrap(function(...)
         on_change(...) end))
     end
-    vim.api.nvim_command(
-      "command! -nargs=1 Watch call luaeval('watch_file(_A)', expand('<args>'))")
+    vim.api.nvim_command("command! -nargs=1 Watch call " ..
+                         "luaeval('watch_file(_A)', expand('<args>'))")
 
 
 Example: TCP echo-server                                          *tcp-server*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -589,9 +589,11 @@ vim.highlight.range({bufnr}, {ns}, {higroup},          *vim.highlight.range()*
                     {start}, {finish},
                     {rtype}, {inclusive})
 
-        Highlights the range between {start} and {finish} (tuples of {line,col})
-        in buffer {bufnr} with the highlight group {higroup} using the namespace
-        {ns}. Optional arguments are the type of range (characterwise, linewise,
+        Highlights the range between {start} and {finish} (tuples of
+        {line,col}) in buffer {bufnr} with the highlight group {higroup}
+        using the namespace {ns}.
+
+        Optional arguments are the type of range (characterwise, linewise,
         or blockwise, see |setreg|; default to characterwise) and whether the
         range is inclusive (default false).
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -112,7 +112,7 @@ Lua functions can be called in multiple ways. Consider the function: >
 
 
 The first way to call a function is: >
-    
+
     example_func(1, 2)
     -- ==== Result ====
     -- A is: 1

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4,12 +4,12 @@
                             NVIM REFERENCE MANUAL
 
 
-Lua engine                                                *lua* *Lua*
+Lua engine                                                         *lua* *Lua*
 
-                                      Type |gO| to see the table of contents.
+                                       Type |gO| to see the table of contents.
 
 ==============================================================================
-INTRODUCTION                                                *lua-intro*
+INTRODUCTION                                                       *lua-intro*
 
 The Lua 5.1 language is builtin and always available.  Try this command to get
 an idea of what lurks beneath: >
@@ -30,9 +30,9 @@ finds and loads Lua modules.  The conventions are similar to VimL plugins,
 with some extra features.  See |lua-require-example| for a walkthrough.
 
 ==============================================================================
-IMPORTING LUA MODULES                                        *lua-require*
+IMPORTING LUA MODULES                                            *lua-require*
 
-                                                        *lua-package-path*
+                                                            *lua-package-path*
 Nvim automatically adjusts `package.path` and `package.cpath` according to
 effective 'runtimepath' value.  Adjustment happens whenever 'runtimepath' is
 changed.  `package.path` is adjusted by simply appending `/lua/?.lua` and
@@ -96,12 +96,12 @@ Note:
   is better to not have them in 'runtimepath' at all.
 
 ==============================================================================
-Lua Syntax Information                                         *lua-syntax-help*
+Lua Syntax Information                                       *lua-syntax-help*
 
 While Lua has a simple syntax, there are a few things to understand,
 particularly when looking at the documentation above.
 
-                                                      *lua-syntax-call-function*
+                                                    *lua-syntax-call-function*
 
 Lua functions can be called in multiple ways. Consider the function: >
 
@@ -156,7 +156,7 @@ function without any parentheses. This is most often used to approximate
 
 
 ------------------------------------------------------------------------------
-LUA PLUGIN EXAMPLE                                        *lua-require-example*
+LUA PLUGIN EXAMPLE                                       *lua-require-example*
 
 The following example plugin adds a command `:MakeCharBlob` which transforms 
 current buffer into a long `unsigned char` array.  Lua contains transformation 
@@ -233,7 +233,7 @@ lua/charblob.lua: >
     }
 
 ==============================================================================
-COMMANDS                                                *lua-commands*
+COMMANDS                                                        *lua-commands*
 
 These commands execute a Lua chunk from either the command line (:lua, :luado)
 or a file (:luafile) on the given line [range]. As always in Lua, each chunk
@@ -244,7 +244,7 @@ command calls. The |lua-stdlib| modules, user modules, and anything else on
 The Lua print() function redirects its output to the Nvim message area, with
 arguments separated by " " (space) instead of "\t" (tab).
 
-                                                        *:lua*
+                                                                        *:lua*
 :[range]lua {chunk}
                         Executes Lua chunk {chunk}.
 
@@ -255,7 +255,7 @@ arguments separated by " " (space) instead of "\t" (tab).
 <                        To see the LuaJIT version: >
                             :lua print(jit.version)
 <
-                                                        *:lua-heredoc*
+                                                                *:lua-heredoc*
 :[range]lua << [endmarker]
 {script}
 {endmarker}
@@ -279,7 +279,7 @@ arguments separated by " " (space) instead of "\t" (tab).
 <                        Note that the `local` variables will disappear when
                         the block finishes. But not globals.
 
-                                                        *:luado*
+                                                                      *:luado*
 :[range]luado {body}    Executes Lua chunk "function(line, linenr) {body} end"
                         for each buffer line in [range], where `line` is the
                         current line text (without <EOL>), and `linenr` is the
@@ -297,7 +297,7 @@ arguments separated by " " (space) instead of "\t" (tab).
                             :luado if bp:match(line) then return "-->\t" .. line end
 <
 
-                                                        *:luafile*
+                                                                    *:luafile*
 :[range]luafile {file}
                         Execute Lua script in {file}.
                         The whole argument is used as a single file name.
@@ -309,7 +309,7 @@ arguments separated by " " (space) instead of "\t" (tab).
 <
 
 ==============================================================================
-luaeval()                                                *lua-eval* *luaeval()*
+luaeval()                                               *lua-eval* *luaeval()*
 
 The (dual) equivalent of "vim.eval" for passing Lua values to Nvim is
 "luaeval". "luaeval" takes an expression string and an optional argument used 
@@ -347,9 +347,9 @@ cases there is the following agreement:
 3. Table with string keys, at least one of which contains NUL byte, is also 
    considered to be a dictionary, but this time it is converted to 
    a |msgpack-special-map|.
-                                                        *lua-special-tbl*
 4. Table with `vim.type_idx` key may be a dictionary, a list or floating-point 
    value:
+                                                             *lua-special-tbl*
    - `{[vim.type_idx]=vim.types.float, [vim.val_idx]=1}` is converted to 
      a floating-point 1.0. Note that by default integral Lua numbers are 
      converted to |Number|s, non-integral are converted to |Float|s. This 
@@ -378,7 +378,7 @@ Return value is also always converted. When converting,
 |msgpack-special-dict|s are treated specially.
 
 ==============================================================================
-Vimscript v:lua interface                                *v:lua-call*
+Vimscript v:lua interface                                         *v:lua-call*
 
 From Vimscript the special `v:lua` prefix can be used to call Lua functions
 which are global or accessible from global tables. The expression >
@@ -414,7 +414,7 @@ Note: `v:lua` without a call is not allowed in a Vimscript expression:
 
 
 ==============================================================================
-Lua standard modules                                        *lua-stdlib*
+Lua standard modules                                              *lua-stdlib*
 
 The Nvim Lua "standard library" (stdlib) is the `vim` module, which exposes
 various functions and sub-modules.  It is always loaded, thus require("vim")
@@ -448,7 +448,7 @@ Note that underscore-prefixed functions (e.g. "_os_proc_children") are
 internal/private and must not be used by plugins.
 
 ------------------------------------------------------------------------------
-VIM.LOOP                                                *lua-loop* *vim.loop*
+VIM.LOOP                                                 *lua-loop* *vim.loop*
 
 `vim.loop` exposes all features of the Nvim event-loop.  This is a low-level
 API that provides functionality for networking, filesystem, and process
@@ -495,7 +495,7 @@ Example: repeating timer
     print('sleeping');
 
 
-Example: File-change detection                                *watch-file*
+Example: File-change detection                                    *watch-file*
     1. Save this code to a file.
     2. Execute it with ":luafile %".
     3. Use ":Watch %" to watch any file.
@@ -521,7 +521,7 @@ Example: File-change detection                                *watch-file*
       "command! -nargs=1 Watch call luaeval('watch_file(_A)', expand('<args>'))")
 
 
-Example: TCP echo-server                                *tcp-server*
+Example: TCP echo-server                                          *tcp-server*
     1. Save this code to a file.
     2. Execute it with ":luafile %".
     3. Note the port number.
@@ -568,7 +568,7 @@ If you want to exclude visual selections from highlighting on yank, use
  au TextYankPost * silent! lua vim.highlight.on_yank {on_visual=false}
 <
 
-vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
+vim.highlight.on_yank({opts})                        *vim.highlight.on_yank()*
         Highlights the yanked text. The fields of the optional dict {opts}
         control the highlight:
           - {higroup} highlight group for yanked region (default `"IncSearch"`)
@@ -576,9 +576,10 @@ vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
           - {on_macro} highlight when executing macro (default `false`)
           - {on_visual} highlight when yanking visual selection (default `true`)
           - {event} event structure (default `vim.v.event`)
+vim.highlight.range({bufnr}, {ns}, {higroup},          *vim.highlight.range()*
+                    {start}, {finish},
+                    {rtype}, {inclusive})
 
-vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
-                                                       *vim.highlight.range()*
         Highlights the range between {start} and {finish} (tuples of {line,col})
         in buffer {bufnr} with the highlight group {higroup} using the namespace
         {ns}. Optional arguments are the type of range (characterwise, linewise,
@@ -586,12 +587,12 @@ vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclu
         range is inclusive (default false).
 
 ------------------------------------------------------------------------------
-VIM.REGEX                                                        *lua-regex*
+VIM.REGEX                                                          *lua-regex*
 
 Vim regexes can be used directly from lua. Currently they only allow
 matching within a single line.
 
-vim.regex({re})                                                *vim.regex()*
+vim.regex({re})                                                  *vim.regex()*
 
         Parse the regex {re} and return a regex object. 'magic' and
         'ignorecase' options are ignored, lua regexes always defaults to magic
@@ -600,7 +601,7 @@ vim.regex({re})                                                *vim.regex()*
 
 Regex objects support the following methods:
 
-regex:match_str({str})                                        *regex:match_str()*
+regex:match_str({str})                                     *regex:match_str()*
         Match the string against the regex. If the string should match the
         regex precisely, surround the regex with `^` and `$`.
         If the was a match, the byte indices for the beginning and end of
@@ -608,28 +609,28 @@ regex:match_str({str})                                        *regex:match_str()
         As any integer is truth-y, `regex:match()` can be directly used
         as a condition in an if-statement.
 
-regex:match_line({bufnr}, {line_idx}[, {start}, {end}])        *regex:match_line()*
+regex:match_line({bufnr}, {line_idx}[, {start}, {end}])   *regex:match_line()*
         Match line {line_idx} (zero-based) in buffer {bufnr}. If {start} and
         {end} are supplied, match only this byte index range. Otherwise see
         |regex:match_str()|. If {start} is used, then the returned byte
         indices will be relative {start}.
 
 ------------------------------------------------------------------------------
-VIM                                                        *lua-builtin*
+VIM                                                              *lua-builtin*
 
-vim.api.{func}({...})                                        *vim.api*
+vim.api.{func}({...})                                                *vim.api*
         Invokes Nvim |API| function {func} with arguments {...}.
         Example: call the "nvim_get_current_line()" API function: >
             print(tostring(vim.api.nvim_get_current_line()))
 
-vim.in_fast_event()                                        *vim.in_fast_event()*
+vim.in_fast_event()                                      *vim.in_fast_event()*
         Returns true if the code is executing as part of a "fast" event
         handler, where most of the API is disabled. These are low-level events
         (e.g. |lua-loop-callbacks|) which can be invoked whenever Nvim polls
         for input.  When this is `false` most API functions are callable (but
         may be subject to other restrictions such as |textlock|).
 
-vim.NIL                                                                    *vim.NIL*
+vim.NIL                                                              *vim.NIL*
         Special value used to represent NIL in msgpack-rpc and |v:null| in
         vimL interaction, and similar cases. Lua `nil` cannot be used as
         part of a lua table representing a Dictionary or Array, as it
@@ -646,7 +647,7 @@ vim.empty_dict()                                            *vim.empty_dict()*
         Note: if numeric keys are added to the table, the metatable will be
         ignored and the dict converted to a list/array anyway.
 
-vim.region({bufnr}, {pos1}, {pos2}, {type}, {inclusive})       *vim.region()*
+vim.region({bufnr}, {pos1}, {pos2}, {type}, {inclusive})        *vim.region()*
         Converts a selection specified by the buffer ({bufnr}), starting
         position ({pos1}, a zero-indexed pair `{line1,column1}`), ending
         position ({pos2}, same format as {pos1}), the type of the register
@@ -654,7 +655,7 @@ vim.region({bufnr}, {pos1}, {pos2}, {type}, {inclusive})       *vim.region()*
         whether the selection is inclusive or not, into a zero-indexed table 
         of linewise selections of the form `{linenr = {startcol, endcol}}` .
 
-                                             *vim.register_keystroke_callback()*
+                                           *vim.register_keystroke_callback()*
 vim.register_keystroke_callback({fn}, {ns_id})
         Register a lua {fn} with an {ns_id} to be run after every keystroke.
 
@@ -682,7 +683,7 @@ vim.register_keystroke_callback({fn}, {ns_id})
 
         NOTE: {fn} will *NOT* be cleared from |nvim_buf_clear_namespace()|
 
-vim.rpcnotify({channel}, {method}[, {args}...])                    *vim.rpcnotify()*
+vim.rpcnotify({channel}, {method}[, {args}...])              *vim.rpcnotify()*
         Sends {event} to {channel} via |RPC| and returns immediately.
         If {channel} is 0, the event is broadcast to all channels.
 
@@ -695,7 +696,7 @@ vim.rpcrequest({channel}, {method}[, {args}...])            *vim.rpcrequest()*
         Note: NIL values as part of the return value is represented as
         |vim.NIL| special value
 
-vim.stricmp({a}, {b})                                        *vim.stricmp()*
+vim.stricmp({a}, {b})                                          *vim.stricmp()*
         Compares strings case-insensitively.  Returns 0, 1 or -1 if strings
         are equal, {a} is greater than {b} or {a} is lesser than {b},
         respectively.
@@ -710,7 +711,7 @@ vim.str_utfindex({str}[, {index}])                        *vim.str_utfindex()*
         point each. An {index} in the middle of a UTF-8 sequence is rounded
         upwards to the end of that sequence.
 
-vim.str_byteindex({str}, {index}[, {use_utf16}])        *vim.str_byteindex()*
+vim.str_byteindex({str}, {index}[, {use_utf16}])         *vim.str_byteindex()*
         Convert UTF-32 or UTF-16 {index} to byte index. If {use_utf16} is not
         supplied, it defaults to false (use UTF-32). Returns the byte index.
 
@@ -718,12 +719,12 @@ vim.str_byteindex({str}, {index}[, {use_utf16}])        *vim.str_byteindex()*
         in the middle of a UTF-16 sequence is rounded upwards to the end of that
         sequence.
 
-vim.schedule({callback})                                *vim.schedule()*
+vim.schedule({callback})                                      *vim.schedule()*
         Schedules {callback} to be invoked soon by the main event-loop. Useful
         to avoid |textlock| or other temporary restrictions.
 
 
-vim.defer_fn({fn}, {timeout})                                    *vim.defer_fn*
+vim.defer_fn({fn}, {timeout})                                   *vim.defer_fn*
     Defers calling {fn} until {timeout} ms passes.  Use to do a one-shot timer
     that calls {fn}.
 
@@ -788,14 +789,14 @@ vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
     end
 <
 
-vim.type_idx                                                *vim.type_idx*
+vim.type_idx                                                    *vim.type_idx*
         Type index for use in |lua-special-tbl|.  Specifying one of the 
         values from |vim.types| allows typing the empty table (it is 
         unclear whether empty Lua table represents empty list or empty array) 
         and forcing integral numbers to be |Float|.  See |lua-special-tbl| for 
         more details.
 
-vim.val_idx                                                *vim.val_idx*
+vim.val_idx                                                      *vim.val_idx*
         Value index for tables representing |Float|s.  A table representing 
         floating-point value 1.0 looks like this: >
             {
@@ -804,7 +805,7 @@ vim.val_idx                                                *vim.val_idx*
             }
 <        See also |vim.type_idx| and |lua-special-tbl|.
 
-vim.types                                                *vim.types*
+vim.types                                                          *vim.types*
         Table with possible values for |vim.type_idx|.  Contains two sets 
         of key-value pairs: first maps possible values for |vim.type_idx| 
         to human-readable strings, second maps human-readable type names to 
@@ -824,24 +825,24 @@ vim.types                                                *vim.types*
         only contain values for these three types.
 
 ------------------------------------------------------------------------------
-LUA-VIMSCRIPT BRIDGE                                    *lua-vimscript*
+LUA-VIMSCRIPT BRIDGE                                           *lua-vimscript*
 
 Nvim Lua provides an interface to Vimscript variables and functions, and
 editor commands and options.
 
-vim.call({func}, {...})                                        *vim.call()*
+vim.call({func}, {...})                                           *vim.call()*
         Invokes |vim-function| or |user-function| {func} with arguments {...}.
         See also |vim.fn|.
         Equivalent to: >
             vim.fn[func]({...})
 
-vim.cmd({cmd})                                          *vim.cmd()*
+vim.cmd({cmd})                                                     *vim.cmd()*
         Invokes an Ex command (the ":" commands, Vimscript statements).
         See also |ex-cmd-index|.
         Example: >
             vim.cmd('echo 42')
 
-vim.fn.{func}({...})                                        *vim.fn*
+vim.fn.{func}({...})                                                  *vim.fn*
         Invokes |vim-function| or |user-function| {func} with arguments {...}.
         To call autoload functions, use the syntax: >
             vim.fn['some#function']({...})
@@ -858,7 +859,7 @@ vim.fn.{func}({...})                                        *vim.fn*
         enumerates functions that were called at least once.
 
 
-                                                        *lua-vim-variables*
+                                                           *lua-vim-variables*
 The Vim editor global dictionaries |g:| |w:| |b:| |t:| |v:| can be accessed
 from Lua conveniently and idiomatically by referencing the `vim.*` Lua tables
 described below. In this way you can easily read and modify global Vimscript
@@ -870,27 +871,27 @@ Example: >
     print(vim.g.foo)  -- Get and print the g:foo Vimscript variable.
     vim.g.foo = nil   -- Delete (:unlet) the Vimscript variable.
 
-vim.g                                                   *vim.g*
+vim.g                                                                  *vim.g*
         Global (|g:|) editor variables.
         Key with no value returns `nil`.
 
-vim.b                                                   *vim.b*
+vim.b                                                                  *vim.b*
         Buffer-scoped (|b:|) variables for the current buffer.
         Invalid or unset key returns `nil`.
 
-vim.w                                                   *vim.w*
+vim.w                                                                  *vim.w*
         Window-scoped (|w:|) variables for the current window.
         Invalid or unset key returns `nil`.
 
-vim.t                                                   *vim.t*
+vim.t                                                                  *vim.t*
         Tabpage-scoped (|t:|) variables for the current tabpage.
         Invalid or unset key returns `nil`.
 
-vim.v                                                   *vim.v*
+vim.v                                                                  *vim.v*
         |v:| variables.
         Invalid or unset key returns `nil`.
 
-vim.env                                                 *vim.env*
+vim.env                                                              *vim.env*
         Environment variables defined in the editor session.
         See |expand-env| and |:let-environment| for the Vimscript behavior.
         Invalid or unset key returns `nil`.
@@ -899,23 +900,23 @@ vim.env                                                 *vim.env*
             print(vim.env.TERM)
 <
 
-                                                        *lua-vim-options*
+                                                             *lua-vim-options*
 From Lua you can work with editor |options| by reading and setting items in
 these Lua tables:
 
-vim.o                                                   *vim.o*
+vim.o                                                                  *vim.o*
         Get or set editor options, like |:set|. Invalid key is an error.
         Example: >
             vim.o.cmdheight = 4
             print(vim.o.columns)
 
-vim.bo                                                  *vim.bo*
+vim.bo                                                                *vim.bo*
         Get or set buffer-scoped |local-options|. Invalid key is an error.
         Example: >
             vim.bo.buflisted = true
             print(vim.bo.comments)
 
-vim.wo                                                  *vim.wo*
+vim.wo                                                                *vim.wo*
         Get or set window-scoped |local-options|. Invalid key is an error.
         Example: >
             vim.wo.cursorcolumn = true

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -268,15 +268,18 @@ arguments separated by " " (space) instead of "\t" (tab).
                         >
                             function! CurrentLineInfo()
                             lua << EOF
-                            local linenr = vim.api.nvim_win_get_cursor(0)[1]
-                            local curline = vim.api.nvim_buf_get_lines(
-                                    0, linenr, linenr + 1, false)[1]
-                            print(string.format("Current line [%d] has %d bytes",
-                                    linenr, #curline))
+                            local linenr, curline, formatstr
+                            linenr = vim.api.nvim_win_get_cursor(0)[1]
+                            curline = vim.api.nvim_buf_get_lines(0,
+                                                                 linenr,
+                                                                 linenr + 1,
+                                                                 false)[1]
+                            formatstr = "Current line [%d] has %d bytes"
+                            print(string.format(output, linenr, #curline))
                             EOF
                             endfunction
 
-<                        Note that the `local` variables will disappear when
+<                       Note that the `local` variables will disappear when
                         the block finishes. But not globals.
 
                                                                       *:luado*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -685,8 +685,9 @@ vim.register_keystroke_callback({fn}, {ns_id})
                     If {fn} is `nil`, it removes the callback for the
                     associated {ns_id}.
 
-            {ns_id}: (number)  Namespace ID. If not passed or 0, will generate
-                     and return a new namespace ID from |nvim_create_namespace()|
+            {ns_id}: (number): Namespace ID.
+                     If not passed or 0, will generate and return a new
+                     namespace ID from |nvim_create_namespace()|
 
         Return: ~
             (number) Namespace ID associated with {fn}

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -677,13 +677,13 @@ vim.register_keystroke_callback({fn}, {ns_id})
         Register a lua {fn} with an {ns_id} to be run after every keystroke.
 
         Parameters: ~
-            {fn}: (function): Function to call on keystroke.
-                    It should take one argument, which is a string.
-                    The string will contain the literal keys typed.
-                    See |i_CTRL-V|
+            {fn}:    (function): Function to call on keystroke.
+                     It should take one argument, which is a string.
+                     The string will contain the literal keys typed.
+                     See |i_CTRL-V|
 
-                    If {fn} is `nil`, it removes the callback for the
-                    associated {ns_id}.
+                     If {fn} is `nil`, it removes the callback for the
+                     associated {ns_id}.
 
             {ns_id}: (number): Namespace ID.
                      If not passed or 0, will generate and return a new
@@ -816,11 +816,11 @@ vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
 
 vim.type_idx                                                    *vim.type_idx*
 
-        Type index for use in |lua-special-tbl|.  Specifying one of the 
-        values from |vim.types| allows typing the empty table (it is 
-        unclear whether empty Lua table represents empty list or empty array) 
-        and forcing integral numbers to be |Float|.  See |lua-special-tbl| for 
-        more details.
+        Type index for use in |lua-special-tbl|.  Specifying one of the values
+        from |vim.types| allows typing the empty table (it is unclear whether
+        empty Lua table represents empty list or empty array) and forcing
+        integral numbers to be |Float|.  See |lua-special-tbl| for more
+        details.
 
 vim.val_idx                                                      *vim.val_idx*
 
@@ -889,7 +889,6 @@ vim.fn.{func}({...})                                                  *vim.fn*
         Note: vim.fn keys are generated lazily, thus `pairs(vim.fn)` only
         enumerates functions that were called at least once.
 
-
                                                            *lua-vim-variables*
 The Vim editor global dictionaries |g:| |w:| |b:| |t:| |v:| can be accessed
 from Lua conveniently and idiomatically by referencing the `vim.*` Lua tables
@@ -936,12 +935,13 @@ vim.env                                                              *vim.env*
             vim.env.FOO = 'bar'
             print(vim.env.TERM)
 <
-From Lua you can work with editor |options| by               *lua-vim-options*
-reading and setting items in these Lua tables:
+From Lua you can work with editor |options| by reading and   *lua-vim-options*
+setting items in these Lua tables:
 
 vim.o                                                                  *vim.o*
 
         Get or set editor options, like |:set|. Invalid key is an error.
+
         Example: >
             vim.o.cmdheight = 4
             print(vim.o.columns)
@@ -949,6 +949,7 @@ vim.o                                                                  *vim.o*
 vim.bo                                                                *vim.bo*
 
         Get or set buffer-scoped |local-options|. Invalid key is an error.
+
         Example: >
             vim.bo.buflisted = true
             print(vim.bo.comments)
@@ -956,6 +957,7 @@ vim.bo                                                                *vim.bo*
 vim.wo                                                                *vim.wo*
 
         Get or set window-scoped |local-options|. Invalid key is an error.
+
         Example: >
             vim.wo.cursorcolumn = true
             print(vim.wo.foldmarker)
@@ -966,400 +968,395 @@ Lua module: vim                                                      *lua-vim*
 
 inspect({object}, {options})                                   *vim.inspect()*
 
-                Return a human-readable representation of the given object.
+        Return a human-readable representation of the given object.
 
-                See also: ~
-                    https://github.com/kikito/inspect.lua
-                    https://github.com/mpeterv/vinspect
+        See also: ~
+            https://github.com/kikito/inspect.lua
+            https://github.com/mpeterv/vinspect
 
 make_meta_accessor({get}, {set}, {del})             *vim.make_meta_accessor()*
 
-                TODO: Documentation
+        TODO: Documentation
 
 paste({lines}, {phase})                                          *vim.paste()*
 
-                Paste handler, invoked by |nvim_paste()| when a conforming UI
-                (such as the |TUI|) pastes text into the editor.
+        Paste handler, invoked by |nvim_paste()| when a conforming UI
+        (such as the |TUI|) pastes text into the editor.
 
-                Example: To remove ANSI color codes when pasting: >
+        Example: To remove ANSI color codes when pasting: >
 
-                 vim.paste = (function(overridden)
-                   return function(lines, phase)
-                     for i,line in ipairs(lines) do
-                       -- Scrub ANSI color codes from paste input.
-                       lines[i] = line:gsub('\27%[[0-9;mK]+', '')
-                     end
-                     overridden(lines, phase)
-                   end
-                 end)(vim.paste)
+         vim.paste = (function(overridden)
+           return function(lines, phase)
+             for i,line in ipairs(lines) do
+               -- Scrub ANSI color codes from paste input.
+               lines[i] = line:gsub('\27%[[0-9;mK]+', '')
+             end
+             overridden(lines, phase)
+           end
+         end)(vim.paste)
 <
 
-                Parameters: ~
-                    {lines}  |readfile()|-style list of lines to paste.
-                             |channel-lines|
-                    {phase}  -1: "non-streaming" paste: the call contains all
-                             lines. If paste is "streamed", `phase` indicates the stream state:
-                             • 1: starts the paste (exactly once)
-                             • 2: continues the paste (zero or more times)
-                             • 3: ends the paste (exactly once)
+        Parameters: ~
+            {lines}  |readfile()|-style list of lines to paste.
+                     |channel-lines|
+            {phase}  -1: "non-streaming" paste: the call contains all
+                     lines. If paste is "streamed", `phase` indicates the stream state:
+                     • 1: starts the paste (exactly once)
+                     • 2: continues the paste (zero or more times)
+                     • 3: ends the paste (exactly once)
 
-                Return: ~
-                    false if client should cancel the paste.
+        Return: ~
+            false if client should cancel the paste.
 
-                See also: ~
-                    |paste|
+        See also: ~
+            |paste|
 
 schedule_wrap({cb})                                      *vim.schedule_wrap()*
 
-                Defers callback `cb` until the Nvim API is safe to call.
+        Defers callback `cb` until the Nvim API is safe to call.
 
-                See also: ~
-                    |lua-loop-callbacks|
-                    |vim.schedule()|
-                    |vim.in_fast_event()|
+        See also: ~
+            |lua-loop-callbacks|
+            |vim.schedule()|
+            |vim.in_fast_event()|
 
 
 
 
 deep_equal({a}, {b})                                        *vim.deep_equal()*
 
-                TODO: Documentation
+        TODO: Documentation
 
 deepcopy({orig})                                              *vim.deepcopy()*
 
-                Returns a deep copy of the given object. Non-table objects are
-                copied as in a typical Lua assignment, whereas table objects
-                are copied recursively. Functions are naively copied, so
-                functions in the copied table point to the same functions as
-                those in the input table. Userdata and threads are not copied
-                and will throw an error.
+        Returns a deep copy of the given object. Non-table objects are copied
+        as in a typical Lua assignment, whereas table objects are copied
+        recursively. Functions are naively copied, so functions in the copied
+        table point to the same functions as those in the input table.
+        Userdata and threads are not copied and will throw an error.
 
-                Parameters: ~
-                    {orig}  Table to copy
+        Parameters: ~
+            {orig}  Table to copy
 
-                Return: ~
-                    New table of copied keys and (nested) values.
+        Return: ~
+            New table of copied keys and (nested) values.
 
 endswith({s}, {suffix})                                       *vim.endswith()*
 
-                Tests if `s` ends with `suffix` .
+        Tests if `s` ends with `suffix` .
 
-                Parameters: ~
-                    {s}       (string) a string
-                    {suffix}  (string) a suffix
+        Parameters: ~
+            {s}       (string) a string
+            {suffix}  (string) a suffix
 
-                Return: ~
-                    (boolean) true if `suffix` is a suffix of s
+        Return: ~
+            (boolean) true if `suffix` is a suffix of s
 
 gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
 
-                Splits a string at each instance of a separator.
+        Splits a string at each instance of a separator.
 
-                Parameters: ~
-                    {s}      String to split
-                    {sep}    Separator string or pattern
-                    {plain}  If `true` use `sep` literally (passed to
-                             String.find)
+        Parameters: ~
+            {s}      String to split
+            {sep}    Separator string or pattern
+            {plain}  If `true` use `sep` literally (passed to
+                     String.find)
 
-                Return: ~
-                    Iterator over the split components
+        Return: ~
+            Iterator over the split components
 
-                See also: ~
-                    |vim.split()|
-                    https://www.lua.org/pil/20.2.html
-                    http://lua-users.org/wiki/StringLibraryTutorial
+        See also: ~
+            |vim.split()|
+            https://www.lua.org/pil/20.2.html
+            http://lua-users.org/wiki/StringLibraryTutorial
 
 is_callable({f})                                           *vim.is_callable()*
 
-                Returns true if object `f` can be called as a function.
+        Returns true if object `f` can be called as a function.
 
-                Parameters: ~
-                    {f}  Any object
+        Parameters: ~
+            {f}  Any object
 
-                Return: ~
-                    true if `f` is callable, else false
+        Return: ~
+            true if `f` is callable, else false
 
 is_valid({opt})                                               *vim.is_valid()*
 
-                TODO: Documentation
+        TODO: Documentation
 
 list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
 
-                Extends a list-like table with the values of another list-like
-                table.
+        Extends a list-like table with the values of another list-like
+        table.
 
-                NOTE: This mutates dst!
+        NOTE: This mutates dst!
 
-                Parameters: ~
-                    {dst}     list which will be modified and appended to.
-                    {src}     list from which values will be inserted.
-                    {start}   Start index on src. defaults to 1
-                    {finish}  Final index on src. defaults to #src
+        Parameters: ~
+            {dst}     list which will be modified and appended to.
+            {src}     list from which values will be inserted.
+            {start}   Start index on src. defaults to 1
+            {finish}  Final index on src. defaults to #src
 
-                Return: ~
-                    dst
+        Return: ~
+            dst
 
-                See also: ~
-                    |vim.tbl_extend()|
+        See also: ~
+            |vim.tbl_extend()|
 
 pesc({s})                                                         *vim.pesc()*
 
-                Escapes magic chars in a Lua pattern.
+        Escapes magic chars in a Lua pattern.
 
-                Parameters: ~
-                    {s}  String to escape
+        Parameters: ~
+            {s}  String to escape
 
-                Return: ~
-                    %-escaped pattern string
+        Return: ~
+            %-escaped pattern string
 
-                See also: ~
-                    https://github.com/rxi/lume
+        See also: ~
+            https://github.com/rxi/lume
 
 split({s}, {sep}, {plain})                                       *vim.split()*
 
-                Splits a string at each instance of a separator.
+        Splits a string at each instance of a separator.
 
-                Examples: >
-                 split(":aa::b:", ":")     --> {'','aa','','b',''}
-                 split("axaby", "ab?")     --> {'','x','y'}
-                 split(x*yz*o, "*", true)  --> {'x','yz','o'}
+        Examples: >
+         split(":aa::b:", ":")     --> {'','aa','','b',''}
+         split("axaby", "ab?")     --> {'','x','y'}
+         split(x*yz*o, "*", true)  --> {'x','yz','o'}
 <
 
-                Parameters: ~
-                    {s}      String to split
-                    {sep}    Separator string or pattern
-                    {plain}  If `true` use `sep` literally (passed to
-                             String.find)
+        Parameters: ~
+            {s}      String to split
+            {sep}    Separator string or pattern
+            {plain}  If `true` use `sep` literally (passed to
+                     String.find)
 
-                Return: ~
-                    List-like table of the split components.
+        Return: ~
+            List-like table of the split components.
 
-                See also: ~
-                    |vim.gsplit()|
+        See also: ~
+            |vim.gsplit()|
 
 startswith({s}, {prefix})                                   *vim.startswith()*
 
-                Tests if `s` starts with `prefix`.
+        Tests if `s` starts with `prefix`.
 
-                Parameters: ~
-                    {s}       (string) a string
-                    {prefix}  (string) a prefix
+        Parameters: ~
+            {s}       (string) a string
+            {prefix}  (string) a prefix
 
-                Return: ~
-                    (boolean) true if `prefix` is a prefix of s
+        Return: ~
+            (boolean) true if `prefix` is a prefix of s
 
 tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
 
-                Add the reverse lookup values to an existing table. For
-                example: tbl_add_reverse_lookup { A = 1 } == { [1] = 'A , A = 1 }`
+        Add the reverse lookup values to an existing table. For
+        example: tbl_add_reverse_lookup { A = 1 } == { [1] = 'A , A = 1 }`
 
-                Parameters: ~
-                    {o}  table The table to add the reverse to.
+        Parameters: ~
+            {o}  table The table to add the reverse to.
 
 tbl_contains({t}, {value})                                *vim.tbl_contains()*
 
-                Checks if a list-like (vector) table contains `value`.
+        Checks if a list-like (vector) table contains `value`.
 
-                Parameters: ~
-                    {t}      Table to check
-                    {value}  Value to compare
+        Parameters: ~
+            {t}      Table to check
+            {value}  Value to compare
 
-                Return: ~
-                    true if `t` contains `value`
+        Return: ~
+            true if `t` contains `value`
 
 tbl_count({t})                                               *vim.tbl_count()*
 
-                Counts the number of non-nil values in table `t`.
->
-    vim.tbl_count({ a=1, b=2 }) => 2
-    vim.tbl_count({ 1, 2 }) => 2
+        Counts the number of non-nil values in table `t`. >
+        vim.tbl_count({ a=1, b=2 }) => 2
+        vim.tbl_count({ 1, 2 }) => 2
 <
+        Parameters: ~
+            {t}  Table
 
-                Parameters: ~
-                    {t}  Table
+        Return: ~
+            Number that is the number of the value in table
 
-                Return: ~
-                    Number that is the number of the value in table
-
-                See also: ~
-                    https://github.com/Tieske/Penlight/blob/master/lua/pl/tablex.lua
+        See also: ~
+            https://github.com/Tieske/Penlight/blob/master/lua/pl/tablex.lua
 
 tbl_deep_extend({behavior}, {...})                     *vim.tbl_deep_extend()*
 
-                Merges recursively two or more map-like tables.
+        Merges recursively two or more map-like tables.
 
-                Parameters: ~
-                    {behavior}  Decides what to do if a key is found in more
-                                than one map:
-                                • "error": raise an error
-                                • "keep": use value from the leftmost map
-                                • "force": use value from the rightmost map
-                    {...}       Two or more map-like tables.
+        Parameters: ~
+            {behavior}  Decides what to do if a key is found in more
+                        than one map:
+                        - "error": raise an error
+                        - "keep": use value from the leftmost map
+                        - "force": use value from the rightmost map
+            {...}       Two or more map-like tables.
 
-                See also: ~
-                    |tbl_extend()|
+        See also: ~
+            |tbl_extend()|
 
 tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
 
-                Merges two or more map-like tables.
+        Merges two or more map-like tables.
 
-                Parameters: ~
-                    {behavior}  Decides what to do if a key is found in more
-                                than one map:
-                                • "error": raise an error
-                                • "keep": use value from the leftmost map
-                                • "force": use value from the rightmost map
-                    {...}       Two or more map-like tables.
+        Parameters: ~
+            {behavior}  Decides what to do if a key is found in more
+                        than one map:
+                        • "error": raise an error
+                        • "keep": use value from the leftmost map
+                        • "force": use value from the rightmost map
+            {...}       Two or more map-like tables.
 
-                See also: ~
-                    |extend()|
+        See also: ~
+            |extend()|
 
 tbl_filter({func}, {t})                                     *vim.tbl_filter()*
 
-                Filter a table using a predicate function
+        Filter a table using a predicate function
 
-                Parameters: ~
-                    {func}  function or callable table
-                    {t}     table
+        Parameters: ~
+            {func}  function or callable table
+            {t}     table
 
 tbl_flatten({t})                                           *vim.tbl_flatten()*
 
-                Creates a copy of a list-like table such that any nested
-                tables are "unrolled" and appended to the result.
+        Creates a copy of a list-like table such that any nested tables are
+        "unrolled" and appended to the result.
 
-                Parameters: ~
-                    {t}  List-like table
+        Parameters: ~
+            {t}  List-like table
 
-                Return: ~
-                    Flattened copy of the given list-like table.
+        Return: ~
+            Flattened copy of the given list-like table.
 
-                See also: ~
-                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
+        See also: ~
+            Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_isempty({t})                                           *vim.tbl_isempty()*
 
-                Checks if a table is empty.
+        Checks if a table is empty.
 
-                Parameters: ~
-                    {t}  Table to check
+        Parameters: ~
+            {t}  Table to check
 
-                See also: ~
-                    https://github.com/premake/premake-core/blob/master/src/base/table.lua
+        See also: ~
+            https://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_islist({t})                                             *vim.tbl_islist()*
 
-                Tests if a Lua table can be treated as an array.
+        Tests if a Lua table can be treated as an array.
 
-                Empty table `{}` is assumed to be an array, unless it was
-                created by |vim.empty_dict()| or returned as a dict-like |API|
-                or Vimscript result, for example from |rpcrequest()| or
-                |vim.fn|.
+        Empty table `{}` is assumed to be an array, unless it was created by
+        |vim.empty_dict()| or returned as a dict-like |API| or Vimscript
+        result, for example from |rpcrequest()| or |vim.fn|.
 
-                Parameters: ~
-                    {t}  Table
+        Parameters: ~
+            {t}  Table
 
-                Return: ~
-                    `true` if array-like table, else `false` .
+        Return: ~
+            `true` if array-like table, else `false` .
 
 tbl_keys({t})                                                 *vim.tbl_keys()*
 
-                Return a list of all keys used in a table. However, the order
-                of the return table of keys is not guaranteed.
+        Return a list of all keys used in a table. However, the order of the
+        return table of keys is not guaranteed.
 
-                Parameters: ~
-                    {t}  Table
+        Parameters: ~
+            {t}  Table
 
-                Return: ~
-                    list of keys
+        Return: ~
+            list of keys
 
-                See also: ~
-                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
+        See also: ~
+            Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_map({func}, {t})                                           *vim.tbl_map()*
 
-                Apply a function to all values of a table.
+        Apply a function to all values of a table.
 
-                Parameters: ~
-                    {func}  function or callable table
-                    {t}     table
+        Parameters: ~
+            {func}  function or callable table
+            {t}     table
 
 tbl_values({t})                                             *vim.tbl_values()*
 
-                Return a list of all values used in a table. However, the
-                order of the return table of values is not guaranteed.
+        Return a list of all values used in a table. However, the order of
+        the return table of values is not guaranteed.
 
-                Parameters: ~
-                    {t}  Table
+        Parameters: ~
+            {t}  Table
 
-                Return: ~
-                    list of values
+        Return: ~
+            list of values
 
 trim({s})                                                         *vim.trim()*
 
-                Trim whitespace (Lua pattern "%s") from both sides of a
-                string.
+        Trim whitespace (Lua pattern "%s") from both sides of a string.
 
-                Parameters: ~
-                    {s}  String to trim
+        Parameters: ~
+            {s}  String to trim
 
-                Return: ~
-                    String with whitespace removed from its beginning and end
+        Return: ~
+            String with whitespace removed from its beginning and end
 
-                See also: ~
-                    https://www.lua.org/pil/20.2.html
+        See also: ~
+            https://www.lua.org/pil/20.2.html
 
 validate({opt})                                               *vim.validate()*
 
-                Validates a parameter specification (types and values).
+        Validates a parameter specification (types and values).
 
-                Usage example: >
+        Usage example: >
 
-                  function user.new(name, age, hobbies)
-                    vim.validate{
-                      name={name, 'string'},
-                      age={age, 'number'},
-                      hobbies={hobbies, 'table'},
-                    }
-                    ...
-                  end
+          function user.new(name, age, hobbies)
+            vim.validate{
+              name={name, 'string'},
+              age={age, 'number'},
+              hobbies={hobbies, 'table'},
+            }
+            ...
+          end
 <
 
-                Examples with explicit argument values (can be run directly): >
+        Examples with explicit argument values (can be run directly): >
 
-                  vim.validate{arg1={{'foo'}, 'table'}, arg2={'foo', 'string'}}
-                     => NOP (success)
-<
->
-    vim.validate{arg1={1, 'table'}}
-       => error('arg1: expected table, got number')
+        vim.validate{arg1={{'foo'}, 'table'}, arg2={'foo', 'string'}}
+        => NOP (success)
 <
 >
-    vim.validate{arg1={3, function(a) return (a % 2) == 0 end, 'even number'}}
-       => error('arg1: expected even number, got 3')
+        vim.validate{arg1={1, 'table'}}
+        => error('arg1: expected table, got number')
+<
+>
+        vim.validate{arg1={3, function(a) return (a % 2) == 0 end, 'even number'}}
+        => error('arg1: expected even number, got 3')
 <
 
-                Parameters: ~
-                    {opt}  Map of parameter names to validations. Each key is
-                           a parameter name; each value is a tuple in one of
-                           these forms:
-                           1. (arg_value, type_name, optional)
-                              • arg_value: argument value
-                              • type_name: string type name, one of: ("table",
-                                "t", "string", "s", "number", "n", "boolean",
-                                "b", "function", "f", "nil", "thread",
-                                "userdata")
-                              • optional: (optional) boolean, if true, `nil`
-                                is valid
+        Parameters: ~
+            {opt}  Map of parameter names to validations. Each key is
+                   a parameter name; each value is a tuple in one of
+                   these forms:
+                   1. (arg_value, type_name, optional)
+                      • arg_value: argument value
+                      • type_name: string type name, one of: ("table",
+                        "t", "string", "s", "number", "n", "boolean",
+                        "b", "function", "f", "nil", "thread",
+                        "userdata")
+                      • optional: (optional) boolean, if true, `nil`
+                        is valid
 
-                           2. (arg_value, fn, msg)
-                              • arg_value: argument value
-                              • fn: any function accepting one argument,
-                                returns true if and only if the argument is
-                                valid. Can optionally return an additional
-                                informative error message as the second
-                                returned value.
-                              • msg: (optional) error string if validation
-                                fails
+                   2. (arg_value, fn, msg)
+                      • arg_value: argument value
+                      • fn: any function accepting one argument,
+                        returns true if and only if the argument is
+                        valid. Can optionally return an additional
+                        informative error message as the second
+                        returned value.
+                      • msg: (optional) error string if validation
+                        fails
 
 
 ==============================================================================
@@ -1367,45 +1364,45 @@ Lua module: uri                                                      *lua-uri*
 
 uri_from_bufnr({bufnr})                                 *vim.uri_from_bufnr()*
 
-                Get a URI from a bufnr
+        Get a URI from a bufnr
 
-                Parameters: ~
-                    {bufnr}  (number): Buffer number
+        Parameters: ~
+            {bufnr}  (number): Buffer number
 
-                Return: ~
-                    URI
+        Return: ~
+            URI
 
 uri_from_fname({path})                                  *vim.uri_from_fname()*
 
-                Get a URI from a file path.
+        Get a URI from a file path.
 
-                Parameters: ~
-                    {path}  (string): Path to file
+        Parameters: ~
+            {path}  (string): Path to file
 
-                Return: ~
-                    URI
+        Return: ~
+            URI
 
 uri_to_bufnr({uri})                                       *vim.uri_to_bufnr()*
 
-                Return or create a buffer for a uri.
+      Return or create a buffer for a uri.
 
-                Parameters: ~
-                    {uri}  (string): The URI
+      Parameters: ~
+          {uri}  (string): The URI
 
-                Return: ~
-                    bufnr.
+      Return: ~
+          bufnr.
 
-                Note:
-                    Creates buffer but does not load it
+      Note:
+          Creates buffer but does not load it
 
 uri_to_fname({uri})                                       *vim.uri_to_fname()*
 
-                Get a filename from a URI
+      Get a filename from a URI
 
-                Parameters: ~
-                    {uri}  (string): The URI
+      Parameters: ~
+          {uri}  (string): The URI
 
-                Return: ~
-                    Filename
+      Return: ~
+          Filename
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -574,11 +574,17 @@ If you want to exclude visual selections from highlighting on yank, use
 vim.highlight.on_yank({opts})                        *vim.highlight.on_yank()*
         Highlights the yanked text. The fields of the optional dict {opts}
         control the highlight:
-          - {higroup} highlight group for yanked region (default `"IncSearch"`)
-          - {timeout} time in ms before highlight is cleared (default `150`)
-          - {on_macro} highlight when executing macro (default `false`)
-          - {on_visual} highlight when yanking visual selection (default `true`)
-          - {event} event structure (default `vim.v.event`)
+          - {higroup} highlight group for yanked region
+            (default `"IncSearch"`)
+          - {timeout} time in ms before highlight is cleared
+            (default `150`)
+          - {on_macro} highlight when executing macro
+            (default `false`)
+          - {on_visual} highlight when yanking visual selection
+            (default `true`)
+          - {event} event structure
+            (default `vim.v.event`)
+
 vim.highlight.range({bufnr}, {ns}, {higroup},          *vim.highlight.range()*
                     {start}, {finish},
                     {rtype}, {inclusive})


### PR DESCRIPTION
*This PR isn't 100% complete and requesting review, but before I really get involved in it I figure it's worth checking how much interest there would be in merging. It's quite a heavy change set in terms of line count even if content largely remains as-is. I can understand if it's seen as a bit heavy handed, though commits are kept as atomic as feasible.*

I noticed some of the layout/formatting in `runtime/doc/lua.txt` was inconsistent.

This included:

- Mixed tabs and spaces (even swapping on the same line!):
  - It seems that most newer documentation was written with just spaces, the code style guide specifies spaces over tabs, though that is for *code*, not *documentation*.
  - Tabs have been converted to spaces.
  - I recognize that the modeline specifies 8 spaces for tabs, but again, tabs vs spaces was applied so inconsistently that this didn't really have useful implications.

- Lines overrunning 78 characters:
  - This was sometimes an result of tabs vs spaces, or just inconsistently applied rules.
  - Lines have been re-wrapped to 78 characters where possible (some lines such as URLs or "one liner" vim command examples are left as is (_for now?_)).

- Inconsistent justification of tags:
  - Many tags were not justified to the right edge of 78ch.
  - Tags have been justified.

- Inconsistent blank lines
  - This included after "tags lines", function signatures, some examples, headings, etc.
  - Tags and signatures are followed by a blank line
  - Style guide for some examples isn't so clear, one line examples vs multi line etc.
  - Incomplete.

- Inconsistent indentation for function documentation
  - vim.uri and vim module were indented much deeper than the vim bridge docs. At some point this was _maybe_ to align the documentation paragraphs with the function signatures, but it no longer aligned with anything. This might have also just been a side effect of some docs having been written with tabs, then those spaces were converted at some point.
  - Indentation has been normalized to 4 spaces, which matches the lua-vimscript section, and also I think makes more sense as it allows for less wrap issues and the super deep indentation seemed unnecessary.

As I wrote at the start, this is more of an RFC, welcome to trash it as it is somewhat opinionated. There are still inconsistencies around stuff such as `:lua` and `:luado` separating it's description by a new line or in-line with the command, tags in or out of line with the command , etc. 

I couldn't find an actual documentation style guide, so I tried to infer what I could. Perhaps that would also be a good project (along with a linter or aid of some kind probably)?