### PR TITLE
[RDY] Remove -Z flag from --help message

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2044,7 +2044,6 @@ static void usage(void)
   mch_msg(_("  -u <config>           Use this config file\n"));
   mch_msg(_("  -v, --version         Print version information\n"));
   mch_msg(_("  -V[N][file]           Verbose [level][file]\n"));
-  mch_msg(_("  -Z                    Restricted mode\n"));
   mch_msg("\n");
   mch_msg(_("  --api-info            Write msgpack-encoded API metadata to stdout\n"));
   mch_msg(_("  --embed               Use stdin/stdout as a msgpack-rpc channel\n"));

--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -3290,10 +3290,6 @@ msgstr "-o[N]\t\tMaak N vensters oop (verstek: een vir elke lêer)"
 #~ msgid "  -V[N][file]           Verbose [level][file]\n"
 #~ msgstr ""
 
-#, fuzzy
-#~ msgid "  -Z                    Restricted mode\n"
-#~ msgstr "                              vir twee modusse   "
-
 #~ msgid "  --api-info            Write msgpack-encoded API metadata to stdout\n"
 #~ msgstr ""
 
@@ -7472,9 +7468,6 @@ msgstr "E446: Geen lêernaam onder loper"
 
 #~ msgid "-b\t\t\tBinary mode"
 #~ msgstr "-b\t\t\tBinêre modus"
-
-#~ msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-#~ msgstr "-Z\t\t\tBeperkte modus (soos \"rvim\")"
 
 #~ msgid "-R\t\t\tReadonly mode (like \"view\")"
 #~ msgstr "-R\t\t\tLeesalleen modus (soos \"view\")"

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -3469,10 +3469,6 @@ msgstr "-y\t\t\tMode senzill (com \"evim\", sense modes)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMode només lectura (com \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tMode restringit (com \"rvim)"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tNo permet modificar (escriure) fitxers"

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -3547,10 +3547,6 @@ msgstr "-v\t\t\tSnadný režim (stejné jako \"evim\", žádné módy )"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tRežim pouze_pro_ètení (jako \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tOmezený režim (stejné jako \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmìny (ukládání souborù) zakázány"

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -3547,10 +3547,6 @@ msgstr "-v\t\t\tSnadný re¾im (stejné jako \"evim\", ¾ádné módy )"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tRe¾im pouze_pro_ètení (jako \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tOmezený re¾im (stejné jako \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmìny (ukládání souborù) zakázány"

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -3015,9 +3015,6 @@ msgstr "-y\t\t\tEasy-tilstand (ligesom \"evim\", tilstandsløs)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivebeskyttet tilstand (ligesom \"view\")"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tRestriktiv tilstand (ligesom \"rvim\")"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tÆndringer (skrivning af filer) ikke tilladt"
 

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -2895,10 +2895,6 @@ msgstr "-y\t\t\tLeichter Modus (wie \"evim\", ohne Modi)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModus ohne Schreibrechte (wie \"view\")"
 
-#: ../main.c:2186
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tEingeschränkter Modus (wie \"rvim\")"
-
 #: ../main.c:2187
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tÄnderungen (beim Schreiben von Dateien) sind nicht erlaubt"

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -3368,10 +3368,6 @@ msgstr ""
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr ""
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr ""
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr ""

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -2989,9 +2989,6 @@ msgstr "-y\t\t\tFacila reĝimo (kiel \"evim\", senreĝima)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tNurlegebla reĝimo (kiel \"view\")"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tLimigita reĝimo (kiel \"rvim\")"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tŜanĝoj (skribo al dosieroj) nepermeseblaj"
 

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -3524,10 +3524,6 @@ msgstr "-y\t\t\tModo fácil (como \"evim\", sin modo)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModo de solo lectura (como \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tModo restringido (como \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModificación de archivos desactivada"

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -3249,10 +3249,6 @@ msgstr ""
 #~ msgstr "                              kahta tilaa varten "
 
 #, fuzzy
-#~ msgid "  -Z                    Restricted mode\n"
-#~ msgstr "                              kahta tilaa varten "
-
-#, fuzzy
 #~ msgid "  -m                    Modifications (writing files) not allowed\n"
 #~ msgstr "-m\t\t\tMuokkaukset (kirjoittaminen tiedostoon) pois käytöstä"
 
@@ -6960,9 +6956,6 @@ msgstr "Lista tai luku tarvitaan"
 
 #~ msgid "-b\t\t\tBinary mode"
 #~ msgstr "-b\t\t\tBinääritila"
-
-#~ msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-#~ msgstr "-Z\t\t\tRajoitettu tila (kuten rvimillä)"
 
 #~ msgid "-R\t\t\tReadonly mode (like \"view\")"
 #~ msgstr "-R\t\t\tKirjoitussuojattu tila (kuten view'lla)"

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -3231,9 +3231,6 @@ msgstr "-y\t\tMode facile (comme \"evim\", vim sans modes)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\tMode lecture seule (comme \"view\")"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\tMode restreint (comme \"rvim\")"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\tInterdire l'enregistrement des fichiers"
 

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -3022,9 +3022,6 @@ msgstr "-y\t\t\tMód éasca (mar \"evim\", gan mhóid)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMód inléite amháin (mar \"view\")"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tMód srianta (mar \"rvim\")"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tNí cheadaítear athruithe (.i. scríobh na gcomhad)"
 

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -3510,10 +3510,6 @@ msgstr "-y\t\t\tModalità Facile (come \"evim\", senza modalità)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tModalità Sola Lettura (come \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tModalità Ristretta (come \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tRiscritture del file non permesse"

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -3024,9 +3024,6 @@ msgstr "-y\t\t\tイージーモード (\"evim\" と同じ、モード無)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t読込専用モード (\"view\" と同じ)"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\t制限モード (\"rvim\" と同じ)"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t変更 (ファイル保存時) をできないようにする"
 

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -3024,9 +3024,6 @@ msgstr "-y\t\t\tイージーモード (\"evim\" と同じ、モード無)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t読込専用モード (\"view\" と同じ)"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\t制限モード (\"rvim\" と同じ)"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t変更 (ファイル保存時) をできないようにする"
 

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -3438,10 +3438,6 @@ msgstr "-y\t\t\t쉬운 상태 (\"evim\"과 같음, modeless)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t읽기 전용 상태 (\"view\"와 같음)"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\t제한된 상태 (\"rvim\"과 같음)"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t수정(파일 쓰기)이 허용되지 않음"

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -3452,10 +3452,6 @@ msgstr "-y\t\t\tLett modus (som \"evim\", uten modus)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivebeskyttet modus (som \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tBegrenset modus (som \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifisering (lagring av filer) ikke tillatt"

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -3449,10 +3449,6 @@ msgstr "-y\t\t\tEenvoudige modus (zoals \"evim\", zonder modus)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tAlleen-lezen modus (zoals \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tBeperkte modus (zoals \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tAanpassingen (bestanden opslaan) niet toegestaan"

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -3452,10 +3452,6 @@ msgstr "-y\t\t\tLett modus (som \"evim\", uten modus)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivebeskyttet modus (som \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tBegrenset modus (som \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifisering (lagring av filer) ikke tillatt"

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -3417,10 +3417,6 @@ msgstr "-y\t\t\tTryb łatwy (jak \"evim\", bez trybów)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tTryb wyłącznie do odczytu (jak \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tTryb ograniczenia (jak \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModyfikacje (zapisywanie plików) niedozwolone"

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -6229,10 +6229,6 @@ msgstr "-y\t\t\tModo fÃ¡cil (como \"evim\", o Vim nÃ£o modal)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tmodo somente-leitura (como \"view\")"
 
-#: ../main.c:2186
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tmodo restrito (como \"rvim\")"
-
 #: ../main.c:2187
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tNão permitir alterações (gravação de arquivos)"

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -3442,10 +3442,6 @@ msgstr "-y\t\t\tПростой режим (как \"evim\", безрежимны
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tТолько для чтения (как \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tОграниченный режим (как \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tБез возможности сохранения изменений (записи файлов)"

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -3450,10 +3450,6 @@ msgstr "-y\t\t\tJednoduchý mód (rovnaké ako \"evim\", bezmódový)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMód iba pre èítanie (ako \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tObmedzený mód (rovnaké ako \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmeny (ukladanie súborov) zakázané"

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -3450,10 +3450,6 @@ msgstr "-y\t\t\tJednoduchý mód (rovnaké ako \"evim\", bezmódový)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tMód iba pre èítanie (ako \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tObmedzený mód (rovnaké ako \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tZmeny (ukladanie súborov) zakázané"

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -3028,9 +3028,6 @@ msgstr "-y\t\t\tEasy режим (као \"evim\", безрежимни)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tReadonly режим (као \"view\")"
 
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tRestricted режим (као \"rvim\")"
-
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tИзмене (уписивање датотека) нису дозвољене"
 

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -5735,10 +5735,6 @@ msgstr "-y\t\t\tLätt läge (som \"evim\", lägeslös)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tSkrivskyddat läge (som \"view\")"
 
-#: ../main.c:2186
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tBegränsat läge (som \"rvim\")"
-
 #: ../main.c:2187
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tModifieringar (skriva filer) inte tillåtet"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -3367,9 +3367,6 @@ msgstr "  -v, --version         Надрукувати інформацію пр
 msgid "  -V[N][file]           Verbose [level][file]\n"
 msgstr "  -V[N][файл]           Більше повідомлень [рівень][файл]\n"
 
-msgid "  -Z                    Restricted mode\n"
-msgstr "  -Z                    Обмежений режим\n"
-
 msgid "  --api-info            Write msgpack-encoded API metadata to stdout\n"
 msgstr ""
 "  --api-info            Записати метадані API, серіалізовані у msgpack, у "

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -3479,10 +3479,6 @@ msgstr "-y\t\t\tChế độ đơn giản (giống \"evim\", không có chế đ�
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\tChế độ chỉ đọc (giống \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\tChế độ hạn chế (giống \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\tKhông có khả năng ghi nhớ thay đổi (ghi nhớ tập tin)"

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -3427,10 +3427,6 @@ msgstr "-y\t\t\t容易模式 (同 \"evim\"，无模式)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t只读模式 (同 \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\t限制模式 (同 \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t不可修改(写入文件)"

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -3482,10 +3482,6 @@ msgstr "-y\t\t\t簡易模式 (同 \"evim\", modeless)"
 msgid "-R\t\t\tReadonly mode (like \"view\")"
 msgstr "-R\t\t\t唯讀模式 (同 \"view\")"
 
-#: ../main.c:2208
-msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
-msgstr "-Z\t\t\t限制模式 (同 \"rvim\")"
-
 #: ../main.c:2209
 msgid "-m\t\t\tModifications (writing files) not allowed"
 msgstr "-m\t\t\t不可修改 (寫入檔案)"


### PR DESCRIPTION
Restricted mode (-Z) was removed in #11996 and lingering references to it in the man pages were removed in #13338. This PR removes its reference from the `--help` message and removes all translations of that line from `src/nvim/po/*.po` files. Fixes #13731.