### PR TITLE
doc: remove mentions of compile-time flags

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -568,9 +568,7 @@ with ".".  Vim does not recognize a comment (starting with '"') after the
 			option is empty (this is the default), use the
 			internal formatting function |C-indenting| and
 			|'lisp'|.  But when 'indentexpr' is not empty, it will
-			be used instead |indent-expression|.  When Vim was
-			compiled without internal formatting then the "indent"
-			program is used as a last resort.
+			be used instead |indent-expression|.
 
 							*==*
 ==			Filter [count] lines like with ={motion}.
@@ -1011,9 +1009,7 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			with `zp`.  (for {Visual} see |Visual-mode|)
 
 							*:y* *:yank* *E850*
-:[range]y[ank] [x]	Yank [range] lines [into register x]. Yanking to the
-			"* or "+ registers is possible only when the
-			|+clipboard| feature is included.
+:[range]y[ank] [x]	Yank [range] lines [into register x].
 
 :[range]y[ank] [x] {count}
 			Yank {count} lines, starting with last line number
@@ -1802,8 +1798,7 @@ found here: |sort()|, |uniq()|.
 			With [f] sorting is done on the Float in the line.
 			The value of Float is determined similar to passing
 			the text (after or inside a {pattern} match) to
-			str2float() function. This option is available only
-			if Vim was compiled with Floating point support.
+			str2float() function.
 
 			With [x] sorting is done on the first hexadecimal
 			number in the line (after or inside a {pattern}

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -165,7 +165,7 @@ ROUBLE
 The rouble sign was added in 2014 as 0x20bd.  Vim supports the digraphs =R and
 =P for this.  Note that R= and P= are other characters.
 
-							*digraph-table*
+						*digraph-table* *digraph-table-mbyte*
 char  digraph	hex	dec	official name ~
 ^@	NU	0x00	  0	NULL (NUL)
 ^A	SH	0x01	  1	START OF HEADING (SOH)
@@ -341,12 +341,6 @@ $	DO	0x24	 36	DOLLAR SIGN
 ý	y'	0xfd	253	LATIN SMALL LETTER Y WITH ACUTE
 þ	th	0xfe	254	LATIN SMALL LETTER THORN (Icelandic)
 ÿ	y:	0xff	255	LATIN SMALL LETTER Y WITH DIAERESIS
-
-If you are using a multibyte 'encoding', Vim provides this enhanced set of
-additional digraphs:
-
-							*digraph-table-mbyte*
-char  digraph	hex	dec	official name ~
 Ā	A-	0100	0256	LATIN CAPITAL LETTER A WITH MACRON
 ā	a-	0101	0257	LATIN SMALL LETTER A WITH MACRON
 Ă	A(	0102	0258	LATIN CAPITAL LETTER A WITH BREVE

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -342,8 +342,8 @@ $	DO	0x24	 36	DOLLAR SIGN
 þ	th	0xfe	254	LATIN SMALL LETTER THORN (Icelandic)
 ÿ	y:	0xff	255	LATIN SMALL LETTER Y WITH DIAERESIS
 
-If your Vim is compiled with |multibyte| support and you are using a multibyte
-'encoding', Vim provides this enhanced set of additional digraphs:
+If you are using a multibyte 'encoding', Vim provides this enhanced set of
+additional digraphs:
 
 							*digraph-table-mbyte*
 char  digraph	hex	dec	official name ~

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3252,8 +3252,7 @@ count({comp}, {expr} [, {ic} [, {start}]])			*count()*
 cscope_connection([{num} , {dbpath} [, {prepend}]])
 		Checks for the existence of a |cscope| connection.  If no
 		parameters are specified, then the function returns:
-			0, if cscope was not available (not compiled in), or
-			   if there are no cscope connections;
+			0, if there are no cscope connections;
 			1, if there is at least one cscope connection.
 
 		If parameters are specified, then the value of {num}
@@ -5299,9 +5298,6 @@ iconv({expr}, {from}, {to})				*iconv()*
 		are replaced with "?".
 		The encoding names are whatever the iconv() library function
 		can accept, see ":!man 3 iconv".
-		Most conversions require Vim to be compiled with the |+iconv|
-		feature.  Otherwise only UTF-8 to latin1 conversion and back
-		can be done.
 		Note that Vim uses UTF-8 for all Unicode encodings, conversion
 		from/to UCS-2 is automatically changed to use UTF-8.  You
 		cannot use UCS-2 in a string anyway, because of the NUL bytes.
@@ -5830,8 +5826,7 @@ lispindent({lnum})					*lispindent()*
 		indenting rules, as with 'lisp'.
 		The indent is counted in spaces, the value of 'tabstop' is
 		relevant.  {lnum} is used just like in |getline()|.
-		When {lnum} is invalid or Vim was not compiled the
-		|+lispindent| feature, -1 is returned.
+		When {lnum} is invalid, -1 is returned.
 
 list2str({list} [, {utf8}])				*list2str()*
 		Convert each number in {list} to a character string can
@@ -7150,7 +7145,6 @@ rubyeval({expr})					*rubyeval()*
 		Hashes are represented as Vim |Dictionary| type.
 		Other objects are represented as strings resulted from their
 		"Object#to_s" method.
-		{only available when compiled with the |+ruby| feature}
 
 screenattr({row}, {col})					*screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather
@@ -9139,8 +9133,6 @@ undofile({name})					*undofile()*
 		If {name} is empty undofile() returns an empty string, since a
 		buffer without a file name will not write an undo file.
 		Useful in combination with |:wundo| and |:rundo|.
-		When compiled without the |+persistent_undo| option this always
-		returns an empty string.
 
 undotree()						*undotree()*
 		Return the current state of the undo tree in a dictionary with

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -175,7 +175,6 @@ system.  To do this, put these commands in your vimrc file: >
 	:map <F4> :emenu <C-Z>
 Pressing <F4> will start the menu.  You can now use the cursor keys to select
 a menu entry.  Hit <Enter> to execute it.  Hit <Esc> if you want to cancel.
-This does require the |+menu| feature enabled at compile time.
 
 Creating New Menus					*creating-menus*
 
@@ -473,9 +472,8 @@ Executing Menus						*execute-menus*
 				insert-mode menu Eg: >
 	:emenu File.Exit
 
-If the console-mode vim has been compiled with WANT_MENU defined, you can
-use :emenu to access useful menu items you may have got used to from GUI
-mode.  See 'wildmenu' for an option that works well with this.  See
+You can use :emenu to access useful menu items you may have got used to from
+GUI mode.  See 'wildmenu' for an option that works well with this.  See
 |console-menus| for an example.
 
 When using a range, if the lines match with '<,'>, then the menu is executed

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -249,7 +249,6 @@ command: >
 
 It is possible to add translated help files, next to the original English help
 files.  Vim will search for all help in "doc" directories in 'runtimepath'.
-This is only available when compiled with the |+multi_lang| feature.
 
 At this moment translations are available for:
 	Chinese  - multiple authors

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -32,10 +32,6 @@ downloading Ruby there.
 			This form of the |:ruby| command is mainly useful for
 			including ruby code in vim scripts.
 
-			Note: This command doesn't work when the Ruby feature
-			wasn't compiled in.  To avoid errors, see
-			|script-here|.
-
 Example Vim script: >
 
 	function! RedGem()

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -699,8 +699,7 @@ tag		char	      note action in Normal mode	~
 
 tag		char	      note action in Normal mode	~
 ------------------------------------------------------------------------------
-|g_CTRL-A|	g CTRL-A	   only when compiled with MEM_PROFILE
-				   defined: dump a memory profile
+|g_CTRL-A|	g CTRL-A	   dump a memory profile
 |g_CTRL-G|	g CTRL-G	   show information about current cursor
 				   position
 |g_CTRL-H|	g CTRL-H	   start Select block mode

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -335,8 +335,8 @@ Vim will automatically convert from one to another encoding in several places:
   "utf-8" (requires a gettext version that supports this).
 - When reading a Vim script where |:scriptencoding| is different from
   "utf-8".
-Conversion for reading and writing files may also be specified with the
-'charconvert' option.
+Most of these require the |+iconv| feature.  Conversion for reading and
+writing files may also be specified with the 'charconvert' option.
 
 Useful utilities for converting the charset:
     All:	    iconv

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -335,8 +335,8 @@ Vim will automatically convert from one to another encoding in several places:
   "utf-8" (requires a gettext version that supports this).
 - When reading a Vim script where |:scriptencoding| is different from
   "utf-8".
-Most of these require the |+iconv| feature.  Conversion for reading and
-writing files may also be specified with the 'charconvert' option.
+Conversion for reading and writing files may also be specified with the
+'charconvert' option.
 
 Useful utilities for converting the charset:
     All:	    iconv

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -325,11 +325,10 @@ This works slightly differently:
   Go back to editing the gdb command with any command that starts Insert mode,
   such as `a` or `i`.
 - The program being debugged will run in a separate window.  On MS-Windows
-  this is a new console window.  On Unix, if the |+terminal| feature is
-  available a Terminal window will be opened to run the debugged program in.
+  this is a new console window.
 
 						*termdebug_use_prompt*
-Prompt mode can be used even when the |+terminal| feature is present with: >
+Prompt mode can be used with: >
 	let g:termdebug_use_prompt = 1
 
 <

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -324,8 +324,7 @@ This works slightly differently:
   mode with <Esc>, then you can move around in the buffer, copy/paste, etc.
   Go back to editing the gdb command with any command that starts Insert mode,
   such as `a` or `i`.
-- The program being debugged will run in a separate window.  On MS-Windows
-  this is a new console window.
+- A separate :terminal window will be opened to run the debugged program in.
 
 						*termdebug_use_prompt*
 Prompt mode can be used with: >

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3803,9 +3803,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	`:lgrepadd`, `:cfile`, `:cgetfile`, `:caddfile`, `:lfile`, `:lgetfile`,
 	and `:laddfile`.
 
-	This would be mostly useful when you use MS-Windows.  If GNU libiconv
-	is used, setting 'makeencoding' to "char" has the same effect as
-	setting to the system locale encoding.  Example: >
+	This would be mostly useful when you use MS-Windows.  If |+iconv| is
+	enabled and GNU libiconv is used, setting 'makeencoding' to "char" has
+	the same effect as setting to the system locale encoding.  Example: >
 		:set makeencoding=char	" system locale is used
 <
 						*'makeprg'* *'mp'*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2138,8 +2138,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global or local to buffer |global-local|
 	External program to use for "=" command.  When this option is empty
 	the internal formatting functions are used; either 'lisp', 'cindent'
-	or 'indentexpr'.  When Vim was compiled without internal formatting,
-	the "indent" program is used.
+	or 'indentexpr'.
 	Environment variables are expanded |:set_env|.  See |option-backslash|
 	about including spaces and backslashes.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
@@ -3804,9 +3803,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	`:lgrepadd`, `:cfile`, `:cgetfile`, `:caddfile`, `:lfile`, `:lgetfile`,
 	and `:laddfile`.
 
-	This would be mostly useful when you use MS-Windows.  If |+iconv| is
-	enabled and GNU libiconv is used, setting 'makeencoding' to "char" has
-	the same effect as setting to the system locale encoding.  Example: >
+	This would be mostly useful when you use MS-Windows.  If GNU libiconv
+	is used, setting 'makeencoding' to "char" has the same effect as
+	setting to the system locale encoding.  Example: >
 		:set makeencoding=char	" system locale is used
 <
 						*'makeprg'* *'mp'*
@@ -7093,8 +7092,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Allows writing to any file with no need for "!" override.
 
 			     *'writebackup'* *'wb'* *'nowritebackup'* *'nowb'*
-'writebackup' 'wb'	boolean	(default on with |+writebackup| feature, off
-					otherwise)
+'writebackup' 'wb'	boolean	(default on)
 			global
 	Make a backup before overwriting a file.  The backup is removed after
 	the file was successfully written, unless the 'backup' option is

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -103,10 +103,9 @@ will use the "latin1" print character encoding file.
 
 When 'encoding' is set to a multibyte encoding, Vim will try to convert
 characters to the printing encoding for printing (if 'printencoding' is empty
-then the conversion will be to latin1).  Conversion to a printing encoding
-other than latin1 will require Vim to be compiled with the |+iconv| feature.
-If no conversion is possible then printing will fail.  Any characters that
-cannot be converted will be replaced with upside down question marks.
+then the conversion will be to latin1). If no conversion is possible then
+printing will fail.  Any characters that cannot be converted will be replaced
+with upside down question marks.
 
 Two print character encoding files are provided to support default Mac and
 HPUX character encodings and are used by default on these platforms. Code page
@@ -176,9 +175,7 @@ the font.  When omitted, the point size is 10.
 'printheader' 'pheader'  string  (default "%<%f%h%m%=Page %N")
 			 global
 This defines the format of the header produced in |:hardcopy| output.  The
-option is defined in the same way as the 'statusline' option.  If Vim has not
-been compiled with the |+statusline| feature, this option has no effect and a
-simple default header is used, which shows the page number.  The same simple
+option is defined in the same way as the 'statusline' option.  The same simple
 header is used when this option is empty.
 
 							*pmbcs-option*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -903,11 +903,9 @@ OBSCURE
 Profiling						*profile* *profiling*
 
 Profiling means that Vim measures the time that is spent on executing
-functions and/or scripts.  The |+profile| feature is required for this.
-It is only included when Vim was compiled with "huge" features.
+functions and/or scripts.
 
-You can also use the |reltime()| function to measure time.  This only requires
-the |+reltime| feature, which is present more often.
+You can also use the |reltime()| function to measure time.
 
 For profiling syntax highlighting see |:syntime|.
 

--- a/runtime/doc/russian.txt
+++ b/runtime/doc/russian.txt
@@ -47,9 +47,6 @@ different codepages from
 
     http://www.sourceforge.net/projects/ruvim/
 
-Make sure that your Vim is at least 6.2.506 and use ruvim 0.5 or later for
-automatic installs.
-
 After downloading an archive from RuVim project, unpack it into your
 $VIMRUNTIME directory.  We recommend using UTF-8 archive.
 

--- a/runtime/doc/russian.txt
+++ b/runtime/doc/russian.txt
@@ -48,8 +48,7 @@ different codepages from
     http://www.sourceforge.net/projects/ruvim/
 
 Make sure that your Vim is at least 6.2.506 and use ruvim 0.5 or later for
-automatic installs.  Vim also needs to be compiled with |+gettext| feature for
-user interface items translations to work.
+automatic installs.
 
 After downloading an archive from RuVim project, unpack it into your
 $VIMRUNTIME directory.  We recommend using UTF-8 archive.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -480,7 +480,6 @@ accordingly.  Vim proceeds in this order:
 	- The |--noplugin| command line argument is used.
 	- The |--clean| command line argument is used.
 	- The "-u NONE" command line argument is used |-u|.
-	- When Vim was compiled without the |+eval| feature.
 	Note that using "-c 'set noloadplugins'" doesn't work, because the
 	commands from the command line have not been executed yet.  You can
 	use "--cmd 'set noloadplugins'" or "--cmd 'set loadplugins'" |--cmd|.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -371,9 +371,6 @@ the desired value, or restored to their default by removing the variable using
 Remarks:
 - Some truly ancient browsers may not show the background colors.
 - From most browsers you can also print the file (in color)!
-- The latest TOhtml may actually work with older versions of Vim, but some
-  features such as conceal support will not function, and the colors may be
-  incorrect for an old Vim without GUI support compiled in.
 
 Here is an example how to run the script over all .c and .h files from a
 Unix shell: >
@@ -4745,8 +4742,7 @@ in their own color.
 			This is basically the same as >
 				:echo g:colors_name
 <			In case g:colors_name has not been defined :colo will
-			output "default".  When compiled without the |+eval|
-			feature it will output "unknown".
+			output "default".
 
 :colo[rscheme] {name}	Load color scheme {name}.  This searches 'runtimepath'
 			for the file "colors/{name}.(vim|lua)".  The first one that
@@ -5403,9 +5399,6 @@ This is aimed at authors of a syntax file.
 If your syntax causes redrawing to be slow, here are a few hints on making it
 faster.  To see slowness switch on some features that usually interfere, such
 as 'relativenumber' and |folding|.
-
-Note: this is only available when compiled with the |+profile| feature.
-You many need to build Vim with "huge" features.
 
 To find out what patterns are consuming most time, get an overview with this
 sequence: >

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -367,11 +367,11 @@ be a bug.  If you really want the old Vi behavior, set the 't' flag in
 'cpoptions'.
 
 							*tag-binary-search*
-Vim uses binary searching in the tags file to find the desired tag quickly
-(when enabled at compile time |+tag_binary|).  But this only works if the
-tags file was sorted on ASCII byte value.  Therefore, if no match was found,
-another try is done with a linear search.  If you only want the linear search,
-reset the 'tagbsearch' option.  Or better: Sort the tags file!
+Vim uses binary searching in the tags file to find the desired tag quickly.
+But this only works if the tags file was sorted on ASCII byte value.
+Therefore, if no match was found, another try is done with a linear search.
+If you only want the linear search, reset the 'tagbsearch' option.  Or better:
+Sort the tags file!
 
 Note that the binary searching is disabled when not looking for a tag with a
 specific name.  This happens when ignoring case and when a regular expression
@@ -665,9 +665,6 @@ These commands look for a string in the current file and in all encountered
 included files (recursively).  This can be used to find the definition of a
 variable, function or macro.  If you only want to search in the current
 buffer, use the commands listed at |pattern-searches|.
-
-These commands are not available when the |+find_in_path| feature was disabled
-at compile time.
 
 When a line is encountered that includes another file, that file is searched
 before continuing in the current buffer.  Files included by included files are

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -30,8 +30,7 @@ New tests should be added as new style tests.  These use functions such as
 |assert_equal()| to keep the test commands and the expected result in one
 place.
 						*old-style-testing*
-In some cases an old style test needs to be used.  E.g. when testing Vim
-without the |+eval| feature.
+In some cases an old style test needs to be used.
 
 Find more information in the file src/testdir/README.txt.
 

--- a/runtime/doc/usr_45.txt
+++ b/runtime/doc/usr_45.txt
@@ -31,13 +31,6 @@ this command: >
 If it replies with "C", this means the default is being used, which is
 English.
 
-	Note:
-	Using different languages only works when Vim was compiled to handle
-	it.  To find out if it works, use the ":version" command and check the
-	output for "+gettext" and "+multi_lang".  If they are there, you are
-	OK.  If you see "-gettext" or "-multi_lang" you will have to find
-	another Vim.
-
 What if you would like your messages in a different language?  There are
 several ways.  Which one you should use depends on the capabilities of your
 system.


### PR DESCRIPTION
Neovim always compiles everything in so those are useless at best and confusing at worst.