### PR TITLE
[RDY] doc: Consolidate upon python -m pip invocation for the Python module

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -400,8 +400,6 @@ function! s:check_python(version) abort
     endfor
   endif
 
-  let pip = 'pip' . (a:version == 2 ? '' : '3')
-
   if empty(python_exe)
     " No Python executable can import 'neovim'. Check if any Python executable
     " can import 'pynvim'. If so, that Python failed to import 'neovim' as
@@ -413,9 +411,9 @@ function! s:check_python(version) abort
             \ 'Detected pip upgrade failure: Python executable can import "pynvim" but '
             \ . 'not "neovim": '. pynvim_exe,
             \ "Use that Python version to reinstall \"pynvim\" and optionally \"neovim\".\n"
-            \ . pip ." uninstall pynvim neovim\n"
-            \ . pip ." install pynvim\n"
-            \ . pip ." install neovim  # only if needed by third-party software")
+            \ . pynvim_exe ." -m pip uninstall pynvim neovim\n"
+            \ . pynvim_exe ." -m pip install pynvim\n"
+            \ . pynvim_exe ." -m pip install neovim  # only if needed by third-party software")
     endif
   else
     let [pyversion, current, latest, status] = s:version_info(python_exe)
@@ -440,7 +438,7 @@ function! s:check_python(version) abort
     if s:is_bad_response(current)
       call health#report_error(
         \ "pynvim is not installed.\nError: ".current,
-        \ ['Run in shell: '. pip .' install pynvim'])
+        \ ['Run in shell: '. python_exe .' -m pip install pynvim'])
     endif
 
     if s:is_bad_response(latest)

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -88,7 +88,7 @@ Example using pyenv: >
     pyenv install 3.4.4
     pyenv virtualenv 3.4.4 py3nvim
     pyenv activate py3nvim
-    pip install pynvim
+    python3 -m pip install pynvim
     pyenv which python  # Note the path
 The last command reports the interpreter path, add it to your init.vim: >
     let g:python3_host_prog = '/path/to/py3nvim/bin/python'


### PR DESCRIPTION
The current guidance for installing Python packages is to use

    python -m pip install <package_name>

Instead of

    pip install <package_name>

This ensures that one is using the version of pip that is tied to the environment's interpreter (and, thusly, its packages).  This has [been endorsed by a core maintainer](https://snarky.ca/why-you-should-use-python-m-pip/) as the recommended way to invoke pip.

As there currently are a few places where the old invocation was used, attempt to bring them in line.

Fixes #14234