### PR TITLE
fix(lsp): update workspace/applyEdit handler signature

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -144,7 +144,7 @@ M['textDocument/codeAction'] = function(_, result)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
-M['workspace/applyEdit'] = function(_, _, workspace_edit)
+M['workspace/applyEdit'] = function(_, workspace_edit)
   if not workspace_edit then return end
   -- TODO(ashkan) Do something more with label?
   if workspace_edit.label then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1226,7 +1226,7 @@ describe('LSP', function()
           label = nil;
           edit = {};
         }
-        return vim.lsp.handlers['workspace/applyEdit'](nil, nil, apply_edit)
+        return vim.lsp.handlers['workspace/applyEdit'](nil, apply_edit)
       ]])
     end)
   end)


### PR DESCRIPTION
I think the default handler for `workspace/applyEdit` wasn't updated in #15504. This PR updates the signature to match.