### PR TITLE
lsp: configure diagnostic display with autocommands

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1247,8 +1247,9 @@ on_publish_diagnostics({_}, {_}, {params}, {client_id}, {_}, {config})
                      signs = function(bufnr, client_id)
                        return vim.bo[bufnr].show_signs == false
                      end,
-                     -- Disable a feature
-                     update_in_insert = false,
+                     -- Override on which autocommands diagnostics are displayed.
+                     -- Default: { "InsertLeave", "CursorHoldI" },
+                     show_diagnostic_autocmds = { "BufWritePost" },
                    }
                  )
 <

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1001,14 +1001,18 @@ function M.on_publish_diagnostics(_, _, params, client_id, _, config)
     signs = true,
     underline = true,
     virtual_text = true,
-    show_diagnostic_autocmds = { "InsertLeave", "CursorHoldI" },
+    show_diagnostic_autocmds = false,
   }, config)
 
   _bufs_waiting_to_update[bufnr][client_id] = config
 
-  local key = make_augroup_key(bufnr, client_id)
-  if not registered[key] then
-      M._schedule_display(bufnr, client_id, config)
+  if config.show_diagnostic_autocmds then
+    local key = make_augroup_key(bufnr, client_id)
+    if not registered[key] then
+        M._schedule_display(bufnr, client_id, config)
+    end
+  else
+    M.display(diagnostics, bufnr, client_id, config)
   end
 
 end


### PR DESCRIPTION
Closes #13324

@tjdevries I'm opening this so we can discuss

* Cleaned up separation of logic between on_publish_diagnostic, display, and schedule display
* Display now only handles displaying things, schedule display handles making the autocmd,  the handler sets the flag and validates the config (maybe this is called often enough that we should move this back into schedule_display, but I don't think it should be under display itself)
* I factored out resolve_optional_value to clean up display
* show_diagnostic_autocmds vs display_diagnostic_autocmds? autocmds vs autocommands?
* Should we clear the autocmd on terminating the client? I don't think we current do this now
* Maybe we should store registered[key] and _bufs_waiting_to_update[bufnr][client_id] under the same datastructure under client? See this commit in another [branch](https://github.com/mjlbach/neovim/commit/106cc2873ef2359fcba55292d646027f9441522c))
* Maybe we should store config globally per client, instead of wrapping the diagnostic handler (I don't know if the table extend really has any tangible performance impact.

```lua
local nvim_lsp = require('lspconfig')

local on_attach = function(client, bufnr)
  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
  vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
    vim.lsp.diagnostic.on_publish_diagnostics, {
      -- disable virtual text
      virtual_text = false;

      -- show signs
      signs = true,

      show_diagnostic_autocmds = { "BufWritePost" },
      -- show_diagnostic_autocmds = { "InsertLeave", "CursorHoldI" },
    }
  )
end

nvim_lsp.pyright.setup {
    on_attach = on_attach,
}
```

