### PR TITLE
fix: vim.notify default impl error

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -500,7 +500,7 @@ function vim.notify(msg, log_level, _opts)
   if log_level == vim.log.levels.ERROR then
     vim.api.nvim_err_writeln(msg)
   else
-    vim.api.nvim_echo(msg)
+    vim.api.nvim_echo({{msg}}, true, {})
   end
 end
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -476,13 +476,16 @@ describe('API', function()
   end)
 
   describe('nvim_notify', function()
+    it('can notify a info message', function()
+      nvim("notify", "hello world", 2, {})
+    end)
+
     it('can be overriden', function()
       command("lua vim.notify = function(...) return 42 end")
       eq(42, meths.exec_lua("return vim.notify('Hello world')", {}))
       nvim("notify", "hello world", 4, {})
     end)
   end)
-
 
   describe('nvim_input', function()
     it("VimL error: does NOT fail, updates v:errmsg", function()


### PR DESCRIPTION
This fixes the following vim.notify error.

```
$ ./neovim/build/bin/nvim --headless -u NORC +"lua vim.notify('msg')"
Error detected while processing command line:
E5108: Error executing lua vim.lua:503: Expected 3 arguments
```
