### PR TITLE
fix(runtime): don't use regexes inside lua require'mod'

### DIFF
--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -48,5 +48,8 @@ return {
     "style";
     "noautocmd";
   };
+  runtime = {
+    "is_lua";
+  };
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -756,6 +756,11 @@ ArrayOf(String) nvim_list_runtime_paths(Error *err)
   return nvim_get_runtime_file(NULL_STRING, true, err);
 }
 
+Array nvim__runtime_inspect(void)
+{
+  return runtime_inspect();
+}
+
 /// Find files in runtime directories
 ///
 /// 'name' can contain wildcards. For example
@@ -793,6 +798,25 @@ String nvim__get_lib_dir(void)
 {
   return cstr_as_string(get_lib_dir());
 }
+
+/// Find files in runtime directories
+///
+/// @param pat pattern of files to search for
+/// @param all whether to return all matches or only the first
+/// @param options
+///          is_lua: only search lua subdirs
+/// @return list of absolute paths to the found files
+ArrayOf(String) nvim__get_runtime(Array pat, Boolean all, Dict(runtime) *opts, Error *err)
+  FUNC_API_SINCE(8)
+  FUNC_API_FAST
+{
+  bool is_lua = api_object_to_bool(opts->is_lua, "is_lua", false, err);
+  if (ERROR_SET(err)) {
+    return (Array)ARRAY_DICT_INIT;
+  }
+  return runtime_get_named(is_lua, pat, all);
+}
+
 
 /// Changes the global working directory.
 ///

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -419,7 +419,7 @@ local function process_function(fn)
 
   if not fn.fast then
     write_shifted_output(output, string.format([[
-    if (!nlua_is_deferred_safe(lstate)) {
+    if (!nlua_is_deferred_safe()) {
       return luaL_error(lstate, e_luv_api_disabled, "%s");
     }
     ]], fn.name))

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -790,7 +790,7 @@ int nlua_call(lua_State *lstate)
   Error err = ERROR_INIT;
   size_t name_len;
   const char_u *name = (const char_u *)luaL_checklstring(lstate, 1, &name_len);
-  if (!nlua_is_deferred_safe(lstate)) {
+  if (!nlua_is_deferred_safe()) {
     return luaL_error(lstate, e_luv_api_disabled, "vimL function");
   }
 
@@ -846,7 +846,7 @@ free_vim_args:
 
 static int nlua_rpcrequest(lua_State *lstate)
 {
-  if (!nlua_is_deferred_safe(lstate)) {
+  if (!nlua_is_deferred_safe()) {
     return luaL_error(lstate, e_luv_api_disabled, "rpcrequest");
   }
   return nlua_rpc(lstate, true);
@@ -1316,7 +1316,7 @@ Object nlua_call_ref(LuaRef ref, const char *name, Array args, bool retval, Erro
 
 /// check if the current execution context is safe for calling deferred API
 /// methods. Luv callbacks are unsafe as they are called inside the uv loop.
-bool nlua_is_deferred_safe(lua_State *lstate)
+bool nlua_is_deferred_safe(void)
 {
   return in_fast_callback == 0;
 }

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -57,28 +57,29 @@ end
 function vim._load_package(name)
   local basename = name:gsub('%.', '/')
   local paths = {"lua/"..basename..".lua", "lua/"..basename.."/init.lua"}
-  for _,path in ipairs(paths) do
-    local found = vim.api.nvim_get_runtime_file(path, false)
-    if #found > 0 then
-      local f, err = loadfile(found[1])
-      return f or error(err)
-    end
+  local found = vim.api.nvim__get_runtime(paths, false, {is_lua=true})
+  if #found > 0 then
+    local f, err = loadfile(found[1])
+    return f or error(err)
   end
 
+  local so_paths = {}
   for _,trail in ipairs(vim._so_trails) do
     local path = "lua"..trail:gsub('?', basename) -- so_trails contains a leading slash
-    local found = vim.api.nvim_get_runtime_file(path, false)
-    if #found > 0 then
-      -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is
-      -- a) strip prefix up to and including the first dash, if any
-      -- b) replace all dots by underscores
-      -- c) prepend "luaopen_"
-      -- So "foo-bar.baz" should result in "luaopen_bar_baz"
-      local dash = name:find("-", 1, true)
-      local modname = dash and name:sub(dash + 1) or name
-      local f, err = package.loadlib(found[1], "luaopen_"..modname:gsub("%.", "_"))
-      return f or error(err)
-    end
+    table.insert(so_paths, path)
+  end
+
+  found = vim.api.nvim__get_runtime(so_paths, false, {is_lua=true})
+  if #found > 0 then
+    -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is
+    -- a) strip prefix up to and including the first dash, if any
+    -- b) replace all dots by underscores
+    -- c) prepend "luaopen_"
+    -- So "foo-bar.baz" should result in "luaopen_bar_baz"
+    local dash = name:find("-", 1, true)
+    local modname = dash and name:sub(dash + 1) or name
+    local f, err = package.loadlib(found[1], "luaopen_"..modname:gsub("%.", "_"))
+    return f or error(err)
   end
   return nil
 end

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -10,6 +10,7 @@ typedef void (*DoInRuntimepathCB)(char_u *, void *);
 typedef struct {
   char *path;
   bool after;
+  TriState has_lua;
 } SearchPathItem;
 
 typedef kvec_t(SearchPathItem) RuntimeSearchPath;

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -328,6 +328,15 @@ describe('startup', function()
     eq({9003, '\thowdy'}, exec_lua [[ return { _G.y, _G.z } ]])
   end)
 
+  it("handles require from &packpath in an async handler", function()
+      -- NO! you cannot just speed things up by calling async functions during startup!
+      -- It doesn't make anything actually faster! NOOOO!
+    pack_clear [[ lua require'async_leftpad'('brrrr', 'async_res') ]]
+
+    -- haha, async leftpad go brrrrr
+    eq('\tbrrrr', exec_lua [[ return _G.async_res ]])
+  end)
+
   it("handles :packadd during startup", function()
     -- control group: opt/bonus is not availabe by default
     pack_clear [[

--- a/test/functional/fixtures/pack/foo/start/fancyplugin/after/lua/fancy_y.lua
+++ b/test/functional/fixtures/pack/foo/start/fancyplugin/after/lua/fancy_y.lua
@@ -1,0 +1,1 @@
+return "I am fancy_y.lua"

--- a/test/functional/fixtures/pack/foo/start/fancyplugin/after/lua/fancy_z.lua
+++ b/test/functional/fixtures/pack/foo/start/fancyplugin/after/lua/fancy_z.lua
@@ -1,0 +1,1 @@
+return "I am fancy_z.lua"

--- a/test/functional/fixtures/pack/foo/start/fancyplugin/lua/fancy_x.lua
+++ b/test/functional/fixtures/pack/foo/start/fancyplugin/lua/fancy_x.lua
@@ -1,0 +1,1 @@
+return "I am fancy_x.lua"

--- a/test/functional/fixtures/pack/foo/start/fancyplugin/lua/fancy_x/init.lua
+++ b/test/functional/fixtures/pack/foo/start/fancyplugin/lua/fancy_x/init.lua
@@ -1,0 +1,1 @@
+return "I am init.lua of fancy_x!"

--- a/test/functional/fixtures/pack/foo/start/fancyplugin/lua/fancy_y/init.lua
+++ b/test/functional/fixtures/pack/foo/start/fancyplugin/lua/fancy_y/init.lua
@@ -1,0 +1,2 @@
+
+return "I am init.lua of fancy_y!"

--- a/test/functional/fixtures/start/nvim-leftpad/lua/async_leftpad.lua
+++ b/test/functional/fixtures/start/nvim-leftpad/lua/async_leftpad.lua
@@ -1,0 +1,3 @@
+return function (val, res)
+  vim.loop.new_async(function() _G[res] = require'leftpad'(val) end):send()
+end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2255,7 +2255,7 @@ end)
 
 describe('lua: require("mod") from packages', function()
   before_each(function()
-    command('set rtp+=test/functional/fixtures')
+    command('set rtp+=test/functional/fixtures pp+=test/functional/fixtures')
   end)
 
   it('propagates syntax error', function()
@@ -2265,5 +2265,14 @@ describe('lua: require("mod") from packages', function()
     ]]
 
     matches("unexpected symbol", syntax_error_msg)
+  end)
+
+  it('uses the right order of mod.lua vs mod/init.lua', function()
+    -- lua/fancy_x.lua takes precedence over lua/fancy_x/init.lua
+    eq('I am fancy_x.lua', exec_lua [[ return require'fancy_x' ]])
+    -- but lua/fancy_y/init.lua takes precedence over after/lua/fancy_y.lua
+    eq('I am init.lua of fancy_y!', exec_lua [[ return require'fancy_y' ]])
+    -- safety check: after/lua/fancy_z.lua is still loaded
+    eq('I am fancy_z.lua', exec_lua [[ return require'fancy_z' ]])
   end)
 end)


### PR DESCRIPTION
fixes #15147 and fixes #15497 . Also sketch "subdir" caching, currently this only caches whether an rtp entry has a "lua/" subdir but we could consider cache other subdirs potentially or even "lua/mybigplugin/" possibly.