### PR TITLE
lsp: use details for call hierarchies

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -344,7 +344,7 @@ local make_call_hierarchy_handler = function(direction)
       for _, range in pairs(call_hierarchy_call.fromRanges) do
         table.insert(items, {
           filename = assert(vim.uri_to_fname(call_hierarchy_item.uri)),
-          text = call_hierarchy_item.name,
+          text = call_hierarchy_item.detail,
           lnum = range.start.line + 1,
           col = range.start.character + 1,
         })


### PR DESCRIPTION
This is a bit more verbose as it contains the full signature rather than just the function name.