### PR TITLE
fix(diagnostic): error on invalid severity value

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -27,7 +27,10 @@ local global_diagnostic_options = {
 
 ---@private
 local function to_severity(severity)
-  return type(severity) == 'string' and M.severity[string.upper(severity)] or severity
+  if type(severity) == 'string' then
+    return assert(M.severity[string.upper(severity)], string.format("Invalid severity: %s", severity))
+  end
+  return severity
 end
 
 ---@private


### PR DESCRIPTION
Users can pass string values for severities that match with the enum names (e.g. "Warn" or "Info") which are converted to the corresponding numerical value in `to_severity`. Invalid strings were simply left as-is, which caused confusing errors later on. Instead, report an invalid severity string right up front to make the problem clear.
