### PR TITLE
[LSP] - Add in clientInfo to initalize_params.

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -582,7 +582,7 @@ function lsp.start_client(config)
     local valid_traces = {
       off = 'off'; messages = 'messages'; verbose = 'verbose';
     }
-    local version = vim.fn.api_info().version
+    local version = vim.version()
     local initialize_params = {
       -- The process Id of the parent process that started the server. Is null if
       -- the process has not been started by another process.  If the parent

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -582,6 +582,7 @@ function lsp.start_client(config)
     local valid_traces = {
       off = 'off'; messages = 'messages'; verbose = 'verbose';
     }
+    local version = vim.fn.api_info().version
     local initialize_params = {
       -- The process Id of the parent process that started the server. Is null if
       -- the process has not been started by another process.  If the parent
@@ -592,7 +593,7 @@ function lsp.start_client(config)
       -- since 3.15.0
       clientInfo = {
         name = "Neovim",
-        version = vim.fn.matchstr(vim.fn.execute("version"), [[NVIM \zs[^\n]\+]]) or vim.Nil
+        version = string.format("%s.%s.%s", version.major, version.minor, version.patch)
       };
       -- The rootPath of the workspace. Is null if no folder is open.
       --

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -588,6 +588,12 @@ function lsp.start_client(config)
       -- process is not alive then the server should exit (see exit notification)
       -- its process.
       processId = uv.getpid();
+      -- Information about the client
+      -- since 3.15.0
+      clientInfo = {
+        name = "Neovim",
+        version = vim.fn.matchstr(vim.fn.execute("version"), [[NVIM \zs[^\n]\+]]) or vim.Nil
+      };
       -- The rootPath of the workspace. Is null if no folder is open.
       --
       -- @deprecated in favour of rootUri.


### PR DESCRIPTION
Some servers (like Metals in my case) will actually pull this
info from the initalize_params and display it in the logs. I
know from the server perspective it helps at times to have this
available to pull from to have more details about the client and
version. You can see that this is part of the spec here:

microsoft.github.io/language-server-protocol/specification#initialize