### PR TITLE
tests: timeout at 20 minutes

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -58,6 +58,7 @@ execute_process(
     --lpath=?.lua
     ${BUSTED_ARGS}
     ${TEST_PATH}
+  TIMEOUT 1200
   WORKING_DIRECTORY ${WORKING_DIR}
   ERROR_VARIABLE err
   RESULT_VARIABLE res


### PR DESCRIPTION
Set a maximum test run-time of 20 minutes to:
- fail faster
- avoid wasting CI resources
- set a bound on the test time (if tests take longer than 20 minutes we   need to invest in parallelizing them...)

Timeout looks like:

    -- Tests exited non-zero: Process terminated due to timeout
    -- No output to stderr.
    CMake Error at /…/neovim/cmake/RunTests.cmake:86
    (message):
      functional tests failed with error: Process terminated due to timeout