### PR TITLE
Port vim-patch:8.2.3547: opening the quickfix window triggers BufWinEnter twice 

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -335,8 +335,10 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags)
     do_modelines(0);
     curbuf->b_flags &= ~(BF_CHECK_RO | BF_NEVERLOADED);
 
-    apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, false, curbuf,
-                          &retval);
+    if ((flags & READ_NOWINENTER) == 0) {
+      apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, false, curbuf,
+                            &retval);
+    }
 
     // restore curwin/curbuf and a few other things
     aucmd_restbuf(&aco);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2279,6 +2279,7 @@ theend:
 ///                 ECMD_ADDBUF: don't edit, just add to buffer list
 ///                 ECMD_ALTBUF: like ECMD_ADDBUF and also set the alternate
 ///                 file
+///                 ECMD_NOWINENTER: Do not trigger BufWinEnter
 /// @param oldwin   Should be "curwin" when editing a new buffer in the current
 ///                 window, NULL when splitting the window first.  When not NULL
 ///                 info of the previous buffer for "oldwin" is stored.
@@ -2735,7 +2736,10 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
       /*
        * Open the buffer and read the file.
        */
-      if (should_abort(open_buffer(FALSE, eap, readfile_flags))) {
+      if (flags & ECMD_NOWINENTER) {
+        readfile_flags |= READ_NOWINENTER;
+      }
+      if (should_abort(open_buffer(false, eap, readfile_flags))) {
         retval = FAIL;
       }
 
@@ -2751,8 +2755,10 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
 
       apply_autocmds_retval(EVENT_BUFENTER, NULL, NULL, FALSE, curbuf,
                             &retval);
-      apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, FALSE, curbuf,
-                            &retval);
+      if ((flags & ECMD_NOWINENTER) == 0) {
+        apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, false, curbuf,
+                              &retval);
+      }
     }
     check_arg_idx(curwin);
 

--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -16,7 +16,8 @@
 #define ECMD_OLDBUF          0x04    // use existing buffer if it exists
 #define ECMD_FORCEIT         0x08    // ! used in Ex command
 #define ECMD_ADDBUF          0x10    // don't edit, just add to buffer list
-#define ECMD_ALTBUF         0x20  // like ECMD_ADDBUF and set the alternate file
+#define ECMD_ALTBUF          0x20    // like ECMD_ADDBUF and set the alternate file
+#define ECMD_NOWINENTER      0x40    // do not trigger BufWinEnter
 
 // for lnum argument in do_ecmd()
 #define ECMD_LASTL      (linenr_T)0     // use last position in loaded file

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -13,6 +13,7 @@
 #define READ_DUMMY      0x10    // reading into a dummy buffer
 #define READ_KEEP_UNDO  0x20    // keep undo info
 #define READ_FIFO       0x40    // read from fifo or socket
+#define READ_NOWINENTER 0x80    // do not trigger BufWinEnter
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3643,12 +3643,12 @@ static int qf_open_new_cwindow(qf_info_T *qi, int height)
   if (qf_buf != NULL) {
     // Use the existing quickfix buffer
     if (do_ecmd(qf_buf->b_fnum, NULL, NULL, NULL, ECMD_ONE,
-                ECMD_HIDE + ECMD_OLDBUF, oldwin) == FAIL) {
+                ECMD_HIDE + ECMD_OLDBUF + ECMD_NOWINENTER, oldwin) == FAIL) {
       return FAIL;
     }
   } else {
     // Create a new quickfix buffer
-    if (do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, oldwin) == FAIL) {
+    if (do_ecmd(0, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE + ECMD_NOWINENTER, oldwin) == FAIL) {
       return FAIL;
     }
   }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -705,6 +705,23 @@ func Test_vimgreptitle()
   augroup! QfBufWinEnter
 endfunc
 
+func Test_bufwinenter_once()
+  augroup QfBufWinEnter
+    au!
+    au BufWinEnter * let g:got_afile ..= 'got ' .. expand('<afile>')
+  augroup END
+  let g:got_afile = ''
+  copen
+  call assert_equal('got quickfix', g:got_afile)
+
+  cclose
+  unlet g:got_afile
+  augroup QfBufWinEnter
+    au!
+  augroup END
+  augroup! QfBufWinEnter
+endfunc
+
 func XqfTitleTests(cchar)
   call s:setup_commands(a:cchar)
 


### PR DESCRIPTION
This ports [this patch](https://github.com/vim/vim/commit/1d30fde3c989a962e0e1af4cbcf90e1ea483f1f4) to NeoVim. Due to the code differences, the patch was ported by hand. I confirmed it indeed works using the repro described in https://github.com/vim/vim/issues/9022.