### PR TITLE
ci(labeler): refine labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,8 +35,7 @@
   - src/nvim/mouse*
 
 "documentation":
-  - runtime/doc/*
-  - CONTRIBUTING.md
+  - all: ["runtime/doc/*"]
 
 "clipboard":
   - runtime/autoload/provider/clipboard.vim


### PR DESCRIPTION
I haven't fleshed out all the rules, but basically I'm thinking the `documentation` label be applied if only documentation was changed without any code changes.