### PR TITLE
refactor(screen): let win_line() always handle fillers after last line

### DIFF
--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -21,6 +21,8 @@ typedef struct foldinfo {
   long fi_lines;
 } foldinfo_T;
 
+#define FOLDINFO_INIT { 0, 0, 0, 0 }
+
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "fold.h.generated.h"


### PR DESCRIPTION
A small breakout of #15351 . Virtual lines are built upon filler lines, so it simplifies stuff immensely if `screen.c` only has one code path for filler lines. Running this separately to see if it causes any trouble specifically.