### PR TITLE
vim-patch:8.1.{936,1193}

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2001,7 +2001,9 @@ static void didset_options2(void)
 
   // Parse default for 'wildmode'.
   check_opt_wim();
+  xfree(curbuf->b_p_vsts_array);
   tabstop_set(curbuf->b_p_vsts, &curbuf->b_p_vsts_array);
+  xfree(curbuf->b_p_vts_array);
   tabstop_set(curbuf->b_p_vts,  &curbuf->b_p_vts_array);
 }
 
@@ -3167,9 +3169,7 @@ ambw_end:
       if (errmsg == NULL) {
         long *oldarray = curbuf->b_p_vts_array;
         if (tabstop_set(*varp, &(curbuf->b_p_vts_array))) {
-          if (oldarray) {
-            xfree(oldarray);
-          }
+          xfree(oldarray);
           if (foldmethodIsIndent(curwin)) {
             foldUpdateAll(curwin);
           }

--- a/src/nvim/testdir/test_gn.vim
+++ b/src/nvim/testdir/test_gn.vim
@@ -1,9 +1,8 @@
 " Test for gn command
 
 func Test_gn_command()
-  set belloff=all
   noautocmd new
-  " replace a single char by itsself quoted:
+  " replace a single char by itself quoted:
   call setline('.', 'abc x def x ghi x jkl')
   let @/ = 'x'
   exe "norm! cgn'x'\<esc>.."
@@ -157,7 +156,6 @@ func Test_gn_command()
   sil! %d _
 
   set wrapscan&vim
-  set belloff&vim
 endfunc
 
 func Test_gN_repeat()

--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -97,7 +97,7 @@ func Do_test_quotestar_for_x11()
   if has('unix') && has('gui') && !has('gui_running')
     let @* = ''
 
-    " Running in a terminal and the GUI is avaiable: Tell the server to open
+    " Running in a terminal and the GUI is available: Tell the server to open
     " the GUI and check that the remote command still works.
     " Need to wait for the GUI to start up, otherwise the send hangs in trying
     " to send to the terminal window.

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -109,6 +109,8 @@ func Test_recording_esc_sequence()
   bwipe!
   if exists('save_F2')
     let &t_F2 = save_F2
+  else
+    set t_F2=
   endif
 endfunc
 

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -30,7 +30,7 @@ func Test_syn_iskeyword()
 	\ 'CREATE TABLE FOOBAR(',
 	\ '    DLTD_BY VARCHAR2(100)',
 	\ ');',
-  	\ ''])
+	\ ''])
 
   syntax on
   set ft=sql
@@ -521,7 +521,7 @@ func Test_synstack_synIDtrans()
 
   norm f/
   call assert_equal(['cComment', 'cCommentStart'], map(synstack(line("."), col(".")), 'synIDattr(v:val, "name")'))
-  call assert_equal(['Comment', 'Comment'],        map(synstack(line("."), col(".")), 'synIDattr(synIDtrans(v:val), "name")'))
+  call assert_equal(['Comment', 'Comment'],	   map(synstack(line("."), col(".")), 'synIDattr(synIDtrans(v:val), "name")'))
 
   norm fA
   call assert_equal(['cComment'], map(synstack(line("."), col(".")), 'synIDattr(v:val, "name")'))

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -142,9 +142,6 @@ endfunc
 
 " Test autocommands
 function Test_tabpage_with_autocmd()
-  if !has('autocmd')
-    return
-  endif
   command -nargs=1 -bar C :call add(s:li, '=== ' . <q-args> . ' ===')|<args>
   augroup TestTabpageGroup
     au!

--- a/src/nvim/testdir/test_vartabs.vim
+++ b/src/nvim/testdir/test_vartabs.vim
@@ -5,6 +5,7 @@ if !has("vartabs")
 endif
 
 source view_util.vim
+
 func s:compare_lines(expect, actual)
   call assert_equal(join(a:expect, "\n"), join(a:actual, "\n"))
 endfunc
@@ -371,4 +372,10 @@ func Test_vartabs_failures()
   call assert_fails('set vsts=8,,8,')
   call assert_fails('set vts=,8')
   call assert_fails('set vsts=,8')
+endfunc
+
+func Test_vartabs_reset()
+  set vts=8
+  set all&
+  call assert_equal('', &vts)
 endfunc

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -255,7 +255,6 @@ func TriggerTheProblem()
 endfunc
 
 func Test_visual_mode_reset()
-  set belloff=all
   enew
   let g:msg = "Everything's fine."
   enew
@@ -268,7 +267,6 @@ func Test_visual_mode_reset()
   exe "normal! GV:call TriggerTheProblem()\<CR>"
   call assert_equal("Everything's fine.", g:msg)
 
-  set belloff&
 endfunc
 
 func Test_Visual_word_textobject()


### PR DESCRIPTION
Include unmerged patch v8.0.1200 changes
because this patch depends on `set beloff=all` removed in 1 test.

https://github.com/neovim/neovim/pull/13851/commits/a70d904ad0e2037c7fb2ae10a20f840af3544496 is an incomplete port so port the remaining changes.