### PR TITLE
fix(lsp): allow apply_text_edits to append text (insert at last line)

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -73,7 +73,7 @@ function M.set_lines(lines, A, B, new_lines)
   -- way the LSP describes the range including the last newline is by
   -- specifying a line number after what we would call the last line.
   local i_n = math.min(B[1] + 1, #lines)
-  if not (i_0 >= 1 and i_0 <= #lines and i_n >= 1 and i_n <= #lines) then
+  if not (i_0 >= 1 and i_0 <= #lines + 1 and i_n >= 1 and i_n <= #lines) then
     error("Invalid range: "..vim.inspect{A = A; B = B; #lines, new_lines})
   end
   local prefix = ""


### PR DESCRIPTION
Fixes #14017

When formatting a buffer using lsp, text edits that insert text after the last line fails.

Below is an example of `stylua` with `efm`.

```lua
 local a = 13

```
the formatting of the code example above is not preserved with github markdown, so check the source to see the exact code causing this issue.

Efm will create two text edits:

1. replace all lines with the empty string
2. add the new formatted text at the end

`lsp.util. apply_text_edits` applies the text edits in reverse order, so the new text is added first and then the first two lines are cleared. 

![image](https://user-images.githubusercontent.com/292349/119096700-bff47980-b9c8-11eb-92c4-c9b3505bdea4.png)

The issue is the check for the text edit in `lsp.util.set_lines`.
There it is expected that the start region is one of the existing lines, but for text edits that insert text after the existing lines, this should also work.

The fix was to simply check that the start region A should be either one of the existing lines, or the line after the last line.