### PR TITLE
[RDY] Allow nil in list when decoding lsp responses

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -50,8 +50,13 @@ recursive_convert_NIL = function(v, tbl_processed)
     return nil
   elseif not tbl_processed[v] and type(v) == 'table' then
     tbl_processed[v] = true
+    local inside_list = vim.tbl_islist(v)
     return vim.tbl_map(function(x)
-      return recursive_convert_NIL(x, tbl_processed)
+      if not inside_list or (inside_list and type(x) == "table") then
+        return recursive_convert_NIL(x, tbl_processed)
+      else
+        return x
+      end
     end, v)
   end
 

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -464,6 +464,23 @@ function tests.invalid_header()
   io.stdout:write("Content-length: \r\n")
 end
 
+function tests.decode_nil()
+  skeleton {
+    on_init = function(_)
+      return { capabilities = {} }
+    end;
+    body = function()
+      notify('start')
+      notify("workspace/executeCommand", {
+        arguments = { "EXTRACT_METHOD", {metadata = {field = vim.NIL}}, 3, 0, 6123, vim.NIL },
+        command = "refactor.perform",
+        title = "EXTRACT_METHOD"
+      })
+      notify('finish')
+    end;
+  }
+end
+
 -- Tests will be indexed by TEST_NAME
 
 local kill_timer = vim.loop.new_timer()


### PR DESCRIPTION
This PR is based on the discussion in #13829, where `nil` is being dropped whilst decoding the lsp server responses (and requests?). It simply uses `vim.tbl_islist` as suggested there. One question I still have is if we have to check that the list doesn't contain any tables that might need to have nil values converted. I'm not very familiar with the lsp implementation here so not sure if that's necessary.

It does however resolve the issue in #14564 and so will hopefully also fix #13829

@mjlbach was this what you had in mind regarding a fix for #13829

#### Todo
- [x] Check that this hasn't broken anything...