### PR TITLE
vim-patch:8.2.3520: cannot define a function for thesaurus completion

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -804,6 +804,9 @@ CTRL-X CTRL-K		Search the files given with the 'dictionary' option
 	CTRL-P		Search backwards for next matching keyword.  This
 			keyword replaces the previous matching keyword.
 
+
+Completing words in 'thesaurus'				*compl-thesaurus*
+
 							*i_CTRL-X_CTRL-T*
 CTRL-X CTRL-T		Works as CTRL-X CTRL-K, but in a special way.  It uses
 			the 'thesaurus' option instead of 'dictionary'.  If a
@@ -812,28 +815,65 @@ CTRL-X CTRL-T		Works as CTRL-X CTRL-K, but in a special way.  It uses
 			matches, even though they don't complete the word.
 			Thus a word can be completely replaced.
 
-			For an example, imagine the 'thesaurus' file has a
-			line like this: >
-				angry furious mad enraged
-<			Placing the cursor after the letters "ang" and typing
-			CTRL-X CTRL-T would complete the word "angry";
-			subsequent presses would change the word to "furious",
-			"mad" etc.
-			Other uses include translation between two languages,
-			or grouping API functions by keyword.
-
-			If the 'thesaurusfunc' option is set, then the user
-			specified function is invoked to get the list of
-			completion matches and the 'thesaurus' option is not
-			used. See |complete-functions| for an explanation of
-			how the function is invoked and what it should return.
-
 	CTRL-T	or
 	CTRL-N		Search forward for next matching keyword.  This
 			keyword replaces the previous matching keyword.
 
 	CTRL-P		Search backwards for next matching keyword.  This
 			keyword replaces the previous matching keyword.
+
+In the file used by the 'thesaurus' option each line in the file should
+contain words with similar meaning, separated by non-keyword characters (white
+space is preferred).  Maximum line length is 510 bytes.
+
+For an example, imagine the 'thesaurus' file has a line like this: >
+	angry furious mad enraged
+<Placing the cursor after the letters "ang" and typing CTRL-X CTRL-T would
+complete the word "angry"; subsequent presses would change the word to
+"furious", "mad" etc.
+
+Other uses include translation between two languages, or grouping API
+functions by keyword.
+
+An English word list was added to this github issue:
+https://github.com/vim/vim/issues/629#issuecomment-443293282
+Unpack thesaurus_pkg.zip, put the thesaurus.txt file somewhere, e.g.
+~/.vim/thesaurus/english.txt, and the 'thesaurus' option to this file name.
+
+					
+Completing keywords with 'thesaurusfunc'		*compl-thesaurusfunc*
+
+If the 'thesaurusfunc' option is set, then the user specified function is
+invoked to get the list of completion matches and the 'thesaurus' option is
+not used. See |complete-functions| for an explanation of how the function is
+invoked and what it should return.
+
+Here is an example that uses the "aiksaurus" command (provided by Magnus
+Groß): >
+
+	func Thesaur(findstart, base)
+	    if a:findstart
+		let line = getline('.')
+		let start = col('.') - 1
+		while start > 0 && line[start - 1] =~ '\a'
+		   let start -= 1
+		endwhile
+		return start
+	    else
+		let res = []
+		let h = ''
+		for l in split(system('aiksaurus '.shellescape(a:base)), '\n')
+		    if l[:3] == '=== '
+		    	let h = substitute(l[4:], ' =*$', '', '')
+		    elseif l[0] =~ '\a'
+			call extend(res, map(split(l, ', '), {_, val -> {'word': val, 'menu': '('.h.')'}}))
+		    endif
+		endfor
+		return res
+	    endif
+	endfunc
+
+	set thesaurusfunc=Thesaur
 
 
 Completing keywords in the current and included files	*compl-keyword*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -822,6 +822,12 @@ CTRL-X CTRL-T		Works as CTRL-X CTRL-K, but in a special way.  It uses
 			Other uses include translation between two languages,
 			or grouping API functions by keyword.
 
+			If the 'thesaurusfunc' option is set, then the user
+			specified function is invoked to get the list of
+			completion matches and the 'thesaurus' option is not
+			used. See |complete-functions| for an explanation of
+			how the function is invoked and what it should return.
+
 	CTRL-T	or
 	CTRL-N		Search forward for next matching keyword.  This
 			keyword replaces the previous matching keyword.
@@ -1032,7 +1038,7 @@ CTRL-X CTRL-Z		Stop completion without changing the text.
 
 FUNCTIONS FOR FINDING COMPLETIONS			*complete-functions*
 
-This applies to 'completefunc' and 'omnifunc'.
+This applies to 'completefunc', 'thesaurusfunc' and 'omnifunc'.
 
 The function is called in two different ways:
 - First the function is called to find the start of the text to be completed.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6459,6 +6459,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	uses another default.
 	Backticks cannot be used in this option for security reasons.
 
+						*'thesaurusfunc'* *'tsrfu'*
+'thesaurusfunc' 'tsrfu'	string	(default: empty)
+			local to buffer
+	This option specifies a function to be used for thesaurus completion
+	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T|
+	See |complete-functions| for an explanation of how the function is
+	invoked and what it should return.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
 			     *'tildeop'* *'top'* *'notildeop'* *'notop'*
 'tildeop' 'top'		boolean	(default off)
 			global

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6445,27 +6445,26 @@ A jump table for the options with a short description can be found at |Q_op|.
 'thesaurus' 'tsr'	string	(default "")
 			global or local to buffer |global-local|
 	List of file names, separated by commas, that are used to lookup words
-	for thesaurus completion commands |i_CTRL-X_CTRL-T|.
+	for thesaurus completion commands |i_CTRL-X_CTRL-T|.  See
+	|compl-thesaurus|.
 
-	Each line in the file should contain words with similar meaning,
-	separated by non-keyword characters (white space is preferred).
-	Maximum line length is 510 bytes.
+	This option is not used if 'thesaurusfunc' is set, either for the
+	buffer or globally.
 
 	To include a comma in a file name precede it with a backslash.  Spaces
 	after a comma are ignored, otherwise spaces are included in the file
-	name.  See |option-backslash| about using backslashes.
-	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	directories from the list.  This avoids problems when a future version
-	uses another default.
-	Backticks cannot be used in this option for security reasons.
+	name.  See |option-backslash| about using backslashes.  The use of
+	|:set+=| and |:set-=| is preferred when adding or removing directories
+	from the list.  This avoids problems when a future version uses
+	another default.  Backticks cannot be used in this option for security
+	reasons.
 
 						*'thesaurusfunc'* *'tsrfu'*
 'thesaurusfunc' 'tsrfu'	string	(default: empty)
-			local to buffer
+			global or local to buffer |global-local|
 	This option specifies a function to be used for thesaurus completion
-	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T|
-	See |complete-functions| for an explanation of how the function is
-	invoked and what it should return.
+	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
+
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -895,6 +895,7 @@ Short explanation of each option:		*option-list*
 'terse'			    shorten some messages
 'textwidth'	  'tw'	    maximum width of text that is being inserted
 'thesaurus'	  'tsr'     list of thesaurus files for keyword completion
+'thesaurusfunc'	  'tsrfu'   function to be used for thesaurus completion
 'tildeop'	  'top'     tilde command "~" behaves like an operator
 'timeout'	  'to'	    time out on mappings and key codes
 'timeoutlen'	  'tm'	    time out time in milliseconds

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1967,7 +1967,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_cpt);
   clear_string_option(&buf->b_p_cfu);
   clear_string_option(&buf->b_p_ofu);
-  clear_string_option(&buf->b_p_thsfu);
+  clear_string_option(&buf->b_p_tsrfu);
   clear_string_option(&buf->b_p_gp);
   clear_string_option(&buf->b_p_mp);
   clear_string_option(&buf->b_p_efm);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1967,6 +1967,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_cpt);
   clear_string_option(&buf->b_p_cfu);
   clear_string_option(&buf->b_p_ofu);
+  clear_string_option(&buf->b_p_thsfu);
   clear_string_option(&buf->b_p_gp);
   clear_string_option(&buf->b_p_mp);
   clear_string_option(&buf->b_p_efm);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -698,7 +698,7 @@ struct file_buffer {
 #endif
   char_u *b_p_cfu;              ///< 'completefunc'
   char_u *b_p_ofu;              ///< 'omnifunc'
-  char_u *b_p_thsfu;            ///< 'thesaurusfunc'
+  char_u *b_p_tsrfu;            ///< 'thesaurusfunc'
   char_u *b_p_tfu;              ///< 'tagfunc'
   int b_p_eol;                  ///< 'endofline'
   int b_p_fixeol;               ///< 'fixendofline'

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -698,6 +698,7 @@ struct file_buffer {
 #endif
   char_u *b_p_cfu;              ///< 'completefunc'
   char_u *b_p_ofu;              ///< 'omnifunc'
+  char_u *b_p_thsfu;            ///< 'thesaurusfunc'
   char_u *b_p_tfu;              ///< 'tagfunc'
   int b_p_eol;                  ///< 'endofline'
   int b_p_fixeol;               ///< 'fixendofline'

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -698,7 +698,6 @@ struct file_buffer {
 #endif
   char_u *b_p_cfu;              ///< 'completefunc'
   char_u *b_p_ofu;              ///< 'omnifunc'
-  char_u *b_p_tsrfu;            ///< 'thesaurusfunc'
   char_u *b_p_tfu;              ///< 'tagfunc'
   int b_p_eol;                  ///< 'endofline'
   int b_p_fixeol;               ///< 'fixendofline'
@@ -768,6 +767,7 @@ struct file_buffer {
   unsigned b_tc_flags;          ///< flags for 'tagcase'
   char_u *b_p_dict;             ///< 'dictionary' local value
   char_u *b_p_tsr;              ///< 'thesaurus' local value
+  char_u *b_p_tsrfu;            ///< 'thesaurusfunc' local value
   long b_p_ul;                  ///< 'undolevels' local value
   int b_p_udf;                  ///< 'undofile'
   char_u *b_p_lw;               ///< 'lispwords' local value

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2071,7 +2071,7 @@ static bool check_compl_option(bool dict_opt)
 {
   if (dict_opt
       ? (*curbuf->b_p_dict == NUL && *p_dict == NUL && !curwin->w_p_spell)
-      : (*curbuf->b_p_tsr == NUL && *p_tsr == NUL && *curbuf->b_p_thsfu == NUL)) {
+      : (*curbuf->b_p_tsr == NUL && *p_tsr == NUL && *curbuf->b_p_tsrfu == NUL)) {
     ctrl_x_mode = CTRL_X_NORMAL;
     edit_submode = NULL;
     msg_attr((dict_opt
@@ -3932,7 +3932,7 @@ static char_u *get_complete_funcname(int type) {
   case CTRL_X_OMNI:
     return curbuf->b_p_ofu;
   case CTRL_X_THESAURUS:
-    return curbuf->b_p_thsfu;
+    return curbuf->b_p_tsrfu;
   default:
     return (char_u *)"";
   }
@@ -4117,8 +4117,8 @@ int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
 static int thesaurus_func_complete(int type)
 {
   return (type == CTRL_X_THESAURUS
-          && curbuf->b_p_thsfu != NULL
-          && *curbuf->b_p_thsfu != NUL);
+          && curbuf->b_p_tsrfu != NULL
+          && *curbuf->b_p_tsrfu != NUL);
 }
 
 // Get the next expansion(s), using "compl_pattern".

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -139,6 +139,7 @@ static char_u *p_cpt;
 static char_u *p_cfu;
 static char_u *p_ofu;
 static char_u *p_tfu;
+static char_u *p_thsfu;
 static int p_eol;
 static int p_fixeol;
 static int p_et;
@@ -5915,6 +5916,8 @@ static char_u *get_varp(vimoption_T *p)
     return (char_u *)&(curbuf->b_p_sw);
   case PV_TFU:
     return (char_u *)&(curbuf->b_p_tfu);
+  case PV_THSFU:
+    return (char_u *)&(curbuf->b_p_thsfu);
   case PV_TS:
     return (char_u *)&(curbuf->b_p_ts);
   case PV_TW:
@@ -6184,6 +6187,7 @@ void buf_copy_options(buf_T *buf, int flags)
 #endif
       buf->b_p_cfu = vim_strsave(p_cfu);
       buf->b_p_ofu = vim_strsave(p_ofu);
+      buf->b_p_thsfu = vim_strsave(p_thsfu);
       buf->b_p_tfu = vim_strsave(p_tfu);
       buf->b_p_sts = p_sts;
       buf->b_p_sts_nopaste = p_sts_nopaste;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5916,7 +5916,7 @@ static char_u *get_varp(vimoption_T *p)
     return (char_u *)&(curbuf->b_p_sw);
   case PV_TFU:
     return (char_u *)&(curbuf->b_p_tfu);
-  case PV_THSFU:
+  case PV_TSRFU:
     return (char_u *)&(curbuf->b_p_thsfu);
   case PV_TS:
     return (char_u *)&(curbuf->b_p_ts);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -139,7 +139,6 @@ static char_u *p_cpt;
 static char_u *p_cfu;
 static char_u *p_ofu;
 static char_u *p_tfu;
-static char_u *p_thsfu;
 static int p_eol;
 static int p_fixeol;
 static int p_et;
@@ -2036,6 +2035,7 @@ void check_buf_options(buf_T *buf)
   check_string_option(&buf->b_p_tc);
   check_string_option(&buf->b_p_dict);
   check_string_option(&buf->b_p_tsr);
+  check_string_option(&buf->b_p_tsrfu);
   check_string_option(&buf->b_p_lw);
   check_string_option(&buf->b_p_bkc);
   check_string_option(&buf->b_p_menc);
@@ -5538,6 +5538,9 @@ void unset_global_local_option(char *name, void *from)
   case PV_TSR:
     clear_string_option(&buf->b_p_tsr);
     break;
+  case PV_TSRFU:
+    clear_string_option(&buf->b_p_tsrfu);
+    break;
   case PV_FP:
     clear_string_option(&buf->b_p_fp);
     break;
@@ -5621,6 +5624,8 @@ static char_u *get_varp_scope(vimoption_T *p, int opt_flags)
       return (char_u *)&(curbuf->b_p_dict);
     case PV_TSR:
       return (char_u *)&(curbuf->b_p_tsr);
+    case PV_TSRFU:
+      return (char_u *)&(curbuf->b_p_tsrfu);
     case PV_TFU:
       return (char_u *)&(curbuf->b_p_tfu);
     case PV_SBR:
@@ -5697,6 +5702,9 @@ static char_u *get_varp(vimoption_T *p)
   case PV_TSR:
     return *curbuf->b_p_tsr != NUL
            ? (char_u *)&(curbuf->b_p_tsr) : p->var;
+  case PV_TSRFU:
+    return *curbuf->b_p_tsrfu != NUL
+           ? (char_u *)&(curbuf->b_p_tsrfu) : p->var;
   case PV_FP:
     return *curbuf->b_p_fp != NUL
            ? (char_u *)&(curbuf->b_p_fp) : p->var;
@@ -5916,8 +5924,6 @@ static char_u *get_varp(vimoption_T *p)
     return (char_u *)&(curbuf->b_p_sw);
   case PV_TFU:
     return (char_u *)&(curbuf->b_p_tfu);
-  case PV_TSRFU:
-    return (char_u *)&(curbuf->b_p_thsfu);
   case PV_TS:
     return (char_u *)&(curbuf->b_p_ts);
   case PV_TW:
@@ -6187,7 +6193,6 @@ void buf_copy_options(buf_T *buf, int flags)
 #endif
       buf->b_p_cfu = vim_strsave(p_cfu);
       buf->b_p_ofu = vim_strsave(p_ofu);
-      buf->b_p_thsfu = vim_strsave(p_thsfu);
       buf->b_p_tfu = vim_strsave(p_tfu);
       buf->b_p_sts = p_sts;
       buf->b_p_sts_nopaste = p_sts_nopaste;
@@ -6258,6 +6263,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_inex = vim_strsave(p_inex);
       buf->b_p_dict = empty_option;
       buf->b_p_tsr = empty_option;
+      buf->b_p_tsrfu = empty_option;
       buf->b_p_qe = vim_strsave(p_qe);
       buf->b_p_udf = p_udf;
       buf->b_p_lw = empty_option;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -826,6 +826,7 @@ enum {
   BV_SW,
   BV_SWF,
   BV_TFU,
+  BV_THSFU,
   BV_TAGS,
   BV_TC,
   BV_TS,

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -686,6 +686,7 @@ EXTERN long p_titlelen;         ///< 'titlelen'
 EXTERN char_u *p_titleold;      ///< 'titleold'
 EXTERN char_u *p_titlestring;   ///< 'titlestring'
 EXTERN char_u *p_tsr;           ///< 'thesaurus'
+EXTERN char_u *p_tsrfu;         ///< 'thesaurusfunc'
 EXTERN int p_tgc;               ///< 'termguicolors'
 EXTERN int p_ttimeout;          ///< 'ttimeout'
 EXTERN long p_ttm;              ///< 'ttimeoutlen'
@@ -826,7 +827,7 @@ enum {
   BV_SW,
   BV_SWF,
   BV_TFU,
-  BV_THSFU,
+  BV_TSRFU,
   BV_TAGS,
   BV_TC,
   BV_TS,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2536,6 +2536,15 @@ return {
       defaults={if_true=""}
     },
     {
+      full_name='thesaurusfunc', abbreviation='tsrfu',
+      short_desc=N_("function used for thesaurus completion"),
+      type='string', scope={'buffer'},
+      secure=true,
+      alloced=true,
+      varname='p_thsfu',
+      defaults={if_true=""}
+    },
+    {
       full_name='tildeop', abbreviation='top',
       short_desc=N_("tilde command \"~\" behaves like an operator"),
       type='bool', scope={'global'},

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2538,10 +2538,10 @@ return {
     {
       full_name='thesaurusfunc', abbreviation='tsrfu',
       short_desc=N_("function used for thesaurus completion"),
-      type='string', scope={'buffer'},
+      type='string', scope={'global', 'buffer'},
       secure=true,
       alloced=true,
-      varname='p_thsfu',
+      varname='p_tsrfu',
       defaults={if_true=""}
     },
     {

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -870,6 +870,48 @@ func Test_edit_CTRL_T()
   bw!
 endfunc
 
+" Test 'thesaurusfunc'
+func MyThesaurus(findstart, base)
+  let mythesaurus = [
+        \ #{word: "happy",
+        \   synonyms: "cheerful,blissful,flying high,looking good,peppy"},
+        \ #{word: "kind",
+        \   synonyms: "amiable,bleeding-heart,heart in right place"}]
+  if a:findstart
+    " locate the start of the word
+    let line = getline('.')
+    let start = col('.') - 1
+    while start > 0 && line[start - 1] =~ '\a'
+      let start -= 1
+    endwhile
+    return start
+  else
+    " find strings matching with "a:base"
+    let res = []
+    for w in mythesaurus
+      if w.word =~ '^' . a:base
+        call add(res, w.word)
+        call extend(res, split(w.synonyms, ","))
+      endif
+    endfor
+    return res
+  endif
+endfunc
+
+func Test_thesaurus_func()
+  new
+  set thesaurus=
+  set thesaurusfunc=MyThesaurus
+  call setline(1, "an ki")
+  call cursor(1, 1)
+  call feedkeys("A\<c-x>\<c-t>\<c-n>\<cr>\<esc>", 'tnix')
+  call assert_equal(['an amiable', ''], getline(1, '$'))
+  set thesaurusfunc=NonExistingFunc
+  call assert_fails("normal $a\<C-X>\<C-T>", 'E117:')
+  set thesaurusfunc&
+  %bw!
+endfunc
+
 func Test_edit_CTRL_U()
   " Test 'completefunc'
   new

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -900,16 +900,24 @@ endfunc
 
 func Test_thesaurus_func()
   new
-  set thesaurus=
-  set thesaurusfunc=MyThesaurus
+  set thesaurus=notused
+  set thesaurusfunc=NotUsed
+  setlocal thesaurusfunc=MyThesaurus
   call setline(1, "an ki")
   call cursor(1, 1)
   call feedkeys("A\<c-x>\<c-t>\<c-n>\<cr>\<esc>", 'tnix')
   call assert_equal(['an amiable', ''], getline(1, '$'))
+
+  setlocal thesaurusfunc=NonExistingFunc
+  call assert_fails("normal $a\<C-X>\<C-T>", 'E117:')
+
+  setlocal thesaurusfunc=
   set thesaurusfunc=NonExistingFunc
   call assert_fails("normal $a\<C-X>\<C-T>", 'E117:')
-  set thesaurusfunc&
   %bw!
+
+  set thesaurusfunc=
+  set thesaurus=
 endfunc
 
 func Test_edit_CTRL_U()

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -209,7 +209,7 @@ func Test_set_completion()
 
   " Expand abbreviation of options.
   call feedkeys(":set ts\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set tabstop thesaurus', @:)
+  call assert_equal('"set tabstop thesaurus thesaurusfunc', @:)
 
   " Expand current value
   call feedkeys(":set fileencodings=\<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
Problem:    Cannot define a function for thesaurus completion.
Solution:   Add 'thesaurusfunc'. (Yegappan Lakshmanan, closes vim/vim#8987,
            closes 8950)
https://github.com/vim/vim/commit/160e994d768d03a3c826b58115cde94df8fce607