### PR TITLE
Signal autocmd: support SIGWINCH

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -827,7 +827,8 @@ ShellCmdPost			After executing a shell command with |:!cmd|,
 							*Signal*
 Signal				After Nvim receives a signal. The pattern is
 				matched against the signal name. Only
-				"SIGUSR1" is supported.  Example: >
+				"SIGUSR1" and "SIGWINCH" are supported.
+				Example: >
 				    autocmd Signal SIGUSR1 call some#func()
 <							*ShellFilterPost*
 ShellFilterPost			After executing a shell command with

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -490,6 +490,12 @@ static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
     return;
   }
 
+  // Ask the terminal to send us the background color in case the winch is due
+  // to the terminal changing themes.
+  TUIData *tuidata = ui->data;
+  tuidata->input.waiting_for_bg_response = 5;
+  unibi_out_ext(ui, tuidata->unibi_ext.get_bg);
+
   tui_guess_size(ui);
   loop_schedule_deferred(&main_loop, event_create(sigwinch_event, 0));
   ui_schedule_refresh();

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -15,6 +15,8 @@
 
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/vim.h"
+
+#include "nvim/autocmd.h"
 #include "nvim/ascii.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/signal.h"
@@ -489,7 +491,12 @@ static void sigwinch_cb(SignalWatcher *watcher, int signum, void *data)
   }
 
   tui_guess_size(ui);
+  loop_schedule_deferred(&main_loop, event_create(sigwinch_event, 0));
   ui_schedule_refresh();
+}
+
+static void sigwinch_event(void **arg) {
+  apply_autocmds(EVENT_SIGNAL, (char_u *)"SIGWINCH" , NULL, false, curbuf);
 }
 
 static bool attrs_differ(UI *ui, int id1, int id2, bool rgb)


### PR DESCRIPTION
When my OS (macos) switches from light mode to dark mode automatically my editor (iterm2) will now switch colorschemes automatically and send `SIGWINCH` to any process that is currently running. 

I'd like to add an autocmmand for when neovim receives `SIGWINCH`, that way I can decide myself if the winch is because of resizing or because of the outside colorscheme changing and I can swap the background mode of my nvim theme myself if the latter.

I have it sort of working: 

https://user-images.githubusercontent.com/1973/137401558-1a84e119-f419-4564-89ad-49a717935be8.mp4

But it does sometimes crash neovim, so I think something is wrong. If someone can help me get on the right track, I can add tests and make this a proper PR.

Thanks for consideration.
