### PR TITLE
lsp: prompt correct error when language server start fails

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -376,6 +376,9 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
       spawn_params.env = env_merge(extra_spawn_params.env)
     end
     handle, pid = uv.spawn(cmd, spawn_params, onexit)
+    if handle == nil then
+      error(string.format("start `%s` failed: %s", cmd, pid))
+    end
   end
 
   --@private
@@ -386,7 +389,7 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
   --@returns true if the payload could be scheduled, false if the main event-loop is in the process of closing.
   local function encode_and_send(payload)
     local _ = log.debug() and log.debug("rpc.send.payload", payload)
-    if handle:is_closing() then return false end
+    if handle == nil or handle:is_closing() then return false end
     -- TODO(ashkan) remove this once we have a Lua json_encode
     schedule(function()
       local encoded = assert(json_encode(payload))


### PR DESCRIPTION
LSP client starts the language server but not check whether it is run correctly. As a result, it will show a message because `handle` is `nil`. This MR checks the handle and prompt error immediately when language server start fails.

Original error message:
```
E5108: Error executing lua ...latest/nvim-osx64/share/nvim/runtime/lua/vim/lsp/rpc.lua:389: attempt to index upvalue 'handle' (a nil value)
```

Now:
```
E5108: Error executing lua ...latest/nvim-osx64/share/nvim/runtime/lua/vim/lsp/rpc.lua:380: start `solargraph` failed: ENOENT: no such file or directory
```