### PR TITLE
tests: Take into account magic hyphen.

### DIFF
--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -428,9 +428,9 @@ end)
 
 describe('clean', function()
   clear()
-  ok(string.match(meths.get_option('runtimepath'), funcs.stdpath('config')) ~= nil)
+  ok(string.find(meths.get_option('runtimepath'), funcs.stdpath('config'), 1, true) ~= nil)
   clear('--clean')
-  ok(string.match(meths.get_option('runtimepath'), funcs.stdpath('config')) == nil)
+  ok(string.find(meths.get_option('runtimepath'), funcs.stdpath('config'), 1, true) == nil)
 end)
 
 describe('user config init', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1477,7 +1477,7 @@ describe("TUI", function()
 
     retry(nil, 3000, function()  -- Wait for log file to be flushed.
       local log = read_file('Xtest_tui_verbose_log') or ''
-      eq('--- Terminal info --- {{{\n', string.match(log, '--- Terminal.-\n'))
+      eq('--- Terminal info --- {{{\n', string.match(log, '%-%-%- Terminal.-\n'))
       ok(#log > 50)
     end)
   end)


### PR DESCRIPTION
In Lua patterns the hyphen works like a non-greedy version of Vim's `*`.
- Use `%-` when you need a literal hyphen.
- If you don't need a regular expression at all, use something like
  ```
  string.find(text, pattern, 1, true)
  ```
  so that the pattern is regarded as a plain, non-magical string.
  See [1] and [2] in the Lua manual.

[1]: https://www.lua.org/manual/5.1/manual.html#pdf-Patterns
[2]: https://www.lua.org/manual/5.1/manual.html#pdf-string.find