### PR TITLE
feat: `vim.merge`

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -200,6 +200,10 @@ function vim.tbl_isempty(t)
   return next(t) == nil
 end
 
+local function can_merge(v)
+  return type(v) == "table" and (vim.tbl_isempty(v) or not vim.tbl_islist(v))
+end
+
 local function tbl_extend(behavior, deep_extend, ...)
   if (behavior ~= 'error' and behavior ~= 'keep' and behavior ~= 'force') then
     error('invalid "behavior": '..tostring(behavior))
@@ -219,8 +223,8 @@ local function tbl_extend(behavior, deep_extend, ...)
     vim.validate{["after the second argument"] = {tbl,'t'}}
     if tbl then
       for k, v in pairs(tbl) do
-        if type(v) == 'table' and deep_extend and not vim.tbl_islist(v) then
-          ret[k] = tbl_extend(behavior, true, ret[k] or vim.empty_dict(), v)
+        if deep_extend and can_merge(v) and can_merge(ret[k]) then
+          ret[k] = tbl_extend(behavior, true, ret[k], v)
         elseif behavior ~= 'force' and ret[k] ~= nil then
           if behavior == 'error' then
             error('key found in more than one map: '..k)

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -238,6 +238,26 @@ local function tbl_extend(behavior, deep_extend, ...)
   return ret
 end
 
+--- Merges the values similar to vim.tbl_deep_extend with the **force** behavior,
+--- but the values can be any type, in which case they override the values on the left.
+--- Values will me merged in-place in the first left-most table. If you want the result to be in
+--- a new table, then simply pass an empty table as the first argument `vim.merge({}, ...)`
+function vim.merge(...)
+  local values = { ... }
+  local ret = values[1]
+  for i = 2, #values, 1 do
+    local value = values[i]
+    if can_merge(ret) and can_merge(value) then
+      for k, v in pairs(value) do
+        ret[k] = vim.merge(ret[k], v)
+      end
+    else
+      ret = value
+    end
+  end
+  return ret
+end
+
 --- Merges two or more map-like tables.
 ---
 --@see |extend()|

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -603,6 +603,31 @@ describe('lua stdlib', function()
       return vim.tbl_islist(c) and count == 0
     ]]))
 
+    eq(exec_lua([[
+      local a = { a = { b = 1 } }
+      local b = { a = {} }
+      return vim.tbl_deep_extend("force", a, b)
+    ]]), {a = {b = 1}})
+
+    eq(exec_lua([[
+      local a = { a = 123 }
+      local b = { a = { b = 1} }
+      return vim.tbl_deep_extend("force", a, b)
+    ]]), {a = {b = 1}})
+
+    ok(exec_lua([[
+      local a = { a = {[2] = 3} }
+      local b = { a = {[3] = 3} }
+      local c = vim.tbl_deep_extend("force", a, b)
+      return vim.deep_equal(c, {a = {[3] = 3}})
+    ]]))
+
+    eq(exec_lua([[
+      local a = { a = { b = 1} }
+      local b = { a = 123 }
+      return vim.tbl_deep_extend("force", a, b)
+    ]]), {a = 123 })
+
     eq('Error executing lua: vim/shared.lua:0: invalid "behavior": nil',
       pcall_err(exec_lua, [[
         return vim.tbl_deep_extend()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -647,6 +647,37 @@ describe('lua stdlib', function()
     )
   end)
 
+  it("vim.merge", function()
+    eq(exec_lua([[return vim.merge({})]]), {})
+    eq(exec_lua([[return vim.merge(1)]]), 1)
+    eq(exec_lua([[return vim.merge(1, 2)]]), 2)
+    eq(exec_lua([[return vim.merge({ 1 }, 2)]]), 2)
+    eq(exec_lua([[return vim.merge(1, { 2 })]]), { 2 })
+    eq(exec_lua([[return vim.merge({ a = 1 }, { b = 1 })]]), { a = 1, b = 1 })
+    eq(exec_lua([[return vim.merge({ a = 1 }, {})]]), { a = 1 })
+    eq(exec_lua([[return vim.merge({ a = { b = 1 } }, { a = 1 })]]), { a = 1 })
+    eq(exec_lua([[return vim.merge({ a = { b = 1 } }, { a = { c = 1 } })]]), { a = { b = 1, c = 1 } })
+    ok(exec_lua([[
+      local a = vim.merge({ [10] = 'a'}, { [20] = 'b'})
+      return vim.deep_equal(a, {[20] = "b"})
+    ]]), {[20] = 'b'})
+    ok(exec_lua([[
+      local a = vim.merge({ [1] = 'a'}, { [20] = 'b'})
+      return vim.deep_equal(a, {[20] = "b"})
+    ]]), {[20] = 'b'})
+    ok(exec_lua([[
+      local a = vim.merge({ 'a'}, { [20] = 'b'})
+      return vim.deep_equal(a, {[20] = "b"})
+    ]]), {[20] = 'b'})
+    eq(exec_lua([[return vim.merge()]]), NIL)
+    eq(exec_lua([[
+      local a = {x = {a = 1, b = 2}}
+      local b = {x = {a = 2, c = {y = 3}}}
+      local c = {x = {c = 4, d = {y = 4}}}
+      return vim.merge(a, b, c)
+      ]]), {x = {a = 2, b = 2, c = 4, d = {y = 4}}})
+  end)
+
   it('vim.tbl_count', function()
     eq(0, exec_lua [[ return vim.tbl_count({}) ]])
     eq(0, exec_lua [[ return vim.tbl_count(vim.empty_dict()) ]])


### PR DESCRIPTION
This PR includes `vim.merge`, an utility function that is similar to `vim.tbl_deep_extend` with the **force** option, but also works for other types than tables.

> --- Merges the values similar to vim.tbl_deep_extend with the **force** behavior,
--- but the values can be any type, in which case they override the values on the left.
--- Values will me merged in-place in the first left-most table. If you want the result to be in
--- a new table, then simply pass an empty table as the first argument `vim.merge({}, ...)`

## Note

This PR includes a commit from another PR #15094. Not sure how that works 😅. I assume when the other PR is merged, this will also be able to merge.