### PR TITLE
vim-patch:8.2.{0174,1933,1935,1946,2286,2287}

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1742,13 +1742,21 @@ Vim has a sorting function and a sorting command.  The sorting function can be
 found here: |sort()|, |uniq()|.
 
 							*:sor* *:sort*
-:[range]sor[t][!] [b][f][i][n][o][r][u][x] [/{pattern}/]
+:[range]sor[t][!] [b][f][i][l][n][o][r][u][x] [/{pattern}/]
 			Sort lines in [range].  When no range is given all
 			lines are sorted.
 
 			With [!] the order is reversed.
 
 			With [i] case is ignored.
+
+			With [l] sort uses the current locale. See
+			`language collate` to check or set the locale used
+			for ordering. For example, with "en_US.UTF8",
+			Ö will be ordered after O and before P,
+			whereas with the Swedish locale "sv_SE.UTF8",
+			it will be after Z.
+			Case is typically ignored by the locale.
 
 			Options [n][f][x][o][b] are mutually exclusive.
 
@@ -1816,8 +1824,7 @@ found here: |sort()|, |uniq()|.
 Note that using `:sort` with `:global` doesn't sort the matching lines, it's
 quite useless.
 
-The details about sorting depend on the library function used.  There is no
-guarantee that sorting obeys the current locale.  You will have to try it out.
+`:sort` does not use the current locale unless the l flag is used.
 Vim does do a "stable" sort.
 
 The sorting can be interrupted, but if you interrupt it too late in the

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1750,13 +1750,15 @@ found here: |sort()|, |uniq()|.
 
 			With [i] case is ignored.
 
-			With [l] sort uses the current locale. See
-			`language collate` to check or set the locale used
-			for ordering. For example, with "en_US.UTF8",
-			Ö will be ordered after O and before P,
-			whereas with the Swedish locale "sv_SE.UTF8",
-			it will be after Z.
-			Case is typically ignored by the locale.
+			With [l] sort uses the current collation locale.
+			Implementation details: strcoll() is used to compare
+			strings. See |:language| to check or set the collation
+			locale. Example: >
+				:language collate en_US.UTF-8
+				:%sort l
+<			|v:collate| can also used to check the current locale.
+			Sorting using the locale typically ignores case.
+			This does not work properly on Mac.
 
 			Options [n][f][x][o][b] are mutually exclusive.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8359,15 +8359,25 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		When {func} is given and it is '1' or 'i' then case is
 		ignored.
 
-		When {func} is given and it is 'l' then the current locale
-		is used for ordering. See `language collate` to check or set
-		the locale used for ordering.  For example, with "en_US.UTF8",
-		Ö will be ordered after O and before P, whereas with the
-		Swedish locale "sv_SE.UTF8", it will be after Z.
-		Case is typically ignored by the locale.
+		When {func} is given and it is 'l' then the current collation
+		locale is used for ordering. Implementation details: strcoll()
+		is used to compare strings. See |:language| check or set the
+		collation locale. |v:collate| can also be used to check the
+		current locale. Sorting using the locale typically ignores
+		case. Example: >
+			" ö is sorted similarly to o with English locale.
+			:language collate en_US.UTF8
+			:echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<			['n', 'o', 'O', 'ö', 'p', 'z'] ~
+>
+			" ö is sorted after z with Swedish locale.
+			:language collate sv_SE.UTF8
+			:echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<			['n', 'o', 'O', 'p', 'z', 'ö'] ~
+		This does not work properly on Mac.
 
 		When {func} is given and it is 'n' then all items will be
-		sorted numerical (Implementation detail: This uses the
+		sorted numerical (Implementation detail: this uses the
 		strtod() function to parse numbers, Strings, Lists, Dicts and
 		Funcrefs will be considered as being 0).
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1495,6 +1495,15 @@ v:cmdarg	This variable is used for two purposes:
 		   the argument for the ":hardcopy" command.  This can be used
 		   in 'printexpr'.
 
+						*v:collate* *collate-variable*
+v:collate	The current locale setting for collation order of the runtime
+		environment.  This allows Vim scripts to be aware of the
+		current locale encoding.  Technical: it's the value of
+		LC_COLLATE.  When not using a locale the value is "C".
+		This variable can not be set directly, use the |:language|
+		command.
+		See |multi-lang|.
+
 					*v:cmdbang* *cmdbang-variable*
 v:cmdbang	Set like v:cmdarg for a file read/write command.  When a "!"
 		was used the value is 1, otherwise it is 0.  Note that this

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8359,6 +8359,13 @@ sort({list} [, {func} [, {dict}]])			*sort()* *E702*
 		When {func} is given and it is '1' or 'i' then case is
 		ignored.
 
+		When {func} is given and it is 'l' then the current locale
+		is used for ordering. See `language collate` to check or set
+		the locale used for ordering.  For example, with "en_US.UTF8",
+		Ö will be ordered after O and before P, whereas with the
+		Swedish locale "sv_SE.UTF8", it will be after Z.
+		Case is typically ignored by the locale.
+
 		When {func} is given and it is 'n' then all items will be
 		sorted numerical (Implementation detail: This uses the
 		strtod() function to parse numbers, Strings, Lists, Dicts and

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -31,6 +31,7 @@ use of "-" and "_".
 :lan[guage] mes[sages]
 :lan[guage] cty[pe]
 :lan[guage] tim[e]
+:lan[guage] col[late]
 			Print the current language (aka locale).
 			With the "messages" argument the language used for
 			messages is printed.  Technical: LC_MESSAGES.
@@ -38,15 +39,19 @@ use of "-" and "_".
 			character encoding is printed.  Technical: LC_CTYPE.
 			With the "time" argument the language used for
 			strftime() is printed.  Technical: LC_TIME.
+			With the "collate" argument the language used for
+			collation order is printed.  Technical: LC_COLLATE.
 			Without argument all parts of the locale are printed
 			(this is system dependent).
 			The current language can also be obtained with the
-			|v:lang|, |v:ctype| and |v:lc_time| variables.
+			|v:lang|, |v:ctype|, |v:collate| and |v:lc_time|
+			variables.
 
 :lan[guage] {name}
 :lan[guage] mes[sages] {name}
 :lan[guage] cty[pe] {name}
 :lan[guage] tim[e] {name}
+:lan[guage] col[late] {name}
 			Set the current language (aka locale) to {name}.
 			The locale {name} must be a valid locale on your
 			system.  Some systems accept aliases like "en" or
@@ -66,7 +71,10 @@ use of "-" and "_".
 			With the "time" argument the language used for time
 			and date messages is set.  This affects strftime().
 			This sets $LC_TIME.
-			Without an argument both are set, and additionally
+			With the "collate" argument the language used for the
+			collation order is set.  This affects sorting of
+			characters. This sets $LC_COLLATE.
+			Without an argument all are set, and additionally
 			$LANG is set.
 			The LC_NUMERIC value will always be set to "C" so
 			that floating point numbers use '.' as the decimal

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -225,6 +225,7 @@ static struct vimvar {
   VV(VV_EVENT,          "event",            VAR_DICT, VV_RO),
   VV(VV_ECHOSPACE,      "echospace",        VAR_NUMBER, VV_RO),
   VV(VV_ARGV,           "argv",             VAR_LIST, VV_RO),
+  VV(VV_COLLATE,        "collate",          VAR_STRING, VV_RO),
   VV(VV_EXITING,        "exiting",          VAR_NUMBER, VV_RO),
   // Neovim
   VV(VV_STDERR,         "stderr",           VAR_NUMBER, VV_RO),

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -154,6 +154,7 @@ typedef enum {
     VV_EVENT,
     VV_ECHOSPACE,
     VV_ARGV,
+    VV_COLLATE,
     VV_EXITING,
     // Neovim
     VV_STDERR,

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9166,6 +9166,7 @@ static void f_sockconnect(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// struct storing information about current sort
 typedef struct {
   int item_compare_ic;
+  bool item_compare_lc;
   bool item_compare_numeric;
   bool item_compare_numbers;
   bool item_compare_float;
@@ -9240,10 +9241,10 @@ static int item_compare(const void *s1, const void *s2, bool keep_zero)
     p2 = "";
   }
   if (!sortinfo->item_compare_numeric) {
-    if (sortinfo->item_compare_ic) {
-      res = STRICMP(p1, p2);
+    if (sortinfo->item_compare_lc) {
+      res = strcoll(p1, p2);
     } else {
-      res = STRCMP(p1, p2);
+      res = sortinfo->item_compare_ic ? STRICMP(p1, p2): STRCMP(p1, p2);
     }
   } else {
     double n1, n2;
@@ -9378,6 +9379,7 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
     }
 
     info.item_compare_ic = false;
+    info.item_compare_lc = false;
     info.item_compare_numeric = false;
     info.item_compare_numbers = false;
     info.item_compare_float = false;
@@ -9422,6 +9424,9 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
           } else if (strcmp(info.item_compare_func, "i") == 0) {
             info.item_compare_func = NULL;
             info.item_compare_ic = true;
+          } else if (strcmp(info.item_compare_func, "l") == 0) {
+            info.item_compare_func = NULL;
+            info.item_compare_lc = true;
           }
         }
       }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3627,6 +3627,14 @@ void set_lang_var(void)
   loc = get_locale_val(LC_TIME);
 # endif
   set_vim_var_string(VV_LC_TIME, loc, -1);
+
+# ifdef HAVE_GET_LOCALE_VAL
+  loc = get_locale_val(LC_COLLATE);
+# else
+  // setlocale() not supported: use the default value
+  loc = "C";
+# endif
+  set_vim_var_string(VV_COLLATE, loc, -1);
 }
 
 #ifdef HAVE_WORKING_LIBINTL
@@ -3667,6 +3675,10 @@ void ex_language(exarg_T *eap)
       what = LC_TIME;
       name = skipwhite(p);
       whatstr = "time ";
+    } else if (STRNICMP(eap->arg, "collate", p - eap->arg) == 0) {
+      what = LC_COLLATE;
+      name = skipwhite(p);
+      whatstr = "collate ";
     }
   }
 
@@ -3711,7 +3723,7 @@ void ex_language(exarg_T *eap)
       // Reset $LC_ALL, otherwise it would overrule everything.
       os_setenv("LC_ALL", "", 1);
 
-      if (what != LC_TIME) {
+      if (what != LC_TIME && what != LC_COLLATE) {
         // Tell gettext() what to translate to.  It apparently doesn't
         // use the currently effective locale.
         if (what == LC_ALL) {
@@ -3726,7 +3738,7 @@ void ex_language(exarg_T *eap)
         }
       }
 
-      // Set v:lang, v:lc_time and v:ctype to the final result.
+      // Set v:lang, v:lc_time, v:collate and v:ctype to the final result.
       set_lang_var();
       maketitle();
     }
@@ -3811,12 +3823,15 @@ char_u *get_lang_arg(expand_T *xp, int idx)
   if (idx == 2) {
     return (char_u *)"time";
   }
+  if (idx == 3) {
+    return (char_u *)"collate";
+  }
 
   init_locales();
   if (locales == NULL) {
     return NULL;
   }
-  return locales[idx - 3];
+  return locales[idx - 4];
 }
 
 /// Function given to ExpandGeneric() to obtain the available locales.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3642,7 +3642,8 @@ const char * set_one_cmd_context(
     } else {
       if (strncmp(arg, "messages", p - arg) == 0
           || strncmp(arg, "ctype", p - arg) == 0
-          || strncmp(arg, "time", p - arg) == 0) {
+          || strncmp(arg, "time", p - arg) == 0
+          || strncmp(arg, "collate", p - arg) == 0) {
         xp->xp_context = EXPAND_LOCALES;
         xp->xp_pattern = skipwhite((const char_u *)p);
       } else {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -615,10 +615,20 @@ func Test_cmdline_complete_bang()
 endfunc
 
 funct Test_cmdline_complete_languages()
+  let lang = substitute(execute('language time'), '.*"\(.*\)"$', '\1', '')
+  call assert_equal(lang, v:lc_time)
+
+  let lang = substitute(execute('language ctype'), '.*"\(.*\)"$', '\1', '')
+  call assert_equal(lang, v:ctype)
+
+  let lang = substitute(execute('language collate'), '.*"\(.*\)"$', '\1', '')
+  call assert_equal(lang, v:collate)
+
   let lang = substitute(execute('language messages'), '.*"\(.*\)"$', '\1', '')
+  call assert_equal(lang, v:lang)
 
   call feedkeys(":language \<c-a>\<c-b>\"\<cr>", 'tx')
-  call assert_match('^"language .*\<ctype\>.*\<messages\>.*\<time\>', @:)
+  call assert_match('^"language .*\<collate\>.*\<ctype\>.*\<messages\>.*\<time\>', @:)
 
   if has('unix')
     " TODO: these tests don't work on Windows. lang appears to be 'C'
@@ -632,6 +642,9 @@ funct Test_cmdline_complete_languages()
     call assert_match('^"language .*\<' . lang . '\>', @:)
 
     call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
+    call assert_match('^"language .*\<' . lang . '\>', @:)
+
+    call feedkeys(":language collate \<c-a>\<c-b>\"\<cr>", 'tx')
     call assert_match('^"language .*\<' . lang . '\>', @:)
   endif
 endfunc

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -54,6 +54,132 @@ func Test_buffers_lastused()
   bwipeout bufc
 endfunc
 
+" Test for the :copy command
+func Test_copy()
+  new
+
+  call setline(1, ['L1', 'L2', 'L3', 'L4'])
+  " copy lines in a range to inside the range
+  1,3copy 2
+  call assert_equal(['L1', 'L2', 'L1', 'L2', 'L3', 'L3', 'L4'], getline(1, 7))
+
+  close!
+endfunc
+
+" Test for the :file command
+func Test_file_cmd()
+  call assert_fails('3file', 'E474:')
+  call assert_fails('0,0file', 'E474:')
+  call assert_fails('0file abc', 'E474:')
+endfunc
+
+" Test for the :drop command
+func Test_drop_cmd()
+  call writefile(['L1', 'L2'], 'Xfile')
+  enew | only
+  drop Xfile
+  call assert_equal('L2', getline(2))
+  " Test for switching to an existing window
+  below new
+  drop Xfile
+  call assert_equal(1, winnr())
+  " Test for splitting the current window
+  enew | only
+  set modified
+  drop Xfile
+  call assert_equal(2, winnr('$'))
+  " Check for setting the argument list
+  call assert_equal(['Xfile'], argv())
+  enew | only!
+  call delete('Xfile')
+endfunc
+
+" Test for the :append command
+func Test_append_cmd()
+  new
+  call setline(1, ['  L1'])
+  call feedkeys(":append\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L1', '  L2', '  L3'], getline(1, '$'))
+  %delete _
+  " append after a specific line
+  call setline(1, ['  L1', '  L2', '  L3'])
+  call feedkeys(":2append\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L1', '  L2', '  L4', '  L5', '  L3'], getline(1, '$'))
+  %delete _
+  " append with toggling 'autoindent'
+  call setline(1, ['  L1'])
+  call feedkeys(":append!\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L1', '    L2', '      L3'], getline(1, '$'))
+  call assert_false(&autoindent)
+  %delete _
+  " append with 'autoindent' set and toggling 'autoindent'
+  set autoindent
+  call setline(1, ['  L1'])
+  call feedkeys(":append!\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L1', '  L2', '  L3'], getline(1, '$'))
+  call assert_true(&autoindent)
+  set autoindent&
+  close!
+endfunc
+
+" Test for the :insert command
+func Test_insert_cmd()
+  set noautoindent " test assumes noautoindent, but it's on by default in Nvim
+  new
+  call setline(1, ['  L1'])
+  call feedkeys(":insert\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L2', '  L3', '  L1'], getline(1, '$'))
+  %delete _
+  " insert before a specific line
+  call setline(1, ['  L1', '  L2', '  L3'])
+  call feedkeys(":2insert\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L1', '  L4', '  L5', '  L2', '  L3'], getline(1, '$'))
+  %delete _
+  " insert with toggling 'autoindent'
+  call setline(1, ['  L1'])
+  call feedkeys(":insert!\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
+  call assert_equal(['    L2', '      L3', '  L1'], getline(1, '$'))
+  call assert_false(&autoindent)
+  %delete _
+  " insert with 'autoindent' set and toggling 'autoindent'
+  set autoindent
+  call setline(1, ['  L1'])
+  call feedkeys(":insert!\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L2', '  L3', '  L1'], getline(1, '$'))
+  call assert_true(&autoindent)
+  set autoindent&
+  close!
+endfunc
+
+" Test for the :change command
+func Test_change_cmd()
+  set noautoindent " test assumes noautoindent, but it's on by default in Nvim
+  new
+  call setline(1, ['  L1', 'L2', 'L3'])
+  call feedkeys(":change\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L4', '  L5', 'L2', 'L3'], getline(1, '$'))
+  %delete _
+  " change a specific line
+  call setline(1, ['  L1', '  L2', '  L3'])
+  call feedkeys(":2change\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L1', '  L4', '  L5', '  L3'], getline(1, '$'))
+  %delete _
+  " change with toggling 'autoindent'
+  call setline(1, ['  L1', 'L2', 'L3'])
+  call feedkeys(":change!\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')
+  call assert_equal(['    L4', '      L5', 'L2', 'L3'], getline(1, '$'))
+  call assert_false(&autoindent)
+  %delete _
+  " change with 'autoindent' set and toggling 'autoindent'
+  set autoindent
+  call setline(1, ['  L1', 'L2', 'L3'])
+  call feedkeys(":change!\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')
+  call assert_equal(['  L4', '  L5', 'L2', 'L3'], getline(1, '$'))
+  call assert_true(&autoindent)
+  set autoindent&
+  close!
+endfunc
+
 " Test for the :confirm command dialog
 func Test_confirm_cmd()
   CheckNotGui

--- a/src/nvim/testdir/test_fnameescape.vim
+++ b/src/nvim/testdir/test_fnameescape.vim
@@ -18,4 +18,10 @@ func Test_fnameescape()
   endtry
   call assert_true(status, "ExclamationMark")
   call delete(fname)
+
+  call assert_equal('\-', fnameescape('-'))
+  call assert_equal('\+', fnameescape('+'))
+  call assert_equal('\>', fnameescape('>'))
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_ga.vim
+++ b/src/nvim/testdir/test_ga.vim
@@ -18,6 +18,7 @@ func Test_ga_command()
   call assert_equal("\nNUL",                             Do_ga(''))
   call assert_equal("\n<^A>  1,  Hex 01,  Oct 001, Digr SH",    Do_ga("\x01"))
   call assert_equal("\n<^I>  9,  Hex 09,  Oct 011, Digr HT",    Do_ga("\t"))
+  call assert_equal("\n<^@>  0,  Hex 00,  Octal 000",    Do_ga("\n"))
 
   call assert_equal("\n<e>  101,  Hex 65,  Octal 145",   Do_ga('e'))
 
@@ -30,5 +31,13 @@ func Test_ga_command()
   call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401", Do_ga("e\u0301"))
   call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401 < ̱> 817, Hex 0331, Octal 1461", Do_ga("e\u0301\u0331"))
   call assert_equal("\n<e>  101,  Hex 65,  Octal 145 < ́> 769, Hex 0301, Octal 1401 < ̱> 817, Hex 0331, Octal 1461 < ̸> 824, Hex 0338, Octal 1470", Do_ga("e\u0301\u0331\u0338"))
+
+  " When using Mac fileformat, CR instead of NL is used for line termination
+  enew!
+  set fileformat=mac
+  call assert_equal("\n<^J>  10,  Hex 0a,  Oct 012, Digr NU",    Do_ga("\r"))
+
   bwipe!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_global.vim
+++ b/src/nvim/testdir/test_global.vim
@@ -29,3 +29,11 @@ func Test_nested_global()
   call assert_equal(['nothing', '++found', 'found bad', 'bad'], getline(1, 4))
   bwipe!
 endfunc
+
+func Test_global_error()
+  call assert_fails('g\\a', 'E10:')
+  call assert_fails('g', 'E148:')
+  call assert_fails('g/\(/y', 'E476:')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_move.vim
+++ b/src/nvim/testdir/test_move.vim
@@ -35,6 +35,11 @@ func Test_move()
 
   call assert_fails('1,2move 1', 'E134')
   call assert_fails('2,3move 2', 'E134')
+  call assert_fails("move -100", 'E16:')
+  call assert_fails("move +100", 'E16:')
+  call assert_fails('move', 'E16:')
 
   %bwipeout!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -629,6 +629,25 @@ func Test_visualbell()
   set belloff=all
 endfunc
 
+" Test for the 'write' option
+func Test_write()
+  new
+  call setline(1, ['L1'])
+  set nowrite
+  call assert_fails('write Xfile', 'E142:')
+  set write
+  close!
+endfunc
+
+" Test for 'buftype' option
+func Test_buftype()
+  new
+  call setline(1, ['L1'])
+  set buftype=nowrite
+  call assert_fails('write', 'E382:')
+  close!
+endfunc
+
 " Test for setting option values using v:false and v:true
 func Test_opt_boolean()
   set number&

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -13,6 +13,25 @@ func Test_sort_strings()
   " numbers compared as strings
   call assert_equal([1, 2, 3], sort([3, 2, 1]))
   call assert_equal([13, 28, 3], sort([3, 28, 13]))
+
+  call assert_equal(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
+  \            sort(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ']))
+
+  call assert_equal(['A', 'a', 'o', 'O', 'p', 'P', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
+  \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'i'))
+
+  let lc = execute('language collate')
+  " With the following locales, the accentuated letters are ordered
+  " similarly to the non-accentuated letters...
+  if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
+    call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
+    \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+  " ... whereas with a Swedish locale, the accentuated letters are ordered
+  " after Z.
+  elseif lc =~? '"sv.*utf-\?8"'
+    call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
+    \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+  endif
 endfunc
 
 func Test_sort_numeric()
@@ -1222,6 +1241,58 @@ func Test_sort_cmd()
 	\    ]
 	\ },
 	\ ]
+
+    " With the following locales, the accentuated letters are ordered
+    " similarly to the non-accentuated letters...
+    let lc = execute('language collate')
+    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
+      let tests += [
+	\ {
+	\    'name' : 'sort with locale',
+	\    'cmd' : '%sort l',
+	\    'input' : [
+	\	'A',
+	\	'E',
+	\	'O',
+	\	'À',
+	\	'È',
+	\	'É',
+	\	'Ô',
+	\	'Œ',
+	\	'Z',
+	\	'a',
+	\	'e',
+	\	'o',
+	\	'à',
+	\	'è',
+	\	'é',
+	\	'ô',
+	\	'œ',
+	\	'z'
+	\    ],
+	\    'expected' : [
+	\	'a',
+	\	'A',
+	\	'à',
+	\	'À',
+	\	'e',
+	\	'E',
+	\	'é',
+	\	'É',
+	\	'è',
+	\	'È',
+	\	'o',
+	\	'O',
+	\	'ô',
+	\	'Ô',
+	\	'œ',
+	\	'Œ',
+	\	'z',
+	\	'Z'
+	\    ]
+	\ },
+	\ ]
+  endif
 
   for t in tests
     enew!

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -20,17 +20,20 @@ func Test_sort_strings()
   call assert_equal(['A', 'a', 'o', 'O', 'p', 'P', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
   \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'i'))
 
-  let lc = execute('language collate')
-  " With the following locales, the accentuated letters are ordered
-  " similarly to the non-accentuated letters...
-  if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
-    call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
-    \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
-  " ... whereas with a Swedish locale, the accentuated letters are ordered
-  " after Z.
-  elseif lc =~? '"sv.*utf-\?8"'
-    call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
-    \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+  " This does not appear to work correctly on Mac.
+  if !has('mac')
+    let lc = execute('language collate')
+    " With the following locales, the accentuated letters are ordered
+    " similarly to the non-accentuated letters...
+    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
+      call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
+      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+    " ... whereas with a Swedish locale, the accentuated letters are ordered
+    " after Z.
+    elseif lc =~? '"sv.*utf-\?8"'
+      call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
+      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+    endif
   endif
 endfunc
 
@@ -1243,9 +1246,10 @@ func Test_sort_cmd()
 	\ ]
 
     " With the following locales, the accentuated letters are ordered
-    " similarly to the non-accentuated letters...
+    " similarly to the non-accentuated letters.
+    " This does not appear to work on Mac
     let lc = execute('language collate')
-    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
+    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"' && !has('mac')
       let tests += [
 	\ {
 	\    'name' : 'sort with locale',

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -14,23 +14,24 @@ func Test_sort_strings()
   call assert_equal([1, 2, 3], sort([3, 2, 1]))
   call assert_equal([13, 28, 3], sort([3, 28, 13]))
 
-  call assert_equal(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
-  \            sort(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ']))
+  call assert_equal(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'Œ', 'œ'],
+  \            sort(['A', 'O', 'P', 'a', 'o', 'p', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'Œ']))
 
-  call assert_equal(['A', 'a', 'o', 'O', 'p', 'P', 'Ä', 'Ô', 'ä', 'ô', 'œ', 'œ'],
-  \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'i'))
+  call assert_equal(['A', 'a', 'o', 'O', 'p', 'P', 'Ä', 'Ô', 'ä', 'ô', 'Œ', 'œ'],
+  \            sort(['A', 'a', 'o', 'O', 'œ', 'Œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'i'))
 
   " This does not appear to work correctly on Mac.
   if !has('mac')
-    if v:collate =~? '^en_ca.*\.utf-\?8$' && !has('mac')
+    if v:collate =~? '^\(en\|fr\)_ca.utf-\?8$'
       " with Canadian English capitals come before lower case.
-      call assert_equal(['A', 'a', 'Ä', 'ä', 'O', 'o', 'Ô', 'ô', 'œ', 'œ', 'P', 'p'],
-      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+      " 'Œ' is omitted because it can sort before or after 'œ'
+      call assert_equal(['A', 'a', 'Ä', 'ä', 'O', 'o', 'Ô', 'ô', 'œ', 'P', 'p'],
+      \            sort(['A', 'a', 'o', 'O', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     elseif v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
       " With the following locales, the accentuated letters are ordered
       " similarly to the non-accentuated letters...
-      call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
-      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+      call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'Œ', 'p', 'P'],
+      \            sort(['A', 'a', 'o', 'O', 'œ', 'Œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     elseif v:collate =~? '^sv.*utf-\?8$'
       " ... whereas with a Swedish locale, the accentuated letters are ordered
       " after Z.
@@ -1255,8 +1256,9 @@ func Test_sort_cmd()
 
     " This does not appear to work correctly on Mac.
     if !has('mac')
-      if v:collate =~? '^en_ca.*\.utf-\?8$'
+      if v:collate =~? '^\(en\|fr\)_ca.utf-\?8$'
         " en_CA.utf-8 sorts capitals before lower case
+        " 'Œ' is omitted because it can sort before or after 'œ'
         let tests += [
           \ {
           \    'name' : 'sort with locale ' .. v:collate,
@@ -1269,7 +1271,6 @@ func Test_sort_cmd()
           \	'È',
           \	'É',
           \	'Ô',
-          \	'Œ',
           \	'Z',
           \	'a',
           \	'e',
@@ -1297,7 +1298,6 @@ func Test_sort_cmd()
           \	'Ô',
           \	'ô',
           \	'œ',
-          \	'Œ',
           \	'Z',
           \	'z'
           \    ]

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -22,14 +22,18 @@ func Test_sort_strings()
 
   " This does not appear to work correctly on Mac.
   if !has('mac')
-    " With the following locales, the accentuated letters are ordered
-    " similarly to the non-accentuated letters...
-    if v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
+    if v:collate =~? '^en_ca.*\.utf-\?8$' && !has('mac')
+      " with Canadian English capitals come before lower case.
+      call assert_equal(['A', 'a', 'Ä', 'ä', 'O', 'o', 'Ô', 'ô', 'œ', 'œ', 'P', 'p'],
+      \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
+    elseif v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
+      " With the following locales, the accentuated letters are ordered
+      " similarly to the non-accentuated letters...
       call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
-    " ... whereas with a Swedish locale, the accentuated letters are ordered
-    " after Z.
     elseif v:collate =~? '^sv.*utf-\?8$'
+      " ... whereas with a Swedish locale, the accentuated letters are ordered
+      " after Z.
       call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     endif
@@ -1249,56 +1253,106 @@ func Test_sort_cmd()
 	\ },
 	\ ]
 
-    " With the following locales, the accentuated letters are ordered
-    " similarly to the non-accentuated letters.
-    " This does not appear to work on Mac
-    if v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$' && !has('mac')
-      let tests += [
-	\ {
-	\    'name' : 'sort with locale',
-	\    'cmd' : '%sort l',
-	\    'input' : [
-	\	'A',
-	\	'E',
-	\	'O',
-	\	'À',
-	\	'È',
-	\	'É',
-	\	'Ô',
-	\	'Œ',
-	\	'Z',
-	\	'a',
-	\	'e',
-	\	'o',
-	\	'à',
-	\	'è',
-	\	'é',
-	\	'ô',
-	\	'œ',
-	\	'z'
-	\    ],
-	\    'expected' : [
-	\	'a',
-	\	'A',
-	\	'à',
-	\	'À',
-	\	'e',
-	\	'E',
-	\	'é',
-	\	'É',
-	\	'è',
-	\	'È',
-	\	'o',
-	\	'O',
-	\	'ô',
-	\	'Ô',
-	\	'œ',
-	\	'Œ',
-	\	'z',
-	\	'Z'
-	\    ]
-	\ },
-	\ ]
+    " This does not appear to work correctly on Mac.
+    if !has('mac')
+      if v:collate =~? '^en_ca.*\.utf-\?8$'
+        " en_CA.utf-8 sorts capitals before lower case
+        let tests += [
+          \ {
+          \    'name' : 'sort with locale ' .. v:collate,
+          \    'cmd' : '%sort l',
+          \    'input' : [
+          \	'A',
+          \	'E',
+          \	'O',
+          \	'À',
+          \	'È',
+          \	'É',
+          \	'Ô',
+          \	'Œ',
+          \	'Z',
+          \	'a',
+          \	'e',
+          \	'o',
+          \	'à',
+          \	'è',
+          \	'é',
+          \	'ô',
+          \	'œ',
+          \	'z'
+          \    ],
+          \    'expected' : [
+          \	'A',
+          \	'a',
+          \	'À',
+          \	'à',
+          \	'E',
+          \	'e',
+          \	'É',
+          \	'é',
+          \	'È',
+          \	'è',
+          \	'O',
+          \	'o',
+          \	'Ô',
+          \	'ô',
+          \	'œ',
+          \	'Œ',
+          \	'Z',
+          \	'z'
+          \    ]
+          \ },
+          \ ]
+      elseif v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
+      " With these locales, the accentuated letters are ordered
+      " similarly to the non-accentuated letters.
+        let tests += [
+          \ {
+          \    'name' : 'sort with locale ' .. v:collate,
+          \    'cmd' : '%sort l',
+          \    'input' : [
+          \	'A',
+          \	'E',
+          \	'O',
+          \	'À',
+          \	'È',
+          \	'É',
+          \	'Ô',
+          \	'Œ',
+          \	'Z',
+          \	'a',
+          \	'e',
+          \	'o',
+          \	'à',
+          \	'è',
+          \	'é',
+          \	'ô',
+          \	'œ',
+          \	'z'
+          \    ],
+          \    'expected' : [
+          \	'a',
+          \	'A',
+          \	'à',
+          \	'À',
+          \	'e',
+          \	'E',
+          \	'é',
+          \	'É',
+          \	'è',
+          \	'È',
+          \	'o',
+          \	'O',
+          \	'ô',
+          \	'Ô',
+          \	'œ',
+          \	'Œ',
+          \	'z',
+          \	'Z'
+          \    ]
+          \ },
+          \ ]
+    endif
   endif
 
   for t in tests

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -22,19 +22,23 @@ func Test_sort_strings()
 
   " This does not appear to work correctly on Mac.
   if !has('mac')
-    let lc = execute('language collate')
     " With the following locales, the accentuated letters are ordered
     " similarly to the non-accentuated letters...
-    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"'
+    if v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$'
       call assert_equal(['a', 'A', 'ä', 'Ä', 'o', 'O', 'ô', 'Ô', 'œ', 'œ', 'p', 'P'],
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     " ... whereas with a Swedish locale, the accentuated letters are ordered
     " after Z.
-    elseif lc =~? '"sv.*utf-\?8"'
+    elseif v:collate =~? '^sv.*utf-\?8$'
       call assert_equal(['a', 'A', 'o', 'O', 'p', 'P', 'ä', 'Ä', 'œ', 'œ', 'ô', 'Ô'],
       \            sort(['A', 'a', 'o', 'O', 'œ', 'œ', 'p', 'P', 'Ä', 'ä', 'ô', 'Ô'], 'l'))
     endif
   endif
+endfunc
+
+func Test_sort_null_string()
+  " null strings are sorted as empty strings.
+  call assert_equal(['', 'a', 'b'], sort(['b', v:_null_string, 'a']))
 endfunc
 
 func Test_sort_numeric()
@@ -1248,8 +1252,7 @@ func Test_sort_cmd()
     " With the following locales, the accentuated letters are ordered
     " similarly to the non-accentuated letters.
     " This does not appear to work on Mac
-    let lc = execute('language collate')
-    if lc =~? '"\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8"' && !has('mac')
+    if v:collate =~? '^\(en\|es\|de\|fr\|it\|nl\).*\.utf-\?8$' && !has('mac')
       let tests += [
 	\ {
 	\    'name' : 'sort with locale',

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -426,6 +426,8 @@ func Test_substitute_errors()
   call assert_fails('s/FOO/bar/', 'E486:')
   call assert_fails('s/foo/bar/@', 'E488:')
   call assert_fails('s/\(/bar/', 'E476:')
+  call assert_fails('s afooabara', 'E146:')
+  call assert_fails('s\\a', 'E10:')
 
   setl nomodifiable
   call assert_fails('s/foo/bar/', 'E21:')

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -164,6 +164,69 @@ func Test_writefile_autowrite_nowrite()
   set noautowrite
 endfunc
 
+" Test for ':w !<cmd>' to pipe lines from the current buffer to an external
+" command.
+func Test_write_pipe_to_cmd()
+  if !has('unix')
+    return
+  endif
+  new
+  call setline(1, ['L1', 'L2', 'L3', 'L4'])
+  2,3w !cat > Xfile
+  call assert_equal(['L2', 'L3'], readfile('Xfile'))
+  close!
+  call delete('Xfile')
+endfunc
+
+" Test for :saveas
+func Test_saveas()
+  call assert_fails('saveas', 'E471:')
+  call writefile(['L1'], 'Xfile')
+  new Xfile
+  new
+  call setline(1, ['L1'])
+  call assert_fails('saveas Xfile', 'E139:')
+  close!
+  enew | only
+  call delete('Xfile')
+endfunc
+
+func Test_write_errors()
+  " Test for writing partial buffer
+  call writefile(['L1', 'L2', 'L3'], 'Xfile')
+  new Xfile
+  call assert_fails('1,2write', 'E140:')
+  close!
+
+  " Try to overwrite a directory
+  if has('unix')
+    call mkdir('Xdir1')
+    call assert_fails('write Xdir1', 'E17:')
+    call delete('Xdir1', 'd')
+  endif
+
+  " Test for :wall for a buffer with no name
+  enew | only
+  call setline(1, ['L1'])
+  call assert_fails('wall', 'E141:')
+  enew!
+
+  " Test for writing a 'readonly' file
+  new Xfile
+  set readonly
+  call assert_fails('write', 'E45:')
+  close
+
+  " Test for writing to a read-only file
+  new Xfile
+  call setfperm('Xfile', 'r--r--r--')
+  call assert_fails('write', 'E505:')
+  call setfperm('Xfile', 'rw-rw-rw-')
+  close
+
+  call delete('Xfile')
+endfunc
+
 func Test_writefile_sync_dev_stdout()
   if !has('unix')
     return

--- a/test/functional/legacy/packadd_spec.lua
+++ b/test/functional/legacy/packadd_spec.lua
@@ -267,6 +267,8 @@ describe('packadd', function()
         call assert_match('look-here', tags1[0])
         let tags2 = readfile(docdir2 . '/tags')
         call assert_match('look-away', tags2[0])
+
+        call assert_fails('helptags abcxyz', 'E150:')
       endfunc
 
       func Test_colorscheme()


### PR DESCRIPTION
Main goal of this PR is to port v8.2.1933.

- v8.2.0174 isn't strictly necessary. I can remove this patch from the PR if it makes it easier to review.
- v8.2.0988 is partially ported so `v:collate` is available for v8.2.1933 and the test patches thereafter.
- vim/vim@3132cdd is partially ported as it has up-to-date docs for the locale-based `:sort`.
- The Mac-specific `oldtest` patches are indeed needed to have the OSX CI succeed on my fork. :smile:

CC @flyxyz123; does this fix your issue?

Closes #14394 _(if I didn't screw up)_.