### PR TITLE
Fix undeclared identifier when HAVE_READLINK is not defined

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7044,7 +7044,8 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     xfree(buf);
   }
 # else
-  rettv->vval.v_string = (char_u *)xstrdup(fname);
+  char *v = os_realpath(fname, NULL);
+  rettv->vval.v_string = (char_u *)(v == NULL ? xstrdup(fname) : v);
 # endif
 #endif
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7044,7 +7044,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     xfree(buf);
   }
 # else
-  rettv->vval.v_string = (char_u *)xstrdup(p);
+  rettv->vval.v_string = (char_u *)xstrdup(fname);
 # endif
 #endif
 


### PR DESCRIPTION
I was able to build neovim from master on Android/Termux (with the help of some patches found on reddit) with this fix.
I'm not even sure how it came up since I have `readlink` installed but still got the undeclared identifier error.