### PR TITLE
fix(lsp): handle missing client_id in error message

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -457,14 +457,18 @@ for k, fn in pairs(M) do
     })
 
     if err then
-      local client = vim.lsp.get_client_by_id(client_id)
-      local client_name = client and client.name or string.format("client_id=%d", client_id)
       -- LSP spec:
       -- interface ResponseError:
       --  code: integer;
       --  message: string;
       --  data?: string | number | boolean | array | object | null;
-      return err_message(client_name .. ': ' .. tostring(err.code) .. ': ' .. err.message)
+      if client_id then
+        local client = vim.lsp.get_client_by_id(client_id)
+        local client_name = client and client.name or string.format("client_id=%d", client_id)
+        return err_message(client_name .. ': ' .. tostring(err.code) .. ': ' .. err.message)
+      else
+        return err_message(tostring(err.code) .. ': ' .. err.message)
+      end
     end
 
     return fn(err, method, params, client_id, bufnr, config)


### PR DESCRIPTION
Repro with pyright:
1. nvim main.py
2. `:lua vim.lsp.buf.declaration()`
results in an error due to a missing client id 

> E5108: Error executing lua ...apped-master/share/nvim/runtime/lua/vim/lsp/handlers.lua:461: bad argument #2 to 'format' (number expected, got nil)     

This is due to this check: https://github.com/neovim/neovim/blob/968b4acd14568c9f9fed0dbace9527e3f7bbf493/runtime/lua/vim/lsp.lua#L1273-L1282

Which checks all clients attached to a given buffer. The error isn't on a particular client, but rather that no clients exist which support the method. The solution is to omit the client id in the error message.