### PR TITLE
fix(treesitter): set match limit for query cursors

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1073,6 +1073,7 @@ static int node_rawquery(lua_State *L)
   // TODO(bfredl): these are expensive allegedly,
   // use a reuse list later on?
   TSQueryCursor *cursor = ts_query_cursor_new();
+  ts_query_cursor_set_match_limit(cursor, 32);
   ts_query_cursor_exec(cursor, query, node);
 
   bool captures = lua_toboolean(L, 3);


### PR DESCRIPTION
Upstream tree-sitter raised the number of pending matches for a query cursor
from 32 to 64k in https://github.com/tree-sitter/tree-sitter/commit/78010722a49ed6224c773c22b0d25a8c9fbde584, which severely impacted performance
for some highlighting queries. This uses the `ts_query_cursor_set_match_limit`
function introduced in https://github.com/tree-sitter/tree-sitter/commit/cd96552448a6e0d4eb27fc54b27cb5130c4b6f76 to manually set this back to the old
default of 32.

It may be worthwhile to check which queries lead to such a high number of pending matches, or whether a higher limit than 32 may be useful. Other queries than highlighting may also profit from an even higher (or lower) limit, so this should probably be turned into an option and exposed (at some later time).

Fixes #14897