### PR TITLE
feat(screen): virtual lines

### DIFF
--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -150,7 +150,7 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
   decor->virt_text = virt_text;
   decor->virt_text_width = width;
 
-  extmark_set(buf, ns_id, 0, (int)line, 0, -1, -1, decor, true,
+  extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, decor, true,
               false, kExtmarkNoUndo);
   return src_id;
 }

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1627,7 +1627,7 @@ VirtText parse_virt_text(Array chunks, Error *err, int *width)
       }
     }
 
-    char *text = transstr(str.size > 0 ? str.data : "");  // allocates
+    char *text = transstr(str.size > 0 ? str.data : "", false);  // allocates
     w += (int)mb_string2cells((char_u *)text);
 
     kv_push(virt_text, ((VirtTextChunk){ .text = text, .hl_id = hl_id }));

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -65,6 +65,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
+#include "nvim/plines.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"
 #include "nvim/screen.h"
@@ -820,6 +821,7 @@ static void free_buffer_stuff(buf_T *buf, int free_flags)
   uc_clear(&buf->b_ucmds);               // clear local user commands
   buf_delete_signs(buf, (char_u *)"*");  // delete any signs
   extmark_free_all(buf);                 // delete any extmarks
+  clear_virt_lines(buf, -1);
   map_clear_int(buf, MAP_ALL_MODES, true, false);    // clear local mappings
   map_clear_int(buf, MAP_ALL_MODES, true, true);     // clear local abbrevs
   XFREE_CLEAR(buf->b_start_fenc);
@@ -3262,7 +3264,7 @@ void maketitle(void)
         buf_p += MIN(size, SPACE_FOR_FNAME);
       } else {
         buf_p += transstr_buf((const char *)path_tail(curbuf->b_fname),
-                              buf_p, SPACE_FOR_FNAME + 1);
+                              buf_p, SPACE_FOR_FNAME + 1, true);
       }
 
       switch (bufIsChanged(curbuf)
@@ -3311,7 +3313,7 @@ void maketitle(void)
         // room for the server name.  When there is no room (very long
         // file name) use (...).
         if ((size_t)(buf_p - buf) < SPACE_FOR_DIR) {
-          char *const tbuf = transstr(buf_p);
+          char *const tbuf = transstr(buf_p, true);
           const size_t free_space = SPACE_FOR_DIR - (size_t)(buf_p - buf) + 1;
           const size_t dir_len = xstrlcpy(buf_p, tbuf, free_space);
           buf_p += MIN(dir_len, free_space - 1);
@@ -4657,7 +4659,7 @@ void get_rel_pos(win_T *wp, char_u *buf, int buflen)
   long below;          // number of lines below window
 
   above = wp->w_topline - 1;
-  above += diff_check_fill(wp, wp->w_topline) - wp->w_topfill;
+  above += win_get_fill(wp, wp->w_topline) - wp->w_topfill;
   if (wp->w_topline == 1 && wp->w_topfill >= 1) {
     // All buffer lines are displayed and there is an indication
     // of filler lines, that can be considered seeing all lines.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -868,6 +868,12 @@ struct file_buffer {
   Map(uint64_t, ExtmarkItem) b_extmark_index[1];
   Map(uint64_t, ExtmarkNs) b_extmark_ns[1];         // extmark namespaces
 
+  VirtLines b_virt_lines;
+  uint64_t b_virt_line_mark;
+  int b_virt_line_pos;
+  bool b_virt_line_above;
+  bool b_virt_line_leftcol;
+
   // array of channel_id:s which have asked to receive updates for this
   // buffer.
   kvec_t(uint64_t) update_channels;

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -7,14 +7,6 @@
 
 // actual Decoration data is in extmark_defs.h
 
-typedef struct {
-  char *text;
-  int hl_id;
-} VirtTextChunk;
-
-typedef kvec_t(VirtTextChunk) VirtText;
-#define VIRTTEXT_EMPTY ((VirtText)KV_INITIAL_VALUE)
-
 typedef uint16_t DecorPriority;
 #define DECOR_PRIORITY_BASE 0x1000
 

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1985,26 +1985,6 @@ static int diff_cmp(char_u *s1, char_u *s2)
   return 0;
 }
 
-/// Return the number of filler lines above "lnum".
-///
-/// @param wp
-/// @param lnum
-///
-/// @return Number of filler lines above lnum
-int diff_check_fill(win_T *wp, linenr_T lnum)
-{
-  // be quick when there are no filler lines
-  if (!(diff_flags & DIFF_FILLER)) {
-    return 0;
-  }
-  int n = diff_check(wp, lnum);
-
-  if (n <= 0) {
-    return 0;
-  }
-  return n;
-}
-
 /// Set the topline of "towin" to match the position in "fromwin", so that they
 /// show the same diff'ed lines.
 ///
@@ -2029,6 +2009,7 @@ void diff_set_topline(win_T *fromwin, win_T *towin)
     ex_diffupdate(NULL);
   }
   towin->w_topfill = 0;
+
 
   // search for a change that includes "lnum" in the list of diffblocks.
   for (dp = curtab->tp_first_diff; dp != NULL; dp = dp->df_next) {
@@ -2253,6 +2234,13 @@ bool diffopt_closeoff(void)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return (diff_flags & DIFF_CLOSE_OFF) != 0;
+}
+
+// Return true if 'diffopt' contains "filler".
+bool diffopt_filler(void)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return (diff_flags & DIFF_FILLER) != 0;
 }
 
 /// Find the difference within a changed line.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3344,12 +3344,10 @@ static char_u *ins_compl_mode(void)
  */
 static int ins_compl_bs(void)
 {
-  char_u *line;
-  char_u *p;
-
-  line = get_cursor_line_ptr();
-  p = line + curwin->w_cursor.col;
+  char_u *line = get_cursor_line_ptr();
+  char_u *p = line + curwin->w_cursor.col;
   MB_PTR_BACK(line, p);
+  ptrdiff_t p_off = p - line;
 
   // Stop completion when the whole word was deleted.  For Omni completion
   // allow the word to be deleted, we won't match everything.
@@ -3369,8 +3367,12 @@ static int ins_compl_bs(void)
     ins_compl_restart();
   }
 
+  // ins_compl_restart() calls update_screen(0) which may invalidate the pointer
+  // TODO(bfredl): get rid of random update_screen() calls deep inside completion logic
+  line = get_cursor_line_ptr();
+
   xfree(compl_leader);
-  compl_leader = vim_strnsave(line + compl_col, (int)(p - line) - compl_col);
+  compl_leader = vim_strnsave(line + compl_col, (int)p_off - compl_col);
   ins_compl_new_leader();
   if (compl_shown_match != NULL) {
     // Make sure current match is not a hidden item.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1802,7 +1802,7 @@ static void f_did_filetype(typval_T *argvars, typval_T *rettv, FunPtr fptr)
  */
 static void f_diff_filler(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  rettv->vval.v_number = diff_check_fill(curwin, tv_get_lnum(argvars));
+  rettv->vval.v_number = MAX(0, diff_check(curwin, tv_get_lnum(argvars)));
 }
 
 /*
@@ -10801,7 +10801,7 @@ static void f_strridx(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 static void f_strtrans(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = (char_u *)transstr(tv_get_string(&argvars[0]));
+  rettv->vval.v_string = (char_u *)transstr(tv_get_string(&argvars[0]), true);
 }
 
 /*

--- a/src/nvim/extmark_defs.h
+++ b/src/nvim/extmark_defs.h
@@ -6,6 +6,16 @@
 
 typedef struct Decoration Decoration;
 
+typedef struct {
+  char *text;
+  int hl_id;
+} VirtTextChunk;
+
+typedef kvec_t(VirtTextChunk) VirtText;
+#define VIRTTEXT_EMPTY ((VirtText)KV_INITIAL_VALUE)
+typedef kvec_t(VirtText) VirtLines;
+
+
 typedef struct
 {
   uint64_t ns_id;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1875,7 +1875,7 @@ char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldin
         }
       }
       if (*p != NUL) {
-        p = (char_u *)transstr((const char *)text);
+        p = (char_u *)transstr((const char *)text, true);
         xfree(text);
         text = p;
       }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -241,7 +241,7 @@ retnomove:
     if (row < 0) {
       count = 0;
       for (first = true; curwin->w_topline > 1; ) {
-        if (curwin->w_topfill < diff_check(curwin, curwin->w_topline)) {
+        if (curwin->w_topfill < win_get_fill(curwin, curwin->w_topline)) {
           count++;
         } else {
           count += plines_win(curwin, curwin->w_topline - 1, true);
@@ -251,8 +251,8 @@ retnomove:
         }
         first = false;
         (void)hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
-        if (curwin->w_topfill < diff_check(curwin, curwin->w_topline)) {
-          ++curwin->w_topfill;
+        if (curwin->w_topfill < win_get_fill(curwin, curwin->w_topline)) {
+          curwin->w_topfill++;
         } else {
           --curwin->w_topline;
           curwin->w_topfill = 0;
@@ -283,11 +283,10 @@ retnomove:
         }
 
         if (curwin->w_topfill > 0) {
-          --curwin->w_topfill;
+          curwin->w_topfill--;
         } else {
-          ++curwin->w_topline;
-          curwin->w_topfill =
-            diff_check_fill(curwin, curwin->w_topline);
+          curwin->w_topline++;
+          curwin->w_topfill = win_get_fill(curwin, curwin->w_topline);
         }
       }
       check_topfill(curwin, false);
@@ -373,12 +372,12 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 
   while (row > 0) {
     // Don't include filler lines in "count"
-    if (win->w_p_diff
+    if (win_may_fill(win)
         && !hasFoldingWin(win, lnum, NULL, NULL, true, NULL)) {
       if (lnum == win->w_topline) {
         row -= win->w_topfill;
       } else {
-        row -= diff_check_fill(win, lnum);
+        row -= win_get_fill(win, lnum);
       }
       count = plines_win_nofill(win, lnum, true);
     } else {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5261,16 +5261,15 @@ static void nv_scroll(cmdarg_T *cap)
   } else {
     if (cap->cmdchar == 'M') {
       // Don't count filler lines above the window.
-      used -= diff_check_fill(curwin, curwin->w_topline)
+      used -= win_get_fill(curwin, curwin->w_topline)
               - curwin->w_topfill;
       validate_botline(curwin);  // make sure w_empty_rows is valid
       half = (curwin->w_height_inner - curwin->w_empty_rows + 1) / 2;
       for (n = 0; curwin->w_topline + n < curbuf->b_ml.ml_line_count; n++) {
         // Count half he number of filler lines to be "below this
         // line" and half to be "above the next line".
-        if (n > 0 && used + diff_check_fill(curwin, curwin->w_topline
-                                            + n) / 2 >= half) {
-          --n;
+        if (n > 0 && used + win_get_fill(curwin, curwin->w_topline + n) / 2 >= half) {
+          n--;
           break;
         }
         used += plines_win(curwin, curwin->w_topline + n, true);

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -514,7 +514,7 @@ void pum_redraw(void)
             char_u saved = *p;
 
             *p = NUL;
-            st = (char_u *)transstr((const char *)s);
+            st = (char_u *)transstr((const char *)s, true);
             *p = saved;
 
             if (pum_rl) {


### PR DESCRIPTION
Note: probably not the final api. But for now

    vim.api.nvim_buf_set_extmark(0, ns, 5, 0, {virt_lines={{{'line 1', 'String'}}, {{'line 2 ', 'ErrorMsg'}, {'text','LineNr'}}, }})

Limitation: only one (1) block of virtual lines per buffer! To enable quick prototyping. we can lift this limitation later.