### PR TITLE
LSP: Improvements to client status messaging

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -355,6 +355,9 @@ end
 ---  - {resolved_capabilities} (table): Normalized table of
 ---    capabilities that we have detected based on the initialize
 ---    response from the server in `server_capabilities`.
+---
+---  - {messages} (table): Current progress information from $/progress and
+--     buffer-specific status messages from the server.
 function lsp.client()
   error()
 end
@@ -569,8 +572,9 @@ function lsp.start_client(config)
     -- TODO(remove-callbacks)
     callbacks = handlers;
     handlers = handlers;
-    -- for $/progress report
-    messages = { name = name, messages = {}, progress = {}, status = {} }
+
+    -- for $/progress report and buffer status messages
+    messages = { messages = {}, progress = {}, status = {} };
   }
 
   -- Store the uninitialized_clients for cleanup in case we exit before initialize finishes.
@@ -919,6 +923,9 @@ function lsp.buf_attach_client(bufnr, client_id)
         for_each_buffer_client(bufnr, function(client, _client_id)
           if client.resolved_capabilities.text_document_open_close then
             client.notify('textDocument/didClose', params)
+          end
+          if client.messages.status[uri] then
+            client.messages.status[uri] = nil
           end
         end)
         util.buf_versions[bufnr] = nil

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -35,7 +35,6 @@ local function progress_callback(_, _, params, client_id)
   local val = params.value    -- unspecified yet
   local token = params.token  -- string or number
 
-
   if val.kind then
     if val.kind == 'begin' then
       client.messages.progress[token] = {
@@ -68,9 +67,8 @@ M['$/progress'] = progress_callback
 M['window/workDoneProgress/create'] =  function(_, _, params, client_id)
   local client = vim.lsp.get_client_by_id(client_id)
   local token = params.token  -- string or number
-  local client_name = client and client.name or string.format("id=%d", client_id)
   if not client then
-    err_message("LSP[", client_name, "] client has shut down after sending the message")
+    err_message("LSP[id=", client_id, "] client has shut down after sending the message")
   end
   client.messages.progress[token] = {}
   return vim.NIL


### PR DESCRIPTION
Some language servers have extensions that provide a per-file status
message that can be useful for display in the vim statusline. This
commit provides support for tracking per-buffer status messages from the
server.

This also cleans up some of the handlers for $/progress and related.