### PR TITLE
update nvim.appdata.xml to reflect version 0.4.4

### DIFF
--- a/runtime/nvim.appdata.xml
+++ b/runtime/nvim.appdata.xml
@@ -26,6 +26,7 @@
   </screenshots>
 
   <releases>
+    <release date="2020-08-04" version="0.4.4"/>
     <release date="2019-11-06" version="0.4.3"/>
     <release date="2019-09-15" version="0.4.2"/>
     <release date="2019-09-15" version="0.4.1"/>


### PR DESCRIPTION
I didn't know what the canonical release date of 0.4.4 is. The dates as shown by the github releases view do not exactly match the dates in the nvim.appdata.xml. But I took the release date as reported by github now anyways.
Let me know if I should use a different date.