### PR TITLE
lsp: Add support for create,rename,delete workspaceEdit resourceOperations

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -750,7 +750,7 @@ function protocol.make_client_capabilities()
       workspaceFolders = true;
       applyEdit = true;
       workspaceEdit = {
-        resourceOperations = {'rename',},
+        resourceOperations = {'rename', 'create',},
       };
     };
     callHierarchy = {

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -750,7 +750,7 @@ function protocol.make_client_capabilities()
       workspaceFolders = true;
       applyEdit = true;
       workspaceEdit = {
-        resourceOperations = {'rename', 'create',},
+        resourceOperations = {'rename', 'create', 'delete',},
       };
     };
     callHierarchy = {

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -749,6 +749,9 @@ function protocol.make_client_capabilities()
       };
       workspaceFolders = true;
       applyEdit = true;
+      workspaceEdit = {
+        resourceOperations = {'rename',},
+      };
     };
     callHierarchy = {
       dynamicRegistration = false;


### PR DESCRIPTION
eclipse.jdt.ls can utilize this. For example if you rename a classname it will automatically also rename the file.

todo:

- [x] support `create`
- [x] support `delete`


All three are required to be listed in the `resourceOperations` capabilities for eclipse.jdt.ls to utilize the rename feature.
