### PR TITLE
fix: correctly capture uri scheme on windows 

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -75,13 +75,22 @@ local function uri_from_fname(path)
 end
 
 local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):.*'
+local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):[a-zA-Z]:.*'
 
 --- Get a URI from a bufnr
 ---@param bufnr (number): Buffer number
 ---@return URI
 local function uri_from_bufnr(bufnr)
   local fname = vim.api.nvim_buf_get_name(bufnr)
-  local scheme = fname:match(URI_SCHEME_PATTERN)
+  local volume_path = fname:match("^([a-zA-Z]:).*")
+  local is_windows = volume_path ~= nil
+  local scheme
+  if is_windows then
+    fname = fname:gsub("\\", "/")
+    scheme = fname:match(WINDOWS_URI_SCHEME_PATTERN)
+  else
+    scheme = fname:match(URI_SCHEME_PATTERN)
+  end
   if scheme then
     return fname
   else

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
+local write_file = require('test.helpers').write_file
 
 describe('URI methods', function()
   before_each(function()
@@ -156,6 +157,22 @@ describe('URI methods', function()
       end)
     end)
 
+  end)
+
+  describe('uri from bufnr', function()
+    it('Windows paths should not be treated as uris', function()
+      if not helpers.iswin() then return end
+
+      local file = helpers.tmpname()
+      write_file(file, 'Test content')
+        local test_case = string.format([[
+          local file = '%s'
+          return vim.uri_from_bufnr(vim.fn.bufadd(file))
+        ]], file)
+        local expected_uri = 'file:///' .. file:gsub("\\", "/")
+        eq(expected_uri, exec_lua(test_case))
+        os.remove(file)
+    end)
   end)
 
   describe('uri to bufnr', function()


### PR DESCRIPTION
Closes: #15261
* Why are we matching to determine if the filepath is windows? Can't we just use uv.os_uname?

* I feel like some of these uri functions are a little redundant, one saves like 2 lines.
* I wish we had pcre as a dep, because then we could use the vscode regex (I'm not translating it into a vim regex)


cc @donbex 