### PR TITLE
lsp: deep copy vim.lsp.log when reloading

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -10,7 +10,7 @@ local log = {}
 -- Can be used to lookup the number from the name or the name from the number.
 -- Levels by name: 'trace', 'debug', 'info', 'warn', 'error'
 -- Level numbers begin with 'trace' at 0
-log.levels = vim.log.levels
+log.levels = vim.deepcopy(vim.log.levels)
 
 -- Default log level is warn.
 local current_log_level = log.levels.WARN


### PR DESCRIPTION
If `vim.lsp.log` is loaded the second time (when I am trying to modify my configuration), 
the vim.log.levels will be modified with additional entries from 0-5.
This will cause the require to fail as `level:lower` may iter over number values.
I also think that `vim.log.levels` should not be modified by the `vim.lsp.log`.
