### PR TITLE
vim-patch:8.2.{456,458,461,470,2274,2277}

### DIFF
--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -116,5 +116,7 @@ func Test_confirm_cmd_cancel()
   call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
         \ term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "N")
+  call WaitForAssert({-> assert_match('^ *0,0-1         All$',
+        \ term_getline(buf, 20))}, 1000)
   call StopVimInTerminal(buf)
 endfunc

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -1,5 +1,7 @@
 " Tests for various Ex commands.
 
+source check.vim
+
 func Test_ex_delete()
   new
   call setline(1, ['a', 'b', 'c'])
@@ -39,4 +41,77 @@ func Test_buffers_lastused()
   bwipeout bufa
   bwipeout bufb
   bwipeout bufc
+endfunc
+
+" Test for the :confirm command dialog
+func Test_confirm_cmd()
+  CheckNotGui
+  CheckRunVimInTerminal
+  call writefile(['foo1'], 'foo')
+  call writefile(['bar1'], 'bar')
+  " Test for saving all the modified buffers
+  let buf = RunVimInTerminal('', {'rows': 20})
+  call term_sendkeys(buf, ":set nomore\n")
+  call term_sendkeys(buf, ":new foo\n")
+  call term_sendkeys(buf, ":call setline(1, 'foo2')\n")
+  call term_sendkeys(buf, ":new bar\n")
+  call term_sendkeys(buf, ":call setline(1, 'bar2')\n")
+  call term_sendkeys(buf, ":wincmd b\n")
+  call term_sendkeys(buf, ":confirm qall\n")
+  call WaitForAssert({-> assert_match('\[Y\]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, "A")
+  call StopVimInTerminal(buf)
+  call assert_equal(['foo2'], readfile('foo'))
+  call assert_equal(['bar2'], readfile('bar'))
+  " Test for discarding all the changes to modified buffers
+  let buf = RunVimInTerminal('', {'rows': 20})
+  call term_sendkeys(buf, ":set nomore\n")
+  call term_sendkeys(buf, ":new foo\n")
+  call term_sendkeys(buf, ":call setline(1, 'foo3')\n")
+  call term_sendkeys(buf, ":new bar\n")
+  call term_sendkeys(buf, ":call setline(1, 'bar3')\n")
+  call term_sendkeys(buf, ":wincmd b\n")
+  call term_sendkeys(buf, ":confirm qall\n")
+  call WaitForAssert({-> assert_match('\[Y\]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, "D")
+  call StopVimInTerminal(buf)
+  call assert_equal(['foo2'], readfile('foo'))
+  call assert_equal(['bar2'], readfile('bar'))
+  " Test for saving and discarding changes to some buffers
+  let buf = RunVimInTerminal('', {'rows': 20})
+  call term_sendkeys(buf, ":set nomore\n")
+  call term_sendkeys(buf, ":new foo\n")
+  call term_sendkeys(buf, ":call setline(1, 'foo4')\n")
+  call term_sendkeys(buf, ":new bar\n")
+  call term_sendkeys(buf, ":call setline(1, 'bar4')\n")
+  call term_sendkeys(buf, ":wincmd b\n")
+  call term_sendkeys(buf, ":confirm qall\n")
+  call WaitForAssert({-> assert_match('\[Y\]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, "N")
+  call WaitForAssert({-> assert_match('\[Y\]es, (N)o, (C)ancel: ', term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, "Y")
+  call StopVimInTerminal(buf)
+  call assert_equal(['foo4'], readfile('foo'))
+  call assert_equal(['bar2'], readfile('bar'))
+
+  call delete('foo')
+  call delete('bar')
+endfunc
+
+func Test_confirm_cmd_cancel()
+  " Test for closing a window with a modified buffer
+  let buf = RunVimInTerminal('', {'rows': 20})
+  call term_sendkeys(buf, ":set nomore\n")
+  call term_sendkeys(buf, ":new\n")
+  call term_sendkeys(buf, ":call setline(1, 'abc')\n")
+  call term_sendkeys(buf, ":confirm close\n")
+  call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
+        \ term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, "C")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":confirm close\n")
+  call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
+        \ term_getline(buf, 20))}, 1000)
+  call term_sendkeys(buf, "N")
+  call StopVimInTerminal(buf)
 endfunc

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -99,6 +99,9 @@ func Test_confirm_cmd()
 endfunc
 
 func Test_confirm_cmd_cancel()
+  CheckNotGui
+  CheckRunVimInTerminal
+
   " Test for closing a window with a modified buffer
   let buf = RunVimInTerminal('', {'rows': 20})
   call term_sendkeys(buf, ":set nomore\n")

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -111,7 +111,7 @@ func Test_confirm_cmd_cancel()
   call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
         \ term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "C")
-  call term_wait(buf, 50)
+  call WaitForAssert({-> assert_equal('', term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, ":confirm close\n")
   call WaitForAssert({-> assert_match('^\[Y\]es, (N)o, (C)ancel: *$',
         \ term_getline(buf, 20))}, 1000)


### PR DESCRIPTION
These patches add tests that won't run because they depend on Vim's terminal. I ported these patches only to include the recent N/A patches in the commit message.