### PR TITLE
test/ui/cmdline: set notimeout to remove indeterminism

### DIFF
--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -759,6 +759,7 @@ local function test_cmdline(linegrid)
   end)
 
   it("doesn't send invalid events when aborting mapping #10000", function()
+    command('set notimeout')
     command('cnoremap ab c')
 
     feed(':xa')


### PR DESCRIPTION
Test from 4bf05ba3997b8033ccfd76503cd1fe14a9557a0f
fails on my machine because of screen indeterminism.