### PR TITLE
fix(terminal): don't require ! to close a stopped terminal buffer

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -13,7 +13,7 @@ from the connected program.
 Terminal buffers behave like normal buffers, except:
 - With 'modifiable', lines can be edited but not deleted.
 - 'scrollback' controls how many lines are kept.
-- Output is followed if the cursor is on the last line.
+- Output is followed ("tailed") if cursor is on the last line.
 - 'modified' is the default. You can set 'nomodified' to avoid a warning when
   closing the terminal buffer.
 - 'bufhidden' defaults to "hide".

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1218,8 +1218,8 @@ do_buffer(
       return FAIL;
     }
 
-    if (!forceit && (buf->terminal || bufIsChanged(buf))) {
-      if ((p_confirm || cmdmod.confirm) && p_write && !buf->terminal) {
+    if (!forceit && bufIsChanged(buf)) {
+      if ((p_confirm || cmdmod.confirm) && p_write) {
         dialog_changed(buf, false);
         if (!bufref_valid(&bufref)) {
           // Autocommand deleted buffer, oops! It's not changed now.
@@ -1231,22 +1231,22 @@ do_buffer(
           return FAIL;
         }
       } else {
-        if (buf->terminal) {
-          if (p_confirm || cmdmod.confirm) {
-            if (!dialog_close_terminal(buf)) {
-              return FAIL;
-            }
-          } else {
-            EMSG2(_("E89: %s will be killed (add ! to override)"),
-                  (char *)buf->b_fname);
-            return FAIL;
-          }
-        } else {
-          EMSGN(_("E89: No write since last change for buffer %" PRId64
-                  " (add ! to override)"),
-                buf->b_fnum);
+        EMSGN(_("E89: No write since last change for buffer %" PRId64
+                " (add ! to override)"),
+              buf->b_fnum);
+        return FAIL;
+      }
+    }
+
+    if (!forceit && buf->terminal && terminal_running(buf->terminal)) {
+      if (p_confirm || cmdmod.confirm) {
+        if (!dialog_close_terminal(buf)) {
           return FAIL;
         }
+      } else {
+        EMSG2(_("E89: %s will be killed (add ! to override)"),
+              (char *)buf->b_fname);
+        return FAIL;
       }
     }
 


### PR DESCRIPTION
Closes #4683.

- If the job in a terminal buffer is still running then `!` is still required.
- Change jobwait() such that it always flushes the proc-events queue. Previously it only did this when it actually waited on the process.