### PR TITLE
vim-patch:8.0.1119: quitting a split terminal window kills the job

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -417,20 +417,18 @@ void close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last)
   win_T *the_curwin = curwin;
   tabpage_T *the_curtab = curtab;
 
-  // Force unloading or deleting when 'bufhidden' says so, but not for terminal
-  // buffers.
+  // Force unloading or deleting when 'bufhidden' says so.
   // The caller must take care of NOT deleting/freeing when 'bufhidden' is
   // "hide" (otherwise we could never free or delete a buffer).
-  if (!buf->terminal) {
-    if (buf->b_p_bh[0] == 'd') {         // 'bufhidden' == "delete"
-      del_buf = true;
-      unload_buf = true;
-    } else if (buf->b_p_bh[0] == 'w') {  // 'bufhidden' == "wipe"
-      del_buf = true;
-      unload_buf = true;
-      wipe_buf = true;
-    } else if (buf->b_p_bh[0] == 'u')    // 'bufhidden' == "unload"
-      unload_buf = true;
+  if (buf->b_p_bh[0] == 'd') {         // 'bufhidden' == "delete"
+    del_buf = true;
+    unload_buf = true;
+  } else if (buf->b_p_bh[0] == 'w') {  // 'bufhidden' == "wipe"
+    del_buf = true;
+    unload_buf = true;
+    wipe_buf = true;
+  } else if (buf->b_p_bh[0] == 'u') {  // 'bufhidden' == "unload"
+    unload_buf = true;
   }
 
   if (buf->terminal && (unload_buf || del_buf || wipe_buf)) {


### PR DESCRIPTION
Problem:    Quitting a split terminal window kills the job. (Yasuhiro
            Matsumoto)
Solution:   Only stop terminal job if it is the last window.
https://github.com/vim/vim/commit/8adb0d03ca2694922da915356d7ede05e31c5a5c

Supersedes #10396. Is that an acceptable way to port this patch, given that neovim treats terminal buffers differently? That change is a no-op, just brings non-terminal-specific code closer to vim's.

@janlazo for thoughts.