### PR TITLE
treesitter: Include language in invalid query error

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1276,8 +1276,8 @@ int tslua_parse_query(lua_State *L)
   TSQuery *query = ts_query_new(lang, src, (uint32_t)len, &error_offset, &error_type);
 
   if (!query) {
-    return luaL_error(L, "query: %s at position %d",
-                      query_err_string(error_type), (int)error_offset);
+    return luaL_error(L, "query: %s at position %d for language %s",
+                      query_err_string(error_type), (int)error_offset, lang_name);
   }
 
   TSQuery **ud = lua_newuserdata(L, sizeof(TSQuery *));  // [udata]


### PR DESCRIPTION
The error message often gives very little context what went wrong. E.g. `invalid node` type can either mean that there is some error in the query or that the wrong language for a specific language has been chosen. Including the language for which the error has occurred helps to find the actual issue.

probably we should include also `src + error_offset` to mark the erroneous position in the string. E.g.
```
invalid node type at position XXX for language YYY:
...((bla) (blub) @foo) ...
          Λ
```