### PR TITLE
lsp: Change diagnostic.get_all result to table including bufnr

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1049,7 +1049,7 @@ get_all()                                       *vim.lsp.diagnostic.get_all()*
                 Get all diagnostics for all clients
 
                 Return: ~
-                    Diagnostic[]
+                    {bufnr:Diagnostic[]}
 
                                               *vim.lsp.diagnostic.get_count()*
 get_count({bufnr}, {severity}, {client_id})

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -308,15 +308,16 @@ end
 
 --- Get all diagnostics for all clients
 ---
----@return Diagnostic[]
+---@return {bufnr: Diagnostic[]}
 function M.get_all()
-  local all_diagnostics = {}
-  for _, buf_diagnostics in pairs(diagnostic_cache) do
+  local diagnostics_by_bufnr = {}
+  for bufnr, buf_diagnostics in pairs(diagnostic_cache) do
+    diagnostics_by_bufnr[bufnr] = {}
     for _, client_diagnostics in pairs(buf_diagnostics) do
-      vim.list_extend(all_diagnostics, client_diagnostics)
+      vim.list_extend(diagnostics_by_bufnr[bufnr], client_diagnostics)
     end
   end
-  return all_diagnostics
+  return diagnostics_by_bufnr
 end
 
 --- Return associated diagnostics for bufnr

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -68,20 +68,23 @@ describe('vim.lsp.diagnostic', function()
   describe('vim.lsp.diagnostic', function()
     describe('handle_publish_diagnostics', function()
       it('should be able to retrieve diagnostics from all buffers and clients', function()
-        eq(3, exec_lua [[
+        local result = exec_lua [[
           vim.lsp.diagnostic.save(
             {
               make_error('Diagnostic #1', 1, 1, 1, 1),
               make_error('Diagnostic #2', 2, 1, 2, 1),
-            }, 0, 1
+            }, 1, 1
           )
           vim.lsp.diagnostic.save(
             {
               make_error('Diagnostic #3', 3, 1, 3, 1),
-            }, 1, 2
+            }, 2, 2
           )
-          return #vim.lsp.diagnostic.get_all()
-        ]])
+          return vim.lsp.diagnostic.get_all()
+        ]]
+        eq(2, #result)
+        eq(2, #result[1])
+        eq('Diagnostic #1', result[1][1].message)
       end)
       it('should be able to save and count a single client error', function()
         eq(1, exec_lua [[
@@ -153,7 +156,6 @@ describe('vim.lsp.diagnostic', function()
           }
         ]])
       end)
-
       it('should handle one server clearing highlights while the other still has highlights', function()
         -- 1 Error (1)
         -- 1 Warning (2)


### PR DESCRIPTION
So that when they're retrieved via `get` or `get_all` users can
associate them to the right buffer.

See https://github.com/neovim/neovim/pull/13285#issuecomment-727771640

Wasn't sure whether to enrich the diagnostic within `get_all` ad-hoc or whether on save.
I already did the save part in my overriden handler, which is why I didn't notice the lack of it.

https://github.com/mfussenegger/dotfiles/blob/b739dd9ae3a133793a1c7fa69685b0029efb76ec/vim/.config/nvim/lua/lsp-diagnostics.lua#L36-L37