### PR TITLE
Fix(treesitter): Make treesitter.inspect_lang include last field name

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -222,8 +222,9 @@ int tslua_inspect_lang(lua_State *L)
   lua_setfield(L, -2, "symbols");  // [retval]
 
   size_t nfields = (size_t)ts_language_field_count(lang);
-  lua_createtable(L, nfields-1, 1);  // [retval, fields]
-  for (size_t i = 0; i < nfields; i++) {
+  lua_createtable(L, nfields, 1);  // [retval, fields]
+  // Field IDs go from 1 to nfields inclusive (extra index 0 maps to NULL)
+  for (size_t i = 1; i <= nfields; i++) {
     lua_pushstring(L, ts_language_field_name_for_id(lang, i));
     lua_rawseti(L, -2, i);  // [retval, fields]
   }


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter/pull/988#issuecomment-788291610

@stsewd 

Strangely, the last field of a generated grammar is missing in `inspect_language`. The reason for this is that that the IDs for the fields are actually running from `1` to `nfields` inclusive. E.g. from RST parser
```
enum {
  field_body = 1,
  field_link = 2,
  field_name = 3,
};

static const char *ts_field_names[] = {
  [0] = NULL,
  [field_body] = "body",
  [field_link] = "link",
  [field_name] = "name",
};
```

This can also been observed in the implementation of ts_language_field_id_for_name
```
TSFieldId ts_language_field_id_for_name(
  const TSLanguage *self,
  const char *name,
  uint32_t name_length
) {
  uint32_t count = ts_language_field_count(self);
  for (TSSymbol i = 1; i < count + 1; i++) {
    switch (strncmp(name, self->field_names[i], name_length)) {
      case 0:
        if (self->field_names[i][name_length] == 0) return i;
        break;
      case -1:
        return 0;
      default:
        break;
    }
  }
  return 0;
}
```

I don't know whether we should rely on this implementation detail... But it makes `inspect_language` work correctly ("name" was missing before)

![image](https://user-images.githubusercontent.com/7189118/109562219-64f46a00-7ade-11eb-8da6-0782a77b652e.png)

The ID for the symbols are actually smaller (used in the loop before the field loop) than number of symbols and the last symbol will always be `ERROR`
