### PR TITLE
Refactor `diff.c` and add diff parsing unit tests

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1088,24 +1088,16 @@ static int diff_file_internal(diffio_T *diffio)
   return OK;
 }
 
-/// Make a diff between files "tmp_orig" and "tmp_new", results in "tmp_diff".
-///
-/// @param dio
-///
-/// @return OK or FAIL
-static int diff_file(diffio_T *dio)
+static void diff_file_external(diffio_T *dio)
 {
   char *tmp_orig = (char *)dio->dio_orig.din_fname;
   char *tmp_new = (char *)dio->dio_new.din_fname;
   char *tmp_diff = (char *)dio->dio_diff.dout_fname;
+
   if (*p_dex != NUL) {
     // Use 'diffexpr' to generate the diff file.
     eval_diff(tmp_orig, tmp_new, tmp_diff);
-    return OK;
-  }
-  // Use xdiff for generating the diff.
-  if (dio->dio_internal) {
-    return diff_file_internal(dio);
+    return;
   } else {
     const size_t len = (strlen(tmp_orig) + strlen(tmp_new) + strlen(tmp_diff)
                         + STRLEN(p_srr) + 27);
@@ -1135,7 +1127,22 @@ static int diff_file(diffio_T *dio)
                      NULL);
     unblock_autocmds();
     xfree(cmd);
+  }
+}
+
+/// Make a diff between files "tmp_orig" and "tmp_new", results in "tmp_diff".
+///
+/// @param dio
+///
+/// @return OK or FAIL
+static int diff_file(diffio_T *dio)
+{
+  if (*p_dex != NUL || !dio->dio_internal) {
+    diff_file_external(dio);
     return OK;
+  } else {
+    // Use xdiff for generating the diff.
+    return diff_file_internal(dio);
   }
 }
 

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -709,7 +709,7 @@ static void clear_diffout(diffout_T *dout)
 /// @param din
 ///
 /// @return FAIL for failure.
-static int diff_write_buffer(buf_T *buf, diffin_T *din)
+static int diff_write_buffer(buf_T *buf, mmfile_t *din_mmfile)
 {
   linenr_T lnum;
   char_u *s;
@@ -734,8 +734,8 @@ static int diff_write_buffer(buf_T *buf, diffin_T *din)
     }
     return FAIL;
   }
-  din->din_mmfile.ptr = (char *)ptr;
-  din->din_mmfile.size = len;
+  din_mmfile->ptr = (char *)ptr;
+  din_mmfile->size = len;
 
   len = 0;
   for (lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
@@ -776,7 +776,7 @@ static int diff_write_buffer(buf_T *buf, diffin_T *din)
 static int diff_write(buf_T *buf, diffin_T *din)
 {
   if (din->din_fname == NULL) {
-    return diff_write_buffer(buf, din);
+    return diff_write_buffer(buf, &din->din_mmfile);
   }
 
   // Always use 'fileformat' set to "unix".

--- a/src/nvim/diff.h
+++ b/src/nvim/diff.h
@@ -11,6 +11,23 @@ EXTERN bool diff_need_scrollbind INIT(= false);
 
 EXTERN bool need_diff_redraw INIT(= false);  // need to call diff_redraw()
 
+// used for diff result
+typedef struct {
+    char_u   *dout_fname;  // used for external diff
+    garray_T  dout_ga;     // used for internal diff
+} diffout_T;
+
+// Diff2Hunk represents a forward linked list of diff hunks as defined by
+// unified or ed-style diff formats.
+typedef struct diff2_hunk Diff2Hunk;
+struct diff2_hunk {
+  Diff2Hunk  *next;
+  linenr_T       lstart_orig;
+  linenr_T       count_orig;
+  long           lstart_dest;
+  long           count_dest;
+};
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "diff.h.generated.h"
 #endif

--- a/test/unit/diff_spec.lua
+++ b/test/unit/diff_spec.lua
@@ -1,0 +1,97 @@
+local ffi = require('ffi')
+local io = require('io')
+local lfs = require('lfs')
+local helpers = require('test.unit.helpers')(after_each)
+local itp = helpers.gen_itp(it)
+
+local cimport = helpers.cimport
+local eq      = helpers.eq
+local to_cstr = helpers.to_cstr
+
+local diff = cimport('./src/nvim/diff.h')
+
+local function new_Diff2Hunk(lstart_orig, count_orig, lstart_dest, count_dest)
+  local hunk = ffi.new('Diff2Hunk')
+  hunk.lstart_orig = lstart_orig
+  hunk.count_orig = count_orig
+  hunk.lstart_dest = lstart_dest
+  hunk.count_dest = count_dest
+  return hunk
+end
+
+local function eq_Diff2Hunk(hunkl, hunkr)
+  eq(hunkl.lstart_orig, hunkr.lstart_orig)
+  eq(hunkl.count_orig, hunkr.count_orig)
+  eq(hunkl.lstart_dest, hunkr.lstart_dest)
+  eq(hunkl.count_dest, hunkr.count_dest)
+end
+
+describe('diff.c', function()
+  local unit_test_directory_name = 'unit-test-directory'
+  before_each(function()
+    lfs.mkdir(unit_test_directory_name);
+  end)
+
+  after_each(function()
+    lfs.rmdir(unit_test_directory_name)
+  end)
+
+  describe('diff_parse', function()
+    itp('parses an external ed-style diff', function()
+      local diff_file_name = unit_test_directory_name .. '/' .. 'ext-ed.diff'
+      local diff_file = io.open(diff_file_name, 'w')
+      diff_file:write('0a1\n')
+      diff_file:write('> 1r\n')
+      diff_file:write('1d1\n')
+      diff_file:write('< 1l\n')
+      diff_file:write('2,3c2,3\n')
+      diff_file:write('< 2l\n')
+      diff_file:write('< 3l\n')
+      diff_file:write('> 2r\n')
+      diff_file:write('> 3r\n')
+      io.close(diff_file)
+
+      local input = ffi.new('diffout_T')
+      input.dout_fname = to_cstr(diff_file_name)
+      local output = ffi.new('Diff2Hunk*[1]')
+      local result = diff.diff_parse(input, output)
+      eq(true, result)
+      eq(3, diff.diff2_hunk_list_length(output[0]))
+      eq_Diff2Hunk(new_Diff2Hunk(1, 0, 1, 1), output[0])
+      eq_Diff2Hunk(new_Diff2Hunk(1, 1, 2, 0), output[0].next)
+      eq_Diff2Hunk(new_Diff2Hunk(2, 2, 2, 2), output[0].next.next)
+
+      diff.diff2_hunk_list_dealloc(output[0])
+      os.remove(diff_file_name)
+    end)
+
+    itp('parses an external unified-style diff', function()
+      local diff_file_name = unit_test_directory_name .. '/' .. 'ext-unif.diff'
+      local diff_file = io.open(diff_file_name, 'w')
+      diff_file:write('--- a	2021-05-16 11:51:41.739056110 +0200\n')
+      diff_file:write('+++ b	2021-05-16 11:51:44.372400145 +0200\n')
+      diff_file:write('@@ -1 +1 @@\n')
+      diff_file:write('-a\n')
+      diff_file:write('+b\n')
+      io.close(diff_file)
+
+      local input = ffi.new('diffout_T')
+      input.dout_fname = to_cstr(diff_file_name)
+      local output = ffi.new('Diff2Hunk*[1]')
+      local result = diff.diff_parse(input, output)
+      eq(true, result)
+      eq(1, diff.diff2_hunk_list_length(output[0]))
+      eq_Diff2Hunk(new_Diff2Hunk(1, 1, 1, 1), output[0])
+
+      diff.diff2_hunk_list_dealloc(output[0])
+      os.remove(diff_file_name)
+    end)
+    itp('returns false when it can\'t read the file', function()
+      local input = ffi.new('diffout_T')
+      input.dout_fname = to_cstr('does_not_exist')
+      local output = ffi.new('Diff2Hunk*[1]')
+      local result = diff.diff_parse(input, output)
+      eq(false, result)
+    end)
+  end)
+end)


### PR DESCRIPTION
I have refactored `diff.c` in preparation for tackling (or helping tackle) https://github.com/neovim/neovim/issues/14521 and https://github.com/neovim/neovim/issues/14522.

I believe the refactoring changes I propose are beneficial on their own, and I tried my best to follow develop guidelines at [the wiki](https://github.com/neovim/neovim/wiki).