### PR TITLE
[RDY] doc: Fix incorrect LSP diagnostic-related helptags

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -247,7 +247,7 @@ For |lsp-notification|, each |lsp-handler| has this signature: >
                             of a particular handler.
 
                             For an example, see:
-                                |vim.lsp.diagnostics.on_publish_diagnostics()|
+                                |vim.lsp.diagnostic.on_publish_diagnostics()|
 
                             To configure a particular |lsp-handler|, see:
                                 |lsp-handler-configuration|
@@ -1104,7 +1104,7 @@ get_next({opts})                               *vim.lsp.diagnostic.get_next()*
                 Get the previous diagnostic closest to the cursor_position
 
                 Parameters: ~
-                    {opts}  table See |vim.lsp.diagnostics.goto_next()|
+                    {opts}  table See |vim.lsp.diagnostic.goto_next()|
 
                 Return: ~
                     table Next diagnostic
@@ -1114,7 +1114,7 @@ get_next_pos({opts})                       *vim.lsp.diagnostic.get_next_pos()*
                 current buffer.
 
                 Parameters: ~
-                    {opts}  table See |vim.lsp.diagnostics.goto_next()|
+                    {opts}  table See |vim.lsp.diagnostic.goto_next()|
 
                 Return: ~
                     table Next diagnostic position
@@ -1123,7 +1123,7 @@ get_prev({opts})                               *vim.lsp.diagnostic.get_prev()*
                 Get the previous diagnostic closest to the cursor_position
 
                 Parameters: ~
-                    {opts}  table See |vim.lsp.diagnostics.goto_next()|
+                    {opts}  table See |vim.lsp.diagnostic.goto_next()|
 
                 Return: ~
                     table Previous diagnostic
@@ -1133,7 +1133,7 @@ get_prev_pos({opts})                       *vim.lsp.diagnostic.get_prev_pos()*
                 current buffer.
 
                 Parameters: ~
-                    {opts}  table See |vim.lsp.diagnostics.goto_next()|
+                    {opts}  table See |vim.lsp.diagnostic.goto_next()|
 
                 Return: ~
                     table Previous diagnostic position
@@ -1196,7 +1196,7 @@ goto_prev({opts})                             *vim.lsp.diagnostic.goto_prev()*
                 Move to the previous diagnostic
 
                 Parameters: ~
-                    {opts}  table See |vim.lsp.diagnostics.goto_next()|
+                    {opts}  table See |vim.lsp.diagnostic.goto_next()|
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
 on_publish_diagnostics({_}, {_}, {params}, {client_id}, {_}, {config})

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -509,7 +509,7 @@ end
 
 --- Get the previous diagnostic closest to the cursor_position
 ---
----@param opts table See |vim.lsp.diagnostics.goto_next()|
+---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic
 function M.get_prev(opts)
   opts = opts or {}
@@ -522,7 +522,7 @@ function M.get_prev(opts)
 end
 
 --- Return the pos, {row, col}, for the prev diagnostic in the current buffer.
----@param opts table See |vim.lsp.diagnostics.goto_next()|
+---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic position
 function M.get_prev_pos(opts)
   return _iter_diagnostic_lines_pos(
@@ -532,7 +532,7 @@ function M.get_prev_pos(opts)
 end
 
 --- Move to the previous diagnostic
----@param opts table See |vim.lsp.diagnostics.goto_next()|
+---@param opts table See |vim.lsp.diagnostic.goto_next()|
 function M.goto_prev(opts)
   return _iter_diagnostic_move_pos(
     "DiagnosticPrevious",
@@ -542,7 +542,7 @@ function M.goto_prev(opts)
 end
 
 --- Get the previous diagnostic closest to the cursor_position
----@param opts table See |vim.lsp.diagnostics.goto_next()|
+---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic
 function M.get_next(opts)
   opts = opts or {}
@@ -555,7 +555,7 @@ function M.get_next(opts)
 end
 
 --- Return the pos, {row, col}, for the next diagnostic in the current buffer.
----@param opts table See |vim.lsp.diagnostics.goto_next()|
+---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic position
 function M.get_next_pos(opts)
   return _iter_diagnostic_lines_pos(

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1021,7 +1021,7 @@ do
 
   --@deprecated
   function M.buf_diagnostics_signs(bufnr, diagnostics, client_id)
-    warn_once("buf_diagnostics_signs is deprecated. Use 'vim.lsp.diagnostics.set_signs'")
+    warn_once("buf_diagnostics_signs is deprecated. Use 'vim.lsp.diagnostic.set_signs'")
     return vim.lsp.diagnostic.set_signs(diagnostics, bufnr, client_id)
   end
 


### PR DESCRIPTION
I noticed a few helptags in the LSP documentation weren't working due to using `vim.lsp.diagnostics` instead of `vim.lsp.diagnostic`. After this, `rg` shows no more occurances of `vim.lsp.diagnostics`in the codebase.