### PR TITLE
fix(diagnostic): check for nil in show_diagnostics

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -379,7 +379,7 @@ end
 ---@param diagnostics table: The diagnostics to display
 ---@return table {popup_bufnr, win_id}
 local function show_diagnostics(opts, diagnostics)
-  if vim.tbl_isempty(diagnostics) then
+  if not diagnostics or vim.tbl_isempty(diagnostics) then
     return
   end
   local lines = {}


### PR DESCRIPTION
#15765 fixes some cases by returning an empty table rather than nil, but that table is [being indexed in show_diagnostics](https://github.com/neovim/neovim/blob/057606e845f36df045466af2821244026b6cf0f3/runtime/lua/vim/diagnostic.lua#L1138), so we still end up with `nil`. I should have caught this; my mistake.

I was eventually able to reproduce #15763 and can confirm that this *actually* fixes it.
