### PR TITLE
Make exmode_active and enum

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2755,9 +2755,10 @@ int do_ecmd(
         curwin->w_set_curswant = TRUE;
       } else
         beginline(BL_SOL | BL_FIX);
-    } else {                  /* no line number, go to last line in Ex mode */
-      if (exmode_active)
+    } else {  // no line number, go to last line in Ex mode
+      if (exmode_active != EMStateNone) {
         curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
+      }
       beginline(BL_WHITE | BL_FIX);
     }
   }
@@ -3750,7 +3751,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout,
            * Loop until 'y', 'n', 'q', CTRL-E or CTRL-Y typed.
            */
           while (subflags.do_ask) {
-            if (exmode_active) {
+            if (exmode_active != EMStateNone) {
               char_u      *resp;
               colnr_T sc, ec;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -193,10 +193,11 @@ void do_exmode(int improved)
   linenr_T prev_line;
   int changedtick;
 
-  if (improved)
-    exmode_active = EXMODE_VIM;
-  else
-    exmode_active = EXMODE_NORMAL;
+  if (improved) {
+    exmode_active = EMStateVim;
+  } else {
+    exmode_active = EMStateNormal;
+  }
   State = NORMAL;
 
   /* When using ":global /pat/ visual" and then "Q" we return to continue
@@ -212,7 +213,7 @@ void do_exmode(int improved)
   while (exmode_active) {
     /* Check for a ":normal" command and no more characters left. */
     if (ex_normal_busy > 0 && typebuf.tb_len == 0) {
-      exmode_active = 0;
+      exmode_active = EMStateNone;
       break;
     }
     msg_scroll = true;

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -16,10 +16,6 @@
 #define VALID_PATH              1
 #define VALID_HEAD              2
 
-/* Values for exmode_active (0 is no exmode) */
-#define EXMODE_NORMAL           1
-#define EXMODE_VIM              2
-
 // Structure used to save the current state.  Used when executing Normal mode
 // commands while in any other mode.
 typedef struct {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6563,7 +6563,7 @@ static int open_cmdwin(void)
   save_cmdline(&save_ccline);
 
   // No Ex mode here!
-  exmode_active = 0;
+  exmode_active = EMStateNone;
 
   State = NORMAL;
   setmouse();

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -621,7 +621,14 @@ EXTERN long opcount INIT(= 0);          // count for pending operator
 EXTERN int motion_force INIT(=0);       // motion force for pending operator
 
 // Ex Mode (Q) state
-EXTERN int exmode_active INIT(= 0);     // Zero, EXMODE_NORMAL or EXMODE_VIM.
+// Values for exmode_active (0 is no exmode)
+typedef enum {
+  EMStateNone = 0,
+  EMStateNormal,
+  EMStateVim
+} exmode_state_t;
+
+EXTERN exmode_state_t exmode_active INIT(= EMStateNone);
 EXTERN int ex_no_reprint INIT(=false);  // No need to print after z or p.
 
 EXTERN int reg_recording INIT(= 0);     // register for recording  or zero

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -2387,7 +2387,7 @@ int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
   return OK;
 }
 
-static int prt_add_resource(struct prt_ps_resource_S *resource)
+static bool prt_add_resource(struct prt_ps_resource_S *resource)
 {
   FILE*       fd_resource;
   char_u resource_buffer[512];
@@ -2396,17 +2396,17 @@ static int prt_add_resource(struct prt_ps_resource_S *resource)
   fd_resource = os_fopen((char *)resource->filename, READBIN);
   if (fd_resource == NULL) {
     EMSG2(_("E456: Can't open file \"%s\""), resource->filename);
-    return FALSE;
+    return false;
   }
   switch (resource->type) {
   case PRT_RESOURCE_TYPE_PROCSET:
   case PRT_RESOURCE_TYPE_ENCODING:
   case PRT_RESOURCE_TYPE_CMAP:
     prt_dsc_resources("BeginResource", prt_resource_types[resource->type],
-        (char *)resource->title);
+                      (char *)resource->title);
     break;
   default:
-    return FALSE;
+    return false;
   }
 
   prt_dsc_textline("BeginDocument", (char *)resource->filename);
@@ -2418,14 +2418,14 @@ static int prt_add_resource(struct prt_ps_resource_S *resource)
       EMSG2(_("E457: Can't read PostScript resource file \"%s\""),
           resource->filename);
       fclose(fd_resource);
-      return FALSE;
+      return false;
     }
     if (bytes_read == 0)
       break;
     prt_write_file_raw_len(resource_buffer, bytes_read);
     if (prt_file_error) {
       fclose(fd_resource);
-      return FALSE;
+      return false;
     }
   }
   fclose(fd_resource);
@@ -2434,7 +2434,7 @@ static int prt_add_resource(struct prt_ps_resource_S *resource)
 
   prt_dsc_noarg("EndResource");
 
-  return TRUE;
+  return true;
 }
 
 int mch_print_begin(prt_settings_T *psettings)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -318,7 +318,7 @@ int main(int argc, char **argv)
   debug_break_level = params.use_debug_break_level;
 
   // Read ex-commands if invoked with "-es".
-  if (!params.input_isatty && silent_mode && exmode_active == EXMODE_NORMAL) {
+  if (!params.input_isatty && silent_mode && exmode_active == EMStateNormal) {
     input_start(STDIN_FILENO);
   }
 
@@ -772,7 +772,7 @@ static bool edit_stdin(bool explicit, mparm_T *parmp)
 {
   bool implicit = !headless_mode
     && !embedded_mode
-    && exmode_active != EXMODE_NORMAL  // -E/-Es but not -e/-es.
+    && exmode_active != EMStateNormal  // -E/-Es but not -e/-es.
     && !parmp->input_isatty
     && scriptin[0] == NULL;  // `-s -` was not given.
   return explicit || implicit;
@@ -915,11 +915,11 @@ static void command_line_scan(mparm_T *parmp)
           break;
         }
         case 'e': {  // "-e" Ex mode
-          exmode_active = EXMODE_NORMAL;
+          exmode_active = EMStateNormal;
           break;
         }
         case 'E': {  // "-E" Ex mode
-          exmode_active = EXMODE_VIM;
+          exmode_active = EMStateVim;
           break;
         }
         case 'f': {  // "-f"  GUI: run in foreground.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1324,12 +1324,14 @@ void msg_start(void)
       0;
   } else if (msg_didout) {                // start message on next line
     msg_putchar('\n');
-    did_return = TRUE;
-    if (exmode_active != EXMODE_NORMAL)
+    did_return = true;
+    if (exmode_active != EMStateNormal) {
       cmdline_row = msg_row;
+    }
   }
-  if (!msg_didany || lines_left < 0)
+  if (!msg_didany || lines_left < 0) {
     msg_starthere();
+  }
   if (msg_silent == 0) {
     msg_didout = false;                     // no output on current line yet
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1188,7 +1188,7 @@ static void normal_check_interrupt(NormalState *s)
         && s->previous_got_int) {
       // Typed two CTRL-C in a row: go back to ex mode as if "Q" was
       // used and keep "got_int" set, so that it aborts ":g".
-      exmode_active = EXMODE_NORMAL;
+      exmode_active = EMStateNormal;
       State = NORMAL;
     } else if (!global_busy || !exmode_active) {
       if (!quit_more) {
@@ -1398,7 +1398,7 @@ static int normal_check(VimState *state)
     if (s->noexmode) {
       return 0;
     }
-    do_exmode(exmode_active == EXMODE_VIM);
+    do_exmode(exmode_active == EMStateVim);
     return -1;
   }
 

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -173,9 +173,9 @@ char *get_mode(void)
     }
   } else if ((State & CMDLINE) || exmode_active) {
     buf[0] = 'c';
-    if (exmode_active == EXMODE_VIM) {
+    if (exmode_active == EMStateVim) {
       buf[1] = 'v';
-    } else if (exmode_active == EXMODE_NORMAL) {
+    } else if (exmode_active == EMStateNormal) {
       buf[1] = 'e';
     }
   } else if (State & TERM_FOCUS) {


### PR DESCRIPTION
When reviewing #15151 I came accross the fact that `exmode_active`
should be an enum, and thus I changed that.

I see two advantages to this:

- Actually stop using ints to do random things, in this case this
  variable was only taking thres values (0, 1, and 2).
- Help the compiler optimize this (maybe).

Also continues the work done by @dungardoc in removing TRUE/FALSE.
