### PR TITLE
ex_getln.c: fix highlighting issue with :vlobal and :s cmds - issue 1…

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -516,7 +516,16 @@ static void may_do_incsearch_highlighting(int firstc, long count,
         if (*(ccline.cmdbuff+skiplen+i) == '/'){
 	  query[j++] = '\\';
 	}
-	query[j++] = *(ccline.cmdbuff+skiplen+i);
+	else if(*(ccline.cmdbuff+skiplen+i) == '\\' &&
+		  i+1 < strlen((const char*)(ccline.cmdbuff+skiplen)) &&
+		*(ccline.cmdbuff+skiplen+i+1) == '/'){
+	  // if the delimiter is already present, skip this one.
+	  query[j++] = '\\';
+	  query[j++] = '/';
+	  i+=1;
+	  continue;
+	}
+        query[j++] = *(ccline.cmdbuff+skiplen+i);
       }
       
       found = do_search(NULL, firstc == ':' ? '/' : firstc, query, count,

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -205,7 +205,7 @@ describe('highlight defaults', function()
     [1] = {bold = true}})
   end)
 
-  --Regression Test STASEN TODO
+  --Regression Test for issue #13141
   it('Substitute with delimiter', function()
     screen:try_resize(15,4)
     feed('ihello/world<esc>')

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -205,6 +205,24 @@ describe('highlight defaults', function()
     [1] = {bold = true}})
   end)
 
+  --Regression Test STASEN TODO
+  it('Substitute with delimiter', function()
+    screen:try_resize(15,4)
+    feed('ihello/world<esc>')
+    feed('gg:%s,lo/.o') 
+    screen:expect([[
+      hel{3:lo/wo}rld    |
+      {1:~              }|
+      {1:~              }|
+      :%s,lo/.o^      |
+    ]], {
+      [1] = {bold=true, foreground=Screen.colors.Blue},
+      [2] = {background = Screen.colors.Yellow}, --search
+      [3] = {reverse = true},
+      [4] = {foreground = Screen.colors.red} --message
+      })
+  end)
+
   it('end of file markers', function()
     screen:try_resize(53, 4)
     screen:expect([[


### PR DESCRIPTION
…3141 - reg test in ui/highlight_spec.lua
[RFC] - Fix for issue #13141, `:s`, `:smagic`, `:snomagic`, and `:vglobal` had incorrect highlighting when a delimiter other than '/' was used and '/' was present in the search pattern. I've managed to fix this by editing `do_incsearch_highlighting()` in ex_getln.c, I added a boolean parameter that is to be set to true when incsearch is handling one of these functions, then I copy the pattern and insert backslashes before the forward slashes to fool the `do_search()` function in `may_do_incsearch_highlighting()`. No further action was needed because nvim was using the correct pattern when making the substitution. When `set inccommand=...` is defined the issue was not present, because in that case a different search function was called to handle screen highlighting; `; `search_regcomp` in `search.c`. I've added a regression test to functional/ui/highlight_spec.lua.

Please give me feedback, this is one of my first open source contributions, otherwise it should be set to pull. :) 