### PR TITLE
Fix #8696

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -917,13 +917,19 @@ char *vim_getenv(const char *name)
   }
 #endif
 
+  bool vimruntime = (strcmp(name, "VIMRUNTIME") == 0);
+  bool vimenv = (strcmp(name, "VIM") == 0);
+  bool in_vimterm = (os_getenv("VIM_TERMINAL") != NULL);
+
   const char *kos_env_path = os_getenv(name);
-  if (kos_env_path != NULL) {
+  // VIM or VIMRUNTIME need to be set when run in vim terminal
+  if (kos_env_path != NULL
+      && !((vimruntime && in_vimterm) || (vimenv && in_vimterm))
+      ) {
     return xstrdup(kos_env_path);
   }
 
-  bool vimruntime = (strcmp(name, "VIMRUNTIME") == 0);
-  if (!vimruntime && strcmp(name, "VIM") != 0) {
+  if (!vimruntime && !vimenv) {
     return NULL;
   }
 
@@ -936,7 +942,7 @@ char *vim_getenv(const char *name)
 #endif
       ) {
     kos_env_path = os_getenv("VIM");
-    if (kos_env_path != NULL) {
+    if (kos_env_path != NULL && !in_vimterm) {
       vim_path = vim_version_dir(kos_env_path);
       if (vim_path == NULL) {
         vim_path = xstrdup(kos_env_path);

--- a/test/functional/eval/environ_spec.lua
+++ b/test/functional/eval/environ_spec.lua
@@ -78,3 +78,50 @@ describe('empty $HOME', function()
     write_and_test_tilde()
   end)
 end)
+
+describe('inside $VIM_TERMINAL', function()
+  local vimterminal = os.getenv("VIM_TERMINAL")
+  local vimruntime = os.getenv("VIMRUNTIME")
+  local vimenv = os.getenv("VIM")
+  local fake_vimterminal = "802"
+  local fake_vimruntime = "/usr/share/vim/vim82"
+  local fake_vimenv = "/usr/share/vim"
+
+  --recover $VIM_TERMINAL, $VIMRUNTIME, $VIM after each test
+  after_each(function()
+    if vimterminal ~= nil then
+      setenv('VIM_TERMINAL', vimterminal)
+    else
+      setenv('VIM_TERMINAL', "")
+    end
+
+    if vimruntime ~= nil then
+      setenv('VIMRUNTIME', vimruntime)
+    else
+      setenv('VIMRUNTIME', "")
+    end
+
+    if vimenv ~= nil then
+      setenv('VIM', vimenv)
+    else
+      setenv('VIM', "")
+    end
+  end)
+
+  -- fake a VIM_TERMINAL environment
+  local function fake_vim_terminal_env()
+    setenv("VIM_TERMINAL", fake_vimterminal)
+    setenv("VIMRUNTIME", fake_vimruntime)
+    setenv("VIM", fake_vimenv)
+  end
+
+  -- check if $VIMRUNTIME/$VIM is explictly set
+  local function test_vimruntime()
+    return (eval("$VIMRUNTIME") ~= fake_vimruntime) and (eval("$VIM") ~= fake_vimenv)
+  end
+
+  it("When $VIM_TERMINAL set, VIM/VIMRUNTIME need to be set explicitly", function()
+    fake_vim_terminal_env()
+    eq(true, test_vimruntime())
+  end)
+end)


### PR DESCRIPTION
It set VIM/VIMRUNTIME correctly for neovim running inside of a vim's terminal
This could resolve https://github.com/neovim/neovim/issues/8696