### PR TITLE
docs: provide minimal init.lua and recommend it

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,13 +51,12 @@ body:
     attributes:
       label: "How to reproduce the issue"
       description: |
-        - [Prepare](https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#reporting-problems) a minimal config that reproduces the problem with `nvim -u minimal.lua` and provide it below.
+        - Try to reproduce with `nvim --clean` ("factory defaults").
+        - If necessary, [include](https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#reporting-problems) a minimal config that reproduces the problem with `nvim -u minimal.lua`.
         - For build failures: list the exact steps including CMake flags (if any).
         - For shell-related problems: try `env -i TERM=ansi-256color "$(which nvim)"`.
       placeholder: |
-        1. `nvim -u minimal.lua` 
-        2. `:edit foo` 
-        3. `yiwp` 
+        `nvim --clean` ...
     validations:
       required: true
 
@@ -72,12 +71,3 @@ body:
       label: "Actual behavior"
     validations:
       required: true
-
-  - type: textarea
-    attributes:
-      label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue. You can start with the provided [`minimal.lua`](https://github.com/neovim/neovim/blob/master/contrib/minimal.lua). If _absolutely_ necessary, add plugins and config options from your `init.lua` at the indicated lines."
-      render: Lua
-    validations:
-      required: true
-

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: "Vim (not Nvim) behaves the same?"
       description: "Does `vim -u DEFAULTS` have the same issue? Note the exact Vim version (`8.x.yyyy`)."
-      placeholder: "no, vim 7.3.432"
+      placeholder: "no (vim 8.2.2671)"
     validations:
       required: true
   - type: input
@@ -36,10 +36,9 @@ body:
   - type: input
     attributes:
       label: "$TERM environment variable"
-      placeholder: "echo $TERM"
+      placeholder: "xterm-256color"
     validations:
       required: true
-
   - type: input
     attributes:
       label: "Installation"
@@ -52,20 +51,20 @@ body:
     attributes:
       label: "How to reproduce the issue"
       description: |
-        - Steps to reproduce using `nvim -u NORC` or `nvim -u NONE` (try both).
+        - [Prepare](https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#reporting-problems) a minimal config that reproduces the problem with `nvim -u minimal.lua` and provide it below.
         - For build failures: list the exact steps including CMake flags (if any).
         - For shell-related problems: try `env -i TERM=ansi-256color "$(which nvim)"`.
       placeholder: |
-        nvim -u NONE
-        :edit foo
-        yiwp
+        1. `nvim -u minimal.lua` 
+        2. `:edit foo` 
+        3. `yiwp` 
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: "Expected behavior"
-      description: "Describe the behavior you expect. May include logs, images, or videos."
+      description: "Describe the behavior you expect. May include logs (`:edit $NVIM_LOG_FILE`), images, or videos."
     validations:
       required: true
   - type: textarea
@@ -73,3 +72,12 @@ body:
       label: "Actual behavior"
     validations:
       required: true
+
+  - type: textarea
+    attributes:
+      label: "Minimal config"
+      description: "Minimal(!) configuration necessary to reproduce the issue. You can start with the provided [`minimal.lua`](https://github.com/neovim/neovim/blob/master/contrib/minimal.lua). If _absolutely_ necessary, add plugins and config options from your `init.lua` at the indicated lines."
+      render: Lua
+    validations:
+      required: true
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ Getting started
 If you want to help but don't know where to start, here are some
 low-risk/isolated tasks:
 
-- [Merge a Vim patch].
 - Try a [good first issue](../../labels/good-first-issue) or [complexity:low] issue.
 - Fix bugs found by [Clang](#clang-scan-build), [PVS](#pvs-studio) or
   [Coverity](#coverity).
 - [Improve documentation][wiki-contribute-help]
+- [Merge a Vim patch]. [Runtime updates](https://github.com/vim/vim/search?q=update+runtime+files&type=commits) are easiest to get started.
 
 Reporting problems
 ------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,15 +16,22 @@ low-risk/isolated tasks:
 Reporting problems
 ------------------
 
+Before opening a new issue:
+
 - [Check the FAQ][wiki-faq].
 - [Search existing issues][github-issues] (including closed!)
 - Update Neovim to the latest version to see if your problem persists.
-- [Bisect](https://neovim.io/doc/user/starting.html#bisect) your config: disable plugins incrementally, to narrow down the cause of the issue.
-- [Bisect][git-bisect] Neovim's source code to find the cause of a regression, if you can. This is _extremely_ helpful.
+
+When reporting an issue:
+
+- [Bisect](https://neovim.io/doc/user/starting.html#bisect) your config: disable plugins and remove settings incrementally, to narrow down the cause of the issue.
+- Using this information, prepare a [minimal config](https://github.com/neovim/neovim/blob/master/contrib/minimal.lua) that reproduces the problem with `nvim -u minimal.lua`.
+- Check the logs: `:edit $NVIM_LOG_FILE`.
+- For shell-related problems: try `env -i TERM=ansi-256color "$(which nvim)"`.
+- Include `cmake --system-information` for build-related issues.
+- If there issue is a regression (i.e., the problem did not occur in an earlier version), [bisect][git-bisect] Neovim's source code to find exactly when it was introduced. This is _extremely_ helpful.
 - When reporting a crash, [include a stacktrace](https://github.com/neovim/neovim/wiki/FAQ#backtrace-linux).
 - Use [ASAN/UBSAN](#clang-sanitizers-asan-and-ubsan) to get detailed errors for segfaults and undefined behavior.
-- Check the logs. `:edit $NVIM_LOG_FILE`
-- Include `cmake --system-information` for build-related issues.
 
 Developer guidelines
 --------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,9 @@ Before opening a new issue:
 
 When reporting an issue:
 
+- First try to reproduce with `nvim --clean` ("factory defaults").
 - [Bisect](https://neovim.io/doc/user/starting.html#bisect) your config: disable plugins and remove settings incrementally, to narrow down the cause of the issue.
-- Using this information, prepare a [minimal config](https://github.com/neovim/neovim/blob/master/contrib/minimal.lua) that reproduces the problem with `nvim -u minimal.lua`.
+- If the problem involves plugins, preparing a [minimal config](https://github.com/neovim/neovim/blob/master/contrib/minimal.lua) that reproduces the problem with `nvim -u minimal.lua` can be very helpful.
 - Check the logs: `:edit $NVIM_LOG_FILE`.
 - For shell-related problems: try `env -i TERM=ansi-256color "$(which nvim)"`.
 - Include `cmake --system-information` for build-related issues.

--- a/contrib/minimal.lua
+++ b/contrib/minimal.lua
@@ -1,0 +1,30 @@
+local minimal_path = vim.fn.stdpath 'cache' .. '/test-minimal-config/site'
+
+vim.cmd [[set runtimepath=$VIMRUNTIME]]
+vim.cmd('set packpath=' .. minimal_path)
+
+_G.load_config = function()
+  -- ADD INIT.LUA SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
+end
+
+local function load_plugins()
+  require('packer').startup {
+    {
+      'wbthomason/packer.nvim',
+      -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
+    },
+    config = {
+      package_root = minimal_path .. '/pack',
+      compile_path = minimal_path .. '/pack/_loader/start/_load/plugin/packer_compiled.lua',
+      display = { non_interactive = true },
+    },
+  }
+end
+
+local install_path = minimal_path .. '/pack/packer/start/packer.nvim'
+if vim.fn.isdirectory(install_path) == 0 then
+  vim.fn.system { 'git', 'clone', '--depth=1', 'git://github.com/wbthomason/packer.nvim', install_path }
+end
+load_plugins()
+require('packer').sync()
+vim.cmd [[autocmd User PackerComplete ++once echo "Ready!" | lua load_config()]]


### PR DESCRIPTION
Add a `minimal.lua` for reproducing issues in a reproducible clean
environment (config _and_ plugins/packages). This bootstraps packer into
`/tmp/nvim` (so unixy platforms only for now; Windows users need to
manually change the paths to `%TEMP%`) if needed, synchronizes all
specified plugins (to ensure up-to-date environment even if used
previously) and loads the specified `init.lua` settings.

Mention this in `CONTRIBUTING.md` and the bug issue template.

@dundargoc @vigoux 