### PR TITLE
refactor(lint): apply clang-tidy fixes (1)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ TabWidth: 2
 UseTab: Never
 IndentCaseLabels: true
 BreakBeforeBraces: Linux
-AlignEscapedNewlinesLeft: false
+AlignEscapedNewlines: DontAlign
 AllowShortFunctionsOnASingleLine: false
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 2
@@ -17,4 +17,5 @@ AllowShortLoopsOnASingleLine: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: true
 BreakBeforeTernaryOperators: true
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 2
+

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -631,7 +631,7 @@ static void remote_ui_raw_line(UI *ui, Integer grid, Integer row, Integer startc
       remote_ui_highlight_set(ui, (int)clearattr);
       // legacy eol_clear was only ever used with cleared attributes
       // so be on the safe side
-      if (clearattr == 0 && clearcol == Columns) {
+      if (clearattr == 0 && clearcol == g_columns) {
         Array args = ARRAY_DICT_INIT;
         push_call(ui, "eol_clear", args);
       } else {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2826,8 +2826,8 @@ Array nvim__inspect_cell(Integer grid, Integer row, Integer col, Error *err)
     }
   }
 
-  if (row < 0 || row >= g->Rows
-      || col < 0 || col >= g->Columns) {
+  if (row < 0 || row >= g->g_rows
+      || col < 0 || col >= g->g_columns) {
     return ret;
   }
   size_t off = g->line_offset[(size_t)row] + (size_t)col;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3226,7 +3226,7 @@ void maketitle(void)
 
   if (p_title) {
     if (p_titlelen > 0) {
-      maxlen = (int)(p_titlelen * Columns / 100);
+      maxlen = (int)(p_titlelen * g_columns / 100);
       if (maxlen < 10) {
         maxlen = 10;
       }
@@ -4823,7 +4823,7 @@ void do_arg_all(int count, int forceit, int keep_tabs)
       wpnext = wp->w_next;
       buf = wp->w_buffer;
       if (buf->b_ffname == NULL
-          || (!keep_tabs && (buf->b_nwindows > 1 || wp->w_width != Columns))) {
+          || (!keep_tabs && (buf->b_nwindows > 1 || wp->w_width != g_columns))) {
         i = opened_len;
       } else {
         // check if the buffer in this window is in the arglist
@@ -5072,9 +5072,9 @@ void ex_buffer_all(exarg_T *eap)
       wpnext = wp->w_next;
       if ((wp->w_buffer->b_nwindows > 1
            || ((cmdmod.split & WSP_VERT)
-               ? wp->w_height + wp->w_status_height < Rows - p_ch
+               ? wp->w_height + wp->w_status_height < g_rows - p_ch
                - tabline_height()
-               : wp->w_width != Columns)
+               : wp->w_width != g_columns)
            || (had_tab > 0 && wp != firstwin))
           && !ONE_WINDOW
           && !(wp->w_closing ||

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -941,8 +941,8 @@ struct tabpage_S {
   win_T           *tp_prevwin;      ///< previous window in this Tab page
   win_T           *tp_firstwin;     ///< first window in this Tab page
   win_T           *tp_lastwin;      ///< last window in this Tab page
-  long tp_old_Rows;                 ///< Rows when Tab page was left
-  long tp_old_Columns;              ///< Columns when Tab page was left
+  long tp_old_rows;                 ///< Rows when Tab page was left
+  long tp_old_columns;              ///< Columns when Tab page was left
   long tp_ch_used;                  ///< value of 'cmdheight' when frame size
                                     ///< was set
 

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -58,7 +58,7 @@ void change_warning(buf_T *buf, int col)
     // Do what msg() does, but with a column offset if the warning should
     // be after the mode message.
     msg_start();
-    if (msg_row == Rows - 1) {
+    if (msg_row == g_rows - 1) {
       msg_col = col;
     }
     msg_source(HL_ATTR(HLF_W));
@@ -73,7 +73,7 @@ void change_warning(buf_T *buf, int col)
     }
     buf->b_did_warn = true;
     redraw_cmdline = false;  // don't redraw and erase the message
-    if (msg_row < Rows - 1) {
+    if (msg_row < g_rows - 1) {
       showmode();
     }
   }

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -268,7 +268,7 @@ void do_debug(char_u *cmd)
                        DOCMD_VERBOSE|DOCMD_EXCRESET);
       debug_break_level = n;
     }
-    lines_left = (int)(Rows - 1);
+    lines_left = (int)(g_rows - 1);
   }
   xfree(cmdline);
 
@@ -277,7 +277,7 @@ void do_debug(char_u *cmd)
   redraw_all_later(NOT_VALID);
   need_wait_return = false;
   msg_scroll = save_msg_scroll;
-  lines_left = (int)(Rows - 1);
+  lines_left = (int)(g_rows - 1);
   State = save_State;
   debug_mode = false;
   did_emsg = save_did_emsg;

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1768,7 +1768,7 @@ static void printdigraph(const digr_T *dp, result_T *previous)
       }
       *previous = dp->result;
     }
-    if (msg_col > Columns - list_width) {
+    if (msg_col > g_columns - list_width) {
       msg_putchar('\n');
     }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1592,7 +1592,7 @@ void edit_putchar(int c, bool highlight)
     pc_col = 0;
     pc_status = PC_STATUS_UNSET;
     if (curwin->w_p_rl) {
-      pc_col += curwin->w_grid.Columns - 1 - curwin->w_wcol;
+      pc_col += curwin->w_grid.g_columns - 1 - curwin->w_wcol;
       const int fix_col = grid_fix_col(&curwin->w_grid, pc_col, pc_row);
 
       if (fix_col != pc_col) {
@@ -1706,7 +1706,7 @@ void display_dollar(colnr_T col)
   char_u *p = get_cursor_line_ptr();
   curwin->w_cursor.col -= utf_head_off(p, p + col);
   curs_columns(curwin, false);              // Recompute w_wrow and w_wcol
-  if (curwin->w_wcol < curwin->w_grid.Columns) {
+  if (curwin->w_wcol < curwin->w_grid.g_columns) {
     edit_putchar('$', false);
     dollar_vcol = curwin->w_virtcol;
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7329,8 +7329,8 @@ void screenchar_adjust_grid(ScreenGrid **grid, int *row, int *col)
   // have its own buffer, this should just read from it instead.
   msg_scroll_flush();
   if (msg_grid.chars && msg_grid.comp_index > 0 && *row >= msg_grid.comp_row
-      && *row < (msg_grid.Rows + msg_grid.comp_row)
-      && *col < msg_grid.Columns) {
+      && *row < (msg_grid.g_rows + msg_grid.comp_row)
+      && *col < msg_grid.g_columns) {
     *grid = &msg_grid;
     *row -= msg_grid.comp_row;
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4979,8 +4979,8 @@ static void f_inputlist(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   msg_start();
-  msg_row = Rows - 1;   // for when 'cmdheight' > 1
-  lines_left = Rows;    // avoid more prompt
+  msg_row = g_rows - 1;   // for when 'cmdheight' > 1
+  lines_left = g_rows;    // avoid more prompt
   msg_scroll = true;
   msg_clr_eos();
 
@@ -8223,8 +8223,8 @@ static void f_screenattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   int row = (int)tv_get_number_chk(&argvars[0], NULL) - 1;
   int col = (int)tv_get_number_chk(&argvars[1], NULL) - 1;
-  if (row < 0 || row >= default_grid.Rows
-      || col < 0 || col >= default_grid.Columns) {
+  if (row < 0 || row >= default_grid.g_rows
+      || col < 0 || col >= default_grid.g_columns) {
     c = -1;
   } else {
     ScreenGrid *grid = &default_grid;
@@ -8241,8 +8241,8 @@ static void f_screenchar(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   int row = tv_get_number_chk(&argvars[0], NULL) - 1;
   int col = tv_get_number_chk(&argvars[1], NULL) - 1;
-  if (row < 0 || row >= default_grid.Rows
-      || col < 0 || col >= default_grid.Columns) {
+  if (row < 0 || row >= default_grid.g_rows
+      || col < 0 || col >= default_grid.g_columns) {
     c = -1;
   } else {
     ScreenGrid *grid = &default_grid;
@@ -8257,8 +8257,8 @@ static void f_screenchars(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   int row = tv_get_number_chk(&argvars[0], NULL) - 1;
   int col = tv_get_number_chk(&argvars[1], NULL) - 1;
-  if (row < 0 || row >= default_grid.Rows
-      || col < 0 || col >= default_grid.Columns) {
+  if (row < 0 || row >= default_grid.g_rows
+      || col < 0 || col >= default_grid.g_columns) {
     tv_list_alloc_ret(rettv, 0);
     return;
   }
@@ -8324,8 +8324,8 @@ static void f_screenstring(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->v_type = VAR_STRING;
   int row = tv_get_number_chk(&argvars[0], NULL) - 1;
   int col = tv_get_number_chk(&argvars[1], NULL) - 1;
-  if (row < 0 || row >= default_grid.Rows
-      || col < 0 || col >= default_grid.Columns) {
+  if (row < 0 || row >= default_grid.g_rows
+      || col < 0 || col >= default_grid.g_columns) {
     return;
   }
   ScreenGrid *grid = &default_grid;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2229,7 +2229,7 @@ void ex_function(exarg_T *eap)
       line_to_free = theline;
     }
     if (KeyTyped) {
-      lines_left = Rows - 1;
+      lines_left = g_rows - 1;
     }
     if (theline == NULL) {
       EMSG(_("E126: Missing :endfunction"));

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1350,7 +1350,7 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char_u *cmd,
 
   // Create the shell command in allocated memory.
   cmd_buf = make_filter_cmd(cmd, itmp, otmp);
-  ui_cursor_goto(Rows - 1, 0);
+  ui_cursor_goto(g_rows - 1, 0);
 
   if (do_out) {
     if (u_save((line2), (linenr_T)(line2 + 1)) == FAIL) {
@@ -1516,7 +1516,7 @@ void do_shell(char_u *cmd, int flags)
 
   // put the message cursor at the end of the screen, avoids wait_return()
   // to overwrite the text that the external command showed
-  msg_row = Rows - 1;
+  msg_row = g_rows - 1;
   msg_col = 0;
 
   apply_autocmds(EVENT_SHELLCMDPOST, NULL, NULL, false, curbuf);
@@ -2976,7 +2976,7 @@ void ex_append(exarg_T *eap)
                              NUL, eap->cookie, indent, true);
       State = save_State;
     }
-    lines_left = Rows - 1;
+    lines_left = g_rows - 1;
     if (theline == NULL) {
       break;
     }
@@ -3088,7 +3088,7 @@ void ex_z(exarg_T *eap)
   // Vi compatible: ":z!" uses display height, without a count uses
   // 'scroll'
   if (eap->forceit) {
-    bigness = Rows - 1;
+    bigness = g_rows - 1;
   } else if (ONE_WINDOW) {
     bigness = curwin->w_p_scr * 2;
   } else {
@@ -3189,7 +3189,7 @@ void ex_z(exarg_T *eap)
     if (minus && i == lnum) {
       msg_putchar('\n');
 
-      for (j = 1; j < Columns; j++) {
+      for (j = 1; j < g_columns; j++) {
         msg_putchar('-');
       }
     }
@@ -3199,7 +3199,7 @@ void ex_z(exarg_T *eap)
     if (minus && i == lnum) {
       msg_putchar('\n');
 
-      for (j = 1; j < Columns; j++) {
+      for (j = 1; j < g_columns; j++) {
         msg_putchar('-');
       }
     }
@@ -3903,7 +3903,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
               redraw_later(curwin, SOME_VALID);
 
               curwin->w_p_fen = save_p_fen;
-              if (msg_row == Rows - 1) {
+              if (msg_row == g_rows - 1) {
                 msg_didout = false;                     // avoid a scroll-up
               }
               msg_starthere();
@@ -4846,7 +4846,7 @@ void ex_help(exarg_T *eap)
        * specified, the current window is vertically split and
        * narrow. */
       n = WSP_HELP;
-      if (cmdmod.split == 0 && curwin->w_width != Columns
+      if (cmdmod.split == 0 && curwin->w_width != g_columns
           && curwin->w_width < 80) {
         n |= WSP_TOP;
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -223,7 +223,7 @@ void do_exmode(void)
     prev_line = curwin->w_cursor.lnum;
     cmdline_row = msg_row;
     do_cmdline(NULL, getexline, NULL, 0);
-    lines_left = Rows - 1;
+    lines_left = g_rows - 1;
 
     if ((prev_line != curwin->w_cursor.lnum
          || changedtick != buf_get_changedtick(curbuf)) && !ex_no_reprint) {
@@ -234,7 +234,7 @@ void do_exmode(void)
           /* go up one line, to overwrite the ":<CR>" line, so the
            * output doesn't contain empty lines. */
           msg_row = prev_msg_row;
-          if (prev_msg_row == Rows - 1) {
+          if (prev_msg_row == g_rows - 1) {
             msg_row--;
           }
         }
@@ -5466,7 +5466,7 @@ static void uc_list(char_u *name, size_t name_len)
       msg_outtrans(IObuff);
 
       msg_outtrans_special(cmd->uc_rep, false,
-                           name_len == 0 ? Columns - 47 : 0);
+                           name_len == 0 ? g_columns - 47 : 0);
       if (p_verbose > 0) {
         last_set_msg(cmd->uc_script_ctx);
       }
@@ -6864,8 +6864,8 @@ static void ex_stop(exarg_T *eap)
   apply_autocmds(EVENT_VIMSUSPEND, NULL, NULL, false, NULL);
 
   // TODO(bfredl): the TUI should do this on suspend
-  ui_cursor_goto(Rows - 1, 0);
-  ui_call_grid_scroll(1, 0, Rows, 0, Columns, 1, 0);
+  ui_cursor_goto(g_rows - 1, 0);
+  ui_call_grid_scroll(1, 0, g_rows, 0, g_columns, 1, 0);
   ui_flush();
   ui_call_suspend();  // call machine specific function
 
@@ -7378,14 +7378,14 @@ static void ex_resize(exarg_T *eap)
     if (*eap->arg == '-' || *eap->arg == '+') {
       n += wp->w_width;
     } else if (n == 0 && eap->arg[0] == NUL) {  // default is very wide
-      n = Columns;
+      n = g_columns;
     }
     win_setwidth_win(n, wp);
   } else {
     if (*eap->arg == '-' || *eap->arg == '+') {
       n += wp->w_height;
     } else if (n == 0 && eap->arg[0] == NUL) {  // default is very high
-      n = Rows-1;
+      n = g_rows-1;
     }
     win_setheight_win(n, wp);
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3238,7 +3238,7 @@ void put_on_cmdline(char_u *str, int len, int redraw)
       msg_col -= i;
       if (msg_col < 0) {
         msg_col += g_columns;
-        --msg_row;
+        msg_row--;
       }
     }
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1709,7 +1709,7 @@ static int command_line_handle_key(CommandLineState *s)
       XFREE_CLEAR(ccline.cmdbuff);        // no commandline to return
       if (!cmd_silent && !ui_has(kUICmdline)) {
         if (cmdmsg_rl) {
-          msg_col = Columns;
+          msg_col = g_columns;
         } else {
           msg_col = 0;
         }
@@ -1858,7 +1858,7 @@ static int command_line_handle_key(CommandLineState *s)
       }
 
       int cells = cmdline_charsize(ccline.cmdpos);
-      if (KeyTyped && ccline.cmdspos + cells >= Columns * Rows) {
+      if (KeyTyped && ccline.cmdspos + cells >= g_columns * g_rows) {
         break;
       }
 
@@ -1931,8 +1931,8 @@ static int command_line_handle_key(CommandLineState *s)
     for (ccline.cmdpos = 0; ccline.cmdpos < ccline.cmdlen;
          ccline.cmdpos++) {
       int cells = cmdline_charsize(ccline.cmdpos);
-      if (mouse_row <= cmdline_row + ccline.cmdspos / Columns
-          && mouse_col < ccline.cmdspos % Columns + cells) {
+      if (mouse_row <= cmdline_row + ccline.cmdspos / g_columns
+          && mouse_col < ccline.cmdspos % g_columns + cells) {
         break;
       }
 
@@ -2456,7 +2456,7 @@ static int cmd_screencol(int bytepos)
 
   int col = cmd_startcol();
   if (KeyTyped) {
-    m = Columns * Rows;
+    m = g_columns * g_rows;
     if (m < 0) {        // overflow, Columns or Rows at weird value
       m = MAXCOL;
     }
@@ -2486,7 +2486,7 @@ static void correct_screencol(int idx, int cells, int *col)
 {
   if (utfc_ptr2len(ccline.cmdbuff + idx) > 1
       && utf_ptr2cells(ccline.cmdbuff + idx) > 1
-      && (*col) % Columns + cells > Columns) {
+      && (*col) % g_columns + cells > g_columns) {
     (*col)++;
   }
 }
@@ -3237,7 +3237,7 @@ void put_on_cmdline(char_u *str, int len, int redraw)
       ccline.cmdspos -= i;
       msg_col -= i;
       if (msg_col < 0) {
-        msg_col += Columns;
+        msg_col += g_columns;
         --msg_row;
       }
     }
@@ -3255,7 +3255,7 @@ void put_on_cmdline(char_u *str, int len, int redraw)
     msg_no_more = FALSE;
   }
   if (KeyTyped) {
-    m = Columns * Rows;
+    m = g_columns * g_rows;
     if (m < 0) {            // overflow, Columns or Rows at weird value
       m = MAXCOL;
     }
@@ -3481,7 +3481,7 @@ static void redrawcmdprompt(void)
   }
   if (ccline.cmdprompt != NULL) {
     msg_puts_attr((const char *)ccline.cmdprompt, ccline.cmdattr);
-    ccline.cmdindent = msg_col + (msg_row - cmdline_row) * Columns;
+    ccline.cmdindent = msg_col + (msg_row - cmdline_row) * g_columns;
     // do the reverse of cmd_startcol()
     if (ccline.cmdfirstc != NUL) {
       ccline.cmdindent--;
@@ -3547,7 +3547,7 @@ void redrawcmd(void)
 void compute_cmdrow(void)
 {
   if (exmode_active || msg_scrolled != 0) {
-    cmdline_row = Rows - 1;
+    cmdline_row = g_rows - 1;
   } else {
     win_T *wp = lastwin_nofloating();
     cmdline_row = wp->w_winrow + wp->w_height
@@ -3571,16 +3571,16 @@ static void cursorcmd(void)
   }
 
   if (cmdmsg_rl) {
-    msg_row = cmdline_row  + (ccline.cmdspos / (Columns - 1));
-    msg_col = Columns - (ccline.cmdspos % (Columns - 1)) - 1;
+    msg_row = cmdline_row  + (ccline.cmdspos / (g_columns - 1));
+    msg_col = g_columns - (ccline.cmdspos % (g_columns - 1)) - 1;
     if (msg_row <= 0) {
-      msg_row = Rows - 1;
+      msg_row = g_rows - 1;
     }
   } else {
-    msg_row = cmdline_row + (ccline.cmdspos / Columns);
-    msg_col = ccline.cmdspos % Columns;
-    if (msg_row >= Rows) {
-      msg_row = Rows - 1;
+    msg_row = cmdline_row + (ccline.cmdspos / g_columns);
+    msg_col = ccline.cmdspos % g_columns;
+    if (msg_row >= g_rows) {
+      msg_row = g_rows - 1;
     }
   }
 
@@ -3601,7 +3601,7 @@ void gotocmdline(bool clr)
   }
   msg_start();
   if (cmdmsg_rl) {
-    msg_col = Columns - 1;
+    msg_col = g_columns - 1;
   } else {
     msg_col = 0;  // always start in column 0
   }
@@ -4279,7 +4279,7 @@ static int showmatches(expand_T *xp, int wildmenu)
     } else {
       // compute the number of columns and lines for the listing
       maxlen += 2;          // two spaces between file names
-      columns = (Columns + 2) / maxlen;
+      columns = (g_columns + 2) / maxlen;
       if (columns < 1) {
         columns = 1;
       }
@@ -6203,9 +6203,9 @@ void ex_history(exarg_T *eap)
           msg_putchar('\n');
           snprintf((char *)IObuff, IOSIZE, "%c%6d  ", i == idx ? '>' : ' ',
                    hist[i].hisnum);
-          if (vim_strsize(hist[i].hisstr) > Columns - 10) {
+          if (vim_strsize(hist[i].hisstr) > g_columns - 10) {
             trunc_string(hist[i].hisstr, IObuff + STRLEN(IObuff),
-                         Columns - 10, IOSIZE - (int)STRLEN(IObuff));
+                         g_columns - 10, IOSIZE - (int)STRLEN(IObuff));
           } else {
             STRCAT(IObuff, hist[i].hisstr);
           }

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -78,17 +78,17 @@ static int ses_winsizes(FILE *fd, int restore_size, win_T *tab_firstwin)
                       "exe '%dresize ' . ((&lines * %" PRId64
                       " + %" PRId64 ") / %" PRId64 ")\n",
                       n, (int64_t)wp->w_height,
-                      (int64_t)Rows / 2, (int64_t)Rows) < 0)) {
+                      (int64_t)g_rows / 2, (int64_t)g_rows) < 0)) {
         return FAIL;
       }
 
       // restore width when not full width
-      if (wp->w_width < Columns
+      if (wp->w_width < g_columns
           && (fprintf(fd,
                       "exe 'vert %dresize ' . ((&columns * %" PRId64
                       " + %" PRId64 ") / %" PRId64 ")\n",
-                      n, (int64_t)wp->w_width, (int64_t)Columns / 2,
-                      (int64_t)Columns) < 0)) {
+                      n, (int64_t)wp->w_width, (int64_t)g_columns / 2,
+                      (int64_t)g_columns) < 0)) {
         return FAIL;
       }
     }
@@ -589,7 +589,7 @@ static int makeopens(FILE *fd, char_u *dirnow)
   if (ssop_flags & SSOP_RESIZE) {
     // Note: after the restore we still check it worked!
     if (fprintf(fd, "set lines=%" PRId64 " columns=%" PRId64 "\n",
-                (int64_t)Rows, (int64_t)Columns) < 0) {
+                (int64_t)g_rows, (int64_t)g_columns) < 0) {
       return FAIL;
     }
   }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1996,7 +1996,7 @@ static int vgetorpeek(bool advance)
               set_option_value("paste", !p_paste, NULL, 0);
               if (!(State & INSERT)) {
                 msg_col = 0;
-                msg_row = Rows - 1;
+                msg_row = g_rows - 1;
                 msg_clr_eos();                          // clear ruler
               }
               status_redraw_all();

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -83,14 +83,14 @@ EXTERN struct nvim_stats_s {
 //                      0          not starting anymore
 
 // Number of Rows and Columns in the screen.
-// Note: Use default_grid.Rows and default_grid.Columns to access items in
+// Note: Use default_grid.g_rows and default_grid.g_columns to access items in
 // default_grid.chars[]. They may have different values when the screen
 // wasn't (re)allocated yet after setting Rows or Columns (e.g., when starting
 // up).
 #define DFLT_COLS       80              // default value for 'columns'
 #define DFLT_ROWS       24              // default value for 'lines'
-EXTERN int Rows INIT(= DFLT_ROWS);     // nr of rows in the screen
-EXTERN int Columns INIT(= DFLT_COLS);  // nr of columns in the screen
+EXTERN int g_rows INIT(= DFLT_ROWS);     // nr of rows in the screen
+EXTERN int g_columns INIT(= DFLT_COLS);  // nr of columns in the screen
 
 EXTERN NS ns_hl_active INIT(= 0);         // current ns that defines highlights
 EXTERN bool ns_hl_changed INIT(= false);  // highlight need update

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -58,8 +58,8 @@ struct ScreenGrid {
   int *dirty_col;
 
   // the size of the allocated grid.
-  int Rows;
-  int Columns;
+  int g_rows;
+  int g_columns;
 
   // The state of the grid is valid. Otherwise it needs to be redrawn.
   bool valid;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -603,8 +603,8 @@ static void prt_header(prt_settings_T *const psettings, const int pagenum, const
 static void prt_message(char_u *s)
 {
   // TODO(bfredl): delete this
-  grid_fill(&default_grid, Rows - 1, Rows, 0, Columns, ' ', ' ', 0);
-  grid_puts(&default_grid, s, Rows - 1, 0, HL_ATTR(HLF_R));
+  grid_fill(&default_grid, g_rows - 1, g_rows, 0, g_columns, ' ', ' ', 0);
+  grid_puts(&default_grid, s, g_rows - 1, 0, HL_ATTR(HLF_R));
   ui_flush();
 }
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1658,7 +1658,7 @@ static void cs_print_tags_priv(char **matches, char **cntxts,
     assert(buf_len >= 0);
 
     // Print the context only if it fits on the same line.
-    if (msg_col + buf_len >= Columns) {
+    if (msg_col + buf_len >= g_columns) {
       msg_putchar('\n');
     }
     msg_advance(12);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
 
   full_screen = !silent_mode;
 
-  // Set the default values for the options that use Rows and Columns.
+  // Set the default values for the options that use g_rows and g_columns.
   win_init_size();
   // Set the 'diff' option now, so that it can be checked for in a vimrc
   // file.  There is no buffer yet though.
@@ -295,8 +295,8 @@ int main(int argc, char **argv)
     diff_win_options(firstwin, false);
   }
 
-  assert(p_ch >= 0 && Rows >= p_ch && Rows - p_ch <= INT_MAX);
-  cmdline_row = (int)(Rows - p_ch);
+  assert(p_ch >= 0 && g_rows >= p_ch && g_rows - p_ch <= INT_MAX);
+  cmdline_row = (int)(g_rows - p_ch);
   msg_row = cmdline_row;
   screenalloc();  // allocate screen buffers
   set_init_2(headless_mode);
@@ -592,7 +592,7 @@ void getout(int exitval)
   set_vim_var_nr(VV_EXITING, exitval);
 
   // Position the cursor on the last screen line, below all the text
-  ui_cursor_goto(Rows - 1, 0);
+  ui_cursor_goto(g_rows - 1, 0);
 
   // Optionally print hashtable efficiency.
   hash_debug_results();
@@ -681,7 +681,7 @@ void getout(int exitval)
   }
 
   // Position the cursor again, the autocommands may have moved it
-  ui_cursor_goto(Rows - 1, 0);
+  ui_cursor_goto(g_rows - 1, 0);
 
   // Apply 'titleold'.
   if (p_title && *p_titleold != NUL) {

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -631,15 +631,15 @@ static char_u *mark_line(pos_T *mp, int lead_len)
   if (mp->lnum == 0 || mp->lnum > curbuf->b_ml.ml_line_count) {
     return vim_strsave((char_u *)"-invalid-");
   }
-  assert(Columns >= 0 && (size_t)Columns <= SIZE_MAX);
+  assert(g_columns >= 0 && (size_t)g_columns <= SIZE_MAX);
   // Allow for up to 5 bytes per character.
-  s = vim_strnsave(skipwhite(ml_get(mp->lnum)), (size_t)Columns * 5);
+  s = vim_strnsave(skipwhite(ml_get(mp->lnum)), (size_t)g_columns * 5);
 
   // Truncate the line to fit it in the window
   len = 0;
   for (p = s; *p != NUL; MB_PTR_ADV(p)) {
     len += ptr2cells(p);
-    if (len >= Columns - lead_len) {
+    if (len >= g_columns - lead_len) {
       break;
     }
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1878,13 +1878,13 @@ static char_u *screen_puts_mbyte(char_u *s, int l, int attr)
     msg_col -= cw;
     if (msg_col == 0) {
       msg_col = g_columns;
-      ++msg_row;
+      msg_row++;
     }
   } else {
     msg_col += cw;
     if (msg_col >= g_columns) {
       msg_col = 0;
-      ++msg_row;
+      msg_row++;
     }
   }
   return s + l;
@@ -2165,8 +2165,8 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr, int recurs
     wrap = *s == '\n'
            || msg_col + t_col >= g_columns
            || (utf_ptr2cells(s) > 1
-               && msg_col + t_col >= g_columns - 1)
-    ;
+               && msg_col + t_col >= g_columns - 1);
+
     if (t_col > 0 && (wrap || *s == '\r' || *s == '\b'
                       || *s == '\t' || *s == BELL)) {
       // Output any postponed text.
@@ -2678,7 +2678,7 @@ static int do_more_prompt(int typed_char)
     // "g<": Find first line on the last page.
     mp_last = msg_sb_start(last_msgchunk);
     for (i = 0; i < g_rows - 2 && mp_last != NULL
-         && mp_last->sb_prev != NULL; ++i) {
+         && mp_last->sb_prev != NULL; i++) {
       mp_last = msg_sb_start(mp_last->sb_prev);
     }
   }
@@ -2799,7 +2799,7 @@ static int do_more_prompt(int typed_char)
 
         // go to start of line at top of the screen
         for (i = 0; i < g_rows - 2 && mp != NULL && mp->sb_prev != NULL;
-             ++i) {
+             i++) {
           mp = msg_sb_start(mp->sb_prev);
         }
 
@@ -2831,7 +2831,7 @@ static int do_more_prompt(int typed_char)
                       HL_ATTR(HLF_MSG));
             for (i = 0; mp != NULL && i < g_rows - 1; i++) {
               mp = disp_sb_line(i, mp);
-              ++msg_scrolled;
+              msg_scrolled++;
             }
             to_redraw = false;
           }
@@ -2932,12 +2932,12 @@ static void msg_screen_putchar(int c, int attr)
   if (cmdmsg_rl) {
     if (--msg_col == 0) {
       msg_col = g_columns;
-      ++msg_row;
+      msg_row++;
     }
   } else {
     if (++msg_col >= g_columns) {
       msg_col = 0;
-      ++msg_row;
+      msg_row++;
     }
   }
 }
@@ -2963,7 +2963,7 @@ void msg_moremsg(int full)
 void repeat_message(void)
 {
   if (State == ASKMORE) {
-    msg_moremsg(TRUE);          // display --more-- message again
+    msg_moremsg(true);          // display --more-- message again
     msg_row = g_rows - 1;
   } else if (State == CONFIRM) {
     display_confirm_msg();      // display ":confirm" message again
@@ -3240,7 +3240,7 @@ int redirecting(void)
 void verbose_enter(void)
 {
   if (*p_vfile != NUL) {
-    ++msg_silent;
+    msg_silent++;
   }
 }
 
@@ -3263,7 +3263,7 @@ void verbose_leave(void)
 void verbose_enter_scroll(void)
 {
   if (*p_vfile != NUL) {
-    ++msg_silent;
+    msg_silent++;
   } else {
     // always scroll up, don't overwrite
     msg_scroll = TRUE;
@@ -3433,7 +3433,7 @@ int do_dialog(int type, char_u *title, char_u *message, char_u *buttons, int dfl
    * Since we wait for a keypress, don't make the
    * user press RETURN as well afterwards.
    */
-  ++no_wait_return;
+  no_wait_return++;
   hotkeys = msg_show_console_dialog(message, buttons, dfltbutton);
 
   for (;; ) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2972,9 +2972,9 @@ void repeat_message(void)
     ui_cursor_goto(msg_row, msg_col);     // put cursor back
   } else if (State == HITRETURN || State == SETWSIZE) {
     if (msg_row == g_rows - 1) {
-      /* Avoid drawing the "hit-enter" prompt below the previous one,
-       * overwrite it.  Esp. useful when regaining focus and a
-       * FocusGained autocmd exists but didn't draw anything. */
+      // Avoid drawing the "hit-enter" prompt below the previous one,
+      // overwrite it.  Esp. useful when regaining focus and a
+      // FocusGained autocmd exists but didn't draw anything.
       msg_didout = false;
       msg_col = 0;
       msg_clr_eos();

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -482,8 +482,8 @@ static win_T *mouse_find_grid_win(int *gridp, int *rowp, int *colp)
     win_T *wp = get_win_by_grid_handle(*gridp);
     if (wp && wp->w_grid_alloc.chars
         && !(wp->w_floating && !wp->w_float_config.focusable)) {
-      *rowp = MIN(*rowp-wp->w_grid.row_offset, wp->w_grid.Rows-1);
-      *colp = MIN(*colp-wp->w_grid.col_offset, wp->w_grid.Columns-1);
+      *rowp = MIN(*rowp-wp->w_grid.row_offset, wp->w_grid.g_rows-1);
+      *colp = MIN(*colp-wp->w_grid.col_offset, wp->w_grid.g_columns-1);
       return wp;
     }
   } else if (*gridp == 0) {
@@ -730,16 +730,16 @@ int mouse_check_fold(void)
   int click_row = mouse_row;
   int click_col = mouse_col;
   int mouse_char = ' ';
-  int max_row = Rows;
-  int max_col = Columns;
+  int max_row = g_rows;
+  int max_col = g_columns;
   int multigrid = ui_has(kUIMultigrid);
 
   win_T *wp;
 
   wp = mouse_find_win(&click_grid, &click_row, &click_col);
   if (wp && multigrid) {
-    max_row = wp->w_grid_alloc.Rows;
-    max_col = wp->w_grid_alloc.Columns;
+    max_row = wp->w_grid_alloc.g_rows;
+    max_col = wp->w_grid_alloc.g_columns;
   }
 
   if (wp && mouse_row >= 0 && mouse_row < max_row

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1895,7 +1895,7 @@ int onepage(Direction dir, long count)
 
     loff.fill = 0;
     if (dir == FORWARD) {
-      if (ONE_WINDOW && p_window > 0 && p_window < Rows - 1) {
+      if (ONE_WINDOW && p_window > 0 && p_window < g_rows - 1) {
         // Vi compatible scrolling
         if (p_window <= 2) {
           ++curwin->w_topline;
@@ -1931,7 +1931,7 @@ int onepage(Direction dir, long count)
         max_topfill();
         continue;
       }
-      if (ONE_WINDOW && p_window > 0 && p_window < Rows - 1) {
+      if (ONE_WINDOW && p_window > 0 && p_window < g_rows - 1) {
         // Vi compatible scrolling (sort of)
         if (p_window <= 2) {
           --curwin->w_topline;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2469,7 +2469,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
     // click in a tab selects that tab page
     if (is_click
         && cmdwin_type == 0
-        && mouse_col < Columns) {
+        && mouse_col < g_columns) {
       in_tab_line = true;
       c1 = tab_page_click_defs[mouse_col].tabnr;
       switch (tab_page_click_defs[mouse_col].type) {
@@ -3594,7 +3594,7 @@ static void display_showcmd(void)
   }
 
   msg_grid_validate();
-  int showcmd_row = Rows - 1;
+  int showcmd_row = g_rows - 1;
   grid_puts_line_start(&msg_grid_adj, showcmd_row);
 
   if (!showcmd_is_clear) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3712,7 +3712,7 @@ void ex_display(exarg_T *eap)
       msg_putchar(name);
       MSG_PUTS("   ");
 
-      int n = Columns - 11;
+      int n = g_columns - 11;
       for (size_t j = 0; j < yb->y_size && n > 1; j++) {
         if (j) {
           MSG_PUTS_ATTR("^J", attr);
@@ -3801,7 +3801,7 @@ static void dis_msg(const char_u *p, bool skip_esc)
   int n;
   int l;
 
-  n = Columns - 6;
+  n = g_columns - 6;
   while (*p != NUL
          && !(*p == ESC && skip_esc && *(p + 1) == NUL)
          && (n -= ptr2cells(p)) >= 0) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -775,7 +775,7 @@ void free_all_options(void)
 #endif
 
 
-/// Initialize the options, part two: After getting Rows and Columns.
+/// Initialize the options, part two: After getting g_rows and g_columns.
 void set_init_2(bool headless)
 {
   // set in set_init_1 but logging is not allowed there
@@ -793,12 +793,12 @@ void set_init_2(bool headless)
 
   /*
    * 'window' is only for backwards compatibility with Vi.
-   * Default is Rows - 1.
+   * Default is g_rows - 1.
    */
   if (!option_was_set("window")) {
-    p_window = Rows - 1;
+    p_window = g_rows - 1;
   }
-  set_number_default("window", Rows - 1);
+  set_number_default("window", g_rows - 1);
   (void)parse_printoptions();      // parse 'printoptions' default value
 }
 
@@ -4142,7 +4142,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbu
 {
   char_u *errmsg = NULL;
   long old_value = *(long *)varp;
-  long old_Rows = Rows;                 // remember old Rows
+  long old_rows = g_rows;                 // remember old g_rows
   long *pp = (long *)varp;
 
   // Disallow changing some options from secure mode.
@@ -4298,16 +4298,16 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbu
   // For these options we want to fix some invalid values.
   if (pp == &p_window) {
     if (p_window < 1) {
-      p_window = Rows - 1;
-    } else if (p_window >= Rows) {
-      p_window = Rows - 1;
+      p_window = g_rows - 1;
+    } else if (p_window >= g_rows) {
+      p_window = g_rows - 1;
     }
   } else if (pp == &p_ch) {
     if (ui_has(kUIMessages)) {
       p_ch = 0;
     }
-    if (p_ch > Rows - min_rows() + 1) {
-      p_ch = Rows - min_rows() + 1;
+    if (p_ch > g_rows - min_rows() + 1) {
+      p_ch = g_rows - min_rows() + 1;
     }
   }
 
@@ -4413,7 +4413,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbu
   }
 
 
-  // Check the (new) bounds for Rows and Columns here.
+  // Check the (new) bounds for g_rows and g_columns here.
   if (p_lines < min_rows() && full_screen) {
     if (errbuf != NULL) {
       vim_snprintf((char *)errbuf, errbuflen,
@@ -4437,7 +4437,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbu
 
   // If the screen (shell) height has been changed, assume it is the
   // physical screenheight.
-  if (p_lines != Rows || p_columns != Columns) {
+  if (p_lines != g_rows || p_columns != g_columns) {
     // Changing the screen size is not allowed while updating the screen.
     if (updating_screen) {
       *pp = old_value;
@@ -4447,16 +4447,16 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbu
       // TODO(bfredl): is this branch ever needed?
       // Postpone the resizing; check the size and cmdline position for
       // messages.
-      Rows = (int)p_lines;
-      Columns = (int)p_columns;
+      g_rows = (int)p_lines;
+      g_columns = (int)p_columns;
       check_shellsize();
-      if (cmdline_row > Rows - p_ch && Rows > p_ch) {
-        assert(p_ch >= 0 && Rows - p_ch <= INT_MAX);
-        cmdline_row = (int)(Rows - p_ch);
+      if (cmdline_row > g_rows - p_ch && g_rows > p_ch) {
+        assert(p_ch >= 0 && g_rows - p_ch <= INT_MAX);
+        cmdline_row = (int)(g_rows - p_ch);
       }
     }
-    if (p_window >= Rows || !option_was_set("window")) {
-      p_window = Rows - 1;
+    if (p_window >= g_rows || !option_was_set("window")) {
+      p_window = g_rows - 1;
     }
   }
 
@@ -4476,9 +4476,9 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char_u *errbu
       curwin->w_p_scr = curwin->w_height;
     }
   }
-  if ((p_sj < -100 || p_sj >= Rows) && full_screen) {
-    if (Rows != old_Rows) {     // Rows changed, just adjust p_sj
-      p_sj = Rows / 2;
+  if ((p_sj < -100 || p_sj >= g_rows) && full_screen) {
+    if (g_rows != old_rows) {     // g_rows changed, just adjust p_sj
+      p_sj = g_rows / 2;
     } else {
       errmsg = e_scroll;
       p_sj = 1;
@@ -5063,11 +5063,11 @@ static void showoptions(int all, int opt_flags)
      * display the items
      */
     if (run == 1) {
-      assert(Columns <= INT_MAX - GAP
-             && Columns + GAP >= INT_MIN + 3
-             && (Columns + GAP - 3) / INC >= INT_MIN
-             && (Columns + GAP - 3) / INC <= INT_MAX);
-      cols = (int)((Columns + GAP - 3) / INC);
+      assert(g_columns <= INT_MAX - GAP
+             && g_columns + GAP >= INT_MIN + 3
+             && (g_columns + GAP - 3) / INC >= INT_MIN
+             && (g_columns + GAP - 3) / INC <= INT_MAX);
+      cols = (int)((g_columns + GAP - 3) / INC);
       if (cols == 0) {
         cols = 1;
       }
@@ -5464,13 +5464,13 @@ void comp_col(void)
     }
   }
   assert(sc_col >= 0
-         && INT_MIN + sc_col <= Columns
-         && Columns - sc_col <= INT_MAX);
-  sc_col = (int)(Columns - sc_col);
+         && INT_MIN + sc_col <= g_columns
+         && g_columns - sc_col <= INT_MAX);
+  sc_col = (int)(g_columns - sc_col);
   assert(ru_col >= 0
-         && INT_MIN + ru_col <= Columns
-         && Columns - ru_col <= INT_MAX);
-  ru_col = (int)(Columns - ru_col);
+         && INT_MIN + ru_col <= g_columns
+         && g_columns - ru_col <= INT_MAX);
+  ru_col = (int)(g_columns - ru_col);
   if (sc_col <= 0) {            // screen too narrow, will become a mess
     sc_col = 1;
   }

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -328,11 +328,11 @@ static unsigned int handle_mouse_event(char **ptr, uint8_t *buf, unsigned int bu
     if (col >= 0 && row >= 0) {
       // Make sure the mouse position is valid.  Some terminals may
       // return weird values.
-      if (col >= Columns) {
-        col = Columns - 1;
+      if (col >= g_columns) {
+        col = g_columns - 1;
       }
-      if (row >= Rows) {
-        row = Rows - 1;
+      if (row >= g_rows) {
+        row = g_rows - 1;
       }
       mouse_grid = 0;
       mouse_row = row;

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -340,7 +340,7 @@ int os_expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file
     // With interactive completion, the error message is not printed.
     if (!(flags & EW_SILENT)) {
       msg_putchar('\n');                // clear bottom line quickly
-      cmdline_row = Rows - 1;           // continue on last line
+      cmdline_row = g_rows - 1;           // continue on last line
       MSG(_(e_wildexpand));
       msg_start();                    // don't overwrite this message
     }

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -279,7 +279,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       def_width = max_width;
     }
 
-    if ((((cursor_col < Columns - p_pw) || (cursor_col < Columns - max_width))
+    if ((((cursor_col < g_columns - p_pw) || (cursor_col < g_columns - max_width))
          && !pum_rl)
         || (pum_rl && ((cursor_col > p_pw) || (cursor_col > max_width)))) {
       // align pum with "cursor_col"
@@ -289,9 +289,9 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       if (pum_rl) {
         pum_width = pum_col - pum_scrollbar + 1;
       } else {
-        assert(Columns - pum_col - pum_scrollbar >= INT_MIN
-               && Columns - pum_col - pum_scrollbar <= INT_MAX);
-        pum_width = (int)(Columns - pum_col - pum_scrollbar);
+        assert(g_columns - pum_col - pum_scrollbar >= INT_MIN
+               && g_columns - pum_col - pum_scrollbar <= INT_MAX);
+        pum_width = (int)(g_columns - pum_col - pum_scrollbar);
       }
 
       if ((pum_width > max_width + pum_kind_width + pum_extra_width + 1)
@@ -304,19 +304,19 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
           pum_width = (int)p_pw;
         }
       } else if (((cursor_col > p_pw || cursor_col > max_width) && !pum_rl)
-                 || (pum_rl && (cursor_col < Columns - p_pw
-                                || cursor_col < Columns - max_width))) {
+                 || (pum_rl && (cursor_col < g_columns - p_pw
+                                || cursor_col < g_columns - max_width))) {
         // align pum edge with "cursor_col"
         if (pum_rl && W_ENDCOL(curwin) < max_width + pum_scrollbar + 1) {
           pum_col = cursor_col + max_width + pum_scrollbar + 1;
-          if (pum_col >= Columns) {
-            pum_col = Columns - 1;
+          if (pum_col >= g_columns) {
+            pum_col = g_columns - 1;
           }
         } else if (!pum_rl) {
-          if (curwin->w_wincol > Columns - max_width - pum_scrollbar
+          if (curwin->w_wincol > g_columns - max_width - pum_scrollbar
               && max_width <= p_pw) {
             // use full width to end of the screen
-            pum_col = Columns - max_width - pum_scrollbar;
+            pum_col = g_columns - max_width - pum_scrollbar;
             if (pum_col < 0) {
               pum_col = 0;
             }
@@ -326,7 +326,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
         if (pum_rl) {
           pum_width = pum_col - pum_scrollbar + 1;
         } else {
-          pum_width = Columns - pum_col - pum_scrollbar;
+          pum_width = g_columns - pum_col - pum_scrollbar;
         }
 
         if (pum_width < p_pw) {
@@ -336,8 +336,8 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
               pum_width = pum_col;
             }
           } else {
-            if (pum_width >= Columns - pum_col) {
-              pum_width = Columns - pum_col - 1;
+            if (pum_width >= g_columns - pum_col) {
+              pum_width = g_columns - pum_col - 1;
             }
           }
         } else if (pum_width > max_width + pum_kind_width + pum_extra_width + 1
@@ -348,16 +348,16 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
           }
         }
       }
-    } else if (Columns < def_width) {
+    } else if (g_columns < def_width) {
       // not enough room, will use what we have
       if (pum_rl) {
-        assert(Columns - 1 >= INT_MIN);
-        pum_col = (int)(Columns - 1);
+        assert(g_columns - 1 >= INT_MIN);
+        pum_col = (int)(g_columns - 1);
       } else {
         pum_col = 0;
       }
-      assert(Columns - 1 >= INT_MIN);
-      pum_width = (int)(Columns - 1);
+      assert(g_columns - 1 >= INT_MIN);
+      pum_width = (int)(g_columns - 1);
     } else {
       if (max_width > p_pw) {
         // truncate
@@ -367,9 +367,9 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       if (pum_rl) {
         pum_col = max_width - 1;
       } else {
-        assert(Columns - max_width >= INT_MIN
-               && Columns - max_width <= INT_MAX);
-        pum_col = (int)(Columns - max_width);
+        assert(g_columns - max_width >= INT_MIN
+               && g_columns - max_width <= INT_MAX);
+        pum_col = (int)(g_columns - max_width);
       }
       pum_width = max_width - pum_scrollbar;
     }
@@ -432,9 +432,9 @@ void pum_redraw(void)
   must_redraw_pum = false;
 
   if (!pum_grid.chars
-      || pum_grid.Rows != pum_height || pum_grid.Columns != grid_width) {
+      || pum_grid.g_rows != pum_height || pum_grid.g_columns != grid_width) {
     grid_alloc(&pum_grid, pum_height, grid_width, !invalid_grid, false);
-    ui_call_grid_resize(pum_grid.handle, pum_grid.Columns, pum_grid.Rows);
+    ui_call_grid_resize(pum_grid.handle, pum_grid.g_columns, pum_grid.g_rows);
   } else if (invalid_grid) {
     grid_invalidate(&pum_grid);
   }
@@ -704,7 +704,7 @@ static int pum_set_selected(int n, int repeat)
     // Skip this also when there is not much room.
     // NOTE: Be very careful not to sync undo!
     if ((pum_array[pum_selected].pum_info != NULL)
-        && (Rows > 10)
+        && (g_rows > 10)
         && (repeat <= 1)
         && (vim_strchr(p_cot, 'p') != NULL)) {
       win_T *curwin_save = curwin;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2457,7 +2457,7 @@ static int jump_to_help_window(qf_info_T *qi, bool newwin, int *opened_window)
     // specified, the current window is vertically split and narrow.
     int flags = WSP_HELP;
     if (cmdmod.split == 0
-        && curwin->w_width != Columns
+        && curwin->w_width != g_columns
         && curwin->w_width < 80) {
       flags |= WSP_TOP;
     }
@@ -3253,7 +3253,7 @@ static void qf_msg(qf_info_T *qi, int which, char *lead)
     }
     xstrlcat((char *)buf, title, IOSIZE);
   }
-  trunc_string(buf, buf, Columns - 1, IOSIZE);
+  trunc_string(buf, buf, g_columns - 1, IOSIZE);
   msg(buf);
 }
 
@@ -3662,7 +3662,7 @@ static int qf_open_new_cwindow(qf_info_T *qi, int height)
 
   // Only set the height when still in the same tab page and there is no
   // window to the side.
-  if (curtab == prevtab && curwin->w_width == Columns) {
+  if (curtab == prevtab && curwin->w_width == g_columns) {
     win_setheight(height);
   }
   curwin->w_p_wfh = true;  // set 'winfixheight'

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -869,7 +869,8 @@ static void win_update(win_T *wp, Providers *providers)
       }
     }
     if (mod_top != 0 && hasAnyFolding(wp)) {
-      linenr_T lnumt, lnumb;
+      linenr_T lnumt;
+      linenr_T lnumb;
 
       /*
        * A change in a line can cause lines above it to become folded or
@@ -1131,7 +1132,8 @@ static void win_update(win_T *wp, Providers *providers)
   // check if we are updating or removing the inverted part
   if ((VIsual_active && buf == curwin->w_buffer)
       || (wp->w_old_cursor_lnum != 0 && type != NOT_VALID)) {
-    linenr_T from, to;
+    linenr_T from;
+    linenr_T to;
 
     if (VIsual_active) {
       if (VIsual_mode != wp->w_old_visual_mode || type == INVERTED_ALL) {
@@ -1199,7 +1201,8 @@ static void win_update(win_T *wp, Providers *providers)
        * First compute the actual start and end column.
        */
       if (VIsual_mode == Ctrl_V) {
-        colnr_T fromc, toc;
+        colnr_T fromc;
+        colnr_T toc;
         int save_ve_flags = ve_flags;
 
         if (curwin->w_p_lbr) {
@@ -1870,7 +1873,8 @@ static int line_putchar(buf_T *buf, LineState *s, schar_T *dest, int maxcells, b
   const char_u *p = (char_u *)s->p;
   int cells = utf_ptr2cells(p);
   int c_len = utfc_ptr2len(p);
-  int u8c, u8cc[MAX_MCO];
+  int u8c;
+  int u8cc[MAX_MCO];
   if (cells > maxcells) {
     return -1;
   }
@@ -1887,7 +1891,9 @@ static int line_putchar(buf_T *buf, LineState *s, schar_T *dest, int maxcells, b
   } else {
     if (p_arshape && !p_tbidi && arabic_char(u8c)) {
       // Do Arabic shaping.
-      int pc, pc1, nc;
+      int pc;
+      int pc1;
+      int nc;
       int pcc[MAX_MCO];
       int firstbyte = *p;
 
@@ -2123,14 +2129,15 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
   int right_curline_col = 0;
 
   // draw_state: items that are drawn in sequence:
-#define WL_START        0               // nothing done yet
-#define WL_CMDLINE     WL_START + 1    // cmdline window column
-#define WL_FOLD        WL_CMDLINE + 1  // 'foldcolumn'
-#define WL_SIGN        WL_FOLD + 1     // column for signs
-#define WL_NR           WL_SIGN + 1     // line number
-#define WL_BRI         WL_NR + 1       // 'breakindent'
-#define WL_SBR         WL_BRI + 1       // 'showbreak' or 'diff'
-#define WL_LINE         WL_SBR + 1      // text in the line
+#define WL_START       0                 // nothing done yet
+#define WL_CMDLINE     (WL_START + 1)    // cmdline window column
+#define WL_FOLD        (WL_CMDLINE + 1)  // 'foldcolumn'
+#define WL_SIGN        (WL_FOLD + 1)     // column for signs
+#define WL_NR          (WL_SIGN + 1)     // line number
+#define WL_BRI         (WL_NR + 1)       // 'breakindent'
+#define WL_SBR         (WL_BRI + 1)      // 'showbreak' or 'diff'
+#define WL_LINE        (WL_SBR + 1)      // text in the line
+
   int draw_state = WL_START;            // what to draw next
 
   int syntax_flags    = 0;
@@ -2268,7 +2275,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
 
     // handle Visual active in this window
     if (VIsual_active && wp->w_buffer == curwin->w_buffer) {
-      pos_T *top, *bot;
+      pos_T *top;
+      pos_T *bot;
 
       if (ltoreq(curwin->w_cursor, VIsual)) {
         // Visual is after curwin->w_cursor
@@ -3365,7 +3373,9 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         mb_l = 1;
       } else if (p_arshape && !p_tbidi && arabic_char(mb_c)) {
         // Do Arabic shaping.
-        int pc, pc1, nc;
+        int pc;
+        int pc1;
+        int nc;
         int pcc[MAX_MCO];
 
         // The idea of what is the previous and next
@@ -4439,7 +4449,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
                        wp, wp->w_hl_attr_normal, wrap);
       if (wrap) {
         ScreenGrid *current_grid = grid;
-        int current_row = row, dummy_col = 0;  // dummy_col unused
+        int current_row = row;
+        int dummy_col = 0;  // dummy_col unused
         screen_adjust_grid(&current_grid, &current_row, &dummy_col);
 
         // Force a redraw of the first column of the next line.
@@ -4644,7 +4655,8 @@ static void get_sign_display_info(bool nrcol, win_T *wp, sign_attrs_T sattrs[], 
         *c_finalp = NUL;
 
         if (nrcol) {
-          int n, width = number_width(wp) - 2;
+          int n;
+          int width = number_width(wp) - 2;
           for (n = 0; n < width; n++) {
             extra[n] = ' ';
           }
@@ -4726,7 +4738,8 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, 
   bool clear_next = false;
   int char_cells;                           // 1: normal char
                                             // 2: occupies two display cells
-  int start_dirty = -1, end_dirty = 0;
+  int start_dirty = -1;
+  int end_dirty = 0;
 
   // TODO(bfredl): check all callsites and eliminate
   // Check for illegal row and col, just in case
@@ -4881,7 +4894,8 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, 
  */
 void rl_mirror(char_u *str)
 {
-  char_u *p1, *p2;
+  char_u      *p1;
+  char_u      *p2;
   int t;
 
   for (p1 = str, p2 = str + STRLEN(str) - 1; p1 < p2; ++p1, --p2) {
@@ -5279,7 +5293,8 @@ static void win_redr_status(win_T *wp)
       p = (char_u *)"<";                // No room for file name!
       len = 1;
     } else {
-      int clen = 0, i;
+      int clen = 0;
+      int i;
 
       // Count total number of display cells.
       clen = (int)mb_string2cells(p);
@@ -5614,7 +5629,8 @@ static void win_redr_border(win_T *wp)
 
 
   int *adj = wp->w_border_adj;
-  int irow = wp->w_height_inner, icol = wp->w_width_inner;
+  int irow = wp->w_height_inner;
+  int icol = wp->w_width_inner;
 
   if (adj[0]) {
     grid_puts_line_start(grid, 0);
@@ -5823,7 +5839,9 @@ void grid_puts_len(ScreenGrid *grid, char_u *text, int textlen, int row, int col
   int u8cc[MAX_MCO];
   int clear_next_cell = FALSE;
   int prev_c = 0;                       // previous Arabic character
-  int pc, nc, nc1;
+  int pc;
+  int nc;
+  int nc1;
   int pcc[MAX_MCO];
   int need_redraw;
   bool do_flush = false;
@@ -6282,7 +6300,8 @@ void grid_fill(ScreenGrid *grid, int start_row, int end_row, int start_col, int 
 {
   schar_T sc;
 
-  int row_off = 0, col_off = 0;
+  int row_off = 0;
+  int col_off = 0;
   screen_adjust_grid(&grid, &row_off, &col_off);
   start_row += row_off;
   end_row += row_off;
@@ -6845,7 +6864,6 @@ void grid_ins_lines(ScreenGrid *grid, int row, int line_count, int end, int col,
     ui_call_grid_scroll(grid->handle, row, end, col, col+width, -line_count, 0);
   }
 
-  return;
 }
 
 /// delete lines on the screen and move lines up.
@@ -6896,8 +6914,6 @@ void grid_del_lines(ScreenGrid *grid, int row, int line_count, int end, int col,
   if (!grid->throttled) {
     ui_call_grid_scroll(grid->handle, row, end, col, col+width, line_count, 0);
   }
-
-  return;
 }
 
 
@@ -7855,20 +7871,20 @@ void limit_screen_size(void)
 
 void win_new_shellsize(void)
 {
-  static long old_Rows = 0;
-  static long old_Columns = 0;
+  static long old_rows = 0;
+  static long old_columns = 0;
 
-  if (old_Rows != Rows) {
+  if (old_rows != Rows) {
     // If 'window' uses the whole screen, keep it using that.
     // Don't change it when set with "-w size" on the command line.
-    if (p_window == old_Rows - 1 || (old_Rows == 0 && p_window == 0)) {
+    if (p_window == old_rows - 1 || (old_rows == 0 && p_window == 0)) {
       p_window = Rows - 1;
     }
-    old_Rows = Rows;
+    old_rows = Rows;
     shell_new_rows();  // update window sizes
   }
-  if (old_Columns != Columns) {
-    old_Columns = Columns;
+  if (old_columns != Columns) {
+    old_columns = Columns;
     shell_new_columns();  // update window sizes
   }
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6863,7 +6863,6 @@ void grid_ins_lines(ScreenGrid *grid, int row, int line_count, int end, int col,
   if (!grid->throttled) {
     ui_call_grid_scroll(grid->handle, row, end, col, col+width, -line_count, 0);
   }
-
 }
 
 /// delete lines on the screen and move lines up.

--- a/src/nvim/screen.h
+++ b/src/nvim/screen.h
@@ -59,8 +59,8 @@ extern StlClickDefinition *tab_page_click_defs;
 /// Size of the tab_page_click_defs array
 extern long tab_page_click_defs_size;
 
-#define W_ENDCOL(wp)   (wp->w_wincol + wp->w_width)
-#define W_ENDROW(wp)   (wp->w_winrow + wp->w_height)
+#define W_ENDCOL(wp)   ((wp)->w_wincol + (wp)->w_width)
+#define W_ENDROW(wp)   ((wp)->w_winrow + (wp)->w_height)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "screen.h.generated.h"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1224,10 +1224,10 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char_u *pat, long count,
           len = 0;  // adjusted below
         } else if (msg_scrolled != 0 && !cmd_silent) {
           // Use all the columns.
-          len = (Rows - msg_row) * Columns - 1;
+          len = (g_rows - msg_row) * g_columns - 1;
         } else {
           // Use up to 'showcmd' column.
-          len = (Rows - msg_row - 1) * Columns + sc_col - 1;
+          len = (g_rows - msg_row - 1) * g_columns + sc_col - 1;
         }
         if (len < STRLEN(p) + off_len + SEARCH_STAT_BUF_LEN + 3) {
           len = STRLEN(p) + off_len + SEARCH_STAT_BUF_LEN + 3;

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -3354,7 +3354,8 @@ static ShaDaReadResult msgpack_read_uint64(ShaDaReadDef *const sd_reader, const 
   error_desc
 #define CHECK_KEY(key, expected) ( \
                                    (key).via.str.size == sizeof(expected) - 1 \
-                                   && STRNCMP((key).via.str.ptr, expected, sizeof(expected) - 1) == 0)
+                                   && STRNCMP((key).via.str.ptr, expected, \
+                                              sizeof(expected) - 1) == 0)
 #define CLEAR_GA_AND_ERROR_OUT(ga) \
   do { \
     ga_clear(&(ga)); \

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -47,8 +47,8 @@
 #include "nvim/vim.h"
 
 #ifdef HAVE_BE64TOH
-# define BSD_SOURCE 1
-# define DEFAULT_SOURCE 1
+# define _BSD_SOURCE 1
+# define _DEFAULT_SOURCE 1
 # include ENDIAN_INCLUDE_FILE
 #endif
 

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -47,8 +47,8 @@
 #include "nvim/vim.h"
 
 #ifdef HAVE_BE64TOH
-# define _BSD_SOURCE 1
-# define _DEFAULT_SOURCE 1
+# define BSD_SOURCE 1
+# define DEFAULT_SOURCE 1
 # include ENDIAN_INCLUDE_FILE
 #endif
 
@@ -70,20 +70,20 @@ KHASH_SET_INIT_STR(strset)
 #define find_shada_parameter(...) \
   ((const char *)find_shada_parameter(__VA_ARGS__))
 #define home_replace_save(a, b) \
-  ((char *)home_replace_save(a, (char_u *)b))
+  ((char *)home_replace_save(a, (char_u *)(b)))
 #define home_replace(a, b, c, d, e) \
-  home_replace(a, (char_u *)b, (char_u *)c, d, e)
+  home_replace(a, (char_u *)(b), (char_u *)(c), d, e)
 #define vim_rename(a, b) \
-  (vim_rename((char_u *)a, (char_u *)b))
+  (vim_rename((char_u *)(a), (char_u *)(b)))
 #define mb_strnicmp(a, b, c) \
-  (mb_strnicmp((char_u *)a, (char_u *)b, c))
+  (mb_strnicmp((char_u *)(a), (char_u *)(b), c))
 #define path_try_shorten_fname(b) \
-  ((char *)path_try_shorten_fname((char_u *)b))
+  ((char *)path_try_shorten_fname((char_u *)(b)))
 #define buflist_new(ffname, sfname, ...) \
   (buflist_new((char_u *)ffname, (char_u *)sfname, __VA_ARGS__))
-#define os_isdir(f) (os_isdir((char_u *)f))
-#define regtilde(s, m) ((char *)regtilde((char_u *)s, m))
-#define path_tail_with_sep(f) ((char *)path_tail_with_sep((char_u *)f))
+#define os_isdir(f) (os_isdir((char_u *)(f)))
+#define regtilde(s, m) ((char *)regtilde((char_u *)(s), m))
+#define path_tail_with_sep(f) ((char *)path_tail_with_sep((char_u *)(f)))
 
 #define SEARCH_KEY_MAGIC "sm"
 #define SEARCH_KEY_SMARTCASE "sc"
@@ -441,7 +441,7 @@ typedef struct sd_write_def {
     } \
   }
 #define DEFAULT_POS { 1, 0, 0 }
-static const pos_T default_pos = DEFAULT_POS;
+static const pos_T kDefaultPos = DEFAULT_POS;
 static const ShadaEntry sd_default_values[] = {
   [kSDItemMissing] = { .type = kSDItemMissing, .timestamp = 0 },
   DEF_SDE(Header, header, .size = 0),
@@ -532,8 +532,8 @@ static inline void hmll_init(HMLList *const hmll, const size_t size)
 ///
 /// @return `for` cycle header (use `HMLL_FORALL(hmll, cur_entry) {body}`).
 #define HMLL_FORALL(hmll, cur_entry, code) \
-  for (HMLListEntry *cur_entry = (hmll)->first; cur_entry != NULL; \
-       cur_entry = cur_entry->next) { \
+  for (HMLListEntry *(cur_entry) = (hmll)->first; (cur_entry) != NULL; \
+       (cur_entry) = (cur_entry)->next) { \
     code \
   } \
 
@@ -633,8 +633,8 @@ static inline void hmll_insert(HMLList *const hmll, HMLListEntry *hmll_entry, co
 ///
 /// @return `for` cycle header (use `HMLL_FORALL(hmll, cur_entry) {body}`).
 #define HMLL_ITER_BACK(hmll, cur_entry, code) \
-  for (cur_entry = (hmll)->last; cur_entry != NULL; \
-       cur_entry = cur_entry->prev) { \
+  for ((cur_entry) = (hmll)->last; (cur_entry) != NULL; \
+       (cur_entry) = (cur_entry)->prev) { \
     code \
   }
 
@@ -1106,13 +1106,13 @@ static inline bool marks_equal(const pos_T a, const pos_T b)
                     entry, fname_cond, free_func, fin_func, \
                     idxadj_func, afterfree_func) \
   do { \
-    const int jl_len = (int)jumps_size; \
+    const int jl_len = (int)(jumps_size); \
     int i; \
     for (i = jl_len; i > 0; i--) { \
-      const jumps_type jl_entry = jumps[i - 1]; \
-      if (jl_entry.timestamp_attr <= entry.timestamp) { \
-        if (marks_equal(jl_entry.mark_attr, entry.data.filemark.mark) \
-            && fname_cond) { \
+      const jumps_type jl_entry = (jumps)[i - 1]; \
+      if (jl_entry.timestamp_attr <= (entry).timestamp) { \
+        if (marks_equal(jl_entry.mark_attr, (entry).data.filemark.mark) \
+            && (fname_cond)) { \
           i = -1; \
         } \
         break; \
@@ -1120,30 +1120,30 @@ static inline bool marks_equal(const pos_T a, const pos_T b)
     } \
     if (i > 0) { \
       if (jl_len == JUMPLISTSIZE) { \
-        free_func(jumps[0]); \
+        free_func((jumps)[0]); \
         i--; \
         if (i > 0) { \
-          memmove(&jumps[0], &jumps[1], sizeof(jumps[1]) * (size_t)i); \
+          memmove(&(jumps)[0], &(jumps)[1], sizeof((jumps)[1]) * (size_t)i); \
         } \
       } else if (i != jl_len) { \
-        memmove(&jumps[i + 1], &jumps[i], \
-                sizeof(jumps[0]) * (size_t)(jl_len - i)); \
+        memmove(&(jumps)[i + 1], &(jumps)[i], \
+                sizeof((jumps)[0]) * (size_t)(jl_len - i)); \
       } \
     } else if (i == 0) { \
       if (jl_len == JUMPLISTSIZE) { \
         i = -1; \
       } else if (jl_len > 0) { \
-        memmove(&jumps[1], &jumps[0], sizeof(jumps[0]) * (size_t)jl_len); \
+        memmove(&(jumps)[1], &(jumps)[0], sizeof((jumps)[0]) * (size_t)jl_len); \
       } \
     } \
     if (i != -1) { \
-      jumps[i] = fin_func(entry); \
+      (jumps)[i] = fin_func(entry); \
       if (jl_len < JUMPLISTSIZE) { \
-        jumps_size++; \
+        (jumps_size)++; \
       } \
       idxadj_func(i); \
     } else { \
-      shada_free_shada_entry(&entry); \
+      shada_free_shada_entry(&(entry)); \
       afterfree_func(entry); \
     } \
   } while (0)
@@ -1340,7 +1340,7 @@ static void shada_read(ShaDaReadDef *const sd_reader, const int flags)
       } else {
 #define SDE_TO_XFMARK(entry) fm
 #define ADJUST_IDX(i) \
-  if (curwin->w_jumplistidx >= i \
+  if (curwin->w_jumplistidx >= (i) \
       && curwin->w_jumplistidx + 1 <= curwin->w_jumplistlen) { \
     curwin->w_jumplistidx++; \
   }
@@ -1589,7 +1589,7 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
     } \
   } while (0)
 #define CHECK_DEFAULT(entry, attr) \
-  (sd_default_values[entry.type].data.attr == entry.data.attr)
+  (sd_default_values[(entry).type].data.attr == (entry).data.attr)
 #define ONE_IF_NOT_DEFAULT(entry, attr) \
   ((size_t)(!CHECK_DEFAULT(entry, attr)))
   switch (entry.type) {
@@ -1679,7 +1679,7 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
   do { \
     if (!CHECK_DEFAULT(entry, search_pattern.attr)) { \
       PACK_STATIC_STR(name); \
-      if (sd_default_values[entry.type].data.search_pattern.attr) { \
+      if (sd_default_values[(entry).type].data.search_pattern.attr) { \
         msgpack_pack_false(spacker); \
       } else { \
         msgpack_pack_true(spacker); \
@@ -1782,9 +1782,9 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
       const size_t map_size = (size_t)(
                                        1  // Buffer name
                                        + (size_t)(entry.data.buffer_list.buffers[i].pos.lnum
-                                                  != default_pos.lnum)
+                                                  != kDefaultPos.lnum)
                                        + (size_t)(entry.data.buffer_list.buffers[i].pos.col
-                                                  != default_pos.col)
+                                                  != kDefaultPos.col)
                                        // Additional entries, if any:
                                        + (size_t)(
                                                   entry.data.buffer_list.buffers[i].additional_data
@@ -2260,12 +2260,12 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
       } else {
 #define FREE_POSSIBLY_FREED_SHADA_ENTRY(entry) \
   do { \
-    if (entry.can_free_entry) { \
-      shada_free_shada_entry(&entry.data); \
+    if ((entry).can_free_entry) { \
+      shada_free_shada_entry(&(entry).data); \
     } \
   } while (0)
 #define SDE_TO_PFSDE(entry) \
-  ((PossiblyFreedShadaEntry) { .can_free_entry = true, .data = entry })
+  ((PossiblyFreedShadaEntry) { .can_free_entry = true, .data = (entry) })
 #define AFTERFREE_DUMMY(entry)
 #define DUMMY_IDX_ADJ(i)
         MERGE_JUMPS(filemarks->changes_size, filemarks->changes,
@@ -2617,9 +2617,9 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
         continue;
       case VAR_DICT: {
         dict_T *di = vartv.vval.v_dict;
-        int copyID = get_copyID();
-        if (!set_ref_in_ht(&di->dv_hashtab, copyID, NULL)
-            && copyID == di->dv_copyID) {
+        int copy_id = get_copyID();
+        if (!set_ref_in_ht(&di->dv_hashtab, copy_id, NULL)
+            && copy_id == di->dv_copyID) {
           tv_clear(&vartv);
           continue;
         }
@@ -2627,9 +2627,9 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
       }
       case VAR_LIST: {
         list_T *l = vartv.vval.v_list;
-        int copyID = get_copyID();
-        if (!set_ref_in_list(l, copyID, NULL)
-            && copyID == l->lv_copyID) {
+        int copy_id = get_copyID();
+        if (!set_ref_in_list(l, copy_id, NULL)
+            && copy_id == l->lv_copyID) {
           tv_clear(&vartv);
           continue;
         }
@@ -2853,8 +2853,8 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
 #define PACK_WMS_ARRAY(wms_array) \
   do { \
     for (size_t i_ = 0; i_ < ARRAY_SIZE(wms_array); i_++) { \
-      if (wms_array[i_].data.type != kSDItemMissing) { \
-        if (shada_pack_pfreed_entry(packer, wms_array[i_], max_kbyte) \
+      if ((wms_array)[i_].data.type != kSDItemMissing) { \
+        if (shada_pack_pfreed_entry(packer, (wms_array)[i_], max_kbyte) \
             == kSDWriteFailed) { \
           ret = kSDWriteFailed; \
           goto shada_write_exit; \
@@ -2874,7 +2874,7 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
   }
 #define PACK_WMS_ENTRY(wms_entry) \
   do { \
-    if (wms_entry.data.type != kSDItemMissing) { \
+    if ((wms_entry).data.type != kSDItemMissing) { \
       if (shada_pack_pfreed_entry(packer, wms_entry, max_kbyte) \
           == kSDWriteFailed) { \
         ret = kSDWriteFailed; \
@@ -3353,15 +3353,15 @@ static ShaDaReadResult msgpack_read_uint64(ShaDaReadDef *const sd_reader, const 
   entry_name " entry at position %" PRIu64 " " \
   error_desc
 #define CHECK_KEY(key, expected) ( \
-                                   key.via.str.size == sizeof(expected) - 1 \
-                                   && STRNCMP(key.via.str.ptr, expected, sizeof(expected) - 1) == 0)
+                                   (key).via.str.size == sizeof(expected) - 1 \
+                                   && STRNCMP((key).via.str.ptr, expected, sizeof(expected) - 1) == 0)
 #define CLEAR_GA_AND_ERROR_OUT(ga) \
   do { \
-    ga_clear(&ga); \
+    ga_clear(&(ga)); \
     goto shada_read_next_item_error; \
   } while (0)
 #define ID(s) s
-#define BINDUP(b) xmemdupz(b.ptr, b.size)
+#define BINDUP(b) xmemdupz((b).ptr, (b).size)
 #define TOINT(s) ((int)(s))
 #define TOLONG(s) ((long)(s))
 #define TOCHAR(s) ((char)(s))
@@ -3374,28 +3374,28 @@ static ShaDaReadResult msgpack_read_uint64(ShaDaReadDef *const sd_reader, const 
       emsgf(_(READERR(entry_name, error_desc)), initial_fpos); \
       CLEAR_GA_AND_ERROR_OUT(ad_ga); \
     } \
-    tgt = proc(obj.via.attr); \
+    (tgt) = proc((obj).via.attr); \
   } while (0)
 #define CHECK_KEY_IS_STR(un, entry_name) \
-  if (un.data.via.map.ptr[i].key.type != MSGPACK_OBJECT_STR) { \
+  if ((un).data.via.map.ptr[i].key.type != MSGPACK_OBJECT_STR) { \
     emsgf(_(READERR(entry_name, "has key which is not a string")), \
           initial_fpos); \
     CLEAR_GA_AND_ERROR_OUT(ad_ga); \
-  } else if (un.data.via.map.ptr[i].key.via.str.size == 0) { \
+  } else if ((un).data.via.map.ptr[i].key.via.str.size == 0) { \
     emsgf(_(READERR(entry_name, "has empty key")), initial_fpos); \
     CLEAR_GA_AND_ERROR_OUT(ad_ga); \
   }
 #define CHECKED_KEY(un, entry_name, name, error_desc, tgt, condition, attr, \
                     proc) \
   else if (CHECK_KEY(  /* NOLINT(readability/braces) */ \
-                       un.data.via.map.ptr[i].key, name)) { \
+                       (un).data.via.map.ptr[i].key, name)) { \
     CHECKED_ENTRY(condition, "has " name " key value " error_desc, \
-                  entry_name, un.data.via.map.ptr[i].val, \
+                  entry_name, (un).data.via.map.ptr[i].val, \
                   tgt, attr, proc); \
   }
 #define TYPED_KEY(un, entry_name, name, type_name, tgt, objtype, attr, proc) \
   CHECKED_KEY(un, entry_name, name, "which is not " type_name, tgt, \
-              un.data.via.map.ptr[i].val.type == MSGPACK_OBJECT_##objtype, \
+              (un).data.via.map.ptr[i].val.type == MSGPACK_OBJECT_##objtype, \
               attr, proc)
 #define BOOLEAN_KEY(un, entry_name, name, tgt) \
   TYPED_KEY(un, entry_name, name, "a boolean", tgt, BOOLEAN, boolean, ID)
@@ -3406,9 +3406,9 @@ static ShaDaReadResult msgpack_read_uint64(ShaDaReadDef *const sd_reader, const 
             BIN_CONVERTED)
 #define INT_KEY(un, entry_name, name, tgt, proc) \
   CHECKED_KEY(un, entry_name, name, "which is not an integer", tgt, \
-              ((un.data.via.map.ptr[i].val.type \
+              (((un).data.via.map.ptr[i].val.type \
                 == MSGPACK_OBJECT_POSITIVE_INTEGER) \
-               || (un.data.via.map.ptr[i].val.type \
+               || ((un).data.via.map.ptr[i].val.type \
                    == MSGPACK_OBJECT_NEGATIVE_INTEGER)), \
               i64, proc)
 #define INTEGER_KEY(un, entry_name, name, tgt) \
@@ -3419,13 +3419,13 @@ static ShaDaReadResult msgpack_read_uint64(ShaDaReadDef *const sd_reader, const 
   else {  /* NOLINT(readability/braces) */ \
     ga_grow(&ad_ga, 1); \
     memcpy(((char *)ad_ga.ga_data) + ((size_t)ad_ga.ga_len \
-                                      * sizeof(*un.data.via.map.ptr)), \
-           un.data.via.map.ptr + i, \
-           sizeof(*un.data.via.map.ptr)); \
+                                      * sizeof(*(un).data.via.map.ptr)), \
+           (un).data.via.map.ptr + i, \
+           sizeof(*(un).data.via.map.ptr)); \
     ad_ga.ga_len++; \
   }
 #define CONVERTED(str, len) (xmemdupz((str), (len)))
-#define BIN_CONVERTED(b) CONVERTED(b.ptr, b.size)
+#define BIN_CONVERTED(b) CONVERTED((b).ptr, (b).size)
 #define SET_ADDITIONAL_DATA(tgt, name) \
   do { \
     if (ad_ga.ga_len) { \
@@ -3448,7 +3448,7 @@ static ShaDaReadResult msgpack_read_uint64(ShaDaReadDef *const sd_reader, const 
         tv_clear(&adtv); \
         goto shada_read_next_item_error; \
       } \
-      tgt = adtv.vval.v_dict; \
+      (tgt) = adtv.vval.v_dict; \
     } \
     ga_clear(&ad_ga); \
   } while (0)
@@ -3917,7 +3917,7 @@ shada_read_next_item_start:
                 initial_fpos);
           goto shada_read_next_item_error;
         }
-        entry->data.buffer_list.buffers[i].pos = default_pos;
+        entry->data.buffer_list.buffers[i].pos = kDefaultPos;
         garray_T ad_ga;
         ga_init(&ad_ga, sizeof(*(unpacked_2.data.via.map.ptr)), 1);
         {

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2924,8 +2924,8 @@ void spell_suggest(int count)
 
   // Get the list of suggestions.  Limit to 'lines' - 2 or the number in
   // 'spellsuggest', whatever is smaller.
-  if (sps_limit > (int)Rows - 2) {
-    limit = (int)Rows - 2;
+  if (sps_limit > (int)g_rows - 2) {
+    limit = (int)g_rows- 2;
   } else {
     limit = sps_limit;
   }
@@ -2943,13 +2943,13 @@ void spell_suggest(int count)
     // When 'rightleft' is set the list is drawn right-left.
     cmdmsg_rl = curwin->w_p_rl;
     if (cmdmsg_rl) {
-      msg_col = Columns - 1;
+      msg_col = g_columns - 1;
     }
 
     // List the suggestions.
     msg_start();
-    msg_row = Rows - 1;         // for when 'cmdheight' > 1
-    lines_left = Rows;          // avoid more prompt
+    msg_row = g_rows - 1;         // for when 'cmdheight' > 1
+    lines_left = g_rows;          // avoid more prompt
     vim_snprintf((char *)IObuff, IOSIZE, _("Change \"%.*s\" to:"),
                  sug.su_badlen, sug.su_badptr);
     if (cmdmsg_rl && STRNCMP(IObuff, "Change", 6) == 0) {
@@ -3022,7 +3022,7 @@ void spell_suggest(int count)
     if (mouse_used) {
       selected -= lines_left;
     }
-    lines_left = Rows;                  // avoid more prompt
+    lines_left = g_rows;                  // avoid more prompt
     // don't delay for 'smd' in normal_cmd()
     msg_scroll = msg_scroll_save;
   }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -505,10 +505,10 @@ void syntax_start(win_T *wp, linenr_T lnum)
    * Advance from the sync point or saved state until the current line.
    * Save some entries for syncing with later on.
    */
-  if (syn_block->b_sst_len <= Rows) {
+  if (syn_block->b_sst_len <= g_rows) {
     dist = 999999;
   } else {
-    dist = syn_buf->b_ml.ml_line_count / (syn_block->b_sst_len - Rows) + 1;
+    dist = syn_buf->b_ml.ml_line_count / (syn_block->b_sst_len - g_rows) + 1;
   }
   while (current_lnum < lnum) {
     syn_start_line();
@@ -1066,7 +1066,7 @@ static void syn_stack_alloc(void)
   synstate_T *from;
   synstate_T *sstp;
 
-  len = syn_buf->b_ml.ml_line_count / SST_DIST + Rows * 2;
+  len = syn_buf->b_ml.ml_line_count / SST_DIST + g_rows * 2;
   if (len < SST_MIN_ENTRIES) {
     len = SST_MIN_ENTRIES;
   } else if (len > SST_MAX_ENTRIES) {
@@ -1075,7 +1075,7 @@ static void syn_stack_alloc(void)
   if (syn_block->b_sst_len > len * 2 || syn_block->b_sst_len < len) {
     // Allocate 50% too much, to avoid reallocating too often.
     len = syn_buf->b_ml.ml_line_count;
-    len = (len + len / 2) / SST_DIST + Rows * 2;
+    len = (len + len / 2) / SST_DIST + g_rows * 2;
     if (len < SST_MIN_ENTRIES) {
       len = SST_MIN_ENTRIES;
     } else if (len > SST_MAX_ENTRIES) {
@@ -1207,10 +1207,10 @@ static bool syn_stack_cleanup(void)
   }
 
   // Compute normal distance between non-displayed entries.
-  if (syn_block->b_sst_len <= Rows) {
+  if (syn_block->b_sst_len <= g_rows) {
     dist = 999999;
   } else {
-    dist = syn_buf->b_ml.ml_line_count / (syn_block->b_sst_len - Rows) + 1;
+    dist = syn_buf->b_ml.ml_line_count / (syn_block->b_sst_len - g_rows) + 1;
   }
 
   /*
@@ -3821,8 +3821,8 @@ static void syn_list_cluster(int id)
   if (msg_col >= endcol) {      // output at least one space
     endcol = msg_col + 1;
   }
-  if (Columns <= endcol) {      // avoid hang for tiny window
-    endcol = Columns - 1;
+  if (g_columns <= endcol) {      // avoid hang for tiny window
+    endcol = g_columns - 1;
   }
 
   msg_advance(endcol);
@@ -6138,10 +6138,10 @@ static void syntime_report(void)
 
     msg_advance(69);
     int len;
-    if (Columns < 80) {
+    if (g_columns < 80) {
       len = 20;       // will wrap anyway
     } else {
-      len = Columns - 70;
+      len = g_columns - 70;
     }
     if (len > (int)STRLEN(p->pattern)) {
       len = (int)STRLEN(p->pattern);
@@ -7544,7 +7544,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
   } else if ((ui_has(kUIMessages) || msg_silent) && !force_newline) {
     msg_putchar(' ');
     adjust = false;
-  } else if (msg_col + outlen + 1 >= Columns || force_newline) {
+  } else if (msg_col + outlen + 1 >= g_columns || force_newline) {
     msg_putchar('\n');
     if (got_int) {
       return true;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -93,7 +93,7 @@ typedef struct hl_group {
 static garray_T highlight_ga = GA_EMPTY_INIT_VALUE;
 Map(cstr_t, int) highlight_unames = MAP_INIT;
 
-static inline struct hl_group *HL_TABLE(void)
+static inline struct hl_group *hl_table(void)
 {
   return ((struct hl_group *)((highlight_ga.ga_data)));
 }
@@ -244,7 +244,7 @@ static char *(spo_name_tab[SPO_COUNT]) =
 
 #define SYN_ITEMS(buf)  ((synpat_T *)((buf)->b_syn_patterns.ga_data))
 
-#define NONE_IDX        -2      // value of sp_sync_idx for "NONE"
+#define NONE_IDX        (-2)      // value of sp_sync_idx for "NONE"
 
 /*
  * Flags for b_syn_sync_flags:
@@ -330,9 +330,9 @@ static int keepend_level = -1;
 static char msg_no_items[] = N_("No Syntax items defined for this buffer");
 
 // value of si_idx for keywords
-#define KEYWORD_IDX     -1
+#define KEYWORD_IDX     (-1)
 // valid of si_cont_list for containing all but contained groups
-#define ID_LIST_ALL     (int16_t *)-1
+#define ID_LIST_ALL     ((int16_t *)-1)
 
 static int next_seqnr = 1;              // value to use for si_seqnr
 
@@ -404,7 +404,8 @@ void syntax_start(win_T *wp, linenr_T lnum)
   synstate_T *p;
   synstate_T *last_valid = NULL;
   synstate_T *last_min_valid = NULL;
-  synstate_T *sp, *prev = NULL;
+  synstate_T *sp;
+  synstate_T *prev = NULL;
   linenr_T parsed_lnum;
   linenr_T first_stored;
   int dist;
@@ -1061,7 +1062,8 @@ void syn_stack_free_all(synblock_T *block)
 static void syn_stack_alloc(void)
 {
   long len;
-  synstate_T *to, *from;
+  synstate_T *to;
+  synstate_T *from;
   synstate_T *sstp;
 
   len = syn_buf->b_ml.ml_line_count / SST_DIST + Rows * 2;
@@ -1146,7 +1148,9 @@ void syn_stack_apply_changes(buf_T *buf)
 
 static void syn_stack_apply_changes_block(synblock_T *block, buf_T *buf)
 {
-  synstate_T *p, *prev, *np;
+  synstate_T *p;
+  synstate_T *prev;
+  synstate_T *np;
   linenr_T n;
 
   prev = NULL;
@@ -1192,7 +1196,8 @@ static void syn_stack_apply_changes_block(synblock_T *block, buf_T *buf)
 /// @return  true if at least one entry was freed.
 static bool syn_stack_cleanup(void)
 {
-  synstate_T *p, *prev;
+  synstate_T *p;
+  synstate_T *prev;
   disptick_T tick;
   int dist;
   bool retval = false;
@@ -1264,7 +1269,8 @@ static void syn_stack_free_entry(synblock_T *block, synstate_T *p)
  */
 static synstate_T *syn_stack_find_entry(linenr_T lnum)
 {
-  synstate_T *p, *prev;
+  synstate_T *p;
+  synstate_T *prev;
 
   prev = NULL;
   for (p = syn_block->b_sst_first; p != NULL; prev = p, p = p->sst_next) {
@@ -1437,7 +1443,8 @@ static void load_current_state(synstate_T *from)
 static bool syn_stack_equal(synstate_T *sp)
 {
   bufstate_T *bp;
-  reg_extmatch_T *six, *bsx;
+  reg_extmatch_T *six;
+  reg_extmatch_T *bsx;
 
   // First a quick check if the stacks have the same size end nextlist.
   if (sp->sst_stacksize != current_state.ga_len
@@ -1692,7 +1699,8 @@ static int syn_current_attr(const bool syncing, const bool displaying, bool *con
   lpos_T eos_pos;               // end-of-start match (start region)
   lpos_T eoe_pos;               // end-of-end pattern
   int end_idx;                  // group ID for end pattern
-  stateitem_T *cur_si, *sip = NULL;
+  stateitem_T *cur_si;
+  stateitem_T *sip = NULL;
   int startcol;
   int endcol;
   long flags;
@@ -2633,7 +2641,8 @@ static void find_endpos(int idx, lpos_T *startpos, lpos_T *m_endpos, lpos_T *hl_
                         long *flagsp, lpos_T *end_endpos, int *end_idx, reg_extmatch_T *start_ext)
 {
   colnr_T matchcol;
-  synpat_T *spp, *spp_skip;
+  synpat_T *spp;
+  synpat_T *spp_skip;
   int start_idx;
   int best_idx;
   regmmatch_T regmatch;
@@ -3768,7 +3777,7 @@ static void syn_list_one(const int id, const bool syncing, const bool link_only)
       }
       msg_putchar(' ');
       if (spp->sp_sync_idx >= 0) {
-        msg_outtrans(HL_TABLE()[SYN_ITEMS(curwin->w_s)
+        msg_outtrans(hl_table()[SYN_ITEMS(curwin->w_s)
                                 [spp->sp_sync_idx].sp_syn.id - 1].sg_name);
       } else {
         MSG_PUTS("NONE");
@@ -3778,11 +3787,11 @@ static void syn_list_one(const int id, const bool syncing, const bool link_only)
   }
 
   // list the link, if there is one
-  if (HL_TABLE()[id - 1].sg_link && (did_header || link_only) && !got_int) {
+  if (hl_table()[id - 1].sg_link && (did_header || link_only) && !got_int) {
     (void)syn_list_header(did_header, 0, id, true);
     msg_puts_attr("links to", attr);
     msg_putchar(' ');
-    msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
+    msg_outtrans(hl_table()[hl_table()[id - 1].sg_link - 1].sg_name);
   }
 }
 
@@ -3846,7 +3855,7 @@ static void put_id_list(const char *const name, const int16_t *const list, const
       msg_putchar('@');
       msg_outtrans(SYN_CLSTR(curwin->w_s)[scl_id].scl_name);
     } else {
-      msg_outtrans(HL_TABLE()[*p - 1].sg_name);
+      msg_outtrans(hl_table()[*p - 1].sg_name);
     }
     if (p[1]) {
       msg_putchar(',');
@@ -3857,7 +3866,7 @@ static void put_id_list(const char *const name, const int16_t *const list, const
 
 static void put_pattern(const char *const s, const int c, const synpat_T *const spp, const int attr)
 {
-  static const char *const sepchars = "/+=-#@\"|'^&";
+  static const char *const kSepchars = "/+=-#@\"|'^&";
   int i;
 
   // May have to write "matchgroup=group"
@@ -3868,7 +3877,7 @@ static void put_pattern(const char *const s, const int c, const synpat_T *const 
     if (last_matchgroup == 0) {
       msg_outtrans((char_u *)"NONE");
     } else {
-      msg_outtrans(HL_TABLE()[last_matchgroup - 1].sg_name);
+      msg_outtrans(hl_table()[last_matchgroup - 1].sg_name);
     }
     msg_putchar(' ');
   }
@@ -3878,15 +3887,15 @@ static void put_pattern(const char *const s, const int c, const synpat_T *const 
   msg_putchar(c);
 
   // output the pattern, in between a char that is not in the pattern
-  for (i = 0; vim_strchr(spp->sp_pattern, sepchars[i]) != NULL; ) {
-    if (sepchars[++i] == NUL) {
+  for (i = 0; vim_strchr(spp->sp_pattern, kSepchars[i]) != NULL; ) {
+    if (kSepchars[++i] == NUL) {
       i = 0;            // no good char found, just use the first one
       break;
     }
   }
-  msg_putchar(sepchars[i]);
+  msg_putchar(kSepchars[i]);
   msg_outtrans(spp->sp_pattern);
-  msg_putchar(sepchars[i]);
+  msg_putchar(kSepchars[i]);
 
   // output any pattern options
   bool first = true;
@@ -4157,7 +4166,8 @@ static char_u *get_group_name(char_u *arg, char_u **name_end)
 ///              Return NULL for any error;
 static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_char, int skip)
 {
-  char_u *gname_start, *gname;
+  char_u *gname_start;
+  char_u *gname;
   int syn_id;
   int len = 0;
   char *p;
@@ -4166,7 +4176,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
     char *name;
     int argtype;
     int flags;
-  } flagtab[] = { { "cCoOnNtTaAiInNeEdD",      0,      HL_CONTAINED },
+  } kFlagtab[] = { { "cCoOnNtTaAiInNeEdD",      0,      HL_CONTAINED },
                   { "oOnNeElLiInNeE",          0,      HL_ONELINE },
                   { "kKeEeEpPeEnNdD",          0,      HL_KEEPEND },
                   { "eExXtTeEnNdD",            0,      HL_EXTEND },
@@ -4185,7 +4195,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
                   { "cCoOnNtTaAiInNsS",        1,      0 },
                   { "cCoOnNtTaAiInNeEdDiInN",  2,      0 },
                   { "nNeExXtTgGrRoOuUpP",      3,      0 }, };
-  static const char *const first_letters = "cCoOkKeEtTsSgGdDfFnN";
+  static const char *const kFirstLetters = "cCoOkKeEtTsSgGdDfFnN";
 
   if (arg == NULL) {            // already detected error
     return NULL;
@@ -4201,12 +4211,12 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
      * Need to skip quickly when no option name is found.
      * Also avoid tolower(), it's slow.
      */
-    if (strchr(first_letters, *arg) == NULL) {
+    if (strchr(kFirstLetters, *arg) == NULL) {
       break;
     }
 
-    for (fidx = ARRAY_SIZE(flagtab); --fidx >= 0; ) {
-      p = flagtab[fidx].name;
+    for (fidx = ARRAY_SIZE(kFlagtab); --fidx >= 0; ) {
+      p = kFlagtab[fidx].name;
       int i;
       for (i = 0, len = 0; p[i] != NUL; i += 2, ++len) {
         if (arg[len] != p[i] && arg[len] != p[i + 1]) {
@@ -4214,13 +4224,13 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
         }
       }
       if (p[i] == NUL && (ascii_iswhite(arg[len])
-                          || (flagtab[fidx].argtype > 0
+                          || (kFlagtab[fidx].argtype > 0
                               ? arg[len] == '='
                               : ends_excmd(arg[len])))) {
         if (opt->keyword
-            && (flagtab[fidx].flags == HL_DISPLAY
-                || flagtab[fidx].flags == HL_FOLD
-                || flagtab[fidx].flags == HL_EXTEND)) {
+            && (kFlagtab[fidx].flags == HL_DISPLAY
+                || kFlagtab[fidx].flags == HL_FOLD
+                || kFlagtab[fidx].flags == HL_EXTEND)) {
           // treat "display", "fold" and "extend" as a keyword
           fidx = -1;
         }
@@ -4231,7 +4241,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       break;
     }
 
-    if (flagtab[fidx].argtype == 1) {
+    if (kFlagtab[fidx].argtype == 1) {
       if (!opt->has_cont_list) {
         EMSG(_("E395: contains argument not accepted here"));
         return NULL;
@@ -4239,15 +4249,15 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       if (get_id_list(&arg, 8, &opt->cont_list, skip) == FAIL) {
         return NULL;
       }
-    } else if (flagtab[fidx].argtype == 2) {
+    } else if (kFlagtab[fidx].argtype == 2) {
       if (get_id_list(&arg, 11, &opt->cont_in_list, skip) == FAIL) {
         return NULL;
       }
-    } else if (flagtab[fidx].argtype == 3) {
+    } else if (kFlagtab[fidx].argtype == 3) {
       if (get_id_list(&arg, 9, &opt->next_list, skip) == FAIL) {
         return NULL;
       }
-    } else if (flagtab[fidx].argtype == 11 && arg[5] == '=') {
+    } else if (kFlagtab[fidx].argtype == 11 && arg[5] == '=') {
       // cchar=?
       *conceal_char = utf_ptr2char(arg + 6);
       arg += mb_ptr2len(arg + 6) - 1;
@@ -4257,11 +4267,11 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       }
       arg = skipwhite(arg + 7);
     } else {
-      opt->flags |= flagtab[fidx].flags;
+      opt->flags |= kFlagtab[fidx].flags;
       arg = skipwhite(arg + len);
 
-      if (flagtab[fidx].flags == HL_SYNC_HERE
-          || flagtab[fidx].flags == HL_SYNC_THERE) {
+      if (kFlagtab[fidx].flags == HL_SYNC_HERE
+          || kFlagtab[fidx].flags == HL_SYNC_THERE) {
         if (opt->sync_idx == NULL) {
           EMSG(_("E393: group[t]here not accepted here"));
           return NULL;
@@ -4293,7 +4303,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
 
         xfree(gname);
         arg = skipwhite(arg);
-      } else if (flagtab[fidx].flags == HL_FOLD
+      } else if (kFlagtab[fidx].flags == HL_FOLD
                  && foldmethodIsSyntax(curwin)) {
         // Need to update folds later.
         foldUpdateAll(curwin);
@@ -4487,7 +4497,7 @@ static void syn_cmd_keyword(exarg_T *eap, int syncing)
               kw = p + 1;
               break;   // skip over the "]"
             }
-            const int l = (*mb_ptr2len)(p + 1);
+            const int l = (mb_ptr2len)(p + 1);
 
             memmove(p, p + 1, l);
             p += l;
@@ -5462,7 +5472,7 @@ static int get_id_list(char_u **const arg, const int keylen, int16_t **const lis
           regmatch.rm_ic = TRUE;
           id = 0;
           for (int i = highlight_ga.ga_len; --i >= 0; ) {
-            if (vim_regexec(&regmatch, HL_TABLE()[i].sg_name, (colnr_T)0)) {
+            if (vim_regexec(&regmatch, hl_table()[i].sg_name, (colnr_T)0)) {
               if (round == 2) {
                 // Got more items than expected; can happen
                 // when adding items that match:
@@ -5771,10 +5781,10 @@ bool syntax_present(win_T *win)
 
 
 static enum {
-  EXP_SUBCMD,       // expand ":syn" sub-commands
-  EXP_CASE,         // expand ":syn case" arguments
-  EXP_SPELL,        // expand ":syn spell" arguments
-  EXP_SYNC          // expand ":syn sync" arguments
+  kExpSubcmd,       // expand ":syn" sub-commands
+  kExpCase,         // expand ":syn case" arguments
+  kExpSpell,        // expand ":syn spell" arguments
+  kExpSync          // expand ":syn sync" arguments
 } expand_what;
 
 /*
@@ -5804,7 +5814,7 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
 {
   // Default: expand subcommands.
   xp->xp_context = EXPAND_SYNTAX;
-  expand_what = EXP_SUBCMD;
+  expand_what = kExpSubcmd;
   xp->xp_pattern = (char_u *)arg;
   include_link = 0;
   include_default = 0;
@@ -5817,11 +5827,11 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
       if (*skiptowhite(xp->xp_pattern) != NUL) {
         xp->xp_context = EXPAND_NOTHING;
       } else if (STRNICMP(arg, "case", p - arg) == 0) {
-        expand_what = EXP_CASE;
+        expand_what = kExpCase;
       } else if (STRNICMP(arg, "spell", p - arg) == 0) {
-        expand_what = EXP_SPELL;
+        expand_what = kExpSpell;
       } else if (STRNICMP(arg, "sync", p - arg) == 0) {
-        expand_what = EXP_SYNC;
+        expand_what = kExpSync;
       } else if (STRNICMP(arg, "keyword", p - arg) == 0
                  || STRNICMP(arg, "region", p - arg) == 0
                  || STRNICMP(arg, "match", p - arg) == 0
@@ -5841,18 +5851,18 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
 char_u *get_syntax_name(expand_T *xp, int idx)
 {
   switch (expand_what) {
-  case EXP_SUBCMD:
+  case kExpSubcmd:
     return (char_u *)subcommands[idx].name;
-  case EXP_CASE: {
+  case kExpCase: {
     static char *case_args[] = { "match", "ignore", NULL };
     return (char_u *)case_args[idx];
   }
-  case EXP_SPELL: {
+  case kExpSpell: {
     static char *spell_args[] =
     { "toplevel", "notoplevel", "default", NULL };
     return (char_u *)spell_args[idx];
   }
-  case EXP_SYNC: {
+  case kExpSync: {
     static char *sync_args[] =
     { "ccomment", "clear", "fromstart",
       "linebreaks=", "linecont", "lines=", "match",
@@ -6123,7 +6133,7 @@ static void syntime_report(void)
     MSG_PUTS(profile_msg(p->average));
     MSG_PUTS(" ");
     msg_advance(50);
-    msg_outtrans(HL_TABLE()[p->id - 1].sg_name);
+    msg_outtrans(hl_table()[p->id - 1].sg_name);
     MSG_PUTS(" ");
 
     msg_advance(69);
@@ -6470,8 +6480,7 @@ const char *const highlight_init_cmdline[] = {
   "default link NvimInvalidOptionSigil NvimInvalidIdentifier",
   "default link NvimInvalidOptionName NvimInvalidIdentifier",
   "default link NvimInvalidOptionScope NvimInvalidIdentifierScope",
-  "default link NvimInvalidOptionScopeDelimiter "
-  "NvimInvalidIdentifierScopeDelimiter",
+  "default link NvimInvalidOptionScopeDelimiter NvimInvalidIdentifierScopeDelimiter",
 
   "default link NvimInvalidEnvironmentSigil NvimInvalidOptionSigil",
   "default link NvimInvalidEnvironmentName NvimInvalidIdentifier",
@@ -6803,7 +6812,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     }
 
     if (from_id > 0) {
-      hlgroup = &HL_TABLE()[from_id - 1];
+      hlgroup = &hl_table()[from_id - 1];
       if (dodefault && (forceit || hlgroup->sg_deflink == 0)) {
         hlgroup->sg_deflink = to_id;
         hlgroup->sg_deflink_sctx = current_sctx;
@@ -6872,14 +6881,14 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   }
 
   // Make a copy so we can check if any attribute actually changed
-  item_before = HL_TABLE()[idx];
-  is_normal_group = (STRCMP(HL_TABLE()[idx].sg_name_u, "NORMAL") == 0);
+  item_before = hl_table()[idx];
+  is_normal_group = (STRCMP(hl_table()[idx].sg_name_u, "NORMAL") == 0);
 
   // Clear the highlighting for ":hi clear {group}" and ":hi clear".
   if (doclear || (forceit && init)) {
     highlight_clear(idx);
     if (!doclear) {
-      HL_TABLE()[idx].sg_set = 0;
+      hl_table()[idx].sg_set = 0;
     }
   }
 
@@ -6905,9 +6914,9 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       linep = (const char *)skipwhite((const char_u *)linep);
 
       if (strcmp(key, "NONE") == 0) {
-        if (!init || HL_TABLE()[idx].sg_set == 0) {
+        if (!init || hl_table()[idx].sg_set == 0) {
           if (!init) {
-            HL_TABLE()[idx].sg_set |= SG_CTERM+SG_GUI;
+            hl_table()[idx].sg_set |= SG_CTERM+SG_GUI;
           }
           highlight_clear(idx);
         }
@@ -6976,34 +6985,34 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           break;
         }
         if (*key == 'C') {
-          if (!init || !(HL_TABLE()[idx].sg_set & SG_CTERM)) {
+          if (!init || !(hl_table()[idx].sg_set & SG_CTERM)) {
             if (!init) {
-              HL_TABLE()[idx].sg_set |= SG_CTERM;
+              hl_table()[idx].sg_set |= SG_CTERM;
             }
-            HL_TABLE()[idx].sg_cterm = attr;
-            HL_TABLE()[idx].sg_cterm_bold = false;
+            hl_table()[idx].sg_cterm = attr;
+            hl_table()[idx].sg_cterm_bold = false;
           }
         } else if (*key == 'G') {
-          if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
+          if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
             if (!init) {
-              HL_TABLE()[idx].sg_set |= SG_GUI;
+              hl_table()[idx].sg_set |= SG_GUI;
             }
-            HL_TABLE()[idx].sg_gui = attr;
+            hl_table()[idx].sg_gui = attr;
           }
         }
       } else if (STRCMP(key, "FONT") == 0) {
         // in non-GUI fonts are simply ignored
       } else if (STRCMP(key, "CTERMFG") == 0 || STRCMP(key, "CTERMBG") == 0) {
-        if (!init || !(HL_TABLE()[idx].sg_set & SG_CTERM)) {
+        if (!init || !(hl_table()[idx].sg_set & SG_CTERM)) {
           if (!init) {
-            HL_TABLE()[idx].sg_set |= SG_CTERM;
+            hl_table()[idx].sg_set |= SG_CTERM;
           }
 
           /* When setting the foreground color, and previously the "bold"
            * flag was set for a light color, reset it now */
-          if (key[5] == 'F' && HL_TABLE()[idx].sg_cterm_bold) {
-            HL_TABLE()[idx].sg_cterm &= ~HL_BOLD;
-            HL_TABLE()[idx].sg_cterm_bold = false;
+          if (key[5] == 'F' && hl_table()[idx].sg_cterm_bold) {
+            hl_table()[idx].sg_cterm &= ~HL_BOLD;
+            hl_table()[idx].sg_cterm_bold = false;
           }
 
           if (ascii_isdigit(*arg)) {
@@ -7046,21 +7055,21 @@ void do_highlight(const char *line, const bool forceit, const bool init)
             // set/reset bold attribute to get light foreground
             // colors (on some terminals, e.g. "linux")
             if (bold == kTrue) {
-              HL_TABLE()[idx].sg_cterm |= HL_BOLD;
-              HL_TABLE()[idx].sg_cterm_bold = true;
+              hl_table()[idx].sg_cterm |= HL_BOLD;
+              hl_table()[idx].sg_cterm_bold = true;
             } else if (bold == kFalse) {
-              HL_TABLE()[idx].sg_cterm &= ~HL_BOLD;
+              hl_table()[idx].sg_cterm &= ~HL_BOLD;
             }
           }
           // Add one to the argument, to avoid zero.  Zero is used for
           // "NONE", then "color" is -1.
           if (key[5] == 'F') {
-            HL_TABLE()[idx].sg_cterm_fg = color + 1;
+            hl_table()[idx].sg_cterm_fg = color + 1;
             if (is_normal_group) {
               cterm_normal_fg_color = color + 1;
             }
           } else {
-            HL_TABLE()[idx].sg_cterm_bg = color + 1;
+            hl_table()[idx].sg_cterm_bg = color + 1;
             if (is_normal_group) {
               cterm_normal_bg_color = color + 1;
               if (!ui_rgb_attached()) {
@@ -7087,95 +7096,95 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           }
         }
       } else if (strcmp(key, "GUIFG") == 0) {
-        char **namep = &HL_TABLE()[idx].sg_rgb_fg_name;
+        char **namep = &hl_table()[idx].sg_rgb_fg_name;
 
-        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
+        if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
           if (!init) {
-            HL_TABLE()[idx].sg_set |= SG_GUI;
+            hl_table()[idx].sg_set |= SG_GUI;
           }
 
           if (*namep == NULL || STRCMP(*namep, arg) != 0) {
             xfree(*namep);
             if (strcmp(arg, "NONE") != 0) {
               *namep = xstrdup(arg);
-              HL_TABLE()[idx].sg_rgb_fg = name_to_color(arg);
+              hl_table()[idx].sg_rgb_fg = name_to_color(arg);
             } else {
               *namep = NULL;
-              HL_TABLE()[idx].sg_rgb_fg = -1;
+              hl_table()[idx].sg_rgb_fg = -1;
             }
             did_change = true;
           }
         }
 
         if (is_normal_group) {
-          normal_fg = HL_TABLE()[idx].sg_rgb_fg;
+          normal_fg = hl_table()[idx].sg_rgb_fg;
         }
       } else if (STRCMP(key, "GUIBG") == 0) {
-        char **const namep = &HL_TABLE()[idx].sg_rgb_bg_name;
+        char **const namep = &hl_table()[idx].sg_rgb_bg_name;
 
-        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
+        if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
           if (!init) {
-            HL_TABLE()[idx].sg_set |= SG_GUI;
+            hl_table()[idx].sg_set |= SG_GUI;
           }
 
           if (*namep == NULL || STRCMP(*namep, arg) != 0) {
             xfree(*namep);
             if (STRCMP(arg, "NONE") != 0) {
               *namep = xstrdup(arg);
-              HL_TABLE()[idx].sg_rgb_bg = name_to_color(arg);
+              hl_table()[idx].sg_rgb_bg = name_to_color(arg);
             } else {
               *namep = NULL;
-              HL_TABLE()[idx].sg_rgb_bg = -1;
+              hl_table()[idx].sg_rgb_bg = -1;
             }
             did_change = true;
           }
         }
 
         if (is_normal_group) {
-          normal_bg = HL_TABLE()[idx].sg_rgb_bg;
+          normal_bg = hl_table()[idx].sg_rgb_bg;
         }
       } else if (strcmp(key, "GUISP") == 0) {
-        char **const namep = &HL_TABLE()[idx].sg_rgb_sp_name;
+        char **const namep = &hl_table()[idx].sg_rgb_sp_name;
 
-        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
+        if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
           if (!init) {
-            HL_TABLE()[idx].sg_set |= SG_GUI;
+            hl_table()[idx].sg_set |= SG_GUI;
           }
 
           if (*namep == NULL || STRCMP(*namep, arg) != 0) {
             xfree(*namep);
             if (strcmp(arg, "NONE") != 0) {
               *namep = xstrdup(arg);
-              HL_TABLE()[idx].sg_rgb_sp = name_to_color(arg);
+              hl_table()[idx].sg_rgb_sp = name_to_color(arg);
             } else {
               *namep = NULL;
-              HL_TABLE()[idx].sg_rgb_sp = -1;
+              hl_table()[idx].sg_rgb_sp = -1;
             }
             did_change = true;
           }
         }
 
         if (is_normal_group) {
-          normal_sp = HL_TABLE()[idx].sg_rgb_sp;
+          normal_sp = hl_table()[idx].sg_rgb_sp;
         }
       } else if (strcmp(key, "START") == 0 || strcmp(key, "STOP") == 0) {
         // Ignored for now
       } else if (strcmp(key, "BLEND") == 0) {
         if (strcmp(arg, "NONE") != 0) {
-          HL_TABLE()[idx].sg_blend = strtol(arg, NULL, 10);
+          hl_table()[idx].sg_blend = strtol(arg, NULL, 10);
         } else {
-          HL_TABLE()[idx].sg_blend = -1;
+          hl_table()[idx].sg_blend = -1;
         }
       } else {
         emsgf(_("E423: Illegal argument: %s"), key_start);
         error = true;
         break;
       }
-      HL_TABLE()[idx].sg_cleared = false;
+      hl_table()[idx].sg_cleared = false;
 
       // When highlighting has been given for a group, don't link it.
-      if (!init || !(HL_TABLE()[idx].sg_set & SG_LINK)) {
-        HL_TABLE()[idx].sg_link = 0;
+      if (!init || !(hl_table()[idx].sg_set & SG_LINK)) {
+        hl_table()[idx].sg_link = 0;
       }
 
       // Continue with next argument.
@@ -7206,8 +7215,8 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     } else {
       set_hl_attr(idx);
     }
-    HL_TABLE()[idx].sg_script_ctx = current_sctx;
-    HL_TABLE()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
+    hl_table()[idx].sg_script_ctx = current_sctx;
+    hl_table()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
   }
   xfree(key);
   xfree(arg);
@@ -7215,7 +7224,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   // Only call highlight_changed() once, after a sequence of highlight
   // commands, and only if an attribute actually changed
   if ((did_change
-       || memcmp(&HL_TABLE()[idx], &item_before, sizeof(item_before)) != 0)
+       || memcmp(&hl_table()[idx], &item_before, sizeof(item_before)) != 0)
       && !did_highlight_changed) {
     // Do not trigger a redraw when highlighting is changed while
     // redrawing.  This may happen when evaluating 'statusline' changes the
@@ -7259,14 +7268,14 @@ void restore_cterm_colors(void)
 /// @return TRUE if highlight group "idx" has any settings.
 static int hl_has_settings(int idx, bool check_link)
 {
-  return HL_TABLE()[idx].sg_cleared == 0
-         && (HL_TABLE()[idx].sg_attr != 0
-             || HL_TABLE()[idx].sg_cterm_fg != 0
-             || HL_TABLE()[idx].sg_cterm_bg != 0
-             || HL_TABLE()[idx].sg_rgb_fg_name != NULL
-             || HL_TABLE()[idx].sg_rgb_bg_name != NULL
-             || HL_TABLE()[idx].sg_rgb_sp_name != NULL
-             || (check_link && (HL_TABLE()[idx].sg_set & SG_LINK)));
+  return hl_table()[idx].sg_cleared == 0
+         && (hl_table()[idx].sg_attr != 0
+             || hl_table()[idx].sg_cterm_fg != 0
+             || hl_table()[idx].sg_cterm_bg != 0
+             || hl_table()[idx].sg_rgb_fg_name != NULL
+             || hl_table()[idx].sg_rgb_bg_name != NULL
+             || hl_table()[idx].sg_rgb_sp_name != NULL
+             || (check_link && (hl_table()[idx].sg_set & SG_LINK)));
 }
 
 /*
@@ -7274,26 +7283,26 @@ static int hl_has_settings(int idx, bool check_link)
  */
 static void highlight_clear(int idx)
 {
-  HL_TABLE()[idx].sg_cleared = true;
+  hl_table()[idx].sg_cleared = true;
 
-  HL_TABLE()[idx].sg_attr = 0;
-  HL_TABLE()[idx].sg_cterm = 0;
-  HL_TABLE()[idx].sg_cterm_bold = false;
-  HL_TABLE()[idx].sg_cterm_fg = 0;
-  HL_TABLE()[idx].sg_cterm_bg = 0;
-  HL_TABLE()[idx].sg_gui = 0;
-  HL_TABLE()[idx].sg_rgb_fg = -1;
-  HL_TABLE()[idx].sg_rgb_bg = -1;
-  HL_TABLE()[idx].sg_rgb_sp = -1;
-  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_fg_name);
-  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_bg_name);
-  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_sp_name);
-  HL_TABLE()[idx].sg_blend = -1;
+  hl_table()[idx].sg_attr = 0;
+  hl_table()[idx].sg_cterm = 0;
+  hl_table()[idx].sg_cterm_bold = false;
+  hl_table()[idx].sg_cterm_fg = 0;
+  hl_table()[idx].sg_cterm_bg = 0;
+  hl_table()[idx].sg_gui = 0;
+  hl_table()[idx].sg_rgb_fg = -1;
+  hl_table()[idx].sg_rgb_bg = -1;
+  hl_table()[idx].sg_rgb_sp = -1;
+  XFREE_CLEAR(hl_table()[idx].sg_rgb_fg_name);
+  XFREE_CLEAR(hl_table()[idx].sg_rgb_bg_name);
+  XFREE_CLEAR(hl_table()[idx].sg_rgb_sp_name);
+  hl_table()[idx].sg_blend = -1;
   // Restore default link and context if they exist. Otherwise clears.
-  HL_TABLE()[idx].sg_link = HL_TABLE()[idx].sg_deflink;
+  hl_table()[idx].sg_link = hl_table()[idx].sg_deflink;
   // Since we set the default link, set the location to where the default
   // link was set.
-  HL_TABLE()[idx].sg_script_ctx = HL_TABLE()[idx].sg_deflink_sctx;
+  hl_table()[idx].sg_script_ctx = hl_table()[idx].sg_deflink_sctx;
 }
 
 
@@ -7306,7 +7315,7 @@ static void highlight_clear(int idx)
 
 static void highlight_list_one(const int id)
 {
-  struct hl_group *const sgp = &HL_TABLE()[id - 1];  // index is ID minus one
+  struct hl_group *const sgp = &hl_table()[id - 1];  // index is ID minus one
   bool didh = false;
 
   if (message_filtered(sgp->sg_name)) {
@@ -7337,7 +7346,7 @@ static void highlight_list_one(const int id)
     didh = true;
     msg_puts_attr("links to", HL_ATTR(HLF_D));
     msg_putchar(' ');
-    msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
+    msg_outtrans(hl_table()[hl_table()[id - 1].sg_link - 1].sg_name);
   }
 
   if (!didh) {
@@ -7353,11 +7362,11 @@ Dictionary get_global_hl_defs(void)
   Dictionary rv = ARRAY_DICT_INIT;
   for (int i = 1; i <= highlight_ga.ga_len && !got_int; i++) {
     Dictionary attrs = ARRAY_DICT_INIT;
-    struct hl_group *h = &HL_TABLE()[i - 1];
+    struct hl_group *h = &hl_table()[i - 1];
     if (h->sg_attr > 0) {
       attrs = hlattrs2dict(syn_attr2entry(h->sg_attr), true);
     } else if (h->sg_link > 0) {
-      const char *link = (const char *)HL_TABLE()[h->sg_link - 1].sg_name;
+      const char *link = (const char *)hl_table()[h->sg_link - 1].sg_name;
       PUT(attrs, "link", STRING_OBJ(cstr_to_string(link)));
     }
     PUT(rv, (const char *)h->sg_name, DICTIONARY_OBJ(attrs));
@@ -7429,9 +7438,9 @@ const char *highlight_has_attr(const int id, const int flag, const int modec)
   }
 
   if (modec == 'g') {
-    attr = HL_TABLE()[id - 1].sg_gui;
+    attr = hl_table()[id - 1].sg_gui;
   } else {
-    attr = HL_TABLE()[id - 1].sg_cterm;
+    attr = hl_table()[id - 1].sg_cterm;
   }
 
   return (attr & flag) ? "1" : NULL;
@@ -7472,11 +7481,11 @@ const char *highlight_color(const int id, const char *const what, const int mode
   if (modec == 'g') {
     if (what[2] == '#' && ui_rgb_attached()) {
       if (fg) {
-        n = HL_TABLE()[id - 1].sg_rgb_fg;
+        n = hl_table()[id - 1].sg_rgb_fg;
       } else if (sp) {
-        n = HL_TABLE()[id - 1].sg_rgb_sp;
+        n = hl_table()[id - 1].sg_rgb_sp;
       } else {
-        n = HL_TABLE()[id - 1].sg_rgb_bg;
+        n = hl_table()[id - 1].sg_rgb_bg;
       }
       if (n < 0 || n > 0xffffff) {
         return NULL;
@@ -7485,21 +7494,21 @@ const char *highlight_color(const int id, const char *const what, const int mode
       return name;
     }
     if (fg) {
-      return (const char *)HL_TABLE()[id - 1].sg_rgb_fg_name;
+      return (const char *)hl_table()[id - 1].sg_rgb_fg_name;
     }
     if (sp) {
-      return (const char *)HL_TABLE()[id - 1].sg_rgb_sp_name;
+      return (const char *)hl_table()[id - 1].sg_rgb_sp_name;
     }
-    return (const char *)HL_TABLE()[id - 1].sg_rgb_bg_name;
+    return (const char *)hl_table()[id - 1].sg_rgb_bg_name;
   }
   if (font || sp) {
     return NULL;
   }
   if (modec == 'c') {
     if (fg) {
-      n = HL_TABLE()[id - 1].sg_cterm_fg - 1;
+      n = hl_table()[id - 1].sg_cterm_fg - 1;
     } else {
-      n = HL_TABLE()[id - 1].sg_cterm_bg - 1;
+      n = hl_table()[id - 1].sg_cterm_bg - 1;
     }
     if (n < 0) {
       return NULL;
@@ -7530,7 +7539,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
     if (got_int) {
       return true;
     }
-    msg_outtrans(HL_TABLE()[id - 1].sg_name);
+    msg_outtrans(hl_table()[id - 1].sg_name);
     endcol = 15;
   } else if ((ui_has(kUIMessages) || msg_silent) && !force_newline) {
     msg_putchar(' ');
@@ -7570,7 +7579,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
 static void set_hl_attr(int idx)
 {
   HlAttrs at_en = HLATTRS_INIT;
-  struct hl_group *sgp = HL_TABLE() + idx;
+  struct hl_group *sgp = hl_table() + idx;
 
   at_en.cterm_ae_attr = sgp->sg_cterm;
   at_en.cterm_fg_color = sgp->sg_cterm_fg;
@@ -7653,7 +7662,7 @@ char_u *syn_id2name(int id)
   if (id <= 0 || id > highlight_ga.ga_len) {
     return (char_u *)"";
   }
-  return HL_TABLE()[id - 1].sg_name;
+  return hl_table()[id - 1].sg_name;
 }
 
 
@@ -7735,7 +7744,7 @@ static int syn_add_group(char_u *name)
 static void syn_unadd_group(void)
 {
   highlight_ga.ga_len--;
-  HlGroup *item = &HL_TABLE()[highlight_ga.ga_len];
+  HlGroup *item = &hl_table()[highlight_ga.ga_len];
   map_del(cstr_t, int)(&highlight_unames, item->sg_name_u);
   xfree(item->sg_name);
   xfree(item->sg_name_u);
@@ -7747,7 +7756,7 @@ static void syn_unadd_group(void)
 int syn_id2attr(int hl_id)
 {
   hl_id = syn_get_final_id(hl_id);
-  struct hl_group *sgp = &HL_TABLE()[hl_id - 1];  // index is ID minus one
+  struct hl_group *sgp = &hl_table()[hl_id - 1];  // index is ID minus one
 
   int attr = ns_get_hl(-1, hl_id, false, sgp->sg_set);
   if (attr >= 0) {
@@ -7774,7 +7783,7 @@ int syn_get_final_id(int hl_id)
    * Look out for loops!  Break after 100 links.
    */
   for (count = 100; --count >= 0; ) {
-    struct hl_group *sgp = &HL_TABLE()[hl_id - 1];  // index is ID minus one
+    struct hl_group *sgp = &hl_table()[hl_id - 1];  // index is ID minus one
 
     // ACHTUNG: when using "tmp" attribute (no link) the function might be
     // called twice. it needs be smart enough to remember attr only to
@@ -7801,7 +7810,7 @@ int syn_get_final_id(int hl_id)
 void highlight_attr_set_all(void)
 {
   for (int idx = 0; idx < highlight_ga.ga_len; idx++) {
-    struct hl_group *sgp = &HL_TABLE()[idx];
+    struct hl_group *sgp = &hl_table()[idx];
     if (sgp->sg_rgb_bg_name != NULL) {
       sgp->sg_rgb_bg = name_to_color(sgp->sg_rgb_bg_name);
     }
@@ -7819,7 +7828,7 @@ void highlight_attr_set_all(void)
 static void combine_stl_hlt(int id, int id_S, int id_alt, int hlcnt, int i, int hlf, int *table)
   FUNC_ATTR_NONNULL_ALL
 {
-  struct hl_group *const hlt = HL_TABLE();
+  struct hl_group *const hlt = hl_table();
 
   if (id_alt == 0) {
     memset(&hlt[hlcnt + i], 0, sizeof(struct hl_group));
@@ -7860,8 +7869,8 @@ void highlight_changed(void)
 {
   int id;
   char_u userhl[30];  // use 30 to avoid compiler warning
-  int id_S = -1;
-  int id_SNC = 0;
+  int id_s = -1;
+  int id_snc = 0;
   int hlcnt;
 
   need_highlight_changed = false;
@@ -7874,9 +7883,9 @@ void highlight_changed(void)
     }
     int final_id = syn_get_final_id(id);
     if (hlf == HLF_SNC) {
-      id_SNC = final_id;
+      id_snc = final_id;
     } else if (hlf == HLF_S) {
-      id_S = final_id;
+      id_s = final_id;
     }
 
     highlight_attr[hlf] = hl_get_ui_attr(hlf, final_id,
@@ -7902,10 +7911,10 @@ void highlight_changed(void)
   // get_attr_entry()
   ga_grow(&highlight_ga, 10);
   hlcnt = highlight_ga.ga_len;
-  if (id_S == -1) {
+  if (id_s == -1) {
     // Make sure id_S is always valid to simplify code below. Use the last entry
-    memset(&HL_TABLE()[hlcnt + 9], 0, sizeof(struct hl_group));
-    id_S = hlcnt + 10;
+    memset(&hl_table()[hlcnt + 9], 0, sizeof(struct hl_group));
+    id_s = hlcnt + 10;
   }
   for (int i = 0; i < 9; i++) {
     sprintf((char *)userhl, "User%d", i + 1);
@@ -7915,7 +7924,7 @@ void highlight_changed(void)
       highlight_stlnc[i] = 0;
     } else {
       highlight_user[i] = syn_id2attr(id);
-      combine_stl_hlt(id, id_S, id_SNC, hlcnt, i, HLF_SNC, highlight_stlnc);
+      combine_stl_hlt(id, id_s, id_snc, hlcnt, i, HLF_SNC, highlight_stlnc);
     }
   }
   highlight_ga.ga_len = hlcnt;
@@ -8008,7 +8017,7 @@ const char *get_highlight_name_ext(expand_T *xp, int idx, bool skip_cleared)
   }
 
   // Items are never removed from the table, skip the ones that were cleared.
-  if (skip_cleared && idx < highlight_ga.ga_len && HL_TABLE()[idx].sg_cleared) {
+  if (skip_cleared && idx < highlight_ga.ga_len && hl_table()[idx].sg_cleared) {
     return "";
   }
 
@@ -8026,7 +8035,7 @@ const char *get_highlight_name_ext(expand_T *xp, int idx, bool skip_cleared)
   } else if (idx >= highlight_ga.ga_len) {
     return NULL;
   }
-  return (const char *)HL_TABLE()[idx].sg_name;
+  return (const char *)hl_table()[idx].sg_name;
 }
 
 color_name_table_T color_name_table[] = {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -93,7 +93,7 @@ typedef struct hl_group {
 static garray_T highlight_ga = GA_EMPTY_INIT_VALUE;
 Map(cstr_t, int) highlight_unames = MAP_INIT;
 
-static inline struct hl_group *hl_table(void)
+static inline struct hl_group *HL_TABLE(void)
 {
   return ((struct hl_group *)((highlight_ga.ga_data)));
 }
@@ -244,7 +244,7 @@ static char *(spo_name_tab[SPO_COUNT]) =
 
 #define SYN_ITEMS(buf)  ((synpat_T *)((buf)->b_syn_patterns.ga_data))
 
-#define NONE_IDX        (-2)      // value of sp_sync_idx for "NONE"
+#define NONE_IDX        -2      // value of sp_sync_idx for "NONE"
 
 /*
  * Flags for b_syn_sync_flags:
@@ -330,9 +330,9 @@ static int keepend_level = -1;
 static char msg_no_items[] = N_("No Syntax items defined for this buffer");
 
 // value of si_idx for keywords
-#define KEYWORD_IDX     (-1)
+#define KEYWORD_IDX     -1
 // valid of si_cont_list for containing all but contained groups
-#define ID_LIST_ALL     ((int16_t *)-1)
+#define ID_LIST_ALL     (int16_t *)-1
 
 static int next_seqnr = 1;              // value to use for si_seqnr
 
@@ -404,8 +404,7 @@ void syntax_start(win_T *wp, linenr_T lnum)
   synstate_T *p;
   synstate_T *last_valid = NULL;
   synstate_T *last_min_valid = NULL;
-  synstate_T *sp;
-  synstate_T *prev = NULL;
+  synstate_T *sp, *prev = NULL;
   linenr_T parsed_lnum;
   linenr_T first_stored;
   int dist;
@@ -1062,8 +1061,7 @@ void syn_stack_free_all(synblock_T *block)
 static void syn_stack_alloc(void)
 {
   long len;
-  synstate_T *to;
-  synstate_T *from;
+  synstate_T *to, *from;
   synstate_T *sstp;
 
   len = syn_buf->b_ml.ml_line_count / SST_DIST + g_rows * 2;
@@ -1148,9 +1146,7 @@ void syn_stack_apply_changes(buf_T *buf)
 
 static void syn_stack_apply_changes_block(synblock_T *block, buf_T *buf)
 {
-  synstate_T *p;
-  synstate_T *prev;
-  synstate_T *np;
+  synstate_T *p, *prev, *np;
   linenr_T n;
 
   prev = NULL;
@@ -1196,8 +1192,7 @@ static void syn_stack_apply_changes_block(synblock_T *block, buf_T *buf)
 /// @return  true if at least one entry was freed.
 static bool syn_stack_cleanup(void)
 {
-  synstate_T *p;
-  synstate_T *prev;
+  synstate_T *p, *prev;
   disptick_T tick;
   int dist;
   bool retval = false;
@@ -1269,8 +1264,7 @@ static void syn_stack_free_entry(synblock_T *block, synstate_T *p)
  */
 static synstate_T *syn_stack_find_entry(linenr_T lnum)
 {
-  synstate_T *p;
-  synstate_T *prev;
+  synstate_T *p, *prev;
 
   prev = NULL;
   for (p = syn_block->b_sst_first; p != NULL; prev = p, p = p->sst_next) {
@@ -1443,8 +1437,7 @@ static void load_current_state(synstate_T *from)
 static bool syn_stack_equal(synstate_T *sp)
 {
   bufstate_T *bp;
-  reg_extmatch_T *six;
-  reg_extmatch_T *bsx;
+  reg_extmatch_T *six, *bsx;
 
   // First a quick check if the stacks have the same size end nextlist.
   if (sp->sst_stacksize != current_state.ga_len
@@ -1699,8 +1692,7 @@ static int syn_current_attr(const bool syncing, const bool displaying, bool *con
   lpos_T eos_pos;               // end-of-start match (start region)
   lpos_T eoe_pos;               // end-of-end pattern
   int end_idx;                  // group ID for end pattern
-  stateitem_T *cur_si;
-  stateitem_T *sip = NULL;
+  stateitem_T *cur_si, *sip = NULL;
   int startcol;
   int endcol;
   long flags;
@@ -2641,8 +2633,7 @@ static void find_endpos(int idx, lpos_T *startpos, lpos_T *m_endpos, lpos_T *hl_
                         long *flagsp, lpos_T *end_endpos, int *end_idx, reg_extmatch_T *start_ext)
 {
   colnr_T matchcol;
-  synpat_T *spp;
-  synpat_T *spp_skip;
+  synpat_T *spp, *spp_skip;
   int start_idx;
   int best_idx;
   regmmatch_T regmatch;
@@ -3777,7 +3768,7 @@ static void syn_list_one(const int id, const bool syncing, const bool link_only)
       }
       msg_putchar(' ');
       if (spp->sp_sync_idx >= 0) {
-        msg_outtrans(hl_table()[SYN_ITEMS(curwin->w_s)
+        msg_outtrans(HL_TABLE()[SYN_ITEMS(curwin->w_s)
                                 [spp->sp_sync_idx].sp_syn.id - 1].sg_name);
       } else {
         MSG_PUTS("NONE");
@@ -3787,11 +3778,11 @@ static void syn_list_one(const int id, const bool syncing, const bool link_only)
   }
 
   // list the link, if there is one
-  if (hl_table()[id - 1].sg_link && (did_header || link_only) && !got_int) {
+  if (HL_TABLE()[id - 1].sg_link && (did_header || link_only) && !got_int) {
     (void)syn_list_header(did_header, 0, id, true);
     msg_puts_attr("links to", attr);
     msg_putchar(' ');
-    msg_outtrans(hl_table()[hl_table()[id - 1].sg_link - 1].sg_name);
+    msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
   }
 }
 
@@ -3855,7 +3846,7 @@ static void put_id_list(const char *const name, const int16_t *const list, const
       msg_putchar('@');
       msg_outtrans(SYN_CLSTR(curwin->w_s)[scl_id].scl_name);
     } else {
-      msg_outtrans(hl_table()[*p - 1].sg_name);
+      msg_outtrans(HL_TABLE()[*p - 1].sg_name);
     }
     if (p[1]) {
       msg_putchar(',');
@@ -3866,7 +3857,7 @@ static void put_id_list(const char *const name, const int16_t *const list, const
 
 static void put_pattern(const char *const s, const int c, const synpat_T *const spp, const int attr)
 {
-  static const char *const kSepchars = "/+=-#@\"|'^&";
+  static const char *const sepchars = "/+=-#@\"|'^&";
   int i;
 
   // May have to write "matchgroup=group"
@@ -3877,7 +3868,7 @@ static void put_pattern(const char *const s, const int c, const synpat_T *const 
     if (last_matchgroup == 0) {
       msg_outtrans((char_u *)"NONE");
     } else {
-      msg_outtrans(hl_table()[last_matchgroup - 1].sg_name);
+      msg_outtrans(HL_TABLE()[last_matchgroup - 1].sg_name);
     }
     msg_putchar(' ');
   }
@@ -3887,15 +3878,15 @@ static void put_pattern(const char *const s, const int c, const synpat_T *const 
   msg_putchar(c);
 
   // output the pattern, in between a char that is not in the pattern
-  for (i = 0; vim_strchr(spp->sp_pattern, kSepchars[i]) != NULL; ) {
-    if (kSepchars[++i] == NUL) {
+  for (i = 0; vim_strchr(spp->sp_pattern, sepchars[i]) != NULL; ) {
+    if (sepchars[++i] == NUL) {
       i = 0;            // no good char found, just use the first one
       break;
     }
   }
-  msg_putchar(kSepchars[i]);
+  msg_putchar(sepchars[i]);
   msg_outtrans(spp->sp_pattern);
-  msg_putchar(kSepchars[i]);
+  msg_putchar(sepchars[i]);
 
   // output any pattern options
   bool first = true;
@@ -4166,8 +4157,7 @@ static char_u *get_group_name(char_u *arg, char_u **name_end)
 ///              Return NULL for any error;
 static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_char, int skip)
 {
-  char_u *gname_start;
-  char_u *gname;
+  char_u *gname_start, *gname;
   int syn_id;
   int len = 0;
   char *p;
@@ -4176,7 +4166,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
     char *name;
     int argtype;
     int flags;
-  } kFlagtab[] = { { "cCoOnNtTaAiInNeEdD",      0,      HL_CONTAINED },
+  } flagtab[] = { { "cCoOnNtTaAiInNeEdD",      0,      HL_CONTAINED },
                   { "oOnNeElLiInNeE",          0,      HL_ONELINE },
                   { "kKeEeEpPeEnNdD",          0,      HL_KEEPEND },
                   { "eExXtTeEnNdD",            0,      HL_EXTEND },
@@ -4195,7 +4185,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
                   { "cCoOnNtTaAiInNsS",        1,      0 },
                   { "cCoOnNtTaAiInNeEdDiInN",  2,      0 },
                   { "nNeExXtTgGrRoOuUpP",      3,      0 }, };
-  static const char *const kFirstLetters = "cCoOkKeEtTsSgGdDfFnN";
+  static const char *const first_letters = "cCoOkKeEtTsSgGdDfFnN";
 
   if (arg == NULL) {            // already detected error
     return NULL;
@@ -4211,12 +4201,12 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
      * Need to skip quickly when no option name is found.
      * Also avoid tolower(), it's slow.
      */
-    if (strchr(kFirstLetters, *arg) == NULL) {
+    if (strchr(first_letters, *arg) == NULL) {
       break;
     }
 
-    for (fidx = ARRAY_SIZE(kFlagtab); --fidx >= 0; ) {
-      p = kFlagtab[fidx].name;
+    for (fidx = ARRAY_SIZE(flagtab); --fidx >= 0; ) {
+      p = flagtab[fidx].name;
       int i;
       for (i = 0, len = 0; p[i] != NUL; i += 2, ++len) {
         if (arg[len] != p[i] && arg[len] != p[i + 1]) {
@@ -4224,13 +4214,13 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
         }
       }
       if (p[i] == NUL && (ascii_iswhite(arg[len])
-                          || (kFlagtab[fidx].argtype > 0
+                          || (flagtab[fidx].argtype > 0
                               ? arg[len] == '='
                               : ends_excmd(arg[len])))) {
         if (opt->keyword
-            && (kFlagtab[fidx].flags == HL_DISPLAY
-                || kFlagtab[fidx].flags == HL_FOLD
-                || kFlagtab[fidx].flags == HL_EXTEND)) {
+            && (flagtab[fidx].flags == HL_DISPLAY
+                || flagtab[fidx].flags == HL_FOLD
+                || flagtab[fidx].flags == HL_EXTEND)) {
           // treat "display", "fold" and "extend" as a keyword
           fidx = -1;
         }
@@ -4241,7 +4231,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       break;
     }
 
-    if (kFlagtab[fidx].argtype == 1) {
+    if (flagtab[fidx].argtype == 1) {
       if (!opt->has_cont_list) {
         EMSG(_("E395: contains argument not accepted here"));
         return NULL;
@@ -4249,15 +4239,15 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       if (get_id_list(&arg, 8, &opt->cont_list, skip) == FAIL) {
         return NULL;
       }
-    } else if (kFlagtab[fidx].argtype == 2) {
+    } else if (flagtab[fidx].argtype == 2) {
       if (get_id_list(&arg, 11, &opt->cont_in_list, skip) == FAIL) {
         return NULL;
       }
-    } else if (kFlagtab[fidx].argtype == 3) {
+    } else if (flagtab[fidx].argtype == 3) {
       if (get_id_list(&arg, 9, &opt->next_list, skip) == FAIL) {
         return NULL;
       }
-    } else if (kFlagtab[fidx].argtype == 11 && arg[5] == '=') {
+    } else if (flagtab[fidx].argtype == 11 && arg[5] == '=') {
       // cchar=?
       *conceal_char = utf_ptr2char(arg + 6);
       arg += mb_ptr2len(arg + 6) - 1;
@@ -4267,11 +4257,11 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       }
       arg = skipwhite(arg + 7);
     } else {
-      opt->flags |= kFlagtab[fidx].flags;
+      opt->flags |= flagtab[fidx].flags;
       arg = skipwhite(arg + len);
 
-      if (kFlagtab[fidx].flags == HL_SYNC_HERE
-          || kFlagtab[fidx].flags == HL_SYNC_THERE) {
+      if (flagtab[fidx].flags == HL_SYNC_HERE
+          || flagtab[fidx].flags == HL_SYNC_THERE) {
         if (opt->sync_idx == NULL) {
           EMSG(_("E393: group[t]here not accepted here"));
           return NULL;
@@ -4303,7 +4293,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
 
         xfree(gname);
         arg = skipwhite(arg);
-      } else if (kFlagtab[fidx].flags == HL_FOLD
+      } else if (flagtab[fidx].flags == HL_FOLD
                  && foldmethodIsSyntax(curwin)) {
         // Need to update folds later.
         foldUpdateAll(curwin);
@@ -4497,7 +4487,7 @@ static void syn_cmd_keyword(exarg_T *eap, int syncing)
               kw = p + 1;
               break;   // skip over the "]"
             }
-            const int l = (mb_ptr2len)(p + 1);
+            const int l = (*mb_ptr2len)(p + 1);
 
             memmove(p, p + 1, l);
             p += l;
@@ -5472,7 +5462,7 @@ static int get_id_list(char_u **const arg, const int keylen, int16_t **const lis
           regmatch.rm_ic = TRUE;
           id = 0;
           for (int i = highlight_ga.ga_len; --i >= 0; ) {
-            if (vim_regexec(&regmatch, hl_table()[i].sg_name, (colnr_T)0)) {
+            if (vim_regexec(&regmatch, HL_TABLE()[i].sg_name, (colnr_T)0)) {
               if (round == 2) {
                 // Got more items than expected; can happen
                 // when adding items that match:
@@ -5781,10 +5771,10 @@ bool syntax_present(win_T *win)
 
 
 static enum {
-  kExpSubcmd,       // expand ":syn" sub-commands
-  kExpCase,         // expand ":syn case" arguments
-  kExpSpell,        // expand ":syn spell" arguments
-  kExpSync          // expand ":syn sync" arguments
+  EXP_SUBCMD,       // expand ":syn" sub-commands
+  EXP_CASE,         // expand ":syn case" arguments
+  EXP_SPELL,        // expand ":syn spell" arguments
+  EXP_SYNC          // expand ":syn sync" arguments
 } expand_what;
 
 /*
@@ -5814,7 +5804,7 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
 {
   // Default: expand subcommands.
   xp->xp_context = EXPAND_SYNTAX;
-  expand_what = kExpSubcmd;
+  expand_what = EXP_SUBCMD;
   xp->xp_pattern = (char_u *)arg;
   include_link = 0;
   include_default = 0;
@@ -5827,11 +5817,11 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
       if (*skiptowhite(xp->xp_pattern) != NUL) {
         xp->xp_context = EXPAND_NOTHING;
       } else if (STRNICMP(arg, "case", p - arg) == 0) {
-        expand_what = kExpCase;
+        expand_what = EXP_CASE;
       } else if (STRNICMP(arg, "spell", p - arg) == 0) {
-        expand_what = kExpSpell;
+        expand_what = EXP_SPELL;
       } else if (STRNICMP(arg, "sync", p - arg) == 0) {
-        expand_what = kExpSync;
+        expand_what = EXP_SYNC;
       } else if (STRNICMP(arg, "keyword", p - arg) == 0
                  || STRNICMP(arg, "region", p - arg) == 0
                  || STRNICMP(arg, "match", p - arg) == 0
@@ -5851,18 +5841,18 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
 char_u *get_syntax_name(expand_T *xp, int idx)
 {
   switch (expand_what) {
-  case kExpSubcmd:
+  case EXP_SUBCMD:
     return (char_u *)subcommands[idx].name;
-  case kExpCase: {
+  case EXP_CASE: {
     static char *case_args[] = { "match", "ignore", NULL };
     return (char_u *)case_args[idx];
   }
-  case kExpSpell: {
+  case EXP_SPELL: {
     static char *spell_args[] =
     { "toplevel", "notoplevel", "default", NULL };
     return (char_u *)spell_args[idx];
   }
-  case kExpSync: {
+  case EXP_SYNC: {
     static char *sync_args[] =
     { "ccomment", "clear", "fromstart",
       "linebreaks=", "linecont", "lines=", "match",
@@ -6133,7 +6123,7 @@ static void syntime_report(void)
     MSG_PUTS(profile_msg(p->average));
     MSG_PUTS(" ");
     msg_advance(50);
-    msg_outtrans(hl_table()[p->id - 1].sg_name);
+    msg_outtrans(HL_TABLE()[p->id - 1].sg_name);
     MSG_PUTS(" ");
 
     msg_advance(69);
@@ -6480,7 +6470,8 @@ const char *const highlight_init_cmdline[] = {
   "default link NvimInvalidOptionSigil NvimInvalidIdentifier",
   "default link NvimInvalidOptionName NvimInvalidIdentifier",
   "default link NvimInvalidOptionScope NvimInvalidIdentifierScope",
-  "default link NvimInvalidOptionScopeDelimiter NvimInvalidIdentifierScopeDelimiter",
+  "default link NvimInvalidOptionScopeDelimiter "
+  "NvimInvalidIdentifierScopeDelimiter",
 
   "default link NvimInvalidEnvironmentSigil NvimInvalidOptionSigil",
   "default link NvimInvalidEnvironmentName NvimInvalidIdentifier",
@@ -6812,7 +6803,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     }
 
     if (from_id > 0) {
-      hlgroup = &hl_table()[from_id - 1];
+      hlgroup = &HL_TABLE()[from_id - 1];
       if (dodefault && (forceit || hlgroup->sg_deflink == 0)) {
         hlgroup->sg_deflink = to_id;
         hlgroup->sg_deflink_sctx = current_sctx;
@@ -6881,14 +6872,14 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   }
 
   // Make a copy so we can check if any attribute actually changed
-  item_before = hl_table()[idx];
-  is_normal_group = (STRCMP(hl_table()[idx].sg_name_u, "NORMAL") == 0);
+  item_before = HL_TABLE()[idx];
+  is_normal_group = (STRCMP(HL_TABLE()[idx].sg_name_u, "NORMAL") == 0);
 
   // Clear the highlighting for ":hi clear {group}" and ":hi clear".
   if (doclear || (forceit && init)) {
     highlight_clear(idx);
     if (!doclear) {
-      hl_table()[idx].sg_set = 0;
+      HL_TABLE()[idx].sg_set = 0;
     }
   }
 
@@ -6914,9 +6905,9 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       linep = (const char *)skipwhite((const char_u *)linep);
 
       if (strcmp(key, "NONE") == 0) {
-        if (!init || hl_table()[idx].sg_set == 0) {
+        if (!init || HL_TABLE()[idx].sg_set == 0) {
           if (!init) {
-            hl_table()[idx].sg_set |= SG_CTERM+SG_GUI;
+            HL_TABLE()[idx].sg_set |= SG_CTERM+SG_GUI;
           }
           highlight_clear(idx);
         }
@@ -6985,34 +6976,34 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           break;
         }
         if (*key == 'C') {
-          if (!init || !(hl_table()[idx].sg_set & SG_CTERM)) {
+          if (!init || !(HL_TABLE()[idx].sg_set & SG_CTERM)) {
             if (!init) {
-              hl_table()[idx].sg_set |= SG_CTERM;
+              HL_TABLE()[idx].sg_set |= SG_CTERM;
             }
-            hl_table()[idx].sg_cterm = attr;
-            hl_table()[idx].sg_cterm_bold = false;
+            HL_TABLE()[idx].sg_cterm = attr;
+            HL_TABLE()[idx].sg_cterm_bold = false;
           }
         } else if (*key == 'G') {
-          if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
+          if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
             if (!init) {
-              hl_table()[idx].sg_set |= SG_GUI;
+              HL_TABLE()[idx].sg_set |= SG_GUI;
             }
-            hl_table()[idx].sg_gui = attr;
+            HL_TABLE()[idx].sg_gui = attr;
           }
         }
       } else if (STRCMP(key, "FONT") == 0) {
         // in non-GUI fonts are simply ignored
       } else if (STRCMP(key, "CTERMFG") == 0 || STRCMP(key, "CTERMBG") == 0) {
-        if (!init || !(hl_table()[idx].sg_set & SG_CTERM)) {
+        if (!init || !(HL_TABLE()[idx].sg_set & SG_CTERM)) {
           if (!init) {
-            hl_table()[idx].sg_set |= SG_CTERM;
+            HL_TABLE()[idx].sg_set |= SG_CTERM;
           }
 
           /* When setting the foreground color, and previously the "bold"
            * flag was set for a light color, reset it now */
-          if (key[5] == 'F' && hl_table()[idx].sg_cterm_bold) {
-            hl_table()[idx].sg_cterm &= ~HL_BOLD;
-            hl_table()[idx].sg_cterm_bold = false;
+          if (key[5] == 'F' && HL_TABLE()[idx].sg_cterm_bold) {
+            HL_TABLE()[idx].sg_cterm &= ~HL_BOLD;
+            HL_TABLE()[idx].sg_cterm_bold = false;
           }
 
           if (ascii_isdigit(*arg)) {
@@ -7055,21 +7046,21 @@ void do_highlight(const char *line, const bool forceit, const bool init)
             // set/reset bold attribute to get light foreground
             // colors (on some terminals, e.g. "linux")
             if (bold == kTrue) {
-              hl_table()[idx].sg_cterm |= HL_BOLD;
-              hl_table()[idx].sg_cterm_bold = true;
+              HL_TABLE()[idx].sg_cterm |= HL_BOLD;
+              HL_TABLE()[idx].sg_cterm_bold = true;
             } else if (bold == kFalse) {
-              hl_table()[idx].sg_cterm &= ~HL_BOLD;
+              HL_TABLE()[idx].sg_cterm &= ~HL_BOLD;
             }
           }
           // Add one to the argument, to avoid zero.  Zero is used for
           // "NONE", then "color" is -1.
           if (key[5] == 'F') {
-            hl_table()[idx].sg_cterm_fg = color + 1;
+            HL_TABLE()[idx].sg_cterm_fg = color + 1;
             if (is_normal_group) {
               cterm_normal_fg_color = color + 1;
             }
           } else {
-            hl_table()[idx].sg_cterm_bg = color + 1;
+            HL_TABLE()[idx].sg_cterm_bg = color + 1;
             if (is_normal_group) {
               cterm_normal_bg_color = color + 1;
               if (!ui_rgb_attached()) {
@@ -7096,95 +7087,95 @@ void do_highlight(const char *line, const bool forceit, const bool init)
           }
         }
       } else if (strcmp(key, "GUIFG") == 0) {
-        char **namep = &hl_table()[idx].sg_rgb_fg_name;
+        char **namep = &HL_TABLE()[idx].sg_rgb_fg_name;
 
-        if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
+        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
           if (!init) {
-            hl_table()[idx].sg_set |= SG_GUI;
+            HL_TABLE()[idx].sg_set |= SG_GUI;
           }
 
           if (*namep == NULL || STRCMP(*namep, arg) != 0) {
             xfree(*namep);
             if (strcmp(arg, "NONE") != 0) {
               *namep = xstrdup(arg);
-              hl_table()[idx].sg_rgb_fg = name_to_color(arg);
+              HL_TABLE()[idx].sg_rgb_fg = name_to_color(arg);
             } else {
               *namep = NULL;
-              hl_table()[idx].sg_rgb_fg = -1;
+              HL_TABLE()[idx].sg_rgb_fg = -1;
             }
             did_change = true;
           }
         }
 
         if (is_normal_group) {
-          normal_fg = hl_table()[idx].sg_rgb_fg;
+          normal_fg = HL_TABLE()[idx].sg_rgb_fg;
         }
       } else if (STRCMP(key, "GUIBG") == 0) {
-        char **const namep = &hl_table()[idx].sg_rgb_bg_name;
+        char **const namep = &HL_TABLE()[idx].sg_rgb_bg_name;
 
-        if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
+        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
           if (!init) {
-            hl_table()[idx].sg_set |= SG_GUI;
+            HL_TABLE()[idx].sg_set |= SG_GUI;
           }
 
           if (*namep == NULL || STRCMP(*namep, arg) != 0) {
             xfree(*namep);
             if (STRCMP(arg, "NONE") != 0) {
               *namep = xstrdup(arg);
-              hl_table()[idx].sg_rgb_bg = name_to_color(arg);
+              HL_TABLE()[idx].sg_rgb_bg = name_to_color(arg);
             } else {
               *namep = NULL;
-              hl_table()[idx].sg_rgb_bg = -1;
+              HL_TABLE()[idx].sg_rgb_bg = -1;
             }
             did_change = true;
           }
         }
 
         if (is_normal_group) {
-          normal_bg = hl_table()[idx].sg_rgb_bg;
+          normal_bg = HL_TABLE()[idx].sg_rgb_bg;
         }
       } else if (strcmp(key, "GUISP") == 0) {
-        char **const namep = &hl_table()[idx].sg_rgb_sp_name;
+        char **const namep = &HL_TABLE()[idx].sg_rgb_sp_name;
 
-        if (!init || !(hl_table()[idx].sg_set & SG_GUI)) {
+        if (!init || !(HL_TABLE()[idx].sg_set & SG_GUI)) {
           if (!init) {
-            hl_table()[idx].sg_set |= SG_GUI;
+            HL_TABLE()[idx].sg_set |= SG_GUI;
           }
 
           if (*namep == NULL || STRCMP(*namep, arg) != 0) {
             xfree(*namep);
             if (strcmp(arg, "NONE") != 0) {
               *namep = xstrdup(arg);
-              hl_table()[idx].sg_rgb_sp = name_to_color(arg);
+              HL_TABLE()[idx].sg_rgb_sp = name_to_color(arg);
             } else {
               *namep = NULL;
-              hl_table()[idx].sg_rgb_sp = -1;
+              HL_TABLE()[idx].sg_rgb_sp = -1;
             }
             did_change = true;
           }
         }
 
         if (is_normal_group) {
-          normal_sp = hl_table()[idx].sg_rgb_sp;
+          normal_sp = HL_TABLE()[idx].sg_rgb_sp;
         }
       } else if (strcmp(key, "START") == 0 || strcmp(key, "STOP") == 0) {
         // Ignored for now
       } else if (strcmp(key, "BLEND") == 0) {
         if (strcmp(arg, "NONE") != 0) {
-          hl_table()[idx].sg_blend = strtol(arg, NULL, 10);
+          HL_TABLE()[idx].sg_blend = strtol(arg, NULL, 10);
         } else {
-          hl_table()[idx].sg_blend = -1;
+          HL_TABLE()[idx].sg_blend = -1;
         }
       } else {
         emsgf(_("E423: Illegal argument: %s"), key_start);
         error = true;
         break;
       }
-      hl_table()[idx].sg_cleared = false;
+      HL_TABLE()[idx].sg_cleared = false;
 
       // When highlighting has been given for a group, don't link it.
-      if (!init || !(hl_table()[idx].sg_set & SG_LINK)) {
-        hl_table()[idx].sg_link = 0;
+      if (!init || !(HL_TABLE()[idx].sg_set & SG_LINK)) {
+        HL_TABLE()[idx].sg_link = 0;
       }
 
       // Continue with next argument.
@@ -7215,8 +7206,8 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     } else {
       set_hl_attr(idx);
     }
-    hl_table()[idx].sg_script_ctx = current_sctx;
-    hl_table()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
+    HL_TABLE()[idx].sg_script_ctx = current_sctx;
+    HL_TABLE()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
   }
   xfree(key);
   xfree(arg);
@@ -7224,7 +7215,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   // Only call highlight_changed() once, after a sequence of highlight
   // commands, and only if an attribute actually changed
   if ((did_change
-       || memcmp(&hl_table()[idx], &item_before, sizeof(item_before)) != 0)
+       || memcmp(&HL_TABLE()[idx], &item_before, sizeof(item_before)) != 0)
       && !did_highlight_changed) {
     // Do not trigger a redraw when highlighting is changed while
     // redrawing.  This may happen when evaluating 'statusline' changes the
@@ -7268,14 +7259,14 @@ void restore_cterm_colors(void)
 /// @return TRUE if highlight group "idx" has any settings.
 static int hl_has_settings(int idx, bool check_link)
 {
-  return hl_table()[idx].sg_cleared == 0
-         && (hl_table()[idx].sg_attr != 0
-             || hl_table()[idx].sg_cterm_fg != 0
-             || hl_table()[idx].sg_cterm_bg != 0
-             || hl_table()[idx].sg_rgb_fg_name != NULL
-             || hl_table()[idx].sg_rgb_bg_name != NULL
-             || hl_table()[idx].sg_rgb_sp_name != NULL
-             || (check_link && (hl_table()[idx].sg_set & SG_LINK)));
+  return HL_TABLE()[idx].sg_cleared == 0
+         && (HL_TABLE()[idx].sg_attr != 0
+             || HL_TABLE()[idx].sg_cterm_fg != 0
+             || HL_TABLE()[idx].sg_cterm_bg != 0
+             || HL_TABLE()[idx].sg_rgb_fg_name != NULL
+             || HL_TABLE()[idx].sg_rgb_bg_name != NULL
+             || HL_TABLE()[idx].sg_rgb_sp_name != NULL
+             || (check_link && (HL_TABLE()[idx].sg_set & SG_LINK)));
 }
 
 /*
@@ -7283,26 +7274,26 @@ static int hl_has_settings(int idx, bool check_link)
  */
 static void highlight_clear(int idx)
 {
-  hl_table()[idx].sg_cleared = true;
+  HL_TABLE()[idx].sg_cleared = true;
 
-  hl_table()[idx].sg_attr = 0;
-  hl_table()[idx].sg_cterm = 0;
-  hl_table()[idx].sg_cterm_bold = false;
-  hl_table()[idx].sg_cterm_fg = 0;
-  hl_table()[idx].sg_cterm_bg = 0;
-  hl_table()[idx].sg_gui = 0;
-  hl_table()[idx].sg_rgb_fg = -1;
-  hl_table()[idx].sg_rgb_bg = -1;
-  hl_table()[idx].sg_rgb_sp = -1;
-  XFREE_CLEAR(hl_table()[idx].sg_rgb_fg_name);
-  XFREE_CLEAR(hl_table()[idx].sg_rgb_bg_name);
-  XFREE_CLEAR(hl_table()[idx].sg_rgb_sp_name);
-  hl_table()[idx].sg_blend = -1;
+  HL_TABLE()[idx].sg_attr = 0;
+  HL_TABLE()[idx].sg_cterm = 0;
+  HL_TABLE()[idx].sg_cterm_bold = false;
+  HL_TABLE()[idx].sg_cterm_fg = 0;
+  HL_TABLE()[idx].sg_cterm_bg = 0;
+  HL_TABLE()[idx].sg_gui = 0;
+  HL_TABLE()[idx].sg_rgb_fg = -1;
+  HL_TABLE()[idx].sg_rgb_bg = -1;
+  HL_TABLE()[idx].sg_rgb_sp = -1;
+  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_fg_name);
+  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_bg_name);
+  XFREE_CLEAR(HL_TABLE()[idx].sg_rgb_sp_name);
+  HL_TABLE()[idx].sg_blend = -1;
   // Restore default link and context if they exist. Otherwise clears.
-  hl_table()[idx].sg_link = hl_table()[idx].sg_deflink;
+  HL_TABLE()[idx].sg_link = HL_TABLE()[idx].sg_deflink;
   // Since we set the default link, set the location to where the default
   // link was set.
-  hl_table()[idx].sg_script_ctx = hl_table()[idx].sg_deflink_sctx;
+  HL_TABLE()[idx].sg_script_ctx = HL_TABLE()[idx].sg_deflink_sctx;
 }
 
 
@@ -7315,7 +7306,7 @@ static void highlight_clear(int idx)
 
 static void highlight_list_one(const int id)
 {
-  struct hl_group *const sgp = &hl_table()[id - 1];  // index is ID minus one
+  struct hl_group *const sgp = &HL_TABLE()[id - 1];  // index is ID minus one
   bool didh = false;
 
   if (message_filtered(sgp->sg_name)) {
@@ -7346,7 +7337,7 @@ static void highlight_list_one(const int id)
     didh = true;
     msg_puts_attr("links to", HL_ATTR(HLF_D));
     msg_putchar(' ');
-    msg_outtrans(hl_table()[hl_table()[id - 1].sg_link - 1].sg_name);
+    msg_outtrans(HL_TABLE()[HL_TABLE()[id - 1].sg_link - 1].sg_name);
   }
 
   if (!didh) {
@@ -7362,11 +7353,11 @@ Dictionary get_global_hl_defs(void)
   Dictionary rv = ARRAY_DICT_INIT;
   for (int i = 1; i <= highlight_ga.ga_len && !got_int; i++) {
     Dictionary attrs = ARRAY_DICT_INIT;
-    struct hl_group *h = &hl_table()[i - 1];
+    struct hl_group *h = &HL_TABLE()[i - 1];
     if (h->sg_attr > 0) {
       attrs = hlattrs2dict(syn_attr2entry(h->sg_attr), true);
     } else if (h->sg_link > 0) {
-      const char *link = (const char *)hl_table()[h->sg_link - 1].sg_name;
+      const char *link = (const char *)HL_TABLE()[h->sg_link - 1].sg_name;
       PUT(attrs, "link", STRING_OBJ(cstr_to_string(link)));
     }
     PUT(rv, (const char *)h->sg_name, DICTIONARY_OBJ(attrs));
@@ -7438,9 +7429,9 @@ const char *highlight_has_attr(const int id, const int flag, const int modec)
   }
 
   if (modec == 'g') {
-    attr = hl_table()[id - 1].sg_gui;
+    attr = HL_TABLE()[id - 1].sg_gui;
   } else {
-    attr = hl_table()[id - 1].sg_cterm;
+    attr = HL_TABLE()[id - 1].sg_cterm;
   }
 
   return (attr & flag) ? "1" : NULL;
@@ -7481,11 +7472,11 @@ const char *highlight_color(const int id, const char *const what, const int mode
   if (modec == 'g') {
     if (what[2] == '#' && ui_rgb_attached()) {
       if (fg) {
-        n = hl_table()[id - 1].sg_rgb_fg;
+        n = HL_TABLE()[id - 1].sg_rgb_fg;
       } else if (sp) {
-        n = hl_table()[id - 1].sg_rgb_sp;
+        n = HL_TABLE()[id - 1].sg_rgb_sp;
       } else {
-        n = hl_table()[id - 1].sg_rgb_bg;
+        n = HL_TABLE()[id - 1].sg_rgb_bg;
       }
       if (n < 0 || n > 0xffffff) {
         return NULL;
@@ -7494,21 +7485,21 @@ const char *highlight_color(const int id, const char *const what, const int mode
       return name;
     }
     if (fg) {
-      return (const char *)hl_table()[id - 1].sg_rgb_fg_name;
+      return (const char *)HL_TABLE()[id - 1].sg_rgb_fg_name;
     }
     if (sp) {
-      return (const char *)hl_table()[id - 1].sg_rgb_sp_name;
+      return (const char *)HL_TABLE()[id - 1].sg_rgb_sp_name;
     }
-    return (const char *)hl_table()[id - 1].sg_rgb_bg_name;
+    return (const char *)HL_TABLE()[id - 1].sg_rgb_bg_name;
   }
   if (font || sp) {
     return NULL;
   }
   if (modec == 'c') {
     if (fg) {
-      n = hl_table()[id - 1].sg_cterm_fg - 1;
+      n = HL_TABLE()[id - 1].sg_cterm_fg - 1;
     } else {
-      n = hl_table()[id - 1].sg_cterm_bg - 1;
+      n = HL_TABLE()[id - 1].sg_cterm_bg - 1;
     }
     if (n < 0) {
       return NULL;
@@ -7539,7 +7530,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
     if (got_int) {
       return true;
     }
-    msg_outtrans(hl_table()[id - 1].sg_name);
+    msg_outtrans(HL_TABLE()[id - 1].sg_name);
     endcol = 15;
   } else if ((ui_has(kUIMessages) || msg_silent) && !force_newline) {
     msg_putchar(' ');
@@ -7579,7 +7570,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
 static void set_hl_attr(int idx)
 {
   HlAttrs at_en = HLATTRS_INIT;
-  struct hl_group *sgp = hl_table() + idx;
+  struct hl_group *sgp = HL_TABLE() + idx;
 
   at_en.cterm_ae_attr = sgp->sg_cterm;
   at_en.cterm_fg_color = sgp->sg_cterm_fg;
@@ -7662,7 +7653,7 @@ char_u *syn_id2name(int id)
   if (id <= 0 || id > highlight_ga.ga_len) {
     return (char_u *)"";
   }
-  return hl_table()[id - 1].sg_name;
+  return HL_TABLE()[id - 1].sg_name;
 }
 
 
@@ -7744,7 +7735,7 @@ static int syn_add_group(char_u *name)
 static void syn_unadd_group(void)
 {
   highlight_ga.ga_len--;
-  HlGroup *item = &hl_table()[highlight_ga.ga_len];
+  HlGroup *item = &HL_TABLE()[highlight_ga.ga_len];
   map_del(cstr_t, int)(&highlight_unames, item->sg_name_u);
   xfree(item->sg_name);
   xfree(item->sg_name_u);
@@ -7756,7 +7747,7 @@ static void syn_unadd_group(void)
 int syn_id2attr(int hl_id)
 {
   hl_id = syn_get_final_id(hl_id);
-  struct hl_group *sgp = &hl_table()[hl_id - 1];  // index is ID minus one
+  struct hl_group *sgp = &HL_TABLE()[hl_id - 1];  // index is ID minus one
 
   int attr = ns_get_hl(-1, hl_id, false, sgp->sg_set);
   if (attr >= 0) {
@@ -7783,7 +7774,7 @@ int syn_get_final_id(int hl_id)
    * Look out for loops!  Break after 100 links.
    */
   for (count = 100; --count >= 0; ) {
-    struct hl_group *sgp = &hl_table()[hl_id - 1];  // index is ID minus one
+    struct hl_group *sgp = &HL_TABLE()[hl_id - 1];  // index is ID minus one
 
     // ACHTUNG: when using "tmp" attribute (no link) the function might be
     // called twice. it needs be smart enough to remember attr only to
@@ -7810,7 +7801,7 @@ int syn_get_final_id(int hl_id)
 void highlight_attr_set_all(void)
 {
   for (int idx = 0; idx < highlight_ga.ga_len; idx++) {
-    struct hl_group *sgp = &hl_table()[idx];
+    struct hl_group *sgp = &HL_TABLE()[idx];
     if (sgp->sg_rgb_bg_name != NULL) {
       sgp->sg_rgb_bg = name_to_color(sgp->sg_rgb_bg_name);
     }
@@ -7828,7 +7819,7 @@ void highlight_attr_set_all(void)
 static void combine_stl_hlt(int id, int id_S, int id_alt, int hlcnt, int i, int hlf, int *table)
   FUNC_ATTR_NONNULL_ALL
 {
-  struct hl_group *const hlt = hl_table();
+  struct hl_group *const hlt = HL_TABLE();
 
   if (id_alt == 0) {
     memset(&hlt[hlcnt + i], 0, sizeof(struct hl_group));
@@ -7869,8 +7860,8 @@ void highlight_changed(void)
 {
   int id;
   char_u userhl[30];  // use 30 to avoid compiler warning
-  int id_s = -1;
-  int id_snc = 0;
+  int id_S = -1;
+  int id_SNC = 0;
   int hlcnt;
 
   need_highlight_changed = false;
@@ -7883,9 +7874,9 @@ void highlight_changed(void)
     }
     int final_id = syn_get_final_id(id);
     if (hlf == HLF_SNC) {
-      id_snc = final_id;
+      id_SNC = final_id;
     } else if (hlf == HLF_S) {
-      id_s = final_id;
+      id_S = final_id;
     }
 
     highlight_attr[hlf] = hl_get_ui_attr(hlf, final_id,
@@ -7911,10 +7902,10 @@ void highlight_changed(void)
   // get_attr_entry()
   ga_grow(&highlight_ga, 10);
   hlcnt = highlight_ga.ga_len;
-  if (id_s == -1) {
+  if (id_S == -1) {
     // Make sure id_S is always valid to simplify code below. Use the last entry
-    memset(&hl_table()[hlcnt + 9], 0, sizeof(struct hl_group));
-    id_s = hlcnt + 10;
+    memset(&HL_TABLE()[hlcnt + 9], 0, sizeof(struct hl_group));
+    id_S = hlcnt + 10;
   }
   for (int i = 0; i < 9; i++) {
     sprintf((char *)userhl, "User%d", i + 1);
@@ -7924,7 +7915,7 @@ void highlight_changed(void)
       highlight_stlnc[i] = 0;
     } else {
       highlight_user[i] = syn_id2attr(id);
-      combine_stl_hlt(id, id_s, id_snc, hlcnt, i, HLF_SNC, highlight_stlnc);
+      combine_stl_hlt(id, id_S, id_SNC, hlcnt, i, HLF_SNC, highlight_stlnc);
     }
   }
   highlight_ga.ga_len = hlcnt;
@@ -8017,7 +8008,7 @@ const char *get_highlight_name_ext(expand_T *xp, int idx, bool skip_cleared)
   }
 
   // Items are never removed from the table, skip the ones that were cleared.
-  if (skip_cleared && idx < highlight_ga.ga_len && hl_table()[idx].sg_cleared) {
+  if (skip_cleared && idx < highlight_ga.ga_len && HL_TABLE()[idx].sg_cleared) {
     return "";
   }
 
@@ -8035,7 +8026,7 @@ const char *get_highlight_name_ext(expand_T *xp, int idx, bool skip_cleared)
   } else if (idx >= highlight_ga.ga_len) {
     return NULL;
   }
-  return (const char *)hl_table()[idx].sg_name;
+  return (const char *)HL_TABLE()[idx].sg_name;
 }
 
 color_name_table_T color_name_table[] = {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -707,7 +707,7 @@ print_tag_list(
     if (taglen < 18) {
         taglen = 18;
     }
-    if (taglen > Columns - 25) {
+    if (taglen > g_columns - 25) {
         taglen = MAXCOL;
     }
     if (msg_col == 0) {
@@ -784,7 +784,7 @@ print_tag_list(
                 // print all other extra fields
                 attr = HL_ATTR(HLF_CM);
                 while (*p && *p != '\r' && *p != '\n') {
-                    if (msg_col + ptr2cells(p) >= Columns) {
+                    if (msg_col + ptr2cells(p) >= g_columns) {
                         msg_putchar('\n');
                         if (got_int) {
                             break;
@@ -831,7 +831,7 @@ print_tag_list(
         }
 
         while (p != command_end) {
-            if (msg_col + (*p == TAB ? 1 : ptr2cells(p)) > Columns) {
+            if (msg_col + (*p == TAB ? 1 : ptr2cells(p)) > g_columns) {
                 msg_putchar('\n');
             }
             if (got_int) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1446,7 +1446,7 @@ static void invalidate(UI *ui, int top, int bot, int left, int right)
   }
 }
 
-/// Tries to get the user's wanted dimensions (columns and rows) for the entire
+/// Tries to get the user's wanted dimensions (g_columns and g_rows) for the entire
 /// application (i.e., the host terminal).
 static void tui_guess_size(UI *ui)
 {
@@ -1454,12 +1454,12 @@ static void tui_guess_size(UI *ui)
   int width = 0, height = 0;
 
   // 1 - look for non-default 'columns' and 'lines' options during startup
-  if (data->is_starting && (Columns != DFLT_COLS || Rows != DFLT_ROWS)) {
+  if (data->is_starting && (g_columns != DFLT_COLS || g_rows != DFLT_ROWS)) {
     did_user_set_dimensions = true;
-    assert(Columns >= INT_MIN && Columns <= INT_MAX);
-    assert(Rows >= INT_MIN && Rows <= INT_MAX);
-    width = Columns;
-    height = Rows;
+    assert(g_columns >= INT_MIN && g_columns <= INT_MAX);
+    assert(g_rows >= INT_MIN && g_rows <= INT_MAX);
+    width = g_columns;
+    height = g_rows;
     goto end;
   }
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -385,7 +385,7 @@ void ui_set_ext_option(UI *ui, UIExtension ext, bool active)
 void ui_line(ScreenGrid *grid, int row, int startcol, int endcol, int clearcol,
              int clearattr, bool wrap)
 {
-  assert(0 <= row && row < grid->Rows);
+  assert(0 <= row && row < grid->g_rows);
   LineFlags flags = wrap ? kLineFlagWrap : 0;
   if (startcol == -1) {
     startcol = 0;
@@ -402,7 +402,7 @@ void ui_line(ScreenGrid *grid, int row, int startcol, int endcol, int clearcol,
   if (p_wd && !(rdb_flags & RDB_COMPOSITOR)) {
     // If 'writedelay' is active, set the cursor to indicate what was drawn.
     ui_call_grid_cursor_goto(grid->handle, row,
-                             MIN(clearcol, (int)grid->Columns-1));
+                             MIN(clearcol, (int)grid->g_columns-1));
     ui_call_flush();
     uint64_t wd = (uint64_t)labs(p_wd);
     os_microdelay(wd * 1000u, true);

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2022,8 +2022,8 @@ static void version_msg_wrap(char_u *s, int wrap)
   int len = (int)vim_strsize(s) + (wrap ? 2 : 0);
 
   if (!got_int
-      && (len < Columns)
-      && (msg_col + len >= Columns)
+      && (len < g_columns)
+      && (msg_col + len >= g_columns)
       && (*s != '\n')) {
     msg_putchar('\n');
   }
@@ -2079,7 +2079,7 @@ void list_in_columns(char_u **items, int size, int current)
   }
   width += 1;
 
-  if (Columns < width) {
+  if (g_columns < width) {
     // Not enough screen columns - show one per line
     for (i = 0; i < item_count; i++) {
       version_msg_wrap(items[i], i == current);
@@ -2092,7 +2092,7 @@ void list_in_columns(char_u **items, int size, int current)
 
   // The rightmost column doesn't need a separator.
   // Sacrifice it to fit in one more column if possible.
-  int ncol = (int)(Columns + 1) / width;
+  int ncol = (int)(g_columns + 1) / width;
   int nrow = item_count / ncol + (item_count % ncol ? 1 : 0);
   int cur_row = 1;
 
@@ -2235,11 +2235,11 @@ void intro_message(int colon)
   size_t lines_size = ARRAY_SIZE(lines);
   assert(lines_size <= LONG_MAX);
 
-  blanklines = Rows - ((long)lines_size - 1l);
+  blanklines = g_rows - ((long)lines_size - 1l);
 
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {
-    blanklines -= Rows - topframe->fr_height;
+    blanklines -= g_rows - topframe->fr_height;
   }
 
   if (blanklines < 0) {
@@ -2254,7 +2254,7 @@ void intro_message(int colon)
   // start displaying the message lines after half of the blank lines
   row = blanklines / 2;
 
-  if (((row >= 2) && (Columns >= 50)) || colon) {
+  if (((row >= 2) && (g_columns >= 50)) || colon) {
     for (i = 0; i < (int)ARRAY_SIZE(lines); ++i) {
       p = lines[i];
 
@@ -2296,7 +2296,7 @@ static void do_intro_line(long row, char_u *mesg, int attr)
   // Center the message horizontally.
   col = vim_strsize(mesg);
 
-  col = (Columns - col) / 2;
+  col = (g_columns - col) / 2;
 
   if (col < 0) {
     col = 0;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2255,7 +2255,7 @@ void intro_message(int colon)
   row = blanklines / 2;
 
   if (((row >= 2) && (g_columns >= 50)) || colon) {
-    for (i = 0; i < (int)ARRAY_SIZE(lines); ++i) {
+    for (i = 0; i < (int)ARRAY_SIZE(lines); i++) {
       p = lines[i];
 
       if (sponsor != 0) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4930,10 +4930,9 @@ static void frame_remove(frame_T *frp)
 }
 
 
-/*
- * Called from win_new_shellsize() after g_rows changed.
- * This only does the current tab page, others must be done when made active.
- */
+
+/// Called from win_new_shellsize() after g_rows changed.
+/// This only does the current tab page, others must be done when made active.
 void shell_new_rows(void)
 {
   int h = (int)ROWS_AVAIL;
@@ -4958,9 +4957,8 @@ void shell_new_rows(void)
   curtab->tp_ch_used = p_ch;
 }
 
-/*
- * Called from win_new_shellsize() after g_columns changed.
- */
+
+/// Called from win_new_shellsize() after g_columns changed.
 void shell_new_columns(void)
 {
   if (firstwin == NULL) {       // not initialized yet


### PR DESCRIPTION
List of most notable fixes:
  - enclose macro arguments in parentheses (bugprone)
  - naming conventions
  - variable declaration
