### PR TITLE
fix(lsp): maintain client_ids table structure when filtering

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -144,9 +144,13 @@ local function for_each_buffer_client(bufnr, fn, restrict_client_ids)
   end
 
   if restrict_client_ids and #restrict_client_ids > 0 then
-    client_ids = vim.tbl_filter(function(item)
-        return vim.tbl_contains(restrict_client_ids, item)
-      end, vim.tbl_keys(client_ids))
+    local filtered_client_ids = {}
+    for client_id in pairs(client_ids) do
+      if vim.tbl_contains(restrict_client_ids, client_id) then
+        filtered_client_ids[client_id] = true
+      end
+    end
+    client_ids = filtered_client_ids
   end
 
   for client_id in pairs(client_ids) do


### PR DESCRIPTION
The `restrict_client_ids` functionality added to `for_each_buffer_client` in d288daac2bdc7e1e7da58656cd26a4311811120c can cause requests to be sent to servers that don't support a given method (see [this null-ls issue](https://github.com/jose-elias-alvarez/null-ls.nvim/issues/254) for details and reproduction steps). 

As mentioned in the linked issue, it looks like that the way `client_ids` is filtered changes its structure from a table with client ID indexes and boolean values to a simple list of client IDs, which means that iterating over the table with `pairs` will not work as expected. This PR changes how `client_ids` is filtered to maintain the original structure, which fixes the issue. 