### PR TITLE
functionaltest: fix running tests under gdbserver

### DIFF
--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -278,8 +278,9 @@ describe('server -> client', function()
     local nvim_argv = merge_args(helpers.nvim_argv, {'--headless'})
     local function connect_test(server, mode, address)
       local serverpid = funcs.getpid()
-      local client = spawn(nvim_argv)
-      set_session(client, true)
+      local client = spawn(nvim_argv, false, nil, true)
+      set_session(client)
+
       local clientpid = funcs.getpid()
       neq(serverpid, clientpid)
       local id = funcs.sockconnect(mode, address, {rpc=true})
@@ -288,7 +289,7 @@ describe('server -> client', function()
       funcs.rpcrequest(id, 'nvim_set_current_line', 'hello')
       local client_id = funcs.rpcrequest(id, 'nvim_get_api_info')[1]
 
-      set_session(server, true)
+      set_session(server)
       eq(serverpid, funcs.getpid())
       eq('hello', meths.get_current_line())
 
@@ -296,7 +297,7 @@ describe('server -> client', function()
       funcs.rpcrequest(client_id, 'nvim_set_current_line', 'howdy!')
       eq(id, funcs.rpcrequest(client_id, 'nvim_get_api_info')[1])
 
-      set_session(client, true)
+      set_session(client)
       eq(clientpid, funcs.getpid())
       eq('howdy!', meths.get_current_line())
 

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -29,11 +29,11 @@ describe('channels', function()
   end)
 
   pending('can connect to socket', function()
-    local server = spawn(nvim_argv)
+    local server = spawn(nvim_argv, nil, nil, true)
     set_session(server)
     local address = funcs.serverlist()[1]
-    local client = spawn(nvim_argv)
-    set_session(client, true)
+    local client = spawn(nvim_argv, nil, nil, true)
+    set_session(client)
     source(init)
 
     meths.set_var('address', address)
@@ -42,11 +42,11 @@ describe('channels', function()
     ok(id > 0)
 
     command("call chansend(g:id, msgpackdump([[2,'nvim_set_var',['code',23]]]))")
-    set_session(server, true)
+    set_session(server)
     retry(nil, 1000, function()
       eq(23, meths.get_var('code'))
     end)
-    set_session(client, true)
+    set_session(client)
 
     command("call chansend(g:id, msgpackdump([[0,0,'nvim_eval',['2+3']]]))")
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -96,10 +96,7 @@ function module.get_session()
   return session
 end
 
-function module.set_session(s, keep)
-  if session and not keep then
-    session:close()
-  end
+function module.set_session(s)
   session = s
 end
 
@@ -366,7 +363,11 @@ local function remove_args(args, args_rm)
   return new_args
 end
 
-function module.spawn(argv, merge, env)
+function module.spawn(argv, merge, env, keep)
+  if session and not keep then
+    session:close()
+  end
+
   local child_stream = ChildProcessStream.spawn(
       merge and module.merge_args(prepend_argv, argv) or argv,
       env)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2026,6 +2026,8 @@ describe('lua stdlib', function()
         -- Would wait ten seconds if results blocked.
         wait_result = vim.wait(10000, function() return vim.g.timer_result end)
 
+        timer:close()
+
         return {
           time = (start_time + 5) > get_time(),
           wait_result = wait_result,
@@ -2044,6 +2046,8 @@ describe('lua stdlib', function()
         end))
 
         wait_result = vim.wait(300, function() return vim.g.timer_result end, nil, true)
+
+        timer:close()
 
         return {
           wait_result = wait_result,


### PR DESCRIPTION
It was not possible to run the tests under the gdbserver because we were
not closing the old session before starting a new one. This caused the
server to not to be able to bind to the given address and crashing the
tests.

This commit closes the old session before starting a new one.