### PR TITLE
lsp: use upper case drive letters in URI on Windows

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -101,6 +101,7 @@ local function uri_to_fname(uri)
   -- TODO improve this.
   if is_windows_file_uri(uri) then
     uri = uri:gsub('^file:///', '')
+    uri = uri:gsub('^([a-z]):', function(a) return string.upper(a) .. ":" end)
     uri = uri:gsub('/', '\\')
   else
     uri = uri:gsub('^file://', '')


### PR DESCRIPTION
Closes #13970 

Language servers detach from diagnostics after first save on windows. This is because we path the URI returned from the language server (which converts everything to lower case) to vim's file path matching which is case sensitive (to the buffer name, which still has the upper case drive letter).

@dhazel can you test?