### PR TITLE
chore: use codespell to spell check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ For Comment) and `[RDY]` (Ready).
 
 ### Commit messages
 
-Follow the [convential commits guidelines][conventional_commits] to *make reviews easier* and to make
+Follow the [conventional commits guidelines][conventional_commits] to *make reviews easier* and to make
 the VCS/git logs more valuable. The general structure of a commit message is as follows:
 
 ```

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -158,7 +158,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height,
   }
 
   if (ui->ui_ext[kUIMessages]) {
-    // This uses attribute indicies, so ext_linegrid is needed.
+    // This uses attribute indices, so ext_linegrid is needed.
     ui->ui_ext[kUILinegrid] = true;
     // Cmdline uses the messages area, so it should be externalized too.
     ui->ui_ext[kUICmdline] = true;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -217,7 +217,7 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///
 /// @param ns_id number of namespace for this highlight
 /// @param name highlight group name, like ErrorMsg
-/// @param val highlight definiton map, like |nvim_get_hl_by_name|.
+/// @param val highlight definition map, like |nvim_get_hl_by_name|.
 ///            in addition the following keys are also recognized:
 ///              `default`: don't override existing definition,
 ///                         like `hi default`
@@ -384,7 +384,7 @@ Integer nvim_input(String keys)
 ///       by calling it multiple times in a loop: the intermediate mouse
 ///       positions will be ignored. It should be used to implement real-time
 ///       mouse input in a GUI. The deprecated pseudokey form
-///       ("<LeftMouse><col,row>") of |nvim_input()| has the same limitiation.
+///       ("<LeftMouse><col,row>") of |nvim_input()| has the same limitation.
 ///
 /// @param button Mouse button: one of "left", "right", "middle", "wheel".
 /// @param action For ordinary buttons, one of "press", "drag", "release".
@@ -558,7 +558,7 @@ Object nvim_exec_lua(String code, Array args, Error *err)
 /// Notify the user with a message
 ///
 /// Relays the call to vim.notify . By default forwards your message in the
-/// echo area but can be overriden to trigger desktop notifications.
+/// echo area but can be overridden to trigger desktop notifications.
 ///
 /// @param msg        Message to display to the user
 /// @param log_level  The log level
@@ -1260,7 +1260,7 @@ fail:
 ///
 /// By default (and currently the only option) the terminal will not be
 /// connected to an external process. Instead, input send on the channel
-/// will be echoed directly by the terminal. This is useful to disply
+/// will be echoed directly by the terminal. This is useful to display
 /// ANSI terminal sequences returned as part of a rpc message, or similar.
 ///
 /// Note: to directly initiate the terminal using the right size, display the
@@ -1290,7 +1290,7 @@ Integer nvim_open_term(Buffer buffer, Dictionary opts, Error *err)
   TerminalOptions topts;
   Channel *chan = channel_alloc(kChannelStreamInternal);
   topts.data = chan;
-  // NB: overriden in terminal_check_size if a window is already
+  // NB: overridden in terminal_check_size if a window is already
   // displaying the buffer
   topts.width = (uint16_t)MAX(curwin->w_width_inner - win_col_off(curwin), 0);
   topts.height = (uint16_t)curwin->w_height_inner;
@@ -2237,7 +2237,7 @@ typedef kvec_withinit_t(ExprASTConvStackItem, 16) ExprASTConvStack;
 ///          - "arg": String, error message argument.
 ///        - "len": Amount of bytes successfully parsed. With flags equal to ""
 ///                 that should be equal to the length of expr string.
-///                 (“Sucessfully parsed” here means “participated in AST
+///                 (“Successfully parsed” here means “participated in AST
 ///                  creation”, not “till the first error”.)
 ///        - "ast": AST, either nil or a dictionary with these keys:
 ///          - "type": node type, one of the value names from ExprASTNodeType
@@ -2925,7 +2925,7 @@ void nvim__screenshot(String path)
 /// Note: this function should not be called often. Rather, the callbacks
 /// themselves can be used to throttle unneeded callbacks. the `on_start`
 /// callback can return `false` to disable the provider until the next redraw.
-/// Similarily, return `false` in `on_win` will skip the `on_lines` calls
+/// Similarly, return `false` in `on_win` will skip the `on_lines` calls
 /// for that window (but any extmarks set in `on_win` will still be used).
 /// A plugin managing multiple sources of decoration should ideally only set
 /// one provider, and merge the sources internally. You can use multiple `ns_id`

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -394,7 +394,7 @@ void nvim_win_set_config(Window window, Dictionary config, Error *err)
     return;
   }
   bool new_float = !win->w_floating;
-  // reuse old values, if not overriden
+  // reuse old values, if not overridden
   FloatConfig fconfig = new_float ? FLOAT_CONFIG_INIT : win->w_float_config;
 
   if (!parse_float_config(config, &fconfig, !new_float, false, err)) {

--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -793,7 +793,7 @@ bool arabic_maycombine(int two)
   return false;
 }
 
-// A_firstc_laa returns first character of LAA combination if it ex.ists
+// A_firstc_laa returns first character of LAA combination if it exists
 // in: "c" base character
 // in: "c1" first composing character
 static int A_firstc_laa(int c, int c1)

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1492,7 +1492,7 @@ void set_curbuf(buf_T *buf, int action)
   set_bufref(&prevbufref, prevbuf);
   set_bufref(&newbufref, buf);
 
-  // Autocommands may delete the curren buffer and/or the buffer we wan to go
+  // Autocommands may delete the curren buffer and/or the buffer we want to go
   // to.  In those cases don't close the buffer.
   if (!apply_autocmds(EVENT_BUFLEAVE, NULL, NULL, false, curbuf)
       || (bufref_valid(&prevbufref) && bufref_valid(&newbufref)
@@ -1673,7 +1673,7 @@ static int top_file_num = 1;            ///< highest file number
 
 /// Initialize b:changedtick and changedtick_val attribute
 ///
-/// @param[out]  buf  Buffer to intialize for.
+/// @param[out]  buf  Buffer to initialize for.
 static inline void buf_init_changedtick(buf_T *const buf)
   FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
 {
@@ -3590,7 +3590,7 @@ int build_stl_str_hl(
 
 
   // Proceed character by character through the statusline format string
-  // fmt_p is the current positon in the input buffer
+  // fmt_p is the current position in the input buffer
   for (char_u *fmt_p = usefmt; *fmt_p; ) {
     if (curitem == (int)stl_items_len) {
         size_t new_len = stl_items_len * 3 / 2;
@@ -4738,7 +4738,7 @@ static bool append_arg_number(win_T *wp, char_u *buf, int buflen, bool add_file)
 // When resolving a link both "*sfname" and "*ffname" will point to the same
 // allocated memory.
 // The "*ffname" and "*sfname" pointer values on call will not be freed.
-// Note that the resulting "*ffname" pointer should be considered not allocaed.
+// Note that the resulting "*ffname" pointer should be considered not allocated.
 void fname_expand(buf_T *buf, char_u **ffname, char_u **sfname)
 {
   if (*ffname == NULL) {  // no file name given, nothing to do

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -313,7 +313,7 @@ void buf_updates_send_splice(
     return;
   }
 
-  // notify each of the active callbakcs
+  // notify each of the active callbacks
   size_t j = 0;
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1732,7 +1732,7 @@ int open_line(
   }
   if (did_append) {
     changed_lines(curwin->w_cursor.lnum, 0, curwin->w_cursor.lnum, 1L, true);
-    // bail out and just get the final lenght of the line we just manipulated
+    // bail out and just get the final length of the line we just manipulated
     bcount_t extra = (bcount_t)STRLEN(ml_get(curwin->w_cursor.lnum));
     extmark_splice(curbuf, (int)curwin->w_cursor.lnum-1, 0,
                    0, 0, 0, 1, 0, 1+extra, kExtmarkUndo);

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -30,7 +30,7 @@ void decor_init(void)
 /// @param src_id src_id to use or 0 to use a new src_id group,
 ///               or -1 for ungrouped highlight.
 /// @param hl_id Highlight group id
-/// @param pos_start Cursor position to start the hightlighting at
+/// @param pos_start Cursor position to start the highlighting at
 /// @param pos_end Cursor position to end the highlighting at
 /// @param offset Move the whole highlighting this many columns to the right
 void bufhl_add_hl_pos_offset(buf_T *buf,

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1869,7 +1869,7 @@ int diff_check(win_T *wp, linenr_T lnum)
 /// @param  idx1  first entry in diff "dp"
 /// @param  idx2  second entry in diff "dp"
 ///
-/// @return true if two entires are equal.
+/// @return true if two entries are equal.
 static bool diff_equal_entry(diff_T *dp, int idx1, int idx2)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(1)
 {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2453,7 +2453,7 @@ static int ins_compl_add(char_u *const str, int len,
 ///
 /// @param  match  completion match
 /// @param  str    character string to check
-/// @param  len    lenth of "str"
+/// @param  len    length of "str"
 static bool ins_compl_equal(compl_T *match, char_u *str, size_t len)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
@@ -8024,7 +8024,7 @@ static void ins_bs_one(colnr_T *vcolp)
 
 /// Handle Backspace, delete-word and delete-line in Insert mode.
 ///
-/// @param          c                 charcter that was typed
+/// @param          c                 character that was typed
 /// @param          mode              backspace mode to use
 /// @param[in,out]  inserted_space_p  whether a space was the last
 //                                    character inserted
@@ -8251,7 +8251,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         ins_bs_one(&vcol);
       }
     } else {
-      // Delete upto starting point, start of line or previous word.
+      // Delete up to starting point, start of line or previous word.
       int prev_cclass = 0;
 
       int cclass = mb_get_class(get_cursor_pos_ptr());

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8151,7 +8151,7 @@ void set_vim_var_special(const VimVarIndex idx, const SpecialVarValue val)
 ///
 /// @param[in]  idx  Index of variable to set.
 /// @param[in]  val  Value to set to. Will be copied.
-/// @param[in]  len  Legth of that value or -1 in which case strlen() will be
+/// @param[in]  len  Length of that value or -1 in which case strlen() will be
 ///                  used.
 void set_vim_var_string(const VimVarIndex idx, const char *const val,
                         const ptrdiff_t len)
@@ -8957,7 +8957,7 @@ static void set_var_const(const char *name, const size_t name_len,
           const char *const val = tv_get_string(tv);
 
           // Careful: when assigning to v:errmsg and tv_get_string()
-          // causes an error message the variable will alrady be set.
+          // causes an error message the variable will already be set.
           if (v->di_tv.vval.v_string == NULL) {
             v->di_tv.vval.v_string = (char_u *)xstrdup(val);
           }

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -16,7 +16,7 @@ static char *e_letwrong = N_("E734: Wrong variable type for %s=");
 
 char *e_listidx = N_("E684: list index out of range: %" PRId64);
 
-/// Hanle tv1 += tv2, -=, *=, /=,  %=, .=
+/// Handle tv1 += tv2, -=, *=, /=,  %=, .=
 ///
 /// @param[in,out]  tv1  First operand, modified typval.
 /// @param[in]  tv2  Second operand.

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -836,7 +836,7 @@ int tv_list_join(garray_T *const gap, list_T *const l, const char *const sep)
   return retval;
 }
 
-/// Chech whether two lists are equal
+/// Check whether two lists are equal
 ///
 /// @param[in]  l1  First list to compare.
 /// @param[in]  l2  Second list to compare.

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -55,7 +55,7 @@ enum ListLenSpecials {
 #define VARNUMBER_MAX INT64_MAX
 #define UVARNUMBER_MAX UINT64_MAX
 
-/// Mimimal possible value of varnumber_T variable
+/// Minimal possible value of varnumber_T variable
 #define VARNUMBER_MIN INT64_MIN
 
 /// %d printf format specifier for varnumber_T
@@ -322,7 +322,7 @@ struct ufunc {
   int          uf_prof_initialized;
   // Managing cfuncs
   cfunc_T      uf_cb;            ///< C function extension callback
-  cfunc_free_T uf_cb_free;       ///< C function extesion free callback
+  cfunc_free_T uf_cb_free;       ///< C function extension free callback
   void        *uf_cb_state;      ///< State of C function extension.
   // Profiling the function as a whole.
   int          uf_tm_count;      ///< nr of calls

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3029,13 +3029,13 @@ int do_return(exarg_T *eap, int reanimate, int is_cmd, void *rettv)
     current_funccal->returned = false;
   }
 
-  /*
-   * Cleanup (and inactivate) conditionals, but stop when a try conditional
-   * not in its finally clause (which then is to be executed next) is found.
-   * In this case, make the ":return" pending for execution at the ":endtry".
-   * Otherwise, return normally.
-   */
-  idx = cleanup_conditionals(eap->cstack, 0, TRUE);
+  //
+  // Cleanup (and deactivate) conditionals, but stop when a try conditional
+  // not in its finally clause (which then is to be executed next) is found.
+  // In this case, make the ":return" pending for execution at the ":endtry".
+  // Otherwise, return normally.
+  //
+  idx = cleanup_conditionals(eap->cstack, 0, true);
   if (idx >= 0) {
     cstack->cs_pending[idx] = CSTP_RETURN;
 

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -19,7 +19,7 @@
 # include "event/stream.c.generated.h"
 #endif
 
-// For compatbility with libuv < 1.19.0 (tested on 1.18.0)
+// For compatibility with libuv < 1.19.0 (tested on 1.18.0)
 #if UV_VERSION_MINOR < 19
 #define uv_stream_get_write_queue_size(stream) stream->write_queue_size
 #endif

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -103,7 +103,7 @@ typedef struct {
 // the preview window
 typedef struct {
   kvec_t(SubResult) subresults;
-  linenr_T lines_needed;  // lines neede in the preview window
+  linenr_T lines_needed;  // lines needed in the preview window
 } PreviewLines;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -4819,7 +4819,7 @@ char_u *check_help_lang(char_u *arg)
  * Return a heuristic indicating how well the given string matches.  The
  * smaller the number, the better the match.  This is the order of priorities,
  * from best match to worst match:
- *	- Match with least alpha-numeric characters is better.
+ *	- Match with least alphanumeric characters is better.
  *	- Match with least total characters is better.
  *	- Match towards the start is better.
  *	- Match starting with "+" is worse (feature instead of command)

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -3501,7 +3501,7 @@ void do_finish(exarg_T *eap, int reanimate)
                                             eap->cookie))->finished = false;
   }
 
-  // Cleanup (and inactivate) conditionals, but stop when a try conditional
+  // Cleanup (and deactivate) conditionals, but stop when a try conditional
   // not in its finally clause (which then is to be executed next) is found.
   // In this case, make the ":finish" pending for execution at the ":endtry".
   // Otherwise, finish normally.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -97,7 +97,7 @@ static garray_T ucmds = {0, 0, sizeof(ucmd_T), 4, NULL};
 #define USER_CMD(i) (&((ucmd_T *)(ucmds.ga_data))[i])
 #define USER_CMD_GA(gap, i) (&((ucmd_T *)((gap)->ga_data))[i])
 
-/* Wether a command index indicates a user command. */
+// Whether a command index indicates a user command.
 # define IS_USER_CMDIDX(idx) ((int)(idx) < 0)
 
 /* Struct for storing a line inside a while/for loop */
@@ -2956,12 +2956,13 @@ const char * set_one_cmd_context(
     }
   }
 
-  /*
-   * If the cursor is touching the command, and it ends in an alpha-numeric
-   * character, complete the command name.
-   */
-  if (*p == NUL && ASCII_ISALNUM(p[-1]))
+  //
+  // If the cursor is touching the command, and it ends in an alphanumeric
+  // character, complete the command name.
+  //
+  if (*p == NUL && ASCII_ISALNUM(p[-1])) {
     return NULL;
+  }
 
   if (ea.cmdidx == CMD_SIZE) {
     if (*cmd == 's' && vim_strchr((const char_u *)"cgriI", cmd[1]) != NULL) {

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -210,7 +210,7 @@ bool cause_errthrow(const char_u *mesg, bool severe, bool *ignore)
    * not skipped.  Errors in those commands may affect what of the subsequent
    * commands are regarded part of catch and finally clauses.  Catching the
    * exception would then cause execution of commands not intended by the
-   * user, who wouldn't even get aware of the problem.  Therefor, discard the
+   * user, who wouldn't even get aware of the problem.  Therefore, discard the
    * exception currently being thrown to prevent it from being caught.  Just
    * execute finally clauses and terminate.
    */
@@ -1022,7 +1022,7 @@ void ex_continue(exarg_T *eap)
   else {
     /* Try to find the matching ":while".  This might stop at a try
      * conditional not in its finally clause (which is then to be executed
-     * next).  Therefor, inactivate all conditionals except the ":while"
+     * next).  Therefore, deactivate all conditionals except the ":while"
      * itself (if reached). */
     idx = cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, FALSE);
     assert(idx >= 0);
@@ -1051,14 +1051,14 @@ void ex_break(exarg_T *eap)
   int idx;
   cstack_T *const cstack = eap->cstack;
 
-  if (cstack->cs_looplevel <= 0 || cstack->cs_idx < 0)
+  if (cstack->cs_looplevel <= 0 || cstack->cs_idx < 0) {
     eap->errmsg = (char_u *)N_("E587: :break without :while or :for");
-  else {
-    /* Inactivate conditionals until the matching ":while" or a try
-     * conditional not in its finally clause (which is then to be
-     * executed next) is found.  In the latter case, make the ":break"
-     * pending for execution at the ":endtry". */
-    idx = cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, TRUE);
+  } else {
+    // Deactivate conditionals until the matching ":while" or a try
+    // conditional not in its finally clause (which is then to be
+    // executed next) is found.  In the latter case, make the ":break"
+    // pending for execution at the ":endtry". */
+    idx = cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, true);
     if (idx >= 0 && !(cstack->cs_flags[idx] & (CSF_WHILE | CSF_FOR))) {
       cstack->cs_pending[idx] = CSTP_BREAK;
       report_make_pending(CSTP_BREAK, NULL);
@@ -1179,15 +1179,15 @@ void do_throw(cstack_T *cstack)
   int idx;
   int inactivate_try = FALSE;
 
-  /*
-   * Cleanup and inactivate up to the next surrounding try conditional that
-   * is not in its finally clause.  Normally, do not inactivate the try
-   * conditional itself, so that its ACTIVE flag can be tested below.  But
-   * if a previous error or interrupt has not been converted to an exception,
-   * inactivate the try conditional, too, as if the conversion had been done,
-   * and reset the did_emsg or got_int flag, so this won't happen again at
-   * the next surrounding try conditional.
-   */
+  //
+  // Cleanup and deactivate up to the next surrounding try conditional that
+  // is not in its finally clause.  Normally, do not deactivate the try
+  // conditional itself, so that its ACTIVE flag can be tested below.  But
+  // if a previous error or interrupt has not been converted to an exception,
+  // deactivate the try conditional, too, as if the conversion had been done,
+  // and reset the did_emsg or got_int flag, so this won't happen again at
+  // the next surrounding try conditional.
+  //
 #ifndef THROW_ON_ERROR_TRUE
   if (did_emsg && !THROW_ON_ERROR) {
     inactivate_try = TRUE;

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -19,7 +19,7 @@
 // Marks live in namespaces that allow plugins/users to segregate marks
 // from other users.
 //
-// Deleting marks only happens when explicitly calling extmark_del, deleteing
+// Deleting marks only happens when explicitly calling extmark_del, deleting
 // over a range of marks will only move the marks. Deleting on a mark will
 // leave it in same position unless it is on the EOL of a line.
 //

--- a/src/nvim/extmark_defs.h
+++ b/src/nvim/extmark_defs.h
@@ -23,8 +23,8 @@ typedef kvec_t(ExtmarkUndoObject) extmark_undo_vec_t;
 
 typedef enum {
   kExtmarkNOOP,        // Extmarks shouldn't be moved
-  kExtmarkUndo,        // Operation should be reversable/undoable
-  kExtmarkNoUndo,      // Operation should not be reversable
+  kExtmarkUndo,        // Operation should be reversible/undoable
+  kExtmarkNoUndo,      // Operation should not be reversible
   kExtmarkUndoNoRedo,  // Operation should be undoable, but not redoable
 } ExtmarkOp;
 

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -247,7 +247,7 @@ for i = 1, #functions do
             (j - 1)..'].type == kObjectTypeInteger) {')
           output:write('\n    '..converted..' = (Float)args.items['..(j - 1)..'].data.integer;')
         end
-        -- accept empty lua tables as empty dictionarys
+        -- accept empty lua tables as empty dictionaries
         if rt:match('^Dictionary') then
           output:write('\n  } else if (args.items['..(j - 1)..'].type == kObjectTypeArray && args.items['..(j - 1)..'].data.array.size == 0) {') --luacheck: ignore 631
           output:write('\n    '..converted..' = (Dictionary)ARRAY_DICT_INIT;')

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2413,7 +2413,7 @@ static int vgetorpeek(bool advance)
  *	1. a scriptfile
  *	2. the keyboard
  *
- *  As much characters as we can get (upto 'maxlen') are put in "buf" and
+ *  As much characters as we can get (up to 'maxlen') are put in "buf" and
  *  NUL terminated (buffer length must be 'maxlen' + 1).
  *  Minimum for "maxlen" is 3!!!!
  *

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -141,7 +141,7 @@ EXTERN int cmdline_row;
 EXTERN int redraw_cmdline INIT(= false);          // cmdline must be redrawn
 EXTERN int clear_cmdline INIT(= false);           // cmdline must be cleared
 EXTERN int mode_displayed INIT(= false);          // mode is being displayed
-EXTERN int cmdline_star INIT(= false);            // cmdline is crypted
+EXTERN int cmdline_star INIT(= false);            // cmdline is encrypted
 EXTERN int redrawing_cmdline INIT(= false);       // cmdline is being redrawn
 EXTERN int cmdline_was_last_drawn INIT(= false);  // cmdline was last drawn
 

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -86,7 +86,7 @@ struct ScreenGrid {
   int zindex;
 
   // Below is state owned by the compositor. Should generally not be set/read
-  // outside this module, except for specific compatibilty hacks
+  // outside this module, except for specific compatibility hacks
 
   // position of the grid on the composed screen.
   int comp_row;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -1767,7 +1767,7 @@ static bool prt_open_resource(struct prt_ps_resource_S *resource)
       break;
 
     case PRT_DSC_ENDCOMMENTS_TYPE:
-      // Wont find title or resource after this comment, stop searching
+      // Won't find title or resource after this comment, stop searching
       seen_all = true;
       break;
 

--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -9,11 +9,11 @@
  * Any special key code sequences are replaced by these codes.
  */
 
-/*
- * For MSDOS some keys produce codes larger than 0xff. They are split into two
- * chars, the first one is K_NUL.
- */
-#define K_NUL                   (0xce)  // for MSDOS: special key follows
+//
+// For MS-DOS some keys produce codes larger than 0xff. They are split into two
+// chars, the first one is K_NUL.
+//
+#define K_NUL                   (0xce)  // for MS-DOS: special key follows
 
 /*
  * K_SPECIAL is the first byte of a special key code and is always followed by

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -7,7 +7,7 @@
 #include "auto/config.h"
 #include "nvim/macros.h"
 
-// USDT probes. Example invokation:
+// USDT probes. Example invocation:
 //     NVIM_PROBE(nvim_foo_bar, 1, string.data);
 #if defined(HAVE_SYS_SDT_H)
 #include <sys/sdt.h> // NOLINT

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -144,12 +144,12 @@ static int nlua_stricmp(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   return 1;
 }
 
-/// convert byte index to UTF-32 and UTF-16 indicies
+/// convert byte index to UTF-32 and UTF-16 indices
 ///
 /// Expects a string and an optional index. If no index is supplied, the length
 /// of the string is returned.
 ///
-/// Returns two values: the UTF-32 and UTF-16 indicies.
+/// Returns two values: the UTF-32 and UTF-16 indices.
 static int nlua_str_utfindex(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 {
   size_t s1_len;
@@ -173,7 +173,7 @@ static int nlua_str_utfindex(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   return 2;
 }
 
-/// convert UTF-32 or UTF-16 indicies to byte index.
+/// convert UTF-32 or UTF-16 indices to byte index.
 ///
 /// Expects up to three args: string, index and use_utf16.
 /// If use_utf16 is not supplied it defaults to false (use UTF-32)
@@ -234,7 +234,7 @@ static int nlua_luv_cfpcall(lua_State *lstate, int nargs, int nresult,
 
     multiqueue_put(main_loop.events, nlua_luv_error_event,
                    1, xstrdup(error));
-    lua_pop(lstate, 1);  // error mesage
+    lua_pop(lstate, 1);  // error message
     retval = -status;
   } else {  // LUA_OK
     if (nresult == LUA_MULTRET) {
@@ -585,7 +585,7 @@ static lua_State *global_lstate = NULL;
 
 /// Enter lua interpreter
 ///
-/// Calls nlua_init() if needed. Is responsible for pre-lua call initalization
+/// Calls nlua_init() if needed. Is responsible for pre-lua call initialization
 /// like updating `package.[c]path` with directories derived from &runtimepath.
 ///
 /// @return Interpreter instance to use. Will either be initialized now or

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -384,7 +384,7 @@ static int parser_parse(lua_State *L)
   // Sometimes parsing fails (timeout, or wrong parser ABI)
   // In those case, just return an error.
   if (!new_tree) {
-    return luaL_error(L, "An error occured when parsing.");
+    return luaL_error(L, "An error occurred when parsing.");
   }
 
   // The new tree will be pushed to the stack, without copy, owwership is now to

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -108,7 +108,7 @@ int setmark_pos(int c, pos_T *pos, int fnum)
     return OK;
   }
 
-  // Can't set a mark in a non-existant buffer.
+  // Can't set a mark in a non-existent buffer.
   buf_T *buf = buflist_findnr(fnum);
   if (buf == NULL) {
     return FAIL;

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -49,7 +49,7 @@ struct mtnode_s {
   int32_t n;
   int32_t level;
   // TODO(bfredl): we could consider having a only-sometimes-valid
-  // index into parent for faster "chached" lookup.
+  // index into parent for faster "cached" lookup.
   mtnode_t *parent;
   mtkey_t key[2 * MT_BRANCH_FACTOR - 1];
   mtnode_t *ptr[];

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -118,15 +118,15 @@ struct pointer_block {
  * etc. Thus the order of the lines is the opposite of the line number.
  */
 struct data_block {
-  uint16_t db_id;               /* ID for data block: DATA_ID */
-  unsigned db_free;             /* free space available */
-  unsigned db_txt_start;        /* byte where text starts */
-  unsigned db_txt_end;          /* byte just after data block */
-  linenr_T db_line_count;       /* number of lines in this block */
-  unsigned db_index[1];         /* index for start of line (actually bigger)
-                                 * followed by empty space upto db_txt_start
-                                 * followed by the text in the lines until
-                                 * end of page */
+  uint16_t db_id;               // ID for data block: DATA_ID
+  unsigned db_free;             // free space available
+  unsigned db_txt_start;        // byte where text starts
+  unsigned db_txt_end;          // byte just after data block
+  linenr_T db_line_count;       // number of lines in this block
+  unsigned db_index[1];         // index for start of line (actually bigger)
+                                // followed by empty space up to db_txt_start
+                                // followed by the text in the lines until
+                                // end of page
 };
 
 /*

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -955,7 +955,7 @@ char_u *set_context_in_menu_cmd(expand_T *xp, const char *cmd, char_u *arg,
       after_dot = p + 1;
   }
 
-  // ":popup" only uses menues, not entries
+  // ":popup" only uses menus, not entries
   expand_menus = !((*cmd == 't' && cmd[1] == 'e') || *cmd == 'p');
   expand_emenu = (*cmd == 'e');
   if (expand_menus && ascii_iswhite(*p)) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6554,9 +6554,9 @@ static void n_start_visual_mode(int c)
   VIsual_mode = c;
   VIsual_active = true;
   VIsual_reselect = true;
-  /* Corner case: the 0 position in a tab may change when going into
-   * virtualedit.  Recalculate curwin->w_cursor to avoid bad hilighting.
-   */
+  // Corner case: the 0 position in a tab may change when going into
+  // virtualedit.  Recalculate curwin->w_cursor to avoid bad highlighting.
+  //
   if (c == Ctrl_V && (ve_flags & VE_BLOCK) && gchar_cursor() == TAB) {
     validate_virtcol();
     coladvance(curwin->w_virtcol);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -954,7 +954,7 @@ static void set_yreg_additional_data(yankreg_T *reg, dict_T *additional_data)
 
 /*
  * Stuff string "p" into yank register "regname" as a single line (append if
- * uppercase). "p" must have been alloced.
+ * uppercase). "p" must have been allocated.
  *
  * return FAIL for failure, OK otherwise
  */
@@ -1066,7 +1066,7 @@ do_execreg(
     if (reg->y_array == NULL)
       return FAIL;
 
-    // Disallow remaping for ":@r".
+    // Disallow remapping for ":@r".
     int remap = colon ? REMAP_NONE : REMAP_YES;
 
     /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1174,10 +1174,10 @@ int do_set(
         }
       }
 
-      /*
-       * allow '=' and ':' as MSDOS command.com allows only one
-       * '=' character per "set" command line. grrr. (jw)
-       */
+      //
+      // allow '=' and ':' as MS-DOS command.com allows only one
+      // '=' character per "set" command line. grrr. (jw)
+      //
       if (nextchar == '?'
           || (prefix == 1
               && vim_strchr((char_u *)"=:&<", nextchar) == NULL
@@ -2719,7 +2719,7 @@ ambw_end:
                : opt_idx);
     // Update free_oldval now that we have the opt_idx for 'shada', otherwise
     // there would be a disconnect between the check for P_ALLOCED at the start
-    // of the function and the set of P_ALLOCED at the end of the fuction.
+    // of the function and the set of P_ALLOCED at the end of the function.
     free_oldval = (options[opt_idx].flags & P_ALLOCED);
     for (s = p_shada; *s; ) {
       // Check it's a valid character
@@ -5363,7 +5363,7 @@ static int put_setstring(FILE *fd, char *cmd, char *name,
       home_replace(NULL, *valuep, buf, size, false);
 
       // If the option value is longer than MAXPATHL, we need to append
-      // earch comma separated part of the option sperately, so that it
+      // search comma separated part of the option separately, so that it
       // can be expanded when read back.
       if (size >= MAXPATHL && (flags & P_COMMA) != 0
           && vim_strchr(*valuep, ',') != NULL) {

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -740,11 +740,11 @@ EXTERN long p_wd;               // 'writedelay'
 EXTERN int p_force_on;          ///< options that cannot be turned off.
 EXTERN int p_force_off;         ///< options that cannot be turned on.
 
-/*
- * "indir" values for buffer-local opions.
- * These need to be defined globally, so that the BV_COUNT can be used with
- * b_p_scriptID[].
- */
+//
+// "indir" values for buffer-local options.
+// These need to be defined globally, so that the BV_COUNT can be used with
+// b_p_scriptID[].
+//
 enum {
   BV_AI = 0
   , BV_AR

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -4,7 +4,7 @@
 /// @file fileio.c
 ///
 /// Buffered reading/writing to a file. Unlike fileio.c this is not dealing with
-/// Nvim stuctures for buffer, with autocommands, etc: just fopen/fread/fwrite
+/// Nvim structures for buffer, with autocommands, etc: just fopen/fread/fwrite
 /// replacement.
 
 #include <assert.h>

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1119,7 +1119,7 @@ uint64_t os_fileinfo_blocksize(const FileInfo *file_info)
 ///
 /// @param path Path to the file.
 /// @param[out] file_info Pointer to a `FileID` to fill in.
-/// @return `true` on sucess, `false` for failure.
+/// @return `true` on success, `false` for failure.
 bool os_fileid(const char *path, FileID *file_id)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -104,7 +104,7 @@ conpty_t *os_conpty_init(char **in_name, char **out_name,
   HRESULT hr;
   hr = pCreatePseudoConsole(size, in_read, out_write, 0, &conpty_object->pty);
   if (FAILED(hr)) {
-    emsg = "create psudo console failed";
+    emsg = "create pseudo console failed";
     goto failed;
   }
 

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -383,7 +383,7 @@ int path_fnamencmp(const char *const fname1, const char *const fname2,
 ///
 /// @param[in]  fname1  First fname to append to.
 /// @param[in]  len1    Length of fname1.
-/// @param[in]  fname2  Secord part of the file name.
+/// @param[in]  fname2  Second part of the file name.
 /// @param[in]  len2    Length of fname2.
 /// @param[in]  sep     If true and fname1 does not end with a path separator,
 ///                     add a path separator before fname2.

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -250,7 +250,7 @@ void time_start(const char *message)
     return;
   }
 
-  // intialize the global variables
+  // initialize the global variables
   g_prev_time = g_start_time = profile_start();
 
   fprintf(time_fd, "\n\ntimes in msec\n");

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2421,7 +2421,7 @@ static qfline_T *get_nth_entry(qf_list_T *qfl, int errornr, int *new_qfidx)
   return qf_ptr;
 }
 
-/// Get a entry specied by 'errornr' and 'dir' from the current
+/// Get a entry specified by 'errornr' and 'dir' from the current
 /// quickfix/location list. 'errornr' specifies the index of the entry and 'dir'
 /// specifies the direction (FORWARD/BACKWARD/FORWARD_FILE/BACKWARD_FILE).
 /// Returns a pointer to the entry and the index of the new entry is stored in
@@ -4807,7 +4807,7 @@ static qfline_T *qf_find_entry_after_pos(
   FUNC_ATTR_NONNULL_ALL
 {
   if (qf_entry_after_pos(qfp, pos, linewise)) {
-    // First entry is after postion 'pos'
+    // First entry is after position 'pos'
     return qfp;
   }
 
@@ -5744,7 +5744,7 @@ static void unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
   }
 }
 
-/// Copy the specified quickfix entry items into a new dict and appened the dict
+/// Copy the specified quickfix entry items into a new dict and append the dict
 /// to 'list'.  Returns OK on success.
 static int get_qfline_items(qfline_T *qfp, list_T *list)
 {
@@ -6000,7 +6000,7 @@ static int qf_getprop_qfidx(qf_info_T *qi, dict_T *what)
   if ((di = tv_dict_find(what, S_LEN("id"))) != NULL) {
     // Look for a list with the specified id
     if (di->di_tv.v_type == VAR_NUMBER) {
-      // For zero, use the current list or the list specifed by 'nr'
+      // For zero, use the current list or the list specified by 'nr'
       if (di->di_tv.vval.v_number != 0) {
         qf_idx = qf_id2nr(qi, (unsigned)di->di_tv.vval.v_number);
       }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2006,7 +2006,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
   char_u      *line;                  // current line
   char_u      *ptr;                   // current position in "line"
   int row;                            // row in the window, excl w_winrow
-  ScreenGrid *grid = &wp->w_grid;     // grid specfic to the window
+  ScreenGrid *grid = &wp->w_grid;     // grid specific to the window
 
   char_u extra[57];                   // sign, line number and 'fdc' must
                                       // fit in here
@@ -2653,7 +2653,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
     off += col;
   }
 
-  // wont highlight after TERM_ATTRS_MAX columns
+  // won't highlight after TERM_ATTRS_MAX columns
   int term_attrs[TERM_ATTRS_MAX] = { 0 };
   if (wp->w_buffer->terminal) {
     terminal_get_line_attributes(wp->w_buffer->terminal, wp, lnum, term_attrs);
@@ -5530,7 +5530,7 @@ static void win_redr_border(win_T *wp)
   }
 }
 
-// Low-level functions to manipulate invidual character cells on the
+// Low-level functions to manipulate individual character cells on the
 // screen grid.
 
 /// Put a ASCII character in a screen cell.
@@ -6837,7 +6837,7 @@ int showmode(void)
     msg_pos_mode();
     attr = HL_ATTR(HLF_CM);                     // Highlight mode
 
-    // When the screen is too narrow to show the entire mode messsage,
+    // When the screen is too narrow to show the entire mode message,
     // avoid scrolling and truncate instead.
     msg_no_more = true;
     int save_lines_left = lines_left;
@@ -6953,7 +6953,7 @@ int showmode(void)
     msg_clr_cmdline();
   }
 
-  // NB: also handles clearing the showmode if it was emtpy or disabled
+  // NB: also handles clearing the showmode if it was empty or disabled
   msg_ext_flush_showmode();
 
   /* In Visual mode the size of the selected area must be redrawn. */

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4451,7 +4451,7 @@ static void update_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos,
     // Unfortunately, there is no STRNICMP function.
     // XXX: above comment should be "no MB_STRCMP function" ?
     if (!(chgtick == buf_get_changedtick(curbuf)
-          && lastpat != NULL  // supress clang/NULL passed as nonnull parameter
+          && lastpat != NULL  // suppress clang/NULL passed as nonnull parameter
           && STRNICMP(lastpat, spats[last_idx].pat, STRLEN(lastpat)) == 0
           && STRLEN(lastpat) == STRLEN(spats[last_idx].pat)
           && equalpos(lastpos, *cursor_pos)

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -143,7 +143,7 @@ int sign_group_get_next_signid(buf_T *buf, const char_u *groupname)
     group = HI2SG(hi);
   }
 
-  // Search for the next usuable sign identifier
+  // Search for the next usable sign identifier
   while (!found) {
     if (group == NULL) {
       id = next_sign_id++;    // global group

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6127,7 +6127,7 @@ static const char *highlight_init_dark[] = {
 };
 
 const char *const highlight_init_cmdline[] = {
-  // XXX When modifying a list modify it in both valid and invalid halfs.
+  // XXX When modifying a list modify it in both valid and invalid halves.
   // TODO(ZyX-I): merge valid and invalid groups via a macros.
 
   // NvimInternalError should appear only when highlighter has a bug.

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3291,7 +3291,7 @@ static void tagstack_clear(win_T *wp)
 }
 
 // Remove the oldest entry from the tag stack and shift the rest of
-// the entires to free up the top of the stack.
+// the entries to free up the top of the stack.
 static void tagstack_shift(win_T *wp)
 {
   taggy_T *tagstack = wp->w_tagstack;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1025,7 +1025,7 @@ static void tui_mouse_on(UI *ui)
   if (!data->mouse_enabled) {
 #ifdef WIN32
     // Windows versions with vtp(ENABLE_VIRTUAL_TERMINAL_PROCESSING) and
-    // no vti(ENABLE_VIRTUAL_TERMINAL_INPUT) will need to use mouse traking of
+    // no vti(ENABLE_VIRTUAL_TERMINAL_INPUT) will need to use mouse tracking of
     // libuv. For this reason, vtp (vterm) state of libuv is temporarily
     // disabled because the control sequence needs to be processed by libuv
     // instead of Windows vtp.
@@ -1048,7 +1048,7 @@ static void tui_mouse_off(UI *ui)
   if (data->mouse_enabled) {
 #ifdef WIN32
     // Windows versions with vtp(ENABLE_VIRTUAL_TERMINAL_PROCESSING) and
-    // no vti(ENABLE_VIRTUAL_TERMINAL_INPUT) will need to use mouse traking of
+    // no vti(ENABLE_VIRTUAL_TERMINAL_INPUT) will need to use mouse tracking of
     // libuv. For this reason, vtp (vterm) state of libuv is temporarily
     // disabled because the control sequence needs to be processed by libuv
     // instead of Windows vtp.

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -214,7 +214,7 @@ void ui_comp_remove_grid(ScreenGrid *grid)
   grid->comp_index = 0;
 
   // recompose the area under the grid
-  // inefficent when being overlapped: only draw up to grid->comp_index
+  // inefficient when being overlapped: only draw up to grid->comp_index
   ui_comp_compose_grid(grid);
 }
 
@@ -594,7 +594,7 @@ static void ui_comp_msg_set_pos(UI *ui, Integer grid, Integer row,
       int first_row = MAX((int)row-(scrolled?1:0), 0);
       compose_area(first_row, Rows-delta, 0, Columns);
     } else {
-      // scroll separator togheter with message text
+      // scroll separator together with message text
       int first_row = MAX((int)row-(msg_was_scrolled?1:0), 0);
       ui_composed_call_grid_scroll(1, first_row, Rows, 0, Columns, delta, 0);
       if (scrolled && !msg_was_scrolled && row > 0) {

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -270,7 +270,7 @@ enum { FOLD_TEXT_LEN = 51 };  //!< buffer size for get_foldtext()
 /// On some systems case in a file name does not matter, on others it does.
 ///
 /// @note Does not account for maximum name lengths and things like "../dir",
-///       thus it is not 100% accurate. OS may also use different algorythm for
+///       thus it is not 100% accurate. OS may also use different algorithm for
 ///       case-insensitive comparison.
 ///
 /// @param[in]  x  First file name to compare.


### PR DESCRIPTION
Codespell is designed for source codes, so it mostly targets comments
and strings which is perfect for neovim.

Any changes that isn't strictly spelling fixes are made solely to make
clint happy.