### PR TITLE
fix(vim-patch.sh -m): Show all commits touching a file, not just the first

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -593,18 +593,20 @@ list_missing_previous_vimpatches_for_patch() {
     _set_missing_vimpatches 1 -- "${fname}"
 
     set +u  # Avoid "unbound variable" with bash < 4.4 below.
-    local missing_vim_commit_info="${missing_vim_patches[0]}"
-    if [[ -z "${missing_vim_commit_info}" ]]; then
-      printf -- "-\n"
-    else
-      local missing_vim_commit="${missing_vim_commit_info%%:*}"
-      if [[ -z "${vim_tag}" ]] || [[ "${missing_vim_commit}" < "${vim_tag}" ]]; then
-        printf -- "%s\n" "$missing_vim_commit_info"
-        missing_list+=("$missing_vim_commit_info")
+    for missing_vim_commit_info in "${missing_vim_patches[@]}"; do
+      if [[ -z "${missing_vim_commit_info}" ]]; then
+        printf -- "-\r"
       else
-        printf -- "-\n"
+        printf -- "-\r"
+        local missing_vim_commit="${missing_vim_commit_info%%:*}"
+        if [[ -z "${vim_tag}" ]] || [[ "${missing_vim_commit}" < "${vim_tag}" ]]; then
+          printf -- "%s\n" "$missing_vim_commit_info"
+          missing_list+=("$missing_vim_commit_info")
+        else
+          printf -- "-\r"
+        fi
       fi
-    fi
+    done
     set -u
   done
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -578,7 +578,7 @@ list_missing_previous_vimpatches_for_patch() {
   local -a fnames
   while IFS= read -r line ; do
     fnames+=("$line")
-  done < <(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id --name-only -r "${vim_commit}")
+  done < <(git -C "${VIM_SOURCE_DIR}" diff-tree --no-commit-id --name-only -r "${vim_commit}" -- . ':!src/version.c')
   local i=0
   local n=${#fnames[@]}
   printf '=== getting missing patches for %d files ===\n' "$n"


### PR DESCRIPTION
Before
------

```
$ ./scripts/vim-patch.sh -m v8.1.1378
=== getting missing patches for 5 files ===
[1/5] src/evalfunc.c: v8.0.1592: terminal windows in a session are not properly restored
[2/5] src/fileio.c: v8.0.1300: file permissions may end up wrong when writing
[3/5] src/proto/fileio.pro: -
[4/5] src/testdir/test_functions.vim: v8.1.0832: confirm() is not tested
[5/5] src/version.c: v8.0.1119: quitting a split terminal window kills the job
✘ 4 missing previous Vim patches:
 - v8.0.1119: quitting a split terminal window kills the job
   3 files changed, 39 insertions(+), 20 deletions(-)
 - v8.0.1300: file permissions may end up wrong when writing
   7 files changed, 88 insertions(+), 24 deletions(-)
 - v8.0.1592: terminal windows in a session are not properly restored
   12 files changed, 274 insertions(+), 20 deletions(-)
 - v8.1.0832: confirm() is not tested
   2 files changed, 57 insertions(+)
```

After
----

```
$ ./scripts/vim-patch.sh -m v8.1.1378 
=== getting missing patches for 5 files ===
v8.0.1592: terminal windows in a session are not properly restored
v8.0.1609: shell commands in the GUI use a dumb terminal
v8.0.1804: using :normal in terminal window causes problems
v8.1.0050: $VIM_TERMINAL is also set when not in a terminal window
v8.1.0367: getchar(1) no longer processes pending messages
v8.1.0579: cannot attach properties to text
v8.1.0690: setline() and setbufline() do not clear text properties
v8.1.0735: cannot handle binary data
v8.1.0736: code for Blob not sufficiently tested
v8.1.0742: not all Blob operations are tested
v8.1.0743: giving error messages is not flexible
v8.1.0753: printf format not checked for semsg()
v8.1.0755: error message for get() on a Blob with invalid index
v8.1.0779: argument for message functions is inconsistent
v8.1.0793: incorrect error messages for functions that take a Blob
v8.1.0797: error E898 is used twice
v8.1.0815: dialog for file changed outside of Vim not tested
v8.1.0846: not easy to recognize the system Vim runs on
v8.1.0870: Vim doesn't use the new ConPTY support in Windows 10
v8.1.0892: failure when closing a window when location list is in use
v8.1.0894: MS-Windows: resolve() does not return a reparse point
v8.1.0897: can modify a:000 when using a reference
v8.1.0941: macros for MS-Windows are inconsistent
v8.1.1035: prop_remove() second argument is not optional
v8.1.1044: no way to check the reference count of objects
v8.1.1071: cannot get composing characters from the screen
v8.1.1076: file for Insert mode is much too big
v8.1.1116: cannot enforce a Vim script style
v8.1.1136: decoding of mouse click escape sequence is not tested
v8.1.1190: has('vimscript-3') does not work
v8.1.1210: support for user commands is spread out
v8.1.1218: cannot set a directory for a tab page
v8.1.1267: cannot check if GPM mouse support is working
v8.1.1291: not easy to change directory and restore
v8.1.1321: no docs or tests for listener functions
v8.1.1332: cannot flush listeners without redrawing, mix of changes
v8.1.1355: obvious mistakes are accepted as valid expressions
v8.0.1300: file permissions may end up wrong when writing
v8.0.1307: compiler warning for ignoring return value
v8.0.1459: cannot handle change of directory
v8.1.0306: plural messages are not translated properly
v8.1.0743: giving error messages is not flexible
v8.1.0779: argument for message functions is inconsistent
v8.1.0879: MS-Windows: temp name encoding can be wrong
v8.1.0895: MS-Windows: dealing with temp name encoding not quite right
v8.1.0941: macros for MS-Windows are inconsistent
v8.1.0832: confirm() is not testedim: -
v8.1.0846: not easy to recognize the system Vim runs on
v8.1.0878: test for has('bsd') fails on some BSD systems
v8.1.0884: double check for bsd systems
v8.1.0894: MS-Windows: resolve() does not return a reparse point
v8.1.1336: some eval functionality is not covered by tests
v8.0.1119: quitting a split terminal window kills the job
v8.0.1300: file permissions may end up wrong when writing
v8.0.1307: compiler warning for ignoring return value
v8.0.1367: patch 8.0.1367
v8.0.1459: cannot handle change of directory
v8.0.1460: missing file in patch
v8.0.1461: missing another file in patch
v8.0.1463: test fails without 'autochdir' option
v8.0.1558: no right-click menu in a terminal
v8.0.1562: the terminal debugger can't set a breakpoint with the mouse
v8.0.1570: can't use :popup for a menu in the terminal
v8.0.1574: show cursor in wrong place when using popup menu
v8.0.1588: popup menu hangs after typing CTRL-C
v8.0.1592: terminal windows in a session are not properly restored
v8.0.1609: shell commands in the GUI use a dumb terminal
v8.0.1616: Win32: shell commands in the GUI open a new console
v8.0.1706: cannot sent CTRL-\ to a terminal window
v8.0.1732: crash when terminal API call deletes the buffer
v8.0.1743: terminal window options are named inconsistently
v8.0.1794: duplicate term options after renaming
v8.0.1804: using :normal in terminal window causes problems
v8.1.0035: not easy to switch between prompt buffer and other windows
v8.1.0040: warnings from 64-bit compiler
v8.1.0042: if omni completion opens a window Insert mode is stopped
v8.1.0049: shell cannot tell running in a terminal window
v8.1.0050: $VIM_TERMINAL is also set when not in a terminal window
v8.1.0058: display problem with margins and scrolling
v8.1.0062: popup menu broken if a callback changes the window layout
v8.1.0064: typing CTRL-W in a prompt buffer shows mode "-- --"
v8.1.0065: balloon displayed at the wrong position
v8.1.0072: use of 'termwinkey' is inconsistent
v8.1.0087: v:shell_error is always zero when using terminal for "!cmd"
v8.1.0136: Lua tests don't cover new features
v8.1.0139: Lua tests fail on some platforms
v8.1.0164: luaeval('vim.buffer().name') returns an error
v8.1.0228: dropping files is ignored while Vim is busy
v8.1.0300: the old window title might be freed twice
v8.1.0304: no redraw when using a STOP signal on Vim and then CONT
v8.1.0306: plural messages are not translated properly
v8.1.0312: wrong type for flags used in signal handlers
v8.1.0328: inputlist() doesn't work with a timer
v8.1.0342: crash when a callback deletes a window that is being used
v8.1.0367: getchar(1) no longer processes pending messages
v8.1.0425: ml_get error and crash with appendbufline()
v8.1.0439: recursive use of getcmdline() still not protected
v8.1.0487: no menus specifically for the terminal window
v8.1.0535: increment/decrement might get interrupted by updating folds
v8.1.0579: cannot attach properties to text
v8.1.0582: text properties are not enabled
v8.1.0601: a few compiler warnings
v8.1.0602: DirChanged is also triggered when directory didn't change
v8.1.0604: autocommand test fails on MS-Windows
v8.1.0612: cannot use two global runtime dirs with configure
v8.1.0634: text properties cannot cross line boundaries
v8.1.0636: line2byte() gives wrong values with text properties
v8.1.0638: text property highlighting is off by one column
v8.1.0639: text properties test fails on MS-Windows
v8.1.0643: computing byte offset wrong
v8.1.0654: when deleting a line text property flags are not adjusted
v8.1.0655: when appending a line text property flags are not added
v8.1.0663: text property display wrong when 'number' is set
v8.1.0665: text property display wrong when 'spell' is set
v8.1.0667: textprop test leaves file behind
v8.1.0672: the Lua interface doesn't know about v:null
v8.1.0675: text property column in screen columns is not practical
v8.1.0676: textprop screendump test fails
v8.1.0681: text properties as not adjusted for deleted text
v8.1.0682: text properties not adjusted when backspacing replaced text
v8.1.0684: warnings from 64-bit compiler
v8.1.0688: text properties are not restored by undo
v8.1.0689: undo with text properties not tested
v8.1.0690: setline() and setbufline() do not clear text properties
v8.1.0691: text properties are not adjusted for :substitute
v8.1.0694: when using text props may free memory that is not allocated
v8.1.0695: internal error when using :popup
v8.1.0703: compiler warnings with 64-bit compiler
v8.1.0707: text property columns are not adjusted for changed indent
v8.1.0710: when using timers may wait for job exit quite long
v8.1.0711: test files still use function!
v8.1.0735: cannot handle binary data
v8.1.0736: code for Blob not sufficiently tested
v8.1.0737: compiler warning for uninitialized variable
v8.1.0738: using freed memory, for loop over blob leaks memory
v8.1.0741: viminfo with Blob is not tested
v8.1.0742: not all Blob operations are tested
v8.1.0743: giving error messages is not flexible
v8.1.0748: using sprintf() instead of semsg()
v8.1.0753: printf format not checked for semsg()
v8.1.0755: error message for get() on a Blob with invalid index
v8.1.0756: copy() does not make a copy of a Blob
v8.1.0757: not enough documentation for Blobs
v8.1.0761: default value for brief_wait is wrong
v8.1.0765: string format of a Blob can't be parsed back
v8.1.0768: updating completions may cause the popup menu to flicker
v8.1.0770: inconsistent use of ELAPSED_FUNC
v8.1.0779: argument for message functions is inconsistent
v8.1.0793: incorrect error messages for functions that take a Blob
v8.1.0797: error E898 is used twice
v8.1.0798: changing a blob while iterating over it works strangely
v8.1.0802: negative index doesn't work for Blob
v8.1.0815: dialog for file changed outside of Vim not tested
v8.1.0820: test for sending large data over channel sometimes fails
v8.1.0824: SunOS/Solaris has a problem with ttys
v8.1.0829: when 'hidden' is set session creates extra buffers
v8.1.0832: confirm() is not tested
v8.1.0845: having job_status() free the job causes problems
v8.1.0846: not easy to recognize the system Vim runs on
v8.1.0857: indent functionality is not separated
v8.1.0863: cannot see what signal caused a job to end
v8.1.0870: Vim doesn't use the new ConPTY support in Windows 10
v8.1.0876: completion match not displayed when popup menu is not shown
v8.1.0878: test for has('bsd') fails on some BSD systems
v8.1.0879: MS-Windows: temp name encoding can be wrong
v8.1.0880: MS-Windows: inconsistent selection of winpty/conpty
v8.1.0884: double check for bsd systems
v8.1.0890: pty allocation wrong if using file for out channel
v8.1.0892: failure when closing a window when location list is in use
v8.1.0894: MS-Windows: resolve() does not return a reparse point
v8.1.0895: MS-Windows: dealing with temp name encoding not quite right
v8.1.0897: can modify a:000 when using a reference
v8.1.0906: using clumsy way to get console window handle
v8.1.0909: MS-Windows: using ConPTY even though it is not stable
v8.1.0914: code related to findfile() is spread out
v8.1.0918: MS-Windows: startup messages are not converted
v8.1.0928: stray log function call
v8.1.0940: MS-Windows console resizing not handled properly
v8.1.0941: macros for MS-Windows are inconsistent
v8.1.0942: options window still checks for the multi_byte feature
v8.1.0953: a very long file is truncated at 2^31 lines
v8.1.0969: message written during startup is truncated
v8.1.0970: text properties test fails when 'encoding' is not utf-8
v8.1.0977: blob not tested with Ruby
v8.1.0999: use register one too often and not properly tested
v8.1.1004: function "luaV_setref()" not covered with tests
v8.1.1019: Lua: may garbage collect function reference in use
v8.1.1022: may use NULL pointer when out of memory
v8.1.1023: may use NULL pointer when indexing a blob
v8.1.1028: MS-Windows: memory leak when creating terminal fails
v8.1.1035: prop_remove() second argument is not optional
v8.1.1038: Arabic support excludes Farsi
v8.1.1043: Lua interface does not support Blob
v8.1.1044: no way to check the reference count of objects
v8.1.1071: cannot get composing characters from the screen
v8.1.1076: file for Insert mode is much too big
v8.1.1078: when 'listchars' is set a composing char on a space is wrong
v8.1.1079: no need for a separate ScreenLinesUtf8() test function
v8.1.1083: MS-Windows: hang when opening a file on network share
v8.1.1085: compiler warning for possibly uninitialized variable
v8.1.1090: MS-Windows: modify_fname() has problems with some 'encoding'
v8.1.1103: MS-Windows: old API calls are no longer needed
v8.1.1106: no test for 'writedelay'
v8.1.1110: composing chars on space wrong when 'listchars' is set
v8.1.1116: cannot enforce a Vim script style
v8.1.1133: compiler warning for uninitialized struct member
v8.1.1136: decoding of mouse click escape sequence is not tested
v8.1.1184: undo file left behind after running test
v8.1.1188: not all Vim variables require the v: prefix
v8.1.1190: has('vimscript-3') does not work
v8.1.1195: Vim script debugger functionality needs cleanup
v8.1.1200: old style comments in debugger source
v8.1.1210: support for user commands is spread out
v8.1.1218: cannot set a directory for a tab page
v8.1.1224: MS-Windows: cannot specify font weight
v8.1.1226: {not in Vi} remarks get in the way of useful help text
v8.1.1259: crash when exiting early
v8.1.1265: when GPM mouse support is enabled double clicks do not work
v8.1.1267: cannot check if GPM mouse support is working
v8.1.1274: after :unmenu can still execute the menu with :emenu
v8.1.1276: cannot combine text properties with syntax highlighting
v8.1.1278: missing change for "combine" field
v8.1.1280: remarks about functionality not in Vi clutters the help
v8.1.1291: not easy to change directory and restore
v8.1.1320: it is not possible to track changes to a buffer
v8.1.1321: no docs or tests for listener functions
v8.1.1326: no test for listener with partial
v8.1.1328: no test for listener with undo operation
v8.1.1329: plans for popup window support are spread out
v8.1.1332: cannot flush listeners without redrawing, mix of changes
v8.1.1333: text properties don't always move after changes
v8.1.1335: listener callback is called after inserting text
v8.1.1336: some eval functionality is not covered by tests
v8.1.1337: get empty text prop when splitting line just after text prop
v8.1.1340: attributes from 'cursorline' overwrite textprop
v8.1.1341: text properties are lost when joining lines
v8.1.1343: text properties not adjusted for Visual block mode delete
v8.1.1344: Coverity complains about possibly using a NULL pointer
v8.1.1351: text property wrong after :substitute
v8.1.1355: obvious mistakes are accepted as valid expressions
v8.1.1359: text property wrong after :substitute with backslash
v8.1.1364: design for popup window support needs more details
v8.1.1376: warnings for size_t/int mixups
495282b6e7e418d072a8ab53c9056b269dc308b7: Correct list of patch numbers
2b72821924ff514727b60fb0b647d5caae8336f7: Update version.c for missing patch number
fe712ced6e1509d1e16b12d2b5581f89d0f9f4df: Fix duplicated code that only appears in git.
87fda407f8ecf947ba6ce72ac21f69ff04d909cd: Also fix the patch number.
85d9b03f84f59c4c6013d6bd7e6d1bb8091ee8c5: Correct list of patches.
c882e4d169fd5e0364bc91642040337efe7327a6: Add missing change to version.c
✘ 197 missing previous Vim patches:
 - 2b72821924ff514727b60fb0b647d5caae8336f7: Update version.c for missing patch number
   1 file changed, 2 insertions(+)
 - 495282b6e7e418d072a8ab53c9056b269dc308b7: Correct list of patch numbers
   1 file changed, 2 deletions(-)
 - 85d9b03f84f59c4c6013d6bd7e6d1bb8091ee8c5: Correct list of patches.
   1 file changed, 2 deletions(-)
 - 87fda407f8ecf947ba6ce72ac21f69ff04d909cd: Also fix the patch number.
   1 file changed, 2 insertions(+)
 - c882e4d169fd5e0364bc91642040337efe7327a6: Add missing change to version.c
   1 file changed, 2 insertions(+)
 - fe712ced6e1509d1e16b12d2b5581f89d0f9f4df: Fix duplicated code that only appears in git.
   1 file changed, 4 deletions(-)
 - v8.0.1119: quitting a split terminal window kills the job
   3 files changed, 39 insertions(+), 20 deletions(-)
 - v8.0.1300: file permissions may end up wrong when writing
   7 files changed, 88 insertions(+), 24 deletions(-)
 - v8.0.1307: compiler warning for ignoring return value
   2 files changed, 3 insertions(+), 1 deletion(-)
 - v8.0.1367: patch 8.0.1367
   2 files changed, 3 insertions(+), 1 deletion(-)
 - v8.0.1459: cannot handle change of directory
   12 files changed, 94 insertions(+), 15 deletions(-)
 - v8.0.1460: missing file in patch
   2 files changed, 11 insertions(+), 2 deletions(-)
 - v8.0.1461: missing another file in patch
   2 files changed, 18 insertions(+), 2 deletions(-)
 - v8.0.1463: test fails without 'autochdir' option
   2 files changed, 5 insertions(+)
 - v8.0.1558: no right-click menu in a terminal
   7 files changed, 344 insertions(+), 152 deletions(-)
 - v8.0.1562: the terminal debugger can't set a breakpoint with the mouse
   3 files changed, 103 insertions(+), 43 deletions(-)
 - v8.0.1570: can't use :popup for a menu in the terminal
   6 files changed, 53 insertions(+), 12 deletions(-)
 - v8.0.1574: show cursor in wrong place when using popup menu
   4 files changed, 19 insertions(+), 6 deletions(-)
 - v8.0.1588: popup menu hangs after typing CTRL-C
   2 files changed, 4 insertions(+), 2 deletions(-)
 - v8.0.1592: terminal windows in a session are not properly restored
   12 files changed, 274 insertions(+), 20 deletions(-)
 - v8.0.1609: shell commands in the GUI use a dumb terminal
   10 files changed, 416 insertions(+), 164 deletions(-)
 - v8.0.1616: Win32: shell commands in the GUI open a new console
   2 files changed, 79 insertions(+), 1 deletion(-)
 - v8.0.1706: cannot sent CTRL-\ to a terminal window
   3 files changed, 9 insertions(+), 1 deletion(-)
 - v8.0.1732: crash when terminal API call deletes the buffer
   5 files changed, 57 insertions(+), 5 deletions(-)
 - v8.0.1743: terminal window options are named inconsistently
   8 files changed, 108 insertions(+), 56 deletions(-)
 - v8.0.1794: duplicate term options after renaming
   6 files changed, 31 insertions(+), 66 deletions(-)
 - v8.0.1804: using :normal in terminal window causes problems
   4 files changed, 7 insertions(+), 5 deletions(-)
 - v8.1.0035: not easy to switch between prompt buffer and other windows
   5 files changed, 82 insertions(+), 1 deletion(-)
 - v8.1.0040: warnings from 64-bit compiler
   2 files changed, 4 insertions(+), 2 deletions(-)
 - v8.1.0042: if omni completion opens a window Insert mode is stopped
   2 files changed, 16 insertions(+), 4 deletions(-)
 - v8.1.0049: shell cannot tell running in a terminal window
   5 files changed, 44 insertions(+), 10 deletions(-)
 - v8.1.0050: $VIM_TERMINAL is also set when not in a terminal window
   8 files changed, 66 insertions(+), 33 deletions(-)
 - v8.1.0058: display problem with margins and scrolling
   2 files changed, 19 insertions(+), 9 deletions(-)
 - v8.1.0062: popup menu broken if a callback changes the window layout
   4 files changed, 71 insertions(+), 20 deletions(-)
 - v8.1.0064: typing CTRL-W in a prompt buffer shows mode "-- --"
   4 files changed, 7 insertions(+), 3 deletions(-)
 - v8.1.0065: balloon displayed at the wrong position
   2 files changed, 12 insertions(+), 4 deletions(-)
 - v8.1.0072: use of 'termwinkey' is inconsistent
   3 files changed, 12 insertions(+), 4 deletions(-)
 - v8.1.0087: v:shell_error is always zero when using terminal for "!cmd"
   6 files changed, 80 insertions(+), 25 deletions(-)
 - v8.1.0136: Lua tests don't cover new features
   3 files changed, 67 insertions(+), 24 deletions(-)
 - v8.1.0139: Lua tests fail on some platforms
   2 files changed, 5 insertions(+), 3 deletions(-)
 - v8.1.0164: luaeval('vim.buffer().name') returns an error
   3 files changed, 8 insertions(+), 7 deletions(-)
 - v8.1.0228: dropping files is ignored while Vim is busy
   8 files changed, 202 insertions(+), 115 deletions(-)
 - v8.1.0300: the old window title might be freed twice
   2 files changed, 11 insertions(+), 2 deletions(-)
 - v8.1.0304: no redraw when using a STOP signal on Vim and then CONT
   4 files changed, 74 insertions(+), 34 deletions(-)
 - v8.1.0306: plural messages are not translated properly
   8 files changed, 79 insertions(+), 128 deletions(-)
 - v8.1.0312: wrong type for flags used in signal handlers
   4 files changed, 15 insertions(+), 12 deletions(-)
 - v8.1.0328: inputlist() doesn't work with a timer
   3 files changed, 26 insertions(+), 19 deletions(-)
 - v8.1.0342: crash when a callback deletes a window that is being used
   3 files changed, 42 insertions(+), 23 deletions(-)
 - v8.1.0367: getchar(1) no longer processes pending messages
   2 files changed, 9 insertions(+)
 - v8.1.0425: ml_get error and crash with appendbufline()
   3 files changed, 35 insertions(+)
 - v8.1.0439: recursive use of getcmdline() still not protected
   5 files changed, 63 insertions(+), 97 deletions(-)
 - v8.1.0487: no menus specifically for the terminal window
   19 files changed, 269 insertions(+), 120 deletions(-)
 - v8.1.0535: increment/decrement might get interrupted by updating folds
   2 files changed, 26 insertions(+)
 - v8.1.0579: cannot attach properties to text
   26 files changed, 1747 insertions(+), 46 deletions(-)
 - v8.1.0582: text properties are not enabled
   3 files changed, 17 insertions(+), 11 deletions(-)
 - v8.1.0601: a few compiler warnings
   4 files changed, 10 insertions(+), 9 deletions(-)
 - v8.1.0602: DirChanged is also triggered when directory didn't change
   5 files changed, 61 insertions(+), 27 deletions(-)
 - v8.1.0604: autocommand test fails on MS-Windows
   3 files changed, 4 insertions(+), 2 deletions(-)
 - v8.1.0612: cannot use two global runtime dirs with configure
   7 files changed, 54 insertions(+), 18 deletions(-)
 - v8.1.0634: text properties cannot cross line boundaries
   4 files changed, 145 insertions(+), 61 deletions(-)
 - v8.1.0636: line2byte() gives wrong values with text properties
   6 files changed, 66 insertions(+), 26 deletions(-)
 - v8.1.0638: text property highlighting is off by one column
   3 files changed, 75 insertions(+), 67 deletions(-)
 - v8.1.0639: text properties test fails on MS-Windows
   2 files changed, 3 insertions(+)
 - v8.1.0643: computing byte offset wrong
   3 files changed, 6 insertions(+), 4 deletions(-)
 - v8.1.0654: when deleting a line text property flags are not adjusted
   5 files changed, 193 insertions(+), 10 deletions(-)
 - v8.1.0655: when appending a line text property flags are not added
   4 files changed, 117 insertions(+), 31 deletions(-)
 - v8.1.0663: text property display wrong when 'number' is set
   2 files changed, 4 insertions(+), 2 deletions(-)
 - v8.1.0665: text property display wrong when 'spell' is set
   4 files changed, 97 insertions(+), 25 deletions(-)
 - v8.1.0667: textprop test leaves file behind
   2 files changed, 3 insertions(+), 1 deletion(-)
 - v8.1.0672: the Lua interface doesn't know about v:null
   3 files changed, 11 insertions(+), 4 deletions(-)
 - v8.1.0675: text property column in screen columns is not practical
   7 files changed, 59 insertions(+), 48 deletions(-)
 - v8.1.0676: textprop screendump test fails
   2 files changed, 5 insertions(+), 2 deletions(-)
 - v8.1.0681: text properties as not adjusted for deleted text
   5 files changed, 29 insertions(+), 4 deletions(-)
 - v8.1.0682: text properties not adjusted when backspacing replaced text
   5 files changed, 98 insertions(+), 21 deletions(-)
 - v8.1.0684: warnings from 64-bit compiler
   3 files changed, 10 insertions(+), 8 deletions(-)
 - v8.1.0688: text properties are not restored by undo
   5 files changed, 137 insertions(+), 73 deletions(-)
 - v8.1.0689: undo with text properties not tested
   2 files changed, 55 insertions(+)
 - v8.1.0690: setline() and setbufline() do not clear text properties
   3 files changed, 35 insertions(+), 2 deletions(-)
 - v8.1.0691: text properties are not adjusted for :substitute
   5 files changed, 182 insertions(+), 18 deletions(-)
 - v8.1.0694: when using text props may free memory that is not allocated
   2 files changed, 12 insertions(+), 3 deletions(-)
 - v8.1.0695: internal error when using :popup
   6 files changed, 32 insertions(+), 5 deletions(-)
 - v8.1.0703: compiler warnings with 64-bit compiler
   3 files changed, 9 insertions(+), 6 deletions(-)
 - v8.1.0707: text property columns are not adjusted for changed indent
   3 files changed, 47 insertions(+), 6 deletions(-)
 - v8.1.0710: when using timers may wait for job exit quite long
   3 files changed, 67 insertions(+), 8 deletions(-)
 - v8.1.0711: test files still use function!
   35 files changed, 456 insertions(+), 430 deletions(-)
 - v8.1.0735: cannot handle binary data
   27 files changed, 1354 insertions(+), 114 deletions(-)
 - v8.1.0736: code for Blob not sufficiently tested
   10 files changed, 155 insertions(+), 38 deletions(-)
 - v8.1.0737: compiler warning for uninitialized variable
   2 files changed, 3 insertions(+), 1 deletion(-)
 - v8.1.0738: using freed memory, for loop over blob leaks memory
   2 files changed, 13 insertions(+), 7 deletions(-)
 - v8.1.0741: viminfo with Blob is not tested
   5 files changed, 120 insertions(+), 31 deletions(-)
 - v8.1.0742: not all Blob operations are tested
   4 files changed, 65 insertions(+), 3 deletions(-)
 - v8.1.0743: giving error messages is not flexible
   95 files changed, 1967 insertions(+), 2022 deletions(-)
 - v8.1.0748: using sprintf() instead of semsg()
   2 files changed, 16 insertions(+), 17 deletions(-)
 - v8.1.0753: printf format not checked for semsg()
   16 files changed, 55 insertions(+), 31 deletions(-)
 - v8.1.0755: error message for get() on a Blob with invalid index
   3 files changed, 21 insertions(+), 3 deletions(-)
 - v8.1.0756: copy() does not make a copy of a Blob
   3 files changed, 24 insertions(+), 1 deletion(-)
 - v8.1.0757: not enough documentation for Blobs
   2 files changed, 140 insertions(+), 15 deletions(-)
 - v8.1.0761: default value for brief_wait is wrong
   2 files changed, 3 insertions(+), 1 deletion(-)
 - v8.1.0765: string format of a Blob can't be parsed back
   4 files changed, 32 insertions(+), 24 deletions(-)
 - v8.1.0768: updating completions may cause the popup menu to flicker
   5 files changed, 65 insertions(+), 13 deletions(-)
 - v8.1.0770: inconsistent use of ELAPSED_FUNC
   6 files changed, 26 insertions(+), 26 deletions(-)
 - v8.1.0779: argument for message functions is inconsistent
   56 files changed, 679 insertions(+), 698 deletions(-)
 - v8.1.0793: incorrect error messages for functions that take a Blob
   6 files changed, 38 insertions(+), 19 deletions(-)
 - v8.1.0797: error E898 is used twice
   4 files changed, 5 insertions(+), 3 deletions(-)
 - v8.1.0798: changing a blob while iterating over it works strangely
   5 files changed, 50 insertions(+), 23 deletions(-)
 - v8.1.0802: negative index doesn't work for Blob
   5 files changed, 20 insertions(+), 6 deletions(-)
 - v8.1.0815: dialog for file changed outside of Vim not tested
   6 files changed, 217 insertions(+), 120 deletions(-)
 - v8.1.0820: test for sending large data over channel sometimes fails
   3 files changed, 44 insertions(+), 38 deletions(-)
 - v8.1.0824: SunOS/Solaris has a problem with ttys
   9 files changed, 147 insertions(+), 68 deletions(-)
 - v8.1.0829: when 'hidden' is set session creates extra buffers
   3 files changed, 48 insertions(+), 20 deletions(-)
 - v8.1.0832: confirm() is not tested
   2 files changed, 57 insertions(+)
 - v8.1.0845: having job_status() free the job causes problems
   5 files changed, 109 insertions(+), 31 deletions(-)
 - v8.1.0846: not easy to recognize the system Vim runs on
   7 files changed, 114 insertions(+), 42 deletions(-)
 - v8.1.0857: indent functionality is not separated
   19 files changed, 4746 insertions(+), 4689 deletions(-)
 - v8.1.0863: cannot see what signal caused a job to end
   6 files changed, 65 insertions(+), 3 deletions(-)
 - v8.1.0870: Vim doesn't use the new ConPTY support in Windows 10
   17 files changed, 694 insertions(+), 73 deletions(-)
 - v8.1.0876: completion match not displayed when popup menu is not shown
   2 files changed, 9 insertions(+), 3 deletions(-)
 - v8.1.0878: test for has('bsd') fails on some BSD systems
   2 files changed, 4 insertions(+)
 - v8.1.0879: MS-Windows: temp name encoding can be wrong
   2 files changed, 20 insertions(+)
 - v8.1.0880: MS-Windows: inconsistent selection of winpty/conpty
   12 files changed, 106 insertions(+), 87 deletions(-)
 - v8.1.0884: double check for bsd systems
   2 files changed, 2 insertions(+), 1 deletion(-)
 - v8.1.0890: pty allocation wrong if using file for out channel
   3 files changed, 74 insertions(+), 14 deletions(-)
 - v8.1.0892: failure when closing a window when location list is in use
   7 files changed, 95 insertions(+), 36 deletions(-)
 - v8.1.0894: MS-Windows: resolve() does not return a reparse point
   7 files changed, 286 insertions(+), 6 deletions(-)
 - v8.1.0895: MS-Windows: dealing with temp name encoding not quite right
   2 files changed, 18 insertions(+), 32 deletions(-)
 - v8.1.0897: can modify a:000 when using a reference
   8 files changed, 90 insertions(+), 55 deletions(-)
 - v8.1.0906: using clumsy way to get console window handle
   2 files changed, 3 insertions(+), 16 deletions(-)
 - v8.1.0909: MS-Windows: using ConPTY even though it is not stable
   5 files changed, 32 insertions(+), 11 deletions(-)
 - v8.1.0914: code related to findfile() is spread out
   22 files changed, 2775 insertions(+), 2724 deletions(-)
 - v8.1.0918: MS-Windows: startup messages are not converted
   4 files changed, 104 insertions(+), 61 deletions(-)
 - v8.1.0928: stray log function call
   2 files changed, 2 insertions(+), 1 deletion(-)
 - v8.1.0940: MS-Windows console resizing not handled properly
   5 files changed, 50 insertions(+), 7 deletions(-)
 - v8.1.0941: macros for MS-Windows are inconsistent
   68 files changed, 537 insertions(+), 539 deletions(-)
 - v8.1.0942: options window still checks for the multi_byte feature
   2 files changed, 34 insertions(+), 38 deletions(-)
 - v8.1.0953: a very long file is truncated at 2^31 lines
   2 files changed, 12 insertions(+), 10 deletions(-)
 - v8.1.0969: message written during startup is truncated
   3 files changed, 19 insertions(+)
 - v8.1.0970: text properties test fails when 'encoding' is not utf-8
   3 files changed, 7 insertions(+), 2 deletions(-)
 - v8.1.0977: blob not tested with Ruby
   3 files changed, 13 insertions(+), 1 deletion(-)
 - v8.1.0999: use register one too often and not properly tested
   3 files changed, 90 insertions(+), 5 deletions(-)
 - v8.1.1004: function "luaV_setref()" not covered with tests
   2 files changed, 7 insertions(+)
 - v8.1.1019: Lua: may garbage collect function reference in use
   3 files changed, 83 insertions(+), 64 deletions(-)
 - v8.1.1022: may use NULL pointer when out of memory
   2 files changed, 4 insertions(+)
 - v8.1.1023: may use NULL pointer when indexing a blob
   2 files changed, 6 insertions(+), 1 deletion(-)
 - v8.1.1028: MS-Windows: memory leak when creating terminal fails
   2 files changed, 5 insertions(+)
 - v8.1.1035: prop_remove() second argument is not optional
   4 files changed, 51 insertions(+), 10 deletions(-)
 - v8.1.1038: Arabic support excludes Farsi
   11 files changed, 417 insertions(+), 1027 deletions(-)
 - v8.1.1043: Lua interface does not support Blob
   4 files changed, 264 insertions(+), 26 deletions(-)
 - v8.1.1044: no way to check the reference count of objects
   4 files changed, 182 insertions(+), 2 deletions(-)
 - v8.1.1071: cannot get composing characters from the screen
   6 files changed, 151 insertions(+), 2 deletions(-)
 - v8.1.1076: file for Insert mode is much too big
   24 files changed, 4334 insertions(+), 4181 deletions(-)
 - v8.1.1078: when 'listchars' is set a composing char on a space is wrong
   3 files changed, 48 insertions(+), 19 deletions(-)
 - v8.1.1079: no need for a separate ScreenLinesUtf8() test function
   4 files changed, 5 insertions(+), 22 deletions(-)
 - v8.1.1083: MS-Windows: hang when opening a file on network share
   2 files changed, 15 insertions(+), 235 deletions(-)
 - v8.1.1085: compiler warning for possibly uninitialized variable
   2 files changed, 17 insertions(+), 10 deletions(-)
 - v8.1.1090: MS-Windows: modify_fname() has problems with some 'encoding'
   2 files changed, 18 insertions(+), 10 deletions(-)
 - v8.1.1103: MS-Windows: old API calls are no longer needed
   8 files changed, 701 insertions(+), 1545 deletions(-)
 - v8.1.1106: no test for 'writedelay'
   2 files changed, 22 insertions(+)
 - v8.1.1110: composing chars on space wrong when 'listchars' is set
   3 files changed, 63 insertions(+), 30 deletions(-)
 - v8.1.1116: cannot enforce a Vim script style
   14 files changed, 177 insertions(+), 32 deletions(-)
 - v8.1.1133: compiler warning for uninitialized struct member
   2 files changed, 3 insertions(+), 1 deletion(-)
 - v8.1.1136: decoding of mouse click escape sequence is not tested
   5 files changed, 56 insertions(+), 2 deletions(-)
 - v8.1.1184: undo file left behind after running test
   2 files changed, 3 insertions(+)
 - v8.1.1188: not all Vim variables require the v: prefix
   5 files changed, 36 insertions(+), 10 deletions(-)
 - v8.1.1190: has('vimscript-3') does not work
   3 files changed, 6 insertions(+)
 - v8.1.1195: Vim script debugger functionality needs cleanup
   17 files changed, 1063 insertions(+), 1001 deletions(-)
 - v8.1.1200: old style comments in debugger source
   3 files changed, 83 insertions(+), 85 deletions(-)
 - v8.1.1210: support for user commands is spread out
   29 files changed, 1778 insertions(+), 1738 deletions(-)
 - v8.1.1218: cannot set a directory for a tab page
   20 files changed, 441 insertions(+), 66 deletions(-)
 - v8.1.1224: MS-Windows: cannot specify font weight
   6 files changed, 172 insertions(+), 134 deletions(-)
 - v8.1.1226: {not in Vi} remarks get in the way of useful help text
   3 files changed, 118 insertions(+), 404 deletions(-)
 - v8.1.1259: crash when exiting early
   5 files changed, 44 insertions(+), 26 deletions(-)
 - v8.1.1265: when GPM mouse support is enabled double clicks do not work
   4 files changed, 35 insertions(+), 19 deletions(-)
 - v8.1.1267: cannot check if GPM mouse support is working
   5 files changed, 19 insertions(+), 2 deletions(-)
 - v8.1.1274: after :unmenu can still execute the menu with :emenu
   3 files changed, 20 insertions(+), 2 deletions(-)
 - v8.1.1276: cannot combine text properties with syntax highlighting
   6 files changed, 49 insertions(+), 14 deletions(-)
 - v8.1.1278: missing change for "combine" field
   2 files changed, 13 insertions(+)
 - v8.1.1280: remarks about functionality not in Vi clutters the help
   64 files changed, 757 insertions(+), 753 deletions(-)
 - v8.1.1291: not easy to change directory and restore
   9 files changed, 220 insertions(+), 81 deletions(-)
 - v8.1.1320: it is not possible to track changes to a buffer
   4 files changed, 151 insertions(+)
 - v8.1.1321: no docs or tests for listener functions
   9 files changed, 165 insertions(+), 19 deletions(-)
 - v8.1.1326: no test for listener with partial
   3 files changed, 57 insertions(+), 31 deletions(-)
 - v8.1.1328: no test for listener with undo operation
   2 files changed, 11 insertions(+)
 - v8.1.1329: plans for popup window support are spread out
   4 files changed, 279 insertions(+)
 - v8.1.1332: cannot flush listeners without redrawing, mix of changes
   7 files changed, 250 insertions(+), 43 deletions(-)
 - v8.1.1333: text properties don't always move after changes
   6 files changed, 92 insertions(+), 21 deletions(-)
 - v8.1.1335: listener callback is called after inserting text
   6 files changed, 126 insertions(+), 46 deletions(-)
 - v8.1.1336: some eval functionality is not covered by tests
   9 files changed, 62 insertions(+), 7 deletions(-)
 - v8.1.1337: get empty text prop when splitting line just after text prop
   3 files changed, 8 insertions(+), 5 deletions(-)
 - v8.1.1340: attributes from 'cursorline' overwrite textprop
   5 files changed, 10 insertions(+), 7 deletions(-)
 - v8.1.1341: text properties are lost when joining lines
   6 files changed, 168 insertions(+), 11 deletions(-)
 - v8.1.1343: text properties not adjusted for Visual block mode delete
   7 files changed, 109 insertions(+), 10 deletions(-)
 - v8.1.1344: Coverity complains about possibly using a NULL pointer
   3 files changed, 14 insertions(+), 7 deletions(-)
 - v8.1.1351: text property wrong after :substitute
   9 files changed, 45 insertions(+), 11 deletions(-)
 - v8.1.1355: obvious mistakes are accepted as valid expressions
   13 files changed, 86 insertions(+), 28 deletions(-)
 - v8.1.1359: text property wrong after :substitute with backslash
   10 files changed, 72 insertions(+), 17 deletions(-)
 - v8.1.1364: design for popup window support needs more details
   2 files changed, 153 insertions(+), 56 deletions(-)
 - v8.1.1376: warnings for size_t/int mixups
   3 files changed, 7 insertions(+), 5 deletions(-)
```