### PR TITLE
api: Allow nvim_buf_set_text to append after last line

### DIFF
--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -423,6 +423,10 @@ describe('api/buf', function()
       -- will join multiple lines if needed
       set_text(0, 6, 3, 4, {'bar'})
       eq({'hello bar'}, get_lines(0,  1, true))
+
+      -- can append text after last line
+      set_text(2, 0, 2, 0, {'new line'})
+      eq({'hello bar', '', 'new line'}, get_lines(0, -1, true))
     end)
 
     it('works with undo', function()


### PR DESCRIPTION
If you've a buffer with:

    first_line
    second_line

This now allows to use nvim_buf_set_text to insert text after the second
line:

    nvim_buf_set_text(0, 2, 0, 2, 0, {'third line'})

Before this was an error (start_row out of bounds) and it was necessary
to append the text on the last column of the last line:

    nvim_buf_set_text(0, 1, 10, 1, 10, {'', 'third line'})
