### PR TITLE
BugFix: Memory error double free

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1820,7 +1820,6 @@ static bool do_user_initialization(void)
     }
 
     xfree(vimrc_path);
-    xfree(init_lua_path);
     return false;
   }
   xfree(init_lua_path);


### PR DESCRIPTION
init_lua_path was cleared twice in main.c:1823 & main.c:1826

I'm wondering why didn't asan reporte this...