### PR TITLE
vim-patch:8.2.2147: quickfix window title not updated in all tab pages

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3824,17 +3824,21 @@ static buf_T *qf_find_buf(qf_info_T *qi)
   return NULL;
 }
 
-/// Update the w:quickfix_title variable in the quickfix/location list window
+/// Update the w:quickfix_title variable in the quickfix/location list window in
+/// all the tab pages.
 static void qf_update_win_titlevar(qf_info_T *qi)
+  FUNC_ATTR_NONNULL_ALL
 {
-  win_T *win;
+  qf_list_T *const qfl = qf_get_curlist(qi);
+  win_T *const save_curwin = curwin;
 
-  if ((win = qf_find_win(qi)) != NULL) {
-    win_T *curwin_save = curwin;
-    curwin = win;
-    qf_set_title_var(qf_get_curlist(qi));
-    curwin = curwin_save;
+  FOR_ALL_TAB_WINDOWS(tp, win) {
+    if (is_qf_win(win, qi)) {
+      curwin = win;
+      qf_set_title_var(qfl);
+    }
   }
+  curwin = save_curwin;
 }
 
 // Find the quickfix buffer.  If it exists, update the contents.

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3762,6 +3762,30 @@ func Test_qftitle()
   call setqflist([], 'r', {'items' : [{'filename' : 'a.c', 'lnum' : 10}]})
   call assert_equal('Errors', w:quickfix_title)
   cclose
+
+  " Switching to another quickfix list in one tab page should update the
+  " quickfix window title and statusline in all the other tab pages also
+  call setqflist([], 'f')
+  %bw!
+  cgetexpr ['file_one:1:1: error in the first quickfix list']
+  call setqflist([], 'a', {'title': 'first quickfix list'})
+  cgetexpr ['file_two:2:1: error in the second quickfix list']
+  call setqflist([], 'a', {'title': 'second quickfix list'})
+  copen
+  wincmd t
+  tabnew two
+  copen
+  wincmd t
+  colder
+  call assert_equal('first quickfix list', gettabwinvar(1, 2, 'quickfix_title'))
+  call assert_equal('first quickfix list', gettabwinvar(2, 2, 'quickfix_title'))
+  call assert_equal(1, tabpagewinnr(1))
+  call assert_equal(1, tabpagewinnr(2))
+  tabnew
+  call setqflist([], 'a', {'title': 'new quickfix title'})
+  call assert_equal('new quickfix title', gettabwinvar(1, 2, 'quickfix_title'))
+  call assert_equal('new quickfix title', gettabwinvar(2, 2, 'quickfix_title'))
+  %bw!
 endfunc
 
 func Test_lbuffer_with_bwipe()


### PR DESCRIPTION
Problem:    Quickfix window title not updated in all tab pages.
Solution:   Update the quickfix window title in all tab pages. (Yegappan
            Lakshmanan, closes vim/vim#7481, closes vim/vim#7466)
https://github.com/vim/vim/commit/530bed993e41bda6f717a8ddd0acb39464f95336