### PR TITLE
fixed typo

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -284,7 +284,7 @@ for those who want to experiment with this feature and contribute to
 its development.
 
 Highlights are defined in the same query format as in the tree-sitter highlight
-crate, which some limitations and additions. Set a highlight query for a
+crate, with some limitations and additions. Set a highlight query for a
 buffer with this code: >
 
     local query = [[


### PR DESCRIPTION
```diff
  Highlights are defined in the same query format as in the tree-sitter highlight
- crate, which some limitations and additions. Set a highlight query for a
+ crate, with some limitations and additions. Set a highlight query for a
  buffer with this code: >
```