### PR TITLE
provider: configure verbosity of provider error messages

### DIFF
--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -82,6 +82,7 @@ typedef struct {
   LuaRef redraw_end;
   LuaRef hl_def;
   int hl_valid;
+  bool did_emsg;
 } DecorProvider;
 
 EXTERN kvec_t(DecorProvider) decor_providers INIT(= KV_INITIAL_VALUE);
@@ -91,7 +92,7 @@ EXTERN bool provider_active INIT(= false);
 #define DECORATION_PROVIDER_INIT(ns_id) (DecorProvider) \
                                  { ns_id, false, LUA_NOREF, LUA_NOREF, \
                                    LUA_NOREF, LUA_NOREF, LUA_NOREF, \
-                                   LUA_NOREF, -1 }
+                                   LUA_NOREF, -1, false }
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "decoration.h.generated.h"

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -541,6 +541,7 @@ static char *(p_rdb_values[]) = {
   "nothrottle",
   "invalid",
   "nodelta",
+  "provider",
   NULL
 };
 # endif
@@ -548,6 +549,7 @@ static char *(p_rdb_values[]) = {
 # define RDB_NOTHROTTLE         0x002
 # define RDB_INVALID            0x004
 # define RDB_NODELTA            0x008
+# define RDB_PROVIDER           0x010
 
 EXTERN long p_rdt;              // 'redrawtime'
 EXTERN int p_remap;             // 'remap'

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -167,7 +167,7 @@ static bool resizing = false;
 
 static char * provider_first_error = NULL;
 
-static bool provider_invoke(NS ns_id, const char *name, LuaRef ref,
+static bool provider_invoke(DecorProvider *p, const char *name, LuaRef ref,
                             Array args, bool default_true)
 {
   Error err = ERROR_INIT;
@@ -184,18 +184,35 @@ static bool provider_invoke(NS ns_id, const char *name, LuaRef ref,
   }
 
   if (ERROR_SET(&err)) {
-    const char *ns_name = describe_ns(ns_id);
-    ELOG("error in provider %s:%s: %s", ns_name, name, err.msg);
-    bool verbose_errs = true;  // TODO(bfredl):
-    if (verbose_errs && provider_first_error == NULL) {
-      static char errbuf[IOSIZE];
-      snprintf(errbuf, sizeof errbuf, "%s: %s", ns_name, err.msg);
-      provider_first_error = xstrdup(errbuf);
+    static char errbuf[IOSIZE];
+    const char *ns_name = describe_ns(p->ns_id);
+    snprintf(errbuf, sizeof errbuf,
+             "error in display provider %s:%s: %s", ns_name, name, err.msg);
+    ELOG("%s", errbuf);
+    if (rdb_flags & RDB_PROVIDER) {
+      if (provider_first_error == NULL) {
+        snprintf(errbuf, sizeof errbuf, "%s:%s: %s", ns_name, name, err.msg);
+        provider_first_error = xstrdup(errbuf);
+      }
+    } else {
+      if (!p->did_emsg) {
+        p->did_emsg = true;
+        multiqueue_put(main_loop.events, provider_emsg,
+                       1, (void *)xstrdup(errbuf));
+
+      }
     }
   }
 
   api_free_object(ret);
   return false;
+}
+
+static void provider_emsg(void **argv)
+{
+  char *errmsg = argv[0];
+  emsg((char_u *)errmsg);
+  xfree(errmsg);
 }
 
 /// Redraw a window later, with update_screen(type).
@@ -487,7 +504,7 @@ int update_screen(int type)
       FIXED_TEMP_ARRAY(args, 2);
       args.items[0] = INTEGER_OBJ(display_tick);
       args.items[1] = INTEGER_OBJ(type);
-      active = provider_invoke(p->ns_id, "start", p->redraw_start, args, true);
+      active = provider_invoke(p, "start", p->redraw_start, args, true);
     } else {
       active = true;
     }
@@ -565,7 +582,7 @@ int update_screen(int type)
           if (p && p->redraw_buf != LUA_NOREF) {
             FIXED_TEMP_ARRAY(args, 1);
             args.items[0] = BUFFER_OBJ(buf->handle);
-            provider_invoke(p->ns_id, "buf", p->redraw_buf, args, true);
+            provider_invoke(p, "buf", p->redraw_buf, args, true);
           }
         }
         buf->b_mod_tick_decor = display_tick;
@@ -638,7 +655,7 @@ int update_screen(int type)
     if (p->redraw_end != LUA_NOREF) {
       FIXED_TEMP_ARRAY(args, 1);
       args.items[0] = INTEGER_OBJ(display_tick);
-      provider_invoke(p->ns_id, "end", p->redraw_end, args, true);
+      provider_invoke(p, "end", p->redraw_end, args, true);
     }
   }
   kvi_destroy(providers);
@@ -1311,7 +1328,7 @@ static void win_update(win_T *wp, Providers *providers)
       // TODO(bfredl): we are not using this, but should be first drawn line?
       args.items[2] = INTEGER_OBJ(wp->w_topline-1);
       args.items[3] = INTEGER_OBJ(knownmax);
-      if (provider_invoke(p->ns_id, "win", p->redraw_win, args, true)) {
+      if (provider_invoke(p, "win", p->redraw_win, args, true)) {
         kvi_push(line_providers, p);
       }
     }
@@ -2171,7 +2188,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
         args.items[0] = WINDOW_OBJ(wp->handle);
         args.items[1] = BUFFER_OBJ(buf->handle);
         args.items[2] = INTEGER_OBJ(lnum-1);
-        if (provider_invoke(p->ns_id, "line", p->redraw_line, args, true)) {
+        if (provider_invoke(p, "line", p->redraw_line, args, true)) {
           has_decor = true;
         } else {
           // return 'false' or error: skip rest of this window


### PR DESCRIPTION
configure the verbosity of decoration provider (for most users: tree-sitter highlight) with 'redrawdebug' option. By default show only one error message to the user as an EMSG (all messages still available in the log), but opt-in to the inline errors using `set redrawdebug+=provider`