### PR TITLE
Folded hl group not applied on folded lines with syntax matches

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2550,7 +2550,9 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
    */
   cur = wp->w_match_head;
   shl_flag = false;
-  while ((cur != NULL || !shl_flag) && !number_only) {
+  while ((cur != NULL || !shl_flag) && !number_only
+         && foldinfo.fi_lines == 0
+         ) {
     if (!shl_flag) {
       shl = &search_hl;
       shl_flag = true;

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -9,6 +9,15 @@ local meths = helpers.meths
 local source = helpers.source
 local assert_alive = helpers.assert_alive
 
+
+local content1 = [[
+        This is a
+        valid English
+        sentence composed by
+        an exhausted developer
+        in his cave.
+        ]]
+
 describe("folded lines", function()
   before_each(function()
     clear()
@@ -119,18 +128,31 @@ describe("folded lines", function()
 
     it("work with spell", function()
       command("set spell")
-      insert([[
-        This is a
-        valid English
-        sentence composed by
-        an exhausted developer
-        in his cave.
-        ]])
+      insert(content1)
 
       feed("gg")
       feed("zf3j")
       if not multigrid then
-        -- screen:snapshot_util()
+        screen:expect{grid=[[
+          {5:^+--  4 lines: This is a······················}|
+          in his cave.                                 |
+                                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+                                                       |
+        ]]}
+      end
+    end)
+
+    it("work with matches", function()
+      insert(content1)
+      command("highlight MyWord gui=bold guibg=red   guifg=white")
+      command("call matchadd('MyWord', '\\V' . 'test', -1)")
+      feed("gg")
+      feed("zf3j")
+      if not multigrid then
         screen:expect{grid=[[
           {5:^+--  4 lines: This is a······················}|
           in his cave.                                 |


### PR DESCRIPTION
address the match part of https://github.com/neovim/neovim/issues/12982