### PR TITLE
Add macos-11 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unixish:
-    name: ${{ matrix.os }} ${{ matrix.flavor }} (cc=${{ matrix.cc }})
+    name: ${{ matrix.runner }} ${{ matrix.flavor }} (cc=${{ matrix.cc }})
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +83,7 @@ jobs:
           path: |
             ${{ env.CACHE_NVIM_DEPS_DIR }}
             ~/.ccache
-          key: ${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.cc }}-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
+          key: ${{ matrix.runner }}-${{ matrix.flavor }}-${{ matrix.cc }}-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
 
       - name: Build third-party
         run: ./ci/before_script.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           - cc: clang
             runner: macos-10.15
             os: osx
+          - cc: clang
+            runner: macos-11.0
+            os: osx
           - flavor: functionaltest-lua
             cc: gcc
             runner: ubuntu-20.04


### PR DESCRIPTION
I'm not sure how much difference we should expect between 10.15 and 11, but I figure we can start with both jobs and prune 10.15 later.

10.15 is still used for the release job, under the "build using oldest available image" pragma.