### PR TITLE
fix on_detach in lsp.diagnostic

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -317,9 +317,9 @@ function M.save(diagnostics, bufnr, client_id)
 
     -- Clean up our data when the buffer unloads.
     api.nvim_buf_attach(bufnr, false, {
-      on_detach = function()
-        clear_diagnostic_cache(bufnr, client_id)
-        _diagnostic_cleanup[bufnr][client_id] = nil
+      on_detach = function(_, b)
+        clear_diagnostic_cache(b, client_id)
+        _diagnostic_cleanup[b][client_id] = nil
       end
     })
   end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -317,8 +317,8 @@ function M.save(diagnostics, bufnr, client_id)
 
     -- Clean up our data when the buffer unloads.
     api.nvim_buf_attach(bufnr, false, {
-      on_detach = function(b)
-        clear_diagnostic_cache(b, client_id)
+      on_detach = function()
+        clear_diagnostic_cache(bufnr, client_id)
         _diagnostic_cleanup[bufnr][client_id] = nil
       end
     })


### PR DESCRIPTION
`lsp.diagnostic.get_all()` was returning diagnotics for `:bwipeout`ed
buffers because the diagnostic cache is not cleared. The first argument
of on_detach callback is the string "detach", not the bufnr.