### PR TITLE
vim-patch:8.2.3460

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -199,7 +199,7 @@ static void au_cleanup(void)
   }
 
   // Loop over all events.
-  for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+  for (event = (event_T)0; (int)event < NUM_EVENTS;
        event = (event_T)((int)event + 1)) {
     // Loop over all autocommand patterns.
     prev_ap = &(first_autopat[(int)event]);
@@ -266,7 +266,7 @@ void aubuflocal_remove(buf_T *buf)
   }
 
   // invalidate buflocals looping through events
-  for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+  for (event = (event_T)0; (int)event < NUM_EVENTS;
        event = (event_T)((int)event + 1)) {
     // loop over all autocommand patterns
     for (ap = first_autopat[(int)event]; ap != NULL; ap = ap->next) {
@@ -321,7 +321,7 @@ static void au_del_group(char_u *name)
     AutoPat *ap;
     int in_use = false;
 
-    for (event = (event_T)0; (int)event < (int)NUM_EVENTS;
+    for (event = (event_T)0; (int)event < NUM_EVENTS;
          event = (event_T)((int)event + 1)) {
       for (ap = first_autopat[(int)event]; ap != NULL; ap = ap->next) {
         if (ap->group == i && ap->pat != NULL) {
@@ -475,7 +475,7 @@ static char_u *find_end_event(char_u *arg, int have_group)
     pat = arg + 1;
   } else {
     for (pat = arg; *pat && *pat != '|' && !ascii_iswhite(*pat); pat = p) {
-      if ((int)event_name2nr(pat, &p) >= (int)NUM_EVENTS) {
+      if ((int)event_name2nr(pat, &p) >= NUM_EVENTS) {
         if (have_group) {
           EMSG2(_("E216: No such event: %s"), pat);
         } else {
@@ -701,7 +701,7 @@ void do_autocmd(char_u *arg_in, int forceit)
     if (!forceit && *cmd != NUL) {
       EMSG(_(e_cannot_define_autocommands_for_all_events));
     } else {
-      for (event_T event = (event_T)0; event < (int)NUM_EVENTS;
+      for (event_T event = (event_T)0; event < NUM_EVENTS;
            event = (event_T)(event + 1)) {
         if (do_autocmd_event(event, pat, once, nested, cmd, forceit, group)
             == FAIL) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -117,7 +117,7 @@ static int read_buffer(int read_stdin, exarg_T *eap, int flags)
   line_count = curbuf->b_ml.ml_line_count;
   retval = readfile(read_stdin ? NULL : curbuf->b_ffname,
                     read_stdin ? NULL : curbuf->b_fname,
-                    (linenr_T)line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
+                    line_count, (linenr_T)0, (linenr_T)MAXLNUM, eap,
                     flags | READ_BUFFER);
   if (retval == OK) {
     // Delete the binary lines.

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -398,7 +398,7 @@ void dbg_check_breakpoint(exarg_T *eap)
       // replace K_SNR with "<SNR>"
       if (debug_breakpoint_name[0] == K_SPECIAL
           && debug_breakpoint_name[1] == KS_EXTRA
-          && debug_breakpoint_name[2] == (int)KE_SNR) {
+          && debug_breakpoint_name[2] == KE_SNR) {
         p = (char_u *)"<SNR>";
       } else {
         p = (char_u *)"";

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1570,7 +1570,7 @@ int vgetc(void)
             // a CSI (0x9B),
             // of a K_SPECIAL - KS_EXTRA - KE_CSI, which is CSI too.
             c = vgetorpeek(true);
-            if (vgetorpeek(true) == (int)KE_CSI && c == KS_EXTRA) {
+            if (vgetorpeek(true) == KE_CSI && c == KS_EXTRA) {
               buf[i] = CSI;
             }
           }
@@ -1946,7 +1946,7 @@ static int vgetorpeek(bool advance)
                       && (mp->m_keys[0] != K_SPECIAL
                           || mp->m_keys[1] != KS_EXTRA
                           || mp->m_keys[2]
-                          != (int)KE_SNR)) {
+                          != KE_SNR)) {
                     continue;
                   }
                   /*
@@ -2228,7 +2228,7 @@ static int vgetorpeek(bool advance)
                   if (!ascii_iswhite(ptr[col])) {
                     curwin->w_wcol = vcol;
                   }
-                  vcol += lbr_chartabsize(ptr, ptr + col, (colnr_T)vcol);
+                  vcol += lbr_chartabsize(ptr, ptr + col, vcol);
                   col += utfc_ptr2len(ptr + col);
                 }
                 curwin->w_wrow = curwin->w_cline_row

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -643,12 +643,8 @@ void ex_hardcopy(exarg_T *eap)
    * PS.)
    */
   if (mch_print_init(&settings,
-                     curbuf->b_fname == NULL
-          ? (char_u *)buf_spname(curbuf)
-          : curbuf->b_sfname == NULL
-          ? curbuf->b_fname
-          : curbuf->b_sfname,
-                     eap->forceit) == FAIL) {
+                     curbuf->b_fname == NULL ? buf_spname(curbuf) : curbuf->b_sfname ==
+                     NULL ? curbuf->b_fname : curbuf->b_sfname, eap->forceit) == FAIL) {
     return;
   }
 

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -1089,8 +1089,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
     size_t matched = 0;
 
     // read output
-    cs_fill_results((char *)pat, totmatches, nummatches, &matches,
-                    &contexts, &matched);
+    cs_fill_results(pat, totmatches, nummatches, &matches, &contexts, &matched);
     xfree(nummatches);
     if (matches == NULL) {
       return FALSE;
@@ -1475,13 +1474,14 @@ retry:
    *
    *    <filename> <context> <line number> <pattern>
    */
-  if ((name = strtok((char *)buf, (const char *)" ")) == NULL) {
+  char *saveptr = NULL;
+  if ((name = os_strtok(buf, (const char *)" ", &saveptr)) == NULL) {
     return NULL;
   }
-  if ((*context = strtok(NULL, (const char *)" ")) == NULL) {
+  if ((*context = os_strtok(NULL, (const char *)" ", &saveptr)) == NULL) {
     return NULL;
   }
-  if ((*linenumber = strtok(NULL, (const char *)" ")) == NULL) {
+  if ((*linenumber = os_strtok(NULL, (const char *)" ", &saveptr)) == NULL) {
     return NULL;
   }
   *search = *linenumber + strlen(*linenumber) + 1;      // +1 to skip \0

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -794,7 +794,7 @@ void curs_columns(win_T *wp, int may_scroll)
       // column
       char_u *const sbr = get_showbreak_value(wp);
       if (*sbr && *get_cursor_pos_ptr() == NUL
-          && wp->w_wcol == (int)vim_strsize(sbr)) {
+          && wp->w_wcol == vim_strsize(sbr)) {
         wp->w_wcol = 0;
       }
     }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2245,7 +2245,7 @@ findtag_end:
             }
           }
         }
-        matches[match_count++] = (char_u *)mfp;
+        matches[match_count++] = mfp;
       }
     }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2019,7 +2019,7 @@ void ex_version(exarg_T *eap)
 /// @param wrap
 static void version_msg_wrap(char_u *s, int wrap)
 {
-  int len = (int)vim_strsize(s) + (wrap ? 2 : 0);
+  int len = vim_strsize(s) + (wrap ? 2 : 0);
 
   if (!got_int
       && (len < Columns)
@@ -2070,7 +2070,7 @@ void list_in_columns(char_u **items, int size, int current)
   // Find the length of the longest item, use that + 1 as the column width.
   int i;
   for (i = 0; size < 0 ? items[i] != NULL : i < size; i++) {
-    int l = (int)vim_strsize(items[i]) + (i == current ? 2 : 0);
+    int l = vim_strsize(items[i]) + (i == current ? 2 : 0);
 
     if (l > width) {
       width = l;


### PR DESCRIPTION
#### vim-patch:8.2.3460: some type casts are not needed

Problem:    Some type casts are not needed.
Solution:   Remove unnecessary type casts. (closes vim/vim#8934)
https://github.com/vim/vim/commit/dfa5e464d459f84200a73d178f1ecefe75bbe511