### PR TITLE
fix(lua): opt appending/prepending onto {""}

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -422,6 +422,12 @@ local prepend_value = (function()
     end,
 
     [OptionTypes.ARRAY] = function(left, right)
+      -- prevent prepending before ""
+      -- https://github.com/neovim/neovim/issues/14828
+      if #left == 1 and left[1] == "" then
+        left = {}
+      end
+
       for i = #right, 1, -1 do
         table.insert(left, 1, right[i])
       end

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -463,6 +463,12 @@ local add_value = (function()
     end,
 
     [OptionTypes.ARRAY] = function(left, right)
+      -- prevent appending onto "" default values
+      -- https://github.com/neovim/neovim/issues/14828
+      if #left == 1 and left[1] == "" then
+        left = {}
+      end
+
       for _, v in ipairs(right) do
         table.insert(left, v)
       end


### PR DESCRIPTION
**What**

When setting an option via `:append` or `:prepend`, check if the table contains only the default `""` value and ignore it if so.

**Why**

Calling `lua vim.opt.wildignore:append{'*.foo', '*.bar'}` ends up appending onto the default `{""}` table, which breaks the option because it ends up being ", *.foo, *.bar".

This patch may have unforseen consequences, I am don't know vim's options enough to know if sometimes having `x=,a,b,c` is what you want, probably not? Also not included are specific tests, can add if PR has interest.

See also: https://github.com/neovim/neovim/issues/14828