### PR TITLE
vim-patch:8.2.3089: garbage collection has useless code

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3459,54 +3459,54 @@ dictitem_T *find_var_in_scoped_ht(const char *name, const size_t namelen,
 /// Set "copyID + 1" in previous_funccal and callers.
 bool set_ref_in_previous_funccal(int copyID)
 {
-  bool abort = false;
-
-  for (funccall_T *fc = previous_funccal; !abort && fc != NULL;
+  for (funccall_T *fc = previous_funccal; fc != NULL;
        fc = fc->caller) {
     fc->fc_copyID = copyID + 1;
-    abort = abort
-      || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID + 1, NULL)
-      || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID + 1, NULL)
-      || set_ref_in_list(&fc->l_varlist, copyID + 1, NULL);
+    if (set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID + 1, NULL)
+        || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID + 1, NULL)
+        || set_ref_in_list(&fc->l_varlist, copyID + 1, NULL)) {
+      return true;
+    }
   }
-  return abort;
+  return false;
 }
 
 static bool set_ref_in_funccal(funccall_T *fc, int copyID)
 {
-  bool abort = false;
-
   if (fc->fc_copyID != copyID) {
     fc->fc_copyID = copyID;
-    abort = abort
-      || set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL)
-      || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL)
-      || set_ref_in_list(&fc->l_varlist, copyID, NULL)
-      || set_ref_in_func(NULL, fc->func, copyID);
+    if (set_ref_in_ht(&fc->l_vars.dv_hashtab, copyID, NULL)
+        || set_ref_in_ht(&fc->l_avars.dv_hashtab, copyID, NULL)
+        || set_ref_in_list(&fc->l_varlist, copyID, NULL)
+        || set_ref_in_func(NULL, fc->func, copyID)) {
+      return true;
+    }
   }
-  return abort;
+  return false;
 }
 
 /// Set "copyID" in all local vars and arguments in the call stack.
 bool set_ref_in_call_stack(int copyID)
 {
-  bool abort = false;
-
-  for (funccall_T *fc = current_funccal; !abort && fc != NULL;
+  for (funccall_T *fc = current_funccal; fc != NULL;
        fc = fc->caller) {
-    abort = abort || set_ref_in_funccal(fc, copyID);
-  }
-
-  // Also go through the funccal_stack.
-  for (funccal_entry_T *entry = funccal_stack; !abort && entry != NULL;
-       entry = entry->next) {
-    for (funccall_T *fc = entry->top_funccal; !abort && fc != NULL;
-         fc = fc->caller) {
-      abort = abort || set_ref_in_funccal(fc, copyID);
+    if (set_ref_in_funccal(fc, copyID)) {
+      return true;
     }
   }
 
-  return abort;
+  // Also go through the funccal_stack.
+  for (funccal_entry_T *entry = funccal_stack; entry != NULL;
+       entry = entry->next) {
+    for (funccall_T *fc = entry->top_funccal; fc != NULL;
+         fc = fc->caller) {
+      if (set_ref_in_funccal(fc, copyID)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 /// Set "copyID" in all functions available by name.
@@ -3514,7 +3514,6 @@ bool set_ref_in_functions(int copyID)
 {
   int todo;
   hashitem_T *hi = NULL;
-  bool abort = false;
   ufunc_T *fp;
 
   todo = (int)func_hashtab.ht_used;
@@ -3522,24 +3521,25 @@ bool set_ref_in_functions(int copyID)
     if (!HASHITEM_EMPTY(hi)) {
       todo--;
       fp = HI2UF(hi);
-      if (!func_name_refcount(fp->uf_name)) {
-        abort = abort || set_ref_in_func(NULL, fp, copyID);
+      if (!func_name_refcount(fp->uf_name)
+          && set_ref_in_func(NULL, fp, copyID)) {
+        return true;
       }
     }
   }
-  return abort;
+  return false;
 }
 
 /// Set "copyID" in all function arguments.
 bool set_ref_in_func_args(int copyID)
 {
-  bool abort = false;
-
   for (int i = 0; i < funcargs.ga_len; i++) {
-    abort = abort || set_ref_in_item(((typval_T **)funcargs.ga_data)[i],
-                                     copyID, NULL, NULL);
+    if (set_ref_in_item(((typval_T **)funcargs.ga_data)[i],
+                        copyID, NULL, NULL)) {
+       return true;
+    }
   }
-  return abort;
+  return false;
 }
 
 /// Mark all lists and dicts referenced through function "name" with "copyID".


### PR DESCRIPTION
Problem:    Garbage collection has useless code.
Solution:   Bail out when aborting. (closes vim/vim#8504)
https://github.com/vim/vim/commit/20cc52832067d22a3cd47dfb0805251228c32e7d