### PR TITLE
fix(buffer_updates): handle :delete of the very last line in buffer

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -413,7 +413,11 @@ void deleted_lines(linenr_T lnum, long count)
 /// be triggered to display the cursor.
 void deleted_lines_mark(linenr_T lnum, long count)
 {
-  mark_adjust(lnum, (linenr_T)(lnum + count - 1), (long)MAXLNUM, -count,
+  // if we deleted the entire buffer, we need to implicity add a new empty line
+  bool made_empty = (count > 0) && curbuf->b_ml.ml_flags & ML_EMPTY;
+
+  mark_adjust(lnum, (linenr_T)(lnum + count - 1), (long)MAXLNUM,
+              -count + (made_empty?1:0),
               kExtmarkUndo);
   changed_lines(lnum, 0, lnum + count, -count, true);
 }

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -1063,6 +1063,31 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it("delete in completely empty buffer", function()
+      local check_events = setup_eventcheck(verify, nil)
+
+      command "delete"
+      check_events { }
+    end)
+
+    it("delete the only line of a buffer", function()
+      local check_events = setup_eventcheck(verify, {"AAA"})
+
+      command "delete"
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 0, 0, 1, 0, 4, 1, 0, 1 };
+      }
+    end)
+
+    it("delete the last line of a buffer with two lines", function()
+      local check_events = setup_eventcheck(verify, {"AAA", "BBB"})
+
+      command "2delete"
+      check_events {
+        { "test1", "bytes", 1, 3, 1, 0, 4, 1, 0, 4, 0, 0, 0 };
+      }
+    end)
+
     teardown(function()
       os.remove "Xtest-reload"
       os.remove "Xtest-undofile"


### PR DESCRIPTION
Another error I found while debugging https://github.com/neovim/neovim/pull/14994 . (only the middle tests fails on master, but I added the others to avoid new regressions).