### PR TITLE
[WIP] exposing fnameescape through vim.api

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -740,6 +740,14 @@ Integer nvim_strwidth(String text, Error *err)
   return (Integer)mb_string2cells((char_u *)text.data);
 }
 
+String nvim_fnameescape(String fname, Error *err)
+  FUNC_API_SINCE(7)
+  FUNC_API_FAST
+{
+  return cstr_as_string(
+      (char *) vim_strsave_fnameescape(fname.data, false));
+}
+
 /// Gets the paths contained in 'runtimepath'.
 ///
 /// @return List of paths


### PR DESCRIPTION
I want `fnameescape` to be exposed through `vim.api`. This code doesn't work right now, I'm getting 3 warnings I don't know how to deal with. Any help would be appreciated.