### PR TITLE
vim-patch:8.2.2454: leading space can not be made visible

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3716,6 +3716,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*lcs-space*
 	  space:c	Character to show for a space.  When omitted, spaces
 			are left blank.
+							*lcs-lead*
+	  lead:c	Character to show for leading spaces.  When omitted,
+			leading spaces are blank.  Overrides the "space"
+			setting for leading spaces.
 							*lcs-trail*
 	  trail:c	Character to show for trailing spaces.  When omitted,
 			trailing spaces are blank.  Overrides the "space"

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1201,6 +1201,7 @@ struct window_S {
     int tab1;                       ///< first tab character
     int tab2;                       ///< second tab character
     int tab3;                       ///< third tab character
+    int lead;
     int trail;
     int conceal;
   } w_p_lcs_chars;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1705,6 +1705,7 @@ void msg_prt_line(char_u *s, int list)
   char_u *p_extra = NULL;  // init to make SASC shut up
   int n;
   int attr = 0;
+  char_u *lead = NULL;
   char_u *trail = NULL;
   int l;
 
@@ -1712,11 +1713,24 @@ void msg_prt_line(char_u *s, int list)
     list = true;
   }
 
-  // find start of trailing whitespace
-  if (list && curwin->w_p_lcs_chars.trail) {
-    trail = s + STRLEN(s);
-    while (trail > s && ascii_iswhite(trail[-1])) {
-      trail--;
+  if (list) {
+    // find start of trailing whitespace
+    if (curwin->w_p_lcs_chars.trail) {
+      trail = s + STRLEN(s);
+      while (trail > s && ascii_iswhite(trail[-1])) {
+        trail--;
+      }
+    }
+    // find end of leading whitespace
+    if (curwin->w_p_lcs_chars.lead) {
+      lead = s;
+      while (ascii_iswhite(lead[0])) {
+        lead++;
+      }
+      // in a line full of spaces all of them are treated as trailing
+      if (*lead == NUL) {
+        lead = NULL;
+      }
     }
   }
 
@@ -1792,6 +1806,9 @@ void msg_prt_line(char_u *s, int list)
         c = *p_extra++;
         /* Use special coloring to be able to distinguish <hex> from
          * the same in plain text. */
+        attr = HL_ATTR(HLF_8);
+      } else if (c == ' ' && lead != NULL && s <= lead) {
+        c = curwin->w_p_lcs_chars.lead;
         attr = HL_ATTR(HLF_8);
       } else if (c == ' ' && trail != NULL && s > trail) {
         c = curwin->w_p_lcs_chars.trail;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3477,6 +3477,7 @@ static char_u *set_chars_option(win_T *wp, char_u **varp, bool set)
     { &wp->w_p_lcs_chars.prec,    "precedes", NUL  },
     { &wp->w_p_lcs_chars.space,   "space",    NUL  },
     { &wp->w_p_lcs_chars.tab2,    "tab",      NUL  },
+    { &wp->w_p_lcs_chars.lead,    "lead",     NUL  },
     { &wp->w_p_lcs_chars.trail,   "trail",    NUL  },
     { &wp->w_p_lcs_chars.conceal, "conceal",  NUL  },
   };

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -110,6 +110,35 @@ func Test_listchars()
 	      \ '.....h>-$',
 	      \ 'iii<<<<><<$', '$'], l)
 
+  " Test lead and trail
+  normal ggdG
+  set listchars=eol:$
+  set listchars+=lead:>,trail:<,space:x
+  set list
+
+  call append(0, [
+	      \ '    ffff    ',
+	      \ '          gg',
+	      \ 'h           ',
+	      \ '            ',
+	      \ '    0  0    ',
+	      \ ])
+
+  let expected = [
+	      \ '>>>>ffff<<<<$',
+	      \ '>>>>>>>>>>gg$',
+	      \ 'h<<<<<<<<<<<$',
+	      \ '<<<<<<<<<<<<$',
+	      \ '>>>>0xx0<<<<$',
+              \ '$'
+	      \ ]
+  redraw!
+  for i in range(1, 5)
+    call cursor(i, 1)
+    call assert_equal([expected[i - 1]], ScreenLines(i, virtcol('$')))
+  endfor
+
+  call assert_equal(expected, split(execute("%list"), "\n"))
 
   " test nbsp
   normal ggdG


### PR DESCRIPTION
#### vim-patch:8.2.2454: leading space can not be made visible

Problem:    Leading space can not be made visible.
Solution:   Add "lead:" to 'listchars'. (closes vim/vim#7772)
https://github.com/vim/vim/commit/91478ae49a1b2dc1de63821db731a343e855dcc0

Resolves: #9233