### PR TITLE
fix: vim.opt

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -414,6 +414,12 @@ local convert_value_to_lua = (function()
         return value
       end
 
+      -- Empty strings mean that there is nothing there,
+      -- so empty table should be returned.
+      if value == '' then
+        return {}
+      end
+
       -- Handles unescaped commas in a list.
       if string.find(value, ",,,") then
         local comma_split = vim.split(value, ",,,")
@@ -450,6 +456,12 @@ local convert_value_to_lua = (function()
 
     [OptionTypes.SET] = function(info, value)
       if type(value) == "table" then return value end
+
+      -- Empty strings mean that there is nothing there,
+      -- so empty table should be returned.
+      if value == '' then
+        return {}
+      end
 
       assert(info.flaglist, "That is the only one I know how to handle")
 

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -325,9 +325,12 @@ local convert_value_to_vim = (function()
       return result
     end,
 
-    [OptionTypes.ARRAY] = function(_, value)
+    [OptionTypes.ARRAY] = function(info, value)
       if type(value) == "string" then return value end
-      return table.concat(remove_duplicate_values(value), ",")
+      if not info.allows_duplicates then
+        value = remove_duplicate_values(value)
+      end
+      return table.concat(value, ",")
     end,
 
     [OptionTypes.MAP] = function(_, value)

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -209,12 +209,17 @@ local function get_scoped_option(k, set_type)
   end
 
   if is_window_option(info) then
-    if vim.api.nvim_get_option_info(k).was_set then
-      local was_set, value = pcall(a.nvim_win_get_option, 0, k)
-      if was_set then return value end
+    local ok, value = pcall(a.nvim_win_get_option, 0, k)
+    if ok then
+      return value
     end
 
-    return a.nvim_get_option(k)
+    local global_ok, global_val = pcall(a.nvim_get_option, k)
+    if global_ok then
+      return global_val
+    end
+
+    error("win_get: This should never happen. File an issue and tag @tjdevries")
   end
 
   error("This fallback case should not be possible. " .. k)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7765,6 +7765,7 @@ static Dictionary vimoption2dict(vimoption_T *opt)
     }
     PUT(dict, "type", CSTR_TO_OBJ(type));
     PUT(dict, "default", def);
+    PUT(dict, "allows_duplicates", BOOL(!(opt->flags & P_NODUP)));
 
     return dict;
 }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3152,7 +3152,7 @@ return {
       full_name='wildmode', abbreviation='wim',
       short_desc=N_("mode for 'wildchar' command-line expansion"),
       type='string', list='onecomma', scope={'global'},
-      deny_duplicates=true,
+      deny_duplicates=false,
       vim=true,
       varname='p_wim',
       defaults={if_true={vi="", vim="full"}}

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2003,6 +2003,7 @@ describe('API', function()
 
     it('should have information about window options', function()
       eq({
+        allows_duplicates = true,
         commalist = false;
         default = "";
         flaglist = false;
@@ -2020,6 +2021,7 @@ describe('API', function()
 
     it('should have information about buffer options', function()
       eq({
+        allows_duplicates = true,
         commalist = false,
         default = "",
         flaglist = false,
@@ -2041,6 +2043,7 @@ describe('API', function()
       eq(false, meths.get_option'showcmd')
 
       eq({
+        allows_duplicates = true,
         commalist = false,
         default = true,
         flaglist = false,

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1228,6 +1228,21 @@ describe('lua stdlib', function()
       eq("only-local", result[8])
     end)
 
+    it('should allow you to retrieve window opts even if they have not been set', function()
+      local result = exec_lua [[
+        local result = {}
+        table.insert(result, vim.opt.number:get())
+        table.insert(result, vim.opt_local.number:get())
+
+        vim.opt_local.number = true
+        table.insert(result, vim.opt.number:get())
+        table.insert(result, vim.opt_local.number:get())
+
+        return result
+      ]]
+      eq({false, false, true, true}, result)
+    end)
+
     it('should allow all sorts of string manipulation', function()
       eq({'hello', 'hello world', 'start hello world'}, exec_lua [[
         local results = {}

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1569,7 +1569,15 @@ describe('lua stdlib', function()
       eq(wildignore, 'super_first,first,foo')
     end)
 
-  end)
+    it('should not remove duplicates from wildmode: #14708', function()
+      local wildmode = exec_lua [[
+        vim.opt.wildmode = {"full", "list", "full"}
+        return vim.o.wildmode
+      ]]
+
+      eq(wildmode, 'full,list,full')
+    end)
+  end) -- vim.opt
 
   it('vim.cmd', function()
     exec_lua [[

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1731,6 +1731,26 @@ describe('lua stdlib', function()
         ]]))
       end)
     end)
+
+    -- isfname=a,b,c,,,d,e,f
+    it('can handle isfname ,,,', function()
+      local result = exec_lua [[
+        vim.opt.isfname = "a,b,,,c"
+        return { vim.opt.isfname:get(), vim.api.nvim_get_option('isfname') }
+      ]]
+
+      eq({{",", "a", "b", "c"}, "a,b,,,c"}, result)
+    end)
+
+    -- isfname=a,b,c,^,,def
+    it('can handle isfname ,^,,', function()
+      local result = exec_lua [[
+        vim.opt.isfname = "a,b,^,,c"
+        return { vim.opt.isfname:get(), vim.api.nvim_get_option('isfname') }
+      ]]
+
+      eq({{"^,", "a", "b", "c"}, "a,b,^,,c"}, result)
+    end)
   end) -- vim.opt
 
   it('vim.cmd', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1751,6 +1751,70 @@ describe('lua stdlib', function()
 
       eq({{"^,", "a", "b", "c"}, "a,b,^,,c"}, result)
     end)
+
+
+
+    describe('https://github.com/neovim/neovim/issues/14828', function()
+      it('gives empty list when item is empty:array', function()
+        eq({}, exec_lua [[
+          vim.cmd("set wildignore=")
+          return vim.opt.wildignore:get()
+        ]])
+
+        eq({}, exec_lua [[
+          vim.opt.wildignore = {}
+          return vim.opt.wildignore:get()
+        ]])
+      end)
+
+      it('gives empty list when item is empty:set', function()
+        eq({}, exec_lua [[
+          vim.cmd("set formatoptions=")
+          return vim.opt.formatoptions:get()
+        ]])
+
+        eq({}, exec_lua [[
+          vim.opt.formatoptions = {}
+          return vim.opt.formatoptions:get()
+        ]])
+      end)
+
+      it('does not append to empty item', function()
+        eq({"*.foo", "*.bar"},  exec_lua [[
+          vim.opt.wildignore = {}
+          vim.opt.wildignore:append { "*.foo", "*.bar" }
+
+          return vim.opt.wildignore:get()
+        ]])
+      end)
+
+      it('does not prepend to empty item', function()
+        eq({"*.foo", "*.bar"},  exec_lua [[
+          vim.opt.wildignore = {}
+          vim.opt.wildignore:prepend { "*.foo", "*.bar" }
+
+          return vim.opt.wildignore:get()
+        ]])
+      end)
+
+      it('append to empty set', function()
+        eq({ t = true },  exec_lua [[
+          vim.opt.formatoptions = {}
+          vim.opt.formatoptions:append("t")
+
+          return vim.opt.formatoptions:get()
+        ]])
+      end)
+
+      it('prepend to empty set', function()
+        eq({ t = true },  exec_lua [[
+          vim.opt.formatoptions = {}
+          vim.opt.formatoptions:prepend("t")
+
+          return vim.opt.formatoptions:get()
+        ]])
+      end)
+    end)
   end) -- vim.opt
 
   it('vim.cmd', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1592,6 +1592,128 @@ describe('lua stdlib', function()
 
       eq(wildmode, 'full,list,full')
     end)
+
+    describe('option types', function()
+      it('should allow to set option with numeric value', function()
+        eq(4, exec_lua [[
+          vim.opt.tabstop = 4
+          return vim.bo.tabstop
+        ]])
+
+        matches("Invalid option type 'string' for 'tabstop'", pcall_err(exec_lua, [[
+          vim.opt.tabstop = '4'
+        ]]))
+        matches("Invalid option type 'boolean' for 'tabstop'", pcall_err(exec_lua, [[
+          vim.opt.tabstop = true
+        ]]))
+        matches("Invalid option type 'table' for 'tabstop'", pcall_err(exec_lua, [[
+          vim.opt.tabstop = {4, 2}
+        ]]))
+        matches("Invalid option type 'function' for 'tabstop'", pcall_err(exec_lua, [[
+          vim.opt.tabstop = function()
+            return 4
+          end
+        ]]))
+      end)
+
+      it('should allow to set option with boolean value', function()
+        eq(true, exec_lua [[
+          vim.opt.undofile = true
+          return vim.bo.undofile
+        ]])
+
+        matches("Invalid option type 'number' for 'undofile'", pcall_err(exec_lua, [[
+          vim.opt.undofile = 0
+        ]]))
+        matches("Invalid option type 'table' for 'undofile'", pcall_err(exec_lua, [[
+          vim.opt.undofile = {true}
+        ]]))
+        matches("Invalid option type 'string' for 'undofile'", pcall_err(exec_lua, [[
+          vim.opt.undofile = 'true'
+        ]]))
+        matches("Invalid option type 'function' for 'undofile'", pcall_err(exec_lua, [[
+          vim.opt.undofile = function()
+            return true
+          end
+        ]]))
+      end)
+
+      it('should allow to set option with array or string value', function()
+        eq('indent,eol,start', exec_lua [[
+          vim.opt.backspace = {'indent','eol','start'}
+          return vim.go.backspace
+        ]])
+        eq('indent,eol,start', exec_lua [[
+          vim.opt.backspace = 'indent,eol,start'
+          return vim.go.backspace
+        ]])
+
+        matches("Invalid option type 'boolean' for 'backspace'", pcall_err(exec_lua, [[
+          vim.opt.backspace = true
+        ]]))
+        matches("Invalid option type 'number' for 'backspace'", pcall_err(exec_lua, [[
+          vim.opt.backspace = 2
+        ]]))
+        matches("Invalid option type 'function' for 'backspace'", pcall_err(exec_lua, [[
+          vim.opt.backspace = function()
+            return 'indent,eol,start'
+          end
+        ]]))
+      end)
+
+      it('should allow set option with map or string value', function()
+        eq("eol:~,space:.", exec_lua [[
+          vim.opt.listchars = {
+            eol = "~",
+            space = ".",
+          }
+          return vim.o.listchars
+        ]])
+        eq("eol:~,space:.,tab:>~", exec_lua [[
+          vim.opt.listchars = "eol:~,space:.,tab:>~"
+          return vim.o.listchars
+        ]])
+
+        matches("Invalid option type 'boolean' for 'listchars'", pcall_err(exec_lua, [[
+          vim.opt.listchars = true
+        ]]))
+        matches("Invalid option type 'number' for 'listchars'", pcall_err(exec_lua, [[
+          vim.opt.listchars = 2
+        ]]))
+        matches("Invalid option type 'function' for 'listchars'", pcall_err(exec_lua, [[
+          vim.opt.listchars = function()
+            return "eol:~,space:.,tab:>~"
+          end
+        ]]))
+      end)
+
+      it('should allow set option with set or string value', function()
+        local ww = exec_lua [[
+          vim.opt.whichwrap = {
+            b = true,
+            s = 1,
+          }
+          return vim.go.whichwrap
+        ]]
+        eq(true, ww == "bs" or ww == "sb")
+        eq("b,s,<,>,[,]", exec_lua [[
+          vim.opt.whichwrap = "b,s,<,>,[,]"
+          return vim.go.whichwrap
+        ]])
+
+        matches("Invalid option type 'boolean' for 'whichwrap'", pcall_err(exec_lua, [[
+          vim.opt.whichwrap = true
+        ]]))
+        matches("Invalid option type 'number' for 'whichwrap'", pcall_err(exec_lua, [[
+          vim.opt.whichwrap = 2
+        ]]))
+        matches("Invalid option type 'function' for 'whichwrap'", pcall_err(exec_lua, [[
+          vim.opt.whichwrap = function()
+            return "b,s,<,>,[,]"
+          end
+        ]]))
+      end)
+    end)
   end) -- vim.opt
 
   it('vim.cmd', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1314,6 +1314,22 @@ describe('lua stdlib', function()
         eq("*.c", wildignore[1])
       end)
 
+      it('should work for options that are both commalist and flaglist', function()
+        local result = exec_lua [[
+          vim.opt.whichwrap = "b,s"
+          return vim.opt.whichwrap:get()
+        ]]
+
+        eq({b = true, s = true}, result)
+
+        result = exec_lua [[
+          vim.opt.whichwrap = { b = true, s = false, h = true }
+          return vim.opt.whichwrap:get()
+        ]]
+
+        eq({b = true, h = true}, result)
+      end)
+
       it('should work for key-value pair options', function()
         local listchars = exec_lua [[
           vim.opt.listchars = "tab:>~,space:_"
@@ -1695,7 +1711,8 @@ describe('lua stdlib', function()
           }
           return vim.go.whichwrap
         ]]
-        eq(true, ww == "bs" or ww == "sb")
+
+        eq(ww, "b,s")
         eq("b,s,<,>,[,]", exec_lua [[
           vim.opt.whichwrap = "b,s,<,>,[,]"
           return vim.go.whichwrap


### PR DESCRIPTION
Fix #14708: wildmode now works as expected and does not filter old values.