### PR TITLE
vim-patch:gpg,gpg,gpg,gpg,8.1.0342,gpg,gpg,gpg,gpg,8.1.0342,gpg,gpg,gpg,gpg,8.0.1732

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -391,6 +391,27 @@ bool buf_valid(buf_T *buf)
   return false;
 }
 
+/// Give an error message  when the buffer is locked or the
+/// screen is being redrawn and the buffer is in a window.
+///
+///@returns Wether the buffer can be unloaded.
+static int can_unload_buffer(buf_T *buf)
+{
+  int can_unload = !buf->b_locked;
+
+  if (can_unload && updating_screen) {
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
+      if (wp->w_buffer == buf) {
+        can_unload = FALSE;
+      }
+    }
+  }
+  if (!can_unload)
+    EMSG(_("E937: Attempt to delete a buffer that is in use"));
+  return can_unload;
+}
+
+
 /// Close the link to a buffer.
 ///
 /// @param win    If not NULL, set b_last_cursor.
@@ -445,8 +466,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last)
 
   // Disallow deleting the buffer when it is locked (already being closed or
   // halfway a command that relies on it). Unloading is allowed.
-  if (buf->b_locked > 0 && (del_buf || wipe_buf)) {
-    EMSG(_("E937: Attempt to delete a buffer that is in use"));
+  if ((del_buf || wipe_buf) && !can_unload_buffer(buf)) {
     return false;
   }
 
@@ -1211,6 +1231,11 @@ do_buffer(
   if (unload) {
     int forward;
     bufref_T bufref;
+
+    if (!can_unload_buffer(buf)) {
+      return FAIL;
+    }
+
     set_bufref(&bufref, buf);
 
     /* When unloading or deleting a buffer that's already unloaded and

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -295,7 +295,10 @@ void terminal_close(Terminal *term, char *msg)
   }
 
   if (buf) {
+    aco_save_T aco;
+    aucmd_prepbuf(&aco, buf);
     apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
+    aucmd_restbuf(&aco);
   }
 }
 


### PR DESCRIPTION
gpg: Signature made Wed 04 Aug 2021 11:53:05 AM CEST
gpg:                using RSA key D9AFCB795A02046B2A8E7BEB16A6001CD57B9100
gpg: Good signature from "Thomas Vigouroux <tomvig38@gmail.com>" [ultimate]
gpg:                 aka "Thomas Vigouroux <thomas.vigouroux@grenoble-inp.org>" [ultimate]
#### vim-patch:8.1.0342: crash when a callback deletes a window that is being used

Problem:    Crash when a callback deletes a window that is being used.
Solution:   Do not unload a buffer that is being displayed while redrawing the
            screen. Also avoid invoking callbacks while redrawing.
            (closes vim/vim#2107)
https://github.com/vim/vim/commit/94f01956a583223dafe24135489d0ab1100ab0ad


gpg: Signature made Wed 04 Aug 2021 11:53:05 AM CEST
gpg:                using RSA key D9AFCB795A02046B2A8E7BEB16A6001CD57B9100
gpg: Good signature from "Thomas Vigouroux <tomvig38@gmail.com>" [ultimate]
gpg:                 aka "Thomas Vigouroux <thomas.vigouroux@grenoble-inp.org>" [ultimate]
#### vim-patch:8.1.0342: crash when a callback deletes a window that is being used

Problem:    Crash when a callback deletes a window that is being used.
Solution:   Do not unload a buffer that is being displayed while redrawing the
            screen. Also avoid invoking callbacks while redrawing.
            (closes vim/vim#2107)
https://github.com/vim/vim/commit/94f01956a583223dafe24135489d0ab1100ab0ad


gpg: Signature made Wed 04 Aug 2021 11:53:06 AM CEST
gpg:                using RSA key D9AFCB795A02046B2A8E7BEB16A6001CD57B9100
gpg: Good signature from "Thomas Vigouroux <tomvig38@gmail.com>" [ultimate]
gpg:                 aka "Thomas Vigouroux <thomas.vigouroux@grenoble-inp.org>" [ultimate]
#### vim-patch:8.0.1732: crash when terminal API call deletes the buffer

Problem:    Crash when terminal API call deletes the buffer.
Solution:   Lock the buffer while calling a function. (closes vim/vim#2813)
https://github.com/vim/vim/commit/a997b45c7e350ea5b378ca0c52ed3d4cc610975c