### PR TITLE
contrib: add clang-tools to nix flake

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -72,6 +72,7 @@
                 jq # jq for scripts/vim-patch.sh -r
                 shellcheck # for `make shlint`
                 doxygen    # for script/gen_vimdoc.py
+                clang-tools # for clangd to find the correct headers
               ]);
 
               shellHook = oa.shellHook + ''


### PR DESCRIPTION
This allows clang to find the correct headers for clangd.