### PR TITLE
lsp: add custom syntax rule for floating window

### DIFF
--- a/runtime/ftplugin/lsp_markdown.vim
+++ b/runtime/ftplugin/lsp_markdown.vim
@@ -1,0 +1,11 @@
+" Vim filetype plugin
+" Language:		lsp_markdown
+" Maintainer:		Michael Lingelbach <m.j.lbach@gmail.com>
+" Last Change:		2021 Mar 09
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/markdown.vim
+" vim:set sw=2:

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -873,8 +873,11 @@ function M.fancy_floating_markdown(contents, opts)
   -- This is because the syntax command doesn't accept a target.
   local cwin = vim.api.nvim_get_current_win()
   vim.api.nvim_set_current_win(winnr)
+  api.nvim_win_set_option(winnr, 'conceallevel', 2)
+  api.nvim_win_set_option(winnr, 'concealcursor', 'n')
 
-  vim.cmd("ownsyntax markdown")
+  vim.cmd("ownsyntax lsp_markdown")
+  vim.cmd("set filetype=lsp_markdown")
   local idx = 1
   --@private
   local function apply_syntax_to_region(ft, start, finish)

--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -1,0 +1,16 @@
+" Vim syntax file
+" Language:	lsp_markdown
+" Maintainer:	Michael Lingelbach <m.j.lbach@gmail.com
+" URL:		http://neovim.io
+" Remark:	Uses markdown syntax file
+
+runtime! syntax/markdown.vim
+
+syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
+syntax region mkdNonListItemBlock start=/\(\%^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@!\|\n\(\_^\_$\|\s\{4,}[^]\|\t+[^\t]\)\@!\)/ end=/^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@=/  contains=@mkdNonListItem
+
+syntax region mkdEscape matchgroup=mkdEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/.\zs/ keepend contains=mkdEscapeCh contained oneline concealends
+syntax match mkdEscapeCh /./ contained
+syntax match mkdNbsp /&nbsp;/ conceal cchar= 
+
+hi def link mkdEscape special


### PR DESCRIPTION
Closes #14032

This is a bit more complicated, maybe better? alternative solution to the floating win syntax problem for which I opened #14069. Right now this is basically a modification of plasticboy's markdown highlighting rules with some extensions, it could probably be drastically slimmed down and based on the default syntax rules.
