### PR TITLE
fix(build): export symbols on Windows

### DIFF
--- a/src/nvim/generators/c_grammar.lua
+++ b/src/nvim/generators/c_grammar.lua
@@ -16,6 +16,7 @@ local ws = S(' \t') + nl
 local fill = ws ^ 0
 local c_comment = P('//') * (not_nl ^ 0)
 local c_preproc = P('#') * (not_nl ^ 0)
+local dllexport = P('DLLEXPORT') * (ws ^ 1)
 local typed_container =
   (P('ArrayOf(') + P('DictionaryOf(') + P('Dict(')) * ((any - P(')')) ^ 1) * P(')')
 local c_id = (
@@ -33,6 +34,7 @@ local c_param = Ct(c_param_type * C(c_id))
 local c_param_list = c_param * (fill * (P(',') * fill * c_param) ^ 0)
 local c_params = Ct(c_void + c_param_list)
 local c_proto = Ct(
+  (dllexport ^ -1) *
   Cg(c_type, 'return_type') * Cg(c_id, 'name') *
   fill * P('(') * fill * Cg(c_params, 'parameters') * fill * P(')') *
   Cg(Cc(false), 'fast') *

--- a/src/nvim/generators/gen_declarations.lua
+++ b/src/nvim/generators/gen_declarations.lua
@@ -216,7 +216,16 @@ local footer = [[
 #include "nvim/func_attr.h"
 ]]
 
-local non_static = header
+local non_static = header .. [[
+#ifndef DLLEXPORT
+#  ifdef WIN32
+#    define DLLEXPORT __declspec(dllexport)
+#  else
+#    define DLLEXPORT
+#  endif
+#endif
+]]
+
 local static = header
 
 local filepattern = '^#%a* (%d+) "([^"]-)/?([^"/]+)"'
@@ -269,6 +278,7 @@ while init ~= nil do
       declaration = declaration:gsub(' $', '')
       declaration = declaration:gsub('^ ', '')
       declaration = declaration .. ';'
+
       if os.getenv('NVIM_GEN_DECLARATIONS_LINE_NUMBERS') == '1' then
         declaration = declaration .. ('  // %s/%s:%u'):format(
             curdir, curfile, declline)
@@ -277,6 +287,7 @@ while init ~= nil do
       if declaration:sub(1, 6) == 'static' then
         static = static .. declaration
       else
+        declaration = 'DLLEXPORT ' .. declaration
         non_static = non_static .. declaration
       end
       declendpos = e

--- a/test/functional/lua/ffi_spec.lua
+++ b/test/functional/lua/ffi_spec.lua
@@ -1,0 +1,62 @@
+local helpers = require('test.functional.helpers')(after_each)
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+local clear = helpers.clear
+
+before_each(clear)
+
+describe('ffi.cdef', function()
+  it('can use Neovim core functions', function()
+    if not exec_lua("return pcall(require, 'ffi')") then
+      pending('missing LuaJIT FFI')
+    end
+
+    eq(12, exec_lua[[
+      local ffi = require('ffi')
+
+      ffi.cdef('int curwin_col_off(void);')
+
+      vim.cmd('set number numberwidth=4 signcolumn=yes:4')
+
+      return ffi.C.curwin_col_off()
+    ]])
+
+    eq(20, exec_lua[=[
+      local ffi = require('ffi')
+
+      ffi.cdef[[
+        typedef unsigned char char_u;
+        typedef struct window_S win_T;
+        typedef struct {} stl_hlrec_t;
+        typedef struct {} StlClickRecord;
+        typedef struct {} Error;
+
+        win_T *find_window_by_handle(int Window, Error *err);
+
+        int build_stl_str_hl(
+          win_T *wp,
+          char_u *out,
+          size_t outlen,
+          char_u *fmt,
+          int use_sandbox,
+          char_u fillchar,
+          int maxwidth,
+          stl_hlrec_t **hltab,
+          StlClickRecord **tabtab
+        );
+      ]]
+
+      return ffi.C.build_stl_str_hl(
+        ffi.C.find_window_by_handle(0, ffi.new('Error')),
+        ffi.new('char_u[1024]'),
+        1024,
+        ffi.cast('char_u*', 'StatusLineOfLength20'),
+        0,
+        0,
+        0,
+        nil,
+        nil
+      )
+    ]=])
+  end)
+end)


### PR DESCRIPTION
Second take on #15989, this time modifying the header generator instead of tampering with the build system.

Closes #15063 