### PR TITLE
feat(api): get width without margin

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -168,9 +168,10 @@ void nvim_win_set_height(Window window, Integer height, Error *err)
 /// Gets the window width
 ///
 /// @param window   Window handle, or 0 for current window
+/// @param inner    Exclude the left margin
 /// @param[out] err Error details, if any
 /// @return Width as a count of columns
-Integer nvim_win_get_width(Window window, Error *err)
+Integer nvim_win_get_width(Window window, Boolean inner, Error *err)
   FUNC_API_SINCE(1)
 {
   win_T *win = find_window_by_handle(window, err);
@@ -179,7 +180,11 @@ Integer nvim_win_get_width(Window window, Error *err)
     return 0;
   }
 
-  return win->w_width;
+  if (inner) {
+    return win->w_width - win_col_off(win);
+  } else {
+    return win->w_width;
+  }
 }
 
 /// Sets the window width. This will only succeed if the screen is split


### PR DESCRIPTION
Needed for https://github.com/romgrk/nvim-treesitter-context so we can remove the [hacky gutter width code](https://github.com/romgrk/nvim-treesitter-context/blob/6855cc725ee7d98dff00886d22d687ef7ba82c4f/lua/treesitter-context.lua#L149) which messes with the cursor.

This is an API breaking change. Ideally I'd like the new `inner` argument to be optional and default to `false` but AFAIK the api doesn't have varargs like the legacy vim functions have.