### PR TITLE
fix(nvim): notify dict watchers on nvim_set_var and vim.g setter

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1781,7 +1781,7 @@ void tv_dict_watcher_notify(dict_T *const dict, const char *const key, typval_T 
     tv_dict_add(argv[2].vval.v_dict, v);
   }
 
-  if (oldtv) {
+  if (oldtv && oldtv->v_type != VAR_UNKNOWN) {
     dictitem_T *const v = tv_dict_item_alloc_len(S_LEN("old"));
     tv_copy(oldtv, &v->di_tv);
     tv_dict_add(argv[2].vval.v_dict, v);

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1348,12 +1348,8 @@ void set_var_const(const char *name, const size_t name_len, typval_T *const tv, 
   }
 
   if (watched) {
-    if (oldtv.v_type == VAR_UNKNOWN) {
-      tv_dict_watcher_notify(dict, (char *)v->di_key, &v->di_tv, NULL);
-    } else {
-      tv_dict_watcher_notify(dict, (char *)v->di_key, &v->di_tv, &oldtv);
-      tv_clear(&oldtv);
-    }
+    tv_dict_watcher_notify(dict, (char *)v->di_key, &v->di_tv, &oldtv);
+    tv_clear(&oldtv);
   }
 
   if (is_const) {

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -369,12 +369,19 @@ int nlua_setvar(lua_State *lstate)
     return 0;
   }
 
+  bool watched = tv_dict_is_watched(dict);
+
   if (del) {
     // Delete the key
     if (di == NULL) {
       // Doesn't exist, nothing to do
       return 0;
     } else {
+      // Notify watchers
+      if (watched) {
+        tv_dict_watcher_notify(dict, key.data, NULL, &di->di_tv);
+      }
+
       // Delete the entry
       tv_dict_item_remove(dict, di);
     }
@@ -388,17 +395,29 @@ int nlua_setvar(lua_State *lstate)
       return luaL_error(lstate, "Couldn't convert lua value");
     }
 
+    typval_T oldtv = TV_INITIAL_VALUE;
+
     if (di == NULL) {
       // Need to create an entry
       di = tv_dict_item_alloc_len(key.data, key.size);
       tv_dict_add(dict, di);
     } else {
+      if (watched) {
+        tv_copy(&di->di_tv, &oldtv);
+      }
       // Clear the old value
       tv_clear(&di->di_tv);
     }
 
     // Update the value
     tv_copy(&tv, &di->di_tv);
+
+    // Notify watchers
+    if (watched) {
+      tv_dict_watcher_notify(dict, key.data, &tv, &oldtv);
+      tv_clear(&oldtv);
+    }
+
     // Clear the temporary variable
     tv_clear(&tv);
   }


### PR DESCRIPTION
One thing I noticed with this, is that `nlua_setvar` shares a decent amount of code/structure with `dict_set_var`. Could/should `nlua_setvar` be made to call `dict_set_var` somehow? I haven't tried that, it seems like it could be a bit of a hassle (due to the differences), but figured I'd mention it.

EDIT for why this PR exists:

Currently if you do `dictwatcheradd(g:, 'some_var', 'SomeHandler')` (assuming `SomeHandler` is defined) and run `:lua vim.g.some_var = 1` or `:lua vim.api.nvim_set_var('some_var', 1)`, `SomeHandler` is never called. It _is_ called when doing `let g:some_var = 1` however. This PR makes it such that all of those ways of updating `some_var` notify the dict watcher.