### PR TITLE
window.c: fix floating window border width calculation

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -676,9 +676,17 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
 
   wp->w_float_config = fconfig;
 
+  bool has_border = wp->w_floating && wp->w_float_config.border;
+  for (int i = 0; i < 4; i++) {
+    wp->w_border_adj[i] =
+      has_border && wp->w_float_config.border_chars[2 * i+1][0];
+  }
+
   if (!ui_has(kUIMultigrid)) {
-    wp->w_height = MIN(wp->w_height, Rows-1);
-    wp->w_width = MIN(wp->w_width, Columns);
+    wp->w_height = MIN(wp->w_height,
+                       Rows - 1 - (wp->w_border_adj[0] + wp->w_border_adj[2]));
+    wp->w_width = MIN(wp->w_width,
+                      Columns - (wp->w_border_adj[1] + wp->w_border_adj[3]));
   }
 
   win_set_inner_size(wp);
@@ -767,8 +775,8 @@ void ui_ext_win_position(win_T *wp)
 
       int comp_row = (int)row - (south ? wp->w_height : 0);
       int comp_col = (int)col - (east ? wp->w_width : 0);
-      comp_row = MAX(MIN(comp_row, Rows-wp->w_height-1), 0);
-      comp_col = MAX(MIN(comp_col, Columns-wp->w_width), 0);
+      comp_row = MAX(MIN(comp_row, Rows-wp->w_height_outer-1), 0);
+      comp_col = MAX(MIN(comp_col, Columns-wp->w_width_outer), 0);
       wp->w_winrow = comp_row;
       wp->w_wincol = comp_col;
       bool valid = (wp->w_redr_type == 0);
@@ -5733,12 +5741,6 @@ void win_set_inner_size(win_T *wp)
 
   if (wp->w_buffer->terminal) {
     terminal_check_size(wp->w_buffer->terminal);
-  }
-
-  bool has_border = wp->w_floating && wp->w_float_config.border;
-  for (int i = 0; i < 4; i++) {
-    wp->w_border_adj[i] =
-      has_border && wp->w_float_config.border_chars[2 * i+1][0];
   }
 
   wp->w_height_outer = (wp->w_height_inner

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -910,6 +910,57 @@ describe('float window', function()
       end
     end)
 
+    it('terminates border on edge of viewport when window extends past viewport', function()
+      local buf = meths.create_buf(false, false)
+      meths.open_win(buf, false, {relative='editor', width=40, height=7, row=0, col=0, border="single"})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {5:┌────────────────────────────────────────┐}|
+          {5:│}{1:                                        }{5:│}|
+          {5:│}{2:~                                       }{5:│}|
+          {5:│}{2:~                                       }{5:│}|
+          {5:│}{2:~                                       }{5:│}|
+          {5:│}{2:~                                       }{5:│}|
+          {5:│}{2:~                                       }{5:│}|
+          {5:│}{2:~                                       }{5:│}|
+          {5:└────────────────────────────────────────┘}|
+        ]], float_pos={
+          [4] = { { id = 1001 }, "NW", 1, 0, 0, true }
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0};
+          [4] = {win = {id = 1001}, topline = 0, botline = 2, curline = 0, curcol = 0};
+        }}
+      else
+        screen:expect{grid=[[
+          {5:^┌──────────────────────────────────────┐}|
+          {5:│}{1:                                      }{5:│}|
+          {5:│}{2:~                                     }{5:│}|
+          {5:│}{2:~                                     }{5:│}|
+          {5:│}{2:~                                     }{5:│}|
+          {5:└──────────────────────────────────────┘}|
+                                                  |
+        ]]}
+      end
+    end)
+
     it('with border show popupmenu', function()
       screen:try_resize(40,10)
       local buf = meths.create_buf(false, false)


### PR DESCRIPTION
Closes #14478 and #14377 
* lift calculation of w_border_adj into win_config_float
* Check max floating window width agains w_width_outer instead of
  w_width when position window