### PR TITLE
fix(diagnostic): do not override existing config settings

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -259,7 +259,8 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                     following:
                     • `false` : Disable this feature
                     • `true` : Enable this feature, use default settings.
-                    • `table` : Enable this feature with overrides.
+                    • `table` : Enable this feature with overrides. Use an
+                      empty table to use default values.
                     • `function` : Function with signature (namespace, bufnr)
                       that returns any of the above.
 

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -254,6 +254,24 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                 Configure diagnostic options globally or for a specific
                 diagnostic namespace.
 
+                Configuration can be specified globally, per-namespace, or
+                ephemerally (i.e. only for a single call to
+                |vim.diagnostic.set()| or |vim.diagnostic.show()|). Ephemeral
+                configuration has highest priority, followed by namespace
+                configuration, and finally global configuration.
+
+                For example, if a user enables virtual text globally with >
+
+                   vim.diagnostic.config({virt_text = true})
+<
+
+                and a diagnostic producer sets diagnostics with >
+
+                   vim.diagnostic.set(ns, 0, diagnostics, {virt_text = false})
+<
+
+                then virtual text will not be enabled for those diagnostics.
+
                 Note:
                     Each of the configuration options below accepts one of the
                     following:
@@ -461,8 +479,9 @@ match({str}, {pat}, {groups}, {severity_map}, {defaults})
                 For example, consider a line of output from a linter: >
 
                  WARNING filename:27:3: Variable 'foo' does not exist
+<
 
-                < This can be parsed into a diagnostic |diagnostic-structure|
+                This can be parsed into a diagnostic |diagnostic-structure|
                 with: >
 
                  local s = "WARNING filename:27:3: Variable 'foo' does not exist"

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -557,7 +557,7 @@ end
 ---@note Each of the configuration options below accepts one of the following:
 ---         - `false`: Disable this feature
 ---         - `true`: Enable this feature, use default settings.
----         - `table`: Enable this feature with overrides.
+---         - `table`: Enable this feature with overrides. Use an empty table to use default values.
 ---         - `function`: Function with signature (namespace, bufnr) that returns any of the above.
 ---
 ---@param opts table Configuration table with the following keys:

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -554,6 +554,23 @@ end
 --- Configure diagnostic options globally or for a specific diagnostic
 --- namespace.
 ---
+--- Configuration can be specified globally, per-namespace, or ephemerally
+--- (i.e. only for a single call to |vim.diagnostic.set()| or
+--- |vim.diagnostic.show()|). Ephemeral configuration has highest priority,
+--- followed by namespace configuration, and finally global configuration.
+---
+--- For example, if a user enables virtual text globally with
+--- <pre>
+---   vim.diagnostic.config({virt_text = true})
+--- </pre>
+---
+--- and a diagnostic producer sets diagnostics with
+--- <pre>
+---   vim.diagnostic.set(ns, 0, diagnostics, {virt_text = false})
+--- </pre>
+---
+--- then virtual text will not be enabled for those diagnostics.
+---
 ---@note Each of the configuration options below accepts one of the following:
 ---         - `false`: Disable this feature
 ---         - `true`: Enable this feature, use default settings.
@@ -1287,6 +1304,7 @@ end
 --- <pre>
 --- WARNING filename:27:3: Variable 'foo' does not exist
 --- </pre>
+---
 --- This can be parsed into a diagnostic |diagnostic-structure|
 --- with:
 --- <pre>

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -473,6 +473,78 @@ describe('vim.diagnostic', function()
   end)
 
   describe('config()', function()
+    it('works with global, namespace, and ephemeral options', function()
+      eq(1, exec_lua [[
+        vim.diagnostic.config({
+          virtual_text = false,
+        })
+
+        vim.diagnostic.config({
+          virtual_text = true,
+          underline = false,
+        }, diagnostic_ns)
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+          make_error('Some Error', 4, 4, 4, 4),
+        })
+
+        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
+      ]])
+
+      eq(1, exec_lua [[
+        vim.diagnostic.config({
+          virtual_text = false,
+        })
+
+        vim.diagnostic.config({
+          virtual_text = false,
+          underline = false,
+        }, diagnostic_ns)
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+          make_error('Some Error', 4, 4, 4, 4),
+        }, {virtual_text = true})
+
+        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
+      ]])
+
+      eq(0, exec_lua [[
+        vim.diagnostic.config({
+          virtual_text = false,
+        })
+
+        vim.diagnostic.config({
+          virtual_text = {severity=vim.diagnostic.severity.ERROR},
+          underline = false,
+        }, diagnostic_ns)
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+          make_warning('Some Warning', 4, 4, 4, 4),
+        }, {virtual_text = true})
+
+        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
+      ]])
+
+      eq(1, exec_lua [[
+        vim.diagnostic.config({
+          virtual_text = false,
+        })
+
+        vim.diagnostic.config({
+          virtual_text = {severity=vim.diagnostic.severity.ERROR},
+          underline = false,
+        }, diagnostic_ns)
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+          make_warning('Some Warning', 4, 4, 4, 4),
+        }, {
+          virtual_text = {} -- An empty table uses default values
+        })
+
+        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
+      ]])
+    end)
+
     it('can use functions for config values', function()
       exec_lua [[
         vim.diagnostic.config({


### PR DESCRIPTION
When using `true` as the value of a configuration option, the option is configured to use default values. For example, if a user configures virtual text to include the source globally (using vim.diagnostic.config) and a specific namespace or producer configures virtual text with `virt_text = true`, the user's global configuration is overriden.

Instead, interpret a value of `true` to mean "use existing settings if defined, otherwise use defaults".
