### PR TITLE
[RFC] Fix `:%g@a/b` only highlighting 'a'

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3928,7 +3928,7 @@ static linenr_T get_address(exarg_T *eap,
         }
         searchcmdlen = 0;
         flags = silent ? 0 : SEARCH_HIS | SEARCH_MSG;
-        if (!do_search(NULL, c, cmd, 1L, flags, NULL)) {
+        if (!do_search(NULL, c, c, cmd, 1L, flags, NULL)) {
           curwin->w_cursor = pos;
           cmd = NULL;
           goto error;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -490,7 +490,7 @@ static void may_do_incsearch_highlighting(int firstc, long count,
     ccline.cmdbuff[skiplen + patlen] = NUL;
     memset(&sia, 0, sizeof(sia));
     sia.sa_tm = &tm;
-    found = do_search(NULL, firstc == ':' ? '/' : firstc,
+    found = do_search(NULL, firstc, firstc == ':' ? '/' : firstc,
                       ccline.cmdbuff + skiplen, count,
                       search_flags, &sia);
     ccline.cmdbuff[skiplen + patlen] = next_char;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5459,7 +5459,7 @@ static int normal_search(
   curwin->w_set_curswant = true;
 
   memset(&sia, 0, sizeof(sia));
-  i = do_search(cap->oap, dir, pat, cap->count1,
+  i = do_search(cap->oap, dir, dir, pat, cap->count1,
                 opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, &sia);
   if (wrapped != NULL) {
     *wrapped = sia.sa_wrapped;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2798,7 +2798,7 @@ static void qf_jump_goto_line(linenr_T qf_lnum, int qf_col, char_u qf_viscol,
     // Move the cursor to the first line in the buffer
     pos_T save_cursor = curwin->w_cursor;
     curwin->w_cursor.lnum = 0;
-    if (!do_search(NULL, '/', qf_pattern, (long)1, SEARCH_KEEP, NULL)) {
+    if (!do_search(NULL, '/', '/', qf_pattern, (long)1, SEARCH_KEEP, NULL)) {
       curwin->w_cursor = save_cursor;
     }
   }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1021,12 +1021,13 @@ static int first_submatch(regmmatch_T *rp)
  * Return 0 for failure, 1 for found, 2 for found and line offset added.
  */
 int do_search(
-    oparg_T         *oap,           /* can be NULL */
-    int dirc,                       /* '/' or '?' */
+    oparg_T         *oap,   // can be NULL
+    int pattern_delimiter,  // Pattern delimiter, e.g. '@' for :%s@abc@def@
+    int dirc,               // '/' or '?'
     char_u          *pat,
     long count,
     int options,
-    searchit_arg_T  *sia        // optional arguments or NULL
+    searchit_arg_T  *sia    // optional arguments or NULL
 )
 {
   pos_T pos;                    /* position of the last match */
@@ -1122,7 +1123,7 @@ int do_search(
        * If there is a matching '/' or '?', toss it.
        */
       ps = strcopy;
-      p = skip_regexp(pat, dirc, p_magic, &strcopy);
+      p = skip_regexp(pat, pattern_delimiter, p_magic, &strcopy);
       if (strcopy != ps) {
         /* made a copy of "pat" to change "\?" to "?" */
         searchcmdlen += (int)(STRLEN(pat) - STRLEN(strcopy));

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3035,7 +3035,7 @@ void ex_spellrepall(exarg_T *eap)
   sub_nlines = 0;
   curwin->w_cursor.lnum = 0;
   while (!got_int) {
-    if (do_search(NULL, '/', frompat, 1L, SEARCH_KEEP, NULL) == 0
+    if (do_search(NULL, '/', '/', frompat, 1L, SEARCH_KEEP, NULL) == 0
         || u_save_cursor() == FAIL) {
       break;
     }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2809,7 +2809,7 @@ static int jumpto_tag(
         // start search before first line
         curwin->w_cursor.lnum = 0;
       }
-      if (do_search(NULL, pbuf[0], pbuf + 1, (long)1,
+      if (do_search(NULL, pbuf[0], pbuf[0], pbuf + 1, (long)1,
                     search_options, NULL)) {
         retval = OK;
       } else {
@@ -2819,8 +2819,8 @@ static int jumpto_tag(
         /*
          * try again, ignore case now
          */
-        p_ic = TRUE;
-        if (!do_search(NULL, pbuf[0], pbuf + 1, (long)1,
+        p_ic = true;
+        if (!do_search(NULL, pbuf[0], pbuf[0], pbuf + 1, (long)1,
                        search_options, NULL)) {
           // Failed to find pattern, take a guess: "^func  ("
           found = 2;
@@ -2828,11 +2828,13 @@ static int jumpto_tag(
           cc = *tagp.tagname_end;
           *tagp.tagname_end = NUL;
           snprintf((char *)pbuf, LSIZE, "^%s\\s\\*(", tagp.tagname);
-          if (!do_search(NULL, '/', pbuf, (long)1, search_options, NULL)) {
+          if (!do_search(NULL, '/', '/', pbuf, (long)1, search_options,
+                         NULL)) {
             // Guess again: "^char * \<func  ("
             snprintf((char *)pbuf, LSIZE, "^\\[#a-zA-Z_]\\.\\*\\<%s\\s\\*(",
                      tagp.tagname);
-            if (!do_search(NULL, '/', pbuf, (long)1, search_options, NULL)) {
+            if (!do_search(NULL, '/', '/', pbuf, (long)1, search_options,
+                           NULL)) {
               found = 0;
             }
           }

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2785,3 +2785,19 @@ it('long :%s/ with inccommand does not collapse cmdline', function()
     AAAAAAA^     |
   ]])
 end)
+
+it(':%g@a/b highlights entire pattern', function()
+  local screen = Screen.new(10,5)
+  clear()
+  common_setup(screen)
+  command('set inccommand=nosplit')
+  feed('ia/b/c<Esc>')
+  feed(':%g@a/b')
+  screen:expect([[
+    {10:a/b}/c       |
+    {15:~           }|
+    {15:~           }|
+    {15:~           }|
+    :%g@a/b^     |
+  ]])
+end)


### PR DESCRIPTION
This commit fixes a bug where typing `:%g@a/b` only highlighted `a`
instead of `a/b` in the buffer.
