### PR TITLE
Fix #10386

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -348,11 +348,17 @@ void terminal_close(Terminal **termpp, int status)
 
   if (buf && !is_autocmd_blocked()) {
     save_v_event_T save_v_event;
+    aco_save_T aco;
+
     dict_T *dict = get_v_event(&save_v_event);
     tv_dict_add_nr(dict, S_LEN("status"), status);
     tv_dict_set_keys_readonly(dict);
+    aucmd_prepbuf(&aco, buf);
+
     apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
     restore_v_event(dict, &save_v_event);
+
+    aucmd_restbuf(&aco);
   }
 }
 

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -235,6 +235,13 @@ describe(':terminal buffer', function()
     feed_command('bdelete!')
   end)
 
+  it("does not free curbuf of exit ##10386", function()
+    feed_command "autocmd TermClose * bd!"
+    feed_command "terminal"
+    feed_command "bd!"
+    assert_alive()
+  end)
+
   describe('handles confirmations', function()
     it('with :confirm', function()
       feed_command('terminal')


### PR DESCRIPTION
Fixes #10386, using vim-patches and help from [this commit](https://github.com/bkoropoff/neovim/commit/bcd2a8967b50680316230faa2920f4cda51d8b99) from @bkropoff.

Include a few vim patches:
- vim-patch:8.1.0342: crash when a callback deletes a window that is being used
- vim-patch:8.0.1732: crash when terminal API call deletes the buffer
