### PR TITLE
doc: Add link to Homebrew formula in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install from package
 Pre-built packages for Windows, macOS, and Linux are found on the
 [Releases](https://github.com/neovim/neovim/releases/) page.
 
-[Managed packages] are in Homebrew, [Debian], [Ubuntu], [Fedora], [Arch Linux],
+[Managed packages] are in [Homebrew], [Debian], [Ubuntu], [Fedora], [Arch Linux],
 [Gentoo], and more!
 
 Install from source
@@ -137,5 +137,6 @@ Apache 2.0 license, except for contributions copied from Vim (identified by the
 [Fedora]: https://apps.fedoraproject.org/packages/neovim
 [Arch Linux]: https://www.archlinux.org/packages/?q=neovim
 [Gentoo]: https://packages.gentoo.org/packages/app-editors/neovim
+[Homebrew]: https://formulae.brew.sh/formula/neovim
 
 <!-- vim: set tw=80: -->


### PR DESCRIPTION
This PR adds link to `neovim` Homebrew formula:

https://formulae.brew.sh/formula/neovim

The page is useful because it contains:

- How to install it
- Package information (e.g. current version)
- List of dependencies
- Analytics (how many people are using it)