### PR TITLE
refactor(memfile_test): replace long_u type with size_t.

### DIFF
--- a/src/nvim/testdir/samples/memfile_test.c
+++ b/src/nvim/testdir/samples/memfile_test.c
@@ -37,8 +37,8 @@ test_mf_hash(void)
     mf_hashtab_T   ht;
     mf_hashitem_T  *item;
     blocknr_T      key;
-    long_u	   i;
-    long_u	   num_buckets;
+    size_t	   i;
+    size_t	   num_buckets;
 
     mf_hash_init(&ht);
 


### PR DESCRIPTION
long_u was a custom integer type that is no longer used.
More information can be found in https://github.com/neovim/neovim/issues/459.