### PR TITLE
vim-patch:8.1.0829: when 'hidden' is set session creates extra buffers

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -583,22 +583,6 @@ static int makeopens(FILE *fd, char_u *dirnow)
     return FAIL;
   }
 
-  // Now put the other buffers into the buffer list.
-  FOR_ALL_BUFFERS(buf) {
-    if (!(only_save_windows && buf->b_nwindows == 0)
-        && !(buf->b_help && !(ssop_flags & SSOP_HELP))
-        && buf->b_fname != NULL
-        && buf->b_p_bl) {
-      if (fprintf(fd, "badd +%" PRId64 " ",
-                  buf->b_wininfo == NULL
-                  ? (int64_t)1L
-                  : (int64_t)buf->b_wininfo->wi_fpos.lnum) < 0
-          || ses_fname(fd, buf, &ssop_flags, true) == FAIL) {
-        return FAIL;
-      }
-    }
-  }
-
   // the global argument list
   if (ses_arglist(fd, "argglobal", &global_alist.al_ga,
                   !(ssop_flags & SSOP_CURDIR), &ssop_flags) == FAIL) {
@@ -813,12 +797,31 @@ static int makeopens(FILE *fd, char_u *dirnow)
     return FAIL;
   }
 
+  // Now put the remaining buffers into the buffer list.
+  // This is near the end, so that when 'hidden' is set we don't create extra
+  // buffers.  If the buffer was already created with another command the
+  // ":badd" will have no effect.
+  FOR_ALL_BUFFERS(buf) {
+    if (!(only_save_windows && buf->b_nwindows == 0)
+        && !(buf->b_help && !(ssop_flags & SSOP_HELP))
+        && buf->b_fname != NULL
+        && buf->b_p_bl) {
+      if (fprintf(fd, "badd +%" PRId64 " ",
+                  buf->b_wininfo == NULL
+                  ? (int64_t)1L
+                  : (int64_t)buf->b_wininfo->wi_fpos.lnum) < 0
+          || ses_fname(fd, buf, &ssop_flags, true) == FAIL) {
+        return FAIL;
+      }
+    }
+  }
+
   //
   // Wipe out an empty unnamed buffer we started in.
   //
   if (fprintf(fd, "%s",
               "if exists('s:wipebuf') "
-              "&& len(win_findbuf(s:wipebuf)) == 0"
+              "&& len(win_findbuf(s:wipebuf)) == 0 "
               "&& getbufvar(s:wipebuf, '&buftype') isnot# 'terminal'\n"
               "  silent exe 'bwipe ' . s:wipebuf\n"
               "endif\n"

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -287,6 +287,29 @@ func Test_mksession_blank_windows()
   call delete('Xtest_mks.out')
 endfunc
 
+func Test_mksession_buffer_count()
+  set hidden
+
+  " Edit exactly three files in the current session.
+  %bwipe!
+  e Xfoo | tabe Xbar | tabe Xbaz
+  tabdo write
+  mksession! Xtest_mks.out
+
+  " Verify that loading the session does not create additional buffers.
+  %bwipe!
+  source Xtest_mks.out
+  call assert_equal(3, len(getbufinfo()))
+
+  " Clean up.
+  call delete('Xfoo')
+  call delete('Xbar')
+  call delete('Xbaz')
+  call delete('Xtest_mks.out')
+  %bwipe!
+  set hidden&
+endfunc
+
 if has('extra_search')
 
 func Test_mksession_hlsearch()

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -43,7 +43,7 @@ describe(':mksession', function()
     -- Restore session.
     command('source '..session_file)
 
-    eq({3,3,2},
+    eq({2,2,4},
       {funcs.winbufnr(1), funcs.winbufnr(2), funcs.winbufnr(3)})
   end)
 
@@ -91,7 +91,12 @@ describe(':mksession', function()
     command('tabnext 1')
     eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '1', funcs.expand('%:p'))
     command('tabnext 2')
-    eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', funcs.expand('%:p'))
+    -- :mksession stores paths using unix slashes, but Nvim doesn't adjust these
+    -- for absolute paths in all cases yet. Absolute paths are used in the
+    -- session file after :tcd, so we need to expect unix slashes here for now
+    -- eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', funcs.expand('%:p'))
+    eq(cwd_dir:gsub([[\]], '/') .. '/' .. tmpfile_base .. '2',
+      funcs.expand('%:p'))
   end)
 
   it('restores CWD for :terminal buffers #11288', function()


### PR DESCRIPTION
Problem:   When 'hidden' is set session creates extra buffers.
Solution:   Move :badd commands to the end. (Jason Franklin)
https://github.com/vim/vim/commit/d39e275b57493f9e25e1b62f84810571eee30cf4

Adjust some tests in `ex_cmds/mksession_spec.lua`:

- `restores same :terminal buf in splits`: Buffers aren't always `:badd`ed
  in the same order as they're `:edit`ed, `:balt`ed, etc., so the order of
  buffers in the buffer list may change slightly now that `:badd` happens
  after. (https://github.com/vim/vim/issues/4352)
- `restores buffers with tab-local CWD`: This is explained in a comment.
  The underlying problem (unrelated to this PR) seems non-trivial to fix, and
  requires updates to many tests; it seems better to leave it be for now.

Closes #15051.
