### PR TITLE
lsp: Fix range end offset off by one character

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1595,6 +1595,12 @@ function M.make_given_range_params(start_pos, end_pos)
   if B[2] > 0 then
     B = {B[1], M.character_offset(0, B[1], B[2])}
   end
+  -- we need to offset the end character position otherwise we loose the last
+  -- character of the selection, as LSP end position is exclusive
+  -- see https://microsoft.github.io/language-server-protocol/specification#range
+  if vim.o.selection ~= 'exclusive' then
+    B[2] = B[2] + 1
+  end
   return {
     textDocument = M.make_text_document_params(),
     range = {


### PR DESCRIPTION
fix #14547 fix #13544

Credit to @kristijanhusak who actually [came up with this fix](https://github.com/neovim/neovim/issues/13544), cc @mjlbach.

## Description of the fixed issue

The last character of the buffer selection was omitted from the range returned by `make_given_range_params()`, which is undesirable because the end position is exclusive in the LSP specification:

> A range in a text document expressed as (zero-based) start and end positions. A range is comparable to a selection in an editor. Therefore the end position is exclusive.
> https://microsoft.github.io/language-server-protocol/specification#range

These two screencasts exhibit the faulty behavior:

* I created a simple code action command on my LSP server which prints the range offsets and the extracted text. Note that the last character of the selection is not part of the range. This is especially visible when selecting in backward.
    
    https://user-images.githubusercontent.com/58686775/118176717-121a2580-b432-11eb-8cc0-21643f63fe14.mov

* To give a real world example, [I maintain a Markdown-based LSP server](https://github.com/mickael-menu/zk) which can create a link from the current selection. The server works well with VS Code or coc.nvim, but you can see in this screencast that the link is not created as you would expect:
    
    https://user-images.githubusercontent.com/58686775/118179589-c5d0e480-b435-11eb-8a1d-d82ad29b50f9.mov