### PR TITLE
get_str_line: Replace grow_array usage

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2720,12 +2720,9 @@ static char_u *get_str_line(int c, void *cookie, int indent, bool do_concat)
     i++;
   }
   size_t line_length = i - p->offset;
-  garray_T ga;
-  ga_init(&ga, (int)sizeof(char_u), (int)line_length);
-  ga_concat_len(&ga, (char *)p->buf + p->offset, line_length);
-  ga_append(&ga, '\0');
+  char_u *buf = xmemdupz(p->buf + p->offset, line_length);
   p->offset = i + 1;
-  return ga.ga_data;
+  return buf;
 }
 
 static int source_using_linegetter(void *cookie,


### PR DESCRIPTION
A single xmemdupz is sufficient, as it is already zero-terminating the string. 

This is a minor improvment on #14455 suggested by @oni-link here: https://github.com/neovim/neovim/pull/14455#discussion_r625014342