### PR TITLE
Adding clangd language server config file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/       # Search build/ directory for compile_commands.json


### PR DESCRIPTION
Adding clangd language serever config file to point to build/ directory for compile_commands.json (requires clangd version 12+)