### PR TITLE
[WIP] vim.ui: add ui module

### DIFF
--- a/runtime/lua/vim/ui/_utils.lua
+++ b/runtime/lua/vim/ui/_utils.lua
@@ -1,6 +1,6 @@
-local tbl = {}
+local utils = {}
 
-function tbl.apply_defaults(original, defaults)
+function utils.tbl_apply_defaults(original, defaults)
   if original == nil then
     original = {}
   end
@@ -16,4 +16,4 @@ function tbl.apply_defaults(original, defaults)
   return original
 end
 
-return tbl
+return utils

--- a/runtime/lua/vim/ui/_utils.lua
+++ b/runtime/lua/vim/ui/_utils.lua
@@ -16,4 +16,17 @@ function utils.tbl_apply_defaults(original, defaults)
   return original
 end
 
+function utils.tbl_longest_str(tbl)
+  local len = 0
+
+  for _,str in pairs(tbl) do
+    local str_len = #str
+    if str_len > len then
+      len = str_len
+    end
+  end
+
+  return len
+end
+
 return utils

--- a/runtime/lua/vim/ui/border.lua
+++ b/runtime/lua/vim/ui/border.lua
@@ -1,4 +1,4 @@
-local tbl = require('vim.ui.ui_table')
+local utils = require('vim.ui._utils')
 
 local Border = {}
 
@@ -87,7 +87,7 @@ function Border:new(content_bufnr, content_win_id, content_win_options, border_w
   assert(type(content_win_id) == 'number', "Must supply a valid win_id. It's possible you forgot to call with ':'")
 
   -- TODO: Probably can use just deep_extend, now that it's available
-  border_win_options = tbl.apply_defaults(border_win_options, {
+  border_win_options = utils.tbl_apply_defaults(border_win_options, {
     border_thickness = Border._default_thickness,
 
     -- Border options, could be passed as a list?

--- a/runtime/lua/vim/ui/border.lua
+++ b/runtime/lua/vim/ui/border.lua
@@ -1,0 +1,147 @@
+local tbl = require('vim.ui.ui_table')
+
+local Border = {}
+
+Border.__index = Border
+
+Border._default_thickness = {
+  top = 1,
+  right = 1,
+  bot = 1,
+  left = 1,
+}
+
+function Border._create_lines(content_win_options, border_win_options)
+  -- TODO: Handle border width, which I haven't right here.
+  local thickness = border_win_options.border_thickness
+
+  local top_enabled = thickness.top == 1
+  local right_enabled = thickness.right == 1
+  local bot_enabled = thickness.bot == 1
+  local left_enabled = thickness.left == 1
+
+  local border_lines = {}
+
+  local topline = nil
+
+  local topleft = (left_enabled and border_win_options.topleft) or ''
+  local topright = (right_enabled and border_win_options.topright) or ''
+
+  if content_win_options.row > 0 then
+    if border_win_options.title then
+      local title = border_win_options.title
+      if title ~= '' then
+        title = string.format(" %s ", title)
+      end
+      local title_len = string.len(title)
+
+      local midpoint = math.floor(content_win_options.width / 2)
+      local left_start = midpoint - math.floor(title_len / 2)
+
+      topline = string.format("%s%s%s%s%s",
+        topleft,
+        string.rep(border_win_options.top, left_start),
+        title,
+        string.rep(border_win_options.top, content_win_options.width - title_len - left_start),
+        topright
+      )
+    else
+      if top_enabled then
+        topline = topleft
+          .. string.rep(border_win_options.top, content_win_options.width)
+          .. topright
+      end
+    end
+  end
+
+  if topline then
+    table.insert(border_lines, topline)
+  end
+
+  local middle_line = string.format(
+    "%s%s%s",
+    (left_enabled and border_win_options.left) or '',
+    string.rep(' ', content_win_options.width),
+    (right_enabled and border_win_options.right) or ''
+  )
+
+  for _ = 1, content_win_options.height do
+    table.insert(border_lines, middle_line)
+  end
+
+  if bot_enabled then
+    table.insert(border_lines,
+      string.format(
+        "%s%s%s",
+        (left_enabled and border_win_options.botleft) or '',
+        string.rep(border_win_options.bot, content_win_options.width),
+        (right_enabled and border_win_options.botright) or ''
+      )
+    )
+  end
+
+  return border_lines
+end
+
+function Border:new(content_bufnr, content_win_id, content_win_options, border_win_options)
+  assert(type(content_win_id) == 'number', "Must supply a valid win_id. It's possible you forgot to call with ':'")
+
+  -- TODO: Probably can use just deep_extend, now that it's available
+  border_win_options = tbl.apply_defaults(border_win_options, {
+    border_thickness = Border._default_thickness,
+
+    -- Border options, could be passed as a list?
+    topleft  = '╔',
+    topright = '╗',
+    top      = '═',
+    left     = '║',
+    right    = '║',
+    botleft  = '╚',
+    botright = '╝',
+    bot      = '═',
+  })
+
+  local obj = {}
+
+  obj.content_win_id = content_win_id
+  obj.content_win_options = content_win_options
+  obj._border_win_options = border_win_options
+
+
+  obj.bufnr = vim.api.nvim_create_buf(false, true)
+  assert(obj.bufnr, "Failed to create border buffer")
+
+  obj.contents = Border._create_lines(content_win_options, border_win_options)
+  vim.api.nvim_buf_set_lines(obj.bufnr, 0, -1, false, obj.contents)
+
+  local thickness = border_win_options.border_thickness
+
+  obj.win_id = vim.api.nvim_open_win(obj.bufnr, false, {
+    anchor = content_win_options.anchor,
+    relative = content_win_options.relative,
+    style = "minimal",
+    row = content_win_options.row - thickness.top,
+    col = content_win_options.col - thickness.left,
+    width = content_win_options.width + thickness.left + thickness.right,
+    height = content_win_options.height + thickness.top + thickness.bot,
+  })
+
+  vim.cmd(string.format(
+    "autocmd BufLeave,BufDelete <buffer=%s> ++nested ++once :lua require('vim.ui.window').close_related_win(%s, %s)",
+    content_bufnr,
+    content_win_id,
+    obj.win_id))
+
+  vim.cmd(string.format(
+    "autocmd WinClosed,WinLeave <buffer=%s> ++nested ++once :lua require('vim.ui.window').try_close(%s, true)",
+    content_bufnr,
+    obj.win_id))
+
+
+  setmetatable(obj, Border)
+
+  return obj
+end
+
+
+return Border

--- a/runtime/lua/vim/ui/float.lua
+++ b/runtime/lua/vim/ui/float.lua
@@ -1,7 +1,7 @@
 local Border = require('vim.ui.border')
 local utils = require('vim.ui._utils')
 
-_AssociatedBufs = {}
+_NvimUI_AssociatedBufs = {}
 
 
 local clear_buf_on_leave = function(bufnr)
@@ -113,7 +113,7 @@ function win_float.centered_with_top_win(top_text, options)
   local primary_border = Border:new(primary_bufnr, primary_win_id, primary_win_opts, {})
   local minor_border = Border:new(minor_bufnr, minor_win_id, minor_win_opts, {})
 
-  _AssociatedBufs[primary_bufnr] = {
+  _NvimUI_AssociatedBufs[primary_bufnr] = {
     primary_win_id, minor_win_id, primary_border.win_id, minor_border.win_id
   }
 
@@ -184,7 +184,7 @@ function win_float.percentage_range_window(col_range, row_range, options)
 
   local border = Border:new(bufnr, win_id, win_opts, {})
 
-  _AssociatedBufs[bufnr] = { win_id, border.win_id, }
+  _NvimUI_AssociatedBufs[bufnr] = { win_id, border.win_id, }
 
   clear_buf_on_leave(bufnr)
 
@@ -198,17 +198,17 @@ function win_float.percentage_range_window(col_range, row_range, options)
 end
 
 function win_float.clear(bufnr)
-  if _AssociatedBufs[bufnr] == nil then
+  if _NvimUI_AssociatedBufs[bufnr] == nil then
     return
   end
 
-  for _, win_id in ipairs(_AssociatedBufs[bufnr]) do
+  for _, win_id in ipairs(_NvimUI_AssociatedBufs[bufnr]) do
     if vim.api.nvim_win_is_valid(win_id) then
       vim.fn.nvim_win_close(win_id, true)
     end
   end
 
-  _AssociatedBufs[bufnr] = nil
+  _NvimUI_AssociatedBufs[bufnr] = nil
 end
 
 return win_float

--- a/runtime/lua/vim/ui/float.lua
+++ b/runtime/lua/vim/ui/float.lua
@@ -1,0 +1,214 @@
+local Border = require('vim.ui.border')
+local tbl = require('vim.ui.ui_table')
+
+_AssociatedBufs = {}
+
+
+local clear_buf_on_leave = function(bufnr)
+  vim.cmd(
+    string.format(
+      "autocmd WinLeave,BufLeave,BufDelete <buffer=%s> ++once ++nested lua require('vim.ui.float').clear(%s)",
+      bufnr,
+      bufnr
+    )
+  )
+end
+
+local win_float = {}
+
+win_float.default_options = {
+  winblend = 15,
+  percentage = 0.9,
+}
+
+function win_float.default_opts(options)
+  options = tbl.apply_defaults(options, win_float.default_options)
+
+  local width = math.floor(vim.o.columns * options.percentage)
+  local height = math.floor(vim.o.lines * options.percentage)
+
+  local top = math.floor(((vim.o.lines - height) / 2) - 1)
+  local left = math.floor((vim.o.columns - width) / 2)
+
+  local opts = {
+    relative = 'editor',
+    row      = top,
+    col      = left,
+    width    = width,
+    height   = height,
+    style    = 'minimal'
+  }
+
+  return opts
+end
+
+function win_float.centered(options)
+  options = tbl.apply_defaults(options, win_float.default_options)
+
+  local win_opts = win_float.default_opts(options)
+
+  local bufnr = vim.fn.nvim_create_buf(false, true)
+  local win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+
+  vim.cmd('setlocal nocursorcolumn')
+  vim.fn.nvim_win_set_option(win_id, 'winblend', options.winblend)
+
+  vim.cmd(
+    string.format(
+      "autocmd WinLeave <buffer> silent! execute 'bdelete! %s'",
+      bufnr
+    )
+  )
+
+  return {
+    bufnr=bufnr,
+    win_id=win_id,
+  }
+end
+
+function win_float.centered_with_top_win(top_text, options)
+  options = tbl.apply_defaults(options, win_float.default_options)
+
+  table.insert(top_text, 1, string.rep("=", 80))
+  table.insert(top_text, string.rep("=", 80))
+
+  local primary_win_opts = win_float.default_opts(nil, nil, options)
+  local minor_win_opts = vim.deepcopy(primary_win_opts)
+
+  primary_win_opts.height = primary_win_opts.height - #top_text - 1
+  primary_win_opts.row = primary_win_opts.row + #top_text + 1
+
+  minor_win_opts.height = #top_text
+
+  local minor_bufnr = vim.api.nvim_create_buf(false, true)
+  local minor_win_id = vim.api.nvim_open_win(minor_bufnr, true, minor_win_opts)
+
+  vim.cmd('setlocal nocursorcolumn')
+  vim.fn.nvim_win_set_option(minor_win_id, 'winblend', options.winblend)
+
+  vim.api.nvim_buf_set_lines(minor_bufnr, 0, -1, false, top_text)
+
+  local primary_bufnr = vim.fn.nvim_create_buf(false, true)
+  local primary_win_id = vim.fn.nvim_open_win(primary_bufnr, true, primary_win_opts)
+
+  vim.cmd('setlocal nocursorcolumn')
+  vim.fn.nvim_win_set_option(primary_win_id, 'winblend', options.winblend)
+
+  -- vim.cmd(
+  --   string.format(
+  --     "autocmd WinLeave,BufDelete,BufLeave <buffer=%s> ++once ++nested silent! execute 'bdelete! %s'",
+  --     primary_buf,
+  --     minor_buf
+  --   )
+  -- )
+
+  -- vim.cmd(
+  --   string.format(
+  --     "autocmd WinLeave,BufDelete,BufLeave <buffer> ++once ++nested silent! execute 'bdelete! %s'",
+  --     primary_buf
+  --   )
+  -- )
+
+
+  local primary_border = Border:new(primary_bufnr, primary_win_id, primary_win_opts, {})
+  local minor_border = Border:new(minor_bufnr, minor_win_id, minor_win_opts, {})
+
+  _AssociatedBufs[primary_bufnr] = {
+    primary_win_id, minor_win_id, primary_border.win_id, minor_border.win_id
+  }
+
+  clear_buf_on_leave(primary_bufnr)
+
+  return {
+    bufnr = primary_bufnr,
+    win_id = primary_win_id,
+
+    minor_bufnr = minor_bufnr,
+    minor_win_id = minor_win_id,
+  }
+end
+
+--- Create window that takes up certain percentags of the current screen.
+---
+--- Works regardless of current buffers, tabs, splits, etc.
+--@param col_range number | Table:
+--                  If number, then center the window taking up this percentage of the screen.
+--                  If table, first index should be start, second_index should be end
+--@param row_range number | Table:
+--                  If number, then center the window taking up this percentage of the screen.
+--                  If table, first index should be start, second_index should be end
+function win_float.percentage_range_window(col_range, row_range, options)
+  options = tbl.apply_defaults(options, win_float.default_options)
+
+  local win_opts = win_float.default_opts(options)
+  win_opts.relative = "editor"
+
+  local height_percentage, row_start_percentage
+  if type(row_range) == 'number' then
+    assert(row_range <= 1)
+    assert(row_range > 0)
+    height_percentage = row_range
+    row_start_percentage = (1 - height_percentage) / 2
+  elseif type(row_range) == 'table' then
+    height_percentage = row_range[2] - row_range[1]
+    row_start_percentage = row_range[1]
+  else
+    error(string.format("Invalid type for 'row_range': %p", row_range))
+  end
+
+  win_opts.height = math.ceil(vim.o.lines * height_percentage)
+  win_opts.row = math.ceil(vim.o.lines *  row_start_percentage)
+
+  local width_percentage, col_start_percentage
+  if type(col_range) == 'number' then
+    assert(col_range <= 1)
+    assert(col_range > 0)
+    width_percentage = col_range
+    col_start_percentage = (1 - width_percentage) / 2
+  elseif type(col_range) == 'table' then
+    width_percentage = col_range[2] - col_range[1]
+    col_start_percentage = col_range[1]
+  else
+    error(string.format("Invalid type for 'col_range': %p", col_range))
+  end
+
+  win_opts.col = math.floor(vim.o.columns * col_start_percentage)
+  win_opts.width = math.floor(vim.o.columns * width_percentage)
+
+  local bufnr = options.bufnr or vim.fn.nvim_create_buf(false, true)
+  local win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+  vim.api.nvim_win_set_buf(win_id, bufnr)
+
+  vim.cmd('setlocal nocursorcolumn')
+  vim.fn.nvim_win_set_option(win_id, 'winblend', options.winblend)
+
+  local border = Border:new(bufnr, win_id, win_opts, {})
+
+  _AssociatedBufs[bufnr] = { win_id, border.win_id, }
+
+  clear_buf_on_leave(bufnr)
+
+  return {
+    bufnr = bufnr,
+    win_id = win_id,
+
+    border_bufnr = border.bufnr,
+    border_win_id = border.win_id,
+  }
+end
+
+function win_float.clear(bufnr)
+  if _AssociatedBufs[bufnr] == nil then
+    return
+  end
+
+  for _, win_id in ipairs(_AssociatedBufs[bufnr]) do
+    if vim.api.nvim_win_is_valid(win_id) then
+      vim.fn.nvim_win_close(win_id, true)
+    end
+  end
+
+  _AssociatedBufs[bufnr] = nil
+end
+
+return win_float

--- a/runtime/lua/vim/ui/float.lua
+++ b/runtime/lua/vim/ui/float.lua
@@ -1,5 +1,5 @@
 local Border = require('vim.ui.border')
-local tbl = require('vim.ui.ui_table')
+local utils = require('vim.ui._utils')
 
 _AssociatedBufs = {}
 
@@ -22,7 +22,7 @@ win_float.default_options = {
 }
 
 function win_float.default_opts(options)
-  options = tbl.apply_defaults(options, win_float.default_options)
+  options = utils.tbl_apply_defaults(options, win_float.default_options)
 
   local width = math.floor(vim.o.columns * options.percentage)
   local height = math.floor(vim.o.lines * options.percentage)
@@ -43,7 +43,7 @@ function win_float.default_opts(options)
 end
 
 function win_float.centered(options)
-  options = tbl.apply_defaults(options, win_float.default_options)
+  options = utils.tbl_apply_defaults(options, win_float.default_options)
 
   local win_opts = win_float.default_opts(options)
 
@@ -67,7 +67,7 @@ function win_float.centered(options)
 end
 
 function win_float.centered_with_top_win(top_text, options)
-  options = tbl.apply_defaults(options, win_float.default_options)
+  options = utils.tbl_apply_defaults(options, win_float.default_options)
 
   table.insert(top_text, 1, string.rep("=", 80))
   table.insert(top_text, string.rep("=", 80))
@@ -138,7 +138,7 @@ end
 --                  If number, then center the window taking up this percentage of the screen.
 --                  If table, first index should be start, second_index should be end
 function win_float.percentage_range_window(col_range, row_range, options)
-  options = tbl.apply_defaults(options, win_float.default_options)
+  options = utils.tbl_apply_defaults(options, win_float.default_options)
 
   local win_opts = win_float.default_opts(options)
   win_opts.relative = "editor"

--- a/runtime/lua/vim/ui/layout.lua
+++ b/runtime/lua/vim/ui/layout.lua
@@ -1,0 +1,77 @@
+local float = require('vim.ui.float')
+local utils = require('vim.ui._utils')
+
+-- TODO(smolck): Just for testing, don't intend to keep this
+local function make_win(text, options)
+  options = utils.tbl_apply_defaults(options, {
+    relative = 'editor',
+    row      = 0,
+    col      = 0,
+    width    = 5,
+    height   = 5,
+    style    = 'minimal'
+  })
+  -- local win_opts = float.default_opts(options)
+  local win_opts = options
+
+  local bufnr = vim.fn.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { text or 'This is just for testing' })
+
+  local win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+
+  return win_id
+end
+
+-- TODO(smolck): Is `partition` an accurate/good name?
+local function partition(max_height, max_width, starting_row, starting_col, input, is_horizontal)
+  for i, win_id in ipairs(input) do
+    local row, col
+    if is_horizontal then
+      row = starting_row + (max_height * (i - 1))
+      col = starting_col
+    else
+      row = starting_row
+      col = starting_col + (max_width * (i - 1))
+    end
+
+    if type(win_id) == 'table' then
+      local horizontal = not is_horizontal
+      partition(
+        horizontal and math.floor(max_height / #win_id) or max_height,
+        horizontal and max_width or math.floor(max_width / #win_id),
+        row,
+        col,
+        win_id,
+        horizontal
+      )
+    else
+      vim.api.nvim_win_set_config(win_id, {
+        row = row,
+        col = col,
+        width = max_width,
+        height = max_height,
+        relative = 'win',
+      })
+    end
+  end
+end
+
+-- TODO(smolck): Error on invalid layouts, like:
+-- ui.layout {
+--     { make_win(),
+--         { make_win('col left'), make_win('col right'), { make_win('underneath col right?') } },
+--       make_win(),
+--     },
+--     { make_win() },
+-- }
+local function layout(input)
+  local max_width = math.floor(vim.o.columns / #input)
+
+  for i, tbl in ipairs(input) do
+    local col = max_width * (i - 1)
+    local max_height = math.floor(vim.o.lines / #tbl)
+    partition(max_height, max_width, 0, col, tbl, true, false)
+  end
+end
+
+return layout

--- a/runtime/lua/vim/ui/layout.lua
+++ b/runtime/lua/vim/ui/layout.lua
@@ -1,4 +1,3 @@
-local float = require('vim.ui.float')
 local utils = require('vim.ui._utils')
 
 -- TODO(smolck): Just for testing, don't intend to keep this
@@ -11,7 +10,6 @@ local function make_win(text, options)
     height   = 5,
     style    = 'minimal'
   })
-  -- local win_opts = float.default_opts(options)
   local win_opts = options
 
   local bufnr = vim.fn.nvim_create_buf(false, true)

--- a/runtime/lua/vim/ui/notification.lua
+++ b/runtime/lua/vim/ui/notification.lua
@@ -1,0 +1,105 @@
+local utils = require('vim.ui._utils')
+
+vim.api.nvim_command("hi NotificationInfo guifg=#80ff95")
+vim.api.nvim_command("hi NotificationWarning guifg=#fff454")
+vim.api.nvim_command("hi NotificationError guifg=#c44323")
+
+local function notification(message, options)
+  if type(message) == "string" then
+    message = { message }
+  end
+
+  if type(message) ~= "table" then
+    error("First argument has to be either a table or a string")
+  end
+
+  options = options or {}
+  options.type = options.type or "info"
+  options.delay = options.delay or 2000
+
+  local width = utils.tbl_longest_str(message)
+  local height = #message
+  local row = options.row
+  local col = vim.api.nvim_get_option("columns") - 3
+
+  local buf = vim.api.nvim_create_buf(false, true)
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, message)
+
+  local window = vim.api.nvim_open_win(buf, false, {
+    relative = "editor",
+    row = row,
+    col = col,
+    width = width,
+    anchor = "SE",
+    height = height,
+    style = "minimal"
+  })
+
+  local border_buf = vim.api.nvim_create_buf(false, true)
+  local border_buf_lines = {}
+  width = width + 2
+
+  table.insert(border_buf_lines, string.format("╭%s╮", string.rep("─", width)))
+
+  for _=1,height do
+    table.insert(border_buf_lines, string.format("│%s│", string.rep(" ", width)))
+  end
+
+  table.insert(border_buf_lines, string.format("╰%s╯", string.rep("─", width)))
+
+  vim.api.nvim_buf_set_lines(border_buf, 0, -1, false, border_buf_lines)
+
+  local border_win = vim.api.nvim_open_win(border_buf, false, {
+    relative = "editor",
+    row = row + 1,
+    col = col + 3,
+    width = width + 3,
+    anchor = "SE",
+    height = height + 2,
+    style = "minimal"
+  })
+
+  if options.type == "info" then
+    vim.api.nvim_win_set_option(window, "winhl", "Normal:NotificationInfo")
+    vim.api.nvim_win_set_option(border_win, "winhl", "Normal:NotificationInfo")
+  elseif options.type == "warning" then
+    vim.api.nvim_win_set_option(window, "winhl", "Normal:NotificationWarning")
+    vim.api.nvim_win_set_option(border_win, "winhl", "Normal:NotificationWarning")
+  else
+    vim.api.nvim_win_set_option(window, "winhl", "Normal:NotificationError")
+    vim.api.nvim_win_set_option(border_win, "winhl", "Normal:NotificationError")
+  end
+
+  local timer
+  local delete = function()
+
+    if timer:is_active() then
+      timer:stop()
+    end
+
+    if vim.fn.winbufnr(window) ~= -1 then
+      vim.api.nvim_win_close(window, false)
+      vim.api.nvim_win_close(border_win, false)
+    end
+  end
+
+  timer = vim.defer_fn(delete, options.delay)
+
+  return {
+    window = window,
+    height = height,
+    width = width,
+    row = row,
+    col = col,
+    border = {
+      window = border_win,
+      buffer = border_buf
+    },
+    content = message,
+    delete = delete
+  }
+
+end
+
+return notification

--- a/runtime/lua/vim/ui/popup.lua
+++ b/runtime/lua/vim/ui/popup.lua
@@ -1,0 +1,209 @@
+--- popup.lua
+---
+--- Wrapper to make the popup api from vim in neovim.
+
+local vim = vim
+
+local Border = require("vim.ui.border")
+
+local popup = {}
+
+popup._pos_map = {
+  topleft="NW",
+  topright="NE",
+  botleft="SW",
+  botright="SE",
+}
+
+-- Keep track of hidden popups, so we can load them with popup.show()
+popup._hidden = {}
+
+
+local function dict_default(options, key, default)
+  if options[key] == nil then
+    return default[key]
+  else
+    return options[key]
+  end
+end
+
+
+function popup.popup_create(what, vim_options)
+  local bufnr
+  if type(what) == 'number' then
+    bufnr = what
+  else
+    bufnr = vim.fn.nvim_create_buf(false, true)
+    assert(bufnr, "Failed to create buffer")
+
+    -- TODO: Handle list of lines
+    vim.fn.nvim_buf_set_lines(bufnr, 0, -1, true, {what})
+  end
+
+  local option_defaults = {
+    posinvert = true
+  }
+
+  local win_opts = {}
+
+  if vim_options.line then
+    -- TODO: Need to handle "cursor", "cursor+1", ...
+    win_opts.row = vim_options.line
+  else
+    -- TODO: It says it needs to be "vertically cenetered"?...
+    -- wut is that.
+    win_opts.row = 0
+  end
+
+  if vim_options.col then
+    -- TODO: Need to handle "cursor", "cursor+1", ...
+    win_opts.col = vim_options.col
+  else
+    -- TODO: It says it needs to be "horizontally cenetered"?...
+    win_opts.col = 0
+  end
+
+  if vim_options.pos then
+    if vim_options.pos == 'center' then
+      -- TODO: Do centering..
+    else
+      win_opts.anchor = popup._pos_map[vim_options.pos]
+    end
+  end
+
+  -- posinvert	When FALSE the value of "pos" is always used.  When
+  -- 		TRUE (the default) and the popup does not fit
+  -- 		vertically and there is more space on the other side
+  -- 		then the popup is placed on the other side of the
+  -- 		position indicated by "line".
+  if dict_default(vim_options, 'posinvert', option_defaults) then
+    -- TODO: handle the invert thing
+  end
+
+  -- 	fixed		When FALSE (the default), and:
+  -- 			 - "pos" is "botleft" or "topleft", and
+  -- 			 - "wrap" is off, and
+  -- 			 - the popup would be truncated at the right edge of
+  -- 			   the screen, then
+  -- 			the popup is moved to the left so as to fit the
+  -- 			contents on the screen.  Set to TRUE to disable this.
+
+  win_opts.style = 'minimal'
+
+  -- Feels like maxheigh, minheight, maxwidth, minwidth will all be related
+  win_opts.height = 5
+  win_opts.width = 25
+
+  -- textprop	When present the popup is positioned next to a text
+  -- 		property with this name and will move when the text
+  -- 		property moves.  Use an empty string to remove.  See
+  -- 		|popup-textprop-pos|.
+  -- related:
+  --   textpropwin
+  --   textpropid
+
+  -- border
+  local border_options = {}
+  if vim_options.border then
+    local b_top, b_rgight, b_bot, b_left, b_topleft, b_topright, b_botright, b_botleft
+    if vim_options.borderchars == nil then
+      b_top , b_rgight , b_bot , b_left , b_topleft , b_topright , b_botright , b_botleft = {
+        '-' , '|'      , '-'   , '|'    , '┌'        , '┐'       , '┘'       , '└'
+      }
+    elseif #vim_options.borderchars == 1 then
+      -- TODO: Unpack 8 times cool to the same vars
+      print('...')
+    elseif #vim_options.borderchars == 2 then
+      -- TODO: Unpack to edges & corners
+      print('...')
+    elseif #vim_options.borderchars == 8 then
+      b_top , b_rgight , b_bot , b_left , b_topleft , b_topright , b_botright , b_botleft = vim_options.borderhighlight
+    end
+  end
+
+  win_opts.relative = "editor"
+
+  local win_id
+  if vim_options.hidden then
+    assert(false, "I have not implemented this yet and don't know how")
+  else
+    win_id = vim.fn.nvim_open_win(bufnr, true, win_opts)
+  end
+
+
+  -- Moved, handled after since we need the window ID
+  if vim_options.moved then
+    if vim_options.moved == 'any' then
+      vim.lsp.util.close_preview_autocmd({'CursorMoved', 'CursorMovedI'}, win_id)
+    elseif vim_options.moved == 'word' then
+      -- TODO: Handle word, WORD, expr, and the range functions... which seem hard?
+    end
+  else
+    vim.cmd(
+      string.format(
+        "autocmd BufLeave <buffer=%s> ++once call nvim_win_close(%s, v:false)",
+        bufnr,
+        win_id
+      )
+    )
+  end
+
+  if vim_options.time then
+    local timer = vim.loop.new_timer()
+    timer:start(vim_options.time, 0, vim.schedule_wrap(function()
+      vim.fn.nvim_close_win(win_id, false)
+    end))
+  end
+
+  -- Buffer Options
+  if vim_options.cursorline then
+    vim.fn.nvim_win_set_option(0, 'cursorline', true)
+  end
+
+  -- vim.fn.nvim_win_set_option(0, 'wrap', dict_default(vim_options, 'wrap', option_defaults))
+
+  -- ===== Not Implemented Options =====
+  -- flip: not implemented at the time of writing
+  -- Mouse:
+  --    mousemoved: no idea how to do the things with the mouse, so it's an exercise for the reader.
+  --    drag: mouses are hard
+  --    resize: mouses are hard
+  --    close: mouses are hard
+  --
+  -- scrollbar
+  -- scrollbarhighlight
+  -- thumbhighlight
+  --
+  -- tabpage: seems useless
+
+  -- Create border
+
+  -- title
+  if vim_options.title then
+    border_options.title = vim_options.title
+
+    if vim_options.border == 0 or vim_options.border == nil then
+      vim_options.border = 1
+      border_options.width = 1
+    end
+  end
+
+  if vim_options.border then
+    Border:new(bufnr, win_id, win_opts, border_options)
+  end
+
+  -- TODO: Perhaps there's a way to return an object that looks like a window id,
+  --    but actually has some extra metadata about it.
+  --
+  --    This would make `hidden` a lot easier to manage
+  return win_id
+end
+
+function popup.show(self, asdf)
+end
+
+popup.show = function()
+end
+
+return popup
+

--- a/runtime/lua/vim/ui/ui_table.lua
+++ b/runtime/lua/vim/ui/ui_table.lua
@@ -1,0 +1,19 @@
+local tbl = {}
+
+function tbl.apply_defaults(original, defaults)
+  if original == nil then
+    original = {}
+  end
+
+  original = vim.deepcopy(original)
+
+  for k, v in pairs(defaults) do
+    if original[k] == nil then
+      original[k] = v
+    end
+  end
+
+  return original
+end
+
+return tbl

--- a/runtime/lua/vim/ui/window.lua
+++ b/runtime/lua/vim/ui/window.lua
@@ -1,0 +1,18 @@
+
+local window = {}
+
+window.try_close = function(win_id, force)
+  if force == nil then
+    force = true
+  end
+
+  pcall(vim.api.nvim_win_close, win_id, force)
+end
+
+window.close_related_win = function(parent_win_id, child_win_id)
+  window.try_close(parent_win_id, true)
+  window.try_close(child_win_id, true)
+end
+
+return window
+


### PR DESCRIPTION
I wanted to open the PR so this can serve as a conversation point. The goal of this is to provide a cohesive set of UI elements for plugin authors to leverage and to avoid duplication of UI components across plugins, and within neovim itself.

cc @smolck 

- [ ] Implement full popup_* api compatibility (vimscript wrappers)
- [ ] Add checkboxes/radio selectors
- [ ] vim.ui.prompt_text
- [ ] vim.ui.select_many
- [x] vim.ui.notification (see neogit)
- [x] vim.ui.layout  (see [here](https://github.com/nvim-telescope/telescope.nvim/blob/141dc6d55e4f53ee9527adc164a0d39725394bfd/lua/telescope/pickers/layout_strategies.lua))
- [ ] Add additional border/styling options
- [ ] Dynamically resize windows as the neovim window changes shape
- [ ] Interface for easily overriding handlers