### PR TITLE
vim-patch:8.2.3020: unreachable code

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4184,10 +4184,6 @@ static char_u *invalid_range(exarg_T *eap)
         }
         break;
       case ADDR_UNSIGNED:
-        if (eap->line2 < 0) {
-          return (char_u *)_(e_invrange);
-        }
-        break;
       case ADDR_NONE:
         // Will give an error elsewhere.
         break;


### PR DESCRIPTION
Problem:    Unreachable code.
Solution:   Remove the code. (closes vim/vim#8406)
https://github.com/vim/vim/commit/2fb749568662c86992aea3b596458b9e470f223d