### PR TITLE
feat(lsp): hide triple - in hover window

### DIFF
--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -8,10 +8,12 @@
 " markdown.vim syntax files
 execute 'source' expand('<sfile>:p:h') .. '/markdown.vim'
 
-syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
+syn cluster mkdNonListItem add=mkdEscape,mkdNbsp,mkdLine
 
 syntax region mkdEscape matchgroup=mkdEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/.\zs/ keepend contains=mkdEscapeCh oneline concealends
 syntax match mkdEscapeCh /./ contained
 syntax match mkdNbsp /&nbsp;/ conceal cchar= 
+syntax match mkdLine /---/ conceal cchar= 
+syntax match markdownH2 "" contained
 
 hi def link mkdEscape special


### PR DESCRIPTION
This thing has been bothering me for a while. Hover result can contain `---` because it's used as a horizontal line for markdown (similar to HTML's `<hr />`). Because Neovim can't display a thin horizontal line like other GUI text editor, I think removing it is a better solution. Here's some example from dart analyzer and sumneko lua.
Not sure why Dart's empty line is a bit different though.

| before | after |
| ---       | ---    |
|  ![Shot-2021-05-03_1](https://user-images.githubusercontent.com/51877647/116831511-1183c280-abda-11eb-805b-b5684173f540.png) | ![Shot-2021-05-03](https://user-images.githubusercontent.com/51877647/116831507-0892f100-abda-11eb-881e-28519727c92a.png) |
| ![Shot-2021-05-03_2](https://user-images.githubusercontent.com/51877647/116831525-2bbda080-abda-11eb-84eb-baa72d098847.png) | ![Shot-2021-05-03_3](https://user-images.githubusercontent.com/51877647/116831526-311aeb00-abda-11eb-8ba7-3ac0d5d05170.png) |



