### PR TITLE
viml: embed Lua syntax highlighting [skip ci]

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -70,6 +70,8 @@ the differences.
 - |matchit| plugin is enabled. To disable it in your config: >
     :let loaded_matchit = 1
 
+- |g:vimsyn_embed| defaults to "l" to enable Lua highlighting
+
 ==============================================================================
 3. New Features						       *nvim-features*
 

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -616,7 +616,7 @@ syn region	vimGlobal	matchgroup=Statement start='\<v\%[global]!\=/' skip='\\.' e
 "   g:vimsyn_embed =~# 'r' : embed ruby
 "   g:vimsyn_embed =~# 't' : embed tcl
 if !exists("g:vimsyn_embed")
- let g:vimsyn_embed= 0
+ let g:vimsyn_embed = 'l'
 endif
 
 " [-- lua --] {{{3


### PR DESCRIPTION
- **2015**: Vim enables all supported languages for `g:vimsyn_embed` by default.
- **2017**: Justin disables all of them by default to avoid potential performance hits.
- **2021**: We welcome our Lua overlords and only enable Lua highlighting by default.

That way, Lua blocks in Vim files have syntax highlighting as well, e.g.

```vim
lua << EOF
lsp_complete_installable_servers = function()
  return table.concat(require'lspconfig'.available_servers(), '\n')
end
require'lspconfig'._root._setup()
EOF
```