### PR TITLE
chore(tui): remove obsolete code

### DIFF
--- a/src/nvim/os/tty.c
+++ b/src/nvim/os/tty.c
@@ -23,15 +23,6 @@
 /// @param out_fd stdout file descriptor
 void os_tty_guess_term(const char **term, int out_fd)
 {
-  bool winpty = (os_getenv("NVIM") != NULL);
-
-  if (winpty) {
-    // Force TERM=win32con when running in winpty.
-    *term = "win32con";
-    uv_tty_set_vterm_state(UV_TTY_UNSUPPORTED);
-    return;
-  }
-
   bool conemu_ansi = strequal(os_getenv("ConEmuANSI"), "ON");
   bool vtp = false;
 


### PR DESCRIPTION
Initially, we planned to set the `NVIM` environment variable to detect that neovim is running in the neovim built-in terminal. At the time this code was written, there was no way for a parent to set environment variables for a program running in an embedded terminal. Later it was implemented in  #12937, but the code to set the `NVIM` was not added. #11390 now uses `ConPTY` instead of `winpty` when possible, so it is no longer necessary to force the use of `win32con` even when running inside an embedded terminal. Therefore, we now do not need this code.

fixes #15787.