### PR TITLE
Update vim_diff.txt

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -182,8 +182,6 @@ Highlight groups:
   |hl-Whitespace| highlights 'listchars' whitespace
 
 Input/Mappings:
-  |<Cmd>| pseudokey
-
   ALT (|META|) chords always work (even in the |TUI|). Map |<M-| with any key:
   <M-1>, <M-BS>, <M-Del>, <M-Ins>, <M-/>, <M-\>, <M-Space>, <M-Enter>, etc.
   Case-sensitive: <M-a> and <M-A> are two different keycodes.
@@ -215,7 +213,6 @@ Signs:
   Signs are removed if the associated line is deleted.
 
 Variables:
-  |v:exiting|
   |v:progpath| is always absolute ("full")
   |v:windowid| is always available (for use by external UIs)
 


### PR DESCRIPTION
Patch 8.2.1978 added the support for the <Cmd> pseudo key in maps.
Patch 8.2.2070 added the support for the v:exiting variable.