### PR TITLE
Fix highlight colors with TERM=linux

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -110,8 +110,7 @@ width of the terminal.
 
 							*tui-colors*
 Nvim uses 256 colours by default, ignoring |terminfo| for most terminal types,
-including "linux" (whose virtual terminals have had 256-colour support since
-4.8) and anything claiming to be "xterm".  Also when $COLORTERM or $TERM
+including anything claiming to be "xterm" and when $COLORTERM or $TERM
 contain the string "256".
 
 Nvim similarly assumes that any terminal emulator that sets $COLORTERM to any

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -357,6 +357,7 @@ EXTERN int provider_call_nesting INIT(= 0);
 
 
 EXTERN int t_colors INIT(= 256);                // int value of T_CCO
+EXTERN int bg_colors INIT(= 0);                 // override bg color count if > 0
 
 // When highlight_match is true, highlight a match, starting at the cursor
 // position.  Search_match_lines is the number of lines after the match (0 for

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6581,7 +6581,7 @@ void init_highlight(bool both, bool reset)
    * With 8 colors brown is equal to yellow, need to use black for Search fg
    * to avoid Statement highlighted text disappears.
    * Clear the attributes, needed when changing the t_Co value. */
-  if (t_colors > 8) {
+  if ((bg_colors != 0 ? bg_colors : t_colors) > 8) {
     do_highlight((*p_bg == 'l'
          ? "Visual cterm=NONE ctermbg=LightGrey"
          : "Visual cterm=NONE ctermbg=DarkGrey"), false, true);
@@ -6692,7 +6692,7 @@ int lookup_color(const int idx, const bool foreground, TriState *const boldp)
     return -1;
   }
 
-  if (t_colors == 8) {
+  if (t_colors == 8 || (!foreground && bg_colors == 8)) {
     // t_Co is 8: use the 8 colors table
     color = color_numbers_8[idx];
     if (foreground) {
@@ -7087,7 +7087,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
                 if (color >= 0) {
                   int dark = -1;
 
-                  if (t_colors < 16) {
+                  if ((bg_colors != 0 ? bg_colors : t_colors) < 16) {
                     dark = (color == 0 || color == 4);
                   } else if (color < 16) {
                     // Limit the heuristic to the standard 16 colors

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1198,12 +1198,12 @@ describe("TUI 't_Co' (terminal colors)", function()
 
   -- Linux kernel terminal emulator:
 
-  it("TERM=linux uses 256 colors", function()
-    assert_term_colors("linux", nil, 256)
+  it("TERM=linux uses 16 colors", function()
+    assert_term_colors("linux", nil, 16)
   end)
 
-  it("TERM=linux-16color uses 256 colors", function()
-    assert_term_colors("linux-16color", nil, 256)
+  it("TERM=linux-16color uses 16 colors", function()
+    assert_term_colors("linux-16color", nil, 16)
   end)
 
   it("TERM=linux-256color uses 256 colors", function()


### PR DESCRIPTION
`TERM=linux` technically recognizes 256-color SGR, but it can only render 16-color FG/8-color BG. To utilize the full range of its capabilities while still letting Neovim work around its limitations, I added
`bg_colors`, intended to let it know bg color support differs from fg color support. Also, `init_highlight` wasn't being called after loading terminfo which rendered the highlight fallback for terminals that only support 8 colors useless.

Fixes #15963.