### PR TITLE
Fix colors in terminal by maintaining COLORTERM

### DIFF
--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -160,8 +160,21 @@ static void init_child(PtyProcess *ptyproc)
   os_unsetenv("COLUMNS");
   os_unsetenv("LINES");
   os_unsetenv("TERMCAP");
-  os_unsetenv("COLORTERM");
   os_unsetenv("COLORFGBG");
+  // setting COLORTERM to "truecolor" if termguicolors is set and 256
+  // otherwise, but only if it was set in the parent terminal at all
+  if (os_env_exists("COLORTERM")) {
+    const char *colorterm = os_getenv("COLORTERM");
+    if (colorterm != NULL) {
+      if (p_tgc) {
+        os_setenv("COLORTERM", "truecolor", 1);
+      } else {
+        os_setenv("COLORTERM", "256", 1);
+      }
+    } else {
+      os_unsetenv("COLORTERM");
+    }
+  }
 
   signal(SIGCHLD, SIG_DFL);
   signal(SIGHUP, SIG_DFL);


### PR DESCRIPTION
There are multiple issues with colors not working as expected in Neovim's
terminal (e.g., #10836, https://github.com/junegunn/fzf.vim/issues/1065,
https://github.com/nvim-telescope/telescope.nvim/issues/228). The reason is that
`COLORTERM` is not set, or better actively unset by Neovim.
I don't know why it is done, it is there since the file _pty_process_unix.c_ was
added, maybe a workaround at that time, because Truecolor wasn't supported?

Removing the removal of `COLORTERM` does fix the issue for my environment
(Linux, Alacritty, Tmux, `termguicolor` enabled) when using `bat` in Neovim
terminal as well as in Fzf.vim and Telescope.nvim.

Fixes https://github.com/neovim/neovim/issues/10836