### PR TITLE
refactor(tests): use assert_alive()

### DIFF
--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -12,6 +12,7 @@ local feed = helpers.feed
 local clear = helpers.clear
 local command = helpers.command
 local meths = helpers.meths
+local assert_alive = helpers.assert_alive
 
 local function expect(contents)
   return eq(contents, helpers.curbuf_contents())
@@ -1381,13 +1382,13 @@ describe('API/extmarks', function()
   end)
 
   it('does not crash with append/delete/undo seqence', function()
-     meths.exec([[
+    meths.exec([[
       let ns = nvim_create_namespace('myplugin')
       call nvim_buf_set_extmark(0, ns, 0, 0, {})
       call append(0, '')
       %delete
       undo]],false)
-    eq(2, meths.eval('1+1')) -- did not crash
+    assert_alive()
   end)
 
   it('works with left and right gravity', function()

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -11,6 +11,7 @@ local meths = helpers.meths
 local spawn, merge_args = helpers.spawn, helpers.merge_args
 local set_session = helpers.set_session
 local pcall_err = helpers.pcall_err
+local assert_alive = helpers.assert_alive
 
 describe('server -> client', function()
   local cid
@@ -33,7 +34,7 @@ describe('server -> client', function()
 
       call jobstop(ch1)
     ]])
-    eq(2, eval("1+1"))  -- Still alive?
+    assert_alive()
   end)
 
   describe('simple call', function()
@@ -158,7 +159,7 @@ describe('server -> client', function()
           -- do some busywork, so the first request will return
           -- before this one
           for _ = 1, 5 do
-            eq(2, eval("1+1"))
+            assert_alive()
           end
           eq(1, eval('rpcnotify('..cid..', "nested_done")'))
           return 'done!'

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
 local fmt = string.format
+local assert_alive = helpers.assert_alive
 local NIL = helpers.NIL
 local clear, nvim, eq, neq = helpers.clear, helpers.nvim, helpers.eq, helpers.neq
 local command = helpers.command
@@ -58,7 +59,7 @@ describe('API', function()
     eq({'notification', 'nvim_error_event',
         {error_types.Exception.id, 'Invalid method: nvim_bogus'}}, next_msg())
     -- error didn't close channel.
-    eq(2, eval('1+1'))
+    assert_alive()
   end)
 
   it('failed async request emits nvim_error_event', function()
@@ -68,7 +69,7 @@ describe('API', function()
         {error_types.Exception.id, 'Vim:E492: Not an editor command: bogus'}},
         next_msg())
     -- error didn't close channel.
-    eq(2, eval('1+1'))
+    assert_alive()
   end)
 
   it('does not set CA_COMMAND_BUSY #7254', function()

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 
+local assert_alive = helpers.assert_alive
 local command = helpers.command
 local feed_command = helpers.feed_command
 local eval = helpers.eval
@@ -53,7 +54,7 @@ describe(':cquit', function()
     if redir_msg then
       eq('\n' .. redir_msg, redir_exec(cmdline))
       poke_eventloop()
-      eq(2, eval("1+1"))  -- Still alive?
+      assert_alive()
     else
       funcs.system({nvim_prog, '-u', 'NONE', '-i', 'NONE', '--headless', '--cmd', cmdline})
       eq(exit_code, eval('v:shell_error'))

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
+local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local command = helpers.command
 local ok = helpers.ok
@@ -231,7 +232,7 @@ describe('startup', function()
 
   it('does not crash if --embed is given twice', function()
     clear{args={'--embed'}}
-    eq(2, eval('1+1'))
+    assert_alive()
   end)
 
   it('does not crash when expanding cdpath during early_init', function()

--- a/test/functional/eval/modeline_spec.lua
+++ b/test/functional/eval/modeline_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
+local assert_alive = helpers.assert_alive
 local clear, command, write_file = helpers.clear, helpers.command, helpers.write_file
-local eq, eval = helpers.eq, helpers.eval
 
 describe("modeline", function()
   local tempfile = helpers.tmpname()
@@ -14,6 +14,6 @@ describe("modeline", function()
     write_file(tempfile, 'vim100000000000000000000000')
     command('e! ' .. tempfile)
 
-    eq(2, eval('1+1'))  -- Still alive?
+    assert_alive()
   end)
 end)

--- a/test/functional/eval/system_spec.lua
+++ b/test/functional/eval/system_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 
+local assert_alive = helpers.assert_alive
 local nvim_dir = helpers.nvim_dir
 local eq, call, clear, eval, feed_command, feed, nvim =
   helpers.eq, helpers.call, helpers.clear, helpers.eval, helpers.feed_command,
@@ -302,7 +303,7 @@ describe('system()', function()
       if v_errnum then
         eq("E5677:", v_errnum)
       end
-      eq(2, eval("1+1"))  -- Still alive?
+      assert_alive()
     end)
   end)
 
@@ -317,11 +318,11 @@ describe('system()', function()
       if v_errnum then
         eq("E5677:", v_errnum)
       end
-      eq(2, eval("1+1"))  -- Still alive?
+      assert_alive()
     end)
     it('works with an empty string', function()
       eq("test\n", eval('system("echo test", "")'))
-      eq(2, eval("1+1"))  -- Still alive?
+      assert_alive()
     end)
   end)
 

--- a/test/functional/ex_cmds/dict_notifications_spec.lua
+++ b/test/functional/ex_cmds/dict_notifications_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local assert_alive = helpers.assert_alive
 local clear, nvim, source = helpers.clear, helpers.nvim, helpers.source
 local insert = helpers.insert
 local eq, next_msg = helpers.eq, helpers.next_msg
@@ -325,7 +326,7 @@ describe('VimL dictionary notifications', function()
       ]])
 
       command('call MakeWatch()')
-      eq(2, eval('1+1')) -- Still alive?
+      assert_alive()
     end)
   end)
 
@@ -354,7 +355,7 @@ describe('VimL dictionary notifications', function()
 
     command([[call dictwatcherdel(b:, 'changedtick', 'OnTickChanged')]])
     insert('t');
-    eq(2, eval('1+1')) -- Still alive?
+    assert_alive()
   end)
 
   it('does not cause use-after-free when unletting from callback', function()

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local lfs = require('lfs')
 local eq, eval, expect, source =
   helpers.eq, helpers.eval, helpers.expect, helpers.source
+local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local command = helpers.command
 local feed = helpers.feed
@@ -26,7 +27,7 @@ describe(':recover', function()
     -- Also check filename ending with ".swp". #9504
     eq('Vim(recover):E306: Cannot open '..swapname2,
       pcall_err(command, 'recover '..swapname2))  -- Should not segfault. #2117
-    eq(2, eval('1+1'))  -- Still alive?
+    assert_alive()
   end)
 
 end)

--- a/test/functional/insert/ctrl_o_spec.lua
+++ b/test/functional/insert/ctrl_o_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
@@ -45,7 +46,7 @@ describe('insert-mode Ctrl-O', function()
   it("doesn't cancel Ctrl-O mode when processing event", function()
     feed('iHello World<c-o>')
     eq({mode='niI', blocking=false}, meths.get_mode()) -- fast event
-    eq(2, eval('1+1')) -- causes K_EVENT key
+    assert_alive()  -- causes K_EVENT key
     eq({mode='niI', blocking=false}, meths.get_mode()) -- still in ctrl-o mode
     feed('dd')
     eq({mode='i', blocking=false}, meths.get_mode()) -- left ctrl-o mode

--- a/test/functional/legacy/eval_spec.lua
+++ b/test/functional/legacy/eval_spec.lua
@@ -1,6 +1,7 @@
 -- Test for various eval features.
 
 local helpers = require('test.functional.helpers')(after_each)
+local assert_alive = helpers.assert_alive
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, command, expect = helpers.clear, helpers.command, helpers.expect
 local eq, eval, write_file = helpers.eq, helpers.eval, helpers.write_file
@@ -506,7 +507,7 @@ describe('eval', function()
     command("call setreg('0',x)")
 
     -- nvim didn't crash and "0 was emptied
-    eq(2, eval("1+1"))
+    assert_alive()
     eq({}, eval("getreg('0',1,1)"))
 
     -- x is a mutable list

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local Screen = require('test.functional.ui.screen')
 
+local assert_alive = helpers.assert_alive
 local meths = helpers.meths
 local command = helpers.command
 local clear = helpers.clear
@@ -510,8 +511,7 @@ describe('stdpath()', function()
     eq(datadir, funcs.fnamemodify(funcs.stdpath('data'), ':t'))
     eq('table', type(funcs.stdpath('config_dirs')))
     eq('table', type(funcs.stdpath('data_dirs')))
-    -- Check for crash. #8393
-    eq(2, eval('1+1'))
+    assert_alive()  -- Check for crash. #8393
   end)
 
   context('returns a String', function()

--- a/test/functional/options/tabstop_spec.lua
+++ b/test/functional/options/tabstop_spec.lua
@@ -1,9 +1,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 
+local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local feed = helpers.feed
-local eq = helpers.eq
-local eval = helpers.eval
 
 describe("'tabstop' option", function()
   before_each(function()
@@ -18,6 +17,6 @@ describe("'tabstop' option", function()
     -- Set 'tabstop' to a very high value.
     -- Use feed(), not command(), to provoke crash.
     feed(':set tabstop=3000000000<CR>')
-    eq(2, eval("1+1"))  -- Still alive?
+    assert_alive()
   end)
 end)

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local assert_alive = helpers.assert_alive
 local eval, command, feed = helpers.eval, helpers.command, helpers.feed
 local eq, clear, insert = helpers.eq, helpers.clear, helpers.insert
 local expect, write_file = helpers.expect, helpers.write_file
@@ -116,6 +117,6 @@ describe('python3 provider', function()
     feed_command("exe 'split' tempname()")
     feed_command("bwipeout!")
     feed_command('help help')
-    eq(2, eval('1+1'))  -- Still alive?
+    assert_alive()
   end)
 end)

--- a/test/functional/provider/ruby_spec.lua
+++ b/test/functional/provider/ruby_spec.lua
@@ -1,10 +1,10 @@
 local helpers = require('test.functional.helpers')(after_each)
 
+local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local command = helpers.command
 local curbufmeths = helpers.curbufmeths
 local eq = helpers.eq
-local eval = helpers.eval
 local exc_exec = helpers.exc_exec
 local expect = helpers.expect
 local feed = helpers.feed
@@ -107,7 +107,7 @@ describe('ruby provider', function()
     helpers.add_builddir_to_rtp()
     command([=[autocmd BufDelete * ruby VIM::evaluate('expand("<afile>")')]=])
     feed_command('help help')
-    eq(2, eval('1+1'))  -- Still alive?
+    assert_alive()
   end)
 end)
 

--- a/test/functional/shada/history_spec.lua
+++ b/test/functional/shada/history_spec.lua
@@ -2,7 +2,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, meths, nvim_feed, eq =
   helpers.command, helpers.funcs, helpers.meths, helpers.feed, helpers.eq
-local eval = helpers.eval
+local assert_alive = helpers.assert_alive
 
 local shada_helpers = require('test.functional.shada.helpers')
 local reset, clear = shada_helpers.reset, shada_helpers.clear
@@ -244,7 +244,7 @@ describe('ShaDa support code', function()
     nvim_command('wshada')
     nvim_command('set shada=\'10,:0')
     nvim_command('wshada')
-    eq(2, eval('1+1')) -- check nvim still running
+    assert_alive()
   end)
 
 end)

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
+local assert_alive = helpers.assert_alive
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local poke_eventloop = helpers.poke_eventloop
 local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.source
@@ -300,7 +301,7 @@ describe('No heap-buffer-overflow when using', function()
     feed('$')
     -- Let termopen() modify the buffer
     feed_command('call termopen("echo")')
-    eq(2, eval('1+1')) -- check nvim still running
+    assert_alive()
     feed_command('bdelete!')
   end)
 end)
@@ -310,6 +311,6 @@ describe('No heap-buffer-overflow when', function()
     feed_command('set nowrap')
     feed_command('autocmd TermOpen * startinsert')
     feed_command('call feedkeys("4000ai\\<esc>:terminal!\\<cr>")')
-    eq(2, eval('1+1'))
+    assert_alive()
   end)
 end)

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
+local assert_alive = helpers.assert_alive
 local clear, poke_eventloop, nvim = helpers.clear, helpers.poke_eventloop, helpers.nvim
 local nvim_dir, source, eq = helpers.nvim_dir, helpers.source, helpers.eq
 local feed = helpers.feed
@@ -215,7 +216,7 @@ describe(':terminal (with fake shell)', function()
       -- handler), :terminal cleanup is pending on the main-loop.
       -- This write should be ignored (not crash, #5445).
       feed('iiYYYYYYY')
-      eq(2, eval("1+1"))  -- Still alive?
+      assert_alive()
   end)
 
   it('works with findfile()', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -8,12 +8,12 @@ local helpers = require('test.functional.helpers')(after_each)
 local uname = helpers.uname
 local thelpers = require('test.functional.terminal.helpers')
 local Screen = require('test.functional.ui.screen')
+local assert_alive = helpers.assert_alive
 local eq = helpers.eq
 local feed_command = helpers.feed_command
 local feed_data = thelpers.feed_data
 local clear = helpers.clear
 local command = helpers.command
-local eval = helpers.eval
 local nvim_dir = helpers.nvim_dir
 local retry = helpers.retry
 local nvim_prog = helpers.nvim_prog
@@ -82,7 +82,7 @@ describe('TUI', function()
     command('call jobresize(b:terminal_job_id, 1, 4)')
     screen:try_resize(57, 17)
     command('call jobresize(b:terminal_job_id, 57, 17)')
-    eq(2, eval("1+1"))  -- Still alive?
+    assert_alive()
   end)
 
   it('accepts resize while pager is active', function()

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
+local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local feed, nvim = helpers.feed, helpers.nvim
 local feed_command = helpers.feed_command
@@ -33,7 +34,7 @@ describe(':terminal', function()
     command('vsplit foo')
     eq(3, eval("winnr('$')"))
     feed('ZQ')  -- Close split, should not crash. #7538
-    eq(2, eval("1+1"))  -- Still alive?
+    assert_alive()
   end)
 
   it('does not change size on WinEnter', function()

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -5036,7 +5036,7 @@ describe('float window', function()
           ]])
         end
 
-        eq(2, eval('1+1'))
+        assert_alive()
       end)
 
       it("o (:only) non-float", function()

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -1,9 +1,9 @@
 local Screen = require('test.functional.ui.screen')
 local helpers = require('test.functional.helpers')(after_each)
 local child_session = require('test.functional.terminal.helpers')
+local assert_alive = helpers.assert_alive
 local mkdir, write_file, rmdir = helpers.mkdir, helpers.write_file, helpers.rmdir
 local eq = helpers.eq
-local eval = helpers.eval
 local feed = helpers.feed
 local feed_command = helpers.feed_command
 local iswin = helpers.iswin
@@ -86,12 +86,12 @@ describe("shell command :!", function()
 
   it("cat a binary file #4142", function()
     feed(":exe 'silent !cat '.shellescape(v:progpath)<CR>")
-    eq(2, eval('1+1'))  -- Still alive?
+    assert_alive()
   end)
 
   it([[display \x08 char #4142]], function()
     feed(":silent !echo \08<CR>")
-    eq(2, eval('1+1'))  -- Still alive?
+    assert_alive()
   end)
 
   it('handles control codes', function()

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
+local assert_alive = helpers.assert_alive
 local clear, feed = helpers.clear, helpers.feed
 local source = helpers.source
 local insert = helpers.insert
@@ -9,7 +10,6 @@ local funcs = helpers.funcs
 local get_pathsep = helpers.get_pathsep
 local eq = helpers.eq
 local pcall_err = helpers.pcall_err
-local eval = helpers.eval
 
 describe('ui/ext_popupmenu', function()
   local screen
@@ -2211,6 +2211,6 @@ describe('builtin popupmenu', function()
     feed('$i')
     funcs.complete(col - max_len, items)
     feed('<c-y>')
-    eq(2, eval('1+1'))
+    assert_alive()
   end)
 end)

--- a/test/functional/viml/completion_spec.lua
+++ b/test/functional/viml/completion_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
+local assert_alive = helpers.assert_alive
 local clear, feed = helpers.clear, helpers.feed
 local eval, eq, neq = helpers.eval, helpers.eq, helpers.neq
 local feed_command, source, expect = helpers.feed_command, helpers.source, helpers.expect
@@ -870,7 +871,7 @@ describe('completion', function()
       {3:-- Keyword completion (^N^P) }{4:match 1 of 2}                   |
     ]])
 
-    eval('1 + 1')
+    assert_alive()
     -- popupmenu still visible
     screen:expect{grid=[[
       foobar fooegg                                               |


### PR DESCRIPTION
Just a lil' cleanup. assert_alive() gives a better error message on failure, and of course adds some structure/formality.