### PR TITLE
fix: also splice extmarks in preview buffers

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -50,7 +50,7 @@ function M._create_parser(bufnr, lang, opts)
     end
   end
 
-  a.nvim_buf_attach(self.bufnr, false, {on_bytes=bytes_cb, on_detach=detach_cb})
+  a.nvim_buf_attach(self.bufnr, false, {on_bytes=bytes_cb, on_detach=detach_cb, preview=true})
 
   self:parse()
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -121,6 +121,8 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
 ///               - buffer handle
 ///             - utf_sizes: include UTF-32 and UTF-16 size of the replaced
 ///               region, as args to `on_lines`.
+///             - preview: also attach to command preview (i.e. 'inccommand')
+///               events.
 /// @param[out] err Error details, if any
 /// @return False if attach failed (invalid parameter, or buffer isn't loaded);
 ///         otherwise True. TODO: LUA_API_NO_EVAL
@@ -176,6 +178,12 @@ Boolean nvim_buf_attach(uint64_t channel_id,
         goto error;
       }
       cb.utf_sizes = v->data.boolean;
+    } else if (is_lua && strequal("preview", k.data)) {
+      if (v->type != kObjectTypeBoolean) {
+        api_set_error(err, kErrorTypeValidation, "preview must be boolean");
+        goto error;
+      }
+      cb.preview = v->data.boolean;
     } else {
       api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
       goto error;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -491,9 +491,10 @@ typedef struct {
   LuaRef on_changedtick;
   LuaRef on_detach;
   bool utf_sizes;
+  bool preview;
 } BufUpdateCallbacks;
 #define BUF_UPDATE_CALLBACKS_INIT { LUA_NOREF, LUA_NOREF, LUA_NOREF, \
-                                    LUA_NOREF, false }
+                                    LUA_NOREF, false, false }
 
 EXTERN int curbuf_splice_pending INIT(= 0);
 

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -237,7 +237,7 @@ void buf_updates_send_changes(buf_T *buf,
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
-    if (cb.on_lines != LUA_NOREF) {
+    if (cb.on_lines != LUA_NOREF && (cb.preview || !(State & CMDPREVIEW))) {
       Array args = ARRAY_DICT_INIT;
       Object items[8];
       args.size = 6;  // may be increased to 8 below
@@ -298,7 +298,7 @@ void buf_updates_send_splice(
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
-    if (cb.on_bytes != LUA_NOREF) {
+    if (cb.on_bytes != LUA_NOREF && (cb.preview || !(State & CMDPREVIEW))) {
       FIXED_TEMP_ARRAY(args, 11);
 
       // the first argument is always the buffer handle

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3909,17 +3909,13 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
 
           ADJUST_SUB_FIRSTLNUM();
 
-          // TODO(bfredl): adjust also in preview, because decorations?
-          // this has some robustness issues, will look into later.
-          bool do_splice = !preview;
+          // TODO(bfredl): this has some robustness issues, look into later.
           bcount_t replaced_bytes = 0;
           lpos_T start = regmatch.startpos[0], end = regmatch.endpos[0];
-          if (do_splice) {
-            for (i = 0; i < nmatch-1; i++) {
-              replaced_bytes += STRLEN(ml_get(lnum_start+i)) + 1;
-            }
-            replaced_bytes += end.col - start.col;
+          for (i = 0; i < nmatch-1; i++) {
+            replaced_bytes += STRLEN(ml_get(lnum_start+i)) + 1;
           }
+          replaced_bytes += end.col - start.col;
 
 
           // Now the trick is to replace CTRL-M chars with a real line
@@ -3964,14 +3960,12 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
           current_match.end.col = new_endcol;
           current_match.end.lnum = lnum;
 
-          if (do_splice) {
-            int matchcols = end.col - ((end.lnum == start.lnum)
-                                       ? start.col : 0);
-            int subcols = new_endcol - ((lnum == lnum_start) ? start_col : 0);
-            extmark_splice(curbuf, lnum_start-1, start_col,
-                           end.lnum-start.lnum, matchcols, replaced_bytes,
-                           lnum-lnum_start, subcols, sublen-1, kExtmarkUndo);
-          }
+          int matchcols = end.col - ((end.lnum == start.lnum)
+                                     ? start.col : 0);
+          int subcols = new_endcol - ((lnum == lnum_start) ? start_col : 0);
+          extmark_splice(curbuf, lnum_start-1, start_col,
+                         end.lnum-start.lnum, matchcols, replaced_bytes,
+                         lnum-lnum_start, subcols, sublen-1, kExtmarkUndo);
         }
 
 


### PR DESCRIPTION
We indeed need to adjust extmarks in preview windows.

Should I add a test for that ?

Fixes #12967