### PR TITLE
[RFC] feat(treesitter): allow to set highlight priority for queries

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2334,8 +2334,9 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                                 inserted (true for right, false for left).
                                 Defaults to false.
                               • priority: a priority value for the highlight
-                                group. For example treesitter highlighting
-                                uses a value of 100.
+                                group. Default: 4096. For example, treesitter
+                                highlighting uses a default value of 100 (see
+                                |lua-treesitter-highlight-priority|).
 
                 Return: ~
                     Id of the created/updated extmark

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -294,6 +294,19 @@ identical identifiers, highlighting both as |hl-WarningMsg|: >
     ((binary_expression left: (identifier) @WarningMsg.left right: (identifier) @WarningMsg.right)
      (eq? @WarningMsg.left @WarningMsg.right))
 <
+Treesitter Highlighting Priority            *lua-treesitter-highlight-priority*
+
+Tree-sitter uses |nvim_buf_set_extmark()| to set highlights with a default 
+priority of 100. This enables plugins to set a highlighting priority lower or
+higher than tree-sitter. It is also possible to change the priority of an
+individual query pattern manually by setting its `"priority"` metadata attribute: >
+
+    (
+      (super_important_node) @ImportantHighlight
+      ; Give the whole query highlight priority higher than the default (100)
+      (set! "priority" 105)
+    )
+<
 
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -248,7 +248,7 @@ local function on_line_impl(self, buf, line)
     end
 
     while line >= state.next_row do
-      local capture, node = state.iter()
+      local capture, node, metadata = state.iter()
 
       if capture == nil then break end
 
@@ -260,7 +260,7 @@ local function on_line_impl(self, buf, line)
                                { end_line = end_row, end_col = end_col,
                                  hl_group = hl,
                                  ephemeral = true,
-                                 priority = 100 -- Low but leaves room below
+                                 priority = tonumber(metadata.priority) or 100 -- Low but leaves room below
                                 })
       end
       if start_row > line then


### PR DESCRIPTION
This allows to set a per-query priority for highlighting. We currently have no good way to specify the priority of competing highlight queries. Sometimes regions with larger want to paint also over smaller highlights.

An alternative approach would be to allow a per-capture priority. Chose to have it per-query to be simpler.

A possible disadvantage of the current approach be that users would now be able to set a much higher priority for their query. Should there be a max-priority for tree-sitter that is enforced?

Addresses https://github.com/sogaiu/tree-sitter-clojure/issues/14

With
```scheme
(
 (dis_expr) @comment
 (#set! "priority" 110) ; or `set-priority! @comment 110`???
)
```
Before (`#_` want the whole following parenthesis to be comment, but cannot since smaller regions have priority over larger ones) :
![Screenshot_20210717_144446](https://user-images.githubusercontent.com/7189118/126037504-fc76275c-360c-46b1-aac9-858a6a5030ac.png)

After: (`#_` can set a higher priority to paint over other highlights)

![Screenshot_20210717_144058](https://user-images.githubusercontent.com/7189118/126037506-44694359-df0d-4159-a4f6-dccea53536e7.png)


Related discussion: https://nvim-treesitter.zulipchat.com/#narrow/stream/252338-help/topic/clojure.3A.20.23_.20related.20highlighting/near/245774701

@sogaiu

TODO:
 -  tests
- docs
 
TODOs other repos:
 - update TSHighlightCaptures under cursor for this feature
 - add above query to nvim-treesitter