### PR TITLE
refactor: update uncrustify config and format screen.c

### DIFF
--- a/contrib/uncrustify.cfg
+++ b/contrib/uncrustify.cfg
@@ -1,4 +1,4 @@
-# Uncrustify_d-0.73.0_f
+# Uncrustify_d-0.73.0-159-81b1bc77
 
 #
 # General options
@@ -149,7 +149,7 @@ sp_enum_colon                   = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space around preprocessor '##' concatenation operator.
 #
 # Default: add
-sp_pp_concat                    = ignore      # ignore/add/remove/force/not_defined
+sp_pp_concat                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after preprocessor '#' stringify operator.
 # Also affects the '#@' charizing operator.
@@ -190,7 +190,7 @@ sp_before_ptr_star              = ignore   # ignore/add/remove/force/not_defined
 # variable name. If set to ignore, sp_before_ptr_star is used instead.
 sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space between pointer stars '*'.
+# Add or remove space between pointer stars '*', as in 'int ***a;'.
 sp_between_ptr_star             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer star '*', if followed by a word.
@@ -210,13 +210,21 @@ sp_after_ptr_star_qualifier     = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_after_ptr_star and sp_type_func.
 sp_after_ptr_star_func          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space after a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after a pointer star '*', if followed by an open
-# parenthesis, as in 'void* (*)().
+# parenthesis, as in 'void* (*)()'.
 sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a pointer star '*', if followed by a function
 # prototype or function definition.
 sp_before_ptr_star_func         = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_before_ptr_star_trailing     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&'.
 sp_before_byref                 = ignore   # ignore/add/remove/force/not_defined
@@ -251,11 +259,15 @@ sp_before_byref_func            = ignore   # ignore/add/remove/force/not_defined
 # following word.
 #
 # Default: force
-sp_after_type                   = ignore    # ignore/add/remove/force/not_defined
+sp_after_type                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'decltype(...)' and word,
 # brace or function call.
 sp_after_decltype               = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove space before the parenthesis in the D constructs
+# 'template Foo(' and 'class Foo('.
+sp_before_template_paren        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'template' and '<'.
 # If set to ignore, sp_before_angle is used.
@@ -289,7 +301,7 @@ sp_angle_word                   = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between '>' and '>' in '>>' (template stuff).
 #
 # Default: add
-sp_angle_shift                  = ignore      # ignore/add/remove/force/not_defined
+sp_angle_shift                  = ignore   # ignore/add/remove/force/not_defined
 
 # (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
 # that sp_angle_shift cannot remove the space without this option.
@@ -313,7 +325,7 @@ sp_inside_sparen_open           = remove   # ignore/add/remove/force/not_defined
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '((' or '))' of control statements.
-# sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
@@ -330,6 +342,12 @@ sp_brace_close_while            = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between 'while' and '('. Overrides sp_before_sparen.
 sp_while_paren_open             = ignore   # ignore/add/remove/force/not_defined
 
+# (D) Add or remove space between 'invariant' and '('.
+sp_invariant_paren              = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove space after the ')' in 'invariant (C) c'.
+sp_after_invariant_paren        = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
 sp_special_semi                 = ignore   # ignore/add/remove/force/not_defined
 
@@ -341,18 +359,23 @@ sp_before_semi                  = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space before ';' in non-empty 'for' statements.
 sp_before_semi_for              = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before a semicolon of an empty part of a for statement.
+# Add or remove space before a semicolon of an empty left part of a for
+# statement, as in 'for ( <here> ; ; )'.
 sp_before_semi_for_empty        = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the semicolons of an empty middle part of a for
+# statement, as in 'for ( ; <here> ; )'.
+sp_between_semi_for_empty       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ';', except when followed by a comment.
 #
 # Default: add
-sp_after_semi                   = ignore      # ignore/add/remove/force/not_defined
+sp_after_semi                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ';' in non-empty 'for' statements.
 #
 # Default: force
-sp_after_semi_for               = ignore    # ignore/add/remove/force/not_defined
+sp_after_semi_for               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the final semicolon of an empty part of a for
 # statement, as in 'for ( ; ; <here> )'.
@@ -381,26 +404,51 @@ sp_inside_square                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space inside '[]'.
 sp_inside_square_empty          = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
-sp_after_comma                  = add   # ignore/add/remove/force/not_defined
+# (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
+# ']'. If set to ignore, sp_inside_square is used.
+sp_inside_square_oc_array       = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before ','.
+# Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
+sp_after_comma                  = add      # ignore/add/remove/force/not_defined
+
+# Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.
 #
 # Default: remove
 sp_before_comma                 = remove   # ignore/add/remove/force/not_defined
+
+# (C#) Add or remove space between ',' and ']' in multidimensional array type
+# like 'int[,,]'.
+sp_after_mdatype_commas         = ignore   # ignore/add/remove/force/not_defined
+
+# (C#) Add or remove space between '[' and ',' in multidimensional array type
+# like 'int[,,]'.
+sp_before_mdatype_commas        = ignore   # ignore/add/remove/force/not_defined
+
+# (C#) Add or remove space between ',' in multidimensional array type
+# like 'int[,,]'.
+sp_between_mdatype_commas       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between an open parenthesis and comma,
 # i.e. '(,' vs. '( ,'.
 #
 # Default: force
-sp_paren_comma                  = ignore    # ignore/add/remove/force/not_defined
+sp_paren_comma                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the variadic '...' when preceded by a
+# non-punctuator.
+# The value REMOVE will be overriden with FORCE
+sp_after_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the variadic '...' when preceded by a
 # non-punctuator.
+# The value REMOVE will be overriden with FORCE
 sp_before_ellipsis              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a type and '...'.
 sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove space between a type and '?'.
+sp_type_question                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and '...'.
 sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
@@ -462,11 +510,17 @@ sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between 'decltype' and '('.
 sp_decltype_paren               = ignore   # ignore/add/remove/force/not_defined
 
+# (Pawn) Add or remove space after the tag keyword.
+sp_after_tag                    = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space inside enum '{' and '}'.
 sp_inside_braces_enum           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside struct/union '{' and '}'.
 sp_inside_braces_struct         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'
+sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after open brace in an unnamed temporary
 # direct-list-initialization.
@@ -480,7 +534,7 @@ sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force/not_def
 sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{' and '}'.
-sp_inside_braces                = add   # ignore/add/remove/force/not_defined
+sp_inside_braces                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{}'.
 sp_inside_braces_empty          = ignore   # ignore/add/remove/force/not_defined
@@ -540,6 +594,9 @@ sp_fparen_brace                 = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_fparen_brace.
 sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force/not_defined
 
+# (Java) Add or remove space between ')' and '{{' of double brace initializer.
+sp_fparen_dbrace                = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space between function name and '(' on function calls.
 sp_func_call_paren              = ignore   # ignore/add/remove/force/not_defined
 
@@ -591,6 +648,26 @@ sp_after_throw                  = ignore   # ignore/add/remove/force/not_defined
 # If set to ignore, sp_before_sparen is used.
 sp_catch_paren                  = ignore   # ignore/add/remove/force/not_defined
 
+# (OC) Add or remove space between '@catch' and '('
+# in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
+sp_oc_catch_paren               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space before Objective-C protocol list
+# as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between class name and '('
+# in '@interface className(categoryName)<ProtocolName>:BaseClass'
+sp_oc_classname_paren           = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove space between 'version' and '('
+# in 'version (something) { }'. If set to ignore, sp_before_sparen is used.
+sp_version_paren                = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove space between 'scope' and '('
+# in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.
+sp_scope_paren                  = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space between 'super' and '(' in 'super (something)'.
 #
 # Default: remove
@@ -608,10 +685,10 @@ sp_macro                        = ignore   # ignore/add/remove/force/not_defined
 sp_macro_func                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'else' and '{' if on the same line.
-sp_else_brace                   = add   # ignore/add/remove/force/not_defined
+sp_else_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'else' if on the same line.
-sp_brace_else                   = add   # ignore/add/remove/force/not_defined
+sp_brace_else                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and the name of a typedef on the same line.
 sp_brace_typedef                = ignore   # ignore/add/remove/force/not_defined
@@ -620,8 +697,17 @@ sp_brace_typedef                = ignore   # ignore/add/remove/force/not_defined
 # 'catch' are on the same line, as in 'catch (decl) <here> {'.
 sp_catch_brace                  = ignore   # ignore/add/remove/force/not_defined
 
+# (OC) Add or remove space before the '{' of a '@catch' statement, if the '{'
+# and '@catch' are on the same line, as in '@catch (decl) <here> {'.
+# If set to ignore, sp_catch_brace is used.
+sp_oc_catch_brace               = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space between '}' and 'catch' if on the same line.
 sp_brace_catch                  = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between '}' and '@catch' if on the same line.
+# If set to ignore, sp_brace_catch is used.
+sp_oc_brace_catch               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'finally' and '{' if on the same line.
 sp_finally_brace                = ignore   # ignore/add/remove/force/not_defined
@@ -642,13 +728,16 @@ sp_word_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between a variable and '{' for a namespace.
 #
 # Default: add
-sp_word_brace_ns                = ignore      # ignore/add/remove/force/not_defined
+sp_word_brace_ns                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '::' operator.
 sp_before_dc                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '::' operator.
 sp_after_dc                     = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove around the D named array initializer ':' operator.
+sp_d_array_colon                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '!' (not) unary operator.
 #
@@ -691,7 +780,76 @@ sp_incdec                       = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space before a backslash-newline at the end of a line.
 #
 # Default: add
-sp_before_nl_cont               = ignore      # ignore/add/remove/force/not_defined
+sp_before_nl_cont               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'
+# or '+(int) bar;'.
+sp_after_oc_scope               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after the colon in message specs,
+# i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.
+sp_after_oc_colon               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space before the colon in message specs,
+# i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.
+sp_before_oc_colon              = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after the colon in message specs,
+# i.e. '[object setValue:1];' vs. '[object setValue: 1];'.
+sp_after_send_oc_colon          = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space before the colon in message specs,
+# i.e. '[object setValue:1];' vs. '[object setValue :1];'.
+sp_before_send_oc_colon         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after the (type) in message specs,
+# i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.
+sp_after_oc_type                = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after the first (type) in message specs,
+# i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.
+sp_after_oc_return_type         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between '@selector' and '(',
+# i.e. '@selector(msgName)' vs. '@selector (msgName)'.
+# Also applies to '@protocol()' constructs.
+sp_after_oc_at_sel              = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between '@selector(x)' and the following word,
+# i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.
+sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space inside '@selector' parentheses,
+# i.e. '@selector(foo)' vs. '@selector( foo )'.
+# Also applies to '@protocol()' constructs.
+sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space before a block pointer caret,
+# i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.
+sp_before_oc_block_caret        = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after a block pointer caret,
+# i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.
+sp_after_oc_block_caret         = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between the receiver and selector in a message,
+# as in '[receiver selector ...]'.
+sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space after '@property'.
+sp_after_oc_property            = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove space between '@synchronized' and the open parenthesis,
+# i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.
+sp_after_oc_synchronized        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the ':' in 'b ? t : f'.
 sp_cond_colon                   = ignore   # ignore/add/remove/force/not_defined
@@ -729,6 +887,9 @@ sp_cond_ternary_short           = ignore   # ignore/add/remove/force/not_defined
 # sense here.
 sp_case_label                   = ignore   # ignore/add/remove/force/not_defined
 
+# (D) Add or remove space around the D '..' operator.
+sp_range                        = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ':' in a Java/C++11 range-based 'for',
 # as in 'for (Type var : <here> expr)'.
 sp_after_for_colon              = ignore   # ignore/add/remove/force/not_defined
@@ -736,6 +897,9 @@ sp_after_for_colon              = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space before ':' in a Java/C++11 range-based 'for',
 # as in 'for (Type var <here> : expr)'.
 sp_before_for_colon             = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
+sp_extern_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force/not_defined
@@ -785,10 +949,13 @@ sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force/not_defined
 sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a trailing or embedded comment.
-sp_before_tr_emb_cmt            = add   # ignore/add/remove/force/not_defined
+sp_before_tr_emb_cmt            = add      # ignore/add/remove/force/not_defined
 
 # Number of spaces before a trailing or embedded comment.
 sp_num_before_tr_emb_cmt        = 2        # unsigned number
+
+# (Java) Add or remove space between an annotation and the open parenthesis.
+sp_annotation_paren             = ignore   # ignore/add/remove/force/not_defined
 
 # If true, vbrace tokens are dropped to the previous token and skipped.
 sp_skip_vbrace_tokens           = false    # true/false
@@ -872,6 +1039,13 @@ indent_brace_parent             = false    # true/false
 # Whether to indent based on the open parenthesis instead of the open brace
 # in '({\n'.
 indent_paren_open_brace         = false    # true/false
+
+# (C#) Whether to indent the brace of a C# delegate by another level.
+indent_cs_delegate_brace        = false    # true/false
+
+# (C#) Whether to indent a C# delegate (to handle delegates with no brace) by
+# another level.
+indent_cs_delegate_body         = false    # true/false
 
 # Whether to indent the body of a 'namespace'.
 indent_namespace                = false    # true/false
@@ -989,7 +1163,7 @@ indent_func_throw               = 0        # unsigned number
 # false: do not add an indent for the brace on the same line as the macro
 #
 # Default: true
-indent_macro_brace              = false     # true/false
+indent_macro_brace              = false    # true/false
 
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
@@ -1000,7 +1174,10 @@ indent_member                   = 0        # unsigned number
 indent_member_single            = false    # true/false
 
 # Spaces to indent single line ('//') comments on lines before code.
-indent_sing_line_comments       = 0        # unsigned number
+indent_single_line_comments_before = 0        # unsigned number
+
+# Spaces to indent single line ('//') comments on lines after code.
+indent_single_line_comments_after = 0        # unsigned number
 
 # When opening a paren for a control statement (if, for, while, etc), increase
 # the indent level by this value. Negative values decrease the indent level.
@@ -1008,7 +1185,7 @@ indent_sparen_extra             = 0        # number
 
 # Whether to indent trailing single line ('//') comments relative to the code
 # instead of trying to keep the same absolute column.
-indent_relative_single_line_comments = true    # true/false
+indent_relative_single_line_comments = true     # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
 # It might wise to choose the same value for the option indent_case_brace.
@@ -1079,7 +1256,7 @@ indent_paren_after_func_decl    = false    # true/false
 
 # Whether to indent the open parenthesis of a function call,
 # if the parenthesis is on its own line.
-indent_paren_after_func_call    = true    # true/false
+indent_paren_after_func_call    = true     # true/false
 
 # Whether to indent a comma when inside a brace.
 # If true, aligns under the open brace.
@@ -1128,6 +1305,50 @@ indent_off_after_assign         = false    # true/false
 # Default: true
 indent_align_paren              = true     # true/false
 
+# (OC) Whether to indent Objective-C code inside message selectors.
+indent_oc_inside_msg_sel        = false    # true/false
+
+# (OC) Whether to indent Objective-C blocks at brace level instead of usual
+# rules.
+indent_oc_block                 = false    # true/false
+
+# (OC) Indent for Objective-C blocks in a message relative to the parameter
+# name.
+#
+# =0: Use indent_oc_block rules
+# >0: Use specified number of spaces to indent
+indent_oc_block_msg             = 0        # unsigned number
+
+# (OC) Minimum indent for subsequent parameters
+indent_oc_msg_colon             = 0        # unsigned number
+
+# (OC) Whether to prioritize aligning with initial colon (and stripping spaces
+# from lines, if necessary).
+#
+# Default: true
+indent_oc_msg_prioritize_first_colon = true     # true/false
+
+# (OC) Whether to indent blocks the way that Xcode does by default
+# (from the keyword if the parameter is on its own line; otherwise, from the
+# previous indentation level). Requires indent_oc_block_msg=true.
+indent_oc_block_msg_xcode_style = false    # true/false
+
+# (OC) Whether to indent blocks from where the brace is, relative to a
+# message keyword. Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_keyword = false    # true/false
+
+# (OC) Whether to indent blocks from where the brace is, relative to a message
+# colon. Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_colon  = false    # true/false
+
+# (OC) Whether to indent blocks from where the block caret is.
+# Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_caret  = false    # true/false
+
+# (OC) Whether to indent blocks from where the brace caret is.
+# Requires indent_oc_block_msg=true.
+indent_oc_block_msg_from_brace  = false    # true/false
+
 # When indenting after virtual brace open and newline add further spaces to
 # reach this minimum indent.
 indent_min_vbrace_open          = 0        # unsigned number
@@ -1153,7 +1374,12 @@ indent_cpp_lambda_body          = false    # true/false
 #        add the indent for the return.
 #
 # Default: true
-indent_compound_literal_return  = false     # true/false
+indent_compound_literal_return  = false    # true/false
+
+# (C#) Whether to indent a 'using' block if no braces are used.
+#
+# Default: true
+indent_using_block              = true     # true/false
 
 # How to indent the continuation of ternary operator.
 #
@@ -1202,6 +1428,9 @@ nl_enum_leave_one_liners        = false    # true/false
 # Don't split one-line get or set functions.
 nl_getset_leave_one_liners      = false    # true/false
 
+# (C#) Don't split one-line property get or set functions.
+nl_cs_property_leave_one_liners = false    # true/false
+
 # Don't split one-line function definitions, as in 'int foo() { return 0; }'.
 # might modify nl_func_type_name
 nl_func_leave_one_liners        = false    # true/false
@@ -1221,6 +1450,30 @@ nl_do_leave_one_liners          = false    # true/false
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
 
+# (OC) Don't split one-line Objective-C messages.
+nl_oc_msg_leave_one_liner       = false    # true/false
+
+# (OC) Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove newline between Objective-C block signature and '{'.
+nl_oc_block_brace               = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove blank line before '@interface' statement.
+nl_oc_before_interface          = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove blank line before '@implementation' statement.
+nl_oc_before_implementation     = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove blank line before '@end' statement.
+nl_oc_before_end                = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove newline between '@interface' and '{'.
+nl_oc_interface_brace           = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove newline between '@implementation' and '{'.
+nl_oc_implementation_brace      = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove newlines at the start of the file.
 nl_start_of_file                = ignore   # ignore/add/remove/force/not_defined
 
@@ -1238,8 +1491,15 @@ nl_end_of_file_min              = 0        # unsigned number
 # Add or remove newline between '=' and '{'.
 nl_assign_brace                 = ignore   # ignore/add/remove/force/not_defined
 
+# (D) Add or remove newline between '=' and '['.
+nl_assign_square                = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove newline between '[]' and '{'.
 nl_tsquare_brace                = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove newline after '= ['. Will also affect the newline before
+# the ']'.
+nl_after_square_assign          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function call's ')' and '{', as in
 # 'list_for_each(item, &list) { }'.
@@ -1307,8 +1567,16 @@ nl_for_brace                    = ignore   # ignore/add/remove/force/not_defined
 # 'catch (decl) <here> {'.
 nl_catch_brace                  = ignore   # ignore/add/remove/force/not_defined
 
+# (OC) Add or remove newline before the '{' of a '@catch' statement, as in
+# '@catch (decl) <here> {'. If set to ignore, nl_catch_brace is used.
+nl_oc_catch_brace               = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove newline between '}' and 'catch'.
 nl_brace_catch                  = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Add or remove newline between '}' and '@catch'. If set to ignore,
+# nl_brace_catch is used.
+nl_oc_brace_catch               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and ']'.
 nl_brace_square                 = ignore   # ignore/add/remove/force/not_defined
@@ -1318,6 +1586,18 @@ nl_brace_fparen                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'while' and '{'.
 nl_while_brace                  = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove newline between 'scope (x)' and '{'.
+nl_scope_brace                  = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove newline between 'unittest' and '{'.
+nl_unittest_brace               = ignore   # ignore/add/remove/force/not_defined
+
+# (D) Add or remove newline between 'version (x)' and '{'.
+nl_version_brace                = ignore   # ignore/add/remove/force/not_defined
+
+# (C#) Add or remove newline between 'using' and '{'.
+nl_using_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between two open or close braces. Due to general
 # newline/brace handling, REMOVE may not work.
@@ -1584,6 +1864,10 @@ nl_template_args                = false    # true/false
 # Whether to add a newline before '>' of a template parameter list.
 nl_template_end                 = false    # true/false
 
+# (OC) Whether to put each Objective-C message parameter on a separate line.
+# See nl_oc_msg_leave_one_liner.
+nl_oc_msg_args                  = false    # true/false
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 
@@ -1600,6 +1884,10 @@ nl_return_expr                  = ignore   # ignore/add/remove/force/not_defined
 # Whether to add a newline after semicolons, except in 'for' statements.
 nl_after_semicolon              = false    # true/false
 
+# (Java) Add or remove newline between the ')' and '{{' of the double brace
+# initializer.
+nl_paren_dbrace_open            = ignore   # ignore/add/remove/force/not_defined
+
 # Whether to add a newline after the type in an unnamed temporary
 # direct-list-initialization.
 nl_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
@@ -1612,8 +1900,10 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
+# Whether to add a newline before '{'.
+nl_before_brace_open            = false    # true/false
+
+# Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line
@@ -1693,6 +1983,12 @@ nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 # Add or remove blank line after 'do/while' statement.
 nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
 
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
+
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
 nl_before_return                = false    # true/false
@@ -1703,6 +1999,9 @@ nl_after_return                 = false    # true/false
 
 # Whether to put a blank line before a member '.' or '->' operators.
 nl_before_member                = ignore   # ignore/add/remove/force/not_defined
+
+# (Java) Whether to put a blank line after a member '.' or '->' operators.
+nl_after_member                 = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to double-space commented-entries in 'struct'/'union'/'enum'.
 nl_ds_struct_enum_cmt           = false    # true/false
@@ -1741,7 +2040,7 @@ nl_create_while_one_liner       = false    # true/false
 # a single line.
 nl_create_func_def_one_liner    = false    # true/false
 
-# Whether to split one-line simple unbraced if statements into three lines by
+# Whether to split one-line simple list definitions into three lines by
 # adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
 nl_create_list_one_liner        = false    # true/false
 
@@ -1885,6 +2184,9 @@ nl_after_multiline_comment      = false    # true/false
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
 
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
+
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
 
@@ -1937,11 +2239,25 @@ nl_comment_func_def             = 0        # unsigned number
 # 0: No change (default).
 nl_after_try_catch_finally      = 0        # unsigned number
 
+# (C#) The number of newlines before and after a property, indexer or event
+# declaration.
+#
+# 0: No change (default).
+nl_around_cs_property           = 0        # unsigned number
+
+# (C#) The number of newlines between the get/set/add/remove handlers.
+#
+# 0: No change (default).
+nl_between_get_set              = 0        # unsigned number
+
+# (C#) Add or remove newline between property and the '{'.
+nl_property_brace               = ignore   # ignore/add/remove/force/not_defined
+
 # Whether to remove blank lines after '{'.
-eat_blanks_after_open_brace     = true    # true/false
+eat_blanks_after_open_brace     = true     # true/false
 
 # Whether to remove blank lines before '}'.
-eat_blanks_before_close_brace   = true    # true/false
+eat_blanks_before_close_brace   = true     # true/false
 
 # How aggressively to remove extra newlines not in preprocessor.
 #
@@ -1949,6 +2265,13 @@ eat_blanks_before_close_brace   = true    # true/false
 # 1: Remove most newlines not handled by other config
 # 2: Remove all newlines and reformat completely by config
 nl_remove_extra_newlines        = 0        # unsigned number
+
+# (Java) Add or remove newline after an annotation statement. Only affects
+# annotations that are after a newline.
+nl_after_annotation             = ignore   # ignore/add/remove/force/not_defined
+
+# (Java) Add or remove newline between two annotations.
+nl_between_annotation           = ignore   # ignore/add/remove/force/not_defined
 
 # The number of newlines before a whole-file #ifdef.
 #
@@ -2021,7 +2344,7 @@ pos_shift                       = ignore   # ignore/break/force/lead/trail/join/
 #
 
 # Try to limit code width to N columns.
-code_width                      = 100        # unsigned number
+code_width                      = 100      # unsigned number
 
 # Whether to fully split long 'for' statements at semi-colons.
 ls_for_split_full               = false    # true/false
@@ -2299,6 +2622,11 @@ align_single_line_brace         = false    # true/false
 # Gap for align_single_line_brace.
 align_single_line_brace_gap     = 0        # unsigned number
 
+# (OC) The span for aligning Objective-C message specifications.
+#
+# 0: Don't align (default).
+align_oc_msg_spec_span          = 0        # unsigned number
+
 # Whether to align macros wrapped with a backslash and a newline. This will
 # not work right if the macro contains a multi-line comment.
 align_nl_cont                   = false    # true/false
@@ -2326,6 +2654,25 @@ align_eigen_comma_init          = false    # true/false
 
 # Whether to align text after 'asm volatile ()' colons.
 align_asm_colon                 = false    # true/false
+
+# (OC) Span for aligning parameters in an Objective-C message call
+# on the ':'.
+#
+# 0: Don't align.
+align_oc_msg_colon_span         = 0        # unsigned number
+
+# (OC) Whether to always align with the first parameter, even if it is too
+# short.
+align_oc_msg_colon_first        = false    # true/false
+
+# (OC) Whether to align parameters in an Objective-C '+' or '-' declaration
+# on the ':'.
+align_oc_decl_colon             = false    # true/false
+
+# (OC) Whether to not align parameters in an Objectve-C message call if first
+# colon is not on next line of the message call (the same way Xcode does
+# aligment)
+align_oc_msg_colon_xcode_like   = false    # true/false
 
 #
 # Comment modification options
@@ -2378,7 +2725,7 @@ cmt_reflow_indent_to_paragraph_start = false    # true/false
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
-cmt_convert_tab_to_spaces       = true    # true/false
+cmt_convert_tab_to_spaces       = true     # true/false
 
 # Whether to apply changes to multi-line comments, including cmt_width,
 # keyword substitution and leading chars.
@@ -2401,6 +2748,9 @@ cmt_align_doxygen_javadoc_tags  = false    # true/false
 #
 # Default: 1
 cmt_sp_before_doxygen_javadoc_tags = 1        # unsigned number
+
+# Whether to change trailing, single-line c-comments into cpp-comments.
+cmt_trailing_single_line_c_to_cpp = true     # true/false
 
 # Whether to group c-comments that look like they are in a block.
 cmt_c_group                     = false    # true/false
@@ -2511,11 +2861,14 @@ cmt_insert_before_ctor_dtor     = false    # true/false
 mod_full_brace_do               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove braces on a single-line 'for' statement.
-mod_full_brace_for              = add   # ignore/add/remove/force/not_defined
+mod_full_brace_for              = add      # ignore/add/remove/force/not_defined
+
+# (Pawn) Add or remove braces on a single-line function definition.
+mod_full_brace_function         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove braces on a single-line 'if' statement. Braces will not be
 # removed if the braced statement contains an 'else'.
-mod_full_brace_if               = add   # ignore/add/remove/force/not_defined
+mod_full_brace_if               = add      # ignore/add/remove/force/not_defined
 
 # Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either
 # have, or do not have, braces. If true, braces will be added if any block
@@ -2531,7 +2884,7 @@ mod_full_brace_if_chain         = false    # true/false
 mod_full_brace_if_chain_only    = false    # true/false
 
 # Add or remove braces on single-line 'while' statement.
-mod_full_brace_while            = add   # ignore/add/remove/force/not_defined
+mod_full_brace_while            = add      # ignore/add/remove/force/not_defined
 
 # Add or remove braces on single-line 'using ()' statement.
 mod_full_brace_using            = ignore   # ignore/add/remove/force/not_defined
@@ -2558,12 +2911,18 @@ mod_full_brace_nl_block_rem_mlcond = false    # true/false
 # Add or remove unnecessary parenthesis on 'return' statement.
 mod_paren_on_return             = ignore   # ignore/add/remove/force/not_defined
 
+# (Pawn) Whether to change optional semicolons to real semicolons.
+mod_pawn_semicolon              = false    # true/false
+
 # Whether to fully parenthesize Boolean expressions in 'while' and 'if'
 # statement, as in 'if (a && b > c)' => 'if (a && (b > c))'.
 mod_full_paren_if_bool          = false    # true/false
 
 # Whether to remove superfluous semicolons.
 mod_remove_extra_semicolon      = false    # true/false
+
+# Whether to remove duplicate include.
+mod_remove_duplicate_include    = false    # true/false
 
 # If a function body exceeds the specified number of newlines and doesn't have
 # a comment after the close brace, a comment will be added.
@@ -2595,10 +2954,13 @@ mod_sort_case_sensitive         = false    # true/false
 # Whether to sort consecutive single-line 'import' statements.
 mod_sort_import                 = false    # true/false
 
+# (C#) Whether to sort consecutive single-line 'using' statements.
+mod_sort_using                  = false    # true/false
+
 # Whether to sort consecutive single-line '#include' statements (C/C++) and
 # '#import' statements (Objective-C). Be aware that this has the potential to
 # break your code if your includes/imports have ordering dependencies.
-mod_sort_include                = true    # true/false
+mod_sort_include                = true     # true/false
 
 # Whether to prioritize '#include' and '#import' statements that contain
 # filename without extension when sorting is enabled.
@@ -2610,14 +2972,14 @@ mod_sort_incl_import_prioritize_extensionless = false    # true/false
 
 # Whether to prioritize '#include' and '#import' statements that contain
 # angle over quotes when sorting is enabled.
-mod_sort_incl_import_prioritize_angle_over_quotes = true    # true/false
+mod_sort_incl_import_prioritize_angle_over_quotes = true     # true/false
 
 # Whether to ignore file extension in '#include' and '#import' statements
 # for sorting comparison.
 mod_sort_incl_import_ignore_extension = false    # true/false
 
 # Whether to group '#include' and '#import' statements when sorting is enabled.
-mod_sort_incl_import_grouping_enabled = true    # true/false
+mod_sort_incl_import_grouping_enabled = true     # true/false
 
 # Whether to move a 'break' that appears after a fully braced 'case' before
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
@@ -2633,6 +2995,33 @@ mod_remove_empty_return         = false    # true/false
 
 # Add or remove the comma after the last value of an enumeration.
 mod_enum_last_comma             = ignore   # ignore/add/remove/force/not_defined
+
+# (OC) Whether to organize the properties. If true, properties will be
+# rearranged according to the mod_sort_oc_property_*_weight factors.
+mod_sort_oc_properties          = false    # true/false
+
+# (OC) Weight of a class property modifier.
+mod_sort_oc_property_class_weight = 0        # number
+
+# (OC) Weight of 'atomic' and 'nonatomic'.
+mod_sort_oc_property_thread_safe_weight = 0        # number
+
+# (OC) Weight of 'readwrite' when organizing properties.
+mod_sort_oc_property_readwrite_weight = 0        # number
+
+# (OC) Weight of a reference type specifier ('retain', 'copy', 'assign',
+# 'weak', 'strong') when organizing properties.
+mod_sort_oc_property_reference_weight = 0        # number
+
+# (OC) Weight of getter type ('getter=') when organizing properties.
+mod_sort_oc_property_getter_weight = 0        # number
+
+# (OC) Weight of setter type ('setter=') when organizing properties.
+mod_sort_oc_property_setter_weight = 0        # number
+
+# (OC) Weight of nullability type ('nullable', 'nonnull', 'null_unspecified',
+# 'null_resettable') when organizing properties.
+mod_sort_oc_property_nullability_weight = 0        # number
 
 #
 # Preprocessor options
@@ -2676,6 +3065,9 @@ pp_indent_if                    = 0        # number
 
 # Whether to indent the code between #if, #else and #endif.
 pp_if_indent_code               = false    # true/false
+
+# Whether to indent the body of an #if that encompasses all the code in the file.
+pp_indent_in_guard              = false    # true/false
 
 # Whether to indent '#define' at the brace level. If false, these are
 # indented from column 1.
@@ -2786,6 +3178,12 @@ use_form_feed_no_more_as_whitespace_character = false    # true/false
 # Warn levels - 1: error, 2: warning (default), 3: note
 #
 
+# (C#) Warning is given if doing tab-to-\t replacement and we have found one
+# in a C# verbatim string literal.
+#
+# Default: 2
+warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
+
 # Limit the number of loops.
 # Used by uncrustify.cpp to exit from infinite loop.
 # 0: no limit.
@@ -2857,30 +3255,29 @@ debug_truncate                  = 0        # unsigned number
 #       `macro-close END_MESSAGE_MAP`
 #
 #
-# option(s) with 'not default' value: 0
+set PREPROC                      FUNC_API_CHECK_TEXTLOCK
+set PREPROC                      FUNC_API_DEPRECATED_SINCE
+set PREPROC                      FUNC_API_FAST
+set PREPROC                      FUNC_API_LUA_ONLY
+set PREPROC                      FUNC_API_NOEXPORT
+set PREPROC                      FUNC_API_REMOTE_ONLY
+set PREPROC                      FUNC_API_SINCE
+set PREPROC                      FUNC_ATTR_ALWAYS_INLINE
+set PREPROC                      FUNC_ATTR_CONST
+set PREPROC                      FUNC_ATTR_MALLOC
+set PREPROC                      FUNC_ATTR_NONNULL_ALL
+set PREPROC                      FUNC_ATTR_NONNULL_ARG
+set PREPROC                      FUNC_ATTR_NONNULL_RET
+set PREPROC                      FUNC_ATTR_NORETURN
+set PREPROC                      FUNC_ATTR_NO_SANITIZE_UNDEFINED
+set PREPROC                      FUNC_ATTR_PRINTF
+set PREPROC                      FUNC_ATTR_PURE
+set PREPROC                      FUNC_ATTR_UNUSED
+set PREPROC                      FUNC_ATTR_WARN_UNUSED_RESULT
+set PREPROC                      REAL_FATTR_ALWAYS_INLINE
+set PREPROC                      REAL_FATTR_CONST
+set PREPROC                      REAL_FATTR_NONNULL_ALL
+set PREPROC                      REAL_FATTR_PURE
+set PREPROC                      REAL_FATTR_WARN_UNUSED_RESULT
+# option(s) with 'not default' value: 56
 #
-
-set PREPROC FUNC_API_CHECK_TEXTLOCK
-set PREPROC FUNC_API_DEPRECATED_SINCE
-set PREPROC FUNC_API_FAST
-set PREPROC FUNC_API_LUA_ONLY
-set PREPROC FUNC_API_NOEXPORT
-set PREPROC FUNC_API_REMOTE_ONLY
-set PREPROC FUNC_API_SINCE
-set PREPROC FUNC_ATTR_ALWAYS_INLINE
-set PREPROC FUNC_ATTR_CONST
-set PREPROC FUNC_ATTR_MALLOC
-set PREPROC FUNC_ATTR_NONNULL_ALL
-set PREPROC FUNC_ATTR_NONNULL_ARG
-set PREPROC FUNC_ATTR_NONNULL_RET
-set PREPROC FUNC_ATTR_NORETURN
-set PREPROC FUNC_ATTR_NO_SANITIZE_UNDEFINED
-set PREPROC FUNC_ATTR_PRINTF
-set PREPROC FUNC_ATTR_PURE
-set PREPROC FUNC_ATTR_UNUSED
-set PREPROC FUNC_ATTR_WARN_UNUSED_RESULT
-set PREPROC REAL_FATTR_ALWAYS_INLINE
-set PREPROC REAL_FATTR_CONST
-set PREPROC REAL_FATTR_NONNULL_ALL
-set PREPROC REAL_FATTR_PURE
-set PREPROC REAL_FATTR_WARN_UNUSED_RESULT

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -135,7 +135,7 @@ static size_t linebuf_size = 0;
 static schar_T *linebuf_char = NULL;
 static sattr_T *linebuf_attr = NULL;
 
-static match_T search_hl;       /* used for 'hlsearch' highlight matching */
+static match_T search_hl;       // used for 'hlsearch' highlight matching
 
 StlClickDefinition *tab_page_click_defs = NULL;
 
@@ -210,7 +210,7 @@ void redraw_later(win_T *wp, int type)
     if (type >= NOT_VALID) {
       wp->w_lines_valid = 0;
     }
-    if (must_redraw < type) {   /* must_redraw is the maximum of all windows */
+    if (must_redraw < type) {   // must_redraw is the maximum of all windows
       must_redraw = type;
     }
   }
@@ -336,7 +336,7 @@ int update_screen(int type)
   }
 
   if (must_redraw) {
-    if (type < must_redraw) {       /* use maximal type */
+    if (type < must_redraw) {       // use maximal type
       type = must_redraw;
     }
 
@@ -347,7 +347,7 @@ int update_screen(int type)
     must_redraw = 0;
   }
 
-  /* Need to update w_lines[]. */
+  // Need to update w_lines[].
   if (curwin->w_lines_valid == 0 && type < NOT_VALID) {
     type = NOT_VALID;
   }
@@ -447,10 +447,10 @@ int update_screen(int type)
   win_ui_flush();
   msg_ext_check_clear();
 
-  /* reset cmdline_row now (may have been changed temporarily) */
+  // reset cmdline_row now (may have been changed temporarily)
   compute_cmdrow();
 
-  /* Check for changed highlighting */
+  // Check for changed highlighting
   if (need_highlight_changed) {
     highlight_changed();
   }
@@ -503,7 +503,7 @@ int update_screen(int type)
     redraw_tabline = true;
   }
 
-  if (clear_cmdline) {          /* going to clear cmdline (done below) */
+  if (clear_cmdline) {          // going to clear cmdline (done below)
     check_for_delay(FALSE);
   }
 
@@ -606,7 +606,7 @@ int update_screen(int type)
       win_update(wp, &providers);
     }
 
-    /* redraw status line after the window to minimize cursor movement */
+    // redraw status line after the window to minimize cursor movement
     if (wp->w_redr_status) {
       win_redr_status(wp);
     }
@@ -635,7 +635,7 @@ int update_screen(int type)
     showmode();
   }
 
-  /* May put up an introductory message when not editing a file */
+  // May put up an introductory message when not editing a file
   if (!did_intro) {
     maybe_intro_message();
   }
@@ -754,10 +754,10 @@ static void win_update(win_T *wp, Providers *providers)
   bool scrolled_down = false;   // true when scrolled down when w_topline got smaller a bit
   bool top_to_mod = false;      // redraw above mod_top
 
-  int row;                      /* current window row to display */
-  linenr_T lnum;                /* current buffer lnum to display */
-  int idx;                      /* current index in w_lines[] */
-  int srow;                     /* starting row of the current line */
+  int row;                      // current window row to display
+  linenr_T lnum;                // current buffer lnum to display
+  int idx;                      // current index in w_lines[]
+  int srow;                     // starting row of the current line
 
   bool eof = false;             // if true, we hit the end of the file
   bool didline = false;         // if true, we finished the last line
@@ -772,7 +772,7 @@ static void win_update(win_T *wp, Providers *providers)
 #define DID_LINE 2      // updated a normal line
 #define DID_FOLD 3      // updated a folded line
   int did_update = DID_NONE;
-  linenr_T syntax_last_parsed = 0;              /* last parsed text line */
+  linenr_T syntax_last_parsed = 0;              // last parsed text line
   linenr_T mod_top = 0;
   linenr_T mod_bot = 0;
   int save_got_int;
@@ -952,10 +952,10 @@ static void win_update(win_T *wp, Providers *providers)
       }
     }
     if (top_end == 0) {
-      /* not found (cannot happen?): redraw everything */
+      // not found (cannot happen?): redraw everything
       type = NOT_VALID;
     } else {
-      /* top area defined, the rest is VALID */
+      // top area defined, the rest is VALID
       type = VALID;
     }
   }
@@ -1003,7 +1003,7 @@ static void win_update(win_T *wp, Providers *providers)
       }
       if (j < wp->w_grid.Rows - 2) {               // not too far off
         i = plines_m_win(wp, wp->w_topline, wp->w_lines[0].wl_lnum - 1);
-        /* insert extra lines for previously invisible filler lines */
+        // insert extra lines for previously invisible filler lines
         if (wp->w_lines[0].wl_lnum != wp->w_topline) {
           i += diff_check_fill(wp, wp->w_lines[0].wl_lnum)
                - wp->w_old_topfill;
@@ -1044,7 +1044,7 @@ static void win_update(win_T *wp, Providers *providers)
        * needs updating.
        */
 
-      /* try to find wp->w_topline in wp->w_lines[].wl_lnum */
+      // try to find wp->w_topline in wp->w_lines[].wl_lnum
       j = -1;
       row = 0;
       for (i = 0; i < wp->w_lines_valid; i++) {
@@ -1071,7 +1071,7 @@ static void win_update(win_T *wp, Providers *providers)
         } else {
           row += diff_check_fill(wp, wp->w_topline);
         }
-        /* ... but don't delete new filler lines. */
+        // ... but don't delete new filler lines.
         row -= wp->w_topfill;
         if (row > 0) {
           win_scroll_lines(wp, 0, -row);
@@ -1097,7 +1097,7 @@ static void win_update(win_T *wp, Providers *providers)
             }
             bot_start += wp->w_lines[idx++].wl_size;
 
-            /* stop at the last valid entry in w_lines[].wl_size */
+            // stop at the last valid entry in w_lines[].wl_size
             if (++j >= wp->w_lines_valid) {
               wp->w_lines_valid = idx;
               break;
@@ -1119,19 +1119,19 @@ static void win_update(win_T *wp, Providers *providers)
       mid_end = wp->w_grid.Rows;
     }
   } else {
-    /* Not VALID or INVERTED: redraw all lines. */
+    // Not VALID or INVERTED: redraw all lines.
     mid_start = 0;
     mid_end = wp->w_grid.Rows;
   }
 
   if (type == SOME_VALID) {
-    /* SOME_VALID: redraw all lines. */
+    // SOME_VALID: redraw all lines.
     mid_start = 0;
     mid_end = wp->w_grid.Rows;
     type = NOT_VALID;
   }
 
-  /* check if we are updating or removing the inverted part */
+  // check if we are updating or removing the inverted part
   if ((VIsual_active && buf == curwin->w_buffer)
       || (wp->w_old_cursor_lnum != 0 && type != NOT_VALID)) {
     linenr_T from, to;
@@ -1148,7 +1148,7 @@ static void win_update(win_T *wp, Providers *providers)
           from = VIsual.lnum;
           to = curwin->w_cursor.lnum;
         }
-        /* redraw more when the cursor moved as well */
+        // redraw more when the cursor moved as well
         if (wp->w_old_cursor_lnum < from) {
           from = wp->w_old_cursor_lnum;
         }
@@ -1173,7 +1173,7 @@ static void win_update(win_T *wp, Providers *providers)
         } else {
           from = wp->w_old_cursor_lnum;
           to = curwin->w_cursor.lnum;
-          if (from == 0) {              /* Visual mode just started */
+          if (from == 0) {              // Visual mode just started
             from = to;
           }
         }
@@ -1231,7 +1231,7 @@ static void win_update(win_T *wp, Providers *providers)
         wp->w_old_cursor_lcol = toc;
       }
     } else {
-      /* Use the line numbers of the old Visual area. */
+      // Use the line numbers of the old Visual area.
       if (wp->w_old_cursor_lnum < wp->w_old_visual_lnum) {
         from = wp->w_old_cursor_lnum;
         to = wp->w_old_visual_lnum;
@@ -1279,7 +1279,7 @@ static void win_update(win_T *wp, Providers *providers)
       } else {
         mid_start = 0;
       }
-      while (lnum < from && idx < wp->w_lines_valid) {          /* find start */
+      while (lnum < from && idx < wp->w_lines_valid) {          // find start
         if (wp->w_lines[idx].wl_valid) {
           mid_start += wp->w_lines[idx].wl_size;
         } else if (!scrolled_down) {
@@ -1297,7 +1297,7 @@ static void win_update(win_T *wp, Providers *providers)
       for (; idx < wp->w_lines_valid; idx++) {                  // find end
         if (wp->w_lines[idx].wl_valid
             && wp->w_lines[idx].wl_lnum >= to + 1) {
-          /* Only update until first row of this line */
+          // Only update until first row of this line
           mid_end = srow;
           break;
         }
@@ -1319,7 +1319,7 @@ static void win_update(win_T *wp, Providers *providers)
     wp->w_old_visual_col = 0;
   }
 
-  /* reset got_int, otherwise regexp won't work */
+  // reset got_int, otherwise regexp won't work
   save_got_int = got_int;
   got_int = 0;
   // Set the time limit to 'redrawtime'.
@@ -1329,7 +1329,7 @@ static void win_update(win_T *wp, Providers *providers)
   /*
    * Update all the window rows.
    */
-  idx = 0;              /* first entry in w_lines[].wl_size */
+  idx = 0;              // first entry in w_lines[].wl_size
   row = 0;
   srow = 0;
   lnum = wp->w_topline;  // first line shown in window
@@ -1369,7 +1369,7 @@ static void win_update(win_T *wp, Providers *providers)
       break;
     }
 
-    /* stop updating when hit the end of the file */
+    // stop updating when hit the end of the file
     if (lnum > buf->b_ml.ml_line_count) {
       eof = true;
       break;
@@ -1509,15 +1509,15 @@ static void win_update(win_T *wp, Providers *providers)
             if (j < i) {
               int x = row + new_rows;
 
-              /* move entries in w_lines[] upwards */
+              // move entries in w_lines[] upwards
               for (;; ) {
-                /* stop at last valid entry in w_lines[] */
+                // stop at last valid entry in w_lines[]
                 if (i >= wp->w_lines_valid) {
                   wp->w_lines_valid = j;
                   break;
                 }
                 wp->w_lines[j] = wp->w_lines[i];
-                /* stop at a line that won't fit */
+                // stop at a line that won't fit
                 if (x + (int)wp->w_lines[j].wl_size
                     > wp->w_grid.Rows) {
                   wp->w_lines_valid = j + 1;
@@ -1529,8 +1529,8 @@ static void win_update(win_T *wp, Providers *providers)
               if (bot_start > x) {
                 bot_start = x;
               }
-            } else {       /* j > i */
-                           /* move entries in w_lines[] downwards */
+            } else {       // j > i
+                           // move entries in w_lines[] downwards
               j -= i;
               wp->w_lines_valid += j;
               if (wp->w_lines_valid > wp->w_grid.Rows) {
@@ -1572,7 +1572,7 @@ static void win_update(win_T *wp, Providers *providers)
         row = wp->w_grid.Rows + 1;
       } else {
         prepare_search_hl(wp, lnum);
-        /* Let the syntax stuff know we skipped a few lines. */
+        // Let the syntax stuff know we skipped a few lines.
         if (syntax_last_parsed != 0 && syntax_last_parsed + 1 < lnum
             && syntax_present(wp)) {
           syntax_end_parsing(syntax_last_parsed + 1);
@@ -1724,7 +1724,7 @@ static void win_update(win_T *wp, Providers *providers)
   }
   syn_set_timeout(NULL);
 
-  /* Reset the type of redrawing required, the window has been updated. */
+  // Reset the type of redrawing required, the window has been updated.
   wp->w_redr_type = 0;
   wp->w_old_topfill = wp->w_topfill;
   wp->w_old_botfill = wp->w_botfill;
@@ -1794,7 +1794,7 @@ static void win_update(win_T *wp, Providers *providers)
   }
 
 
-  /* restore got_int, unless CTRL-C was hit while redrawing */
+  // restore got_int, unless CTRL-C was hit while redrawing
   if (!got_int) {
     got_int = save_got_int;
   }
@@ -2067,12 +2067,12 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
   int saved_c_final = 0;
   int saved_char_attr = 0;
 
-  int n_attr = 0;                       /* chars with special attr */
-  int saved_attr2 = 0;                  /* char_attr saved for n_attr */
-  int n_attr3 = 0;                      /* chars with overruling special attr */
-  int saved_attr3 = 0;                  /* char_attr saved for n_attr3 */
+  int n_attr = 0;                       // chars with special attr
+  int saved_attr2 = 0;                  // char_attr saved for n_attr
+  int n_attr3 = 0;                      // chars with overruling special attr
+  int saved_attr3 = 0;                  // char_attr saved for n_attr3
 
-  int n_skip = 0;                       /* nr of chars to skip for 'nowrap' */
+  int n_skip = 0;                       // nr of chars to skip for 'nowrap'
 
   int fromcol = -10;                    // start of inverting
   int tocol = MAXCOL;                   // end of inverting
@@ -2082,29 +2082,29 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
   pos_T pos;
   long v;
 
-  int char_attr = 0;                    /* attributes for next character */
-  int attr_pri = FALSE;                 /* char_attr has priority */
+  int char_attr = 0;                    // attributes for next character
+  int attr_pri = FALSE;                 // char_attr has priority
   int area_highlighting = FALSE;           /* Visual or incsearch highlighting
                                               in this line */
-  int attr = 0;                         /* attributes for area highlighting */
-  int area_attr = 0;                    /* attributes desired by highlighting */
-  int search_attr = 0;                  /* attributes desired by 'hlsearch' */
-  int vcol_save_attr = 0;               /* saved attr for 'cursorcolumn' */
-  int syntax_attr = 0;                  /* attributes desired by syntax */
-  int has_syntax = FALSE;               /* this buffer has syntax highl. */
+  int attr = 0;                         // attributes for area highlighting
+  int area_attr = 0;                    // attributes desired by highlighting
+  int search_attr = 0;                  // attributes desired by 'hlsearch'
+  int vcol_save_attr = 0;               // saved attr for 'cursorcolumn'
+  int syntax_attr = 0;                  // attributes desired by syntax
+  int has_syntax = FALSE;               // this buffer has syntax highl.
   int save_did_emsg;
   int eol_hl_off = 0;                   // 1 if highlighted char after EOL
   bool draw_color_col = false;          // highlight colorcolumn
   int *color_cols = NULL;               // pointer to according columns array
   bool has_spell = false;               // this buffer has spell checking
 # define SPWORDLEN 150
-  char_u nextline[SPWORDLEN * 2];       /* text with start of the next line */
-  int nextlinecol = 0;                  /* column where nextline[] starts */
+  char_u nextline[SPWORDLEN * 2];       // text with start of the next line
+  int nextlinecol = 0;                  // column where nextline[] starts
   int nextline_idx = 0;                 /* index in nextline[] where next line
                                            starts */
-  int spell_attr = 0;                   /* attributes desired by spelling */
-  int word_end = 0;                     /* last byte with same spell_attr */
-  static linenr_T checked_lnum = 0;     /* line number for "checked_col" */
+  int spell_attr = 0;                   // attributes desired by spelling
+  int word_end = 0;                     // last byte with same spell_attr
+  static linenr_T checked_lnum = 0;     // line number for "checked_col"
   static int checked_col = 0;           /* column in "checked_lnum" up to which
                                          * there are no spell errors */
   static int cap_col = -1;              // column to check for Cap word
@@ -2156,16 +2156,16 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
   int left_curline_col = 0;
   int right_curline_col = 0;
 
-  /* draw_state: items that are drawn in sequence: */
-#define WL_START        0               /* nothing done yet */
-# define WL_CMDLINE     WL_START + 1    /* cmdline window column */
-# define WL_FOLD        WL_CMDLINE + 1  /* 'foldcolumn' */
-# define WL_SIGN        WL_FOLD + 1     /* column for signs */
-#define WL_NR           WL_SIGN + 1     /* line number */
-# define WL_BRI         WL_NR + 1       /* 'breakindent' */
-# define WL_SBR         WL_BRI + 1       /* 'showbreak' or 'diff' */
-#define WL_LINE         WL_SBR + 1      /* text in the line */
-  int draw_state = WL_START;            /* what to draw next */
+  // draw_state: items that are drawn in sequence:
+#define WL_START        0               // nothing done yet
+# define WL_CMDLINE     WL_START + 1    // cmdline window column
+# define WL_FOLD        WL_CMDLINE + 1  // 'foldcolumn'
+# define WL_SIGN        WL_FOLD + 1     // column for signs
+#define WL_NR           WL_SIGN + 1     // line number
+# define WL_BRI         WL_NR + 1       // 'breakindent'
+# define WL_SBR         WL_BRI + 1       // 'showbreak' or 'diff'
+#define WL_LINE         WL_SBR + 1      // text in the line
+  int draw_state = WL_START;            // what to draw next
 
   int syntax_flags    = 0;
   int syntax_seqnr    = 0;
@@ -2189,7 +2189,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
     boguscols = 0; \
   }
 
-  if (startrow > endrow) {              /* past the end already! */
+  if (startrow > endrow) {              // past the end already!
     return startrow;
   }
 
@@ -2392,14 +2392,14 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
   if (filler_lines < 0) {
     if (filler_lines == -1) {
       if (diff_find_change(wp, lnum, &change_start, &change_end)) {
-        diff_hlf = HLF_ADD;             /* added line */
+        diff_hlf = HLF_ADD;             // added line
       } else if (change_start == 0) {
-        diff_hlf = HLF_TXD;             /* changed text */
+        diff_hlf = HLF_TXD;             // changed text
       } else {
-        diff_hlf = HLF_CHD;             /* changed line */
+        diff_hlf = HLF_CHD;             // changed line
       }
     } else {
-      diff_hlf = HLF_ADD;               /* added line */
+      diff_hlf = HLF_ADD;               // added line
     }
     filler_lines = 0;
     area_highlighting = TRUE;
@@ -2479,7 +2479,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
      * current line into nextline[].  Above the start of the next line was
      * copied to nextline[SPWORDLEN]. */
     if (nextline[SPWORDLEN] == NUL) {
-      /* No next line or it is empty. */
+      // No next line or it is empty.
       nextlinecol = MAXCOL;
       nextline_idx = 0;
     } else {
@@ -2492,7 +2492,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         STRMOVE(nextline + v, nextline + SPWORDLEN);
         nextline_idx = v + 1;
       } else {
-        /* Long line, use only the last SPWORDLEN bytes. */
+        // Long line, use only the last SPWORDLEN bytes.
         nextlinecol = v - SPWORDLEN;
         memmove(nextline, line + nextlinecol, SPWORDLEN);  // -V512
         nextline_idx = SPWORDLEN + 1;
@@ -2610,11 +2610,11 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         spell_hlf = HLF_COUNT;
         word_end = (int)(spell_to_word_end(ptr, wp) - line + 1);
       } else {
-        /* bad word found, use attributes until end of word */
+        // bad word found, use attributes until end of word
         assert(len <= INT_MAX);
         word_end = wp->w_cursor.col + (int)len + 1;
 
-        /* Turn index into actual attributes. */
+        // Turn index into actual attributes.
         if (spell_hlf != HLF_COUNT) {
           spell_attr = highlight_attr[spell_hlf];
         }
@@ -2640,7 +2640,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         fromcol_prev = fromcol;
         fromcol = -1;
       } else if ((colnr_T)fromcol < wp->w_virtcol) {
-        /* restart highlighting after the cursor */
+        // restart highlighting after the cursor
         fromcol_prev = wp->w_virtcol;
       }
     }
@@ -2748,7 +2748,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       if (draw_state == WL_CMDLINE - 1 && n_extra == 0) {
         draw_state = WL_CMDLINE;
         if (cmdwin_type != 0 && wp == curwin) {
-          /* Draw the cmdline character. */
+          // Draw the cmdline character.
           n_extra = 1;
           c_extra = cmdwin_type;
           c_final = NUL;
@@ -2949,7 +2949,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           char_attr = win_hl_attr(wp, HLF_DED);
         }
         if (*p_sbr != NUL && need_showbreak) {
-          /* Draw 'showbreak' at the start of each broken line. */
+          // Draw 'showbreak' at the start of each broken line.
           p_extra = p_sbr;
           c_extra = NUL;
           c_final = NUL;
@@ -2981,7 +2981,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         }
 
         if (saved_n_extra) {
-          /* Continue item from end of wrapped line. */
+          // Continue item from end of wrapped line.
           n_extra = saved_n_extra;
           c_extra = saved_c_extra;
           c_final = saved_c_final;
@@ -3539,7 +3539,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
               checked_col = (int)((p - nextline) + len - nextline_idx);
             }
 
-            /* Turn index into actual attributes. */
+            // Turn index into actual attributes.
             if (spell_hlf != HLF_COUNT) {
               spell_attr = highlight_attr[spell_hlf];
             }
@@ -3553,7 +3553,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
                 cap_col = (int)((p - nextline) + cap_col
                                 - nextline_idx);
               } else {
-                /* Compute the actual column. */
+                // Compute the actual column.
                 cap_col += (int)(prev_ptr - line);
               }
             }
@@ -3600,7 +3600,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           c_final = NUL;
           if (ascii_iswhite(c)) {
             if (c == TAB) {
-              /* See "Tab alignment" below. */
+              // See "Tab alignment" below.
               FIX_FOR_BOGUSCOLS;
             }
             if (!wp->w_p_list) {
@@ -3749,7 +3749,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
                  ? wp->w_p_lcs_chars.tab3
                  : wp->w_p_lcs_chars.tab1;
             if (wp->w_p_lbr) {
-              c_extra = NUL;  /* using p_extra from above */
+              c_extra = NUL;  // using p_extra from above
             } else {
               c_extra = wp->w_p_lcs_chars.tab2;
             }
@@ -3818,7 +3818,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
             n_extra = byte2cells(c) - 1;
           }
           if ((dy_flags & DY_UHEX) && wp->w_p_rl) {
-            rl_mirror(p_extra);                 /* reverse "<12>" */
+            rl_mirror(p_extra);                 // reverse "<12>"
           }
           c_extra = NUL;
           c_final = NUL;
@@ -4068,7 +4068,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         v = wp->w_leftcol;
       }
 
-      /* check if line ends before left margin */
+      // check if line ends before left margin
       if (vcol < v + col - win_col_off(wp)) {
         vcol = v + col - win_col_off(wp);
       }
@@ -4290,7 +4290,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           tocol++;
         }
         if (wp->w_p_rl) {
-          /* now it's time to backup one cell */
+          // now it's time to backup one cell
           --off;
           --col;
         }
@@ -4376,12 +4376,12 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       char_attr = vcol_save_attr;
     }
 
-    /* restore attributes after "predeces" in 'listchars' */
+    // restore attributes after "predeces" in 'listchars'
     if (draw_state > WL_NR && n_attr3 > 0 && --n_attr3 == 0) {
       char_attr = saved_attr3;
     }
 
-    /* restore attributes after last 'listchars' or 'number' char */
+    // restore attributes after last 'listchars' or 'number' char
     if (n_attr > 0 && draw_state == WL_LINE && --n_attr == 0) {
       char_attr = saved_attr2;
     }
@@ -4439,7 +4439,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         row = endrow;
       }
 
-      /* When line got too long for screen break here. */
+      // When line got too long for screen break here.
       if (row == endrow) {
         ++row;
         break;
@@ -4452,7 +4452,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         off += col;
       }
 
-      /* reset the drawing state for the start of a wrapped line */
+      // reset the drawing state for the start of a wrapped line
       draw_state = WL_START;
       saved_n_extra = n_extra;
       saved_p_extra = p_extra;
@@ -4471,9 +4471,9 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         break;
       }
     }
-  }     /* for every character in the line */
+  }     // for every character in the line
 
-  /* After an empty line check first word for capital. */
+  // After an empty line check first word for capital.
   if (*skipwhite(line) == NUL) {
     capcol_lnum = lnum + 1;
     cap_col = 0;
@@ -4711,7 +4711,7 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, 
   max_off_to = grid->line_offset[row] + grid->Columns;
 
   if (rlflag) {
-    /* Clear rest first, because it's left of the text. */
+    // Clear rest first, because it's left of the text.
     if (clear_width > 0) {
       while (col <= endcol && grid->chars[off_to][0] == ' '
              && grid->chars[off_to][1] == NUL
@@ -4945,7 +4945,7 @@ static int status_match_len(expand_T *xp, char_u *s)
   int emenu = (xp->xp_context == EXPAND_MENUS
                || xp->xp_context == EXPAND_MENUNAMES);
 
-  /* Check for menu separators - replace with '|'. */
+  // Check for menu separators - replace with '|'.
   if (emenu && menu_is_separator(s)) {
     return 1;
   }
@@ -4987,14 +4987,14 @@ static int skip_status_match_char(expand_T *xp, char_u *s)
  *
  * If inversion is possible we use it. Else '=' characters are used.
  */
-void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches,          /* list of matches */
+void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches,          // list of matches
                              int match, int showtail)
 {
 #define L_MATCH(m) (showtail ? sm_gettail(matches[m], false) : matches[m])
   int row;
   char_u      *buf;
   int len;
-  int clen;                     /* length in screen cells */
+  int clen;                     // length in screen cells
   int fillchar;
   int attr;
   int i;
@@ -5008,26 +5008,26 @@ void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches,   
   int emenu;
   int l;
 
-  if (matches == NULL) {        /* interrupted completion? */
+  if (matches == NULL) {        // interrupted completion?
     return;
   }
 
   buf = xmalloc(Columns * MB_MAXBYTES + 1);
 
-  if (match == -1) {    /* don't show match but original text */
+  if (match == -1) {    // don't show match but original text
     match = 0;
     highlight = false;
   }
-  /* count 1 for the ending ">" */
+  // count 1 for the ending ">"
   clen = status_match_len(xp, L_MATCH(match)) + 3;
   if (match == 0) {
     first_match = 0;
   } else if (match < first_match) {
-    /* jumping left, as far as we can go */
+    // jumping left, as far as we can go
     first_match = match;
     add_left = true;
   } else {
-    /* check if match fits on the screen */
+    // check if match fits on the screen
     for (i = first_match; i < match; ++i) {
       clen += status_match_len(xp, L_MATCH(i)) + 2;
     }
@@ -5037,7 +5037,7 @@ void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches,   
     // jumping right, put match at the left
     if ((long)clen > Columns) {
       first_match = match;
-      /* if showing the last match, we can add some on the left */
+      // if showing the last match, we can add some on the left
       clen = 2;
       for (i = match; i < num_matches; ++i) {
         clen += status_match_len(xp, L_MATCH(i)) + 2;
@@ -5079,7 +5079,7 @@ void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches,   
     }
 
     s = L_MATCH(i);
-    /* Check for menu separators - replace with '|' */
+    // Check for menu separators - replace with '|'
     emenu = (xp->xp_context == EXPAND_MENUS
              || xp->xp_context == EXPAND_MENUNAMES);
     if (emenu && menu_is_separator(s)) {
@@ -5199,7 +5199,7 @@ static void win_redr_status(win_T *wp)
     // popup menu is visible and may be drawn over it
     wp->w_redr_status = true;
   } else if (*p_stl != NUL || *wp->w_p_stl != NUL) {
-    /* redraw custom status line */
+    // redraw custom status line
     redraw_custom_statusline(wp);
   } else {
     fillchar = fillchar_status(&attr, wp);
@@ -5361,7 +5361,7 @@ bool get_keymap_str(win_T *wp, char_u *fmt, char_u *buf, int len)
 
     curbuf = wp->w_buffer;
     curwin = wp;
-    STRCPY(buf, "b:keymap_name");       /* must be writable */
+    STRCPY(buf, "b:keymap_name");       // must be writable
     ++emsg_skip;
     s = p = eval_to_string(buf, NULL, FALSE);
     --emsg_skip;
@@ -5417,9 +5417,9 @@ static void win_redr_custom(win_T *wp, bool draw_ruler)
   }
   entered = true;
 
-  /* setup environment for the task at hand */
+  // setup environment for the task at hand
   if (wp == NULL) {
-    /* Use 'tabline'.  Always at the first line of the screen. */
+    // Use 'tabline'.  Always at the first line of the screen.
     stl = p_tal;
     row = 0;
     fillchar = ' ';
@@ -5433,7 +5433,7 @@ static void win_redr_custom(win_T *wp, bool draw_ruler)
 
     if (draw_ruler) {
       stl = p_ruf;
-      /* advance past any leading group spec - implicit in ru_col */
+      // advance past any leading group spec - implicit in ru_col
       if (*stl == '%') {
         if (*++stl == '-') {
           stl++;
@@ -5499,7 +5499,7 @@ static void win_redr_custom(win_T *wp, bool draw_ruler)
   len = (size_t)len < sizeof(buf) ? len : (int)sizeof(buf) - 1;
   xfree(p);
 
-  /* fill up with "fillchar" */
+  // fill up with "fillchar"
   while (width < maxwidth && len < (int)sizeof(buf) - 1) {
     len += utf_char2bytes(fillchar, buf + len);
     width++;
@@ -5782,7 +5782,7 @@ void grid_puts_len(ScreenGrid *grid, char_u *text, int textlen, int row, int col
   int u8c = 0;
   int u8cc[MAX_MCO];
   int clear_next_cell = FALSE;
-  int prev_c = 0;                       /* previous Arabic character */
+  int prev_c = 0;                       // previous Arabic character
   int pc, nc, nc1;
   int pcc[MAX_MCO];
   int need_redraw;
@@ -6065,9 +6065,9 @@ static void prepare_search_hl(win_T *wp, linenr_T lnum)
  * shl->lnum is zero.
  * Careful: Any pointers for buffer lines will become invalid.
  */
-static void next_search_hl(win_T *win, match_T *shl,               /* points to search_hl or a match */
-                           linenr_T lnum, colnr_T mincol,                /* minimal column for a match */
-                           matchitem_T *cur               /* to retrieve match positions if any */
+static void next_search_hl(win_T *win, match_T *shl,               // points to search_hl or a match
+                           linenr_T lnum, colnr_T mincol,                // minimal column for a match
+                           matchitem_T *cur               // to retrieve match positions if any
                            )
   FUNC_ATTR_NONNULL_ARG(2)
 {
@@ -6103,7 +6103,7 @@ static void next_search_hl(win_T *win, match_T *shl,               /* points to 
   for (;; ) {
     // Stop searching after passing the time limit.
     if (profile_passed_limit(shl->tm)) {
-      shl->lnum = 0;                    /* no match found in time */
+      shl->lnum = 0;                    // no match found in time
       break;
     }
     // Three situations:
@@ -6476,9 +6476,9 @@ retry:
     msg_grid_invalid = true;
   }
 
-  win_new_shellsize();      /* fit the windows in the new sized shell */
+  win_new_shellsize();      // fit the windows in the new sized shell
 
-  comp_col();           /* recompute columns for shown command and ruler */
+  comp_col();           // recompute columns for shown command and ruler
 
   // We're changing the size of the screen.
   // - Allocate new arrays for default_grid
@@ -6902,16 +6902,16 @@ int showmode(void)
 
     bool nwr_save = need_wait_return;
 
-    /* wait a bit before overwriting an important message */
+    // wait a bit before overwriting an important message
     check_for_delay(FALSE);
 
-    /* if the cmdline is more than one line high, erase top lines */
+    // if the cmdline is more than one line high, erase top lines
     need_clear = clear_cmdline;
     if (clear_cmdline && cmdline_row < Rows - 1) {
       msg_clr_cmdline();  // will reset clear_cmdline
     }
 
-    /* Position on the last line in the window, column 0 */
+    // Position on the last line in the window, column 0
     msg_pos_mode();
     attr = HL_ATTR(HLF_CM);                     // Highlight mode
 
@@ -7038,7 +7038,7 @@ int showmode(void)
   // NB: also handles clearing the showmode if it was empty or disabled
   msg_ext_flush_showmode();
 
-  /* In Visual mode the size of the selected area must be redrawn. */
+  // In Visual mode the size of the selected area must be redrawn.
   if (VIsual_active) {
     clear_showcmd();
   }
@@ -7147,7 +7147,7 @@ void draw_tabline(void)
   assert(Columns == tab_page_click_defs_size);
   clear_tab_page_click_defs(tab_page_click_defs, tab_page_click_defs_size);
 
-  /* Use the 'tabline' option if it's set. */
+  // Use the 'tabline' option if it's set.
   if (*p_tal != NUL) {
     int saved_did_emsg = did_emsg;
 
@@ -7233,7 +7233,7 @@ void draw_tabline(void)
 
       room = scol - col + tabwidth - 1;
       if (room > 0) {
-        /* Get buffer name in NameBuff[] */
+        // Get buffer name in NameBuff[]
         get_trans_bufname(cwp->w_buffer);
         (void)shorten_dir(NameBuff);
         len = vim_strsize(NameBuff);
@@ -7270,7 +7270,7 @@ void draw_tabline(void)
     }
     grid_fill(&default_grid, 0, 1, col, Columns, c, c, attr_fill);
 
-    /* Put an "X" for closing the current tab if there are several. */
+    // Put an "X" for closing the current tab if there are several.
     if (first_tabpage->tp_next != NULL) {
       grid_putchar(&default_grid, 'X', 0, Columns - 1, attr_nosel);
       tab_page_click_defs[Columns - 1] = (StlClickDefinition) {
@@ -7407,7 +7407,7 @@ void showruler(bool always)
       || (p_title && (stl_syntax & STL_IN_TITLE))) {
     maketitle();
   }
-  /* Redraw the tab pages line if needed. */
+  // Redraw the tab pages line if needed.
   if (redraw_tabline) {
     draw_tabline();
   }
@@ -7685,12 +7685,12 @@ void screen_resize(int width, int height)
     return;
   }
 
-  if (width < 0 || height < 0) {    /* just checking... */
+  if (width < 0 || height < 0) {    // just checking...
     return;
   }
 
   if (State == HITRETURN || State == SETWSIZE) {
-    /* postpone the resizing */
+    // postpone the resizing
     State = SETWSIZE;
     return;
   }


### PR DESCRIPTION
Also set new option cmt_trailing_single_line_c_to_cpp to true. It
converts trailing, single-line c-comments (/**/) into cpp-comments (//).