### PR TITLE
Auto sign column with minimum size support

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5536,6 +5536,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   "auto"   	only when there is a sign to display
 	   "auto:[1-9]" resize to accommodate multiple signs up to the
 	                given number (maximum 9), e.g. "auto:4"
+	   "auto:[1-8]-[2-9]"
+	                resize to accommodate multiple signs up to the
+			given maximum number (maximum 9) while keeping
+			at least the given minimum (maximum 8) fixed
+			space. The minimum number should always be less
+			than the maximum number, e.g. "auto:2-5"
 	   "no"	    	never
 	   "yes"    	always
 	   "yes:[1-9]"  always, with fixed space for signs up to the given

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3238,7 +3238,7 @@ static int int_cmp(const void *a, const void *b)
 int check_signcolumn(char_u *val)
 {
   // check for basic match
-  if (check_opt_strings(val, p_scl_values, false) == OK) {     
+  if (check_opt_strings(val, p_scl_values, false) == OK) {
     return OK;
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -318,14 +318,6 @@ static char *(p_csl_values[]) =       { "slash", "backslash", NULL };
 static char *(p_icm_values[]) =       { "nosplit", "split", NULL };
 static char *(p_scl_values[]) =       { "yes", "no", "auto", "auto:1", "auto:2",
   "auto:3", "auto:4", "auto:5", "auto:6", "auto:7", "auto:8", "auto:9",
-  "auto:1-2", "auto:1-3", "auto:1-4", "auto:1-5", "auto:1-6", "auto:1-7", "auto:1-8", "auto:1-9",
-  "auto:2-3", "auto:2-4", "auto:2-5", "auto:2-6", "auto:2-7", "auto:2-8", "auto:2-9",
-  "auto:3-4", "auto:3-5", "auto:3-6", "auto:3-7", "auto:3-8", "auto:3-9",
-  "auto:4-5", "auto:4-6", "auto:4-7", "auto:4-8", "auto:4-9",
-  "auto:5-6", "auto:5-7", "auto:5-8", "auto:5-9",
-  "auto:6-7", "auto:6-8", "auto:6-9",
-  "auto:7-8", "auto:7-9",
-  "auto:8-9",
   "yes:1", "yes:2", "yes:3", "yes:4", "yes:5", "yes:6", "yes:7", "yes:8",
   "yes:9", "number", NULL };
 static char *(p_fdc_values[]) =       { "auto", "auto:1", "auto:2",
@@ -2921,7 +2913,7 @@ ambw_end:
 #endif
   } else if (varp == &curwin->w_p_scl) {
     // 'signcolumn'
-    if (check_opt_strings(*varp, p_scl_values, false) != OK) {
+    if (check_signcolumn(*varp) != OK) {
       errmsg = e_invarg;
     }
     // When changing the 'signcolumn' to or from 'number', recompute the
@@ -3238,6 +3230,29 @@ ambw_end:
 static int int_cmp(const void *a, const void *b)
 {
   return *(const int *)a - *(const int *)b;
+}
+
+/// Handle setting 'signcolumn' for value 'val'
+///
+/// @return OK when the value is valid, FAIL otherwise
+int check_signcolumn(char_u *val)
+{
+  // check for basic match
+  if (check_opt_strings(val, p_scl_values, false) == OK) {     
+    return OK;
+  }
+
+  // check for 'auto:<NUMBER>-<NUMBER>'
+  if (STRLEN(val) == 8
+      && !STRNCMP(val, "auto:", 5)
+      && ascii_isdigit(*(val + 5))
+      && *(val + 6) == '-'
+      && ascii_isdigit(*(val + 7))
+      ) {
+    return OK;
+  }
+
+  return FAIL;
 }
 
 /// Handle setting 'colorcolumn' or 'textwidth' in window "wp".

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -318,6 +318,14 @@ static char *(p_csl_values[]) =       { "slash", "backslash", NULL };
 static char *(p_icm_values[]) =       { "nosplit", "split", NULL };
 static char *(p_scl_values[]) =       { "yes", "no", "auto", "auto:1", "auto:2",
   "auto:3", "auto:4", "auto:5", "auto:6", "auto:7", "auto:8", "auto:9",
+  "auto:1-2", "auto:1-3", "auto:1-4", "auto:1-5", "auto:1-6", "auto:1-7", "auto:1-8", "auto:1-9",
+  "auto:2-3", "auto:2-4", "auto:2-5", "auto:2-6", "auto:2-7", "auto:2-8", "auto:2-9",
+  "auto:3-4", "auto:3-5", "auto:3-6", "auto:3-7", "auto:3-8", "auto:3-9",
+  "auto:4-5", "auto:4-6", "auto:4-7", "auto:4-8", "auto:4-9",
+  "auto:5-6", "auto:5-7", "auto:5-8", "auto:5-9",
+  "auto:6-7", "auto:6-8", "auto:6-9",
+  "auto:7-8", "auto:7-9",
+  "auto:8-9",
   "yes:1", "yes:2", "yes:3", "yes:4", "yes:5", "yes:6", "yes:7", "yes:8",
   "yes:9", "number", NULL };
 static char *(p_fdc_values[]) =       { "auto", "auto:1", "auto:2",
@@ -7095,7 +7103,7 @@ int csh_like_shell(void)
 /// buffer signs and on user configuration.
 int win_signcol_count(win_T *wp)
 {
-  int maximum = 1, needed_signcols;
+  int minimum = 0, maximum = 1, needed_signcols;
   const char *scl = (const char *)wp->w_p_scl;
 
   // Note: It checks "no" or "number" in 'signcolumn' option
@@ -7119,9 +7127,14 @@ int win_signcol_count(win_T *wp)
   if (!strncmp(scl, "auto:", 5)) {
     // Variable depending on a configuration
     maximum = scl[5] - '0';
+    // auto:<NUM>-<NUM>
+    if (strlen(scl) == 8 && *(scl + 6) == '-') {
+      minimum = maximum;
+      maximum = scl[7] - '0';
+    }
   }
 
-  return MIN(maximum, needed_signcols);
+  return MAX(minimum, MIN(maximum, needed_signcols));
 }
 
 /// Get window or buffer local options

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3245,10 +3245,15 @@ int check_signcolumn(char_u *val)
   // check for 'auto:<NUMBER>-<NUMBER>'
   if (STRLEN(val) == 8
       && !STRNCMP(val, "auto:", 5)
-      && ascii_isdigit(*(val + 5))
-      && *(val + 6) == '-'
-      && ascii_isdigit(*(val + 7))
+      && ascii_isdigit(val[5])
+      && val[6] == '-'
+      && ascii_isdigit(val[7])
       ) {
+    int min = val[5] - '0';
+    int max = val[7] - '0';
+    if (min < 1 || max < 2 || min > 8 || max > 9 || min >= max) {
+      return FAIL;
+    }
     return OK;
   }
 

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -266,6 +266,111 @@ describe('Signs', function()
       ]]}
     end)
 
+    it('auto-resize sign column with minimum size (#13783)', function()
+      feed('ia<cr>b<cr>c<cr><esc>')
+      command('set number')
+      -- sign column should always accommodate at the minimum size
+      command('set signcolumn=auto:1-3')
+      screen:expect([[
+        {2:  }{6:  1 }a                                              |
+        {2:  }{6:  2 }b                                              |
+        {2:  }{6:  3 }c                                              |
+        {2:  }{6:  4 }^                                               |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      -- should support up to 8 signs at minimum
+      command('set signcolumn=auto:8-9')
+      screen:expect([[
+        {2:                }{6:  1 }a                                |
+        {2:                }{6:  2 }b                                |
+        {2:                }{6:  3 }c                                |
+        {2:                }{6:  4 }^                                 |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      -- should keep the same sign size when signs are not exceeding
+      -- the minimum
+      command('set signcolumn=auto:2-5')
+      command('sign define pietSearch text=>> texthl=Search')
+      command('sign place 1 line=1 name=pietSearch buffer=1')
+      screen:expect([[
+        {1:>>}{2:  }{6:  1 }a                                            |
+        {2:    }{6:  2 }b                                            |
+        {2:    }{6:  3 }c                                            |
+        {2:    }{6:  4 }^                                             |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      -- should resize itself when signs are exceeding minimum but
+      -- not over the maximum
+      command('sign place 2 line=1 name=pietSearch buffer=1')
+      command('sign place 3 line=1 name=pietSearch buffer=1')
+      command('sign place 4 line=1 name=pietSearch buffer=1')
+      screen:expect([[
+        {1:>>>>>>>>}{6:  1 }a                                        |
+        {2:        }{6:  2 }b                                        |
+        {2:        }{6:  3 }c                                        |
+        {2:        }{6:^  4 }                                         |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      -- should keep the column at maximum size when signs are
+      -- exceeding the maximum
+      command('sign place 5 line=1 name=pietSearch buffer=1')
+      command('sign place 6 line=1 name=pietSearch buffer=1')
+      command('sign place 7 line=1 name=pietSearch buffer=1')
+      command('sign place 8 line=1 name=pietSearch buffer=1')
+      screen:expect([[
+        {1:>>>>>>>>>>}{6:  1 }a                                      |
+        {2:          }{6:  2 }b                                      |
+        {2:          }{6:  3 }c                                      |
+        {2:        ^  }{6:  4 }                                       |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+    end)
+
     it('ignores signs with no icon and text when calculting the signcolumn width', function()
       feed('ia<cr>b<cr>c<cr><esc>')
       command('set number')


### PR DESCRIPTION
Closes #13783 

CC @teto 

----

I saw that there is either weird behavior or my misunderstanding on placing multiple signs in the same line, causing the cursor to stay in the same position.

Input (as in lua tests)
```
ia<cr>b<cr>c<cr><esc>
```

Commands
```
set number
set signcolumn=auto:2
sign define pietSearch text=>> texthl=Search
sign place 1 line=1 name=pietSearch buffer=1
sign place 2 line=1 name=pietSearch buffer=1
sign place 3 line=1 name=pietSearch buffer=1
sign place 4 line=1 name=pietSearch buffer=1
```

https://user-images.githubusercontent.com/1087399/105209089-030a2180-5b7c-11eb-8e1e-7def1c1e790e.mov
