### PR TITLE
fix(init.lua): set $MYVIMRC to absolute path during startup

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2112,7 +2112,7 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
     verbose_leave();
   }
   if (is_vimrc == DOSO_VIMRC) {
-    vimrc_found(fname_exp, (char_u *)"MYVIMRC");
+    vimrc_found((char *)fname_exp, "MYVIMRC");
   }
 
 #ifdef USE_CRNL

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1781,23 +1781,23 @@ static bool do_user_initialization(void)
   }
 
   char_u *init_lua_path = (char_u *)stdpaths_user_conf_subpath("init.lua");
+  char_u *user_vimrc = (char_u *)stdpaths_user_conf_subpath("init.vim");
+
+  // init.lua
   if (os_path_exists(init_lua_path)
       && do_source(init_lua_path, true, DOSO_VIMRC)) {
-    os_setenv("MYVIMRC", (const char *)init_lua_path, 1);
-    char_u *vimrc_path = (char_u *)stdpaths_user_conf_subpath("init.vim");
-
-    if (os_path_exists(vimrc_path)) {
+    if (os_path_exists(user_vimrc)) {
       EMSG3(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua_path,
-            vimrc_path);
+            user_vimrc);
     }
 
-    xfree(vimrc_path);
+    xfree(user_vimrc);
     xfree(init_lua_path);
     return false;
   }
   xfree(init_lua_path);
 
-  char_u *user_vimrc = (char_u *)stdpaths_user_conf_subpath("init.vim");
+  // init.vim
   if (do_source(user_vimrc, true, DOSO_VIMRC) != FAIL) {
     do_exrc = p_exrc;
     if (do_exrc) {
@@ -1809,6 +1809,7 @@ static bool do_user_initialization(void)
     return do_exrc;
   }
   xfree(user_vimrc);
+
   char *const config_dirs = stdpaths_get_xdg_var(kXDGConfigDirs);
   if (config_dirs != NULL) {
     const void *iter = NULL;
@@ -1839,6 +1840,7 @@ static bool do_user_initialization(void)
     } while (iter != NULL);
     xfree(config_dirs);
   }
+
   if (execute_env("EXINIT") == OK) {
     do_exrc = p_exrc;
     return do_exrc;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6888,15 +6888,15 @@ static void paste_option_changed(void)
 ///
 /// Set the values for options that didn't get set yet to the defaults.
 /// When "fname" is not NULL, use it to set $"envname" when it wasn't set yet.
-void vimrc_found(char_u *fname, char_u *envname)
+void vimrc_found(char *fname, char *envname)
 {
   if (fname != NULL && envname != NULL) {
-    char *p = vim_getenv((char *)envname);
+    char *p = vim_getenv(envname);
     if (p == NULL) {
       // Set $MYVIMRC to the first vimrc file found.
-      p = FullName_save((char *)fname, false);
+      p = FullName_save(fname, false);
       if (p != NULL) {
-        os_setenv((char *)envname, p, 1);
+        os_setenv(envname, p, 1);
         xfree(p);
       }
     } else {

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -472,7 +472,7 @@ describe('user config init', function()
     clear{ args_rm={'-u' }, env=xenv }
 
     eq(1, eval('g:lua_rc'))
-    eq(init_lua_path, eval('$MYVIMRC'))
+    eq(funcs.fnamemodify(init_lua_path, ':p'), eval('$MYVIMRC'))
   end)
 
   describe 'with explicitly provided config'(function()


### PR DESCRIPTION
- main.c: remove os_setenv("MYVIMRC",…), it is already done by  do_source().
  - This also sets $MYVIMRC to a full (absolute) path.
- code cleanup.