### PR TITLE
fix(tests): don't attempt to call ui functions in free_all_mem()

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -69,9 +69,16 @@ static int pending_has_mouse = -1;
 #else
 static size_t uilog_seen = 0;
 static char uilog_last_event[1024] = { 0 };
+
+#ifndef EXITFREE
+#define entered_free_all_mem false
+#endif
+
 # define UI_LOG(funname) \
   do { \
-    if (strequal(uilog_last_event, STR(funname))) { \
+    if (entered_free_all_mem) { \
+      /* do nothing, we cannot log now */ \
+    } else if (strequal(uilog_last_event, STR(funname))) { \
       uilog_seen++; \
     } else { \
       if (uilog_seen > 0) { \
@@ -105,6 +112,10 @@ static char uilog_last_event[1024] = { 0 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui_events_call.generated.h"
+#endif
+
+#ifndef EXITFREE
+#undef entered_free_all_mem
 #endif
 
 void ui_init(void)


### PR DESCRIPTION
Assertion failure was caused in

    #0 in logmsg neovim/src/nvim/log.c:139:17
    #1 in ui_call_update_menu neovim/build/src/nvim/auto/ui_events_call.generated.h:8:3
    #2 in ex_menu neovim/src/nvim/menu.c:263:3
    #3 in do_one_cmd neovim/src/nvim/ex_docmd.c:1981:5
    #4 in do_cmdline neovim/src/nvim/ex_docmd.c:602:20
    #5 in do_cmdline_cmd neovim/src/nvim/ex_docmd.c:287:10
    #6 in free_all_mem neovim/src/nvim/memory.c:596:3
    #7 in os_exit neovim/src/nvim/main.c:574:3
    #8 in exit_event neovim/src/nvim/msgpack_rpc/channel.c:569:5

This causes a lot of noise when reading stderr output from tests.