### PR TITLE
fix(lsp): set_loclist should target current win

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1202,6 +1202,8 @@ function M.set_loclist(opts)
 
   local open_loclist = if_nil(opts.open_loclist, true)
 
+  local win_id = vim.api.nvim_get_current_win()
+
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer_diags = M.get(bufnr, opts.client_id)
 
@@ -1234,7 +1236,7 @@ function M.set_loclist(opts)
 
   table.sort(items, function(a, b) return a.lnum < b.lnum end)
 
-  util.set_loclist(items)
+  util.set_loclist(items, win_id)
   if open_loclist then
     vim.cmd [[lopen]]
   end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1599,8 +1599,8 @@ end
 --- Can be obtained with e.g. |vim.lsp.util.locations_to_items()|.
 ---
 --@param items (table) list of items
-function M.set_loclist(items)
-  vim.fn.setloclist(0, {}, ' ', {
+function M.set_loclist(items, win_id)
+  vim.fn.setloclist(win_id or 0, {}, ' ', {
     title = 'Language Server';
     items = items;
   })


### PR DESCRIPTION
Currently, for large number of diagnostics, the delay in populating loclist may be sufficient for a user to switch to another window, resulting in the loclist being populated on the wrong window.

Closes: #14639

@YorickPeterse please confirm this fixes your issue, I haven't tested.