### PR TITLE
win/package: remove cat,tidy

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -506,11 +506,9 @@ if(WIN32)
     "file(MAKE_DIRECTORY \"${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms\")")
   foreach(DEP_FILE IN ITEMS
                       ca-bundle.crt
-                      cat.exe
                       curl.exe
                       diff.exe
                       tee.exe
-                      tidy.exe
                       win32yank.exe
                       winpty-agent.exe
                       winpty.dll

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -175,7 +175,7 @@ set(LUA_COMPAT53_SHA256 bec3a23114a3d9b3218038309657f0f506ad10dfbc03bb54e91da7e5
 set(GPERF_URL https://github.com/neovim/deps/raw/ff5b4b18a87397a8564016071ae64f64bcd8c635/opt/gperf-3.1.tar.gz)
 set(GPERF_SHA256 588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2)
 
-# 7za.exe cat.exe curl.exe ca-bundle.crt diff.exe tee.exe tidy.exe xxd.exe
+# cat.exe curl.exe ca-bundle.crt diff.exe tee.exe xxd.exe
 set(WINTOOLS_URL https://github.com/neovim/deps/raw/2f9acbecf06365c10baa3c0087f34a54c9c6f949/opt/win32tools.zip)
 set(WINTOOLS_SHA256 8bfce7e3a365721a027ce842f2ec1cf878f1726233c215c05964aac07300798c)
 


### PR DESCRIPTION
Neovim should not bundle external tools
that are not needed in the runtime environment.

cat.exe is meant for tests only.
Install a mingw/msys2/busybox environment which bundle cat.exe.
tidy.exe was never used in tests and is not required in Neovim runtime.
busybox and tidy.exe can be installed via scoop.

Ref: https://github.com/neovim/neovim/issues/14078