### PR TITLE
LSP: align active signature parameter above the cursor

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -525,6 +525,19 @@ LspDiagnosticsSignHint
   Used for "Hint" signs in sign column.
   See |vim.lsp.diagnostic.set_signs()|
 
+                                                   *lsp-highlight-signature*
+Signature Highlights:
+
+Highlight groups that are meant to be used by |vim.lsp.buf.signature_help()|.
+
+                                                   *hl-LspSignatureParamActive*
+LspSignatureParamActive   used for highlighting the active signature parameter
+                                                   *hl-LspSignatureActive*
+LspSignatureActive        used for highlighting the active signature
+                                                   *hl-LspSignatureInactive*
+LspSignatureInactive      used for highlighting the inactive signatures, for
+                          languages that support function overloading
+
 ==============================================================================
 AUTOCOMMANDS                                                *lsp-autocommands*
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -337,18 +337,24 @@ M['textDocument/implementation'] = location_handler
 ---         - See |vim.api.nvim_open_win()|
 ---     - parametersOnly: (default=false)
 ---         - Display only a list of parameters
+---     - suppressPrint: (default=false)
+---         - Stop printing a message if no signature is available
 function M.signature_help(_, method, result, _, bufnr, config)
   config = config or {}
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
-    print('No signature help available')
+    if not config.suppressPrint then
+      print('No signature help available')
+    end
     return
   end
   local lines, highlights = util.get_signature_help_with_highlights(result, config.parametersOnly or false)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
-    print('No signature help available')
+    if not config.suppressPrint then
+      print('No signature help available')
+    end
     return
   end
   local syntax = api.nvim_buf_get_option(bufnr, 'syntax')

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -357,6 +357,12 @@ function M.signature_help(_, method, result, _, bufnr, config)
     end
     return
   end
+
+  if highlights and #highlights > 1 then
+    print(vim.inspect(highlights))
+    config.offset_x = -highlights[2].col - 1
+  end
+
   local syntax = api.nvim_buf_get_option(bufnr, 'syntax')
   if syntax == "" then
     syntax = api.nvim_buf_get_option(bufnr, 'filetype')

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -333,6 +333,8 @@ M['textDocument/implementation'] = location_handler
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
 ---         - See |vim.api.nvim_open_win()|
+---     - parametersOnly: (default=false)
+---         - Display only a list of parameters
 function M.signature_help(_, method, result, _, bufnr, config)
   config = config or {}
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
@@ -341,7 +343,7 @@ function M.signature_help(_, method, result, _, bufnr, config)
     print('No signature help available')
     return
   end
-  local lines = util.convert_signature_help_to_markdown_lines(result)
+  local lines = util.convert_signature_help_to_markdown_lines(result, config.parametersOnly or false)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
     print('No signature help available')

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -7,7 +7,7 @@ local buf = require 'vim.lsp.buf'
 
 local M = {}
 
-local ns = api.nvim_create_namespace("lsp/popup")
+local signature_help_ns = api.nvim_create_namespace("lsp/signature_help")
 
 -- FIXME: DOC: Expose in vimdocs
 
@@ -335,24 +335,24 @@ M['textDocument/implementation'] = location_handler
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
 ---         - See |vim.api.nvim_open_win()|
----     - parametersOnly: (default=false)
+---     - parameters_only: (default=false)
 ---         - Display only a list of parameters
----     - suppressPrint: (default=false)
+---     - suppress_print: (default=false)
 ---         - Stop printing a message if no signature is available
 function M.signature_help(_, method, result, _, bufnr, config)
   config = config or {}
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
-    if not config.suppressPrint then
+    if not config.suppress_print then
       print('No signature help available')
     end
     return
   end
-  local lines, highlights = util.get_signature_help_with_highlights(result, config.parametersOnly or false)
+  local lines, highlights = util.get_signature_help_with_highlights(result, config.parameters_only or false)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
-    if not config.suppressPrint then
+    if not config.suppress_print then
       print('No signature help available')
     end
     return
@@ -367,7 +367,7 @@ function M.signature_help(_, method, result, _, bufnr, config)
 
   if highlights then
     for _, hi in ipairs(highlights) do
-      api.nvim_buf_set_extmark(p_bufnr, ns, hi.line, hi.col, hi.opts)
+      api.nvim_buf_set_extmark(p_bufnr, signature_help_ns, hi.line, hi.col, hi.opts)
     end
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -345,18 +345,19 @@ function M.signature_help(_, method, result, _, bufnr, config)
     print('No signature help available')
     return
   end
-  local lines, highlights = util.convert_signature_help_to_markdown_lines(result, config.parametersOnly or false)
+  local lines, highlights = util.get_signature_help_with_highlights(result, config.parametersOnly or false)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
     print('No signature help available')
     return
   end
   local syntax = api.nvim_buf_get_option(bufnr, 'syntax')
-  local filetype = api.nvim_buf_get_option(bufnr, 'filetype')
+  if syntax == "" then
+    syntax = api.nvim_buf_get_option(bufnr, 'filetype')
+  end
   local p_bufnr, _ = util.focusable_preview(method, function()
-    return lines, filetype, config
+    return lines, syntax, config
   end)
-  api.nvim_buf_set_option(p_bufnr, 'syntax', syntax)
 
   if highlights then
     for _, hi in ipairs(highlights) do

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -801,7 +801,7 @@ end
 local function parameter_range_in_signature(signature, active_parameter)
   local from
   local to = 0
-  for i = 0,#signature.parameters-1,1 do
+  for i = 0,#signature.parameters-1 do
     local parameter_label = signature.parameters[i+1].label
     from, to = signature.label:find(parameter_label, to + 1, true)
 
@@ -851,9 +851,9 @@ local function build_signature_label_from_parameters(signature, active_parameter
   return label, from + 1, to
 end
 
-local function signature_label(signature, active_parameter, parametersOnly)
+local function signature_label(signature, active_parameter, parameters_only)
   local label, from, to
-  if parametersOnly then
+  if parameters_only then
     label, from, to = build_signature_label_from_parameters(signature, active_parameter)
   else
     label = signature.label
@@ -907,7 +907,7 @@ end
 --@param signature_help Response of `textDocument/SignatureHelp`
 --@returns list of lines of converted markdown.
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
-function M.get_signature_help_with_highlights(signature_help, parametersOnly)
+function M.get_signature_help_with_highlights(signature_help, parameters_only)
   if not signature_help.signatures then
     return
   end
@@ -928,7 +928,7 @@ function M.get_signature_help_with_highlights(signature_help, parametersOnly)
   end
 
   local active_parameter = signature.activeParameter or signature_help.activeParameter or 0
-  local label, active_offset = signature_label(signature, active_parameter, parametersOnly)
+  local label, active_offset = signature_label(signature, active_parameter, parameters_only)
 
   local hl_param = "LspSignatureParamActive"
 
@@ -938,9 +938,9 @@ function M.get_signature_help_with_highlights(signature_help, parametersOnly)
     table.insert(highlights, { line = 0, col = active_offset[1], opts = { end_line = 0, end_col = active_offset[2], hl_group = hl_param, priority = 100 } })
   end
 
-  for i = 1,#signature_help.signatures,1 do
+  for i = 1,#signature_help.signatures do
     if i ~= active_signature + 1 then
-      label, active_offset = signature_label(signature_help.signatures[i], active_parameter, parametersOnly)
+      label, active_offset = signature_label(signature_help.signatures[i], active_parameter, parameters_only)
       table.insert(contents, label)
       table.insert(highlights, { line = i, col = 0, opts = { end_line = i, end_col = label:len(), hl_group = "LspSignatureInactive", priority = 200 } })
       if active_offset then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -799,7 +799,8 @@ function M.convert_input_to_markdown_lines(input, contents)
 end
 
 local function parameter_range_in_signature(signature, active_parameter)
-  local from, to = 0, 0
+  local from
+  local to = 0
   for i = 0,#signature.parameters-1,1 do
     local parameter_label = signature.parameters[i+1].label
     from, to = signature.label:find(parameter_label, to + 1, true)
@@ -894,7 +895,7 @@ local function signature_label(signature, active_parameter, parametersOnly)
   end
 
 
-  label, _ = label:gsub("\\n", " ")
+  label = label:gsub("\\n", " ")
   if from ~= nil and to ~= nil then
     return label, {from - 1, to}
   end


### PR DESCRIPTION
This PR is based #14456  and adds a single commit to it.  It uses any highlight data to fill the offset_x parameter of the lsp popup so that active parameter appears right above the cursor:

![Screenshot from 2021-05-04 14-56-48](https://user-images.githubusercontent.com/7908/117007602-23ed2180-acea-11eb-9444-580c6a98b867.png)


This feels like a good usability improvement, provided the other PR is also accepted.