### PR TITLE
fix(process_wait): drain proc.events directly

### DIFF
--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -200,9 +200,9 @@ int process_wait(Process *proc, int ms, MultiQueue *events)
   if (proc->refcount == 1) {
     // Job exited, free its resources.
     decref(proc);
-    if (events) {
+    if (proc->events) {
       // the decref call created an exit event, process it now
-      multiqueue_process_events(events);
+      multiqueue_process_events(proc->events);
     }
   } else {
     proc->refcount--;


### PR DESCRIPTION
After a process's refcnt is decremented to zero, it enqueues a
`process_close_event` on its own event queue. In `process_wait`, this
event should be processed immediately so that any process close
callbacks are executed before `process_wait` returns.

Update `process_wait` to always process the process's event queue after
the process is freed, rather than the event queue passed in as an
argument.

For some context, see [this discussion](https://github.com/neovim/neovim/pull/15402#discussion_r693424998).