### PR TITLE
[RDY] Fix problem with doautocmd and modeline

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1063,7 +1063,7 @@ function M.display(diagnostics, bufnr, client_id, config)
     M.set_signs(diagnostics, bufnr, client_id, nil, signs_opts)
   end
 
-  vim.api.nvim_command("doautocmd User LspDiagnosticsChanged")
+  vim.api.nvim_command("doautocmd <nomodeline> User LspDiagnosticsChanged")
 end
 -- }}}
 -- Diagnostic User Functions {{{

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -60,7 +60,7 @@ local function progress_callback(_, _, params, client_id)
     table.insert(client.messages, {content = val, show_once = true, shown = 0})
   end
 
-  vim.api.nvim_command("doautocmd User LspProgressUpdate")
+  vim.api.nvim_command("doautocmd <nomodeline> User LspProgressUpdate")
 end
 
 M['$/progress'] = progress_callback


### PR DESCRIPTION
This fixes an issue i had trying to integrate lsp diagnostics into my statusline. I used `au User LspDiagnosticsChanged redrawstatus!` to redraw my statusline when lsp diagnostics change. Because neovim uses `doautocmd User LspDiagnosticsChanged` to apply the autocommand, modelines get processed again (see `h: doautocmd`). Fortunately this can be suppressed using the `<nomodeline>` flag. I replaced every `doautocmd` call, that issues a User command, with `doautocmd <nomodeline>`.

### Example
Use the following file and command to reproduce: `nvim --clean -u test.vim test.vim`
```vim
" Test {{{
set modeline
au User Test echom 'test'
" }}}

" vim: foldmethod=marker foldenable foldlevel=0
```
![Peek 2020-12-21 12-50](https://user-images.githubusercontent.com/9465658/102782365-87109400-4399-11eb-92a6-108081d92885.gif)
