### PR TITLE
fix(lua)!: make require() always prefer earlier dirs in rtp (fix #15497)

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -62,13 +62,13 @@ function vim._load_package(name)
     return f or error(err)
   end
 
-  local paths = {}
+  paths = {}
   for _,trail in ipairs(vim._so_trails) do
     table.insert(paths, "lua"..trail)
   end
-  local paths = table.concat(paths, " ")
-  local paths = paths:gsub('?', basename) -- so_trails contains a leading slash
-  local found = vim.api.nvim_get_runtime_file(paths, false)
+  paths = table.concat(paths, " ")
+  paths = paths:gsub('?', basename) -- so_trails contains a leading slash
+  found = vim.api.nvim_get_runtime_file(paths, false)
   if #found > 0 then
     -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is
     -- a) strip prefix up to and including the first dash, if any

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -55,29 +55,30 @@ end
 
 function vim._load_package(name)
   local basename = name:gsub('%.', '/')
-  local paths = {"lua/"..basename..".lua", "lua/"..basename.."/init.lua"}
-  for _,path in ipairs(paths) do
-    local found = vim.api.nvim_get_runtime_file(path, false)
-    if #found > 0 then
-      local f, err = loadfile(found[1])
-      return f or error(err)
-    end
+  local paths = "lua/"..basename..".lua lua/"..basename.."/init.lua"
+  local found = vim.api.nvim_get_runtime_file(paths, false)
+  if #found > 0 then
+    local f, err = loadfile(found[1])
+    return f or error(err)
   end
 
+  local paths = {}
   for _,trail in ipairs(vim._so_trails) do
-    local path = "lua"..trail:gsub('?', basename) -- so_trails contains a leading slash
-    local found = vim.api.nvim_get_runtime_file(path, false)
-    if #found > 0 then
-      -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is
-      -- a) strip prefix up to and including the first dash, if any
-      -- b) replace all dots by underscores
-      -- c) prepend "luaopen_"
-      -- So "foo-bar.baz" should result in "luaopen_bar_baz"
-      local dash = name:find("-", 1, true)
-      local modname = dash and name:sub(dash + 1) or name
-      local f, err = package.loadlib(found[1], "luaopen_"..modname:gsub("%.", "_"))
-      return f or error(err)
-    end
+    table.insert(paths, "lua"..trail)
+  end
+  local paths = table.concat(paths, " ")
+  local paths = paths:gsub('?', basename) -- so_trails contains a leading slash
+  local found = vim.api.nvim_get_runtime_file(paths, false)
+  if #found > 0 then
+    -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is
+    -- a) strip prefix up to and including the first dash, if any
+    -- b) replace all dots by underscores
+    -- c) prepend "luaopen_"
+    -- So "foo-bar.baz" should result in "luaopen_bar_baz"
+    local dash = name:find("-", 1, true)
+    local modname = dash and name:sub(dash + 1) or name
+    local f, err = package.loadlib(found[1], "luaopen_"..modname:gsub("%.", "_"))
+    return f or error(err)
   end
   return nil
 end


### PR DESCRIPTION
Currently, if `runtimepath` is `a,b`, `require()` loads the first module found with this search order:
1. a/lua/mod.lua
2. b/lua/mod.lua
3. a/lua/mod/init.lua
4. b/lua/mod/init.lua

This changes the search order to:
1. a/lua/mod.lua
2. a/lua/mod/init.lua
3. b/lua/mod.lua
4. b/lua/mod/init.lua

This also changes the .so search order to act similarly, preferring earlier rtp position over position in `_so_trails`, although at least on Linux `_so_trails` only has one entry by default.

This is technically a breaking change, but I doubt many configurations in the wild rely on this behaviour. If a local copy of a module exists in a directory found earlier in `runtimepath` than its original and both use either the `mod.lua` or `mod/init.lua` pattern, this does not affect which module gets loaded.

If this is merged, it should be merged before #15491 so that PR can be updated to correctly reference the new search order.

Fixes #15497