### PR TITLE
nvim_buf_set_text

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -523,10 +523,10 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer,
                        ArrayOf(String) replacement, Error *err)
   FUNC_API_SINCE(7)
 {
+  FIXED_TEMP_ARRAY(scratch, 1);
   if (replacement.size == 0) {
-    String s = { .data = "", .size = 0 };
-    ADD(replacement, STRING_OBJ(s));
-    replacement.size = 1;
+    scratch.items[0] = STRING_OBJ(STATIC_CSTR_AS_STRING(""));
+    replacement = scratch;
   }
 
   buf_T *buf = find_buffer_by_handle(buffer, err);

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1369,6 +1369,22 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id,
     return 0;
   }
 
+  bool right_gravity = true;
+  for (size_t i = 0; i < opts.size; i++) {
+    String k = opts.items[i].key;
+    Object *v = &opts.items[i].value;
+    if (strequal("right_gravity", k.data)) {
+      if (v->type != kObjectTypeBoolean) {
+        api_set_error(err, kErrorTypeValidation, "right_gravity is not a boolean");
+        return 0;
+      }
+      right_gravity = v->data.boolean;
+    } else {
+      api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
+      return 0;
+    }
+  }
+
   size_t len = 0;
   if (line < 0 || line > buf->b_ml.ml_line_count) {
     api_set_error(err, kErrorTypeValidation, "line value outside range");
@@ -1527,6 +1543,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id,
   }
 
   return (Integer)id;
+  /* id_num = extmark_set(buf, (uint64_t)ns_id, id_num, */
+  /*                      (int)line, (colnr_T)col, kExtmarkUndo, right_gravity); */
 
 error:
   clear_virttext(&virt_text);

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -526,7 +526,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   FUNC_API_SINCE(7)
 {
   if (replacement.size == 0) {
-    String s = {.data = "", .size = 0};
+    String s = { .data = "", .size = 0 };
     ADD(replacement, STRING_OBJ(s));
     replacement.size = 1;
   }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -710,8 +710,6 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust marks if we managed to switch to a window that holds
-  // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start_row,
               (linenr_T)end_row,
               MAXLNUM,

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -362,22 +362,9 @@ void nvim_buf_set_lines(uint64_t channel_id,
     return;
   }
 
-  for (size_t i = 0; i < replacement.size; i++) {
-    if (replacement.items[i].type != kObjectTypeString) {
-      api_set_error(err,
-                    kErrorTypeValidation,
-                    "All items in the replacement array must be strings");
-      return;
-    }
-    // Disallow newlines in the middle of the line.
-    if (channel_id != VIML_INTERNAL_CALL) {
-      const String l = replacement.items[i].data.string;
-      if (memchr(l.data, NL, l.size)) {
-        api_set_error(err, kErrorTypeValidation,
-                      "String cannot contain newlines");
-        return;
-      }
-    }
+  bool disallow_nl = (channel_id != VIML_INTERNAL_CALL);
+  if (!check_string_array(replacement, disallow_nl, err)) {
+    return;
   }
 
   size_t new_len = replacement.size;
@@ -485,6 +472,153 @@ end:
   xfree(lines);
   aucmd_restbuf(&aco);
   try_end(err);
+}
+
+void nvim_buf_set_text(uint64_t channel_id,
+                       Buffer buffer,
+                       Integer start_row,
+                       Integer start_col,
+                       Integer end_row,
+                       Integer end_col,
+                       ArrayOf(String) replacement,
+                       Error *err)
+  FUNC_API_SINCE(7)
+{
+  // TODO: treat [] as [''] for convenience
+  assert(replacement.size > 0);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+  if (!buf) {
+    return;
+  }
+  size_t new_len = replacement.size;
+
+  // TODO: do the nl-for-NUL dance as well?
+  bool disallow_nl = (channel_id != VIML_INTERNAL_CALL);
+  if (!check_string_array(replacement, disallow_nl, err)) {
+    return;
+  }
+
+  // TODO: check range is ordered and everything!
+  // start_row, end_row within buffer len (except add text past the end?)
+  char *str_at_start = (char *)ml_get_buf(buf, start_row+1, false);
+  if (start_col < 0 || (size_t)start_col > strlen(str_at_start)) {
+    api_set_error(err, kErrorTypeValidation, "start_col out of bounds");
+    return;
+  }
+
+  char *str_at_end = (char *)ml_get_buf(buf, end_row+1, false);
+  size_t len_at_end = strlen(str_at_end);
+  if (end_col < 0 || (size_t)end_col > len_at_end) {
+    api_set_error(err, kErrorTypeValidation, "end_col out of bounds");
+    return;
+  }
+
+  String first_item = replacement.items[0].data.string;
+  size_t firstlen = (size_t)start_col+first_item.size;
+  size_t last_part_len = strlen(str_at_end) - (size_t)end_col;
+  if (replacement.size == 1) {
+    firstlen += last_part_len;
+  }
+  char *first = xmallocz(firstlen), *last = NULL;
+  memcpy(first, str_at_start, (size_t)start_col);
+  memcpy(first+start_col, first_item.data, first_item.size);
+  if (replacement.size == 1) {
+    memcpy(first+start_col+first_item.size, str_at_end+end_col, last_part_len);
+  } else {
+    String last_item = replacement.items[replacement.size-1].data.string;
+    last = xmallocz(last_item.size+last_part_len);
+    memcpy(last, last_item.data, last_item.size);
+    memcpy(last+last_item.size, str_at_end+end_col, last_part_len);
+  }
+
+  char **lines = (new_len != 0) ? xcalloc(new_len, sizeof(char *)) : NULL;
+  lines[0] = first;
+  for (size_t i = 1; i < new_len-1; i++) {
+    lines[i] = replacement.items[i].data.string.data;
+  }
+  if (replacement.size > 1) {
+    lines[replacement.size-1] = last;
+  }
+
+  try_start();
+  aco_save_T aco;
+  aucmd_prepbuf(&aco, (buf_T *)buf);
+
+  if (!MODIFIABLE(buf)) {
+    api_set_error(err, kErrorTypeException, "Buffer is not 'modifiable'");
+    goto end;
+  }
+
+  // TODO: dubbel KOLLA KOLLA indexen här
+  if (u_save((linenr_T)start_row, (linenr_T)end_row+2) == FAIL) {
+    api_set_error(err, kErrorTypeException, "Failed to save undo information");
+    goto end;
+  }
+
+
+  ptrdiff_t extra = 0;  // lines added to text, can be negative
+  size_t old_len = (size_t)(end_row-start_row+1);
+
+  // If the size of the range is reducing (ie, new_len < old_len) we
+  // need to delete some old_len. We do this at the start, by
+  // repeatedly deleting line "start".
+  size_t to_delete = (new_len < old_len) ? (size_t)(old_len - new_len) : 0;
+  for (size_t i = 0; i < to_delete; i++) {
+    if (ml_delete((linenr_T)start_row+1, false) == FAIL) {
+      api_set_error(err, kErrorTypeException, "Failed to delete line");
+      goto end;
+    }
+  }
+
+  if (to_delete > 0) {
+    extra -= (ptrdiff_t)to_delete;
+  }
+
+  // For as long as possible, replace the existing old_len with the
+  // new old_len. This is a more efficient operation, as it requires
+  // less memory allocation and freeing.
+  size_t to_replace = old_len < new_len ? old_len : new_len;
+  for (size_t i = 0; i < to_replace; i++) {
+    int64_t lnum = start_row + 1 + (int64_t)i;
+
+    if (lnum >= MAXLNUM) {
+      api_set_error(err, kErrorTypeValidation, "Index value is too high");
+      goto end;
+    }
+
+    if (ml_replace((linenr_T)lnum, (char_u *)lines[i], false) == FAIL) {
+      api_set_error(err, kErrorTypeException, "Failed to replace line");
+      goto end;
+    }
+    // Mark lines that haven't been passed to the buffer as they need
+    // to be freed later
+    lines[i] = NULL;
+  }
+
+  // Now we may need to insert the remaining new old_len
+  for (size_t i = to_replace; i < new_len; i++) {
+    int64_t lnum = start_row + (int64_t)i;
+
+    if (lnum >= MAXLNUM) {
+      api_set_error(err, kErrorTypeValidation, "Index value is too high");
+      goto end;
+    }
+
+    if (ml_append((linenr_T)lnum, (char_u *)lines[i], 0, false) == FAIL) {
+      api_set_error(err, kErrorTypeException, "Failed to insert line");
+      goto end;
+    }
+
+    // Same as with replacing, but we also need to free lines
+    xfree(lines[i]);
+    lines[i] = NULL;
+    extra++;
+  }
+
+end:
+  aucmd_restbuf(&aco);
+  try_end(err);
+  
 }
 
 /// Returns the byte offset of a line (0-indexed). |api-indexing|

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -490,13 +490,6 @@ void nvim_buf_set_text(uint64_t channel_id,
   if (!buf) {
     return;
   }
-  size_t new_len = replacement.size;
-
-  // TODO: do the nl-for-NUL dance as well?
-  bool disallow_nl = (channel_id != VIML_INTERNAL_CALL);
-  if (!check_string_array(replacement, disallow_nl, err)) {
-    return;
-  }
 
   // TODO: check range is ordered and everything!
   // start_row, end_row within buffer len (except add text past the end?)
@@ -513,6 +506,13 @@ void nvim_buf_set_text(uint64_t channel_id,
     return;
   }
 
+  bool disallow_nl = (channel_id != VIML_INTERNAL_CALL);
+  if (!check_string_array(replacement, disallow_nl, err)) {
+    return;
+  }
+
+  size_t new_len = replacement.size;
+
   String first_item = replacement.items[0].data.string;
   String last_item = replacement.items[replacement.size-1].data.string;
   size_t firstlen = (size_t)start_col+first_item.size;
@@ -523,18 +523,26 @@ void nvim_buf_set_text(uint64_t channel_id,
   char *first = xmallocz(firstlen), *last = NULL;
   memcpy(first, str_at_start, (size_t)start_col);
   memcpy(first+start_col, first_item.data, first_item.size);
+  memchrsub(first+start_col, NUL, NL, first_item.size);
   if (replacement.size == 1) {
     memcpy(first+start_col+first_item.size, str_at_end+end_col, last_part_len);
   } else {
     last = xmallocz(last_item.size+last_part_len);
     memcpy(last, last_item.data, last_item.size);
+    memchrsub(last, NUL, NL, last_item.size);
     memcpy(last+last_item.size, str_at_end+end_col, last_part_len);
   }
 
   char **lines = (new_len != 0) ? xcalloc(new_len, sizeof(char *)) : NULL;
   lines[0] = first;
   for (size_t i = 1; i < new_len-1; i++) {
-    lines[i] = replacement.items[i].data.string.data;
+    const String l = replacement.items[i].data.string;
+
+    // Fill lines[i] with l's contents. Convert NULs to newlines as required by
+    // NL-used-for-NUL.
+    lines[i] = xmemdupz(l.data, l.size);
+    memchrsub(lines[i], NUL, NL, l.size);
+    /* lines[i] = replacement.items[i].data.string.data; */
   }
   if (replacement.size > 1) {
     lines[replacement.size-1] = last;
@@ -610,6 +618,7 @@ void nvim_buf_set_text(uint64_t channel_id,
     }
 
     // Same as with replacing, but we also need to free lines
+    xfree(lines[i]);
     lines[i] = NULL;
     extra++;
   }
@@ -636,6 +645,10 @@ void nvim_buf_set_text(uint64_t channel_id,
   fix_cursor((linenr_T)start_row+1, (linenr_T)end_row+1, (linenr_T)extra);
 
 end:
+  for (size_t i = 0; i < new_len; i++) {
+    xfree(lines[i]);
+  }
+  xfree(lines);
   aucmd_restbuf(&aco);
   try_end(err);
 }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -522,7 +522,7 @@ void nvim_buf_set_text(uint64_t channel_id,
                        Error *err)
   FUNC_API_SINCE(7)
 {
-  // TODO: treat [] as [''] for convenience
+  // TODO(chentau): treat [] as [''] for convenience
   assert(replacement.size > 0);
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (!buf) {
@@ -577,7 +577,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   } else {
       char_u *line;
       old_byte += (bcount_t)strlen(str_at_start) - start_col;
-      for (size_t i = 0; i < (size_t)end_row - start_row; i++){
+      for (size_t i = 0; i < (size_t)(end_row - start_row); i++) {
           int64_t lnum = start_row + (int64_t)i;
 
           if (lnum >= MAXLNUM) {
@@ -1577,8 +1577,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id,
   }
 
   return (Integer)id;
-  /* id_num = extmark_set(buf, (uint64_t)ns_id, id_num, */
-  /*                      (int)line, (colnr_T)col, kExtmarkUndo, right_gravity); */
 
 error:
   clear_virttext(&virt_text);

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -586,18 +586,13 @@ void nvim_buf_set_text(uint64_t channel_id,
   } else {
       const char *bufline;
       old_byte += (bcount_t)strlen(str_at_start) - start_col;
-      for (int64_t i = 0; i < end_row - start_row; i++) {
+      for (int64_t i = 1; i < end_row - start_row; i++) {
           int64_t lnum = start_row + i;
 
-          if (lnum >= MAXLNUM) {
-            api_set_error(err, kErrorTypeValidation, "Index value is too high");
-            goto end;
-          }
-
           bufline = (char *)ml_get_buf(buf, lnum, false);
-          old_byte += (bcount_t)(strlen(bufline));
+          old_byte += (bcount_t)(strlen(bufline))+1;
       }
-      old_byte += (bcount_t)end_col;
+      old_byte += (bcount_t)end_col+1;
   }
 
   String first_item = replacement.items[0].data.string;
@@ -631,11 +626,11 @@ void nvim_buf_set_text(uint64_t channel_id,
     // NL-used-for-NUL.
     lines[i] = xmemdupz(l.data, l.size);
     memchrsub(lines[i], NUL, NL, l.size);
-    new_byte += (bcount_t)(l.size);
+    new_byte += (bcount_t)(l.size)+1;
   }
   if (replacement.size > 1) {
     lines[replacement.size-1] = last;
-    new_byte += (bcount_t)(last_item.size);
+    new_byte += (bcount_t)(last_item.size)+1;
   }
 
   try_start();
@@ -724,7 +719,7 @@ void nvim_buf_set_text(uint64_t channel_id,
               kExtmarkNOOP);
 
   colnr_T col_extent = (colnr_T)(end_col
-                                 - ((end_col > start_col) ? start_col : 0));
+                                 - ((end_row == start_row) ? start_col : 0));
   extmark_splice(buf, (int)start_row-1, (colnr_T)start_col,
                  (int)(end_row-start_row), col_extent, old_byte,
                  (int)new_len-1, (colnr_T)last_item.size, new_byte,

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -541,7 +541,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   // check range is ordered and everything!
   // start_row, end_row within buffer len (except add text past the end?)
   start_row = normalize_index(buf, start_row, &oob);
-  if (oob) {
+  if (oob || start_row == buf->b_ml.ml_line_count + 1) {
     api_set_error(err, kErrorTypeValidation, "start_row out of bounds");
     return;
   }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -500,7 +500,8 @@ end:
 /// Indexing is zero-based, end-exclusive.
 ///
 /// To insert text at a given index, set `start` and `end` ranges to the same
-/// index. To delete a range, set `replacement` to an empty array.
+/// index. To delete a range, set `replacement` to an array containing
+/// an empty string.
 ///
 /// Prefer nvim_buf_set_lines when modifying entire lines.
 ///
@@ -568,6 +569,8 @@ void nvim_buf_set_text(uint64_t channel_id,
     return;
   }
 
+  size_t new_len = replacement.size;
+
   bcount_t new_byte = 0;
   bcount_t old_byte = 0;
 
@@ -575,7 +578,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   if (start_row == end_row) {
       old_byte = (bcount_t)end_col - start_col;
   } else {
-      char_u *line;
+      char *line;
       old_byte += (bcount_t)strlen(str_at_start) - start_col;
       for (size_t i = 0; i < (size_t)(end_row - start_row); i++) {
           int64_t lnum = start_row + (int64_t)i;
@@ -585,13 +588,11 @@ void nvim_buf_set_text(uint64_t channel_id,
             goto end;
           }
 
-          line = ml_get_buf(buf, lnum, false);
-          old_byte += (bcount_t)(strlen((char *)line));
+          line = (char *)ml_get_buf(buf, lnum, false);
+          old_byte += (bcount_t)(strlen(line));
       }
       old_byte += end_col;
   }
-
-  size_t new_len = replacement.size;
 
   String first_item = replacement.items[0].data.string;
   String last_item = replacement.items[replacement.size-1].data.string;

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -474,6 +474,23 @@ end:
   try_end(err);
 }
 
+/// Sets (replaces) a range in the buffer.
+///
+/// Indexing is zero-based, end-exclusive.
+///
+/// To insert text at a given index, set `start` and `end` ranges to the same
+/// index. To delete a range, set `replacement` to an empty array.
+///
+/// Prefer nvim_buf_set_lines when modifying entire lines.
+///
+/// @param channel_id
+/// @param buffer           Buffer handle, or 0 for current buffer
+/// @param start_row        First line index
+/// @param start_column     Last column
+/// @param end_row          Last line index (exclusive)
+/// @param end_column       Last column
+/// @param replacement      Array of lines to use as replacement
+/// @param[out] err         Error details, if any
 void nvim_buf_set_text(uint64_t channel_id,
                        Buffer buffer,
                        Integer start_row,

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -577,7 +577,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   } else {
       char_u *line;
       old_byte += (bcount_t)strlen(str_at_start) - start_col;
-      for (size_t i = 0; i < (bcount_t)end_row - start_row; i++){
+      for (size_t i = 0; i < (size_t)end_row - start_row; i++){
           int64_t lnum = start_row + (int64_t)i;
 
           if (lnum >= MAXLNUM) {

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -309,6 +309,27 @@ end:
   return rv;
 }
 
+static bool check_string_array(Array arr, bool disallow_nl, Error *err)
+{
+  for (size_t i = 0; i < arr.size; i++) {
+    if (arr.items[i].type != kObjectTypeString) {
+      api_set_error(err,
+                    kErrorTypeValidation,
+                    "All items in the replacement array must be strings");
+      return false;
+    }
+    // Disallow newlines in the middle of the line.
+    if (disallow_nl) {
+      const String l = arr.items[i].data.string;
+      if (memchr(l.data, NL, l.size)) {
+        api_set_error(err, kErrorTypeValidation,
+                      "String cannot contain newlines");
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 /// Sets (replaces) a line-range in the buffer.
 ///
@@ -519,10 +540,10 @@ void nvim_buf_set_text(uint64_t channel_id,
   }
 
   end_row = normalize_index(buf, end_row, &oob);
-  /* if (oob) { */
-  /*   api_set_error(err, kErrorTypeValidation, "end_row out of bounds"); */
-  /*   return; */
-  /* } */
+  if (oob) {
+    api_set_error(err, kErrorTypeValidation, "end_row out of bounds");
+    return;
+  }
 
   char *str_at_start = (char *)ml_get_buf(buf, start_row, false);
   if (start_col < 0 || (size_t)start_col > strlen(str_at_start)) {
@@ -547,10 +568,36 @@ void nvim_buf_set_text(uint64_t channel_id,
     return;
   }
 
+  bcount_t new_byte = 0;
+  bcount_t old_byte = 0;
+
+  // calculate byte size of old region before it gets modified/deleted
+  if (start_row == end_row) {
+      old_byte = (bcount_t)end_col - start_col;
+  } else {
+      char_u *line;
+      old_byte += (bcount_t)strlen(str_at_start) - start_col;
+      for (size_t i = 0; i < (bcount_t)end_row - start_row; i++){
+          int64_t lnum = start_row + (int64_t)i;
+
+          if (lnum >= MAXLNUM) {
+            api_set_error(err, kErrorTypeValidation, "Index value is too high");
+            goto end;
+          }
+
+          line = ml_get_buf(buf, lnum, false);
+          old_byte += (bcount_t)(strlen((char *)line));
+      }
+      old_byte += end_col;
+  }
+
   size_t new_len = replacement.size;
 
   String first_item = replacement.items[0].data.string;
   String last_item = replacement.items[replacement.size-1].data.string;
+
+  new_byte += (bcount_t)(first_item.size);
+
   size_t firstlen = (size_t)start_col+first_item.size;
   size_t last_part_len = strlen(str_at_end) - (size_t)end_col;
   if (replacement.size == 1) {
@@ -578,10 +625,11 @@ void nvim_buf_set_text(uint64_t channel_id,
     // NL-used-for-NUL.
     lines[i] = xmemdupz(l.data, l.size);
     memchrsub(lines[i], NUL, NL, l.size);
-    /* lines[i] = replacement.items[i].data.string.data; */
+    new_byte += (bcount_t)(l.size);
   }
   if (replacement.size > 1) {
     lines[replacement.size-1] = last;
+    new_byte += (bcount_t)(last_item.size);
   }
 
   try_start();
@@ -593,7 +641,7 @@ void nvim_buf_set_text(uint64_t channel_id,
     goto end;
   }
 
-  if (u_save((linenr_T)start_row - 1, (linenr_T)end_row) == FAIL) {
+  if (u_save((linenr_T)start_row - 1, (linenr_T)end_row + 1) == FAIL) {
     api_set_error(err, kErrorTypeException, "Failed to save undo information");
     goto end;
   }
@@ -670,8 +718,10 @@ void nvim_buf_set_text(uint64_t channel_id,
   colnr_T col_extent = (colnr_T)(end_col
                                  - ((end_col > start_col) ? start_col : 0));
   extmark_splice(buf, (int)start_row-1, (colnr_T)start_col,
-                 (int)(end_row-start_row), col_extent,
-                 (int)new_len-1, (colnr_T)last_item.size, kExtmarkUndo);
+                 (int)(end_row-start_row), col_extent, (bcount_t)(old_byte),
+                 (int)new_len-1, (colnr_T)last_item.size, (bcount_t)new_byte,
+                 kExtmarkUndo);
+
 
   changed_lines((linenr_T)start_row, 0, (linenr_T)end_row, (long)extra, true);
 
@@ -1367,22 +1417,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id,
   if (!ns_initialized((uint64_t)ns_id)) {
     api_set_error(err, kErrorTypeValidation, "Invalid ns_id");
     return 0;
-  }
-
-  bool right_gravity = true;
-  for (size_t i = 0; i < opts.size; i++) {
-    String k = opts.items[i].key;
-    Object *v = &opts.items[i].value;
-    if (strequal("right_gravity", k.data)) {
-      if (v->type != kObjectTypeBoolean) {
-        api_set_error(err, kErrorTypeValidation, "right_gravity is not a boolean");
-        return 0;
-      }
-      right_gravity = v->data.boolean;
-    } else {
-      api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
-      return 0;
-    }
   }
 
   size_t len = 0;

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -491,18 +491,37 @@ void nvim_buf_set_text(uint64_t channel_id,
     return;
   }
 
-  // TODO: check range is ordered and everything!
+  bool oob = false;
+
+  // check range is ordered and everything!
   // start_row, end_row within buffer len (except add text past the end?)
-  char *str_at_start = (char *)ml_get_buf(buf, start_row+1, false);
+  start_row = normalize_index(buf, start_row, &oob);
+  if (oob) {
+    api_set_error(err, kErrorTypeValidation, "start_row out of bounds");
+    return;
+  }
+
+  end_row = normalize_index(buf, end_row, &oob);
+  /* if (oob) { */
+  /*   api_set_error(err, kErrorTypeValidation, "end_row out of bounds"); */
+  /*   return; */
+  /* } */
+
+  char *str_at_start = (char *)ml_get_buf(buf, start_row, false);
   if (start_col < 0 || (size_t)start_col > strlen(str_at_start)) {
     api_set_error(err, kErrorTypeValidation, "start_col out of bounds");
     return;
   }
 
-  char *str_at_end = (char *)ml_get_buf(buf, end_row+1, false);
+  char *str_at_end = (char *)ml_get_buf(buf, end_row, false);
   size_t len_at_end = strlen(str_at_end);
   if (end_col < 0 || (size_t)end_col > len_at_end) {
     api_set_error(err, kErrorTypeValidation, "end_col out of bounds");
+    return;
+  }
+
+  if (start_row > end_row || (end_row == start_row && start_col > end_col)) {
+    api_set_error(err, kErrorTypeValidation, "start is higher than end");
     return;
   }
 
@@ -557,12 +576,10 @@ void nvim_buf_set_text(uint64_t channel_id,
     goto end;
   }
 
-  // TODO: dubbel KOLLA KOLLA indexen här
-  if (u_save((linenr_T)start_row, (linenr_T)end_row+2) == FAIL) {
+  if (u_save((linenr_T)start_row - 1, (linenr_T)end_row) == FAIL) {
     api_set_error(err, kErrorTypeException, "Failed to save undo information");
     goto end;
   }
-
 
   ptrdiff_t extra = 0;  // lines added to text, can be negative
   size_t old_len = (size_t)(end_row-start_row+1);
@@ -572,7 +589,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   // repeatedly deleting line "start".
   size_t to_delete = (new_len < old_len) ? (size_t)(old_len - new_len) : 0;
   for (size_t i = 0; i < to_delete; i++) {
-    if (ml_delete((linenr_T)start_row+1, false) == FAIL) {
+    if (ml_delete((linenr_T)start_row, false) == FAIL) {
       api_set_error(err, kErrorTypeException, "Failed to delete line");
       goto end;
     }
@@ -587,7 +604,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   // less memory allocation and freeing.
   size_t to_replace = old_len < new_len ? old_len : new_len;
   for (size_t i = 0; i < to_replace; i++) {
-    int64_t lnum = start_row + 1 + (int64_t)i;
+    int64_t lnum = start_row + (int64_t)i;
 
     if (lnum >= MAXLNUM) {
       api_set_error(err, kErrorTypeValidation, "Index value is too high");
@@ -605,7 +622,7 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   // Now we may need to insert the remaining new old_len
   for (size_t i = to_replace; i < new_len; i++) {
-    int64_t lnum = start_row + (int64_t)i;
+    int64_t lnum = start_row + (int64_t)i - 1;
 
     if (lnum >= MAXLNUM) {
       api_set_error(err, kErrorTypeValidation, "Index value is too high");
@@ -634,15 +651,15 @@ void nvim_buf_set_text(uint64_t channel_id,
               kExtmarkNOOP);
 
   colnr_T col_extent = (colnr_T)(end_col
-                                 - ((end_row > start_col) ? start_col : 0));
-  extmark_splice(buf, (int)start_row, (colnr_T)start_col,
+                                 - ((end_col > start_col) ? start_col : 0));
+  extmark_splice(buf, (int)start_row-1, (colnr_T)start_col,
                  (int)(end_row-start_row), col_extent,
                  (int)new_len-1, (colnr_T)last_item.size, kExtmarkUndo);
 
-  changed_lines((linenr_T)start_row+1, 0, (linenr_T)end_row+1, (long)extra, true);
+  changed_lines((linenr_T)start_row, 0, (linenr_T)end_row, (long)extra, true);
 
   // TODO: adjust cursor like an extmark ( i e it was inside last_part_len)
-  fix_cursor((linenr_T)start_row+1, (linenr_T)end_row+1, (linenr_T)extra);
+  fix_cursor((linenr_T)start_row, (linenr_T)end_row, (linenr_T)extra);
 
 end:
   for (size_t i = 0; i < new_len; i++) {

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -610,7 +610,6 @@ void nvim_buf_set_text(uint64_t channel_id,
     }
 
     // Same as with replacing, but we also need to free lines
-    xfree(lines[i]);
     lines[i] = NULL;
     extra++;
   }

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -495,34 +495,32 @@ end:
   try_end(err);
 }
 
-/// Sets (replaces) a range in the buffer, retaining any extmarks
-/// that may lie in that range.
+/// Sets (replaces) a range in the buffer
 ///
-/// Indexing is zero-based; end_row is inclusive, while end_col is
-/// exclusive.
+/// This is recommended over nvim_buf_set_lines when only modifying parts of a
+/// line, as extmarks will be preserved on non-modified parts of the touched
+/// lines.
+///
+/// Indexing is zero-based and end-exclusive.
 ///
 /// To insert text at a given index, set `start` and `end` ranges to the same
 /// index. To delete a range, set `replacement` to an array containing
 /// an empty string, or simply an empty array.
 ///
-/// Prefer nvim_buf_set_lines when adding or deleting entire lines.
+/// Prefer nvim_buf_set_lines when adding or deleting entire lines only.
 ///
 /// @param channel_id
 /// @param buffer           Buffer handle, or 0 for current buffer
 /// @param start_row        First line index
 /// @param start_column     Last column
-/// @param end_row          Last line index (inclusive)
-/// @param end_column       Last column (exclusive)
+/// @param end_row          Last line index
+/// @param end_column       Last column
 /// @param replacement      Array of lines to use as replacement
 /// @param[out] err         Error details, if any
-void nvim_buf_set_text(uint64_t channel_id,
-                       Buffer buffer,
-                       Integer start_row,
-                       Integer start_col,
-                       Integer end_row,
-                       Integer end_col,
-                       ArrayOf(String) replacement,
-                       Error *err)
+void nvim_buf_set_text(uint64_t channel_id, Buffer buffer,
+                       Integer start_row, Integer start_col,
+                       Integer end_row, Integer end_col,
+                       ArrayOf(String) replacement, Error *err)
   FUNC_API_SINCE(7)
 {
   if (replacement.size == 0) {

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -453,7 +453,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust marks if we managed to switch to a window that holds
+  // Only adjust mapks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start,
               (linenr_T)(end - 1),
@@ -514,6 +514,7 @@ void nvim_buf_set_text(uint64_t channel_id,
   }
 
   String first_item = replacement.items[0].data.string;
+  String last_item = replacement.items[replacement.size-1].data.string;
   size_t firstlen = (size_t)start_col+first_item.size;
   size_t last_part_len = strlen(str_at_end) - (size_t)end_col;
   if (replacement.size == 1) {
@@ -525,7 +526,6 @@ void nvim_buf_set_text(uint64_t channel_id,
   if (replacement.size == 1) {
     memcpy(first+start_col+first_item.size, str_at_end+end_col, last_part_len);
   } else {
-    String last_item = replacement.items[replacement.size-1].data.string;
     last = xmallocz(last_item.size+last_part_len);
     memcpy(last, last_item.data, last_item.size);
     memcpy(last+last_item.size, str_at_end+end_col, last_part_len);
@@ -615,10 +615,30 @@ void nvim_buf_set_text(uint64_t channel_id,
     extra++;
   }
 
+  // Adjust marks. Invalidate any which lie in the
+  // changed range, and move any in the remainder of the buffer.
+  // Only adjust mapks if we managed to switch to a window that holds
+  // the buffer, otherwise line numbers will be invalid.
+  mark_adjust((linenr_T)start_row,
+              (linenr_T)end_row,
+              MAXLNUM,
+              (long)extra,
+              kExtmarkNOOP);
+
+  colnr_T col_extent = (colnr_T)(end_col
+                                 - ((end_row > start_col) ? start_col : 0));
+  extmark_splice(buf, (int)start_row, (colnr_T)start_col,
+                 (int)(end_row-start_row), col_extent,
+                 (int)new_len-1, (colnr_T)last_item.size, kExtmarkUndo);
+
+  changed_lines((linenr_T)start_row+1, 0, (linenr_T)end_row+1, (long)extra, true);
+
+  // TODO: adjust cursor like an extmark ( i e it was inside last_part_len)
+  fix_cursor((linenr_T)start_row+1, (linenr_T)end_row+1, (linenr_T)extra);
+
 end:
   aucmd_restbuf(&aco);
   try_end(err);
-  
 }
 
 /// Returns the byte offset of a line (0-indexed). |api-indexing|

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -453,7 +453,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust mapks if we managed to switch to a window that holds
+  // Only adjust marks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start,
               (linenr_T)(end - 1),
@@ -642,7 +642,7 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   // Adjust marks. Invalidate any which lie in the
   // changed range, and move any in the remainder of the buffer.
-  // Only adjust mapks if we managed to switch to a window that holds
+  // Only adjust marks if we managed to switch to a window that holds
   // the buffer, otherwise line numbers will be invalid.
   mark_adjust((linenr_T)start_row,
               (linenr_T)end_row,
@@ -658,7 +658,10 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   changed_lines((linenr_T)start_row, 0, (linenr_T)end_row, (long)extra, true);
 
-  // TODO: adjust cursor like an extmark ( i e it was inside last_part_len)
+  // adjust cursor like an extmark ( i e it was inside last_part_len)
+  if (curwin->w_cursor.lnum == end_row && curwin->w_cursor.col > end_col) {
+    curwin->w_cursor.col -= col_extent - (colnr_T)last_item.size;
+  }
   fix_cursor((linenr_T)start_row, (linenr_T)end_row, (linenr_T)extra);
 
 end:

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -591,13 +591,11 @@ void nvim_buf_set_text(uint64_t channel_id,
           line = (char *)ml_get_buf(buf, lnum, false);
           old_byte += (bcount_t)(strlen(line));
       }
-      old_byte += end_col;
+      old_byte += (bcount_t)end_col;
   }
 
   String first_item = replacement.items[0].data.string;
   String last_item = replacement.items[replacement.size-1].data.string;
-
-  new_byte += (bcount_t)(first_item.size);
 
   size_t firstlen = (size_t)start_col+first_item.size;
   size_t last_part_len = strlen(str_at_end) - (size_t)end_col;
@@ -619,6 +617,7 @@ void nvim_buf_set_text(uint64_t channel_id,
 
   char **lines = (new_len != 0) ? xcalloc(new_len, sizeof(char *)) : NULL;
   lines[0] = first;
+  new_byte += (bcount_t)(first_item.size);
   for (size_t i = 1; i < new_len-1; i++) {
     const String l = replacement.items[i].data.string;
 
@@ -719,8 +718,8 @@ void nvim_buf_set_text(uint64_t channel_id,
   colnr_T col_extent = (colnr_T)(end_col
                                  - ((end_col > start_col) ? start_col : 0));
   extmark_splice(buf, (int)start_row-1, (colnr_T)start_col,
-                 (int)(end_row-start_row), col_extent, (bcount_t)(old_byte),
-                 (int)new_len-1, (colnr_T)last_item.size, (bcount_t)new_byte,
+                 (int)(end_row-start_row), col_extent, old_byte,
+                 (int)new_len-1, (colnr_T)last_item.size, new_byte,
                  kExtmarkUndo);
 
 

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -71,7 +71,7 @@ static ExtmarkNs *buf_ns_ref(buf_T *buf, uint64_t ns_id, bool put) {
 /// @returns the mark id
 uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
                      int row, colnr_T col, int end_row, colnr_T end_col,
-                     Decoration *decor, ExtmarkOp op)
+                     Decoration *decor, ExtmarkOp op, bool right_gravity)
 {
   ExtmarkNs *ns = buf_ns_ref(buf, ns_id, true);
   assert(ns != NULL);
@@ -112,7 +112,7 @@ uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
                              row, col, true,
                              end_row, end_col, false);
   } else {
-    mark = marktree_put(buf->b_marktree, row, col, true);
+    mark = marktree_put(buf->b_marktree, row, col, right_gravity);
   }
 
 revised:

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -71,7 +71,7 @@ static ExtmarkNs *buf_ns_ref(buf_T *buf, uint64_t ns_id, bool put) {
 /// @returns the mark id
 uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
                      int row, colnr_T col, int end_row, colnr_T end_col,
-                     Decoration *decor, ExtmarkOp op, bool right_gravity)
+                     Decoration *decor, ExtmarkOp op)
 {
   ExtmarkNs *ns = buf_ns_ref(buf, ns_id, true);
   assert(ns != NULL);
@@ -112,7 +112,7 @@ uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
                              row, col, true,
                              end_row, end_col, false);
   } else {
-    mark = marktree_put(buf->b_marktree, row, col, right_gravity);
+    mark = marktree_put(buf->b_marktree, row, col, true);
   }
 
 revised:
@@ -560,6 +560,23 @@ void extmark_adjust(buf_T *buf,
                       new_row, 0, new_byte, undo);
 }
 
+// Adjust extmarks following a text edit.
+//
+// @param buf
+// @param start_row   Start row of the region to be changed
+// @param start_col   Start col of the region to be changed
+// @param old_row     End row of the region to be changed.
+//                      Encoded as an offset to start_row.
+// @param old_col     End col of the region to be changed. Encodes
+//                      an offset from start_col if old_row = 0; otherwise,
+//                      encodes the end column of the old region.
+// @param old_byte    Byte extent of the region to be changed.
+// @param new_row     Row offset of the new region.
+// @param new_col     Col offset of the new region. Encodes an offset from
+//                      start_col if new_row = 0; otherwise, encodes
+//                      the end column of the new region.
+// @param new_byte    Byte extent of the new region.
+// @param undo
 void extmark_splice(buf_T *buf,
                     int start_row, colnr_T start_col,
                     int old_row, colnr_T old_col, bcount_t old_byte,

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -392,6 +392,89 @@ describe('api/buf', function()
     end)
   end)
 
+  describe('nvim_buf_get_lines, nvim_buf_set_text', function()
+    local get_lines, set_text = curbufmeths.get_lines, curbufmeths.set_text
+    local line_count = curbufmeths.line_count
+
+    it('works', function()
+      insert([[
+      hello foo!
+      text
+      ]])
+
+      eq({'hello foo!'}, get_lines(0, 1, true))
+
+
+      -- can replace a single word
+      set_text(0, 6, 0, 9, {'world'})
+      eq({'hello world!', 'text'}, get_lines(0, 2, true))
+
+      -- can replace with multiple lines
+      local err = set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
+      eq({'hello foo', 'wo', 'more!', 'text'}, get_lines(0,  4, true))
+
+      -- will join multiple lines if needed
+      set_text(0, 6, 3, 4, {'bar'})
+      eq({'hello bar'}, get_lines(0,  1, true))
+    end)
+
+    it('updates the cursor position', function()
+      insert([[
+      hello world!
+      ]])
+
+      -- position the cursor on `!`
+      curwin('set_cursor', {1, 11})
+      -- replace 'world' with 'foo'
+      set_text(0, 6, 0, 11, {'foo'})
+      eq('hello foo!', curbuf_depr('get_line', 0))
+      -- cursor should be moved left by two columns (replacement is shorter by 2 chars)
+      eq({1, 9}, curwin('get_cursor'))
+    end)
+
+    it('can handle NULs', function()
+      set_text(0, 0, 0, 0, {'ab\0cd'})
+      eq('ab\0cd', curbuf_depr('get_line', 0))
+    end)
+
+    it('adjusts extmarks', function()
+      local ns = request('nvim_create_namespace', "my-fancy-plugin")
+      insert([[
+      foo bar
+      baz
+      ]])
+      local id1 = curbufmeths.set_extmark(ns, 0, 0, 1, {})
+      local id2 = curbufmeths.set_extmark(ns, 0, 0, 7, {})
+      local id3 = curbufmeths.set_extmark(ns, 0, 1, 1, {})
+      set_text(0, 4, 0, 7, {"q"})
+
+      -- TODO: if we set text at 0,3, what happens to the mark at 0,3
+
+      eq({'foo q', 'baz'}, get_lines(0, 2, true))
+      -- mark before replacement point is unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id1)
+      eq({0, 1}, rv)
+      -- mark gets shifted back because the replacement was shorter
+      rv = curbufmeths.get_extmark_by_id(ns, id2)
+      eq({0, 5}, rv)
+      -- mark on the next line is unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id3)
+      eq({1, 1}, rv)
+
+      -- replacing the text spanning two lines will adjust the mark on the next line
+      set_text(0, 3, 1, 3, {"qux"})
+      rv = curbufmeths.get_extmark_by_id(ns, id3)
+      eq({'fooqux', ''}, get_lines(0, 2, true))
+      eq({0, 6}, rv)
+      -- but mark before replacement point is still unaffected
+      rv = curbufmeths.get_extmark_by_id(ns, id1)
+      eq({0, 1}, rv)
+      -- and the mark in the middle was shifted to the end of the insertion
+      rv = curbufmeths.get_extmark_by_id(ns, id2)
+      eq({0, 6}, rv)
+    end)
+  end)
+
   describe('nvim_buf_get_offset', function()
     local get_offset = curbufmeths.get_offset
     it('works', function()

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -394,7 +394,6 @@ describe('api/buf', function()
 
   describe('nvim_buf_get_lines, nvim_buf_set_text', function()
     local get_lines, set_text = curbufmeths.get_lines, curbufmeths.set_text
-    local line_count = curbufmeths.line_count
 
     it('works', function()
       insert([[
@@ -418,7 +417,7 @@ describe('api/buf', function()
       eq({'hello world!', 'text'}, get_lines(0, 2, true))
 
       -- can replace with multiple lines
-      local err = set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
+      set_text(0, 6, 0, 11, {'foo', 'wo', 'more'})
       eq({'hello foo', 'wo', 'more!', 'text'}, get_lines(0,  4, true))
 
       -- will join multiple lines if needed
@@ -426,7 +425,7 @@ describe('api/buf', function()
       eq({'hello bar'}, get_lines(0,  1, true))
     end)
 
-    pending('can handle multibyte characters', function()
+    pending('uses virtual columns instead of columns', function()
         insert([[
         hellØ world!
         ]])
@@ -445,6 +444,7 @@ describe('api/buf', function()
     it('works with undo', function()
         insert([[
         hello world!
+        foo bar
         ]])
 
         -- setting text
@@ -459,6 +459,11 @@ describe('api/buf', function()
 
         -- inserting newlines
         set_text(0, 0, 0, 0, {'hello', 'mr '})
+        feed('u')
+        eq({'hello world!'}, get_lines(0, 1, true))
+
+        -- deleting newlines
+        set_text(0, 0, 1, 4, {'hello'})
         feed('u')
         eq({'hello world!'}, get_lines(0, 1, true))
     end)
@@ -493,30 +498,36 @@ describe('api/buf', function()
       local id3 = curbufmeths.set_extmark(ns, 1, 1, {})
       set_text(0, 4, 0, 7, {"q"})
 
-      -- TODO: if we set text at 0,3, what happens to the mark at 0,3
-
       eq({'foo q', 'baz'}, get_lines(0, 2, true))
       -- mark before replacement point is unaffected
-      rv = curbufmeths.get_extmark_by_id(ns, id1, {})
-      eq({0, 1}, rv)
+      eq({0, 1}, curbufmeths.get_extmark_by_id(ns, id1, {}))
       -- mark gets shifted back because the replacement was shorter
-      rv = curbufmeths.get_extmark_by_id(ns, id2, {})
-      eq({0, 5}, rv)
+      eq({0, 5}, curbufmeths.get_extmark_by_id(ns, id2, {}))
       -- mark on the next line is unaffected
-      rv = curbufmeths.get_extmark_by_id(ns, id3, {})
-      eq({1, 1}, rv)
+      eq({1, 1}, curbufmeths.get_extmark_by_id(ns, id3, {}))
 
       -- replacing the text spanning two lines will adjust the mark on the next line
       set_text(0, 3, 1, 3, {"qux"})
-      rv = curbufmeths.get_extmark_by_id(ns, id3, {})
       eq({'fooqux', ''}, get_lines(0, 2, true))
-      eq({0, 6}, rv)
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id3, {}))
       -- but mark before replacement point is still unaffected
-      rv = curbufmeths.get_extmark_by_id(ns, id1, {})
-      eq({0, 1}, rv)
+      eq({0, 1}, curbufmeths.get_extmark_by_id(ns, id1, {}))
       -- and the mark in the middle was shifted to the end of the insertion
-      rv = curbufmeths.get_extmark_by_id(ns, id2, {})
-      eq({0, 6}, rv)
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id2, {}))
+
+      -- marks should be put back into the same place after undoing
+      set_text(0, 0, 0, 2, {''})
+      feed('u')
+      eq({0, 1}, curbufmeths.get_extmark_by_id(ns, id1, {}))
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id2, {}))
+      eq({0, 6}, curbufmeths.get_extmark_by_id(ns, id3, {}))
+
+	  -- marks should be shifted over by the correct number of bytes for multibyte
+	  -- chars
+	  set_text(0, 0, 0, 0, {'Ø'})
+	  eq({0, 3}, curbufmeths.get_extmark_by_id(ns, id1, {}))
+	  eq({0, 8}, curbufmeths.get_extmark_by_id(ns, id2, {}))
+	  eq({0, 8}, curbufmeths.get_extmark_by_id(ns, id3, {}))
     end)
   end)
 

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -425,22 +425,6 @@ describe('api/buf', function()
       eq({'hello bar'}, get_lines(0,  1, true))
     end)
 
-    pending('uses virtual columns instead of columns', function()
-        insert([[
-        hellØ world!
-        ]])
-
-        eq({'hellØ world!'}, get_lines(0, 1, true))
-
-        -- inserting multibyte
-        set_text(0, 11, 0, 11, {'Ø'})
-        eq({'hellØ worldØ!'}, get_lines(0, 1, true))
-
-        -- deleting multibyte
-        set_text(0, 0, 0, 6, {''})
-        eq({'worldØ!'}, get_lines(0, 1, true))
-    end)
-
     it('works with undo', function()
         insert([[
         hello world!

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -290,7 +290,8 @@ describe('lua: nvim_buf_attach on_bytes', function()
     -- TODO: while we are brewing the real strong coffe,
     -- verify should check buf_get_offset after every check_events
     if verify then
-      eq(meths.buf_get_offset(0, meths.buf_line_count(0)), string.len(shadowbytes))
+      local len = meths.buf_get_offset(0, meths.buf_line_count(0))
+      eq(len == -1 and 1 or len, string.len(shadowbytes))
     end
     exec_lua("return test_register(...)", 0, "test1", false, false, true)
     meths.buf_get_changedtick(0)
@@ -313,18 +314,12 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
         if event[1] == verify_name and event[2] == "bytes" then
           local _, _, _, _, _, _, start_byte, _, _, old_byte, _, _, new_byte = unpack(event)
-          print("FURR", string.len(shadowbytes))
-          print("BURRMURR", old_byte, new_byte)
           local before = string.sub(shadowbytes, 1, start_byte)
           -- no text in the tests will contain 0xff bytes (invalid UTF-8)
           -- so we can use it as marker for unknown bytes
           local unknown = string.rep('\255', new_byte)
           local after = string.sub(shadowbytes, start_byte + old_byte + 1)
-          print("auur", string.len(before))
-          print("nurr", string.len(unknown))
-          print("durr", string.len(after))
           shadowbytes = before .. unknown .. after
-          print("rororo", string.len(shadowbytes))
         end
       end
 
@@ -332,7 +327,6 @@ describe('lua: nvim_buf_attach on_bytes', function()
       local bytes = table.concat(text, '\n') .. '\n'
 
       eq(string.len(bytes), string.len(shadowbytes), '\non_bytes: total bytecount of buffer is wrong')
-      print("HURRR", string.len(bytes))
       for i = 1, string.len(shadowbytes) do
         local shadowbyte = string.sub(shadowbytes, i, i)
         if shadowbyte ~= '\255' then

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -12,8 +12,6 @@ local feed = helpers.feed
 local deepcopy = helpers.deepcopy
 local expect_events = helpers.expect_events
 
-local inspect = require 'vim.inspect'
-
 local origlines = {"original line 1",
                    "original line 2",
                    "original line 3",

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -553,19 +553,35 @@ describe('lua: nvim_buf_attach on_bytes', function()
       check_events {
         { "test1", "bytes", 1, 5, 0, 8, 8, 1, 2, 10, 0, 5, 5 };
       }
-      print(inspect(meths.buf_get_lines(0, 0, -1, true)))
 
       meths.buf_set_text(0, 4, 0, 6, 0, {"was 5,6",""})
-      print(inspect(meths.buf_get_lines(0, 0, -1, true)))
       check_events {
         { "test1", "bytes", 1, 6, 4, 0, 75, 2, 0, 32, 1, 0, 8 };
       }
-
 
       eq({ "originalJOINYiginal line 2", "orivery text line 3", "origi splitty",
            "line l line 4", "was 5,6", "    indented line" },
          meths.buf_get_lines(0, 0, -1, true))
 
+    end)
+
+    it('nvim_buf_set_text delete', function()
+      local check_events = setup_eventcheck(verify, origlines)
+
+      -- really {""} but accepts {} as a shorthand
+      meths.buf_set_text(0, 0, 0, 1, 0, {})
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 1, 0, 16, 0, 0, 0 };
+      }
+
+      -- TODO(bfredl): this works but is not as convenient as set_lines
+      meths.buf_set_text(0, 4, 15, 5, 17, {""})
+      check_events {
+        { "test1", "bytes", 1, 4, 4, 15, 79, 1, 17, 18, 0, 0, 0 };
+      }
+      eq({ "original line 2", "original line 3", "original line 4",
+           "original line 5", "original line 6" },
+         meths.buf_get_lines(0, 0, -1, true))
     end)
   end
 


### PR DESCRIPTION
This is a continuation of #12249, rebased on master.

Additional changes:

- fixed undo
- added some more tests
- removed the gravity changes - I'll probably follow up with that in a separate pr.
- updated all extmark functions to match the newer api.
- Added some documentation for extmark_splice, since I found that function to be kind of confusing at first. Let me know if I didn't get it right, or if the doc change is not wanted
