### PR TITLE
lsp: Allow decoded.result to be `false`

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -518,7 +518,7 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
         send_response(decoded.id, err, result)
       end)
     -- This works because we are expecting vim.NIL here
-    elseif decoded.id and (decoded.result or decoded.error) then
+    elseif decoded.id and (decoded.result ~= vim.NIL or decoded.error ~= vim.NIL) then
       -- Server Result
       decoded.error = convert_NIL(decoded.error)
       decoded.result = convert_NIL(decoded.result)


### PR DESCRIPTION
Some servers might respond to `workspace/executeCommand` requests with a
boolean result and that could be `false`.

A `false` result should be allowed and not trigger the `on_error`
handler:

    -- Invalid server message
    on_error(client_errors.INVALID_SERVER_MESSAGE, decoded)

Concrete example where this occurred is with eclipse.jdt.ls:

    vim.lsp.buf_request(
      0,
      'workspace/executeCommand',
      {
        command = 'java.project.isTestFile',
        arguments = { vim.uri_from_bufnr(0), },
      },
      function(err, _, resp)
        print(vim.inspect(err), vim.inspect(resp))
      end
    )