### PR TITLE
fix(gen_vimdoc.py): spacing around inline elements

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1877,7 +1877,7 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                                    callbacks.
                     {opts}         Optional parameters.
                                    • on_lines: Lua callback invoked on change.
-                                     Return`true`to detach. Args:
+                                     Return `true` to detach. Args:
                                      • the string "lines"
                                      • buffer handle
                                      • b:changedtick
@@ -1893,7 +1893,7 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                                    • on_bytes: lua callback invoked on change.
                                      This callback receives more granular
                                      information about the change compared to
-                                     on_lines. Return`true`to detach. Args:
+                                     on_lines. Return `true` to detach. Args:
                                      • the string "bytes"
                                      • buffer handle
                                      • b:changedtick
@@ -2332,7 +2332,7 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                               • hl_mode : control how highlights are combined
                                 with the highlights of the text. Currently
                                 only affects virt_text highlights, but might
-                                affect`hl_group`in later versions.
+                                affect `hl_group` in later versions.
                                 • "replace": only show the virt_text color.
                                   This is the default
                                 • "combine": combine with background text
@@ -2742,28 +2742,29 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                     {buffer}  Buffer to display, or 0 for current buffer
                     {enter}   Enter the window (make it the current window)
                     {config}  Map defining the window configuration. Keys:
-                              • `relative`: Sets the window layout to "floating", placed
-                                at (row,col) coordinates relative to:
+                              • relative: Sets the window layout to
+                                "floating", placed at (row,col) coordinates
+                                relative to:
                                 • "editor" The global editor grid
                                 • "win" Window given by the `win` field, or
                                   current window.
                                 • "cursor" Cursor position in current window.
 
-                              • `win` : |window-ID| for relative="win".
-                              • `anchor`: Decides which corner of the float to place
-                                at (row,col):
+                              • win: |window-ID| for relative="win".
+                              • anchor: Decides which corner of the float to
+                                place at (row,col):
                                 • "NW" northwest (default)
                                 • "NE" northeast
                                 • "SW" southwest
                                 • "SE" southeast
 
-                              • `width` : Window width (in character cells).
+                              • width: Window width (in character cells).
                                 Minimum of 1.
-                              • `height` : Window height (in character cells).
+                              • height: Window height (in character cells).
                                 Minimum of 1.
-                              • `bufpos`: Places float relative to buffer text (only
-                                when relative="win"). Takes a tuple of
-                                zero-indexed [line, column].`row`and`col`if given are applied relative to this
+                              • bufpos: Places float relative to buffer text
+                                (only when relative="win"). Takes a tuple of
+                                zero-indexed [line, column]. `row` and `col` if given are applied relative to this
                                 position, else they default to:
                                 • `row=1` and `col=0` if `anchor` is "NW" or
                                   "NE"
@@ -2771,19 +2772,19 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                                   "SE" (thus like a tooltip near the buffer
                                   text).
 
-                              • `row` : Row position in units of "screen cell
+                              • row: Row position in units of "screen cell
                                 height", may be fractional.
-                              • `col` : Column position in units of "screen
-                                cell width", may be fractional.
-                              • `focusable` : Enable focus by user actions
+                              • col: Column position in units of "screen cell
+                                width", may be fractional.
+                              • focusable: Enable focus by user actions
                                 (wincmds, mouse events). Defaults to true.
                                 Non-focusable windows can be entered by
                                 |nvim_set_current_win()|.
-                              • `external` : GUI should display the window as
-                                an external top-level window. Currently
-                                accepts no other positioning configuration
-                                together with this.
-                              • `zindex`: Stacking order. floats with higher`zindex`go on top on floats with lower indices. Must
+                              • external: GUI should display the window as an
+                                external top-level window. Currently accepts
+                                no other positioning configuration together
+                                with this.
+                              • zindex: Stacking order. floats with higher `zindex` go on top on floats with lower indices. Must
                                 be larger than zero. The following screen
                                 elements have hard-coded z-indices:
                                 • 100: insert completion popupmenu
@@ -2794,7 +2795,7 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                                   are recommended, unless there is a good
                                   reason to overshadow builtin elements.
 
-                              • `style`: Configure the appearance of the window.
+                              • style: Configure the appearance of the window.
                                 Currently only takes one non-empty value:
                                 • "minimal" Nvim will display the window with
                                   many UI options disabled. This is useful
@@ -2809,9 +2810,9 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                                   and clearing the |EndOfBuffer| region in
                                   'winhighlight'.
 
-                              • `border`: Style of (optional) window border. This can
-                                either be a string or an array. The string
-                                values are
+                              • border: Style of (optional) window border.
+                                This can either be a string or an array. The
+                                string values are
                                 • "none": No border (default).
                                 • "single": A single line box.
                                 • "double": A double line box.
@@ -2841,7 +2842,7 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                                   It could also be specified by character: [
                                   {"+", "MyCorner"}, {"x", "MyBorder"} ].
 
-                              • `noautocmd` : If true then no buffer-related
+                              • noautocmd: If true then no buffer-related
                                 autocommand events such as |BufEnter|,
                                 |BufLeave| or |BufWinEnter| may fire from
                                 calling this function.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -670,7 +670,7 @@ omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
                     {base}       If findstart=0, text to match against
 
                 Return: ~
-                    (number) Decided by`findstart`:
+                    (number) Decided by {findstart}:
                     • findstart=0: column where the completion starts, or -2
                       or -3
                     • findstart=1: list of matches (actually just calls

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1518,7 +1518,7 @@ tbl_flatten({t})                                           *vim.tbl_flatten()*
                     Flattened copy of the given list-like table.
 
                 See also: ~
-                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
+                    From https://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_isempty({t})                                           *vim.tbl_isempty()*
                 Checks if a table is empty.
@@ -1554,7 +1554,7 @@ tbl_keys({t})                                                 *vim.tbl_keys()*
                     list of keys
 
                 See also: ~
-                    Fromhttps://github.com/premake/premake-core/blob/master/src/base/table.lua
+                    From https://github.com/premake/premake-core/blob/master/src/base/table.lua
 
 tbl_map({func}, {t})                                           *vim.tbl_map()*
                 Apply a function to all values of a table.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1430,7 +1430,7 @@ end
 ---@param findstart 0 or 1, decides behavior
 ---@param base If findstart=0, text to match against
 ---
----@returns (number) Decided by `findstart`:
+---@returns (number) Decided by {findstart}:
 --- - findstart=0: column where the completion starts, or -2 or -3
 --- - findstart=1: list of matches (actually just calls |complete()|)
 function lsp.omnifunc(findstart, base)

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -506,6 +506,11 @@ def render_node(n, text, prefix='', indent='', width=62):
             text += indent + prefix + result
     elif n.nodeName in ('para', 'heading'):
         for c in n.childNodes:
+            if (is_inline(c)
+                    and '' != get_text(c).strip()
+                    and text
+                    and ' ' != text[-1]):
+                text += ' '
             text += render_node(c, text, indent=indent, width=width)
     elif n.nodeName == 'itemizedlist':
         for c in n.childNodes:

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -61,36 +61,36 @@
 /// @param buffer Buffer to display, or 0 for current buffer
 /// @param enter  Enter the window (make it the current window)
 /// @param config Map defining the window configuration. Keys:
-///   - `relative`: Sets the window layout to "floating", placed at (row,col)
+///   - relative: Sets the window layout to "floating", placed at (row,col)
 ///                 coordinates relative to:
 ///      - "editor" The global editor grid
 ///      - "win"    Window given by the `win` field, or current window.
 ///      - "cursor" Cursor position in current window.
-///   - `win`: |window-ID| for relative="win".
-///   - `anchor`: Decides which corner of the float to place at (row,col):
+///   - win: |window-ID| for relative="win".
+///   - anchor: Decides which corner of the float to place at (row,col):
 ///      - "NW" northwest (default)
 ///      - "NE" northeast
 ///      - "SW" southwest
 ///      - "SE" southeast
-///   - `width`: Window width (in character cells). Minimum of 1.
-///   - `height`: Window height (in character cells). Minimum of 1.
-///   - `bufpos`: Places float relative to buffer text (only when
+///   - width: Window width (in character cells). Minimum of 1.
+///   - height: Window height (in character cells). Minimum of 1.
+///   - bufpos: Places float relative to buffer text (only when
 ///               relative="win"). Takes a tuple of zero-indexed [line, column].
 ///               `row` and `col` if given are applied relative to this
 ///               position, else they default to:
 ///               - `row=1` and `col=0` if `anchor` is "NW" or "NE"
 ///               - `row=0` and `col=0` if `anchor` is "SW" or "SE"
 ///               (thus like a tooltip near the buffer text).
-///   - `row`: Row position in units of "screen cell height", may be fractional.
-///   - `col`: Column position in units of "screen cell width", may be
+///   - row: Row position in units of "screen cell height", may be fractional.
+///   - col: Column position in units of "screen cell width", may be
 ///            fractional.
-///   - `focusable`: Enable focus by user actions (wincmds, mouse events).
+///   - focusable: Enable focus by user actions (wincmds, mouse events).
 ///       Defaults to true. Non-focusable windows can be entered by
 ///       |nvim_set_current_win()|.
-///   - `external`: GUI should display the window as an external
+///   - external: GUI should display the window as an external
 ///       top-level window. Currently accepts no other positioning
 ///       configuration together with this.
-///   - `zindex`: Stacking order. floats with higher `zindex` go on top on
+///   - zindex: Stacking order. floats with higher `zindex` go on top on
 ///               floats with lower indices. Must be larger than zero. The
 ///               following screen elements have hard-coded z-indices:
 ///       - 100: insert completion popupmenu
@@ -99,7 +99,7 @@
 ///     The default value for floats are 50.  In general, values below 100 are
 ///     recommended, unless there is a good reason to overshadow builtin
 ///     elements.
-///   - `style`: Configure the appearance of the window. Currently only takes
+///   - style: Configure the appearance of the window. Currently only takes
 ///       one non-empty value:
 ///       - "minimal"  Nvim will display the window with many UI options
 ///                    disabled. This is useful when displaying a temporary
@@ -110,7 +110,7 @@
 ///                    end-of-buffer region is hidden by setting `eob` flag of
 ///                    'fillchars' to a space char, and clearing the
 ///                    |EndOfBuffer| region in 'winhighlight'.
-///   - `border`: Style of (optional) window border. This can either be a string
+///   - border: Style of (optional) window border. This can either be a string
 ///      or an array. The string values are
 ///     - "none": No border (default).
 ///     - "single": A single line box.
@@ -134,7 +134,7 @@
 ///     By default, `FloatBorder` highlight is used, which links to `VertSplit`
 ///     when not defined.  It could also be specified by character:
 ///       [ {"+", "MyCorner"}, {"x", "MyBorder"} ].
-///   - `noautocmd`: If true then no buffer-related autocommand events such as
+///   - noautocmd: If true then no buffer-related autocommand events such as
 ///                  |BufEnter|, |BufLeave| or |BufWinEnter| may fire from
 ///                  calling this function.
 ///


### PR DESCRIPTION
The spacing fix drew attention to a couple of places that were using incorrect formatting such as the key listing for `nvim_open_win`, so those were fixed too.

This was inspired by the auto-generation produced [here](https://github.com/neovim/neovim/pull/16091/files#diff-51fab2b766d0a3b606462e95de492190df173b7296147912307cdad636cd492aL305-R305) which causes the formatting to be rendered incorrectly. It ended up fixing a few other spots as well.
