### PR TITLE
fix: changed byte ranges for indented lines

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1690,7 +1690,6 @@ int open_line(
       if (trunc_line && !(flags & OPENLINE_KEEPTRAIL)) {
         truncate_spaces(saved_line);
       }
-
       ml_replace(curwin->w_cursor.lnum, saved_line, false);
 
       int new_len = (int)STRLEN(saved_line);
@@ -1705,7 +1704,6 @@ int open_line(
       }
 
       saved_line = NULL;
-
       if (did_append) {
         changed_lines(curwin->w_cursor.lnum, curwin->w_cursor.col,
                       curwin->w_cursor.lnum + 1, 1L, true);
@@ -1726,7 +1724,6 @@ int open_line(
       } else {
         changed_bytes(curwin->w_cursor.lnum, curwin->w_cursor.col);
       }
-
     }
 
     // Put the cursor on the new line.  Careful: the scrollup() above may

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1717,7 +1717,7 @@ int open_line(
         }
         // Always move extmarks - Here we move only the line where the
         // cursor is, the previous mark_adjust takes care of the lines after
-        int cols_added = mincol-1+less_cols_off-less_cols-new_len;
+        int cols_added = mincol-1+less_cols_off-less_cols;
         extmark_splice(curbuf, (int)lnum-1, mincol-1 - cols_spliced,
                        0, less_cols_off, less_cols_off,
                        1, cols_added, 1 + cols_added, kExtmarkUndo);

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -401,8 +401,8 @@ describe('lua: nvim_buf_attach on_bytes', function()
         }
         feed '<cr>'
         check_events {
-          { "test1", "bytes", 1, 4, 8, 0, 115, 0, 4, 4, 0, 0, 0 };
-          { "test1", "bytes", 1, 5, 7, 4, 118, 0, 0, 0, 1, 4, 5 };
+          { "test1", "bytes", 1, 4, 7, 0, 114, 0, 4, 4, 0, 0, 0 };
+          { "test1", "bytes", 1, 5, 7, 0, 114, 0, 0, 0, 1, 4, 5 };
         }
     end)
 
@@ -447,8 +447,8 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
       feed '<CR>'
       check_events {
-        { "test1", "bytes", 1, 6, 2, 2, 16, 0, 1, 1, 0, 0, 0 };
-        { "test1", "bytes", 1, 7, 1, 3, 14, 0, 0, 0, 1, 3, 4 };
+        { "test1", "bytes", 1, 6, 1, 2, 13, 0, 1, 1, 0, 0, 0 };
+        { "test1", "bytes", 1, 7, 1, 2, 13, 0, 0, 0, 1, 3, 4 };
       }
     end)
 


### PR DESCRIPTION
This PR is related to changed byte when inserting a newline. Previously when reading the byte ranges using `on_bytes` and modifying a local copy of the buffer according to the modified byte ranges, it resulted in discrepancies when inserting a new indented line. This is an attempt to fix it.

## Issue

This is the case which resulted in wrong byte ranges.

```lua
function f()

                    -- add a new line here using <CR>
  return 0
end
```
It generates two events because of the indentation.
```
{ "bytes", 6, 4, 2, 0, 18, 0, 2, 2, 0, 0, 0 } { "function hello()", "", "  ", "  return 0", "end" }
{ "bytes", 6, 5, 1, 2, 19, 0, 0, 0, 1, 2, 3 } { "function hello()", "", "  ", "  return 0", "end" }
```

The first event deletes indentation on the return statement line (which is probably a one off error because it should delete the indentation on the previous line).
The second event adds an empty with indentation which is correct.

## Fix

```
{ "bytes", 5, 4, 1, 0, 17, 0, 2, 2, 0, 0, 0 } { "function hello()", "", "  ", "  return 0", "end" }
{ "bytes", 5, 5, 1, 0, 17, 0, 0, 0, 1, 2, 3 } { "function hello()", "", "  ", "  return 0", "end" }
```

I fixed the correct the byte ranges. Are there run tests to validate the behaviour?