### PR TITLE
[RDY] chore(PVS/V751): tui.c, Parameter is not used

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1125,7 +1125,8 @@ static void tui_mode_change(UI *ui, String mode, Integer mode_idx)
 
 static void tui_grid_scroll(UI *ui, Integer g, Integer startrow, Integer endrow,
                             Integer startcol, Integer endcol,
-                            Integer rows, Integer cols FUNC_ATTR_UNUSED)
+                            Integer rows,
+                            Integer cols FUNC_ATTR_UNUSED)  // -V751
 {
   TUIData *data = ui->data;
   UGrid *grid = &data->grid;


### PR DESCRIPTION
False positive. Documentation for grid_scroll says "`cols` is always
zero, reserved for future use".