### PR TITLE
build: Add ${CMAKE_THREAD_LIBS_INIT} to LIBUV_LIBRARIES

### DIFF
--- a/cmake/FindLibUV.cmake
+++ b/cmake/FindLibUV.cmake
@@ -75,6 +75,13 @@ if(WIN32)
   list(APPEND LIBUV_LIBRARIES ws2_32)
 endif()
 
+if(Threads_FOUND)
+  # TODO: Fix the cmake file to properly handle static deps for bundled builds.
+  # Meanwhile just include the threads library if CMake tells us there's one to
+  # use.
+  list(APPEND LIBUV_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 include(FindPackageHandleStandardArgs)
 
 # handle the QUIETLY and REQUIRED arguments and set LIBUV_FOUND to TRUE


### PR DESCRIPTION
This is a workaround for not yet having fully correct `Find*` cmake modules for static builds (c.f., https://github.com/Tronic/cmake-modules/issues/3#issuecomment-624469020)

Cc @clason