### PR TITLE
Add zindex setup for floating popup

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -990,6 +990,7 @@ function M.make_floating_popup_options(width, height, opts)
     style = 'minimal',
     width = width,
     border = opts.border or default_border,
+    zindex = opts.zindex or 50,
   }
 end
 


### PR DESCRIPTION
This PR is related to the issue: https://github.com/ray-x/lsp_signature.nvim/issues/45

The root cause is compe with tabnine is very slow and the floating window is displayed after the signature floating window is shown.

I need a way to pass zindex into lsp floating window so it could be on top (or on bottom) 

The default value is  ` kZIndexFloatDefault = 50, ` from grid_defs.h