### PR TITLE
fix(treesitter): do not map hl_group when no mapping is set

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -22,8 +22,6 @@ local _link_default_highlight_once = function(from, to)
   return from
 end
 
--- These are conventions defined by nvim-treesitter, though it
--- needs to be user extensible also.
 TSHighlighter.hl_map = {
     ["error"] = "Error",
 

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -116,7 +116,7 @@ function TSHighlighterQuery:_get_hl_from_capture(capture)
     -- From "Normal.left" only keep "Normal"
     return vim.split(name, '.', true)[1], true
   else
-    return TSHighlighter.hl_map[name] or name, false
+    return TSHighlighter.hl_map[name] or 0, false
   end
 end
 


### PR DESCRIPTION
This changes the behavior of the hl_cache to the old one: when no hl_group exist

- when the capture looks like a hlgroup (UpperCase) -> use it
- when hl_map contains a mapping -> use it
- else do nothing (before: map capture to non-existing highlight group)

Before also captures `@foo.bar` would intend to use the hlgroup `foo.bar`
which results in a confusing error since hlgroups can't contain dots.