### PR TITLE
ci: correctly label dependencies PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,9 @@
   - runtime/lua/vim/treesitter.lua
   - runtime/lua/vim/treesitter/*
 
+"dependencies":
+  - third-party/**/*
+
 "topic: spell":
   - src/nvim/spell*
 
@@ -39,3 +42,8 @@
 
 "topic: diff":
   - src/nvim/diff.*
+
+"topic: build":
+  - CMakeLists.txt
+  - "**/CMakeLists.txt"
+  - "**/*.cmake"


### PR DESCRIPTION
Configures the labeler to handle PRs related to third-party.

I saw that when opening #14776.
