### PR TITLE
fix(lua): preserve argument list ... which has not the same length as #{...} 

### DIFF
--- a/runtime/lua/vim/F.lua
+++ b/runtime/lua/vim/F.lua
@@ -27,5 +27,14 @@ function F.nil_wrap(fn)
   end
 end
 
+--- like {...} except preserve the lenght explicitly
+function F.pack_len(...)
+  return {n=select('#', ...), ...}
+end
+
+--- like unpack() but use the length set by F.pack_len if present
+function F.unpack_len(t)
+  return unpack(t, 1, t.n)
+end
 
 return F

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -273,8 +273,8 @@ end
 ---@see |vim.in_fast_event()|
 function vim.schedule_wrap(cb)
   return (function (...)
-    local args = {...}
-    vim.schedule(function() cb(unpack(args)) end)
+    local args = vim.F.pack_len(...)
+    vim.schedule(function() cb(vim.F.unpack_len(args)) end)
   end)
 end
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -17,6 +17,7 @@ local matches = helpers.matches
 local source = helpers.source
 local NIL = helpers.NIL
 local retry = helpers.retry
+local next_msg = helpers.next_msg
 
 before_each(clear)
 
@@ -2175,6 +2176,24 @@ describe('lua stdlib', function()
       ]]
 
       eq(false, pcall_result)
+    end)
+  end)
+
+  describe('vim.schedule_wrap', function()
+    it('preserves argument lists', function()
+      exec_lua [[
+        local fun = vim.schedule_wrap(function(kling, klang, klonk)
+          vim.rpcnotify(1, 'mayday_mayday', {a=kling, b=klang, c=klonk})
+        end)
+        fun("BOB", nil, "MIKE")
+      ]]
+      eq({'notification', 'mayday_mayday', {{a='BOB', c='MIKE'}}}, next_msg())
+
+      -- let's gooooo
+      exec_lua [[
+        vim.schedule_wrap(function(...) vim.rpcnotify(1, 'boogalo', select('#', ...)) end)(nil,nil,nil,nil)
+      ]]
+      eq({'notification', 'boogalo', {4}}, next_msg())
     end)
   end)
 


### PR DESCRIPTION
It is well known fact that lua tables used as lists does not have one uniquely defined length. A table like `{'alpha', nil, 'omega'}` has 3 as one possible length, and 1 as another length. Which length is preferred by the _length operator_ might vary depending on the weekday, whether the eventual jit engine has been warmed up or not, or the phase of Jupiter's moons.

However, an _argument list_ like `fun(3, nil, 2)` does have a determinate length, i e obviously 3 in this case. What is less obvious is that `fun(3, nil, 2, nil)` has the well-defined length of 4, which is not even a possible length of the table `{3, nil, 2, nil}` !

Due to this impedance mismatch in the very core of the language, argument lists can not be preserved by the common idiom of `unpack({...})`. Therefore, we define new functions `unpack_len(pack_len(...))`  to fully preserve the argument list, when `...` is being shadowed in a nested closure.