### PR TITLE
tree-sitter: Add parent reference to LanguageTree

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -15,7 +15,8 @@ LanguageTree.__index = LanguageTree
 -- @param opts.queries A table of language to injection query strings.
 --                     This is useful for overriding the built-in runtime file
 --                     searching for the injection language query per language.
-function LanguageTree.new(source, lang, opts)
+-- @param parent Optionally set parent for this language tree
+function LanguageTree.new(source, lang, opts, parent)
   language.require_language(lang)
   opts = opts or {}
 
@@ -27,6 +28,7 @@ function LanguageTree.new(source, lang, opts)
     _regions = {},
     _trees = {},
     _opts = opts,
+    _parent = parent,
     _injection_query = custom_queries[lang]
       and query.parse_query(lang, custom_queries[lang])
       or query.get_query(lang, "injections"),
@@ -80,6 +82,11 @@ end
 -- Returns a map of language to child tree.
 function LanguageTree:children()
   return self._children
+end
+
+-- Returns the parent of this language tree (if any)
+function LanguageTree:parent()
+  return self._parent
 end
 
 -- Returns the source content of the language tree (bufnr or string).
@@ -199,7 +206,7 @@ function LanguageTree:add_child(lang)
     self:remove_child(lang)
   end
 
-  self._children[lang] = LanguageTree.new(self._source, lang, self._opts)
+  self._children[lang] = LanguageTree.new(self._source, lang, self._opts, self)
 
   self:invalidate()
   self:_do_callback('child_added', self._children[lang])

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -473,6 +473,7 @@ int x = INT_MAX;
         ]])
 
         eq("table", exec_lua("return type(parser:children().c)"))
+        eq(true, exec_lua("return parser:children().c:parent() == parser"))
         eq(5, exec_lua("return #parser:children().c:trees()"))
         eq({
           {0, 0, 7, 0},   -- root tree


### PR DESCRIPTION
At the moment, you can only get the parent of a tree in very indirect
ways by iterating over all tree and check their children. It would
be a lot more ergonomic to just add a reference to the parent when
adding a child tree.

@steelsojka, @kyazdani42 