### PR TITLE
feat(lsp): implement vim.lsp.diagnostic.redraw()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1451,6 +1451,22 @@ on_publish_diagnostics({_}, {_}, {params}, {client_id}, {_}, {config})
                                 • Sort diagnostics (and thus signs and virtual
                                   text)
 
+redraw({bufnr}, {client_id})                     *vim.lsp.diagnostic.redraw()*
+                Redraw diagnostics for the given buffer and client
+
+                This calls the "textDocument/publishDiagnostics" handler
+                manually using the cached diagnostics already received from
+                the server. This can be useful for redrawing diagnostics after
+                making changes in diagnostics configuration.
+                |lsp-handler-configuration|
+
+                Parameters: ~
+                    {bufnr}      (optional, number): Buffer handle, defaults
+                                 to current
+                    {client_id}  (optional, number): Redraw diagnostics for
+                                 the given client. The default is to redraw
+                                 diagnostics for all attached clients.
+
 reset({client_id}, {buffer_client_map})           *vim.lsp.diagnostic.reset()*
                 Clear diagnotics and diagnostic cache
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -453,15 +453,7 @@ local function text_document_did_open_handler(bufnr, client)
 
   -- Next chance we get, we should re-do the diagnostics
   vim.schedule(function()
-    vim.lsp.handlers["textDocument/publishDiagnostics"](
-      nil,
-      "textDocument/publishDiagnostics",
-      {
-        diagnostics = vim.lsp.diagnostic.get(bufnr, client.id),
-        uri = vim.uri_from_bufnr(bufnr),
-      },
-      client.id
-    )
+    vim.lsp.diagnostic.redraw(bufnr, client.id)
   end)
 end
 


### PR DESCRIPTION
Add a new function to redraw diagnostics from the current diagnostic cache, without receiving a "publishDiagnostics" message from the server.  This is already being done in two places in the Lua stdlib, so this function unifies that functionality in addition to providing it to third party plugins.

An example use case for this could be a command or key-binding for toggling diagnostics virtual text. The virtual text configuration option can be toggled using `vim.lsp.with` followed by `vim.lsp.diagnostic.redraw()` to immediately redraw the diagnostics with the updated setting.
