### PR TITLE
feat(api): allow arguments to be optional

### DIFF
--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -161,13 +161,10 @@ describe('luaeval(vim.api.…)', function()
        exc_exec([[call luaeval("vim.api.nvim__id({1, foo=42})")]]))
     eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Cannot convert given lua type',
        exc_exec([[call luaeval("vim.api.nvim__id({42, vim.api.nvim__id})")]]))
-    -- Errors in number of arguments
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 1 argument',
-       exc_exec([[call luaeval("vim.api.nvim__id()")]]))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 1 argument',
-       exc_exec([[call luaeval("vim.api.nvim__id(1, 2)")]]))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 2 arguments',
-       exc_exec([[call luaeval("vim.api.nvim_set_var(1, 2, 3)")]]))
+    -- Does not error with incorrect arguments
+    eq(0, exc_exec([[call luaeval("vim.api.nvim__id()")]]))
+    eq(0, exc_exec([[call luaeval("vim.api.nvim__id(1, 2)")]]))
+    eq(0, exc_exec([[call luaeval("vim.api.nvim_set_var('myvar', 2, 3)")]]))
     -- Error in argument types
     eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua string',
        exc_exec([[call luaeval("vim.api.nvim_set_var(1, 2)")]]))


### PR DESCRIPTION
Currently lua functions in vim.api have an argument length check. This
check is pointless since the users can fake the arguments by passing in
nils. E.g.

  vim.api.nvim_win_get_width()
  > E5108: Error executing lua [string ":lua"]:1: Expected 1 argument

However:

  vim.api.nvim_win_get_width(nil)
  > 98

This change allows API function arguments to be omitted by pushing extra
nils onto the stack.

The main benefit to this change is that it allows extra arguments to be
added to functions without introducing a breaking change.
