### PR TITLE
docs(diagnostics): add "priority" option to signs table

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -253,6 +253,12 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                    • severity: Only show signs for diagnostics
                                      matching the given severity
                                      |diagnostic-severity|
+                                   • priority: (number, default 10) Base
+                                     priority to use for signs. When
+                                     {severity_sort} is used, the priority of
+                                     a sign is adjusted based on its severity.
+                                     Otherwise, all signs use the same
+                                     priority.
 
                                  • update_in_insert: (default false) Update
                                    diagnostics in Insert mode (if false,

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -556,6 +556,9 @@ end
 ---       - signs: (default true) Use signs for diagnostics. Options:
 ---                * severity: Only show signs for diagnostics matching the given severity
 ---                |diagnostic-severity|
+---                * priority: (number, default 10) Base priority to use for signs. When
+---                {severity_sort} is used, the priority of a sign is adjusted based on
+---                its severity. Otherwise, all signs use the same priority.
 ---       - update_in_insert: (default false) Update diagnostics in Insert mode (if false,
 ---                           diagnostics are updated on InsertLeave)
 ---       - severity_sort: (default false) Sort diagnostics by severity. This affects the order in


### PR DESCRIPTION
This feature was added in #15785, but the docs for `vim.diagnostic.config()` weren't updated.
