### PR TITLE
feat(lua): startup profiling

### DIFF
--- a/runtime/lua/vim/dumpster_fire.lua
+++ b/runtime/lua/vim/dumpster_fire.lua
@@ -1,0 +1,64 @@
+local mpack = require'mpack'
+
+local M = {}
+_G.d = M
+
+M.cache = {}
+
+function vim._load_hooky(mod, path, f)
+  local dump = string.dump(f)
+  M.cache[mod] = {path, dump}
+  M.dirty = true
+end
+
+function M.dump_cache(path)
+  local f = io.open(path, 'wb')
+  f:write(mpack.pack(M.cache))
+end
+
+function M.load_cache(path)
+  local f = io.open(path, 'rb')
+  M.cache = mpack.unpack(f:read'*a')
+  M.dirty = false
+end
+
+M.tried, M.did = {}, {}
+
+function M.preloader(name)
+  table.insert(M.tried, name)
+  if M.cache[name] == nil then
+    return
+  end
+  local f,codes = unpack(M.cache[name])
+  -- TODO: compare a hashish or a timestamp of the file, or something stupid
+  if vim.fn.filereadable(f) == 0 then
+    return "cached file was joinked"
+  end
+  table.insert(M.did, name)
+  return vim.startup_profile("require'"..name.."' [cached] execute", function() return loadstring(codes)() end)
+end
+
+function M.megapreload()
+  for k,v in pairs(M.cache) do
+    if package.loaded[k] == nil then
+      package.preload[k] = M.preloader
+    end
+  end
+end
+
+function M.dumpster_test(name)
+  if vim.fn.filereadable(name) == 1 then
+    M.load_cache(name)
+    M.megapreload()
+  end
+  function _G.__dumpster_enter()
+    _G.__dumpster_enter = nil
+    if M.dirty then
+      M.dump_cache(name)
+      M.dirty = false
+    end
+  end
+  vim.cmd [[autocmd VimEnter * lua _G.__dumpster_enter()]]
+end
+
+return M

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -818,6 +818,15 @@ ArrayOf(String) nvim_get_runtime_file(String name, Boolean all, Error *err)
 {
   Array rv = ARRAY_DICT_INIT;
 
+  // start measuring lua load time if --startuptime was passed and
+  // time_fd was successfully opened afterwards.
+  proftime_T rel_time;
+  proftime_T start_time;
+  if (time_fd != NULL) {
+    time_push(&rel_time, &start_time);
+  }
+  
+
   int flags = DIP_START | (all ? DIP_ALL : 0);
 
   if (name.size == 0 || name.data[name.size-1] == '/') {
@@ -826,6 +835,16 @@ ArrayOf(String) nvim_get_runtime_file(String name, Boolean all, Error *err)
 
   do_in_runtimepath((char_u *)(name.size ? name.data : ""),
                     flags, find_runtime_cb, &rv);
+
+
+  if (time_fd != NULL) {
+    char buff[IOSIZE];
+    snprintf(buff, sizeof(buff), "rtp lookup: %s", name.size ? name.data : "WUT");
+    time_msg(buff, &start_time);
+    time_pop(rel_time);
+  }
+
+
   return rv;
 }
 

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -61,6 +61,9 @@ function vim._load_package(name)
     local found = vim.api.nvim_get_runtime_file(path, false)
     if #found > 0 then
       local f, err = loadfile(found[1])
+      if rawget(vim, "_load_hooky") then
+        vim._load_hooky(name, found[1], f)
+      end
       return f and function() return vim.startup_profile("require'"..name.."' execute", f) end or error(err)
     end
   end
@@ -84,7 +87,7 @@ function vim._load_package(name)
 end)
 end
 
-table.insert(package.loaders, 1, vim._load_package)
+table.insert(package.loaders, 2, vim._load_package)
 
 -- These are for loading runtime modules lazily since they aren't available in
 -- the nvim binary as specified in executor.c

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -54,13 +54,14 @@ for s in  (package.cpath..';'):gmatch('[^;]*;') do
 end
 
 function vim._load_package(name)
+  return vim.startup_profile("require'"..name.."' lookup/parse", function()
   local basename = name:gsub('%.', '/')
   local paths = {"lua/"..basename..".lua", "lua/"..basename.."/init.lua"}
   for _,path in ipairs(paths) do
     local found = vim.api.nvim_get_runtime_file(path, false)
     if #found > 0 then
       local f, err = loadfile(found[1])
-      return f or error(err)
+      return f and function() return vim.startup_profile("require'"..name.."' execute", f) end or error(err)
     end
   end
 
@@ -80,6 +81,7 @@ function vim._load_package(name)
     end
   end
   return nil
+end)
 end
 
 table.insert(package.loaders, 1, vim._load_package)


### PR DESCRIPTION
Note: too verbose to include in `--startuptime` by default, but I wanted detailed profiling to work on optimizing the separate steps.

Provides lines in startuptime for
- `require'my.module' lookup/parse` total time of the `require` loader (returns the loaded module as an unexecuted function
- `require'my.module' execute` actually executing the code inside the module (should be very fast if it just defines a module of functions)
- `rtp lookup: ...` any use of nvim_get_runtime_file (runs nested within lookup/parse for a lua require).