### PR TITLE
ci: allow older git versions when using lintcommit

### DIFF
--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -106,7 +106,7 @@ end
 function M.main(opt)
   _trace = not opt or not not opt.trace
 
-  local branch = run({'git', 'branch', '--show-current'}, true)
+  local branch = run({'git', 'rev-parse', '--abbrev-ref', 'HEAD'}, true)
   -- TODO(justinmk): check $GITHUB_REF
   local ancestor = run({'git', 'merge-base', 'origin/master', branch})
   if not ancestor then


### PR DESCRIPTION
More specifically, use "git rev-parse --abbrev-ref HEAD" instead of "git
branch --show-current" to get current branch.