### PR TITLE
treesitter: support multi-line nodes in get_node_text

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -208,10 +208,6 @@ local predicate_handlers = {
   ["lua-match?"] = function(match, _, source, predicate)
       local node = match[predicate[2]]
       local regex = predicate[3]
-      local start_row, _, end_row, _ = node:range()
-      if start_row ~= end_row then
-        return false
-      end
 
       return string.find(M.get_node_text(node, source), regex)
   end,

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -155,8 +155,6 @@ function M.parse_query(lang, query)
   return self
 end
 
--- TODO(vigoux): support multiline nodes too
-
 --- Gets the text corresponding to a given node
 -- @param node the node
 -- @param bufnr the buffer from which the node is extracted.
@@ -165,11 +163,20 @@ function M.get_node_text(node, source)
   local end_row, end_col, end_byte = node:end_()
 
   if type(source) == "number" then
-    if start_row ~= end_row then
-      return nil
+    local last_line = end_row+1
+    if end_col == 0 then
+      last_line = end_row
     end
-    local line = a.nvim_buf_get_lines(source, start_row, start_row+1, true)[1]
-    return string.sub(line, start_col+1, end_col)
+    local lines = a.nvim_buf_get_lines(source, start_row, last_line, true)
+    lines[1] = string.sub(lines[1], start_col+1)
+
+    local end_index = end_col
+    if #lines == 1 then
+      end_index = end_col - start_col
+    end
+    lines[#lines] = string.sub(lines[#lines], 1, end_index)
+
+    return table.concat(lines, "\n")
   elseif type(source) == "string" then
     return source:sub(start_byte+1, end_byte)
   end


### PR DESCRIPTION
vim.treesitter.get_node_text now works with multi-line nodes.

Also lets `#lua-match?` match on multi-line nodes, without breaking existing single-line matches.