### PR TITLE
reafactor(lsp): factor out applying codeAction edits/commands

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1189,6 +1189,15 @@ save({lenses}, {bufnr}, {client_id})                 *vim.lsp.codelens.save()*
 
 
 ==============================================================================
+
+Lua module: vim.lsp.codeaction                                *lsp-codeaction*
+
+                                                  *vim.lsp.codeaction.apply()*
+apply({action}, {ctx})
+                Apply edits/commands from a codeAction
+
+
+==============================================================================
 Lua module: vim.lsp.handlers                                    *lsp-handlers*
 
 hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*

--- a/runtime/lua/vim/lsp/codeaction.lua
+++ b/runtime/lua/vim/lsp/codeaction.lua
@@ -1,0 +1,33 @@
+local buf = require 'vim.lsp.buf'
+local util = require 'vim.lsp.util'
+local vim = vim
+local M = {}
+
+function M.apply(action, ctx)
+  -- textDocument/codeAction can return either Command[] or CodeAction[]
+  --
+  -- CodeAction
+  --  ...
+  --  edit?: WorkspaceEdit    -- <- must be applied before command
+  --  command?: Command
+  --
+  -- Command:
+  --  title: string
+  --  command: string
+  --  arguments?: any[]
+  --
+  if action.edit then
+    util.apply_workspace_edit(action.edit)
+  end
+  if action.command then
+    local command = type(action.command) == 'table' and action.command or action
+    local fn = vim.lsp.commands[command.command]
+    if fn then
+      fn(command, ctx)
+    else
+      buf.execute_command(command)
+    end
+  end
+end
+
+return M

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -155,6 +155,7 @@ CONFIG = {
             'buf.lua',
             'diagnostic.lua',
             'codelens.lua',
+            'codeaction.lua',
             'handlers.lua',
             'util.lua',
             'log.lua',


### PR DESCRIPTION
this is so custom lsp handlers like https://github.com/RishabhRD/nvim-lsputils/blob/master/lua/lsputil/actions.lua#L108 don't have to track master and reimplement applying codeActions