### PR TITLE
[RDY] api: Add nvim_win_get_buftext_offset.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ set(NVIM_VERSION_PATCH 0)
 set(NVIM_VERSION_PRERELEASE "-dev") # for package maintainers
 
 # API level
-set(NVIM_API_LEVEL 7)         # Bump this after any API change.
+set(NVIM_API_LEVEL 8)         # Bump this after any API change.
 set(NVIM_API_LEVEL_COMPAT 0)  # Adjust this after a _breaking_ API change.
 set(NVIM_API_PRERELEASE true)
 

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2424,6 +2424,23 @@ nvim_win_get_width({window})                            *nvim_win_get_width()*
                 Return: ~
                     Width as a count of columns
 
+nvim_win_get_buftext_offset({window})           *nvim_win_get_buftext_offset()*
+                Gets the window-space start offset of the buffer text
+
+                Returns the window-space offset at which the text from the
+                buffer start in the given window. This takes into account the
+                number / relative-number columns’ widths as long as the sign
+                columns’ widths.
+
+                The behavior is the same should you be using 'wrap' or
+                'nowrap'.
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+
+                Return: ~
+                    Offset as a count of columns
+
 nvim_win_is_valid({window})                              *nvim_win_is_valid()*
                 Checks if a window is valid
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -236,6 +236,34 @@ void nvim_win_set_width(Window window, Integer width, Error *err)
   try_end(err);
 }
 
+/// Gets the window-space start offset of the buffer text
+///
+/// @param window   Window handle, or 0 for current window
+/// @param[out] err Error details, if any
+/// @return Offset as a count of columns
+Integer nvim_win_get_buftext_offset(Window window, Error *err)
+  FUNC_API_SINCE(8)
+{
+  win_T *win = find_window_by_handle(window, err);
+
+  if (!win) {
+    return 0;
+  }
+
+  Integer left_side_width = win->w_nrwidth;
+
+  // if w_nrwidth is non-zero, add 1 for the extra space
+  if (left_side_width > 0) {
+    left_side_width++;
+  }
+
+  left_side_width += win_signcol_count(win) * win_signcol_width(win);
+
+  // we add 1 to get the offset of the beginning of the buffer text in
+  // the window
+  return left_side_width + 1;
+}
+
 /// Gets a window-scoped (w:) variable
 ///
 /// @param window   Window handle, or 0 for current window


### PR DESCRIPTION
This adds the `nvim_win_get_buftext_offset` API to query the window-space offset of the beginning of the buffer text in the window.