### PR TITLE
[RDY] Handle warnings in vim.notify

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -522,6 +522,8 @@ function vim.notify(msg, log_level, _opts)
 
   if log_level == vim.log.levels.ERROR then
     vim.api.nvim_err_writeln(msg)
+  elseif log_level == vim.log.levels.WARN then
+    vim.api.nvim_echo({{msg, 'WarningMsg'}}, true, {})
   else
     vim.api.nvim_echo({{msg}}, true, {})
   end


### PR DESCRIPTION
With this warnings notifications will be displayed with `WarningMsg` highlight group instead of like normal messages. 

Current default `vim.notify` handles errors but rest are displayed as regular messages . As warnings aren't displayed differently they don't standout as much as they should . This should make `nvim_notify` more useful even if user hasn't overwritten vim.notify :)