### PR TITLE
Revert "tests: unit: fix preprocess: pass -m32 for 32bit ABI (#11073)"

### DIFF
--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -89,10 +89,6 @@ local Gcc = {
   get_defines_extra_flags = {'-std=c99', '-dM', '-E'},
   get_declarations_extra_flags = {'-std=c99', '-P', '-E'},
 }
-if ffi.abi("32bit") then
-  table.insert(Gcc.get_defines_extra_flags, '-m32')
-  table.insert(Gcc.get_declarations_extra_flags, '-m32')
-end
 
 function Gcc:define(name, args, val)
   local define = '-D' .. name


### PR DESCRIPTION
This reverts commit ed11721b6bb36042ab065b5045c8eb01115b8902.

It broke multiple 32-bit builds and isn't actually required for building
in a true x86 32-bit environment.

* [armel](https://buildd.debian.org/status/fetch.php?pkg=neovim&arch=armel&ver=0.5.0-1&stamp=1628570331&raw=0)
* [armhf](https://buildd.debian.org/status/fetch.php?pkg=neovim&arch=armhf&ver=0.5.0-1&stamp=1628569985&raw=0)
* [mipsel](https://buildd.debian.org/status/fetch.php?pkg=neovim&arch=mipsel&ver=0.5.0-1&stamp=1628572550&raw=0)