### PR TITLE
feat(lsp): allow subset of CodeActionContext as arg to code_action methods

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -869,12 +869,17 @@ clear_references()                            *vim.lsp.buf.clear_references()*
                 Removes document highlights from current buffer.
 
 code_action({context})                             *vim.lsp.buf.code_action()*
-                Selects a code action from the input list that is available at
-                the current cursor position.
+                Selects a code action available at the current cursor
+                position.
 
                 Parameters: ~
-                    {context}  (table, optional) Valid `CodeActionContext`
-                               object
+                    {context}  table|nil `CodeActionContext` of the LSP specification:
+                               • diagnostics: (table|nil) LSP`Diagnostic[]` . Inferred from the current position if not
+                                 provided.
+                               • only: (string|nil) LSP `CodeActionKind` used
+                                 to filter the code actions. Most language
+                                 servers support values like `refactor` or
+                                 `quickfix` .
 
                 See also: ~
                     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
@@ -1015,8 +1020,13 @@ range_code_action({context}, {start_pos}, {end_pos})
                 Performs |vim.lsp.buf.code_action()| for a given range.
 
                 Parameters: ~
-                    {context}    (table, optional) Valid `CodeActionContext`
-                                 object
+                    {context}    table|nil `CodeActionContext` of the LSP specification:
+                                 • diagnostics: (table|nil) LSP`Diagnostic[]` . Inferred from the current position if not
+                                   provided.
+                                 • only: (string|nil) LSP `CodeActionKind`
+                                   used to filter the code actions. Most
+                                   language servers support values like
+                                   `refactor` or `quickfix` .
                     {start_pos}  ({number, number}, optional) mark-indexed
                                  position. Defaults to the start of the last
                                  visual selection.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -480,8 +480,10 @@ end
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 function M.code_action(context)
   validate { context = { context, 't', true } }
-  local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
-  context = vim.tbl_deep_extend('keep', context or {}, { diagnostics = diagnostics })
+  context = context or {}
+  if not context.diagnostics then
+    context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
+  end
   local params = util.make_range_params()
   params.context = context
   code_action_request(params)
@@ -504,8 +506,10 @@ end
 ---Defaults to the end of the last visual selection.
 function M.range_code_action(context, start_pos, end_pos)
   validate { context = { context, 't', true } }
-  local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
-  context = vim.tbl_deep_extend('keep', context or {}, { diagnostics = diagnostics })
+  context = context or {}
+  if not context.diagnostics then
+    context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
+  end
   local params = util.make_given_range_params(start_pos, end_pos)
   params.context = context
   code_action_request(params)

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -466,14 +466,22 @@ local function code_action_request(params)
   end)
 end
 
---- Selects a code action from the input list that is available at the current
+--- Selects a code action available at the current
 --- cursor position.
 ---
----@param context: (table, optional) Valid `CodeActionContext` object
+---@param context table|nil `CodeActionContext` of the LSP specification:
+---               - diagnostics: (table|nil)
+---                             LSP `Diagnostic[]`. Inferred from the current
+---                             position if not provided.
+---               - only: (string|nil)
+---                      LSP `CodeActionKind` used to filter the code actions.
+---                      Most language servers support values like `refactor`
+---                      or `quickfix`.
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 function M.code_action(context)
   validate { context = { context, 't', true } }
-  context = context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
+  local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
+  context = vim.tbl_deep_extend('keep', context or {}, { diagnostics = diagnostics })
   local params = util.make_range_params()
   params.context = context
   code_action_request(params)
@@ -481,14 +489,23 @@ end
 
 --- Performs |vim.lsp.buf.code_action()| for a given range.
 ---
----@param context: (table, optional) Valid `CodeActionContext` object
+---
+---@param context table|nil `CodeActionContext` of the LSP specification:
+---               - diagnostics: (table|nil)
+---                             LSP `Diagnostic[]`. Inferred from the current
+---                             position if not provided.
+---               - only: (string|nil)
+---                      LSP `CodeActionKind` used to filter the code actions.
+---                      Most language servers support values like `refactor`
+---                      or `quickfix`.
 ---@param start_pos ({number, number}, optional) mark-indexed position.
 ---Defaults to the start of the last visual selection.
 ---@param end_pos ({number, number}, optional) mark-indexed position.
 ---Defaults to the end of the last visual selection.
 function M.range_code_action(context, start_pos, end_pos)
   validate { context = { context, 't', true } }
-  context = context or { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
+  local diagnostics = vim.lsp.diagnostic.get_line_diagnostics()
+  context = vim.tbl_deep_extend('keep', context or {}, { diagnostics = diagnostics })
   local params = util.make_given_range_params(start_pos, end_pos)
   params.context = context
   code_action_request(params)


### PR DESCRIPTION
This makes it easier to filter the code actions. For example:

    vim.lsp.buf.code_action { only = 'refactor' }
