### PR TITLE
[RDY] fix(lsp): guard against negative diagnostic line numbers

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -271,12 +271,12 @@ local function set_diagnostic_cache(diagnostics, bufnr, client_id)
     end
     -- Account for servers that place diagnostics on terminating newline
     if buf_line_count > 0 then
-      diagnostic.range.start.line = math.min(
+      diagnostic.range.start.line = math.max(math.min(
         diagnostic.range.start.line, buf_line_count - 1
-      )
-      diagnostic.range["end"].line = math.min(
+      ), 0)
+      diagnostic.range["end"].line = math.max(math.min(
         diagnostic.range["end"].line, buf_line_count - 1
-      )
+      ), 0)
     end
   end
 


### PR DESCRIPTION
**What**

This patch adds a guard to `set_diagnostic_cache` so that `start.line` is never less than `0`.

**Why**

The underlying tool (`dialyzer`) for the Elixir language server (`elixir-ls`) sometimes returns it's errors with a line number of 0.

Somewhere between it, the language server and neovim, these `0`'s become `-1`'s.

These `-1`'s end up in things line `nvim_buf_add_highlight()` and `diagnostic.lua`'s `set_virtual_text()`; Once there, nvim starts spewing `line number outside range` errors, which requires the user to press return repeatedly to clear, only to have they re-appear in quick fashion, making the editor basically unusable.

By setting these to `0`, we can avoid the nvim errors and still show the diagnostic warnings. This does smear the malformed warnings onto the one line but this is likely much preferred over having the editor "soft crash" and getting *no warnings*.

I am not currently sure whether this is intended behaviour in `dialyzer` or a mistaken `line - 1` in `elixir-ls` or `nvim`, or if `-1` is actually in spec, but I figure Neovim should try to save users from this kind of stuff if possible. I would bet there are other language servers out there just waiting cause the same issue.