### PR TITLE
feat: add CursorLineSign and CursorLineFold highlights

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -47,6 +47,9 @@ The color of the column is set with the SignColumn highlight group
 
 	:highlight SignColumn guibg=darkgrey
 <
+If 'cursorline' is enabled, then the CursorLineSign highlight group is used
+|hl-CursorLineSign|.
+
 							*sign-identifier*
 Each placed sign is identified by a number called the sign identifier. This
 identifier is used to jump to the sign or to remove the sign. The identifier
@@ -130,6 +133,10 @@ See |sign_define()| for the equivalent Vim script function.
 
 	texthl={group}
 		Highlighting group used for the text item.
+
+	culhl={group}
+		Highlighting group used for the text item when the cursor is
+		on the same line as the sign and 'cursorline' is enabled.
 
 	Example: >
 		:sign define MySign text=>> texthl=Search linehl=DiffText
@@ -380,6 +387,9 @@ sign_define({list})
 		   numhl	highlight group used for 'number' column at the
 				associated line. Overrides |hl-LineNr|,
 				|hl-CursorLineNr|.
+		   culhl	highlight group used for the text item when
+				the cursor is on the same line as the sign and
+				'cursorline' is enabled.
 
 		If the sign named {name} already exists, then the attributes
 		of the sign are updated.
@@ -424,6 +434,9 @@ sign_getdefined([{name}])				*sign_getdefined()*
 		   numhl	highlight group used for 'number' column at the
 				associated line. Overrides |hl-LineNr|,
 				|hl-CursorLineNr|.
+		   culhl	highlight group used for the text item when
+				the cursor is on the same line as the sign and
+				'cursorline' is enabled.
 
 		Returns an empty List if there are no signs and when {name} is
 		not found.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5060,7 +5060,6 @@ IncSearch	'incsearch' highlighting; also used for the text replaced with
 		":s///c"
 							*hl-Substitute*
 Substitute	|:substitute| replacement text highlighting
-
 							*hl-LineNr*
 LineNr		Line number for ":number" and ":#" commands, and when 'number'
 		or 'relativenumber' option is set.
@@ -5068,6 +5067,10 @@ LineNr		Line number for ":number" and ":#" commands, and when 'number'
 CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt' is
 		set to "number" or "both", or 'relativenumber' is set, for
 		the cursor line.
+							*hl-CursorLineSign*
+CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
+							*hl-CursorLineFold*
+CursorLineFold	Like FoldColumn when 'cursorline' is set for the cursor line.
 							*hl-MatchParen*
 MatchParen	The character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -64,6 +64,8 @@ typedef enum {
   , HLF_CM          // Mode (e.g., "-- INSERT --")
   , HLF_N           // line number for ":number" and ":#" commands
   , HLF_CLN         // current line number
+  , HLF_CLS         // current line sign column
+  , HLF_CLF         // current line fold
   , HLF_R           // return to continue message and yes/no questions
   , HLF_S           // status lines
   , HLF_SNC         // status lines of not-current windows
@@ -119,6 +121,8 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_CM] = "ModeMsg",
   [HLF_N] = "LineNr",
   [HLF_CLN] = "CursorLineNr",
+  [HLF_CLS] = "CursorLineSign",
+  [HLF_CLF] = "CursorLineFold",
   [HLF_R] = "Question",
   [HLF_S] = "StatusLine",
   [HLF_SNC] = "StatusLineNC",

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2697,7 +2697,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
           p_extra = p_extra_free;
           c_extra = NUL;
           c_final = NUL;
-          if (wp->w_p_cul && lnum == wp->w_cursor.lnum) {
+          if (wp->w_p_cul && *wp->w_p_culopt != 'l'
+              && lnum == wp->w_cursor.lnum) {
             char_attr = win_hl_attr(wp, HLF_CLF);
           } else {
             char_attr = win_hl_attr(wp, HLF_FC);
@@ -4487,7 +4488,7 @@ static void get_sign_display_info(
   if (nrcol) {
     *n_extrap = number_width(wp) + 1;
   } else {
-    if (wp->w_p_cul && wp->w_cursor.lnum == lnum) {
+    if (wp->w_p_cul && *wp->w_p_culopt != 'l' && wp->w_cursor.lnum == lnum) {
       *char_attrp = win_hl_attr(wp, HLF_CLS);
     } else {
       *char_attrp = win_hl_attr(wp, HLF_SC);
@@ -4532,7 +4533,8 @@ static void get_sign_display_info(
         }
       }
 
-      if (wp->w_p_cul && wp->w_cursor.lnum == lnum && sattr->sat_culhl > 0) {
+      if (wp->w_p_cul && *wp->w_p_culopt != 'l' && wp->w_cursor.lnum == lnum
+          && sattr->sat_culhl > 0) {
         *char_attrp = sattr->sat_culhl;
       } else {
         *char_attrp = sattr->sat_texthl;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2697,7 +2697,11 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
           p_extra = p_extra_free;
           c_extra = NUL;
           c_final = NUL;
-          char_attr = win_hl_attr(wp, HLF_FC);
+          if (wp->w_p_cul && lnum == wp->w_cursor.lnum) {
+            char_attr = win_hl_attr(wp, HLF_CLF);
+          } else {
+            char_attr = win_hl_attr(wp, HLF_FC);
+          }
         }
       }
 
@@ -2709,7 +2713,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
           int count = win_signcol_count(wp);
           if (count > 0) {
               get_sign_display_info(
-                  false, wp, sattrs, row,
+                  false, wp, sattrs, lnum, row,
                   startrow, filler_lines, filler_todo, count,
                   &c_extra, &c_final, extra, sizeof(extra),
                   &p_extra, &n_extra,
@@ -2731,7 +2735,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
               && num_signs > 0) {
             int count = win_signcol_count(wp);
             get_sign_display_info(
-                true, wp, sattrs, row,
+                true, wp, sattrs, lnum, row,
                 startrow, filler_lines, filler_todo, count,
                 &c_extra, &c_final, extra, sizeof(extra),
                 &p_extra, &n_extra,
@@ -4460,6 +4464,7 @@ static void get_sign_display_info(
     bool nrcol,
     win_T *wp,
     sign_attrs_T sattrs[],
+    int lnum,
     int row,
     int startrow,
     int filler_lines,
@@ -4482,7 +4487,11 @@ static void get_sign_display_info(
   if (nrcol) {
     *n_extrap = number_width(wp) + 1;
   } else {
-    *char_attrp = win_hl_attr(wp, HLF_SC);
+    if (wp->w_p_cul && wp->w_cursor.lnum == lnum) {
+      *char_attrp = win_hl_attr(wp, HLF_CLS);
+    } else {
+      *char_attrp = win_hl_attr(wp, HLF_SC);
+    }
     *n_extrap = win_signcol_width(wp);
   }
 
@@ -4522,7 +4531,12 @@ static void get_sign_display_info(
           (*pp_extra)[*n_extrap] = NUL;
         }
       }
-      *char_attrp = sattr->sat_texthl;
+
+      if (wp->w_p_cul && wp->w_cursor.lnum == lnum && sattr->sat_culhl > 0) {
+        *char_attrp = sattr->sat_culhl;
+      } else {
+        *char_attrp = sattr->sat_texthl;
+      }
     }
   }
 

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -33,7 +33,8 @@ struct sign
     int         sn_line_hl;     // highlight ID for line
     int         sn_text_hl;     // highlight ID for text
     int         sn_num_hl;      // highlight ID for line number
-    int         sn_cul_hl;      // highlight ID for text on current line when 'cursorline' is set
+    int         sn_cul_hl;      // highlight ID for text on current line when
+                                // 'cursorline' is set
 };
 
 static sign_T *first_sign = NULL;

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -37,6 +37,7 @@ typedef struct sign_attrs_S {
     int     sat_typenr;
     char_u *sat_text;
     int     sat_texthl;
+    int     sat_culhl;
     int     sat_linehl;
     int     sat_numhl;
 } sign_attrs_T;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6039,6 +6039,8 @@ static const char *highlight_init_both[] = {
   "default link MsgSeparator StatusLine",
   "default link NormalFloat Pmenu",
   "default link FloatBorder VertSplit",
+  "default link CursorLineSign SignColumn",
+  "default link CursorLineFold FoldColumn",
   "default FloatShadow blend=80 guibg=Black",
   "default FloatShadowThrough blend=100 guibg=Black",
   "RedrawDebugNormal cterm=reverse gui=reverse",

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -41,6 +41,7 @@ describe("folded lines", function()
         [9] = {bold = true, foreground = Screen.colors.Brown},
         [10] = {background = Screen.colors.LightGrey, underline = true},
         [11] = {bold=true},
+        [12] = {background = Screen.colors.Grey90},
       })
     end)
 
@@ -80,6 +81,117 @@ describe("folded lines", function()
           {1:~                                            }|
           {1:~                                            }|
                                                        |
+        ]])
+      end
+    end)
+
+    it("highlights with CursorLineFold when 'cursorline' is set", function()
+      command("set cursorline foldcolumn=2 foldmethod=marker")
+      command("hi link CursorLineFold Search")
+      insert(content1)
+      feed("zf3j")
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:  }This is a                                  |
+          {7:  }valid English                              |
+          {7:  }sentence composed by                       |
+          {7:  }an exhausted developer                     |
+          {7:  }in his cave.                               |
+          {6:  }{12:^                                           }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+        {7:  }This is a                                  |
+        {7:  }valid English                              |
+        {7:  }sentence composed by                       |
+        {7:  }an exhausted developer                     |
+        {7:  }in his cave.                               |
+        {6:  }{12:^                                           }|
+        {1:~                                            }|
+                                                     |
+        ]])
+      end
+      feed("k")
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:  }This is a                                  |
+          {7:  }valid English                              |
+          {7:  }sentence composed by                       |
+          {7:  }an exhausted developer                     |
+          {6:  }{12:^in his cave.                               }|
+          {7:  }                                           |
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+        {7:  }This is a                                  |
+        {7:  }valid English                              |
+        {7:  }sentence composed by                       |
+        {7:  }an exhausted developer                     |
+        {6:  }{12:^in his cave.                               }|
+        {7:  }                                           |
+        {1:~                                            }|
+                                                     |
+        ]])
+      end
+      command("set cursorlineopt=line")
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:  }This is a                                  |
+          {7:  }valid English                              |
+          {7:  }sentence composed by                       |
+          {7:  }an exhausted developer                     |
+          {7:  }{12:^in his cave.                               }|
+          {7:  }                                           |
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+        {7:  }This is a                                  |
+        {7:  }valid English                              |
+        {7:  }sentence composed by                       |
+        {7:  }an exhausted developer                     |
+        {7:  }{12:^in his cave.                               }|
+        {7:  }                                           |
+        {1:~                                            }|
+                                                     |
         ]])
       end
     end)

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -157,6 +157,99 @@ describe('Signs', function()
       ]])
     end)
 
+    it('higlights the cursorline sign with culhl', function()
+      feed('ia<cr>b<cr>c<esc>')
+      command('sign define piet text=>> texthl=Search culhl=ErrorMsg')
+      command('sign place 1 line=1 name=piet buffer=1')
+      command('sign place 2 line=2 name=piet buffer=1')
+      command('sign place 3 line=3 name=piet buffer=1')
+      command('set cursorline')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {1:>>}b                                                  |
+        {8:>>}{3:^c                                                  }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      feed('k')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {8:>>}{3:^b                                                  }|
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set nocursorline')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {1:>>}^b                                                  |
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set cursorline cursorlineopt=line')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {1:>>}{3:^b                                                  }|
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set cursorlineopt=number')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {8:>>}^b                                                  |
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+    end)
+
     it('multiple signs #9295', function()
       feed('ia<cr>b<cr>c<cr><esc>')
       command('set number')


### PR DESCRIPTION
CursorLineSign and CursorLineFold are similar to CursorLineNr, but apply to the sign and fold columns, respectively.

Add a new attribute to the `sign_define()` function, "culhl", that defines the highlight used for the sign when the cursor is on the same line and the 'cursorline' setting is enabled.

Closes #14473.
