### PR TITLE
refactor(diagnostic)!: replace 'show_*' functions with 'open_float'

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -262,12 +262,12 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
 
                 For example, if a user enables virtual text globally with >
 
-                   vim.diagnostic.config({virt_text = true})
+                   vim.diagnostic.config({virt_textual = true})
 <
 
                 and a diagnostic producer sets diagnostics with >
 
-                   vim.diagnostic.set(ns, 0, diagnostics, {virt_text = false})
+                   vim.diagnostic.set(ns, 0, diagnostics, {virt_textual = false})
 <
 
                 then virtual text will not be enabled for those diagnostics.
@@ -302,7 +302,7 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                    • format: (function) A function that takes
                                      a diagnostic as input and returns a
                                      string. The return value is the text used
-                                     to display the diagnostic. Example:>
+                                     to display the diagnostic. Example: >
 
                                        function(diagnostic)
                                          if diagnostic.severity == vim.diagnostic.severity.ERROR then
@@ -323,6 +323,18 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      a sign is adjusted based on its severity.
                                      Otherwise, all signs use the same
                                      priority.
+
+                                 • float: Options for floating windows:
+                                   • severity: See |diagnostic-severity|.
+                                   • show_header: (boolean, default true) Show
+                                     "Diagnostics:" header
+                                   • source: (string) Include the diagnostic
+                                     source in the message. One of "always" or
+                                     "if_many".
+                                   • format: (function) A function that takes
+                                     a diagnostic as input and returns a
+                                     string. The return value is the text used
+                                     to display the diagnostic.
 
                                  • update_in_insert: (default false) Update
                                    diagnostics in Insert mode (if false,
@@ -442,12 +454,10 @@ goto_next({opts})                                 *vim.diagnostic.goto_next()*
                             • wrap: (boolean, default true) Whether to loop
                               around file or not. Similar to 'wrapscan'.
                             • severity: See |diagnostic-severity|.
-                            • enable_popup: (boolean, default true) Call
-                              |vim.diagnostic.show_line_diagnostics()| on
-                              jump.
-                            • popup_opts: (table) Table to pass as {opts}
-                              parameter to
-                              |vim.diagnostic.show_line_diagnostics()|
+                            • float: (boolean or table, default true) If
+                              |TRUE|, call |vim.diagnostic.open_float()| after
+                              moving. If a table, pass the table as the {opts}
+                              parameter to |vim.diagnostic.open_float()|.
                             • win_id: (number, default 0) Window ID
 
 goto_prev({opts})                                 *vim.diagnostic.goto_prev()*
@@ -507,6 +517,46 @@ match({str}, {pat}, {groups}, {severity_map}, {defaults})
                 Return: ~
                     diagnostic |diagnostic-structure| or `nil` if {pat} fails
                     to match {str}.
+
+open_float({bufnr}, {opts})                      *vim.diagnostic.open_float()*
+                Show diagnostics in a floating window.
+
+                Parameters: ~
+                    {bufnr}  number|nil Buffer number. Defaults to the current
+                             buffer.
+                    {opts}   table|nil Configuration table with the same keys
+                             as |vim.lsp.util.open_floating_preview()| in
+                             addition to the following:
+                             • namespace: (number) Limit diagnostics to the
+                               given namespace
+                             • scope: (string, default "buffer") Show
+                               diagnostics from the whole buffer ("buffer"),
+                               the current cursor line ("line"), or the
+                               current cursor position ("cursor").
+                             • pos: (number or table) If {scope} is "line" or
+                               "cursor", use this position rather than the
+                               cursor position. If a number, interpreted as a
+                               line number; otherwise, a (row, col) tuple.
+                             • severity_sort: (default false) Sort diagnostics
+                               by severity. Overrides the setting from
+                               |vim.diagnostic.config()|.
+                             • severity: See |diagnostic-severity|. Overrides
+                               the setting from |vim.diagnostic.config()|.
+                             • show_header: (boolean, default true) Show
+                               "Diagnostics:" header. Overrides the setting
+                               from |vim.diagnostic.config()|.
+                             • source: (string) Include the diagnostic source
+                               in the message. One of "always" or "if_many".
+                               Overrides the setting from
+                               |vim.diagnostic.config()|.
+                             • format: (function) A function that takes a
+                               diagnostic as input and returns a string. The
+                               return value is the text used to display the
+                               diagnostic. Overrides the setting from
+                               |vim.diagnostic.config()|.
+
+                Return: ~
+                    tuple ({float_bufnr}, {win_id})
 
 reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
                 Remove all diagnostics from the given namespace.
@@ -580,51 +630,6 @@ show({namespace}, {bufnr}, {diagnostics}, {opts})
                                    subset of diagnostics.
                     {opts}         table|nil Display options. See
                                    |vim.diagnostic.config()|.
-
-                                      *vim.diagnostic.show_line_diagnostics()*
-show_line_diagnostics({opts}, {bufnr}, {lnum})
-                Open a floating window with the diagnostics from the given
-                line.
-
-                Parameters: ~
-                    {opts}   table Configuration table. See
-                             |vim.diagnostic.show_position_diagnostics()|.
-                    {bufnr}  number|nil Buffer number. Defaults to the current
-                             buffer.
-                    {lnum}   number|nil Line number. Defaults to line number
-                             of cursor.
-
-                Return: ~
-                    tuple ({popup_bufnr}, {win_id})
-
-                                  *vim.diagnostic.show_position_diagnostics()*
-show_position_diagnostics({opts}, {bufnr}, {position})
-                Open a floating window with the diagnostics at the given
-                position.
-
-                Parameters: ~
-                    {opts}      table|nil Configuration table with the same
-                                keys as |vim.lsp.util.open_floating_preview()|
-                                in addition to the following:
-                                • namespace: (number) Limit diagnostics to the
-                                  given namespace
-                                • severity: See |diagnostic-severity|.
-                                • show_header: (boolean, default true) Show
-                                  "Diagnostics:" header
-                                • source: (string) Include the diagnostic
-                                  source in the message. One of "always" or
-                                  "if_many".
-                                • format: (function) A function that takes a
-                                  diagnostic as input and returns a string.
-                                  The return value is the text used to display
-                                  the diagnostic.
-                    {bufnr}     number|nil Buffer number. Defaults to the
-                                current buffer.
-                    {position}  table|nil The (0,0)-indexed position. Defaults
-                                to the current cursor position.
-
-                Return: ~
-                    tuple ({popup_bufnr}, {win_id})
 
 toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
                 Convert a list of diagnostics to a list of quickfix items that

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -262,12 +262,12 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
 
                 For example, if a user enables virtual text globally with >
 
-                   vim.diagnostic.config({virt_textual = true})
+                   vim.diagnostic.config({virtual_text = true})
 <
 
                 and a diagnostic producer sets diagnostics with >
 
-                   vim.diagnostic.set(ns, 0, diagnostics, {virt_textual = false})
+                   vim.diagnostic.set(ns, 0, diagnostics, {virtual_text = false})
 <
 
                 then virtual text will not be enabled for those diagnostics.
@@ -455,7 +455,7 @@ goto_next({opts})                                 *vim.diagnostic.goto_next()*
                               around file or not. Similar to 'wrapscan'.
                             • severity: See |diagnostic-severity|.
                             • float: (boolean or table, default true) If
-                              |TRUE|, call |vim.diagnostic.open_float()| after
+                              "true", call |vim.diagnostic.open_float()| after
                               moving. If a table, pass the table as the {opts}
                               parameter to |vim.diagnostic.open_float()|.
                             • win_id: (number, default 0) Window ID

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -19,6 +19,7 @@ local global_diagnostic_options = {
   signs = true,
   underline = true,
   virtual_text = true,
+  float = true,
   update_in_insert = false,
   severity_sort = false,
 }
@@ -154,7 +155,7 @@ end
 ---@private
 local function get_resolved_options(opts, namespace, bufnr)
   local ns = namespace and get_namespace(namespace) or {}
-  local resolved = vim.tbl_extend('keep', opts or {}, ns.opts or {}, global_diagnostic_options)
+  local resolved = vim.tbl_deep_extend('keep', opts or {}, ns.opts or {}, global_diagnostic_options)
   for k in pairs(global_diagnostic_options) do
     if resolved[k] ~= nil then
       resolved[k] = resolve_optional_value(k, resolved[k], namespace, bufnr)

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -551,14 +551,15 @@ end
 ---@param position table|nil The (0,0)-indexed position
 ---@return table {popup_bufnr, win_id}
 function M.show_position_diagnostics(opts, buf_nr, position)
-  if opts then
-    if opts.severity then
-      opts.severity = severity_lsp_to_vim(opts.severity)
-    elseif opts.severity_limit then
-      opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
-    end
+  opts = opts or {}
+  opts.where = "cursor"
+  opts.pos = position
+  if opts.severity then
+    opts.severity = severity_lsp_to_vim(opts.severity)
+  elseif opts.severity_limit then
+    opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
   end
-  return vim.diagnostic.show_position_diagnostics(opts, buf_nr, position)
+  return vim.diagnostic.open_float(buf_nr, opts)
 end
 
 --- Open a floating window with the diagnostics from {line_nr}
@@ -573,11 +574,13 @@ end
 ---@param client_id number|nil the client id
 ---@return table {popup_bufnr, win_id}
 function M.show_line_diagnostics(opts, buf_nr, line_nr, client_id)
+  opts = opts or {}
+  opts.where = "line"
+  opts.pos = line_nr
   if client_id then
-    opts = opts or {}
     opts.namespace = M.get_namespace(client_id)
   end
-  return vim.diagnostic.show_line_diagnostics(opts, buf_nr, line_nr)
+  return vim.diagnostic.open_float(buf_nr, opts)
 end
 
 --- Redraw diagnostics for the given buffer and client


### PR DESCRIPTION
`show_line_diagnostics()` and `show_position_diagnostics()` are almost identical; they differ only in the fact that the latter also accepts a column to form a full position, rather than just a line. This is not enough to justify two separate interfaces for this common functionality.

Renaming this to simply `show_diagnostics()` is one step forward, but that is also not a good name as the `_diagnostics()` suffix is redundant. However, we cannot name it simply `show()` since that function already exists with entirely different semantics.

Instead, combine these two into a single `open_float()` function that handles all of the cases of previewing diagnostics in a floating window. Also add a "float" key to `vim.diagnostic.config()` to provide global values of configuration options that can be overridden ephemerally. This makes the preview API consistent with the rest of the diagnostic API.

**This is a breaking change.**

Differences in API usage:

| **Before** | **After** |
| ---- | --- |
| `vim.diagnostic.show_line_diagnostics()` | `vim.diagnostic.open_float(0, {scope="line"})` |
| `vim.diagnostic.show_position_diagnostics()` | `vim.diagnostic.open_float(0, {scope="cursor"})` |
| `vim.diagnostic.goto_next { enable_popup = true, popup_opts = {...}` | `vim.diagnostic.goto_next { float = {...} }` |
| `vim.diagnostic.show_line_diagnostics({opts}, buffer, 17)` | `vim.diagnostic.open_float(buffer, {{opts}, scope="line", pos=17}` |
| `vim.diagnostic.show_position_diagnositcs({opts}, buffer, {row, col})` | `vim.diagnostic.open_float(buffer, {{opts}, scope="cursor", pos={row, col}}` |
