### PR TITLE
WIP: Fix codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,10 +4,6 @@
 codecov:
   notify:
     require_ci_to_pass: no
-  ci:
-    - appveyor
-    - travis
-    - !neovim-qb.szakmeister.net
 
 coverage:
   precision: 2


### PR DESCRIPTION
 - remove ci list: should not be required, and failed validation because
   of obsolete "!neovim-qb.szakmeister.net" entry