### PR TITLE
[RDY] fix(ci): manually remove conflicting mogodb files to allow brew upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           # Workaround brew issues
           rm -f /usr/local/bin/2to3
           brew update >/dev/null
+          # remove broken mongodb-community package
+          brew remove mongodb-community
           brew upgrade
           brew install automake ccache perl cpanminus ninja
 


### PR DESCRIPTION
macOS CI was failing because:

- brew upgrade fails because,
- mongodb-community cant upgrade because,
- some symlinks are owned by ...  mongodb-community...

so we manually remove some files before running brew upgrade. Brew recommends running brew unlink but it has no effect.
