### PR TITLE
Note currently supported JSON-RPC channels in :help.

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -230,7 +230,7 @@ function default_dispatchers.on_error(code, err)
 end
 
 --- Starts an LSP server process and create an LSP RPC client object to
---- interact with it. Interactions are currently limited to stdin/stdout.
+--- interact with it. Communication with the server is currently limited to stdio.
 ---
 ---@param cmd (string) Command to start the LSP server.
 ---@param cmd_args (table) List of additional string arguments to pass to {cmd}.

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -230,7 +230,7 @@ function default_dispatchers.on_error(code, err)
 end
 
 --- Starts an LSP server process and create an LSP RPC client object to
---- interact with it.
+--- interact with it. Interactions are currently limited to stdin/stdout.
 ---
 ---@param cmd (string) Command to start the LSP server.
 ---@param cmd_args (table) List of additional string arguments to pass to {cmd}.


### PR DESCRIPTION
This just notes explicitly in :help that neovim talks to LSP servers over stdio currently (per discussion with @mjlbach on the neovim channel).

