### PR TITLE
vim-patch:8.2.2522: Beancount filetype not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -212,6 +212,9 @@ au BufNewFile,BufRead *.bc			setf bc
 " BDF font
 au BufNewFile,BufRead *.bdf			setf bdf
 
+" Beancount
+au BufNewFile,BufRead *.beancount		setf beancount
+
 " BibTeX bibliography database file
 au BufNewFile,BufRead *.bib			setf bib
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -79,6 +79,7 @@ let s:filename_checks = {
     \ 'bc': ['file.bc'],
     \ 'bdf': ['file.bdf'],
     \ 'bib': ['file.bib'],
+    \ 'beancount': ['file.beancount'],
     \ 'bindzone': ['named.root'],
     \ 'blank': ['file.bl'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],


### PR DESCRIPTION
Problem:    Beancount filetype not recognized.
Solution:   Add a detection rule. (Brian Ryall, closes vim/vim#7859)
https://github.com/vim/vim/commit/9bbd883b3528b37dcacad22ad58861105a9ae428