### PR TITLE
feat(ui): add `opt.kind` to `vim.ui.select`

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -529,6 +529,7 @@ local function on_code_action_results(results, ctx)
 
   vim.ui.select(action_tuples, {
     prompt = 'Code actions:',
+    kind = 'codeaction',
     format_item = function(action_tuple)
       local title = action_tuple[2].title:gsub('\r\n', '\\r\\n')
       return title:gsub('\n', '\\n')

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -10,13 +10,10 @@ local M = {}
 ---               Function to format an
 ---               individual item from `items`. Defaults to `tostring`.
 ---     - kind (string|nil)
----               Kind of `items`.
+---               Arbitrary hint string indicating the item shape.
 ---               Plugins reimplementing `vim.ui.select` may wish to
----               display different ui elements depending on the
----               the structure of `items`, or the context in which
----               `select` is called. `kind` allows authors
----               of such plugins to opt into maintaining such
----               behavior.
+---               use this to infer the structure or semantics of
+---               `items`, or the context in which select() was called.
 ---@param on_choice function ((item|nil, idx|nil) -> ())
 ---               Called once the user made a choice.
 ---               `idx` is the 1-based index of `item` within `item`.

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -9,6 +9,14 @@ local M = {}
 ---     - format_item (function item -> text)
 ---               Function to format an
 ---               individual item from `items`. Defaults to `tostring`.
+---     - kind (string|nil)
+---               Kind of `items`.
+---               Plugins reimplementing `vim.ui.select` may wish to
+---               display different ui elements depending on the
+---               the structure of `items`, or the context in which
+---               `select` is called. `kind` allows authors
+---               of such plugins to opt into maintaining such
+---               behavior.
 ---@param on_choice function ((item|nil, idx|nil) -> ())
 ---               Called once the user made a choice.
 ---               `idx` is the 1-based index of `item` within `item`.


### PR DESCRIPTION
from discussion in https://github.com/neovim/neovim/pull/15808

if one were to reimplement `vim.ui.select` with a fuzzy picker, you might want some information about the underlying structure of `items` in order to generate a preview window for example 