### PR TITLE
lua: make vim.o use the relevant scope automatically 

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -365,7 +365,7 @@ do
   )
   vim.g = make_meta_accessor(nil_wrap(a.nvim_get_var), a.nvim_set_var, a.nvim_del_var)
   vim.v = make_meta_accessor(nil_wrap(a.nvim_get_vvar), a.nvim_set_vvar)
-  vim.o = make_meta_accessor(a.nvim_get_option, a.nvim_set_option)
+  vim.go = make_meta_accessor(a.nvim_get_option, a.nvim_set_option)
 
   local function getenv(k)
     local v = vim.fn.getenv(k)
@@ -375,32 +375,40 @@ do
     return v
   end
   vim.env = make_meta_accessor(getenv, vim.fn.setenv)
-  -- TODO(ashkan) if/when these are available from an API, generate them
-  -- instead of hardcoding.
-  local window_options = {
-              arab = true;       arabic = true;   breakindent = true; breakindentopt = true;
-               bri = true;       briopt = true;            cc = true;           cocu = true;
-              cole = true;  colorcolumn = true; concealcursor = true;   conceallevel = true;
-               crb = true;          cuc = true;           cul = true;     cursorbind = true;
-      cursorcolumn = true;   cursorline = true;          diff = true;            fcs = true;
-               fdc = true;          fde = true;           fdi = true;            fdl = true;
-               fdm = true;          fdn = true;           fdt = true;            fen = true;
-         fillchars = true;          fml = true;           fmr = true;     foldcolumn = true;
-        foldenable = true;     foldexpr = true;    foldignore = true;      foldlevel = true;
-        foldmarker = true;   foldmethod = true;  foldminlines = true;    foldnestmax = true;
-          foldtext = true;          lbr = true;           lcs = true;      linebreak = true;
-              list = true;    listchars = true;            nu = true;         number = true;
-       numberwidth = true;          nuw = true; previewwindow = true;            pvw = true;
-    relativenumber = true;    rightleft = true;  rightleftcmd = true;             rl = true;
-               rlc = true;          rnu = true;           scb = true;            scl = true;
-               scr = true;       scroll = true;    scrollbind = true;     signcolumn = true;
-             spell = true;   statusline = true;           stl = true;            wfh = true;
-               wfw = true;        winbl = true;      winblend = true;   winfixheight = true;
-       winfixwidth = true; winhighlight = true;         winhl = true;           wrap = true;
-  }
+
+  local options_info = a.nvim_get_all_options_info()
+  for n,v in pairs(options_info) do
+    if v.shortname ~= "" then options_info[v.shortname] = v end
+  end
+
+  local function set_scoped_option(k, v)
+    local info = options_info[k]
+    -- all options except window options have global value,
+    -- because reasons.
+    if info.scope ~= "win" or info.global_local then
+      a.nvim_set_option(k,v)
+    end
+
+    -- TODO(bfredl): this matches init.vim behavior of :set
+    -- but not always runtime behavior
+    if not info.global_local then
+      if info.scope == "win" then
+        a.nvim_win_set_option(0, k, v)
+      elseif info.scope == "buf" then
+        a.nvim_buf_set_option(0, k, v)
+      end
+    end
+  end
+  local function get_scoped_option(k)
+    -- TODO: use curbuf/curwin for scoped options
+    return a.nvim_get_option(k)
+  end
+
+  vim.o = make_meta_accessor(get_scoped_option, set_scoped_option)
+
   local function new_buf_opt_accessor(bufnr)
     local function get(k)
-      if window_options[k] then
+      if not options_info[k] or options_info[k].scope ~= 'buf' then
         return a.nvim_err_writeln(k.." is a window option, not a buffer option")
       end
       if bufnr == nil and type(k) == "number" then
@@ -409,7 +417,7 @@ do
       return a.nvim_buf_get_option(bufnr or 0, k)
     end
     local function set(k, v)
-      if window_options[k] then
+      if not options_info[k] or options_info[k].scope ~= 'buf' then
         return a.nvim_err_writeln(k.." is a window option, not a buffer option")
       end
       return a.nvim_buf_set_option(bufnr or 0, k, v)


### PR DESCRIPTION
rename `vim.o` to `vim.go` (global option) and make `vim.o` use the relevant scope automatically.
This is a complement to #13479, and fixes the scoping issue of `vim.o` only, while `vim.opt` also ads an object-oriented model for commalist options and so forth. and if we decide to change `vim.o` to use this model, this just merges a _subset_ of that change earlier (as this is a much smaller change to test/review)