### PR TITLE
ci(gha/win): Do not rename python.exe to python3.exe if it exists

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -88,11 +88,14 @@ elseif ($compiler -eq 'MSVC') {
 if (-not $NoTests) {
   # Setup python (use AppVeyor system python)
 
-  C:\hostedtoolcache\windows\Python\2.7.18\x64\python.exe -m pip install pynvim ; exitIfFailed
-  C:\hostedtoolcache\windows\Python\3.5.4\x64\python.exe -m pip install pynvim ; exitIfFailed
-  # Disambiguate python3
-  move C:\hostedtoolcache\windows\Python\3.5.4\x64\python.exe C:\hostedtoolcache\windows\Python\3.5.4\x64\python3.exe
-  $env:PATH = "C:\hostedtoolcache\windows\Python\3.5.4\x64;C:\hostedtoolcache\windows\Python\2.7.18\x64;$env:PATH"
+  # Disambiguate python3, if needed
+  if (-not (Test-Path -Path C:\hostedtoolcache\windows\Python\3.5.4\x64\python3.exe) ) {
+    move C:\hostedtoolcache\windows\Python\3.5.4\x64\python.exe C:\hostedtoolcache\windows\Python\3.5.4\x64\python3.exe
+  }
+  $env:PATH = "C:\hostedtoolcache\windows\Python\2.7.18\x64;C:\hostedtoolcache\windows\Python\3.5.4\x64;$env:PATH"
+
+  python -m pip install pynvim ; exitIfFailed
+  python3 -m pip install pynvim ; exitIfFailed
   # Sanity check
   python  -c "import pynvim; print(str(pynvim))" ; exitIfFailed
   python3 -c "import pynvim; print(str(pynvim))" ; exitIfFailed


### PR DESCRIPTION
GHA now provides python3.exe by default -- actions/python-versions#78

Ensure Python 2 directory is earlier in $PATH so bare python always
invokes Python 2.