### PR TITLE
[wip]: stop loclist from opening when empty when using `set_loclist()`

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1225,7 +1225,7 @@ function M.set_loclist(opts)
 
   util.set_loclist(items)
   if open_loclist then
-    vim.cmd [[lopen]]
+    vim.cmd [[lwindow]]
   end
 end
 -- }}}


### PR DESCRIPTION
a simple change that hopefully brings a bit more utility to the `set_loclist()` diagnostic helper. 