### PR TITLE
[RDY] tree-sitter ensure there is a nested table allocated for `#set!`

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -253,7 +253,11 @@ local directive_handlers = {
   ["set!"] = function(_, _, _, pred, metadata)
     if #pred == 4 then
       -- (#set! @capture "key" "value")
-      metadata[pred[2]][pred[3]] = pred[4]
+      local capture = pred[2]
+      if not metadata[capture] then
+        metadata[capture] = {}
+      end
+      metadata[capture][pred[3]] = pred[4]
     else
       -- (#set! "key" "value")
       metadata[pred[2]] = pred[3]


### PR DESCRIPTION
## What

The following usage of the `#set!` directive for tree-sitter queries throws the following error message. This bug was uncovered while doing some testing for https://github.com/nvim-treesitter/nvim-treesitter/pull/1190. 

```scheme
(#set! @number "key" "value")
```

```
test/functional/helpers.lua:107: Error executing lua: vim/treesitter/query.lua:256: attempt to index a nil value
```

## Fix

To fix this we need to ensure that a table is allocated for `metadata[pred[2]]` for the directive handler.

```lua
-- (#set! @capture "key" "value")
metadata[pred[2]][pred[3]] = pred[4]
```

