### PR TITLE
fix: support severity_sort option for show_diagnostic functions

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -401,9 +401,9 @@ local function show_diagnostics(opts, diagnostics)
   local severity_sort = global_diagnostic_options.severity_sort
   if severity_sort then
     if type(severity_sort) == "table" and severity_sort.reverse then
-      table.sort(diagnostics, function(a, b) return a.severity < b.severity end)
-    else
       table.sort(diagnostics, function(a, b) return a.severity > b.severity end)
+    else
+      table.sort(diagnostics, function(a, b) return a.severity < b.severity end)
     end
   end
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -125,9 +125,7 @@ local function get_namespace(ns)
       end
     end
 
-    if not name then
-      return vim.notify("namespace does not exist or is anonymous", vim.log.levels.ERROR)
-    end
+    assert(name, "namespace does not exist or is anonymous")
 
     all_namespaces[ns] = {
       name = name,
@@ -396,6 +394,17 @@ local function show_diagnostics(opts, diagnostics)
 
   if opts.source then
     diagnostics = prefix_source(opts.source, diagnostics)
+  end
+
+  -- Use global setting for severity_sort since 'show_diagnostics' is namespace
+  -- independent
+  local severity_sort = global_diagnostic_options.severity_sort
+  if severity_sort then
+    if type(severity_sort) == "table" and severity_sort.reverse then
+      table.sort(diagnostics, function(a, b) return a.severity < b.severity end)
+    else
+      table.sort(diagnostics, function(a, b) return a.severity > b.severity end)
+    end
   end
 
   for i, diagnostic in ipairs(diagnostics) do
@@ -1140,7 +1149,6 @@ function M.show_position_diagnostics(opts, bufnr, position)
   local diagnostics = M.get(bufnr, opts)
   clamp_line_numbers(bufnr, diagnostics)
   local position_diagnostics = vim.tbl_filter(match_position_predicate, diagnostics)
-  table.sort(position_diagnostics, function(a, b) return a.severity < b.severity end)
   return show_diagnostics(opts, position_diagnostics)
 end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1013,6 +1013,44 @@ describe('vim.diagnostic', function()
         return lines
       ]])
     end)
+
+    it('respects severity_sort', function()
+      exec_lua [[vim.api.nvim_win_set_buf(0, diagnostic_bufnr)]]
+
+      eq({"1. Syntax error", "2. Info", "3. Error", "4. Warning"}, exec_lua [[
+        local diagnostics = {
+          make_error("Syntax error", 0, 1, 0, 3),
+          make_info('Info', 0, 3, 0, 4),
+          make_error('Error', 0, 2, 0, 2),
+          make_warning('Warning', 0, 0, 0, 1),
+        }
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+
+        vim.diagnostic.config({severity_sort = false})
+
+        local popup_bufnr, winnr = vim.diagnostic.show_line_diagnostics { show_header = false }
+        local lines = vim.api.nvim_buf_get_lines(popup_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]])
+
+      eq({"1. Syntax error", "2. Error", "3. Warning", "4. Info"}, exec_lua [[
+        vim.diagnostic.config({severity_sort = true})
+        local popup_bufnr, winnr = vim.diagnostic.show_line_diagnostics { show_header = false }
+        local lines = vim.api.nvim_buf_get_lines(popup_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]])
+
+      eq({"1. Info", "2. Warning", "3. Error", "4. Syntax error"}, exec_lua [[
+        vim.diagnostic.config({severity_sort = { reverse = true } })
+        local popup_bufnr, winnr = vim.diagnostic.show_line_diagnostics { show_header = false }
+        local lines = vim.api.nvim_buf_get_lines(popup_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]])
+    end)
   end)
 
   describe('setloclist()', function()


### PR DESCRIPTION
Support the `severity_sort` option for `show_{line,position}_diagnostics`.

Closes #15947.
