### PR TITLE
fix_cursor: do not change line number when edit will not impact cursor row

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1918,7 +1918,6 @@ static void fix_cursor(linenr_T lo, linenr_T hi, linenr_T extra)
       curwin->w_cursor.lnum += extra;
       check_cursor_col();
     } else if (extra < 0) {
-      curwin->w_cursor.lnum = lo;
       check_cursor();
     } else {
       check_cursor_col();

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -225,6 +225,14 @@ describe('lua buffer event callbacks: on_lines', function()
     eq(1, meths.get_var('listener_cursor_line'))
   end)
 
+  it('has valid cursor position while deleting lines', function()
+    meths.buf_set_lines(0, 0, -1, true, { "line_1", "line_2", "line_3", "line_4"})
+    meths.win_set_cursor(0, {2, 0})
+    eq(2, meths.win_get_cursor(0)[1])
+    meths.buf_set_lines(0, 0, -1, true, { "line_1", "line_2", "line_3"})
+    eq(2, meths.win_get_cursor(0)[1])
+  end)
+
   it('does not SEGFAULT when calling win_findbuf in on_detach', function()
 
     exec_lua[[


### PR DESCRIPTION
Closes #13691, related: https://github.com/neovim/nvim-lspconfig/issues/465

Not sure if this is the right thing to do (not sure why extra was being used, but cursor was uniformly being set to the beginning row of edit range), but it fixes the issue. 

Edit: If this is the desired behavior, I'll write a test.