### PR TITLE
fix(lsp): Make focusable_{preview,float} focusable

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1323,7 +1323,7 @@ function M.open_floating_preview(contents, syntax, opts)
   api.nvim_buf_set_lines(floating_bufnr, 0, -1, true, contents)
   api.nvim_buf_set_option(floating_bufnr, 'modifiable', false)
   api.nvim_buf_set_option(floating_bufnr, 'bufhidden', 'wipe')
-  M.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "BufLeave"}, floating_winnr)
+  M.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden"}, floating_winnr)
   return floating_bufnr, floating_winnr
 end
 


### PR DESCRIPTION
The preview window created by `focusable_{float,preview}` could be set to
be closed automatically as soon as a list of autocmds fired.
However, the autocommands `WinLeave` and `BufLeave` fire before leaving the
'parent' window, so the preview window would be destroyed right before
it'd get focus, throwing an error instead.

This is just the tiny one-line fix from the spaghetti mess that #12720
has become.