### PR TITLE
[DNM] Switch to OpenResty LuaJIT2

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -151,8 +151,8 @@ set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0
 set(MSGPACK_SHA256 bfbb71b7c02f806393bc3cbc491b40523b89e64f83860c58e3e54af47de176e4)
 
 # https://github.com/LuaJIT/LuaJIT/tree/v2.1
-set(LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/b4b2dce9fc3ffaaaede39b36d06415311e2aa516.tar.gz)
-set(LUAJIT_SHA256 6c9e46877db2df16ca0fa76db4043ed30a1ae60c89d9ba2c3e4d35eb2360cd4d)
+set(LUAJIT_URL https://github.com/openresty/luajit2/archive/v2.1-20201229.tar.gz)
+set(LUAJIT_SHA256 4275bf97356d713826e7195d1c330568b6089ff1fd4c6954f998e0f60a2baa30)
 
 set(LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz)
 set(LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -151,8 +151,8 @@ set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0
 set(MSGPACK_SHA256 bfbb71b7c02f806393bc3cbc491b40523b89e64f83860c58e3e54af47de176e4)
 
 # https://github.com/LuaJIT/LuaJIT/tree/v2.1
-set(LUAJIT_URL https://github.com/openresty/luajit2/archive/v2.1-20201229.tar.gz)
-set(LUAJIT_SHA256 4275bf97356d713826e7195d1c330568b6089ff1fd4c6954f998e0f60a2baa30)
+set(LUAJIT_URL https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20211210.tar.gz)
+set(LUAJIT_SHA256 605a8ac048ce8fcb872286abf674491467c3483d759e071721cea9a50e5bd220)
 
 set(LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz)
 set(LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333)


### PR DESCRIPTION
Building neovim HEAD (and thus 0.5) on Apple M1 requires a non-released commit of <https://github.com/LuaJIT/LuaJIT>. While LuaJIT is not unmaintained at the moment, they seem reluctant to release a new (beta) version that could be tagged as a dependency. This makes distributions unhappy, which in some cases are looking to drop LuaJIT in favor of a fork with regular releases -- in particular, https://github.com/openresty/luajit2 ([MoonJIT](https://github.com/moonjit/moonjit) has shut down and forwarded their patches to LuaJIT2.)

This PR replaces in `CMakeLists.txt` the unreleased commit of LuaJIT with the latest release of LuaJIT2, which is up-to-date with upstream as of October 13 (in particular, including the commits needed to build on Apple M1) with a handful of unrelated commits on top.

Preliminary tests indicate that this is a drop-in replacement, so I wanted to see if CI agrees. (Even if _we_ don't want to switch, this might be useful to keep around as a "canary" that warns of possible downstream issues.)

**EDIT** Homebrew in fact now [builds neovim with OpenResty LuaJIT2 instead of LuaJIT](https://github.com/Homebrew/homebrew-core/commit/3d3a50406d79662404b5b717b07a5e283931b42b).