### PR TITLE
Treesitter: check for EOF on get_node_text

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -175,7 +175,8 @@ function M.get_node_text(node, source)
   local end_row, end_col, end_byte = node:end_()
 
   if type(source) == "number" then
-    if start_row ~= end_row then
+    local eof_row = vim.api.nvim_buf_line_count(source)
+    if start_row ~= end_row or start_row >= eof_row then
       return nil
     end
     local line = a.nvim_buf_get_lines(source, start_row, start_row+1, true)[1]


### PR DESCRIPTION
So, treesitter has this weird thing
where it can match the `EOF` mark.
The position of that mark is (n + 1, 0),
where n is the last line of the file.

We have been bitten by this in some other occasions,
probably worth mentioning it in the docs somewhere.

Ref https://github.com/nvim-treesitter/nvim-treesitter/issues/1531

I'm not sure if I should be able to put a test for this one, since we need a parser that tries to match the EOF (like ruby's heredocs)