### PR TITLE
fix(lsp): take splits into account for `vim.lsp.util.make_floating_popup_opts`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -881,7 +881,8 @@ function M.make_floating_popup_options(width, height, opts)
   local anchor = ''
   local row, col
 
-  local lines_above = vim.fn.winline() - 1
+  local win_pos = vim.api.nvim_win_get_position(0)
+  local lines_above = win_pos[1] + vim.fn.winline() - 1
   local lines_below = vim.fn.winheight(0) - lines_above
 
   if lines_above < lines_below then
@@ -894,7 +895,7 @@ function M.make_floating_popup_options(width, height, opts)
     row = -get_border_size(opts).height
   end
 
-  if vim.fn.wincol() + width <= api.nvim_get_option('columns') then
+  if win_pos[2] + vim.fn.wincol() + width <= api.nvim_get_option('columns') then
     anchor = anchor..'W'
     col = 0
   else

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -883,7 +883,7 @@ function M.make_floating_popup_options(width, height, opts)
 
   local win_pos = vim.api.nvim_win_get_position(0)
   local lines_above = win_pos[1] + vim.fn.winline() - 1
-  local lines_below = vim.fn.winheight(0) - lines_above
+  local lines_below = api.nvim_get_option('lines') - lines_above
 
   if lines_above < lines_below then
     anchor = anchor..'N'


### PR DESCRIPTION
`vim.lsp.util.make_floating_popup_options` would give the incorrect anchor as splits were not taken into account in the calculation. This will make sure the exact cursor position w.r.t to the editor is taken.

This is a single vertical split where the cursor is on the right window and in the previous version, the anchor would be in the west direction even though that would result in shifting the window as it would reach the right edge.

https://user-images.githubusercontent.com/67177269/118445376-fc478180-b70b-11eb-96ea-0659dfed0ced.mov

New version will make sure to take splits into account and get the correct anchor:

https://user-images.githubusercontent.com/67177269/118445394-010c3580-b70c-11eb-9131-75fa27bd7c1c.mov


