### PR TITLE
fix(lsp): ignore inline carriage return

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -521,7 +521,7 @@ function M.compute_diff(old_lines, new_lines, start_line_idx, end_line_idx, offs
       start = { line = start_line - 1, character = start_char},
       ["end"] = { line = adj_end_line, character = end_char}
     },
-    text = text,
+    text = text = text:gsub("\r", " "),
     rangeLength = length + 1,
   }
 


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/15532

I don't think this is the right fix. I'd just like to start a discussion about what could be the right fix.

In the protocol: `To ensure that both client and server split the string into the same line representation the protocol specifies the following end-of-line sequences: ‘\n’, ‘\r\n’ and ‘\r’.`

The issue is, vim allows inline carriage returns (c-v c-m), this completely breaks our notion of buffer positioning. When *deleting* an inline carriage return, all language-server-node derived servers as well as sumneko will desynchronize their buffer state, as they assume that a carriage return must be EOL in accordance with the rpotocol.  This will desynchronize the neovim buffer state with the server.

The options:
* This PR: use a placeholder blank character when sending that to the server, as then the servers representation of the buffer will match that of neovim's. I don't like this "hack", because the minute we save the file to disk, the server is free to read the file with the saved `^M`/`\r`  and do whatever it wants with it, including crashing when the buffer state and the on disk state of the file diverge (see julials). Not super happy with this one.
* Internally split the buffers on carriage returns to normalize the neovim buffer state to  that which the language server protocol expects (carriage return delineates newline) and keep an internal mapping of the true 8-bit clean buffer position to the LSP compatible buffer.
* Ask to amend the protocol
* Search/replace all inline carriage returns when sending text changes with a placeholder char (like this PR does), but also ensure that when saving to disk, or first sending to the language server, these are replaced as well
* Ask users to not use plugins that use inline carriage returns, and ask users to unmap c-v c-m
* Add a mode to neovim that disallows inline carriage returns (inserts them as newlines), this may or may not break vim-surround

See also:
*  my conversation with @sumneko who was kind enough to confirm my suspicion, and point out exactly how this impacts synchronization with lua-language-server https://matrix.to/#/!JAfPjWAdLCtgeCAwnS:matrix.org/$163437861641380pkmPO:matrix.org?via=matrix.org&via=libera.chat&via=gitter.im

* this repo containing the json packets we send which reproduces the issue: https://github.com/mjlbach/test-sumneko

* the packet that causes the breakage, deleting an line `^M`
```json
{
	"jsonrpc": "2.0",
	"params": {
		"textDocument": {
			"uri": "file:\/\/\/home\/michael\/test\/main.lua",
			"version": 9
		},
		"contentChanges": [
			{
				"range": {
					"end": {
						"line": 0,
						"character": 7
					},
					"start": {
						"line": 0,
						"character": 6
					}
				},
				"rangeLength": 1,
				"text": ""
			}
		]
	},
	"method": "textDocument\/didChange"
}
```