### PR TITLE
treesitter config: query_file_ignore

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -350,6 +350,20 @@ individual query pattern manually by setting its `"priority"` metadata attribute
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*
 
+config({opts}, {scope})                                             *config()*
+                Configure treesitter options globally or for a specific lang.
+
+                Parameters: ~
+                    {opts}   table Configuration table with the following
+                             keys:
+                             • query_file_ignore: List of string patterns. If
+                               the path of query file matches any of the
+                               patterns in this list, it will be ignored.
+                    {scope}  number|string|nil Update the opts for the given
+                             scope. The opts will be updated for specific
+                             buffer (number) or specific language (string) or
+                             any language (nil).
+
 get_parser({bufnr}, {lang}, {opts})                             *get_parser()*
                 Gets the parser for this bufnr / ft combination.
 

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -1,4 +1,5 @@
 local a = vim.api
+local config = require'vim.treesitter.config'
 local query = require'vim.treesitter.query'
 local language = require'vim.treesitter.language'
 local LanguageTree = require'vim.treesitter.languagetree'
@@ -26,6 +27,24 @@ setmetatable(M, {
       end
    end
  })
+
+--- Configure treesitter options globally or for a specific lang.
+---
+---@param opts table Configuration table with the following keys:
+---       - query_file_ignore: List of string patterns. If the path of query
+---                            file matches any of the patterns in this list,
+---                            it will be ignored.
+---@param scope number|string|nil Update the opts for the given scope. The opts
+---                               will be updated for specific buffer (number)
+---                               or specific language (string) or any language
+---                               (nil).
+function M.config(opts, scope)
+  if not opts then
+    return config.get(scope)
+  end
+
+  return config.set(opts, scope)
+end
 
 --- Creates a new parser.
 ---

--- a/runtime/lua/vim/treesitter/config.lua
+++ b/runtime/lua/vim/treesitter/config.lua
@@ -1,0 +1,109 @@
+local M = {}
+
+local initial_config = {
+  query_file_ignore = {},
+}
+
+local config_buf_var_name = "_treesitter_config"
+local config_by_lang = {
+  ["*"] = vim.deepcopy(initial_config),
+}
+
+
+local validate_argmap = {
+  query_file_ignore = {
+    "table",
+    true,
+  },
+}
+
+---@private
+local function validate_config(key, value)
+  if not validate_argmap[key] then
+    error(string.format("invalid treesitter option: %s", key))
+    return
+  end
+
+  vim.validate({
+    [key] = {
+      value,
+      validate_argmap[key][1],
+      validate_argmap[key][2],
+    },
+  })
+
+  return value
+end
+
+---@private
+local function get_config_for_buf(bufnr)
+  local ok, result = pcall(vim.api.nvim_buf_get_var, bufnr, config_buf_var_name)
+  if ok then
+    return result or {}
+  end
+  return {}
+end
+
+---@private
+local function set_config_for_buf(bufnr, config)
+  vim.api.nvim_buf_set_var(bufnr, config_buf_var_name, config)
+end
+
+---@private
+local function get_config_for_lang(lang)
+  if not config_by_lang[lang] then
+    config_by_lang[lang] = {}
+  end
+  return config_by_lang[lang]
+end
+
+---@private
+local function set_config_for_lang(lang, config)
+  config_by_lang[lang] = config
+end
+
+---@private
+function M.get(lang, bufnr)
+  local language = type(lang) == "string" and lang or vim.bo.filetype
+  local config = vim.tbl_extend(
+    "keep",
+    get_config_for_buf(bufnr or 0),
+    get_config_for_lang(language),
+    get_config_for_lang("*")
+  )
+  return config
+end
+
+---@private
+function M.set(options, scope)
+  local config
+
+  local bufnr = type(scope) == "number" and scope or nil
+  local lang = bufnr and nil or (scope or "*")
+
+  if bufnr then
+    config = get_config_for_buf(bufnr)
+  else
+    config = get_config_for_lang(lang)
+  end
+
+  for key, value in pairs(options) do
+    local resolved_value
+
+    if type(value) == "function" then
+      resolved_value = value(config[key] or vim.deepcopy(initial_config[key]))
+    else
+      resolved_value = value
+    end
+
+    config[key] = validate_config(key, resolved_value)
+  end
+
+  if bufnr then
+    set_config_for_buf(bufnr, config)
+  else
+    set_config_for_lang(lang, config)
+  end
+end
+
+return M

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -1,0 +1,59 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+
+before_each(clear)
+
+describe('vim.treesitter.get_query_files', function()
+  it('returns query files for specific language', function()
+    exec_lua [[
+      query_files = vim.treesitter.get_query_files('c', 'highlights')
+    ]]
+    eq(1, exec_lua "return #query_files")
+  end)
+
+  it('respects config: query_file_ignore', function()
+    -- adding ignore pattern
+    exec_lua [[
+      vim.treesitter.config({
+        query_file_ignore = { "/runtime/" }
+      }, "c")
+      query_files = vim.treesitter.get_query_files('c', 'highlights')
+    ]]
+    eq(0, exec_lua "return #query_files")
+
+    -- removing ignore pattern
+    exec_lua [[
+      vim.treesitter.config({
+        query_file_ignore = {}
+      }, "c")
+      query_files = vim.treesitter.get_query_files('c', 'highlights')
+    ]]
+    eq(1, exec_lua "return #query_files")
+
+    -- adding ignore pattern (using callback function)
+    exec_lua [[
+      vim.treesitter.config({
+        query_file_ignore = function(patterns)
+          table.insert(patterns, "/runtime/")
+          return patterns
+        end
+      }, "c")
+      query_files = vim.treesitter.get_query_files('c', 'highlights')
+    ]]
+    eq(0, exec_lua "return #query_files")
+
+    -- removing ignore pattern (using callback function)
+    exec_lua [[
+      vim.treesitter.config({
+        query_file_ignore = function(patterns)
+          return nil
+        end
+      }, "c")
+      query_files = vim.treesitter.get_query_files('c', 'highlights')
+    ]]
+    eq(1, exec_lua "return #query_files")
+  end)
+end)


### PR DESCRIPTION
resolves #15244

## Description

- Introduces `vim.treesitter.config` method. It is used for updating configuration options for treesitter.
- Introduces treesitter configuration option: `query_file_ignore`

## Usage

### Usage: `vim.treesitter.config(options, scope)`

Treesitter config can be set for these:
- for any language
- for a specific language
- for a specific buffer

**set config for a specific buffer**

```lua
vim.treesitter.config({
  query_file_ignore = {},
}, 0)
```

**set config for a specific language**

```lua
vim.treesitter.config({
  query_file_ignore = {},
}, "lua")
```

**set config for any language**

```lua
vim.treesitter.config({
  query_file_ignore = {},
})
```

### Usage: config `query_file_ignore`

_Lua string pattern: https://www.lua.org/pil/20.2.html_

**Ignore all query files from a specific plugin**:

```lua
vim.treesitter.config({
  query_file_ignore = { "/nvim%-treesitter/" },
}, "lua")
```

**Ignore specific query file from a specific plugin**:

```lua
vim.treesitter.config({
  query_file_ignore = { "/nvim%-treesitter/.+/indents.scm" },
}, "lua")
```

**Ignore all query files from all plugins**:

```lua
vim.treesitter.config({
  query_file_ignore = { ".+" },
}, "lua")
```

**Add/Remove a specific ignore file pattern**:

```lua
vim.treesitter.config({
  query_file_ignore = function(patterns)
    table.insert(patterns, "/nvim%-treesitter/") -- or filter it out to remove
    return patterns
  end,
}, "lua")
```

**Clear all ignore file patterns**:

```lua
vim.treesitter.config({
  query_file_ignore = {},
}, "lua")
-- or
vim.treesitter.config({
  query_file_ignore = function(patterns)
    return nil
  end,
}, "lua")
```