### PR TITLE
Add a possibility to disable map K in termdebug

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -298,7 +298,7 @@ breakpoint, or use the "Clear breakpoint" right-click menu entry.
 Inspecting variables ~
 					*termdebug-variables* *:Evaluate*
  `:Evaluate`	    evaluate the expression under the cursor
- `K`		    same
+ `K`		    same (see |termdebug_map_K| to disable)
  `:Evaluate` {expr}   evaluate {expr}
  `:'<,'>Evaluate`     evaluate the Visually selected text
 
@@ -329,6 +329,10 @@ This works slightly differently:
 						*termdebug_use_prompt*
 Prompt mode can be used even when the |+terminal| feature is present with: >
 	let g:termdebug_use_prompt = 1
+<
+						*termdebug_map_K*
+The K key is normally mapped to :Evaluate. If you do not want this use: >
+	let g:termdebug_map_K = 0
 
 
 Communication ~

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Update: 2018 Jun 3
+" Last Update: 2021 Mar 9
 "
 " WORK IN PROGRESS - Only the basics work
 " Note: On MS-Windows you need a recent version of gdb.  The one included with
@@ -653,8 +653,8 @@ func s:InstallCommands()
   command Source call s:GotoSourcewinOrCreateIt()
   command Winbar call s:InstallWinbar()
 
-  " TODO: can the K mapping be restored?
   if !exists('g:termdebug_map_K') || g:termdebug_map_K
+    let s:k_map_saved = maparg('K', 'n', 0, 1)
     nnoremap K :Evaluate<CR>
   endif
 
@@ -693,8 +693,9 @@ func s:DeleteCommands()
   delcommand Source
   delcommand Winbar
 
-  if !exists('g:termdebug_map_K') || g:termdebug_map_K
-    nunmap K
+  if exists('s:k_map_saved')
+    call mapset('n', 0, s:k_map_saved)
+    unlet s:k_map_saved
   endif
 
   exe 'sign unplace ' . s:pc_id

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -654,7 +654,9 @@ func s:InstallCommands()
   command Winbar call s:InstallWinbar()
 
   " TODO: can the K mapping be restored?
-  nnoremap K :Evaluate<CR>
+  if !exists('g:termdebug_map_K') || g:termdebug_map_K
+    nnoremap K :Evaluate<CR>
+  endif
 
   let &cpo = save_cpo
 endfunc
@@ -691,7 +693,9 @@ func s:DeleteCommands()
   delcommand Source
   delcommand Winbar
 
-  nunmap K
+  if !exists('g:termdebug_map_K') || g:termdebug_map_K
+    nunmap K
+  endif
 
   exe 'sign unplace ' . s:pc_id
   for [id, entries] in items(s:breakpoints)


### PR DESCRIPTION
When termdebug plugin is used, the previous mapping for K was lost.
This is a workaround, which allows to disable that behavior.