### PR TITLE
Do not delete the nightly tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,13 +149,6 @@ jobs:
         run: echo 'SUBJECT=Nvim development (prerelease) build' >> $GITHUB_ENV
       - if: env.TAG_NAME != 'nightly'
         run: echo 'SUBJECT=Nvim release build' >> $GITHUB_ENV
-      - if: env.TAG_NAME == 'nightly'
-        uses: dev-drprasad/delete-tag-and-release@v0.1.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          delete_release: false
-          tag_name: nightly
       - uses: meeDamian/github-release@2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The [latest](https://github.com/neovim/neovim/actions/runs/475152704) nightly release action removed the nightly tag and failed to create a new one.

The [dev-drprasad/delete-tag-and-release](https://github.com/dev-drprasad/delete-tag-and-release) should not delete the nightly release in the first place due to the `delete_release: false`. Unfortunately, this is hindered by https://github.com/dev-drprasad/delete-tag-and-release/issues/5.

I suppose that since [meeDamian/github-release](https://github.com/meeDamian/github-release) is used with `allow_override: ${{ env.TAG_NAME == 'nightly' }}` we can drop the `dev-drprasad/delete-tag-and-release` altogether.