### PR TITLE
feat(diagnostic): add option to include diagnostic source

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -75,7 +75,9 @@ For each of the functions below, use the corresponding function in
 *vim.lsp.diagnostic.get_prev()*
 *vim.lsp.diagnostic.get_prev_pos()*
 *vim.lsp.diagnostic.get_virtual_text_chunks_for_line()*
-			Use |vim.diagnostic.get_virt_text_chunks()| instead.
+				No replacement. Use options provided by
+				|vim.diagnostic.config()| to customize
+				virtual text.
 *vim.lsp.diagnostic.goto_next()*
 *vim.lsp.diagnostic.goto_prev()*
 *vim.lsp.diagnostic.redraw()*		Use |vim.diagnostic.show()| instead.

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -47,6 +47,7 @@ A diagnostic is a Lua table with the following keys:
 	end_col: The final column of the diagnostic
 	severity: The severity of the diagnostic |vim.diagnostic.severity|
 	message: The diagnostic text
+	source: The source of the diagnostic
 
 Diagnostics use the same indexing as the rest of the Nvim API (i.e. 0-based
 rows and columns). |api-indexing|
@@ -226,6 +227,9 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                    • severity: Only show virtual text for
                                      diagnostics matching the given severity
                                      |diagnostic-severity|
+                                   • source: (string) Include the diagnostic
+                                     source in virtual text. One of "always"
+                                     or "if_many".
 
                                  • signs: (default true) Use signs for
                                    diagnostics. Options:
@@ -532,6 +536,9 @@ show_position_diagnostics({opts}, {bufnr}, {position})
                                 • severity: See |diagnostic-severity|.
                                 • show_header: (boolean, default true) Show
                                   "Diagnostics:" header
+                                • source: (string) Include the diagnostic
+                                  source in the message. One of "always" or
+                                  "if_many".
                     {bufnr}     number|nil Buffer number. Defaults to the
                                 current buffer.
                     {position}  table|nil The (0,0)-indexed position. Defaults

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -333,26 +333,6 @@ get_prev_pos({opts})                           *vim.diagnostic.get_prev_pos()*
                 Return: ~
                     table Previous diagnostic position as a (row, col) tuple.
 
-                                       *vim.diagnostic.get_virt_text_chunks()*
-get_virt_text_chunks({line_diags}, {opts})
-                Get virtual text chunks to display using
-                |nvim_buf_set_extmark()|.
-
-                Parameters: ~
-                    {line_diags}  table The diagnostics associated with the
-                                  line.
-                    {opts}        table|nil Configuration table with the
-                                  following keys:
-                                  • prefix: (string) Prefix to display before
-                                    virtual text on line.
-                                  • spacing: (number) Number of spaces to
-                                    insert before virtual text.
-
-                Return: ~
-                    array of ({text}, {hl_group}) tuples. This can be passed
-                    directly to the {virt_text} option of
-                    |nvim_buf_set_extmark()|.
-
 goto_next({opts})                                 *vim.diagnostic.goto_next()*
                 Move to the next diagnostic.
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -851,6 +851,8 @@ end
 ---@param opts table|nil Configuration table with the following keys:
 ---            - prefix: (string) Prefix to display before virtual text on line.
 ---            - spacing: (number) Number of spaces to insert before virtual text.
+---            - source: (string) Include the diagnostic source in virtual text. One of "always" or
+---                      "if_many".
 ---@private
 function M._set_virtual_text(namespace, bufnr, diagnostics, opts)
   vim.validate {
@@ -872,7 +874,7 @@ function M._set_virtual_text(namespace, bufnr, diagnostics, opts)
     if opts and opts.severity then
       line_diagnostics = filter_by_severity(opts.severity, line_diagnostics)
     end
-    local virt_texts = M.get_virt_text_chunks(line_diagnostics, opts)
+    local virt_texts = M._get_virt_text_chunks(line_diagnostics, opts)
 
     if virt_texts then
       vim.api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
@@ -885,13 +887,11 @@ end
 
 --- Get virtual text chunks to display using |nvim_buf_set_extmark()|.
 ---
----@param line_diags table The diagnostics associated with the line.
----@param opts table|nil Configuration table with the following keys:
----            - prefix: (string) Prefix to display before virtual text on line.
----            - spacing: (number) Number of spaces to insert before virtual text.
----@return array of ({text}, {hl_group}) tuples. This can be passed directly to
----        the {virt_text} option of |nvim_buf_set_extmark()|.
-function M.get_virt_text_chunks(line_diags, opts)
+--- Exported for backward compatibility with
+--- vim.lsp.diagnostic.get_virtual_text_chunks_for_line(). When that function is eventually removed,
+--- this can be made local.
+---@private
+function M._get_virt_text_chunks(line_diags, opts)
   if #line_diags == 0 then
     return nil
   end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -103,6 +103,7 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
       end_col = line_byte_from_position(buf_lines, _end.line, _end.character, offset_encoding),
       severity = severity_lsp_to_vim(diagnostic.severity),
       message = diagnostic.message,
+      source = diagnostic.source,
       user_data = {
         lsp = {
           code = diagnostic.code,
@@ -132,6 +133,7 @@ local function diagnostic_vim_to_lsp(diagnostics)
       },
       severity = severity_vim_to_lsp(diagnostic.severity),
       message = diagnostic.message,
+      source = diagnostic.source,
     }, diagnostic.user_data and (diagnostic.user_data.lsp or {}) or {})
   end, diagnostics)
 end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -529,7 +529,7 @@ end
 ---@return an array of [text, hl_group] arrays. This can be passed directly to
 ---        the {virt_text} option of |nvim_buf_set_extmark()|.
 function M.get_virtual_text_chunks_for_line(bufnr, _, line_diags, opts)
-  return vim.diagnostic.get_virt_text_chunks(diagnostic_lsp_to_vim(line_diags, bufnr), opts)
+  return vim.diagnostic._get_virt_text_chunks(diagnostic_lsp_to_vim(line_diags, bufnr), opts)
 end
 
 --- Open a floating window with the diagnostics from {position}


### PR DESCRIPTION
Add an option to virtual text display and floating window previews to include diagnostic source in the diagnostic message.

Closes #15716.