### PR TITLE
fix: include ci/ in exported tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 *.h linguist-language=C
 src/nvim/testdir/test42.in diff
 .github/ export-ignore
-ci/ export-ignore
 .travis.yml export-ignore
 codecov.yml export-ignore
 .builds/ export-ignore


### PR DESCRIPTION
src/nvim/testdir/runnvim.sh re-uses the test suite code from ci/ to
cleanup the output of legacy tests.

Closes #15856