### PR TITLE
doc(diagnostic, lsp): Mention passing on of options

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -373,39 +373,8 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      Otherwise, all signs use the same
                                      priority.
 
-                                 • float: Options for floating windows:
-                                   • severity: See |diagnostic-severity|.
-                                   • header: (string or table) String to use
-                                     as the header for the floating window. If
-                                     a table, it is interpreted as a [text,
-                                     hl_group] tuple. Defaults to
-                                     "Diagnostics:".
-                                   • source: (string) Include the diagnostic
-                                     source in the message. One of "always" or
-                                     "if_many".
-                                   • format: (function) A function that takes
-                                     a diagnostic as input and returns a
-                                     string. The return value is the text used
-                                     to display the diagnostic.
-                                   • prefix: (function, string, or table)
-                                     Prefix each diagnostic in the floating
-                                     window. If a function, it must have the
-                                     signature (diagnostic, i, total) ->
-                                     (string, string), where {i} is the index
-                                     of the diagnostic being evaluated and
-                                     {total} is the total number of
-                                     diagnostics displayed in the window. The
-                                     function should return a string which is
-                                     prepended to each diagnostic in the
-                                     window as well as an (optional) highlight
-                                     group which will be used to highlight the
-                                     prefix. If {prefix} is a table, it is
-                                     interpreted as a [text, hl_group] tuple
-                                     as in |nvim_echo()|; otherwise, if
-                                     {prefix} is a string, it is prepended to
-                                     each diagnostic in the window with no
-                                     highlight.
-
+                                 • float: Options for floating windows. See
+                                   |vim.diagnostic.open_float()|.
                                  • update_in_insert: (default false) Update
                                    diagnostics in Insert mode (if false,
                                    diagnostics are updated on InsertLeave)
@@ -641,8 +610,21 @@ open_float({bufnr}, {opts})                      *vim.diagnostic.open_float()*
                                diagnostic. Overrides the setting from
                                |vim.diagnostic.config()|.
                              • prefix: (function, string, or table) Prefix
-                               each diagnostic in the floating window.
-                               Overrides the setting from
+                               each diagnostic in the floating window. If a
+                               function, it must have the signature
+                               (diagnostic, i, total) -> (string, string),
+                               where {i} is the index of the diagnostic being
+                               evaluated and {total} is the total number of
+                               diagnostics displayed in the window. The
+                               function should return a string which is
+                               prepended to each diagnostic in the window as
+                               well as an (optional) highlight group which
+                               will be used to highlight the prefix. If
+                               {prefix} is a table, it is interpreted as a
+                               [text, hl_group] tuple as in |nvim_echo()|;
+                               otherwise, if {prefix} is a string, it is
+                               prepended to each diagnostic in the window with
+                               no highlight. Overrides the setting from
                                |vim.diagnostic.config()|.
 
                 Return: ~

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1593,24 +1593,27 @@ open_floating_preview({contents}, {syntax}, {opts})
                 Parameters: ~
                     {contents}  table of lines to show in window
                     {syntax}    string of syntax to set for opened buffer
-                    {opts}      dictionary with optional fields
-                                • height of floating window
-                                • width of floating window
-                                • wrap boolean enable wrapping of long lines
-                                  (defaults to true)
-                                • wrap_at character to wrap at for computing
-                                  height when wrap is enabled
-                                • max_width maximal width of floating window
-                                • max_height maximal height of floating window
-                                • pad_top number of lines to pad contents at
-                                  top
-                                • pad_bottom number of lines to pad contents
-                                  at bottom
-                                • focus_id if a popup with this id is opened,
-                                  then focus it
-                                • close_events list of events that closes the
+                    {opts}      table with optional fields (additional keys
+                                are passed on to |vim.api.nvim_open_win()|)
+                                • height: (number) height of floating window
+                                • width: (number) width of floating window
+                                • wrap: (boolean, default true) wrap long
+                                  lines
+                                • wrap_at: (string) character to wrap at for
+                                  computing height when wrap is enabled
+                                • max_width: (number) maximal width of
                                   floating window
-                                • focusable (boolean, default true): Make
+                                • max_height: (number) maximal height of
+                                  floating window
+                                • pad_top: (number) number of lines to pad
+                                  contents at top
+                                • pad_bottom: (number) number of lines to pad
+                                  contents at bottom
+                                • focus_id: (string) if a popup with this id
+                                  is opened, then focus it
+                                • close_events: (table) list of events that
+                                  closes the floating window
+                                • focusable: (boolean, default true) Make
                                   float focusable
 
                 Return: ~

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -537,26 +537,7 @@ end
 ---                * priority: (number, default 10) Base priority to use for signs. When
 ---                {severity_sort} is used, the priority of a sign is adjusted based on
 ---                its severity. Otherwise, all signs use the same priority.
----       - float: Options for floating windows:
----                  * severity: See |diagnostic-severity|.
----                  * header: (string or table) String to use as the header for the floating
----                            window. If a table, it is interpreted as a [text, hl_group] tuple.
----                            Defaults to "Diagnostics:".
----                  * source: (string) Include the diagnostic source in
----                            the message. One of "always" or "if_many".
----                  * format: (function) A function that takes a diagnostic as input and returns a
----                            string. The return value is the text used to display the diagnostic.
----                  * prefix: (function, string, or table) Prefix each diagnostic in the floating
----                            window. If a function, it must have the signature (diagnostic, i,
----                            total) -> (string, string), where {i} is the index of the diagnostic
----                            being evaluated and {total} is the total number of diagnostics
----                            displayed in the window. The function should return a string which
----                            is prepended to each diagnostic in the window as well as an
----                            (optional) highlight group which will be used to highlight the
----                            prefix. If {prefix} is a table, it is interpreted as a [text,
----                            hl_group] tuple as in |nvim_echo()|; otherwise, if {prefix} is a
----                            string, it is prepended to each diagnostic in the window with no
----                            highlight.
+---       - float: Options for floating windows. See |vim.diagnostic.open_float()|.
 ---       - update_in_insert: (default false) Update diagnostics in Insert mode (if false,
 ---                           diagnostics are updated on InsertLeave)
 ---       - severity_sort: (default false) Sort diagnostics by severity. This affects the order in
@@ -564,6 +545,7 @@ end
 ---                         are displayed before lower severities (e.g. ERROR is displayed before WARN).
 ---                         Options:
 ---                         * reverse: (boolean) Reverse sort order
+---
 ---@param namespace number|nil Update the options for the given namespace. When omitted, update the
 ---                            global diagnostic options.
 function M.config(opts, namespace)
@@ -1173,7 +1155,17 @@ end
 ---            - format: (function) A function that takes a diagnostic as input and returns a
 ---                      string. The return value is the text used to display the diagnostic.
 ---                      Overrides the setting from |vim.diagnostic.config()|.
----            - prefix: (function, string, or table) Prefix each diagnostic in the floating window.
+---            - prefix: (function, string, or table) Prefix each diagnostic in the floating
+---                      window. If a function, it must have the signature (diagnostic, i,
+---                      total) -> (string, string), where {i} is the index of the diagnostic
+---                      being evaluated and {total} is the total number of diagnostics
+---                      displayed in the window. The function should return a string which
+---                      is prepended to each diagnostic in the window as well as an
+---                      (optional) highlight group which will be used to highlight the
+---                      prefix. If {prefix} is a table, it is interpreted as a [text,
+---                      hl_group] tuple as in |nvim_echo()|; otherwise, if {prefix} is a
+---                      string, it is prepended to each diagnostic in the window with no
+---                      highlight.
 ---                      Overrides the setting from |vim.diagnostic.config()|.
 ---@return tuple ({float_bufnr}, {win_id})
 function M.open_float(bufnr, opts)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1223,18 +1223,18 @@ end
 ---
 ---@param contents table of lines to show in window
 ---@param syntax string of syntax to set for opened buffer
----@param opts dictionary with optional fields
----             - height    of floating window
----             - width     of floating window
----             - wrap boolean enable wrapping of long lines (defaults to true)
----             - wrap_at   character to wrap at for computing height when wrap is enabled
----             - max_width  maximal width of floating window
----             - max_height maximal height of floating window
----             - pad_top    number of lines to pad contents at top
----             - pad_bottom number of lines to pad contents at bottom
----             - focus_id if a popup with this id is opened, then focus it
----             - close_events list of events that closes the floating window
----             - focusable (boolean, default true): Make float focusable
+---@param opts table with optional fields (additional keys are passed on to |vim.api.nvim_open_win()|)
+---             - height: (number) height of floating window
+---             - width: (number) width of floating window
+---             - wrap: (boolean, default true) wrap long lines
+---             - wrap_at: (string) character to wrap at for computing height when wrap is enabled
+---             - max_width: (number) maximal width of floating window
+---             - max_height: (number) maximal height of floating window
+---             - pad_top: (number) number of lines to pad contents at top
+---             - pad_bottom: (number) number of lines to pad contents at bottom
+---             - focus_id: (string) if a popup with this id is opened, then focus it
+---             - close_events: (table) list of events that closes the floating window
+---             - focusable: (boolean, default true) Make float focusable
 ---@returns bufnr,winnr buffer and window number of the newly created floating
 ---preview window
 function M.open_floating_preview(contents, syntax, opts)


### PR DESCRIPTION
Fix vim.diagnostic.config() not mentioning unused options for floats
being passed on to vim.lsp.util.open_floating_preview()

Fix vim.lsp.util.open_floating_preview() not mentioning unused options
being passed on to vim.api.nvim_open_win()