### PR TITLE
fix(lsp): fix cursor row after textEdits

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -335,10 +335,12 @@ function M.apply_text_edits(text_edits, bufnr)
   end
 
   if is_cursor_fixed then
-    vim.api.nvim_win_set_cursor(0, {
-      cursor.row + 1,
-      math.min(cursor.col, #(vim.api.nvim_buf_get_lines(bufnr, cursor.row, cursor.row + 1, false)[1] or ''))
-    })
+    local is_valid_cursor = true
+    is_valid_cursor = is_valid_cursor and cursor.row < vim.api.nvim_buf_line_count(bufnr)
+    is_valid_cursor = is_valid_cursor and cursor.col <= #(vim.api.nvim_buf_get_lines(bufnr, cursor.row, cursor.row + 1, false)[1] or '')
+    if is_valid_cursor then
+      vim.api.nvim_win_set_cursor(0, { cursor.row + 1, cursor.col })
+    end
   end
 
   -- Remove final line if needed

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1164,10 +1164,11 @@ describe('LSP', function()
         eq({ 2, 6 }, funcs.nvim_win_get_cursor(0))
       end)
 
-      it('fix the cursor to the valid column if the content was removed', function()
+      it('fix the cursor to the valid col if the content was removed', function()
         funcs.nvim_win_set_cursor(0, { 2, 6 })
         local edits = {
-          make_edit(1, 0, 1, 19, '')
+          make_edit(1, 0, 1, 6, ''),
+          make_edit(1, 6, 1, 19, '')
         }
         exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
         eq({
@@ -1178,6 +1179,19 @@ describe('LSP', function()
           'å å ɧ 汉语 ↥ 🤦 🦄';
         }, buf_lines(1))
         eq({ 2, 0 }, funcs.nvim_win_get_cursor(0))
+      end)
+
+      it('fix the cursor to the valid row if the content was removed', function()
+        funcs.nvim_win_set_cursor(0, { 2, 6 })
+        local edits = {
+          make_edit(1, 0, 1, 6, ''),
+          make_edit(0, 18, 5, 0, '')
+        }
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        eq({
+          'First line of text';
+        }, buf_lines(1))
+        eq({ 1, 6 }, funcs.nvim_win_get_cursor(0))
       end)
 
       it('fix the cursor row', function()


### PR DESCRIPTION
Fixes #15951

Currently, only the cursor column is fixed. However, it seems that the cursor row needs to be fixed as well.