### PR TITLE
test: fix `vim.highlight.on_yank's` meaningless test

### DIFF
--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -86,9 +86,9 @@ function highlight.on_yank(opts)
 
   vim.defer_fn(
     function()
-      if api.nvim_buf_is_valid(bufnr) then
+      -- if api.nvim_buf_is_valid(bufnr) then
         api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
-      end
+      -- end
     end,
     timeout
   )

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -86,9 +86,9 @@ function highlight.on_yank(opts)
 
   vim.defer_fn(
     function()
-      -- if api.nvim_buf_is_valid(bufnr) then
+      if api.nvim_buf_is_valid(bufnr) then
         api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
-      -- end
+      end
     end,
     timeout
   )

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
-local funcs = helpers.funcs
 local exec_lua = helpers.exec_lua
+local eq = helpers.eq
+local eval = helpers.eval
 local command = helpers.command
 local clear = helpers.clear
 
@@ -12,15 +13,13 @@ describe('vim.highlight.on_yank', function()
 
   it('does not show errors even if buffer is wiped before timeout', function()
     command('new')
-    local bufnr = funcs.bufnr("%")
     exec_lua[[
       vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y", regtype = "v"}})
       vim.cmd('bwipeout!')
     ]]
-    exec_lua[[vim.wait(10)]]
-    local pattern = [[vim/highlight.lua:%d+: Invalid buffer id: ]] .. bufnr
-    local exists = pcall(helpers.assert_log, pattern)
-    assert.is_false(exists, string.format("%q should not be in log", pattern))
+    helpers.sleep(10)
+    helpers.feed('<cr>') -- avoid hang if error message exists
+    eq('', eval('v:errmsg'))
   end)
 
 end)


### PR DESCRIPTION
To fix flaky test, I changed to check `v:errmsg` instead of log.
ref. https://github.com/neovim/neovim/pull/15482#discussion_r696715834
