### PR TITLE
refactor(diagnostic): use sign priority for severity_sort

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -187,6 +187,11 @@ can be customized using the following: >
 	sign define DiagnosticSignInfo text=I texthl=DiagnosticSignInfo linehl= numhl=
 	sign define DiagnosticSignHint text=H texthl=DiagnosticSignHint linehl= numhl=
 
+When the "severity_sort" option is set (see |vim.diagnostic.config()|) the
+priority of each sign depends on the severity of the associated diagnostic.
+Otherwise, all signs have the same priority (the value of the "priority"
+option in the "signs" table of |vim.diagnostic.config()| or 10 if unset).
+
 ==============================================================================
 EVENTS							*diagnostic-events*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -794,6 +794,8 @@ end
 ---@param bufnr number Buffer number
 ---@param diagnostics table A list of diagnostic items |diagnostic-structure|. When omitted the
 ---                       current diagnostics in the given buffer are used.
+---@param opts table Configuration table with the following keys:
+---            - priority: Set the priority of the signs |sign-priority|.
 ---@private
 function M._set_signs(namespace, bufnr, diagnostics, opts)
   vim.validate {
@@ -814,20 +816,22 @@ function M._set_signs(namespace, bufnr, diagnostics, opts)
 
   define_default_signs()
 
+  -- 10 is the default sign priority when none is explicitly specified
+  local priority = opts.signs and opts.signs.priority or 10
   local get_priority
   if opts.severity_sort then
     if type(opts.severity_sort) == "table" and opts.severity_sort.reverse then
       get_priority = function(severity)
-        return severity - vim.diagnostic.severity.ERROR
+        return priority + (severity - vim.diagnostic.severity.ERROR)
       end
     else
       get_priority = function(severity)
-        return vim.diagnostic.severity.HINT - severity
+        return priority + (vim.diagnostic.severity.HINT - severity)
       end
     end
   else
     get_priority = function()
-      return 0
+      return priority
     end
   end
 
@@ -838,7 +842,7 @@ function M._set_signs(namespace, bufnr, diagnostics, opts)
       sign_highlight_map[diagnostic.severity],
       bufnr,
       {
-        priority = 10 + get_priority(diagnostic.severity),
+        priority = get_priority(diagnostic.severity),
         lnum = diagnostic.lnum + 1
       }
     )


### PR DESCRIPTION
Rather than relying on the order in which signs are placed to dictate the order in which they are displayed, explicitly set the priority of the sign according to the severity of the diagnostic and the value of `severity_sort`. If `severity_sort` is false or unset then all signs use the same priority.
