### PR TITLE
logging: move nvim logs to XDG_CACHE_HOME

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -327,7 +327,7 @@ Print version information and exit.
 .Sh ENVIRONMENT
 .Bl -tag -width Fl
 .It Ev NVIM_LOG_FILE
-Low-level log file, usually found at ~/.local/share/nvim/log.
+Low-level log file, usually found at ~/.cache/nvim/log.
 :help $NVIM_LOG_FILE
 .It Ev VIM
 Used to locate user files, such as init.vim.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1342,7 +1342,7 @@ LOG FILE					*$NVIM_LOG_FILE*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE
-Usually the file is ~/.local/share/nvim/log unless that path is inaccessible
+Usually the file is ~/.cache/nvim/log unless that path is inaccessible
 or if $NVIM_LOG_FILE was set before |startup|.
 
 

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -28,7 +28,7 @@ do
   local function path_join(...)
     return table.concat(vim.tbl_flatten{...}, path_sep)
   end
-  local logfilename = path_join(vim.fn.stdpath('data'), 'lsp.log')
+  local logfilename = path_join(vim.fn.stdpath('cache'), 'lsp.log')
 
   --- Returns the log filename.
   --@returns (string) log filename
@@ -36,7 +36,7 @@ do
     return logfilename
   end
 
-  vim.fn.mkdir(vim.fn.stdpath('data'), "p")
+  vim.fn.mkdir(vim.fn.stdpath('cache'), "p")
   local logfile = assert(io.open(logfilename, "a+"))
   for level, levelnr in pairs(log.levels) do
     -- Also export the log level on the root object.

--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -38,7 +38,7 @@ alternate file (e.g. stderr) use `LOG_CALLSTACK_TO_FILE(FILE*)`. Requires
 Many log messages have a shared prefix, such as "UI" or "RPC". Use the shell to
 filter the log, e.g. at DEBUG level you might want to exclude UI messages:
 
-    tail -F ~/.local/share/nvim/log | cat -v | stdbuf -o0 grep -v UI | stdbuf -o0 tee -a log
+    tail -F ~/.cache/nvim/log | cat -v | stdbuf -o0 grep -v UI | stdbuf -o0 tee -a log
 
 Build with ASAN
 ---------------

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -51,7 +51,7 @@ static bool log_try_create(char *fname)
 
 /// Initializes path to log file. Sets $NVIM_LOG_FILE if empty.
 ///
-/// Tries $NVIM_LOG_FILE, or falls back to $XDG_DATA_HOME/nvim/log. Path to log
+/// Tries $NVIM_LOG_FILE, or falls back to $XDG_CACHE_HOME/nvim/log. Path to log
 /// file is cached, so only the first call has effect, unless first call was not
 /// successful. Failed initialization indicates either a bug in expand_env()
 /// or both $NVIM_LOG_FILE and $HOME environment variables are undefined.
@@ -70,7 +70,7 @@ static bool log_path_init(void)
       || os_isdir((char_u *)log_file_path)
       || !log_try_create(log_file_path)) {
     // Invalid $NVIM_LOG_FILE or failed to expand; fall back to default.
-    char *defaultpath = stdpaths_user_data_subpath("log", 0, true);
+    char *defaultpath = stdpaths_user_cache_subpath("log");
     size_t len = xstrlcpy(log_file_path, defaultpath, size);
     xfree(defaultpath);
     // Fall back to .nvimlog

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -108,6 +108,17 @@ char *get_xdg_home(const XDGVarType idx)
   return dir;
 }
 
+/// Return subpath of $XDG_CACHE_HOME
+///
+/// @param[in]  fname  New component of the path.
+///
+/// @return [allocated] `$XDG_CACHE_HOME/nvim/{fname}`
+char *stdpaths_user_cache_subpath(const char *fname)
+  FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
+{
+  return concat_fnames_realloc(get_xdg_home(kXDGCacheHome), fname, true);
+}
+
 /// Return subpath of $XDG_CONFIG_HOME
 ///
 /// @param[in]  fname  New component of the path.

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -204,9 +204,8 @@ describe('startup defaults', function()
   end)
 
   describe('$NVIM_LOG_FILE', function()
-    local datasubdir = iswin() and 'nvim-data' or 'nvim'
     local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgdatadir = xdgdir..'/'..datasubdir
+    local xdgcachedir = xdgdir..'/nvim'
     after_each(function()
       os.remove('Xtest-logpath')
       rmdir(xdgdir)
@@ -218,25 +217,25 @@ describe('startup defaults', function()
       }})
       eq('Xtest-logpath', eval('$NVIM_LOG_FILE'))
     end)
-    it('defaults to stdpath("data")/log if empty', function()
-      eq(true, mkdir(xdgdir) and mkdir(xdgdatadir))
+    it('defaults to stdpath("cache")/log if empty', function()
+      eq(true, mkdir(xdgdir) and mkdir(xdgcachedir))
       clear({env={
-        XDG_DATA_HOME=xdgdir,
+        XDG_CACHE_HOME=xdgdir,
         NVIM_LOG_FILE='',  -- Empty is invalid.
       }})
-      eq(xdgdir..'/'..datasubdir..'/log', string.gsub(eval('$NVIM_LOG_FILE'), '\\', '/'))
+      eq(xdgcachedir..'/log', string.gsub(eval('$NVIM_LOG_FILE'), '\\', '/'))
     end)
-    it('defaults to stdpath("data")/log if invalid', function()
-      eq(true, mkdir(xdgdir) and mkdir(xdgdatadir))
+    it('defaults to stdpath("cache")/log if invalid', function()
+      eq(true, mkdir(xdgdir) and mkdir(xdgcachedir))
       clear({env={
-        XDG_DATA_HOME=xdgdir,
+        XDG_CACHE_HOME=xdgdir,
         NVIM_LOG_FILE='.',  -- Any directory is invalid.
       }})
-      eq(xdgdir..'/'..datasubdir..'/log', string.gsub(eval('$NVIM_LOG_FILE'), '\\', '/'))
+      eq(xdgcachedir..'/log', string.gsub(eval('$NVIM_LOG_FILE'), '\\', '/'))
     end)
-    it('defaults to .nvimlog if stdpath("data") is invalid', function()
+    it('defaults to .nvimlog if stdpath("cache") is invalid', function()
       clear({env={
-        XDG_DATA_HOME='Xtest-missing-xdg-dir',
+        XDG_CACHE_HOME='Xtest-missing-xdg-dir',
         NVIM_LOG_FILE='.',  -- Any directory is invalid.
       }})
       eq('.nvimlog', eval('$NVIM_LOG_FILE'))


### PR DESCRIPTION
Closes #13706

* moves neovim's logs (including for language servers) to $XDG_CACHE_HOME


cc @teto @clason 