### PR TITLE
lsp: Add more configuration for handlers

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -652,7 +652,7 @@ end
 
 --- Jumps to a location.
 ---
---@param location (`Location`|`LocationLink`)
+---@param location Location|LocationLink: A Location or Location Link
 --@returns `true` if the jump succeeded
 function M.jump_to_location(location)
   -- location may be Location or LocationLink


### PR DESCRIPTION
If someone wants to take this over, this is pretty similar to the concept that we were going for in https://github.com/neovim/neovim/pull/12966

This will allow you to more easily manage / re-use internal logic for doing location handling, without having to copy and paste.

```lua
vim.lsp.handlers["textDocument/definition"] = vim.lsp.with(
  vim.lsp.handlers.location, {
    location_callback = function(location)
      vim.cmd [[vsplit]]
      vim.lsp.util.jump_to_location(location)
    end
  }
)
```
