### PR TITLE
vim-patch:8.2.3394: filler lines are wrong when changing text in diff mode

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -453,13 +453,18 @@ void changed_window_setting_win(win_T *wp)
  */
 void set_topline(win_T *wp, linenr_T lnum)
 {
-  /* go to first of folded lines */
+  linenr_T prev_topline = wp->w_topline;
+
+  // go to first of folded lines
   (void)hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
-  /* Approximate the value of w_botline */
+  // Approximate the value of w_botline
   wp->w_botline += lnum - wp->w_topline;
   wp->w_topline = lnum;
   wp->w_topline_was_set = true;
-  wp->w_topfill = 0;
+  if (lnum != prev_topline) {
+    // Keep the filler lines when the topline didn't change.
+    wp->w_topfill = 0;
+  }
   wp->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_TOPLINE);
   // Don't set VALID_TOPLINE here, 'scrolloff' needs to be checked.
   redraw_later(wp, VALID);

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -965,6 +965,30 @@ func Test_diff_screen()
   call delete('XdiffSetup')
 endfunc
 
+func Test_diff_with_scroll_and_change()
+  CheckScreendump
+
+  let lines =<< trim END
+	call setline(1, range(1, 15))
+	vnew
+	call setline(1, range(9, 15))
+	windo diffthis
+	wincmd h
+	exe "normal Gl5\<C-E>"
+  END
+  call writefile(lines, 'Xtest_scroll_change')
+  let buf = RunVimInTerminal('-S Xtest_scroll_change', {})
+
+  call VerifyScreenDump(buf, 'Test_diff_scroll_change_01', {})
+
+  call term_sendkeys(buf, "ax\<Esc>")
+  call VerifyScreenDump(buf, 'Test_diff_scroll_change_02', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_scroll_change')
+endfunc
+
 func Test_diff_with_cursorline()
   CheckScreendump
 

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -1128,3 +1128,72 @@ it('diff updates line numbers below filler lines', function()
       signcolumn=auto                       |
   ]]}
 end)
+
+it('Align the filler lines when changing text in diff mode', function()
+  clear()
+  local screen = Screen.new(40, 20)
+  screen:attach()
+  screen:set_default_attr_ids({
+    [1] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.Gray};
+    [2] = {background = Screen.colors.LightCyan, foreground = Screen.colors.Blue1, bold = true};
+    [3] = {reverse = true};
+    [4] = {background = Screen.colors.LightBlue};
+    [5] = {background = Screen.colors.LightMagenta};
+    [6] = {background = Screen.colors.Red, bold = true};
+    [7] = {foreground = Screen.colors.Blue1, bold = true};
+    [8] = {reverse = true, bold = true};
+  })
+  source([[
+    call setline(1, range(1, 15))
+    vnew
+    call setline(1, range(9, 15))
+    windo diffthis
+    wincmd h
+    exe "normal Gl5\<C-E>"
+  ]])
+  screen:expect{grid=[[
+    {1:  }{2:------------------}{3:│}{1:  }{4:6                }|
+    {1:  }{2:------------------}{3:│}{1:  }{4:7                }|
+    {1:  }{2:------------------}{3:│}{1:  }{4:8                }|
+    {1:  }9                 {3:│}{1:  }9                |
+    {1:  }10                {3:│}{1:  }10               |
+    {1:  }11                {3:│}{1:  }11               |
+    {1:  }12                {3:│}{1:  }12               |
+    {1:  }13                {3:│}{1:  }13               |
+    {1:  }14                {3:│}{1:  }14               |
+    {1:- }1^5                {3:│}{1:- }15               |
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {8:[No Name] [+]        }{3:[No Name] [+]      }|
+                                            |
+  ]]}
+  feed('ax<Esc>')
+  screen:expect{grid=[[
+    {1:  }{2:------------------}{3:│}{1:  }{4:6                }|
+    {1:  }{2:------------------}{3:│}{1:  }{4:7                }|
+    {1:  }{2:------------------}{3:│}{1:  }{4:8                }|
+    {1:  }9                 {3:│}{1:  }9                |
+    {1:  }10                {3:│}{1:  }10               |
+    {1:  }11                {3:│}{1:  }11               |
+    {1:  }12                {3:│}{1:  }12               |
+    {1:  }13                {3:│}{1:  }13               |
+    {1:  }14                {3:│}{1:  }14               |
+    {1:  }{5:15}{6:^x}{5:               }{3:│}{1:  }{5:15               }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {7:~                   }{3:│}{7:~                  }|
+    {8:[No Name] [+]        }{3:[No Name] [+]      }|
+                                            |
+  ]]}
+end)


### PR DESCRIPTION
Problem:    Filler lines are wrong when changing text in diff mode.
Solution:   Don't change the filler lines on every change.  Check
            scrollbinding when updating the filler lines. (closes vim/vim#8809)
https://github.com/vim/vim/commit/04626c243c47af91c2580eaf23e12286180e0e81