### PR TITLE
vim-patch:8.1.{680,1901},8.2.{1043,2196,2236,2551.2559,2560}

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -287,8 +287,7 @@ character is written at the end of each line.  Thus if you want to insert a
 
 						*i_CTRL-X* *insert_expand*
 CTRL-X enters a sub-mode where several commands can be used.  Most of these
-commands do keyword completion; see |ins-completion|.  These are not available
-when Vim was compiled without the |+insert_expand| feature.
+commands do keyword completion; see |ins-completion|.
 
 Two commands can be used to scroll the window up or down, without exiting
 insert mode:
@@ -591,9 +590,6 @@ entering new data while keeping all the columns aligned.
 In Insert and Replace mode, there are several commands to complete part of a
 keyword or line that has been typed.  This is useful if you are using
 complicated keywords (e.g., function names with capitals and underscores).
-
-These commands are not available when the |+insert_expand| feature was
-disabled at compile time.
 
 Completion can be done for:
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4090,8 +4090,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	In the "popup" model the right mouse button produces a pop-up menu.
 	You need to define this first, see |popup-menu|.
-	In a terminal the popup menu works if Vim is compiled with the
-	|+insert_expand| option.
 
 	Note that you can further refine the meaning of buttons with mappings.
 	See |mouse-overview|.  But mappings are NOT used for modeless selection.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4856,7 +4856,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to window
 	Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
 	set to half the number of lines in the window when the window size
-	changes.  If you give a count to the CTRL-U or CTRL-D command it will
+	changes.  This may happen when enabling the |status-line| or
+	'tabline' option after setting the 'scroll' option.
+	If you give a count to the CTRL-U or CTRL-D command it will
 	be used as the new value for 'scroll'.  Reset to half the window
 	height with ":set scroll=0".
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3024,6 +3024,7 @@ void scriptnames_slash_adjust(void)
 # endif
 
 /// Get a pointer to a script name.  Used for ":verbose set".
+/// Message appended to "Last set from "
 char_u *get_scriptname(LastSet last_set, bool *should_free)
 {
   *should_free = false;
@@ -3039,6 +3040,8 @@ char_u *get_scriptname(LastSet last_set, bool *should_free)
       return (char_u *)_("environment variable");
     case SID_ERROR:
       return (char_u *)_("error handler");
+    case SID_WINLAYOUT:
+      return (char_u *)_("changed window size");
     case SID_LUA:
       return (char_u *)_("Lua");
     case SID_API_CLIENT:

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -333,9 +333,10 @@ EXTERN int garbage_collect_at_exit INIT(= false);
 #define SID_ENV         -4      // for sourcing environment variable
 #define SID_ERROR       -5      // option was reset because of an error
 #define SID_NONE        -6      // don't set scriptID
-#define SID_LUA         -7      // for Lua scripts/chunks
-#define SID_API_CLIENT  -8      // for API clients
-#define SID_STR         -9      // for sourcing a string
+#define SID_WINLAYOUT   -7      // changing window size
+#define SID_LUA         -8      // for Lua scripts/chunks
+#define SID_API_CLIENT  -9      // for API clients
+#define SID_STR         -10     // for sourcing a string
 
 // Script CTX being sourced or was sourced to define the current function.
 EXTERN sctx_T current_sctx INIT(= { 0 COMMA 0 COMMA 0 });

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -180,6 +180,11 @@ EXTERN int compl_cont_status INIT(= 0);
 # define CONT_LOCAL     32      // for ctrl_x_mode 0, ^X^P/^X^N do a local
                                 // expansion, (eg use complete=.)
 
+EXTERN char_u *edit_submode INIT(= NULL);        // msg for CTRL-X submode
+EXTERN char_u *edit_submode_pre INIT(= NULL);    // prepended to edit_submode
+EXTERN char_u *edit_submode_extra INIT(= NULL);  // appended to edit_submode
+EXTERN hlf_T edit_submode_highl;                 // highl. method for extra info
+
 // state for putting characters in the message area
 EXTERN int cmdmsg_rl INIT(= false);  // cmdline is drawn right to left
 EXTERN int msg_col;
@@ -639,10 +644,6 @@ EXTERN int arrow_used;                  // Normally false, set to true after
                                         // to call u_sync()
 EXTERN bool ins_at_eol INIT(= false);   // put cursor after eol when
                                         // restarting edit after CTRL-O
-EXTERN char_u *edit_submode INIT(= NULL);  // msg for CTRL-X submode
-EXTERN char_u *edit_submode_pre INIT(= NULL);  // prepended to edit_submode
-EXTERN char_u *edit_submode_extra INIT(= NULL);  // appended to edit_submode
-EXTERN hlf_T edit_submode_highl;        // highl. method for extra info
 
 EXTERN int no_abbr INIT(= true);        // true when no abbreviations loaded
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7152,11 +7152,13 @@ static void win_redr_ruler(win_T *wp, int always)
   if (wp->w_cursor.lnum > wp->w_buffer->b_ml.ml_line_count)
     return;
 
-  /* Don't draw the ruler while doing insert-completion, it might overwrite
-   * the (long) mode message. */
-  if (wp == lastwin && lastwin->w_status_height == 0)
-    if (edit_submode != NULL)
+  // Don't draw the ruler while doing insert-completion, it might overwrite
+  // the (long) mode message.
+  if (wp == lastwin && lastwin->w_status_height == 0) {
+    if (edit_submode != NULL) {
       return;
+    }
+  }
 
   if (*p_ruf) {
     int save_called_emsg = called_emsg;

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -37,7 +37,6 @@ source test_recover.vim
 source test_scroll_opt.vim
 source test_sort.vim
 source test_sha256.vim
-source test_statusline.vim
 source test_suspend.vim
 source test_syn_attr.vim
 source test_tabline.vim

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -636,4 +636,23 @@ func Test_isfname_with_options()
   setlocal keywordprg&
 endfunc
 
+" Test that resetting laststatus does change scroll option
+func Test_opt_reset_scroll()
+  " See test/functional/legacy/options_spec.lua
+  CheckRunVimInTerminal
+  let vimrc =<< trim [CODE]
+    set scroll=2
+    set laststatus=2
+  [CODE]
+  call writefile(vimrc, 'Xscroll')
+  let buf = RunVimInTerminal('-S Xscroll', {'rows': 16, 'cols': 45})
+  call term_sendkeys(buf, ":verbose set scroll?\n")
+  call WaitForAssert({-> assert_match('Last set.*window size', term_getline(buf, 15))})
+  call assert_match('^\s*scroll=7$', term_getline(buf, 14))
+  call StopVimInTerminal(buf)
+
+  " clean up
+  call delete('Xscroll')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1,5 +1,7 @@
 " Test for options
 
+source check.vim
+
 func Test_whichwrap()
   set whichwrap=b,s
   call assert_equal('b,s', &whichwrap)
@@ -602,6 +604,27 @@ func Test_opt_boolean()
   let &nu = v:false
   call assert_equal(0, &nu)
   set number&
+endfunc
+
+func Test_opt_winminheight_term()
+  " See test/functional/legacy/options_spec.lua
+  CheckRunVimInTerminal
+
+  " The tabline should be taken into account.
+  let lines =<< trim END
+    set wmh=0 stal=2
+    below sp | wincmd _
+    below sp | wincmd _
+    below sp | wincmd _
+    below sp
+  END
+  call writefile(lines, 'Xwinminheight')
+  let buf = RunVimInTerminal('-S Xwinminheight', #{rows: 11})
+  call term_sendkeys(buf, ":set wmh=1\n")
+  call WaitForAssert({-> assert_match('E36: Not enough room', term_getline(buf, 11))})
+
+  call StopVimInTerminal(buf)
+  call delete('Xwinminheight')
 endfunc
 
 " Test for setting option value containing spaces with isfname+=32

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -1,12 +1,12 @@
 " Test 'statusline'
 "
 " Not tested yet:
-"   %a
 "   %N
 "   %T
 "   %X
 
 source view_util.vim
+source check.vim
 source term_util.vim
 
 func s:get_statusline()
@@ -61,7 +61,19 @@ func Test_statusline_will_be_disabled_with_error()
 endfunc
 
 func Test_statusline()
-  new Xstatusline
+  CheckFeature quickfix
+
+  " %a: Argument list ({current} of {max})
+  set statusline=%a
+  call assert_match('^\s*$', s:get_statusline())
+  arglocal a1 a2
+  rewind
+  call assert_match('^ (1 of 2)\s*$', s:get_statusline())
+  next
+  call assert_match('^ (2 of 2)\s*$', s:get_statusline())
+  e Xstatusline
+  call assert_match('^ ((2) of 2)\s*$', s:get_statusline())
+
   only
   set laststatus=2
   set splitbelow

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5960,9 +5960,17 @@ void win_new_width(win_T *wp, int width)
 
 void win_comp_scroll(win_T *wp)
 {
+  const long old_w_p_scr = wp->w_p_scr;
+
   wp->w_p_scr = wp->w_height / 2;
-  if (wp->w_p_scr == 0)
+  if (wp->w_p_scr == 0) {
     wp->w_p_scr = 1;
+  }
+  if (wp->w_p_scr != old_w_p_scr) {
+    // Used by "verbose set scroll".
+    wp->w_p_script_ctx[WV_SCROLL].script_ctx.sc_sid = SID_WINLAYOUT;
+    wp->w_p_script_ctx[WV_SCROLL].script_ctx.sc_lnum = 0;
+  }
 }
 
 /*

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5501,7 +5501,7 @@ void win_setminheight(void)
 
   // loop until there is a 'winminheight' that is possible
   while (p_wmh > 0) {
-    const int room = Rows - p_ch;
+    const int room = Rows - p_ch - tabline_height();
     const int needed = frame_minheight(topframe, NULL);
     if (room >= needed) {
       break;

--- a/test/functional/legacy/options_spec.lua
+++ b/test/functional/legacy/options_spec.lua
@@ -1,6 +1,10 @@
+-- See also: src/nvim/testdir/test_options.vim
 local helpers = require('test.functional.helpers')(after_each)
 local command, clear = helpers.command, helpers.clear
 local source, expect = helpers.source, helpers.expect
+local exc_exec = helpers.exc_exec;
+local matches = helpers.matches;
+local Screen = require('test.functional.ui.screen')
 
 describe('options', function()
   setup(clear)
@@ -11,7 +15,7 @@ describe('options', function()
 end)
 
 describe('set', function()
-  setup(clear)
+  before_each(clear)
 
   it("should keep two comma when 'path' is changed", function()
     source([[
@@ -23,5 +27,18 @@ describe('set', function()
     expect([[
 
       foo,,bar]])
+  end)
+
+  it('winminheight works', function()
+    local screen = Screen.new(20, 11)
+    screen:attach()
+    source([[
+      set wmh=0 stal=2
+      below sp | wincmd _
+      below sp | wincmd _
+      below sp | wincmd _
+      below sp
+    ]])
+    matches('E36: Not enough room', exc_exec('set wmh=1'))
   end)
 end)

--- a/test/functional/legacy/options_spec.lua
+++ b/test/functional/legacy/options_spec.lua
@@ -41,4 +41,32 @@ describe('set', function()
     ]])
     matches('E36: Not enough room', exc_exec('set wmh=1'))
   end)
+
+  it('scroll works', function()
+    local screen = Screen.new(42, 16)
+    screen:attach()
+    source([[
+      set scroll=2
+      set laststatus=2
+    ]])
+    command('verbose set scroll?')
+    screen:expect([[
+                                                |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+      ~                                         |
+                                                |
+        scroll=7                                |
+              Last set from changed window size |
+      Press ENTER or type command to continue^   |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Strange that `test_statusline.vim` failed if executed from `test_alot.vim`. `test_alot.vim` does not have `test_statusline.vim` since patch v8.2.0164.