### PR TITLE
fix(lsp): accept file URIs without a hostname

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -74,7 +74,7 @@ local function uri_from_fname(path)
   return table.concat(uri_parts)
 end
 
-local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):/+.*'
+local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):.*'
 
 --- Get a URI from a bufnr
 --@param bufnr (number): Buffer number

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -52,7 +52,7 @@ end
 
 --@private
 local function is_windows_file_uri(uri)
-  return uri:match('^file:///[a-zA-Z]:') ~= nil
+  return uri:match('^file:/+[a-zA-Z]:') ~= nil
 end
 
 --- Get a URI from a file path.
@@ -74,7 +74,7 @@ local function uri_from_fname(path)
   return table.concat(uri_parts)
 end
 
-local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*)://.*'
+local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):/+.*'
 
 --- Get a URI from a bufnr
 --@param bufnr (number): Buffer number
@@ -100,10 +100,10 @@ local function uri_to_fname(uri)
   uri = uri_decode(uri)
   -- TODO improve this.
   if is_windows_file_uri(uri) then
-    uri = uri:gsub('^file:///', '')
+    uri = uri:gsub('^file:/+', '')
     uri = uri:gsub('/', '\\')
   else
-    uri = uri:gsub('^file://', '')
+    uri = uri:gsub('^file:/+', '/')
   end
   return uri
 end

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -53,8 +53,14 @@ describe('URI methods', function()
 
   describe('uri to filepath', function()
     describe('decode Unix file path', function()
-      it('file path includes only ascii charactors', function()
+      it('file path includes only ascii characters', function()
         exec_lua("uri = 'file:///Foo/Bar/Baz.txt'")
+
+        eq('/Foo/Bar/Baz.txt', exec_lua("return vim.uri_to_fname(uri)"))
+      end)
+
+      it('local file path without hostname', function()
+        exec_lua("uri = 'file:/Foo/Bar/Baz.txt'")
 
         eq('/Foo/Bar/Baz.txt', exec_lua("return vim.uri_to_fname(uri)"))
       end)
@@ -79,6 +85,15 @@ describe('URI methods', function()
       it('file path includes only ascii charactors', function()
         local test_case = [[
         local uri = 'file:///C:/Foo/Bar/Baz.txt'
+        return vim.uri_to_fname(uri)
+        ]]
+
+        eq('C:\\Foo\\Bar\\Baz.txt', exec_lua(test_case))
+      end)
+
+      it('local file path without hostname', function()
+        local test_case = [[
+        local uri = 'file:/C:/Foo/Bar/Baz.txt'
         return vim.uri_to_fname(uri)
         ]]
 

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -140,6 +140,12 @@ describe('URI methods', function()
           return vim.uri_to_fname('JDT://content/%5C/')
         ]])
       end)
+
+      it('uri_to_fname returns non-file scheme URI without authority unchanged', function()
+        eq('zipfile:/path/to/archive.zip%3A%3Afilename.txt', exec_lua [[
+          return vim.uri_to_fname('zipfile:/path/to/archive.zip%3A%3Afilename.txt')
+        ]])
+      end)
     end)
 
     describe('decode URI without scheme', function()
@@ -155,6 +161,15 @@ describe('URI methods', function()
   describe('uri to bufnr', function()
     it('uri_to_bufnr & uri_from_bufnr returns original uri for non-file uris', function()
       local uri = 'jdt://contents/java.base/java.util/List.class?=sql/%5C/home%5C/user%5C/.jabba%5C/jdk%5C/openjdk%5C@1.14.0%5C/lib%5C/jrt-fs.jar%60java.base=/javadoc_location=/https:%5C/%5C/docs.oracle.com%5C/en%5C/java%5C/javase%5C/14%5C/docs%5C/api%5C/=/%3Cjava.util(List.class'
+      local test_case = string.format([[
+        local uri = '%s'
+        return vim.uri_from_bufnr(vim.uri_to_bufnr(uri))
+      ]], uri)
+      eq(uri, exec_lua(test_case))
+    end)
+
+    it('uri_to_bufnr & uri_from_bufnr returns original uri for non-file uris without authority', function()
+      local uri = 'zipfile:/path/to/archive.zip%3A%3Afilename.txt'
       local test_case = string.format([[
         local uri = '%s'
         return vim.uri_from_bufnr(vim.uri_to_bufnr(uri))

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -11,7 +11,7 @@ describe('vim.lsp.codelens', function()
   after_each(helpers.clear)
 
   it('on_codelens_stores_and_displays_lenses', function()
-    local fake_uri = "file://fake/uri"
+    local fake_uri = "file:///fake/uri"
     local bufnr = exec_lua([[
       fake_uri = ...
       local bufnr = vim.uri_to_bufnr(fake_uri)

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -49,7 +49,7 @@ describe('vim.lsp.diagnostic', function()
       end
     ]]
 
-    fake_uri = "file://fake/uri"
+    fake_uri = "file:///fake/uri"
 
     exec_lua([[
       fake_uri = ...

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1147,14 +1147,14 @@ describe('LSP', function()
           make_edit(0, 0, 0, 3, "First ↥ 🤦 🦄")
         },
         textDocument = {
-          uri = "file://fake/uri";
+          uri = "file:///fake/uri";
           version = editVersion
         }
       }
     end
     before_each(function()
       target_bufnr = exec_lua [[
-        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local bufnr = vim.uri_to_bufnr("file:///fake/uri")
         local lines = {"1st line of text", "2nd line of 语text"}
         vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, lines)
         return bufnr
@@ -1234,7 +1234,7 @@ describe('LSP', function()
           make_edit(row, 0, row, 1000, new_line)
         },
         textDocument = {
-          uri = "file://fake/uri";
+          uri = "file:///fake/uri";
           version = editVersion
         }
       }
@@ -1252,7 +1252,7 @@ describe('LSP', function()
 
     before_each(function()
       local ret = exec_lua [[
-        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local bufnr = vim.uri_to_bufnr("file:///fake/uri")
         local lines = {
           "Original Line #1",
           "Original Line #2"
@@ -1532,19 +1532,19 @@ describe('LSP', function()
     it('Convert Location[] to items', function()
       local expected = {
         {
-          filename = 'fake/uri',
+          filename = '/fake/uri',
           lnum = 1,
           col = 3,
           text = 'testing'
         },
       }
       local actual = exec_lua [[
-        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local bufnr = vim.uri_to_bufnr("file:///fake/uri")
         local lines = {"testing", "123"}
         vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, lines)
         local locations = {
           {
-            uri = 'file://fake/uri',
+            uri = 'file:///fake/uri',
             range = {
               start = { line = 0, character = 2 },
               ['end'] = { line = 0, character = 3 },
@@ -1558,14 +1558,14 @@ describe('LSP', function()
     it('Convert LocationLink[] to items', function()
       local expected = {
         {
-          filename = 'fake/uri',
+          filename = '/fake/uri',
           lnum = 1,
           col = 3,
           text = 'testing'
         },
       }
       local actual = exec_lua [[
-        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local bufnr = vim.uri_to_bufnr("file:///fake/uri")
         local lines = {"testing", "123"}
         vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, lines)
         local locations = {
@@ -1779,14 +1779,14 @@ describe('LSP', function()
         local expected = {
           {
             col = 1,
-            filename = 'test_a',
+            filename = '/test_a',
             kind = 'File',
             lnum = 2,
             text = '[File] TestA'
           },
           {
             col = 1,
-            filename = 'test_b',
+            filename = '/test_b',
             kind = 'Module',
             lnum = 4,
             text = '[Module] TestB'
@@ -1809,7 +1809,7 @@ describe('LSP', function()
                     line = 2
                   }
                 },
-                uri = "file://test_a"
+                uri = "file:///test_a"
               },
               contanerName = "TestAContainer"
             },
@@ -1828,7 +1828,7 @@ describe('LSP', function()
                     line = 4
                   }
                 },
-                uri = "file://test_b"
+                uri = "file:///test_b"
               },
               contanerName = "TestBContainer"
             }
@@ -1867,7 +1867,7 @@ describe('LSP', function()
 
     before_each(function()
       target_bufnr = exec_lua [[
-        local bufnr = vim.uri_to_bufnr("file://fake/uri")
+        local bufnr = vim.uri_to_bufnr("file:///fake/uri")
         local lines = {"1st line of text", "å å ɧ 汉语 ↥ 🤦 🦄"}
         vim.api.nvim_buf_set_lines(bufnr, 0, 1, false, lines)
         return bufnr
@@ -1876,7 +1876,7 @@ describe('LSP', function()
 
     local location = function(start_line, start_char, end_line, end_char)
       return {
-        uri = "file://fake/uri",
+        uri = "file:///fake/uri",
         range = {
           start = { line = start_line, character = start_char },
           ["end"] = { line = end_line, character = end_char },
@@ -1901,7 +1901,7 @@ describe('LSP', function()
 
     it('jumps to a LocationLink', function()
       local pos = jump({
-          targetUri = "file://fake/uri",
+          targetUri = "file:///fake/uri",
           targetSelectionRange = {
             start = { line = 0, character = 4 },
             ["end"] = { line = 0, character = 4 },


### PR DESCRIPTION
RFC 8089, which defines the file URI scheme, also [allows URIs without a hostname](https://datatracker.ietf.org/doc/html/rfc8089#section-2), i.e. of the form `file:/path/to/file` instead of `file:///path/to/file`. These are returned by some language servers (e.g. [vdmj](https://github.com/nickbattle/vdmj/issues/54)), causing neovim to throw an error after initialisation. Since they accepted by other LSP implementations, such as the ones in VSCode and Eclipse's lsp4e, it is reasonable for neovim to accept them as well.