### PR TITLE
vim-patch:8.2.3012: when 'rightleft' is set the line number is drawn …

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2757,8 +2757,9 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
               }
               if (wp->w_p_rl) {                       // reverse line numbers
                 // like rl_mirror(), but keep the space at the end
-                char_u *p2 = skiptowhite(extra) - 1;
-                for (char_u *p1 = extra; p1 < p2; p1++, p2--) {
+                char_u *p2 = skipwhite(extra);
+                p2 = skiptowhite(p2) - 1;
+                for (char_u *p1 = skipwhite(extra); p1 < p2; p1++, p2--) {
                   const int t = *p1;
                   *p1 = *p2;
                   *p2 = t;

--- a/src/nvim/testdir/test_number.vim
+++ b/src/nvim/testdir/test_number.vim
@@ -1,5 +1,6 @@
 " Test for 'number' and 'relativenumber'
 
+source check.vim
 source view_util.vim
 
 func s:screen_lines(start, end) abort
@@ -263,3 +264,27 @@ func Test_relativenumber_uninitialised()
   redraw
   bwipe!
 endfunc
+
+" Test for displaying line numbers with 'rightleft'
+func Test_number_rightleft()
+  CheckFeature rightleft
+  new
+  setlocal number
+  setlocal rightleft
+  call setline(1, range(1, 1000))
+  normal! 9Gzt
+  redraw!
+  call assert_match('^\s\+9 9$', Screenline(1))
+  normal! 10Gzt
+  redraw!
+  call assert_match('^\s\+01 10$', Screenline(1))
+  normal! 100Gzt
+  redraw!
+  call assert_match('^\s\+001 100$', Screenline(1))
+  normal! 1000Gzt
+  redraw!
+  call assert_match('^\s\+0001 1000$', Screenline(1))
+  bw!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
…reversed

Problem:    When 'rightleft' is set the line number is sometimes drawn
            reversed.
Solution:   Adjust how space is handled. (Christian Brabandt, closes vim/vim#8389,
            closes vim/vim#8391)
https://github.com/vim/vim/commit/29f0dc3689eafcf7888e06d57d1cf79e62c5c148