### PR TITLE
fix(lsp): fix last line diagnostics not displaying occasionally

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -270,18 +270,15 @@ local function set_diagnostic_cache(diagnostics, bufnr, client_id)
   -- client to interpret diagnostics as error, warning, info or hint.
   -- TODO: Replace this with server-specific heuristics to infer severity.
   local buf_line_count = vim.api.nvim_buf_line_count(bufnr)
+  local last_line = vim.api.nvim_buf_get_lines(bufnr, buf_line_count-1, buf_line_count, true)[1]
   for _, diagnostic in ipairs(diagnostics) do
     if diagnostic.severity == nil then
       diagnostic.severity = DiagnosticSeverity.Error
     end
     -- Account for servers that place diagnostics on terminating newline
-    if buf_line_count > 0 then
-      diagnostic.range.start.line = math.max(math.min(
-        diagnostic.range.start.line, buf_line_count - 1
-      ), 0)
-      diagnostic.range["end"].line = math.max(math.min(
-        diagnostic.range["end"].line, buf_line_count - 1
-      ), 0)
+    if buf_line_count > 0 and last_line and diagnostic.range.start.line >= buf_line_count then
+      diagnostic.range.start.line = buf_line_count - 1
+      diagnostic.range.start.character = string.len(last_line) - 1
     end
   end
 


### PR DESCRIPTION
This PR does a couple of adjustments to fix #15591 and https://github.com/jose-elias-alvarez/null-ls.nvim/issues/164#issuecomment-914876418.

### 1) Avoid adjusting end ranges

The bug arises when a valid diagnostic starts on the last line and ends on the next (out of range) line. Consider a buffer with 5 lines, and a diagnostic containing the range ([ref](https://github.com/jose-elias-alvarez/null-ls.nvim/issues/164#issuecomment-914876418)):

```
   range = {
      end = {
        character = 0,
        line = 5
      },
      start = {
        character = 4,
        line = 4
      }
    },
```

By adjusting lines to be 4 at max, we would be modifying the end position to be before the start position, causing it to be an invalid range. Since most display logic should be based on start position, it should be ok to leave end ranges as is.

### 2) Set start position character to last line's length in buffer

Consider a buffer with 23 lines and a diagnostic containing the following range ([ref](https://github.com/neovim/neovim/issues/13476#issuecomment-762664563)):

```
    range = {
      end = {
        character = 0,
        line = 23
      },
      start = {
        character = 0,
        line = 23
      }
    },
```

The start position here is "out of range", causing start.line to be adjusted to 22. However, since start.character remains as 0, this diagnostic may appear before other diagnostics even though it's expected to be the last reported diagnostic. The proposed fix here would be to set start.character to the length of the last line in the buffer.

### 3) Avoid -1 defensive programming

#14737 tries to change -1's to 0's, which may not be needed:
- the same author appears to have already applied a fix to the LS having the issue (see https://github.com/elixir-lsp/elixir-ls/pull/558)
- we generally don't expect language servers to return -1 (see [doc](https://microsoft.github.io/language-server-protocol/specification#position)). If other language servers have the same issue, it should be fixed at the LS level
- '-1' is usually a special number representing the last element (eg. last character of a string), changing to 0 in this case may not be appropriate