### PR TITLE
fix(tags): increase tag name buffer to 256 bytes

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3062,7 +3062,7 @@ expand_tags (
   int i;
   int c;
   int tagnmflag;
-  char_u tagnm[100];
+  char_u tagnm[256];
   tagptrs_T t_p;
   int ret;
 


### PR DESCRIPTION
It is currently only 100 bytes, which is too short.

Closes #14026.
