### PR TITLE
unused macros: Remove a five unused macros.

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -45,8 +45,6 @@ static bool chartab_initialized = false;
     (buf)->b_chartab[(unsigned)(c) >> 6] &= ~(1ull << ((c) & 0x3f))
 #define GET_CHARTAB_TAB(chartab, c) \
     ((chartab)[(unsigned)(c) >> 6] & (1ull << ((c) & 0x3f)))
-#define GET_CHARTAB(buf, c) \
-    GET_CHARTAB_TAB((buf)->b_chartab, c)
 
 // Table used below, see init_chartab() for an explanation
 static char_u g_chartab[256];

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -964,7 +964,6 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
 
 #define PRT_PS_DEFAULT_DPI          (72)    // Default user space resolution
 #define PRT_PS_DEFAULT_FONTSIZE     (10)
-#define PRT_PS_DEFAULT_BUFFER_SIZE  (80)
 
 #define PRT_MEDIASIZE_LEN  (sizeof(prt_mediasize) / \
                             sizeof(struct prt_mediasize_S))

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -55,7 +55,6 @@
 
 #define T MT_BRANCH_FACTOR
 #define ILEN (sizeof(mtnode_t)+(2 * T) * sizeof(void *))
-#define key_t SKRAPET
 
 #define RIGHT_GRAVITY (((uint64_t)1) << 63)
 #define ANTIGRAVITY(id) ((id)&(RIGHT_GRAVITY-1))
@@ -64,8 +63,6 @@
 #define PAIRED MARKTREE_PAIRED_FLAG
 #define END_FLAG MARKTREE_END_FLAG
 #define ID_INCR (((uint64_t)1) << 2)
-
-#define PROP_MASK (RIGHT_GRAVITY|PAIRED|END_FLAG)
 
 #define rawkey(itr) (itr->node->key[itr->i])
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -206,7 +206,6 @@ typedef struct vimoption {
                                 // local option: indirect option index
   char_u      *def_val[2];      // default values for variable (vi and vim)
   LastSet last_set;             // script in which the option was last set
-# define SCTX_INIT , { 0, 0, 0 }
 } vimoption_T;
 
 #define VI_DEFAULT  0       // def_val[VI_DEFAULT] is Vi default value


### PR DESCRIPTION
Removes:
- GET_CHARTAB
- PRT_PS_DEFAULT_BUFFER_SIZE
- key_t
- PROP_MASK
- SCTX_INIT

Referring #13505.