### PR TITLE
ci(typo): correct extraction of co-authors

### DIFF
--- a/scripts/squash_typos.py
+++ b/scripts/squash_typos.py
@@ -211,11 +211,9 @@ def main():
     rebase_onto_master()
     force_push(pr_branch)
 
-    message_body_before = "\n".join(
-        subprocess.check_output(
-            ["git", "log", "--format=%B", "-n1", pr_branch], text=True
-        ).splitlines()[2:]
-    )
+    message_body_before = subprocess.check_output(
+        ["git", "log", "--format=%B", "-n1", pr_branch], text=True
+    ).split("\n\n")[-1]
 
     rebase_onto_pr()
     force_push(pr_branch)


### PR DESCRIPTION
Forgot commit messages can be longer than 1 line. No, I don't wanna talk about it.