### PR TITLE
docs: clarify :runtime START, OPT behavior

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -201,10 +201,12 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			When [!] is included, all found files are sourced.
 			Else only the first found file is sourced.
 
-			When [where] is omitted only 'runtimepath' is used.
+			When [where] is omitted, first 'runtimepath' is
+			searched, then directories under "start" in 'packpath'
+			are searched.
 			Other values:
-				START	search under "start" in 'packpath'
-				OPT 	search under "opt" in 'packpath'
+				START	search only under "start" in 'packpath'
+				OPT 	search only under "opt" in 'packpath'
 				PACK	search under "start" and "opt" in
 					'packpath'
 				ALL	first use 'runtimepath', then search


### PR DESCRIPTION
By default, the `:runtime` command searches `pack/*/start` in `'packpath'` along with `'runtimepath'`. Update the documentation to reflect this behavior.