### PR TITLE
lua: add vim.reg

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -901,6 +901,14 @@ vim.env                                                 *vim.env*
             vim.env.FOO = 'bar'
             print(vim.env.TERM)
 <
+vim.reg                                                 *vim.reg*
+        Vim |registers|.
+        See |:let-register| for the Vimscript behavior.
+        Example: >
+            vim.reg.a = 'foo'
+            vim.reg.A = 'bar'
+            print(vim.reg.a)
+<
 
                                                         *lua-vim-options*
 From Lua you can work with editor |options| by reading and setting items in

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -368,6 +368,19 @@ do
     return v
   end
   vim.env = make_meta_accessor(getenv, vim.fn.setenv)
+
+  local function getreg(k)
+    local regname = tostring(k)
+    assert(#regname == 1, ("Invalid register name: '%s'"):format(regname))
+    return vim.fn.getreg(regname)
+  end
+  local function setreg(k, v)
+    local regname = tostring(k)
+    assert(#regname == 1, ("Invalid register name: '%s'"):format(regname))
+    return vim.fn.setreg(regname, v)
+  end
+  vim.reg = make_meta_accessor(getreg, setreg)
+
   -- TODO(ashkan) if/when these are available from an API, generate them
   -- instead of hardcoding.
   local window_options = {

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1040,6 +1040,21 @@ describe('lua stdlib', function()
     eq(true, funcs.luaeval "vim.env.B == nil")
   end)
 
+  it('vim.reg', function()
+    exec_lua [[
+    vim.fn.setreg("a", 123)
+    vim.reg.b = 123
+    vim.reg.B = 456
+    ]]
+    eq('123', funcs.luaeval "vim.reg.a")
+    eq('123456', funcs.luaeval "vim.reg.b")
+    eq(true, funcs.luaeval "vim.reg.c == ''")
+    matches("^Error executing lua: .*: Invalid register name: '`'$",
+      pcall_err(exec_lua, "vim.reg['`'] = 'test'"))
+    matches("^Error executing lua: .*: Invalid register name: 'aaaa'$",
+      pcall_err(exec_lua, "print(vim.reg.aaaa)"))
+  end)
+
   it('vim.v', function()
     eq(funcs.luaeval "vim.api.nvim_get_vvar('progpath')", funcs.luaeval "vim.v.progpath")
     eq(false, funcs.luaeval "vim.v['false']")


### PR DESCRIPTION
Lua already has meta-accessors for most types of `let` assignments, but there is currently no equivalent for `let @x`-style assignments.

This PR implements a simple wrapper around `vim.fn.getreg()` and `vim.fn.setreg()`. I tried modelling it after the existing `vim.env` meta-accessor.

Note: I chose to raise an error if the key is longer than one character because `getreg()` and `setreg()` only read the first character and silently ignore the rest of the string, which I thought could lead to confusing bugs (`:call setreg('abc', 'test')` assigns to register `a`).