### PR TITLE
GHA: Switch to ubuntu-20.04 image for Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   linux:
     name: ${{ matrix.flavor }} (cc=${{ matrix.cc }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -26,12 +26,12 @@ jobs:
         if: matrix.flavor == 'asan' || matrix.flavor == 'tsan'
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
+          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
 
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential ccache cmake cpanminus cscope gcc-multilib gdb gettext gperf language-pack-tr libtool-bin locales ninja-build pkg-config python python-pip python-setuptools python3 python3-pip python3-setuptools unzip valgrind xclip
+          sudo apt-get install -y autoconf automake build-essential ccache cmake cpanminus cscope gcc-multilib gdb gettext gperf language-pack-tr libtool-bin locales ninja-build pkg-config python3 python3-pip python3-setuptools unzip valgrind xclip
 
       - name: Install new clang
         if: matrix.flavor == 'asan' || matrix.flavor == 'tsan'

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -15,8 +15,10 @@ fi
 # Use default CC to avoid compilation problems when installing Python modules.
 echo "Install neovim module for Python 3."
 CC=cc python3 -m pip -q install --user --upgrade pynvim
-echo "Install neovim module for Python 2."
-CC=cc python2 -m pip -q install --user --upgrade pynvim
+if python2 -m pip -c True 2>&1; then
+  echo "Install neovim module for Python 2."
+  CC=cc python2 -m pip -q install --user --upgrade pynvim
+fi
 
 echo "Install neovim RubyGem."
 gem install --no-document --bindir "$HOME/.local/bin" --user-install --pre neovim


### PR DESCRIPTION
Stop explicitly installing Ubuntu's python package, since most of the Python 2 packages (and importantly pip/setuptools) have been removed in this Ubuntu version.