### PR TITLE
lua: track reference ownership with ASAN when present

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -222,11 +222,7 @@ Boolean nvim_buf_attach(uint64_t channel_id,
   return buf_updates_register(buf, channel_id, cb, send_buffer);
 
 error:
-  // TODO(bfredl): ASAN build should check that the ref table is empty?
-  api_free_luaref(cb.on_lines);
-  api_free_luaref(cb.on_bytes);
-  api_free_luaref(cb.on_changedtick);
-  api_free_luaref(cb.on_detach);
+  buffer_update_callbacks_free(cb);
   return false;
 }
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1708,33 +1708,6 @@ const char *describe_ns(NS ns_id)
   return "(UNKNOWN PLUGIN)";
 }
 
-DecorProvider *get_provider(NS ns_id, bool force)
-{
-  ssize_t i;
-  for (i = 0; i < (ssize_t)kv_size(decor_providers); i++) {
-    DecorProvider *item = &kv_A(decor_providers, i);
-    if (item->ns_id == ns_id) {
-      return item;
-    } else if (item->ns_id > ns_id) {
-      break;
-    }
-  }
-
-  if (!force) {
-    return NULL;
-  }
-
-  for (ssize_t j = (ssize_t)kv_size(decor_providers)-1; j >= i; j++) {
-    // allocates if needed:
-    (void)kv_a(decor_providers, (size_t)j+1);
-    kv_A(decor_providers, (size_t)j+1) = kv_A(decor_providers, j);
-  }
-  DecorProvider *item = &kv_a(decor_providers, (size_t)i);
-  *item = DECORATION_PROVIDER_INIT(ns_id);
-
-  return item;
-}
-
 static bool parse_float_anchor(String anchor, FloatAnchor *out)
 {
   if (anchor.size == 0) {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2708,6 +2708,7 @@ Dictionary nvim__stats(void)
   Dictionary rv = ARRAY_DICT_INIT;
   PUT(rv, "fsync", INTEGER_OBJ(g_stats.fsync));
   PUT(rv, "redraw", INTEGER_OBJ(g_stats.redraw));
+  PUT(rv, "lua_refcount", INTEGER_OBJ(nlua_refcount));
   return rv;
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2881,19 +2881,6 @@ void nvim__screenshot(String path)
   ui_call_screenshot(path);
 }
 
-static void clear_provider(DecorProvider *p)
-{
-  if (p == NULL) {
-    return;
-  }
-  NLUA_CLEAR_REF(p->redraw_start);
-  NLUA_CLEAR_REF(p->redraw_buf);
-  NLUA_CLEAR_REF(p->redraw_win);
-  NLUA_CLEAR_REF(p->redraw_line);
-  NLUA_CLEAR_REF(p->redraw_end);
-  p->active = false;
-}
-
 /// Set or change decoration provider for a namespace
 ///
 /// This is a very general purpose interface for having lua callbacks
@@ -2938,8 +2925,8 @@ void nvim_set_decoration_provider(Integer ns_id, DictionaryOf(LuaRef) opts,
                                   Error *err)
   FUNC_API_SINCE(7) FUNC_API_LUA_ONLY
 {
-  DecorProvider *p = get_provider((NS)ns_id, true);
-  clear_provider(p);
+  DecorProvider *p = get_decor_provider((NS)ns_id, true);
+  decor_provider_clear(p);
 
   // regardless of what happens, it seems good idea to redraw
   redraw_all_later(NOT_VALID);  // TODO(bfredl): too soon?
@@ -2982,5 +2969,5 @@ void nvim_set_decoration_provider(Integer ns_id, DictionaryOf(LuaRef) opts,
   p->active = true;
   return;
 error:
-  clear_provider(p);
+  decor_provider_clear(p);
 }

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -176,7 +176,7 @@ void buf_updates_unload(buf_T *buf, bool can_reload)
     if (keep) {
       kv_A(buf->update_callbacks, j++) = kv_A(buf->update_callbacks, i);
     } else {
-      free_update_callbacks(cb);
+      buffer_update_callbacks_free(cb);
     }
   }
   kv_size(buf->update_callbacks) = j;
@@ -290,7 +290,7 @@ void buf_updates_send_changes(buf_T *buf,
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
-        free_update_callbacks(cb);
+        buffer_update_callbacks_free(cb);
         keep = false;
       }
       api_free_object(res);
@@ -342,7 +342,7 @@ void buf_updates_send_splice(
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
-        free_update_callbacks(cb);
+        buffer_update_callbacks_free(cb);
         keep = false;
       }
     }
@@ -378,7 +378,7 @@ void buf_updates_changedtick(buf_T *buf)
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
-        free_update_callbacks(cb);
+        buffer_update_callbacks_free(cb);
         keep = false;
       }
       api_free_object(res);
@@ -406,8 +406,11 @@ void buf_updates_changedtick_single(buf_T *buf, uint64_t channel_id)
     rpc_send_event(channel_id, "nvim_buf_changedtick_event", args);
 }
 
-static void free_update_callbacks(BufUpdateCallbacks cb)
+void buffer_update_callbacks_free(BufUpdateCallbacks cb)
 {
   api_free_luaref(cb.on_lines);
+  api_free_luaref(cb.on_bytes);
   api_free_luaref(cb.on_changedtick);
+  api_free_luaref(cb.on_reload);
+  api_free_luaref(cb.on_detach);
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6263,6 +6263,7 @@ void common_function(typval_T *argvars, typval_T *rettv,
     // function(dict.MyFunc, [arg])
     arg_pt = argvars[0].vval.v_partial;
     s = partial_name(arg_pt);
+    // TODO(bfredl): do the entire nlua_is_table_from_lua dance
   } else {
     // function('MyFunc', [arg], dict)
     s = (char_u *)tv_get_string(&argvars[0]);
@@ -7362,7 +7363,6 @@ bool callback_from_typval(Callback *const callback, typval_T *const arg)
     char_u *name = nlua_register_table_as_callable(arg);
 
     if (name != NULL) {
-      func_ref(name);
       callback->data.funcref = vim_strsave(name);
       callback->type = kCallbackFuncref;
     } else {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -810,6 +810,7 @@ static void f_call(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
+  bool owned = false;
   char_u      *func;
   partial_T   *partial = NULL;
   dict_T      *selfdict = NULL;
@@ -820,6 +821,7 @@ static void f_call(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     func = partial_name(partial);
   } else if (nlua_is_table_from_lua(&argvars[0])) {
     func = nlua_register_table_as_callable(&argvars[0]);
+    owned = true;
   } else {
     func = (char_u *)tv_get_string(&argvars[0]);
   }
@@ -837,6 +839,9 @@ static void f_call(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   func_call(func, &argvars[1], partial, selfdict, rettv);
+  if (owned) {
+    func_unref(func);
+  }
 }
 
 /*

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -219,6 +219,7 @@ list_T *tv_list_alloc(const ptrdiff_t len)
   list->lv_used_next = gc_first_list;
   gc_first_list = list;
   list_log(list, NULL, (void *)(uintptr_t)len, "alloc");
+  list->lua_table_ref = LUA_NOREF;
   return list;
 }
 
@@ -302,7 +303,7 @@ void tv_list_free_list(list_T *const l)
   }
   list_log(l, NULL, NULL, "freelist");
 
-  nlua_free_typval_list(l);
+  NLUA_CLEAR_REF(l->lua_table_ref);
   xfree(l);
 }
 
@@ -1404,6 +1405,8 @@ dict_T *tv_dict_alloc(void)
   d->dv_copyID = 0;
   QUEUE_INIT(&d->watchers);
 
+  d->lua_table_ref = LUA_NOREF;
+
   return d;
 }
 
@@ -1454,7 +1457,7 @@ void tv_dict_free_dict(dict_T *const d)
     d->dv_used_next->dv_used_prev = d->dv_used_prev;
   }
 
-  nlua_free_typval_dict(d);
+  NLUA_CLEAR_REF(d->lua_table_ref);
   xfree(d);
 }
 

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -151,7 +151,7 @@ int hl_get_syn_attr(int ns_id, int idx, HlAttrs at_en)
 
 void ns_hl_def(NS ns_id, int hl_id, HlAttrs attrs, int link_id)
 {
-  DecorProvider *p = get_provider(ns_id, true);
+  DecorProvider *p = get_decor_provider(ns_id, true);
   if ((attrs.rgb_ae_attr & HL_DEFAULT)
       && map_has(ColorKey, ColorItem)(ns_hl, ColorKey(ns_id, hl_id))) {
     return;
@@ -175,7 +175,7 @@ int ns_get_hl(NS ns_id, int hl_id, bool link, bool nodefault)
     ns_id = ns_hl_active;
   }
 
-  DecorProvider *p = get_provider(ns_id, true);
+  DecorProvider *p = get_decor_provider(ns_id, true);
   ColorItem it = map_get(ColorKey, ColorItem)(ns_hl, ColorKey(ns_id, hl_id));
   // TODO(bfredl): map_ref true even this?
   bool valid_cache = it.version >= p->hl_valid;

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -400,7 +400,6 @@ nlua_pop_typval_table_processing_end:
       case LUA_TFUNCTION: {
         LuaCFunctionState *state = xmalloc(sizeof(LuaCFunctionState));
         state->lua_callable.func_ref = nlua_ref(lstate, -1);
-        state->lua_callable.table_ref = LUA_NOREF;
 
         char_u *name = register_cfunc(
             &nlua_CFunction_func_call,
@@ -412,6 +411,7 @@ nlua_pop_typval_table_processing_end:
         break;
       }
       case LUA_TUSERDATA: {
+        // TODO(bfredl): check mt.__call and convert to function?
         nlua_pushref(lstate, nlua_nil_ref);
         bool is_nil = lua_rawequal(lstate, -2, -1);
         lua_pop(lstate, 1);

--- a/src/nvim/lua/converter.h
+++ b/src/nvim/lua/converter.h
@@ -11,7 +11,6 @@
 
 typedef struct {
   LuaRef func_ref;
-  LuaRef table_ref;
 } LuaCallable;
 
 typedef struct {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -594,6 +594,10 @@ void nlua_free_all_mem(void)
   if (!global_lstate) {
     return;
   }
+  lua_State *lstate = global_lstate;
+
+  nlua_unref(lstate, nlua_nil_ref);
+  nlua_unref(lstate, nlua_empty_dict_ref);
 
 #ifdef NLUA_TRACK_REFS
   if (nlua_refcount) {
@@ -604,7 +608,7 @@ void nlua_free_all_mem(void)
 #endif
 
   nlua_refcount = 0;
-  lua_close(global_lstate);
+  lua_close(lstate);
 }
 
 static void nlua_print_event(void **argv)

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -931,19 +931,11 @@ void nlua_pushref(lua_State *lstate, LuaRef ref)
   lua_rawgeti(lstate, LUA_REGISTRYINDEX, ref);
 }
 
+
 /// Gets a new reference to an object stored at original_ref
 ///
 /// NOTE: It does not copy the value, it creates a new ref to the lua object.
 ///       Leaves the stack unchanged.
-LuaRef nlua_newref(lua_State *lstate, LuaRef original_ref)
-{
-  nlua_pushref(lstate, original_ref);
-  LuaRef new_ref = nlua_ref(lstate, -1);
-  lua_pop(lstate, 1);
-
-  return new_ref;
-}
-
 LuaRef api_new_luaref(LuaRef original_ref)
 {
   if (original_ref == LUA_NOREF) {
@@ -951,7 +943,10 @@ LuaRef api_new_luaref(LuaRef original_ref)
   }
 
   lua_State *const lstate = nlua_enter();
-  return nlua_newref(lstate, original_ref);
+  nlua_pushref(lstate, original_ref);
+  LuaRef new_ref = nlua_ref(lstate, -1);
+  lua_pop(lstate, 1);
+  return new_ref;
 }
 
 
@@ -1061,25 +1056,13 @@ int typval_exec_lua_callable(
     typval_T *rettv
 )
 {
-  int offset = 0;
   LuaRef cb = lua_cb.func_ref;
-
-  if (cb == LUA_NOREF) {
-    // This shouldn't happen.
-    luaL_error(lstate, "Invalid function passed to VimL");
-    return ERROR_OTHER;
-  }
 
   nlua_pushref(lstate, cb);
 
-  if (lua_cb.table_ref != LUA_NOREF) {
-    offset += 1;
-    nlua_pushref(lstate, lua_cb.table_ref);
-  }
-
   PUSH_ALL_TYPVALS(lstate, argvars, argcount, false);
 
-  if (lua_pcall(lstate, argcount + offset, 1, 0)) {
+  if (lua_pcall(lstate, argcount, 1, 0)) {
     nlua_print(lstate);
     return ERROR_OTHER;
   }
@@ -1546,6 +1529,8 @@ static int regex_match_line(lua_State *lstate)
   return nret;
 }
 
+// Required functions for lua c functions as VimL callbacks
+
 int nlua_CFunction_func_call(
     int argcount,
     typval_T *argvars,
@@ -1555,53 +1540,40 @@ int nlua_CFunction_func_call(
     lua_State *const lstate = nlua_enter();
     LuaCFunctionState *funcstate = (LuaCFunctionState *)state;
 
-    return typval_exec_lua_callable(
-        lstate,
-        funcstate->lua_callable,
-        argcount,
-        argvars,
-        rettv);
+    return typval_exec_lua_callable(lstate, funcstate->lua_callable,
+                                    argcount, argvars, rettv);
 }
-/// Required functions for lua c functions as VimL callbacks
+
 void nlua_CFunction_func_free(void *state)
 {
     lua_State *const lstate = nlua_enter();
     LuaCFunctionState *funcstate = (LuaCFunctionState *)state;
 
     nlua_unref(lstate, funcstate->lua_callable.func_ref);
-    nlua_unref(lstate, funcstate->lua_callable.table_ref);
     xfree(funcstate);
 }
 
 bool nlua_is_table_from_lua(typval_T *const arg)
 {
-  if (arg->v_type != VAR_DICT && arg->v_type != VAR_LIST) {
+  if (arg->v_type == VAR_DICT) {
+    return arg->vval.v_dict->lua_table_ref != LUA_NOREF;
+  } else if (arg->v_type == VAR_LIST) {
+    return arg->vval.v_list->lua_table_ref != LUA_NOREF;
+  } else {
     return false;
   }
-
-  if (arg->v_type == VAR_DICT) {
-    return arg->vval.v_dict->lua_table_ref > 0
-      && arg->vval.v_dict->lua_table_ref != LUA_NOREF;
-  } else if (arg->v_type == VAR_LIST) {
-    return arg->vval.v_list->lua_table_ref > 0
-      && arg->vval.v_list->lua_table_ref != LUA_NOREF;
-  }
-
-  return false;
 }
 
 char_u *nlua_register_table_as_callable(typval_T *const arg)
 {
-  if (!nlua_is_table_from_lua(arg)) {
-    return NULL;
-  }
-
-  LuaRef table_ref;
+  LuaRef table_ref = LUA_NOREF;
   if (arg->v_type == VAR_DICT) {
     table_ref = arg->vval.v_dict->lua_table_ref;
   } else if (arg->v_type == VAR_LIST) {
     table_ref = arg->vval.v_list->lua_table_ref;
-  } else {
+  }
+
+  if (table_ref == LUA_NOREF) {
     return NULL;
   }
 
@@ -1611,53 +1583,32 @@ char_u *nlua_register_table_as_callable(typval_T *const arg)
   int top = lua_gettop(lstate);
 #endif
 
-  nlua_pushref(lstate, table_ref);
+  nlua_pushref(lstate, table_ref);  // [table]
   if (!lua_getmetatable(lstate, -1)) {
+    lua_pop(lstate, 1);
+    assert(top == lua_gettop(lstate));
     return NULL;
-  }
+  }  // [table, mt]
 
-  lua_getfield(lstate, -1, "__call");
+  lua_getfield(lstate, -1, "__call");  // [table, mt, mt.__call]
   if (!lua_isfunction(lstate, -1)) {
+    lua_pop(lstate, 3);
+    assert(top == lua_gettop(lstate));
     return NULL;
   }
-
-  LuaRef new_table_ref = nlua_newref(lstate, table_ref);
+  lua_pop(lstate, 2);  // [table]
 
   LuaCFunctionState *state = xmalloc(sizeof(LuaCFunctionState));
   state->lua_callable.func_ref = nlua_ref(lstate, -1);
-  state->lua_callable.table_ref = new_table_ref;
 
-  char_u *name = register_cfunc(
-      &nlua_CFunction_func_call,
-      &nlua_CFunction_func_free,
-      state);
+  char_u *name = register_cfunc(&nlua_CFunction_func_call,
+                                &nlua_CFunction_func_free, state);
 
 
-  lua_pop(lstate, 3);
+  lua_pop(lstate, 1);  // []
   assert(top == lua_gettop(lstate));
 
   return name;
-}
-
-/// Helper function to free a list_T
-void nlua_free_typval_list(list_T *const l)
-{
-  if (l->lua_table_ref != LUA_NOREF && l->lua_table_ref > 0) {
-    lua_State *const lstate = nlua_enter();
-    nlua_unref(lstate, l->lua_table_ref);
-    l->lua_table_ref = LUA_NOREF;
-  }
-}
-
-
-/// Helper function to free a dict_T
-void nlua_free_typval_dict(dict_T *const d)
-{
-  if (d->lua_table_ref != LUA_NOREF && d->lua_table_ref > 0) {
-    lua_State *const lstate = nlua_enter();
-    nlua_unref(lstate, d->lua_table_ref);
-    d->lua_table_ref = LUA_NOREF;
-  }
 }
 
 void nlua_execute_log_keystroke(int c)

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -16,6 +16,8 @@ void nlua_add_api_functions(lua_State *lstate) REAL_FATTR_NONNULL_ALL;
 EXTERN LuaRef nlua_nil_ref INIT(= LUA_NOREF);
 EXTERN LuaRef nlua_empty_dict_ref INIT(= LUA_NOREF);
 
+EXTERN int nlua_refcount INIT(= 0);
+
 #define set_api_error(s, err) \
     do { \
       Error *err_ = (err); \

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -20,6 +20,7 @@
 #include "nvim/sign.h"
 #include "nvim/api/vim.h"
 #include "nvim/lua/executor.h"
+#include "nvim/decoration.h"
 
 #ifdef UNIT_TESTING
 # define malloc(size) mem_malloc(size)
@@ -696,6 +697,8 @@ void free_all_mem(void)
   list_free_log();
 
   check_quickfix_busy();
+
+  decor_free_all_mem();
 
   nlua_free_all_mem();
 }

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -19,6 +19,7 @@
 #include "nvim/ui.h"
 #include "nvim/sign.h"
 #include "nvim/api/vim.h"
+#include "nvim/lua/executor.h"
 
 #ifdef UNIT_TESTING
 # define malloc(size) mem_malloc(size)
@@ -695,6 +696,8 @@ void free_all_mem(void)
   list_free_log();
 
   check_quickfix_busy();
+
+  nlua_free_all_mem();
 }
 
 #endif


### PR DESCRIPTION
- explicitly mark nlua_ref calls with a marker allocation to give ASAN tracebacks for leaked references (and double unrefs become double free:s)
- with `EXIT_FREE` call `lua_close` to invoke finalizers in global state (should reduce LSAN noise)

To help debug/fix issues like #14216 