### PR TITLE
[LSP] - Don't automatically force shutdown on second restart.

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -916,7 +916,7 @@ function lsp.start_client(config)
 
   -- Track this so that we can escalate automatically if we've alredy tried a
   -- graceful shutdown
-  local tried_graceful_shutdown = false
+  local graceful_shutdown_failed = false
   --@private
   --- Stops a client, optionally with force.
   ---
@@ -938,11 +938,10 @@ function lsp.start_client(config)
     if handle:is_closing() then
       return
     end
-    if force or (not client.initialized) or tried_graceful_shutdown then
+    if force or (not client.initialized) or graceful_shutdown_failed then
       handle:kill(15)
       return
     end
-    tried_graceful_shutdown = true
     -- Sending a signal after a process has exited is acceptable.
     rpc.request('shutdown', nil, function(err, _)
       if err == nil then
@@ -950,6 +949,7 @@ function lsp.start_client(config)
       else
         -- If there was an error in the shutdown request, then term to be safe.
         handle:kill(15)
+        graceful_shutdown_failed = true
       end
     end)
   end


### PR DESCRIPTION
This is maybe a bit of a niche case, but I hit on this often as I'm
developing a server, and therefore continually restarting it to get the
latest changes of the server. Previously, I could only do this once
since if you send in a request to restart/shut down the server, it will
register it as a `tried_graceful_shutdown = true` meaning that the next
restart would force it to be killed instead of another graceful exit.

Instead, this changes the name a bit and now it will only mark
`graceful_shutdown_failed = true` _if_ it actually fails to gracefully
shutdown. This change allows for a user to restart multiple times in a
situation like mine where nothing is going wrong, but I just want to
restart continually as I'm developing without having to close and
reopen.