### PR TITLE
Update vim_diff.txt and credits

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -169,6 +169,7 @@ Vim would never have become what it is now, without the help of these people!
 	Ken Takata		fixes and features
 	Kazunobu Kuriyama	GTK 3
 	Christian Brabandt	many fixes, features, user support, etc.
+	Yegappan Lakshmanan	many quickfix features
 
 I wish to thank all the people that sent me bug reports and suggestions.  The
 list is too long to mention them all here.  Vim would not be the same without

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -194,8 +194,7 @@ Options:
   'cpoptions'   flags: |cpo-_|
   'display'     flags: "msgsep" minimizes scrolling when showing messages
   'guicursor'   works in the terminal
-  'fillchars'   flags: "msgsep" (see 'display'), "foldopen", "foldsep",
-                "foldclose"
+  'fillchars'   flags: "msgsep" (see 'display')
   'foldcolumn'  supports up to 9 dynamic/fixed columns
   'inccommand'  shows interactive results for |:substitute|-like commands
   'pumblend'    pseudo-transparent popupmenu


### PR DESCRIPTION

Patch 8.2.2524 added the support for the fields 'foldopen', 'foldclose'
and 'foldsep' to the 'fillchars' option in Vim:

http://ftp.vim.org/pub/vim/patches/8.2/8.2.2524

Update the credits in intro.txt based on Vim credits.
