### PR TITLE
chore: remove deprecated lua module tshighlighter

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -12,11 +12,7 @@ local M = vim.tbl_extend("error", query, language)
 
 setmetatable(M, {
   __index = function (t, k)
-      if k == "TSHighlighter" then
-        a.nvim_err_writeln("vim.TSHighlighter is deprecated, please use vim.treesitter.highlighter")
-        t[k] = require'vim.treesitter.highlighter'
-        return t[k]
-      elseif k == "highlighter" then
+      if k == "highlighter" then
         t[k] = require'vim.treesitter.highlighter'
         return t[k]
       end

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -171,7 +171,7 @@ int tslua_add_language(lua_State *L)
 
   TSLanguage *lang = lang_parser();
   if (lang == NULL) {
-    return luaL_error(L, "Failed to load parser: internal error");
+    return luaL_error(L, "Failed to load parser %s: internal error", path);
   }
 
   uint32_t lang_version = ts_language_version(lang);
@@ -179,7 +179,8 @@ int tslua_add_language(lua_State *L)
       || lang_version > TREE_SITTER_LANGUAGE_VERSION) {
     return luaL_error(
         L,
-        "ABI version mismatch : supported between %d and %d, found %d",
+        "ABI version mismatch for %s: supported between %d and %d, found %d",
+        path,
         TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION,
         TREE_SITTER_LANGUAGE_VERSION, lang_version);
   }


### PR DESCRIPTION
Before:
`ter/share/nvim/runtime/lua/vim/treesitter/language.lua:33: ABI version mismatch : supported between 13 and 13, found 12`
After:
`E5108: Error executing lua /home/teto/neovim/runtime/lua/vim/treesitter/language.lua:33: ABI version mismatch for /home/teto/.config/nvim/parser/nix.so: supported between 13 and 13, found 12`

How nice would it be if these errors used vim.notify . But it is tricky so I postponed it.