### PR TITLE
log.c: warn instead of error on failed stdpath('cache') creation

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1339,7 +1339,7 @@ DATA DIRECTORY (DEFAULT) ~
 Note: Throughout the user manual these defaults are used as placeholders, e.g.
 "~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
 
-LOG FILE					*$NVIM_LOG_FILE* *E5010*
+LOG FILE					*$NVIM_LOG_FILE*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE


### PR DESCRIPTION
Closes #13771

TLDR, brew and nix both use an immutable home directory in which we try to create a $HOME/.cache/nvim. We gracefully fail during runtime while reporting the error to the user (no one should be using an immutable cache at runtime), !however, reporting this error causes a problem during buildtime while running helptag generation. Which is why brew fails to install. The exact command is:
`/tmp/neovim-20210116-4155-1txrl6u/build/bin/nvim -u NONE -i NONE -e --headless -c helptags\ ++t\ doc -c quit`

You can reproduce the same issue at runtime by making ~/.cache/nvim not writeable by your user. It will report an error (in nvim) which can be dismissed.