### PR TITLE
vim-patch:8.2.3537: mode() does not return the right value in 'operatorfunc'

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2167,6 +2167,7 @@ static void op_function(const oparg_T *oap)
   FUNC_ATTR_NONNULL_ALL
 {
   const TriState save_virtual_op = virtual_op;
+  const bool save_finish_op = finish_op;
 
   if (*p_opfunc == NUL) {
     EMSG(_("E774: 'operatorfunc' is empty"));
@@ -2193,9 +2194,13 @@ static void op_function(const oparg_T *oap)
     // function.
     virtual_op = kNone;
 
+    // Reset finish_op so that mode() returns the right value.
+    finish_op = false;
+
     (void)call_func_retnr(p_opfunc, 1, argv);
 
     virtual_op = save_virtual_op;
+    finish_op = save_finish_op;
   }
 }
 

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -711,6 +711,20 @@ func Test_mode()
   call assert_equal('c-cv', g:current_modes)
   " How to test Ex mode?
 
+  " Test mode in operatorfunc (it used to be Operator-pending).
+  set operatorfunc=OperatorFunc
+  function OperatorFunc(_)
+    call Save_mode()
+  endfunction
+  execute "normal! g@l\<Esc>"
+  call assert_equal('n-n', g:current_modes)
+  execute "normal! i\<C-o>g@l\<Esc>"
+  call assert_equal('n-niI', g:current_modes)
+  execute "normal! R\<C-o>g@l\<Esc>"
+  call assert_equal('n-niR', g:current_modes)
+  execute "normal! gR\<C-o>g@l\<Esc>"
+  call assert_equal('n-niV', g:current_modes)
+
   if has('terminal')
     term
     call feedkeys("\<C-W>N", 'xt')
@@ -723,6 +737,8 @@ func Test_mode()
   iunmap <F2>
   xunmap <F2>
   set complete&
+  set operatorfunc&
+  delfunction OperatorFunc
 endfunc
 
 func Test_append()


### PR DESCRIPTION
#### vim-patch:8.2.3537: mode() does not return the right value in 'operatorfunc'

Problem:    mode() does not return the right value in 'operatorfunc'.
Solution:   Reset finish_op while calling 'operatorfunc'.
https://github.com/vim/vim/commit/75c30e96cf280a8cc01ac01c41a9252db3e503cc