### PR TITLE
Provide API function to get time in nanoseconds

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -47,6 +47,7 @@
 #include "nvim/getchar.h"
 #include "nvim/os/input.h"
 #include "nvim/os/process.h"
+#include "nvim/os/time.h"
 #include "nvim/viml/parser/expressions.h"
 #include "nvim/viml/parser/parser.h"
 #include "nvim/ui.h"
@@ -2870,4 +2871,14 @@ void nvim_set_decoration_provider(Integer ns_id, DictionaryOf(LuaRef) opts,
   return;
 error:
   clear_provider(p);
+}
+
+
+/// Get current Unix timestamp with nanosecond precision.
+///
+/// @return current Unix timestamp
+Float nvim_get_currenttime(void)
+FUNC_API_SINCE(7)
+{
+    return os_timef();
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2876,9 +2876,12 @@ error:
 
 /// Get current Unix timestamp with nanosecond precision.
 ///
-/// @return current Unix timestamp
-Float nvim_get_currenttime(void)
+/// This timer is initialized and then reset each time time_init() function
+/// from os/time.c is called.
+///
+/// @return elapsed nanoseconds since last epoch.
+Integer nvim_get_time_ns(void)
   FUNC_API_SINCE(7)
 {
-  return os_timef();
+  return os_timens();
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2883,5 +2883,5 @@ error:
 Integer nvim_get_time_ns(void)
   FUNC_API_SINCE(7)
 {
-  return (Integer) os_timens();
+  return (Integer)os_timens();
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2880,5 +2880,5 @@ error:
 Float nvim_get_currenttime(void)
 FUNC_API_SINCE(7)
 {
-    return os_timef();
+  return os_timef();
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2883,5 +2883,5 @@ error:
 Integer nvim_get_time_ns(void)
   FUNC_API_SINCE(7)
 {
-  return os_timens();
+  return (Integer) os_timens();
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2878,7 +2878,7 @@ error:
 ///
 /// @return current Unix timestamp
 Float nvim_get_currenttime(void)
-FUNC_API_SINCE(7)
+  FUNC_API_SINCE(7)
 {
   return os_timef();
 }

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -15,7 +15,8 @@
 
 static uv_mutex_t delay_mutex;
 static uv_cond_t delay_cond;
-
+static Timestamp init_time_s;
+static uint64_t init_time_ns;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/time.c.generated.h"
@@ -26,6 +27,9 @@ void time_init(void)
 {
   uv_mutex_init(&delay_mutex);
   uv_cond_init(&delay_cond);
+
+  init_time_s = os_time();
+  init_time_ns = os_hrtime();
 }
 
 /// Gets a high-resolution (nanosecond), monotonically-increasing time relative
@@ -203,4 +207,14 @@ Timestamp os_time(void)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return (Timestamp) time(NULL);
+}
+
+/// Obtains the current Unix timestamp with nanosecond precision.
+///
+/// @return Fractional seconds since epoch.
+double os_timef(void)
+  FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return ((double)init_time_s
+          + ((double)(os_hrtime() - init_time_ns) * 0.000000001));
 }

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -211,10 +211,9 @@ Timestamp os_time(void)
 
 /// Obtains the current Unix timestamp with nanosecond precision.
 ///
-/// @return Fractional seconds since epoch.
-double os_timef(void)
+/// @return nanoseconds since epoch.
+uint64_t os_timens(void)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  return ((double)init_time_s
-          + ((double)(os_hrtime() - init_time_ns) * 0.000000001));
+  return os_hrtime() - init_time_ns;
 }


### PR DESCRIPTION
This PR aims to solve #4433. API function `nvim_get_time_ns()` calls `os_timens()` which returns elapsed nanoseconds since `time_init()` was called (effectively neovim's launch).

It is my first contribution to an open source project, but I have been using vim for a while. I read the guidelines and I hope I'm not missing something. I'd like to get some feedback!