### PR TITLE
build: isolate the user environment XDG_DATA_DIRS on tests

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -10,6 +10,7 @@ set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
 set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
 set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)
 set(ENV{XDG_DATA_HOME} ${BUILD_DIR}/Xtest_xdg/share)
+unset(ENV{XDG_DATA_DIRS})
 
 if(NOT DEFINED ENV{NVIM_LOG_FILE})
   set(ENV{NVIM_LOG_FILE} ${BUILD_DIR}/.nvimlog)


### PR DESCRIPTION
# Problem
Some tests were not passing on my machine, specifically in `test/functional/api/vim_spec.lua` the two tests under `describe('nvim_get_runtime_file...` by unsetting `XDG_DATA_DIRS` I was able to solve the issue, <del>considering that this xdg directory usually contains `XDG_DATA_HOME` as well and we are already overriding, I believe this is the way.</del>

Window CI doesn't like if we set it to the same value as `XDG_DATA_HOME` let's try just unset on the env variable.

side note: never used cmake before, but seems to work, glad to fix any issue or roast.
