### PR TITLE
fix(lsp): pass bufnr for async formatting

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -223,15 +223,15 @@ M['textDocument/rename'] = function(_, _, result)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting
-M['textDocument/rangeFormatting'] = function(_, _, result)
+M['textDocument/rangeFormatting'] = function(_, _, result, _, bufnr)
   if not result then return end
-  util.apply_text_edits(result)
+  util.apply_text_edits(result, bufnr)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
-M['textDocument/formatting'] = function(_, _, result)
+M['textDocument/formatting'] = function(_, _, result, _, bufnr)
   if not result then return end
-  util.apply_text_edits(result)
+  util.apply_text_edits(result, bufnr)
 end
 
 --@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion


### PR DESCRIPTION
Closes #15089

the `textDocument/rangeFormatting` nad `textDocument/formatting` did not
preserve pass bufnr to apply_text_edits, meaning edits were applied to
the user's currently active buffer. This could result in text being
applied to the wrong buffer.