### PR TITLE
Extmarks: manually zero out `curbuf->deleted_bytes2` on substitute and join

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4230,6 +4230,8 @@ skip:
     }
   }
 
+  curbuf->deleted_bytes2 = 0;
+
   if (first_line != 0) {
     /* Need to subtract the number of added lines from "last_line" to get
      * the line number before the change (same as adding the number of

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3977,6 +3977,7 @@ int do_join(size_t count,
   del_lines((long)count - 1, false);
   curwin->w_cursor.lnum = t;
   curbuf_splice_pending--;
+  curbuf->deleted_bytes2 = 0;
 
   /*
    * Set the cursor column:

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -1001,6 +1001,39 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("flushes delbytes on substitute", function()
+      local check_events = setup_eventcheck(verify, {"AAA", "BBB", "CCC"})
+
+      feed("gg0")
+      command("s/AAA/GGG/")
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 0, 3, 3, 0, 3, 3 };
+      }
+
+      -- check that byte updates for :delete (which uses curbuf->deleted_bytes2)
+      -- are correct
+      command("delete")
+      check_events {
+        { "test1", "bytes", 1, 4, 0, 0, 0, 1, 0, 4, 0, 0, 0 };
+      }
+    end)
+
+    it("flushes delbytes on join", function()
+      local check_events = setup_eventcheck(verify, {"AAA", "BBB", "CCC"})
+
+      feed("gg0J")
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 3, 3, 1, 0, 1, 0, 1, 1 };
+      }
+
+      command("delete")
+      check_events {
+        { "test1", "bytes", 1, 5, 0, 0, 0, 1, 0, 8, 0, 0, 0 };
+      }
+    end)
+
     teardown(function()
       os.remove "Xtest-reload"
       os.remove "Xtest-undofile"


### PR DESCRIPTION
Fixes #14333.

Moves the `extmark_splice` call after any calls to `ml_delete/ml_replace`, to ensure that `deleted_bytes2` gets correctly set to 0. I'm not sure if this is the right fix; I'll need to investigate to make sure this doesn't accidentally break anything.