### PR TITLE
Fix vim.api.nvim_win_get_number to return window numbers.

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -381,7 +381,7 @@ Integer nvim_win_get_number(Window window, Error *err)
   }
 
   int tabnr;
-  win_get_tabwin(window, &tabnr, &rv);
+  win_get_tabwin(win->handle, &tabnr, &rv);
 
   return rv;
 }


### PR DESCRIPTION
Closes: #14467

Fix found by @bfredl faster than I could even type up the bug.

(And indeed seems to now return proper IDs in a locally compiled build).