### PR TITLE
fix(bufupdate): send events when inserting with virtualedit

### DIFF
--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -14,6 +14,7 @@
 #include "nvim/misc1.h"
 #include "nvim/move.h"
 #include "nvim/screen.h"
+#include "nvim/extmark.h"
 #include "nvim/state.h"
 #include "nvim/vim.h"
 #include "nvim/ascii.h"
@@ -181,7 +182,7 @@ static int coladvance2(
         memset(newline + idx, ' ', (size_t)correct);
 
         ml_replace(pos->lnum, newline, false);
-        changed_bytes(pos->lnum, (colnr_T)idx);
+        inserted_bytes(pos->lnum, (colnr_T)idx, 0, correct);
         idx += correct;
         col = wcol;
       } else {
@@ -206,7 +207,7 @@ static int coladvance2(
         memcpy(newline + idx + csize, line + idx + 1, n);
 
         ml_replace(pos->lnum, newline, false);
-        changed_bytes(pos->lnum, idx);
+        inserted_bytes(pos->lnum, idx, 1, csize);
         idx += (csize - 1 + correct);
         col += correct;
       }

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -936,6 +936,26 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("virtual edit", function ()
+      local check_events = setup_eventcheck(verify, { "", "	" })
+
+      meths.set_option("virtualedit", "all")
+
+      feed [[<Right><Right>iab<ESC>]]
+
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 0, 0, 0, 0, 2, 2 };
+        { "test1", "bytes", 1, 4, 0, 2, 2, 0, 0, 0, 0, 2, 2 };
+      }
+
+      feed [[j<Right><Right>iab<ESC>]]
+
+      check_events {
+        { "test1", "bytes", 1, 5, 1, 0, 5, 0, 1, 1, 0, 8, 8 };
+        { "test1", "bytes", 1, 6, 1, 5, 10, 0, 0, 0, 0, 2, 2 };
+      }
+    end)
+
     it("block visual paste", function()
       local check_events = setup_eventcheck(verify, {"AAA",
                                                      "BBB",


### PR DESCRIPTION
Problem first raised [here](https://github.com/nvim-treesitter/nvim-treesitter/issues/1304).

I am not sure if I don't go too deep in the fix for this, maybe
@bfredl has an opinion about that.

cc @TornaxO7
