### PR TITLE
feat(terminal): keep splits when :terminal exits

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -628,6 +628,29 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last)
   return true;
 }
 
+/// Close a buffer but keep its window open if in a split.
+///
+/// @param buf Buffer pointer
+/// @param action Same as @ref close_buffer
+void buf_close_keepwin(buf_T *buf, int action)
+{
+  buf_T *last = NULL;
+  bool keepwin = false;
+  if (!ONE_WINDOW) {
+    last = handle_get_buffer(curwin->w_alt_fnum);
+    if (last && last->handle != buf->handle && last->b_p_bl) {
+      keepwin = true;
+    }
+  }
+
+  if (keepwin) {
+    set_curbuf(last, DOBUF_GOTO);
+    close_buffer(NULL, buf, action, false);
+  } else {
+    do_buffer(action, DOBUF_FIRST, FORWARD, buf->b_fnum, true);
+  }
+}
+
 /// Make buffer not contain a file.
 void buf_clear_file(buf_T *buf)
 {

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -4,6 +4,7 @@
 #include "nvim/api/private/converter.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/ui.h"
+#include "nvim/buffer.h"
 #include "nvim/channel.h"
 #include "nvim/eval.h"
 #include "nvim/eval/encode.h"
@@ -802,7 +803,10 @@ static void term_close(void *data)
 {
   Channel *chan = data;
   process_stop(&chan->stream.proc);
-  terminal_wipe(chan->term);
+  buf_T *buf = handle_get_buffer(terminal_buf(chan->term));
+  if (buf) {
+    buf_close_keepwin(buf, DOBUF_WIPE);
+  }
   multiqueue_put(chan->events, term_delayed_free, 1, data);
 }
 

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -802,6 +802,7 @@ static void term_close(void *data)
 {
   Channel *chan = data;
   process_stop(&chan->stream.proc);
+  terminal_wipe(chan->term);
   multiqueue_put(chan->events, term_delayed_free, 1, data);
 }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -455,7 +455,27 @@ void terminal_enter(void)
     s->term->destroy = true;
     s->term->opts.close_cb(s->term->opts.data);
     if (wipe) {
-      do_cmdline_cmd("bwipeout!");
+      // If the terminal is open in a split AND an alternate file exists AND
+      // that file is not already open in another window, open the alternate
+      // file in the current window
+      bool keep_split = !ONE_WINDOW;
+      if (keep_split) {
+        buf_T *last = handle_get_buffer(curwin->w_alt_fnum);
+        if (last && last->handle != curbuf->handle && last->b_p_bl) {
+          FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+            if (wp->w_buffer->handle == last->handle) {
+              keep_split = false;
+              break;
+            }
+          }
+        }
+      }
+
+      if (keep_split) {
+        do_cmdline_cmd("buffer #");
+      } else {
+        do_cmdline_cmd("bwipeout!");
+      }
     }
   }
 }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -369,33 +369,6 @@ void terminal_check_size(Terminal *term)
   invalidate_terminal(term, -1, -1);
 }
 
-void terminal_wipe(Terminal *term)
-{
-  if (term->buf_handle != 0) {
-    // If the terminal is open in a split AND an alternate file exists AND
-    // that file is not already open in another window, open the alternate
-    // file in the current window
-    bool keep_split = !ONE_WINDOW;
-    if (keep_split) {
-      buf_T *last = handle_get_buffer(curwin->w_alt_fnum);
-      if (last && last->handle != curbuf->handle && last->b_p_bl) {
-        FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-          if (wp->w_buffer->handle == last->handle) {
-            keep_split = false;
-            break;
-          }
-        }
-      }
-    }
-
-    if (keep_split) {
-      do_cmdline_cmd("buffer #");
-    } else {
-      do_cmdline_cmd("bwipeout!");
-    }
-  }
-}
-
 void terminal_enter(void)
 {
   buf_T *buf = curbuf;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -369,6 +369,31 @@ void terminal_check_size(Terminal *term)
   invalidate_terminal(term, -1, -1);
 }
 
+void terminal_wipe(void)
+{
+  // If the terminal is open in a split AND an alternate file exists AND
+  // that file is not already open in another window, open the alternate
+  // file in the current window
+  bool keep_split = !ONE_WINDOW;
+  if (keep_split) {
+    buf_T *last = handle_get_buffer(curwin->w_alt_fnum);
+    if (last && last->handle != curbuf->handle && last->b_p_bl) {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+        if (wp->w_buffer->handle == last->handle) {
+          keep_split = false;
+          break;
+        }
+      }
+    }
+  }
+
+  if (keep_split) {
+    do_cmdline_cmd("buffer #");
+  } else {
+    do_cmdline_cmd("bwipeout!");
+  }
+}
+
 void terminal_enter(void)
 {
   buf_T *buf = curbuf;
@@ -455,27 +480,7 @@ void terminal_enter(void)
     s->term->destroy = true;
     s->term->opts.close_cb(s->term->opts.data);
     if (wipe) {
-      // If the terminal is open in a split AND an alternate file exists AND
-      // that file is not already open in another window, open the alternate
-      // file in the current window
-      bool keep_split = !ONE_WINDOW;
-      if (keep_split) {
-        buf_T *last = handle_get_buffer(curwin->w_alt_fnum);
-        if (last && last->handle != curbuf->handle && last->b_p_bl) {
-          FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-            if (wp->w_buffer->handle == last->handle) {
-              keep_split = false;
-              break;
-            }
-          }
-        }
-      }
-
-      if (keep_split) {
-        do_cmdline_cmd("buffer #");
-      } else {
-        do_cmdline_cmd("bwipeout!");
-      }
+      terminal_wipe();
     }
   }
 }


### PR DESCRIPTION
If a terminal buffer is open in a split, maintain that split by re-opening the alternate file if it exists, is loaded, and is not already visible in another window.

Closes #5176.
