### PR TITLE
api: fix use-after-free in nvim_chan_send

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1333,7 +1333,8 @@ void nvim_chan_send(Integer chan, String data, Error *err)
     return;
   }
 
-  channel_send((uint64_t)chan, data.data, data.size, &error);
+  channel_send((uint64_t)chan, data.data, data.size,
+               false, &error);
   if (error) {
     api_set_error(err, kErrorTypeValidation, "%s", error);
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -916,7 +916,7 @@ static void f_chansend(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
   uint64_t id = argvars[0].vval.v_number;
   const char *error = NULL;
-  rettv->vval.v_number = channel_send(id, input, input_len, &error);
+  rettv->vval.v_number = channel_send(id, input, input_len, true, &error);
   if (error) {
     EMSG(error);
   }

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -963,8 +963,10 @@ describe('jobs', function()
       return rv
     end
 
+    local j
     local function send(str)
-      nvim('command', 'call jobsend(j, "'..str..'")')
+      -- check no nvim_chan_free double free with pty job (#14198)
+      meths.chan_send(j, str)
     end
 
     before_each(function()
@@ -979,6 +981,7 @@ describe('jobs', function()
       nvim('command', 'let g:job_opts.pty = 1')
       nvim('command', 'let exec = [expand("<cfile>:p")]')
       nvim('command', "let j = jobstart(exec, g:job_opts)")
+      j = eval'j'
       eq('tty ready', next_chunk())
     end)
 


### PR DESCRIPTION
fixes #14198 . curious that existing tests did not trigger this, but maybe msgpack-rpc freeing happens too late to notice.