### PR TITLE
vim-patch:8.1.2212,8.2.{51,782,856,1174,1212,2206,2211}

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -954,9 +954,13 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			delete and yank) ({.%#:} only work with put).
 
 							*:reg* *:registers*
-:reg[isters]		Display the contents of all numbered and named
-			registers.  If a register is written to for |:redir|
-			it will not be listed.
+:reg[isters]		Display the type and contents of all numbered and
+			named registers.  If a register is written to for
+			|:redir| it will not be listed.
+			Type can be one of:
+			"c"	for |characterwise| text
+			"l"	for |linewise| text
+			"b"	for |blockwise-visual| text
 
 
 :reg[isters] {arg}	Display the contents of the numbered and named

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -89,6 +89,10 @@ static inline bool ascii_iswhite(int)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
+static inline bool ascii_iswhite_or_nul(int)
+  REAL_FATTR_CONST
+  REAL_FATTR_ALWAYS_INLINE;
+
 static inline bool ascii_isdigit(int)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
@@ -115,6 +119,14 @@ static inline bool ascii_isspace(int)
 static inline bool ascii_iswhite(int c)
 {
   return c == ' ' || c == '\t';
+}
+
+/// Checks if `c` is a space or tab character or NUL.
+///
+/// @see {ascii_isdigit}
+static inline bool ascii_iswhite_or_nul(int c)
+{
+  return ascii_iswhite(c) || c == NUL;
 }
 
 /// Check whether character is a decimal digit.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2556,6 +2556,7 @@ void free_for_info(void *fi_void)
 
 
 void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
+  FUNC_ATTR_NONNULL_ALL
 {
   int got_eq = FALSE;
   int c;
@@ -2638,6 +2639,23 @@ void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
       }
     }
   }
+
+  // ":exe one two" completes "two"
+  if ((cmdidx == CMD_execute
+       || cmdidx == CMD_echo
+       || cmdidx == CMD_echon
+       || cmdidx == CMD_echomsg)
+      && xp->xp_context == EXPAND_EXPRESSION) {
+    for (;;) {
+      char_u *const n = skiptowhite(arg);
+
+      if (n == arg || ascii_iswhite_or_nul(*skipwhite(n))) {
+        break;
+      }
+      arg = skipwhite(n);
+    }
+  }
+
   xp->xp_pattern = arg;
 }
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -577,6 +577,17 @@ funct Test_cmdline_complete_languages()
   endif
 endfunc
 
+func Test_cmdline_complete_expression()
+  let g:SomeVar = 'blah'
+  for cmd in ['exe', 'echo', 'echon', 'echomsg']
+    call feedkeys(":" .. cmd .. " SomeV\<Tab>\<C-B>\"\<CR>", 'tx')
+    call assert_match('"' .. cmd .. ' SomeVar', @:)
+    call feedkeys(":" .. cmd .. " foo SomeV\<Tab>\<C-B>\"\<CR>", 'tx')
+    call assert_match('"' .. cmd .. ' foo SomeVar', @:)
+  endfor
+  unlet g:SomeVar
+endfunc
+
 func Test_cmdline_write_alternatefile()
   new
   call setline('.', ['one', 'two'])

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -548,6 +548,13 @@ func Test_cmdline_complete_user_names()
   endif
 endfunc
 
+func Test_cmdline_complete_bang()
+  if executable('whoami')
+    call feedkeys(":!whoam\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_match('^".*\<whoami\>', @:)
+  endif
+endfunc
+
 funct Test_cmdline_complete_languages()
   let lang = substitute(execute('language messages'), '.*"\(.*\)"$', '\1', '')
 

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -52,27 +52,27 @@ func Test_display_registers()
     let b = execute('registers')
 
     call assert_equal(a, b)
-    call assert_match('^\n--- Registers ---\n'
-          \ .         '""   a\n'
-          \ .         '"0   ba\n'
-          \ .         '"1   b\n'
-          \ .         '"a   b\n'
+    call assert_match('^\nType Name Content\n'
+          \ .         '  c  ""   a\n'
+          \ .         '  c  "0   ba\n'
+          \ .         '  c  "1   b\n'
+          \ .         '  c  "a   b\n'
           \ .         '.*'
-          \ .         '"-   a\n'
+          \ .         '  c  "-   a\n'
           \ .         '.*'
-          \ .         '":   ls\n'
-          \ .         '"%   file2\n'
-          \ .         '"#   file1\n'
-          \ .         '"/   bar\n'
-          \ .         '"=   2\*4', a)
+          \ .         '  c  ":   ls\n'
+          \ .         '  c  "%   file2\n'
+          \ .         '  c  "#   file1\n'
+          \ .         '  c  "/   bar\n'
+          \ .         '  c  "=   2\*4', a)
 
     let a = execute('registers a')
-    call assert_match('^\n--- Registers ---\n'
-          \ .         '"a   b', a)
+    call assert_match('^\nType Name Content\n'
+          \ .         '  c  "a   b', a)
 
     let a = execute('registers :')
-    call assert_match('^\n--- Registers ---\n'
-          \ .         '":   ls', a)
+    call assert_match('^\nType Name Content\n'
+          \ .         '  c  ":   ls', a)
 
     bwipe!
 endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -2,6 +2,9 @@
 " Tests for register operations
 "
 
+source check.vim
+source view_util.vim
+
 " This test must be executed first to check for empty and unset registers.
 func Test_aaa_empty_reg_test()
   call assert_fails('normal @@', 'E748:')
@@ -75,6 +78,19 @@ func Test_display_registers()
           \ .         '  c  ":   ls', a)
 
     bwipe!
+endfunc
+
+func Test_recording_status_in_ex_line()
+  norm qx
+  redraw!
+  call assert_equal('recording @x', Screenline(&lines))
+  set shortmess=q
+  redraw!
+  call assert_equal('recording', Screenline(&lines))
+  set shortmess&
+  norm q
+  redraw!
+  call assert_equal('', Screenline(&lines))
 endfunc
 
 " Check that replaying a typed sequence does not use an Esc and following

--- a/test/functional/provider/clipboard_spec.lua
+++ b/test/functional/provider/clipboard_spec.lua
@@ -605,10 +605,10 @@ describe('clipboard (with fake clipboard.vim)', function()
       {0:~                                                           }|
       {4:                                                            }|
       :registers                                                  |
-      {1:--- Registers ---}                                           |
-      "*   some{2:^J}star data{2:^J}                                      |
-      "+   such{2:^J}plus{2:^J}stuff                                      |
-      ":   let g:test_clip['+'] = ['such', 'plus', 'stuff']       |
+      {1:Type Name Content}                                           |
+        l  "*   some{2:^J}star data{2:^J}                                 |
+        c  "+   such{2:^J}plus{2:^J}stuff                                 |
+        c  ":   let g:test_clip['+'] = ['such', 'plus', 'stuff']  |
       {3:Press ENTER or type command to continue}^                     |
     ]], {
       [0] = {bold = true, foreground = Screen.colors.Blue},


### PR DESCRIPTION
vim-patch:8.2.2206: :exe command line completion only works for first argument

Problem:    :exe command line completion only works for first argument.
Solution:   Skip over text if more is following. (closes vim/vim#7546)
https://github.com/vim/vim/commit/4941b5effd7f6a26583a949c92ee50276a3b43f9

Port "IS_WHITE_OR_NUL" macro from patch v8.2.0562
as "ascii_iswhite_or_nul()" inline function.