### PR TITLE
[RDY] fix(float): skip non-focusable windows for :windo

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1409,6 +1409,7 @@ void ex_listdo(exarg_T *eap)
     listcmd_busy = true;            // avoids setting pcmark below
 
     while (!got_int && buf != NULL) {
+      bool execute = true;
       if (eap->cmdidx == CMD_argdo) {
         // go to argument "i"
         if (i == ARGCOUNT) {
@@ -1434,11 +1435,14 @@ void ex_listdo(exarg_T *eap)
           break;
         }
         assert(wp);
-        win_goto(wp);
-        if (curwin != wp) {
-          break;    // something must be wrong
+        execute = !wp->w_floating || wp->w_float_config.focusable;
+        if (execute) {
+          win_goto(wp);
+          if (curwin != wp) {
+            break;    // something must be wrong
+          }
         }
-        wp = curwin->w_next;
+        wp = wp->w_next;
       } else if (eap->cmdidx == CMD_tabdo) {
         // go to window "tp"
         if (!valid_tabpage(tp)) {
@@ -1461,8 +1465,10 @@ void ex_listdo(exarg_T *eap)
 
       i++;
       // execute the command
-      do_cmdline(eap->arg, eap->getline, eap->cookie,
-                 DOCMD_VERBOSE + DOCMD_NOWAIT);
+      if (execute) {
+        do_cmdline(eap->arg, eap->getline, eap->cookie,
+                   DOCMD_VERBOSE + DOCMD_NOWAIT);
+      }
 
       if (eap->cmdidx == CMD_bufdo) {
         // Done?
@@ -1513,7 +1519,7 @@ void ex_listdo(exarg_T *eap)
         }
       }
 
-      if (eap->cmdidx == CMD_windo) {
+      if (eap->cmdidx == CMD_windo && execute) {
         validate_cursor();              // cursor may have moved
         // required when 'scrollbind' has been set
         if (curwin->w_p_scb) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1,11 +1,13 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
+local global_helpers = require('test.helpers')
 local os = require('os')
 local clear, feed = helpers.clear, helpers.feed
 local assert_alive = helpers.assert_alive
 local command, feed_command = helpers.command, helpers.feed_command
 local eval = helpers.eval
 local eq = helpers.eq
+local neq = helpers.neq
 local exec_lua = helpers.exec_lua
 local insert = helpers.insert
 local meths = helpers.meths
@@ -13,6 +15,7 @@ local curbufmeths = helpers.curbufmeths
 local funcs = helpers.funcs
 local run = helpers.run
 local pcall_err = helpers.pcall_err
+local tbl_contains = global_helpers.tbl_contains
 
 describe('float window', function()
   before_each(function()
@@ -278,6 +281,125 @@ describe('float window', function()
     eq(12, pos[2])
   end)
 
+  it('is not operated on by windo when non-focusable #15374', function()
+    command([[
+      let winids = []
+      windo call add(winids, win_getid())
+    ]])
+    local windo_count_before = eval('len(winids)')
+    local winid = exec_lua([[
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local opts = {
+        relative = 'editor',
+        focusable = false,
+        height = 5,
+        width = 5,
+        col = 5,
+        row = 5,
+      }
+      return vim.api.nvim_open_win(bufnr, false, opts)
+    ]])
+    command([[
+      let winids = []
+      windo call add(winids, win_getid())
+    ]])
+    local windo_count_after = eval('len(winids)')
+    eq(windo_count_before, windo_count_after)
+    eq(false, tbl_contains(eval('winids'), winid))
+  end)
+
+  it('is operated on by windo when focusable', function()
+    command([[
+      let winids = []
+      windo call add(winids, win_getid())
+    ]])
+    local windo_count_before = eval('len(winids)')
+    local winid = exec_lua([[
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local opts = {
+        relative = 'editor',
+        focusable = true,
+        height = 5,
+        width = 5,
+        col = 5,
+        row = 5,
+      }
+      return vim.api.nvim_open_win(bufnr, false, opts)
+    ]])
+    command([[
+      let winids = []
+      windo call add(winids, win_getid())
+    ]])
+    local windo_count_after = eval('len(winids)')
+    eq(windo_count_before + 1, windo_count_after)
+    eq(true, tbl_contains(eval('winids'), winid))
+  end)
+
+  it('is not active after windo when non-focusable #15374', function()
+    local winid = exec_lua([[
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local opts = {
+        relative = 'editor',
+        focusable = false,
+        height = 5,
+        width = 5,
+        col = 5,
+        row = 5,
+      }
+      return vim.api.nvim_open_win(bufnr, false, opts)
+    ]])
+    command('windo echo')
+    neq(eval('win_getid()'), winid)
+  end)
+
+  it('is active after windo when focusable', function()
+    local winid = exec_lua([[
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local opts = {
+        relative = 'editor',
+        focusable = true,
+        height = 5,
+        width = 5,
+        col = 5,
+        row = 5,
+      }
+      return vim.api.nvim_open_win(bufnr, false, opts)
+    ]])
+    command('windo echo')
+    eq(eval('win_getid()'), winid)
+  end)
+
+  it('supports windo with focusable and non-focusable floats', function()
+    local winids = exec_lua([[
+      local result = {vim.api.nvim_get_current_win()}
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local opts = {
+        relative = 'editor',
+        focusable = false,
+        height = 5,
+        width = 5,
+        col = 5,
+        row = 5,
+      }
+      vim.api.nvim_open_win(bufnr, false, opts)
+      opts.focusable = true
+      table.insert(result, vim.api.nvim_open_win(bufnr, false, opts))
+      opts.focusable = false
+      vim.api.nvim_open_win(bufnr, false, opts)
+      opts.focusable = true
+      table.insert(result, vim.api.nvim_open_win(bufnr, false, opts))
+      opts.focusable = false
+      vim.api.nvim_open_win(bufnr, false, opts)
+      return result
+    ]])
+    table.sort(winids)
+    command([[
+      let winids = []
+      windo call add(winids, win_getid())
+      call sort(winids)
+    ]])
+    eq(winids, eval('winids'))
+  end)
 
   local function with_ext_multigrid(multigrid)
     local screen


### PR DESCRIPTION
This updates `:windo` so that it does not operate in non-focusable windows.

The documentation for `:windo` says that it works like doing this:

```vim
CTRL-W t
:{cmd}
CTRL-W w
:{cmd}
etc.
```

Since `ctrl-w w` does not navigate to non-focusable windows, the documentation suggests `:windo` would not operate in non-focusable windows.

The documentation for `nvim_open_win()` describes focusable as:

```
focusable : Enable focus by user actions
(wincmds, mouse events). Defaults to true.
Non-focusable windows can be entered by
nvim_set_current_win().
```

This suggests that `:windo`, which is a user action, would not permit focusing on a non-focusable window. The example in #15374, prior to the update in this PR, results in `:windo` shifting focus to a non-focusable window.

The update in this PR addresses #15374.