### PR TITLE
Minor observational corrections to the nvim_buf_set_extmark documentation

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2252,7 +2252,7 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                 Parameters: ~
                     {buffer}  Buffer handle, or 0 for current buffer
                     {ns_id}   Namespace id from |nvim_create_namespace()|
-                    {line}    Line number where to place the mark, 0-based
+                    {line}    Line where to place the mark, 0-based
                     {col}     Column where to place the mark, 0-based
                     {opts}    Optional parameters.
                               • id : id of the extmark to edit.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2252,14 +2252,14 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                 Parameters: ~
                     {buffer}  Buffer handle, or 0 for current buffer
                     {ns_id}   Namespace id from |nvim_create_namespace()|
-                    {line}    Line number where to place the mark
-                    {col}     Column where to place the mark
+                    {line}    Line number where to place the mark, 0-based
+                    {col}     Column where to place the mark, 0-based
                     {opts}    Optional parameters.
                               • id : id of the extmark to edit.
                               • end_line : ending line of the mark, 0-based
                                 inclusive.
                               • end_col : ending col of the mark, 0-based
-                                inclusive.
+                                exclusive.
                               • hl_group : name of the highlight group used to
                                 highlight this mark.
                               • virt_text : virtual text to link to this mark.

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1412,12 +1412,12 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id,
 ///
 /// @param buffer  Buffer handle, or 0 for current buffer
 /// @param ns_id  Namespace id from |nvim_create_namespace()|
-/// @param line  Line number where to place the mark
-/// @param col  Column where to place the mark
+/// @param line  Line where to place the mark, 0-based
+/// @param col  Column where to place the mark, 0-based
 /// @param opts  Optional parameters.
 ///               - id : id of the extmark to edit.
 ///               - end_line : ending line of the mark, 0-based inclusive.
-///               - end_col : ending col of the mark, 0-based inclusive.
+///               - end_col : ending col of the mark, 0-based exclusive.
 ///               - hl_group : name of the highlight group used to highlight
 ///                   this mark.
 ///               - virt_text : virtual text to link to this mark.


### PR DESCRIPTION
Add a note for the line and col, saying they are 0-based.
The end_col appears to be exclusive, unline the end_line.