### PR TITLE
autocmd: RecordingEnter, RecordingLeave  ("macro" events)

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -815,6 +815,14 @@ RemoteReply			When a reply from a Vim that functions as
 				Note that even if an autocommand is defined,
 				the reply should be read with |remote_read()|
 				to consume it.
+							*RecordingEnter*
+RecordingEnter			When a macro starts to be recorded.
+				The pattern is the current file name, and
+				|reg_recording()| is the current register that
+				is used.
+							*RecordinLeave*
+RecordingLeave			When the is the end of a macro recording.
+				The pattern is the current file name.
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using
 				the |:mksession| command.

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -816,12 +816,12 @@ RemoteReply			When a reply from a Vim that functions as
 				the reply should be read with |remote_read()|
 				to consume it.
 							*RecordingEnter*
-RecordingEnter			When a macro starts to be recorded.
+RecordingEnter			When a macro starts recording.
 				The pattern is the current file name, and
 				|reg_recording()| is the current register that
 				is used.
 							*RecordinLeave*
-RecordingLeave			When the is the end of a macro recording.
+RecordingLeave			When a macro stops recording.
 				The pattern is the current file name.
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2567,6 +2567,7 @@ readdir({dir} [, {expr}])	List	file names in {dir} selected by {expr}
 readfile({fname} [, {type} [, {max}]])
 				List	get list of lines from file {fname}
 reg_executing()			String	get the executing register name
+reg_recorded()			String	get the last recorded register name
 reg_recording()			String	get the recording register name
 reltime([{start} [, {end}]])	List	get time value
 reltimefloat({time})		Float	turn the time value into a Float
@@ -7452,6 +7453,11 @@ reg_executing()						*reg_executing()*
 		Returns the single letter name of the register being executed.
 		Returns an empty string when no register is being executed.
 		See |@|.
+
+reg_recorded()						*reg_recorded()*
+		Returns the single letter name of the last recorded register.
+		Returns an empty string string when nothing was recorded yet.
+		See |q|.
 
 reg_recording()						*reg_recording()*
 		Returns the single letter name of the register being recorded.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -7457,7 +7457,7 @@ reg_executing()						*reg_executing()*
 reg_recorded()						*reg_recorded()*
 		Returns the single letter name of the last recorded register.
 		Returns an empty string string when nothing was recorded yet.
-		See |q|.
+		See |q| and |Q|.
 
 reg_recording()						*reg_recording()*
 		Returns the single letter name of the register being recorded.

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -564,8 +564,8 @@ The command CTRL-\ CTRL-G or <C-\><C-G> can be used to go to Insert mode when
 make sure Vim is in the mode indicated by 'insertmode', without knowing in
 what mode Vim currently is.
 
-				*gQ* *Q* *mode-Ex* *Ex-mode* *Ex* *EX* *E501*
-Q or gQ			Switch to Ex mode.  This is like typing ":" commands
+				*gQ* *mode-Ex* *Ex-mode* *Ex* *EX* *E501*
+gQ			Switch to Ex mode.  This is like typing ":" commands
 			one after another, except:
 			- You don't have to keep pressing ":".
 			- The screen doesn't get updated after each command.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -147,6 +147,9 @@ q			Stops recording.
 							*@@* *E748*
 @@			Repeat the previous @{0-9a-z":*} [count] times.
 
+							*Q*
+Q			Repeat the last recorded register [count] times.
+
 							*:@*
 :[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an Ex
 			command.  First set cursor at line [addr] (default is

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -149,6 +149,7 @@ q			Stops recording.
 
 							*Q*
 Q			Repeat the last recorded register [count] times.
+			See |reg_recorded()|
 
 							*:@*
 :[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an Ex

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -218,6 +218,7 @@ Input/Mappings:
 
 Normal commands:
   |gO| shows a filetype-defined "outline" of the current buffer.
+  |Q|  replays the last recorded macro.
 
 Options:
   'cpoptions'   flags: |cpo-_|

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -73,6 +73,8 @@ return {
     'QuickFixCmdPost',        -- after :make, :grep etc.
     'QuickFixCmdPre',         -- before :make, :grep etc.
     'QuitPre',                -- before :quit
+    'RecordingEnter',         -- when starting to record a macro
+    'RecordingLeave',          -- when stopping to record a macro
     'RemoteReply',            -- upon string reception from a remote vim
     'SessionLoadPost',        -- after loading a session file
     'ShellCmdPost',           -- after ":!cmd"
@@ -127,6 +129,8 @@ return {
   nvim_specific = {
     BufModifiedSet=true,
     DirChanged=true,
+    RecordingEnter=true,
+    RecordingLeave=true,
     Signal=true,
     TabClosed=true,
     TabNew=true,

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -74,7 +74,7 @@ return {
     'QuickFixCmdPre',         -- before :make, :grep etc.
     'QuitPre',                -- before :quit
     'RecordingEnter',         -- when starting to record a macro
-    'RecordingLeave',          -- when stopping to record a macro
+    'RecordingLeave',         -- just before a macro stops recording
     'RemoteReply',            -- upon string reception from a remote vim
     'SessionLoadPost',        -- after loading a session file
     'ShellCmdPost',           -- after ":!cmd"

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -276,6 +276,7 @@ return {
     readfile={args={1, 3}},
     reg_executing={},
     reg_recording={},
+    reg_recorded={},
     reltime={args={0, 2}},
     reltimefloat={args=1},
     reltimestr={args=1},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7338,6 +7338,11 @@ static void f_reg_recording(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   return_register(reg_recording, rettv);
 }
 
+static void f_reg_recorded(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  return_register(reg_recorded, rettv);
+}
+
 /// list2proftime - convert a List to proftime_T
 ///
 /// @param arg The input list, must be of type VAR_LIST and have

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -627,6 +627,7 @@ EXTERN bool ex_no_reprint INIT(=false);   // No need to print after z or p.
 
 EXTERN int reg_recording INIT(= 0);     // register for recording  or zero
 EXTERN int reg_executing INIT(= 0);     // register being executed or zero
+EXTERN int reg_recorded INIT(= 0);      // last recorded register or zero
 
 EXTERN int no_mapping INIT(= false);    // currently no mapping allowed
 EXTERN int no_zero_mapping INIT(= 0);   // mapping zero not allowed

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -236,7 +236,7 @@ static const struct nv_cmd {
   { 'N',       nv_next,        0,                      SEARCH_REV },
   { 'O',       nv_open,        0,                      0 },
   { 'P',       nv_put,         0,                      0 },
-  { 'Q',       nv_exmode,      NV_NCW,                 0 },
+  { 'Q',       nv_regrecorded, 0,                      0 },
   { 'R',       nv_Replace,     0,                      false },
   { 'S',       nv_subst,       NV_KEEPREG,             0 },
   { 'T',       nv_csearch,     NV_NCH_ALW|NV_LANG,     BACKWARD },
@@ -4771,15 +4771,18 @@ dozet:
 /*
  * "Q" command.
  */
-static void nv_exmode(cmdarg_T *cap)
+static void nv_regrecorded(cmdarg_T *cap)
 {
-  /*
-   * Ignore 'Q' in Visual mode, just give a beep.
-   */
-  if (VIsual_active) {
-    vim_beep(BO_EX);
-  } else if (!checkclearop(cap->oap)) {
-    do_exmode();
+  if (checkclearop(cap->oap)) {
+    return;
+  }
+
+  while (cap->count1-- && !got_int) {
+    if (do_execreg(reg_recorded, false, false, false) == false) {
+      clearopbeep(cap->oap);
+      break;
+    }
+    line_breakcheck();
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -236,7 +236,7 @@ static const struct nv_cmd {
   { 'N',       nv_next,        0,                      SEARCH_REV },
   { 'O',       nv_open,        0,                      0 },
   { 'P',       nv_put,         0,                      0 },
-  { 'Q',       nv_regrecorded, 0,                      0 },
+  { 'Q',       nv_regreplay, 0,                      0 },
   { 'R',       nv_Replace,     0,                      false },
   { 'S',       nv_subst,       NV_KEEPREG,             0 },
   { 'T',       nv_csearch,     NV_NCH_ALW|NV_LANG,     BACKWARD },
@@ -4771,7 +4771,7 @@ dozet:
 /*
  * "Q" command.
  */
-static void nv_regrecorded(cmdarg_T *cap)
+static void nv_regreplay(cmdarg_T *cap)
 {
   if (checkclearop(cap->oap)) {
     return;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -925,6 +925,7 @@ int do_record(int c)
     // Get the recorded key hits.  K_SPECIAL and CSI will be escaped, this
     // needs to be removed again to put it in a register.  exec_reg then
     // adds the escaping back later.
+    apply_autocmds(EVENT_RECORDINGLEAVE, NULL, NULL, false, curbuf);
     reg_recorded = reg_recording;
     reg_recording = 0;
     if (ui_has(kUIMessages)) {
@@ -946,8 +947,6 @@ int do_record(int c)
       retval = stuff_yank(regname, p);
 
       y_previous = old_y_previous;
-
-      apply_autocmds(EVENT_RECORDINGLEAVE, NULL, NULL, false, curbuf);
     }
   }
   return retval;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -925,6 +925,7 @@ int do_record(int c)
     // Get the recorded key hits.  K_SPECIAL and CSI will be escaped, this
     // needs to be removed again to put it in a register.  exec_reg then
     // adds the escaping back later.
+    reg_recorded = reg_recording;
     reg_recording = 0;
     if (ui_has(kUIMessages)) {
       showmode();

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -919,13 +919,12 @@ int do_record(int c)
       showmode();
       regname = c;
       retval = OK;
+      apply_autocmds(EVENT_RECORDINGENTER, NULL, NULL, false, curbuf);
     }
-  } else {                        // stop recording
-    /*
-     * Get the recorded key hits.  K_SPECIAL and CSI will be escaped, this
-     * needs to be removed again to put it in a register.  exec_reg then
-     * adds the escaping back later.
-     */
+  } else {  // stop recording
+    // Get the recorded key hits.  K_SPECIAL and CSI will be escaped, this
+    // needs to be removed again to put it in a register.  exec_reg then
+    // adds the escaping back later.
     reg_recording = 0;
     if (ui_has(kUIMessages)) {
       showmode();
@@ -939,15 +938,15 @@ int do_record(int c)
       // Remove escaping for CSI and K_SPECIAL in multi-byte chars.
       vim_unescape_csi(p);
 
-      /*
-       * We don't want to change the default register here, so save and
-       * restore the current register name.
-       */
+      // We don't want to change the default register here, so save and
+      // restore the current register name.
       old_y_previous = y_previous;
 
       retval = stuff_yank(regname, p);
 
       y_previous = old_y_previous;
+
+      apply_autocmds(EVENT_RECORDINGLEAVE, NULL, NULL, false, curbuf);
     }
   }
   return retval;

--- a/test/functional/autocmd/recording_spec.lua
+++ b/test/functional/autocmd/recording_spec.lua
@@ -39,13 +39,14 @@ describe('RecordingLeave', function()
 
   it('gives the correct reg_recorded()', function()
     source_vim [[
-      let g:recorded = ''
+      let g:recorded = 'a'
       let g:recording = ''
       autocmd RecordingLeave * let g:recording = reg_recording()
       autocmd RecordingLeave * let g:recorded = reg_recorded()
       execute "normal! qqyyq"
     ]]
-    eq('', eval 'g:recording')
-    eq('q', eval('g:recorded'))
+    eq('q', eval 'g:recording')
+    eq('', eval 'g:recorded')
+    eq('q', eval 'reg_recorded()')
   end)
 end)

--- a/test/functional/autocmd/recording_spec.lua
+++ b/test/functional/autocmd/recording_spec.lua
@@ -1,0 +1,39 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local eq = helpers.eq
+local eval = helpers.eval
+local source_vim = helpers.source
+
+describe('RecordingEnter', function()
+  before_each(clear)
+  it('works', function()
+    source_vim [[
+      let g:recorded = 0
+      autocmd RecordingEnter * let g:recorded += 1
+      execute "normal! qqyyq"
+    ]]
+    eq(1, eval('g:recorded'))
+  end)
+
+  it('gives a correct reg_recording()', function()
+    source_vim [[
+      let g:recording = ''
+      autocmd RecordingEnter * let g:recording = reg_recording()
+      execute "normal! qqyyq"
+    ]]
+    eq('q', eval('g:recording'))
+  end)
+end)
+
+describe('RecordingLeave', function()
+  before_each(clear)
+  it('works', function()
+    source_vim [[
+      let g:recorded = 0
+      autocmd RecordingLeave * let g:recorded += 1
+      execute "normal! qqyyq"
+    ]]
+    eq(1, eval('g:recorded'))
+  end)
+end)

--- a/test/functional/autocmd/recording_spec.lua
+++ b/test/functional/autocmd/recording_spec.lua
@@ -36,4 +36,16 @@ describe('RecordingLeave', function()
     ]]
     eq(1, eval('g:recorded'))
   end)
+
+  it('gives the correct reg_recorded()', function()
+    source_vim [[
+      let g:recorded = ''
+      let g:recording = ''
+      autocmd RecordingLeave * let g:recording = reg_recording()
+      autocmd RecordingLeave * let g:recorded = reg_recorded()
+      execute "normal! qqyyq"
+    ]]
+    eq('', eval 'g:recording')
+    eq('q', eval('g:recorded'))
+  end)
 end)

--- a/test/functional/editor/macro_spec.lua
+++ b/test/functional/editor/macro_spec.lua
@@ -6,6 +6,8 @@ local feed = helpers.feed
 local clear = helpers.clear
 local expect = helpers.expect
 local command = helpers.command
+local insert = helpers.insert
+local curbufmeths = helpers.curbufmeths
 
 describe('macros', function()
   before_each(clear)
@@ -26,5 +28,30 @@ describe('macros', function()
     feed('@i')
     expect('llllll')
     eq(eval('@i'), 'lxxx')
+  end)
+
+  it('can be replayed with Q', function()
+    insert [[hello
+hello
+hello]]
+    feed [[gg]]
+
+    feed [[qqAFOO<esc>q]]
+    eq({'helloFOO', 'hello', 'hello'}, curbufmeths.get_lines(0, -1, false))
+
+    feed[[Q]]
+    eq({'helloFOOFOO', 'hello', 'hello'}, curbufmeths.get_lines(0, -1, false))
+
+    feed[[G3Q]]
+    eq({'helloFOOFOO', 'hello', 'helloFOOFOOFOO'}, curbufmeths.get_lines(0, -1, false))
+  end)
+end)
+
+describe('reg_recorded()', function()
+  before_each(clear)
+
+  it('returns the correct value', function()
+    feed [[qqyyq]]
+    eq('q', eval('reg_recorded()'))
   end)
 end)


### PR DESCRIPTION
Add some autocmds to determine when the user is recording macros.

TODO:
- [x] Add `RecordingStart` and `RecordingStop` autocmds
- [x] Add `reg_recorded()`, to query what was the latest recorded register
- [x] Provide a default mapping using these features

Fixes partially #15404, cc @clason @justinmk
