### PR TITLE
[RDY] man.vim: Set iskeyword explicitly.

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -139,8 +139,6 @@ function! s:put_page(page) abort
   setlocal modifiable
   setlocal noreadonly
   setlocal noswapfile
-  " git-ls-files(1) is all one keyword/tag-target
-  setlocal iskeyword+=(,)
   silent keepjumps %delete _
   silent put =a:page
   while getline(1) =~# '^\s*$'

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -16,7 +16,11 @@ setlocal noswapfile buftype=nofile bufhidden=hide
 setlocal nomodified readonly nomodifiable
 setlocal noexpandtab tabstop=8 softtabstop=8 shiftwidth=8
 setlocal wrap breakindent linebreak
-setlocal iskeyword+=-
+
+" Parentheses and '-' for references like `git-ls-files(1)`; '@' for systemd
+" pages; ':' for Perl and C++ pages.  Here, I intentionally omit the locale
+" specific characters matched by `@`.
+setlocal iskeyword=@-@,:,a-z,A-Z,48-57,_,.,-,(,)
 
 setlocal nonumber norelativenumber
 setlocal foldcolumn=0 colorcolumn=0 nolist nofoldenable

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -28,9 +28,10 @@ setlocal foldcolumn=0 colorcolumn=0 nolist nofoldenable
 setlocal tagfunc=man#goto_tag
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nnoremap <silent> <buffer> j          gj
-  nnoremap <silent> <buffer> k          gk
-  nnoremap <silent> <buffer> gO         :call man#show_toc()<CR>
+  nnoremap <silent> <buffer> j             gj
+  nnoremap <silent> <buffer> k             gk
+  nnoremap <silent> <buffer> gO            :call man#show_toc()<CR>
+  nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
   if s:pager
     nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
   else


### PR DESCRIPTION
This also fixes `:Man!`, which wasn't setting 'iskeyword' to contain
parentheses.

Tagging the maintainer, @nhooyr.