### PR TITLE
fix(lsp): expose ContentModified error code to callbacks

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -531,14 +531,11 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
       -- We sent a number, so we expect a number.
       local result_id = tonumber(decoded.id)
 
-      -- Do not surface RequestCancelled or ContentModified to users, it is RPC-internal.
+      -- Do not surface RequestCancelled to users, it is RPC-internal.
       if decoded.error then
         local mute_error = false
         if decoded.error.code == protocol.ErrorCodes.RequestCancelled then
           local _ = log.debug() and log.debug("Received cancellation ack", decoded)
-          mute_error = true
-        elseif decoded.error.code == protocol.ErrorCodes.ContentModified then
-          local _ = log.debug() and log.debug("Received content modified ack", decoded)
           mute_error = true
         end
 

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -163,6 +163,35 @@ function tests.capabilities_for_client_supports_method()
   }
 end
 
+function tests.check_forward_request_cancelled()
+  skeleton {
+    on_init = function(_)
+      return { capabilities = {} }
+    end;
+    body = function()
+      expect_request("error_code_test", function()
+        return {code = -32800}, nil
+      end)
+      notify('finish')
+    end;
+  }
+end
+
+function tests.check_forward_content_modified()
+  skeleton {
+    on_init = function(_)
+      return { capabilities = {} }
+    end;
+    body = function()
+      expect_request("error_code_test", function()
+        return {code = -32801}, nil
+      end)
+      expect_notification('finish')
+      notify('finish')
+    end;
+  }
+end
+
 function tests.basic_finish()
   skeleton {
     on_init = function(params)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -478,6 +478,54 @@ describe('LSP', function()
       }
     end)
 
+    it('should not forward RequestCancelled to callback', function()
+      local expected_handlers = {
+        {NIL, "finish", {}, 1};
+      }
+      local client
+      test_rpc_server {
+        test_name = "check_forward_request_cancelled";
+        on_init = function(_client)
+          _client.request("error_code_test")
+          client = _client
+        end;
+        on_exit = function(code, signal)
+          eq(0, code, "exit code", fake_lsp_logfile)
+          eq(0, signal, "exit signal", fake_lsp_logfile)
+          eq(0, #expected_handlers, "did not call expected handler")
+        end;
+        on_handler = function(err, method, ...)
+          eq(table.remove(expected_handlers), {err, method, ...}, "expected handler")
+          if method == 'finish' then client.stop() end
+        end;
+      }
+    end)
+
+    it('should forward ContentModified to callback', function()
+      local expected_handlers = {
+        {NIL, "finish", {}, 1};
+        {{code = -32801}, "error_code_test", NIL, 1, NIL};
+      }
+      local client
+      test_rpc_server {
+        test_name = "check_forward_content_modified";
+        on_init = function(_client)
+          _client.request("error_code_test")
+          client = _client
+        end;
+        on_exit = function(code, signal)
+          eq(0, code, "exit code", fake_lsp_logfile)
+          eq(0, signal, "exit signal", fake_lsp_logfile)
+          eq(0, #expected_handlers, "did not call expected handler")
+        end;
+        on_handler = function(err, method, ...)
+          eq(table.remove(expected_handlers), {err, method, ...}, "expected handler")
+          if method == 'error_code_test' then client.notify("finish") end
+          if method == 'finish' then client.stop() end
+        end;
+      }
+    end)
+
     it('should not send didOpen if the buffer closes before init', function()
       local expected_handlers = {
         {NIL, "shutdown", {}, 1};


### PR DESCRIPTION
Currently LSP RPC clears the callback on `ContentModified` error code, considering this "RPC internal". We would like to argue that this isn't completely the case, as the [LSP specification claims that "clients can resend the request if they know how to"](https://microsoft.github.io/language-server-protocol/specification#implementationConsiderations). It's currently being used by the [Lean 4 VSCode extension](https://github.com/leanprover-community/vscode-lean4/blob/d5f1926be34e73af23d551be779a5b98e721e0ba/lean4-infoview/src/infoview/info.tsx#L246), which we're trying to replicate over at Julian/lean.nvim#108.

Also, let me know if these tests look alright!