### PR TITLE
feat(lua): add vim.tbl_repeat

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -174,6 +174,21 @@ function vim.tbl_filter(func, t)
   return rettab
 end
 
+--- Create a table with a given value repeated multiple times.
+---
+--- Does *not* copy the provided object, so the returned table contains
+--- identical objects.
+---
+---@param value the value to repeat
+---@param count integer the number of times to repeat the given value
+function vim.tbl_repeat(value, count)
+  vim.validate{count={count, "number"}}
+
+  local result = {}
+  for i=1, count do result[i] = value end
+  return result
+end
+
 --- Checks if a list-like (vector) table contains `value`.
 ---
 --@param t Table to check

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -438,6 +438,13 @@ describe('lua stdlib', function()
     ]]))
   end)
 
+  it('vim.tbl_repeat', function()
+    eq({{1, 2, 3}, {1, 2, 3}, {1, 2, 3}, {1, 2, 3}},
+      exec_lua("return vim.tbl_repeat({1, 2, 3}, 4)"))
+    eq({"foo"}, exec_lua("return vim.tbl_repeat('foo', 1)"))
+    eq({}, exec_lua("return vim.tbl_repeat(123, 0)"))
+  end)
+
   it('vim.tbl_islist', function()
     eq(true, exec_lua("return vim.tbl_islist({})"))
     eq(false, exec_lua("return vim.tbl_islist(vim.empty_dict())"))


### PR DESCRIPTION
Creates a table with a repeated value.

This is upstreaming some [code of ours downstream](https://github.com/Julian/lean.nvim/blob/main/lua/lean/_util.lua#L6-L13), where our use case is [populating a buffer with the same line repeated multiple times](https://github.com/Julian/lean.nvim/blob/0b57857eb23c78df9f008ca4cfc20ca57cc5ff87/lua/lean/sorry.lua#L29-L31).