### PR TITLE
LSP: Implement textDocument/documentColor

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -905,6 +905,16 @@ document_highlight()                        *vim.lsp.buf.document_highlight()*
     vim.api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()]]
 <
 
+document_color()                        *vim.lsp.buf.document_color()*
+                Send request to server to resolve document colors for the
+                current buffer. This request can be associated to key mapping
+                or to events such as `TextChanged` , eg:
+>
+    vim.api.nvim_command [[ autocmd TextChanged,InsertLeave * lua vim.lsp.buf.document_color() ]]
+<
+                Note:
+                    Many servers do not implement this method.
+
 document_symbol()                              *vim.lsp.buf.document_symbol()*
                 Lists all symbols in the current buffer in the quickfix
                 window.
@@ -1044,6 +1054,76 @@ workspace_symbol({query})                     *vim.lsp.buf.workspace_symbol()*
 
                 Parameters: ~
                     {query}  (string, optional)
+
+
+==============================================================================
+Lua module: vim.lsp.color                                     *lsp-color*
+
+                                                   *vim.lsp.color.buf_color()*
+buf_color({client_id}, {bufnr}, {color_infos}, {config})
+
+                Show the colors in the buffer.
+
+                Parameters: ~
+		  {client_id}   number See |vim.lsp.client|.
+                  {bufnr}       number Buffer number.
+                  {color_infos} table ColorInformation table
+                  {config}      table See |vim.lsp.color.on_document_color()|
+
+                                                        *vim.lsp.color.buf_()*
+buf_clear_color({client_id}, {bufnr})
+
+                Clear the colors shown in the buffer.
+
+                Parameters: ~
+		  {client_id}   number See |vim.lsp.client|.
+                  {bufnr}       number Buffer number.
+
+                                           *vim.lsp.color.on_document_color()*
+on_document_color({_}, {_}, {result}, {client_id}, {bufnr}, {config})
+
+                |lsp-handler| for the method "textDocument/documentColor"
+>
+                 vim.lsp.handlers["textDocument/documentColor"] = vim.lsp.with(
+                   vim.lsp.color.on_document_color, {
+                     -- Change the color of the background of the text
+                     background = false,
+                     -- Change the color of the text itself
+                     foreground = false,
+                     -- Show the color as virtual text
+                     virtual_text = false,
+                     -- The text to color when using virtual_text
+                     virtual_text_str = '■',
+                     -- The background color to use when applying an alpha
+                     background_color = {r=255, g=255, b=255},
+                   }
+                 )
+<
+                Parameters: ~
+                  {result}    table ColorInformation table
+		  {client_id} number See |vim.lsp.client|.
+                  {bufnr}     number Buffer number.
+                  {config}    table Configuration table.
+                              • background: (default=false)
+                                • Show color in text background.
+
+                              • foreground: (default=false)
+                                • Show color in text foreground.
+
+                              • virtual_text: (default=false)
+                                • Show color as virtual text.
+
+                              • virtual_text_str: (default='■')
+                                • String to show as virtual text.
+
+                              • background_color: (default=vim.color.decode_24bit_rgb(vim.api.nvim_get_hl_by_name('Normal', true)['background']))
+                                • Background color to use when applying an
+                                alpha. By default the |highlight-guibg| of
+                                |hl-Normal| is used. This option has to be a
+                                table with three keys: r, g, b.
+
+                See also: ~
+                    https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
 
 
 ==============================================================================

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -905,7 +905,7 @@ document_highlight()                        *vim.lsp.buf.document_highlight()*
     vim.api.nvim_command [[autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()]]
 <
 
-document_color()                        *vim.lsp.buf.document_color()*
+document_color()                                *vim.lsp.buf.document_color()*
                 Send request to server to resolve document colors for the
                 current buffer. This request can be associated to key mapping
                 or to events such as `TextChanged` , eg:
@@ -1059,7 +1059,7 @@ workspace_symbol({query})                     *vim.lsp.buf.workspace_symbol()*
 ==============================================================================
 Lua module: vim.lsp.color                                     *lsp-color*
 
-                                                   *vim.lsp.color.buf_color()*
+                                                    *vim.lsp.color.buf_color()*
 buf_color({client_id}, {bufnr}, {color_infos}, {config})
 
                 Show the colors in the buffer.
@@ -1070,7 +1070,7 @@ buf_color({client_id}, {bufnr}, {color_infos}, {config})
                   {color_infos} table ColorInformation table
                   {config}      table See |vim.lsp.color.on_document_color()|
 
-                                                        *vim.lsp.color.buf_()*
+                                              *vim.lsp.color.buf_clear_color()*
 buf_clear_color({client_id}, {bufnr})
 
                 Clear the colors shown in the buffer.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1296,6 +1296,99 @@ validate({opt})                                               *vim.validate()*
                                 fails
 
 
+
+==============================================================================
+Lua module: color                                                    *lua-vim*
+
+rgba_to_rgb({rgba}, {bg_rgb})                        *vim.color.rgba_to_rgb()*
+
+                Returns the RGB after having applied the alpha.
+
+                Parameters: ~
+                   {rgba}   (table): RGBA values.
+                              • r: Red color in [0,255]
+                              • g: Green color in [0,255]
+                              • b: Blue color in [0,255]
+                              • a: Red color in [0,1]
+                   {bg_rgb} (table): RGB values for the background when
+                            applying the alpha to {rgba}.
+                              • r: Red color in [0,255]
+                              • g: Green color in [0,255]
+                              • b: Blue color in [0,255]
+
+                Return: ~
+                   (table): RGB value.
+			• r: Red color in [0,255]
+			• g: Green color in [0,255]
+			• b: Blue color in [0,255]
+			• a: Red color in [0,1]
+
+
+rgb_to_hex({rgb})                                    *vim.color.rgba_to_rgb()*
+
+                Returns a 6-digit string containing the hex version of {rgba}.
+
+                Parameters: ~
+                   {rgba}   (table): RGBA values.
+                              • r: Red color in [0,255]
+                              • g: Green color in [0,255]
+                              • b: Blue color in [0,255]
+
+                Return: ~
+                    (string) 6-digit hex
+
+
+rgba_to_hex({rgba}, {bg_rgb})                        *vim.color.rgba_to_rgb()*
+
+
+                Returns a 6-digit string containing the hex version of {rgba}.
+
+                Parameters: ~
+                   {rgba}   (table): RGBA values.
+                              • r: Red color in [0,255]
+                              • g: Green color in [0,255]
+                              • b: Blue color in [0,255]
+                              • a: Red color in [0,1]
+                   {bg_rgb} (table): RGB values for the background when
+                            applying the alpha to {rgba}.
+                              • r: Red color in [0,255]
+                              • g: Green color in [0,255]
+                              • b: Blue color in [0,255]
+
+                Return: ~
+                    (string) 6-digit hex
+
+decode_24_bit_rgb({rgb_24bit})                       *vim.color.rgba_to_rgb()*
+
+                Returns individual RGB values for a given 24-bit RGB value.
+
+                Parameters: ~
+                    {rgb_24bit}  (number): 24-bit RGB value.
+
+                Return: ~
+                    (table) RGB values.
+			• r: Red color in [0,255]
+			• g: Green color in [0,255]
+			• b: Blue color in [0,255]
+
+
+perceived_lightness({rgb})                           *vim.color.rgba_to_rgb()*
+
+		Returns the perceived lightness of {rgb} where white is 100
+		and black is 0.
+
+		Note: See https://stackoverflow.com/a/56678483.
+
+                Parameters: ~
+                   {rgba}   (table): RGBA values.
+                              • r: Red color in [0,255]
+                              • g: Green color in [0,255]
+                              • b: Blue color in [0,255]
+                              • a: Red color in [0,1]
+
+                Return: ~
+                    (number) lightness in [0,100].
+
 ==============================================================================
 Lua module: uri                                                      *lua-uri*
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1298,7 +1298,7 @@ validate({opt})                                               *vim.validate()*
 
 
 ==============================================================================
-Lua module: color                                                    *lua-vim*
+Lua module: color                                                  *lua-color*
 
 rgba_to_rgb({rgba}, {bg_rgb})                        *vim.color.rgba_to_rgb()*
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1324,7 +1324,7 @@ rgba_to_rgb({rgba}, {bg_rgb})                        *vim.color.rgba_to_rgb()*
 			• a: Red color in [0,1]
 
 
-rgb_to_hex({rgb})                                    *vim.color.rgba_to_rgb()*
+rgb_to_hex({rgb})                                     *vim.color.rgb_to_hex()*
 
                 Returns a 6-digit string containing the hex version of {rgba}.
 
@@ -1338,7 +1338,7 @@ rgb_to_hex({rgb})                                    *vim.color.rgba_to_rgb()*
                     (string) 6-digit hex
 
 
-rgba_to_hex({rgba}, {bg_rgb})                        *vim.color.rgba_to_rgb()*
+rgba_to_hex({rgba}, {bg_rgb})                        *vim.color.rgba_to_hex()*
 
 
                 Returns a 6-digit string containing the hex version of {rgba}.
@@ -1358,7 +1358,7 @@ rgba_to_hex({rgba}, {bg_rgb})                        *vim.color.rgba_to_rgb()*
                 Return: ~
                     (string) 6-digit hex
 
-decode_24_bit_rgb({rgb_24bit})                       *vim.color.rgba_to_rgb()*
+decode_24_bit_rgb({rgb_24bit})                 *vim.color.decode_24_bit_rgb()*
 
                 Returns individual RGB values for a given 24-bit RGB value.
 
@@ -1372,7 +1372,7 @@ decode_24_bit_rgb({rgb_24bit})                       *vim.color.rgba_to_rgb()*
 			• b: Blue color in [0,255]
 
 
-perceived_lightness({rgb})                           *vim.color.rgba_to_rgb()*
+perceived_lightness({rgb})                   *vim.color.perceived_lightness()*
 
 		Returns the perceived lightness of {rgb} where white is 100
 		and black is 0.

--- a/runtime/lua/vim/color.lua
+++ b/runtime/lua/vim/color.lua
@@ -1,0 +1,50 @@
+local validate = vim.validate
+local get_hl_by_name = vim.api.nvim_get_hl_by_name
+local rshift, band = bit.rshift, bit.band
+
+local M = {}
+
+-- TODO(RRethy) Documentation
+function M.rgb_with_alpha(r, g, b, a)
+  validate {
+    r = {r, 'n', false};
+    g = {g, 'n', false};
+    b = {b, 'n', false};
+    a = {a, 'n', true};
+  }
+  if not a then a = 1 end
+
+  local bg_rgb = get_hl_by_name('Normal', true)['background']
+
+  local bg_r = rshift(bg_rgb, 16)
+  local bg_g = band(rshift(bg_rgb, 8), 255)
+  local bg_b = band(bg_rgb, 255)
+
+  r = (r % 256) * a + bg_r * (1 - a)
+  g = (g % 256) * a + bg_g * (1 - a)
+  b = (b % 256) * a + bg_b * (1 - a)
+
+  return r, g, b
+end
+
+function M.rgb_to_hex(r, g, b)
+  validate {
+    r = {r, 'n', false};
+    g = {g, 'n', false};
+    b = {b, 'n', false};
+  }
+  return bit.tohex(bit.bor(bit.lshift(r, 16), bit.lshift(g, 8), b), 6)
+end
+
+function M.rgba_to_hex(r, g, b, a)
+  validate {
+    r = {r, 'n', false};
+    g = {g, 'n', false};
+    b = {b, 'n', false};
+    a = {a, 'n', true};
+  }
+
+  return M.rgb_to_hex(M.rgb_with_alpha(r, g, b, a))
+end
+
+return M

--- a/runtime/lua/vim/color.lua
+++ b/runtime/lua/vim/color.lua
@@ -63,7 +63,7 @@ end
 --@returns (table) with keys 'r', 'g', 'b' in [0,255]
 function M.decode_24bit_rgb(rgb_24bit)
   validate { rgb_24bit = {rgb_24bit, 'n', true} }
-  local r = rshift(rgb_24bit, 16)
+  local r = band(rshift(rgb_24bit, 16), 255)
   local g = band(rshift(rgb_24bit, 8), 255)
   local b = band(rgb_24bit, 255)
   return {r=r, g=g, b=b}

--- a/runtime/lua/vim/color.lua
+++ b/runtime/lua/vim/color.lua
@@ -4,8 +4,7 @@ local rshift, band = bit.rshift, bit.band
 
 local M = {}
 
--- TODO(RRethy) Documentation
-function M.rgb_with_alpha(r, g, b, a)
+function M.rgba_to_rgb(r, g, b, a)
   validate {
     r = {r, 'n', false};
     g = {g, 'n', false};
@@ -44,7 +43,26 @@ function M.rgba_to_hex(r, g, b, a)
     a = {a, 'n', true};
   }
 
-  return M.rgb_to_hex(M.rgb_with_alpha(r, g, b, a))
+  return M.rgb_to_hex(M.rgba_to_rgb(r, g, b, a))
+end
+
+-- https://stackoverflow.com/a/56678483
+function M.perceived_lightness(r, g, b)
+  function gamma_encode(v)
+    return v / 255
+  end
+  function linearize(v)
+    return v <= 0.04045 and v / 12.92 or math.pow((v + 0.055) / 1.055, 2.4)
+  end
+
+  r = linearize(gamma_encode(r))
+  g = linearize(gamma_encode(g))
+  b = linearize(gamma_encode(b))
+
+  -- calculate luminance
+  local L = 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+  return L <= (216/24389) and L * (24389/27) or math.pow(L, 1/3)*116-16
 end
 
 return M

--- a/runtime/lua/vim/color.lua
+++ b/runtime/lua/vim/color.lua
@@ -4,6 +4,13 @@ local rshift, band = bit.rshift, bit.band
 
 local M = {}
 
+--- Returns an rgb for a given rgba by blending it with the background.
+---
+--@param r number for red value in [0,255]
+--@param g number for green value in [0,255]
+--@param b number for blue value in [0,255]
+--@param a alpha value in [0,1]
+--@returns (number, number, number) red, green, blue values
 function M.rgba_to_rgb(r, g, b, a)
   validate {
     r = {r, 'n', false};
@@ -26,6 +33,12 @@ function M.rgba_to_rgb(r, g, b, a)
   return r, g, b
 end
 
+--- Returns a string containing the hex for a given rgb
+---
+--@param r number for red value in [0,255]
+--@param g number for green value in [0,255]
+--@param b number for blue value in [0,255]
+--@returns (string) 6 digit hex representing the rgb params
 function M.rgb_to_hex(r, g, b)
   validate {
     r = {r, 'n', false};
@@ -35,6 +48,13 @@ function M.rgb_to_hex(r, g, b)
   return bit.tohex(bit.bor(bit.lshift(r, 16), bit.lshift(g, 8), b), 6)
 end
 
+--- Returns a string containing the hex for a given rgba
+---
+--@param r number for red value in [0,255]
+--@param g number for green value in [0,255]
+--@param b number for blue value in [0,255]
+--@param a alpha value in [0,1]
+--@returns (string) 6 digit hex representing the rgba params
 function M.rgba_to_hex(r, g, b, a)
   validate {
     r = {r, 'n', false};
@@ -46,7 +66,14 @@ function M.rgba_to_hex(r, g, b, a)
   return M.rgb_to_hex(M.rgba_to_rgb(r, g, b, a))
 end
 
--- https://stackoverflow.com/a/56678483
+--- Returns the perceived lightness of the rgb value. Calculated using -
+--- the formula from https://stackoverflow.com/a/56678483. Can be used to
+--- determine which colors have similar lightness.
+---
+--@param r number for red value in [0,255]
+--@param g number for green value in [0,255]
+--@param b number for blue value in [0,255]
+--@returns (number) lightness in the range [0,100]
 function M.perceived_lightness(r, g, b)
   function gamma_encode(v)
     return v / 255

--- a/runtime/lua/vim/color.lua
+++ b/runtime/lua/vim/color.lua
@@ -1,94 +1,97 @@
-local validate = vim.validate
-local get_hl_by_name = vim.api.nvim_get_hl_by_name
-local rshift, band = bit.rshift, bit.band
+local tohex, bor, lshift, rshift, band = bit.tohex, bit.bor, bit.lshift, bit.rshift, bit.band
+local validate, api = vim.validate, vim.api
 
 local M = {}
 
---- Returns an rgb for a given rgba by blending it with the background.
+--- Returns a table containing the RGB values produced by applying the alpha in
+--- @rgba with the background in @bg_rgb.
 ---
---@param r number for red value in [0,255]
---@param g number for green value in [0,255]
---@param b number for blue value in [0,255]
---@param a alpha value in [0,1]
---@returns (number, number, number) red, green, blue values
-function M.rgba_to_rgb(r, g, b, a)
+--@param rgba (table) with keys 'r', 'g', 'b' in [0,255] and key 'a' in [0,1]
+--@param bg_rgb (table) with keys 'r', 'g', 'b' in in [0,255] to use as the
+--       background color when applying the alpha
+--@returns (table) with keys 'r', 'g', 'b' in [0,255]
+function M.rgba_to_rgb(rgba, bg_rgb)
   validate {
-    r = {r, 'n', false};
-    g = {g, 'n', false};
-    b = {b, 'n', false};
-    a = {a, 'n', true};
+    rgba = {rgba, 't', true},
+    bg_rgb = {bg_rgb, 't', false},
+    r = {rgba.r, 'n', true},
+    g = {rgba.g, 'n', true},
+    b = {rgba.b, 'n', true},
+    a = {rgba.a, 'n', true},
   }
-  if not a then a = 1 end
 
-  local bg_rgb = get_hl_by_name('Normal', true)['background']
+  bg_rgb = bg_rgb or M.decode_24bit_rgb(api.nvim_get_hl_by_name('Normal', true)['background'])
+  validate {
+    bg_r = {bg_rgb.r, 'n', true},
+    bg_g = {bg_rgb.g, 'n', true},
+    bg_b = {bg_rgb.b, 'n', true},
+  }
 
-  local bg_r = rshift(bg_rgb, 16)
-  local bg_g = band(rshift(bg_rgb, 8), 255)
-  local bg_b = band(bg_rgb, 255)
+  local r = rgba.r * rgba.a + bg_rgb.r * (1 - rgba.a)
+  local g = rgba.g * rgba.a + bg_rgb.g * (1 - rgba.a)
+  local b = rgba.b * rgba.a + bg_rgb.b * (1 - rgba.a)
 
-  r = (r % 256) * a + bg_r * (1 - a)
-  g = (g % 256) * a + bg_g * (1 - a)
-  b = (b % 256) * a + bg_b * (1 - a)
-
-  return r, g, b
+  return {r=r, g=g, b=b}
 end
 
---- Returns a string containing the hex for a given rgb
+--- Returns a string containing the 6 digit hex value for a given RGB.
 ---
---@param r number for red value in [0,255]
---@param g number for green value in [0,255]
---@param b number for blue value in [0,255]
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
 --@returns (string) 6 digit hex representing the rgb params
-function M.rgb_to_hex(r, g, b)
+function M.rgb_to_hex(rgb)
   validate {
-    r = {r, 'n', false};
-    g = {g, 'n', false};
-    b = {b, 'n', false};
+    r = {rgb.r, 'n', false};
+    g = {rgb.g, 'n', false};
+    b = {rgb.b, 'n', false};
   }
-  return bit.tohex(bit.bor(bit.lshift(r, 16), bit.lshift(g, 8), b), 6)
+  return tohex(bor(lshift(rgb.r, 16), lshift(rgb.g, 8), rgb.b), 6)
 end
 
---- Returns a string containing the hex for a given rgba
+--- Returns a string containing the 6 digit hex value produced by applying the alpha in
+--- the @rgba with the background @bg_rgb.
 ---
---@param r number for red value in [0,255]
---@param g number for green value in [0,255]
---@param b number for blue value in [0,255]
---@param a alpha value in [0,1]
---@returns (string) 6 digit hex representing the rgba params
-function M.rgba_to_hex(r, g, b, a)
-  validate {
-    r = {r, 'n', false};
-    g = {g, 'n', false};
-    b = {b, 'n', false};
-    a = {a, 'n', true};
-  }
-
-  return M.rgb_to_hex(M.rgba_to_rgb(r, g, b, a))
+--@param rgba (table) with keys 'r', 'g', 'b' in [0,255] and key 'a' in [0,1]
+--@returns (string) 6 digit hex
+function M.rgba_to_hex(rgba, bg_rgb)
+  return M.rgb_to_hex(M.rgba_to_rgb(rgba, bg_rgb))
 end
 
---- Returns the perceived lightness of the rgb value. Calculated using -
+--- Returns a table containing the RGB values encoded inside 24 least
+--- significant bits of the number @rgb_24bit
+---
+--@param rgb_24bit (number) 24-bit RGB value
+--@returns (table) with keys 'r', 'g', 'b' in [0,255]
+function M.decode_24bit_rgb(rgb_24bit)
+  validate { rgb_24bit = {rgb_24bit, 'n', true} }
+  local r = rshift(rgb_24bit, 16)
+  local g = band(rshift(rgb_24bit, 8), 255)
+  local b = band(rgb_24bit, 255)
+  return {r=r, g=g, b=b}
+end
+
+--- Returns the perceived lightness of the rgb value. Calculated using
 --- the formula from https://stackoverflow.com/a/56678483. Can be used to
 --- determine which colors have similar lightness.
 ---
---@param r number for red value in [0,255]
---@param g number for green value in [0,255]
---@param b number for blue value in [0,255]
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
 --@returns (number) lightness in the range [0,100]
-function M.perceived_lightness(r, g, b)
-  function gamma_encode(v)
+function M.perceived_lightness(rgb)
+  local function gamma_encode(v)
     return v / 255
   end
-  function linearize(v)
+  local function linearize(v)
     return v <= 0.04045 and v / 12.92 or math.pow((v + 0.055) / 1.055, 2.4)
   end
 
-  r = linearize(gamma_encode(r))
-  g = linearize(gamma_encode(g))
-  b = linearize(gamma_encode(b))
+  -- convert from sRGB to linear values
+  local r = linearize(gamma_encode(rgb.r))
+  local g = linearize(gamma_encode(rgb.g))
+  local b = linearize(gamma_encode(rgb.b))
 
   -- calculate luminance
   local L = 0.2126 * r + 0.7152 * g + 0.0722 * b
 
+  -- calculate Y* (perceived lightness) from luminance
   return L <= (216/24389) and L * (24389/27) or math.pow(L, 1/3)*116-16
 end
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -23,6 +23,7 @@ local lsp = {
 
   buf = require'vim.lsp.buf';
   diagnostic = require'vim.lsp.diagnostic';
+  color = require'vim.lsp.color';
   util = util;
 
   -- Allow raw RPC access.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -51,6 +51,7 @@ lsp._request_name_to_capability = {
   ['textDocument/formatting'] = 'document_formatting';
   ['textDocument/completion'] = 'completion';
   ['textDocument/documentHighlight'] = 'document_highlight';
+  ['textDocument/documentColor'] = 'document_color';
 }
 
 -- TODO improve handling of scratch buffers with LSP attached.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -330,11 +330,24 @@ function M.clear_references()
   util.buf_clear_references()
 end
 
+--- Send request to server to resolve document colors for the
+--- current text document position. This request can be associated
+--- to key mapping or to events such as `TextChanged` and `InsertLeave`, eg:
+---
+--- <pre>
+--- vim.api.nvim_command [[autocmd TextChanged,InsertLeave <buffer> lua vim.lsp.buf.document_color()]]
+--- </pre>
 function M.document_color()
   local params = {
     textDocument = util.make_text_document_params()
   }
   request('textDocument/documentColor', params)
+end
+
+--- Removes document color highlights from current buffer.
+---
+function M.clear_document_color()
+  util.buf_clear_document_color()
 end
 
 --- Selects a code action from the input list that is available at the current

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -330,6 +330,13 @@ function M.clear_references()
   util.buf_clear_references()
 end
 
+function M.document_color()
+  local params = {
+    textDocument = util.make_text_document_params()
+  }
+  request('textDocument/documentColor', params)
+end
+
 --- Selects a code action from the input list that is available at the current
 --- cursor position.
 --

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -344,12 +344,6 @@ function M.document_color()
   request('textDocument/documentColor', params)
 end
 
---- Removes document color highlights from current buffer.
----
-function M.clear_document_color()
-  util.buf_clear_document_color()
-end
-
 --- Selects a code action from the input list that is available at the current
 --- cursor position.
 --

--- a/runtime/lua/vim/lsp/color.lua
+++ b/runtime/lua/vim/lsp/color.lua
@@ -1,0 +1,123 @@
+local color = require 'vim.color'
+local highlight = require 'vim.highlight'
+local validate = vim.validate
+local api = vim.api
+
+local document_color_ns = api.nvim_create_namespace("vim_lsp_documentColor")
+
+local M = {}
+
+--- Changes the guibg to @rgb for the text in @range. Also changes the guifg to
+--- either #ffffff or #000000 based on which makes the text easier to read for
+--- the given guibg
+---
+--@param bufnr (number) buffer handle
+--@param range (table) with the structure:
+--       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+local function highlight_background(bufnr, range, rgb)
+    local hex = color.rgb_to_hex(rgb)
+    local fghex = color.perceived_lightness(rgb) < 50 and 'ffffff' or '000000'
+
+    local hlname = string.format('LspDocumentColorBackground%s', hex)
+    api.nvim_command(string.format('highlight %s guibg=#%s guifg=#%s', hlname, hex, fghex))
+
+    local start_pos = {range["start"]["line"], range["start"]["character"]}
+    local end_pos = {range["end"]["line"], range["end"]["character"]}
+    highlight.range(bufnr, document_color_ns, hlname, start_pos, end_pos)
+end
+
+--- Changes the guifg to @rgb for the text in @range.
+---
+--@param bufnr (number) buffer handle
+--@param range (table) with the structure:
+--       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+local function highlight_foreground(bufnr, range, rgb)
+    local hex = color.rgb_to_hex(rgb)
+
+    local hlname = string.format('LspDocumentColorForeground%s', hex)
+    api.nvim_command(string.format('highlight %s guifg=#%s', hlname, hex))
+
+    local start_pos = {range["start"]["line"], range["start"]["character"]}
+    local end_pos = {range["end"]["line"], range["end"]["character"]}
+    highlight.range(bufnr, document_color_ns, hlname, start_pos, end_pos)
+end
+
+--- Adds virtual text with the color @rgb and the text @virtual_text_str on
+--- the last line of the @range.
+---
+--@param bufnr (number) buffer handle
+--@param range (table) with the structure:
+--       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+--@param virtual_text_str (string) to display as virtual text and color
+local function highlight_virtual_text(bufnr, range, rgb, virtual_text_str)
+    local hex = color.rgb_to_hex(rgb)
+
+    local hlname = string.format('LspDocumentColorVirtualText%s', hex)
+    api.nvim_command(string.format('highlight %s guifg=#%s', hlname, hex))
+
+    local line = range['end']['line']
+    api.nvim_buf_set_virtual_text(bufnr, document_color_ns, line, {{virtual_text_str, hlname}}, {})
+end
+
+--- Clears the previous document colors and adds the new document colors from @result.
+--- Follows the same signature as :h lsp-handler
+function M.on_document_color(_, _, result, _, bufnr, config)
+  -- TODO debounce it and document
+  if not bufnr then return end
+  M.buf_clear_highlights(bufnr)
+  if not result then return end
+  M.buf_highlight(bufnr, result, config)
+end
+
+--- Shows a list of document colors for a certain buffer.
+---
+--@param bufnr buffer id
+--@param color_infos Table of `ColorInformation` objects to highlight.
+--       See https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
+function M.buf_highlight(bufnr, color_infos, config)
+  validate {
+    bufnr = {bufnr, 'n', false},
+    color_infos = {color_infos, 't', false},
+    config = {config, 't', true},
+  }
+  if not color_infos or not bufnr then return end
+
+  config = vim.lsp._with_extend('vim.lsp.color.on_document_color', {
+    background = false,
+    foreground = false,
+    virtual_text = false,
+    virtual_text_str = '■',
+    background_color = vim.color.decode_24bit_rgb(vim.api.nvim_get_hl_by_name('Normal', true)['background']),
+  }, config)
+
+  for _, color_info in ipairs(color_infos) do
+    local rgba, range = color_info.color, color_info.range
+    local r, g, b, a = rgba.red*255, rgba.green*255, rgba.blue*255, rgba.alpha
+    local rgb = color.rgba_to_rgb({r=r, g=g, b=b, a=a}, config.background_color)
+
+    if config.background then
+      highlight_background(bufnr, range, rgb)
+    end
+
+    if config.foreground then
+      highlight_foreground(bufnr, range, rgb)
+    end
+
+    if config.virtual_text then
+      highlight_virtual_text(bufnr, range, rgb, config.virtual_text_str)
+    end
+  end
+end
+
+--- Removes document color highlights from a buffer.
+---
+--@param bufnr buffer id
+function M.buf_clear_highlights(bufnr)
+    validate { bufnr = {bufnr, 'n', true} }
+    api.nvim_buf_clear_namespace(bufnr, document_color_ns, 0, -1)
+end
+
+return M

--- a/runtime/lua/vim/lsp/color.lua
+++ b/runtime/lua/vim/lsp/color.lua
@@ -3,81 +3,95 @@ local highlight = require 'vim.highlight'
 local validate = vim.validate
 local api = vim.api
 
-local document_color_ns = api.nvim_create_namespace("vim_lsp_documentColor")
+local client_ns = {}
 
 local M = {}
+
+--- Returns the namespace for the given client_id
+---
+--@param client_id number client id
+--@return number
+local function get_client_ns(client_id)
+  if client_ns[client_id] == nil then
+    client_ns[client_id] = api.nvim_create_namespace('vim_lsp_documentColor_'..client_id)
+  end
+  return client_ns[client_id]
+end
 
 --- Changes the guibg to @rgb for the text in @range. Also changes the guifg to
 --- either #ffffff or #000000 based on which makes the text easier to read for
 --- the given guibg
 ---
+--@param client_id number client id
 --@param bufnr (number) buffer handle
 --@param range (table) with the structure:
 --       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
 --@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
-local function highlight_background(bufnr, range, rgb)
-    local hex = color.rgb_to_hex(rgb)
-    local fghex = color.perceived_lightness(rgb) < 50 and 'ffffff' or '000000'
+local function color_background(client_id, bufnr, range, rgb)
+  local hex = color.rgb_to_hex(rgb)
+  local fghex = color.perceived_lightness(rgb) < 50 and 'ffffff' or '000000'
 
-    local hlname = string.format('LspDocumentColorBackground%s', hex)
-    api.nvim_command(string.format('highlight %s guibg=#%s guifg=#%s', hlname, hex, fghex))
+  local hlname = string.format('LspDocumentColorBackground%s', hex)
+  api.nvim_command(string.format('highlight %s guibg=#%s guifg=#%s', hlname, hex, fghex))
 
-    local start_pos = {range["start"]["line"], range["start"]["character"]}
-    local end_pos = {range["end"]["line"], range["end"]["character"]}
-    highlight.range(bufnr, document_color_ns, hlname, start_pos, end_pos)
+  local start_pos = {range["start"]["line"], range["start"]["character"]}
+  local end_pos = {range["end"]["line"], range["end"]["character"]}
+  highlight.range(bufnr, get_client_ns(client_id), hlname, start_pos, end_pos)
 end
 
 --- Changes the guifg to @rgb for the text in @range.
 ---
+--@param client_id number client id
 --@param bufnr (number) buffer handle
 --@param range (table) with the structure:
 --       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
 --@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
-local function highlight_foreground(bufnr, range, rgb)
-    local hex = color.rgb_to_hex(rgb)
+local function color_foreground(client_id, bufnr, range, rgb)
+  local hex = color.rgb_to_hex(rgb)
 
-    local hlname = string.format('LspDocumentColorForeground%s', hex)
-    api.nvim_command(string.format('highlight %s guifg=#%s', hlname, hex))
+  local hlname = string.format('LspDocumentColorForeground%s', hex)
+  api.nvim_command(string.format('highlight %s guifg=#%s', hlname, hex))
 
-    local start_pos = {range["start"]["line"], range["start"]["character"]}
-    local end_pos = {range["end"]["line"], range["end"]["character"]}
-    highlight.range(bufnr, document_color_ns, hlname, start_pos, end_pos)
+  local start_pos = {range["start"]["line"], range["start"]["character"]}
+  local end_pos = {range["end"]["line"], range["end"]["character"]}
+  highlight.range(bufnr, get_client_ns(client_id), hlname, start_pos, end_pos)
 end
 
 --- Adds virtual text with the color @rgb and the text @virtual_text_str on
 --- the last line of the @range.
 ---
+--@param client_id number client id
 --@param bufnr (number) buffer handle
 --@param range (table) with the structure:
 --       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
 --@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
 --@param virtual_text_str (string) to display as virtual text and color
-local function highlight_virtual_text(bufnr, range, rgb, virtual_text_str)
-    local hex = color.rgb_to_hex(rgb)
+local function color_virtual_text(client_id, bufnr, range, rgb, virtual_text_str)
+  local hex = color.rgb_to_hex(rgb)
 
-    local hlname = string.format('LspDocumentColorVirtualText%s', hex)
-    api.nvim_command(string.format('highlight %s guifg=#%s', hlname, hex))
+  local hlname = string.format('LspDocumentColorVirtualText%s', hex)
+  api.nvim_command(string.format('highlight %s guifg=#%s', hlname, hex))
 
-    local line = range['end']['line']
-    api.nvim_buf_set_virtual_text(bufnr, document_color_ns, line, {{virtual_text_str, hlname}}, {})
+  local line = range['end']['line']
+  api.nvim_buf_set_virtual_text(bufnr, get_client_ns(client_id), line, {{virtual_text_str, hlname}}, {})
 end
 
 --- Clears the previous document colors and adds the new document colors from @result.
 --- Follows the same signature as :h lsp-handler
-function M.on_document_color(_, _, result, _, bufnr, config)
-  -- TODO debounce it and document
-  if not bufnr then return end
-  M.buf_clear_highlights(bufnr)
+function M.on_document_color(_, _, result, client_id, bufnr, config)
+  if not bufnr or not client_id then return end
+  M.buf_clear_color(client_id, bufnr)
   if not result then return end
-  M.buf_highlight(bufnr, result, config)
+  M.buf_color(client_id, bufnr, result, config)
 end
 
 --- Shows a list of document colors for a certain buffer.
 ---
+--@param client_id number client id
 --@param bufnr buffer id
 --@param color_infos Table of `ColorInformation` objects to highlight.
 --       See https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
-function M.buf_highlight(bufnr, color_infos, config)
+function M.buf_color(client_id, bufnr, color_infos, config)
   validate {
     bufnr = {bufnr, 'n', false},
     color_infos = {color_infos, 't', false},
@@ -86,12 +100,12 @@ function M.buf_highlight(bufnr, color_infos, config)
   if not color_infos or not bufnr then return end
 
   config = vim.lsp._with_extend('vim.lsp.color.on_document_color', {
-    background = false,
-    foreground = false,
-    virtual_text = false,
-    virtual_text_str = '■',
-    background_color = vim.color.decode_24bit_rgb(vim.api.nvim_get_hl_by_name('Normal', true)['background']),
-  }, config)
+      background = false,
+      foreground = false,
+      virtual_text = false,
+      virtual_text_str = '■',
+      background_color = vim.color.decode_24bit_rgb(vim.api.nvim_get_hl_by_name('Normal', true)['background']),
+    }, config)
 
   for _, color_info in ipairs(color_infos) do
     local rgba, range = color_info.color, color_info.range
@@ -99,25 +113,29 @@ function M.buf_highlight(bufnr, color_infos, config)
     local rgb = color.rgba_to_rgb({r=r, g=g, b=b, a=a}, config.background_color)
 
     if config.background then
-      highlight_background(bufnr, range, rgb)
+      color_background(client_id, bufnr, range, rgb)
     end
 
     if config.foreground then
-      highlight_foreground(bufnr, range, rgb)
+      color_foreground(client_id, bufnr, range, rgb)
     end
 
     if config.virtual_text then
-      highlight_virtual_text(bufnr, range, rgb, config.virtual_text_str)
+      color_virtual_text(client_id, bufnr, range, rgb, config.virtual_text_str)
     end
   end
 end
 
 --- Removes document color highlights from a buffer.
 ---
+--@param client_id number client id
 --@param bufnr buffer id
-function M.buf_clear_highlights(bufnr)
-    validate { bufnr = {bufnr, 'n', true} }
-    api.nvim_buf_clear_namespace(bufnr, document_color_ns, 0, -1)
+function M.buf_clear_color(client_id, bufnr)
+  validate {
+    client_id = {client_id, 'n', true},
+    bufnr = {bufnr, 'n', true}
+  }
+  api.nvim_buf_clear_namespace(bufnr, get_client_ns(client_id), 0, -1)
 end
 
 return M

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -315,6 +315,7 @@ M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)
   util.buf_highlight_references(bufnr, result)
 end
 
+--@see https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
 M['textDocument/documentColor'] = function(_, _, result, _, bufnr, _)
   if not result then return end
   util.buf_clear_document_color(bufnr)

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -317,6 +317,7 @@ end
 
 M['textDocument/documentColor'] = function(_, _, result, _, bufnr, _)
   if not result then return end
+  util.buf_clear_document_color(bufnr)
   util.buf_highlight_colors(bufnr, result)
 end
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -316,9 +316,8 @@ M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)
 end
 
 M['textDocument/documentColor'] = function(_, _, result, _, bufnr, _)
-  print("===========================")
-  print(vim.inspect(result))
-  print("===========================")
+  if not result then return end
+  util.buf_highlight_colors(bufnr, result)
 end
 
 --@private

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -315,6 +315,12 @@ M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)
   util.buf_highlight_references(bufnr, result)
 end
 
+M['textDocument/documentColor'] = function(_, _, result, _, bufnr, _)
+  print("===========================")
+  print(vim.inspect(result))
+  print("===========================")
+end
+
 --@private
 ---
 --- Displays call hierarchy in the quickfix window.

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -316,10 +316,8 @@ M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
-M['textDocument/documentColor'] = function(_, _, result, _, bufnr, _)
-  if not result then return end
-  util.buf_clear_document_color(bufnr)
-  util.buf_highlight_colors(bufnr, result)
+M['textDocument/documentColor'] = function(...)
+  return require('vim.lsp.color').on_document_color(...)
 end
 
 --@private

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -703,6 +703,9 @@ function protocol.make_client_capabilities()
       documentHighlight = {
         dynamicRegistration = false
       };
+      documentColor = {
+        dynamicRegistration = false;
+      };
       documentSymbol = {
         dynamicRegistration = false;
         symbolKind = {
@@ -966,6 +969,7 @@ function protocol.resolve_capabilities(server_capabilities)
   general_properties.document_range_formatting = server_capabilities.documentRangeFormattingProvider or false
   general_properties.call_hierarchy = server_capabilities.callHierarchyProvider or false
   general_properties.execute_command = server_capabilities.executeCommandProvider ~= nil
+  general_properties.document_color = server_capabilities.colorProvider or false
 
   if server_capabilities.renameProvider == nil then
     general_properties.rename = false

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1134,10 +1134,15 @@ do --[[ documentColor ]]
     api.nvim_buf_clear_namespace(bufnr, document_color_ns, 0, -1)
   end
 
+  --- Shows a list of document colors for a certain buffer.
+  ---
+  --@param bufnr buffer id
+  --@param color_infos List of `ColorInformation` objects to highlight
   function M.buf_highlight_colors(bufnr, color_infos)
     validate { bufnr = {bufnr, 'n', true} }
     for _, color_info in ipairs(color_infos) do
       local rgba, range = color_info['color'], color_info['range']
+
       local r, g, b = color.rgba_to_rgb(rgba['red']*255, rgba['green']*255, rgba['blue']*255, rgba['alpha'])
       local color_hex = color.rgb_to_hex(r, g, b)
       local fghex = color.perceived_lightness(r, g, b) < 50 and 'ffffff' or '000000'

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1134,14 +1134,16 @@ do --[[ documentColor ]]
     api.nvim_buf_clear_namespace(bufnr, document_color_ns, 0, -1)
   end
 
-  -- TODO(RRethy) Documentation
   function M.buf_highlight_colors(bufnr, color_infos)
     validate { bufnr = {bufnr, 'n', true} }
     for _, color_info in ipairs(color_infos) do
       local rgba, range = color_info['color'], color_info['range']
-      local hex = color.rgba_to_hex(rgba['red']*255, rgba['green']*255, rgba['blue']*255, rgba['alpha'])
-      local hlname = string.format('LspDocumentColor%s', hex)
-      api.nvim_command(string.format('highlight %s guibg=#%s', hlname, hex))
+      local r, g, b = color.rgba_to_rgb(rgba['red']*255, rgba['green']*255, rgba['blue']*255, rgba['alpha'])
+      local color_hex = color.rgb_to_hex(r, g, b)
+      local fghex = color.perceived_lightness(r, g, b) < 50 and 'ffffff' or '000000'
+
+      local hlname = string.format('LspDocumentColor%s', color_hex)
+      api.nvim_command(string.format('highlight %s guibg=#%s guifg=#%s', hlname, color_hex, fghex))
 
       local start_pos = {range["start"]["line"], range["start"]["character"]}
       local end_pos = {range["end"]["line"], range["end"]["character"]}

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1121,6 +1121,18 @@ do --[[ References ]]
       highlight.range(bufnr, reference_ns, document_highlight_kind[kind], start_pos, end_pos)
     end
   end
+end
+
+do --[[ documentColor ]]
+  local document_color_ns = api.nvim_create_namespace("vim_lsp_documentColor")
+
+  --- Removes document color highlights from a buffer.
+  ---
+  --@param bufnr buffer id
+  function M.buf_clear_document_color(bufnr)
+    validate { bufnr = {bufnr, 'n', true} }
+    api.nvim_buf_clear_namespace(bufnr, document_color_ns, 0, -1)
+  end
 
   -- TODO(RRethy) Documentation
   function M.buf_highlight_colors(bufnr, color_infos)
@@ -1128,9 +1140,12 @@ do --[[ References ]]
     for _, color_info in ipairs(color_infos) do
       local rgba, range = color_info['color'], color_info['range']
       local hex = color.rgba_to_hex(rgba['red']*255, rgba['green']*255, rgba['blue']*255, rgba['alpha'])
+      local hlname = string.format('LspDocumentColor%s', hex)
+      api.nvim_command(string.format('highlight %s guibg=#%s', hlname, hex))
 
-      -- TODO(RRethy) Show the hex
-      print(hex)
+      local start_pos = {range["start"]["line"], range["start"]["character"]}
+      local end_pos = {range["end"]["line"], range["end"]["character"]}
+      highlight.range(bufnr, document_color_ns, hlname, start_pos, end_pos)
     end
   end
 end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -4,7 +4,6 @@ local validate = vim.validate
 local api = vim.api
 local list_extend = vim.list_extend
 local highlight = require 'vim.highlight'
-local color = require 'vim.color'
 
 local npcall = vim.F.npcall
 local split = vim.split
@@ -1119,40 +1118,6 @@ do --[[ References ]]
       }
       local kind = reference["kind"] or protocol.DocumentHighlightKind.Text
       highlight.range(bufnr, reference_ns, document_highlight_kind[kind], start_pos, end_pos)
-    end
-  end
-end
-
-do --[[ documentColor ]]
-  local document_color_ns = api.nvim_create_namespace("vim_lsp_documentColor")
-
-  --- Removes document color highlights from a buffer.
-  ---
-  --@param bufnr buffer id
-  function M.buf_clear_document_color(bufnr)
-    validate { bufnr = {bufnr, 'n', true} }
-    api.nvim_buf_clear_namespace(bufnr, document_color_ns, 0, -1)
-  end
-
-  --- Shows a list of document colors for a certain buffer.
-  ---
-  --@param bufnr buffer id
-  --@param color_infos List of `ColorInformation` objects to highlight
-  function M.buf_highlight_colors(bufnr, color_infos)
-    validate { bufnr = {bufnr, 'n', true} }
-    for _, color_info in ipairs(color_infos) do
-      local rgba, range = color_info['color'], color_info['range']
-
-      local r, g, b = color.rgba_to_rgb(rgba['red']*255, rgba['green']*255, rgba['blue']*255, rgba['alpha'])
-      local color_hex = color.rgb_to_hex(r, g, b)
-      local fghex = color.perceived_lightness(r, g, b) < 50 and 'ffffff' or '000000'
-
-      local hlname = string.format('LspDocumentColor%s', color_hex)
-      api.nvim_command(string.format('highlight %s guibg=#%s guifg=#%s', hlname, color_hex, fghex))
-
-      local start_pos = {range["start"]["line"], range["start"]["character"]}
-      local end_pos = {range["end"]["line"], range["end"]["character"]}
-      highlight.range(bufnr, document_color_ns, hlname, start_pos, end_pos)
     end
   end
 end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -4,6 +4,7 @@ local validate = vim.validate
 local api = vim.api
 local list_extend = vim.list_extend
 local highlight = require 'vim.highlight'
+local color = require 'vim.color'
 
 local npcall = vim.F.npcall
 local split = vim.split
@@ -1118,6 +1119,18 @@ do --[[ References ]]
       }
       local kind = reference["kind"] or protocol.DocumentHighlightKind.Text
       highlight.range(bufnr, reference_ns, document_highlight_kind[kind], start_pos, end_pos)
+    end
+  end
+
+  -- TODO(RRethy) Documentation
+  function M.buf_highlight_colors(bufnr, color_infos)
+    validate { bufnr = {bufnr, 'n', true} }
+    for _, color_info in ipairs(color_infos) do
+      local rgba, range = color_info['color'], color_info['range']
+      local hex = color.rgba_to_hex(rgba['red']*255, rgba['green']*255, rgba['blue']*255, rgba['alpha'])
+
+      -- TODO(RRethy) Show the hex
+      print(hex)
     end
   end
 end

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -277,6 +277,9 @@ local function __index(t, key)
   elseif key == 'F' then
     t.F = require('vim.F')
     return t.F
+  elseif key == 'color' then
+    t.color = require('vim.color')
+    return t.color
   end
 end
 

--- a/test/functional/lua/color_spec.lua
+++ b/test/functional/lua/color_spec.lua
@@ -1,0 +1,133 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local exec_lua = helpers.exec_lua
+local eq = helpers.eq
+
+describe('color methods', function()
+  before_each(function()
+    clear()
+  end)
+
+  describe('rgba_to_rgb', function()
+    it('has no effect when using alpha of 1', function()
+      exec_lua [[
+        rgba = {r=100,g=100,b=100,a=1}
+        bg_rgb = {r=0,g=0,b=0}
+      ]]
+
+      eq({r=100,g=100,b=100}, exec_lua('return vim.color.rgba_to_rgb(rgba, bg_rgb)'))
+    end)
+
+    it('becomes background rgb when using alpha of 0', function()
+      exec_lua [[
+        rgba = {r=100,g=100,b=100,a=0}
+        bg_rgb = {r=0,g=0,b=0}
+      ]]
+
+      eq({r=0,g=0,b=0}, exec_lua('return vim.color.rgba_to_rgb(rgba, bg_rgb)'))
+    end)
+
+    it('has the correct rgb when using decimal alpha', function()
+      exec_lua [[
+        rgba = {r=100,g=100,b=100,a=0.5}
+        bg_rgb = {r=0,g=0,b=0}
+      ]]
+
+      eq({r=50,g=50,b=50}, exec_lua('return vim.color.rgba_to_rgb(rgba, bg_rgb)'))
+    end)
+  end)
+
+  describe('rgb_to_hex', function()
+    it('has the correct hex', function()
+      exec_lua('rgb = {r=100,g=100,b=100}')
+
+      eq('646464', exec_lua('return vim.color.rgb_to_hex(rgb)'))
+    end)
+
+    it('produces hex values and not base 10', function()
+      exec_lua('rgb = {r=250,g=250,b=250}')
+
+      eq('fafafa', exec_lua('return vim.color.rgb_to_hex(rgb)'))
+    end)
+  end)
+
+  describe('rgba_to_hex', function()
+    it('has no effect when using alpha of 1', function()
+      exec_lua [[
+        rgba = {r=100,g=100,b=100,a=1}
+        bg_rgb = {r=0,g=0,b=0}
+      ]]
+
+      eq('646464', exec_lua('return vim.color.rgba_to_hex(rgba, bg_rgb)'))
+    end)
+
+    it('becomes background rgb when using alpha of 0', function()
+      exec_lua [[
+        rgba = {r=100,g=100,b=100,a=0}
+        bg_rgb = {r=0,g=0,b=0}
+      ]]
+
+      eq('000000', exec_lua('return vim.color.rgba_to_hex(rgba, bg_rgb)'))
+    end)
+
+    it('has the correct rgb when using decimal alpha', function()
+      exec_lua [[
+        rgba = {r=100,g=100,b=100,a=0.5}
+        bg_rgb = {r=0,g=0,b=0}
+      ]]
+
+      eq('323232', exec_lua('return vim.color.rgba_to_hex(rgba, bg_rgb)'))
+    end)
+  end)
+
+  describe('decode_24bit_rgb', function()
+    it('looks at the 24 least significant bits', function()
+      exec_lua [[
+        r = 255
+        g = 255
+        b = 255
+        bit25 = 1
+        rgb_24bit = bit.bor(bit.lshift(bit25, 24), bit.lshift(r, 16), bit.lshift(g, 8), b)
+      ]]
+
+      eq({r=255,g=255,b=255}, exec_lua('return vim.color.decode_24bit_rgb(rgb_24bit)'))
+    end)
+
+    it('decodes each of rgb individually', function()
+      exec_lua [[
+        r = 120 -- 11110000
+        g = 170 -- 10101010
+        b = 204 -- 11001100
+        rgb_24bit = bit.bor(bit.lshift(r, 16), bit.lshift(g, 8), b)
+      ]]
+
+      eq({r=120,g=170,b=204}, exec_lua('return vim.color.decode_24bit_rgb(rgb_24bit)'))
+    end)
+  end)
+
+  describe('perceived_lightness', function()
+    it('assigns a lightness of 0 to black', function()
+      exec_lua('rgb = {r=0,g=0,b=0}')
+
+      eq(0, exec_lua('return vim.color.perceived_lightness(rgb)'))
+    end)
+
+    it('assigns a lightness of 100 to white', function()
+      exec_lua('rgb = {r=255,g=255,b=255}')
+
+      eq(100, exec_lua('return vim.color.perceived_lightness(rgb)'))
+    end)
+
+    it('assigns correct lightness to blue', function()
+      exec_lua('rgb = {r=0,g=0,b=255}')
+
+      eq(32, exec_lua('return math.floor(vim.color.perceived_lightness(rgb))'))
+    end)
+
+    it('assigns correct lightness to lime', function()
+      exec_lua('rgb = {r=0,g=255,b=0}')
+
+      eq(87, exec_lua('return math.floor(vim.color.perceived_lightness(rgb))'))
+    end)
+  end)
+end)


### PR DESCRIPTION
Implements https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor.

Config:

```lua
require 'lspconfig'.cssls.setup {
    handlers = {
        ["textDocument/documentColor"] = vim.lsp.with(
            vim.lsp.color.on_document_color, {
                background = true,
                -- foreground = true,
                -- virtual_text = true,
            }
        )
    },
    on_attach = function(client)
      api.nvim_command [[ autocmd TextChanged,InsertLeave * lua vim.lsp.buf.document_color() ]]
      vim.lsp.buf.document_color()
    end
}
```

<img width="1392" alt="Screen Shot 2021-01-06 at 4 36 29 PM" src="https://user-images.githubusercontent.com/21000943/103822080-6e60d900-503d-11eb-8fd2-cf59074c802a.png">
<img width="1392" alt="Screen Shot 2021-01-06 at 4 36 40 PM" src="https://user-images.githubusercontent.com/21000943/103822101-7456ba00-503d-11eb-83dd-10ad09497628.png">
<img width="1392" alt="Screen Shot 2021-01-06 at 4 36 55 PM" src="https://user-images.githubusercontent.com/21000943/103822113-7882d780-503d-11eb-9818-8f13371299ee.png">

The main logic is in `runtime/lua/vim/lsp/color.lua` which adds colors the buffer. It has 3 ways of adding the color, either background, foreground, or virtual text.

There's also a module I added at `runtime/lua/vim/color.lua` which is just some utility functions for working with rgb colors. Most are self-explanatory, the `perceived_lightness` is used when adding background colors because we need to update the text foreground color as well to either white or black so it remains readable.

Documentation for each was added to lsp.txt and lua.txt respectively.