### PR TITLE
fix!: make :runtime work as advertised

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -235,7 +235,6 @@ int do_in_runtimepath(char_u *name, int flags, DoInRuntimepathCB callback,
 /// return FAIL when no file could be sourced, OK otherwise.
 int source_runtime(char_u *name, int flags)
 {
-  flags |= (flags & DIP_NORTP) ? 0 : DIP_START;
   return source_in_path(p_rtp, name, flags);
 }
 


### PR DESCRIPTION
With no `[where]` argument, the `:runtime` command should only execute files directly under the user's 'runtimepath'. However, the flags are being modified to also search under the start directory within 'packpath' when there is no `[where]` argument. This breaks the contract of how :runtime is supposed to work according to the documentation and results in files being sourced when they shouldn't be.

The motivation behind modifying the flags was to allow users to access files under start directories from their init.vim or init.lua files; that is, _before_ packages had been loaded and added to the 'runtimepath'. However, Neovim already provides a mechanism to do this that aligns with documented and established behavior through the use of :packload and :packloadall.

Revert the flag modification to have :runtime again work as documented.

Closes #15272.