### PR TITLE
extmark: buffer update fixes for `noexpandtab` and `:retab`

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -8787,10 +8787,6 @@ static bool ins_tab(void)
     getvcol(curwin, &fpos, &vcol, NULL, NULL);
     getvcol(curwin, cursor, &want_vcol, NULL, NULL);
 
-    // save start of changed region for extmark_splice
-    int start_row = fpos.lnum;
-    colnr_T start_col = fpos.col;
-
     // Use as many TABs as possible.  Beware of 'breakindent', 'showbreak'
     // and 'linebreak' adding extra virtual columns.
     while (ascii_iswhite(*ptr)) {
@@ -8841,8 +8837,8 @@ static bool ins_tab(void)
           }
         }
         if (!(State & VREPLACE_FLAG)) {
-          extmark_splice_cols(curbuf, start_row - 1, start_col,
-                              cursor->col - start_col, fpos.col - start_col,
+          extmark_splice_cols(curbuf, fpos.lnum - 1, change_col,
+                              cursor->col - change_col, fpos.col - change_col,
                               kExtmarkUndo);
         }
       }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -790,7 +790,8 @@ void ex_retab(exarg_T *eap)
             /* len is actual number of white characters used */
             len = num_spaces + num_tabs;
             old_len = (long)STRLEN(ptr);
-            new_line = xmalloc(old_len - col + start_col + len + 1);
+            long new_len = old_len - col + start_col + len + 1;
+            new_line = xmalloc(new_len);
 
             if (start_col > 0)
               memmove(new_line, ptr, (size_t)start_col);
@@ -803,6 +804,8 @@ void ex_retab(exarg_T *eap)
             if (ml_replace(lnum, new_line, false) == OK) {
               // "new_line" may have been copied
               new_line = curbuf->b_ml.ml_line_ptr;
+              extmark_splice_cols(curbuf, lnum - 1, 0, (colnr_T)old_len,
+                                  (colnr_T)new_len - 1, kExtmarkUndo);
             }
             if (first_line == 0) {
               first_line = lnum;

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -670,7 +670,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
       command("set noet")
       command("set ts=4")
       command("set sw=2")
-      command("set sts=2")
+      command("set sts=4")
 
       local check_events = setup_eventcheck(verify, {'asdfasdf'})
 
@@ -688,6 +688,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
         { "test1", "bytes", 1, 6, 0, 3, 3, 0, 0, 0, 0, 1, 1 },
         { "test1", "bytes", 1, 7, 0, 0, 0, 0, 4, 4, 0, 1, 1 },
       }
+
 
       feed("<esc>u")
       check_events {
@@ -727,6 +728,29 @@ describe('lua: nvim_buf_attach on_bytes', function()
           { "test1", "bytes", 1, 28, 0, 0, 0, 0, 1, 1, 0, 0, 0 };
           { "test1", "bytes", 1, 29, 0, 0, 0, 0, 0, 0, 0, 1, 1 };
           { "test1", "bytes", 1, 31, 0, 0, 0, 0, 4, 4, 0, 1, 1 };
+      }
+
+      -- inserting tab after other tabs
+      command("set sw=4")
+      feed("<esc>0a<tab>")
+      check_events {
+        { "test1", "bytes", 1, 32, 0, 1, 1, 0, 0, 0, 0, 1, 1 };
+        { "test1", "bytes", 1, 33, 0, 2, 2, 0, 0, 0, 0, 1, 1 };
+        { "test1", "bytes", 1, 34, 0, 3, 3, 0, 0, 0, 0, 1, 1 };
+        { "test1", "bytes", 1, 35, 0, 4, 4, 0, 0, 0, 0, 1, 1 };
+        { "test1", "bytes", 1, 36, 0, 1, 1, 0, 4, 4, 0, 1, 1 };
+      }
+    end)
+
+    it("retab", function()
+      command("set noet")
+      command("set ts=4")
+
+      local check_events = setup_eventcheck(verify, {"			asdf"})
+      command("retab 8")
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 0, 7, 7, 0, 9, 9 };
       }
     end)
 


### PR DESCRIPTION
#14124 Didn't completely address the case of inserting tabs after whitespace/other tabs.

In addition, add's an `extmark_splice` call to `ex_retab`.

@bfredl 