### PR TITLE
fix: win_close from other tabpage

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2710,7 +2710,11 @@ static win_T *win_free_mem(
   // When deleting the current window of another tab page select a new
   // current window.
   if (tp != NULL && win == tp->tp_curwin) {
-    tp->tp_curwin = wp;
+    if (win_valid(tp->tp_prevwin) && tp->tp_prevwin != win) {
+      tp->tp_curwin = tp->tp_prevwin;
+    } else {
+      tp->tp_curwin = tp->tp_firstwin;
+    }
   }
 
   return wp;

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -350,6 +350,7 @@ describe('API/win', function()
 
     it('closing current (float) window of another tabpage #15313', function()
       command('tabedit')
+      eq(2, eval('tabpagenr()'))
       local win = meths.open_win(0, true, {
         relative='editor', row=10, col=10, width=50, height=10
       })

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -347,6 +347,19 @@ describe('API/win', function()
       eq(2, #meths.list_wins())
       eq('', funcs.getcmdwintype())
     end)
+
+    it('does not make tabpage invalid even if close floating window from other tabpage', function()
+      command('tabedit')
+      local win = meths.open_win(0, true, {
+        relative='editor', row=10, col=10, width=50, height=10
+      })
+      local tabpage = eval('tabpagenr()')
+      command('tabprevious')
+      meths.win_close(win, false)
+
+      meths.tabpage_get_win(tabpage)
+      helpers.assert_alive()
+    end)
   end)
 
   describe('hide', function()

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -357,7 +357,7 @@ describe('API/win', function()
       command('tabprevious')
       meths.win_close(win, false)
 
-      meths.tabpage_get_win(tabpage)
+      eq(1000, meths.tabpage_get_win(tabpage))
       helpers.assert_alive()
     end)
   end)

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -359,7 +359,7 @@ describe('API/win', function()
       eq(1, eval('tabpagenr()'))
       meths.win_close(win, false)
 
-      eq(1000, meths.tabpage_get_win(tabpage))
+      eq(1001, meths.tabpage_get_win(tabpage).id)
       helpers.assert_alive()
     end)
   end)

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -348,7 +348,7 @@ describe('API/win', function()
       eq('', funcs.getcmdwintype())
     end)
 
-    it('does not make tabpage invalid even if close floating window from other tabpage', function()
+    it('closing current (float) window of another tabpage #15313', function()
       command('tabedit')
       local win = meths.open_win(0, true, {
         relative='editor', row=10, col=10, width=50, height=10

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -355,6 +355,7 @@ describe('API/win', function()
       })
       local tabpage = eval('tabpagenr()')
       command('tabprevious')
+      eq(1, eval('tabpagenr()'))
       meths.win_close(win, false)
 
       eq(1000, meths.tabpage_get_win(tabpage))


### PR DESCRIPTION
Fix #15313 

📝 test output before fix
```
[ RUN      ] API/win close does not make tabpage invalid even if close floating window from other tabpage: -- Tests exited non-zero: SIGPIPE
-- No output to stderr.
CMake Error at /home/notomo/workspace/neovim/cmake/RunTests.cmake:85 (message):
  functional tests failed with error: SIGPIPE
```
