### PR TITLE
fix(defaults): "syntax sync maxlines=1" on CmdwinEnter

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1141,7 +1141,7 @@ The |getcmdwintype()| function returns the type of the command-line being
 edited as described in |cmdwin-char|.
 
 Nvim defines this default CmdWinEnter autocmd in the "nvim_cmdwin" group: >
-    autocmd CmdWinEnter [:>] exe 'syntax sync minlines=1 maxlines='..&cmdwinheight
+    autocmd CmdWinEnter [:>] syntax sync minlines=1 maxlines=1
 <
 You can disable this in your config with "autocmd! nvim_cmdwin". |default-autocmds|
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -388,8 +388,8 @@ argument.
 ==============================================================================
 Initialization					*initialization* *startup*
 
-At startup, Vim checks environment variables and files and sets values
-accordingly.  Vim proceeds in this order:
+At startup, Nvim checks environment variables and files and sets values
+accordingly, proceeding as follows:
 
 1. Set the 'shell' option			*SHELL* *COMSPEC*
 	The environment variable SHELL, if it exists, is used to set the
@@ -406,9 +406,7 @@ accordingly.  Vim proceeds in this order:
 	Nvim started with |--embed| waits for the UI to connect before
 	proceeding to load user configuration.
 
-4. Setup default mappings and autocommands.
-	Default mappings |default-mappings| and autocommands |default-autocmds|
-	are created.
+4. Setup |default-mappings| and  |default-autocmds|.
 
 5. Load user config (execute Ex commands from files, environment, …).
 	$VIMINIT environment variable is read as one Ex command line (separate
@@ -501,21 +499,16 @@ accordingly.  Vim proceeds in this order:
 9. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
-	This means that Vim will figure out the values of 'shellpipe' and
+	This means that Nvim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
 10. Set 'updatecount' to zero, if "-n" command argument used
 
-11. Set binary options
-	If the "-b" flag was given to Vim, the options for binary editing will
-	be set now.  See |-b|.
+11. Set binary options if the |-b| flag was given.
 
-12. Read the ShaDa file
-	See |shada-file|.
+12. Read the |shada-file|.
 
-13. Read the quickfix file
-	If the "-q" flag was given to Vim, the quickfix file is read.  If this
-	fails, Vim exits.
+13. Read the quickfix file if the |-q| flag was given, or exit on failure.
 
 14. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
@@ -523,13 +516,13 @@ accordingly.  Vim proceeds in this order:
 	When the |-p| flag was given, tab pages will be created (but not
 	displayed yet).
 	When switching screens, it happens now.  Redrawing starts.
-	If the "-q" flag was given to Vim, the first error is jumped to.
+	If the |-q| flag was given, the first error is jumped to.
 	Buffers for all windows will be loaded, without triggering |BufAdd|
 	autocommands.
 
 15. Execute startup commands
-	If a "-t" flag was given to Vim, the tag is jumped to.
-	The commands given with the |-c| and |+cmd| arguments are executed.
+	If a |-t| flag was given, the tag is jumped to.
+	Commands given with |-c| and |+cmd| are executed.
 	If the 'insertmode' option is set, Insert mode is entered.
 	The starting flag is reset, has("vim_starting") will now return zero.
 	The |v:vim_did_enter| variable is set to 1.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -90,13 +90,10 @@ Default autocommands exist in the following groups. Use ":autocmd! {group}" to
 remove them and ":autocmd {group}" to see how they're defined.
 
 nvim_terminal:
-- BufReadCmd: New files with a name matching
-              `term://(.{-}//(\d+:)?)?\zs.*` are treated as terminal
-              buffers. |terminal-start|
+- BufReadCmd: Treats "term://" buffers as |terminal| buffers. |terminal-start|
 
 nvim_cmdwin:
-- CmdWinEnter: Synchronize syntax highlighting within the command
-               window.
+- CmdwinEnter: Limits syntax sync to maxlines=1 in the |cmdwin|.
 
 ==============================================================================
 3. New Features						       *nvim-features*

--- a/src/nvim/aucmd.c
+++ b/src/nvim/aucmd.c
@@ -41,7 +41,6 @@ void init_default_autocmds(void)
   // open terminals when opening files that start with term://
 #define PROTO "term://"
   do_cmdline_cmd("augroup nvim_terminal");
-  do_cmdline_cmd("autocmd!");
   do_cmdline_cmd("autocmd BufReadCmd " PROTO "* ++nested "
                  "if !exists('b:term_title')|call termopen("
                  // Capture the command string
@@ -56,7 +55,7 @@ void init_default_autocmds(void)
 
   // limit syntax synchronization in the command window
   do_cmdline_cmd("augroup nvim_cmdwin");
-  do_cmdline_cmd("autocmd! CmdWinEnter [:>] exe 'syntax sync minlines=1 maxlines='..&cmdwinheight");
+  do_cmdline_cmd("autocmd! CmdwinEnter [:>] syntax sync minlines=1 maxlines=1");
   do_cmdline_cmd("augroup END");
 }
 


### PR DESCRIPTION
I mistakenly suggested maxlines=&cmdwinheight, forgetting that it is
calculated from topline, not cursor. maxlines=1 makes the most sense in
cmdwin.

ref #15401 622a36b1f1c652a8de433028bc4a03a1216db23f