### PR TITLE
fix(extmarks): splice extmarks on nv_Undo

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -3050,6 +3050,8 @@ void u_undoline(void)
   oldp = u_save_line(curbuf->b_u_line_lnum);
   ml_replace(curbuf->b_u_line_lnum, curbuf->b_u_line_ptr, true);
   changed_bytes(curbuf->b_u_line_lnum, 0);
+  extmark_splice_cols(curbuf, (int)curbuf->b_u_line_lnum-1, 0, (colnr_T)STRLEN(oldp),
+      (colnr_T)STRLEN(curbuf->b_u_line_ptr), kExtmarkUndo);
   xfree(curbuf->b_u_line_ptr);
   curbuf->b_u_line_ptr = oldp;
 

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -1050,6 +1050,19 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("sends updates on U", function()
+      feed("ggiAAA<cr>BBB")
+      feed("<esc>gg$a CCC")
+
+      local check_events = setup_eventcheck(verify, nil)
+
+      feed("ggU")
+
+      check_events {
+         { "test1", "bytes", 1, 6, 0, 7, 7, 0, 0, 0, 0, 3, 3 };
+      }
+    end)
+
     teardown(function()
       os.remove "Xtest-reload"
       os.remove "Xtest-undofile"


### PR DESCRIPTION
Fixes a buffer updates/treesitter related bug I saw on reddit.