### PR TITLE
fix(lsp): syntax improvements for lsp_markdown

### DIFF
--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -10,8 +10,14 @@ execute 'source' expand('<sfile>:p:h') .. '/markdown.vim'
 
 syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
 
-syntax region mkdEscape matchgroup=mkdEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/.\zs/ keepend contains=mkdEscapeCh oneline concealends
-syntax match mkdEscapeCh /./ contained
+syn clear markdownEscape
+syntax region markdownEscape matchgroup=markdownEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/./ containedin=ALL keepend oneline concealends
+
+" conceal html entities
 syntax match mkdNbsp /&nbsp;/ conceal cchar= 
+syntax match mkdLt /&lt;/  conceal cchar=<
+syntax match mkdGt /&gt;/  conceal cchar=>
+syntax match mkdAmp /&amp;/  conceal cchar=&
+syntax match mkdQuot /&quot;/  conceal cchar="
 
 hi def link mkdEscape special


### PR DESCRIPTION
This PR adds additional conceal rules for html entities and extends `markdownEscape` to include a bigger set of escape sequences.

Given the following `Lua` code:

```lua
-- entities: This &lt;foo&gt;, quot: &quot;, ampersand: &amp;
-- escaped markdown: __foo\_bar__
-- **bold** *italic*
local foo = 123
```

Before:
![image](https://user-images.githubusercontent.com/292349/123444523-d5426200-d58b-11eb-8a6f-1aa532c979b6.png)

After:
![image](https://user-images.githubusercontent.com/292349/123444490-ca87cd00-d58b-11eb-9517-ab087dcbcae4.png)

This fixes display issues for **intelliphense** and **vscode-css-langserver**
