### PR TITLE
executor: add wrapper to luv.spawn on Windows

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -241,6 +241,21 @@ static int nlua_luv_cfpcall(lua_State *lstate, int nargs, int nresult,
   return retval;
 }
 
+#ifdef WIN32
+static int nlua_luv_spawn(lua_State *lstate)
+{
+  size_t s_len;
+  const char *cmd = luaL_checklstring(lstate, 1, &s_len);
+  char *abspath;
+  if (s_len != 0 && os_can_exe(cmd, &abspath, true)) {
+    lua_pushstring(lstate, abspath);
+    lua_replace(lstate, 1);
+    xfree(abspath);
+  }
+  return (lua_tocfunction(lstate, lua_upvalueindex(1)))(lstate);
+}
+#endif
+
 static void nlua_schedule_event(void **argv)
 {
   LuaRef cb = (LuaRef)(ptrdiff_t)argv[0];
@@ -471,6 +486,13 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   luaopen_luv(lstate);
   lua_pushvalue(lstate, -1);
   lua_setfield(lstate, -3, "loop");
+
+#ifdef WIN32
+  // replace luv.spawn with a wrapper.
+  lua_getfield(lstate, -1, "spawn");
+  lua_pushcclosure(lstate, nlua_luv_spawn, 1);
+  lua_setfield(lstate, -2, "spawn");
+#endif
 
   // package.loaded.luv = vim.loop
   // otherwise luv will be reinitialized when require'luv'


### PR DESCRIPTION
Batch file execution is not possible with luv.spawn on Windows. Modify it to be able to execute batch files by adding a wrapper that uses `os_can_exe()` as well as `jobstart()`.