### PR TITLE
fix(runtime): Fix bugs regarding lua runtime files

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2665,7 +2665,8 @@ static void cmd_source_buffer(const exarg_T *eap)
   };
   if (curbuf != NULL && curbuf->b_fname
       && path_with_extension((const char *)curbuf->b_fname, "lua")) {
-    nlua_source_using_linegetter(get_buffer_line, (void *)&cookie, ":source");
+    nlua_source_using_linegetter(get_buffer_line, (void *)&cookie,
+                                 ":source (no file)");
   } else {
     source_using_linegetter((void *)&cookie, get_buffer_line,
                             ":source (no file)");
@@ -3002,8 +3003,17 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   }
 
   if (path_with_extension((const char *)fname, "lua")) {
+    // TODO(shadmansaleh): Properly handle :verbose for lua
+    // For now change currennt_sctx before sourcing lua files
+    // So verbose doesn't say everything was done in line 1 since we don't know
+    const sctx_T current_sctx_backup = current_sctx;
+    const linenr_T sourcing_lnum_backup = sourcing_lnum;
+    current_sctx.sc_lnum = 0;
+    sourcing_lnum = 0;
     // Source the file as lua
     retval = (int)nlua_exec_file((const char *)fname);
+    current_sctx = current_sctx_backup;
+    sourcing_lnum = sourcing_lnum_backup;
   } else {
     // Call do_cmdline, which will call getsourceline() to get the lines.
     do_cmdline(firstline, getsourceline, (void *)&cookie,

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3011,15 +3011,15 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
     current_sctx.sc_lnum = 0;
     sourcing_lnum = 0;
     // Source the file as lua
-    retval = (int)nlua_exec_file((const char *)fname);
+    nlua_exec_file((const char *)fname);
     current_sctx = current_sctx_backup;
     sourcing_lnum = sourcing_lnum_backup;
   } else {
     // Call do_cmdline, which will call getsourceline() to get the lines.
     do_cmdline(firstline, getsourceline, (void *)&cookie,
                DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_REPEAT);
-    retval = OK;
   }
+  retval = OK;
 
   if (l_do_profiling == PROF_YES) {
     // Get "si" again, "script_items" may have been reallocated.

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1164,6 +1164,13 @@ static void nlua_typval_exec(const char *lcmd, size_t lcmd_len,
 int nlua_source_using_linegetter(LineGetter fgetline,
                                  void *cookie, char *name)
 {
+  const linenr_T save_sourcing_lnum = sourcing_lnum;
+  const sctx_T save_current_sctx = current_sctx;
+  current_sctx.sc_sid = SID_STR;
+  current_sctx.sc_seq = 0;
+  current_sctx.sc_lnum = 0;
+  sourcing_lnum = 0;
+
   garray_T ga;
   char_u *line = NULL;
 
@@ -1174,6 +1181,9 @@ int nlua_source_using_linegetter(LineGetter fgetline,
   char *code = (char *)ga_concat_strings_sep(&ga, "\n");
   size_t len = strlen(code);
   nlua_typval_exec(code, len, name, NULL, 0, false, NULL);
+
+  sourcing_lnum = save_sourcing_lnum;
+  current_sctx = save_current_sctx;
   ga_clear_strings(&ga);
   xfree(code);
   return OK;


### PR DESCRIPTION
### 1. Fix inconsistent verbose message on sourcing lua 

When a keymap is set from lua currently verbose message always says
it's set from line 1.

![Example](https://files.gitter.im/5506b96e15522ed4b3dd5317/Y8z1/image.png)

That's incorrect because we don't really know when
it was set. So until proper `:verbose` support isn't added for lua `:verbose` should's say the line no.

### 2. fix(source): Source giving E484 & parsing error at line 1 for lua files

It's happening because do_source is only expected to return FAIL when it
was unable to open file . But `nlua_exec_file` returns fail for parsing
and execution error too . Those errors are emitted through `nlua_error`.

So now return value of nlua_exec_file is ignored like do_cmdline. It now
only returns fail when it was unable to open file that check is done
before calling nlua_exec_file or do_cmdline. Errors in nlua_exec_file
are still directly emitted through nlua_error like before.