### PR TITLE
feat(treesitter): support query quantifiers

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -241,14 +241,14 @@ local function on_line_impl(self, buf, line)
     -- Some injected languages may not have highlight queries.
     if not highlighter_query:query() then return end
 
-    if state.iter == nil then
+    if not state.iter then
       state.iter = highlighter_query:query():iter_captures(root_node, self.bufnr, line, root_end_row + 1)
     end
 
     while line >= state.next_row do
       local capture, node, metadata = state.iter()
 
-      if capture == nil then break end
+      if not capture then break end
 
       local start_row, start_col, end_row, end_col = node:range()
       local hl = highlighter_query.hl_cache[capture]

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -37,7 +37,7 @@ local hl_query = [[
   ; Use lua regexes
   ((identifier) @Identifier (#contains? @Identifier "lua_"))
   ((identifier) @Constant (#lua-match? @Constant "^[A-Z_]+$"))
-  ((identifier) @Normal (#vim-match? @Constant "^lstate$"))
+  ((identifier) @Normal (#vim-match? @Normal "^lstate$"))
 
   ((binary_expression left: (identifier) @WarningMsg.left right: (identifier) @WarningMsg.right) (#eq? @WarningMsg.left @WarningMsg.right))
 


### PR DESCRIPTION
Do this by making tables instead of just nodes for when quantifiers are used, and match multiple nodes.

This needs a discussion about how to handle predicates.

There is two solutions as I see:

1. Let the predicates handle that, maybe for convenience provide some utilities to do it (like, do an `and` of the predicates over all nodes)
2. Always call the predicate with one combination of the quantified nodes. Which does not sound good because of the lack of adaptability, the amount of code needed, and the unnecessary complexity of this.