### PR TITLE
feat(diagnostic): update jumplist on goto_next/prev

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -510,6 +510,9 @@ local function diagnostic_move_pos(opts, pos)
     return
   end
 
+  -- Save position in the window's jumplist
+  vim.api.nvim_win_call(win_id, function() vim.cmd("normal! m'") end)
+
   vim.api.nvim_win_set_cursor(win_id, {pos[1] + 1, pos[2]})
 
   if enable_popup then


### PR DESCRIPTION
`goto_next`/`goto_prev` doesn't update the jumplist, so you can't return to your previous position via `<C-I>`, `<C-O>`, etc.
Instead, update the jumplist (similiar to the LSP client's `jump_to_location`).
