### PR TITLE
feat(lua): add :verbose support for lua config

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6716,8 +6716,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When bigger than zero, Vim will give messages about what it is doing.
 	Currently, these messages are given:
-	>= 1	When the shada file is read or written.
-	>= 2	When a file is ":source"'ed.
+	>= 1	Lua assignments to options,keymaps etc.
+	>= 2	When a file is ":source"'ed and when the shada file is read or written..
 	>= 3	UI info, terminal capabilities
 	>= 4	Shell commands.
 	>= 5	Every searched tags file and include file.

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -461,10 +461,11 @@ g8			Print the hex values of the bytes used in the
 							*:verbose-cmd*
 When 'verbose' is non-zero, listing the value of a Vim option or a key map or
 an abbreviation or a user-defined function or a command or a highlight group
-or an autocommand will also display where it was last defined.  If it was
-defined manually then there will be no "Last set" message.  When it was
-defined while executing a function, user command or autocommand, the script in
-which it was defined is reported.
+or an autocommand will also display where it was last defined. If they were
+defined in Lua they will only be located if 'verbose' is set. So Start
+nvim with -V1 arg to see them. If it was defined manually then there
+will be no "Last set" message.  When it was defined while executing a function,
+user command or autocommand, the script in which it was defined is reported.
 
 							*K*
 [count]K       		Runs the program given by 'keywordprg' to lookup the

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -64,6 +64,7 @@ set(LUA_F_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/F.lua)
 set(LUA_META_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/_meta.lua)
 set(LUA_FILETYPE_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/filetype.lua)
 set(LUA_LOAD_PACKAGE_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/_load_package.lua)
+set(LUA_KEYMAP_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/keymap.lua)
 set(CHAR_BLOB_GENERATOR ${GENERATOR_DIR}/gen_char_blob.lua)
 set(LINT_SUPPRESS_FILE ${PROJECT_BINARY_DIR}/errors.json)
 set(LINT_SUPPRESS_URL_BASE "https://raw.githubusercontent.com/neovim/doc/gh-pages/reports/clint")
@@ -338,6 +339,7 @@ add_custom_command(
       ${LUA_META_MODULE_SOURCE} lua_meta_module
       ${LUA_FILETYPE_MODULE_SOURCE} lua_filetype_module
       ${LUA_LOAD_PACKAGE_MODULE_SOURCE} lua_load_package_module
+      ${LUA_KEYMAP_MODULE_SOURCE} lua_keymap_module
   DEPENDS
     ${CHAR_BLOB_GENERATOR}
     ${LUA_VIM_MODULE_SOURCE}
@@ -347,6 +349,7 @@ add_custom_command(
     ${LUA_META_MODULE_SOURCE}
     ${LUA_FILETYPE_MODULE_SOURCE}
     ${LUA_LOAD_PACKAGE_MODULE_SOURCE}
+    ${LUA_KEYMAP_MODULE_SOURCE}
   VERBATIM
 )
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -953,11 +953,11 @@ ArrayOf(Dictionary) nvim_buf_get_keymap(uint64_t channel_id, Buffer buffer, Stri
 /// @see |nvim_set_keymap()|
 ///
 /// @param  buffer  Buffer handle, or 0 for current buffer
-void nvim_buf_set_keymap(Buffer buffer, String mode, String lhs, String rhs, Dict(keymap) *opts,
-                         Error *err)
+void nvim_buf_set_keymap(uint64_t channel_id, Buffer buffer, String mode, String lhs, String rhs,
+                         Dict(keymap) *opts, Error *err)
   FUNC_API_SINCE(6)
 {
-  modify_keymap(buffer, false, mode, lhs, rhs, opts, err);
+  modify_keymap(channel_id, buffer, false, mode, lhs, rhs, opts, err);
 }
 
 /// Unmaps a buffer-local |mapping| for the given mode.
@@ -965,11 +965,12 @@ void nvim_buf_set_keymap(Buffer buffer, String mode, String lhs, String rhs, Dic
 /// @see |nvim_del_keymap()|
 ///
 /// @param  buffer  Buffer handle, or 0 for current buffer
-void nvim_buf_del_keymap(Buffer buffer, String mode, String lhs, Error *err)
+void nvim_buf_del_keymap(uint64_t channel_id, Buffer buffer, String mode,
+                         String lhs, Error *err)
   FUNC_API_SINCE(6)
 {
   String rhs = { .data = "", .size = 0 };
-  modify_keymap(buffer, true, mode, lhs, rhs, NULL, err);
+  modify_keymap(channel_id, buffer, true, mode, lhs, rhs, NULL, err);
 }
 
 /// Gets a map of buffer-local |user-commands|.

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -22,11 +22,11 @@
 
 /// @deprecated
 /// @see nvim_exec
-String nvim_command_output(String command, Error *err)
+String nvim_command_output(uint64_t channel_id, String command, Error *err)
   FUNC_API_SINCE(1)
   FUNC_API_DEPRECATED_SINCE(7)
 {
-  return nvim_exec(command, true, err);
+  return nvim_exec(channel_id, command, true, err);
 }
 
 /// @deprecated Use nvim_exec_lua() instead.

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -585,8 +585,8 @@ Array string_to_array(const String input, bool crlf)
 /// @param  buffer    Buffer handle for a specific buffer, or 0 for the current
 ///                   buffer, or -1 to signify global behavior ("all buffers")
 /// @param  is_unmap  When true, removes the mapping that matches {lhs}.
-void modify_keymap(Buffer buffer, bool is_unmap, String mode, String lhs, String rhs,
-                   Dict(keymap) *opts, Error *err)
+void modify_keymap(uint64_t channel_id, Buffer buffer, bool is_unmap, String mode, String lhs,
+                   String rhs, Dict(keymap) *opts, Error *err)
 {
   LuaRef lua_funcref = LUA_NOREF;
   bool global = (buffer == -1);
@@ -598,6 +598,8 @@ void modify_keymap(Buffer buffer, bool is_unmap, String mode, String lhs, String
   if (!target_buf) {
     return;
   }
+
+  const sctx_T save_current_sctx = api_set_sctx(channel_id);
 
   if (opts != NULL && opts->callback.type == kObjectTypeLuaRef) {
     lua_funcref = opts->callback.data.luaref;
@@ -710,6 +712,7 @@ void modify_keymap(Buffer buffer, bool is_unmap, String mode, String lhs, String
 
   parsed_args.rhs_lua = LUA_NOREF;  // don't clear ref on success
 fail_and_free:
+  current_sctx = save_current_sctx;
   NLUA_CLEAR_REF(parsed_args.rhs_lua);
   xfree(parsed_args.rhs);
   xfree(parsed_args.orig_rhs);
@@ -1621,4 +1624,21 @@ int find_sid(uint64_t channel_id)
   default:
     return SID_API_CLIENT;
   }
+}
+
+/// Sets sctx for API calls.
+///
+/// @param channel_id     api clients id. Used to determine if it's a internal
+///                       call or a rpc call.
+/// @return returns       previous value of current_sctx. To be used
+///                       to be used for restoring sctx to previous state.
+sctx_T api_set_sctx(uint64_t channel_id)
+{
+  sctx_T old_current_sctx = current_sctx;
+  if (channel_id != VIML_INTERNAL_CALL) {
+    current_sctx.sc_sid =
+      channel_id == LUA_INTERNAL_CALL ? SID_LUA : SID_API_CLIENT;
+    current_sctx.sc_lnum = 0;
+  }
+  return old_current_sctx;
 }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1586,6 +1586,7 @@ ArrayOf(Dictionary) nvim_get_keymap(uint64_t channel_id, String mode)
 ///     nmap <nowait> <Space><NL> <Nop>
 /// </pre>
 ///
+/// @param channel_id
 /// @param  mode  Mode short-name (map command prefix: "n", "i", "v", "x", …)
 ///               or "!" for |:map!|, or empty string for |:map|.
 /// @param  lhs   Left-hand-side |{lhs}| of the mapping.
@@ -1597,10 +1598,11 @@ ArrayOf(Dictionary) nvim_get_keymap(uint64_t channel_id, String mode)
 ///               a Lua function to call when the mapping is executed.
 ///               Values are Booleans. Unknown key is an error.
 /// @param[out]   err   Error details, if any.
-void nvim_set_keymap(String mode, String lhs, String rhs, Dict(keymap) *opts, Error *err)
+void nvim_set_keymap(uint64_t channel_id, String mode, String lhs, String rhs, Dict(keymap) *opts,
+                     Error *err)
   FUNC_API_SINCE(6)
 {
-  modify_keymap(-1, false, mode, lhs, rhs, opts, err);
+  modify_keymap(channel_id, -1, false, mode, lhs, rhs, opts, err);
 }
 
 /// Unmaps a global |mapping| for the given mode.
@@ -1608,10 +1610,10 @@ void nvim_set_keymap(String mode, String lhs, String rhs, Dict(keymap) *opts, Er
 /// To unmap a buffer-local mapping, use |nvim_buf_del_keymap()|.
 ///
 /// @see |nvim_set_keymap()|
-void nvim_del_keymap(String mode, String lhs, Error *err)
+void nvim_del_keymap(uint64_t channel_id, String mode, String lhs, Error *err)
   FUNC_API_SINCE(6)
 {
-  nvim_buf_del_keymap(-1, mode, lhs, err);
+  nvim_buf_del_keymap(channel_id, -1, mode, lhs, err);
 }
 
 /// Gets a map of global (non-buffer-local) Ex commands.

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -37,7 +37,7 @@
 /// @param[out] err Error details (Vim error), if any
 /// @return Output (non-error, non-shell |:!|) if `output` is true,
 ///         else empty string.
-String nvim_exec(String src, Boolean output, Error *err)
+String nvim_exec(uint64_t channel_id, String src, Boolean output, Error *err)
   FUNC_API_SINCE(7)
 {
   const int save_msg_silent = msg_silent;
@@ -52,11 +52,16 @@ String nvim_exec(String src, Boolean output, Error *err)
   if (output) {
     msg_silent++;
   }
+
+  const sctx_T save_current_sctx = api_set_sctx(channel_id);
+
   do_source_str(src.data, "nvim_exec()");
   if (output) {
     capture_ga = save_capture_ga;
     msg_silent = save_msg_silent;
   }
+
+  current_sctx = save_current_sctx;
   try_end(err);
 
   if (ERROR_SET(err)) {

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1086,6 +1086,7 @@ int autocmd_register(int64_t id, event_T event, char_u *pat, int patlen, int gro
   ac->exec = aucmd_exec_copy(aucmd);
   ac->script_ctx = current_sctx;
   ac->script_ctx.sc_lnum += sourcing_lnum;
+  nlua_set_sctx(&ac->script_ctx);
   ac->next = NULL;
   ac->once = once;
   ac->nested = nested;

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -256,7 +256,8 @@ static inline void ctx_save_funcs(Context *ctx, bool scriptonly)
       size_t cmd_len = sizeof("func! ") + STRLEN(name);
       char *cmd = xmalloc(cmd_len);
       snprintf(cmd, cmd_len, "func! %s", name);
-      String func_body = nvim_exec(cstr_as_string(cmd), true, &err);
+      String func_body = nvim_exec(VIML_INTERNAL_CALL, cstr_as_string(cmd),
+                                   true, &err);
       xfree(cmd);
       if (!ERROR_SET(&err)) {
         ADD(ctx->funcs, STRING_OBJ(func_body));

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9369,10 +9369,31 @@ static hashtab_T *find_var_ht_dict(const char *name, const size_t name_len, cons
   } else if (*name == 'l' && funccal != NULL) {  // local variable
     *d = &funccal->l_vars;
   } else if (*name == 's'  // script variable
-             && (current_sctx.sc_sid > 0 || current_sctx.sc_sid == SID_STR)
+             && (current_sctx.sc_sid > 0 || current_sctx.sc_sid == SID_STR
+                 || current_sctx.sc_sid == SID_LUA)
              && current_sctx.sc_sid <= ga_scripts.ga_len) {
     // For anonymous scripts without a script item, create one now so script vars can be used
-    if (current_sctx.sc_sid == SID_STR) {
+    if (current_sctx.sc_sid == SID_LUA) {
+      // try to resolve lua filename & line no so it can be shown in lastset messages.
+      nlua_set_sctx(&current_sctx);
+      if (current_sctx.sc_sid != SID_LUA) {
+        // Great we have valid location. Now here this out we'll create a new
+        // script context with the name and lineno of this one. why ?
+        // for behavioral consistency. With this different anonymous exec from
+        // same file can't access each others script local stuff. We need to do
+        // this all other cases except this will act like that otherwise.
+        const LastSet last_set = (LastSet){
+          .script_ctx = current_sctx,
+          .channel_id = LUA_INTERNAL_CALL,
+        };
+        bool should_free;
+        // should_free is ignored as script_sctx will be resolved to a fnmae
+        // & new_script_item will consume it.
+        char_u *sc_name = get_scriptname(last_set, &should_free);
+        new_script_item(sc_name, &current_sctx.sc_sid);
+      }
+    }
+    if (current_sctx.sc_sid == SID_STR || current_sctx.sc_sid == SID_LUA) {
       new_script_item(NULL, &current_sctx.sc_sid);
     }
     *d = &SCRIPT_SV(current_sctx.sc_sid)->sv_dict;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2573,6 +2573,7 @@ void ex_function(exarg_T *eap)
   fp->uf_calls = 0;
   fp->uf_script_ctx = current_sctx;
   fp->uf_script_ctx.sc_lnum += sourcing_lnum_top;
+  nlua_set_sctx(&fp->uf_script_ctx);
 
   goto ret_free;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5277,6 +5277,7 @@ int uc_add_command(char_u *name, size_t name_len, char_u *rep, uint32_t argt, lo
   cmd->uc_compl = compl;
   cmd->uc_script_ctx = current_sctx;
   cmd->uc_script_ctx.sc_lnum += sourcing_lnum;
+  nlua_set_sctx(&cmd->uc_script_ctx);
   cmd->uc_compl_arg = compl_arg;
   cmd->uc_compl_luaref = compl_luaref;
   cmd->uc_addr_type = addr_type;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3086,6 +3086,7 @@ int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev, buf_T 
                 mp->m_expr = args->expr;
                 mp->m_script_ctx = current_sctx;
                 mp->m_script_ctx.sc_lnum += sourcing_lnum;
+                nlua_set_sctx(&mp->m_script_ctx);
                 if (args->desc != NULL) {
                   mp->m_desc = xstrdup(args->desc);
                 }
@@ -3166,6 +3167,7 @@ int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev, buf_T 
   mp->m_expr = args->expr;
   mp->m_script_ctx = current_sctx;
   mp->m_script_ctx.sc_lnum += sourcing_lnum;
+  nlua_set_sctx(&mp->m_script_ctx);
   mp->m_desc = NULL;
   if (args->desc != NULL) {
     mp->m_desc = xstrdup(args->desc);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -16,6 +16,7 @@
 #include "nvim/change.h"
 #include "nvim/cursor.h"
 #include "nvim/eval/userfunc.h"
+#include "nvim/eval/typval.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/time.h"
 #include "nvim/ex_cmds2.h"
@@ -651,6 +652,15 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
     }
     // [package, loaded, module]
     lua_setfield(lstate, -2, "vim.filetype");  // [package, loaded]
+
+    code = (char *)&lua_keymap_module[0];
+    if (luaL_loadbuffer(lstate, code, sizeof(lua_keymap_module) - 1, "@vim/keymap.lua")
+        || nlua_pcall(lstate, 0, 1)) {
+      nlua_error(lstate, _("E5106: Error while creating vim.keymap module: %.*s"));
+      return 1;
+    }
+    // [package, loaded, module]
+    lua_setfield(lstate, -2, "vim.keymap");  // [package, loaded]
 
     lua_pop(lstate, 2);  // []
   }
@@ -1806,6 +1816,69 @@ void nlua_execute_on_key(int c)
   // [ ]
   assert(top == lua_gettop(lstate));
 #endif
+}
+
+// Checks if str is in blacklist array
+static bool is_in_ignorelist(const char *str, char *ignorelist[], int ignorelist_size)
+{
+  for (int i = 0; i < ignorelist_size; i++) {
+    if (strncmp(ignorelist[i], str, strlen(ignorelist[i])) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+// Get sctx of current file being sourced if doesn't exist generate it
+static sctx_T *nlua_get_sourcing_sctx(void)
+{
+  lua_State *const lstate = global_lstate;
+  sctx_T *retval = (sctx_T *)xmalloc(sizeof(sctx_T));
+  retval->sc_seq = -1;
+  retval->sc_sid = SID_LUA;
+  retval->sc_lnum = -1;
+  lua_Debug *info = (lua_Debug *)xmalloc(sizeof(lua_Debug));
+
+  // Files where internal wrappers are defined so we can ignore them
+  // like vim.o/opt etc are defined in _meta.lua
+  char *ignorelist[] = {
+    "vim/_meta.lua",
+    "vim/keymap.lua",
+  };
+  int blacklist_size = sizeof(ignorelist) / sizeof(ignorelist[0]);
+
+  for (int level = 1; true; level++) {
+    if (lua_getstack(lstate, level, info) != 1) {
+      goto cleanup;
+    }
+    if (lua_getinfo(lstate, "nSl", info) == 0) {
+      goto cleanup;
+    }
+
+    if (info->what[0] == 'C' || info->source[0] != '@'
+        || is_in_ignorelist(info->source+1, ignorelist, blacklist_size)) {
+      continue;
+    }
+    break;
+  }
+  char *source_path = fix_fname(info->source + 1);
+  get_current_script_id((char_u *)source_path, retval);
+  xfree(source_path);
+  retval->sc_lnum = info->currentline;
+
+cleanup:
+  xfree(info);
+  return retval;
+}
+
+// Sets the editor "script context" during Lua execution. Used by :verbose.
+// @param[out] current
+void nlua_set_sctx(sctx_T *current)
+{
+  if (p_verbose > 0 && current->sc_sid == SID_LUA) {
+    sctx_T *lua_sctx = nlua_get_sourcing_sctx();
+    *current = *lua_sctx;
+    xfree(lua_sctx);
+  }
 }
 
 void nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap)

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -43,6 +43,9 @@ assert(vim.inspect)
 vim.filetype = package.loaded['vim.filetype']
 assert(vim.filetype)
 
+vim.keymap = package.loaded['vim.keymap']
+assert(vim.keymap)
+
 -- These are for loading runtime modules lazily since they aren't available in
 -- the nvim binary as specified in executor.c
 setmetatable(vim, {
@@ -69,9 +72,6 @@ setmetatable(vim, {
     elseif key == 'ui' then
       t.ui = require('vim.ui')
       return t.ui
-    elseif key == 'keymap' then
-      t.keymap = require('vim.keymap')
-      return t.keymap
     end
   end
 })

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3878,6 +3878,7 @@ static void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)
 {
   int both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
   int indir = (int)options[opt_idx].indir;
+  nlua_set_sctx(&script_ctx);
   const LastSet last_set = {
     .script_ctx = {
       script_ctx.sc_sid,

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -153,7 +153,7 @@ int do_in_path(char_u *path, char *name, int flags, DoInRuntimepathCB callback, 
 
     if (flags & DIP_ERR) {
       semsg(_(e_dirnotf), basepath, name);
-    } else if (p_verbose > 0) {
+    } else if (p_verbose > 1) {
       verbose_enter();
       smsg(_("not found in '%s': \"%s\""), basepath, name);
       verbose_leave();
@@ -286,7 +286,7 @@ int do_in_cached_path(char_u *name, int flags, DoInRuntimepathCB callback, void 
   if (!did_one && name != NULL) {
     if (flags & DIP_ERR) {
       semsg(_(e_dirnotf), "runtime path", name);
-    } else if (p_verbose > 0) {
+    } else if (p_verbose > 1) {
       verbose_enter();
       smsg(_("not found in runtime path: \"%s\""), name);
       verbose_leave();

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -831,7 +831,7 @@ static int shada_read_file(const char *const file, const int flags)
   ShaDaReadDef sd_reader;
   const int of_ret = open_shada_file_for_reading(fname, &sd_reader);
 
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     smsg(_("Reading ShaDa file \"%s\"%s%s%s%s"),
          fname,
@@ -3036,7 +3036,7 @@ shada_write_file_nomerge: {}
     return FAIL;
   }
 
-  if (p_verbose > 0) {
+  if (p_verbose > 1) {
     verbose_enter();
     smsg(_("Writing ShaDa file \"%s\""), fname);
     verbose_leave();

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -27,6 +27,7 @@
 #include "nvim/highlight.h"
 #include "nvim/indent_c.h"
 #include "nvim/keymap.h"
+#include "nvim/lua/executor.h"
 #include "nvim/macros.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
@@ -6919,6 +6920,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         hlgroup->sg_deflink = to_id;
         hlgroup->sg_deflink_sctx = current_sctx;
         hlgroup->sg_deflink_sctx.sc_lnum += sourcing_lnum;
+        nlua_set_sctx(&hlgroup->sg_deflink_sctx);
       }
     }
 
@@ -6939,6 +6941,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         hlgroup->sg_link = to_id;
         hlgroup->sg_script_ctx = current_sctx;
         hlgroup->sg_script_ctx.sc_lnum += sourcing_lnum;
+        nlua_set_sctx(&hlgroup->sg_script_ctx);
         hlgroup->sg_cleared = false;
         redraw_all_later(SOME_VALID);
 
@@ -7319,6 +7322,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     }
     HL_TABLE()[idx].sg_script_ctx = current_sctx;
     HL_TABLE()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
+    nlua_set_sctx(&HL_TABLE()[idx].sg_script_ctx);
   }
   xfree(key);
   xfree(arg);

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -15,6 +15,9 @@ local pcall_err = helpers.pcall_err
 local shallowcopy = helpers.shallowcopy
 local sleep = helpers.sleep
 
+local sid_api_client = -9
+local sid_lua = -8
+
 describe('nvim_get_keymap', function()
   before_each(clear)
 
@@ -340,7 +343,7 @@ describe('nvim_get_keymap', function()
       script=0,
       silent=0,
       expr=0,
-      sid=0,
+      sid=sid_lua,
       buffer=0,
       nowait=0,
       mode='n',
@@ -357,7 +360,7 @@ describe('nvim_get_keymap', function()
       script=0,
       silent=0,
       expr=0,
-      sid=0,
+      sid=sid_api_client,
       buffer=0,
       nowait=0,
       mode='n',
@@ -400,7 +403,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     to_return.silent = not opts.silent and 0 or 1
     to_return.nowait = not opts.nowait and 0 or 1
     to_return.expr = not opts.expr and 0 or 1
-    to_return.sid = not opts.sid and 0 or opts.sid
+    to_return.sid = not opts.sid and sid_api_client or opts.sid
     to_return.buffer = not opts.buffer and 0 or opts.buffer
     to_return.lnum = not opts.lnum and 0 or opts.lnum
     to_return.desc = opts.desc
@@ -625,7 +628,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
   it('interprets control sequences in expr-quotes correctly when called '
      ..'inside vim', function()
     command([[call nvim_set_keymap('i', "\<space>", "\<tab>", {})]])
-    eq(generate_mapargs('i', '<Space>', '\t', {}),
+    eq(generate_mapargs('i', '<Space>', '\t', {sid=0}),
        get_mapargs('i', '<Space>'))
     feed('i ')
     eq({'\t'}, curbufmeths.get_lines(0, -1, 0))
@@ -807,7 +810,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     local mapargs = funcs.maparg('asdf', 'n', false, true)
     assert.Truthy(type(mapargs.callback) == 'number', 'callback is not luaref number')
     mapargs.callback = nil
-    eq(generate_mapargs('n', 'asdf', nil, {}), mapargs)
+    eq(generate_mapargs('n', 'asdf', nil, {sid=sid_lua}), mapargs)
   end)
 
   it('can make lua expr mappings', function()

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -1,0 +1,153 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local eq = helpers.eq
+local exec = helpers.exec
+local exec_capture = helpers.exec_capture
+local write_file = helpers.write_file
+local call_viml_function = helpers.meths.call_function
+
+describe('lua :verbose', function()
+  local script_location, script_file
+  -- All test cases below use the same nvim instance.
+  setup(function()
+    clear{args={'-V1'}}
+    script_file = 'test_verbose.lua'
+    local current_dir = call_viml_function('getcwd', {})
+    current_dir = call_viml_function('fnamemodify', {current_dir, ':~'})
+    script_location = table.concat{current_dir, helpers.get_pathsep(), script_file}
+
+    write_file(script_file, [[
+vim.api.nvim_set_option('hlsearch', false)
+vim.bo.expandtab = true
+vim.opt.number = true
+vim.api.nvim_set_keymap('n', '<leader>key1', ':echo "test"<cr>', {noremap = true})
+vim.keymap.set('n', '<leader>key2', ':echo "test"<cr>')
+
+vim.api.nvim_exec("augroup test_group\
+                     autocmd!\
+                     autocmd FileType c setl cindent\
+                     augroup END\
+                  ", false)
+
+vim.api.nvim_command("command Bdelete :bd")
+vim.api.nvim_add_user_command("TestCommand", ":echo 'Hello'", {})
+
+vim.api.nvim_exec ("\
+function Close_Window() abort\
+  wincmd -\
+endfunction\
+", false)
+]])
+    exec(':source '..script_file)
+  end)
+
+  teardown(function()
+    os.remove(script_file)
+  end)
+
+  it('"Last set" for option set by Lua', function()
+    local result = exec_capture(':verbose set hlsearch?')
+    eq(string.format([[
+nohlsearch
+	Last set from %s line 1]],
+       script_location), result)
+  end)
+
+  it('"Last set" for option set by vim.o', function()
+    local result = exec_capture(':verbose set expandtab?')
+    eq(string.format([[
+  expandtab
+	Last set from %s line 2]],
+       script_location), result)
+  end)
+
+  it('"Last set" for option set by vim.opt', function()
+    local result = exec_capture(':verbose set number?')
+    eq(string.format([[
+  number
+	Last set from %s line 3]],
+       script_location), result)
+  end)
+
+  it('"Last set" for keymap set by Lua', function()
+    local result = exec_capture(':verbose map <leader>key1')
+    eq(string.format([[
+
+n  \key1       * :echo "test"<CR>
+	Last set from %s line 4]],
+       script_location), result)
+  end)
+
+  it('"Last set" for keymap set by vim.keymap', function()
+    local result = exec_capture(':verbose map <leader>key2')
+    eq(string.format([[
+
+n  \key2       * :echo "test"<CR>
+	Last set from %s line 5]],
+       script_location), result)
+  end)
+
+  it('"Last set" for autocmd by vim.api.nvim_exec', function()
+    local result = exec_capture(':verbose autocmd test_group Filetype c')
+    eq(string.format([[
+--- Autocommands ---
+test_group  FileType
+    c         setl cindent
+	Last set from %s line 7]],
+       script_location), result)
+  end)
+
+  it('"Last set" for command defined by nvim_command', function()
+    local result = exec_capture(':verbose command Bdelete')
+    eq(string.format([[
+    Name              Args Address Complete    Definition
+    Bdelete           0                        :bd
+	Last set from %s line 13]],
+       script_location), result)
+  end)
+
+  it('"Last set" for command defined by nvim_add_user_command', function()
+    local result = exec_capture(':verbose command TestCommand')
+    eq(string.format([[
+    Name              Args Address Complete    Definition
+    TestCommand       0                        :echo 'Hello'
+	Last set from %s line 14]],
+       script_location), result)
+  end)
+
+  it('"Last set for function', function()
+    local result = exec_capture(':verbose function Close_Window')
+    eq(string.format([[
+   function Close_Window() abort
+	Last set from %s line 16
+1    wincmd -
+   endfunction]],
+       script_location), result)
+  end)
+end)
+
+describe('lua verbose:', function()
+  local script_file
+
+  setup(function()
+    clear()
+    script_file = 'test_luafile.lua'
+    write_file(script_file, [[
+    vim.api.nvim_set_option('hlsearch', false)
+    ]])
+    exec(':source '..script_file)
+  end)
+
+  teardown(function()
+    os.remove(script_file)
+  end)
+
+  it('is disabled when verbose = 0', function()
+    local result = exec_capture(':verbose set hlsearch?')
+    eq([[
+nohlsearch
+	Last set from Lua]], result)
+  end)
+end)
+

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -38,6 +38,13 @@ function Close_Window() abort\
   wincmd -\
 endfunction\
 ", false)
+
+local ret = vim.api.nvim_exec ("\
+function! s:return80()\
+  return 80\
+endfunction\
+let &tw = s:return80()\
+", true)
 ]])
     exec(':source '..script_file)
   end)
@@ -123,6 +130,14 @@ test_group  FileType
 	Last set from %s line 16
 1    wincmd -
    endfunction]],
+       script_location), result)
+  end)
+
+  it('"Last set" works with anonymous sid', function()
+    local result = exec_capture(':verbose set tw?')
+    eq(string.format([[
+  textwidth=80
+	Last set from %s line 22]],
        script_location), result)
   end)
 end)


### PR DESCRIPTION
Currently `:verbose` doesn't show enough information when keymap/options are set from lua . It either shows 'last set from lua' or just 'last set from filename' without line no when that file is sourced . Which also becomes inacurate when you require a file that sets the option from the sourced file .

This solves that . Now proper location is  show with `:verbose`.

To get the verbose info you need tp start neovim with atleast verbose level 1 `nvim -V1` . Lua debug calls are quite slow so it's made optin.
