### PR TITLE
[release-0.5] Revert "tests: unit: fix preprocess: pass -m32 for 32bit ABI (#11073)"

### DIFF
--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -89,10 +89,6 @@ local Gcc = {
   get_defines_extra_flags = {'-std=c99', '-dM', '-E'},
   get_declarations_extra_flags = {'-std=c99', '-P', '-E'},
 }
-if ffi.abi("32bit") then
-  table.insert(Gcc.get_defines_extra_flags, '-m32')
-  table.insert(Gcc.get_declarations_extra_flags, '-m32')
-end
 
 function Gcc:define(name, args, val)
   local define = '-D' .. name


### PR DESCRIPTION
Backport of #15386