### PR TITLE
Evaluate results of %{} blocks in statusline

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4017,8 +4017,8 @@ int build_stl_str_hl(
 
       // If the output of the expression needs to be evaluated
       // replace the %{} block with the result of evaluation
-      if (str != NULL && *str != 0 && strchr((const char *)str, '%') != NULL &&
-            evaldepth < MAX_STL_EVAL_DEPTH) {
+      if (str != NULL && *str != 0 && strchr((const char *)str, '%') != NULL
+          && evaldepth < MAX_STL_EVAL_DEPTH) {
         size_t parsed_usefmt = (size_t)(block_start - usefmt - 1);
         size_t str_length = strlen((const char *)str);
         size_t fmt_length = strlen((const char *)fmt_p);

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -10,6 +10,10 @@
 #include "nvim/eval.h"
 #include "nvim/macros.h"
 
+// Determines how deeply nested %{} blocks will be evaluated
+// in statusline.
+#define MAX_STL_EVAL_DEPTH 100
+
 // Values for buflist_getfile()
 enum getf_values {
   GETF_SETMARK = 0x01, // set pcmark before jumping

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -241,6 +241,18 @@ func Test_statusline()
   call assert_match('^vimLineComment\s*$', s:get_statusline())
   syntax off
 
+  "%{: evaluates enxpressions present in result of %{} expression
+  func! Inner_eval()
+    return '%n some other text'
+  endfunc
+  func! Outer_eval()
+    return 'some text %{Inner_eval()}'
+  endfunc
+  set statusline=%{Outer_eval()}
+  call assert_match('^some text ' . bufnr() . ' some other text\s*$', s:get_statusline())
+  delfunc Inner_eval
+  delfunc Outer_eval
+
   "%(: Start of item group.
   set statusline=ab%(cd%q%)de
   call assert_match('^abde\s*$', s:get_statusline())

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -241,7 +241,7 @@ func Test_statusline()
   call assert_match('^vimLineComment\s*$', s:get_statusline())
   syntax off
 
-  "%{: evaluates enxpressions present in result of %{} expression
+  "%{: evaluates expressions present in result of %{} expression
   func! Inner_eval()
     return '%n some other text'
   endfunc


### PR DESCRIPTION
Currently results of %{} blocks gets directly displayed in statusline.
Because of results of %{} blocks cann't contain expressions like
%#highlight# or %f etc . This pr changes that .

The idea is simple it just replaces the %{} block with it's result and continue evaluating.