### PR TITLE
handlers: Handle nil client_id while throwing errors

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -435,7 +435,7 @@ for k, fn in pairs(M) do
 
     if err then
       local client = vim.lsp.get_client_by_id(ctx.client_id)
-      local client_name = client and client.name or string.format("client_id=%d", ctx.client_id)
+      local client_name = client and client.name or ctx.client_id and string.format("client_id=%d", ctx.client_id) or "unknown"
       -- LSP spec:
       -- interface ResponseError:
       --  code: integer;


### PR DESCRIPTION
Without this change, trying to refresh codelenses on dartls:
`E5108: Error executing lua /usr/share/nvim/runtime/lua/vim/lsp/handlers.lua:458: bad argument #2 to 'format' (number expected, got nil)`

With this change, same circumstances:
`unknown: -32601: method textDocument/codeLens is not supported by any of the servers registered for the current buffer`

The 'unknown' maybe needs a change