### PR TITLE
lsp: use `detail` in qf-list for call hierarchies

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -372,7 +372,7 @@ local make_call_hierarchy_handler = function(direction)
       for _, range in pairs(call_hierarchy_call.fromRanges) do
         table.insert(items, {
           filename = assert(vim.uri_to_fname(call_hierarchy_item.uri)),
-          text = call_hierarchy_item.name,
+          text = call_hierarchy_item.detail or call_hierarchy_item.name,
           lnum = range.start.line + 1,
           col = range.start.character + 1,
         })


### PR DESCRIPTION
`detail` will contain more information about the function, typically its
signature, which is more useful than only its name.