### PR TITLE
[RFC] Extmarks: remove `curbuf->deleted_bytes2` from `op_delete`

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1676,12 +1676,18 @@ int op_delete(oparg_T *oap)
 
       curbuf_splice_pending++;
       pos_T startpos = curwin->w_cursor;  // start position for delete
+      bcount_t deleted_bytes = (bcount_t)STRLEN(
+          ml_get(startpos.lnum)) + 1 - startpos.col;
       truncate_line(true);        // delete from cursor to end of line
 
       curpos = curwin->w_cursor;  // remember curwin->w_cursor
       curwin->w_cursor.lnum++;
+
+      for (linenr_T i = 1; i <= oap->line_count - 2; i++) {
+        deleted_bytes += (bcount_t)STRLEN(
+            ml_get(startpos.lnum + i)) + 1;
+      }
       del_lines(oap->line_count - 2, false);
-      bcount_t deleted_bytes = (bcount_t)curbuf->deleted_bytes2 - startpos.col;
 
       // delete from start of line until op_end
       n = (oap->end.col + 1 - !oap->inclusive);

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -461,6 +461,36 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("deleting lines", function()
+      local check_events = setup_eventcheck(verify, origlines)
+
+      feed("dd")
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 1, 0, 16, 0, 0, 0 };
+      }
+
+      feed("d2j")
+
+      check_events {
+        { "test1", "bytes", 1, 4, 0, 0, 0, 3, 0, 48, 0, 0, 0 };
+      }
+
+      feed("ld<c-v>2j")
+
+      check_events {
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 1, 1, 0, 0, 0 };
+        { "test1", "bytes", 1, 5, 1, 1, 16, 0, 1, 1, 0, 0, 0 };
+        { "test1", "bytes", 1, 5, 2, 1, 31, 0, 1, 1, 0, 0, 0 };
+      }
+
+      feed("vjwd")
+
+      check_events {
+        { "test1", "bytes", 1, 10, 0, 1, 1, 1, 9, 23, 0, 0, 0 };
+      }
+    end)
+
     it("changing lines", function()
       local check_events = setup_eventcheck(verify, origlines)
 


### PR DESCRIPTION
Should hopefully make deleting lines more robust.

@bfredl @vigoux 