### PR TITLE
add vim.ui.pick

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -109,6 +109,7 @@
               shellHook = ''
                 export NVIM_PYTHON_LOG_LEVEL=DEBUG
                 export NVIM_LOG_FILE=/tmp/nvim.log
+                export VIMRUNTIME=$PWD/runtime
 
                 # ASAN_OPTIONS=detect_leaks=1
                 export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -575,13 +575,13 @@ Object nvim_notify(String msg, Integer log_level, Dictionary opts, Error *err)
   return nlua_exec(STATIC_CSTR_AS_STRING("return vim.notify(...)"), args, err);
 }
 
-/// Notify the user with a message
+/// Let the user select an entry from a list
 ///
-/// Relays the call to vim.notify . By default forwards your message in the
-/// echo area but can be overridden to trigger desktop notifications.
+/// Relays the call to vim.ui.pick. Defaults to inputlist in absence of a loaded
+/// runtime.
 ///
-/// @param msg        Message to display to the user
-/// @param log_level  The log level
+/// @param entries    A dictionary with the displayed line as keys and result as
+///                   values
 /// @param opts       Options like 'prompt'
 /// @param[out] err   Error details, if any
 Object nvim_pick(Dictionary entries, Dictionary opts, Error *err)
@@ -591,7 +591,7 @@ Object nvim_pick(Dictionary entries, Dictionary opts, Error *err)
   args.items[0] = DICTIONARY_OBJ(entries);
   args.items[1] = DICTIONARY_OBJ(opts);
 
-  return nlua_exec(STATIC_CSTR_AS_STRING("return vim.pick(...)"), args, err);
+  return nlua_exec(STATIC_CSTR_AS_STRING("return vim.ui.pick(...)"), args, err);
 }
 
 /// Calls a VimL function.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -575,6 +575,25 @@ Object nvim_notify(String msg, Integer log_level, Dictionary opts, Error *err)
   return nlua_exec(STATIC_CSTR_AS_STRING("return vim.notify(...)"), args, err);
 }
 
+/// Notify the user with a message
+///
+/// Relays the call to vim.notify . By default forwards your message in the
+/// echo area but can be overridden to trigger desktop notifications.
+///
+/// @param msg        Message to display to the user
+/// @param log_level  The log level
+/// @param opts       Options like 'prompt'
+/// @param[out] err   Error details, if any
+Object nvim_pick(Dictionary entries, Dictionary opts, Error *err)
+  FUNC_API_SINCE(8)
+{
+  FIXED_TEMP_ARRAY(args, 3);
+  args.items[0] = DICTIONARY_OBJ(entries);
+  args.items[1] = DICTIONARY_OBJ(opts);
+
+  return nlua_exec(STATIC_CSTR_AS_STRING("return vim.pick(...)"), args, err);
+}
+
 /// Calls a VimL function.
 ///
 /// @param fn Function name

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -424,6 +424,14 @@ function vim.notify(msg, log_level, _opts)
   end
 end
 
+vim.ui = {
+  --- Picker
+  --- without a runtime, relies on inputlist()
+  --  see :help nvim_pick
+  pick = function (entries, opts)
+    return vim.fn.inputlist(vim.tbl_values(entries))
+  end
+}
 
 local on_keystroke_callbacks = {}
 

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -429,7 +429,17 @@ vim.ui = {
   --- without a runtime, relies on inputlist()
   --  see :help nvim_pick
   pick = function (entries, opts)
-    return vim.fn.inputlist(vim.tbl_values(entries))
+    local descriptions = vim.tbl_keys(entries)
+    if opts.prompt then
+      table.insert(descriptions, opts.prompt)
+    end
+
+    local res = vim.fn.inputlist(descriptions)
+    if res <= 0 then
+      -- the user selected the first entry (=prompt) or cancelled
+      return
+    end
+    return entries[res]
   end
 }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -525,6 +525,25 @@ describe('API', function()
     end)
   end)
 
+  describe('nvim_pick', function()
+    it('can select an item', function()
+      local items = {
+        description1 = "value 1",
+        description2 = "value 2",
+      }
+      local opts = {
+        prompt = "Select item"
+      }
+      nvim("pick", "", opts)
+    end)
+
+    it('can be overriden', function()
+      command("lua vim.ui.pick = function(...) return 42 end")
+      eq(42, meths.exec_lua("return vim.ui.pick({1='Hello world', 2='toto'})", {}))
+      nvim("notify", "hello world", 4, {})
+    end)
+  end)
+
   describe('nvim_input', function()
     it("VimL error: does NOT fail, updates v:errmsg", function()
       local status, _ = pcall(nvim, "input", ":call bogus_fn()<CR>")


### PR DESCRIPTION
I've finally snapped, every plugin has a different picker interface and so I dont know where to look: I would like all plugins to use the same selection mechanism.
It's a very rough draft (needs tests etc) but having a first version of `vim.ui.pick` would already improve the situation a lot, we can then refine it before the 0.6 release..

It defaults to inputlist for now but there is a project to add vim.ui components so we could have a floating window component that replaces it when loading runtime. Now I wonder if picking should be a UI event too.

right now in my init.lua I tested with:
```
if vim.ui then


vim.ui.pick = function (entries, opts)
	acceptable_files = vim.tbl_values(entries)


	local pickers = require "telescope.pickers"
	local finders = require "telescope.finders"
	local actions = require "telescope.actions"

	pickers.new({
	prompt_title = "test vim.pick",
	finder = finders.new_table {
	results = acceptable_files,
	entry_maker = function(line)
	  return {
		value = line,
	    ordinal = line,
	    display = line,
	  }
	end,

    attach_mappings = function(_)
      actions.select_default:replace(actions.run_builtin)
      return true
    end,
	}
}):find()
```
@tjdevries I actually spent more time writing the telescope picker than the neovim changes, and right now upon selection it opens the file but I just would like to return the selected entry, how can I do it ? 