### PR TITLE
vim-patch:89a9c159f23f

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " netrw.vim: Handles file transfer and remote directory listing across
 "            AUTOLOAD SECTION
-" Date:		Sep 18, 2020
-" Version:	170
+" Date:		Aug 16, 2021
+" Version:	171
 " Maintainer:	Charles E Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -43,7 +43,7 @@ if exists("s:needspatches")
  endfor
 endif
 
-let g:loaded_netrw = "v170"
+let g:loaded_netrw = "v171"
 if !exists("s:NOTE")
  let s:NOTE    = 0
  let s:WARNING = 1
@@ -93,7 +93,7 @@ fun! netrw#ErrorMsg(level,msg,errnum)
    else
     let msg= level.a:msg
    endif
-   let s:popuperr_id  = popup_beval(msg,{})
+   let s:popuperr_id  = popup_atcursor(msg,{})
    let s:popuperr_text= ""
  elseif g:netrw_use_errorwindow
    " (default) netrw creates a one-line window to show error/warning
@@ -322,6 +322,7 @@ call s:NetrwInit("g:netrw_banner"      , 1)
 call s:NetrwInit("g:netrw_browse_split", 0)
 call s:NetrwInit("g:netrw_bufsettings" , "noma nomod nonu nobl nowrap ro nornu")
 call s:NetrwInit("g:netrw_chgwin"      , -1)
+call s:NetrwInit("g:netrw_clipboard"   , 1)
 call s:NetrwInit("g:netrw_compress"    , "gzip")
 call s:NetrwInit("g:netrw_ctags"       , "ctags")
 if exists("g:netrw_cursorline") && !exists("g:netrw_cursor")
@@ -331,6 +332,7 @@ endif
 call s:NetrwInit("g:netrw_cursor"      , 2)
 let s:netrw_usercul = &cursorline
 let s:netrw_usercuc = &cursorcolumn
+"call Decho("(netrw) COMBAK: cuc=".&l:cuc." cul=".&l:cul." initialization of s:netrw_cu[cl]")
 call s:NetrwInit("g:netrw_cygdrive","/cygdrive")
 " Default values - d-g ---------- {{{3
 call s:NetrwInit("s:didstarstar",0)
@@ -1606,7 +1608,8 @@ endfun
 fun! s:NetrwOptionsSave(vt)
 "  call Dfunc("s:NetrwOptionsSave(vt<".a:vt.">) win#".winnr()." buf#".bufnr("%")."<".bufname(bufnr("%")).">"." winnr($)=".winnr("$")." mod=".&mod." ma=".&ma)
 "  call Decho(a:vt."netrw_optionsave".(exists("{a:vt}netrw_optionsave")? ("=".{a:vt}netrw_optionsave) : " doesn't exist"),'~'.expand("<slnum>"))
-"  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
+"  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt." hid=".&hid,'~'.expand("<slnum>"))
+"  call Decho("(s:NetrwOptionsSave) lines=".&lines)
 
   if !exists("{a:vt}netrw_optionsave")
    let {a:vt}netrw_optionsave= 1
@@ -1632,6 +1635,9 @@ fun! s:NetrwOptionsSave(vt)
   let {a:vt}netrw_cinokeep  = &l:cino
   let {a:vt}netrw_comkeep   = &l:com
   let {a:vt}netrw_cpokeep   = &l:cpo
+  let {a:vt}netrw_cuckeep   = &l:cuc
+  let {a:vt}netrw_culkeep   = &l:cul
+"  call Decho("(s:NetrwOptionsSave) COMBAK: cuc=".&l:cuc." cul=".&l:cul)
   let {a:vt}netrw_diffkeep  = &l:diff
   let {a:vt}netrw_fenkeep   = &l:fen
   if !exists("g:netrw_ffkeep") || g:netrw_ffkeep
@@ -1639,9 +1645,11 @@ fun! s:NetrwOptionsSave(vt)
   endif
   let {a:vt}netrw_fokeep    = &l:fo           " formatoptions
   let {a:vt}netrw_gdkeep    = &l:gd           " gdefault
+  let {a:vt}netrw_gokeep    = &l:go           " guioptions
   let {a:vt}netrw_hidkeep   = &l:hidden
   let {a:vt}netrw_imkeep    = &l:im
   let {a:vt}netrw_iskkeep   = &l:isk
+  let {a:vt}netrw_lines     = &lines
   let {a:vt}netrw_lskeep    = &l:ls
   let {a:vt}netrw_makeep    = &l:ma
   let {a:vt}netrw_magickeep = &l:magic
@@ -1693,12 +1701,17 @@ fun! s:NetrwOptionsSafe(islocal)
   endif
   call s:NetrwSetSafeSetting("&l:ci",0)
   call s:NetrwSetSafeSetting("&l:cin",0)
-  call s:NetrwSetSafeSetting("&l:bh","hide")
+  if g:netrw_fastbrowse > a:islocal
+   call s:NetrwSetSafeSetting("&l:bh","hide")
+  else
+   call s:NetrwSetSafeSetting("&l:bh","delete")
+  endif
   call s:NetrwSetSafeSetting("&l:cino","")
   call s:NetrwSetSafeSetting("&l:com","")
   if &cpo =~ 'a' | call s:NetrwSetSafeSetting("&cpo",substitute(&cpo,'a','','g')) | endif
   if &cpo =~ 'A' | call s:NetrwSetSafeSetting("&cpo",substitute(&cpo,'A','','g')) | endif
   setl fo=nroql2
+  call s:NetrwSetSafeSetting("&go","begmr")
   call s:NetrwSetSafeSetting("&l:hid",0)
   call s:NetrwSetSafeSetting("&l:im",0)
   setl isk+=@ isk+=* isk+=/
@@ -1712,7 +1725,10 @@ fun! s:NetrwOptionsSafe(islocal)
   call s:NetrwSetSafeSetting("&l:tw",0)
   call s:NetrwSetSafeSetting("&l:wig","")
   setl cedit&
-  call s:NetrwCursor()
+
+  " set up cuc and cul based on g:netrw_cursor and listing style
+  " COMBAK -- cuc cul related
+  call s:NetrwCursor(0)
 
   " allow the user to override safe options
 "  call Decho("ft<".&ft."> ei=".&ei,'~'.expand("<slnum>"))
@@ -1730,11 +1746,14 @@ endfun
 " s:NetrwOptionsRestore: restore options (based on prior s:NetrwOptionsSave) {{{2
 fun! s:NetrwOptionsRestore(vt)
 "  call Dfunc("s:NetrwOptionsRestore(vt<".a:vt.">) win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> winnr($)=".winnr("$"))
+"  call Decho("(s:NetrwOptionsRestore) lines=".&lines)
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
   if !exists("{a:vt}netrw_optionsave")
 "   call Decho("case ".a:vt."netrw_optionsave : doesn't exist",'~'.expand("<slnum>"))
-"   call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
-"   call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
+"   call Decho("..doing filetype detect anyway")
+   filetype detect
+"   call Decho("..settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
+"   call Decho("..ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
 "   call Dret("s:NetrwOptionsRestore : ".a:vt."netrw_optionsave doesn't exist")
    return
   endif
@@ -1751,41 +1770,53 @@ fun! s:NetrwOptionsRestore(vt)
     endif
    endif
   endif
+"  call Decho("(s:NetrwOptionsRestore) #1 lines=".&lines)
   call s:NetrwRestoreSetting(a:vt."netrw_aikeep","&l:ai")
   call s:NetrwRestoreSetting(a:vt."netrw_awkeep","&l:aw")
   call s:NetrwRestoreSetting(a:vt."netrw_blkeep","&l:bl")
   call s:NetrwRestoreSetting(a:vt."netrw_btkeep","&l:bt")
   call s:NetrwRestoreSetting(a:vt."netrw_bombkeep","&l:bomb")
+"  call Decho("(s:NetrwOptionsRestore) #2 lines=".&lines)
   call s:NetrwRestoreSetting(a:vt."netrw_cedit","&cedit")
   call s:NetrwRestoreSetting(a:vt."netrw_cikeep","&l:ci")
   call s:NetrwRestoreSetting(a:vt."netrw_cinkeep","&l:cin")
   call s:NetrwRestoreSetting(a:vt."netrw_cinokeep","&l:cino")
   call s:NetrwRestoreSetting(a:vt."netrw_comkeep","&l:com")
+"  call Decho("(s:NetrwOptionsRestore) #3 lines=".&lines)
   call s:NetrwRestoreSetting(a:vt."netrw_cpokeep","&l:cpo")
   call s:NetrwRestoreSetting(a:vt."netrw_diffkeep","&l:diff")
   call s:NetrwRestoreSetting(a:vt."netrw_fenkeep","&l:fen")
   if exists("g:netrw_ffkeep") && g:netrw_ffkeep
    call s:NetrwRestoreSetting(a:vt."netrw_ffkeep")","&l:ff")
   endif
-  call s:NetrwRestoreSetting(a:vt."netrw_fokeep","&l:fo")
-  call s:NetrwRestoreSetting(a:vt."netrw_gdkeep","&l:gd")
-  call s:NetrwRestoreSetting(a:vt."netrw_hidkeep","&l:hidden")
-  call s:NetrwRestoreSetting(a:vt."netrw_imkeep","&l:im")
-  call s:NetrwRestoreSetting(a:vt."netrw_iskkeep","&l:isk")
-  call s:NetrwRestoreSetting(a:vt."netrw_lskeep","&l:ls")
-  call s:NetrwRestoreSetting(a:vt."netrw_makeep","&l:ma")
+"  call Decho("(s:NetrwOptionsRestore) #4 lines=".&lines)
+  call s:NetrwRestoreSetting(a:vt."netrw_fokeep"   ,"&l:fo")
+  call s:NetrwRestoreSetting(a:vt."netrw_gdkeep"   ,"&l:gd")
+  call s:NetrwRestoreSetting(a:vt."netrw_gokeep"   ,"&l:go")
+  call s:NetrwRestoreSetting(a:vt."netrw_hidkeep"  ,"&l:hidden")
+"  call Decho("(s:NetrwOptionsRestore) #5 lines=".&lines)
+  call s:NetrwRestoreSetting(a:vt."netrw_imkeep"   ,"&l:im")
+  call s:NetrwRestoreSetting(a:vt."netrw_iskkeep"  ,"&l:isk")
+"  call Decho("(s:NetrwOptionsRestore) #6 lines=".&lines)
+  call s:NetrwRestoreSetting(a:vt."netrw_lines"    ,"&lines")
+"  call Decho("(s:NetrwOptionsRestore) #7 lines=".&lines)
+  call s:NetrwRestoreSetting(a:vt."netrw_lskeep"   ,"&l:ls")
+  call s:NetrwRestoreSetting(a:vt."netrw_makeep"   ,"&l:ma")
   call s:NetrwRestoreSetting(a:vt."netrw_magickeep","&l:magic")
-  call s:NetrwRestoreSetting(a:vt."netrw_modkeep","&l:mod")
-  call s:NetrwRestoreSetting(a:vt."netrw_nukeep","&l:nu")
-  call s:NetrwRestoreSetting(a:vt."netrw_rnukeep","&l:rnu")
-  call s:NetrwRestoreSetting(a:vt."netrw_repkeep","&l:report")
-  call s:NetrwRestoreSetting(a:vt."netrw_rokeep","&l:ro")
-  call s:NetrwRestoreSetting(a:vt."netrw_selkeep","&l:sel")
+  call s:NetrwRestoreSetting(a:vt."netrw_modkeep"  ,"&l:mod")
+  call s:NetrwRestoreSetting(a:vt."netrw_nukeep"   ,"&l:nu")
+"  call Decho("(s:NetrwOptionsRestore) #8 lines=".&lines)
+  call s:NetrwRestoreSetting(a:vt."netrw_rnukeep"  ,"&l:rnu")
+  call s:NetrwRestoreSetting(a:vt."netrw_repkeep"  ,"&l:report")
+  call s:NetrwRestoreSetting(a:vt."netrw_rokeep"   ,"&l:ro")
+  call s:NetrwRestoreSetting(a:vt."netrw_selkeep"  ,"&l:sel")
+"  call Decho("(s:NetrwOptionsRestore) #9 lines=".&lines)
   call s:NetrwRestoreSetting(a:vt."netrw_spellkeep","&l:spell")
-  call s:NetrwRestoreSetting(a:vt."netrw_twkeep","&l:tw")
-  call s:NetrwRestoreSetting(a:vt."netrw_wigkeep","&l:wig")
-  call s:NetrwRestoreSetting(a:vt."netrw_wrapkeep","&l:wrap")
+  call s:NetrwRestoreSetting(a:vt."netrw_twkeep"   ,"&l:tw")
+  call s:NetrwRestoreSetting(a:vt."netrw_wigkeep"  ,"&l:wig")
+  call s:NetrwRestoreSetting(a:vt."netrw_wrapkeep" ,"&l:wrap")
   call s:NetrwRestoreSetting(a:vt."netrw_writekeep","&l:write")
+"  call Decho("(s:NetrwOptionsRestore) #10 lines=".&lines)
   call s:NetrwRestoreSetting("s:yykeep","@@")
   " former problem: start with liststyle=0; press <i> : result, following line resets l:ts.
   " Fixed; in s:PerformListing, when w:netrw_liststyle is s:LONGLIST, will use a printf to pad filename with spaces
@@ -1827,9 +1858,11 @@ fun! s:NetrwOptionsRestore(vt)
   " were having their filetype detect-generated settings overwritten by
   " NetrwOptionRestore.
   if &ft != "netrw"
-"   call Decho("filetype detect  (ft=".&ft.")",'~'.expand("<slnum>"))
+"   call Decho("before: filetype detect  (ft=".&ft.")",'~'.expand("<slnum>"))
    filetype detect
+"   call Decho("after : filetype detect  (ft=".&ft.")",'~'.expand("<slnum>"))
   endif
+"  call Decho("(s:NetrwOptionsRestore) lines=".&lines)
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
 "  call Dret("s:NetrwOptionsRestore : tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> modified=".&modified." modifiable=".&modifiable." readonly=".&readonly)
 endfun
@@ -1879,7 +1912,7 @@ fun! s:NetrwRestoreSetting(keepvar,setting)
   " typically called from s:NetrwOptionsRestore
   "   call s:NetrwRestoreSettings(keep-option-variable-name,'associated-option')
   "   ex. call s:NetrwRestoreSetting(a:vt."netrw_selkeep","&l:sel")
-  "  Restores option (if different) from a keepvar
+  "  Restores option (but only if different) from a:keepvar
   if exists(a:keepvar)
    exe "let keepvarval= ".a:keepvar
    exe "let setting= ".a:setting
@@ -2801,14 +2834,16 @@ fun! netrw#SetTreetop(iscmd,...)
 "  call Decho("inittreetop<".(exists("inittreetop")? inittreetop : "n/a").">")
 
   if (a:iscmd == 0 || a:1 == "") && exists("inittreetop")
-   let treedir= s:NetrwTreePath(inittreetop)
+   let treedir         = s:NetrwTreePath(inittreetop)
 "   call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
   else
    if isdirectory(s:NetrwFile(a:1))
 "    call Decho("a:1<".a:1."> is a directory",'~'.expand("<slnum>"))
-    let treedir= a:1
+    let treedir         = a:1
+    let s:netrw_treetop = treedir
    elseif exists("b:netrw_curdir") && (isdirectory(s:NetrwFile(b:netrw_curdir."/".a:1)) || a:1 =~ '^\a\{3,}://')
-    let treedir= b:netrw_curdir."/".a:1
+    let treedir         = b:netrw_curdir."/".a:1
+    let s:netrw_treetop = treedir
 "    call Decho("a:1<".a:1."> is NOT a directory, using treedir<".treedir.">",'~'.expand("<slnum>"))
    else
     " normally the cursor is left in the message window.
@@ -2816,7 +2851,8 @@ fun! netrw#SetTreetop(iscmd,...)
     let netrwbuf= bufnr("%")
     call netrw#ErrorMsg(s:ERROR,"sorry, ".a:1." doesn't seem to be a directory!",95)
     exe bufwinnr(netrwbuf)."wincmd w"
-    let treedir= "."
+    let treedir         = "."
+    let s:netrw_treetop = getcwd()
    endif
   endif
 "  call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
@@ -4071,6 +4107,7 @@ fun! s:NetrwFileInfo(islocal,fname)
    elseif g:netrw_sizestyle =~# 'h'
     let lsopt= "-lsadh --si"
    endif
+"   call Decho("(s:NetrwFileInfo) lsopt<".lsopt.">")
    if (has("unix") || has("macunix")) && executable("/bin/ls")
 
     if getline(".") == "../"
@@ -4132,9 +4169,10 @@ endfun
 " s:NetrwGetBuffer: [get a new|find an old netrw] buffer for a netrw listing {{{2
 "   returns 0=cleared buffer
 "           1=re-used buffer (buffer not cleared)
+"  Nov 09, 2020: tst952 shows that when user does :set hidden that NetrwGetBuffer will come up with a [No Name] buffer (hid fix)
 fun! s:NetrwGetBuffer(islocal,dirname)
 "  call Dfunc("s:NetrwGetBuffer(islocal=".a:islocal." dirname<".a:dirname.">) liststyle=".g:netrw_liststyle)
-"  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo,'~'.expand("<slnum>"))
+"  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." hid=".&hid,'~'.expand("<slnum>"))
 "  call Decho("netrwbuf dictionary=".(exists("s:netrwbuf")? string(s:netrwbuf) : 'n/a'),'~'.expand("<slnum>"))
 "  call Dredir("ls!","s:NetrwGetBuffer")
   let dirname= a:dirname
@@ -4184,17 +4222,26 @@ fun! s:NetrwGetBuffer(islocal,dirname)
   endif
 "  call Decho("  bufnum#".bufnum,'~'.expand("<slnum>"))
 
-  " highjack the current buffer if
-  "   it has the desired name
-  "   it is empty
-"  call Decho("deciding if I can highjack the current buffer#".bufnr("%"),'~'.expand("<slnum>"))
-"  call Decho("..dirname<".dirname.">",'~'.expand("<slnum>"))
-"  call Decho("..bufname<".bufname("%").">",'~'.expand("<slnum>"))
-"  call Decho("..getline($)<".getline("$").">",'~'.expand("<slnum>"))
-  if dirname == bufname("%") && line("$") == 1 && getline("%") == ""
+  " highjack the current buffer
+  "   IF the buffer already has the desired name
+  "   AND it is empty
+  let curbuf = bufname("%")
+  if curbuf == '.'
+   let curbuf = getcwd()
+  endif
+"  call Dredir("ls!","NetrwGetFile (renamed buffer back to remote filename<".rfile."> : expand(%)<".expand("%").">)")
+"  call Decho("deciding if netrw may highjack the current buffer#".bufnr("%")."<".curbuf.">",'~'.expand("<slnum>"))
+"  call Decho("..dirname<".dirname.">  IF dirname == bufname",'~'.expand("<slnum>"))
+"  call Decho("..curbuf<".curbuf.">",'~'.expand("<slnum>"))
+"  call Decho("..line($)=".line("$")." AND this is 1",'~'.expand("<slnum>"))
+"  call Decho("..getline(%)<".getline("%").">  AND this line is empty",'~'.expand("<slnum>"))
+  if dirname == curbuf && line("$") == 1 && getline("%") == ""
 "   call Dret("s:NetrwGetBuffer 0<cleared buffer> : highjacking buffer#".bufnr("%"))
    return 0
+  else  " DEBUG
+"   call Decho("..did NOT highjack buffer",'~'.expand("<slnum>"))
   endif
+  " Aug 14, 2021: was thinking about looking for a [No Name] buffer here and using it, but that might cause problems
 
   " get enew buffer and name it -or- re-use buffer {{{3
   if bufnum < 0      " get enew buffer and name it
@@ -4519,7 +4566,7 @@ fun! s:NetrwListStyle(islocal)
   " refresh the listing
 "  call Decho("refresh the listing",'~'.expand("<slnum>"))
   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-  NetrwKeepj call s:NetrwCursor()
+  NetrwKeepj call s:NetrwCursor(0)
 
   " repoint t:netrw_lexbufnr if appropriate
   if exists("repointlexbufnr")
@@ -4725,7 +4772,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
   endif
 "  call Decho("b:netrw_curdir<".b:netrw_curdir.">")
 
-  " NetrwBrowseChgDir: save options and initialize {{{3
+  " NetrwBrowseChgDir; save options and initialize {{{3
 "  call Decho("saving options",'~'.expand("<slnum>"))
   call s:SavePosn(s:netrw_posn)
   NetrwKeepj call s:NetrwOptionsSave("s:")
@@ -4793,6 +4840,8 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict") && newdir !~ '^\(/\|\a:\)'
 "    call Decho("edit-a-file: handle tree listing: w:netrw_treedict<".(exists("w:netrw_treedict")? string(w:netrw_treedict) : 'n/a').">",'~'.expand("<slnum>"))
 "    call Decho("edit-a-file: newdir<".newdir.">",'~'.expand("<slnum>"))
+"    let newdir = s:NetrwTreePath(s:netrw_treetop)
+"    call Decho("edit-a-file: COMBAK why doesn't this recognize file1's directory???")
     let dirname= s:NetrwTreeDir(a:islocal)
     "COMBAK : not working for a symlink -- but what about a regular file? a directory?
 "    call Decho("COMBAK : not working for a symlink -- but what about a regular file? a directory?")
@@ -4906,7 +4955,8 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
       exe "NetrwKeepj e ".fnameescape(dirname)
      endif
 "     call Decho("edit-a-file: after e! ".dirname.": hidden=".&hidden." bufhidden<".&bufhidden."> mod=".&mod,'~'.expand("<slnum>"))
-     call s:NetrwCursor()
+     " COMBAK -- cuc cul related
+     call s:NetrwCursor(1)
      if &hidden || &bufhidden == "hide"
       " file came from vim's hidden storage.  Don't "restore" options with it.
       let dorestore= 0
@@ -4927,8 +4977,8 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
      elseif type(g:Netrw_funcref) == 3
 "      call Decho("edit-a-file: handling a list of g:Netrw_funcrefs",'~'.expand("<slnum>"))
       for Fncref in g:Netrw_funcref
-       if type(FncRef) == 2
-        NetrwKeepj call FncRef()
+       if type(Fncref) == 2
+        NetrwKeepj call Fncref()
        endif
       endfor
      endif
@@ -5220,6 +5270,12 @@ fun! netrw#BrowseX(fname,remote)
   endif
 "  call Decho("not a local file nor a webpage request",'~'.expand("<slnum>"))
 
+  if exists("g:netrw_browsex_viewer") && exists("g:netrw_browsex_support_remote") && !g:netrw_browsex_support_remote
+    let remote = a:remote
+  else
+    let remote = 0
+  endif
+
   let ykeep      = @@
   let screenposn = winsaveview()
 "  call Decho("saving posn to screenposn<".string(screenposn).">",'~'.expand("<slnum>"))
@@ -5264,9 +5320,9 @@ fun! netrw#BrowseX(fname,remote)
   endif
 "  call Decho("exten<".exten.">",'~'.expand("<slnum>"))
 
-  if a:remote == 1
+  if remote == 1
    " create a local copy
-"   call Decho("remote: a:remote=".a:remote.": create a local copy of <".a:fname.">",'~'.expand("<slnum>"))
+"   call Decho("remote: remote=".remote.": create a local copy of <".a:fname.">",'~'.expand("<slnum>"))
    setl bh=delete
    call netrw#NetRead(3,a:fname)
    " attempt to rename tempfile
@@ -5288,7 +5344,7 @@ fun! netrw#BrowseX(fname,remote)
     let fname= s:netrw_tmpfile
    endif
   else
-"   call Decho("local: a:remote=".a:remote.": handling local copy of <".a:fname.">",'~'.expand("<slnum>"))
+"   call Decho("local: remote=".remote.": handling local copy of <".a:fname.">",'~'.expand("<slnum>"))
    let fname= a:fname
    " special ~ handler for local
    if fname =~ '^\~' && expand("$HOME") != ""
@@ -5382,8 +5438,8 @@ fun! netrw#BrowseX(fname,remote)
    if a:fname =~ '^https\=://'
     " atril does not appear to understand how to handle html -- so use gvim to edit the document
     let use_ctrlo= 0
-"    call Decho("(COMBAK) fname<".fname.">")
-"    call Decho("(COMBAK) a:fname<".a:fname.">")
+"    call Decho("fname<".fname.">")
+"    call Decho("a:fname<".a:fname.">")
     call s:NetrwExe("sil! !gvim ".fname.' -c "keepj keepalt file '.fnameescape(a:fname).'"')
 
    else
@@ -5431,12 +5487,12 @@ fun! netrw#BrowseX(fname,remote)
   "          return to prior buffer (directory listing)
   "          Feb 12, 2008: had to de-activiate removal of
   "          temporary file because it wasn't getting seen.
-"  if a:remote == 1 && fname != a:fname
+"  if remote == 1 && fname != a:fname
 ""   call Decho("deleting temporary file<".fname.">",'~'.expand("<slnum>"))
 "   call s:NetrwDelete(fname)
 "  endif
 
-  if a:remote == 1
+  if remote == 1
    setl bh=delete bt=nofile
    if g:netrw_use_noswf
     setl noswf
@@ -5495,7 +5551,7 @@ fun! s:NetrwBufRename(newname)
    let b:junk= 1
 "   call Decho("rename buffer: sil! keepj keepalt file ".fnameescape(a:newname),'~'.expand("<slnum>"))
    exe 'sil! keepj keepalt file '.fnameescape(a:newname)
-"   call Dredir("ls!","s:NetrwBufRename (before bwipe)")
+"   call Dredir("ls!","s:NetrwBufRename (before bwipe)~".expand("<slnum>"))
    let oldbufnr= bufnr(oldbufname)
 "   call Decho("oldbufname<".oldbufname."> oldbufnr#".oldbufnr,'~'.expand("<slnum>"))
 "   call Decho("bufnr(%)=".bufnr("%"),'~'.expand("<slnum>"))
@@ -5504,6 +5560,9 @@ fun! s:NetrwBufRename(newname)
     exe "bwipe! ".oldbufnr
 "   else " Decho
 "    call Decho("did *not* bwipe buf#".oldbufnr,'~'.expand("<slnum>"))
+"    call Decho("..reason: if oldbufname<".oldbufname."> is empty",'~'.expand("<slnum>"))"
+"    call Decho("..reason: if oldbufnr#".oldbufnr." is -1",'~'.expand("<slnum>"))"
+"    call Decho("..reason: if oldbufnr#".oldbufnr." != bufnr(%)#".bufnr("%"),'~'.expand("<slnum>"))"
    endif
 "   call Dredir("ls!","s:NetrwBufRename (after rename)")
 "  else " Decho
@@ -6482,7 +6541,7 @@ fun! s:NetrwMaps(islocal)
    if !hasmapto('<Plug>NetrwRefresh')
     nmap <buffer> <unique> <c-l> <Plug>NetrwRefresh
    endif
-   nnoremap <buffer> <silent> <Plug>NetrwRefresh		<c-l>:call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,(w:netrw_liststyle == 3)? w:netrw_treetop : './'))<cr>
+   nnoremap <buffer> <silent> <Plug>NetrwRefresh		<c-l>:call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,(exists("w:netrw_liststyle") && exists("w:netrw_treetop") && w:netrw_liststyle == 3)? w:netrw_treetop : './'))<cr>
    if s:didstarstar || !mapcheck("<s-down>","n")
     nnoremap <buffer> <silent> <s-down>	:Nexplore<cr>
    endif
@@ -8110,6 +8169,23 @@ fun! s:NetrwOpenFile(islocal)
   call inputsave()
   let fname= input("Enter filename: ")
   call inputrestore()
+"  call Decho("(s:NetrwOpenFile) fname<".fname.">",'~'.expand("<slnum>"))
+
+  " determine if Lexplore is in use
+  if exists("t:netrw_lexbufnr")
+   " check if t:netrw_lexbufnr refers to a netrw window
+"   call Decho("(s:netrwOpenFile) ..t:netrw_lexbufnr=".t:netrw_lexbufnr,'~'.expand("<slnum>"))
+   let lexwinnr = bufwinnr(t:netrw_lexbufnr)
+   if lexwinnr != -1 && exists("g:netrw_chgwin") && g:netrw_chgwin != -1
+"    call Decho("(s:netrwOpenFile) ..Lexplore in use",'~'.expand("<slnum>"))
+    exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
+    exe "NetrwKeepj e ".fnameescape(fname)
+    let @@= ykeep
+"    call Dret("s:NetrwOpenFile : creating a file with Lexplore mode")
+   endif
+  endif
+
+  " Does the filename contain a path?
   if fname !~ '[/\\]'
    if exists("b:netrw_curdir")
     if exists("g:netrw_quiet")
@@ -8448,6 +8524,7 @@ fun! s:NetrwPrevWinOpen(islocal)
   let lastwinnr = winnr("$")
   let curword   = s:NetrwGetWord()
   let choice    = 0
+  let s:prevwinopen= 1	" lets s:NetrwTreeDir() know that NetrwPrevWinOpen called it
   let s:treedir = s:NetrwTreeDir(a:islocal)
   let curdir    = s:treedir
 "  call Decho("winnr($)#".lastwinnr." curword<".curword.">",'~'.expand("<slnum>"))
@@ -8775,7 +8852,7 @@ fun! s:NetrwPreview(path) range
     "    0 :             1: top       -- preview window is horizontally split off and on the top
     "    0 :             0: bot       -- preview window is horizontally split off and on the bottom
     "
-    " Note that the file being previewed is already known to not be a directory, hence we can avoid doing a LocalBrowse() check via
+    " Note that the file being previewed is already known to not be a directory, hence we can avoid doing a LocalBrowseCheck() check via
     " the BufEnter event set up in netrwPlugin.vim
 "    call Decho("exe ".(g:netrw_alto? "top " : "bot ").(g:netrw_preview? "vert " : "")."pedit ".fnameescape(a:path),'~'.expand("<slnum>"))
     let eikeep = &ei
@@ -9210,13 +9287,19 @@ fun! s:NetrwTreeDir(islocal)
 "  call Decho("g:netrw_keepdir  =".(exists("g:netrw_keepdir")?   g:netrw_keepdir   : 'n/a'),'~'.expand("<slnum>"))
 "  call Decho("w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a'),'~'.expand("<slnum>"))
 "  call Decho("w:netrw_treetop  =".(exists("w:netrw_treetop")?   w:netrw_treetop   : 'n/a'),'~'.expand("<slnum>"))
+"  call Decho("current line<".getline(".").">")
 
-  if exists("s:treedir")
+  if exists("s:treedir") && exists("s:prevwinopen")
    " s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early
+"   call Decho('s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early')
    let treedir= s:treedir
    unlet s:treedir
-"   call Dret("s:NetrwTreeDir ".treedir)
+   unlet s:prevwinopen
+"   call Dret("s:NetrwTreeDir ".treedir.": early return since s:treedir existed previously")
    return treedir
+  endif
+  if exists("s:prevwinopen")
+   unlet s:prevwinopen
   endif
 
   if !exists("b:netrw_curdir") || b:netrw_curdir == ""
@@ -9424,19 +9507,28 @@ endfun
 "                     Called by s:PerformListing()
 fun! s:NetrwTreeListing(dirname)
   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-"   call Dfunc("NetrwTreeListing() bufname<".expand("%").">")
+"   call Dfunc("s:NetrwTreeListing() bufname<".expand("%").">")
 "   call Decho("curdir<".a:dirname.">",'~'.expand("<slnum>"))
 "   call Decho("win#".winnr().": w:netrw_treetop ".(exists("w:netrw_treetop")? "exists" : "doesn't exist")." w:netrw_treedict ".(exists("w:netrw_treedict")? "exists" : "doesn't exit"),'~'.expand("<slnum>"))
 "   call Decho("g:netrw_banner=".g:netrw_banner.": banner ".(g:netrw_banner? "enabled" : "suppressed").": (line($)=".line("$")." byte2line(1)=".byte2line(1)." bannercnt=".w:netrw_bannercnt.")",'~'.expand("<slnum>"))
 
    " update the treetop
-"   call Decho("update the treetop",'~'.expand("<slnum>"))
    if !exists("w:netrw_treetop")
+"    call Decho("update the treetop  (w:netrw_treetop doesn't exist yet)",'~'.expand("<slnum>"))
     let w:netrw_treetop= a:dirname
+    let s:netrw_treetop= w:netrw_treetop
 "    call Decho("w:netrw_treetop<".w:netrw_treetop."> (reusing)",'~'.expand("<slnum>"))
    elseif (w:netrw_treetop =~ ('^'.a:dirname) && s:Strlen(a:dirname) < s:Strlen(w:netrw_treetop)) || a:dirname !~ ('^'.w:netrw_treetop)
+"    call Decho("update the treetop  (override w:netrw_treetop with a:dirname<".a:dirname.">)",'~'.expand("<slnum>"))
     let w:netrw_treetop= a:dirname
+    let s:netrw_treetop= w:netrw_treetop
 "    call Decho("w:netrw_treetop<".w:netrw_treetop."> (went up)",'~'.expand("<slnum>"))
+   endif
+   if exists("w:netrw_treetop")
+    let s:netrw_treetop= w:netrw_treetop
+   else
+    let w:netrw_treetop= getcwd()
+    let s:netrw_treetop= w:netrw_treetop
    endif
 
    if !exists("w:netrw_treedict")
@@ -9475,7 +9567,7 @@ fun! s:NetrwTreeListing(dirname)
 
    exe "setl ".g:netrw_bufsettings
 
-"   call Dret("NetrwTreeListing : bufname<".expand("%").">")
+"   call Dret("s:NetrwTreeListing : bufname<".expand("%").">")
    return
   endif
 endfun
@@ -10619,7 +10711,7 @@ endfun
 " ---------------------------------------------------------------------
 " netrw#LocalBrowseCheck: {{{2
 fun! netrw#LocalBrowseCheck(dirname)
-  " This function is called by netrwPlugin.vim's s:LocalBrowse(), s:NetrwRexplore(),
+  " This function is called by netrwPlugin.vim's s:LocalBrowseCheck(), s:NetrwRexplore(),
   " and by <cr> when atop a listed file/directory (via a buffer-local map)
   "
   " unfortunate interaction -- split window debugging can't be used here, must use
@@ -10770,7 +10862,7 @@ endfun
 "  Hiding   a buffer means that it will be re-used   when examined, hence "fast".
 "                       (re-using a buffer may not be as accurate)
 "
-"  s:netrw_events : doesn't exist, s:LocalFastBrowser() will install autocmds whena med or fast browsing
+"  s:netrw_events : doesn't exist, s:LocalFastBrowser() will install autocmds with medium-speed or fast browsing
 "                   =1: autocmds installed, but ignore next FocusGained event to avoid initial double-refresh of listing.
 "                       BufEnter may be first event, then a FocusGained event.  Ignore the first FocusGained event.
 "                       If :Explore used: it sets s:netrw_events to 2, so no FocusGained events are ignored.
@@ -10932,13 +11024,14 @@ fun! s:LocalListing()
      let sz= s:NetrwHumanReadable(sz)
     endif
     let longfile= printf("%-".(g:netrw_maxfilenamelen+1)."s",pfile)
-    let pfile   = longfile.fsz." ".strftime(g:netrw_timefmt,getftime(filename))
+    let pfile   = longfile.sz." ".strftime(g:netrw_timefmt,getftime(filename))
 "    call Decho("longlist support: sz=".sz." fsz=".fsz,'~'.expand("<slnum>"))
    endif
 
    if     g:netrw_sort_by =~# "^t"
     " sort by time (handles time up to 1 quintillion seconds, US)
     " Decorate listing by prepending a timestamp/  .  Sorting will then be done based on time.
+"    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (time)")
 "    call Decho("getftime(".filename.")=".getftime(filename),'~'.expand("<slnum>"))
     let t  = getftime(filename)
     let ft = strpart("000000000000000000",1,18-strlen(t)).t
@@ -10948,6 +11041,7 @@ fun! s:LocalListing()
 
    elseif g:netrw_sort_by =~ "^s"
     " sort by size (handles file sizes up to 1 quintillion bytes, US)
+"    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (size)")
 "    call Decho("getfsize(".filename.")=".getfsize(filename),'~'.expand("<slnum>"))
     let sz   = getfsize(filename)
     if g:netrw_sizestyle =~# "[hH]"
@@ -10960,6 +11054,7 @@ fun! s:LocalListing()
 
    else
     " sort by name
+"    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (name)")
 "    call Decho("exe NetrwKeepj put ='".pfile."'",'~'.expand("<slnum>"))
     sil! NetrwKeepj put=pfile
    endif
@@ -11682,19 +11777,32 @@ endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwCursor: responsible for setting cursorline/cursorcolumn based upon g:netrw_cursor {{{2
-fun! s:NetrwCursor()
+fun! s:NetrwCursor(editfile)
   if !exists("w:netrw_liststyle")
    let w:netrw_liststyle= g:netrw_liststyle
   endif
 "  call Dfunc("s:NetrwCursor() ft<".&ft."> liststyle=".w:netrw_liststyle." g:netrw_cursor=".g:netrw_cursor." s:netrw_usercuc=".s:netrw_usercuc." s:netrw_usercul=".s:netrw_usercul)
 
+"  call Decho("(s:NetrwCursor) COMBAK: cuc=".&l:cuc." cul=".&l:cul)
+
   if &ft != "netrw"
    " if the current window isn't a netrw directory listing window, then use user cursorline/column
    " settings.  Affects when netrw is used to read/write a file using scp/ftp/etc.
 "   call Decho("case ft!=netrw: use user cul,cuc",'~'.expand("<slnum>"))
-   let &l:cursorline   = s:netrw_usercul
-   let &l:cursorcolumn = s:netrw_usercuc
 
+  elseif g:netrw_cursor == 8
+   if w:netrw_liststyle == s:WIDELIST
+    setl cursorline
+    setl cursorcolumn
+   else
+    setl cursorline
+   endif
+  elseif g:netrw_cursor == 7
+    setl cursorline
+  elseif g:netrw_cursor == 6
+   if w:netrw_liststyle == s:WIDELIST
+    setl cursorline
+   endif
   elseif g:netrw_cursor == 4
    " all styles: cursorline, cursorcolumn
 "   call Decho("case g:netrw_cursor==4: setl cul cuc",'~'.expand("<slnum>"))
@@ -11711,26 +11819,22 @@ fun! s:NetrwCursor()
    else
 "    call Decho("case g:netrw_cursor==3 and not wide: setl cul (use user's cuc)",'~'.expand("<slnum>"))
     setl cursorline
-    let &l:cursorcolumn   = s:netrw_usercuc
    endif
 
   elseif g:netrw_cursor == 2
    " thin-long-tree: cursorline, user's cursorcolumn
    " wide          : cursorline, user's cursorcolumn
 "   call Decho("case g:netrw_cursor==2: setl cuc (use user's cul)",'~'.expand("<slnum>"))
-   let &l:cursorcolumn = s:netrw_usercuc
    setl cursorline
 
   elseif g:netrw_cursor == 1
    " thin-long-tree: user's cursorline, user's cursorcolumn
    " wide          : cursorline,        user's cursorcolumn
-   let &l:cursorcolumn = s:netrw_usercuc
    if w:netrw_liststyle == s:WIDELIST
 "    call Decho("case g:netrw_cursor==2 and wide: setl cul (use user's cuc)",'~'.expand("<slnum>"))
     setl cursorline
    else
 "    call Decho("case g:netrw_cursor==2 and not wide: (use user's cul,cuc)",'~'.expand("<slnum>"))
-    let &l:cursorline   = s:netrw_usercul
    endif
 
   else
@@ -11740,6 +11844,7 @@ fun! s:NetrwCursor()
    let &l:cursorcolumn = s:netrw_usercuc
   endif
 
+" call Decho("(s:NetrwCursor) COMBAK: cuc=".&l:cuc." cul=".&l:cul)
 "  call Dret("s:NetrwCursor : l:cursorline=".&l:cursorline." l:cursorcolumn=".&l:cursorcolumn)
 endfun
 
@@ -11753,6 +11858,7 @@ fun! s:RestoreCursorline()
   if exists("s:netrw_usercuc")
    let &l:cursorcolumn = s:netrw_usercuc
   endif
+"  call Decho("(s:RestoreCursorline) COMBAK: cuc=".&l:cuc." cul=".&l:cul)
 "  call Dret("s:RestoreCursorline : restored cul=".&l:cursorline." cuc=".&l:cursorcolumn)
 endfun
 
@@ -11788,10 +11894,36 @@ fun! s:NetrwDelete(path)
 endfun
 
 " ---------------------------------------------------------------------
+" s:NetrwBufRemover: removes a buffer that: {{{2s
+"                    has buffer-id > 1
+"                    is unlisted
+"                    is unnamed
+"                    does not appear in any window
+fun! s:NetrwBufRemover(bufid)
+"  call Dfunc("s:NetrwBufRemover(".a:bufid.")")
+"  call Decho("buf#".a:bufid."           ".((a:bufid > 1)? ">" : "≯")." must be >1 for removal","~".expand("<slnum>"))
+"  call Decho("buf#".a:bufid." is        ".(buflisted(a:bufid)? "listed" : "unlisted"),"~".expand("<slnum>"))
+"  call Decho("buf#".a:bufid." has name <".bufname(a:bufid).">","~".expand("<slnum>"))
+"  call Decho("buf#".a:bufid." has winid#".bufwinid(a:bufid),"~".expand("<slnum>"))
+
+  if a:bufid > 1 && !buflisted(a:bufid) && bufname(a:bufid) == "" && bufwinid(a:bufid) == -1
+"   call Decho("(s:NetrwBufRemover) removing buffer#".a:bufid,"~".expand("<slnum>"))
+   exe "bd! ".a:bufid
+  endif
+
+"  call Dret("s:NetrwBufRemover")
+endfun
+
+" ---------------------------------------------------------------------
 " s:NetrwEnew: opens a new buffer, passes netrw buffer variables through {{{2
 fun! s:NetrwEnew(...)
 "  call Dfunc("s:NetrwEnew() a:0=".a:0." win#".winnr()." winnr($)=".winnr("$")." bufnr($)=".bufnr("$")." expand(%)<".expand("%").">")
 "  call Decho("curdir<".((a:0>0)? a:1 : "")."> buf#".bufnr("%")."<".bufname("%").">",'~'.expand("<slnum>"))
+
+  " Clean out the last buffer: 
+  " Check if the last buffer has # > 1, is unlisted, is unnamed, and does not appear in a window
+  " If so, delete it.
+  call s:NetrwBufRemover(bufnr("$"))
 
   " grab a function-local-variable copy of buffer variables
 "  call Decho("make function-local copy of netrw variables",'~'.expand("<slnum>"))

--- a/runtime/autoload/netrwSettings.vim
+++ b/runtime/autoload/netrwSettings.vim
@@ -1,7 +1,7 @@
 " netrwSettings.vim: makes netrw settings simpler
-" Date:		Nov 09, 2016
+" Date:		Aug 12, 2021
 " Maintainer:	Charles E Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
-" Version:	16
+" Version:	17	ASTRO-ONLY
 " Copyright:    Copyright (C) 1999-2007 Charles E. Campbell {{{1
 "               Permission is hereby granted to use and distribute this code,
 "               with or without modifications, provided that this copyright
@@ -19,7 +19,7 @@
 if exists("g:loaded_netrwSettings") || &cp
   finish
 endif
-let g:loaded_netrwSettings = "v16"
+let g:loaded_netrwSettings = "v17"
 if v:version < 700
  echohl WarningMsg
  echo "***warning*** this version of netrwSettings needs vim 7.0"
@@ -31,7 +31,7 @@ endif
 " NetrwSettings: {{{1
 fun! netrwSettings#NetrwSettings()
   " this call is here largely just to insure that netrw has been loaded
-  call netrw#SavePosn()
+  call netrw#WinPath("")
   if !exists("g:loaded_netrw")
    echohl WarningMsg | echomsg "***sorry*** netrw needs to be loaded prior to using NetrwSettings" | echohl None
    return

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -139,9 +139,9 @@ include the "|" in the option value, use "\|" instead.  This example sets the
 This sets the 'titlestring' option to "hi" and 'iconstring' to "there": >
    :set titlestring=hi|set iconstring=there
 
-Similarly, the double quote character starts a comment.  To include the '"' in
-the option value, use '\"' instead.  This example sets the 'titlestring'
-option to 'hi "there"': >
+Similarly, in legacy script the double quote character starts a comment.  To
+include the '"' in the option value, use '\"' instead.  This example sets the
+'titlestring' option to 'hi "there"': >
    :set titlestring=hi\ \"there\"
 
 For Win32 backslashes in file names are mostly not removed.  More precise: For

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -139,9 +139,9 @@ include the "|" in the option value, use "\|" instead.  This example sets the
 This sets the 'titlestring' option to "hi" and 'iconstring' to "there": >
    :set titlestring=hi|set iconstring=there
 
-Similarly, in legacy script the double quote character starts a comment.  To
-include the '"' in the option value, use '\"' instead.  This example sets the
-'titlestring' option to 'hi "there"': >
+Similarly, the double quote character starts a comment.  To include the '"' in
+the option value, use '\"' instead.  This example sets the 'titlestring'
+option to 'hi "there"': >
    :set titlestring=hi\ \"there\"
 
 For Win32 backslashes in file names are mostly not removed.  More precise: For

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -54,6 +54,7 @@ Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
       Browsing With A Horizontally Split Window...........|netrw-o|
       Browsing With A New Tab.............................|netrw-t|
       Browsing With A Vertically Split Window.............|netrw-v|
+      Change File Permission..............................|netrw-gp|
       Change Listing Style.(thin wide long tree)..........|netrw-i|
       Changing To A Bookmarked Directory..................|netrw-gb|
       Changing To A Predecessor Directory.................|netrw-u|
@@ -1095,6 +1096,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   gf	Force treatment as file                              |netrw-gf|
 	   gh	Quick hide/unhide of dot-files                       |netrw-gh|
 	   gn	Make top of tree the directory below the cursor      |netrw-gn|
+	   gp	Change local-only file permissions                   |netrw-gp|
 	   i	Cycle between thin, long, wide, and tree listings    |netrw-i|
 	   I	Toggle the displaying of the banner                  |netrw-I|
 	   mb	Bookmark current directory                           |netrw-mb|
@@ -1510,6 +1512,8 @@ Netrw determines which special handler by the following method:
     If g:netrw_browsex_viewer == '-', then netrwFileHandlers#Invoke() will be
     used instead (see |netrw_filehandler|).
 
+    If the viewer you wish to use does not support handling of a remote URL
+    directory, set |g:netrw_browsex_support_remote| to 0.
   * for Windows 32 or 64, the URL and FileProtocolHandler dlls are used.
   * for Gnome (with gnome-open): gnome-open is used.
   * for KDE (with kfmclient)   : kfmclient is used
@@ -2104,8 +2108,8 @@ the two directories the same, use the "cd" map (type cd).  That map will
 set Vim's notion of the current directory to netrw's current browsing
 directory.
 
-|netrw-cd|: This map's name was changed from "c" to cd (see |netrw-cd|).
-          This change was done to allow for |netrw-cb| and |netrw-cB| maps.
+|netrw-cd| : This map's name was changed from "c" to cd (see |netrw-cd|).
+           This change was done to allow for |netrw-cb| and |netrw-cB| maps.
 
 Associated setting variable: |g:netrw_keepdir|
 
@@ -2607,13 +2611,29 @@ your browsing preferences.  (see also: |netrw-settings|)
 				a script/function to handle the given
 				extension.  (see |netrw_filehandler|).
 
+  *g:netrw_browsex_support_remote*
+				specify if the specified viewer supports a
+				remote URL.  (see |netrw-handler|).
+
   *g:netrw_chgperm*		Unix/Linux: "chmod PERM FILENAME"
 				Windows:    "cacls FILENAME /e /p PERM"
 				Used to change access permission for a file.
 
+  *g:netrw_clipboard*		=1
+  				By default, netrw will attempt to insure that
+				the clipboard's values will remain unchanged.
+				However, some users report that they have
+				speed problems with this; consequently, this
+				option, when set to zero,  lets such users
+				prevent netrw from saving and restoring the
+				clipboard (the latter is done only as needed).
+				That means that if the clipboard is changed
+				(inadvertently) by normal netrw operation that
+				it will not be restored to its prior state.
+
   *g:netrw_compress*		="gzip"
-				    Will compress marked files with this
-				    command
+				Will compress marked files with this
+				command
 
   *g:Netrw_corehandler*		Allows one to specify something additional
 				to do when handling <core> files via netrw's
@@ -2639,12 +2659,23 @@ your browsing preferences.  (see also: |netrw-settings|)
 				 =2        cul u-cuc        cul u-cuc
 				 =3        cul u-cuc        cul   cuc
 				 =4        cul   cuc        cul   cuc
+				 =5      U-cul U-cuc      U-cul U-cuc
+				 =6      U-cul U-cuc        cul U-cuc
+				 =7        cul U-cuc        cul U-cuc
+				 =8        cul U-cuc        cul   cuc
 
 				Where
-				  u-cul : user's |'cursorline'|   setting used
-				  u-cuc : user's |'cursorcolumn'| setting used
-				  cul   : |'cursorline'|  locally set
-				  cuc   : |'cursorcolumn'| locally set
+				  u-cul : user's |'cursorline'|   initial setting used
+				  u-cuc : user's |'cursorcolumn'| initial setting used
+				  U-cul : user's |'cursorline'|   current setting used
+				  U-cuc : user's |'cursorcolumn'| current setting used
+				  cul   : |'cursorline'|   will be locally set
+				  cuc   : |'cursorcolumn'| will be locally set
+
+				  The "initial setting" means the values of
+				  the |'cuc'| and |'cul'| settings in effect when
+				  netrw last saw |g:netrw_cursor| >= 5 or when
+				  netrw was initially run.
 
   *g:netrw_decompress*		= { ".gz"  : "gunzip" ,
 				    ".bz2" : "bunzip2" ,
@@ -2654,7 +2685,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				  decompression programs.
 
   *g:netrw_dirhistmax*            =10: controls maximum quantity of past
-                                     history.  May be zero to supppress
+                                     history.  May be zero to suppress
 				     history.
 				     (related: |netrw-qb| |netrw-u| |netrw-U|)
 
@@ -3140,6 +3171,9 @@ OPEN A NEW FILE IN NETRW'S CURRENT DIRECTORY		*netrw-%* {{{2
 To open a new file in netrw's current directory, press "%".  This map
 will query the user for a new filename; an empty file by that name will
 be placed in the netrw's current directory (ie. b:netrw_curdir).
+
+If Lexplore (|netrw-:Lexplore|) is in use, the new file will be generated
+in the |g:netrw_chgwin| window.
 
 Related topics:               |netrw-d|
 
@@ -3808,7 +3842,7 @@ netrw:
 	  Decho.vim is provided as a "vimball"; see |vimball-intro|.  You
 	  should edit the Decho.vba.gz file and source it in: >
 
-		vim Decho.vba.gz
+	  	vim Decho.vba.gz
 		:so %
 		:q
 <
@@ -3876,6 +3910,32 @@ netrw:
 ==============================================================================
 12. History						*netrw-history* {{{1
 
+	v171:	Oct 09, 2020	* included code in s:NetrwOptionsSafe()
+				  to allow |'bh'| to be set to delete when
+				  rather than hide when g:netrw_fastbrowse
+				  was zero.
+				* Installed |g:netrw_clipboard| setting
+				* Installed option bypass for |'guioptions'|
+				  a/A settings
+				* Changed popup_beval() to |popup_atcursor|()
+				  in netrw#ErrorMsg (lacygoill). Apparently
+				  popup_beval doesn't reliably close the
+				  popup when the mouse is moved.
+				* VimEnter() now using win_execute to examine
+				  buffers for an attempt to open a directory.
+				  Avoids issues with popups/terminal from
+				  command line. (lacygoill)
+		Jun 28, 2021	* (zeertzjq) provided a patch for use of
+				  xmap,xno instead of vmap,vno in
+				  netrwPlugin.vim. Avoids entanglement with
+				  select mode.
+		Jul 14, 2021	* Fixed problem addressed by tst976; opening
+				  a file using tree mode, going up a
+				  directory, and opening a file there was
+				  opening the file in the wrong directory.
+		Jul 28, 2021	* (Ingo Karkat) provided a patch fixing an
+				  E488 error with netrwPlugin.vim
+				  (occurred for vim versions < 8.02)
 	v170:	Mar 11, 2020	* (reported by Reiner Herrmann) netrw+tree
 				  would not hide with the ^\..* pattern
 				  correctly.
@@ -3892,7 +3952,7 @@ netrw:
 		Jun 07, 2020	* (reported by Jo Totland) repeatedly invoking
 				  :Lexplore and quitting it left unused
 				  hidden buffers.  Netrw will now set netrw
-				  buffers created by :Lexplore to |bh|=wipe.
+				  buffers created by :Lexplore to |'bh'|=wipe.
 	v169:	Dec 20, 2019	* (reported by amkarthik) that netrw's x
 				  (|netrw-x|) would throw an error when
 				  attempting to open a local directory.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1096,11 +1096,13 @@ The ColdFusion syntax file is based on the HTML syntax file.
 
 CPP						*cpp.vim* *ft-cpp-syntax*
 
-Most of things are same as |ft-c-syntax|.
+Most things are the same as |ft-c-syntax|.
 
 Variable		Highlight ~
 cpp_no_cpp11		don't highlight C++11 standard items
 cpp_no_cpp14		don't highlight C++14 standard items
+cpp_no_cpp17		don't highlight C++17 standard items
+cpp_no_cpp20		don't highlight C++20 standard items
 
 
 CSH						*csh.vim* *ft-csh-syntax*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Jul 03
+" Last Change:	2021 Aug 23
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/ftplugin/scala.vim
+++ b/runtime/ftplugin/scala.vim
@@ -3,7 +3,7 @@
 " Maintainer:           Derek Wyatt
 " URL:                  https://github.com/derekwyatt/vim-scala
 " License:              Same as Vim
-" Last Change:          02 August 2016
+" Last Change:          11 August 2021
 " ----------------------------------------------------------------------------
 
 if exists('b:did_ftplugin') || &cp
@@ -26,8 +26,8 @@ setlocal commentstring=//\ %s
 
 setlocal shiftwidth=2 softtabstop=2 expandtab
 
-setlocal include='^\s*import'
-setlocal includeexpr='substitute(v:fname,"\\.","/","g")'
+setlocal include=^\\s*import
+setlocal includeexpr=substitute(v:fname,'\\.','/','g')
 
 setlocal path+=src/main/scala,src/test/scala
 setlocal suffixesadd=.scala

--- a/runtime/indent/scala.vim
+++ b/runtime/indent/scala.vim
@@ -20,7 +20,10 @@ endif
 let s:keepcpo= &cpo
 set cpo&vim
 
-let s:defMatcher = '\%(\%(private\|protected\)\%(\[[^\]]*\]\)\?\s\+\|abstract\s\+\|override\s\+\)*\<def\>'
+let s:annotationMatcher = '@[A-Za-z._]\+\s\+'
+let s:modifierMatcher = s:annotationMatcher . '\|\%(private\|protected\)\%(\[[^\]]*\]\)\?\s\+\|abstract\s\+\|override\s\+\|final\s\+'
+let s:defMatcher = '\%(' . s:modifierMatcher . '\)*\<def\>'
+let s:valMatcher = '\%(' . s:modifierMatcher . '\|lazy\s\+\)*\<va[lr]\>'
 let s:funcNameMatcher = '\w\+'
 let s:typeSpecMatcher = '\%(\s*\[\_[^\]]*\]\)'
 let s:defArgMatcher = '\%((\_.\{-})\)'
@@ -184,7 +187,7 @@ function! scala#NumberOfBraceGroups(line)
 endfunction
 
 function! scala#MatchesIncompleteDefValr(line)
-  if a:line =~ '^\s*\%(' . s:defMatcher . '\|\<va[lr]\>\).*[=({]\s*$'
+  if a:line =~ '^\s*\%(' . s:defMatcher . '\|' . s:valMatcher . '\).*[=({]\s*$'
     return 1
   else
     return 0
@@ -434,7 +437,7 @@ function! GetScalaIndent()
   " If 'val', 'var', 'def' end with =, this is a one-line block
   if (prevline =~ '^\s*\<\%(\%(}\?\s*else\s\+\)\?if\|for\|while\)\>.*[)=]\s*$' && scala#NumberOfBraceGroups(prevline) <= 1)
         \ || prevline =~ '^\s*' . s:defMatcher . '.*=\s*$'
-        \ || prevline =~ '^\s*\<va[lr]\>.*[=]\s*$'
+        \ || prevline =~ '^\s*' . s:valMatcher . '.*[=]\s*$'
         \ || prevline =~ '^\s*\%(}\s*\)\?\<else\>\s*$'
         \ || prevline =~ '=\s*$'
     call scala#ConditionalConfirm("4")

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2021 Aug 06
+" Last Change: 2021 Aug 23
 "
 " WORK IN PROGRESS - Only the basics work
 " Note: On MS-Windows you need a recent version of gdb.  The one included with
@@ -342,6 +342,9 @@ func s:StartDebug_term(dict)
   " Disable pagination, it causes everything to stop at the gdb
   " "Type <return> to continue" prompt.
   call s:SendCommand('set pagination off')
+
+  " Set the filetype, this can be used to add mappings.
+  set filetype=termdebug
 
   call s:StartDebugCommon(a:dict)
 endfunc

--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -2,7 +2,7 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2021 May 04
+" Last Change:	2021 Aug 23
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -60,7 +60,7 @@ if !exists("cpp_no_cpp14")
   syn match cppFloat		display contained "\<\d\+\.\d*\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
   syn match cppFloat		display contained "\<\.\d\+\(e[-+]\=\d\+\)\=\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
   syn match cppFloat		display contained "\<\d\+e[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
-  syn region cppString		start=+\(L\|u\|u8\|U\|R\|LR\|u8R\|uR\|UR\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"\(sv\|s\|_\i*\)\=+ end='$' contains=cSpecial,cFormat,@Spell
+  syn region cppString		start=+\(L\|u\|u8\|U\)\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"\(sv\|s\|_\i*\)\=+ end='$' contains=cSpecial,cFormat,@Spell
 endif
 
 " C++ 17 extensions
@@ -69,6 +69,20 @@ if !exists("cpp_no_cpp17")
   syn match cppCast		"\<reinterpret_pointer_cast\s*$"
   syn match cppFloat		display contained "\<0x\x*\.\x\+p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
   syn match cppFloat		display contained "\<0x\x\+\.\=p[-+]\=\d\+\([FfLl]\|i[fl]\=\|h\|min\|s\|ms\|us\|ns\|_\i*\)\=\>"
+
+  " TODO: push this up to c.vim if/when supported in C23
+  syn match cppCharacter	"u8'[^\\]'"
+  syn match cppCharacter	"u8'[^']*'" contains=cSpecial
+  if exists("c_gnu")
+    syn match cppSpecialError	  "u8'\\[^'\"?\\abefnrtv]'"
+    syn match cppSpecialCharacter "u8'\\['\"?\\abefnrtv]'"
+  else
+    syn match cppSpecialError	  "u8'\\[^'\"?\\abfnrtv]'"
+    syn match cppSpecialCharacter "u8'\\['\"?\\abfnrtv]'"
+  endif
+  syn match cppSpecialCharacter display "u8'\\\o\{1,3}'"
+  syn match cppSpecialCharacter display "u8'\\x\x\+'"
+
 endif
 
 " C++ 20 extensions
@@ -99,6 +113,9 @@ hi def link cppType		Type
 hi def link cppStorageClass	StorageClass
 hi def link cppStructure		Structure
 hi def link cppBoolean		Boolean
+hi def link cppCharacter		cCharacter
+hi def link cppSpecialCharacter		cSpecialCharacter
+hi def link cppSpecialError		cSpecialError
 hi def link cppConstant		Constant
 hi def link cppRawStringDelimiter	Delimiter
 hi def link cppRawString		String

--- a/runtime/syntax/gemtext.vim
+++ b/runtime/syntax/gemtext.vim
@@ -1,0 +1,24 @@
+" Vim syntax file
+" Language:             Gemtext markup language
+" Maintainer:           Suneel Freimuth <suneelfreimuth1@gmail.com>
+" Latest Revision:      2020-11-21
+" Filenames:            *.gmi
+
+if exists('b:current_syntax')
+    finish
+endif
+
+syntax match  Heading  /^#\{1,3}.\+$/
+syntax match  List     /^\* /
+syntax match  LinkURL  /^=>\s*\S\+/
+syntax match  Quote    /^>.\+/
+syntax region Preformatted start=/^```/ end=/```/
+
+highlight default link Heading  Special
+highlight default link List     Statement
+highlight default link LinkURL  Underlined
+highlight default link Quote    Constant
+highlight default link Preformatted Identifier
+
+let b:current_syntax = 'gemtext'
+

--- a/runtime/syntax/scala.vim
+++ b/runtime/syntax/scala.vim
@@ -3,8 +3,7 @@
 " Maintainer:           Derek Wyatt
 " URL:                  https://github.com/derekwyatt/vim-scala
 " License:              Same as Vim
-" Last Change:          2021 Aug 11
-"                       by Jesse Atkinson, PR #8746
+" Last Change:          23 August 2021
 " ----------------------------------------------------------------------------
 
 if !exists('main_syntax')
@@ -103,9 +102,9 @@ syn match scalaTypeTypeDeclaration /(/ contained nextgroup=scalaTypeTypeExtensio
 syn match scalaTypeTypeDeclaration /\%(⇒\|=>\)\ze/ contained nextgroup=scalaTypeTypeDeclaration contains=scalaTypeTypeExtension skipwhite
 syn match scalaTypeTypeDeclaration /\<[_\.A-Za-z0-9$]\+\>/ contained nextgroup=scalaTypeTypeExtension,scalaTypeTypeEquals skipwhite
 syn match scalaTypeTypeEquals /=\ze[^>]/ contained nextgroup=scalaTypeTypePostDeclaration skipwhite
-syn match scalaTypeTypeExtension /)\?\_s*\zs\%(⇒\|=>\|<:\|:>\|=:=\|::\|#\)/ contained nextgroup=scalaTypeTypeDeclaration skipwhite
+syn match scalaTypeTypeExtension /)\?\_s*\zs\%(⇒\|=>\|<:\|:>\|=:=\|::\|#\)/ contained contains=scalaTypeOperator nextgroup=scalaTypeTypeDeclaration skipwhite
 syn match scalaTypeTypePostDeclaration /\<[_\.A-Za-z0-9$]\+\>/ contained nextgroup=scalaTypeTypePostExtension skipwhite
-syn match scalaTypeTypePostExtension /\%(⇒\|=>\|<:\|:>\|=:=\|::\)/ contained nextgroup=scalaTypeTypePostDeclaration skipwhite
+syn match scalaTypeTypePostExtension /\%(⇒\|=>\|<:\|:>\|=:=\|::\)/ contained contains=scalaTypeOperator nextgroup=scalaTypeTypePostDeclaration skipwhite
 hi link scalaTypeTypeDeclaration Type
 hi link scalaTypeTypeExtension Keyword
 hi link scalaTypeTypePostDeclaration Special
@@ -114,21 +113,23 @@ hi link scalaTypeTypePostExtension Keyword
 syn match scalaTypeDeclaration /(/ contained nextgroup=scalaTypeExtension contains=scalaRoundBrackets skipwhite
 syn match scalaTypeDeclaration /\%(⇒\|=>\)\ze/ contained nextgroup=scalaTypeDeclaration contains=scalaTypeExtension skipwhite
 syn match scalaTypeDeclaration /\<[_\.A-Za-z0-9$]\+\>/ contained nextgroup=scalaTypeExtension skipwhite
-syn match scalaTypeExtension /)\?\_s*\zs\%(⇒\|=>\|<:\|:>\|=:=\|::\|#\)/ contained nextgroup=scalaTypeDeclaration skipwhite
+syn match scalaTypeExtension /)\?\_s*\zs\%(⇒\|=>\|<:\|:>\|=:=\|::\|#\)/ contained contains=scalaTypeOperator nextgroup=scalaTypeDeclaration skipwhite
 hi link scalaTypeDeclaration Type
 hi link scalaTypeExtension Keyword
 hi link scalaTypePostExtension Keyword
 
 syn match scalaTypeAnnotation /\%([_a-zA-Z0-9$\s]:\_s*\)\ze[_=(\.A-Za-z0-9$]\+/ skipwhite nextgroup=scalaTypeDeclaration contains=scalaRoundBrackets
 syn match scalaTypeAnnotation /)\_s*:\_s*\ze[_=(\.A-Za-z0-9$]\+/ skipwhite nextgroup=scalaTypeDeclaration
-hi link scalaTypeAnnotation Normal
+hi clear scalaTypeAnnotation
 
-syn match scalaCaseFollowing /\<[_\.A-Za-z0-9$]\+\>/ contained
-syn match scalaCaseFollowing /`[^`]\+`/ contained
+syn match scalaCaseFollowing /\<[_\.A-Za-z0-9$]\+\>/ contained contains=scalaCapitalWord
+syn match scalaCaseFollowing /`[^`]\+`/ contained contains=scalaCapitalWord
 hi link scalaCaseFollowing Special
 
-syn keyword scalaKeywordModifier abstract override final lazy implicit implicitly private protected sealed null require super
+syn keyword scalaKeywordModifier abstract override final lazy implicit private protected sealed null super
+syn keyword scalaSpecialFunction implicitly require
 hi link scalaKeywordModifier Function
+hi link scalaSpecialFunction Function
 
 syn keyword scalaSpecial this true false ne eq
 syn keyword scalaSpecial new nextgroup=scalaInstanceDeclaration skipwhite
@@ -152,14 +153,14 @@ hi link scalaTripleIString String
 syn match scalaInterpolation /\$[a-zA-Z0-9_$]\+/ contained
 exe 'syn region scalaInterpolationB matchgroup=scalaInterpolationBoundary start=/\${/ end=/}/ contained contains=' . s:ContainedGroup()
 hi link scalaInterpolation Function
-hi link scalaInterpolationB Normal
+hi clear scalaInterpolationB
 
 syn region scalaFString matchgroup=scalaInterpolationBrackets start=/f"/ skip=/\\"/ end=/"/ contains=scalaFInterpolation,scalaFInterpolationB,scalaEscapedChar,scalaUnicodeChar
 syn match scalaFInterpolation /\$[a-zA-Z0-9_$]\+\(%[-A-Za-z0-9\.]\+\)\?/ contained
 exe 'syn region scalaFInterpolationB matchgroup=scalaInterpolationBoundary start=/${/ end=/}\(%[-A-Za-z0-9\.]\+\)\?/ contained contains=' . s:ContainedGroup()
 hi link scalaFString String
 hi link scalaFInterpolation Function
-hi link scalaFInterpolationB Normal
+hi clear scalaFInterpolationB
 
 syn region scalaTripleString start=/"""/ end=/"""\%([^"]\|$\)/ contains=scalaEscapedChar,scalaUnicodeChar
 syn region scalaTripleFString matchgroup=scalaInterpolationBrackets start=/f"""/ end=/"""\%([^"]\|$\)/ contains=scalaFInterpolation,scalaFInterpolationB,scalaEscapedChar,scalaUnicodeChar
@@ -200,7 +201,6 @@ hi link scalaDocLinks Function
 hi link scalaParameterAnnotation Function
 hi link scalaParamAnnotationValue Keyword
 hi link scalaCommentAnnotation Function
-hi link scalaCommentCodeBlockBrackets String
 hi link scalaCommentCodeBlock String
 hi link scalaTodo Todo
 

--- a/runtime/syntax/structurizr.vim
+++ b/runtime/syntax/structurizr.vim
@@ -1,0 +1,76 @@
+" Vim syntax file
+" Language:      Structurizr DSL
+" Maintainer:    Bastian Venthur <venthur@debian.org>
+" Last Change:   2021-08-16
+" Remark:        For a language reference, see
+"                https://github.com/structurizr/dsl
+
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syn case ignore
+
+" comments
+syn match scomment "#.*$"
+syn match scomment "//.*$"
+syn region scomment start="/\*" end="\*/"
+
+" keywords
+syn keyword skeyword animation
+syn keyword skeyword autoLayout
+syn keyword skeyword branding
+syn keyword skeyword component
+syn keyword skeyword configuration
+syn keyword skeyword container
+syn keyword skeyword containerinstance
+syn keyword skeyword custom
+syn keyword skeyword deployment
+syn keyword skeyword deploymentenvironment
+syn keyword skeyword deploymentgroup
+syn keyword skeyword deploymentnode
+syn keyword skeyword dynamic
+syn keyword skeyword element
+syn keyword skeyword enterprise
+syn keyword skeyword exclude
+syn keyword skeyword filtered
+syn keyword skeyword group
+syn keyword skeyword healthcheck
+syn keyword skeyword impliedrelationships
+syn keyword skeyword include
+syn keyword skeyword infrastructurenode
+syn keyword skeyword model
+syn keyword skeyword person
+syn keyword skeyword perspectives
+syn keyword skeyword properties
+syn keyword skeyword relationship
+syn keyword skeyword softwaresystem
+syn keyword skeyword softwaresysteminstance
+syn keyword skeyword styles
+syn keyword skeyword systemcontext
+syn keyword skeyword systemlandscape
+syn keyword skeyword tags
+syn keyword skeyword terminology
+syn keyword skeyword theme
+syn keyword skeyword title
+syn keyword skeyword url
+syn keyword skeyword users
+syn keyword skeyword views
+syn keyword skeyword workspace
+
+syn match skeyword "\!adrs\s\+"
+syn match skeyword "\!constant\s\+"
+syn match skeyword "\!docs\s\+"
+syn match skeyword "\!identifiers\s\+"
+syn match skeyword "\!include\s\+"
+
+syn region sstring oneline start='"' end='"'
+
+syn region sblock start='{' end='}' fold transparent
+
+hi def link sstring string
+hi def link scomment comment
+hi def link skeyword keyword
+
+let b:current_syntax = "structurizr"


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/89a9c159f23fb7b3e24e6d09068adfc24a73afcb

Omit:
nsis/lang/turkish.nsi
pixmaps/gen-inline-pixbufs.sh
doc/popup.txt
doc/terminal.txt
tutor/tutor*
src/[g]vimtutor
CONTRIBUTING.md

Skip:
doc/eval.txt (needs 8.1.2342)
doc/testing.txt (needs 8.2.0299)