### PR TITLE
feat(lsp): use same formatting for `signature_help` as `hover`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -951,7 +951,7 @@ end
 ---
 --@param location a single `Location` or `LocationLink`
 --@returns (bufnr,winnr) buffer and window number of floating window or nil
-function M.preview_location(location)
+function M.preview_location(location, opts)
   -- location may be LocationLink or Location (more useful for the former)
   local uri = location.targetUri or location.uri
   if uri == nil then return end
@@ -962,7 +962,13 @@ function M.preview_location(location)
   local range = location.targetRange or location.range
   local contents = api.nvim_buf_get_lines(bufnr, range.start.line, range["end"].line+1, false)
   local syntax = api.nvim_buf_get_option(bufnr, 'syntax')
-  return M.open_floating_preview(contents, syntax)
+  if syntax == "" then
+    -- When no syntax is set, we use filetype as fallback. This might not result
+    -- in a valid syntax definition. See also ft detection in fancy_floating_win.
+    -- An empty syntax is more common now with TreeSitter, since TS disables syntax.
+    syntax = api.nvim_buf_get_option(bufnr, 'filetype')
+  end
+  return M.open_floating_preview(contents, syntax, opts)
 end
 
 --@private

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -804,9 +804,10 @@ end
 --- Converts `textDocument/SignatureHelp` response to markdown lines.
 ---
 --@param signature_help Response of `textDocument/SignatureHelp`
+--@param ft optional filetype that will be use as the `lang` for the label markdown code block
 --@returns list of lines of converted markdown.
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
-function M.convert_signature_help_to_markdown_lines(signature_help)
+function M.convert_signature_help_to_markdown_lines(signature_help, ft)
   if not signature_help.signatures then
     return
   end
@@ -824,7 +825,12 @@ function M.convert_signature_help_to_markdown_lines(signature_help)
   if not signature then
     return
   end
-  vim.list_extend(contents, vim.split(signature.label, '\n', true))
+  local label = signature.label
+  if ft then
+    -- wrap inside a code block so fancy_markdown can render it properly
+    label = ("```%s\n%s\n```"):format(ft, label)
+  end
+  vim.list_extend(contents, vim.split(label, '\n', true))
   if signature.documentation then
     M.convert_input_to_markdown_lines(signature.documentation, contents)
   end


### PR DESCRIPTION
Right now, `signature_help` renders the documentation differently than `hover`.
This PR fixes that. What's included:

* use `fancy_floating_markdown` for `signature_help`
* format the signature label with the `filetype` of the buffer
* small fix to my other PR #14596: changes the hl group for a code block without `lang` from `markdownCodeBlock` to `markdownCode` (I checked in a regular markdown file, and that is the correct one)
* `preview_location`: fall-back to `filetype` if `syntax` is not set (needed for buffers with TreeSitter highlighting enabled, since TreeSitter disables syntax)
* while debugging another issue, I found the root cause for #14596 why regions sometimes didn't get the correct syntax applied. Resetting `b:current_syntax` is needed to load multiple syntax files in  the same buffer. Some syntax files don't do anything if another syntax file already had this set. Because of this change, some of the code I added in the previous PR could be removed again. It also fixes another border case where markdown wasn't properly rendered. Sorry I didn't catch this sooner!
* allow passing popup options to `preview_location` as requested by @clason

Signature help improvements:

Before:
![image](https://user-images.githubusercontent.com/292349/119107791-6c882880-b9d4-11eb-911c-5d24e57a5960.png)

After:
![image](https://user-images.githubusercontent.com/292349/119129662-0effd600-b9ec-11eb-8ac2-30039760063d.png)

Python:

Before:
![image](https://user-images.githubusercontent.com/292349/119129800-4078a180-b9ec-11eb-8ecb-49c7256bfdd7.png)

After:
![image](https://user-images.githubusercontent.com/292349/119129767-35be0c80-b9ec-11eb-9a1b-d98fbca20ddc.png)
