### PR TITLE
Allow @injection.* in tree-sitter injection queries

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -303,11 +303,11 @@ function LanguageTree:_get_injections()
         local offset_range = data and data.offset
 
         -- Lang should override any other language tag
-        if name == "language" then
+        if name == "injection.language" or name == "language" then
           lang = query.get_node_text(node, self._source)
-        elseif name == "combined" then
+        elseif name == "injection.combined" or name == "combined" then
           combined = true
-        elseif name == "content" then
+        elseif name == "injection.content" or name == "content" then
           injection_node = offset_range or node
         -- Ignore any tags that start with "_"
         -- Allows for other tags to be used in matches


### PR DESCRIPTION
This allows using `@injection.language` and `@language` (For compatibility with existing queries) when writing an injection query.

This is what is specified in the official tree-sitter docs, see [here](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection). Also see [this](https://github.com/nvim-treesitter/nvim-treesitter/issues/873) issue on the nvim-treesitter repo for a little more context.