### PR TITLE
vim-patch:8.2.2737

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -784,9 +784,18 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
 
   // Redraw the statusline in case it uses the current mode using the mode()
   // function.
-  if (!cmd_silent && msg_scrolled == 0 && *p_stl != NUL) {
-    curwin->w_redr_status = true;
-    redraw_statuslines();
+  if (!cmd_silent && msg_scrolled == 0) {
+    bool found_one = false;
+
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      if (*p_stl != NUL || *wp->w_p_stl != NUL) {
+        wp->w_redr_status = true;
+        found_one = true;
+      }
+    }
+    if (found_one) {
+      redraw_statuslines();
+    }
   }
 
   did_emsg = false;

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -444,19 +444,20 @@ func Test_statusline_using_mode()
   CheckScreendump
 
   let lines =<< trim END
-    set laststatus=2
-    let &statusline = '-%{mode()}-'
+    setlocal statusline=-%{mode()}-
+    split
+    setlocal statusline=+%{mode()}+
   END
   call writefile(lines, 'XTest_statusline')
 
-  let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 5, 'cols': 50})
+  let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 7, 'cols': 50})
   call VerifyScreenDump(buf, 'Test_statusline_mode_1', {})
 
   call term_sendkeys(buf, ":")
   call VerifyScreenDump(buf, 'Test_statusline_mode_2', {})
 
   " clean up
-  call term_sendkeys(buf, "\<CR>")
+  call term_sendkeys(buf, "close\<CR>")
   call StopVimInTerminal(buf)
   call delete('XTest_statusline')
 endfunc


### PR DESCRIPTION
Fixes #14316 
In the vim patch, the macro `FOR_ALL_WINDOWS(wp)` from globals.h was used but this isn't defined in neovims globals.h so I just substituted it in manually. Not sure if this is the correct thing to do.