### PR TITLE
fix(buffer_updates): make lockmarks not affect extmarks and buffer updates

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1036,9 +1036,10 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2, long amount, lo
     }
 
     sign_mark_adjust(line1, line2, amount, amount_after);
-    if (op != kExtmarkNOOP) {
-      extmark_adjust(curbuf, line1, line2, amount, amount_after, op);
-    }
+  }
+
+  if (op != kExtmarkNOOP) {
+    extmark_adjust(curbuf, line1, line2, amount, amount_after, op);
   }
 
   // previous context mark

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -349,7 +349,12 @@ describe('lua: nvim_buf_attach on_bytes', function()
       end
 
       local text = meths.buf_get_lines(0, 0, -1, true)
-      local bytes = table.concat(text, '\n') .. '\n'
+      local bytes = table.concat(text, '\n')
+      if #text ~= 1 or #bytes ~= 0 then
+        -- Not empty buffer.
+        -- Append '\n' only if buffer is not empty, see nvim_buf_get_lines().
+        bytes = bytes .. '\n'
+      end
 
       eq(string.len(bytes), string.len(shadowbytes), '\non_bytes: total bytecount of buffer is wrong')
       for i = 1, string.len(shadowbytes) do
@@ -1087,6 +1092,47 @@ describe('lua: nvim_buf_attach on_bytes', function()
         { "test1", "bytes", 1, 3, 1, 0, 4, 1, 0, 4, 0, 0, 0 };
       }
     end)
+
+    local function test_lockmarks(mode)
+      if not mode then mode = "" end
+      it("test_lockmarks " .. mode .. " %delete _", function()
+        local check_events = setup_eventcheck(verify, {"AAA", "BBB", "CCC"})
+
+        command(mode .. " %delete _")
+        check_events {
+          { "test1", "bytes", 1, 3, 0, 0, 0, 3, 0, 12, 0, 0, 0 };
+        }
+      end)
+
+      it("test_lockmarks " .. mode .. " append()", function()
+        local check_events = setup_eventcheck(verify)
+
+        command(mode .. " call append(0, 'CCC')")
+        check_events {
+          { "test1", "bytes", 1, 2, 0, 0, 0, 0, 0, 0, 1, 0, 4 };
+        }
+
+        command(mode .. " call append(1, 'BBBB')")
+        check_events {
+          { "test1", "bytes", 1, 3, 1, 0, 4, 0, 0, 0, 1, 0, 5 };
+        }
+
+        command(mode .. " call append(2, '')")
+        check_events {
+          { "test1", "bytes", 1, 4, 2, 0, 9, 0, 0, 0, 1, 0, 1 };
+        }
+
+        command(mode .. " $delete _")
+        check_events {
+          { "test1", "bytes", 1, 5, 3, 0, 10, 1, 0, 1, 0, 0, 0 };
+        }
+
+        eq("CCC|BBBB|", table.concat(meths.buf_get_lines(0, 0, -1, true), "|"))
+      end)
+    end
+
+    test_lockmarks()
+    test_lockmarks "lockmarks"
 
     teardown(function()
       os.remove "Xtest-reload"

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -349,12 +349,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
       end
 
       local text = meths.buf_get_lines(0, 0, -1, true)
-      local bytes = table.concat(text, '\n')
-      if #text ~= 1 or #bytes ~= 0 then
-        -- Not empty buffer.
-        -- Append '\n' only if buffer is not empty, see nvim_buf_get_lines().
-        bytes = bytes .. '\n'
-      end
+      local bytes = table.concat(text, '\n') .. '\n'
 
       eq(string.len(bytes), string.len(shadowbytes), '\non_bytes: total bytecount of buffer is wrong')
       for i = 1, string.len(shadowbytes) do
@@ -1094,17 +1089,17 @@ describe('lua: nvim_buf_attach on_bytes', function()
     end)
 
     local function test_lockmarks(mode)
-      if not mode then mode = "" end
-      it("test_lockmarks " .. mode .. " %delete _", function()
+      local description = (mode ~= "") and mode or "(baseline)"
+      it("test_lockmarks " .. description .. " %delete _", function()
         local check_events = setup_eventcheck(verify, {"AAA", "BBB", "CCC"})
 
         command(mode .. " %delete _")
         check_events {
-          { "test1", "bytes", 1, 3, 0, 0, 0, 3, 0, 12, 0, 0, 0 };
+          { "test1", "bytes", 1, 3, 0, 0, 0, 3, 0, 12, 1, 0, 1 };
         }
       end)
 
-      it("test_lockmarks " .. mode .. " append()", function()
+      it("test_lockmarks " .. description .. " append()", function()
         local check_events = setup_eventcheck(verify)
 
         command(mode .. " call append(0, 'CCC')")
@@ -1131,7 +1126,8 @@ describe('lua: nvim_buf_attach on_bytes', function()
       end)
     end
 
-    test_lockmarks()
+    -- check that behavior is identical with and without "lockmarks"
+    test_lockmarks ""
     test_lockmarks "lockmarks"
 
     teardown(function()


### PR DESCRIPTION
update of https://github.com/neovim/neovim/pull/14994 which I cannot push to for some reason.