### PR TITLE
refactor(lint): apply clang-tidy fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ TabWidth: 2
 UseTab: Never
 IndentCaseLabels: true
 BreakBeforeBraces: Linux
-AlignEscapedNewlinesLeft: false
+AlignEscapedNewlines: DontAlign
 AllowShortFunctionsOnASingleLine: false
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 2
@@ -17,4 +17,5 @@ AllowShortLoopsOnASingleLine: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: true
 BreakBeforeTernaryOperators: true
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 2
+

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -415,9 +415,9 @@ static inline int parse_json_string(const char *const buf, const size_t buf_len,
   bool hasnul = false;
 #define PUT_FST_IN_PAIR(fst_in_pair, str_end) \
   do { \
-    if (fst_in_pair != 0) { \
-      str_end += utf_char2bytes(fst_in_pair, (char_u *)str_end); \
-      fst_in_pair = 0; \
+    if ((fst_in_pair) != 0) { \
+      (str_end) += utf_char2bytes(fst_in_pair, (char_u *)(str_end)); \
+      (fst_in_pair) = 0; \
     } \
   } while (0)
   for (const char *t = s; t < p; t++) {

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -294,8 +294,8 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
 
 #define TYPVAL_ENCODE_CONV_STRING(tv, buf, len) \
   do { \
-    const char *const buf_ = (const char *)buf; \
-    if (buf == NULL) { \
+    const char *const buf_ = (const char *)(buf); \
+    if ((buf) == NULL) { \
       ga_concat(gap, "''"); \
     } else { \
       const size_t len_ = (len); \
@@ -384,14 +384,14 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
 
 #define TYPVAL_ENCODE_CONV_FUNC_BEFORE_ARGS(tv, len) \
   do { \
-    if (len != 0) { \
+    if ((len) != 0) { \
       ga_concat(gap, ", "); \
     } \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_FUNC_BEFORE_SELF(tv, len) \
   do { \
-    if ((ptrdiff_t)len != -1) { \
+    if ((ptrdiff_t)(len) != -1) { \
       ga_concat(gap, ", "); \
     } \
   } while (0)
@@ -453,12 +453,12 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
     size_t backref = 0; \
     for (; backref < kv_size(*mpstack); backref++) { \
       const MPConvStackVal mpval = kv_A(*mpstack, backref); \
-      if (mpval.type == conv_type) { \
-        if (conv_type == kMPConvDict) { \
+      if (mpval.type == (conv_type)) { \
+        if ((conv_type) == kMPConvDict) { \
           if ((void *)mpval.data.d.dict == (void *)(val)) { \
             break; \
           } \
-        } else if (conv_type == kMPConvList) { \
+        } else if ((conv_type) == kMPConvList) { \
           if ((void *)mpval.data.l.list == (void *)(val)) { \
             break; \
           } \
@@ -488,19 +488,19 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
     size_t backref = 0; \
     for (; backref < kv_size(*mpstack); backref++) { \
       const MPConvStackVal mpval = kv_A(*mpstack, backref); \
-      if (mpval.type == conv_type) { \
-        if (conv_type == kMPConvDict) { \
-          if ((void *)mpval.data.d.dict == (void *)val) { \
+      if (mpval.type == (conv_type)) { \
+        if ((conv_type) == kMPConvDict) { \
+          if ((void *)mpval.data.d.dict == (void *)(val)) { \
             break; \
           } \
-        } else if (conv_type == kMPConvList) { \
-          if ((void *)mpval.data.l.list == (void *)val) { \
+        } else if ((conv_type) == kMPConvList) { \
+          if ((void *)mpval.data.l.list == (void *)(val)) { \
             break; \
           } \
         } \
       } \
     } \
-    if (conv_type == kMPConvDict) { \
+    if ((conv_type) == kMPConvDict) { \
       vim_snprintf(ebuf, ARRAY_SIZE(ebuf), "{...@%zu}", backref); \
     } else { \
       vim_snprintf(ebuf, ARRAY_SIZE(ebuf), "[...@%zu]", backref); \
@@ -610,7 +610,7 @@ static inline int convert_to_json_string(garray_T *const gap, const char *const 
     // This is done to make resulting values displayable on screen also not from
     // Neovim.
 #define ENCODE_RAW(ch) \
-  (ch >= 0x20 && utf_printable(ch))
+  ((ch) >= 0x20 && utf_printable(ch))
     for (size_t i = 0; i < utf_len;) {
       const int ch = utf_ptr2char((char_u *)utf_buf + i);
       const size_t shift = (ch == 0 ? 1 : ((size_t)utf_ptr2len((char_u *)utf_buf + i)));
@@ -789,7 +789,7 @@ bool encode_check_json_key(const typval_T *const tv)
 #undef TYPVAL_ENCODE_SPECIAL_DICT_KEY_CHECK
 #define TYPVAL_ENCODE_SPECIAL_DICT_KEY_CHECK(label, key) \
   do { \
-    if (!encode_check_json_key(&key)) { \
+    if (!encode_check_json_key(&(key))) { \
       emsg(_("E474: Invalid key in special dictionary")); \
       goto label; \
     } \
@@ -912,7 +912,7 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_STRING(tv, buf, len) \
   do { \
-    if (buf == NULL) { \
+    if ((buf) == NULL) { \
       msgpack_pack_bin(packer, 0); \
     } else { \
       const size_t len_ = (len); \
@@ -923,7 +923,7 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_STR_STRING(tv, buf, len) \
   do { \
-    if (buf == NULL) { \
+    if ((buf) == NULL) { \
       msgpack_pack_str(packer, 0); \
     } else { \
       const size_t len_ = (len); \
@@ -934,11 +934,11 @@ char *encode_tv2json(typval_T *tv, size_t *len)
 
 #define TYPVAL_ENCODE_CONV_EXT_STRING(tv, buf, len, type) \
   do { \
-    if (buf == NULL) { \
-      msgpack_pack_ext(packer, 0, (int8_t)type); \
+    if ((buf) == NULL) { \
+      msgpack_pack_ext(packer, 0, (int8_t)(type)); \
     } else { \
       const size_t len_ = (len); \
-      msgpack_pack_ext(packer, len_, (int8_t)type); \
+      msgpack_pack_ext(packer, len_, (int8_t)(type)); \
       msgpack_pack_ext_body(packer, buf, len_); \
     } \
   } while (0)

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4250,7 +4250,8 @@ static void f_win_splitmove(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   win_T *wp;
   win_T *targetwin;
-  int flags = 0, size = 0;
+  int flags = 0;
+  int size = 0;
 
   wp = find_win_by_nr_or_id(&argvars[0]);
   targetwin = find_win_by_nr_or_id(&argvars[1]);
@@ -5471,8 +5472,8 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   bool clear_env = false;
   bool overlapped = false;
   ChannelStdinMode stdin_mode = kChannelStdinPipe;
-  CallbackReader on_stdout = CALLBACK_READER_INIT,
-                 on_stderr = CALLBACK_READER_INIT;
+  CallbackReader on_stdout = CALLBACK_READER_INIT;
+  CallbackReader on_stderr = CALLBACK_READER_INIT;
   Callback on_exit = CALLBACK_NONE;
   char *cwd = NULL;
   dictitem_T *job_env = NULL;
@@ -5535,7 +5536,8 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
   }
 
-  uint16_t width = 0, height = 0;
+  uint16_t width = 0;
+  uint16_t height = 0;
   char *term_name = NULL;
 
   if (pty) {
@@ -8353,7 +8355,9 @@ static void f_screenpos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   pos_T pos;
   int row = 0;
-  int scol = 0, ccol = 0, ecol = 0;
+  int scol = 0;
+  int ccol = 0;
+  int ecol = 0;
 
   tv_dict_alloc_ret(rettv);
   dict_T *dict = rettv->vval.v_dict;
@@ -8555,7 +8559,9 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
   FUNC_ATTR_NONNULL_ARG(1, 2, 3)
 {
   char_u *save_cpo;
-  char_u *pat, *pat2 = NULL, *pat3 = NULL;
+  char_u *pat;
+  char_u *pat2 = NULL;
+  char_u *pat3 = NULL;
   long retval = 0;
   pos_T pos;
   pos_T firstpos;
@@ -11405,8 +11411,8 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  CallbackReader on_stdout = CALLBACK_READER_INIT,
-                 on_stderr = CALLBACK_READER_INIT;
+  CallbackReader on_stdout = CALLBACK_READER_INIT;
+  CallbackReader on_stderr = CALLBACK_READER_INIT;
   Callback on_exit = CALLBACK_NONE;
   dict_T *job_opts = NULL;
   const char *cwd = ".";
@@ -11702,7 +11708,6 @@ static void f_tr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 error:
   semsg(_(e_invarg2), fromstr);
   ga_clear(&ga);
-  return;
 }
 
 // "trim({expr})" function

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -879,8 +879,8 @@ void tv_list_reverse(list_T *const l)
 #define SWAP(a, b) \
   do { \
     tmp = a; \
-    a = b; \
-    b = tmp; \
+    (a) = b; \
+    (b) = tmp; \
   } while (0)
   listitem_T *tmp;
 
@@ -2251,36 +2251,36 @@ void tv_blob_copy(typval_T *const from, typval_T *const to)
 
 #define TYPVAL_ENCODE_CONV_NIL(tv) \
   do { \
-    tv->vval.v_special = kSpecialVarNull; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_special = kSpecialVarNull; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_BOOL(tv, num) \
   do { \
-    tv->vval.v_bool = kBoolVarFalse; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_bool = kBoolVarFalse; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_NUMBER(tv, num) \
   do { \
-    (void)num; \
-    tv->vval.v_number = 0; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (void)(num); \
+    (tv)->vval.v_number = 0; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_UNSIGNED_NUMBER(tv, num)
 
 #define TYPVAL_ENCODE_CONV_FLOAT(tv, flt) \
   do { \
-    tv->vval.v_float = 0; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_float = 0; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_STRING(tv, buf, len) \
   do { \
     xfree(buf); \
-    tv->vval.v_string = NULL; \
-    tv->v_lock = VAR_UNLOCKED; \
+    (tv)->vval.v_string = NULL; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 #define TYPVAL_ENCODE_CONV_STR_STRING(tv, buf, len)
@@ -2289,9 +2289,9 @@ void tv_blob_copy(typval_T *const from, typval_T *const to)
 
 #define TYPVAL_ENCODE_CONV_BLOB(tv, blob, len) \
   do { \
-    tv_blob_unref(tv->vval.v_blob); \
-    tv->vval.v_blob = NULL; \
-    tv->v_lock = VAR_UNLOCKED; \
+    tv_blob_unref((tv)->vval.v_blob); \
+    (tv)->vval.v_blob = NULL; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 static inline int _nothing_conv_func_start(typval_T *const tv, char_u *const fun)
@@ -2348,9 +2348,9 @@ static inline void _nothing_conv_func_end(typval_T *const tv, const int copyID)
 
 #define TYPVAL_ENCODE_CONV_EMPTY_LIST(tv) \
   do { \
-    tv_list_unref(tv->vval.v_list); \
-    tv->vval.v_list = NULL; \
-    tv->v_lock = VAR_UNLOCKED; \
+    tv_list_unref((tv)->vval.v_list); \
+    (tv)->vval.v_list = NULL; \
+    (tv)->v_lock = VAR_UNLOCKED; \
   } while (0)
 
 static inline void _nothing_conv_empty_dict(typval_T *const tv, dict_T **const dictp)
@@ -2364,8 +2364,8 @@ static inline void _nothing_conv_empty_dict(typval_T *const tv, dict_T **const d
 }
 #define TYPVAL_ENCODE_CONV_EMPTY_DICT(tv, dict) \
   do { \
-    assert((void *)&dict != (void *)&TYPVAL_ENCODE_NODICT_VAR); \
-    _nothing_conv_empty_dict(tv, ((dict_T **)&dict)); \
+    assert((void *)&(dict) != (void *)&TYPVAL_ENCODE_NODICT_VAR); \
+    _nothing_conv_empty_dict(tv, ((dict_T **)&(dict))); \
   } while (0)
 
 static inline int _nothing_conv_real_list_after_start(typval_T *const tv,
@@ -2386,7 +2386,7 @@ static inline int _nothing_conv_real_list_after_start(typval_T *const tv,
 
 #define TYPVAL_ENCODE_CONV_REAL_LIST_AFTER_START(tv, mpsv) \
   do { \
-    if (_nothing_conv_real_list_after_start(tv, &mpsv) != NOTDONE) { \
+    if (_nothing_conv_real_list_after_start(tv, &(mpsv)) != NOTDONE) { \
       goto typval_encode_stop_converting_one_item; \
     } \
   } while (0)
@@ -2426,8 +2426,9 @@ static inline int _nothing_conv_real_dict_after_start(typval_T *const tv, dict_T
 
 #define TYPVAL_ENCODE_CONV_REAL_DICT_AFTER_START(tv, dict, mpsv) \
   do { \
-    if (_nothing_conv_real_dict_after_start(tv, (dict_T **)&dict, (void *)&TYPVAL_ENCODE_NODICT_VAR, \
-                                            &mpsv) != NOTDONE) { \
+    if (_nothing_conv_real_dict_after_start(tv, (dict_T **)&(dict), \
+                                            (void *)&TYPVAL_ENCODE_NODICT_VAR, \
+                                            &(mpsv)) != NOTDONE) { \
       goto typval_encode_stop_converting_one_item; \
     } \
   } while (0)
@@ -2446,7 +2447,7 @@ static inline void _nothing_conv_dict_end(typval_T *const tv, dict_T **const dic
   }
 }
 #define TYPVAL_ENCODE_CONV_DICT_END(tv, dict) \
-  _nothing_conv_dict_end(tv, (dict_T **)&dict, \
+  _nothing_conv_dict_end(tv, (dict_T **)&(dict), \
                          (void *)&TYPVAL_ENCODE_NODICT_VAR)
 
 #define TYPVAL_ENCODE_CONV_RECURSE(val, conv_type)
@@ -2630,9 +2631,9 @@ void tv_item_lock(typval_T *const tv, const int deep, const bool lock, const boo
   // lock/unlock the item itself
 #define CHANGE_LOCK(lock, var) \
   do { \
-    var = ((VarLockStatus[]) { \
-      [VAR_UNLOCKED] = (lock ? VAR_LOCKED : VAR_UNLOCKED), \
-      [VAR_LOCKED] = (lock ? VAR_LOCKED : VAR_UNLOCKED), \
+    (var) = ((VarLockStatus[]) { \
+      [VAR_UNLOCKED] = ((lock) ? VAR_LOCKED : VAR_UNLOCKED), \
+      [VAR_LOCKED] = ((lock) ? VAR_LOCKED : VAR_UNLOCKED), \
       [VAR_FIXED] = VAR_FIXED, \
     })[var]; \
   } while (0)

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -265,7 +265,8 @@ int get_lambda_tv(char_u **arg, typval_T *rettv, bool evaluate)
   (*arg)++;
 
   if (evaluate) {
-    int len, flags = 0;
+    int len;
+    int flags = 0;
     char_u *p;
     garray_T newlines;
 

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -549,10 +549,10 @@ static bool typval_conv_special = false;
   do { \
     for (size_t backref = kv_size(*mpstack); backref; backref--) { \
       const MPConvStackVal mpval = kv_A(*mpstack, backref - 1); \
-      if (mpval.type == conv_type) { \
-        if (conv_type == kMPConvDict \
-              ? (void *)mpval.data.d.dict == (void *)(val) \
-              : (void *)mpval.data.l.list == (void *)(val)) { \
+      if (mpval.type == (conv_type)) { \
+        if ((conv_type) == kMPConvDict \
+            ? (void *)mpval.data.d.dict == (void *)(val) \
+            : (void *)mpval.data.l.list == (void *)(val)) { \
           lua_pushvalue(lstate, \
                         -((int)((kv_size(*mpstack) - backref + 1) * 2))); \
           break; \

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -54,11 +54,11 @@ typedef struct {
 #endif
 
 #define PUSH_ALL_TYPVALS(lstate, args, argcount, special) \
-  for (int i = 0; i < argcount; i++) { \
-    if (args[i].v_type == VAR_UNKNOWN) { \
+  for (int i = 0; i < (argcount); i++) { \
+    if ((args)[i].v_type == VAR_UNKNOWN) { \
       lua_pushnil(lstate); \
     } else { \
-      nlua_push_typval(lstate, &args[i], special); \
+      nlua_push_typval(lstate, &(args)[i], special); \
     } \
   }
 
@@ -671,7 +671,7 @@ int nlua_call(lua_State *lstate)
   typval_T vim_args[MAX_FUNC_ARGS + 1];
   int i = 0;  // also used for freeing the variables
   for (; i < nargs; i++) {
-    lua_pushvalue(lstate, (int)i+2);
+    lua_pushvalue(lstate, i+2);
     if (!nlua_pop_typval(lstate, &vim_args[i])) {
       api_set_error(&err, kErrorTypeException,
                     "error converting argument %d", i+1);
@@ -736,7 +736,7 @@ static int nlua_rpc(lua_State *lstate, bool request)
   Array args = ARRAY_DICT_INIT;
 
   for (int i = 0; i < nargs; i++) {
-    lua_pushvalue(lstate, (int)i+3);
+    lua_pushvalue(lstate, i+3);
     ADD(args, nlua_pop_Object(lstate, false, &err));
     if (ERROR_SET(&err)) {
       api_free_array(args);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1123,8 +1123,10 @@ static void tui_grid_scroll(UI *ui, Integer g, Integer startrow,  // -V751
 {
   TUIData *data = ui->data;
   UGrid *grid = &data->grid;
-  int top = (int)startrow, bot = (int)endrow-1;
-  int left = (int)startcol, right = (int)endcol-1;
+  int top = (int)startrow;
+  int bot = (int)endrow-1;
+  int left = (int)startcol;
+  int right = (int)endcol-1;
 
   bool fullwidth = left == 0 && right == ui->width-1;
   data->scroll_region_is_full_screen = fullwidth
@@ -1445,7 +1447,8 @@ static void invalidate(UI *ui, int top, int bot, int left, int right)
 static void tui_guess_size(UI *ui)
 {
   TUIData *data = ui->data;
-  int width = 0, height = 0;
+  int width = 0;
+  int height = 0;
 
   // 1 - look for non-default 'columns' and 'lines' options during startup
   if (data->is_starting && (Columns != DFLT_COLS || Rows != DFLT_ROWS)) {


### PR DESCRIPTION
List of most notable fixes:
  - enclose macro arguments in parentheses (bugprone)
  - variable declaration
