### PR TITLE
vim-patch:8.2.2694: when 'matchpairs' is empty every character beeps

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2047,6 +2047,7 @@ assert_inrange({lower}, {upper}, {actual} [, {msg}])
 				Number	assert {actual} is inside the range
 assert_match({pat}, {text} [, {msg}])
 				Number	assert {pat} matches {text}
+assert_nobeep({cmd})		Number	assert {cmd} does not cause a beep
 assert_notequal({exp}, {act} [, {msg}])
 				Number	assert {exp} is not equal {act}
 assert_notmatch({pat}, {text} [, {msg}])
@@ -2638,7 +2639,8 @@ argv([{nr} [, {winid}])
 assert_beeps({cmd})					*assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does
 		NOT produce a beep or visual bell.
-		Also see |assert_fails()| and |assert-return|.
+		Also see |assert_fails()|, |assert_nobeep()| and
+		|assert-return|.
 
 							*assert_equal()*
 assert_equal({expected}, {actual}, [, {msg}])
@@ -2720,6 +2722,11 @@ assert_match({pattern}, {actual} [, {msg}])
 	assert_match('^f.*o$', 'foobar')
 <		Will result in a string to be added to |v:errors|:
 	test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
+
+assert_nobeep({cmd})					*assert_nobeep()*
+		Run {cmd} and add an error message to |v:errors| if it
+		produces a beep or visual bell.
+		Also see |assert_beeps()|.
 
 							*assert_notequal()*
 assert_notequal({expected}, {actual} [, {msg}])

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5981,6 +5981,35 @@ static void assert_append_cmd_or_arg(garray_T *gap, typval_T *argvars,
   }
 }
 
+int assert_beeps(typval_T *argvars, bool no_beep)
+  FUNC_ATTR_NONNULL_ALL
+{
+  const char *const cmd = tv_get_string_chk(&argvars[0]);
+  int ret = 0;
+
+  called_vim_beep = false;
+  suppress_errthrow = true;
+  emsg_silent = false;
+  do_cmdline_cmd(cmd);
+  if (no_beep ? called_vim_beep : !called_vim_beep) {
+    garray_T ga;
+    prepare_assert_error(&ga);
+    if (no_beep) {
+      ga_concat(&ga, (const char_u *)"command did beep: ");
+    } else {
+      ga_concat(&ga, (const char_u *)"command did not beep: ");
+    }
+    ga_concat(&ga, (const char_u *)cmd);
+    assert_error(&ga);
+    ga_clear(&ga);
+    ret = 1;
+  }
+
+  suppress_errthrow = false;
+  emsg_on_display = false;
+  return ret;
+}
+
 int assert_fails(typval_T *argvars)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -26,7 +26,7 @@ return {
     arglistid={args={0, 2}},
     argv={args={0, 2}},
     asin={args=1, func="float_op_wrapper", data="&asin"},  -- WJMc
-    assert_beeps={args={1, 2}},
+    assert_beeps={args={1}},
     assert_equal={args={2, 3}},
     assert_equalfile={args={2, 3}},
     assert_exception={args={1, 2}},
@@ -34,6 +34,7 @@ return {
     assert_false={args={1, 2}},
     assert_inrange={args={3, 4}},
     assert_match={args={2, 3}},
+    assert_nobeep={args={1}},
     assert_notequal={args={2, 3}},
     assert_notmatch={args={2, 3}},
     assert_report={args=1},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -391,28 +391,16 @@ static void f_argv(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
+// "assert_beeps(cmd [, error])" function
 static void f_assert_beeps(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  const char *const cmd = tv_get_string_chk(&argvars[0]);
-  garray_T ga;
-  int ret = 0;
+  rettv->vval.v_number = assert_beeps(argvars, false);
+}
 
-  called_vim_beep = false;
-  suppress_errthrow = true;
-  emsg_silent = false;
-  do_cmdline_cmd(cmd);
-  if (!called_vim_beep) {
-    prepare_assert_error(&ga);
-    ga_concat(&ga, (const char_u *)"command did not beep: ");
-    ga_concat(&ga, (const char_u *)cmd);
-    assert_error(&ga);
-    ga_clear(&ga);
-    ret = 1;
-  }
-
-  suppress_errthrow = false;
-  emsg_on_display = false;
-  rettv->vval.v_number = ret;
+// "assert_nobeep(cmd [, error])" function
+static void f_assert_nobeep(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  rettv->vval.v_number = assert_beeps(argvars, true);
 }
 
 // "assert_equal(expected, actual[, msg])" function

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2326,6 +2326,9 @@ showmatch(
       return;
     }
   }
+  if (*p == NUL) {
+    return;
+  }
 
   if ((lpos = findmatch(NULL, NUL)) == NULL) {  // no match, so beep
     vim_beep(BO_MATCH);

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -891,6 +891,14 @@ func Test_mps()
   bwipe!
 endfunc
 
+func Test_empty_matchpairs()
+  split
+  set matchpairs= showmatch
+  call assert_nobeep('call feedkeys("ax\tx\t\<Esc>", "xt")')
+  set matchpairs& noshowmatch
+  bwipe!
+endfunc
+
 " Test for ra on multi-byte characters
 func Test_ra_multibyte()
   new


### PR DESCRIPTION
Problem:    When 'matchpairs' is empty every character beeps. (Marco Hinz)
Solution:   Bail out when no character in 'matchpairs' was found.
            (closes vim/vim#8053)  Add assert_nobeep().
https://github.com/vim/vim/commit/5b8cabfef7c3707f3e53e13844d90e5a217e1e84