### PR TITLE
test: fix hangup in server_notifications_spec.lua

### DIFF
--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -5,7 +5,7 @@ local eq, clear, eval, command, nvim, next_msg =
 local meths = helpers.meths
 local exec_lua = helpers.exec_lua
 local retry = helpers.retry
-local isCI = helpers.isCI
+local sleep = helpers.sleep
 
 describe('notify', function()
   local channel
@@ -77,10 +77,6 @@ describe('notify', function()
   end)
 
   it('cancels stale events on channel close', function()
-      if isCI() then
-        pending('Sporadic hangs on CI (c.f., #14083). Skip until it is fixed.')
-        return
-      end
     if helpers.pending_win32(pending) then return end
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")
     eq({id=catchan, stream='job', mode='rpc', client = {}}, exec_lua ([[
@@ -89,6 +85,7 @@ describe('notify', function()
       return vim.api.nvim_get_chan_info(...)
     ]], catchan))
     eq(2, eval('1+1'))  -- Still alive?
+    sleep(1)
     eq({false, 'Invalid channel: '..catchan},
       exec_lua ([[ return {pcall(vim.rpcrequest, ..., 'nvim_eval', '1+1')}]], catchan))
     retry(nil, 3000, function() eq({}, meths.get_chan_info(catchan)) end) -- cat be dead :(


### PR DESCRIPTION
functionaltest hangups at the last test in server_notifications_spec.lua: 'cancels stale events on channel close'. The test was added on Dec 15, 2020, but stated to hang-up recently (I don't know why). It seems a possible fix (or workaround?) is to add a sleep() as in this PR. Many CI tests are failing due to this problem.
