### PR TITLE
vim-patch:8.2.3236: mode() does not indicate using CTRL-O in Select mode

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6350,6 +6350,10 @@ mode([expr])	Return a string that indicates the current mode.
 		   s	    Select by character
 		   S	    Select by line
 		   CTRL-S   Select blockwise
+		   vs	    Visual by character using |v_CTRL-O| from
+				Select mode
+		   Vs	    Visual by line using |v_CTRL-O| from Select mode
+		   CTRL-Vs  Visual blockwise using |v_CTRL-O| from Select mode
 		   i	    Insert
 		   ic	    Insert mode completion |compl-generic|
 		   ix	    Insert mode |i_CTRL-X| completion

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -524,6 +524,8 @@ EXTERN pos_T VIsual;
 EXTERN int VIsual_active INIT(= false);
 /// Whether Select mode is active.
 EXTERN int VIsual_select INIT(= false);
+/// Restart Select mode when next cmd finished
+EXTERN int restart_VIsual_select INIT(= 0);
 /// Whether to restart the selection after a Select-mode mapping or menu.
 EXTERN int VIsual_reselect;
 /// Type of Visual mode.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -92,8 +92,6 @@ static linenr_T resel_VIsual_line_count;        /* number of lines */
 static colnr_T resel_VIsual_vcol;               /* nr of cols or end col */
 static int VIsual_mode_orig = NUL;              /* saved Visual mode */
 
-static int restart_VIsual_select = 0;
-
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "normal.c.generated.h"

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -144,6 +144,9 @@ char *get_mode(void)
       buf[0] = (char)(VIsual_mode + 's' - 'v');
     } else {
       buf[0] = (char)VIsual_mode;
+      if (restart_VIsual_select) {
+        buf[1] = 's';
+      }
     }
   } else if (State == HITRETURN || State == ASKMORE || State == SETWSIZE
              || State == CONFIRM) {

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -534,6 +534,7 @@ func Test_mode()
   set complete=.
 
   inoremap <F2> <C-R>=Save_mode()<CR>
+  xnoremap <F2> <Cmd>call Save_mode()<CR>
 
   normal! 3G
   exe "normal i\<F2>\<Esc>"
@@ -645,6 +646,14 @@ func Test_mode()
   call assert_equal("\<C-S>", mode(1))
   call feedkeys("\<Esc>", 'xt')
 
+  " v_CTRL-O
+  exe "normal gh\<C-O>\<F2>\<Esc>"
+  call assert_equal("v-vs", g:current_modes)
+  exe "normal gH\<C-O>\<F2>\<Esc>"
+  call assert_equal("V-Vs", g:current_modes)
+  exe "normal g\<C-H>\<C-O>\<F2>\<Esc>"
+  call assert_equal("\<C-V>-\<C-V>s", g:current_modes)
+
   call feedkeys(":echo \<C-R>=Save_mode()\<C-U>\<CR>", 'xt')
   call assert_equal('c-c', g:current_modes)
   call feedkeys("gQecho \<C-R>=Save_mode()\<CR>\<CR>vi\<CR>", 'xt')
@@ -653,6 +662,7 @@ func Test_mode()
 
   bwipe!
   iunmap <F2>
+  xunmap <F2>
   set complete&
 endfunc
 


### PR DESCRIPTION
Problem:    mode() does not indicate using CTRL-O in Select mode.
Solution:   Use "vs" and similar. (closes vim/vim#8640)
https://github.com/vim/vim/commit/eaf3f36168f85c8e0ab7083cd996b9fbe937045d