### PR TITLE
lsp:use if_nil variable replace vim.F.if_nil

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -988,8 +988,8 @@ function protocol.resolve_capabilities(server_capabilities)
   elseif type(workspace.workspaceFolders) == 'table' then
     workspace_properties = {
       workspace_folder_properties = {
-        supported = vim.F.if_nil(workspace.workspaceFolders.supported, false);
-        changeNotifications = vim.F.if_nil(workspace.workspaceFolders.changeNotifications, false);
+        supported = if_nil(workspace.workspaceFolders.supported, false);
+        changeNotifications = if_nil(workspace.workspaceFolders.changeNotifications, false);
 
       }
     }


### PR DESCRIPTION
@tjdevries  had define `if_nil` variable , so we can use it not call `vim.F`.

https://github.com/neovim/neovim/blob/4537ff659efbc65f4c94b88cce8fb3c39d03aae5/runtime/lua/vim/lsp/protocol.lua#L3