### PR TITLE
Add :help referenced README.txt runtime files

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -126,6 +126,8 @@ endforeach()
 
 file(GLOB_RECURSE RUNTIME_FILES
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+  colors/README.txt  # referenced in ':help :colorscheme'
+  indent/README.txt  # referenced in ':help indent-expression'
   rgb.txt
   *.vim *.lua *.dict *.py *.rb *.ps *.spl *.tutor *.tutor.json)
 


### PR DESCRIPTION
The `:help` pages reference `README.txt` files that are currently not included in `$VIMRUNTIME`. This PR updates `CMakeLists.txt` so that these files are included.

I did not include the other `README.txt` files (e.g., `compiler/README.txt`). Perhaps those should be included as well (excluding `indent/testdir/README.txt`) for user reference, but they're not mentioned in the `:help` pages.

In preparing this update, I noticed that there are various references to files in `$VIMRUNTIME/lang` (e.g., `:help multilang-menus` mentions Vim scripts that can be found in that directory). The `lang/` directory is not present under `runtime/` of the Neovim repo and thus was not addressed as part of this PR.