### PR TITLE
lsp(start_client): Allow passing custom workspaceFolders to the LSP

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -591,7 +591,7 @@ end
 ---
 --@param name (string, default=client-id) Name in log messages.
 --
---@param workspaceFolder (table) List of workspace folders passed to the
+--@param workspace_folders (table) List of workspace folders passed to the
 --- LSP server. See `workspaceFolders` in the LSP spec.
 ---
 --@param get_language_id function(bufnr, filetype) -> language ID as string.
@@ -779,8 +779,8 @@ function lsp.start_client(config)
     }
     local version = vim.version()
 
-    if not config.workspaceFolders then
-      config.workspaceFolders = {{
+    if not config.workspace_folders then
+      config.workspace_folders = {{
         uri = vim.uri_from_fname(config.root_dir);
         name = string.format("%s", config.root_dir);
       }};
@@ -826,7 +826,7 @@ function lsp.start_client(config)
       --  -- workspace folder in the user interface.
       --  name
       -- }
-      workspaceFolders = config.workspaceFolders,
+      workspaceFolders = config.workspace_folders,
     }
     if config.before_init then
       -- TODO(ashkan) handle errors here.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -592,7 +592,7 @@ end
 --@param name (string, default=client-id) Name in log messages.
 --
 --@param workspace_folders (table) List of workspace folders passed to the
---- LSP server. See `workspaceFolders` in the LSP spec.
+--- language server. See `workspaceFolders` in the LSP spec.
 ---
 --@param get_language_id function(bufnr, filetype) -> language ID as string.
 --- Defaults to the filetype.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -592,7 +592,8 @@ end
 --@param name (string, default=client-id) Name in log messages.
 --
 --@param workspace_folders (table) List of workspace folders passed to the
---- language server. See `workspaceFolders` in the LSP spec.
+--- language server. Defaults to root_dir if not set. See `workspaceFolders` in
+--- the LSP spec
 ---
 --@param get_language_id function(bufnr, filetype) -> language ID as string.
 --- Defaults to the filetype.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -590,6 +590,9 @@ end
 --- as `initializationOptions`. See `initialize` in the LSP spec.
 ---
 --@param name (string, default=client-id) Name in log messages.
+--
+--@param workspaceFolder (table) List of workspace folders passed to the
+--- LSP server. See `workspaceFolders` in the LSP spec.
 ---
 --@param get_language_id function(bufnr, filetype) -> language ID as string.
 --- Defaults to the filetype.
@@ -775,6 +778,14 @@ function lsp.start_client(config)
       off = 'off'; messages = 'messages'; verbose = 'verbose';
     }
     local version = vim.version()
+
+    if not config.workspaceFolders then
+      config.workspaceFolders = {{
+        uri = vim.uri_from_fname(config.root_dir);
+        name = string.format("%s", config.root_dir);
+      }};
+    end
+
     local initialize_params = {
       -- The process Id of the parent process that started the server. Is null if
       -- the process has not been started by another process.  If the parent
@@ -815,10 +826,7 @@ function lsp.start_client(config)
       --  -- workspace folder in the user interface.
       --  name
       -- }
-      workspaceFolders = {{
-        uri = vim.uri_from_fname(config.root_dir);
-        name = string.format("%s", config.root_dir);
-      }};
+      workspaceFolders = config.workspaceFolders,
     }
     if config.before_init then
       -- TODO(ashkan) handle errors here.


### PR DESCRIPTION
* rootPath and rootURI has been deprecated in favor of workspaceFolders. 

* This can also be useful for other languages that need to commonly
  open a certain directory (like flutter or lua), which would help
  prevent spinning up a new language server altogether.

* In case no workspaceFolders are passed, we fallback to what we had
  before.