### PR TITLE
lua: highlight the active parameter

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -534,6 +534,19 @@ LspCodeLens
    Used to color the virtual text of the codelens. See
    |nvim_buf_set_virtual_text()|.
 
+                                                   *lsp-highlight-signature*
+Signature Highlights:
+
+Highlight groups that are meant to be used by |vim.lsp.buf.signature_help()|.
+
+                                                   *hl-LspSignatureParamActive*
+LspSignatureParamActive   used for highlighting the active signature parameter
+                                                   *hl-LspSignatureActive*
+LspSignatureActive        used for highlighting the active signature
+                                                   *hl-LspSignatureInactive*
+LspSignatureInactive      used for highlighting the inactive signatures, for
+                          languages that support function overloading
+
 ==============================================================================
 AUTOCOMMANDS                                                *lsp-autocommands*
 


### PR DESCRIPTION
This is for #14217 and #14444

I wanted to somehow highlight the active parameter in the signature help popup. Currently I'm using markdown's `**` symbols to bold the active parameter, though I don't really like this approach. While it seems to work when used with the `ray-x/lsp_signature.nvim` plugin (the markdown is parsed and the active parameter appears in bold and different color), when using the built-in `buf.signature_help` function, the markdown is not processed at all. Is there a way to somehow use a vim-specific escape sequence for a highlight, if such a thing is possible? I'm also not entirely sure whether I'm using the utf16 helper functions correctly.

I also try to support multiple signatures, for languages that support function overloading. I wasn't really able to test this feature, as the only languages I know that support overloading (java, kotlin, python) either don't seem to support the `signatureHelp` request in their language servers or only return the first signature. In theory, this should display all signatures in a single popup, with the active one appearing first. This is what IntelliJ is doing, and I think it's a better approach than requiring user interaction like vscode. In the same light, I also removed the documentation, as that makes the popup rather huge, and I find it distracts from it's task of showing the signature itself (and documentation can be had in the hover action anyway). For this portion, I wonder if it is possible to to know beforehand whether the popup will appear below or above the cursor? Showing the active signature first currently only works if the popup appears below the cursor. However, if the popup appears below, then the active one will be the furthest one from view, which isn't ideal. Or if that's not possible, perhaps there's a way to add a highlight to just the line that contains the active signature?

