### PR TITLE
fix(man.vim): <unique> keybindings 

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -28,8 +28,8 @@ setlocal foldcolumn=0 colorcolumn=0 nolist nofoldenable
 setlocal tagfunc=man#goto_tag
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nnoremap <silent> <buffer> j             gj
-  nnoremap <silent> <buffer> k             gk
+  nnoremap <unique> <silent> <buffer> j             gj
+  nnoremap <unique> <silent> <buffer> k             gk
   nnoremap <silent> <buffer> gO            :call man#show_toc()<CR>
   nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
   if s:pager


### PR DESCRIPTION
Fixes #14688. I did as instructed by @doronbehar.

With `<unique>` nvim throws `E225: global mapping already exists for j`, which I don't know how to get rid of. Other than that, it works as expected.