### PR TITLE
Allow specifying a languageId for a lsp

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -751,6 +751,9 @@ start_client({config})                                *vim.lsp.start_client()*
                                        See `initialize` in the LSP spec.
                     {name}             (string, default=client-id) Name in log
                                        messages.
+                    {language_id}      Function (bufnr, filetype) should return
+                                       the language ID as string. Defaults to
+                                       the filetype.
                     {offset_encoding}  (default="utf-16") One of "utf-8",
                                        "utf-16", or "utf-32" which is the
                                        encoding that the LSP server expects.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -273,12 +273,13 @@ local function text_document_did_open_handler(bufnr, client)
   if not vim.api.nvim_buf_is_loaded(bufnr) then
     return
   end
+  local filetype = nvim_buf_get_option(bufnr, 'filetype')
+  local languageId = client.config.language_id and client.config.language_id(bufnr, filetype) or filetype
   local params = {
     textDocument = {
       version = 0;
       uri = vim.uri_from_bufnr(bufnr);
-      -- TODO make sure our filetypes are compatible with languageId names.
-      languageId = nvim_buf_get_option(bufnr, 'filetype');
+      languageId = languageId;
       text = buf_get_full_text(bufnr);
     }
   }


### PR DESCRIPTION
For some languages the filetype might not match the languageId the
language server accepts. In these cases the config for the language
server can contain a function which gets the current buffer and filetype
and returns a languageId. When it isn't provided the filetype is used
instead.

Simple example which just overwrites the languageId:
```lua
require'lspconfig'.sourcekit.setup{
    language_id = function(bufnr, ft)
        return 'swift'
    end;
}
```

Closes #13093

@tjdevries Please have a look.