### PR TITLE
perf(lua): optimize vim.deep_equal

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1210,7 +1210,17 @@ schedule_wrap({cb})                                      *vim.schedule_wrap()*
 
 
 deep_equal({a}, {b})                                        *vim.deep_equal()*
-                TODO: Documentation
+                Deep compare values for equality
+
+                Tables are compared recursively unless they both provide the `eq` methamethod.
+                All other types are compared using the equality `==` operator.
+
+                Parameters: ~
+                    {a}  first value
+                    {b}  second value
+
+                Return: ~
+                    `true` if values are equals, else `false` .
 
 deepcopy({orig})                                              *vim.deepcopy()*
                 Returns a deep copy of the given object. Non-table objects are

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -267,6 +267,12 @@ function vim.tbl_deep_extend(behavior, ...)
 end
 
 --- Deep compare values for equality
+---
+--- Tables are compared recursively unless they both provide the `eq` methamethod.
+--- All other types are compared using the equality `==` operator.
+--@param a first value
+--@param b second value
+--@returns `true` if values are equals, else `false`.
 function vim.deep_equal(a, b)
   if a == b then return true end
   if type(a) ~= type(b) then return false end

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -270,9 +270,9 @@ end
 ---
 --- Tables are compared recursively unless they both provide the `eq` methamethod.
 --- All other types are compared using the equality `==` operator.
---@param a first value
---@param b second value
---@returns `true` if values are equals, else `false`.
+---@param a first value
+---@param b second value
+---@returns `true` if values are equals, else `false`.
 function vim.deep_equal(a, b)
   if a == b then return true end
   if type(a) ~= type(b) then return false end

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -271,14 +271,13 @@ function vim.deep_equal(a, b)
   if a == b then return true end
   if type(a) ~= type(b) then return false end
   if type(a) == 'table' then
-    -- TODO improve this algorithm's performance.
     for k, v in pairs(a) do
       if not vim.deep_equal(v, b[k]) then
         return false
       end
     end
-    for k, v in pairs(b) do
-      if not vim.deep_equal(v, a[k]) then
+    for k, _ in pairs(b) do
+      if a[k] == nil then
         return false
       end
     end


### PR DESCRIPTION
By remembering the keys already compared in a, repeating comparisons is avoided. Thanks: https://stackoverflow.com/a/32660766

I've also added documentation. 