### PR TITLE
refactor(lsp): consolidate the different floating window methods into `open_floating_preview`

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1151,6 +1151,7 @@ function M.show_line_diagnostics(opts, bufnr, line_nr, client_id)
     end
   end
 
+  opts.focus_id = "line_diagnostics"
   local popup_bufnr, winnr = util.open_floating_preview(lines, 'plaintext', opts)
   for i, hi in ipairs(highlights) do
     local prefixlen, hiname = unpack(hi)

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -260,22 +260,18 @@ end
 ---         - See |vim.api.nvim_open_win()|
 function M.hover(_, method, result, _, _, config)
   config = config or {}
-  local bufnr, winnr = util.focusable_float(method, function()
-    if not (result and result.contents) then
-      -- return { 'No information available' }
-      return
-    end
-    local markdown_lines = util.convert_input_to_markdown_lines(result.contents)
-    markdown_lines = util.trim_empty_lines(markdown_lines)
-    if vim.tbl_isempty(markdown_lines) then
-      -- return { 'No information available' }
-      return
-    end
-    local bufnr, winnr = util.fancy_floating_markdown(markdown_lines, config)
-    util.close_preview_autocmd({"CursorMoved", "BufHidden", "InsertCharPre"}, winnr)
-    return bufnr, winnr
-  end)
-  return bufnr, winnr
+  config.focus_id = method
+  if not (result and result.contents) then
+    -- return { 'No information available' }
+    return
+  end
+  local markdown_lines = util.convert_input_to_markdown_lines(result.contents)
+  markdown_lines = util.trim_empty_lines(markdown_lines)
+  if vim.tbl_isempty(markdown_lines) then
+    -- return { 'No information available' }
+    return
+  end
+  return util.open_floating_preview(markdown_lines, "markdown", config)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
@@ -333,26 +329,21 @@ M['textDocument/implementation'] = location_handler
 ---         - See |vim.api.nvim_open_win()|
 function M.signature_help(_, method, result, _, bufnr, config)
   config = config or {}
+  config.focus_id = method
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
     print('No signature help available')
     return
   end
-  local p_bufnr, winnr = util.focusable_float(method, function()
-    local ft = api.nvim_buf_get_option(bufnr, 'filetype')
-    local lines = util.convert_signature_help_to_markdown_lines(result, ft)
-    lines = util.trim_empty_lines(lines)
-    if vim.tbl_isempty(lines) then
-      print('No signature help available')
-      return
-    end
-    local p_bufnr, p_winnr = util.fancy_floating_markdown(lines, config)
-    util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "BufHidden", "InsertCharPre"}, p_winnr)
-
-    return p_bufnr, p_winnr
-  end)
-  return p_bufnr, winnr
+  local ft = api.nvim_buf_get_option(bufnr, 'filetype')
+  local lines = util.convert_signature_help_to_markdown_lines(result, ft)
+  lines = util.trim_empty_lines(lines)
+  if vim.tbl_isempty(lines) then
+    print('No signature help available')
+    return
+  end
+  return util.open_floating_preview(lines, "markdown", config)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp

--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -4,7 +4,9 @@
 " URL:		http://neovim.io
 " Remark:	Uses markdown syntax file
 
-runtime! syntax/markdown.vim
+" always source the system included markdown instead of any other installed
+" markdown.vim syntax files
+execute 'source' expand('<sfile>:p:h') .. '/markdown.vim'
 
 syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
 


### PR DESCRIPTION
There were currently multiple ways to open floating windows.

This PR consolidates all the functionality under `open_floating_preview`

* `vim.lsp.util.preview_location` is now also focusable
*  `vim.lsp.diagnostics.show_line_diagnostics` is now also focusable
* added to `open_floating_preview`:
  - `opts.focus_id` to make it focusable
  - `opts.fancy_markdown` defaults to `true`
  - if `syntax == "markdown"` and `opts.fancy_markdown`, then the fancy rendering is used (old `fancy_floating_markdown`)
  - added `q` to close the float when focused
* deprecated methods:
  - `focusable_float`
  - `focusable_preview`
  - `fancy_floating_markdown`
* fixes:
  - `lsp_markdown.vim` always force using the default `markdown.vim` (so not any other installed markdown syntax)
  - for the fancy markdown, it is needed to apply the `lsp_markdown` regions seperately instead of setting it on the buffer. Otherwise, there's situations where the markdown syntax `bleeds` through the other syntax regions.
  - fancy markdown: keep track of syntaxes we already included. no need to include a syntax more than once
  - only apply `close_events` when they're not empty
  - disable folding in the popup (fixes #14627)
  - enable wrapping (fixes #12281)
* utility method `format_fancy_markdown`, that can be used by external plugins to format markdown in given buffers similar to the lsp floating windows. (for integration with compe, saga, ...)

Once the PR is approved, I'll create seperate commits for the different changes

## Where are floating windows used right now?

* `vim.lsp.util.preview_location`
* `vim.lsp.handlers.signature_help`
* `vim.lsp.handlers.hover`
* `vim.lsp.diagnostics.show_line_diagnostics`