### PR TITLE
[RDY] Redraw line when entering insert mode on line even when cursor position is the same

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1421,10 +1421,9 @@ static void ins_redraw(
     bool ready                  // not busy with something
 )
 {
-  bool conceal_cursor_moved = false;
-
-  if (char_avail())
+  if (char_avail()) {
     return;
+  }
 
   // Trigger CursorMoved if the cursor moved.  Not when the popup menu is
   // visible, the command might delete it.
@@ -1444,7 +1443,6 @@ static void ins_redraw(
       update_curswant();
       ins_apply_autocmds(EVENT_CURSORMOVEDI);
     }
-    conceal_cursor_moved = true;
     curwin->w_last_cursormoved = curwin->w_cursor;
   }
 
@@ -1500,8 +1498,7 @@ static void ins_redraw(
     curbuf->b_changed_invalid = false;
   }
 
-  if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)
-      && conceal_cursor_moved) {
+  if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)) {
     redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, meths = helpers.clear, helpers.meths
 local eq = helpers.eq
+local feed = helpers.feed
 local command = helpers.command
 
 describe('ui/cursor', function()
@@ -317,6 +318,37 @@ describe('ui/cursor', function()
         end
       end
     end)
+  end)
+
+  it("updates cursor position when entering insert mode #13916", function()
+    helpers.insert([[foobarfoobarfoobar]])
+    -- move to end of line
+    feed("$")
+
+    command("set conceallevel=1")
+    command("set concealcursor=ni")
+    command("set conceallevel=1")
+
+    command("syn match Foo /foobar/ conceal cchar=&")
+
+    screen:expect([[
+  &&&^                      |
+  ~                        |
+  ~                        |
+  ~                        |
+                           |
+    ]])
+
+    feed("i")
+    -- cursor should stay in place, not jump to column 16
+
+    screen:expect([[
+  &&&^                      |
+  ~                        |
+  ~                        |
+  ~                        |
+  -- INSERT --             |
+    ]])
   end)
 
 end)


### PR DESCRIPTION
Fixes #13916. Not sure why `conceal_cursor_moved` was needed in the first place.