### PR TITLE
diagnostics: Show how to override default handlers in docs (WAS: Only show one sign per severity per line)

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -201,7 +201,52 @@ DiagnosticsChanged	After diagnostics have changed.
 Example: >
 	autocmd User DiagnosticsChanged lua vim.diagnostic.setqflist({open = false })
 <
+==============================================================================
+CUSTOMIZATION						*diagnostic-config*
 
+If you need more customization over the way diagnostics are displayed than the
+built-in configuration options provide, you can override the display handler
+explicitly. For example, use the following to only show a sign for the highest
+severity diagnostic on a given line: >
+
+	-- Disable the default signs handler
+	vim.diagnostic.config({signs = false})
+
+	-- Create a namespace. This won't be used to add any diagnostics,
+	-- only to display them.
+	local ns = vim.api.nvim_create_namespace("my_namespace")
+
+	-- Create a reference to the original function
+	local orig_show = vim.diagnostic.show
+
+	local function set_signs(bufnr)
+	  -- Get all diagnostics from the current buffer
+	  local diagnostics = vim.diagnostic.get(bufnr)
+
+	  -- Find the "worst" diagnostic per line
+	  local max_severity_per_line = {}
+	  for _, d in pairs(diagnostics) do
+	    local m = max_severity_per_line[d.lnum]
+	    if not m or d.severity < m.severity then
+	      max_severity_per_line[d.lnum] = d
+	    end
+	  end
+
+	  -- Show the filtered diagnostics using the custom namespace. Use the
+	  -- reference to the original function to avoid a loop.
+	  local filtered_diagnostics = vim.tbl_values(max_severity_per_line)
+	  orig_show(ns, bufnr, filtered_diagnostics, {
+	    virtual_text=false,
+	    underline=false,
+	    signs=true
+	  })
+	end
+
+	function vim.diagnostic.show(namespace, bufnr, ...)
+	  orig_show(namespace, bufnr, ...)
+	  set_signs(bufnr)
+	end
+<
 ==============================================================================
 Lua module: vim.diagnostic                                    *diagnostic-api*
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -874,6 +874,26 @@ describe('vim.diagnostic', function()
         return count_extmarks(diagnostic_bufnr, diagnostic_ns)
       ]])
     end)
+
+    it('sets signs', function()
+      local result = exec_lua [[
+        vim.diagnostic.config({
+          signs = true,
+        })
+
+        local diagnostics = {
+          make_error('Error', 1, 1, 1, 2),
+          make_warning('Warning', 3, 3, 3, 3),
+        }
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+
+        return vim.fn.sign_getplaced(diagnostic_bufnr, {group = '*'})[1].signs
+      ]]
+
+      eq({2, 'DiagnosticSignError'}, {result[1].lnum, result[1].name})
+      eq({4, 'DiagnosticSignWarn'}, {result[2].lnum, result[2].name})
+    end)
   end)
 
   describe('show_line_diagnostics()', function()
@@ -991,37 +1011,6 @@ describe('vim.diagnostic', function()
         local lines = vim.api.nvim_buf_get_lines(popup_bufnr, 0, -1, false)
         vim.api.nvim_win_close(winnr, true)
         return lines
-      ]])
-    end)
-  end)
-
-  describe('set_signs()', function()
-    -- TODO(tjdevries): Find out why signs are not displayed when set from Lua...??
-    pending('sets signs by default', function()
-      exec_lua [[
-        vim.diagnostic.config({
-          update_in_insert = true,
-          signs = true,
-        })
-
-        local diagnostics = {
-          make_error('Delayed Diagnostic', 1, 1, 1, 2),
-          make_error('Delayed Diagnostic', 3, 3, 3, 3),
-        }
-
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-
-        vim.diagnostic._set_signs(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        -- return vim.fn.sign_getplaced()
-      ]]
-
-      nvim("input", "o")
-      nvim("input", "<esc>")
-
-      -- TODO(tjdevries): Find a way to get the signs to display in the test...
-      eq(nil, exec_lua [[
-        return im.fn.sign_getplaced()[1].signs
       ]])
     end)
   end)


### PR DESCRIPTION
Closes #15770.

Also include documentation on how to customize/replace the built-in decoration/display handlers.
