### PR TITLE
LSP: Fix apply text edit

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -211,7 +211,7 @@ function M.apply_text_edits(text_edits, bufnr)
   local lines = api.nvim_buf_get_lines(bufnr, start_line, finish_line + 1, false)
   local fix_eol = api.nvim_buf_get_option(bufnr, 'fixeol')
   local set_eol = fix_eol and api.nvim_buf_line_count(bufnr) <= finish_line + 1
-  if set_eol and #lines[#lines] ~= 0 then
+  if set_eol and (#lines == 0 or #lines[#lines] ~= 0) then
     table.insert(lines, '')
   end
 
@@ -224,7 +224,10 @@ function M.apply_text_edits(text_edits, bufnr)
   if set_eol and #lines[#lines] == 0 then
     table.remove(lines)
   end
-  api.nvim_buf_set_lines(bufnr, start_line, finish_line + 1, false, lines)
+  api.nvim_buf_set_lines(bufnr, start_line, (start_line + #lines), false, lines)
+  if finish_line > start_line + #lines then
+    api.nvim_buf_set_lines(bufnr, (start_line + #lines), finish_line, false, { })
+  end
 end
 
 -- local valid_windows_path_characters = "[^<>:\"/\\|?*]"


### PR DESCRIPTION
This should not be merged. Calling set text when the end of the replacement range is greater than the number of lines in the buffer leads to the cursor being reset to the beginning of the buffer.

Here is a video of me triggering `vim.lsp.buf.format()`

before:
https://user-images.githubusercontent.com/13316262/103604699-bd383280-4ec6-11eb-90af-bcfb937a53af.mov

after:
https://user-images.githubusercontent.com/13316262/103604697-bc070580-4ec6-11eb-932f-b0e841251f38.mov

