### PR TITLE
fix(diagnostic): preserve fields from LSP diagnostics

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -103,10 +103,14 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
       end_col = line_byte_from_position(buf_lines, _end.line, _end.character, offset_encoding),
       severity = severity_lsp_to_vim(diagnostic.severity),
       message = diagnostic.message,
-      code = diagnostic.code,
-      codeDescription = diagnostic.codeDescription,
-      tags = diagnostic.tags,
-      relatedInformation = diagnostic.relatedInformation,
+      user_data = {
+        lsp = {
+          code = diagnostic.code,
+          codeDescription = diagnostic.codeDescription,
+          tags = diagnostic.tags,
+          relatedInformation = diagnostic.relatedInformation,
+        },
+      },
     }
   end, diagnostics)
 end
@@ -114,7 +118,7 @@ end
 ---@private
 local function diagnostic_vim_to_lsp(diagnostics)
   return vim.tbl_map(function(diagnostic)
-    return {
+    return vim.tbl_extend("error", {
       range = {
         start = {
           line = diagnostic.lnum,
@@ -127,11 +131,7 @@ local function diagnostic_vim_to_lsp(diagnostics)
       },
       severity = severity_vim_to_lsp(diagnostic.severity),
       message = diagnostic.message,
-      code = diagnostic.code,
-      codeDescription = diagnostic.codeDescription,
-      tags = diagnostic.tags,
-      relatedInformation = diagnostic.relatedInformation,
-    }
+    }, diagnostic.user_data and (diagnostic.user_data.lsp or {}) or {})
   end, diagnostics)
 end
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -102,7 +102,11 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
       end_lnum = _end.line,
       end_col = line_byte_from_position(buf_lines, _end.line, _end.character, offset_encoding),
       severity = severity_lsp_to_vim(diagnostic.severity),
-      message = diagnostic.message
+      message = diagnostic.message,
+      code = diagnostic.code,
+      codeDescription = diagnostic.codeDescription,
+      tags = diagnostic.tags,
+      relatedInformation = diagnostic.relatedInformation,
     }
   end, diagnostics)
 end
@@ -123,6 +127,10 @@ local function diagnostic_vim_to_lsp(diagnostics)
       },
       severity = severity_vim_to_lsp(diagnostic.severity),
       message = diagnostic.message,
+      code = diagnostic.code,
+      codeDescription = diagnostic.codeDescription,
+      tags = diagnostic.tags,
+      relatedInformation = diagnostic.relatedInformation,
     }
   end, diagnostics)
 end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -109,6 +109,7 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
           codeDescription = diagnostic.codeDescription,
           tags = diagnostic.tags,
           relatedInformation = diagnostic.relatedInformation,
+          data = diagnostic.data,
         },
       },
     }

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -428,6 +428,30 @@ describe('vim.lsp.diagnostic', function()
         end)
       end)
     end)
+
+    it('maintains LSP information when translating diagnostics', function()
+      local result = exec_lua [[
+        local diagnostics = {
+          make_error("Error 1", 1, 1, 1, 5),
+        }
+
+        diagnostics[1].code = 42
+        diagnostics[1].tags = {"foo", "bar"}
+
+        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
+          uri = fake_uri,
+          diagnostics = diagnostics,
+        }, {client_id=1})
+
+        return {
+          vim.diagnostic.get(diagnostic_bufnr, {lnum=1})[1],
+          vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1)[1],
+        }
+      ]]
+      eq({code = 42, tags = {"foo", "bar"}}, result[1].user_data.lsp)
+      eq(42, result[2].code)
+      eq({"foo", "bar"}, result[2].tags)
+    end)
   end)
 
   describe("vim.lsp.diagnostic.get_line_diagnostics", function()

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -437,6 +437,7 @@ describe('vim.lsp.diagnostic', function()
 
         diagnostics[1].code = 42
         diagnostics[1].tags = {"foo", "bar"}
+        diagnostics[1].data = "Hello world"
 
         vim.lsp.diagnostic.on_publish_diagnostics(nil, {
           uri = fake_uri,
@@ -448,9 +449,10 @@ describe('vim.lsp.diagnostic', function()
           vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1)[1],
         }
       ]]
-      eq({code = 42, tags = {"foo", "bar"}}, result[1].user_data.lsp)
+      eq({code = 42, tags = {"foo", "bar"}, data = "Hello world"}, result[1].user_data.lsp)
       eq(42, result[2].code)
       eq({"foo", "bar"}, result[2].tags)
+      eq("Hello world", result[2].data)
     end)
   end)
 


### PR DESCRIPTION
Closes #15733.

(Note that the `source` field is already added in #15717).