### PR TITLE
lsp: don't invoke vim.notify on sigterm of language server

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -542,7 +542,7 @@ function lsp.start_client(config)
       client_ids[client_id] = nil
     end
 
-    if code ~= 0 or signal ~= 0 then
+    if code ~= 0 or (signal ~= 0 and signal ~= 15) then
       local msg = string.format("Client %s quit with exit code %s and signal %s", client_id, code, signal)
       vim.schedule(function()
         vim.notify(msg, vim.log.levels.WARN)


### PR DESCRIPTION
@mfussenegger You're right, I was wrong. In practice this is really annoying.