### PR TITLE
lsp: invoke vim.notify when client exits with code or signal other than 0

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -542,6 +542,13 @@ function lsp.start_client(config)
       client_ids[client_id] = nil
     end
 
+    if code ~= 0 or signal ~= 0 then
+      local msg = string.format("Client %s quit with exit code %s and signal %s", client_id, code, signal)
+      vim.schedule(function()
+        vim.notify(msg, vim.log.levels.WARN)
+      end)
+    end
+
     if config.on_exit then
       pcall(config.on_exit, code, signal, client_id)
     end


### PR DESCRIPTION
closes: #12610

@tjdevries you had assigned yourself but I wanted to do this since it came up when I was debugging a rust-analyzer crash. Should we notify on any exit? I just did non-zero exit codes for now. 