### PR TITLE
fix(lsp): guard against `nil` in lsp.buf_request_all

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1318,7 +1318,7 @@ function lsp.buf_request_all(bufnr, method, params, callback)
   local cancel, client_request_ids
 
   local set_expected_result_count = once(function()
-    for _ in pairs(client_request_ids) do
+    for _ in pairs(client_request_ids or {}) do
       expected_result_count = expected_result_count + 1
     end
   end)


### PR DESCRIPTION
Calling `vim.lsp.buf.code_action()` with *null-ls* attached to a buffer
when no *null-ls* code action is available causes `lsp.buf_request_all`
to throw an error, because `client_request_ids` is `nil`.

This change defensively iterates over `client_request_ids or {}`.

I don't know if this is the correct fix. Frankly, I don't really
understand how this can work at all in other scenarios. From reading the
code, it seems that `client_request_ids` would always be nil when
`_sync_handler` is called. I would be really happy, if someone could
enlighten me.

```
local client_request_ids

...

-- client_request_ids is accessed in _sync_handler (before it is assigned?)
client_request_ids, cancel = lsp.buf_request(bufnr, method, params, _sync_handler)
```

Version:

    NVIM v0.6.0-dev+a8c3d50fa

Error:

    E5108: Error executing lua ...r/neovim/HEAD-a8c3d50/share/nvim/runtime/lua/vim/lsp.l ua:1321: bad argument #1 to 'pairs' (table expected, got nil)