### PR TITLE
tutor: force one sign per line

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -104,6 +104,10 @@ function! tutor#CheckLine(line)
     if exists('b:tutor_metadata') && has_key(b:tutor_metadata, 'expect')
         let bufn = bufnr('%')
         let ctext = getline(a:line)
+        let signs = sign_getplaced('.', {'lnum': a:line})[0].signs
+        if !empty(signs)
+            call sign_unplace('', {'id': signs[0].id})
+        endif
         if b:tutor_metadata['expect'][string(a:line)] == -1 || ctext ==# b:tutor_metadata['expect'][string(a:line)]
             exe "sign place ".b:tutor_sign_id." line=".a:line." name=tutorok buffer=".bufn
         else


### PR DESCRIPTION
The only thing setting signs in the tutor buffer (buftype=nofile), should be tutor.vim itself.

Instead of endlessly piling up new signs per line, just unplace any sign on the line before placing a new one.

Closes https://github.com/neovim/neovim/issues/13808
Closes https://github.com/neovim/neovim/pull/13809