### PR TITLE
[RFC] vim-patch:8.2.0946: cannot use "q" to cancel a number prompt

### DIFF
--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -752,8 +752,10 @@ get_number (
       skip_redraw = TRUE;           /* skip redraw once */
       do_redraw = FALSE;
       break;
-    } else if (c == CAR || c == NL || c == Ctrl_C || c == ESC)
+    } else if (c == CAR || c == NL || c == Ctrl_C || c == ESC
+               || c == 'q') {
       break;
+    }
   }
   no_mapping--;
   return n;
@@ -770,11 +772,13 @@ int prompt_for_number(int *mouse_used)
   int save_cmdline_row;
   int save_State;
 
-  /* When using ":silent" assume that <CR> was entered. */
-  if (mouse_used != NULL)
-    MSG_PUTS(_("Type number and <Enter> or click with mouse (empty cancels): "));
-  else
-    MSG_PUTS(_("Type number and <Enter> (empty cancels): "));
+  // When using ":silent" assume that <CR> was entered.
+  if (mouse_used != NULL) {
+    MSG_PUTS(_("Type number and <Enter> or click with mouse "
+               "(q or empty cancels): "));
+  } else {
+    MSG_PUTS(_("Type number and <Enter> (q or empty cancels): "));
+  }
 
   /* Set the state such that text can be selected/copied/pasted and we still
    * get mouse events. */

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1039,6 +1039,18 @@ func Test_inputlist()
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>3\<cr>", 'tx')
   call assert_equal(3, c)
 
+  " CR to cancel
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>\<cr>", 'tx')
+  call assert_equal(0, c)
+
+  " Esc to cancel
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>\<Esc>", 'tx')
+  call assert_equal(0, c)
+
+  " q to cancel
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>q", 'tx')
+  call assert_equal(0, c)
+
   call assert_fails('call inputlist("")', 'E686:')
 endfunc
 


### PR DESCRIPTION
Problem:    Cannot use "q" to cancel a number prompt.
Solution:   Recognize "q" instead of ignoring it.
https://github.com/vim/vim/commit/eebd555733491cb55b9f30fe28772c0fd0ebacf7