### PR TITLE
vim-patch:8.2.3522: cannot use \x and \u when setting 'listchars'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3792,6 +3792,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The characters ':' and ',' should not be used.  UTF-8 characters can
 	be used.  All characters must be single width.
 
+	Each character can be specified as hex: >
+		set listchars=eol:\\x24
+		set listchars=eol:\\u21b5
+		set listchars=eol:\\U000021b5
+<	Note that a double backslash is used.  The number of hex characters
+	must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
+
 	Examples: >
 	    :set lcs=tab:>-,trail:-
 	    :set lcs=tab:>-,eol:<,nbsp:%

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1642,6 +1642,16 @@ int hex2nr(int c)
   return c - '0';
 }
 
+/// Convert two hex characters to a byte.
+/// Return -1 if one of the characters is not hex.
+int hexhex2nr(char_u *p)
+{
+  if (!ascii_isxdigit(p[0]) || !ascii_isxdigit(p[1])) {
+    return -1;
+  }
+  return (hex2nr(p[0]) << 4) + hex2nr(p[1]);
+}
+
 /// Check that "str" starts with a backslash that should be removed.
 /// For Windows this is only done when the character after the
 /// backslash is not a normal file name character.

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -286,6 +286,10 @@ func Test_listchars_unicode()
   call cursor(1, 1)
   call assert_equal(expected, ScreenLines(1, virtcol('$')))
 
+  set listchars=eol:\\u21d4,space:\\u2423,multispace:≡\\u2262\\U00002263,nbsp:\\U00002260,tab:←↔\\u2192
+  redraw!
+  call assert_equal(expected, ScreenLines(1, virtcol('$')))
+
   set listchars+=lead:⇨,trail:⇦
   let expected = ['⇨⇨⇨⇨⇨⇨⇨⇨a←↔↔↔↔↔→b␣c≠d⇦⇦⇔']
   redraw!


### PR DESCRIPTION
#### vim-patch:8.2.3522: cannot use \x and \u when setting 'listchars'
Problem:    Cannot use \x and \u when setting 'listchars'.
Solution:   Support hex and unicode in hex form.
https://github.com/vim/vim/commit/93ff6720fe4427341bc426b6d46e6324f226c270
