### PR TITLE
screen: fix problem with p_ch

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7507,6 +7507,10 @@ void screen_resize(int width, int height)
   Rows = height;
   Columns = width;
   check_shellsize();
+  int max_p_ch = Rows - min_rows() + 1;
+  if (!ui_has(kUIMessages) && p_ch > max_p_ch) {
+    p_ch = max_p_ch ? max_p_ch : 1;
+  }
   height = Rows;
   width = Columns;
   p_lines = Rows;

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed = helpers.clear, helpers.feed
 local source = helpers.source
 local command = helpers.command
+local assert_alive = helpers.assert_alive
 
 local function new_screen(opt)
   local screen = Screen.new(25, 5)
@@ -840,5 +841,16 @@ describe('cmdline redraw', function()
     :012345678901234567890123|
     456789^                   |
     ]], unchanged=true}
+  end)
+end)
+
+describe("cmdline height", function()
+  it("does not crash resized screen #14263", function()
+    clear()
+    local screen = Screen.new(25, 10)
+    screen:attach()
+    command('set cmdheight=9999')
+    screen:try_resize(25, 5)
+    assert_alive()
   end)
 end)


### PR DESCRIPTION
When the screen is resized, `p_ch` is not re-set to the appropriate value. As a result, access to invalid addresses was occurring.

fixes #14263.