### PR TITLE
fix(health/python3): remove obsolete check

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -423,10 +423,6 @@ function! s:check_python(version) abort
                   \ ' This could lead to confusing error messages.')
     endif
 
-    if a:version == 3 && str2float(pyversion) < 3.3
-      call health#report_warn('Python 3.3+ is recommended.')
-    endif
-
     call health#report_info('Python version: ' . pyversion)
 
     if s:is_bad_response(status)


### PR DESCRIPTION
Python 3.3 reached its end-of-life `2017-09-29`:

  https://www.python.org/dev/peps/pep-0398

Closes https://github.com/neovim/neovim/issues/14586