### PR TITLE
feat(lsp)!: change handler signature

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1439,7 +1439,7 @@ goto_prev({opts})                             *vim.lsp.diagnostic.goto_prev()*
                     {opts}  table See |vim.lsp.diagnostic.goto_next()|
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
-on_publish_diagnostics({_}, {_}, {params}, {client_id}, {_}, {config})
+on_publish_diagnostics({_}, {result}, {ctx}, {config})
                 |lsp-handler| for the method "textDocument/publishDiagnostics"
 
                 Note:
@@ -1737,7 +1737,7 @@ get({bufnr})                                          *vim.lsp.codelens.get()*
                     table ( `CodeLens[]` )
 
                                               *vim.lsp.codelens.on_codelens()*
-on_codelens({err}, {_}, {result}, {client_id}, {bufnr})
+on_codelens({err}, {result}, {ctx}, {_})
                 |lsp-handler| for the method `textDocument/codeLens`
 
 refresh()                                         *vim.lsp.codelens.refresh()*
@@ -1765,8 +1765,7 @@ save({lenses}, {bufnr}, {client_id})                 *vim.lsp.codelens.save()*
 ==============================================================================
 Lua module: vim.lsp.handlers                                    *lsp-handlers*
 
-                                                    *vim.lsp.handlers.hover()*
-hover({_}, {method}, {result}, {_}, {_}, {config})
+hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
                 |lsp-handler| for the method "textDocument/hover" >
 
                  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
@@ -1784,7 +1783,7 @@ hover({_}, {method}, {result}, {_}, {_}, {config})
                                 • See |vim.api.nvim_open_win()|
 
                                            *vim.lsp.handlers.signature_help()*
-signature_help({_}, {method}, {result}, {client_id}, {bufnr}, {config})
+signature_help({_}, {result}, {ctx}, {config})
                 |lsp-handler| for the method "textDocument/signatureHelp". The
                 active parameter is highlighted with
                 |hl-LspSignatureActiveParameter|. >

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -202,23 +202,28 @@ responses and notifications from LSP servers.
 
 For |lsp-request|, each |lsp-handler| has this signature: >
 
-  function(err, method, result, client_id, bufnr, config)
+  function(err, result, ctx, config)
 <
         Parameters: ~
             {err}       (table|nil)
                             When the language server is unable to complete a
                             request, a table with information about the error
                             is sent. Otherwise, it is `nil`. See |lsp-response|.
-            {method}    (string)
-                            The |lsp-method| name.
             {result}    (Result | Params | nil)
                             When the language server is able to succesfully
                             complete a request, this contains the `result` key
                             of the response. See |lsp-response|.
-            {client_id} (number)
-                            The ID of the |vim.lsp.client|.
-            {bufnr}     (Buffer)
-                            Buffer handle, or 0 for current.
+            {ctx}       (table)
+                            Context describes additional calling state
+                            associated with the handler. It consists of the
+                            following key, value pairs:
+
+                            {method}    (string)
+                                            The |lsp-method| name.
+                            {client_id} (number)
+                                            The ID of the |vim.lsp.client|.
+                            {bufnr}     (Buffer)
+                                           Buffer handle, or 0 for current.
             {config}    (table)
                             Configuration for the handler.
 
@@ -238,21 +243,24 @@ For |lsp-request|, each |lsp-handler| has this signature: >
 
 For |lsp-notification|, each |lsp-handler| has this signature: >
 
-  function(err, method, params, client_id, bufnr, config)
+  function(err, result, ctx, config)
 <
         Parameters: ~
             {err}       (nil)
                             This is always `nil`.
                             See |lsp-notification|
-            {method}    (string)
-                            The |lsp-method| name.
-            {params}    (Params)
+            {result}    (Result)
                             This contains the `params` key of the notification.
                             See |lsp-notification|
-            {client_id} (number)
-                            The ID of the |vim.lsp.client|
-            {bufnr}     (nil)
-                            `nil`, as the server doesn't have an associated buffer.
+            {ctx}       (table)
+                            Context describes additional calling state
+                            associated with the handler. It consists of the
+                            following key, value pairs:
+
+                            {method}    (string)
+                                            The |lsp-method| name.
+                            {client_id} (number)
+                                            The ID of the |vim.lsp.client|.
             {config}    (table)
                             Configuration for the handler.
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1577,14 +1577,12 @@ validate({opt})                                               *vim.validate()*
 
                   vim.validate{arg1={{'foo'}, 'table'}, arg2={'foo', 'string'}}
                      => NOP (success)
-<
->
-    vim.validate{arg1={1, 'table'}}
-       => error('arg1: expected table, got number')
-<
->
-    vim.validate{arg1={3, function(a) return (a % 2) == 0 end, 'even number'}}
-       => error('arg1: expected even number, got 3')
+
+                  vim.validate{arg1={1, 'table'}}
+                     => error('arg1: expected table, got number')
+
+                  vim.validate{arg1={3, function(a) return (a % 2) == 0 end, 'even number'}}
+                     => error('arg1: expected even number, got 3')
 <
 
                 Parameters: ~

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -531,11 +531,9 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop})
       for id, node in pairs(match) do
         local name = query.captures[id]
         -- `node` was captured by the `name` capture in the match
-<
->
-    local node_data = metadata[id] -- Node level metadata
-<
->
+
+        local node_data = metadata[id] -- Node level metadata
+
         ... use the info here ...
       end
     end

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -433,7 +433,7 @@ local function code_action_request(params)
     for _, r in pairs(results) do
       vim.list_extend(actions, r.result or {})
     end
-    vim.lsp.handlers[method](nil, method, actions, nil, bufnr)
+    vim.lsp.handlers[method](nil, actions, {bufnr=bufnr, method=method})
   end)
 end
 

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -196,17 +196,17 @@ end
 
 --- |lsp-handler| for the method `textDocument/codeLens`
 ---
-function M.on_codelens(err, _, result, client_id, bufnr)
+function M.on_codelens(err, result, ctx, _)
   assert(not err, vim.inspect(err))
 
-  M.save(result, bufnr, client_id)
+  M.save(result, ctx.bufnr, ctx.client_id)
 
   -- Eager display for any resolved (and unresolved) lenses and refresh them
   -- once resolved.
-  M.display(result, bufnr, client_id)
-  resolve_lenses(result, bufnr, client_id, function()
-    M.display(result, bufnr, client_id)
-    active_refreshes[bufnr] = nil
+  M.display(result, ctx.bufnr, ctx.client_id)
+  resolve_lenses(result, ctx.bufnr, ctx.client_id, function()
+    M.display(result, ctx.bufnr, ctx.client_id)
+    active_refreshes[ctx.bufnr] = nil
   end)
 end
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1020,15 +1020,16 @@ end
 ---         - Update diagnostics in InsertMode or wait until InsertLeave
 ---     - severity_sort:    (default=false)
 ---         - Sort diagnostics (and thus signs and virtual text)
-function M.on_publish_diagnostics(_, _, params, client_id, _, config)
-  local uri = params.uri
+function M.on_publish_diagnostics(_, result, ctx, config)
+  local client_id = ctx.client_id
+  local uri = result.uri
   local bufnr = vim.uri_to_bufnr(uri)
 
   if not bufnr then
     return
   end
 
-  local diagnostics = params.diagnostics
+  local diagnostics = result.diagnostics
 
   if config and if_nil(config.severity_sort, false) then
     table.sort(diagnostics, function(a, b) return a.severity > b.severity end)
@@ -1204,15 +1205,17 @@ function M.redraw(bufnr, client_id)
   -- the user may have set with vim.lsp.with.
   vim.lsp.handlers["textDocument/publishDiagnostics"](
     nil,
-    "textDocument/publishDiagnostics",
     {
       uri = vim.uri_from_bufnr(bufnr),
       diagnostics = M.get(bufnr, client_id),
     },
-    client_id,
-    bufnr
-  )
-end
+    {
+      method = "textDocument/publishDiagnostics",
+      client_id = client_id,
+      bufnr = bufnr,
+    }
+    )
+  end
 
 -- }}}
 -- Diagnostic User Functions {{{

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -18,19 +18,20 @@ local function err_message(...)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_executeCommand
-M['workspace/executeCommand'] = function()
+M['workspace/executeCommand'] = function(_, _, _, _)
   -- Error handling is done implicitly by wrapping all handlers; see end of this file
 end
 
 ---@private
-local function progress_handler(_, _, params, client_id)
+local function progress_handler(_, result, ctx, _)
+  local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
   local client_name = client and client.name or string.format("id=%d", client_id)
   if not client then
     err_message("LSP[", client_name, "] client has shut down after sending the message")
   end
-  local val = params.value    -- unspecified yet
-  local token = params.token  -- string or number
+  local val = result.value    -- unspecified yet
+  local token = result.token  -- string or number
 
 
   if val.kind then
@@ -62,9 +63,10 @@ end
 M['$/progress'] = progress_handler
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_workDoneProgress_create
-M['window/workDoneProgress/create'] =  function(_, _, params, client_id)
+M['window/workDoneProgress/create'] =  function(_, result, ctx)
+  local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
-  local token = params.token  -- string or number
+  local token = result.token  -- string or number
   local client_name = client and client.name or string.format("id=%d", client_id)
   if not client then
     err_message("LSP[", client_name, "] client has shut down after sending the message")
@@ -74,11 +76,11 @@ M['window/workDoneProgress/create'] =  function(_, _, params, client_id)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_showMessageRequest
-M['window/showMessageRequest'] = function(_, _, params)
+M['window/showMessageRequest'] = function(_, result)
 
-  local actions = params.actions
-  print(params.message)
-  local option_strings = {params.message, "\nRequest Actions:"}
+  local actions = result.actions
+  print(result.message)
+  local option_strings = {result.message, "\nRequest Actions:"}
   for i, action in ipairs(actions) do
     local title = action.title:gsub('\r\n', '\\r\\n')
     title = title:gsub('\n', '\\n')
@@ -95,7 +97,8 @@ M['window/showMessageRequest'] = function(_, _, params)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_registerCapability
-M['client/registerCapability'] = function(_, _, _, client_id)
+M['client/registerCapability'] = function(_, _, ctx)
+  local client_id = ctx.client_id
   local warning_tpl = "The language server %s triggers a registerCapability "..
                       "handler despite dynamicRegistration set to false. "..
                       "Report upstream, this warning is harmless"
@@ -107,24 +110,24 @@ M['client/registerCapability'] = function(_, _, _, client_id)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
-M['textDocument/codeAction'] = function(_, _, actions)
-  if actions == nil or vim.tbl_isempty(actions) then
+M['textDocument/codeAction'] = function(_, result)
+  if result == nil or vim.tbl_isempty(result) then
     print("No code actions available")
     return
   end
 
-  local option_strings = {"Code Actions:"}
-  for i, action in ipairs(actions) do
+  local option_strings = {"Code actions:"}
+  for i, action in ipairs(result) do
     local title = action.title:gsub('\r\n', '\\r\\n')
     title = title:gsub('\n', '\\n')
     table.insert(option_strings, string.format("%d. %s", i, title))
   end
 
   local choice = vim.fn.inputlist(option_strings)
-  if choice < 1 or choice > #actions then
+  if choice < 1 or choice > #result then
     return
   end
-  local action_chosen = actions[choice]
+  local action_chosen = result[choice]
   -- textDocument/codeAction can return either Command[] or CodeAction[].
   -- If it is a CodeAction, it can have either an edit, a command or both.
   -- Edits should be executed first
@@ -155,28 +158,29 @@ M['workspace/applyEdit'] = function(_, _, workspace_edit)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_configuration
-M['workspace/configuration'] = function(_, _, params, client_id)
+M['workspace/configuration'] = function(_, result, ctx)
+  local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
   if not client then
     err_message("LSP[id=", client_id, "] client has shut down after sending the message")
     return
   end
-  if not params.items then
+  if not result.items then
     return {}
   end
 
-  local result = {}
-  for _, item in ipairs(params.items) do
+  local response = {}
+  for _, item in ipairs(result.items) do
     if item.section then
       local value = util.lookup_section(client.config.settings, item.section) or vim.NIL
       -- For empty sections with no explicit '' key, return settings as is
       if value == vim.NIL and item.section == '' then
         value = client.config.settings or vim.NIL
       end
-      table.insert(result, value)
+      table.insert(response, value)
     end
   end
-  return result
+  return response
 end
 
 M['textDocument/publishDiagnostics'] = function(...)
@@ -200,16 +204,16 @@ end
 ---@param map_result function `((resp, bufnr) -> list)` to convert the response
 ---@param entity name of the resource used in a `not found` error message
 local function response_to_list(map_result, entity)
-  return function(_, _, result, _, bufnr, config)
+  return function(_,result, ctx, config)
     if not result or vim.tbl_isempty(result) then
       vim.notify('No ' .. entity .. ' found')
     else
       config = config or {}
       if config.loclist then
-        util.set_loclist(map_result(result, bufnr))
+        util.set_loclist(map_result(result, ctx.bufnr))
         api.nvim_command("lopen")
       else
-        util.set_qflist(map_result(result, bufnr))
+        util.set_qflist(map_result(result, ctx.bufnr))
         api.nvim_command("copen")
       end
     end
@@ -227,25 +231,25 @@ M['textDocument/documentSymbol'] = response_to_list(util.symbols_to_items, 'docu
 M['workspace/symbol'] = response_to_list(util.symbols_to_items, 'symbols')
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename
-M['textDocument/rename'] = function(_, _, result)
+M['textDocument/rename'] = function(_, result, _)
   if not result then return end
   util.apply_workspace_edit(result)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting
-M['textDocument/rangeFormatting'] = function(_, _, result, _, bufnr)
+M['textDocument/rangeFormatting'] = function(_, result, ctx, _)
   if not result then return end
-  util.apply_text_edits(result, bufnr)
+  util.apply_text_edits(result, ctx.bufnr)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
-M['textDocument/formatting'] = function(_, _, result, _, bufnr)
+M['textDocument/formatting'] = function(_, result, ctx, _)
   if not result then return end
-  util.apply_text_edits(result, bufnr)
+  util.apply_text_edits(result, ctx.bufnr)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
-M['textDocument/completion'] = function(_, _, result)
+M['textDocument/completion'] = function(_, result, _, _)
   if vim.tbl_isempty(result or {}) then return end
   local row, col = unpack(api.nvim_win_get_cursor(0))
   local line = assert(api.nvim_buf_get_lines(0, row-1, row, false)[1])
@@ -270,9 +274,9 @@ end
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
 ---         - See |vim.api.nvim_open_win()|
-function M.hover(_, method, result, _, _, config)
+function M.hover(_, result, ctx, config)
   config = config or {}
-  config.focus_id = method
+  config.focus_id = ctx.method
   if not (result and result.contents) then
     -- return { 'No information available' }
     return
@@ -292,12 +296,12 @@ M['textDocument/hover'] = M.hover
 ---@private
 --- Jumps to a location. Used as a handler for multiple LSP methods.
 ---@param _ (not used)
----@param method (string) LSP method name
 ---@param result (table) result of LSP method; a location or a list of locations.
+---@param ctx (table) table containing the context of the request, including the method
 ---(`textDocument/definition` can return `Location` or `Location[]`
-local function location_handler(_, method, result)
+local function location_handler(_, result, ctx, _)
   if result == nil or vim.tbl_isempty(result) then
-    local _ = log.info() and log.info(method, 'No location found')
+    local _ = log.info() and log.info(ctx.method, 'No location found')
     return nil
   end
 
@@ -339,9 +343,9 @@ M['textDocument/implementation'] = location_handler
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
 ---         - See |vim.api.nvim_open_win()|
-function M.signature_help(_, method, result, client_id, bufnr, config)
+function M.signature_help(_, result, ctx, config)
   config = config or {}
-  config.focus_id = method
+  config.focus_id = ctx.method
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
@@ -350,9 +354,9 @@ function M.signature_help(_, method, result, client_id, bufnr, config)
     end
     return
   end
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
   local triggers = client.resolved_capabilities.signature_help_trigger_characters
-  local ft = api.nvim_buf_get_option(bufnr, 'filetype')
+  local ft = api.nvim_buf_get_option(ctx.bufnr, 'filetype')
   local lines, hl = util.convert_signature_help_to_markdown_lines(result, ft, triggers)
   lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
@@ -372,9 +376,9 @@ end
 M['textDocument/signatureHelp'] = M.signature_help
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
-M['textDocument/documentHighlight'] = function(_, _, result, _, bufnr, _)
+M['textDocument/documentHighlight'] = function(_, result, ctx, _)
   if not result then return end
-  util.buf_highlight_references(bufnr, result)
+  util.buf_highlight_references(ctx.bufnr, result)
 end
 
 ---@private
@@ -385,7 +389,7 @@ end
 ---@returns `CallHierarchyIncomingCall[]` if {direction} is `"from"`,
 ---@returns `CallHierarchyOutgoingCall[]` if {direction} is `"to"`,
 local make_call_hierarchy_handler = function(direction)
-  return function(_, _, result)
+  return function(_, result)
     if not result then return end
     local items = {}
     for _, call_hierarchy_call in pairs(result) do
@@ -411,9 +415,10 @@ M['callHierarchy/incomingCalls'] = make_call_hierarchy_handler('from')
 M['callHierarchy/outgoingCalls'] = make_call_hierarchy_handler('to')
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_logMessage
-M['window/logMessage'] = function(_, _, result, client_id)
+M['window/logMessage'] = function(_, result, ctx, _)
   local message_type = result.type
   local message = result.message
+  local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
   local client_name = client and client.name or string.format("id=%d", client_id)
   if not client then
@@ -432,9 +437,10 @@ M['window/logMessage'] = function(_, _, result, client_id)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#window_showMessage
-M['window/showMessage'] = function(_, _, result, client_id)
+M['window/showMessage'] = function(_, result, ctx, _)
   local message_type = result.type
   local message = result.message
+  local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
   local client_name = client and client.name or string.format("id=%d", client_id)
   if not client then
@@ -451,14 +457,14 @@ end
 
 -- Add boilerplate error validation and logging for all of these.
 for k, fn in pairs(M) do
-  M[k] = function(err, method, params, client_id, bufnr, config)
-    local _ = log.debug() and log.debug('default_handler', method, {
-      params = params, client_id = client_id, err = err, bufnr = bufnr, config = config
+  M[k] = function(err, result, ctx, config)
+    local _ = log.debug() and log.debug('default_handler', ctx.method, {
+      err = err, result = result, ctx=vim.inspect(ctx), config = config
     })
 
     if err then
-      local client = vim.lsp.get_client_by_id(client_id)
-      local client_name = client and client.name or string.format("client_id=%d", client_id)
+      local client = vim.lsp.get_client_by_id(ctx.client_id)
+      local client_name = client and client.name or string.format("client_id=%d", ctx.client_id)
       -- LSP spec:
       -- interface ResponseError:
       --  code: integer;
@@ -467,7 +473,7 @@ for k, fn in pairs(M) do
       return err_message(client_name .. ': ' .. tostring(err.code) .. ': ' .. err.message)
     end
 
-    return fn(err, method, params, client_id, bufnr, config)
+    return fn(err, result, ctx, config)
   end
 end
 

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -32,7 +32,7 @@ describe('vim.lsp.codelens', function()
           command = { title = 'Lens1', command = 'Dummy' }
         },
       }
-      vim.lsp.codelens.on_codelens(nil, 'textDocument/codeLens', lenses, 1, bufnr)
+      vim.lsp.codelens.on_codelens(nil, lenses, {method='textDocument/codeLens', client_id=1, bufnr=bufnr})
     ]], bufnr)
 
     local stored_lenses = exec_lua('return vim.lsp.codelens.get(...)', bufnr)

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -205,8 +205,8 @@ describe('vim.lsp.diagnostic', function()
             make_warning("Warning 1", 2, 1, 2, 5),
           }
 
-          vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_1_diags }, 1)
-          vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_2_diags }, 2)
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, { uri = fake_uri, diagnostics = server_1_diags }, {client_id=1})
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, { uri = fake_uri, diagnostics = server_2_diags }, {client_id=2})
           return {
             vim.lsp.diagnostic.get_count(diagnostic_bufnr, "Error", 1),
             vim.lsp.diagnostic.get_count(diagnostic_bufnr, "Warning", 2),
@@ -251,8 +251,8 @@ describe('vim.lsp.diagnostic', function()
             make_warning("Warning 1", 2, 1, 2, 5),
           }
 
-          vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_1_diags }, 1)
-          vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_2_diags }, 2)
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, { uri = fake_uri, diagnostics = server_1_diags }, {client_id=1})
+          vim.lsp.diagnostic.on_publish_diagnostics(nil, { uri = fake_uri, diagnostics = server_2_diags }, {client_id=2})
 
           vim.lsp.diagnostic.disable(diagnostic_bufnr, 1)
 
@@ -290,8 +290,8 @@ describe('vim.lsp.diagnostic', function()
               make_warning("Warning 1", 2, 1, 2, 5),
             }
 
-            vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_1_diags }, 1)
-            vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, { uri = fake_uri, diagnostics = server_2_diags }, 2)
+            vim.lsp.diagnostic.on_publish_diagnostics(nil, { uri = fake_uri, diagnostics = server_1_diags }, {client_id=1})
+            vim.lsp.diagnostic.on_publish_diagnostics(nil, { uri = fake_uri, diagnostics = server_2_diags }, {client_id=2})
             return {
               vim.lsp.diagnostic.get_count(diagnostic_bufnr, "Error", 1),
               vim.lsp.diagnostic.get_count(diagnostic_bufnr, "Warning", 2),
@@ -467,14 +467,14 @@ describe('vim.lsp.diagnostic', function()
 
     it('should return all diagnostics when no severity is supplied', function()
       eq(2, exec_lua [[
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, {
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
           uri = fake_uri,
           diagnostics = {
             make_error("Error 1", 1, 1, 1, 5),
             make_warning("Warning on Server 1", 1, 1, 2, 5),
             make_error("Error On Other Line", 2, 1, 1, 5),
           }
-        }, 1)
+        }, {client_id=1})
 
         return #vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1)
       ]])
@@ -482,7 +482,7 @@ describe('vim.lsp.diagnostic', function()
 
     it('should return only requested diagnostics when severity_limit is supplied', function()
       eq(2, exec_lua [[
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, {
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
           uri = fake_uri,
           diagnostics = {
             make_error("Error 1", 1, 1, 1, 5),
@@ -490,7 +490,7 @@ describe('vim.lsp.diagnostic', function()
             make_information("Ignored information", 1, 1, 2, 5),
             make_error("Error On Other Line", 2, 1, 1, 5),
           }
-        }, 1)
+        }, {client_id=1})
 
         return #vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1, { severity_limit = "Warning" })
       ]])
@@ -502,12 +502,12 @@ describe('vim.lsp.diagnostic', function()
       exec_lua [[
         vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
           virtual_text = function() return true end,
-        })(nil, nil, {
+        })(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
       ]]
 
@@ -519,12 +519,12 @@ describe('vim.lsp.diagnostic', function()
       exec_lua [[
         vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
           virtual_text = function() return false end,
-        })(nil, nil, {
+        })(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
       ]]
 
@@ -541,12 +541,12 @@ describe('vim.lsp.diagnostic', function()
       exec_lua [[
         vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
           update_in_insert = false,
-        })(nil, nil, {
+        })(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
       ]]
 
@@ -583,12 +583,12 @@ describe('vim.lsp.diagnostic', function()
           return SetVirtualTextOriginal(...)
         end
 
-        PublishDiagnostics(nil, nil, {
+        PublishDiagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
       ]]
 
@@ -637,12 +637,12 @@ describe('vim.lsp.diagnostic', function()
           return SetVirtualTextOriginal(...)
         end
 
-        PublishDiagnostics(nil, nil, {
+        PublishDiagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
       ]]
 
@@ -679,12 +679,12 @@ describe('vim.lsp.diagnostic', function()
       exec_lua [[
         vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
           update_in_insert = true,
-        })(nil, nil, {
+        })(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
       ]]
 
@@ -709,12 +709,12 @@ describe('vim.lsp.diagnostic', function()
           },
         })
 
-        PublishDiagnostics(nil, nil, {
+        PublishDiagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
 
         return vim.api.nvim_buf_get_extmarks(
@@ -746,12 +746,12 @@ describe('vim.lsp.diagnostic', function()
           end,
         })
 
-        PublishDiagnostics(nil, nil, {
+        PublishDiagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Delayed Diagnostic', 4, 4, 4, 4),
             }
-          }, 1
+          }, {client_id=1}
         )
 
         return vim.api.nvim_buf_get_extmarks(
@@ -779,12 +779,12 @@ describe('vim.lsp.diagnostic', function()
             },
           })
 
-          PublishDiagnostics(nil, nil, {
+          PublishDiagnostics(nil, {
               uri = fake_uri,
               diagnostics = {
                 make_warning('Delayed Diagnostic', 4, 4, 4, 4),
               }
-            }, 1
+            }, {client_id=1}
           )
 
           return count_of_extmarks_for_client(diagnostic_bufnr, 1)
@@ -870,10 +870,10 @@ describe('vim.lsp.diagnostic', function()
         }
 
         vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, {
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
             uri = fake_uri,
             diagnostics = diagnostics
-          }, 1
+          }, {client_id=1}
         )
 
         vim.lsp.diagnostic.set_signs(diagnostics, diagnostic_bufnr, 1)
@@ -895,13 +895,13 @@ describe('vim.lsp.diagnostic', function()
       local loc_list = exec_lua [[
         vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
 
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, {
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Farther Diagnostic', 4, 4, 4, 4),
               make_error('Lower Diagnostic', 1, 1, 1, 1),
             }
-          }, 1
+          }, {client_id=1}
         )
 
         vim.lsp.diagnostic.set_loclist()
@@ -916,20 +916,20 @@ describe('vim.lsp.diagnostic', function()
       local loc_list = exec_lua [[
         vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
 
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, {
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_error('Lower Diagnostic', 1, 1, 1, 1),
             }
-          }, 1
+          }, {client_id=1}
         )
 
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, nil, {
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
             uri = fake_uri,
             diagnostics = {
               make_warning('Farther Diagnostic', 4, 4, 4, 4),
             }
-          }, 2
+          }, {client_id=2}
         )
 
         vim.lsp.diagnostic.set_loclist()


### PR DESCRIPTION
Previously, the handler signature was:

  function(err, method, params, client_id, bufnr, config)

In order to better support external plugins that wish to extend the
protocol, there is other information which would be advantageous to
forward to the client, such as the original params of the request that
generated the callback.

In order to do this, we would need to break symmetry of the handlers, to
add an additional "params" as the 7th argument.

Instead, this PR changes the signature of the handlers to:

  function(err, result, context, config)

where context includes params, client_id, and bufnr. This also leaves
flexibility for future use-cases.

Todos:
- [x] fix tests
- [x] make sure I didn't break anything
- [x] update docs
- [x] warn plugin authors
- [x] Decide what to do about compatibility question