### PR TITLE
feat(lua): add vim.autoload

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -579,5 +579,26 @@ function vim.is_callable(f)
   return type(m.__call) == 'function'
 end
 
+--- Create a wrapper around {module} that defers loading until used
+---
+--- Use vim.autoload to create a reference to a module without loading it. The
+--- module will be loaded when it is accessed for the first time.
+---
+--- In many cases, this can be used as a drop-in replacement to `require`.
+---@param module Name of the Lua module to autoload
+function vim.autoload(module)
+  return setmetatable({}, {
+    __index = function(_, k)
+      return require(module)[k]
+    end,
+    __newindex = function(_, k, v)
+      require(module)[k] = v
+    end,
+    __call = function(_, ...)
+      require(module)(...)
+    end,
+  })
+end
+
 return vim
 -- vim:sw=2 ts=2 et


### PR DESCRIPTION
A problem faced by many Lua plugin authors is the fact that when you want to create an easier-to-use namespace to other Lua modules, you need to "require" those modules at the top level of your current module, e.g.

```lua
local foo = require("foo")
local bar = require("bar")
```

This needs to be done even if you don't use any of those modules until much later. This adds considerable startup time to Lua plugins as they need to essentially load the entirety of their codebase up front.

Contrast this to the autoload function concept of VimL, where functions are not even loaded until called.

Add a similar feature to the Neovim Lua stdlib that uses some metatable trickery to defer actually requiring the module until it's actually accessed. Our example above would become

```lua
local foo = vim.autoload("foo")
local bar = vim.autoload("bar")
```

This provides an easy interface into the 'foo' and 'bar' modules, but does not actually load either of these modules until one of the modules members is accessed, e.g.:

```lua
foo.doSomething()
```