### PR TITLE
fix(runtime): add compressed {&packpath}/start/*/pack/*[/after] representation to &rtp

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1306,35 +1306,6 @@ static void set_window_layout(mparm_T *paramp)
   }
 }
 
-/*
- * Read all the plugin files.
- * Only when compiled with +eval, since most plugins need it.
- */
-static void load_plugins(void)
-{
-  if (p_lpl) {
-    char_u *rtp_copy = NULL;
-    char_u *const plugin_pattern_vim = (char_u *)"plugin/**/*.vim";  // NOLINT
-    char_u *const plugin_pattern_lua = (char_u *)"plugin/**/*.lua";  // NOLINT
-
-    // don't use source_runtime() yet so we can check for :packloadall below
-    source_in_path(p_rtp, plugin_pattern_vim, DIP_ALL | DIP_NOAFTER);
-    source_in_path(p_rtp, plugin_pattern_lua, DIP_ALL | DIP_NOAFTER);
-    TIME_MSG("loading rtp plugins");
-    xfree(rtp_copy);
-
-    // Only source "start" packages if not done already with a :packloadall
-    // command.
-    if (!did_source_packages) {
-      load_start_packages();
-    }
-    TIME_MSG("loading packages");
-
-    source_runtime(plugin_pattern_vim, DIP_ALL | DIP_AFTER);
-    source_runtime(plugin_pattern_lua, DIP_ALL | DIP_AFTER);
-    TIME_MSG("loading after plugins");
-  }
-}
 
 /*
  * "-q errorfile": Load the error file now.

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -12,10 +12,12 @@ local funcs = helpers.funcs
 local iswin = helpers.iswin
 local meths = helpers.meths
 local matches = helpers.matches
+local mkdir_p = helpers.mkdir_p
 local ok, nvim_async, feed = helpers.ok, helpers.nvim_async, helpers.feed
 local is_os = helpers.is_os
 local parse_context = helpers.parse_context
 local request = helpers.request
+local rmdir = helpers.rmdir
 local source = helpers.source
 local next_msg = helpers.next_msg
 local tmpname = helpers.tmpname
@@ -1574,6 +1576,18 @@ describe('API', function()
   end)
 
   describe('nvim_list_runtime_paths', function()
+    setup(function()
+      local pathsep = helpers.get_pathsep()
+      mkdir_p('Xtest'..pathsep..'a')
+      mkdir_p('Xtest'..pathsep..'b')
+    end)
+    teardown(function()
+      rmdir 'Xtest'
+    end)
+    before_each(function()
+      meths.set_current_dir 'Xtest'
+    end)
+
     it('returns nothing with empty &runtimepath', function()
       meths.set_option('runtimepath', '')
       eq({}, meths.list_runtime_paths())
@@ -1601,8 +1615,7 @@ describe('API', function()
       local long_path = ('/a'):rep(8192)
       meths.set_option('runtimepath', long_path)
       local paths_list = meths.list_runtime_paths()
-      neq({long_path}, paths_list)
-      eq({long_path:sub(1, #(paths_list[1]))}, paths_list)
+      eq({}, paths_list)
     end)
   end)
 


### PR DESCRIPTION
by suggestion by @tpope https://github.com/neovim/neovim/pull/15632#issuecomment-930639395

Summary:

We can add `XDG_DATA_DIR/nvim/site/pack/*/start/*` (et al) as an _unexpanded_ wildchar to `&rtp` which keeps it both short and explicit and still supporting `globpath(&rtp, ...)`.

ref #15101 