### PR TITLE
man.vim: Use page title instead of full path.

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -434,8 +434,11 @@ function! man#goto_tag(pattern, flags, info) abort
   let l:structured = []
 
   for l:path in l:paths
-    let l:n = s:extract_sect_and_name_path(l:path)[1]
-    let l:structured += [{ 'name': l:n, 'path': l:path }]
+    let [l:sect, l:name] = s:extract_sect_and_name_path(l:path)
+    let l:structured += [{
+          \ 'name': l:name,
+          \ 'title': l:name . '(' . l:sect . ')'
+          \ }]
   endfor
 
   if &cscopetag
@@ -446,7 +449,7 @@ function! man#goto_tag(pattern, flags, info) abort
   return map(l:structured, {
   \  _, entry -> {
   \      'name': entry.name,
-  \      'filename': 'man://' . entry.path,
+  \      'filename': 'man://' . entry.title,
   \      'cmd': '1'
   \    }
   \  })


### PR DESCRIPTION
In commit 63f0ca326322376271, `tagfunc` was introduced to
`runtime/autoload/man.vim`. Nonetheless the tag function instead
of using a short buffer name (e.g. `man://foo(3)`) uses the full
path to the man page (e.g. `man:///usr/share/.../foo.3.gz`). This
behaviour is inconsistent with `:Man!`, thus this commit.

Closes #13334