### PR TITLE
[RDY] fix(ci): Fix OpenBSD CI by altering dep build path

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,17 +1,17 @@
 # sourcehut CI: https://builds.sr.ht/~jmk/neovim
 
-image: openbsd/6.7
+image: openbsd/6.9
 
 packages:
-- autoconf-2.69p2
-- automake-1.15.1
+- autoconf-2.71
+- automake-1.16.3
 - cmake
-- gettext-runtime-0.20.1p1
-- gettext-tools-0.20.1p3
+- gettext-runtime-0.21p1
+- gettext-tools-0.21p1
 - gmake
 - libtool
-- ninja-1.10.0
-- unzip-6.0p13
+- ninja-1.10.2p0
+- unzip-6.0p14
 
 sources:
 - https://github.com/neovim/neovim
@@ -23,8 +23,8 @@ environment:
 
 tasks:
 - build-deps: |
-    export AUTOCONF_VERSION=2.69
-    export AUTOMAKE_VERSION=1.15
+    export AUTOCONF_VERSION=2.71
+    export AUTOMAKE_VERSION=1.16
     mkdir neovim/.deps
     cd neovim/.deps
     cmake -G Ninja ../third-party/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,23 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Prefer our bundled versions of dependencies.
 if(DEFINED ENV{DEPS_BUILD_DIR})
-  set(DEPS_PREFIX "$ENV{DEPS_BUILD_DIR}/usr" CACHE PATH "Path prefix for finding dependencies")
+  if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+    # pkg-config 29.2 has a bug on OpenBSD which causes it to drop any paths that
+    # *contain* system include paths. To avoid this, we prefix what would be
+    # "/usr/include" as "/_usr/include".
+    # This check is also performed in the third-party/CMakeLists.txt and in the
+    # else clause following here.
+    # https://github.com/neovim/neovim/pull/14745#issuecomment-860201794
+    set(DEPS_PREFIX "$ENV{DEPS_BUILD_DIR}/_usr" CACHE PATH "Path prefix for finding dependencies")
+  else()
+    set(DEPS_PREFIX "$ENV{DEPS_BUILD_DIR}/usr" CACHE PATH "Path prefix for finding dependencies")
+  endif()
 else()
-  set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/usr" CACHE PATH "Path prefix for finding dependencies")
+  if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+    set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/_usr" CACHE PATH "Path prefix for finding dependencies")
+  else()
+    set(DEPS_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/.deps/usr" CACHE PATH "Path prefix for finding dependencies")
+  endif()
   # When running from within CLion or Visual Studio,
   # build bundled dependencies automatically.
   if(NOT EXISTS ${DEPS_PREFIX}

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -21,7 +21,17 @@ if(HAS_OG_FLAG)
   set(DEFAULT_MAKE_CFLAGS CFLAGS+=-Og ${DEFAULT_MAKE_CFLAGS})
 endif()
 
-set(DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/usr" CACHE PATH "Dependencies install directory.")
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  # pkg-config 29.2 has a bug on OpenBSD which causes it to drop any paths that
+  # *contain* system include paths. To avoid this, we prefix what would be
+  # "/usr/include" as "/_usr/include".
+  # This check is also performed in the root CMakeLists.txt
+  # https://github.com/neovim/neovim/pull/14745#issuecomment-860201794
+  set(DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/_usr" CACHE PATH "Dependencies install directory.")
+else()
+  set(DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/usr" CACHE PATH "Dependencies install directory.")
+endif()
+
 set(DEPS_BIN_DIR "${DEPS_INSTALL_DIR}/bin" CACHE PATH "Dependencies binary install directory.")
 set(DEPS_LIB_DIR "${DEPS_INSTALL_DIR}/lib" CACHE PATH "Dependencies library install directory.")
 set(DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build" CACHE PATH "Dependencies build directory.")


### PR DESCRIPTION
**What**

Detect OpenBSD host in `third-party/CMakeLists.txt` and `CMakeLists.txt` and adjust  `DEPS_INSTALL_DIR` and `DEPS_PREFIX` respectively.

**Why**

This fix applies a work around to OpenBSD's `pkg-config` which drops any path that ends in `/usr/include` (i.e: `/home/ci/neovim/.deps/usr/include/`).

The patch is a bit of a hack, someone with better knowledge of the CI system may have a better solution (Setting up a `DEP_USR_DIR` var?).

This PR is mostly to check if the patch works in the CI environment, it does in my virtual box.

You actually should be able to set `PKG_CONFIG_SYSTEM_INCLUDE_PATH` to something else to avoid the discarding but it doesn't seem to work.

See also https://github.com/neovim/neovim/pull/14745 for more details.
