### PR TITLE
checkhealth: do not ignore node_modules

### DIFF
--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -50,7 +50,7 @@ endfunction
 function! provider#node#Detect() abort
   let minver = [6, 0]
   if exists('g:node_host_prog')
-    return [expand(g:node_host_prog), '']
+    return [expand(g:node_host_prog, v:true), '']
   endif
   if !executable('node')
     return ['', 'node not found (or not executable)']

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -23,7 +23,7 @@ function! provider#pythonx#Require(host) abort
 endfunction
 
 function! s:get_python_executable_from_host_var(major_version) abort
-  return expand(get(g:, 'python'.(a:major_version == 3 ? '3' : '').'_host_prog', ''))
+  return expand(get(g:, 'python'.(a:major_version == 3 ? '3' : '').'_host_prog', ''), v:true)
 endfunction
 
 function! s:get_python_candidates(major_version) abort
@@ -44,7 +44,7 @@ function! provider#pythonx#DetectByModule(module, major_version) abort
   let python_exe = s:get_python_executable_from_host_var(a:major_version)
 
   if !empty(python_exe)
-    return [exepath(expand(python_exe)), '']
+    return [exepath(expand(python_exe, v:true)), '']
   endif
 
   let candidates = s:get_python_candidates(a:major_version)

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -46,7 +46,7 @@ endfunction
 
 function! s:detect()
   if exists("g:ruby_host_prog")
-    return expand(g:ruby_host_prog)
+    return expand(g:ruby_host_prog, v:true)
   elseif has('win32')
     return exepath('neovim-ruby-host.bat')
   else


### PR DESCRIPTION
All Node modules are installed in `*/node_modules/**`. Make sure that the check
finds those, even when the user set `wildignore` to ignore that path.

Fixes https://github.com/neovim/neovim/issues/14388