### PR TITLE
Revert "lsp: fix blocking in closing of clients"

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1179,38 +1179,11 @@ function lsp._vim_exit_handler()
     client.stop()
   end
 
-  local function wait_async(timeout, ms, predicate, cb)
-    local timer = uv.new_timer()
-    local time = 0
-
-    local function done(in_time)
-      timer:stop()
-      timer:close()
-      cb(in_time)
+  if not vim.wait(500, function() return tbl_isempty(active_clients) end, 50) then
+    for _, client in pairs(active_clients) do
+      client.stop(true)
     end
-
-    timer:start(0, ms, function()
-      if predicate() == true then
-        done(true)
-        return
-      end
-
-      if time == timeout then
-        done(false)
-        return
-      end
-
-      time = time + ms
-    end)
   end
-
-  wait_async(500, 50, function() return tbl_isempty(active_clients) end, function(in_time)
-    if not in_time then
-      for _, client in pairs(active_clients) do
-        client.stop(true)
-      end
-    end
-  end)
 end
 
 nvim_command("autocmd VimLeavePre * lua vim.lsp._vim_exit_handler()")


### PR DESCRIPTION
Fixes #14428

This reverts commit 2e6c09838f88803f31d229002715628639631897.

* Fixes #14428
* This commit caused neovim to close while open handles to the uv timer
  to kill active language servers were still open

