### PR TITLE
chore(flake): fix for recent nixpkgs

### DIFF
--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1625697353,
-        "narHash": "sha256-/v85RkZ0Z+lxipkG2sjYNRINktc8VySbLQmPbirY0hQ=",
+        "lastModified": 1630074300,
+        "narHash": "sha256-BFM7OiXRs0RvSUZd6NCGAKWVPn3VodgYQ4TUQXxbMBU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "87807e64a5ef5206b745a40af118c7be8db73681",
+        "rev": "21c937f8cb1e6adcfeb36dfd6c90d9d9bfab1d28",
         "type": "github"
       },
       "original": {

--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -20,12 +20,16 @@
 
           # a development binary to help debug issues
           neovim-debug = let
-            stdenv = pkgs.stdenvAdapters.keepDebugInfo (if pkgs.stdenv.isLinux then pkgs.llvmPackages_latest.stdenv else pkgs.stdenv);
+            stdenv = if pkgs.stdenv.isLinux then pkgs.llvmPackages_latest.stdenv else pkgs.stdenv;
           in
-            pkgs.enableDebugging ((neovim.override {
-            lua = pkgs.enableDebugging pkgs.luajit;
+            ((neovim.override {
+            lua = pkgs.luajit;
             inherit stdenv;
           }).overrideAttrs (oa: {
+
+            dontStrip = true;
+            NIX_CFLAGS_COMPILE = " -ggdb -Og";
+
             cmakeBuildType = "Debug";
             cmakeFlags = oa.cmakeFlags ++ [
               "-DMIN_LOG_LEVEL=0"


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/134463 made keepDebugInfo obsolete
for generic packages.
This copies what keepDebugInfo used to do.