### PR TITLE
feat(ui): add vim.ui.input and use in lsp rename

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1071,7 +1071,8 @@ rename({new_name})                                      *vim.lsp.buf.rename()*
 
                 Parameters: ~
                     {new_name}  (string) If not provided, the user will be
-                                prompted for a new name using |input()|.
+                                prompted for a new name using
+                                |vim.ui.input()|.
 
 server_ready()                                    *vim.lsp.buf.server_ready()*
                 Checks whether the language servers attached to the current

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1702,9 +1702,10 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                                     |:command-completion|
                                   • highlight (function) Function that will be
                                     used for highlighting user inputs.
-                    {on_confirm}  function ((input) -> ()) Called once the
-                                  user confirms the input. `input` is what the
-                                  user typed.
+                    {on_confirm}  function ((input|nil) -> ()) Called once the
+                                  user confirms or abort the input. `input` is
+                                  what the user typed. `nil` if the user
+                                  aborted the dialog.
 
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*
                 Prompts the user to pick a single item from a collection of

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1703,7 +1703,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                                   • highlight (function) Function that will be
                                     used for highlighting user inputs.
                     {on_confirm}  function ((input) -> ()) Called once the
-                                  user enters the input. `input` is what the
+                                  user confirms the input. `input` is what the
                                   user typed.
 
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1689,7 +1689,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                 Prompts the user for input
 
                 Parameters: ~
-                    {opts}        table Additional options
+                    {opts}        table Additional options. See |input()|
                                   • prompt (string|nil) Text of the prompt.
                                     Defaults to `Input:` .
                                   • default (string|nil) Default reply to the
@@ -1701,8 +1701,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                                     "-complete=" argument. See
                                     |:command-completion|
                                   • highlight (function) Function that will be
-                                    used for highlighting user inputs. See
-                                    |input()-highlight| for examples.
+                                    used for highlighting user inputs.
                     {on_confirm}  function ((input) -> ()) Called once the
                                   user enters the input. `input` is what the
                                   user typed.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1685,6 +1685,28 @@ uri_to_fname({uri})                                       *vim.uri_to_fname()*
 ==============================================================================
 Lua module: ui                                                        *lua-ui*
 
+input({opts}, {on_confirm})                                   *vim.ui.input()*
+                Prompts the user for input
+
+                Parameters: ~
+                    {opts}        table Additional options
+                                  • prompt (string|nil) Text of the prompt.
+                                    Defaults to `Input:` .
+                                  • default (string|nil) Default reply to the
+                                    input
+                                  • completion (string|nil) Specifies type of
+                                    completion supported for input. Supported
+                                    types are the same that can be supplied to
+                                    a user-defined command using the
+                                    "-complete=" argument. See
+                                    |:command-completion|
+                                  • highlight (function) Function that will be
+                                    used for highlighting user inputs. See
+                                    |input()-highlight| for examples.
+                    {on_confirm}  function ((input) -> ()) Called once the
+                                  user enters the input. `input` is what the
+                                  user typed.
+
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*
                 Prompts the user to pick a single item from a collection of
                 entries

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -247,22 +247,35 @@ end
 --- Renames all references to the symbol under the cursor.
 ---
 ---@param new_name (string) If not provided, the user will be prompted for a new
----name using |input()|.
+---name using |vim.ui.input()|.
 function M.rename(new_name)
-  local params = util.make_position_params()
+  local opts = {
+    prompt = "New Name: "
+  }
+
+  ---@private
+  local function on_confirm(input)
+    if not (input and #input > 0) then return end
+    local params = util.make_position_params()
+    params.newName = input
+    request('textDocument/rename', params)
+  end
+
   local function prepare_rename(err, result)
     if err == nil and result == nil then
       vim.notify('nothing to rename', vim.log.levels.INFO)
       return
     end
     if result and result.placeholder then
-      new_name = new_name or npcall(vfn.input, "New Name: ", result.placeholder)
+      opts.default = result.placeholder
+      if not new_name then npcall(vim.ui.input, opts, on_confirm) end
     elseif result and result.start and result['end'] and
       result.start.line == result['end'].line then
       local line = vfn.getline(result.start.line+1)
       local start_char = result.start.character+1
       local end_char = result['end'].character
-      new_name = new_name or npcall(vfn.input, "New Name: ", string.sub(line, start_char, end_char))
+      opts.default = string.sub(line, start_char, end_char)
+      if not new_name then npcall(vim.ui.input, opts, on_confirm) end
     else
       -- fallback to guessing symbol using <cword>
       --
@@ -270,13 +283,12 @@ function M.rename(new_name)
       -- returns an unexpected response, or requests for "default behavior"
       --
       -- see https://microsoft.github.io/language-server-protocol/specification#textDocument_prepareRename
-      new_name = new_name or npcall(vfn.input, "New Name: ", vfn.expand('<cword>'))
+      opts.default = vfn.expand('<cword>')
+      if not new_name then npcall(vim.ui.input, opts, on_confirm) end
     end
-    if not (new_name and #new_name > 0) then return end
-    params.newName = new_name
-    request('textDocument/rename', params)
+    if new_name then on_confirm(new_name) end
   end
-  request('textDocument/prepareRename', params, prepare_rename)
+  request('textDocument/prepareRename', util.make_position_params(), prepare_rename)
 end
 
 --- Lists all the references to the symbol under the cursor in the quickfix window.

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -48,9 +48,10 @@ end
 ---     - highlight (function)
 ---               Function that will be used for highlighting
 ---               user inputs.
----@param on_confirm function ((input) -> ())
----               Called once the user confirms the input.
+---@param on_confirm function ((input|nil) -> ())
+---               Called once the user confirms or abort the input.
 ---               `input` is what the user typed.
+---               `nil` if the user aborted the dialog.
 function M.input(opts, on_confirm)
   vim.validate {
     on_confirm = { on_confirm, 'function', false },
@@ -58,8 +59,11 @@ function M.input(opts, on_confirm)
 
   opts = opts or {}
   local input = vim.fn.input(opts)
-
-  on_confirm(input)
+  if #input > 0 then
+    on_confirm(input)
+  else
+    on_confirm(nil)
+  end
 end
 
 return M

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -32,5 +32,35 @@ function M.select(items, opts, on_choice)
   end
 end
 
+--- Prompts the user for input
+---
+---@param opts table Additional options
+---     - prompt (string|nil)
+---               Text of the prompt. Defaults to `Input: `.
+---     - default (string|nil)
+---               Default reply to the input
+---     - completion (string|nil)
+---               Specifies type of completion supported
+---               for input. Supported types are the same
+---               that can be supplied to a user-defined
+---               command using the "-complete=" argument.
+---               See |:command-completion|
+---     - highlight (function)
+---               Function that will be used for highlighting
+---               user inputs. See |input()-highlight|
+---               for examples.
+---@param on_confirm function ((input) -> ())
+---               Called once the user enters the input.
+---               `input` is what the user typed.
+function M.input(opts, on_confirm)
+  vim.validate {
+    on_confirm = { on_confirm, 'function', false },
+  }
+
+  opts = opts or {}
+  local input = vim.fn.input(opts)
+
+  on_confirm(input)
+end
 
 return M

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -34,7 +34,7 @@ end
 
 --- Prompts the user for input
 ---
----@param opts table Additional options
+---@param opts table Additional options. See |input()|
 ---     - prompt (string|nil)
 ---               Text of the prompt. Defaults to `Input: `.
 ---     - default (string|nil)
@@ -47,8 +47,7 @@ end
 ---               See |:command-completion|
 ---     - highlight (function)
 ---               Function that will be used for highlighting
----               user inputs. See |input()-highlight|
----               for examples.
+---               user inputs.
 ---@param on_confirm function ((input) -> ())
 ---               Called once the user enters the input.
 ---               `input` is what the user typed.

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -49,7 +49,7 @@ end
 ---               Function that will be used for highlighting
 ---               user inputs.
 ---@param on_confirm function ((input) -> ())
----               Called once the user enters the input.
+---               Called once the user confirms the input.
 ---               `input` is what the user typed.
 function M.input(opts, on_confirm)
   vim.validate {

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -43,4 +43,29 @@ describe('vim.ui', function()
       }, result[2])
     end)
   end)
+
+  describe('input', function()
+    it('can input text', function()
+      local result = exec_lua[[
+        local opts = {
+            prompt = 'Input: ',
+        }
+        local input
+        local cb = function(item)
+          input = item
+        end
+        -- input would require input and block the test;
+        local prompt
+        vim.fn.input = function(opts)
+          prompt = opts.prompt
+          return "Inputted text"
+        end
+        vim.ui.input(opts, cb)
+        vim.wait(100, function() return input ~= nil end)
+        return {input, prompt}
+      ]]
+      eq('Inputted text', result[1])
+      eq('Input: ', result[2])
+    end)
+  end)
 end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2262,9 +2262,9 @@ describe('LSP', function()
             local bufnr = vim.api.nvim_get_current_buf()
             lsp.buf_attach_client(bufnr, TEST_RPC_CLIENT_ID)
             vim.lsp._stubs = {}
-            vim.fn.input = function(prompt, text)
-              vim.lsp._stubs.input_prompt = prompt
-              vim.lsp._stubs.input_text = text
+            vim.fn.input = function(opts, on_confirm)
+              vim.lsp._stubs.input_prompt = opts.prompt
+              vim.lsp._stubs.input_text = opts.default
               return 'renameto' -- expect this value in fake lsp
             end
             vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {'', 'this is line two'})


### PR DESCRIPTION
After vim.ui.select got merged, I got an idea that I wanted to do something similar to `input()`. This is because I want to customize how the input is used in for example renaming with lsp, without overriding the entire rename function. This proposes a solution to this with a function `vim.ui.input`, which I also changed to be used inside rename for lsp.