### PR TITLE
Allow `codeLensProvider` to be false

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -978,7 +978,7 @@ function protocol.resolve_capabilities(server_capabilities)
     general_properties.rename = true
   end
 
-  if server_capabilities.codeLensProvider == nil then
+  if server_capabilities.codeLensProvider == nil or server_capabilities.codeLensProvider == false then
     general_properties.code_lens = false
     general_properties.code_lens_resolve = false
   elseif type(server_capabilities.codeLensProvider) == 'table' then


### PR DESCRIPTION
There are some broken lsp_server (I'm talking mainly about Godot) that reports  `codeLensProvider` as `false`. That goes against the LSP but adding this workaround does not cause any error and fixes the issue.