### PR TITLE
[RFC] vim-patch 8.2.0088: insufficient tests for tags...

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -337,11 +337,11 @@ the same as above, with a "p" prepended.
 A static tag is a tag that is defined for a specific file.  In a C program
 this could be a static function.
 
-In Vi jumping to a tag sets the current search pattern.  This means that
-the "n" command after jumping to a tag does not search for the same pattern
-that it did before jumping to the tag.  Vim does not do this as we consider it
-to be a bug.  You can still find the tag search pattern in the search history.
-If you really want the old Vi behavior, set the 't' flag in 'cpoptions'.
+In Vi jumping to a tag sets the current search pattern.  This means that the
+"n" command after jumping to a tag does not search for the same pattern that
+it did before jumping to the tag.  Vim does not do this as we consider it to
+be a bug.  If you really want the old Vi behavior, set the 't' flag in
+'cpoptions'.
 
 							*tag-binary-search*
 Vim uses binary searching in the tags file to find the desired tag quickly
@@ -419,8 +419,7 @@ would otherwise go unnoticed.  Example: >
 
 In Vi the ":tag" command sets the last search pattern when the tag is searched
 for.  In Vim this is not done, the previous search pattern is still remembered,
-unless the 't' flag is present in 'cpoptions'.  The search pattern is always
-put in the search history, so you can modify it if searching fails.
+unless the 't' flag is present in 'cpoptions'.
 
 							*tags-option*
 The 'tags' option is a list of file names.  Each of these files is searched

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8809,8 +8809,6 @@ static void f_settagstack(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
     if (set_tagstack(wp, d, action) == OK) {
       rettv->vval.v_number = 0;
-    } else {
-      EMSG(_(e_listreq));
     }
 }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -908,7 +908,7 @@ add_llist_tags(
         if (len > 128) {
             len = 128;
         }
-        xstrlcpy((char *)tag_name, (const char *)tagp.tagname, len);
+        xstrlcpy((char *)tag_name, (const char *)tagp.tagname, len + 1);
         tag_name[len] = NUL;
 
         // Save the tag file name
@@ -975,7 +975,8 @@ add_llist_tags(
             if (cmd_len > (CMDBUFFSIZE - 5)) {
                 cmd_len = CMDBUFFSIZE - 5;
             }
-            xstrlcat((char *)cmd, (char *)cmd_start, cmd_len);
+            snprintf((char *)cmd + len, CMDBUFFSIZE + 1 - len,
+                     "%.*s", cmd_len, cmd_start);
             len += cmd_len;
 
             if (cmd[len - 1] == '$') {
@@ -3406,6 +3407,7 @@ int set_tagstack(win_T *wp, const dict_T *d, int action)
 
   if ((di = tv_dict_find(d, "items", -1)) != NULL) {
     if (di->di_tv.v_type != VAR_LIST) {
+      EMSG(_(e_listreq));
       return FAIL;
     }
     l = di->di_tv.vval.v_list;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3002,7 +3002,8 @@ static int test_for_current(char_u *fname, char_u *fname_end, char_u *tag_fname,
  */
 static int find_extra(char_u **pp)
 {
-  char_u      *str = *pp;
+  char_u *str = *pp;
+  char_u first_char = **pp;
 
   // Repeat for addresses separated with ';'
   for (;; ) {
@@ -3010,7 +3011,7 @@ static int find_extra(char_u **pp)
       str = skipdigits(str);
     } else if (*str == '/' || *str == '?') {
       str = skip_regexp(str + 1, *str, false, NULL);
-      if (*str != **pp) {
+      if (*str != first_char) {
         str = NULL;
       } else {
         str++;
@@ -3028,6 +3029,7 @@ static int find_extra(char_u **pp)
       break;
     }
     str++;  // skip ';'
+    first_char = *str;
   }
 
   if (str != NULL && STRNCMP(str, ";\"", 2) == 0) {

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -469,6 +469,34 @@ func Test_pum_with_folds_two_tabs()
   call delete('Xpumscript')
 endfunc
 
+" Test for inserting the tag search pattern in insert mode
+func Test_ins_compl_tag_sft()
+  call writefile([
+        \ "!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "first\tXfoo\t/^int first() {}$/",
+        \ "second\tXfoo\t/^int second() {}$/",
+        \ "third\tXfoo\t/^int third() {}$/"],
+        \ 'Xtags')
+  set tags=Xtags
+  let code =<< trim [CODE]
+    int first() {}
+    int second() {}
+    int third() {}
+  [CODE]
+  call writefile(code, 'Xfoo')
+
+  enew
+  set showfulltag
+  exe "normal isec\<C-X>\<C-]>\<C-N>\<CR>"
+  call assert_equal('int second() {}', getline(1))
+  set noshowfulltag
+
+  call delete('Xtags')
+  call delete('Xfoo')
+  set tags&
+  %bwipe!
+endfunc
+
 " Test to ensure 'Scanning...' messages are not recorded in messages history
 func Test_z1_complete_no_history()
   new

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -81,4 +81,28 @@ func Test_tagfunc()
   call delete('Xfile1')
 endfunc
 
+" Test for modifying the tag stack from a tag function and jumping to a tag
+" from a tag function
+func Test_tagfunc_settagstack()
+  func Mytagfunc1(pat, flags, info)
+    call settagstack(1, {'tagname' : 'mytag', 'from' : [0, 10, 1, 0]})
+    return [{'name' : 'mytag', 'filename' : 'Xtest', 'cmd' : '1'}]
+  endfunc
+  set tagfunc=Mytagfunc1
+  call writefile([''], 'Xtest')
+  call assert_fails('tag xyz', 'E986:')
+
+  func Mytagfunc2(pat, flags, info)
+    tag test_tag
+    return [{'name' : 'mytag', 'filename' : 'Xtest', 'cmd' : '1'}]
+  endfunc
+  set tagfunc=Mytagfunc2
+  call assert_fails('tag xyz', 'E986:')
+
+  call delete('Xtest')
+  set tagfunc&
+  delfunc Mytagfunc1
+  delfunc Mytagfunc2
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
There were some hidden bugs created by incorrectly translating vim_strncpy and STRNCAT.