### PR TITLE
Remove deleteFoldRecurse's unused buffer argument

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -840,7 +840,7 @@ static void clear_wininfo(buf_T *buf)
   while (buf->b_wininfo != NULL) {
     wip = buf->b_wininfo;
     buf->b_wininfo = wip->wi_next;
-    free_wininfo(wip, buf);
+    free_wininfo(wip);
   }
 }
 
@@ -2543,7 +2543,7 @@ void buflist_setfpos(buf_T *const buf, win_T *const win,
     }
     if (copy_options && wip->wi_optset) {
       clear_winopt(&wip->wi_opt);
-      deleteFoldRecurse(buf, &wip->wi_folds);
+      deleteFoldRecurse(&wip->wi_folds);
     }
   }
   if (lnum != 0) {

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -796,7 +796,7 @@ void deleteFold(
  */
 void clearFolding(win_T *win)
 {
-  deleteFoldRecurse(win->w_buffer, &win->w_folds);
+  deleteFoldRecurse(&win->w_folds);
   win->w_foldinvalid = false;
 }
 
@@ -1356,7 +1356,7 @@ static void deleteFoldEntry(win_T *const wp, garray_T *const gap, const int idx,
   fold_T *fp = (fold_T *)gap->ga_data + idx;
   if (recursive || GA_EMPTY(&fp->fd_nested)) {
     // recursively delete the contained folds
-    deleteFoldRecurse(wp->w_buffer, &fp->fd_nested);
+    deleteFoldRecurse(&fp->fd_nested);
     gap->ga_len--;
     if (idx < gap->ga_len) {
       memmove(fp, fp + 1, sizeof(*fp) * (size_t)(gap->ga_len - idx));
@@ -1398,9 +1398,9 @@ static void deleteFoldEntry(win_T *const wp, garray_T *const gap, const int idx,
 /*
  * Delete nested folds in a fold.
  */
-void deleteFoldRecurse(buf_T *bp, garray_T *gap)
+void deleteFoldRecurse(garray_T *gap)
 {
-# define DELETE_FOLD_NESTED(fd) deleteFoldRecurse(bp, &((fd)->fd_nested))
+# define DELETE_FOLD_NESTED(fd) deleteFoldRecurse(&((fd)->fd_nested))
   GA_DEEP_CLEAR(gap, fold_T, DELETE_FOLD_NESTED);
 }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4599,11 +4599,11 @@ static win_T *win_alloc(win_T *after, int hidden)
 
 // Free one wininfo_T.
 void
-free_wininfo(wininfo_T *wip, buf_T *bp)
+free_wininfo(wininfo_T *wip)
 {
   if (wip->wi_optset) {
     clear_winopt(&wip->wi_opt);
-    deleteFoldRecurse(bp, &wip->wi_folds);
+    deleteFoldRecurse(&wip->wi_folds);
   }
   xfree(wip);
 }
@@ -4675,7 +4675,7 @@ win_free (
             } else {
               wip2->wi_prev->wi_next = wip2->wi_next;
             }
-            free_wininfo(wip2, buf);
+            free_wininfo(wip2);
             break;
           }
         }


### PR DESCRIPTION
I noticed when porting https://github.com/vim/vim/commit/4882d983397057ea91c584c5a54aaccf15016d18 for PR #14884 that `deleteFoldRecurse` has an unused `buffer` argument not present in Vim's version of that function.

There is no Vim patch to port for this change. The argument was added to Neovim in 12fdb114d1fdc85a26cf60e9af91b243cc59cfa0.