### PR TITLE
sign: Fix overflow during adjustment on Windows

### DIFF
--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -742,15 +742,15 @@ void sign_mark_adjust(
     next = sign->se_next;
     new_lnum = sign->se_lnum;
     if (sign->se_lnum >= line1 && sign->se_lnum <= line2) {
-      if (amount == MAXLNUM && (!is_fixed || signcol >= 2)) {
+      if (amount != MAXLNUM) {
+        new_lnum += amount;
+      } else if (!is_fixed || signcol >= 2) {
         *lastp = next;
         if (next) {
           next->se_prev = last;
         }
         xfree(sign);
         continue;
-      } else {
-        new_lnum += amount;
       }
     } else if (sign->se_lnum > line2) {
       new_lnum += amount_after;


### PR DESCRIPTION
On Windows, `new_lnum + MAXLNUM` causes overflow and as a result the line number of that sign becomes invalid negative number. This occurs when the `set signcolumn=yes`, in other words `signcolumn` is not `auto` and the sign column is less than 2 columns.

The related change was made in the commit f2ed7605da45eb79a4f7bb89fb19f680fb5a4927. Originally the above addition is only executed if `amount != MAXLNUM`, so reintroducing this check fixes the bug and will hardly produces a new bug.

Fixes #14460.