### PR TITLE
api: add nvim_win_call

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1931,6 +1931,34 @@ describe('lua stdlib', function()
       eq(buf2, val)
     end)
   end)
+
+  describe('vim.api.nvim_win_call', function()
+    it('can access window options', function()
+      command('vsplit')
+      local win1 = meths.get_current_win()
+      command('wincmd w')
+      local win2 = exec_lua [[
+        win2 = vim.api.nvim_get_current_win()
+        return win2
+      ]]
+      command('wincmd p')
+
+      eq('', meths.win_get_option(win1, 'winhighlight'))
+      eq('', meths.win_get_option(win2, 'winhighlight'))
+
+      local val = exec_lua [[
+        return vim.api.nvim_win_call(win2, function()
+          vim.cmd "setlocal winhighlight=Normal:Normal"
+          return vim.api.nvim_get_current_win()
+        end)
+      ]]
+
+      eq('', meths.win_get_option(win1, 'winhighlight'))
+      eq('Normal:Normal', meths.win_get_option(win2, 'winhighlight'))
+      eq(win1, meths.get_current_win())
+      eq(win2, val)
+    end)
+  end)
 end)
 
 describe('lua: require("mod") from packages', function()


### PR DESCRIPTION
Thanks to `win_execute()` implementation, we can add `nvim_win_call()`.
This is useful like `nvim_buf_call()`.

```lua
local bufnr = vim.api.nvim_create_buf(false, true)
vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.fn["repeat"]({""}, 100))
local window = vim.api.nvim_open_win(bufnr, false, {
  width = 50,
  height = 10,
  relative = "editor",
  row = 10,
  col = 10,
})
vim.api.nvim_win_call(window, function()
  vim.cmd("normal! G")
  print(vim.fn.line("w0"), vim.fn.line("w$"), vim.fn.winline()) -- can use functions that work with current window
end)
```
