### PR TITLE
fix(inccommand): ignore trailing commands only for previewing command

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -304,6 +304,7 @@ int do_cmdline_cmd(const char *cmd)
 ///   DOCMD_KEYTYPED - Don't reset KeyTyped.
 ///   DOCMD_EXCRESET - Reset the exception environment (used for debugging).
 ///   DOCMD_KEEPLINE - Store first typed line (for repeating with ".").
+///   DOCMD_PREVIEW  - During 'inccommand' preview.
 ///
 /// @param cookie  argument for fgetline()
 ///
@@ -606,7 +607,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
     recursive--;
 
     // Ignore trailing '|'-separated commands in preview-mode ('inccommand').
-    if (State & CMDPREVIEW) {
+    if ((State & CMDPREVIEW) && (flags & DOCMD_PREVIEW)) {
       next_cmdline = NULL;
     }
 

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -11,6 +11,7 @@
 #define DOCMD_KEYTYPED  0x08      // don't reset KeyTyped
 #define DOCMD_EXCRESET  0x10      // reset exception environment (for debugging
 #define DOCMD_KEEPLINE  0x20      // keep typed line for repeating with "."
+#define DOCMD_PREVIEW   0x40      // during 'inccommand' preview
 
 /* defines for eval_vars() */
 #define VALID_PATH              1

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2251,7 +2251,7 @@ static int command_line_changed(CommandLineState *s)
     State |= CMDPREVIEW;
     emsg_silent++;  // Block error reporting as the command may be incomplete
     msg_silent++;   // Block messages, namely ones that prompt
-    do_cmdline(ccline.cmdbuff, NULL, NULL, DOCMD_KEEPLINE|DOCMD_NOWAIT);
+    do_cmdline(ccline.cmdbuff, NULL, NULL, DOCMD_KEEPLINE|DOCMD_NOWAIT|DOCMD_PREVIEW);
     msg_silent--;   // Unblock messages
     emsg_silent--;  // Unblock error reporting
 

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1487,6 +1487,29 @@ describe("inccommand=nosplit", function()
     ]])
     eq(eval('v:null'), eval('v:exiting'))
   end)
+
+  it("does not break bar-separated command #8796", function()
+    source([[
+      function! F()
+        if v:false | return | endif
+      endfun
+    ]])
+    command('call timer_start(10, {-> F()}, {"repeat":-1})')
+    feed(':%s/')
+    sleep(20)  -- Allow some timer activity.
+    screen:expect([[
+      Inc substitution on |
+      two lines           |
+      Inc substitution on |
+      two lines           |
+                          |
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      {15:~                   }|
+      :%s/^                |
+    ]])
+  end)
 end)
 
 describe(":substitute, 'inccommand' with a failing expression", function()


### PR DESCRIPTION
Since the `State` is global, other scripts are unexpectedly affected during the
'inccommand' preview. This commit introduces a new flag for `do_cmdline`, in
order to ignore trailing '|'-separated commands only for the command invoking
the preview.

fix #8796, update #7494