### PR TITLE
fix(eval): callback_call can't handle v:lua function

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -393,6 +393,7 @@ where the args are converted to Lua values. The expression >
 is equivalent to the Lua chunk >
     return somemod.func(...)
 
+                                                        *E921* *E5108*
 In addition, functions of packages can be accessed like >
     v:lua.require'mypack'.func(arg1, arg2)
     v:lua.require'mypack.submod'.func(arg1, arg2)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -974,6 +974,7 @@ EXTERN char_u e_bufloaded[] INIT(= N_("E139: File is loaded in another buffer"))
 EXTERN char_u e_notset[] INIT(= N_("E764: Option '%s' is not set"));
 EXTERN char_u e_invalidreg[] INIT(= N_("E850: Invalid register name"));
 EXTERN char_u e_dirnotf[] INIT(= N_("E919: Directory not found in '%s': \"%s\""));
+EXTERN char_u e_invalidcallbackarg[] INIT(= N_("E921: Invalid callback argument"));
 EXTERN char_u e_au_recursive[] INIT(= N_("E952: Autocommand caused recursive behavior"));
 EXTERN char_u e_autocmd_close[] INIT(= N_("E813: Cannot close autocmd window"));
 EXTERN char_u e_unsupportedoption[] INIT(= N_("E519: Option not supported"));


### PR DESCRIPTION
I think the patch should fix the issue caused by supporting lambda callback function for `qftf` (https://github.com/neovim/neovim/commit/4cb0bf09421e88adb812bb716b56af22bd51353e). But I don't know where the test should write to.
I search `callback_call` in the project, no test case is found.  Any guides are appreciated.