### PR TITLE
fix(bufupdates): send updates for append() with lockmarks

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -960,6 +960,7 @@ These commands are not marks themselves, but jump to a mark:
 			- the view of a window on a buffer
 			- folds
 			- diffs
+			- extmarks
 
 :kee[pmarks] {command}				*:kee* *:keep* *:keepmarks*
 			Currently only has effect for the filter command

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1003,24 +1003,22 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2,
     }
 
     sign_mark_adjust(line1, line2, amount, amount_after);
-    if (op != kExtmarkNOOP) {
-      extmark_adjust(curbuf, line1, line2, amount, amount_after, op);
-    }
   }
-
-  /* previous context mark */
+  if (op != kExtmarkNOOP) {
+    extmark_adjust(curbuf, line1, line2, amount, amount_after, op);
+  }
+  // previous context mark
   one_adjust(&(curwin->w_pcmark.lnum));
 
-  /* previous pcmark */
+  // previous pcmark
   one_adjust(&(curwin->w_prev_pcmark.lnum));
 
-  /* saved cursor for formatting */
-  if (saved_cursor.lnum != 0)
+  // saved cursor for formatting
+  if (saved_cursor.lnum != 0) {
     one_adjust_nodel(&(saved_cursor.lnum));
+  }
 
-  /*
-   * Adjust items in all windows related to the current buffer.
-   */
+  // Adjust items in all windows related to the current buffer.
   FOR_ALL_TAB_WINDOWS(tab, win) {
     if (!cmdmod.lockmarks) {
       /* Marks in the jumplist.  When deleting lines, this may create

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -1001,6 +1001,14 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("append with lockmarks", function ()
+      local check_events = setup_eventcheck(verify, {"AAA", "BBB"})
+
+      funcs.execute("lockmarks call append(1, 'abc')")
+
+      check_events {}
+    end)
+
     teardown(function()
       os.remove "Xtest-reload"
       os.remove "Xtest-undofile"


### PR DESCRIPTION
Correctly send updates when calling `append()` with `:lockmarks`.

Fixes #14772
