### PR TITLE
fix(doc): various fixes

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -913,22 +913,7 @@ This replaces an end-of-line with a new line containing the value of $HOME. >
 This replaces each 'E' character with a euro sign.  Read more in |<Char->|.
 
 
-4.3 Search and replace					*search-replace*
-
-							*:pro* *:promptfind*
-:promptf[ind] [string]
-			Put up a Search dialog.  When [string] is given, it is
-			used as the initial search string.
-			{only for Win32 GUI}
-
-						*:promptr* *:promptrepl*
-:promptr[epl] [string]
-			Put up a Search/Replace dialog.  When [string] is
-			given, it is used as the initial search string.
-			{only for Win32 GUI}
-
-
-4.4 Changing tabs					*change-tabs*
+4.3 Changing tabs					*change-tabs*
 							*:ret* *:retab* *:retab!*
 :[range]ret[ab][!] [new_tabstop]
 			Replace all sequences of white-space containing a

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -532,7 +532,6 @@ that see the '"' as part of their argument:
     :normal
     :ownsyntax
     :popup
-    :promptfind (and the like)
     :registers
     :return
     :sort
@@ -571,8 +570,6 @@ followed by another Vim command:
     :make
     :normal
     :perlfile
-    :promptfind
-    :promptrepl
     :pyfile
     :python
     :registers

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1457,8 +1457,6 @@ tag		command		action ~
 |:print|	:p[rint]	print lines
 |:profdel|	:profd[el]	stop profiling a function or script
 |:profile|	:prof[ile]	profiling functions and scripts
-|:promptfind|	:pro[mptfind]	open GUI dialog for searching
-|:promptrepl|	:promptr[epl]	open GUI dialog for search/replace
 |:pop|		:po[p]		jump to older entry in tag stack
 |:popup|	:popu[p]	popup a menu by name
 |:ppop|		:pp[op]		":pop" in preview window

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1201,6 +1201,7 @@ tag		command		action ~
 |:cgetfile|	:cg[etfile]	read file with error messages
 |:changes|	:changes	print the change list
 |:chdir|	:chd[ir]	change directory
+|:checkhealth|	:checkh[ealth]	run healthchecks
 |:checkpath|	:che[ckpath]	list included files
 |:checktime|	:checkt[ime]	check timestamp of loaded buffers
 |:chistory|	:chi[story]	list the error lists
@@ -1278,6 +1279,7 @@ tag		command		action ~
 |:endtry|	:endt[ry]	end previous :try
 |:endwhile|	:endw[hile]	end previous :while
 |:enew|		:ene[w]		edit a new, unnamed buffer
+|:eval|		:ev[al]		evaluate an expression and discard the result
 |:ex|		:ex		same as ":edit"
 |:execute|	:exe[cute]	execute result of expressions
 |:exit|		:exi[t]		same as ":xit"
@@ -1451,9 +1453,9 @@ tag		command		action ~
 |:packloadall|	:packl[oadall]	load all packages under 'packpath'
 |:pclose|	:pc[lose]	close preview window
 |:pedit|	:ped[it]	edit file in the preview window
-|:perl|		:perl		execute perl command
-|:perldo|	:perldo		execute perl command for each line
-|:perfile|	:perlfile	execute perl script file
+|:perl|		:pe[rl]		execute perl command
+|:perldo|	:perld[o]	execute perl command for each line
+|:perlfile|	:perlf[ile]	execute perl script file
 |:print|	:p[rint]	print lines
 |:profdel|	:profd[el]	stop profiling a function or script
 |:profile|	:prof[ile]	profiling functions and scripts
@@ -1535,7 +1537,6 @@ tag		command		action ~
 				buffer list
 |:scriptnames|	:scr[iptnames]	list names of all sourced Vim scripts
 |:scriptencoding| :scripte[ncoding]  encoding used in sourced Vim script
-|:scriptversion|  :scriptv[ersion]   version of Vim script used
 |:scscope|	:scs[cope]	split window and execute cscope command
 |:set|		:se[t]		show or set options
 |:setfiletype|	:setf[iletype]	set 'filetype', unless it was set already

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1547,8 +1547,6 @@ tag		command		action ~
 |:sign|		:sig[n]		manipulate signs
 |:silent|	:sil[ent]	run a command silently
 |:sleep|	:sl[eep]	do nothing for a few seconds
-|:sleep!|	:sl[eep]!	do nothing for a few seconds, without the
-				cursor visible
 |:slast|	:sla[st]	split window and go to last file in the
 				argument list
 |:smagic|	:sm[agic]	:substitute with 'magic'

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -855,7 +855,7 @@ Here is an example that counts the number of spaces with <F4>: >
 	    set clipboard= selection=inclusive
 	    let commands = #{line: "'[V']y", char: "`[v`]y", block: "`[\<c-v>`]y"}
 	    silent exe 'noautocmd keepjumps normal! ' .. get(commands, a:type, '')
-	    echom getreg('"')->count(' ')
+	    echom count(getreg('"'), ' ')
 	  finally
 	    call setreg('"', reg_save)
 	    call setpos("'<", visual_marks_save[0])

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -462,7 +462,7 @@ the current window, try this custom `:HelpCurwin` command:
 	    execute mods .. ' helpclose'
 	    let s:did_open_help = v:true
 	  endif
-	  if !getcompletion(a:subject, 'help')->empty()
+	  if !empty(getcompletion(a:subject, 'help'))
 	    execute mods .. ' edit ' .. &helpfile
 	  endif
 	  return 'help ' .. a:subject

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -506,7 +506,8 @@ gO			Show a filetype-specific, navigable "outline" of the
 			Queued messages are processed during the sleep.
 
 							*:sl!* *:sleep!*
-:[N]sl[eep]! [N] [m]	Same as above, but hide the cursor.
+:[N]sl[eep]! [N] [m]	Same as above. Unlike Vim, it does not hide the
+			cursor. |vim-differences|
 
 ==============================================================================
 2. Using Vim like less or more					*less*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -421,6 +421,8 @@ Commands:
   :mode (no longer accepts an argument)
   :open
   :Print
+  :promptfind
+  :promptrepl
   :shell
   :smile
   :tearoff

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -424,6 +424,7 @@ Commands:
   :promptfind
   :promptrepl
   :shell
+  :sleep! (does not hide the cursor; same as :sleep)
   :smile
   :tearoff
 


### PR DESCRIPTION
- Replace uses of method call syntax, as v8.1.1803 and friends aren't ported yet.
- Remove references to `:promptfind` and `:promptrepl` as they're N/A.
- Add `:eval` and `:checkhealth` to `index.txt` (`:eval` is also missing upstream _**Edit**: will be added in vim's next runtime update_).
- Fix `:perlfile` typo in `index.txt` and add the abbreviations for `:perl`, `:perlfile` and `:perldo`.
- Removes `:scriptversion` from `index.txt`, as that command isn't ported yet. (#14611)

This should cover all of the missing and unimplemented ex commands in `index.txt` and the uses of method calls elsewhere.

Closes #14847.