### PR TITLE
feat(api): evaluate statusline string

### DIFF
--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -51,5 +51,12 @@ return {
   runtime = {
     "is_lua";
   };
+  eval_statusline = {
+    "winid";
+    "maxwidth";
+    "fillchar";
+    "highlights";
+    "use_tabline";
+  };
 }
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1681,3 +1681,15 @@ bool set_mark(buf_T *buf, String name, Integer line, Integer col, Error *err)
   }
   return res;
 }
+
+/// Get default statusline highlight for window
+const char *get_default_stl_hl(win_T *wp)
+{
+  if (wp == NULL) {
+    return "TabLineFill";
+  } else if (wp == curwin) {
+    return "StatusLine";
+  } else {
+    return "StatusLineNC";
+  }
+}

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7379,7 +7379,7 @@ void get_trans_bufname(buf_T *buf)
 /*
  * Get the character to use in a status line.  Get its attributes in "*attr".
  */
-static int fillchar_status(int *attr, win_T *wp)
+int fillchar_status(int *attr, win_T *wp)
 {
   int fill;
   bool is_curwin = (wp == curwin);

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2367,4 +2367,79 @@ describe('API', function()
       eq({2, 2, buf.id, mark[4]}, mark)
     end)
   end)
+  describe('nvim_eval_statusline', function()
+    it('works', function()
+      eq({
+          str = '%StatusLineStringWithHighlights',
+          width = 31
+        },
+        meths.eval_statusline(
+          '%%StatusLineString%#WarningMsg#WithHighlights',
+          {}))
+    end)
+    it('doesn\'t exceed maxwidth', function()
+      eq({
+          str = 'Should be trun>',
+          width = 15
+        },
+        meths.eval_statusline(
+          'Should be truncated%<',
+          { maxwidth = 15 }))
+    end)
+    describe('highlight parsing', function()
+      it('works', function()
+        eq({
+            str = "TextWithWarningHighlightTextWithUserHighlight",
+            width = 45,
+            highlights = {
+              { start = 0, group = 'WarningMsg' },
+              { start = 24, group = 'User1' }
+            },
+          },
+          meths.eval_statusline(
+            '%#WarningMsg#TextWithWarningHighlight%1*TextWithUserHighlight',
+            { highlights = true }))
+      end)
+      it('works with no highlight', function()
+        eq({
+            str = "TextWithNoHighlight",
+            width = 19,
+            highlights = {
+              { start = 0, group = 'StatusLine' },
+            },
+          },
+          meths.eval_statusline(
+            'TextWithNoHighlight',
+            { highlights = true }))
+      end)
+      it('works with inactive statusline', function()
+        command('split')
+
+        eq({
+            str = 'TextWithNoHighlightTextWithWarningHighlight',
+            width = 43,
+            highlights = {
+              { start = 0, group = 'StatusLineNC' },
+              { start = 19, group = 'WarningMsg' }
+            }
+          },
+          meths.eval_statusline(
+            'TextWithNoHighlight%#WarningMsg#TextWithWarningHighlight',
+            { winid = meths.list_wins()[2].id, highlights = true }))
+      end)
+      it('works with tabline', function()
+        eq({
+            str = 'TextWithNoHighlightTextWithWarningHighlight',
+            width = 43,
+            highlights = {
+              { start = 0, group = 'TabLineFill' },
+              { start = 19, group = 'WarningMsg' }
+            }
+          },
+          meths.eval_statusline(
+            'TextWithNoHighlight%#WarningMsg#TextWithWarningHighlight',
+            { use_tabline = true, highlights = true }))
+      end)
+    end)
+  end)
 end)


### PR DESCRIPTION
Previously, there was no way to evaluate a statusline string through the Neovim API. This adds an API function `nvim_eval_statusline` to allow evaluating a statusline string and getting information regarding it.

Closes https://github.com/neovim/neovim/issues/15849