### PR TITLE
fix(treesitter): do not escape in match?

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -231,7 +231,7 @@ local predicate_handlers = {
 
     local compiled_vim_regexes = setmetatable({}, {
       __index = function(t, pattern)
-        local res = vim.regex(check_magic(vim.fn.escape(pattern, '\\')))
+        local res = vim.regex(check_magic(pattern))
         rawset(t, pattern, res)
         return res
       end

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -235,6 +235,41 @@ void ui_refresh(void)
     }, res)
   end)
 
+  it('can match special regex characters like \\ * + ( with `vim-match?`', function()
+    if pending_c_parser(pending) then return end
+
+    insert('char* astring = "\\n"; (1 + 1) * 2 != 2;')
+
+    local res = exec_lua([[
+      cquery = vim.treesitter.parse_query("c", '((_) @plus (vim-match? @plus "^\\\\+$"))'..
+                                               '((_) @times (vim-match? @times "^\\\\*$"))'..
+                                               '((_) @paren (vim-match? @paren "^\\\\($"))'..
+                                               '((_) @escape (vim-match? @escape "^\\\\\\\\n$"))'..
+                                               '((_) @string (vim-match? @string "^\\"\\\\\\\\n\\"$"))')
+      parser = vim.treesitter.get_parser(0, "c")
+      tree = parser:parse()[1]
+      res = {}
+      for pattern, match in cquery:iter_matches(tree:root(), 0) do
+        -- can't transmit node over RPC. just check the name and range
+        local mrepr = {}
+        for cid,node in pairs(match) do
+          table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+        end
+        table.insert(res, {pattern, mrepr})
+      end
+      return res
+    ]])
+
+    eq({
+      { 2, { { "times", '*', 0, 4, 0, 5 } } },
+      { 5, { { "string", 'string_literal', 0, 16, 0, 20 } } },
+      { 4, { { "escape", 'escape_sequence', 0, 17, 0, 19 } } },
+      { 3, { { "paren", '(', 0, 22, 0, 23 } } },
+      { 1, { { "plus", '+', 0, 25, 0, 26 } } },
+      { 2, { { "times", '*', 0, 30, 0, 31 } } },
+    }, res)
+  end)
+
   it('allow loading query with escaped quotes and capture them with `lua-match?` and `vim-match?`', function()
     if pending_c_parser(pending) then return end
 


### PR DESCRIPTION
As mentioned here https://github.com/neovim/neovim/pull/14344#issuecomment-817199247 the `vim.escape` is actually a bug. It was only mitigated with https://github.com/neovim/neovim/issues/12595.

This enables us to also escape characters like `+`, `*`, `(` and matches the behavior of tree-sitter even though it usually doubles the backslashes. They have been not working for a long time now.

![image](https://user-images.githubusercontent.com/7189118/115063184-84f3b780-9eeb-11eb-95bf-aedc04ebfe07.png)

To match `\n` you need 4 `\\\\` first to escape the scm-string, then to escape the special character of `\` in regexes. In our Lua tests you addionally need to escape lua so `\\\\\\\\`.

Happy to break everyone's queries. Please don't hate me!