### PR TITLE
lsp/tests: Ensure client is stopped in basic_init tests

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -193,6 +193,12 @@ describe('LSP', function()
   end)
 
   describe('basic_init test', function()
+    after_each(function()
+      stop()
+      exec_lua("lsp.stop_client(lsp.get_active_clients())")
+      exec_lua("lsp._vim_exit_handler()")
+    end)
+
     it('should run correctly', function()
       local expected_callbacks = {
         {NIL, "test", {}, 1};
@@ -304,11 +310,9 @@ describe('LSP', function()
       }
     end)
     it('workspace/configuration returns NIL per section if client was started without config.settings', function()
+      clear()
       fake_lsp_server_setup('workspace/configuration no settings')
-      eq({
-        NIL,
-        NIL,
-      }, exec_lua [[
+      eq({ NIL, NIL, }, exec_lua [[
         local params = {
           items = {
             {section = 'foo'},


### PR DESCRIPTION
If https://github.com/neovim/neovim/pull/13708 introduced a test failure, this
may be the reason.

Can't reproduce locally, let's see what CI says.