### PR TITLE
fix(diagnostic): don't return nil when callers expect a table

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -249,7 +249,7 @@ end
 ---@private
 local function diagnostic_lines(diagnostics)
   if not diagnostics then
-    return
+    return {}
   end
 
   local diagnostics_by_line = {}


### PR DESCRIPTION
`diagnostic_lines()` returns a table, so make the early exit condition an empty table rather than `nil`. This way functions that use the return value from `diagnostic_lines` don't have to do a bunch of defensive nil checking and can always assume they're operating on a table.

Closes #15763.