### PR TITLE
LSP: Fix formatting sync to work with multiple servers

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -136,12 +136,13 @@ end
 --@param timeout_ms (number) Request timeout
 function M.formatting_sync(options, timeout_ms)
   local params = util.make_formatting_params(options)
-  local result = vim.lsp.buf_request_sync(0, "textDocument/formatting", params, timeout_ms)
-  if not result or vim.tbl_isempty(result) then return end
-  local _, formatting_result = next(result)
-  result = formatting_result.result
-  if not result then return end
-  vim.lsp.util.apply_text_edits(result)
+  local results = vim.lsp.buf_request_sync(0, "textDocument/formatting", params, timeout_ms)
+  if not results or vim.tbl_isempty(results) then return end
+  for _, result in ipairs(results) do
+    if result and not vim.tbl_isempty(result) then
+      vim.lsp.util.apply_text_edits(result.result)
+    end
+  end
 end
 
 --- Formats a given range.


### PR DESCRIPTION
If there is more than one server attached to a buffer, each one will
respond with changes to be applied.

I don't think the changes from every server were being applied before.

This fixes it by iterating through each table and applying the changes
in `.result`.

Example:

```lua
{ {
    result = {}
  }, {
    result = { {
        newText = "",
        range = {
          end = {
            character = 0,
            line = 30
          },
          start = {
            character = 0,
            line = 29
          }
        }
      } }
  } }
```

I'm having better results with this when running `tsserver` with `efm-langserver`
by monkeypatching.

Also, #13233  is relevant here. I don't know why it didn't work for me.

Thanks.