### PR TITLE
fix(gcc): compile warnings in nvim_buf_set_lines

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -477,7 +477,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
       goto end;
     }
 
-    inserted_bytes += STRLEN(lines[i]) + 1;
+    inserted_bytes += (bcount_t)STRLEN(lines[i]) + 1;
     // Mark lines that haven't been passed to the buffer as they need
     // to be freed later
     lines[i] = NULL;
@@ -497,7 +497,7 @@ void nvim_buf_set_lines(uint64_t channel_id,
       goto end;
     }
 
-    inserted_bytes += STRLEN(lines[i]) + 1;
+    inserted_bytes += (bcount_t)STRLEN(lines[i]) + 1;
 
     // Same as with replacing, but we also need to free lines
     xfree(lines[i]);


### PR DESCRIPTION
Make the `size_t` to `bcount_t` (`ptrdiff_t`) conversions explicit in #14501.

This appeases GCC 9.3.0's latest `-Wsign-conversion` tantrum.
(This shouldn't conflict with #14528)