### PR TITLE
feat(:source, nvim_exec): support script-local variables

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9191,8 +9191,12 @@ static hashtab_T *find_var_ht_dict(const char *name, const size_t name_len, cons
   } else if (*name == 'l' && funccal != NULL) {  // local variable
     *d = &funccal->l_vars;
   } else if (*name == 's'  // script variable
-             && current_sctx.sc_sid > 0
+             && (current_sctx.sc_sid > 0 || current_sctx.sc_sid == SID_STR)
              && current_sctx.sc_sid <= ga_scripts.ga_len) {
+    // For anonymous scripts without a script item, create one now so script vars can be used
+    if (current_sctx.sc_sid == SID_STR) {
+      new_script_item(NULL, &current_sctx.sc_sid);
+    }
     *d = &SCRIPT_SV(current_sctx.sc_sid)->sv_dict;
   }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1939,6 +1939,29 @@ static char_u *get_str_line(int c, void *cookie, int indent, bool do_concat)
   return ga.ga_data;
 }
 
+/// Create a new script item and allocate script-local vars. @see new_script_vars
+///
+/// @param  name  File name of the script. NULL for anonymous :source.
+/// @param[out]  sid_out  SID of the new item.
+/// @return pointer to the created script item.
+static scriptitem_T *new_script_item(char_u *const name, scid_T *const sid_out)
+{
+  static scid_T last_current_SID = 0;
+  const scid_T sid = ++last_current_SID;
+  if (sid_out != NULL) {
+    *sid_out = sid;
+  }
+  ga_grow(&script_items, (int)(sid - script_items.ga_len));
+  while (script_items.ga_len < sid) {
+    script_items.ga_len++;
+    SCRIPT_ITEM(script_items.ga_len).sn_name = NULL;
+    SCRIPT_ITEM(script_items.ga_len).sn_prof_on = false;
+  }
+  SCRIPT_ITEM(sid).sn_name = name;
+  new_script_vars(sid);  // Allocate the local script variables to use for this script.
+  return &SCRIPT_ITEM(sid);
+}
+
 static int source_using_linegetter(void *cookie, LineGetter fgetline, const char *traceback_name)
 {
   char_u *save_sourcing_name = sourcing_name;
@@ -1955,7 +1978,7 @@ static int source_using_linegetter(void *cookie, LineGetter fgetline, const char
   sourcing_lnum = 0;
 
   const sctx_T save_current_sctx = current_sctx;
-  current_sctx.sc_sid = SID_STR;
+  new_script_item(NULL, &current_sctx.sc_sid);
   current_sctx.sc_seq = 0;
   current_sctx.sc_lnum = save_sourcing_lnum;
   funccal_entry_T entry;
@@ -2036,7 +2059,6 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
   char_u *fname_exp;
   char_u *firstline = NULL;
   int retval = FAIL;
-  static scid_T last_current_SID = 0;
   static int last_current_SID_seq = 0;
   int save_debug_break_level = debug_break_level;
   scriptitem_T *si = NULL;
@@ -2183,15 +2205,7 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
     }
   }
   if (current_sctx.sc_sid == 0) {
-    current_sctx.sc_sid = ++last_current_SID;
-    ga_grow(&script_items, (int)(current_sctx.sc_sid - script_items.ga_len));
-    while (script_items.ga_len < current_sctx.sc_sid) {
-      script_items.ga_len++;
-      SCRIPT_ITEM(script_items.ga_len).sn_name = NULL;
-      SCRIPT_ITEM(script_items.ga_len).sn_prof_on = false;
-    }
-    si = &SCRIPT_ITEM(current_sctx.sc_sid);
-    si->sn_name = fname_exp;
+    si = new_script_item(fname_exp, &current_sctx.sc_sid);
     fname_exp = vim_strsave(si->sn_name);  // used for autocmd
     if (file_id_ok) {
       si->file_id_valid = true;
@@ -2199,9 +2213,6 @@ int do_source(char_u *fname, int check_other, int is_vimrc)
     } else {
       si->file_id_valid = false;
     }
-
-    // Allocate the local script variables to use for this script.
-    new_script_vars(current_sctx.sc_sid);
   }
 
   if (l_do_profiling == PROF_YES) {
@@ -2375,16 +2386,21 @@ char_u *get_scriptname(LastSet last_set, bool *should_free)
   case SID_LUA:
     return (char_u *)_("Lua");
   case SID_API_CLIENT:
-    vim_snprintf((char *)IObuff, IOSIZE,
-                 _("API client (channel id %" PRIu64 ")"),
-                 last_set.channel_id);
+    snprintf((char *)IObuff, IOSIZE, _("API client (channel id %" PRIu64 ")"), last_set.channel_id);
     return IObuff;
   case SID_STR:
     return (char_u *)_("anonymous :source");
-  default:
+  default: {
+    char_u *const sname = SCRIPT_ITEM(last_set.script_ctx.sc_sid).sn_name;
+    if (sname == NULL) {
+      snprintf((char *)IObuff, IOSIZE, _("anonymous :source (script id %d)"),
+               last_set.script_ctx.sc_sid);
+      return IObuff;
+    }
+
     *should_free = true;
-    return home_replace_save(NULL,
-                             SCRIPT_ITEM(last_set.script_ctx.sc_sid).sn_name);
+    return home_replace_save(NULL, sname);
+  }
   }
 }
 

--- a/src/nvim/ex_cmds2.h
+++ b/src/nvim/ex_cmds2.h
@@ -16,6 +16,31 @@
 #define CCGD_ALLBUF     8       // may write all buffers
 #define CCGD_EXCMD      16      // may suggest using !
 
+/// Also store the dev/ino, so that we don't have to stat() each
+/// script when going through the list.
+typedef struct scriptitem_S {
+  char_u *sn_name;
+  bool file_id_valid;
+  FileID file_id;
+  bool sn_prof_on;              ///< true when script is/was profiled
+  bool sn_pr_force;             ///< forceit: profile functions in this script
+  proftime_T sn_pr_child;       ///< time set when going into first child
+  int sn_pr_nest;               ///< nesting for sn_pr_child
+  // profiling the script as a whole
+  int sn_pr_count;              ///< nr of times sourced
+  proftime_T sn_pr_total;       ///< time spent in script + children
+  proftime_T sn_pr_self;        ///< time spent in script itself
+  proftime_T sn_pr_start;       ///< time at script start
+  proftime_T sn_pr_children;    ///< time in children after script start
+  // profiling the script per line
+  garray_T sn_prl_ga;           ///< things stored for every line
+  proftime_T sn_prl_start;      ///< start time for current line
+  proftime_T sn_prl_children;   ///< time spent in children for this line
+  proftime_T sn_prl_wait;       ///< wait start time for current line
+  linenr_T sn_prl_idx;          ///< index of line being timed; -1 if none
+  int sn_prl_execed;            ///< line being timed was executed
+} scriptitem_T;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ex_cmds2.h.generated.h"
 #endif

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -335,7 +335,7 @@ EXTERN int garbage_collect_at_exit INIT(= false);
 #define SID_WINLAYOUT   -7      // changing window size
 #define SID_LUA         -8      // for Lua scripts/chunks
 #define SID_API_CLIENT  -9      // for API clients
-#define SID_STR         -10     // for sourcing a string
+#define SID_STR         -10     // for sourcing a string with no script item
 
 // Script CTX being sourced or was sourced to define the current function.
 EXTERN sctx_T current_sctx INIT(= { 0 COMMA 0 COMMA 0 });

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -89,6 +89,14 @@ describe('API', function()
 
     it(':verbose set {option}?', function()
       nvim('exec', 'set nowrap', false)
+      eq('nowrap\n\tLast set from anonymous :source',
+        nvim('exec', 'verbose set wrap?', true))
+
+      -- Using script var to force creation of a script item
+      nvim('exec', [[
+        let s:a = 1
+        set nowrap
+      ]], false)
       eq('nowrap\n\tLast set from anonymous :source (script id 1)',
         nvim('exec', 'verbose set wrap?', true))
     end)
@@ -155,6 +163,20 @@ describe('API', function()
           let s:pirate = 'script-scoped varrrrr'
           call nvim_exec('echo s:pirate', 1)
         ]], false))
+
+      -- Script items are created only on script var access
+      eq('1\n0', nvim('exec', [[
+          echo expand("<SID>")->empty()
+          let s:a = 123
+          echo expand("<SID>")->empty()
+        ]], true))
+
+      eq('1\n0', nvim('exec', [[
+          echo expand("<SID>")->empty()
+          function s:a() abort
+          endfunction
+          echo expand("<SID>")->empty()
+        ]], true))
     end)
 
     it('non-ASCII input', function()

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -26,13 +26,17 @@ describe(':source', function()
         \ k: "v"
        "\ (o_o)
         \ }
+      let c = expand("<SID>")->empty()
       let s:s = 0zbeef.cafe
-      let c = s:s]])
+      let d = s:s]])
 
     command('source')
     eq('2', meths.exec('echo a', true))
     eq("{'k': 'v'}", meths.exec('echo b', true))
-    eq("0zBEEFCAFE", meths.exec('echo c', true))
+
+    -- Script items are created only on script var access
+    eq("1", meths.exec('echo c', true))
+    eq("0zBEEFCAFE", meths.exec('echo d', true))
 
     exec('set cpoptions+=C')
     eq('Vim(let):E15: Invalid expression: #{', exc_exec('source'))
@@ -62,7 +66,7 @@ describe(':source', function()
     feed_command(':source')
     eq('4', meths.exec('echo a', true))
     eq("{'K': 'V'}", meths.exec('echo b', true))
-    eq("<SNR>3_C()", meths.exec('echo D()', true))
+    eq("<SNR>1_C()", meths.exec('echo D()', true))
 
     -- Source last line only
     feed_command(':$source')

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -25,11 +25,14 @@ describe(':source', function()
       let b = #{
         \ k: "v"
        "\ (o_o)
-        \ }]])
+        \ }
+      let s:s = 0zbeef.cafe
+      let c = s:s]])
 
     command('source')
     eq('2', meths.exec('echo a', true))
     eq("{'k': 'v'}", meths.exec('echo b', true))
+    eq("0zBEEFCAFE", meths.exec('echo c', true))
 
     exec('set cpoptions+=C')
     eq('Vim(let):E15: Invalid expression: #{', exc_exec('source'))
@@ -43,7 +46,11 @@ describe(':source', function()
       let b = #{
        "\ (>_<)
         \ K: "V"
-        \ }]])
+        \ }
+      function! s:C() abort
+        return expand("<SID>") .. "C()"
+      endfunction
+      let D = {-> s:C()}]])
 
     -- Source the 2nd line only
     feed('ggjV')
@@ -55,6 +62,11 @@ describe(':source', function()
     feed_command(':source')
     eq('4', meths.exec('echo a', true))
     eq("{'K': 'V'}", meths.exec('echo b', true))
+    eq("<SNR>3_C()", meths.exec('echo D()', true))
+
+    -- Source last line only
+    feed_command(':$source')
+    eq('Vim(echo):E117: Unknown function: s:C', exc_exec('echo D()'))
 
     exec('set cpoptions+=C')
     eq('Vim(let):E15: Invalid expression: #{', exc_exec("'<,'>source"))


### PR DESCRIPTION
While investigating script scope support for `nvim_exec`, I came across #13143.
The PR has unfortunately gathered some dust, so I thought I'd rebase it with a few changes:

 - Omit `script_type_E`. Use `sn_name == NULL` to determine anon items.
 - Keep `SID_STR`. Used by anon :source for .lua files (no item).
 - Show SID in `get_scriptname` output (:verbose set).
 - Factor item creation into `new_script_item`.
 - Leave `sc_seq = 0` (anon scripts don't re-use the same item when re-sourced).
 - Add tests for :source.

One thing to maybe note is that a new item is created for _every_ `nvim_exec` call/anonymous `:source`.
E.g: if many `vim.cmd`s are used in a loop, this could create a lot of script items; maybe not a problem in practice?