### PR TITLE
vim-patch:8.2.0095: cannot specify exit code for :cquit

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -187,12 +187,17 @@ processing a quickfix or location list command, it will be aborted.
 			current window is used instead of the quickfix list.
 
 							*:cq* *:cquit*
-:[count]cq[uit]		Quit Nvim with an error code, or the code specified in
-			[count].  Useful when Nvim is called from another
-			program: e.g. `git commit` will abort the comitting
-			process, `fc` (built-in for shells like bash and zsh)
-			will not execute the command.
-
+:cq[uit][!]
+:{N}cq[uit][!]
+:cq[uit][!] {N}		Quit Vim with error code {N}.  {N} defaults to one.
+			Useful when Vim is called from another program:
+			e.g., a compiler will not compile the same file again,
+			`git commit` will abort the committing process, `fc`
+			(built-in for shells like bash and zsh) will not
+			execute the command, etc.  will not compile the same
+			file again.
+			{N} can also be zero, in which case Vim exits
+			normally.
 			WARNING: All changes in files are lost.  It works like
 			":qall!" |:qall|, except that Nvim exits non-zero or
 			[count].

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6317,17 +6317,14 @@ static void ex_quit(exarg_T *eap)
   }
 }
 
-/*
- * ":cquit".
- */
+/// ":cquit".
 static void ex_cquit(exarg_T *eap)
 {
+  // this does not always pass on the exit code to the Manx compiler. why?
   getout(eap->addr_count > 0 ? (int)eap->line2 : EXIT_FAILURE);
 }
 
-/*
- * ":qall": try to quit all windows
- */
+/// ":qall": try to quit all windows
 static void ex_quit_all(exarg_T *eap)
 {
   if (cmdwin_type != 0) {

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3,6 +3,8 @@
 source check.vim
 CheckFeature quickfix
 
+source screendump.vim
+
 set encoding=utf-8
 
 func s:setup_commands(cchar)
@@ -4408,6 +4410,31 @@ func Test_search_in_dirstack()
   set efm&
   exe 'cd ' . save_cwd
   call delete('Xtestdir', 'rf')
+endfunc
+
+" Test for :cquit
+func Test_cquit()
+  " Exit Vim with a non-zero value
+  if RunVim([], ["cquit 7"], '')
+    call assert_equal(7, v:shell_error)
+  endif
+
+  if RunVim([], ["50cquit"], '')
+    call assert_equal(50, v:shell_error)
+  endif
+
+  " Exit Vim with default value
+  if RunVim([], ["cquit"], '')
+    call assert_equal(1, v:shell_error)
+  endif
+
+  " Exit Vim with zero value
+  if RunVim([], ["cquit 0"], '')
+    call assert_equal(0, v:shell_error)
+  endif
+
+  " Exit Vim with negative value
+  call assert_fails('-3cquit', 'E16:')
 endfunc
 
 " Test for adding an invalid entry with the quickfix window open and making


### PR DESCRIPTION
Cherry-picked from #13079 