### PR TITLE
vim-patch:8.2.3285: scdoc filetype is not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1519,6 +1519,9 @@ au BufNewFile,BufRead *.sbt			setf sbt
 " Scilab
 au BufNewFile,BufRead *.sci,*.sce		setf scilab
 
+" scdoc
+au BufNewFile,BufRead *.scd			setf scdoc
+
 " SCSS
 au BufNewFile,BufRead *.scss			setf scss
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -431,6 +431,7 @@ let s:filename_checks = {
     \ 'scilab': ['file.sci', 'file.sce'],
     \ 'screen': ['.screenrc', 'screenrc'],
     \ 'sexplib': ['file.sexp'],
+    \ 'scdoc': ['file.scd'],
     \ 'scss': ['file.scss'],
     \ 'sd': ['file.sd'],
     \ 'sdc': ['file.sdc'],


### PR DESCRIPTION
Problem:    Scdoc filetype is not recognized.
Solution:   Add filetype detection. (Gregory Anders, closes vim/vim#8701)
https://github.com/vim/vim/commit/dd097bdc1376e4ca2cfd4a4d64021b6ba0df4bed
