### PR TITLE
New users getting stuck in :Tutor Lesson 0

### DIFF
--- a/runtime/tutor/en/vim-01-beginner.tutor
+++ b/runtime/tutor/en/vim-01-beginner.tutor
@@ -18,8 +18,6 @@ won't be saved. Don't worry about messing things up; just remember that
 pressing [<Esc>](<Esc>) and then [u](u) will undo the latest change.
 
 This tutorial is interactive, and there are a few things you should know.
-- Type [<Enter>](<Enter>) on links [like this](holy-grail    ) to open the linked help section.
-- Or simply type [K](K) on any word to find its documentation!
 - Sometimes you will be required to modify text like
 
     this here


### PR DESCRIPTION
Opening this "Issue" as a PR to provide better context.

Lesson 0 suggests opening help links, but it's unclear for new users how to exit these help pages. `:q` is covered later in lesson 1.2. Suggesting that this content be reordered in a more beginner-friendly way.

Also, it's pretty easy for new users to accidentally add or delete a line, which then breaks auto-checking (:heavy_check_mark: / :x: in the sidebar). I think that's more confusing than the original vimtutor behavior. It also seems more difficult for maintainers to keep up with matching these hardcoded line numbers in [tutor.tutor.json](https://github.com/neovim/neovim/blob/master/runtime/tutor/tutor.tutor.json)  (unless these are autogenerated somehow).