### PR TITLE
Close floating windows when calling win_close()

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -506,7 +506,7 @@ void nvim_win_hide(Window window, Error *err)
   TryState tstate;
   try_enter(&tstate);
   if (tabpage == curtab) {
-    win_close(win, false);
+    win_close(win, false, false);
   } else {
     win_close_othertab(win, false, tabpage);
   }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -863,7 +863,7 @@ void goto_buffer(exarg_T *eap, int start, int dir, int count)
     enter_cleanup(&cs);
 
     // Quitting means closing the split window, nothing else.
-    win_close(curwin, true);
+    win_close(curwin, true, false);
     swap_exists_action = SEA_NONE;
     swap_exists_did_quit = true;
 
@@ -1274,7 +1274,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     while (buf == curbuf
            && !(curwin->w_closing || curwin->w_buffer->b_locked > 0)
            && (!ONE_WINDOW || first_tabpage->tp_next != NULL)) {
-      if (win_close(curwin, false) == FAIL) {
+      if (win_close(curwin, false, false) == FAIL) {
         break;
       }
     }
@@ -4888,7 +4888,7 @@ void do_arg_all(int count, int forceit, int keep_tabs)
               && (first_tabpage->tp_next == NULL || !had_tab)) {
             use_firstwin = true;
           } else {
-            win_close(wp, !buf_hide(buf) && !bufIsChanged(buf));
+            win_close(wp, !buf_hide(buf) && !bufIsChanged(buf), false);
             // check if autocommands removed the next window
             if (!win_valid(wpnext)) {
               // start all over...
@@ -5079,7 +5079,7 @@ void ex_buffer_all(exarg_T *eap)
           && !ONE_WINDOW
           && !(wp->w_closing ||
                wp->w_buffer->b_locked > 0)) {
-        win_close(wp, false);
+        win_close(wp, false, false);
         wpnext = firstwin;              // just in case an autocommand does
                                         // something strange with windows
         tpnext = first_tabpage;         // start all over...
@@ -5160,7 +5160,7 @@ void ex_buffer_all(exarg_T *eap)
         enter_cleanup(&cs);
 
         // User selected Quit at ATTENTION prompt; close this window.
-        win_close(curwin, true);
+        win_close(curwin, true, false);
         open_wins--;
         swap_exists_action = SEA_NONE;
         swap_exists_did_quit = true;
@@ -5202,7 +5202,7 @@ void ex_buffer_all(exarg_T *eap)
       // BufWrite Autocommands made the window invalid, start over
       wp = lastwin;
     } else if (r) {
-      win_close(wp, !buf_hide(wp->w_buffer));
+      win_close(wp, !buf_hide(wp->w_buffer), false);
       open_wins--;
       wp = lastwin;
     } else {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5823,7 +5823,7 @@ void ex_helpclose(exarg_T *eap)
 {
   FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
     if (bt_help(win->w_buffer)) {
-      win_close(win, false);
+      win_close(win, false, eap->forceit);
       return;
     }
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6556,7 +6556,7 @@ static void ex_quit(exarg_T *eap)
     }
     not_exiting();
     // close window; may free buffer
-    win_close(wp, !buf_hide(wp->w_buffer) || eap->forceit);
+    win_close(wp, !buf_hide(wp->w_buffer) || eap->forceit, eap->forceit);
   }
 }
 
@@ -6671,7 +6671,7 @@ void ex_win_close(int forceit, win_T *win, tabpage_T *tp)
 
   // free buffer when not hiding it or when it's a scratch buffer
   if (tp == NULL) {
-    win_close(win, !need_hide && !buf_hide(buf));
+    win_close(win, !need_hide && !buf_hide(buf), forceit);
   } else {
     win_close_othertab(win, !need_hide && !buf_hide(buf), tp);
   }
@@ -6850,7 +6850,7 @@ static void ex_hide(exarg_T *eap)
       if (win == NULL) {
         win = lastwin;
       }
-      win_close(win, false);
+      win_close(win, false, eap->forceit);
     }
   }
 }
@@ -6908,7 +6908,7 @@ static void ex_exit(exarg_T *eap)
     }
     not_exiting();
     // Quit current window, may free the buffer.
-    win_close(curwin, !buf_hide(curwin->w_buffer));
+    win_close(curwin, !buf_hide(curwin->w_buffer), eap->forceit);
   }
 }
 
@@ -7512,7 +7512,7 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
           /* Reset the error/interrupt/exception state here so that
            * aborting() returns FALSE when closing a window. */
           enter_cleanup(&cs);
-          win_close(curwin, !need_hide && !buf_hide(curbuf));
+          win_close(curwin, !need_hide && !buf_hide(curbuf), false);
 
           /* Restore the error/interrupt/exception state if not
            * discarded by a new aborting error, interrupt, or

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6835,7 +6835,7 @@ static void ex_hide(exarg_T *eap)
   // ":hide" or ":hide | cmd": hide current window
   if (!eap->skip) {
     if (eap->addr_count == 0) {
-      win_close(curwin, false);  // don't free buffer
+      win_close(curwin, false, eap->forceit);  // don't free buffer
     } else {
       int winnr = 0;
       win_T *win = NULL;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6455,7 +6455,7 @@ static int open_cmdwin(void)
     set_bufref(&bufref, curbuf);
     win_goto(old_curwin);
     if (win_valid(wp) && wp != curwin) {
-      win_close(wp, true);
+      win_close(wp, true, false);
     }
 
     // win_close() may have already wiped the buffer when 'bh' is

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1535,7 +1535,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
 
   // When w_arg_idx is -1 remove the window (see create_windows()).
   if (curwin->w_arg_idx == -1) {
-    win_close(curwin, true);
+    win_close(curwin, true, false);
     advance = false;
   }
 
@@ -1547,7 +1547,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
     // When w_arg_idx is -1 remove the window (see create_windows()).
     if (curwin->w_arg_idx == -1) {
       arg_idx++;
-      win_close(curwin, true);
+      win_close(curwin, true, false);
       advance = false;
       continue;
     }
@@ -1594,7 +1594,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
           did_emsg = FALSE;             // avoid hit-enter prompt
           getout(1);
         }
-        win_close(curwin, true);
+        win_close(curwin, true, false);
         advance = false;
       }
       if (arg_idx == GARGCOUNT - 1) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2995,7 +2995,7 @@ static void qf_jump_newwin(qf_info_T *qi, int dir, int errornr, int forceit, boo
 
   if (retval != OK) {
     if (opened_window) {
-      win_close(curwin, true);          // Close opened window
+      win_close(curwin, true, false);          // Close opened window
     }
     if (qf_ptr != NULL && qf_ptr->qf_fnum != 0) {
       // Couldn't open file, so put index back where it was.  This could
@@ -3550,7 +3550,7 @@ void ex_cclose(exarg_T *eap)
   // Find existing quickfix window and close it.
   win = qf_find_win(qi);
   if (win != NULL) {
-    win_close(win, false);
+    win_close(win, false, false);
   }
 }
 
@@ -3624,7 +3624,7 @@ static int qf_open_new_cwindow(qf_info_T *qi, int height)
   // win_split, so add a check to ensure that the win is still here
   if (IS_LL_STACK(qi) && !win_valid(win)) {
     // close the window that was supposed to be for the loclist
-    win_close(curwin, false);
+    win_close(curwin, false, false);
     return FAIL;
   }
 
@@ -5676,7 +5676,7 @@ static void wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
     if (firstwin->w_next != NULL) {
       for (win_T *wp = firstwin; wp != NULL; wp = wp->w_next) {
         if (wp->w_buffer == buf) {
-          if (win_close(wp, false) == OK) {
+          if (win_close(wp, false, false) == OK) {
             did_one = true;
           }
           break;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2916,7 +2916,7 @@ static int jumpto_tag(
   } else {
     RedrawingDisabled--;
     if (postponed_split) {              // close the window
-      win_close(curwin, false);
+      win_close(curwin, false, false);
       postponed_split = 0;
     }
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -306,7 +306,7 @@ newwindow:
         newtab = curtab;
         goto_tabpage_tp(oldtab, true, true);
         if (curwin == wp) {
-          win_close(curwin, false);
+          win_close(curwin, false, false);
         }
         if (valid_tabpage(newtab)) {
           goto_tabpage_tp(newtab, true, true);
@@ -451,7 +451,7 @@ wingotofile:
         RESET_BINDING(curwin);
         if (do_ecmd(0, ptr, NULL, NULL, ECMD_LASTL, ECMD_HIDE, NULL) == FAIL) {
           // Failed to open the file, close the window opened for it.
-          win_close(curwin, false);
+          win_close(curwin, false, false);
           goto_tabpage_win(oldtab, oldwin);
         } else if (nchar == 'F' && lnum >= 0) {
           curwin->w_cursor.lnum = lnum;
@@ -2242,7 +2242,7 @@ void close_windows(buf_T *buf, int keep_curwin)
   for (win_T *wp = firstwin; wp != NULL && !ONE_WINDOW; ) {
     if (wp->w_buffer == buf && (!keep_curwin || wp != curwin)
         && !(wp->w_closing || wp->w_buffer->b_locked > 0)) {
-      if (win_close(wp, false) == FAIL) {
+      if (win_close(wp, false, false) == FAIL) {
         // If closing the window fails give up, to avoid looping forever.
         break;
       }
@@ -2320,6 +2320,22 @@ bool last_nonfloat(win_T *wp) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
   return wp != NULL && firstwin == wp && !(wp->w_next && !wp->w_floating);
 }
 
+/// Check if floating windows can be closed.
+///
+/// @return true if all floating windows can be closed
+static bool can_close_floating_windows(tabpage_T *tab, bool forceit)
+{
+  FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
+    buf_T *buf = wp->w_buffer;
+    int need_hide = (bufIsChanged(buf) && buf->b_nwindows <= 1);
+
+    if (need_hide && !buf_hide(buf) && !forceit) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Close the possibly last window in a tab page.
 ///
 /// @param  win          window to close
@@ -2383,7 +2399,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, tabpage_T *prev
 //
 // Called by :quit, :close, :xit, :wq and findtag().
 // Returns FAIL when the window was not closed.
-int win_close(win_T *win, bool free_buf)
+int win_close(win_T *win, bool free_buf, bool force)
 {
   win_T *wp;
   bool other_buffer = false;
@@ -2413,9 +2429,17 @@ int win_close(win_T *win, bool free_buf)
   }
   if ((firstwin == win && lastwin_nofloating() == win)
       && lastwin->w_floating) {
-    // TODO(bfredl): we might close the float also instead
-    EMSG(e_floatonly);
-    return FAIL;
+    if (can_close_floating_windows(curtab, force)) {
+      FOR_ALL_WINDOWS_IN_TAB(wpp, curtab) {
+        if (wpp->w_floating) {
+          win_close(wpp, free_buf, force);
+        }
+      }
+    }
+    else {
+      EMSG(e_floatonly);
+      return FAIL;
+    }
   }
 
   /* When closing the last window in a tab page first go to another tab page
@@ -3560,7 +3584,7 @@ void close_others(int message, int forceit)
         continue;
       }
     }
-    win_close(wp, !buf_hide(wp->w_buffer) && !bufIsChanged(wp->w_buffer));
+    win_close(wp, !buf_hide(wp->w_buffer) && !bufIsChanged(wp->w_buffer), false);
   }
 
   if (message && !ONE_WINDOW) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2325,11 +2325,15 @@ bool last_nonfloat(win_T *wp) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 /// @return true if all floating windows can be closed
 static bool can_close_floating_windows(tabpage_T *tab, bool forceit)
 {
+  if (forceit) {
+    return true;
+  }
+
   FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
     buf_T *buf = wp->w_buffer;
     int need_hide = (bufIsChanged(buf) && buf->b_nwindows <= 1);
 
-    if (need_hide && !buf_hide(buf) && !forceit) {
+    if (need_hide && !buf_hide(buf)) {
       return false;
     }
   }
@@ -2435,8 +2439,7 @@ int win_close(win_T *win, bool free_buf, bool force)
           win_close(wpp, free_buf, force);
         }
       }
-    }
-    else {
+    } else {
       EMSG(e_floatonly);
       return FAIL;
     }
@@ -3584,7 +3587,9 @@ void close_others(int message, int forceit)
         continue;
       }
     }
-    win_close(wp, !buf_hide(wp->w_buffer) && !bufIsChanged(wp->w_buffer), false);
+    win_close(wp,
+              !buf_hide(wp->w_buffer) && !bufIsChanged(wp->w_buffer),
+              false);
   }
 
   if (message && !ONE_WINDOW) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -278,6 +278,27 @@ describe('float window', function()
     eq(12, pos[2])
   end)
 
+  it('closed when the last non-float window is closed', function()
+    local tabpage = exec_lua([[
+      vim.cmd('edit ./src/nvim/main.c')
+      vim.cmd('tabedit %')
+
+      local buf = vim.api.nvim_create_buf(false, true)
+      local win = vim.api.nvim_open_win(buf, false, {
+        relative = 'win',
+        row = 1,
+        col = 1,
+        width = 10,
+        height = 2
+      })
+
+      vim.cmd('quit')
+
+      return vim.api.nvim_get_current_tabpage()
+    ]])
+
+    eq(1, tabpage)
+  end)
 
   local function with_ext_multigrid(multigrid)
     local screen


### PR DESCRIPTION
Closes #11440

Closes floating windows when `win_close()` is called. When there are modified non-hideable buffers in the floating windows, fails unless `force` is passed to `win_close(buf, free_buf, force)`.

I introduced a new parameter to `win_close()` instead of re-using `free_buf` because the way it is used currently didn't seem to match exactly the wanted behavior here, but I could try to make it fit if another parameter is juged too much.