### PR TITLE
vim-patch:8.1.{323,777,933,938},8.2.{178,248,547,581,592,646,658,793,1608,1975,1991,1992,1993,1994,1998,1999,2003,2007,2008,2009}

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1132,12 +1132,6 @@ struct VimMenu {
   vimmenu_T   *next;                 ///< Next item in menu
 };
 
-typedef struct {
-  int wb_startcol;
-  int wb_endcol;
-  vimmenu_T *wb_menu;
-} winbar_item_T;
-
 /// Structure which contains all information that belongs to a window.
 ///
 /// All row numbers are relative to the start of the window, except w_winrow.
@@ -1354,10 +1348,6 @@ struct window_S {
 
   char_u      *w_localdir;          /* absolute path of local directory or
                                        NULL */
-  vimmenu_T *w_winbar;            // The root of the WinBar menu hierarchy.
-  winbar_item_T *w_winbar_items;  // list of items in the WinBar
-  int w_winbar_height;            // 1 if there is a window toolbar
-
   // Options local to a window.
   // They are local because they influence the layout of the window or
   // depend on the window layout.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6433,7 +6433,7 @@ dict_T *get_win_info(win_T *wp, int16_t tpnr, int16_t winnr)
   tv_dict_add_nr(dict, S_LEN("winrow"), wp->w_winrow + 1);
   tv_dict_add_nr(dict, S_LEN("topline"), wp->w_topline);
   tv_dict_add_nr(dict, S_LEN("botline"), wp->w_botline - 1);
-  tv_dict_add_nr(dict, S_LEN("winbar"), wp->w_winbar_height);
+  tv_dict_add_nr(dict, S_LEN("winbar"), 0);
   tv_dict_add_nr(dict, S_LEN("width"), wp->w_width);
   tv_dict_add_nr(dict, S_LEN("bufnr"), wp->w_buffer->b_fnum);
   tv_dict_add_nr(dict, S_LEN("wincol"), wp->w_wincol + 1);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2987,11 +2987,12 @@ static void f_getchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       // illegal argument or getchar(0) and no char avail: return zero
       n = 0;
     } else {
-      // getchar(0) and char avail: return char
+      // getchar(0) and char avail() != NUL: get a character.
+      // Note that vpeekc_any() returns K_SPECIAL for K_IGNORE.
       n = safe_vgetc();
     }
 
-    if (n == K_IGNORE) {
+    if (n == K_IGNORE || n == K_VER_SCROLLBAR || n == K_HOR_SCROLLBAR) {
       continue;
     }
     break;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2601,11 +2601,6 @@ do_mouse (
                              oap == NULL ? NULL : &(oap->inclusive),
                              which_button);
 
-  // A click in the window toolbar has no side effects.
-  if (jump_flags & MOUSE_WINBAR) {
-    return false;
-  }
-
   moved = (jump_flags & CURSOR_MOVED);
   in_status_line = (jump_flags & IN_STATUS_LINE);
   in_sep_line = (jump_flags & IN_SEP_LINE);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1112,8 +1112,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
   // add a status line when p_ls == 1 and splitting the first window
   if (one_nonfloat() && p_ls == 1 && oldwin->w_status_height == 0) {
-    if ((oldwin->w_height + oldwin->w_winbar_height) <= p_wmh
-        && new_in_layout) {
+    if (oldwin->w_height <= p_wmh && new_in_layout) {
       EMSG(_(e_noroom));
       return FAIL;
     }
@@ -1210,7 +1209,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
      * height.
      */
     // Current window requires at least 1 space.
-    wmh1 = (p_wmh == 0 ? 1 : p_wmh) + curwin->w_winbar_height;
+    wmh1 = p_wmh == 0 ? 1 : p_wmh;
     needed = wmh1 + STATUS_HEIGHT;
     if (flags & WSP_ROOM) {
       needed += p_wh - wmh1;
@@ -1408,12 +1407,12 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     if (flags & (WSP_TOP | WSP_BOT)) {
       /* set height and row of new window to full height */
       wp->w_winrow = tabline_height();
-      win_new_height(wp, curfrp->fr_height - (p_ls > 0) - wp->w_winbar_height);
+      win_new_height(wp, curfrp->fr_height - (p_ls > 0));
       wp->w_status_height = (p_ls > 0);
     } else {
       /* height and row of new window is same as current window */
       wp->w_winrow = oldwin->w_winrow;
-      win_new_height(wp, oldwin->w_height + oldwin->w_winbar_height);
+      win_new_height(wp, oldwin->w_height);
       wp->w_status_height = oldwin->w_status_height;
     }
     frp->fr_height = curfrp->fr_height;
@@ -1460,7 +1459,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
      * one row for the status line */
     win_new_height(wp, new_size);
     if (flags & (WSP_TOP | WSP_BOT)) {
-      int new_fr_height = curfrp->fr_height - new_size + wp->w_winbar_height;
+      int new_fr_height = curfrp->fr_height - new_size;
 
       if (!((flags & WSP_BOT) && p_ls == 0)) {
         new_fr_height -= STATUS_HEIGHT;
@@ -1474,8 +1473,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       wp->w_status_height = STATUS_HEIGHT;
       oldwin->w_winrow += wp->w_height + STATUS_HEIGHT;
     } else {            // new window below current one
-      wp->w_winrow = oldwin->w_winrow + oldwin->w_height
-        + STATUS_HEIGHT + oldwin->w_winbar_height;
+      wp->w_winrow = oldwin->w_winrow + oldwin->w_height + STATUS_HEIGHT;
       wp->w_status_height = oldwin->w_status_height;
       if (!(flags & WSP_BOT)) {
         oldwin->w_status_height = STATUS_HEIGHT;
@@ -1690,7 +1688,7 @@ make_windows (
                 - (p_wiw - p_wmw)) / (p_wmw + 1);
   } else {
     // Each window needs at least 'winminheight' lines and a status line.
-    maxcount = (curwin->w_height + curwin->w_winbar_height
+    maxcount = (curwin->w_height
                 + curwin->w_status_height
                 - (p_wh - p_wmh)) / (p_wmh + STATUS_HEIGHT);
   }
@@ -3155,9 +3153,7 @@ frame_new_height (
   if (topfrp->fr_win != NULL) {
     // Simple case: just one window.
     win_new_height(topfrp->fr_win,
-                   height
-                   - topfrp->fr_win->w_status_height
-                   - topfrp->fr_win->w_winbar_height);
+                   height - topfrp->fr_win->w_status_height);
   } else if (topfrp->fr_layout == FR_ROW) {
     do {
       // All frames in this row get the same new height.
@@ -3464,8 +3460,7 @@ static void frame_fix_width(win_T *wp)
 static void frame_fix_height(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  wp->w_frame->fr_height =
-    wp->w_height + wp->w_status_height + wp->w_winbar_height;
+  wp->w_frame->fr_height = wp->w_height + wp->w_status_height;
 }
 
 /*
@@ -3488,11 +3483,10 @@ static int frame_minheight(frame_T *topfrp, win_T *next_curwin)
       // window: minimal height of the window plus status line
       m = p_wmh + topfrp->fr_win->w_status_height;
       if (topfrp->fr_win == curwin && next_curwin == NULL) {
-        // Current window is minimal one line high and WinBar is visible.
+        // Current window is minimal one line high.
         if (p_wmh == 0) {
           m++;
         }
-        m += curwin->w_winbar_height;
       }
     }
   } else if (topfrp->fr_layout == FR_ROW) {
@@ -4804,8 +4798,6 @@ win_free (
 
   qf_free_all(wp);
 
-  remove_winbar(wp);
-
   xfree(wp->w_p_cc_cols);
 
   win_free_grid(wp, false);
@@ -5092,8 +5084,7 @@ static void frame_comp_pos(frame_T *topfrp, int *row, int *col)
       wp->w_redr_status = true;
       wp->w_pos_changed = true;
     }
-    // WinBar will not show if the window height is zero
-    const int h = wp->w_height + wp->w_winbar_height + wp->w_status_height;
+    const int h = wp->w_height + wp->w_status_height;
     *row += h > topfrp->fr_height ? topfrp->fr_height : h;
     *col += wp->w_width + wp->w_vsep_width;
   } else {
@@ -5135,7 +5126,6 @@ void win_setheight_win(int height, win_T *win)
     if (height == 0) {
       height = 1;
     }
-    height += curwin->w_winbar_height;
   }
 
   if (win->w_floating) {
@@ -5231,9 +5221,8 @@ static void frame_setheight(frame_T *curfrp, int height)
         room_cmdline = 0;
       } else {
         win_T *wp = lastwin_nofloating();
-        room_cmdline = Rows - p_ch - (wp->w_winrow
-                                      + wp->w_height + wp->w_winbar_height +
-                                      wp->w_status_height);
+        room_cmdline = Rows - p_ch
+          - (wp->w_winrow + wp->w_height + wp->w_status_height);
         if (room_cmdline < 0) {
           room_cmdline = 0;
         }

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -232,20 +232,53 @@ describe("shell command :!", function()
   if has_powershell() then
     it('powershell supports literal strings', function()
       set_shell_powershell()
-      local screen = Screen.new(30, 4)
+      local screen = Screen.new(45, 4)
       screen:attach()
       feed_command([[!'Write-Output $a']])
-      screen:expect{any='\nWrite%-Output %$a', timeout=10000}
+      screen:expect([[
+        :!'Write-Output $a'                          |
+        Write-Output $a                              |
+                                                     |
+        Press ENTER or type command to continue^      |
+      ]])
       feed_command([[!$a = 1; Write-Output '$a']])
-      screen:expect{any='\n%$a', timeout=10000}
+      screen:expect([[
+        :!$a = 1; Write-Output '$a'                  |
+        $a                                           |
+                                                     |
+        Press ENTER or type command to continue^      |
+      ]])
       feed_command([[!"Write-Output $a"]])
-      screen:expect{any='\nWrite%-Output', timeout=10000}
+      screen:expect([[
+        :!"Write-Output $a"                          |
+        Write-Output                                 |
+                                                     |
+        Press ENTER or type command to continue^      |
+      ]])
       feed_command([[!$a = 1; Write-Output "$a"]])
-      screen:expect{any='\n1', timeout=10000}
-      feed_command(iswin()
-        and [[!& 'C:\\Windows\\system32\\cmd.exe' /c 'echo $a']]
-        or  [[!& '/bin/sh' -c 'echo ''$a''']])
-      screen:expect{any='\n%$a', timeout=10000}
+      screen:expect([[
+        :!$a = 1; Write-Output "$a"                  |
+        1                                            |
+                                                     |
+        Press ENTER or type command to continue^      |
+      ]])
+      if iswin() then
+        feed_command([[!& 'cmd.exe' /c 'echo $a']])
+        screen:expect([[
+          :!& 'cmd.exe' /c 'echo $a'                   |
+          $a                                           |
+                                                       |
+          Press ENTER or type command to continue^      |
+        ]])
+      else
+        feed_command([[!& '/bin/sh' -c 'echo ''$a''']])
+        screen:expect([[
+          :!& '/bin/sh' -c 'echo ''$a'''               |
+          $a                                           |
+                                                       |
+          Press ENTER or type command to continue^      |
+        ]])
+      end
     end)
   end
 end)


### PR DESCRIPTION
vim-patch:8.2.1608: Vim9: getchar() test fails with GUI

Problem:    Vim9: getchar() test fails with GUI.
Solution:   Avoid that getchar(0) gets stuck on K_IGNORE.
https://github.com/vim/vim/commit/15183b41c4416b7638cce26de0a9a83e55948bdc

N/A patches for version.c:

vim-patch:8.1.0323: reverse order of VTP calls only needed the first time

Problem:    Reverse order of VTP calls only needed the first time.
Solution:   Add a flag to remember the state. (Nobuhiro Takasaki, closes vim/vim#3366)
https://github.com/vim/vim/commit/2551c037e41b3c2702d3ec30ee518c11966b19e6

vim-patch:8.1.0777: Win32: using pipes for channel does not work well

Problem:    Win32: using pipes for channel does not work well.
Solution:   Use a larger buffer and handle overlaps. (Yasuhiro Matsumoto,
            closes vim/vim#3782)
https://github.com/vim/vim/commit/b091f30bf38eacb31b9d8c97c82c7e0af9866301

vim-patch:8.1.0933: When using VTP scroll region isn't used properly

Problem:    When using VTP scroll region isn't used properly.
Solution:   Make better use of the scroll region. (Nobuhiro Takasaki,
            closes vim/vim#3974)
https://github.com/vim/vim/commit/6982f42f33b2868e4b9884514cfe8e357b727498

vim-patch:8.1.0938: background color is wrong in MS-Windows console

Problem:    Background color is wrong in MS-Windows console when not using VTP.
Solution:   Use g_attrCurrent. (Nobuhiro Takasaki, closes vim/vim#3987)
https://github.com/vim/vim/commit/21edde87426eeeaf46e118a137a7fa0e86ad167e

vim-patch:8.2.0178: with VTP the screen may not be restored properly

Problem:    With VTP the screen may not be restored properly.
Solution:   Add another set of saved RGB values. (Nobuhiro Takasaki,
            closes vim/vim#5548)
https://github.com/vim/vim/commit/df54382eacdbfa10291adb80ad6b89ad83bd7c9b

vim-patch:8.2.0248: MS-Windows: dealing with deprecation is too complicated

Problem:    MS-Windows: dealing with deprecation is too complicated.
Solution:   Use io.h directly. Move _CRT_SECURE_NO_DEPRECATE to the build
            file. Suppress C4091 warning by setting "_WIN32_WINNT". (Ken
            Takata, closes vim/vim#5626)
https://github.com/vim/vim/commit/2f189750887636fecd440d7ef353d9224e48713f

vim-patch:8.2.0547: Win32: restoring screen not always done right

Problem:    Win32: restoring screen not always done right.
Solution:   Use a more appropriate method. (Nobuhiro Takasaki, closes vim/vim#5909)
https://github.com/vim/vim/commit/e7f234120f71a75f0c7c2a67e0b70c6450c50a02

vim-patch:8.2.0581: Win32 console: the cursor position is always top-left

Problem:    Win32 console: the cursor position is always top-left.
Solution:   Revert the patch for restoring screen.
https://github.com/vim/vim/commit/81ccbf199f0d553efdd57bec9bb8e23d91d2fb0d

vim-patch:8.2.0592: MS-Windows with VTP: cursor is not made invisible

Problem:    MS-Windows with VTP: cursor is not made invisible.
Solution:   Output the code to make the cursor visible or invisible. (Nobuhiro
            Takasaki, closes vim/vim#5941)
https://github.com/vim/vim/commit/2695de63e370235c4d3d73e3fe07cc1006de3460

vim-patch:8.2.0646: t_Co uses the value of $COLORS in the GUI

Problem:    t_Co uses the value of $COLORS in the GUI. (Masato Nishihata)
Solution:   Ignore $COLORS for the GUI. (closes vim/vim#5992)
https://github.com/vim/vim/commit/759d81549c1340185f0d92524c563bb37697ea88

vim-patch:8.2.0658: HP-UX build fails when setenv() is not defined

Problem:    HP-UX build fails when setenv() is not defined.
Solution:   Change "colors" to "t_colors". (John Marriott)
https://github.com/vim/vim/commit/affc8fd2cda77fbd47df2594da417a9f9a9bb9b6

vim-patch:8.2.0793: MS-Windows: cannot build GUI with small features

Problem:    MS-Windows: cannot build GUI with small features. (Michael Soyka)
Solution:   Add #ifdef around use of windowsVersion. (Ken Takata)
https://github.com/vim/vim/commit/1e1d2e89fa460328883bb09fb13a24e26ef1ab31

vim-patch:8.2.1975: Win32: memory leak when encoding conversion fails

Problem:    Win32: memory leak when encoding conversion fails.
Solution:   Free the allocated memory. (Ken Takata, closes vim/vim#7277)
https://github.com/vim/vim/commit/bbf9f344afd08954163191ed678352fb554fc254

vim-patch:8.2.1991: Coverity warns for not using the ga_grow() return value

Problem:    Coverity warns for not using the ga_grow() return value.
Solution:   Bail out if ga_grow() fails. (Yegappan Lakshmanan, closes vim/vim#7303)
https://github.com/vim/vim/commit/ca359cbedd0d603124776e7a6ca0ae79ffc34cdc

vim-patch:8.2.1992: build fails with small features

Problem:    Build fails with small features.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/4792a679f9e08fc6026a596be3d364cecb70b049

vim-patch:8.2.1993: occasional failure of the netbeans test

Problem:    Occasional failure of the netbeans test.
Solution:   Add "silent!". (Yegappan Lakshmanan, closes vim/vim#7304)
https://github.com/vim/vim/commit/50dc3ecc642ee88348cb353cf85d08eac26c75dd

vim-patch:8.2.1994: MS-Windows: MinGW always does a full build

Problem:    MS-Windows: MinGW always does a full build.
Solution:   Only check if $OUTDIR exists. (Masamichi Abe, closes vim/vim#7311)
https://github.com/vim/vim/commit/c4390fe6c0d1b47b1acd373d7e8ef986412c0600

vim-patch:8.2.1998: terminal Cmd test sometimes fails to close popup

Problem:    Terminal Cmd test sometimes fails to close popup.
Solution:   Add "term_finish" option.
https://github.com/vim/vim/commit/27f4f6baeeb25e1597a7827f4a509ecf2eb8e6e2

vim-patch:8.2.1999: terminal popup test sometimes fails

Problem:    Terminal popup test sometimes fails.
Solution:   Wait for the popup to close.
https://github.com/vim/vim/commit/e6329e4c55cd81b6134820eab6a10b02c11c1277