### PR TITLE
feat(lua): allow passing handles to `vim.b/w/t`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -928,6 +928,7 @@ Example: >
     vim.g.foo = 5     -- Set the g:foo Vimscript variable.
     print(vim.g.foo)  -- Get and print the g:foo Vimscript variable.
     vim.g.foo = nil   -- Delete (:unlet) the Vimscript variable.
+    vim.b[2].foo = 6  -- Set b:foo for buffer 2
 
 vim.g                                                   *vim.g*
         Global (|g:|) editor variables.
@@ -935,15 +936,18 @@ vim.g                                                   *vim.g*
 
 vim.b                                                   *vim.b*
         Buffer-scoped (|b:|) variables for the current buffer.
-        Invalid or unset key returns `nil`.
+        Invalid or unset key returns `nil`. Can be indexed with
+        an integer to access variables for a specific buffer.
 
 vim.w                                                   *vim.w*
         Window-scoped (|w:|) variables for the current window.
-        Invalid or unset key returns `nil`.
+        Invalid or unset key returns `nil`. Can be indexed with
+        an integer to access variables for a specific window.
 
 vim.t                                                   *vim.t*
         Tabpage-scoped (|t:|) variables for the current tabpage.
-        Invalid or unset key returns `nil`.
+        Invalid or unset key returns `nil`. Can be indexed with
+        an integer to access variables for a specific tabpage.
 
 vim.v                                                   *vim.v*
         |v:| variables.

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -323,22 +323,25 @@ end
 do
   local validate = vim.validate
 
-  local function make_dict_accessor(scope)
+  local function make_dict_accessor(scope, handle)
     validate {
       scope = {scope, 's'};
     }
     local mt = {}
     function mt:__newindex(k, v)
-      return vim._setvar(scope, 0, k, v)
+      return vim._setvar(scope, handle or 0, k, v)
     end
     function mt:__index(k)
-      return vim._getvar(scope, 0, k)
+      if handle == nil and type(k) == 'number' then
+        return make_dict_accessor(scope, k)
+      end
+      return vim._getvar(scope, handle or 0, k)
     end
     return setmetatable({}, mt)
   end
 
-  vim.g = make_dict_accessor('g')
-  vim.v = make_dict_accessor('v')
+  vim.g = make_dict_accessor('g', false)
+  vim.v = make_dict_accessor('v', false)
   vim.b = make_dict_accessor('b')
   vim.w = make_dict_accessor('w')
   vim.t = make_dict_accessor('t')


### PR DESCRIPTION
`vim.bo` can target a specific buffer by indexing with a number, e.g: `vim.bo[2].filetype` can get/set the filetype for buffer 2. This change replicates that behaviour for the variable namespace.
