### PR TITLE
vim-patch:90df4b9d4234

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -499,8 +499,10 @@ CursorMoved			After the cursor was moved in Normal or Visual
 				mode or to another window.  Also when the text
 				of the cursor line has been changed, e.g. with
 				"x", "rx" or "p".
-				Not triggered when there is typeahead or when
-				an operator is pending.
+				Not triggered when there is typeahead, when
+				an operator is pending or when moving to
+				another window while remaining at the same
+				cursor position.
 				For an example see |match-parens|.
 				Note: Cannot be skipped with |:noautocmd|.
 				Careful: This is triggered very often, don't

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1317,7 +1317,17 @@ The lambda expression is also useful for jobs and timers: >
 	Handler called
 	Handler called
 
-Note how execute() is used to execute an Ex command.  That's ugly though.
+Note that it is possible to cause memory to be used and not freed if the
+closure is referenced by the context it depends on: >
+	function Function()
+	   let x = 0
+	   let F = {-> x}
+	 endfunction
+The closure uses "x" from the function scope, and "F" in that same scope
+refers to the closure.  This cycle results in the memory not being freed.
+Recommendation: don't do this.
+
+Notice how execute() is used to execute an Ex command.  That's ugly though.
 
 
 Lambda expressions have internal names like '<lambda>42'.  If you get an error
@@ -1722,7 +1732,8 @@ v:fcs_choice	What should happen after a |FileChangedShell| event was
 		Vim behaves like it is empty, there is no warning message.
 
 					*v:fname* *fname-variable*
-v:fname		The file name set by 'includeexpr'.  Empty otherwise.
+v:fname		When evaluating 'includeexpr': the file name that was
+		detected.  Empty otherwise.
 
 					*v:fname_in* *fname_in-variable*
 v:fname_in	The name of the input file.  Valid while evaluating:
@@ -7456,6 +7467,10 @@ screenpos({winid}, {lnum}, {col})				*screenpos()*
 		The "curscol" value is where the cursor would be placed.  For
 		a Tab it would be the same as "endcol", while for a double
 		width character it would be the same as "col".
+		The |conceal| feature is ignored here, the column numbers are
+ 		as if 'conceallevel' is zero.  You can set the cursor to the
+ 		right position and use |screencol()| to get the value with
+ 		|conceal| taken into account.
 
 screenrow()							*screenrow()*
 		The result is a Number, which is the current screen row of the

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1053,7 +1053,8 @@ On the second invocation the arguments are:
 
 The function must return a List with the matching words.  These matches
 usually include the "a:base" text.  When there are no matches return an empty
-List.
+List.  Note that the cursor may have moved since the first invocation, the
+text may have been changed.
 
 In order to return more information than the matching words, return a Dict
 that contains the List.  The Dict can have these items:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1384,11 +1384,17 @@ To select syntax highlighting file for Euphoria, as well as for
 auto-detecting the *.e and *.E file extensions as Euphoria file type,
 add the following line to your startup file: >
 
-	:let filetype_euphoria = "euphoria3"
+	:let g:filetype_euphoria = "euphoria3"
 
 <	or >
 
-	:let filetype_euphoria = "euphoria4"
+	:let g:filetype_euphoria = "euphoria4"
+
+Elixir and Euphoria share the *.ex file extension.  If the filetype is 
+specifically set as Euphoria with the g:filetype_euphoria variable, or the
+file is determined to be Euphoria based on keywords in the file, then the
+filetype will be set as Euphoria. Otherwise, the filetype will default to
+Elixir.
 
 
 ERLANG						*erlang.vim* *ft-erlang-syntax*
@@ -1404,6 +1410,22 @@ put the following line in your vimrc: >
 To enable highlighting some special atoms, put this in your vimrc: >
 
       :let g:erlang_highlight_special_atoms = 1
+
+
+ELIXIR						*elixir.vim* *ft-elixir-syntax*
+
+Elixir is a dynamic, functional language for building scalable and maintainable
+applications.
+
+The following file extensions are auto-detected as Elixir file types:
+
+	*.ex, *.exs, *.eex, *.leex, *.lock
+
+Elixir and Euphoria share the *.ex file extension. If the filetype is 
+specifically set as Euphoria with the g:filetype_euphoria variable, or the
+file is determined to be Euphoria based on keywords in the file, then the
+filetype will be set as Euphoria. Otherwise, the filetype will default to
+Elixir.
 
 
 FLEXWIKI				*flexwiki.vim* *ft-flexwiki-syntax*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Jun 13
+" Last Change:	2021 Jul 03
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/indent/pascal.vim
+++ b/runtime/indent/pascal.vim
@@ -2,7 +2,7 @@
 " Language:    Pascal
 " Maintainer:  Neil Carter <n.carter@swansea.ac.uk>
 " Created:     2004 Jul 13
-" Last Change: 2017 Jun 13
+" Last Change: 2021 Jul 01
 "
 " This is version 2.0, a complete rewrite.
 "
@@ -19,6 +19,8 @@ setlocal indentkeys&
 setlocal indentkeys+==end;,==const,==type,==var,==begin,==repeat,==until,==for
 setlocal indentkeys+==program,==function,==procedure,==object,==private
 setlocal indentkeys+==record,==if,==else,==case
+
+let b:undo_indent = "setl indentkeys< indentexpr<"
 
 if exists("*GetPascalIndent")
 	finish

--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -1,58 +1,109 @@
-" Vim syntax file
-" Language:	Go
-" Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
-" Last Change:	2014 Aug 16
-
-" Options:
-"   There are some options for customizing the highlighting; the recommended
-"   settings are the default values, but you can write:
-"     let OPTION_NAME = 0
-"   in your ~/.vimrc file to disable particular options. You can also write:
-"     let OPTION_NAME = 1
-"   to enable particular options. At present, all options default to on.
+" Copyright 2009 The Go Authors. All rights reserved.
+" Use of this source code is governed by a BSD-style
+" license that can be found in the LICENSE file.
 "
-"   - g:go_highlight_array_whitespace_error
-"     Highlights white space after "[]".
-"   - g:go_highlight_chan_whitespace_error
-"     Highlights white space around the communications operator that don't
-"     follow the standard style.
-"   - g:go_highlight_extra_types
-"     Highlights commonly used library types (io.Reader, etc.).
-"   - g:go_highlight_space_tab_error
-"     Highlights instances of tabs following spaces.
-"   - g:go_highlight_trailing_whitespace_error
-"     Highlights trailing white space.
+" go.vim: Vim syntax file for Go.
+" Language:             Go
+" Maintainer:           Billie Cleek <bhcleek@gmail.com>
+" Latest Revision:      2021-06-26
+" License:              BSD-style. See LICENSE file in source repository.
+" Repository:           https://github.com/fatih/vim-go
 
 " Quit when a (custom) syntax file was already loaded
-if exists('b:current_syntax')
+if exists("b:current_syntax")
   finish
 endif
 
-if !exists('g:go_highlight_array_whitespace_error')
-  let g:go_highlight_array_whitespace_error = 1
-endif
-if !exists('g:go_highlight_chan_whitespace_error')
-  let g:go_highlight_chan_whitespace_error = 1
-endif
-if !exists('g:go_highlight_extra_types')
-  let g:go_highlight_extra_types = 1
-endif
-if !exists('g:go_highlight_space_tab_error')
-  let g:go_highlight_space_tab_error = 1
-endif
-if !exists('g:go_highlight_trailing_whitespace_error')
-  let g:go_highlight_trailing_whitespace_error = 1
-endif
+let s:keepcpo = &cpo
+set cpo&vim
+
+function! s:FoldEnable(...) abort
+  if a:0 > 0
+    return index(s:FoldEnable(), a:1) > -1
+  endif
+  return get(g:, 'go_fold_enable', ['block', 'import', 'varconst', 'package_comment'])
+endfunction
+
+function! s:HighlightArrayWhitespaceError() abort
+  return get(g:, 'go_highlight_array_whitespace_error', 0)
+endfunction
+
+function! s:HighlightChanWhitespaceError() abort
+  return get(g:, 'go_highlight_chan_whitespace_error', 0)
+endfunction
+
+function! s:HighlightExtraTypes() abort
+  return get(g:, 'go_highlight_extra_types', 0)
+endfunction
+
+function! s:HighlightSpaceTabError() abort
+  return get(g:, 'go_highlight_space_tab_error', 0)
+endfunction
+
+function! s:HighlightTrailingWhitespaceError() abort
+  return get(g:, 'go_highlight_trailing_whitespace_error', 0)
+endfunction
+
+function! s:HighlightOperators() abort
+  return get(g:, 'go_highlight_operators', 0)
+endfunction
+
+function! s:HighlightFunctions() abort
+  return get(g:, 'go_highlight_functions', 0)
+endfunction
+
+function! s:HighlightFunctionParameters() abort
+  return get(g:, 'go_highlight_function_parameters', 0)
+endfunction
+
+function! s:HighlightFunctionCalls() abort
+  return get(g:, 'go_highlight_function_calls', 0)
+endfunction
+
+function! s:HighlightFields() abort
+  return get(g:, 'go_highlight_fields', 0)
+endfunction
+
+function! s:HighlightTypes() abort
+  return get(g:, 'go_highlight_types', 0)
+endfunction
+
+function! s:HighlightBuildConstraints() abort
+  return get(g:, 'go_highlight_build_constraints', 0)
+endfunction
+
+function! s:HighlightStringSpellcheck() abort
+  return get(g:, 'go_highlight_string_spellcheck', 1)
+endfunction
+
+function! s:HighlightFormatStrings() abort
+  return get(g:, 'go_highlight_format_strings', 1)
+endfunction
+
+function! s:HighlightGenerateTags() abort
+  return get(g:, 'go_highlight_generate_tags', 0)
+endfunction
+
+function! s:HighlightVariableAssignments() abort
+  return get(g:, 'go_highlight_variable_assignments', 0)
+endfunction
+
+function! s:HighlightVariableDeclarations() abort
+  return get(g:, 'go_highlight_variable_declarations', 0)
+endfunction
 
 syn case match
 
-syn keyword     goDirective         package import
-syn keyword     goDeclaration       var const type
-syn keyword     goDeclType          struct interface
+syn keyword     goPackage           package
+syn keyword     goImport            import    contained
+syn keyword     goVar               var       contained
+syn keyword     goConst             const     contained
 
-hi def link     goDirective         Statement
+hi def link     goPackage           Statement
+hi def link     goImport            Statement
+hi def link     goVar               Keyword
+hi def link     goConst             Keyword
 hi def link     goDeclaration       Keyword
-hi def link     goDeclType          Keyword
 
 " Keywords within functions
 syn keyword     goStatement         defer go goto return break continue fallthrough
@@ -78,27 +129,37 @@ hi def link     goUnsignedInts      Type
 hi def link     goFloats            Type
 hi def link     goComplexes         Type
 
-" Treat func specially: it's a declaration at the start of a line, but a type
-" elsewhere. Order matters here.
-syn match       goType              /\<func\>/
-syn match       goDeclaration       /^func\>/
-
 " Predefined functions and values
-syn keyword     goBuiltins          append cap close complex copy delete imag len
-syn keyword     goBuiltins          make new panic print println real recover
-syn keyword     goConstants         iota true false nil
+syn keyword     goBuiltins                 append cap close complex copy delete imag len
+syn keyword     goBuiltins                 make new panic print println real recover
+syn keyword     goBoolean                  true false
+syn keyword     goPredefinedIdentifiers    nil iota
 
-hi def link     goBuiltins          Keyword
-hi def link     goConstants         Keyword
+hi def link     goBuiltins                 Identifier
+hi def link     goBoolean                  Boolean
+hi def link     goPredefinedIdentifiers    goBoolean
 
 " Comments; their contents
 syn keyword     goTodo              contained TODO FIXME XXX BUG
 syn cluster     goCommentGroup      contains=goTodo
-syn region      goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell
-syn region      goComment           start="//" end="$" contains=@goCommentGroup,@Spell
+
+syn region      goComment           start="//" end="$" contains=goGenerate,@goCommentGroup,@Spell
+if s:FoldEnable('comment')
+  syn region    goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell fold
+  syn match     goComment           "\v(^\s*//.*\n)+" contains=goGenerate,@goCommentGroup,@Spell fold
+else
+  syn region    goComment           start="/\*" end="\*/" contains=@goCommentGroup,@Spell
+endif
 
 hi def link     goComment           Comment
 hi def link     goTodo              Todo
+
+if s:HighlightGenerateTags()
+  syn match       goGenerateVariables contained /\%(\$GOARCH\|\$GOOS\|\$GOFILE\|\$GOLINE\|\$GOPACKAGE\|\$DOLLAR\)\>/
+  syn region      goGenerate          start="^\s*//go:generate" end="$" contains=goGenerateVariables
+  hi def link     goGenerate          PreProc
+  hi def link     goGenerateVariables Special
+endif
 
 " Go escapes
 syn match       goEscapeOctal       display contained "\\[0-7]\{3}"
@@ -118,8 +179,30 @@ hi def link     goEscapeError       Error
 
 " Strings and their contents
 syn cluster     goStringGroup       contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU,goEscapeError
-syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
-syn region      goRawString         start=+`+ end=+`+
+if s:HighlightStringSpellcheck()
+  syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup,@Spell
+  syn region      goRawString         start=+`+ end=+`+ contains=@Spell
+else
+  syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
+  syn region      goRawString         start=+`+ end=+`+
+endif
+
+if s:HighlightFormatStrings()
+  " [n] notation is valid for specifying explicit argument indexes
+  " 1. Match a literal % not preceded by a %.
+  " 2. Match any number of -, #, 0, space, or +
+  " 3. Match * or [n]* or any number or nothing before a .
+  " 4. Match * or [n]* or any number or nothing after a .
+  " 5. Match [n] or nothing before a verb
+  " 6. Match a formatting verb
+  syn match       goFormatSpecifier   /\
+        \%([^%]\%(%%\)*\)\
+        \@<=%[-#0 +]*\
+        \%(\%(\%(\[\d\+\]\)\=\*\)\|\d\+\)\=\
+        \%(\.\%(\%(\%(\[\d\+\]\)\=\*\)\|\d\+\)\=\)\=\
+        \%(\[\d\+\]\)\=[vTtbcdoqxXUeEfFgGspw]/ contained containedin=goString,goRawString
+  hi def link     goFormatSpecifier   goSpecialString
+endif
 
 hi def link     goString            String
 hi def link     goRawString         String
@@ -131,70 +214,262 @@ syn region      goCharacter         start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=
 hi def link     goCharacter         Character
 
 " Regions
-syn region      goBlock             start="{" end="}" transparent fold
 syn region      goParen             start='(' end=')' transparent
+if s:FoldEnable('block')
+  syn region    goBlock             start="{" end="}" transparent fold
+else
+  syn region    goBlock             start="{" end="}" transparent
+endif
+
+" import
+if s:FoldEnable('import')
+  syn region    goImport            start='import (' end=')' transparent fold contains=goImport,goString,goComment
+else
+  syn region    goImport            start='import (' end=')' transparent contains=goImport,goString,goComment
+endif
+
+" var, const
+if s:FoldEnable('varconst')
+  syn region    goVar               start='var ('   end='^\s*)$' transparent fold
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+  syn region    goConst             start='const (' end='^\s*)$' transparent fold
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+else
+  syn region    goVar               start='var ('   end='^\s*)$' transparent
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+  syn region    goConst             start='const (' end='^\s*)$' transparent
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+endif
+
+" Single-line var, const, and import.
+syn match       goSingleDecl        /\%(import\|var\|const\) [^(]\@=/ contains=goImport,goVar,goConst
 
 " Integers
-syn match       goDecimalInt        "\<\d\+\([Ee]\d\+\)\?\>"
-syn match       goHexadecimalInt    "\<0x\x\+\>"
-syn match       goOctalInt          "\<0\o\+\>"
-syn match       goOctalError        "\<0\o*[89]\d*\>"
+syn match       goDecimalInt        "\<-\=\(0\|[1-9]_\?\(\d\|\d\+_\?\d\+\)*\)\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goDecimalError      "\<-\=\(_\(\d\+_*\)\+\|\([1-9]\d*_*\)\+__\(\d\+_*\)\+\|\([1-9]\d*_*\)\+_\+\)\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goHexadecimalInt    "\<-\=0[xX]_\?\(\x\+_\?\)\+\>"
+syn match       goHexadecimalError  "\<-\=0[xX]_\?\(\x\+_\?\)*\(\([^ \t0-9A-Fa-f_)]\|__\)\S*\|_\)\>"
+syn match       goOctalInt          "\<-\=0[oO]\?_\?\(\o\+_\?\)\+\>"
+syn match       goOctalError        "\<-\=0[0-7oO_]*\(\([^ \t0-7oOxX_/)\]\}\:]\|[oO]\{2,\}\|__\)\S*\|_\|[oOxX]\)\>"
+syn match       goBinaryInt         "\<-\=0[bB]_\?\([01]\+_\?\)\+\>"
+syn match       goBinaryError       "\<-\=0[bB]_\?[01_]*\([^ \t01_)]\S*\|__\S*\|_\)\>"
 
 hi def link     goDecimalInt        Integer
+hi def link     goDecimalError      Error
 hi def link     goHexadecimalInt    Integer
+hi def link     goHexadecimalError  Error
 hi def link     goOctalInt          Integer
+hi def link     goOctalError        Error
+hi def link     goBinaryInt         Integer
+hi def link     goBinaryError       Error
 hi def link     Integer             Number
 
 " Floating point
-syn match       goFloat             "\<\d\+\.\d*\([Ee][-+]\d\+\)\?\>"
-syn match       goFloat             "\<\.\d\+\([Ee][-+]\d\+\)\?\>"
-syn match       goFloat             "\<\d\+[Ee][-+]\d\+\>"
+syn match       goFloat             "\<-\=\d\+\.\d*\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goFloat             "\<-\=\.\d\+\%([Ee][-+]\=\d\+\)\=\>"
 
 hi def link     goFloat             Float
 
 " Imaginary literals
-syn match       goImaginary         "\<\d\+i\>"
-syn match       goImaginary         "\<\d\+\.\d*\([Ee][-+]\d\+\)\?i\>"
-syn match       goImaginary         "\<\.\d\+\([Ee][-+]\d\+\)\?i\>"
-syn match       goImaginary         "\<\d\+[Ee][-+]\d\+i\>"
+syn match       goImaginary         "\<-\=\d\+i\>"
+syn match       goImaginary         "\<-\=\d\+[Ee][-+]\=\d\+i\>"
+syn match       goImaginaryFloat    "\<-\=\d\+\.\d*\%([Ee][-+]\=\d\+\)\=i\>"
+syn match       goImaginaryFloat    "\<-\=\.\d\+\%([Ee][-+]\=\d\+\)\=i\>"
 
 hi def link     goImaginary         Number
+hi def link     goImaginaryFloat    Float
 
 " Spaces after "[]"
-if go_highlight_array_whitespace_error != 0
-  syn match goSpaceError display "\(\[\]\)\@<=\s\+"
+if s:HighlightArrayWhitespaceError()
+  syn match goSpaceError display "\%(\[\]\)\@<=\s\+"
 endif
 
 " Spacing errors around the 'chan' keyword
-if go_highlight_chan_whitespace_error != 0
+if s:HighlightChanWhitespaceError()
   " receive-only annotation on chan type
-  syn match goSpaceError display "\(<-\)\@<=\s\+\(chan\>\)\@="
+  "
+  " \(\<chan\>\)\@<!<-  (only pick arrow when it doesn't come after a chan)
+  " this prevents picking up 'chan<- chan<-' but not '<- chan'
+  syn match goSpaceError display "\%(\%(\<chan\>\)\@<!<-\)\@<=\s\+\%(\<chan\>\)\@="
+
   " send-only annotation on chan type
-  syn match goSpaceError display "\(\<chan\)\@<=\s\+\(<-\)\@="
+  "
+  " \(<-\)\@<!\<chan\>  (only pick chan when it doesn't come after an arrow)
+  " this prevents picking up '<-chan <-chan' but not 'chan <-'
+  syn match goSpaceError display "\%(\%(<-\)\@<!\<chan\>\)\@<=\s\+\%(<-\)\@="
+
   " value-ignoring receives in a few contexts
-  syn match goSpaceError display "\(\(^\|[={(,;]\)\s*<-\)\@<=\s\+"
+  syn match goSpaceError display "\%(\%(^\|[={(,;]\)\s*<-\)\@<=\s\+"
 endif
 
 " Extra types commonly seen
-if go_highlight_extra_types != 0
-  syn match goExtraType /\<bytes\.\(Buffer\)\>/
-  syn match goExtraType /\<io\.\(Reader\|Writer\|ReadWriter\|ReadWriteCloser\)\>/
-  syn match goExtraType /\<reflect\.\(Kind\|Type\|Value\)\>/
+if s:HighlightExtraTypes()
+  syn match goExtraType /\<bytes\.\%(Buffer\)\>/
+  syn match goExtraType /\<context\.\%(Context\)\>/
+  syn match goExtraType /\<io\.\%(Reader\|ReadSeeker\|ReadWriter\|ReadCloser\|ReadWriteCloser\|Writer\|WriteCloser\|Seeker\)\>/
+  syn match goExtraType /\<reflect\.\%(Kind\|Type\|Value\)\>/
   syn match goExtraType /\<unsafe\.Pointer\>/
 endif
 
 " Space-tab error
-if go_highlight_space_tab_error != 0
+if s:HighlightSpaceTabError()
   syn match goSpaceError display " \+\t"me=e-1
 endif
 
 " Trailing white space error
-if go_highlight_trailing_whitespace_error != 0
+if s:HighlightTrailingWhitespaceError()
   syn match goSpaceError display excludenl "\s\+$"
 endif
 
 hi def link     goExtraType         Type
 hi def link     goSpaceError        Error
+
+
+
+" included from: https://github.com/athom/more-colorful.vim/blob/master/after/syntax/go.vim
+"
+" Comments; their contents
+syn keyword     goTodo              contained NOTE
+hi def link     goTodo              Todo
+
+syn match goVarArgs /\.\.\./
+
+" Operators;
+if s:HighlightOperators()
+  " match single-char operators:          - + % < > ! & | ^ * =
+  " and corresponding two-char operators: -= += %= <= >= != &= |= ^= *= ==
+  syn match goOperator /[-+%<>!&|^*=]=\?/
+  " match / and /=
+  syn match goOperator /\/\%(=\|\ze[^/*]\)/
+  " match two-char operators:               << >> &^
+  " and corresponding three-char operators: <<= >>= &^=
+  syn match goOperator /\%(<<\|>>\|&^\)=\?/
+  " match remaining two-char operators: := && || <- ++ --
+  syn match goOperator /:=\|||\|<-\|++\|--/
+  " match ...
+
+  hi def link     goPointerOperator   goOperator
+  hi def link     goVarArgs           goOperator
+endif
+hi def link     goOperator          Operator
+
+" Functions;
+if s:HighlightFunctions() || s:HighlightFunctionParameters()
+  syn match goDeclaration       /\<func\>/ nextgroup=goReceiver,goFunction,goSimpleParams skipwhite skipnl
+  syn match goReceiverVar       /\w\+\ze\s\+\%(\w\|\*\)/ nextgroup=goPointerOperator,goReceiverType skipwhite skipnl contained
+  syn match goPointerOperator   /\*/ nextgroup=goReceiverType contained skipwhite skipnl
+  syn match goFunction          /\w\+/ nextgroup=goSimpleParams contained skipwhite skipnl
+  syn match goReceiverType      /\w\+/ contained
+  if s:HighlightFunctionParameters()
+    syn match goSimpleParams      /(\%(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goParamName,goType nextgroup=goFunctionReturn skipwhite skipnl
+    syn match goFunctionReturn   /(\%(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goParamName,goType skipwhite skipnl
+    syn match goParamName        /\w\+\%(\s*,\s*\w\+\)*\ze\s\+\%(\w\|\.\|\*\|\[\)/ contained nextgroup=goParamType skipwhite skipnl
+    syn match goParamType        /\%([^,)]\|\_s\)\+,\?/ contained nextgroup=goParamName skipwhite skipnl
+                          \ contains=goVarArgs,goType,goSignedInts,goUnsignedInts,goFloats,goComplexes,goDeclType,goBlock
+    hi def link   goReceiverVar    goParamName
+    hi def link   goParamName      Identifier
+  endif
+  syn match goReceiver          /(\s*\w\+\%(\s\+\*\?\s*\w\+\)\?\s*)\ze\s*\w/ contained nextgroup=goFunction contains=goReceiverVar skipwhite skipnl
+else
+  syn keyword goDeclaration func
+endif
+hi def link     goFunction          Function
+
+" Function calls;
+if s:HighlightFunctionCalls()
+  syn match goFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
+endif
+hi def link     goFunctionCall      Type
+
+" Fields;
+if s:HighlightFields()
+  " 1. Match a sequence of word characters coming after a '.'
+  " 2. Require the following but dont match it: ( \@= see :h E59)
+  "    - The symbols: / - + * %   OR
+  "    - The symbols: [] {} <> )  OR
+  "    - The symbols: \n \r space OR
+  "    - The symbols: , : .
+  " 3. Have the start of highlight (hs) be the start of matched
+  "    pattern (s) offsetted one to the right (+1) (see :h E401)
+  syn match       goField   /\.\w\+\
+        \%(\%([\/\-\+*%]\)\|\
+        \%([\[\]{}<\>\)]\)\|\
+        \%([\!=\^|&]\)\|\
+        \%([\n\r\ ]\)\|\
+        \%([,\:.]\)\)\@=/hs=s+1
+endif
+hi def link    goField              Identifier
+
+" Structs & Interfaces;
+if s:HighlightTypes()
+  syn match goTypeConstructor      /\<\w\+{\@=/
+  syn match goTypeDecl             /\<type\>/ nextgroup=goTypeName skipwhite skipnl
+  syn match goTypeName             /\w\+/ contained nextgroup=goDeclType skipwhite skipnl
+  syn match goDeclType             /\<\%(interface\|struct\)\>/ skipwhite skipnl
+  hi def link     goReceiverType      Type
+else
+  syn keyword goDeclType           struct interface
+  syn keyword goDeclaration        type
+endif
+hi def link     goTypeConstructor   Type
+hi def link     goTypeName          Type
+hi def link     goTypeDecl          Keyword
+hi def link     goDeclType          Keyword
+
+" Variable Assignments
+if s:HighlightVariableAssignments()
+  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*([-^+|^\/%&]|\*|\<\<|\>\>|\&\^)?\=[^=])/
+  hi def link   goVarAssign         Special
+endif
+
+" Variable Declarations
+if s:HighlightVariableDeclarations()
+  syn match goVarDefs /\v\w+(,\s*\w+)*\ze(\s*:\=)/
+  hi def link   goVarDefs           Special
+endif
+
+" Build Constraints
+if s:HighlightBuildConstraints()
+  syn match   goBuildKeyword      display contained "+build"
+  " Highlight the known values of GOOS, GOARCH, and other +build options.
+  syn keyword goBuildDirectives   contained
+        \ android darwin dragonfly freebsd linux nacl netbsd openbsd plan9
+        \ solaris windows 386 amd64 amd64p32 arm armbe arm64 arm64be ppc64
+        \ ppc64le mips mipsle mips64 mips64le mips64p32 mips64p32le ppc
+        \ s390 s390x sparc sparc64 cgo ignore race
+
+  " Other words in the build directive are build tags not listed above, so
+  " avoid highlighting them as comments by using a matchgroup just for the
+  " start of the comment.
+  " The rs=s+2 option lets the \s*+build portion be part of the inner region
+  " instead of the matchgroup so it will be highlighted as a goBuildKeyword.
+  syn region  goBuildComment      matchgroup=goBuildCommentStart
+        \ start="//\s*+build\s"rs=s+2 end="$"
+        \ contains=goBuildKeyword,goBuildDirectives
+  hi def link goBuildCommentStart Comment
+  hi def link goBuildDirectives   Type
+  hi def link goBuildKeyword      PreProc
+endif
+
+if s:HighlightBuildConstraints() || s:FoldEnable('package_comment')
+  " One or more line comments that are followed immediately by a "package"
+  " declaration are treated like package documentation, so these must be
+  " matched as comments to avoid looking like working build constraints.
+  " The he, me, and re options let the "package" itself be highlighted by
+  " the usual rules.
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
+        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' contains=@goCommentGroup,@Spell'
+        \ . (s:FoldEnable('package_comment') ? ' fold' : '')
+  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
+        \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' contains=@goCommentGroup,@Spell'
+        \ . (s:FoldEnable('package_comment') ? ' fold' : '')
+  hi def link goPackageComment    Comment
+endif
+
+" :GoCoverage commands
+hi def link goCoverageNormalText Comment
 
 " Search backwards for a global declaration to start processing the syntax.
 "syn sync match goSync grouphere NONE /^\(const\|var\|type\|func\)\>/
@@ -203,6 +478,9 @@ hi def link     goSpaceError        Error
 " following as a more expensive/less precise workaround.
 syn sync minlines=500
 
-let b:current_syntax = 'go'
+let b:current_syntax = "go"
+
+let &cpo = s:keepcpo
+unlet s:keepcpo
 
 " vim: sw=2 sts=2 et

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -12,7 +12,7 @@
 if exists("b:current_syntax")
   finish
 endif
-let s:keepcpo= &cpo
+let s:keepcpo = &cpo
 set cpo&vim
 
 " vimTodo: contains common special-notices for comments {{{2

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -190,7 +190,7 @@ preprocess_patch() {
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/src/\S*\<\%(testdir/\)\@<!\%('"${na_src}"'\)@norm! d/\v(^diff)|%$' +w +q "$file"
 
   # Remove unwanted Vim doc files.
-  local na_doc='channel\.txt\|netbeans\.txt\|os_\w\+\.txt\|term\.txt\|todo\.txt\|version\d\.txt\|sponsor\.txt\|intro\.txt\|tags'
+  local na_doc='channel\.txt\|netbeans\.txt\|os_\w\+\.txt\|term\.txt\|todo\.txt\|version\d\.txt\|vim9\.txt\|sponsor\.txt\|intro\.txt\|tags'
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/runtime/doc/\<\%('"${na_doc}"'\)\>@norm! d/\v(^diff)|%$' +w +q "$file"
 
   # Remove "Last change ..." changes in doc files.


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/90df4b9d423485f7db16e3a65cab4f14edc815ae

omit .github/CODEOWNERS
omit doc/vim9.txt
omit po/it.po

skip ftplugin/jsonc.vim
skip indent/jsonc.vim
skip syntax/jsonc.vim
(already ported in https://github.com/neovim/neovim/commit/dce50312e1e9af81fb0e3b61d6e70bdf286fbffb)

partial skip doc/eval.txt (needs 8.1.{2304,2321})