### PR TITLE
fix(runtime): malformed command in jsonc ftplugin

### DIFF
--- a/runtime/ftplugin/jsonc.vim
+++ b/runtime/ftplugin/jsonc.vim
@@ -19,7 +19,7 @@ let s:undo_ftplugin = []
 
 " Set comment (formatting) related options. {{{1
 setlocal commentstring=//%s comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
-call add(s:undo_ftplugin, 'commentstring< comments<')
+call add(s:undo_ftplugin, 'setlocal commentstring< comments<')
 
 " Let Vim know how to disable the plug-in.
 call map(s:undo_ftplugin, "'execute ' . string(v:val)")


### PR DESCRIPTION
This fixes an issue where the default jsonc ftplugin script was setting
undo_ftplugin to an invalid command.

Previously:
```
nvim --headless tsconfig.json -n +q
Error detected while processing function <SNR>35_LoadFTPlugin:
line    2:
E492: Not an editor command: commentstring< comments<⏎
```

After change:

```
nvim --headless tsconfig.json -n +q
```