### PR TITLE
fix(lsp): persist diagnostic config for clients

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -211,9 +211,12 @@ function M.on_publish_diagnostics(_, result, ctx, config)
         end
       end
     end
+
+    -- Persist configuration for this client
+    vim.diagnostic.config(config, namespace)
   end
 
-  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id), config)
+  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
 
   -- Keep old autocmd for back compat. This should eventually be removed.
   vim.api.nvim_command("doautocmd <nomodeline> User LspDiagnosticsChanged")

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -212,7 +212,9 @@ function M.on_publish_diagnostics(_, result, ctx, config)
       end
     end
 
-    -- Persist configuration for this client
+    -- Persist configuration to ensure buffer reloads use the same
+    -- configuration. To make lsp.with configuration work (See :help
+    -- lsp-handler-configuration)
     vim.diagnostic.config(config, namespace)
   end
 


### PR DESCRIPTION
Persist configuration settings set with `vim.lsp.with` and `vim.lsp.diagnostic.on_publish_diagnostics` by setting the config for the namespace associated with the client.

Ref: https://github.com/neovim/neovim/pull/16043#issuecomment-945832662

@mfussenegger 