### PR TITLE
fix: fix incorrect call sites of xcalloc

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -315,7 +315,7 @@ ArrayOf(String) nvim_buf_get_lines(uint64_t channel_id,
   }
 
   rv.size = (size_t)(end - start);
-  rv.items = xcalloc(sizeof(Object), rv.size);
+  rv.items = xcalloc(rv.size, sizeof(Object));
 
   if (!buf_collect_lines(buf, rv.size, start,
                          (channel_id != VIML_INTERNAL_CALL), &rv, err)) {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1696,7 +1696,7 @@ void nvim_put(ArrayOf(String) lines, String type, Boolean after,
   FUNC_API_SINCE(6)
   FUNC_API_CHECK_TEXTLOCK
 {
-  yankreg_T *reg = xcalloc(sizeof(yankreg_T), 1);
+  yankreg_T *reg = xcalloc(1, sizeof(yankreg_T));
   if (!prepare_yankreg_from_object(reg, type, lines.size)) {
     api_set_error(err, kErrorTypeValidation, "Invalid type: '%s'", type.data);
     goto cleanup;

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -50,7 +50,7 @@ bool buf_updates_register(buf_T *buf, uint64_t channel_id,
   if (send_buffer) {
     Array args = ARRAY_DICT_INIT;
     args.size = 6;
-    args.items = xcalloc(sizeof(Object), args.size);
+    args.items = xcalloc(args.size, sizeof(Object));
 
     // the first argument is always the buffer handle
     args.items[0] = BUFFER_OBJ(buf->handle);
@@ -68,7 +68,7 @@ bool buf_updates_register(buf_T *buf, uint64_t channel_id,
 
     if (line_count >= 1) {
       linedata.size = line_count;
-      linedata.items = xcalloc(sizeof(Object), line_count);
+      linedata.items = xcalloc(line_count, sizeof(Object));
 
       buf_collect_lines(buf, line_count, 1, true, &linedata, NULL);
     }
@@ -93,7 +93,7 @@ void buf_updates_send_end(buf_T *buf, uint64_t channelid)
 {
     Array args = ARRAY_DICT_INIT;
     args.size = 1;
-    args.items = xcalloc(sizeof(Object), args.size);
+    args.items = xcalloc(args.size, sizeof(Object));
     args.items[0] = BUFFER_OBJ(buf->handle);
     rpc_send_event(channelid, "nvim_buf_detach_event", args);
 }
@@ -211,7 +211,7 @@ void buf_updates_send_changes(buf_T *buf,
     // send through the changes now channel contents now
     Array args = ARRAY_DICT_INIT;
     args.size = 6;
-    args.items = xcalloc(sizeof(Object), args.size);
+    args.items = xcalloc(args.size, sizeof(Object));
 
     // the first argument is always the buffer handle
     args.items[0] = BUFFER_OBJ(buf->handle);
@@ -230,7 +230,7 @@ void buf_updates_send_changes(buf_T *buf,
     if (num_added > 0) {
         STATIC_ASSERT(SIZE_MAX >= MAXLNUM, "size_t smaller than MAXLNUM");
         linedata.size = (size_t)num_added;
-        linedata.items = xcalloc(sizeof(Object), (size_t)num_added);
+        linedata.items = xcalloc((size_t)num_added, sizeof(Object));
         buf_collect_lines(buf, (size_t)num_added, firstline, true, &linedata,
                           NULL);
     }
@@ -394,7 +394,7 @@ void buf_updates_changedtick_single(buf_T *buf, uint64_t channel_id)
 {
     Array args = ARRAY_DICT_INIT;
     args.size = 2;
-    args.items = xcalloc(sizeof(Object), args.size);
+    args.items = xcalloc(args.size, sizeof(Object));
 
     // the first argument is always the buffer handle
     args.items[0] = BUFFER_OBJ(buf->handle);

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1018,14 +1018,14 @@ static ExtmarkUndoObject *unserialize_extmark(bufinfo_T *bi, bool *error,
   extup->type = type;
   if (type == kExtmarkSplice) {
     n_elems = (size_t)sizeof(ExtmarkSplice) / sizeof(uint8_t);
-    buf = xcalloc(sizeof(uint8_t), n_elems);
+    buf = xcalloc(n_elems, sizeof(uint8_t));
     if (!undo_read(bi, buf, n_elems)) {
       goto error;
     }
     extup->data.splice = *(ExtmarkSplice *)buf;
   } else if (type == kExtmarkMove) {
     n_elems = (size_t)sizeof(ExtmarkMove) / sizeof(uint8_t);
-    buf = xcalloc(sizeof(uint8_t), n_elems);
+    buf = xcalloc(n_elems, sizeof(uint8_t));
     if (!undo_read(bi, buf, n_elems)) {
       goto error;
     }


### PR DESCRIPTION
The number of elements comes first and the size of each element second.
