### PR TITLE
fix(lua): verify buffer in highlight.on_yank

### DIFF
--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -85,7 +85,11 @@ function highlight.on_yank(opts)
   highlight.range(bufnr, yank_ns, higroup, pos1, pos2, event.regtype, event.inclusive)
 
   vim.defer_fn(
-    function() api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1) end,
+    function()
+      if api.nvim_buf_is_valid(bufnr) then
+        api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
+      end
+    end,
     timeout
   )
 end

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -1,0 +1,24 @@
+local helpers = require('test.functional.helpers')(after_each)
+local funcs = helpers.funcs
+local exec_lua = helpers.exec_lua
+local command = helpers.command
+local clear = helpers.clear
+
+describe('vim.highlight.on_yank', function()
+
+  before_each(function()
+    clear()
+  end)
+
+  it('does not show errors even if buffer is wiped before timeout', function()
+    command('new')
+    local bufnr = funcs.bufnr("%")
+    exec_lua[[
+      vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y", regtype = "v"}})
+      vim.cmd('bwipeout!')
+    ]]
+    exec_lua[[vim.wait(10)]]
+    assert.no.exists_log([[vim/highlight.lua:%d+: Invalid buffer id: ]] .. bufnr)
+  end)
+
+end)

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -18,7 +18,9 @@ describe('vim.highlight.on_yank', function()
       vim.cmd('bwipeout!')
     ]]
     exec_lua[[vim.wait(10)]]
-    assert.no.exists_log([[vim/highlight.lua:%d+: Invalid buffer id: ]] .. bufnr)
+    local pattern = [[vim/highlight.lua:%d+: Invalid buffer id: ]] .. bufnr
+    local exists = pcall(helpers.assert_log, pattern)
+    assert.is_false(exists, string.format("%q should not be in log", pattern))
   end)
 
 end)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -116,6 +116,23 @@ function module.assert_log(pat, logfile)
     pat, nrlines, logfile, logtail))
 end
 
+local function exists_log(state, arguments, _)
+  local pat = arguments[1]
+  local logfile = arguments[2] or os.getenv('NVIM_LOG_FILE') or '.nvimlog'
+  local nrlines = 10
+  local lines = module.read_file_list(logfile, -nrlines) or {}
+  local log_msg = string.format('(last %d lines): %s:\n%s', nrlines, logfile, table.concat(lines, "\n"))
+  for _,line in ipairs(lines) do
+    if line:match(pat) then
+      state.failure_message = string.format('Pattern %q found in log%s', pat, log_msg)
+      return true
+    end
+  end
+  state.failure_message = string.format('Pattern %q not found in log%s', pat, log_msg)
+  return false
+end
+assert:register('assertion', 'exists_log', exists_log)
+
 -- Invokes `fn` and returns the error string (with truncated paths), or raises
 -- an error if `fn` succeeds.
 --

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -116,23 +116,6 @@ function module.assert_log(pat, logfile)
     pat, nrlines, logfile, logtail))
 end
 
-local function exists_log(state, arguments, _)
-  local pat = arguments[1]
-  local logfile = arguments[2] or os.getenv('NVIM_LOG_FILE') or '.nvimlog'
-  local nrlines = 10
-  local lines = module.read_file_list(logfile, -nrlines) or {}
-  local log_msg = string.format('(last %d lines): %s:\n%s', nrlines, logfile, table.concat(lines, "\n"))
-  for _,line in ipairs(lines) do
-    if line:match(pat) then
-      state.failure_message = string.format('Pattern %q found in log%s', pat, log_msg)
-      return true
-    end
-  end
-  state.failure_message = string.format('Pattern %q not found in log%s', pat, log_msg)
-  return false
-end
-assert:register('assertion', 'exists_log', exists_log)
-
 -- Invokes `fn` and returns the error string (with truncated paths), or raises
 -- an error if `fn` succeeds.
 --


### PR DESCRIPTION
This resolves an error the same with https://github.com/neovim/neovim/pull/14705 .
The differences are the followings:
- not to use pcall
- try to add a test

### Error message

```
Error executing vim.schedule lua callback: ...im/nvim-linux64/share/nvim/runtime/lua/vim/highlight.lua:88: Invalid buffer id: 2
```

### Reproduce code

```lua
vim.cmd("new")
local bufnr = vim.api.nvim_get_current_buf()
vim.highlight.on_yank({timeout = 50, on_macro = true, event = {operator = "y", regtype = "v"}})
vim.cmd("bw! " .. bufnr)
```
