### PR TITLE
feat(ts): add query.list_directives

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -226,6 +226,18 @@ Here is a list of built-in predicates :
 Each predicate has a `not-` prefixed predicate that is just the negation of
 the predicate.
 
+						*vim.treesitter.query.add_predicate()*
+vim.treesitter.query.add_predicate({name}, {handler})
+
+This adds a predicate with the name {name} to be used in queries.
+{handler} should be a function whose signature will be : >
+	handler(match, pattern, bufnr, predicate)
+<
+						*vim.treesitter.query.list_predicates()*
+vim.treesitter.query.list_predicates()
+
+This lists the currently available predicates to use in queries.
+
 Treesitter Query Directive				*lua-treesitter-directives*
 
 Treesitter queries can also contain `directives`. Directives store metadata for a node
@@ -248,18 +260,6 @@ Here is a list of built-in directives:
 		offsets applied. The arguments are
 		`({capture_id}, {start_row}, {start_col}, {end_row}, {end_col}, {key?})`
 		The default key is "offset".
-
-					*vim.treesitter.query.add_predicate()*
-vim.treesitter.query.add_predicate({name}, {handler})
-
-This adds a predicate with the name {name} to be used in queries.
-{handler} should be a function whose signature will be : >
-	handler(match, pattern, bufnr, predicate)
-<
-					*vim.treesitter.query.list_predicates()*
-vim.treesitter.query.list_predicates()
-
-This lists the currently available predicates to use in queries.
 
 					*vim.treesitter.query.add_directive()*
 vim.treesitter.query.add_directive({name}, {handler})

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -249,6 +249,33 @@ Here is a list of built-in directives:
 		`({capture_id}, {start_row}, {start_col}, {end_row}, {end_col}, {key?})`
 		The default key is "offset".
 
+					*vim.treesitter.query.add_predicate()*
+vim.treesitter.query.add_predicate({name}, {handler})
+
+This adds a predicate with the name {name} to be used in queries.
+{handler} should be a function whose signature will be : >
+	handler(match, pattern, bufnr, predicate)
+<
+					*vim.treesitter.query.list_predicates()*
+vim.treesitter.query.list_predicates()
+
+This lists the currently available predicates to use in queries.
+
+					*vim.treesitter.query.add_directive()*
+vim.treesitter.query.add_directive({name}, {handler})
+
+This adds a directive with the name {name} to be used in queries.
+{handler} should be a function whose signature will be : >
+	handler(match, pattern, bufnr, predicate, metadata)
+Handlers can set match level data by setting directly on the metadata object `metadata.key = value`
+Handlers can set node level data by using the capture id on the metadata table
+`metadata[capture_id].key = value`
+
+					*vim.treesitter.query.list_directives()*
+vim.treesitter.query.list_directives()
+
+This lists the currently available directives to use in queries.
+
 Treesitter syntax highlighting (WIP)			*lua-treesitter-highlight*
 
 NOTE: This is a partially implemented feature, and not usable as a default

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -351,6 +351,11 @@ function M.add_directive(name, handler, force)
   directive_handlers[name] = handler
 end
 
+--- Returns the list of currently supported directives
+function M.list_directives()
+  return vim.tbl_keys(directive_handlers)
+end
+
 --- Returns the list of currently supported predicates
 function M.list_predicates()
   return vim.tbl_keys(predicate_handlers)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -646,6 +646,19 @@ int x = INT_MAX;
           {2, 29, 2, 68}  -- READ_STRING_OK(x, y) (char_u *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
+      it("should list all directives", function()
+        local res_list = exec_lua[[
+        local query = require'vim.treesitter.query'
+
+        local list = query.list_directives()
+
+        table.sort(list)
+
+        return list
+        ]]
+
+        eq({ 'offset!', 'set!' }, res_list)
+      end)
     end)
   end)
 


### PR DESCRIPTION
Directives have a symmetrical API when compared to predicates. So we could also add `list_directives` similar to `list_predicates`. CON: `offset!` is very much tied to injections at the moment (though the metadata could be read by anyone). Perhaps it should stay private a bit longer..?

Also put documentation of predicates into the predicates section. 

