### PR TITLE
doc: Add missing parameter for range_formatting

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -961,6 +961,9 @@ range_formatting({options}, {start_pos}, {end_pos})
                 Parameters: ~
                     {options}    Table with valid `FormattingOptions` entries.
                     {start_pos}  ({number, number}, optional) mark-indexed
+                                 position. Defaults to the start of the last
+                                 visual selection.
+                    {end_pos}    ({number, number}, optional) mark-indexed
                                  position. Defaults to the end of the last
                                  visual selection.
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -149,7 +149,7 @@ end
 --@param options Table with valid `FormattingOptions` entries.
 --@param start_pos ({number, number}, optional) mark-indexed position.
 ---Defaults to the start of the last visual selection.
---@param start_pos ({number, number}, optional) mark-indexed position.
+--@param end_pos ({number, number}, optional) mark-indexed position.
 ---Defaults to the end of the last visual selection.
 function M.range_formatting(options, start_pos, end_pos)
   validate { options = {options, 't', true} }


### PR DESCRIPTION
A small PR to add a missing parameter in the LSP doc. Also fixes a typo in the description of `range_formatting()`.