### PR TITLE
api: move deprecated functions to separate files

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1,7 +1,7 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
-// Much of this code was adapted from 'if_py_both.h' from the original
+// Some of this code was adapted from 'if_py_both.h' from the original
 // vim source
 #include <stdbool.h>
 #include <stdint.h>
@@ -78,34 +78,6 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
   }
 
   return buf->b_ml.ml_line_count;
-}
-
-/// Gets a buffer line
-///
-/// @deprecated use nvim_buf_get_lines instead.
-///             for positive indices (including 0) use
-///                 "nvim_buf_get_lines(buffer, index, index+1, true)"
-///             for negative indices use
-///                 "nvim_buf_get_lines(buffer, index-1, index, true)"
-///
-/// @param buffer   Buffer handle
-/// @param index    Line index
-/// @param[out] err Error details, if any
-/// @return Line string
-String buffer_get_line(Buffer buffer, Integer index, Error *err)
-{
-  String rv = { .size = 0 };
-
-  index = convert_index(index);
-  Array slice = nvim_buf_get_lines(0, buffer, index, index+1, true, err);
-
-  if (!ERROR_SET(err) && slice.size) {
-    rv = slice.items[0].data.string;
-  }
-
-  xfree(slice.items);
-
-  return rv;
 }
 
 /// Activates buffer-update events on a channel, or as Lua callbacks.
@@ -258,68 +230,6 @@ void nvim__buf_redraw_range(Buffer buffer, Integer first, Integer last,
   redraw_buf_range_later(buf, (linenr_T)first+1, (linenr_T)last);
 }
 
-/// Sets a buffer line
-///
-/// @deprecated use nvim_buf_set_lines instead.
-///             for positive indices use
-///                 "nvim_buf_set_lines(buffer, index, index+1, true, [line])"
-///             for negative indices use
-///                 "nvim_buf_set_lines(buffer, index-1, index, true, [line])"
-///
-/// @param buffer   Buffer handle
-/// @param index    Line index
-/// @param line     Contents of the new line
-/// @param[out] err Error details, if any
-void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
-{
-  Object l = STRING_OBJ(line);
-  Array array = { .items = &l, .size = 1 };
-  index = convert_index(index);
-  nvim_buf_set_lines(0, buffer, index, index+1, true,  array, err);
-}
-
-/// Deletes a buffer line
-///
-/// @deprecated use nvim_buf_set_lines instead.
-///             for positive indices use
-///                 "nvim_buf_set_lines(buffer, index, index+1, true, [])"
-///             for negative indices use
-///                 "nvim_buf_set_lines(buffer, index-1, index, true, [])"
-/// @param buffer   buffer handle
-/// @param index    line index
-/// @param[out] err Error details, if any
-void buffer_del_line(Buffer buffer, Integer index, Error *err)
-{
-  Array array = ARRAY_DICT_INIT;
-  index = convert_index(index);
-  nvim_buf_set_lines(0, buffer, index, index+1, true, array, err);
-}
-
-/// Retrieves a line range from the buffer
-///
-/// @deprecated use nvim_buf_get_lines(buffer, newstart, newend, false)
-///             where newstart = start + int(not include_start) - int(start < 0)
-///                   newend = end + int(include_end) - int(end < 0)
-///                   int(bool) = 1 if bool is true else 0
-/// @param buffer         Buffer handle
-/// @param start          First line index
-/// @param end            Last line index
-/// @param include_start  True if the slice includes the `start` parameter
-/// @param include_end    True if the slice includes the `end` parameter
-/// @param[out] err       Error details, if any
-/// @return Array of lines
-ArrayOf(String) buffer_get_line_slice(Buffer buffer,
-                                      Integer start,
-                                      Integer end,
-                                      Boolean include_start,
-                                      Boolean include_end,
-                                      Error *err)
-{
-  start = convert_index(start) + !include_start;
-  end = convert_index(end) + include_end;
-  return nvim_buf_get_lines(0, buffer, start , end, false, err);
-}
-
 /// Gets a line-range from the buffer.
 ///
 /// Indexing is zero-based, end-exclusive. Negative indices are interpreted
@@ -389,35 +299,6 @@ end:
   }
 
   return rv;
-}
-
-
-/// Replaces a line range on the buffer
-///
-/// @deprecated use nvim_buf_set_lines(buffer, newstart, newend, false, lines)
-///             where newstart = start + int(not include_start) + int(start < 0)
-///                   newend = end + int(include_end) + int(end < 0)
-///                   int(bool) = 1 if bool is true else 0
-///
-/// @param buffer         Buffer handle, or 0 for current buffer
-/// @param start          First line index
-/// @param end            Last line index
-/// @param include_start  True if the slice includes the `start` parameter
-/// @param include_end    True if the slice includes the `end` parameter
-/// @param replacement    Array of lines to use as replacement (0-length
-//                        array will delete the line range)
-/// @param[out] err       Error details, if any
-void buffer_set_line_slice(Buffer buffer,
-                           Integer start,
-                           Integer end,
-                           Boolean include_start,
-                           Boolean include_end,
-                           ArrayOf(String) replacement,
-                           Error *err)
-{
-  start = convert_index(start) + !include_start;
-  end = convert_index(end) + include_end;
-  nvim_buf_set_lines(0, buffer, start, end, false, replacement, err);
 }
 
 
@@ -787,48 +668,6 @@ void nvim_buf_del_var(Buffer buffer, String name, Error *err)
   dict_set_var(buf->b_vars, name, NIL, true, false, err);
 }
 
-/// Sets a buffer-scoped (b:) variable
-///
-/// @deprecated
-///
-/// @param buffer     Buffer handle, or 0 for current buffer
-/// @param name       Variable name
-/// @param value      Variable value
-/// @param[out] err   Error details, if any
-/// @return Old value or nil if there was no previous value.
-///
-///         @warning It may return nil if there was no previous value
-///                  or if previous value was `v:null`.
-Object buffer_set_var(Buffer buffer, String name, Object value, Error *err)
-{
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-
-  if (!buf) {
-    return (Object) OBJECT_INIT;
-  }
-
-  return dict_set_var(buf->b_vars, name, value, false, true, err);
-}
-
-/// Removes a buffer-scoped (b:) variable
-///
-/// @deprecated
-///
-/// @param buffer     Buffer handle, or 0 for current buffer
-/// @param name       Variable name
-/// @param[out] err   Error details, if any
-/// @return Old value
-Object buffer_del_var(Buffer buffer, String name, Error *err)
-{
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-
-  if (!buf) {
-    return (Object) OBJECT_INIT;
-  }
-
-  return dict_set_var(buf->b_vars, name, NIL, true, true, err);
-}
-
 
 /// Gets a buffer option value
 ///
@@ -867,28 +706,6 @@ void nvim_buf_set_option(uint64_t channel_id, Buffer buffer,
   }
 
   set_option_to(channel_id, buf, SREQ_BUF, name, value, err);
-}
-
-/// Gets the buffer number
-///
-/// @deprecated The buffer number now is equal to the object id,
-///             so there is no need to use this function.
-///
-/// @param buffer     Buffer handle, or 0 for current buffer
-/// @param[out] err   Error details, if any
-/// @return Buffer number
-Integer nvim_buf_get_number(Buffer buffer, Error *err)
-  FUNC_API_SINCE(1)
-  FUNC_API_DEPRECATED_SINCE(2)
-{
-  Integer rv = 0;
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-
-  if (!buf) {
-    return rv;
-  }
-
-  return buf->b_fnum;
 }
 
 /// Gets the full file name for the buffer
@@ -1015,25 +832,6 @@ Boolean nvim_buf_is_valid(Buffer buffer)
   Boolean ret = find_buffer_by_handle(buffer, &stub) != NULL;
   api_clear_error(&stub);
   return ret;
-}
-
-/// Inserts a sequence of lines to a buffer at a certain index
-///
-/// @deprecated use nvim_buf_set_lines(buffer, lnum, lnum, true, lines)
-///
-/// @param buffer     Buffer handle
-/// @param lnum       Insert the lines after `lnum`. If negative, appends to
-///                   the end of the buffer.
-/// @param lines      Array of lines
-/// @param[out] err   Error details, if any
-void buffer_insert(Buffer buffer,
-                   Integer lnum,
-                   ArrayOf(String) lines,
-                   Error *err)
-{
-  // "lnum" will be the index of the line after inserting,
-  // no matter if it is negative or not
-  nvim_buf_set_lines(0, buffer, lnum, lnum, true, lines, err);
 }
 
 /// Return a tuple (row,col) representing the position of the named mark.
@@ -1667,27 +1465,6 @@ void nvim_buf_clear_namespace(Buffer buffer,
                 (int)line_end-1, MAXCOL);
 }
 
-/// Clears highlights and virtual text from namespace and range of lines
-///
-/// @deprecated use |nvim_buf_clear_namespace()|.
-///
-/// @param buffer     Buffer handle, or 0 for current buffer
-/// @param ns_id      Namespace to clear, or -1 to clear all.
-/// @param line_start Start of range of lines to clear
-/// @param line_end   End of range of lines to clear (exclusive) or -1 to clear
-///                   to end of file.
-/// @param[out] err   Error details, if any
-void nvim_buf_clear_highlight(Buffer buffer,
-                              Integer ns_id,
-                              Integer line_start,
-                              Integer line_end,
-                              Error *err)
-  FUNC_API_SINCE(1)
-{
-  nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end, err);
-}
-
-
 /// Set the virtual text (annotation) for a buffer line.
 ///
 /// By default (and currently the only option) the text will be placed after
@@ -1872,9 +1649,4 @@ static int64_t normalize_index(buf_T *buf, int64_t index, bool *oob)
   // Convert the index to a vim line number
   index++;
   return index;
-}
-
-static int64_t convert_index(int64_t index)
-{
-  return index < 0 ? index - 1 : index;
 }

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -1,0 +1,367 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "nvim/api/deprecated.h"
+#include "nvim/api/buffer.h"
+#include "nvim/api/vim.h"
+#include "nvim/api/private/helpers.h"
+#include "nvim/api/private/defs.h"
+#include "nvim/lua/executor.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/deprecated.c.generated.h"
+#endif
+
+/// @deprecated
+/// @see nvim_exec
+String nvim_command_output(String command, Error *err)
+  FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(7)
+{
+  return nvim_exec(command, true, err);
+}
+
+/// @deprecated Use nvim_exec_lua() instead.
+/// @see nvim_exec_lua
+Object nvim_execute_lua(String code, Array args, Error *err)
+  FUNC_API_SINCE(3)
+  FUNC_API_DEPRECATED_SINCE(7)
+  FUNC_API_REMOTE_ONLY
+{
+  return nlua_exec(code, args, err);
+}
+
+/// Gets the buffer number
+///
+/// @deprecated The buffer number now is equal to the object id,
+///             so there is no need to use this function.
+///
+/// @param buffer     Buffer handle, or 0 for current buffer
+/// @param[out] err   Error details, if any
+/// @return Buffer number
+Integer nvim_buf_get_number(Buffer buffer, Error *err)
+  FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(2)
+{
+  Integer rv = 0;
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+
+  if (!buf) {
+    return rv;
+  }
+
+  return buf->b_fnum;
+}
+
+/// Clears highlights and virtual text from namespace and range of lines
+///
+/// @deprecated use |nvim_buf_clear_namespace()|.
+///
+/// @param buffer     Buffer handle, or 0 for current buffer
+/// @param ns_id      Namespace to clear, or -1 to clear all.
+/// @param line_start Start of range of lines to clear
+/// @param line_end   End of range of lines to clear (exclusive) or -1 to clear
+///                   to end of file.
+/// @param[out] err   Error details, if any
+void nvim_buf_clear_highlight(Buffer buffer,
+                              Integer ns_id,
+                              Integer line_start,
+                              Integer line_end,
+                              Error *err)
+  FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(7)
+{
+  nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end, err);
+}
+
+
+/// Inserts a sequence of lines to a buffer at a certain index
+///
+/// @deprecated use nvim_buf_set_lines(buffer, lnum, lnum, true, lines)
+///
+/// @param buffer     Buffer handle
+/// @param lnum       Insert the lines after `lnum`. If negative, appends to
+///                   the end of the buffer.
+/// @param lines      Array of lines
+/// @param[out] err   Error details, if any
+void buffer_insert(Buffer buffer,
+                   Integer lnum,
+                   ArrayOf(String) lines,
+                   Error *err)
+{
+  // "lnum" will be the index of the line after inserting,
+  // no matter if it is negative or not
+  nvim_buf_set_lines(0, buffer, lnum, lnum, true, lines, err);
+}
+
+/// Gets a buffer line
+///
+/// @deprecated use nvim_buf_get_lines instead.
+///             for positive indices (including 0) use
+///                 "nvim_buf_get_lines(buffer, index, index+1, true)"
+///             for negative indices use
+///                 "nvim_buf_get_lines(buffer, index-1, index, true)"
+///
+/// @param buffer   Buffer handle
+/// @param index    Line index
+/// @param[out] err Error details, if any
+/// @return Line string
+String buffer_get_line(Buffer buffer, Integer index, Error *err)
+{
+  String rv = { .size = 0 };
+
+  index = convert_index(index);
+  Array slice = nvim_buf_get_lines(0, buffer, index, index+1, true, err);
+
+  if (!ERROR_SET(err) && slice.size) {
+    rv = slice.items[0].data.string;
+  }
+
+  xfree(slice.items);
+
+  return rv;
+}
+
+/// Sets a buffer line
+///
+/// @deprecated use nvim_buf_set_lines instead.
+///             for positive indices use
+///                 "nvim_buf_set_lines(buffer, index, index+1, true, [line])"
+///             for negative indices use
+///                 "nvim_buf_set_lines(buffer, index-1, index, true, [line])"
+///
+/// @param buffer   Buffer handle
+/// @param index    Line index
+/// @param line     Contents of the new line
+/// @param[out] err Error details, if any
+void buffer_set_line(Buffer buffer, Integer index, String line, Error *err)
+{
+  Object l = STRING_OBJ(line);
+  Array array = { .items = &l, .size = 1 };
+  index = convert_index(index);
+  nvim_buf_set_lines(0, buffer, index, index+1, true,  array, err);
+}
+
+/// Deletes a buffer line
+///
+/// @deprecated use nvim_buf_set_lines instead.
+///             for positive indices use
+///                 "nvim_buf_set_lines(buffer, index, index+1, true, [])"
+///             for negative indices use
+///                 "nvim_buf_set_lines(buffer, index-1, index, true, [])"
+/// @param buffer   buffer handle
+/// @param index    line index
+/// @param[out] err Error details, if any
+void buffer_del_line(Buffer buffer, Integer index, Error *err)
+{
+  Array array = ARRAY_DICT_INIT;
+  index = convert_index(index);
+  nvim_buf_set_lines(0, buffer, index, index+1, true, array, err);
+}
+
+/// Retrieves a line range from the buffer
+///
+/// @deprecated use nvim_buf_get_lines(buffer, newstart, newend, false)
+///             where newstart = start + int(not include_start) - int(start < 0)
+///                   newend = end + int(include_end) - int(end < 0)
+///                   int(bool) = 1 if bool is true else 0
+/// @param buffer         Buffer handle
+/// @param start          First line index
+/// @param end            Last line index
+/// @param include_start  True if the slice includes the `start` parameter
+/// @param include_end    True if the slice includes the `end` parameter
+/// @param[out] err       Error details, if any
+/// @return Array of lines
+ArrayOf(String) buffer_get_line_slice(Buffer buffer,
+                                      Integer start,
+                                      Integer end,
+                                      Boolean include_start,
+                                      Boolean include_end,
+                                      Error *err)
+{
+  start = convert_index(start) + !include_start;
+  end = convert_index(end) + include_end;
+  return nvim_buf_get_lines(0, buffer, start , end, false, err);
+}
+
+/// Replaces a line range on the buffer
+///
+/// @deprecated use nvim_buf_set_lines(buffer, newstart, newend, false, lines)
+///             where newstart = start + int(not include_start) + int(start < 0)
+///                   newend = end + int(include_end) + int(end < 0)
+///                   int(bool) = 1 if bool is true else 0
+///
+/// @param buffer         Buffer handle, or 0 for current buffer
+/// @param start          First line index
+/// @param end            Last line index
+/// @param include_start  True if the slice includes the `start` parameter
+/// @param include_end    True if the slice includes the `end` parameter
+/// @param replacement    Array of lines to use as replacement (0-length
+//                        array will delete the line range)
+/// @param[out] err       Error details, if any
+void buffer_set_line_slice(Buffer buffer,
+                           Integer start,
+                           Integer end,
+                           Boolean include_start,
+                           Boolean include_end,
+                           ArrayOf(String) replacement,
+                           Error *err)
+{
+  start = convert_index(start) + !include_start;
+  end = convert_index(end) + include_end;
+  nvim_buf_set_lines(0, buffer, start, end, false, replacement, err);
+}
+
+
+/// Sets a buffer-scoped (b:) variable
+///
+/// @deprecated
+///
+/// @param buffer     Buffer handle, or 0 for current buffer
+/// @param name       Variable name
+/// @param value      Variable value
+/// @param[out] err   Error details, if any
+/// @return Old value or nil if there was no previous value.
+///
+///         @warning It may return nil if there was no previous value
+///                  or if previous value was `v:null`.
+Object buffer_set_var(Buffer buffer, String name, Object value, Error *err)
+{
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+
+  if (!buf) {
+    return NIL;
+  }
+
+  return dict_set_var(buf->b_vars, name, value, false, true, err);
+}
+
+/// Removes a buffer-scoped (b:) variable
+///
+/// @deprecated
+///
+/// @param buffer     Buffer handle, or 0 for current buffer
+/// @param name       Variable name
+/// @param[out] err   Error details, if any
+/// @return Old value
+Object buffer_del_var(Buffer buffer, String name, Error *err)
+{
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+
+  if (!buf) {
+    return NIL;
+  }
+
+  return dict_set_var(buf->b_vars, name, NIL, true, true, err);
+}
+
+/// Sets a window-scoped (w:) variable
+///
+/// @deprecated
+///
+/// @param window   Window handle, or 0 for current window
+/// @param name     Variable name
+/// @param value    Variable value
+/// @param[out] err Error details, if any
+/// @return Old value or nil if there was no previous value.
+///
+///         @warning It may return nil if there was no previous value
+///                  or if previous value was `v:null`.
+Object window_set_var(Window window, String name, Object value, Error *err)
+{
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return NIL;
+  }
+
+  return dict_set_var(win->w_vars, name, value, false, true, err);
+}
+
+/// Removes a window-scoped (w:) variable
+///
+/// @deprecated
+///
+/// @param window   Window handle, or 0 for current window
+/// @param name     variable name
+/// @param[out] err Error details, if any
+/// @return Old value
+Object window_del_var(Window window, String name, Error *err)
+{
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return NIL;
+  }
+
+  return dict_set_var(win->w_vars, name, NIL, true, true, err);
+}
+
+/// Sets a tab-scoped (t:) variable
+///
+/// @deprecated
+///
+/// @param tabpage  Tabpage handle, or 0 for current tabpage
+/// @param name     Variable name
+/// @param value    Variable value
+/// @param[out] err Error details, if any
+/// @return Old value or nil if there was no previous value.
+///
+///         @warning It may return nil if there was no previous value
+///                  or if previous value was `v:null`.
+Object tabpage_set_var(Tabpage tabpage, String name, Object value, Error *err)
+{
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
+
+  if (!tab) {
+    return NIL;
+  }
+
+  return dict_set_var(tab->tp_vars, name, value, false, true, err);
+}
+
+/// Removes a tab-scoped (t:) variable
+///
+/// @deprecated
+///
+/// @param tabpage  Tabpage handle, or 0 for current tabpage
+/// @param name     Variable name
+/// @param[out] err Error details, if any
+/// @return Old value
+Object tabpage_del_var(Tabpage tabpage, String name, Error *err)
+{
+  tabpage_T *tab = find_tab_by_handle(tabpage, err);
+
+  if (!tab) {
+    return NIL;
+  }
+
+  return dict_set_var(tab->tp_vars, name, NIL, true, true, err);
+}
+
+/// @deprecated
+/// @see nvim_set_var
+/// @warning May return nil if there was no previous value
+///          OR if previous value was `v:null`.
+/// @return Old value or nil if there was no previous value.
+Object vim_set_var(String name, Object value, Error *err)
+{
+  return dict_set_var(&globvardict, name, value, false, true, err);
+}
+
+/// @deprecated
+/// @see nvim_del_var
+Object vim_del_var(String name, Error *err)
+{
+  return dict_set_var(&globvardict, name, NIL, true, true, err);
+}
+
+static int64_t convert_index(int64_t index)
+{
+  return index < 0 ? index - 1 : index;
+}

--- a/src/nvim/api/deprecated.h
+++ b/src/nvim/api/deprecated.h
@@ -1,0 +1,11 @@
+#ifndef NVIM_API_DEPRECATED_H
+#define NVIM_API_DEPRECATED_H
+
+#include <stdint.h>
+
+#include "nvim/api/private/defs.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/deprecated.h.generated.h"
+#endif
+#endif  // NVIM_API_DEPRECATED_H

--- a/src/nvim/api/private/dispatch.c
+++ b/src/nvim/api/private/dispatch.c
@@ -19,6 +19,7 @@
 #include "nvim/api/ui.h"
 #include "nvim/api/vim.h"
 #include "nvim/api/window.h"
+#include "nvim/api/deprecated.h"
 
 static Map(String, MsgpackRpcRequestHandler) *methods = NULL;
 

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -97,48 +97,6 @@ void nvim_tabpage_del_var(Tabpage tabpage, String name, Error *err)
   dict_set_var(tab->tp_vars, name, NIL, true, false, err);
 }
 
-/// Sets a tab-scoped (t:) variable
-///
-/// @deprecated
-///
-/// @param tabpage  Tabpage handle, or 0 for current tabpage
-/// @param name     Variable name
-/// @param value    Variable value
-/// @param[out] err Error details, if any
-/// @return Old value or nil if there was no previous value.
-///
-///         @warning It may return nil if there was no previous value
-///                  or if previous value was `v:null`.
-Object tabpage_set_var(Tabpage tabpage, String name, Object value, Error *err)
-{
-  tabpage_T *tab = find_tab_by_handle(tabpage, err);
-
-  if (!tab) {
-    return (Object) OBJECT_INIT;
-  }
-
-  return dict_set_var(tab->tp_vars, name, value, false, true, err);
-}
-
-/// Removes a tab-scoped (t:) variable
-///
-/// @deprecated
-///
-/// @param tabpage  Tabpage handle, or 0 for current tabpage
-/// @param name     Variable name
-/// @param[out] err Error details, if any
-/// @return Old value
-Object tabpage_del_var(Tabpage tabpage, String name, Error *err)
-{
-  tabpage_T *tab = find_tab_by_handle(tabpage, err);
-
-  if (!tab) {
-    return (Object) OBJECT_INIT;
-  }
-
-  return dict_set_var(tab->tp_vars, name, NIL, true, true, err);
-}
-
 /// Gets the current window in a tabpage
 ///
 /// @param tabpage  Tabpage handle, or 0 for current tabpage

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -15,6 +15,7 @@
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/buffer.h"
 #include "nvim/api/window.h"
+#include "nvim/api/deprecated.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/lua/executor.h"
@@ -479,15 +480,6 @@ String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt,
   return cstr_as_string(ptr);
 }
 
-/// @deprecated
-/// @see nvim_exec
-String nvim_command_output(String command, Error *err)
-  FUNC_API_SINCE(1)
-  FUNC_API_DEPRECATED_SINCE(7)
-{
-  return nvim_exec(command, true, err);
-}
-
 /// Evaluates a VimL |expression|.
 /// Dictionaries and Lists are recursively expanded.
 ///
@@ -532,16 +524,6 @@ Object nvim_eval(String expr, Error *err)
   });
 
   return rv;
-}
-
-/// @deprecated Use nvim_exec_lua() instead.
-/// @see nvim_exec_lua
-Object nvim_execute_lua(String code, Array args, Error *err)
-  FUNC_API_SINCE(3)
-  FUNC_API_DEPRECATED_SINCE(7)
-  FUNC_API_REMOTE_ONLY
-{
-  return nlua_exec(code, args, err);
 }
 
 /// Execute Lua code. Parameters (if any) are available as `...` inside the
@@ -918,23 +900,6 @@ void nvim_del_var(String name, Error *err)
   FUNC_API_SINCE(1)
 {
   dict_set_var(&globvardict, name, NIL, true, false, err);
-}
-
-/// @deprecated
-/// @see nvim_set_var
-/// @warning May return nil if there was no previous value
-///          OR if previous value was `v:null`.
-/// @return Old value or nil if there was no previous value.
-Object vim_set_var(String name, Object value, Error *err)
-{
-  return dict_set_var(&globvardict, name, value, false, true, err);
-}
-
-/// @deprecated
-/// @see nvim_del_var
-Object vim_del_var(String name, Error *err)
-{
-  return dict_set_var(&globvardict, name, NIL, true, true, err);
 }
 
 /// Gets a v: variable.

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -288,48 +288,6 @@ void nvim_win_del_var(Window window, String name, Error *err)
   dict_set_var(win->w_vars, name, NIL, true, false, err);
 }
 
-/// Sets a window-scoped (w:) variable
-///
-/// @deprecated
-///
-/// @param window   Window handle, or 0 for current window
-/// @param name     Variable name
-/// @param value    Variable value
-/// @param[out] err Error details, if any
-/// @return Old value or nil if there was no previous value.
-///
-///         @warning It may return nil if there was no previous value
-///                  or if previous value was `v:null`.
-Object window_set_var(Window window, String name, Object value, Error *err)
-{
-  win_T *win = find_window_by_handle(window, err);
-
-  if (!win) {
-    return (Object) OBJECT_INIT;
-  }
-
-  return dict_set_var(win->w_vars, name, value, false, true, err);
-}
-
-/// Removes a window-scoped (w:) variable
-///
-/// @deprecated
-///
-/// @param window   Window handle, or 0 for current window
-/// @param name     variable name
-/// @param[out] err Error details, if any
-/// @return Old value
-Object window_del_var(Window window, String name, Error *err)
-{
-  win_T *win = find_window_by_handle(window, err);
-
-  if (!win) {
-    return (Object) OBJECT_INIT;
-  }
-
-  return dict_set_var(win->w_vars, name, NIL, true, true, err);
-}
-
 /// Gets a window option value
 ///
 /// @param window   Window handle, or 0 for current window


### PR DESCRIPTION
Most these are just calls to non-deprecated variants, and take up unnecessary space and search hits in the other files.