### PR TITLE
Treesitter: fix skipping matches when changing the range

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1045,7 +1045,7 @@ static int query_next_capture(lua_State *L)
 
     uint32_t n_pred;
     ts_query_predicates_for_pattern(query, match.pattern_index, &n_pred);
-    if (n_pred > 0 && capture_index == 0) {
+    if (n_pred > 0) {
       lua_pushvalue(L, lua_upvalueindex(4));  // [index, node, match]
       set_match(L, &match, lua_upvalueindex(2));
       lua_pushinteger(L, match.pattern_index+1);


### PR DESCRIPTION
`Query:iter_captures(node, 0, 0, 3)` some times returns the wrong
matches when the range is changed.

You can replicate this with

```tex
\hypersetup{
citecolor=red,
urlcolor=blue,
}
```

```lua
local parsers = require "nvim-treesitter.parsers"
local query = require "vim.treesitter.query"

local function print(str)
  vim.api.nvim_out_write(vim.inspect(str) .. "\n")
end

local lang = "latex"

local parser = parsers.get_parser(0, lang)
local tree = parser:parse()[1]
local node = tree:root()
local q = query.get_query(lang, "highlights")
for id, n, metadata in q:iter_captures(node, 0, 0, 3) do
  print("Capture: " .. id .. " / " .. q.captures[id])
  print("Node: " .. n:type())
end
```

- Open the test.tex file, and set the filetype to tex (`:set ft=tex | set syntax=`).
- Run `luafile test.lua`
- Matches are correct
- Now change the range to `iter_captures(node, 0, 1, 3)`
- It will return extra matches that shouldn't be there.

I have tracked this down to the predicates being skipped,
and they are skipped because `match` is nill here
https://github.com/neovim/neovim/blob/c36df20aef22288f47e19084d2671327f7cd878c/runtime/lua/vim/treesitter/query.lua#L483
And match is nill because of the additional check of `capture_index == 0`.

Ref https://github.com/nvim-treesitter/nvim-treesitter/issues/1506
This fixes a lot of bugs on nvim-treesitter were the highlights randomly
change.