### PR TITLE
Make vim.lsp.util.symbols_to_items walk iteratively to improve performance

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1704,7 +1704,9 @@ function M.symbols_to_items(symbols, bufnr)
         })
         if symbol.children then
           for _, v in ipairs(_symbols_to_items(symbol.children, _items, _bufnr)) do
-            vim.list_extend(_items, v)
+            for _, s in ipairs(v) do
+              table.insert(_items, s)
+            end
           end
         end
       end


### PR DESCRIPTION
I made this simple change beacause i've found that walking recursively slow down the function a lot, for example taking some big javascript files, in my laptop the recursive version take up to 10 seconds, while the iterative function take a time in the order of millisecond.
I don't know why this is causing so much overhead, because i don't know much about lua, so this pull request it's more about askiing you why, and some possible solution about that.