### PR TITLE
fix: prevent K_EVENT from stopping Select mode CTRL-O

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -8404,13 +8404,13 @@ static void nv_event(cmdarg_T *cap)
   // not safe to perform garbage collection because there could be unreferenced
   // lists or dicts being used.
   may_garbage_collect = false;
-  bool may_restart = (restart_edit != 0);
+  bool may_restart = (restart_edit != 0 || restart_VIsual_select != 0);
   state_handle_k_event();
   finish_op = false;
   if (may_restart) {
     // Tricky: if restart_edit was set before the handler we are in ctrl-o mode,
     // but if not, the event should be allowed to trigger :startinsert.
-    cap->retval |= CA_COMMAND_BUSY;  // don't call edit() now
+    cap->retval |= CA_COMMAND_BUSY;  // don't call edit() or restart Select now
   }
 }
 

--- a/test/functional/insert/ctrl_o_spec.lua
+++ b/test/functional/insert/ctrl_o_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require('test.functional.helpers')(after_each)
-local assert_alive = helpers.assert_alive
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
@@ -46,7 +45,7 @@ describe('insert-mode Ctrl-O', function()
   it("doesn't cancel Ctrl-O mode when processing event", function()
     feed('iHello World<c-o>')
     eq({mode='niI', blocking=false}, meths.get_mode()) -- fast event
-    assert_alive()  -- causes K_EVENT key
+    eq(2, eval('1+1'))  -- causes K_EVENT key
     eq({mode='niI', blocking=false}, meths.get_mode()) -- still in ctrl-o mode
     feed('dd')
     eq({mode='i', blocking=false}, meths.get_mode()) -- left ctrl-o mode

--- a/test/functional/visual/ctrl_o_spec.lua
+++ b/test/functional/visual/ctrl_o_spec.lua
@@ -1,0 +1,23 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local eq = helpers.eq
+local eval = helpers.eval
+local expect = helpers.expect
+local feed = helpers.feed
+local meths = helpers.meths
+
+describe('select-mode Ctrl-O', function()
+  before_each(clear)
+
+  it("doesn't cancel Ctrl-O mode when processing event", function()
+    feed('iHello World<esc>gh<c-o>')
+    eq({mode='vs', blocking=false}, meths.get_mode()) -- fast event
+    eq(2, eval('1+1'))  -- causes K_EVENT key
+    eq({mode='vs', blocking=false}, meths.get_mode()) -- still in ctrl-o mode
+    feed('^')
+    eq({mode='s', blocking=false}, meths.get_mode()) -- left ctrl-o mode
+    feed('h')
+    eq({mode='i', blocking=false}, meths.get_mode()) -- entered insert mode
+    expect('h') -- selection is the whole line and is replaced
+  end)
+end)


### PR DESCRIPTION
The problem this PR attempts to solve: When using Goneovim, Select mode `CTRL-O` returns back to Select mode immediately (even with `--clean`). Neovim TUI (with some plugins) also randomly returns to Select mode even if no keys are pressed when using `CTRL-O` in Select mode.