### PR TITLE
vim-patch:8.2.3399: Octave files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -264,6 +264,13 @@ func dist#ft#ProtoCheck(default)
 endfunc
 
 func dist#ft#FTm()
+  if exists("g:filetype_m")
+    exe "setf " . g:filetype_m
+    return
+  endif
+
+  let octave_block_terminators = '\<end\%(_try_catch\|classdef\|enumeration\|events\|for\|function\|if\|methods\|parfor\|properties\|switch\|while\)\>'
+
   let n = 1
   let saw_comment = 0 " Whether we've seen a multiline comment leader.
   while n < 100
@@ -278,6 +285,13 @@ func dist#ft#FTm()
       setf objc
       return
     endif
+    if line =~ '^\s*\%(#\|%!\|[#%]{\=\s*$\)' ||
+	  \ line =~ '^\s*unwind_protect\>' ||
+	  \ line =~ '\%(^\|;\)\s*' .. octave_block_terminators
+      setf octave
+      return
+    endif
+    " TODO: could be Matlab or Octave
     if line =~ '^\s*%'
       setf matlab
       return
@@ -298,11 +312,8 @@ func dist#ft#FTm()
     " or Murphi based on the comment leader. Assume the former as it is more
     " common.
     setf objc
-  elseif exists("g:filetype_m")
-    " Use user specified default filetype for .m
-    exe "setf " . g:filetype_m
   else
-    " Default is matlab
+    " Default is Matlab
     setf matlab
   endif
 endfunc

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -135,6 +135,7 @@ can be used to overrule the filetype used for certain extensions:
 	*.inc		g:filetype_inc
 	*.w		g:filetype_w	|ft-cweb-syntax|
 	*.i		g:filetype_i	|ft-progress-syntax|
+	*.m		g:filetype_m	|ft-mathematica-syntax|
 	*.p		g:filetype_p	|ft-pascal-syntax|
 	*.pp		g:filetype_pp	|ft-pascal-syntax|
 	*.sh		g:bash_is_sh	|ft-sh-syntax|

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1025,7 +1025,7 @@ au BufNewFile,BufRead *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md  setf markdown
 " Mason
 au BufNewFile,BufRead *.mason,*.mhtml,*.comp	setf mason
 
-" Mathematica, Matlab, Murphi or Objective C
+" Mathematica, Matlab, Murphi, Objective C or Octave
 au BufNewFile,BufRead *.m			call dist#ft#FTm()
 
 " Mathematica notebook
@@ -1170,6 +1170,9 @@ au BufNewFile,BufRead *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli
 
 " Occam
 au BufNewFile,BufRead *.occ			setf occam
+
+" Octave
+au BufNewFile,BufRead octave.conf,.octaverc,octaverc	setf octave
 
 " Omnimark
 au BufNewFile,BufRead *.xom,*.xin		setf omnimark

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -295,6 +295,7 @@ let s:filename_checks = {
     \ 'lss': ['file.lss'],
     \ 'lua': ['file.lua', 'file.rockspec', 'file.nse'],
     \ 'lynx': ['lynx.cfg'],
+    \ 'matlab': ['file.m'],
     \ 'm3build': ['m3makefile', 'm3overrides'],
     \ 'm3quake': ['file.quake', 'cm3.cfg'],
     \ 'm4': ['file.at'],
@@ -350,6 +351,7 @@ let s:filename_checks = {
     \ 'obj': ['file.obj'],
     \ 'ocaml': ['file.ml', 'file.mli', 'file.mll', 'file.mly', '.ocamlinit', 'file.mlt', 'file.mlp', 'file.mlip', 'file.mli.cppo', 'file.ml.cppo'],
     \ 'occam': ['file.occ'],
+    \ 'octave': ['octaverc', '.octaverc', 'octave.conf'],
     \ 'omnimark': ['file.xom', 'file.xin'],
     \ 'opam': ['opam', 'file.opam', 'file.opam.template'],
     \ 'openroad': ['file.or'],
@@ -825,4 +827,96 @@ func Test_dsl_file()
   filetype off
 endfunc
 
+func Test_m_file()
+  filetype on
+
+  call writefile(['looks like Matlab'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('matlab', &filetype)
+  bwipe!
+
+  let g:filetype_m = 'octave'
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+  unlet g:filetype_m
+
+  " Test dist#ft#FTm()
+
+  " Objective-C
+
+  call writefile(['// Objective-C line comment'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('objc', &filetype)
+  bwipe!
+
+  call writefile(['/* Objective-C block comment */'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('objc', &filetype)
+  bwipe!
+
+  call writefile(['#import "test.m"'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('objc', &filetype)
+  bwipe!
+
+  " Octave
+
+  call writefile(['# Octave line comment'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+
+  call writefile(['#{', 'Octave block comment',  '#}'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+
+  call writefile(['%{', 'Octave block comment', '%}'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+
+  call writefile(['%!test "Octave test"'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+
+  call writefile(['unwind_protect'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+
+  call writefile(['function test(); 42; endfunction'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('octave', &filetype)
+  bwipe!
+
+  " Mathematica
+
+  call writefile(['(* Mathematica comment'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('mma', &filetype)
+  bwipe!
+
+  " Murphi
+
+  call writefile(['-- Murphi comment'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('murphi', &filetype)
+  bwipe!
+
+  call writefile(['/* Murphi block comment */', 'Type'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('murphi', &filetype)
+  bwipe!
+
+  call writefile(['Type'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('murphi', &filetype)
+  bwipe!
+
+  call delete('Xfile.m')
+  filetype off
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Octave files are not recognized.
Solution:   Detect Octave files. (Doug Kearns)
https://github.com/vim/vim/commit/deba5eb195d6ac70171d4973091fa884809fa3fa