### PR TITLE
[LSP] - Option  to  truncate LSP diagnostic virtual text on newline.

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1397,6 +1397,9 @@ set_virtual_text({diagnostics}, {bufnr}, {client_id}, {diagnostic_ns}, {opts})
                                        • Limit severity of diagnostics found.
                                          E.g. "Warning" means { "Error",
                                          "Warning" } will be valid.
+                                     • truncated (boolean): Whether virtual
+                                       text should be truncated on newline.
+
 
                                   *vim.lsp.diagnostic.show_line_diagnostics()*
 show_line_diagnostics({opts}, {bufnr}, {line_nr}, {client_id})

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -727,6 +727,7 @@ end
 ---             - spacing (number): Number of spaces to insert before virtual text
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
+--              - truncated (boolean): Whether to truncate virtual text on newline.
 function M.set_virtual_text(diagnostics, bufnr, client_id, diagnostic_ns, opts)
   opts = opts or {}
 
@@ -786,7 +787,11 @@ function M.get_virtual_text_chunks_for_line(bufnr, line, line_diags, opts)
     local newline_index, _ = string.find(stripped_msg, "\n")
     local diagnostic_msg
     if newline_index then
-      diagnostic_msg = string.sub(stripped_msg, 1, newline_index - 1)
+      if opts.truncated then
+        diagnostic_msg = string.sub(stripped_msg, 1, newline_index - 1)
+      else
+        diagnostic_msg = stripped_msg:gsub("\n", " ")
+      end
     else
       diagnostic_msg = stripped_msg
     end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -757,10 +757,19 @@ function M.get_virtual_text_chunks_for_line(bufnr, line, line_diags, opts)
   -- TODO(tjdevries): Allow different servers to be shown first somehow?
   -- TODO(tjdevries): Display server name associated with these?
   if last.message then
+    local stripped_msg = last.message:gsub("\r", "")
+    local newline_index, _ = string.find(stripped_msg, "\n")
+    local diagnostic_msg
+    if newline_index then
+      diagnostic_msg = string.sub(stripped_msg, 1, newline_index - 1)
+    else
+      diagnostic_msg = stripped_msg
+    end
+
     table.insert(
       virt_texts,
       {
-        string.format("%s %s", prefix, last.message:gsub("\r", ""):gsub("\n", "  ")),
+        string.format("%s %s", prefix, diagnostic_msg),
         virtual_text_highlight_map[last.severity]
       }
     )

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -333,24 +333,31 @@ describe('vim.lsp.diagnostic', function()
   end)
 
   describe('vim.lsp.diagnostic.get_virtual_text_chunks_for_line', function()
-    it('should correctly return the full message if no new lines are present', function()
+    it('should correctly return the full message with newlines as spaces if not truncated', function()
+      local virtual_texts = exec_lua [[
+      local diags = { make_error('Simple diagnostic message\nHere is line two', 2, 2, 2) }
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      ]]
+      eq('■ Simple diagnostic message Here is line two', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
+    end)
+    it('should correctly return the full message if no new lines are present and truncated set', function()
       local virtual_texts = exec_lua [[
       local diags = { make_error('Simple diagnostic message', 2, 2, 2) }
-      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags, {truncated = true})
       ]]
       eq('■ Simple diagnostic message', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
     end)
-    it('should correctly return truncated on new line', function()
+    it('should correctly return truncated on new line if truncated is set', function()
       local virtual_texts = exec_lua [[
       local diags = { make_error('Simple diagnostic message\nSecond line with more details', 2, 2, 2) }
-      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags, {truncated = true})
       ]]
       eq('■ Simple diagnostic message', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
     end)
-    it('should correctly return truncated on new line, even on windows!', function()
+    it('should correctly return truncated on newline if truncated is set, even on windows!', function()
       local virtual_texts = exec_lua [[
       local diags = { make_error('Simple diagnostic message\n\rSecond line with more details', 2, 2, 2) }
-      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags, {truncated = true})
       ]]
       eq('■ Simple diagnostic message', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
     end)

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -332,6 +332,29 @@ describe('vim.lsp.diagnostic', function()
     end)
   end)
 
+  describe('vim.lsp.diagnostic.get_virtual_text_chunks_for_line', function()
+    it('should correctly return the full message if no new lines are present', function()
+      local virtual_texts = exec_lua [[
+      local diags = { make_error('Simple diagnostic message', 2, 2, 2) }
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      ]]
+      eq('■ Simple diagnostic message', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
+    end)
+    it('should correctly return truncated on new line', function()
+      local virtual_texts = exec_lua [[
+      local diags = { make_error('Simple diagnostic message\nSecond line with more details', 2, 2, 2) }
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      ]]
+      eq('■ Simple diagnostic message', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
+    end)
+    it('should correctly return truncated on new line, even on windows!', function()
+      local virtual_texts = exec_lua [[
+      local diags = { make_error('Simple diagnostic message\n\rSecond line with more details', 2, 2, 2) }
+      return vim.lsp.diagnostic.get_virtual_text_chunks_for_line(diagnostic_bufnr, 2, diags)
+      ]]
+      eq('■ Simple diagnostic message', virtual_texts[2][1]) -- [2] to skip the '    ' and [1] target the msg of the chunk
+    end)
+  end)
   describe("vim.lsp.diagnostic.get_line_diagnostics", function()
     it('should return an empty table when no diagnostics are present', function()
       eq({}, exec_lua [[return vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1)]])


### PR DESCRIPTION
Currently when we have a diagnostic that contains a new line, we simply
strip it out and replace it with a space. For some languages this may
work fine, but for a lot of typed languages that have longer signatures
or types and also multi-line diagnostics, this falls apart pretty quickly.
This takes a different approach and if a new line is detected it will
instead truncate the diagnostic message (only for the virtual text) and
only display the first line making a more succinct message. Then when they
go to view the diagnostic they will continue to see the full message as they
would have before.

Here are a few images to illustrate this. The current behavior looks like this:

_A longer example with a stack trace include, which will never show correctly_
<img width="1680" alt="Screenshot 2021-01-09 at 11 12 35" src="https://user-images.githubusercontent.com/13974112/104089127-80748e80-526c-11eb-8c03-f0d3411631e2.png">

_A shorter example that already causes issues if the screen is split_
<img width="851" alt="Screenshot 2021-01-09 at 11 13 49" src="https://user-images.githubusercontent.com/13974112/104089133-908c6e00-526c-11eb-8b2d-8e4828c18d71.png">

The proposed behavior would look like this:

_Longer example now only shows the first line_
<img width="1128" alt="Screenshot 2021-01-09 at 11 03 10" src="https://user-images.githubusercontent.com/13974112/104089142-ab5ee280-526c-11eb-8015-ccf49d052f5d.png">

_To see the rest of the diagnostic, you'd still be able to view it as before_
<img width="1151" alt="Screenshot 2021-01-09 at 11 03 26" src="https://user-images.githubusercontent.com/13974112/104089158-c5002a00-526c-11eb-9930-cf182048cc16.png">

_And even the shorter examples still get the main point across_
<img width="551" alt="Screenshot 2021-01-09 at 11 08 45" src="https://user-images.githubusercontent.com/13974112/104089164-d77a6380-526c-11eb-996e-60c1e7fce2dd.png">

_And again with the details still there_
<img width="551" alt="Screenshot 2021-01-09 at 11 08 53" src="https://user-images.githubusercontent.com/13974112/104089170-e2cd8f00-526c-11eb-91d2-f066277d3d56.png">

