### PR TITLE
Open funcs_data.mpack in binary mode

### DIFF
--- a/scripts/genvimvim.lua
+++ b/scripts/genvimvim.lua
@@ -123,7 +123,7 @@ end
 w('\n\nsyn case match')
 local vimfun_start = 'syn keyword vimFuncName contained '
 w('\n\n' .. vimfun_start)
-funcs = mpack.unpack(io.open(funcs_file):read("*all"))
+funcs = mpack.unpack(io.open(funcs_file, 'rb'):read("*all"))
 local started = 0
 for name, def in pairs(funcs) do
   if name then


### PR DESCRIPTION
This updates `genvimvim.lua` so that `funcs_data.mpack` is opened in binary mode.

Without this, tests are failing on Windows on PRs #14744 and #14937.