### PR TITLE
vim-patch:8.2.3125: variables are set but not used

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -1161,8 +1161,6 @@ static int nfa_regatom(void)
   int emit_range;
   int negated;
   int startc = -1;
-  int endc = -1;
-  int oldstartc = -1;
   int save_prev_at_start = prev_at_start;
 
   c = getchr();
@@ -1572,7 +1570,7 @@ collection:
        * Failed to recognize a character class. Use the simple
        * version that turns [abc] into 'a' OR 'b' OR 'c'
        */
-      startc = endc = oldstartc = -1;
+      startc = -1;
       negated = false;
       if (*regparse == '^') {                           // negated range
         negated = true;
@@ -1589,7 +1587,7 @@ collection:
       // Emit the OR branches for each character in the []
       emit_range = false;
       while (regparse < endp) {
-        oldstartc = startc;
+        int oldstartc = startc;
         startc = -1;
         got_coll_char = false;
         if (*regparse == '[') {
@@ -1729,7 +1727,7 @@ collection:
 
         /* Previous char was '-', so this char is end of range. */
         if (emit_range) {
-          endc = startc;
+          int endc = startc;
           startc = oldstartc;
           if (startc > endc) {
             EMSG_RET_FAIL(_(e_reverse_range));


### PR DESCRIPTION
Problem:    Variables are set but not used.
Solution:   Move the declarations to the block where they are used.
            (closes vim/vim#8527)
https://github.com/vim/vim/commit/09f688c33aad9692276dfb68842cf0621a0e2002