### PR TITLE
vim-patch:6c391a74fe90

### DIFF
--- a/runtime/autoload/ada.vim
+++ b/runtime/autoload/ada.vim
@@ -67,13 +67,13 @@ if exists ('g:ada_with_gnat_project_files')
     endfor
 endif
 
-" Section: add	standart exception {{{2
+" Section: add	standard exception {{{2
 "
 for Item in ['Constraint_Error', 'Program_Error', 'Storage_Error', 'Tasking_Error', 'Status_Error', 'Mode_Error', 'Name_Error', 'Use_Error', 'Device_Error', 'End_Error', 'Data_Error', 'Layout_Error', 'Length_Error', 'Pattern_Error', 'Index_Error', 'Translation_Error', 'Time_Error', 'Argument_Error', 'Tag_Error', 'Picture_Error', 'Terminator_Error', 'Conversion_Error', 'Pointer_Error', 'Dereference_Error', 'Update_Error']
     let g:ada#Keywords += [{
 	    \ 'word':  Item,
 	    \ 'menu':  'exception',
-	    \ 'info':  'Ada standart exception.',
+	    \ 'info':  'Ada standard exception.',
 	    \ 'kind':  'x',
 	    \ 'icase': 1}]
 endfor
@@ -210,7 +210,7 @@ function ada#Word (...)
    let l:Line = substitute (getline (l:Line_Nr), g:ada#Comment, '', '' )
 
    " Cope with tag searching for items in comments; if we are, don't loop
-   " backards looking for previous lines
+   " backwards looking for previous lines
    if l:Column_Nr > strlen(l:Line)
       " We were in a comment
       let l:Line = getline(l:Line_Nr)

--- a/runtime/autoload/adacomplete.vim
+++ b/runtime/autoload/adacomplete.vim
@@ -14,7 +14,7 @@
 "		15.10.2006 MK Bram's suggestion for runtime integration
 "		05.11.2006 MK Bram suggested not to use include protection for
 "			      autoload
-"		05.11.2006 MK Bram suggested agaist using setlocal omnifunc 
+"		05.11.2006 MK Bram suggested against using setlocal omnifunc 
 "		05.11.2006 MK Bram suggested to save on spaces
 "    Help Page: ft-ada-omni
 "------------------------------------------------------------------------------

--- a/runtime/autoload/csscomplete.vim
+++ b/runtime/autoload/csscomplete.vim
@@ -311,7 +311,7 @@ function! csscomplete#CompleteCSS(findstart, base)
       let values = ["normal", "italic", "oblique", "small-caps", "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900", "xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "larger", "smaller", "sans-serif", "serif", "monospace", "cursive", "fantasy", "caption", "icon", "menu", "message-box", "small-caption", "status-bar"]
     elseif prop =~ '^\%(height\|width\)$'
       let values = ["auto", "border-box", "content-box", "max-content", "min-content", "available", "fit-content"]
-    elseif prop =~ '^\%(left\|rigth\)$'
+    elseif prop =~ '^\%(left\|right\)$'
       let values = ["auto"]
     elseif prop == 'image-rendering'
       let values = ["auto", "crisp-edges", "pixelated"]

--- a/runtime/autoload/decada.vim
+++ b/runtime/autoload/decada.vim
@@ -23,7 +23,7 @@ endif
 
 function decada#Unit_Name () dict				     " {{{1
     "	Convert filename into acs unit:
-    "	    1:  remove the file extenstion.
+    "	    1:  remove the file extension.
     "	    2:  replace all double '_' or '-' with an dot (which denotes a separate)
     "	    3:  remove a trailing '_' (which denotes a specification)
     return substitute (substitute (expand ("%:t:r"), '__\|-', ".", "g"), '_$', "", '')

--- a/runtime/autoload/haskellcomplete.vim
+++ b/runtime/autoload/haskellcomplete.vim
@@ -54,7 +54,7 @@ function! haskellcomplete#Complete(findstart, base)
 
     if b:completingLangExtension
         if a:base ==? ""
-            " Return all posible Lang extensions
+            " Return all possible Lang extensions
             return s:langExtensions
         else
             let l:matches = []
@@ -70,7 +70,7 @@ function! haskellcomplete#Complete(findstart, base)
 
     elseif b:completingOptionsGHC
         if a:base ==? ""
-            " Return all posible GHC options
+            " Return all possible GHC options
             return s:optionsGHC
         else
             let l:matches = []
@@ -86,7 +86,7 @@ function! haskellcomplete#Complete(findstart, base)
 
     elseif b:completingModule
         if a:base ==? ""
-            " Return all posible modules
+            " Return all possible modules
             return s:commonModules
         else
             let l:matches = []

--- a/runtime/autoload/htmlcomplete.vim
+++ b/runtime/autoload/htmlcomplete.vim
@@ -486,7 +486,7 @@ function! htmlcomplete#CompleteTags(findstart, base)
 			endif
 		endif
 		" Value of attribute completion {{{
-		" If attr contains =\s*[\"'] we catched value of attribute
+		" If attr contains =\s*[\"'] we match value of attribute
 		if attr =~ "=\s*[\"']" || attr =~ "=\s*$"
 			" Let do attribute specific completion
 			let attrname = matchstr(attr, '.*\ze\s*=')

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -4222,7 +4222,7 @@ fun! s:NetrwGetBuffer(islocal,dirname)
   endif
 "  call Decho("  bufnum#".bufnum,'~'.expand("<slnum>"))
 
-  " highjack the current buffer
+  " hijack the current buffer
   "   IF the buffer already has the desired name
   "   AND it is empty
   let curbuf = bufname("%")
@@ -4230,7 +4230,7 @@ fun! s:NetrwGetBuffer(islocal,dirname)
    let curbuf = getcwd()
   endif
 "  call Dredir("ls!","NetrwGetFile (renamed buffer back to remote filename<".rfile."> : expand(%)<".expand("%").">)")
-"  call Decho("deciding if netrw may highjack the current buffer#".bufnr("%")."<".curbuf.">",'~'.expand("<slnum>"))
+"  call Decho("deciding if netrw may hijack the current buffer#".bufnr("%")."<".curbuf.">",'~'.expand("<slnum>"))
 "  call Decho("..dirname<".dirname.">  IF dirname == bufname",'~'.expand("<slnum>"))
 "  call Decho("..curbuf<".curbuf.">",'~'.expand("<slnum>"))
 "  call Decho("..line($)=".line("$")." AND this is 1",'~'.expand("<slnum>"))
@@ -4239,7 +4239,7 @@ fun! s:NetrwGetBuffer(islocal,dirname)
 "   call Dret("s:NetrwGetBuffer 0<cleared buffer> : highjacking buffer#".bufnr("%"))
    return 0
   else  " DEBUG
-"   call Decho("..did NOT highjack buffer",'~'.expand("<slnum>"))
+"   call Decho("..did NOT hijack buffer",'~'.expand("<slnum>"))
   endif
   " Aug 14, 2021: was thinking about looking for a [No Name] buffer here and using it, but that might cause problems
 
@@ -6790,7 +6790,7 @@ fun! s:NetrwMarkFile(islocal,fname)
 
   " sanity check
   if empty(a:fname)
-"   call Dret("s:NetrwMarkFile : emtpy fname")
+"   call Dret("s:NetrwMarkFile : empty fname")
    return
   endif
   let curdir = s:NetrwGetCurdir(a:islocal)

--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -9,7 +9,7 @@
 "
 "		let g:phpcomplete_relax_static_constraint = 1/0  [default 0]
 "			Enables completion for non-static methods when completing for static context (::).
-"			This generates E_STRICT level warning, but php calls these methods nontheless.
+"			This generates E_STRICT level warning, but php calls these methods nonetheless.
 "
 "		let g:phpcomplete_complete_for_unknown_classes = 1/0 [default 0]
 "			Enables completion of variables and functions in "everything under the sun" fashion
@@ -28,7 +28,7 @@
 "			This option controls the number of characters the user needs to type before
 "			the tags will be searched for namespaces and classes in typed out namespaces in
 "			"use ..." context. Setting this to 0 is not recommended because that means the code
-"			have to scan every tag, and vim's taglist() function runs extremly slow with a
+"			have to scan every tag, and vim's taglist() function runs extremely slow with a
 "			"match everything" pattern.
 "
 "		let g:phpcomplete_parse_docblock_comments = 1/0 [default 0]
@@ -268,7 +268,7 @@ function! phpcomplete#CompleteUse(base) " {{{
 				call add(no_namespace_matches, {'word': namespace_for_class.'\'.tag.name, 'kind': tag.kind, 'menu': tag.filename, 'info': tag.filename })
 			endif
 		endfor
-		" if it seems that the tags file have namespace informations we can safely throw
+		" if it seems that the tags file have namespace information we can safely throw
 		" away namespaceless tag matches since we can be sure they are invalid
 		if patched_ctags_detected
 			no_namespace_matches = []
@@ -810,7 +810,7 @@ function! phpcomplete#CompleteClassName(base, kinds, current_namespace, imports)
 		endif
 	endfor
 
-	" resolve the typed in part with namespaces (if theres a \ in it)
+	" resolve the typed in part with namespaces (if there's a \ in it)
 	let [tag_match_pattern, namespace_for_class] = phpcomplete#ExpandClassName(a:base, a:current_namespace, a:imports)
 
 	let tags = []
@@ -926,11 +926,11 @@ function! s:getNextCharWithPos(filelines, current_pos) " {{{
 endfunction " }}}
 
 function! phpcomplete#EvaluateModifiers(modifiers, required_modifiers, prohibited_modifiers) " {{{
-	" if theres no modifier, and no modifier is allowed and no modifier is required
+	" if there's no modifier, and no modifier is allowed and no modifier is required
 	if len(a:modifiers) == 0 && len(a:required_modifiers) == 0
 		return 1
 	else
-		" check if every requred modifier is present
+		" check if every required modifier is present
 		for required_modifier in a:required_modifiers
 			if index(a:modifiers, required_modifier) == -1
 				return 0
@@ -1258,7 +1258,7 @@ function! phpcomplete#GetCurrentInstruction(line_number, col_number, phpbegin) "
 				endif
 			endif
 
-			" save the coma position for later use if theres a "naked" , possibly separating a parameter and it is not in a parented part
+			" save the coma position for later use if there's a "naked" , possibly separating a parameter and it is not in a parented part
 			if first_coma_break_pos == -1 && current_char == ','
 				let first_coma_break_pos = len(instruction)
 			endif
@@ -1304,7 +1304,7 @@ function! phpcomplete#GetCurrentInstruction(line_number, col_number, phpbegin) "
 
 	" there were a "naked" coma in the instruction
 	if first_coma_break_pos != -1
-		if instruction !~? '^use' && instruction !~? '^class' " use ... statements and class delcarations should not be broken up by comas
+		if instruction !~? '^use' && instruction !~? '^class' " use ... statements and class declarations should not be broken up by comas
 			let pos = (-1 * first_coma_break_pos) + 1
 			let instruction = instruction[pos :]
 		endif
@@ -1316,7 +1316,7 @@ function! phpcomplete#GetCurrentInstruction(line_number, col_number, phpbegin) "
 		" clear everything up until the first (
 		let instruction = substitute(instruction, '^\(if\|while\|foreach\|for\)\s*(\s*', '', '')
 
-		" lets iterate trough the instruction until we can find the pair for the opening (
+		" lets iterate through the instruction until we can find the pair for the opening (
 		let i = 0
 		let depth = 1
 		while i < len(instruction)
@@ -1424,7 +1424,7 @@ function! phpcomplete#GetCallChainReturnType(classname_candidate, class_candidat
 						let parts = split(substitute(type, '^\\', '', ''), '\')
 						let class_candidate_namespace = join(parts[0:-2], '\')
 						let classname_candidate = parts[-1]
-						" check for renamed namepsace in imports
+						" check for renamed namespace in imports
 						if has_key(classstructure.imports, class_candidate_namespace)
 							let class_candidate_namespace = classstructure.imports[class_candidate_namespace].name
 						endif
@@ -2023,7 +2023,7 @@ function! phpcomplete#GetCachedClassContents(classlocation, class_name) " {{{
 			if getftime(classstructure.file) != classstructure.mtime
 				let valid = 0
 				" we could break here, but the time required for checking probably worth
-				" the the memory we can free by checking every file in the cached hirearchy
+				" the memory we can free by checking every file in the cached hierarchy
 				call phpcomplete#ClearCachedClassContents(classstructure.file)
 			endif
 		endfor
@@ -2037,7 +2037,7 @@ function! phpcomplete#GetCachedClassContents(classlocation, class_name) " {{{
 			call remove(s:cache_classstructures, cache_key)
 			call phpcomplete#ClearCachedClassContents(full_file_path)
 
-			" fall trough for the read from files path
+			" fall through for the read from files path
 		endif
 	else
 		call phpcomplete#ClearCachedClassContents(full_file_path)
@@ -2590,7 +2590,7 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 				let search_line = line
 				let use_line = line
 
-				" add lines from the file until theres no ';' in them
+				" add lines from the file until there's no ';' in them
 				while search_line !~? ';' && l > 0
 					" file lines are reversed so we need to go backwards
 					let l -= 1
@@ -2622,7 +2622,7 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 			" find kind flags from tags or built in methods for the objects we extracted
 			" they can be either classes, interfaces or namespaces, no other thing is importable in php
 			for [key, import] in items(imports)
-				" if theres a \ in the name we have it's definitely not a built in thing, look for tags
+				" if there's a \ in the name we have it's definitely not a built in thing, look for tags
 				if import.name =~ '\\'
 					let patched_ctags_detected = 0
 					let [classname, namespace_for_classes] = phpcomplete#ExpandClassName(import.name, '\', {})
@@ -2679,10 +2679,10 @@ function! phpcomplete#GetCurrentNameSpace(file_lines) " {{{
 						let import['kind'] = 'i'
 						let import['builtin'] = 1
 					else
-						" or can be a tag with exactly matchign name
+						" or can be a tag with exactly matching name
 						let tags = phpcomplete#GetTaglist('^'.import['name'].'$')
 						for tag in tags
-							" search for the first matchin namespace, class, interface with no namespace
+							" search for the first matching namespace, class, interface with no namespace
 							if !has_key(tag, 'namespace') && (tag.kind == 'n' || tag.kind == 'c' || tag.kind == 'i' || tag.kind == 't')
 								call extend(import, tag)
 								let import['builtin'] = 0
@@ -2900,7 +2900,7 @@ for [ext, data] in items(php_builtin['functions'])
 	call extend(g:php_builtin_functions, data)
 endfor
 
-" Built in classs
+" Built in class
 let g:php_builtin_classes = {}
 for [ext, data] in items(php_builtin['classes'])
 	call extend(g:php_builtin_classes, data)
@@ -2918,10 +2918,10 @@ for [ext, data] in items(php_builtin['constants'])
 	call extend(g:php_constants, data)
 endfor
 
-" When the classname not found or found but the tags dosen't contain that
-" class we will try to complate any method of any builtin class. To speed up
+" When the classname not found or found but the tags doesn't contain that
+" class we will try to complete any method of any builtin class. To speed up
 " that lookup we compile a 'ClassName::MethodName':'info' dictionary from the
-" builtin class informations
+" builtin class information
 let g:php_builtin_object_functions = {}
 
 " When completing for 'everyting imaginable' (no class context, not a

--- a/runtime/autoload/python3complete.vim
+++ b/runtime/autoload/python3complete.vim
@@ -173,7 +173,7 @@ class Completer(object):
                 pass
         if len(arg_text) == 0:
             # The doc string sometimes contains the function signature
-            #  this works for alot of C modules that are part of the
+            #  this works for a lot of C modules that are part of the
             #  standard library
             doc = func_obj.__doc__
             if doc:

--- a/runtime/autoload/pythoncomplete.vim
+++ b/runtime/autoload/pythoncomplete.vim
@@ -191,7 +191,7 @@ class Completer(object):
                 pass
         if len(arg_text) == 0:
             # The doc string sometimes contains the function signature
-            #  this works for alot of C modules that are part of the
+            #  this works for a lot of C modules that are part of the
             #  standard library
             doc = func_obj.__doc__
             if doc:

--- a/runtime/autoload/sqlcomplete.vim
+++ b/runtime/autoload/sqlcomplete.vim
@@ -17,7 +17,7 @@
 "       and complete it.
 "
 " Version 16.0 (Dec 2015)
-"     - NF: If reseting the cache and table, procedure or view completion
+"     - NF: If resetting the cache and table, procedure or view completion
 "           had been used via dbext, have dbext delete or recreate the 
 "           dictionary so that new objects are picked up for the 
 "           next completion.
@@ -554,7 +554,7 @@ function! sqlcomplete#PreCacheSyntax(...)
         let syn_group_arr = g:omni_sql_precache_syntax_groups
     endif
     " For each group specified in the list, precache all
-    " the sytnax items.
+    " the syntax items.
     if !empty(syn_group_arr)
         for group_name in syn_group_arr
             let syn_items = extend( syn_items, s:SQLCGetSyntaxList(group_name) )
@@ -577,7 +577,7 @@ function! sqlcomplete#ResetCacheSyntax(...)
         let syn_group_arr = g:omni_sql_precache_syntax_groups
     endif
     " For each group specified in the list, precache all
-    " the sytnax items.
+    " the syntax items.
     if !empty(syn_group_arr)
         for group_name in syn_group_arr
             let list_idx = index(s:syn_list, group_name, 0, &ignorecase)
@@ -843,7 +843,7 @@ function! s:SQLCGetColumns(table_name, list_type)
          let curline    = line(".")
          let curcol     = col(".")
 
-         " Do not let searchs wrap
+         " Do not let searches wrap
          setlocal nowrapscan
          " If . was entered, look at the word just before the .
          " We are looking for something like this:
@@ -863,7 +863,7 @@ function! s:SQLCGetColumns(table_name, list_type)
          " Search forward until one of the following:
          "     1.  Another select/update/delete statement
          "     2.  A ; at the end of a line (the delimiter)
-         "     3.  The end of the file (incase no delimiter)
+         "     3.  The end of the file (in case no delimiter)
          " Yank the visually selected text into the "y register.
          exec 'silent! normal! vl/\c\(\<select\>\|\<update\>\|\<delete\>\|;\s*$\|\%$\)'."\n".'"yy'
 

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -778,7 +778,7 @@ fun! tar#Vimuntar(...)
    elseif executable("gzip")
     silent exe "!gzip -d ".shellescape(tartail)
    else
-    echoerr "unable to decompress<".tartail."> on this sytem"
+    echoerr "unable to decompress<".tartail."> on this system"
     if simplify(curdir) != simplify(tarhome)
      " remove decompressed tarball, restore directory
 "     call Decho("delete(".tartail.".tar)")

--- a/runtime/autoload/tohtml.vim
+++ b/runtime/autoload/tohtml.vim
@@ -693,7 +693,7 @@ func! tohtml#GetUserSettings() "{{{
     let user_settings = {}
 
     " Define the correct option if the old option name exists and we haven't
-    " already defined the correct one. Maybe I'll put out a warnig message about
+    " already defined the correct one. Maybe I'll put out a warning message about
     " this sometime and remove the old option entirely at some even later time,
     " but for now just silently accept the old option.
     if exists('g:use_xhtml') && !exists("g:html_use_xhtml")

--- a/runtime/autoload/xmlcomplete.vim
+++ b/runtime/autoload/xmlcomplete.vim
@@ -199,7 +199,7 @@ function! xmlcomplete#CompleteTags(findstart, base)
 	" 1. Events attributes
 	if context =~ '\s'
 
-		" If attr contains =\s*[\"'] we catched value of attribute
+		" If attr contains =\s*[\"'] we catch value of attribute
 		if attr =~ "=\s*[\"']" || attr =~ "=\s*$"
 			" Let do attribute specific completion
 			let attrname = matchstr(attr, '.*\ze\s*=')

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -81,7 +81,7 @@ fun! zip#Browse(zipfile)
   " sanity checks
   if !exists("*fnameescape")
    if &verbose > 1
-    echoerr "the zip plugin is not available (your vim doens't support fnameescape())"
+    echoerr "the zip plugin is not available (your vim doesn't support fnameescape())"
    endif
    return
   endif

--- a/runtime/compiler/fpc.vim
+++ b/runtime/compiler/fpc.vim
@@ -12,6 +12,6 @@ if exists(":CompilerSet") != 2		" older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-" NOTE: compiler must be runned with -vb to write whole source path, not only file
+" NOTE: compiler must be run with -vb to write whole source path, not only file
 " name.
 CompilerSet errorformat=%f(%l\\,%c)\ %m

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -18,7 +18,7 @@ endif
 if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 			\(!filereadable('Makefile') && !filereadable('makefile'))
 	" If buffer-local variable 'tex_flavor' exists, it defines TeX flavor,
-	" otherwize the same for global variable with same name, else it will be
+	" otherwise the same for global variable with same name, else it will be
 	" LaTeX
 	if exists("b:tex_flavor")
 		let current_compiler = b:tex_flavor

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4094,14 +4094,17 @@ finddir({name} [, {path} [, {count}]])				*finddir()*
 		Find directory {name} in {path}.  Supports both downwards and
 		upwards recursive directory searches.  See |file-searching|
 		for the syntax of {path}.
+
 		Returns the path of the first found match.  When the found
 		directory is below the current directory a relative path is
 		returned.  Otherwise a full path is returned.
 		If {path} is omitted or empty then 'path' is used.
+
 		If the optional {count} is given, find {count}'s occurrence of
 		{name} in {path} instead of the first one.
 		When {count} is negative return all the matches in a |List|.
-		This is quite similar to the ex-command |:find|.
+
+		This is quite similar to the ex-command `:find`.
 
 findfile({name} [, {path} [, {count}]])				*findfile()*
 		Just like |finddir()|, but find a file instead of a directory.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5751,6 +5751,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If the name "cjk" is included East Asian characters are excluded from
 	spell checking.  This is useful when editing text that also has Asian
 	words.
+	Note that the "medical" dictionary does not exist, it is just an
+	example of a longer name.
 							*E757*
 	As a special case the name of a .spl file can be given as-is.  The
 	first "_xx" in the name is removed and used as the region name

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -823,8 +823,12 @@ DEFINING BREAKPOINTS
 		Sets a breakpoint, that will break whenever the {expression}
 		evaluates to a different value. Example: >
 			:breakadd expr g:lnum
-
 <		Will break, whenever the global variable lnum changes.
+
+		Errors in evaluation are suppressed, you can use the name of a
+		variable that does not exist yet.  This also means you will
+		not notice anything if the expression has a mistake.
+
 		Note if you watch a |script-variable| this will break
 		when switching scripts, since the script variable is only
 		valid in the script where it has been defined and if that

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -271,7 +271,7 @@ Closing a window
 ----------------
 
 :q[uit]
-:{count}q[uit]
+:{count}q[uit]						*:count_quit*
 CTRL-W q						*CTRL-W_q*
 CTRL-W CTRL-Q						*CTRL-W_CTRL-Q*
 		Without {count}: Quit the current window. If {count} is
@@ -363,7 +363,8 @@ CTRL-W CTRL-C						*CTRL-W_CTRL-C*
 CTRL-W o						*CTRL-W_o* *E445*
 CTRL-W CTRL-O					*CTRL-W_CTRL-O* *:on* *:only*
 		Make the current window the only one on the screen. All other
-		windows are closed. For {count} see |:quit|.
+		windows are closed.  For {count} see the `:quit` command
+ 		above |:count_quit|.
 
 		When the 'hidden' option is set, all buffers in closed windows
 		become hidden.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1396,7 +1396,7 @@ au BufNewFile,BufRead *.ptl,*.pyi,SConstruct		   setf python
 " Radiance
 au BufNewFile,BufRead *.rad,*.mat		setf radiance
 
-" Raku (formelly Perl6)
+" Raku (formerly Perl6)
 au BufNewFile,BufRead *.pm6,*.p6,*.t6,*.pod6,*.raku,*.rakumod,*.rakudoc,*.rakutest  setf raku
 
 " Ratpoison config/command files

--- a/runtime/ftplugin/dosini.vim
+++ b/runtime/ftplugin/dosini.vim
@@ -1,5 +1,5 @@
 " Vim filetype plugin file
-" Language:             Configuration File (ini file) for MSDOS/MS Windows
+" Language:             Configuration File (ini file) for MS-DOS/MS Windows
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2008-07-09
 

--- a/runtime/ftplugin/matlab.vim
+++ b/runtime/ftplugin/matlab.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	matlab
 " Maintainer:	Jake Wasserman <jwasserman at gmail dot com>
-" Last Change: 	2019 Sep 27
+" Update By:    Gabriel Dupras
+" Last Change: 	2021 Aug 30
 
 " Contributors:
 " Charles Campbell
@@ -15,9 +16,9 @@ let s:save_cpo = &cpo
 set cpo-=C
 
 if exists("loaded_matchit")
- let s:conditionalEnd = '\%(([^()]*\)\@!\<end\>\%([^()]*)\)\@!'
+ let s:conditionalEnd = '\%(\%(^\|;\)\s*\)\@<=end\>'
  let b:match_words=
-   \ '\<\%(if\|switch\|for\|while\)\>:\<\%(elseif\|case\|break\|continue\|else\|otherwise\)\>:'.s:conditionalEnd.','.
+   \ '\<\%(if\|switch\|for\|while\|try\)\>:\<\%(elseif\|case\|break\|continue\|else\|otherwise\|catch\)\>:' . s:conditionalEnd . ',' .
    \ '\<function\>:\<return\>:\<endfunction\>'
  unlet s:conditionalEnd
 endif

--- a/runtime/ftplugin/ocaml.vim
+++ b/runtime/ftplugin/ocaml.vim
@@ -371,7 +371,7 @@ endfunction
               endif
             else
               let annot_file_name = ''
-              "(Pierre Vittet: I have commented 4b because this was chrashing
+              "(Pierre Vittet: I have commented 4b because this was crashing
               "my vim (it produced infinite loop))
               "
               " 4b. anarchy : the renamed _build directory may be higher in the hierarchy
@@ -462,8 +462,8 @@ endfunction
 
   "b. 'search' and 'match' work to find the type information
 
-      "In:  - lin1,col1: postion of expression first char
-      "     - lin2,col2: postion of expression last char
+      "In:  - lin1,col1: position of expression first char
+      "     - lin2,col2: position of expression last char
       "Out: - the pattern to be looked for to find the block
       " Must be called in the source buffer (use of line2byte)
     function! s:Block_pattern(lin1,lin2,col1,col2)
@@ -581,7 +581,7 @@ endfunction
       let res = substitute (a:res, "\n", "", "g" )
       "remove double space
       let res =substitute(res , "  ", " ", "g")
-      "remove space at begining of string.
+      "remove space at beginning of string.
       let res = substitute(res, "^ *", "", "g")
       return res
     endfunction

--- a/runtime/ftplugin/octave.vim
+++ b/runtime/ftplugin/octave.vim
@@ -1,0 +1,63 @@
+" Vim filetype plugin file
+" Language:	GNU Octave
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2021 Sep 02
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" TODO: update Matlab ftplugin and source it as the base file?
+
+setlocal comments=s:%{,m:\ ,e:%},s:#{,m:\ ,e:#},:%,:#
+setlocal commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+setlocal keywordprg=info\ octave\ --vi-keys\ --index-search
+
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_words = '\<unwind_protect\>:\<unwind_protect_cleanup\>:\<end_unwind_protect\>'
+  if exists("octave_use_matlab_end")
+    let b:match_words ..= ',' ..
+	                \ '\<\%(classdef\|enumeration\|events\|for\|function\|if\|methods\|parfor\|properties\|switch\|while\|try\)\>' ..
+                        \ ':' ..
+			\ '\<\%(elseif\|else\|case\|otherwise\|break\|continue\|catch\)\>' ..
+                        \ ':' ..
+			\ '\<end\>'
+  else
+    let b:match_words ..= ',' ..
+                        \ '\<classdef\>:\<endclassdef\>,' ..
+			\ '\<enumeration\>:\<endenumeration\>,' ..
+			\ '\<events\>:\<endevents\>,' ..
+			\ '\<do\>:\<\%(break\|continue\)\>:\<until\>' ..
+			\ '\<for\>:\<\%(break\|continue\)\>:\<endfor\>,' ..
+			\ '\<function\>:\<return\>:\<endfunction\>,' ..
+			\ '\<if\>:\<\%(elseif\|else\)\>:\<endif\>,' ..
+			\ '\<methods\>:\<endmethods\>,' ..
+			\ '\<parfor\>:\<endparfor\>,' ..
+			\ '\<properties\>:\<endproperties\>,' ..
+			\ '\<switch\>:\<\%(case\|otherwise\)\>:\<endswitch\>,' ..
+			\ '\<while\>:\<\%(break\|continue\)\>:\<endwhile\>,' ..
+			\ '\<try\>:\<catch\>:\<end_try_catch\>'
+  endif
+  " only match in statement position
+  let s:statement_start = escape('\%(\%(^\|;\)\s*\)\@<=', '\')
+  let b:match_words = substitute(b:match_words, '\\<', s:statement_start, 'g')
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "GNU Octave Source Files (*.m)\t*.m\n" ..
+		     \ "All Files (*.*)\t*.*\n"
+endif
+
+let b:undo_ftplugin = "setl com< cms< fo< kp< " ..
+		    \ "| unlet! b:browsefilter b:match_words"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/systemverilog.vim
+++ b/runtime/ftplugin/systemverilog.vim
@@ -32,7 +32,7 @@ if exists("loaded_matchit")
     \ '\<checker\>:\<endchecker\>,' .
     \ '\<class\>:\<endclass\>,' .
     \ '\<clocking\>:\<endclocking\>,' .
-    \ '\<gruop\>:\<endgruop\>,' .
+    \ '\<group\>:\<endgroup\>,' .
     \ '\<interface\>:\<endinterface\>,' .
     \ '\<package\>:\<endpackage\>,' .
     \ '\<program\>:\<endprogram\>,' .

--- a/runtime/ftplugin/tex.vim
+++ b/runtime/ftplugin/tex.vim
@@ -28,7 +28,7 @@ let &l:define .= '\|\\\(re\)\=new\(boolean\|command\|counter\|environment\|font'
 
 " Tell Vim how to recognize LaTeX \include{foo} and plain \input bar :
 let &l:include .= '\|\\include{'
-" On some file systems, "{" and "}" are inluded in 'isfname'.  In case the
+" On some file systems, "{" and "}" are included in 'isfname'.  In case the
 " TeX file has \include{fname} (LaTeX only), strip everything except "fname".
 let &l:includeexpr = "substitute(v:fname, '^.\\{-}{\\|}.*', '', 'g')"
 

--- a/runtime/indent/ada.vim
+++ b/runtime/indent/ada.vim
@@ -219,7 +219,7 @@ function GetAdaIndent()
       " Move indent in twice (next 'when' will move back)
       let ind = ind + 2 * shiftwidth()
    elseif line =~ '^\s*end\s*record\>'
-      " Move indent back to tallying 'type' preceeding the 'record'.
+      " Move indent back to tallying 'type' preceding the 'record'.
       " Allow indent to be equal to 'end record's.
       let ind = s:MainBlockIndent( ind+shiftwidth(), lnum, 'type\>', '' )
    elseif line =~ '\(^\s*new\>.*\)\@<!)\s*[;,]\s*$'

--- a/runtime/indent/cdl.vim
+++ b/runtime/indent/cdl.vim
@@ -16,8 +16,8 @@ if exists("*CdlGetIndent")
     "finish
 endif
 
-" find out if an "...=..." expresion is an assignment (or a conditional)
-" it scans 'line' first, and then the previos lines
+" find out if an "...=..." expression is an assignment (or a conditional)
+" it scans 'line' first, and then the previous lines
 fun! CdlAsignment(lnum, line)
   let f = -1
   let lnum = a:lnum
@@ -33,7 +33,7 @@ fun! CdlAsignment(lnum, line)
       endif
       " it's formula if there's a ';', 'elsE', 'theN', 'enDif' or 'expr'
       " conditional if there's a '<', '>', 'elseif', 'if', 'and', 'or', 'not',
-      " 'memberis', 'childrenof' and other \k\+of funcions
+      " 'memberis', 'childrenof' and other \k\+of functions
       let f = line[inicio-1] =~? '[en;]' || strpart(line, inicio-4, 4) =~? 'ndif\|expr'
     endw
     let lnum = prevnonblank(lnum-1)
@@ -106,7 +106,7 @@ fun! CdlGetIndent(lnum)
     elseif c == '(' || c ==? 'f' " '(' or 'if'
       let ind = ind + shiftwidth()
     else " c == '='
-      " if it is an asignment increase indent
+      " if it is an assignment increase indent
       if f == -1 " we don't know yet, find out
 	let f = CdlAsignment(lnum, strpart(line, 0, inicio))
       end
@@ -117,11 +117,11 @@ fun! CdlGetIndent(lnum)
   endw
 
   " CURRENT LINE, if it starts with a closing element, decrease indent
-  " or if it starts with '=' (asignment), increase indent
+  " or if it starts with '=' (assignment), increase indent
   if match(thisline, '^\c\s*\(else\|then\|endif\|[);]\)') >= 0
     let ind = ind - shiftwidth()
   elseif match(thisline, '^\s*=') >= 0
-    if f == -1 " we don't know yet if is an asignment, find out
+    if f == -1 " we don't know yet if is an assignment, find out
       let f = CdlAsignment(lnum, "")
     end
     if f == 1 " formula increase it

--- a/runtime/indent/config.vim
+++ b/runtime/indent/config.vim
@@ -62,8 +62,8 @@ function GetConfigIndent()
     let ind = s:GetOffsetOf(line, '\[')
   endif
 
-  " if previous line had an unmatched closing parantheses,
-  " indent to the matching opening parantheses
+  " if previous line had an unmatched closing parentheses,
+  " indent to the matching opening parentheses
   if line =~ '[^(]\+\\\@<!)$'
     call search(')', 'bW')
     let lnum = searchpair('\\\@<!(', '', ')', 'bWn')

--- a/runtime/indent/dtd.vim
+++ b/runtime/indent/dtd.vim
@@ -119,16 +119,16 @@ function GetDTDIndent()
     " Next comes the content model.  If the token we’ve found isn’t a
     " parenthesis it must be either ANY, EMPTY or some random junk.  Either
     " way, we’re done indenting this element, so set it to that of the first
-    " line so that the terminating “>” winds up having the same indention.
+    " line so that the terminating “>” winds up having the same indentation.
     if token != '('
       return indent
     endif
 
     " Now go through the content model.  We need to keep track of the nesting
     " of parentheses.  As soon as we hit 0 we’re done.  If that happens we must
-    " have a complete content model.  Thus set indention to be the same as that
+    " have a complete content model.  Thus set indentation to be the same as that
     " of the first line so that the terminating “>” winds up having the same
-    " indention.  Otherwise, we’ll indent to the innermost parentheses not yet
+    " indentation.  Otherwise, we’ll indent to the innermost parentheses not yet
     " matched.
     let [indent_of_innermost, end] = s:indent_to_innermost_parentheses(line, end)
     if indent_of_innermost != -1

--- a/runtime/indent/erlang.vim
+++ b/runtime/indent/erlang.vim
@@ -57,7 +57,7 @@ endfunction
 " ======================
 
 " Indtokens are "indentation tokens". See their exact format in the
-" documentaiton of the s:GetTokensFromLine function.
+" documentation of the s:GetTokensFromLine function.
 
 " Purpose:
 "   Calculate the new virtual column after the given segment of a line.
@@ -75,7 +75,7 @@ endfunction
 "   s:CalcVCol("\t'\tx', b", 1, 4, 4)  -> 10
 function! s:CalcVCol(line, first_index, last_index, vcol, tabstop)
 
-  " We copy the relevent segment of the line, otherwise if the line were
+  " We copy the relevant segment of the line, otherwise if the line were
   " e.g. `"\t", term` then the else branch below would consume the `", term`
   " part at once.
   let line = a:line[a:first_index : a:last_index]
@@ -604,7 +604,7 @@ endfunction
 function! s:BeginElementFoundIfEmpty(stack, token, curr_vcol, stored_vcol, sw)
   if empty(a:stack)
     if a:stored_vcol ==# -1
-      call s:Log('    "' . a:token . '" directly preceeds LTI -> return')
+      call s:Log('    "' . a:token . '" directly precedes LTI -> return')
       return [1, a:curr_vcol + a:sw]
     else
       call s:Log('    "' . a:token .
@@ -825,7 +825,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
         if ret | return res | endif
 
         if stored_vcol ==# -1
-          call s:Log('    End of clause directly preceeds LTI -> return')
+          call s:Log('    End of clause directly precedes LTI -> return')
           return 0
         else
           call s:Log('    End of clause (but not end of line) -> return')

--- a/runtime/indent/json.vim
+++ b/runtime/indent/json.vim
@@ -1,6 +1,6 @@
 " Vim indent file
 " Language:		JSON
-" Mantainer:		Eli Parra <eli@elzr.com> https://github.com/elzr/vim-json
+" Maintainer:		Eli Parra <eli@elzr.com> https://github.com/elzr/vim-json
 " Last Change:          2020 Aug 30
 "   https://github.com/jakar/vim-json/commit/20b650e22aa750c4ab6a66aa646bdd95d7cd548a#diff-e81fc111b2052e306d126bd9989f7b7c
 " Original Author:	Rogerz Zhang <rogerz.zhang at gmail.com> http://github.com/rogerz/vim-json

--- a/runtime/indent/lifelines.vim
+++ b/runtime/indent/lifelines.vim
@@ -11,7 +11,7 @@ endif
 let b:did_indent = 1
 
 " LifeLines uses cindent without ; line terminator, C functions
-" declarations, C keywords, C++ formating
+" declarations, C keywords, C++ formatting
 setlocal cindent
 setlocal cinwords=""
 setlocal cinoptions+=+0

--- a/runtime/indent/objc.vim
+++ b/runtime/indent/objc.vim
@@ -15,7 +15,7 @@ setlocal cindent
 " Set the function to do the work.
 setlocal indentexpr=GetObjCIndent()
 
-" To make a colon (:) suggest an indentation other than a goto/swich label,
+" To make a colon (:) suggest an indentation other than a goto/switch label,
 setlocal indentkeys-=:
 setlocal indentkeys+=<:>
 

--- a/runtime/indent/pov.vim
+++ b/runtime/indent/pov.vim
@@ -44,7 +44,7 @@ function GetPoVRayIndent()
     return -1
   endif
 
-  " Search backwards for the frist non-empty, non-comment line.
+  " Search backwards for the first non-empty, non-comment line.
   let plnum = prevnonblank(v:lnum - 1)
   let plind = indent(plnum)
   while plnum > 0 && synIDattr(synID(plnum, plind+1, 0), "name") =~? "comment"

--- a/runtime/indent/ruby.vim
+++ b/runtime/indent/ruby.vim
@@ -265,7 +265,7 @@ function! GetRubyIndent(...) abort
         \ ]
 
   " Most Significant line based on the previous one -- in case it's a
-  " contination of something above
+  " continuation of something above
   let indent_info.plnum_msl = s:GetMSL(indent_info.plnum)
 
   for callback_name in indent_callback_names

--- a/runtime/indent/sqlanywhere.vim
+++ b/runtime/indent/sqlanywhere.vim
@@ -9,7 +9,7 @@
 " Notes:
 "    Indenting keywords are based on Oracle and Sybase Adaptive Server
 "    Anywhere (ASA).  Test indenting was done with ASA stored procedures and
-"    fuctions and Oracle packages which contain stored procedures and
+"    functions and Oracle packages which contain stored procedures and
 "    functions.
 "    This has not been tested against Microsoft SQL Server or
 "    Sybase Adaptive Server Enterprise (ASE) which use the Transact-SQL

--- a/runtime/indent/systemverilog.vim
+++ b/runtime/indent/systemverilog.vim
@@ -64,7 +64,7 @@ function SystemVerilogIndent()
     let vverb = 0
   endif
 
-  " Indent accoding to last line
+  " Indent according to last line
   " End of multiple-line comment
   if last_line =~ '\*/\s*$' && last_line !~ '/\*.\{-}\*/'
     let ind = ind - offset_comment1
@@ -220,7 +220,7 @@ function SystemVerilogIndent()
 
   endif
 
-  " Return the indention
+  " Return the indentation
   return ind
 endfunction
 

--- a/runtime/indent/tex.vim
+++ b/runtime/indent/tex.vim
@@ -288,7 +288,7 @@ function! GetTeXIndent() " {{{
             let ind = ind - shiftwidth()
             let stay = 0
         endif
-        " lines following to '\item' are intented once again:
+        " lines following to '\item' are indented once again:
         if line =~ g:tex_items
             let ind = ind + shiftwidth()
             let stay = 0

--- a/runtime/indent/treetop.vim
+++ b/runtime/indent/treetop.vim
@@ -34,5 +34,5 @@ function GetTreetopIndent()
     let ind -= shiftwidth()
   end
 
-  retur ind
+  return ind
 endfunction

--- a/runtime/indent/typescript.vim
+++ b/runtime/indent/typescript.vim
@@ -460,7 +460,7 @@ function! Fixedgq(lnum, count)
         return 1
     endif
 
-    " Put all the lines on one line and do normal spliting after that
+    " Put all the lines on one line and do normal splitting after that
     if l:count > 1
         while l:count > 1
             let l:count -= 1

--- a/runtime/indent/verilog.vim
+++ b/runtime/indent/verilog.vim
@@ -76,7 +76,7 @@ function GetVerilogIndent()
     let vverb = 0
   endif
 
-  " Indent accoding to last line
+  " Indent according to last line
   " End of multiple-line comment
   if last_line =~ '\*/\s*$' && last_line !~ '/\*.\{-}\*/'
     let ind = ind - offset_comment1
@@ -219,7 +219,7 @@ function GetVerilogIndent()
 
   endif
 
-  " Return the indention
+  " Return the indentation
   return ind
 endfunction
 

--- a/runtime/keymap/kana.vim
+++ b/runtime/keymap/kana.vim
@@ -364,7 +364,7 @@ ppu っぷ
 ppe っぺ
 ppo っぽ
 
-" Proceded by a small `tu' and followed by a small 'ya', 'yu' or 'yo'
+" Preceded by a small `tu' and followed by a small 'ya', 'yu' or 'yo'
 kkya っきゃ
 kkyu っきゅ
 kkyo っきょ
@@ -683,7 +683,7 @@ PPU ップ
 PPE ッペ
 PPO ッポ
 
-" Proceded by a small `tu' and followed by a small 'ya', 'yu' or 'yo'
+" Preceded by a small `tu' and followed by a small 'ya', 'yu' or 'yo'
 KKYA ッキャ
 KKYU ッキュ
 KKYO ッキョ

--- a/runtime/keymap/korean.vim
+++ b/runtime/keymap/korean.vim
@@ -10,7 +10,7 @@
 " BUT, simply mapping each letter of Hangul with sequence of alphabet 1 by 1
 " can fail to combine Hangul jamo (conconants and vowels) right.
 " For example, sequentially pressing `ㅅㅓㅇㅜㄹㄷㅐㅎㅏㄱㅛ` can not only be
-" combined as `서울대학교`, but alse `성ㅜㄹ댛ㅏㄱ교`, which is totally 
+" combined as `서울대학교`, but also `성ㅜㄹ댛ㅏㄱ교`, which is totally 
 " nonsense. 
 " Though combining Hangul is deterministic with law that each letter must be 
 " one of (consonant + vowel) or (consonant + vowel + consonant), there is no

--- a/runtime/keymap/russian-jcukenwintype.vim
+++ b/runtime/keymap/russian-jcukenwintype.vim
@@ -4,7 +4,7 @@
 " Useful mainly with utf-8 but may work with other encodings
 
 " Derived from russian-jcuken.vim by Artem Chuprina <ran@ran.pp.ru>
-" Typewriter variant of standart russian layout
+" Typewriter variant of standard russian layout
 " Maintainer:   Denis Proskurin <danwerspb@gmail.com>
 " Last Changed: 2015 May 15
 

--- a/runtime/keymap/russian-typograph.vim
+++ b/runtime/keymap/russian-typograph.vim
@@ -106,7 +106,7 @@ loadkeymap
 <char-0x005d>	    <char-0x044a>	" CYRILLIC SMALL LETTER HARD SIGN
 <char-0x007d>	    <char-0x042a>	" CYRILLIC CAPITAL LETTER HARD SIGN
 
-"	    ALPHABETIC 2st ROW
+"	    ALPHABETIC 2nd ROW
 
 <char-0x0061>	    <char-0x0444>	" CYRILLIC SMALL LETTER EF
 <char-0x0041>	    <char-0x0424>	" CYRILLIC CAPITAL LETTER EF
@@ -131,7 +131,7 @@ loadkeymap
 <char-0x0027>	    <char-0x044d>	" CYRILLIC SMALL LETTER E
 <char-0x0022>	    <char-0x042d>	" CYRILLIC CAPITAL LETTER E
 
-"	    ALPHABETIC 3st ROW
+"	    ALPHABETIC 3rd ROW
 
 <char-0x007a>	    <char-0x044f>	" CYRILLIC SMALL LETTER YA
 <char-0x005a>	    <char-0x042f>	" CYRILLIC CAPITAL LETTER YA

--- a/runtime/plugin/tohtml.vim
+++ b/runtime/plugin/tohtml.vim
@@ -62,7 +62,7 @@ let g:loaded_2html_plugin = 'vim8.1_v2'
 "   7.3_v14 (Vim 7.3.1246): Allow suppressing line number anchors using
 "			    g:html_line_ids=0. Allow customizing
 "			    important IDs (like line IDs and fold IDs) using
-"			    g:html_id_expr evalutated when the buffer conversion
+"			    g:html_id_expr evaluated when the buffer conversion
 "			    is started.
 "   7.3_v13 (Vim 7.3.1088): Keep foldmethod at manual in the generated file and
 "			    insert modeline to set it to manual.

--- a/runtime/syntax/2html.vim
+++ b/runtime/syntax/2html.vim
@@ -499,7 +499,7 @@ if s:settings.prevent_copy =~# 'n'
     endif
   elseif s:settings.line_ids
     " if lines are not being numbered the only reason this function gets called
-    " is to put the line IDs on each line; "text" will be emtpy but lnr will
+    " is to put the line IDs on each line; "text" will be empty but lnr will
     " always be non-zero, however we don't want to use the <input> because that
     " won't work as nice for empty text
     function! s:HtmlFormat_n(text, style_id, diff_style_id, lnr)
@@ -1034,7 +1034,7 @@ if !s:settings.no_progress
   " ProgressBar Indicator
   let s:progressbar={}
 
-  " Progessbar specific functions
+  " Progressbar specific functions
 
   func! s:SetProgbarColor()
     if hlID("TOhtmlProgress") != 0

--- a/runtime/syntax/abel.vim
+++ b/runtime/syntax/abel.vim
@@ -59,7 +59,7 @@ syn region abelSpecifier start='istype' end=';' contains=abelTypeIdChar,abelType
 syn match  abelTypeIdChar "[,']" contained
 syn match  abelTypeIdEnd  ";" contained
 
-" string contstants and special characters within them
+" string constants and special characters within them
 syn match  abelSpecial contained "\\['\\]"
 syn region abelString start=+'+ skip=+\\"+ end=+'+ contains=abelSpecial
 

--- a/runtime/syntax/ada.vim
+++ b/runtime/syntax/ada.vim
@@ -159,7 +159,7 @@ endif
 
 " Section: end {{{1
 " Unless special ("end loop", "end if", etc.), "end" marks the end of a
-" begin, package, task etc. Assiging it to adaEnd.
+" begin, package, task etc. Assigning it to adaEnd.
 syntax match    adaEnd	/\<end\>/
 
 syntax keyword  adaPreproc		 pragma

--- a/runtime/syntax/ahdl.vim
+++ b/runtime/syntax/ahdl.vim
@@ -38,7 +38,7 @@ syn keyword ahdlMegafunction lpm_rom lpm_dff lpm_tff clklock pll ntsc
 
 syn keyword ahdlTodo contained TODO
 
-" String contstants
+" String constants
 syn region ahdlString start=+"+  skip=+\\"+  end=+"+
 
 " valid integer number formats (decimal, binary, octal, hex)

--- a/runtime/syntax/aspvbs.vim
+++ b/runtime/syntax/aspvbs.vim
@@ -108,7 +108,7 @@ syn match AspVBSMethods contained "Response\.\w*"
 " Colorize boolean constants:
 syn keyword AspVBSMethods contained true false
 
-" AspVBScript Number Contstants
+" AspVBScript Number Constants
 " Integer number, or floating point number without a dot.
 syn match  AspVBSNumber	contained	"\<\d\+\>"
 " Floating point number, with dot
@@ -116,7 +116,7 @@ syn match  AspVBSNumber	contained	"\<\d\+\.\d*\>"
 " Floating point number, starting with a dot
 syn match  AspVBSNumber	contained	"\.\d\+\>"
 
-" String and Character Contstants
+" String and Character Constants
 " removed (skip=+\\\\\|\\"+) because VB doesn't have backslash escaping in
 " strings (or does it?)
 syn region  AspVBSString	contained	  start=+"+  end=+"+ keepend
@@ -143,7 +143,7 @@ syn cluster AspVBScriptTop contains=AspVBSStatement,AspVBSFunction,AspVBSMethods
 syn region AspVBSFold start="^\s*\(class\)\s\+.*$" end="^\s*end\s\+\(class\)\>.*$" fold contained transparent keepend
 syn region AspVBSFold start="^\s*\(private\|public\)\=\(\s\+default\)\=\s\+\(sub\|function\)\s\+.*$" end="^\s*end\s\+\(function\|sub\)\>.*$" fold contained transparent keepend
 
-" Define AspVBScript delimeters
+" Define AspVBScript delimiters
 " <%= func("string_with_%>_in_it") %> This is illegal in ASP syntax.
 syn region  AspVBScriptInsideHtmlTags keepend matchgroup=Delimiter start=+<%=\=+ end=+%>+ contains=@AspVBScriptTop, AspVBSFold
 syn region  AspVBScriptInsideHtmlTags keepend matchgroup=Delimiter start=+<script\s\+language="\=vbscript"\=[^>]*\s\+runatserver[^>]*>+ end=+</script>+ contains=@AspVBScriptTop

--- a/runtime/syntax/cfg.vim
+++ b/runtime/syntax/cfg.vim
@@ -32,7 +32,7 @@ syn match  CfgComment	"#.*"
 syn match  CfgComment	";.*"
 syn match  CfgComment	"\/\/.*"
 
-" Define the default hightlighting.
+" Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 hi def link CfgOnOff     Label
 hi def link CfgComment	Comment

--- a/runtime/syntax/csc.vim
+++ b/runtime/syntax/csc.vim
@@ -141,7 +141,7 @@ sy	keyword	cscBPMacro	contained EndLoop AllMembers SelectedMembers If Else EndIf
 sy	match	cscBPMacro	contained	"!"
 sy	match	cscBPW	"!\s*\a*"	contains=cscBPmacro
 
-" when wanted, highlighting lhs members or erros in asignments (may lag the editing)
+" when wanted, highlighting lhs members or errors in assignments (may lag the editing)
 if exists("csc_asignment")
 	sy	match	cscEqError	'\("[^"]*"\s*\|[^][\t !%()*+,--/:;<=>{}~]\+\s*\|->\s*\)*=\([^=]\@=\|$\)'
 	sy	region	cscFormula	transparent matchgroup=cscVarName start='\("[^"]*"\|[^][\t !%()*+,--/:;<=>{}~]\+\)\s*=\([^=]\@=\|\n\)' skip='"[^"]*"' end=';' contains=ALLBUT,cscFormula,cscFormulaIn,cscBPMacro,cscCondition

--- a/runtime/syntax/cupl.vim
+++ b/runtime/syntax/cupl.vim
@@ -23,7 +23,7 @@ syn keyword cuplTodo contained TODO XXX FIXME
 " cuplHeaderContents uses default highlighting except for numbers
 syn match cuplHeaderContents ".\+;"me=e-1 contains=cuplNumber contained
 
-" String contstants
+" String constants
 syn region cuplString start=+'+ end=+'+
 syn region cuplString start=+"+ end=+"+
 

--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language:	MSDOS batch file (with NT command extensions)
+" Language:	MS-DOS batch file (with NT command extensions)
 " Maintainer:	Mike Williams <mrw@eandem.co.uk>
 " Filenames:    *.bat
 " Last Change:	6th September 2009

--- a/runtime/syntax/doxygen.vim
+++ b/runtime/syntax/doxygen.vim
@@ -1,4 +1,4 @@
-" DoxyGen syntax hilighting extension for c/c++/idl/java
+" DoxyGen syntax highlighting extension for c/c++/idl/java
 " Language:     doxygen on top of c, cpp, idl, java, php
 " Maintainer:   Michael Geddes <vimmer@frog.wheelycreek.net>
 " Author:       Michael Geddes
@@ -54,7 +54,7 @@ let s:cpo_save = &cpo
 try
   set cpo&vim
 
-  " Start of Doxygen syntax hilighting:
+  " Start of Doxygen syntax highlighting:
   "
 
   " C/C++ Style line comments
@@ -256,7 +256,7 @@ endif
   syn match doxygenLinkRest +[^*@\\]\|\*/\@!\|[@\\]\(endlink\>\)\@!+ contained skipnl nextgroup=doxygenLinkRest,doxygenContinueLinkComment
   syn match doxygenContinueLinkComment contained +^\s*\*\=[^/]+me=e-1 nextgroup=doxygenLinkRest
   syn match doxygenLinkError "\*/" contained
-  " #Link hilighting.
+  " #Link highlighting.
   syn match doxygenHashLink /\(\h\w*\)\?#\(\.\w\@=\|\w\+\|::\|()\)\+/ contained contains=doxygenHashSpecial
   syn match doxygenHashSpecial /#/ contained
   syn match doxygenHyperLink /\(\s\|^\s*\*\?\)\@<=\(http\|https\|ftp\):\/\/[-0-9a-zA-Z_?&=+#%/.!':;@~]\+/ contained
@@ -306,7 +306,7 @@ endif
   syn region doxygenFormula contained matchgroup=doxygenFormulaEnds start=+f\[+ end=+[@\\]f]+ contains=doxygenFormulaSpecial,doxygenFormulaOperator,doxygenAtom
   syn region doxygenAtom contained transparent matchgroup=doxygenFormulaOperator start=+{+ end=+}+ contains=doxygenAtom,doxygenFormulaSpecial,doxygenFormulaOperator
 
-  " Add TODO hilighting.
+  " Add TODO highlighting.
   syn keyword doxygenTODO contained TODO README XXX FIXME
 
   " Supported HTML subset.  Not perfect, but okay.

--- a/runtime/syntax/focexec.vim
+++ b/runtime/syntax/focexec.vim
@@ -8,7 +8,7 @@
 " this is a very simple syntax file - I will be improving it
 " one thing is how to do computes
 " I don't like that &vars and FUSE() functions highlight to the same color
-" I think some of these things should get different hilights -
+" I think some of these things should get different highlights -
 "  should MODIFY commands look different than TABLE?
 
 " quit when a syntax file was already loaded

--- a/runtime/syntax/forth.vim
+++ b/runtime/syntax/forth.vim
@@ -181,7 +181,7 @@ syn keyword forthMath DECIMAL HEX BASE
 syn match forthInteger '\<-\=[0-9]\+.\=\>'
 syn match forthInteger '\<&-\=[0-9]\+.\=\>'
 " recognize hex and binary numbers, the '$' and '%' notation is for gforth
-syn match forthInteger '\<\$\x*\x\+\>' " *1* --- dont't mess
+syn match forthInteger '\<\$\x*\x\+\>' " *1* --- don't mess
 syn match forthInteger '\<\x*\d\x*\>'  " *2* --- this order!
 syn match forthInteger '\<%[0-1]*[0-1]\+\>'
 syn match forthFloat '\<-\=\d*[.]\=\d\+[DdEe]\d\+\>'

--- a/runtime/syntax/hamster.vim
+++ b/runtime/syntax/hamster.vim
@@ -9,7 +9,7 @@
 " It allows the use of multiple news- and mailserver and combines them to one
 " mail- and newsserver for the news/mail-client. It load faster than a normal
 " newsreader because many threads can run simultaneous. It contains scorefile
-" for news and mail, a build-in script language, the GUI allows translation to
+" for news and mail, a built-in script language, the GUI allows translation to
 " other languages, it can be used in a network and that's not all features...
 "
 " quit when a syntax file was already loaded

--- a/runtime/syntax/idl.vim
+++ b/runtime/syntax/idl.vim
@@ -7,7 +7,7 @@
 
 " This is an experiment.  IDL's structure is simple enough to permit a full
 " grammar based approach to rather than using a few heuristics.  The result
-" is large and somewhat repetative but seems to work.
+" is large and somewhat repetitive but seems to work.
 
 " There are some Microsoft extensions to idl files that are here.  Some of
 " them are disabled by defining idl_no_ms_extensions.

--- a/runtime/syntax/iss.vim
+++ b/runtime/syntax/iss.vim
@@ -2,10 +2,10 @@
 " Language:             Inno Setup File (iss file) and My InnoSetup extension
 " Maintainer:           Jason Mills (jmills@cs.mun.ca)
 " Previous Maintainer:  Dominique Stéphan (dominique@mggen.com)
-" Last Change:          2019 Sep 27
+" Last Change:          2021 Aug 30
 "
 " Todo:
-"  - The paramter String: is matched as flag string (because of case ignore).
+"  - The parameter String: is matched as flag string (because of case ignore).
 "  - Pascal scripting syntax is not recognized.
 "  - Embedded double quotes confuse string matches. e.g. "asfd""asfa"
 

--- a/runtime/syntax/mma.vim
+++ b/runtime/syntax/mma.vim
@@ -12,7 +12,7 @@
 "
 "       let filetype_m="mma"
 "
-" I also recommend setting the default 'Comment' hilighting to something
+" I also recommend setting the default 'Comment' highlighting to something
 " other than the color used for 'Function', since both are plentiful in
 " most mathematica files, and they are often the same color (when using
 " background=dark).
@@ -109,7 +109,7 @@ syntax match mmaemPHAsis "\%(^\|\s\)(\@<!\*[a-zA-Z0-9]\+\%([- \t':]\+[a-zA-Z0-9]
 syntax region mmaComment start=+(\*+ end=+\*)+ skipempty contains=@mmaNotes,mmaItem,@mmaCommentStrings,mmaemPHAsis,mmaComment
 
 " Function Comments:
-"   just like a normal comment except the first sentance is Special ala Java
+"   just like a normal comment except the first sentence is Special ala Java
 "   (** *)
 "   TODO - fix this for nesting, or not...
 syntax region mmaFunctionComment start="(\*\*\+" end="\*\+)" contains=@mmaNotes,mmaItem,mmaFunctionTitle,@mmaCommentStrings,mmaemPHAsis,mmaComment

--- a/runtime/syntax/objc.vim
+++ b/runtime/syntax/objc.vim
@@ -64,7 +64,7 @@ syn keyword objcStorageClass nullable nonnull null_unspecified
 " ObjC type specifier
 syn keyword objcTypeSpecifier __kindof __covariant
 
-" ObjC Type Infomation Parameters
+" ObjC Type Information Parameters
 syn keyword objcTypeInfoParams ObjectType KeyType
 
 " shorthand

--- a/runtime/syntax/postscr.vim
+++ b/runtime/syntax/postscr.vim
@@ -6,7 +6,7 @@
 " URL:          http://www.eandem.co.uk/mrw/vim
 "
 " Options Flags:
-" postscr_level                 - language level to use for highligting (1, 2, or 3)
+" postscr_level                 - language level to use for highlighting (1, 2, or 3)
 " postscr_display               - include display PS operators
 " postscr_ghostscript           - include GS extensions
 " postscr_fonts                 - highlight standard font names (a lot for PS 3)
@@ -469,12 +469,12 @@ if postscr_level == 2 || postscr_level == 3
   syn keyword postscrConstant   contained SubsVector UnderlineThickness FamilyName FontBBox CurMID
   syn keyword postscrConstant   contained Weight
 
-" PS2 User paramters
+" PS2 User parameters
   syn keyword postscrConstant   contained MaxFontItem MinFontCompress MaxUPathItem MaxFormItem MaxPatternItem
   syn keyword postscrConstant   contained MaxScreenItem MaxOpStack MaxDictStack MaxExecStack MaxLocalVM
   syn keyword postscrConstant   contained VMReclaim VMThreshold
 
-" PS2 System paramters
+" PS2 System parameters
   syn keyword postscrConstant   contained SystemParamsPassword StartJobPassword BuildTime ByteOrder RealFormat
   syn keyword postscrConstant   contained MaxFontCache CurFontCache MaxOutlineCache CurOutlineCache
   syn keyword postscrConstant   contained MaxUPathCache CurUPathCache MaxFormCache CurFormCache
@@ -504,7 +504,7 @@ if postscr_level == 2 || postscr_level == 3
   syn keyword postscrL2Operator   accuratescreens checkscreen pagemargin pageparams setaccuratescreens setpage
   syn keyword postscrL2Operator   setpagemargin setpageparams
 
-" Misc compatability operators
+" Misc compatibility operators
   syn keyword postscrL2Operator   appletalktype buildtime byteorder checkpassword defaulttimeouts diskonline
   syn keyword postscrL2Operator   diskstatus manualfeed manualfeedtimeout margins mirrorprint pagecount
   syn keyword postscrL2Operator   pagestackorder printername processcolors sethardwareiomode setjobtimeout

--- a/runtime/syntax/sgml.vim
+++ b/runtime/syntax/sgml.vim
@@ -174,7 +174,7 @@ syn match   sgmlAbbrEndTag +/+
 " SGML specific
 " abbreviated regions
 "
-" No highlighing, highlighing is done by contained elements.
+" No highlighting, highlighting is done by contained elements.
 "
 " PROVIDES: @sgmlRegionHook
 "
@@ -192,7 +192,7 @@ syn match   sgmlAbbrRegion
 " real (non-empty) elements. We cannot do syntax folding
 " as in xml, because end tags may be optional in sgml depending
 " on the dtd.
-" No highlighing, highlighing is done by contained elements.
+" No highlighting, highlighting is done by contained elements.
 "
 " PROVIDES: @sgmlRegionHook
 "
@@ -225,7 +225,7 @@ syn region   sgmlRegion
 "
 " <tag id="lola"/>
 "
-" TODO use sgmlEmptyTag intead of sgmlTag
+" TODO use sgmlEmptyTag instead of sgmlTag
 syn match    sgmlEmptyRegion
     \ +<[^ /!?>"']\(\_[^"'<>]\|"\_[^"]*"\|'\_[^']*'\)*/>+
     \ contains=sgmlEmptyTag

--- a/runtime/syntax/spup.vim
+++ b/runtime/syntax/spup.vim
@@ -25,7 +25,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-" don't hightlight several keywords like subsections
+" don't highlight several keywords like subsections
 "let strict_subsections = 1
 
 " highlight types usually found in DECLARE section
@@ -177,7 +177,7 @@ syn cluster spupOrdinary  contains=spupNumber,spupIdentifier,spupSymbol
 syn cluster spupOrdinary  add=spupError,spupString,spupComment
 syn cluster spupTextproc  contains=spupTextprocGeneric,spupTextprocError
 
-" define syncronizing; especially OPERATION sections can become very large
+" define synchronizing; especially OPERATION sections can become very large
 syn sync clear
 syn sync minlines=100
 syn sync maxlines=500

--- a/runtime/syntax/st.vim
+++ b/runtime/syntax/st.vim
@@ -44,7 +44,7 @@ syn match  stCharacter	"$."
 
 syn case ignore
 
-" the symols prefixed by a '#'
+" the symbols prefixed by a '#'
 syn match  stSymbol	"\(#\<[a-z_][a-z0-9_]*\>\)"
 syn match  stSymbol	"\(#'[^']*'\)"
 
@@ -58,7 +58,7 @@ syn match  stFloat	"\<\d\+e[-+]\=\d\+[fl]\=\>"
 
 syn case match
 
-" a try to higlight paren mismatches
+" a try to highlight paren mismatches
 syn region stParen	transparent start='(' end=')' contains=ALLBUT,stParenError
 syn match  stParenError	")"
 syn region stBlock	transparent start='\[' end='\]' contains=ALLBUT,stBlockError

--- a/runtime/syntax/tmux.vim
+++ b/runtime/syntax/tmux.vim
@@ -8,7 +8,7 @@ if exists("b:current_syntax")
     finish
 endif
 
-" Explicitly change compatiblity options to Vim's defaults because this file
+" Explicitly change compatibility options to Vim's defaults because this file
 " uses line continuations.
 let s:original_cpo = &cpo
 set cpo&vim


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/6c391a74fe90190796ca0b0c010112948a6e75d7

omit autoload/getscript.vim

skip doc/eval.txt (needs 8.2.2468)
skip doc/various.txt (needs 8.2.3400)

(typofixes courtesy of @dundargoc)