### PR TITLE
fix(ci): change autolabel to "treesitter"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,7 @@
 "tui":
   - src/nvim/tui/tui.*
 
-"tree-sitter":
+"treesitter":
   - src/nvim/lua/treesitter.*
   - runtime/lua/vim/treesitter.lua
   - runtime/lua/vim/treesitter/*


### PR DESCRIPTION
Open issues and PRs are almost all labeled `treesitter` instead of `tree-sitter`; this change improves consistency.