### PR TITLE
[LSP] make formatting fall back to range formatting

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -242,7 +242,7 @@ function M.formatting_seq_sync(options, timeout_ms, order)
     if client.resolved_capabilities.document_formatting then
       local params = util.make_formatting_params(options)
       result, err = client.request_sync("textDocument/formatting", params, timeout_ms)
-    else
+    elseif client.resolved_capabilities.document_range_formatting then
       local last_line = vim.fn.line("$")
       local last_col = vim.fn.col({ last_line, "$" })
       local params = util.make_given_range_params({ 1, 0 }, { last_line, last_col })


### PR DESCRIPTION
## Why?
At least the three language servers that come bundled with VSCode (html, css, json) don't support documentFormatting, but do support documentRangeFormatting.
All of them are widely used language servers.
I think it's a sane default to fall back to range formatting, since range formatting on the whole range is semantically the same as document formatting.
As a side note, VSCode also does this (falls back to using documentRangeFormatting when documentFormatting is not available), see: https://github.com/microsoft/vscode/blob/c8bd5b211acd8055a81654dcf40367f422bc22e0/src/vs/editor/contrib/format/format.ts#L73-L89
