### PR TITLE
[RDY] Notification provider

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -10,13 +10,7 @@ local log = {}
 -- Can be used to lookup the number from the name or the name from the number.
 -- Levels by name: 'trace', 'debug', 'info', 'warn', 'error'
 -- Level numbers begin with 'trace' at 0
-log.levels = {
-  TRACE = 0;
-  DEBUG = 1;
-  INFO  = 2;
-  WARN  = 3;
-  ERROR = 4;
-}
+log.levels = vim.log.levels
 
 -- Default log level is warn.
 local current_log_level = log.levels.WARN

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -545,6 +545,26 @@ Object nvim_exec_lua(String code, Array args, Error *err)
   return nlua_exec(code, args, err);
 }
 
+/// Notify the user with a message
+///
+/// Relays the call to vim.notify . By default forwards your message in the
+/// echo area but can be overriden to trigger desktop notifications.
+///
+/// @param msg        Message to display to the user
+/// @param log_level  The log level
+/// @param opts       Reserved for future use.
+/// @param[out] err   Error details, if any
+Object nvim_notify(String msg, Integer log_level, Dictionary opts, Error *err)
+  FUNC_API_SINCE(7)
+{
+  FIXED_TEMP_ARRAY(args, 3);
+  args.items[0] = STRING_OBJ(msg);
+  args.items[1] = INTEGER_OBJ(log_level);
+  args.items[2] = DICTIONARY_OBJ(opts);
+
+  return nlua_exec(STATIC_CSTR_AS_STRING("return vim.notify(...)"), args, err);
+}
+
 /// Calls a VimL function.
 ///
 /// @param fn Function name

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -17,10 +17,11 @@
 #endif
 
 
-#define DEBUG_LOG_LEVEL 0
-#define INFO_LOG_LEVEL 1
-#define WARN_LOG_LEVEL 2
-#define ERROR_LOG_LEVEL 3
+#define TRACE_LOG_LEVEL 0
+#define DEBUG_LOG_LEVEL 1
+#define INFO_LOG_LEVEL 2
+#define WARN_LOG_LEVEL 3
+#define ERROR_LOG_LEVEL 4
 
 #define DLOG(...)
 #define DLOGN(...)

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -39,6 +39,16 @@ assert(vim)
 vim.inspect = package.loaded['vim.inspect']
 assert(vim.inspect)
 
+vim.log = {
+  levels = {
+    TRACE = 0;
+    DEBUG = 1;
+    INFO  = 2;
+    WARN  = 3;
+    ERROR = 4;
+  }
+}
+
 -- Internal-only until comments in #8107 are addressed.
 -- Returns:
 --    {errcode}, {output}
@@ -477,6 +487,23 @@ function vim.defer_fn(fn, timeout)
 
   return timer
 end
+
+
+--- Notification provider
+--- without a runtime, writes to :Messages
+--  see :help nvim_notify
+--@param msg Content of the notification to show to the user
+--@param log_level Optional log level
+--@param opts Dictionary with optional options (timeout, etc)
+function vim.notify(msg, log_level, _opts)
+
+  if log_level == vim.log.levels.ERROR then
+    vim.api.nvim_err_writeln(msg)
+  else
+    vim.api.nvim_echo(msg)
+  end
+end
+
 
 local on_keystroke_callbacks = {}
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -475,6 +475,15 @@ describe('API', function()
     end)
   end)
 
+  describe('nvim_notify', function()
+    it('can be overriden', function()
+      command("lua vim.notify = function(...) return 42 end")
+      eq(42, meths.exec_lua("return vim.notify('Hello world')", {}))
+      nvim("notify", "hello world", 4, {})
+    end)
+  end)
+
+
   describe('nvim_input', function()
     it("VimL error: does NOT fail, updates v:errmsg", function()
       local status, _ = pcall(nvim, "input", ":call bogus_fn()<CR>")


### PR DESCRIPTION
Address https://github.com/neovim/neovim/issues/5562 : notifications in the command line are a pain, especially wit LSP now.
I would like the possibility to use system notifications for instance (or floating windows to mimic system level notifications).

Adds a `vim.notify` function to send such notifications. By default it sends it as usual but you can override it with for instance
```
vim.notify = function notify_external(log_level, msg)
	vim.fn.jobstart({"notify-send", msg })
end
```

I've noticed a mismatch between https://github.com/neovim/neovim/blob/8950f4e94af1534852cab5f41066d7c21330bd64/runtime/lua/vim/lsp/log.lua#L13 and https://github.com/neovim/neovim/blob/8950f4e94af1534852cab5f41066d7c21330bd64/src/nvim/log.h#L20 I suppose we should fix that  (either add or remove a TRACE level) and expose it to lua.
Also could support a dict to be forward compatible with options (timeout, icon).

@mjlbach @tjdevries @bfredl