### PR TITLE
add support for completionItem/resolve

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1140,17 +1140,12 @@ end
 --- Get the details of the completion item
 function lsp._resolve_completion_detail()
   local bufnr = resolve_bufnr()
-  local completed_item_var = vim.api.nvim_get_vvar('completed_item')
+  local completed_item_var = vim.v.completed_item
   local item = completed_item_var.user_data.lsp.completion_item
-  local lnum = item.data.line
   lsp.buf_request(bufnr, 'completionItem/resolve', item, function(err, _, result)
     if err or not result then return end
     if result.additionalTextEdits then
-      local edits = vim.tbl_filter(
-        function(x) return x.range.start.line ~= (lnum - 1) end,
-        result.additionalTextEdits
-      )
-      util.apply_text_edits(edits, bufnr)
+      util.apply_text_edits(result.additionalTextEdits, bufnr)
     end
   end)
 end

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -940,6 +940,7 @@ function lsp.buf_attach_client(bufnr, client_id)
   if client then
     client._on_attach(bufnr)
   end
+
   return true
 end
 
@@ -1284,6 +1285,9 @@ end
 
 -- Define the LspDiagnostics signs if they're not defined already.
 require('vim.lsp.diagnostic')._define_default_signs_and_highlights()
+
+-- On CompleteDone, let's try to resolve the completion entry detail
+vim.api.nvim_command("autocmd CompleteDone <buffer> lua require'vim.lsp.util'.get_completion_item_resolve()")
 
 return lsp
 -- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1138,10 +1138,13 @@ function lsp.on_complete_done()
   local bufnr = resolve_bufnr()
   local completed_item_var = vim.v.completed_item
   if
-    completed_item_var and completed_item_var.user_data and completed_item_var.user_data.lsp and
-      completed_item_var.user_data.lsp.completion_item
+    completed_item_var and
+    completed_item_var.user_data and
+    completed_item_var.user_data.nvim and
+    completed_item_var.user_data.nvim.lsp and
+    completed_item_var.user_data.nvim.lsp.completion_item
    then
-    local item = completed_item_var.user_data.lsp.completion_item
+    local item = completed_item_var.user_data.nvim.lsp.completion_item
     lsp.buf_request(bufnr, "completionItem/resolve", item, function(err, _, result)
       if err or not result then
         return

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1133,9 +1133,8 @@ function lsp.buf_notify(bufnr, method, params)
 end
 
 
---@private
 --- Get the details of the completion item
-function lsp._resolve_completion_detail()
+function lsp.on_complete_done()
   local bufnr = resolve_bufnr()
   local completed_item_var = vim.v.completed_item
   if

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -443,9 +443,11 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       dup = 1,
       empty = 1,
       user_data = {
+        nvim = {
           lsp = {
             completion_item = completion_item
           }
+        }
       },
     })
   end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -397,6 +397,13 @@ function M._get_completion_item_kind_name(completion_item_kind)
   return protocol.CompletionItemKind[completion_item_kind] or "Unknown"
 end
 
+--@private
+--- Get the details of the completion item
+local function get_completion_item_resolve(completion_item)
+  local bufnr = api.nvim_get_current_buf()
+  return vim.lsp.buf_request_sync(bufnr, 'completionItem/resolve', completion_item)
+end
+
 --- Turns the result of a `textDocument/completion` request into vim-compatible
 --- |complete-items|.
 ---
@@ -431,6 +438,7 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
     end
 
     local word = get_completion_word(completion_item)
+    local lsp_completion_item = get_completion_item_resolve(completion_item) or completion_item
     table.insert(matches, {
       word = word,
       abbr = completion_item.label,
@@ -443,7 +451,7 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       user_data = {
         nvim = {
           lsp = {
-            completion_item = completion_item
+            completion_item = lsp_completion_item
           }
         }
       },

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -400,13 +400,10 @@ end
 --@private
 --- Get the details of the completion item
 function M.get_completion_item_resolve()
-  print('Am I running?')
   local bufnr = api.nvim_get_current_buf()
   local completed_item_var = api.nvim_get_vvar('completed_item')
   local item = completed_item_var.user_data.lsp.completion_item
   local lnum = item.data.line
-
-  print(vim.inspect(item))
 
   vim.lsp.buf_request(bufnr, 'completionItem/resolve', item, function(err, _, result)
     if err or not result then return end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -397,25 +397,6 @@ function M._get_completion_item_kind_name(completion_item_kind)
   return protocol.CompletionItemKind[completion_item_kind] or "Unknown"
 end
 
---@private
---- Get the details of the completion item
-function M.get_completion_item_resolve()
-  local bufnr = api.nvim_get_current_buf()
-  local completed_item_var = api.nvim_get_vvar('completed_item')
-  local item = completed_item_var.user_data.lsp.completion_item
-  local lnum = item.data.line
-
-  vim.lsp.buf_request(bufnr, 'completionItem/resolve', item, function(err, _, result)
-    if err or not result then return end
-    if result.additionalTextEdits then
-      local edits = vim.tbl_filter(
-        function(x) return x.range.start.line ~= (lnum - 1) end,
-        result.additionalTextEdits
-      )
-      M.apply_text_edits(edits, bufnr)
-    end
-  end)
-end
 
 --- Turns the result of a `textDocument/completion` request into vim-compatible
 --- |complete-items|.
@@ -462,11 +443,9 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
       dup = 1,
       empty = 1,
       user_data = {
-        -- nvim = {
           lsp = {
             completion_item = completion_item
           }
-        -- }
       },
     })
   end


### PR DESCRIPTION
Adding initial support for `completionItem/resolve` requests. 

Initially mentioned in https://github.com/neovim/neovim/issues/13199

After completion, some sources can supply additional information, like `additionalTextEdits`. For lsps like typescript, they can auto-import the completion item that was just selected.


https://twitter.com/mhartington/status/1333140077510340623


Marking as WIP for now, as there is https://github.com/neovim/neovim/pull/12874

cc @tjdevries 