### PR TITLE
window.c: address Coverity failure

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4666,7 +4666,8 @@ win_free (
         // If there already is an entry with "wi_win" set to NULL it
         // must be removed, it would never be used.
         for (wip2 = buf->b_wininfo; wip2 != NULL; wip2 = wip2->wi_next) {
-          if (wip2->wi_win == NULL) {
+          // `wip2 != wip` to satisfy Coverity. #14884
+          if (wip2 != wip && wip2->wi_win == NULL) {
             if (wip2->wi_next != NULL) {
               wip2->wi_next->wi_prev = wip2->wi_prev;
             }


### PR DESCRIPTION
This update adds a check that `wip2` does not point to the same address as `wip`, to address the Coverity test failure from PR #14884.

Based on the `if` clauses, `free_wininfo(wip2, ...)` is only called when `wip2->wi_win == NULL` and `wip->wi_win == wp`. I think `wip2` would only point to the same address as `wip` in scenarios where `wp` were `NULL`, which can be assumed otherwise based on the earlier code. Explicitly adding a check to the `if` clause is intended to satisfy static analysis.