### PR TITLE
found a typo in docs/api.txt

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1251,7 +1251,7 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
                 For instance, for a floating display, first create an empty
                 buffer using |nvim_create_buf()|, then display it using
                 |nvim_open_win()|, and then call this function. Then
-                |nvim_chan_send()| cal be called immediately to process
+                |nvim_chan_send()| can be called immediately to process
                 sequences in a virtual terminal having the intended size.
 
                 Parameters: ~

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1221,7 +1221,7 @@ fail:
 /// buffer in a configured window before calling this. For instance, for a
 /// floating display, first create an empty buffer using |nvim_create_buf()|,
 /// then display it using |nvim_open_win()|, and then  call this function.
-/// Then |nvim_chan_send()| cal be called immediately to process sequences
+/// Then |nvim_chan_send()| can be called immediately to process sequences
 /// in a virtual terminal having the intended size.
 ///
 /// @param buffer the buffer to use (expected to be empty)


### PR DESCRIPTION
I think it is supposed to 'can' instead of 'cal'.