### PR TITLE
fix(lsp): check if buffer is valid in changetracking

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -381,7 +381,7 @@ do
       end
       state.pending_change = function()
         state.pending_change = nil
-        if client.is_stopped() then
+        if client.is_stopped() or not vim.api.nvim_buf_is_valid(bufnr) then
           return
         end
         local contentChanges


### PR DESCRIPTION
This tiny PR fixes an issue that occurs when the following conditions are met:

1. A client is initialized with the `debounce_text_changes` flag;
2. The client does not support incremental sync; and
3. A user modifies a buffer, then removes it from the buffer list before the timeout specified by `debounce_text_changes`. 

Currently, in this situation Neovim will attempt to get the buffer's content using `nvim_buf_get_lines`, which will throw an error when the buffer number is invalid. This PR fixes the issue by checking whether the buffer number is valid beforehand. 