### PR TITLE
fix(lua): make core vim module not dependent on $VIMRUNTIME modules

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -56,6 +56,8 @@ set(VIM_MODULE_FILE ${GENERATED_DIR}/lua/vim_module.generated.h)
 set(LUA_VIM_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/src/nvim/lua/vim.lua)
 set(LUA_SHARED_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/shared.lua)
 set(LUA_INSPECT_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/inspect.lua)
+set(LUA_F_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/F.lua)
+set(LUA_META_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/_meta.lua)
 set(CHAR_BLOB_GENERATOR ${GENERATOR_DIR}/gen_char_blob.lua)
 set(LINT_SUPPRESS_FILE ${PROJECT_BINARY_DIR}/errors.json)
 set(LINT_SUPPRESS_URL_BASE "https://raw.githubusercontent.com/neovim/doc/gh-pages/reports/clint")
@@ -325,11 +327,15 @@ add_custom_command(
       ${LUA_VIM_MODULE_SOURCE} vim_module
       ${LUA_SHARED_MODULE_SOURCE} shared_module
       ${LUA_INSPECT_MODULE_SOURCE} inspect_module
+      ${LUA_F_MODULE_SOURCE} lua_F_module
+      ${LUA_META_MODULE_SOURCE} lua_meta_module
   DEPENDS
     ${CHAR_BLOB_GENERATOR}
     ${LUA_VIM_MODULE_SOURCE}
     ${LUA_SHARED_MODULE_SOURCE}
     ${LUA_INSPECT_MODULE_SOURCE}
+    ${LUA_F_MODULE_SOURCE}
+    ${LUA_META_MODULE_SOURCE}
 )
 
 list(APPEND NVIM_GENERATED_SOURCES

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -544,8 +544,17 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
       return 1;
     }
     // [package, loaded, inspect]
-
     lua_setfield(lstate, -2, "vim.inspect");  // [package, loaded]
+
+    code = (char *)&lua_F_module[0];
+    if (luaL_loadbuffer(lstate, code, strlen(code), "@vim/F.lua")
+        || lua_pcall(lstate, 0, 1, 0)) {
+      nlua_error(lstate, _("E5106: Error while creating vim.F module: %.*s"));
+      return 1;
+    }
+    // [package, loaded, module]
+    lua_setfield(lstate, -2, "vim.F");  // [package, loaded]
+
     lua_pop(lstate, 2);  // []
   }
 
@@ -556,6 +565,22 @@ static int nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
       nlua_error(lstate, _("E5106: Error while creating vim module: %.*s"));
       return 1;
     }
+  }
+
+  {
+    lua_getglobal(lstate, "package");  // [package]
+    lua_getfield(lstate, -1, "loaded");  // [package, loaded]
+
+    const char *code = (char *)&lua_meta_module[0];
+    if (luaL_loadbuffer(lstate, code, strlen(code), "@vim/_meta.lua")
+        || lua_pcall(lstate, 0, 1, 0)) {
+      nlua_error(lstate, _("E5106: Error while creating vim._meta module: %.*s"));
+      return 1;
+    }
+    // [package, loaded, module]
+    lua_setfield(lstate, -2, "vim._meta");  // [package, loaded]
+
+    lua_pop(lstate, 2);  // []
   }
 
   return 0;

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -642,6 +642,4 @@ vim._expand_pat_get_parts = function(lua_string)
   return parts, search_index
 end
 
-pcall(require, 'vim._meta')
-
 return module


### PR DESCRIPTION
fixes #15524

Note: this is obviously a quickfix. A scalabe solution will involve being able to specify a _list_ of modules in cmakelists, to be put into ` packages.preload`, without needing to manually copypasta a blurb of C code. Perhaps even involving bytecode for static builds (to speedup initialization)