### PR TITLE
vim-patch:8.1.2243: typos in comments

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -391,7 +391,7 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T
             off = 0;
 
             if (last < line2) {
-              // 2. delete at end of of diff
+              // 2. delete at end of diff
               dp->df_count[idx] -= last - lnum_deleted + 1;
 
               if ((dp->df_next != NULL)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -363,7 +363,7 @@ EXTERN int t_colors INIT(= 256);                // int value of T_CCO
 // a match within one line), search_match_endcol the column number of the
 // character just after the match in the last line.
 EXTERN bool highlight_match INIT(= false);         // show search match pos
-EXTERN linenr_T search_match_lines;                // lines of of matched string
+EXTERN linenr_T search_match_lines;                // lines of matched string
 EXTERN colnr_T search_match_endcol;                // col nr of match end
 EXTERN linenr_T search_first_line INIT(= 0);       // for :{FIRST},{last}s/pat
 EXTERN linenr_T search_last_line INIT(= MAXLNUM);  // for :{first},{LAST}s/pat

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1558,7 +1558,7 @@ void msg_make(char_u *arg)
 /// the character/string -- webb
 ///
 /// @param from  true for LHS of a mapping
-/// @param maxlen  screen columns, 0 for unlimeted
+/// @param maxlen  screen columns, 0 for unlimited
 int msg_outtrans_special(const char_u *strstart, bool from, int maxlen)
 {
   if (strstart == NULL) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5359,7 +5359,7 @@ static int put_setstring(FILE *fd, char *cmd, char *name, char_u **valuep, uint6
       home_replace(NULL, *valuep, buf, size, false);
 
       // If the option value is longer than MAXPATHL, we need to append
-      // search comma separated part of the option separately, so that it
+      // each comma separated part of the option separately, so that it
       // can be expanded when read back.
       if (size >= MAXPATHL && (flags & P_COMMA) != 0
           && vim_strchr(*valuep, ',') != NULL) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1237,7 +1237,7 @@ static void qf_new_list(qf_info_T *qi, const char_u *qf_title)
 
   // If the current entry is not the last entry, delete entries beyond
   // the current entry.  This makes it possible to browse in a tree-like
-  // way with ":grep'.
+  // way with ":grep".
   while (qi->qf_listcount > qi->qf_curlist + 1) {
     qf_free(&qi->qf_lists[--qi->qf_listcount]);
   }


### PR DESCRIPTION
Problem:    Typos in comments.
Solution:   Fix the typos. (Dominique Pelle, closes vim/vim#5160)  Also adjust
            formatting a bit.
https://github.com/vim/vim/commit/32aa10203bd0b4b270def03311a4599f9ffdecc4