### PR TITLE
fix(uri): Windows paths should not be considered URIs

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -82,7 +82,8 @@ local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):.*'
 local function uri_from_bufnr(bufnr)
   local fname = vim.api.nvim_buf_get_name(bufnr)
   local scheme = fname:match(URI_SCHEME_PATTERN)
-  if scheme then
+  -- Windows paths should not be considered URIs
+  if scheme and scheme:len() > 1 then
     return fname
   else
     return uri_from_fname(fname)

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -158,6 +158,19 @@ describe('URI methods', function()
 
   end)
 
+  describe('uri from bufnr', function()
+    it('Windows paths should not be treated as uris', function()
+      if not helpers.iswin() then return end
+      local file = 'C:\foo\bar.txt'
+      local uri = 'file:/C:/foo/bar.txt'
+        local test_case = string.format([[
+          local file = '%s'
+          return vim.uri_from_bufnr(vim.fn.bufadd(file))
+        ]], file)
+        eq(uri, exec_lua(test_case))
+    end)
+  end)
+
   describe('uri to bufnr', function()
     it('uri_to_bufnr & uri_from_bufnr returns original uri for non-file uris', function()
       local uri = 'jdt://contents/java.base/java.util/List.class?=sql/%5C/home%5C/user%5C/.jabba%5C/jdk%5C/openjdk%5C@1.14.0%5C/lib%5C/jrt-fs.jar%60java.base=/javadoc_location=/https:%5C/%5C/docs.oracle.com%5C/en%5C/java%5C/javase%5C/14%5C/docs%5C/api%5C/=/%3Cjava.util(List.class'


### PR DESCRIPTION
Windows paths are essentially URIs with `\` delimited paths, which makes it difficult for us to distinguish them from genuine URIs based on pattern-matching alone. However, language servers expect file paths to be passed with file URIs. This is the simplest solution I could think of to exclude Windows paths from being considered valid URIs, although there are at least a couple of other options:
- Use `URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):[^\]*'`, on the assumption that genuine URIs will never contain a `\` -- I don't know if this is actually the case, though.
- Blindly check if `fname` is a file, which I presume would be too expensive.

Fixes #15261