### PR TITLE
feat(lsp): add noautocmd to floating popup options

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -956,6 +956,7 @@ end
 ---        - border (string or table) override `border`
 ---        - focusable (string or table) override `focusable`
 ---        - zindex (string or table) override `zindex`, defaults to 50
+---        - noautocmd (boolean): override `noautocmd`
 ---@returns (table) Options
 function M.make_floating_popup_options(width, height, opts)
   validate {
@@ -1002,6 +1003,7 @@ function M.make_floating_popup_options(width, height, opts)
     width = width,
     border = opts.border or default_border,
     zindex = opts.zindex or 50,
+    noautocmd = opts.noautocmd,
   }
 end
 


### PR DESCRIPTION
This adds an option to use the `config.noautocmd` argument of `nvim_open_win` in the functions that make use of `vim.lsp.util.make_floating_popup_options`.

The main motivation for this change is to be able to work around the problem described in https://github.com/neovim/neovim/issues/15300, which is that creating a popup generates BufLeave (current buffer), BufEnter (popup), which is **not** followed by BufEnter (current buffer). This breaks some plugins, in my case it prevents using [vim-repeat](https://github.com/tpope/vim-repeat) with `vim.diagnostic.goto_next`. `vim-repeat` depends on BufEnter/BufLeave to update `g:repeat_tick=b:changedtick`. Creating a popup results in `g:repeat_tick` being updated in the BufEnter (popup) to the popup's `b:changedtick` which is always lower then changedtick of current buffer if it was already edited, and `vim.diagnostic.goto_next` will not be repeated in that case.

With this change user is able to use something like:
```vim
nnoremap ]d <cmd>call repeat#set(']d')<cr><cmd>lua vim.diagnostic.goto_next { popup_opts = { noautocmd=true } }<cr>
```
to have a repeatable jump to diagnostic.

I also wonder if maybe `noautocmd` shouldn be the default for popup windows, but I don't really know if this would break something important? The most interesting  autocomds would probably fire during buffer creation, not during `nvim_open_win`, so maybe it would be ok?
