### PR TITLE
refactor(api): remove redundant api_set_error

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1486,7 +1486,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id,
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (!buf) {
-    api_set_error(err, kErrorTypeValidation, "Invalid buffer id");
     return 0;
   }
 


### PR DESCRIPTION
This error is already handled by `find_buffer_by_handle`
https://github.com/neovim/neovim/blob/c479b903598d042bf8f396cdc3ef3dc65734cbd9/src/nvim/api/private/helpers.c#L633-L646