### PR TITLE
startup: do "syntax enable" instead of "syntax on" after init.vim

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -375,7 +375,7 @@ int main(int argc, char **argv)
     // Does ":filetype plugin indent on".
     filetype_maybe_enable();
     // Sources syntax/syntax.vim, which calls `:filetype on`.
-    syn_maybe_on();
+    syn_maybe_enable();
   }
 
   // Read all the plugin files.

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3469,13 +3469,13 @@ static void syn_cmd_onoff(exarg_T *eap, char *name)
   }
 }
 
-void syn_maybe_on(void)
+void syn_maybe_enable(void)
 {
   if (!did_syntax_onoff) {
     exarg_T ea;
     ea.arg = (char_u *)"";
     ea.skip = false;
-    syn_cmd_onoff(&ea, "syntax");
+    syn_cmd_enable(&ea, false);
   }
 }
 


### PR DESCRIPTION
"syntax on" overwrites existing highlight groups, while "syntax enable" just sets missing groups. This change prevents user defined highlights in init.vim/lua to get overwritten. The manual recommends "syntax enable" fornew configurations anyway, "on" command was probably used as it is the implicit default.