### PR TITLE
template: make sure people read `:h vim-differences`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,10 +9,15 @@ labels: bug
 <!-- Before reporting: search existing issues and check the FAQ. -->
 
 - `nvim --version`:
-- `vim -u DEFAULTS` (version: ) behaves differently?
 - Operating system/version:
 - Terminal name/version:
 - `$TERM`:
+
+<!--
+If this report is about different behaviour between Nvim and Vim, make sure to
+read `:h vim-differences` first. Otherwise remove the next line.
+-->
+[ ] `vim -u DEFAULTS` (version: ) behaves differently
 
 ### Steps to reproduce using `nvim -u NORC`
 


### PR DESCRIPTION
People should read `:h vim-differences` before reporting a different behaviour between Nvim and Vim.