### PR TITLE
vim-patch:8.2.3490: superfluous return statements

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2553,8 +2553,6 @@ void buflist_setfpos(buf_T *const buf, win_T *const win, linenr_T lnum, colnr_T 
   if (wip->wi_next) {
     wip->wi_next->wi_prev = wip;
   }
-
-  return;
 }
 
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -293,7 +293,6 @@ static void add_buff(buffheader_T *const buf, const char *const s, ptrdiff_t sle
     buf->bh_curr->b_next = p;
     buf->bh_curr = p;
   }
-  return;
 }
 
 /*

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1272,7 +1272,6 @@ theend:
     apply_autocmds(EVENT_BUFREADPOST, NULL, curbuf->b_fname, FALSE, curbuf);
     apply_autocmds(EVENT_BUFWINENTER, NULL, curbuf->b_fname, FALSE, curbuf);
   }
-  return;
 }
 
 /// Find the names of swap files in current directory and the directory given
@@ -2798,7 +2797,6 @@ void ml_clearmarked(void)
   }
 
   lowest_marked = 0;
-  return;
 }
 
 size_t ml_flush_deleted_bytes(buf_T *buf, size_t *codepoints, size_t *codeunits)

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2104,7 +2104,6 @@ static void get_scroll_overlap(lineoff_T *lp, int dir)
   } else {
     *lp = loff2;        // 2 lines overlap
   }
-  return;
 }
 
 // Scroll 'scroll' lines up or down.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6509,8 +6509,6 @@ void set_context_in_set_cmd(expand_T *xp, char_u *arg, int opt_flags)
       break;
     }
   }
-
-  return;
 }
 
 int ExpandSettings(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***file)


### PR DESCRIPTION
Problem:    Superfluous return statements.
Solution:   Remove superfluous return statements from void functions.
            (closes vim/vim#8977)
https://github.com/vim/vim/commit/3826c0513bc9370583be550c864358c7eeb5605a