### PR TITLE
lsp: Use incremental sync by default

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -749,15 +749,6 @@ start_client({config})                                *vim.lsp.start_client()*
 
                 The following parameters describe fields in the {config}
                 table.
->
-
-    -- In init function for the client, you can do:
-    local custom_init = function(client)
-      if client.config.flags then
-        client.config.flags.allow_incremental_sync = true
-      end
-    end
-<
 
                 Parameters: ~
                     {root_dir}         (required, string) Directory where the
@@ -856,8 +847,8 @@ start_client({config})                                *vim.lsp.start_client()*
                     {flags}            A table with flags for the client. The
                                        current (experimental) flags are:
                                        • allow_incremental_sync (bool, default
-                                         false): Allow using on_line callbacks
-                                         for lsp
+                                         true): Allow using incremental sync
+                                         for buffer edits
 
                 Return: ~
                     Client id. |vim.lsp.get_client_by_id()| Note: client may


### PR DESCRIPTION
With the new implementation added in
https://github.com/neovim/neovim/pull/14079 I think this is now working
well enough to enable it by default.

There are high CPU usage issues popping up now and then and they might
at least partially be related to the full-text sync. 

- https://github.com/neovim/neovim/issues/14087
- https://github.com/neovim/neovim/issues/14037

@mjlbach @tjdevries what do you think?