### PR TITLE
[RDY] lsp: clear diagnostics on client shutdown

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -679,6 +679,14 @@ get_active_clients()                            *vim.lsp.get_active_clients()*
                 Return: ~
                     Table of |vim.lsp.client| objects
 
+                                          *vim.lsp.get_buffers_by_client_id()*
+get_buffers_by_client_id({client_id})
+                Parameters: ~
+                    {client_id}  client id
+
+                Return: ~
+                    list of buffer ids
+
 get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
                 Gets a client by id, or nil if the id is invalid. The returned
                 client may not yet be fully initialized.
@@ -1754,7 +1762,7 @@ make_workspace_params({added}, {removed})
                 Create the workspace params
 
                 Parameters: ~
-                    {added}
+                    {added}    
                     {removed}
 
                                         *vim.lsp.util.open_floating_preview()*


### PR DESCRIPTION
closes #13695

I also want to be able to list buffers by client for better reporting in `:LspInfo`, which this PR addresses as well 
with `vim.lsp.get_buffers_by_client_id()`

@pretentious7 try this out. It will respect the list of client_ids you pass in, so you can limit it to the client attached to the current buffer as well.

https://user-images.githubusercontent.com/13316262/104971905-131bd880-59a5-11eb-9457-d26d7d1e97b0.mov

