### PR TITLE
fix(lsp): prefer selectionRange over range for document symbols in vim.lsp.util.symbols_to_items

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1385,13 +1385,13 @@ function M.symbols_to_items(symbols, bufnr)
           kind = kind,
           text = '['..kind..'] '..symbol.name,
         })
-      elseif symbol.range then -- DocumentSymbole type
+      elseif symbol.selectionRange then -- DocumentSymbole type
         local kind = M._get_symbol_kind_name(symbol.kind)
         table.insert(_items, {
           -- bufnr = _bufnr,
           filename = vim.api.nvim_buf_get_name(_bufnr),
-          lnum = symbol.range.start.line + 1,
-          col = symbol.range.start.character + 1,
+          lnum = symbol.selectionRange.start.line + 1,
+          col = symbol.selectionRange.start.character + 1,
           kind = kind,
           text = '['..kind..'] '..symbol.name
         })


### PR DESCRIPTION
Currently, `vim.lsp.util.symbols_to_items` leads `vim.lsp.buf.document_symbol` to go to the beginning of the line, for instance, of a function or class (specified in say Python), as opposed to the actual symbol (i.e. right on the function/class name) as the beginning of the location is pulled from `range` rather than `selectionRange`.

As per the [LSP Document Symbol Specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol) `selectionRange` is preferred over `range` when picking a (document) symbol.

> 	/**
> 	 * The range enclosing this symbol not including leading/trailing whitespace
> 	 * but everything else like comments. This information is typically used to
> 	 * determine if the clients cursor is inside the symbol to reveal in the
> 	 * symbol in the UI.
> 	 */
> 	range: Range;
> 
> 	/**
> 	 * The range that should be selected and revealed when this symbol is being
> 	 * picked, e.g. the name of a function. Must be contained by the `range`.
> 	 */
> 	selectionRange: Range;

This change also makes jumping to a symbol between `vim.lsp.buf.document_symbol` and `vim.lsp.buf.workspace_symbol` consistent.