### PR TITLE
float: add "solid" border style

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1765,6 +1765,7 @@ static void parse_border_style(Object style, FloatConfig *fconfig, Error *err)
     { "double", { "╔", "═", "╗", "║", "╝", "═", "╚", "║" }, false },
     { "single", { "┌", "─", "┐", "│", "┘", "─", "└", "│" }, false },
     { "shadow", { "", "", " ", " ", " ", " ", " ", "" }, true },
+    { "solid", { " ", " ", " ", " ", " ", " ", " ", " " }, false },
     { NULL, { { NUL } } , false },
   };
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -690,6 +690,49 @@ describe('float window', function()
         ]]}
       end
 
+      meths.win_set_config(win, {border="solid"})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 5
+          {5:           }|
+          {5: }{1: halloj! }{5: }|
+          {5: }{1: BORDAA  }{5: }|
+          {5:           }|
+        ]], float_pos={
+          [5] = { { id = 1002 }, "NW", 1, 2, 5, true }
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0};
+          [5] = {win = {id = 1002}, topline = 0, botline = 2, curline = 0, curcol = 0};
+        }}
+      else
+        screen:expect{grid=[[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }{5:           }{0:                        }|
+          {0:~    }{5: }{1: halloj! }{5: }{0:                        }|
+          {0:~    }{5: }{1: BORDAA  }{5: }{0:                        }|
+          {0:~    }{5:           }{0:                        }|
+                                                  |
+        ]]}
+      end
+
       -- support: ascii char, UTF-8 char, composed char, highlight per char
       meths.win_set_config(win, {border={"x", {"å", "ErrorMsg"}, {"\\"}, {"n̈̊", "Search"}}})
       if multigrid then


### PR DESCRIPTION
It looks solid with the default `FloatBorder` group.

If you set the bgcolor of `FloatBorder` to the same color as for `FloatNormal`, you get the impression of an "1-cell padding".

Although it's easy to add custom border styles, I'm under the impression that a lot of people would want this. But maybe I'm wrong. :)