### PR TITLE
docs: add lua-cjson to third-party licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,6 +199,7 @@ The externally maintained libraries used by Neovim are:
   - lua-compat: MIT license
   - tree-sitter: MIT license
   - xdiff: LGPL license
+  - lua-cjson: MIT license
 
 ====
 


### PR DESCRIPTION
Missing comment from @justinmk in #14871 

Also, he mentioned adding the 3rd party sources to src/nvim/README.md, but there is currently no mention of tree-sitter, mpack, etc. so not sure where to put it.