### PR TITLE
Remove unneeded space in front of command description

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -736,7 +736,7 @@ tag		char	      note action in Normal mode	~
 				   search pattern and Visually select it
 |gP|		["x]gP		2  put the text [from register x] before the
 				   cursor N times, leave the cursor after it
-|gQ|		gQ		    switch to "Ex" mode with Vim editing
+|gQ|		gQ		   switch to "Ex" mode with Vim editing
 |gR|		gR		2  enter Virtual Replace mode
 |gT|		gT		   go to the previous tab page
 |gU|		gU{motion}	2  make Nmove text uppercase


### PR DESCRIPTION
Fix #13901