### PR TITLE
[WIP] doc: Update Funcref example at eval.txt

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -156,9 +156,13 @@ This will invoke the function as if using: >
 	call myDict.Callback('foo', 'bar')
 
 Note that binding a function to a Dictionary also happens when the function is
-a member of the Dictionary: >
+a member of the Dictionary, for example: >
 
-	let myDict.myFunction = MyFunction
+	function MyFunction() dict
+	  echo self
+	endfunction
+
+	let myDict.myFunction = function('MyFunction')
 	call myDict.myFunction()
 
 Here MyFunction() will get myDict passed as "self".  This happens when the


### PR DESCRIPTION
The current documentation example on function references on dictionaries can't
be executed directly. Improve the example by providing a function example and
replacing `MyFunction` by `function('MyFunction')`

This should address #14283