### PR TITLE
fix(lsp): resolve bufnr in buf_is_attached

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1152,7 +1152,7 @@ end
 ---@param bufnr (number) Buffer handle, or 0 for current
 ---@param client_id (number) the client id
 function lsp.buf_is_attached(bufnr, client_id)
-  return (all_buffer_active_clients[bufnr] or {})[client_id] == true
+  return (all_buffer_active_clients[resolve_bufnr(bufnr)] or {})[client_id] == true
 end
 
 --- Gets a client by id, or nil if the id is invalid.


### PR DESCRIPTION
The documentation for `lsp.buf_is_attached` states that the first argument can be `0` to get the current buffer handle. However, since `bufnr` is passed as-is, `0` doesn't currently work. 

This PR uses `resolve_bufnr` to make `0` work as described in the documentation. 