### PR TITLE
log.c: remove reporting error on log creation

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -75,11 +75,7 @@ static bool log_path_init(void)
     char *failed_dir = NULL;
     if (!os_isdir((char_u *)cachehome)) {
         int ret;
-        if ((ret = os_mkdir_recurse(cachehome, 0700, &failed_dir)) != 0) {
-          EMSG3(_(LOGERR "Failed to create directory %s "
-                  "for writing logs: %s"),
-                failed_dir, os_strerror(ret));
-        }
+        ret = os_mkdir_recurse(cachehome, 0700, &failed_dir);
     }
     XFREE_CLEAR(failed_dir);
     XFREE_CLEAR(cachehome);


### PR DESCRIPTION
Closes #13771

TLDR, brew and nix both use an immutable home directory in which we try to create a $HOME/.cache/nvim. We gracefully fail during runtime while reporting the error to the user (no one should be using an immutable cache at *runtime*), !however, reporting this error causes a problem during buildtime while running helptag generation. Which is why brew fails to install. The exact command is:
`/tmp/neovim-20210116-4155-1txrl6u/build/bin/nvim -u NONE -i NONE -e --headless -c helptags\ ++t\ doc -c quit`

You can reproduce the same issue at runtime by making ~/.cache/nvim not writeable by your user. It will report an error (in nvim) which can be dismissed.

Removing the reporting of the error removes the issue. IDK if there's an internal error message mechanism that we have that would work, but IEMSG and EMSG (ofc) do not work.