### PR TITLE
vim-patch:2346a6378483,4d8f476176ea,90df4b9d4234,6aa57295cfbe Update runtime files

### DIFF
--- a/runtime/autoload/rubycomplete.vim
+++ b/runtime/autoload/rubycomplete.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Mark Guzman <segfault@hasno.info>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2019 Feb 25
+" Last Change:		2020 Apr 12
 " ----------------------------------------------------------------------------
 "
 " Ruby IRB/Complete author: Keiju ISHITSUKA(keiju@ishitsuka.com)
@@ -501,13 +501,8 @@ class VimRubyCompletion
     return if rails_base == nil
     $:.push rails_base unless $:.index( rails_base )
 
-    rails_config = rails_base + "config/"
-    rails_lib = rails_base + "lib/"
-    $:.push rails_config unless $:.index( rails_config )
-    $:.push rails_lib unless $:.index( rails_lib )
-
-    bootfile = rails_config + "boot.rb"
-    envfile = rails_config + "environment.rb"
+    bootfile = rails_base + "config/boot.rb"
+    envfile = rails_base + "config/environment.rb"
     if File.exists?( bootfile ) && File.exists?( envfile )
       begin
         require bootfile

--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -171,6 +171,13 @@ o  Enable Arabic settings [short-cut]
 	 and its support is preferred due to its level of offerings.
 	 'arabic' when 'termbidi' is enabled only sets the keymap.
 
+	 For vertical window isolation while setting 'termbidi' an LTR
+	 vertical separator like "l" or "𝖨" may be used.  It may also be
+	 hidden by changing its color to the foreground color: >
+		:set fillchars=vert:l
+		:hi VertSplit ctermbg=White
+<	Note that this is a workaround, not a proper solution.
+
    If, on the other hand, you'd like to be verbose and explicit and
    are opting not to use the 'arabic' short-cut command, here's what
    is needed (i.e. if you use ':set arabic' you can skip this section) -

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -747,11 +747,14 @@ For compatibility with Vi these two exceptions are allowed:
 "\/{string}/" and "\?{string}?" do the same as "//{string}/r".
 "\&{string}&" does the same as "//{string}/".
 						*pattern-delimiter* *E146*
-Instead of the '/' which surrounds the pattern and replacement string, you
-can use any other single-byte character, but not an alphanumeric character,
-'\', '"' or '|'.  This is useful if you want to include a '/' in the search
-pattern or replacement string.  Example: >
+Instead of the '/' which surrounds the pattern and replacement string, you can
+use another single-byte character.  This is useful if you want to include a
+'/' in the search pattern or replacement string.  Example: >
 	:s+/+//+
+
+You can use most characters, but not an alphanumeric character, '\', '"' or
+'|'.  In Vim9 script you should not use '#' because it may be recognized as
+the start of a comment.
 
 For the definition of a pattern, see |pattern|.  In Visual block mode, use
 |/\%V| in the pattern to have the substitute work in the block only.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -153,7 +153,12 @@ CTRL-R {register}					*c_CTRL-R* *c_<C-R>*
 				too.
 				When the result is a Float it's automatically
 				converted to a String.
-		See |registers| about registers.
+				Note that when you only want to move the
+				cursor and not insert anything, you must make
+				sure the expression evaluates to an empty
+				string.  E.g.: >
+					<C-R><C-R>=setcmdpos(2)[-1]<CR>
+<		See |registers| about registers.
 		Implementation detail: When using the |expression| register
 		and invoking setcmdpos(), this sets the position before
 		inserting the resulting string.  Use CTRL-R CTRL-R to set the
@@ -1067,7 +1072,7 @@ in Normal mode and Insert mode.
 It is possible to use ":", "/" and other commands that use the command-line,
 but it's not possible to open another command-line window then.  There is no
 nesting.
-							*E11*
+							*E11* *E1188*
 The command-line window is not a normal window.  It is not possible to move to
 another window or edit another buffer.  All commands that would do this are
 disabled in the command-line window.  Of course it _is_ possible to execute

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -334,9 +334,11 @@ between file1 and file2: >
 
 The ">" is replaced with the value of 'shellredir'.
 
-The output of "diff" must be a normal "ed" style diff or a unified diff.  Do
-NOT use a context diff.  This example explains the format that Vim expects for
-the "ed" style diff: >
+The output of "diff" must be a normal "ed" style diff or a unified diff.  A
+context diff will NOT work.  For a unified diff no context lines can be used.
+Using "diff -u" will NOT work, use "diff -U0".
+
+This example explains the format that Vim expects for the "ed" style diff: >
 
 	1a2
 	> bbb

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1060,7 +1060,8 @@ Floating point numbers can be written in two forms:
 	[-+]{N}.{M}[eE][-+]{exp}
 
 {N} and {M} are numbers.  Both {N} and {M} must be present and can only
-contain digits.
+contain digits, except that in |Vim9| script in {N} single quotes between
+digits are ignored.
 [-+] means there is an optional plus or minus sign.
 {exp} is the exponent, power of 10.
 Only a decimal point is accepted, not a comma.  No matter what the current
@@ -1688,7 +1689,8 @@ v:fcs_choice	What should happen after a |FileChangedShell| event was
 		Vim behaves like it is empty, there is no warning message.
 
 					*v:fname* *fname-variable*
-v:fname		The file name set by 'includeexpr'.  Empty otherwise.
+v:fname		When evaluating 'includeexpr': the file name that was
+		detected.  Empty otherwise.
 
 					*v:fname_in* *fname_in-variable*
 v:fname_in	The name of the input file.  Valid while evaluating:
@@ -1822,7 +1824,7 @@ v:null		Special value used to put "null" in JSON and NIL in msgpack.
 v:numbermax	Maximum value of a number.
 
 					*v:numbermin* *numbermin-variable*
-v:numbermin	Minimum value of a number (negative)
+v:numbermin	Minimum value of a number (negative).
 
 					*v:numbersize* *numbersize-variable*
 v:numbersize	Number of bits in a Number.  This is normally 64, but on some
@@ -2442,11 +2444,11 @@ shiftwidth([{col}])		Number	effective value of 'shiftwidth'
 sign_define({name} [, {dict}])	Number	define or update a sign
 sign_define({list})		List	define or update a list of signs
 sign_getdefined([{name}])	List	get a list of defined signs
-sign_getplaced([{expr} [, {dict}]])
+sign_getplaced([{buf} [, {dict}]])
 				List	get a list of placed signs
-sign_jump({id}, {group}, {expr})
+sign_jump({id}, {group}, {buf})
 				Number	jump to a sign
-sign_place({id}, {group}, {name}, {expr} [, {dict}])
+sign_place({id}, {group}, {name}, {buf} [, {dict}])
 				Number	place a sign
 sign_placelist({list})		List	place a list of signs
 sign_undefine([{name}])		Number	undefine a sign
@@ -2499,7 +2501,7 @@ submatch({nr} [, {list}])	String or List
 substitute({expr}, {pat}, {sub}, {flags})
 				String	all {pat} in {expr} replaced with {sub}
 swapinfo({fname})		Dict	information about swap file {fname}
-swapname({expr})		String	swap file of buffer {expr}
+swapname({buf})			String	swap file of buffer {buf}
 synID({lnum}, {col}, {trans})	Number	syntax ID at {lnum} and {col}
 synIDattr({synID}, {what} [, {mode}])
 				String	attribute {what} of syntax ID {synID}
@@ -2754,7 +2756,7 @@ browsedir({title}, {initdir})
 		browsing is not possible, an empty string is returned.
 
 bufadd({name})						*bufadd()*
-		Add a buffer to the buffer list with {name}.
+		Add a buffer to the buffer list with String {name}.
 		If a buffer for file {name} already exists, return that buffer
 		number.  Otherwise return the buffer number of the newly
 		created buffer.  When {name} is an empty string then a new
@@ -2988,10 +2990,10 @@ charidx({string}, {idx} [, {countcc}])
 		The index of the first character is zero.
 		If there are no multibyte characters the returned value is
 		equal to {idx}.
-		When {countcc} is omitted or zero, then composing characters
-		are not counted separately, their byte length is added to the
-		preceding base character.
-		When {countcc} is set to 1, then composing characters are
+		When {countcc} is omitted or |FALSE|, then composing characters
+		are not counted separately, their byte length is
+		added to the preceding base character.
+		When {countcc} is |TRUE|, then composing characters are
 		counted as separate characters.
 		Returns -1 if the arguments are invalid or if {idx} is greater
 		than the index of the last byte in {string}.  An error is
@@ -3068,6 +3070,7 @@ complete({startcol}, {matches})			*complete()* *E785*
 		match.
 		{matches} must be a |List|.  Each |List| item is one match.
 		See |complete-items| for the kind of items that are possible.
+		"longest" in 'completeopt' is ignored.
 		Note that the after calling this function you need to avoid
 		inserting anything that would cause completion to stop.
 		The match can be selected with CTRL-N and CTRL-P as usual with
@@ -3102,8 +3105,8 @@ complete_check()				*complete_check()*
 		Only to be used by the function specified with the
 		'completefunc' option.
 
-							*complete_info()*
-complete_info([{what}])
+
+complete_info([{what}])				*complete_info()*
 		Returns a |Dictionary| with information about Insert mode
 		completion.  See |ins-completion|.
 		The items are:
@@ -3117,7 +3120,9 @@ complete_info([{what}])
 				See |complete-items|.
 		   selected	Selected item index.  First index is zero.
 				Index is -1 if no item is selected (showing
-				typed text only)
+				typed text only, or the last completion after
+				no item is selected when using the <Up> or
+				<Down> keys)
 		   inserted	Inserted string. [NOT IMPLEMENT YET]
 
 							*complete_info_mode*
@@ -3587,9 +3592,11 @@ exists({expr})	The result is a Number, which is |TRUE| if {expr} is
 			varname		internal variable (see
 					|internal-variables|).  Also works
 					for |curly-braces-names|, |Dictionary|
-					entries, |List| items, etc.  Beware
-					that evaluating an index may cause an
-					error message for an invalid
+					entries, |List| items, etc.
+					Does not work for local variables in a
+					compiled `:def` function.
+					Beware that evaluating an index may
+					cause an error message for an invalid
 					expression.  E.g.: >
 					   :let l = [1, 2, 3]
 					   :echo exists("l[5]")
@@ -3730,7 +3737,7 @@ expand({expr} [, {nosuf} [, {list}]])				*expand()*
 		buffer with no name, results in the current directory, with a
 		'/' added.
 
-		When {expr} does not start with '%', '#' or '<', it is
+		When {string} does not start with '%', '#' or '<', it is
 		expanded like a file name is expanded on the command line.
 		'suffixes' and 'wildignore' are used, unless the optional
 		{nosuf} argument is given and it is |TRUE|.
@@ -4190,8 +4197,8 @@ getbufinfo([{dict}])
 			bufloaded	include only loaded buffers.
 			bufmodified	include only modified buffers.
 
-		Otherwise, {expr} specifies a particular buffer to return
-		information for.  For the use of {expr}, see |bufname()|
+		Otherwise, {buf} specifies a particular buffer to return
+		information for.  For the use of {buf}, see |bufname()|
 		above.  If the buffer is found the returned List has one item.
 		Otherwise the result is an empty list.
 
@@ -4456,9 +4463,9 @@ getcmdwintype()						*getcmdwintype()*
 		when not in the command-line window.
 
 getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
-		Return a list of command-line completion matches. {type}
-		specifies what for.  The following completion types are
-		supported:
+		Return a list of command-line completion matches. The String
+		{type} argument specifies what for.  The following completion
+		types are supported:
 
 		arglist		file names in argument list
 		augroup		autocmd groups
@@ -4551,8 +4558,8 @@ getfontname([{name}])					*getfontname()*
 		Without an argument returns the name of the normal font being
 		used.  Like what is used for the Normal highlight group
 		|hl-Normal|.
-		With an argument a check is done whether {name} is a valid
-		font name.  If not then an empty string is returned.
+		With an argument a check is done whether String {name} is a
+		valid font name.  If not then an empty string is returned.
 		Otherwise the actual font name is returned, or {name} if the
 		GUI does not support obtaining the real name.
 		Only works when the GUI is running, thus not in your vimrc or
@@ -4681,20 +4688,20 @@ getloclist({nr},[, {what}])				*getloclist()*
 			:echo getloclist(5, {'filewinid': 0})
 
 
-getmarklist([{expr}])					*getmarklist()*
-		Without the {expr} argument returns a |List| with information
+getmarklist([{buf}])					*getmarklist()*
+		Without the {buf} argument returns a |List| with information
 		about all the global marks. |mark|
 
-		If the optional {expr} argument is specified, returns the
-		local marks defined in buffer {expr}.  For the use of {expr},
+		If the optional {buf} argument is specified, returns the
+		local marks defined in buffer {buf}.  For the use of {buf},
 		see |bufname()|.
 
 		Each item in the returned List is a |Dict| with the following:
-		    name - name of the mark prefixed by "'"
-		    pos - a |List| with the position of the mark:
+		    mark   name of the mark prefixed by "'"
+		    pos	   a |List| with the position of the mark:
 				[bufnum, lnum, col, off]
-			  Refer to |getpos()| for more information.
-		    file - file name
+			   Refer to |getpos()| for more information.
+		    file   file name
 
 		Refer to |getpos()| for getting information about a specific
 		mark.
@@ -4705,6 +4712,8 @@ getmatches([{win}])					*getmatches()*
 		|getmatches()| is useful in combination with |setmatches()|,
 		as |setmatches()| can restore a list of matches saved by
 		|getmatches()|.
+		If {win} is specified, use the window with this number or
+		window ID instead of the current window.
 		Example: >
 			:echo getmatches()
 <			[{'group': 'MyGroup1', 'pattern': 'TODO',
@@ -4773,8 +4782,10 @@ getqflist([{what}])					*getqflist()*
 			valid	|TRUE|: recognized error message
 
 		When there is no error list or it's empty, an empty list is
-		returned. Quickfix list entries with non-existing buffer
-		number are returned with "bufnr" set to zero.
+		returned. Quickfix list entries with a non-existing buffer
+		number are returned with "bufnr" set to zero (Note: some
+		functions accept buffer number zero for the alternate buffer,
+		you may need to explicitly check for zero).
 
 		Useful application: Find pattern matches in multiple files and
 		do something with them: >
@@ -4851,6 +4862,7 @@ getreg([{regname} [, 1 [, {list}]]])			*getreg()*
 		{regname}.  Example: >
 			:let cliptext = getreg('*')
 <		When {regname} was not set the result is an empty string.
+		The {regname} argument is a string.
 
 		getreg('=') returns the last evaluated value of the expression
 		register.  (For use in maps.)
@@ -5191,6 +5203,7 @@ hasmapto({what} [, {mode} [, {abbr}]])			*hasmapto()*
 		that contains {what} in somewhere in the rhs (what it is
 		mapped to) and this mapping exists in one of the modes
 		indicated by {mode}.
+		The arguments {what} and {mode} are strings.
 		When {abbr} is there and it is |TRUE| use abbreviations
 		instead of mappings.  Don't forget to specify Insert and/or
 		Command-line mode.
@@ -5311,8 +5324,8 @@ hostname()						*hostname()*
 		which Vim is currently running.  Machine names greater than
 		256 characters long are truncated.
 
-iconv({expr}, {from}, {to})				*iconv()*
-		The result is a String, which is the text {expr} converted
+iconv({string}, {from}, {to})				*iconv()*
+		The result is a String, which is the text {string} converted
 		from encoding {from} to encoding {to}.
 		When the conversion completely fails an empty string is
 		returned.  When some characters could not be converted they
@@ -5549,8 +5562,9 @@ isinf({expr})						*isinf()*
 islocked({expr})					*islocked()* *E786*
 		The result is a Number, which is |TRUE| when {expr} is the
 		name of a locked variable.
-		{expr} must be the name of a variable, |List| item or
-		|Dictionary| entry, not the variable itself!  Example: >
+		The string argument {expr} must be the name of a variable,
+		|List| item or |Dictionary| entry, not the variable itself!
+		Example: >
 			:let alist = [0, ['a', 'b'], 2, 3]
 			:lockvar 1 alist
 			:echo islocked('alist')		" 1
@@ -7015,6 +7029,7 @@ remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 
 remote_foreground({server})				*remote_foreground()*
 		Move the Vim server with the name {server} to the foreground.
+		The {server} argument is a string.
 		This works like: >
 			remote_expr({server}, "foreground()")
 <		Except that on Win32 systems the client does the work, to work
@@ -8641,7 +8656,7 @@ substitute({expr}, {pat}, {sub}, {flags})		*substitute()*
 		|sub-replace-special|.  For example, to replace something with
 		"\n" (two characters), use "\\\\n" or '\\n'.
 
-		When {pat} does not match in {expr}, {expr} is returned
+		When {pat} does not match in {string}, {string} is returned
 		unmodified.
 
 		Example: >
@@ -8698,7 +8713,7 @@ synID({lnum}, {col}, {trans})				*synID()*
 		line.  'synmaxcol' applies, in a longer line zero is returned.
 		Note that when the position is after the last character,
 		that's where the cursor can be in Insert mode, synID() returns
-		zero.
+		zero.  {lnum} is used like with |getline()|.
 
 		When {trans} is |TRUE|, transparent items are reduced to the
 		item that they reveal.  This is useful when wanting to know
@@ -8757,7 +8772,7 @@ synconcealed({lnum}, {col})				*synconcealed()*
 		The result is a |List| with currently three items:
 		1. The first item in the list is 0 if the character at the
 		   position {lnum} and {col} is not part of a concealable
-		   region, 1 if it is.
+		   region, 1 if it is.  {lnum} is used like with |getline()|.
 		2. The second item in the list is a string. If the first item
 		   is 1, the second item contains the text which will be
 		   displayed in place of the concealed text, depending on the
@@ -8781,8 +8796,9 @@ synconcealed({lnum}, {col})				*synconcealed()*
 
 synstack({lnum}, {col})					*synstack()*
 		Return a |List|, which is the stack of syntax items at the
-		position {lnum} and {col} in the current window.  Each item in
-		the List is an ID like what |synID()| returns.
+		position {lnum} and {col} in the current window.  {lnum} is
+		used like with |getline()|.  Each item in the List is an ID
+		like what |synID()| returns.
 		The first item in the List is the outer region, following are
 		items contained in that one.  The last one is what |synID()|
 		returns, unless not the whole item is highlighted or it is a
@@ -11725,7 +11741,7 @@ displayed.
 
 							*except-several-errors*
 When several errors appear in a single command, the first error message is
-usually the most specific one and therefor converted to the error exception.
+usually the most specific one and therefore converted to the error exception.
    Example: >
 	echo novar
 causes >

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -580,7 +580,7 @@ To disable bold highlighting: >
 MARKDOWN                                                *ft-markdown-plugin*
 
 To enable folding use this: >
-        let g:markdown_folding = 1
+	let g:markdown_folding = 1
 <
 
 PDF							*ft-pdf-plugin*

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -535,6 +535,8 @@ nest, the nested fold is one character right of the fold it's contained in.
 
 A closed fold is indicated with a '+'.
 
+These characters can be changed with the 'fillchars' option.
+
 Where the fold column is too narrow to display all nested folds, digits are
 shown to indicate the nesting level.
 

--- a/runtime/doc/ft_ps1.txt
+++ b/runtime/doc/ft_ps1.txt
@@ -1,4 +1,4 @@
-*ps1.txt*  A Windows PowerShell syntax plugin for Vim
+*ft_ps1.txt*  A Windows PowerShell syntax plugin for Vim
 
 Author:  Peter Provost <https://www.github.com/PProvost>
 License: Apache 2.0

--- a/runtime/doc/ft_raku.txt
+++ b/runtime/doc/ft_raku.txt
@@ -1,4 +1,4 @@
-*vim-raku.txt*	The Raku programming language filetype
+*ft_raku.txt*	The Raku programming language filetype
 
                                                       *vim-raku*
 
@@ -45,7 +45,7 @@ Numbers, subscripts and superscripts are available with 's' and 'S':
 	1s ₁    1S ¹  ~
 	2s ₂    9S ⁹  ~
 
-But some don´t come defined by default. Those are digraph definitions you can
+But some don't come defined by default. Those are digraph definitions you can
 add in your ~/.vimrc file. >
 	exec 'digraph \\ '.char2nr('∖')
 	exec 'digraph \< '.char2nr('≼')

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1053,7 +1053,8 @@ On the second invocation the arguments are:
 
 The function must return a List with the matching words.  These matches
 usually include the "a:base" text.  When there are no matches return an empty
-List.
+List.  Note that the cursor may have moved since the first invocation, the
+text may have been changed.
 
 In order to return more information than the matching words, return a Dict
 that contains the List.  The Dict can have these items:
@@ -1124,7 +1125,7 @@ match to the total list.  These matches should then not appear in the returned
 list!  Call |complete_check()| now and then to allow the user to press a key
 while still searching for matches.  Stop searching when it returns non-zero.
 
-							*E839* *E840*
+							*E840*
 The function is allowed to move the cursor, it is restored afterwards.
 The function is not allowed to move to another window or delete text.
 

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -52,9 +52,14 @@ or change text.  The following operators are available:
 	|<|	<	shift left
 	|zf|	zf	define a fold
 	|g@|	g@	call function set with the 'operatorfunc' option
-
+						*motion-count-multiplied*
 If the motion includes a count and the operator also had a count before it,
 the two counts are multiplied.  For example: "2d3w" deletes six words.
+						*operator-doubled*
+When doubling the operator it operates on a line.  When using a count, before
+or after the first character, that many lines are operated upon.  Thus `3dd`
+deletes three lines. A count before and after the first character is
+multiplied, thus `2y3y` yanks six lines.
 
 After applying the operator the cursor is mostly left at the start of the text
 that was operated upon.  For example, "yfe" doesn't move the cursor, but "yFe"
@@ -187,9 +192,9 @@ l		or					*l*
 							*$* *<End>* *<kEnd>*
 $  or <End>		To the end of the line.  When a count is given also go
 			[count - 1] lines downward, or as far is possible.
-			|inclusive| motion.  If a count of 2 of larger is
+			|inclusive| motion.  If a count of 2 or larger is
 			given and the cursor is on the last line, that is an
-			error an the cursor doesn't move.
+			error and the cursor doesn't move.
 			In Visual mode the cursor goes to just after the last
 			character in the line.
 			When 'virtualedit' is active, "$" may move the cursor

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4352,19 +4352,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 		- abbreviations are disabled
 		- 'autoindent' is reset
 		- 'expandtab' is reset
-		- 'formatoptions' is used like it is empty
+		- 'hkmap' is reset
 		- 'revins' is reset
 		- 'ruler' is reset
 		- 'showmatch' is reset
-		- 'smartindent' is reset
 		- 'smarttab' is reset
 		- 'softtabstop' is set to 0
 		- 'textwidth' is set to 0
 		- 'wrapmargin' is set to 0
+		- 'varsofttabstop' is made empty
 	These options keep their value, but their effect is disabled:
 		- 'cindent'
+		- 'formatoptions' is used like it is empty
 		- 'indentexpr'
 		- 'lisp'
+		- 'smartindent'
 	NOTE: When you start editing another file while the 'paste' option is
 	on, settings from the modelines or autocommands may change the
 	settings again, causing trouble when pasting text.  You might want to

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1204,7 +1204,7 @@ x	A single character, with no special meaning, matches itself
 
 \%d123	Matches the character specified with a decimal number.  Must be
 	followed by a non-digit.
-\%o40	Matches the character specified with an octal number up to 0377.
+\%o40	Matches the character specified with an octal number up to 0o377.
 	Numbers below 0o40 must be followed by a non-octal digit or a
 	non-digit.
 \%x2a	Matches the character specified with up to two hexadecimal characters.

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -3808,7 +3808,7 @@ netrw:
 	  Decho.vim is provided as a "vimball"; see |vimball-intro|.  You
 	  should edit the Decho.vba.gz file and source it in: >
 
-	  	vim Decho.vba.gz
+		vim Decho.vba.gz
 		:so %
 		:q
 <

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1333,7 +1333,8 @@ Basic items
 	%o		module name (finds a string)
 	%l		line number (finds a number)
 	%c		column number (finds a number representing character
-			column of the error, (1 <tab> == 1 character column))
+			column of the error, byte index, a <tab> is 1
+			character column)
 	%v		virtual column number (finds a number representing
 			screen column of the error (1 <tab> == 8 screen
 			columns))

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -255,7 +255,9 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			ftdetect scripts are loaded, only the matching
 			directories are added to 'runtimepath'.  This is
 			useful in your .vimrc.  The plugins will then be
-			loaded during initialization, see |load-plugins|.
+			loaded during initialization, see |load-plugins| (note
+			that the loading order will be reversed, because each
+			directory is inserted before others).
 			Note that for ftdetect scripts to be loaded
 			you will need to write `filetype plugin indent on`
 			AFTER all `packadd!` commands.
@@ -780,6 +782,16 @@ About the additional commands in debug mode:
   is reset (because it's not clear what you want to repeat).
 - When you want to use the Ex command with the same name, prepend a colon:
   ":cont", ":next", ":finish" (or shorter).
+							*vim9-debug*
+When debugging a compiled :def function, "step" will stop before every
+executed line, not every single instruction.  Thus it works mostly like a not
+compiled function.  Access to local variables is limited you can use: >
+	echo varname
+But not much else.
+When executing a command that is not a specific bytecode instruction but
+executed like a normal Ex command, "step" will stop once in the compiled
+context, where local variables can be inspected, and once just before
+executing the command.
 
 The backtrace shows the hierarchy of function calls, e.g.:
 	>bt ~

--- a/runtime/doc/rileft.txt
+++ b/runtime/doc/rileft.txt
@@ -70,7 +70,7 @@ o  Invocations
 
 o  Typing backwards					*ins-reverse*
    ----------------
-   In lieu of using full-fledged the 'rightleft' option, one can opt for
+   In lieu of using the full-fledged 'rightleft' option, one can opt for
    reverse insertion.  When the 'revins' (reverse insert) option is set,
    inserting happens backwards.  This can be used to type right-to-left
    text.  When inserting characters the cursor is not moved and the text

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1127,10 +1127,10 @@ flag to avoid lots of errors.
 CIRCUMFIX						*spell-CIRCUMFIX*
 
 The CIRCUMFIX flag means a prefix and suffix must be added at the same time.
-If a prefix has the CIRCUMFIX flag than only suffixes with the CIRCUMFIX flag
+If a prefix has the CIRCUMFIX flag then only suffixes with the CIRCUMFIX flag
 can be added, and the other way around.
-An alternative is to only specify the suffix, and give the that suffix two
-flags: The required prefix and the NEEDAFFIX flag.  |spell-NEEDAFFIX|
+An alternative is to only specify the suffix, and give that suffix two flags:
+the required prefix and the NEEDAFFIX flag.  |spell-NEEDAFFIX|
 
 
 PFXPOSTPONE						*spell-PFXPOSTPONE*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -887,7 +887,7 @@ For Visual Basic use: >
 
 BAAN						    *baan.vim* *baan-syntax*
 
-The baan.vim gives syntax support for BaanC of release BaanIV upto SSA ERP LN
+The baan.vim gives syntax support for BaanC of release BaanIV up to SSA ERP LN
 for both 3 GL and 4 GL programming. Large number of standard defines/constants
 are supported.
 
@@ -1384,11 +1384,17 @@ To select syntax highlighting file for Euphoria, as well as for
 auto-detecting the *.e and *.E file extensions as Euphoria file type,
 add the following line to your startup file: >
 
-	:let filetype_euphoria="euphoria3"
+	:let g:filetype_euphoria = "euphoria3"
 
-	or
+<	or >
 
-	:let filetype_euphoria="euphoria4"
+	:let g:filetype_euphoria = "euphoria4"
+
+Elixir and Euphoria share the *.ex file extension.  If the filetype is 
+specifically set as Euphoria with the g:filetype_euphoria variable, or the
+file is determined to be Euphoria based on keywords in the file, then the
+filetype will be set as Euphoria. Otherwise, the filetype will default to
+Elixir.
 
 
 ERLANG						*erlang.vim* *ft-erlang-syntax*
@@ -1404,6 +1410,22 @@ put the following line in your vimrc: >
 To enable highlighting some special atoms, put this in your vimrc: >
 
       :let g:erlang_highlight_special_atoms = 1
+
+
+ELIXIR						*elixir.vim* *ft-elixir-syntax*
+
+Elixir is a dynamic, functional language for building scalable and maintainable
+applications.
+
+The following file extensions are auto-detected as Elixir file types:
+
+	*.ex, *.exs, *.eex, *.leex, *.lock
+
+Elixir and Euphoria share the *.ex file extension. If the filetype is 
+specifically set as Euphoria with the g:filetype_euphoria variable, or the
+file is determined to be Euphoria based on keywords in the file, then the
+filetype will be set as Euphoria. Otherwise, the filetype will default to
+Elixir.
 
 
 FLEXWIKI				*flexwiki.vim* *ft-flexwiki-syntax*
@@ -3385,8 +3407,8 @@ syntax highlighting script handles this with the following logic:
  Tex: Match Check Control~
 
 	Sometimes one actually wants mismatched parentheses, square braces,
-	and or curly braces; for example, \text{(1,10] is a range from but
-	not including 1 to and including 10}.  This wish, of course, conflicts
+	and or curly braces; for example, \text{(1,10]} is a range from but
+	not including 1 to and including 10.  This wish, of course, conflicts
 	with the desire to provide delimiter mismatch detection.  To
 	accommodate these conflicting goals, syntax/tex.vim provides >
 		g:tex_matchcheck = '[({[]'
@@ -4024,7 +4046,7 @@ match in the same position overrules an earlier one).  The "transparent"
 argument makes the "myVim" match use the same highlighting as "myString".  But
 it does not contain anything.  If the "contains=NONE" argument would be left
 out, then "myVim" would use the contains argument from myString and allow
-"myWord" to be contained, which will be highlighted as a Constant.  This
+"myWord" to be contained, which will be highlighted as a Comment.  This
 happens because a contained match doesn't match inside itself in the same
 position, thus the "myVim" match doesn't overrule the "myWord" match here.
 

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -235,7 +235,7 @@ windows like this:
 	+----------------------------------+
 
 Clearly the last one should be at the top.  Go to that window (using CTRL-W w)
-and the type this command: >
+and then type this command: >
 
 	CTRL-W K
 

--- a/runtime/doc/usr_09.txt
+++ b/runtime/doc/usr_09.txt
@@ -109,7 +109,7 @@ when the 'wrap' option has been reset (more about that later).
 
 When there are vertically split windows, only the windows on the right side
 will have a scrollbar.  However, when you move the cursor to a window on the
-left, it will be this one the that scrollbar controls.  This takes a bit of
+left, it will be this one that the scrollbar controls.  This takes a bit of
 time to get used to.
    When you work with vertically split windows, consider adding a scrollbar on
 the left.  This can be done with a menu item, or with the 'guioptions' option:

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -419,7 +419,7 @@ abcdefghijklmnopqrstuvwxyz
 
 abcdefghijklmnSTRINGopqrstuvwxyz
 abc	      STRING  defghijklmnopqrstuvwxyz
-abcdef  ghi   STRING	jklmnopqrstuvwxyz
+abcdef  ghi   STRING  	jklmnopqrstuvwxyz
 abcdefghijklmnSTRINGopqrstuvwxyz
 
 2. fo<C-v>3j$ASTRING<ESC>					*v_b_A_example*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Apr 17
+" Last Change:	2021 Jul 03
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/ftplugin/chicken.vim
+++ b/runtime/ftplugin/chicken.vim
@@ -2,6 +2,7 @@
 " Last Change: 2018-03-05
 " Author: Evan Hanson <evhan@foldling.org>
 " Maintainer: Evan Hanson <evhan@foldling.org>
+" Repository: https://git.foldling.org/vim-scheme.git
 " URL: https://foldling.org/vim/ftplugin/chicken.vim
 " Notes: These are supplemental settings, to be loaded after the core
 " Scheme ftplugin file (ftplugin/scheme.vim). Enable it by setting

--- a/runtime/ftplugin/eruby.vim
+++ b/runtime/ftplugin/eruby.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2019 Jan 06
+" Last Change:		2020 Jun 28
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -118,7 +118,7 @@ endif
 " TODO: comments=
 setlocal commentstring=<%#%s%>
 
-let b:undo_ftplugin = "setl cms< "
+let b:undo_ftplugin = "setl cms< " .
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin
 
 let &cpo = s:save_cpo

--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2019 Nov 06
+" Last Change:		2020 Feb 13
 
 if (exists("b:did_ftplugin"))
   finish
@@ -112,7 +112,7 @@ else
   if !exists('g:ruby_default_path')
     if has("ruby") && has("win32")
       ruby ::VIM::command( 'let g:ruby_default_path = split("%s",",")' % $:.join(%q{,}) )
-    elseif executable('ruby')
+    elseif executable('ruby') && !empty($HOME)
       let g:ruby_default_path = s:query_path($HOME)
     else
       let g:ruby_default_path = map(split($RUBYLIB,':'), 'v:val ==# "." ? "" : v:val')

--- a/runtime/ftplugin/scheme.vim
+++ b/runtime/ftplugin/scheme.vim
@@ -1,9 +1,10 @@
 " Vim filetype plugin file
 " Language: Scheme (R7RS)
-" Last Change: 2019 Nov 18
+" Last Change: 2019-11-19
 " Author: Evan Hanson <evhan@foldling.org>
 " Maintainer: Evan Hanson <evhan@foldling.org>
 " Previous Maintainer: Sergey Khorev <sergey.khorev@gmail.com>
+" Repository: https://git.foldling.org/vim-scheme.git
 " URL: https://foldling.org/vim/ftplugin/scheme.vim
 
 if exists('b:did_ftplugin')
@@ -48,7 +49,7 @@ let b:undo_ftplugin = b:undo_ftplugin . ' lispwords<'
 let b:did_scheme_ftplugin = 1
 
 if exists('b:is_chicken') || exists('g:is_chicken')
-  exe 'ru! ftplugin/chicken.vim'
+  runtime! ftplugin/chicken.vim
 endif
 
 unlet b:did_scheme_ftplugin

--- a/runtime/indent/bzl.vim
+++ b/runtime/indent/bzl.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Bazel (http://bazel.io)
 " Maintainer:	David Barnett (https://github.com/google/vim-ft-bzl)
-" Last Change:	2017 Jun 13
+" Last Change:	2021 Jul 08
 
 if exists('b:did_indent')
   finish
@@ -41,30 +41,41 @@ function GetBzlIndent(lnum) abort
     if exists('g:pyindent_open_paren')
       let l:pyindent_open_paren = g:pyindent_open_paren
     endif
-    let g:pyindent_nested_paren = 'shiftwidth() * 2'
-    let g:pyindent_open_paren = 'shiftwidth() * 2'
+    let g:pyindent_nested_paren = 'shiftwidth()'
+    let g:pyindent_open_paren = 'shiftwidth()'
   endif
 
   let l:indent = -1
 
-  " Indent inside parens.
-  " Align with the open paren unless it is at the end of the line.
-  " E.g.
-  "   open_paren_not_at_EOL(100,
-  "                         (200,
-  "                          300),
-  "                         400)
-  "   open_paren_at_EOL(
-  "       100, 200, 300, 400)
   call cursor(a:lnum, 1)
   let [l:par_line, l:par_col] = searchpairpos('(\|{\|\[', '', ')\|}\|\]', 'bW',
       \ "line('.') < " . (a:lnum - s:maxoff) . " ? dummy :" .
       \ " synIDattr(synID(line('.'), col('.'), 1), 'name')" .
       \ " =~ '\\(Comment\\|String\\)$'")
   if l:par_line > 0
-    call cursor(l:par_line, 1)
-    if l:par_col != col('$') - 1
-      let l:indent = l:par_col
+    " Indent inside parens.
+    if searchpair('(\|{\|\[', '', ')\|}\|\]', 'W',
+      \ "line('.') < " . (a:lnum - s:maxoff) . " ? dummy :" .
+      \ " synIDattr(synID(line('.'), col('.'), 1), 'name')" .
+      \ " =~ '\\(Comment\\|String\\)$'") && line('.') == a:lnum
+      " If cursor is at close parens, match indent with open parens.
+      " E.g.
+      "   foo(
+      "   )
+      let l:indent = indent(l:par_line)
+    else
+      " Align with the open paren unless it is at the end of the line.
+      " E.g.
+      "   open_paren_not_at_EOL(100,
+      "                         (200,
+      "                          300),
+      "                         400)
+      "   open_paren_at_EOL(
+      "       100, 200, 300, 400)
+      call cursor(l:par_line, 1)
+      if l:par_col != col('$') - 1
+        let l:indent = l:par_col
+      endif
     endif
   endif
 

--- a/runtime/indent/pascal.vim
+++ b/runtime/indent/pascal.vim
@@ -2,7 +2,7 @@
 " Language:    Pascal
 " Maintainer:  Neil Carter <n.carter@swansea.ac.uk>
 " Created:     2004 Jul 13
-" Last Change: 2017 Jun 13
+" Last Change: 2021 Jul 01
 "
 " This is version 2.0, a complete rewrite.
 "
@@ -19,6 +19,8 @@ setlocal indentkeys&
 setlocal indentkeys+==end;,==const,==type,==var,==begin,==repeat,==until,==for
 setlocal indentkeys+==program,==function,==procedure,==object,==private
 setlocal indentkeys+==record,==if,==else,==case
+
+let b:undo_indent = "setl indentkeys< indentexpr<"
 
 if exists("*GetPascalIndent")
 	finish

--- a/runtime/indent/python.vim
+++ b/runtime/indent/python.vim
@@ -2,7 +2,7 @@
 " Language:		Python
 " Maintainer:		Bram Moolenaar <Bram@vim.org>
 " Original Author:	David Bustos <bustos@caltech.edu>
-" Last Change:		2019 Feb 21
+" Last Change:		2021 May 26
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -191,7 +191,7 @@ function GetPythonIndent(lnum)
   if getline(a:lnum) =~ '^\s*\(elif\|else\)\>'
 
     " Unless the previous line was a one-liner
-    if getline(plnumstart) =~ '^\s*\(for\|if\|try\)\>'
+    if getline(plnumstart) =~ '^\s*\(for\|if\|elif\|try\)\>'
       return plindent
     endif
 

--- a/runtime/indent/ruby.vim
+++ b/runtime/indent/ruby.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Nikolai Weibull <now at bitwi.se>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:		2021 Feb 03
 
 " 0. Initialization {{{1
 " =================

--- a/runtime/indent/testdir/xml.in
+++ b/runtime/indent/testdir/xml.in
@@ -15,7 +15,7 @@ text comment
 </tag1>
 <!--
 text comment
-end coment -->
+end comment -->
 </tag0>
 <!-- END_INDENT -->
 

--- a/runtime/indent/testdir/xml.ok
+++ b/runtime/indent/testdir/xml.ok
@@ -15,7 +15,7 @@
         </tag1>
         <!--
                 text comment
-        end coment -->
+        end comment -->
 </tag0>
 <!-- END_INDENT -->
 

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -2,7 +2,7 @@
 " Language:	YAML
 " Maintainer:	Nikolai Pavlov <zyx.vim@gmail.com>
 " Last Update:	Lukas Reineke
-" Last Change:	2021 Jan 19
+" Last Change:	2021 Aug 13
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')

--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -4,7 +4,7 @@ For instructions on installing this file, type
 	`:help matchit-install`
 inside Vim.
 
-For Vim version 8.1.  Last change:  2020 Mar 01
+For Vim version 8.1.  Last change:  2021 May 17
 
 
 		  VIM REFERENCE MANUAL    by Benji Fisher et al
@@ -322,7 +322,7 @@ should work (and have the same effect as "foobar:barfoo:endfoobar"), although
 this has not been thoroughly tested.
 
 You can use |zero-width| patterns such as |\@<=| and |\zs|.  (The latter has
-not been thouroughly tested in matchit.vim.)  For example, if the keyword "if"
+not been thoroughly tested in matchit.vim.)  For example, if the keyword "if"
 must occur at the start of the line, with optional white space, you might use
 the pattern "\(^\s*\)\@<=if" so that the cursor will end on the "i" instead of
 at the start of the line.  For another example, if HTML had only one tag then

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2021 May 16
+" Last Change: 2021 May 18
 "
 " WORK IN PROGRESS - Only the basics work
 " Note: On MS-Windows you need a recent version of gdb.  The one included with
@@ -127,6 +127,10 @@ func s:StartDebug_internal(dict)
   let s:pid = 0
   let s:asmwin = 0
 
+  if exists('#User#TermdebugStartPre')
+    doauto <nomodeline> User TermdebugStartPre
+  endif
+
   " Uncomment this line to write logging in "debuglog".
   " call ch_logfile('debuglog', 'w')
 
@@ -172,6 +176,10 @@ func s:StartDebug_internal(dict)
       call s:GotoAsmwinOrCreateIt()
       call win_gotoid(curwinid)
     endif
+  endif
+
+  if exists('#User#TermdebugStartPost')
+    doauto <nomodeline> User TermdebugStartPost
   endif
 endfunc
 

--- a/runtime/syntax/8th.vim
+++ b/runtime/syntax/8th.vim
@@ -293,7 +293,7 @@ syn region eighthComment start="\zs\\" end="$" contains=eighthTodo
 " Define the default highlighting.
 if !exists("did_eighth_syntax_inits")
     let did_eighth_syntax_inits=1
-    " The default methods for highlighting. Can be overriden later.
+    " The default methods for highlighting. Can be overridden later.
     hi def link eighthTodo Todo
     hi def link eighthOperators Operator
     hi def link eighthMath Number

--- a/runtime/syntax/aptconf.vim
+++ b/runtime/syntax/aptconf.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	APT config file
 " Maintainer:	Yann Amar <quidame@poivron.org>
-" Last Change:	2015 Dec 22
+" Last Change:	2021 Jul 12
 
 " quit when a syntax file was already loaded
 if !exists("main_syntax")
@@ -396,10 +396,13 @@ syn cluster	aptconfSynaptic_ contains=aptconfSynaptic,
 " }}}
 " Unattended Upgrade: {{{
 syn keyword	aptconfUnattendedUpgrade contained
-	\ AutoFixInterruptedDpkg Automatic-Reboot Automatic-Reboot-Time
-	\ Automatic-Reboot-WithUsers InstallOnShutdown Mail MailOnlyOnError
-	\ MinimalSteps Origins-Pattern Package-Blacklist
-	\ Remove-Unused-Dependencies
+	\ Allow-APT-Mark-Fallback Allow-downgrade AutoFixInterruptedDpkg
+	\ Automatic-Reboot Automatic-Reboot-Time Automatic-Reboot-WithUsers
+	\ Debug InstallOnShutdown Mail MailOnlyOnError MailReport MinimalSteps
+	\ OnlyOnACPower Origins-Pattern Package-Blacklist
+	\ Remove-New-Unused-Dependencies Remove-Unused-Dependencies
+	\ Remove-Unused-Kernel-Packages Skip-Updates-On-Metered-Connections
+	\ SyslogEnable SyslogFacility Verbose
 
 syn cluster	aptconfUnattendedUpgrade_ contains=aptconfUnattendedUpgrade
 " }}}

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Jan 11
+" Last Change:	2021 May 24
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -413,6 +413,9 @@ if exists("c_autodoc")
   syn cluster cCommentGroup add=cAutodocReal
   syn cluster cPreProcGroup add=cAutodocReal
 endif
+
+" be able to fold #pragma regions
+syn region	cPragma		start="^\s*#pragma\s\+region\>" end="^\s*#pragma\s\+endregion\>" transparent keepend extend fold
 
 " Highlight User Labels
 syn cluster	cMultiGroup	contains=cIncluded,cSpecial,cCommentSkip,cCommentString,cComment2String,@cCommentGroup,cCommentStartError,cUserCont,cUserLabel,cBitField,cOctalZero,cCppOutWrapper,cCppInWrapper,@cCppOutInGroup,cFormat,cNumber,cFloat,cOctal,cOctalError,cNumbersCom,cCppParen,cCppBracket,cCppString

--- a/runtime/syntax/chicken.vim
+++ b/runtime/syntax/chicken.vim
@@ -1,8 +1,9 @@
 " Vim syntax file
 " Language: Scheme (CHICKEN)
-" Last Change: 2018-02-05
+" Last Change: 2021 Jul 30
 " Author: Evan Hanson <evhan@foldling.org>
 " Maintainer: Evan Hanson <evhan@foldling.org>
+" Repository: https://git.foldling.org/vim-scheme.git
 " URL: https://foldling.org/vim/syntax/chicken.vim
 " Notes: This is supplemental syntax, to be loaded after the core Scheme
 " syntax file (syntax/scheme.vim). Enable it by setting b:is_chicken=1
@@ -36,9 +37,23 @@ if len(s:c)
   syn region c matchgroup=schemeComment start=/#>/ end=/<#/ contains=@c
 endif
 
+# SRFI 26
+syn match schemeSyntax /\(([ \t\n]*\)\@<=\(cut\|cute\)\>/
+
+syn keyword schemeSyntax and-let*
 syn keyword schemeSyntax define-record
+syn keyword schemeSyntax set!-values
+syn keyword schemeSyntax fluid-let
+syn keyword schemeSyntax let-optionals
+syn keyword schemeSyntax let-optionals*
+syn keyword schemeSyntax letrec-values
+syn keyword schemeSyntax nth-value
+syn keyword schemeSyntax receive
 
 syn keyword schemeLibrarySyntax declare
+syn keyword schemeLibrarySyntax define-interface
+syn keyword schemeLibrarySyntax functor
+syn keyword schemeLibrarySyntax include-relative
 syn keyword schemeLibrarySyntax module
 syn keyword schemeLibrarySyntax reexport
 syn keyword schemeLibrarySyntax require-library
@@ -52,10 +67,12 @@ syn keyword schemeTypeSyntax define-specialization
 syn keyword schemeTypeSyntax define-type
 syn keyword schemeTypeSyntax the
 
-syn keyword schemeExtraSyntax and-let*
 syn keyword schemeExtraSyntax match
 syn keyword schemeExtraSyntax match-lambda
 syn keyword schemeExtraSyntax match-lambda*
+syn keyword schemeExtraSyntax match-let
+syn keyword schemeExtraSyntax match-let*
+syn keyword schemeExtraSyntax match-letrec
 
 syn keyword schemeSpecialSyntax define-compiler-syntax
 syn keyword schemeSpecialSyntax define-constant

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -2,7 +2,7 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2021 Jan 12
+" Last Change:	2021 May 04
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -44,33 +44,45 @@ if !exists("cpp_no_cpp11")
   syn keyword cppConstant	ATOMIC_WCHAR_T_LOCK_FREE ATOMIC_SHORT_LOCK_FREE
   syn keyword cppConstant	ATOMIC_INT_LOCK_FREE ATOMIC_LONG_LOCK_FREE
   syn keyword cppConstant	ATOMIC_LLONG_LOCK_FREE ATOMIC_POINTER_LOCK_FREE
-  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"+ contains=@Spell
+  syn region cppRawString	matchgroup=cppRawStringDelimiter start=+\%(u8\|[uLU]\)\=R"\z([[:alnum:]_{}[\]#<>%:;.?*\+\-/\^&|~!=,"']\{,16}\)(+ end=+)\z1"\(sv\|s\|_[_a-zA-Z][_a-zA-Z0-9]*\)\=+ contains=@Spell
   syn match cppCast		"\<\(const\|static\|dynamic\)_pointer_cast\s*<"me=e-1
   syn match cppCast		"\<\(const\|static\|dynamic\)_pointer_cast\s*$"
 endif
 
 " C++ 14 extensions
 if !exists("cpp_no_cpp14")
-  syn case ignore
-  syn match cppNumber		display "\<0b[01]\('\=[01]\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-  syn match cppNumber		display "\<[1-9]\('\=\d\+\)*\(u\=l\{0,2}\|ll\=u\)\>" contains=cFloat
-  syn match cppNumber		display "\<0x\x\('\=\x\+\)*\(u\=l\{0,2}\|ll\=u\)\>"
-  syn case match
-endif
-
-" C++ 20 extensions
-if !exists("cpp_no_cpp20")
-  syn keyword cppStatement	co_await co_return co_yield requires
-  syn keyword cppStorageClass	consteval constinit
-  syn keyword cppStructure	concept
-  syn keyword cppType		char8_t
-  syn keyword cppModule		import module export
+  syn match cppNumbers		display transparent "\<\d\|\.\d" contains=cppNumber,cppFloat
+  syn match cppNumber		display contained "\<0\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<[1-9]\('\=\d\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0\o\+\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0b[01]\('\=[01]\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppNumber		display contained "\<0x\x\('\=\x\+\)*\([Uu]\=\([Ll]\|LL\|ll\)\|\([Ll]\|LL\|ll\)\=[Uu]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\d\+\.\d*\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\.\d\+\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<\d\+e[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn region cppString		start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"\(sv\|s\|_\i*\)\=+ end='$' contains=cSpecial,cFormat,@Spell
 endif
 
 " C++ 17 extensions
 if !exists("cpp_no_cpp17")
   syn match cppCast		"\<reinterpret_pointer_cast\s*<"me=e-1
   syn match cppCast		"\<reinterpret_pointer_cast\s*$"
+  syn match cppFloat		display contained "\<0x\x*\.\x\+p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+  syn match cppFloat		display contained "\<0x\x\+\.\=p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+endif
+
+" C++ 20 extensions
+if !exists("cpp_no_cpp20")
+  syn match cppNumber		display contained "\<0\(y\|d\)\>"
+  syn match cppNumber		display contained "\<[1-9]\('\=\d\+\)*\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0\o\+\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0b[01]\('\=[01]\+\)*\(y\|d\)\>"
+  syn match cppNumber		display contained "\<0x\x\('\=\x\+\)*\(y\|d\)\>"
+  syn keyword cppStatement	co_await co_return co_yield requires
+  syn keyword cppStorageClass	consteval constinit
+  syn keyword cppStructure	concept
+  syn keyword cppType		char8_t
+  syn keyword cppModule		import module export
 endif
 
 " The minimum and maximum operators in GNU C++
@@ -90,7 +102,9 @@ hi def link cppBoolean		Boolean
 hi def link cppConstant		Constant
 hi def link cppRawStringDelimiter	Delimiter
 hi def link cppRawString		String
+hi def link cppString		String
 hi def link cppNumber		Number
+hi def link cppFloat		Number
 hi def link cppModule		Include
 
 let b:current_syntax = "cpp"

--- a/runtime/syntax/debchangelog.vim
+++ b/runtime/syntax/debchangelog.vim
@@ -3,7 +3,7 @@
 " Maintainer:  Debian Vim Maintainers
 " Former Maintainers: Gerfried Fuchs <alfie@ist.org>
 "                     Wichert Akkerman <wakkerma@debian.org>
-" Last Change: 2020 Nov 28
+" Last Change: 2021 Aug 03
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/master/syntax/debchangelog.vim
 
 " Standard syntax initialization
@@ -24,7 +24,7 @@ let s:supported = [
       \ 'jessie', 'stretch', 'buster', 'bullseye', 'bookworm',
       \ 'trixie', 'sid', 'rc-buggy',
       \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'groovy', 'hirsute', 'devel'
+      \ 'trusty', 'xenial', 'bionic', 'focal', 'hirsute', 'impish', 'devel'
       \ ]
 let s:unsupported = [
       \ 'frozen', 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
@@ -34,7 +34,7 @@ let s:unsupported = [
       \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
       \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
       \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
-      \ 'disco', 'eoan'
+      \ 'disco', 'eoan', 'groovy'
       \ ]
 let &cpo=s:cpo
 

--- a/runtime/syntax/debsources.vim
+++ b/runtime/syntax/debsources.vim
@@ -2,7 +2,7 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers
 " Former Maintainer: Matthijs Mohlmann <matthijs@cacholong.nl>
-" Last Change: 2020 Nov 28
+" Last Change: 2021 Aug 03
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/master/syntax/debsources.vim
 
 " Standard syntax initialization
@@ -26,7 +26,7 @@ let s:supported = [
       \ 'jessie', 'stretch', 'buster', 'bullseye', 'bookworm',
       \ 'trixie', 'sid', 'rc-buggy',
       \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'groovy', 'hirsute', 'devel'
+      \ 'trusty', 'xenial', 'bionic', 'focal', 'hirsute', 'impish', 'devel'
       \ ]
 let s:unsupported = [
       \ 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
@@ -36,7 +36,7 @@ let s:unsupported = [
       \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
       \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
       \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
-      \ 'disco', 'eoan'
+      \ 'disco', 'eoan', 'groovy'
       \ ]
 let &cpo=s:cpo
 

--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -1,58 +1,109 @@
-" Vim syntax file
-" Language:	Go
-" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
-" Last Change:	2014 Aug 16
-
-" Options:
-"   There are some options for customizing the highlighting; the recommended
-"   settings are the default values, but you can write:
-"     let OPTION_NAME = 0
-"   in your ~/.vimrc file to disable particular options. You can also write:
-"     let OPTION_NAME = 1
-"   to enable particular options. At present, all options default to on.
+" Copyright 2009 The Go Authors. All rights reserved.
+" Use of this source code is governed by a BSD-style
+" license that can be found in the LICENSE file.
 "
-"   - g:go_highlight_array_whitespace_error
-"     Highlights white space after "[]".
-"   - g:go_highlight_chan_whitespace_error
-"     Highlights white space around the communications operator that don't
-"     follow the standard style.
-"   - g:go_highlight_extra_types
-"     Highlights commonly used library types (io.Reader, etc.).
-"   - g:go_highlight_space_tab_error
-"     Highlights instances of tabs following spaces.
-"   - g:go_highlight_trailing_whitespace_error
-"     Highlights trailing white space.
+" go.vim: Vim syntax file for Go.
+" Language:             Go
+" Maintainer:           Billie Cleek <bhcleek@gmail.com>
+" Latest Revision:      2021-06-26
+" License:              BSD-style. See LICENSE file in source repository.
+" Repository:           https://github.com/fatih/vim-go
 
 " Quit when a (custom) syntax file was already loaded
-if exists('b:current_syntax')
+if exists("b:current_syntax")
   finish
 endif
 
-if !exists('g:go_highlight_array_whitespace_error')
-  let g:go_highlight_array_whitespace_error = 1
-endif
-if !exists('g:go_highlight_chan_whitespace_error')
-  let g:go_highlight_chan_whitespace_error = 1
-endif
-if !exists('g:go_highlight_extra_types')
-  let g:go_highlight_extra_types = 1
-endif
-if !exists('g:go_highlight_space_tab_error')
-  let g:go_highlight_space_tab_error = 1
-endif
-if !exists('g:go_highlight_trailing_whitespace_error')
-  let g:go_highlight_trailing_whitespace_error = 1
-endif
+let s:keepcpo = &cpo
+set cpo&vim
+
+function! s:FoldEnable(...) abort
+  if a:0 > 0
+    return index(s:FoldEnable(), a:1) > -1
+  endif
+  return get(g:, 'go_fold_enable', ['block', 'import', 'varconst', 'package_comment'])
+endfunction
+
+function! s:HighlightArrayWhitespaceError() abort
+  return get(g:, 'go_highlight_array_whitespace_error', 0)
+endfunction
+
+function! s:HighlightChanWhitespaceError() abort
+  return get(g:, 'go_highlight_chan_whitespace_error', 0)
+endfunction
+
+function! s:HighlightExtraTypes() abort
+  return get(g:, 'go_highlight_extra_types', 0)
+endfunction
+
+function! s:HighlightSpaceTabError() abort
+  return get(g:, 'go_highlight_space_tab_error', 0)
+endfunction
+
+function! s:HighlightTrailingWhitespaceError() abort
+  return get(g:, 'go_highlight_trailing_whitespace_error', 0)
+endfunction
+
+function! s:HighlightOperators() abort
+  return get(g:, 'go_highlight_operators', 0)
+endfunction
+
+function! s:HighlightFunctions() abort
+  return get(g:, 'go_highlight_functions', 0)
+endfunction
+
+function! s:HighlightFunctionParameters() abort
+  return get(g:, 'go_highlight_function_parameters', 0)
+endfunction
+
+function! s:HighlightFunctionCalls() abort
+  return get(g:, 'go_highlight_function_calls', 0)
+endfunction
+
+function! s:HighlightFields() abort
+  return get(g:, 'go_highlight_fields', 0)
+endfunction
+
+function! s:HighlightTypes() abort
+  return get(g:, 'go_highlight_types', 0)
+endfunction
+
+function! s:HighlightBuildConstraints() abort
+  return get(g:, 'go_highlight_build_constraints', 0)
+endfunction
+
+function! s:HighlightStringSpellcheck() abort
+  return get(g:, 'go_highlight_string_spellcheck', 1)
+endfunction
+
+function! s:HighlightFormatStrings() abort
+  return get(g:, 'go_highlight_format_strings', 1)
+endfunction
+
+function! s:HighlightGenerateTags() abort
+  return get(g:, 'go_highlight_generate_tags', 0)
+endfunction
+
+function! s:HighlightVariableAssignments() abort
+  return get(g:, 'go_highlight_variable_assignments', 0)
+endfunction
+
+function! s:HighlightVariableDeclarations() abort
+  return get(g:, 'go_highlight_variable_declarations', 0)
+endfunction
 
 syn case match
 
-syn keyword     goDirective         package import
-syn keyword     goDeclaration       var const type
-syn keyword     goDeclType          struct interface
+syn keyword     goPackage           package
+syn keyword     goImport            import    contained
+syn keyword     goVar               var       contained
+syn keyword     goConst             const     contained
 
-hi def link     goDirective         Statement
+hi def link     goPackage           Statement
+hi def link     goImport            Statement
+hi def link     goVar               Keyword
+hi def link     goConst             Keyword
 hi def link     goDeclaration       Keyword
-hi def link     goDeclType          Keyword
 
 " Keywords within functions
 syn keyword     goStatement         defer go goto return break continue fallthrough
@@ -78,27 +129,37 @@ hi def link     goUnsignedInts      Type
 hi def link     goFloats            Type
 hi def link     goComplexes         Type
 
-" Treat func specially: it's a declaration at the start of a line, but a type
-" elsewhere. Order matters here.
-syn match       goType              /\<func\>/
-syn match       goDeclaration       /^func\>/
-
 " Predefined functions and values
-syn keyword     goBuiltins          append cap close complex copy delete imag len
-syn keyword     goBuiltins          make new panic print println real recover
-syn keyword     goConstants         iota true false nil
+syn keyword     goBuiltins                 append cap close complex copy delete imag len
+syn keyword     goBuiltins                 make new panic print println real recover
+syn keyword     goBoolean                  true false
+syn keyword     goPredefinedIdentifiers    nil iota
 
-hi def link     goBuiltins          Keyword
-hi def link     goConstants         Keyword
+hi def link     goBuiltins                 Identifier
+hi def link     goBoolean                  Boolean
+hi def link     goPredefinedIdentifiers    goBoolean
 
 " Comments; their contents
 syn keyword     goTodo              contained TODO FIXME XXX BUG
 syn cluster     goCommentGroup      contains=goTodo
-syn region      goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell
-syn region      goComment           start="//" end="$" contains=@goCommentGroup,@Spell
+
+syn region      goComment           start="//" end="$" contains=goGenerate,@goCommentGroup,@Spell
+if s:FoldEnable('comment')
+  syn region    goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell fold
+  syn match     goComment           "\v(^\s*//.*\n)+" contains=goGenerate,@goCommentGroup,@Spell fold
+else
+  syn region    goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell
+endif
 
 hi def link     goComment           Comment
 hi def link     goTodo              Todo
+
+if s:HighlightGenerateTags()
+  syn match       goGenerateVariables contained /\%(\$GOARCH\|\$GOOS\|\$GOFILE\|\$GOLINE\|\$GOPACKAGE\|\$DOLLAR\)\>/
+  syn region      goGenerate          start="^\s*//go:generate" end="$" contains=goGenerateVariables
+  hi def link     goGenerate          PreProc
+  hi def link     goGenerateVariables Special
+endif
 
 " Go escapes
 syn match       goEscapeOctal       display contained "\\[0-7]\{3}"
@@ -118,8 +179,30 @@ hi def link     goEscapeError       Error
 
 " Strings and their contents
 syn cluster     goStringGroup       contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU,goEscapeError
-syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
-syn region      goRawString         start=+`+ end=+`+
+if s:HighlightStringSpellcheck()
+  syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup,@Spell
+  syn region      goRawString         start=+`+ end=+`+ contains=@Spell
+else
+  syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
+  syn region      goRawString         start=+`+ end=+`+
+endif
+
+if s:HighlightFormatStrings()
+  " [n] notation is valid for specifying explicit argument indexes
+  " 1. Match a literal % not preceded by a %.
+  " 2. Match any number of -, #, 0, space, or +
+  " 3. Match * or [n]* or any number or nothing before a .
+  " 4. Match * or [n]* or any number or nothing after a .
+  " 5. Match [n] or nothing before a verb
+  " 6. Match a formatting verb
+  syn match       goFormatSpecifier   /\
+        \%([^%]\%(%%\)*\)\
+        \@<=%[-#0 +]*\
+        \%(\%(\%(\[\d\+\]\)\=\*\)\|\d\+\)\=\
+        \%(\.\%(\%(\%(\[\d\+\]\)\=\*\)\|\d\+\)\=\)\=\
+        \%(\[\d\+\]\)\=[vTtbcdoqxXUeEfFgGspw]/ contained containedin=goString,goRawString
+  hi def link     goFormatSpecifier   goSpecialString
+endif
 
 hi def link     goString            String
 hi def link     goRawString         String
@@ -131,70 +214,262 @@ syn region      goCharacter         start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=
 hi def link     goCharacter         Character
 
 " Regions
-syn region      goBlock             start="{" end="}" transparent fold
 syn region      goParen             start='(' end=')' transparent
+if s:FoldEnable('block')
+  syn region    goBlock             start="{" end="}" transparent fold
+else
+  syn region    goBlock             start="{" end="}" transparent
+endif
+
+" import
+if s:FoldEnable('import')
+  syn region    goImport            start='import (' end=')' transparent fold contains=goImport,goString,goComment
+else
+  syn region    goImport            start='import (' end=')' transparent contains=goImport,goString,goComment
+endif
+
+" var, const
+if s:FoldEnable('varconst')
+  syn region    goVar               start='var ('   end='^\s*)$' transparent fold
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+  syn region    goConst             start='const (' end='^\s*)$' transparent fold
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+else
+  syn region    goVar               start='var ('   end='^\s*)$' transparent
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+  syn region    goConst             start='const (' end='^\s*)$' transparent
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+endif
+
+" Single-line var, const, and import.
+syn match       goSingleDecl        /\%(import\|var\|const\) [^(]\@=/ contains=goImport,goVar,goConst
 
 " Integers
-syn match       goDecimalInt        "\<\d\+\([Ee]\d\+\)\?\>"
-syn match       goHexadecimalInt    "\<0x\x\+\>"
-syn match       goOctalInt          "\<0\o\+\>"
-syn match       goOctalError        "\<0\o*[89]\d*\>"
+syn match       goDecimalInt        "\<-\=\(0\|[1-9]_\?\(\d\|\d\+_\?\d\+\)*\)\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goDecimalError      "\<-\=\(_\(\d\+_*\)\+\|\([1-9]\d*_*\)\+__\(\d\+_*\)\+\|\([1-9]\d*_*\)\+_\+\)\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goHexadecimalInt    "\<-\=0[xX]_\?\(\x\+_\?\)\+\>"
+syn match       goHexadecimalError  "\<-\=0[xX]_\?\(\x\+_\?\)*\(\([^ \t0-9A-Fa-f_)]\|__\)\S*\|_\)\>"
+syn match       goOctalInt          "\<-\=0[oO]\?_\?\(\o\+_\?\)\+\>"
+syn match       goOctalError        "\<-\=0[0-7oO_]*\(\([^ \t0-7oOxX_/)\]\}\:]\|[oO]\{2,\}\|__\)\S*\|_\|[oOxX]\)\>"
+syn match       goBinaryInt         "\<-\=0[bB]_\?\([01]\+_\?\)\+\>"
+syn match       goBinaryError       "\<-\=0[bB]_\?[01_]*\([^ \t01_)]\S*\|__\S*\|_\)\>"
 
 hi def link     goDecimalInt        Integer
+hi def link     goDecimalError      Error
 hi def link     goHexadecimalInt    Integer
+hi def link     goHexadecimalError  Error
 hi def link     goOctalInt          Integer
+hi def link     goOctalError        Error
+hi def link     goBinaryInt         Integer
+hi def link     goBinaryError       Error
 hi def link     Integer             Number
 
 " Floating point
-syn match       goFloat             "\<\d\+\.\d*\([Ee][-+]\d\+\)\?\>"
-syn match       goFloat             "\<\.\d\+\([Ee][-+]\d\+\)\?\>"
-syn match       goFloat             "\<\d\+[Ee][-+]\d\+\>"
+syn match       goFloat             "\<-\=\d\+\.\d*\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goFloat             "\<-\=\.\d\+\%([Ee][-+]\=\d\+\)\=\>"
 
 hi def link     goFloat             Float
 
 " Imaginary literals
-syn match       goImaginary         "\<\d\+i\>"
-syn match       goImaginary         "\<\d\+\.\d*\([Ee][-+]\d\+\)\?i\>"
-syn match       goImaginary         "\<\.\d\+\([Ee][-+]\d\+\)\?i\>"
-syn match       goImaginary         "\<\d\+[Ee][-+]\d\+i\>"
+syn match       goImaginary         "\<-\=\d\+i\>"
+syn match       goImaginary         "\<-\=\d\+[Ee][-+]\=\d\+i\>"
+syn match       goImaginaryFloat    "\<-\=\d\+\.\d*\%([Ee][-+]\=\d\+\)\=i\>"
+syn match       goImaginaryFloat    "\<-\=\.\d\+\%([Ee][-+]\=\d\+\)\=i\>"
 
 hi def link     goImaginary         Number
+hi def link     goImaginaryFloat    Float
 
 " Spaces after "[]"
-if go_highlight_array_whitespace_error != 0
-  syn match goSpaceError display "\(\[\]\)\@<=\s\+"
+if s:HighlightArrayWhitespaceError()
+  syn match goSpaceError display "\%(\[\]\)\@<=\s\+"
 endif
 
 " Spacing errors around the 'chan' keyword
-if go_highlight_chan_whitespace_error != 0
+if s:HighlightChanWhitespaceError()
   " receive-only annotation on chan type
-  syn match goSpaceError display "\(<-\)\@<=\s\+\(chan\>\)\@="
+  "
+  " \(\<chan\>\)\@<!<-  (only pick arrow when it doesn't come after a chan)
+  " this prevents picking up 'chan<- chan<-' but not '<- chan'
+  syn match goSpaceError display "\%(\%(\<chan\>\)\@<!<-\)\@<=\s\+\%(\<chan\>\)\@="
+
   " send-only annotation on chan type
-  syn match goSpaceError display "\(\<chan\)\@<=\s\+\(<-\)\@="
+  "
+  " \(<-\)\@<!\<chan\>  (only pick chan when it doesn't come after an arrow)
+  " this prevents picking up '<-chan <-chan' but not 'chan <-'
+  syn match goSpaceError display "\%(\%(<-\)\@<!\<chan\>\)\@<=\s\+\%(<-\)\@="
+
   " value-ignoring receives in a few contexts
-  syn match goSpaceError display "\(\(^\|[={(,;]\)\s*<-\)\@<=\s\+"
+  syn match goSpaceError display "\%(\%(^\|[={(,;]\)\s*<-\)\@<=\s\+"
 endif
 
 " Extra types commonly seen
-if go_highlight_extra_types != 0
-  syn match goExtraType /\<bytes\.\(Buffer\)\>/
-  syn match goExtraType /\<io\.\(Reader\|Writer\|ReadWriter\|ReadWriteCloser\)\>/
-  syn match goExtraType /\<reflect\.\(Kind\|Type\|Value\)\>/
+if s:HighlightExtraTypes()
+  syn match goExtraType /\<bytes\.\%(Buffer\)\>/
+  syn match goExtraType /\<context\.\%(Context\)\>/
+  syn match goExtraType /\<io\.\%(Reader\|ReadSeeker\|ReadWriter\|ReadCloser\|ReadWriteCloser\|Writer\|WriteCloser\|Seeker\)\>/
+  syn match goExtraType /\<reflect\.\%(Kind\|Type\|Value\)\>/
   syn match goExtraType /\<unsafe\.Pointer\>/
 endif
 
 " Space-tab error
-if go_highlight_space_tab_error != 0
+if s:HighlightSpaceTabError()
   syn match goSpaceError display " \+\t"me=e-1
 endif
 
 " Trailing white space error
-if go_highlight_trailing_whitespace_error != 0
+if s:HighlightTrailingWhitespaceError()
   syn match goSpaceError display excludenl "\s\+$"
 endif
 
 hi def link     goExtraType         Type
 hi def link     goSpaceError        Error
+
+
+
+" included from: https://github.com/athom/more-colorful.vim/blob/master/after/syntax/go.vim
+"
+" Comments; their contents
+syn keyword     goTodo              contained NOTE
+hi def link     goTodo              Todo
+
+syn match goVarArgs /\.\.\./
+
+" Operators;
+if s:HighlightOperators()
+  " match single-char operators:          - + % < > ! & | ^ * =
+  " and corresponding two-char operators: -= += %= <= >= != &= |= ^= *= ==
+  syn match goOperator /[-+%<>!&|^*=]=\?/
+  " match / and /=
+  syn match goOperator /\/\%(=\|\ze[^/*]\)/
+  " match two-char operators:               << >> &^
+  " and corresponding three-char operators: <<= >>= &^=
+  syn match goOperator /\%(<<\|>>\|&^\)=\?/
+  " match remaining two-char operators: := && || <- ++ --
+  syn match goOperator /:=\|||\|<-\|++\|--/
+  " match ...
+
+  hi def link     goPointerOperator   goOperator
+  hi def link     goVarArgs           goOperator
+endif
+hi def link     goOperator          Operator
+
+" Functions;
+if s:HighlightFunctions() || s:HighlightFunctionParameters()
+  syn match goDeclaration       /\<func\>/ nextgroup=goReceiver,goFunction,goSimpleParams skipwhite skipnl
+  syn match goReceiverVar       /\w\+\ze\s\+\%(\w\|\*\)/ nextgroup=goPointerOperator,goReceiverType skipwhite skipnl contained
+  syn match goPointerOperator   /\*/ nextgroup=goReceiverType contained skipwhite skipnl
+  syn match goFunction          /\w\+/ nextgroup=goSimpleParams contained skipwhite skipnl
+  syn match goReceiverType      /\w\+/ contained
+  if s:HighlightFunctionParameters()
+    syn match goSimpleParams      /(\%(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goParamName,goType nextgroup=goFunctionReturn skipwhite skipnl
+    syn match goFunctionReturn   /(\%(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goParamName,goType skipwhite skipnl
+    syn match goParamName        /\w\+\%(\s*,\s*\w\+\)*\ze\s\+\%(\w\|\.\|\*\|\[\)/ contained nextgroup=goParamType skipwhite skipnl
+    syn match goParamType        /\%([^,)]\|\_s\)\+,\?/ contained nextgroup=goParamName skipwhite skipnl
+                          \ contains=goVarArgs,goType,goSignedInts,goUnsignedInts,goFloats,goComplexes,goDeclType,goBlock
+    hi def link   goReceiverVar    goParamName
+    hi def link   goParamName      Identifier
+  endif
+  syn match goReceiver          /(\s*\w\+\%(\s\+\*\?\s*\w\+\)\?\s*)\ze\s*\w/ contained nextgroup=goFunction contains=goReceiverVar skipwhite skipnl
+else
+  syn keyword goDeclaration func
+endif
+hi def link     goFunction          Function
+
+" Function calls;
+if s:HighlightFunctionCalls()
+  syn match goFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
+endif
+hi def link     goFunctionCall      Type
+
+" Fields;
+if s:HighlightFields()
+  " 1. Match a sequence of word characters coming after a '.'
+  " 2. Require the following but dont match it: ( \@= see :h E59)
+  "    - The symbols: / - + * %   OR
+  "    - The symbols: [] {} <> )  OR
+  "    - The symbols: \n \r space OR
+  "    - The symbols: , : .
+  " 3. Have the start of highlight (hs) be the start of matched
+  "    pattern (s) offsetted one to the right (+1) (see :h E401)
+  syn match       goField   /\.\w\+\
+        \%(\%([\/\-\+*%]\)\|\
+        \%([\[\]{}<\>\)]\)\|\
+        \%([\!=\^|&]\)\|\
+        \%([\n\r\ ]\)\|\
+        \%([,\:.]\)\)\@=/hs=s+1
+endif
+hi def link    goField              Identifier
+
+" Structs & Interfaces;
+if s:HighlightTypes()
+  syn match goTypeConstructor      /\<\w\+{\@=/
+  syn match goTypeDecl             /\<type\>/ nextgroup=goTypeName skipwhite skipnl
+  syn match goTypeName             /\w\+/ contained nextgroup=goDeclType skipwhite skipnl
+  syn match goDeclType             /\<\%(interface\|struct\)\>/ skipwhite skipnl
+  hi def link     goReceiverType      Type
+else
+  syn keyword goDeclType           struct interface
+  syn keyword goDeclaration        type
+endif
+hi def link     goTypeConstructor   Type
+hi def link     goTypeName          Type
+hi def link     goTypeDecl          Keyword
+hi def link     goDeclType          Keyword
+
+" Variable Assignments
+if s:HighlightVariableAssignments()
+  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*([-^+|^\/%&]|\*|\<\<|\>\>|\&\^)?\=[^=])/
+  hi def link   goVarAssign         Special
+endif
+
+" Variable Declarations
+if s:HighlightVariableDeclarations()
+  syn match goVarDefs /\v\w+(,\s*\w+)*\ze(\s*:\=)/
+  hi def link   goVarDefs           Special
+endif
+
+" Build Constraints
+if s:HighlightBuildConstraints()
+  syn match   goBuildKeyword      display contained "+build"
+  " Highlight the known values of GOOS, GOARCH, and other +build options.
+  syn keyword goBuildDirectives   contained
+        \ android darwin dragonfly freebsd linux nacl netbsd openbsd plan9
+        \ solaris windows 386 amd64 amd64p32 arm armbe arm64 arm64be ppc64
+        \ ppc64le mips mipsle mips64 mips64le mips64p32 mips64p32le ppc
+        \ s390 s390x sparc sparc64 cgo ignore race
+
+  " Other words in the build directive are build tags not listed above, so
+  " avoid highlighting them as comments by using a matchgroup just for the
+  " start of the comment.
+  " The rs=s+2 option lets the \s*+build portion be part of the inner region
+  " instead of the matchgroup so it will be highlighted as a goBuildKeyword.
+  syn region  goBuildComment      matchgroup=goBuildCommentStart
+        \ start="//\s*+build\s"rs=s+2 end="$"
+        \ contains=goBuildKeyword,goBuildDirectives
+  hi def link goBuildCommentStart Comment
+  hi def link goBuildDirectives   Type
+  hi def link goBuildKeyword      PreProc
+endif
+
+if s:HighlightBuildConstraints() || s:FoldEnable('package_comment')
+  " One or more line comments that are followed immediately by a "package"
+  " declaration are treated like package documentation, so these must be
+  " matched as comments to avoid looking like working build constraints.
+  " The he, me, and re options let the "package" itself be highlighted by
+  " the usual rules.
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
+        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' contains=@goCommentGroup,@Spell'
+        \ . (s:FoldEnable('package_comment') ? ' fold' : '')
+  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
+        \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' contains=@goCommentGroup,@Spell'
+        \ . (s:FoldEnable('package_comment') ? ' fold' : '')
+  hi def link goPackageComment    Comment
+endif
+
+" :GoCoverage commands
+hi def link goCoverageNormalText Comment
 
 " Search backwards for a global declaration to start processing the syntax.
 "syn sync match goSync grouphere NONE /^\(const\|var\|type\|func\)\>/
@@ -203,6 +478,9 @@ hi def link     goSpaceError        Error
 " following as a more expensive/less precise workaround.
 syn sync minlines=500
 
-let b:current_syntax = 'go'
+let b:current_syntax = "go"
+
+let &cpo = s:keepcpo
+unlet s:keepcpo
 
 " vim: sw=2 sts=2 et

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	Bram Moolenaar (Bram@vim.org)
-" Last Change:	2020 Jul 28
+" Last Change:	2021 Jun 13
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -71,6 +71,7 @@ syn match helpSpecial		"\[line]"
 syn match helpSpecial		"\[count]"
 syn match helpSpecial		"\[offset]"
 syn match helpSpecial		"\[cmd]"
+syn match helpNormal		"vim9\[cmd]"
 syn match helpSpecial		"\[num]"
 syn match helpSpecial		"\[+num]"
 syn match helpSpecial		"\[-num]"

--- a/runtime/syntax/pascal.vim
+++ b/runtime/syntax/pascal.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainers:	Xavier Crégut <xavier.cregut@enseeiht.fr>
 "			Mario Eusebio <bio@dq.fct.unl.pt>
-" Last Change:		2021 Apr 23
+" Last Change:		2021 May 20
 
 " Contributors: Tim Chase <tchase@csc.com>,
 "		Stas Grabois <stsi@vtrails.com>,

--- a/runtime/syntax/redif.vim
+++ b/runtime/syntax/redif.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:          ReDIF
 " Maintainer:        Axel Castellane <axel.castellane@polytechnique.edu>
-" Last Change:       2013 April 17
+" Last Change:       2021 Jul 28
 " Original Author:   Axel Castellane
 " Source:            http://openlib.org/acmes/root/docu/redif_1.html
 " File Extension:    rdf

--- a/runtime/syntax/ruby.vim
+++ b/runtime/syntax/ruby.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2019 Jul 13
+" Last Change:		2021 Jun 06
 " ----------------------------------------------------------------------------
 "
 " Previous Maintainer:	Mirko Nasato
@@ -66,7 +66,7 @@ endfunction
 com! -nargs=* SynFold call s:run_syntax_fold(<q-args>)
 
 " Not-Top Cluster {{{1
-syn cluster rubyNotTop contains=@rubyCommentNotTop,@rubyStringNotTop,@rubyRegexpSpecial,@rubyDeclaration,@rubyExceptionHandler,@rubyClassOperator,rubyConditional,rubyModuleName,rubyClassName,rubySymbolDelimiter,rubyParentheses
+syn cluster rubyNotTop contains=@rubyCommentNotTop,@rubyStringNotTop,@rubyRegexpSpecial,@rubyDeclaration,@rubyExceptionHandler,@rubyClassOperator,rubyConditional,rubyModuleName,rubyClassName,rubySymbolDelimiter,rubyParentheses,@Spell
 
 " Whitespace Errors {{{1
 if exists("ruby_space_errors")
@@ -92,7 +92,7 @@ if exists("ruby_operators") || exists("ruby_pseudo_operators")
   syn match rubyBooleanOperator    "\%(\w\|[^\x00-\x7F]\)\@1<!!\|&&\|||"
   syn match rubyRangeOperator	   "\.\.\.\="
   syn match rubyAssignmentOperator "=>\@!\|-=\|/=\|\*\*=\|\*=\|&&=\|&=\|||=\||=\|%=\|+=\|>>=\|<<=\|\^="
-  syn match rubyAssignmentOperator "=>\@!" containedin=rubyBlockParameterList " TODO: this is inelegant
+  syn match rubyAssignmentOperator "=>\@!" contained containedin=rubyBlockParameterList " TODO: this is inelegant
   syn match rubyEqualityOperator   "===\|==\|!=\|!\~\|=\~"
 
   syn region rubyBracketOperator matchgroup=rubyOperator start="\%(\%(\w\|[^\x00-\x7F]\)[?!]\=\|[]})]\)\@2<=\[" end="]" contains=ALLBUT,@rubyNotTop
@@ -134,10 +134,10 @@ syn match rubyCurlyBraceEscape	  "\\[{}]"  contained display
 syn match rubyAngleBracketEscape  "\\[<>]"  contained display
 syn match rubySquareBracketEscape "\\[[\]]" contained display
 
-syn region rubyNestedParentheses    start="("  skip="\\\\\|\\)"  matchgroup=rubyString end=")"	transparent contained
-syn region rubyNestedCurlyBraces    start="{"  skip="\\\\\|\\}"  matchgroup=rubyString end="}"	transparent contained
-syn region rubyNestedAngleBrackets  start="<"  skip="\\\\\|\\>"  matchgroup=rubyString end=">"	transparent contained
-syn region rubyNestedSquareBrackets start="\[" skip="\\\\\|\\\]" matchgroup=rubyString end="\]"	transparent contained
+syn region rubyNestedParentheses    start="("  skip="\\\\\|\\)"  end=")"	transparent contained
+syn region rubyNestedCurlyBraces    start="{"  skip="\\\\\|\\}"  end="}"	transparent contained
+syn region rubyNestedAngleBrackets  start="<"  skip="\\\\\|\\>"  end=">"	transparent contained
+syn region rubyNestedSquareBrackets start="\[" skip="\\\\\|\\\]" end="\]"	transparent contained
 
 syn cluster rubySingleCharEscape contains=rubyBackslashEscape,rubyQuoteEscape,rubySpaceEscape,rubyParenthesisEscape,rubyCurlyBraceEscape,rubyAngleBracketEscape,rubySquareBracketEscape
 syn cluster rubyNestedBrackets	 contains=rubyNested.\+
@@ -193,7 +193,7 @@ SynFold ':' syn region rubySymbol matchgroup=rubySymbolDelimiter start="[]})\"':
 
 syn match rubyCapitalizedMethod "\%(\%(^\|[^.]\)\.\s*\)\@<!\<\u\%(\w\|[^\x00-\x7F]\)*\>\%(\s*(\)\@="
 
-syn region rubyParentheses	  start="("				 end=")" contains=ALLBUT,@rubyNotTop containedin=rubyBlockParameterList
+syn region rubyParentheses	  start="("				 end=")" contains=ALLBUT,@rubyNotTop contained containedin=rubyBlockParameterList
 syn region rubyBlockParameterList start="\%(\%(\<do\>\|{\)\_s*\)\@32<=|" end="|" contains=ALLBUT,@rubyNotTop,@rubyProperOperator
 
 if exists('ruby_global_variable_error')
@@ -332,7 +332,7 @@ SynFold '<<' syn region rubyString start=+\%(\%(class\|::\|\.\@1<!\.\)\_s*\|\%([
 syn match rubyAliasDeclaration	"[^[:space:];#.()]\+" contained contains=rubySymbol,@rubyGlobalVariable nextgroup=rubyAliasDeclaration2 skipwhite
 syn match rubyAliasDeclaration2 "[^[:space:];#.()]\+" contained contains=rubySymbol,@rubyGlobalVariable
 syn match rubyMethodDeclaration "[^[:space:];#(]\+"   contained contains=rubyConstant,rubyBoolean,rubyPseudoVariable,rubyInstanceVariable,rubyClassVariable,rubyGlobalVariable
-syn match rubyClassDeclaration	"[^[:space:];#<]\+"   contained contains=rubyClassName,rubyScopeOperator nextgroup=rubySuperClassOperator skipwhite skipnl
+syn match rubyClassDeclaration	"[^[:space:];#<]\+"   contained contains=rubyClassName,rubyScopeOperator nextgroup=rubySuperClassOperator skipwhite
 syn match rubyModuleDeclaration "[^[:space:];#<]\+"   contained contains=rubyModuleName,rubyScopeOperator
 
 syn match rubyMethodName "\<\%([_[:alpha:]]\|[^\x00-\x7F]\)\%([_[:alnum:]]\|[^\x00-\x7F]\)*[?!=]\=\%([[:alnum:]_.:?!=]\|[^\x00-\x7F]\)\@!"			      contained containedin=rubyMethodDeclaration
@@ -462,7 +462,7 @@ endif
 syn match rubyDefinedOperator "\%#=1\<defined?" display
 
 " 1.9-style Hash Keys and Keyword Parameters {{{1
-syn match rubySymbol "\%([{(|,]\_s*\)\@<=\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[?!]\=::\@!"he=e-1
+syn match rubySymbol "\%(\w\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[?!]\=::\@!"he=e-1 contained containedin=rubyBlockParameterList,rubyCurlyBlock
 syn match rubySymbol "[]})\"':]\@1<!\<\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],;]\@="he=e-1
 syn match rubySymbol "[[:space:],{(]\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],;]\@="hs=s+1,he=e-1
 

--- a/runtime/syntax/scala.vim
+++ b/runtime/syntax/scala.vim
@@ -3,7 +3,8 @@
 " Maintainer:           Derek Wyatt
 " URL:                  https://github.com/derekwyatt/vim-scala
 " License:              Same as Vim
-" Last Change:          20 May 2016
+" Last Change:          2021 Aug 11
+"                       by Jesse Atkinson, PR #8746
 " ----------------------------------------------------------------------------
 
 if !exists('main_syntax')
@@ -66,7 +67,7 @@ syn match scalaChar /'\\u[A-Fa-f0-9]\{4}'/ contains=scalaUnicodeChar
 syn match scalaEscapedChar /\\[\\"'ntbrf]/
 syn match scalaUnicodeChar /\\u[A-Fa-f0-9]\{4}/
 hi link scalaChar Character
-hi link scalaEscapedChar Function
+hi link scalaEscapedChar Special
 hi link scalaUnicodeChar Special
 
 syn match scalaOperator "||"

--- a/runtime/syntax/scheme.vim
+++ b/runtime/syntax/scheme.vim
@@ -1,10 +1,11 @@
 " Vim syntax file
 " Language: Scheme (R7RS)
-" Last Change: 2018-01-06
+" Last Change: 2021-01-03
 " Author: Evan Hanson <evhan@foldling.org>
 " Maintainer: Evan Hanson <evhan@foldling.org>
 " Previous Author: Dirk van Deun <dirk@igwe.vub.ac.be>
 " Previous Maintainer: Sergey Khorev <sergey.khorev@gmail.com>
+" Repository: https://git.foldling.org/vim-scheme.git
 " URL: https://foldling.org/vim/syntax/scheme.vim
 
 if exists('b:current_syntax')
@@ -13,6 +14,8 @@ endif
 
 let s:cpo = &cpo
 set cpo&vim
+
+syn spell notoplevel
 
 syn match schemeParentheses "[^ '`\t\n()\[\]";]\+"
 syn match schemeParentheses "[)\]]"
@@ -35,7 +38,7 @@ syn region schemeUnquote matchgroup=schemeParentheses start=/,@(/ end=/)/ contai
 syn region schemeQuoteForm matchgroup=schemeData start=/(/ end=/)/ contained contains=ALLBUT,schemeQuasiquote,schemeQuasiquoteForm,schemeUnquote,schemeForm,schemeDatumCommentForm,schemeImport,@schemeImportCluster,@schemeSyntaxCluster
 syn region schemeQuasiquoteForm matchgroup=schemeData start=/(/ end=/)/ contained contains=ALLBUT,schemeQuote,schemeForm,schemeDatumCommentForm,schemeImport,@schemeImportCluster,@schemeSyntaxCluster
 
-syn region schemeString start=/\(\\\)\@<!"/ skip=/\\[\\"]/ end=/"/
+syn region schemeString start=/\(\\\)\@<!"/ skip=/\\[\\"]/ end=/"/ contains=@Spell
 syn region schemeSymbol start=/\(\\\)\@<!|/ skip=/\\[\\|]/ end=/|/
 
 syn match schemeNumber /\(#[dbeio]\)*[+\-]*\([0-9]\+\|inf.0\|nan.0\)\(\/\|\.\)\?[0-9+\-@\ilns]*\>/
@@ -47,9 +50,9 @@ syn match schemeBoolean /#f\(alse\)\?/
 syn match schemeCharacter /#\\.[^ `'\t\n\[\]()]*/
 syn match schemeCharacter /#\\x[0-9a-fA-F]\+/
 
-syn match schemeComment /;.*$/
+syn match schemeComment /;.*$/ contains=@Spell
 
-syn region schemeMultilineComment start=/#|/ end=/|#/ contains=schemeMultilineComment
+syn region schemeMultilineComment start=/#|/ end=/|#/ contains=schemeMultilineComment,@Spell
 
 syn region schemeForm matchgroup=schemeParentheses start="(" end=")" contains=ALLBUT,schemeUnquote,schemeDatumCommentForm,@schemeImportCluster
 syn region schemeForm matchgroup=schemeParentheses start="\[" end="\]" contains=ALLBUT,schemeUnquote,schemeDatumCommentForm,@schemeImportCluster
@@ -63,7 +66,7 @@ else
   syn region schemeImport matchgroup=schemeImport start="\(([ \t\n]*\)\@<=\(import\)\>" end=")"me=e-1 contained contains=schemeImportForm,schemeIdentifier,schemeComment,schemeDatumComment
 endif
 
-syn match   schemeImportKeyword "\(([ \t\n]*\)\@<=\(except\|only\|prefix\|rename\|srfi\)\>"
+syn match   schemeImportKeyword "\(([ \t\n]*\)\@<=\(except\|only\|prefix\|rename\)\>"
 syn region  schemeImportForm matchgroup=schemeParentheses start="(" end=")" contained contains=schemeIdentifier,schemeComment,schemeDatumComment,@schemeImportCluster
 syn cluster schemeImportCluster contains=schemeImportForm,schemeImportKeyword
 

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Nov 24, 2020
-" Version:		196
+" Last Change:		Feb 18, 2021
+" Version:		198
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from Eric Brunet (eric.brunet@ens.fr) and heredoc fixes from Felipe Contreras
@@ -13,33 +13,35 @@ if exists("b:current_syntax")
   finish
 endif
 
-" trying to answer the question: which shell is /bin/sh, really?
-" If the user has not specified any of g:is_kornshell, g:is_bash, g:is_posix, g:is_sh, then guess.
-if getline(1) =~ '\<ksh$'
+" If the shell script itself specifies which shell to use, use it
+if getline(1) =~ '\<ksh\>'
  let b:is_kornshell = 1
-elseif getline(1) =~ '\<bash$'
+elseif getline(1) =~ '\<bash\>'
  let b:is_bash      = 1
-elseif getline(1) =~ '\<dash$'
+elseif getline(1) =~ '\<dash\>'
  let b:is_dash      = 1
 elseif !exists("g:is_kornshell") && !exists("g:is_bash") && !exists("g:is_posix") && !exists("g:is_sh") && !exists("g:is_dash")
+ " user did not specify which shell to use, and 
+ " the script itself does not specify which shell to use. FYI: /bin/sh is ambiguous.
+ " Assuming /bin/sh is executable, and if its a link, find out what it links to.
  let s:shell = ""
  if executable("/bin/sh")
   let s:shell = resolve("/bin/sh")
  elseif executable("/usr/bin/sh")
   let s:shell = resolve("/usr/bin/sh")
  endif
- if     s:shell =~ 'ksh$'
+ if     s:shell =~ '\<ksh\>'
   let b:is_kornshell= 1
- elseif s:shell =~ 'bash$'
+ elseif s:shell =~ '\<bash\>'
   let b:is_bash = 1
- elseif s:shell =~ 'dash$'
+ elseif s:shell =~ '\<dash\>'
   let b:is_dash = 1
  endif
  unlet s:shell
 endif
 
 " handling /bin/sh with is_kornshell/is_sh {{{1
-" b:is_sh is set when "#! /bin/sh" is found;
+" b:is_sh will be set when "#! /bin/sh" is found;
 " However, it often is just a masquerade by bash (typically Linux)
 " or kornshell (typically workstations with Posix "sh").
 " So, when the user sets "g:is_bash", "g:is_kornshell",
@@ -98,12 +100,14 @@ if g:sh_fold_enabled && &fdm == "manual"
  setl fdm=syntax
 endif
 
-" set up the syntax-highlighting iskeyword
+" set up the syntax-highlighting for iskeyword
 if (v:version == 704 && has("patch-7.4.1142")) || v:version > 704
- if exists("b:is_bash")
-  exe "syn iskeyword ".&iskeyword.",-,:"
- else
-  exe "syn iskeyword ".&iskeyword.",-"
+ if !exists("g:sh_syntax_isk") || (exists("g:sh_syntax_isk") && g:sh_syntax_isk)
+  if exists("b:is_bash")
+   exe "syn iskeyword ".&iskeyword.",-,:"
+  else
+   exe "syn iskeyword ".&iskeyword.",-"
+  endif
  endif
 endif
 
@@ -374,12 +378,11 @@ elseif !exists("g:sh_no_error")
  syn region  shExDoubleQuote	matchGroup=Error start=+\$"+ skip=+\\\\\|\\.+ end=+"+	contains=shStringSpecial
 endif
 syn region  shSingleQuote	matchgroup=shQuote start=+'+ end=+'+		contains=@Spell	nextgroup=shSpecialStart,shSpecialSQ
-syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\.+ end=+"+	contains=@shDblQuoteList,shStringSpecial,@Spell	nextgroup=shSpecialStart
-syn region  shDoubleQuote	matchgroup=shQuote start=+"+ matchgroup=shSpecial skip=+\\"+ matchgroup=shQuote end=+"+		contained	contains=@shDblQuoteList,shStringSpecial,@Spell	nextgroup=shSpecialStart
+syn region  shDoubleQuote	matchgroup=shQuote start=+\%(\%(\\\\\)*\\\)\@<!"+ skip=+\\.+ end=+"+			contains=@shDblQuoteList,shStringSpecial,@Spell	nextgroup=shSpecialStart
 syn match   shStringSpecial	"[^[:print:] \t]"			contained
-syn match   shStringSpecial	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"			nextgroup=shComment
-syn match   shSpecialSQ	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"		contained	nextgroup=shBkslshSnglQuote,@shNoZSList
-syn match   shSpecialDQ	"[^\\]\zs\%(\\\\\)*\\[\\"'`$()#]"		contained	nextgroup=shBkslshDblQuote,@shNoZSList
+syn match   shStringSpecial	"[^\\]\zs\%(\\\\\)*\(\\[\\"'`$()#]\)\+"			nextgroup=shComment
+syn match   shSpecialSQ	"[^\\]\zs\%(\\\\\)*\(\\[\\"'`$()#]\)\+"		contained	nextgroup=shBkslshSnglQuote,@shNoZSList
+syn match   shSpecialDQ	"[^\\]\zs\%(\\\\\)*\(\\[\\"'`$()#]\)\+"		contained	nextgroup=shBkslshDblQuote,@shNoZSList
 syn match   shSpecialStart	"\%(\\\\\)*\\[\\"'`$()#]"			contained	nextgroup=shBkslshSnglQuote,shBkslshDblQuote,@shNoZSList
 syn match   shSpecial	"^\%(\\\\\)*\\[\\"'`$()#]"
 syn match   shSpecialNoZS	contained	"\%(\\\\\)*\\[\\"'`$()#]"
@@ -402,6 +405,7 @@ syn match	shQuickComment	contained	"#.*$"
 syn match	shBQComment	contained	"#.\{-}\ze`"	contains=@shCommentGroup
 
 " Here Documents: {{{1
+"  (modified by Felipe Contreras)
 " =========================================
 ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc01 start="<<\s*\z([^ \t|>]\+\)"		matchgroup=shHereDoc01 end="^\z1\s*$"	contains=@shDblQuoteList
 ShFoldHereDoc syn region shHereDoc matchgroup=shHereDoc02 start="<<-\s*\z([^ \t|>]\+\)"		matchgroup=shHereDoc02 end="^\s*\z1\s*$"	contains=@shDblQuoteList

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -12,7 +12,7 @@
 if exists("b:current_syntax")
   finish
 endif
-let s:keepcpo= &cpo
+let s:keepcpo = &cpo
 set cpo&vim
 
 " vimTodo: contains common special-notices for comments {{{2
@@ -200,7 +200,7 @@ syn keyword vimAugroupKey contained	aug[roup]
 
 " Operators: {{{2
 " =========
-syn cluster	vimOperGroup	contains=vimEnvvar,vimFunc,vimFuncVar,vimOper,vimOperParen,vimNumber,vimString,vimRegister,vimContinue,vim9Comment
+syn cluster	vimOperGroup	contains=vimEnvvar,vimFunc,vimFuncVar,vimOper,vimOperParen,vimNumber,vimString,vimType,vimRegister,vimContinue,vim9Comment
 syn match	vimOper	"\%#=1\(==\|!=\|>=\|<=\|=\~\|!\~\|>\|<\|=\)[?#]\{0,2}"	skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"\(\<is\|\<isnot\)[?#]\{0,2}\>"			skipwhite nextgroup=vimString,vimSpecFile
 syn match	vimOper	"||\|&&\|[-+.!]"				skipwhite nextgroup=vimString,vimSpecFile
@@ -981,6 +981,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimSyntax	vimCommand
  hi def link vimSynType	vimSpecial
  hi def link vimTodo	Todo
+ hi def link vimType	Type
  hi def link vimUnmap	vimMap
  hi def link vimUserAttrbCmpltFunc	Special
  hi def link vimUserAttrbCmplt	vimSpecial

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -2,7 +2,7 @@
 #
 # Do ":help uganda"  in Vim to read copying and usage conditions.
 # Do ":help credits" in Vim to see a list of people who contributed.
-# Copyright (C) 2017
+# Copyright (C) 2021
 # This file is distributed under the same license as the Vim package.
 # FIRST AUTHOR Ivan Pešić <ivan.pesic@gmail.com>, 2017.
 #
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Vim(Serbian)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-14 01:49+0400\n"
-"PO-Revision-Date: 2021-02-14 01:54+0400\n"
+"POT-Creation-Date: 2021-06-13 13:16+0400\n"
+"PO-Revision-Date: 2021-06-13 13:50+0400\n"
 "Last-Translator: Ivan Pešić <ivan.pesic@gmail.com>\n"
 "Language-Team: Serbian\n"
 "Language: sr\n"
@@ -96,6 +96,9 @@ msgstr "Извршавање %s"
 #, c-format
 msgid "autocommand %s"
 msgstr "аутокоманда %s"
+
+msgid "E972: Blob value does not have the right number of bytes"
+msgstr "E972: Блоб вредност нема одговарајући број бајтова"
 
 msgid "E831: bf_key_init() called with empty password"
 msgstr "E831: bf_key_init() је позвана са празном лозинком"
@@ -6422,6 +6425,13 @@ msgstr "E853: Име аргумента је дуплирано: %s"
 msgid "E989: Non-default argument follows default argument"
 msgstr "E989: Неподразумевани аргумент следи иза подразумеваног аргумента"
 
+msgid "E126: Missing :endfunction"
+msgstr "E126: Недостаје :endfunction"
+
+#, c-format
+msgid "W22: Text found after :endfunction: %s"
+msgstr "W22: Пронађен текст након :endfunction: %s"
+
 #, c-format
 msgid "E451: Expected }: %s"
 msgstr "E451: Очекује се }: %s"
@@ -6496,17 +6506,6 @@ msgstr "E862: Овде не може да се користи g:"
 #, c-format
 msgid "E932: Closure function should not be at top level: %s"
 msgstr "E932: Затварајућа функција не би требало да буде на највишем нивоу: %s"
-
-msgid "E126: Missing :endfunction"
-msgstr "E126: Недостаје :endfunction"
-
-#, c-format
-msgid "W1001: Text found after :enddef: %s"
-msgstr "W1001: Пронађен је текст након :enddef: %s"
-
-#, c-format
-msgid "W22: Text found after :endfunction: %s"
-msgstr "W22: Пронађен текст након :endfunction: %s"
 
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
@@ -6983,8 +6982,8 @@ msgid "E475: Invalid value for argument %s: %s"
 msgstr "E475: Неважећа вредност за аргумент %s: %s"
 
 #, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Неважећи израз: %s"
+msgid "E15: Invalid expression: \"%s\""
+msgstr "E15: Неважећи израз: „%s”"
 
 msgid "E16: Invalid range"
 msgstr "E16: Неважећи опсег"

--- a/src/nvim/po/tr.po
+++ b/src/nvim/po/tr.po
@@ -1,16 +1,16 @@
 # Turkish translations for Vim
 # Vim Türkçe çevirileri
-# Copyright (C) 2020 Emir SARI <bitigchi@me.com>
+# Copyright (C) 2021 Emir SARI <emir_sari@msn.com>
 # This file is distributed under the same license as the Vim package.
-# Emir SARI <bitigchi@me.com>, 2019-2020
+# Emir SARI <emir_sari@msn.com>, 2019-2021
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Vim Turkish Localization Project\n"
-"Report-Msgid-Bugs-To: Emir SARI <bitigchi@me.com>\n"
-"POT-Creation-Date: 2020-11-29 00:20+0300\n"
-"PO-Revision-Date: 2020-11-29 20:00+0300\n"
-"Last-Translator: Emir SARI <bitigchi@me.com>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-16 17:56+0300\n"
+"PO-Revision-Date: 2021-07-16 20:00+0300\n"
+"Last-Translator: Emir SARI <emir_sari@msn.com>\n"
 "Language-Team: Turkish <https://github.com/bitigchi/vim>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
@@ -28,7 +28,7 @@ msgid "E165: Cannot go beyond last file"
 msgstr "E165: Son dosyadan öteye gidilemez"
 
 msgid "E610: No argument to delete"
-msgstr "E610: Silinecek bir değişken yok"
+msgstr "E610: Silinecek bir argüman yok"
 
 msgid "E249: window layout changed unexpectedly"
 msgstr "E249: Pencere yerleşimi beklenmedik bir biçimde değişti"
@@ -94,6 +94,9 @@ msgstr "%s çalıştırılıyor"
 msgid "autocommand %s"
 msgstr "%s otokomutu"
 
+msgid "E972: Blob value does not have the right number of bytes"
+msgstr "E972: İkili geniş nesne değeri doğru bayt sayısına sahip değil"
+
 msgid "E831: bf_key_init() called with empty password"
 msgstr "E831: bf_key_init() boş bir şifre ile çağrıldı"
 
@@ -131,6 +134,27 @@ msgstr "E931: Arabellek kaydedilemedi"
 msgid "E937: Attempt to delete a buffer that is in use: %s"
 msgstr "E937: Kullanımda olan bir arabellek silinmeye çalışılıyor: %s"
 
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Son arabellek bellekten kaldırılamıyor"
+
+msgid "E84: No modified buffer found"
+msgstr "E84: Değiştirilmiş bir arabellek bulunamadı"
+
+msgid "E85: There is no listed buffer"
+msgstr "E85: Listelenmiş bir arabellek yok"
+
+msgid "E87: Cannot go beyond last buffer"
+msgstr "E87: Son arabellekten öteye gidilemez"
+
+msgid "E88: Cannot go before first buffer"
+msgstr "E88: İlk arabellekten öncesine gidilemez"
+
+#, c-format
+msgid "E89: No write since last change for buffer %d (add ! to override)"
+msgstr ""
+"E89: %d numaralı arabellek son değişiklikten sonra yazılmadı (geçersiz "
+"kılmak için ! ekleyin)"
+
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Hiçbir arabellek bellekten kaldırılmadı"
 
@@ -157,27 +181,6 @@ msgid "%d buffer wiped out"
 msgid_plural "%d buffers wiped out"
 msgstr[0] "%d arabellek yok edildi"
 msgstr[1] "%d arabellek yok edildi"
-
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Son arabellek bellekten kaldırılamıyor"
-
-msgid "E84: No modified buffer found"
-msgstr "E84: Değiştirilmiş bir arabellek bulunamadı"
-
-msgid "E85: There is no listed buffer"
-msgstr "E85: Listelenmiş bir arabellek yok"
-
-msgid "E87: Cannot go beyond last buffer"
-msgstr "E87: Son arabellekten öteye gidilemez"
-
-msgid "E88: Cannot go before first buffer"
-msgstr "E88: İlk arabellekten öncesine gidilemez"
-
-#, c-format
-msgid "E89: No write since last change for buffer %d (add ! to override)"
-msgstr ""
-"E89: %d numaralı arabellek son değişiklikten sonra yazılmadı (geçersiz "
-"kılmak için ! ekleyin)"
 
 msgid "E948: Job still running (add ! to end the job)"
 msgstr "E948: İş hâlâ sürüyor (bitirmek için ! ekleyin)"
@@ -424,13 +427,13 @@ msgid "E901: gethostbyname() in channel_open()"
 msgstr "E901: channel_open() içinde gethostbyname()"
 
 msgid "E903: received command with non-string argument"
-msgstr "E903: Dizi olmayan değişken içeren komut alındı"
+msgstr "E903: Dizi olmayan argüman içeren komut alındı"
 
 msgid "E904: last argument for expr/call must be a number"
-msgstr "E904: İfadenin/çağrının son değişkeni bir sayı olmalıdır"
+msgstr "E904: İfadenin/çağrının son argüman bir sayı olmalıdır"
 
 msgid "E904: third argument for call must be a list"
-msgstr "E904: Çağrının üçüncü değişkeni bir liste olmalıdır"
+msgstr "E904: Çağrının üçüncü argümanı bir liste olmalıdır"
 
 #, c-format
 msgid "E905: received unknown command: %s"
@@ -449,7 +452,7 @@ msgstr "E631: %s(): Yazma başarısız"
 
 #, c-format
 msgid "E917: Cannot use a callback with %s()"
-msgstr "E917: %s() ile geri çağırma kullanılamaz"
+msgstr "E917: %s() ile geri çağırma kullanılamıyor"
 
 msgid "E912: cannot use ch_evalexpr()/ch_sendexpr() with a raw or nl channel"
 msgstr "E912: ch_evalexpr()/ch_sendexpr() raw/nl kanalları ile kullanılamaz"
@@ -511,6 +514,11 @@ msgid "Warning: Using a weak encryption method; see :help 'cm'"
 msgstr ""
 "Uyarı: Zayıf bir şifreleme yöntemi kullanılıyor; bilgi için: :help 'cm'"
 
+msgid ""
+"Note: Encryption of swapfile not supported, disabling swap- and undofile"
+msgstr "Takas dosyası şifrelemesi desteklenmiyor, takas ve geri al dosyası "
+"devre dışı bırakılıyor"
+
 msgid "Enter encryption key: "
 msgstr "Şifreleme anahtarı girin: "
 
@@ -570,7 +578,7 @@ msgid "%3d  expr %s"
 msgstr "%3d  ifade %s"
 
 msgid "extend() argument"
-msgstr "extend() değişkeni"
+msgstr "extend() argümanı"
 
 #, c-format
 msgid "E737: Key already exists: %s"
@@ -728,9 +736,6 @@ msgstr "E708: [:] en son gelmelidir"
 msgid "E709: [:] requires a List or Blob value"
 msgstr "E709: [:] bir liste veya ikili geniş nesne değeri gerektirir"
 
-msgid "E972: Blob value does not have the right number of bytes"
-msgstr "E972: İkili geniş nesne değeri doğru bayt sayısına sahip değil"
-
 msgid "E996: Cannot lock a range"
 msgstr "E996: Erim kilitlenemiyor"
 
@@ -741,7 +746,7 @@ msgid "E260: Missing name after ->"
 msgstr "E260: -> sonrası ad eksik"
 
 msgid "E695: Cannot index a Funcref"
-msgstr "E695: Bir Funcref dizinlenemez"
+msgstr "E695: Bir Funcref dizinlenemiyor"
 
 msgid "Not enough memory to set references, garbage collection aborted!"
 msgstr "Referansları ayarlamak için yetersiz bellek, atık toplama durduruldu"
@@ -758,9 +763,6 @@ msgid ""
 msgstr ""
 "\n"
 "\tEn son şuradan ayarlandı: "
-
-msgid "E808: Number or Float required"
-msgstr "E808: Sayı veya kayan noktalı değer gerekiyor"
 
 #, c-format
 msgid "E158: Invalid buffer name: %s"
@@ -780,7 +782,7 @@ msgid "E922: expected a dict"
 msgstr "E922: Bir sözlük bekleniyordu"
 
 msgid "E923: Second argument of function() must be a list or a dict"
-msgstr "E923: function() ikinci değişkeni bir liste veya sözlük olmalıdır"
+msgstr "E923: function() ikinci argümanı bir liste veya sözlük olmalıdır"
 
 msgid ""
 "&OK\n"
@@ -882,7 +884,7 @@ msgid "E742: Cannot change value of %s"
 msgstr "E742: %s değeri değiştirilemiyor"
 
 msgid "E921: Invalid callback argument"
-msgstr "E921: Geçersiz geri çağırma değişkeni"
+msgstr "E921: Geçersiz geri çağırma argümanı"
 
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Oct %03o, Digr %s"
@@ -926,6 +928,10 @@ msgstr "E135: *Süzgeç* otokomutları şu anki arabelleği değiştirmemelidir"
 
 msgid "[No write since last change]\n"
 msgstr "[Son değişiklikten sonra yazılmadı]\n"
+
+#, c-format
+msgid "E503: \"%s\" is not a file or writable device"
+msgstr "E503: \"%s\", bir dosya veya yazılabilir aygıt değil"
 
 msgid "Save As"
 msgstr "Farklı Kaydet"
@@ -985,7 +991,7 @@ msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: yeni %s arabelleğini otokomutlar beklenmedik bir biçimde sildi"
 
 msgid "E144: non-numeric argument to :z"
-msgstr "E144: :z için sayısal olmayan değişken"
+msgstr "E144: :z için sayısal olmayan argüman"
 
 msgid "E145: Shell commands and some functionality not allowed in rvim"
 msgstr "E145: rvim içinde kabuk komutları ve bazı işlevselliğe izin verilmez"
@@ -1091,9 +1097,6 @@ msgstr "Kaynak alınan dosyanın sonu"
 msgid "End of function"
 msgstr "İşlevin sonu"
 
-msgid "E464: Ambiguous use of user-defined command"
-msgstr "E464: Kullanıcı tanımlı komutun belirsiz kullanımı"
-
 msgid "E492: Not an editor command"
 msgstr "E492: Bir düzenleyici komutu değil"
 
@@ -1178,7 +1181,7 @@ msgid "E187: Unknown"
 msgstr "E187: Bilinmeyen"
 
 msgid "E465: :winsize requires two number arguments"
-msgstr "E465: :winsize iki adet sayı değişken gerektirir"
+msgstr "E465: :winsize iki adet sayı argüman gerektirir"
 
 #, c-format
 msgid "Window position: X %d, Y %d"
@@ -1188,7 +1191,7 @@ msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Pencere konumunu alma özelliği bu platformda mevcut değil"
 
 msgid "E466: :winpos requires two number arguments"
-msgstr "E466: :winpos iki adet sayı değişken gerektirir"
+msgstr "E466: :winpos iki adet sayı argüman gerektirir"
 
 msgid "E930: Cannot use :redir inside execute()"
 msgstr "E930: :redir, execute() içinde kullanılamaz"
@@ -1339,6 +1342,9 @@ msgstr "E788: Şu anda başka bir arabellek düzenlenemez"
 
 msgid "E811: Not allowed to change buffer information now"
 msgstr "E811: Şu anda arabellek bilgisi değiştirilemez"
+
+msgid "[Command Line]"
+msgstr "[Komut Satırı]"
 
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Etkin pencere veya arabellek silinmiş"
@@ -1530,7 +1536,7 @@ msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Çok fazla sembolik bağlantı (çevrim?)"
 
 msgid "writefile() first argument must be a List or a Blob"
-msgstr "writefile() ilk değişkeni bir liste veya ikili geniş nesne olmalıdır"
+msgstr "writefile() ilk argümanı bir liste veya ikili geniş nesne olmalıdır"
 
 msgid "Select Directory dialog"
 msgstr "Dizin Seç iletişim kutusu"
@@ -1580,6 +1586,9 @@ msgstr "E446: İmleç altında bir dosya adı yok"
 #, c-format
 msgid "E447: Can't find file \"%s\" in path"
 msgstr "E447: \"%s\" dosyası yol içinde bulunamadı"
+
+msgid "E808: Number or Float required"
+msgstr "E808: Sayı veya kayan noktalı değer gerekiyor"
 
 msgid "E490: No fold found"
 msgstr "E490: Kıvırma bulunamadı"
@@ -1805,7 +1814,7 @@ msgstr "E671: Pencere başlığı \"%s\" bulunamıyor"
 
 #, c-format
 msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-msgstr "E243: \"-%s\" değişkeni desteklenmiyor; OLE sürümünü kullanın."
+msgstr "E243: \"-%s\" argümanı desteklenmiyor; OLE sürümünü kullanın."
 
 msgid "E988: GUI cannot be used. Cannot execute gvim.exe."
 msgstr "E988: Grafik arabirim kullanılamaz. gvim.exe çalıştırılamadı."
@@ -2042,11 +2051,11 @@ msgstr "E411: Vurgulama grubu bulunamadı: %s"
 
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
-msgstr "E412: Yetersiz sayıda değişken: \":highlight link %s\""
+msgstr "E412: Yetersiz sayıda argüman: \":highlight link %s\""
 
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
-msgstr "E413: Çok fazla değişken: \":highlight link %s\""
+msgstr "E413: Çok fazla argüman: \":highlight link %s\""
 
 msgid "E414: group has settings, highlight link ignored"
 msgstr "E414: Grup ayarları mevcut, vurgulama bağlantısı yok sayıldı"
@@ -2061,7 +2070,7 @@ msgstr "E416: Eksik eşittir imi: %s"
 
 #, c-format
 msgid "E417: missing argument: %s"
-msgstr "E417: Eksik değişkenler: %s"
+msgstr "E417: Argüman eksik: %s"
 
 #, c-format
 msgid "E418: Illegal value: %s"
@@ -2086,7 +2095,7 @@ msgstr "E422: Uçbirim kodu çok uzun: %s"
 
 #, c-format
 msgid "E423: Illegal argument: %s"
-msgstr "E423: İzin verilmeyen değişken: %s"
+msgstr "E423: İzin verilmeyen argüman: %s"
 
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Çok fazla değişik vurgulama kuralları kullanılıyor"
@@ -2295,7 +2304,7 @@ msgid "unknown option"
 msgstr "bilinmeyen seçenek"
 
 msgid "window index is out of range"
-msgstr "pencere dizini erimin dışında"
+msgstr "pencere sırası erimin dışında"
 
 msgid "couldn't open buffer"
 msgstr "arabellek açılamadı"
@@ -2513,9 +2522,6 @@ msgstr " Dahili anahtar sözcük tamamlaması (^N^P)"
 msgid "Hit end of paragraph"
 msgstr "Paragrafın sonuna varıldı"
 
-msgid "E839: Completion function changed window"
-msgstr "E839: Tamamlama işlevi pencereyi değiştirdi"
-
 msgid "E840: Completion function deleted text"
 msgstr "E840: Tamamlama işlevi metni sildi"
 
@@ -2594,23 +2600,23 @@ msgstr "E938: JSON'da yinelenmiş anahtar: \"%s\""
 
 #, c-format
 msgid "E899: Argument of %s must be a List or Blob"
-msgstr "E899: %s değişkeni bir liste veya ikili geniş nesne olmalıdır"
+msgstr "E899: %s argümanı bir liste veya ikili geniş nesne olmalıdır"
 
 msgid "E900: maxdepth must be non-negative number"
 msgstr "E900: maxdepth negatif olmayan bir sayı olmalı"
 
 msgid "flatten() argument"
-msgstr "flatten() değişkeni"
+msgstr "flatten() argümanı"
 
 #, c-format
 msgid "E696: Missing comma in List: %s"
 msgstr "E696: Listede virgül eksik: %s"
 
 msgid "sort() argument"
-msgstr "sort() değişkeni"
+msgstr "sort() argümanı"
 
 msgid "uniq() argument"
-msgstr "uniq() değişkeni"
+msgstr "uniq() argümanı"
 
 msgid "E702: Sort compare function failed"
 msgstr "E702: Sıralayıp karşılaştırma işlevi başarısız oldu"
@@ -2619,25 +2625,28 @@ msgid "E882: Uniq compare function failed"
 msgstr "E882: Benzersizlik karşılaştırma işlevi başarısız oldu"
 
 msgid "map() argument"
-msgstr "map() değişkeni"
+msgstr "map() argümanı"
 
 msgid "mapnew() argument"
-msgstr "mapnew() değişkeni"
+msgstr "mapnew() argümanı"
 
 msgid "filter() argument"
-msgstr "filter() değişkeni"
+msgstr "filter() argümanı"
 
 msgid "add() argument"
-msgstr "add() değişkeni"
+msgstr "add() argümanı"
+
+msgid "extendnew() argument"
+msgstr "extendnew() argümanı"
 
 msgid "insert() argument"
-msgstr "insert() değişkeni"
+msgstr "insert() argümanı"
 
 msgid "remove() argument"
-msgstr "remove() değişkeni"
+msgstr "remove() argümanı"
 
 msgid "reverse() argument"
-msgstr "reverse() değişkeni"
+msgstr "reverse() argümanı"
 
 #, c-format
 msgid "Current %slanguage: \"%s\""
@@ -2648,22 +2657,22 @@ msgid "E197: Cannot set language to \"%s\""
 msgstr "E197: \"%s\" diline ayarlanamıyor"
 
 msgid "Unknown option argument"
-msgstr "Bilinmeyen seçenek değişkeni"
+msgstr "Bilinmeyen seçenek argümanı"
 
 msgid "Too many edit arguments"
-msgstr "Çok fazla düzenleme değişkeni"
+msgstr "Çok fazla düzenleme argümanı"
 
 msgid "Argument missing after"
-msgstr "Şundan sonra değişken eksik:"
+msgstr "Şundan sonra argüman eksik:"
 
 msgid "Garbage after option argument"
-msgstr "Seçenek değişkeninden sonra anlamsız veri"
+msgstr "Seçenek argümanından sonra anlamsız veri"
 
 msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
-msgstr "Çok fazla \"+komut\", \"-c komut\" veya \"--cmd komut\" değişkeni"
+msgstr "Çok fazla \"+komut\", \"-c komut\" veya \"--cmd komut\" argümanı"
 
 msgid "Invalid argument for"
-msgstr "Şunun için geçersiz değişken:"
+msgstr "Şunun için geçersiz argüman:"
 
 #, c-format
 msgid "%d files to edit\n"
@@ -2735,7 +2744,7 @@ msgstr ""
 "Kullanım:"
 
 msgid " vim [arguments] "
-msgstr " vim [değişkenler] "
+msgstr " vim [argümanlar] "
 
 msgid ""
 "\n"
@@ -2967,21 +2976,21 @@ msgid ""
 "Arguments recognised by gvim (Motif version):\n"
 msgstr ""
 "\n"
-"gvim tarafından tanınan değişkenler (Motif sürümü):\n"
+"gvim tarafından tanınan argümanlar (Motif sürümü):\n"
 
 msgid ""
 "\n"
 "Arguments recognised by gvim (neXtaw version):\n"
 msgstr ""
 "\n"
-"gvim tarafından tanınan değişkenler (neXtaw sürümü):\n"
+"gvim tarafından tanınan argümanlar (neXtaw sürümü):\n"
 
 msgid ""
 "\n"
 "Arguments recognised by gvim (Athena version):\n"
 msgstr ""
 "\n"
-"gvim tarafından tanınan değişkenler (Athena sürümü):\n"
+"gvim tarafından tanınan argümanlar (Athena sürümü):\n"
 
 msgid "-display <display>\tRun Vim on <display>"
 msgstr "-display <ekran>\tVim'i <ekran>'da çalıştır"
@@ -3032,7 +3041,7 @@ msgid ""
 "Arguments recognised by gvim (GTK+ version):\n"
 msgstr ""
 "\n"
-"gvim tarafından tanınan değişkenler (GTK+ sürümü):\n"
+"gvim tarafından tanınan argümanlar (GTK+ sürümü):\n"
 
 msgid "-display <display>\tRun Vim on <display> (also: --display)"
 msgstr "-display <ekran>\tVim'i <ekran>'da çalıştır (veya: --display)"
@@ -3078,7 +3087,7 @@ msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: İzin verilmeyen kip"
 
 msgid "E460: entries missing in mapset() dict argument"
-msgstr "E460: mapset() sözlük değişkeninde eksik girdiler"
+msgstr "E460: mapset() sözlük argümanında eksik girdiler"
 
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
@@ -3716,13 +3725,13 @@ msgstr ""
 "İ&ptal"
 
 msgid "E766: Insufficient arguments for printf()"
-msgstr "E766: printf() için yetersiz değişkenler"
+msgstr "E766: printf() için yetersiz argüman"
 
 msgid "E807: Expected Float argument for printf()"
-msgstr "E807: printf() için kayan noktalı değer türünde değişken bekleniyordu"
+msgstr "E807: printf() için kayan noktalı değer türünde argüman bekleniyordu"
 
 msgid "E767: Too many arguments to printf()"
-msgstr "E767: printf() için çok fazla değişken"
+msgstr "E767: printf() için çok fazla argüman"
 
 msgid "Type number and <Enter> or click with the mouse (q or empty cancels): "
 msgstr ""
@@ -4014,11 +4023,11 @@ msgstr "E531: Grafik arabirimi başlatmak için \":gui\" yazın"
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: 'backupext' ve 'patchmode' birbirine eşit"
 
-msgid "E834: Conflicts with value of 'listchars'"
-msgstr "E834: 'listchars' değeriyle çakışmalar var"
-
 msgid "E835: Conflicts with value of 'fillchars'"
 msgstr "E835: 'fillchars' değeriyle çakışmalar var"
+
+msgid "E834: Conflicts with value of 'listchars'"
+msgstr "E834: 'listchars' değeriyle çakışmalar var"
 
 msgid "E617: Cannot be changed in the GTK+ 2 GUI"
 msgstr "E617: GTK+ 2 grafik arabiriminde değiştirilemez"
@@ -4392,7 +4401,7 @@ msgid "Cannot open file \"%s\""
 msgstr "\"%s\" dosyası açılamıyor"
 
 msgid "cannot have both a list and a \"what\" argument"
-msgstr "ya birinci ya da son değişken belirtilmelidir"
+msgstr "ya birinci ya da son argüman belirtilmelidir"
 
 msgid "E681: Buffer is not loaded"
 msgstr "E681: Arabellek yüklenemedi"
@@ -4725,16 +4734,19 @@ msgid "modeline"
 msgstr "kip satırı"
 
 msgid "--cmd argument"
-msgstr "--cmd değişkeni"
+msgstr "--cmd argümanı"
 
 msgid "-c argument"
-msgstr "-c değişkeni"
+msgstr "-c argümanı"
 
 msgid "environment variable"
 msgstr "ortam değişkeni"
 
 msgid "error handler"
 msgstr "hata işleyicisi"
+
+msgid "changed window size"
+msgstr "değiştirilen pencere boyutu"
 
 msgid "W15: Warning: Wrong line separator, ^M may be missing"
 msgstr "W15: Uyarı: Yanlış satır ayırıcısı, ^M eksik olabilir"
@@ -5215,6 +5227,9 @@ msgstr "E765: 'spellfile' içinde %d adet girdi yok"
 msgid "Word '%.*s' removed from %s"
 msgstr "'%.*s' sözcüğü %s içinden çıkartıldı"
 
+msgid "Seek error in spellfile"
+msgstr "Yazım dosyasında arama hatası"
+
 #, c-format
 msgid "Word '%.*s' added to %s"
 msgstr "'%.*s' sözcüğü %s dosyasına eklendi"
@@ -5242,7 +5257,7 @@ msgstr " < \"%.*s\""
 
 #, c-format
 msgid "E390: Illegal argument: %s"
-msgstr "E390: İzin verilmeyen değişken: %s"
+msgstr "E390: İzin verilmeyen argüman: %s"
 
 msgid "No Syntax items defined for this buffer"
 msgstr "Bu arabellek için sözdizim ögeleri tanımlanmamış"
@@ -5343,7 +5358,7 @@ msgid " line breaks"
 msgstr " satır sonu"
 
 msgid "E395: contains argument not accepted here"
-msgstr "E395: Burada kabul edilmeyen bir değişken içeriyor"
+msgstr "E395: Burada kabul edilmeyen bir argüman içeriyor"
 
 msgid "E844: invalid cchar value"
 msgstr "E844: Geçersiz cchar değeri"
@@ -5375,7 +5390,7 @@ msgstr "E398: '=' eksik: %s"
 
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
-msgstr "E399: Yetersiz değişken: %s sözdizim bölgesi"
+msgstr "E399: Yetersiz sayıda argüman: %s sözdizim bölgesi"
 
 msgid "E848: Too many syntax clusters"
 msgstr "E848: Çok fazla sözdizim kümesi"
@@ -5396,7 +5411,7 @@ msgstr "E403: Sözdizim eşitlemesi: Satır devamları dizgisi iki kez tanımlan
 
 #, c-format
 msgid "E404: Illegal arguments: %s"
-msgstr "E404: İzin verilmeyen değişkenler: %s"
+msgstr "E404: İzin verilmeyen argümanlar: %s"
 
 #, c-format
 msgid "E405: Missing equal sign: %s"
@@ -5404,7 +5419,7 @@ msgstr "E405: Eşittir imi eksik: %s"
 
 #, c-format
 msgid "E406: Empty argument: %s"
-msgstr "E406: Boş değişken: %s"
+msgstr "E406: Boş argüman: %s"
 
 #, c-format
 msgid "E407: %s not allowed here"
@@ -5539,7 +5554,7 @@ msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: termcap içinde \"%s\" girdisi yok"
 
 msgid "E437: terminal capability \"cm\" required"
-msgstr "E437: \"cm\" uçbirim kabiliyeti gerekiyor"
+msgstr "E437: \"cm\" uçbirim yeteneği gerekiyor"
 
 msgid ""
 "\n"
@@ -5688,16 +5703,16 @@ msgstr "E914: Bir Kanal, Kayan Noktalı Değer yerine kullanılıyor"
 msgid "E975: Using a Blob as a Float"
 msgstr "E975: Bir İkili Geniş Nesne, Kayan Noktalı Değer yerine kullanılıyor"
 
-msgid "E729: using Funcref as a String"
+msgid "E729: Using a Funcref as a String"
 msgstr "E729: Funcref bir Dizi yerine kullanılıyor"
 
-msgid "E730: using List as a String"
+msgid "E730: Using a List as a String"
 msgstr "E730: Liste bir Dizi yerine kullanılıyor"
 
-msgid "E731: using Dictionary as a String"
+msgid "E731: Using a Dictionary as a String"
 msgstr "E731: Sözlük bir Dizi yerine kullanılıyor"
 
-msgid "E976: using Blob as a String"
+msgid "E976: Using a Blob as a String"
 msgstr "E976: İkili Geniş Nesne bir Dizi yerine kullanılıyor"
 
 msgid "E977: Can only compare Blob with Blob"
@@ -5892,16 +5907,16 @@ msgid "E180: Invalid complete value: %s"
 msgstr "E180: Geçersiz tam değer: %s"
 
 msgid "E468: Completion argument only allowed for custom completion"
-msgstr "E468: Tamamlama değişkenine yalnızca özel tamamlamalarda izin verilir"
+msgstr "E468: Tamamlama argümanına yalnızca özel tamamlamalarda izin verilir"
 
 msgid "E467: Custom completion requires a function argument"
-msgstr "E467: Özel tamamlama bir işlev değişkeni gerektirir"
+msgstr "E467: Özel tamamlama bir işlev argümanı gerektirir"
 
 msgid "E175: No attribute specified"
 msgstr "E175: Bir öznitelik belirtilmemiş"
 
 msgid "E176: Invalid number of arguments"
-msgstr "E176: Geçersiz değişken sayısı"
+msgstr "E176: Geçersiz argüman sayısı"
 
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Sayım iki defa belirtilemez"
@@ -5910,10 +5925,10 @@ msgid "E178: Invalid default value for count"
 msgstr "E178: Sayım için geçersiz öntanımlı değer"
 
 msgid "E179: argument required for -complete"
-msgstr "E179: -complete için değişken gerekiyor"
+msgstr "E179: -complete için argüman gerekiyor"
 
 msgid "E179: argument required for -addr"
-msgstr "E179: -addr için değişken gerekiyor"
+msgstr "E179: -addr için argüman gerekiyor"
 
 #, c-format
 msgid "E174: Command already exists: add ! to replace it: %s"
@@ -5948,14 +5963,21 @@ msgstr "E130: Bilinmeyen işlev: %s"
 
 #, c-format
 msgid "E125: Illegal argument: %s"
-msgstr "E125: İzin verilmeyen değişken: %s"
+msgstr "E125: İzin verilmeyen argüman: %s"
 
 #, c-format
 msgid "E853: Duplicate argument name: %s"
-msgstr "E853: Yinelenen değişken adı: %s"
+msgstr "E853: Yinelenen argüman adı: %s"
 
 msgid "E989: Non-default argument follows default argument"
-msgstr "E989: Öntanımlı olmayan değişken öntanımlı değişkenden sonra"
+msgstr "E989: Öntanımlı olmayan argüman öntanımlı argümandan sonra"
+
+msgid "E126: Missing :endfunction"
+msgstr "E126: :endfunction eksik"
+
+#, c-format
+msgid "W22: Text found after :endfunction: %s"
+msgstr "W22: :endfunction sonrası metin bulundu: %s"
 
 #, c-format
 msgid "E451: Expected }: %s"
@@ -5963,11 +5985,11 @@ msgstr "E451: } bekleniyordu: %s"
 
 #, c-format
 msgid "E740: Too many arguments for function %s"
-msgstr "E740: %s işlevi için çok fazla değişken"
+msgstr "E740: %s işlevi için çok fazla argüman"
 
 #, c-format
 msgid "E116: Invalid arguments for function %s"
-msgstr "E116: %s işlevi için geçersiz değişkenler"
+msgstr "E116: %s işlevi için geçersiz argümanlar"
 
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: İşlevin çağırdığı derinlik 'maxfuncdepth'ten daha yüksek"
@@ -5989,7 +6011,7 @@ msgid "%s returning %s"
 msgstr "%s, %s döndürüyor"
 
 msgid "E699: Too many arguments"
-msgstr "E699: Çok fazla değişken"
+msgstr "E699: Çok fazla argüman"
 
 #, c-format
 msgid "E276: Cannot use function as a method: %s"
@@ -6031,17 +6053,6 @@ msgstr "E862: g: burada kullanılamaz"
 #, c-format
 msgid "E932: Closure function should not be at top level: %s"
 msgstr "E932: Kapatma işlevi en üst düzeyde olmamalıdır: %s"
-
-msgid "E126: Missing :endfunction"
-msgstr "E126: :endfunction eksik"
-
-#, c-format
-msgid "W1001: Text found after :enddef: %s"
-msgstr "W1001: :enddef sonrası metin bulundu: %s"
-
-#, c-format
-msgid "W22: Text found after :endfunction: %s"
-msgstr "W22: :endfunction sonrası metin bulundu: %s"
 
 #, c-format
 msgid "E707: Function name conflicts with variable: %s"
@@ -6605,6 +6616,55 @@ msgstr "gvimext.dll hatası"
 msgid "Path length too long!"
 msgstr "Yol çok uzun!"
 
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: \\ sonrasında /, ? veya & gelmeli"
+
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Komut satırı penceresinde geçersiz; <CR> çalıştırır, CTRL-C çıkar"
+
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr ""
+"E12: Geçerli dizin veya etiket aramasında exrc veya vimrc'den komutlara izin "
+"verilmiyor"
+
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Dosya mevcut (geçersiz kılmak için ! ekleyin)"
+
+#, c-format
+msgid "E15: Invalid expression: \"%s\""
+msgstr "E15: Geçersiz ifade: \"%s\""
+
+msgid "E16: Invalid range"
+msgstr "E16: Geçersiz erim"
+
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" bir dizin"
+
+msgid "E18: Unexpected characters in :let"
+msgstr "E18: :let içinde beklenmeyen karakter"
+
+msgid "E18: Unexpected characters in assignment"
+msgstr "E18: Atama içerisinde beklenmedik karakterler"
+
+msgid "E19: Mark has invalid line number"
+msgstr "E19: İm satır numarası geçersiz"
+
+msgid "E20: Mark not set"
+msgstr "E20: İm ayarlanmamış"
+
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Değişiklik yapılamıyor, 'modifiable' kapalı"
+
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Betikler çok iç içe geçmiş"
+
+msgid "E23: No alternate file"
+msgstr "E23: Başka bir dosya yok"
+
+msgid "E24: No such abbreviation"
+msgstr "E24: Böyle bir kısaltma yok"
+
 #, c-format
 msgid "E121: Undefined variable: %s"
 msgstr "E121: Tanımlanmamış değişken: %s"
@@ -6612,6 +6672,9 @@ msgstr "E121: Tanımlanmamış değişken: %s"
 #, c-format
 msgid "E121: Undefined variable: %c:%s"
 msgstr "E121: Tanımlanmamış değişken: %c:%s"
+
+msgid "E464: Ambiguous use of user-defined command"
+msgstr "E464: Kullanıcı tanımlı komutun belirsiz kullanımı"
 
 msgid "E476: Invalid command"
 msgstr "E476: Geçersiz komut"
@@ -6633,15 +6696,19 @@ msgid ""
 "E856: \"assert_fails()\" second argument must be a string or a list with one "
 "or two strings"
 msgstr ""
-"E856: \"assert_fails()\" ikinci değişkeni bir dizi veya bir veya iki dizili "
+"E856: \"assert_fails()\" ikinci argüman bir dizi veya bir veya iki dizili "
 "bir liste olmalıdır"
+
+#, c-format
+msgid "E908: using an invalid value as a String: %s"
+msgstr "E908: Geçersiz bir değer bir Dizi yerine kullanılıyor: %s"
 
 msgid "E909: Cannot index a special variable"
 msgstr "E909: Özel bir değişken dizinlenemiyor"
 
 #, c-format
-msgid "E1100: Missing :var: %s"
-msgstr "E1100: :var eksik: %s"
+msgid "E1100: Command not supported in Vim9 script (missing :var?): %s"
+msgstr "E1100: Komut Vim9 betiğinde desteklenmiyor (:var? eksik): %s"
 
 #, c-format
 msgid "E1001: Variable not found: %s"
@@ -6655,18 +6722,18 @@ msgid "E1003: Missing return value"
 msgstr "E1003: Dönüş değeri eksik"
 
 #, c-format
-msgid "E1004: White space required before and after '%s'"
-msgstr "E1004: '%s' öncesinde ve sonrasında boşluk gerekiyor"
+msgid "E1004: White space required before and after '%s' at \"%s\""
+msgstr "E1004: Şu konumda '%s' öncesinde ve sonrasında boşluk gerekiyor: \"%s\""
 
 msgid "E1005: Too many argument types"
-msgstr "E1005: Çok fazla değişken türü"
+msgstr "E1005: Çok fazla argüman türü"
 
 #, c-format
 msgid "E1006: %s is used as an argument"
-msgstr "E1006: %s bir değişken olarak kullanılıyor"
+msgstr "E1006: %s bir argüman olarak kullanılıyor"
 
 msgid "E1007: Mandatory argument after optional argument"
-msgstr "E1007: İsteğe bağlı değişken sonrasında zorunlu değişken"
+msgstr "E1007: İsteğe bağlı argüman sonrasında zorunlu argüman"
 
 msgid "E1008: Missing <type>"
 msgstr "E1008: <tür> eksik"
@@ -6688,7 +6755,7 @@ msgstr "E1012: Tür uyumsuzluğu, %s bekleniyordu, ancak %s alındı"
 
 #, c-format
 msgid "E1013: Argument %d: type mismatch, expected %s but got %s"
-msgstr "E1013: %d değişkeni: Tür uyumsuzluğu, %s bekleniyordu, ancak %s alındı"
+msgstr "E1013: %d argümanı: Tür uyumsuzluğu, %s bekleniyordu, ancak %s alındı"
 
 #, c-format
 msgid "E1014: Invalid key: %s"
@@ -6728,8 +6795,8 @@ msgid "E1022: Type or initialization required"
 msgstr "E1022: Tür veya ilklendirme gerekiyor"
 
 #, c-format
-msgid "E1023: Using a Number as a Bool: %d"
-msgstr "E1023: Bir Sayı, bir Bool yerine kullanılıyor: %d"
+msgid "E1023: Using a Number as a Bool: %lld"
+msgstr "E1023: Bir Sayı, bir Boole yerine kullanılıyor: %lld"
 
 msgid "E1024: Using a Number as a String"
 msgstr "E1024: Bir Sayı, bir Dizi yerine kullanılıyor"
@@ -6768,11 +6835,11 @@ msgid "E1034: Cannot use reserved name %s"
 msgstr "E1034: Ayrılmış ad %s kullanılamaz"
 
 msgid "E1035: % requires number arguments"
-msgstr "E1035: %, sayı değişkenler gerektirir"
+msgstr "E1035: %, sayı argümanları gerektirir"
 
 #, c-format
 msgid "E1036: %c requires number or float arguments"
-msgstr "E1036: %c, sayı veya kayan noktalı değer değişkenler gerektirir"
+msgstr "E1036: %c, sayı veya kayan noktalı değer argümanları gerektirir"
 
 #, c-format
 msgid "E1037: Cannot use \"%s\" with %s"
@@ -6798,7 +6865,7 @@ msgid "E1043: Invalid command after :export"
 msgstr "E1043: :export sonrası geçersiz komut"
 
 msgid "E1044: Export with invalid argument"
-msgstr "E1044: Geçersiz değişkenle dışa aktarım"
+msgstr "E1044: Geçersiz argümanla dışa aktarım"
 
 msgid "E1045: Missing \"as\" after *"
 msgstr "E1045: * sonrası \"as\" eksik"
@@ -6817,11 +6884,12 @@ msgstr "E1048: Betikte öge bulunamadı: %s"
 msgid "E1049: Item not exported in script: %s"
 msgstr "E1049: Betikte öge dışa aktarılmadı: %s"
 
-msgid "E1050: Colon required before a range"
-msgstr "E1050: Bir erim öncesi iki nokta gerekiyor"
+#, c-format
+msgid "E1050: Colon required before a range: %s"
+msgstr "E1050: Bir erim öncesi iki nokta gerekiyor: %s"
 
 msgid "E1051: Wrong argument type for +"
-msgstr "E1051: + için hatalı değişken türü"
+msgstr "E1051: + için hatalı argüman türü"
 
 #, c-format
 msgid "E1052: Cannot declare an option: %s"
@@ -6875,12 +6943,12 @@ msgid "E1067: Separator mismatch: %s"
 msgstr "E1067: Ayırıcı uyumsuzluğu: %s"
 
 #, c-format
-msgid "E1068: No white space allowed before '%s'"
-msgstr "E1068: '%s' önce boşluğa izin verilmiyor"
+msgid "E1068: No white space allowed before '%s': %s"
+msgstr "E1068: '%s' önce boşluğa izin verilmiyor: %s"
 
 #, c-format
-msgid "E1069: White space required after '%s'"
-msgstr "E1069: '%s' sonrası boşluk gerekiyor"
+msgid "E1069: White space required after '%s': %s"
+msgstr "E1069: '%s' sonrası boşluk gerekiyor: %s"
 
 msgid "E1070: Missing \"from\""
 msgstr "E1070: \"from\" eksik"
@@ -6908,7 +6976,7 @@ msgstr "E1076: Bu Vim kayan noktalı değer desteği ile derlenmemiş"
 
 #, c-format
 msgid "E1077: Missing argument type for %s"
-msgstr "E1077: %s için değişken türü eksik"
+msgstr "E1077: %s için argüman türü eksik"
 
 #, c-format
 msgid "E1081: Cannot unlet %s"
@@ -6933,7 +7001,7 @@ msgid "E1086: Cannot use :function inside :def"
 msgstr "E1086: :def içinde :function kullanılamaz"
 
 msgid "E1087: Cannot use an index when declaring a variable"
-msgstr "E1087: Bir değişken tanımlarken indeks kullanılamaz"
+msgstr "E1087: Bir değişken tanımlarken dizinleme kullanılamaz"
 
 #, c-format
 msgid "E1089: Unknown variable: %s"
@@ -6941,7 +7009,7 @@ msgstr "E1089: Bilinmeyen değişken: %s"
 
 #, c-format
 msgid "E1090: Cannot assign to argument %s"
-msgstr "E1090: %s değişkenine atanamıyor"
+msgstr "E1090: %s argümanına atanamıyor"
 
 #, c-format
 msgid "E1091: Function is not compiled: %s"
@@ -6989,11 +7057,11 @@ msgid "E1105: Cannot convert %s to string"
 msgstr "E1105: %s bir diziye dönüştürülemiyor"
 
 msgid "E1106: One argument too many"
-msgstr "E1106: Bir değişken fazladan"
+msgstr "E1106: Bir argüman fazladan"
 
 #, c-format
 msgid "E1106: %d arguments too many"
-msgstr "E1106: %d değişken fazladan"
+msgstr "E1106: %d argüman fazladan"
 
 msgid "E1107: String, List, Dict or Blob required"
 msgstr "E1107: Dizi, Liste, Sözlük veya İkili Nesne gerekiyor"
@@ -7026,10 +7094,10 @@ msgid "E1114: Only values of 0x100 and higher supported"
 msgstr "E1114: Yalnızca 0x100 ve daha yüksek değerler destekleniyor"
 
 msgid "E1115: \"assert_fails()\" fourth argument must be a number"
-msgstr "E1115: \"assert_fails()\" dördüncü değişkeni bir sayı olmalıdır"
+msgstr "E1115: \"assert_fails()\" dördüncü argüman bir sayı olmalıdır"
 
 msgid "E1116: \"assert_fails()\" fifth argument must be a string"
-msgstr "E1116: \"assert_fails()\" beşinci değişkeni bir dizi olmalıdır"
+msgstr "E1116: \"assert_fails()\" beşinci argüman bir dizi olmalıdır"
 
 msgid "E1117: Cannot use ! with nested :def"
 msgstr "E1117: !, iç içe geçmiş :def ile kullanılamaz"
@@ -7080,7 +7148,7 @@ msgid "E1131: Cannot add to null blob"
 msgstr "E1131: Null ikili geniş nesnesine ekleme yapılamaz"
 
 msgid "E1132: Missing function argument"
-msgstr "E1132: İşlev değişkeni eksik"
+msgstr "E1132: İşlev argümanı eksik"
 
 msgid "E1133: Cannot extend a null dict"
 msgstr "E1133: Bir null sözlük genişletilemez"
@@ -7108,11 +7176,258 @@ msgstr "E1138: Bir Boole, Sayı yerine kullanılıyor"
 msgid "E1139: Missing matching bracket after dict key"
 msgstr "E1139: Sözlük anahtarı sonrası eşleşen ayraç eksik"
 
-msgid "E1140: For argument must be a sequence of lists"
-msgstr "E1140: For değişkeni listelerin bir sıralaması olmalıdır"
+msgid "E1140: :for argument must be a sequence of lists"
+msgstr "E1140: :for argümanı listelerin bir sıralaması olmalıdır"
 
 msgid "E1141: Indexable type required"
 msgstr "E1141: İndekslenebilir tür gerekiyor"
+
+msgid "E1142: Non-empty string required"
+msgstr "E1142: Boş olmayan dizi gerekiyor"
+
+#, c-format
+msgid "E1143: Empty expression: \"%s\""
+msgstr "E1143: Boş ifade: \"%s\""
+
+#, c-format
+msgid "E1144: Command \"%s\" is not followed by white space: %s"
+msgstr "E1144: \"%s\" komutu sonrasında boşluk gelmiyor: %s"
+
+#, c-format
+msgid "E1145: Missing heredoc end marker: %s"
+msgstr "E1145: Son imleyicisi eksik: %s"
+
+#, c-format
+msgid "E1146: Command not recognized: %s"
+msgstr "E1146: Komut tanınamadı: %s"
+
+msgid "E1147: List not set"
+msgstr "E1147: Liste ayarlanmamış"
+
+#, c-format
+msgid "E1148: Cannot index a %s"
+msgstr "E1148: Bir %s dizinlenemiyor"
+
+#, c-format
+msgid "E1149: Script variable is invalid after reload in function %s"
+msgstr "E1149: %s işlevindeki yeniden yüklemeden sonra betik değişkeni geçersiz"
+
+msgid "E1150: Script variable type changed"
+msgstr "E1150: Betik değişkeni türü değiştirildi"
+
+msgid "E1151: Mismatched endfunction"
+msgstr "E1151: Eşleşmeyen endfunction"
+
+msgid "E1152: Mismatched enddef"
+msgstr "E1152: Eşleşmeyen enddef"
+
+msgid "E1153: Invalid operation for bool"
+msgstr "E1153: Boole için geçersiz işlem"
+
+msgid "E1154: Divide by zero"
+msgstr "E1154: Sıfır ile bölüm"
+
+msgid "E1155: Cannot define autocommands for ALL events"
+msgstr "E1155: Otokomutlar TÜM olaylar için tanımlanamıyor"
+
+msgid "E1156: Cannot change the argument list recursively"
+msgstr "E1156: Değişken listesi özyineli olarak değiştirilemiyor"
+
+msgid "E1157: Missing return type"
+msgstr "E1157: Dönüş türü eksik"
+
+msgid "E1158: Cannot use flatten() in Vim9 script"
+msgstr "E1158: flatten(), Vim9 betiğinde kullanılamaz"
+
+msgid "E1159: Cannot split a window when closing the buffer"
+msgstr "E1159: Arabellek kapatılırken bir pencere bölünemez"
+
+msgid "E1160: Cannot use a default for variable arguments"
+msgstr "E1160: Değişken argümanları için bir öntanımlı kullanılamaz"
+
+#, c-format
+msgid "E1161: Cannot json encode a %s"
+msgstr "E1161: Bir %s JSON olarak kodlanamıyor"
+
+#, c-format
+msgid "E1162: Register name must be one character: %s"
+msgstr "E1162: Yazmaç adı tek bir karakter olmalıdır: %s"
+
+#, c-format
+msgid "E1163: Variable %d: type mismatch, expected %s but got %s"
+msgstr "E1163: %d değişkeni: Tür uyumsuzluğu, %s bekleniyordu, ancak %s alındı"
+
+msgid "E1164: vim9cmd must be followed by a command"
+msgstr "E1164: vim9cmd sonrasında bir komut gelmelidir"
+
+#, c-format
+msgid "E1165: Cannot use a range with an assignment: %s"
+msgstr "E1165: Bir atama ile bir erim kullanılamıyor: %s"
+
+msgid "E1166: Cannot use a range with a dictionary"
+msgstr "E1166: Bir sözlük ile bir erim kullanılamıyor"
+
+#, c-format
+msgid "E1167: Argument name shadows existing variable: %s"
+msgstr "E1167: Argüman adı var olan değişkeni gölgeliyor: %s"
+
+#, c-format
+msgid "E1168: Argument already declared in the script: %s"
+msgstr "E1168: Betikte argüman halihazırda tanımlanmış: %s"
+
+msgid "E1169: 'import * as {name}' not supported here"
+msgstr "E1169: 'import * as {name} burada desteklenmiyor"
+
+msgid "E1170: Cannot use #{ to start a comment"
+msgstr "E1170: Bir yorum başlatmak için #{ kullanılamaz"
+
+msgid "E1171: Missing } after inline function"
+msgstr "E1171: Satıriçi işlevden sonra } eksik"
+
+msgid "E1172: Cannot use default values in a lambda"
+msgstr "E1172: Bir lambda içerisinde öntanımlı değerler kullanılamıyor"
+
+#, c-format
+msgid "E1173: Text found after enddef: %s"
+msgstr "E1173: :enddef sonrası metin bulundu: %s"
+
+#, c-format
+msgid "E1174: String required for argument %d"
+msgstr "E1174: %d argümanı için dizi gerekiyor"
+
+#, c-format
+msgid "E1175: Non-empty string required for argument %d"
+msgstr "E1175: %d argümanı için boş olmayan dizi gerekiyor"
+
+msgid "E1176: Misplaced command modifier"
+msgstr "E1176: Yanlış yere konulmuş komut değiştiricisi"
+
+#, c-format
+msgid "E1177: For loop on %s not supported"
+msgstr "E1177: %s üzerinde for döngüsü desteklenmiyor"
+
+msgid "E1178: Cannot lock or unlock a local variable"
+msgstr "E1178: Bir yerel değişken kilitlenemiyor/kilidi açılamıyor"
+
+#, c-format
+msgid ""
+"E1179: Failed to extract PWD from %s, check your shell's config related to "
+"OSC 7"
+msgstr ""
+"E1179: %s içinden PWD çıkarılamadı, kabuğunuzun OSC 7 ile ilgili "
+"yapılandırmasını denetleyin"
+
+#, c-format
+msgid "E1180: Variable arguments type must be a list: %s"
+msgstr "E1180: Değişken argümanları türü bir liste olmalıdır: %s"
+
+msgid "E1181: Cannot use an underscore here"
+msgstr "E1181: Alt çizgi burada kullanılamaz"
+
+msgid "E1182: Blob required"
+msgstr "E1182: İkili geniş nesne gerekiyor"
+
+#, c-format
+msgid "E1183: Cannot use a range with an assignment operator: %s"
+msgstr "E1183: Bir atama işleci ile bir erim kullanılamıyor: %s"
+
+msgid "E1184: Blob not set"
+msgstr "E1184: İkili geniş nesne ayarlanmamış"
+
+msgid "E1185: Cannot nest :redir"
+msgstr "E1185: :redir içe geçirilemiyor"
+
+msgid "E1185: Missing :redir END"
+msgstr "E1185: :redir END eksik"
+
+#, c-format
+msgid "E1186: Expression does not result in a value: %s"
+msgstr "E1186: İfade bir değer sonucu vermiyor: %s"
+
+msgid "E1187: Failed to source defaults.vim"
+msgstr "E1187: defaults.vim kaynaklanamadı"
+
+msgid "E1188: Cannot open a terminal from the command line window"
+msgstr "E1188: Komut satırı penceresinden bir uçbirim açılamıyor"
+
+#, c-format
+msgid "E1189: Cannot use :legacy with this command: %s"
+msgstr "E1189: :legacy, bu komut ile kullanılamıyor: %s"
+
+msgid "E1190: One argument too few"
+msgstr "E1190: Bir argüman daha gerekiyor"
+
+#, c-format
+msgid "E1190: %d arguments too few"
+msgstr "E1190: %d argüman daha gerekiyor"
+
+#, c-format
+msgid "E1191: Call to function that failed to compile: %s"
+msgstr "E1191: Derlenemeyen işlev çağrısı: %s"
+
+msgid "E1192: Empty function name"
+msgstr "E1192: Boş işlev adı"
+
+msgid "E1193: cryptmethod xchacha20 not built into this Vim"
+msgstr "E1193: cryptmethod xchacha20 bu Vim ile kullanılamıyor"
+
+msgid "E1194: Cannot encrypt header, not enough space"
+msgstr "E1194: Üstbilgi şifrelenemiyor, yetersiz alan"
+
+msgid "E1195: Cannot encrypt buffer, not enough space"
+msgstr "E1195: Arabellek şifrelenemiyor, yetersiz alan"
+
+msgid "E1196: Cannot decrypt header, not enough space"
+msgstr "E1196: Üstbilgi şifresi çözülemiyor, yetersiz alan"
+
+msgid "E1197: Cannot allocate_buffer for encryption"
+msgstr "E1197: Şifreleme için allocate_buffer yapılamıyor"
+
+msgid "E1198: Decryption failed: Header incomplete!"
+msgstr "E1198: Şifre çözümü başarısız: Üstbilgi tam değil!"
+
+msgid "E1199: Cannot decrypt buffer, not enough space"
+msgstr "E1199: Arabellek şifresi çözülemiyor, yetersiz alan"
+
+msgid "E1200: Decryption failed!"
+msgstr "E1200: Şifre çözümü başarısız!"
+
+msgid "E1201: Decryption failed: pre-mature end of file!"
+msgstr "E1201: Şifre çözümü başarısız: Beklenmedik dosya sonu!"
+
+#, c-format
+msgid "E1202: No white space allowed after '%s': %s"
+msgstr "E1202: '%s' sonrası boşluğa izin verilmiyor: %s"
+
+#, c-format
+msgid "E1203: Dot can only be used on a dictionary: %s"
+msgstr "E1203: Nokta yalnızca bir sözlükte kullanılabilir: %s"
+
+#, c-format
+msgid "E1204: No Number allowed after .: '\\%%%c'"
+msgstr "E1204: . sonrası Sayıya izin verilmiyor: '\\%%%c'"
+
+msgid "E1205: No white space allowed between option and"
+msgstr "E1205: and seçeneği arasında boşluğa izin verilmiyor"
+
+#, c-format
+msgid "E1206: Dictionary required for argument %d"
+msgstr "E1206: %d argümanı için sözlük gerekiyor"
+
+#, c-format
+msgid "E1207: Expression without an effect: %s"
+msgstr "E1207: Bir efekt olmadan ifade: %s"
+
+msgid "E1208: -complete used without -nargs"
+msgstr "E1208: -complete, -nargs olmadan kullanıldı"
+
+#, c-format
+msgid "E1209: Invalid value for a line number: \"%s\""
+msgstr "E1209: Satır numarası için geçersiz değer: \"%s\""
+
+#, c-format
+msgid "E1210: Number required for argument %d"
+msgstr "E1210: %d argümanı için sayı gerekiyor"
 
 msgid "--No lines in buffer--"
 msgstr "--Arabellek içinde satır yok--"
@@ -7122,17 +7437,6 @@ msgstr "E470: Komut durduruldu"
 
 msgid "E471: Argument required"
 msgstr "E471: Değişken gerekiyor"
-
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: \\ sonrasında /, ? veya & gelmeli"
-
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Komut satırı penceresinde geçersiz; <CR> çalıştırır, CTRL-C çıkar"
-
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Geçerli dizin veya etiket aramasında exrc veya vimrc'den komutlara izin "
-"verilmiyor"
 
 msgid "E171: Missing :endif"
 msgstr "E171: :endif eksik"
@@ -7164,9 +7468,6 @@ msgstr "E588: :while olmadan :endwhile"
 msgid "E588: :endfor without :for"
 msgstr "E588: :for olmadan :endfor"
 
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Dosya mevcut (geçersiz kılmak için ! ekleyin)"
-
 msgid "E472: Command failed"
 msgstr "E472: Komut başarısız oldu"
 
@@ -7193,34 +7494,23 @@ msgid "Interrupted"
 msgstr "Yarıda kesildi"
 
 msgid "E474: Invalid argument"
-msgstr "E474: Geçersiz değişken"
+msgstr "E474: Geçersiz argüman"
 
 #, c-format
 msgid "E475: Invalid argument: %s"
-msgstr "E475: Geçersiz değişken: %s"
+msgstr "E475: Geçersiz argüman: %s"
 
 #, c-format
 msgid "E983: Duplicate argument: %s"
-msgstr "E983: Yinelenen değişken: %s"
+msgstr "E983: Yinelenen argüman: %s"
 
 #, c-format
 msgid "E475: Invalid value for argument %s"
-msgstr "E475: %s değişkeni için geçersiz değer"
+msgstr "E475: %s argümanı için geçersiz değer"
 
 #, c-format
 msgid "E475: Invalid value for argument %s: %s"
-msgstr "E475: %s değişkeni için geçersiz değer: %s"
-
-#, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Geçersiz ifade: %s"
-
-msgid "E16: Invalid range"
-msgstr "E16: Geçersiz erim"
-
-#, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" bir dizin"
+msgstr "E475: %s argümanı için geçersiz değer: %s"
 
 msgid "E756: Spell checking is not possible"
 msgstr "E756: Yazım denetimi olanaklı değil"
@@ -7235,24 +7525,6 @@ msgstr "E667: Fsync başarısız oldu"
 #, c-format
 msgid "E448: Could not load library function %s"
 msgstr "E448: %s kitaplık işlevi yüklenemedi"
-
-msgid "E19: Mark has invalid line number"
-msgstr "E19: İm satır numarası geçersiz"
-
-msgid "E20: Mark not set"
-msgstr "E20: İm ayarlanmamış"
-
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Değişiklik yapılamıyor, 'modifiable' kapalı"
-
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Betikler çok iç içe geçmiş"
-
-msgid "E23: No alternate file"
-msgstr "E23: Başka bir dosya yok"
-
-msgid "E24: No such abbreviation"
-msgstr "E24: Böyle bir kısaltma yok"
 
 msgid "E477: No ! allowed"
 msgstr "E477: ! imine izin verilmiyor"
@@ -7327,7 +7599,7 @@ msgid "E485: Can't read file %s"
 msgstr "E485: %s dosyası okunamıyor"
 
 msgid "E38: Null argument"
-msgstr "E38: Anlamsız değişken"
+msgstr "E38: Anlamsız argüman"
 
 msgid "E39: Number expected"
 msgstr "E39: Sayı bekleniyordu"
@@ -7392,6 +7664,9 @@ msgstr "E794: Değişken kum havuzunda ayarlanamıyor: \"%s\""
 msgid "E928: String required"
 msgstr "E928: Dizi gerekiyor"
 
+msgid "E889: Number required"
+msgstr "E889: Sayı gerekiyor"
+
 msgid "E713: Cannot use empty key for Dictionary"
 msgstr "E713: Sözlük için boş anahtar kullanılamaz"
 
@@ -7411,11 +7686,11 @@ msgstr "E978: İkili geniş nesne için geçersiz işlem"
 
 #, c-format
 msgid "E118: Too many arguments for function: %s"
-msgstr "E118: İşlev için çok fazla değişken: %s"
+msgstr "E118: İşlev için çok fazla argüman: %s"
 
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
-msgstr "E119: Şu işlev için yetersiz sayıda değişken: %s"
+msgstr "E119: Şu işlev için yetersiz sayıda argüman: %s"
 
 #, c-format
 msgid "E933: Function was deleted: %s"
@@ -7437,17 +7712,14 @@ msgstr "E697: Liste sonunda ']' eksik: %s"
 
 #, c-format
 msgid "E712: Argument of %s must be a List or Dictionary"
-msgstr "E712: %s ögesinin değişkeni bir liste veya sözlük olmalıdır"
+msgstr "E712: %s ögesinin argümanı bir liste veya sözlük olmalıdır"
 
 #, c-format
 msgid "E896: Argument of %s must be a List, Dictionary or Blob"
-msgstr "E896: %s değişkeni bir liste, sözlük veya ikili geniş nesne olmalıdır"
+msgstr "E896: %s argümanı bir liste, sözlük veya ikili geniş nesne olmalıdır"
 
 msgid "E804: Cannot use '%' with Float"
 msgstr "E804: Bir kayan noktalı değer ile '%' kullanılamaz"
-
-msgid "E908: using an invalid value as a String"
-msgstr "E908: Geçersiz bir değer bir Dizi yerine kullanılıyor"
 
 msgid "E996: Cannot lock an option"
 msgstr "E996: Seçenek kilitlenemiyor"
@@ -7455,9 +7727,6 @@ msgstr "E996: Seçenek kilitlenemiyor"
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Bilinmeyen seçenek: %s"
-
-msgid "E18: Unexpected characters in :let"
-msgstr "E18: :let içinde beklenmeyen karakter"
 
 #, c-format
 msgid "E998: Reduce of an empty %s with no initial value"
@@ -7616,7 +7885,7 @@ msgstr "E957: Geçersiz pencere numarası"
 
 #, c-format
 msgid "E686: Argument of %s must be a List"
-msgstr "E686: %s değişkeni bir liste olmalı"
+msgstr "E686: %s argümanı bir liste olmalı"
 
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: '?' sonrası ':' eksik"
@@ -7685,7 +7954,7 @@ msgstr "'%s' anahtarı sözlüğe eklenemedi"
 
 #, c-format
 msgid "index must be int or slice, not %s"
-msgstr "dizin bir tamsayı veya dilim olmalıdır, %s olamaz"
+msgstr "sıra bir tamsayı veya dilim olmalıdır, %s olamaz"
 
 #, c-format
 msgid "expected str() or unicode() instance, but got %s"
@@ -7762,10 +8031,10 @@ msgid "expected sequence element of size 2, but got sequence of size %d"
 msgstr "2 boyut bir sıralama bekleniyordu, ancak %d boyut bir sıralama geldi"
 
 msgid "list constructor does not accept keyword arguments"
-msgstr "liste yapıcısı anahtar sözcük değişkenleri kabul etmez"
+msgstr "liste yapıcısı anahtar sözcük argümanları kabul etmez"
 
 msgid "list index out of range"
-msgstr "liste dizini erimin dışında"
+msgstr "liste sırası erimin dışında"
 
 #, c-format
 msgid "internal error: failed to get Vim list item %d"
@@ -8013,8 +8282,7 @@ msgstr ""
 "düzenleyebilirsiniz."
 
 msgid "\" Hit <Enter> on a help line to open a help window on this option."
-msgstr ""
-"\" Yardım penceresini açmak için seçenek adı üzerinde <Enter>'a basın."
+msgstr "\" Yardım penceresini açmak için seçenek adı üzerinde <Enter>'a basın."
 
 msgid "\" Hit <Enter> on an index line to jump there."
 msgstr ""
@@ -8056,7 +8324,8 @@ msgid "moving around, searching and patterns"
 msgstr "dolaşma, arama ve dizgeler"
 
 msgid "list of flags specifying which commands wrap to another line"
-msgstr "hangi komutların diğer satıra kaydırıldığını belirleyen bayraklar\n"
+msgstr ""
+"hangi komutların diğer satıra kaydırıldığını belirleyen bayraklar\n"
 "listesi"
 
 msgid ""
@@ -8080,6 +8349,9 @@ msgstr ":cd için kullanılan dizin adları listesi"
 
 msgid "change to directory of file in buffer"
 msgstr "arabellekteki dosyanın olduğu dizine değiştir"
+
+msgid "change to pwd of shell in terminal buffer"
+msgstr "uçbirim arabelleğindeki kabuğun pwd'sine geç"
 
 msgid "search commands wrap around the end of the buffer"
 msgstr "arama komutları, arabelleğin sonunda kaydırılır"
@@ -8320,7 +8592,8 @@ msgid "multiple windows"
 msgstr "çoklu pencereler"
 
 msgid "0, 1 or 2; when to use a status line for the last window"
-msgstr "0, 1 veya 2; son pencere için ne zaman bir durum satırı\n"
+msgstr ""
+"0, 1 veya 2; son pencere için ne zaman bir durum satırı\n"
 "kullanılacağı"
 
 msgid "alternate format to be used for a status line"
@@ -8382,7 +8655,8 @@ msgid "this window scrolls together with other bound windows"
 msgstr "bu pencere, bağlı diğer pencerelerle birlikte kayar"
 
 msgid "\"ver\", \"hor\" and/or \"jump\"; list of options for 'scrollbind'"
-msgstr "\"ver\", \"hor\" ve/veya \"jump\"; 'scrollbind' için seçenekler listesi"
+msgstr ""
+"\"ver\", \"hor\" ve/veya \"jump\"; 'scrollbind' için seçenekler listesi"
 
 msgid "this window's cursor moves together with other bound windows"
 msgstr "bu pencerenin imleci bağlı diğer pencerelerle birlikte kayar"
@@ -8394,7 +8668,8 @@ msgid "key that precedes Vim commands in a terminal window"
 msgstr "bir uçbirim penceresinde Vim komutlarından önce gelen düğme"
 
 msgid "max number of lines to keep for scrollback in a terminal window"
-msgstr "bir uçbirim penceresinde geri kaydırma için kullanılacak\n"
+msgstr ""
+"bir uçbirim penceresinde geri kaydırma için kullanılacak\n"
 "en çok satır sayısı"
 
 msgid "type of pty to use for a terminal window"
@@ -8522,8 +8797,7 @@ msgid "list of flags that specify how the GUI works"
 msgstr "grafik arabirimin nice çalıştığını belirleyen bayraklar listesi"
 
 msgid "\"icons\", \"text\" and/or \"tooltips\"; how to show the toolbar"
-msgstr ""
-"\"icons\", \"text\" ve/veya \"tooltips\"; araç çubuğu kipleri "
+msgstr "\"icons\", \"text\" ve/veya \"tooltips\"; araç çubuğu kipleri "
 
 msgid "size of toolbar icons"
 msgstr "araç çubuğu simgelerinin boyutu"
@@ -8679,7 +8953,8 @@ msgid "list of directories for undo files"
 msgstr "geri al dosyaları için dizinler listesi"
 
 msgid "maximum number lines to save for undo on a buffer reload"
-msgstr "arabellek yeniden yüklemesinde geri al için kaydedilecek\n"
+msgstr ""
+"arabellek yeniden yüklemesinde geri al için kaydedilecek\n"
 "en çok satır sayısı"
 
 msgid "changes have been made and not written to a file"
@@ -8704,7 +8979,8 @@ msgid "definition of what comment lines look like"
 msgstr "yorum satırlarının nice görüneceğinin tanımı"
 
 msgid "list of flags that tell how automatic formatting works"
-msgstr "kendiliğinden biçimlendirmenin nice çalıştığını anlatan\n"
+msgstr ""
+"kendiliğinden biçimlendirmenin nice çalıştığını anlatan\n"
 "bayraklar listesi"
 
 msgid "pattern to recognize a numbered list"
@@ -8714,7 +8990,8 @@ msgid "expression used for \"gq\" to format lines"
 msgstr "satırları biçimlendirmek için \"gq\" için kullanılan ifade"
 
 msgid "specifies how Insert mode completion works for CTRL-N and CTRL-P"
-msgstr "Ekleme kipi tamamlamasının CTRL-N ve CTRL-P için nice çalıştığını\n"
+msgstr ""
+"Ekleme kipi tamamlamasının CTRL-N ve CTRL-P için nice çalıştığını\n"
 "belirler"
 
 msgid "whether to use a popup menu for Insert mode completion"
@@ -8739,7 +9016,8 @@ msgid "list of dictionary files for keyword completion"
 msgstr "anahtar sözcük tamamlaması için sözlük dosyaları listesi"
 
 msgid "list of thesaurus files for keyword completion"
-msgstr "anahtar sözcük tamamlaması için eşanlamlılar sözlüğü dosyaları\n"
+msgstr ""
+"anahtar sözcük tamamlaması için eşanlamlılar sözlüğü dosyaları\n"
 "listesi"
 
 msgid "adjust case of a keyword completion match"
@@ -8883,7 +9161,8 @@ msgid "markers used when 'foldmethod' is \"marker\""
 msgstr "'foldmethod' \"marker\" olduğunda kullanılan imleyiciler"
 
 msgid "maximum fold depth for when 'foldmethod' is \"indent\" or \"syntax\""
-msgstr "'foldmethod' \"indent\" veya \"syntax\" olduğunda kullanılan en çok\n"
+msgstr ""
+"'foldmethod' \"indent\" veya \"syntax\" olduğunda kullanılan en çok\n"
 "kıvırma derinliği"
 
 msgid "diff mode"
@@ -9013,7 +9292,8 @@ msgid "use a swap file for this buffer"
 msgstr "bu arabellek için bir takas dosyası kullan"
 
 msgid "\"sync\", \"fsync\" or empty; how to flush a swap file to disk"
-msgstr "\"sync\", \"fsync\", veya boş; bir takas dosyasının diske\n"
+msgstr ""
+"\"sync\", \"fsync\", veya boş; bir takas dosyasının diske\n"
 "nice floşlanacağı"
 
 msgid "number of characters typed to cause a swap file update"
@@ -9089,13 +9369,14 @@ msgid "characters to escape when 'shellxquote' is ("
 msgstr "'shellxquote' ( iken kaçırılacak karakterler"
 
 msgid "argument for 'shell' to execute a command"
-msgstr "bir komut çalıştırmak için 'shell' için değişken"
+msgstr "bir komut çalıştırmak için 'shell' için argüman"
 
 msgid "used to redirect command output to a file"
 msgstr "komut çıktısını bir dosyaya yeniden yönlendirmek için kullanılır"
 
 msgid "use a temp file for shell commands instead of using a pipe"
-msgstr "bir veri yolu kullanımı yerine kabuk komutları için geçici\n"
+msgstr ""
+"bir veri yolu kullanımı yerine kabuk komutları için geçici\n"
 "bir dosya kullan"
 
 msgid "program used for \"=\" command"
@@ -9108,7 +9389,8 @@ msgid "program used for the \"K\" command"
 msgstr "\"K\" komutu için kullanılan program"
 
 msgid "warn when using a shell command and a buffer has changes"
-msgstr "bir kabuk komutu kullanılıyorsa ve arabellekte değişiklikler\n"
+msgstr ""
+"bir kabuk komutu kullanılıyorsa ve arabellekte değişiklikler\n"
 "varsa uyar"
 
 msgid "running make and jumping to errors (quickfix)"
@@ -9124,7 +9406,8 @@ msgid "program used for the \":make\" command"
 msgstr "\":make\" komutu için kullanılan program"
 
 msgid "string used to put the output of \":make\" in the error file"
-msgstr "\":make\" komutunun çıktısını hata dosyasına koymak için\n"
+msgstr ""
+"\":make\" komutunun çıktısını hata dosyasına koymak için\n"
 "kullanılan dizi"
 
 msgid "name of the errorfile for the 'makeprg' command"
@@ -9179,7 +9462,8 @@ msgid "insert characters backwards"
 msgstr "karakterleri geriye doğru ekle"
 
 msgid "allow CTRL-_ in Insert and Command-line mode to toggle 'revins'"
-msgstr "'revins' açıp kapatmak için Ekleme ve Komut Satırı kipinde\n"
+msgstr ""
+"'revins' açıp kapatmak için Ekleme ve Komut Satırı kipinde\n"
 "CTRL-_ izin ver"
 
 msgid "the ASCII code for the first letter of the Hebrew alphabet"
@@ -9210,8 +9494,9 @@ msgid "apply 'langmap' to mapped characters"
 msgstr "eşlemlenen karakterlere 'langmap' uygula"
 
 msgid "when set never use IM; overrules following IM options"
-msgstr "ayarlandığında hiçbir zaman IM kullanma; aşağıdaki IM seçeneklerini "
-"geçersiz kılar"
+msgstr ""
+"ayarlandığında hiçbir zaman IM kullanma; aşağıdaki IM seçeneklerini geçersiz "
+"kılar"
 
 msgid "in Insert mode: 1: use :lmap; 2: use IM; 0: neither"
 msgstr "Ekleme kipinde: 1: :lmap kullan; 2; IM kullan; 0: hiçbiri"


### PR DESCRIPTION
https://github.com/vim/vim/commit/2346a6378483c9871016f9fc821ec5cbea638f13
https://github.com/vim/vim/commit/4d8f476176eadfc745bcb8e143460029048f858d
https://github.com/vim/vim/commit/90df4b9d423485f7db16e3a65cab4f14edc815ae
https://github.com/vim/vim/commit/6aa57295cfbe8f21c15f0671e45fd53cf990d404

This PR adds in the four missing runtime updates found by running `./scripts/vim-patch.sh -L --grep "Update runtime files" -- src`. This PR replaces former runtime update PR I opened [here](https://github.com/neovim/neovim/pull/15418) as that PR only pulled in the latest and not all the missing ones in order.