### PR TITLE
LSP: Implement client/registerCapability for dynamicRegistration

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -639,7 +639,7 @@ client()                                                      *vim.lsp.client*
                     user to |vim.lsp.start_client()|.
                   • {server_capabilities} (table): Response from the server
                     sent on `initialize` describing the server's capabilities.
-                  • {resolved_capabilities} (table): Normalized table of
+                  • {resolved_server_capabilities} (table): Normalized table of
                     capabilities that we have detected based on the initialize
                     response from the server in `server_capabilities` .
 
@@ -1917,8 +1917,8 @@ make_client_capabilities()
                 Gets a new ClientCapabilities object describing the LSP client
                 capabilities.
 
-                                     *vim.lsp.protocol.resolve_capabilities()*
-resolve_capabilities({server_capabilities})
+                              *vim.lsp.protocol.resolve_server_capabilities()*
+resolve_server_capabilities({server_capabilities})
                 `*` to match one or more characters in a path segment `?` to
                 match on one character in a path segment `**` to match any
                 number of path segments, including none `{}` to group

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -620,7 +620,7 @@ function protocol.make_client_capabilities()
         didSave = true;
       };
       codeAction = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
 
         codeActionLiteralSupport = {
           codeActionKind = {
@@ -633,7 +633,7 @@ function protocol.make_client_capabilities()
         };
       };
       completion = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
         completionItem = {
           -- Until we can actually expand snippet, move cursor and allow for true snippet experience,
           -- this should be disabled out of the box.
@@ -659,23 +659,27 @@ function protocol.make_client_capabilities()
         contextSupport = false;
       };
       declaration = {
+        dynamicRegistration = true;
         linkSupport = true;
       };
       definition = {
+        dynamicRegistration = true;
         linkSupport = true;
       };
       implementation = {
+        dynamicRegistration = true;
         linkSupport = true;
       };
       typeDefinition = {
+        dynamicRegistration = true;
         linkSupport = true;
       };
       hover = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
         contentFormat = { protocol.MarkupKind.Markdown; protocol.MarkupKind.PlainText };
       };
       signatureHelp = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
         signatureInformation = {
           documentationFormat = { protocol.MarkupKind.Markdown; protocol.MarkupKind.PlainText };
           -- parameterInformation = {
@@ -684,13 +688,13 @@ function protocol.make_client_capabilities()
         };
       };
       references = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
       };
       documentHighlight = {
-        dynamicRegistration = false
+        dynamicRegistration = true
       };
       documentSymbol = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
         symbolKind = {
           valueSet = (function()
             local res = {}
@@ -702,14 +706,20 @@ function protocol.make_client_capabilities()
         };
         hierarchicalDocumentSymbolSupport = true;
       };
+      formatting = {
+        dynamicRegistration = true;
+      };
+      rangeFormatting = {
+        dynamicRegistration = true;
+      };
       rename = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
         prepareSupport = true;
       };
     };
     workspace = {
       symbol = {
-        dynamicRegistration = false;
+        dynamicRegistration = true;
         symbolKind = {
           valueSet = (function()
             local res = {}
@@ -721,11 +731,17 @@ function protocol.make_client_capabilities()
         };
         hierarchicalWorkspaceSymbolSupport = true;
       };
+      executeCommand = {
+        dynamicRegistration = true;
+      };
+      didChangeConfiguration = {
+        dynamicRegistration = true;
+      };
       workspaceFolders = true;
       applyEdit = true;
     };
     callHierarchy = {
-      dynamicRegistration = false;
+      dynamicRegistration = true;
     };
     experimental = nil;
     window = {
@@ -885,7 +901,10 @@ interface ServerCapabilities {
 --]]
 
 --- Creates a normalized object describing LSP server capabilities.
-function protocol.resolve_capabilities(server_capabilities)
+---
+--@param server_capabilities (table) list of capabilities reported by the server to
+--@returns (table) processed table consisting of keys (server_capability) and values (boolean)
+function protocol.resolve_server_capabilities(server_capabilities)
   local general_properties = {}
   local text_document_sync_properties
   do

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -142,6 +142,29 @@ function tests.basic_check_capabilities()
   }
 end
 
+function tests.check_register_capability()
+  skeleton {
+    on_init = function(_params)
+      return {
+        capabilities = {
+          completionProvider = nil;
+          hoverProvider = nil;
+        }
+      }
+    end;
+    body = function()
+      notify('start')
+      notify('client/registerCapability', { registrations = {
+              { id = 1; method = "textDocument/completion"; registerOptions = {}; };
+              { id = 2; method = "textDocument/hover"; registerOptions = {}; };
+          }})
+      -- this should receive vim.NIL
+      expect_notification('client/registerCapability', nil)
+      notify('shutdown')
+    end;
+  }
+end
+
 function tests.capabilities_for_client_supports_method()
   skeleton {
     on_init = function(params)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -248,7 +248,7 @@ describe('LSP', function()
       test_rpc_server {
         test_name = "basic_init";
         on_init = function(client)
-          eq(0, client.resolved_capabilities().text_document_did_change)
+          eq(0, client.resolved_server_capabilities().text_document_did_change)
           client.request('shutdown')
           client.notify('exit')
         end;
@@ -313,7 +313,7 @@ describe('LSP', function()
         on_init = function(client)
           client.stop()
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
         end;
         on_exit = function(code, signal)
           eq(0, code, "exit code", fake_lsp_logfile)
@@ -334,11 +334,11 @@ describe('LSP', function()
         on_init = function(client)
           client.stop()
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().completion)
-          eq(true, client.resolved_capabilities().hover)
-          eq(false, client.resolved_capabilities().goto_definition)
-          eq(false, client.resolved_capabilities().rename)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().completion)
+          eq(true, client.resolved_server_capabilities().hover)
+          eq(false, client.resolved_server_capabilities().goto_definition)
+          eq(false, client.resolved_server_capabilities().rename)
 
           -- known methods for resolved capabilities
           eq(true, client.supports_method("textDocument/hover"))
@@ -457,8 +457,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           client.notify('finish')
         end;
         on_exit = function(code, signal)
@@ -498,8 +498,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(not lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID), "Shouldn't attach twice")
           ]]
@@ -541,8 +541,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]
@@ -584,8 +584,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]
@@ -633,8 +633,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(full_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(full_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]
@@ -682,8 +682,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local sync_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Incremental")
-          eq(sync_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(sync_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]
@@ -731,8 +731,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local sync_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Incremental")
-          eq(sync_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(sync_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]
@@ -775,8 +775,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local sync_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(sync_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(sync_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]
@@ -826,8 +826,8 @@ describe('LSP', function()
         on_init = function(_client)
           client = _client
           local sync_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
-          eq(sync_kind, client.resolved_capabilities().text_document_did_change)
-          eq(true, client.resolved_capabilities().text_document_open_close)
+          eq(sync_kind, client.resolved_server_capabilities().text_document_did_change)
+          eq(true, client.resolved_server_capabilities().text_document_open_close)
           exec_lua [[
             assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
           ]]


### PR DESCRIPTION
Closes #13634: add support for dynamicRegistration.

When receiving a registerCapability request from the server, the client will now match this request against the table used to store server capabilities, and update resolved_capabilities accordingly. This allows the handlers to fire corresponding to the server's newly resolved capabilities, even if these were not broadcast during initialization. Currently, if the requested capability is not found in lsp._request_name_to_server_capability or lsp._request_name_to_notification_request, the lsp client will log a warning that an unsupported dynamicRegistration request has been made. I have not yet enabled broadcasting these dynamicRegistration capabilities by default.

I also added a separate client.notification_requests property for storing the requested notifications from the server. These use the same mechanism as registerCapability, but are conceptually different as they inform the client that the server wishes to receive notifications on certain types of events. Currently, we already send notifications on workspace/didChangeConfiguration events, so I enabled dynamicRegistration for this capability, along with all others currently supported by neovim. The only other notification requests currently in the spec are those under fileOperations (workspace/didCreateFiles, workspace/willRenameFiles, workspace/didRenameFiles, workspace/willDeleteFiles) and workspace/didChangeWatchedFiles.

I also renamed resolved_capabilities to resolved_server_capabilities for clarity, as I might add a resolved_client_capabilities matching the structure of resolved_server_capabilities.