### PR TITLE
doc(lsp): Clarify opts for show_line_diagnostics()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1550,6 +1550,10 @@ show_line_diagnostics({opts}, {bufnr}, {line_nr}, {client_id})
                     {opts}       table Configuration table
                                  • show_header (boolean, default true): Show
                                    "Diagnostics:" header.
+                                 • Plus all the opts for
+                                   |vim.lsp.diagnostic.get_line_diagnostics()|
+                                   and |vim.lsp.util.open_floating_preview()|
+                                   can be used here.
                     {bufnr}      number The buffer number
                     {line_nr}    number The line number
                     {client_id}  number|nil the client id

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1123,6 +1123,8 @@ end
 --- </pre>
 ---@param opts table Configuration table
 ---     - show_header (boolean, default true): Show "Diagnostics:" header.
+---     - Plus all the opts for |vim.lsp.diagnostic.get_line_diagnostics()|
+---          and |vim.lsp.util.open_floating_preview()| can be used here.
 ---@param bufnr number The buffer number
 ---@param line_nr number The line number
 ---@param client_id number|nil the client id


### PR DESCRIPTION
Specifying what opts are for `vim.lsp.diagnostics.show_line_diagnostics()`

closes #14816 

@jdhao @mjlbach is this ok ?