### PR TITLE
fix(lsp): restore marks after `apply_text_edits`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -41,6 +41,9 @@ ADDED FEATURES                                                     *news-added*
 
 The following new APIs or features were added.
 
+• Neovim's LSP client now always saves and restores named buffer marks when
+  applying text edits.
+
 • Nvim's LSP client now advertises the general.positionEncodings client
   capability to indicate to servers that it supports utf-8, utf-16, and utf-32
   encodings. If the server responds with the positionEncoding capability in

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1679,6 +1679,54 @@ describe('LSP', function()
         'foobar';
       }, buf_lines(1))
     end)
+    it('it restores marks', function()
+      local edits = {
+        make_edit(1, 0, 2, 5, "foobar");
+        make_edit(4, 0, 5, 0, "barfoo");
+      }
+      eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 2, 1, {})'))
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
+      eq({
+        'First line of text';
+        'foobar line of text';
+        'Fourth line of text';
+        'barfoo';
+      }, buf_lines(1))
+      local mark = exec_lua('return vim.api.nvim_buf_get_mark(1, "a")')
+      eq({ 2, 1 }, mark)
+    end)
+
+    it('it restores marks to last valid col', function()
+      local edits = {
+        make_edit(1, 0, 2, 15, "foobar");
+        make_edit(4, 0, 5, 0, "barfoo");
+      }
+      eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 2, 10, {})'))
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
+      eq({
+        'First line of text';
+        'foobarext';
+        'Fourth line of text';
+        'barfoo';
+      }, buf_lines(1))
+      local mark = exec_lua('return vim.api.nvim_buf_get_mark(1, "a")')
+      eq({ 2, 9 }, mark)
+    end)
+
+    it('it restores marks to last valid line', function()
+      local edits = {
+        make_edit(1, 0, 4, 5, "foobar");
+        make_edit(4, 0, 5, 0, "barfoo");
+      }
+      eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 4, 1, {})'))
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
+      eq({
+        'First line of text';
+        'foobaro';
+      }, buf_lines(1))
+      local mark = exec_lua('return vim.api.nvim_buf_get_mark(1, "a")')
+      eq({ 2, 1 }, mark)
+    end)
 
     describe('cursor position', function()
       it('don\'t fix the cursor if the range contains the cursor', function()


### PR DESCRIPTION
Right now, whenever any text edits are applied to the buffer, all `marks` part of those lines will be lost.

This is mostly problematic for code formatters that format the whole buffer like `prettier`, `luafmt`, ... (Fixes #14307)

This PR does the following:
* saves marks right before `nvim_buf_set_lines` is called inside `apply_text_edits`
* checks if any marks were lost after doing `nvim_buf_set_lines`
* restores those marks to the previous positions

AFAIK, restoring those marks to their previous position is the best short-term solution.

When doing atomic changes inside a vim doc, vim keeps track of those changes and can update the positions of marks accordingly, but in this case we have a whole doc that changed. There's no simple way to update the positions of all marks from the previous document state to the new document state.  We would need to do a line-based diff in order to track the changes to mark positions. But even then, it's pretty tricky.

## Testing

The easiest way to test this is:
* have a formatter enabled
* open any file
* create a couple of marks
* indent the whole file to the right
* save the file

Without this PR, all marks will be removed.
With this PR, they will be preserved

## Other
Based on a suggestion by @mjlbach, I also tried creating `extmarks` from the `marks` positions right before the text edits to restore them afterwards, but we have similar problems there. All the `extmarks` were moved to the end of the document.

