### PR TITLE
Clarify that nvim_put()'s {after} and {follow} parameters expect boolean values true, or false.

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1418,7 +1418,7 @@ nvim_put({lines}, {type}, {after}, {follow})                      *nvim_put()*
                     {after}   Insert after cursor (like |p|), or before (like
                               |P|). Expects boolean value: true, or false.
                     {follow}  Place cursor at end of inserted text. Expects
-                              boolean value true, or false.
+                              boolean value: true, or false.
 
                                                     *nvim_replace_termcodes()*
 nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1415,10 +1415,9 @@ nvim_put({lines}, {type}, {after}, {follow})                      *nvim_put()*
                               • "c" |charwise| mode
                               • "l" |linewise| mode
                               • "" guess by contents, see |setreg()|
-                    {after}   Insert after cursor (like |p|), or before (like
-                              |P|). Expects boolean value: true, or false.
-                    {follow}  Place cursor at end of inserted text. Expects
-                              boolean value: true, or false.
+                    {after}   If true insert after cursor (like |p|), or before (like
+                              |P|).
+                    {follow}  If true place cursor at end of inserted text.
 
                                                     *nvim_replace_termcodes()*
 nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1416,8 +1416,9 @@ nvim_put({lines}, {type}, {after}, {follow})                      *nvim_put()*
                               • "l" |linewise| mode
                               • "" guess by contents, see |setreg()|
                     {after}   Insert after cursor (like |p|), or before (like
-                              |P|).
-                    {follow}  Place cursor at end of inserted text.
+                              |P|). Expects boolean value: true, or false.
+                    {follow}  Place cursor at end of inserted text. Expects
+                              boolean value true, or false.
 
                                                     *nvim_replace_termcodes()*
 nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1546,8 +1546,8 @@ theend:
 ///              - "c" |charwise| mode
 ///              - "l" |linewise| mode
 ///              - ""  guess by contents, see |setreg()|
-/// @param after  Insert after cursor (like |p|), or before (like |P|).
-/// @param follow  Place cursor at end of inserted text.
+/// @param after  If true insert after cursor (like |p|), or before (like |P|).
+/// @param follow  If true place cursor at end of inserted text.
 /// @param[out] err Error details, if any
 void nvim_put(ArrayOf(String) lines, String type, Boolean after,
               Boolean follow, Error *err)


### PR DESCRIPTION
I was looking at the API documentation on neovim.io and it was not clear what the third and fourth parameters {after} and {follow} expected for their respective data-types. I figured out what they expected by looking at a PR for nvim_paste() that uses nvim_put(). 

I think that it would be clearer to future plugin developers, or users of the API to say what the parameters expect.

Thank you.