### PR TITLE
added ccls-cache in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ compile_commands.json
 /tmp/
 /.clangd/
 /.cache/clangd/
+/.ccls-cache/
 
 .DS_Store
 *.mo


### PR DESCRIPTION
Many developers use ccls lsp for their workflow. Having ccls-cache in gitignore help them a lot while making commit and PR.