### PR TITLE
api(echo): should clear cmdline before echo

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1011,8 +1011,9 @@ void nvim_echo(Array chunks, Boolean history, Dictionary opts, Error *err)
   }
 
   no_wait_return++;
-  bool need_clear = true;
   msg_start();
+  msg_clr_eos();
+  bool need_clear = false;
   for (uint32_t i = 0; i < kv_size(hl_msg); i++) {
     HlMessageChunk chunk = kv_A(hl_msg, i);
     msg_multiline_attr((const char *)chunk.text.data, chunk.attr,

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2021,6 +2021,20 @@ describe('API', function()
       command('highlight Special guifg=SlateBlue')
     end)
 
+    it('should clear cmdline message before echo', function()
+      feed(':call nvim_echo([["msg"]], v:false, {})<CR>')
+      screen:expect{grid=[[
+        ^                                        |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        msg                                     |
+      ]]}
+    end)
+
     it('can show highlighted line', function()
       nvim_async("echo", {{"msg_a"}, {"msg_b", "Statement"}, {"msg_c", "Special"}}, true, {})
       screen:expect{grid=[[


### PR DESCRIPTION
This pr follows up  https://github.com/neovim/neovim/pull/13673 🙏

## Problem

Cmdline is not cleared if the message doesn't have any newline.

```
:lua vim.api.nvim_echo({{"msg", "Todo"}}, false, {})
```

![echo_api_bug](https://user-images.githubusercontent.com/18519692/105354580-18428700-5c34-11eb-9431-d1e4aa6faf40.png)
