### PR TITLE
fix(ci): re-run GHA for ready_for_review events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: '**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
       - 'release-[0-9]+.[0-9]+'


### PR DESCRIPTION
By default, the pull_request target only runs for the "opened", "synchronize", and "reopened" events.

Since we've disabled GHA CI for "draft" PRs, the "ready_for_review" event also needs to be included so CI is automatically run when leaving draft status.