### PR TITLE
fix(man.vim): filetype=man is too eager

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -6,14 +6,6 @@ if exists('b:did_ftplugin') || &filetype !=# 'man'
 endif
 let b:did_ftplugin = 1
 
-let s:pager = !exists('b:man_sect')
-
-if s:pager
-  call man#init_pager()
-endif
-
-setlocal noswapfile buftype=nofile bufhidden=hide
-setlocal nomodified readonly nomodifiable
 setlocal noexpandtab tabstop=8 softtabstop=8 shiftwidth=8
 setlocal wrap breakindent linebreak
 
@@ -32,11 +24,7 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> k             gk
   nnoremap <silent> <buffer> gO            :call man#show_toc()<CR>
   nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
-  if s:pager
-    nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
-  else
-    nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c
-  endif
+  nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c
 endif
 
 if get(g:, 'ft_man_folding_enable', 0)

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -6,7 +6,7 @@ endif
 let g:loaded_man = 1
 
 command! -bang -bar -range=-1 -complete=customlist,man#complete -nargs=* Man
-      \ if <bang>0 | set ft=man |
+      \ if <bang>0 | call man#init_pager() |
       \ else | call man#open_page(<count>, <q-mods>, <f-args>) | endif
 
 augroup man

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -27,11 +27,7 @@ if &filetype != 'man'
   finish
 endif
 
-if !exists('b:man_sect')
-  call man#init_pager()
-endif
-
-if b:man_sect =~# '^[023]'
+if get(b:, 'man_sect', '') =~# '^[023]'
   syntax case match
   syntax include @c $VIMRUNTIME/syntax/c.vim
   syntax match manCFuncDefinition display '\<\h\w*\>\ze\(\s\|\n\)*(' contained


### PR DESCRIPTION
Problem:
"set filetype=man" assumes the user wants :Man features, this does extra
stuff like renaming the buffer as "man://".

Solution:
- old entrypoint was ":set filetype=man", but this is too presumptuous
- make the entrypoints more explicit:
  1. when the ":Man" command is run
  2. when a "man://" buffer is opened
- remove the tricky b:man_sect checks in ftplugin/man.vim and syntax/man.vim
- MANPAGER is supported via ":Man!", as documented.

fixes #15487