### PR TITLE
vim-patch:8.2.3385,8.2.3393

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8290,6 +8290,10 @@ shellescape({string} [, {special}])			*shellescape()*
 		- The <NL> character is escaped (twice if {special} is
 		  a ||non-zero-arg|).
 
+		If 'shell' contains "fish" in the tail, the "\" character will
+		be escaped because in fish it is used as an escape character
+		inside single quotes.
+
 		Example of use with a |:!| command: >
 		    :exe '!dir ' . shellescape(expand('<cfile>'), 1)
 <		This results in a directory listing for the file under the

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7618,6 +7618,12 @@ int csh_like_shell(void)
   return strstr((char *)path_tail(p_sh), "csh") != NULL;
 }
 
+/// Return true when 'shell' has "fish" in the tail.
+bool fish_like_shell(void)
+{
+  return strstr((char *)path_tail(p_sh), "fish") != NULL;
+}
+
 /// Return the number of requested sign columns, based on current
 /// buffer signs and on user configuration.
 int win_signcol_count(win_T *wp)

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -190,12 +190,17 @@ char_u *vim_strsave_shellescape(const char_u *string,
   char_u      *escaped_string;
   size_t l;
   int csh_like;
+  bool fish_like;
 
   /* Only csh and similar shells expand '!' within single quotes.  For sh and
    * the like we must not put a backslash before it, it will be taken
    * literally.  If do_special is set the '!' will be escaped twice.
    * Csh also needs to have "\n" escaped twice when do_special is set. */
   csh_like = csh_like_shell();
+
+  // Fish shell uses '\' as an escape character within single quotes, so '\'
+  // itself must be escaped to get a literal '\'.
+  fish_like = fish_like_shell();
 
   /* First count the number of extra bytes required. */
   size_t length = STRLEN(string) + 3;       // two quotes and a trailing NUL
@@ -219,6 +224,9 @@ char_u *vim_strsave_shellescape(const char_u *string,
     if (do_special && find_cmdline_var(p, &l) >= 0) {
       ++length;                         /* insert backslash */
       p += l - 1;
+    }
+    if (*p == '\\' && fish_like) {
+      length++;  // insert backslash
     }
   }
 
@@ -266,6 +274,10 @@ char_u *vim_strsave_shellescape(const char_u *string,
       while (--l != SIZE_MAX)                /* copy the var */
         *d++ = *p++;
       continue;
+    }
+    if (*p == '\\' && fish_like) {
+      *d++ = '\\';
+      *d++ = *p++;
     }
 
     MB_COPY_CHAR(p, d);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -278,6 +278,7 @@ char_u *vim_strsave_shellescape(const char_u *string,
     if (*p == '\\' && fish_like) {
       *d++ = '\\';
       *d++ = *p++;
+      continue;
     }
 
     MB_COPY_CHAR(p, d);

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1174,6 +1174,14 @@ func Test_shellescape()
 
   call assert_equal("'te\\\\xt'", shellescape("te\\xt"))
   call assert_equal("'te\\\\xt'", shellescape("te\\xt", 1))
+  call assert_equal("'te\\\\'\\''xt'", shellescape("te\\'xt"))
+  call assert_equal("'te\\\\'\\''xt'", shellescape("te\\'xt", 1))
+  call assert_equal("'te\\\\!xt'", shellescape("te\\!xt"))
+  call assert_equal("'te\\\\\\!xt'", shellescape("te\\!xt", 1))
+  call assert_equal("'te\\\\%xt'", shellescape("te\\%xt"))
+  call assert_equal("'te\\\\\\%xt'", shellescape("te\\%xt", 1))
+  call assert_equal("'te\\\\#xt'", shellescape("te\\#xt"))
+  call assert_equal("'te\\\\\\#xt'", shellescape("te\\#xt", 1))
 
   let &shell = save_shell
 endfunc

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1160,6 +1160,21 @@ func Test_shellescape()
   call assert_equal("'te\\\nxt'", shellescape("te\nxt"))
   call assert_equal("'te\\\\\nxt'", shellescape("te\nxt", 1))
 
+  set shell=fish
+  call assert_equal("'text'", shellescape('text'))
+  call assert_equal("'te\"xt'", shellescape('te"xt'))
+  call assert_equal("'te'\\''xt'", shellescape("te'xt"))
+
+  call assert_equal("'te%xt'", shellescape("te%xt"))
+  call assert_equal("'te\\%xt'", shellescape("te%xt", 1))
+  call assert_equal("'te#xt'", shellescape("te#xt"))
+  call assert_equal("'te\\#xt'", shellescape("te#xt", 1))
+  call assert_equal("'te!xt'", shellescape("te!xt"))
+  call assert_equal("'te\\!xt'", shellescape("te!xt", 1))
+
+  call assert_equal("'te\\\\xt'", shellescape("te\\xt"))
+  call assert_equal("'te\\\\xt'", shellescape("te\\xt", 1))
+
   let &shell = save_shell
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.3385: escaping for fish shell does not work properly

Problem:    Escaping for fish shell does not work properly.
Solution:   Insert a backslash before a backslash. (Jason Cox, closes vim/vim#8810)
https://github.com/vim/vim/commit/6e82351130ddb8d13cf3748b47f07cae77886fc7


#### vim-patch:8.2.3393: escaping for fish shell is skipping some characters

Problem:    Escaping for fish shell is skipping some characters.
Solution:   Escape character after backslash if needed. (Jason Cox,
            closes vim/vim#8827)
https://github.com/vim/vim/commit/6631597452d4644f485a09e4036d117e5f91de70