### PR TITLE
Allow URI schemes other than file: without authority

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -74,7 +74,7 @@ local function uri_from_fname(path)
   return table.concat(uri_parts)
 end
 
-local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*)://.*'
+local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):.*'
 
 --- Get a URI from a bufnr
 --@param bufnr (number): Buffer number

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -125,6 +125,12 @@ describe('URI methods', function()
           return vim.uri_to_fname('JDT://content/%5C/')
         ]])
       end)
+
+      it('uri_to_fname returns non-file scheme URI without authority unchanged', function()
+        eq('zipfile:/path/to/archive.zip%3A%3Afilename.txt', exec_lua [[
+          return vim.uri_to_fname('zipfile:/path/to/archive.zip%3A%3Afilename.txt')
+        ]])
+      end)
     end)
 
     describe('decode URI without scheme', function()
@@ -140,6 +146,15 @@ describe('URI methods', function()
   describe('uri to bufnr', function()
     it('uri_to_bufnr & uri_from_bufnr returns original uri for non-file uris', function()
       local uri = 'jdt://contents/java.base/java.util/List.class?=sql/%5C/home%5C/user%5C/.jabba%5C/jdk%5C/openjdk%5C@1.14.0%5C/lib%5C/jrt-fs.jar%60java.base=/javadoc_location=/https:%5C/%5C/docs.oracle.com%5C/en%5C/java%5C/javase%5C/14%5C/docs%5C/api%5C/=/%3Cjava.util(List.class'
+      local test_case = string.format([[
+        local uri = '%s'
+        return vim.uri_from_bufnr(vim.uri_to_bufnr(uri))
+      ]], uri)
+      eq(uri, exec_lua(test_case))
+    end)
+
+    it('uri_to_bufnr & uri_from_bufnr returns original uri for non-file uris without authority', function()
+      local uri = 'zipfile:/path/to/archive.zip%3A%3Afilename.txt'
       local test_case = string.format([[
         local uri = '%s'
         return vim.uri_from_bufnr(vim.uri_to_bufnr(uri))


### PR DESCRIPTION
As discussed in #14867 the current URI scheme regex is too restrictive as it only allows URIs that have a path component beginning with `//`.

https://github.com/neovim/neovim/blob/7685fc9ecd2a1a0b6c62fe56a14de8441d9f3a58/runtime/lua/vim/uri.lua#L77