### PR TITLE
Extmarks api: allow for gravity

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -69,7 +69,7 @@ void bufhl_add_hl_pos_offset(buf_T *buf,
     }
     (void)extmark_set(buf, (uint64_t)src_id, 0,
                       (int)lnum-1, hl_start, (int)lnum-1+end_off, hl_end,
-                      decor, kExtmarkNoUndo);
+                      decor, true, kExtmarkNoUndo);
   }
 }
 

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -69,7 +69,7 @@ void bufhl_add_hl_pos_offset(buf_T *buf,
     }
     (void)extmark_set(buf, (uint64_t)src_id, 0,
                       (int)lnum-1, hl_start, (int)lnum-1+end_off, hl_end,
-                      decor, true, kExtmarkNoUndo);
+                      decor, true, false, kExtmarkNoUndo);
   }
 }
 

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -71,7 +71,8 @@ static ExtmarkNs *buf_ns_ref(buf_T *buf, uint64_t ns_id, bool put) {
 /// @returns the mark id
 uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
                      int row, colnr_T col, int end_row, colnr_T end_col,
-                     Decoration *decor, bool right_gravity, ExtmarkOp op)
+                     Decoration *decor, bool right_gravity,
+                     bool end_right_gravity, ExtmarkOp op)
 {
   ExtmarkNs *ns = buf_ns_ref(buf, ns_id, true);
   assert(ns != NULL);
@@ -110,7 +111,7 @@ uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
   if (end_row > -1) {
     mark = marktree_put_pair(buf->b_marktree,
                              row, col, right_gravity,
-                             end_row, end_col, false);
+                             end_row, end_col, end_right_gravity);
   } else {
     mark = marktree_put(buf->b_marktree, row, col, right_gravity);
   }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -71,7 +71,7 @@ static ExtmarkNs *buf_ns_ref(buf_T *buf, uint64_t ns_id, bool put) {
 /// @returns the mark id
 uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
                      int row, colnr_T col, int end_row, colnr_T end_col,
-                     Decoration *decor, ExtmarkOp op)
+                     Decoration *decor, bool right_gravity, ExtmarkOp op)
 {
   ExtmarkNs *ns = buf_ns_ref(buf, ns_id, true);
   assert(ns != NULL);
@@ -109,10 +109,10 @@ uint64_t extmark_set(buf_T *buf, uint64_t ns_id, uint64_t id,
 
   if (end_row > -1) {
     mark = marktree_put_pair(buf->b_marktree,
-                             row, col, true,
+                             row, col, right_gravity,
                              end_row, end_col, false);
   } else {
-    mark = marktree_put(buf->b_marktree, row, col, true);
+    mark = marktree_put(buf->b_marktree, row, col, right_gravity);
   }
 
 revised:

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1389,6 +1389,40 @@ describe('API/extmarks', function()
       undo]],false)
     eq(2, meths.eval('1+1')) -- did not crash
   end)
+
+  it('works with left and right gravity', function()
+    -- right gravity should move with inserted text, while
+    -- left gravity should stay in place.
+    curbufmeths.set_extmark(ns, 0, 5, {gravity = 'left'})
+    curbufmeths.set_extmark(ns, 0, 5, {gravity = 'right'})
+    feed([[Aasdfasdf]])
+
+    eq({ {1, 0, 5}, {2, 0, 13} },
+        curbufmeths.get_extmarks(ns, 0, -1, {}))
+
+    -- but both move when text is inserted before
+    feed([[<esc>Iasdf<esc>]])
+    -- eq({}, curbufmeths.get_lines(0, -1, true))
+    eq({ {1, 0, 9}, {2, 0, 17} },
+        curbufmeths.get_extmarks(ns, 0, -1, {}))
+
+    -- clear text
+    curbufmeths.set_text(0, 0, 0, 17, {})
+
+    -- handles set_text correctly as well
+    eq({ {1, 0, 0}, {2, 0, 0} },
+        meths.buf_get_extmarks(0, ns, 0, -1, {}))
+    curbufmeths.set_text(0, 0, 0, 0, {'asdfasdf'})
+    eq({ {1, 0, 0}, {2, 0, 8} },
+        curbufmeths.get_extmarks(ns, 0, -1, {}))
+
+    feed('u')
+    -- handles pasting
+    meths.exec([[let @a='asdfasdf']], false)
+    feed([["ap]])
+    eq({ {1, 0, 0}, {2, 0, 8} },
+        meths.buf_get_extmarks(0, ns, 0, -1, {}))
+  end)
 end)
 
 describe('Extmarks buffer api with many marks', function()

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1393,8 +1393,8 @@ describe('API/extmarks', function()
   it('works with left and right gravity', function()
     -- right gravity should move with inserted text, while
     -- left gravity should stay in place.
-    curbufmeths.set_extmark(ns, 0, 5, {gravity = 'left'})
-    curbufmeths.set_extmark(ns, 0, 5, {gravity = 'right'})
+    curbufmeths.set_extmark(ns, 0, 5, {right_gravity = false})
+    curbufmeths.set_extmark(ns, 0, 5, {right_gravity = true})
     feed([[Aasdfasdf]])
 
     eq({ {1, 0, 5}, {2, 0, 13} },


### PR DESCRIPTION
Allows for extmark gravity to be set.

An example: suppose we have the following text, with an extmark placed where the pipe is:

`asdf|asdf`

normally, if we type (gravity = "right"), the extmark will move with the cursor:

`asdfhello|asdf`

but with gravity = "left", the extmark will stay put:

`asdf|helloasdf`.

To decide: do we want to allow gravity for the end_col and end_row of extmarks as well? Would be useful to know of potential use cases where this would be needed.