### PR TITLE
[RDY] lsp: add client/registerCapability handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -97,6 +97,18 @@ M['window/showMessageRequest'] = function(_, _, params)
   end
 end
 
+--@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_registerCapability
+M['client/registerCapability'] = function(_, _, _, client_id)
+  local warning_tpl = "The language server %s triggers a registerCapability "..
+                      "handler despite dynamicRegistration set to false. "..
+                      "Report upstream, this warning is harmless"
+  local client = vim.lsp.get_client_by_id(client_id)
+  local client_name = client and client.name or string.format("id=%d", client_id)
+  local warning = string.format(warning_tpl, client_name)
+  log.warn(warning)
+  return vim.NIL
+end
+
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 M['textDocument/codeAction'] = function(_, _, actions)
   if actions == nil or vim.tbl_isempty(actions) then


### PR DESCRIPTION
Until we support dynamicRegistration, we should handle the client/registerCapability in core. There are still some language servers that send this request despite dynamicRegistration not being registered client-side (we got an upstream [fix](https://github.com/microsoft/vscode-languageserver-node/commit/5bc82ac3c1c656aa70615c9e3e065fa04e41506e) for the node ones, but this depends on them bumping vscode-languageserver-node). 

We have a workaround in nvim-lspconfig, but people using the core's client would also expect their language server's not to crash. I also want to remove all custom handlers from nvim-lspconfig (this is the last one left).

See also: https://github.com/neovim/nvim-lspconfig/pull/508