### PR TITLE
fix(pty): Always use $TERM from the job's env dict

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5607,7 +5607,6 @@ jobstart({cmd}[, {opts}])				*jobstart()*
 			      before invoking `on_stderr`. |channel-buffered|
 		  stdout_buffered: (boolean) Collect data until EOF (stream
 			      closed) before invoking `on_stdout`. |channel-buffered|
-		  TERM:	      (string) Sets the `pty` $TERM environment variable.
 		  width:      (number) Width of the `pty` terminal.
 
 		{opts} is passed as |self| dictionary to the callback; the

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -270,9 +270,6 @@ static void process_close_event(void **argv)
 {
   Process *proc = argv[0];
   shell_free_argv(proc->argv);
-  if (proc->type == kProcessTypePty) {
-    xfree(((PtyProcess *)proc)->term_name);
-  }
   if (proc->cb) {  // "on_exit" for jobstart(). See channel_job_start().
     proc->cb(proc, proc->status, proc->data);
   }

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -182,8 +182,6 @@ static void init_child(PtyProcess *ptyproc)
   char *prog = ptyproc->process.argv[0];
 
   assert(proc->env);
-  tv_dict_add_str(proc->env, S_LEN("TERM"),
-                  ptyproc->term_name ? ptyproc->term_name : "ansi");
   environ = tv_dict_to_env(proc->env);
   execvp(prog, proc->argv);
   ELOG("execvp failed: %s: %s", strerror(errno), prog);

--- a/src/nvim/os/pty_process_unix.h
+++ b/src/nvim/os/pty_process_unix.h
@@ -17,7 +17,6 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
 {
   PtyProcess rv;
   rv.process = process_init(loop, kProcessTypePty, data);
-  rv.term_name = NULL;
   rv.width = 80;
   rv.height = 24;
   rv.tty_fd = -1;

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -37,7 +37,6 @@ static inline PtyProcess pty_process_init(Loop *loop, void *data)
 {
   PtyProcess rv;
   rv.process = process_init(loop, kProcessTypePty, data);
-  rv.term_name = NULL;
   rv.width = 80;
   rv.height = 24;
   rv.object.winpty = NULL;


### PR DESCRIPTION
Before #12937, the only way to specify the `$TERM` for a pty job was through the `TERM` key in the job's opts dict.  This was shuttled to the child process throug a special field on the PtyProcess object and injected into the environment after forking.

Now that we have a proper way to specify the environment for a job, we can simply ensure that the env dict has a proper `TERM` set and avoid the extra shuttling of data around.

This deprecates the use of the `TERM` option, but will still honor it if present, although at a lower priority than a `TERM` present in the env dict.

This also fixes #13874 because we're no longer trying to overwrite `TERM` in the env dict with the special pty `term_name`.  Doing so raises an internal error because of the existing key which, under certain circumstances, would cause the "hit enter" prompt.  However, since the child process had already forked, there was no way for the user to acknowledge the prompt and we would just hang there.