### PR TITLE
fix(lsp): add textDocument/prepareRename to capability map

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -41,6 +41,7 @@ lsp._request_name_to_capability = {
   ['textDocument/documentSymbol'] = 'document_symbol';
   ['textDocument/prepareCallHierarchy'] = 'call_hierarchy';
   ['textDocument/rename'] = 'rename';
+  ['textDocument/prepareRename'] = 'rename';
   ['textDocument/codeAction'] = 'code_action';
   ['textDocument/codeLens'] = 'code_lens';
   ['codeLens/resolve'] = 'code_lens_resolve';


### PR DESCRIPTION
This is a simple fix for #15899, as it should at least stop calling
`prepareRename` on servers that don't support renaming.

I imagine a better fix would be to inspect the actual value for, but
that requires some plumbing changes on how capabilities are evaluated
before sending requests out.