### PR TITLE
Extmarks: flush curbuf->deleted_bytes2 after calling do_move

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -968,12 +968,6 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   mark_adjust_nofold(last_line - num_lines + 1, last_line,
                      -(last_line - dest - extra), 0L, kExtmarkNOOP);
 
-  // extmarks are handled separately
-  extmark_move_region(curbuf, line1-1, 0, start_byte,
-                      line2-line1+1, 0, extent_byte,
-                      dest+line_off, 0, dest_byte+byte_off,
-                      kExtmarkUndo);
-
   changed_lines(last_line - num_lines + 1, 0, last_line + 1, -extra, false);
 
   // send update regarding the new lines that were added
@@ -994,6 +988,11 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     else
       smsg(_("%" PRId64 " lines moved"), (int64_t)num_lines);
   }
+
+  extmark_move_region(curbuf, line1-1, 0, start_byte,
+                      line2-line1+1, 0, extent_byte,
+                      dest+line_off, 0, dest_byte+byte_off,
+                      kExtmarkUndo);
 
   /*
    * Leave the cursor on the last of the moved lines.

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -702,6 +702,7 @@ void extmark_move_region(
     int new_row, colnr_T new_col, bcount_t new_byte,
     ExtmarkOp undo)
 {
+  curbuf->deleted_bytes2 = 0;
   // TODO(bfredl): this is not synced to the buffer state inside the callback.
   // But unless we make the undo implementation smarter, this is not ensured
   // anyway.

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -889,6 +889,23 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
     end)
 
+    it("flushes deleted bytes on move", function()
+      local check_events = setup_eventcheck(verify, {"AAA", "BBB", "CCC", "DDD"})
+
+      feed(":.move+1<cr>")
+
+      check_events {
+        { "test1", "bytes", 1, 5, 0, 0, 0, 1, 0, 4, 0, 0, 0 };
+        { "test1", "bytes", 1, 5, 1, 0, 4, 0, 0, 0, 1, 0, 4 };
+      }
+
+      feed("jd2j")
+
+      check_events {
+        { "test1", "bytes", 1, 6, 2, 0, 8, 2, 0, 8, 0, 0, 0 };
+      }
+    end)
+
     teardown(function()
       os.remove "Xtest-reload"
       os.remove "Xtest-undofile"


### PR DESCRIPTION
This was causing other operations that relied on `curbuf->deleted_bytes2` (like linewise delete) to send incorrect byte sizes.

i get the sense that there may be quite a few of these types of bugs, would it be worth removing ‘curbuf->deleted_bytes2’ entirely?

@bfredl @vigoux 