### PR TITLE
refactor(tests): remove redir_exec

### DIFF
--- a/test/deprecated.lua
+++ b/test/deprecated.lua
@@ -1,0 +1,9 @@
+-- Island of Misfit Toys
+
+local M = {}
+
+function M.redir_exec()
+  error('redir_exec is deprecated, use nvim_exec() or helpers.exec_capture()')
+end
+
+return M

--- a/test/deprecated.lua
+++ b/test/deprecated.lua
@@ -3,7 +3,7 @@
 local M = {}
 
 function M.redir_exec()
-  error('redir_exec is deprecated, use nvim_exec() or helpers.exec_capture()')
+  error('redir_exec is deprecated, use nvim_exec() or pcall_err()')
 end
 
 return M

--- a/test/functional/autocmd/tabnewentered_spec.lua
+++ b/test/functional/autocmd/tabnewentered_spec.lua
@@ -7,7 +7,7 @@ local eval = helpers.eval
 local eq = helpers.eq
 local feed = helpers.feed
 local nvim = helpers.nvim
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 
 describe('TabNewEntered', function()
   describe('au TabNewEntered', function()
@@ -77,7 +77,6 @@ describe('tabpage/previous', function()
 
         eq(dedent([=[
 
-
           Tab page 1
               [No Name]
           Tab page 2
@@ -86,7 +85,7 @@ describe('tabpage/previous', function()
           >   [No Name]
           Tab page 4
           #   [No Name]]=]),
-           redir_exec('tabs')
+           exec_capture('tabs')
         )
 
         -- The previous tab is now the fourth.
@@ -117,7 +116,6 @@ describe('tabpage/previous', function()
       feed(characters)
       eq(dedent([=[
 
-
          Tab page 1
              [No Name]
          Tab page 2
@@ -128,7 +126,7 @@ describe('tabpage/previous', function()
              [No Name]
          Tab page 5
              [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the third.
@@ -161,7 +159,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
          #   [No Name]
          Tab page 2
@@ -170,7 +167,7 @@ describe('tabpage/previous', function()
              [No Name]
          Tab page 4
          >   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the first.
@@ -205,7 +202,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
          >   [No Name]
          Tab page 2
@@ -214,7 +210,7 @@ describe('tabpage/previous', function()
              [No Name]
          Tab page 4
          #   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the fourth.
@@ -247,7 +243,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
              [No Name]
          Tab page 2
@@ -256,7 +251,7 @@ describe('tabpage/previous', function()
          #   [No Name]
          Tab page 4
          >   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the third.
@@ -291,7 +286,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
          #   [No Name]
          Tab page 2
@@ -300,7 +294,7 @@ describe('tabpage/previous', function()
          >   [No Name]
          Tab page 4
              [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the first.
@@ -333,7 +327,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
              [No Name]
          Tab page 2
@@ -342,7 +335,7 @@ describe('tabpage/previous', function()
              [No Name]
          Tab page 4
          >   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the second.
@@ -377,7 +370,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
              [No Name]
          Tab page 2
@@ -386,7 +378,7 @@ describe('tabpage/previous', function()
              [No Name]
          Tab page 4
          #   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the fourth.
@@ -444,14 +436,13 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
              [No Name]
          Tab page 2
              [No Name]
          Tab page 3
          >   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
 
       -- The previous tab is now the "zero".
@@ -567,7 +558,6 @@ describe('tabpage/previous', function()
 
       eq(dedent([=[
 
-
          Tab page 1
              [No Name]
          Tab page 2
@@ -578,7 +568,7 @@ describe('tabpage/previous', function()
              [No Name]
          Tab page 4
          >   [No Name]]=]),
-         redir_exec('tabs')
+         exec_capture('tabs')
       )
   end)
 end)

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -8,7 +8,8 @@ local eq = helpers.eq
 local run = helpers.run
 local funcs = helpers.funcs
 local nvim_prog = helpers.nvim_prog
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
+local exec_capture = helpers.exec_capture
 local poke_eventloop = helpers.poke_eventloop
 
 describe('v:exiting', function()
@@ -52,7 +53,7 @@ end)
 describe(':cquit', function()
   local function test_cq(cmdline, exit_code, redir_msg)
     if redir_msg then
-      eq('\n' .. redir_msg, redir_exec(cmdline))
+      eq(redir_msg, pcall_err(function() return exec_capture(cmdline) end))
       poke_eventloop()
       assert_alive()
     else
@@ -86,14 +87,14 @@ describe(':cquit', function()
   end)
 
   it('exits with redir msg for multiple exit codes after :cquit 1 2', function()
-    test_cq('cquit 1 2', nil, 'E488: Trailing characters: cquit 1 2')
+    test_cq('cquit 1 2', nil, 'Vim(cquit):E488: Trailing characters: cquit 1 2')
   end)
 
   it('exits with redir msg for non-number exit code after :cquit X', function()
-    test_cq('cquit X', nil, 'E488: Trailing characters: cquit X')
+    test_cq('cquit X', nil, 'Vim(cquit):E488: Trailing characters: cquit X')
   end)
 
   it('exits with redir msg for negative exit code after :cquit -1', function()
-    test_cq('cquit -1', nil, 'E488: Trailing characters: cquit -1')
+    test_cq('cquit -1', nil, 'Vim(cquit):E488: Trailing characters: cquit -1')
   end)
 end)

--- a/test/functional/editor/jump_spec.lua
+++ b/test/functional/editor/jump_spec.lua
@@ -5,7 +5,7 @@ local command = helpers.command
 local eq = helpers.eq
 local funcs = helpers.funcs
 local feed = helpers.feed
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 local write_file = helpers.write_file
 
 describe('jumplist', function()
@@ -78,7 +78,7 @@ describe("jumpoptions=stack behaves like 'tagstack'", function()
     feed('<C-O>')
     feed('<C-O>')
 
-    eq(   '\n'
+    eq(   ''
        .. ' jump line  col file/text\n'
        .. '   4   102    0 \n'
        .. '   3     1    0 Line 1\n'
@@ -87,11 +87,11 @@ describe("jumpoptions=stack behaves like 'tagstack'", function()
        .. '>  0    30    0 Line 30\n'
        .. '   1    40    0 Line 40\n'
        .. '   2    50    0 Line 50',
-       redir_exec('jumps'))
+       exec_capture('jumps'))
 
     feed('90gg')
 
-    eq(   '\n'
+    eq(   ''
        .. ' jump line  col file/text\n'
        .. '   5   102    0 \n'
        .. '   4     1    0 Line 1\n'
@@ -99,14 +99,14 @@ describe("jumpoptions=stack behaves like 'tagstack'", function()
        .. '   2    20    0 Line 20\n'
        .. '   1    30    0 Line 30\n'
        .. '>',
-       redir_exec('jumps'))
+       exec_capture('jumps'))
   end)
 
   it('does not add the same location twice adjacently', function()
     feed('60gg')
     feed('60gg')
 
-    eq(   '\n'
+    eq(   ''
        .. ' jump line  col file/text\n'
        .. '   7   102    0 \n'
        .. '   6     1    0 Line 1\n'
@@ -116,14 +116,14 @@ describe("jumpoptions=stack behaves like 'tagstack'", function()
        .. '   2    40    0 Line 40\n'
        .. '   1    50    0 Line 50\n'
        .. '>',
-       redir_exec('jumps'))
+       exec_capture('jumps'))
   end)
 
   it('does add the same location twice nonadjacently', function()
     feed('10gg')
     feed('20gg')
 
-    eq(   '\n'
+    eq(   ''
        .. ' jump line  col file/text\n'
        .. '   8   102    0 \n'
        .. '   7     1    0 Line 1\n'
@@ -134,6 +134,6 @@ describe("jumpoptions=stack behaves like 'tagstack'", function()
        .. '   2    50    0 Line 50\n'
        .. '   1    10    0 Line 10\n'
        .. '>',
-       redir_exec('jumps'))
+       exec_capture('jumps'))
   end)
 end)

--- a/test/functional/ex_cmds/echo_spec.lua
+++ b/test/functional/ex_cmds/echo_spec.lua
@@ -10,7 +10,7 @@ local source = helpers.source
 local dedent = helpers.dedent
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 local matches = helpers.matches
 
 describe(':echo :echon :echomsg :echoerr', function()
@@ -199,10 +199,8 @@ describe(':echo :echon :echomsg :echoerr', function()
         let d.tdr = TestDictRef
       ]])
       eq(dedent([[
-
-          function('TestDict', {'tdr': function('TestDict', {...@1})})
           function('TestDict', {'tdr': function('TestDict', {...@1})})]]),
-         redir_exec('echo String(d.tdr)'))
+         exec_capture('echo String(d.tdr)'))
     end)
 
     it('dumps automatically created partials', function()
@@ -229,10 +227,8 @@ describe(':echo :echon :echomsg :echoerr', function()
     function()
       meths.set_var('d', {v=true})
       eq(dedent([[
-
-          {'p': function('<SNR>2_Test2', {...@0}), 'f': function('<SNR>2_Test2'), 'v': v:true}
           {'p': function('<SNR>2_Test2', {...@0}), 'f': function('<SNR>2_Test2'), 'v': v:true}]]),
-        redir_exec('echo String(extend(extend(g:d, {"f": g:Test2_f}), {"p": g:d.f}))'))
+        exec_capture('echo String(extend(extend(g:d, {"f": g:Test2_f}), {"p": g:d.f}))'))
     end)
 
     it('does not show errors when dumping partials referencing the same dictionary',
@@ -256,10 +252,8 @@ describe(':echo :echon :echomsg :echoerr', function()
       -- test/unit/api/private_helpers_spec.lua.
       eval('add(l, function("Test1", l))')
       eq(dedent([=[
-
-          function('Test1', [[[...@2], function('Test1', [[...@2]])], function('Test1', [[[...@4], function('Test1', [[...@4]])]])])
           function('Test1', [[[...@2], function('Test1', [[...@2]])], function('Test1', [[[...@4], function('Test1', [[...@4]])]])])]=]),
-        redir_exec('echo String(function("Test1", l))'))
+        exec_capture('echo String(function("Test1", l))'))
     end)
 
     it('does not crash or halt when dumping partials with reference cycles in self and arguments',
@@ -270,10 +264,8 @@ describe(':echo :echon :echomsg :echoerr', function()
       eval('add(l, function("Test1", l))')
       eval('add(l, function("Test1", d))')
       eq(dedent([=[
-
-          {'p': function('<SNR>2_Test2', [[[...@3], function('Test1', [[...@3]]), function('Test1', {...@0})], function('Test1', [[[...@5], function('Test1', [[...@5]]), function('Test1', {...@0})]]), function('Test1', {...@0})], {...@0}), 'f': function('<SNR>2_Test2'), 'v': v:true}
           {'p': function('<SNR>2_Test2', [[[...@3], function('Test1', [[...@3]]), function('Test1', {...@0})], function('Test1', [[[...@5], function('Test1', [[...@5]]), function('Test1', {...@0})]]), function('Test1', {...@0})], {...@0}), 'f': function('<SNR>2_Test2'), 'v': v:true}]=]),
-        redir_exec('echo String(extend(extend(g:d, {"f": g:Test2_f}), {"p": function(g:d.f, l)}))'))
+        exec_capture('echo String(extend(extend(g:d, {"f": g:Test2_f}), {"p": function(g:d.f, l)}))'))
     end)
   end)
 
@@ -303,8 +295,8 @@ describe(':echo :echon :echomsg :echoerr', function()
     it('dumps recursive lists without error', function()
       meths.set_var('l', {})
       eval('add(l, l)')
-      eq('\n[[...@0]]\n[[...@0]]', redir_exec('echo String(l)'))
-      eq('\n[[[...@1]]]\n[[[...@1]]]', redir_exec('echo String([l])'))
+      eq('[[...@0]]', exec_capture('echo String(l)'))
+      eq('[[[...@1]]]', exec_capture('echo String([l])'))
     end)
   end)
 
@@ -333,10 +325,10 @@ describe(':echo :echon :echomsg :echoerr', function()
     it('dumps recursive dictionaries without the error', function()
       meths.set_var('d', {d=1})
       eval('extend(d, {"d": d})')
-      eq('\n{\'d\': {...@0}}\n{\'d\': {...@0}}',
-         redir_exec('echo String(d)'))
-      eq('\n{\'out\': {\'d\': {...@1}}}\n{\'out\': {\'d\': {...@1}}}',
-         redir_exec('echo String({"out": d})'))
+      eq('{\'d\': {...@0}}',
+         exec_capture('echo String(d)'))
+      eq('{\'out\': {\'d\': {...@1}}}',
+         exec_capture('echo String({"out": d})'))
     end)
   end)
 

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -3,8 +3,7 @@ local lfs = require('lfs')
 local eq, eval, clear, write_file, source, insert =
   helpers.eq, helpers.eval, helpers.clear, helpers.write_file,
   helpers.source, helpers.insert
-local redir_exec = helpers.redir_exec
-local exc_exec = helpers.exc_exec
+local pcall_err = helpers.pcall_err
 local command = helpers.command
 local feed_command = helpers.feed_command
 local funcs = helpers.funcs
@@ -96,25 +95,24 @@ describe(':write', function()
     eq(funcs.fnamemodify('.', ':p:h'), funcs.fnamemodify('.', ':p:h:~'))
     -- Message from check_overwrite
     if not iswin() then
-      eq(('\nE17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
-        redir_exec('write .'))
+      eq(('Vim(write):E17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
+        pcall_err(command, 'write .'))
     end
     meths.set_option('writeany', true)
     -- Message from buf_write
-    eq(('\nE502: "." is a directory'),
-       redir_exec('write .'))
+    eq(('Vim(write):E502: "." is a directory'), pcall_err(command, 'write .'))
     funcs.mkdir(fname_bak)
     meths.set_option('backupdir', '.')
     meths.set_option('backup', true)
     write_file(fname, 'content0')
-    eq(0, exc_exec('edit ' .. fname))
+    command('edit ' .. fname)
     funcs.setline(1, 'TTY')
     eq('Vim(write):E510: Can\'t make backup file (add ! to override)',
-       exc_exec('write'))
+       pcall_err(command, 'write'))
     meths.set_option('backup', false)
     funcs.setfperm(fname, 'r--------')
     eq('Vim(write):E505: "Xtest-functional-ex_cmds-write" is read-only (add ! to override)',
-       exc_exec('write'))
+       pcall_err(command, 'write'))
     if iswin() then
       eq(0, os.execute('del /q/f ' .. fname))
       eq(0, os.execute('rd /q/s ' .. fname_bak))
@@ -127,6 +125,6 @@ describe(':write', function()
     if iswin() then return end
     lfs.link(fname_bak .. ('/xxxxx'):rep(20), fname, true)
     eq('Vim(write):E166: Can\'t open linked file for writing',
-       exc_exec('write!'))
+       pcall_err(command, 'write!'))
   end)
 end)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -785,19 +785,6 @@ function module.exec_lua(code, ...)
   return module.meths.exec_lua(code, {...})
 end
 
-function module.redir_exec(cmd)
-  module.meths.set_var('__redir_exec_cmd', cmd)
-  module.command([[
-    redir => g:__redir_exec_output
-      silent! execute g:__redir_exec_cmd
-    redir END
-  ]])
-  local ret = module.meths.get_var('__redir_exec_output')
-  module.meths.del_var('__redir_exec_output')
-  module.meths.del_var('__redir_exec_cmd')
-  return ret
-end
-
 function module.get_pathsep()
   return iswin() and '\\' or '/'
 end
@@ -893,7 +880,8 @@ function module.mkdir_p(path)
     or 'mkdir -p '..path))
 end
 
-module = global_helpers.tbl_extend('error', module, global_helpers)
+module = global_helpers.tbl_extend('error', module, global_helpers,
+  require('test.deprecated'))
 
 return function(after_each)
   if after_each then

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -880,8 +880,7 @@ function module.mkdir_p(path)
     or 'mkdir -p '..path))
 end
 
-module = global_helpers.tbl_extend('error', module, global_helpers,
-  require('test.deprecated'))
+module = global_helpers.tbl_extend('error', module, global_helpers)
 
 return function(after_each)
   if after_each then

--- a/test/functional/legacy/063_match_and_matchadd_spec.lua
+++ b/test/functional/legacy/063_match_and_matchadd_spec.lua
@@ -6,7 +6,7 @@ local Screen = require('test.functional.ui.screen')
 local eval, clear, command = helpers.eval, helpers.clear, helpers.command
 local eq, neq = helpers.eq, helpers.neq
 local insert = helpers.insert
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
 
 describe('063: Test for ":match", "matchadd()" and related functions', function()
   setup(clear)
@@ -67,9 +67,7 @@ describe('063: Test for ":match", "matchadd()" and related functions', function(
 
     -- matchdelete throws error and returns -1 on failure
     neq(true, pcall(function() eval('matchdelete(42)') end))
-    eq('\nE803: ID not found: 42',
-       redir_exec("let r2 = matchdelete(42)"))
-    eq(-1, eval('r2'))
+    eq('Vim(let):E803: ID not found: 42', pcall_err(command, 'let r2 = matchdelete(42)'))
 
     -- Check that "clearmatches()" clears all matches defined by ":match" and
     -- "matchadd()".
@@ -105,9 +103,8 @@ describe('063: Test for ":match", "matchadd()" and related functions', function(
     -- Check that "setmatches()" will not add two matches with the same ID. The
     -- expected behaviour (for now) is to add the first match but not the
     -- second and to return -1.
-    eq('\nE801: ID already taken: 1',
-       redir_exec("let r1 = setmatches([{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 1}, {'group': 'MyGroup2', 'pattern': 'FIXME', 'priority': 10, 'id': 1}])"))
-    eq(-1, eval("r1"))
+    eq('Vim(let):E801: ID already taken: 1',
+       pcall_err(command, "let r1 = setmatches([{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 1}, {'group': 'MyGroup2', 'pattern': 'FIXME', 'priority': 10, 'id': 1}])"))
     eq({{group = 'MyGroup1', pattern = 'TODO', priority = 10, id = 1}}, eval('getmatches()'))
 
     -- Check that "setmatches()" returns 0 if successful and otherwise -1.
@@ -116,14 +113,11 @@ describe('063: Test for ":match", "matchadd()" and related functions', function(
     eq(0,eval("setmatches([])"))
     eq(0,eval("setmatches([{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 1}])"))
     command("call clearmatches()")
-    eq('\nE714: List required', redir_exec("let rf1 = setmatches(0)"))
-    eq(-1, eval('rf1'))
-    eq('\nE474: List item 0 is either not a dictionary or an empty one',
-       redir_exec("let rf2 = setmatches([0])"))
-    eq(-1, eval('rf2'))
-    eq('\nE474: List item 0 is missing one of the required keys',
-       redir_exec("let rf3 = setmatches([{'wrong key': 'wrong value'}])"))
-    eq(-1, eval('rf3'))
+    eq('Vim(let):E714: List required', pcall_err(command, 'let rf1 = setmatches(0)'))
+    eq('Vim(let):E474: List item 0 is either not a dictionary or an empty one',
+       pcall_err(command, 'let rf2 = setmatches([0])'))
+    eq('Vim(let):E474: List item 0 is missing one of the required keys',
+       pcall_err(command, "let rf3 = setmatches([{'wrong key': 'wrong value'}])"))
 
     -- Check that "matchaddpos()" positions matches correctly
     insert('abcdefghijklmnopq')

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -3,7 +3,7 @@ local nvim = helpers.meths
 local clear, eq, neq = helpers.clear, helpers.eq, helpers.neq
 local curbuf, buf = helpers.curbuf, helpers.bufmeths
 local curwin = helpers.curwin
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 local source, command = helpers.source, helpers.command
 
 local function declare_hook_function()
@@ -102,13 +102,13 @@ local function get_new_window_number()
   local old_win = curwin()
   command('botright new')
   local new_win = curwin()
-  local new_winnr = redir_exec('echo winnr()')
+  local new_winnr = exec_capture('echo winnr()')
   command('wincmd p') -- move previous window
 
   neq(old_win, new_win)
   eq(old_win, curwin())
 
-  return new_winnr:gsub('\n', '')
+  return new_winnr
 end
 
 describe('au OptionSet', function()

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -15,14 +15,14 @@ local command = helpers.command
 local exc_exec = helpers.exc_exec
 local pcall_err = helpers.pcall_err
 local write_file = helpers.write_file
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 local curbufmeths = helpers.curbufmeths
 
 before_each(clear)
 
 describe(':lua command', function()
   it('works', function()
-    eq('', redir_exec(
+    eq('', exec_capture(
       'lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"TEST"})'))
     eq({'', 'TEST'}, curbufmeths.get_lines(0, 100, false))
     source(dedent([[
@@ -67,18 +67,19 @@ describe(':lua command', function()
     eq({'', 'ETTS', 'TTSE', 'STTE'}, curbufmeths.get_lines(0, 100, false))
   end)
   it('preserves global and not preserves local variables', function()
-    eq('', redir_exec('lua gvar = 42'))
-    eq('', redir_exec('lua local lvar = 100500'))
+    eq('', exec_capture('lua gvar = 42'))
+    eq('', exec_capture('lua local lvar = 100500'))
     eq(NIL, funcs.luaeval('lvar'))
     eq(42, funcs.luaeval('gvar'))
   end)
   it('works with long strings', function()
     local s = ('x'):rep(100500)
 
-    eq('\nE5107: Error loading lua [string ":lua"]:1: unfinished string near \'<eof>\'', redir_exec(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s})'):format(s)))
+    eq('Vim(lua):E5107: Error loading lua [string ":lua"]:0: unfinished string near \'<eof>\'',
+      pcall_err(command, ('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s})'):format(s)))
     eq({''}, curbufmeths.get_lines(0, -1, false))
 
-    eq('', redir_exec(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s"})'):format(s)))
+    eq('', exec_capture(('lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"%s"})'):format(s)))
     eq({'', s}, curbufmeths.get_lines(0, -1, false))
   end)
 
@@ -144,34 +145,34 @@ end)
 describe(':luado command', function()
   it('works', function()
     curbufmeths.set_lines(0, 1, false, {"ABC", "def", "gHi"})
-    eq('', redir_exec('luado lines = (lines or {}) lines[#lines + 1] = {linenr, line}'))
+    eq('', exec_capture('luado lines = (lines or {}) lines[#lines + 1] = {linenr, line}'))
     eq({'ABC', 'def', 'gHi'}, curbufmeths.get_lines(0, -1, false))
     eq({{1, 'ABC'}, {2, 'def'}, {3, 'gHi'}}, funcs.luaeval('lines'))
 
     -- Automatic transformation of numbers
-    eq('', redir_exec('luado return linenr'))
+    eq('', exec_capture('luado return linenr'))
     eq({'1', '2', '3'}, curbufmeths.get_lines(0, -1, false))
 
-    eq('', redir_exec('luado return ("<%02x>"):format(line:byte())'))
+    eq('', exec_capture('luado return ("<%02x>"):format(line:byte())'))
     eq({'<31>', '<32>', '<33>'}, curbufmeths.get_lines(0, -1, false))
   end)
   it('stops processing lines when suddenly out of lines', function()
     curbufmeths.set_lines(0, 1, false, {"ABC", "def", "gHi"})
-    eq('', redir_exec('2,$luado runs = ((runs or 0) + 1) vim.api.nvim_command("%d")'))
+    eq('', exec_capture('2,$luado runs = ((runs or 0) + 1) vim.api.nvim_command("%d")'))
     eq({''}, curbufmeths.get_lines(0, -1, false))
     eq(1, funcs.luaeval('runs'))
   end)
   it('works correctly when changing lines out of range', function()
     curbufmeths.set_lines(0, 1, false, {"ABC", "def", "gHi"})
-    eq('\nE322: line number out of range: 1 past the end\nE320: Cannot find line 2',
-       redir_exec('2,$luado vim.api.nvim_command("%d") return linenr'))
+    eq('Vim(luado):E322: line number out of range: 1 past the end',
+       pcall_err(command, '2,$luado vim.api.nvim_command("%d") return linenr'))
     eq({''}, curbufmeths.get_lines(0, -1, false))
   end)
   it('fails on errors', function()
-    eq([[Vim(luado):E5109: Error loading lua: [string ":luado"]:1: unexpected symbol near ')']],
-       exc_exec('luado ()'))
-    eq([[Vim(luado):E5111: Error calling lua: [string ":luado"]:1: attempt to perform arithmetic on global 'liness' (a nil value)]],
-       exc_exec('luado return liness + 1'))
+    eq([[Vim(luado):E5109: Error loading lua: [string ":luado"]:0: unexpected symbol near ')']],
+       pcall_err(command, 'luado ()'))
+    eq([[Vim(luado):E5111: Error calling lua: [string ":luado"]:0: attempt to perform arithmetic on global 'liness' (a nil value)]],
+       pcall_err(command, 'luado return liness + 1'))
   end)
   it('works with NULL errors', function()
     eq([=[Vim(luado):E5111: Error calling lua: [NULL]]=],
@@ -179,17 +180,18 @@ describe(':luado command', function()
   end)
   it('fails in sandbox when needed', function()
     curbufmeths.set_lines(0, 1, false, {"ABC", "def", "gHi"})
-    eq('\nE48: Not allowed in sandbox: sandbox luado runs = (runs or 0) + 1',
-       redir_exec('sandbox luado runs = (runs or 0) + 1'))
+    eq('Vim(luado):E48: Not allowed in sandbox',
+       pcall_err(command, 'sandbox luado runs = (runs or 0) + 1'))
     eq(NIL, funcs.luaeval('runs'))
   end)
   it('works with long strings', function()
     local s = ('x'):rep(100500)
 
-    eq('\nE5109: Error loading lua: [string ":luado"]:1: unfinished string near \'<eof>\'', redir_exec(('luado return "%s'):format(s)))
+    eq('Vim(luado):E5109: Error loading lua: [string ":luado"]:0: unfinished string near \'<eof>\'',
+      pcall_err(command, ('luado return "%s'):format(s)))
     eq({''}, curbufmeths.get_lines(0, -1, false))
 
-    eq('', redir_exec(('luado return "%s"'):format(s)))
+    eq('', exec_capture(('luado return "%s"'):format(s)))
     eq({s}, curbufmeths.get_lines(0, -1, false))
   end)
 end)
@@ -207,7 +209,7 @@ describe(':luafile', function()
         vim.api.nvim_buf_set_lines(1, 2, 3, false, {"TTSE"})
         vim.api.nvim_buf_set_lines(1, 3, 4, false, {"STTE"})
     ]])
-    eq('', redir_exec('luafile ' .. fname))
+    eq('', exec_capture('luafile ' .. fname))
     eq({'', 'ETTS', 'TTSE', 'STTE'}, curbufmeths.get_lines(0, 100, false))
   end)
 

--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -3,7 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local meths, curwinmeths, curbufmeths, nvim_command, funcs, eq =
   helpers.meths, helpers.curwinmeths, helpers.curbufmeths, helpers.command,
   helpers.funcs, helpers.eq
-local exc_exec, redir_exec = helpers.exc_exec, helpers.redir_exec
+local exc_exec, exec_capture = helpers.exc_exec, helpers.exec_capture
 
 local shada_helpers = require('test.functional.shada.helpers')
 local reset, clear = shada_helpers.reset, shada_helpers.clear
@@ -144,10 +144,10 @@ describe('ShaDa support code', function()
     nvim_command('normal! gg')
     nvim_command('enew')
     nvim_command('normal! gg')
-    local saved = redir_exec('jumps')
+    local saved = exec_capture('jumps')
     nvim_command('qall')
     reset()
-    eq(saved, redir_exec('jumps'))
+    eq(saved, exec_capture('jumps'))
   end)
 
   it('when dumping jump list also dumps current position', function()

--- a/test/functional/shada/merging_spec.lua
+++ b/test/functional/shada/merging_spec.lua
@@ -3,7 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local nvim_command, funcs, curbufmeths, eq =
   helpers.command, helpers.funcs,
   helpers.curbufmeths, helpers.eq
-local exc_exec, redir_exec = helpers.exc_exec, helpers.redir_exec
+local exc_exec, exec_capture = helpers.exc_exec, helpers.exec_capture
 
 local shada_helpers = require('test.functional.shada.helpers')
 local reset, clear, get_shada_rw =
@@ -910,14 +910,13 @@ describe('ShaDa jumps support code', function()
            .. '\008\007\018\131\162mX\195\161f\196\006' .. mock_file_path .. 'f\161l\002')
     eq(0, exc_exec(sdrcmd()))
     eq('', curbufmeths.get_name())
-    eq('\n'
-       .. ' jump line  col file/text\n'
+    eq(   ' jump line  col file/text\n'
        .. '   5     2    0 ' .. mock_file_path .. 'c\n'
        .. '   4     2    0 ' .. mock_file_path .. 'd\n'
        .. '   3     3    0 ' .. mock_file_path .. 'd\n'
        .. '   2     2    0 ' .. mock_file_path .. 'e\n'
        .. '   1     2    0 ' .. mock_file_path .. 'f\n'
-       .. '>', redir_exec('jumps'))
+       .. '>', exec_capture('jumps'))
   end)
 
   it('merges jumps when writing', function()
@@ -1001,14 +1000,13 @@ describe('ShaDa changes support code', function()
            .. '\011\004\018\131\162mX\195\161f\196\006' .. mock_file_path .. 'c\161l\005'
            .. '\011\008\018\131\162mX\195\161f\196\006' .. mock_file_path .. 'c\161l\004')
     eq(0, exc_exec(sdrcmd()))
-    eq('\n'
-       .. 'change line  col text\n'
+    eq(   'change line  col text\n'
        .. '    5     1    0 0\n'
        .. '    4     2    0 1\n'
        .. '    3     5    0 4\n'
        .. '    2     3    0 2\n'
        .. '    1     4    0 3\n'
-       .. '>', redir_exec('changes'))
+       .. '>', exec_capture('changes'))
   end)
 
   it('merges changes when writing', function()

--- a/test/functional/vimscript/changedtick_spec.lua
+++ b/test/functional/vimscript/changedtick_spec.lua
@@ -8,8 +8,8 @@ local funcs = helpers.funcs
 local meths = helpers.meths
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local redir_exec = helpers.redir_exec
 local pcall_err = helpers.pcall_err
+local exec_capture = helpers.exec_capture
 local curbufmeths = helpers.curbufmeths
 
 before_each(clear)
@@ -56,35 +56,35 @@ describe('b:changedtick', function()
     local ct = changedtick()
     local ctn = ct + 100500
     eq(0, exc_exec('let d = b:'))
-    eq('\nE46: Cannot change read-only variable "b:changedtick"',
-       redir_exec('let b:changedtick = ' .. ctn))
-    eq('\nE46: Cannot change read-only variable "b:["changedtick"]"',
-       redir_exec('let b:["changedtick"] = ' .. ctn))
-    eq('\nE46: Cannot change read-only variable "b:.changedtick"',
-       redir_exec('let b:.changedtick = ' .. ctn))
-    eq('\nE46: Cannot change read-only variable "d.changedtick"',
-       redir_exec('let d.changedtick = ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "b:changedtick"',
+       pcall_err(command, 'let b:changedtick = ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "b:["changedtick"]"',
+       pcall_err(command, 'let b:["changedtick"] = ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "b:.changedtick"',
+       pcall_err(command, 'let b:.changedtick = ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "d.changedtick"',
+       pcall_err(command, 'let d.changedtick = ' .. ctn))
     eq('Key is read-only: changedtick',
       pcall_err(curbufmeths.set_var, 'changedtick', ctn))
 
-    eq('\nE795: Cannot delete variable b:changedtick',
-       redir_exec('unlet b:changedtick'))
-    eq('\nE46: Cannot change read-only variable "b:.changedtick"',
-       redir_exec('unlet b:.changedtick'))
-    eq('\nE46: Cannot change read-only variable "b:["changedtick"]"',
-       redir_exec('unlet b:["changedtick"]'))
-    eq('\nE46: Cannot change read-only variable "d.changedtick"',
-       redir_exec('unlet d.changedtick'))
+    eq('Vim(unlet):E795: Cannot delete variable b:changedtick',
+       pcall_err(command, 'unlet b:changedtick'))
+    eq('Vim(unlet):E46: Cannot change read-only variable "b:.changedtick"',
+       pcall_err(command, 'unlet b:.changedtick'))
+    eq('Vim(unlet):E46: Cannot change read-only variable "b:["changedtick"]"',
+       pcall_err(command, 'unlet b:["changedtick"]'))
+    eq('Vim(unlet):E46: Cannot change read-only variable "d.changedtick"',
+       pcall_err(command, 'unlet d.changedtick'))
     eq('Key is read-only: changedtick',
       pcall_err(curbufmeths.del_var, 'changedtick'))
     eq(ct, changedtick())
 
-    eq('\nE46: Cannot change read-only variable "b:["changedtick"]"',
-       redir_exec('let b:["changedtick"] += ' .. ctn))
-    eq('\nE46: Cannot change read-only variable "b:["changedtick"]"',
-       redir_exec('let b:["changedtick"] -= ' .. ctn))
-    eq('\nE46: Cannot change read-only variable "b:["changedtick"]"',
-       redir_exec('let b:["changedtick"] .= ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "b:["changedtick"]"',
+       pcall_err(command, 'let b:["changedtick"] += ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "b:["changedtick"]"',
+       pcall_err(command, 'let b:["changedtick"] -= ' .. ctn))
+    eq('Vim(let):E46: Cannot change read-only variable "b:["changedtick"]"',
+       pcall_err(command, 'let b:["changedtick"] .= ' .. ctn))
 
     eq(ct, changedtick())
 
@@ -93,23 +93,22 @@ describe('b:changedtick', function()
     eq(ct + 1, changedtick())
   end)
   it('is listed in :let output', function()
-    eq('\nb:changedtick         #2',
-       redir_exec(':let b:'))
+    eq('b:changedtick         #2', exec_capture(':let b:'))
   end)
   it('fails to unlock b:changedtick', function()
     eq(0, exc_exec('let d = b:'))
     eq(0, funcs.islocked('b:changedtick'))
     eq(0, funcs.islocked('d.changedtick'))
-    eq('\nE940: Cannot lock or unlock variable b:changedtick',
-       redir_exec('unlockvar b:changedtick'))
-    eq('\nE46: Cannot change read-only variable "d.changedtick"',
-       redir_exec('unlockvar d.changedtick'))
+    eq('Vim(unlockvar):E940: Cannot lock or unlock variable b:changedtick',
+       pcall_err(command, 'unlockvar b:changedtick'))
+    eq('Vim(unlockvar):E46: Cannot change read-only variable "d.changedtick"',
+       pcall_err(command, 'unlockvar d.changedtick'))
     eq(0, funcs.islocked('b:changedtick'))
     eq(0, funcs.islocked('d.changedtick'))
-    eq('\nE940: Cannot lock or unlock variable b:changedtick',
-       redir_exec('lockvar b:changedtick'))
-    eq('\nE46: Cannot change read-only variable "d.changedtick"',
-       redir_exec('lockvar d.changedtick'))
+    eq('Vim(lockvar):E940: Cannot lock or unlock variable b:changedtick',
+       pcall_err(command, 'lockvar b:changedtick'))
+    eq('Vim(lockvar):E46: Cannot change read-only variable "d.changedtick"',
+       pcall_err(command, 'lockvar d.changedtick'))
     eq(0, funcs.islocked('b:changedtick'))
     eq(0, funcs.islocked('d.changedtick'))
   end)
@@ -119,24 +118,24 @@ describe('b:changedtick', function()
   end)
   it('cannot be changed by filter() or map()', function()
     eq(2, changedtick())
-    eq('\nE795: Cannot delete variable filter() argument',
-       redir_exec('call filter(b:, 0)'))
-    eq('\nE742: Cannot change value of map() argument',
-       redir_exec('call map(b:, 0)'))
-    eq('\nE742: Cannot change value of map() argument',
-       redir_exec('call map(b:, "v:val")'))
+    eq('Vim(call):E795: Cannot delete variable filter() argument',
+       pcall_err(command, 'call filter(b:, 0)'))
+    eq('Vim(call):E742: Cannot change value of map() argument',
+       pcall_err(command, 'call map(b:, 0)'))
+    eq('Vim(call):E742: Cannot change value of map() argument',
+       pcall_err(command, 'call map(b:, "v:val")'))
     eq(2, changedtick())
   end)
   it('cannot be remove()d', function()
     eq(2, changedtick())
-    eq('\nE795: Cannot delete variable remove() argument',
-       redir_exec('call remove(b:, "changedtick")'))
+    eq('Vim(call):E795: Cannot delete variable remove() argument',
+       pcall_err(command, 'call remove(b:, "changedtick")'))
     eq(2, changedtick())
   end)
   it('does not inherit VAR_FIXED when copying dictionary over', function()
     eq(2, changedtick())
-    eq('', redir_exec('let d1 = copy(b:)|let d1.changedtick = 42'))
-    eq('', redir_exec('let d2 = copy(b:)|unlet d2.changedtick'))
+    eq('', exec_capture('let d1 = copy(b:)|let d1.changedtick = 42'))
+    eq('', exec_capture('let d2 = copy(b:)|unlet d2.changedtick'))
     eq(2, changedtick())
   end)
 end)

--- a/test/functional/vimscript/ctx_functions_spec.lua
+++ b/test/functional/vimscript/ctx_functions_spec.lua
@@ -9,7 +9,7 @@ local feed = helpers.feed
 local map = helpers.tbl_map
 local nvim = helpers.nvim
 local parse_context = helpers.parse_context
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 local source = helpers.source
 local trim = helpers.trim
 local write_file = helpers.write_file
@@ -163,33 +163,29 @@ describe('context functions', function()
       endfunction
       ]])
 
-      eq('\nHello, World!', redir_exec([[call Greet('World')]]))
-      eq('\nHello, World!'..
+      eq('Hello, World!', exec_capture([[call Greet('World')]]))
+      eq('Hello, World!'..
          '\nHello, One!'..
          '\nHello, Two!'..
          '\nHello, Three!',
-         redir_exec([[call GreetAll('World', 'One', 'Two', 'Three')]]))
+         exec_capture([[call GreetAll('World', 'One', 'Two', 'Three')]]))
 
       call('SaveSFuncs')
       call('DeleteSFuncs')
 
-      eq('\nError detected while processing function Greet:'..
-         '\nline    1:'..
-         '\nE117: Unknown function: s:greet',
-         redir_exec([[call Greet('World')]]))
-      eq('\nError detected while processing function GreetAll:'..
-         '\nline    1:'..
-         '\nE117: Unknown function: s:greet_all',
-         redir_exec([[call GreetAll('World', 'One', 'Two', 'Three')]]))
+      eq('Vim(call):E117: Unknown function: s:greet',
+         pcall_err(command, [[call Greet('World')]]))
+      eq('Vim(call):E117: Unknown function: s:greet_all',
+         pcall_err(command, [[call GreetAll('World', 'One', 'Two', 'Three')]]))
 
       call('RestoreFuncs')
 
-      eq('\nHello, World!', redir_exec([[call Greet('World')]]))
-      eq('\nHello, World!'..
+      eq('Hello, World!', exec_capture([[call Greet('World')]]))
+      eq('Hello, World!'..
          '\nHello, One!'..
          '\nHello, Two!'..
          '\nHello, Three!',
-         redir_exec([[call GreetAll('World', 'One', 'Two', 'Three')]]))
+         exec_capture([[call GreetAll('World', 'One', 'Two', 'Three')]]))
     end)
 
     it('saves and restores functions properly', function()
@@ -206,12 +202,12 @@ describe('context functions', function()
       endfunction
       ]])
 
-      eq('\nHello, World!', redir_exec([[call Greet('World')]]))
-      eq('\nHello, World!'..
+      eq('Hello, World!', exec_capture([[call Greet('World')]]))
+      eq('Hello, World!'..
          '\nHello, One!'..
          '\nHello, Two!'..
          '\nHello, Three!',
-         redir_exec([[call GreetAll('World', 'One', 'Two', 'Three')]]))
+         exec_capture([[call GreetAll('World', 'One', 'Two', 'Three')]]))
 
       call('ctxpush', {'funcs'})
       command('delfunction Greet')
@@ -223,12 +219,12 @@ describe('context functions', function()
 
       call('ctxpop')
 
-      eq('\nHello, World!', redir_exec([[call Greet('World')]]))
-      eq('\nHello, World!'..
+      eq('Hello, World!', exec_capture([[call Greet('World')]]))
+      eq('Hello, World!'..
          '\nHello, One!'..
          '\nHello, Two!'..
          '\nHello, Three!',
-         redir_exec([[call GreetAll('World', 'One', 'Two', 'Three')]]))
+         exec_capture([[call GreetAll('World', 'One', 'Two', 'Three')]]))
     end)
 
     it('errors out when context stack is empty', function()

--- a/test/functional/vimscript/execute_spec.lua
+++ b/test/functional/vimscript/execute_spec.lua
@@ -3,7 +3,6 @@ local eq = helpers.eq
 local eval = helpers.eval
 local clear = helpers.clear
 local source = helpers.source
-local redir_exec = helpers.redir_exec
 local exc_exec = helpers.exc_exec
 local funcs = helpers.funcs
 local Screen = require('test.functional.ui.screen')
@@ -15,7 +14,14 @@ describe('execute()', function()
   before_each(clear)
 
   it('captures the same result as :redir', function()
-    eq(redir_exec('messages'), funcs.execute('messages'))
+    command([[
+      echomsg 'foo 1'
+      echomsg 'foo 2'
+      redir => g:__redir_output
+        silent! messages
+      redir END
+    ]])
+    eq(eval('g:__redir_output'), funcs.execute('messages'))
   end)
 
   it('captures the concatenated outputs of a List of commands', function()

--- a/test/functional/vimscript/json_functions_spec.lua
+++ b/test/functional/vimscript/json_functions_spec.lua
@@ -6,7 +6,7 @@ local eq = helpers.eq
 local eval = helpers.eval
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
 local NIL = helpers.NIL
 local source = helpers.source
 
@@ -517,9 +517,8 @@ describe('json_decode() function', function()
 
   it('does not overflow when writing error message about decoding ["", ""]',
   function()
-    eq('\nE474: Attempt to decode a blank string'
-       .. '\nE474: Failed to parse \n',
-       redir_exec('call json_decode(["", ""])'))
+    eq('Vim(call):E474: Attempt to decode a blank string',
+       pcall_err(command, 'call json_decode(["", ""])'))
   end)
 end)
 

--- a/test/functional/vimscript/let_spec.lua
+++ b/test/functional/vimscript/let_spec.lua
@@ -5,7 +5,7 @@ local clear = helpers.clear
 local command = helpers.command
 local eval = helpers.eval
 local meths = helpers.meths
-local redir_exec = helpers.redir_exec
+local exec_capture = helpers.exec_capture
 local source = helpers.source
 local nvim_dir = helpers.nvim_dir
 
@@ -14,14 +14,14 @@ before_each(clear)
 describe(':let', function()
   it('correctly lists variables with curly-braces', function()
     meths.set_var('v', {0})
-    eq('\nv                     [0]', redir_exec('let {"v"}'))
+    eq('v                     [0]', exec_capture('let {"v"}'))
   end)
 
   it('correctly lists variables with subscript', function()
     meths.set_var('v', {0})
-    eq('\nv[0]                  #0', redir_exec('let v[0]'))
-    eq('\ng:["v"][0]            #0', redir_exec('let g:["v"][0]'))
-    eq('\n{"g:"}["v"][0]        #0', redir_exec('let {"g:"}["v"][0]'))
+    eq('v[0]                  #0', exec_capture('let v[0]'))
+    eq('g:["v"][0]            #0', exec_capture('let g:["v"][0]'))
+    eq('{"g:"}["v"][0]        #0', exec_capture('let {"g:"}["v"][0]'))
   end)
 
   it(":unlet self-referencing node in a List graph #6070", function()

--- a/test/functional/vimscript/minmax_functions_spec.lua
+++ b/test/functional/vimscript/minmax_functions_spec.lua
@@ -2,29 +2,28 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local eq = helpers.eq
 local eval = helpers.eval
+local command = helpers.command
 local clear = helpers.clear
 local funcs = helpers.funcs
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
 
 before_each(clear)
 for _, func in ipairs({'min', 'max'}) do
   describe(func .. '()', function()
     it('gives a single error message when multiple values failed conversions',
     function()
-      eq('\nE745: Using a List as a Number\n0',
-         redir_exec('echo ' .. func .. '([-5, [], [], [], 5])'))
-      eq('\nE745: Using a List as a Number\n0',
-         redir_exec('echo ' .. func .. '({1:-5, 2:[], 3:[], 4:[], 5:5})'))
+      eq('Vim(echo):E745: Using a List as a Number',
+         pcall_err(command, 'echo ' .. func .. '([-5, [], [], [], 5])'))
+      eq('Vim(echo):E745: Using a List as a Number',
+         pcall_err(command, 'echo ' .. func .. '({1:-5, 2:[], 3:[], 4:[], 5:5})'))
       for errmsg, errinput in pairs({
-        ['E745: Using a List as a Number'] = '[]',
-        ['E805: Using a Float as a Number'] = '0.0',
-        ['E703: Using a Funcref as a Number'] = 'function("tr")',
-        ['E728: Using a Dictionary as a Number'] = '{}',
+        ['Vim(echo):E745: Using a List as a Number'] = '[]',
+        ['Vim(echo):E805: Using a Float as a Number'] = '0.0',
+        ['Vim(echo):E703: Using a Funcref as a Number'] = 'function("tr")',
+        ['Vim(echo):E728: Using a Dictionary as a Number'] = '{}',
       }) do
-        eq('\n' .. errmsg .. '\n0',
-           redir_exec('echo ' .. func .. '([' .. errinput .. '])'))
-        eq('\n' .. errmsg .. '\n0',
-           redir_exec('echo ' .. func .. '({1:' .. errinput .. '})'))
+        eq(errmsg, pcall_err(command, 'echo ' .. func .. '([' .. errinput .. '])'))
+        eq(errmsg, pcall_err(command, 'echo ' .. func .. '({1:' .. errinput .. '})'))
       end
     end)
     it('works with arrays/dictionaries with zero items', function()
@@ -42,9 +41,8 @@ for _, func in ipairs({'min', 'max'}) do
     it('errors out for invalid types', function()
       for _, errinput in ipairs({'1', 'v:true', 'v:false', 'v:null',
                                  'function("tr")', '""'}) do
-        eq(('\nE712: Argument of %s() must be a List or Dictionary\n0'):format(
-            func),
-           redir_exec('echo ' .. func .. '(' .. errinput .. ')'))
+        eq(('Vim(echo):E712: Argument of %s() must be a List or Dictionary'):format(func),
+           pcall_err(command, 'echo ' .. func .. '(' .. errinput .. ')'))
       end
     end)
   end)

--- a/test/functional/vimscript/null_spec.lua
+++ b/test/functional/vimscript/null_spec.lua
@@ -1,13 +1,25 @@
 local helpers = require('test.functional.helpers')(after_each)
 
 local curbufmeths = helpers.curbufmeths
-local redir_exec = helpers.redir_exec
 local exc_exec = helpers.exc_exec
 local command = helpers.command
 local clear = helpers.clear
 local meths = helpers.meths
 local funcs = helpers.funcs
 local eq = helpers.eq
+
+local function redir_exec(cmd)
+  meths.set_var('__redir_exec_cmd', cmd)
+  command([[
+    redir => g:__redir_exec_output
+      silent! execute g:__redir_exec_cmd
+    redir END
+  ]])
+  local ret = meths.get_var('__redir_exec_output')
+  meths.del_var('__redir_exec_output')
+  meths.del_var('__redir_exec_cmd')
+  return ret
+end
 
 describe('NULL', function()
   before_each(function()

--- a/test/functional/vimscript/sort_spec.lua
+++ b/test/functional/vimscript/sort_spec.lua
@@ -8,7 +8,7 @@ local meths = helpers.meths
 local funcs = helpers.funcs
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
 
 before_each(clear)
 
@@ -50,8 +50,7 @@ describe('sort()', function()
         return (a:a > a:b) - (a:a < a:b)
       endfunction
     ]])
-    eq('\nE745: Using a List as a Number\nE702: Sort compare function failed',
-       redir_exec('let sl = sort([1, 0, [], 3, 2], "Cmp")'))
-    eq({1, 0, {}, 3, 2}, meths.get_var('sl'))
+    eq('Vim(let):E745: Using a List as a Number',
+       pcall_err(command, 'let sl = sort([1, 0, [], 3, 2], "Cmp")'))
   end)
 end)

--- a/test/functional/vimscript/uniq_spec.lua
+++ b/test/functional/vimscript/uniq_spec.lua
@@ -2,10 +2,9 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local eq = helpers.eq
 local clear = helpers.clear
-local meths = helpers.meths
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
 
 before_each(clear)
 
@@ -24,8 +23,7 @@ describe('uniq()', function()
         return (a:a > a:b) - (a:a < a:b)
       endfunction
     ]])
-    eq('\nE745: Using a List as a Number\nE882: Uniq compare function failed',
-       redir_exec('let fl = uniq([0, 0, [], 1, 1], "Cmp")'))
-    eq({0, {}, 1, 1}, meths.get_var('fl'))
+    eq('Vim(let):E745: Using a List as a Number',
+       pcall_err(command, 'let fl = uniq([0, 0, [], 1, 1], "Cmp")'))
   end)
 end)

--- a/test/functional/vimscript/writefile_spec.lua
+++ b/test/functional/vimscript/writefile_spec.lua
@@ -8,7 +8,8 @@ local meths = helpers.meths
 local exc_exec = helpers.exc_exec
 local read_file = helpers.read_file
 local write_file = helpers.write_file
-local redir_exec = helpers.redir_exec
+local pcall_err = helpers.pcall_err
+local command = helpers.command
 
 local fname = 'Xtest-functional-eval-writefile'
 local dname = fname .. '.d'
@@ -106,51 +107,51 @@ describe('writefile()', function()
 
   it('shows correct file name when supplied numbers', function()
     meths.set_current_dir(dname)
-    eq('\nE482: Can\'t open file 2 for writing: illegal operation on a directory',
-       redir_exec(('call writefile([42], %s)'):format(ddname_tail)))
+    eq('Vim(call):E482: Can\'t open file 2 for writing: illegal operation on a directory',
+       pcall_err(command, ('call writefile([42], %s)'):format(ddname_tail)))
   end)
 
   it('errors out with invalid arguments', function()
     write_file(fname, 'TEST')
-    eq('\nE119: Not enough arguments for function: writefile',
-       redir_exec('call writefile()'))
-    eq('\nE119: Not enough arguments for function: writefile',
-       redir_exec('call writefile([])'))
-    eq('\nE118: Too many arguments for function: writefile',
-       redir_exec(('call writefile([], "%s", "b", 1)'):format(fname)))
+    eq('Vim(call):E119: Not enough arguments for function: writefile',
+       pcall_err(command, 'call writefile()'))
+    eq('Vim(call):E119: Not enough arguments for function: writefile',
+       pcall_err(command, 'call writefile([])'))
+    eq('Vim(call):E118: Too many arguments for function: writefile',
+       pcall_err(command, ('call writefile([], "%s", "b", 1)'):format(fname)))
     for _, arg in ipairs({'0', '0.0', 'function("tr")', '{}', '"test"'}) do
-      eq('\nE475: Invalid argument: writefile() first argument must be a List or a Blob',
-         redir_exec(('call writefile(%s, "%s", "b")'):format(arg, fname)))
+      eq('Vim(call):E475: Invalid argument: writefile() first argument must be a List or a Blob',
+         pcall_err(command, ('call writefile(%s, "%s", "b")'):format(arg, fname)))
     end
     for _, args in ipairs({'[], %s, "b"', '[], "' .. fname .. '", %s'}) do
-      eq('\nE806: using Float as a String',
-         redir_exec(('call writefile(%s)'):format(args:format('0.0'))))
-      eq('\nE730: using List as a String',
-         redir_exec(('call writefile(%s)'):format(args:format('[]'))))
-      eq('\nE731: using Dictionary as a String',
-         redir_exec(('call writefile(%s)'):format(args:format('{}'))))
-      eq('\nE729: using Funcref as a String',
-         redir_exec(('call writefile(%s)'):format(args:format('function("tr")'))))
+      eq('Vim(call):E806: using Float as a String',
+         pcall_err(command, ('call writefile(%s)'):format(args:format('0.0'))))
+      eq('Vim(call):E730: using List as a String',
+         pcall_err(command, ('call writefile(%s)'):format(args:format('[]'))))
+      eq('Vim(call):E731: using Dictionary as a String',
+         pcall_err(command, ('call writefile(%s)'):format(args:format('{}'))))
+      eq('Vim(call):E729: using Funcref as a String',
+         pcall_err(command, ('call writefile(%s)'):format(args:format('function("tr")'))))
     end
-    eq('\nE5060: Unknown flag: «»',
-       redir_exec(('call writefile([], "%s", "bs«»")'):format(fname)))
+    eq('Vim(call):E5060: Unknown flag: «»',
+       pcall_err(command, ('call writefile([], "%s", "bs«»")'):format(fname)))
     eq('TEST', read_file(fname))
   end)
 
   it('does not write to file if error in list', function()
     local args = '["tset"] + repeat([%s], 3), "' .. fname .. '"'
-    eq('\nE805: Expected a Number or a String, Float found',
-        redir_exec(('call writefile(%s)'):format(args:format('0.0'))))
+    eq('Vim(call):E805: Expected a Number or a String, Float found',
+        pcall_err(command, ('call writefile(%s)'):format(args:format('0.0'))))
     eq(nil, read_file(fname))
     write_file(fname, 'TEST')
-    eq('\nE745: Expected a Number or a String, List found',
-        redir_exec(('call writefile(%s)'):format(args:format('[]'))))
+    eq('Vim(call):E745: Expected a Number or a String, List found',
+        pcall_err(command, ('call writefile(%s)'):format(args:format('[]'))))
     eq('TEST', read_file(fname))
-    eq('\nE728: Expected a Number or a String, Dictionary found',
-        redir_exec(('call writefile(%s)'):format(args:format('{}'))))
+    eq('Vim(call):E728: Expected a Number or a String, Dictionary found',
+        pcall_err(command, ('call writefile(%s)'):format(args:format('{}'))))
     eq('TEST', read_file(fname))
-    eq('\nE703: Expected a Number or a String, Funcref found',
-        redir_exec(('call writefile(%s)'):format(args:format('function("tr")'))))
+    eq('Vim(call):E703: Expected a Number or a String, Funcref found',
+        pcall_err(command, ('call writefile(%s)'):format(args:format('function("tr")'))))
     eq('TEST', read_file(fname))
   end)
 end)

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -810,6 +810,6 @@ function module.read_nvim_log(logfile, ci_rename)
   return log
 end
 
-module = shared.tbl_extend('error', module, Paths, shared)
+module = shared.tbl_extend('error', module, Paths, shared, require('test.deprecated'))
 
 return module


### PR DESCRIPTION
Problem
-------

- `redir_exec` is obsolete, but it keeps getting used in new tests because people copy existing tests.
- Disadvantages of `redir_exec`:
  - Captures extra junk before the actual error/message that we _want_ to test.
  - Does not fail on error, unlike e.g. `command()`.

Solution
--------

- Use new functions like `nvim_exec` and `pcall_err`.