### PR TITLE
vim-patch:8.1.0734,8.2.{119,234,2149,2150,2151,2153,2154}

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -893,6 +893,9 @@ void ex_mkrc(exarg_T *eap)
                           && (*flagp & SSOP_OPTIONS))) {
       failed |= (makemap(fd, NULL) == FAIL
                  || makeset(fd, OPT_GLOBAL, false) == FAIL);
+      if (p_hls && fprintf(fd, "%s", "set hlsearch\n") < 0) {
+        failed = true;
+      }
     }
 
     if (!failed && view_session) {
@@ -949,9 +952,14 @@ void ex_mkrc(exarg_T *eap)
       }
       if (fprintf(fd,
                   "%s",
-                  "let &g:so = s:so_save | let &g:siso = s:siso_save\n"
-                  "doautoall SessionLoadPost\n")
+                  "let &g:so = s:so_save | let &g:siso = s:siso_save\n")
           < 0) {
+        failed = true;
+      }
+      if (no_hlsearch && fprintf(fd, "%s", "nohlsearch\n") < 0) {
+        failed = true;
+      }
+      if (fprintf(fd, "%s", "doautoall SessionLoadPost\n") < 0) {
         failed = true;
       }
       if (eap->cmdidx == CMD_mksession) {

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -20,6 +20,7 @@ set tags=./tags,tags
 set undodir^=.
 set wildoptions=
 set startofline
+set sessionoptions&vi
 
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -128,6 +128,7 @@ func Test_mksession()
   call delete('Xtest_mks.out')
   call delete(tmpfile)
   let &wrap = wrap_save
+  set sessionoptions&
 endfunc
 
 func Test_mksession_winheight()
@@ -154,7 +155,7 @@ func Test_mksession_rtp()
     return
   endif
   new
-  set sessionoptions+=options
+  set sessionoptions&vi
   let _rtp=&rtp
   " Make a real long (invalid) runtimepath value,
   " that should exceed PATH_MAX (hopefully)
@@ -174,6 +175,7 @@ func Test_mksession_rtp()
   call assert_equal(expected, li)
 
   call delete('Xtest_mks.out')
+  set sessionoptions&
 endfunc
 
 " Verify that arglist is stored correctly to the session file.
@@ -217,6 +219,25 @@ func Test_mksession_one_buffer_two_windows()
   bwipe!
   call delete('Xtest_mks.out')
 endfunc
+
+if has('extra_search')
+
+func Test_mksession_hlsearch()
+  set sessionoptions&vi
+  set hlsearch
+  mksession! Xtest_mks.out
+  nohlsearch
+  source Xtest_mks.out
+  call assert_equal(1, v:hlsearch, 'session should restore search highlighting state')
+  nohlsearch
+  mksession! Xtest_mks.out
+  source Xtest_mks.out
+  call assert_equal(0, v:hlsearch, 'session should restore search highlighting state')
+  set sessionoptions&
+  call delete('Xtest_mks.out')
+endfunc
+
+endif
 
 " Test :mkview with a file argument.
 func Test_mkview_file()


### PR DESCRIPTION
Problem:    The hlsearch state is not stored in a session file.
Solution:   Add "nohlsearch" if appropriate. (Jason Franklin)
https://github.com/vim/vim/commit/e3c74d249ac36404d8af25f74baf335d143b30e3

Vi default for 'sessionoptions' includes 'options'.
Use 'set sessionoptions&vi' to use Vim's default 'sessionoptions'.
If a test sets 'sessionoptions',
reset 'sessionoptions' at the end of the test.