### PR TITLE
Retain cursorlineopt=number in terminal mode

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -53,7 +53,7 @@ next key is sent unless it is <C-N>. Use <C-\><C-N> to return to normal-mode.
 
 Terminal-mode forces these local options:
 
-    'nocursorline'
+    'cursorlineopt' = number
     'nocursorcolumn'
     'scrolloff' = 0
     'sidescrolloff' = 0
@@ -171,7 +171,7 @@ program window	A terminal window for the executed program.  When "run" is
 
 The current window is used to show the source code.  When gdb pauses the
 source file location will be displayed, if possible.  A sign is used to
-highlight the current position, using highlight group debugPC.	 
+highlight the current position, using highlight group debugPC.
 
 If the buffer in the current window is modified, another window will be opened
 to display the current gdb position.
@@ -222,7 +222,7 @@ Put focus on the gdb window and type: >
 	run
 Vim will start running in the program window. Put focus there and type: >
 	:help gui
-Gdb will run into the ex_help breakpoint.  The source window now shows the 
+Gdb will run into the ex_help breakpoint.  The source window now shows the
 ex_cmds.c file.  A red "1 " marker will appear in the signcolumn where the
 breakpoint was set.  The line where the debugger stopped is highlighted.  You
 can now step through the program.  You will see the highlighting move as the

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -22,14 +22,28 @@ describe(':terminal buffer', function()
 
   it('terminal-mode forces various options', function()
     feed([[<C-\><C-N>]])
-    command('setlocal cursorline cursorcolumn scrolloff=4 sidescrolloff=7')
-    eq({ 1, 1, 4, 7 }, eval('[&l:cursorline, &l:cursorcolumn, &l:scrolloff, &l:sidescrolloff]'))
+    command('setlocal cursorline cursorlineopt=both cursorcolumn scrolloff=4 sidescrolloff=7')
+    eq({ 'both', 1, 1, 4, 7 }, eval('[&l:cursorlineopt, &l:cursorline, &l:cursorcolumn, &l:scrolloff, &l:sidescrolloff]'))
     eq('n', eval('mode()'))
 
     -- Enter terminal-mode ("insert" mode in :terminal).
     feed('i')
     eq('t', eval('mode()'))
-    eq({ 0, 0, 0, 0 }, eval('[&l:cursorline, &l:cursorcolumn, &l:scrolloff, &l:sidescrolloff]'))
+    eq({ 'number', 1, 0, 0, 0 }, eval('[&l:cursorlineopt, &l:cursorline, &l:cursorcolumn, &l:scrolloff, &l:sidescrolloff]'))
+  end)
+
+  it('terminal-mode does not change cursorlineopt if cursorline is disabled', function()
+    feed([[<C-\><C-N>]])
+    command('setlocal nocursorline cursorlineopt=both')
+    feed('i')
+    eq({ 0, 'both' }, eval('[&l:cursorline, &l:cursorlineopt]'))
+  end)
+
+  it('terminal-mode disables cursorline when cursorlineopt is only set to "line', function()
+    feed([[<C-\><C-N>]])
+    command('setlocal cursorline cursorlineopt=line')
+    feed('i')
+    eq({ 0, 'line' }, eval('[&l:cursorline, &l:cursorlineopt]'))
   end)
 
   describe('when a new file is edited', function()


### PR DESCRIPTION
When entering terminal mode, cursorlineopt is no longer entirely
disabled. Instead, it's set to `number`. Doing so ensures that users
using `set cursorline` combined with `set cursorlineopt=number` have
consistent highlighting of the line numbers, instead of this being
disabled when entering terminal mode.

The patch was suggested by Gregory Anders in comment
https://github.com/neovim/neovim/issues/15481#issuecomment-905742792.

This fixes https://github.com/neovim/neovim/issues/15481