### PR TITLE
macros.h: Remove unused CURSOR_BAR_RIGHT macro.

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -98,9 +98,6 @@
 
 # define UTF_COMPOSINGLIKE(p1, p2)  utf_composinglike((p1), (p2))
 
-// Whether to draw the vertical bar on the right side of the cell.
-# define CURSOR_BAR_RIGHT (curwin->w_p_rl && (!(State & CMDLINE) || cmdmsg_rl))
-
 // MB_PTR_ADV(): advance a pointer to the next character, taking care of
 // multi-byte characters if needed.
 // MB_PTR_BACK(): backup a pointer to the previous character, taking care of


### PR DESCRIPTION
Closes #13505.