### PR TITLE
fix(ui): s/format_entry/format_item in ui.select to match docs

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -149,7 +149,7 @@ M['textDocument/codeAction'] = function(_, result, ctx)
 
   vim.ui.select(result, {
     prompt = 'Code actions:',
-    format_entry = function(action)
+    format_item = function(action)
       local title = action.title:gsub('\r\n', '\\r\\n')
       return title:gsub('\n', '\\n')
     end,

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -20,9 +20,9 @@ function M.select(items, opts, on_choice)
   }
   opts = opts or {}
   local choices = {opts.prompt or 'Select one of:'}
-  local format_entry = opts.format_entry or tostring
+  local format_item = opts.format_item or tostring
   for i, item in pairs(items) do
-    table.insert(choices, string.format('%d: %s', i, format_entry(item)))
+    table.insert(choices, string.format('%d: %s', i, format_item(item)))
   end
   local choice = vim.fn.inputlist(choices)
   if choice < 1 or choice > #items then

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -17,7 +17,7 @@ describe('vim.ui', function()
           { name = 'Item 2' },
         }
         local opts = {
-          format_entry = function(entry)
+          format_item = function(entry)
             return entry.name
           end
         }


### PR DESCRIPTION
Follow up to https://github.com/neovim/neovim/pull/15771
I had updated the docs after the naming discussion but forgot to update
the code to reflect the change.
