### PR TITLE
refactor: extract lsp.util.trim_empty_lines to stdlib

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1771,15 +1771,6 @@ text_document_completion_list_to_complete_items({result}, {prefix})
                 See also: ~
                     |complete-items|
 
-trim_empty_lines({lines})                    *vim.lsp.util.trim_empty_lines()*
-                Removes empty lines from the beginning and end.
-
-                Parameters: ~
-                    {lines}  (table) list of lines to trim
-
-                Return: ~
-                    (table) trimmed list of lines
-
                                 *vim.lsp.util.try_trim_markdown_code_blocks()*
 try_trim_markdown_code_blocks({lines})
                 Accepts markdown lines and tries to reduce them to a filetype

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1529,6 +1529,19 @@ list_slice({list}, {start}, {finish})                       *vim.list_slice()*
                 Return: ~
                     Copy of table sliced from start to finish (inclusive)
 
+list_trim_empty({list})                                *vim.list_trim_empty()*
+                Removes empty elements from the beginning and end of a
+                list-like table.
+
+                An element is considered empty if it has length 0 (for
+                strings) or is an empty table.
+
+                Parameters: ~
+                    {list}  (table) list-like table
+
+                Return: ~
+                    (table) trimmed list
+
 pesc({s})                                                         *vim.pesc()*
                 Escapes magic chars in a Lua pattern.
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1705,22 +1705,9 @@ end
 --- Removes empty lines from the beginning and end.
 ---@param lines (table) list of lines to trim
 ---@returns (table) trimmed list of lines
+---@deprecated Prefer vim.list_trim_empty
 function M.trim_empty_lines(lines)
-  local start = 1
-  for i = 1, #lines do
-    if lines[i] ~= nil and #lines[i] > 0 then
-      start = i
-      break
-    end
-  end
-  local finish = 1
-  for i = #lines, 1, -1 do
-    if lines[i] ~= nil and #lines[i] > 0 then
-      finish = i
-      break
-    end
-  end
-  return vim.list_extend({}, lines, start, finish)
+  return vim.list_trim_empty(lines)
 end
 
 --- Accepts markdown lines and tries to reduce them to a filetype if they

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -489,6 +489,37 @@ function vim.list_slice(list, start, finish)
   return new_list
 end
 
+--- Removes empty elements from the beginning and end of a list-like table.
+---
+--- An element is considered empty if it has length 0 (for strings) or is an empty table.
+---
+---@param list (table) list-like table
+---@returns (table) trimmed list
+function vim.list_trim_empty(list)
+  vim.validate{list={list, "table"}}
+
+  ---@private
+  local function empty(e)
+    return (type(e) == "string" and #e == 0) or (type(e) == "table" and next(e) == nil)
+  end
+
+  local start = 1
+  for i = 1, #list do
+    if list[i] ~= nil and not empty(list[i]) then
+      start = i
+      break
+    end
+  end
+  local finish = 1
+  for i = #list, 1, -1 do
+    if list[i] ~= nil and not empty(list[i]) then
+      finish = i
+      break
+    end
+  end
+  return vim.list_slice(list, start, finish)
+end
+
 --- Trim whitespace (Lua pattern "%s") from both sides of a string.
 ---
 ---@see https://www.lua.org/pil/20.2.html

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -316,6 +316,24 @@ describe('lua stdlib', function()
       pcall_err(split, 'string', 'string', 1))
   end)
 
+  it("vim.list_trim_empty", function()
+    local function list_trim_empty(t)
+      return exec_lua([[return vim.list_trim_empty(...)]], t)
+    end
+    eq({"hello", "", "world"}, list_trim_empty({"", "hello", "", "world", "", ""}))
+    eq({"hello", "", "world"}, list_trim_empty({"", "hello", "", "world"}))
+    eq({"hello", "", "world"}, list_trim_empty({"hello", "", "world", "", ""}))
+    eq({"hello", "", "world"}, list_trim_empty({"hello", "", "world"}))
+    eq({1}, list_trim_empty({{}, 1, ""}))
+    eq({{foo = "bar"}, 42}, list_trim_empty({{}, "", nil, {foo = "bar"}, 42, nil, {}}))
+
+    eq(dedent([[
+        Error executing lua: vim/shared.lua:0: list: expected table, got string
+        stack traceback:
+            vim/shared.lua:0: in function <vim/shared.lua:0>]]),
+      pcall_err(list_trim_empty, "string"))
+  end)
+
   it('vim.trim', function()
     local trim = function(s)
       return exec_lua('return vim.trim(...)', s)


### PR DESCRIPTION
Removing empty elements from an array is a generally useful procedure with use-cases outside of LSP. Extract the `vim.lsp.util.trim_empty_lines` function into the top level vim module as `vim.list_trim_empty`.

The lsp.util method is kept for now for backward compatibility.
