### PR TITLE
autoread episode III: revenge of the trees

### DIFF
--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -69,9 +69,10 @@ struct u_header {
 #endif
 };
 
-/* values for uh_flags */
-#define UH_CHANGED  0x01        /* b_changed flag before undo/after redo */
-#define UH_EMPTYBUF 0x02        /* buffer was empty */
+// values for uh_flags
+#define UH_CHANGED  0x01        // b_changed flag before undo/after redo
+#define UH_EMPTYBUF 0x02        // buffer was empty
+#define UH_RELOAD   0x04        // buffer was reloaded
 
 /// Structure passed around between undofile functions.
 typedef struct {

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -635,6 +635,27 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
 
       eq({'new line 1 new line 2', 'new line 3'}, meths.buf_get_lines(0, 0, -1, true))
+
+      -- check we can undo and redo a reload event.
+      feed 'u'
+      check_events {
+        { "test1", "bytes", 1, 8, 0, 10, 10, 0, 1, 1, 1, 0, 1 };
+      }
+
+      feed 'u'
+      check_events {
+        { "test1", "reload", 1 };
+      }
+
+      feed '<c-r>'
+      check_events {
+        { "test1", "reload", 1 };
+      }
+
+      feed '<c-r>'
+      check_events {
+        { "test1", "bytes", 1, 14, 0, 10, 10, 1, 0, 1, 0, 1, 1 };
+      }
     end)
 
     teardown(function()


### PR DESCRIPTION
as the TODO says when 'undoreload' is set we really should have all the info needed for a proper splice event. This should be good enough in the meanwhile to keep your tree-sitter trees in sync when you walk the undo trees.