### PR TITLE
[RDY] runtime: Updated Dockerfile syntax with latest from Vim upstream

### DIFF
--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -1,6 +1,6 @@
 " dockerfile.vim - Syntax highlighting for Dockerfiles
 " Maintainer:   Honza Pokorny <https://honza.ca>
-" Last Change:  2020 Jan 27
+" Last Change:  2020 Feb 11
 " License:      BSD
 
 " https://docs.docker.com/engine/reference/builder/
@@ -22,12 +22,12 @@ syntax region dockerfileFrom matchgroup=dockerfileKeyword start=/\v^\s*(FROM)\ze
 syntax keyword dockerfileKeyword contained ADD ARG CMD COPY ENTRYPOINT ENV EXPOSE HEALTHCHECK LABEL MAINTAINER ONBUILD RUN SHELL STOPSIGNAL USER VOLUME WORKDIR
 syntax match dockerfileOption contained /\v(^|\s)\zs--\S+/
 
-syntax match dockerfileInstruction contained /\v(\S+)(\s+--\S+)*/             contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileValue
-syntax match dockerfileInstruction contained /\v(ADD|COPY)(\s+--\S+)*/        contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileJSON
-syntax match dockerfileInstruction contained /\v(HEALTHCHECK)(\s+--\S+)*/     contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileInstruction
-syntax match dockerfileInstruction contained /\v(CMD|ENTRYPOINT|RUN)/         contains=dockerfileKeyword skipwhite nextgroup=dockerfileShell
-syntax match dockerfileInstruction contained /\v(CMD|ENTRYPOINT|RUN)\ze\s+\[/ contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
-syntax match dockerfileInstruction contained /\v(SHELL|VOLUME)/               contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v<(\S+)>(\s+--\S+)*/             contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileValue
+syntax match dockerfileInstruction contained /\v<(ADD|COPY)>(\s+--\S+)*/        contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v<(HEALTHCHECK)>(\s+--\S+)*/     contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileInstruction
+syntax match dockerfileInstruction contained /\v<(CMD|ENTRYPOINT|RUN)>/         contains=dockerfileKeyword skipwhite nextgroup=dockerfileShell
+syntax match dockerfileInstruction contained /\v<(CMD|ENTRYPOINT|RUN)>\ze\s+\[/ contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v<(SHELL|VOLUME)>/               contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
 
 syntax region dockerfileString contained start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region dockerfileJSON   contained keepend start=/\v\[/ skip=/\v\\\_./ end=/\v$/ contains=@JSON

--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -1,26 +1,45 @@
 " dockerfile.vim - Syntax highlighting for Dockerfiles
 " Maintainer:   Honza Pokorny <https://honza.ca>
-" Version:      0.6
-" Last Change:  2019 Aug 16
+" Last Change:  2020 Jan 27
 " License:      BSD
 
+" https://docs.docker.com/engine/reference/builder/
 
 if exists("b:current_syntax")
     finish
 endif
 
-let b:current_syntax = "dockerfile"
+syntax include @JSON syntax/json.vim
+unlet b:current_syntax
+
+syntax include @Shell syntax/sh.vim
+unlet b:current_syntax
 
 syntax case ignore
+syntax match dockerfileLinePrefix /\v^\s*(ONBUILD\s+)?\ze\S/ contains=dockerfileKeyword nextgroup=dockerfileInstruction skipwhite
+syntax region dockerfileFrom matchgroup=dockerfileKeyword start=/\v^\s*(FROM)\ze(\s|$)/ skip=/\v\\\_./ end=/\v((^|\s)AS(\s|$)|$)/ contains=dockerfileOption
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s/
+syntax keyword dockerfileKeyword contained ADD ARG CMD COPY ENTRYPOINT ENV EXPOSE HEALTHCHECK LABEL MAINTAINER ONBUILD RUN SHELL STOPSIGNAL USER VOLUME WORKDIR
+syntax match dockerfileOption contained /\v(^|\s)\zs--\S+/
 
-syntax match dockerfileKeyword /\v(AS)/
+syntax match dockerfileInstruction contained /\v(\S+)(\s+--\S+)*/             contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileValue
+syntax match dockerfileInstruction contained /\v(ADD|COPY)(\s+--\S+)*/        contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v(HEALTHCHECK)(\s+--\S+)*/     contains=dockerfileKeyword,dockerfileOption skipwhite nextgroup=dockerfileInstruction
+syntax match dockerfileInstruction contained /\v(CMD|ENTRYPOINT|RUN)/         contains=dockerfileKeyword skipwhite nextgroup=dockerfileShell
+syntax match dockerfileInstruction contained /\v(CMD|ENTRYPOINT|RUN)\ze\s+\[/ contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
+syntax match dockerfileInstruction contained /\v(SHELL|VOLUME)/               contains=dockerfileKeyword skipwhite nextgroup=dockerfileJSON
 
-syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
+syntax region dockerfileString contained start=/\v"/ skip=/\v\\./ end=/\v"/
+syntax region dockerfileJSON   contained keepend start=/\v\[/ skip=/\v\\\_./ end=/\v$/ contains=@JSON
+syntax region dockerfileShell  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=@Shell
+syntax region dockerfileValue  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=dockerfileString
 
-syntax match dockerfileComment "\v^\s*#.*$"
+syntax region dockerfileComment start=/\v^\s*#/ end=/\v$/
+set commentstring=#\ %s
 
 hi def link dockerfileString String
 hi def link dockerfileKeyword Keyword
 hi def link dockerfileComment Comment
+hi def link dockerfileOption Special
+
+let b:current_syntax = "dockerfile"


### PR DESCRIPTION
Fixes issues with Dockerfile syntax highlighting by taking the latest upstream Vim syntax file

Before:
![image](https://user-images.githubusercontent.com/11874892/100513812-3af27b00-3170-11eb-9198-1fe5569caa35.png)

After:
![image](https://user-images.githubusercontent.com/11874892/100513847-683f2900-3170-11eb-9558-274626be4e3d.png)