### PR TITLE
fix(lsp): enable additional capabilities

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -1003,8 +1003,7 @@ function protocol.resolve_capabilities(server_capabilities)
   elseif type(server_capabilities.declarationProvider) == 'boolean' then
     general_properties.declaration = server_capabilities.declarationProvider
   elseif type(server_capabilities.declarationProvider) == 'table' then
-    -- TODO: support more detailed declarationProvider options.
-    general_properties.declaration = false
+    general_properties.declaration = server_capabilities.declarationProvider
   else
     error("The server sent invalid declarationProvider")
   end
@@ -1014,8 +1013,7 @@ function protocol.resolve_capabilities(server_capabilities)
   elseif type(server_capabilities.typeDefinitionProvider) == 'boolean' then
     general_properties.type_definition = server_capabilities.typeDefinitionProvider
   elseif type(server_capabilities.typeDefinitionProvider) == 'table' then
-    -- TODO: support more detailed typeDefinitionProvider options.
-    general_properties.type_definition = false
+    general_properties.type_definition = server_capabilities.typeDefinitionProvider
   else
     error("The server sent invalid typeDefinitionProvider")
   end
@@ -1025,8 +1023,7 @@ function protocol.resolve_capabilities(server_capabilities)
   elseif type(server_capabilities.implementationProvider) == 'boolean' then
     general_properties.implementation = server_capabilities.implementationProvider
   elseif type(server_capabilities.implementationProvider) == 'table' then
-    -- TODO(ashkan) support more detailed implementation options.
-    general_properties.implementation = false
+    general_properties.implementation = server_capabilities.implementationProvider
   else
     error("The server sent invalid implementationProvider")
   end


### PR DESCRIPTION
declaration, type-definition, and implementation providers were
previously disabled upon receiving table output from the server
capabilities. The workDoneProgress capability is sent for many servers
for all supported; default to setting capability to table instead of
false.

See, for example pyright, which previously had disabled declaration/type-definition providers despite being supported server side 

> [ DEBUG ] 2021-08-23T15:02:54-0400 ] ...ovim-unwrapped-master/share/nvim/runtime/lua/vim/lsp.lua:856 ]	"LSP[pyright]"	"server_capabilities"	{  callHierarchyProvider = true,  codeActionProvider = {    codeActionKinds = { "quickfix", "source.organizeImports" },    workDoneProgress = true  },  completionProvider = {    resolveProvider = true,    triggerCharacters = { ".", "[" },    workDoneProgress = true  },  declarationProvider = {    workDoneProgress = true  },  definitionProvider = {    workDoneProgress = true  },  documentHighlightProvider = {    workDoneProgress = true  },  documentSymbolProvider = {    workDoneProgress = true  },  executeCommandProvider = {    commands = {},    workDoneProgress = true  },  hoverProvider = {    workDoneProgress = true  },  referencesProvider = {    workDoneProgress = true  },  renameProvider = {    workDoneProgress = true  },  signatureHelpProvider = {    triggerCharacters = { "(", ",", ")" },    workDoneProgress = true  },  textDocumentSync = 2,  workspaceSymbolProvider = {    workDoneProgress = true  }}
