### PR TITLE
vim-patch:8.1.0986,8.2.{2678,2683,2686}

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -775,9 +775,9 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     redrawcmd();
   }
 
-  // redraw the statusline for statuslines that display the current mode
-  // using the mode() function.
-  if (!cmd_silent && msg_scrolled == 0) {
+  // Redraw the statusline in case it uses the current mode using the mode()
+  // function.
+  if (!cmd_silent && msg_scrolled == 0 && *p_stl != NUL) {
     curwin->w_redr_status = true;
     redraw_statuslines();
   }

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -33,6 +33,7 @@ source test_move.vim
 source test_partial.vim
 source test_popup.vim
 source test_put.vim
+source test_rename.vim
 source test_scroll_opt.vim
 source test_sort.vim
 source test_sha256.vim

--- a/src/nvim/testdir/test_rename.vim
+++ b/src/nvim/testdir/test_rename.vim
@@ -1,0 +1,119 @@
+" Test rename()
+
+func Test_rename_file_to_file()
+  call writefile(['foo'], 'Xrename1')
+
+  call assert_equal(0, rename('Xrename1', 'Xrename2'))
+
+  call assert_equal('', glob('Xrename1'))
+  call assert_equal(['foo'], readfile('Xrename2'))
+
+  " When the destination file already exists, it should be overwritten.
+  call writefile(['foo'], 'Xrename1')
+  call writefile(['bar'], 'Xrename2')
+
+  call assert_equal(0, rename('Xrename1', 'Xrename2'))
+  call assert_equal('', glob('Xrename1'))
+  call assert_equal(['foo'], readfile('Xrename2'))
+
+  call delete('Xrename2')
+endfunc
+
+func Test_rename_file_ignore_case()
+  " With 'fileignorecase', renaming file will go through a temp file
+  " when the source and destination file only differ by case.
+  set fileignorecase
+  call writefile(['foo'], 'Xrename')
+
+  call assert_equal(0, rename('Xrename', 'XRENAME'))
+
+  call assert_equal(['foo'], readfile('XRENAME'))
+
+  set fileignorecase&
+  call delete('XRENAME')
+endfunc
+
+func Test_rename_same_file()
+  call writefile(['foo'], 'Xrename')
+
+  " When the source and destination are the same file, nothing
+  " should be done. The source file should not be deleted.
+  call assert_equal(0, rename('Xrename', 'Xrename'))
+  call assert_equal(['foo'], readfile('Xrename'))
+
+  call assert_equal(0, rename('./Xrename', 'Xrename'))
+  call assert_equal(['foo'], readfile('Xrename'))
+
+  call delete('Xrename')
+endfunc
+
+func Test_rename_dir_to_dir()
+  call mkdir('Xrenamedir1')
+  call writefile(['foo'], 'Xrenamedir1/Xrenamefile')
+
+  call assert_equal(0, rename('Xrenamedir1', 'Xrenamedir2'))
+
+  call assert_equal('', glob('Xrenamedir1'))
+  call assert_equal(['foo'], readfile('Xrenamedir2/Xrenamefile'))
+
+  call delete('Xrenamedir2/Xrenamefile')
+  call delete('Xrenamedir2', 'd')
+endfunc
+
+func Test_rename_same_dir()
+  call mkdir('Xrenamedir')
+  call writefile(['foo'], 'Xrenamedir/Xrenamefile')
+
+  call assert_equal(0, rename('Xrenamedir', 'Xrenamedir'))
+
+  call assert_equal(['foo'], readfile('Xrenamedir/Xrenamefile'))
+
+  call delete('Xrenamedir/Xrenamefile')
+  call delete('Xrenamedir', 'd')
+endfunc
+
+func Test_rename_copy()
+  " Check that when original file can't be deleted, rename()
+  " still succeeds but copies the file.
+  call mkdir('Xrenamedir')
+  call writefile(['foo'], 'Xrenamedir/Xrenamefile')
+  call setfperm('Xrenamedir', 'r-xr-xr-x')
+
+  call assert_equal(0, rename('Xrenamedir/Xrenamefile', 'Xrenamefile'))
+
+  if !has('win32')
+    " On Windows, the source file is removed despite
+    " its directory being made not writable.
+    call assert_equal(['foo'], readfile('Xrenamedir/Xrenamefile'))
+  endif
+  call assert_equal(['foo'], readfile('Xrenamefile'))
+
+  call setfperm('Xrenamedir', 'rwxrwxrwx')
+  call delete('Xrenamedir/Xrenamefile')
+  call delete('Xrenamedir', 'd')
+  call delete('Xrenamefile')
+endfunc
+
+func Test_rename_fails()
+  throw 'skipped: TODO: '
+  call writefile(['foo'], 'Xrenamefile')
+
+  " Can't rename into a non-existing directory.
+  call assert_notequal(0, rename('Xrenamefile', 'Xdoesnotexist/Xrenamefile'))
+
+  " Can't rename a non-existing file.
+  call assert_notequal(0, rename('Xdoesnotexist', 'Xrenamefile2'))
+  call assert_equal('', glob('Xrenamefile2'))
+
+  " When rename() fails, the destination file should not be deleted.
+  call assert_notequal(0, rename('Xdoesnotexist', 'Xrenamefile'))
+  call assert_equal(['foo'], readfile('Xrenamefile'))
+
+  " Can't rename to en empty file name.
+  call assert_notequal(0, rename('Xrenamefile', ''))
+
+  call assert_fails('call rename("Xrenamefile", [])', 'E730')
+  call assert_fails('call rename(0z, "Xrenamefile")', 'E976')
+
+  call delete('Xrenamefile')
+endfunc

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -440,6 +440,27 @@ func Test_statusline_removed_group()
   call delete('XTest_statusline')
 endfunc
 
+func Test_statusline_using_mode()
+  CheckScreendump
+
+  let lines =<< trim END
+    set laststatus=2
+    let &statusline = '-%{mode()}-'
+  END
+  call writefile(lines, 'XTest_statusline')
+
+  let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 5, 'cols': 50})
+  call VerifyScreenDump(buf, 'Test_statusline_mode_1', {})
+
+  call term_sendkeys(buf, ":")
+  call VerifyScreenDump(buf, 'Test_statusline_mode_2', {})
+
+  " clean up
+  call term_sendkeys(buf, "\<CR>")
+  call StopVimInTerminal(buf)
+  call delete('XTest_statusline')
+endfunc
+
 func Test_statusline_after_split_vsplit()
   only
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -456,6 +456,8 @@ describe('ui/ext_messages', function()
       {1:~                        }|
     ]], messages={
       {kind="echomsg", content={{"stuff"}}},
+    }, showmode={
+      { "-- INSERT --", 3 }
     }}
   end)
 


### PR DESCRIPTION
Skip Test_rename_fails() because 'blob' feature is not ported yet.