### PR TITLE
lsp: remove deprecated references to 'callbacks'

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -16,10 +16,7 @@ local validate = vim.validate
 local lsp = {
   protocol = protocol;
 
-  -- TODO(tjdevries): Add in the warning that `callbacks` is no longer supported.
-  -- util.warn_once("vim.lsp.callbacks is deprecated. Use vim.lsp.handlers instead.")
   handlers = default_handlers;
-  callbacks = default_handlers;
 
   buf = require'vim.lsp.buf';
   diagnostic = require'vim.lsp.diagnostic';
@@ -219,8 +216,6 @@ local function validate_client_config(config)
   }
   validate {
     root_dir        = { config.root_dir, is_dir, "directory" };
-    -- TODO(remove-callbacks)
-    callbacks       = { config.callbacks, "t", true };
     handlers        = { config.handlers, "t", true };
     capabilities    = { config.capabilities, "t", true };
     cmd_cwd         = { config.cmd_cwd, optional_validator(is_dir), "directory" };
@@ -234,13 +229,6 @@ local function validate_client_config(config)
     offset_encoding = { config.offset_encoding, "s", true };
     flags           = { config.flags, "t", true };
   }
-
-  -- TODO(remove-callbacks)
-  if config.handlers and config.callbacks then
-    error(debug.traceback(
-      "Unable to configure LSP with both 'config.handlers' and 'config.callbacks'. Use 'config.handlers' exclusively."
-    ))
-  end
 
   local cmd, cmd_args = lsp._cmd_parts(config.cmd)
   local offset_encoding = valid_encodings.UTF16
@@ -473,8 +461,7 @@ function lsp.start_client(config)
 
   local client_id = next_client_id()
 
-  -- TODO(remove-callbacks)
-  local handlers = config.handlers or config.callbacks or {}
+  local handlers = config.handlers or {}
   local name = config.name or tostring(client_id)
   local log_prefix = string.format("LSP[%s]", name)
 
@@ -573,8 +560,6 @@ function lsp.start_client(config)
     offset_encoding = offset_encoding;
     config = config;
 
-    -- TODO(remove-callbacks)
-    callbacks = handlers;
     handlers = handlers;
     -- for $/progress report
     messages = { name = name, messages = {}, progress = {}, status = {} }

--- a/runtime/lua/vim/lsp/callbacks.lua
+++ b/runtime/lua/vim/lsp/callbacks.lua
@@ -1,4 +1,0 @@
-local util = require 'vim.lsp.util'
-
-util._warn_once("require('vim.lsp.callbacks') is deprecated. Use vim.lsp.handlers instead.")
-return require('vim.lsp.handlers')

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -18,14 +18,6 @@ end
 
 local M = {}
 
--- TODO(remove-callbacks)
-M.diagnostics_by_buf = setmetatable({}, {
-  __index = function(_, bufnr)
-    warn_once("diagnostics_by_buf is deprecated. Use 'vim.lsp.diagnostic.get'")
-    return vim.lsp.diagnostic.get(bufnr)
-  end
-})
-
 --@private
 local function split_lines(value)
   return split(value, '\n', true)
@@ -1025,78 +1017,6 @@ function M.open_floating_preview(contents, filetype, opts)
   api.nvim_buf_set_option(floating_bufnr, 'bufhidden', 'wipe')
   M.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"}, floating_winnr)
   return floating_bufnr, floating_winnr
-end
-
--- TODO(remove-callbacks)
-do
-  --@deprecated
-  function M.get_severity_highlight_name(severity)
-    warn_once("vim.lsp.util.get_severity_highlight_name is deprecated.")
-    return vim.lsp.diagnostic._get_severity_highlight_name(severity)
-  end
-
-  --@deprecated
-  function M.buf_clear_diagnostics(bufnr, client_id)
-    warn_once("buf_clear_diagnostics is deprecated. Use vim.lsp.diagnostic.clear")
-    return vim.lsp.diagnostic.clear(bufnr, client_id)
-  end
-
-  --@deprecated
-  function M.get_line_diagnostics()
-    warn_once("get_line_diagnostics is deprecated. Use vim.lsp.diagnostic.get_line_diagnostics")
-
-    local bufnr = api.nvim_get_current_buf()
-    local line_nr = api.nvim_win_get_cursor(0)[1] - 1
-
-    return vim.lsp.diagnostic.get_line_diagnostics(bufnr, line_nr)
-  end
-
-  --@deprecated
-  function M.show_line_diagnostics()
-    warn_once("show_line_diagnostics is deprecated. Use vim.lsp.diagnostic.show_line_diagnostics")
-
-    local bufnr = api.nvim_get_current_buf()
-    local line_nr = api.nvim_win_get_cursor(0)[1] - 1
-
-    return vim.lsp.diagnostic.show_line_diagnostics(bufnr, line_nr)
-  end
-
-  --@deprecated
-  function M.buf_diagnostics_save_positions(bufnr, diagnostics, client_id)
-    warn_once("buf_diagnostics_save_positions is deprecated. Use vim.lsp.diagnostic.save")
-    return vim.lsp.diagnostic.save(diagnostics, bufnr, client_id)
-  end
-
-  --@deprecated
-  function M.buf_diagnostics_get_positions(bufnr, client_id)
-    warn_once("buf_diagnostics_get_positions is deprecated. Use vim.lsp.diagnostic.get")
-    return vim.lsp.diagnostic.get(bufnr, client_id)
-  end
-
-  --@deprecated
-  function M.buf_diagnostics_underline(bufnr, diagnostics, client_id)
-    warn_once("buf_diagnostics_underline is deprecated. Use 'vim.lsp.diagnostic.set_underline'")
-    return vim.lsp.diagnostic.set_underline(diagnostics, bufnr, client_id)
-  end
-
-  --@deprecated
-  function M.buf_diagnostics_virtual_text(bufnr, diagnostics, client_id)
-    warn_once("buf_diagnostics_virtual_text is deprecated. Use 'vim.lsp.diagnostic.set_virtual_text'")
-    return vim.lsp.diagnostic.set_virtual_text(diagnostics, bufnr, client_id)
-  end
-
-  --@deprecated
-  function M.buf_diagnostics_signs(bufnr, diagnostics, client_id)
-    warn_once("buf_diagnostics_signs is deprecated. Use 'vim.lsp.diagnostic.set_signs'")
-    return vim.lsp.diagnostic.set_signs(diagnostics, bufnr, client_id)
-  end
-
-  --@deprecated
-  function M.buf_diagnostics_count(kind, client_id)
-    warn_once("buf_diagnostics_count is deprecated. Use 'vim.lsp.diagnostic.get_count'")
-    return vim.lsp.diagnostic.get_count(vim.api.nvim_get_current_buf(), client_id, kind)
-  end
-
 end
 
 do --[[ References ]]

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -70,11 +70,11 @@ local function expect_notification(method, params, ...)
       ..., "expect_notification", "message")
 end
 
-local function expect_request(method, callback, ...)
+local function expect_request(method, handler, ...)
   local req = read_message()
   assert_eq(method, req.method,
       ..., "expect_request", "method")
-  local err, result = callback(req.params)
+  local err, result = handler(req.params)
   respond(req.id, err, result)
 end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -44,7 +44,7 @@ local function fake_lsp_server_setup(test_name, timeout_ms)
       handlers = setmetatable({}, {
         __index = function(t, method)
           return function(...)
-            return vim.rpcrequest(1, 'callback', ...)
+            return vim.rpcrequest(1, 'handler', ...)
           end
         end;
       });
@@ -89,7 +89,7 @@ local function test_rpc_server(config)
       end
       return NIL
     end
-    if method == 'callback' then
+    if method == 'handler' then
       if config.on_callback then
         config.on_callback(unpack(args))
       end
@@ -205,7 +205,7 @@ describe('LSP', function()
       }
       test_rpc_server {
         test_name = "basic_init";
-        on_init = function(client, _init_result)
+        on_init = function(client, _)
           -- client is a dummy object which will queue up commands to be run
           -- once the server initializes. It can't accept lua callbacks or
           -- other types that may be unserializable for now.
@@ -386,7 +386,7 @@ describe('LSP', function()
             exec_lua([=[
               BUFFER = vim.api.nvim_get_current_buf()
               lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID)
-              vim.lsp.callbacks['textDocument/typeDefinition'] = function(err, method)
+              vim.lsp.handlers['textDocument/typeDefinition'] = function(err, method)
                 vim.lsp._last_lsp_callback = { err = err; method = method }
               end
               vim.lsp._unsupported_method = function(method)
@@ -425,7 +425,7 @@ describe('LSP', function()
         test_name = "capabilities_for_client_supports_method";
         on_setup = function()
             exec_lua([=[
-              vim.lsp.callbacks['textDocument/typeDefinition'] = function(err, method)
+              vim.lsp.handlers['textDocument/typeDefinition'] = function(err, method)
                 vim.lsp._last_lsp_callback = { err = err; method = method }
               end
               vim.lsp._unsupported_method = function(method)
@@ -897,8 +897,8 @@ describe('LSP', function()
           eq(0, code, "exit code", fake_lsp_logfile)
           eq(0, signal, "exit signal", fake_lsp_logfile)
         end;
-        on_callback = function(err, method, params, client_id)
-          eq(table.remove(expected_callbacks), {err, method, params, client_id}, "expected callback")
+        on_handler = function(err, method, params, client_id)
+          eq(table.remove(expected_callbacks), {err, method, params, client_id}, "expected handler")
         end;
       }
     end)
@@ -1779,8 +1779,8 @@ describe('LSP', function()
             uri = "file:///src/main.rs"
           }
         } }
-        local callback = require'vim.lsp.handlers'['callHierarchy/outgoingCalls']
-        callback(nil, nil, rust_analyzer_response)
+        local handler = require'vim.lsp.handlers'['callHierarchy/outgoingCalls']
+        handler(nil, nil, rust_analyzer_response)
         return vim.fn.getqflist()
       ]=])
 
@@ -1851,8 +1851,8 @@ describe('LSP', function()
           } }
         } }
 
-        local callback = require'vim.lsp.handlers'['callHierarchy/incomingCalls']
-        callback(nil, nil, rust_analyzer_response)
+        local handler = require'vim.lsp.handlers'['callHierarchy/incomingCalls']
+        handler(nil, nil, rust_analyzer_response)
         return vim.fn.getqflist()
       ]=])
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -41,7 +41,7 @@ local function fake_lsp_server_setup(test_name, timeout_ms)
         "-c", string.format("lua TIMEOUT = %d", timeout),
         "-c", "luafile "..fixture_filename,
       };
-      callbacks = setmetatable({}, {
+      handlers = setmetatable({}, {
         __index = function(t, method)
           return function(...)
             return vim.rpcrequest(1, 'callback', ...)


### PR DESCRIPTION
vim.lsp.callbacks was deprecated a few months ago. This is a cleanup before the release.
Use vim.lsp.handlers instead.

cc @tjdevries 