### PR TITLE
fix(shada): remove deleted marks from shada

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -52,9 +52,6 @@
  * shada).
  */
 
-/// Global marks (marks with file number or name)
-static xfmark_T namedfm[NGLOBALMARKS];
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "mark.c.generated.h"
 #endif
@@ -979,6 +976,7 @@ void ex_delmarks(exarg_T *eap)
         for (i = from; i <= to; ++i) {
           if (lower) {
             curbuf->b_namedm[i - 'a'].mark.lnum = 0;
+            curbuf->b_namedm[i - 'a'].timestamp = os_time();
           } else {
             if (digit) {
               n = i - '0' + NMARKS;
@@ -987,17 +985,24 @@ void ex_delmarks(exarg_T *eap)
             }
             namedfm[n].fmark.mark.lnum = 0;
             namedfm[n].fmark.fnum = 0;
+            namedfm[n].fmark.timestamp = os_time();
             XFREE_CLEAR(namedfm[n].fname);
           }
         }
       } else {
         switch (*p) {
         case '"':
-          CLEAR_FMARK(&curbuf->b_last_cursor); break;
+          curbuf->b_last_cursor.timestamp = os_time();
+          CLEAR_FMARK(&curbuf->b_last_cursor);
+          break;
         case '^':
-          CLEAR_FMARK(&curbuf->b_last_insert); break;
+          curbuf->b_last_insert.timestamp = os_time();
+          CLEAR_FMARK(&curbuf->b_last_insert);
+          break;
         case '.':
-          CLEAR_FMARK(&curbuf->b_last_change); break;
+          curbuf->b_last_change.timestamp = os_time();
+          CLEAR_FMARK(&curbuf->b_last_change);
+          break;
         case '[':
           curbuf->b_op_start.lnum    = 0; break;
         case ']':

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -87,5 +87,7 @@ typedef struct xfilemark {
 } xfmark_T;
 
 #define INIT_XFMARK { INIT_FMARK, NULL }
+/// Global marks (marks with file number or name)
+EXTERN xfmark_T namedfm[NGLOBALMARKS] INIT(= { 0 });
 
 #endif // NVIM_MARK_DEFS_H

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2173,6 +2173,12 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
           shada_free_shada_entry(&entry);
           break;
         }
+        if (wms->global_marks[idx].data.type == kSDItemMissing) {
+          if (namedfm[idx].fmark.timestamp >= entry.timestamp) {
+            shada_free_shada_entry(&entry);
+            break;
+          }
+        }
         COMPARE_WITH_ENTRY(&wms->global_marks[idx], entry);
       }
       break;
@@ -2203,6 +2209,7 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
             entry;
         } else {
           PossiblyFreedShadaEntry *const wms_entry = &filemarks->marks[idx];
+          bool set_wms = true;
           if (wms_entry->data.type != kSDItemMissing) {
             if (wms_entry->data.timestamp >= entry.timestamp) {
               shada_free_shada_entry(&entry);
@@ -2215,8 +2222,23 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
               }
               shada_free_shada_entry(&wms_entry->data);
             }
+          } else {
+            FOR_ALL_BUFFERS(buf) {
+              if (buf->b_ffname != NULL
+                  && FNAMECMP(entry.data.filemark.fname, buf->b_ffname) == 0) {
+                fmark_T fm;
+                mark_get(buf, curwin, &fm, kMarkBufLocal, (int)entry.data.filemark.name);
+                if (fm.timestamp >= entry.timestamp) {
+                  set_wms = false;
+                  shada_free_shada_entry(&entry);
+                  break;
+                }
+              }
+            }
           }
-          *wms_entry = pfs_entry;
+          if (set_wms) {
+            *wms_entry = pfs_entry;
+          }
         }
       } else {
 #define FREE_POSSIBLY_FREED_SHADA_ENTRY(entry) \

--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local meths, curwinmeths, curbufmeths, nvim_command, funcs, eq =
   helpers.meths, helpers.curwinmeths, helpers.curbufmeths, helpers.command,
   helpers.funcs, helpers.eq
+local feed = helpers.feed
 local exc_exec, exec_capture = helpers.exc_exec, helpers.exec_capture
 local expect_exit = helpers.expect_exit
 
@@ -247,5 +248,27 @@ describe('ShaDa support code', function()
     }
     eq('', funcs.system(argv))
     eq(0, exc_exec('rshada'))
+  end)
+
+  it("updates deleted marks", function()
+    nvim_command("edit " .. testfilename)
+
+    nvim_command("mark A")
+    nvim_command("mark a")
+    -- create a change to set the '.' mark,
+    -- since it can't be set via :mark
+    feed("ggi <esc>")
+    nvim_command("wshada")
+
+    nvim_command("delmarks A")
+    nvim_command("delmarks a")
+    nvim_command("delmarks .")
+
+    nvim_command("wshada")
+    nvim_command("rshada")
+
+    eq("Vim(normal):E20: Mark not set", exc_exec("normal! `A"))
+    eq("Vim(normal):E20: Mark not set", exc_exec("normal! `a"))
+    eq("Vim(normal):E20: Mark not set", exc_exec("normal! `."))
   end)
 end)


### PR DESCRIPTION
When a mark is deleted in the neovim instance but present in the shada file, compare their timestamps. If the neovim mark was modified later, then flush the mark in the shada file.

Currently works with lower/uppercase marks; doesn't work for file marks and special marks like `"` and `.`.

Attempts to fix #4295.