### PR TITLE
Allow to get window options before they have been set.

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -209,12 +209,12 @@ local function get_scoped_option(k, set_type)
   end
 
   if is_window_option(info) then
-    if vim.api.nvim_get_option_info(k).was_set then
-      local was_set, value = pcall(a.nvim_win_get_option, 0, k)
-      if was_set then return value end
+    local was_set, value = pcall(a.nvim_win_get_option, 0, k)
+    if was_set then
+      return value
+    else
+      return a.nvim_get_option(k)
     end
-
-    return a.nvim_get_option(k)
   end
 
   error("This fallback case should not be possible. " .. k)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1228,6 +1228,14 @@ describe('lua stdlib', function()
       eq("only-local", result[8])
     end)
 
+    it('should allow you to retrieve window opts even if they have not been set', function()
+      local result = exec_lua [[
+        local result = vim.opt.number:get()
+        return result
+      ]]
+      eq(false, result)
+    end)
+
     it('should allow all sorts of string manipulation', function()
       eq({'hello', 'hello world', 'start hello world'}, exec_lua [[
         local results = {}


### PR DESCRIPTION
This closes #14677, but I also am a little unsure if there are times
where this may not be correct. However, this just changes the behavior
that even if `was_set` was false, we still get for
`nvim_win_get_option`.