### PR TITLE
refactor(options): remove obsolete distinction of "vi" vs "vim" defaults

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -69,7 +69,6 @@ local get_flags = function(o)
     {'alloced'},
     {'nodefault'},
     {'no_mkrc'},
-    {'vi_def'},
     {'secure'},
     {'gettext'},
     {'noglob'},
@@ -119,8 +118,11 @@ local get_value = function(v)
   return '(char_u *) ' .. value_dumpers[type(v)](v)
 end
 
-local get_defaults = function(d)
-  return ('{' .. get_value(d.vi) .. ', ' .. get_value(d.vim) .. '}')
+local get_defaults = function(d,n)
+  if (d.vi == nil and d.vim == nil) or (d.vi ~= nil and d.vim ~= nil) then
+    error("option '"..n.."' should have one and only one default value")
+  end
+  return get_value(d.vim or d.vi)
 end
 
 local defines = {}
@@ -169,11 +171,11 @@ local dump_option = function(i, o)
     if o.defaults.condition then
       w(get_cond(o.defaults.condition))
     end
-    w('    .def_val=' .. get_defaults(o.defaults.if_true))
+    w('    .def_val=' .. get_defaults(o.defaults.if_true, o.full_name))
     if o.defaults.condition then
       if o.defaults.if_false then
         w('#else')
-        w('    .def_val=' .. get_defaults(o.defaults.if_false))
+        w('    .def_val=' .. get_defaults(o.defaults.if_false, o.full_name))
       end
       w('#endif')
     end

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -70,7 +70,6 @@ local get_flags = function(o)
     {'nodefault'},
     {'no_mkrc'},
     {'vi_def'},
-    {'vim'},
     {'secure'},
     {'gettext'},
     {'noglob'},

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -16,8 +16,6 @@
 // - If it's a numeric option, add any necessary bounds checks to
 //   set_num_option().
 // - If it's a list of flags, add some code in do_set(), search for WW_ALL.
-// - When adding an option with expansion (P_EXPAND), but with a different
-//   default for Vi and Vim (no P_VI_DEF), add some code at VIMEXP.
 // - Add documentation! doc/options.txt, and any other related places.
 // - Add an entry in runtime/optwin.vim.
 
@@ -208,12 +206,10 @@ typedef struct vimoption {
                                 // buffer-local option: global value
   idopt_T indir;                // global option: PV_NONE;
                                 // local option: indirect option index
-  char_u      *def_val[2];      // default values for variable (vi and vim)
+  char_u      *def_val;         // default values for variable (neovim!!)
   LastSet last_set;             // script in which the option was last set
 } vimoption_T;
 
-#define VI_DEFAULT  0       // def_val[VI_DEFAULT] is Vi default value
-#define VIM_DEFAULT 1       // def_val[VIM_DEFAULT] is Vim default value
 
 /*
  * Flags
@@ -232,7 +228,6 @@ typedef struct vimoption {
                                  // use free() when assigning new value
 #define P_WAS_SET       0x100U   // option has been set/reset
 #define P_NO_MKRC       0x200U   // don't include in :mkvimrc output
-#define P_VI_DEF        0x400U   // Use Vi default for Vim
 
 // when option changed, what to display:
 #define P_RSTAT         0x1000U  ///< redraw status lines
@@ -458,7 +453,7 @@ void set_init_1(bool clean_arg)
         buf[j] = NUL;
         opt_idx = findoption("cdpath");
         if (opt_idx >= 0) {
-          options[opt_idx].def_val[VI_DEFAULT] = buf;
+          options[opt_idx].def_val = buf;
           options[opt_idx].flags |= P_DEF_ALLOCED;
         } else {
           xfree(buf);           // cannot happen
@@ -526,7 +521,7 @@ void set_init_1(bool clean_arg)
   check_win_options(curwin);
   check_options();
 
-  // Set all options to their Vim default
+  // Set all options to their default value
   set_options_default(OPT_FREE);
 
   // set 'laststatus'
@@ -562,15 +557,10 @@ void set_init_1(bool clean_arg)
     if (p != NULL) {
       p = xstrdup(p);
       *(char **)options[opt_idx].var = p;
-      /* VIMEXP
-       * Defaults for all expanded options are currently the same for Vi
-       * and Vim.  When this changes, add some code here!  Also need to
-       * split P_DEF_ALLOCED in two.
-       */
       if (options[opt_idx].flags & P_DEF_ALLOCED) {
-        xfree(options[opt_idx].def_val[VI_DEFAULT]);
+        xfree(options[opt_idx].def_val);
       }
-      options[opt_idx].def_val[VI_DEFAULT] = (char_u *)p;
+      options[opt_idx].def_val = (char_u *)p;
       options[opt_idx].flags |= P_DEF_ALLOCED;
     }
   }
@@ -613,39 +603,34 @@ void set_init_1(bool clean_arg)
 
 /// Set an option to its default value.
 /// This does not take care of side effects!
-static void
-set_option_default(
-    int opt_idx,
-    int opt_flags,              // OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
-    int compatible              // use Vi default value
-)
+///
+/// @param opt_flags OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
+static void set_option_default(int opt_idx, int opt_flags)
 {
   char_u      *varp;            // pointer to variable for current option
-  int dvi;                      // index in def_val[]
   int both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
 
   varp = get_varp_scope(&(options[opt_idx]), both ? OPT_LOCAL : opt_flags);
   uint32_t flags = options[opt_idx].flags;
   if (varp != NULL) {       // skip hidden option, nothing to do for it
-    dvi = ((flags & P_VI_DEF) || compatible) ? VI_DEFAULT : VIM_DEFAULT;
     if (flags & P_STRING) {
       /* Use set_string_option_direct() for local options to handle
        * freeing and allocating the value. */
       if (options[opt_idx].indir != PV_NONE) {
         set_string_option_direct(NULL, opt_idx,
-                                 options[opt_idx].def_val[dvi], opt_flags, 0);
+                                 options[opt_idx].def_val, opt_flags, 0);
       } else {
         if ((opt_flags & OPT_FREE) && (flags & P_ALLOCED)) {
           free_string_option(*(char_u **)(varp));
         }
-        *(char_u **)varp = options[opt_idx].def_val[dvi];
+        *(char_u **)varp = options[opt_idx].def_val;
         options[opt_idx].flags &= ~P_ALLOCED;
       }
     } else if (flags & P_NUM)   {
       if (options[opt_idx].indir == PV_SCROLL) {
         win_comp_scroll(curwin);
       } else {
-        long def_val = (long)options[opt_idx].def_val[dvi];
+        long def_val = (long)options[opt_idx].def_val;
         if ((long *)varp == &curwin->w_p_so
             || (long *)varp == &curwin->w_p_siso) {
           // 'scrolloff' and 'sidescrolloff' local values have a
@@ -661,7 +646,7 @@ set_option_default(
         }
       }
     } else {  // P_BOOL
-      *(int *)varp = (int)(intptr_t)options[opt_idx].def_val[dvi];
+      *(int *)varp = (int)(intptr_t)options[opt_idx].def_val;
 #ifdef UNIX
       // 'modeline' defaults to off for root
       if (options[opt_idx].indir == PV_ML && getuid() == ROOT_UID) {
@@ -691,7 +676,7 @@ set_options_default(
 {
   for (int i = 0; options[i].fullname; i++) {
     if (!(options[i].flags & P_NODEFAULT)) {
-      set_option_default(i, opt_flags, false);
+      set_option_default(i, opt_flags);
     }
   }
 
@@ -715,10 +700,10 @@ static void set_string_default(const char *name, char *val, bool allocated)
   int opt_idx = findoption(name);
   if (opt_idx >= 0) {
     if (options[opt_idx].flags & P_DEF_ALLOCED) {
-      xfree(options[opt_idx].def_val[VI_DEFAULT]);
+      xfree(options[opt_idx].def_val);
     }
 
-    options[opt_idx].def_val[VI_DEFAULT] = allocated
+    options[opt_idx].def_val = allocated
         ? (char_u *)val
         : (char_u *)xstrdup(val);
     options[opt_idx].flags |= P_DEF_ALLOCED;
@@ -765,7 +750,7 @@ void set_number_default(char *name, long val)
 
   opt_idx = findoption(name);
   if (opt_idx >= 0) {
-    options[opt_idx].def_val[VI_DEFAULT] = (char_u *)(intptr_t)val;
+    options[opt_idx].def_val = (char_u *)(intptr_t)val;
   }
 }
 
@@ -780,7 +765,7 @@ void free_all_options(void)
         free_string_option(*(char_u **)options[i].var);
       }
       if (options[i].flags & P_DEF_ALLOCED) {
-        free_string_option(options[i].def_val[VI_DEFAULT]);
+        free_string_option(options[i].def_val);
       }
     } else if (options[i].var != VAR_WIN && (options[i].flags & P_STRING)) {
       // buffer-local option: free global value
@@ -803,7 +788,7 @@ void set_init_2(bool headless)
   // which results in the actual value computed from the window height.
   idx = findoption("scroll");
   if (idx >= 0 && !(options[idx].flags & P_WAS_SET)) {
-    set_option_default(idx, OPT_LOCAL, false);
+    set_option_default(idx, OPT_LOCAL);
   }
   comp_col();
 
@@ -849,11 +834,11 @@ void set_init_3(void)
                ) {
       if (do_sp) {
         p_sp = (char_u *)"|& tee";
-        options[idx_sp].def_val[VI_DEFAULT] = p_sp;
+        options[idx_sp].def_val = p_sp;
       }
       if (do_srr) {
         p_srr = (char_u *)">&";
-        options[idx_srr].def_val[VI_DEFAULT] = p_srr;
+        options[idx_srr].def_val = p_srr;
       }
     } else if (fnamecmp(p, "sh") == 0
                || fnamecmp(p, "ksh") == 0
@@ -869,11 +854,11 @@ void set_init_3(void)
       // Always use POSIX shell style redirection if we reach this
       if (do_sp) {
         p_sp = (char_u *)"2>&1| tee";
-        options[idx_sp].def_val[VI_DEFAULT] = p_sp;
+        options[idx_sp].def_val = p_sp;
       }
       if (do_srr) {
         p_srr = (char_u *)">%s 2>&1";
-        options[idx_srr].def_val[VI_DEFAULT] = p_srr;
+        options[idx_srr].def_val = p_srr;
       }
     }
     xfree(p);
@@ -940,12 +925,12 @@ void set_title_defaults(void)
    */
   idx1 = findoption("title");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
-    options[idx1].def_val[VI_DEFAULT] = (char_u *)(intptr_t)0;
+    options[idx1].def_val = (char_u *)(intptr_t)0;
     p_title = 0;
   }
   idx1 = findoption("icon");
   if (idx1 >= 0 && !(options[idx1].flags & P_WAS_SET)) {
-    options[idx1].def_val[VI_DEFAULT] = (char_u *)(intptr_t)0;
+    options[idx1].def_val = (char_u *)(intptr_t)0;
     p_icon = 0;
   }
 }
@@ -985,7 +970,6 @@ int do_set(
   int adding;                       // "opt+=arg"
   int prepending;                   // "opt^=arg"
   int removing;                     // "opt-=arg"
-  int cp_val = 0;
 
   if (*arg == NUL) {
     showoptions(0, opt_flags);
@@ -1156,13 +1140,10 @@ int do_set(
 
       if (vim_strchr((char_u *)"?=:!&<", nextchar) != NULL) {
         arg += len;
-        cp_val = false;
         if (nextchar == '&' && arg[1] == 'v' && arg[2] == 'i') {
-          if (arg[3] == 'm') {          // "opt&vim": set to Vim default
-            cp_val = false;
+          if (arg[3] == 'm') {  // "opt&vim": set to Vim default
             arg += 3;
-          } else {                    // "opt&vi": set to Vi default
-            cp_val = true;
+          } else {  // "opt&vi": set to Vi default
             arg += 2;
           }
         }
@@ -1229,9 +1210,7 @@ int do_set(
           if (nextchar == '!') {
             value = *(int *)(varp) ^ 1;
           } else if (nextchar == '&') {
-            value = (int)(intptr_t)options[opt_idx].def_val[
-                ((flags & P_VI_DEF) || cp_val)
-                ?  VI_DEFAULT : VIM_DEFAULT];
+            value = (int)(intptr_t)options[opt_idx].def_val;
           } else if (nextchar == '<') {
             // For 'autoread' -1 means to use global value.
             if ((int *)varp == &curbuf->b_p_ar
@@ -1276,8 +1255,7 @@ int do_set(
             // other        error
             arg++;
             if (nextchar == '&') {
-              value = (long)(intptr_t)options[opt_idx].def_val[
-                  ((flags & P_VI_DEF) || cp_val) ? VI_DEFAULT : VIM_DEFAULT];
+              value = (long)(intptr_t)options[opt_idx].def_val;
             } else if (nextchar == '<') {
               // For 'undolevels' NO_LOCAL_UNDOLEVEL means to
               // use the global value.
@@ -1354,14 +1332,12 @@ int do_set(
               origval = oldval;
             }
 
-            if (nextchar == '&') {              // set to default val
-              newval = options[opt_idx].def_val[
-                ((flags & P_VI_DEF) || cp_val)
-                ?  VI_DEFAULT : VIM_DEFAULT];
-              /* expand environment variables and ~ (since the
-               * default value was already expanded, only
-               * required when an environment variable was set
-               * later */
+            if (nextchar == '&') {  // set to default val
+              newval = options[opt_idx].def_val;
+              // expand environment variables and ~ (since the
+              // default value was already expanded, only
+              // required when an environment variable was set
+              // later
               new_value_alloced = true;
               if (newval == NULL) {
                 newval = empty_option;
@@ -5090,20 +5066,17 @@ showoptions(
 /// Return true if option "p" has its default value.
 static int optval_default(vimoption_T *p, char_u *varp)
 {
-  int dvi;
-
   if (varp == NULL) {
     return true;            // hidden option is always at default
   }
-  dvi = (p->flags & P_VI_DEF) ? VI_DEFAULT : VIM_DEFAULT;
   if (p->flags & P_NUM) {
-    return *(long *)varp == (long)(intptr_t)p->def_val[dvi];
+    return *(long *)varp == (long)(intptr_t)p->def_val;
   }
   if (p->flags & P_BOOL) {
-    return *(int *)varp == (int)(intptr_t)p->def_val[dvi];
+    return *(int *)varp == (int)(intptr_t)p->def_val;
   }
   // P_STRING
-  return STRCMP(*(char_u **)varp, p->def_val[dvi]) == 0;
+  return STRCMP(*(char_u **)varp, p->def_val) == 0;
 }
 
 /// Send update to UIs with values of UI relevant options
@@ -6152,7 +6125,7 @@ void reset_modifiable(void)
   p_ma = false;
   opt_idx = findoption("ma");
   if (opt_idx >= 0) {
-    options[opt_idx].def_val[VI_DEFAULT] = false;
+    options[opt_idx].def_val = false;
   }
 }
 
@@ -6851,7 +6824,7 @@ static void paste_option_changed(void)
 
 /// vimrc_found() - Called when a vimrc or "VIMINIT" has been found.
 ///
-/// Set the values for options that didn't get set yet to the Vim defaults.
+/// Set the values for options that didn't get set yet to the defaults.
 /// When "fname" is not NULL, use it to set $"envname" when it wasn't set yet.
 void vimrc_found(char_u *fname, char_u *envname)
 {
@@ -7745,8 +7718,7 @@ static Dictionary vimoption2dict(vimoption_T *opt)
     const char *type;
     Object def;
     // TODO(bfredl): do you even nocp?
-    char_u *def_val = opt->def_val[(opt->flags & P_VI_DEF)
-                                   ? VI_DEFAULT : VIM_DEFAULT];
+    char_u *def_val = opt->def_val;
     if (opt->flags & P_STRING) {
       type = "string";
       def = CSTR_TO_OBJ(def_val ? (char *)def_val : "");

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -233,7 +233,6 @@ typedef struct vimoption {
 #define P_WAS_SET       0x100U   // option has been set/reset
 #define P_NO_MKRC       0x200U   // don't include in :mkvimrc output
 #define P_VI_DEF        0x400U   // Use Vi default for Vim
-#define P_VIM           0x800U   // Vim option
 
 // when option changed, what to display:
 #define P_RSTAT         0x1000U  ///< redraw status lines

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10,7 +10,7 @@
 --    secure=nil, gettext=nil, noglob=nil, normal_fname_chars=nil,
 --    pri_mkrc=nil, deny_in_modelines=nil, normal_dname_chars=nil,
 --    modelineexpr=nil,
---    expand=nil, nodefault=nil, no_mkrc=nil, vi_def=true, vim=true,
+--    expand=nil, nodefault=nil, no_mkrc=nil, vi_def=true,
 --    alloced=nil,
 --    save_pv_indir=nil,
 --    redraw={'curswant'},
@@ -65,7 +65,6 @@ return {
       short_desc=N_("Arabic as a default second language"),
       type='bool', scope={'window'},
       vi_def=true,
-      vim=true,
       redraw={'curswant'},
       defaults={if_true={vi=false}}
     },
@@ -74,7 +73,6 @@ return {
       short_desc=N_("do shaping for Arabic characters"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       redraw={'all_windows', 'ui_option'},
 
       varname='p_arshape',
@@ -85,7 +83,6 @@ return {
       short_desc=N_("allow CTRL-_ in Insert and Command-line mode"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_ari',
       defaults={if_true={vi=false}}
     },
@@ -140,7 +137,6 @@ return {
       full_name='background', abbreviation='bg',
       short_desc=N_("\"dark\" or \"light\", used for highlight colors"),
       type='string', scope={'global'},
-      vim=true,
       redraw={'all_windows'},
       varname='p_bg',
       defaults={if_true={vi="light",vim="dark"}}
@@ -150,7 +146,6 @@ return {
       short_desc=N_("how backspace works at start of line"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vim=true,
       varname='p_bs',
       defaults={if_true={vi="", vim="indent,eol,start"}}
     },
@@ -159,7 +154,6 @@ return {
       short_desc=N_("keep backup file after overwriting a file"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_bk',
       defaults={if_true={vi=false}}
     },
@@ -168,7 +162,6 @@ return {
       short_desc=N_("make backup as a copy, don't rename the file"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
-      vim=true,
       varname='p_bkc',
       defaults={
         condition='UNIX',
@@ -247,7 +240,6 @@ return {
       short_desc=N_("wrapped line repeats indent"),
       type='bool', scope={'window'},
       vi_def=true,
-      vim=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -347,7 +339,6 @@ return {
       short_desc=N_("do C program indenting"),
       type='bool', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_cin',
       defaults={if_true={vi=false}}
     },
@@ -506,7 +497,6 @@ return {
       full_name='completeslash', abbreviation='csl',
       type='string', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_csl',
       enable_if='BACKSLASH_IN_FILENAME',
       defaults={if_true={vi=""}}
@@ -524,7 +514,6 @@ return {
       short_desc=N_("make 'autoindent' use existing indent structure"),
       type='bool', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_ci',
       defaults={if_true={vi=false}}
     },
@@ -532,7 +521,6 @@ return {
       full_name='cpoptions', abbreviation='cpo',
       short_desc=N_("flags for Vi-compatible behavior"),
       type='string', list='flags', scope={'global'},
-      vim=true,
       redraw={'all_windows'},
       varname='p_cpo',
       defaults={if_true={vi=macros('CPO_VI'), vim=macros('CPO_VIM')}}
@@ -542,7 +530,6 @@ return {
       short_desc=N_("how many components of the path to show"),
       type='number', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_cspc',
       defaults={if_true={vi=0}}
     },
@@ -570,7 +557,6 @@ return {
       short_desc=N_("Use cscope.out path basename as prefix"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_csre',
       defaults={if_true={vi=0}}
     },
@@ -579,7 +565,6 @@ return {
       short_desc=N_("use cscope for tag commands"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_cst',
       defaults={if_true={vi=0}}
     },
@@ -588,7 +573,6 @@ return {
       short_desc=N_("determines \":cstag\" search order"),
       type='number', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_csto',
       defaults={if_true={vi=0}}
     },
@@ -597,7 +581,6 @@ return {
       short_desc=N_("give messages when adding a cscope database"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_csverbose',
       defaults={if_true={vi=1}}
     },
@@ -648,7 +631,6 @@ return {
       short_desc=N_("delete combining characters on their own"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_deco',
       defaults={if_true={vi=false}}
     },
@@ -698,7 +680,6 @@ return {
       short_desc=N_("enable the entering of digraphs in Insert mode"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_dg',
       defaults={if_true={vi=false}}
     },
@@ -718,7 +699,6 @@ return {
       short_desc=N_("list of flags for how to display text"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vim=true,
       redraw={'all_windows'},
       varname='p_dy',
       defaults={if_true={vi="", vim="lastline,msgsep"}}
@@ -827,7 +807,6 @@ return {
       short_desc=N_("use spaces when <Tab> is inserted"),
       type='bool', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_et',
       defaults={if_true={vi=false}}
     },
@@ -876,7 +855,6 @@ return {
       short_desc=N_("automatically detected values for 'fileformat'"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vim=true,
       varname='p_ffs',
       defaults={if_true={vi=macros('DFLT_FFS_VI'), vim=macros('DFLT_FFS_VIM')}}
     },
@@ -956,7 +934,6 @@ return {
       short_desc=N_("expression used when 'foldmethod' is \"expr\""),
       type='string', scope={'window'},
       vi_def=true,
-      vim=true,
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
@@ -967,7 +944,6 @@ return {
       short_desc=N_("ignore lines when 'foldmethod' is \"indent\""),
       type='string', scope={'window'},
       vi_def=true,
-      vim=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="#"}}
@@ -995,7 +971,6 @@ return {
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       vi_def=true,
-      vim=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="{{{,}}}"}}
@@ -1005,7 +980,6 @@ return {
       short_desc=N_("folding type"),
       type='string', scope={'window'},
       vi_def=true,
-      vim=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="manual"}}
@@ -1041,7 +1015,6 @@ return {
       short_desc=N_("expression used to display for a closed fold"),
       type='string', scope={'window'},
       vi_def=true,
-      vim=true,
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
@@ -1052,7 +1025,6 @@ return {
       short_desc=N_("expression used with \"gq\" command"),
       type='string', scope={'buffer'},
       vi_def=true,
-      vim=true,
       modelineexpr=true,
       alloced=true,
       varname='p_fex',
@@ -1062,7 +1034,6 @@ return {
       full_name='formatoptions', abbreviation='fo',
       short_desc=N_("how automatic formatting is to be done"),
       type='string', list='flags', scope={'buffer'},
-      vim=true,
       alloced=true,
       varname='p_fo',
       defaults={if_true={vi=macros('DFLT_FO_VI'), vim=macros('DFLT_FO_VIM')}}
@@ -1100,7 +1071,6 @@ return {
       short_desc=N_("the \":substitute\" flag 'g' is default on"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_gd',
       defaults={if_true={vi=false}}
     },
@@ -1231,7 +1201,6 @@ return {
       full_name='history', abbreviation='hi',
       short_desc=N_("number of command-lines that are remembered"),
       type='number', scope={'global'},
-      vim=true,
       varname='p_hi',
       defaults={if_true={vi=0, vim=10000}}
     },
@@ -1240,7 +1209,6 @@ return {
       short_desc=N_("Hebrew keyboard mapping"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_hkmap',
       defaults={if_true={vi=false}}
     },
@@ -1249,7 +1217,6 @@ return {
       short_desc=N_("phonetic Hebrew keyboard mapping"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_hkmapp',
       defaults={if_true={vi=false}}
     },
@@ -1257,7 +1224,6 @@ return {
       full_name='hlsearch', abbreviation='hls',
       short_desc=N_("highlight matches with last search pattern"),
       type='bool', scope={'global'},
-      vim=true,
       redraw={'all_windows'},
       varname='p_hls',
       defaults={if_true={vi=false, vim=true}}
@@ -1355,7 +1321,6 @@ return {
       full_name='incsearch', abbreviation='is',
       short_desc=N_("highlight match while typing search pattern"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_is',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -1364,7 +1329,6 @@ return {
       short_desc=N_("expression used to obtain the indent of a line"),
       type='string', scope={'buffer'},
       vi_def=true,
-      vim=true,
       modelineexpr=true,
       alloced=true,
       varname='p_inde',
@@ -1393,7 +1357,6 @@ return {
       short_desc=N_("start the edit of a file in Insert mode"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_im',
       defaults={if_true={vi=false}}
     },
@@ -1430,7 +1393,6 @@ return {
       short_desc=N_("characters included in keywords"),
       type='string', list='comma', scope={'buffer'},
       deny_duplicates=true,
-      vim=true,
       alloced=true,
       varname='p_isk',
       defaults={if_true={vi="@,48-57,_", vim="@,48-57,_,192-255"}}
@@ -1451,7 +1413,6 @@ return {
       short_desc=N_("two spaces after a period with a join command"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_js',
       defaults={if_true={vi=true}}
     },
@@ -1461,7 +1422,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_jop',
-      vim=true,
       defaults={if_true={vim=''}}
     },
     {
@@ -1534,7 +1494,6 @@ return {
       full_name='laststatus', abbreviation='ls',
       short_desc=N_("tells when last window has status lines"),
       type='number', scope={'global'},
-      vim=true,
       redraw={'all_windows'},
       varname='p_ls',
       defaults={if_true={vi=1,vim=2}}
@@ -1604,7 +1563,6 @@ return {
       short_desc=N_("characters for displaying in list mode"),
       type='string', list='onecomma', scope={'global', 'window'},
       deny_duplicates=true,
-      vim=true,
       alloced=true,
       redraw={'current_window'},
       varname='p_lcs',
@@ -1726,7 +1684,6 @@ return {
       full_name='modeline', abbreviation='ml',
       short_desc=N_("recognize modelines at start or end of file"),
       type='bool', scope={'buffer'},
-      vim=true,
       varname='p_ml',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -1770,7 +1727,6 @@ return {
       full_name='more',
       short_desc=N_("listings when the whole screen is filled"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_more',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -1843,7 +1799,6 @@ return {
       full_name='numberwidth', abbreviation='nuw',
       short_desc=N_("number of columns used for the line number"),
       type='number', scope={'window'},
-      vim=true,
       redraw={'current_window'},
       defaults={if_true={vi=8, vim=4}}
     },
@@ -1943,7 +1898,6 @@ return {
       short_desc=N_("preserve the indent structure when reindenting"),
       type='bool', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_pi',
       defaults={if_true={vi=false}}
     },
@@ -2153,7 +2107,6 @@ return {
       short_desc=N_("inserting characters will work backwards"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_ri',
       defaults={if_true={vi=false}}
     },
@@ -2179,7 +2132,6 @@ return {
       short_desc=N_("show cursor line and column in the status line"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       redraw={'statuslines'},
       varname='p_ru',
       defaults={if_true={vi=true}}
@@ -2237,7 +2189,6 @@ return {
       short_desc=N_("minimum number of lines to scroll"),
       type='number', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_sj',
       defaults={if_true={vi=1}}
     },
@@ -2246,7 +2197,6 @@ return {
       short_desc=N_("minimum nr. of lines above and below cursor"),
       type='number', scope={'global', 'window'},
       vi_def=true,
-      vim=true,
       redraw={'all_windows'},
       varname='p_so',
       defaults={if_true={vi=0}}
@@ -2299,7 +2249,6 @@ return {
       short_desc=N_("options for |:mksession|"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vim=true,
       varname='p_ssop',
       defaults={if_true={
         vi="blank,buffers,curdir,folds,help,options,tabpages,winsize",
@@ -2431,7 +2380,6 @@ return {
       short_desc=N_("round indent to multiple of shiftwidth"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_sr',
       defaults={if_true={vi=false}}
     },
@@ -2447,7 +2395,6 @@ return {
       full_name='shortmess', abbreviation='shm',
       short_desc=N_("list of flags, reduce length of messages"),
       type='string', list='flags', scope={'global'},
-      vim=true,
       varname='p_shm',
       defaults={if_true={vi="S", vim="filnxtToOF"}}
     },
@@ -2464,7 +2411,6 @@ return {
       full_name='showcmd', abbreviation='sc',
       short_desc=N_("show (partial) command in status line"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_sc',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -2488,7 +2434,6 @@ return {
       full_name='showmode', abbreviation='smd',
       short_desc=N_("message on status line to show current mode"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_smd',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -2514,7 +2459,6 @@ return {
       short_desc=N_("min. nr. of columns to left and right of cursor"),
       type='number', scope={'global', 'window'},
       vi_def=true,
-      vim=true,
       redraw={'all_windows'},
       varname='p_siso',
       defaults={if_true={vi=0}}
@@ -2533,7 +2477,6 @@ return {
       short_desc=N_("no ignore case when pattern has uppercase"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_scs',
       defaults={if_true={vi=false}}
     },
@@ -2542,7 +2485,6 @@ return {
       short_desc=N_("smart autoindenting for C programs"),
       type='bool', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_si',
       defaults={if_true={vi=false}}
     },
@@ -2550,7 +2492,6 @@ return {
       full_name='smarttab', abbreviation='sta',
       short_desc=N_("use 'shiftwidth' when inserting <Tab>"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_sta',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -2559,7 +2500,6 @@ return {
       short_desc=N_("number of spaces that <Tab> uses while editing"),
       type='number', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_sts',
       defaults={if_true={vi=0}}
     },
@@ -2723,7 +2663,6 @@ return {
       full_name='tagfunc', abbreviation='tfu',
       short_desc=N_("function used to perform tag searches"),
       type='string', scope={'buffer'},
-      vim=true,
       vi_def=true,
       varname='p_tfu',
       defaults={if_true={vi=""}}
@@ -2742,7 +2681,6 @@ return {
       full_name='tabpagemax', abbreviation='tpm',
       short_desc=N_("maximum number of tab pages for |-p| and \"tab all\""),
       type='number', scope={'global'},
-      vim=true,
       varname='p_tpm',
       defaults={if_true={vi=10, vim=50}}
     },
@@ -2767,7 +2705,6 @@ return {
       full_name='tagcase', abbreviation='tc',
       short_desc=N_("how to handle case when searching in tags files"),
       type='string', scope={'global', 'buffer'},
-      vim=true,
       varname='p_tc',
       defaults={if_true={vi="followic", vim="followic"}}
     },
@@ -2783,7 +2720,6 @@ return {
       full_name='tagrelative', abbreviation='tr',
       short_desc=N_("file names in tag file are relative"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_tr',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -2833,7 +2769,6 @@ return {
       full_name='termpastefilter', abbreviation='tpf',
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vim=true,
       varname='p_tpf',
       defaults={if_true={vi="", vim="BS,HT,ESC,DEL"}}
     },
@@ -2850,7 +2785,6 @@ return {
       short_desc=N_("maximum width of text that is being inserted"),
       type='number', scope={'buffer'},
       vi_def=true,
-      vim=true,
       redraw={'current_buffer'},
       varname='p_tw',
       defaults={if_true={vi=0}}
@@ -2871,7 +2805,6 @@ return {
       short_desc=N_("tilde command \"~\" behaves like an operator"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_to',
       defaults={if_true={vi=false}}
     },
@@ -2931,7 +2864,6 @@ return {
       short_desc=N_("out on mappings"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       redraw={'ui_option'},
       varname='p_ttimeout',
       defaults={if_true={vi=true}}
@@ -2970,7 +2902,6 @@ return {
       short_desc=N_("save undo information in a file"),
       type='bool', scope={'buffer'},
       vi_def=true,
-      vim=true,
       varname='p_udf',
       defaults={if_true={vi=false}}
     },
@@ -3078,7 +3009,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       vi_def=true,
-      vim=true,
       redraw={'curswant'},
       varname='p_ve',
       defaults={if_true={vi="", vim=""}}
@@ -3103,7 +3033,6 @@ return {
       full_name='whichwrap', abbreviation='ww',
       short_desc=N_("allow specified keys to cross line boundaries"),
       type='string', list='flagscomma', scope={'global'},
-      vim=true,
       varname='p_ww',
       defaults={if_true={vi="", vim="b,s"}}
     },
@@ -3111,7 +3040,6 @@ return {
       full_name='wildchar', abbreviation='wc',
       short_desc=N_("command-line character for wildcard expansion"),
       type='number', scope={'global'},
-      vim=true,
       varname='p_wc',
       defaults={if_true={vi=imacros('Ctrl_E'), vim=imacros('TAB')}}
     },
@@ -3144,7 +3072,6 @@ return {
       full_name='wildmenu', abbreviation='wmnu',
       short_desc=N_("use menu for command line completion"),
       type='bool', scope={'global'},
-      vim=true,
       varname='p_wmnu',
       defaults={if_true={vi=false, vim=true}}
     },
@@ -3153,7 +3080,6 @@ return {
       short_desc=N_("mode for 'wildchar' command-line expansion"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=false,
-      vim=true,
       varname='p_wim',
       defaults={if_true={vi="", vim="full"}}
     },
@@ -3162,7 +3088,6 @@ return {
       short_desc=N_("specifies how command line completion is done"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vim=true,
       varname='p_wop',
       defaults={if_true={vi='', vim='pum,tagfile'}}
     },
@@ -3292,7 +3217,6 @@ return {
       short_desc=N_("make a backup before overwriting a file"),
       type='bool', scope={'global'},
       vi_def=true,
-      vim=true,
       varname='p_wb',
       defaults={if_true={vi=true}}
     },

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10,7 +10,7 @@
 --    secure=nil, gettext=nil, noglob=nil, normal_fname_chars=nil,
 --    pri_mkrc=nil, deny_in_modelines=nil, normal_dname_chars=nil,
 --    modelineexpr=nil,
---    expand=nil, nodefault=nil, no_mkrc=nil, vi_def=true,
+--    expand=nil, nodefault=nil, no_mkrc=nil,
 --    alloced=nil,
 --    save_pv_indir=nil,
 --    redraw={'curswant'},
@@ -55,7 +55,6 @@ return {
       full_name='aleph', abbreviation='al',
       short_desc=N_("ASCII code of the letter Aleph (Hebrew)"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'curswant'},
       varname='p_aleph',
       defaults={if_true={vi=224}}
@@ -64,7 +63,6 @@ return {
       full_name='arabic', abbreviation='arab',
       short_desc=N_("Arabic as a default second language"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'curswant'},
       defaults={if_true={vi=false}}
     },
@@ -72,7 +70,6 @@ return {
       full_name='arabicshape', abbreviation='arshape',
       short_desc=N_("do shaping for Arabic characters"),
       type='bool', scope={'global'},
-      vi_def=true,
       redraw={'all_windows', 'ui_option'},
 
       varname='p_arshape',
@@ -82,7 +79,6 @@ return {
       full_name='allowrevins', abbreviation='ari',
       short_desc=N_("allow CTRL-_ in Insert and Command-line mode"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_ari',
       defaults={if_true={vi=false}}
     },
@@ -90,7 +86,6 @@ return {
       full_name='ambiwidth', abbreviation='ambw',
       short_desc=N_("what to do with Unicode chars of ambiguous width"),
       type='string', scope={'global'},
-      vi_def=true,
       redraw={'all_windows', 'ui_option'},
       varname='p_ambw',
       defaults={if_true={vi="single"}}
@@ -99,7 +94,6 @@ return {
       full_name='autochdir', abbreviation='acd',
       short_desc=N_("change directory to the file in the current window"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_acd',
       defaults={if_true={vi=false}}
     },
@@ -108,20 +102,19 @@ return {
       short_desc=N_("take indent for new line from previous line"),
       type='bool', scope={'buffer'},
       varname='p_ai',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='autoread', abbreviation='ar',
       short_desc=N_("autom. read file when changed outside of Vim"),
       type='bool', scope={'global', 'buffer'},
       varname='p_ar',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='autowrite', abbreviation='aw',
       short_desc=N_("automatically write file if changed"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_aw',
       defaults={if_true={vi=false}}
     },
@@ -129,7 +122,6 @@ return {
       full_name='autowriteall', abbreviation='awa',
       short_desc=N_("as 'autowrite', but works with more commands"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_awa',
       defaults={if_true={vi=false}}
     },
@@ -139,7 +131,7 @@ return {
       type='string', scope={'global'},
       redraw={'all_windows'},
       varname='p_bg',
-      defaults={if_true={vi="light",vim="dark"}}
+      defaults={if_true={vim="dark"}}
     },
     {
       full_name='backspace', abbreviation='bs',
@@ -147,13 +139,12 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_bs',
-      defaults={if_true={vi="", vim="indent,eol,start"}}
+      defaults={if_true={vim="indent,eol,start"}}
     },
     {
       full_name='backup', abbreviation='bk',
       short_desc=N_("keep backup file after overwriting a file"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_bk',
       defaults={if_true={vi=false}}
     },
@@ -165,8 +156,8 @@ return {
       varname='p_bkc',
       defaults={
         condition='UNIX',
-        if_true={vi="yes", vim="auto"},
-        if_false={vi="auto", vim="auto"}
+        if_true={vim="auto"},
+        if_false={vim="auto"}
       },
     },
     {
@@ -175,7 +166,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand='nodefault',
       varname='p_bdir',
       defaults={if_true={vi=''}}
@@ -185,7 +175,6 @@ return {
       short_desc=N_("extension used for the backup file"),
       type='string', scope={'global'},
       normal_fname_chars=true,
-      vi_def=true,
       varname='p_bex',
       defaults={if_true={vi="~"}}
     },
@@ -194,7 +183,6 @@ return {
       short_desc=N_("no backup for files that match these patterns"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_bsk',
       defaults={if_true={vi=""}}
     },
@@ -203,7 +191,6 @@ return {
       short_desc=N_("do not ring the bell for these reasons"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_bo',
       defaults={if_true={vi="all"}}
     },
@@ -211,7 +198,6 @@ return {
       full_name='binary', abbreviation='bin',
       short_desc=N_("read/write/edit file in binary mode"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_bin',
       defaults={if_true={vi=false}}
@@ -221,7 +207,6 @@ return {
       short_desc=N_("a Byte Order Mark to the file"),
       type='bool', scope={'buffer'},
       no_mkrc=true,
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_bomb',
       defaults={if_true={vi=false}}
@@ -230,7 +215,6 @@ return {
       full_name='breakat', abbreviation='brk',
       short_desc=N_("characters that may cause a line break"),
       type='string', list='flags', scope={'global'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_breakat',
       defaults={if_true={vi=" \t!@*-+;:,./?"}}
@@ -239,7 +223,6 @@ return {
       full_name='breakindent', abbreviation='bri',
       short_desc=N_("wrapped line repeats indent"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -248,7 +231,6 @@ return {
       short_desc=N_("settings for 'breakindent'"),
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       redraw={'current_buffer'},
       defaults={if_true={vi=""}},
@@ -257,7 +239,6 @@ return {
       full_name='browsedir', abbreviation='bsdir',
       short_desc=N_("which directory to start browsing in"),
       type='string', scope={'global'},
-      vi_def=true,
       enable_if=false,
     },
     {
@@ -265,7 +246,6 @@ return {
       short_desc=N_("what to do when buffer is no longer in window"),
       type='string', scope={'buffer'},
       noglob=true,
-      vi_def=true,
       alloced=true,
       varname='p_bh',
       defaults={if_true={vi=""}}
@@ -275,7 +255,6 @@ return {
       short_desc=N_("whether the buffer shows up in the buffer list"),
       type='bool', scope={'buffer'},
       noglob=true,
-      vi_def=true,
       varname='p_bl',
       defaults={if_true={vi=1}}
     },
@@ -284,7 +263,6 @@ return {
       short_desc=N_("special type of buffer"),
       type='string', scope={'buffer'},
       noglob=true,
-      vi_def=true,
       alloced=true,
       varname='p_bt',
       defaults={if_true={vi=""}}
@@ -294,7 +272,6 @@ return {
       short_desc=N_("specifies how case of letters is changed"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_cmp',
       defaults={if_true={vi="internal,keepascii"}}
     },
@@ -303,7 +280,6 @@ return {
       short_desc=N_("list of directories searched with \":cd\""),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       expand=true,
       secure=true,
       varname='p_cdpath',
@@ -314,7 +290,7 @@ return {
       short_desc=N_("used to open the command-line window"),
       type='string', scope={'global'},
       varname='p_cedit',
-      defaults={if_true={vi="", vim=macros('CTRL_F_STR')}}
+      defaults={if_true={vim=macros('CTRL_F_STR')}}
     },
     {
       full_name='channel',
@@ -330,7 +306,6 @@ return {
       short_desc=N_("expression for character encoding conversion"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_ccv',
       defaults={if_true={vi=""}}
     },
@@ -338,7 +313,6 @@ return {
       full_name='cindent', abbreviation='cin',
       short_desc=N_("do C program indenting"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_cin',
       defaults={if_true={vi=false}}
     },
@@ -347,7 +321,6 @@ return {
       short_desc=N_("keys that trigger indent when 'cindent' is set"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       varname='p_cink',
       defaults={if_true={vi=indentkeys_default}}
@@ -357,7 +330,6 @@ return {
       short_desc=N_("how to do indenting when 'cindent' is set"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       varname='p_cino',
       defaults={if_true={vi=""}}
@@ -367,7 +339,6 @@ return {
       short_desc=N_("words where 'si' and 'cin' add an indent"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       varname='p_cinw',
       defaults={if_true={vi="if,else,while,do,for,switch"}}
@@ -377,7 +348,6 @@ return {
       short_desc=N_("use the clipboard as the unnamed register"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_cb',
       defaults={if_true={vi=""}}
     },
@@ -385,7 +355,6 @@ return {
       full_name='cmdheight', abbreviation='ch',
       short_desc=N_("number of lines to use for the command-line"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_ch',
       defaults={if_true={vi=1}}
@@ -394,7 +363,6 @@ return {
       full_name='cmdwinheight', abbreviation='cwh',
       short_desc=N_("height of the command-line window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_cwh',
       defaults={if_true={vi=7}}
     },
@@ -403,7 +371,6 @@ return {
       short_desc=N_("columns to highlight"),
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=""}}
     },
@@ -412,7 +379,6 @@ return {
       short_desc=N_("number of columns in the display"),
       type='number', scope={'global'},
       no_mkrc=true,
-      vi_def=true,
       redraw={'everything'},
       varname='p_columns',
       defaults={if_true={vi=macros('DFLT_COLS')}}
@@ -422,7 +388,6 @@ return {
       short_desc=N_("patterns that can start a comment line"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       redraw={'curswant'},
       varname='p_com',
@@ -432,7 +397,6 @@ return {
       full_name='commentstring', abbreviation='cms',
       short_desc=N_("template for comments; used for fold marker"),
       type='string', scope={'buffer'},
-      vi_def=true,
       alloced=true,
       redraw={'curswant'},
       varname='p_cms',
@@ -446,7 +410,7 @@ return {
       varname='p_force_off',
       -- pri_mkrc isn't needed here, optval_default()
       -- always returns TRUE for 'compatible'
-      defaults={if_true={vi=true, vim=false}}
+      defaults={if_true={vim=false}}
     },
     {
       full_name='complete', abbreviation='cpt',
@@ -455,13 +419,12 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cpt',
-      defaults={if_true={vi=".,w,b,u,t,i", vim=".,w,b,u,t"}}
+      defaults={if_true={vim=".,w,b,u,t"}}
     },
     {
       full_name='concealcursor', abbreviation='cocu',
       short_desc=N_("whether concealable text is hidden in cursor line"),
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi=""}}
@@ -470,7 +433,6 @@ return {
       full_name='conceallevel', abbreviation='cole',
       short_desc=N_("whether concealable text is shown or hidden"),
       type='number', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=0}}
     },
@@ -479,7 +441,6 @@ return {
       short_desc=N_("function to be used for Insert mode completion"),
       type='string', scope={'buffer'},
       secure=true,
-      vi_def=true,
       alloced=true,
       varname='p_cfu',
       defaults={if_true={vi=""}}
@@ -489,14 +450,12 @@ return {
       short_desc=N_("options for Insert mode completion"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_cot',
       defaults={if_true={vi="menu,preview"}}
     },
     {
       full_name='completeslash', abbreviation='csl',
       type='string', scope={'buffer'},
-      vi_def=true,
       varname='p_csl',
       enable_if='BACKSLASH_IN_FILENAME',
       defaults={if_true={vi=""}}
@@ -505,7 +464,6 @@ return {
       full_name='confirm', abbreviation='cf',
       short_desc=N_("ask what to do about unsaved/read-only files"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_confirm',
       defaults={if_true={vi=false}}
     },
@@ -513,7 +471,6 @@ return {
       full_name='copyindent', abbreviation='ci',
       short_desc=N_("make 'autoindent' use existing indent structure"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_ci',
       defaults={if_true={vi=false}}
     },
@@ -523,13 +480,12 @@ return {
       type='string', list='flags', scope={'global'},
       redraw={'all_windows'},
       varname='p_cpo',
-      defaults={if_true={vi=macros('CPO_VI'), vim=macros('CPO_VIM')}}
+      defaults={if_true={vim=macros('CPO_VIM')}}
     },
     {
       full_name='cscopepathcomp', abbreviation='cspc',
       short_desc=N_("how many components of the path to show"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_cspc',
       defaults={if_true={vi=0}}
     },
@@ -538,7 +494,6 @@ return {
       short_desc=N_("command to execute cscope"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_csprg',
       defaults={if_true={vi="cscope"}}
@@ -548,7 +503,6 @@ return {
       short_desc=N_("use quickfix window for cscope results"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_csqf',
       defaults={if_true={vi=""}}
     },
@@ -556,7 +510,6 @@ return {
       full_name='cscoperelative', abbreviation='csre',
       short_desc=N_("Use cscope.out path basename as prefix"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_csre',
       defaults={if_true={vi=0}}
     },
@@ -564,7 +517,6 @@ return {
       full_name='cscopetag', abbreviation='cst',
       short_desc=N_("use cscope for tag commands"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_cst',
       defaults={if_true={vi=0}}
     },
@@ -572,7 +524,6 @@ return {
       full_name='cscopetagorder', abbreviation='csto',
       short_desc=N_("determines \":cstag\" search order"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_csto',
       defaults={if_true={vi=0}}
     },
@@ -580,7 +531,6 @@ return {
       full_name='cscopeverbose', abbreviation='csverb',
       short_desc=N_("give messages when adding a cscope database"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_csverbose',
       defaults={if_true={vi=1}}
     },
@@ -588,7 +538,6 @@ return {
       full_name='cursorbind', abbreviation='crb',
       short_desc=N_("move cursor in window as it moves in other windows"),
       type='bool', scope={'window'},
-      vi_def=true,
       pv_name='p_crbind',
       defaults={if_true={vi=false}}
     },
@@ -596,7 +545,6 @@ return {
       full_name='cursorcolumn', abbreviation='cuc',
       short_desc=N_("highlight the screen column of the cursor"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window_only'},
       defaults={if_true={vi=false}}
     },
@@ -604,7 +552,6 @@ return {
       full_name='cursorline', abbreviation='cul',
       short_desc=N_("highlight the screen line of the cursor"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window_only'},
       defaults={if_true={vi=false}}
     },
@@ -612,7 +559,6 @@ return {
       full_name='debug',
       short_desc=N_("to \"msg\" to see all error messages"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_debug',
       defaults={if_true={vi=""}}
     },
@@ -620,7 +566,6 @@ return {
       full_name='define', abbreviation='def',
       short_desc=N_("pattern to be used to find a macro definition"),
       type='string', scope={'global', 'buffer'},
-      vi_def=true,
       alloced=true,
       redraw={'curswant'},
       varname='p_def',
@@ -630,7 +575,6 @@ return {
       full_name='delcombine', abbreviation='deco',
       short_desc=N_("delete combining characters on their own"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_deco',
       defaults={if_true={vi=false}}
     },
@@ -640,7 +584,6 @@ return {
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       normal_dname_chars=true,
-      vi_def=true,
       expand=true,
       varname='p_dict',
       defaults={if_true={vi=""}}
@@ -650,7 +593,6 @@ return {
       short_desc=N_("diff mode for the current window"),
       type='bool', scope={'window'},
       noglob=true,
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -659,7 +601,6 @@ return {
       short_desc=N_("expression used to obtain a diff file"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       redraw={'curswant'},
       varname='p_dex',
       defaults={if_true={vi=""}}
@@ -669,7 +610,6 @@ return {
       short_desc=N_("options for using diff mode"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       varname='p_dip',
@@ -679,7 +619,6 @@ return {
       full_name='digraph', abbreviation='dg',
       short_desc=N_("enable the entering of digraphs in Insert mode"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_dg',
       defaults={if_true={vi=false}}
     },
@@ -689,7 +628,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand='nodefault',
       varname='p_dir',
       defaults={if_true={vi=''}}
@@ -701,13 +639,12 @@ return {
       deny_duplicates=true,
       redraw={'all_windows'},
       varname='p_dy',
-      defaults={if_true={vi="", vim="lastline,msgsep"}}
+      defaults={if_true={vim="lastline,msgsep"}}
     },
     {
       full_name='eadirection', abbreviation='ead',
       short_desc=N_("in which direction 'equalalways' works"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_ead',
       defaults={if_true={vi="both"}}
     },
@@ -715,7 +652,6 @@ return {
       full_name='edcompatible', abbreviation='ed',
 	  short_desc=N_("No description"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_force_off',
       defaults={if_true={vi=false}}
     },
@@ -723,7 +659,6 @@ return {
       full_name='emoji', abbreviation='emo',
 	  short_desc=N_("No description"),
       type='bool', scope={'global'},
-      vi_def=true,
       redraw={'all_windows', 'ui_option'},
       varname='p_emoji',
       defaults={if_true={vi=true}}
@@ -733,7 +668,6 @@ return {
       short_desc=N_("encoding used internally"),
       type='string', scope={'global'},
       deny_in_modelines=true,
-      vi_def=true,
       varname='p_enc',
       defaults={if_true={vi=macros('ENC_DFLT')}}
     },
@@ -742,7 +676,6 @@ return {
       short_desc=N_("write <EOL> for last line in file"),
       type='bool', scope={'buffer'},
       no_mkrc=true,
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_eol',
       defaults={if_true={vi=true}}
@@ -751,7 +684,6 @@ return {
       full_name='equalalways', abbreviation='ea',
       short_desc=N_("windows are automatically made the same size"),
       type='bool', scope={'global'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_ea',
       defaults={if_true={vi=true}}
@@ -761,7 +693,6 @@ return {
       short_desc=N_("external program to use for \"=\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_ep',
       defaults={if_true={vi=""}}
@@ -770,7 +701,6 @@ return {
       full_name='errorbells', abbreviation='eb',
       short_desc=N_("ring the bell for error messages"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_eb',
       defaults={if_true={vi=false}}
     },
@@ -779,7 +709,6 @@ return {
       short_desc=N_("name of the errorfile for the QuickFix mode"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_ef',
       defaults={if_true={vi=macros('DFLT_ERRORFILE')}}
@@ -789,7 +718,6 @@ return {
       short_desc=N_("description of the lines in the error file"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_efm',
       defaults={if_true={vi=macros('DFLT_EFM')}}
     },
@@ -798,7 +726,6 @@ return {
       short_desc=N_("autocommand events that are ignored"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_ei',
       defaults={if_true={vi=""}}
     },
@@ -806,7 +733,6 @@ return {
       full_name='expandtab', abbreviation='et',
       short_desc=N_("use spaces when <Tab> is inserted"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_et',
       defaults={if_true={vi=false}}
     },
@@ -815,7 +741,6 @@ return {
       short_desc=N_("read .nvimrc and .exrc in the current directory"),
       type='bool', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_exrc',
       defaults={if_true={vi=false}}
     },
@@ -824,7 +749,6 @@ return {
       short_desc=N_("file encoding for multi-byte text"),
       type='string', scope={'buffer'},
       no_mkrc=true,
-      vi_def=true,
       alloced=true,
       redraw={'statuslines', 'current_buffer'},
       varname='p_fenc',
@@ -835,7 +759,6 @@ return {
       short_desc=N_("automatically detected character encodings"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_fencs',
       defaults={if_true={vi="ucs-bom,utf-8,default,latin1"}}
     },
@@ -844,7 +767,6 @@ return {
       short_desc=N_("file format used for file I/O"),
       type='string', scope={'buffer'},
       no_mkrc=true,
-      vi_def=true,
       alloced=true,
       redraw={'curswant', 'statuslines'},
       varname='p_ff',
@@ -856,13 +778,12 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ffs',
-      defaults={if_true={vi=macros('DFLT_FFS_VI'), vim=macros('DFLT_FFS_VIM')}}
+      defaults={if_true={vim=macros('DFLT_FFS_VIM')}}
     },
     {
       full_name='fileignorecase', abbreviation='fic',
       short_desc=N_("ignore case when using file names"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_fic',
       defaults={
         condition='CASE_INSENSITIVE_FILENAME',
@@ -876,7 +797,6 @@ return {
       type='string', scope={'buffer'},
       noglob=true,
       normal_fname_chars=true,
-      vi_def=true,
       alloced=true,
       expand=true,
       varname='p_ft',
@@ -887,7 +807,6 @@ return {
       short_desc=N_("characters to use for displaying special items"),
       type='string', list='onecomma', scope={'global', 'window'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       varname='p_fcs',
@@ -897,7 +816,6 @@ return {
       full_name='fixendofline', abbreviation='fixeol',
       short_desc=N_("make sure last line in file has <EOL>"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_fixeol',
       defaults={if_true={vi=true}}
@@ -907,7 +825,6 @@ return {
       short_desc=N_("close a fold when the cursor leaves it"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       redraw={'current_window'},
       varname='p_fcl',
       defaults={if_true={vi=""}}
@@ -916,7 +833,6 @@ return {
       full_name='foldcolumn', abbreviation='fdc',
       short_desc=N_("width of the column used to indicate folds"),
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="0"}}
@@ -925,7 +841,6 @@ return {
       full_name='foldenable', abbreviation='fen',
       short_desc=N_("set to display all folds open"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=true}}
     },
@@ -933,7 +848,6 @@ return {
       full_name='foldexpr', abbreviation='fde',
       short_desc=N_("expression used when 'foldmethod' is \"expr\""),
       type='string', scope={'window'},
-      vi_def=true,
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
@@ -943,7 +857,6 @@ return {
       full_name='foldignore', abbreviation='fdi',
       short_desc=N_("ignore lines when 'foldmethod' is \"indent\""),
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="#"}}
@@ -952,7 +865,6 @@ return {
       full_name='foldlevel', abbreviation='fdl',
       short_desc=N_("close folds with a level higher than this"),
       type='number', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=0}}
     },
@@ -960,7 +872,6 @@ return {
       full_name='foldlevelstart', abbreviation='fdls',
       short_desc=N_("'foldlevel' when starting to edit a file"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'curswant'},
       varname='p_fdls',
       defaults={if_true={vi=-1}}
@@ -970,7 +881,6 @@ return {
       short_desc=N_("markers used when 'foldmethod' is \"marker\""),
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="{{{,}}}"}}
@@ -979,7 +889,6 @@ return {
       full_name='foldmethod', abbreviation='fdm',
       short_desc=N_("folding type"),
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="manual"}}
@@ -988,7 +897,6 @@ return {
       full_name='foldminlines', abbreviation='fml',
       short_desc=N_("minimum number of lines for a fold to be closed"),
       type='number', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=1}}
     },
@@ -996,7 +904,6 @@ return {
       full_name='foldnestmax', abbreviation='fdn',
       short_desc=N_("maximum fold depth"),
       type='number', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=20}}
     },
@@ -1005,7 +912,6 @@ return {
       short_desc=N_("for which commands a fold will be opened"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       redraw={'curswant'},
       varname='p_fdo',
       defaults={if_true={vi="block,hor,mark,percent,quickfix,search,tag,undo"}}
@@ -1014,7 +920,6 @@ return {
       full_name='foldtext', abbreviation='fdt',
       short_desc=N_("expression used to display for a closed fold"),
       type='string', scope={'window'},
-      vi_def=true,
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
@@ -1024,7 +929,6 @@ return {
       full_name='formatexpr', abbreviation='fex',
       short_desc=N_("expression used with \"gq\" command"),
       type='string', scope={'buffer'},
-      vi_def=true,
       modelineexpr=true,
       alloced=true,
       varname='p_fex',
@@ -1036,13 +940,12 @@ return {
       type='string', list='flags', scope={'buffer'},
       alloced=true,
       varname='p_fo',
-      defaults={if_true={vi=macros('DFLT_FO_VI'), vim=macros('DFLT_FO_VIM')}}
+      defaults={if_true={vim=macros('DFLT_FO_VIM')}}
     },
     {
       full_name='formatlistpat', abbreviation='flp',
       short_desc=N_("pattern used to recognize a list header"),
       type='string', scope={'buffer'},
-      vi_def=true,
       alloced=true,
       varname='p_flp',
       defaults={if_true={vi="^\\s*\\d\\+[\\]:.)}\\t ]\\s*"}}
@@ -1052,7 +955,6 @@ return {
       short_desc=N_("name of external program used with \"gq\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_fp',
       defaults={if_true={vi=""}}
@@ -1062,7 +964,6 @@ return {
       short_desc=N_("whether to invoke fsync() after file write"),
       type='bool', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_fs',
       defaults={if_true={vi=false}}
     },
@@ -1070,7 +971,6 @@ return {
       full_name='gdefault', abbreviation='gd',
       short_desc=N_("the \":substitute\" flag 'g' is default on"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_gd',
       defaults={if_true={vi=false}}
     },
@@ -1079,7 +979,6 @@ return {
       short_desc=N_("format of 'grepprg' output"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_gefm',
       defaults={if_true={vi=macros('DFLT_GREPFORMAT')}}
     },
@@ -1088,7 +987,6 @@ return {
       short_desc=N_("program to use for \":grep\""),
       type='string', scope={'global', 'buffer'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_gp',
       defaults={
@@ -1104,7 +1002,6 @@ return {
       short_desc=N_("GUI: settings for cursor shape and blinking"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_guicursor',
       defaults={if_true={vi="n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"}}
     },
@@ -1113,7 +1010,6 @@ return {
       short_desc=N_("GUI: Name(s) of font(s) to be used"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_guifont',
       redraw={'ui_option'},
       defaults={if_true={vi=""}}
@@ -1123,7 +1019,6 @@ return {
       short_desc=N_("list of font names for double-wide characters"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       redraw={'ui_option'},
       varname='p_guifontwide',
       defaults={if_true={vi=""}}
@@ -1132,7 +1027,6 @@ return {
       full_name='guioptions', abbreviation='go',
       short_desc=N_("GUI: Which components and options are used"),
       type='string', list='flags', scope={'global'},
-      vi_def=true,
       redraw={'all_windows'},
       enable_if=false,
     },
@@ -1140,7 +1034,6 @@ return {
       full_name='guitablabel', abbreviation='gtl',
       short_desc=N_("GUI: custom label for a tab page"),
       type='string', scope={'global'},
-      vi_def=true,
       modelineexpr=true,
       redraw={'current_window'},
       enable_if=false,
@@ -1149,7 +1042,6 @@ return {
       full_name='guitabtooltip', abbreviation='gtt',
       short_desc=N_("GUI: custom tooltip for a tab page"),
       type='string', scope={'global'},
-      vi_def=true,
       redraw={'current_window'},
       enable_if=false,
     },
@@ -1158,7 +1050,6 @@ return {
       short_desc=N_("full path name of the main help file"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_hf',
       defaults={if_true={vi=macros('DFLT_HELPFILE')}}
@@ -1167,7 +1058,6 @@ return {
       full_name='helpheight', abbreviation='hh',
       short_desc=N_("minimum height of a new help window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_hh',
       defaults={if_true={vi=20}}
     },
@@ -1176,7 +1066,6 @@ return {
       short_desc=N_("preferred help languages"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_hlg',
       defaults={if_true={vi=""}}
     },
@@ -1184,7 +1073,6 @@ return {
       full_name='hidden', abbreviation='hid',
       short_desc=N_("don't unload buffer when it is |abandon|ed"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_hid',
       defaults={if_true={vi=false}}
     },
@@ -1193,7 +1081,6 @@ return {
       short_desc=N_("sets highlighting mode for various occasions"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_hl',
       defaults={if_true={vi=macros('HIGHLIGHT_INIT')}}
     },
@@ -1202,13 +1089,12 @@ return {
       short_desc=N_("number of command-lines that are remembered"),
       type='number', scope={'global'},
       varname='p_hi',
-      defaults={if_true={vi=0, vim=10000}}
+      defaults={if_true={vim=10000}}
     },
     {
       full_name='hkmap', abbreviation='hk',
       short_desc=N_("Hebrew keyboard mapping"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_hkmap',
       defaults={if_true={vi=false}}
     },
@@ -1216,7 +1102,6 @@ return {
       full_name='hkmapp', abbreviation='hkp',
       short_desc=N_("phonetic Hebrew keyboard mapping"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_hkmapp',
       defaults={if_true={vi=false}}
     },
@@ -1226,13 +1111,12 @@ return {
       type='bool', scope={'global'},
       redraw={'all_windows'},
       varname='p_hls',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='icon',
       short_desc=N_("Vim set the text of the window icon"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_icon',
       defaults={if_true={vi=false}}
     },
@@ -1240,7 +1124,6 @@ return {
       full_name='iconstring',
       short_desc=N_("to use for the Vim icon text"),
       type='string', scope={'global'},
-      vi_def=true,
       modelineexpr=true,
       varname='p_iconstring',
       defaults={if_true={vi=""}}
@@ -1249,7 +1132,6 @@ return {
       full_name='ignorecase', abbreviation='ic',
       short_desc=N_("ignore case in search patterns"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_ic',
       defaults={if_true={vi=false}}
     },
@@ -1257,7 +1139,6 @@ return {
       full_name='imcmdline', abbreviation='imc',
       short_desc=N_("use IM when starting to edit a command line"),
       type='bool', scope={'global'},
-      vi_def=true,
       enable_if=false,
       defaults={if_true={vi=false}}
     },
@@ -1265,7 +1146,6 @@ return {
       full_name='imdisable', abbreviation='imd',
       short_desc=N_("do not use the IM in any mode"),
       type='bool', scope={'global'},
-      vi_def=true,
       enable_if=false,
       defaults={if_true={vi=false}}
     },
@@ -1273,7 +1153,6 @@ return {
       full_name='iminsert', abbreviation='imi',
       short_desc=N_("use :lmap or IM in Insert mode"),
       type='number', scope={'buffer'},
-      vi_def=true,
       varname='p_iminsert', pv_name='p_imi',
       defaults={
         if_true={vi=macros('B_IMODE_NONE')},
@@ -1283,7 +1162,6 @@ return {
       full_name='imsearch', abbreviation='ims',
       short_desc=N_("use :lmap or IM when typing a search pattern"),
       type='number', scope={'buffer'},
-      vi_def=true,
       varname='p_imsearch', pv_name='p_ims',
       defaults={
         if_true={vi=macros('B_IMODE_USE_INSERT')},
@@ -1293,7 +1171,6 @@ return {
       full_name='inccommand', abbreviation='icm',
 	  short_desc=N_("Live preview of substitution"),
       type='string', scope={'global'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_icm',
       defaults={if_true={vi=""}}
@@ -1302,7 +1179,6 @@ return {
       full_name='include', abbreviation='inc',
       short_desc=N_("pattern to be used to find an include file"),
       type='string', scope={'global', 'buffer'},
-      vi_def=true,
       alloced=true,
       varname='p_inc',
       defaults={if_true={vi="^\\s*#\\s*include"}}
@@ -1311,7 +1187,6 @@ return {
       full_name='includeexpr', abbreviation='inex',
       short_desc=N_("expression used to process an include line"),
       type='string', scope={'buffer'},
-      vi_def=true,
       modelineexpr=true,
       alloced=true,
       varname='p_inex',
@@ -1322,13 +1197,12 @@ return {
       short_desc=N_("highlight match while typing search pattern"),
       type='bool', scope={'global'},
       varname='p_is',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='indentexpr', abbreviation='inde',
       short_desc=N_("expression used to obtain the indent of a line"),
       type='string', scope={'buffer'},
-      vi_def=true,
       modelineexpr=true,
       alloced=true,
       varname='p_inde',
@@ -1339,7 +1213,6 @@ return {
       short_desc=N_("keys that trigger indenting with 'indentexpr'"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       varname='p_indk',
       defaults={if_true={vi=indentkeys_default}}
@@ -1348,7 +1221,6 @@ return {
       full_name='infercase', abbreviation='inf',
       short_desc=N_("adjust case of match for keyword completion"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_inf',
       defaults={if_true={vi=false}}
     },
@@ -1356,7 +1228,6 @@ return {
       full_name='insertmode', abbreviation='im',
       short_desc=N_("start the edit of a file in Insert mode"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_im',
       defaults={if_true={vi=false}}
     },
@@ -1365,7 +1236,6 @@ return {
       short_desc=N_("characters included in file names and pathnames"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_isf',
       defaults={
         condition='BACKSLASH_IN_FILENAME',
@@ -1380,7 +1250,6 @@ return {
       short_desc=N_("characters included in identifiers"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_isi',
       defaults={
         condition='WIN32',
@@ -1395,14 +1264,13 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_isk',
-      defaults={if_true={vi="@,48-57,_", vim="@,48-57,_,192-255"}}
+      defaults={if_true={vim="@,48-57,_,192-255"}}
     },
     {
       full_name='isprint', abbreviation='isp',
       short_desc=N_("printable characters"),
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_isp',
       defaults={if_true={vi="@,161-255"}
@@ -1412,7 +1280,6 @@ return {
       full_name='joinspaces', abbreviation='js',
       short_desc=N_("two spaces after a period with a join command"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_js',
       defaults={if_true={vi=true}}
     },
@@ -1430,7 +1297,6 @@ return {
       type='string', scope={'buffer'},
       normal_fname_chars=true,
       pri_mkrc=true,
-      vi_def=true,
       alloced=true,
       redraw={'statuslines', 'current_buffer'},
       varname='p_keymap', pv_name='p_kmap',
@@ -1441,7 +1307,6 @@ return {
       short_desc=N_("enable starting/stopping selection with keys"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_km',
       defaults={if_true={vi=""}}
     },
@@ -1450,7 +1315,6 @@ return {
       short_desc=N_("program to use for the \"K\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_kp',
       defaults={
@@ -1463,7 +1327,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       varname='p_langmap',
       defaults={if_true={vi=""}}
     },
@@ -1472,7 +1335,6 @@ return {
       short_desc=N_("language to be used for the menus"),
       type='string', scope={'global'},
       normal_fname_chars=true,
-      vi_def=true,
       varname='p_lm',
       defaults={if_true={vi=""}}
     },
@@ -1481,14 +1343,14 @@ return {
       short_desc=N_("do not apply 'langmap' to mapped characters"),
       type='bool', scope={'global'},
       varname='p_lnr',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='langremap', abbreviation='lrm',
       short_desc=N_('No description'),
       type='bool', scope={'global'},
       varname='p_lrm',
-      defaults={if_true={vi=true, vim=false}}
+      defaults={if_true={vim=false}}
     },
     {
       full_name='laststatus', abbreviation='ls',
@@ -1496,13 +1358,12 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows'},
       varname='p_ls',
-      defaults={if_true={vi=1,vim=2}}
+      defaults={if_true={vim=2}}
     },
     {
       full_name='lazyredraw', abbreviation='lz',
       short_desc=N_("don't redraw while executing macros"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_lz',
       defaults={if_true={vi=false}}
     },
@@ -1510,7 +1371,6 @@ return {
       full_name='linebreak', abbreviation='lbr',
       short_desc=N_("wrap long lines at a blank"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -1519,7 +1379,6 @@ return {
       short_desc=N_("of lines in the display"),
       type='number', scope={'global'},
       no_mkrc=true,
-      vi_def=true,
       redraw={'everything'},
       varname='p_lines',
       defaults={if_true={vi=macros('DFLT_ROWS')}}
@@ -1528,7 +1387,6 @@ return {
       full_name='linespace', abbreviation='lsp',
       short_desc=N_("number of pixel lines to use between characters"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'ui_option'},
       varname='p_linespace',
       defaults={if_true={vi=0}}
@@ -1537,7 +1395,6 @@ return {
       full_name='lisp',
       short_desc=N_("indenting for Lisp"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_lisp',
       defaults={if_true={vi=false}}
     },
@@ -1546,7 +1403,6 @@ return {
       short_desc=N_("words that change how lisp indenting works"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_lispwords', pv_name='p_lw',
       defaults={if_true={vi=macros('LISPWORD_VALUE')}}
     },
@@ -1554,7 +1410,6 @@ return {
       full_name='list',
       short_desc=N_("<Tab> and <EOL>"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -1566,13 +1421,12 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_lcs',
-      defaults={if_true={vi="eol:$", vim="tab:> ,trail:-,nbsp:+"}}
+      defaults={if_true={vim="tab:> ,trail:-,nbsp:+"}}
     },
     {
       full_name='loadplugins', abbreviation='lpl',
       short_desc=N_("load plugin scripts when starting up"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_lpl',
       defaults={if_true={vi=true}}
     },
@@ -1580,7 +1434,6 @@ return {
       full_name='magic',
       short_desc=N_("special characters in search patterns"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_magic',
       defaults={if_true={vi=true}}
     },
@@ -1589,7 +1442,6 @@ return {
       short_desc=N_("name of the errorfile for \":make\""),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_mef',
       defaults={if_true={vi=""}}
@@ -1598,7 +1450,6 @@ return {
       full_name='makeencoding', abbreviation='menc',
       short_desc=N_("Converts the output of external commands"),
       type='string', scope={'global', 'buffer'},
-      vi_def=true,
       varname='p_menc',
       defaults={if_true={vi=""}}
     },
@@ -1607,7 +1458,6 @@ return {
       short_desc=N_("program to use for the \":make\" command"),
       type='string', scope={'global', 'buffer'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_mp',
       defaults={if_true={vi="make"}}
@@ -1617,7 +1467,6 @@ return {
       short_desc=N_("pairs of characters that \"%\" can match"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       varname='p_mps',
       defaults={if_true={vi="(:),{:},[:]"}}
@@ -1626,7 +1475,6 @@ return {
       full_name='matchtime', abbreviation='mat',
       short_desc=N_("tenths of a second to show matching paren"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mat',
       defaults={if_true={vi=5}}
     },
@@ -1634,7 +1482,6 @@ return {
       full_name='maxcombine', abbreviation='mco',
       short_desc=N_("maximum nr of combining characters displayed"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mco',
       defaults={if_true={vi=6}}
     },
@@ -1642,7 +1489,6 @@ return {
       full_name='maxfuncdepth', abbreviation='mfd',
       short_desc=N_("maximum recursive depth for user functions"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mfd',
       defaults={if_true={vi=100}}
     },
@@ -1650,7 +1496,6 @@ return {
       full_name='maxmapdepth', abbreviation='mmd',
       short_desc=N_("maximum recursive depth for mapping"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mmd',
       defaults={if_true={vi=1000}}
     },
@@ -1658,7 +1503,6 @@ return {
       full_name='maxmempattern', abbreviation='mmp',
       short_desc=N_("maximum memory (in Kbyte) used for pattern search"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mmp',
       defaults={if_true={vi=1000}}
     },
@@ -1666,7 +1510,6 @@ return {
       full_name='menuitems', abbreviation='mis',
       short_desc=N_("maximum number of items in a menu"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mis',
       defaults={if_true={vi=25}}
     },
@@ -1675,7 +1518,6 @@ return {
       short_desc=N_("memory used before |:mkspell| compresses the tree"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_msm',
       defaults={if_true={vi="460000,2000,500"}}
@@ -1685,13 +1527,12 @@ return {
       short_desc=N_("recognize modelines at start or end of file"),
       type='bool', scope={'buffer'},
       varname='p_ml',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='modelineexpr', abbreviation='mle',
       short_desc=N_("allow some options to be set in modeline"),
       type='bool', scope={'global'},
-      vi_def=true,
       secure=true,
       varname='p_mle',
       defaults={if_true={vi=false}}
@@ -1700,7 +1541,6 @@ return {
       full_name='modelines', abbreviation='mls',
       short_desc=N_("number of lines checked for modelines"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mls',
       defaults={if_true={vi=5}}
     },
@@ -1709,7 +1549,6 @@ return {
       short_desc=N_("changes to the text are not possible"),
       type='bool', scope={'buffer'},
       noglob=true,
-      vi_def=true,
       varname='p_ma',
       defaults={if_true={vi=true}}
     },
@@ -1718,7 +1557,6 @@ return {
       short_desc=N_("buffer has been modified"),
       type='bool', scope={'buffer'},
       no_mkrc=true,
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_mod',
       defaults={if_true={vi=false}}
@@ -1728,20 +1566,19 @@ return {
       short_desc=N_("listings when the whole screen is filled"),
       type='bool', scope={'global'},
       varname='p_more',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='mouse',
       short_desc=N_("the use of mouse clicks"),
       type='string', list='flags', scope={'global'},
       varname='p_mouse',
-      defaults={if_true={vi="", vim=""}}
+      defaults={if_true={vim=""}}
     },
     {
       full_name='mousefocus', abbreviation='mousef',
       short_desc=N_("keyboard focus follows the mouse"),
       type='bool', scope={'global'},
-      vi_def=true,
       redraw={'ui_option'},
       varname='p_mousef',
       defaults={if_true={vi=false}}
@@ -1750,7 +1587,6 @@ return {
       full_name='mousehide', abbreviation='mh',
       short_desc=N_("hide mouse pointer while typing"),
       type='bool', scope={'global'},
-      vi_def=true,
       enable_if=false,
       defaults={if_true={vi=true}}
     },
@@ -1758,7 +1594,6 @@ return {
       full_name='mousemodel', abbreviation='mousem',
       short_desc=N_("changes meaning of mouse buttons"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_mousem',
       defaults={if_true={vi="extend"}}
     },
@@ -1767,14 +1602,12 @@ return {
       short_desc=N_("shape of the mouse pointer in different modes"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       enable_if=false,
     },
     {
       full_name='mousetime', abbreviation='mouset',
       short_desc=N_("max time between mouse double-click"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_mouset',
       defaults={if_true={vi=500}}
     },
@@ -1785,13 +1618,12 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_nf',
-      defaults={if_true={vi="bin,octal,hex", vim="bin,hex"}}
+      defaults={if_true={vim="bin,hex"}}
     },
     {
       full_name='number', abbreviation='nu',
       short_desc=N_("print the line number in front of each line"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -1800,14 +1632,13 @@ return {
       short_desc=N_("number of columns used for the line number"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=8, vim=4}}
+      defaults={if_true={vim=4}}
     },
     {
       full_name='omnifunc', abbreviation='ofu',
       short_desc=N_("function for filetype-specific completion"),
       type='string', scope={'buffer'},
       secure=true,
-      vi_def=true,
       alloced=true,
       varname='p_ofu',
       defaults={if_true={vi=""}}
@@ -1816,16 +1647,14 @@ return {
       full_name='opendevice', abbreviation='odev',
       short_desc=N_("allow reading/writing devices on MS-Windows"),
       type='bool', scope={'global'},
-      vi_def=true,
       enable_if=false,
-      defaults={if_true={vi=false, vim=false}}
+      defaults={if_true={vim=false}}
     },
     {
       full_name='operatorfunc', abbreviation='opfunc',
       short_desc=N_("function to be called for |g@| operator"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_opfunc',
       defaults={if_true={vi=""}}
     },
@@ -1835,7 +1664,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_pp',
       defaults={if_true={vi=''}}
@@ -1844,7 +1672,6 @@ return {
       full_name='paragraphs', abbreviation='para',
       short_desc=N_("nroff macros that separate paragraphs"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_para',
       defaults={if_true={vi="IPLPPPQPP TPHPLIPpLpItpplpipbp"}}
     },
@@ -1853,7 +1680,6 @@ return {
       short_desc=N_("pasting text"),
       type='bool', scope={'global'},
       pri_mkrc=true,
-      vi_def=true,
       varname='p_paste',
       defaults={if_true={vi=false}}
     },
@@ -1861,7 +1687,6 @@ return {
       full_name='pastetoggle', abbreviation='pt',
       short_desc=N_("key code that causes 'paste' to toggle"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_pt',
       defaults={if_true={vi=""}}
     },
@@ -1870,7 +1695,6 @@ return {
       short_desc=N_("expression used to patch a file"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_pex',
       defaults={if_true={vi=""}}
     },
@@ -1879,7 +1703,6 @@ return {
       short_desc=N_("keep the oldest version of a file"),
       type='string', scope={'global'},
       normal_fname_chars=true,
-      vi_def=true,
       varname='p_pm',
       defaults={if_true={vi=""}}
     },
@@ -1888,7 +1711,6 @@ return {
       short_desc=N_("list of directories searched with \"gf\" et.al."),
       type='string', list='comma', scope={'global', 'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       expand=true,
       varname='p_path',
       defaults={if_true={vi=".,/usr/include,,"}}
@@ -1897,7 +1719,6 @@ return {
       full_name='preserveindent', abbreviation='pi',
       short_desc=N_("preserve the indent structure when reindenting"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_pi',
       defaults={if_true={vi=false}}
     },
@@ -1905,7 +1726,6 @@ return {
       full_name='previewheight', abbreviation='pvh',
       short_desc=N_("height of the preview window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_pvh',
       defaults={if_true={vi=12}}
     },
@@ -1914,7 +1734,6 @@ return {
       short_desc=N_("identifies the preview window"),
       type='bool', scope={'window'},
       noglob=true,
-      vi_def=true,
       redraw={'statuslines'},
       defaults={if_true={vi=false}}
     },
@@ -1923,7 +1742,6 @@ return {
       short_desc=N_("name of the printer to be used for :hardcopy"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_pdev',
       defaults={if_true={vi=""}}
     },
@@ -1931,7 +1749,6 @@ return {
       full_name='printencoding', abbreviation='penc',
       short_desc=N_("encoding to be used for printing"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_penc',
       defaults={if_true={vi=""}}
     },
@@ -1940,7 +1757,6 @@ return {
       short_desc=N_("expression used to print PostScript for :hardcopy"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_pexpr',
       defaults={if_true={vi=""}}
     },
@@ -1948,7 +1764,6 @@ return {
       full_name='printfont', abbreviation='pfn',
       short_desc=N_("name of the font to be used for :hardcopy"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_pfn',
       defaults={if_true={vi="courier"}}
     },
@@ -1956,7 +1771,6 @@ return {
       full_name='printheader', abbreviation='pheader',
       short_desc=N_("format of the header used for :hardcopy"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_header',
       defaults={if_true={vi="%<%f%h%m%=Page %N"}}
     },
@@ -1964,7 +1778,6 @@ return {
       full_name='printmbcharset', abbreviation='pmbcs',
       short_desc=N_("CJK character set to be used for :hardcopy"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_pmcs',
       defaults={if_true={vi=""}}
     },
@@ -1972,7 +1785,6 @@ return {
       full_name='printmbfont', abbreviation='pmbfn',
       short_desc=N_("font names to be used for CJK output of :hardcopy"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_pmfn',
       defaults={if_true={vi=""}}
     },
@@ -1981,7 +1793,6 @@ return {
       short_desc=N_("controls the format of :hardcopy output"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_popt',
       defaults={if_true={vi=""}}
     },
@@ -1989,7 +1800,6 @@ return {
       full_name='prompt',
       short_desc=N_("enable prompt in Ex mode"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_prompt',
       defaults={if_true={vi=true}}
     },
@@ -1997,7 +1807,6 @@ return {
       full_name='pumblend', abbreviation='pb',
       short_desc=N_("Controls transparency level of popup menu"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'ui_option'},
       varname='p_pb',
       defaults={if_true={vi=0}}
@@ -2006,7 +1815,6 @@ return {
       full_name='pumheight', abbreviation='ph',
       short_desc=N_("maximum height of the popup menu"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_ph',
       defaults={if_true={vi=0}}
     },
@@ -2014,7 +1822,6 @@ return {
       full_name='pumwidth', abbreviation='pw',
       short_desc=N_("minimum width of the popup menu"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_pw',
       defaults={if_true={vi=15}}
     },
@@ -2023,7 +1830,6 @@ return {
       short_desc=N_("selects default python version to use"),
       type='number', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_pyx',
       defaults={if_true={vi=0}}
     },
@@ -2031,7 +1837,6 @@ return {
       full_name='quickfixtextfunc', abbreviation='qftf',
       short_desc=N_("customize the quickfix window"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_qftf',
       defaults={if_true={vi=""}}
     },
@@ -2039,7 +1844,6 @@ return {
       full_name='quoteescape', abbreviation='qe',
       short_desc=N_("escape characters used in a string"),
       type='string', scope={'buffer'},
-      vi_def=true,
       alloced=true,
       varname='p_qe',
       defaults={if_true={vi="\\"}}
@@ -2049,7 +1853,6 @@ return {
       short_desc=N_("disallow writing the buffer"),
       type='bool', scope={'buffer'},
       noglob=true,
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_ro',
       defaults={if_true={vi=false}}
@@ -2058,7 +1861,6 @@ return {
       full_name='redrawdebug', abbreviation='rdb',
       short_desc=N_("Changes the way redrawing works (debug)"),
       type='string', list='onecomma', scope={'global'},
-      vi_def=true,
       varname='p_rdb',
       defaults={if_true={vi=''}}
     },
@@ -2066,7 +1868,6 @@ return {
       full_name='redrawtime', abbreviation='rdt',
       short_desc=N_("timeout for 'hlsearch' and |:match| highlighting"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_rdt',
       defaults={if_true={vi=2000}}
     },
@@ -2074,7 +1875,6 @@ return {
       full_name='regexpengine', abbreviation='re',
       short_desc=N_("default regexp engine to use"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_re',
       defaults={if_true={vi=0}}
     },
@@ -2082,7 +1882,6 @@ return {
       full_name='relativenumber', abbreviation='rnu',
       short_desc=N_("show relative line number in front of each line"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -2090,7 +1889,6 @@ return {
       full_name='remap',
       short_desc=N_("mappings to work recursively"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_remap',
       defaults={if_true={vi=true}}
     },
@@ -2098,7 +1896,6 @@ return {
       full_name='report',
       short_desc=N_("for reporting nr. of lines changed"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_report',
       defaults={if_true={vi=2}}
     },
@@ -2106,7 +1903,6 @@ return {
       full_name='revins', abbreviation='ri',
       short_desc=N_("inserting characters will work backwards"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_ri',
       defaults={if_true={vi=false}}
     },
@@ -2114,7 +1910,6 @@ return {
       full_name='rightleft', abbreviation='rl',
       short_desc=N_("window is right-to-left oriented"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -2122,7 +1917,6 @@ return {
       full_name='rightleftcmd', abbreviation='rlc',
       short_desc=N_("commands for which editing works right-to-left"),
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="search"}}
@@ -2131,7 +1925,6 @@ return {
       full_name='ruler', abbreviation='ru',
       short_desc=N_("show cursor line and column in the status line"),
       type='bool', scope={'global'},
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_ru',
       defaults={if_true={vi=true}}
@@ -2140,7 +1933,6 @@ return {
       full_name='rulerformat', abbreviation='ruf',
       short_desc=N_("custom format for the ruler"),
       type='string', scope={'global'},
-      vi_def=true,
       alloced=true,
       modelineexpr=true,
       redraw={'statuslines'},
@@ -2153,7 +1945,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand='nodefault',
       varname='p_rtp',
       defaults={if_true={vi=''}}
@@ -2163,7 +1954,6 @@ return {
       short_desc=N_("lines to scroll with CTRL-U and CTRL-D"),
       type='number', scope={'window'},
       no_mkrc=true,
-      vi_def=true,
       pv_name='p_scroll',
       defaults={if_true={vi=0}}
     },
@@ -2171,7 +1961,6 @@ return {
       full_name='scrollback', abbreviation='scbk',
       short_desc=N_("lines to scroll with CTRL-U and CTRL-D"),
       type='number', scope={'buffer'},
-      vi_def=true,
       varname='p_scbk',
       redraw={'current_buffer'},
       defaults={if_true={vi=-1}}
@@ -2180,7 +1969,6 @@ return {
       full_name='scrollbind', abbreviation='scb',
       short_desc=N_("scroll in window as other windows scroll"),
       type='bool', scope={'window'},
-      vi_def=true,
       pv_name='p_scbind',
       defaults={if_true={vi=false}}
     },
@@ -2188,7 +1976,6 @@ return {
       full_name='scrolljump', abbreviation='sj',
       short_desc=N_("minimum number of lines to scroll"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_sj',
       defaults={if_true={vi=1}}
     },
@@ -2196,7 +1983,6 @@ return {
       full_name='scrolloff', abbreviation='so',
       short_desc=N_("minimum nr. of lines above and below cursor"),
       type='number', scope={'global', 'window'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_so',
       defaults={if_true={vi=0}}
@@ -2206,7 +1992,6 @@ return {
       short_desc=N_("how 'scrollbind' should behave"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_sbo',
       defaults={if_true={vi="ver,jump"}}
     },
@@ -2214,7 +1999,6 @@ return {
       full_name='sections', abbreviation='sect',
       short_desc=N_("nroff macros that separate sections"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_sections',
       defaults={if_true={vi="SHNHH HUnhsh"}}
     },
@@ -2223,7 +2007,6 @@ return {
       short_desc=N_("mode for reading .vimrc in current dir"),
       type='bool', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_secure',
       defaults={if_true={vi=false}}
     },
@@ -2231,7 +2014,6 @@ return {
       full_name='selection', abbreviation='sel',
       short_desc=N_("what type of selection to use"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_sel',
       defaults={if_true={vi="inclusive"}}
     },
@@ -2240,7 +2022,6 @@ return {
       short_desc=N_("when to use Select mode instead of Visual mode"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_slm',
       defaults={if_true={vi=""}}
     },
@@ -2251,7 +2032,6 @@ return {
       deny_duplicates=true,
       varname='p_ssop',
       defaults={if_true={
-        vi="blank,buffers,curdir,folds,help,options,tabpages,winsize",
         vim="blank,buffers,curdir,folds,help,tabpages,winsize"
       }}
     },
@@ -2262,14 +2042,13 @@ return {
       deny_duplicates=true,
       secure=true,
       varname='p_shada',
-      defaults={if_true={vi="", vim="!,'100,<50,s10,h"}}
+      defaults={if_true={vim="!,'100,<50,s10,h"}}
     },
     {
       full_name='shadafile', abbreviation='sdf',
       short_desc=N_("overrides the filename used for shada"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       secure=true,
       expand=true,
       varname='p_shadafile',
@@ -2280,7 +2059,6 @@ return {
       short_desc=N_("name of shell to use for external commands"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_sh',
       defaults={
@@ -2294,7 +2072,6 @@ return {
       short_desc=N_("flag to shell to execute one command"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_shcf',
       defaults={
         condition='WIN32',
@@ -2307,7 +2084,6 @@ return {
       short_desc=N_("string to put output of \":make\" in error file"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_sp',
       defaults={
         condition='WIN32',
@@ -2320,7 +2096,6 @@ return {
       short_desc=N_("quote character(s) for around shell command"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_shq',
       defaults={if_true={vi=""}}
     },
@@ -2329,7 +2104,6 @@ return {
       short_desc=N_("string to put output of filter in a temp file"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_srr',
       defaults={
         condition='WIN32',
@@ -2341,7 +2115,6 @@ return {
       full_name='shellslash', abbreviation='ssl',
       short_desc=N_("use forward slash for shell file names"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_ssl',
       enable_if='BACKSLASH_IN_FILENAME',
       defaults={if_true={vi=false}}
@@ -2351,14 +2124,13 @@ return {
       short_desc=N_("whether to use a temp file for shell commands"),
       type='bool', scope={'global'},
       varname='p_stmp',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='shellxquote', abbreviation='sxq',
       short_desc=N_("like 'shellquote', but include redirection"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_sxq',
       defaults={
         condition='WIN32',
@@ -2371,7 +2143,6 @@ return {
       short_desc=N_("characters to escape when 'shellxquote' is ("),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       varname='p_sxe',
       defaults={if_true={vi=""}}
     },
@@ -2379,7 +2150,6 @@ return {
       full_name='shiftround', abbreviation='sr',
       short_desc=N_("round indent to multiple of shiftwidth"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_sr',
       defaults={if_true={vi=false}}
     },
@@ -2387,7 +2157,6 @@ return {
       full_name='shiftwidth', abbreviation='sw',
       short_desc=N_("number of spaces to use for (auto)indent step"),
       type='number', scope={'buffer'},
-      vi_def=true,
       varname='p_sw',
       defaults={if_true={vi=8}}
     },
@@ -2396,13 +2165,12 @@ return {
       short_desc=N_("list of flags, reduce length of messages"),
       type='string', list='flags', scope={'global'},
       varname='p_shm',
-      defaults={if_true={vi="S", vim="filnxtToOF"}}
+      defaults={if_true={vim="filnxtToOF"}}
     },
     {
       full_name='showbreak', abbreviation='sbr',
       short_desc=N_("string to use at the start of wrapped lines"),
       type='string', scope={'global'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_sbr',
       defaults={if_true={vi=""}}
@@ -2412,13 +2180,12 @@ return {
       short_desc=N_("show (partial) command in status line"),
       type='bool', scope={'global'},
       varname='p_sc',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='showfulltag', abbreviation='sft',
       short_desc=N_("show full tag pattern when completing tag"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_sft',
       defaults={if_true={vi=false}}
     },
@@ -2426,7 +2193,6 @@ return {
       full_name='showmatch', abbreviation='sm',
       short_desc=N_("briefly jump to matching bracket if insert one"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_sm',
       defaults={if_true={vi=false}}
     },
@@ -2435,13 +2201,12 @@ return {
       short_desc=N_("message on status line to show current mode"),
       type='bool', scope={'global'},
       varname='p_smd',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='showtabline', abbreviation='stal',
       short_desc=N_("tells when the tab pages line is displayed"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'all_windows', 'ui_option'},
       varname='p_stal',
       defaults={if_true={vi=1}}
@@ -2450,7 +2215,6 @@ return {
       full_name='sidescroll', abbreviation='ss',
       short_desc=N_("minimum number of columns to scroll horizontal"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_ss',
       defaults={if_true={vi=1}}
     },
@@ -2458,7 +2222,6 @@ return {
       full_name='sidescrolloff', abbreviation='siso',
       short_desc=N_("min. nr. of columns to left and right of cursor"),
       type='number', scope={'global', 'window'},
-      vi_def=true,
       redraw={'all_windows'},
       varname='p_siso',
       defaults={if_true={vi=0}}
@@ -2467,7 +2230,6 @@ return {
       full_name='signcolumn', abbreviation='scl',
       short_desc=N_("when to display the sign column"),
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi="auto"}}
@@ -2476,7 +2238,6 @@ return {
       full_name='smartcase', abbreviation='scs',
       short_desc=N_("no ignore case when pattern has uppercase"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_scs',
       defaults={if_true={vi=false}}
     },
@@ -2484,7 +2245,6 @@ return {
       full_name='smartindent', abbreviation='si',
       short_desc=N_("smart autoindenting for C programs"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_si',
       defaults={if_true={vi=false}}
     },
@@ -2493,13 +2253,12 @@ return {
       short_desc=N_("use 'shiftwidth' when inserting <Tab>"),
       type='bool', scope={'global'},
       varname='p_sta',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='softtabstop', abbreviation='sts',
       short_desc=N_("number of spaces that <Tab> uses while editing"),
       type='number', scope={'buffer'},
-      vi_def=true,
       varname='p_sts',
       defaults={if_true={vi=0}}
     },
@@ -2507,7 +2266,6 @@ return {
       full_name='spell',
       short_desc=N_("spell checking"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=false}}
     },
@@ -2515,7 +2273,6 @@ return {
       full_name='spellcapcheck', abbreviation='spc',
       short_desc=N_("pattern to locate end of a sentence"),
       type='string', scope={'buffer'},
-      vi_def=true,
       alloced=true,
       redraw={'current_buffer'},
       varname='p_spc',
@@ -2527,7 +2284,6 @@ return {
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       alloced=true,
       expand=true,
       varname='p_spf',
@@ -2538,7 +2294,6 @@ return {
       short_desc=N_("language(s) to do spell checking for"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       expand=true,
       redraw={'current_buffer'},
@@ -2551,7 +2306,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_sps',
       defaults={if_true={vi="best"}}
@@ -2561,16 +2315,14 @@ return {
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_spo',
-      defaults={if_true={vi="", vim=""}}
+      defaults={if_true={vim=""}}
     },
     {
       full_name='splitbelow', abbreviation='sb',
       short_desc=N_("new window from split is below the current one"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_sb',
       defaults={if_true={vi=false}}
     },
@@ -2578,7 +2330,6 @@ return {
       full_name='splitright', abbreviation='spr',
       short_desc=N_("new window is put right of the current one"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_spr',
       defaults={if_true={vi=false}}
     },
@@ -2586,7 +2337,6 @@ return {
       full_name='startofline', abbreviation='sol',
       short_desc=N_("commands move cursor to first non-blank in line"),
       type='bool', scope={'global'},
-      vi_def=true,
       vim=false,
       varname='p_sol',
       defaults={if_true={vi=false}}
@@ -2595,7 +2345,6 @@ return {
       full_name='statusline', abbreviation='stl',
       short_desc=N_("custom format for the status line"),
       type='string', scope={'global', 'window'},
-      vi_def=true,
       alloced=true,
       modelineexpr=true,
       redraw={'statuslines'},
@@ -2607,7 +2356,6 @@ return {
       short_desc=N_("suffixes that are ignored with multiple match"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_su',
       defaults={if_true={vi=".bak,~,.o,.h,.info,.swp,.obj"}}
     },
@@ -2616,7 +2364,6 @@ return {
       short_desc=N_("suffixes added when searching for a file"),
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       alloced=true,
       varname='p_sua',
       defaults={if_true={vi=""}}
@@ -2625,7 +2372,6 @@ return {
       full_name='swapfile', abbreviation='swf',
       short_desc=N_("whether to use a swapfile for a buffer"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       redraw={'statuslines'},
       varname='p_swf',
       defaults={if_true={vi=true}}
@@ -2635,7 +2381,6 @@ return {
       short_desc=N_("sets behavior when switching to another buffer"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_swb',
       defaults={if_true={vi=""}}
     },
@@ -2643,7 +2388,6 @@ return {
       full_name='synmaxcol', abbreviation='smc',
       short_desc=N_("maximum column to find syntax items"),
       type='number', scope={'buffer'},
-      vi_def=true,
       redraw={'current_buffer'},
       varname='p_smc',
       defaults={if_true={vi=3000}}
@@ -2654,7 +2398,6 @@ return {
       type='string', scope={'buffer'},
       noglob=true,
       normal_fname_chars=true,
-      vi_def=true,
       alloced=true,
       varname='p_syn',
       defaults={if_true={vi=""}}
@@ -2663,7 +2406,6 @@ return {
       full_name='tagfunc', abbreviation='tfu',
       short_desc=N_("function used to perform tag searches"),
       type='string', scope={'buffer'},
-      vi_def=true,
       varname='p_tfu',
       defaults={if_true={vi=""}}
     },
@@ -2671,7 +2413,6 @@ return {
       full_name='tabline', abbreviation='tal',
       short_desc=N_("custom format for the console tab pages line"),
       type='string', scope={'global'},
-      vi_def=true,
       modelineexpr=true,
       redraw={'all_windows'},
       varname='p_tal',
@@ -2682,13 +2423,12 @@ return {
       short_desc=N_("maximum number of tab pages for |-p| and \"tab all\""),
       type='number', scope={'global'},
       varname='p_tpm',
-      defaults={if_true={vi=10, vim=50}}
+      defaults={if_true={vim=50}}
     },
     {
       full_name='tabstop', abbreviation='ts',
       short_desc=N_("number of spaces that <Tab> in file uses"),
       type='number', scope={'buffer'},
-      vi_def=true,
       redraw={'current_buffer'},
       varname='p_ts',
       defaults={if_true={vi=8}}
@@ -2697,7 +2437,6 @@ return {
       full_name='tagbsearch', abbreviation='tbs',
       short_desc=N_("use binary searching in tags files"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_tbs',
       defaults={if_true={vi=true}}
     },
@@ -2706,13 +2445,12 @@ return {
       short_desc=N_("how to handle case when searching in tags files"),
       type='string', scope={'global', 'buffer'},
       varname='p_tc',
-      defaults={if_true={vi="followic", vim="followic"}}
+      defaults={if_true={vim="followic"}}
     },
     {
       full_name='taglength', abbreviation='tl',
       short_desc=N_("number of significant characters for a tag"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_tl',
       defaults={if_true={vi=0}}
     },
@@ -2721,14 +2459,13 @@ return {
       short_desc=N_("file names in tag file are relative"),
       type='bool', scope={'global'},
       varname='p_tr',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='tags', abbreviation='tag',
       short_desc=N_("list of file names used by the tag command"),
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
-      vi_def=true,
       expand=true,
       varname='p_tags',
       defaults={if_true={vi="./tags;,tags"}}
@@ -2737,7 +2474,6 @@ return {
       full_name='tagstack', abbreviation='tgst',
       short_desc=N_("push tags onto the tag stack"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_tgst',
       defaults={if_true={vi=true}}
     },
@@ -2745,7 +2481,6 @@ return {
       full_name='termbidi', abbreviation='tbidi',
       short_desc=N_("terminal takes care of bi-directionality"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_tbidi',
       defaults={if_true={vi=false}}
     },
@@ -2753,14 +2488,12 @@ return {
       full_name='termencoding', abbreviation='tenc',
       short_desc=N_("Terminal encodig"),
       type='string', scope={'global'},
-      vi_def=true,
       defaults={if_true={vi=""}}
     },
     {
       full_name='termguicolors', abbreviation='tgc',
       short_desc=N_("Terminal true color support"),
       type='bool', scope={'global'},
-      vi_def=false,
       redraw={'ui_option'},
       varname='p_tgc',
       defaults={if_true={vi=false}}
@@ -2770,13 +2503,12 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_tpf',
-      defaults={if_true={vi="", vim="BS,HT,ESC,DEL"}}
+      defaults={if_true={vim="BS,HT,ESC,DEL"}}
     },
     {
       full_name='terse',
       short_desc=N_("hides notification of search wrap"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_terse',
       defaults={if_true={vi=false}}
     },
@@ -2784,7 +2516,6 @@ return {
       full_name='textwidth', abbreviation='tw',
       short_desc=N_("maximum width of text that is being inserted"),
       type='number', scope={'buffer'},
-      vi_def=true,
       redraw={'current_buffer'},
       varname='p_tw',
       defaults={if_true={vi=0}}
@@ -2795,7 +2526,6 @@ return {
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       normal_dname_chars=true,
-      vi_def=true,
       expand=true,
       varname='p_tsr',
       defaults={if_true={vi=""}}
@@ -2804,7 +2534,6 @@ return {
       full_name='tildeop', abbreviation='top',
       short_desc=N_("tilde command \"~\" behaves like an operator"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_to',
       defaults={if_true={vi=false}}
     },
@@ -2812,7 +2541,6 @@ return {
       full_name='timeout', abbreviation='to',
       short_desc=N_("time out on mappings and key codes"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_timeout',
       defaults={if_true={vi=true}}
     },
@@ -2820,7 +2548,6 @@ return {
       full_name='timeoutlen', abbreviation='tm',
       short_desc=N_("time out time in milliseconds"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_tm',
       defaults={if_true={vi=1000}}
     },
@@ -2828,7 +2555,6 @@ return {
       full_name='title',
       short_desc=N_("Vim set the title of the window"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_title',
       defaults={if_true={vi=false}}
     },
@@ -2836,7 +2562,6 @@ return {
       full_name='titlelen',
       short_desc=N_("of 'columns' used for window title"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_titlelen',
       defaults={if_true={vi=85}}
     },
@@ -2846,7 +2571,6 @@ return {
       type='string', scope={'global'},
       secure=true,
       no_mkrc=true,
-      vi_def=true,
       varname='p_titleold',
       defaults={if_true={vi=""}}
     },
@@ -2854,7 +2578,6 @@ return {
       full_name='titlestring',
       short_desc=N_("to use for the Vim window title"),
       type='string', scope={'global'},
-      vi_def=true,
       modelineexpr=true,
       varname='p_titlestring',
       defaults={if_true={vi=""}}
@@ -2863,7 +2586,6 @@ return {
       full_name='ttimeout',
       short_desc=N_("out on mappings"),
       type='bool', scope={'global'},
-      vi_def=true,
       redraw={'ui_option'},
       varname='p_ttimeout',
       defaults={if_true={vi=true}}
@@ -2872,7 +2594,6 @@ return {
       full_name='ttimeoutlen', abbreviation='ttm',
       short_desc=N_("time out time for key codes in milliseconds"),
       type='number', scope={'global'},
-      vi_def=true,
       redraw={'ui_option'},
       varname='p_ttm',
       defaults={if_true={vi=50}}
@@ -2882,7 +2603,6 @@ return {
 	  short_desc=N_("No description"),
       type='bool', scope={'global'},
       no_mkrc=true,
-      vi_def=true,
       varname='p_force_on',
       defaults={if_true={vi=true}}
     },
@@ -2892,7 +2612,6 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       secure=true,
-      vi_def=true,
       expand='nodefault',
       varname='p_udir',
       defaults={if_true={vi=''}}
@@ -2901,7 +2620,6 @@ return {
       full_name='undofile', abbreviation='udf',
       short_desc=N_("save undo information in a file"),
       type='bool', scope={'buffer'},
-      vi_def=true,
       varname='p_udf',
       defaults={if_true={vi=false}}
     },
@@ -2909,7 +2627,6 @@ return {
       full_name='undolevels', abbreviation='ul',
       short_desc=N_("maximum number of changes that can be undone"),
       type='number', scope={'global', 'buffer'},
-      vi_def=true,
       varname='p_ul',
       defaults={if_true={vi=1000}}
     },
@@ -2917,7 +2634,6 @@ return {
       full_name='undoreload', abbreviation='ur',
       short_desc=N_("max nr of lines to save for undo on a buffer reload"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_ur',
       defaults={if_true={vi=10000}}
     },
@@ -2925,7 +2641,6 @@ return {
       full_name='updatecount', abbreviation='uc',
       short_desc=N_("after this many characters flush swap file"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_uc',
       defaults={if_true={vi=200}}
     },
@@ -2933,7 +2648,6 @@ return {
       full_name='updatetime', abbreviation='ut',
       short_desc=N_("after this many milliseconds flush swap file"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_ut',
       defaults={if_true={vi=4000}}
     },
@@ -2941,7 +2655,6 @@ return {
       full_name='varsofttabstop', abbreviation='vsts',
       short_desc=N_("list of numbers of spaces that <Tab> uses while editing"),
       type='string', list='comma', scope={'buffer'},
-      vi_def=true,
       varname='p_vsts',
       defaults={if_true={vi=""}}
     },
@@ -2949,7 +2662,6 @@ return {
       full_name='vartabstop', abbreviation='vts',
       short_desc=N_("list of numbers of spaces that <Tab> in file uses"),
       type='string', list='comma', scope={'buffer'},
-      vi_def=true,
       varname='p_vts',
       redraw={'current_buffer'},
       defaults={if_true={vi=""}}
@@ -2958,7 +2670,6 @@ return {
       full_name='verbose', abbreviation='vbs',
       short_desc=N_("give informative messages"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_verbose',
       defaults={if_true={vi=0}}
     },
@@ -2967,7 +2678,6 @@ return {
       short_desc=N_("file to write messages in"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand=true,
       varname='p_vfile',
       defaults={if_true={vi=""}}
@@ -2977,7 +2687,6 @@ return {
       short_desc=N_("directory where to store files with :mkview"),
       type='string', scope={'global'},
       secure=true,
-      vi_def=true,
       expand='nodefault',
       varname='p_vdir',
       defaults={if_true={vi=''}}
@@ -2987,7 +2696,6 @@ return {
       short_desc=N_("specifies what to save for :mkview"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_vop',
       defaults={if_true={vi="folds,options,cursor,curdir"}}
     },
@@ -3008,16 +2716,14 @@ return {
       short_desc=N_("when to use virtual editing"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       redraw={'curswant'},
       varname='p_ve',
-      defaults={if_true={vi="", vim=""}}
+      defaults={if_true={vim=""}}
     },
     {
       full_name='visualbell', abbreviation='vb',
       short_desc=N_("use visual bell instead of beeping"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_vb',
       defaults={if_true={vi=false}}
     },
@@ -3025,7 +2731,6 @@ return {
       full_name='warn',
       short_desc=N_("for shell command when buffer was changed"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_warn',
       defaults={if_true={vi=true}}
     },
@@ -3034,20 +2739,19 @@ return {
       short_desc=N_("allow specified keys to cross line boundaries"),
       type='string', list='flagscomma', scope={'global'},
       varname='p_ww',
-      defaults={if_true={vi="", vim="b,s"}}
+      defaults={if_true={vim="b,s"}}
     },
     {
       full_name='wildchar', abbreviation='wc',
       short_desc=N_("command-line character for wildcard expansion"),
       type='number', scope={'global'},
       varname='p_wc',
-      defaults={if_true={vi=imacros('Ctrl_E'), vim=imacros('TAB')}}
+      defaults={if_true={vim=imacros('TAB')}}
     },
     {
       full_name='wildcharm', abbreviation='wcm',
       short_desc=N_("like 'wildchar' but also works when mapped"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_wcm',
       defaults={if_true={vi=0}}
     },
@@ -3056,7 +2760,6 @@ return {
       short_desc=N_("files matching these patterns are not completed"),
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
-      vi_def=true,
       varname='p_wig',
       defaults={if_true={vi=""}}
     },
@@ -3064,7 +2767,6 @@ return {
       full_name='wildignorecase', abbreviation='wic',
       short_desc=N_("ignore case when completing file names"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_wic',
       defaults={if_true={vi=false}}
     },
@@ -3073,7 +2775,7 @@ return {
       short_desc=N_("use menu for command line completion"),
       type='bool', scope={'global'},
       varname='p_wmnu',
-      defaults={if_true={vi=false, vim=true}}
+      defaults={if_true={vim=true}}
     },
     {
       full_name='wildmode', abbreviation='wim',
@@ -3081,7 +2783,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=false,
       varname='p_wim',
-      defaults={if_true={vi="", vim="full"}}
+      defaults={if_true={vim="full"}}
     },
     {
       full_name='wildoptions', abbreviation='wop',
@@ -3089,13 +2791,12 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_wop',
-      defaults={if_true={vi='', vim='pum,tagfile'}}
+      defaults={if_true={vim='pum,tagfile'}}
     },
     {
       full_name='winaltkeys', abbreviation='wak',
       short_desc=N_("when the windows system handles ALT keys"),
       type='string', scope={'global'},
-      vi_def=true,
       varname='p_wak',
       defaults={if_true={vi="menu"}}
     },
@@ -3103,7 +2804,6 @@ return {
       full_name='winblend', abbreviation='winbl',
       short_desc=N_("Controls transparency level for floating windows"),
       type='number', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=0}}
     },
@@ -3111,7 +2811,6 @@ return {
       full_name='winhighlight', abbreviation='winhl',
       short_desc=N_("Setup window-local highlights");
       type='string', scope={'window'},
-      vi_def=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true={vi=""}}
@@ -3120,7 +2819,6 @@ return {
       full_name='window', abbreviation='wi',
       short_desc=N_("nr of lines to scroll for CTRL-F and CTRL-B"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_window',
       defaults={if_true={vi=0}}
     },
@@ -3128,7 +2826,6 @@ return {
       full_name='winheight', abbreviation='wh',
       short_desc=N_("minimum number of lines for the current window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_wh',
       defaults={if_true={vi=1}}
     },
@@ -3136,7 +2833,6 @@ return {
       full_name='winfixheight', abbreviation='wfh',
       short_desc=N_("keep window height when opening/closing windows"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'statuslines'},
       defaults={if_true={vi=false}}
     },
@@ -3144,7 +2840,6 @@ return {
       full_name='winfixwidth', abbreviation='wfw',
       short_desc=N_("keep window width when opening/closing windows"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'statuslines'},
       defaults={if_true={vi=false}}
     },
@@ -3152,7 +2847,6 @@ return {
       full_name='winminheight', abbreviation='wmh',
       short_desc=N_("minimum number of lines for any window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_wmh',
       defaults={if_true={vi=1}}
     },
@@ -3160,7 +2854,6 @@ return {
       full_name='winminwidth', abbreviation='wmw',
       short_desc=N_("minimal number of columns for any window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_wmw',
       defaults={if_true={vi=1}}
     },
@@ -3168,7 +2861,6 @@ return {
       full_name='winwidth', abbreviation='wiw',
       short_desc=N_("minimal number of columns for current window"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_wiw',
       defaults={if_true={vi=20}}
     },
@@ -3176,7 +2868,6 @@ return {
       full_name='wrap',
       short_desc=N_("lines wrap and continue on the next line"),
       type='bool', scope={'window'},
-      vi_def=true,
       redraw={'current_window'},
       defaults={if_true={vi=true}}
     },
@@ -3184,7 +2875,6 @@ return {
       full_name='wrapmargin', abbreviation='wm',
       short_desc=N_("chars from the right where wrapping starts"),
       type='number', scope={'buffer'},
-      vi_def=true,
       varname='p_wm',
       defaults={if_true={vi=0}}
     },
@@ -3192,7 +2882,6 @@ return {
       full_name='wrapscan', abbreviation='ws',
       short_desc=N_("searches wrap around the end of the file"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_ws',
       defaults={if_true={vi=true}}
     },
@@ -3200,7 +2889,6 @@ return {
       full_name='write',
       short_desc=N_("to a file is allowed"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_write',
       defaults={if_true={vi=true}}
     },
@@ -3208,7 +2896,6 @@ return {
       full_name='writeany', abbreviation='wa',
       short_desc=N_("write to file with no need for \"!\" override"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_wa',
       defaults={if_true={vi=false}}
     },
@@ -3216,7 +2903,6 @@ return {
       full_name='writebackup', abbreviation='wb',
       short_desc=N_("make a backup before overwriting a file"),
       type='bool', scope={'global'},
-      vi_def=true,
       varname='p_wb',
       defaults={if_true={vi=true}}
     },
@@ -3224,7 +2910,6 @@ return {
       full_name='writedelay', abbreviation='wd',
       short_desc=N_("delay this many msec for each char (for debug)"),
       type='number', scope={'global'},
-      vi_def=true,
       varname='p_wd',
       defaults={if_true={vi=0}}
     },

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -20,7 +20,7 @@ set tags=./tags,tags
 set undodir^=.
 set wildoptions=
 set startofline
-set sessionoptions&vi
+set sessionoptions+=options
 
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -170,7 +170,7 @@ func Test_mksession_rtp()
     return
   endif
   new
-  set sessionoptions&vi
+  set sessionoptions+=options
   let _rtp=&rtp
   " Make a real long (invalid) runtimepath value,
   " that should exceed PATH_MAX (hopefully)
@@ -290,7 +290,7 @@ endfunc
 if has('extra_search')
 
 func Test_mksession_hlsearch()
-  set sessionoptions&vi
+  set sessionoptions+=options
   set hlsearch
   mksession! Xtest_mks.out
   nohlsearch
@@ -630,7 +630,7 @@ endfunc
 
 " Test for mksession with a named scratch buffer
 func Test_mksession_scratch()
-  set sessionoptions&vi
+  set sessionoptions+=options
   enew | only
   file Xscratch
   set buftype=nofile

--- a/test/functional/legacy/listchars_spec.lua
+++ b/test/functional/legacy/listchars_spec.lua
@@ -8,7 +8,7 @@ local clear, feed_command, expect = helpers.clear, helpers.feed_command, helpers
 describe("'listchars'", function()
   before_each(function()
     clear()
-    feed_command('set listchars&vi')
+    feed_command('set listchars=eol:$')
   end)
 
   -- luacheck: ignore 613 (Trailing whitespace in a string)

--- a/test/functional/legacy/mksession_spec.lua
+++ b/test/functional/legacy/mksession_spec.lua
@@ -12,7 +12,7 @@ describe('mksession', function()
   end)
 
   it('supports "skiprtp" value', function()
-    command('set sessionoptions&vi')
+    command('set sessionoptions+=options')
     command('set rtp+=$HOME')
     command('set pp+=$HOME')
     command('mksession! Xtest_mks.out')


### PR DESCRIPTION
It might come as a shocking surprise, but the defaults we actually support are the neovim defaults, not the defaults of an _other editor_ (or two other editors). 

The "vi defaults" were used over conflicting "vim defaults" only if `'compatible'` was set, an option which was disabled long ago.

