### PR TITLE
vim-patch:8.2.0017

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1409,9 +1409,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When this option is set it overrules 'shellslash' for completion:
 	- When this option is set to "slash", a forward slash is used for path
 	  completion in insert mode. This is useful when editing HTML tag, or
-	  Makefile with 'noshellslash' on Windows.
+	  Makefile with 'noshellslash' on MS-Windows.
 	- When this option is set to "backslash", backslash is used. This is
-	  useful when editing a batch file with 'shellslash' set on Windows.
+	  useful when editing a batch file with 'shellslash' set on MS-Windows.
 	- When this option is empty, same character is used as for
 	  'shellslash'.
 	For Insert mode completion the buffer-local value is used.  For

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1804,7 +1804,7 @@ First of all you must choose a name for your plugin.  The features provided
 by the plugin should be clear from its name.  And it should be unlikely that
 someone else writes a plugin with the same name but which does something
 different.  And please limit the name to 8 characters, to avoid problems on
-old Windows systems.
+old MS-Windows systems.
 
 A script that corrects typing mistakes could be called "typecorr.vim".  We
 will use it here as an example.


### PR DESCRIPTION
#### vim-patch:8.2.0017: OS/2 and MS-DOS are still mentioned

Problem:    OS/2 and MS-DOS are still mentioned, even though support was
            removed long ago.
Solution:   Update documentation. (Yegappan Lakshmanan, closes vim/vim#5368)
https://github.com/vim/vim/commit/6f345a1458df2db03fba7863492404e9dc8b817c