### PR TITLE
Runtime: vim.inspect: Show file+line for functions

### DIFF
--- a/runtime/lua/vim/inspect.lua
+++ b/runtime/lua/vim/inspect.lua
@@ -289,7 +289,7 @@ function Inspector:putTable(t)
 end
 
 function Inspector:putFunction(f)
-  local info = debug.getinfo(f)
+  local info = debug.getinfo(f, 'S')
   self:puts(
     '<',
     'function ', self:getId(f), ': ',

--- a/runtime/lua/vim/inspect.lua
+++ b/runtime/lua/vim/inspect.lua
@@ -288,6 +288,16 @@ function Inspector:putTable(t)
   end
 end
 
+function Inspector:putFunction(f)
+  local info = debug.getinfo(f)
+  self:puts(
+    '<',
+    'function ', self:getId(f), ': ',
+    info.source, ':', info.linedefined,
+    '>'
+  )
+end
+
 function Inspector:putValue(v)
   local tv = type(v)
 
@@ -298,6 +308,8 @@ function Inspector:putValue(v)
     self:puts(tostring(v))
   elseif tv == 'table' then
     self:putTable(v)
+  elseif tv == 'function' then
+    self:putFunction(v)
   else
     self:puts('<', tv, ' ', self:getId(v), '>')
   end

--- a/runtime/lua/vim/inspect.lua
+++ b/runtime/lua/vim/inspect.lua
@@ -290,12 +290,19 @@ end
 
 function Inspector:putFunction(f)
   local info = debug.getinfo(f, 'S')
-  self:puts(
-    '<',
-    'function ', self:getId(f), ': ',
-    info.source, ':', info.linedefined,
-    '>'
-  )
+  local source, line = info.source, info.linedefined
+
+  local contents = {'<function ', self:getId(f)}
+  if vim.startswith(source, '@') or vim.startswith(source, '=') then
+    source = source:sub(2)
+  end
+  vim.list_extend(contents, {': ', source})
+  if line >= 0 then
+    vim.list_extend(contents, {':', line})
+  end
+  contents[#contents+1] = '>'
+
+  self:puts(unpack(contents))
 end
 
 function Inspector:putValue(v)


### PR DESCRIPTION
Makes `vim.inspect()` more useful for functions by showing where they are defined.

Since `vim.inspect` shouldn't be used in any hot code paths anyways, I hope using the `debug` module (which is said to have non-optimal performance) in this way is appropriate.

Side note: This is not terribly for functions defined in C (like, for example, API functions).

Example output of `print(vim.inspect(vim.lsp.handlers))`:

```lua
{
  ["$/progress"] = <function 1: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["callHierarchy/incomingCalls"] = <function 2: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["callHierarchy/outgoingCalls"] = <function 3: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/codeAction"] = <function 4: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/completion"] = <function 5: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/declaration"] = <function 6: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/definition"] = <function 7: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/documentHighlight"] = <function 8: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/documentSymbol"] = <function 9: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/formatting"] = <function 10: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/hover"] = <function 11: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/implementation"] = <function 12: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/publishDiagnostics"] = <function 13: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp.lua:1250>,
  ["textDocument/rangeFormatting"] = <function 14: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/references"] = <function 15: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/rename"] = <function 16: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/signatureHelp"] = <function 17: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["textDocument/typeDefinition"] = <function 18: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["window/logMessage"] = <function 19: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["window/showMessage"] = <function 20: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["window/showMessageRequest"] = <function 21: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["window/workDoneProgress/create"] = <function 22: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["workspace/applyEdit"] = <function 23: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["workspace/configuration"] = <function 24: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["workspace/executeCommand"] = <function 25: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>,
  ["workspace/symbol"] = <function 26: /home/ajaam/.local/opt/nvim/share/nvim/runtime/lua/vim/lsp/handlers.lua:393>
}
```

Example output of `print vim.inspect(vim.api.nvim_command))`:

```lua
<function 1: [C]>
```