### PR TITLE
fix: source syncolors.vim after startup scripts

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -366,19 +366,16 @@ int main(int argc, char **argv)
   // Execute --cmd arguments.
   exe_pre_commands(&params);
 
-  // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
-  bool enable_syntax =
-    (params.use_vimrc == NULL || !strequal(params.use_vimrc, "NONE"));
-
-  // Source syncolor.vim to set up default UI highlights
-  if (enable_syntax) {
-    source_runtime((char_u *)"syntax/syncolor.vim", DIP_ALL);
-  }
-
   // Source startup scripts.
   source_startup_scripts(&params);
 
-  if (enable_syntax) {
+  // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
+  if (params.use_vimrc == NULL || !strequal(params.use_vimrc, "NONE")) {
+    // Source syncolor.vim to set up default UI highlights if the user didn't
+    // already enable a colorscheme
+    if (!get_var_value("g:colors_name")) {
+      source_runtime((char_u *)"syntax/syncolor.vim", DIP_ALL);
+    }
     // Does ":filetype plugin indent on".
     filetype_maybe_enable();
     // Sources syntax/syntax.vim, which calls `:filetype on`.


### PR DESCRIPTION
This fixes an issue introduced in #14771 (fix: source syncolors.vim
before startup scripts) that affected highlights for users who set
'background' to light in their startup script. Because syncolor.vim
checks for the value of &background, it was always setting up the 'dark'
background colors, which looked wrong for users using light backgrounds.

The primary benefit of #14771 is that it decoupled highlighting from the
syntax engine. This is useful for e.g. treesitter, which still makes use
of highlights even if the syntax engine is disabled. For this reason, it
is still worthwhile to source syncolor.vim separately from synload.vim,
which #14771 accomplishes. However, we should still source syncolor.vim
after the user startup scripts, to ensure that we are respecting the
options the user sets.

Another corollary benefit is that this reduces some redundancy in
highlight definitions, since we now only source syncolors.vim if the
user did not already enable a colorscheme.

See the discussion [here](https://github.com/neovim/neovim/pull/14771#issuecomment-886016934).

Closes #15176.