### PR TITLE
Make lsp.buf.rename()’s prompt show the old name when renaming.

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -252,7 +252,18 @@ function M.rename(new_name)
   -- TODO(ashkan) use prepareRename
   -- * result: [`Range`](#range) \| `{ range: Range, placeholder: string }` \| `null` describing the range of the string to rename and optionally a placeholder text of the string content to be renamed. If `null` is returned then it is deemed that a 'textDocument/rename' request is not valid at the given position.
   local params = util.make_position_params()
-  new_name = new_name or npcall(vfn.input, "New Name: ", vfn.expand('<cword>'))
+  local current_name = vfn.expand('<cword>')
+
+  -- ensure the current name is not bigger than 30% of the window width; if it is, we do not display it in the prompt
+  local winwidth = vfn.winwidth(0)
+  local prompt
+  if vfn.strdisplaywidth(current_name) < winwidth * 0.3 then
+    prompt = string.format("Rename '%s': ", current_name)
+  else
+    prompt = 'Rename: '
+  end
+
+  new_name = new_name or npcall(vfn.input, prompt, current_name)
   if not (new_name and #new_name > 0) then return end
   params.newName = new_name
   request('textDocument/rename', params)


### PR DESCRIPTION
# Note to reviewer(s)

It would probably be better to have this on two aligned lines but the `input` function doesn’t seem to really support this if the statusline gets updated. The idea would be to have something like:

```
Old name: FooBar
New name: ZooQuux
```

Where the user would type in `ZooQuux`.

# Current situation

![Screenshot_20210409_015253](https://user-images.githubusercontent.com/506592/114110070-f07bca80-98d6-11eb-869b-d8ca412e9903.png)

If the name is too long, it doesn’t appear in the prompt:

![Screenshot_20210409_015333](https://user-images.githubusercontent.com/506592/114110083-f8d40580-98d6-11eb-84ed-759934ea5550.png)
