### PR TITLE
feat: add support for v:lua references in 'quickfixtextfunc'

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1125,9 +1125,9 @@ bool tv_callback_equal(const Callback *cb1, const Callback *cb2)
     // maybe change dictwatcheradd to return a watcher id instead?
     return cb1->data.partial == cb2->data.partial;
   case kCallbackLuaFunc:
-    return STRCMP(cb1->data.funcref, cb2->data.funcref) == 0 &&
-           cb1->data.partial == cb2->data.partial &&
-           is_luafunc(cb1->data.partial);
+    return STRCMP(cb1->data.funcref, cb2->data.funcref) == 0
+           && cb1->data.partial == cb2->data.partial
+           && is_luafunc(cb1->data.partial);
   case kCallbackNone:
     return true;
   }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1124,6 +1124,10 @@ bool tv_callback_equal(const Callback *cb1, const Callback *cb2)
     // FIXME: this is inconsistent with tv_equal but is needed for precision
     // maybe change dictwatcheradd to return a watcher id instead?
     return cb1->data.partial == cb2->data.partial;
+  case kCallbackLuaFunc:
+    return STRCMP(cb1->data.funcref, cb2->data.funcref) == 0 &&
+           cb1->data.partial == cb2->data.partial &&
+           is_luafunc(cb1->data.partial);
   case kCallbackNone:
     return true;
   }
@@ -1137,6 +1141,7 @@ void callback_free(Callback *callback)
 {
   switch (callback->type) {
   case kCallbackFuncref:
+  case kCallbackLuaFunc:
     func_unref(callback->data.funcref);
     xfree(callback->data.funcref);
     break;

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -72,6 +72,7 @@ typedef enum {
   kCallbackNone = 0,
   kCallbackFuncref,
   kCallbackPartial,
+  kCallbackLuaFunc,
 } CallbackType;
 
 typedef struct {


### PR DESCRIPTION
The `'quickfixtextfunc'` option works differently than other `*func` variants such as `'omnifunc'` and `'completefunc'` because it parses its value as a `Callback` struct, which currently does not support `v:lua` function references. Callbacks support only function references or partials, and partials are only supported when the name of the partial function is present in the `partial_T` struct.

However, `v:lua` function references use a static `partial_T` struct. This makes it impossible to use the callback machinery to call a `v:lua` partial since we cannot mutate the single static `partial_T` struct among multiple callback instances.

We get around this by introducing a new callback type `kCallbackLuaFunc`. This is a blend of the `Funcref` and `Partial` types in that it takes both a function name (the name of the Lua function) as well as a `partial_T` struct (the static struct used for `v:lua` references). This allows callbacks to specify a function name without mutating the static struct.
