### PR TITLE
Revert "Use oldest macOS version for release workflow"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           retention-days: 1
 
   macOS:
-    runs-on: macos-10.13
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Reverts neovim/neovim#13514