### PR TITLE
Basic syntax highlighting for Idris

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -718,6 +718,9 @@ au BufNewFile,BufRead *.vc,*.ev,*.sum,*.errsum	setf hercules
 " HEX (Intel)
 au BufNewFile,BufRead *.hex,*.h32		setf hex
 
+" Idris
+au BufNewFile,BufRead *.idr			setf idris
+
 " Hollywood
 au BufRead,BufNewFile *.hws			setf hollywood
 

--- a/runtime/syntax/idris.vim
+++ b/runtime/syntax/idris.vim
@@ -1,0 +1,16 @@
+" Vim syntax file
+" Language:		Idris
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" Read the Haskell syntax to start with:
+" Idris and Haskell are very similar
+runtime! syntax/haskell.vim
+unlet b:current_syntax
+
+let b:current_syntax = "idris"
+
+" Options for vi: ts=8 sw=2 sts=2 nowrap noexpandtab ft=vim


### PR DESCRIPTION
Just reuse Haskell highlighting for now.

Tested with:

```
VIMRUNTIME=~/devel/neovim/runtime nvim SomeFile.idr
```

<img width="777" alt="Screenshot 2021-01-21 at 17 14 31" src="https://user-images.githubusercontent.com/28969/105386288-2381bc80-5c0c-11eb-9f8a-5213e000a0b3.png">
