### PR TITLE
feat(api): nvim_select_popupmenu_item() finish completion even if pum not visible

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2844,7 +2844,8 @@ Object nvim_get_proc(Integer pid, Error *err)
 /// ensure the mapping doesn't end completion mode.
 ///
 /// @param item   Index (zero-based) of the item to select. Value of -1 selects
-///               nothing and restores the original text.
+///               nothing and restores the original text. If value is neither
+///               -1 nor a valid index, this API call is silently ignored.
 /// @param insert Whether the selection should be inserted in the buffer.
 /// @param finish Finish the completion and dismiss the popupmenu. Implies
 ///               `insert`.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1042,12 +1042,13 @@ check_pum:
     if (pum_want.active) {
       if (pum_visible()) {
         insert_do_complete(s);
-        if (pum_want.finish) {
-          // accept the item and stop completion
-          ins_compl_prep(Ctrl_Y);
-        }
       }
       pum_want.active = false;
+    }
+    if (pum_want.finish) {
+      // accept the item and stop completion
+      ins_compl_prep(Ctrl_Y);
+      pum_want.finish = false;
     }
     break;
 
@@ -4757,6 +4758,9 @@ ins_compl_next (
 void pum_ext_select_item(int item, bool insert, bool finish)
 {
   if (!pum_visible() || item < -1 || item >= compl_match_arraysize) {
+    if (compl_started && item == -1) {
+      pum_want.finish = finish;
+    }
     return;
   }
   pum_want.active = true;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -256,6 +256,22 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|
       {2:-- INSERT --}                                                |
     ]])
+    eq('i', eval('nvim_get_mode().mode'))
+
+    feed('<C-r>=TestComplete()<CR><c-p>aaa')
+    screen:expect([[
+                                                                  |
+      aaa^                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]])
+    eq('ic', eval('nvim_get_mode().mode'))
+    meths.select_popupmenu_item(-1,true,true,{})
+    eq('i', eval('nvim_get_mode().mode'))
 
     command('imap <f1> <cmd>call nvim_select_popupmenu_item(2,v:true,v:false,{})<cr>')
     command('imap <f2> <cmd>call nvim_select_popupmenu_item(-1,v:false,v:false,{})<cr>')


### PR DESCRIPTION
This is related to <https://github.com/ms-jpq/coq_nvim/pull/122>. `coq_nvim` calls `complete()` asynchronously on every keystroke, when there are no matches pum is not shown Neovim is still in `ins-completion` mode, which makes `i_CTRL-E` hard to use. I first tried to make it feed `complete_CTRL-E` when there are no matches, but it seems to break something. `nvim_select_popupmenu_item()` is the closest function that can achieve this purpose, but currently it doesn't end `ins-completion` if pum is not visible.

This PR makes `nvim_select_popupmenu_item(-1, true, true, {})` finish `ins-completion` even if pum is not visible. The documentation also says it is ignored when `ins-completion` is not active, so it shouldn't be ignored in this case.