### PR TITLE
fix(healthcheck): update builtins to the new format

### DIFF
--- a/runtime/autoload/health/lsp.vim
+++ b/runtime/autoload/health/lsp.vim
@@ -1,5 +1,0 @@
-function! health#lsp#check() abort
-  call health#report_start('Checking language server client configuration')
-  lua require 'vim.lsp.health'.check_health()
-endfunction
-

--- a/runtime/autoload/health/treesitter.vim
+++ b/runtime/autoload/health/treesitter.vim
@@ -1,5 +1,0 @@
-function! health#treesitter#check() abort
-  call health#report_start('Checking treesitter configuration')
-  lua require 'vim.treesitter.health'.check_health()
-endfunction
-

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 --- Performs a healthcheck for LSP
-function M.check_health()
+function M.check()
   local report_info = vim.fn['health#report_info']
   local report_warn = vim.fn['health#report_warn']
 

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -9,7 +9,7 @@ function M.list_parsers()
 end
 
 --- Performs a healthcheck for treesitter integration
-function M.check_health()
+function M.check()
   local report_info = vim.fn['health#report_info']
   local report_ok = vim.fn['health#report_ok']
   local report_error = vim.fn['health#report_error']


### PR DESCRIPTION
Make built in healthchecks for lsp and treesitter use Lua, after https://github.com/neovim/neovim/pull/15259