### PR TITLE
clang/'Dead assignment': ignore warning.

### DIFF
--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -905,6 +905,7 @@ continue_same_node:
           refkey(b, enditr->node, enditr->i);
         } else {
           past_right = true; // NOLINT
+          (void)past_right;
           break;
         }
       }


### PR DESCRIPTION
It was deemed to be informative even if it wasn't used.
https://github.com/neovim/neovim/pull/11900#discussion_r381860165 .