### PR TITLE
fix(vim.opt): vimL map string values not trimmed

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -494,7 +494,6 @@ local convert_value_to_lua = (function()
       for _, key_value_str in ipairs(comma_split) do
         local key, value = unpack(vim.split(key_value_str, ":"))
         key = vim.trim(key)
-        value = vim.trim(value)
 
         result[key] = value
       end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1332,12 +1332,12 @@ describe('lua stdlib', function()
 
       it('should work for key-value pair options', function()
         local listchars = exec_lua [[
-          vim.opt.listchars = "tab:>~,space:_"
+          vim.opt.listchars = "tab:> ,space:_"
           return vim.opt.listchars:get()
         ]]
 
         eq({
-          tab = ">~",
+          tab = "> ",
           space = "_",
         }, listchars)
       end)


### PR DESCRIPTION
Options formatted as a list of comma-separated key-value pairs may have values that contain leading and trailing whitespace characters. For example, the `listchars` option has a default value of`"tab:> ,trail:-,nbsp:+"`. When converting this value to a lua table, leading and trailing whitespace should not be trimmed.