### PR TITLE
vim-patch:d2ea7cf10a4d

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -798,9 +798,10 @@ QuickFixCmdPost			Like QuickFixCmdPre, but after a quickfix
 							*QuitPre*
 QuitPre				When using `:quit`, `:wq` or `:qall`, before
 				deciding whether it closes the current window
-				or quits Vim.  Can be used to close any
-				non-essential window if the current window is
-				the last ordinary window.
+				or quits Vim.  For `:wq` the buffer is written
+				before QuitPre is triggered.  Can be used to
+				close any non-essential window if the current
+				window is the last ordinary window.
 				See also |ExitPre|, ||WinClosed|.
 							*RemoteReply*
 RemoteReply			When a reply from a Vim that functions as

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1070,7 +1070,7 @@ in Normal mode and Insert mode.
 It is possible to use ":", "/" and other commands that use the command-line,
 but it's not possible to open another command-line window then.  There is no
 nesting.
-							*E11*
+							*E11* *E1188*
 The command-line window is not a normal window.  It is not possible to move to
 another window or edit another buffer.  All commands that would do this are
 disabled in the command-line window.  Of course it _is_ possible to execute

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -334,9 +334,11 @@ between file1 and file2: >
 
 The ">" is replaced with the value of 'shellredir'.
 
-The output of "diff" must be a normal "ed" style diff or a unified diff.  Do
-NOT use a context diff.  This example explains the format that Vim expects for
-the "ed" style diff: >
+The output of "diff" must be a normal "ed" style diff or a unified diff.  A
+context diff will NOT work.  For a unified diff no context lines can be used.
+Using "diff -u" will NOT work, use "diff -U0".
+
+This example explains the format that Vim expects for the "ed" style diff: >
 
 	1a2
 	> bbb

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -436,7 +436,7 @@ the space bar):
 			     replace the column list with the list of tables.
 			   - This allows you to quickly drill down into a
 			     table to view its columns and back again.
-			   - <Right> and <Left> can be also be chosen via
+			   - <Right> and <Left> can also be chosen via
 			     your |init.vim| >
                                 let g:ftplugin_sql_omni_key_right = '<Right>'
                                 let g:ftplugin_sql_omni_key_left  = '<Left>'

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1612,7 +1612,7 @@ tag		command		action ~
 |:tab|		:tab		create new tab when opening new window
 |:tag|		:ta[g]		jump to tag
 |:tags|		:tags		show the contents of the tag stack
-|:tcd|		:tcd		change directory for tab page
+|:tcd|		:tc[d]		change directory for tab page
 |:tchdir|	:tch[dir]	change directory for tab page
 |:terminal|	:te[rminal]	open a terminal buffer
 |:tfirst|	:tf[irst]	jump to first matching tag

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6101,6 +6101,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'switchbuf' 'swb'	string	(default "")
 			global
 	This option controls the behavior when switching between buffers.
+	Mostly for |quickfix| commands some values are also used for other
+	commands, as mentioned below.
 	Possible values (comma separated list):
 	   useopen	If included, jump to the first open window that
 			contains the specified buffer (if there is one).

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1333,7 +1333,8 @@ Basic items
 	%o		module name (finds a string)
 	%l		line number (finds a number)
 	%c		column number (finds a number representing character
-			column of the error, (1 <tab> == 1 character column))
+			column of the error, byte index, a <tab> is 1
+			character column)
 	%v		virtual column number (finds a number representing
 			screen column of the error (1 <tab> == 8 screen
 			columns))

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1110,10 +1110,10 @@ flag to avoid lots of errors.
 CIRCUMFIX						*spell-CIRCUMFIX*
 
 The CIRCUMFIX flag means a prefix and suffix must be added at the same time.
-If a prefix has the CIRCUMFIX flag than only suffixes with the CIRCUMFIX flag
+If a prefix has the CIRCUMFIX flag then only suffixes with the CIRCUMFIX flag
 can be added, and the other way around.
-An alternative is to only specify the suffix, and give the that suffix two
-flags: The required prefix and the NEEDAFFIX flag.  |spell-NEEDAFFIX|
+An alternative is to only specify the suffix, and give that suffix two flags:
+the required prefix and the NEEDAFFIX flag.  |spell-NEEDAFFIX|
 
 
 PFXPOSTPONE						*spell-PFXPOSTPONE*

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -235,7 +235,7 @@ windows like this:
 	+----------------------------------+
 
 Clearly the last one should be at the top.  Go to that window (using CTRL-W w)
-and the type this command: >
+and then type this command: >
 
 	CTRL-W K
 

--- a/runtime/doc/usr_09.txt
+++ b/runtime/doc/usr_09.txt
@@ -109,7 +109,7 @@ when the 'wrap' option has been reset (more about that later).
 
 When there are vertically split windows, only the windows on the right side
 will have a scrollbar.  However, when you move the cursor to a window on the
-left, it will be this one the that scrollbar controls.  This takes a bit of
+left, it will be this one that the scrollbar controls.  This takes a bit of
 time to get used to.
    When you work with vertically split windows, consider adding a scrollbar on
 the left.  This can be done with a menu item, or with the 'guioptions' option:

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -419,7 +419,7 @@ abcdefghijklmnopqrstuvwxyz
 
 abcdefghijklmnSTRINGopqrstuvwxyz
 abc	      STRING  defghijklmnopqrstuvwxyz
-abcdef  ghi   STRING	jklmnopqrstuvwxyz
+abcdef  ghi   STRING  	jklmnopqrstuvwxyz
 abcdefghijklmnSTRINGopqrstuvwxyz
 
 2. fo<C-v>3j$ASTRING<ESC>					*v_b_A_example*

--- a/runtime/indent/python.vim
+++ b/runtime/indent/python.vim
@@ -2,7 +2,7 @@
 " Language:		Python
 " Maintainer:		Bram Moolenaar <Bram@vim.org>
 " Original Author:	David Bustos <bustos@caltech.edu>
-" Last Change:		2019 Feb 21
+" Last Change:		2021 May 26
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -191,7 +191,7 @@ function GetPythonIndent(lnum)
   if getline(a:lnum) =~ '^\s*\(elif\|else\)\>'
 
     " Unless the previous line was a one-liner
-    if getline(plnumstart) =~ '^\s*\(for\|if\|try\)\>'
+    if getline(plnumstart) =~ '^\s*\(for\|if\|elif\|try\)\>'
       return plindent
     endif
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2021 May 16
+" Last Change: 2021 May 18
 "
 " WORK IN PROGRESS - Only the basics work
 " Note: On MS-Windows you need a recent version of gdb.  The one included with
@@ -181,6 +181,15 @@ func s:CloseBuffers()
   unlet! s:gdbwin
 endfunc
 
+func s:CheckGdbRunning()
+  if nvim_get_chan_info(s:gdb_job_id) == {}
+    echoerr string(g:termdebugger) . ' exited unexpectedly'
+    call s:CloseBuffers()
+    return ''
+  endif
+  return 'ok'
+endfunc
+
 func s:StartDebug_term(dict)
   " Open a terminal window without a job, to run the debugged program in.
   execute s:vertical ? 'vnew' : 'new'
@@ -229,7 +238,7 @@ func s:StartDebug_term(dict)
   let gdb_args = get(a:dict, 'gdb_args', [])
   let proc_args = get(a:dict, 'proc_args', [])
 
-  let cmd = [g:termdebugger, '-quiet', '-tty', pty] + gdb_args
+  let cmd = [g:termdebugger, '-quiet', '-tty', pty, '--eval-command', 'echo startupdone\n'] + gdb_args
   "call ch_log('executing "' . join(cmd) . '"')
   execute 'new'
   let s:gdb_job_id = termopen(cmd, {'on_exit': function('s:EndTermDebug')})
@@ -246,9 +255,28 @@ func s:StartDebug_term(dict)
   let s:gdbbuf = gdb_job_info['buffer']
   let s:gdbwin = win_getid(winnr())
 
-  " Set arguments to be run.  First wait a bit to make detecting gdb a bit
-  " more reliable.
-  sleep 200m
+  " Wait for the "startupdone" message before sending any commands.
+  let try_count = 0
+  while 1
+    if s:CheckGdbRunning() != 'ok'
+      return
+    endif
+
+    for lnum in range(1, 200)
+      if term_getline(s:gdbbuf, lnum) =~ 'startupdone'
+	  let try_count = 9999
+	  break
+      endif
+    endfor
+    let try_count += 1
+    if try_count > 300
+      " done or give up after five seconds
+      break
+    endif
+    sleep 10m
+  endwhile
+
+  " Set arguments to be run.
   if len(proc_args)
     call chansend(s:gdb_job_id, 'set args ' . join(proc_args) . "\r")
   endif
@@ -260,9 +288,7 @@ func s:StartDebug_term(dict)
   " why the debugger doesn't work.
   let try_count = 0
   while 1
-    if nvim_get_chan_info(s:gdb_job_id) == {}
-      echoerr string(g:termdebugger) . ' exited unexpectedly'
-      call s:CloseBuffers()
+    if s:CheckGdbRunning() != 'ok'
       return
     endif
 

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Jan 11
+" Last Change:	2021 May 24
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -413,6 +413,9 @@ if exists("c_autodoc")
   syn cluster cCommentGroup add=cAutodocReal
   syn cluster cPreProcGroup add=cAutodocReal
 endif
+
+" be able to fold #pragma regions
+syn region	cPragma		start="^\s*#pragma\s\+region\>" end="^\s*#pragma\s\+endregion\>" transparent keepend extend fold
 
 " Highlight User Labels
 syn cluster	cMultiGroup	contains=cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserCont,cUserLabel,cBitField,cOctalZero,cCppOutWrapper,cCppInWrapper,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom,cCppParen,cCppBracket,cCppString

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -2,7 +2,7 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2021 Jan 12
+" Last Change:	2021 May 04
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -44,33 +44,45 @@ if !exists("cpp_no_cpp11")
   syn keyword cppConstant	ATOMIC_WCHAR_T_LOCK_FREE ATOMIC_SHORT_LOCK_FREE
   syn keyword cppConstant	ATOMIC_INT_LOCK_FREE ATOMIC_LONG_LOCK_FREE
   syn keyword cppConstant	ATOMIC_LLONG_LOCK_FREE ATOMIC_POINTER_LOCK_FREE
-  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
+  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"\(sv\|s\|_[_a-zA-Z][_a-zA-Z0-9]*\)\=+ contains=@Spell
   syn match cppCast		"\<\(const\|static\|dynamic\)_pointer_cast\s*<"me=e-1
   syn match cppCast		"\<\(const\|static\|dynamic\)_pointer_cast\s*$"
 endif
 
 " C++ 14 extensions
 if !exists("cpp_no_cpp14")
-  syn case ignore
-  syn match cppNumber		display "\<0b[01]\('\=[01]\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-  syn match cppNumber		display "\<[1-9]\('\=\d\+\)*\(u\=l\{0,2}\|ll\=u\)\>" contains=cFloat
-  syn match cppNumber		display "\<0x\x\('\=\x\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-  syn case match
-endif
-
-" C++ 20 extensions
-if !exists("cpp_no_cpp20")
-  syn keyword cppStatement	co_await co_return co_yield requires
-  syn keyword cppStorageClass	consteval constinit
-  syn keyword cppStructure	concept
-  syn keyword cppType		char8_t
-  syn keyword cppModule		import module export
+  syn match cppNumbers		display transparent "\<\d\|\.\d" contains=cppNumber,cppFloat
+  syn match cppNumber		display contained "\<0\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<[1-9]\('\=\d\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0\o\+\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0b[01]\('\=[01]\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0x\x\('\=\x\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\d\+\.\d*\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\.\d\+\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\d\+e[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn region cppString		start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"\(sv\|s\|_\i*\)\=+ end='$' contains=cSpecial,cFormat,@Spell
 endif
 
 " C++ 17 extensions
 if !exists("cpp_no_cpp17")
   syn match cppCast		"\<reinterpret_pointer_cast\s*<"me=e-1
   syn match cppCast		"\<reinterpret_pointer_cast\s*$"
+  syn match cppFloat		display contained "\<0x\x*\.\x\+p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<0x\x\+\.\=p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+endif
+
+" C++ 20 extensions
+if !exists("cpp_no_cpp20")
+  syn match cppNumber		display contained "\<0\(y\|d\)\>"
+  syn match cppNumber		display contained "\<[1-9]\('\=\d\+\)*\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0\o\+\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0b[01]\('\=[01]\+\)*\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0x\x\('\=\x\+\)*\(y\|d\)\>"
+  syn keyword cppStatement	co_await co_return co_yield requires
+  syn keyword cppStorageClass	consteval constinit
+  syn keyword cppStructure	concept
+  syn keyword cppType		char8_t
+  syn keyword cppModule		import module export
 endif
 
 " The minimum and maximum operators in GNU C++
@@ -90,7 +102,9 @@ hi def link cppBoolean		Boolean
 hi def link cppConstant		Constant
 hi def link cppRawStringDelimiter	Delimiter
 hi def link cppRawString		String
+hi def link cppString		String
 hi def link cppNumber		Number
+hi def link cppFloat		Number
 hi def link cppModule		Include
 
 let b:current_syntax = "cpp"

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Nov 24, 2020
-" Version:		196
+" Last Change:		Feb 18, 2021
+" Version:		198
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from Eric Brunet (eric.brunet@ens.fr) and heredoc fixes from Felipe Contreras
@@ -13,33 +13,35 @@ if exists("b:current_syntax")
   finish
 endif
 
-" trying to answer the question: which shell is /bin/sh, really?
-" If the user has not specified any of g:is_kornshell, g:is_bash, g:is_posix, g:is_sh, then guess.
-if getline(1) =~ '\<ksh$'
+" If the shell script itself specifies which shell to use, use it
+if getline(1) =~ '\<ksh\>'
  let b:is_kornshell = 1
-elseif getline(1) =~ '\<bash$'
+elseif getline(1) =~ '\<bash\>'
  let b:is_bash      = 1
-elseif getline(1) =~ '\<dash$'
+elseif getline(1) =~ '\<dash\>'
  let b:is_dash      = 1
 elseif !exists("g:is_kornshell") && !exists("g:is_bash") && !exists("g:is_posix") && !exists("g:is_sh") && !exists("g:is_dash")
+ " user did not specify which shell to use, and 
+ " the script itself does not specify which shell to use. FYI: /bin/sh is ambiguous.
+ " Assuming /bin/sh is executable, and if its a link, find out what it links to.
  let s:shell = ""
  if executable("/bin/sh")
   let s:shell = resolve("/bin/sh")
  elseif executable("/usr/bin/sh")
   let s:shell = resolve("/usr/bin/sh")
  endif
- if     s:shell =~ 'ksh$'
+ if     s:shell =~ '\<ksh\>'
   let b:is_kornshell= 1
- elseif s:shell =~ 'bash$'
+ elseif s:shell =~ '\<bash\>'
   let b:is_bash = 1
- elseif s:shell =~ 'dash$'
+ elseif s:shell =~ '\<dash\>'
   let b:is_dash = 1
  endif
  unlet s:shell
 endif
 
 " handling /bin/sh with is_kornshell/is_sh {{{1
-" b:is_sh is set when "#! /bin/sh" is found;
+" b:is_sh will be set when "#! /bin/sh" is found;
 " However, it often is just a masquerade by bash (typically Linux)
 " or kornshell (typically workstations with Posix "sh").
 " So, when the user sets "g:is_bash", "g:is_kornshell",
@@ -98,12 +100,14 @@ if g:sh_fold_enabled && &fdm == "manual"
  setl fdm=syntax
 endif
 
-" set up the syntax-highlighting iskeyword
+" set up the syntax-highlighting for iskeyword
 if (v:version == 704 && has("patch-7.4.1142")) || v:version > 704
- if exists("b:is_bash")
-  exe "syn iskeyword ".&iskeyword.",-,:"
- else
-  exe "syn iskeyword ".&iskeyword.",-"
+ if !exists("g:sh_syntax_isk") || (exists("g:sh_syntax_isk") && g:sh_syntax_isk)
+  if exists("b:is_bash")
+   exe "syn iskeyword ".&iskeyword.",-,:"
+  else
+   exe "syn iskeyword ".&iskeyword.",-"
+  endif
  endif
 endif
 
@@ -374,12 +378,11 @@ elseif !exists("g:sh_no_error")
  syn region  shExDoubleQuote	matchGroup=Error start=+\$"+ skip=+\\\\\|\\.+ end=+"+	contains=shStringSpecial
 endif
 syn region  shSingleQuote	matchgroup=shQuote start=+'+ end=+'+		contains=@Spell	nextgroup=shSpecialStart,shSpecialSQ
-syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\.+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell	nextgroup=shSpecialStart
-syn region  shDoubleQuote	matchgroup=shQuote start=+"+ matchgroup=shSpecial skip=+\\"+ matchgroup=shQuote end=+"+		contained	contains=@shDblQuoteList,shStringSpecial,@Spell	nextgroup=shSpecialStart
+syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\.+ end=+"+			contains=@shDblQuoteList,shStringSpecial,@Spell	nextgroup=shSpecialStart
 syn match   shStringSpecial	"[^[:print:] \t]"			contained
-syn match   shStringSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"			nextgroup=shComment
-syn match   shSpecialSQ	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"		contained	nextgroup=shBkslshSnglQuote,@shNoZSList
-syn match   shSpecialDQ	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"		contained	nextgroup=shBkslshDblQuote,@shNoZSList
+syn match   shStringSpecial	"[^\\]\zs\%(\\\\\)*\(\\[\\"'`$()#]\)\+"			nextgroup=shComment
+syn match   shSpecialSQ	"[^\\]\zs\%(\\\\\)*\(\\[\\"'`$()#]\)\+"		contained	nextgroup=shBkslshSnglQuote,@shNoZSList
+syn match   shSpecialDQ	"[^\\]\zs\%(\\\\\)*\(\\[\\"'`$()#]\)\+"		contained	nextgroup=shBkslshDblQuote,@shNoZSList
 syn match   shSpecialStart	"\%(\\\\\)*\\[\\"'`$()#]"			contained	nextgroup=shBkslshSnglQuote,shBkslshDblQuote,@shNoZSList
 syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"
 syn match   shSpecialNoZS	contained	"\%(\\\\\)*\\[\\"'`$()#]"
@@ -402,6 +405,7 @@ syn match	shQuickComment	contained	"#.*$"
 syn match	shBQComment	contained	"#.\{-}\ze`"	contains=@shCommentGroup
 
 " Here Documents: {{{1
+"  (modified by Felipe Contreras)
 " =========================================
 ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc01 start="<<\s*\z([^ \t|>]\+\)"		matchgroup=shHereDoc01 end="^\z1\s*$"	contains=@shDblQuoteList
 ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc02 start="<<-\s*\z([^ \t|>]\+\)"		matchgroup=shHereDoc02 end="^\s*\z1\s*$"	contains=@shDblQuoteList

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -149,7 +149,7 @@ syn match vimNumber	'\<0[xX]\x\+'		       skipwhite nextgroup=vimGlobal,vimSubst
 syn match vimNumber	'\%(^\|\A\)\zs#\x\{6}'             	       skipwhite nextgroup=vimGlobal,vimSubst,vimCommand,vimComment,vim9Comment
 syn match vimNumber	'\<0[zZ][a-zA-Z0-9.]\+'                    skipwhite nextgroup=vimGlobal,vimSubst,vimCommand,vimComment,vim9Comment
 syn match vimNumber	'0[0-7]\+'		       skipwhite nextgroup=vimGlobal,vimSubst,vimCommand,vimComment,vim9Comment           
-syn match vimNumber	'0b[01]\+'		       skipwhite nextgroup=vimGlobal,vimSubst,vimCommand,vimComment,vim9Comment           
+syn match vimNumber	'0[bB][01]\+'		       skipwhite nextgroup=vimGlobal,vimSubst,vimCommand,vimComment,vim9Comment           
 
 " All vimCommands are contained by vimIsCommand. {{{2
 syn match vimCmdSep	"[:|]\+"	skipwhite nextgroup=vimAddress,vimAutoCmd,vimEcho,vimIsCommand,vimExtCmd,vimFilter,vimLet,vimMap,vimMark,vimSet,vimSyntax,vimUserCmd
@@ -355,8 +355,8 @@ syn match	vimCmplxRepeat	'[^a-zA-Z_/\\()]q[0-9a-zA-Z"]\>'lc=1
 syn match	vimCmplxRepeat	'@[0-9a-z".=@:]\ze\($\|[^a-zA-Z]\>\)'
 
 " Set command and associated set-options (vimOptions) with comment {{{2
-syn region	vimSet		matchgroup=vimCommand start="\<\%(setl\%[ocal]\|setg\%[lobal]\|se\%[t]\)\>" skip="\%(\\\\\)*\\." end="$" end="|" matchgroup=vimNotation end="<[cC][rR]>" keepend oneline contains=vimSetEqual,vimOption,vimErrSetting,vimComment,vim9Comment,vimSetString,vimSetMod
-syn region	vimSetEqual	contained	start="[=:]\|[-+^]=" skip="\\\\\|\\\s" end="[| \t]\|$"me=e-1	contains=vimCtrlChar,vimSetSep,vimNotation,vimEnvvar oneline
+syn region	vimSet		matchgroup=vimCommand start="\<\%(setl\%[ocal]\|setg\%[lobal]\|se\%[t]\)\>" skip="\%(\\\\\)*\\." end="$" end="|" matchgroup=vimNotation end="<[cC][rR]>" oneline keepend contains=vimSetEqual,vimOption,vimErrSetting,vimComment,vim9Comment,vimSetString,vimSetMod
+syn region	vimSetEqual	contained	start="[=:]\|[-+^]=" skip="\\\\\|\\\s" end="[| \t]"me=e-1 end="$"	contains=vimCtrlChar,vimSetSep,vimNotation,vimEnvvar
 syn region	vimSetString	contained	start=+="+hs=s+1	skip=+\\\\\|\\"+  end=+"+		contains=vimCtrlChar
 syn match	vimSetSep	contained	"[,:]"
 syn match	vimSetMod	contained	"&vim\=\|[!&?<]\|all&"
@@ -435,7 +435,8 @@ syn match vimFunc		"\%(\%([sSgGbBwWtTlL]:\|<[sS][iI][dD]>\)\=\%(\w\+\.\)*\I[a-zA
 syn match vimUserFunc contained	"\%(\%([sSgGbBwWtTlL]:\|<[sS][iI][dD]>\)\=\%(\w\+\.\)*\I[a-zA-Z0-9_.]*\)\|\<\u[a-zA-Z0-9.]*\>\|\<if\>"	contains=vimNotation
 
 " User Command Highlighting: {{{2
-syn match vimUsrCmd	'^\s*\zs\u\w*.*$'
+"syn match vimUsrCmd	'^\s*\zs\u\w*.*$'
+syn match vimUsrCmd	'^\s*\zs\u\%(\w*\)\@>\%([(#[]\|\s\+\%([-+*/%]\=\|\.\.\)=\)\@!'
 
 " Errors And Warnings: {{{2
 " ====================
@@ -573,7 +574,7 @@ syn case match
 syn match	vimHiAttribList	contained	"\i\+"	contains=vimHiAttrib
 syn match	vimHiAttribList	contained	"\i\+,"he=e-1	contains=vimHiAttrib nextgroup=vimHiAttribList
 syn case ignore
-syn keyword	vimHiCtermColor	contained	black blue brown cyan darkblue darkcyan darkgray darkgreen darkgrey darkmagenta darkred darkyellow gray green grey lightblue lightcyan lightgray lightgreen lightgrey lightmagenta lightred magenta red white yellow
+syn keyword	vimHiCtermColor	contained	black blue brown cyan darkblue darkcyan darkgray darkgreen darkgrey darkmagenta darkred darkyellow gray green grey grey40 grey50 grey90 lightblue lightcyan lightgray lightgreen lightgrey lightmagenta lightred lightyellow magenta red seagreen white yellow
 syn match	vimHiCtermColor	contained	"\<color\d\{1,3}\>"
 
 syn case match


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/d2ea7cf10a4d026ebd402594d656af7d5c811c24


First time trying to merge a patch from vim :D, please do let me know if something isn't right.

- I didn't port the changes from tutor https://github.com/vim/vim/commit/d2ea7cf10a4d026ebd402594d656af7d5c811c24#diff-99ebc6b7f456528df8d873c46f34540b01652103e104b9195cb9a0b0d7e8a7bd (tracked it down to this file https://github.com/stsewd/neovim/blob/0b4c53fc23581abb14b6d4c567dc08720f509020/runtime/tutor/en/vim-01-beginner.tutor#L907-L907, should I update it here?)
- Didn't port a recommendation about truecolors and tmux https://github.com/vim/vim/commit/d2ea7cf10a4d026ebd402594d656af7d5c811c24#diff-e891ea60176f3f0bf0aa9bcd13c22cdb77f377ea932fe9515f5e0b16df8740da, other references to that part  haven't been ported, so I skipped it as well.
- The changes in termdebug I just followed what logically looks the same, I don't use that plugin.
- vim.vim had more changes but just left what the tool was able to patch, same as https://github.com/neovim/neovim/commit/b1cd67b62e58c7f7d4139416e6813f8f50bc0fd6#diff-7a82881606d3861674909df27974e1c38c3e031d00f486ca01ccff1d9bceed0f