### PR TITLE
perf(api): avoid spurious allocations when converting small objects

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -29,7 +29,7 @@ set(API_UI_EVENTS_GENERATOR ${GENERATOR_DIR}/gen_api_ui_events.lua)
 set(GENERATOR_C_GRAMMAR ${GENERATOR_DIR}/c_grammar.lua)
 set(API_METADATA ${PROJECT_BINARY_DIR}/api_metadata.mpack)
 set(FUNCS_DATA ${PROJECT_BINARY_DIR}/funcs_data.mpack)
-set(MSGPACK_LUA_C_BINDINGS ${GENERATED_DIR}/msgpack_lua_c_bindings.generated.c)
+set(LUA_API_C_BINDINGS ${GENERATED_DIR}/lua_api_c_bindings.generated.c)
 set(HEADER_GENERATOR ${GENERATOR_DIR}/gen_declarations.lua)
 set(GENERATED_INCLUDES_DIR ${PROJECT_BINARY_DIR}/include)
 set(GENERATED_API_DISPATCH ${GENERATED_DIR}/api/private/dispatch_wrappers.generated.h)
@@ -305,11 +305,11 @@ add_custom_command(OUTPUT ${GENERATED_UNICODE_TABLES}
 
 add_custom_command(
   OUTPUT ${GENERATED_API_DISPATCH} ${GENERATED_FUNCS_METADATA}
-         ${API_METADATA} ${MSGPACK_LUA_C_BINDINGS}
+         ${API_METADATA} ${LUA_API_C_BINDINGS}
   COMMAND ${LUA_PRG} ${API_DISPATCH_GENERATOR} ${CMAKE_CURRENT_LIST_DIR}
                      ${GENERATED_API_DISPATCH}
                      ${GENERATED_FUNCS_METADATA} ${API_METADATA}
-                     ${MSGPACK_LUA_C_BINDINGS}
+                     ${LUA_API_C_BINDINGS}
                      ${API_HEADERS}
   DEPENDS
     ${API_HEADERS}
@@ -333,7 +333,7 @@ add_custom_command(
 )
 
 list(APPEND NVIM_GENERATED_SOURCES
-  "${MSGPACK_LUA_C_BINDINGS}"
+  "${LUA_API_C_BINDINGS}"
 )
 
 add_custom_command(

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -7,7 +7,7 @@ if arg[1] == '--help' then
   print('      2: dispatch output file (dispatch_wrappers.generated.h)')
   print('      3: functions metadata output file (funcs_metadata.generated.h)')
   print('      4: API metadata output file (api_metadata.mpack)')
-  print('      5: lua C bindings output file (msgpack_lua_c_bindings.generated.c)')
+  print('      5: lua C bindings output file (lua_api_c_bindings.generated.c)')
   print('      rest: C files where API functions are defined')
 end
 assert(#arg >= 4)
@@ -378,7 +378,7 @@ output:write('\n')
 local lua_c_functions = {}
 
 local function process_function(fn)
-  local lua_c_function_name = ('nlua_msgpack_%s'):format(fn.name)
+  local lua_c_function_name = ('nlua_api_%s'):format(fn.name)
   write_shifted_output(output, string.format([[
 
   static int %s(lua_State *lstate)

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -86,8 +86,9 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
   FUNC_ATTR_NONNULL_ALL
 {
   bool ret = true;
-  kvec_t(MPToAPIObjectStackItem) stack = KV_INITIAL_VALUE;
-  kv_push(stack, ((MPToAPIObjectStackItem) {
+  kvec_withinit_t(MPToAPIObjectStackItem, 2) stack = KV_INITIAL_VALUE;
+  kvi_init(stack);
+  kvi_push(stack, ((MPToAPIObjectStackItem) {
     .mobj = obj,
     .aobj = arg,
     .container = false,
@@ -155,7 +156,7 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
             const size_t idx = cur.idx;
             cur.idx++;
             kv_last(stack) = cur;
-            kv_push(stack, ((MPToAPIObjectStackItem) {
+            kvi_push(stack, ((MPToAPIObjectStackItem) {
               .mobj = &cur.mobj->via.array.ptr[idx],
               .aobj = &cur.aobj->data.array.items[idx],
               .container = false,
@@ -209,7 +210,7 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
               }
             }
             if (ret) {
-              kv_push(stack, ((MPToAPIObjectStackItem) {
+              kvi_push(stack, ((MPToAPIObjectStackItem) {
                 .mobj = &cur.mobj->via.map.ptr[idx].val,
                 .aobj = &cur.aobj->data.dictionary.items[idx].value,
                 .container = false,
@@ -265,7 +266,7 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
       (void)kv_pop(stack);
     }
   }
-  kv_destroy(stack);
+  kvi_destroy(stack);
   return ret;
 }
 
@@ -375,8 +376,9 @@ typedef struct {
 void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
   FUNC_ATTR_NONNULL_ARG(2)
 {
-  kvec_t(APIToMPObjectStackItem) stack = KV_INITIAL_VALUE;
-  kv_push(stack, ((APIToMPObjectStackItem) { &result, false, 0 }));
+  kvec_withinit_t(APIToMPObjectStackItem, 2) stack = KV_INITIAL_VALUE;
+  kvi_init(stack);
+  kvi_push(stack, ((APIToMPObjectStackItem) { &result, false, 0 }));
   while (kv_size(stack)) {
     APIToMPObjectStackItem cur = kv_last(stack);
     STATIC_ASSERT(kObjectTypeWindow == kObjectTypeBuffer + 1
@@ -428,7 +430,7 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
             const size_t idx = cur.idx;
             cur.idx++;
             kv_last(stack) = cur;
-            kv_push(stack, ((APIToMPObjectStackItem) {
+            kvi_push(stack, ((APIToMPObjectStackItem) {
               .aobj = &cur.aobj->data.array.items[idx],
               .container = false,
             }));
@@ -451,7 +453,7 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
             kv_last(stack) = cur;
             msgpack_rpc_from_string(cur.aobj->data.dictionary.items[idx].key,
                                     res);
-            kv_push(stack, ((APIToMPObjectStackItem) {
+            kvi_push(stack, ((APIToMPObjectStackItem) {
               .aobj = &cur.aobj->data.dictionary.items[idx].value,
               .container = false,
             }));
@@ -468,7 +470,7 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
       (void)kv_pop(stack);
     }
   }
-  kv_destroy(stack);
+  kvi_destroy(stack);
 }
 
 void msgpack_rpc_from_array(Array result, msgpack_packer *res)


### PR DESCRIPTION
A small fix broken out of a larger upcoming perf/refactor.

Converter functions like `nlua_pop_Object` use a heap-allocated stack to handle complex nested objects. However, these are often called with simple, primitive values like integers or bools wrapped in an Object. Avoid the extra memory allocation in this case using kvec_withinit_t.

Also rename `nlua_msgpack_` as it has nothing to do with msgpack. it made more sense back in the day when for a long time msgpack used to _use to be_ the only way to access this API.
