### PR TITLE
ci: move openbsd image to latest

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,6 +1,6 @@
 # sourcehut CI: https://builds.sr.ht/~jmk/neovim
 
-image: openbsd/6.7
+image: openbsd/latest
 
 packages:
 - autoconf-2.69p2


### PR DESCRIPTION
This avoids the need to manually bump the version when sourcehut drops a
given version, at the expense of having to maybe fix something when
latest is updated to point at something else.

6.7 has been dropped from sourcehut and prompted this commit.