### PR TITLE
refactor(undo): don't assume curbuf in u_compute_hash

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8010,16 +8010,16 @@ static void ex_wundo(exarg_T *eap)
 {
   char_u hash[UNDO_HASH_SIZE];
 
-  u_compute_hash(hash);
-  u_write_undo((char *) eap->arg, eap->forceit, curbuf, hash);
+  u_compute_hash(curbuf, hash);
+  u_write_undo((char *)eap->arg, eap->forceit, curbuf, hash);
 }
 
 static void ex_rundo(exarg_T *eap)
 {
   char_u hash[UNDO_HASH_SIZE];
 
-  u_compute_hash(hash);
-  u_read_undo((char *) eap->arg, hash, NULL);
+  u_compute_hash(curbuf, hash);
+  u_read_undo((char *)eap->arg, hash, NULL);
 }
 
 /// ":redo".

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4967,13 +4967,10 @@ int buf_check_timestamp(buf_T *buf)
     buf_reload(buf, orig_mode);
     if (buf->b_p_udf && buf->b_ffname != NULL) {
       char_u hash[UNDO_HASH_SIZE];
-      buf_T           *save_curbuf = curbuf;
 
-      /* Any existing undo file is unusable, write it now. */
-      curbuf = buf;
-      u_compute_hash(hash);
-      u_write_undo(NULL, FALSE, buf, hash);
-      curbuf = save_curbuf;
+      // Any existing undo file is unusable, write it now.
+      u_compute_hash(buf, hash);
+      u_write_undo(NULL, false, buf, hash);
     }
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3837,22 +3837,19 @@ static char *set_bool_option(const int opt_idx, char_u *const varp,
     // any changes in between.
     if (curbuf->b_p_udf || p_udf) {
       char_u hash[UNDO_HASH_SIZE];
-      buf_T       *save_curbuf = curbuf;
 
       FOR_ALL_BUFFERS(bp) {
-        curbuf = bp;
         // When 'undofile' is set globally: for every buffer, otherwise
         // only for the current buffer: Try to read in the undofile,
         // if one exists, the buffer wasn't changed and the buffer was
         // loaded
-        if ((curbuf == save_curbuf
+        if ((curbuf == bp
              || (opt_flags & OPT_GLOBAL) || opt_flags == 0)
-            && !curbufIsChanged() && curbuf->b_ml.ml_mfp != NULL) {
-          u_compute_hash(hash);
-          u_read_undo(NULL, hash, curbuf->b_fname);
+            && !bufIsChanged(bp) && bp->b_ml.ml_mfp != NULL) {
+          u_compute_hash(bp, hash);
+          u_read_undo(NULL, hash, bp->b_fname);
         }
       }
-      curbuf = save_curbuf;
     }
   } else if ((int *)varp == &curbuf->b_p_ro) {
     // when 'readonly' is reset globally, also reset readonlymode

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -631,18 +631,20 @@ int u_savecommon(buf_T *buf,
 
 static char_u e_not_open[] = N_("E828: Cannot open undo file for writing: %s");
 
-/*
- * Compute the hash for the current buffer text into hash[UNDO_HASH_SIZE].
- */
-void u_compute_hash(char_u *hash)
+/// Compute the hash for a buffer text into hash[UNDO_HASH_SIZE].
+///
+/// @param[in] buf The buffer used to compute the hash
+/// @param[in] hash Array of size UNDO_HASH_SIZE in which to store the value of
+///                 the hash
+void u_compute_hash(buf_T *buf, char_u *hash)
 {
   context_sha256_T ctx;
   linenr_T lnum;
   char_u              *p;
 
   sha256_start(&ctx);
-  for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; ++lnum) {
-    p = ml_get(lnum);
+  for (lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
+    p = ml_get_buf(buf, lnum, false);
     sha256_update(&ctx, p, (uint32_t)(STRLEN(p) + 1));
   }
   sha256_finish(&ctx, hash);

--- a/test/unit/undo_spec.lua
+++ b/test/unit/undo_spec.lua
@@ -38,7 +38,7 @@ child_call_once(function()
   --
   -- compute a hash for this undofile
   buffer_hash = ffi.new('char_u[32]')
-  undo.u_compute_hash(buffer_hash)
+  undo.u_compute_hash(file_buffer, buffer_hash)
 end)
 
 


### PR DESCRIPTION
Followup of #12971.

Other occurences of `save_curbuf` are actually a bit trickier, so I
don't think I'll be able to piggyback more changes into this PR.
