### PR TITLE
lsp: preprocess markdown special characters before rendering floating window

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -506,7 +506,9 @@ function M.convert_input_to_markdown_lines(input, contents)
 
       -- Some servers send input.value as empty, so let's ignore this :(
       -- assert(type(input.value) == 'string')
-      list_extend(contents, split_lines(input.value or ''))
+      local stripped_message = string.gsub(input.value or '', "(\\)(.)", "%2")
+      stripped_message = string.gsub(stripped_message, "&nbsp;", " ")
+      list_extend(contents, split_lines(stripped_message))
     -- MarkupString variation 2
     elseif input.language then
       -- Some servers send input.value as empty, so let's ignore this :(


### PR DESCRIPTION
closes #14032

@tjdevries I changed my mind again 😆 This is a pretty simple fix which I think will satisfy 90% of people for 0.5. If the need arises we can deprecate this in the future if we have more elaborate markdown rules for floating windows.

@VVKot do you want to test this? 

Before:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/13316262/110223914-23701000-7e8c-11eb-9de5-db215497a2b1.png">

After:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/13316262/110223907-16ebb780-7e8c-11eb-87cc-3e4dd36c8f16.png">
