### PR TITLE
feat(lsp): vim.lsp.config

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1531,8 +1531,7 @@ function lsp._with_extend(name, options, user_config)
   return resulting_config
 end
 
--- Define the LspDiagnostics signs if they're not defined already.
-require('vim.lsp.diagnostic')._define_default_signs_and_highlights()
+lsp.setup = require("vim.lsp.config").setup
 
 return lsp
 -- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/config.lua
+++ b/runtime/lua/vim/lsp/config.lua
@@ -1,0 +1,88 @@
+local protocol = require("vim.lsp.protocol")
+
+local M = {}
+
+---@class LspOptions
+local defaults = {
+  floating_preview = {
+    offset_x = 0,
+    offset_y = 0,
+    border = nil, -- nil for default, single, duoble, shadow
+  },
+  stylize_markdown_fences = { -- map of markdown code block langs to syntax
+    console = "sh",
+    js = "javascript",
+    jsx = "javascriptreact",
+    shell = "sh",
+    ts = "typescript",
+    tsx = "typescriptreact",
+  },
+  diagnostics = {
+    signs = {
+      error = "E",
+      warning = "W",
+      information = "I",
+      hint = "H",
+    },
+    display = {
+      signs = true,
+      underline = true,
+      virtual_text = true,
+      update_in_insert = false,
+      severity_sort = false,
+    },
+  },
+  protocol = { symbols = {}, completion_items = {} },
+}
+
+---@type LspOptions
+M.options = {}
+
+-- Configure the built-in LSP client.
+--
+-- @param opts LspOptions
+--     - floating_preview:
+--          * default options for lsp floating windows
+--          * See |vim.lsp.util.open_floating_preview|
+--     - stylize_markdown_fences:
+--          * table of markdown code block langs to syntax
+--          * for example, this will map a *ts* code-block to the **typescript** syntax
+--     - diagnostics:
+--          * display: See |vim.lsp.handlers.on_publish_diagnostics|
+--          * signs: table of diagnostic severity to sign
+--     - protocol:
+--          * completion_items:
+--               - table of completion item kind to display text
+--               - See |vim.lsp.protocol.CompletionItemKind|
+--          * symbols:
+--               - table of symbol kind to display text
+--               - See |vim.lsp.protocol.SymbolKind|
+function M.setup(opts)
+  opts = opts or {}
+
+  M.options = vim.tbl_deep_extend("force", {}, defaults, M.options, opts)
+
+  -- configure diagnostics
+  -- only override the signs when we explicitely pass them in the options
+  require("vim.lsp.diagnostic")._setup({}, opts.diagnostics and opts.diagnostics.signs)
+
+  -- configure completion item kind
+  for i, kind in ipairs(protocol.CompletionItemKind) do
+    protocol.CompletionItemKind[i] = M.options.protocol.completion_items[kind] or kind
+  end
+
+  -- configure symbol item kind
+  for i, kind in ipairs(protocol.SymbolKind) do
+    protocol.SymbolKind[i] = M.options.protocol.symbols[kind] or kind
+  end
+end
+
+function M.reset()
+  M.options = {}
+  M.setup()
+end
+
+-- use defer, since we require modules requiring config
+vim.defer_fn(M.setup, 0)
+
+return M

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -219,7 +219,7 @@ local function tbl_extend(behavior, deep_extend, ...)
     vim.validate{["after the second argument"] = {tbl,'t'}}
     if tbl then
       for k, v in pairs(tbl) do
-        if type(v) == 'table' and deep_extend and not vim.tbl_islist(v) then
+        if type(v) == 'table' and deep_extend and not vim.tbl_islist(v) and (ret[k] == nil or type(ret[k]) == "table") then
           ret[k] = tbl_extend(behavior, true, ret[k] or vim.empty_dict(), v)
         elseif behavior ~= 'force' and ret[k] ~= nil then
           if behavior == 'error' then


### PR DESCRIPTION
This PR adds `vim.lsp.config` that can configure various aspects of the built-in LSP client through `vim.lsp.setup({...})`

## Usage

The following example, configures borders for all `floating_preview`s and uses custom symbols for diagnostics signs, and completion item kinds.

```lua
vim.lsp.setup({
  floating_preview = { border = "single" },
  diagnostics = {
    signs = { error = " ", warning = " ", hint = " ", information = " " },
    display = {
      underline = true,
      update_in_insert = false,
      virtual_text = { spacing = 4, prefix = "●" },
      severity_sort = true,
    },
  },
  protocol = {
    completion_items = {
      Class = " ",
      Color = " ",
      Constant = " ",
      Constructor = " ",
      Enum = "了 ",
      EnumMember = " ",
      Field = " ",
      File = " ",
      Folder = " ",
      Function = " ",
      Interface = "ﰮ ",
      Keyword = " ",
      Method = "ƒ ",
      Module = " ",
      Property = " ",
      Snippet = "﬌ ",
      Struct = " ",
      Text = " ",
      Unit = " ",
      Value = " ",
      Variable = " ",
    },
  },
})

```

## Other

* fix for `vim.tbl_deep_extend`: would fail with `vim.tbl_deep_extend("force", {a=true}, {a={b= 1}})` 
* Supersedes #14617
* Fixes #14616
