### PR TITLE
fix(runtime): make a copy of runtime_search_path when iterating

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2398,7 +2398,7 @@ static char_u *did_set_string_option(int opt_idx, char_u **varp, bool new_value_
       didset_vimruntime = false;
     }
   } else if (varp == &p_rtp || varp == &p_pp) {  // 'runtimepath' 'packpath'
-    invalidate_search_path();
+    runtime_search_path_invalidate();
   } else if (varp == &curwin->w_p_culopt
              || gvarp == &curwin->w_allbuf_opt.wo_culopt) {  // 'cursorlineopt'
     if (**varp == NUL || fill_culopt_flags(*varp, curwin) != OK) {

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -358,6 +358,12 @@ describe('startup', function()
     pack_clear [[ lua _G.test_loadorder = {} vim.cmd "packadd! superspecial\nruntime! filen.lua" ]]
     eq({'ordinary', 'SuperSpecial', 'FANCY', 'FANCY after', 'SuperSpecial after', 'ordinary after'}, exec_lua [[ return _G.test_loadorder ]])
   end)
+
+  it("handles the correct order with a package that changes packpath", function()
+    pack_clear [[ lua _G.test_loadorder = {} vim.cmd "packadd! funky\nruntime! filen.lua" ]]
+    eq({'ordinary', 'funky!', 'FANCY', 'FANCY after', 'ordinary after'}, exec_lua [[ return _G.test_loadorder ]])
+    eq({'ordinary', 'funky!', 'ordinary after'}, exec_lua [[ return _G.nested_order ]])
+  end)
 end)
 
 describe('sysinit', function()

--- a/test/functional/fixtures/pack/foo/opt/funky/filen.lua
+++ b/test/functional/fixtures/pack/foo/opt/funky/filen.lua
@@ -1,0 +1,12 @@
+table.insert(_G.test_loadorder, "funky!")
+
+if not _G.nesty then
+  _G.nesty = true
+  local save_order = _G.test_loadorder
+  _G.test_loadorder = {}
+  _G.vim.o.pp = "" -- funky!
+  vim.cmd [[runtime! filen.lua ]]
+  _G.nested_order = _G.test_loadorder
+  _G.test_loadorder = save_order
+  _G.nesty = nil
+end


### PR DESCRIPTION
This is to prevent concurrent modification, just like save_rtp in the vim 8 implementation

fixes #15807 