### PR TITLE
[RFC] Add nvim_grid_get_window

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -523,3 +523,21 @@ void nvim_win_close(Window window, Boolean force, Error *err)
   ex_win_close(force, win, tabpage == curtab ? NULL : tabpage);
   vim_ignored = try_leave(&tstate, err);
 }
+
+
+/// Gets the current window for grid.
+///
+/// @param grid   Grid id.
+/// @param[out] err Error details, if any.
+/// @return Window id.
+Window nvim_grid_get_window(Integer grid, Error *err)
+  FUNC_API_SINCE(7)
+  FUNC_API_REMOTE_ONLY
+{
+  win_T *win = get_win_by_grid_handle(grid);
+  if (win == NULL) {
+    api_set_error(err, kErrorTypeException, "No win for this grid.");
+    return 0;
+  }
+  return win->handle;
+}


### PR DESCRIPTION
There currently is no way to figure out what window belongs to what grid. This
is something I need, as I'm working on a UI that maps one "os window" to one
"neovim grid" and when the user tries to destroy an OS window, I need to
destroy the corresponding neovim grid.

Thanks to this patch, I can fetch the windows of a grid and close them one by
one, which ultimately results in the closure of the grid.

This patch can't be merged as is for the following reasons:
- There can be multiple windows for a single grid. This isn't taken into
  account.
- It should probably be gated in a way that prevents users from calling this if
  they don't have ext_multigrid.
- It lacks tests.

I'm opening this pr with the hope that we could start a conversation about this :).
