### PR TITLE
fix(man.vim): use `-addr=other` instead of `-range=-1`

### DIFF
--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -5,7 +5,7 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-command! -bang -bar -range=-1 -complete=customlist,man#complete -nargs=* Man
+command! -bang -bar -addr=other -complete=customlist,man#complete -nargs=* Man
       \ if <bang>0 | call man#init_pager() |
       \ else | call man#open_page(<count>, <q-mods>, <f-args>) | endif
 


### PR DESCRIPTION
`-range=-1` requires the current file to have at least `<count>` lines, whereas `-addr=other` doesn't.

`-addr=other` also sets `<count>` to `-1` by default when it is not specified, though this feature seems undocumented.