### PR TITLE
ci(labeler): add "tests" and "ci" labels to the labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,7 @@
 
 "documentation":
   - runtime/doc/*
+  - CONTRIBUTING.md
 
 "clipboard":
   - runtime/autoload/provider/clipboard.vim
@@ -47,3 +48,12 @@
   - CMakeLists.txt
   - "**/CMakeLists.txt"
   - "**/*.cmake"
+
+"tests":
+  - test/**/*
+
+"ci":
+  - .github/labeler.yml
+  - .github/workflows/**/*
+  - .builds/*
+  - ci/**/*


### PR DESCRIPTION
Also added "CONTRIBUTING.md" file under the "documentation" label since
it gets changed fairly often.