### PR TITLE
fix(lsp) Wrap `textDocument/codeAction` command logic in conditional

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -143,12 +143,14 @@ M['textDocument/codeAction'] = function(_, result, ctx)
   if action.edit then
     util.apply_workspace_edit(action.edit)
   end
-  local command = type(action.command) == 'table' and action.command or action
-  local fn = vim.lsp.commands[command.command]
-  if fn then
-    fn(command, ctx)
-  else
-    buf.execute_command(command)
+  if action.command then
+    local command = type(action.command) == 'table' and action.command or action
+    local fn = vim.lsp.commands[command.command]
+    if fn then
+      fn(command, ctx)
+    else
+      buf.execute_command(command)
+    end
   end
 end
 


### PR DESCRIPTION
This is a follow-up to the work done in
https://github.com/neovim/neovim/commit/6c03601e3adb4c3c4d47f148df8df20401b88677.
There are valid situations where a `textDocument/codeAction` is returned
without a command, since a command in optional. For example from Metals,
the Scala language server when you get a code action to add a missing
import, it looks like this:

```json
[Trace - 03:19:15 PM] Sending response 'textDocument/codeAction - (58)'. Processing request took 133ms
Result: [
  {
    "title": "Import \u0027Instant\u0027 from package \u0027java.time\u0027",
    "kind": "quickfix",
    "diagnostics": [
      {
        "range": {
          "start": {
            "line": 6,
            "character": 10
          },
          "end": {
            "line": 6,
            "character": 17
          }
        },
        "severity": 1,
        "source": "bloop",
        "message": "not found: value Instant"
      }
    ],
    "edit": {
      "changes": {
        "file:///Users/ckipp/Documents/scala-workspace/sanity/src/main/scala/Thing.scala": [
          {
            "range": {
              "start": {
                "line": 6,
                "character": 10
              },
              "end": {
                "line": 6,
                "character": 17
              }
            },
            "newText": "Instant"
          },
          {
            "range": {
              "start": {
                "line": 1,
                "character": 0
              },
              "end": {
                "line": 1,
                "character": 0
              }
            },
            "newText": "\nimport java.time.Instant\n"
          }
        ]
      }
    }
  }
]
```

This change just wraps the logic that grabs the command in a conditional
to skip it if there is no command.