### PR TITLE
ci(GHA/release): Delete the release when creating a new nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          delete_release: ''
+          delete_release: true
           tag_name: nightly
       - uses: meeDamian/github-release@2.0
         with:


### PR DESCRIPTION
This reverts #13733.  Disabling delete of the release leaves behind a draft release associated with the previous nightly tag, which is annoying to cleanup.

In the rare circumstances that the creation of a new nightly fails after deleting the previous nightly, the job can be re-run or a nightly can be missing for a day.