### PR TITLE
feat(--headless): do not print anything when stdioopen() has been used

### DIFF
--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -96,6 +96,8 @@ struct Channel {
 
 EXTERN PMap(uint64_t) channels INIT(= MAP_INIT);
 
+EXTERN Callback on_print INIT(= CALLBACK_INIT);
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "channel.h.generated.h"
 #endif

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -10213,6 +10213,10 @@ static void f_stdioopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (!tv_dict_get_callback(opts, S_LEN("on_stdin"), &on_stdin.cb)) {
     return;
   }
+  if (!tv_dict_get_callback(opts, S_LEN("on_print"), &on_print)) {
+    return;
+  }
+
   on_stdin.buffered = tv_dict_get_number(opts, "stdin_buffered");
   if (on_stdin.buffered && on_stdin.cb.type == kCallbackNone) {
     on_stdin.self = opts;

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -81,7 +81,8 @@ typedef struct {
   } data;
   CallbackType type;
 } Callback;
-#define CALLBACK_NONE ((Callback){ .type = kCallbackNone })
+#define CALLBACK_INIT { .type = kCallbackNone }
+#define CALLBACK_NONE ((Callback)CALLBACK_INIT)
 
 /// Structure holding dictionary watcher
 typedef struct dict_watcher {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2647,6 +2647,17 @@ static void msg_puts_printf(const char *str, const ptrdiff_t maxlen)
   char buf[7];
   char *p;
 
+  if (on_print.type != kCallbackNone) {
+    typval_T argv[1];
+    argv[0].v_type = VAR_STRING;
+    argv[0].v_lock = VAR_UNLOCKED;
+    argv[0].vval.v_string = (char_u *)str;
+    typval_T rettv = TV_INITIAL_VALUE;
+    callback_call(&on_print, 1, argv, &rettv);
+    tv_clear(&rettv);
+    return;
+  }
+
   while ((maxlen < 0 || s - str < maxlen) && *s != NUL) {
     int len = utf_ptr2len((const char_u *)s);
     if (!(silent_mode && p_verbose == 0)) {


### PR DESCRIPTION
This implements the change discussed in https://github.com/glacambre/firenvim/issues/1196#issuecomment-931384120 . I'm not sure how to write the test for it, I looked at the already-existing tests that used stdioopen() and they didn't really seem to use a pattern that I could re-use.

I also thought it'd be neat to allow specifying an `on_print` callback in stdioopen's arguments, allowing the caller to handle messages that would have been written to stdout had `stdioopen` not been called. I can't think of a way to do this without creating a global CallbackReader, initializing it in f_stdioopen() and using it in msg_puts_printf. Does this sound reasonable, or would you suggest another approach? (It'd also make writing the test easier, as I could then re-use the existing patterns for testing `stdioopen`)