### PR TITLE
feat(highlights): some improvements

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -159,6 +159,7 @@ Commands:
   |:drop| is always available
   |:Man| is available by default, with many improvements such as completion
   |:sign-define| accepts a `numhl` argument, to highlight the line number
+  |:match| can be invoked before highlight group is defined
 
 Events:
   |Signal|
@@ -176,6 +177,7 @@ Functions:
   |msgpackdump()|, |msgpackparse()| provide msgpack de/serialization
   |stdpath()|
   |system()|, |systemlist()| can run {cmd} directly (without 'shell')
+  |matchadd()| can be called before highlight group is defined
 
 Highlight groups:
   |highlight-blend| controls blend level for a highlight group

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4253,7 +4253,7 @@ int build_stl_str_hl(
       if (*fmt_p == '#') {
         stl_items[curitem].type = Highlight;
         stl_items[curitem].start = out_p;
-        stl_items[curitem].minwid = -syn_namen2id(t, (int)(fmt_p - t));
+        stl_items[curitem].minwid = -syn_name2id_len(t, (size_t)(fmt_p - t));
         curitem++;
         fmt_p++;
       }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -166,6 +166,7 @@ void early_init(mparm_T *paramp)
   init_path(argv0 ? argv0 : "nvim");
   init_normal_cmds();   // Init the table of Normal mode commands.
   highlight_init();
+  syntax_init();
 
 #ifdef WIN32
   OSVERSIONINFO ovi;

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -194,6 +194,7 @@ static inline bool ColorKey_eq(ColorKey ae1, ColorKey ae2)
 
 MAP_IMPL(int, int, DEFAULT_INITIALIZER)
 MAP_IMPL(cstr_t, ptr_t, DEFAULT_INITIALIZER)
+MAP_IMPL(cstr_t, int, DEFAULT_INITIALIZER)
 MAP_IMPL(ptr_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(uint64_t, ptr_t, DEFAULT_INITIALIZER)
 MAP_IMPL(uint64_t, ssize_t, SSIZE_INITIALIZER)

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -36,6 +36,7 @@
 //
 MAP_DECLS(int, int)
 MAP_DECLS(cstr_t, ptr_t)
+MAP_DECLS(cstr_t, int)
 MAP_DECLS(ptr_t, ptr_t)
 MAP_DECLS(uint64_t, ptr_t)
 MAP_DECLS(uint64_t, ssize_t)

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -157,7 +157,10 @@ func Test_match_error()
 endfunc
 
 func Test_matchadd_error()
-  call assert_fails("call matchadd('GroupDoesNotExist', 'X')", 'E28:')
+  call clearmatches()
+  " Nvim: not an error anymore:
+  call matchadd('GroupDoesNotExist', 'X')
+  call assert_equal([{'group': 'GroupDoesNotExist', 'pattern': 'X', 'priority': 10, 'id': 13}], getmatches())
   call assert_fails("call matchadd('Search', '\\(')", 'E475:')
   call assert_fails("call matchadd('Search', 'XXX', 1, 123, 1)", 'E715:')
   call assert_fails("call matchadd('Error', 'XXX', 1, 3)", 'E798:')

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6534,8 +6534,7 @@ int match_add(win_T *wp, const char *const grp, const char *const pat,
       cur = cur->next;
     }
   }
-  if ((hlg_id = syn_name2id((const char_u *)grp)) == 0) {
-    EMSG2(_(e_nogroup), grp);
+  if ((hlg_id = syn_check_group((const char_u *)grp, strlen(grp))) == 0) {
     return -1;
   }
   if (pat != NULL && (regprog = vim_regcomp((char_u *)pat, RE_MAGIC)) == NULL) {

--- a/test/functional/eval/match_functions_spec.lua
+++ b/test/functional/eval/match_functions_spec.lua
@@ -6,7 +6,6 @@ local clear = helpers.clear
 local funcs = helpers.funcs
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local pcall_err = helpers.pcall_err
 
 before_each(clear)
 
@@ -40,13 +39,13 @@ describe('setmatches()', function()
     }}, funcs.getmatches())
   end)
 
-  it('fails with -1 if highlight group is not defined', function()
-    eq('Vim:E28: No such highlight group name: 1',
-      pcall_err(funcs.setmatches, {{group=1, pattern=2, id=3, priority=4}}))
-    eq({}, funcs.getmatches())
-    eq('Vim:E28: No such highlight group name: 1',
-      pcall_err(funcs.setmatches, {{group=1, pos1={2}, pos2={6}, id=3, priority=4, conceal=5}}))
-    eq({}, funcs.getmatches())
+  it('does not fail if highlight group is not defined', function()
+    eq(0, funcs.setmatches{{group=1, pattern=2, id=3, priority=4}})
+    eq({{group='1', pattern='2', id=3, priority=4}},
+       funcs.getmatches())
+    eq(0, funcs.setmatches{{group=1, pos1={2}, pos2={6}, id=3, priority=4, conceal=5}})
+    eq({{group='1', pos1={2}, pos2={6}, id=3, priority=4, conceal='5'}},
+       funcs.getmatches())
   end)
 end)
 


### PR DESCRIPTION
- make `syn_check_group` allocation free for existing group (so it is as efficient to use as `syn_name2id` always)
- `:match MyGroup /foobar/` throws a meaningless error if it is done before defining `MyGroup`. Make it shut up and to what the user asked about instead. (this ordering requirement does not exist for other usages of highlight).
- use a hashtable for `syn_name2id`. This mostly has an impact when using multiple filetypes (otherwise the only filetype would be first in the lookup order anyway).