### PR TITLE
fix(lsp): cleanup progress messages for the correct client

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -226,9 +226,10 @@ function M.get_progress_messages()
       table.remove(client.messages, item.idx)
     end
 
-    for _, item in ipairs(progress_remove) do
-      client.messages.progress[item.token] = nil
-    end
+  end
+
+  for _, item in ipairs(progress_remove) do
+    item.client.messages.progress[item.token] = nil
   end
 
   return new_messages


### PR DESCRIPTION
When you have multiple clients open that generate progress with the same token, messages were incorrectlty cleaned from other clients, resulting in a nil value at https://github.com/neovim/neovim/blob/d0f10a7addc17149d7e63ff20705762c357eb469/runtime/lua/vim/lsp/handlers.lua#L44

This PR fixes that