### PR TITLE
Fix pumvisible() check introduced in #12900

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -726,7 +726,7 @@ function M.focusable_float(unique_name, fn)
   local bufnr = api.nvim_get_current_buf()
   do
     local win = find_window_by_var(unique_name, bufnr)
-    if win and api.nvim_win_is_valid(win) and not vim.fn.pumvisible() then
+    if win and api.nvim_win_is_valid(win) and vim.fn.pumvisible() == 0 then
       api.nvim_set_current_win(win)
       api.nvim_command("stopinsert")
       return


### PR DESCRIPTION
`pumvisible()` returns a number, and numbers are always `true` in Lua,
so the return value needs to be checked explicitly.

Using https://github.com/neovim/neovim/pull/12900 as context, it appears
the intention was to move into the `if` branch when the completion popup
is not shown (i.e. `vim.fn.pumvisible() == 0`).