### PR TITLE
fix(man.vim): reduce false positives for manReference

### DIFF
--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -6,7 +6,7 @@ if exists('b:current_syntax')
 endif
 
 syntax case  ignore
-syntax match manReference      display '[^()[:space:]]\+([0-9nx][a-z]*)'
+syntax match manReference      display '[^()[:space:]]\+(\%([0-9][a-z]*\|[nlpox]\))'
 syntax match manSectionHeading display '^\S.*$'
 syntax match manHeader         display '^\%1l.*$'
 syntax match manSubHeading     display '^ \{3\}\S.*$'


### PR DESCRIPTION
When the text between the parentheses begins with a letter and contains multiple letters, it is not very likely to be a reference to another man page. For example, there are many false positives in `xkeyboard-config(7)`.