### PR TITLE
feat(lsp): add codeAction/resolve support

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -451,6 +451,7 @@ function M.clear_references()
 end
 
 
+---@private
 local function on_code_action_results(results, ctx)
   local action_tuples = {}
   for client_id, result in pairs(results) do
@@ -472,7 +473,7 @@ local function on_code_action_results(results, ctx)
       local command = type(action.command) == 'table' and action.command or action
       local fn = vim.lsp.commands[command.command]
       if fn then
-        local enriched_ctx = vim.deep_copy(ctx)
+        local enriched_ctx = vim.deepcopy(ctx)
         enriched_ctx.client_id = client.id
         fn(command, ctx)
       else
@@ -519,7 +520,7 @@ local function on_code_action_results(results, ctx)
 
   vim.ui.select(action_tuples, {
     prompt = 'Code actions:',
-    format_entry = function(action_tuple)
+    format_item = function(action_tuple)
       local title = action_tuple[2].title:gsub('\r\n', '\\r\\n')
       return title:gsub('\n', '\\n')
     end,

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -452,6 +452,15 @@ end
 
 
 ---@private
+--
+--- This is not public because the main extension point is
+--- vim.ui.select which can be overridden independently.
+---
+--- Can't call/use vim.lsp.handlers['textDocument/codeAction'] because it expects
+--- `(err, CodeAction[] | Command[], ctx)`, but we want to aggregate the results
+--- from multiple clients to have 1 single UI prompt for the user, yet we still
+--- need to be able to link a `CodeAction|Command` to the right client for
+--- `codeAction/resolve`
 local function on_code_action_results(results, ctx)
   local action_tuples = {}
   for client_id, result in pairs(results) do

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -3,7 +3,6 @@ local protocol = require 'vim.lsp.protocol'
 local util = require 'vim.lsp.util'
 local vim = vim
 local api = vim.api
-local buf = require 'vim.lsp.buf'
 
 local M = {}
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -109,53 +109,6 @@ M['client/registerCapability'] = function(_, _, ctx)
   return vim.NIL
 end
 
---see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
-M['textDocument/codeAction'] = function(_, result, ctx)
-  if result == nil or vim.tbl_isempty(result) then
-    print("No code actions available")
-    return
-  end
-
-  ---@private
-  local function on_user_choice(action)
-    if not action then
-      return
-    end
-    -- textDocument/codeAction can return either Command[] or CodeAction[]
-    --
-    -- CodeAction
-    --  ...
-    --  edit?: WorkspaceEdit    -- <- must be applied before command
-    --  command?: Command
-    --
-    -- Command:
-    --  title: string
-    --  command: string
-    --  arguments?: any[]
-    --
-    if action.edit then
-      util.apply_workspace_edit(action.edit)
-    end
-    if action.command then
-      local command = type(action.command) == 'table' and action.command or action
-      local fn = vim.lsp.commands[command.command]
-      if fn then
-        fn(command, ctx)
-      else
-        buf.execute_command(command)
-      end
-    end
-  end
-
-  vim.ui.select(result, {
-    prompt = 'Code actions:',
-    format_item = function(action)
-      local title = action.title:gsub('\r\n', '\\r\\n')
-      return title:gsub('\n', '\\n')
-    end,
-  }, on_user_choice)
-end
-
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
 M['workspace/applyEdit'] = function(_, workspace_edit)
   if not workspace_edit then return end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -645,6 +645,10 @@ function protocol.make_client_capabilities()
             end)();
           };
         };
+        dataSupport = true;
+        resolveSupport = {
+          properties = { 'edit', }
+        };
       };
       completion = {
         dynamicRegistration = false;

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -564,6 +564,35 @@ function tests.decode_nil()
   }
 end
 
+
+function tests.code_action_with_resolve()
+  skeleton {
+    on_init = function()
+      return {
+        capabilities = {
+          codeActionProvider = {
+            resolveProvider = true
+          }
+        }
+      }
+    end;
+    body = function()
+      notify('start')
+      local cmd = {
+        title = 'Command 1',
+        command = 'dummy1'
+      }
+      expect_request('textDocument/codeAction', function()
+        return nil, { cmd, }
+      end)
+      expect_request('codeAction/resolve', function()
+        return nil, cmd
+      end)
+      notify('shutdown')
+    end;
+  }
+end
+
 -- Tests will be indexed by TEST_NAME
 
 local kill_timer = vim.loop.new_timer()


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/15339 https://github.com/neovim/neovim/issues/15828

See https://microsoft.github.io/language-server-protocol/specification#codeAction_resolve 

Adds support for lazily resolving the `edit` property of code actions. For
language servers supporting this capability it should reduce the time it takes
to show the code action options.

This changes the `code_action` and `range_code_action` implementations to no
longer call the global `textDocument/codeAction` handler. The reason for that
is that it is necessary to use the right client to resolve a code action. So a
structure like `(CodeAction | Command, ClientId)[]` is needed. But the handler
interface only supports `err, CodeAction[] | Command[], ctx`.


## todo

- [x] update tests
