### PR TITLE
lsp: hover window should return buf/winnr from focusable float

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -269,7 +269,7 @@ end
 ---         - See |vim.api.nvim_open_win()|
 function M.hover(_, method, result, _, _, config)
   config = config or {}
-  util.focusable_float(method, function()
+  local bufnr, winnr = util.focusable_float(method, function()
     if not (result and result.contents) then
       -- return { 'No information available' }
       return
@@ -286,6 +286,7 @@ function M.hover(_, method, result, _, _, config)
     util.close_preview_autocmd({"CursorMoved", "BufHidden", "InsertCharPre"}, winnr)
     return bufnr, winnr
   end)
+  return bufnr, winnr
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover


### PR DESCRIPTION
This allows for additional customization, such as a keymap to return to main window:

```lua

  local overridden_hover = vim.lsp.with(vim.lsp.handlers.hover, {
       -- Use a sharp border with `FloatBorder` highlights
       border = "single"
     }
    )

  vim.lsp.handlers["textDocument/hover"] = function(...)
    local buf = overridden_hover (...) -- this previously returned nil
    vim.api.nvim_buf_set_keymap(buf, 'n', 'K', '<Cmd>wincmd p<CR>', {noremap = true, silent = true})
  end

```