### PR TITLE
treesitter: default start and end row when omitted

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -195,7 +195,8 @@ query:iter_captures({node}, {bufnr}, {start_row}, {end_row})
 	text of the buffer. {start_row} and {end_row} can be used to limit
 	matches inside a row range (this is typically used with root node
 	as the node, i e to get syntax highlight matches in the current
-	viewport)
+	viewport). When omitted the start and end row values are used from
+        the given node.
 
 	The iterator returns three values, a numeric id identifying the capture,
 	the captured node, and metadata from any directives processing the match.

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -353,6 +353,12 @@ function Query:iter_captures(node, source, start, stop)
   if type(source) == "number" and source == 0 then
     source = vim.api.nvim_get_current_buf()
   end
+
+  if start == nil and stop == nil then
+    start, _, stop, _ = node:range()
+    stop = stop + 1 -- Make stop inclusive
+  end
+
   local raw_iter = node:_rawquery(self.query, true, start, stop)
   local function iter()
     local capture, captured_node, match = raw_iter()
@@ -385,6 +391,12 @@ function Query:iter_matches(node, source, start, stop)
   if type(source) == "number" and source == 0 then
     source = vim.api.nvim_get_current_buf()
   end
+
+  if start == nil and stop == nil then
+    start, _, stop, _ = node:range()
+    stop = stop + 1 -- Make stop inclusive
+  end
+
   local raw_iter = node:_rawquery(self.query, false, start, stop)
   local function iter()
     local pattern, match = raw_iter()

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -340,6 +340,19 @@ function Query:apply_directives(match, pattern, source, metadata)
   end
 end
 
+
+--- Returns the start and stop value if set else the node's range.
+-- When the node's range is used, the stop is incremented by 1
+-- to make the search inclusive.
+local function value_or_node_range(start, stop, node)
+  if start == nil and stop == nil then
+    local node_start, _, node_stop, _ = node:range()
+    return node_start, node_stop + 1 -- Make stop inclusive
+  end
+
+  return start, stop
+end
+
 --- Iterates of the captures of self on a given range.
 --
 -- @param node The node under witch the search will occur
@@ -354,10 +367,7 @@ function Query:iter_captures(node, source, start, stop)
     source = vim.api.nvim_get_current_buf()
   end
 
-  if start == nil and stop == nil then
-    start, _, stop, _ = node:range()
-    stop = stop + 1 -- Make stop inclusive
-  end
+  start, stop = value_or_node_range(start, stop, node)
 
   local raw_iter = node:_rawquery(self.query, true, start, stop)
   local function iter()
@@ -392,10 +402,7 @@ function Query:iter_matches(node, source, start, stop)
     source = vim.api.nvim_get_current_buf()
   end
 
-  if start == nil and stop == nil then
-    start, _, stop, _ = node:range()
-    stop = stop + 1 -- Make stop inclusive
-  end
+  start, stop = value_or_node_range(start, stop, node)
 
   local raw_iter = node:_rawquery(self.query, false, start, stop)
   local function iter()


### PR DESCRIPTION
Add support for default start and end row when omitted in the
query:iter_captures and query:iter_matches functions.

When the start and end row values are omitted, the values of the given
node is used. The end row value is incremented by 1 to include the node end
row in the match.

Updated tests and docs accordingly.

See also #13761 