### PR TITLE
fix: handle unset local value of global-local option

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -292,7 +292,9 @@ Object get_option_from(void *from, int type, String name, Error *err)
     return rv;
   }
 
-  if (flags & SOPT_BOOL) {
+  if (flags & SOPT_UNSET) {
+    api_set_error(err, kErrorTypeException, "Failed to get value for option '%s'", name.data);
+  } else if (flags & SOPT_BOOL) {
     rv.type = kObjectTypeBoolean;
     rv.data.boolean = numval ? true : false;
   } else if (flags & SOPT_NUM) {


### PR DESCRIPTION
When `nvim_win_get_option` or `nvim_buf_get_option` are used to get the local value of a global-local number option, and the local value is unset, the return value is an uninitialized number.

For string-valued global-local options, an error is returned. Extend this behavior for number-valued global-local options as well, instead of returning a garbage value. This also makes the Lua `vim.opt` / `vim.o` API work as expected, since those functions depend on `nvim_{but,win}_get_option` returning an error when the local value is unset.

Closes #15587.
