### PR TITLE
feat(api): add "viS" to mode() result

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6347,6 +6347,7 @@ mode([expr])	Return a string that indicates the current mode.
 		   v	    Visual by character
 		   V	    Visual by line
 		   CTRL-V   Visual blockwise
+		   viS	    Visual using |v_CTRL-O| in |Select-mode|
 		   s	    Select by character
 		   S	    Select by line
 		   CTRL-S   Select blockwise

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -525,6 +525,8 @@ EXTERN pos_T VIsual;
 EXTERN int VIsual_active INIT(= false);
 /// Whether Select mode is active.
 EXTERN int VIsual_select INIT(= false);
+/// Restart Select mode when next cmd finished
+EXTERN int restart_VIsual_select INIT(= 0);
 /// Whether to restart the selection after a Select-mode mapping or menu.
 EXTERN int VIsual_reselect;
 /// Type of Visual mode.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -92,8 +92,6 @@ static linenr_T resel_VIsual_line_count;        /* number of lines */
 static colnr_T resel_VIsual_vcol;               /* nr of cols or end col */
 static int VIsual_mode_orig = NUL;              /* saved Visual mode */
 
-static int restart_VIsual_select = 0;
-
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "normal.c.generated.h"

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -144,6 +144,10 @@ char *get_mode(void)
       buf[0] = (char)(VIsual_mode + 's' - 'v');
     } else {
       buf[0] = (char)VIsual_mode;
+      if (restart_VIsual_select) {
+        buf[1] = 'i';
+        buf[2] = 'S';
+      }
     }
   } else if (State == HITRETURN || State == ASKMORE || State == SETWSIZE
              || State == CONFIRM) {

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -534,6 +534,7 @@ func Test_mode()
   set complete=.
 
   inoremap <F2> <C-R>=Save_mode()<CR>
+  xnoremap <F2> <Cmd>call Save_mode()<CR>
 
   normal! 3G
   exe "normal i\<F2>\<Esc>"
@@ -621,6 +622,10 @@ func Test_mode()
   exe "normal gR\<C-O>:call Save_mode()\<Cr>\<Esc>"
   call assert_equal("n-niV", g:current_modes)
 
+  " v_CTRL-O
+  exe "normal gh\<C-O>\<F2>\<Esc>"
+  call assert_equal("v-viS", g:current_modes)
+
   " How to test operator-pending mode?
 
   call feedkeys("v", 'xt')
@@ -653,6 +658,7 @@ func Test_mode()
 
   bwipe!
   iunmap <F2>
+  xunmap <F2>
   set complete&
 endfunc
 


### PR DESCRIPTION
`mode()` returns `viS` for Visual using v_CTRL-O in Select mode.