### PR TITLE
[RDY] fix(doc/api): Remove 'border' as unsupported

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -422,7 +422,7 @@ Buffer text can be highlighted by typical mechanisms (syntax highlighting,
 options from the current window; specify `style=minimal` in |nvim_open_win()|
 to disable various visual features such as the 'number' column.
 
-Currently, floating windows don't support widgets like border or scrollbar.
+Currently, floating windows don't support some widgets like scrollbar.
 
 Example: create a float with scratch buffer: >
 


### PR DESCRIPTION
PR #13998 added support for floating window borders.

This PR removes `border` as an example of an unsupported widget from the `api.txt` documentation. Additionally, `some` was added for clarification (in contrast to `all`, which might be assumed otherwise).