### PR TITLE
diagnostics: updates to severity_sort

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -239,7 +239,9 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                  • severity_sort: (default false) Sort
                                    diagnostics by severity. This affects the
                                    order in which signs and virtual text are
-                                   displayed. Options:
+                                   displayed. When true, higher severities are
+                                   displayed before lower severities (e.g.
+                                   ERROR is displayed before WARN). Options:
                                    • reverse: (boolean) Reverse sort order
                     {namespace}  number|nil Update the options for the given
                                  namespace. When omitted, update the global

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -452,7 +452,9 @@ end
 ---       - update_in_insert: (default false) Update diagnostics in Insert mode (if false,
 ---                           diagnostics are updated on InsertLeave)
 ---       - severity_sort: (default false) Sort diagnostics by severity. This affects the order in
----                         which signs and virtual text are displayed. Options:
+---                         which signs and virtual text are displayed. When true, higher severities
+---                         are displayed before lower severities (e.g. ERROR is displayed before WARN).
+---                         Options:
 ---                         * reverse: (boolean) Reverse sort order
 ---@param namespace number|nil Update the options for the given namespace. When omitted, update the
 ---                            global diagnostic options.
@@ -998,9 +1000,9 @@ function M.show(namespace, bufnr, diagnostics, opts)
 
   if vim.F.if_nil(opts.severity_sort, false) then
     if type(opts.severity_sort) == "table" and opts.severity_sort.reverse then
-      table.sort(diagnostics, function(a, b) return a.severity > b.severity end)
-    else
       table.sort(diagnostics, function(a, b) return a.severity < b.severity end)
+    else
+      table.sort(diagnostics, function(a, b) return a.severity > b.severity end)
     end
   end
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1,5 +1,3 @@
-local log = require('vim.lsp.log')
-
 ---@brief lsp-diagnostic
 ---
 ---@class Diagnostic
@@ -466,10 +464,7 @@ function M.set_signs(diagnostics, bufnr, client_id, _, opts)
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
   end
 
-  local ok = vim.diagnostic._set_signs(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id), opts)
-  if not ok then
-    log.debug("Failed to place signs:", diagnostics)
-  end
+  vim.diagnostic._set_signs(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id), opts)
 end
 
 --- Set underline for given diagnostics

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -202,11 +202,9 @@ function M.on_publish_diagnostics(_, result, ctx, config)
         end
       end
     end
-
-    vim.diagnostic.config(config, namespace)
   end
 
-  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
+  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id), config)
 
   -- Keep old autocmd for back compat. This should eventually be removed.
   vim.api.nvim_command("doautocmd <nomodeline> User LspDiagnosticsChanged")


### PR DESCRIPTION
Update the default severity_sort order so that when `severity_sort` is true, higher severities are displayed before lower severities (e.g. ERROR is displayed over WARN).

