### PR TITLE
LSP: Track active requests to the language server on the client object

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -452,6 +452,22 @@ LspSignatureActiveParameter
    |vim.lsp.handlers.signature_help()|.
 
 ==============================================================================
+EVENTS                                                            *lsp-events*
+
+LspProgressUpdate                                          *LspProgressUpdate*
+   Upon receipt of a progress notification from the server. See
+   |vim.lsp.util.get_progress_messages()|.
+
+LspRequest                                                        *LspRequest*
+   After a change to the active set of pending LSP requests. See {requests}
+   in |vim.lsp.client|.
+
+Example: >
+   autocmd User LspProgressUpdate redrawstatus
+   autocmd User LspRequest redrawstatus
+<
+
+==============================================================================
 Lua module: vim.lsp                                                 *lsp-core*
 
 buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*
@@ -608,6 +624,11 @@ client()                                                      *vim.lsp.client*
                     server.
                   • {handlers} (table): The handlers used by the client as
                     described in |lsp-handler|.
+                  • {requests} (table): The current pending requests in flight
+                    to the server. Entries are key-value pairs with the key
+                    being the request ID while the value is a table with `type`,
+                    `bufnr`, and `method` key-value pairs. `type` is either "pending"
+                    for an active request, or "cancel" for a cancel request.
                   • {config} (table): copy of the table that was passed by the
                     user to |vim.lsp.start_client()|.
                   • {server_capabilities} (table): Response from the server

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -275,6 +275,55 @@ function tests.check_forward_content_modified()
   }
 end
 
+function tests.check_pending_request_tracked()
+  skeleton {
+    on_init = function(_)
+      return { capabilities = {} }
+    end;
+    body = function()
+        local msg = read_message()
+        assert_eq('slow_request', msg.method)
+        expect_notification('release')
+        respond(msg.id, nil, {})
+        expect_notification('finish')
+        notify('finish')
+    end;
+  }
+end
+
+function tests.check_cancel_request_tracked()
+  skeleton {
+    on_init = function(_)
+      return { capabilities = {} }
+    end;
+    body = function()
+        local msg = read_message()
+        assert_eq('slow_request', msg.method)
+        expect_notification('$/cancelRequest', {id=msg.id})
+        expect_notification('release')
+        respond(msg.id, {code = -32800}, nil)
+        notify('finish')
+    end;
+  }
+end
+
+function tests.check_tracked_requests_cleared()
+  skeleton {
+    on_init = function(_)
+      return { capabilities = {} }
+    end;
+    body = function()
+        local msg = read_message()
+        assert_eq('slow_request', msg.method)
+        expect_notification('$/cancelRequest', {id=msg.id})
+        expect_notification('release')
+        respond(msg.id, nil, {})
+        expect_notification('finish')
+        notify('finish')
+    end;
+  }
+end
+
 function tests.basic_finish()
   skeleton {
     on_init = function(params)


### PR DESCRIPTION
This PR addresses the last remaining items keeping me from switching to the native LSP client over coc.nvim. That is:

1. A way to see the currently pending (active) requests to the language server (like in a status line)
2. A way to see requests for which cancellations have been requested
3. A way to cancel pending requests on CursorMoved events that does not require wrapping all of the requests (and handlers!) in a special function.

I know that `lsp.buf_request()` already returns a list of request IDs and a function to cancel them all. This PR doesn't break any existing code that uses this. However, this particular method only works if each request is wrapped appropriately. The built-in request convenience functions don't return the result of `buf_request()` so they have to be re-written with the proper method name and location params.

Even if the request functions were rewritten to return the IDs and cancellation function, there is still no way to watch pending requests if they are cancelled by the language server (either due to a user request, or due to a ContentModified error). The RPC layer swallows these responses up and never even gives the opportunity for an observer to see that a request is no longer pending to be able to clear out any external mechanism for tracking them.

I've been using this patch to great effect with the following status line and CursorMoved function:

https://gist.github.com/jdrouhard/50aa56c8f54ba9a1e94112422262e56c
https://gist.github.com/jdrouhard/d5524ed2153bfb36ffa2cc492e4d5267
