### PR TITLE
lsp: Fix text payload in didSave notification

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -858,8 +858,8 @@ function lsp._text_document_did_save_handler(bufnr)
       client.notify('textDocument/didSave', {
         textDocument = {
           uri = uri;
-          text = included_text;
-        }
+        };
+        text = included_text;
       })
     end
   end)


### PR DESCRIPTION
Spotted this while looking at https://github.com/neovim/neovim/pull/13362

According to the specification[1] the payload must look like this:

    interface DidSaveTextDocumentParams {
    	/**
    	 * The document that was saved.
    	 */
    	textDocument: TextDocumentIdentifier;

    	/**
    	 * Optional the content when saved. Depends on the includeText value
    	 * when the save notification was requested.
    	 */
    	text?: string;
    }

`text` must be on the same level as `textDocument`.

Where `TextDocumentIdentifier` is:

    interface TextDocumentIdentifier {
	/**
	 * The text document's URI.
	 */
	uri: DocumentUri;
    }

[1]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave