### PR TITLE
vim-patch:8.2.{1967,2058,2467}

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1144,6 +1144,7 @@ tag		command		action ~
 |:bNext|	:bN[ext]	go to previous buffer in the buffer list
 |:ball|		:ba[ll]		open a window for each buffer in the buffer list
 |:badd|		:bad[d]		add buffer to the buffer list
+|:balt|		:balt		like ":badd" but also set the alternate file
 |:bdelete|	:bd[elete]	remove a buffer from the buffer list
 |:behave|	:be[have]	set mouse and selection behavior
 |:belowright|	:bel[owright]	make split window appear right or below

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1039,6 +1039,11 @@ list of buffers. |unlisted-buffer|
 		line when the buffer is first entered.  Note that other
 		commands after the + will be ignored.
 
+						 *:balt*
+:balt [+lnum] {fname}
+		Like `:badd` and also set the alternate file for the current
+		window to {fname}.
+
 :[N]bd[elete][!]			*:bd* *:bdel* *:bdelete* *E516*
 :bd[elete][!] [N]
 		Unload buffer [N] (default: current buffer) and delete it from

--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -16,7 +16,7 @@
 #define ECMD_OLDBUF          0x04    // use existing buffer if it exists
 #define ECMD_FORCEIT         0x08    // ! used in Ex command
 #define ECMD_ADDBUF          0x10    // don't edit, just add to buffer list
-
+#define ECMD_ALTBUF         0x20  // like ECMD_ADDBUF and set the alternate file
 
 /* for lnum argument in do_ecmd() */
 #define ECMD_LASTL      (linenr_T)0     /* use last position in loaded file */

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -176,6 +176,12 @@ module.cmds = {
     func='ex_edit',
   },
   {
+    command='balt',
+    flags=bit.bor(NEEDARG, FILE1, CMDARG, TRLBAR, CMDWIN),
+    addr_type='ADDR_NONE',
+    func='ex_edit',
+  },
+  {
     command='bdelete',
     flags=bit.bor(BANG, RANGE, BUFNAME, COUNT, EXTRA, TRLBAR),
     addr_type='ADDR_BUFFERS',

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7271,9 +7271,7 @@ static void ex_find(exarg_T *eap)
   }
 }
 
-/*
- * ":edit", ":badd", ":visual".
- */
+/// ":edit", ":badd", ":balt", ":visual".
 static void ex_edit(exarg_T *eap)
 {
   do_exedit(eap, NULL);
@@ -7355,6 +7353,7 @@ do_exedit(
                 // After a split we can use an existing buffer.
                 + (old_curwin != NULL ? ECMD_OLDBUF : 0)
                 + (eap->cmdidx == CMD_badd ? ECMD_ADDBUF : 0)
+                + (eap->cmdidx == CMD_balt ? ECMD_ALTBUF : 0)
                 , old_curwin == NULL ? curwin : NULL) == FAIL) {
       // Editing the file failed.  If the window was split, close it.
       if (old_curwin != NULL) {
@@ -8725,7 +8724,7 @@ ssize_t find_cmdline_var(const char_u *src, size_t *usedlen)
  * Evaluate cmdline variables.
  *
  * change '%'	    to curbuf->b_ffname
- *	  '#'	    to curwin->w_altfile
+ *	  '#'	    to curwin->w_alt_fnum
  *	  '<cword>' to word under the cursor
  *	  '<cWORD>' to WORD under the cursor
  *	  '<cexpr>' to C-expression under the cursor

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7345,7 +7345,9 @@ do_exedit(
     else if (eap->cmdidx == CMD_enew)
       readonlymode = FALSE;         /* 'readonly' doesn't make sense in an
                                        empty buffer */
-    setpcmark();
+    if (eap->cmdidx != CMD_balt && eap->cmdidx != CMD_badd) {
+      setpcmark();
+    }
     if (do_ecmd(0, (eap->cmdidx == CMD_enew ? NULL : eap->arg),
                 NULL, eap, eap->do_ecmd_lnum,
                 (buf_hide(curbuf) ? ECMD_HIDE : 0)

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -449,9 +449,9 @@ static int put_view(
                 "let s:l = %" PRId64 " - ((%" PRId64
                 " * winheight(0) + %" PRId64 ") / %" PRId64 ")\n"
                 "if s:l < 1 | let s:l = 1 | endif\n"
-                "exe s:l\n"
+                "keepjumps exe s:l\n"
                 "normal! zt\n"
-                "%" PRId64 "\n",
+                "keepjumps %" PRId64 "\n",
                 (int64_t)wp->w_cursor.lnum,
                 (int64_t)(wp->w_cursor.lnum - wp->w_topline),
                 (int64_t)(wp->w_height_inner / 2),

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -384,6 +384,17 @@ static int put_view(
     xfree(fname_esc);
   }
 
+  if (wp->w_alt_fnum) {
+    buf_T *const alt = buflist_findnr(wp->w_alt_fnum);
+
+    // Set the alternate file.
+    if (alt != NULL && alt->b_fname != NULL && *alt->b_fname != NUL
+        && (fputs("balt ", fd) < 0
+            || ses_fname(fd, alt, flagp, true) == FAIL)) {
+      return FAIL;
+    }
+  }
+
   //
   // Local mappings and abbreviations.
   //

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -388,7 +388,8 @@ static int put_view(
     buf_T *const alt = buflist_findnr(wp->w_alt_fnum);
 
     // Set the alternate file.
-    if (alt != NULL && alt->b_fname != NULL && *alt->b_fname != NUL
+    if ((flagp == &ssop_flags) && alt != NULL && alt->b_fname != NULL
+        && *alt->b_fname != NUL
         && (fputs("balt ", fd) < 0
             || ses_fname(fd, alt, flagp, true) == FAIL)) {
       return FAIL;

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -1,0 +1,10 @@
+" Tests for Vim buffer
+
+func Test_balt()
+  new SomeNewBuffer
+  balt +3 OtherBuffer
+  e #
+  call assert_equal('OtherBuffer', bufname())
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -399,6 +399,58 @@ func Test_mkview_no_file_name()
   %bwipe
 endfunc
 
+func Test_mkview_loadview_jumplist()
+  set viewdir=Xviewdir
+  au BufWinLeave * silent mkview
+  " au BufWinEnter * silent loadview
+
+  edit Xfile1
+  call setline(1, ['a', 'bbbbbbb', 'c'])
+  normal j3l
+  call assert_equal([2, 4], getcurpos()[1:2])
+  write
+
+  edit Xfile2
+  call setline(1, ['d', 'eeeeeee', 'f'])
+  normal j5l
+  call assert_equal([2, 6], getcurpos()[1:2])
+  write
+
+  edit Xfile3
+  call setline(1, ['g', 'h', 'iiiii'])
+  normal jj3l
+  call assert_equal([3, 4], getcurpos()[1:2])
+  write
+
+  " The commented :au above was moved here so that :mkview (on BufWinLeave) can
+  " run before :loadview. This is needed because Nvim's :loadview raises E484 if
+  " the view can't be opened, while Vim's silently fails instead.
+  au BufWinEnter * silent loadview
+
+  edit Xfile1
+  call assert_equal([2, 4], getcurpos()[1:2])
+  edit Xfile2
+  call assert_equal([2, 6], getcurpos()[1:2])
+  edit Xfile3
+  call assert_equal([3, 4], getcurpos()[1:2])
+
+  exe "normal \<C-O>"
+  call assert_equal('Xfile2', expand('%'))
+  call assert_equal([2, 6], getcurpos()[1:2])
+  exe "normal \<C-O>"
+  call assert_equal('Xfile1', expand('%'))
+  call assert_equal([2, 4], getcurpos()[1:2])
+
+  au! BufWinLeave
+  au! BufWinEnter
+  bwipe!
+  call delete('Xviewdir', 'rf')
+  call delete('Xfile1')
+  call delete('Xfile2')
+  call delete('Xfile3')
+  set viewdir&
+endfunc
+
 " A clean session (one empty buffer, one window, and one tab) should not
 " set any error messages when sourced because no commands should fail.
 func Test_mksession_no_errmsg()
@@ -687,6 +739,29 @@ func Test_scrolloff()
   call delete('Xtest_mks.out')
   setlocal so& siso&
   set sessionoptions&
+endfunc
+
+func Test_altfile()
+  edit Xone
+  split Xtwo
+  edit Xtwoalt
+  edit #
+  wincmd w
+  edit Xonealt
+  edit #
+  mksession! Xtest_altfile
+  only
+  bwipe Xonealt
+  bwipe Xtwoalt
+  bwipe!
+  source Xtest_altfile
+  call assert_equal('Xone', bufname())
+  call assert_equal('Xonealt', bufname('#'))
+  wincmd w
+  call assert_equal('Xtwo', bufname())
+  call assert_equal('Xtwoalt', bufname('#'))
+  only
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -317,6 +317,20 @@ func Test_mkview_open_folds()
   %bwipe
 endfunc
 
+func Test_mkview_no_balt()
+  edit Xtestfile1
+  edit Xtestfile2
+
+  mkview! Xtestview
+  bdelete Xtestfile1
+
+  source Xtestview
+  call assert_equal(0, buflisted('Xtestfile1'))
+
+  call delete('Xtestview')
+  %bwipe
+endfunc
+
 " Test :mkview with a file argument.
 func Test_mkview_file()
   " Create a view with line number and a fold.


### PR DESCRIPTION
One small difference for 8.2.2058: the `au BufWinEnter * silent loadview` line in `Test_mkview_loadview_jumplist()` was moved down a few lines until after the views are written, as `:loadview` in Nvim will throw E484 if it can't open the view (and also to avoid #13490).

Hopefully this is fine. 😄