### PR TITLE
fix(lsp): check mode in omnifunc callback

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1421,7 +1421,7 @@ function lsp.omnifunc(findstart, base)
 
   local items = {}
   lsp.buf_request(bufnr, 'textDocument/completion', params, function(err, _, result)
-    if err or not result then return end
+    if err or not result or vim.fn.mode() ~= "i" then return end
     local matches = util.text_document_completion_list_to_complete_items(result, prefix)
     -- TODO(ashkan): is this the best way to do this?
     vim.list_extend(items, matches)


### PR DESCRIPTION
Since `vim.lsp.omnifunc` uses [an async callback](https://github.com/neovim/neovim/blob/b10cda83faac977c97bfa241b02ca35ebb2fd458/runtime/lua/vim/lsp.lua#L1423), it's possible that the user will have already exited insert mode by the time the callback is called, especially when using slower servers on larger projects. This situation triggers the following error:

```
Error executing vim.schedule lua callback: Vim:E785: complete() can only be used in Insert mode
```

This tiny PR adds a check to the callback to make sure the user is still in insert mode before calling `complete()`. 