### PR TITLE
fix(lsp): default to UTF-16 in make_position_params

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1788,7 +1788,9 @@ local function make_position_param()
   if not line then
     return { line = 0; character = 0; }
   end
-  col = str_utfindex(line, col)
+  -- TODO handle offset_encoding
+  local _
+  _, col = str_utfindex(line, col)
   return { line = row; character = col; }
 end
 


### PR DESCRIPTION
I run
```
:echo luaeval("vim.lsp.util.make_position_params()")
```
on `a𐐀b` with my cursor on `b`, then I got a position which has a character of '2'

I do some search then I found #12221

After reading the doc of `str_utfindex`, I am pretty sure that `make_position_param()` should use the second return value of `str_utfindex()`

Sorry for poor English.