### PR TITLE
feat(lsp): allow diagnostics to be disabled in a buffer

### DIFF
--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -241,6 +241,28 @@ describe('vim.lsp.diagnostic', function()
         ]]))
       end)
 
+      it('should not display diagnostics when disabled', function()
+        eq({0, 0}, exec_lua [[
+          local server_1_diags = {
+            make_error("Error 1", 1, 1, 1, 5),
+            make_warning("Warning on Server 1", 2, 1, 2, 5),
+          }
+          local server_2_diags = {
+            make_warning("Warning 1", 2, 1, 2, 5),
+          }
+
+          vim.lsp.diagnostic.disable(diagnostic_bufnr)
+
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_1_diags }, 1)
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_2_diags }, 2)
+
+          return {
+            count_of_extmarks_for_client(diagnostic_bufnr, 1),
+            count_of_extmarks_for_client(diagnostic_bufnr, 2),
+          }
+        ]])
+      end)
+
       describe('reset', function()
         it('diagnostic count is 0 and displayed diagnostics are 0 after call', function()
           -- 1 Error (1)

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -242,7 +242,7 @@ describe('vim.lsp.diagnostic', function()
       end)
 
       it('should not display diagnostics when disabled', function()
-        eq({0, 0}, exec_lua [[
+        eq({0, 2}, exec_lua [[
           local server_1_diags = {
             make_error("Error 1", 1, 1, 1, 5),
             make_warning("Warning on Server 1", 2, 1, 2, 5),
@@ -251,10 +251,20 @@ describe('vim.lsp.diagnostic', function()
             make_warning("Warning 1", 2, 1, 2, 5),
           }
 
-          vim.lsp.diagnostic.disable(diagnostic_bufnr)
-
           vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_1_diags }, 1)
           vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_2_diags }, 2)
+
+          vim.lsp.diagnostic.disable(diagnostic_bufnr, 1)
+
+          return {
+            count_of_extmarks_for_client(diagnostic_bufnr, 1),
+            count_of_extmarks_for_client(diagnostic_bufnr, 2),
+          }
+        ]])
+
+        eq({4, 0}, exec_lua [[
+          vim.lsp.diagnostic.enable(diagnostic_bufnr, 1)
+          vim.lsp.diagnostic.disable(diagnostic_bufnr, 2)
 
           return {
             count_of_extmarks_for_client(diagnostic_bufnr, 1),


### PR DESCRIPTION
Add two new methods to allow diagnostics to be disabled (and re-enabled)
in the current buffer. When diagnostics are disabled they are simply not
displayed to the user, but they are still sent by the server and
processed by the client.

Disabling diagnotics can be helpful in a number of scenarios. For
example, if one is working on a buffer with an overwhelming amount of
diagnostic warnings it can be helpful to simply disable diagnostics
without disabling the LSP client entirely. This also allows users more
flexibility on when and how they may want diagnostic information to be
displayed. For example, some users may not want to display diagnostic
information until after the buffer is first written.
