### PR TITLE
vim-patch:8.2.2523: Svelte filetype not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1491,6 +1491,9 @@ au BufNewFile,BufRead *.sdl,*.pr		setf sdl
 " sed
 au BufNewFile,BufRead *.sed			setf sed
 
+" svelte
+au BufNewFile,BufRead *.svelte			setf svelte
+
 " Sieve (RFC 3028, 5228)
 au BufNewFile,BufRead *.siv,*.sieve		setf sieve
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -427,6 +427,7 @@ let s:filename_checks = {
     \ 'slrnrc': ['.slrnrc'],
     \ 'slrnsc': ['file.score'],
     \ 'sm': ['sendmail.cf'],
+    \ 'svelte': ['file.svelte'],
     \ 'smarty': ['file.tpl'],
     \ 'smcl': ['file.hlp', 'file.ihlp', 'file.smcl'],
     \ 'smith': ['file.smt', 'file.smith'],


### PR DESCRIPTION
Problem:    Svelte filetype not recognized.
Solution:   Add a detection rule. (Brian Ryall, closes vim/vim#7858)
https://github.com/vim/vim/commit/c0fcb6e0b10050145e7d334b68b1bdc5201fed05