### PR TITLE
Do not delete the nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          delete_release: false
+          delete_release: ''
           tag_name: nightly
       - uses: meeDamian/github-release@2.0
         with:


### PR DESCRIPTION
Due to a bug in a dependency, the GitHub action defaults to removing a release for nightly. This is a continuation of https://github.com/neovim/neovim/pull/13732.