### PR TITLE
refactor(options): remove vi/vim default value distinction

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -119,10 +119,10 @@ local get_value = function(v)
 end
 
 local get_defaults = function(d,n)
-  if (d.vi == nil and d.vim == nil) or (d.vi ~= nil and d.vim ~= nil) then
-    error("option '"..n.."' should have one and only one default value")
+  if d == nil then
+    error("option '"..n.."' should have a default value")
   end
-  return get_value(d.vim or d.vi)
+  return get_value(d)
 end
 
 local defines = {}

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6,7 +6,7 @@
 --    type='number', list=nil, scope={'global'},
 --    deny_duplicates=nil,
 --    enable_if=nil,
---    defaults={condition=nil, if_true={vi=224, vim=0}, if_false=nil},
+--    defaults={condition=nil, if_true=224, if_false=nil},
 --    secure=nil, gettext=nil, noglob=nil, normal_fname_chars=nil,
 --    pri_mkrc=nil, deny_in_modelines=nil, normal_dname_chars=nil,
 --    modelineexpr=nil,
@@ -21,7 +21,6 @@
 -- scopes: global, buffer, window
 -- redraw options: statuslines, current_window, curent_window_only,
 --                 current_buffer, all_windows, everything, curswant
--- default: {vi=…[, vim=…]}
 -- defaults: {condition=#if condition, if_true=default, if_false=default}
 -- #if condition:
 --    string: #ifdef string
@@ -57,14 +56,14 @@ return {
       type='number', scope={'global'},
       redraw={'curswant'},
       varname='p_aleph',
-      defaults={if_true={vi=224}}
+      defaults={if_true=224}
     },
     {
       full_name='arabic', abbreviation='arab',
       short_desc=N_("Arabic as a default second language"),
       type='bool', scope={'window'},
       redraw={'curswant'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='arabicshape', abbreviation='arshape',
@@ -73,14 +72,14 @@ return {
       redraw={'all_windows', 'ui_option'},
 
       varname='p_arshape',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='allowrevins', abbreviation='ari',
       short_desc=N_("allow CTRL-_ in Insert and Command-line mode"),
       type='bool', scope={'global'},
       varname='p_ari',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='ambiwidth', abbreviation='ambw',
@@ -88,42 +87,42 @@ return {
       type='string', scope={'global'},
       redraw={'all_windows', 'ui_option'},
       varname='p_ambw',
-      defaults={if_true={vi="single"}}
+      defaults={if_true="single"}
     },
     {
       full_name='autochdir', abbreviation='acd',
       short_desc=N_("change directory to the file in the current window"),
       type='bool', scope={'global'},
       varname='p_acd',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='autoindent', abbreviation='ai',
       short_desc=N_("take indent for new line from previous line"),
       type='bool', scope={'buffer'},
       varname='p_ai',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='autoread', abbreviation='ar',
       short_desc=N_("autom. read file when changed outside of Vim"),
       type='bool', scope={'global', 'buffer'},
       varname='p_ar',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='autowrite', abbreviation='aw',
       short_desc=N_("automatically write file if changed"),
       type='bool', scope={'global'},
       varname='p_aw',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='autowriteall', abbreviation='awa',
       short_desc=N_("as 'autowrite', but works with more commands"),
       type='bool', scope={'global'},
       varname='p_awa',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='background', abbreviation='bg',
@@ -131,7 +130,7 @@ return {
       type='string', scope={'global'},
       redraw={'all_windows'},
       varname='p_bg',
-      defaults={if_true={vim="dark"}}
+      defaults={if_true="dark"}
     },
     {
       full_name='backspace', abbreviation='bs',
@@ -139,14 +138,14 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_bs',
-      defaults={if_true={vim="indent,eol,start"}}
+      defaults={if_true="indent,eol,start"}
     },
     {
       full_name='backup', abbreviation='bk',
       short_desc=N_("keep backup file after overwriting a file"),
       type='bool', scope={'global'},
       varname='p_bk',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='backupcopy', abbreviation='bkc',
@@ -156,8 +155,8 @@ return {
       varname='p_bkc',
       defaults={
         condition='UNIX',
-        if_true={vim="auto"},
-        if_false={vim="auto"}
+        if_true="auto",
+        if_false="auto"
       },
     },
     {
@@ -168,7 +167,7 @@ return {
       secure=true,
       expand='nodefault',
       varname='p_bdir',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='backupext', abbreviation='bex',
@@ -176,7 +175,7 @@ return {
       type='string', scope={'global'},
       normal_fname_chars=true,
       varname='p_bex',
-      defaults={if_true={vi="~"}}
+      defaults={if_true="~"}
     },
     {
       full_name='backupskip', abbreviation='bsk',
@@ -184,7 +183,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_bsk',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='belloff', abbreviation='bo',
@@ -192,7 +191,7 @@ return {
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       varname='p_bo',
-      defaults={if_true={vi="all"}}
+      defaults={if_true="all"}
     },
     {
       full_name='binary', abbreviation='bin',
@@ -200,7 +199,7 @@ return {
       type='bool', scope={'buffer'},
       redraw={'statuslines'},
       varname='p_bin',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='bomb',
@@ -209,7 +208,7 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_bomb',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='breakat', abbreviation='brk',
@@ -217,14 +216,14 @@ return {
       type='string', list='flags', scope={'global'},
       redraw={'all_windows'},
       varname='p_breakat',
-      defaults={if_true={vi=" \t!@*-+;:,./?"}}
+      defaults={if_true=" \t!@*-+;:,./?"}
     },
     {
       full_name='breakindent', abbreviation='bri',
       short_desc=N_("wrapped line repeats indent"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='breakindentopt', abbreviation='briopt',
@@ -233,7 +232,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       redraw={'current_buffer'},
-      defaults={if_true={vi=""}},
+      defaults={if_true=""},
     },
     {
       full_name='browsedir', abbreviation='bsdir',
@@ -248,7 +247,7 @@ return {
       noglob=true,
       alloced=true,
       varname='p_bh',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='buflisted', abbreviation='bl',
@@ -256,7 +255,7 @@ return {
       type='bool', scope={'buffer'},
       noglob=true,
       varname='p_bl',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='buftype', abbreviation='bt',
@@ -265,7 +264,7 @@ return {
       noglob=true,
       alloced=true,
       varname='p_bt',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='casemap', abbreviation='cmp',
@@ -273,7 +272,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_cmp',
-      defaults={if_true={vi="internal,keepascii"}}
+      defaults={if_true="internal,keepascii"}
     },
     {
       full_name='cdpath', abbreviation='cd',
@@ -283,14 +282,14 @@ return {
       expand=true,
       secure=true,
       varname='p_cdpath',
-      defaults={if_true={vi=",,"}}
+      defaults={if_true=",,"}
     },
     {
       full_name='cedit',
       short_desc=N_("used to open the command-line window"),
       type='string', scope={'global'},
       varname='p_cedit',
-      defaults={if_true={vim=macros('CTRL_F_STR')}}
+      defaults={if_true=macros('CTRL_F_STR')}
     },
     {
       full_name='channel',
@@ -299,7 +298,7 @@ return {
       no_mkrc=true,
       nodefault=true,
       varname='p_channel',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='charconvert', abbreviation='ccv',
@@ -307,14 +306,14 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_ccv',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='cindent', abbreviation='cin',
       short_desc=N_("do C program indenting"),
       type='bool', scope={'buffer'},
       varname='p_cin',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='cinkeys', abbreviation='cink',
@@ -323,7 +322,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cink',
-      defaults={if_true={vi=indentkeys_default}}
+      defaults={if_true=indentkeys_default}
     },
     {
       full_name='cinoptions', abbreviation='cino',
@@ -332,7 +331,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cino',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='cinwords', abbreviation='cinw',
@@ -341,7 +340,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cinw',
-      defaults={if_true={vi="if,else,while,do,for,switch"}}
+      defaults={if_true="if,else,while,do,for,switch"}
     },
     {
       full_name='clipboard', abbreviation='cb',
@@ -349,7 +348,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_cb',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='cmdheight', abbreviation='ch',
@@ -357,14 +356,14 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows'},
       varname='p_ch',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='cmdwinheight', abbreviation='cwh',
       short_desc=N_("height of the command-line window"),
       type='number', scope={'global'},
       varname='p_cwh',
-      defaults={if_true={vi=7}}
+      defaults={if_true=7}
     },
     {
       full_name='colorcolumn', abbreviation='cc',
@@ -372,7 +371,7 @@ return {
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       redraw={'current_window'},
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='columns', abbreviation='co',
@@ -381,7 +380,7 @@ return {
       no_mkrc=true,
       redraw={'everything'},
       varname='p_columns',
-      defaults={if_true={vi=macros('DFLT_COLS')}}
+      defaults={if_true=macros('DFLT_COLS')}
     },
     {
       full_name='comments', abbreviation='com',
@@ -391,7 +390,7 @@ return {
       alloced=true,
       redraw={'curswant'},
       varname='p_com',
-      defaults={if_true={vi="s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"}}
+      defaults={if_true="s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"}
     },
     {
       full_name='commentstring', abbreviation='cms',
@@ -400,7 +399,7 @@ return {
       alloced=true,
       redraw={'curswant'},
       varname='p_cms',
-      defaults={if_true={vi="/*%s*/"}}
+      defaults={if_true="/*%s*/"}
     },
     {
       full_name='compatible', abbreviation='cp',
@@ -410,7 +409,7 @@ return {
       varname='p_force_off',
       -- pri_mkrc isn't needed here, optval_default()
       -- always returns TRUE for 'compatible'
-      defaults={if_true={vim=false}}
+      defaults={if_true=false}
     },
     {
       full_name='complete', abbreviation='cpt',
@@ -419,7 +418,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cpt',
-      defaults={if_true={vim=".,w,b,u,t"}}
+      defaults={if_true=".,w,b,u,t"}
     },
     {
       full_name='concealcursor', abbreviation='cocu',
@@ -427,14 +426,14 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='conceallevel', abbreviation='cole',
       short_desc=N_("whether concealable text is shown or hidden"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='completefunc', abbreviation='cfu',
@@ -443,7 +442,7 @@ return {
       secure=true,
       alloced=true,
       varname='p_cfu',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='completeopt', abbreviation='cot',
@@ -451,28 +450,28 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_cot',
-      defaults={if_true={vi="menu,preview"}}
+      defaults={if_true="menu,preview"}
     },
     {
       full_name='completeslash', abbreviation='csl',
       type='string', scope={'buffer'},
       varname='p_csl',
       enable_if='BACKSLASH_IN_FILENAME',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='confirm', abbreviation='cf',
       short_desc=N_("ask what to do about unsaved/read-only files"),
       type='bool', scope={'global'},
       varname='p_confirm',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='copyindent', abbreviation='ci',
       short_desc=N_("make 'autoindent' use existing indent structure"),
       type='bool', scope={'buffer'},
       varname='p_ci',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='cpoptions', abbreviation='cpo',
@@ -480,14 +479,14 @@ return {
       type='string', list='flags', scope={'global'},
       redraw={'all_windows'},
       varname='p_cpo',
-      defaults={if_true={vim=macros('CPO_VIM')}}
+      defaults={if_true=macros('CPO_VIM')}
     },
     {
       full_name='cscopepathcomp', abbreviation='cspc',
       short_desc=N_("how many components of the path to show"),
       type='number', scope={'global'},
       varname='p_cspc',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='cscopeprg', abbreviation='csprg',
@@ -496,7 +495,7 @@ return {
       secure=true,
       expand=true,
       varname='p_csprg',
-      defaults={if_true={vi="cscope"}}
+      defaults={if_true="cscope"}
     },
     {
       full_name='cscopequickfix', abbreviation='csqf',
@@ -504,56 +503,56 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_csqf',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='cscoperelative', abbreviation='csre',
       short_desc=N_("Use cscope.out path basename as prefix"),
       type='bool', scope={'global'},
       varname='p_csre',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='cscopetag', abbreviation='cst',
       short_desc=N_("use cscope for tag commands"),
       type='bool', scope={'global'},
       varname='p_cst',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='cscopetagorder', abbreviation='csto',
       short_desc=N_("determines \":cstag\" search order"),
       type='number', scope={'global'},
       varname='p_csto',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='cscopeverbose', abbreviation='csverb',
       short_desc=N_("give messages when adding a cscope database"),
       type='bool', scope={'global'},
       varname='p_csverbose',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='cursorbind', abbreviation='crb',
       short_desc=N_("move cursor in window as it moves in other windows"),
       type='bool', scope={'window'},
       pv_name='p_crbind',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='cursorcolumn', abbreviation='cuc',
       short_desc=N_("highlight the screen column of the cursor"),
       type='bool', scope={'window'},
       redraw={'current_window_only'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='cursorline', abbreviation='cul',
       short_desc=N_("highlight the screen line of the cursor"),
       type='bool', scope={'window'},
       redraw={'current_window_only'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='cursorlineopt', abbreviation='culopt',
@@ -561,14 +560,14 @@ return {
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       redraw={'current_window_only'},
-      defaults={if_true={vi="both"}}
+      defaults={if_true="both"}
     },
     {
       full_name='debug',
       short_desc=N_("to \"msg\" to see all error messages"),
       type='string', scope={'global'},
       varname='p_debug',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='define', abbreviation='def',
@@ -577,14 +576,14 @@ return {
       alloced=true,
       redraw={'curswant'},
       varname='p_def',
-      defaults={if_true={vi="^\\s*#\\s*define"}}
+      defaults={if_true="^\\s*#\\s*define"}
     },
     {
       full_name='delcombine', abbreviation='deco',
       short_desc=N_("delete combining characters on their own"),
       type='bool', scope={'global'},
       varname='p_deco',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='dictionary', abbreviation='dict',
@@ -594,7 +593,7 @@ return {
       normal_dname_chars=true,
       expand=true,
       varname='p_dict',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='diff',
@@ -602,7 +601,7 @@ return {
       type='bool', scope={'window'},
       noglob=true,
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='diffexpr', abbreviation='dex',
@@ -611,7 +610,7 @@ return {
       secure=true,
       redraw={'curswant'},
       varname='p_dex',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='diffopt', abbreviation='dip',
@@ -621,14 +620,14 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_dip',
-      defaults={if_true={vi="internal,filler,closeoff"}}
+      defaults={if_true="internal,filler,closeoff"}
     },
     {
       full_name='digraph', abbreviation='dg',
       short_desc=N_("enable the entering of digraphs in Insert mode"),
       type='bool', scope={'global'},
       varname='p_dg',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='directory', abbreviation='dir',
@@ -638,7 +637,7 @@ return {
       secure=true,
       expand='nodefault',
       varname='p_dir',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='display', abbreviation='dy',
@@ -647,21 +646,21 @@ return {
       deny_duplicates=true,
       redraw={'all_windows'},
       varname='p_dy',
-      defaults={if_true={vim="lastline,msgsep"}}
+      defaults={if_true="lastline,msgsep"}
     },
     {
       full_name='eadirection', abbreviation='ead',
       short_desc=N_("in which direction 'equalalways' works"),
       type='string', scope={'global'},
       varname='p_ead',
-      defaults={if_true={vi="both"}}
+      defaults={if_true="both"}
     },
     {
       full_name='edcompatible', abbreviation='ed',
 	  short_desc=N_("No description"),
       type='bool', scope={'global'},
       varname='p_force_off',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='emoji', abbreviation='emo',
@@ -669,7 +668,7 @@ return {
       type='bool', scope={'global'},
       redraw={'all_windows', 'ui_option'},
       varname='p_emoji',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='encoding', abbreviation='enc',
@@ -677,7 +676,7 @@ return {
       type='string', scope={'global'},
       deny_in_modelines=true,
       varname='p_enc',
-      defaults={if_true={vi=macros('ENC_DFLT')}}
+      defaults={if_true=macros('ENC_DFLT')}
     },
     {
       full_name='endofline', abbreviation='eol',
@@ -686,7 +685,7 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_eol',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='equalalways', abbreviation='ea',
@@ -694,7 +693,7 @@ return {
       type='bool', scope={'global'},
       redraw={'all_windows'},
       varname='p_ea',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='equalprg', abbreviation='ep',
@@ -703,14 +702,14 @@ return {
       secure=true,
       expand=true,
       varname='p_ep',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='errorbells', abbreviation='eb',
       short_desc=N_("ring the bell for error messages"),
       type='bool', scope={'global'},
       varname='p_eb',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='errorfile', abbreviation='ef',
@@ -719,7 +718,7 @@ return {
       secure=true,
       expand=true,
       varname='p_ef',
-      defaults={if_true={vi=macros('DFLT_ERRORFILE')}}
+      defaults={if_true=macros('DFLT_ERRORFILE')}
     },
     {
       full_name='errorformat', abbreviation='efm',
@@ -727,7 +726,7 @@ return {
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       varname='p_efm',
-      defaults={if_true={vi=macros('DFLT_EFM')}}
+      defaults={if_true=macros('DFLT_EFM')}
     },
     {
       full_name='eventignore', abbreviation='ei',
@@ -735,14 +734,14 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ei',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='expandtab', abbreviation='et',
       short_desc=N_("use spaces when <Tab> is inserted"),
       type='bool', scope={'buffer'},
       varname='p_et',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='exrc', abbreviation='ex',
@@ -750,7 +749,7 @@ return {
       type='bool', scope={'global'},
       secure=true,
       varname='p_exrc',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='fileencoding', abbreviation='fenc',
@@ -760,7 +759,7 @@ return {
       alloced=true,
       redraw={'statuslines', 'current_buffer'},
       varname='p_fenc',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='fileencodings', abbreviation='fencs',
@@ -768,7 +767,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_fencs',
-      defaults={if_true={vi="ucs-bom,utf-8,default,latin1"}}
+      defaults={if_true="ucs-bom,utf-8,default,latin1"}
     },
     {
       full_name='fileformat', abbreviation='ff',
@@ -778,7 +777,7 @@ return {
       alloced=true,
       redraw={'curswant', 'statuslines'},
       varname='p_ff',
-      defaults={if_true={vi=macros('DFLT_FF')}}
+      defaults={if_true=macros('DFLT_FF')}
     },
     {
       full_name='fileformats', abbreviation='ffs',
@@ -786,7 +785,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ffs',
-      defaults={if_true={vim=macros('DFLT_FFS_VIM')}}
+      defaults={if_true=macros('DFLT_FFS_VIM')}
     },
     {
       full_name='fileignorecase', abbreviation='fic',
@@ -795,8 +794,8 @@ return {
       varname='p_fic',
       defaults={
         condition='CASE_INSENSITIVE_FILENAME',
-        if_true={vi=true},
-        if_false={vi=false},
+        if_true=true,
+        if_false=false,
       }
     },
     {
@@ -808,7 +807,7 @@ return {
       alloced=true,
       expand=true,
       varname='p_ft',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='fillchars', abbreviation='fcs',
@@ -818,7 +817,7 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_fcs',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='fixendofline', abbreviation='fixeol',
@@ -826,7 +825,7 @@ return {
       type='bool', scope={'buffer'},
       redraw={'statuslines'},
       varname='p_fixeol',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='foldclose', abbreviation='fcl',
@@ -835,7 +834,7 @@ return {
       deny_duplicates=true,
       redraw={'current_window'},
       varname='p_fcl',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='foldcolumn', abbreviation='fdc',
@@ -843,14 +842,14 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="0"}}
+      defaults={if_true="0"}
     },
     {
       full_name='foldenable', abbreviation='fen',
       short_desc=N_("set to display all folds open"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='foldexpr', abbreviation='fde',
@@ -859,7 +858,7 @@ return {
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="0"}}
+      defaults={if_true="0"}
     },
     {
       full_name='foldignore', abbreviation='fdi',
@@ -867,14 +866,14 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="#"}}
+      defaults={if_true="#"}
     },
     {
       full_name='foldlevel', abbreviation='fdl',
       short_desc=N_("close folds with a level higher than this"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='foldlevelstart', abbreviation='fdls',
@@ -882,7 +881,7 @@ return {
       type='number', scope={'global'},
       redraw={'curswant'},
       varname='p_fdls',
-      defaults={if_true={vi=-1}}
+      defaults={if_true=-1}
     },
     {
       full_name='foldmarker', abbreviation='fmr',
@@ -891,7 +890,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="{{{,}}}"}}
+      defaults={if_true="{{{,}}}"}
     },
     {
       full_name='foldmethod', abbreviation='fdm',
@@ -899,21 +898,21 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="manual"}}
+      defaults={if_true="manual"}
     },
     {
       full_name='foldminlines', abbreviation='fml',
       short_desc=N_("minimum number of lines for a fold to be closed"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='foldnestmax', abbreviation='fdn',
       short_desc=N_("maximum fold depth"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=20}}
+      defaults={if_true=20}
     },
     {
       full_name='foldopen', abbreviation='fdo',
@@ -922,7 +921,7 @@ return {
       deny_duplicates=true,
       redraw={'curswant'},
       varname='p_fdo',
-      defaults={if_true={vi="block,hor,mark,percent,quickfix,search,tag,undo"}}
+      defaults={if_true="block,hor,mark,percent,quickfix,search,tag,undo"}
     },
     {
       full_name='foldtext', abbreviation='fdt',
@@ -931,7 +930,7 @@ return {
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="foldtext()"}}
+      defaults={if_true="foldtext()"}
     },
     {
       full_name='formatexpr', abbreviation='fex',
@@ -940,7 +939,7 @@ return {
       modelineexpr=true,
       alloced=true,
       varname='p_fex',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='formatoptions', abbreviation='fo',
@@ -948,7 +947,7 @@ return {
       type='string', list='flags', scope={'buffer'},
       alloced=true,
       varname='p_fo',
-      defaults={if_true={vim=macros('DFLT_FO_VIM')}}
+      defaults={if_true=macros('DFLT_FO_VIM')}
     },
     {
       full_name='formatlistpat', abbreviation='flp',
@@ -956,7 +955,7 @@ return {
       type='string', scope={'buffer'},
       alloced=true,
       varname='p_flp',
-      defaults={if_true={vi="^\\s*\\d\\+[\\]:.)}\\t ]\\s*"}}
+      defaults={if_true="^\\s*\\d\\+[\\]:.)}\\t ]\\s*"}
     },
     {
       full_name='formatprg', abbreviation='fp',
@@ -965,7 +964,7 @@ return {
       secure=true,
       expand=true,
       varname='p_fp',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='fsync', abbreviation='fs',
@@ -973,14 +972,14 @@ return {
       type='bool', scope={'global'},
       secure=true,
       varname='p_fs',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='gdefault', abbreviation='gd',
       short_desc=N_("the \":substitute\" flag 'g' is default on"),
       type='bool', scope={'global'},
       varname='p_gd',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='grepformat', abbreviation='gfm',
@@ -988,7 +987,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_gefm',
-      defaults={if_true={vi=macros('DFLT_GREPFORMAT')}}
+      defaults={if_true=macros('DFLT_GREPFORMAT')}
     },
     {
       full_name='grepprg', abbreviation='gp',
@@ -1001,8 +1000,8 @@ return {
         condition='WIN32',
         -- Add an extra file name so that grep will always
         -- insert a file name in the match line. */
-        if_true={vi="findstr /n $* nul"},
-        if_false={vi="grep -n $* /dev/null"}
+        if_true="findstr /n $* nul",
+        if_false="grep -n $* /dev/null"
       }
     },
     {
@@ -1011,7 +1010,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_guicursor',
-      defaults={if_true={vi="n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"}}
+      defaults={if_true="n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"}
     },
     {
       full_name='guifont', abbreviation='gfn',
@@ -1020,7 +1019,7 @@ return {
       deny_duplicates=true,
       varname='p_guifont',
       redraw={'ui_option'},
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='guifontwide', abbreviation='gfw',
@@ -1029,7 +1028,7 @@ return {
       deny_duplicates=true,
       redraw={'ui_option'},
       varname='p_guifontwide',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='guioptions', abbreviation='go',
@@ -1060,14 +1059,14 @@ return {
       secure=true,
       expand=true,
       varname='p_hf',
-      defaults={if_true={vi=macros('DFLT_HELPFILE')}}
+      defaults={if_true=macros('DFLT_HELPFILE')}
     },
     {
       full_name='helpheight', abbreviation='hh',
       short_desc=N_("minimum height of a new help window"),
       type='number', scope={'global'},
       varname='p_hh',
-      defaults={if_true={vi=20}}
+      defaults={if_true=20}
     },
     {
       full_name='helplang', abbreviation='hlg',
@@ -1075,14 +1074,14 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_hlg',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='hidden', abbreviation='hid',
       short_desc=N_("don't unload buffer when it is |abandon|ed"),
       type='bool', scope={'global'},
       varname='p_hid',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='highlight', abbreviation='hl',
@@ -1090,28 +1089,28 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_hl',
-      defaults={if_true={vi=macros('HIGHLIGHT_INIT')}}
+      defaults={if_true=macros('HIGHLIGHT_INIT')}
     },
     {
       full_name='history', abbreviation='hi',
       short_desc=N_("number of command-lines that are remembered"),
       type='number', scope={'global'},
       varname='p_hi',
-      defaults={if_true={vim=10000}}
+      defaults={if_true=10000}
     },
     {
       full_name='hkmap', abbreviation='hk',
       short_desc=N_("Hebrew keyboard mapping"),
       type='bool', scope={'global'},
       varname='p_hkmap',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='hkmapp', abbreviation='hkp',
       short_desc=N_("phonetic Hebrew keyboard mapping"),
       type='bool', scope={'global'},
       varname='p_hkmapp',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='hlsearch', abbreviation='hls',
@@ -1119,14 +1118,14 @@ return {
       type='bool', scope={'global'},
       redraw={'all_windows'},
       varname='p_hls',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='icon',
       short_desc=N_("Vim set the text of the window icon"),
       type='bool', scope={'global'},
       varname='p_icon',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='iconstring',
@@ -1134,28 +1133,28 @@ return {
       type='string', scope={'global'},
       modelineexpr=true,
       varname='p_iconstring',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='ignorecase', abbreviation='ic',
       short_desc=N_("ignore case in search patterns"),
       type='bool', scope={'global'},
       varname='p_ic',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='imcmdline', abbreviation='imc',
       short_desc=N_("use IM when starting to edit a command line"),
       type='bool', scope={'global'},
       enable_if=false,
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='imdisable', abbreviation='imd',
       short_desc=N_("do not use the IM in any mode"),
       type='bool', scope={'global'},
       enable_if=false,
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='iminsert', abbreviation='imi',
@@ -1163,7 +1162,7 @@ return {
       type='number', scope={'buffer'},
       varname='p_iminsert', pv_name='p_imi',
       defaults={
-        if_true={vi=macros('B_IMODE_NONE')},
+        if_true=macros('B_IMODE_NONE'),
       }
     },
     {
@@ -1172,7 +1171,7 @@ return {
       type='number', scope={'buffer'},
       varname='p_imsearch', pv_name='p_ims',
       defaults={
-        if_true={vi=macros('B_IMODE_USE_INSERT')},
+        if_true=macros('B_IMODE_USE_INSERT'),
       }
     },
     {
@@ -1181,7 +1180,7 @@ return {
       type='string', scope={'global'},
       redraw={'all_windows'},
       varname='p_icm',
-      defaults={if_true={vi="nosplit"}}
+      defaults={if_true="nosplit"}
     },
     {
       full_name='include', abbreviation='inc',
@@ -1189,7 +1188,7 @@ return {
       type='string', scope={'global', 'buffer'},
       alloced=true,
       varname='p_inc',
-      defaults={if_true={vi="^\\s*#\\s*include"}}
+      defaults={if_true="^\\s*#\\s*include"}
     },
     {
       full_name='includeexpr', abbreviation='inex',
@@ -1198,14 +1197,14 @@ return {
       modelineexpr=true,
       alloced=true,
       varname='p_inex',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='incsearch', abbreviation='is',
       short_desc=N_("highlight match while typing search pattern"),
       type='bool', scope={'global'},
       varname='p_is',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='indentexpr', abbreviation='inde',
@@ -1214,7 +1213,7 @@ return {
       modelineexpr=true,
       alloced=true,
       varname='p_inde',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='indentkeys', abbreviation='indk',
@@ -1223,21 +1222,21 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_indk',
-      defaults={if_true={vi=indentkeys_default}}
+      defaults={if_true=indentkeys_default}
     },
     {
       full_name='infercase', abbreviation='inf',
       short_desc=N_("adjust case of match for keyword completion"),
       type='bool', scope={'buffer'},
       varname='p_inf',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='insertmode', abbreviation='im',
       short_desc=N_("start the edit of a file in Insert mode"),
       type='bool', scope={'global'},
       varname='p_im',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='isfname', abbreviation='isf',
@@ -1249,8 +1248,8 @@ return {
         condition='BACKSLASH_IN_FILENAME',
         -- Excluded are: & and ^ are special in cmd.exe
         -- ( and ) are used in text separating fnames */
-        if_true={vi="@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,="},
-        if_false={vi="@,48-57,/,.,-,_,+,,,#,$,%,~,="}
+        if_true="@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=",
+        if_false="@,48-57,/,.,-,_,+,,,#,$,%,~,="
       }
     },
     {
@@ -1261,8 +1260,8 @@ return {
       varname='p_isi',
       defaults={
         condition='WIN32',
-        if_true={vi="@,48-57,_,128-167,224-235"},
-        if_false={vi="@,48-57,_,192-255"}
+        if_true="@,48-57,_,128-167,224-235",
+        if_false="@,48-57,_,192-255"
       }
     },
     {
@@ -1272,7 +1271,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_isk',
-      defaults={if_true={vim="@,48-57,_,192-255"}}
+      defaults={if_true="@,48-57,_,192-255"}
     },
     {
       full_name='isprint', abbreviation='isp',
@@ -1281,7 +1280,7 @@ return {
       deny_duplicates=true,
       redraw={'all_windows'},
       varname='p_isp',
-      defaults={if_true={vi="@,161-255"}
+      defaults={if_true="@,161-255"
       }
     },
     {
@@ -1289,7 +1288,7 @@ return {
       short_desc=N_("two spaces after a period with a join command"),
       type='bool', scope={'global'},
       varname='p_js',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='jumpoptions', abbreviation='jop',
@@ -1297,7 +1296,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_jop',
-      defaults={if_true={vim=''}}
+      defaults={if_true=''}
     },
     {
       full_name='keymap', abbreviation='kmp',
@@ -1308,7 +1307,7 @@ return {
       alloced=true,
       redraw={'statuslines', 'current_buffer'},
       varname='p_keymap', pv_name='p_kmap',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='keymodel', abbreviation='km',
@@ -1316,7 +1315,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_km',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='keywordprg', abbreviation='kp',
@@ -1326,7 +1325,7 @@ return {
       expand=true,
       varname='p_kp',
       defaults={
-        if_true={vi=":Man"},
+        if_true=":Man",
       }
     },
     {
@@ -1336,7 +1335,7 @@ return {
       deny_duplicates=true,
       secure=true,
       varname='p_langmap',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='langmenu', abbreviation='lm',
@@ -1344,21 +1343,21 @@ return {
       type='string', scope={'global'},
       normal_fname_chars=true,
       varname='p_lm',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='langnoremap', abbreviation='lnr',
       short_desc=N_("do not apply 'langmap' to mapped characters"),
       type='bool', scope={'global'},
       varname='p_lnr',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='langremap', abbreviation='lrm',
       short_desc=N_('No description'),
       type='bool', scope={'global'},
       varname='p_lrm',
-      defaults={if_true={vim=false}}
+      defaults={if_true=false}
     },
     {
       full_name='laststatus', abbreviation='ls',
@@ -1366,21 +1365,21 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows'},
       varname='p_ls',
-      defaults={if_true={vim=2}}
+      defaults={if_true=2}
     },
     {
       full_name='lazyredraw', abbreviation='lz',
       short_desc=N_("don't redraw while executing macros"),
       type='bool', scope={'global'},
       varname='p_lz',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='linebreak', abbreviation='lbr',
       short_desc=N_("wrap long lines at a blank"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='lines',
@@ -1389,7 +1388,7 @@ return {
       no_mkrc=true,
       redraw={'everything'},
       varname='p_lines',
-      defaults={if_true={vi=macros('DFLT_ROWS')}}
+      defaults={if_true=macros('DFLT_ROWS')}
     },
     {
       full_name='linespace', abbreviation='lsp',
@@ -1397,14 +1396,14 @@ return {
       type='number', scope={'global'},
       redraw={'ui_option'},
       varname='p_linespace',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='lisp',
       short_desc=N_("indenting for Lisp"),
       type='bool', scope={'buffer'},
       varname='p_lisp',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='lispwords', abbreviation='lw',
@@ -1412,14 +1411,14 @@ return {
       type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       varname='p_lispwords', pv_name='p_lw',
-      defaults={if_true={vi=macros('LISPWORD_VALUE')}}
+      defaults={if_true=macros('LISPWORD_VALUE')}
     },
     {
       full_name='list',
       short_desc=N_("<Tab> and <EOL>"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='listchars', abbreviation='lcs',
@@ -1429,21 +1428,21 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_lcs',
-      defaults={if_true={vim="tab:> ,trail:-,nbsp:+"}}
+      defaults={if_true="tab:> ,trail:-,nbsp:+"}
     },
     {
       full_name='loadplugins', abbreviation='lpl',
       short_desc=N_("load plugin scripts when starting up"),
       type='bool', scope={'global'},
       varname='p_lpl',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='magic',
       short_desc=N_("special characters in search patterns"),
       type='bool', scope={'global'},
       varname='p_magic',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='makeef', abbreviation='mef',
@@ -1452,14 +1451,14 @@ return {
       secure=true,
       expand=true,
       varname='p_mef',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='makeencoding', abbreviation='menc',
       short_desc=N_("Converts the output of external commands"),
       type='string', scope={'global', 'buffer'},
       varname='p_menc',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='makeprg', abbreviation='mp',
@@ -1468,7 +1467,7 @@ return {
       secure=true,
       expand=true,
       varname='p_mp',
-      defaults={if_true={vi="make"}}
+      defaults={if_true="make"}
     },
     {
       full_name='matchpairs', abbreviation='mps',
@@ -1477,49 +1476,49 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_mps',
-      defaults={if_true={vi="(:),{:},[:]"}}
+      defaults={if_true="(:),{:},[:]"}
     },
     {
       full_name='matchtime', abbreviation='mat',
       short_desc=N_("tenths of a second to show matching paren"),
       type='number', scope={'global'},
       varname='p_mat',
-      defaults={if_true={vi=5}}
+      defaults={if_true=5}
     },
     {
       full_name='maxcombine', abbreviation='mco',
       short_desc=N_("maximum nr of combining characters displayed"),
       type='number', scope={'global'},
       varname='p_mco',
-      defaults={if_true={vi=6}}
+      defaults={if_true=6}
     },
     {
       full_name='maxfuncdepth', abbreviation='mfd',
       short_desc=N_("maximum recursive depth for user functions"),
       type='number', scope={'global'},
       varname='p_mfd',
-      defaults={if_true={vi=100}}
+      defaults={if_true=100}
     },
     {
       full_name='maxmapdepth', abbreviation='mmd',
       short_desc=N_("maximum recursive depth for mapping"),
       type='number', scope={'global'},
       varname='p_mmd',
-      defaults={if_true={vi=1000}}
+      defaults={if_true=1000}
     },
     {
       full_name='maxmempattern', abbreviation='mmp',
       short_desc=N_("maximum memory (in Kbyte) used for pattern search"),
       type='number', scope={'global'},
       varname='p_mmp',
-      defaults={if_true={vi=1000}}
+      defaults={if_true=1000}
     },
     {
       full_name='menuitems', abbreviation='mis',
       short_desc=N_("maximum number of items in a menu"),
       type='number', scope={'global'},
       varname='p_mis',
-      defaults={if_true={vi=25}}
+      defaults={if_true=25}
     },
     {
       full_name='mkspellmem', abbreviation='msm',
@@ -1528,14 +1527,14 @@ return {
       secure=true,
       expand=true,
       varname='p_msm',
-      defaults={if_true={vi="460000,2000,500"}}
+      defaults={if_true="460000,2000,500"}
     },
     {
       full_name='modeline', abbreviation='ml',
       short_desc=N_("recognize modelines at start or end of file"),
       type='bool', scope={'buffer'},
       varname='p_ml',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='modelineexpr', abbreviation='mle',
@@ -1543,14 +1542,14 @@ return {
       type='bool', scope={'global'},
       secure=true,
       varname='p_mle',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='modelines', abbreviation='mls',
       short_desc=N_("number of lines checked for modelines"),
       type='number', scope={'global'},
       varname='p_mls',
-      defaults={if_true={vi=5}}
+      defaults={if_true=5}
     },
     {
       full_name='modifiable', abbreviation='ma',
@@ -1558,7 +1557,7 @@ return {
       type='bool', scope={'buffer'},
       noglob=true,
       varname='p_ma',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='modified', abbreviation='mod',
@@ -1567,21 +1566,21 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_mod',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='more',
       short_desc=N_("listings when the whole screen is filled"),
       type='bool', scope={'global'},
       varname='p_more',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='mouse',
       short_desc=N_("the use of mouse clicks"),
       type='string', list='flags', scope={'global'},
       varname='p_mouse',
-      defaults={if_true={vim=""}}
+      defaults={if_true=""}
     },
     {
       full_name='mousefocus', abbreviation='mousef',
@@ -1589,21 +1588,21 @@ return {
       type='bool', scope={'global'},
       redraw={'ui_option'},
       varname='p_mousef',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='mousehide', abbreviation='mh',
       short_desc=N_("hide mouse pointer while typing"),
       type='bool', scope={'global'},
       enable_if=false,
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='mousemodel', abbreviation='mousem',
       short_desc=N_("changes meaning of mouse buttons"),
       type='string', scope={'global'},
       varname='p_mousem',
-      defaults={if_true={vi="extend"}}
+      defaults={if_true="extend"}
     },
     {
       full_name='mouseshape', abbreviation='mouses',
@@ -1617,7 +1616,7 @@ return {
       short_desc=N_("max time between mouse double-click"),
       type='number', scope={'global'},
       varname='p_mouset',
-      defaults={if_true={vi=500}}
+      defaults={if_true=500}
     },
     {
       full_name='nrformats', abbreviation='nf',
@@ -1626,21 +1625,21 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_nf',
-      defaults={if_true={vim="bin,hex"}}
+      defaults={if_true="bin,hex"}
     },
     {
       full_name='number', abbreviation='nu',
       short_desc=N_("print the line number in front of each line"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='numberwidth', abbreviation='nuw',
       short_desc=N_("number of columns used for the line number"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vim=4}}
+      defaults={if_true=4}
     },
     {
       full_name='omnifunc', abbreviation='ofu',
@@ -1649,14 +1648,14 @@ return {
       secure=true,
       alloced=true,
       varname='p_ofu',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='opendevice', abbreviation='odev',
       short_desc=N_("allow reading/writing devices on MS-Windows"),
       type='bool', scope={'global'},
       enable_if=false,
-      defaults={if_true={vim=false}}
+      defaults={if_true=false}
     },
     {
       full_name='operatorfunc', abbreviation='opfunc',
@@ -1664,7 +1663,7 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_opfunc',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='packpath', abbreviation='pp',
@@ -1674,14 +1673,14 @@ return {
       secure=true,
       expand=true,
       varname='p_pp',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='paragraphs', abbreviation='para',
       short_desc=N_("nroff macros that separate paragraphs"),
       type='string', scope={'global'},
       varname='p_para',
-      defaults={if_true={vi="IPLPPPQPP TPHPLIPpLpItpplpipbp"}}
+      defaults={if_true="IPLPPPQPP TPHPLIPpLpItpplpipbp"}
     },
     {
       full_name='paste',
@@ -1689,14 +1688,14 @@ return {
       type='bool', scope={'global'},
       pri_mkrc=true,
       varname='p_paste',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='pastetoggle', abbreviation='pt',
       short_desc=N_("key code that causes 'paste' to toggle"),
       type='string', scope={'global'},
       varname='p_pt',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='patchexpr', abbreviation='pex',
@@ -1704,7 +1703,7 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_pex',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='patchmode', abbreviation='pm',
@@ -1712,7 +1711,7 @@ return {
       type='string', scope={'global'},
       normal_fname_chars=true,
       varname='p_pm',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='path', abbreviation='pa',
@@ -1721,21 +1720,21 @@ return {
       deny_duplicates=true,
       expand=true,
       varname='p_path',
-      defaults={if_true={vi=".,/usr/include,,"}}
+      defaults={if_true=".,/usr/include,,"}
     },
     {
       full_name='preserveindent', abbreviation='pi',
       short_desc=N_("preserve the indent structure when reindenting"),
       type='bool', scope={'buffer'},
       varname='p_pi',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='previewheight', abbreviation='pvh',
       short_desc=N_("height of the preview window"),
       type='number', scope={'global'},
       varname='p_pvh',
-      defaults={if_true={vi=12}}
+      defaults={if_true=12}
     },
     {
       full_name='previewwindow', abbreviation='pvw',
@@ -1743,7 +1742,7 @@ return {
       type='bool', scope={'window'},
       noglob=true,
       redraw={'statuslines'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='printdevice', abbreviation='pdev',
@@ -1751,14 +1750,14 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_pdev',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='printencoding', abbreviation='penc',
       short_desc=N_("encoding to be used for printing"),
       type='string', scope={'global'},
       varname='p_penc',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='printexpr', abbreviation='pexpr',
@@ -1766,35 +1765,35 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_pexpr',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='printfont', abbreviation='pfn',
       short_desc=N_("name of the font to be used for :hardcopy"),
       type='string', scope={'global'},
       varname='p_pfn',
-      defaults={if_true={vi="courier"}}
+      defaults={if_true="courier"}
     },
     {
       full_name='printheader', abbreviation='pheader',
       short_desc=N_("format of the header used for :hardcopy"),
       type='string', scope={'global'},
       varname='p_header',
-      defaults={if_true={vi="%<%f%h%m%=Page %N"}}
+      defaults={if_true="%<%f%h%m%=Page %N"}
     },
     {
       full_name='printmbcharset', abbreviation='pmbcs',
       short_desc=N_("CJK character set to be used for :hardcopy"),
       type='string', scope={'global'},
       varname='p_pmcs',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='printmbfont', abbreviation='pmbfn',
       short_desc=N_("font names to be used for CJK output of :hardcopy"),
       type='string', scope={'global'},
       varname='p_pmfn',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='printoptions', abbreviation='popt',
@@ -1802,14 +1801,14 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_popt',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='prompt',
       short_desc=N_("enable prompt in Ex mode"),
       type='bool', scope={'global'},
       varname='p_force_on',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='pumblend', abbreviation='pb',
@@ -1817,21 +1816,21 @@ return {
       type='number', scope={'global'},
       redraw={'ui_option'},
       varname='p_pb',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='pumheight', abbreviation='ph',
       short_desc=N_("maximum height of the popup menu"),
       type='number', scope={'global'},
       varname='p_ph',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='pumwidth', abbreviation='pw',
       short_desc=N_("minimum width of the popup menu"),
       type='number', scope={'global'},
       varname='p_pw',
-      defaults={if_true={vi=15}}
+      defaults={if_true=15}
     },
     {
       full_name='pyxversion', abbreviation='pyx',
@@ -1839,14 +1838,14 @@ return {
       type='number', scope={'global'},
       secure=true,
       varname='p_pyx',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='quickfixtextfunc', abbreviation='qftf',
       short_desc=N_("customize the quickfix window"),
       type='string', scope={'global'},
       varname='p_qftf',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='quoteescape', abbreviation='qe',
@@ -1854,7 +1853,7 @@ return {
       type='string', scope={'buffer'},
       alloced=true,
       varname='p_qe',
-      defaults={if_true={vi="\\"}}
+      defaults={if_true="\\"}
     },
     {
       full_name='readonly', abbreviation='ro',
@@ -1863,63 +1862,63 @@ return {
       noglob=true,
       redraw={'statuslines'},
       varname='p_ro',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='redrawdebug', abbreviation='rdb',
       short_desc=N_("Changes the way redrawing works (debug)"),
       type='string', list='onecomma', scope={'global'},
       varname='p_rdb',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='redrawtime', abbreviation='rdt',
       short_desc=N_("timeout for 'hlsearch' and |:match| highlighting"),
       type='number', scope={'global'},
       varname='p_rdt',
-      defaults={if_true={vi=2000}}
+      defaults={if_true=2000}
     },
     {
       full_name='regexpengine', abbreviation='re',
       short_desc=N_("default regexp engine to use"),
       type='number', scope={'global'},
       varname='p_re',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='relativenumber', abbreviation='rnu',
       short_desc=N_("show relative line number in front of each line"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='remap',
       short_desc=N_("mappings to work recursively"),
       type='bool', scope={'global'},
       varname='p_remap',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='report',
       short_desc=N_("for reporting nr. of lines changed"),
       type='number', scope={'global'},
       varname='p_report',
-      defaults={if_true={vi=2}}
+      defaults={if_true=2}
     },
     {
       full_name='revins', abbreviation='ri',
       short_desc=N_("inserting characters will work backwards"),
       type='bool', scope={'global'},
       varname='p_ri',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='rightleft', abbreviation='rl',
       short_desc=N_("window is right-to-left oriented"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='rightleftcmd', abbreviation='rlc',
@@ -1927,7 +1926,7 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="search"}}
+      defaults={if_true="search"}
     },
     {
       full_name='ruler', abbreviation='ru',
@@ -1935,7 +1934,7 @@ return {
       type='bool', scope={'global'},
       redraw={'statuslines'},
       varname='p_ru',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='rulerformat', abbreviation='ruf',
@@ -1945,7 +1944,7 @@ return {
       modelineexpr=true,
       redraw={'statuslines'},
       varname='p_ruf',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='runtimepath', abbreviation='rtp',
@@ -1955,7 +1954,7 @@ return {
       secure=true,
       expand='nodefault',
       varname='p_rtp',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='scroll', abbreviation='scr',
@@ -1963,7 +1962,7 @@ return {
       type='number', scope={'window'},
       no_mkrc=true,
       pv_name='p_scroll',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='scrollback', abbreviation='scbk',
@@ -1971,21 +1970,21 @@ return {
       type='number', scope={'buffer'},
       varname='p_scbk',
       redraw={'current_buffer'},
-      defaults={if_true={vi=-1}}
+      defaults={if_true=-1}
     },
     {
       full_name='scrollbind', abbreviation='scb',
       short_desc=N_("scroll in window as other windows scroll"),
       type='bool', scope={'window'},
       pv_name='p_scbind',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='scrolljump', abbreviation='sj',
       short_desc=N_("minimum number of lines to scroll"),
       type='number', scope={'global'},
       varname='p_sj',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='scrolloff', abbreviation='so',
@@ -1993,7 +1992,7 @@ return {
       type='number', scope={'global', 'window'},
       redraw={'all_windows'},
       varname='p_so',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='scrollopt', abbreviation='sbo',
@@ -2001,14 +2000,14 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_sbo',
-      defaults={if_true={vi="ver,jump"}}
+      defaults={if_true="ver,jump"}
     },
     {
       full_name='sections', abbreviation='sect',
       short_desc=N_("nroff macros that separate sections"),
       type='string', scope={'global'},
       varname='p_sections',
-      defaults={if_true={vi="SHNHH HUnhsh"}}
+      defaults={if_true="SHNHH HUnhsh"}
     },
     {
       full_name='secure',
@@ -2016,14 +2015,14 @@ return {
       type='bool', scope={'global'},
       secure=true,
       varname='p_secure',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='selection', abbreviation='sel',
       short_desc=N_("what type of selection to use"),
       type='string', scope={'global'},
       varname='p_sel',
-      defaults={if_true={vi="inclusive"}}
+      defaults={if_true="inclusive"}
     },
     {
       full_name='selectmode', abbreviation='slm',
@@ -2031,7 +2030,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_slm',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='sessionoptions', abbreviation='ssop',
@@ -2039,9 +2038,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ssop',
-      defaults={if_true={
-        vim="blank,buffers,curdir,folds,help,tabpages,winsize"
-      }}
+      defaults={if_true="blank,buffers,curdir,folds,help,tabpages,winsize"}
     },
     {
       full_name='shada', abbreviation='sd',
@@ -2050,7 +2047,7 @@ return {
       deny_duplicates=true,
       secure=true,
       varname='p_shada',
-      defaults={if_true={vim="!,'100,<50,s10,h"}}
+      defaults={if_true="!,'100,<50,s10,h"}
     },
     {
       full_name='shadafile', abbreviation='sdf',
@@ -2060,7 +2057,7 @@ return {
       secure=true,
       expand=true,
       varname='p_shadafile',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='shell', abbreviation='sh',
@@ -2071,8 +2068,8 @@ return {
       varname='p_sh',
       defaults={
         condition='WIN32',
-        if_true={vi="cmd.exe"},
-        if_false={vi="sh"}
+        if_true="cmd.exe",
+        if_false="sh"
       }
     },
     {
@@ -2083,8 +2080,8 @@ return {
       varname='p_shcf',
       defaults={
         condition='WIN32',
-        if_true={vi="/s /c"},
-        if_false={vi="-c"}
+        if_true="/s /c",
+        if_false="-c"
       }
     },
     {
@@ -2095,8 +2092,8 @@ return {
       varname='p_sp',
       defaults={
         condition='WIN32',
-        if_true={vi=">%s 2>&1"},
-        if_false={vi="| tee"},
+        if_true=">%s 2>&1",
+        if_false="| tee",
       }
     },
     {
@@ -2105,7 +2102,7 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_shq',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='shellredir', abbreviation='srr',
@@ -2115,8 +2112,8 @@ return {
       varname='p_srr',
       defaults={
         condition='WIN32',
-        if_true={vi=">%s 2>&1"},
-        if_false={vi=">"}
+        if_true=">%s 2>&1",
+        if_false=">"
       }
     },
     {
@@ -2125,14 +2122,14 @@ return {
       type='bool', scope={'global'},
       varname='p_ssl',
       enable_if='BACKSLASH_IN_FILENAME',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='shelltemp', abbreviation='stmp',
       short_desc=N_("whether to use a temp file for shell commands"),
       type='bool', scope={'global'},
       varname='p_stmp',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='shellxquote', abbreviation='sxq',
@@ -2142,8 +2139,8 @@ return {
       varname='p_sxq',
       defaults={
         condition='WIN32',
-        if_true={vi="\""},
-        if_false={vi=""},
+        if_true="\"",
+        if_false="",
       }
     },
     {
@@ -2152,28 +2149,28 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_sxe',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='shiftround', abbreviation='sr',
       short_desc=N_("round indent to multiple of shiftwidth"),
       type='bool', scope={'global'},
       varname='p_sr',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='shiftwidth', abbreviation='sw',
       short_desc=N_("number of spaces to use for (auto)indent step"),
       type='number', scope={'buffer'},
       varname='p_sw',
-      defaults={if_true={vi=8}}
+      defaults={if_true=8}
     },
     {
       full_name='shortmess', abbreviation='shm',
       short_desc=N_("list of flags, reduce length of messages"),
       type='string', list='flags', scope={'global'},
       varname='p_shm',
-      defaults={if_true={vim="filnxtToOF"}}
+      defaults={if_true="filnxtToOF"}
     },
     {
       full_name='showbreak', abbreviation='sbr',
@@ -2181,35 +2178,35 @@ return {
       type='string', scope={'global'},
       redraw={'all_windows'},
       varname='p_sbr',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='showcmd', abbreviation='sc',
       short_desc=N_("show (partial) command in status line"),
       type='bool', scope={'global'},
       varname='p_sc',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='showfulltag', abbreviation='sft',
       short_desc=N_("show full tag pattern when completing tag"),
       type='bool', scope={'global'},
       varname='p_sft',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='showmatch', abbreviation='sm',
       short_desc=N_("briefly jump to matching bracket if insert one"),
       type='bool', scope={'global'},
       varname='p_sm',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='showmode', abbreviation='smd',
       short_desc=N_("message on status line to show current mode"),
       type='bool', scope={'global'},
       varname='p_smd',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='showtabline', abbreviation='stal',
@@ -2217,14 +2214,14 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows', 'ui_option'},
       varname='p_stal',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='sidescroll', abbreviation='ss',
       short_desc=N_("minimum number of columns to scroll horizontal"),
       type='number', scope={'global'},
       varname='p_ss',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='sidescrolloff', abbreviation='siso',
@@ -2232,7 +2229,7 @@ return {
       type='number', scope={'global', 'window'},
       redraw={'all_windows'},
       varname='p_siso',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='signcolumn', abbreviation='scl',
@@ -2240,42 +2237,42 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi="auto"}}
+      defaults={if_true="auto"}
     },
     {
       full_name='smartcase', abbreviation='scs',
       short_desc=N_("no ignore case when pattern has uppercase"),
       type='bool', scope={'global'},
       varname='p_scs',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='smartindent', abbreviation='si',
       short_desc=N_("smart autoindenting for C programs"),
       type='bool', scope={'buffer'},
       varname='p_si',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='smarttab', abbreviation='sta',
       short_desc=N_("use 'shiftwidth' when inserting <Tab>"),
       type='bool', scope={'global'},
       varname='p_sta',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='softtabstop', abbreviation='sts',
       short_desc=N_("number of spaces that <Tab> uses while editing"),
       type='number', scope={'buffer'},
       varname='p_sts',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='spell',
       short_desc=N_("spell checking"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='spellcapcheck', abbreviation='spc',
@@ -2284,7 +2281,7 @@ return {
       alloced=true,
       redraw={'current_buffer'},
       varname='p_spc',
-      defaults={if_true={vi="[.?!]\\_[\\])'\"	 ]\\+"}}
+      defaults={if_true="[.?!]\\_[\\])'\"	 ]\\+"}
     },
     {
       full_name='spellfile', abbreviation='spf',
@@ -2295,7 +2292,7 @@ return {
       alloced=true,
       expand=true,
       varname='p_spf',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='spelllang', abbreviation='spl',
@@ -2306,7 +2303,7 @@ return {
       expand=true,
       redraw={'current_buffer'},
       varname='p_spl',
-      defaults={if_true={vi="en"}}
+      defaults={if_true="en"}
     },
     {
       full_name='spellsuggest', abbreviation='sps',
@@ -2316,7 +2313,7 @@ return {
       secure=true,
       expand=true,
       varname='p_sps',
-      defaults={if_true={vi="best"}}
+      defaults={if_true="best"}
     },
     {
       full_name='spelloptions', abbreviation='spo',
@@ -2325,21 +2322,21 @@ return {
       secure=true,
       expand=true,
       varname='p_spo',
-      defaults={if_true={vim=""}}
+      defaults={if_true=""}
     },
     {
       full_name='splitbelow', abbreviation='sb',
       short_desc=N_("new window from split is below the current one"),
       type='bool', scope={'global'},
       varname='p_sb',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='splitright', abbreviation='spr',
       short_desc=N_("new window is put right of the current one"),
       type='bool', scope={'global'},
       varname='p_spr',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='startofline', abbreviation='sol',
@@ -2347,7 +2344,7 @@ return {
       type='bool', scope={'global'},
       vim=false,
       varname='p_sol',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='statusline', abbreviation='stl',
@@ -2357,7 +2354,7 @@ return {
       modelineexpr=true,
       redraw={'statuslines'},
       varname='p_stl',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='suffixes', abbreviation='su',
@@ -2365,7 +2362,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_su',
-      defaults={if_true={vi=".bak,~,.o,.h,.info,.swp,.obj"}}
+      defaults={if_true=".bak,~,.o,.h,.info,.swp,.obj"}
     },
     {
       full_name='suffixesadd', abbreviation='sua',
@@ -2374,7 +2371,7 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_sua',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='swapfile', abbreviation='swf',
@@ -2382,7 +2379,7 @@ return {
       type='bool', scope={'buffer'},
       redraw={'statuslines'},
       varname='p_swf',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='switchbuf', abbreviation='swb',
@@ -2390,7 +2387,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_swb',
-      defaults={if_true={vi="uselast"}}
+      defaults={if_true="uselast"}
     },
     {
       full_name='synmaxcol', abbreviation='smc',
@@ -2398,7 +2395,7 @@ return {
       type='number', scope={'buffer'},
       redraw={'current_buffer'},
       varname='p_smc',
-      defaults={if_true={vi=3000}}
+      defaults={if_true=3000}
     },
     {
       full_name='syntax', abbreviation='syn',
@@ -2408,14 +2405,14 @@ return {
       normal_fname_chars=true,
       alloced=true,
       varname='p_syn',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='tagfunc', abbreviation='tfu',
       short_desc=N_("function used to perform tag searches"),
       type='string', scope={'buffer'},
       varname='p_tfu',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='tabline', abbreviation='tal',
@@ -2424,14 +2421,14 @@ return {
       modelineexpr=true,
       redraw={'all_windows'},
       varname='p_tal',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='tabpagemax', abbreviation='tpm',
       short_desc=N_("maximum number of tab pages for |-p| and \"tab all\""),
       type='number', scope={'global'},
       varname='p_tpm',
-      defaults={if_true={vim=50}}
+      defaults={if_true=50}
     },
     {
       full_name='tabstop', abbreviation='ts',
@@ -2439,35 +2436,35 @@ return {
       type='number', scope={'buffer'},
       redraw={'current_buffer'},
       varname='p_ts',
-      defaults={if_true={vi=8}}
+      defaults={if_true=8}
     },
     {
       full_name='tagbsearch', abbreviation='tbs',
       short_desc=N_("use binary searching in tags files"),
       type='bool', scope={'global'},
       varname='p_tbs',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='tagcase', abbreviation='tc',
       short_desc=N_("how to handle case when searching in tags files"),
       type='string', scope={'global', 'buffer'},
       varname='p_tc',
-      defaults={if_true={vim="followic"}}
+      defaults={if_true="followic"}
     },
     {
       full_name='taglength', abbreviation='tl',
       short_desc=N_("number of significant characters for a tag"),
       type='number', scope={'global'},
       varname='p_tl',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='tagrelative', abbreviation='tr',
       short_desc=N_("file names in tag file are relative"),
       type='bool', scope={'global'},
       varname='p_tr',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='tags', abbreviation='tag',
@@ -2476,27 +2473,27 @@ return {
       deny_duplicates=true,
       expand=true,
       varname='p_tags',
-      defaults={if_true={vi="./tags;,tags"}}
+      defaults={if_true="./tags;,tags"}
     },
     {
       full_name='tagstack', abbreviation='tgst',
       short_desc=N_("push tags onto the tag stack"),
       type='bool', scope={'global'},
       varname='p_tgst',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='termbidi', abbreviation='tbidi',
       short_desc=N_("terminal takes care of bi-directionality"),
       type='bool', scope={'global'},
       varname='p_tbidi',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='termencoding', abbreviation='tenc',
       short_desc=N_("Terminal encodig"),
       type='string', scope={'global'},
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='termguicolors', abbreviation='tgc',
@@ -2504,21 +2501,21 @@ return {
       type='bool', scope={'global'},
       redraw={'ui_option'},
       varname='p_tgc',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='termpastefilter', abbreviation='tpf',
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_tpf',
-      defaults={if_true={vim="BS,HT,ESC,DEL"}}
+      defaults={if_true="BS,HT,ESC,DEL"}
     },
     {
       full_name='terse',
       short_desc=N_("hides notification of search wrap"),
       type='bool', scope={'global'},
       varname='p_terse',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='textwidth', abbreviation='tw',
@@ -2526,7 +2523,7 @@ return {
       type='number', scope={'buffer'},
       redraw={'current_buffer'},
       varname='p_tw',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='thesaurus', abbreviation='tsr',
@@ -2536,42 +2533,42 @@ return {
       normal_dname_chars=true,
       expand=true,
       varname='p_tsr',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='tildeop', abbreviation='top',
       short_desc=N_("tilde command \"~\" behaves like an operator"),
       type='bool', scope={'global'},
       varname='p_to',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='timeout', abbreviation='to',
       short_desc=N_("time out on mappings and key codes"),
       type='bool', scope={'global'},
       varname='p_timeout',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='timeoutlen', abbreviation='tm',
       short_desc=N_("time out time in milliseconds"),
       type='number', scope={'global'},
       varname='p_tm',
-      defaults={if_true={vi=1000}}
+      defaults={if_true=1000}
     },
     {
       full_name='title',
       short_desc=N_("Vim set the title of the window"),
       type='bool', scope={'global'},
       varname='p_title',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='titlelen',
       short_desc=N_("of 'columns' used for window title"),
       type='number', scope={'global'},
       varname='p_titlelen',
-      defaults={if_true={vi=85}}
+      defaults={if_true=85}
     },
     {
       full_name='titleold',
@@ -2580,7 +2577,7 @@ return {
       secure=true,
       no_mkrc=true,
       varname='p_titleold',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='titlestring',
@@ -2588,7 +2585,7 @@ return {
       type='string', scope={'global'},
       modelineexpr=true,
       varname='p_titlestring',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='ttimeout',
@@ -2596,7 +2593,7 @@ return {
       type='bool', scope={'global'},
       redraw={'ui_option'},
       varname='p_ttimeout',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='ttimeoutlen', abbreviation='ttm',
@@ -2604,7 +2601,7 @@ return {
       type='number', scope={'global'},
       redraw={'ui_option'},
       varname='p_ttm',
-      defaults={if_true={vi=50}}
+      defaults={if_true=50}
     },
     {
       full_name='ttyfast', abbreviation='tf',
@@ -2612,7 +2609,7 @@ return {
       type='bool', scope={'global'},
       no_mkrc=true,
       varname='p_force_on',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='undodir', abbreviation='udir',
@@ -2622,49 +2619,49 @@ return {
       secure=true,
       expand='nodefault',
       varname='p_udir',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='undofile', abbreviation='udf',
       short_desc=N_("save undo information in a file"),
       type='bool', scope={'buffer'},
       varname='p_udf',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='undolevels', abbreviation='ul',
       short_desc=N_("maximum number of changes that can be undone"),
       type='number', scope={'global', 'buffer'},
       varname='p_ul',
-      defaults={if_true={vi=1000}}
+      defaults={if_true=1000}
     },
     {
       full_name='undoreload', abbreviation='ur',
       short_desc=N_("max nr of lines to save for undo on a buffer reload"),
       type='number', scope={'global'},
       varname='p_ur',
-      defaults={if_true={vi=10000}}
+      defaults={if_true=10000}
     },
     {
       full_name='updatecount', abbreviation='uc',
       short_desc=N_("after this many characters flush swap file"),
       type='number', scope={'global'},
       varname='p_uc',
-      defaults={if_true={vi=200}}
+      defaults={if_true=200}
     },
     {
       full_name='updatetime', abbreviation='ut',
       short_desc=N_("after this many milliseconds flush swap file"),
       type='number', scope={'global'},
       varname='p_ut',
-      defaults={if_true={vi=4000}}
+      defaults={if_true=4000}
     },
     {
       full_name='varsofttabstop', abbreviation='vsts',
       short_desc=N_("list of numbers of spaces that <Tab> uses while editing"),
       type='string', list='comma', scope={'buffer'},
       varname='p_vsts',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='vartabstop', abbreviation='vts',
@@ -2672,14 +2669,14 @@ return {
       type='string', list='comma', scope={'buffer'},
       varname='p_vts',
       redraw={'current_buffer'},
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='verbose', abbreviation='vbs',
       short_desc=N_("give informative messages"),
       type='number', scope={'global'},
       varname='p_verbose',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='verbosefile', abbreviation='vfile',
@@ -2688,7 +2685,7 @@ return {
       secure=true,
       expand=true,
       varname='p_vfile',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='viewdir', abbreviation='vdir',
@@ -2697,7 +2694,7 @@ return {
       secure=true,
       expand='nodefault',
       varname='p_vdir',
-      defaults={if_true={vi=''}}
+      defaults={if_true=''}
     },
     {
       full_name='viewoptions', abbreviation='vop',
@@ -2705,7 +2702,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_vop',
-      defaults={if_true={vi="folds,cursor,curdir"}}
+      defaults={if_true="folds,cursor,curdir"}
     },
     {
       -- Alias for "shada".
@@ -2726,42 +2723,42 @@ return {
       deny_duplicates=true,
       redraw={'curswant'},
       varname='p_ve',
-      defaults={if_true={vim=""}}
+      defaults={if_true=""}
     },
     {
       full_name='visualbell', abbreviation='vb',
       short_desc=N_("use visual bell instead of beeping"),
       type='bool', scope={'global'},
       varname='p_vb',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='warn',
       short_desc=N_("for shell command when buffer was changed"),
       type='bool', scope={'global'},
       varname='p_warn',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='whichwrap', abbreviation='ww',
       short_desc=N_("allow specified keys to cross line boundaries"),
       type='string', list='flagscomma', scope={'global'},
       varname='p_ww',
-      defaults={if_true={vim="b,s"}}
+      defaults={if_true="b,s"}
     },
     {
       full_name='wildchar', abbreviation='wc',
       short_desc=N_("command-line character for wildcard expansion"),
       type='number', scope={'global'},
       varname='p_wc',
-      defaults={if_true={vim=imacros('TAB')}}
+      defaults={if_true=imacros('TAB')}
     },
     {
       full_name='wildcharm', abbreviation='wcm',
       short_desc=N_("like 'wildchar' but also works when mapped"),
       type='number', scope={'global'},
       varname='p_wcm',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='wildignore', abbreviation='wig',
@@ -2769,21 +2766,21 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_wig',
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='wildignorecase', abbreviation='wic',
       short_desc=N_("ignore case when completing file names"),
       type='bool', scope={'global'},
       varname='p_wic',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='wildmenu', abbreviation='wmnu',
       short_desc=N_("use menu for command line completion"),
       type='bool', scope={'global'},
       varname='p_wmnu',
-      defaults={if_true={vim=true}}
+      defaults={if_true=true}
     },
     {
       full_name='wildmode', abbreviation='wim',
@@ -2791,7 +2788,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=false,
       varname='p_wim',
-      defaults={if_true={vim="full"}}
+      defaults={if_true="full"}
     },
     {
       full_name='wildoptions', abbreviation='wop',
@@ -2799,21 +2796,21 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_wop',
-      defaults={if_true={vim='pum,tagfile'}}
+      defaults={if_true='pum,tagfile'}
     },
     {
       full_name='winaltkeys', abbreviation='wak',
       short_desc=N_("when the windows system handles ALT keys"),
       type='string', scope={'global'},
       varname='p_wak',
-      defaults={if_true={vi="menu"}}
+      defaults={if_true="menu"}
     },
     {
       full_name='winblend', abbreviation='winbl',
       short_desc=N_("Controls transparency level for floating windows"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='winhighlight', abbreviation='winhl',
@@ -2821,105 +2818,105 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true={vi=""}}
+      defaults={if_true=""}
     },
     {
       full_name='window', abbreviation='wi',
       short_desc=N_("nr of lines to scroll for CTRL-F and CTRL-B"),
       type='number', scope={'global'},
       varname='p_window',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='winheight', abbreviation='wh',
       short_desc=N_("minimum number of lines for the current window"),
       type='number', scope={'global'},
       varname='p_wh',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='winfixheight', abbreviation='wfh',
       short_desc=N_("keep window height when opening/closing windows"),
       type='bool', scope={'window'},
       redraw={'statuslines'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='winfixwidth', abbreviation='wfw',
       short_desc=N_("keep window width when opening/closing windows"),
       type='bool', scope={'window'},
       redraw={'statuslines'},
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='winminheight', abbreviation='wmh',
       short_desc=N_("minimum number of lines for any window"),
       type='number', scope={'global'},
       varname='p_wmh',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='winminwidth', abbreviation='wmw',
       short_desc=N_("minimal number of columns for any window"),
       type='number', scope={'global'},
       varname='p_wmw',
-      defaults={if_true={vi=1}}
+      defaults={if_true=1}
     },
     {
       full_name='winwidth', abbreviation='wiw',
       short_desc=N_("minimal number of columns for current window"),
       type='number', scope={'global'},
       varname='p_wiw',
-      defaults={if_true={vi=20}}
+      defaults={if_true=20}
     },
     {
       full_name='wrap',
       short_desc=N_("lines wrap and continue on the next line"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='wrapmargin', abbreviation='wm',
       short_desc=N_("chars from the right where wrapping starts"),
       type='number', scope={'buffer'},
       varname='p_wm',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
     {
       full_name='wrapscan', abbreviation='ws',
       short_desc=N_("searches wrap around the end of the file"),
       type='bool', scope={'global'},
       varname='p_ws',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='write',
       short_desc=N_("to a file is allowed"),
       type='bool', scope={'global'},
       varname='p_write',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='writeany', abbreviation='wa',
       short_desc=N_("write to file with no need for \"!\" override"),
       type='bool', scope={'global'},
       varname='p_wa',
-      defaults={if_true={vi=false}}
+      defaults={if_true=false}
     },
     {
       full_name='writebackup', abbreviation='wb',
       short_desc=N_("make a backup before overwriting a file"),
       type='bool', scope={'global'},
       varname='p_wb',
-      defaults={if_true={vi=true}}
+      defaults={if_true=true}
     },
     {
       full_name='writedelay', abbreviation='wd',
       short_desc=N_("delay this many msec for each char (for debug)"),
       type='number', scope={'global'},
       varname='p_wd',
-      defaults={if_true={vi=0}}
+      defaults={if_true=0}
     },
   }
 }


### PR DESCRIPTION
This is a continuation of f0cc3a9480ffc30624a70ebd1e30146bc03a7029.

The `vi`/`vim` default has no real distinction in the `gen_options.lua` script, so just remove it completely.
