### PR TITLE
LSP: fix messageRequest to not return nested title

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -176,6 +176,7 @@ specification. These LSP requests/notifications are defined by default:
     textDocument/typeDefinition*
     window/logMessage
     window/showMessage
+    window/showMessageRequest
     workspace/applyEdit
     workspace/symbol
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -93,10 +93,7 @@ M['window/showMessageRequest'] = function(_, _, params)
   if choice < 1 or choice > #actions then
       return vim.NIL
   else
-    local action_chosen = actions[choice]
-    return {
-      title = action_chosen;
-    }
+    return actions[choice]
   end
 end
 


### PR DESCRIPTION
Small but important fix.

before:
```
result = { title = { title = "Import build" } }}
```
after:
```
result = { title = "Import build" } }
```

Action shot: 


https://user-images.githubusercontent.com/13316262/103479087-fdd96400-4d7f-11eb-9439-83b3d8183167.mov


cc @ckipp01 (sorry about that, and thanks for noticing/testing!)

@teto Can you take a look and merge this after ckipp has tested? I tested on vuels (which surprisingly didn't have any error before) and metals