### PR TITLE
fix(lsp): fix severity_limit logic in set_loclist

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1214,9 +1214,9 @@ function M.set_loclist(opts)
     if severity then
       return d.severity == severity
     end
-    severity = to_severity(opts.severity_limit)
-    if severity then
-      return d.severity == severity
+    local severity_limit = to_severity(opts.severity_limit)
+    if severity_limit then
+      return d.severity <= severity_limit
     end
     return true
   end


### PR DESCRIPTION
`severity_limit` was doing the same thing as `severity` and preventing errors from appearing in my loclist