### PR TITLE
fix(eval): add the vimscript-1 feature to has()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4403,6 +4403,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "user_commands",
     "vartabs",
     "vertsplit",
+    "vimscript-1",
     "virtualedit",
     "visual",
     "visualextra",

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -138,6 +138,31 @@ func Test_let_errmsg()
   let v:errmsg = ''
 endfunc
 
+" scriptversion 1
+func Test_string_concat_scriptversion1()
+  call assert_true(has('vimscript-1'))
+  let a = 'a'
+  let b = 'b'
+
+  echo a . b
+  let a .= b
+  let vers = 1.2.3
+  call assert_equal('123', vers)
+
+  if has('float')
+    call assert_fails('let f = .5', 'E15:')
+  endif
+endfunc
+
+" scriptversion 1
+func Test_vvar_scriptversion1()
+  call assert_equal(15, 017)
+  call assert_equal(15, 0o17)
+  call assert_equal(15, 0O17)
+  call assert_equal(18, 018)
+  call assert_equal(511, 0o777)
+endfunc
+
 func Test_number_max_min_size()
   " This will fail on systems without 64 bit number support or when not
   " configured correctly.

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -12,6 +12,48 @@ func Test_catch_return_with_error()
   call assert_equal(1, s:foo())
 endfunc
 
+func Test_nocatch_restore_silent_emsg()
+  silent! try
+    throw 1
+  catch
+  endtry
+  echoerr 'wrong'
+  let c1 = nr2char(screenchar(&lines, 1))
+  let c2 = nr2char(screenchar(&lines, 2))
+  let c3 = nr2char(screenchar(&lines, 3))
+  let c4 = nr2char(screenchar(&lines, 4))
+  let c5 = nr2char(screenchar(&lines, 5))
+  call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
+endfunc
+
+func Test_mkdir_p()
+  call mkdir('Xmkdir/nested', 'p')
+  call assert_true(isdirectory('Xmkdir/nested'))
+  try
+    " Trying to make existing directories doesn't error
+    call mkdir('Xmkdir', 'p')
+    call mkdir('Xmkdir/nested', 'p')
+  catch /E739:/
+    call assert_report('mkdir(..., "p") failed for an existing directory')
+  endtry
+  " 'p' doesn't suppress real errors
+  call writefile([], 'Xfile')
+  call assert_fails('call mkdir("Xfile", "p")', 'E739')
+  call delete('Xfile')
+  call delete('Xmkdir', 'rf')
+endfunc
+
+func Test_line_continuation()
+  let array = [5,
+	"\ ignore this
+	\ 6,
+	"\ more to ignore
+	"\ more moreto ignore
+	\ ]
+	"\ and some more
+  call assert_equal([5, 6], array)
+endfunc
+
 func Test_E963()
   " These commands used to cause an internal error prior to vim 8.1.0563
   let v_e = v:errors
@@ -51,32 +93,11 @@ func Test_readfile_binary()
   call delete('XReadfile')
 endfunc
 
-func Test_mkdir_p()
-  call mkdir('Xmkdir/nested', 'p')
-  call assert_true(isdirectory('Xmkdir/nested'))
-  try
-    " Trying to make existing directories doesn't error
-    call mkdir('Xmkdir', 'p')
-    call mkdir('Xmkdir/nested', 'p')
-  catch /E739:/
-    call assert_report('mkdir(..., "p") failed for an existing directory')
-  endtry
-  " 'p' doesn't suppress real errors
-  call writefile([], 'Xfile')
-  call assert_fails('call mkdir("Xfile", "p")', 'E739')
-  call delete('Xfile')
-  call delete('Xmkdir', 'rf')
-endfunc
-
-func Test_line_continuation()
-  let array = [5,
-	"\ ignore this
-	\ 6,
-	"\ more to ignore
-	"\ more moreto ignore
-	\ ]
-	"\ and some more
-  call assert_equal([5, 6], array)
+func Test_let_errmsg()
+  call assert_fails('let v:errmsg = []', 'E730:')
+  let v:errmsg = ''
+  call assert_fails('let v:errmsg = []', 'E730:')
+  let v:errmsg = ''
 endfunc
 
 func Test_string_concatenation()
@@ -115,27 +136,6 @@ func Test_skip_after_throw()
     let x = wincol() || &ts
   catch /something/
   endtry
-endfunc
-
-func Test_nocatch_restore_silent_emsg()
-  silent! try
-    throw 1
-  catch
-  endtry
-  echoerr 'wrong'
-  let c1 = nr2char(screenchar(&lines, 1))
-  let c2 = nr2char(screenchar(&lines, 2))
-  let c3 = nr2char(screenchar(&lines, 3))
-  let c4 = nr2char(screenchar(&lines, 4))
-  let c5 = nr2char(screenchar(&lines, 5))
-  call assert_equal('wrong', c1 . c2 . c3 . c4 . c5)
-endfunc
-
-func Test_let_errmsg()
-  call assert_fails('let v:errmsg = []', 'E730:')
-  let v:errmsg = ''
-  call assert_fails('let v:errmsg = []', 'E730:')
-  let v:errmsg = ''
 endfunc
 
 " scriptversion 1


### PR DESCRIPTION
Include `Test_string_concat_scriptversion1` (from v8.1.1116 and v8.1.1190) to test that
`has('vimscript-1')` works. (Hopefully that's OK)

Ref: https://github.com/neovim/neovim/pull/14611#issuecomment-921099818