### PR TITLE
fix(test runner): handle nil in no-colors output handler

### DIFF
--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -2,7 +2,7 @@ local pretty = require 'pl.pretty'
 local global_helpers = require('test.helpers')
 
 -- Colors are disabled by default. #15610
-local colors = setmetatable({}, {__index = function() return function(s) return s end end})
+local colors = setmetatable({}, {__index = function() return function(s) return s == nil and '' or tostring(s) end end})
 if os.getenv "TEST_COLORS" then
   colors = require 'term.colors'
 end


### PR DESCRIPTION
Problem:
13748512f6d6 #15610 The no-colors codepath of the nvim.lua test output handler does not handle nil, leading to weird symptoms if e.g. a test has a syntax error:

    test/busted/outputHandlers/nvim.lua:105: attempt to concatenate a nil value

Solution:
Coerce to string in no-colors handler.