### PR TITLE
ex_cmds: add cload and lload

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -640,6 +640,12 @@ module.cmds = {
     func='ex_copen',
   },
   {
+    command='cload',
+    flags=bit.bor(TRLBAR),
+    addr_type='ADDR_NONE',
+    func='ex_cload',
+  },
+  {
     command='cprevious',
     flags=bit.bor(RANGE, COUNT, TRLBAR, BANG),
     addr_type='ADDR_UNSIGNED',
@@ -1576,6 +1582,12 @@ module.cmds = {
     flags=bit.bor(RANGE, COUNT, TRLBAR),
     addr_type='ADDR_OTHER',
     func='ex_copen',
+  },
+  {
+    command='lload',
+    flags=bit.bor(TRLBAR),
+    addr_type='ADDR_NONE',
+    func='ex_cload',
   },
   {
     command='lprevious',


### PR DESCRIPTION
Hello,
this is my naive take on implementing an excommand to load the quickfix (buffer) into the current window.

You can test it by runnning `:cload`.
`:lload` was added for analogy.

Is this something that is use full for others?
I could try adding tests, if someone points me to the right direction.

Any feedback is appreciated :)
