### PR TITLE
Add warning when writing terminal buffer to existing file

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1883,7 +1883,7 @@ check_overwrite(
            && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
        || (buf->b_flags & BF_READERR))
       && !p_wa
-      && !bt_nofile(buf)
+      && (!bt_nofile(buf) || bt_terminal(buf)) // check if buffer is terminal
       && os_path_exists(ffname)) {
     if (!eap->forceit && !eap->append) {
 #ifdef UNIX

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1883,7 +1883,7 @@ check_overwrite(
            && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
        || (buf->b_flags & BF_READERR))
       && !p_wa
-      && (!bt_nofile(buf) || bt_terminal(buf)) // check if buffer is terminal
+      && (!bt_nofile(buf) || bt_terminal(buf))
       && os_path_exists(ffname)) {
     if (!eap->forceit && !eap->append) {
 #ifdef UNIX


### PR DESCRIPTION
Addresses #13549. When `:w` is done from a terminal buffer onto an existing file, the write will error. `:w!` overrides this error. 