### PR TITLE
defaults: make <C-L> clear search highlights and update diffs

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -14,6 +14,10 @@ Various commands					*various*
 							*CTRL-L*
 CTRL-L			Clears and redraws the screen.  The redraw may happen
 			later, after processing typeahead.
+							*CTRL-L-default*
+			By default, also clears search highlighting
+			|:nohlsearch| and updates diffs |:diffupdate|.
+			|default-mappings|
 
 							*:mod* *:mode*
 :mod[e]			Clears and redraws the screen.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -75,9 +75,8 @@ the differences.
 
 Default Mappings:					*default-mappings*
 
-- nnoremap Y y$
-- <C-L> clears search highlights |:nohlsearch| and updates diffs
-  |:diffupdate|
+nnoremap Y y$
+nnoremap <C-L> <Cmd>nohlsearch<Bar>diffupdate<CR><C-L>
 
 ==============================================================================
 3. New Features						       *nvim-features*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -74,7 +74,10 @@ the differences.
 
 
 Default Mappings:					*default-mappings*
-  nnoremap Y y$
+
+- nnoremap Y y$
+- <C-L> clears search highlights |:nohlsearch| and updates diffs
+  |:diffupdate|
 
 ==============================================================================
 3. New Features						       *nvim-features*

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6259,8 +6259,8 @@ static int open_cmdwin(void)
   const int histtype = hist_char2type(cmdwin_type);
   if (histtype == HIST_CMD || histtype == HIST_DEBUG) {
     if (p_wc == TAB) {
-      add_map((char_u *)"<buffer> <Tab> <C-X><C-V>", INSERT);
-      add_map((char_u *)"<buffer> <Tab> a<C-X><C-V>", NORMAL);
+      add_map((char_u *)"<buffer> <Tab> <C-X><C-V>", INSERT, false);
+      add_map((char_u *)"<buffer> <Tab> a<C-X><C-V>", NORMAL, false);
     }
     set_option_value("ft", 0L, "vim", OPT_LOCAL);
   }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4357,14 +4357,21 @@ check_map (
 }
 
 
-// Add a mapping "map" for mode "mode".
-// Need to put string in allocated memory, because do_map() will modify it.
+/// Add a mapping. Unlike @ref do_map this copies the {map} argument, so
+/// static or read-only strings can be used.
+///
+/// @param map  C-string containing the arguments of the map/abbrev command,
+///             i.e. everything except the initial `:[X][nore]map`.
+/// @param mode  Bitflags representing the mode in which to set the mapping.
+///              See @ref get_map_mode.
+/// @param nore  If true, make a non-recursive mapping.
 void add_map(char_u *map, int mode, bool nore)
 {
   char_u      *s;
   char_u      *cpo_save = p_cpo;
 
   p_cpo = (char_u *)"";         // Allow <> notation
+  // Need to put string in allocated memory, because do_map() will modify it.
   s = vim_strsave(map);
   (void)do_map(nore ? 2 : 0, s, mode, false);
   xfree(s);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4357,18 +4357,16 @@ check_map (
 }
 
 
-/*
- * Add a mapping "map" for mode "mode".
- * Need to put string in allocated memory, because do_map() will modify it.
- */
-void add_map(char_u *map, int mode)
+// Add a mapping "map" for mode "mode".
+// Need to put string in allocated memory, because do_map() will modify it.
+void add_map(char_u *map, int mode, bool nore)
 {
   char_u      *s;
   char_u      *cpo_save = p_cpo;
 
   p_cpo = (char_u *)"";         // Allow <> notation
   s = vim_strsave(map);
-  (void)do_map(0, s, mode, FALSE);
+  (void)do_map(nore ? 2 : 0, s, mode, false);
   xfree(s);
   p_cpo = cpo_save;
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -399,7 +399,8 @@ void init_normal_cmds(void)
 
 void init_default_mappings(void)
 {
-  add_map((char_u *)"Y y$", NORMAL);
+  add_map((char_u *)"Y y$", NORMAL, true);
+  add_map((char_u *)"<C-L> <Cmd>nohlsearch<Bar>diffupdate<CR><C-L>", NORMAL, true);
 }
 
 /*

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -22,7 +22,7 @@ set wildoptions=
 set startofline
 set sessionoptions+=options
 
-" Unmap default mappings
+" Unmap Nvim default mappings.
 unmap Y
 unmap <C-L>
 

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -21,7 +21,10 @@ set undodir^=.
 set wildoptions=
 set startofline
 set sessionoptions+=options
+
+" Unmap default mappings
 unmap Y
+unmap <C-L>
 
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -42,7 +42,10 @@ module.nvim_set = (
 module.nvim_argv = {
   module.nvim_prog, '-u', 'NONE', '-i', 'NONE',
   '--cmd', module.nvim_set,
-  '--cmd', 'unmap Y', '--embed'}
+  '--cmd', 'unmap Y',
+  '--cmd', 'unmap <C-L>',
+  '--embed'}
+
 -- Directory containing nvim.
 module.nvim_dir = module.nvim_prog:gsub("[/\\][^/\\]+$", "")
 if module.nvim_dir == module.nvim_prog then


### PR DESCRIPTION
Update the default `<C-L>` mapping to clear search highlights (`:nohlsearch`) and update diffs (`:diffupdate`).

Ref #6289