### PR TITLE
[RDY] Fix typo in the help for `<Cmd>` where lhs was used instead of rhs

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -290,7 +290,7 @@ as a special key.
 						*<Cmd>* *:map-cmd*
 The <Cmd> pseudokey begins a "command mapping", which executes the command
 directly (without changing modes).  Where you might use ":...<CR>" in the
-{lhs} of a mapping, you can instead use "<Cmd>...<CR>".
+{rhs} of a mapping, you can instead use "<Cmd>...<CR>".
 Example: >
 	noremap x <Cmd>echo mode(1)<cr>
 <
@@ -314,7 +314,7 @@ Note:
 
 							*E5520*
 <Cmd> commands must terminate, that is, they must be followed by <CR> in the
-{lhs} of the mapping definition.  |Command-line| mode is never entered.
+{rhs} of the mapping definition.  |Command-line| mode is never entered.
 
 
 1.3 MAPPING AND MODES					*:map-modes*


### PR DESCRIPTION
The documentation for the `<Cmd>` pseudokey contains a couple typos, referring to `{lhs}` when it really means `{rhs}` (the same documentation in `vim` is correct). This PR contains nothing else besides fixing these typos.