### PR TITLE
GHA tweaks and a new Coverity workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 *.h linguist-language=C
 src/nvim/testdir/test42.in diff
+.github/ export-ignore
+ci/ export-ignore
+.travis.yml export-ignore
+codecov.yml export-ignore
+.builds/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches: '**'
   pull_request:
-    branches: 'master'
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
 
 jobs:
   unixish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             runner: ubuntu-20.04
             os: linux
           - flavor: tsan
-            cc: clang-11
+            cc: clang-12
             runner: ubuntu-20.04
             os: linux
           - cc: clang

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,44 @@
+name: Coverity
+on:
+  schedule:
+    - cron: '0 10 * * 1'  # Run every Monday at 00:10
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake build-essential cmake gettext gperf libtool-bin locales ninja-build pkg-config unzip
+
+      - name: Download Coverity
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=neovim%2Fneovim" -O coverity_tool.tgz
+          mkdir cov-scan
+          tar ax -f coverity_tool.tgz --strip-components=1 -c cov-scan
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+      - name: Build dependencies
+        run: make deps
+
+      - name: Build/scan neovim
+        run: |
+          env PATH=$(pwd)/cov-scan/bin:$PATH cov-build --dir cov-int make
+
+      - name: Submit results
+        run: |
+          tar zcf cov-scan.tgz cov-int
+          curl --form token=$TOKEN \
+            --form email=$EMAIL \
+            --form file=@cov-scan.tgz \
+            --form version="$(git rev-parse HEAD)" \
+            --form description="Weekly GHA scan" \
+            'https://scan.coverity.com/builds?project=neovim%2Fneovim'
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 # Build on the oldest supported images, so we have broader compatibility
 jobs:
   linux:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     outputs:
       version: ${{ steps.build.outputs.version }}
       release: ${{ steps.build.outputs.release }}
@@ -43,7 +43,7 @@ jobs:
           retention-days: 1
 
   appimage:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
* Bump Ubuntu images to 18.04, since 16.04 is ancient (and outside of standard support)
* Actually use clang-12 for the TSAN check, as intended in 74f8196935a83879c64caff87090ac7341ed5726
* Add weekly Coverity scan

We used to run Coverity scans via Travis, but then disabled those for some reason.  I manually ran them for awhile, but it's better to have it automated.  Once per week, and only for the master branch, will avoid running into any limits issues.