### PR TITLE
Update lsp and api docs with gen_vimdoc changes

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2195,6 +2195,13 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                               • hl_group : name of the highlight group used to
                                 highlight this mark.
                               • virt_text : virtual text to link to this mark.
+                              • virt_text_pos : positioning of virtual text.
+                                Possible values:
+                                • "eol": right after eol character (default)
+                                • "overlay": display over the specified
+                                  column, without shifting the underlying
+                                  text.
+
                               • ephemeral : for use with
                                 |nvim_set_decoration_provider| callbacks. The
                                 mark will only be used for the current redraw

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1318,6 +1318,17 @@ on_publish_diagnostics({_}, {_}, {params}, {client_id}, {_}, {config})
                                 • Update diagnostics in InsertMode or wait
                                   until InsertLeave
 
+reset({client_id}, {buffer_client_map})           *vim.lsp.diagnostic.reset()*
+                Clear diagnotics and diagnostic cache
+
+                Handles saving diagnostics from multiple clients in the same
+                buffer.
+
+                Parameters: ~
+                    {client_id}          number
+                    {buffer_client_map}  table map of buffers to active
+                                         clients
+
 save({diagnostics}, {bufnr}, {client_id})          *vim.lsp.diagnostic.save()*
                 Save diagnostics to the current buffer.
 


### PR DESCRIPTION
Applies the changes generated with ./scripts/gen_vimdoc.py to add
missing documentation.