### PR TITLE
#12861 Fixes of wrong treesitter state synchronization

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1003,9 +1003,10 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2,
     }
 
     sign_mark_adjust(line1, line2, amount, amount_after);
-    if (op != kExtmarkNOOP) {
-      extmark_adjust(curbuf, line1, line2, amount, amount_after, op);
-    }
+  }
+
+  if (op != kExtmarkNOOP) {
+    extmark_adjust(curbuf, line1, line2, amount, amount_after, op);
   }
 
   /* previous context mark */

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -1039,9 +1039,9 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
-    local function do_test_issue_12861(mode)
+    local function test_lockmarks(mode)
       if not mode then mode = "" end
-      it("#12861 lockmarks " .. mode .. " %delete _", function()
+      it("test_lockmarks " .. mode .. " %delete _", function()
         local check_events = setup_eventcheck(verify, {"AAA", "BBB", "CCC"})
 
         command(mode .. " %delete _")
@@ -1050,7 +1050,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
         }
       end)
 
-      it("#12861 lockmarks " .. mode .. " append()", function()
+      it("test_lockmarks " .. mode .. " append()", function()
         local check_events = setup_eventcheck(verify)
 
         command(mode .. " call append(0, 'CCC')")
@@ -1073,12 +1073,12 @@ describe('lua: nvim_buf_attach on_bytes', function()
           { "test1", "bytes", 1, 5, 3, 0, 10, 1, 0, 1, 0, 0, 0 };
         }
 
-        eq("CCCBBBB", table.concat(meths.buf_get_lines(0, 0, -1, true), ""))
+        eq("CCC|BBBB|", table.concat(meths.buf_get_lines(0, 0, -1, true), "|"))
       end)
     end
 
-    do_test_issue_12861()
-    do_test_issue_12861 "lockmarks"
+    test_lockmarks()
+    test_lockmarks "lockmarks"
 
 
     teardown(function()


### PR DESCRIPTION
#12861 mark.c fixed: `lockmarks` option prevents execution of `extmark_adjust()`

Now `mark_adjust()` will trigger appropriate `buf_updates_send_splice()` called by `extmark_adjust()`

Waiting review and users feedback, test case added.