### PR TITLE
lsp: Ensure floating markdown buffers are deleted on hide

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1159,6 +1159,7 @@ function M.fancy_floating_markdown(contents, opts)
   local winnr = api.nvim_open_win(bufnr, false, M.make_floating_popup_options(width, height, opts))
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, stripped)
   api.nvim_buf_set_option(bufnr, 'modifiable', false)
+  api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
 
   -- Switch to the floating window to apply the syntax highlighting.
   -- This is because the syntax command doesn't accept a target.


### PR DESCRIPTION
After the change to use fancy_floating_markdown for the signature help I
noticed that scratch buffers start to accumulate.