### PR TITLE
LSP: Added no_wait option.

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -856,6 +856,8 @@ start_client({config})                                *vim.lsp.start_client()*
                                        |vim.lsp.start_client()|. You can use
                                        this to modify parameters before they
                                        are sent.
+                    {no_wait}          (boolean) Do not wait the language
+                                       server to exit before closing NeoVim.
                     {on_init}          Callback (client, initialize_result)
                                        invoked after LSP "initialize", where
                                        `result` is a table of `capabilities`


### PR DESCRIPTION
On the issue #12478 they are discussing some methods to fix slow closing when using nvim-lsp, so I've decided to implement two new options to let the user choose which closing method they want to use for a specific LSP client. The two methods are:

```
no_wait: (boolean) Do not wait the language server to exit before closing NeoVim.
force_exit: (boolean) Kill the language server instead of waiting them to close.
```

I don't know if this the best way to solve this, but is the most user-friendly way that I can think. 