### PR TITLE
vim-patch:8.1.{737,1385},8.2.{155,165,166,167,168,169,170,172,254,326,3387}

### DIFF
--- a/src/nvim/testdir/test_method.vim
+++ b/src/nvim/testdir/test_method.vim
@@ -1,5 +1,7 @@
 " Tests for ->method()
 
+source check.vim
+
 func Test_list_method()
   let l = [1, 2, 3]
   call assert_equal([1, 2, 3, 4], [1, 2, 3]->add(4))
@@ -118,6 +120,7 @@ func Test_method_funcref()
 endfunc
 
 func Test_method_float()
+  CheckFeature float
   eval 1.234->string()->assert_equal('1.234')
   eval -1.234->string()->assert_equal('-1.234')
 endfunc


### PR DESCRIPTION
Mostly N/A patches for `src/vim9*`, `src/testdir/test_vim9*` files and compiler fixes that were already ported because of Neovim's CI.