### PR TITLE
fix(lsp): replace --- by a line in stylize_markdown

### DIFF
--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -8,12 +8,10 @@
 " markdown.vim syntax files
 execute 'source' expand('<sfile>:p:h') .. '/markdown.vim'
 
-syn cluster mkdNonListItem add=mkdEscape,mkdNbsp,mkdLine
+syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
 
 syntax region mkdEscape matchgroup=mkdEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/.\zs/ keepend contains=mkdEscapeCh oneline concealends
 syntax match mkdEscapeCh /./ contained
 syntax match mkdNbsp /&nbsp;/ conceal cchar= 
-syntax match mkdLine /---/ conceal cchar= 
-syntax match markdownH2 "" contained
 
 hi def link mkdEscape special


### PR DESCRIPTION
Currently only added seperators were replaced by lines.

This PR additionally replaces existing markdown lines by lines **ONLY** in markdown regions.