### PR TITLE
man.vim: convert spaces to underscores

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -197,13 +197,21 @@ function! s:extract_sect_and_name_ref(ref) abort
     if empty(name)
       throw 'manpage reference cannot contain only parentheses'
     endif
-    return ['', name]
+    return ['', s:spaces_to_underscores(name)]
   endif
   let left = split(ref, '(')
   " see ':Man 3X curses' on why tolower.
   " TODO(nhooyr) Not sure if this is portable across OSs
   " but I have not seen a single uppercase section.
-  return [tolower(split(left[1], ')')[0]), left[0]]
+  return [tolower(split(left[1], ')')[0]), s:spaces_to_underscores(left[0])]
+endfunction
+
+" replace spaces in a man page name with underscores
+" intended for PostgreSQL, which has man pages like 'CREATE_TABLE(7)';
+" while editing SQL source code, it's nice to visually select 'CREATE TABLE'
+" and hit 'K', which requires this transformation
+function! s:spaces_to_underscores(str)
+  return substitute(a:str, ' ', '_', 'g')
 endfunction
 
 function! s:get_path(sect, name) abort


### PR DESCRIPTION
PostgreSQL ships with man pages for SQL statements like `CREATE TABLE`,
which are provided with underscores as `man 7 CREATE_TABLE`. This patch
updates `man#open_page` (as used by `:Man`) such that visually selecting
the words `CREATE TABLE` in SQL code and pressing `K` properly opens the
desired man page.

Writing `:Man CREATE TABLE` still does not work, since `CREATE` is
interpreted as a section name. (Similarly, `:Man CREATE TABLE AS` fails
because there are too many arguments to `:Man`.) But this is okay,
because if you're typing it anyway then you can just enter underscores
and also tab-completion properly suggests `:Man CREATE_TABLE(7)`.

This is a bit bespoke, but my box has over 9000 man pages (as reported
by `man -k '' | wc -l`), and not one of them has a space in the man page
name, whereas the Postgres manuals do exist and are actually useful.

Test Plan:
On a machine with Postgres manual pages, running

    nvim -u NORC +'exe "norm iCREATE TABLE foo(x int);" | norm 0veeK'

should open the appropriate man page.

wchargin-branch: man-spaces-to-underscores
