### PR TITLE
[RFC] Fix clipboard error

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -43,7 +43,7 @@ function! s:try_cmd(cmd, ...) abort
       echohl None
       let s:did_error_try_cmd = 1
     endif
-    return 0
+    return []
   endif
   return out
 endfunction
@@ -158,7 +158,8 @@ function! s:clipboard.get(reg) abort
   end
 
   let clipboard_data = s:try_cmd(s:paste[a:reg])
-  if match(&clipboard, '\v(unnamed|unnamedplus)') >= 0 && get(s:selections[a:reg].data, 0, []) ==# clipboard_data
+  if match(&clipboard, '\v(unnamed|unnamedplus)') >= 0
+        \ && get(s:selections[a:reg].data, 0, []) ==# clipboard_data
     " When system clipboard return is same as our cache return the cache
     " as it contains regtype information
     return s:selections[a:reg].data


### PR DESCRIPTION
Fix https://github.com/Shougo/neoyank.vim/issues/26 problem.

Note: `s:try_cmd()` must return list.