### PR TITLE
vim-patch:8.2.3432: octave/Matlab filetype detection does not work pr…

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -269,7 +269,8 @@ func dist#ft#FTm()
     return
   endif
 
-  let octave_block_terminators = '\<end\%(_try_catch\|classdef\|enumeration\|events\|for\|function\|if\|methods\|parfor\|properties\|switch\|while\)\>'
+  " excluding end(for|function|if|switch|while) common to Murphi
+  let octave_block_terminators = '\<end\%(_try_catch\|classdef\|enumeration\|events\|methods\|parfor\|properties\)\>'
 
   let n = 1
   let saw_comment = 0 " Whether we've seen a multiline comment leader.
@@ -285,8 +286,7 @@ func dist#ft#FTm()
       setf objc
       return
     endif
-    if line =~ '^\s*\%(#\|%!\|[#%]{\=\s*$\)' ||
-	  \ line =~ '^\s*unwind_protect\>' ||
+    if line =~ '^\s*\%(#\|%!\)' || line =~ '^\s*unwind_protect\>' ||
 	  \ line =~ '\%(^\|;\)\s*' .. octave_block_terminators
       setf octave
       return

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -868,16 +868,6 @@ func Test_m_file()
   call assert_equal('octave', &filetype)
   bwipe!
 
-  call writefile(['#{', 'Octave block comment',  '#}'], 'Xfile.m')
-  split Xfile.m
-  call assert_equal('octave', &filetype)
-  bwipe!
-
-  call writefile(['%{', 'Octave block comment', '%}'], 'Xfile.m')
-  split Xfile.m
-  call assert_equal('octave', &filetype)
-  bwipe!
-
   call writefile(['%!test "Octave test"'], 'Xfile.m')
   split Xfile.m
   call assert_equal('octave', &filetype)
@@ -888,7 +878,7 @@ func Test_m_file()
   call assert_equal('octave', &filetype)
   bwipe!
 
-  call writefile(['function test(); 42; endfunction'], 'Xfile.m')
+  call writefile(['try; 42; end_try_catch'], 'Xfile.m')
   split Xfile.m
   call assert_equal('octave', &filetype)
   bwipe!
@@ -898,6 +888,13 @@ func Test_m_file()
   call writefile(['(* Mathematica comment'], 'Xfile.m')
   split Xfile.m
   call assert_equal('mma', &filetype)
+  bwipe!
+
+  " MATLAB
+
+  call writefile(['% MATLAB line comment'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('matlab', &filetype)
   bwipe!
 
   " Murphi


### PR DESCRIPTION
…operly

Problem:    Octave/Matlab filetype detection does not work properly.
Solution:   Update the patterns used for matching. (Doug Kearns)
https://github.com/vim/vim/commit/ca0627df69c29508f6f797bef27a1f5fa9a447d3