### PR TITLE
ex_getln: add secret charm

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -215,6 +215,9 @@ CTRL-Y		When there is a modeless selection, copy the selection into
 		the clipboard.
 		If there is no selection CTRL-Y is inserted as a character.
 
+							*c_CTRL-Z*
+CTRL-Z		Trigger 'wildmode'. Same as 'wildcharm', but always available.
+
 CTRL-M or CTRL-J		*c_CTRL-M* *c_CTRL-J* *c_<NL>* *c_<CR>* *c_CR*
 <CR> or <NL>	start entered command
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1024,7 +1024,7 @@ static int command_line_execute(VimState *state, int key)
   }
 
   // free expanded names when finished walking through matches
-  if (!(s->c == p_wc && KeyTyped) && s->c != p_wcm
+  if (!(s->c == p_wc && KeyTyped) && s->c != p_wcm && s->c != Ctrl_Z
       && s->c != Ctrl_N && s->c != Ctrl_P && s->c != Ctrl_A
       && s->c != Ctrl_L) {
     if (compl_match_array) {
@@ -1328,7 +1328,8 @@ static int command_line_execute(VimState *state, int key)
   // - hitting <ESC> twice means: abandon command line.
   // - wildcard expansion is only done when the 'wildchar' key is really
   //   typed, not when it comes from a macro
-  if ((s->c == p_wc && !s->gotesc && KeyTyped) || s->c == p_wcm) {
+  if ((s->c == p_wc && !s->gotesc && KeyTyped) || s->c == p_wcm
+      || s->c == Ctrl_Z) {
     int options = WILD_NO_BEEP;
     if (wim_flags[s->wim_index] & WIM_BUFLASTUSED) {
       options |= WILD_BUFLASTUSED;

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -442,6 +442,7 @@ function module.new_argv(...)
         'NVIM_LOG_FILE',
         'NVIM_RPLUGIN_MANIFEST',
         'GCOV_ERROR_FILE',
+        'XDG_DATA_DIRS',
         'TMPDIR',
       }) do
         if not env_tbl[k] then

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
 local iswin = helpers.iswin
 local funcs = helpers.funcs
+local meths = helpers.meths
 local eq = helpers.eq
 local eval = helpers.eval
 local retry = helpers.retry
@@ -395,6 +396,64 @@ describe("'wildmenu'", function()
       [No Name]                |
                                |
     ]])
+  end)
+
+  it('works with c_CTRL_Z standard mapping', function()
+    screen:set_default_attr_ids {
+      [1] = {bold = true, foreground = Screen.colors.Blue1};
+      [2] = {foreground = Screen.colors.Grey0, background = Screen.colors.Yellow};
+      [3] = {bold = true, reverse = true};
+    }
+
+    -- Wildcharm? where we are going we aint't no need no wildcharm.
+    eq(0, meths.get_option'wildcharm')
+    -- Don't mess the defaults yet (neovim is about backwards compatibility)
+    eq(9, meths.get_option'wildchar')
+    -- Lol what is cnoremap? Some say it can define mappings.
+    command 'set wildchar=0'
+    eq(0, meths.get_option'wildchar')
+
+    command 'cnoremap <f2> <c-z>'
+    feed(':syntax <f2>')
+    screen:expect{grid=[[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {2:case}{3:  clear  cluster  >  }|
+      :syntax case^             |
+    ]]}
+    feed '<esc>'
+
+    command 'set wildmode=longest:full,full'
+    -- this will get cleaner once we have native lua expr mappings:
+    command [[cnoremap <expr> <tab> luaeval("not rawset(_G, 'coin', not coin).coin") ? "<c-z>" : "c"]]
+
+    feed ':syntax <tab>'
+    screen:expect{grid=[[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      :syntax c^                |
+    ]]}
+
+    feed '<tab>'
+    screen:expect{grid=[[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {3:case  clear  cluster  >  }|
+      :syntax c^                |
+    ]]}
+
+    feed '<tab>'
+    screen:expect{grid=[[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      :syntax cc^               |
+    ]]}
   end)
 end)
 


### PR DESCRIPTION
Opt in to this secret world using

    set wildchar=0
    " already the default, but remove if non-zero existing config:
    set wildcharm=0 

now you can map 'wildmode' just like any mode:

    cnoremap <tab> <c-z>
    function! Spacey()
      return getcmdline()[-1:] == "/" ? "\<bs>" : ""
    endfunc
    cnoremap <expr> / wildmenumode() ? Spacey()."/<c-z>" : "/"


What about backwards compatibility?
====

Just do nothing and your existing 'wildchar' and 'wildcharm' will keep working.

Doesn't `<c-z>` mean suspend.
====

Not in cmdline mode. If it would then the recommended wildcharm would not have been `<c-z>` to start with.


Doesn't it break $MY_FAVORITE_MAPPING?
====

No. But if it breaks your or someones config show me. (no, _thinking_ that this might break some hypothetical unspecified config is not enough)

My config relies on `:<c-z>` being a synonym to `:<nop>`!
===
just no.
