### PR TITLE
feat(lsp): use lua-cjson for built-in language server client

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -830,7 +830,7 @@ function lsp.start_client(config)
     rpc.request('initialize', initialize_params, function(init_err, result)
       assert(not init_err, tostring(init_err))
       assert(result, "server sent empty result")
-      rpc.notify('initialized', {[vim.type_idx]=vim.types.dictionary})
+      rpc.notify('initialized', vim.empty_dict())
       client.initialized = true
       uninitialized_clients[client_id] = nil
       client.workspaceFolders = initialize_params.workspaceFolders

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -11,7 +11,7 @@ local validate, schedule, schedule_wrap = vim.validate, vim.schedule, vim.schedu
 ---@param data (table) Data to encode
 ---@returns (string) Encoded object
 local function json_encode(data)
-  local status, result = pcall(vim.fn.json_encode, data)
+  local status, result = pcall(vim.json.encode, data)
   if status then
     return result
   else
@@ -24,7 +24,7 @@ end
 ---@param data (string) Data to decode
 ---@returns (table) Decoded JSON object
 local function json_decode(data)
-  local status, result = pcall(vim.fn.json_decode, data)
+  local status, result = pcall(vim.json.decode, data)
   if status then
     return result
   else
@@ -394,11 +394,8 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
   local function encode_and_send(payload)
     local _ = log.debug() and log.debug("rpc.send", payload)
     if handle == nil or handle:is_closing() then return false end
-    -- TODO(ashkan) remove this once we have a Lua json_encode
-    schedule(function()
-      local encoded = assert(json_encode(payload))
-      stdin:write(format_message_with_content_length(encoded))
-    end)
+    local encoded = assert(json_encode(payload))
+    stdin:write(format_message_with_content_length(encoded))
     return true
   end
 
@@ -582,8 +579,6 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
       on_error(client_errors.INVALID_SERVER_MESSAGE, decoded)
     end
   end
-  -- TODO(ashkan) remove this once we have a Lua json_decode
-  handle_body = schedule_wrap(handle_body)
 
   local request_parser = coroutine.wrap(request_parser_loop)
   request_parser()

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -43,11 +43,11 @@ end
 local function read_message()
   local line = io.read("*l")
   local length = line:lower():match("content%-length:%s*(%d+)")
-  return vim.fn.json_decode(io.read(2 + length):sub(2))
+  return vim.json.decode(io.read(2 + length):sub(2))
 end
 
 local function send(payload)
-  io.stdout:write(format_message_with_content_length(vim.fn.json_encode(payload)))
+  io.stdout:write(format_message_with_content_length(vim.json.encode(payload)))
 end
 
 local function respond(id, err, result)


### PR DESCRIPTION
Now that we have `vim.json`, this removes the need to schedule `vim.fn.json_encode/decode` and improves the general performance of the json decoder in the the case of large responses (typescript server completions, for one) on the order of 2.5-5x.