### PR TITLE
LSP: Fix nil settings handling in workspace/configuration

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -229,6 +229,7 @@ local function validate_client_config(config)
     before_init     = { config.before_init, "f", true };
     offset_encoding = { config.offset_encoding, "s", true };
     flags           = { config.flags, "t", true };
+    settings        = { config.settings, "t", true };
   }
 
   -- TODO(remove-callbacks)
@@ -458,6 +459,7 @@ function lsp.start_client(config)
   local cmd, cmd_args, offset_encoding = cleaned_config.cmd, cleaned_config.cmd_args, cleaned_config.offset_encoding
 
   config.flags = config.flags or {}
+  config.settings = config.settings or {}
 
   local client_id = next_client_id()
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -162,6 +162,7 @@ M['workspace/configuration'] = function(err, _, params, client_id)
   local client = vim.lsp.get_client_by_id(client_id)
   if not client then
     err_message("LSP[id=", client_id, "] client has shut down after sending the message")
+    return
   end
   if err then error(vim.inspect(err)) end
   if not params.items then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -303,6 +303,21 @@ describe('LSP', function()
         end;
       }
     end)
+    it('workspace/configuration returns NIL per section if client was started without config.settings', function()
+      fake_lsp_server_setup('workspace/configuration no settings')
+      eq({
+        NIL,
+        NIL,
+      }, exec_lua [[
+        local params = {
+          items = {
+            {section = 'foo'},
+            {section = 'bar'},
+          }
+        }
+        return vim.lsp.handlers['workspace/configuration'](nil, nil, params, TEST_RPC_CLIENT_ID)
+      ]])
+    end)
 
     it('should verify capabilities sent', function()
       local expected_callbacks = {


### PR DESCRIPTION
The `workspace/configuration` handler could fail with the following
error if `config.settings` is nil:

    runtime/lua/vim/lsp/util.lua:1432: attempt to index local 'settings' (a nil value)"