### PR TITLE
test: do not write into user's ~/.bash_history

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -49,6 +49,9 @@ endif()
 set(ENV{TMPDIR} "${BUILD_DIR}/Xtest_tmpdir/${TEST_PATH}")
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{TMPDIR})
 
+# HISTFILE: do not write into user's ~/.bash_history
+set(ENV{HISTFILE} "/dev/null")
+
 set(ENV{SYSTEM_NAME} ${CMAKE_HOST_SYSTEM_NAME})  # used by test/helpers.lua.
 execute_process(
   COMMAND ${BUSTED_PRG} -v -o test.busted.outputHandlers.${BUSTED_OUTPUT_TYPE}


### PR DESCRIPTION
If I run 'make test' on Linux (Fedora), a few lines like
/_path_/_to_/neovim/build/bin/shell-test REP 31 line
/_path_/_to_/neovim/build/bin/shell-test REP 41 line
are written to my ~/.bash_history.  This is not a serious problem but may be a little bit annoying for users who are using bash as an interactive shell.
These lines are from test/functional/terminal/scrollback_spec.lua.

This PR sets HISTFILE=/dev/null while running the test so that the shell do not write into ~/.bash_history.

I tried
`set(ENV{HISTFILE} "")`
but it didn't work. I don't know why, because running the test from my shell by
`HISTFILE= make test`
does work. I hope /dev/null is available everywhere.