### PR TITLE
ci(labeler): Remove checkout steps

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,12 +19,12 @@ jobs:
       pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
-    - uses: actions/checkout@v2.3.1
-    - run: gh pr checkout ${{ github.event.pull_request.number }}
-
       # Extract type and try to add it as a label
-    - run: gh pr edit --add-label "$(echo "${{ github.event.pull_request.title }}" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')" || true
+    - run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')" || true
 
       # Extract scope and try to add it as a label
-    - run: gh pr edit --add-label "$(echo "${{ github.event.pull_request.title }}" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')" || true
+    - run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')" || true


### PR DESCRIPTION
This changes the labeler workflow, setting GH_REPO and passing PR number to `gh` instead of checking out the PR branch.

That makes the runtime for the workflow more consistent by avoiding the checkout step, which sometimes takes a while:
https://github.com/neovim/neovim/runs/3900160542?check_suite_focus=true#step:3:1
https://github.com/neovim/neovim/runs/3863568575?check_suite_focus=true#step:3:1