### PR TITLE
vim-patch:8.2.2776

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -690,18 +690,16 @@ static int makeopens(FILE *fd, char_u *dirnow)
       return FAIL;
     }
 
-    //
-    // Save current window layout.
-    //
-    PUTLINE_FAIL("set splitbelow splitright");
-    if (ses_win_rec(fd, tab_topframe) == FAIL) {
-      return FAIL;
-    }
-    if (!p_sb && put_line(fd, "set nosplitbelow") == FAIL) {
-      return FAIL;
-    }
-    if (!p_spr && put_line(fd, "set nosplitright") == FAIL) {
-      return FAIL;
+    if (tab_topframe->fr_layout != FR_LEAF) {
+      // Save current window layout.
+      PUTLINE_FAIL("let s:save_splitbelow = &splitbelow");
+      PUTLINE_FAIL("let s:save_splitright = &splitright");
+      PUTLINE_FAIL("set splitbelow splitright");
+      if (ses_win_rec(fd, tab_topframe) == FAIL) {
+        return FAIL;
+      }
+      PUTLINE_FAIL("let &splitbelow = s:save_splitbelow");
+      PUTLINE_FAIL("let &splitright = s:save_splitright");
     }
 
     //
@@ -720,22 +718,26 @@ static int makeopens(FILE *fd, char_u *dirnow)
       }
     }
 
-    // Go to the first window.
-    PUTLINE_FAIL("wincmd t");
+    if (tab_firstwin->w_next != NULL) {
+      // Go to the first window.
+      PUTLINE_FAIL("wincmd t");
 
-    // If more than one window, see if sizes can be restored.
-    // First set 'winheight' and 'winwidth' to 1 to avoid the windows being
-    // resized when moving between windows.
-    // Do this before restoring the view, so that the topline and the
-    // cursor can be set.  This is done again below.
-    // winminheight and winminwidth need to be set to avoid an error if the
-    // user has set winheight or winwidth.
-    if (fprintf(fd,
-                "set winminheight=0\n"
-                "set winheight=1\n"
-                "set winminwidth=0\n"
-                "set winwidth=1\n") < 0) {
-      return FAIL;
+      // If more than one window, see if sizes can be restored.
+      // First set 'winheight' and 'winwidth' to 1 to avoid the windows
+      // being resized when moving between windows.
+      // Do this before restoring the view, so that the topline and the
+      // cursor can be set.  This is done again below.
+      // winminheight and winminwidth need to be set to avoid an error if
+      // the user has set winheight or winwidth.
+      PUTLINE_FAIL("let s:save_winminheight = &winminheight");
+      PUTLINE_FAIL("let s:save_winminwidth = &winminwidth");
+      if (fprintf(fd,
+                  "set winminheight=0\n"
+                  "set winheight=1\n"
+                  "set winminwidth=0\n"
+                  "set winwidth=1\n") < 0) {
+        return FAIL;
+      }
     }
     if (nr > 1 && ses_winsizes(fd, restore_size, tab_firstwin) == FAIL) {
       return FAIL;
@@ -817,17 +819,19 @@ static int makeopens(FILE *fd, char_u *dirnow)
     return FAIL;
   }
 
-  // Re-apply options.
+  // Re-apply 'winheight', 'winwidth' and 'shortmess'.
   if (fprintf(fd,
               "set winheight=%" PRId64 " winwidth=%" PRId64
-              " winminheight=%" PRId64 " winminwidth=%" PRId64
               " shortmess=%s\n",
               (int64_t)p_wh,
               (int64_t)p_wiw,
-              (int64_t)p_wmh,
-              (int64_t)p_wmw,
               p_shm) < 0) {
     return FAIL;
+  }
+  if (tab_firstwin->w_next != NULL) {
+    // Restore 'winminheight' and 'winminwidth'.
+    PUTLINE_FAIL("let &winminheight = s:save_winminheight");
+    PUTLINE_FAIL("let &winminwidth = s:save_winminwidth");
   }
 
   //

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -680,6 +680,24 @@ func Test_mksession_winpos()
   set sessionoptions&
 endfunc
 
+" Test for mksession without options restores winminheight
+func Test_mksession_winminheight()
+  set sessionoptions-=options
+  split
+  mksession! Xtest_mks.out
+  let found_restore = 0
+  let lines = readfile('Xtest_mks.out')
+  for line in lines
+    if line =~ '= s:save_winmin\(width\|height\)'
+      let found_restore += 1
+    endif
+  endfor
+  call assert_equal(2, found_restore)
+  call delete('Xtest_mks.out')
+  close
+  set sessionoptions&
+endfunc
+
 " Test for mksession with 'compatible' option
 func Test_mksession_compatible()
   throw 'skipped: Nvim does not support "compatible" option'


### PR DESCRIPTION
Patch v8.2.1682 is not ported.
Replace "goto fail;" with "return FAIL;".