### PR TITLE
[WIP] feat(fold): add foldreloadslow option, provide highlight targets for nested folds

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -186,6 +186,8 @@ typedef struct {
 # define w_p_fdl_save w_onebuf_opt.wo_fdl_save
   char_u      *wo_fdm;
 # define w_p_fdm w_onebuf_opt.wo_fdm    // 'foldmethod'
+  int wo_fdr;
+#define w_p_fdr w_onebuf_opt.wo_fdr    // 'foldreloadslow'
   char_u      *wo_fdm_save;
 # define w_p_fdm_save w_onebuf_opt.wo_fdm_save  // 'fdm' saved for diff mode
   long wo_fml;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -846,9 +846,14 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 /// Updates folds when leaving insert-mode.
 void foldUpdateAfterInsert(void)
 {
-  if (foldmethodIsManual(curwin)  // foldmethod=manual: No need to update.
-      // These foldmethods are too slow, do not auto-update on insert-leave.
-      || foldmethodIsSyntax(curwin) || foldmethodIsExpr(curwin)) {
+  // foldmethod=manual: No need to update.
+  if (foldmethodIsManual(curwin)) {
+    return;
+  }
+
+  // foldmethod=syntax and foldmethod=expr are too slow to update
+  // unless a user has opted into it with foldreloadslow
+  if (!curwin->w_onebuf_opt.wo_fdr && (foldmethodIsSyntax(curwin) || foldmethodIsExpr(curwin))) {
     return;
   }
 

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -74,6 +74,11 @@ typedef enum {
   , HLF_W           // warning messages
   , HLF_WM          // Wildmenu highlight
   , HLF_FL          // Folded line
+  , HLF_FL1         // Folded line depth 1
+  , HLF_FL2         // Folded line depth 2
+  , HLF_FL3         // Folded line depth 3
+  , HLF_FL4         // Folded line depth 4
+  , HLF_FL5         // Folded line depth 5
   , HLF_FC          // Fold column
   , HLF_ADD         // Added diff line
   , HLF_CHD         // Changed diff line
@@ -129,6 +134,11 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_W] = "WarningMsg",
   [HLF_WM] = "WildMenu",
   [HLF_FL] = "Folded",
+  [HLF_FL1] = "Folded1",
+  [HLF_FL2] = "Folded2",
+  [HLF_FL3] = "Folded3",
+  [HLF_FL4] = "Folded4",
+  [HLF_FL5] = "Folded5",
   [HLF_FC] = "FoldColumn",
   [HLF_ADD] = "DiffAdd",
   [HLF_CHD] = "DiffChange",

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4005,6 +4005,11 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
         EMSG(_(errmsg));
       }
     }
+  } else if ((int *)varp == &curwin->w_allbuf_opt.wo_fdr) { // 'foldreloadslow'
+    // when 'foldreloadslow' is enabled
+    // foldUpdateAfterInsert will always update,
+    // even when using a slow fold method
+    foldUpdateAll(curwin);
   }
 
   if ((int *)varp == &curwin->w_p_arab) {
@@ -5685,6 +5690,7 @@ static char_u *get_varp(vimoption_T *p)
   case PV_FDI:    return (char_u *)&(curwin->w_p_fdi);
   case PV_FDL:    return (char_u *)&(curwin->w_p_fdl);
   case PV_FDM:    return (char_u *)&(curwin->w_p_fdm);
+  case PV_FDR:    return (char_u *)&(curwin->w_p_fdr);
   case PV_FML:    return (char_u *)&(curwin->w_p_fml);
   case PV_FDN:    return (char_u *)&(curwin->w_p_fdn);
   case PV_FDE:    return (char_u *)&(curwin->w_p_fde);
@@ -5842,6 +5848,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fdm = vim_strsave(from->wo_fdm);
   to->wo_fdm_save = from->wo_diff_saved
                     ? vim_strsave(from->wo_fdm_save) : empty_option;
+  to->wo_fdr = from->wo_fdr;
   to->wo_fdn = from->wo_fdn;
   to->wo_fde = vim_strsave(from->wo_fde);
   to->wo_fdt = vim_strsave(from->wo_fdt);

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -852,6 +852,7 @@ enum {
   , WV_FDI
   , WV_FDL
   , WV_FDM
+  , WV_FDR
   , WV_FML
   , WV_FDN
   , WV_FDE

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1011,6 +1011,12 @@ return {
       defaults={if_true={vi="manual"}}
     },
     {
+      full_name='foldreloadslow', abbreviation='fdr',
+      short_desc=N_("whether to reload slow fold methods"),
+      type='bool', scope={'window'},
+      defaults={if_true={vi=false}},
+    },
+    {
       full_name='foldminlines', abbreviation='fml',
       short_desc=N_("minimum number of lines for a fold to be closed"),
       type='number', scope={'window'},

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2927,7 +2927,13 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
         && vcol == 0
         && n_extra == 0
         && row == startrow) {
-        char_attr = win_hl_attr(wp, HLF_FL);
+        // only provide 5 layers of highlighting
+        // and then wrap around to the default
+        hlf_T highlight = HLF_FL;
+        if (foldinfo.fi_level > 0 && foldinfo.fi_level <= 5) {
+          highlight = highlight + foldinfo.fi_level;
+        }
+        char_attr = win_hl_attr(wp, highlight);
 
         linenr_T lnume = lnum + foldinfo.fi_lines - 1;
         memset(buf_fold, ' ', FOLD_TEXT_LEN);


### PR DESCRIPTION
This PR has 2 components (happy to split them up!), both of which are focused on making the folding experience better for outlining + note-taking. Relevant issue: https://github.com/neovim/neovim/issues/14457

1. Add a `foldreloadslow` option, which allows a user to opt into reloading folds with slow fold methods (`syntax` and `expr`)
2. Provide highlight targets for nested folds, to allow users to style them differently based on how deep the fold is

I'm sure this needs some work (testing + better documentation), but I wanted to get it out there for feedback.