### PR TITLE
[RDY] Generate PARAM_COUNT macro

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7700,7 +7700,7 @@ Dictionary get_vimoption(String name, Error *err)
 Dictionary get_all_vimoptions(void)
 {
   Dictionary retval = ARRAY_DICT_INIT;
-  for (size_t i = 0; i < PARAM_COUNT; i++) {
+  for (size_t i = 0; options[i].fullname != NULL; i++) {
     Dictionary opt_dict = vimoption2dict(&options[i]);
     PUT(retval, options[i].fullname, DICTIONARY_OBJ(opt_dict));
   }

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1986,6 +1986,10 @@ describe('API', function()
 
       eq(meths.get_option_info'winhighlight', options_info.winhighlight)
     end)
+
+    it('should not crash when echoed', function()
+      meths.exec("echo nvim_get_all_options_info()", true)
+    end)
   end)
 
   describe('nvim_get_option_info', function()


### PR DESCRIPTION
This PR fixes a bug where running `:echo nvim_get_all_options_info()` would crash.
