### PR TITLE
Diagnostic additions

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -96,7 +96,7 @@ internally and are no longer exposed as part of the API. Instead, use
 
 LSP Utility Functions ~
 
-*vim.lsp.util.diagnostics_to_items()*	Use |vim.diagnostic.tolist()| instead.
+*vim.lsp.util.diagnostics_to_items()*	Use |vim.diagnostic.toqflist()| instead.
 *vim.lsp.util.set_qflist()*		Use |setqflist()| instead.
 *vim.lsp.util.set_loclist()*		Use |setloclist()| instead.
 

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -96,6 +96,7 @@ internally and are no longer exposed as part of the API. Instead, use
 
 LSP Utility Functions ~
 
+*vim.lsp.util.diagnostics_to_items()*	Use |vim.diagnostic.tolist()| instead.
 *vim.lsp.util.set_qflist()*		Use |setqflist()| instead.
 *vim.lsp.util.set_loclist()*		Use |setloclist()| instead.
 

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -265,7 +265,7 @@ enable({bufnr}, {namespace})                         *vim.diagnostic.enable()*
                     {namespace}  number|nil Only enable diagnostics for the
                                  given namespace.
 
-fromlist({list})                                   *vim.diagnostic.fromlist()*
+fromqflist({list})                               *vim.diagnostic.fromqflist()*
                 Convert a list of quickfix items to a list of diagnostics.
 
                 Parameters: ~
@@ -540,8 +540,9 @@ show_position_diagnostics({opts}, {bufnr}, {position})
                 Return: ~
                     tuple ({popup_bufnr}, {win_id})
 
-tolist({diagnostics})                                *vim.diagnostic.tolist()*
-                Convert a list of diagnostics to a list of quickfix items.
+toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
+                Convert a list of diagnostics to a list of quickfix items that
+                can be passed to |setqflist()| or |setloclist()|.
 
                 Parameters: ~
                     {diagnostics}  table List of diagnostics

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -265,6 +265,16 @@ enable({bufnr}, {namespace})                         *vim.diagnostic.enable()*
                     {namespace}  number|nil Only enable diagnostics for the
                                  given namespace.
 
+fromlist({list})                                   *vim.diagnostic.fromlist()*
+                Convert a list of quickfix items to a list of diagnostics.
+
+                Parameters: ~
+                    {list}  table A list of quickfix items from |getqflist()|
+                            or |getloclist()|.
+
+                Return: ~
+                    array of diagnostics |diagnostic-structure|
+
 get({bufnr}, {opts})                                    *vim.diagnostic.get()*
                 Get current diagnostics.
 
@@ -529,5 +539,15 @@ show_position_diagnostics({opts}, {bufnr}, {position})
 
                 Return: ~
                     tuple ({popup_bufnr}, {win_id})
+
+tolist({diagnostics})                                *vim.diagnostic.tolist()*
+                Convert a list of diagnostics to a list of quickfix items.
+
+                Parameters: ~
+                    {diagnostics}  table List of diagnostics
+                                   |diagnostic-structure|.
+
+                Return: ~
+                    array of quickfix list items |setqflist-what|
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -182,8 +182,8 @@ is the first letter of the severity name (for example, "E" for ERROR). Signs
 can be customized using the following: >
 
 	sign define DiagnosticSignError text=E texthl=DiagnosticSignError linehl= numhl=
-	sign define DiagnosticSignWarning text=W texthl=DiagnosticSignWarning linehl= numhl=
-	sign define DiagnosticSignInformation text=I texthl=DiagnosticSignInformation linehl= numhl=
+	sign define DiagnosticSignWarn text=W texthl=DiagnosticSignWarn linehl= numhl=
+	sign define DiagnosticSignInfo text=I texthl=DiagnosticSignInfo linehl= numhl=
 	sign define DiagnosticSignHint text=H texthl=DiagnosticSignHint linehl= numhl=
 
 ==============================================================================

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -384,6 +384,41 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
                     {bufnr}      number|nil Buffer number. Defaults to the
                                  current buffer.
 
+                                                      *vim.diagnostic.match()*
+match({str}, {pat}, {groups}, {severity_map}, {defaults})
+                Parse a diagnostic from a string.
+
+                For example, consider a line of output from a linter: >
+
+                 WARNING filename:27:3: Variable 'foo' does not exist
+
+                < This can be parsed into a diagnostic |diagnostic-structure|
+                with: >
+
+                 local s = "WARNING filename:27:3: Variable 'foo' does not exist"
+                 local pattern = "^(%w+) %w+:(%d+):(%d+): (.+)$"
+                 local groups = {"severity", "lnum", "col", "message"}
+                 vim.diagnostic.match(s, pattern, groups, {WARNING = vim.diagnostic.WARN})
+<
+
+                Parameters: ~
+                    {str}           string String to parse diagnostics from.
+                    {pat}           string Lua pattern with capture groups.
+                    {groups}        table List of fields in a
+                                    |diagnostic-structure| to associate with
+                                    captures from {pat}.
+                    {severity_map}  table A table mapping the severity field
+                                    from {groups} with an item from
+                                    |vim.diagnostic.severity|.
+                    {defaults}      table|nil Table of default values for any
+                                    fields not listed in {groups}. When
+                                    omitted, numeric values default to 0 and
+                                    "severity" defaults to ERROR.
+
+                Return: ~
+                    diagnostic |diagnostic-structure| or `nil` if {pat} fails
+                    to match {str}.
+
 reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
                 Remove all diagnostics from the given namespace.
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -392,7 +392,7 @@ local function set_list(loclist, opts)
     bufnr = vim.api.nvim_win_get_buf(winnr)
   end
   local diagnostics = M.get(bufnr, opts)
-  local items = M.tolist(diagnostics)
+  local items = M.toqflist(diagnostics)
   if loclist then
     vim.fn.setloclist(winnr, {}, ' ', { title = title, items = items })
   else
@@ -1211,11 +1211,12 @@ local errlist_type_map = {
   [M.severity.HINT] = 'N',
 }
 
---- Convert a list of diagnostics to a list of quickfix items.
+--- Convert a list of diagnostics to a list of quickfix items that can be
+--- passed to |setqflist()| or |setloclist()|.
 ---
 ---@param diagnostics table List of diagnostics |diagnostic-structure|.
 ---@return array of quickfix list items |setqflist-what|
-function M.tolist(diagnostics)
+function M.toqflist(diagnostics)
   vim.validate { diagnostics = {diagnostics, 't'} }
 
   local list = {}
@@ -1246,7 +1247,7 @@ end
 ---@param list table A list of quickfix items from |getqflist()| or
 ---            |getloclist()|.
 ---@return array of diagnostics |diagnostic-structure|
-function M.fromlist(list)
+function M.fromqflist(list)
   vim.validate { list = {list, 't'} }
 
   local diagnostics = {}

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -935,7 +935,7 @@ describe('vim.diagnostic', function()
     end)
   end)
 
-  describe('tolist() and fromlist()', function()
+  describe('toqflist() and fromqflist()', function()
     it('works', function()
       local result = exec_lua [[
       vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
@@ -945,9 +945,9 @@ describe('vim.diagnostic', function()
       })
 
       local diagnostics = vim.diagnostic.get(diagnostic_bufnr)
-      vim.fn.setqflist(vim.diagnostic.tolist(diagnostics))
+      vim.fn.setqflist(vim.diagnostic.toqflist(diagnostics))
       local list = vim.fn.getqflist()
-      local new_diagnostics = vim.diagnostic.fromlist(list)
+      local new_diagnostics = vim.diagnostic.fromqflist(list)
 
       -- Remove namespace since it isn't present in the return value of
       -- fromlist()

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -934,4 +934,30 @@ describe('vim.diagnostic', function()
       ]], msg))
     end)
   end)
+
+  describe('tolist() and fromlist()', function()
+    it('works', function()
+      local result = exec_lua [[
+      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+        make_error('Error 1', 0, 1, 0, 1),
+        make_error('Error 2', 1, 1, 1, 1),
+        make_warning('Warning', 2, 2, 2, 2),
+      })
+
+      local diagnostics = vim.diagnostic.get(diagnostic_bufnr)
+      vim.fn.setqflist(vim.diagnostic.tolist(diagnostics))
+      local list = vim.fn.getqflist()
+      local new_diagnostics = vim.diagnostic.fromlist(list)
+
+      -- Remove namespace since it isn't present in the return value of
+      -- fromlist()
+      for _, v in ipairs(diagnostics) do
+        v.namespace = nil
+      end
+
+      return {diagnostics, new_diagnostics}
+      ]]
+      eq(result[1], result[2])
+    end)
+  end)
 end)


### PR DESCRIPTION
- Add `vim.diagnostic.match()`
    * Parse a diagnostic from a string (similar usage to `string.match`)
- Add `vim.diagnostic.tolist()` and `vim.diagnostic.fromlist()`
    * Conversion functions between the list items expected by `setqflist()` and `setloclist()`
    * `vim.diagnostic.tolist()` replaces the `vim.lsp.util.diagnostics_to_items()`

Credit to @mfussenegger for the inspiration for `vim.diagnostic.match()` (adapted from nvim-lint, with permission).