### PR TITLE
vim-patch:8.2.{1666,2045,2659,2662}

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2322,7 +2322,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
         getvcol(curwin, &pos, (colnr_T *)&tocol, NULL, NULL);
       }
       // do at least one character; happens when past end of line
-      if (fromcol == tocol) {
+      if (fromcol == tocol && search_match_endcol) {
         tocol = fromcol + 1;
       }
       area_highlighting = true;

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -36,13 +36,11 @@ NEW_TESTS_IN_ALOT := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' $(add
 NEW_TESTS_IN_ALOT_LATIN := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' test_alot_latin.vim)
 # Ignored tests.
 # test_alot_latin: Nvim does not allow setting encoding.
-# test_autochdir: ported to Lua, but kept for easier merging.
 # test_eval_func: used as include in old-style test (test_eval.in).
 # test_listlbr: Nvim does not allow setting encoding.
 # test_largefile: uses too much resources to run on CI.
 NEW_TESTS_IGNORE := \
   test_alot_latin $(NEW_TESTS_IN_ALOT_LATIN) \
-  test_autochdir \
   test_eval_func \
   test_listlbr \
   test_largefile \

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -36,11 +36,9 @@ NEW_TESTS_IN_ALOT := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' $(add
 NEW_TESTS_IN_ALOT_LATIN := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' test_alot_latin.vim)
 # Ignored tests.
 # test_alot_latin: Nvim does not allow setting encoding.
-# test_listlbr: Nvim does not allow setting encoding.
 # test_largefile: uses too much resources to run on CI.
 NEW_TESTS_IGNORE := \
   test_alot_latin $(NEW_TESTS_IN_ALOT_LATIN) \
-  test_listlbr \
   test_largefile \
 
 NEW_TESTS := $(sort $(basename $(notdir $(wildcard test_*.vim))))

--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -36,12 +36,10 @@ NEW_TESTS_IN_ALOT := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' $(add
 NEW_TESTS_IN_ALOT_LATIN := $(shell sed -n '/^source/ s/^source //; s/\.vim$$//p' test_alot_latin.vim)
 # Ignored tests.
 # test_alot_latin: Nvim does not allow setting encoding.
-# test_eval_func: used as include in old-style test (test_eval.in).
 # test_listlbr: Nvim does not allow setting encoding.
 # test_largefile: uses too much resources to run on CI.
 NEW_TESTS_IGNORE := \
   test_alot_latin $(NEW_TESTS_IN_ALOT_LATIN) \
-  test_eval_func \
   test_listlbr \
   test_largefile \
 

--- a/src/nvim/testdir/test_autochdir.vim
+++ b/src/nvim/testdir/test_autochdir.vim
@@ -1,10 +1,10 @@
 " Test 'autochdir' behavior
 
-if !exists("+autochdir")
-  throw 'Skipped: autochdir feature missing'
-endif
+source check.vim
+CheckOption autochdir
 
 func Test_set_filename()
+  CheckFunction test_autochdir
   let cwd = getcwd()
   call test_autochdir()
   set acd
@@ -17,3 +17,5 @@ func Test_set_filename()
   exe 'cd ' . cwd
   call delete('samples/Xtest')
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -76,7 +76,7 @@ if has('timers')
   endfunc
 
   func Test_OptionSet_modeline()
-    throw 'skipped: Nvim does not support test_override()'
+    CheckFunction test_override
     call test_override('starting', 1)
     au! OptionSet
     augroup set_tabstop
@@ -507,7 +507,7 @@ func s:AutoCommandOptionSet(match)
 endfunc
 
 func Test_OptionSet()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !has("eval") || !exists("+autochdir")
     return
   endif
@@ -648,7 +648,7 @@ func Test_OptionSet()
 endfunc
 
 func Test_OptionSet_diffmode()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   call test_override('starting', 1)
   " 18: Changing an option when entering diff mode
   new
@@ -682,7 +682,7 @@ func Test_OptionSet_diffmode()
 endfunc
 
 func Test_OptionSet_diffmode_close()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   call test_override('starting', 1)
   " 19: Try to close the current window when entering diff mode
   " should not segfault
@@ -1285,9 +1285,9 @@ func Test_autocommand_all_events()
 endfunc
 
 " Test TextChangedI and TextChangedP
+" See test/functional/viml/completion_spec.lua'
 func Test_ChangedP()
-  " Nvim does not support test_override().
-  throw 'skipped: see test/functional/viml/completion_spec.lua'
+  CheckFunction test_override
   new
   call setline(1, ['foo', 'bar', 'foobar'])
   call test_override("char_avail", 1)
@@ -1350,7 +1350,7 @@ func SetLineOne()
 endfunc
 
 func Test_TextChangedI_with_setline()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   new
   call test_override('char_avail', 1)
   autocmd TextChangedI <buffer> call SetLineOne()

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -24,7 +24,7 @@ endfunc
 
 func Test_for_invalid()
   call assert_fails("for x in 99", 'E714:')
-  call assert_fails("for x in 'asdf'", 'E714:')
+  call assert_fails("for x in function('winnr')", 'E714:')
   call assert_fails("for x in {'a': 9}", 'E714:')
 
   if 0

--- a/src/nvim/testdir/test_listlbr.vim
+++ b/src/nvim/testdir/test_listlbr.vim
@@ -1,9 +1,5 @@
 " Test for linebreak and list option (non-utf8)
 
-" Nvim does not allow setting 'encoding', so skip this test.
-finish
-
-set encoding=latin1
 scriptencoding latin1
 
 if !exists("+linebreak") || !has("conceal")
@@ -46,6 +42,7 @@ func Test_set_linebreak()
 endfunc
 
 func Test_linebreak_with_list()
+  throw 'skipped: Nvim does not support enc=latin1'
   call s:test_windows('setl ts=4 sbr=+ list listchars=')
   call setline(1, "\tabcdef hijklmn\tpqrstuvwxyz_1060ABCDEFGHIJKLMNOP ")
   let lines = s:screen_lines([1, 4], winwidth(0))
@@ -217,6 +214,7 @@ func Test_norm_after_block_visual()
 endfunc
 
 func Test_block_replace_after_wrapping()
+  throw 'skipped: Nvim does not support enc=latin1'
   call s:test_windows()
   call setline(1, repeat("a", 150))
   exe "norm! 0yypk147|\<C-V>jr0"

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -1,5 +1,6 @@
 " Tests for :messages, :echomsg, :echoerr
 
+source check.vim
 source shared.vim
 
 func Test_messages()
@@ -77,7 +78,7 @@ func Test_echomsg()
 endfunc
 
 func Test_echoerr()
-  throw 'skipped: Nvim does not support test_ignore_error()'
+  CheckFunction test_ignore_error
   call test_ignore_error('IgNoRe')
   call assert_equal("\nIgNoRe hello", execute(':echoerr "IgNoRe hello"'))
   call assert_equal("\n12345 IgNoRe", execute(':echoerr 12345 "IgNoRe"'))

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -871,7 +871,7 @@ func Test_popup_complete_backwards_ctrl_p()
 endfunc
 
 fun! Test_complete_o_tab()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   let s:o_char_pressed = 0
 
   fun! s:act_on_text_changed()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2660,7 +2660,7 @@ endfunc
 " Test for incsearch highlighting of the :vimgrep pattern
 " This test used to cause "E315: ml_get: invalid lnum" errors.
 func Test_vimgrep_incsearch()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   enew
   set incsearch
   call test_override("char_avail", 1)

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -4,9 +4,9 @@ source shared.vim
 source screendump.vim
 source check.vim
 
+" See test/functional/legacy/search_spec.lua
 func Test_search_cmdline()
-  " See test/functional/legacy/search_spec.lua
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -203,9 +203,9 @@ func Test_search_cmdline()
   bw!
 endfunc
 
+" See test/functional/legacy/search_spec.lua
 func Test_search_cmdline2()
-  " See test/functional/legacy/search_spec.lua
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -352,7 +352,7 @@ func Test_searchc()
 endfunc
 
 func Cmdline3_prep()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   " need to disable char_avail,
   " so that expansion of commandline works
   call test_override("char_avail", 1)
@@ -362,14 +362,13 @@ func Cmdline3_prep()
 endfunc
 
 func Incsearch_cleanup()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   set noincsearch
   call test_override("char_avail", 0)
   bw!
 endfunc
 
 func Test_search_cmdline3()
-  throw 'skipped: Nvim does not support test_override()'
   if !exists('+incsearch')
     return
   endif
@@ -383,7 +382,6 @@ func Test_search_cmdline3()
 endfunc
 
 func Test_search_cmdline3s()
-  throw 'skipped: Nvim does not support test_override()'
   if !exists('+incsearch')
     return
   endif
@@ -410,7 +408,6 @@ func Test_search_cmdline3s()
 endfunc
 
 func Test_search_cmdline3g()
-  throw 'skipped: Nvim does not support test_override()'
   if !exists('+incsearch')
     return
   endif
@@ -434,7 +431,6 @@ func Test_search_cmdline3g()
 endfunc
 
 func Test_search_cmdline3v()
-  throw 'skipped: Nvim does not support test_override()'
   if !exists('+incsearch')
     return
   endif
@@ -451,9 +447,9 @@ func Test_search_cmdline3v()
   call Incsearch_cleanup()
 endfunc
 
+" See test/functional/legacy/search_spec.lua
 func Test_search_cmdline4()
-  " See test/functional/legacy/search_spec.lua
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -508,7 +504,7 @@ func Test_search_cmdline5()
 endfunc
 
 func Test_search_cmdline7()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   " Test that pressing <c-g> in an empty command line
   " does not move the cursor
   if !exists('+incsearch')
@@ -799,7 +795,7 @@ func Test_incsearch_vimgrep_dump()
 endfunc
 
 func Test_keep_last_search_pattern()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -821,7 +817,7 @@ func Test_keep_last_search_pattern()
 endfunc
 
 func Test_word_under_cursor_after_match()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -841,7 +837,7 @@ func Test_word_under_cursor_after_match()
 endfunc
 
 func Test_subst_word_under_cursor()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -883,7 +879,7 @@ func Test_incsearch_with_change()
 endfunc
 
 func Test_incsearch_cmdline_modifier()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -961,7 +957,7 @@ func Test_incsearch_search_dump()
 endfunc
 
 func Test_incsearch_substitute()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif
@@ -983,7 +979,7 @@ func Test_incsearch_substitute()
 endfunc
 
 func Test_incsearch_substitute_long_line()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   new
   call test_override("char_avail", 1)
   set incsearch
@@ -1105,7 +1101,7 @@ func Test_one_error_msg()
 endfunc
 
 func Test_incsearch_add_char_under_cursor()
-  throw 'skipped: Nvim does not support test_override()'
+  CheckFunction test_override
   if !exists('+incsearch')
     return
   endif

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -2,6 +2,7 @@
 
 source shared.vim
 source screendump.vim
+source check.vim
 
 func Test_search_cmdline()
   " See test/functional/legacy/search_spec.lua
@@ -1190,6 +1191,42 @@ func Test_search_smartcase_utf8()
   set ignorecase& smartcase&
   let &encoding = save_enc
   close!
+endfunc
+
+func Test_zzzz_incsearch_highlighting_newline()
+  CheckRunVimInTerminal
+  CheckOption incsearch
+  CheckScreendump
+  new
+  call test_override("char_avail", 1)
+
+  let commands =<< trim [CODE]
+    set incsearch nohls
+    call setline(1, ['test', 'xxx'])
+  [CODE]
+  call writefile(commands, 'Xincsearch_nl')
+  let buf = RunVimInTerminal('-S Xincsearch_nl', {'rows': 5, 'cols': 10})
+  " Need to send one key at a time to force a redraw
+  call term_sendkeys(buf, '/test')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_newline1', {})
+  call term_sendkeys(buf, '\n')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_newline2', {})
+  call term_sendkeys(buf, 'x')
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_newline3', {})
+  call term_sendkeys(buf, 'x')
+  call VerifyScreenDump(buf, 'Test_incsearch_newline4', {})
+  call term_sendkeys(buf, "\<CR>")
+  sleep 100m
+  call VerifyScreenDump(buf, 'Test_incsearch_newline5', {})
+  call StopVimInTerminal(buf)
+
+  " clean up
+  call delete('Xincsearch_nl')
+  call test_override("char_avail", 0)
+  bw
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -1,8 +1,7 @@
 " Test for signs
 
-if !has('signs')
-  finish
-endif
+source check.vim
+CheckFeature signs
 
 source screendump.vim
 
@@ -1541,7 +1540,7 @@ endfunc
 
 " Tests for memory allocation failures in sign functions
 func Test_sign_memfailures()
-  throw 'skipped: Nvim does not support test_alloc_fail()'
+  CheckFunction test_alloc_fail
   call writefile(repeat(["Sun is shining"], 30), "Xsign")
   edit Xsign
 

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -862,6 +862,34 @@ func Test_x_arg()
   call delete('Xtest_x_arg')
 endfunc
 
+" Test for --not-a-term avoiding escape codes.
+func Test_not_a_term()
+  CheckUnix
+  CheckNotGui
+
+  if &shellredir =~ '%s'
+    let redir = printf(&shellredir,  'Xvimout')
+  else
+    let redir = &shellredir .. ' Xvimout'
+  endif
+
+  " Without --not-a-term there are a few escape sequences.
+  " This will take 2 seconds because of the missing --not-a-term
+  let cmd = GetVimProg() .. ' --cmd quit ' .. redir
+  exe "silent !" . cmd
+  " call assert_match("\<Esc>", readfile('Xvimout')->join())
+  call assert_match("\<Esc>", join(readfile('Xvimout')))
+  call delete('Xvimout')
+
+  " With --not-a-term there are no escape sequences.
+  let cmd = GetVimProg() .. ' --not-a-term --cmd quit ' .. redir
+  exe "silent !" . cmd
+  " call assert_notmatch("\<Esc>", readfile('Xvimout')->join())
+  call assert_notmatch("\<Esc>", join(readfile('Xvimout')))
+  call delete('Xvimout')
+endfunc
+
+
 " Test starting vim with various names: vim, ex, view, evim, etc.
 func Test_progname()
   CheckUnix

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -93,7 +93,6 @@ function! Test_system_exmode()
 endfunc
 
 func Test_system_with_shell_quote()
-  throw 'skipped: enable after porting method patches'
   CheckMSWindows
 
   call mkdir('Xdir with spaces', 'p')
@@ -122,7 +121,8 @@ func Test_system_with_shell_quote()
         let msg = printf('shell=%s shellxquote=%s', &shell, &shellxquote)
 
         try
-          let out = 'echo 123'->system()
+          " let out = 'echo 123'->system()
+          let out = system('echo 123')
         catch
           call assert_report(printf('%s: %s', msg, v:exception))
           continue

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -317,8 +317,8 @@ endfunc
 " Test that the garbage collector isn't triggered if a timer callback invokes
 " vgetc().
 func Test_nocatch_garbage_collect()
-  " skipped: Nvim does not support test_garbagecollect_soon(), test_override()
-  return
+  CheckFunction test_garbagecollect_soon
+  CheckFunction test_override
   " 'uptimetime. must be bigger than the timer timeout
   set ut=200
   call test_garbagecollect_soon()

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -3,6 +3,8 @@
 " undo-able pieces.  Do that by setting 'undolevels'.
 " Also tests :earlier and :later.
 
+source check.vim
+
 func Test_undotree()
   new
 
@@ -135,7 +137,7 @@ func BackOne(expected)
 endfunc
 
 func Test_undo_del_chars()
-  throw 'skipped: Nvim does not support test_settime()'
+  CheckFunction test_settime
 
   " Setup a buffer without creating undo entries
   new
@@ -330,7 +332,7 @@ func Test_insert_expr()
 endfunc
 
 func Test_undofile_earlier()
-  throw 'skipped: Nvim does not support test_settime()'
+  CheckFunction test_settime
 
   let t0 = localtime() - 43200
   call test_settime(t0)


### PR DESCRIPTION
Test failure on test_regexp_latin.vim suggests missing regexp patches. The test was executed with `set encoding=utf-8` but nvim shouldn't crash in ASAN build.