### PR TITLE
fix: source syncolors.vim before startup scripts

### DIFF
--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -25,6 +25,8 @@ else
   endif
 endif
 
+let did_syncolor = 1
+
 " Many terminals can only use six different colors (plus black and white).
 " Therefore the number of colors used is kept low. It doesn't look nice with
 " too many colors anyway.

--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -14,10 +14,8 @@ endif
 " let others know that syntax has been switched on
 let syntax_on = 1
 
-" Set the default highlighting colors.  Use a color scheme if specified.
-if exists("colors_name")
-  exe "colors " . colors_name
-else
+" Set the default highlighting colors
+if !exists("colors_name") && !exists("did_syncolor")
   runtime! syntax/syncolor.vim
 endif
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -367,11 +367,19 @@ int main(int argc, char **argv)
   // Execute --cmd arguments.
   exe_pre_commands(&params);
 
+  // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
+  bool enable_syntax =
+    (params.use_vimrc == NULL || !strequal(params.use_vimrc, "NONE"));
+
+  // Source syncolor.vim to set up default UI highlights
+  if (enable_syntax) {
+    source_runtime((char_u *)"syntax/syncolor.vim", DIP_ALL);
+  }
+
   // Source startup scripts.
   source_startup_scripts(&params);
 
-  // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
-  if (params.use_vimrc == NULL || !strequal(params.use_vimrc, "NONE")) {
+  if (enable_syntax) {
     // Does ":filetype plugin indent on".
     filetype_maybe_enable();
     // Sources syntax/syntax.vim, which calls `:filetype on`.


### PR DESCRIPTION
This fixes an issue (#12573) where colorscheme files are sourced twice
upon startup. This occurs when the startup script calls `:colorscheme`,
which sets the `g:colors_name` global variable. When syntax highlighting
is enabled in `syn_maybe_enable()` the `syntax.vim` script is sourced
which in turn sources `synload.vim`. This script checks to see if
`g:colors_name` is set and, if so, runs

    exe "colors " . colors_name

The correct way to handle this is to enable syntax highlighting before
any `:colorscheme` commands are ever used. Since Neovim enables syntax
highlighting outside of the startup scripts, this should therefore be
done before sourcing the startup scripts.

Closes #12573.