### PR TITLE
fixup(clipboard): Fix clipboard provider error not properly handled

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -158,7 +158,9 @@ function! s:clipboard.get(reg) abort
   end
 
   let clipboard_data = s:try_cmd(s:paste[a:reg])
-  if match(&clipboard, '\v(unnamed|unnamedplus)') >= 0 && get(s:selections[a:reg].data, 0, []) ==# clipboard_data
+  if match(&clipboard, '\v(unnamed|unnamedplus)') >= 0
+        \ && type(clipboard_data) == v:t_list
+        \ && get(s:selections[a:reg].data, 0, []) ==# clipboard_data
     " When system clipboard return is same as our cache return the cache
     " as it contains regtype information
     return s:selections[a:reg].data


### PR DESCRIPTION
try_cmd return 0 when error occurs . But that wasn't handled before comparing with cache . That's why the issue occured . I've added a type check to see if `clipboard_data` is a list before comparing it with cache.

closes #14967