### PR TITLE
feat(lsp): Make line diagnostics display prettier

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1211,7 +1211,7 @@ function M.show_line_diagnostics(opts, bufnr, line_nr, client_id)
     table.insert(lines, prefix..message_lines[1])
     table.insert(highlights, {#prefix, hiname})
     for j = 2, #message_lines do
-      table.insert(lines, message_lines[j])
+      table.insert(lines, string.rep(' ', #prefix) .. message_lines[j])
       table.insert(highlights, {0, hiname})
     end
   end


### PR DESCRIPTION
- Removes the numbering prefix if there is only a single diagnostic
- Adds indentation that matches the number prefix to ensure diagnostic
  messages spawning multiple lines align.

Before:

    Diagnostics:
    1. • Variable not in scope: red :: t0 -> t
    • Perhaps you meant one of these:
        ‘rem’ (imported from Prelude), ‘read’ (imported from Prelude),
        ‘pred’ (imported from Prelude)
    2. • Variable not in scope: repeDoubleColon :: [Char] -> t0
    • Perhaps you meant ‘replaceDoubleColon’ (line 32)

After:

    Diagnostics:
    1. • Variable not in scope: red :: t0 -> t
       • Perhaps you meant one of these:
           ‘rem’ (imported from Prelude), ‘read’ (imported from Prelude),
           ‘pred’ (imported from Prelude)
    2. • Variable not in scope: repeDoubleColon :: [Char] -> t0
       • Perhaps you meant ‘replaceDoubleColon’ (line 32)
