### PR TITLE
vim-patch:8.1.0829,8.2.3236,Merge,pull,request,#15213,from,zeertzjq/vim-8.2.3236,8.2.2957,Merge,pull,request,#14744,from,janlazo/vim-8.2.2957,Merge,pull,request,#15062,from,seandewar/vim-8.1.0829,8.1.2019,8.2.3019,8.2.3025,8.2.3163,8.2.3254,fixup!,8.2.3019,8.2.3115,8.2.3136,Merge,pull,request,#15228,from,janlazo/vim-8.2.3002,8.2.3167,8.2.3213,8.2.3225,8.2.3246,8.2.3256,Merge,pull,request,#15234,from,janlazo/vim-8.2.3164,8.1.2029,8.1.2117,8.1.2214,8.2.3204,Merge,pull,request,#15226,from,zeertzjq/vim-8.1.2029,chore(vim-patch.sh),8.2.3285,8.2.3160,8.2.3198,8.2.3141,Merge,pull,request,#15312,from,janlazo/vim-8.2.2639,8.2.3283,6aa5729,Merge,pull,request,#15320,from,neovim/julia,8.2.3295,8.2.3362

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3060,24 +3060,26 @@ expand_tags (
 )
 {
   int i;
-  int c;
-  int tagnmflag;
-  char_u tagnm[100];
+  int extra_flag;
+  char_u *name_buf;
+  size_t name_buf_size = 100;
   tagptrs_T t_p;
   int ret;
 
-  if (tagnames)
-    tagnmflag = TAG_NAMES;
-  else
-    tagnmflag = 0;
+  name_buf = xmalloc(name_buf_size);
+
+  if (tagnames) {
+    extra_flag = TAG_NAMES;
+  } else {
+    extra_flag = 0;
+  }
   if (pat[0] == '/') {
     ret = find_tags(pat + 1, num_file, file,
-                    TAG_REGEXP | tagnmflag | TAG_VERBOSE | TAG_NO_TAGFUNC,
+                    TAG_REGEXP | extra_flag | TAG_VERBOSE | TAG_NO_TAGFUNC,
                     TAG_MANY, curbuf->b_ffname);
   } else {
     ret = find_tags(pat, num_file, file,
-                    TAG_REGEXP | tagnmflag | TAG_VERBOSE
-                    | TAG_NO_TAGFUNC | TAG_NOIC,
+                    TAG_REGEXP | extra_flag | TAG_VERBOSE | TAG_NO_TAGFUNC | TAG_NOIC,
                     TAG_MANY, curbuf->b_ffname);
   }
   if (ret == OK && !tagnames) {
@@ -3085,18 +3087,29 @@ expand_tags (
      * "<tagname>\0<kind>\0<filename>\0"
      */
     for (i = 0; i < *num_file; i++) {
+      size_t len;
+
       parse_match((*file)[i], &t_p);
-      c = (int)(t_p.tagname_end - t_p.tagname);
-      memmove(tagnm, t_p.tagname, (size_t)c);
-      tagnm[c++] = 0;
-      tagnm[c++] = (t_p.tagkind != NULL && *t_p.tagkind)
-                   ? *t_p.tagkind : 'f';
-      tagnm[c++] = 0;
-      memmove((*file)[i] + c, t_p.fname, t_p.fname_end - t_p.fname);
-      (*file)[i][c + (t_p.fname_end - t_p.fname)] = 0;
-      memmove((*file)[i], tagnm, (size_t)c);
+      len = t_p.tagname_end - t_p.tagname;
+      if (len > name_buf_size - 3) {
+        char_u *buf;
+
+        name_buf_size = len + 3;
+        buf = xrealloc(name_buf, name_buf_size);
+        name_buf = buf;
+      }
+
+      memmove(name_buf, t_p.tagname, len);
+      name_buf[len++] = 0;
+      name_buf[len++] = (t_p.tagkind != NULL && *t_p.tagkind)
+                                                   ? *t_p.tagkind : 'f';
+      name_buf[len++] = 0;
+      memmove((*file)[i] + len, t_p.fname, t_p.fname_end - t_p.fname);
+      (*file)[i][len + (t_p.fname_end - t_p.fname)] = 0;
+      memmove((*file)[i], name_buf, len);
     }
   }
+  xfree(name_buf);
   return ret;
 }
 

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -548,6 +548,16 @@ func Test_tag_line_toolong()
   call assert_equal('Xsomewhere', expand('%'))
   call assert_equal(3, getcurpos()[1])
 
+  " expansion on command line works with long lines when &wildoptions contains
+  " 'tagfile'
+  set wildoptions=tagfile
+  call writefile([
+	\ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	file	/^pattern$/;"	f'
+	\ ], 'Xtags')
+  call feedkeys(":tag \<Tab>", 'tx')
+  " Should not crash
+  call assert_true(v:true)
+
   call delete('Xtags')
   call delete('Xsomewhere')
   set tags&


### PR DESCRIPTION
#### vim-patch:8.1.0829: when 'hidden' is set session creates extra buffers

Problem:    When 'hidden' is set session creates extra buffers.
Solution:   Move :badd commands to the end. (Jason Franklin)
https://github.com/vim/vim/commit/d39e275b57493f9e25e1b62f84810571eee30cf4

Adjust some tests in ex_cmds/mksession_spec.lua:

- 'restores same :terminal buf in splits': Buffers aren't always :badded
  in the same order as they're :edited, :balted, etc, so the order of
  buffers in the buffer list may change slightly now that :badd happens
  afterwards.
- 'restores buffers with tab-local CWD': This is explained in a comment.


#### vim-patch:8.2.3236: mode() does not indicate using CTRL-O in Select mode

Problem:    mode() does not indicate using CTRL-O in Select mode.
Solution:   Use "vs" and similar. (closes vim/vim#8640)
https://github.com/vim/vim/commit/eaf3f36168f85c8e0ab7083cd996b9fbe937045d


#### Merge pull request #15213 from zeertzjq/vim-8.2.3236

vim-patch:8.2.3236: mode() does not indicate using CTRL-O in Select mode

#### vim-patch:8.2.2957: using getchar() in Vim9 script is problematic

Problem:    Using getchar() in Vim9 script is problematic.
Solution:   Add getcharstr(). (closes vim/vim#8343)
https://github.com/vim/vim/commit/3a7503c34c65ed15cc08deb5b54aaf2ea51525b4

Cherry-pick Test_getchar() changes from patch v8.1.2304
to sync with upstream.

Port f_getcharstr() to src/nvim/eval/funcs.c, not src/nvim/getchar.c.
Patch v8.1.2042 is not ported yet.


#### Merge pull request #14744 from janlazo/vim-8.2.2957

vim-patch:8.2.2957: using getchar() in Vim9 script is problematic

#### Merge pull request #15062 from seandewar/vim-8.1.0829

vim-patch:8.1.0829: when 'hidden' is set session creates extra buffers

#### vim-patch:8.1.2019: 'cursorline' always highlights the whole line (#15161)

Problem:    'cursorline' always highlights the whole line.
Solution:   Add 'cursorlineopt' to specify what is highlighted.
            (closes vim/vim#4693)
https://github.com/vim/vim/commit/410e98a70bc00ea4bed51e55a8fe20e56a72c087

#### vim-patch:8.2.3019: location list only has the start position.

Problem:    Location list only has the start position.
Solution:   Make it possible to add an end position. (Shane-XB-Qian,
            closes vim/vim#8393)
https://github.com/vim/vim/commit/6864efa59636ccede2af24e3f5f92d78d210d77b

N/A patches for version.c:

vim-patch:8.2.3002: Vim doesn't abort on a fatal Tcl error

Problem:    Vim doesn't abort on a fatal Tcl error.
Solution:   Change emsg() to iemsg(). (Dominique Pellé, closes vim/vim#8383)
https://github.com/vim/vim/commit/affd0bc626560631f1df2e0f68db2f15dbda47e1

vim-patch:8.2.3030: Coverity reports a memory leak

Problem:    Coverity reports a memory leak.
Solution:   Fix the leak and a few typos. (Dominique Pellé, closes vim/vim#8418)
https://github.com/vim/vim/commit/cb54bc65625abad9a0af501acac5c70fba17e2cc

Patch v8.2.3022 is mostly N/A but cannot be included here
because of new feature check for "has()".

vim-patch:8.2.3032: build problems with MSVC, other crypt issues with libsodium

Problem:    Build problems with MSVC, other crypt issues with libsodium.
Solution:   Adjust MSVC makefile. Disable swap file only when 'key' is set.
            Adjust error message used when key is wrong.  Fix Coverity issues.
            (Christian Brabandt, closes vim/vim#8420, closes vim/vim#8411)
https://github.com/vim/vim/commit/226b28b96150e59375d2bff44e0aadd382b0c3f1

vim-patch:8.2.3044: Amiga MorphOS and AROS: process ID is not valid

Problem:    Amiga MorphOS and AROS: process ID is not valid.
Solution:   Use FindTask to return something which is unique to all processes.
            (Ola Söder, closes vim/vim#8444)
https://github.com/vim/vim/commit/3a62b14077c51c739cdc755356882b40c299f1c0

vim-patch:8.2.3046: Amiga MorphOS: Term mode is set using DOS packets

Problem:    Amiga MorphOS: Term mode is set using DOS packets.
Solution:   Use the same way of setting term mdoe on all next gen Amiga-like
            systems.  (Ola Söder, closes vim/vim#8445)
https://github.com/vim/vim/commit/b420ac9d20d484ba0ebf3e328069251a63f96996


#### vim-patch:8.2.3025: not enough tests for quickfix end_col and end_lnum

Problem:    Not enough tests for quickfix end_col and end_lnum.
Solution:   Add a few more test cases. (Shane-XB-Qian, closes vim/vim#8409)
https://github.com/vim/vim/commit/0d5e1ec37fbe75e18acba6f650c59bf91063108c


#### vim-patch:8.2.3163: location list window may open a wrong file

Problem:    Location list window may open a wrong file.
Solution:   Also update the qf_ptr field. (Wei-Chung Wen, closes vim/vim#8565,
            closes vim/vim#8566)
https://github.com/vim/vim/commit/1557b16dad2b1a3466a93d015575cd7fdb4661c9


#### vim-patch:8.2.3254: win_gettype() does not recognize a quickfix window

Problem:    win_gettype() does not recognize a quickfix window.
Solution:   Add "quickfix" and "loclist". (Yegappan Lakshmanan, closes vim/vim#8676)
https://github.com/vim/vim/commit/28d8421bfb3327d7a5e81369977e8fc108b0229e


#### fixup! vim-patch:8.2.3019: location list only has the start position.



#### vim-patch:8.2.3115: Coverity complains about free_wininfo() use

Problem:    Coverity complains about free_wininfo() use.
Solution:   Add a condition that "wip2" is not equal to "wip". (Neovim vim/vim#14996)
https://github.com/vim/vim/commit/b5098060f4acae4dac3203130278c948d670a3d5

This fix came from https://github.com/neovim/neovim/pull/14996.
This commit adds only a comment to be in sync with Vim.

N/A patches for version.c:

vim-patch:8.2.3063: crash when switching 'cryptmethod' to xchaha20 with undo file

Problem:    Crash when switching 'cryptmethod' to xchaha20 with an existing
            undo file. (Martin Tournoij)
Solution:   Disable reading undo file when decoding can't be done inplace.
            (issue vim/vim#8467)
https://github.com/vim/vim/commit/65aee0b714e809b9f19862f3decd35055ed4de10

vim-patch:8.2.3101: missing function prototype for vim_round()

Problem:    Missing function prototype for vim_round().
Solution:   Add the prototype.
https://github.com/vim/vim/commit/67b17a6fc62156383d24dcbd6e6df34e180d7235

vim-patch:8.2.3119: compiler warning for unused argument

Problem:    Compiler warning for unused argument.
Solution:   Add UNUSED.
https://github.com/vim/vim/commit/6a9e5c69cf36676e65ae191264872a3e41bde37f

vim-patch:8.2.3120: crypt with sodium test fails on MS-Windows

Problem:    Crypt with sodium test fails on MS-Windows.
Solution:   Make the tests pass. (closes vim/vim#8428)
https://github.com/vim/vim/commit/db8647277082a8a69a189ded8bd1408af993b54e

vim-patch:8.2.3131: MS-Windows: ipv6 channel test is very flaky in the GUI

Problem:    MS-Windows: ipv6 channel test is very flaky in the GUI.
Solution:   Skip the test.
https://github.com/vim/vim/commit/981217c11f92b37f2baa51492cbe12e85d0ea493

vim-patch:8.2.3140: MS-Windows: ipv6 channel test is very flaky also without GUI

Problem:    MS-Windows: ipv6 channel test is very flaky also without the GUI.
Solution:   Skip the test also without the GUI.
https://github.com/vim/vim/commit/482d2f37a5ce43157ab1e22c26f389770d0c20cf

vim-patch:8.2.3157: crypt test may fail on MS-Windows

Problem:    Crypt test may fail on MS-Windows.
Solution:   Ignore "[unix]" in the file message. (Christian Brabandt,
            closes vim/vim#8561)
https://github.com/vim/vim/commit/16e26a31161d65baca7885c46c43ab4a48399c92

vim-patch:8.2.3218: when using xchaha20 crypt undo file is not removed

Problem:    When using xchaha20 crypt undo file is not removed.
Solution:   Reset 'undofile' and delete the file. (Christian Brabandt,
            closes vim/vim#8630, closes vim/vim#8467)
https://github.com/vim/vim/commit/8a4c812ede5b01a8e71082c1ff4ebfcbf1bd515f

vim-patch:8.2.3245: the crypt key may appear in a swap partition

Problem:    The crypt key may appear in a swap partition.
Solution:   When using xchaha20 use sodium_mlock(). (Christian Brabandt,
            closes vim/vim#8657)
https://github.com/vim/vim/commit/131530a54d0f72b820b027606231744e3a09b9ef


#### vim-patch:8.2.3136: no test for E187 and "No swap file"

Problem:    No test for E187 and "No swap file".
Solution:   Add a test. (Dominique Pellé, closes vim/vim#8540)
https://github.com/vim/vim/commit/fe3418abe0dac65e42e85b5a91c5d0c975bc65bb


#### Merge pull request #15228 from janlazo/vim-8.2.3002

vim-patch:8.2.{3002,3019,3025,3030,3032,3044,3046,3063,3101,3115,3119,3120,3131,3136,3140,3157,3163,3218,3245,3254}

#### vim-patch:8.2.3167: get E12 in a job callback when searching for tags

Problem:    Get E12 in a job callback when searching for tags. (Andy Stewart)
Solution:   Use the sandbox only for executing a command, not for searching.
            (closes vim/vim#8511)
https://github.com/vim/vim/commit/547f94f33098b060da9d62c29d9fcbe9bf1e2b11

N/A patches for version.c:

vim-patch:8.2.3164: MS-Windows: reported version lacks patchlevel

Problem:    MS-Windows: reported version lacks patchlevel, causing some update
            tools to update too often. (Klaus Frank)
Solution:   Add the patchlevel to the version. (Christian Brabandt)
https://github.com/vim/vim/commit/0894e0d8087aad4d467fd7b3d87b1930fe661916

vim-patch:8.2.3192: build failure with small version

Problem:    Build failure with small version (Tony Mechelynck).
Solution:   Remove stray #ifdef.
https://github.com/vim/vim/commit/11d7e62f1d29fdd7a88b86131b7bbb853f29fe8b

vim-patch:8.2.3208: dynamic library load error does not mention why it failed

Problem:    Dynamic library load error does not mention why it failed.
Solution:   Add the error message. (Martin Tournoij, closes vim/vim#8621)
https://github.com/vim/vim/commit/1a3e5747b7df7ddda312bbfd18e04fc2122001fb

vim-patch:8.2.3214: MS-Windows: passing /D does not set the install location

Problem:    MS-Windows: passing /D does not set the install location.
Solution:   Adjust how the installer uses $VIM. Update the documentation.
            (Christian Brabandt, closes vim/vim#8605)
https://github.com/vim/vim/commit/7d60384a00755e5c0112cebeb5e232fc133c9eca

vim-patch:8.2.3231: build failure with small features

Problem:    Build failure with small features.
Solution:   Adjust #ifdef.
https://github.com/vim/vim/commit/9088784972c0ed72997de8752964d6b587218778

vim-patch:8.2.3243: MS-Windows: "edit with multiple Vim" choice is less useful

Problem:    MS-Windows: the "edit with multiple Vim" choice is not that
            useful.
Solution:   Change it to "Edit with multiple tabs". (Michael Soyka,
            closes vim/vim#8645)
https://github.com/vim/vim/commit/83cd0156e01b5befadf12ee66bc26436ee8d023f

vim-patch:8.2.3247: using uninitialized memory when checking for crypt method

Problem:    Using uninitialized memory when checking for crypt method.
Solution:   Check the header length before using the salt and seed.
https://github.com/vim/vim/commit/77ab4e28a26a92628bc85cd580c1bfa2b6230be6

vim-patch:8.2.3250: MS-Windows: cannot build with libsodium

Problem:    MS-Windows: cannot build with libsodium.
Solution:   Change FEAT_SODIUM into HAVE_SODIUM. (Christian Brabandt,
            closes vim/vim#8668, closes vim/vim#8663)
https://github.com/vim/vim/commit/1790be6cb6f2edfd8a833dd848b8df02cef599cf

vim-patch:8.2.3253: channel test fails randomly

Problem:    Channel test fails randomly.
Solution:   Add a sleep after sending the "echoerr" command. (Michael Soyka)
https://github.com/vim/vim/commit/890ee4e2be1dca0c07a91f836e26baead952ae7c

vim-patch:8.2.3260: build failure with small features

Problem:    Build failure with small features.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/335c8c7b206df776b59fb63a1c7f91c8b1425398


#### vim-patch:8.2.3213: NOCOMPOUNDSUGS entry in spell file not tested

Problem:    NOCOMPOUNDSUGS entry in spell file not tested.
Solution:   Add a test. (Dominique Pellé, closes vim/vim#8624)
https://github.com/vim/vim/commit/9c9472ff49b09c3d8f747b330eeb1cdb92bab449


#### vim-patch:8.2.3225: incsearch highlighting is attempted halfway a mapping

Problem:    Incsearch highlighting is attempted halfway a mapping.
Solution:   Only do incsearch highlighting if keys were typed or there is no
            more typeahead.
https://github.com/vim/vim/commit/ccb148ac63941feba879ea4678aa4713d81494f2


#### vim-patch:8.2.3246: memory use after free

Problem:    Memory use after free.
Solution:   When clearing a string option set the pointer to "empty_option".
https://github.com/vim/vim/commit/77111e2bfc7316eb6b1e653386cef6441af806f8


#### vim-patch:8.2.3256: executable test may fail on new Ubuntu system

Problem:    Executable test may fail on new Ubuntu system.
Solution:   Consider /usr/bin/cat and /bin/cat the same.
https://github.com/vim/vim/commit/bf634a0a8b64fda2e53d3e2254fe0ffdc3d67196


#### Merge pull request #15234 from janlazo/vim-8.2.3164

vim-patch:8.2.{3164,3167,3192,3208,3213,3214,3225,3231,3243,3246,3247,3250,3253,3256,3260}

#### vim-patch:8.1.2029: cannot control 'cursorline' highlighting well

Problem:    Cannot control 'cursorline' highlighting well.
Solution:   Add "screenline". (Christian Brabandt, closes vim/vim#4933)
https://github.com/vim/vim/commit/017ba07fa2cdc578245618717229444fd50c470d


#### vim-patch:8.1.2117: CursorLine highlight used while 'cursorline' is off

Problem:    CursorLine highlight used while 'cursorline' is off.
Solution:   Check 'cursorline' is set. (cloes vim/vim#5017)
https://github.com/vim/vim/commit/49474ca12236776bb56aeb9d39bd6592e28157c7


#### vim-patch:8.1.2214: too much is redrawn when 'cursorline' is set

Problem:    Too much is redrawn when 'cursorline' is set.
Solution:   Don't do a complete redraw. (closes vim/vim#5079)
https://github.com/vim/vim/commit/11a58af66fa5c442f0a22c5d59beabf187ed4e89


#### vim-patch:8.2.3204: display garbled when 'cursorline' is set and lines wrap

Problem:    Display garbled when 'cursorline' is set and lines wrap. (Gabriel
            Dupras)
Solution:   Avoid inserting lines twice.
https://github.com/vim/vim/commit/c9e7e344ed390d2a22afb88001b6aa80832d2541


#### Merge pull request #15226 from zeertzjq/vim-8.1.2029

vim-patch:8.1.2029,8.1.2117,8.1.2214,8.2.3204

#### chore(vim-patch.sh): replace hub with gh (#15162)



#### vim-patch:8.2.3285: scdoc filetype is not recognized (#15294)

Problem:    Scdoc filetype is not recognized.
Solution:   Add filetype detection. (Gregory Anders, closes vim/vim#8701)
https://github.com/vim/vim/commit/dd097bdc1376e4ca2cfd4a4d64021b6ba0df4bed

#### vim-patch:8.2.3160: 'breakindent' does not work well for bulleted lists

Problem:    'breakindent' does not work well for bulleted and numbered lists.
Solution:   Add the "list" entry to 'breakindentopt'. (Christian Brabandt,
            closes vim/vim#8564, closes vim/vim#1661)
https://github.com/vim/vim/commit/4a0b85ad0193ac162e2d8458e4b1c5ad2e2b0193


#### vim-patch:8.2.3198: cannot use 'formatlistpat' for breakindent

Problem:    Cannot use 'formatlistpat' for breakindent.
Solution:   Use a negative list indent. (Maxim Kim, closes vim/vim#8594)
https://github.com/vim/vim/commit/f674b358fc18cf1641a066cc5de73da69e651024

Port get_showbreak_value() from patch v8.1.2281
to avoid breaking changes when porting older patches.


#### vim-patch:8.2.3141: no error when using :complete for :command without -nargs

Problem:    No error when using :complete for :command without -nargs.
Solution:   Give an error. (Martin Tournoij, closes vim/vim#8544, closes vim/vim#8541)
https://github.com/vim/vim/commit/de69a7353e9bec552e15dbe3706a9f4e88080fce

N/A patches for version.c:

vim-patch:8.1.1801: cannot build without the +eval feature

Problem:    Cannot build without the +eval feature.
Solution:   Always define funcexe_T.
https://github.com/vim/vim/commit/505e43a20eb25674b18d73971fe3b51dad917f9a

vim-patch:8.1.1818: unused variable

Problem:    Unused variable.
Solution:   Remove the variable. (Mike Williams)
https://github.com/vim/vim/commit/b4a88a0441a65a0c9411c294825a08ca703f541e

vim-patch:8.2.1464: Vim9: build warning for unused variable

Problem:    Vim9: build warning for unused variable.
Solution:   Delete the variable declaration.
https://github.com/vim/vim/commit/829ac868b7615d73dbfb536f7fcd44fc7c5b7c1d

vim-patch:8.2.2639: build failure when fsync() is not available

Problem:    Build failure when fsync() is not available.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/5ea79a2599d35f75e1ae8a75d2711c754c4cb7c4

vim-patch:8.2.2814: Vim9: unused variable

Problem:    Vim9: unused variable. (John Marriott)
Solution:   Adjust #ifdef.
https://github.com/vim/vim/commit/b06b50dfa06e1cbefd634e2735e7cd5ddd5b911c

vim-patch:8.2.2947: build failure without the channel feature

Problem:    Build failure without the channel feature.
Solution:   Add back #ifdef. (John Marriott)
https://github.com/vim/vim/commit/f5bfa8faa7bbe025c10148d37e8b47217a430a3b

vim-patch:8.2.2976: build failure without the +eval feature

Problem:    Build failure without the +eval feature.
Solution:   Add #ifdefs.
https://github.com/vim/vim/commit/8de901e1f1b051e02a61ae76ad7c925e4c0642e5

vim-patch:8.2.2986: build failure without the profile feature

Problem:    Build failure without the profile feature.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/d9f31c13d217b4b97f724774a67a6d1f8640e8ae

vim-patch:8.2.3114: Amiga-like systems: build error using stat()

Problem:    Amiga-like systems: build error using stat().
Solution:   Only build swapfile_process_running() on systems where it is
            actually used. (Ola Söder, closes vim/vim#8519)
https://github.com/vim/vim/commit/599a6e5b3629d943a795cd69e4d3d19886f86405


#### Merge pull request #15312 from janlazo/vim-8.2.2639

vim-patch:8.1.{1818},8.2.{1464,2639,2814,2947,2976,2986,3114,3141,3160,3198}

#### vim-patch:8.2.3283: Julia filetype is not recognized

Problem: Julia filetype is not recognized
Solution: Add filetype detection. (Christian Clason, closes #8700)

issue: vim/vim#7498
vim-patch: vim/vim@0eec851


#### vim-patch:6aa5729

Add Julia runtime files.
https://github.com/vim/vim/commit/6aa57295cfbe8f21c15f0671e45fd53cf990d404


#### Merge pull request #15320 from neovim/julia

vim-patch:8.2.3283: Julia filetype is not recognized
vim-patch:6aa5729: Add Julia runtime files

#### vim-patch:8.2.3295: 'cursorline' should not apply to 'breakindent' #15281

Problem:    'cursorline' should not apply to 'breakindent'.
Solution:   Make 'cursorline' apply to 'breakindent' and 'showbreak'
            consistently. (closes vim/vim#8684)
https://github.com/vim/vim/commit/4f33bc20d7d5444e44d13f954e8219ad1abd26ef

#### vim-patch:8.2.3362: buffer overflow when completing long tag name

Problem:    Buffer overflow when completing long tag name.
Solution:   Allocate the buffer dynamically. (Gregory Anders, closes vim/vim#8769)
https://github.com/vim/vim/commit/489d60996deb5e7c1a3b4633412d54632e6def42