### PR TITLE
fix slow closing of lsp clients when exiting vim

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1057,11 +1057,38 @@ function lsp._vim_exit_handler()
     client.stop()
   end
 
-  if not vim.wait(500, function() return tbl_isempty(active_clients) end, 50) then
-    for _, client in pairs(active_clients) do
-      client.stop(true)
+  local function wait_async(timeout, ms, predicate, cb)
+    local timer = uv.new_timer()
+    local time = 0
+
+    local function done(in_time)
+      timer:stop()
+      timer:close()
+      cb(in_time)
     end
+
+    timer:start(0, ms, function()
+      if predicate() == true then
+        done(true)
+        return
+      end
+
+      if time == timeout then
+        done(false)
+        return
+      end
+
+      time = time + ms
+    end)
   end
+
+  wait_async(500, 50, function() return tbl_isempty(active_clients) end, function(in_time)
+    if not in_time then
+      for _, client in pairs(active_clients) do
+        client.stop(true)
+      end
+    end
+  end)
 end
 
 nvim_command("autocmd VimLeavePre * lua vim.lsp._vim_exit_handler()")


### PR DESCRIPTION
The builtin lsp client for nvim is extremely fast. The only problem is that it takes a long time to close for some servers. For example, for lighter servers like `sumneko_lua` it works fine. However, for larger servers like `haskell_language_server` and `rust-analyzer` neovim will close very slowly and completely block. The issue was that we were using `vim.wait` to check if everything is closed. This pr makes the closing of clients completely async.