### PR TITLE
docs: remove outdated or unnecessary text in style guide

### DIFF
--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -154,14 +154,11 @@ Use `const` pointers whenever possible. Avoid `const` on non-pointer parameter d
     That said, while we encourage putting `const` first, we do not require it.
     But be consistent with the code around you! >
 
-    void foo(const char *p, int i);
-    }
+    void foo(const char *p, int i){}  // OK
 
-    int foo(const int a, const bool b) {
-    }
+    int foo(const int a, const bool b) {} // BAD: avoid const on non-pointers
 
-    int foo(int *const p) {
-    }
+    int foo(int *const p) {}  // Avoid: const after variable type
 
 
 Integer Types ~
@@ -201,25 +198,27 @@ Variable declarations ~
 
 Declare only one variable per line. >
 
-    int i, j = 1
+    int i, j = 1  // BAD
 
 
 Conditions ~
 
 Don't use "yoda-conditions". Use at most one assignment per condition. >
 
-    if (1 == x) {
+    if (1 == x) {  // BAD: Yoda-condition
 
-    if (x == 1) {  //use this order
+    if (x == 1) {  // OK: use this order
 
-    if ((x = f()) && (y = g())) {
+    if ((x = f()) && (y = g())) {  // BAD: two assignment in one condition
 
 
 Function declarations ~
 
 Every function must not have a separate declaration.
 
-Function declarations are created by the gendeclarations.lua script. >
+Function declarations are created by the gendeclarations.lua script.
+
+    Avoid: >
 
     static void f(void);
 
@@ -479,7 +478,7 @@ important, the best code is self-documenting.
 When writing your comments, write for your audience: the next contributor who
 will need to understand your code. Be generous — the next one may be you!
 
-Nvim uses Doxygen comments.
+Nvim uses Doxygen comments as specified by |dev-doc|.
 
 
 Comment Style ~
@@ -814,11 +813,6 @@ example, `"\uFEFF"`, is the Unicode zero-width no-break space character, which
 would be invisible if included in the source as straight UTF-8.
 
 
-Spaces vs. Tabs ~
-
-Use only spaces, and indent 2 spaces at a time. Do not use tabs in your code.
-
-
 Function Declarations and Definitions ~
 
 Return type on the same line as function name, parameters on the same line if
@@ -854,18 +848,9 @@ or if you cannot fit even the first parameter (but only then): >
 
 Some points to note:
 
-- The open parenthesis is always on the same line as the function name.
-- There is never a space between the function name and the open parenthesis.
-- There is never a space between the parentheses and the parameters.
-- The open curly brace is always on the next line.
-- The close curly brace is always on the last line by itself.
-- There should be a space between the close parenthesis and the open curly
-  brace.
 - All parameters should be named, with identical names in the declaration and
   implementation.
 - All parameters should be aligned if possible.
-- Default indentation is 2 spaces.
-- Wrapped parameters have a 4 space indent.
 
 
 Function Calls ~
@@ -909,44 +894,6 @@ In particular, this should be done if the function signature is so long that
 it cannot fit within the maximum line length.
 
 
-Braced Initializer Lists ~
-
-Format a braced list exactly like you would format a function call in its
-place but with one space after the `{` and one space before the `}`
-
-If the braced list follows a name (e.g. a type or variable name), format as if
-the `{}` were the parentheses of a function call with that name. If there is
-no name, assume a zero-length name. >
-
-    struct my_struct m = {  // Here, you could also break before {.
-        superlongvariablename1,
-        superlongvariablename2,
-        { short, interior, list },
-        { interiorwrappinglist,
-          interiorwrappinglist2 } };
-
-
-Conditionals ~
-
-Don't use spaces inside parentheses. Always use curly braces. >
-
-    if (condition) {  // no spaces inside parentheses
-      ...  // 2 space indent.
-    } else if (...) {  // The else goes on the same line as the closing brace.
-      ...
-    } else {
-      ...
-    }
-
-You must have a space between the `if` and the open parenthesis. You must also
-have a space between the close parenthesis and the curly brace, if you're
-using one. >
-
-    if(condition) {   // BAD: space missing after IF.
-    if (condition){   // BAD: space missing before {.
-    if (condition) {  // GOOD: proper space after IF and before {.
-
-
 Loops and Switch Statements ~
 
 Annotate non-trivial fall-through between cases. Empty loop bodies should use
@@ -978,33 +925,6 @@ Empty loop bodies should use `{}` or `continue`, but not a single semicolon. >
 
     while (condition);  // BAD: looks like part of do/while loop.
 
-Pointer Expressions ~
-
-No spaces around period or arrow. Pointer operators do not have trailing
-spaces.
-
-The following are examples of correctly-formatted pointer and reference
-expressions: >
-
-    x = *p;
-    p = &x;
-    x = r.y;
-    x = r->y;
-
-Note that:
-
-    - There are no spaces around the period or arrow when accessing a member.
-    - Pointer operators have no space after the * or &.
-
-When declaring a pointer variable or argument, place the asterisk adjacent to
-the variable name: >
-
-    char *c;
-
-    char * c;  // BAD: spaces on both sides of *
-    char* c;   // BAD
-
-
 Boolean Expressions ~
 
 When you have a boolean expression that is longer than the standard line
@@ -1034,50 +954,10 @@ expr;`. >
     return(result);  // return is not a function!
 
 
-Preprocessor Directives ~
-
-The hash mark that starts a preprocessor directive should always be at the
-beginning of the line.
-
-Even when preprocessor directives are within the body of indented code, the
-directives should start at the beginning of the line.
-
-Nested directives should add one spaces after the hash mark for each level of
-indentation. 
-
-    // GOOD: directives at beginning of line >
-      if (lopsided_score) {
-    #if DISASTER_PENDING      // Correct -- Starts at beginning of line
-        drop_everything();
-    # if NOTIFY               // One space after #
-        notify_client();
-    # endif
-    #endif
-        BackToNormal();
-      }
-
-<    // BAD: indented directives >
-      if (lopsided_score) {
-        #if DISASTER_PENDING  // Wrong!  The "#if" should be at beginning of line
-        drop_everything();
-        #endif                // Wrong!  Do not indent "#endif"
-        back_to_normal();
-      }
-
-
 Horizontal Whitespace ~
 
 Use of horizontal whitespace depends on location. Never put trailing
 whitespace at the end of a line.
-
-    General ~
->
-        if (x) {          // Open braces should always have a space before them.
-          ...
-        }
-        int i = 0;        // Semicolons usually have no space before them.
-        int x[] = { 0 };  // Spaces inside braces for braced-init-list.
-<
 
     Variables ~
 >
@@ -1095,30 +975,6 @@ whitespace at the end of a line.
         };
 <
 
-    Macros ~
->
-        #define FI(x) \  // Don't align \'s in macro definitions.
-          foo();      \
-          bar();      \
-          ...
-<
-
-    Loops and Conditionals ~
->
-        if (b) {              // Space after the keyword in condition.
-        } else {              // Spaces around else.
-        }
-        while (test) {}       // There is usually no space inside parentheses.
-        for (; i < 5; i++) {  // For loops always have a space after the
-          ...                 // semicolon and no a space before the
-          ...                 // semicolon.
-        }
-        switch (i) {
-          case 1:             // No space before colon in a switch case.
-            ...
-          case 2: break;      // Space after a colon if there's code after it.
-<
-
     Operators ~
 >
         x = 0;            // Assignment operators always have spaces around
@@ -1129,23 +985,6 @@ whitespace at the end of a line.
           ...
         v = w*x + y/z;    // Use spaces to indicate operator precedence.
         v = w * (x + z);  // Parentheses should have no spaces inside them.
-        i = (int)d;       // No spaces after a cast operator.
-<
-
-Vertical Whitespace ~
-
-Minimize use of vertical whitespace.
-
-This is more a principle than a rule: don't use blank lines when you don't
-have to. In particular, don't put more than one or two blank lines between
-functions, resist starting functions with a blank line, don't end functions
-with a blank line, and be discriminating with your use of blank lines inside
-functions.
-
-The basic principle is: The more code that fits on one screen, the easier it
-is to follow and understand the control flow of the program. Of course,
-readability can suffer from code being too dense as well as too spread out, so
-use your judgment. But in general, minimize use of vertical whitespace.
 
 
 ==============================================================================

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -161,6 +161,8 @@ Docstring format:
 - Lines start with `///`
 - Special tokens start with `@` followed by the token name:
   `@note`, `@param`, `@returns`
+- Use the [in], [out], [allocated], [static] conventions for the `@param` and
+  `@returns`.
 - Limited markdown is supported.
   - List-items start with `-` (useful to nest or "indent")
 - Use `<pre>`  for code samples.


### PR DESCRIPTION
Things to add:

- [x] For `@param` and `@returns` in doxygen comments, note the `[in]`, `[out]`, `[allocated]`, `[static]` conventions.
- [x] "Thus I would suggest the following addition to the style guide: require trailing comma always when closing brace is placed on the separate line and require absense of trailing comma when closing brace is placed on the same line as the last element in the initializer list." Not sure this can't be entirely automated. Will check on it later to confirm."
> yeah if this isn't already mentioned i would not explain it beyond a very terse mention like Trailing commas are preferred where possible. Autoformat/lint should take care of 99% of the rest.