### PR TITLE
[DNM] tests: fix error with immutable homedir

### DIFF
--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -361,6 +361,7 @@ describe('sysinit', function()
 
     mkdir(xdgdir)
     mkdir(xdgdir .. pathsep .. 'nvim')
+    mkdir(xhome .. pathsep .. 'cache' .. pathsep .. 'nvim')
     write_file(table.concat({xdgdir, 'nvim', 'sysinit.vim'}, pathsep), [[
       let g:loaded = get(g:, "loaded", 0) + 1
       let g:xdg = 1

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -310,7 +310,6 @@ describe('LSP', function()
       }
     end)
     it('workspace/configuration returns NIL per section if client was started without config.settings', function()
-      clear()
       fake_lsp_server_setup('workspace/configuration no settings')
       eq({ NIL, NIL, }, exec_lua [[
         local params = {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -193,6 +193,12 @@ describe('LSP', function()
   end)
 
   describe('basic_init test', function()
+     after_each(function()
+      stop()
+      exec_lua("lsp.stop_client(lsp.get_active_clients())")
+      exec_lua("lsp._vim_exit_handler()")
+    end)
+
     it('should run correctly', function()
       local expected_callbacks = {
         {NIL, "test", {}, 1};
@@ -304,11 +310,9 @@ describe('LSP', function()
       }
     end)
     it('workspace/configuration returns NIL per section if client was started without config.settings', function()
+      clear()
       fake_lsp_server_setup('workspace/configuration no settings')
-      eq({
-        NIL,
-        NIL,
-      }, exec_lua [[
+      eq({ NIL, NIL, }, exec_lua [[
         local params = {
           items = {
             {section = 'foo'},

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -195,7 +195,6 @@ describe('LSP', function()
   describe('basic_init test', function()
      after_each(function()
       stop()
-      exec_lua("lsp.stop_client(lsp.get_active_clients())")
       exec_lua("lsp._vim_exit_handler()")
     end)
 


### PR DESCRIPTION
Using this branch to run tests as to why I can't reproduce the failure on CI locally:
```
[  ERROR   ] 1 error, listed below:
[  ERROR   ] test/functional/core/startup_spec.lua @ 236: startup does not crash when expanding cdpath during early_init
test/helpers.lua:73: Expected objects to be the same.
Passed in:
(nil)
Expected:
(string) ',~doesnotexist'
stack traceback:
	test/helpers.lua:73: in function 'eq'
	test/functional/core/startup_spec.lua:238: in function <test/functional/core/startup_spec.lua:236>


 21 SKIPPED TESTS
 1 ERROR
-- Tests exited non-zero: 1
-- Output to stderr:
ERROR 2021-01-18T18:29:01.934 39015 open_log_file:211: Logging to stderr, failed to open $NVIM_LOG_FILE: Xtest-startup-xdg-logpath/nvim/log
WARN  2021-01-18T18:29:01.934 39015 call_set_error:627: RPC: ch 1 was closed by the client
ERROR 2021-01-18T18:29:01.938 39015 open_log_file:211: Logging to stderr, failed to open $NVIM_LOG_FILE: Xtest-startup-xdg-logpath/nvim/log
INFO  2021-01-18T18:29:01.938 39015 os_exit:586: Nvim exit: 0

CMake Error at /Users/michael/Repositories/neovim_development/neovim/cmake/RunTests.cmake:85 (message):
  functional tests failed with error: 1
```