### PR TITLE
revert: "fix(ci): remove mongodb from brew to avoid brew upgrade error…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
           # Workaround brew issues
           rm -f /usr/local/bin/2to3
           brew update >/dev/null
-          # remove broken mongodb-community package
-          brew remove mongodb-community
           brew upgrade
           brew install automake ccache perl cpanminus ninja
 


### PR DESCRIPTION
… (#15115)"

This reverts commit 5377b2b00aea1a0bde1b81452e6198dabe5b9796.

(Fix no longer needed.)