### PR TITLE
LSP: Add an option to lsp.diagnostic.set_loclist to the workspace

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1197,27 +1197,25 @@ end
 ---             - Exclusive severity to consider. Overrides {severity_limit}
 ---         - {severity_limit}: (DiagnosticSeverity)
 ---             - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
+---         - {workspace}: (boolean, default false)
+---             - Set the list with workspace diagnostics
 function M.set_loclist(opts)
   opts = opts or {}
 
   local open_loclist = if_nil(opts.open_loclist, true)
 
   local win_id = vim.api.nvim_get_current_win()
-
-  local bufnr = vim.api.nvim_get_current_buf()
-  local buffer_diags = M.get(bufnr, opts.client_id)
-
-  if opts.severity then
-    buffer_diags = filter_to_severity_limit(opts.severity, buffer_diags)
-  elseif opts.severity_limit then
-    buffer_diags = filter_by_severity_limit(opts.severity_limit, buffer_diags)
-  end
+  local current_bufnr = vim.api.nvim_get_current_buf()
+  local diags = opts.workspace and M.get_all() or {
+    [current_bufnr] = M.get(current_bufnr, opts.client_id)
+  }
 
   local items = {}
-  local insert_diag = function(diag)
+  local insert_diag = function(bufnr, diag)
     local pos = diag.range.start
     local row = pos.line
-    local col = util.character_offset(bufnr, row, pos.character)
+
+    local col = util.character_offset(bufnr, row, pos.character) or 0
 
     table.insert(items, {
       bufnr = bufnr,
@@ -1228,11 +1226,25 @@ function M.set_loclist(opts)
     })
   end
 
-  for _, diag in ipairs(buffer_diags) do
-    insert_diag(diag)
+  for bufnr, diagnostic in pairs(diags) do
+    if opts.severity then
+      diagnostic = filter_to_severity_limit(opts.severity, diagnostic)
+    elseif opts.severity_limit then
+      diagnostic = filter_by_severity_limit(opts.severity_limit, diagnostic)
+    end
+
+    for _, diag in ipairs(diagnostic) do
+      insert_diag(bufnr, diag)
+    end
   end
 
-  table.sort(items, function(a, b) return a.lnum < b.lnum end)
+  table.sort(items, function(a, b)
+    if a.bufnr == b.bufnr then
+      return a.lnum < b.lnum
+    else
+      return a.bufnr < b.bufnr
+    end
+  end)
 
   util.set_loclist(items, win_id)
   if open_loclist then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1845,8 +1845,9 @@ end
 --@param row 0-indexed line
 --@param col 0-indexed byte offset in line
 --@returns (number, number) UTF-32 and UTF-16 index of the character in line {row} column {col} in buffer {buf}
-function M.character_offset(buf, row, col)
-  local line = api.nvim_buf_get_lines(buf, row, row+1, true)[1]
+function M.character_offset(bufnr, row, col)
+  local uri = vim.uri_from_bufnr(bufnr)
+  local line = M.get_line(uri, row)
   -- If the col is past the EOL, use the line length.
   if col > #line then
     return str_utfindex(line)


### PR DESCRIPTION
This change adds an option to populate the loclist with the workspace diagnostics, rather than the buffer ones

It fixes issue #14481