### PR TITLE
docs(starting): mention init.lua in paths and remove repetition

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -416,11 +416,11 @@ accordingly.  Vim proceeds in this order:
 	the same time.  Each line in a "init.vim" is executed as an Ex command
 	line.  See also |vimrc-intro| and |base-directories|.
 
-	The Nvim config file is "init.vim", located at:
-		Unix		~/.config/nvim/init.vim
-		Windows		~/AppData/Local/nvim/init.vim
+	The config file is located at:
+		Unix		~/.config/nvim/init.vim (or init.lua)
+		Windows		~/AppData/Local/nvim/init.vim (or init.lua)
 	or if |$XDG_CONFIG_HOME| is defined:
-				$XDG_CONFIG_HOME/nvim/init.vim
+				$XDG_CONFIG_HOME/nvim/init.vim (or init.lua)
 
 	If Nvim was started with "-u {file}" then {file} is used as the config
 	and all initializations until 5. are skipped. $MYVIMRC is not set.


### PR DESCRIPTION
~~Could also use `init.(vim|lua)` or similar or just repeat the whole path with `init.lua`, not sure exactly how we want to handle that, thought this could work though.~~

EDIT: Just added `(or init.lua)` to the end of the paths instead of the bracket thing (see [this message from jamessan on matrix](https://matrix.to/#/!JAfPjWAdLCtgeCAwnS:matrix.org/$162438361322424mgjhE:matrix.org?via=matrix.org&via=libera.chat&via=gitter.im)).