### PR TITLE
CMake: Remove duplicate compile flags argument

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -284,7 +284,7 @@ foreach(sfile ${NVIM_SOURCES}
   endif()
   add_custom_command(
     OUTPUT "${gf_c_h}" "${gf_h_h}"
-    COMMAND ${CMAKE_C_COMPILER} ${sfile} ${PREPROC_OUTPUT} ${gen_cflags} ${C_FLAGS_ARRAY}
+    COMMAND ${CMAKE_C_COMPILER} ${sfile} ${PREPROC_OUTPUT} ${gen_cflags}
     COMMAND "${LUA_PRG}" "${HEADER_GENERATOR}" "${sfile}" "${gf_c_h}" "${gf_h_h}" "${gf_i}"
     DEPENDS ${depends})
   list(APPEND NVIM_GENERATED_FOR_SOURCES "${gf_c_h}")


### PR DESCRIPTION
`${C_FLAGS_ARRAY}` is already [part of `${gen_cflags}`](https://github.com/neovim/neovim/blob/4b2997a823ca4235ac0ddea3ba053d417437bf53/src/nvim/CMakeLists.txt#L214) and does not need to be passed explicitly.

Passing it a second time leads to macro redefinition warnings when `-D_FORTIFY_SOURCE=2` is given as part of `CFLAGS` because Neovim enforces `-D_FORTIFY_SOURCE=1`.