### PR TITLE
fix(lsp): prevent double <text> for cached plaintext markup

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -810,16 +810,16 @@ function M.convert_input_to_markdown_lines(input, contents)
       -- If it's plaintext, then wrap it in a <text></text> block
 
       -- Some servers send input.value as empty, so let's ignore this :(
-      input.value = input.value or ''
+      local value = input.value or ''
 
       if input.kind == "plaintext" then
         -- wrap this in a <text></text> block so that stylize_markdown
         -- can properly process it as plaintext
-        input.value = string.format("<text>\n%s\n</text>", input.value or "")
+        value = string.format("<text>\n%s\n</text>", value)
       end
 
-      -- assert(type(input.value) == 'string')
-      list_extend(contents, split_lines(input.value))
+      -- assert(type(value) == 'string')
+      list_extend(contents, split_lines(value))
     -- MarkupString variation 2
     elseif input.language then
       -- Some servers send input.value as empty, so let's ignore this :(


### PR DESCRIPTION
`convert_input_to_markdown_lines` takes an lsp markup object (`input`) and returns the lines  of the resulting markdown.

When the `kind` is `plaintext`, the `input.value` was changed instead of using a temporary variable, meaning that if someone calls that method with the same `input` twice, the results would be double escaped.

This PR fixes this.

Fixes https://github.com/hrsh7th/nvim-compe/issues/440

I will also submit a PR to compe to deal with this in the meantime.

