### PR TITLE
feat(defaults): redefine default diagnostic highlights

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -97,6 +97,9 @@ nvim_terminal:
 nvim_cmdwin:
 - CmdwinEnter: Limits syntax sync to maxlines=1 in the |cmdwin|.
 
+nvim_diagnostic:
+- ColorScheme: Redefine default diagnostic highlights if a colorscheme clears them.
+
 ==============================================================================
 3. New Features						       *nvim-features*
 

--- a/src/nvim/aucmd.c
+++ b/src/nvim/aucmd.c
@@ -57,6 +57,11 @@ void init_default_autocmds(void)
   do_cmdline_cmd("augroup nvim_cmdwin");
   do_cmdline_cmd("autocmd! CmdwinEnter [:>] syntax sync minlines=1 maxlines=1");
   do_cmdline_cmd("augroup END");
+
+  // redefine default diagnostic highlights if a colorscheme clears them
+  do_cmdline_cmd("augroup nvim_diagnostic");
+  do_cmdline_cmd("autocmd! ColorScheme * source $VIMRUNTIME/plugin/diagnostic.vim");
+  do_cmdline_cmd("augroup END");
 }
 
 static void focusgained_event(void **argv)


### PR DESCRIPTION
If a colorscheme clears default diagnostic highlights with ":hi clear" but does not itself define diagnostic highlight groups, this will ensure they are always defined.

An alternative is to define these groups in `syntax.c`.

Conflicts with #14360.

See also https://github.com/neovim/nvim-lspconfig/issues/516