### PR TITLE
fix(treesitter): don't throw an error for missing injected langs

### DIFF
--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -8,7 +8,8 @@ local M = {}
 --
 -- @param lang The language the parser should parse
 -- @param path Optionnal path the parser is located at
-function M.require_language(lang, path)
+-- @param silent Don't throw an error if language not found
+function M.require_language(lang, path, silent)
   if vim._ts_has_language(lang) then
     return true
   end
@@ -16,12 +17,23 @@ function M.require_language(lang, path)
     local fname = 'parser/' .. lang .. '.*'
     local paths = a.nvim_get_runtime_file(fname, false)
     if #paths == 0 then
+      if silent then
+        return false
+      end
+
       -- TODO(bfredl): help tag?
       error("no parser for '"..lang.."' language, see :help treesitter-parsers")
     end
     path = paths[1]
   end
-  vim._ts_add_language(path, lang)
+
+  if silent then
+    return pcall(function() vim._ts_add_language(path, lang) end)
+  else
+    vim._ts_add_language(path, lang)
+  end
+
+  return true
 end
 
 --- Inspects the provided language.

--- a/test/functional/lua/treesitter_spec.lua
+++ b/test/functional/lua/treesitter_spec.lua
@@ -22,6 +22,10 @@ describe('treesitter API', function()
     matches("Error executing lua: Failed to load parser: uv_dlopen: .+",
        pcall_err(exec_lua, "parser = vim.treesitter.require_language('borklang', 'borkbork.so')"))
 
+    -- Should not throw an error when silent
+    eq(false, exec_lua("return vim.treesitter.require_language('borklang', nil, true)"))
+    eq(false, exec_lua("return vim.treesitter.require_language('borklang', 'borkbork.so', true)"))
+
     eq("Error executing lua: .../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.inspect_language('borklang')"))
   end)


### PR DESCRIPTION
This is prevents errors from being thrown for missing injected parsers. Injected languages can depend on node text (IE Markdown).
There errors get thrown while typing the name of the parser in the editor. This merely ignores the injected language if it's not present.