### PR TITLE
fix(lsp): avoid serializing boolean as key

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -289,7 +289,6 @@ function M.references(context)
   params.context = context or {
     includeDeclaration = true;
   }
-  params[vim.type_idx] = vim.types.dictionary
   request('textDocument/references', params)
 end
 


### PR DESCRIPTION
Closes #15809 

In vim.lsp.buf.references, the key vim.type_idx (which evaluates to a
boolean) was set to equal vim.types.dictionary. This resulted in a
boolean key in json which is not allowed by the json spec, and which
lua-cjson fails to serialize.
