### PR TITLE
fix(diagnostics): avoid cryptic error

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1136,6 +1136,10 @@ function M.show_line_diagnostics(opts, bufnr, lnum)
   clamp_line_numbers(bufnr, diagnostics)
   lnum = lnum or (vim.api.nvim_win_get_cursor(0)[1] - 1)
   local line_diagnostics = diagnostic_lines(diagnostics)[lnum]
+  if line_diagnostics == nil then
+    vim.api.nvim_echo({{"No valid diagnostics to show", "WarningMsg"}}, true, {})
+    return
+  end
   return show_diagnostics(opts, line_diagnostics)
 end
 


### PR DESCRIPTION
Problem:
    Running vim.lsp.diagnostic.show_line_diagnostics() on a line that has no lsp diagnostics 
    prompts the user with a cryptic error, about a table being nil.

Solution:
   Prompt user with an informative error.