### PR TITLE
lsp: add on_reload callback for buffer edits outside of neovim

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -935,6 +935,15 @@ function lsp.buf_attach_client(bufnr, client_id)
     -- First time, so attach and set up stuff.
     vim.api.nvim_buf_attach(bufnr, false, {
       on_lines = text_document_did_change_handler;
+      on_reload = function()
+        local params = { textDocument = { uri = uri; } }
+        for_each_buffer_client(bufnr, function(client, _)
+          if client.resolved_capabilities.text_document_open_close then
+            client.notify('textDocument/didClose', params)
+          end
+          text_document_did_open_handler(bufnr, client)
+        end)
+      end;
       on_detach = function()
         local params = { textDocument = { uri = uri; } }
         for_each_buffer_client(bufnr, function(client, _)


### PR DESCRIPTION
Closes #14162 
This should allow the use of external formatters with (such as `:!black %`) without detaching or de-synchronizing buffer state.

Note, I chose to send textDocumentDid{Close,Open} as opposed to sending changes, since the reload/detach handlers are called in lieu of the didChange handler for external edits (I believe)