### PR TITLE
lsp: match textDocument/didChange eol behavior

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -888,9 +888,7 @@ end
 function lsp._text_document_did_save_handler(bufnr)
   bufnr = resolve_bufnr(bufnr)
   local uri = vim.uri_from_bufnr(bufnr)
-  local text = once(function()
-    return table.concat(nvim_buf_get_lines(bufnr, 0, -1, false), '\n')
-  end)
+  local text = once(buf_get_full_text)
   for_each_buffer_client(bufnr, function(client, _client_id)
     if client.resolved_capabilities.text_document_save then
       local included_text


### PR DESCRIPTION
We should be consistent in sending the EOL character to servers(I think). Julia expects this to match on bufwrite, or it crashes when vim appends the newline during the write process.

https://github.com/neovim/nvim-lspconfig/issues/526
https://github.com/julia-vscode/LanguageServer.jl/issues/855
https://github.com/neovim/nvim-lspconfig/pull/654
https://github.com/neovim/nvim-lspconfig/pull/547


cc: @quantum-booty @kdheepak 
