### PR TITLE
[RDY] clang/scan-build

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2717,6 +2717,7 @@ static void ex_unletlock(exarg_T *eap, char_u *argstart, int deep,
   do {
     if (*arg == '$') {
       lv.ll_name = (const char *)arg;
+      lv.ll_name_len = strlen(lv.ll_name);
       lv.ll_tv = NULL;
       arg++;
       if (get_env_len((const char_u **)&arg) == 0) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2508,7 +2508,8 @@ int do_ecmd(
           if (did_decrement && buf_valid(was_curbuf)) {
             was_curbuf->b_nwindows++;
           }
-          if (win_valid_any_tab(oldwin) && oldwin->w_buffer == NULL) {
+        if (oldwin != NULL  // Avoid bogus clang warning.
+            && win_valid_any_tab(oldwin) && oldwin->w_buffer == NULL) {
             oldwin->w_buffer = was_curbuf;
           }
           auto_buf = true;


### PR DESCRIPTION
Uninitialized argument value in do_lock_var:2958

https://neovim.io/doc/reports/clang/report-286433.html#EndPath