### PR TITLE
lsp: update lsp_markdown syntax to not clash with built-in markdown syntax

### DIFF
--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -7,9 +7,8 @@
 runtime! syntax/markdown.vim
 
 syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
-syntax region mkdNonListItemBlock start=/\(\%^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@!\|\n\(\_^\_$\|\s\{4,}[^]\|\t+[^\t]\)\@!\)/ end=/^\(\s*\([-*+]\|\d\+\.\)\s\+\)\@=/  contains=@mkdNonListItem
 
-syntax region mkdEscape matchgroup=mkdEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/.\zs/ keepend contains=mkdEscapeCh contained oneline concealends
+syntax region mkdEscape matchgroup=mkdEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/.\zs/ keepend contains=mkdEscapeCh oneline concealends
 syntax match mkdEscapeCh /./ contained
 syntax match mkdNbsp /&nbsp;/ conceal cchar= 
 


### PR DESCRIPTION
@bluz71 See if this fixes things for you. I use plasticboy's markdown (via vim-polyglot) so I couldn't reproduce your issue before.