### PR TITLE
Refactor option,var functions to use char for param type

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -544,7 +544,7 @@ char_u *au_event_disable(char *what)
   } else {
     STRCAT(new_ei, what);
   }
-  set_string_option_direct((char_u *)"ei", -1, new_ei, OPT_FREE, SID_NONE);
+  set_string_option_direct("ei", -1, new_ei, OPT_FREE, SID_NONE);
   xfree(new_ei);
 
   return save_ei;
@@ -553,7 +553,7 @@ char_u *au_event_disable(char *what)
 void au_event_restore(char_u *old_ei)
 {
   if (old_ei != NULL) {
-    set_string_option_direct((char_u *)"ei", -1, old_ei, OPT_FREE, SID_NONE);
+    set_string_option_direct("ei", -1, old_ei, OPT_FREE, SID_NONE);
     xfree(old_ei);
   }
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3940,9 +3940,9 @@ int build_stl_str_hl(
 
       // Store the current buffer number as a string variable
       vim_snprintf((char *)buf_tmp, sizeof(buf_tmp), "%d", curbuf->b_fnum);
-      set_internal_string_var((char_u *)"g:actual_curbuf", buf_tmp);
+      set_internal_string_var("g:actual_curbuf", buf_tmp);
       vim_snprintf((char *)win_tmp, sizeof(win_tmp), "%d", curwin->handle);
-      set_internal_string_var((char_u *)"g:actual_curwin", win_tmp);
+      set_internal_string_var("g:actual_curwin", win_tmp);
 
       buf_T *const save_curbuf = curbuf;
       win_T *const save_curwin = curwin;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3236,7 +3236,7 @@ void maketitle(void)
                          0, maxlen, NULL, NULL);
         title_str = (char_u *)buf;
         if (called_emsg) {
-          set_string_option_direct((char_u *)"titlestring", -1, (char_u *)"",
+          set_string_option_direct("titlestring", -1, (char_u *)"",
                                    OPT_FREE, SID_ERROR);
         }
         called_emsg |= save_called_emsg;
@@ -3346,7 +3346,7 @@ void maketitle(void)
                          p_iconstring, use_sandbox,
                          0, 0, NULL, NULL);
         if (called_emsg) {
-          set_string_option_direct((char_u *)"iconstring", -1,
+          set_string_option_direct("iconstring", -1,
                                    (char_u *)"", OPT_FREE, SID_ERROR);
         }
         called_emsg |= save_called_emsg;

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -126,7 +126,7 @@ bool ctx_restore(Context *ctx, const int flags)
   }
 
   char_u *op_shada;
-  get_option_value((char_u *)"shada", NULL, &op_shada, OPT_GLOBAL);
+  get_option_value("shada", NULL, &op_shada, OPT_GLOBAL);
   set_option_value("shada", 0L, "!,'100,%", OPT_GLOBAL);
 
   if (flags & kCtxRegs) {

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1375,7 +1375,7 @@ void diff_win_options(win_T *wp, int addbuf)
     }
     wp->w_p_fdm_save = vim_strsave(wp->w_p_fdm);
   }
-  set_string_option_direct((char_u *)"fdm", -1, (char_u *)"diff",
+  set_string_option_direct("fdm", -1, (char_u *)"diff",
                            OPT_LOCAL | OPT_FREE, 0);
   curwin = old_curwin;
   curbuf = curwin->w_buffer;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1848,7 +1848,7 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
         s = tv_get_string_chk(tv);  // != NULL if number or string.
       }
       if (s != NULL && op != NULL && *op != '=') {
-        opt_type = get_option_value(arg, &numval, (char_u **)&stringval,
+        opt_type = get_option_value((char *)arg, &numval, (char_u **)&stringval,
                                     opt_flags);
         if ((opt_type == 1 && *op == '.')
             || (opt_type == 0 && *op != '.')) {
@@ -4537,7 +4537,7 @@ int get_option_tv(const char **const arg, typval_T *const rettv,
 
   c = *option_end;
   *option_end = NUL;
-  opt_type = get_option_value((char_u *)(*arg), &numval,
+  opt_type = get_option_value(*arg, &numval,
                               rettv == NULL ? NULL : &stringval, opt_flags);
 
   if (opt_type == -3) {                 // invalid name

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -523,9 +523,9 @@ var_redir_start(
   tv.v_type = VAR_STRING;
   tv.vval.v_string = (char_u *)"";
   if (append) {
-    set_var_lval(redir_lval, redir_endp, &tv, true, false, (char_u *)".");
+    set_var_lval(redir_lval, redir_endp, &tv, true, false, ".");
   } else {
-    set_var_lval(redir_lval, redir_endp, &tv, true, false, (char_u *)"=");
+    set_var_lval(redir_lval, redir_endp, &tv, true, false, "=");
   }
   clear_lval(redir_lval);
   err = did_emsg;
@@ -585,7 +585,7 @@ void var_redir_stop(void)
       redir_endp = (char_u *)get_lval(redir_varname, NULL, redir_lval,
                                       false, false, 0, FNE_CHECK_START);
       if (redir_endp != NULL && redir_lval->ll_name != NULL) {
-        set_var_lval(redir_lval, redir_endp, &tv, false, false, (char_u *)".");
+        set_var_lval(redir_lval, redir_endp, &tv, false, false, ".");
       }
       clear_lval(redir_lval);
     }
@@ -1925,7 +1925,7 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv,
       if (endchars != NULL && vim_strchr(endchars, *skipwhite(p)) == NULL) {
         EMSG(_(e_letunexp));
       } else {
-        set_var_lval(&lv, p, tv, copy, is_const, op);
+        set_var_lval(&lv, p, tv, copy, is_const, (const char *)op);
         arg_end = p;
       }
     }
@@ -2299,7 +2299,7 @@ void clear_lval(lval_T *lp)
  * "%" for "%=", "." for ".=" or "=" for "=".
  */
 static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv,
-                         int copy, const bool is_const, const char_u *op)
+                         int copy, const bool is_const, const char *op)
 {
   int cc;
   listitem_T  *ri;
@@ -2326,7 +2326,7 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv,
                                TV_CSTRING)
                  && !tv_check_lock(di->di_tv.v_lock, (const char *)lp->ll_name,
                                    TV_CSTRING)))
-            && eexe_mod_op(&tv, rettv, (const char *)op) == OK) {
+            && eexe_mod_op(&tv, rettv, op) == OK) {
           set_var(lp->ll_name, lp->ll_name_len, &tv, false);
         }
         tv_clear(&tv);
@@ -2369,8 +2369,7 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv,
      */
     for (ri = tv_list_first(rettv->vval.v_list); ri != NULL; ) {
       if (op != NULL && *op != '=') {
-        eexe_mod_op(TV_LIST_ITEM_TV(lp->ll_li), TV_LIST_ITEM_TV(ri),
-                    (const char *)op);
+        eexe_mod_op(TV_LIST_ITEM_TV(lp->ll_li), TV_LIST_ITEM_TV(ri), op);
       } else {
         tv_clear(TV_LIST_ITEM_TV(lp->ll_li));
         tv_copy(TV_LIST_ITEM_TV(ri), TV_LIST_ITEM_TV(lp->ll_li));
@@ -2428,7 +2427,7 @@ static void set_var_lval(lval_T *lp, char_u *endp, typval_T *rettv,
       }
 
       if (op != NULL && *op != '=') {
-        eexe_mod_op(lp->ll_tv, rettv, (const char *)op);
+        eexe_mod_op(lp->ll_tv, rettv, op);
         goto notify;
       } else {
         tv_clear(lp->ll_tv);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -455,14 +455,15 @@ void eval_clear(void)
  * Set an internal variable to a string value. Creates the variable if it does
  * not already exist.
  */
-void set_internal_string_var(char_u *name, char_u *value)
+void set_internal_string_var(const char *name, char_u *value)
+  FUNC_ATTR_NONNULL_ARG(1)
 {
-  const typval_T tv = {
+  typval_T tv = {
     .v_type = VAR_STRING,
     .vval.v_string = value,
   };
 
-  set_var((const char *)name, STRLEN(name), (typval_T *)&tv, true);
+  set_var(name, strlen(name), &tv, true);
 }
 
 static lval_T   *redir_lval = NULL;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2149,7 +2149,7 @@ static void f_menu_get(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   tv_list_alloc_ret(rettv, kListLenMayKnow);
   int modes = MENU_ALL_MODES;
   if (argvars[1].v_type == VAR_STRING) {
-    const char_u *const strmodes = (char_u *)tv_get_string(&argvars[1]);
+    const char *const strmodes = tv_get_string(&argvars[1]);
     modes = get_menu_cmd_modes(strmodes, false, NULL, NULL);
   }
   menu_get((char_u *)tv_get_string(&argvars[0]), modes, rettv->vval.v_list);
@@ -3170,7 +3170,7 @@ static void f_getcompletion(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   if (xpc.xp_context == EXPAND_MENUS) {
-    set_context_in_menu_cmd(&xpc, (char_u *)"menu", xpc.xp_pattern, false);
+    set_context_in_menu_cmd(&xpc, "menu", xpc.xp_pattern, false);
     xpc.xp_pattern_len = STRLEN(xpc.xp_pattern);
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4227,7 +4227,7 @@ skip:
   size_t subsize = preview_lines.subresults.size;
   if (preview && !aborting()) {
     if (got_quit || profile_passed_limit(timeout)) {  // Too slow, disable.
-      set_string_option_direct((char_u *)"icm", -1, (char_u *)"", OPT_FREE,
+      set_string_option_direct("icm", -1, (char_u *)"", OPT_FREE,
                                SID_NONE);
     } else if (*p_icm != NUL &&  pat != NULL) {
       if (pre_src_id == 0) {
@@ -4528,7 +4528,7 @@ prepare_tagpreview (
       RESET_BINDING(curwin);                /* don't take over 'scrollbind'
                                                and 'cursorbind' */
       curwin->w_p_diff = false;             // no 'diff'
-      set_string_option_direct((char_u *)"fdc", -1,     // no 'foldcolumn'
+      set_string_option_direct("fdc", -1,     // no 'foldcolumn'
                                (char_u *)"0", OPT_FREE, SID_NONE);
       return true;
     }
@@ -5023,7 +5023,7 @@ int find_help_tags(const char_u *arg, int *num_matches, char_u ***matches,
 static void prepare_help_buffer(void)
 {
   curbuf->b_help = true;
-  set_string_option_direct((char_u *)"buftype", -1, (char_u *)"help",
+  set_string_option_direct("buftype", -1, (char_u *)"help",
                            OPT_FREE|OPT_LOCAL, 0);
 
   // Always set these options after jumping to a help tag, because the
@@ -5033,13 +5033,13 @@ static void prepare_help_buffer(void)
   // Only set it when needed, buf_init_chartab() is some work.
   char_u *p = (char_u *)"!-~,^*,^|,^\",192-255";
   if (STRCMP(curbuf->b_p_isk, p) != 0) {
-    set_string_option_direct((char_u *)"isk", -1, p, OPT_FREE|OPT_LOCAL, 0);
+    set_string_option_direct("isk", -1, p, OPT_FREE|OPT_LOCAL, 0);
     check_buf_options(curbuf);
     (void)buf_init_chartab(curbuf, FALSE);
   }
 
   // Don't use the global foldmethod.
-  set_string_option_direct((char_u *)"fdm", -1, (char_u *)"manual",
+  set_string_option_direct("fdm", -1, (char_u *)"manual",
                            OPT_FREE|OPT_LOCAL, 0);
 
   curbuf->b_p_ts = 8;         // 'tabstop' is 8.
@@ -5659,7 +5659,7 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
   cmdmod.tab = 0;                 // disable :tab modifier
   cmdmod.noswapfile = true;       // disable swap for preview buffer
   // disable file info message
-  set_string_option_direct((char_u *)"shm", -1, (char_u *)"F", OPT_FREE,
+  set_string_option_direct("shm", -1, (char_u *)"F", OPT_FREE,
                            SID_NONE);
 
   bool outside_curline = (eap->line1 != old_cusr.lnum
@@ -5782,7 +5782,7 @@ static buf_T *show_sub(exarg_T *eap, pos_T old_cusr,
   update_screen(SOME_VALID);
   RedrawingDisabled = save_rd;
 
-  set_string_option_direct((char_u *)"shm", -1, save_shm_p, OPT_FREE, SID_NONE);
+  set_string_option_direct("shm", -1, save_shm_p, OPT_FREE, SID_NONE);
   xfree(save_shm_p);
 
   cmdmod = save_cmdmod;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2375,13 +2375,13 @@ void ex_compiler(exarg_T *eap)
     // Set "b:current_compiler" from "current_compiler".
     p = get_var_value("g:current_compiler");
     if (p != NULL) {
-      set_internal_string_var((char_u *)"b:current_compiler", p);
+      set_internal_string_var("b:current_compiler", p);
     }
 
     // Restore "current_compiler" for ":compiler {name}".
     if (!eap->forceit) {
       if (old_cur_comp != NULL) {
-        set_internal_string_var((char_u *)"g:current_compiler",
+        set_internal_string_var("g:current_compiler",
                                 old_cur_comp);
         xfree(old_cur_comp);
       } else {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2179,7 +2179,7 @@ int parse_command_modifiers(exarg_T *eap, char_u **errormsg, bool skip_only)
           // Set 'eventignore' to "all". Restore the
           // existing option value later.
           cmdmod.save_ei = vim_strsave(p_ei);
-          set_string_option_direct((char_u *)"ei", -1,
+          set_string_option_direct("ei", -1,
                                    (char_u *)"all", OPT_FREE, SID_NONE);
         }
         continue;
@@ -2291,9 +2291,8 @@ static void undo_cmdmod(const exarg_T *eap, int save_msg_scroll)
   }
 
   if (cmdmod.save_ei != NULL) {
-    /* Restore 'eventignore' to the value before ":noautocmd". */
-    set_string_option_direct((char_u *)"ei", -1, cmdmod.save_ei,
-        OPT_FREE, SID_NONE);
+    // Restore 'eventignore' to the value before ":noautocmd".
+    set_string_option_direct("ei", -1, cmdmod.save_ei, OPT_FREE, SID_NONE);
     free_string_option(cmdmod.save_ei);
   }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3518,7 +3518,7 @@ const char * set_one_cmd_context(
       // EX_XFILE: file names are handled above.
       if (!(ea.argt & EX_XFILE)) {
         if (context == EXPAND_MENUS) {
-          return (const char *)set_context_in_menu_cmd(xp, (char_u *)cmd,
+          return (const char *)set_context_in_menu_cmd(xp, cmd,
                                                        (char_u *)arg, forceit);
         } else if (context == EXPAND_COMMANDS) {
           return arg;
@@ -3598,7 +3598,7 @@ const char * set_one_cmd_context(
   case CMD_tmenu:                             case CMD_tunmenu:
   case CMD_popup:                             case CMD_emenu:
     return (const char *)set_context_in_menu_cmd(
-        xp, (char_u *)cmd, (char_u *)arg, forceit);
+        xp, cmd, (char_u *)arg, forceit);
 
   case CMD_colorscheme:
     xp->xp_context = EXPAND_COLORS;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -886,7 +886,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     need_wait_return = false;
   }
 
-  set_string_option_direct((char_u *)"icm", -1, s->save_p_icm, OPT_FREE,
+  set_string_option_direct("icm", -1, s->save_p_icm, OPT_FREE,
                            SID_NONE);
   State = s->save_State;
   setmouse();

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1644,8 +1644,7 @@ failed:
     save_file_ff(curbuf);
     // If editing a new file: set 'fenc' for the current buffer.
     // Also for ":read ++edit file".
-    set_string_option_direct((char_u *)"fenc", -1, fenc,
-        OPT_FREE | OPT_LOCAL, 0);
+    set_string_option_direct("fenc", -1, fenc, OPT_FREE | OPT_LOCAL, 0);
   }
   if (fenc_alloced)
     xfree(fenc);
@@ -2002,7 +2001,7 @@ void set_forced_fenc(exarg_T *eap)
 {
   if (eap->force_enc != 0) {
     char_u *fenc = enc_canonize(eap->cmd + eap->force_enc);
-    set_string_option_direct((char_u *)"fenc", -1, fenc, OPT_FREE|OPT_LOCAL, 0);
+    set_string_option_direct("fenc", -1, fenc, OPT_FREE|OPT_LOCAL, 0);
     xfree(fenc);
   }
 }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1404,9 +1404,9 @@ static void load_plugins(void)
 static void handle_quickfix(mparm_T *paramp)
 {
   if (paramp->edit_type == EDIT_QF) {
-    if (paramp->use_ef != NULL)
-      set_string_option_direct((char_u *)"ef", -1,
-          paramp->use_ef, OPT_FREE, SID_CARG);
+    if (paramp->use_ef != NULL) {
+      set_string_option_direct("ef", -1, paramp->use_ef, OPT_FREE, SID_CARG);
+    }
     vim_snprintf((char *)IObuff, IOSIZE, "cfile %s", p_ef);
     if (qf_init(NULL, p_ef, p_efm, true, IObuff, p_menc) < 0) {
       msg_putchar('\n');

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -81,7 +81,7 @@ ex_menu(exarg_T *eap)
                                   // kFalse for "menu disable
   vimmenu_T menuarg;
 
-  modes = get_menu_cmd_modes(eap->cmd, eap->forceit, &noremap, &unmenu);
+  modes = get_menu_cmd_modes((char *)eap->cmd, eap->forceit, &noremap, &unmenu);
   arg = eap->arg;
 
   for (;; ) {
@@ -912,7 +912,9 @@ static int expand_emenu;                /* TRUE for ":emenu" command */
 /*
  * Work out what to complete when doing command line completion of menu names.
  */
-char_u *set_context_in_menu_cmd(expand_T *xp, char_u *cmd, char_u *arg, int forceit)
+char_u *set_context_in_menu_cmd(expand_T *xp, const char *cmd, char_u *arg,
+                                bool forceit)
+  FUNC_ATTR_NONNULL_ALL
 {
   char_u      *after_dot;
   char_u      *p;
@@ -1178,7 +1180,7 @@ static bool menu_namecmp(const char_u *const name, const char_u *const mname)
 ///                     to whether the command is an "unmenu" command.
 int
 get_menu_cmd_modes(
-    const char_u * cmd,
+    const char *cmd,
     bool forceit,
     int *noremap,
     int *unmenu

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4531,7 +4531,7 @@ bool is_tty_option(const char *name)
 #define TCO_BUFFER_SIZE 8
 /// @param name TUI-related option
 /// @param[out,allocated] value option string value
-bool get_tty_option(char *name, char **value)
+bool get_tty_option(const char *name, char **value)
 {
   if (strequal(name, "t_Co")) {
     if (value) {
@@ -4611,17 +4611,17 @@ static int findoption(const char *const arg)
 ///           hidden String option: -2.
 ///                 unknown option: -3.
 int get_option_value(
-    char_u *name,
+    const char *name,
     long *numval,
     char_u **stringval,            ///< NULL when only checking existence
     int opt_flags
 )
 {
-  if (get_tty_option((char *)name, (char **)stringval)) {
+  if (get_tty_option(name, (char **)stringval)) {
     return 0;
   }
 
-  int opt_idx = findoption((const char *)name);
+  int opt_idx = findoption(name);
   if (opt_idx < 0) {  // Unknown option.
     return -3;
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2120,9 +2120,9 @@ static int shada_idx = -1;
 // "set_sid".
 void
 set_string_option_direct(
-    char_u *name,
+    const char *name,
     int opt_idx,
-    char_u *val,
+    const char_u *val,
     int opt_flags,                  // OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
     int set_sid
 )
@@ -2133,7 +2133,7 @@ set_string_option_direct(
   int idx = opt_idx;
 
   if (idx == -1) {  // Use name.
-    idx = findoption((const char *)name);
+    idx = findoption(name);
     if (idx < 0) {  // Not found (should not happen).
       internal_error("set_string_option_direct()");
       IEMSG2(_("For option %s"), name);
@@ -3791,7 +3791,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
     if (p_terse && p == NULL) {
       STRCPY(IObuff, p_shm);
       STRCAT(IObuff, "s");
-      set_string_option_direct((char_u *)"shm", -1, IObuff, OPT_FREE, 0);
+      set_string_option_direct("shm", -1, IObuff, OPT_FREE, 0);
     } else if (!p_terse && p != NULL) {  // remove 's' from p_shm
       STRMOVE(p, p + 1);
     }
@@ -4597,6 +4597,7 @@ bool set_tty_option(const char *name, char *value)
 ///
 /// @return Option index or -1 if option was not found.
 static int findoption(const char *const arg)
+  FUNC_ATTR_NONNULL_ALL
 {
   return findoption_len(arg, strlen(arg));
 }
@@ -7054,7 +7055,7 @@ void set_fileformat(int eol_style, int opt_flags)
 
   // p is NULL if "eol_style" is EOL_UNKNOWN.
   if (p != NULL) {
-    set_string_option_direct((char_u *)"ff",
+    set_string_option_direct("ff",
                              -1,
                              (char_u *)p,
                              OPT_FREE | opt_flags,

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4951,7 +4951,7 @@ void ex_cfile(exarg_T *eap)
     }
   }
   if (*eap->arg != NUL) {
-    set_string_option_direct((char_u *)"ef", -1, eap->arg, OPT_FREE, 0);
+    set_string_option_direct("ef", -1, eap->arg, OPT_FREE, 0);
   }
 
   char_u *enc = (*curbuf->b_p_menc != NUL) ? curbuf->b_p_menc : p_menc;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3665,7 +3665,7 @@ static int qf_open_new_cwindow(qf_info_T *qi, int height)
 static void qf_set_title_var(qf_list_T *qfl)
 {
   if (qfl->qf_title != NULL) {
-    set_internal_string_var((char_u *)"w:quickfix_title", qfl->qf_title);
+    set_internal_string_var("w:quickfix_title", qfl->qf_title);
   }
 }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5092,9 +5092,9 @@ static void redraw_custom_statusline(win_T *wp)
     // When there is an error disable the statusline, otherwise the
     // display is messed up with errors and a redraw triggers the problem
     // again and again.
-    set_string_option_direct((char_u *)"statusline", -1,
-        (char_u *)"", OPT_FREE | (*wp->w_p_stl != NUL
-                                  ? OPT_LOCAL : OPT_GLOBAL), SID_ERROR);
+    set_string_option_direct("statusline", -1, (char_u *)"",
+                             OPT_FREE | (*wp->w_p_stl != NUL
+                                         ? OPT_LOCAL : OPT_GLOBAL), SID_ERROR);
   }
   did_emsg |= saved_did_emsg;
   entered = false;
@@ -5175,7 +5175,7 @@ get_keymap_str (
 static void
 win_redr_custom (
     win_T *wp,
-    int draw_ruler                 /* TRUE or FALSE */
+    bool draw_ruler
 )
 {
   static int entered = FALSE;
@@ -6852,7 +6852,7 @@ void draw_tabline(void)
     did_emsg = false;
     win_redr_custom(NULL, false);
     if (did_emsg) {
-      set_string_option_direct((char_u *)"tabline", -1,
+      set_string_option_direct("tabline", -1,
                                (char_u *)"", OPT_FREE, SID_ERROR);
     }
     did_emsg |= saved_did_emsg;
@@ -7114,11 +7114,12 @@ static void win_redr_ruler(win_T *wp, int always)
   if (*p_ruf) {
     int save_called_emsg = called_emsg;
 
-    called_emsg = FALSE;
-    win_redr_custom(wp, TRUE);
-    if (called_emsg)
-      set_string_option_direct((char_u *)"rulerformat", -1,
-          (char_u *)"", OPT_FREE, SID_ERROR);
+    called_emsg = false;
+    win_redr_custom(wp, true);
+    if (called_emsg) {
+      set_string_option_direct("rulerformat", -1, (char_u *)"",
+                               OPT_FREE, SID_ERROR);
+    }
     called_emsg |= save_called_emsg;
     return;
   }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -6624,7 +6624,7 @@ void ex_spelldump(exarg_T *eap)
   if (no_spell_checking(curwin)) {
     return;
   }
-  get_option_value((char_u *)"spl", &dummy, &spl, OPT_LOCAL);
+  get_option_value("spl", &dummy, &spl, OPT_LOCAL);
 
   // Create a new empty buffer in a new window.
   do_cmdline_cmd("new");

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3419,7 +3419,7 @@ static void syn_cmd_on(exarg_T *eap, int syncing)
  */
 static void syn_cmd_enable(exarg_T *eap, int syncing)
 {
-  set_internal_string_var((char_u *)"syntax_cmd", (char_u *)"enable");
+  set_internal_string_var("syntax_cmd", (char_u *)"enable");
   syn_cmd_onoff(eap, "syntax");
   do_unlet(S_LEN("g:syntax_cmd"), true);
 }
@@ -3432,7 +3432,7 @@ static void syn_cmd_reset(exarg_T *eap, int syncing)
 {
   eap->nextcmd = check_nextcmd(eap->arg);
   if (!eap->skip) {
-    set_internal_string_var((char_u *)"syntax_cmd", (char_u *)"reset");
+    set_internal_string_var("syntax_cmd", (char_u *)"reset");
     do_cmdline_cmd("runtime! syntax/syncolor.vim");
     do_unlet(S_LEN("g:syntax_cmd"), true);
   }
@@ -5614,14 +5614,14 @@ void ex_ownsyntax(exarg_T *eap)
   // Move value of b:current_syntax to w:current_syntax.
   new_value = get_var_value("b:current_syntax");
   if (new_value != NULL) {
-    set_internal_string_var((char_u *)"w:current_syntax", new_value);
+    set_internal_string_var("w:current_syntax", new_value);
   }
 
   // Restore value of b:current_syntax.
   if (old_value == NULL) {
     do_unlet(S_LEN("b:current_syntax"), true);
   } else {
-    set_internal_string_var((char_u *)"b:current_syntax", old_value);
+    set_internal_string_var("b:current_syntax", old_value);
     xfree(old_value);
   }
 }


### PR DESCRIPTION
Change type of some function parameters from char_u to char to reduce type casts in the codebase. I wonder why char_u was used for some function params that are not compared to values beyond the value range of char.

Noticed these while reviewing https://github.com/neovim/neovim/pull/13851

Related: https://github.com/neovim/neovim/issues/459