### PR TITLE
man.vim: `:Man` should not change global value of 'tagfunc' option

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -51,7 +51,7 @@ function! man#open_page(count, mods, ...) abort
 
   let [l:buf, l:save_tfu] = [bufnr(), &tagfunc]
   try
-    set tagfunc=man#goto_tag
+    setlocal tagfunc=man#goto_tag
     let l:target = l:name . '(' . l:sect . ')'
     if a:mods !~# 'tab' && s:find_man()
       execute 'silent keepalt tag' l:target


### PR DESCRIPTION
`:Man ` command implicitly changes the global value of `tagfunc`. To reproduce the issue:

### With the minimal vimrc:

```vim
set tagfunc=CocTagFunc  " a tagfunc provided by lsp client coc.nvim
```

### Steps

- `vim -u mini_vimrc foo.c`, executing `set tagfunc?` gives me `CocTagFunc` which is expected
- `:Man open` opens a split man buffer, in which `set tagfunc?` returns `man#goto_tag` which is expected
- `:e bar.c` opens another c file in a new buffer, in which `set tagfunc?` is still `man#goto_page`, which should be `CocTagFunc`.