### PR TITLE
Revert "api/window: use the "noblock" variants in nvim_win_set_buf"

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -54,7 +54,7 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
     return;
   }
 
-  if (switch_win_noblock(&save_curwin, &save_curtab, win, tab, false) == FAIL) {
+  if (switch_win(&save_curwin, &save_curtab, win, tab, false) == FAIL) {
     api_set_error(err,
                   kErrorTypeException,
                   "Failed to switch to window %d",
@@ -74,7 +74,7 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
   // So do it now.
   validate_cursor();
 
-  restore_win_noblock(save_curwin, save_curtab, false);
+  restore_win(save_curwin, save_curtab, false);
 }
 
 /// Gets the (1,0)-indexed cursor position in the window. |api-indexing|


### PR DESCRIPTION
This reverts commit 1def3d1542d6a65f057e743faea39a760b50db87.

Plugins may depend on catching the following events
when creating windows:
- BufWinEnter
- BufEnter
- BufLeave

Risky to introduce this breaking change on 0.5 release
when 0.5 release should be out by now.

https://github.com/asvetliakov/vscode-neovim/issues/632#issuecomment-837201224