### PR TITLE
ci: add commit linter to GitHub Actions.

### DIFF
--- a/.github/workflows/commitlint.config.js
+++ b/.github/workflows/commitlint.config.js
@@ -1,0 +1,35 @@
+module.exports = {
+	rules: {
+		'body-leading-blank': [1, 'always'],
+		'body-max-line-length': [2, 'always', 100],
+		'footer-leading-blank': [1, 'always'],
+		'footer-max-line-length': [2, 'always', 100],
+		'header-max-length': [2, 'always', 100],
+		'scope-case': [2, 'always', 'lower-case'],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+		],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+		'type-case': [2, 'always', 'lower-case'],
+		'type-empty': [2, 'never'],
+		'type-enum': [
+			2,
+			'always',
+			[
+				'build',
+				'chore',
+				'ci',
+				'docs',
+				'feat',
+				'fix',
+				'perf',
+				'refactor',
+				'revert',
+				'test',
+			],
+		],
+	},
+};

--- a/.github/workflows/commitlint.config_patch.js
+++ b/.github/workflows/commitlint.config_patch.js
@@ -1,0 +1,28 @@
+module.exports = {
+	parserPreset: {
+		parserOpts: { headerPattern: /^([^\(\):]*)(?:\((.*)\))?!?:(.*)$/ }
+	},
+	rules: {
+		'body-leading-blank': [1, 'always'],
+		'body-max-line-length': [2, 'always', 100],
+		'footer-leading-blank': [1, 'always'],
+		'footer-max-line-length': [2, 'always', 100],
+		'scope-case': [2, 'always', 'lower-case'],
+		'subject-case': [
+			2,
+			'never',
+			['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+		],
+		'subject-empty': [2, 'never'],
+		'subject-full-stop': [2, 'never', '.'],
+		'type-case': [2, 'always', 'lower-case'],
+		'type-empty': [2, 'never'],
+		'type-enum': [
+			2,
+			'always',
+			[
+				'vim-patch',
+			],
+		],
+	},
+};

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,18 @@
+name: "Commit Linter"
+on: pull_request
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          fetch-depth: 0
+      - run: npm install --save-dev @commitlint/cli
+      - run: |
+          if [[ "$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.[][0].messageHeadline')" == vim-patch* ]];then
+            npx commitlint --from HEAD~1 --to HEAD --verbose --help-url https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#commit-messages --config .github/workflows/commitlint.config_patch.js
+          else
+            npx commitlint --from HEAD~1 --to HEAD --verbose --help-url https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#commit-messages --config .github/workflows/commitlint.config.js
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,15 +86,35 @@ the VCS/git logs more valuable. The general structure of a commit message is as 
 [optional footer(s)]
 ```
 
-- **Prefix the commit subject with a _type_:** `doc:`, `test:`
-  `runtime:`, ...
-    - Subject line for commits with only style/lint changes can be a single
-      word: `style` or `lint`.
-- **Add the optional scope following <type> if possible:** `(lsp)`, `(treesitter)`, `(multigrid)`, ...
+- Prefix the commit subject with one of the following _types_:
+    - `build`: all changes related to the build system (involving scripts, configurations or tools) and package dependencies.
+    - `ci`: all changes related to the continuous integration and deployment system - involving scripts, configurations or tools.
+    - `docs`: all documentation changes. This includes both external documentation intended for end users as well as internal documentation intended for developers.
+    - `feat`: new abilities or functionality.
+    - `fix`: a bug fix.
+    - `perf`: performance improvements.
+    - `refactor`: modification of the code base which neither adds a feature nor fixes a bug - such as removing redundant code, simplifying the code, renaming variables, etc.
+    - `revert`: revert previous commits.
+    - `test`: all changes related to tests such as refactoring existing tests or adding new tests.
+    - `vim-patch`: all patches from upstream Vim. The commit messages for patches has [slightly different rules](https://github.com/neovim/neovim/wiki/Merging-patches-from-upstream-Vim#pull-requests) as not to interfere with existing scripts.
+    - `chore`: Lastly, if none of the types above fits you may use `chore` as the type.
+
+- Append optional scope to _type_ if possible: `(lsp)`, `(treesitter)` or `(float/windows)`.
+
 - Try to keep the first line under 72 characters.
+
 - A blank line must separate the subject from the description.
-- Breaking changes must be indicated at the very beginning of the footer or body section of a commit. A breaking change must consist of the uppercase text BREAKING CHANGE, followed by a colon, a space, and a description of what has changed about the API.
-- Check your commit message for spelling and grammatical mistakes.
+
+- A breaking API change must be indicated by appending `!` after the type/scope and at the very beginning of the footer with a **BREAKING CHANGE**.
+
+    Example:
+
+    ```
+    refactor(provider)!: drop support for Python 2
+
+    BREAKING CHANGE: refactor to use Python 3 features since Python 2 is no longer supported.
+    ```
+
 - Use the _imperative voice_: "Fix bug" rather than "Fixed bug" or "Fixes bug."
 
 ### Automated builds (CI)


### PR DESCRIPTION
This uses GitHub Actions to call on [commitlint](https://github.com/conventional-changelog/commitlint). There are many predefined [configurations](https://github.com/conventional-changelog/commitlint#shared-configuration); it's currently using the [config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/config-conventional) which is basically the "default" configuration. The lint rules are [highly adjustable](https://commitlint.js.org/#/reference-rules) so I suggest we use the config-conventional as a baseline and then modify it.