### PR TITLE
vim-patch:8.2.0047: cannot skip tests for specific MS-Windows platform

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9333,6 +9333,13 @@ wincol()	The result is a Number, which is the virtual column of the
 		cursor in the window.  This is counting screen cells from the
 		left side of the window.  The leftmost column is one.
 
+							*windowsversion()*
+windowsversion()
+		The result is a String.  For MS-Windows it indicates the OS
+		version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
+		Windows XP is "5.1".  For non-MS-Windows systems the result is
+		an empty string.
+
 winheight({nr})						*winheight()*
 		The result is a Number, which is the height of window {nr}.
 		{nr} can be the window number or the |window-ID|.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -392,6 +392,7 @@ return {
     win_screenpos={args=1},
     winbufnr={args=1},
     wincol={},
+    windowsversion={},
     winheight={args=1},
     winlayout={args={0, 1}},
     winline={},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -11213,6 +11213,13 @@ static void f_winwidth(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
+// "windowsversion()" function
+static void f_windowsversion(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = (char_u *)xstrdup(windowsVersion);
+}
+
 /// "wordcount()" function
 static void f_wordcount(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1052,4 +1052,7 @@ typedef enum {
 #define MIN_CD_SCOPE  kCdScopeWindow
 #define MAX_CD_SCOPE  kCdScopeGlobal
 
+// Only filled for Win32.
+EXTERN char windowsVersion[20] INIT(= { 0 });
+
 #endif  // NVIM_GLOBALS_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -169,6 +169,14 @@ void early_init(mparm_T *paramp)
   init_normal_cmds();   // Init the table of Normal mode commands.
   highlight_init();
 
+#ifdef WIN32
+  OSVERSIONINFO ovi;
+  ovi.dwOSVersionInfoSize = sizeof(ovi);
+  GetVersionEx(&ovi);
+  snprintf(windowsVersion, sizeof(windowsVersion), "%d.%d",
+           (int)ovi.dwMajorVersion, (int)ovi.dwMinorVersion);
+#endif
+
 #if defined(HAVE_LOCALE_H)
   // Setup to use the current locale (for ctype() and many other things).
   // NOTE: Translated messages with encodings other than latin1 will not

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -348,6 +348,16 @@ func Test_set_values()
   endif
 endfunc
 
+func Test_renderoptions()
+  throw 'skipped: Nvim does not support renderoptions'
+  " Only do this for Windows Vista and later, fails on Windows XP and earlier.
+  " Doesn't hurt to do this on a non-Windows system.
+  if windowsversion() !~ '^[345]\.'
+    set renderoptions=type:directx
+    set rop=type:directx
+  endif
+endfunc
+
 func ResetIndentexpr()
   set indentexpr=
 endfunc

--- a/test/functional/eval/function_spec.lua
+++ b/test/functional/eval/function_spec.lua
@@ -2,7 +2,10 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local eq = helpers.eq
+local matches = helpers.matches
 local exc_exec = helpers.exc_exec
+local iswin = helpers.iswin
+local eval = helpers.eval
 
 describe('Up to MAX_FUNC_ARGS arguments are handled by', function()
   local max_func_args = 20  -- from eval.h
@@ -26,4 +29,9 @@ describe('Up to MAX_FUNC_ARGS arguments are handled by', function()
     ret = exc_exec('call rpcnotify(0, "foo", 3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21)')
     eq('Vim(call):E740: Too many arguments for function rpcnotify', ret)
   end)
+end)
+
+it('windowsversion()', function()
+  clear()
+  matches(iswin() and '^%d+%.%d+$' or '^$', eval('windowsversion()'))
 end)


### PR DESCRIPTION
Problem:    Cannot skip tests for specific MS-Windows platform.
Solution:   Add windowsversion().
https://github.com/vim/vim/commit/0c1e3744ff0cd6c17af773046b876b428ff3dded