### PR TITLE
feat(lua): add option helpers for default values

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1035,6 +1035,14 @@ from within Lua.
         In Lua:
             `vim.opt.listchars = { space = '_', tab = '>~' }`
 
+    You can get an option's default value with >
+
+        vim.opt.wildignore:default()
+<
+    To set an option to its default value |:set-&| use: >
+
+        vim.opt.wildignore:reset()
+<
 
 In any of the above examples, to replicate the behavior |setlocal|, use
 `vim.opt_local`. Additionally, to replicate the behavior of |setglobal|, use

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1047,6 +1047,12 @@ from within Lua.
 In any of the above examples, to replicate the behavior |setlocal|, use
 `vim.opt_local`. Additionally, to replicate the behavior of |setglobal|, use
 `vim.opt_global`.
+
+To clear the local value of a |global-local| option set it to "nil". Example: >
+        vim.opt_local.makeprg = nil
+This is equivalent to >
+        :set makeprg<
+<
                                                                      *vim.opt*
 
 |vim.opt| returns an Option object.

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -596,6 +596,9 @@ local create_option_metatable = function(set_type)
       local value
       if self._value ~= nil then
         value = convert_value_to_vim(self._name, self._info, self._value)
+      elseif set_type == SET_TYPES.SET then
+        -- vim.opt.option = nil sets the option back to its default value
+        value = convert_value_to_vim(self._name, self._info, self._info.default)
       end
 
       a.nvim_set_option_value(self._name, value, {scope = scope})

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -596,18 +596,11 @@ local create_option_metatable = function(set_type)
       local value
       if self._value ~= nil then
         value = convert_value_to_vim(self._name, self._info, self._value)
-      else
-        if set_type == SET_TYPES.LOCAL then
-          -- Equivalent to :setlocal option< in Vimscript which sets the local
-          -- value of the option to its global value by copying the value.
-          local global_opt = make_option(self._name, a.nvim_get_option_value(self._name, {scope = "global"}))
-          value = global_opt._value
-        elseif set_type == SET_TYPES.SET then
-          -- Equivalent to :set option< in Vimscript, which removes the local value
-          -- of the option so that the global value will be used. This only
-          -- works for global-local options
-          return a.nvim_set_option_value(self._name, nil, {scope = "local"})
-        end
+      elseif set_type == SET_TYPES.LOCAL then
+        -- Equivalent to :set option< in Vimscript, which removes the local value
+        -- of the option so that the global value will be used. This only
+        -- works for global-local options
+        return a.nvim_set_option_value(self._name, nil, {scope = "local"})
       end
 
       a.nvim_set_option_value(self._name, value, {scope = scope})

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -593,7 +593,23 @@ local create_option_metatable = function(set_type)
     -- To set a value, instead use:
     --  opt[my_option] = value
     _set = function(self)
-      local value = convert_value_to_vim(self._name, self._info, self._value)
+      local value
+      if self._value ~= nil then
+        value = convert_value_to_vim(self._name, self._info, self._value)
+      else
+        if set_type == SET_TYPES.LOCAL then
+          -- Equivalent to :setlocal option< in Vimscript which sets the local
+          -- value of the option to its global value by copying the value.
+          local global_opt = make_option(self._name, a.nvim_get_option_value(self._name, {scope = "global"}))
+          value = global_opt._value
+        elseif set_type == SET_TYPES.SET then
+          -- Equivalent to :set option< in Vimscript, which removes the local value
+          -- of the option so that the global value will be used. This only
+          -- works for global-local options
+          return a.nvim_set_option_value(self._name, nil, {scope = "local"})
+        end
+      end
+
       a.nvim_set_option_value(self._name, value, {scope = scope})
 
       return self

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -596,11 +596,6 @@ local create_option_metatable = function(set_type)
       local value
       if self._value ~= nil then
         value = convert_value_to_vim(self._name, self._info, self._value)
-      elseif set_type == SET_TYPES.LOCAL then
-        -- Equivalent to :set option< in Vimscript, which removes the local value
-        -- of the option so that the global value will be used. This only
-        -- works for global-local options
-        return a.nvim_set_option_value(self._name, nil, {scope = "local"})
       end
 
       a.nvim_set_option_value(self._name, value, {scope = scope})

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -603,6 +603,17 @@ local create_option_metatable = function(set_type)
       return convert_value_to_lua(self._name, self._info, self._value)
     end,
 
+    default = function(self)
+      return convert_value_to_lua(self._name, self._info, self._info.default)
+    end,
+
+    reset = function(self)
+      local value = convert_value_to_vim(self._name, self._info, self._info.default)
+      a.nvim_set_option_value(self._name, value, {scope = scope})
+
+      return self
+    end,
+
     append = function(self, right)
       return self:__add(right):_set()
     end,

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1295,7 +1295,7 @@ describe('lua stdlib', function()
         vim.opt.shiftwidth = 8
         vim.opt_local.shiftwidth = 4
         table.insert(result, vim.opt_local.shiftwidth:get())
-        vim.opt_local.shiftwidth = nil
+        vim.opt_local.shiftwidth = vim.opt_global.shiftwidth:get()
         table.insert(result, vim.opt_local.shiftwidth:get())
         return result
       ]]
@@ -1317,7 +1317,7 @@ describe('lua stdlib', function()
 
       eq("make", result[1])
       eq("dance", result[2])
-      eq("make", result[3])
+      eq("", result[3])
     end)
 
     it('should allow you to retrieve window opts even if they have not been set', function()

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1273,6 +1273,53 @@ describe('lua stdlib', function()
       eq("", result[8])
     end)
 
+    it('should allow options to be reset to default values', function()
+      local result = exec_lua [[
+        local result = {}
+        table.insert(result, vim.opt.shiftwidth:default())
+        vim.opt.shiftwidth = 42
+        table.insert(result, vim.opt.shiftwidth:get())
+        vim.opt.shiftwidth:reset()
+        table.insert(result, vim.opt.shiftwidth:get())
+        return result
+      ]]
+
+      eq(8, result[1])
+      eq(42, result[2])
+      eq(8, result[3])
+    end)
+
+    it('should allow local options to be set to their global value', function()
+      local result =  exec_lua [[
+        local result = {}
+        vim.opt.shiftwidth = 8
+        vim.opt_local.shiftwidth = 4
+        table.insert(result, vim.opt_local.shiftwidth:get())
+        vim.opt_local.shiftwidth = nil
+        table.insert(result, vim.opt_local.shiftwidth:get())
+        return result
+      ]]
+
+      eq(4, result[1])
+      eq(8, result[2])
+    end)
+
+    it('should allow local options to be cleared', function()
+      local result = exec_lua [[
+        local result = {}
+        table.insert(result, vim.opt.makeprg:get())
+        vim.opt_local.makeprg = "dance"
+        table.insert(result, vim.opt_local.makeprg:get())
+        vim.opt_local.makeprg = nil
+        table.insert(result, vim.opt_local.makeprg:get())
+        return result
+      ]]
+
+      eq("make", result[1])
+      eq("dance", result[2])
+      eq("make", result[3])
+    end)
+
     it('should allow you to retrieve window opts even if they have not been set', function()
       local result = exec_lua [[
         local result = {}


### PR DESCRIPTION
Use `vim.opt.option:default()` to get an option's default value and `vim.opt.option:reset()` to set an option back to its default value.

This is the Lua equivalent to `:set option&`.