### PR TITLE
lsp: allow launching language servers with uv_spawn using cwd arg

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -315,8 +315,10 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
     dispatchers = { dispatchers, 't', true };
   }
 
-  if not (vim.fn.executable(cmd) == 1) then
-    error(string.format("The given command %q is not executable.", cmd))
+  if extra_spawn_params and extra_spawn_params.cwd then
+      assert(is_dir(extra_spawn_params.cwd), "cwd must be a directory")
+  elseif not (vim.fn.executable(cmd) == 1) then
+      error(string.format("The given command %q is not executable.", cmd))
   end
   if dispatchers then
     local user_dispatchers = dispatchers
@@ -370,9 +372,6 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
     }
     if extra_spawn_params then
       spawn_params.cwd = extra_spawn_params.cwd
-      if spawn_params.cwd then
-        assert(is_dir(spawn_params.cwd), "cwd must be a directory")
-      end
       spawn_params.env = env_merge(extra_spawn_params.env)
     end
     handle, pid = uv.spawn(cmd, spawn_params, onexit)


### PR DESCRIPTION
Closes #14072

Minor downside in that this doesn't check the error when the executable *in* the new cwd is not valid, but those wouldn't even launch before so I don't consider it a regression :) It still yields an informative error message:

`E5108: Error executing lua /usr/local/share/nvim/runtime/lua/vim/lsp/rpc.lua:380: start `./laniserver.index.js` failed: ENOENT: no such file or directory`

You can test with:

```lua
LaunchPyright = function()
  local settings = {
    python = {
      analysis = {
        autoSearchPaths = true;
        useLibraryCodeForTypes = true;
      };
    };
  };
  local client_id = vim.lsp.start_client({
      cmd = {"./langserver.index.js", "--stdio"};
      cmd_cwd = "/usr/local/lib/node_modules/pyright";
      root_dir = vim.fn.getcwd();
      capabilities = vim.lsp.protocol.make_client_capabilities();
      settings = settings;
      on_init = function(client, _)
        client.notify('workspace/didChangeConfiguration', {
          settings = settings;
        })
      end
    })
  vim.lsp.buf_attach_client(0, client_id)
end

vim.cmd([[
  command! -range LaunchPyright  execute 'lua LaunchPyright()'
]])

```