### PR TITLE
Send correct byte updates on visual paste

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3444,8 +3444,9 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
                          (int)y_size-1, lastsize, totsize,
                          kExtmarkUndo);
         } else if (y_type == kMTLineWise && flags & PUT_LINE_SPLIT) {
-          extmark_splice(curbuf, (int)new_cursor.lnum-1, col, 0, 0, 0,
-                         (int)y_size+1, 0, totsize+1, kExtmarkUndo);
+          // Account for last pasted NL + last NL
+          extmark_splice(curbuf, (int)new_cursor.lnum-1, col + 1, 0, 0, 0,
+                         (int)y_size+1, 0, totsize+2, kExtmarkUndo);
         }
       }
 

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -978,6 +978,22 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("visual paste", function()
+      local check_events= setup_eventcheck(verify, { "aaa {", "b", "}" })
+      -- Setting up
+      feed[[jdd]]
+      check_events {
+        { "test1", "bytes", 1, 3, 1, 0, 6, 1, 0, 2, 0, 0, 0 };
+      }
+
+      -- Actually testing
+      feed[[v%p]]
+      check_events {
+        { "test1", "bytes", 1, 8, 0, 4, 4, 1, 1, 3, 0, 0, 0 };
+        { "test1", "bytes", 1, 8, 0, 4, 4, 0, 0, 0, 2, 0, 3 };
+      }
+    end)
+
     it("nvim_buf_set_lines", function()
       local check_events = setup_eventcheck(verify, {"AAA", "BBB"})
 


### PR DESCRIPTION
One step more towards stable tree-sitter integration.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/1744.
