### PR TITLE
[LSP] - Add a message when a symbol is unable to be renamed.

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -215,10 +215,17 @@ M['textDocument/documentSymbol'] = symbol_handler
 M['workspace/symbol'] = symbol_handler
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename
-M['textDocument/rename'] = function(_, _, result)
-  if not result then return end
-  util.apply_workspace_edit(result)
-end
+M['textDocument/rename'] = function(err, _, result, client_id)
+   if not util.workspace_edit_has_edits(result) then
+     local err_msg = ""
+     if err then err_msg = ": " .. err.message end
+     local client = vim.lsp.get_client_by_id(client_id)
+     local client_name = client and client.name or string.format("id=%d", client_id)
+     err_message("LSP[", client_name, "] Unable to rename symbol", err_msg)
+   else
+     util.apply_workspace_edit(result)
+   end
+ end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting
 M['textDocument/rangeFormatting'] = function(_, _, result)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -624,6 +624,20 @@ function M.text_document_completion_list_to_complete_items(result, prefix)
   return matches
 end
 
+--- Checks to see if a `WorkspaceEdit` contains any edits.
+ ---
+ --- @param workspace_edit (table) `WorkspaceEdit`
+ --- @see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
+ function M.workspace_edit_has_edits(workspace_edit)
+   if not workspace_edit then
+     return false
+   elseif (workspace_edit.documentChanges and #workspace_edit.documentChanges > 0) or
+     (workspace_edit.changes and #workspace_edit.changes > 0) then
+     return true
+   else
+     return false
+   end
+ end
 
 --- Rename old_fname to new_fname
 --

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1167,6 +1167,43 @@ describe('LSP', function()
     end)
   end)
 
+  describe('lsp.util.workspace_edit_has_edits', function()
+    it('returns false if there are no documentChanges or changes', function()
+      local expected = false
+      local actual = exec_lua [[
+        local no_edits = {}
+        return vim.lsp.util.workspace_edit_has_edits(no_edits)
+      ]]
+      eq(expected, actual)
+    end)
+    it('returns false documentChanges exists but is empty', function()
+      local expected = false
+      local actual = exec_lua [[
+        local empty_document_changes = {documentChanges = {}}
+        return vim.lsp.util.workspace_edit_has_edits(empty_document_changes)
+      ]]
+      eq(expected, actual)
+    end)
+    it('returns true if documentChanges is nill but changes has edits', function()
+      local expected = false
+      local actual = exec_lua [[
+        local only_changes = {
+          changes = {
+            ['file://fake/uri'] = {
+              range = {
+                start = { line = 0, character = 2},
+                ['end'] = {line = 0, character = 3}
+              },
+            newText = 'new stuff'
+            }
+          }
+        }
+        return vim.lsp.util.workspace_edit_has_edits(only_changes)
+      ]]
+      eq(expected, actual)
+    end)
+  end)
+
   describe('workspace_apply_edit', function()
     it('workspace/applyEdit returns ApplyWorkspaceEditResponse', function()
       local expected = {


### PR DESCRIPTION
Depending on your server and specific situation a rename cannot always
be executed. To give a concrete example of this, in Metals, we support a
few different file types: Scala files, standalone scripts, worksheets,
etc. In Worksheets we don't have semantic information so we don't offer
rename. In other clients like coc.nvim for example when a user tries to
do a rename (in that case a prepareRename) and there is no edit, it will
show you a warning that the symbol or target cannot be renamed. I want
to offer this as a proposal as a small quality of life improvement so
that if a user attempts to rename something that can't be renamed by the
server, they actually get notified of it and aren't left wondering..
what happened? Why didn't this work?