### PR TITLE
docs: edit man.vim's help entry.

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -510,63 +510,83 @@ Local mappings:
 	to the end of the file in Normal mode.  This means "> " is inserted in
 	each line.
 
+
 MAN					*ft-man-plugin* *:Man* *man.vim*
 
-View manpages in Nvim. Supports highlighting, completion, locales, and
-navigation. Also see |find-manpage|.
-
-man.vim will always attempt to reuse the closest man window (above/left) but
-otherwise create a split.
-
-The case sensitivity of completion is controlled by 'fileignorecase'.
+View man pages in Nvim.  Supports highlighting, completion, locales, and
+navigation.  Also see |find-manpage|.
 
 Commands:
-Man {name}                Display the manpage for {name}.
-Man {sect} {name}         Display the manpage for {name} and section {sect}.
-Man {name}({sect})        Same as above.
-Man {sect} {name}({sect}) Used during completion to show the real section of
-                          when the provided section is a prefix, e.g. 1m vs 1.
-Man {path}                Open the manpage at {path}. Prepend "./" if {path}
-                          is relative to the current directory.
-Man                       Open the manpage for the <cWORD> (man buffers)
-                          or <cword> (non-man buffers) under the cursor.
-Man!                      Display the current buffer contents as a manpage.
+:Man			Open the man page for the <cWORD> (man buffers) or
+			<cword> (non-man buffers) under the cursor.
 
-|:Man| accepts command modifiers. For example, to use a vertical split: >
-     :vertical Man printf
+:Man {name}		Display the man page for {name}.
+
+:Man {sect} {name}	Display the man page for {name} and section {sect}.
+
+:Man {name}({sect})	Same as above.
+
+:Man {path}		Open the man page at {path}.  Prepend "./" or "../"
+			for relative paths.
+
+:Man!			Display the current buffer contents as a man page.
+			Equivalent to ":set filetype=man".
+
+The second and third forms above provide completion for the {name} argument.
+The 'fileignorecase' option allows you to control the case sensitivity of the
+completion. The fifth form provides completion for absolute paths and for
+relative paths (starting with "./" or "../").
+
+If a man buffer already exists, `:Man` will reuse it, otherwise `:Man` will
+create a new horizontal split.  Command modifiers may be used.  For example,
+to open in a vertical split: >
+	:vertical Man printf
+
+`:Man` also generates tags for man pages with prefixes matching {name} within
+a section.  You can use tag commands like |:tselect| to easily access these
+other man pages. See |tagsrch.txt|.
 
 Local mappings:
-K or CTRL-]               Jump to the manpage for the <cWORD> under the
-                          cursor. Takes a count for the section.
-CTRL-T                    Jump back to the location that the manpage was
-                          opened from.
-gO                        Show the manpage outline. |gO|
-q                         :quit if invoked as $MANPAGER, otherwise :close.
+K  or CTRL-]	Jump to the man page for the <cWORD> under the
+		cursor.  Takes a count for the section.
+
+CTRL-T		Jump back to the location that the man page was
+		opened from.  |CTRL-T|
+
+gO		Show the man page outline.  |gO|
+
+q		":quit" if invoked as $MANPAGER, otherwise ":close".
 
 Variables:
-*g:no_man_maps*             Do not create mappings in manpage buffers.
-*g:ft_man_folding_enable*   Fold manpages with foldmethod=indent foldnestmax=1.
-*b:man_default_sects*       Comma-separated, ordered list of preferred sections.
-                          For example in C one usually wants section 3 or 2: >
-                               :let b:man_default_sections = '3,2'
-*g:man_hardwrap*            Hard-wrap to $MANWIDTH or window width if $MANWIDTH is
-                          empty. Enabled by default. Set |FALSE| to enable soft
-                          wrapping.
+b:man_default_sects	Comma-separated, ordered list of preferred sections.
+			For example in C one usually wants section 3 or 2: >
+				:let b:man_default_sections = '3,2'
 
-To use Nvim as a manpager: >
-     export MANPAGER='nvim +Man!'
+g:ft_man_folding_enable
+			Fold man pages with foldmethod=indent foldnestmax=1.
 
-Note that when running `man` from the shell and with that `MANPAGER` in your
-environment, `man` will pre-format the manpage using `groff`. Thus, Neovim
-will inevitably display the manual page as it was passed to it from stdin. One
-of the caveats of this is that the width will _always_ be hard-wrapped and not
-soft wrapped as with `g:man_hardwrap=0`. You can set in your environment: >
-     export MANWIDTH=999
+g:man_hardwrap		Hard-wrap to $MANWIDTH or window width if $MANWIDTH is
+			empty.  Enabled by default.  Set to a false value to
+			enable soft wrapping: >
+				:let g:man_hardwrap = 0
+				
+g:no_man_maps		Define this variable (any value will do) in order to
+			disable local mappings for man buffers.
 
-So `groff`'s pre-formatting output will be the same as with `g:man_hardwrap=0` i.e soft-wrapped.
+							*nvim-manpager*
+To use Nvim as a man pager put this in your environment: >
+	export MANPAGER='nvim +Man!'
 
-To disable bold highlighting: >
-     :highlight link manBold Normal
+Note that man will pre-format the text using groff.  Therefore the MANPAGER
+(Nvim here) will inevitably display the manual page as it was passed to it
+from stdin: hard-wrapped to the number of columns specified by MANWIDTH or to
+the width of the terminal if MANWIDTH is empty.  If you prefer soft-wrapping,
+you can try setting MANWIDTH to a very large number, e.g.: >
+	export MANWIDTH=999
+so that groff's pre-formatted output looks the same as when using `:Man` and
+define the "g:man_hardwrap" variable.  Take into account that the top heading
+of the man page will then expand several lines.
+
 
 PDF							*ft-pdf-plugin*
 


### PR DESCRIPTION
Here I
- Moved the paragraphs so that the related information is closer together (easier to grok).
- Added vertical spacing between descriptions to make it easier to read (and also for consistency with other help pages).
- Changed the indentation from spaces to tabs for consistency with the rest of the file and other help files.

Closes #13360