### PR TITLE
refactor: replace TRUE/FALSE with true/false

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1922,7 +1922,7 @@ static void f_eval(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if (expr_start != NULL && !aborting()) {
       EMSG2(_(e_invexpr2), expr_start);
     }
-    need_clr_eos = FALSE;
+    need_clr_eos = false;
     rettv->v_type = VAR_NUMBER;
     rettv->vval.v_number = 0;
   } else if (*s != NUL) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -562,7 +562,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
         && (cstack.cs_looplevel || has_loop_cmd(next_cmdline))) {
       store_loop_line(&lines_ga, next_cmdline);
     }
-    did_endif = FALSE;
+    did_endif = false;
 
     if (count++ == 0) {
       /*
@@ -940,7 +940,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline,
     }
   }
 
-  did_endif = FALSE;    /* in case do_cmdline used recursively */
+  did_endif = false;    // in case do_cmdline used recursively
 
   call_depth--;
   end_batch_changes();
@@ -7486,7 +7486,7 @@ static void ex_syncbind(exarg_T *eap)
   curwin = save_curwin;
   curbuf = save_curbuf;
   if (curwin->w_p_scb) {
-    did_syncbind = TRUE;
+    did_syncbind = true;
     checkpcmark();
     if (old_linenr != curwin->w_cursor.lnum) {
       char_u ctrl_o[2];

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -832,24 +832,23 @@ void ex_if(exarg_T *eap)
  */
 void ex_endif(exarg_T *eap)
 {
-  did_endif = TRUE;
+  did_endif = true;
   if (eap->cstack->cs_idx < 0
       || (eap->cstack->cs_flags[eap->cstack->cs_idx]
-          & (CSF_WHILE | CSF_FOR | CSF_TRY)))
+          & (CSF_WHILE | CSF_FOR | CSF_TRY))) {
     eap->errmsg = (char_u *)N_("E580: :endif without :if");
-  else {
-    /*
-     * When debugging or a breakpoint was encountered, display the debug
-     * prompt (if not already done).  This shows the user that an ":endif"
-     * is executed when the ":if" or a previous ":elseif" was not TRUE.
-     * Handle a ">quit" debug command as if an interrupt had occurred before
-     * the ":endif".  That is, throw an interrupt exception if appropriate.
-     * Doing this here prevents an exception for a parsing error being
-     * discarded by throwing the interrupt exception later on.
-     */
+  } else {
+    // When debugging or a breakpoint was encountered, display the debug
+    // prompt (if not already done).  This shows the user that an ":endif"
+    // is executed when the ":if" or a previous ":elseif" was not TRUE.
+    // Handle a ">quit" debug command as if an interrupt had occurred before
+    // the ":endif".  That is, throw an interrupt exception if appropriate.
+    // Doing this here prevents an exception for a parsing error being
+    // discarded by throwing the interrupt exception later on.
     if (!(eap->cstack->cs_flags[eap->cstack->cs_idx] & CSF_TRUE)
-        && dbg_check_skipped(eap))
+        && dbg_check_skipped(eap)) {
       (void)do_intthrow(eap->cstack);
+    }
 
     --eap->cstack->cs_idx;
   }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -292,8 +292,8 @@ readfile(
    * display the line. */
   ex_no_reprint = TRUE;
 
-  /* don't display the file info for another buffer now */
-  need_fileinfo = FALSE;
+  // don't display the file info for another buffer now
+  need_fileinfo = false;
 
   // For Unix: Use the short file name whenever possible.
   // Avoids problems with networks and when directory names are changed.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -138,12 +138,12 @@ EXTERN int mod_mask INIT(= 0x0);  // current key modifiers
 // update_screen().
 EXTERN int cmdline_row;
 
-EXTERN int redraw_cmdline INIT(= false);          // cmdline must be redrawn
-EXTERN int clear_cmdline INIT(= false);           // cmdline must be cleared
-EXTERN int mode_displayed INIT(= false);          // mode is being displayed
-EXTERN int cmdline_star INIT(= false);            // cmdline is encrypted
-EXTERN int redrawing_cmdline INIT(= false);       // cmdline is being redrawn
-EXTERN int cmdline_was_last_drawn INIT(= false);  // cmdline was last drawn
+EXTERN int redraw_cmdline INIT(= false);           // cmdline must be redrawn
+EXTERN int clear_cmdline INIT(= false);            // cmdline must be cleared
+EXTERN int mode_displayed INIT(= false);           // mode is being displayed
+EXTERN int cmdline_star INIT(= false);             // cmdline is encrypted
+EXTERN bool redrawing_cmdline INIT(= false);       // cmdline is being redrawn
+EXTERN bool cmdline_was_last_drawn INIT(= false);  // cmdline was last drawn
 
 EXTERN int exec_from_reg INIT(= false);         // executing register
 
@@ -165,7 +165,7 @@ EXTERN int compl_interrupted INIT(= false);
 
 // Set when doing something for completion that may call edit() recursively,
 // which is not allowed. Also used to disable folding during completion
-EXTERN int compl_busy INIT(= false);
+EXTERN bool compl_busy INIT(= false);
 
 // List of flags for method of completion.
 EXTERN int compl_cont_status INIT(= 0);
@@ -201,8 +201,8 @@ EXTERN bool msg_did_scroll INIT(= false);
 
 EXTERN char_u *keep_msg INIT(= NULL);       // msg to be shown after redraw
 EXTERN int keep_msg_attr INIT(= 0);         // highlight attr for keep_msg
-EXTERN int keep_msg_more INIT(= false);     // keep_msg was set by msgmore()
-EXTERN int need_fileinfo INIT(= false);     // do fileinfo() after redraw
+EXTERN bool keep_msg_more INIT(= false);    // keep_msg was set by msgmore()
+EXTERN bool need_fileinfo INIT(= false);    // do fileinfo() after redraw
 EXTERN int msg_scroll INIT(= false);        // msg_start() will scroll
 EXTERN int msg_didout INIT(= false);        // msg_outstr() was used in line
 EXTERN int msg_didany INIT(= false);        // msg_outstr() was used at all
@@ -211,13 +211,13 @@ EXTERN int emsg_off INIT(= 0);              // don't display errors for now,
                                             // unless 'debug' is set.
 EXTERN int info_message INIT(= false);      // printing informative message
 EXTERN bool msg_hist_off INIT(= false);     // don't add messages to history
-EXTERN int need_clr_eos INIT(= false);      // need to clear text before
+EXTERN bool need_clr_eos INIT(= false);     // need to clear text before
                                             // displaying a message.
 EXTERN int emsg_skip INIT(= 0);             // don't display errors for
                                             // expression that is skipped
 EXTERN bool emsg_severe INIT(= false);      // use message of next of several
                                             //  emsg() calls for throw
-EXTERN int did_endif INIT(= false);         // just had ":endif"
+EXTERN bool did_endif INIT(= false);        // just had ":endif"
 EXTERN dict_T vimvardict;                   // Dictionary with v: variables
 EXTERN dict_T globvardict;                  // Dictionary with g: variables
 /// g: value
@@ -234,15 +234,15 @@ EXTERN int rc_did_emsg INIT(= false);       // vim_regcomp() called emsg()
 
 EXTERN int no_wait_return INIT(= 0);        // don't wait for return for now
 EXTERN int need_wait_return INIT(= 0);      // need to wait for return later
-EXTERN int did_wait_return INIT(= false);   // wait_return() was used and
+EXTERN bool did_wait_return INIT(= false);  // wait_return() was used and
                                             // nothing written since then
-EXTERN int need_maketitle INIT(= true);     // call maketitle() soon
+EXTERN bool need_maketitle INIT(= true);    // call maketitle() soon
 
 EXTERN int quit_more INIT(= false);         // 'q' hit at "--more--" msg
 EXTERN int vgetc_busy INIT(= 0);            // when inside vgetc() then > 0
 
-EXTERN int didset_vim INIT(= false);         // did set $VIM ourselves
-EXTERN int didset_vimruntime INIT(= false);  // idem for $VIMRUNTIME
+EXTERN bool didset_vim INIT(= false);         // did set $VIM ourselves
+EXTERN bool didset_vimruntime INIT(= false);  // idem for $VIMRUNTIME
 
 /// Lines left before a "more" message.  Ex mode needs to be able to reset this
 /// after you type something.
@@ -368,7 +368,7 @@ EXTERN colnr_T search_match_endcol;                // col nr of match end
 EXTERN linenr_T search_first_line INIT(= 0);       // for :{FIRST},{last}s/pat
 EXTERN linenr_T search_last_line INIT(= MAXLNUM);  // for :{first},{LAST}s/pat
 
-EXTERN int no_smartcase INIT(= false);          // don't use 'smartcase' once
+EXTERN bool no_smartcase INIT(= false);          // don't use 'smartcase' once
 
 EXTERN int need_check_timestamps INIT(= false);  // need to check file
                                                  // timestamps asap
@@ -555,7 +555,7 @@ EXTERN int end_comment_pending INIT(= NUL);
 // know that it should not attempt to perform scrollbinding due to the scroll
 // that was a result of the ":syncbind." (Otherwise, check_scrollbind() will
 // undo some of the work done by ":syncbind.")  -ralston
-EXTERN int did_syncbind INIT(= false);
+EXTERN bool did_syncbind INIT(= false);
 
 // This flag is set when a smart indent has been performed. When the next typed
 // character is a '{' the inserted tab will be deleted again.
@@ -642,7 +642,7 @@ EXTERN int arrow_used;                  // Normally false, set to true after
 EXTERN bool ins_at_eol INIT(= false);   // put cursor after eol when
                                         // restarting edit after CTRL-O
 
-EXTERN int no_abbr INIT(= true);        // true when no abbreviations loaded
+EXTERN bool no_abbr INIT(= true);       // true when no abbreviations loaded
 
 EXTERN int mapped_ctrl_c INIT(= 0);  // Modes where CTRL-C is mapped.
 
@@ -662,7 +662,7 @@ EXTERN bool cmd_silent INIT(= false);    // don't echo the command line
 EXTERN int swap_exists_action INIT(= SEA_NONE);
 // For dialog when swap file already
 // exists.
-EXTERN int swap_exists_did_quit INIT(= false);
+EXTERN bool swap_exists_did_quit INIT(= false);
 // Selected "quit" at the dialog.
 
 EXTERN char_u IObuff[IOSIZE];               ///< Buffer for sprintf, I/O, etc.
@@ -731,7 +731,7 @@ EXTERN char_u *new_last_cmdline INIT(= NULL);  // new value for last_cmdline
 EXTERN char_u *autocmd_fname INIT(= NULL);     // fname for <afile> on cmdline
 EXTERN int autocmd_bufnr INIT(= 0);            // fnum for <abuf> on cmdline
 EXTERN char_u *autocmd_match INIT(= NULL);     // name for <amatch> on cmdline
-EXTERN int did_cursorhold INIT(= false);       // set when CursorHold t'gerd
+EXTERN bool did_cursorhold INIT(= false);      // set when CursorHold t'gerd
 
 EXTERN int postponed_split INIT(= 0);        // for CTRL-W CTRL-] command
 EXTERN int postponed_split_flags INIT(= 0);  // args for win_split()

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1430,7 +1430,7 @@ static void handle_quickfix(mparm_T *paramp)
 static void handle_tag(char_u *tagname)
 {
   if (tagname != NULL) {
-    swap_exists_did_quit = FALSE;
+    swap_exists_did_quit = false;
 
     vim_snprintf((char *)IObuff, IOSIZE, "ta %s", tagname);
     do_cmdline_cmd((char *)IObuff);
@@ -1638,7 +1638,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
       curwin->w_arg_idx = arg_idx;
       /* Edit file from arg list, if there is one.  When "Quit" selected
        * at the ATTENTION prompt close the window. */
-      swap_exists_did_quit = FALSE;
+      swap_exists_did_quit = false;
       (void)do_ecmd(0, arg_idx < GARGCOUNT
           ? alist_name(&GARGLIST[arg_idx]) : NULL,
           NULL, NULL, ECMD_LASTL, ECMD_HIDE, curwin);

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1284,7 +1284,7 @@ void set_keep_msg(char_u *s, int attr)
     keep_msg = vim_strsave(s);
   else
     keep_msg = NULL;
-  keep_msg_more = FALSE;
+  keep_msg_more = false;
   keep_msg_attr = attr;
 }
 

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -849,7 +849,7 @@ void msgmore(long n)
     }
     if (msg(msg_buf)) {
       set_keep_msg(msg_buf, 0);
-      keep_msg_more = TRUE;
+      keep_msg_more = true;
     }
   }
 }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -474,7 +474,7 @@ void set_last_search_pat(const char_u *s, int idx, int magic, int setlast)
   spats[idx].timestamp = os_time();
   spats[idx].additional_data = NULL;
   spats[idx].magic = magic;
-  spats[idx].no_scs = FALSE;
+  spats[idx].no_scs = false;
   spats[idx].off.dir = '/';
   set_vv_searchforward();
   spats[idx].off.line = FALSE;


### PR DESCRIPTION
I've made sure to check that each type change is self-contained (which is partly why I didn't/couldn't modify the entire globals.h in one go - it'd mean to basically refactor everything at once).

For example, if `int varA = FALSE` is changed to `bool varA = false`, and there later in the file is a 

```
int varB = varA
```

I've then changed it to

```
bool varB = varA
```


If there later happens to be a 

```
int varC = varB
```

then I've also changed that to

```
bool varC = varB
```

and continue recursively until it stops.