### PR TITLE
do_one_cmd: Remove :pyxdo/:pyxfile from "handle <bar>" switch

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -4232,25 +4232,29 @@ static void script_host_execute(char *name, exarg_T *eap)
 
 static void script_host_execute_file(char *name, exarg_T *eap)
 {
-  uint8_t buffer[MAXPATHL];
-  vim_FullName((char *)eap->arg, (char *)buffer, sizeof(buffer), false);
+  if (!eap->skip) {
+    uint8_t buffer[MAXPATHL];
+    vim_FullName((char *)eap->arg, (char *)buffer, sizeof(buffer), false);
 
-  list_T *args = tv_list_alloc(3);
-  // filename
-  tv_list_append_string(args, (const char *)buffer, -1);
-  // current range
-  tv_list_append_number(args, (int)eap->line1);
-  tv_list_append_number(args, (int)eap->line2);
-  (void)eval_call_provider(name, "execute_file", args, true);
+    list_T *args = tv_list_alloc(3);
+    // filename
+    tv_list_append_string(args, (const char *)buffer, -1);
+    // current range
+    tv_list_append_number(args, (int)eap->line1);
+    tv_list_append_number(args, (int)eap->line2);
+    (void)eval_call_provider(name, "execute_file", args, true);
+  }
 }
 
 static void script_host_do_range(char *name, exarg_T *eap)
 {
-  list_T *args = tv_list_alloc(3);
-  tv_list_append_number(args, (int)eap->line1);
-  tv_list_append_number(args, (int)eap->line2);
-  tv_list_append_string(args, (const char *)eap->arg, -1);
-  (void)eval_call_provider(name, "do_range", args, true);
+  if (!eap->skip) {
+    list_T *args = tv_list_alloc(3);
+    tv_list_append_number(args, (int)eap->line1);
+    tv_list_append_number(args, (int)eap->line2);
+    tv_list_append_string(args, (const char *)eap->arg, -1);
+    (void)eval_call_provider(name, "do_range", args, true);
+  }
 }
 
 /// ":drop"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1873,8 +1873,6 @@ static char_u * do_one_cmd(char_u **cmdlinep,
     case CMD_python3:
     case CMD_pythonx:
     case CMD_pyx:
-    case CMD_pyxdo:
-    case CMD_pyxfile:
     case CMD_return:
     case CMD_rightbelow:
     case CMD_ruby:


### PR DESCRIPTION
In 8f288698e4730f6cc91240fe899e93921aff9d71, these commands were incorrectly added to the switch that determines whether a command needs to parse for "|" on their own when ea.skip is set.

This means that "if 0 | pyxfile foo.py | endif" would execute foo.py when it should do nothing.  Removing them from the switch skips to the end of `do_one_cmd()`, avoiding running any script.

As a safety measure, return immediately from script_host_{execute_file,do_range} if `eap->skip` is set.  This is set when VimL is being parsed, to skip past dead code, and should not be executed.