### PR TITLE
feat(lsp): use vim.ui.select() in codelenses

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -97,7 +97,7 @@ function M.run()
         return option.lens.command.title
       end,
     }, function(option)
-      if options then
+      if option then
         execute_lens(option.lens, bufnr, option.client)
       end
     end)

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -91,16 +91,16 @@ function M.run()
     local option = options[1]
     execute_lens(option.lens, bufnr, option.client)
   else
-    local options_strings = {"Code lenses:"}
-    for i, option in ipairs(options) do
-       table.insert(options_strings, string.format('%d. %s', i, option.lens.command.title))
-    end
-    local choice = vim.fn.inputlist(options_strings)
-    if choice < 1 or choice > #options then
-      return
-    end
-    local option = options[choice]
-    execute_lens(option.lens, bufnr, option.client)
+    vim.ui.select(options, {
+      prompt = 'Code lenses:',
+      format_item = function(option)
+        return option.lens.command.title
+      end,
+    }, function(option)
+      if options then
+        execute_lens(option.lens, bufnr, option.client)
+      end
+    end)
   end
 end
 


### PR DESCRIPTION
Use `vim.ui.select()` in codelenses which was added in #15771.
This to allows overriding the selection when `vim.codelenses.run()` is called and mutliple code lenses are available.

**For example**
<img width="529" alt="image" src="https://user-images.githubusercontent.com/423234/137023662-b3365c2d-2eda-4d41-9ab8-42c0b2015e40.png">

