### PR TITLE
Remove leftover handling of restricted mode.

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -13,8 +13,6 @@ function! man#init() abort
   try
     " Check for -l support.
     call s:get_page(s:get_path('', 'man'))
-  catch /E145:/
-    " Ignore the error in restricted mode
   catch /command error .*/
     let s:localfile_arg = v:false
   endtry

--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -1348,10 +1348,6 @@ msgstr "E143: Outobevele het nuwe buffer %s onverwags geskrap"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nie-numeriese parameter vir :z"
 
-#, fuzzy
-#~ msgid "E145: Shell commands not allowed in restricted mode"
-#~ msgstr "E145: Dop bevele nie toegelaat in rvim"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Patrone kan nie deur letters afgebaken word nie"
 

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -1234,10 +1234,6 @@ msgstr "E143: Una auto-ordre ha eliminat el buffer nou %s inesperadament"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Argument no numèric per a :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Les ordres shell no estan permeses en l'rvim"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Les expressions regulars no poden estar delimitades per lletres"

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -1249,10 +1249,6 @@ msgstr "E143: Automatické pøíkazy neoèekávanì smazaly nový buffer %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselný argument pro :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim nepovoluje použití pøíkazù shellu"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulární výrazy nesmí být oddìleny písmeny"

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -1249,10 +1249,6 @@ msgstr "E143: Automatické pøíkazy neoèekávanì smazaly nový buffer %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselný argument pro :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim nepovoluje pou¾ití pøíkazù shellu"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulární výrazy nesmí být oddìleny písmeny"

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -980,9 +980,6 @@ msgstr "E143: Autokommandoer slettede uventede ny buffer %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: ikke-numerisk argument til :z"
 
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Skalkommandoer er ikke tilladt i rvim"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulære udtryk kan ikke afgrænses af bogstaver"
 

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -3,7 +3,7 @@
 # Do ":help uganda"  in Vim to read copying and usage conditions.
 # Do ":help credits" in Vim to see a list of people who contributed.
 #
-# Previous-Translator(s): 
+# Previous-Translator(s):
 # Johannes Zellner <johannes@zellner.org>
 # Gerfried Fuchs <alfie@ist.org>
 msgid ""
@@ -658,10 +658,6 @@ msgstr "E143: Autokommandos löschten unerwartet neuen Puffer %s"
 #: ../ex_cmds.c:3307
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Nicht-numerisches Argument für :z"
-
-#: ../ex_cmds.c:3398
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Shell-Befehle sind in rvim nicht erlaubt"
 
 #: ../ex_cmds.c:3492
 msgid "E146: Regular expressions can't be delimited by letters"

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -1194,10 +1194,6 @@ msgstr ""
 msgid "E144: non-numeric argument to :z"
 msgstr ""
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr ""
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regular expressions cannot be delimited by letters"

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -969,9 +969,6 @@ msgstr "E143: Aŭtokomandoj neatendite forviŝis novan bufron %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nenumera argumento de :z"
 
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Ŝelkomandoj nepermeseblaj en rvim"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Ne eblas limigi regulesprimon per literoj"
 

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -1234,10 +1234,6 @@ msgstr "E143: Las auto-órdenes han eliminado al nuevo búfer %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Argumento no numérico para \":z\""
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: No se permiten órdenes de consola en rvim"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Las expresiones regulares no se pueden delimitar con letras"

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -1515,10 +1515,6 @@ msgstr "E143: Autocommand poisti uuden puskurin odotuksen vastaisesti %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z:n argumentti ei ole numero"
 
-#, fuzzy
-#~ msgid "E145: Shell commands not allowed in restricted mode"
-#~ msgstr "E145: Kuoren komennot eivät toimi rvimissä"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Säännöllistä ilmausta ei voi rajata kirjaimilla"
 

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -1117,12 +1117,6 @@ msgstr "E143: Une autocommande a effacé le nouveau tampon %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: L'argument de :z n'est pas numérique"
 
-# AB - La version française fera peut-être mieux passer l'amère pilule.
-#      La consultation de l'aide donnera l'explication complète à ceux qui
-#      ne comprendraient pas à quoi ce message est dû.
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Les commandes externes sont indisponibles dans rvim"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr ""
 "E146: Les expressions régulières ne peuvent pas être délimitées par des "

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -967,9 +967,6 @@ msgstr "E143: Scrios na huathorduithe maolán nua %s go tobann"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: argóint neamhuimhriúil chun :z"
 
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Ní cheadaítear orduithe blaoisce i rvim"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr ""
 "E146: Ní cheadaítear litreacha mar theormharcóirí ar shloinn ionadaíochta"

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -1220,10 +1220,6 @@ msgstr ""
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: argomento non-numerico a :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Comandi Shell non permessi in rvim"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Le espressioni regolari non possono essere delimitate da lettere"

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -987,9 +987,6 @@ msgstr "E143: autocommandが予期せず新しいバッファ %s を削除しました"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 数ではない引数が :z に渡されました"
 
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvimではシェルコマンドを使えません"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正規表現は文字で区切ることができません"
 

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -987,9 +987,6 @@ msgstr "E143: autocommandが予期せず新しいバッファ %s を削除しま
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 数ではない引数が :z に渡されました"
 
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvimではシェルコマンドを使えません"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正規表現は文字で区切ることができません"
 

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -1215,10 +1215,6 @@ msgstr "E143: Autocommand가 뜻 밖에 새 버퍼 %s을(를) 지웠습니다"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: 숫자가 아닌 인자가 :z에 주어졌습니다"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim에서는 쉘 명령을 사용할 수 없습니다"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 정규표현식은 글자로 구분될 수 없습니다"

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -1231,10 +1231,6 @@ msgstr "E143: Autokommandoer slettet uventet den nye bufferen %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Ikke-numerisk parameter til :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Skallkommandoer er ikke tillatt i rvim"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulære uttrykk kan ikke bli adskilt av bokstaver"

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -1217,10 +1217,6 @@ msgstr "E143: 'Autocommands' hebben het nieuwe buffer %s onverwacht verwijderd"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: niet-numeriek argument voor :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: in rvim zijn shell-opdrachten zijn niet toegestaan"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: reguliere expressies kunnen niet begrensd worden door letters"

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -1231,10 +1231,6 @@ msgstr "E143: Autokommandoer slettet uventet den nye bufferen %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Ikke-numerisk parameter til :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Skallkommandoer er ikke tillatt i rvim"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulære uttrykk kan ikke bli adskilt av bokstaver"

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -1201,10 +1201,6 @@ msgstr "E143: Autokomendy nieoczekiwanie skasowały nowy bufor %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: nienumeryczny argument dla :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Komendy powłoki są niedozwolone w rvim"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Wzorce regularne nie mogą być rozgraniczane literami"

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -4210,10 +4210,6 @@ msgstr ""
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: argumento não-numérico passado a :z"
 
-#: ../ex_cmds.c:3398
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Comandos do shell não são permitidos no rvim"
-
 #: ../ex_cmds.c:3492
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Expressões regulares não podem ser delimitadas por letras"

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -1205,10 +1205,6 @@ msgstr "E143: Автокоманды неожиданно убили новый 
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Параметр команды :z должен быть числом"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Использование команд оболочки не допускается в rvim."
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регулярные выражения не могут разделяться буквами"

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -1219,10 +1219,6 @@ msgstr "E143: Automatické príkazy neoèakávane zmazali novı buffer %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselnı argument pre :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim nepovo¾uje pouitie príkazov shellu"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulárne vırazy nesmú by oddelené písmenami"

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -1219,10 +1219,6 @@ msgstr "E143: Automatické príkazy neoèakávane zmazali nový buffer %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: neèíselný argument pre :z"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim nepovoµuje pou¾itie príkazov shellu"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Regulárne výrazy nesmú by» oddelené písmenami"

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -424,7 +424,7 @@ msgstr "Опција 'dictionary' је празна"
 msgid "'thesaurus' option is empty"
 msgstr "Опција 'thesaurus' је празна"
 
-#, c-format 
+#, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Скенирање речника: %s"
 
@@ -702,7 +702,7 @@ msgstr "E785: complete() може да се користи само у режи�
 msgid "&Ok"
 msgstr "&Ок"
 
-#, c-format 
+#, c-format
 msgid "+-%s%3ld line: "
 msgid_plural "+-%s%3ld lines: "
 msgstr[0] "+-%s%3ld линија: "
@@ -810,7 +810,7 @@ msgstr "E677: Грешка при упису temp датотеке"
 msgid "E921: Invalid callback argument"
 msgstr "E921: Неисправан callback аргумент"
 
-#, c-format 
+#, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Oct %03o, Digr %s"
 msgstr "<%s>%s%s  %d,  Хекс %02x,  Окт %03o, Дигр %s"
 
@@ -818,11 +818,11 @@ msgstr "<%s>%s%s  %d,  Хекс %02x,  Окт %03o, Дигр %s"
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Хекс %02x,  Октално %03o"
 
-#, c-format 
+#, c-format
 msgid "> %d, Hex %04x, Oct %o, Digr %s"
 msgstr "> %d, Хекс %04x, Окт %o, Дигр %s"
 
-#, c-format 
+#, c-format
 msgid "> %d, Hex %08x, Oct %o, Digr %s"
 msgstr "> %d, Хекс %08x, Окт %o, Дигр %s"
 
@@ -980,9 +980,6 @@ msgstr "E143: Аутокоманде су неочекивано обрисал�
 
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: ненумерички аргумент за :z"
-
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Shell команде нису дозвољене у rvim"
 
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регуларни изрази не могу да се раздвајају словима"

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -2622,10 +2622,6 @@ msgstr "E143: Autokommandon tog oväntat bort ny buffert %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: ickenumeriskt argument till :z"
 
-#: ../ex_cmds.c:3398
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Skalkommandon inte tillåtna i rvim"
-
 #: ../ex_cmds.c:3492
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Reguljära uttryck kan inte vara åtskilda av bokstäver"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -1459,10 +1459,6 @@ msgstr "E143: Автокоманди несподівано знищили но�
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: нечисловий аргумент для :z"
 
-msgid ""
-"E145: Shell commands and some functionality not allowed in restricted mode"
-msgstr "E145: У обмеженому режимі не дозволені команди оболонки і деяка функіональність"
-
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Регулярні вирази не можна розділяти літерами"
 

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -1229,10 +1229,6 @@ msgstr "E143: Các lệnh tự động xóa bộ đệm mới ngoài ý muốn %
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: Tham số của lệnh :z phải là số"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: Không cho phép sử dụng lệnh shell trong rvim."
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Không thể phân cách biểu thức chính quy bằng chữ cái"

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -1222,10 +1222,6 @@ msgstr "E143: 自动命令意外地删除了新缓冲区 %s"
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z 不接受非数字的参数"
 
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim 中禁止使用 shell 命令"
-
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: 正则表达式不能用字母作分界"

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -32,8 +32,8 @@
 #   So please change [行"] to [行 "]
 #
 # Q. How to use UTF8 mode on Win32?
-# A. A simple configuration: 
-#   set encoding=utf-8; let $LANG='zh_TW.UTF-8'; 
+# A. A simple configuration:
+#   set encoding=utf-8; let $LANG='zh_TW.UTF-8';
 #   (set langmenu=none or ..)
 #   set fileencodings=ucs-bom,utf-8,japan,taiwan,prc
 #   set fileencoding=taiwan (or utf-8)
@@ -1261,10 +1261,6 @@ msgstr "E143: Autocommands 意外地刪除新緩衝區 %s"
 #: ../ex_cmds.c:3313
 msgid "E144: non-numeric argument to :z"
 msgstr "E144: :z 不接受非數字的參數"
-
-#: ../ex_cmds.c:3404
-msgid "E145: Shell commands not allowed in rvim"
-msgstr "E145: rvim 中禁止使用 shell 命令"
 
 #: ../ex_cmds.c:3498
 msgid "E146: Regular expressions can't be delimited by letters"


### PR DESCRIPTION
On this PR:
- Remove and refactor runtime scripts which handle E145 (restricted mode error).
- Remove the E145 error message from the Gettext files.

Closes #13339