### PR TITLE
Restricted mode (-Z) lingering references.

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -113,9 +113,6 @@ associated with a file.
 To overwrite a file, add an exclamation mark to the relevant Ex command, such as
 .Ic :w! .
 .Ic ":help 'readonly'"
-.It Fl Z
-Restricted mode.
-Disable commands that make use of an external shell.
 .It Fl m
 Resets the 'write' option, to disable file modifications.
 Writing to a file is disabled, but buffers can still be modified.

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -20,8 +20,7 @@ additionally sets up for viewing the differences between the arguments. >
 
 	nvim -d file1 file2 [file3 [file4]]
 
-In addition to the |-d| argument, |-R| may be used for readonly mode
-respectively.
+In addition to the |-d| argument, |-R| may be used for readonly mode.
 
 The second and following arguments may also be a directory name.  Vim will
 then append the file name of the first argument to the directory name to find

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -416,8 +416,8 @@ Aliases:
   gvimdiff  (GUI)
   rgview    (GUI)
   rgvim     (GUI)
-  rview     (alias for "nvim -RZ")
-  rvim      (alias for "nvim -Z")
+  rview
+  rvim
   view      (alias for "nvim -R")
   vimdiff   (alias for "nvim -d" |diff-mode|)
 
@@ -496,6 +496,7 @@ Startup:
   --literal (file args are always literal; to expand wildcards on Windows, use
     |:n| e.g. `nvim +"n *"`)
   Easy mode: eview, evim, nvim -y
+  Restricted mode: rview, rvim, nvim -Z
   Vi mode: nvim -v
 
 Test functions:


### PR DESCRIPTION
As per #11996, restricted mode (-Z) has been removed. Nonetheless in #11996 the man page was not updated. Hence this PR. I also updated `vim_diff.txt` and did a minor grammatical fix on `diff.txt`.