### PR TITLE
fixup(ts): put ts_query_cursor_set_match_limit behind feature guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,6 +393,22 @@ include_directories(SYSTEM ${LIBLUV_INCLUDE_DIRS})
 find_package(TreeSitter REQUIRED)
 include_directories(SYSTEM ${TreeSitter_INCLUDE_DIRS})
 
+list(APPEND CMAKE_REQUIRED_INCLUDES "${TreeSitter_INCLUDE_DIRS}")
+list(APPEND CMAKE_REQUIRED_LIBRARIES "${TreeSitter_LIBRARIES}")
+check_c_source_compiles("
+#include <tree_sitter/api.h>
+int
+main(void)
+{
+  TSQueryCursor *cursor = ts_query_cursor_new();
+  ts_query_cursor_set_match_limit(cursor, 32);
+  return 0;
+}
+" TS_HAS_SET_MATCH_LIMIT)
+if(TS_HAS_SET_MATCH_LIMIT)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNVIM_TS_HAS_SET_MATCH_LIMIT")
+endif()
+
 # Note: The test lib requires LuaJIT; it will be skipped if LuaJIT is missing.
 option(PREFER_LUA "Prefer Lua over LuaJIT in the nvim executable." OFF)
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1073,7 +1073,11 @@ static int node_rawquery(lua_State *L)
   // TODO(bfredl): these are expensive allegedly,
   // use a reuse list later on?
   TSQueryCursor *cursor = ts_query_cursor_new();
+  // TODO(clason): API introduced after tree-sitter release 0.19.5
+  // remove guard when minimum ts version is bumped to 0.19.6+
+#ifdef NVIM_TS_HAS_SET_MATCH_LIMIT
   ts_query_cursor_set_match_limit(cursor, 32);
+#endif
   ts_query_cursor_exec(cursor, query, node);
 
   bool captures = lua_toboolean(L, 3);


### PR DESCRIPTION
This is a fixup for #14915, which used the above-mentioned call to restore the behavior of the pre-release version of tree-sitter to that of 0.19.5. However, this function was introduced after 0.19.5, breaking distro builds that link against 0.19.5 instead of the tag specified in neovim's build script.

Now the function should only be called when it is available _and_ needed. This now builds against both the pre-release tag (with the fix) and 0.19.5 (without the fix). Also tested with `brew install neovim --HEAD` @carlocab

Once tree-sitter is bumped to 0.19.6 (when this is released), this guard can be removed again.

Fixes #14923 (among others)