### PR TITLE
GHA/osx: workaround for brew update error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
           fetch-depth: 0
       - name: Install brew packages
         run: |
+          rm -f /usr/local/bin/2to3
           brew update >/dev/null
           brew install automake ninja
       - name: Build release


### PR DESCRIPTION
fix: https://github.com/neovim/neovim/runs/1593085620?check_suite_focus=true#step:3:15
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.9

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.9

Possible conflicting files are:
/usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/2.7/bin/2to3
```

ref: https://github.com/neovim/neovim/commit/fb0ecf9e70872bc43399f961f0235fbf67d19966
