### PR TITLE
feat(lua): vim.region() visual selection (FKA get_visual_selection)

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -457,6 +457,38 @@ function vim.region(bufnr, pos1, pos2, regtype, inclusive)
   return region
 end
 
+--- Get the current/last visual selection as a string
+---
+--@return selection string containing the last visual selection
+function vim.get_visual_selection()
+	local bufnr = 0
+
+	local pos1 = vim.fn.getpos("'<")
+	local pos2 = vim.fn.getpos("'>")
+
+	local start = { pos1[2] - 1, pos1[3] - 1 + pos1[4] }
+	local finish = { pos2[2] - 1, pos2[3] - 1 + pos2[4] }
+
+	if start[2] < 0 or finish[1] < start[1] then return end
+
+	local region =
+		vim.region(
+			bufnr,
+			start,
+			finish,
+			vim.fn.visualmode(),
+			(vim.o.selection ~= 'exclusive')
+		)
+	local lines =
+		vim.api.nvim_buf_get_lines(bufnr, start[1], finish[1] + 1, false)
+	lines[1] = lines[1]:sub(region[start[1]][1] + 1, region[start[1]][2])
+	if start[1] ~= finish[1] then
+		lines[#lines] =
+			lines[#lines]:sub(region[finish[1]][1] + 1, region[finish[1]][2])
+	end
+	return table.concat(lines)
+end
+
 --- Defers calling `fn` until `timeout` ms passes.
 ---
 --- Use to do a one-shot timer that calls `fn`

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -457,62 +457,91 @@ function vim.region(bufnr, pos1, pos2, regtype, inclusive)
   return region
 end
 
---- Get the current/last visual selection as a string
+--- Get the region between two marks and the start and end positions for the region
 ---
---@return selection string containing the last visual selection
+--@param mark1 Name of mark starting the region
+--@param mark2 Name of mark ending the region
+--@param options Table containing the adjustment function, register type and selection mode
+--@return region region between the two marks, as returned by |vim.region|
+--@return start (row,col) tuple denoting the start of the region
+--@return finish (row,col) tuple denoting the end of the region
+function vim.get_marked_region(mark1, mark2, options)
+  local bufnr = 0
+  local adjust = options.adjust or function(pos1, pos2)
+    return pos1, pos2
+  end
+  local regtype = options.regtype or vim.fn.visualmode()
+  local selection = options.selection or (vim.o.selection ~= 'exclusive')
+
+  local pos1 = vim.fn.getpos(mark1)
+  local pos2 = vim.fn.getpos(mark2)
+  pos1, pos2 = adjust(pos1, pos2)
+
+  local start = { pos1[2] - 1, pos1[3] - 1 + pos1[4] }
+  local finish = { pos2[2] - 1, pos2[3] - 1 + pos2[4] }
+
+  -- Return if start or finish are invalid
+  if start[2] < 0 or finish[1] < start[1] then return end
+
+  local region = vim.region(bufnr, start, finish, regtype, selection)
+  return region, start, finish
+end
+
+--- Get the current visual selection as a string
+---
+--@return selection string containing the current visual selection
 function vim.get_visual_selection()
-	local visual_modes = {
-		v = true,
-		V = true,
-		-- [t'<C-v>'] = true, -- Visual block does not seem to be supported by vim.region
-	}
+  local visual_modes = {
+    v = true,
+    V = true,
+    -- [t'<C-v>'] = true, -- Visual block does not seem to be supported by vim.region
+  }
 
-	-- Return if not in visual mode
-	if visual_modes[vim.api.nvim_get_mode().mode] == nil then return end
+  -- Return if not in visual mode
+  if visual_modes[vim.api.nvim_get_mode().mode] == nil then return end
 
-	local bufnr = 0
+  local options = {}
+  options.adjust = function(pos1, pos2)
+    if vim.fn.visualmode() == "V" then
+      pos1[3] = 1
+      pos2[3] = 2^31 - 1
+    end
 
-	local pos1 = vim.fn.getpos("'<")
-	local pos2 = vim.fn.getpos("'>")
+    if pos1[2] > pos2[2] then
+      pos2[3], pos1[3] = pos1[3], pos2[3]
+      return pos2, pos1
+    elseif pos1[2]==pos2[2] and pos1[3] > pos2[3] then
+      return pos2, pos1
+    else
+      return pos1, pos2
+    end
+  end
 
-	local start = { pos1[2] - 1, pos1[3] - 1 + pos1[4] }
-	local finish = { pos2[2] - 1, pos2[3] - 1 + pos2[4] }
+  local region, start, finish = vim.get_marked_region('v', '.', options)
 
-	-- Return if start or finish are invalid
-	if start[2] < 0 or finish[1] < start[1] then return end
+  -- Compute the number of chars to get from the first line,
+  -- because vim.region returns -1 as the ending col if the
+  -- end of the line is included in the selection
+  local lines =
+    vim.api.nvim_buf_get_lines(bufnr, start[1], finish[1] + 1, false)
+  local line1_end
+  if region[start[1]][2] - region[start[1]][1] < 0 then
+    line1_end = #lines[1] - region[start[1]][1]
+  else
+    line1_end = region[start[1]][2] - region[start[1]][1]
+  end
 
-	local region =
-		vim.region(
-			bufnr,
-			start,
-			finish,
-			vim.fn.visualmode(),
-			(vim.o.selection ~= 'exclusive')
-		)
-	local lines =
-		vim.api.nvim_buf_get_lines(bufnr, start[1], finish[1] + 1, false)
-
-	-- Compute the number of chars to get from the first line,
-	-- because vim.region returns -1 as the ending col if the
-	-- end of the line is included in the selection
-	local line1_end
-	if region[start[1]][2] - region[start[1]][1] < 0 then
-		line1_end = #lines[1] - region[start[1]][1]
-	else
-		line1_end = region[start[1]][2] - region[start[1]][1]
-	end
-
-	lines[1] = vim.fn.strpart(lines[1], region[start[1]][1], line1_end, true)
-	if start[1] ~= finish[1] then
-		lines[#lines] =
-			vim.fn.strpart(
-				lines[#lines],
-				region[finish[1]][1],
-				region[finish[1]][2] - region[finish[1]][1],
-				true
-			)
-	end
-	return table.concat(lines)
+  lines[1] = vim.fn.strpart(lines[1], region[start[1]][1], line1_end, true)
+  if start[1] ~= finish[1] then
+    lines[#lines] =
+      vim.fn.strpart(
+        lines[#lines],
+        region[finish[1]][1],
+        region[finish[1]][2] - region[finish[1]][1],
+        false
+      )
+  end
+  return table.concat(lines)
 end
 
 --- Defers calling `fn` until `timeout` ms passes.

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -491,6 +491,7 @@ end
 ---
 --@return selection string containing the current visual selection
 function vim.get_visual_selection()
+  local bufnr = 0
   local visual_modes = {
     v = true,
     V = true,
@@ -537,8 +538,7 @@ function vim.get_visual_selection()
       vim.fn.strpart(
         lines[#lines],
         region[finish[1]][1],
-        region[finish[1]][2] - region[finish[1]][1],
-        false
+        region[finish[1]][2] - region[finish[1]][1]
       )
   end
   return table.concat(lines)


### PR DESCRIPTION
Function returns the current/last visual selection as a string. Potential changes/considerations that may come under the scope of this PR -
- Refactor the function to separate getting the region demarcated by two marks, and converting the region to a string
- Allow specifying marks to get the region between any two marks (instead of just the visual region marks)
- Reuse region selection in highlight.vim for yanked region highlighting
- Returning a table instead of a string might be helpful
- Removing indentation from each line might be helpful (at least as an option)

**Known issues**
- ~~When the last character in the selection is a multibyte unicode character, the last character is not copied correctly. This appears to be an issue with `vim.region`, where only one byte is copied of the last character~~
- When a visual selection is active, the contents of the last visual selection are returned (instead of the currently active visual selection)
- Does not work as a command (`:lua vim.get_visual_selection()`), and does not work in visual block mode

Pinging @clason, @bfredl, @tjdevries involved in the discussion on Gitter/Matrix