### PR TITLE
extmark: correct extmark_splice call with substitute and inccommand when replacing with escaped backslashes

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6665,6 +6665,10 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest,
   int len = 0;                  /* init for GCC */
   static char_u *eval_result = NULL;
 
+  // We need to keep track of how many backslashes we escape, so that the byte
+  // counts for `extmark_splice` are correct.
+  int num_escaped = 0;
+
   // Be paranoid...
   if ((source == NULL && expr == NULL) || dest == NULL) {
     EMSG(_(e_null));
@@ -6840,6 +6844,7 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest,
           // later.  Used to insert a literal CR.
           default:
             if (backslash) {
+              num_escaped += 1;
               if (copy) {
                 *dst = '\\';
               }
@@ -6979,7 +6984,7 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest,
     *dst = NUL;
 
 exit:
-  return (int)((dst - dest) + 1);
+  return (int)((dst - dest) + 1 - num_escaped);
 }
 
 

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -537,19 +537,64 @@ describe('lua: nvim_buf_attach on_bytes', function()
     end)
 
     it('inccomand=nosplit and substitute', function()
-      local check_events = setup_eventcheck(verify, {"abcde"})
+      local check_events = setup_eventcheck(verify,
+                                            {"abcde", "12345"})
       meths.set_option('inccommand', 'nosplit')
 
-      feed ':%s/bcd/'
+      -- linewise substitute
+      feed(':%s/bcd/')
       check_events {
         { "test1", "bytes", 1, 3, 0, 1, 1, 0, 3, 3, 0, 0, 0 };
         { "test1", "bytes", 1, 5, 0, 1, 1, 0, 0, 0, 0, 3, 3 };
       }
 
-      feed 'a'
+      feed('a')
       check_events {
         { "test1", "bytes", 1, 3, 0, 1, 1, 0, 3, 3, 0, 1, 1 };
         { "test1", "bytes", 1, 5, 0, 1, 1, 0, 1, 1, 0, 3, 3 };
+      }
+
+      feed("<esc>")
+
+      -- splitting lines
+      feed([[:%s/abc/\r]])
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 0, 3, 3, 1, 0, 1 };
+        { "test1", "bytes", 1, 6, 0, 0, 0, 1, 0, 1, 0, 3, 3 };
+      }
+
+      feed("<esc>")
+      -- multi-line regex
+      feed([[:%s/de\n123/a]])
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 3, 3, 1, 3, 6, 0, 1, 1 };
+        { "test1", "bytes", 1, 6, 0, 3, 3, 0, 1, 1, 1, 3, 6 };
+      }
+
+      feed("<esc>")
+      -- replacing with unicode
+      feed(":%s/b/→")
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 3, 3 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 3, 3, 0, 1, 1 };
+      }
+
+      feed("<esc>")
+      -- replacing with escaped characters
+      feed([[:%s/b/\\]])
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 1, 1 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 1, 1, 0, 1, 1 };
+      }
+
+      feed("<esc>")
+      -- replacing with expression register
+      feed([[:%s/b/\=5+5]])
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 };
       }
     end)
 


### PR DESCRIPTION
The byte count returned by `vim_regsub_multi` didn't take into account any escaped backslashes that were removed, so commands like `:%s/abcd/\\` would error out.

@bfredl 