### PR TITLE
Fixed ttimeout documentation.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6429,7 +6429,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
 
 	On very slow systems this may fail, causing cursor keys not to work
-	sometimes.  If you discover this problem you can ":set ttimeout=9999".
+	sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
 	Nvim will wait for the next character to arrive after an <Esc>.
 
 						*'timeoutlen'* *'tm'*


### PR DESCRIPTION
ttimeout is a boolean. The correct command for this line is ":set ttimeoutlen=9999"