### PR TITLE
fix(folds): dont allow inline fold creation

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -571,7 +571,9 @@ void foldCreate(win_T *wp, pos_T start, pos_T end)
   pos_T start_rel = start;
   pos_T end_rel = end;
 
-  if (start.lnum > end.lnum) {
+  if (start.lnum == end.lnum) {
+    return;
+  } else if (start.lnum > end.lnum) {
     // reverse the range
     end = start_rel;
     start = end_rel;


### PR DESCRIPTION
one of my previous change made it possible to create inline folds but as their display is the same as normal text, it just creates a symbol in the foldcolumn which is distracting.