### PR TITLE
docs: 'cdpath' is also used for :tcd

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1159,9 +1159,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'cdpath' 'cd'		string	(default: equivalent to $CDPATH or ",,")
 			global
 	This is a list of directories which will be searched when using the
-	|:cd| and |:lcd| commands, provided that the directory being searched
-	for has a relative path, not an absolute part starting with "/", "./"
-	or "../", the 'cdpath' option is not used then.
+	|:cd|, |:tcd| and |:lcd| commands, provided that the directory being
+	searched for has a relative path, not an absolute part starting with
+	"/", "./" or "../", the 'cdpath' option is not used then.
 	The 'cdpath' option's value has the same form and semantics as
 	|'path'|.  Also see |file-searching|.
 	The default value is taken from $CDPATH, with a "," prepended to look


### PR DESCRIPTION
Ref https://github.com/vim/vim/commit/00aa069db8132851a91cfc5ca7f58ef945c75c73#diff-442131dbc53d601ff38edcc95c73c09272934f92f7cf6601738cc6ceaf8a1e48