### PR TITLE
vim-patch:8.2.2938: after using motion force from feedkeys() it sticks

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3277,6 +3277,7 @@ static void clearop(oparg_T *oap)
   oap->regname = 0;
   oap->motion_force = NUL;
   oap->use_reg_one = false;
+  motion_force = NUL;
 }
 
 static void clearopbeep(oparg_T *oap)

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -861,6 +861,15 @@ func Test_visual_block_mode()
   set tabstop& shiftwidth&
 endfunc
 
+func Test_visual_force_motion_feedkeys()
+    onoremap <expr> i- execute('let g:mode = mode(1)')
+    call feedkeys('dvi-', 'x')
+    call assert_equal('nov', g:mode)
+    call feedkeys('di-', 'x')
+    call assert_equal('no', g:mode)
+    ounmap i-
+endfunc
+
 " Test block-insert using cursor keys for movement
 func Test_visual_block_insert_cursor_keys()
   new


### PR DESCRIPTION
Problem:   After using motion force from feedkeys() it may not be reset.
Solution:   Clear motion_force in clearop().

issue: https://github.com/vim/vim/issues/8323
vim-patch:https://github.com/vim/vim/commit/21492743e80c6740bac65a91311c28bede8ef2f8



