### PR TITLE
perf(treesitter): avoid string lookup of highlight name in hot loop

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -85,8 +85,10 @@ function TSHighlighterQuery.new(lang, query_string)
         hl = _link_default_highlight_once(lang .. hl, hl)
       end
 
-      rawset(table, capture, hl)
-      return hl
+      local id = a.nvim_get_hl_id_by_name(hl)
+
+      rawset(table, capture, id)
+      return id
     end
   })
 


### PR DESCRIPTION
`syn_check_group` takes a surprising amount of time in the profile of `provider_invoke` for tree-sitter even with the hashtable #15422 . These numbers are guaranteed to be stable even if you do "highlight clear" (all attributes disappear, but not the id to name mapping itself), so we can just as well store them in the `hl_cache` directly.
