### PR TITLE
[RFC] vim-patch:8.2.2704, 8.2.2707

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2523,7 +2523,8 @@ static void ins_compl_add_matches(int num_matches, char_u **matches, int icase)
 
   for (int i = 0; i < num_matches && add_r != FAIL; i++) {
     if ((add_r = ins_compl_add(matches[i], -1, NULL, NULL, false, NULL, dir,
-                               icase ? CP_ICASE : 0, false)) == OK) {
+                               CP_FAST | (icase ? CP_ICASE : 0),
+                               false)) == OK) {
       // If dir was BACKWARD then honor it just once.
       dir = FORWARD;
     }
@@ -2598,7 +2599,7 @@ void set_completion(colnr_T startcol, list_T *list)
     flags |= CP_ICASE;
   }
   if (ins_compl_add(compl_orig_text, -1, NULL, NULL, false, NULL, 0,
-                    flags, false) != OK) {
+                    flags | CP_FAST, false) != OK) {
     return;
   }
 
@@ -3318,8 +3319,8 @@ static int ins_compl_bs(void)
   // allow the word to be deleted, we won't match everything.
   // Respect the 'backspace' option.
   if ((int)(p - line) - (int)compl_col < 0
-      || ((int)(p - line) - (int)compl_col == 0
-          && ctrl_x_mode != CTRL_X_OMNI) || ctrl_x_mode == CTRL_X_EVAL
+      || ((int)(p - line) - (int)compl_col == 0 && ctrl_x_mode != CTRL_X_OMNI)
+      || ctrl_x_mode == CTRL_X_EVAL
       || (!can_bs(BS_START) && (int)(p - line) - (int)compl_col
           - compl_length < 0)) {
     return K_BS;
@@ -3934,7 +3935,7 @@ static void ins_compl_add_list(list_T *const list)
 
   // Go through the List with matches and add each of them.
   TV_LIST_ITER(list, li, {
-    if (ins_compl_add_tv(TV_LIST_ITEM_TV(li), dir) == OK) {
+    if (ins_compl_add_tv(TV_LIST_ITEM_TV(li), dir, true) == OK) {
       // If dir was BACKWARD then honor it just once.
       dir = FORWARD;
     } else if (did_emsg) {
@@ -3973,17 +3974,18 @@ static void ins_compl_add_dict(dict_T *dict)
 ///
 /// @param[in]  tv  Object to get matches from.
 /// @param[in]  dir  Completion direction.
+/// @param[in]  fast  use fast_breakcheck() instead of ui_breakcheck().
 ///
 /// @return NOTDONE if the given string is already in the list of completions,
 ///         otherwise it is added to the list and  OK is returned. FAIL will be
 ///         returned in case of error.
-int ins_compl_add_tv(typval_T *const tv, const Direction dir)
+int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *word;
   bool dup = false;
   bool empty = false;
-  int flags = 0;
+  int flags = fast ? CP_FAST : 0;
   char *(cptext[CPT_COUNT]);
   typval_T user_data;
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3978,7 +3978,7 @@ static void ins_compl_add_dict(dict_T *dict)
 ///
 /// @param[in]  tv  Object to get matches from.
 /// @param[in]  dir  Completion direction.
-/// @param[in]  fast  use fast_breakcheck() instead of ui_breakcheck().
+/// @param[in]  fast  use fast_breakcheck() instead of os_breakcheck().
 ///
 /// @return NOTDONE if the given string is already in the list of completions,
 ///         otherwise it is added to the list and  OK is returned. FAIL will be

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2319,7 +2319,11 @@ static int ins_compl_add(char_u *const str, int len,
   const Direction dir = (cdir == kDirectionNotSet ? compl_direction : cdir);
   int flags = flags_arg;
 
-  os_breakcheck();
+  if (flags & CP_FAST) {
+    fast_breakcheck();
+  } else {
+    os_breakcheck();
+  }
 #define FREE_CPTEXT(cptext, cptext_allocated) \
   do { \
     if (cptext != NULL && cptext_allocated) { \

--- a/src/nvim/edit.h
+++ b/src/nvim/edit.h
@@ -19,7 +19,7 @@ typedef enum {
   CP_CONT_S_IPOS = 4,    // use CONT_S_IPOS for compl_cont_status
   CP_EQUAL = 8,          // ins_compl_equal() always returns true
   CP_ICASE = 16,         // ins_compl_equal ignores case
-  CP_FAST = 32,          // use fast_breakcheck instead of ui_breakcheck
+  CP_FAST = 32,          // use fast_breakcheck instead of os_breakcheck
 } cp_flags_T;
 
 typedef int (*IndentGetter)(void);

--- a/src/nvim/edit.h
+++ b/src/nvim/edit.h
@@ -19,6 +19,7 @@ typedef enum {
   CP_CONT_S_IPOS = 4,    // use CONT_S_IPOS for compl_cont_status
   CP_EQUAL = 8,          // ins_compl_equal() always returns true
   CP_ICASE = 16,         // ins_compl_equal ignores case
+  CP_FAST = 32,          // use fast_breakcheck instead of ui_breakcheck
 } cp_flags_T;
 
 typedef int (*IndentGetter)(void);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1098,7 +1098,7 @@ static void f_complete(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  */
 static void f_complete_add(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  rettv->vval.v_number = ins_compl_add_tv(&argvars[0], 0);
+  rettv->vval.v_number = ins_compl_add_tv(&argvars[0], 0, false);
 }
 
 /*


### PR DESCRIPTION
Problem:    Adding a lot of completions can be a bit slow.
Solution:   Use fast_breakcheck() instead of ui_breakcheck() when adding a
            list of completions. (Ben Jackson, closes vim/vim#8061)
https://github.com/vim/vim/commit/440cf096fad7bf628974abc344343b823d79a006

Problem:    Adding a lot of completions can still be a bit slow.
Solution:   Add the check for CP_FAST. (Ben Jackson)
https://github.com/vim/vim/commit/ceb06194337f1a9d30cd12edb7b0dc51830b9cb7