### PR TITLE
fix(:source): copy curbuf lines to memory before sourcing

### DIFF
--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -62,7 +62,7 @@ describe(':source', function()
 
   it('does not break if current buffer is modified while sourced', function()
     insert [[
-      bw!
+      bwipeout!
       let a = 123
     ]]
     command('source')

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -60,6 +60,15 @@ describe(':source', function()
     eq('Vim(let):E15: Invalid expression: #{', exc_exec("'<,'>source"))
   end)
 
+  it('does not break if current buffer is modified while sourced', function()
+    insert [[
+      bw!
+      let a = 123
+    ]]
+    command('source')
+    eq('123', meths.exec('echo a', true))
+  end)
+
   it('multiline heredoc command', function()
     insert([[
       lua << EOF


### PR DESCRIPTION
It's possible for weirdness to happen if `curbuf` is modified while
sourcing from it via `:source` (with no arguments). For example:

- Deleting lines from or wiping `curbuf` can cause internal error E315 to
  be thrown from `ml_get`.
- Changing the `curbuf` to another buffer while sourcing can cause lines
  from the new `curbuf` to then be sourced instead.

I.e: `:source` (no arguments) the following:
```vim
bw!
echom "uh oh"
```

Output:
```
E315: ml_get: invalid lnum: 2
```