### PR TITLE
lsp: Include original request params in handler

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -235,6 +235,10 @@ For |lsp-request|, each |lsp-handler| has this signature: >
                             To configure a particular |lsp-handler|, see:
                                 |lsp-handler-configuration|
 
+	    {params}	(Params | nil)
+			    The params sent with the request which triggered
+			    this response.
+
         Returns: ~
             The |lsp-handler| can respond by returning two values: `result, err`
               Where `err` must be shaped like an RPC error:

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -710,7 +710,7 @@ function lsp.start_client(config)
     end
     local _ = log.debug() and log.debug(log_prefix, "client.request", client_id, method, params, handler, bufnr)
     return rpc.request(method, params, function(err, result)
-      handler(err, method, result, client_id, bufnr)
+      handler(err, method, result, client_id, bufnr, nil, params)
     end)
   end
 
@@ -1274,8 +1274,8 @@ end
 --@param handler (function) See |lsp-handler|
 --@param override_config (table) Table containing the keys to override behavior of the {handler}
 function lsp.with(handler, override_config)
-  return function(err, method, params, client_id, bufnr, config)
-    return handler(err, method, params, client_id, bufnr, vim.tbl_deep_extend("force", config or {}, override_config))
+  return function(err, method, result, client_id, bufnr, config, params)
+    return handler(err, method, result, client_id, bufnr, vim.tbl_deep_extend("force", config or {}, override_config), params)
   end
 end
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -403,16 +403,16 @@ end
 
 -- Add boilerplate error validation and logging for all of these.
 for k, fn in pairs(M) do
-  M[k] = function(err, method, params, client_id, bufnr, config)
+  M[k] = function(err, method, result, client_id, bufnr, config, params)
     local _ = log.debug() and log.debug('default_handler', method, {
-      params = params, client_id = client_id, err = err, bufnr = bufnr, config = config
+      result = result, client_id = client_id, err = err, bufnr = bufnr, config = config, params = params
     })
 
     if err then
       return err_message(tostring(err))
     end
 
-    return fn(err, method, params, client_id, bufnr, config)
+    return fn(err, method, result, client_id, bufnr, config, params)
   end
 end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -249,7 +249,7 @@ describe('LSP', function()
 
     it('should succeed with manual shutdown', function()
       local expected_callbacks = {
-        {NIL, "shutdown", {}, 1, NIL};
+        {NIL, "shutdown", {}, 1, NIL, NIL, NIL};
         {NIL, "test", {}, 1};
       }
       test_rpc_server {


### PR DESCRIPTION
This is mostly motivated by https://github.com/neovim/neovim/issues/12326

Client side commands might need to access the original request
parameters.

Currently this is already possible by using closures with
`vim.lsp.buf_request`, but the global handlers so far couldn't access
the request parameters.


---

Slightly off-topic: Is it too late to change the handler interface in a breaking way?
Something like `(err, result, context, config)` where `context` is a table with `method`, `client_id`, `bufnr` and `params` would reduce the amount of arguments, which helps reduce the amount of `(_, _, result, _, _, ...)`  and make it easier to extend in the future