### PR TITLE
fix(lsp): handlers should focus quickfix list

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -196,7 +196,6 @@ M['textDocument/references'] = function(_, _, result)
   if not result then return end
   util.set_qflist(util.locations_to_items(result))
   api.nvim_command("copen")
-  api.nvim_command("wincmd p")
 end
 
 --@private
@@ -211,7 +210,6 @@ local symbol_handler = function(_, _, result, _, bufnr)
 
   util.set_qflist(util.symbols_to_items(result, bufnr))
   api.nvim_command("copen")
-  api.nvim_command("wincmd p")
 end
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol
 M['textDocument/documentSymbol'] = symbol_handler
@@ -302,7 +300,6 @@ local function location_handler(_, method, result)
     if #result > 1 then
       util.set_qflist(util.locations_to_items(result))
       api.nvim_command("copen")
-      api.nvim_command("wincmd p")
     end
   else
     util.jump_to_location(result)
@@ -383,7 +380,6 @@ local make_call_hierarchy_handler = function(direction)
     end
     util.set_qflist(items)
     api.nvim_command("copen")
-    api.nvim_command("wincmd p")
   end
 end
 


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/14877 https://github.com/neovim/neovim/issues/12906

I'm not in favor of adding an autocommand that closes the quickfix window when selecting references, as if you have multiple references, it's likely you'll want to be able to jump to multiple items in the list to find the correct one.

@mfussenegger @folke this is a fairly user-facing UX change, but I think this is the right thing to do? 