### PR TITLE
fix(treesitter): cache parser per buffer and language

### DIFF
--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -104,6 +104,20 @@ void ui_refresh(void)
   }
 }]]
 
+  it('get_parser() changes the language of the parser', function()
+    local res = exec_lua([[
+      parser = vim.treesitter.get_parser(0, "c")
+      return parser:lang()
+    ]])
+    eq("c", res)
+
+    local ok, err = unpack(exec_lua([[
+       return {pcall(vim.treesitter.get_parser, 0, "cpp")}
+    ]]))
+    assert(not ok)
+    assert(string.find(err, "no parser for 'cpp' language", 1, true))
+  end)
+
   it('allows to iterate over nodes children', function()
     insert(test_text);
 


### PR DESCRIPTION
Currently, the `lang` parameter will only be taken into consideration
if the parser is being created for the first time. If the parser was
already created, requesting a different language will not return a
tree for that language.