### PR TITLE
fix(docs): ignore _*.lua files from auto doc generation

### DIFF
--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -1130,7 +1130,7 @@ Doxyfile = textwrap.dedent('''
     INPUT_FILTER           = "{filter}"
     EXCLUDE                =
     EXCLUDE_SYMLINKS       = NO
-    EXCLUDE_PATTERNS       = */private/* */health.lua
+    EXCLUDE_PATTERNS       = */private/* */health.lua */_*.lua
     EXCLUDE_SYMBOLS        =
     EXTENSION_MAPPING      = lua=C
     EXTRACT_PRIVATE        = NO


### PR DESCRIPTION
The `gen_vimdoc.py` script fails because it finds a file not listed in the LSP sections (`_snippet.lua`). Ignore this file so that `gen_vimdoc.py` runs again.
