### PR TITLE
fix(lsp): take offset_x into account when positioning floating popup

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -972,7 +972,7 @@ function M.make_floating_popup_options(width, height, opts)
     row = -get_border_size(opts).height
   end
 
-  if vim.fn.wincol() + width <= api.nvim_get_option('columns') then
+  if vim.fn.wincol() + width + (opts.offset_x or 0) <= api.nvim_get_option('columns') then
     anchor = anchor..'W'
     col = 0
   else


### PR DESCRIPTION
lsp_signature.nvim uses negative offset_x to align the signature preview to the function call. However, this negative offset is not taken into account when figuring out if the floating popup fits.

(this is my first PR, please let me know if something is missing!)

Thanks!