### PR TITLE
feat(lsp): make hover/signature_help borders configurable

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1147,7 +1147,7 @@ function M.show_line_diagnostics(opts, bufnr, line_nr, client_id)
     end
   end
 
-  local popup_bufnr, winnr = util.open_floating_preview(lines, 'plaintext')
+  local popup_bufnr, winnr = util.open_floating_preview(lines, 'plaintext', opts)
   for i, hi in ipairs(highlights) do
     local prefixlen, hiname = unpack(hi)
     -- Start highlight after the prefix

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -245,8 +245,30 @@ M['textDocument/completion'] = function(_, _, result)
   vim.fn.complete(textMatch+1, matches)
 end
 
---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
-M['textDocument/hover'] = function(_, method, result)
+--- |lsp-handler| for the method "textDocument/hover"
+--- <pre>
+--- vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
+---   vim.lsp.handlers.hover, {
+---     -- Use a sharp border with `FloatBorder` highlights
+---     border = {
+---       {"┌", "FloatBorder"},
+---       {"─", "FloatBorder"},
+---       {"┐", "FloatBorder"},
+---       {"│", "FloatBorder"},
+---       {"┘", "FloatBorder"},
+---       {"─", "FloatBorder"},
+---       {"└", "FloatBorder"},
+---       {"│", "FloatBorder"}
+---     }
+---   }
+--- )
+--- </pre>
+---@param config table Configuration table.
+---     - border:     (default=nil)
+---         - Add borders to the floating window
+---         - See |vim.api.nvim_open_win()|
+function M.hover(_, method, result, _, _, config)
+  config = config or {}
   util.focusable_float(method, function()
     if not (result and result.contents) then
       -- return { 'No information available' }
@@ -258,11 +280,16 @@ M['textDocument/hover'] = function(_, method, result)
       -- return { 'No information available' }
       return
     end
-    local bufnr, winnr = util.fancy_floating_markdown(markdown_lines)
+    local bufnr, winnr = util.fancy_floating_markdown(markdown_lines, {
+      border = config.border
+    })
     util.close_preview_autocmd({"CursorMoved", "BufHidden", "InsertCharPre"}, winnr)
     return bufnr, winnr
   end)
 end
+
+--@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
+M['textDocument/hover'] = M.hover
 
 --@private
 --- Jumps to a location. Used as a handler for multiple LSP methods.
@@ -301,8 +328,30 @@ M['textDocument/typeDefinition'] = location_handler
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_implementation
 M['textDocument/implementation'] = location_handler
 
---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
-M['textDocument/signatureHelp'] = function(_, method, result, _, bufnr)
+--- |lsp-handler| for the method "textDocument/signatureHelp"
+--- <pre>
+--- vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(
+---   vim.lsp.handlers.signature_help, {
+---     -- Use a sharp border with `FloatBorder` highlights
+---     border = {
+---       {"┌", "FloatBorder"},
+---       {"─", "FloatBorder"},
+---       {"┐", "FloatBorder"},
+---       {"│", "FloatBorder"},
+---       {"┘", "FloatBorder"},
+---       {"─", "FloatBorder"},
+---       {"└", "FloatBorder"},
+---       {"│", "FloatBorder"}
+---     }
+---   }
+--- )
+--- </pre>
+---@param config table Configuration table.
+---     - border:     (default=nil)
+---         - Add borders to the floating window
+---         - See |vim.api.nvim_open_win()|
+function M.signature_help(_, method, result, _, bufnr, config)
+  config = config or {}
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
@@ -317,10 +366,13 @@ M['textDocument/signatureHelp'] = function(_, method, result, _, bufnr)
   end
   local syntax = api.nvim_buf_get_option(bufnr, 'syntax')
   local p_bufnr, _ = util.focusable_preview(method, function()
-    return lines, util.try_trim_markdown_code_blocks(lines)
+    return lines, util.try_trim_markdown_code_blocks(lines), config
   end)
   api.nvim_buf_set_option(p_bufnr, 'syntax', syntax)
 end
+
+--@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
+M['textDocument/signatureHelp'] = M.signature_help
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
 M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -875,7 +875,7 @@ function M.make_floating_popup_options(width, height, opts)
     row = row + (opts.offset_y or 0),
     style = 'minimal',
     width = width,
-    border = {
+    border = opts.border or {
       {"", "NormalFloat"},
       {"", "NormalFloat"},
       {"", "NormalFloat"},


### PR DESCRIPTION
make borders configurable for `diagnostic` (by passing border to opts), `hover`, and `signature_help` (using `vim.lsp.with`)

cc @mjlbach 

edit: note for future readers, here's some examples taken from my own config.

<details>

<summary> Click Me </summary>

```lua
local borders = {
  {"┌", "NormalFloat"},
  {"─", "NormalFloat"},
  {"┐", "NormalFloat"},
  {"│", "NormalFloat"},
  {"┘", "NormalFloat"},
  {"─", "NormalFloat"},
  {"└", "NormalFloat"},
  {"│", "NormalFloat"}
}

nnoremap {
  "gD",
  function()
    vim.lsp.diagnostic.show_line_diagnostics {
      border = borders
    }
  end,
  { silent = true },
} 

nnoremap {
  "<Leader>dn",
  function()
    -- or vim.lsp.diagnostic.goto_prev
    vim.lsp.diagnostic.goto_next { popup_opts = { border = borders } }
  end,
  { silent = true },
} 

-- also applies to vim.lsp.handlers["textDocument/signatureHelp"]
vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
  -- change this to vim.lsp.handlers.signature_help for signatureHelp handler
  vim.lsp.handlers.hover, {
    border = borders
  }
)
```

</details>