### PR TITLE
vim-patch:8.2.{2006,2011}

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1301,6 +1301,7 @@ au BufNewFile,BufRead *.pml			setf promela
 
 " Google protocol buffers
 au BufNewFile,BufRead *.proto			setf proto
+au BufNewFile,BufRead *.pbtxt			setf pbtxt
 
 " Protocols
 au BufNewFile,BufRead */etc/protocols		setf protocols

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3505,12 +3505,16 @@ syn_cmd_list(
       syn_match_msg();
       return;
     } else if (!(curwin->w_s->b_syn_sync_flags & SF_MATCH))   {
-      if (curwin->w_s->b_syn_sync_minlines == 0)
+      if (curwin->w_s->b_syn_sync_minlines == 0) {
         MSG_PUTS(_("no syncing"));
-      else {
-        MSG_PUTS(_("syncing starts "));
-        msg_outnum(curwin->w_s->b_syn_sync_minlines);
-        MSG_PUTS(_(" lines before top line"));
+      } else {
+        if (curwin->w_s->b_syn_sync_minlines == MAXLNUM) {
+          MSG_PUTS(_("syncing starts at the first line"));
+        } else {
+          MSG_PUTS(_("syncing starts "));
+          msg_outnum(curwin->w_s->b_syn_sync_minlines);
+          MSG_PUTS(_(" lines before top line"));
+        }
         syn_match_msg();
       }
       return;
@@ -3566,17 +3570,22 @@ static void syn_lines_msg(void)
   if (curwin->w_s->b_syn_sync_maxlines > 0
       || curwin->w_s->b_syn_sync_minlines > 0) {
     MSG_PUTS("; ");
-    if (curwin->w_s->b_syn_sync_minlines > 0) {
-      MSG_PUTS(_("minimal "));
-      msg_outnum(curwin->w_s->b_syn_sync_minlines);
-      if (curwin->w_s->b_syn_sync_maxlines)
-        MSG_PUTS(", ");
+    if (curwin->w_s->b_syn_sync_minlines == MAXLNUM) {
+      MSG_PUTS(_("from the first line"));
+    } else {
+      if (curwin->w_s->b_syn_sync_minlines > 0) {
+        MSG_PUTS(_("minimal "));
+        msg_outnum(curwin->w_s->b_syn_sync_minlines);
+        if (curwin->w_s->b_syn_sync_maxlines) {
+          MSG_PUTS(", ");
+        }
+      }
+      if (curwin->w_s->b_syn_sync_maxlines > 0) {
+        MSG_PUTS(_("maximal "));
+        msg_outnum(curwin->w_s->b_syn_sync_maxlines);
+      }
+      MSG_PUTS(_(" lines before top line"));
     }
-    if (curwin->w_s->b_syn_sync_maxlines > 0) {
-      MSG_PUTS(_("maximal "));
-      msg_outnum(curwin->w_s->b_syn_sync_maxlines);
-    }
-    MSG_PUTS(_(" lines before top line"));
   }
 }
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -329,6 +329,7 @@ let s:filename_checks = {
     \ 'papp': ['file.papp', 'file.pxml', 'file.pxsl'],
     \ 'pascal': ['file.pas', 'file.pp', 'file.dpr', 'file.lpr'],
     \ 'passwd': ['any/etc/passwd', 'any/etc/passwd-', 'any/etc/passwd.edit', 'any/etc/shadow', 'any/etc/shadow-', 'any/etc/shadow.edit', 'any/var/backups/passwd.bak', 'any/var/backups/shadow.bak'],
+    \ 'pbtxt': ['file.pbtxt'],
     \ 'pccts': ['file.g'],
     \ 'pdf': ['file.pdf'],
     \ 'perl': ['file.plx', 'file.al', 'file.psgi', 'gitolite.rc', '.gitolite.rc', 'example.gitolite.rc'],

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -308,6 +308,8 @@ func Test_syntax_arg_skipped()
     syn sync ccomment
   endif
   call assert_notmatch('on C-style comments', execute('syntax sync'))
+  syn sync fromstart
+  call assert_match('syncing starts at the first line', execute('syntax sync'))
 
   syn clear
 endfunc
@@ -669,6 +671,7 @@ func Test_syntax_foldlevel()
   redir END
   call assert_equal("\nsyntax foldlevel start", @c)
   syn sync fromstart
+  call assert_match('from the first line$', execute('syn sync'))
   let a = map(range(3,9), 'foldclosed(v:val)')
   call assert_equal([3,3,3,3,3,3,3], a) " attached cascade folds together
   let a = map(range(10,15), 'foldclosed(v:val)')


### PR DESCRIPTION
vim-patch:8.2.2006: .pbtxt files are not recognized

Problem:    .pbtxt files are not recognized.
Solution:   Recognize .pbtxt as protobuf text buffers. (closes https://github.com/vim/vim/pull/7326)
https://github.com/vim/vim/commit/88774a30c0b1957a6177cdb69d2becedae610299

vim-patch:8.2.2011: "syn sync" reports a very large number

Problem:    "syn sync" reports a very large number.
Solution:   Use "at the first line".
https://github.com/vim/vim/commit/9950280d377a5c0706d141017fcef9cad598b8b0