### PR TITLE
runtime: propagate lua parsing errors while using "require"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,7 +659,7 @@ endif()
 
 if(LUACHECK_PRG)
   add_custom_target(lualint
-    COMMAND ${LUACHECK_PRG} -q runtime/ src/ test/
+    COMMAND ${LUACHECK_PRG} -q runtime/ src/ test/ --exclude-files test/functional/fixtures/lua/syntax_error.lua
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 else()
   add_custom_target(lualint false

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -115,7 +115,8 @@ function vim._load_package(name)
   for _,path in ipairs(paths) do
     local found = vim.api.nvim_get_runtime_file(path, false)
     if #found > 0 then
-      return loadfile(found[1])
+      local f, err = loadfile(found[1])
+      return f or error(err)
     end
   end
 
@@ -123,7 +124,8 @@ function vim._load_package(name)
     local path = "lua/"..trail:gsub('?',basename)
     local found = vim.api.nvim_get_runtime_file(path, false)
     if #found > 0 then
-      return package.loadlib(found[1])
+      local f, err = package.loadlib(found[1])
+      return f or error(err)
     end
   end
   return nil

--- a/test/functional/fixtures/lua/syntax_error.lua
+++ b/test/functional/fixtures/lua/syntax_error.lua
@@ -1,0 +1,1 @@
+- <= the syntax error

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1453,3 +1453,18 @@ describe('lua stdlib', function()
     end)
   end)
 end)
+
+describe('lua: require("mod") from packages', function()
+  before_each(function()
+    command('set rtp+=test/functional/fixtures')
+  end)
+
+  it('propagates syntax error', function()
+    local syntax_error_msg = exec_lua [[
+      local _, err = pcall(require, "syntax_error")
+      return err
+    ]]
+
+    matches("unexpected symbol", syntax_error_msg)
+  end)
+end)


### PR DESCRIPTION
errors returned by `loadfile` in `vim._load_package` are hidden atm.
it can be interpreted as some problem with a loading path because the default error contains "module not found" message provided by other loaders.


fixes #13477

this fix relies on [the default interface](https://pgl.yoyo.org/luai/i/package.loaders) where the error can be returned by the "seacher" function. though I do not like how the message formatted :) at least it's better than nothing

<img width="1262" alt="Screen Shot 2020-12-08 at 01 56 45" src="https://user-images.githubusercontent.com/486807/101415506-19745a80-38f9-11eb-86fa-8dab91610bac.png">

EDIT, extra links
https://www.gammon.com.au/scripts/doc.php?lua=loadfile
https://www.gammon.com.au/scripts/doc.php?lua=package.loadlib