### PR TITLE
vim-patch:8.2.2005: redoing a mapping with <Cmd> doesn't work properly

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4476,9 +4476,7 @@ char_u * getcmdkeycmd(int promptc, void *cookie, int indent, bool do_concat)
       aborted = true;
     } else if (IS_SPECIAL(c1)) {
       if (c1 == K_SNR) {
-        ga_append(&line_ga, (char)K_SPECIAL);
-        ga_append(&line_ga, (char)KS_EXTRA);
-        ga_append(&line_ga, (char)KE_SNR);
+        ga_concat(&line_ga, (char_u *)"<SNR>");
       } else {
         EMSG2(e_cmdmap_key, get_special_key_name(c1, cmod));
         aborted = true;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1485,7 +1485,8 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
     if ((redo_yank || oap->op_type != OP_YANK)
         && ((!VIsual_active || oap->motion_force)
             // Also redo Operator-pending Visual mode mappings.
-            || (cap->cmdchar == ':' && oap->op_type != OP_COLON))
+            || ((cap->cmdchar == ':' || cap->cmdchar == K_COMMAND)
+                && oap->op_type != OP_COLON))
         && cap->cmdchar != 'D'
         && oap->op_type != OP_FOLD
         && oap->op_type != OP_FOLDOPEN
@@ -1678,7 +1679,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
           prep_redo(oap->regname, cap->count0,
                     get_op_char(oap->op_type), get_extra_op_char(oap->op_type),
                     oap->motion_force, cap->cmdchar, cap->nchar);
-        } else if (cap->cmdchar != ':') {
+        } else if (cap->cmdchar != ':' && cap->cmdchar != K_COMMAND) {
           int nchar = oap->op_type == OP_REPLACE ? cap->nchar : NUL;
 
           // reverse what nv_replace() did

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -499,4 +499,40 @@ func Test_mapcomplete()
   call assert_match("abbr! \x01", @:)
 endfunc
 
+func Test_map_cmdkey_redo()
+  func SelectDash()
+    call search('^---\n\zs', 'bcW')
+    norm! V
+    call search('\n\ze---$', 'W')
+  endfunc
+
+  let text =<< trim END
+      ---
+      aaa
+      ---
+      bbb
+      bbb
+      ---
+      ccc
+      ccc
+      ccc
+      ---
+  END
+  new Xcmdtext
+  call setline(1, text)
+
+  onoremap <silent> i- <Cmd>call SelectDash()<CR>
+  call feedkeys('2Gdi-', 'xt')
+  call assert_equal(['---', '---'], getline(1, 2))
+  call feedkeys('j.', 'xt')
+  call assert_equal(['---', '---', '---'], getline(1, 3))
+  call feedkeys('j.', 'xt')
+  call assert_equal(['---', '---', '---', '---'], getline(1, 4))
+
+  bwipe!
+  call delete('Xcmdtext')
+  delfunc SelectDash
+  ounmap i-
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Redoing a mapping with <Cmd> doesn't work properly.
Solution:   Fill the redo buffer.  Use "<SNR>" instead of a key code.
            (closes vim/vim#7282)
https://github.com/vim/vim/commit/c77534c303721df4024fd6cfd51098d593b7d4da