### PR TITLE
Extmarks: send correct buffer events on blockwise paste for nonuniform lines

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3177,7 +3177,8 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       // insert the new text
       totlen = (size_t)(count * (yanklen + spaces)
                         + bd.startspaces + bd.endspaces);
-      newp = (char_u *) xmalloc(totlen + oldlen + 1);
+      int addcount = (int)totlen + lines_appended;
+      newp = (char_u *)xmalloc(totlen + oldlen + 1);
       // copy part up to cursor to new line
       ptr = newp;
       memmove(ptr, oldp, (size_t)bd.textcol);
@@ -3194,6 +3195,8 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
         if ((j < count - 1 || !shortline) && spaces) {
           memset(ptr, ' ', (size_t)spaces);
           ptr += spaces;
+        } else {
+          addcount -= spaces;
         }
       }
       // may insert some spaces after the new text
@@ -3205,7 +3208,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       memmove(ptr, oldp + bd.textcol + delcount, (size_t)columns);
       ml_replace(curwin->w_cursor.lnum, newp, false);
       extmark_splice_cols(curbuf, (int)curwin->w_cursor.lnum-1, bd.textcol,
-                          delcount, (int)totlen + lines_appended, kExtmarkUndo);
+                          delcount, addcount, kExtmarkUndo);
 
       ++curwin->w_cursor.lnum;
       if (i == 0)

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -717,6 +717,26 @@ describe('lua: nvim_buf_attach on_bytes', function()
       command("bw!")
     end)
 
+    it("blockwise paste with uneven line lengths", function()
+      local check_events = setup_eventcheck(verify, {'aaaa', 'aaa', 'aaa'})
+
+      -- eq({}, meths.buf_get_lines(0, 0, -1, true))
+      feed("gg0<c-v>jj$d")
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 0, 4, 4, 0, 0, 0 },
+        { "test1", "bytes", 1, 3, 1, 0, 1, 0, 3, 3, 0, 0, 0 },
+        { "test1", "bytes", 1, 3, 2, 0, 2, 0, 3, 3, 0, 0, 0 },
+      }
+
+      feed("p")
+      check_events {
+        { "test1", "bytes", 1, 4, 0, 0, 0, 0, 0, 0, 0, 4, 4 },
+        { "test1", "bytes", 1, 4, 1, 0, 5, 0, 0, 0, 0, 3, 3 },
+        { "test1", "bytes", 1, 4, 2, 0, 9, 0, 0, 0, 0, 3, 3 },
+      }
+
+    end)
 
     teardown(function()
       os.remove "Xtest-reload"


### PR DESCRIPTION
Fixes #14189.

Previously, the call to `extmark_splice` assumed that padding spaces were inserted even if they actually weren't.