### PR TITLE
refactor(edit)!: remove 'backspace' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -722,27 +722,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	done with ":syntax on".
 
 							*'backspace'* *'bs'*
-'backspace' 'bs'	string	(default "indent,eol,start")
-			global
-	Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
-	mode.  This is a list of items, separated by commas.  Each item allows
-	a way to backspace over something:
-	value	effect	~
-	indent	allow backspacing over autoindent
-	eol	allow backspacing over line breaks (join lines)
-	start	allow backspacing over the start of insert; CTRL-W and CTRL-U
-		stop once at the start of insert.
-	nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
-		insert.
-
-	When the value is empty, Vi compatible backspacing is used.
-
-	For backwards compatibility with version 5.4 and earlier:
-	value	effect	~
-	  0	same as ":set backspace=" (Vi compatible)
-	  1	same as ":set backspace=indent,eol"
-	  2	same as ":set backspace=indent,eol,start"
-	  3	same as ":set backspace=indent,eol,nostop"
+'backspace' 'bs'	Removed. |vim-differences|
+	Nvim always behaves as though 'backspace' is set to "indent,eol,start".
 
 				*'backup'* *'bk'* *'nobackup'* *'nobk'*
 'backup' 'bk'		boolean	(default off)

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -475,6 +475,7 @@ Highlight groups:
 
 Options:
   'antialias'
+  'backspace' ("indent,eol,start" is always used)
   'bioskey' (MS-DOS)
   'conskey' (MS-DOS)
   *'cp'* *'nocompatible'* *'nocp'* *'compatible'* (Nvim is always "nocompatible".)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3332,7 +3332,7 @@ static int ins_compl_bs(void)
   if ((int)(p - line) - (int)compl_col < 0
       || ((int)(p - line) - (int)compl_col == 0 && ctrl_x_mode != CTRL_X_OMNI)
       || ctrl_x_mode == CTRL_X_EVAL
-      || (!can_bs(BS_START) && (int)(p - line) - (int)compl_col
+      || (!can_bs() && (int)(p - line) - (int)compl_col
           - compl_length < 0)) {
     return K_BS;
   }
@@ -7980,8 +7980,7 @@ static void ins_del(void)
   }
   if (gchar_cursor() == NUL) {          // delete newline
     const int temp = curwin->w_cursor.col;
-    if (!can_bs(BS_EOL)  // only if "eol" included
-        || do_join(2, false, true, false, false) == FAIL) {
+    if (do_join(2, false, true, false, false) == FAIL) {
       vim_beep(BO_BS);
     } else {
       curwin->w_cursor.col = temp;
@@ -8051,13 +8050,10 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
   if (buf_is_empty(curbuf)
       || (!revins_on
           && ((curwin->w_cursor.lnum == 1 && curwin->w_cursor.col == 0)
-              || (!can_bs(BS_START)
+              || (!can_bs()
                   && (arrow_used
                       || (curwin->w_cursor.lnum == Insstart_orig.lnum
-                          && curwin->w_cursor.col <= Insstart_orig.col)))
-              || (!can_bs(BS_INDENT) && !arrow_used && ai_col > 0
-                  && curwin->w_cursor.col <= ai_col)
-              || (!can_bs(BS_EOL) && curwin->w_cursor.col == 0)))) {
+                          && curwin->w_cursor.col <= Insstart_orig.col)))))) {
     vim_beep(BO_BS);
     return false;
   }
@@ -8301,11 +8297,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         if (mode == BACKSPACE_CHAR) {
           break;
         }
-      } while (revins_on
-               || (curwin->w_cursor.col > mincol
-                   && (can_bs(BS_NOSTOP)
-                       || (curwin->w_cursor.lnum != Insstart_orig.lnum
-                           || curwin->w_cursor.col != Insstart_orig.col))));
+      } while (revins_on || curwin->w_cursor.col > mincol);
     }
     did_backspace = true;
   }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -281,16 +281,6 @@ enum {
 #define WIM_LIST        0x04
 #define WIM_BUFLASTUSED 0x08
 
-// arguments for can_bs()
-// each defined char should be unique over all values
-// except for BS_START, that intentionally also matches BS_NOSTOP
-// because BS_NOSTOP behaves exactly the same except it
-// does not stop at the start of the insert point
-#define BS_INDENT       'i'     // "Indent"
-#define BS_EOL          'l'     // "eoL"
-#define BS_START        's'     // "Start"
-#define BS_NOSTOP       'p'     // "nostoP
-
 // flags for the 'culopt' option
 #define CULOPT_LINE     0x01    // Highlight complete line
 #define CULOPT_SCRLINE  0x02    // Highlight screen line

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -7,7 +7,6 @@ endif
 let s:did_load = 1
 
 " Align Nvim defaults to Vim.
-set backspace=
 set directory^=.
 set fillchars=vert:\|,fold:-
 set laststatus=1

--- a/src/nvim/testdir/test_backspace_opt.vim
+++ b/src/nvim/testdir/test_backspace_opt.vim
@@ -1,6 +1,7 @@
 " Tests for 'backspace' settings
 
 func Test_backspace_option()
+  throw 'skipped: Nvim only supports backspace="indent,eol,start" #15484'
   set backspace=
   call assert_equal('', &backspace)
   set backspace=indent
@@ -79,6 +80,11 @@ func Test_backspace_ctrl_u()
   exe "normal Avim3\<C-U>\<Esc>\<CR>"
   iunmap <c-u>
   exe "normal Avim4\<C-U>\<C-U>\<Esc>\<CR>"
+
+  if has('nvim')
+    " Nvim only supports backspace="indent,eol,start" #15484
+    return
+  end
 
   " Test with backspace set to the compatible setting
   set backspace= visualbell

--- a/src/nvim/testdir/test_digraph.vim
+++ b/src/nvim/testdir/test_digraph.vim
@@ -245,8 +245,8 @@ func Test_digraphs_option()
   call Put_Dig_BS("P","=")
   call assert_equal(['Р']+repeat(["₽"],2)+['П'], getline(line('.')-3,line('.')))
   " Not a digraph: this is different from <c-k>!
-  call Put_Dig_BS("a","\<bs>")
-  call Put_Dig_BS("\<bs>","a")
+  call Put_Dig_BS("aa","\<bs>")
+  call Put_Dig_BS("aa\<bs>","a")
   call assert_equal(['','a'], getline(line('.')-1,line('.')))
   " Grave
   call Put_Dig_BS("a","!")

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -43,6 +43,7 @@ func Test_edit_01()
   call feedkeys("i\<del>\<esc>", 'tnix')
   call assert_equal([''], getline(1,'$'))
   %d
+  if !has('nvim') " 'backspace' removed in Nvim #15484
   " 5.1) delete linebreak with 'bs' option containing eol
   let _bs=&bs
   set bs=eol
@@ -58,6 +59,7 @@ func Test_edit_01()
   call feedkeys("A\<del>\<esc>", 'tnix')
   call assert_equal(["abc def", "ghi jkl"], getline(1, 2))
   let &bs=_bs
+  endif
   bw!
 endfunc
 

--- a/src/nvim/testdir/test_join.vim
+++ b/src/nvim/testdir/test_join.vim
@@ -264,7 +264,7 @@ action();
   call cursor(2, 1)
   set comments=s1:/*,mb:*,ex:*/,://
   set nojoinspaces fo=j
-  set backspace=eol,start
+  "set backspace=eol,start
 
   .,+3join
   exe "normal j4J\<CR>"
@@ -381,7 +381,7 @@ int i = 7 /* foo *// 3
   set comments+=s1:/*,mb:*,ex:*/,://
   set comments+=s1:>#,mb:#,ex:#<,:<
   set cpoptions-=j joinspaces fo=j
-  set backspace=eol,start
+  "set backspace=eol,start
 
   .,+3join
   exe "normal j4J\<CR>"

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -551,11 +551,13 @@ func Test_completion_respect_bs_option()
   new
   let li = ["aaa", "aaa12345", "aaaabcdef", "aaaABC"]
 
+  if !has('nvim')
   set bs=indent,eol
   call setline(1, li)
   1
   call feedkeys("A\<C-X>\<C-N>\<C-P>\<BS>\<BS>\<BS>\<Esc>", "tx")
   call assert_equal('aaa', getline(1))
+  endif
 
   %d
   set bs=indent,eol,start

--- a/src/nvim/testdir/test_tab.vim
+++ b/src/nvim/testdir/test_tab.vim
@@ -62,7 +62,7 @@ func Test_softtabstop()
   call assert_equal("x   x", getline(1))
 
   call setline(1, 'x       ')
-  set sts=0 sw=0 backspace=start
+  set sts=0 sw=0 "backspace=start
   exe "normal A\<BS>x\<Esc>"
   call assert_equal("x      x", getline(1))
 

--- a/test/functional/legacy/029_join_spec.lua
+++ b/test/functional/legacy/029_join_spec.lua
@@ -138,7 +138,6 @@ describe('joining lines', function()
     feed_command('/^{/+1')
     feed_command('set comments=s1:/*,mb:*,ex:*/,://')
     feed_command('set nojoinspaces')
-    feed_command('set backspace=eol,start')
 
     -- With 'joinspaces' switched off, join lines using both "J" and :join and
     -- verify that comment leaders are stripped or kept as appropriate.
@@ -196,24 +195,6 @@ describe('joining lines', function()
     feed('Avim3<c-u><esc><cr>')
     feed_command('iunmap <c-u>')
     feed('Avim4<c-u><c-u><esc><cr>')
-
-    -- Test with 'backspace' set to the compatible setting.
-    feed_command('set backspace=')
-    feed('A vim5<esc>A<c-u><c-u><esc><cr>')
-    feed('A vim6<esc>Azwei<c-g>u<c-u><esc><cr>')
-    feed_command('inoremap <c-u> <left><c-u>')
-    feed('A vim7<c-u><c-u><esc><cr>')
-
-    expect([[
-      1 this shouldn't be deleted
-      2 this shouldn't be deleted
-      3 this shouldn't be deleted
-      4 this should be deleted3
-      
-      6 this shouldn't be deleted vim5
-      7 this shouldn't be deleted vim6
-      8 this shouldn't be deleted (not touched yet) vim7
-      ]])
   end)
 
   it("removes comment leaders with 'joinspaces' on", function()
@@ -293,10 +274,9 @@ describe('joining lines', function()
     feed_command([[set comments=sO:*\ -,mO:*\ \ ,exO:*/]])
     feed_command('set comments+=s1:/*,mb:*,ex:*/,://')
     feed_command('set comments+=s1:>#,mb:#,ex:#<,:<')
-    feed_command('set backspace=eol,start')
 
-    -- With 'joinspaces' on (the default setting), again join lines and verify
-    -- that comment leaders are stripped or kept as appropriate.
+    -- With 'joinspaces' on, again join lines and verify that comment leaders
+    -- are stripped or kept as appropriate.
     feed_command('.,+3join')
     feed('j4J<cr>')
     feed_command('.,+8join')

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -188,8 +188,8 @@ describe('au OptionSet', function()
     end)
 
     it('should be called in setting backspace option through :let', function()
-      command('let &bs=""')
-      expected_combination({'backspace', 'indent,eol,start', '', 'global'})
+      command('let &bs="indent,eol,start"')
+      expected_combination({'backspace', 'indent,eol,start', 'indent,eol,start', 'global'})
     end)
 
     describe('being set by setbufvar()', function()


### PR DESCRIPTION
This weird option is never used and any value other than the default causes highly irregular behavior and is a remnant of the far distant past.
