### PR TITLE
Cap signcolumn size to 1 for :Tutor to avoid showing old signs

### DIFF
--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -18,6 +18,7 @@ setlocal noundofile
 
 setlocal keywordprg=:help
 setlocal iskeyword=@,-,_
+setlocal signcolumn=auto:1
 
 " The user will have to enable the folds himself, but we provide the foldexpr
 " function.


### PR DESCRIPTION
Fix #13808

It might be better to clear the signs rather than let them be simply hidden due to the size of the signcolumn. However, doing so would require a sizeable change in logic since `:sign unplace` doesn't accept a `line` argument like `:sign place` does.