### PR TITLE
vim-patch:8.1.2229: cannot color number column above/below cursor differently

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5064,10 +5064,15 @@ Substitute	|:substitute| replacement text highlighting
 							*hl-LineNr*
 LineNr		Line number for ":number" and ":#" commands, and when 'number'
 		or 'relativenumber' option is set.
+							*hl-LineNrAbove*
+LineNrAbove	Line number for when the 'relativenumber'
+		option is set, above the cursor line.
+							*hl-LineNrBelow*
+LineNrBelow	Line number for when the 'relativenumber'
+		option is set, below the cursor line.
 							*hl-CursorLineNr*
-CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt' is
-		set to "number" or "both", or 'relativenumber' is set, for
-		the cursor line.
+CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt'
+		contains "number" or is "both", for the cursor line.
 							*hl-MatchParen*
 MatchParen	The character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -63,7 +63,9 @@ typedef enum {
   , HLF_M           // "--More--" message
   , HLF_CM          // Mode (e.g., "-- INSERT --")
   , HLF_N           // line number for ":number" and ":#" commands
-  , HLF_CLN         // current line number
+  , HLF_LNA         // LineNrAbove
+  , HLF_LNB         // LineNrBelow
+  , HLF_CLN         // current line number when 'cursorline' is set
   , HLF_R           // return to continue message and yes/no questions
   , HLF_S           // status lines
   , HLF_SNC         // status lines of not-current windows
@@ -118,6 +120,8 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_M] = "MoreMsg",
   [HLF_CM] = "ModeMsg",
   [HLF_N] = "LineNr",
+  [HLF_LNA] = "LineNrAbove",
+  [HLF_LNB] = "LineNrBelow",
   [HLF_CLN] = "CursorLineNr",
   [HLF_R] = "Question",
   [HLF_S] = "StatusLine",

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -260,15 +260,13 @@ typedef struct vimoption {
 #define P_MLE          0x80000000U  ///< under control of 'modelineexpr'
 
 #define HIGHLIGHT_INIT \
-  "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText," \
-  "d:Directory,e:ErrorMsg,i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr," \
-  "N:CursorLineNr,r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title," \
-  "v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn," \
-  "A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn,-:Conceal," \
-  "B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel," \
-  "x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill," \
-  "!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine," \
-  "0:Whitespace,I:NormalNC"
+  "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText,d:Directory,e:ErrorMsg," \
+  "i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,a:LineNrAbove,b:LineNrBelow,N:CursorLineNr," \
+  "r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg," \
+  "W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn," \
+  "-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar," \
+  "X:PmenuThumb,*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn," \
+  "q:QuickFixLine,0:Whitespace,I:NormalNC"
 
 /*
  * options[] is initialized here.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2812,6 +2812,15 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow,
             n_extra = number_width(wp) + 1;
             char_attr = win_hl_attr(wp, HLF_N);
 
+            if (wp->w_p_rnu && lnum < wp->w_cursor.lnum) {
+              // Use LineNrAbove
+              char_attr = win_hl_attr(wp, HLF_LNA);
+            }
+            if (wp->w_p_rnu && lnum > wp->w_cursor.lnum) {
+              // Use LineNrBelow
+              char_attr = win_hl_attr(wp, HLF_LNB);
+            }
+
             sign_attrs_T *num_sattr = sign_get_attr(SIGN_NUMHL, sattrs, 0, 1);
             if (num_sattr != NULL) {
               // :sign defined with "numhl" highlight.

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6028,6 +6028,8 @@ static const char *highlight_init_both[] = {
   "VertSplit    cterm=reverse gui=reverse",
   "WildMenu     ctermbg=Yellow ctermfg=Black guibg=Yellow guifg=Black",
   "default link EndOfBuffer NonText",
+  "default link LineNrAbove LineNr",
+  "default link LineNrBelow LineNr",
   "default link QuickFixLine Search",
   "default link Substitute Search",
   "default link Whitespace NonText",

--- a/src/nvim/testdir/test_number.vim
+++ b/src/nvim/testdir/test_number.vim
@@ -3,6 +3,8 @@
 source check.vim
 source view_util.vim
 
+source screendump.vim
+
 func s:screen_lines(start, end) abort
   return ScreenLines([a:start, a:end], 8)
 endfunc
@@ -263,6 +265,37 @@ func Test_relativenumber_uninitialised()
   call feedkeys("j", 'xt')
   redraw
   bwipe!
+endfunc
+
+func Test_relativenumber_colors()
+  CheckScreendump
+
+  let lines =<< trim [CODE]
+    call setline(1, range(200))
+    111
+    set number relativenumber
+    hi LineNr ctermfg=red
+  [CODE]
+  call writefile(lines, 'XTest_relnr')
+
+  " Check that the balloon shows up after a mouse move
+  let buf = RunVimInTerminal('-S XTest_relnr', {'rows': 10, 'cols': 50})
+  call term_wait(buf, 100)
+  " Default colors
+  call VerifyScreenDump(buf, 'Test_relnr_colors_1', {})
+
+  call term_sendkeys(buf, ":hi LineNrAbove ctermfg=blue\<CR>")
+  call VerifyScreenDump(buf, 'Test_relnr_colors_2', {})
+
+  call term_sendkeys(buf, ":hi LineNrBelow ctermfg=green\<CR>")
+  call VerifyScreenDump(buf, 'Test_relnr_colors_3', {})
+
+  call term_sendkeys(buf, ":hi clear LineNrAbove\<CR>")
+  call VerifyScreenDump(buf, 'Test_relnr_colors_4', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XTest_relnr')
 endfunc
 
 " Test for displaying line numbers with 'rightleft'

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -212,10 +212,10 @@ describe('ui/cursor', function()
         if m.blinkwait then m.blinkwait = 700 end
       end
       if m.hl_id then
-          m.hl_id = 56
+          m.hl_id = 58
           m.attr = {background = Screen.colors.DarkGray}
       end
-      if m.id_lm then m.id_lm = 57 end
+      if m.id_lm then m.id_lm = 59 end
     end
 
     -- Assert the new expectation.

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1292,6 +1292,75 @@ describe("MsgSeparator highlight and msgsep fillchar", function()
   end)
 end)
 
+describe("'number' and 'relativenumber' highlight", function()
+  before_each(clear)
+
+  it('LineNr, LineNrAbove and LineNrBelow', function()
+    local screen = Screen.new(20,10)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Red},
+      [2] = {foreground = Screen.colors.Blue},
+      [3] = {foreground = Screen.colors.Green},
+    })
+    screen:attach()
+    command('set number relativenumber')
+    command('call setline(1, range(50))')
+    command('highlight LineNr guifg=Red')
+    feed('4j')
+    screen:expect([[
+      {1:  4 }0               |
+      {1:  3 }1               |
+      {1:  2 }2               |
+      {1:  1 }3               |
+      {1:5   }^4               |
+      {1:  1 }5               |
+      {1:  2 }6               |
+      {1:  3 }7               |
+      {1:  4 }8               |
+                          |
+    ]])
+    command('highlight LineNrAbove guifg=Blue')
+    screen:expect([[
+      {2:  4 }0               |
+      {2:  3 }1               |
+      {2:  2 }2               |
+      {2:  1 }3               |
+      {1:5   }^4               |
+      {1:  1 }5               |
+      {1:  2 }6               |
+      {1:  3 }7               |
+      {1:  4 }8               |
+                          |
+    ]])
+    command('highlight LineNrBelow guifg=Green')
+    screen:expect([[
+      {2:  4 }0               |
+      {2:  3 }1               |
+      {2:  2 }2               |
+      {2:  1 }3               |
+      {1:5   }^4               |
+      {3:  1 }5               |
+      {3:  2 }6               |
+      {3:  3 }7               |
+      {3:  4 }8               |
+                          |
+    ]])
+    feed('3j')
+    screen:expect([[
+      {2:  7 }0               |
+      {2:  6 }1               |
+      {2:  5 }2               |
+      {2:  4 }3               |
+      {2:  3 }4               |
+      {2:  2 }5               |
+      {2:  1 }6               |
+      {1:8   }^7               |
+      {3:  1 }8               |
+                          |
+    ]])
+  end)
+end)
+
 describe("'winhighlight' highlight", function()
   local screen
 


### PR DESCRIPTION
#### vim-patch:8.1.2229: cannot color number column above/below cursor differently

Problem:    Cannot color number column above/below cursor differently.
Solution:   Add LineNrAbove and LineNrBelow. (Shaun Brady, closes vim/vim#624)
https://github.com/vim/vim/commit/efae76ab1a43d5a628d8c2fa4218ace6ba597f5d
