### PR TITLE
test(busted): disable colors in test-runner output

### DIFF
--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -1,15 +1,9 @@
 local pretty = require 'pl.pretty'
 local global_helpers = require('test.helpers')
 
-local colors
-
-local isWindows = package.config:sub(1,1) == '\\'
-
-if isWindows then
-  colors = setmetatable({}, {__index = function() return function(s) return s end end})
-else
-  colors = require 'term.colors'
-end
+-- Colors are disabled. #15610
+-- To enable: `local colors = require 'term.colors'`
+local colors = setmetatable({}, {__index = function() return function(s) return s end end})
 
 return function(options)
   local busted = require 'busted'


### PR DESCRIPTION
Problem
-------

Because test/busted/outputHandlers/nvim.lua doesn't know if it's running in a terminal (no "isatty" equivalent), it outputs color codes in CI logs and local tooling that runs the tests in a pipe:

    [1m[33m[ SKIPPED ][0m[0m [36m

This is just noise, hard for humans to read.

Solution
--------

Disable the color codes. If we later find a clever way to detect a terminal in nvim.lua, we might consider re-enabling colors, but that would still affect the CI build logs...