### PR TITLE
alias vim.api.nvim_exec -> vim.cmd

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -309,7 +309,9 @@ setmetatable(vim, {
 })
 
 -- An easier alias for commands.
-vim.cmd = vim.api.nvim_command
+vim.cmd = function(command)
+  return vim.api.nvim_exec(command, false)
+end
 
 -- These are the vim.env/v/g/o/bo/wo variable magic accessors.
 do


### PR DESCRIPTION
Previously vim.cmd was an alias to nvim_command
From now on it is an alias to nvim_exec