### PR TITLE
vim-patch:8.2.{3430,3434,3462,3463,3555,3609,3610}: ModeChanged autocmd

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -721,18 +721,23 @@ MenuPopup			Just before showing the popup menu (under the
 							*ModeChanged*
 ModeChanged			After changing the mode. The pattern is
 				matched against `'old_mode:new_mode'`, for
-				example match against `i:*` to simulate
-				|InsertLeave|.
+				example match against `*:c` to simulate
+				|CmdlineEnter|.
 				The following values of |v:event| are set:
 					old_mode The mode before it changed.
 					new_mode The new mode as also returned
-						by |mode()|.
+						by |mode()| called with a
+						non-zero argument.
 				When ModeChanged is triggered, old_mode will
 				have the value of new_mode when the event was
 				last triggered.
+				This will be triggered on every minor mode
+				change.
 				Usage example to use relative line numbers
 				when entering visual mode: >
-					:autocmd ModeChanged *:v set rnu
+		:au ModeChanged [vV\x16]*:* let &l:rnu = mode() =~# '^[vV\x16]'
+		:au ModeChanged *:[vV\x16]* let &l:rnu = mode() =~# '^[vV\x16]'
+		:au WinEnter,WinLeave * let &l:rnu = mode() =~# '^[vV\x16]'
 <							*OptionSet*
 OptionSet			After setting an option (except during
 				|startup|).  The |autocmd-pattern| is matched

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -718,7 +718,22 @@ MenuPopup			Just before showing the popup menu (under the
 					o	Operator-pending
 					i	Insert
 					c	Command line
-							*OptionSet*
+							*ModeChanged*
+ModeChanged			After changing the mode. The pattern is
+				matched against `'old_mode:new_mode'`, for
+				example match against `i:*` to simulate
+				|InsertLeave|.
+				The following values of |v:event| are set:
+					old_mode The mode before it changed.
+					new_mode The new mode as also returned
+						by |mode()|.
+				When ModeChanged is triggered, old_mode will
+				have the value of new_mode when the event was
+				last triggered.
+				Usage example to use relative line numbers
+				when entering visual mode: >
+					:autocmd ModeChanged *:v set rnu
+<							*OptionSet*
 OptionSet			After setting an option (except during
 				|startup|).  The |autocmd-pattern| is matched
 				against the long option name.  |<amatch>|

--- a/src/nvim/aucmd.c
+++ b/src/nvim/aucmd.c
@@ -8,6 +8,7 @@
 #include "nvim/ex_getln.h"
 #include "nvim/fileio.h"
 #include "nvim/main.h"
+#include "nvim/misc1.h"
 #include "nvim/os/os.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
@@ -25,13 +26,14 @@ void do_autocmd_uienter(uint64_t chanid, bool attached)
   }
   recursive = true;
 
-  dict_T *dict = get_vim_var_dict(VV_EVENT);
+  save_v_event_T save_v_event;
+  dict_T *dict = get_v_event(&save_v_event);
   assert(chanid < VARNUMBER_MAX);
   tv_dict_add_nr(dict, S_LEN("chan"), (varnumber_T)chanid);
   tv_dict_set_keys_readonly(dict);
   apply_autocmds(attached ? EVENT_UIENTER : EVENT_UILEAVE,
                  NULL, NULL, false, curbuf);
-  tv_dict_clear(dict);
+  restore_v_event(dict, &save_v_event);
 
   recursive = false;
 }

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -69,6 +69,7 @@ return {
     'InsertLeave',            -- just after leaving Insert mode
     'InsertLeavePre',         -- just before leaving Insert mode
     'MenuPopup',              -- just before popup menu is displayed
+    'ModeChanged',            -- after changing the mode
     'OptionSet',              -- after setting any option
     'QuickFixCmdPost',        -- after :make, :grep etc.
     'QuickFixCmdPre',         -- before :make, :grep etc.

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1440,7 +1440,7 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
   // invalid.
   if (fname_io == NULL) {
     if (event == EVENT_COLORSCHEME || event == EVENT_COLORSCHEMEPRE
-        || event == EVENT_OPTIONSET) {
+        || event == EVENT_OPTIONSET || event == EVENT_MODECHANGED) {
       autocmd_fname = NULL;
     } else if (fname != NULL && !ends_excmd(*fname)) {
       autocmd_fname = fname;
@@ -1494,11 +1494,12 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
         || event == EVENT_CMDWINLEAVE || event == EVENT_CMDUNDEFINED
         || event == EVENT_COLORSCHEME || event == EVENT_COLORSCHEMEPRE
         || event == EVENT_DIRCHANGED || event == EVENT_FILETYPE
-        || event == EVENT_FUNCUNDEFINED || event == EVENT_OPTIONSET
-        || event == EVENT_QUICKFIXCMDPOST || event == EVENT_QUICKFIXCMDPRE
-        || event == EVENT_REMOTEREPLY || event == EVENT_SPELLFILEMISSING
-        || event == EVENT_SYNTAX || event == EVENT_SIGNAL
-        || event == EVENT_TABCLOSED || event == EVENT_WINCLOSED) {
+        || event == EVENT_FUNCUNDEFINED || event == EVENT_MODECHANGED
+        || event == EVENT_OPTIONSET || event == EVENT_QUICKFIXCMDPOST
+        || event == EVENT_QUICKFIXCMDPRE || event == EVENT_REMOTEREPLY
+        || event == EVENT_SPELLFILEMISSING || event == EVENT_SYNTAX
+        || event == EVENT_SIGNAL || event == EVENT_TABCLOSED
+        || event == EVENT_WINCLOSED) {
       fname = vim_strsave(fname);
     } else {
       fname = (char_u *)FullName_save((char *)fname, false);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -925,6 +925,13 @@ static int do_autocmd_event(event_T event, char_u *pat, bool once, int nested, c
             return FAIL;
           }
         }
+
+        // need to initialize last_mode for the first ModeChanged autocmd
+        if (event == EVENT_MODECHANGED && !has_event(EVENT_MODECHANGED)) {
+          xfree(last_mode);
+          last_mode = get_mode();
+        }
+
         ap->cmds = NULL;
         *prev_ap = ap;
         last_autopat[(int)event] = ap;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1116,6 +1116,12 @@ typedef struct {
   pos_T w_cursor_corr;  // corrected cursor position
 } pos_save_T;
 
+// Struct passed to get_v_event() and restore_v_event().
+typedef struct {
+  bool sve_did_save;
+  hashtab_T sve_hashtab;
+} save_v_event_T;
+
 /// Indices into vimmenu_T->strings[] and vimmenu_T->noremap[] for each mode
 /// \addtogroup MENU_INDEX
 /// @{

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -10,6 +10,7 @@
 #include "nvim/event/socket.h"
 #include "nvim/fileio.h"
 #include "nvim/lua/executor.h"
+#include "nvim/misc1.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/server.h"
 #include "nvim/os/shell.h"
@@ -821,7 +822,8 @@ static void set_info_event(void **argv)
   Channel *chan = argv[0];
   event_T event = (event_T)(ptrdiff_t)argv[1];
 
-  dict_T *dict = get_vim_var_dict(VV_EVENT);
+  save_v_event_T save_v_event;
+  dict_T *dict = get_v_event(&save_v_event);
   Dictionary info = channel_info(chan->id);
   typval_T retval;
   (void)object_to_vim(DICTIONARY_OBJ(info), &retval, NULL);
@@ -829,7 +831,7 @@ static void set_info_event(void **argv)
 
   apply_autocmds(event, NULL, NULL, false, curbuf);
 
-  tv_dict_clear(dict);
+  restore_v_event(dict, &save_v_event);
   api_free_dictionary(info);
   channel_decref(chan);
 }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2719,12 +2719,13 @@ static bool pum_enough_matches(void)
 static void trigger_complete_changed_event(int cur)
 {
   static bool recursive = false;
+  save_v_event_T save_v_event;
 
   if (recursive) {
     return;
   }
 
-  dict_T *v_event = get_vim_var_dict(VV_EVENT);
+  dict_T *v_event = get_v_event(&save_v_event);
   if (cur < 0) {
     tv_dict_add_dict(v_event, S_LEN("completed_item"), tv_dict_alloc());
   } else {
@@ -2740,7 +2741,7 @@ static void trigger_complete_changed_event(int cur)
   textlock--;
   recursive = false;
 
-  tv_dict_clear(v_event);
+  restore_v_event(v_event, &save_v_event);
 }
 
 /// Show the popup menu for the list of matches.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2049,6 +2049,8 @@ static void ins_ctrl_x(void)
     // CTRL-V look like CTRL-N
     ctrl_x_mode = CTRL_X_CMDLINE_CTRL_X;
   }
+
+  trigger_modechanged();
 }
 
 // Whether other than default completion has been selected.
@@ -2661,6 +2663,7 @@ void set_completion(colnr_T startcol, list_T *list)
     show_pum(save_w_wrow, save_w_leftcol);
   }
 
+  trigger_modechanged();
   ui_flush();
 }
 
@@ -3839,6 +3842,8 @@ static bool ins_compl_prep(int c)
     ins_apply_autocmds(EVENT_COMPLETEDONE);
   }
 
+  trigger_modechanged();
+
   /* reset continue_* if we left expansion-mode, if we stay they'll be
    * (re)set properly in ins_complete() */
   if (!vim_is_ctrl_x_key(c)) {
@@ -4587,6 +4592,8 @@ static int ins_compl_get_exp(pos_T *ini)
       compl_curr_match = compl_old_match;
     }
   }
+  trigger_modechanged();
+
   return i;
 }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -385,6 +385,7 @@ static void insert_enter(InsertState *s)
     State = INSERT;
   }
 
+  trigger_modechanged();
   stop_insert_mode = false;
 
   // Need to recompute the cursor position, it might move when the cursor is
@@ -7965,6 +7966,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
 
 
   State = NORMAL;
+  trigger_modechanged();
   // need to position cursor again (e.g. when on a TAB )
   changed_cline_bef_curs();
 
@@ -8066,6 +8068,7 @@ static void ins_insert(int replaceState)
   } else {
     State = replaceState | (State & LANGMAP);
   }
+  trigger_modechanged();
   AppendCharToRedobuff(K_INS);
   showmode();
   ui_cursor_shape();            // may show different cursor shape

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -196,6 +196,7 @@ void do_exmode(void)
 
   exmode_active = true;
   State = NORMAL;
+  trigger_modechanged();
 
   // When using ":global /pat/ visual" and then "Q" we return to continue
   // the :global command.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -880,7 +880,8 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
   TryState tstate;
   Error err = ERROR_INIT;
   bool tl_ret = true;
-  dict_T *dict = get_vim_var_dict(VV_EVENT);
+  save_v_event_T save_v_event;
+  dict_T *dict = get_v_event(&save_v_event);
   char firstcbuf[2];
   firstcbuf[0] = (char)(firstc > 0 ? firstc : '-');
   firstcbuf[1] = 0;
@@ -894,7 +895,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
 
     apply_autocmds(EVENT_CMDLINEENTER, (char_u *)firstcbuf, (char_u *)firstcbuf,
                    false, curbuf);
-    tv_dict_clear(dict);
+    restore_v_event(dict, &save_v_event);
 
 
     tl_ret = try_leave(&tstate, &err);
@@ -925,7 +926,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     if (tv_dict_get_number(dict, "abort") != 0) {
       s->gotesc = 1;
     }
-    tv_dict_clear(dict);
+    restore_v_event(dict, &save_v_event);
   }
 
   cmdmsg_rl = false;
@@ -2290,7 +2291,8 @@ static int command_line_changed(CommandLineState *s)
   if (has_event(EVENT_CMDLINECHANGED)) {
     TryState tstate;
     Error err = ERROR_INIT;
-    dict_T *dict = get_vim_var_dict(VV_EVENT);
+    save_v_event_T save_v_event;
+    dict_T *dict = get_v_event(&save_v_event);
 
     char firstcbuf[2];
     firstcbuf[0] = (char)(s->firstc > 0 ? s->firstc : '-');
@@ -2304,7 +2306,7 @@ static int command_line_changed(CommandLineState *s)
 
     apply_autocmds(EVENT_CMDLINECHANGED, (char_u *)firstcbuf,
                    (char_u *)firstcbuf, false, curbuf);
-    tv_dict_clear(dict);
+    restore_v_event(dict, &save_v_event);
 
     bool tl_ret = try_leave(&tstate, &err);
     if (!tl_ret && ERROR_SET(&err)) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -906,6 +906,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
     }
     tl_ret = true;
   }
+  trigger_modechanged();
 
   state_enter(&s->state);
 
@@ -6547,6 +6548,7 @@ static int open_cmdwin(void)
   cmdmsg_rl = save_cmdmsg_rl;
 
   State = save_State;
+  trigger_modechanged();
   setmouse();
 
   return cmdwin_result;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1603,7 +1603,8 @@ void do_autocmd_dirchanged(char *new_dir, CdScope scope, CdCause cause)
 
   recursive = true;
 
-  dict_T *dict = get_vim_var_dict(VV_EVENT);
+  save_v_event_T save_v_event;
+  dict_T *dict = get_v_event(&save_v_event);
   char buf[8];
 
   switch (scope) {
@@ -1648,7 +1649,7 @@ void do_autocmd_dirchanged(char *new_dir, CdScope scope, CdCause cause)
   apply_autocmds(EVENT_DIRCHANGED, (char_u *)buf, (char_u *)new_dir, false,
                  curbuf);
 
-  tv_dict_clear(dict);
+  restore_v_event(dict, &save_v_event);
 
   recursive = false;
 }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -727,6 +727,7 @@ EXTERN bool listcmd_busy INIT(= false);     // set when :argdo, :windo or
                                             // :bufdo is executing
 EXTERN bool need_start_insertmode INIT(= false);
 // start insert mode soon
+EXTERN char *last_mode INIT(= NULL);
 EXTERN char_u *last_cmdline INIT(= NULL);      // last command line (for ":)
 EXTERN char_u *repeat_cmdline INIT(= NULL);    // command line for "."
 EXTERN char_u *new_last_cmdline INIT(= NULL);  // new value for last_cmdline

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -632,6 +632,7 @@ void free_all_mem(void)
   clear_sb_text(true);            // free any scrollback text
 
   // Free some global vars.
+  xfree(last_mode);
   xfree(last_cmdline);
   xfree(new_last_cmdline);
   set_keep_msg(NULL, 0);

--- a/src/nvim/misc1.c
+++ b/src/nvim/misc1.c
@@ -1067,12 +1067,13 @@ void trigger_modechanged(void)
     return;
   }
 
-  dict_T *v_event = get_vim_var_dict(VV_EVENT);
-
   char *mode = get_mode();
-  if (last_mode == NULL) {
-    last_mode = (char *)vim_strsave((char_u *)"n");
+  if (STRCMP(mode, last_mode) == 0) {
+    xfree(mode);
+    return;
   }
+
+  dict_T *v_event = get_vim_var_dict(VV_EVENT);
   tv_dict_add_str(v_event, S_LEN("new_mode"), mode);
   tv_dict_add_str(v_event, S_LEN("old_mode"), last_mode);
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6789,7 +6789,6 @@ static void n_start_visual_mode(int c)
   VIsual_mode = c;
   VIsual_active = true;
   VIsual_reselect = true;
-  trigger_modechanged();
   // Corner case: the 0 position in a tab may change when going into
   // virtualedit.  Recalculate curwin->w_cursor to avoid bad highlighting.
   //
@@ -6801,6 +6800,7 @@ static void n_start_visual_mode(int c)
 
   foldAdjustVisual();
 
+  trigger_modechanged();
   setmouse();
   // Check for redraw after changing the state.
   conceal_check_cursor_line();

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -487,6 +487,7 @@ static void normal_prepare(NormalState *s)
   if (finish_op != c) {
     ui_cursor_shape();  // may show different cursor shape
   }
+  trigger_modechanged();
 
   // When not finishing an operator and no register name typed, reset the count.
   if (!finish_op && !s->oa.regname) {
@@ -928,6 +929,7 @@ normal_end:
   // Reset finish_op, in case it was set
   s->c = finish_op;
   finish_op = false;
+  trigger_modechanged();
   // Redraw the cursor with another shape, if we were in Operator-pending
   // mode or did a replace command.
   if (s->c || s->ca.cmdchar == 'r') {
@@ -965,6 +967,7 @@ normal_end:
       && s->oa.regname == 0) {
     if (restart_VIsual_select == 1) {
       VIsual_select = true;
+      trigger_modechanged();
       showmode();
       restart_VIsual_select = 0;
     }
@@ -3050,7 +3053,6 @@ static int get_mouse_class(char_u *p)
 void end_visual_mode(void)
 {
   VIsual_active = false;
-  trigger_modechanged();
   setmouse();
   mouse_dragging = 0;
 
@@ -3067,6 +3069,7 @@ void end_visual_mode(void)
   may_clear_cmdline();
 
   adjust_cursor_eol();
+  trigger_modechanged();
 }
 
 /*
@@ -4852,6 +4855,7 @@ static void nv_ctrlg(cmdarg_T *cap)
 {
   if (VIsual_active) {  // toggle Selection/Visual mode
     VIsual_select = !VIsual_select;
+    trigger_modechanged();
     showmode();
   } else if (!checkclearop(cap->oap)) {
     // print full name if count given or :cd used
@@ -4895,6 +4899,7 @@ static void nv_ctrlo(cmdarg_T *cap)
 {
   if (VIsual_active && VIsual_select) {
     VIsual_select = false;
+    trigger_modechanged();
     showmode();
     restart_VIsual_select = 2;          // restart Select mode later
   } else {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3050,6 +3050,7 @@ static int get_mouse_class(char_u *p)
 void end_visual_mode(void)
 {
   VIsual_active = false;
+  trigger_modechanged();
   setmouse();
   mouse_dragging = 0;
 
@@ -6680,6 +6681,7 @@ static void nv_visual(cmdarg_T *cap)
                                               //           or char/line mode
       VIsual_mode = cap->cmdchar;
       showmode();
+      trigger_modechanged();
     }
     redraw_curbuf_later(INVERTED);          // update the inversion
   } else {                // start Visual mode
@@ -6782,6 +6784,7 @@ static void n_start_visual_mode(int c)
   VIsual_mode = c;
   VIsual_active = true;
   VIsual_reselect = true;
+  trigger_modechanged();
   // Corner case: the 0 position in a tab may change when going into
   // virtualedit.  Recalculate curwin->w_cursor to avoid bad highlighting.
   //

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2792,8 +2792,9 @@ static void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
 
   recursive = true;
 
+  save_v_event_T save_v_event;
   // Set the v:event dictionary with information about the yank.
-  dict_T *dict = get_vim_var_dict(VV_EVENT);
+  dict_T *dict = get_v_event(&save_v_event);
 
   // The yanked text contents.
   list_T *const list = tv_list_alloc((ptrdiff_t)reg->y_size);
@@ -2830,7 +2831,7 @@ static void do_autocmd_textyankpost(oparg_T *oap, yankreg_T *reg)
   textlock++;
   apply_autocmds(EVENT_TEXTYANKPOST, NULL, NULL, false, curbuf);
   textlock--;
-  tv_dict_clear(dict);
+  restore_v_event(dict, &save_v_event);
 
   recursive = false;
 }

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -136,7 +136,7 @@ int get_real_state(void)
 /// @returns[allocated] mode string
 char *get_mode(void)
 {
-  char *buf = xcalloc(4, sizeof(char));
+  char *buf = xcalloc(MODE_MAX_LENGTH, sizeof(char));
 
   if (VIsual_active) {
     if (VIsual_select) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -412,6 +412,7 @@ void terminal_enter(void)
   curwin->w_redr_status = true;  // For mode() in statusline. #8323
   ui_busy_start();
   apply_autocmds(EVENT_TERMENTER, NULL, NULL, false, curbuf);
+  trigger_modechanged();
 
   s->state.execute = terminal_execute;
   s->state.check = terminal_check;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -324,10 +324,11 @@ void terminal_close(Terminal *term, int status)
   }
 
   if (buf && !is_autocmd_blocked()) {
-    dict_T *dict = get_vim_var_dict(VV_EVENT);
+    save_v_event_T save_v_event;
+    dict_T *dict = get_v_event(&save_v_event);
     tv_dict_add_nr(dict, S_LEN("status"), status);
     apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
-    tv_dict_clear(dict);
+    restore_v_event(dict, &save_v_event);
   }
 }
 

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1727,4 +1727,12 @@ func Test_recursive_ModeChanged()
   au!
 endfunc
 
+func Test_ModeChanged_starts_visual()
+  " This was triggering ModeChanged before setting VIsual, causing a crash.
+  au! ModeChanged * norm 0u
+  sil! norm 
+
+  au! ModeChanged
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1655,7 +1655,7 @@ func Test_mode_changes()
   func! TestMode()
     call assert_equal(g:mode_seq[g:index], get(v:event, "old_mode"))
     call assert_equal(g:mode_seq[g:index + 1], get(v:event, "new_mode"))
-    call assert_equal(mode(), get(v:event, "new_mode"))
+    call assert_equal(mode(1), get(v:event, "new_mode"))
     let g:index += 1
   endfunc
 
@@ -1667,7 +1667,11 @@ func Test_mode_changes()
   au ModeChanged V:v :call DoIt()
   call feedkeys("Vv\<esc>", 'tnix')
   call assert_equal(4, g:count)
+  call assert_equal(len(g:mode_seq) - 1, g:index)
 
+  let g:index = 0
+  let g:mode_seq = ['n', 'i', 'niI', 'i', 'n']
+  call feedkeys("a\<C-O>l\<esc>", 'tnix')
   call assert_equal(len(g:mode_seq) - 1, g:index)
 
   au! ModeChanged

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1644,4 +1644,38 @@ func Test_read_invalid()
   set encoding=utf-8
 endfunc
 
+" Test for ModeChanged pattern
+func Test_mode_changes()
+  let g:count = 0
+  func! DoIt()
+    let g:count += 1
+  endfunc
+  let g:index = 0
+  let g:mode_seq = ['n', 'i', 'n', 'v', 'V', 'n', 'V', 'v', 'n']
+  func! TestMode()
+    call assert_equal(g:mode_seq[g:index], get(v:event, "old_mode"))
+    call assert_equal(g:mode_seq[g:index + 1], get(v:event, "new_mode"))
+    call assert_equal(mode(), get(v:event, "new_mode"))
+    let g:index += 1
+  endfunc
+
+  au ModeChanged * :call TestMode()
+  au ModeChanged n:* :call DoIt()
+  call feedkeys("i\<esc>vV\<esc>", 'tnix')
+  call assert_equal(2, g:count)
+
+  au ModeChanged V:v :call DoIt()
+  call feedkeys("Vv\<esc>", 'tnix')
+  call assert_equal(4, g:count)
+
+  call assert_equal(len(g:mode_seq) - 1, g:index)
+
+  au! ModeChanged
+  delfunc TestMode
+  unlet! g:mode_seq
+  unlet! g:index
+  delfunc DoIt
+  unlet! g:count
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1721,4 +1721,10 @@ func Test_mode_changes()
   unlet! g:i_to_any
 endfunc
 
+func Test_recursive_ModeChanged()
+  au! ModeChanged * norm 0u
+  sil! norm 
+  au!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1669,10 +1669,31 @@ func Test_mode_changes()
   call assert_equal(4, g:count)
   call assert_equal(len(g:mode_seq) - 1, g:index)
 
+  let g:n_to_i = 0
+  au ModeChanged n:i let g:n_to_i += 1
+  let g:n_to_niI = 0
+  au ModeChanged i:niI let g:n_to_niI += 1
+  let g:niI_to_i = 0
+  au ModeChanged niI:i let g:niI_to_i += 1
+  let g:nany_to_i = 0
+  au ModeChanged n*:i let g:nany_to_i += 1
+  let g:i_to_n = 0
+  au ModeChanged i:n let g:i_to_n += 1
+  let g:nori_to_any = 0
+  au ModeChanged [ni]:* let g:nori_to_any += 1
+  let g:i_to_any = 0
+  au ModeChanged i:* let g:i_to_any += 1
   let g:index = 0
   let g:mode_seq = ['n', 'i', 'niI', 'i', 'n']
   call feedkeys("a\<C-O>l\<esc>", 'tnix')
   call assert_equal(len(g:mode_seq) - 1, g:index)
+  call assert_equal(1, g:n_to_i)
+  call assert_equal(1, g:n_to_niI)
+  call assert_equal(1, g:niI_to_i)
+  call assert_equal(2, g:nany_to_i)
+  call assert_equal(1, g:i_to_n)
+  call assert_equal(2, g:i_to_any)
+  call assert_equal(3, g:nori_to_any)
 
   au! ModeChanged
   delfunc TestMode

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -72,6 +72,8 @@ enum { NUMBUFLEN = 65, };
 #define TERM_FOCUS      0x2000  // Terminal focus mode
 #define CMDPREVIEW      0x4000  // Showing 'inccommand' command "live" preview.
 
+#define MODE_MAX_LENGTH 4       // max mode length returned in mode()
+
 // all mode bits used for mapping
 #define MAP_ALL_MODES   (0x3f | SELECTMODE | TERM_FOCUS)
 

--- a/test/functional/autocmd/modechanged_spec.lua
+++ b/test/functional/autocmd/modechanged_spec.lua
@@ -1,0 +1,31 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear, eval, eq = helpers.clear, helpers.eval, helpers.eq
+local feed, command = helpers.feed, helpers.command
+
+describe('ModeChanged', function()
+  before_each(function()
+    clear()
+    command('let g:count = 0')
+    command('au ModeChanged * let g:event = copy(v:event)')
+    command('au ModeChanged * let g:count += 1')
+  end)
+
+  it('picks up terminal mode changes', function()
+    command("term")
+    feed('i')
+    eq({
+      old_mode = 'nt',
+      new_mode = 't'
+    }, eval('g:event'))
+    feed('<c-\\><c-n>')
+    eq({
+      old_mode = 't',
+      new_mode = 'nt'
+    }, eval('g:event'))
+    eq(3, eval('g:count'))
+    command("bd!")
+
+    -- v:event is cleared after the autocommand is done
+    eq({}, eval('v:event'))
+  end)
+end)


### PR DESCRIPTION
This is a direct port of the generic `ModeChanged` autocmd, that I already implemented for vim.
The autocmd can pattern match against `old_mode:new_mode`, for example:

- To only trigger, when switching from visual mode to visual-line mode, use `autocmd ModeChanged v:V`
- To only trigger, when entering normal mode from any other mode, use `autocmd ModeChanged *:n`

This patch is best tested using:
```bash
build/bin/nvim --clean -Nu <(cat<<EOF
set noshowmode
au ModeChanged * echomsg printf('the old mode was: "%s", the new mode is: "%s"', v:event.old_mode, v:event.new_mode)
EOF
)
```

Let me know if you need any changes! :)