### PR TITLE
refactor(map): remove extra-allocating map_new/map_free functions

### DIFF
--- a/src/nvim/api/private/dispatch.c
+++ b/src/nvim/api/private/dispatch.c
@@ -21,12 +21,12 @@
 #include "nvim/api/window.h"
 #include "nvim/api/deprecated.h"
 
-static Map(String, MsgpackRpcRequestHandler) *methods = NULL;
+static Map(String, MsgpackRpcRequestHandler) methods = MAP_INIT;
 
 static void msgpack_rpc_add_method_handler(String method,
                                            MsgpackRpcRequestHandler handler)
 {
-  map_put(String, MsgpackRpcRequestHandler)(methods, method, handler);
+  map_put(String, MsgpackRpcRequestHandler)(&methods, method, handler);
 }
 
 /// @param name API method name
@@ -37,7 +37,7 @@ MsgpackRpcRequestHandler msgpack_rpc_get_handler_for(const char *name,
 {
   String m = { .data = (char *)name, .size = name_len };
   MsgpackRpcRequestHandler rv =
-    map_get(String, MsgpackRpcRequestHandler)(methods, m);
+    map_get(String, MsgpackRpcRequestHandler)(&methods, m);
 
   if (!rv.fn) {
     api_set_error(error, kErrorTypeException, "Invalid method: %.*s",

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1724,7 +1724,7 @@ const char *describe_ns(NS ns_id)
 {
   String name;
   handle_T id;
-  map_foreach((&namespace_ids), name, id, {
+  map_foreach(&namespace_ids, name, id, {
     if ((NS)id == ns_id && name.size) {
       return name.data;
     }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -63,7 +63,7 @@ void api_vim_free_all_mem(void)
 {
   String name;
   handle_T id;
-  map_foreach((&namespace_ids), name, id, {
+  map_foreach(&namespace_ids, name, id, {
     (void)id;
     xfree(name.data);
   })
@@ -1584,7 +1584,7 @@ Dictionary nvim_get_namespaces(void)
   String name;
   handle_T id;
 
-  map_foreach((&namespace_ids), name, id, {
+  map_foreach(&namespace_ids, name, id, {
     PUT(retval, name.data, INTEGER_OBJ(id));
   })
 

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -32,13 +32,9 @@ static uint64_t next_chan_id = CHAN_STDERR+1;
 /// Teardown the module
 void channel_teardown(void)
 {
-  if (!channels) {
-    return;
-  }
-
   Channel *channel;
 
-  map_foreach_value(channels, channel, {
+  map_foreach_value(&channels, channel, {
     channel_close(channel->id, kChannelPartAll, NULL);
   });
 }
@@ -152,7 +148,6 @@ bool channel_close(uint64_t id, ChannelPart part, const char **error)
 /// Initializes the module
 void channel_init(void)
 {
-  channels = pmap_new(uint64_t)();
   channel_alloc(kChannelStreamStderr);
   rpc_init();
 }
@@ -177,7 +172,7 @@ Channel *channel_alloc(ChannelStreamType type)
   chan->exit_status = -1;
   chan->streamtype = type;
   assert(chan->id <= VARNUMBER_MAX);
-  pmap_put(uint64_t)(channels, chan->id, chan);
+  pmap_put(uint64_t)(&channels, chan->id, chan);
   return chan;
 }
 
@@ -249,7 +244,7 @@ static void free_channel_event(void **argv)
   callback_reader_free(&chan->on_stderr);
   callback_free(&chan->on_exit);
 
-  pmap_del(uint64_t)(channels, chan->id);
+  pmap_del(uint64_t)(&channels, chan->id);
   multiqueue_free(chan->events);
   xfree(chan);
 }
@@ -259,7 +254,7 @@ static void channel_destroy_early(Channel *chan)
   if ((chan->id != --next_chan_id)) {
     abort();
   }
-  pmap_del(uint64_t)(channels, chan->id);
+  pmap_del(uint64_t)(&channels, chan->id);
   chan->id = 0;
 
   if ((--chan->refcount != 0)) {
@@ -899,7 +894,7 @@ Array channel_all_info(void)
 {
   Channel *channel;
   Array ret = ARRAY_DICT_INIT;
-  map_foreach_value(channels, channel, {
+  map_foreach_value(&channels, channel, {
     ADD(ret, DICTIONARY_OBJ(channel_info(channel->id)));
   });
   return ret;

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -89,7 +89,7 @@ struct Channel {
   bool callback_scheduled;
 };
 
-EXTERN PMap(uint64_t) *channels INIT(= NULL);
+EXTERN PMap(uint64_t) channels INIT(= MAP_INIT);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "channel.h.generated.h"
@@ -98,7 +98,7 @@ EXTERN PMap(uint64_t) *channels INIT(= NULL);
 /// @returns Channel with the id or NULL if not found
 static inline Channel *find_channel(uint64_t id)
 {
-  return pmap_get(uint64_t)(channels, id);
+  return pmap_get(uint64_t)(&channels, id);
 }
 
 static inline Stream *channel_instream(Channel *chan)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -265,7 +265,7 @@ static partial_T *vvlua_partial;
 #endif
 
 static uint64_t last_timer_id = 1;
-static PMap(uint64_t) *timers = NULL;
+static PMap(uint64_t) timers = MAP_INIT;
 
 static const char *const msgpack_type_names[] = {
   [kMPNil] = "nil",
@@ -326,7 +326,6 @@ void eval_init(void)
 {
   vimvars[VV_VERSION].vv_nr = VIM_VERSION_100;
 
-  timers = pmap_new(uint64_t)();
   struct vimvar   *p;
 
   init_var_dict(&globvardict, &globvars_var, VAR_DEF_SCOPE);
@@ -4883,7 +4882,7 @@ bool garbage_collect(bool testing)
   // Channels
   {
     Channel *data;
-    map_foreach_value(channels, data, {
+    map_foreach_value(&channels, data, {
       set_ref_in_callback_reader(&data->on_data, copyID, NULL, NULL);
       set_ref_in_callback_reader(&data->on_stderr, copyID, NULL, NULL);
       set_ref_in_callback(&data->on_exit, copyID, NULL, NULL);
@@ -4893,7 +4892,7 @@ bool garbage_collect(bool testing)
   // Timers
   {
     timer_T *timer;
-    map_foreach_value(timers, timer, {
+    map_foreach_value(&timers, timer, {
       set_ref_in_callback(&timer->callback, copyID, NULL, NULL);
     })
   }
@@ -7304,7 +7303,7 @@ static bool set_ref_in_callback_reader(CallbackReader *reader, int copyID,
 
 timer_T *find_timer_by_nr(varnumber_T xx)
 {
-    return pmap_get(uint64_t)(timers, xx);
+    return pmap_get(uint64_t)(&timers, xx);
 }
 
 void add_timer_info(typval_T *rettv, timer_T *timer)
@@ -7331,9 +7330,9 @@ void add_timer_info(typval_T *rettv, timer_T *timer)
 
 void add_timer_info_all(typval_T *rettv)
 {
-  tv_list_alloc_ret(rettv, map_size(timers));
+  tv_list_alloc_ret(rettv, map_size(&timers));
   timer_T *timer;
-  map_foreach_value(timers, timer, {
+  map_foreach_value(&timers, timer, {
     if (!timer->stopped) {
       add_timer_info(rettv, timer);
     }
@@ -7413,7 +7412,7 @@ uint64_t timer_start(const long timeout,
   timer->tw.blockable = true;
   time_watcher_start(&timer->tw, timer_due_cb, timeout, timeout);
 
-  pmap_put(uint64_t)(timers, timer->timer_id, timer);
+  pmap_put(uint64_t)(&timers, timer->timer_id, timer);
   return timer->timer_id;
 }
 
@@ -7435,7 +7434,7 @@ static void timer_close_cb(TimeWatcher *tw, void *data)
   timer_T *timer = (timer_T *)data;
   multiqueue_free(timer->tw.events);
   callback_free(&timer->callback);
-  pmap_del(uint64_t)(timers, timer->timer_id);
+  pmap_del(uint64_t)(&timers, timer->timer_id);
   timer_decref(timer);
 }
 
@@ -7449,7 +7448,7 @@ static void timer_decref(timer_T *timer)
 void timer_stop_all(void)
 {
   timer_T *timer;
-  map_foreach_value(timers, timer, {
+  map_foreach_value(&timers, timer, {
     timer_stop(timer);
   })
 }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -260,7 +260,7 @@ bool extmark_clear(buf_T *buf, uint64_t ns_id,
   }
   uint64_t id;
   ssize_t decor_id;
-  map_foreach((&delete_set), id, decor_id, {
+  map_foreach(&delete_set, id, decor_id, {
     mtpos_t pos = marktree_lookup(buf->b_marktree, id, itr);
     assert(itr->node);
     marktree_del_itr(buf->b_marktree, itr, false);

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -321,8 +321,6 @@ end
 output:write([[
 void msgpack_rpc_init_method_table(void)
 {
-  methods = map_new(String, MsgpackRpcRequestHandler)();
-
 ]])
 
 for i = 1, #functions do

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -68,7 +68,8 @@ typedef struct {
   }
 
 #if __has_feature(address_sanitizer)
-  PMap(handle_T) *nlua_ref_markers = NULL;
+  static PMap(handle_T) nlua_ref_markers = MAP_INIT;
+  static bool nlua_track_refs = false;
 # define NLUA_TRACK_REFS
 #endif
 
@@ -568,7 +569,7 @@ void nlua_init(void)
 #ifdef NLUA_TRACK_REFS
   const char *env = os_getenv("NVIM_LUA_NOTRACK");
   if (!env || !*env) {
-    nlua_ref_markers = pmap_new(handle_T)();
+    nlua_track_refs = true;
   }
 #endif
 
@@ -599,10 +600,10 @@ void nlua_free_all_mem(void)
     fprintf(stderr, "%d lua references were leaked!", nlua_refcount);
   }
 
-  if (nlua_ref_markers) {
+  if (nlua_track_refs) {
     // in case there are leaked luarefs, leak the associated memory
     // to get LeakSanitizer stacktraces on exit
-    pmap_free(handle_T)(nlua_ref_markers);
+    pmap_destroy(handle_T)(&nlua_ref_markers);
   }
 #endif
 
@@ -1001,9 +1002,9 @@ LuaRef nlua_ref(lua_State *lstate, int index)
   if (ref > 0) {
     nlua_refcount++;
 #ifdef NLUA_TRACK_REFS
-  if (nlua_ref_markers) {
+  if (nlua_track_refs) {
     // dummy allocation to make LeakSanitizer track our luarefs
-    pmap_put(handle_T)(nlua_ref_markers, ref, xmalloc(3));
+    pmap_put(handle_T)(&nlua_ref_markers, ref, xmalloc(3));
   }
 #endif
   }
@@ -1017,8 +1018,8 @@ void nlua_unref(lua_State *lstate, LuaRef ref)
     nlua_refcount--;
 #ifdef NLUA_TRACK_REFS
     // NB: don't remove entry from map to track double-unref
-    if (nlua_ref_markers) {
-      xfree(pmap_get(handle_T)(nlua_ref_markers, ref));
+    if (nlua_track_refs) {
+      xfree(pmap_get(handle_T)(&nlua_ref_markers, ref));
     }
 #endif
     luaL_unref(lstate, LUA_REGISTRYINDEX, ref);

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -101,7 +101,7 @@ static struct luaL_Reg treecursor_meta[] = {
   { NULL, NULL }
 };
 
-static PMap(cstr_t) *langs;
+static PMap(cstr_t) langs = MAP_INIT;
 
 static void build_meta(lua_State *L, const char *tname, const luaL_Reg *meta)
 {
@@ -119,8 +119,6 @@ static void build_meta(lua_State *L, const char *tname, const luaL_Reg *meta)
 /// all global state is stored in the regirstry of the lua_State
 void tslua_init(lua_State *L)
 {
-  langs = pmap_new(cstr_t)();
-
   // type metatables
   build_meta(L, TS_META_PARSER, parser_meta);
   build_meta(L, TS_META_TREE, tree_meta);
@@ -133,7 +131,7 @@ void tslua_init(lua_State *L)
 int tslua_has_language(lua_State *L)
 {
   const char *lang_name = luaL_checkstring(L, 1);
-  lua_pushboolean(L, pmap_has(cstr_t)(langs, lang_name));
+  lua_pushboolean(L, pmap_has(cstr_t)(&langs, lang_name));
   return 1;
 }
 
@@ -142,7 +140,7 @@ int tslua_add_language(lua_State *L)
   const char *path = luaL_checkstring(L, 1);
   const char *lang_name = luaL_checkstring(L, 2);
 
-  if (pmap_has(cstr_t)(langs, lang_name)) {
+  if (pmap_has(cstr_t)(&langs, lang_name)) {
     return 0;
   }
 
@@ -185,7 +183,7 @@ int tslua_add_language(lua_State *L)
         TREE_SITTER_LANGUAGE_VERSION, lang_version);
   }
 
-  pmap_put(cstr_t)(langs, xstrdup(lang_name), lang);
+  pmap_put(cstr_t)(&langs, xstrdup(lang_name), lang);
 
   lua_pushboolean(L, true);
   return 1;
@@ -195,7 +193,7 @@ int tslua_inspect_lang(lua_State *L)
 {
   const char *lang_name = luaL_checkstring(L, 1);
 
-  TSLanguage *lang = pmap_get(cstr_t)(langs, lang_name);
+  TSLanguage *lang = pmap_get(cstr_t)(&langs, lang_name);
   if (!lang) {
     return luaL_error(L, "no such language: %s", lang_name);
   }
@@ -243,7 +241,7 @@ int tslua_push_parser(lua_State *L)
   // Gather language name
   const char *lang_name = luaL_checkstring(L, 1);
 
-  TSLanguage *lang = pmap_get(cstr_t)(langs, lang_name);
+  TSLanguage *lang = pmap_get(cstr_t)(&langs, lang_name);
   if (!lang) {
     return luaL_error(L, "no such language: %s", lang_name);
   }
@@ -1127,7 +1125,7 @@ int tslua_parse_query(lua_State *L)
   }
 
   const char *lang_name = lua_tostring(L, 1);
-  TSLanguage *lang = pmap_get(cstr_t)(langs, lang_name);
+  TSLanguage *lang = pmap_get(cstr_t)(&langs, lang_name);
   if (!lang) {
     return luaL_error(L, "no such language: %s", lang_name);
   }

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -54,19 +54,6 @@
   INITIALIZER_DECLARE(T, U, __VA_ARGS__); \
   __KHASH_IMPL(T##_##U##_map,, T, U, 1, T##_hash, T##_eq) \
   \
-  Map(T, U) *map_##T##_##U##_new() \
-  { \
-    Map(T, U) *rv = xcalloc(1, sizeof(Map(T, U))); \
-    /* khash_t table member is zero-initialized */ \
-    return rv; \
-  } \
-  \
-  void map_##T##_##U##_free(Map(T, U) *map) \
-  { \
-    kh_dealloc(T##_##U##_map, &map->table); \
-    xfree(map); \
-  } \
-  \
   void map_##T##_##U##_destroy(Map(T, U) *map) \
   { \
     kh_dealloc(T##_##U##_map, &map->table); \

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -62,8 +62,6 @@ MAP_DECLS(ColorKey, ColorItem)
 #define MAP_INIT { { 0, 0, 0, 0, NULL, NULL, NULL } }
 #define map_init(k, v, map) do { *(map) = (Map(k, v))MAP_INIT; } while (false)
 
-#define map_new(T, U) map_##T##_##U##_new
-#define map_free(T, U) map_##T##_##U##_free
 #define map_destroy(T, U) map_##T##_##U##_destroy
 #define map_get(T, U) map_##T##_##U##_get
 #define map_has(T, U) map_##T##_##U##_has
@@ -75,8 +73,6 @@ MAP_DECLS(ColorKey, ColorItem)
 
 #define map_size(map) ((map)->table.size)
 
-#define pmap_new(T) map_new(T, ptr_t)
-#define pmap_free(T) map_free(T, ptr_t)
 #define pmap_destroy(T) map_destroy(T, ptr_t)
 #define pmap_get(T) map_get(T, ptr_t)
 #define pmap_has(T) map_has(T, ptr_t)
@@ -89,10 +85,10 @@ MAP_DECLS(ColorKey, ColorItem)
 #define pmap_init(k, map) map_init(k, ptr_t, map)
 
 #define map_foreach(map, key, value, block) \
-  kh_foreach(&map->table, key, value, block)
+  kh_foreach(&(map)->table, key, value, block)
 
 #define map_foreach_value(map, value, block) \
-  kh_foreach_value(&map->table, value, block)
+  kh_foreach_value(&(map)->table, value, block)
 
 void pmap_del2(PMap(cstr_t) *map, const char *key);
 

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -27,7 +27,7 @@ typedef struct {
 } RequestEvent;
 
 typedef struct {
-  PMap(cstr_t) *subscribed_events;
+  PMap(cstr_t) subscribed_events[1];
   bool closed;
   msgpack_unpacker *unpacker;
   uint32_t next_request_id;


### PR DESCRIPTION
Note: the reason for removing them is not that there right now is no specific use of them. Rather the issue is that having them available suggests an anti-pattern: they manage an _extra_ heap allocation which has nothing to do with the functionality of the map itself (khash manages the key/value store internally). In case there happens to be a reason to allocate the map structure itself in the future, this should be communicated explicitly using `xcalloc`/`xfree` calls.