### PR TITLE
feat(lsp): make list handlers configurable

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -322,6 +322,18 @@ To configure the behavior of a builtin |lsp-handler|, the convenient method
      }
    }
 <
+  Some handlers do not have an explicitly named handler function (such as
+  |on_publish_diagnostics()|). To override these, first create a reference
+  to the existing handler: >
+
+    local on_references = vim.lsp.handlers["textDocument/references"]
+    vim.lsp.handlers["textDocument/references"] = vim.lsp.with(
+      on_references, {
+        -- Use location list instead of quickfix list
+        loclist = true,
+      }
+    )
+<
                                                       *lsp-handler-resolution*
 Handlers can be set by:
 


### PR DESCRIPTION
The handlers for textDocument/references, textDocument/documentSymbol, and workspace/symbol open their results in the quickfix list by default and are not configurable. They are also incompatible with `vim.lsp.with` as they do not accept a configuration parameter.

Add a `config` parameter to the handler for these three messages which allows them to be configured with `vim.lsp.with`. Additionally, add a new configuration option 'loclist' that, when true, causes these handlers to open their results in the location list rather than the quickfix list.
