### PR TITLE
vim-patch:8.1.0306: plural messages are not translated properly

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1038,14 +1038,14 @@ do_bufdel(
       errormsg = IObuff;
     } else if (deleted >= p_report) {
       if (command == DOBUF_UNLOAD) {
-        smsg(NGETTEXT("%d buffer unloaded", "%d buffers unloaded", deleted),
-             deleted);
+        smsg(NGETTEXT("%d buffer unloaded", "%d buffers unloaded",
+                      (unsigned long)deleted), deleted);
       } else if (command == DOBUF_DEL) {
-        smsg(NGETTEXT("%d buffer deleted", "%d buffers deleted", deleted),
-             deleted);
+        smsg(NGETTEXT("%d buffer deleted", "%d buffers deleted",
+                      (unsigned long)deleted), deleted);
       } else {
-        smsg(NGETTEXT("%d buffer wiped out", "%d buffers wiped out", deleted),
-             deleted);
+        smsg(NGETTEXT("%d buffer wiped out", "%d buffers wiped out",
+                      (unsigned long)deleted), deleted);
       }
     }
   }
@@ -3160,8 +3160,8 @@ fileinfo(
     // Current line and column are already on the screen -- webb
     vim_snprintf_add((char *)buffer, IOSIZE,
                      NGETTEXT("%ld line --%d%%--", "%ld lines --%d%%--",
-                              curbuf->b_ml.ml_line_count),
-                     (long)curbuf->b_ml.ml_line_count, n);
+                              (u_long)curbuf->b_ml.ml_line_count),
+                     (unsigned long)curbuf->b_ml.ml_line_count, n);
   } else {
     vim_snprintf_add((char *)buffer, IOSIZE,
         _("line %" PRId64 " of %" PRId64 " --%d%%-- col "),

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3160,7 +3160,7 @@ fileinfo(
     // Current line and column are already on the screen -- webb
     vim_snprintf_add((char *)buffer, IOSIZE,
                      NGETTEXT("%ld line --%d%%--", "%ld lines --%d%%--",
-                              (u_long)curbuf->b_ml.ml_line_count),
+                              (unsigned long)curbuf->b_ml.ml_line_count),
                      (unsigned long)curbuf->b_ml.ml_line_count, n);
   } else {
     vim_snprintf_add((char *)buffer, IOSIZE,

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1038,23 +1038,14 @@ do_bufdel(
       errormsg = IObuff;
     } else if (deleted >= p_report) {
       if (command == DOBUF_UNLOAD) {
-        if (deleted == 1) {
-          MSG(_("1 buffer unloaded"));
-        } else {
-          smsg(_("%d buffers unloaded"), deleted);
-        }
+        smsg(NGETTEXT("%d buffer unloaded", "%d buffers unloaded", deleted),
+             deleted);
       } else if (command == DOBUF_DEL) {
-        if (deleted == 1) {
-          MSG(_("1 buffer deleted"));
-        } else {
-          smsg(_("%d buffers deleted"), deleted);
-        }
+        smsg(NGETTEXT("%d buffer deleted", "%d buffers deleted", deleted),
+             deleted);
       } else {
-        if (deleted == 1) {
-          MSG(_("1 buffer wiped out"));
-        } else {
-          smsg(_("%d buffers wiped out"), deleted);
-        }
+        smsg(NGETTEXT("%d buffer wiped out", "%d buffers wiped out", deleted),
+             deleted);
       }
     }
   }
@@ -3167,12 +3158,10 @@ fileinfo(
     vim_snprintf_add((char *)buffer, IOSIZE, "%s", _(no_lines_msg));
   } else if (p_ru) {
     // Current line and column are already on the screen -- webb
-    if (curbuf->b_ml.ml_line_count == 1) {
-      vim_snprintf_add((char *)buffer, IOSIZE, _("1 line --%d%%--"), n);
-    } else {
-      vim_snprintf_add((char *)buffer, IOSIZE, _("%" PRId64 " lines --%d%%--"),
-                       (int64_t)curbuf->b_ml.ml_line_count, n);
-    }
+    vim_snprintf_add((char *)buffer, IOSIZE,
+                     NGETTEXT("%ld line --%d%%--", "%ld lines --%d%%--",
+                              curbuf->b_ml.ml_line_count),
+                     (long)curbuf->b_ml.ml_line_count, n);
   } else {
     vim_snprintf_add((char *)buffer, IOSIZE,
         _("line %" PRId64 " of %" PRId64 " --%d%%-- col "),

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5031,8 +5031,8 @@ check_more(
         }
         return FAIL;
       }
-      EMSGN(NGETTEXT("E173: %lld more file to edit",
-                     "E173: %lld more files to edit", (int64_t)n), n);
+      EMSGN(NGETTEXT("E173: %"PRIu64" more file to edit",
+                     "E173: %"PRIu64" more files to edit", n), n);
       quitmore = 2;                 // next try to quit is allowed
     }
     return FAIL;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5023,21 +5023,17 @@ check_more(
       if ((p_confirm || cmdmod.confirm) && curbuf->b_fname != NULL) {
         char_u buff[DIALOG_MSG_SIZE];
 
-        if (n == 1)
-          STRLCPY(buff, _("1 more file to edit.  Quit anyway?"),
-              DIALOG_MSG_SIZE);
-        else
-          vim_snprintf((char *)buff, DIALOG_MSG_SIZE,
-              _("%d more files to edit.  Quit anyway?"), n);
-        if (vim_dialog_yesno(VIM_QUESTION, NULL, buff, 1) == VIM_YES)
+        vim_snprintf((char *)buff, DIALOG_MSG_SIZE,
+                     NGETTEXT("%d more file to edit.  Quit anyway?",
+                              "%d more files to edit.  Quit anyway?", n), n);
+        if (vim_dialog_yesno(VIM_QUESTION, NULL, buff, 1) == VIM_YES) {
           return OK;
+        }
         return FAIL;
       }
-      if (n == 1)
-        EMSG(_("E173: 1 more file to edit"));
-      else
-        EMSGN(_("E173: %" PRId64 " more files to edit"), n);
-      quitmore = 2;                 /* next try to quit is allowed */
+      EMSGN(NGETTEXT("E173: %lld more file to edit",
+                     "E173: %lld more files to edit", n), n);
+      quitmore = 2;                 // next try to quit is allowed
     }
     return FAIL;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5032,7 +5032,7 @@ check_more(
         return FAIL;
       }
       EMSGN(NGETTEXT("E173: %lld more file to edit",
-                     "E173: %lld more files to edit", n), n);
+                     "E173: %lld more files to edit", (int64_t)n), n);
       quitmore = 2;                 // next try to quit is allowed
     }
     return FAIL;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3744,18 +3744,13 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
   if (shortmess(SHM_LINES)) {
      sprintf((char *)p, "%" PRId64 "L, %" PRId64 "C",
              (int64_t)lnum, (int64_t)nchars);
-  }
-  else {
-    if (lnum == 1)
-      STRCPY(p, _("1 line, "));
-    else
-      sprintf((char *)p, _("%" PRId64 " lines, "), (int64_t)lnum);
+  } else {
+    snprintf((char *)p, NGETTEXT("%ld line, ", "%ld lines, ", lnum),
+             "%ld", lnum);
     p += STRLEN(p);
-    if (nchars == 1)
-      STRCPY(p, _("1 character"));
-    else {
-      sprintf((char *)p, _("%" PRId64 " characters"), (int64_t)nchars);
-    }
+    vim_snprintf((char *)p, IOSIZE - (p - IObuff),
+                 NGETTEXT("%lld character", "%lld characters", nchars),
+                 (int64_t)nchars);
   }
 }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3749,8 +3749,8 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
              "%ld", lnum);
     p += STRLEN(p);
     vim_snprintf((char *)p, IOSIZE - (p - IObuff),
-                 NGETTEXT("%"PRIu64" character", "%"PRIu64" characters", nchars),
-                 (int64_t)nchars);
+                 NGETTEXT("%"PRIu64" character", "%"PRIu64" characters",
+                          nchars), (int64_t)nchars);
   }
 }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3749,7 +3749,7 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
              "%ld", lnum);
     p += STRLEN(p);
     vim_snprintf((char *)p, IOSIZE - (p - IObuff),
-                 NGETTEXT("%lld character", "%lld characters", nchars),
+                 NGETTEXT("%"PRIu64" character", "%"PRIu64" characters", nchars),
                  (int64_t)nchars);
   }
 }

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -826,10 +826,14 @@ void msgmore(long n)
   if (pn > p_report) {
     if (n > 0) {
       vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
-                   NGETTEXT("%ld more line", "%ld more lines", pn), pn);
+                   NGETTEXT("%ld more line", "%ld more lines",
+                            (unsigned long)pn),
+                   pn);
     } else {
       vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
-                   NGETTEXT("%ld line less", "%ld fewer lines", pn), pn);
+                   NGETTEXT("%ld line less", "%ld fewer lines",
+                            (unsigned long)pn),
+                   pn);
     }
     if (got_int) {
       xstrlcat((char *)msg_buf, _(" (Interrupted)"), MSG_BUF_LEN);

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -824,18 +824,12 @@ void msgmore(long n)
     pn = -n;
 
   if (pn > p_report) {
-    if (pn == 1) {
-      if (n > 0)
-        STRLCPY(msg_buf, _("1 more line"), MSG_BUF_LEN);
-      else
-        STRLCPY(msg_buf, _("1 line less"), MSG_BUF_LEN);
+    if (n > 0) {
+      vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
+                   NGETTEXT("%ld more line", "%ld more lines", pn), pn);
     } else {
-      if (n > 0)
-        vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
-            _("%" PRId64 " more lines"), (int64_t)pn);
-      else
-        vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
-            _("%" PRId64 " fewer lines"), (int64_t)pn);
+      vim_snprintf((char *)msg_buf, MSG_BUF_LEN,
+                   NGETTEXT("%ld line less", "%ld fewer lines", pn), pn);
     }
     if (got_int) {
       xstrlcat((char *)msg_buf, _(" (Interrupted)"), MSG_BUF_LEN);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -206,7 +206,6 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
 {
   long i;
   int first_char;
-  char_u          *s;
   int block_col = 0;
 
   if (u_save((linenr_T)(oap->start.lnum - 1),
@@ -244,23 +243,22 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
   foldOpenCursor();
 
   if (oap->line_count > p_report) {
-    if (oap->op_type == OP_RSHIFT)
-      s = (char_u *)">";
-    else
-      s = (char_u *)"<";
-    if (oap->line_count == 1) {
-      if (amount == 1)
-        sprintf((char *)IObuff, _("1 line %sed 1 time"), s);
-      else
-        sprintf((char *)IObuff, _("1 line %sed %d times"), s, amount);
+    char *op;
+    char *msg_line_single;
+    char *msg_line_plural;
+
+    if (oap->op_type == OP_RSHIFT) {
+      op = ">";
     } else {
-      if (amount == 1)
-        sprintf((char *)IObuff, _("%" PRId64 " lines %sed 1 time"),
-            (int64_t)oap->line_count, s);
-      else
-        sprintf((char *)IObuff, _("%" PRId64 " lines %sed %d times"),
-            (int64_t)oap->line_count, s, amount);
+      op = "<";
     }
+    msg_line_single = NGETTEXT("%ld line %sed %d time",
+                               "%ld line %sed %d times", amount);
+    msg_line_plural = NGETTEXT("%ld lines %sed %d time",
+                               "%ld lines %sed %d times", amount);
+    vim_snprintf((char *)IObuff, IOSIZE,
+                 NGETTEXT(msg_line_single, msg_line_plural, oap->line_count),
+                 oap->line_count, op, amount);
     msg_attr_keep(IObuff, 0, true, false);
   }
 
@@ -679,10 +677,8 @@ void op_reindent(oparg_T *oap, Indenter how)
 
   if (oap->line_count > p_report) {
     i = oap->line_count - (i + 1);
-    if (i == 1)
-      MSG(_("1 line indented "));
-    else
-      smsg(_("%" PRId64 " lines indented "), (int64_t)i);
+    smsg((char_u *)NGETTEXT("%ld line indented ",
+                            "%ld lines indented ", i), i);
   }
   /* set '[ and '] marks */
   curbuf->b_op_start = oap->start;
@@ -2038,10 +2034,8 @@ void op_tilde(oparg_T *oap)
   curbuf->b_op_end = oap->end;
 
   if (oap->line_count > p_report) {
-    if (oap->line_count == 1)
-      MSG(_("1 line changed"));
-    else
-      smsg(_("%" PRId64 " lines changed"), (int64_t)oap->line_count);
+    smsg((char_u *)NGETTEXT("%ld line changed", "%ld lines changed",
+                            oap->line_count), oap->line_count);
   }
 }
 
@@ -2684,17 +2678,14 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
 
       // redisplay now, so message is not deleted
       update_topline_redraw();
-      if (yanklines == 1) {
-        if (yank_type == kMTBlockWise) {
-          smsg(_("block of 1 line yanked%s"), namebuf);
-        } else {
-          smsg(_("1 line yanked%s"), namebuf);
-        }
-      } else if (yank_type == kMTBlockWise) {
-        smsg(_("block of %" PRId64 " lines yanked%s"),
-             (int64_t)yanklines, namebuf);
+      if (yank_type == kMTBlockWise) {
+        smsg((char_u *)NGETTEXT("block of %ld line yanked%s",
+                                "block of %ld lines yanked%s", yanklines),
+             yanklines, namebuf);
       } else {
-        smsg(_("%" PRId64 " lines yanked%s"), (int64_t)yanklines, namebuf);
+        smsg((char_u *)NGETTEXT("%ld line yanked%s",
+                                "%ld lines yanked%s", yanklines),
+             yanklines, namebuf);
       }
     }
   }
@@ -4696,11 +4687,8 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
     }
 
     if (change_cnt > p_report) {
-      if (change_cnt == 1) {
-        MSG(_("1 line changed"));
-      } else {
-        smsg((char *)_("%" PRId64 " lines changed"), (int64_t)change_cnt);
-      }
+      smsg((char_u *)NGETTEXT("%ld line changed", "%ld lines changed",
+                              change_cnt), change_cnt);
     }
   }
 }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -677,8 +677,7 @@ void op_reindent(oparg_T *oap, Indenter how)
 
   if (oap->line_count > p_report) {
     i = oap->line_count - (i + 1);
-    smsg((char_u *)NGETTEXT("%ld line indented ",
-                            "%ld lines indented ", i), i);
+    smsg(NGETTEXT("%ld line indented ", "%ld lines indented ", i), i);
   }
   /* set '[ and '] marks */
   curbuf->b_op_start = oap->start;
@@ -2034,8 +2033,8 @@ void op_tilde(oparg_T *oap)
   curbuf->b_op_end = oap->end;
 
   if (oap->line_count > p_report) {
-    smsg((char_u *)NGETTEXT("%ld line changed", "%ld lines changed",
-                            oap->line_count), oap->line_count);
+    smsg(NGETTEXT("%ld line changed", "%ld lines changed", oap->line_count),
+         oap->line_count);
   }
 }
 
@@ -2679,12 +2678,11 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
       // redisplay now, so message is not deleted
       update_topline_redraw();
       if (yank_type == kMTBlockWise) {
-        smsg((char_u *)NGETTEXT("block of %ld line yanked%s",
-                                "block of %ld lines yanked%s", yanklines),
+        smsg(NGETTEXT("block of %ld line yanked%s",
+                      "block of %ld lines yanked%s", yanklines),
              yanklines, namebuf);
       } else {
-        smsg((char_u *)NGETTEXT("%ld line yanked%s",
-                                "%ld lines yanked%s", yanklines),
+        smsg(NGETTEXT("%ld line yanked%s", "%ld lines yanked%s", yanklines),
              yanklines, namebuf);
       }
     }
@@ -4687,8 +4685,8 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
     }
 
     if (change_cnt > p_report) {
-      smsg((char_u *)NGETTEXT("%ld line changed", "%ld lines changed",
-                              change_cnt), change_cnt);
+      smsg(NGETTEXT("%ld line changed", "%ld lines changed", change_cnt),
+           change_cnt);
     }
   }
 }


### PR DESCRIPTION
Problem:    Plural messages are not translated properly.
Solution:   Add more usage of NGETTEXT(). (Sergey Alyoshin)
https://github.com/vim/vim/commit/da6e8919e75fa8f961d1b805e877c8a92e76dafb