### PR TITLE
runtime: Patch gitcommit.vim syntax

### DIFF
--- a/runtime/ftplugin/gitcommit.vim
+++ b/runtime/ftplugin/gitcommit.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	git commit file
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
-" Last Change:	2016 Aug 29
+" Last Change:	2019 Dec 05
 
 " Only do this when not done yet for this buffer
 if (exists("b:did_ftplugin"))
@@ -13,8 +13,10 @@ let b:did_ftplugin = 1
 
 setlocal comments=:# commentstring=#\ %s
 setlocal nomodeline tabstop=8 formatoptions+=tl textwidth=72
-setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q
-let b:undo_ftplugin = 'setl modeline< tabstop< formatoptions< tw< com< cms<'
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q formatoptions+=n
+setlocal formatlistpat+=\\\|^\\s*[-*+]\\s\\+
+
+let b:undo_ftplugin = 'setl modeline< tabstop< formatoptions< tw< com< cms< formatlistpat<'
 
 if exists("g:no_gitcommit_commands") || v:version < 700
   finish

--- a/runtime/syntax/gitcommit.vim
+++ b/runtime/syntax/gitcommit.vim
@@ -2,7 +2,7 @@
 " Language:	git commit file
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Filenames:	*.git/COMMIT_EDITMSG
-" Last Change:	2016 Aug 29
+" Last Change:	2019 Dec 05
 
 if exists("b:current_syntax")
   finish
@@ -18,11 +18,18 @@ endif
 syn include @gitcommitDiff syntax/diff.vim
 syn region gitcommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommitDiff
 
-syn match   gitcommitFirstLine	"\%^[^#].*"  nextgroup=gitcommitBlank skipnl
-syn match   gitcommitSummary	"^.\{0,50\}" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
+syn match   gitcommitSummary	"^.*\%<51v." contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
 syn match   gitcommitOverflow	".*" contained contains=@Spell
 syn match   gitcommitBlank	"^[^#].*" contained contains=@Spell
-syn match   gitcommitComment	"^#.*"
+
+if get(g:, "gitcommit_cleanup") is# "scissors"
+  syn match gitcommitFirstLine	"\%^.*" nextgroup=gitcommitBlank skipnl
+  syn region gitcommitComment start=/^# -\+ >8 -\+$/ end=/\%$/ contains=gitcommitDiff
+else
+  syn match gitcommitFirstLine	"\%^[^#].*" nextgroup=gitcommitBlank skipnl
+  syn match gitcommitComment	"^#.*"
+endif
+
 syn match   gitcommitHead	"^\%(#   .*\n\)\+#$" contained transparent
 syn match   gitcommitOnBranch	"\%(^# \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
 syn match   gitcommitOnBranch	"\%(^# \)\@<=Your branch .\{-\} '" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite


### PR DESCRIPTION
I'd like the syntax for this to be in line with vim's for nvim 0.5 users.

My first PR to neovim; I didn't use the vim-patch script, as the original commit doesn't have a per-file granularity, which I assume would be needed for that. I hope the formatting I used fits the spec.