### PR TITLE
Fix popup menu position in multigrid mode

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -440,7 +440,7 @@ void pum_redraw(void)
   }
   if (ui_has(kUIMultigrid)) {
     const char *anchor = pum_above ? "SW" : "NW";
-    int row_off = pum_above ? pum_height : 0;
+    int row_off = pum_above ? -pum_height : 0;
     ui_call_win_float_pos(pum_grid.handle, -1, cstr_to_string(anchor),
                           pum_anchor_grid, pum_row-row_off, pum_col-col_off,
                           false, pum_grid.zindex);


### PR DESCRIPTION
This fixes invalid menu position in multigrid mode #12985

Looks like sign was incorrect.

Before: 
![image](https://user-images.githubusercontent.com/301015/111036723-59336c80-8429-11eb-8101-26e5a6549e89.png)


After: 
![image](https://user-images.githubusercontent.com/301015/111036752-7ec07600-8429-11eb-8662-d257ed03895e.png)


