### PR TITLE
fix(treesitter): use source() method on attach

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -50,7 +50,7 @@ function M._create_parser(bufnr, lang, opts)
     end
   end
 
-  a.nvim_buf_attach(self.bufnr, false, {on_bytes=bytes_cb, on_detach=detach_cb, preview=true})
+  a.nvim_buf_attach(self:source(), false, {on_bytes=bytes_cb, on_detach=detach_cb, preview=true})
 
   self:parse()
 


### PR DESCRIPTION
Fixes an issue that tree-sitter always attached to the current buffer,
instead of the provided buffer.

Thanks @Conni2461 and @glepnir to raise the issue.