### PR TITLE
build(deps)!: bump libuv to 1.42.0 on windows

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -144,14 +144,8 @@ endif()
 
 include(ExternalProject)
 
-if(WIN32)
-  # "nvim" branch of https://github.com/neovim/libuv
-  set(LIBUV_URL https://github.com/neovim/libuv/archive/b899d12b0d56d217f31222da83f8c398355b69ef.tar.gz)
-  set(LIBUV_SHA256 eb7e37b824887e1b31a4e31d1d9bad4c03d8b98532d9cce5f67a3b70495a4b2a)
-else()
-  set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.42.0.tar.gz)
-  set(LIBUV_SHA256 371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764)
-endif()
+set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.42.0.tar.gz)
+set(LIBUV_SHA256 371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764)
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0/msgpack-3.0.0.tar.gz)
 set(MSGPACK_SHA256 bfbb71b7c02f806393bc3cbc491b40523b89e64f83860c58e3e54af47de176e4)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -146,8 +146,8 @@ include(ExternalProject)
 
 if(WIN32)
   # "nvim" branch of https://github.com/neovim/libuv
-  set(LIBUV_URL https://github.com/neovim/libuv/archive/c124607c8893126f2e769c30e03f5d8d665f46a2.tar.gz)
-  set(LIBUV_SHA256 0d54303baba85dc30d099976317abfcf4f4533d9aeb9d629c031a7ca5142bdb5)
+  set(LIBUV_URL https://github.com/clason/libuv/archive/fd70ae175f6d204e8b12018158b22901f8378719.tar.gz)
+  set(LIBUV_SHA256 b331c5c306398f8d62cdf985f93f6ec9973d3cfda285968da230ea609f0a7d9f)
 else()
   set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.42.0.tar.gz)
   set(LIBUV_SHA256 371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -144,8 +144,14 @@ endif()
 
 include(ExternalProject)
 
-set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.42.0.tar.gz)
-set(LIBUV_SHA256 371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764)
+if(WIN32)
+  # "nvim" branch of https://github.com/neovim/libuv
+  set(LIBUV_URL https://github.com/neovim/libuv/archive/b899d12b0d56d217f31222da83f8c398355b69ef.tar.gz)
+  set(LIBUV_SHA256 eb7e37b824887e1b31a4e31d1d9bad4c03d8b98532d9cce5f67a3b70495a4b2a)
+else()
+  set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.42.0.tar.gz)
+  set(LIBUV_SHA256 371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764)
+endif()
 
 set(MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/cpp-3.0.0/msgpack-3.0.0.tar.gz)
 set(MSGPACK_SHA256 bfbb71b7c02f806393bc3cbc491b40523b89e64f83860c58e3e54af47de176e4)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -146,8 +146,8 @@ include(ExternalProject)
 
 if(WIN32)
   # "nvim" branch of https://github.com/neovim/libuv
-  set(LIBUV_URL https://github.com/neovim/libuv/archive/b899d12b0d56d217f31222da83f8c398355b69ef.tar.gz)
-  set(LIBUV_SHA256 eb7e37b824887e1b31a4e31d1d9bad4c03d8b98532d9cce5f67a3b70495a4b2a)
+  set(LIBUV_URL https://github.com/neovim/libuv/archive/c124607c8893126f2e769c30e03f5d8d665f46a2.tar.gz)
+  set(LIBUV_SHA256 0d54303baba85dc30d099976317abfcf4f4533d9aeb9d629c031a7ca5142bdb5)
 else()
   set(LIBUV_URL https://github.com/libuv/libuv/archive/v1.42.0.tar.gz)
   set(LIBUV_SHA256 371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764)


### PR DESCRIPTION
remove the ancient pinned commit for LibUV on Windows to align with other platforms

see discussion on #15740 

BREAKING CHANGE: drops support for Windows 7