### PR TITLE
feat(shared): `tbl_deep_extend` improvements

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -200,6 +200,10 @@ function vim.tbl_isempty(t)
   return next(t) == nil
 end
 
+local function can_merge(v)
+  return type(v) == "table" and (vim.tbl_isempty(v) or not vim.tbl_islist(v))
+end
+
 local function tbl_extend(behavior, deep_extend, ...)
   if (behavior ~= 'error' and behavior ~= 'keep' and behavior ~= 'force') then
     error('invalid "behavior": '..tostring(behavior))
@@ -219,8 +223,8 @@ local function tbl_extend(behavior, deep_extend, ...)
     vim.validate{["after the second argument"] = {tbl,'t'}}
     if tbl then
       for k, v in pairs(tbl) do
-        if type(v) == 'table' and deep_extend and not vim.tbl_islist(v) then
-          ret[k] = tbl_extend(behavior, true, ret[k] or vim.empty_dict(), v)
+        if deep_extend and can_merge(v) and can_merge(ret[k]) then
+          ret[k] = tbl_extend(behavior, true, ret[k], v)
         elseif behavior ~= 'force' and ret[k] ~= nil then
           if behavior == 'error' then
             error('key found in more than one map: '..k)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -603,6 +603,31 @@ describe('lua stdlib', function()
       return vim.tbl_islist(c) and count == 0
     ]]))
 
+    eq(exec_lua([[
+      local a = { a = { b = 1 } }
+      local b = { a = {} }
+      return vim.tbl_deep_extend("force", a, b)
+    ]]), {a = {b = 1}})
+
+    eq(exec_lua([[
+      local a = { a = 123 }
+      local b = { a = { b = 1} }
+      return vim.tbl_deep_extend("force", a, b)
+    ]]), {a = {b = 1}})
+
+    ok(exec_lua([[
+      local a = { a = {[2] = 3} }
+      local b = { a = {[3] = 3} }
+      local c = vim.tbl_deep_extend("force", a, b)
+      return vim.deep_equal(c, {a = {[3] = 3}})
+    ]]))
+
+    eq(exec_lua([[
+      local a = { a = { b = 1} }
+      local b = { a = 123 }
+      return vim.tbl_deep_extend("force", a, b)
+    ]]), {a = 123 })
+
     eq('Error executing lua: vim/shared.lua:0: invalid "behavior": nil',
       pcall_err(exec_lua, [[
         return vim.tbl_deep_extend()


### PR DESCRIPTION
Right now, empty tables are treated as lists in the deep extend method, which means if you use `force` and have an empty table value in a table on the right, it will overwrite the existsing value.

`vim.tbl_deep_extend("force", { ss = { a = 1 } }, { ss = {} })` ==> empty
`vim.tbl_deep_extend("force", { ss = { a = 1 } }, { ss = { b = 1} })` => has both a and b

It also fixes an issue when merging values of a different type. This used to fail:
`vim.tbl_deep_extend("force", {a=true}, {a={b= 1}})`

This PR fixes that.
Additional tests have been included