### PR TITLE
Refactor/uncrustify

### DIFF
--- a/contrib/uncrustify.cfg
+++ b/contrib/uncrustify.cfg
@@ -1194,7 +1194,7 @@ indent_switch_case              = 0        # unsigned number
 # Spaces to indent '{' from 'case'. By default, the brace will appear under
 # the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
 # It might wise to choose the same value for the option indent_switch_case.
-indent_case_brace               = 2        # number
+indent_case_brace               = 0        # number
 
 # indent 'break' with 'case' from 'switch'.
 indent_switch_break_with_case   = false    # true/false
@@ -3279,5 +3279,5 @@ set PREPROC                      REAL_FATTR_CONST
 set PREPROC                      REAL_FATTR_NONNULL_ALL
 set PREPROC                      REAL_FATTR_PURE
 set PREPROC                      REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 61
+# option(s) with 'not default' value: 60
 #

--- a/contrib/uncrustify.cfg
+++ b/contrib/uncrustify.cfg
@@ -2987,7 +2987,7 @@ mod_move_case_break             = false    # true/false
 
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
-mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined
+mod_case_brace                  = remove   # ignore/add/remove/force/not_defined
 
 # Whether to remove a void 'return;' that appears as the last statement in a
 # function.
@@ -3279,5 +3279,5 @@ set PREPROC                      REAL_FATTR_CONST
 set PREPROC                      REAL_FATTR_NONNULL_ALL
 set PREPROC                      REAL_FATTR_PURE
 set PREPROC                      REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 60
+# option(s) with 'not default' value: 61
 #

--- a/contrib/uncrustify.cfg
+++ b/contrib/uncrustify.cfg
@@ -44,12 +44,12 @@ disable_processing_nl_cont      = false    # true/false
 # file.
 #
 # Default:  *INDENT-OFF*
-disable_processing_cmt          = " *INDENT-OFF*"      # string
+disable_processing_cmt          = "uncrustify:indent-off"              # string
 
 # Specify the marker used in comments to (re)enable processing in a file.
 #
 # Default:  *INDENT-ON*
-enable_processing_cmt           = " *INDENT-ON*"     # string
+enable_processing_cmt           = "uncrustify:indent-on"             # string
 
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
@@ -3279,5 +3279,5 @@ set PREPROC                      REAL_FATTR_CONST
 set PREPROC                      REAL_FATTR_NONNULL_ALL
 set PREPROC                      REAL_FATTR_PURE
 set PREPROC                      REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 59
+# option(s) with 'not default' value: 61
 #

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7653,14 +7653,14 @@ int hkmap(int c)
     case ';':
       c = 't'; break;
     default: {
-        static char str[] = "zqbcxlsjphmkwonu ydafe rig";
+      static char str[] = "zqbcxlsjphmkwonu ydafe rig";
 
-        if (c < 'a' || c > 'z') {
-          return c;
-        }
-        c = str[CharOrdLow(c)];
-        break;
+      if (c < 'a' || c > 'z') {
+        return c;
       }
+      c = str[CharOrdLow(c)];
+      break;
+    }
     }
 
     return (int)(CharOrdLow(c) + p_aleph);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2144,36 +2144,36 @@ int parse_command_modifiers(exarg_T *eap, char_u **errormsg, bool skip_only)
       continue;
 
     case 'f': {  // only accept ":filter {pat} cmd"
-        char_u *reg_pat;
+      char_u *reg_pat;
 
-        if (!checkforcmd(&p, "filter", 4) || *p == NUL || ends_excmd(*p)) {
-          break;
-        }
-        if (*p == '!') {
-          cmdmod.filter_force = true;
-          p = skipwhite(p + 1);
-          if (*p == NUL || ends_excmd(*p)) {
-            break;
-          }
-        }
-        if (skip_only) {
-          p = skip_vimgrep_pat(p, NULL, NULL);
-        } else {
-          // NOTE: This puts a NUL after the pattern.
-          p = skip_vimgrep_pat(p, &reg_pat, NULL);
-        }
-        if (p == NULL || *p == NUL) {
-          break;
-        }
-        if (!skip_only) {
-          cmdmod.filter_regmatch.regprog = vim_regcomp(reg_pat, RE_MAGIC);
-          if (cmdmod.filter_regmatch.regprog == NULL) {
-            break;
-          }
-        }
-        eap->cmd = p;
-        continue;
+      if (!checkforcmd(&p, "filter", 4) || *p == NUL || ends_excmd(*p)) {
+        break;
       }
+      if (*p == '!') {
+        cmdmod.filter_force = true;
+        p = skipwhite(p + 1);
+        if (*p == NUL || ends_excmd(*p)) {
+          break;
+        }
+      }
+      if (skip_only) {
+        p = skip_vimgrep_pat(p, NULL, NULL);
+      } else {
+        // NOTE: This puts a NUL after the pattern.
+        p = skip_vimgrep_pat(p, &reg_pat, NULL);
+      }
+      if (p == NULL || *p == NUL) {
+        break;
+      }
+      if (!skip_only) {
+        cmdmod.filter_regmatch.regprog = vim_regcomp(reg_pat, RE_MAGIC);
+        if (cmdmod.filter_regmatch.regprog == NULL) {
+          break;
+        }
+      }
+      eap->cmd = p;
+      continue;
+    }
 
     // ":hide" and ":hide | cmd" are not modifiers
     case 'h':
@@ -2416,19 +2416,19 @@ int parse_cmd_address(exarg_T *eap, char_u **errormsg, bool silent)
           eap->line2 = curbuf->b_ml.ml_line_count;
           break;
         case ADDR_LOADED_BUFFERS: {
-            buf_T *buf = firstbuf;
+          buf_T *buf = firstbuf;
 
-            while (buf->b_next != NULL && buf->b_ml.ml_mfp == NULL) {
-              buf = buf->b_next;
-            }
-            eap->line1 = buf->b_fnum;
-            buf = lastbuf;
-            while (buf->b_prev != NULL && buf->b_ml.ml_mfp == NULL) {
-              buf = buf->b_prev;
-            }
-            eap->line2 = buf->b_fnum;
-            break;
+          while (buf->b_next != NULL && buf->b_ml.ml_mfp == NULL) {
+            buf = buf->b_next;
           }
+          eap->line1 = buf->b_fnum;
+          buf = lastbuf;
+          while (buf->b_prev != NULL && buf->b_ml.ml_mfp == NULL) {
+            buf = buf->b_prev;
+          }
+          eap->line2 = buf->b_fnum;
+          break;
+        }
         case ADDR_BUFFERS:
           eap->line1 = firstbuf->b_fnum;
           eap->line2 = lastbuf->b_fnum;
@@ -3387,48 +3387,48 @@ const char * set_one_cmd_context(expand_T *xp, const char *buff)
 
   case CMD_global:
   case CMD_vglobal: {
-      const int delim = (uint8_t)(*arg);  // Get the delimiter.
-      if (delim) {
-        arg++;  // Skip delimiter if there is one.
-      }
+    const int delim = (uint8_t)(*arg);  // Get the delimiter.
+    if (delim) {
+      arg++;  // Skip delimiter if there is one.
+    }
 
-      while (arg[0] != NUL && (uint8_t)arg[0] != delim) {
-        if (arg[0] == '\\' && arg[1] != NUL) {
-          arg++;
-        }
+    while (arg[0] != NUL && (uint8_t)arg[0] != delim) {
+      if (arg[0] == '\\' && arg[1] != NUL) {
         arg++;
       }
-      if (arg[0] != NUL) {
-        return arg + 1;
-      }
-      break;
+      arg++;
     }
+    if (arg[0] != NUL) {
+      return arg + 1;
+    }
+    break;
+  }
   case CMD_and:
   case CMD_substitute: {
-      const int delim = (uint8_t)(*arg);
-      if (delim) {
-        // Skip "from" part.
-        arg++;
-        arg = (const char *)skip_regexp((char_u *)arg, delim, p_magic, NULL);
-      }
-      // Skip "to" part.
-      while (arg[0] != NUL && (uint8_t)arg[0] != delim) {
-        if (arg[0] == '\\' && arg[1] != NUL) {
-          arg++;
-        }
-        arg++;
-      }
-      if (arg[0] != NUL) {  // Skip delimiter.
-        arg++;
-      }
-      while (arg[0] && strchr("|\"#", arg[0]) == NULL) {
-        arg++;
-      }
-      if (arg[0] != NUL) {
-        return arg;
-      }
-      break;
+    const int delim = (uint8_t)(*arg);
+    if (delim) {
+      // Skip "from" part.
+      arg++;
+      arg = (const char *)skip_regexp((char_u *)arg, delim, p_magic, NULL);
     }
+    // Skip "to" part.
+    while (arg[0] != NUL && (uint8_t)arg[0] != delim) {
+      if (arg[0] == '\\' && arg[1] != NUL) {
+        arg++;
+      }
+      arg++;
+    }
+    if (arg[0] != NUL) {  // Skip delimiter.
+      arg++;
+    }
+    while (arg[0] && strchr("|\"#", arg[0]) == NULL) {
+      arg++;
+    }
+    if (arg[0] != NUL) {
+      return arg;
+    }
+    break;
+  }
   case CMD_isearch:
   case CMD_dsearch:
   case CMD_ilist:
@@ -5984,114 +5984,114 @@ static size_t uc_check_code(char_u *code, size_t len, char_u *buf, ucmd_T *cmd, 
   case ct_LINE2:
   case ct_RANGE:
   case ct_COUNT: {
-      char num_buf[20];
-      long num = (type == ct_LINE1) ? eap->line1 :
-                 (type == ct_LINE2) ? eap->line2 :
-                 (type == ct_RANGE) ? eap->addr_count :
-                 (eap->addr_count > 0) ? eap->line2 : cmd->uc_def;
-      size_t num_len;
+    char num_buf[20];
+    long num = (type == ct_LINE1) ? eap->line1 :
+               (type == ct_LINE2) ? eap->line2 :
+               (type == ct_RANGE) ? eap->addr_count :
+               (eap->addr_count > 0) ? eap->line2 : cmd->uc_def;
+    size_t num_len;
 
-      sprintf(num_buf, "%" PRId64, (int64_t)num);
-      num_len = STRLEN(num_buf);
-      result = num_len;
+    sprintf(num_buf, "%" PRId64, (int64_t)num);
+    num_len = STRLEN(num_buf);
+    result = num_len;
 
-      if (quote) {
-        result += 2;
-      }
-
-      if (buf != NULL) {
-        if (quote) {
-          *buf++ = '"';
-        }
-        STRCPY(buf, num_buf);
-        buf += num_len;
-        if (quote) {
-          *buf = '"';
-        }
-      }
-
-      break;
+    if (quote) {
+      result += 2;
     }
 
-  case ct_MODS: {
-      result = quote ? 2 : 0;
-      if (buf != NULL) {
-        if (quote) {
-          *buf++ = '"';
-        }
-        *buf = '\0';
+    if (buf != NULL) {
+      if (quote) {
+        *buf++ = '"';
       }
-
-      bool multi_mods = false;
-
-      // :aboveleft and :leftabove
-      if (cmdmod.split & WSP_ABOVE) {
-        result += add_cmd_modifier(buf, "aboveleft", &multi_mods);
-      }
-      // :belowright and :rightbelow
-      if (cmdmod.split & WSP_BELOW) {
-        result += add_cmd_modifier(buf, "belowright", &multi_mods);
-      }
-      // :botright
-      if (cmdmod.split & WSP_BOT) {
-        result += add_cmd_modifier(buf, "botright", &multi_mods);
-      }
-
-      typedef struct {
-        bool *set;
-        char *name;
-      } mod_entry_T;
-      static mod_entry_T mod_entries[] = {
-        { &cmdmod.browse, "browse" },
-        { &cmdmod.confirm, "confirm" },
-        { &cmdmod.hide, "hide" },
-        { &cmdmod.keepalt, "keepalt" },
-        { &cmdmod.keepjumps, "keepjumps" },
-        { &cmdmod.keepmarks, "keepmarks" },
-        { &cmdmod.keeppatterns, "keeppatterns" },
-        { &cmdmod.lockmarks, "lockmarks" },
-        { &cmdmod.noswapfile, "noswapfile" }
-      };
-      // the modifiers that are simple flags
-      for (size_t i = 0; i < ARRAY_SIZE(mod_entries); i++) {
-        if (*mod_entries[i].set) {
-          result += add_cmd_modifier(buf, mod_entries[i].name, &multi_mods);
-        }
-      }
-
-      // TODO(vim): How to support :noautocmd?
-      // TODO(vim): How to support :sandbox?
-
-      // :silent
-      if (msg_silent > 0) {
-        result += add_cmd_modifier(buf, emsg_silent > 0 ? "silent!" : "silent",
-                                   &multi_mods);
-      }
-      // :tab
-      if (cmdmod.tab > 0) {
-        result += add_cmd_modifier(buf, "tab", &multi_mods);
-      }
-      // :topleft
-      if (cmdmod.split & WSP_TOP) {
-        result += add_cmd_modifier(buf, "topleft", &multi_mods);
-      }
-
-      // TODO(vim): How to support :unsilent?
-
-      // :verbose
-      if (p_verbose > 0) {
-        result += add_cmd_modifier(buf, "verbose", &multi_mods);
-      }
-      // :vertical
-      if (cmdmod.split & WSP_VERT) {
-        result += add_cmd_modifier(buf, "vertical", &multi_mods);
-      }
-      if (quote && buf != NULL) {
-        buf += result - 2;
+      STRCPY(buf, num_buf);
+      buf += num_len;
+      if (quote) {
         *buf = '"';
       }
-      break;
     }
+
+    break;
+  }
+
+  case ct_MODS: {
+    result = quote ? 2 : 0;
+    if (buf != NULL) {
+      if (quote) {
+        *buf++ = '"';
+      }
+      *buf = '\0';
+    }
+
+    bool multi_mods = false;
+
+    // :aboveleft and :leftabove
+    if (cmdmod.split & WSP_ABOVE) {
+      result += add_cmd_modifier(buf, "aboveleft", &multi_mods);
+    }
+    // :belowright and :rightbelow
+    if (cmdmod.split & WSP_BELOW) {
+      result += add_cmd_modifier(buf, "belowright", &multi_mods);
+    }
+    // :botright
+    if (cmdmod.split & WSP_BOT) {
+      result += add_cmd_modifier(buf, "botright", &multi_mods);
+    }
+
+    typedef struct {
+      bool *set;
+      char *name;
+    } mod_entry_T;
+    static mod_entry_T mod_entries[] = {
+      { &cmdmod.browse, "browse" },
+      { &cmdmod.confirm, "confirm" },
+      { &cmdmod.hide, "hide" },
+      { &cmdmod.keepalt, "keepalt" },
+      { &cmdmod.keepjumps, "keepjumps" },
+      { &cmdmod.keepmarks, "keepmarks" },
+      { &cmdmod.keeppatterns, "keeppatterns" },
+      { &cmdmod.lockmarks, "lockmarks" },
+      { &cmdmod.noswapfile, "noswapfile" }
+    };
+    // the modifiers that are simple flags
+    for (size_t i = 0; i < ARRAY_SIZE(mod_entries); i++) {
+      if (*mod_entries[i].set) {
+        result += add_cmd_modifier(buf, mod_entries[i].name, &multi_mods);
+      }
+    }
+
+    // TODO(vim): How to support :noautocmd?
+    // TODO(vim): How to support :sandbox?
+
+    // :silent
+    if (msg_silent > 0) {
+      result += add_cmd_modifier(buf, emsg_silent > 0 ? "silent!" : "silent",
+                                 &multi_mods);
+    }
+    // :tab
+    if (cmdmod.tab > 0) {
+      result += add_cmd_modifier(buf, "tab", &multi_mods);
+    }
+    // :topleft
+    if (cmdmod.split & WSP_TOP) {
+      result += add_cmd_modifier(buf, "topleft", &multi_mods);
+    }
+
+    // TODO(vim): How to support :unsilent?
+
+    // :verbose
+    if (p_verbose > 0) {
+      result += add_cmd_modifier(buf, "verbose", &multi_mods);
+    }
+    // :vertical
+    if (cmdmod.split & WSP_VERT) {
+      result += add_cmd_modifier(buf, "vertical", &multi_mods);
+    }
+    if (quote && buf != NULL) {
+      buf += result - 2;
+      *buf = '"';
+    }
+    break;
+  }
 
   case ct_REGISTER:
     result = eap->regname ? 1 : 0;

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -724,30 +724,30 @@ static void log_server_msg(uint64_t channel_id, msgpack_sbuffer *packed)
     msgpack_unpack_next(&unpacked, packed->data, packed->size, NULL);
   switch (result) {
   case MSGPACK_UNPACK_SUCCESS: {
-      uint64_t type = unpacked.data.via.array.ptr[0].via.u64;
-      log_lock();
-      FILE *f = open_log_file();
-      fprintf(f, type ? (type == 1 ? RES : NOT) : REQ);
-      log_msg_close(f, unpacked.data);
-      msgpack_unpacked_destroy(&unpacked);
-      break;
-    }
+    uint64_t type = unpacked.data.via.array.ptr[0].via.u64;
+    log_lock();
+    FILE *f = open_log_file();
+    fprintf(f, type ? (type == 1 ? RES : NOT) : REQ);
+    log_msg_close(f, unpacked.data);
+    msgpack_unpacked_destroy(&unpacked);
+    break;
+  }
   case MSGPACK_UNPACK_EXTRA_BYTES:
   case MSGPACK_UNPACK_CONTINUE:
   case MSGPACK_UNPACK_PARSE_ERROR:
   case MSGPACK_UNPACK_NOMEM_ERROR: {
-      log_lock();
-      FILE *f = open_log_file();
-      fprintf(f, ERR);
-      log_msg_close(f, (msgpack_object) {
+    log_lock();
+    FILE *f = open_log_file();
+    fprintf(f, ERR);
+    log_msg_close(f, (msgpack_object) {
         .type = MSGPACK_OBJECT_STR,
         .via.str = {
           .ptr = (char *)msgpack_error_messages[result + MUR_OFF],
           .size = (uint32_t)strlen(msgpack_error_messages[result + MUR_OFF]),
         },
       });
-      break;
-    }
+    break;
+  }
   }
 }
 

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -1,37 +1,36 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
+#include <inttypes.h>
+#include <msgpack.h>
 #include <stdbool.h>
 #include <string.h>
-#include <inttypes.h>
-
 #include <uv.h>
-#include <msgpack.h>
 
 #include "nvim/api/private/helpers.h"
-#include "nvim/api/vim.h"
 #include "nvim/api/ui.h"
-#include "nvim/channel.h"
-#include "nvim/msgpack_rpc/channel.h"
-#include "nvim/event/loop.h"
-#include "nvim/event/libuv_process.h"
-#include "nvim/event/rstream.h"
-#include "nvim/event/wstream.h"
-#include "nvim/event/socket.h"
-#include "nvim/msgpack_rpc/helpers.h"
-#include "nvim/vim.h"
-#include "nvim/main.h"
+#include "nvim/api/vim.h"
 #include "nvim/ascii.h"
-#include "nvim/memory.h"
+#include "nvim/channel.h"
 #include "nvim/eval.h"
-#include "nvim/os_unix.h"
-#include "nvim/message.h"
-#include "nvim/map.h"
-#include "nvim/log.h"
-#include "nvim/misc1.h"
+#include "nvim/event/libuv_process.h"
+#include "nvim/event/loop.h"
+#include "nvim/event/rstream.h"
+#include "nvim/event/socket.h"
+#include "nvim/event/wstream.h"
 #include "nvim/lib/kvec.h"
+#include "nvim/log.h"
+#include "nvim/main.h"
+#include "nvim/map.h"
+#include "nvim/memory.h"
+#include "nvim/message.h"
+#include "nvim/misc1.h"
+#include "nvim/msgpack_rpc/channel.h"
+#include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/os/input.h"
+#include "nvim/os_unix.h"
 #include "nvim/ui.h"
+#include "nvim/vim.h"
 
 #if MIN_LOG_LEVEL > DEBUG_LOG_LEVEL
 #define log_client_msg(...)
@@ -102,7 +101,7 @@ bool rpc_send_event(uint64_t id, const char *name, Array args)
 
   if (channel) {
     send_event(channel, name, args);
-  }  else {
+  } else {
     broadcast_event(name, args);
   }
 
@@ -116,10 +115,7 @@ bool rpc_send_event(uint64_t id, const char *name, Array args)
 /// @param args Array with method arguments
 /// @param[out] error True if the return value is an error
 /// @return Whatever the remote method returned
-Object rpc_send_call(uint64_t id,
-                     const char *method_name,
-                     Array args,
-                     Error *err)
+Object rpc_send_call(uint64_t id, const char *method_name, Array args, Error *err)
 {
   Channel *channel = NULL;
 
@@ -206,8 +202,7 @@ void rpc_unsubscribe(uint64_t id, char *event)
   unsubscribe(channel, event);
 }
 
-static void receive_msgpack(Stream *stream, RBuffer *rbuf, size_t c,
-                            void *data, bool eof)
+static void receive_msgpack(Stream *stream, RBuffer *rbuf, size_t c, void *data, bool eof)
 {
   Channel *channel = data;
   channel_incref(channel);
@@ -463,10 +458,7 @@ static void send_error(Channel *chan, MessageType type, uint32_t id, char *err)
   api_clear_error(&e);
 }
 
-static void send_request(Channel *channel,
-                         uint32_t id,
-                         const char *name,
-                         Array args)
+static void send_request(Channel *channel, uint32_t id, const char *name, Array args)
 {
   const String method = cstr_as_string((char *)name);
   channel_write(channel, serialize_request(channel->id,
@@ -477,9 +469,7 @@ static void send_request(Channel *channel,
                                            1));
 }
 
-static void send_event(Channel *channel,
-                       const char *name,
-                       Array args)
+static void send_event(Channel *channel, const char *name, Array args)
 {
   const String method = cstr_as_string((char *)name);
   channel_write(channel, serialize_request(channel->id,
@@ -528,9 +518,9 @@ static void unsubscribe(Channel *channel, char *event)
 {
   char *event_string = pmap_get(cstr_t)(&event_strings, event);
   if (!event_string) {
-      WLOG("RPC: ch %" PRIu64 ": tried to unsubscribe unknown event '%s'",
-           channel->id, event);
-      return;
+    WLOG("RPC: ch %" PRIu64 ": tried to unsubscribe unknown event '%s'",
+         channel->id, event);
+    return;
   }
   pmap_del(cstr_t)(channel->rpc.subscribed_events, event_string);
 
@@ -589,10 +579,10 @@ void rpc_free(Channel *channel)
 static bool is_rpc_response(msgpack_object *obj)
 {
   return obj->type == MSGPACK_OBJECT_ARRAY
-      && obj->via.array.size == 4
-      && obj->via.array.ptr[0].type == MSGPACK_OBJECT_POSITIVE_INTEGER
-      && obj->via.array.ptr[0].via.u64 == 1
-      && obj->via.array.ptr[1].type == MSGPACK_OBJECT_POSITIVE_INTEGER;
+         && obj->via.array.size == 4
+         && obj->via.array.ptr[0].type == MSGPACK_OBJECT_POSITIVE_INTEGER
+         && obj->via.array.ptr[0].via.u64 == 1
+         && obj->via.array.ptr[1].type == MSGPACK_OBJECT_POSITIVE_INTEGER;
 }
 
 static bool is_valid_rpc_response(msgpack_object *obj, Channel *channel)
@@ -634,12 +624,8 @@ static void call_set_error(Channel *channel, char *msg, int loglevel)
   channel_close(channel->id, kChannelPartRpc, NULL);
 }
 
-static WBuffer *serialize_request(uint64_t channel_id,
-                                  uint32_t request_id,
-                                  const String method,
-                                  Array args,
-                                  msgpack_sbuffer *sbuffer,
-                                  size_t refcount)
+static WBuffer *serialize_request(uint64_t channel_id, uint32_t request_id, const String method,
+                                  Array args, msgpack_sbuffer *sbuffer, size_t refcount)
 {
   msgpack_packer pac;
   msgpack_packer_init(&pac, sbuffer, msgpack_sbuffer_write);
@@ -654,12 +640,8 @@ static WBuffer *serialize_request(uint64_t channel_id,
   return rv;
 }
 
-static WBuffer *serialize_response(uint64_t channel_id,
-                                   MessageType type,
-                                   uint32_t response_id,
-                                   Error *err,
-                                   Object arg,
-                                   msgpack_sbuffer *sbuffer)
+static WBuffer *serialize_response(uint64_t channel_id, MessageType type, uint32_t response_id,
+                                   Error *err, Object arg, msgpack_sbuffer *sbuffer)
 {
   msgpack_packer pac;
   msgpack_packer_init(&pac, sbuffer, msgpack_sbuffer_write);
@@ -733,16 +715,15 @@ static const char *const msgpack_error_messages[] = {
   [MSGPACK_UNPACK_NOMEM_ERROR + MUR_OFF] = "not enough memory",
 };
 
-static void log_server_msg(uint64_t channel_id,
-                           msgpack_sbuffer *packed)
+static void log_server_msg(uint64_t channel_id, msgpack_sbuffer *packed)
 {
   msgpack_unpacked unpacked;
   msgpack_unpacked_init(&unpacked);
   DLOGN("RPC ->ch %" PRIu64 ": ", channel_id);
   const msgpack_unpack_return result =
-      msgpack_unpack_next(&unpacked, packed->data, packed->size, NULL);
+    msgpack_unpack_next(&unpacked, packed->data, packed->size, NULL);
   switch (result) {
-    case MSGPACK_UNPACK_SUCCESS: {
+  case MSGPACK_UNPACK_SUCCESS: {
       uint64_t type = unpacked.data.via.array.ptr[0].via.u64;
       log_lock();
       FILE *f = open_log_file();
@@ -751,29 +732,26 @@ static void log_server_msg(uint64_t channel_id,
       msgpack_unpacked_destroy(&unpacked);
       break;
     }
-    case MSGPACK_UNPACK_EXTRA_BYTES:
-    case MSGPACK_UNPACK_CONTINUE:
-    case MSGPACK_UNPACK_PARSE_ERROR:
-    case MSGPACK_UNPACK_NOMEM_ERROR: {
+  case MSGPACK_UNPACK_EXTRA_BYTES:
+  case MSGPACK_UNPACK_CONTINUE:
+  case MSGPACK_UNPACK_PARSE_ERROR:
+  case MSGPACK_UNPACK_NOMEM_ERROR: {
       log_lock();
       FILE *f = open_log_file();
       fprintf(f, ERR);
       log_msg_close(f, (msgpack_object) {
-          .type = MSGPACK_OBJECT_STR,
-          .via.str = {
-              .ptr = (char *)msgpack_error_messages[result + MUR_OFF],
-              .size = (uint32_t)strlen(
-                  msgpack_error_messages[result + MUR_OFF]),
-          },
+        .type = MSGPACK_OBJECT_STR,
+        .via.str = {
+          .ptr = (char *)msgpack_error_messages[result + MUR_OFF],
+          .size = (uint32_t)strlen(msgpack_error_messages[result + MUR_OFF]),
+        },
       });
       break;
     }
   }
 }
 
-static void log_client_msg(uint64_t channel_id,
-                           bool is_request,
-                           msgpack_object msg)
+static void log_client_msg(uint64_t channel_id, bool is_request, msgpack_object msg)
 {
   DLOGN("RPC <-ch %" PRIu64 ": ", channel_id);
   log_lock();

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -1,19 +1,18 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
-#include <stdbool.h>
 #include <inttypes.h>
-
 #include <msgpack.h>
+#include <stdbool.h>
 
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
-#include "nvim/msgpack_rpc/helpers.h"
+#include "nvim/assert.h"
 #include "nvim/lib/kvec.h"
-#include "nvim/vim.h"
 #include "nvim/log.h"
 #include "nvim/memory.h"
-#include "nvim/assert.h"
+#include "nvim/msgpack_rpc/helpers.h"
+#include "nvim/vim.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "msgpack_rpc/helpers.c.generated.h"
@@ -48,17 +47,17 @@ static msgpack_sbuffer sbuffer;
   } \
   \
   static void msgpack_rpc_from_##lt(Integer o, msgpack_packer *res) \
-    /* *INDENT-OFF* */ \
+  /* *INDENT-OFF* */ \
     FUNC_ATTR_NONNULL_ARG(2) \
-    /* *INDENT-ON* */ \
+/* *INDENT-ON* */ \
   { \
-    msgpack_packer pac; \
-    msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write); \
-    msgpack_pack_int64(&pac, (handle_T)o); \
-    msgpack_pack_ext(res, sbuffer.size, \
-                     kObjectType##t - EXT_OBJECT_TYPE_SHIFT); \
-    msgpack_pack_ext_body(res, sbuffer.data, sbuffer.size); \
-    msgpack_sbuffer_clear(&sbuffer); \
+  msgpack_packer pac; \
+  msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write); \
+  msgpack_pack_int64(&pac, (handle_T)o); \
+  msgpack_pack_ext(res, sbuffer.size, \
+                   kObjectType##t - EXT_OBJECT_TYPE_SHIFT); \
+  msgpack_pack_ext_body(res, sbuffer.data, sbuffer.size); \
+  msgpack_sbuffer_clear(&sbuffer); \
   }
 
 void msgpack_rpc_helpers_init(void)
@@ -91,31 +90,31 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
   kvec_withinit_t(MPToAPIObjectStackItem, 2) stack = KV_INITIAL_VALUE;
   kvi_init(stack);
   kvi_push(stack, ((MPToAPIObjectStackItem) {
-    .mobj = obj,
-    .aobj = arg,
-    .container = false,
-    .idx = 0,
-  }));
+      .mobj = obj,
+      .aobj = arg,
+      .container = false,
+      .idx = 0,
+    }));
   while (ret && kv_size(stack)) {
     MPToAPIObjectStackItem cur = kv_last(stack);
     if (!cur.container) {
       *cur.aobj = NIL;
     }
     switch (cur.mobj->type) {
-      case MSGPACK_OBJECT_NIL: {
+    case MSGPACK_OBJECT_NIL: {
         break;
       }
-      case MSGPACK_OBJECT_BOOLEAN: {
+    case MSGPACK_OBJECT_BOOLEAN: {
         *cur.aobj = BOOLEAN_OBJ(cur.mobj->via.boolean);
         break;
       }
-      case MSGPACK_OBJECT_NEGATIVE_INTEGER: {
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER: {
         STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.i64),
                       "Msgpack integer size does not match API integer");
         *cur.aobj = INTEGER_OBJ(cur.mobj->via.i64);
         break;
       }
-      case MSGPACK_OBJECT_POSITIVE_INTEGER: {
+    case MSGPACK_OBJECT_POSITIVE_INTEGER: {
         STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.u64),
                       "Msgpack integer size does not match API integer");
         if (cur.mobj->via.u64 > API_INTEGER_MAX) {
@@ -126,10 +125,10 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
         break;
       }
 #ifdef NVIM_MSGPACK_HAS_FLOAT32
-      case MSGPACK_OBJECT_FLOAT32:
-      case MSGPACK_OBJECT_FLOAT64:
+    case MSGPACK_OBJECT_FLOAT32:
+    case MSGPACK_OBJECT_FLOAT64:
 #else
-      case MSGPACK_OBJECT_FLOAT:
+    case MSGPACK_OBJECT_FLOAT:
 #endif
       {
         STATIC_ASSERT(sizeof(Float) == sizeof(cur.mobj->via.f64),
@@ -138,18 +137,18 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
         break;
       }
 #define STR_CASE(type, attr, obj, dest, conv) \
-      case type: { \
-        dest = conv(((String) { \
-          .size = obj->via.attr.size, \
-          .data = (obj->via.attr.ptr == NULL || obj->via.attr.size == 0 \
+case type: { \
+    dest = conv(((String) { \
+      .size = obj->via.attr.size, \
+      .data = (obj->via.attr.ptr == NULL || obj->via.attr.size == 0 \
                    ? xmemdupz("", 0) \
                    : xmemdupz(obj->via.attr.ptr, obj->via.attr.size)), \
-        })); \
-        break; \
-      }
+    })); \
+    break; \
+  }
       STR_CASE(MSGPACK_OBJECT_STR, str, cur.mobj, *cur.aobj, STRING_OBJ)
       STR_CASE(MSGPACK_OBJECT_BIN, bin, cur.mobj, *cur.aobj, STRING_OBJ)
-      case MSGPACK_OBJECT_ARRAY: {
+    case MSGPACK_OBJECT_ARRAY: {
         const size_t size = cur.mobj->via.array.size;
         if (cur.container) {
           if (cur.idx >= size) {
@@ -159,25 +158,25 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
             cur.idx++;
             kv_last(stack) = cur;
             kvi_push(stack, ((MPToAPIObjectStackItem) {
-              .mobj = &cur.mobj->via.array.ptr[idx],
-              .aobj = &cur.aobj->data.array.items[idx],
-              .container = false,
-            }));
+                .mobj = &cur.mobj->via.array.ptr[idx],
+                .aobj = &cur.aobj->data.array.items[idx],
+                .container = false,
+              }));
           }
         } else {
           *cur.aobj = ARRAY_OBJ(((Array) {
-            .size = size,
-            .capacity = size,
-            .items = (size > 0
+              .size = size,
+              .capacity = size,
+              .items = (size > 0
                       ? xcalloc(size, sizeof(*cur.aobj->data.array.items))
                       : NULL),
-          }));
+            }));
           cur.container = true;
           kv_last(stack) = cur;
         }
         break;
       }
-      case MSGPACK_OBJECT_MAP: {
+    case MSGPACK_OBJECT_MAP: {
         const size_t size = cur.mobj->via.map.size;
         if (cur.container) {
           if (cur.idx >= size) {
@@ -194,69 +193,69 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
               STR_CASE(MSGPACK_OBJECT_BIN, bin, key,
                        cur.aobj->data.dictionary.items[idx].key, ID)
 #undef ID
-              case MSGPACK_OBJECT_NIL:
-              case MSGPACK_OBJECT_BOOLEAN:
-              case MSGPACK_OBJECT_POSITIVE_INTEGER:
-              case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+            case MSGPACK_OBJECT_NIL:
+            case MSGPACK_OBJECT_BOOLEAN:
+            case MSGPACK_OBJECT_POSITIVE_INTEGER:
+            case MSGPACK_OBJECT_NEGATIVE_INTEGER:
 #ifdef NVIM_MSGPACK_HAS_FLOAT32
-              case MSGPACK_OBJECT_FLOAT32:
-              case MSGPACK_OBJECT_FLOAT64:
+            case MSGPACK_OBJECT_FLOAT32:
+            case MSGPACK_OBJECT_FLOAT64:
 #else
-              case MSGPACK_OBJECT_FLOAT:
+            case MSGPACK_OBJECT_FLOAT:
 #endif
-              case MSGPACK_OBJECT_EXT:
-              case MSGPACK_OBJECT_MAP:
-              case MSGPACK_OBJECT_ARRAY: {
+            case MSGPACK_OBJECT_EXT:
+            case MSGPACK_OBJECT_MAP:
+            case MSGPACK_OBJECT_ARRAY: {
                 ret = false;
                 break;
               }
             }
             if (ret) {
               kvi_push(stack, ((MPToAPIObjectStackItem) {
-                .mobj = &cur.mobj->via.map.ptr[idx].val,
-                .aobj = &cur.aobj->data.dictionary.items[idx].value,
-                .container = false,
-              }));
+                  .mobj = &cur.mobj->via.map.ptr[idx].val,
+                  .aobj = &cur.aobj->data.dictionary.items[idx].value,
+                  .container = false,
+                }));
             }
           }
         } else {
           *cur.aobj = DICTIONARY_OBJ(((Dictionary) {
-            .size = size,
-            .capacity = size,
-            .items = (size > 0
+              .size = size,
+              .capacity = size,
+              .items = (size > 0
                       ? xcalloc(size, sizeof(*cur.aobj->data.dictionary.items))
                       : NULL),
-          }));
+            }));
           cur.container = true;
           kv_last(stack) = cur;
         }
         break;
       }
-      case MSGPACK_OBJECT_EXT: {
+    case MSGPACK_OBJECT_EXT: {
         switch ((ObjectType)(cur.mobj->via.ext.type + EXT_OBJECT_TYPE_SHIFT)) {
-          case kObjectTypeBuffer: {
+        case kObjectTypeBuffer: {
             cur.aobj->type = kObjectTypeBuffer;
             ret = msgpack_rpc_to_buffer(cur.mobj, &cur.aobj->data.integer);
             break;
           }
-          case kObjectTypeWindow: {
+        case kObjectTypeWindow: {
             cur.aobj->type = kObjectTypeWindow;
             ret = msgpack_rpc_to_window(cur.mobj, &cur.aobj->data.integer);
             break;
           }
-          case kObjectTypeTabpage: {
+        case kObjectTypeTabpage: {
             cur.aobj->type = kObjectTypeTabpage;
             ret = msgpack_rpc_to_tabpage(cur.mobj, &cur.aobj->data.integer);
             break;
           }
-          case kObjectTypeNil:
-          case kObjectTypeBoolean:
-          case kObjectTypeInteger:
-          case kObjectTypeFloat:
-          case kObjectTypeString:
-          case kObjectTypeArray:
-          case kObjectTypeDictionary:
-          case kObjectTypeLuaRef: {
+        case kObjectTypeNil:
+        case kObjectTypeBoolean:
+        case kObjectTypeInteger:
+        case kObjectTypeFloat:
+        case kObjectTypeString:
+        case kObjectTypeArray:
+        case kObjectTypeDictionary:
+        case kObjectTypeLuaRef: {
             break;
           }
         }
@@ -272,8 +271,7 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
   return ret;
 }
 
-static bool msgpack_rpc_to_string(const msgpack_object *const obj,
-                                  String *const arg)
+static bool msgpack_rpc_to_string(const msgpack_object *const obj, String *const arg)
   FUNC_ATTR_NONNULL_ALL
 {
   if (obj->type == MSGPACK_OBJECT_BIN || obj->type == MSGPACK_OBJECT_STR) {
@@ -305,8 +303,7 @@ bool msgpack_rpc_to_array(const msgpack_object *const obj, Array *const arg)
   return true;
 }
 
-bool msgpack_rpc_to_dictionary(const msgpack_object *const obj,
-                               Dictionary *const arg)
+bool msgpack_rpc_to_dictionary(const msgpack_object *const obj, Dictionary *const arg)
   FUNC_ATTR_NONNULL_ALL
 {
   if (obj->type != MSGPACK_OBJECT_MAP) {
@@ -319,12 +316,12 @@ bool msgpack_rpc_to_dictionary(const msgpack_object *const obj,
 
   for (uint32_t i = 0; i < obj->via.map.size; i++) {
     if (!msgpack_rpc_to_string(&obj->via.map.ptr[i].key,
-          &arg->items[i].key)) {
+                               &arg->items[i].key)) {
       return false;
     }
 
     if (!msgpack_rpc_to_object(&obj->via.map.ptr[i].val,
-          &arg->items[i].value)) {
+                               &arg->items[i].value)) {
       return false;
     }
   }
@@ -387,43 +384,43 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
                   && kObjectTypeTabpage == kObjectTypeWindow + 1,
                   "Buffer, window and tabpage enum items are in order");
     switch (cur.aobj->type) {
-      case kObjectTypeNil:
-      case kObjectTypeLuaRef: {
+    case kObjectTypeNil:
+    case kObjectTypeLuaRef: {
         // TODO(bfredl): could also be an error. Though kObjectTypeLuaRef
         // should only appear when the caller has opted in to handle references,
         // see nlua_pop_Object.
         msgpack_pack_nil(res);
         break;
       }
-      case kObjectTypeBoolean: {
+    case kObjectTypeBoolean: {
         msgpack_rpc_from_boolean(cur.aobj->data.boolean, res);
         break;
       }
-      case kObjectTypeInteger: {
+    case kObjectTypeInteger: {
         msgpack_rpc_from_integer(cur.aobj->data.integer, res);
         break;
       }
-      case kObjectTypeFloat: {
+    case kObjectTypeFloat: {
         msgpack_rpc_from_float(cur.aobj->data.floating, res);
         break;
       }
-      case kObjectTypeString: {
+    case kObjectTypeString: {
         msgpack_rpc_from_string(cur.aobj->data.string, res);
         break;
       }
-      case kObjectTypeBuffer: {
+    case kObjectTypeBuffer: {
         msgpack_rpc_from_buffer(cur.aobj->data.integer, res);
         break;
       }
-      case kObjectTypeWindow: {
+    case kObjectTypeWindow: {
         msgpack_rpc_from_window(cur.aobj->data.integer, res);
         break;
       }
-      case kObjectTypeTabpage: {
+    case kObjectTypeTabpage: {
         msgpack_rpc_from_tabpage(cur.aobj->data.integer, res);
         break;
       }
-      case kObjectTypeArray: {
+    case kObjectTypeArray: {
         const size_t size = cur.aobj->data.array.size;
         if (cur.container) {
           if (cur.idx >= size) {
@@ -433,9 +430,9 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
             cur.idx++;
             kv_last(stack) = cur;
             kvi_push(stack, ((APIToMPObjectStackItem) {
-              .aobj = &cur.aobj->data.array.items[idx],
-              .container = false,
-            }));
+                .aobj = &cur.aobj->data.array.items[idx],
+                .container = false,
+              }));
           }
         } else {
           msgpack_pack_array(res, size);
@@ -444,7 +441,7 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
         }
         break;
       }
-      case kObjectTypeDictionary: {
+    case kObjectTypeDictionary: {
         const size_t size = cur.aobj->data.dictionary.size;
         if (cur.container) {
           if (cur.idx >= size) {
@@ -456,9 +453,9 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
             msgpack_rpc_from_string(cur.aobj->data.dictionary.items[idx].key,
                                     res);
             kvi_push(stack, ((APIToMPObjectStackItem) {
-              .aobj = &cur.aobj->data.dictionary.items[idx].value,
-              .container = false,
-            }));
+                .aobj = &cur.aobj->data.dictionary.items[idx].value,
+                .container = false,
+              }));
           }
         } else {
           msgpack_pack_map(res, size);
@@ -497,9 +494,7 @@ void msgpack_rpc_from_dictionary(Dictionary result, msgpack_packer *res)
 }
 
 /// Serializes a msgpack-rpc request or notification(id == 0)
-void msgpack_rpc_serialize_request(uint32_t request_id,
-                                   const String method,
-                                   Array args,
+void msgpack_rpc_serialize_request(uint32_t request_id, const String method, Array args,
                                    msgpack_packer *pac)
   FUNC_ATTR_NONNULL_ARG(4)
 {
@@ -515,9 +510,7 @@ void msgpack_rpc_serialize_request(uint32_t request_id,
 }
 
 /// Serializes a msgpack-rpc response
-void msgpack_rpc_serialize_response(uint32_t response_id,
-                                    Error *err,
-                                    Object arg,
+void msgpack_rpc_serialize_response(uint32_t response_id, Error *err, Object arg,
                                     msgpack_packer *pac)
   FUNC_ATTR_NONNULL_ARG(2, 4)
 {
@@ -548,15 +541,15 @@ static bool msgpack_rpc_is_notification(msgpack_object *req)
 msgpack_object *msgpack_rpc_method(msgpack_object *req)
 {
   msgpack_object *obj = req->via.array.ptr
-    + (msgpack_rpc_is_notification(req) ? 1 : 2);
+                        + (msgpack_rpc_is_notification(req) ? 1 : 2);
   return obj->type == MSGPACK_OBJECT_STR || obj->type == MSGPACK_OBJECT_BIN ?
-    obj : NULL;
+         obj : NULL;
 }
 
 msgpack_object *msgpack_rpc_args(msgpack_object *req)
 {
   msgpack_object *obj = req->via.array.ptr
-    + (msgpack_rpc_is_notification(req) ? 2 : 3);
+                        + (msgpack_rpc_is_notification(req) ? 2 : 3);
   return obj->type == MSGPACK_OBJECT_ARRAY ? obj : NULL;
 }
 
@@ -569,8 +562,7 @@ static msgpack_object *msgpack_rpc_msg_id(msgpack_object *req)
   return obj->type == MSGPACK_OBJECT_POSITIVE_INTEGER ? obj : NULL;
 }
 
-MessageType msgpack_rpc_validate(uint32_t *response_id, msgpack_object *req,
-                                 Error *err)
+MessageType msgpack_rpc_validate(uint32_t *response_id, msgpack_object *req, Error *err)
 {
   *response_id = 0;
   // Validate the basic structure of the msgpack-rpc payload

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -102,165 +102,165 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
     }
     switch (cur.mobj->type) {
     case MSGPACK_OBJECT_NIL: {
-        break;
-      }
+      break;
+    }
     case MSGPACK_OBJECT_BOOLEAN: {
-        *cur.aobj = BOOLEAN_OBJ(cur.mobj->via.boolean);
-        break;
-      }
+      *cur.aobj = BOOLEAN_OBJ(cur.mobj->via.boolean);
+      break;
+    }
     case MSGPACK_OBJECT_NEGATIVE_INTEGER: {
-        STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.i64),
-                      "Msgpack integer size does not match API integer");
-        *cur.aobj = INTEGER_OBJ(cur.mobj->via.i64);
-        break;
-      }
+      STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.i64),
+                    "Msgpack integer size does not match API integer");
+      *cur.aobj = INTEGER_OBJ(cur.mobj->via.i64);
+      break;
+    }
     case MSGPACK_OBJECT_POSITIVE_INTEGER: {
-        STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.u64),
-                      "Msgpack integer size does not match API integer");
-        if (cur.mobj->via.u64 > API_INTEGER_MAX) {
-          ret = false;
-        } else {
-          *cur.aobj = INTEGER_OBJ((Integer)cur.mobj->via.u64);
-        }
-        break;
+      STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.u64),
+                    "Msgpack integer size does not match API integer");
+      if (cur.mobj->via.u64 > API_INTEGER_MAX) {
+        ret = false;
+      } else {
+        *cur.aobj = INTEGER_OBJ((Integer)cur.mobj->via.u64);
       }
+      break;
+    }
 #ifdef NVIM_MSGPACK_HAS_FLOAT32
     case MSGPACK_OBJECT_FLOAT32:
     case MSGPACK_OBJECT_FLOAT64:
 #else
     case MSGPACK_OBJECT_FLOAT:
 #endif
-      {
-        STATIC_ASSERT(sizeof(Float) == sizeof(cur.mobj->via.f64),
-                      "Msgpack floating-point size does not match API integer");
-        *cur.aobj = FLOAT_OBJ(cur.mobj->via.f64);
-        break;
-      }
+    {
+      STATIC_ASSERT(sizeof(Float) == sizeof(cur.mobj->via.f64),
+                    "Msgpack floating-point size does not match API integer");
+      *cur.aobj = FLOAT_OBJ(cur.mobj->via.f64);
+      break;
+    }
 #define STR_CASE(type, attr, obj, dest, conv) \
 case type: { \
-    dest = conv(((String) { \
+  dest = conv(((String) { \
       .size = obj->via.attr.size, \
       .data = (obj->via.attr.ptr == NULL || obj->via.attr.size == 0 \
                    ? xmemdupz("", 0) \
                    : xmemdupz(obj->via.attr.ptr, obj->via.attr.size)), \
     })); \
-    break; \
-  }
+  break; \
+}
       STR_CASE(MSGPACK_OBJECT_STR, str, cur.mobj, *cur.aobj, STRING_OBJ)
       STR_CASE(MSGPACK_OBJECT_BIN, bin, cur.mobj, *cur.aobj, STRING_OBJ)
     case MSGPACK_OBJECT_ARRAY: {
-        const size_t size = cur.mobj->via.array.size;
-        if (cur.container) {
-          if (cur.idx >= size) {
-            (void)kv_pop(stack);
-          } else {
-            const size_t idx = cur.idx;
-            cur.idx++;
-            kv_last(stack) = cur;
-            kvi_push(stack, ((MPToAPIObjectStackItem) {
+      const size_t size = cur.mobj->via.array.size;
+      if (cur.container) {
+        if (cur.idx >= size) {
+          (void)kv_pop(stack);
+        } else {
+          const size_t idx = cur.idx;
+          cur.idx++;
+          kv_last(stack) = cur;
+          kvi_push(stack, ((MPToAPIObjectStackItem) {
                 .mobj = &cur.mobj->via.array.ptr[idx],
                 .aobj = &cur.aobj->data.array.items[idx],
                 .container = false,
               }));
-          }
-        } else {
-          *cur.aobj = ARRAY_OBJ(((Array) {
+        }
+      } else {
+        *cur.aobj = ARRAY_OBJ(((Array) {
               .size = size,
               .capacity = size,
               .items = (size > 0
                       ? xcalloc(size, sizeof(*cur.aobj->data.array.items))
                       : NULL),
             }));
-          cur.container = true;
-          kv_last(stack) = cur;
-        }
-        break;
+        cur.container = true;
+        kv_last(stack) = cur;
       }
+      break;
+    }
     case MSGPACK_OBJECT_MAP: {
-        const size_t size = cur.mobj->via.map.size;
-        if (cur.container) {
-          if (cur.idx >= size) {
-            (void)kv_pop(stack);
-          } else {
-            const size_t idx = cur.idx;
-            cur.idx++;
-            kv_last(stack) = cur;
-            const msgpack_object *const key = &cur.mobj->via.map.ptr[idx].key;
-            switch (key->type) {
+      const size_t size = cur.mobj->via.map.size;
+      if (cur.container) {
+        if (cur.idx >= size) {
+          (void)kv_pop(stack);
+        } else {
+          const size_t idx = cur.idx;
+          cur.idx++;
+          kv_last(stack) = cur;
+          const msgpack_object *const key = &cur.mobj->via.map.ptr[idx].key;
+          switch (key->type) {
 #define ID(x) x
-              STR_CASE(MSGPACK_OBJECT_STR, str, key,
-                       cur.aobj->data.dictionary.items[idx].key, ID)
-              STR_CASE(MSGPACK_OBJECT_BIN, bin, key,
-                       cur.aobj->data.dictionary.items[idx].key, ID)
+            STR_CASE(MSGPACK_OBJECT_STR, str, key,
+                     cur.aobj->data.dictionary.items[idx].key, ID)
+            STR_CASE(MSGPACK_OBJECT_BIN, bin, key,
+                     cur.aobj->data.dictionary.items[idx].key, ID)
 #undef ID
-            case MSGPACK_OBJECT_NIL:
-            case MSGPACK_OBJECT_BOOLEAN:
-            case MSGPACK_OBJECT_POSITIVE_INTEGER:
-            case MSGPACK_OBJECT_NEGATIVE_INTEGER:
+          case MSGPACK_OBJECT_NIL:
+          case MSGPACK_OBJECT_BOOLEAN:
+          case MSGPACK_OBJECT_POSITIVE_INTEGER:
+          case MSGPACK_OBJECT_NEGATIVE_INTEGER:
 #ifdef NVIM_MSGPACK_HAS_FLOAT32
-            case MSGPACK_OBJECT_FLOAT32:
-            case MSGPACK_OBJECT_FLOAT64:
+          case MSGPACK_OBJECT_FLOAT32:
+          case MSGPACK_OBJECT_FLOAT64:
 #else
-            case MSGPACK_OBJECT_FLOAT:
+          case MSGPACK_OBJECT_FLOAT:
 #endif
-            case MSGPACK_OBJECT_EXT:
-            case MSGPACK_OBJECT_MAP:
-            case MSGPACK_OBJECT_ARRAY: {
-                ret = false;
-                break;
-              }
-            }
-            if (ret) {
-              kvi_push(stack, ((MPToAPIObjectStackItem) {
+          case MSGPACK_OBJECT_EXT:
+          case MSGPACK_OBJECT_MAP:
+          case MSGPACK_OBJECT_ARRAY: {
+            ret = false;
+            break;
+          }
+          }
+          if (ret) {
+            kvi_push(stack, ((MPToAPIObjectStackItem) {
                   .mobj = &cur.mobj->via.map.ptr[idx].val,
                   .aobj = &cur.aobj->data.dictionary.items[idx].value,
                   .container = false,
                 }));
-            }
           }
-        } else {
-          *cur.aobj = DICTIONARY_OBJ(((Dictionary) {
+        }
+      } else {
+        *cur.aobj = DICTIONARY_OBJ(((Dictionary) {
               .size = size,
               .capacity = size,
               .items = (size > 0
                       ? xcalloc(size, sizeof(*cur.aobj->data.dictionary.items))
                       : NULL),
             }));
-          cur.container = true;
-          kv_last(stack) = cur;
-        }
-        break;
+        cur.container = true;
+        kv_last(stack) = cur;
       }
+      break;
+    }
     case MSGPACK_OBJECT_EXT: {
-        switch ((ObjectType)(cur.mobj->via.ext.type + EXT_OBJECT_TYPE_SHIFT)) {
-        case kObjectTypeBuffer: {
-            cur.aobj->type = kObjectTypeBuffer;
-            ret = msgpack_rpc_to_buffer(cur.mobj, &cur.aobj->data.integer);
-            break;
-          }
-        case kObjectTypeWindow: {
-            cur.aobj->type = kObjectTypeWindow;
-            ret = msgpack_rpc_to_window(cur.mobj, &cur.aobj->data.integer);
-            break;
-          }
-        case kObjectTypeTabpage: {
-            cur.aobj->type = kObjectTypeTabpage;
-            ret = msgpack_rpc_to_tabpage(cur.mobj, &cur.aobj->data.integer);
-            break;
-          }
-        case kObjectTypeNil:
-        case kObjectTypeBoolean:
-        case kObjectTypeInteger:
-        case kObjectTypeFloat:
-        case kObjectTypeString:
-        case kObjectTypeArray:
-        case kObjectTypeDictionary:
-        case kObjectTypeLuaRef: {
-            break;
-          }
-        }
+      switch ((ObjectType)(cur.mobj->via.ext.type + EXT_OBJECT_TYPE_SHIFT)) {
+      case kObjectTypeBuffer: {
+        cur.aobj->type = kObjectTypeBuffer;
+        ret = msgpack_rpc_to_buffer(cur.mobj, &cur.aobj->data.integer);
         break;
       }
+      case kObjectTypeWindow: {
+        cur.aobj->type = kObjectTypeWindow;
+        ret = msgpack_rpc_to_window(cur.mobj, &cur.aobj->data.integer);
+        break;
+      }
+      case kObjectTypeTabpage: {
+        cur.aobj->type = kObjectTypeTabpage;
+        ret = msgpack_rpc_to_tabpage(cur.mobj, &cur.aobj->data.integer);
+        break;
+      }
+      case kObjectTypeNil:
+      case kObjectTypeBoolean:
+      case kObjectTypeInteger:
+      case kObjectTypeFloat:
+      case kObjectTypeString:
+      case kObjectTypeArray:
+      case kObjectTypeDictionary:
+      case kObjectTypeLuaRef: {
+        break;
+      }
+      }
+      break;
+    }
 #undef STR_CASE
     }
     if (!cur.container) {
@@ -386,84 +386,84 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
     switch (cur.aobj->type) {
     case kObjectTypeNil:
     case kObjectTypeLuaRef: {
-        // TODO(bfredl): could also be an error. Though kObjectTypeLuaRef
-        // should only appear when the caller has opted in to handle references,
-        // see nlua_pop_Object.
-        msgpack_pack_nil(res);
-        break;
-      }
+      // TODO(bfredl): could also be an error. Though kObjectTypeLuaRef
+      // should only appear when the caller has opted in to handle references,
+      // see nlua_pop_Object.
+      msgpack_pack_nil(res);
+      break;
+    }
     case kObjectTypeBoolean: {
-        msgpack_rpc_from_boolean(cur.aobj->data.boolean, res);
-        break;
-      }
+      msgpack_rpc_from_boolean(cur.aobj->data.boolean, res);
+      break;
+    }
     case kObjectTypeInteger: {
-        msgpack_rpc_from_integer(cur.aobj->data.integer, res);
-        break;
-      }
+      msgpack_rpc_from_integer(cur.aobj->data.integer, res);
+      break;
+    }
     case kObjectTypeFloat: {
-        msgpack_rpc_from_float(cur.aobj->data.floating, res);
-        break;
-      }
+      msgpack_rpc_from_float(cur.aobj->data.floating, res);
+      break;
+    }
     case kObjectTypeString: {
-        msgpack_rpc_from_string(cur.aobj->data.string, res);
-        break;
-      }
+      msgpack_rpc_from_string(cur.aobj->data.string, res);
+      break;
+    }
     case kObjectTypeBuffer: {
-        msgpack_rpc_from_buffer(cur.aobj->data.integer, res);
-        break;
-      }
+      msgpack_rpc_from_buffer(cur.aobj->data.integer, res);
+      break;
+    }
     case kObjectTypeWindow: {
-        msgpack_rpc_from_window(cur.aobj->data.integer, res);
-        break;
-      }
+      msgpack_rpc_from_window(cur.aobj->data.integer, res);
+      break;
+    }
     case kObjectTypeTabpage: {
-        msgpack_rpc_from_tabpage(cur.aobj->data.integer, res);
-        break;
-      }
+      msgpack_rpc_from_tabpage(cur.aobj->data.integer, res);
+      break;
+    }
     case kObjectTypeArray: {
-        const size_t size = cur.aobj->data.array.size;
-        if (cur.container) {
-          if (cur.idx >= size) {
-            (void)kv_pop(stack);
-          } else {
-            const size_t idx = cur.idx;
-            cur.idx++;
-            kv_last(stack) = cur;
-            kvi_push(stack, ((APIToMPObjectStackItem) {
+      const size_t size = cur.aobj->data.array.size;
+      if (cur.container) {
+        if (cur.idx >= size) {
+          (void)kv_pop(stack);
+        } else {
+          const size_t idx = cur.idx;
+          cur.idx++;
+          kv_last(stack) = cur;
+          kvi_push(stack, ((APIToMPObjectStackItem) {
                 .aobj = &cur.aobj->data.array.items[idx],
                 .container = false,
               }));
-          }
-        } else {
-          msgpack_pack_array(res, size);
-          cur.container = true;
-          kv_last(stack) = cur;
         }
-        break;
+      } else {
+        msgpack_pack_array(res, size);
+        cur.container = true;
+        kv_last(stack) = cur;
       }
+      break;
+    }
     case kObjectTypeDictionary: {
-        const size_t size = cur.aobj->data.dictionary.size;
-        if (cur.container) {
-          if (cur.idx >= size) {
-            (void)kv_pop(stack);
-          } else {
-            const size_t idx = cur.idx;
-            cur.idx++;
-            kv_last(stack) = cur;
-            msgpack_rpc_from_string(cur.aobj->data.dictionary.items[idx].key,
-                                    res);
-            kvi_push(stack, ((APIToMPObjectStackItem) {
+      const size_t size = cur.aobj->data.dictionary.size;
+      if (cur.container) {
+        if (cur.idx >= size) {
+          (void)kv_pop(stack);
+        } else {
+          const size_t idx = cur.idx;
+          cur.idx++;
+          kv_last(stack) = cur;
+          msgpack_rpc_from_string(cur.aobj->data.dictionary.items[idx].key,
+                                  res);
+          kvi_push(stack, ((APIToMPObjectStackItem) {
                 .aobj = &cur.aobj->data.dictionary.items[idx].value,
                 .container = false,
               }));
-          }
-        } else {
-          msgpack_pack_map(res, size);
-          cur.container = true;
-          kv_last(stack) = cur;
         }
-        break;
+      } else {
+        msgpack_pack_map(res, size);
+        cur.container = true;
+        kv_last(stack) = cur;
       }
+      break;
+    }
     }
     if (!cur.container) {
       (void)kv_pop(stack);

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -47,9 +47,9 @@ static msgpack_sbuffer sbuffer;
   } \
   \
   static void msgpack_rpc_from_##lt(Integer o, msgpack_packer *res) \
-  /* *INDENT-OFF* */ \
+/* uncrustify:indent-off */ \
     FUNC_ATTR_NONNULL_ARG(2) \
-/* *INDENT-ON* */ \
+/* uncrustify:indent-on */ \
   { \
   msgpack_packer pac; \
   msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write); \

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -101,20 +101,17 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
       *cur.aobj = NIL;
     }
     switch (cur.mobj->type) {
-    case MSGPACK_OBJECT_NIL: {
+    case MSGPACK_OBJECT_NIL:
       break;
-    }
-    case MSGPACK_OBJECT_BOOLEAN: {
+    case MSGPACK_OBJECT_BOOLEAN:
       *cur.aobj = BOOLEAN_OBJ(cur.mobj->via.boolean);
       break;
-    }
-    case MSGPACK_OBJECT_NEGATIVE_INTEGER: {
+    case MSGPACK_OBJECT_NEGATIVE_INTEGER:
       STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.i64),
                     "Msgpack integer size does not match API integer");
       *cur.aobj = INTEGER_OBJ(cur.mobj->via.i64);
       break;
-    }
-    case MSGPACK_OBJECT_POSITIVE_INTEGER: {
+    case MSGPACK_OBJECT_POSITIVE_INTEGER:
       STATIC_ASSERT(sizeof(Integer) == sizeof(cur.mobj->via.u64),
                     "Msgpack integer size does not match API integer");
       if (cur.mobj->via.u64 > API_INTEGER_MAX) {
@@ -123,7 +120,6 @@ bool msgpack_rpc_to_object(const msgpack_object *const obj, Object *const arg)
         *cur.aobj = INTEGER_OBJ((Integer)cur.mobj->via.u64);
       }
       break;
-    }
 #ifdef NVIM_MSGPACK_HAS_FLOAT32
     case MSGPACK_OBJECT_FLOAT32:
     case MSGPACK_OBJECT_FLOAT64:
@@ -205,10 +201,9 @@ case type: { \
 #endif
           case MSGPACK_OBJECT_EXT:
           case MSGPACK_OBJECT_MAP:
-          case MSGPACK_OBJECT_ARRAY: {
+          case MSGPACK_OBJECT_ARRAY:
             ret = false;
             break;
-          }
           }
           if (ret) {
             kvi_push(stack, ((MPToAPIObjectStackItem) {
@@ -231,23 +226,20 @@ case type: { \
       }
       break;
     }
-    case MSGPACK_OBJECT_EXT: {
+    case MSGPACK_OBJECT_EXT:
       switch ((ObjectType)(cur.mobj->via.ext.type + EXT_OBJECT_TYPE_SHIFT)) {
-      case kObjectTypeBuffer: {
+      case kObjectTypeBuffer:
         cur.aobj->type = kObjectTypeBuffer;
         ret = msgpack_rpc_to_buffer(cur.mobj, &cur.aobj->data.integer);
         break;
-      }
-      case kObjectTypeWindow: {
+      case kObjectTypeWindow:
         cur.aobj->type = kObjectTypeWindow;
         ret = msgpack_rpc_to_window(cur.mobj, &cur.aobj->data.integer);
         break;
-      }
-      case kObjectTypeTabpage: {
+      case kObjectTypeTabpage:
         cur.aobj->type = kObjectTypeTabpage;
         ret = msgpack_rpc_to_tabpage(cur.mobj, &cur.aobj->data.integer);
         break;
-      }
       case kObjectTypeNil:
       case kObjectTypeBoolean:
       case kObjectTypeInteger:
@@ -255,12 +247,10 @@ case type: { \
       case kObjectTypeString:
       case kObjectTypeArray:
       case kObjectTypeDictionary:
-      case kObjectTypeLuaRef: {
+      case kObjectTypeLuaRef:
         break;
       }
-      }
       break;
-    }
 #undef STR_CASE
     }
     if (!cur.container) {
@@ -385,41 +375,33 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
                   "Buffer, window and tabpage enum items are in order");
     switch (cur.aobj->type) {
     case kObjectTypeNil:
-    case kObjectTypeLuaRef: {
+    case kObjectTypeLuaRef:
       // TODO(bfredl): could also be an error. Though kObjectTypeLuaRef
       // should only appear when the caller has opted in to handle references,
       // see nlua_pop_Object.
       msgpack_pack_nil(res);
       break;
-    }
-    case kObjectTypeBoolean: {
+    case kObjectTypeBoolean:
       msgpack_rpc_from_boolean(cur.aobj->data.boolean, res);
       break;
-    }
-    case kObjectTypeInteger: {
+    case kObjectTypeInteger:
       msgpack_rpc_from_integer(cur.aobj->data.integer, res);
       break;
-    }
-    case kObjectTypeFloat: {
+    case kObjectTypeFloat:
       msgpack_rpc_from_float(cur.aobj->data.floating, res);
       break;
-    }
-    case kObjectTypeString: {
+    case kObjectTypeString:
       msgpack_rpc_from_string(cur.aobj->data.string, res);
       break;
-    }
-    case kObjectTypeBuffer: {
+    case kObjectTypeBuffer:
       msgpack_rpc_from_buffer(cur.aobj->data.integer, res);
       break;
-    }
-    case kObjectTypeWindow: {
+    case kObjectTypeWindow:
       msgpack_rpc_from_window(cur.aobj->data.integer, res);
       break;
-    }
-    case kObjectTypeTabpage: {
+    case kObjectTypeTabpage:
       msgpack_rpc_from_tabpage(cur.aobj->data.integer, res);
       break;
-    }
     case kObjectTypeArray: {
       const size_t size = cur.aobj->data.array.size;
       if (cur.container) {

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -48,7 +48,9 @@ static msgpack_sbuffer sbuffer;
   } \
   \
   static void msgpack_rpc_from_##lt(Integer o, msgpack_packer *res) \
+    /* *INDENT-OFF* */ \
     FUNC_ATTR_NONNULL_ARG(2) \
+    /* *INDENT-ON* */ \
   { \
     msgpack_packer pac; \
     msgpack_packer_init(&pac, &sbuffer, msgpack_sbuffer_write); \

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -2,24 +2,24 @@
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
+#include "nvim/ascii.h"
+#include "nvim/eval.h"
+#include "nvim/event/socket.h"
+#include "nvim/fileio.h"
+#include "nvim/garray.h"
+#include "nvim/log.h"
+#include "nvim/main.h"
+#include "nvim/memory.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/server.h"
 #include "nvim/os/os.h"
-#include "nvim/event/socket.h"
-#include "nvim/ascii.h"
-#include "nvim/eval.h"
-#include "nvim/garray.h"
-#include "nvim/vim.h"
-#include "nvim/main.h"
-#include "nvim/memory.h"
-#include "nvim/log.h"
-#include "nvim/fileio.h"
 #include "nvim/path.h"
 #include "nvim/strings.h"
+#include "nvim/vim.h"
 
 #define MAX_CONNECTIONS 32
 #define LISTEN_ADDRESS_ENV_VAR "NVIM_LISTEN_ADDRESS"
@@ -90,7 +90,7 @@ char *server_address_new(void)
   static uint32_t count = 0;
   char template[ADDRESS_MAX_SIZE];
   snprintf(template, ADDRESS_MAX_SIZE,
-    "\\\\.\\pipe\\nvim-%" PRIu64 "-%" PRIu32, os_get_pid(), count++);
+           "\\\\.\\pipe\\nvim-%" PRIu64 "-%" PRIu32, os_get_pid(), count++);
   return xstrdup(template);
 #else
   return (char *)vim_tempname();

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2474,59 +2474,59 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
       c1 = tab_page_click_defs[mouse_col].tabnr;
       switch (tab_page_click_defs[mouse_col].type) {
       case kStlClickDisabled: {
-          break;
-        }
+        break;
+      }
       case kStlClickTabClose: {
-          tabpage_T *tp;
+        tabpage_T *tp;
 
-          // Close the current or specified tab page.
-          if (c1 == 999) {
-            tp = curtab;
-          } else {
-            tp = find_tabpage(c1);
-          }
-          if (tp == curtab) {
-            if (first_tabpage->tp_next != NULL) {
-              tabpage_close(false);
-            }
-          } else if (tp != NULL) {
-            tabpage_close_other(tp, false);
-          }
-          break;
+        // Close the current or specified tab page.
+        if (c1 == 999) {
+          tp = curtab;
+        } else {
+          tp = find_tabpage(c1);
         }
+        if (tp == curtab) {
+          if (first_tabpage->tp_next != NULL) {
+            tabpage_close(false);
+          }
+        } else if (tp != NULL) {
+          tabpage_close_other(tp, false);
+        }
+        break;
+      }
       case kStlClickTabSwitch: {
-          if ((mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK) {
-            // double click opens new page
-            end_visual_mode();
-            tabpage_new();
-            tabpage_move(c1 == 0 ? 9999 : c1 - 1);
-          } else {
-            // Go to specified tab page, or next one if not clicking
-            // on a label.
-            goto_tabpage(c1);
+        if ((mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK) {
+          // double click opens new page
+          end_visual_mode();
+          tabpage_new();
+          tabpage_move(c1 == 0 ? 9999 : c1 - 1);
+        } else {
+          // Go to specified tab page, or next one if not clicking
+          // on a label.
+          goto_tabpage(c1);
 
-            // It's like clicking on the status line of a window.
-            if (curwin != old_curwin) {
-              end_visual_mode();
-            }
+          // It's like clicking on the status line of a window.
+          if (curwin != old_curwin) {
+            end_visual_mode();
           }
-          break;
         }
+        break;
+      }
       case kStlClickFuncRun: {
-          typval_T argv[] = {
-            {
-              .v_lock = VAR_FIXED,
-              .v_type = VAR_NUMBER,
-              .vval = {
-                .v_number = (varnumber_T)tab_page_click_defs[mouse_col].tabnr
-              },
+        typval_T argv[] = {
+          {
+            .v_lock = VAR_FIXED,
+            .v_type = VAR_NUMBER,
+            .vval = {
+              .v_number = (varnumber_T)tab_page_click_defs[mouse_col].tabnr
             },
-            {
-              .v_lock = VAR_FIXED,
-              .v_type = VAR_NUMBER,
-              .vval = {
-                .v_number = (((mod_mask & MOD_MASK_MULTI_CLICK)
-                              == MOD_MASK_4CLICK)
+          },
+          {
+            .v_lock = VAR_FIXED,
+            .v_type = VAR_NUMBER,
+            .vval = {
+              .v_number = (((mod_mask & MOD_MASK_MULTI_CLICK)
+                            == MOD_MASK_4CLICK)
                              ? 4
                              : ((mod_mask & MOD_MASK_MULTI_CLICK)
                                 == MOD_MASK_3CLICK)
@@ -2535,43 +2535,43 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
                                 == MOD_MASK_2CLICK)
                              ? 2
                              : 1)
-              },
             },
-            {
-              .v_lock = VAR_FIXED,
-              .v_type = VAR_STRING,
-              .vval = { .v_string = (char_u *)(which_button == MOUSE_LEFT
+          },
+          {
+            .v_lock = VAR_FIXED,
+            .v_type = VAR_STRING,
+            .vval = { .v_string = (char_u *)(which_button == MOUSE_LEFT
                                                 ? "l"
                                                 : which_button == MOUSE_RIGHT
                                                 ? "r"
                                                 : which_button == MOUSE_MIDDLE
                                                 ? "m"
                                                 : "?") },
+          },
+          {
+            .v_lock = VAR_FIXED,
+            .v_type = VAR_STRING,
+            .vval = {
+              .v_string = (char_u[]) {
+                (char_u)(mod_mask & MOD_MASK_SHIFT ? 's' : ' '),
+                (char_u)(mod_mask & MOD_MASK_CTRL ? 'c' : ' '),
+                (char_u)(mod_mask & MOD_MASK_ALT ? 'a' : ' '),
+                (char_u)(mod_mask & MOD_MASK_META ? 'm' : ' '),
+                NUL
+              }
             },
-            {
-              .v_lock = VAR_FIXED,
-              .v_type = VAR_STRING,
-              .vval = {
-                .v_string = (char_u[]) {
-                  (char_u)(mod_mask & MOD_MASK_SHIFT ? 's' : ' '),
-                  (char_u)(mod_mask & MOD_MASK_CTRL ? 'c' : ' '),
-                  (char_u)(mod_mask & MOD_MASK_ALT ? 'a' : ' '),
-                  (char_u)(mod_mask & MOD_MASK_META ? 'm' : ' '),
-                  NUL
-                }
-              },
-            }
-          };
-          typval_T rettv;
-          funcexe_T funcexe = FUNCEXE_INIT;
-          funcexe.firstline = curwin->w_cursor.lnum;
-          funcexe.lastline = curwin->w_cursor.lnum;
-          funcexe.evaluate = true;
-          (void)call_func((char_u *)tab_page_click_defs[mouse_col].func, -1,
-                          &rettv, ARRAY_SIZE(argv), argv, &funcexe);
-          tv_clear(&rettv);
-          break;
-        }
+          }
+        };
+        typval_T rettv;
+        funcexe_T funcexe = FUNCEXE_INIT;
+        funcexe.firstline = curwin->w_cursor.lnum;
+        funcexe.lastline = curwin->w_cursor.lnum;
+        funcexe.evaluate = true;
+        (void)call_func((char_u *)tab_page_click_defs[mouse_col].func, -1,
+                        &rettv, ARRAY_SIZE(argv), argv, &funcexe);
+        tv_clear(&rettv);
+        break;
+      }
       }
     }
     return true;
@@ -4701,42 +4701,42 @@ dozet:
   case 'w':     // "zw": add wrong word to word list
   case 'G':     // "zG": add good word to temp word list
   case 'W':     // "zW": add wrong word to temp word list
-    {
-      char_u *ptr = NULL;
-      size_t len;
+  {
+    char_u *ptr = NULL;
+    size_t len;
 
-      if (checkclearop(cap->oap)) {
-        break;
-      }
-      if (VIsual_active && !get_visual_text(cap, &ptr, &len)) {
-        return;
-      }
-      if (ptr == NULL) {
-        pos_T pos = curwin->w_cursor;
-
-        /* Find bad word under the cursor.  When 'spell' is
-         * off this fails and find_ident_under_cursor() is
-         * used below. */
-        emsg_off++;
-        len = spell_move_to(curwin, FORWARD, true, true, NULL);
-        emsg_off--;
-        if (len != 0 && curwin->w_cursor.col <= pos.col) {
-          ptr = ml_get_pos(&curwin->w_cursor);
-        }
-        curwin->w_cursor = pos;
-      }
-
-      if (ptr == NULL && (len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0) {
-        return;
-      }
-      assert(len <= INT_MAX);
-      spell_add_word(ptr, (int)len,
-                     nchar == 'w' || nchar == 'W'
-                   ? SPELL_ADD_BAD : SPELL_ADD_GOOD,
-                     (nchar == 'G' || nchar == 'W') ? 0 : (int)cap->count1,
-                     undo);
+    if (checkclearop(cap->oap)) {
+      break;
     }
-    break;
+    if (VIsual_active && !get_visual_text(cap, &ptr, &len)) {
+      return;
+    }
+    if (ptr == NULL) {
+      pos_T pos = curwin->w_cursor;
+
+      /* Find bad word under the cursor.  When 'spell' is
+       * off this fails and find_ident_under_cursor() is
+       * used below. */
+      emsg_off++;
+      len = spell_move_to(curwin, FORWARD, true, true, NULL);
+      emsg_off--;
+      if (len != 0 && curwin->w_cursor.col <= pos.col) {
+        ptr = ml_get_pos(&curwin->w_cursor);
+      }
+      curwin->w_cursor = pos;
+    }
+
+    if (ptr == NULL && (len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0) {
+      return;
+    }
+    assert(len <= INT_MAX);
+    spell_add_word(ptr, (int)len,
+                   nchar == 'w' || nchar == 'W'
+                   ? SPELL_ADD_BAD : SPELL_ADD_GOOD,
+                   (nchar == 'G' || nchar == 'W') ? 0 : (int)cap->count1,
+                   undo);
+  }
+  break;
 
   case '=':     // "z=": suggestions for a badly spelled word
     if (!checkclearop(cap->oap)) {
@@ -7055,19 +7055,19 @@ static void nv_g_cmd(cmdarg_T *cap)
     break;
 
   case 'M': {
-      const char_u *const ptr = get_cursor_line_ptr();
+    const char_u *const ptr = get_cursor_line_ptr();
 
-      oap->motion_type = kMTCharWise;
-      oap->inclusive = false;
-      i = (int)mb_string2cells_len(ptr, STRLEN(ptr));
-      if (cap->count0 > 0 && cap->count0 <= 100) {
-        coladvance((colnr_T)(i * cap->count0 / 100));
-      } else {
-        coladvance((colnr_T)(i / 2));
-      }
-      curwin->w_set_curswant = true;
+    oap->motion_type = kMTCharWise;
+    oap->inclusive = false;
+    i = (int)mb_string2cells_len(ptr, STRLEN(ptr));
+    if (cap->count0 > 0 && cap->count0 <= 100) {
+      coladvance((colnr_T)(i * cap->count0 / 100));
+    } else {
+      coladvance((colnr_T)(i / 2));
     }
-    break;
+    curwin->w_set_curswant = true;
+  }
+  break;
 
   case '_':
     /* "g_": to the last non-blank character in the line or <count> lines
@@ -7099,57 +7099,57 @@ static void nv_g_cmd(cmdarg_T *cap)
   case '$':
   case K_END:
   case K_KEND: {
-      int col_off = curwin_col_off();
+    int col_off = curwin_col_off();
 
-      oap->motion_type = kMTCharWise;
-      oap->inclusive = true;
-      if (curwin->w_p_wrap
-          && curwin->w_width_inner != 0) {
-        curwin->w_curswant = MAXCOL;              // so we stay at the end
-        if (cap->count1 == 1) {
-          int width1 = curwin->w_width_inner - col_off;
-          int width2 = width1 + curwin_col_off2();
+    oap->motion_type = kMTCharWise;
+    oap->inclusive = true;
+    if (curwin->w_p_wrap
+        && curwin->w_width_inner != 0) {
+      curwin->w_curswant = MAXCOL;              // so we stay at the end
+      if (cap->count1 == 1) {
+        int width1 = curwin->w_width_inner - col_off;
+        int width2 = width1 + curwin_col_off2();
 
-          validate_virtcol();
-          i = width1 - 1;
-          if (curwin->w_virtcol >= (colnr_T)width1) {
-            i += ((curwin->w_virtcol - width1) / width2 + 1)
-                 * width2;
-          }
-          coladvance((colnr_T)i);
-
-          // Make sure we stick in this column.
-          validate_virtcol();
-          curwin->w_curswant = curwin->w_virtcol;
-          curwin->w_set_curswant = false;
-          if (curwin->w_cursor.col > 0 && curwin->w_p_wrap) {
-            /*
-             * Check for landing on a character that got split at
-             * the end of the line.  We do not want to advance to
-             * the next screen line.
-             */
-            if (curwin->w_virtcol > (colnr_T)i) {
-              --curwin->w_cursor.col;
-            }
-          }
-        } else if (nv_screengo(oap, FORWARD, cap->count1 - 1) == false) {
-          clearopbeep(oap);
+        validate_virtcol();
+        i = width1 - 1;
+        if (curwin->w_virtcol >= (colnr_T)width1) {
+          i += ((curwin->w_virtcol - width1) / width2 + 1)
+               * width2;
         }
-      } else {
-        if (cap->count1 > 1) {
-          // if it fails, let the cursor still move to the last char
-          (void)cursor_down(cap->count1 - 1, false);
-        }
-        i = curwin->w_leftcol + curwin->w_width_inner - col_off - 1;
         coladvance((colnr_T)i);
 
         // Make sure we stick in this column.
         validate_virtcol();
         curwin->w_curswant = curwin->w_virtcol;
         curwin->w_set_curswant = false;
+        if (curwin->w_cursor.col > 0 && curwin->w_p_wrap) {
+          /*
+           * Check for landing on a character that got split at
+           * the end of the line.  We do not want to advance to
+           * the next screen line.
+           */
+          if (curwin->w_virtcol > (colnr_T)i) {
+            --curwin->w_cursor.col;
+          }
+        }
+      } else if (nv_screengo(oap, FORWARD, cap->count1 - 1) == false) {
+        clearopbeep(oap);
       }
+    } else {
+      if (cap->count1 > 1) {
+        // if it fails, let the cursor still move to the last char
+        (void)cursor_down(cap->count1 - 1, false);
+      }
+      i = curwin->w_leftcol + curwin->w_width_inner - col_off - 1;
+      coladvance((colnr_T)i);
+
+      // Make sure we stick in this column.
+      validate_virtcol();
+      curwin->w_curswant = curwin->w_virtcol;
+      curwin->w_set_curswant = false;
     }
-    break;
+  }
+  break;
 
   /*
    * "g*" and "g#", like "*" and "#" but without using "\<" and "\>"

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2473,9 +2473,8 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
       in_tab_line = true;
       c1 = tab_page_click_defs[mouse_col].tabnr;
       switch (tab_page_click_defs[mouse_col].type) {
-      case kStlClickDisabled: {
+      case kStlClickDisabled:
         break;
-      }
       case kStlClickTabClose: {
         tabpage_T *tp;
 
@@ -2494,7 +2493,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
         }
         break;
       }
-      case kStlClickTabSwitch: {
+      case kStlClickTabSwitch:
         if ((mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK) {
           // double click opens new page
           end_visual_mode();
@@ -2511,7 +2510,6 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
           }
         }
         break;
-      }
       case kStlClickFuncRun: {
         typval_T argv[] = {
           {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2622,64 +2622,64 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
       break;
 
     case kMTCharWise: {
-        colnr_T startcol = 0, endcol = MAXCOL;
-        int is_oneChar = false;
-        colnr_T cs, ce;
-        p = ml_get(lnum);
-        bd.startspaces = 0;
-        bd.endspaces = 0;
+      colnr_T startcol = 0, endcol = MAXCOL;
+      int is_oneChar = false;
+      colnr_T cs, ce;
+      p = ml_get(lnum);
+      bd.startspaces = 0;
+      bd.endspaces = 0;
 
-        if (lnum == oap->start.lnum) {
-          startcol = oap->start.col;
-          if (virtual_op) {
-            getvcol(curwin, &oap->start, &cs, NULL, &ce);
-            if (ce != cs && oap->start.coladd > 0) {
-              /* Part of a tab selected -- but don't
-               * double-count it. */
-              bd.startspaces = (ce - cs + 1)
-                               - oap->start.coladd;
-              startcol++;
-            }
+      if (lnum == oap->start.lnum) {
+        startcol = oap->start.col;
+        if (virtual_op) {
+          getvcol(curwin, &oap->start, &cs, NULL, &ce);
+          if (ce != cs && oap->start.coladd > 0) {
+            /* Part of a tab selected -- but don't
+             * double-count it. */
+            bd.startspaces = (ce - cs + 1)
+                             - oap->start.coladd;
+            startcol++;
           }
         }
-
-        if (lnum == oap->end.lnum) {
-          endcol = oap->end.col;
-          if (virtual_op) {
-            getvcol(curwin, &oap->end, &cs, NULL, &ce);
-            if (p[endcol] == NUL || (cs + oap->end.coladd < ce
-                                     // Don't add space for double-wide
-                                     // char; endcol will be on last byte
-                                     // of multi-byte char.
-                                     && utf_head_off(p, p + endcol) == 0)) {
-              if (oap->start.lnum == oap->end.lnum
-                  && oap->start.col == oap->end.col) {
-                // Special case: inside a single char
-                is_oneChar = true;
-                bd.startspaces = oap->end.coladd
-                                 - oap->start.coladd + oap->inclusive;
-                endcol = startcol;
-              } else {
-                bd.endspaces = oap->end.coladd
-                               + oap->inclusive;
-                endcol -= oap->inclusive;
-              }
-            }
-          }
-        }
-        if (endcol == MAXCOL) {
-          endcol = (colnr_T)STRLEN(p);
-        }
-        if (startcol > endcol
-            || is_oneChar) {
-          bd.textlen = 0;
-        } else {
-          bd.textlen = endcol - startcol + oap->inclusive;
-        }
-        bd.textstart = p + startcol;
-        yank_copy_line(reg, &bd, y_idx, false);
-        break;
       }
+
+      if (lnum == oap->end.lnum) {
+        endcol = oap->end.col;
+        if (virtual_op) {
+          getvcol(curwin, &oap->end, &cs, NULL, &ce);
+          if (p[endcol] == NUL || (cs + oap->end.coladd < ce
+                                   // Don't add space for double-wide
+                                   // char; endcol will be on last byte
+                                   // of multi-byte char.
+                                   && utf_head_off(p, p + endcol) == 0)) {
+            if (oap->start.lnum == oap->end.lnum
+                && oap->start.col == oap->end.col) {
+              // Special case: inside a single char
+              is_oneChar = true;
+              bd.startspaces = oap->end.coladd
+                               - oap->start.coladd + oap->inclusive;
+              endcol = startcol;
+            } else {
+              bd.endspaces = oap->end.coladd
+                             + oap->inclusive;
+              endcol -= oap->inclusive;
+            }
+          }
+        }
+      }
+      if (endcol == MAXCOL) {
+        endcol = (colnr_T)STRLEN(p);
+      }
+      if (startcol > endcol
+          || is_oneChar) {
+        bd.textlen = 0;
+      } else {
+        bd.textlen = endcol - startcol + oap->inclusive;
+      }
+      bd.textstart = p + startcol;
+      yank_copy_line(reg, &bd, y_idx, false);
+      break;
+    }
     // NOTREACHED
     case kMTUnknown:
       abort();
@@ -5781,15 +5781,15 @@ void cursor_pos_info(dict_T *dict)
           len = MAXCOL;
           break;
         case 'v': {
-            colnr_T start_col = (lnum == min_pos.lnum)
+          colnr_T start_col = (lnum == min_pos.lnum)
                               ? min_pos.col : 0;
-            colnr_T end_col = (lnum == max_pos.lnum)
+          colnr_T end_col = (lnum == max_pos.lnum)
                             ? max_pos.col - start_col + 1 : MAXCOL;
 
-            s = ml_get(lnum) + start_col;
-            len = end_col;
-          }
-          break;
+          s = ml_get(lnum) + start_col;
+          len = end_col;
+        }
+        break;
         }
         if (s != NULL) {
           byte_count_cursor += line_count_info(s, &word_count_cursor,
@@ -6222,22 +6222,22 @@ static void set_clipboard(int name, yankreg_T *reg)
   char regtype;
   switch (reg->y_type) {
   case kMTLineWise: {
-      regtype = 'V';
-      tv_list_append_string(lines, NULL, 0);
-      break;
-    }
+    regtype = 'V';
+    tv_list_append_string(lines, NULL, 0);
+    break;
+  }
   case kMTCharWise: {
-      regtype = 'v';
-      break;
-    }
+    regtype = 'v';
+    break;
+  }
   case kMTBlockWise: {
-      regtype = 'b';
-      tv_list_append_string(lines, NULL, 0);
-      break;
-    }
+    regtype = 'b';
+    tv_list_append_string(lines, NULL, 0);
+    break;
+  }
   case kMTUnknown: {
-      abort();
-    }
+    abort();
+  }
   }
 
   list_T *args = tv_list_alloc(3);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -6221,23 +6221,19 @@ static void set_clipboard(int name, yankreg_T *reg)
 
   char regtype;
   switch (reg->y_type) {
-  case kMTLineWise: {
+  case kMTLineWise:
     regtype = 'V';
     tv_list_append_string(lines, NULL, 0);
     break;
-  }
-  case kMTCharWise: {
+  case kMTCharWise:
     regtype = 'v';
     break;
-  }
-  case kMTBlockWise: {
+  case kMTBlockWise:
     regtype = 'b';
     tv_list_append_string(lines, NULL, 0);
     break;
-  }
-  case kMTUnknown: {
+  case kMTUnknown:
     abort();
-  }
   }
 
   list_T *args = tv_list_alloc(3);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5844,21 +5844,21 @@ char_u *get_syntax_name(expand_T *xp, int idx)
   case EXP_SUBCMD:
     return (char_u *)subcommands[idx].name;
   case EXP_CASE: {
-      static char *case_args[] = { "match", "ignore", NULL };
-      return (char_u *)case_args[idx];
-    }
+    static char *case_args[] = { "match", "ignore", NULL };
+    return (char_u *)case_args[idx];
+  }
   case EXP_SPELL: {
-      static char *spell_args[] =
-      { "toplevel", "notoplevel", "default", NULL };
-      return (char_u *)spell_args[idx];
-    }
+    static char *spell_args[] =
+    { "toplevel", "notoplevel", "default", NULL };
+    return (char_u *)spell_args[idx];
+  }
   case EXP_SYNC: {
-      static char *sync_args[] =
-      { "ccomment", "clear", "fromstart",
-        "linebreaks=", "linecont", "lines=", "match",
-        "maxlines=", "minlines=", "region", NULL };
-      return (char_u *)sync_args[idx];
-    }
+    static char *sync_args[] =
+    { "ccomment", "clear", "fromstart",
+      "linebreaks=", "linecont", "lines=", "match",
+      "maxlines=", "minlines=", "region", NULL };
+    return (char_u *)sync_args[idx];
+  }
   }
   return NULL;
 }


### PR DESCRIPTION
The first commit is to work around my first workaround, which is to prevent uncrustify from deindenting the macro attributes like `FUNC_ATTR_NONNULL_ARG`. I'll spare the boring details, but basically this workaround unfortunately breaks when used in macros. I may in the future dig in to the uncrustify codebase and actually fix it but for now this should suffice. The default keywords to disable formatting is `*INDENT-OFF*` and to enable it's `*INDENT-ON*`. These can be changed to be any string we want, so just let me know if you'd like to change them. 

It's also possible to use an arbitrary regex to enable/disable uncrustify instead of a fixed string, like say any three digits followed by four vowels. I think I speak for everyone when I say that we should absolutely never use this but I thought I'd still let you know *just in case*.