### PR TITLE
docs: ignore health.lua files

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -767,17 +767,4 @@ new({source}, {lang}, {opts})                             *languagetree.new()*
                                        the injection language query per
                                        language.
 
-
-==============================================================================
-Lua module: vim.treesitter.health                          *treesitter-health*
-
-check_health()                                                *check_health()*
-                TODO: Documentation
-
-list_parsers()                                                *list_parsers()*
-                Lists the parsers currently installed
-
-                Return: ~
-                    A list of parsers
-
  vim:tw=78:ts=8:ft=help:norl:

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -197,7 +197,6 @@ CONFIG = {
             'query.lua',
             'highlighter.lua',
             'languagetree.lua',
-            'health.lua',
         ],
         'files': ' '.join([
             os.path.join(base_dir, 'runtime/lua/vim/treesitter.lua'),
@@ -1131,7 +1130,7 @@ Doxyfile = textwrap.dedent('''
     INPUT_FILTER           = "{filter}"
     EXCLUDE                =
     EXCLUDE_SYMLINKS       = NO
-    EXCLUDE_PATTERNS       = */private/*
+    EXCLUDE_PATTERNS       = */private/* */health.lua
     EXCLUDE_SYMBOLS        =
     EXTENSION_MAPPING      = lua=C
     EXTRACT_PRIVATE        = NO


### PR DESCRIPTION
The `gen_vimdoc.py` script is failing because of the addition of the `health.lua` file under `runtime/vim/lsp`. One solution is to just add `health.lua` to the `section_order` list, but the healthcheck functions shouldn't be included in the documentation. We could just mark these methods as `---@private` but being able to ignore certain files from the autogenerated docs seems more general-purpose and less error prone, particularly as we start to add more `health.lua` files moving forward.
