### PR TITLE
fix(clipboard): Fix block paste from system clipboard not working properly

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -156,7 +156,14 @@ function! s:clipboard.get(reg) abort
   elseif s:selections[a:reg].owner > 0
     return s:selections[a:reg].data
   end
-  return s:try_cmd(s:paste[a:reg])
+
+  let clipboard_data = s:try_cmd(s:paste[a:reg])
+  if match(&clipboard, '\v(unnamed|unnamedplus)') >= 0 && get(s:selections[a:reg].data, 0, []) == clipboard_data
+    " When system clipboard return is same as our cache return the cache
+    " as it contains regtype information
+    return s:selections[a:reg].data
+  end
+  return clipboard_data
 endfunction
 
 function! s:clipboard.set(lines, regtype, reg) abort
@@ -175,6 +182,9 @@ function! s:clipboard.set(lines, regtype, reg) abort
 
   if s:cache_enabled == 0
     call s:try_cmd(s:copy[a:reg], a:lines)
+    "Cache it anyway we can compare it later to get regtype of the yank
+    let s:selections[a:reg] = copy(s:selection)
+    let s:selections[a:reg].data = [a:lines, a:regtype]
     return 0
   end
 

--- a/test/functional/provider/clipboard_spec.lua
+++ b/test/functional/provider/clipboard_spec.lua
@@ -506,6 +506,20 @@ describe('clipboard (with fake clipboard.vim)', function()
       feed('p')
       eq('textstar', meths.get_current_line())
     end)
+
+    it('Block paste works currectly', function()
+      insert([[
+        aabbcc
+        ddeeff
+      ]])
+      feed('gg^<C-v>') -- Goto start of top line enter visual block mode
+      feed('3ljy^k') -- yank 4x2 block & goto initial location
+      feed('P') -- Paste it infront
+      expect([[
+        aabbaabbcc
+        ddeeddeeff
+      ]])
+    end)
   end)
 
   describe('clipboard=unnamedplus', function()


### PR DESCRIPTION
Block copy and paste from system-clipboard currently breaks formatting.
This fixes it.

The bug occurs because system-clipboard doesn't contain information
about what mode the copy was made.
Probably the simplest solution to this is we keep a cache of copy we last made along
with mode information. If system-clipboard returns the cache we apply
the mode information that we know about that cache.
This should fix copy pasting within neovim instence.

### Importent
This only works when you are copying and pasting within same neovim instance . Means If you try to block copy from one neovim instance to another formating will still break .

closes #1822