### PR TITLE
Add vim.o.noshowmode to neovim 

### DIFF
--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -502,6 +502,7 @@ EXTERN long p_ls;               // 'laststatus'
 EXTERN long p_stal;             // 'showtabline'
 EXTERN char_u   *p_lcs;         // 'listchars'
 
+EXTERN int p_nm                 // 'noshowmode'
 EXTERN int p_lz;                // 'lazyredraw'
 EXTERN int p_lpl;               // 'loadplugins'
 EXTERN int p_magic;             // 'magic'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1822,6 +1822,14 @@ return {
       varname='p_mouset',
       defaults={if_true={vi=500}}
     },
+        {
+      full_name='noshowmode', abbreviation='nm',
+      short_desc=N_("turns off the --INSERT-- etc mode messages at very bottom"),
+      type='bool', scope={'global'},
+      vi_def=true,
+      varname='p_nm',
+      defaults={if_true={vi=false}}
+    },
     {
       full_name='nrformats', abbreviation='nf',
       short_desc=N_("number formats recognized for CTRL-A command"),


### PR DESCRIPTION
This PR adds the basic code to allow for neovim users to `set noshowmode`

The `set noshowmode` option disables "--INSERT--" etc messages in the command bar