### PR TITLE
feat(defaults): support for default autocommands

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1140,6 +1140,11 @@ Thus you can resize the command-line window, but not others.
 The |getcmdwintype()| function returns the type of the command-line being
 edited as described in |cmdwin-char|.
 
+Nvim defines this default CmdWinEnter autocmd in the "nvim_cmdwin" group: >
+    autocmd CmdWinEnter [:>] exe 'syntax sync minlines=1 maxlines='..&cmdwinheight
+<
+You can disable this in your config with "autocmd! nvim_cmdwin". |default-autocmds|
+
 
 AUTOCOMMANDS
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -406,7 +406,11 @@ accordingly.  Vim proceeds in this order:
 	Nvim started with |--embed| waits for the UI to connect before
 	proceeding to load user configuration.
 
-4. Load user config (execute Ex commands from files, environment, …).
+4. Setup default mappings and autocommands.
+	Default mappings |default-mappings| and autocommands |default-autocmds|
+	are created.
+
+5. Load user config (execute Ex commands from files, environment, …).
 	$VIMINIT environment variable is read as one Ex command line (separate
 	multiple commands with '|' or <NL>).
 					*config* *init.vim* *init.lua* *vimrc* *exrc*
@@ -450,7 +454,7 @@ accordingly.  Vim proceeds in this order:
 	-  The file ".nvimrc"
 	-  The file ".exrc"
 
-5. Enable filetype and indent plugins.
+6. Enable filetype and indent plugins.
 	This does the same as the commands: >
 		:runtime! filetype.vim
 		:runtime! ftplugin.vim
@@ -458,13 +462,13 @@ accordingly.  Vim proceeds in this order:
 <	Skipped if ":filetype … off" was called or if the "-u NONE" command
 	line argument was given.
 
-6. Enable syntax highlighting.
+7. Enable syntax highlighting.
 	This does the same as the command: >
 		:runtime! syntax/syntax.vim
 <	Skipped if ":syntax off" was called or if the "-u NONE" command
 	line argument was given.
 
-7. Load the plugin scripts.					*load-plugins*
+8. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >
 		:runtime! plugin/**/*.vim
 		:runtime! plugin/**/*.lua
@@ -494,26 +498,26 @@ accordingly.  Vim proceeds in this order:
 	if packages have been found, but that should not add a directory
 	ending in "after".
 
-8. Set 'shellpipe' and 'shellredir'
+9. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
 	This means that Vim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
-9. Set 'updatecount' to zero, if "-n" command argument used
+10. Set 'updatecount' to zero, if "-n" command argument used
 
-10. Set binary options
+11. Set binary options
 	If the "-b" flag was given to Vim, the options for binary editing will
 	be set now.  See |-b|.
 
-11. Read the ShaDa file
+12. Read the ShaDa file
 	See |shada-file|.
 
-12. Read the quickfix file
+13. Read the quickfix file
 	If the "-q" flag was given to Vim, the quickfix file is read.  If this
 	fails, Vim exits.
 
-13. Open all windows
+14. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
 	displayed yet).
 	When the |-p| flag was given, tab pages will be created (but not
@@ -523,7 +527,7 @@ accordingly.  Vim proceeds in this order:
 	Buffers for all windows will be loaded, without triggering |BufAdd|
 	autocommands.
 
-14. Execute startup commands
+15. Execute startup commands
 	If a "-t" flag was given to Vim, the tag is jumped to.
 	The commands given with the |-c| and |+cmd| arguments are executed.
 	If the 'insertmode' option is set, Insert mode is entered.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -76,12 +76,27 @@ the differences.
 - |g:vimsyn_embed| defaults to "l" to enable Lua highlighting
 
 
-Default Mappings:					*default-mappings*
+Default Mappings ~
+							*default-mappings*
+>
+	nnoremap Y y$
+	nnoremap <C-L> <Cmd>nohlsearch<Bar>diffupdate<CR><C-L>
+	inoremap <C-U> <C-G>u<C-U>
+	inoremap <C-W> <C-G>u<C-W>
+<
+Default Autocommands ~
+							*default-autocmds*
+Default autocommands exist in the following groups. Use ":autocmd! {group}" to
+remove them and ":autocmd {group}" to see how they're defined.
 
-nnoremap Y y$
-nnoremap <C-L> <Cmd>nohlsearch<Bar>diffupdate<CR><C-L>
-inoremap <C-U> <C-G>u<C-U>
-inoremap <C-W> <C-G>u<C-W>
+nvim_terminal:
+- BufReadCmd: New files with a name matching
+              `term://(.{-}//(\d+:)?)?\zs.*` are treated as terminal
+              buffers. |terminal-start|
+
+nvim_cmdwin:
+- CmdWinEnter: Synchronize syntax highlighting within the command
+               window.
 
 ==============================================================================
 3. New Features						       *nvim-features*

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -309,9 +309,6 @@ int main(int argc, char **argv)
   init_highlight(true, false);  // Default highlight groups.
   TIME_MSG("init highlight");
 
-  init_default_mappings();  // Default mappings.
-  TIME_MSG("init default mappings");
-
   // Set the break level after the terminal is initialized.
   debug_break_level = params.use_debug_break_level;
 
@@ -340,21 +337,11 @@ int main(int argc, char **argv)
     TIME_MSG("initialized screen early for UI");
   }
 
-  // open terminals when opening files that start with term://
-#define PROTO "term://"
-  do_cmdline_cmd("augroup nvim_terminal");
-  do_cmdline_cmd("autocmd!");
-  do_cmdline_cmd("autocmd BufReadCmd " PROTO "* nested "
-                 ":if !exists('b:term_title')|call termopen( "
-                 // Capture the command string
-                 "matchstr(expand(\"<amatch>\"), "
-                 "'\\c\\m" PROTO "\\%(.\\{-}//\\%(\\d\\+:\\)\\?\\)\\?\\zs.*'), "
-                 // capture the working directory
-                 "{'cwd': expand(get(matchlist(expand(\"<amatch>\"), "
-                 "'\\c\\m" PROTO "\\(.\\{-}\\)//'), 1, ''))})"
-                 "|endif");
-  do_cmdline_cmd("augroup END");
-#undef PROTO
+  init_default_mappings();  // Default mappings.
+  TIME_MSG("init default mappings");
+
+  init_default_autocmds();
+  TIME_MSG("init default autocommands");
 
   // Reset 'loadplugins' for "-u NONE" before "--cmd" arguments.
   // Allows for setting 'loadplugins' there.


### PR DESCRIPTION
ref #6289 #6399

Add a new default autocommand to limit syntax highlighting
synchronization in the command window. This refactors the nvim_terminal
autocommand out of main() and into a new init_default_autocmds()
function, which is now part of the startup process and can be further
extended with more default autocommands down the road.