### PR TITLE
refactor: remove superfluous function-like macros

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -682,8 +682,8 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
 
   vcol = offset;
 
-#define incr() nudge++; ptr_end += utfc_ptr2len(ptr_end)
-#define decr() nudge--; ptr_end -= utfc_ptr2len(ptr_end)
+#define INCR() nudge++; ptr_end += utfc_ptr2len(ptr_end)
+#define DECR() nudge--; ptr_end -= utfc_ptr2len(ptr_end)
 
   while (ptr < ptr_end && *ptr != NUL) {
     cwidth = win_chartabsize(curwin, ptr, vcol);
@@ -692,7 +692,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
       // A tab will "absorb" any previous adjustments.
       cwidth = MIN(cwidth, nudge);
       while (cwidth > 0) {
-        decr();
+        DECR();
         cwidth--;
       }
     }
@@ -700,20 +700,20 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
     matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
     if (matchid != 0) {
       if (wp->w_p_cole == 3) {
-        incr();
+        INCR();
       } else {
         if (!(row > 0 && ptr == ptr_row_offset)
             && (wp->w_p_cole == 1 || (wp->w_p_cole == 2
                                       && (wp->w_p_lcs_chars.conceal != NUL
                                           || syn_get_sub_char() != NUL)))) {
           // At least one placeholder character will be displayed.
-          decr();
+          DECR();
         }
 
         prev_matchid = matchid;
 
         while (prev_matchid == matchid && *ptr != NUL) {
-          incr();
+          INCR();
           ptr += utfc_ptr2len(ptr);
           matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
         }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -682,9 +682,6 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
 
   vcol = offset;
 
-#define incr() nudge++; ptr_end += utfc_ptr2len(ptr_end)
-#define decr() nudge--; ptr_end -= utfc_ptr2len(ptr_end)
-
   while (ptr < ptr_end && *ptr != NUL) {
     cwidth = win_chartabsize(curwin, ptr, vcol);
     vcol += cwidth;
@@ -692,7 +689,8 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
       // A tab will "absorb" any previous adjustments.
       cwidth = MIN(cwidth, nudge);
       while (cwidth > 0) {
-        decr();
+        nudge--;
+        ptr_end -= utfc_ptr2len(ptr_end);
         cwidth--;
       }
     }
@@ -700,20 +698,23 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
     matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
     if (matchid != 0) {
       if (wp->w_p_cole == 3) {
-        incr();
+        nudge++;
+        ptr_end += utfc_ptr2len(ptr_end);
       } else {
         if (!(row > 0 && ptr == ptr_row_offset)
             && (wp->w_p_cole == 1 || (wp->w_p_cole == 2
                                       && (wp->w_p_lcs_chars.conceal != NUL
                                           || syn_get_sub_char() != NUL)))) {
           // At least one placeholder character will be displayed.
-          decr();
+          nudge--;
+          ptr_end -= utfc_ptr2len(ptr_end);
         }
 
         prev_matchid = matchid;
 
         while (prev_matchid == matchid && *ptr != NUL) {
-          incr();
+          nudge++;
+          ptr_end += utfc_ptr2len(ptr_end);
           ptr += utfc_ptr2len(ptr);
           matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
         }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -682,6 +682,9 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
 
   vcol = offset;
 
+#define incr() nudge++; ptr_end += utfc_ptr2len(ptr_end)
+#define decr() nudge--; ptr_end -= utfc_ptr2len(ptr_end)
+
   while (ptr < ptr_end && *ptr != NUL) {
     cwidth = win_chartabsize(curwin, ptr, vcol);
     vcol += cwidth;
@@ -689,8 +692,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
       // A tab will "absorb" any previous adjustments.
       cwidth = MIN(cwidth, nudge);
       while (cwidth > 0) {
-        nudge--;
-        ptr_end -= utfc_ptr2len(ptr_end);
+        decr();
         cwidth--;
       }
     }
@@ -698,23 +700,20 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
     matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
     if (matchid != 0) {
       if (wp->w_p_cole == 3) {
-        nudge++;
-        ptr_end += utfc_ptr2len(ptr_end);
+        incr();
       } else {
         if (!(row > 0 && ptr == ptr_row_offset)
             && (wp->w_p_cole == 1 || (wp->w_p_cole == 2
                                       && (wp->w_p_lcs_chars.conceal != NUL
                                           || syn_get_sub_char() != NUL)))) {
           // At least one placeholder character will be displayed.
-          nudge--;
-          ptr_end -= utfc_ptr2len(ptr_end);
+          decr();
         }
 
         prev_matchid = matchid;
 
         while (prev_matchid == matchid && *ptr != NUL) {
-          nudge++;
-          ptr_end += utfc_ptr2len(ptr_end);
+          incr();
           ptr += utfc_ptr2len(ptr);
           matchid = syn_get_concealed_id(wp, lnum, (colnr_T)(ptr - line));
         }


### PR DESCRIPTION
Remove following macros:
CONVERTED
HMLL_ITER_BACK
PACK_STRUCT
IGNORE_BUF
find_shada_parameter
path_try_shorten_fname
incr
decr