### PR TITLE
feat(lsp): use `g:markdown_fenced_languages` in `vim.lsp.util.stylized_markdown`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1056,6 +1056,20 @@ function M._trim(contents, opts)
   return contents
 end
 
+-- Generates a table mapping markdown code block lang to vim syntax,
+-- based on g:markdown_fenced_languages
+-- @return a table of lang -> syntax mappings
+local function get_markdown_fences()
+  local fences = {}
+  for _, fence in pairs(vim.g.markdown_fenced_languages or {}) do
+    local lang, syntax = fence:match("^(.*)=(.*)$")
+    if lang then
+      fences[lang] = syntax
+    end
+  end
+  return fences
+end
+
 --- Converts markdown into syntax highlighted regions by stripping the code
 --- blocks and converting them into highlighted code.
 --- This will by default insert a blank line separator after those code block
@@ -1187,11 +1201,13 @@ function M.stylize_markdown(bufnr, contents, opts)
   -- keep track of syntaxes we already inlcuded.
   -- no need to include the same syntax more than once
   local langs = {}
+  local fences = get_markdown_fences()
   local function apply_syntax_to_region(ft, start, finish)
     if ft == "" then
       vim.cmd(string.format("syntax region markdownCode start=+\\%%%dl+ end=+\\%%%dl+ keepend extend", start, finish + 1))
       return
     end
+    ft = fences[ft] or ft
     local name = ft..idx
     idx = idx + 1
     local lang = "@"..ft:upper()


### PR DESCRIPTION
Markdown text coming from `hover` or `signature_help` or other sources, that contains code blocks are processed in `fancy_floating_markdown` and replaced by syntax regions.

Currently the code block `lang` is used as the `syntax`, but this is not always correct.

Vim already has support for mapping code block langs to syntaxes with `g:markdown_fenced_languages`.

This PR simply uses that variable to provide better mappings from langs to syntax. (fixes #14616)

Without this PR:
![image](https://user-images.githubusercontent.com/292349/119229489-2c58a100-bacd-11eb-9bfb-42c1d0bd321d.png)

With this PR:
![image](https://user-images.githubusercontent.com/292349/119229505-3aa6bd00-bacd-11eb-8de0-bd2122cef81a.png)

Example config:

```lua
-- Use proper syntax highlighting in code blocks
local fences = {
  "lua",
  "vim",
  "json",
  "typescript",
  "javascript",
  "js=javascript",
  "ts=typescript",
  "shell=sh",
  "python",
  "sh",
  "bash=sh",
  "console=sh",
}
vim.g.markdown_fenced_languages = fences
```