### PR TITLE
vim-patch:8.1.2304,8.1.2309,8.1.2319,8.1.2321

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5127,7 +5127,6 @@ getmousepos()						*getmousepos()*
 		If the mouse is over a focusable floating window then that
 		window is used.
 
-
 		When using |getchar()| the Vim variables |v:mouse_lnum|,
 		|v:mouse_col| and |v:mouse_winid| also provide these values.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2431,6 +2431,7 @@ getloclist({nr})		List	list of location list items
 getloclist({nr}, {what})	Dict	get specific location list properties
 getmarklist([{buf}])		List	list of global/local marks
 getmatches([{win}])		List	list of current matches
+getmousepos()			Dict	last known mouse position
 getpid()			Number	process ID of Vim
 getpos({expr})			List	position of cursor, mark, etc.
 getqflist()			List	list of quickfix items
@@ -4709,7 +4710,8 @@ getchar([expr])						*getchar()*
 		When the user clicks a mouse button, the mouse event will be
 		returned.  The position can then be found in |v:mouse_col|,
 		|v:mouse_lnum|, |v:mouse_winid| and |v:mouse_win|.
-		Mouse move events will be ignored.
+		|getmousepos()| can also be used.  Mouse move events will be
+		ignored.
 		This example positions the mouse as it would normally happen: >
 			let c = getchar()
 			if c == "\<LeftMouse>" && v:mouse_win > 0
@@ -5099,6 +5101,36 @@ getmatches([{win}])					*getmatches()*
 			'pattern': 'FIXME', 'priority': 10, 'id': 2}] >
 			:unlet m
 <
+getmousepos()						*getmousepos()*
+		Returns a Dictionary with the last known position of the
+		mouse.  This can be used in a mapping for a mouse click.  The
+		items are:
+			screenrow	screen row
+			screencol	screen column
+			winid		Window ID of the click
+			winrow		row inside "winid"
+			wincol		column inside "winid"
+			line		text line inside "winid"
+			column		text column inside "winid"
+		All numbers are 1-based.
+
+		If not over a window, e.g. when in the command line, then only
+		"screenrow" and "screencol" are valid, the others are zero.
+
+		When on the status line below a window or the vertical
+		separater right of a window, the "line" and "column" values
+		are zero.
+
+		When the position is after the text then "column" is the
+		length of the text in bytes.
+
+		If the mouse is over a focusable floating window then that
+		window is used.
+
+
+		When using |getchar()| the Vim variables |v:mouse_lnum|,
+		|v:mouse_col| and |v:mouse_winid| also provide these values.
+
 							*getpid()*
 getpid()	Return a Number which is the process ID of the Vim process.
 		This is a unique number, until Vim exits.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5122,7 +5122,7 @@ getmousepos()						*getmousepos()*
 		are zero.
 
 		When the position is after the text then "column" is the
-		length of the text in bytes.
+		length of the text in bytes plus one.
 
 		If the mouse is over a focusable floating window then that
 		window is used.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -162,6 +162,7 @@ return {
     getloclist={args={1, 2}},
     getmarklist={args={0, 1}},
     getmatches={args={0, 1}},
+    getmousepos={},
     getpid={},
     getpos={args=1},
     getqflist={args={0, 1}},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3750,6 +3750,48 @@ static void f_getmatches(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
+// "getmousepos()" function
+void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  dict_T *d;
+  win_T *wp;
+  int row = mouse_row;
+  int col = mouse_col;
+  int grid = mouse_grid;
+  varnumber_T winid = 0;
+  varnumber_T winrow = 0;
+  varnumber_T wincol = 0;
+  varnumber_T line = 0;
+  varnumber_T column = 0;
+
+  tv_dict_alloc_ret(rettv);
+  d = rettv->vval.v_dict;
+
+  tv_dict_add_nr(d, S_LEN("screenrow"), (varnumber_T)mouse_row + 1);
+  tv_dict_add_nr(d, S_LEN("screencol"), (varnumber_T)mouse_col + 1);
+
+  wp = mouse_find_win(&grid, &row, &col);
+  if (wp != NULL) {
+    int height = wp->w_height + wp->w_status_height;
+    // The height is adjusted by 1 when there is a bottom border. This is not
+    // necessary for a top border since `row` starts at -1 in that case.
+    if (row < height + wp->w_border_adj[2]) {
+      winid = wp->handle;
+      winrow = row + 1 + wp->w_border_adj[0];  // Adjust by 1 for top border
+      wincol = col + 1 + wp->w_border_adj[3];  // Adjust by 1 for left border
+      if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
+        mouse_comp_pos(wp, &row, &col, &line);
+        column = col + 1;
+      }
+    }
+  }
+  tv_dict_add_nr(d, S_LEN("winid"), winid);
+  tv_dict_add_nr(d, S_LEN("winrow"), winrow);
+  tv_dict_add_nr(d, S_LEN("wincol"), wincol);
+  tv_dict_add_nr(d, S_LEN("line"), line);
+  tv_dict_add_nr(d, S_LEN("column"), column);
+}
+
 /*
  * "getpid()" function
  */

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3761,7 +3761,7 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   varnumber_T winid = 0;
   varnumber_T winrow = 0;
   varnumber_T wincol = 0;
-  varnumber_T line = 0;
+  linenr_T line = 0;
   varnumber_T column = 0;
 
   tv_dict_alloc_ret(rettv);
@@ -3788,7 +3788,7 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   tv_dict_add_nr(d, S_LEN("winid"), winid);
   tv_dict_add_nr(d, S_LEN("winrow"), winrow);
   tv_dict_add_nr(d, S_LEN("wincol"), wincol);
-  tv_dict_add_nr(d, S_LEN("line"), line);
+  tv_dict_add_nr(d, S_LEN("line"), (varnumber_T)line);
   tv_dict_add_nr(d, S_LEN("column"), column);
 }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3780,7 +3780,18 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       winrow = row + 1 + wp->w_border_adj[0];  // Adjust by 1 for top border
       wincol = col + 1 + wp->w_border_adj[3];  // Adjust by 1 for left border
       if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
+        char_u *p;
+        int count;
+
         mouse_comp_pos(wp, &row, &col, &line);
+
+        // limit to text length plus one
+        p = ml_get_buf(wp->w_buffer, line, false);
+        count = (int)STRLEN(p);
+        if (col > count) {
+          col = count;
+        }
+
         column = col + 1;
       }
     }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -410,7 +410,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
     col += win->w_skipcol;
     // limit to text length plus one
     p = ml_get_buf(win->w_buffer, lnum, false);
-    count = STRLEN(p);
+    count = (int)STRLEN(p);
     if (col > count) {
       col = count;
     }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -363,7 +363,6 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
   bool retval = false;
   int off;
   int count;
-  char_u *p;
 
   if (win->w_p_rl) {
     col = win->w_width_inner - 1 - col;
@@ -408,12 +407,6 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
     col += row * (win->w_width_inner - off);
     // add skip column (for long wrapping line)
     col += win->w_skipcol;
-    // limit to text length plus one
-    p = ml_get_buf(win->w_buffer, lnum, false);
-    count = (int)STRLEN(p);
-    if (col > count) {
-      col = count;
-    }
   }
 
   if (!win->w_p_wrap) {

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -363,6 +363,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
   bool retval = false;
   int off;
   int count;
+  char_u *p;
 
   if (win->w_p_rl) {
     col = win->w_width_inner - 1 - col;
@@ -407,6 +408,12 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
     col += row * (win->w_width_inner - off);
     // add skip column (for long wrapping line)
     col += win->w_skipcol;
+    // limit to text length plus one
+    p = ml_get_buf(win->w_buffer, lnum, false);
+    count = STRLEN(p);
+    if (col > count) {
+      col = count;
+    }
   }
 
   if (!win->w_p_wrap) {

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -1384,4 +1384,128 @@ describe('ui/mouse/input', function()
 
     end) -- level 3 - wrapped
   end)
+
+  it('getmousepos works correctly', function()
+    local winwidth = meths.get_option('winwidth')
+    -- Set winwidth=1 so that window sizes don't change.
+    meths.set_option('winwidth', 1)
+    command('tabedit')
+    local tabpage = meths.get_current_tabpage()
+    insert('hello')
+    command('vsplit')
+    local opts = {
+      relative='editor',
+      width=12,
+      height=1,
+      col=8,
+      row=1,
+      anchor='NW',
+      style='minimal',
+      border='single',
+      focusable=1
+    }
+    local float = meths.open_win(meths.get_current_buf(), false, opts)
+    command('redraw')
+    local lines = meths.get_option('lines')
+    local columns = meths.get_option('columns')
+
+    -- Test that screenrow and screencol are set properly for all positions.
+    for row = 0, lines - 1 do
+      for col = 0, columns - 1 do
+        -- Skip the X button that would close the tab.
+        if row ~= 0 or col ~= columns - 1 then
+          meths.input_mouse('left', 'press', '', 0, row, col)
+          meths.set_current_tabpage(tabpage)
+          local mousepos = funcs.getmousepos()
+          eq(row + 1, mousepos.screenrow)
+          eq(col + 1, mousepos.screencol)
+          -- All other values should be 0 when clicking on the command line.
+          if row == lines - 1 then
+            eq(0, mousepos.winid)
+            eq(0, mousepos.winrow)
+            eq(0, mousepos.wincol)
+            eq(0, mousepos.line)
+            eq(0, mousepos.column)
+          end
+        end
+      end
+    end
+
+    -- Test that mouse position values are properly set for the floating window
+    -- with a border. 1 is added to the height and width to account for the
+    -- border.
+    for win_row = 0, opts.height + 1 do
+      for win_col = 0, opts.width + 1 do
+        local row = win_row + opts.row
+        local col = win_col + opts.col
+        meths.input_mouse('left', 'press', '', 0, row, col)
+        local mousepos = funcs.getmousepos()
+        eq(float.id, mousepos.winid)
+        eq(win_row + 1, mousepos.winrow)
+        eq(win_col + 1, mousepos.wincol)
+        local line = 0
+        local column = 0
+        if win_row > 0 and win_row < opts.height + 1
+            and win_col > 0 and win_col < opts.width + 1 then
+          -- Because of border, win_row and win_col don't need to be
+          -- incremented by 1.
+          line = math.min(win_row, funcs.line('$'))
+          column = math.min(win_col, #funcs.getline(line) + 1)
+        end
+        eq(line, mousepos.line)
+        eq(column, mousepos.column)
+      end
+    end
+
+    -- Test that mouse position values are properly set for the floating
+    -- window, after removing the border.
+    opts.border = 'none'
+    meths.win_set_config(float, opts)
+    command('redraw')
+    for win_row = 0, opts.height - 1 do
+      for win_col = 0, opts.width - 1 do
+        local row = win_row + opts.row
+        local col = win_col + opts.col
+        meths.input_mouse('left', 'press', '', 0, row, col)
+        local mousepos = funcs.getmousepos()
+        eq(float.id, mousepos.winid)
+        eq(win_row + 1, mousepos.winrow)
+        eq(win_col + 1, mousepos.wincol)
+        local line = math.min(win_row + 1, funcs.line('$'))
+        local column = math.min(win_col + 1, #funcs.getline(line) + 1)
+        eq(line, mousepos.line)
+        eq(column, mousepos.column)
+      end
+    end
+
+    -- Test that mouse position values are properly set for ordinary windows.
+    -- Set the float to be unfocusable instead of closing, to additionally test
+    -- that getmousepos does not consider unfocusable floats. (see discussion
+    -- in PR #14937 for details).
+    opts.focusable = false
+    meths.win_set_config(float, opts)
+    command('redraw')
+    for nr = 1, 2 do
+      for win_row = 0, funcs.winheight(nr) - 1 do
+        for win_col = 0, funcs.winwidth(nr) - 1 do
+          local row = win_row + funcs.win_screenpos(nr)[1] - 1
+          local col = win_col + funcs.win_screenpos(nr)[2] - 1
+          meths.input_mouse('left', 'press', '', 0, row, col)
+          local mousepos = funcs.getmousepos()
+          eq(funcs.win_getid(nr), mousepos.winid)
+          eq(win_row + 1, mousepos.winrow)
+          eq(win_col + 1, mousepos.wincol)
+          local line = math.min(win_row + 1, funcs.line('$'))
+          local column = math.min(win_col + 1, #funcs.getline(line) + 1)
+          eq(line, mousepos.line)
+          eq(column, mousepos.column)
+        end
+      end
+    end
+
+    -- Restore state and release mouse.
+    command('tabclose!')
+    meths.set_option('winwidth', winwidth)
+    meths.input_mouse('left', 'release', '', 0, 0, 0)
+  end)
 end)


### PR DESCRIPTION
This PR ports Vim's `getmousepos()` function to Neovim.

The patches were not applied as-is. The changes include:

* Update code formatting.
* Move `f_getmousepos` from `mouse.c` to `funcs.c`.
* Remove handling for popup windows.
* Add handling for floating windows with borders. The code adds handling to consider borders as part of the window for the purpose of computing `winrow` and `wincol`.
* Add tests.

~Commit df48a6ffdebfca5b5e682119264eba0ac9b1dbde updates `getmousepos()` to consider unfocusable floating windows. This matches how `getmousepos()` works with popup windows in Vim, as popup windows are unfocusable. The update adds an `include_unfocusable` argument to `mouse_find_win` for specifying whether that function should consider unfocusable floating windows. The value `false` was passed in all cases outside `f_getmousepos` so that existing behavior is maintained.~


#### vim-patch:8.1.2304: cannot get the mouse position when getting a mouse click

Problem:    Cannot get the mouse position when getting a mouse click.
Solution:   Add getmousepos().
https://github.com/vim/vim/commit/db3a205147ce2c335d5c2181c1f789277f8775b0


#### vim-patch:8.1.2309: compiler warning for argument type

Problem:    Compiler warning for argument type.
Solution:   Use linenr_T and cast to varnumber_T. (John Marriott)
https://github.com/vim/vim/commit/abe12a1a4fce36bfa5dea3a0ce85603432d1905b


#### vim-patch:8.1.2319: compiler warning for int size

Problem:    Compiler warning for int size.
Solution:   Add typecast. (Mike Williams)
https://github.com/vim/vim/commit/07a63d86338476bafbd1a3ec462672df92666498


#### vim-patch:8.1.2321: cannot select all text with the mouse 

Problem:    Cannot select all text with the mouse. (John Marriott)
Solution:   Move limiting the mouse column to f_getmousepos().
            (closes https://github.com/vim/vim/issues/5242)
https://github.com/vim/vim/commit/0a5aa7b28a39507260acb15c1ef698a33c855cc1