### PR TITLE
fix(codelens): Properly check for nil bufnr

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -9,7 +9,7 @@ local active_refreshes = {}
 --- bufnr -> client_id -> lenses
 local lens_cache_by_buf = setmetatable({}, {
   __index = function(t, b)
-    local key = b > 0 and b or api.nvim_get_current_buf()
+    local key = (b and b > 0) and b or api.nvim_get_current_buf()
     return rawget(t, key)
   end
 })


### PR DESCRIPTION
Fixes vim.lsp.codelens.get() on rust projects

If b is nil then the function would error out, but it works fine now.
