### PR TITLE
ci(GHA): Disable fail-fast for CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   unixish:
     name: ${{ matrix.os }} ${{ matrix.flavor }} (cc=${{ matrix.cc }})
     strategy:
+      fail-fast: false
       matrix:
         include:
           - flavor: asan
@@ -90,6 +91,7 @@ jobs:
       DEPS_PREFIX: "C:/projects/nvim-deps/usr"
 
     strategy:
+      fail-fast: false
       matrix:
         config: [ MINGW_64-gcov, MINGW_32, MSVC_64, MSVC_32 ]
     name: windows (${{ matrix.config }})

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [Twitter](https://twitter.com/Neovim)
 
 [![GitHub CI](https://github.com/neovim/neovim/workflows/CI/badge.svg)](https://github.com/neovim/neovim/actions?query=workflow%3A%22CI%22)
-[![AppVeyor build status](https://ci.appveyor.com/api/projects/status/urdqjrik5u521fac/branch/master?svg=true)](https://ci.appveyor.com/project/neovim/neovim/branch/master)
 [![Codecov coverage](https://img.shields.io/codecov/c/github/neovim/neovim.svg)](https://codecov.io/gh/neovim/neovim)
 [![Coverity Scan analysis](https://scan.coverity.com/projects/2227/badge.svg)](https://scan.coverity.com/projects/2227)
 [![Clang analysis](https://neovim.io/doc/reports/clang/badge.svg)](https://neovim.io/doc/reports/clang)


### PR DESCRIPTION
Removing the Appveyor badge, too, since the CI was disabled in 7dbc82912ae31e3bcf9f848ba0e83291321d79aa.