### PR TITLE
fix(termdebug): replace term_getline with getbufline

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -263,7 +263,7 @@ func s:StartDebug_term(dict)
     endif
 
     for lnum in range(1, 200)
-      if term_getline(s:gdbbuf, lnum) =~ 'startupdone'
+      if get(getbufline(s:gdbbuf, lnum), 0, '') =~ 'startupdone'
     let try_count = 9999
     break
       endif


### PR DESCRIPTION
Correct incomplete runtime file port in
https://github.com/neovim/neovim/commit/79cbbd5179d816a64989243cb1ce85b802a2896f