### PR TITLE
lsp: fix textDocumetn/didSave

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -857,6 +857,7 @@ function lsp._text_document_did_save_handler(bufnr)
       end
       client.notify('textDocument/didSave', {
         textDocument = {
+          version = 0;
           uri = uri;
           text = included_text;
         }


### PR DESCRIPTION
This fixes crash in rust-analyzer due to missing version field