### PR TITLE
runtime: Fix man.vim count handling.

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -18,7 +18,7 @@ function! man#init() abort
   endtry
 endfunction
 
-function! man#open_page(count, count1, mods, ...) abort
+function! man#open_page(count, mods, ...) abort
   if a:0 > 2
     call s:error('too many arguments')
     return
@@ -39,9 +39,7 @@ function! man#open_page(count, count1, mods, ...) abort
   endif
   try
     let [sect, name] = s:extract_sect_and_name_ref(ref)
-    if a:count ==# a:count1
-      " v:count defaults to 0 which is a valid section, and v:count1 defaults to
-      " 1, also a valid section. If they are equal, count explicitly set.
+    if a:count >= 0
       let sect = string(a:count)
     endif
     let path = s:verify_exists(sect, name)

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,9 +5,9 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -bang -bar -range=0 -complete=customlist,man#complete -nargs=* Man
+command! -bang -bar -range=-1 -complete=customlist,man#complete -nargs=* Man
       \ if <bang>0 | set ft=man |
-      \ else | call man#open_page(v:count, v:count1, <q-mods>, <f-args>) | endif
+      \ else | call man#open_page(<count>, <q-mods>, <f-args>) | endif
 
 augroup man
   autocmd!


### PR DESCRIPTION
Here I use a negative number to decide whether the count has been
explicitly set. I think it unlikely that negative sections will ever be
created given that negative numbers complicate argument handling:
```
$ man -1 foo
man: invalid option -- '1'
```
and given that there's already precedence for alphanumeric sections like
`3p`, `3x`, `n`, etc.

---

This does work, though:
```
$ man -S -3 baz
```
With `man baz.-3` and `man 'baz(-3)'`, (GNU) man *might* consider `-3`
internally as a section, but in the end reports as if the whole
argument was the name of a topic:
```
$ man 'baz(-3)'
No manual entry for baz(-3)
```

---

Closes #13411.