### PR TITLE
Use oldest macOS version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           retention-days: 1
 
   macOS:
-    runs-on: macos-10.15
+    runs-on: macos-10.13
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Looks like the macOS builds aren't working on older macOS version:  https://twitter.com/gabrie_viviani/status/1337440167448244224?s=20

I think this should fix it, let me know what you think.

Thanks!