### PR TITLE
fix(checkhealth provider): remove usage of list as string

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -710,7 +710,7 @@ function! s:check_perl() abort
 
   let latest_cpan = s:system(latest_cpan_cmd)
   if s:shell_error || empty(latest_cpan)
-    call health#report_error('Failed to run: '. latest_cpan_cmd,
+    call health#report_error('Failed to run: '. join(latest_cpan_cmd, " "),
           \ ["Make sure you're connected to the internet.",
           \  'Are you behind a firewall or proxy?'])
     return


### PR DESCRIPTION
I can't trigger this on my machine, don't have Perl but It's clear a List is used as a string as #15988 mentions. Since this takes down the rest of providers with it I went ahead an send this PR anyways.

Probably fixes #15988 

Just a few lines above It's defined as a List and then used as a string.

https://github.com/neovim/neovim/blob/639368a14f4e281bf8ff96bca0eb1e3a7b524846/runtime/autoload/health/provider.vim#L705-L709