### PR TITLE
fix(api): check type in nlua_pop_keydict (#15940)

### DIFF
--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -1303,6 +1303,12 @@ void nlua_init_types(lua_State *const lstate)
 
 void nlua_pop_keydict(lua_State *L, void *retval, field_hash hashy, Error *err)
 {
+  if (!lua_istable(L, -1)) {
+    api_set_error(err, kErrorTypeValidation, "Expected lua table");
+    lua_pop(L, -1);
+    return;
+  }
+
   lua_pushnil(L);  // [dict, nil]
   while (lua_next(L, -2)) {
     // [dict, key, value]

--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -194,6 +194,10 @@ describe('luaeval(vim.api.…)', function()
        exc_exec([[call luaeval("vim.api.nvim__id_dictionary(1)")]]))
     eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
        exc_exec([[call luaeval("vim.api.nvim__id_dictionary({[vim.type_idx]=vim.types.array})")]]))
+
+    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
+       exc_exec([[call luaeval("vim.api.nvim_set_keymap('', '', '', '')")]]))
+
     -- TODO: check for errors with Tabpage argument
     -- TODO: check for errors with Window argument
     -- TODO: check for errors with Buffer argument


### PR DESCRIPTION
This should fix #15940. It just checks the type of the stack before popping it in `nlua_pop_keydict`. There is also a test to check that it works.