### PR TITLE
ci: disable false "footer-leading-blank" warning from commitlint

### DIFF
--- a/.github/workflows/commitlint.config_patch.js
+++ b/.github/workflows/commitlint.config_patch.js
@@ -5,7 +5,6 @@ module.exports = {
 	rules: {
 		'body-leading-blank': [1, 'always'],
 		'body-max-line-length': [2, 'always', 100],
-		'footer-leading-blank': [1, 'always'],
 		'footer-max-line-length': [2, 'always', 100],
 		'scope-case': [2, 'always', 'lower-case'],
 		'subject-case': [


### PR DESCRIPTION
It directly interferes with how the vim-patches are formatted. I think it's best to simply disable the warning.