### PR TITLE
fix(screen): missing search highlights when redrawing from timer

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -763,10 +763,8 @@ static void win_update(win_T *wp, Providers *providers)
   bool didline = false;         // if true, we finished the last line
   int i;
   long j;
-  static bool recursive = false;  // being called recursively
-  const linenr_T old_botline = wp->w_botline;
-  const int old_wrow = wp->w_wrow;
-  const int old_wcol = wp->w_wcol;
+  static int recursive = FALSE;         /* being called recursively */
+  int old_botline = wp->w_botline;
   // Remember what happened to the previous line.
 #define DID_NONE 1      // didn't update a line
 #define DID_LINE 2      // updated a normal line
@@ -1745,51 +1743,18 @@ static void win_update(win_T *wp, Providers *providers)
     wp->w_valid |= VALID_BOTLINE;
     wp->w_viewport_invalid = true;
     if (wp == curwin && wp->w_botline != old_botline && !recursive) {
-      const linenr_T old_topline = wp->w_topline;
-      const int new_wcol = wp->w_wcol;
-      recursive = true;
+      recursive = TRUE;
       curwin->w_valid &= ~VALID_TOPLINE;
-      update_topline(curwin);  // may invalidate w_botline again
-
-      if (old_wcol != new_wcol
-          && (wp->w_valid & (VALID_WCOL|VALID_WROW))
-          != (VALID_WCOL|VALID_WROW)) {
-        // A win_line() call applied a fix to screen cursor column to
-        // accommodate concealment of cursor line, but in this call to
-        // update_topline() the cursor's row or column got invalidated.
-        // If they are left invalid, setcursor() will recompute them
-        // but there won't be any further win_line() call to re-fix the
-        // column and the cursor will end up misplaced.  So we call
-        // cursor validation now and reapply the fix again (or call
-        // win_line() to do it for us).
-        validate_cursor();
-        if (wp->w_wcol == old_wcol
-            && wp->w_wrow == old_wrow
-            && old_topline == wp->w_topline) {
-          wp->w_wcol = new_wcol;
-        } else {
-          redrawWinline(wp, wp->w_cursor.lnum);
-        }
-      }
-      // New redraw either due to updated topline or due to wcol fix.
-      if (wp->w_redr_type != 0) {
-        // Don't update for changes in buffer again.
+      update_topline(curwin);         /* may invalidate w_botline again */
+      if (must_redraw != 0) {
+        /* Don't update for changes in buffer again. */
         i = curbuf->b_mod_set;
         curbuf->b_mod_set = false;
-        j = curbuf->b_mod_xlines;
-        curbuf->b_mod_xlines = 0;
         win_update(curwin, providers);
+        must_redraw = 0;
         curbuf->b_mod_set = i;
-        curbuf->b_mod_xlines = j;
       }
-      // Other windows might have w_redr_type raised in update_topline().
-      must_redraw = 0;
-      FOR_ALL_WINDOWS_IN_TAB(wwp, curtab) {
-        if (wwp->w_redr_type > must_redraw) {
-          must_redraw = wwp->w_redr_type;
-        }
-      }
-      recursive = false;
+      recursive = FALSE;
     }
   }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1743,7 +1743,7 @@ static void win_update(win_T *wp, Providers *providers)
     wp->w_valid |= VALID_BOTLINE;
     wp->w_viewport_invalid = true;
     if (wp == curwin && wp->w_botline != old_botline && !recursive) {
-      recursive = TRUE;
+      recursive = true;
       curwin->w_valid &= ~VALID_TOPLINE;
       update_topline(curwin);         /* may invalidate w_botline again */
       if (must_redraw != 0) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1754,7 +1754,7 @@ static void win_update(win_T *wp, Providers *providers)
         must_redraw = 0;
         curbuf->b_mod_set = i;
       }
-      recursive = FALSE;
+      recursive = false;
     }
   }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -764,7 +764,7 @@ static void win_update(win_T *wp, Providers *providers)
   int i;
   long j;
   static bool recursive = false;  // being called recursively
-  int old_botline = wp->w_botline;
+  const linenr_T old_botline = wp->w_botline;
   // Remember what happened to the previous line.
 #define DID_NONE 1      // didn't update a line
 #define DID_LINE 2      // updated a normal line

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1745,7 +1745,7 @@ static void win_update(win_T *wp, Providers *providers)
     if (wp == curwin && wp->w_botline != old_botline && !recursive) {
       recursive = true;
       curwin->w_valid &= ~VALID_TOPLINE;
-      update_topline(curwin);         /* may invalidate w_botline again */
+      update_topline(curwin);  // may invalidate w_botline again
       if (must_redraw != 0) {
         /* Don't update for changes in buffer again. */
         i = curbuf->b_mod_set;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1747,7 +1747,7 @@ static void win_update(win_T *wp, Providers *providers)
       curwin->w_valid &= ~VALID_TOPLINE;
       update_topline(curwin);  // may invalidate w_botline again
       if (must_redraw != 0) {
-        /* Don't update for changes in buffer again. */
+        // Don't update for changes in buffer again.
         i = curbuf->b_mod_set;
         curbuf->b_mod_set = false;
         win_update(curwin, providers);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -763,7 +763,7 @@ static void win_update(win_T *wp, Providers *providers)
   bool didline = false;         // if true, we finished the last line
   int i;
   long j;
-  static int recursive = FALSE;         /* being called recursively */
+  static bool recursive = false;  // being called recursively
   int old_botline = wp->w_botline;
   // Remember what happened to the previous line.
 #define DID_NONE 1      // didn't update a line

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -913,4 +913,46 @@ describe('Screen', function()
     ]]}
     eq(grid_lines, {{2, 0, {{'c', 0, 3}}}})
   end)
+
+  -- Copy of Test_cursor_column_in_concealed_line_after_window_scroll in
+  -- test/functional/ui/syntax_conceal_spec.lua.
+  describe('concealed line after window scroll', function()
+    after_each(function()
+      command(':qall!')
+      os.remove('Xcolesearch')
+    end)
+
+    it('has the correct cursor column', function()
+      insert([[
+      3split
+      let m = matchadd('Conceal', '=')
+      setl conceallevel=2 concealcursor=nc
+      normal gg
+      "==expr==
+      ]])
+
+      command('write Xcolesearch')
+      feed(":so %<CR>")
+
+      -- Jump to something that is beyond the bottom of the window,
+      -- so there's a scroll down.
+      feed("/expr<CR>")
+
+      -- Are the concealed parts of the current line really hidden?
+      -- Is the window's cursor column properly updated for hidden
+      -- parts of the current line?
+      screen:expect{grid=[[
+        setl conceallevel2 concealcursornc                   |
+        normal gg                                            |
+        "{5:^expr}                                                |
+        {2:Xcolesearch                                          }|
+        normal gg                                            |
+        "=={5:expr}==                                            |
+                                                             |
+        {0:~                                                    }|
+        {3:Xcolesearch                                          }|
+        /expr                                                |
+      ]]}
+    end)
+  end)
 end)


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/14064.

I'm actually not sure of the effects of this PR: I reverted subsets of the changes in 910bbc3cca796f7fa941e0f6176cd0061de0e01c and removing these lines fixed the issue. Functional tests all pass so I assume nothing major breaks.

I wasn't able to write a lua test that fails either. I tried adding a test which tries the steps in #14064 to `functional/ui/searchhl_spec.lua` but the test doesn't fail before the changes are applied.
```vim
  it('correctly applies highlighting when redrawing in timer', function()
    feed_command('set hlsearch')
    feed_command('set incsearch')

    insert([[






      line 0
      line 1
      line 2
      line 3
      line 4
      line 5
      line 6
    ]])

    command("autocmd CmdlineChanged * call timer_start(0, {-> execute('redraw')})")

    feed("gg/0")
    screen:expect([[
                                              |
                                              |
                                              |
                                              |
                                              |
        line {3:0}                                |
      /0^                                      |
    ]])
  end)
```

IMO the whole patch can be reverted - I manually performed the actions in the Vim test and it doesn't fail even if the patch isn't applied.