### PR TITLE
refactor: remove PVS comment on top of files

### DIFF
--- a/src/xdiff/xdiffi.c
+++ b/src/xdiff/xdiffi.c
@@ -1,6 +1,3 @@
-// This is an open source non-commercial project. Dear PVS-Studio, please check
-// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-
 /*
  *  LibXDiff by Davide Libenzi ( File Differential Library )
  *  Copyright (C) 2003	Davide Libenzi

--- a/src/xdiff/xemit.c
+++ b/src/xdiff/xemit.c
@@ -1,6 +1,3 @@
-// This is an open source non-commercial project. Dear PVS-Studio, please check
-// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-
 /*
  *  LibXDiff by Davide Libenzi ( File Differential Library )
  *  Copyright (C) 2003	Davide Libenzi

--- a/src/xdiff/xhistogram.c
+++ b/src/xdiff/xhistogram.c
@@ -1,6 +1,3 @@
-// This is an open source non-commercial project. Dear PVS-Studio, please check
-// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-
 /*
  * Copyright (C) 2010, Google Inc.
  * and other copyright owners as documented in JGit's IP log.

--- a/src/xdiff/xpatience.c
+++ b/src/xdiff/xpatience.c
@@ -1,6 +1,3 @@
-// This is an open source non-commercial project. Dear PVS-Studio, please check
-// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-
 /*
  *  LibXDiff by Davide Libenzi ( File Differential Library )
  *  Copyright (C) 2003-2016 Davide Libenzi, Johannes E. Schindelin

--- a/src/xdiff/xprepare.c
+++ b/src/xdiff/xprepare.c
@@ -1,6 +1,3 @@
-// This is an open source non-commercial project. Dear PVS-Studio, please check
-// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-
 /*
  *  LibXDiff by Davide Libenzi ( File Differential Library )
  *  Copyright (C) 2003  Davide Libenzi

--- a/src/xdiff/xutils.c
+++ b/src/xdiff/xutils.c
@@ -1,6 +1,3 @@
-// This is an open source non-commercial project. Dear PVS-Studio, please check
-// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-
 /*
  *  LibXDiff by Davide Libenzi ( File Differential Library )
  *  Copyright (C) 2003	Davide Libenzi


### PR DESCRIPTION
The xdiff directory is excluded from the PVS report so the comment isn't
required.