### PR TITLE
refactor: increase line length limit to 100 characters

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 BasedOnStyle:  Google
 Language: Cpp
-ColumnLimit: 80
+ColumnLimit: 100
 IndentWidth: 2
 TabWidth: 2
 UseTab: Never

--- a/src/clint.py
+++ b/src/clint.py
@@ -264,7 +264,7 @@ _error_suppressions_2 = set()
 
 # The allowed line length of files.
 # This is set by --linelength flag.
-_line_length = 80
+_line_length = 100
 
 # The allowed extensions for file names
 # This is set by --extensions flag.


### PR DESCRIPTION
Let's leave the crusty dusty 80 character limit and embrace the new 120 limit neovim-style.