### PR TITLE
macros: add a dummy statement to allow FALLTHROUGH in an empty case.

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -169,7 +169,7 @@
 
 #if NVIM_HAS_ATTRIBUTE(fallthrough) \
     && (!defined(__apple_build_version__) || __apple_build_version__ >= 7000000)
-# define FALLTHROUGH __attribute__((fallthrough))
+# define FALLTHROUGH {} __attribute__((fallthrough))
 #else
 # define FALLTHROUGH
 #endif


### PR DESCRIPTION
Problem: gcc11 does not like `__attribute__((fallthrough))` in an empty `case` block, like in

```
    case K_S_UP:      FALLTHROUGH;
    case K_UP:        return VTERM_KEY_UP;
```

Solution: add a dummy empty statement as part of the macro.