### PR TITLE
fix(lsp): runtime error buf_request_all if no server supports a request

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1318,13 +1318,17 @@ function lsp.buf_request_all(bufnr, method, params, callback)
   local cancel, client_request_ids
 
   local set_expected_result_count = once(function()
-    for _ in pairs(client_request_ids) do
-      expected_result_count = expected_result_count + 1
+    if client_request_ids then
+      for _ in pairs(client_request_ids) do
+        expected_result_count = expected_result_count + 1
+      end
     end
   end)
 
   local function _sync_handler(err, _, result, client_id)
-    request_results[client_id] = { error = err, result = result }
+    if client_id then
+      request_results[client_id] = { error = err, result = result }
+    end
     result_count = result_count + 1
     set_expected_result_count()
 


### PR DESCRIPTION
When no server would be active to handle the request, `_sync_handler` would fail because the `client_id` is `nil`. Furthermore
`set_expected_result_count` fails because `client_request_ids` is `nil`. This commit adds safety guards for this case, to return an empty mapping instead of failing with a runtime error.

I would be more than happy to add a test but this is my first contribution and lsp_spec.lua is a bit daunting. If somebody could give a pointer what I could do and where I could add a test, that would be very much appreciated!