### PR TITLE
perf(treesitter): use columns to filter matches in TSHighlighter

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -856,8 +856,9 @@ Query:iter_captures({self}, {node}, {source}, {start}, {stop}, {start_col},
                      from
       • {start}      (integer) Starting line for the search
       • {stop}       (integer) Stopping line for the search (end-exclusive)
-      • {start_col}  (integer) Starting column for the search
-      • {end_col}    (integer) Stopping column for the search (end-exclusive)
+      • {start_col}  (integer|nil) Starting column for the search
+      • {end_col}    (integer|nil) Stopping column for the search
+                     (end-exclusive)
       • {self}
 
     Return: ~
@@ -892,8 +893,9 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop}, {start_col},
       • {source}     (integer|string) Source buffer or string to search
       • {start}      (integer) Starting line for the search
       • {stop}       (integer) Stopping line for the search (end-exclusive)
-      • {start_col}  (integer) Starting column for the search
-      • {end_col}    (integer) Stopping column for the search (end-exclusive)
+      • {start_col}  (integer|nil) Starting column for the search
+      • {end_col}    (integer|nil) Stopping column for the search
+                     (end-exclusive)
       • {self}
 
     Return: ~

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -825,7 +825,8 @@ parse_query({lang}, {query})              *vim.treesitter.query.parse_query()*
         Query Parsed query
 
                                                        *Query:iter_captures()*
-Query:iter_captures({self}, {node}, {source}, {start}, {stop})
+Query:iter_captures({self}, {node}, {source}, {start}, {stop}, {start_col},
+                    {end_col})
     Iterate over all captures from all matches inside {node}
 
     {source} is needed if the query contains predicates; then the caller must
@@ -850,18 +851,21 @@ Query:iter_captures({self}, {node}, {source}, {start}, {stop})
 <
 
     Parameters: ~
-      • {node}    |TSNode| under which the search will occur
-      • {source}  (integer|string) Source buffer or string to extract text
-                  from
-      • {start}   (number) Starting line for the search
-      • {stop}    (number) Stopping line for the search (end-exclusive)
+      • {node}       |TSNode| under which the search will occur
+      • {source}     (integer|string) Source buffer or string to extract text
+                     from
+      • {start}      (integer) Starting line for the search
+      • {stop}       (integer) Stopping line for the search (end-exclusive)
+      • {start_col}  (integer) Starting column for the search
+      • {end_col}    (integer) Stopping column for the search (end-exclusive)
       • {self}
 
     Return: ~
         (fun(): integer, TSNode, TSMetadata ): capture id, capture node, metadata
 
                                                         *Query:iter_matches()*
-Query:iter_matches({self}, {node}, {source}, {start}, {stop})
+Query:iter_matches({self}, {node}, {source}, {start}, {stop}, {start_col},
+                   {end_col})
     Iterates the matches of self on a given range.
 
     Iterate over all matches within a {node}. The arguments are the same as
@@ -884,10 +888,12 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop})
 <
 
     Parameters: ~
-      • {node}    |TSNode| under which the search will occur
-      • {source}  (integer|string) Source buffer or string to search
-      • {start}   (integer) Starting line for the search
-      • {stop}    (integer) Stopping line for the search (end-exclusive)
+      • {node}       |TSNode| under which the search will occur
+      • {source}     (integer|string) Source buffer or string to search
+      • {start}      (integer) Starting line for the search
+      • {stop}       (integer) Stopping line for the search (end-exclusive)
+      • {start_col}  (integer) Starting column for the search
+      • {end_col}    (integer) Stopping column for the search (end-exclusive)
       • {self}
 
     Return: ~

--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -29,15 +29,19 @@ local TSNode = {}
 ---@param captures true
 ---@param start integer
 ---@param end_ integer
+---@param start_col integer?
+---@param end_col integer?
 ---@return fun(): integer, TSNode, any
-function TSNode:_rawquery(query, captures, start, end_) end
+function TSNode:_rawquery(query, captures, start, end_, start_col, end_col) end
 
 ---@param query userdata
 ---@param captures false
 ---@param start integer
 ---@param end_ integer
+---@param start_col integer?
+---@param end_col integer?
 ---@return fun(): string, any
-function TSNode:_rawquery(query, captures, start, end_) end
+function TSNode:_rawquery(query, captures, start, end_, start_col, end_col) end
 
 ---@class TSParser
 ---@field parse fun(self: TSParser, tree, source: integer|string): TSTree, integer[]

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -226,8 +226,9 @@ local function on_line_impl(self, buf, line, leftcol, rightcol, is_spell_nav)
     end
 
     if state.iter == nil or state.next_row < line then
-      state.iter =
-        highlighter_query:query():iter_captures(root_node, self.bufnr, line, root_end_row + 1, leftcol, rightcol)
+      state.iter = highlighter_query
+        :query()
+        :iter_captures(root_node, self.bufnr, line, root_end_row + 1, leftcol, rightcol)
     end
 
     while line >= state.next_row do
@@ -252,7 +253,8 @@ local function on_line_impl(self, buf, line, leftcol, rightcol, is_spell_nav)
       local spell_pri_offset = capture_name == 'nospell' and 1 or 0
 
       if
-        hl and end_row >= line
+        hl
+        and end_row >= line
         and (not is_spell_nav or spell ~= nil)
         and (start_col <= rightcol or end_col >= leftcol)
       then

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -201,6 +201,8 @@ end
 ---@param self TSHighlighter
 ---@param buf integer
 ---@param line integer
+---@param leftcol integer
+---@param rightcol integer
 ---@param is_spell_nav boolean
 local function on_line_impl(self, buf, line, leftcol, rightcol, is_spell_nav)
   ---@diagnostic disable:invisible
@@ -276,13 +278,15 @@ local function on_line_impl(self, buf, line, leftcol, rightcol, is_spell_nav)
         break
       end
     end
-  end, true)
+  end)
 end
 
 ---@private
 ---@param _win integer
 ---@param buf integer
 ---@param line integer
+---@param leftcol integer
+---@param rightcol integer
 function TSHighlighter._on_line(_, _win, buf, line, leftcol, rightcol)
   local self = TSHighlighter.active[buf]
   if not self then
@@ -305,7 +309,7 @@ function TSHighlighter._on_spell_nav(_, _, buf, srow, _, erow, _)
   self:reset_highlight_state()
 
   for row = srow, erow do
-    on_line_impl(self, buf, row, true)
+    on_line_impl(self, buf, row, 0, 0, true)
   end
 end
 

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -62,7 +62,7 @@ end
 ---@returns (string[]|string|nil)
 local function buf_range_get_text(buf, range, concat)
   local lines ---@type string[]
-  local start_row, start_col, end_row, end_col = range[1], range[2], range[4], range[4]
+  local start_row, start_col, end_row, end_col = range[1], range[2], range[3], range[4]
   local eof_row = a.nvim_buf_line_count(buf)
   if start_row >= eof_row then
     return nil

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -57,12 +57,12 @@ end
 
 ---@private
 ---@param buf (number)
----@param range (table)
+---@param range (Range4)
 ---@param concat (boolean)
 ---@returns (string[]|string|nil)
 local function buf_range_get_text(buf, range, concat)
-  local lines
-  local start_row, start_col, end_row, end_col = unpack(range)
+  local lines ---@type string[]
+  local start_row, start_col, end_row, end_col = range[1], range[2], range[4], range[4]
   local eof_row = a.nvim_buf_line_count(buf)
   if start_row >= eof_row then
     return nil
@@ -273,8 +273,8 @@ end
 ---@param opts (table|nil) Optional parameters.
 ---          - concat: (boolean) Concatenate result in a string (default true)
 ---          - metadata (table) Metadata of a specific capture. This would be
----            set to `metadata[capture_id]` when using
----            |vim.treesitter.query.add_directive()|.
+---            set to `metadata[capture_id]` when
+---            using |vim.treesitter.query.add_directive()|.
 ---@return (string[]|string|nil)
 function M.get_node_text(node, source, opts)
   opts = opts or {}
@@ -611,12 +611,12 @@ end
 ---@param node TSNode
 ---@param start integer
 ---@param stop integer
----@param start_col integer
----@param end_col integer
+---@param start_col integer?
+---@param end_col integer?
 ---@return integer, integer, integer, integer
 local function value_or_node_range(node, start, stop, start_col, end_col)
-  if start and stop and start_col and end_col then
-    return start, stop, start_col, end_col
+  if start and stop then
+    return start, stop, start_col or 0, end_col or 0
   end
 
   local node_start, node_start_col, node_stop, node_end_col = node:range()
@@ -649,8 +649,8 @@ end
 ---@param source (integer|string) Source buffer or string to extract text from
 ---@param start integer Starting line for the search
 ---@param stop integer Stopping line for the search (end-exclusive)
----@param start_col integer Starting column for the search
----@param end_col integer Stopping column for the search (end-exclusive)
+---@param start_col integer? Starting column for the search
+---@param end_col integer? Stopping column for the search (end-exclusive)
 ---
 ---@return (fun(): integer, TSNode, TSMetadata): capture id, capture node, metadata
 function Query:iter_captures(node, source, start, stop, start_col, end_col)

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -615,7 +615,7 @@ end
 ---@param node TSNode
 ---@return integer, integer
 local function value_or_node_range(start, stop, node, start_col, end_col)
-  if not (start or stop or start_col or end_col)then
+  if not (start or stop or start_col or end_col) then
     local node_start, node_start_col, node_stop, node_end_col = node:range()
     return node_start, node_stop + 1, node_start_col, node_end_col + 1 -- Make stop inclusive
   end

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -608,19 +608,19 @@ end
 -- When the node's range is used, the stop is incremented by 1
 -- to make the search inclusive.
 ---@private
+---@param node TSNode
 ---@param start integer
 ---@param stop integer
 ---@param start_col integer
 ---@param end_col integer
----@param node TSNode
----@return integer, integer
-local function value_or_node_range(start, stop, node, start_col, end_col)
-  if not (start or stop or start_col or end_col) then
-    local node_start, node_start_col, node_stop, node_end_col = node:range()
-    return node_start, node_stop + 1, node_start_col, node_end_col + 1 -- Make stop inclusive
+---@return integer, integer, integer, integer
+local function value_or_node_range(node, start, stop, start_col, end_col)
+  if start and stop and start_col and end_col then
+    return start, stop, start_col, end_col
   end
 
-  return start, stop, start_col or 0, end_col or 0
+  local node_start, node_start_col, node_stop, node_end_col = node:range()
+  return node_start, node_stop + 1, node_start_col, node_end_col + 1 -- Make stop inclusive
 end
 
 --- Iterate over all captures from all matches inside {node}

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -649,9 +649,8 @@ end
 ---@param source (integer|string) Source buffer or string to extract text from
 ---@param start integer Starting line for the search
 ---@param stop integer Stopping line for the search (end-exclusive)
----@param start_col integer? Starting column for the search
----@param end_col integer? Stopping column for the search (end-exclusive)
----
+---@param start_col (integer|nil) Starting column for the search
+---@param end_col (integer|nil) Stopping column for the search (end-exclusive)
 ---@return (fun(): integer, TSNode, TSMetadata): capture id, capture node, metadata
 function Query:iter_captures(node, source, start, stop, start_col, end_col)
   if type(source) == 'number' and source == 0 then
@@ -706,8 +705,8 @@ end
 ---@param source (integer|string) Source buffer or string to search
 ---@param start integer Starting line for the search
 ---@param stop integer Stopping line for the search (end-exclusive)
----@param start_col integer Starting column for the search
----@param end_col integer Stopping column for the search (end-exclusive)
+---@param start_col (integer|nil) Starting column for the search
+---@param end_col (integer|nil) Stopping column for the search (end-exclusive)
 ---
 ---@return (fun(): integer, table<integer,TSNode>, table): pattern id, match, metadata
 function Query:iter_matches(node, source, start, stop, start_col, end_col)

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -148,15 +148,17 @@ void decor_providers_invoke_win(win_T *wp, DecorProviders *providers,
 /// @param[out] has_decor Set when at least one provider invokes a line callback
 /// @param[out] err       Provider error
 void decor_providers_invoke_line(win_T *wp, DecorProviders *providers, int row, bool *has_decor,
-                                 char **err)
+                                 char **err, int leftoffset, int rightoffset)
 {
   for (size_t k = 0; k < kv_size(*providers); k++) {
     DecorProvider *p = kv_A(*providers, k);
     if (p && p->redraw_line != LUA_NOREF) {
-      MAXSIZE_TEMP_ARRAY(args, 3);
+      MAXSIZE_TEMP_ARRAY(args, 5);
       ADD_C(args, WINDOW_OBJ(wp->handle));
       ADD_C(args, BUFFER_OBJ(wp->w_buffer->handle));
       ADD_C(args, INTEGER_OBJ(row));
+      ADD_C(args, INTEGER_OBJ(leftoffset));
+      ADD_C(args,  INTEGER_OBJ(rightoffset));
       if (decor_provider_invoke(p->ns_id, "line", p->redraw_line, args, true, err)) {
         *has_decor = true;
       } else {

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -158,7 +158,7 @@ void decor_providers_invoke_line(win_T *wp, DecorProviders *providers, int row, 
       ADD_C(args, BUFFER_OBJ(wp->w_buffer->handle));
       ADD_C(args, INTEGER_OBJ(row));
       ADD_C(args, INTEGER_OBJ(leftoffset));
-      ADD_C(args,  INTEGER_OBJ(rightoffset));
+      ADD_C(args, INTEGER_OBJ(rightoffset));
       if (decor_provider_invoke(p->ns_id, "line", p->redraw_line, args, true, err)) {
         *has_decor = true;
       } else {

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -762,6 +762,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
   buf_T *buf = wp->w_buffer;
   bool end_fill = (lnum == buf->b_ml.ml_line_count + 1);
 
+  line = end_fill ? "" : ml_get_buf(buf, lnum, false);
+
   if (!number_only) {
     // To speed up the loop below, set extra_check when there is linebreak,
     // trailing white space and/or syntax processing to be done.
@@ -784,10 +786,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
       }
     }
 
-    line = ml_get_buf(buf, lnum, false);
+    // TODO(lewis6991): plines_win here is expensive. Try and remove.
+    int win_lines = end_fill ? 0 : plines_win(wp, lnum, true);
+
     has_decor = decor_redraw_line(buf, lnum - 1, &decor_state);
 
-    int win_lines = plines_win(wp, lnum, true);
     int leftoffset = wp->w_leftcol + wp->w_skipcol;
     int rightoffset = leftoffset + win_lines * (wp->w_width - win_col_off(wp));
     rightoffset = (int)win_linetabsize(wp, lnum, line, rightoffset);
@@ -1003,7 +1006,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
     line_attr_lowprio_save = line_attr_lowprio;
   }
 
-  line = end_fill ? "" : ml_get_buf(wp->w_buffer, lnum, false);
   ptr = line;
 
   if (has_spell && !number_only) {

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -784,9 +784,16 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
       }
     }
 
+    line = ml_get_buf(buf, lnum, false);
     has_decor = decor_redraw_line(buf, lnum - 1, &decor_state);
 
-    decor_providers_invoke_line(wp, providers, lnum - 1, &has_decor, provider_err);
+    int win_lines = plines_win(wp, lnum, true);
+    int leftoffset = wp->w_leftcol + wp->w_skipcol;
+    int rightoffset = leftoffset + win_lines * (wp->w_width - win_col_off(wp));
+    rightoffset = (int)win_linetabsize(wp, lnum, line, rightoffset);
+
+    decor_providers_invoke_line(wp, providers, lnum - 1, &has_decor, provider_err, leftoffset,
+                                rightoffset);
 
     if (*provider_err) {
       provider_err_virt_text(lnum, *provider_err);

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -790,7 +790,15 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
     has_decor = decor_redraw_line(buf, lnum - 1, &decor_state);
 
     int leftoffset = wp->w_leftcol + wp->w_skipcol;
-    int rightoffset = leftoffset + linetabsize_col(leftoffset, line);
+    int rightoffset;
+    int linevlen = linetabsize(line);
+
+    if (wp->w_p_wrap) {
+      // whole line
+      rightoffset = linevlen;
+    } else {
+      rightoffset = MIN(linevlen, leftoffset + wp->w_width);
+    }
 
     decor_providers_invoke_line(wp, providers, lnum - 1, &has_decor, provider_err, leftoffset,
                                 rightoffset);

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1225,7 +1225,11 @@ static int node_rawquery(lua_State *L)
   if (lua_gettop(L) >= 4) {
     uint32_t start = (uint32_t)luaL_checkinteger(L, 4);
     uint32_t end = lua_gettop(L) >= 5 ? (uint32_t)luaL_checkinteger(L, 5) : MAXLNUM;
-    ts_query_cursor_set_point_range(cursor, (TSPoint){ start, 0 }, (TSPoint){ end, 0 });
+    uint32_t start_col = lua_gettop(L) >= 6 ? (uint32_t)luaL_checkinteger(L, 6) : 0;
+    uint32_t end_col = lua_gettop(L) >= 7 ? (uint32_t)luaL_checkinteger(L, 7) : 0;
+    ts_query_cursor_set_point_range(cursor,
+                                    (TSPoint){ start, start_col },
+                                    (TSPoint){ end, end_col });
   }
 
   TSLua_cursor *ud = lua_newuserdata(L, sizeof(*ud));  // [udata]

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -129,6 +129,72 @@ describe('decorations providers', function()
     }
   end)
 
+  it('can handle long lines', function()
+    local line  = [[// Just a long line to make sure we handle wrapping properly. Need to make sure the line spans two screenlines. ]]
+    insert(line)
+    feed'0'
+
+    setup_provider()
+
+    screen:expect{grid=[[
+      ^// Just a long line to make sure we hand|
+      le wrapping properly. Need to make sure |
+      the line spans two screenlines.         |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]]}
+
+    check_trace {
+      { "start", 4 };
+      { "win", 1000, 1, 0, 2 };
+      { "line", 1000, 1, 0, 0, line:len() };
+      { "end", 4 };
+    }
+
+    exec [[set nowrap]]
+
+    screen:expect{grid=[[
+      ^// Just a long line to make sure we hand|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]]}
+
+    check_trace {
+      { "start", 5 };
+      { "win", 1000, 1, 0, 2 };
+      { "line", 1000, 1, 0, 0, 40 };
+      { "end", 5 };
+    }
+
+    feed'$'
+    screen:expect{grid=[[
+      ans two screenlines.^                    |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]]}
+
+    -- helpers.assert_log('dwdqqwDDD')
+    check_trace {
+      { "start", 6 };
+      { "win", 1000, 1, 0, 2 };
+      { "line", 1000, 1, 0, 91, 112 };
+      { "end", 6 };
+    }
+  end)
+
   it('can have single provider', function()
     insert(mulholland)
     setup_provider [[

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -99,13 +99,13 @@ describe('decorations providers', function()
     check_trace {
       { "start", 4 };
       { "win", 1000, 1, 0, 8 };
-      { "line", 1000, 1, 0 };
-      { "line", 1000, 1, 1 };
-      { "line", 1000, 1, 2 };
-      { "line", 1000, 1, 3 };
-      { "line", 1000, 1, 4 };
-      { "line", 1000, 1, 5 };
-      { "line", 1000, 1, 6 };
+      { "line", 1000, 1, 0, 0, 39 };
+      { "line", 1000, 1, 1, 0, 22 };
+      { "line", 1000, 1, 2, 0, 12 };
+      { "line", 1000, 1, 3, 0, 18 };
+      { "line", 1000, 1, 4, 0, 30 };
+      { "line", 1000, 1, 5, 0, 28 };
+      { "line", 1000, 1, 6, 0, 27 };
       { "end", 4 };
     }
 
@@ -124,7 +124,7 @@ describe('decorations providers', function()
       { "start", 5 };
       { "buf", 1 };
       { "win", 1000, 1, 0, 8 };
-      { "line", 1000, 1, 6 };
+      { "line", 1000, 1, 6, 0, 28 };
       { "end", 5 };
     }
   end)

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -191,10 +191,10 @@ describe('decorations providers', function()
     check_trace {
       { "start", 5 };
       { "win", 1000, 1, 0, 5 };
-      { "line", 1000, 1, 0 };
-      { "line", 1000, 1, 1 };
-      { "line", 1000, 1, 2 };
-      { "line", 1000, 1, 3 };
+      { "line", 1000, 1, 0, 0, 23 };
+      { "line", 1000, 1, 1, 0, 21 };
+      { "line", 1000, 1, 2, 0, 24 };
+      { "line", 1000, 1, 3, 0, 0 };
       { "end", 5 };
     }
 


### PR DESCRIPTION
This allows filtering captures that are not useful, and provides a severe performance boost when handling long lines.

cc @bfredl.

---
### Updates from @lewis6991 

Todo:
- [ ] Handle conceal