### PR TITLE
vim-patch:8.2.{2121,2123}

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -742,6 +742,7 @@ static int pum_set_selected(int n, int repeat)
             // Edit a new, empty buffer. Set options for a "wipeout"
             // buffer.
             set_option_value("swf", 0L, NULL, OPT_LOCAL);
+            set_option_value("bl", 0L, NULL, OPT_LOCAL);
             set_option_value("bt", 0L, "nofile", OPT_LOCAL);
             set_option_value("bh", 0L, "wipe", OPT_LOCAL);
             set_option_value("diff", 0L, NULL, OPT_LOCAL);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3605,6 +3605,22 @@ theend:
   if (backpos.ga_maxlen > BACKPOS_INITIAL)
     ga_clear(&backpos);
 
+  // Make sure the end is never before the start.  Can happen when \zs and
+  // \ze are used.
+  if (REG_MULTI) {
+    const lpos_T *const start = &rex.reg_mmatch->startpos[0];
+    const lpos_T *const end = &rex.reg_mmatch->endpos[0];
+
+    if (end->lnum < start->lnum
+        || (end->lnum == start->lnum && end->col < start->col)) {
+      rex.reg_mmatch->endpos[0] = rex.reg_mmatch->startpos[0];
+    }
+  } else {
+    if (rex.reg_match->endp[0] < rex.reg_match->startp[0]) {
+      rex.reg_match->endp[0] = rex.reg_match->startp[0];
+    }
+  }
+
   return retval;
 }
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6591,6 +6591,22 @@ static long nfa_regexec_both(char_u *line, colnr_T startcol,
 #endif
 
 theend:
+  // Make sure the end is never before the start.  Can happen when \zs and
+  // \ze are used.
+  if (REG_MULTI) {
+    const lpos_T *const start = &rex.reg_mmatch->startpos[0];
+    const lpos_T *const end = &rex.reg_mmatch->endpos[0];
+
+    if (end->lnum < start->lnum
+        || (end->lnum == start->lnum && end->col < start->col)) {
+      rex.reg_mmatch->endpos[0] = rex.reg_mmatch->startpos[0];
+    }
+  } else {
+    if (rex.reg_match->endp[0] < rex.reg_match->startp[0]) {
+      rex.reg_match->endp[0] = rex.reg_match->startp[0];
+    }
+  }
+
   return retval;
 }
 

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -755,6 +755,13 @@ func Test_start_end_of_buffer_match()
   bwipe!
 endfunc
 
+func Test_ze_before_zs()
+  call assert_equal('', matchstr(' ', '\%#=1\ze \zs'))
+  call assert_equal('', matchstr(' ', '\%#=2\ze \zs'))
+  call assert_equal(repeat([''], 10), matchlist(' ', '\%#=1\ze \zs'))
+  call assert_equal(repeat([''], 10), matchlist(' ', '\%#=2\ze \zs'))
+endfunc
+
 " Check for detecting error
 func Test_regexp_error()
   set regexpengine=2


### PR DESCRIPTION
8.2.2121 has a test in `test_regexp_latin.vim`, but it isn't actually sourced for Nvim as it sets `encoding`.
8.2.2123 had a test in `test_popupwin.vim`, but I think that file is N/A, so I haven't included it.

Hopefully all this is OK.