### PR TITLE
fix: Use correct bufnr for documentHighlight handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -253,9 +253,8 @@ M['textDocument/signatureHelp'] = function(_, method, result)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
-M['textDocument/documentHighlight'] = function(_, _, result, _)
+M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)
   if not result then return end
-  local bufnr = api.nvim_get_current_buf()
   util.buf_highlight_references(bufnr, result)
 end
 


### PR DESCRIPTION
Currently the handler uses `vim.api.nvim_get_current_buf()` to get the bufnr before adding the highlights for `documentHighlight`. However, since this is an async callback, a user could navigate away from the buffer before the server responds leading to the highlights being applied to the incorrect buffer. In `:h lsp-handler` I noticed that the signature can be `function(err, method, result, client_id, bufnr, config)` which takes in a `bufnr` and would be the correct buffer tied to the lsp request.