### PR TITLE
PVS/V1051: Ignore "modulo by 1" warning for ARRAY_SIZE.

### DIFF
--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -133,6 +133,8 @@
 /// error. A mechanism to detect many (though not all) of those errors at
 /// compile time is implemented. It works by the second division producing
 /// a division by zero in those cases (-Wdiv-by-zero in GCC).
+///
+/// -V:ARRAY_SIZE:1063
 #define ARRAY_SIZE(arr) \
     ((sizeof(arr)/sizeof((arr)[0])) \
      / ((size_t)(!(sizeof(arr) % sizeof((arr)[0])))))


### PR DESCRIPTION
A bit unsure if the comment/explanation is a bit overkill; if so I can reduce/remove it.