### PR TITLE
fix(options.txt): remove vim9script reference

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3797,8 +3797,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Only switch it off when working with old Vi scripts.  In any other
 	situation write patterns that work when 'magic' is on.  Include "\M"
 	when you want to |/\M|.
-	In |Vim9| script the value of 'magic' is ignored, patterns behave like
-	it is always set.
 
 						*'makeef'* *'mef'*
 'makeef' 'mef'		string	(default: "")


### PR DESCRIPTION
caught my eye while scrolling :P

I don't think there're any others