### PR TITLE
Treesitter injection language override

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -306,11 +306,16 @@ function LanguageTree:_get_injections()
       for id, node in pairs(match) do
         local data = metadata[id]
         local name = self._injection_query.captures[id]
+        local language_override = data.language
         local offset_range = data and data.offset
 
         -- Lang should override any other language tag
         if name == "language" then
-          lang = query.get_node_text(node, self._source)
+          if language_override then
+            lang = language_override
+          else
+            lang = query.get_node_text(node, self._source)
+          end
         elseif name == "combined" then
           combined = true
         elseif name == "content" then

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -242,7 +242,14 @@ local directive_handlers = {
     if range[1] < range[3] or (range[1] == range[3] and range[2] <= range[4]) then
       metadata[pred[2]][key] = range
     end
-  end
+  end,
+
+  ["downcase!"] = function(match, _, bufnr, pred, metadata)
+    local node = match[pred[2]]
+    local text = M.get_node_text(node, bufnr)
+    local language = string.lower(text)
+    metadata[pred[2]]['language'] = language
+  end,
 }
 
 --- Adds a new predicate to be used in queries

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -594,6 +594,33 @@ int x = INT_MAX;
 
         eq(result, "value")
       end)
+
+    end)
+  end)
+
+  describe("when calling the downcase directive", function()
+    it("should allow overriding the language", function()
+      insert([[
+        int HTML = 42;
+      ]])
+
+      local result = exec_lua([[
+      local language_override
+
+      local query = vim.treesitter.parse_query("c", '((identifier) @language (#downcase! @language))')
+      local parser = vim.treesitter.get_parser(0, "c")
+
+      for pattern, match, metadata in query:iter_matches(parser:parse()[1]:root(), 0) do
+        for id, node in pairs(match) do
+          local data = metadata[id]
+          language_override = data.language
+        end
+      end
+
+      return language_override
+      ]])
+
+      eq(result, "html")
     end)
   end)
 end)


### PR DESCRIPTION
# What

I split this PR into 2 commits so I'll explain them separately.

## Language Injection Override

The first commit is the part enabling people to override the language to use when injecting a different language in the tree-sitter AST. It will allow custom directives to add a `"language"` key to the metadata table returned when applying directives to an injection query. If this language override is set then the `@language` node text should be ignored.

## Add a `downcase!` directive

In addition to allowing directives to override the language for injection, I added a useful directive that makes use of this new functionality. Often times the text matched by an `@language` node may not exactly resemble the name of the parser for that language. More often than not the parser name will be lowercase, i.e. `html` instead of `HTML`. In the below example ruby code a string constant is defined using ruby's heredoc syntax. The coding conventions for heredocs are to surround the string content with the name of the language in all uppercase letters ie. `HTML`, `SQL`, `JAVASCRIPT`, etc.

```ruby
class A
  MY_HTML = <<~HTML
    <title>This is a title</title>
    <div class="example-class">
      <span>This is a span</span>
    </div>
  HTML
end
```

The `downcase!` directive would be used in an `injection.scm` file like so to convert the `HTML` value in the `@language` node to a valid lowercase `html` name of the parser.

```scm
(heredoc_body
 (heredoc_content) @content
 (heredoc_end) @language
 (#downcase! @language))
```