### PR TITLE
feat: add a runner script for uncrustify

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Style rules are (mostly) defined by `src/uncrustify.cfg` which tries to match
 
   - To use the Nvim `gq` command with `uncrustify`:
   ```
-  if !empty(findfile('src/uncrustify.cfg', ';'))
+  if !empty(findfile('src/.uncrustify', ';'))
     setlocal formatprg=uncrustify\ -q\ -c\ src/uncrustify.cfg\ --replace\ --no-backup
   endif
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,13 +217,29 @@ You can lint a single file (but this will _not_ exclude legacy errors):
 
 ### Style
 
-- Style rules are (mostly) defined by `src/uncrustify.cfg` which tries to match
-  the [style-guide]. To use the Nvim `gq` command with `uncrustify`:
+Style rules are (mostly) defined by `src/uncrustify.cfg` which tries to match
+  the [style-guide]. 
+
+#### Uncrustify
+
+  - To use the Nvim `gq` command with `uncrustify`:
   ```
-  if !empty(findfile('src/.uncrustify', ';'))
+  if !empty(findfile('src/uncrustify.cfg', ';'))
     setlocal formatprg=uncrustify\ -q\ -c\ src/uncrustify.cfg\ --replace\ --no-backup
   endif
   ```
+  - To use it to lint the files that were changed in the last commit:
+  ```shell
+  make uncrustify
+  ```
+  - To use it to lint and *fix* the files that were changed in the last commit:
+  ```shell
+  make uncrustify-fix
+  ```
+  - It's also possible to use it in a commit-hook, check `bash scripts/run_uncrustify.sh -h`
+
+#### clang-format
+
 - There is also `.clang-format` which has drifted from the [style-guide], but
   is available for reference. To use the Nvim `gq` command with `clang-format`:
   ```

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,15 @@ appimage-%:
 
 lint: check-single-includes clint lualint _opt_pylint _opt_shlint _opt_commitlint
 
+style-lint: uncrustify
+
+uncrustify-fix:
+	bash scripts/run_uncrustify.sh -f
+
+uncrustify:
+	bash scripts/run_uncrustify.sh -l
+
+
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".
 ifeq ($(CMAKE_GENERATOR),Ninja)
@@ -226,4 +235,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test lualint pylint shlint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint
+.PHONY: test lualint pylint shlint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage checkprefix

--- a/Makefile
+++ b/Makefile
@@ -235,4 +235,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test lualint pylint shlint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage checkprefix
+.PHONY: test lualint pylint shlint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint style-lint

--- a/scripts/run_uncrustify.sh
+++ b/scripts/run_uncrustify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -eu
+
+BASENAME="$(basename "${0}")"
+
+usage() {
+  echo "Run Uncrustify"
+  echo
+  echo "Usage:  ${BASENAME} [-h | -c | -l ]"
+  echo
+  echo "Options:"
+  echo "    -h                 Show this message and exit."
+  echo "    -c                 Can be used as a commit-hook [will perform both formatting and linting]"
+  echo "    -f                 Use to format the files modified in the last commit"
+  echo "    -l                 Use to lint the files modified in the last commit [github workflow]"
+}
+
+# commit-hook mode
+function commit-hook() {
+  for file in $(git diff --name-only --staged | grep -E '\.(c|h)$'); do
+    if ! uncrustify --check -c src/uncrustify.cfg "$file"; then
+      uncrustify -c src/uncrustify.cfg --replace --no-backup "$file"
+      echo ">> Formatting was performed. You need to commit your files again"
+      exit 1
+    fi
+    [ -f "$file".uncrustify ] && rm "$file".uncrustify
+  done
+}
+
+function last-commit() {
+  for file in $(git diff --name-only HEAD~1 | grep -E '\.(c|h)$'); do
+    if ! uncrustify --check -c src/uncrustify.cfg "$file"; then
+      if [ "$1" == "--fix" ]; then
+        uncrustify -c src/uncrustify.cfg --replace --no-backup "$file"
+      else
+        echo ">> Formatting is required"
+        exit 1
+      fi
+    fi
+    [ -f "$file".uncrustify ] && rm "$file".uncrustify
+  done
+}
+
+while getopts "hclf" opt; do
+  case ${opt} in
+    h)
+      usage
+      exit 0
+      ;;
+    c)
+      commit-hook
+      exit 0
+      ;;
+    l)
+      last-commit
+      exit 0
+      ;;
+    f)
+      last-commit "--fix"
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+done
+
+usage
+
+# vim: et sw=2


### PR DESCRIPTION
The runner allows the following:

- lint the files that were changed in the last commit:
```shell
make uncrustify
```
- lint and *fix* the files that were changed in the last commit:
```shell
make uncrustify-fix
```
- also possible to use it in a commit-hook,
check `bash scripts/run_uncrustify.sh -h`
