### PR TITLE
refactor(lint): apply clang-tidy fixes (2)

### DIFF
--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -415,9 +415,9 @@ static inline int parse_json_string(const char *const buf, const size_t buf_len,
   bool hasnul = false;
 #define PUT_FST_IN_PAIR(fst_in_pair, str_end) \
   do { \
-    if (fst_in_pair != 0) { \
-      str_end += utf_char2bytes(fst_in_pair, (char_u *)str_end); \
-      fst_in_pair = 0; \
+    if ((fst_in_pair) != 0) { \
+      (str_end) += utf_char2bytes(fst_in_pair, (char_u *)(str_end)); \
+      (fst_in_pair) = 0; \
     } \
   } while (0)
   for (const char *t = s; t < p; t++) {
@@ -461,7 +461,7 @@ static inline int parse_json_string(const char *const buf, const size_t buf_len,
       case 'n':
       case 'r':
       case 'f': {
-        static const char escapes[] = {
+        static const char kEscapes[] = {
           ['\\'] = '\\',
           ['/'] = '/',
           ['"'] = '"',
@@ -471,7 +471,7 @@ static inline int parse_json_string(const char *const buf, const size_t buf_len,
           ['r'] = CAR,
           ['f'] = FF,
         };
-        *str_end++ = escapes[(int)*t];
+        *str_end++ = kEscapes[(int)*t];
         break;
       }
       default:

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -471,7 +471,7 @@ static inline int parse_json_string(const char *const buf, const size_t buf_len,
           ['r'] = CAR,
           ['f'] = FF,
         };
-        *str_end++ = kEscapes[(int)*t];
+        *str_end++ = kEscapes[(int)(*t)];
         break;
       }
       default:

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -298,8 +298,8 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
 
 #define TYPVAL_ENCODE_CONV_STRING(tv, buf, len) \
   do { \
-    const char *const buf_ = (const char *)buf; \
-    if (buf == NULL) { \
+    const char *const buf_ = (const char *)(buf); \
+    if ((buf) == NULL) { \
       ga_concat(gap, "''"); \
     } else { \
       const size_t len_ = (len); \
@@ -388,14 +388,14 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
 
 #define TYPVAL_ENCODE_CONV_FUNC_BEFORE_ARGS(tv, len) \
   do { \
-    if (len != 0) { \
+    if ((len) != 0) { \
       ga_concat(gap, ", "); \
     } \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_FUNC_BEFORE_SELF(tv, len) \
   do { \
-    if ((ptrdiff_t)len != -1) { \
+    if ((ptrdiff_t)(len) != -1) { \
       ga_concat(gap, ", "); \
     } \
   } while (0)
@@ -457,12 +457,12 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
     size_t backref = 0; \
     for (; backref < kv_size(*mpstack); backref++) { \
       const MPConvStackVal mpval = kv_A(*mpstack, backref); \
-      if (mpval.type == conv_type) { \
-        if (conv_type == kMPConvDict) { \
+      if (mpval.type == (conv_type)) { \
+        if ((conv_type) == kMPConvDict) { \
           if ((void *)mpval.data.d.dict == (void *)(val)) { \
             break; \
           } \
-        } else if (conv_type == kMPConvList) { \
+        } else if ((conv_type) == kMPConvList) { \
           if ((void *)mpval.data.l.list == (void *)(val)) { \
             break; \
           } \
@@ -492,19 +492,19 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
     size_t backref = 0; \
     for (; backref < kv_size(*mpstack); backref++) { \
       const MPConvStackVal mpval = kv_A(*mpstack, backref); \
-      if (mpval.type == conv_type) { \
-        if (conv_type == kMPConvDict) { \
-          if ((void *)mpval.data.d.dict == (void *)val) { \
+      if (mpval.type == (conv_type)) { \
+        if ((conv_type) == kMPConvDict) { \
+          if ((void *)mpval.data.d.dict == (void *)(val)) { \
             break; \
           } \
-        } else if (conv_type == kMPConvList) { \
-          if ((void *)mpval.data.l.list == (void *)val) { \
+        } else if ((conv_type) == kMPConvList) { \
+          if ((void *)mpval.data.l.list == (void *)(val)) { \
             break; \
           } \
         } \
       } \
     } \
-    if (conv_type == kMPConvDict) { \
+    if ((conv_type) == kMPConvDict) { \
       vim_snprintf(ebuf, ARRAY_SIZE(ebuf), "{...@%zu}", backref); \
     } else { \
       vim_snprintf(ebuf, ARRAY_SIZE(ebuf), "[...@%zu]", backref); \
@@ -577,7 +577,7 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
   } while (0)
 
 /// Escape sequences used in JSON
-static const char escapes[][3] = {
+static const char kEscapes[][3] = {
   [BS] = "\\b",
   [TAB] = "\\t",
   [NL] = "\\n",
@@ -587,7 +587,7 @@ static const char escapes[][3] = {
   [FF] = "\\f",
 };
 
-static const char xdigits[] = "0123456789ABCDEF";
+static const char kXdigits[] = "0123456789ABCDEF";
 
 /// Convert given string to JSON string
 ///
@@ -614,7 +614,7 @@ static inline int convert_to_json_string(garray_T *const gap, const char *const 
     // This is done to make resulting values displayable on screen also not from
     // Neovim.
 #define ENCODE_RAW(ch) \
-  (ch >= 0x20 && utf_printable(ch))
+  ((ch) >= 0x20 && utf_printable(ch))
     for (size_t i = 0; i < utf_len;) {
       const int ch = utf_ptr2char(utf_buf + i);
       const size_t shift = (ch == 0? 1: utf_ptr2len(utf_buf + i));
@@ -669,7 +669,7 @@ static inline int convert_to_json_string(garray_T *const gap, const char *const 
       case CAR:
       case '"':
       case '\\':
-        ga_concat_len(gap, escapes[ch], 2);
+        ga_concat_len(gap, kEscapes[ch], 2);
         break;
       default:
         if (ENCODE_RAW(ch)) {
@@ -677,10 +677,10 @@ static inline int convert_to_json_string(garray_T *const gap, const char *const 
         } else if (ch < SURROGATE_FIRST_CHAR) {
           ga_concat_len(gap, ((const char[]) {
             '\\', 'u',
-            xdigits[(ch >> (4 * 3)) & 0xF],
-            xdigits[(ch >> (4 * 2)) & 0xF],
-            xdigits[(ch >> (4 * 1)) & 0xF],
-            xdigits[(ch >> (4 * 0)) & 0xF],
+            kXdigits[(ch >> (4 * 3)) & 0xF],
+            kXdigits[(ch >> (4 * 2)) & 0xF],
+            kXdigits[(ch >> (4 * 1)) & 0xF],
+            kXdigits[(ch >> (4 * 0)) & 0xF],
           }), sizeof("\\u1234") - 1);
         } else {
           const int tmp = ch - SURROGATE_FIRST_CHAR;
@@ -688,15 +688,15 @@ static inline int convert_to_json_string(garray_T *const gap, const char *const 
           const int lo = SURROGATE_LO_END + ((tmp >>  0) & ((1 << 10) - 1));
           ga_concat_len(gap, ((const char[]) {
             '\\', 'u',
-            xdigits[(hi >> (4 * 3)) & 0xF],
-            xdigits[(hi >> (4 * 2)) & 0xF],
-            xdigits[(hi >> (4 * 1)) & 0xF],
-            xdigits[(hi >> (4 * 0)) & 0xF],
+            kXdigits[(hi >> (4 * 3)) & 0xF],
+            kXdigits[(hi >> (4 * 2)) & 0xF],
+            kXdigits[(hi >> (4 * 1)) & 0xF],
+            kXdigits[(hi >> (4 * 0)) & 0xF],
             '\\', 'u',
-            xdigits[(lo >> (4 * 3)) & 0xF],
-            xdigits[(lo >> (4 * 2)) & 0xF],
-            xdigits[(lo >> (4 * 1)) & 0xF],
-            xdigits[(lo >> (4 * 0)) & 0xF],
+            kXdigits[(lo >> (4 * 3)) & 0xF],
+            kXdigits[(lo >> (4 * 2)) & 0xF],
+            kXdigits[(lo >> (4 * 1)) & 0xF],
+            kXdigits[(lo >> (4 * 0)) & 0xF],
           }), (sizeof("\\u1234") - 1) * 2);
         }
         break;
@@ -793,7 +793,7 @@ bool encode_check_json_key(const typval_T *const tv)
 #undef TYPVAL_ENCODE_SPECIAL_DICT_KEY_CHECK
 #define TYPVAL_ENCODE_SPECIAL_DICT_KEY_CHECK(label, key) \
   do { \
-    if (!encode_check_json_key(&key)) { \
+    if (!encode_check_json_key(&(key))) { \
       EMSG(_("E474: Invalid key in special dictionary")); \
       goto label; \
     } \
@@ -916,7 +916,7 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_STRING(tv, buf, len) \
   do { \
-    if (buf == NULL) { \
+    if ((buf) == NULL) { \
       msgpack_pack_bin(packer, 0); \
     } else { \
       const size_t len_ = (len); \
@@ -927,7 +927,7 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_STR_STRING(tv, buf, len) \
   do { \
-    if (buf == NULL) { \
+    if ((buf) == NULL) { \
       msgpack_pack_str(packer, 0); \
     } else { \
       const size_t len_ = (len); \
@@ -938,11 +938,11 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_EXT_STRING(tv, buf, len, type) \
   do { \
-    if (buf == NULL) { \
-      msgpack_pack_ext(packer, 0, (int8_t)type); \
+    if ((buf) == NULL) { \
+      msgpack_pack_ext(packer, 0, (int8_t)(type)); \
     } else { \
       const size_t len_ = (len); \
-      msgpack_pack_ext(packer, len_, (int8_t)type); \
+      msgpack_pack_ext(packer, len_, (int8_t)(type)); \
       msgpack_pack_ext_body(packer, buf, len_); \
     } \
   } while (0)

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1516,7 +1516,8 @@ static void f_ctxsize(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// @returns 0 when the position could be set, -1 otherwise.
 static void f_cursor(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  long line, col;
+  long line;
+  long col;
   long coladd = 0;
   bool set_curswant = true;
 
@@ -1816,7 +1817,7 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   static int fnum = 0;
   static int change_start = 0;
   static int change_end = 0;
-  static hlf_T hlID = (hlf_T)0;
+  static hlf_T hl_id = (hlf_T)0;
   int filler_lines;
   int col;
 
@@ -1833,30 +1834,30 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv, FunPtr fptr)
         change_start = MAXCOL;
         change_end = -1;
         if (diff_find_change(curwin, lnum, &change_start, &change_end)) {
-          hlID = HLF_ADD;               // added line
+          hl_id = HLF_ADD;               // added line
         } else {
-          hlID = HLF_CHD;               // changed line
+          hl_id = HLF_CHD;               // changed line
         }
       } else {
-        hlID = HLF_ADD;         // added line
+        hl_id = HLF_ADD;         // added line
       }
     } else {
-      hlID = (hlf_T)0;
+      hl_id = (hlf_T)0;
     }
     prev_lnum = lnum;
     changedtick = buf_get_changedtick(curbuf);
     fnum = curbuf->b_fnum;
   }
 
-  if (hlID == HLF_CHD || hlID == HLF_TXD) {
+  if (hl_id == HLF_CHD || hl_id == HLF_TXD) {
     col = tv_get_number(&argvars[1]) - 1;  // Ignore type error in {col}.
     if (col >= change_start && col <= change_end) {
-      hlID = HLF_TXD;  // Changed text.
+      hl_id = HLF_TXD;  // Changed text.
     } else {
-      hlID = HLF_CHD;  // Changed line.
+      hl_id = HLF_CHD;  // Changed line.
     }
   }
-  rettv->vval.v_number = hlID == (hlf_T)0 ? 0 : (int)(hlID + 1);
+  rettv->vval.v_number = hl_id == (hlf_T)0 ? 0 : (int)(hl_id + 1);
 }
 
 /*
@@ -4206,7 +4207,8 @@ static void f_win_splitmove(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   win_T *wp;
   win_T *targetwin;
-  int flags = 0, size = 0;
+  int flags = 0;
+  int size = 0;
 
   wp = find_win_by_nr_or_id(&argvars[0]);
   targetwin = find_win_by_nr_or_id(&argvars[1]);
@@ -4386,7 +4388,7 @@ static void f_glob2regpat(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "has()" function
 static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  static const char *const has_list[] = {
+  static const char *const kHasList[] = {
 #if defined(BSD) && !defined(__APPLE__)
     "bsd",
 #endif
@@ -4514,8 +4516,8 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   bool n = false;
   const char *const name = tv_get_string(&argvars[0]);
-  for (size_t i = 0; i < ARRAY_SIZE(has_list); i++) {
-    if (STRICMP(name, has_list[i]) == 0) {
+  for (size_t i = 0; i < ARRAY_SIZE(kHasList); i++) {
+    if (STRICMP(name, kHasList[i]) == 0) {
       n = true;
       break;
     }
@@ -5414,8 +5416,8 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   bool clear_env = false;
   bool overlapped = false;
   ChannelStdinMode stdin_mode = kChannelStdinPipe;
-  CallbackReader on_stdout = CALLBACK_READER_INIT,
-                 on_stderr = CALLBACK_READER_INIT;
+  CallbackReader on_stdout = CALLBACK_READER_INIT;
+  CallbackReader on_stderr = CALLBACK_READER_INIT;
   Callback on_exit = CALLBACK_NONE;
   char *cwd = NULL;
   dictitem_T *job_env = NULL;
@@ -5478,7 +5480,8 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
   }
 
-  uint16_t width = 0, height = 0;
+  uint16_t width = 0;
+  uint16_t height = 0;
   char *term_name = NULL;
 
   if (pty) {
@@ -7435,7 +7438,8 @@ static void f_reltimestr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 static void f_remove(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   list_T *l;
-  listitem_T *item, *item2;
+  listitem_T *item;
+  listitem_T *item2;
   listitem_T *li;
   long idx;
   long end;
@@ -8049,7 +8053,9 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   sctx_T save_current_sctx;
-  uint8_t *save_sourcing_name, *save_autocmd_fname, *save_autocmd_match;
+  uint8_t *save_sourcing_name;
+  uint8_t *save_autocmd_fname;
+  uint8_t *save_autocmd_match;
   linenr_T save_sourcing_lnum;
   int save_autocmd_bufnr;
   funccal_entry_T funccal_entry;
@@ -8290,7 +8296,9 @@ static void f_screenpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   pos_T pos;
   int row = 0;
-  int scol = 0, ccol = 0, ecol = 0;
+  int scol = 0;
+  int ccol = 0;
+  int ecol = 0;
 
   tv_dict_alloc_ret(rettv);
   dict_T *dict = rettv->vval.v_dict;
@@ -8490,7 +8498,9 @@ long do_searchpair(const char *spat,      // start pattern
   FUNC_ATTR_NONNULL_ARG(1, 2, 3)
 {
   char_u *save_cpo;
-  char_u *pat, *pat2 = NULL, *pat3 = NULL;
+  char_u *pat;
+  char_u *pat2 = NULL;
+  char_u *pat3 = NULL;
   long retval = 0;
   pos_T pos;
   pos_T firstpos;
@@ -9884,7 +9894,8 @@ static int item_compare(const void *s1, const void *s2, bool keep_zero)
       res = sortinfo->item_compare_ic ? STRICMP(p1, p2): STRCMP(p1, p2);
     }
   } else {
-    double n1, n2;
+    double n1;
+    double n2;
     n1 = strtod(p1, &p1);
     n2 = strtod(p2, &p2);
     res = n1 == n2 ? 0 : n1 > n2 ? 1 : -1;
@@ -9916,7 +9927,8 @@ static int item_compare_not_keeping_zero(const void *s1, const void *s2)
 
 static int item_compare2(const void *s1, const void *s2, bool keep_zero)
 {
-  ListSortItem *si1, *si2;
+  ListSortItem *si1;
+  ListSortItem *si2;
   int res;
   typval_T rettv;
   typval_T argv[3];
@@ -10872,16 +10884,16 @@ static void f_submatch(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     emsgf(_("E935: invalid submatch number: %d"), no);
     return;
   }
-  int retList = 0;
+  int ret_list = 0;
 
   if (argvars[1].v_type != VAR_UNKNOWN) {
-    retList = tv_get_number_chk(&argvars[1], &error);
+    ret_list = tv_get_number_chk(&argvars[1], &error);
     if (error) {
       return;
     }
   }
 
-  if (retList == 0) {
+  if (ret_list == 0) {
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = reg_submatch(no);
   } else {
@@ -11341,8 +11353,8 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  CallbackReader on_stdout = CALLBACK_READER_INIT,
-                 on_stderr = CALLBACK_READER_INIT;
+  CallbackReader on_stdout = CALLBACK_READER_INIT;
+  CallbackReader on_stderr = CALLBACK_READER_INIT;
   Callback on_exit = CALLBACK_NONE;
   dict_T *job_opts = NULL;
   const char *cwd = ".";
@@ -11635,7 +11647,6 @@ static void f_tr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 error:
   EMSG2(_(e_invarg2), fromstr);
   ga_clear(&ga);
-  return;
 }
 
 // "trim({expr})" function

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2427,7 +2427,8 @@ static inline int _nothing_conv_real_dict_after_start(typval_T *const tv, dict_T
 
 #define TYPVAL_ENCODE_CONV_REAL_DICT_AFTER_START(tv, dict, mpsv) \
   do { \
-    if (_nothing_conv_real_dict_after_start(tv, (dict_T **)&(dict), (void *)&TYPVAL_ENCODE_NODICT_VAR, \
+    if (_nothing_conv_real_dict_after_start(tv, (dict_T **)&(dict), \
+                                            (void *)&TYPVAL_ENCODE_NODICT_VAR, \
                                             &(mpsv)) != NOTDONE) { \
       goto typval_encode_stop_converting_one_item; \
     } \

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -880,8 +880,8 @@ void tv_list_reverse(list_T *const l)
 #define SWAP(a, b) \
   do { \
     tmp = a; \
-    a = b; \
-    b = tmp; \
+    (a) = b; \
+    (b) = tmp; \
   } while (0)
   listitem_T *tmp;
 
@@ -2252,36 +2252,36 @@ void tv_blob_copy(typval_T *const from, typval_T *const to)
 
 #define TYPVAL_ENCODE_CONV_NIL(tv) \
   do { \
-    tv->vval.v_special = kSpecialVarNull; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_special = kSpecialVarNull; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_BOOL(tv, num) \
   do { \
-    tv->vval.v_bool = kBoolVarFalse; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_bool = kBoolVarFalse; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_NUMBER(tv, num) \
   do { \
-    (void)num; \
-    tv->vval.v_number = 0; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (void)(num); \
+    (tv)->vval.v_number = 0; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_UNSIGNED_NUMBER(tv, num)
 
 #define TYPVAL_ENCODE_CONV_FLOAT(tv, flt) \
   do { \
-    tv->vval.v_float = 0; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_float = 0; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_STRING(tv, buf, len) \
   do { \
     xfree(buf); \
-    tv->vval.v_string = NULL; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_string = NULL; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_STR_STRING(tv, buf, len)
@@ -2290,9 +2290,9 @@ void tv_blob_copy(typval_T *const from, typval_T *const to)
 
 #define TYPVAL_ENCODE_CONV_BLOB(tv, blob, len) \
   do { \
-    tv_blob_unref(tv->vval.v_blob); \
-    tv->vval.v_blob = NULL; \
-    tv->v_lock = VAR_UNLOCKED; \
+    tv_blob_unref((tv)->vval.v_blob); \
+    (tv)->vval.v_blob = NULL; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 static inline int _nothing_conv_func_start(typval_T *const tv, char_u *const fun)
@@ -2300,9 +2300,9 @@ static inline int _nothing_conv_func_start(typval_T *const tv, char_u *const fun
 {
   tv->v_lock = VAR_UNLOCKED;
   if (tv->v_type == VAR_PARTIAL) {
-    partial_T *const pt_ = tv->vval.v_partial;
-    if (pt_ != NULL && pt_->pt_refcount > 1) {
-      pt_->pt_refcount--;
+    partial_T *const pt = tv->vval.v_partial;
+    if (pt != NULL && pt->pt_refcount > 1) {
+      pt->pt_refcount--;
       tv->vval.v_partial = NULL;
       return OK;
     }
@@ -2349,9 +2349,9 @@ static inline void _nothing_conv_func_end(typval_T *const tv, const int copyID)
 
 #define TYPVAL_ENCODE_CONV_EMPTY_LIST(tv) \
   do { \
-    tv_list_unref(tv->vval.v_list); \
-    tv->vval.v_list = NULL; \
-    tv->v_lock = VAR_UNLOCKED; \
+    tv_list_unref((tv)->vval.v_list); \
+    (tv)->vval.v_list = NULL; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 static inline void _nothing_conv_empty_dict(typval_T *const tv, dict_T **const dictp)
@@ -2365,8 +2365,8 @@ static inline void _nothing_conv_empty_dict(typval_T *const tv, dict_T **const d
 }
 #define TYPVAL_ENCODE_CONV_EMPTY_DICT(tv, dict) \
   do { \
-    assert((void *)&dict != (void *)&TYPVAL_ENCODE_NODICT_VAR); \
-    _nothing_conv_empty_dict(tv, ((dict_T **)&dict)); \
+    assert((void *)&(dict) != (void *)&TYPVAL_ENCODE_NODICT_VAR); \
+    _nothing_conv_empty_dict(tv, ((dict_T **)&(dict))); \
   } while (0)
 
 static inline int _nothing_conv_real_list_after_start(typval_T *const tv,
@@ -2387,7 +2387,7 @@ static inline int _nothing_conv_real_list_after_start(typval_T *const tv,
 
 #define TYPVAL_ENCODE_CONV_REAL_LIST_AFTER_START(tv, mpsv) \
   do { \
-    if (_nothing_conv_real_list_after_start(tv, &mpsv) != NOTDONE) { \
+    if (_nothing_conv_real_list_after_start(tv, &(mpsv)) != NOTDONE) { \
       goto typval_encode_stop_converting_one_item; \
     } \
   } while (0)
@@ -2427,8 +2427,8 @@ static inline int _nothing_conv_real_dict_after_start(typval_T *const tv, dict_T
 
 #define TYPVAL_ENCODE_CONV_REAL_DICT_AFTER_START(tv, dict, mpsv) \
   do { \
-    if (_nothing_conv_real_dict_after_start(tv, (dict_T **)&dict, (void *)&TYPVAL_ENCODE_NODICT_VAR, \
-                                            &mpsv) != NOTDONE) { \
+    if (_nothing_conv_real_dict_after_start(tv, (dict_T **)&(dict), (void *)&TYPVAL_ENCODE_NODICT_VAR, \
+                                            &(mpsv)) != NOTDONE) { \
       goto typval_encode_stop_converting_one_item; \
     } \
   } while (0)
@@ -2447,7 +2447,7 @@ static inline void _nothing_conv_dict_end(typval_T *const tv, dict_T **const dic
   }
 }
 #define TYPVAL_ENCODE_CONV_DICT_END(tv, dict) \
-  _nothing_conv_dict_end(tv, (dict_T **)&dict, \
+  _nothing_conv_dict_end(tv, (dict_T **)&(dict), \
                          (void *)&TYPVAL_ENCODE_NODICT_VAR)
 
 #define TYPVAL_ENCODE_CONV_RECURSE(val, conv_type)
@@ -2631,9 +2631,9 @@ void tv_item_lock(typval_T *const tv, const int deep, const bool lock, const boo
   // lock/unlock the item itself
 #define CHANGE_LOCK(lock, var) \
   do { \
-    var = ((VarLockStatus[]) { \
-      [VAR_UNLOCKED] = (lock ? VAR_LOCKED : VAR_UNLOCKED), \
-      [VAR_LOCKED] = (lock ? VAR_LOCKED : VAR_UNLOCKED), \
+    (var) = ((VarLockStatus[]) { \
+      [VAR_UNLOCKED] = ((lock) ? VAR_LOCKED : VAR_UNLOCKED), \
+      [VAR_LOCKED] = ((lock) ? VAR_LOCKED : VAR_UNLOCKED), \
       [VAR_FIXED] = VAR_FIXED, \
     })[var]; \
   } while (0)
@@ -2927,7 +2927,7 @@ bool tv_check_str_or_nr(const typval_T *const tv)
 
 #define FUNC_ERROR "E703: Using a Funcref as a Number"
 
-static const char *const num_errors[] = {
+static const char *const kNumErrors[] = {
   [VAR_PARTIAL]=N_(FUNC_ERROR),
   [VAR_FUNC]=N_(FUNC_ERROR),
   [VAR_LIST]=N_("E745: Using a List as a Number"),
@@ -2963,7 +2963,7 @@ bool tv_check_num(const typval_T *const tv)
   case VAR_FLOAT:
   case VAR_BLOB:
   case VAR_UNKNOWN:
-    EMSG(_(num_errors[tv->v_type]));
+    EMSG(_(kNumErrors[tv->v_type]));
     return false;
   }
   abort();
@@ -2972,7 +2972,7 @@ bool tv_check_num(const typval_T *const tv)
 
 #define FUNC_ERROR "E729: using Funcref as a String"
 
-static const char *const str_errors[] = {
+static const char *const kStrErrors[] = {
   [VAR_PARTIAL]=N_(FUNC_ERROR),
   [VAR_FUNC]=N_(FUNC_ERROR),
   [VAR_LIST]=N_("E730: using List as a String"),
@@ -3008,7 +3008,7 @@ bool tv_check_str(const typval_T *const tv)
   case VAR_FLOAT:
   case VAR_BLOB:
   case VAR_UNKNOWN:
-    EMSG(_(str_errors[tv->v_type]));
+    EMSG(_(kStrErrors[tv->v_type]));
     return false;
   }
   abort();
@@ -3055,7 +3055,7 @@ varnumber_T tv_get_number_chk(const typval_T *const tv, bool *const ret_error)
   case VAR_DICT:
   case VAR_BLOB:
   case VAR_FLOAT:
-    EMSG(_(num_errors[tv->v_type]));
+    EMSG(_(kNumErrors[tv->v_type]));
     break;
   case VAR_NUMBER:
     return tv->vval.v_number;
@@ -3195,7 +3195,7 @@ const char *tv_get_string_buf_chk(const typval_T *const tv, char *const buf)
   case VAR_FLOAT:
   case VAR_BLOB:
   case VAR_UNKNOWN:
-    EMSG(_(str_errors[tv->v_type]));
+    EMSG(_(kStrErrors[tv->v_type]));
     return false;
   }
   return NULL;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -224,7 +224,8 @@ int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
   int varargs;
   int ret;
   char_u *start = skipwhite(*arg + 1);
-  char_u *s, *e;
+  char_u *s;
+  char_u *e;
   bool *old_eval_lavars = eval_lavars_used;
   bool eval_lavars = false;
 
@@ -266,7 +267,8 @@ int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
   (*arg)++;
 
   if (evaluate) {
-    int len, flags = 0;
+    int len;
+    int flags = 0;
     char_u *p;
     garray_T newlines;
 
@@ -2497,7 +2499,8 @@ void ex_function(exarg_T *eap)
 
   if (fp == NULL) {
     if (fudi.fd_dict == NULL && vim_strchr(name, AUTOLOAD_CHAR) != NULL) {
-      int slen, plen;
+      int slen;
+      int plen;
       char_u *scriptname;
 
       // Check that the autoload name matches the script name.


### PR DESCRIPTION
List of most notable fixes:
  - enclose macro arguments in parentheses (bugprone)
  - naming conventions
  - variable declaration
