### PR TITLE
fix(sort): always call changed_lines

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -691,8 +691,10 @@ void ex_sort(exarg_T *eap)
                  count, 0, old_count,
                  lnum - eap->line2, 0, new_count, kExtmarkUndo);
 
-  if (change_occurred || deleted != 0) {
-    changed_lines(eap->line1, 0, eap->line2 + 1, -deleted, true);
+  bool modified = change_occurred || deleted != 0;
+  changed_lines(eap->line1, 0, eap->line2 + 1, -deleted, modified);
+  if (!modified) {
+    unchanged(curbuf, false, false);
   }
 
   curwin->w_cursor.lnum = eap->line1;


### PR DESCRIPTION
This forces to redraw ranges of lines that are changed, when using luahl.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1250.
