### PR TITLE
fix(lsp): add completionItem/resolve to capability mapping

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -52,6 +52,7 @@ lsp._request_name_to_capability = {
   ['textDocument/formatting'] = 'document_formatting';
   ['textDocument/completion'] = 'completion';
   ['textDocument/documentHighlight'] = 'document_highlight';
+  ['completionItem/resolve'] = 'completion';
 }
 
 -- TODO improve handling of scratch buffers with LSP attached.


### PR DESCRIPTION
Something I ran into while using nvim-lsp-compl + multiple servers for a
buffer (similar to prepareRename).