### PR TITLE
[RDY] lsp: strip \ during markdown conversion

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -514,7 +514,8 @@ function M.convert_input_to_markdown_lines(input, contents)
 
       -- Some servers send input.value as empty, so let's ignore this :(
       -- assert(type(input.value) == 'string')
-      list_extend(contents, split_lines(input.value or ''))
+      local stripped_message = string.gsub(input.value or '', "(\\)(%p)", "%2")
+      list_extend(contents, split_lines(stripped_message))
     -- MarkupString variation 2
     elseif input.language then
       -- Some servers send input.value as empty, so let's ignore this :(


### PR DESCRIPTION
Before, our markdown conversion was showing \ during hover, which is used by the language server to escape certain characters.

cc @owarai 

Before:
<img width="1392" alt="Screen Shot 2021-01-19 at 9 15 28 PM" src="https://user-images.githubusercontent.com/13316262/105130441-e4345e00-5a9b-11eb-93e2-ff2b569efa38.png">

After:
<img width="1392" alt="Screen Shot 2021-01-19 at 9 17 39 PM" src="https://user-images.githubusercontent.com/13316262/105130450-e8f91200-5a9b-11eb-8c8d-57e51d8b7904.png">
