### PR TITLE
Doc: Update vim.cmd docs

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -841,10 +841,18 @@ vim.call({func}, {...})					*vim.call()*
             vim.fn[func]({...})
 
 vim.cmd({cmd})                                          *vim.cmd()*
-        Invokes an Ex command (the ":" commands, Vimscript statements).
+        Executes multiple lines of Vimscript at once. It is an alias to
+        |nvim_exec()|, where `output` is set to false. Thus it works identical
+        to |:source|.
         See also |ex-cmd-index|.
         Example: >
             vim.cmd('echo 42')
+            vim.cmd([[
+              augroup My_group
+                autocmd!
+                autocmd FileType c setlocal cindent
+              augroup END
+            ]])
 
 vim.fn.{func}({...})					*vim.fn*
         Invokes |vim-function| or |user-function| {func} with arguments {...}.


### PR DESCRIPTION
Update vim.cmd docs to show multiline commands are supported . This should have gone with #14401 . But I forgot about the docs :D