### PR TITLE
fix(lsp): correctly check for windows in lsp logger

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -17,7 +17,7 @@ local current_log_level = log.levels.WARN
 local log_date_format = "%FT%H:%M:%S%z"
 
 do
-  local path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
+  local path_sep = vim.loop.os_uname().version:match("Windows") and "\\" or "/"
   --@private
   local function path_join(...)
     return table.concat(vim.tbl_flatten{...}, path_sep)


### PR DESCRIPTION
**What**

Use regex match to check if system is windows/mingw in lsp/log.lua

**Why**

By this issue: https://github.com/neovim/neovim/issues/14953, it seems that the check for windows was being done incorrectly in the LSP logger:

https://github.com/neovim/neovim/blob/7d8202087bed0a0baefb61557fcea15087fb01b3/runtime/lua/vim/lsp/log.lua#L20

It should be checking for `Windows_NT`, or maybe more correctly, borrowing from: https://github.com/neovim/nvim-lspconfig/commit/2c6f8dbd7e5adc732c0d679351b2a18d025c650b, calling `match` on  `version` instead which works for Windows and MinGW.

**I don't have a windows machine to test this on, so I am only guessing that 1) this is a bug in the logger, and 2) the check in lspconfig worked.**

Probably need a windows user to test?

I think modern windows machines can handle `/` as a path sep, so it may have just "been working anyway" most of the time provided paths didn't have spaces in it or something..