### PR TITLE
LSP: Disable capabilities not currently supported by language client handlers

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -730,7 +730,15 @@ function protocol.make_client_capabilities()
     experimental = nil;
     window = {
       workDoneProgress = true;
-    }
+      showMessage = {
+        messageActionItem = {
+          additionalPropertiesSupport = false;
+        };
+      };
+      showDocument = {
+        support = false;
+      };
+    };
   }
 end
 


### PR DESCRIPTION
Several language servers are not incorrectly invoking handlers which are not yet implemented in core. 