### PR TITLE
feat(shared): add list_filter

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1055,6 +1055,14 @@ list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
                 See also: ~
                     |vim.tbl_extend()|
 
+list_filter({func}, {t})                                   *vim.list_filter()*
+                Filter a list-like (vector) table using a predicate function
+
+                Parameters: ~
+                    {func}  function or callable table, with signature
+                            func(value)
+                    {t}     list-like table
+
 pesc({s})                                                         *vim.pesc()*
                 Escapes magic chars in a Lua pattern.
 
@@ -1164,7 +1172,8 @@ tbl_filter({func}, {t})                                     *vim.tbl_filter()*
                 Filter a table using a predicate function
 
                 Parameters: ~
-                    {func}  function or callable table
+                    {func}  function or callable table, with signature
+                            func(value, key)
                     {t}     table
 
 tbl_flatten({t})                                           *vim.tbl_flatten()*

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -158,17 +158,33 @@ function vim.tbl_map(func, t)
   return rettab
 end
 
---- Filter a table using a predicate function
+--- Filter a list-like (vector) table using a predicate function
 ---
---@param func function or callable table
---@param t table
-function vim.tbl_filter(func, t)
+--@param func function or callable table, with signature func(value)
+--@param t list-like table
+function vim.list_filter(func, t)
   vim.validate{func={func,'c'},t={t,'t'}}
 
   local rettab = {}
   for _, entry in pairs(t) do
     if func(entry) then
       table.insert(rettab, entry)
+    end
+  end
+  return rettab
+end
+
+--- Filter a table using a predicate function
+---
+--@param func function or callable table, with signature func(value, key)
+--@param t table
+function vim.tbl_filter(func, t)
+  vim.validate{func={func,'c'},t={t,'t'}}
+
+  local rettab = {}
+  for key, entry in pairs(t) do
+    if func(entry, key) then
+      rettab[key] = entry
     end
   end
   return rettab

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -426,15 +426,36 @@ describe('lua stdlib', function()
     ]]))
   end)
 
-  it('vim.tbl_filter', function()
+  it('vim.list_filter', function()
     eq({}, exec_lua([[
-      return vim.tbl_filter(function(v) return (v % 2) == 0 end, {})
+      return vim.list_filter(function(v) return (v % 2) == 0 end, {})
     ]]))
     eq({2}, exec_lua([[
-      return vim.tbl_filter(function(v) return (v % 2) == 0 end, {1, 2, 3})
+      return vim.list_filter(function(v) return (v % 2) == 0 end, {1, 2, 3})
     ]]))
     eq({{i=2}}, exec_lua([[
-      return vim.tbl_filter(function(v) return (v.i % 2) == 0 end, {{i=1}, {i=2}, {i=3}})
+      return vim.list_filter(function(v) return (v.i % 2) == 0 end, {{i=1}, {i=2}, {i=3}})
+    ]]))
+  end)
+
+  it('vim.tbl_filter', function()
+    eq({}, exec_lua([[
+      return vim.tbl_filter(function(v, _) return (v % 2) == 0 end, {})
+    ]]))
+    eq({2}, exec_lua([[
+      return vim.tbl_filter(function(v, _) return (v % 2) == 0 end, {1, 2, 3})
+    ]]))
+    eq({{i=2}}, exec_lua([[
+      return vim.tbl_filter(function(v, _) return (v.i % 2) == 0 end, {{i=1}, {i=2}, {i=3}})
+    ]]))
+    eq({}, exec_lua([[
+      return vim.tbl_filter(function(_, k) return (k % 2) == 0 end, {})
+    ]]))
+    eq({2}, exec_lua([[
+      return vim.tbl_filter(function(_, k) return (k % 2) == 0 end, {1, 2, 3})
+    ]]))
+    eq({{i=2}}, exec_lua([[
+      return vim.tbl_filter(function(_, k) return (k % 2) == 0 end, {{i=1}, {i=2}, {i=3}})
     ]]))
   end)
 


### PR DESCRIPTION
Correctly state that vim.tbl_filter only operates on list like tables.

Fixes #13806
