### PR TITLE
ci(labeler): fix syntax so changes under src/nvim/lua are registered

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
 
 "lua":
   - runtime/lua/**/*
-  - src/nvim/lua
+  - src/nvim/lua/*
 
 "tui":
   - src/nvim/tui/tui.*


### PR DESCRIPTION
The labeler action requires a glob (*) to denote files under a
directory.