### PR TITLE
feat(diagnostic)!: make DiagnosticChanged a first class autocmd

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -289,11 +289,11 @@ option in the "signs" table of |vim.diagnostic.config()| or 10 if unset).
 ==============================================================================
 EVENTS							*diagnostic-events*
 
-							*DiagnosticsChanged*
-DiagnosticsChanged	After diagnostics have changed.
+							*DiagnosticChanged*
+DiagnosticChanged	After diagnostics have changed.
 
 Example: >
-	autocmd User DiagnosticsChanged lua vim.diagnostic.setqflist({open = false })
+	autocmd DiagnosticChanged * lua vim.diagnostic.setqflist({open = false })
 <
 ==============================================================================
 ==============================================================================

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -659,12 +659,14 @@ function M.set(namespace, bufnr, diagnostics, opts)
     M.show(namespace, bufnr, diagnostics, opts)
   end
 
-  vim.api.nvim_command("doautocmd <nomodeline> User DiagnosticsChanged")
+  vim.api.nvim_command(
+    string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.api.nvim_buf_get_name(bufnr))
+  )
 end
 
 --- Get namespace metadata.
 ---
----@param ns number Diagnostic namespace
+---@param namespace number Diagnostic namespace
 ---@return table Namespace metadata
 function M.get_namespace(namespace)
   vim.validate { namespace = { namespace, 'n' } }
@@ -1319,7 +1321,9 @@ function M.reset(namespace, bufnr)
     end
   end
 
-  vim.api.nvim_command("doautocmd <nomodeline> User DiagnosticsChanged")
+  vim.api.nvim_command(
+      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.api.nvim_buf_get_name(bufnr))
+  )
 end
 
 --- Add all diagnostics to the quickfix list.

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -220,9 +220,6 @@ function M.on_publish_diagnostics(_, result, ctx, config)
   end
 
   vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
-
-  -- Keep old autocmd for back compat. This should eventually be removed.
-  vim.api.nvim_command("doautocmd <nomodeline> User LspDiagnosticsChanged")
 end
 
 --- Clear diagnotics and diagnostic cache.

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -37,6 +37,7 @@ return {
     'CursorHoldI',            -- idem, in Insert mode
     'CursorMoved',            -- cursor was moved
     'CursorMovedI',           -- cursor was moved in Insert mode
+    'DiagnosticChanged',      -- diagnostics in a buffer were modified
     'DiffUpdated',            -- diffs have been updated
     'DirChanged',             -- directory changed
     'EncodingChanged',        -- after changing the 'encoding' option
@@ -126,6 +127,7 @@ return {
   -- syntax file
   nvim_specific = {
     BufModifiedSet=true,
+    DiagnosticChanged=true,
     DirChanged=true,
     Signal=true,
     TabClosed=true,


### PR DESCRIPTION
This allows users to hook into diagnostic events with finer granularity (e.g. per-buffer or file).

Closes #16097.

BREAKING CHANGE: Removes `LspDiagnosticsChanged`, changes `User DiagnosticsChanged` to `DiagnosticChanged *` (note singular `Diagnostic`).