### PR TITLE
fix: cleanup severity_sort handling in diagnostics

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1190,8 +1190,10 @@ function M.show_line_diagnostics(opts, bufnr, lnum)
   opts = opts or {}
   opts.focus_id = "line_diagnostics"
   bufnr = get_bufnr(bufnr)
-  opts.lnum = lnum or (vim.api.nvim_win_get_cursor(0)[1] - 1)
-  local line_diagnostics =  M.get(bufnr, opts)
+  local diagnostics = M.get(bufnr, opts)
+  clamp_line_numbers(bufnr, diagnostics)
+  lnum = lnum or (vim.api.nvim_win_get_cursor(0)[1] - 1)
+  local line_diagnostics = diagnostics_per_lines(diagnostics)[lnum]
   return show_diagnostics(opts, line_diagnostics)
 end
 


### PR DESCRIPTION
- Add missing docs for `vim.diagnostic.show_line_diagnostics()` and `vim.diagnostic.show_position_diagnostics()`.
- Read the value `severity_sort` if set or use the global one as a fallback.
- Use `vim.diagnostic.get()` directly in `vim.diagnostic.show_line_diagnostics()` since `lnum` is already known.
