### PR TITLE
feat(terminal): close shell terminals automatically

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -181,6 +181,10 @@ The following changes to existing APIs or features add new behavior.
   supports it, unless |'keywordprg'| was customized before calling
   |vim.lsp.start()|.
 
+• Terminal buffers started with no arguments (and use 'shell') close
+  automatically if the job exited without error, eliminating the (often
+  unwanted) "[Process exited 0]" message.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -249,6 +249,10 @@ gx			Opens the current filepath or URL (decided by
 			Fails if changes have been made to the current buffer,
 			unless 'hidden' is set.
 
+			If {cmd} is omitted, and the 'shell' job exits with no
+			error, the buffer is closed automatically
+			|default-autocmds|.
+
 			To enter |Terminal-mode| automatically: >
 			      autocmd TermOpen * startinsert
 <

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -133,6 +133,8 @@ remove them and ":autocmd {group}" to see how they're defined.
 
 nvim_terminal:
 - BufReadCmd: Treats "term://" buffers as |terminal| buffers. |terminal-start|
+- TermClose: A |terminal| buffer started with no arguments (which thus uses
+  'shell') and which exits with no error is closed automatically.
 
 nvim_cmdwin:
 - CmdwinEnter: Limits syntax sync to maxlines=1 in the |cmdwin|.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8502,6 +8502,16 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   channel_terminal_open(curbuf, chan);
   channel_create_event(chan, NULL);
+
+  do_cmdline_cmd("augroup nvim_terminal_close");
+  do_cmdline_cmd("autocmd! TermClose <buffer> "
+                 " if !v:event.status |"
+                 "   let info = nvim_get_chan_info(&channel) |"
+                 "   if info.argv ==# [&shell] |"
+                 "     exec 'bdelete! ' .. expand('<abuf>') |"
+                 "   endif |"
+                 " endif");
+  do_cmdline_cmd("augroup END");
 }
 
 /// "timer_info([timer])" function

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8507,7 +8507,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   do_cmdline_cmd("autocmd! TermClose <buffer> "
                  " if !v:event.status |"
                  "   let info = nvim_get_chan_info(&channel) |"
-                 "   if info.argv ==# [&shell] |"
+                 "   if get(info, 'argv', []) ==# [&shell] |"
                  "     exec 'bdelete! ' .. expand('<abuf>') |"
                  "   endif |"
                  " endif");

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8502,16 +8502,6 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   channel_terminal_open(curbuf, chan);
   channel_create_event(chan, NULL);
-
-  do_cmdline_cmd("augroup nvim_terminal_close");
-  do_cmdline_cmd("autocmd! TermClose <buffer> "
-                 " if !v:event.status |"
-                 "   let info = nvim_get_chan_info(&channel) |"
-                 "   if get(info, 'argv', []) ==# [&shell] |"
-                 "     exec 'bdelete! ' .. expand('<abuf>') |"
-                 "   endif |"
-                 " endif");
-  do_cmdline_cmd("augroup END");
 }
 
 /// "timer_info([timer])" function

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -103,12 +103,13 @@ describe('autocmd TermClose', function()
 
   it('reports the correct <abuf>', function()
     command('set hidden')
+    command('set shellcmdflag=EXE')
     command('autocmd TermClose * let g:abuf = expand("<abuf>")')
     command('edit foo')
     command('edit bar')
     eq(2, eval('bufnr("%")'))
 
-    command('terminal')
+    command('terminal ls')
     retry(nil, nil, function() eq(3, eval('bufnr("%")')) end)
 
     command('buffer 1')

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -514,7 +514,9 @@ describe("'scrollback' option", function()
 
     -- _Global_ scrollback=-1 defaults :terminal to 10_000.
     command('setglobal scrollback=-1')
-    command('terminal')
+    -- Pass a command to prevent the terminal buffer from automatically
+    -- closing. The ':' command is just a no-op.
+    command('terminal :')
     eq(10000, meths.get_option_value('scrollback', {}))
 
     -- _Local_ scrollback=-1 in :terminal forces the _maximum_.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2075,26 +2075,26 @@ describe('TUI FocusGained/FocusLost', function()
   end)
 
   it('in terminal-mode', function()
-    feed_data(':set shell='..testprg('shell-test')..'\n')
+    feed_data(':set shell='..testprg('shell-test')..' shellcmdflag=EXE\n')
     feed_data(':set noshowmode laststatus=0\n')
 
-    feed_data(':terminal\n')
+    feed_data(':terminal zia\n')
     -- Wait for terminal to be ready.
     screen:expect{grid=[[
-      {1:r}eady $                                           |
+      {1:r}eady $ zia                                       |
+                                                        |
       [Process exited 0]                                |
                                                         |
                                                         |
-                                                        |
-      :terminal                                         |
+      :terminal zia                                     |
       {3:-- TERMINAL --}                                    |
     ]]}
 
     feed_data('\027[I')
     screen:expect{grid=[[
-      {1:r}eady $                                           |
-      [Process exited 0]                                |
+      {1:r}eady $ zia                                       |
                                                         |
+      [Process exited 0]                                |
                                                         |
                                                         |
       gained                                            |
@@ -2103,9 +2103,9 @@ describe('TUI FocusGained/FocusLost', function()
 
     feed_data('\027[O')
     screen:expect([[
-      {1:r}eady $                                           |
-      [Process exited 0]                                |
+      {1:r}eady $ zia                                       |
                                                         |
+      [Process exited 0]                                |
                                                         |
                                                         |
       lost                                              |


### PR DESCRIPTION
When starting a terminal buffer with no arguments (i.e. `:terminal`), automatically close the buffer if the shell exits without an error.

Closes #8975.
