### PR TITLE
fix(diagnostic): clamp line numbers in display layer

### DIFF
--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -842,6 +842,18 @@ describe('vim.diagnostic', function()
         return #vim.api.nvim_buf_get_lines(popup_bufnr, 0, -1, false)
       ]])
     end)
+
+    it('clamps diagnostic line numbers within the valid range', function()
+      eq(1, exec_lua [[
+        local diagnostics = {
+          make_error("Syntax error", 6, 0, 6, 0),
+        }
+        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+        local popup_bufnr, winnr = vim.diagnostic.show_line_diagnostics({show_header = false}, diagnostic_bufnr, 5)
+        return #vim.api.nvim_buf_get_lines(popup_bufnr, 0, -1, false)
+      ]])
+    end)
   end)
 
   describe('set_signs()', function()


### PR DESCRIPTION
Some parts of LSP need to use cached diagnostics as sent from the LSP server unmodified. Rather than fixing invalid line numbers when diagnostics are first set, fix them when they are displayed to the user (e.g. in `show()` or one of the `get_next`/`get_prev` family of functions).

Closes #15591.
Ref #15616.