### PR TITLE
vim-patch:8.2.3466: completion submode not indicated for virtual replace

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -6863,29 +6863,31 @@ mode([expr])	Return a string that indicates the current mode.
 		   niR	    Normal using |i_CTRL-O| in |Replace-mode|
 		   niV	    Normal using |i_CTRL-O| in |Virtual-Replace-mode|
 		   v	    Visual by character
+		   vs	    Visual by character using |v_CTRL-O| in Select mode
 		   V	    Visual by line
+		   Vs	    Visual by line using |v_CTRL-O| in Select mode
 		   CTRL-V   Visual blockwise
+		   CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
 		   s	    Select by character
 		   S	    Select by line
 		   CTRL-S   Select blockwise
-		   vs	    Visual by character using |v_CTRL-O| from
-				Select mode
-		   Vs	    Visual by line using |v_CTRL-O| from Select mode
-		   CTRL-Vs  Visual blockwise using |v_CTRL-O| from Select mode
 		   i	    Insert
 		   ic	    Insert mode completion |compl-generic|
 		   ix	    Insert mode |i_CTRL-X| completion
 		   R	    Replace |R|
 		   Rc	    Replace mode completion |compl-generic|
-		   Rv	    Virtual Replace |gR|
 		   Rx	    Replace mode |i_CTRL-X| completion
+		   Rv	    Virtual Replace |gR|
+		   Rvc	    Virtual Replace mode completion |compl-generic|
+		   Rvx	    Virtual Replace mode |i_CTRL-X| completion
 		   c	    Command-line editing
 		   cv	    Vim Ex mode |Q| or |gQ|
 		   r	    Hit-enter prompt
 		   rm	    The -- more -- prompt
-		   r?	    |:confirm| query of some sort
+		   r?	    A |:confirm| query of some sort
 		   !	    Shell or external command is executing
 		   t	    Terminal mode: keys go to the job
+
 		This is useful in the 'statusline' option or when used
 		with |remote_expr()| In most other places it always returns
 		"c" or "n".

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -161,6 +161,11 @@ char *get_mode(void)
     if (State & VREPLACE_FLAG) {
       buf[0] = 'R';
       buf[1] = 'v';
+      if (ins_compl_active()) {
+        buf[2] = 'c';
+      } else if (ctrl_x_mode_not_defined_yet()) {
+        buf[2] = 'x';
+      }
     } else {
       if (State & REPLACE_FLAG) {
         buf[0] = 'R';

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -585,6 +585,8 @@ func Test_mode()
   exe "normal iabc\<C-X>\<C-L>\<F2>\<Esc>u"
   call assert_equal('i-ic', g:current_modes)
 
+  exe "normal R\<F2>\<Esc>"
+  call assert_equal('R-R', g:current_modes)
   " R_CTRL-P: Multiple matches
   exe "normal RBa\<C-P>\<F2>\<Esc>u"
   call assert_equal('R-Rc', g:current_modes)
@@ -618,6 +620,42 @@ func Test_mode()
   " R_CTRL-X CTRL-L: No match
   exe "normal Rabc\<C-X>\<C-L>\<F2>\<Esc>u"
   call assert_equal('R-Rc', g:current_modes)
+
+  exe "normal gR\<F2>\<Esc>"
+  call assert_equal('R-Rv', g:current_modes)
+  " gR_CTRL-P: Multiple matches
+  exe "normal gRBa\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-P: Single match
+  exe "normal gRBro\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X
+  exe "normal gRBa\<C-X>\<F2>\<Esc>u"
+  call assert_equal('R-Rvx', g:current_modes)
+  " gR_CTRL-X CTRL-P: Multiple matches
+  exe "normal gRBa\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X CTRL-P: Single match
+  exe "normal gRBro\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X CTRL-P + CTRL-P: Single match
+  exe "normal gRBro\<C-X>\<C-P>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X CTRL-L: Multiple matches
+  exe "normal gR\<C-X>\<C-L>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X CTRL-L: Single match
+  exe "normal gRBlu\<C-X>\<C-L>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-P: No match
+  exe "normal gRCom\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X CTRL-P: No match
+  exe "normal gRCom\<C-X>\<C-P>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
+  " gR_CTRL-X CTRL-L: No match
+  exe "normal gRabc\<C-X>\<C-L>\<F2>\<Esc>u"
+  call assert_equal('R-Rvc', g:current_modes)
 
   call assert_equal('n', mode(0))
   call assert_equal('n', mode(1))


### PR DESCRIPTION
#### vim-patch:8.2.3466: completion submode not indicated for virtual replace

Problem:    Completion submode not indicated for virtual replace.
Solution:   Add submode to "Rv". (closes vim/vim#8945)
https://github.com/vim/vim/commit/cc8cd4453332276d55b4a1109eace5785a4f319d