### PR TITLE
Splice extmarks on every line for block visual paste

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3334,6 +3334,9 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
             changed_cline_bef_curs();
             curwin->w_cursor.col += (colnr_T)(totlen - 1);
           }
+          changed_bytes(lnum, col);
+          extmark_splice_cols(curbuf, (int)lnum-1, col,
+                              0, (int)totlen, kExtmarkUndo);
         }
         if (VIsual_active) {
           lnum++;
@@ -3345,12 +3348,10 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       }
 
       curbuf->b_op_end = curwin->w_cursor;
-      /* For "CTRL-O p" in Insert mode, put cursor after last char */
-      if (totlen && (restart_edit != 0 || (flags & PUT_CURSEND)))
-        ++curwin->w_cursor.col;
-      changed_bytes(lnum, col);
-      extmark_splice_cols(curbuf, (int)lnum-1, col,
-                          0, (int)totlen, kExtmarkUndo);
+      // For "CTRL-O p" in Insert mode, put cursor after last char
+      if (totlen && (restart_edit != 0 || (flags & PUT_CURSEND))) {
+        curwin->w_cursor.col++;
+      }
     } else {
       // Insert at least one line.  When y_type is kMTCharWise, break the first
       // line in two.

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -936,6 +936,28 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("block visual paste", function()
+      local check_events = setup_eventcheck(verify, {"AAA",
+                                                     "BBB",
+                                                     "CCC",
+                                                     "DDD",
+                                                     "EEE",
+                                                     "FFF"})
+      funcs.setreg("a", "___")
+      feed([[gg0l<c-v>3jl"ap]])
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 2, 2, 0, 0, 0 };
+        { "test1", "bytes", 1, 3, 1, 1, 3, 0, 2, 2, 0, 0, 0 };
+        { "test1", "bytes", 1, 3, 2, 1, 5, 0, 2, 2, 0, 0, 0 };
+        { "test1", "bytes", 1, 3, 3, 1, 7, 0, 2, 2, 0, 0, 0 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 0, 0, 0, 3, 3 };
+        { "test1", "bytes", 1, 6, 1, 1, 6, 0, 0, 0, 0, 3, 3 };
+        { "test1", "bytes", 1, 7, 2, 1, 11, 0, 0, 0, 0, 3, 3 };
+        { "test1", "bytes", 1, 8, 3, 1, 16, 0, 0, 0, 0, 3, 3 };
+      }
+    end)
+
     teardown(function()
       os.remove "Xtest-reload"
       os.remove "Xtest-undofile"


### PR DESCRIPTION
Previously, `do_put` would send updates for only the paste on the last line. This changes it so that all modified lines have corresponding buffer updates. Not entirely sure if this is the right fix.

@bfredl @vigoux 