### PR TITLE
vim-patch:8.1.2368,8.1.2378,8.1.2379,8.1.2380,8.1.2387,8.1.2388,8.1.2392,8.1.2394,8.1.2395,8.1.2396

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -308,8 +308,8 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags)
     curbuf->b_flags |= BF_READERR;
   }
 
-  /* Need to update automatic folding.  Do this before the autocommands,
-   * they may use the fold info. */
+  // Need to update automatic folding.  Do this before the autocommands,
+  // they may use the fold info.
   foldUpdateAll(curwin);
 
   // need to set w_topline, unless some autocommand already did that.
@@ -864,8 +864,8 @@ void goto_buffer(exarg_T *eap, int start, int dir, int count)
     swap_exists_action = SEA_NONE;
     swap_exists_did_quit = true;
 
-    /* Restore the error/interrupt/exception state if not discarded by a
-     * new aborting error, interrupt, or uncaught exception. */
+    // Restore the error/interrupt/exception state if not discarded by a
+    // new aborting error, interrupt, or uncaught exception.
     leave_cleanup(&cs);
   } else {
     handle_swap_exists(&old_curbuf);
@@ -920,8 +920,8 @@ void handle_swap_exists(bufref_T *old_curbuf)
     }
     // If "old_curbuf" is NULL we are in big trouble here...
 
-    /* Restore the error/interrupt/exception state if not discarded by a
-     * new aborting error, interrupt, or uncaught exception. */
+    // Restore the error/interrupt/exception state if not discarded by a
+    // new aborting error, interrupt, or uncaught exception.
     leave_cleanup(&cs);
   } else if (swap_exists_action == SEA_RECOVER) {
     // Reset the error/interrupt/exception state here so that
@@ -935,8 +935,8 @@ void handle_swap_exists(bufref_T *old_curbuf)
     cmdline_row = msg_row;
     do_modelines(0);
 
-    /* Restore the error/interrupt/exception state if not discarded by a
-     * new aborting error, interrupt, or uncaught exception. */
+    // Restore the error/interrupt/exception state if not discarded by a
+    // new aborting error, interrupt, or uncaught exception.
     leave_cleanup(&cs);
   }
   swap_exists_action = SEA_NONE;  // -V519
@@ -1153,8 +1153,8 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
   } else {
     bp = NULL;
     while (count > 0 || (!unload && !buf->b_p_bl && bp != buf)) {
-      /* remember the buffer where we start, we come back there when all
-       * buffers are unlisted. */
+      // remember the buffer where we start, we come back there when all
+      // buffers are unlisted.
       if (bp == NULL) {
         bp = buf;
       }
@@ -1205,8 +1205,8 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     bufref_T bufref;
     set_bufref(&bufref, buf);
 
-    /* When unloading or deleting a buffer that's already unloaded and
-     * unlisted: fail silently. */
+    // When unloading or deleting a buffer that's already unloaded and
+    // unlisted: fail silently.
     if (action != DOBUF_WIPE && buf->b_ml.ml_mfp == NULL && !buf->b_p_bl) {
       return FAIL;
     }
@@ -1386,8 +1386,8 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
   }
 
   if (buf == NULL) {
-    /* Autocommands must have wiped out all other buffers.  Only option
-     * now is to make the current buffer empty. */
+    // Autocommands must have wiped out all other buffers.  Only option
+    // now is to make the current buffer empty.
     return empty_curbuf(false, forceit, action);
   }
 
@@ -1510,9 +1510,9 @@ void set_curbuf(buf_T *buf, int action)
       }
     }
   }
-  /* An autocommand may have deleted "buf", already entered it (e.g., when
-   * it did ":bunload") or aborted the script processing!
-   * If curwin->w_buffer is null, enter_buffer() will make it valid again */
+  // An autocommand may have deleted "buf", already entered it (e.g., when
+  // it did ":bunload") or aborted the script processing!
+  // If curwin->w_buffer is null, enter_buffer() will make it valid again
   if ((buf_valid(buf) && buf != curbuf
        && !aborting()
        ) || curwin->w_buffer == NULL) {
@@ -2227,8 +2227,8 @@ int buflist_findpat(const char_u *pattern, const char_u *pattern_end, bool unlis
               && (!diffmode || diff_mode_buf(buf))
               && buflist_match(&regmatch, buf, false) != NULL) {
             if (curtab_only) {
-              /* Ignore the match if the buffer is not open in
-               * the current tab. */
+              // Ignore the match if the buffer is not open in
+              // the current tab.
               bool found_window = false;
               FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
                 if (wp->w_buffer == buf) {
@@ -5160,9 +5160,9 @@ void ex_buffer_all(exarg_T *eap)
         swap_exists_action = SEA_NONE;
         swap_exists_did_quit = true;
 
-        /* Restore the error/interrupt/exception state if not
-         * discarded by a new aborting error, interrupt, or uncaught
-         * exception. */
+        // Restore the error/interrupt/exception state if not
+        // discarded by a new aborting error, interrupt, or uncaught
+        // exception.
         leave_cleanup(&cs);
       } else {
         handle_swap_exists(NULL);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -523,7 +523,7 @@ static int insert_check(VimState *state)
     did_cursorhold = false;
   }
 
-  // If the cursor was moved we didn't just insert a space */
+  // If the cursor was moved we didn't just insert a space
   if (arrow_used) {
     s->inserted_space = false;
   }
@@ -835,7 +835,7 @@ static int insert_handle_key(InsertState *s)
 
   case Ctrl_C:        // End input mode
     if (s->c == Ctrl_C && cmdwin_type != 0) {
-      // Close the cmdline window. */
+      // Close the cmdline window.
       cmdwin_result = K_IGNORE;
       got_int = false;         // don't stop executing autocommands et al
       s->nomove = true;
@@ -6346,8 +6346,8 @@ void auto_format(bool trailblank, bool prev_line)
     curwin->w_cursor = pos;
   }
 
-  /* With the 'c' flag in 'formatoptions' and 't' missing: only format
-   * comments. */
+  // With the 'c' flag in 'formatoptions' and 't' missing: only format
+  // comments.
   if (has_format_option(FO_WRAP_COMS) && !has_format_option(FO_WRAP)
       && get_leader_len(old, NULL, false, true) == 0) {
     return;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2026,9 +2026,9 @@ char_u *get_lval(char_u *const name, typval_T *const rettv, lval_T *const lp, co
                                                  p);
     lp->ll_name = lp->ll_exp_name;
     if (lp->ll_exp_name == NULL) {
-      /* Report an invalid expression in braces, unless the
-       * expression evaluation has been cancelled due to an
-       * aborting error, an interrupt, or an exception. */
+      // Report an invalid expression in braces, unless the
+      // expression evaluation has been cancelled due to an
+      // aborting error, an interrupt, or an exception.
       if (!aborting() && !quiet) {
         emsg_severe = true;
         EMSG2(_(e_invarg2), name);
@@ -2173,9 +2173,9 @@ char_u *get_lval(char_u *const name, typval_T *const rettv, lval_T *const lp, co
       lp->ll_dict = lp->ll_tv->vval.v_dict;
       lp->ll_di = tv_dict_find(lp->ll_dict, (const char *)key, len);
 
-      /* When assigning to a scope dictionary check that a function and
-       * variable name is valid (only variable name unless it is l: or
-       * g: dictionary). Disallow overwriting a builtin function. */
+      // When assigning to a scope dictionary check that a function and
+      // variable name is valid (only variable name unless it is l: or
+      // g: dictionary). Disallow overwriting a builtin function.
       if (rettv != NULL && lp->ll_dict->dv_scope != 0) {
         int prevval;
         int wrong;
@@ -2758,8 +2758,8 @@ void set_context_for_expression(expand_T *xp, char_u *arg, cmdidx_T cmdidx)
         xp->xp_context = EXPAND_EXPRESSION;
       }
     } else {
-      /* Doesn't look like something valid, expand as an expression
-       * anyway. */
+      // Doesn't look like something valid, expand as an expression
+      // anyway.
       xp->xp_context = EXPAND_EXPRESSION;
     }
     arg = xp->xp_pattern;
@@ -4927,9 +4927,9 @@ static int get_string_tv(char_u **arg, typval_T *rettv, int evaluate)
             ++p;
             nr = (nr << 4) + hex2nr(*p);
           }
-          ++p;
-          /* For "\u" store the number according to
-           * 'encoding'. */
+          p++;
+          // For "\u" store the number according to
+          // 'encoding'.
           if (c != 'X') {
             name += utf_char2bytes(nr, name);
           } else {
@@ -8452,7 +8452,7 @@ const char_u *find_name_end(const char_u *arg, const char_u **expr_start, const 
       }
     } else if (br_nest == 0 && mb_nest == 0 && *p == ':') {
       // "s:" is start of "s:var", but "n:" is not and can be used in
-      // slice "[n:]".  Also "xx:" is not a namespace. But {ns}: is. */
+      // slice "[n:]".  Also "xx:" is not a namespace. But {ns}: is.
       len = (int)(p - arg);
       if ((len > 1 && p[-1] != '}')
           || (len == 1 && vim_strchr(namespace_char, *arg) == NULL)) {
@@ -9825,12 +9825,12 @@ void ex_echo(exarg_T *eap)
     if (!eap->skip) {
       if (atstart) {
         atstart = false;
-        /* Call msg_start() after eval1(), evaluating the expression
-         * may cause a message to appear. */
+        // Call msg_start() after eval1(), evaluating the expression
+        // may cause a message to appear.
         if (eap->cmdidx == CMD_echo) {
-          /* Mark the saved text as finishing the line, so that what
-           * follows is displayed on a new line when scrolling back
-           * at the more prompt. */
+          // Mark the saved text as finishing the line, so that what
+          // follows is displayed on a new line when scrolling back
+          // at the more prompt.
           msg_sb_eol();
           msg_start();
         }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1720,8 +1720,8 @@ char_u *trans_function_name(char_u **pp, bool skip, int flags, funcdict_T *fdp, 
     return (char_u *)xmemdupz(start, len);
   }
 
-  /* A name starting with "<SID>" or "<SNR>" is local to a script.  But
-   * don't skip over "s:", get_lval() needs it for "s:dict.func". */
+  // A name starting with "<SID>" or "<SNR>" is local to a script.  But
+  // don't skip over "s:", get_lval() needs it for "s:dict.func".
   lead = eval_fname_script((const char *)start);
   if (lead > 2) {
     start += lead;
@@ -2405,14 +2405,14 @@ void ex_function(exarg_T *eap)
     // Add the line to the function.
     ga_grow(&newlines, 1 + sourcing_lnum_off);
 
-    /* Copy the line to newly allocated memory.  get_one_sourceline()
-     * allocates 250 bytes per line, this saves 80% on average.  The cost
-     * is an extra alloc/free. */
+    // Copy the line to newly allocated memory.  get_one_sourceline()
+    // allocates 250 bytes per line, this saves 80% on average.  The cost
+    // is an extra alloc/free.
     p = vim_strsave(theline);
     ((char_u **)(newlines.ga_data))[newlines.ga_len++] = p;
 
-    /* Add NULL lines for continuation lines, so that the line count is
-     * equal to the index in the growarray.   */
+    // Add NULL lines for continuation lines, so that the line count is
+    // equal to the index in the growarray.
     while (sourcing_lnum_off-- > 0) {
       ((char_u **)(newlines.ga_data))[newlines.ga_len++] = NULL;
     }
@@ -2490,8 +2490,8 @@ void ex_function(exarg_T *eap)
       goto erret;
     }
 
-    /* Give the function a sequential number.  Can only be used with a
-     * Funcref! */
+    // Give the function a sequential number.  Can only be used with a
+    // Funcref!
     xfree(name);
     sprintf(numbuf, "%d", ++func_nr);
     name = vim_strsave((char_u *)numbuf);
@@ -3079,13 +3079,13 @@ int do_return(exarg_T *eap, int reanimate, int is_cmd, void *rettv)
     cstack->cs_pending[idx] = CSTP_RETURN;
 
     if (!is_cmd && !reanimate) {
-      /* A pending return again gets pending.  "rettv" points to an
-       * allocated variable with the rettv of the original ":return"'s
-       * argument if present or is NULL else. */
+      // A pending return again gets pending.  "rettv" points to an
+      // allocated variable with the rettv of the original ":return"'s
+      // argument if present or is NULL else.
       cstack->cs_rettv[idx] = rettv;
     } else {
-      /* When undoing a return in order to make it pending, get the stored
-       * return rettv. */
+      // When undoing a return in order to make it pending, get the stored
+      // return rettv.
       if (reanimate) {
         assert(current_funccal->rettv);
         rettv = current_funccal->rettv;
@@ -3214,8 +3214,8 @@ int func_has_ended(void *cookie)
 {
   funccall_T *fcp = (funccall_T *)cookie;
 
-  /* Ignore the "abort" flag if the abortion behavior has been changed due to
-   * an error inside a try conditional. */
+  // Ignore the "abort" flag if the abortion behavior has been changed due to
+  // an error inside a try conditional.
   return ((fcp->func->uf_flags & FC_ABORT) && did_emsg && !aborted_in_try())
          || fcp->returned;
 }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1082,8 +1082,8 @@ void ex_copy(linenr_T line1, linenr_T line2, linenr_T n)
 
   curwin->w_cursor.lnum = n;
   while (line1 <= line2) {
-    /* need to use vim_strsave() because the line will be unlocked within
-     * ml_append() */
+    // need to use vim_strsave() because the line will be unlocked within
+    // ml_append()
     p = vim_strsave(ml_get(line1));
     ml_append(curwin->w_cursor.lnum, p, (colnr_T)0, false);
     xfree(p);
@@ -1206,9 +1206,9 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
   prevcmd = newcmd;
 
   if (bangredo) {  // put cmd in redo buffer for ! command
-    /* If % or # appears in the command, it must have been escaped.
-     * Reescape them, so that redoing them does not substitute them by the
-     * buffername. */
+    // If % or # appears in the command, it must have been escaped.
+    // Reescape them, so that redoing them does not substitute them by the
+    // buffername.
     char_u *cmd = vim_strsave_escaped(prevcmd, (char_u *)"%#");
 
     AppendToRedobuffLit(cmd, -1);
@@ -1237,8 +1237,8 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
 
     do_shell(newcmd, 0);
   } else {                            // :range!
-    /* Careful: This may recursively call do_bang() again! (because of
-     * autocommands) */
+    // Careful: This may recursively call do_bang() again! (because of
+    // autocommands)
     do_filter(line1, line2, eap, newcmd, do_in, do_out);
     apply_autocmds(EVENT_SHELLFILTERPOST, NULL, NULL, false, curbuf);
   }
@@ -1368,9 +1368,9 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char_u *cmd,
   did_check_timestamps = FALSE;
   need_check_timestamps = TRUE;
 
-  /* When interrupting the shell command, it may still have produced some
-   * useful output.  Reset got_int here, so that readfile() won't cancel
-   * reading. */
+  // When interrupting the shell command, it may still have produced some
+  // useful output.  Reset got_int here, so that readfile() won't cancel
+  // reading.
   os_breakcheck();
   got_int = FALSE;
 
@@ -1837,8 +1837,8 @@ int do_write(exarg_T *eap)
       alt_buf = buflist_findname(ffname);
     }
     if (alt_buf != NULL && alt_buf->b_ml.ml_mfp != NULL) {
-      /* Overwriting a file that is loaded in another buffer is not a
-       * good idea. */
+      // Overwriting a file that is loaded in another buffer is not a
+      // good idea.
       EMSG(_(e_bufloaded));
       goto theend;
     }
@@ -2143,8 +2143,8 @@ int not_writing(void)
  */
 static int check_readonly(int *forceit, buf_T *buf)
 {
-  /* Handle a file being readonly when the 'readonly' option is set or when
-   * the file exists and permissions are read-only. */
+  // Handle a file being readonly when the 'readonly' option is set or when
+  // the file exists and permissions are read-only.
   if (!*forceit && (buf->b_p_ro
                     || (os_path_exists(buf->b_ffname)
                         && !os_file_is_writable((char *)buf->b_ffname)))) {
@@ -2612,8 +2612,8 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
     set_buflisted(TRUE);
   }
 
-  /* If autocommands change buffers under our fingers, forget about
-   * editing the file. */
+  // If autocommands change buffers under our fingers, forget about
+  // editing the file.
   if (buf != curbuf) {
     goto theend;
   }
@@ -2677,9 +2677,9 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
     }
     xfree(new_name);
 
-    /* If autocommands change buffers under our fingers, forget about
-     * re-editing the file.  Should do the buf_clear_file(), but perhaps
-     * the autocommands changed the buffer... */
+    // If autocommands change buffers under our fingers, forget about
+    // re-editing the file.  Should do the buf_clear_file(), but perhaps
+    // the autocommands changed the buffer...
     if (buf != curbuf) {
       goto theend;
     }
@@ -2711,8 +2711,8 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
      */
     curwin_init();
 
-    /* It's possible that all lines in the buffer changed.  Need to update
-     * automatic folding for all windows where it's used. */
+    // It's possible that all lines in the buffer changed.  Need to update
+    // automatic folding for all windows where it's used.
     FOR_ALL_TAB_WINDOWS(tp, win) {
       if (win->w_buffer == curbuf) {
         foldUpdateAll(win);
@@ -2744,9 +2744,9 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
       }
       handle_swap_exists(&old_curbuf);
     } else {
-      /* Read the modelines, but only to set window-local options.  Any
-       * buffer-local options have already been set and may have been
-       * changed by the user. */
+      // Read the modelines, but only to set window-local options.  Any
+      // buffer-local options have already been set and may have been
+      // changed by the user.
       do_modelines(OPT_WINONLY);
 
       apply_autocmds_retval(EVENT_BUFENTER, NULL, NULL, FALSE, curbuf,
@@ -2778,16 +2778,16 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
     maketitle();
   }
 
-  /* Tell the diff stuff that this buffer is new and/or needs updating.
-   * Also needed when re-editing the same buffer, because unloading will
-   * have removed it as a diff buffer. */
+  // Tell the diff stuff that this buffer is new and/or needs updating.
+  // Also needed when re-editing the same buffer, because unloading will
+  // have removed it as a diff buffer.
   if (curwin->w_p_diff) {
     diff_buf_add(curbuf);
     diff_invalidate(curbuf);
   }
 
-  /* If the window options were changed may need to set the spell language.
-   * Can only do this after the buffer has been properly setup. */
+  // If the window options were changed may need to set the spell language.
+  // Can only do this after the buffer has been properly setup.
   if (did_get_winopts && curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL) {
     (void)did_set_spelllang(curwin);
   }
@@ -3022,10 +3022,10 @@ void ex_append(exarg_T *eap)
     curbuf->b_p_ai = !curbuf->b_p_ai;
   }
 
-  /* "start" is set to eap->line2+1 unless that position is invalid (when
-   * eap->line2 pointed to the end of the buffer and nothing was appended)
-   * "end" is set to lnum when something has been appended, otherwise
-   * it is the same than "start"  -- Acevedo */
+  // "start" is set to eap->line2+1 unless that position is invalid (when
+  // eap->line2 pointed to the end of the buffer and nothing was appended)
+  // "end" is set to lnum when something has been appended, otherwise
+  // it is the same than "start"  -- Acevedo
   curbuf->b_op_start.lnum = (eap->line2 < curbuf->b_ml.ml_line_count) ?
                             eap->line2 + 1 : curbuf->b_ml.ml_line_count;
   if (eap->cmdidx != CMD_append) {
@@ -3555,8 +3555,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
     pat = NULL;                 // search_regcomp() will use previous pattern
     sub = (char_u *)old_sub.sub;
 
-    /* Vi compatibility quirk: repeating with ":s" keeps the cursor in the
-     * last column after using "$". */
+    // Vi compatibility quirk: repeating with ":s" keeps the cursor in the
+    // last column after using "$".
     endcolumn = (curwin->w_curswant == MAXCOL);
   }
 
@@ -3807,8 +3807,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
         if (subflags.do_ask && !preview) {
           int typed = 0;
 
-          /* change State to CONFIRM, so that the mouse works
-           * properly */
+          // change State to CONFIRM, so that the mouse works
+          // properly
           int save_State = State;
           State = CONFIRM;
           setmouse();                   // disable mouse in xterm
@@ -3864,9 +3864,9 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
               const bool save_p_lz = p_lz;
               int save_p_fen = curwin->w_p_fen;
 
-              curwin->w_p_fen = FALSE;
-              /* Invert the matched string.
-               * Remove the inversion afterwards. */
+              curwin->w_p_fen = false;
+              // Invert the matched string.
+              // Remove the inversion afterwards.
               int temp = RedrawingDisabled;
               RedrawingDisabled = 0;
 
@@ -3874,11 +3874,11 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
               p_lz = false;
 
               if (new_start != NULL) {
-                /* There already was a substitution, we would
-                 * like to show this to the user.  We cannot
-                 * really update the line, it would change
-                 * what matches.  Temporarily replace the line
-                 * and change it back afterwards. */
+                // There already was a substitution, we would
+                // like to show this to the user.  We cannot
+                // really update the line, it would change
+                // what matches.  Temporarily replace the line
+                // and change it back afterwards.
                 orig_line = vim_strsave(ml_get(lnum));
                 char_u *new_line = concat_str(new_start, sub_firstline + copycol);
 
@@ -3908,8 +3908,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
               }
               msg_starthere();
               i = msg_scroll;
-              msg_scroll = 0;                           /* truncate msg when
-                                                           needed */
+              msg_scroll = 0;                           // truncate msg when
+                                                        // needed
               msg_no_more = true;
               msg_ext_set_kind("confirm_sub");
               smsg_attr(HL_ATTR(HLF_R),  // Same highlight as wait_return().
@@ -4878,8 +4878,8 @@ void ex_help(exarg_T *eap)
   if (!p_im) {
     restart_edit = 0;               // don't want insert mode in help file
   }
-  /* Restore KeyTyped, setting 'filetype=help' may reset it.
-   * It is needed for do_tag top open folds under the cursor. */
+  // Restore KeyTyped, setting 'filetype=help' may reset it.
+  // It is needed for do_tag top open folds under the cursor.
   KeyTyped = old_KeyTyped;
 
   do_tag(tag, DT_HELP, 1, FALSE, TRUE);
@@ -5073,11 +5073,10 @@ int find_help_tags(const char_u *arg, int *num_matches, char_u ***matches, bool 
         STRCPY(d + 4, "\\$");
       }
     } else {
-      /* Replace:
-       * "[:...:]" with "\[:...:]"
-       * "[++...]" with "\[++...]"
-       * "\{" with "\\{"               -- matching "} \}"
-       */
+      // Replace:
+      // "[:...:]" with "\[:...:]"
+      // "[++...]" with "\[++...]"
+      // "\{" with "\\{"               -- matching "} \}"
       if ((arg[0] == '[' && (arg[1] == ':'
                              || (arg[1] == '+' && arg[2] == '+')))
           || (arg[0] == '\\' && arg[1] == '{')) {
@@ -5327,8 +5326,8 @@ void fix_help_buffer(void)
         continue;
       }
 
-      /* Go through all directories in 'runtimepath', skipping
-       * $VIMRUNTIME. */
+      // Go through all directories in 'runtimepath', skipping
+      // $VIMRUNTIME.
       char_u *p = p_rtp;
       while (*p != NUL) {
         copy_option_part(&p, NameBuff, MAXPATHL, ",");
@@ -5413,10 +5412,9 @@ void fix_help_buffer(void)
                   if (*s == '\r' || *s == '\n') {
                     *s = NUL;
                   }
-                  /* The text is utf-8 when a byte
-                   * above 127 is found and no
-                   * illegal byte sequence is found.
-                   */
+                  // The text is utf-8 when a byte
+                  // above 127 is found and no
+                  // illegal byte sequence is found.
                   if (*s >= 0x80 && this_utf != kFalse) {
                     this_utf = kTrue;
                     const int l = utf_ptr2len(s);
@@ -5427,9 +5425,9 @@ void fix_help_buffer(void)
                   }
                   ++s;
                 }
-                /* The help file is latin1 or utf-8;
-                 * conversion to the current
-                 * 'encoding' may be required. */
+                // The help file is latin1 or utf-8;
+                // conversion to the current
+                // 'encoding' may be required.
                 vc.vc_type = CONV_NONE;
                 convert_setup(&vc,
                               (char_u *)(this_utf == kTrue ? "utf-8" : "latin1"),
@@ -5716,8 +5714,8 @@ static void do_helptags(char_u *dirname, bool add_help_tags, bool ignore_writeer
     return;
   }
 
-  /* Go over all files in the directory to find out what languages are
-   * present. */
+  // Go over all files in the directory to find out what languages are
+  // present.
   int j;
   ga_init(&ga, 1, 10);
   for (int i = 0; i < filecount; i++) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -340,12 +340,12 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
   int getline_is_func;
   static int call_depth = 0;            // recursiveness
 
-  /* For every pair of do_cmdline()/do_one_cmd() calls, use an extra memory
-   * location for storing error messages to be converted to an exception.
-   * This ensures that the do_errthrow() call in do_one_cmd() does not
-   * combine the messages stored by an earlier invocation of do_one_cmd()
-   * with the command name of the later one.  This would happen when
-   * BufWritePost autocommands are executed after a write error. */
+  // For every pair of do_cmdline()/do_one_cmd() calls, use an extra memory
+  // location for storing error messages to be converted to an exception.
+  // This ensures that the do_errthrow() call in do_one_cmd() does not
+  // combine the messages stored by an earlier invocation of do_one_cmd()
+  // with the command name of the later one.  This would happen when
+  // BufWritePost autocommands are executed after a write error.
   saved_msg_list = msg_list;
   msg_list = &private_msg_list;
   private_msg_list = NULL;
@@ -445,12 +445,12 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
 
     // 1. If repeating, get a previous line from lines_ga.
     if (cstack.cs_looplevel > 0 && current_line < lines_ga.ga_len) {
-      /* Each '|' separated command is stored separately in lines_ga, to
-       * be able to jump to it.  Don't use next_cmdline now. */
+      // Each '|' separated command is stored separately in lines_ga, to
+      // be able to jump to it.  Don't use next_cmdline now.
       XFREE_CLEAR(cmdline_copy);
 
-      /* Check if a function has returned or, unless it has an unclosed
-       * try conditional, aborted. */
+      // Check if a function has returned or, unless it has an unclosed
+      // try conditional, aborted.
       if (getline_is_func) {
         if (do_profiling == PROF_YES) {
           func_line_end(real_cookie);
@@ -630,8 +630,8 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
         new_last_cmdline = NULL;
       }
     } else {
-      /* need to copy the command after the '|' to cmdline_copy, for the
-       * next do_one_cmd() */
+      // need to copy the command after the '|' to cmdline_copy, for the
+      // next do_one_cmd()
       STRMOVE(cmdline_copy, next_cmdline);
       next_cmdline = cmdline_copy;
     }
@@ -656,10 +656,10 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
       if (cstack.cs_lflags & (CSL_HAD_CONT | CSL_HAD_ENDLOOP)) {
         cstack.cs_lflags &= ~(CSL_HAD_CONT | CSL_HAD_ENDLOOP);
 
-        /* Jump back to the matching ":while" or ":for".  Be careful
-         * not to use a cs_line[] from an entry that isn't a ":while"
-         * or ":for": It would make "current_line" invalid and can
-         * cause a crash. */
+        // Jump back to the matching ":while" or ":for".  Be careful
+        // not to use a cs_line[] from an entry that isn't a ":while"
+        // or ":for": It would make "current_line" invalid and can
+        // cause a crash.
         if (!did_emsg && !got_int && !current_exception
             && cstack.cs_idx >= 0
             && (cstack.cs_flags[cstack.cs_idx]
@@ -752,9 +752,9 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
   while (!((got_int || (did_emsg && force_abort) || current_exception)
            && cstack.cs_trylevel == 0)
          && !(did_emsg
-              /* Keep going when inside try/catch, so that the error can be
-               * deal with, except when it is a syntax error, it may cause
-               * the :endtry to be missed. */
+              // Keep going when inside try/catch, so that the error can be
+              // deal with, except when it is a syntax error, it may cause
+              // the :endtry to be missed.
               && (cstack.cs_trylevel == 0 || did_emsg_syntax)
               && used_getline
               && getline_equal(fgetline, cookie, getexline))
@@ -2880,8 +2880,8 @@ int cmd_exists(const char *const name)
     }
   }
 
-  /* Check built-in commands and user defined commands.
-   * For ":2match" and ":3match" we need to skip the number. */
+  // Check built-in commands and user defined commands.
+  // For ":2match" and ":3match" we need to skip the number.
   ea.cmd = (char_u *)((*name == '2' || *name == '3') ? name + 1 : name);
   ea.cmdidx = (cmdidx_T)0;
   int full = false;
@@ -3963,8 +3963,8 @@ static linenr_T get_address(exarg_T *eap, char_u **ptr, cmd_addr_T addr_type, in
       if (skip) {
         ++cmd;
       } else {
-        /* Only accept a mark in another file when it is
-         * used by itself: ":'M". */
+        // Only accept a mark in another file when it is
+        // used by itself: ":'M".
         fp = getmark(*cmd, to_other_file && cmd[1] == NUL);
         ++cmd;
         if (fp == (pos_T *)-1) {
@@ -4444,11 +4444,10 @@ int expand_filename(exarg_T *eap, char_u **cmdlinep, char_u **errormsgp)
       xfree(l);
     }
 
-    /* Need to escape white space et al. with a backslash.
-     * Don't do this for:
-     * - replacement that already has been escaped: "##"
-     * - shell commands (may have to use quotes instead).
-     */
+    // Need to escape white space et al. with a backslash.
+    // Don't do this for:
+    // - replacement that already has been escaped: "##"
+    // - shell commands (may have to use quotes instead).
     if (!eap->usefilter
         && !escaped
         && eap->cmdidx != CMD_bang
@@ -4794,8 +4793,8 @@ static int getargopt(exarg_T *eap)
       *p = TOLOWER_ASC(*p);
     }
   } else {
-    /* Check ++bad= argument.  Must be a single-byte character, "keep" or
-     * "drop". */
+    // Check ++bad= argument.  Must be a single-byte character, "keep" or
+    // "drop".
     if (get_bad_opt(eap->cmd + bad_char_idx, eap) == FAIL) {
       return FAIL;
     }
@@ -6772,15 +6771,15 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
   int h = tabline_height();
   char_u prev_idx[NUMBUFLEN];
 
-  /* Limit to 1000 windows, autocommands may add a window while we close
-   * one.  OK, so I'm paranoid... */
+  // Limit to 1000 windows, autocommands may add a window while we close
+  // one.  OK, so I'm paranoid...
   while (++done < 1000) {
     snprintf((char *)prev_idx, sizeof(prev_idx), "%i", tabpage_index(tp));
     wp = tp->tp_lastwin;
     ex_win_close(forceit, wp, tp);
 
-    /* Autocommands may delete the tab page under our fingers and we may
-     * fail to close a window with a modified buffer. */
+    // Autocommands may delete the tab page under our fingers and we may
+    // fail to close a window with a modified buffer.
     if (!valid_tabpage(tp) || tp->tp_firstwin == wp) {
       break;
     }
@@ -7166,8 +7165,8 @@ void ex_splitview(exarg_T *eap)
                        || eap->cmdidx == CMD_tabfind
                        || eap->cmdidx == CMD_tabnew;
 
-  /* A ":split" in the quickfix window works like ":new".  Don't want two
-   * quickfix windows.  But it's OK when doing ":tab split". */
+  // A ":split" in the quickfix window works like ":new".  Don't want two
+  // quickfix windows.  But it's OK when doing ":tab split".
   if (bt_quickfix(curbuf) && cmdmod.tab == 0) {
     if (eap->cmdidx == CMD_split) {
       eap->cmdidx = CMD_new;
@@ -7514,18 +7513,18 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
           enter_cleanup(&cs);
           win_close(curwin, !need_hide && !buf_hide(curbuf));
 
-          /* Restore the error/interrupt/exception state if not
-           * discarded by a new aborting error, interrupt, or
-           * uncaught exception. */
+          // Restore the error/interrupt/exception state if not
+          // discarded by a new aborting error, interrupt, or
+          // uncaught exception.
           leave_cleanup(&cs);
         }
       }
     } else if (readonlymode && curbuf->b_nwindows == 1) {
-      /* When editing an already visited buffer, 'readonly' won't be set
-       * but the previous value is kept.  With ":view" and ":sview" we
-       * want the  file to be readonly, except when another window is
-       * editing the same buffer. */
-      curbuf->b_p_ro = TRUE;
+      // When editing an already visited buffer, 'readonly' won't be set
+      // but the previous value is kept.  With ":view" and ":sview" we
+      // want the  file to be readonly, except when another window is
+      // editing the same buffer.
+      curbuf->b_p_ro = true;
     }
     readonlymode = n;
   } else {

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -406,9 +406,9 @@ char_u *get_exception_string(void *value, except_type_T type, char_u *cmdname, i
       val = ret + 4;
     }
 
-    /* msg_add_fname may have been used to prefix the message with a file
-     * name in quotes.  In the exception value, put the file name in
-     * parentheses and move it to the end. */
+    // msg_add_fname may have been used to prefix the message with a file
+    // name in quotes.  In the exception value, put the file name in
+    // parentheses and move it to the end.
     for (p = mesg;; p++) {
       if (*p == NUL
           || (*p == 'E'
@@ -922,16 +922,14 @@ void ex_else(exarg_T *eap)
     cstack->cs_flags[cstack->cs_idx] = CSF_ACTIVE;
   }
 
-  /*
-   * When debugging or a breakpoint was encountered, display the debug prompt
-   * (if not already done).  This shows the user that an ":else" or ":elseif"
-   * is executed when the ":if" or previous ":elseif" was not TRUE.  Handle
-   * a ">quit" debug command as if an interrupt had occurred before the
-   * ":else" or ":elseif".  That is, set "skip" and throw an interrupt
-   * exception if appropriate.  Doing this here prevents that an exception
-   * for a parsing errors is discarded when throwing the interrupt exception
-   * later on.
-   */
+  // When debugging or a breakpoint was encountered, display the debug prompt
+  // (if not already done).  This shows the user that an ":else" or ":elseif"
+  // is executed when the ":if" or previous ":elseif" was not TRUE.  Handle
+  // a ">quit" debug command as if an interrupt had occurred before the
+  // ":else" or ":elseif".  That is, set "skip" and throw an interrupt
+  // exception if appropriate.  Doing this here prevents that an exception
+  // for a parsing errors is discarded when throwing the interrupt exception
+  // later on.
   if (!skip && dbg_check_skipped(eap) && got_int) {
     (void)do_intthrow(cstack);
     skip = TRUE;
@@ -1055,11 +1053,11 @@ void ex_continue(exarg_T *eap)
   if (cstack->cs_looplevel <= 0 || cstack->cs_idx < 0) {
     eap->errmsg = (char_u *)N_("E586: :continue without :while or :for");
   } else {
-    /* Try to find the matching ":while".  This might stop at a try
-     * conditional not in its finally clause (which is then to be executed
-     * next).  Therefore, deactivate all conditionals except the ":while"
-     * itself (if reached). */
-    idx = cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, FALSE);
+    // Try to find the matching ":while".  This might stop at a try
+    // conditional not in its finally clause (which is then to be executed
+    // next).  Therefore, deactivate all conditionals except the ":while"
+    // itself (if reached).
+    idx = cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, false);
     assert(idx >= 0);
     if (cstack->cs_flags[idx] & (CSF_WHILE | CSF_FOR)) {
       rewind_conditionals(cstack, idx, CSF_TRY, &cstack->cs_trylevel);
@@ -1070,8 +1068,8 @@ void ex_continue(exarg_T *eap)
        */
       cstack->cs_lflags |= CSL_HAD_CONT;        // let do_cmdline() handle it
     } else {
-      /* If a try conditional not in its finally clause is reached first,
-       * make the ":continue" pending for execution at the ":endtry". */
+      // If a try conditional not in its finally clause is reached first,
+      // make the ":continue" pending for execution at the ":endtry".
       cstack->cs_pending[idx] = CSTP_CONTINUE;
       report_make_pending(CSTP_CONTINUE, NULL);
     }
@@ -1092,7 +1090,7 @@ void ex_break(exarg_T *eap)
     // Deactivate conditionals until the matching ":while" or a try
     // conditional not in its finally clause (which is then to be
     // executed next) is found.  In the latter case, make the ":break"
-    // pending for execution at the ":endtry". */
+    // pending for execution at the ":endtry".
     idx = cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, true);
     if (idx >= 0 && !(cstack->cs_flags[idx] & (CSF_WHILE | CSF_FOR))) {
       cstack->cs_pending[idx] = CSTP_BREAK;
@@ -1155,20 +1153,17 @@ void ex_endwhile(exarg_T *eap)
       // Cleanup and rewind all contained (and unclosed) conditionals.
       (void)cleanup_conditionals(cstack, CSF_WHILE | CSF_FOR, FALSE);
       rewind_conditionals(cstack, idx, CSF_TRY, &cstack->cs_trylevel);
-    }
-    /*
-     * When debugging or a breakpoint was encountered, display the debug
-     * prompt (if not already done).  This shows the user that an
-     * ":endwhile"/":endfor" is executed when the ":while" was not TRUE or
-     * after a ":break".  Handle a ">quit" debug command as if an
-     * interrupt had occurred before the ":endwhile"/":endfor".  That is,
-     * throw an interrupt exception if appropriate.  Doing this here
-     * prevents that an exception for a parsing error is discarded when
-     * throwing the interrupt exception later on.
-     */
-    else if (cstack->cs_flags[cstack->cs_idx] & CSF_TRUE
-             && !(cstack->cs_flags[cstack->cs_idx] & CSF_ACTIVE)
-             && dbg_check_skipped(eap)) {
+    } else if (cstack->cs_flags[cstack->cs_idx] & CSF_TRUE
+               && !(cstack->cs_flags[cstack->cs_idx] & CSF_ACTIVE)
+               && dbg_check_skipped(eap)) {
+      // When debugging or a breakpoint was encountered, display the debug
+      // prompt (if not already done).  This shows the user that an
+      // ":endwhile"/":endfor" is executed when the ":while" was not TRUE or
+      // after a ":break".  Handle a ">quit" debug command as if an
+      // interrupt had occurred before the ":endwhile"/":endfor".  That is,
+      // throw an interrupt exception if appropriate.  Doing this here
+      // prevents that an exception for a parsing error is discarded when
+      // throwing the interrupt exception later on.
       (void)do_intthrow(cstack);
     }
 
@@ -1354,8 +1349,8 @@ void ex_catch(exarg_T *eap)
       }
     }
     if (cstack->cs_flags[idx] & CSF_FINALLY) {
-      /* Give up for a ":catch" after ":finally" and ignore it.
-       * Just parse. */
+      // Give up for a ":catch" after ":finally" and ignore it.
+      // Just parse.
       eap->errmsg = (char_u *)N_("E604: :catch after :finally");
       give_up = TRUE;
     } else {
@@ -1395,16 +1390,16 @@ void ex_catch(exarg_T *eap)
         return;
       }
 
-      /* When debugging or a breakpoint was encountered, display the
-       * debug prompt (if not already done) before checking for a match.
-       * This is a helpful hint for the user when the regular expression
-       * matching fails.  Handle a ">quit" debug command as if an
-       * interrupt had occurred before the ":catch".  That is, discard
-       * the original exception, replace it by an interrupt exception,
-       * and don't catch it in this try block. */
+      // When debugging or a breakpoint was encountered, display the
+      // debug prompt (if not already done) before checking for a match.
+      // This is a helpful hint for the user when the regular expression
+      // matching fails.  Handle a ">quit" debug command as if an
+      // interrupt had occurred before the ":catch".  That is, discard
+      // the original exception, replace it by an interrupt exception,
+      // and don't catch it in this try block.
       if (!dbg_check_skipped(eap) || !do_intthrow(cstack)) {
-        /* Terminate the pattern and avoid the 'l' flag in 'cpoptions'
-         * while compiling it. */
+        // Terminate the pattern and avoid the 'l' flag in 'cpoptions'
+        // while compiling it.
         if (end != NULL) {
           save_char = *end;
           *end = NUL;
@@ -1440,16 +1435,16 @@ void ex_catch(exarg_T *eap)
     }
 
     if (caught) {
-      /* Make this ":catch" clause active and reset did_emsg and got_int.
-       * Put the exception on the caught stack. */
+      // Make this ":catch" clause active and reset did_emsg and got_int.
+      // Put the exception on the caught stack.
       cstack->cs_flags[idx] |= CSF_ACTIVE | CSF_CAUGHT;
       did_emsg = got_int = false;
       catch_exception((except_T *)cstack->cs_exception[idx]);
-      /* It's mandatory that the current exception is stored in the cstack
-       * so that it can be discarded at the next ":catch", ":finally", or
-       * ":endtry" or when the catch clause is left by a ":continue",
-       * ":break", ":return", ":finish", error, interrupt, or another
-       * exception. */
+      // It's mandatory that the current exception is stored in the cstack
+      // so that it can be discarded at the next ":catch", ":finally", or
+      // ":endtry" or when the catch clause is left by a ":continue",
+      // ":break", ":return", ":finish", error, interrupt, or another
+      // exception.
       if (cstack->cs_exception[cstack->cs_idx] != current_exception) {
         internal_error("ex_catch()");
       }
@@ -1576,13 +1571,13 @@ void ex_finally(exarg_T *eap)
         assert(pending >= CHAR_MIN && pending <= CHAR_MAX);
         cstack->cs_pending[cstack->cs_idx] = (char)pending;
 
-        /* It's mandatory that the current exception is stored in the
-         * cstack so that it can be rethrown at the ":endtry" or be
-         * discarded if the finally clause is left by a ":continue",
-         * ":break", ":return", ":finish", error, interrupt, or another
-         * exception.  When emsg() is called for a missing ":endif" or
-         * a missing ":endwhile"/":endfor" detected here, the
-         * exception will be discarded. */
+        // It's mandatory that the current exception is stored in the
+        // cstack so that it can be rethrown at the ":endtry" or be
+        // discarded if the finally clause is left by a ":continue",
+        // ":break", ":return", ":finish", error, interrupt, or another
+        // exception.  When emsg() is called for a missing ":endif" or
+        // a missing ":endwhile"/":endfor" detected here, the
+        // exception will be discarded.
         if (current_exception
             && cstack->cs_exception[cstack->cs_idx] != current_exception) {
           internal_error("ex_finally()");
@@ -1666,21 +1661,20 @@ void ex_endtry(exarg_T *eap)
       }
     }
 
-    /* If there was no finally clause, show the user when debugging or
-     * a breakpoint was encountered that the end of the try conditional has
-     * been reached: display the debug prompt (if not already done).  Do
-     * this on normal control flow or when an exception was thrown, but not
-     * on an interrupt or error not converted to an exception or when
-     * a ":break", ":continue", ":return", or ":finish" is pending.  These
-     * actions are carried out immediately.
-     */
+    // If there was no finally clause, show the user when debugging or
+    // a breakpoint was encountered that the end of the try conditional has
+    // been reached: display the debug prompt (if not already done).  Do
+    // this on normal control flow or when an exception was thrown, but not
+    // on an interrupt or error not converted to an exception or when
+    // a ":break", ":continue", ":return", or ":finish" is pending.  These
+    // actions are carried out immediately.
     if ((rethrow || (!skip
                      && !(cstack->cs_flags[idx] & CSF_FINALLY)
                      && !cstack->cs_pending[idx]))
         && dbg_check_skipped(eap)) {
-      /* Handle a ">quit" debug command as if an interrupt had occurred
-       * before the ":endtry".  That is, throw an interrupt exception and
-       * set "skip" and "rethrow". */
+      // Handle a ">quit" debug command as if an interrupt had occurred
+      // before the ":endtry".  That is, throw an interrupt exception and
+      // set "skip" and "rethrow".
       if (got_int) {
         skip = TRUE;
         (void)do_intthrow(cstack);
@@ -1815,13 +1809,12 @@ void enter_cleanup(cleanup_T *csp)
                    | (current_exception ? CSTP_THROW : 0)
                    | (need_rethrow ? CSTP_THROW : 0);
 
-    /* If we are currently throwing an exception, save it as well.  On an error
-     * not yet converted to an exception, update "force_abort" and reset
-     * "cause_abort" (as do_errthrow() would do).  This is needed for the
-     * do_cmdline() call that is going to be made for autocommand execution.  We
-     * need not save *msg_list because there is an extra instance for every call
-     * of do_cmdline(), anyway.
-     */
+    // If we are currently throwing an exception, save it as well.  On an error
+    // not yet converted to an exception, update "force_abort" and reset
+    // "cause_abort" (as do_errthrow() would do).  This is needed for the
+    // do_cmdline() call that is going to be made for autocommand execution.  We
+    // need not save *msg_list because there is an extra instance for every call
+    // of do_cmdline(), anyway.
     if (current_exception || need_rethrow) {
       csp->exception = current_exception;
       current_exception = NULL;
@@ -1897,13 +1890,10 @@ void leave_cleanup(cleanup_T *csp)
      */
     if (pending & CSTP_THROW) {
       current_exception = csp->exception;
-    }
-    /*
-     * If an error was about to be converted to an exception when
-     * enter_cleanup() was called, let "cause_abort" take the part of
-     * "force_abort" (as done by cause_errthrow()).
-     */
-    else if (pending & CSTP_ERROR) {
+    } else if (pending & CSTP_ERROR) {
+      // If an error was about to be converted to an exception when
+      // enter_cleanup() was called, let "cause_abort" take the part of
+      // "force_abort" (as done by cause_errthrow()).
       cause_abort = force_abort;
       force_abort = FALSE;
     }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2625,8 +2625,8 @@ static void realloc_cmdbuff(int len)
 
   char_u *p = ccline.cmdbuff;
   alloc_cmdbuff(len);                   // will get some more
-  /* There isn't always a NUL after the command, but it may need to be
-   * there, thus copy up to the NUL and add a NUL. */
+  // There isn't always a NUL after the command, but it may need to be
+  // there, thus copy up to the NUL and add a NUL.
   memmove(ccline.cmdbuff, p, (size_t)ccline.cmdlen);
   ccline.cmdbuff[ccline.cmdlen] = NUL;
   xfree(p);
@@ -3427,24 +3427,24 @@ static bool cmdline_paste(int regname, bool literally, bool remcr)
   bool allocated;
   struct cmdline_info save_ccline;
 
-  /* check for valid regname; also accept special characters for CTRL-R in
-   * the command line */
+  // check for valid regname; also accept special characters for CTRL-R in
+  // the command line
   if (regname != Ctrl_F && regname != Ctrl_P && regname != Ctrl_W
       && regname != Ctrl_A && regname != Ctrl_L
       && !valid_yank_reg(regname, false)) {
     return FAIL;
   }
 
-  /* A register containing CTRL-R can cause an endless loop.  Allow using
-   * CTRL-C to break the loop. */
+  // A register containing CTRL-R can cause an endless loop.  Allow using
+  // CTRL-C to break the loop.
   line_breakcheck();
   if (got_int) {
     return FAIL;
   }
 
 
-  /* Need to save and restore ccline.  And set "textlock" to avoid nasty
-   * things like going to another buffer when evaluating an expression. */
+  // Need to save and restore ccline.  And set "textlock" to avoid nasty
+  // things like going to another buffer when evaluating an expression.
   save_cmdline(&save_ccline);
   textlock++;
   const bool i = get_spec_reg(regname, &arg, &allocated, true);
@@ -6411,8 +6411,8 @@ static int open_cmdwin(void)
     }
   }
 
-  /* Replace the empty last line with the current command-line and put the
-   * cursor there. */
+  // Replace the empty last line with the current command-line and put the
+  // cursor there.
   ml_replace(curbuf->b_ml.ml_line_count, ccline.cmdbuff, true);
   curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
   curwin->w_cursor.col = ccline.cmdpos;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -224,8 +224,8 @@ int readfile(char_u *fname, char_u *sfname, linenr_T from, linenr_T lines_to_ski
   bool keep_dest_enc = false;           // don't retry when char doesn't fit
                                         // in destination encoding
   int bad_char_behavior = BAD_REPLACE;
-  /* BAD_KEEP, BAD_DROP or character to
-   * replace with */
+  // BAD_KEEP, BAD_DROP or character to
+  // replace with
   char_u *tmpname = NULL;          // name of 'charconvert' output file
   int fio_flags = 0;
   char_u *fenc;                    // fileencoding to use
@@ -280,8 +280,8 @@ int readfile(char_u *fname, char_u *sfname, linenr_T from, linenr_T lines_to_ski
                    || (sfname == curbuf->b_ffname);
   using_b_fname = (fname == curbuf->b_fname) || (sfname == curbuf->b_fname);
 
-  /* After reading a file the cursor line changes but we don't want to
-   * display the line. */
+  // After reading a file the cursor line changes but we don't want to
+  // display the line.
   ex_no_reprint = true;
 
   // don't display the file info for another buffer now
@@ -454,9 +454,9 @@ int readfile(char_u *fname, char_u *sfname, linenr_T from, linenr_T lines_to_ski
       // been created by someone else, a ":w" will complain.
       curbuf->b_flags |= BF_NEW;
 
-      /* Create a swap file now, so that other Vims are warned
-       * that we are editing this file.  Don't do this for a
-       * "nofile" or "nowrite" buffer type. */
+      // Create a swap file now, so that other Vims are warned
+      // that we are editing this file.  Don't do this for a
+      // "nofile" or "nowrite" buffer type.
       if (!bt_dontwrite(curbuf)) {
         check_need_swap(newfile);
         // SwapExists autocommand may mess things up
@@ -524,9 +524,9 @@ int readfile(char_u *fname, char_u *sfname, linenr_T from, linenr_T lines_to_ski
     curbuf->b_start_bomb = FALSE;
   }
 
-  /* Create a swap file now, so that other Vims are warned that we are
-   * editing this file.
-   * Don't do this for a "nofile" or "nowrite" buffer type. */
+  // Create a swap file now, so that other Vims are warned that we are
+  // editing this file.
+  // Don't do this for a "nofile" or "nowrite" buffer type.
   if (!bt_dontwrite(curbuf)) {
     check_need_swap(newfile);
     if (!read_stdin
@@ -854,8 +854,8 @@ retry:
 #ifdef HAVE_ICONV
       did_iconv = false;
 #endif
-      /* Skip conversion when it's already done (retry for wrong
-       * "fileformat"). */
+      // Skip conversion when it's already done (retry for wrong
+      // "fileformat").
       if (tmpname == NULL) {
         tmpname = readfile_charconvert(fname, fenc, &fd);
         if (tmpname == NULL) {
@@ -876,17 +876,17 @@ retry:
           && iconv_fd == (iconv_t)-1
 #endif
           ) {
-        /* Conversion wanted but we can't.
-         * Try the next conversion in 'fileencodings' */
+        // Conversion wanted but we can't.
+        // Try the next conversion in 'fileencodings'
         advance_fenc = true;
         goto retry;
       }
     }
   }
 
-  /* Set "can_retry" when it's possible to rewind the file and try with
-   * another "fenc" value.  It's FALSE when no other "fenc" to try, reading
-   * stdin or fixed at a specific encoding. */
+  // Set "can_retry" when it's possible to rewind the file and try with
+  // another "fenc" value.  It's FALSE when no other "fenc" to try, reading
+  // stdin or fixed at a specific encoding.
   can_retry = (*fenc != NUL && !read_stdin && !keep_dest_enc && !read_fifo);
 
   if (!skip_read) {
@@ -1014,9 +1014,9 @@ retry:
                 read_buf_col += n;
                 break;
               } else {
-                /* Append whole line and new-line.  Change NL
-                * to NUL to reverse the effect done below. */
-                for (ni = 0; ni < n; ++ni) {
+                // Append whole line and new-line.  Change NL
+                // to NUL to reverse the effect done below.
+                for (ni = 0; ni < n; ni++) {
                   if (p[ni] == NL) {
                     ptr[tlen++] = NUL;
                   } else {
@@ -1076,10 +1076,10 @@ retry:
               *(ptr - conv_restlen) = NUL;
               conv_restlen = 0;
             } else {
-              /* Replace the trailing bytes with the replacement
-               * character if we were converting; if we weren't,
-               * leave the UTF8 checking code to do it, as it
-               * works slightly differently. */
+              // Replace the trailing bytes with the replacement
+              // character if we were converting; if we weren't,
+              // leave the UTF8 checking code to do it, as it
+              // works slightly differently.
               if (bad_char_behavior != BAD_KEEP && (fio_flags != 0
 #ifdef HAVE_ICONV
                                                     || iconv_fd != (iconv_t)-1
@@ -1212,8 +1212,8 @@ retry:
         }
 
         if (from_size > 0) {
-          /* Some remaining characters, keep them for the next
-           * round. */
+          // Some remaining characters, keep them for the next
+          // round.
           memmove(conv_rest, (char_u *)fromp, from_size);
           conv_restlen = (int)from_size;
         }
@@ -1752,11 +1752,11 @@ failed:
     }
     if (newfile || read_buffer) {
       redraw_curbuf_later(NOT_VALID);
-      /* After reading the text into the buffer the diff info needs to
-       * be updated. */
+      // After reading the text into the buffer the diff info needs to
+      // be updated.
       diff_invalidate(curbuf);
-      /* All folds in the window are invalid now.  Mark them for update
-       * before triggering autocommands. */
+      // All folds in the window are invalid now.  Mark them for update
+      // before triggering autocommands.
       foldUpdateAll(curwin);
     } else if (linecnt) {               // appended at least one line
       appended_lines_mark(from, linecnt);
@@ -2129,8 +2129,8 @@ static char_u *readfile_charconvert(char_u *fname, char_u *fenc, int *fdp)
   }
 
   if (errmsg != NULL) {
-    /* Don't use emsg(), it breaks mappings, the retry with
-     * another type of conversion might still work. */
+    // Don't use emsg(), it breaks mappings, the retry with
+    // another type of conversion might still work.
     MSG(errmsg);
     if (tmpname != NULL) {
       os_remove((char *)tmpname);  // delete converted file
@@ -3908,9 +3908,9 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
 static bool time_differs(long t1, long t2) FUNC_ATTR_CONST
 {
 #if defined(__linux__) || defined(MSWIN)
-  /* On a FAT filesystem, esp. under Linux, there are only 5 bits to store
-   * the seconds.  Since the roundoff is done when flushing the inode, the
-   * time may change unexpectedly by one second!!! */
+  // On a FAT filesystem, esp. under Linux, there are only 5 bits to store
+  // the seconds.  Since the roundoff is done when flushing the inode, the
+  // time may change unexpectedly by one second!!!
   return t1 - t2 > 1 || t2 - t1 > 1;
 #else
   return t1 != t2;
@@ -4192,8 +4192,8 @@ static bool need_conversion(const char_u *fenc)
     same_encoding = TRUE;
     fenc_flags = 0;
   } else {
-    /* Ignore difference between "ansi" and "latin1", "ucs-4" and
-     * "ucs-4be", etc. */
+    // Ignore difference between "ansi" and "latin1", "ucs-4" and
+    // "ucs-4be", etc.
     enc_flags = get_fio_flags(p_enc);
     fenc_flags = get_fio_flags(fenc);
     same_encoding = (enc_flags != 0 && fenc_flags == enc_flags);
@@ -4203,8 +4203,8 @@ static bool need_conversion(const char_u *fenc)
     return false;
   }
 
-  /* Encodings differ.  However, conversion is not needed when 'enc' is any
-   * Unicode encoding and the file is UTF-8. */
+  // Encodings differ.  However, conversion is not needed when 'enc' is any
+  // Unicode encoding and the file is UTF-8.
   return !(fenc_flags == FIO_UTF8);
 }
 
@@ -4697,8 +4697,8 @@ int vim_rename(const char_u *from, const char_u *to)
           (void)os_rename(tempname, from);
           return -1;
         }
-        /* If it fails for one temp name it will most likely fail
-         * for any temp name, give up. */
+        // If it fails for one temp name it will most likely fail
+        // for any temp name, give up.
         return -1;
       }
     }
@@ -4954,8 +4954,8 @@ int buf_check_timestamp(buf_T *buf)
       buf_store_file_info(buf, &file_info);
     }
 
-    /* Don't do anything for a directory.  Might contain the file
-     * explorer. */
+    // Don't do anything for a directory.  Might contain the file
+    // explorer.
     if (os_isdir(buf->b_fname)) {
     } else if ((buf->b_p_ar >= 0 ? buf->b_p_ar : p_ar)
                && !bufIsChanged(buf) && file_info_ok) {
@@ -5217,8 +5217,8 @@ void buf_reload(buf_T *buf, int orig_mode)
   // Invalidate diff info if necessary.
   diff_invalidate(curbuf);
 
-  /* Restore the topline and cursor position and check it (lines may
-   * have been removed). */
+  // Restore the topline and cursor position and check it (lines may
+  // have been removed).
   if (old_topline > curbuf->b_ml.ml_line_count) {
     curwin->w_topline = curbuf->b_ml.ml_line_count;
   } else {
@@ -5237,9 +5237,9 @@ void buf_reload(buf_T *buf, int orig_mode)
     }
   }
 
-  /* If the mode didn't change and 'readonly' was set, keep the old
-   * value; the user probably used the ":view" command.  But don't
-   * reset it, might have had a read error. */
+  // If the mode didn't change and 'readonly' was set, keep the old
+  // value; the user probably used the ":view" command.  But don't
+  // reset it, might have had a read error.
   if (orig_mode == curbuf->b_orig_mode) {
     curbuf->b_p_ro |= old_ro;
   }
@@ -5754,8 +5754,8 @@ long write_eintr(int fd, void *buf, size_t bufsize)
   long ret = 0;
   long wlen;
 
-  /* Repeat the write() so long it didn't fail, other than being interrupted
-   * by a signal. */
+  // Repeat the write() so long it didn't fail, other than being interrupted
+  // by a signal.
   while (ret < (long)bufsize) {
     wlen = write(fd, (char *)buf + ret, bufsize - ret);
     if (wlen < 0) {

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -72,12 +72,12 @@ typedef struct {
   linenr_T lnum_save;           // line nr used by foldUpdateIEMSRecurse()
   int lvl;                      // current level (-1 for undefined)
   int lvl_next;                 // level used for next line
-  int start;                    /* number of folds that are forced to start at
-                                   this line. */
-  int end;                      /* level of fold that is forced to end below
-                                   this line */
-  int had_end;                  /* level of fold that is forced to end above
-                                   this line (copy of "end" of prev. line) */
+  int start;                    // number of folds that are forced to start at
+                                // this line.
+  int end;                      // level of fold that is forced to end below
+                                // this line
+  int had_end;                  // level of fold that is forced to end above
+                                // this line (copy of "end" of prev. line)
 } fline_T;
 
 // Flag is set when redrawing is needed.
@@ -405,8 +405,8 @@ void opFoldRange(pos_T firstpos, pos_T lastpos, int opening, int recurse, int ha
   for (lnum = first; lnum <= last; lnum = lnum_next + 1) {
     pos_T temp = { lnum, 0, 0 };
     lnum_next = lnum;
-    /* Opening one level only: next fold to open is after the one going to
-     * be opened. */
+    // Opening one level only: next fold to open is after the one going to
+    // be opened.
     if (opening && !recurse) {
       (void)hasFolding(lnum, NULL, &lnum_next);
     }
@@ -639,8 +639,8 @@ void foldCreate(win_T *wp, pos_T start, pos_T end)
     }
     if (cont > 0) {
       ga_grow(&fold_ga, cont);
-      /* If the first fold starts before the new fold, let the new fold
-       * start there.  Otherwise the existing fold would change. */
+      // If the first fold starts before the new fold, let the new fold
+      // start there.  Otherwise the existing fold would change.
       if (start_rel.lnum > fp->fd_top) {
         start_rel.lnum = fp->fd_top;
       }
@@ -655,8 +655,8 @@ void foldCreate(win_T *wp, pos_T start, pos_T end)
       fold_ga.ga_len += cont;
       i += cont;
 
-      /* Adjust line numbers in contained folds to be relative to the
-       * new fold. */
+      // Adjust line numbers in contained folds to be relative to the
+      // new fold.
       for (int j = 0; j < cont; j++) {
         ((fold_T *)fold_ga.ga_data)[j].fd_top -= start_rel.lnum;
       }
@@ -673,9 +673,8 @@ void foldCreate(win_T *wp, pos_T start, pos_T end)
     fp->fd_top = start_rel.lnum;
     fp->fd_len = end_rel.lnum - start_rel.lnum + 1;
 
-    /* We want the new fold to be closed.  If it would remain open because
-     * of using 'foldlevel', need to adjust fd_flags of containing folds.
-     */
+    // We want the new fold to be closed.  If it would remain open because
+    // of using 'foldlevel', need to adjust fd_flags of containing folds.
     if (use_level && !closed && level < wp->w_p_fdl) {
       closeFold(start, 1L);
     }
@@ -916,8 +915,8 @@ int foldMoveTo(const bool updown, const int dir, const long count)
             break;
           }
         }
-        /* don't look for contained folds, they will always move
-         * the cursor too far. */
+        // don't look for contained folds, they will always move
+        // the cursor too far.
         last = true;
       }
 
@@ -953,8 +952,8 @@ int foldMoveTo(const bool updown, const int dir, const long count)
           }
         }
       } else {
-        /* Open fold found, set cursor to its start/end and then check
-         * nested folds. */
+        // Open fold found, set cursor to its start/end and then check
+        // nested folds.
         if (dir == FORWARD) {
           lnum = fp->fd_top + lnum_off + fp->fd_len - 1;
           if (lnum > curwin->w_cursor.lnum) {
@@ -1375,8 +1374,8 @@ static void deleteFoldEntry(win_T *const wp, garray_T *const gap, const int idx,
       memmove(fp, fp + 1, sizeof(*fp) * (size_t)(gap->ga_len - idx));
     }
   } else {
-    /* Move nested folds one level up, to overwrite the fold that is
-     * deleted. */
+    // Move nested folds one level up, to overwrite the fold that is
+    // deleted.
     int moved = fp->fd_nested.ga_len;
     ga_grow(gap, moved - 1);
     {
@@ -1517,8 +1516,8 @@ static void foldMarkAdjustRecurse(win_T *wp, garray_T *gap, linenr_T line1, line
             fp->fd_len += amount_after;
           }
         } else {
-          /* 5. fold is below line1 and contains line2; need to
-           * correct nested folds too */
+          // 5. fold is below line1 and contains line2; need to
+          // correct nested folds too
           if (amount == MAXLNUM) {
             foldMarkAdjustRecurse(wp, &fp->fd_nested, line1 - fp->fd_top,
                                   line2 - fp->fd_top, amount,
@@ -1660,8 +1659,8 @@ static void foldCreateMarkers(win_T *wp, pos_T start, pos_T end)
   foldAddMarker(buf, start, wp->w_p_fmr, foldstartmarkerlen);
   foldAddMarker(buf, end, foldendmarker, foldendmarkerlen);
 
-  /* Update both changes here, to avoid all folds after the start are
-   * changed when the start marker is inserted and the end isn't. */
+  // Update both changes here, to avoid all folds after the start are
+  // changed when the start marker is inserted and the end isn't.
   // TODO(teto): pass the buffer
   changed_lines(start.lnum, (colnr_T)0, end.lnum, 0L, false);
 
@@ -1857,8 +1856,8 @@ char_u *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldin
     }
 
     if (text != NULL) {
-      /* Replace unprintable characters, if there are any.  But
-       * replace a TAB with a space. */
+      // Replace unprintable characters, if there are any.  But
+      // replace a TAB with a space.
       for (p = text; *p != NUL; p++) {
         int len = utfc_ptr2len(p);
 
@@ -1941,10 +1940,9 @@ void foldtext_cleanup(char_u *str)
         ++len;
       }
 
-      /* May remove 'commentstring' start.  Useful when it's a double
-       * quote and we already removed a double quote. */
-      for (p = s; p > str && ascii_iswhite(p[-1]); --p) {
-        ;
+      // May remove 'commentstring' start.  Useful when it's a double
+      // quote and we already removed a double quote.
+      for (p = s; p > str && ascii_iswhite(p[-1]); p--) {
       }
       if (p >= str + cms_slen
           && STRNCMP(p - cms_slen, cms_start, cms_slen) == 0) {
@@ -2074,12 +2072,12 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
       getlevel = foldlevelIndent;
     }
 
-    /* Backup to a line for which the fold level is defined.  Since it's
-     * always defined for line one, we will stop there. */
+    // Backup to a line for which the fold level is defined.  Since it's
+    // always defined for line one, we will stop there.
     fline.lvl = -1;
-    for (; !got_int; --fline.lnum) {
-      /* Reset lvl_next each time, because it will be set to a value for
-       * the next line, but we search backwards here. */
+    for (; !got_int; fline.lnum--) {
+      // Reset lvl_next each time, because it will be set to a value for
+      // the next line, but we search backwards here.
       fline.lvl_next = -1;
       getlevel(&fline);
       if (fline.lvl >= 0) {
@@ -2128,15 +2126,15 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
     end = start;
   }
   while (!got_int) {
-    /* Always stop at the end of the file ("end" can be past the end of
-     * the file). */
+    // Always stop at the end of the file ("end" can be past the end of
+    // the file).
     if (fline.lnum > wp->w_buffer->b_ml.ml_line_count) {
       break;
     }
     if (fline.lnum > end) {
-      /* For "marker", "expr"  and "syntax"  methods: If a change caused
-       * a fold to be removed, we need to continue at least until where
-       * it ended. */
+      // For "marker", "expr"  and "syntax"  methods: If a change caused
+      // a fold to be removed, we need to continue at least until where
+      // it ended.
       if (getlevel != foldlevelMarker
           && getlevel != foldlevelSyntax
           && getlevel != foldlevelExpr) {
@@ -2334,17 +2332,17 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
        * firstlnum.
        */
       while (!got_int) {
-        /* set concat to 1 if it's allowed to concatenated this fold
-         * with a previous one that touches it. */
+        // set concat to 1 if it's allowed to concatenated this fold
+        // with a previous one that touches it.
         if (flp->start != 0 || flp->had_end <= MAX_LEVEL) {
           concat = 0;
         } else {
           concat = 1;
         }
 
-        /* Find an existing fold to re-use.  Preferably one that
-         * includes startlnum, otherwise one that ends just before
-         * startlnum or starts after it. */
+        // Find an existing fold to re-use.  Preferably one that
+        // includes startlnum, otherwise one that ends just before
+        // startlnum or starts after it.
         if (gap->ga_len > 0
             && (foldFind(gap, startlnum, &fp)
                 || (fp < ((fold_T *)gap->ga_data) + gap->ga_len
@@ -2405,9 +2403,9 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
               i = (int)(fp - (fold_T *)gap->ga_data);
               foldSplit(flp->wp->w_buffer, gap, i, breakstart, breakend - 1);
               fp = (fold_T *)gap->ga_data + i + 1;
-              /* If using the "marker" or "syntax" method, we
-               * need to continue until the end of the fold is
-               * found. */
+              // If using the "marker" or "syntax" method, we
+              // need to continue until the end of the fold is
+              // found.
               if (getlevel == foldlevelMarker
                   || getlevel == foldlevelExpr
                   || getlevel == foldlevelSyntax) {
@@ -2433,8 +2431,8 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
             deleteFoldEntry(flp->wp, gap,
                             (int)(fp - (fold_T *)gap->ga_data), true);
           } else {
-            /* A fold has some lines above startlnum, truncate it
-             * to stop just above startlnum.  */
+            // A fold has some lines above startlnum, truncate it
+            // to stop just above startlnum.
             fp->fd_len = startlnum - fp->fd_top;
             foldMarkAdjustRecurse(flp->wp, &fp->fd_nested,
                                   fp->fd_len, (linenr_T)MAXLNUM,
@@ -2442,8 +2440,8 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
             fold_changed = true;
           }
         } else {
-          /* Insert new fold.  Careful: ga_data may be NULL and it
-           * may change! */
+          // Insert new fold.  Careful: ga_data may be NULL and it
+          // may change!
           if (gap->ga_len == 0) {
             i = 0;
           } else {
@@ -2451,13 +2449,13 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
           }
           foldInsert(gap, i);
           fp = (fold_T *)gap->ga_data + i;
-          /* The new fold continues until bot, unless we find the
-           * end earlier. */
+          // The new fold continues until bot, unless we find the
+          // end earlier.
           fp->fd_top = firstlnum;
           fp->fd_len = bot - firstlnum + 1;
-          /* When the containing fold is open, the new fold is open.
-           * The new fold is closed if the fold above it is closed.
-           * The first fold depends on the containing fold. */
+          // When the containing fold is open, the new fold is open.
+          // The new fold is closed if the fold above it is closed.
+          // The first fold depends on the containing fold.
           if (topflags == FD_OPEN) {
             flp->wp->w_fold_manual = true;
             fp->fd_flags = FD_OPEN;
@@ -2684,8 +2682,8 @@ static void foldSplit(buf_T *buf, garray_T *const gap, const int i, const linenr
   fp[1].fd_small = kNone;
   fp->fd_small = kNone;
 
-  /* Move nested folds below bot to new fold.  There can't be
-   * any between top and bot, they have been removed by the caller. */
+  // Move nested folds below bot to new fold.  There can't be
+  // any between top and bot, they have been removed by the caller.
   garray_T *const gap1 = &fp->fd_nested;
   garray_T *const gap2 = &fp[1].fd_nested;
   if (foldFind(gap1, bot + 1 - fp->fd_top, &fp2)) {
@@ -3039,8 +3037,8 @@ static void foldlevelExpr(fline_T *flp)
     flp->lvl = 0;
   }
 
-  /* KeyTyped may be reset to 0 when calling a function which invokes
-   * do_cmdline().  To make 'foldopen' work correctly restore KeyTyped. */
+  // KeyTyped may be reset to 0 when calling a function which invokes
+  // do_cmdline().  To make 'foldopen' work correctly restore KeyTyped.
   const bool save_keytyped = KeyTyped;
   const int n = eval_foldexpr(flp->wp->w_p_fde, &c);
   KeyTyped = save_keytyped;
@@ -3308,9 +3306,9 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
           }
         }
       } else {
-        /* Open or close the leaf according to the window foldlevel.
-         * Do not close a leaf that is already closed, as it will close
-         * the parent. */
+        // Open or close the leaf according to the window foldlevel.
+        // Do not close a leaf that is already closed, as it will close
+        // the parent.
         level = foldLevelWin(wp, off + fp->fd_top);
         if ((fp->fd_flags == FD_CLOSED && wp->w_p_fdl >= level)
             || (fp->fd_flags != FD_CLOSED && wp->w_p_fdl < level)) {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -144,10 +144,9 @@ static int KeyNoremap = 0;                  // remapping flags
 #define RM_SCRIPT       2       // tb_noremap: remap local script mappings
 #define RM_ABBR         4       // tb_noremap: don't remap, do abbrev.
 
-/* typebuf.tb_buf has three parts: room in front (for result of mappings), the
- * middle for typeahead and room for new characters (which needs to be 3 *
- * MAXMAPLEN) for the Amiga).
- */
+// typebuf.tb_buf has three parts: room in front (for result of mappings), the
+// middle for typeahead and room for new characters (which needs to be 3 *
+// MAXMAPLEN) for the Amiga).
 #define TYPELEN_INIT    (5 * (MAXMAPLEN + 3))
 static char_u typebuf_init[TYPELEN_INIT];       // initial typebuf.tb_buf
 static char_u noremapbuf_init[TYPELEN_INIT];    // initial typebuf.tb_noremap
@@ -682,7 +681,7 @@ static int read_redo(bool init, bool old_redo)
   if ((c = *p) == NUL) {
     return c;
   }
-  // Reverse the conversion done by add_char_buff() */
+  // Reverse the conversion done by add_char_buff()
   // For a multi-byte character get all the bytes and return the
   // converted character.
   if (c != K_SPECIAL || p[1] == KS_SPECIAL) {
@@ -966,9 +965,9 @@ int ins_typebuf(char_u *str, int noremap, int offset, bool nottyped, bool silent
       (char_u)((--nrm >= 0) ? val : RM_YES);
   }
 
-  /* tb_maplen and tb_silent only remember the length of mapped and/or
-   * silent mappings at the start of the buffer, assuming that a mapped
-   * sequence doesn't result in typed characters. */
+  // tb_maplen and tb_silent only remember the length of mapped and/or
+  // silent mappings at the start of the buffer, assuming that a mapped
+  // sequence doesn't result in typed characters.
   if (nottyped || typebuf.tb_maplen > offset) {
     typebuf.tb_maplen += addlen;
   }
@@ -1116,8 +1115,8 @@ void del_typebuf(int len, int offset)
     }
   }
 
-  /* Reset the flag that text received from a client or from feedkeys()
-   * was inserted in the typeahead buffer. */
+  // Reset the flag that text received from a client or from feedkeys()
+  // was inserted in the typeahead buffer.
   typebuf_was_filled = false;
   if (++typebuf.tb_change_cnt == 0) {
     typebuf.tb_change_cnt = 1;
@@ -1167,9 +1166,9 @@ static void gotchars(const char_u *chars, size_t len)
   // output "debug mode" message next time in debug mode
   debug_did_msg = false;
 
-  /* Since characters have been typed, consider the following to be in
-   * another mapping.  Search string will be kept in history. */
-  ++maptick;
+  // Since characters have been typed, consider the following to be in
+  // another mapping.  Search string will be kept in history.
+  maptick++;
 }
 
 /*
@@ -1823,8 +1822,8 @@ static int vgetorpeek(bool advance)
           flush_buffers(FLUSH_INPUT);  // flush all typeahead
 
           if (advance) {
-            /* Also record this character, it might be needed to
-             * get out of Insert mode. */
+            // Also record this character, it might be needed to
+            // get out of Insert mode.
             *typebuf.tb_buf = (char_u)c;
             gotchars(typebuf.tb_buf, 1);
           }
@@ -2311,13 +2310,13 @@ static int vgetorpeek(bool advance)
         /*
          * get a character: 3. from the user - update display
          */
-        /* In insert mode a screen update is skipped when characters
-         * are still available.  But when those available characters
-         * are part of a mapping, and we are going to do a blocking
-         * wait here.  Need to update the screen to display the
-         * changed text so far. Also for when 'lazyredraw' is set and
-         * redrawing was postponed because there was something in the
-         * input buffer (e.g., termresponse). */
+        // In insert mode a screen update is skipped when characters
+        // are still available.  But when those available characters
+        // are part of a mapping, and we are going to do a blocking
+        // wait here.  Need to update the screen to display the
+        // changed text so far. Also for when 'lazyredraw' is set and
+        // redrawing was postponed because there was something in the
+        // input buffer (e.g., termresponse).
         if (((State & INSERT) != 0 || p_lz) && (State & CMDLINE) == 0
             && advance && must_redraw != 0 && !need_wait_return) {
           update_screen(0);

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -794,8 +794,8 @@ void ex_hardcopy(exarg_T *eap)
                 break;                 // reached the end
               }
             } else if (prtpos.ff) {
-              /* Line had a formfeed in it - start new page but
-               * stay on the current line */
+              // Line had a formfeed in it - start new page but
+              // stay on the current line
               break;
             }
           }
@@ -1505,9 +1505,8 @@ static void prt_flush_buffer(void)
       prt_write_real(b / 255.0, 3);
       prt_write_string("bg\n");
     }
-    /* Draw underlines before the text as it makes it slightly easier to
-     * find the starting point.
-     */
+    // Draw underlines before the text as it makes it slightly easier to
+    // find the starting point.
     if (prt_do_underline) {
       if (prt_do_moveto) {
         prt_write_real(prt_pos_x_moveto, 2);
@@ -1696,9 +1695,8 @@ static bool prt_next_dsc(struct prt_dsc_line_S *p_dsc_line)
   return true;
 }
 
-/* Improved hand crafted parser to get the type, title, and version number of a
- * PS resource file so the file details can be added to the DSC header comments.
- */
+/// Improved hand crafted parser to get the type, title, and version number of a
+/// PS resource file so the file details can be added to the DSC header comments.
 static bool prt_open_resource(struct prt_ps_resource_S *resource)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -1906,9 +1904,8 @@ static void prt_dsc_font_resource(char *resource, struct prt_ps_font_S *ps_font)
 
 static void prt_dsc_requirements(int duplex, int tumble, int collate, int color, int num_copies)
 {
-  /* Only output the comment if we need to.
-   * Note: tumble is ignored if we are not duplexing
-   */
+  // Only output the comment if we need to.
+  // Note: tumble is ignored if we are not duplexing
   if (!(duplex || collate || color || (num_copies > 1))) {
     return;
   }
@@ -1967,10 +1964,9 @@ void mch_print_cleanup(void)
   if (prt_out_mbyte) {
     int i;
 
-    /* Free off all CID font names created, but first clear duplicate
-     * pointers to the same string (when the same font is used for more than
-     * one style).
-     */
+    // Free off all CID font names created, but first clear duplicate
+    // pointers to the same string (when the same font is used for more than
+    // one style).
     for (i = PRT_PS_FONT_ROMAN; i <= PRT_PS_FONT_BOLDOBLIQUE; i++) {
       if (prt_ps_mb_font.ps_fontname[i] != NULL) {
         xfree(prt_ps_mb_font.ps_fontname[i]);
@@ -2048,9 +2044,8 @@ static int prt_get_cpl(void)
 {
   if (prt_use_number()) {
     prt_number_width = PRINT_NUMBER_WIDTH * prt_char_width;
-    /* If we are outputting multi-byte characters then line numbers will be
-     * printed with half width characters
-     */
+    // If we are outputting multi-byte characters then line numbers will be
+    // printed with half width characters
     if (prt_out_mbyte) {
       prt_number_width /= 2;
     }
@@ -2168,10 +2163,10 @@ int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
     p_encoding = enc_skip(p_enc);
   }
 
-  /* Look for a multi-byte font that matches the encoding and character set.
-   * Only look if multi-byte character set is defined, or using multi-byte
-   * encoding other than Unicode.  This is because a Unicode encoding does not
-   * uniquely identify a CJK character set to use. */
+  // Look for a multi-byte font that matches the encoding and character set.
+  // Only look if multi-byte character set is defined, or using multi-byte
+  // encoding other than Unicode.  This is because a Unicode encoding does not
+  // uniquely identify a CJK character set to use.
   p_mbenc = NULL;
   props = enc_canon_props(p_encoding);
   if (!(props & ENC_8BIT) && ((*p_pmcs != NUL) || !(props & ENC_UNICODE))) {
@@ -2526,28 +2521,26 @@ int mch_print_begin(prt_settings_T *psettings)
   prt_dsc_textline("Orientation", "Portrait");
   prt_dsc_atend("Pages");
   prt_dsc_textline("PageOrder", "Ascend");
-  /* The bbox does not change with orientation - it is always in the default
-   * user coordinate system!  We have to recalculate right and bottom
-   * coordinates based on the font metrics for the bbox to be accurate. */
+  // The bbox does not change with orientation - it is always in the default
+  // user coordinate system!  We have to recalculate right and bottom
+  // coordinates based on the font metrics for the bbox to be accurate.
   prt_page_margins(prt_mediasize[prt_media].width,
                    prt_mediasize[prt_media].height,
                    &left, &right, &top, &bottom);
   bbox[0] = (int)left;
   if (prt_portrait) {
-    /* In portrait printing the fixed point is the top left corner so we
-     * derive the bbox from that point.  We have the expected cpl chars
-     * across the media and lpp lines down the media.
-     */
+    // In portrait printing the fixed point is the top left corner so we
+    // derive the bbox from that point.  We have the expected cpl chars
+    // across the media and lpp lines down the media.
     bbox[1] = (int)(top - (psettings->lines_per_page + prt_header_height())
                     * prt_line_height);
     bbox[2] = (int)(left + psettings->chars_per_line * prt_char_width
                     + 0.5);
     bbox[3] = (int)(top + 0.5);
   } else {
-    /* In landscape printing the fixed point is the bottom left corner so we
-     * derive the bbox from that point.  We have lpp chars across the media
-     * and cpl lines up the media.
-     */
+    // In landscape printing the fixed point is the bottom left corner so we
+    // derive the bbox from that point.  We have lpp chars across the media
+    // and cpl lines up the media.
     bbox[1] = (int)bottom;
     bbox[2] = (int)(left + ((psettings->lines_per_page
                              + prt_header_height()) * prt_line_height) + 0.5);
@@ -2597,11 +2590,10 @@ int mch_print_begin(prt_settings_T *psettings)
     }
   }
 
-  /* Find an encoding to use for printing.
-   * Check 'printencoding'. If not set or not found, then use 'encoding'. If
-   * that cannot be found then default to "latin1".
-   * Note: VIM specific encoding header is always skipped.
-   */
+  // Find an encoding to use for printing.
+  // Check 'printencoding'. If not set or not found, then use 'encoding'. If
+  // that cannot be found then default to "latin1".
+  // Note: VIM specific encoding header is always skipped.
   if (!prt_out_mbyte) {
     p_encoding = enc_skip(p_penc);
     if (*p_encoding == NUL
@@ -2626,8 +2618,8 @@ int mch_print_begin(prt_settings_T *psettings)
     if (!prt_open_resource(&res_encoding)) {
       return FALSE;
     }
-    /* For the moment there are no checks on encoding resource files to
-     * perform */
+    // For the moment there are no checks on encoding resource files to
+    // perform
   } else {
     p_encoding = enc_skip(p_penc);
     if (*p_encoding == NUL) {
@@ -2643,8 +2635,8 @@ int mch_print_begin(prt_settings_T *psettings)
       if (!prt_open_resource(&res_encoding)) {
         return FALSE;
       }
-      /* For the moment there are no checks on encoding resource files to
-       * perform */
+      // For the moment there are no checks on encoding resource files to
+      // perform
     }
   }
 
@@ -2742,8 +2734,8 @@ int mch_print_begin(prt_settings_T *psettings)
   }
 
   if (!prt_out_mbyte || prt_use_courier) {
-    /* There will be only one Roman font encoding to be included in the PS
-     * file. */
+    // There will be only one Roman font encoding to be included in the PS
+    // file.
     if (!prt_add_resource(&res_encoding)) {
       return FALSE;
     }
@@ -2771,8 +2763,8 @@ int mch_print_begin(prt_settings_T *psettings)
 
   // Font resource inclusion and definition
   if (!prt_out_mbyte || prt_use_courier) {
-    /* When using Courier for ASCII range when printing multi-byte, need to
-     * pick up ASCII encoding to use with it. */
+    // When using Courier for ASCII range when printing multi-byte, need to
+    // pick up ASCII encoding to use with it.
     if (prt_use_courier) {
       p_encoding = (char_u *)prt_ascii_encoding;
     }
@@ -2794,12 +2786,11 @@ int mch_print_begin(prt_settings_T *psettings)
                  prt_ps_courier_font.ps_fontname[PRT_PS_FONT_BOLDOBLIQUE]);
   }
   if (prt_out_mbyte) {
-    /* Define the CID fonts to be used in the job.      Typically CJKV fonts do
-     * not have an italic form being a western style, so where no font is
-     * defined for these faces VIM falls back to an existing face.
-     * Note: if using Courier for the ASCII range then the printout will
-     * have bold/italic/bolditalic regardless of the setting of printmbfont.
-     */
+    // Define the CID fonts to be used in the job.      Typically CJKV fonts do
+    // not have an italic form being a western style, so where no font is
+    // defined for these faces VIM falls back to an existing face.
+    // Note: if using Courier for the ASCII range then the printout will
+    // have bold/italic/bolditalic regardless of the setting of printmbfont.
     prt_dsc_resources("IncludeResource", "font",
                       prt_ps_mb_font.ps_fontname[PRT_PS_FONT_ROMAN]);
     if (!prt_custom_cmap) {
@@ -2872,8 +2863,8 @@ void mch_print_end(prt_settings_T *psettings)
 
   prt_dsc_noarg("EOF");
 
-  /* Write CTRL-D to close serial communication link if used.
-   * NOTHING MUST BE WRITTEN AFTER THIS! */
+  // Write CTRL-D to close serial communication link if used.
+  // NOTHING MUST BE WRITTEN AFTER THIS!
   prt_write_file((char_u *)"\004");
 
   if (!prt_file_error && psettings->outfile == NULL
@@ -2977,13 +2968,12 @@ int mch_print_text_out(char_u *const textp, size_t len)
   char_u *tofree = NULL;
   double char_width = prt_char_width;
 
-  /* Ideally VIM would create a rearranged CID font to combine a Roman and
-   * CJKV font to do what VIM is doing here - use a Roman font for characters
-   * in the ASCII range, and the original CID font for everything else.
-   * The problem is that GhostScript still (as of 8.13) does not support
-   * rearranged fonts even though they have been documented by Adobe for 7
-   * years!  If they ever do, a lot of this code will disappear.
-   */
+  // Ideally VIM would create a rearranged CID font to combine a Roman and
+  // CJKV font to do what VIM is doing here - use a Roman font for characters
+  // in the ASCII range, and the original CID font for everything else.
+  // The problem is that GhostScript still (as of 8.13) does not support
+  // rearranged fonts even though they have been documented by Adobe for 7
+  // years!  If they ever do, a lot of this code will disappear.
   if (prt_use_courier) {
     const bool in_ascii = (len == 1 && *p < 0x80);
     if (prt_in_ascii) {
@@ -3020,9 +3010,8 @@ int mch_print_text_out(char_u *const textp, size_t len)
     }
   }
 
-  /* Output any required changes to the graphics state, after flushing any
-   * text buffered so far.
-   */
+  // Output any required changes to the graphics state, after flushing any
+  // text buffered so far.
   if (prt_attribute_change) {
     prt_flush_buffer();
     // Reset count of number of chars that will be printed
@@ -3100,16 +3089,14 @@ int mch_print_text_out(char_u *const textp, size_t len)
       p++;
     }
   } else {
-    /* Add next character to buffer of characters to output.
-     * Note: One printed character may require several PS characters to
-     * represent it, but we only count them as one printed character.
-     */
+    // Add next character to buffer of characters to output.
+    // Note: One printed character may require several PS characters to
+    // represent it, but we only count them as one printed character.
     ch = *p;
     if (ch < 32 || ch == '(' || ch == ')' || ch == '\\') {
-      /* Convert non-printing characters to either their escape or octal
-       * sequence, ensures PS sent over a serial line does not interfere
-       * with the comms protocol.
-       */
+      // Convert non-printing characters to either their escape or octal
+      // sequence, ensures PS sent over a serial line does not interfere
+      // with the comms protocol.
       ga_append(&prt_ps_buffer, '\\');
       switch (ch) {
       case BS:

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1461,9 +1461,9 @@ static void create_windows(mparm_T *parmp)
             did_emsg = FALSE;               // avoid hit-enter prompt
             getout(1);
           }
-          /* We can't close the window, it would disturb what
-           * happens next.  Clear the file name and set the arg
-           * index to -1 to delete it later. */
+          // We can't close the window, it would disturb what
+          // happens next.  Clear the file name and set the arg
+          // index to -1 to delete it later.
           setfname(curbuf, NULL, NULL, false);
           curwin->w_arg_idx = -1;
           swap_exists_action = SEA_NONE;
@@ -1553,8 +1553,8 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
     // happen when vimrc contains ":sall").
     if (curbuf == firstwin->w_buffer || curbuf->b_ffname == NULL) {
       curwin->w_arg_idx = arg_idx;
-      /* Edit file from arg list, if there is one.  When "Quit" selected
-       * at the ATTENTION prompt close the window. */
+      // Edit file from arg list, if there is one.  When "Quit" selected
+      // at the ATTENTION prompt close the window.
       swap_exists_did_quit = false;
       (void)do_ecmd(0, arg_idx < GARGCOUNT
           ? alist_name(&GARGLIST[arg_idx]) : NULL,

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -675,16 +675,16 @@ static int utf_safe_read_char_adv(const char_u **s, size_t *n)
   }
 
   if (k <= *n) {
-    /* We have a multibyte sequence and it isn't truncated by buffer
-     * limits so utf_ptr2char() is safe to use. Or the first byte is
-     * illegal (k=0), and it's also safe to use utf_ptr2char(). */
+    // We have a multibyte sequence and it isn't truncated by buffer
+    // limits so utf_ptr2char() is safe to use. Or the first byte is
+    // illegal (k=0), and it's also safe to use utf_ptr2char().
     c = utf_ptr2char(*s);
 
-    /* On failure, utf_ptr2char() returns the first byte, so here we
-     * check equality with the first byte. The only non-ASCII character
-     * which equals the first byte of its own UTF-8 representation is
-     * U+00C3 (UTF-8: 0xC3 0x83), so need to check that special case too.
-     * It's safe even if n=1, else we would have k=2 > n. */
+    // On failure, utf_ptr2char() returns the first byte, so here we
+    // check equality with the first byte. The only non-ASCII character
+    // which equals the first byte of its own UTF-8 representation is
+    // U+00C3 (UTF-8: 0xC3 0x83), so need to check that special case too.
+    // It's safe even if n=1, else we would have k=2 > n.
     if (c != (int)(**s) || (c == 0xC3 && (*s)[1] == 0x83)) {
       // byte sequence was successfully decoded
       *s += k;
@@ -1582,8 +1582,8 @@ void show_utf8(void)
   int clen;
   int i;
 
-  /* Get the byte length of the char under the cursor, including composing
-   * characters. */
+  // Get the byte length of the char under the cursor, including composing
+  // characters.
   line = get_cursor_pos_ptr();
   len = utfc_ptr2len(line);
   if (len == 0) {
@@ -1625,8 +1625,8 @@ int utf_head_off(const char_u *base, const char_u *p)
     return 0;
   }
 
-  /* Skip backwards over trailing bytes: 10xx.xxxx
-   * Skip backwards again if on a composing char. */
+  // Skip backwards over trailing bytes: 10xx.xxxx
+  // Skip backwards again if on a composing char.
   const char_u *q;
   for (q = p;; --q) {
     // Move s to the last byte of this char.
@@ -1915,8 +1915,8 @@ void utf_find_illegal(void)
     }
 
     while (*p != NUL) {
-      /* Illegal means that there are not enough trail bytes (checked by
-       * utf_ptr2len()) or too many of them (overlong sequence). */
+      // Illegal means that there are not enough trail bytes (checked by
+      // utf_ptr2len()) or too many of them (overlong sequence).
       len = utf_ptr2len(p);
       if (*p >= 0x80 && (len == 1
                          || utf_char2len(utf_ptr2char(p)) != len)) {

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -106,8 +106,8 @@ struct pointer_block {
   uint16_t pb_id;               // ID for pointer block: PTR_ID
   uint16_t pb_count;            // number of pointers in this block
   uint16_t pb_count_max;        // maximum value for pb_count
-  PTR_EN pb_pointer[1];         /* list of pointers to blocks (actually longer)
-                                 * followed by empty space until end of page */
+  PTR_EN pb_pointer[1];         // list of pointers to blocks (actually longer)
+                                // followed by empty space until end of page
 };
 
 /*
@@ -1333,8 +1333,8 @@ int recover_names(char_u *fname, int list, int nr, char_u **fname_out)
     if (dir_name[0] == '.' && dir_name[1] == NUL) {     // check current dir
       if (fname == NULL) {
         names[0] = vim_strsave((char_u *)"*.sw?");
-        /* For Unix names starting with a dot are special.  MS-Windows
-         * supports this too, on some file systems. */
+        // For Unix names starting with a dot are special.  MS-Windows
+        // supports this too, on some file systems.
         names[1] = vim_strsave((char_u *)".*.sw?");
         names[2] = vim_strsave((char_u *)".sw?");
         num_names = 3;
@@ -1343,11 +1343,11 @@ int recover_names(char_u *fname, int list, int nr, char_u **fname_out)
       }
     } else {                      // check directory dir_name
       if (fname == NULL) {
-        names[0] = (char_u *)concat_fnames((char *)dir_name, "*.sw?", TRUE);
-        /* For Unix names starting with a dot are special.  MS-Windows
-         * supports this too, on some file systems. */
-        names[1] = (char_u *)concat_fnames((char *)dir_name, ".*.sw?", TRUE);
-        names[2] = (char_u *)concat_fnames((char *)dir_name, ".sw?", TRUE);
+        names[0] = (char_u *)concat_fnames((char *)dir_name, "*.sw?", true);
+        // For Unix names starting with a dot are special.  MS-Windows
+        // supports this too, on some file systems.
+        names[1] = (char_u *)concat_fnames((char *)dir_name, ".*.sw?", true);
+        names[2] = (char_u *)concat_fnames((char *)dir_name, ".sw?", true);
         num_names = 3;
       } else {
         int len = (int)STRLEN(dir_name);
@@ -3377,8 +3377,8 @@ static void attention_message(buf_T *buf, char_u *fname)
       MSG_PUTS(_("      NEWER than swap file!\n"));
     }
   }
-  /* Some of these messages are long to allow translation to
-   * other languages. */
+  // Some of these messages are long to allow translation to
+  // other languages.
   MSG_PUTS(_("\n(1) Another program may be editing the same file.  If this is"
              " the case,\n    be careful not to end up with two different"
              " instances of the same\n    file when making changes."
@@ -3551,7 +3551,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
         }
 
         // give the ATTENTION message when there is an old swap file
-        // for the current file, and the buffer was not recovered. */
+        // for the current file, and the buffer was not recovered.
         if (differ == false && !(curbuf->b_flags & BF_RECOVERED)
             && vim_strchr(p_shm, SHM_ATTENTION) == NULL) {
           int choice = 0;

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -305,8 +305,8 @@ static int add_menu_path(const char_u *const menu_path, vimmenu_T *menuarg,
   parent = NULL;
   name = path_name;
   while (*name) {
-    /* Get name of this element in the menu hierarchy, and the simplified
-     * name (without mnemonic and accelerator text). */
+    // Get name of this element in the menu hierarchy, and the simplified
+    // name (without mnemonic and accelerator text).
     next_name = menu_name_skip(name);
     map_to = menutrans_lookup(name, (int)STRLEN(name));
     if (map_to != NULL) {
@@ -481,8 +481,8 @@ erret:
   xfree(path_name);
   xfree(dname);
 
-  /* Delete any empty submenu we added before discovering the error.  Repeat
-   * for higher levels. */
+  // Delete any empty submenu we added before discovering the error.  Repeat
+  // for higher levels.
   while (parent != NULL && parent->children == NULL) {
     if (parent->parent == NULL) {
       menup = root_menu_ptr;
@@ -650,8 +650,8 @@ static void free_menu(vimmenu_T **menup)
   menu = *menup;
 
 
-  /* Don't change *menup until after calling gui_mch_destroy_menu(). The
-   * MacOS code needs the original structure to properly delete the menu. */
+  // Don't change *menup until after calling gui_mch_destroy_menu(). The
+  // MacOS code needs the original structure to properly delete the menu.
   *menup = menu->next;
   xfree(menu->name);
   xfree(menu->dname);
@@ -1122,8 +1122,8 @@ char_u *get_menu_names(expand_T *xp, int idx)
           should_advance = true;
         }
       }
-      /* hack on menu separators:  use a 'magic' char for the separator
-       * so that '.' in names gets escaped properly */
+      // hack on menu separators:  use a 'magic' char for the separator
+      // so that '.' in names gets escaped properly
       STRCAT(tbuffer, "\001");
       str = tbuffer;
     } else {
@@ -1404,10 +1404,10 @@ static void execute_menu(const exarg_T *eap, vimmenu_T *menu)
     mode = "Visual";
     idx = MENU_INDEX_VISUAL;
 
-    /* GEDDES: This is not perfect - but it is a
-     * quick way of detecting whether we are doing this from a
-     * selection - see if the range matches up with the visual
-     * select start and end.  */
+    // GEDDES: This is not perfect - but it is a
+    // quick way of detecting whether we are doing this from a
+    // selection - see if the range matches up with the visual
+    // select start and end.
     if ((curbuf->b_visual.vi_start.lnum == eap->line1)
         && (curbuf->b_visual.vi_end.lnum) == eap->line2) {
       // Set it up for visual mode - equivalent to gv.
@@ -1434,8 +1434,8 @@ static void execute_menu(const exarg_T *eap, vimmenu_T *menu)
 
     check_cursor();
 
-    /* Adjust the cursor to make sure it is in the correct pos
-     * for exclusive mode */
+    // Adjust the cursor to make sure it is in the correct pos
+    // for exclusive mode
     if (*p_sel == 'e' && gchar_cursor() != NUL) {
       curwin->w_cursor.col++;
     }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -414,14 +414,14 @@ static int find_command(int cmdchar)
     return -1;
   }
 
-  /* We use the absolute value of the character.  Special keys have a
-   * negative value, but are sorted on their absolute value. */
+  // We use the absolute value of the character.  Special keys have a
+  // negative value, but are sorted on their absolute value.
   if (cmdchar < 0) {
     cmdchar = -cmdchar;
   }
 
-  /* If the character is in the first part: The character is the index into
-   * nv_cmd_idx[]. */
+  // If the character is in the first part: The character is the index into
+  // nv_cmd_idx[].
   assert(nv_max_linear < (int)NV_CMDS_SIZE);
   if (cmdchar <= nv_max_linear) {
     return nv_cmd_idx[cmdchar];
@@ -3897,8 +3897,8 @@ bool find_decl(char_u *ptr, size_t len, bool locally, bool thisblock, int flags_
 
   pat = xmalloc(len + 7);
 
-  /* Put "\V" before the pattern to avoid that the special meaning of "."
-   * and "~" causes trouble. */
+  // Put "\V" before the pattern to avoid that the special meaning of "."
+  // and "~" causes trouble.
   assert(len <= INT_MAX);
   sprintf((char *)pat, vim_iswordp(ptr) ? "\\V\\<%.*s\\>" : "\\V%.*s",
           (int)len, ptr);
@@ -4252,9 +4252,9 @@ void scroll_redraw(int up, long count)
     check_cursor_moved(curwin);
     curwin->w_valid |= VALID_TOPLINE;
 
-    /* If moved back to where we were, at least move the cursor, otherwise
-     * we get stuck at one position.  Don't move the cursor up if the
-     * first line of the buffer is already on the screen */
+    // If moved back to where we were, at least move the cursor, otherwise
+    // we get stuck at one position.  Don't move the cursor up if the
+    // first line of the buffer is already on the screen
     while (curwin->w_topline == prev_topline
            && curwin->w_topfill == prev_topfill) {
       if (up) {
@@ -4338,7 +4338,7 @@ static void nv_zet(cmdarg_T *cap)
 dozet:
   // "zf" and "zF" are always an operator, "zd", "zo", "zO", "zc"
   // and "zC" only in Visual mode.  "zj" and "zk" are motion
-  // commands. */
+  // commands.
   if (cap->nchar != 'f' && cap->nchar != 'F'
       && !(VIsual_active && vim_strchr((char_u *)"dcCoO", cap->nchar))
       && cap->nchar != 'j' && cap->nchar != 'k'
@@ -5003,9 +5003,9 @@ static void nv_ident(cmdarg_T *cap)
     return;
   }
 
-  /* Allocate buffer to put the command in.  Inserting backslashes can
-   * double the length of the word.  p_kp / curbuf->b_p_kp could be added
-   * and some numbers. */
+  // Allocate buffer to put the command in.  Inserting backslashes can
+  // double the length of the word.  p_kp / curbuf->b_p_kp could be added
+  // and some numbers.
   char_u *kp = *curbuf->b_p_kp == NUL ? p_kp : curbuf->b_p_kp;  // 'keywordprg'
   assert(*kp != NUL);  // option.c:do_set() should default to ":help" if empty.
   bool kp_ex = (*kp == ':');  // 'keywordprg' is an ex command
@@ -5046,8 +5046,8 @@ static void nv_ident(cmdarg_T *cap)
       STRCAT(buf, kp);
       STRCAT(buf, " ");
     } else {
-      /* An external command will probably use an argument starting
-       * with "-" as an option.  To avoid trouble we skip the "-". */
+      // An external command will probably use an argument starting
+      // with "-" as an option.  To avoid trouble we skip the "-".
       while (*ptr == '-' && n > 0) {
         ++ptr;
         --n;
@@ -5058,8 +5058,8 @@ static void nv_ident(cmdarg_T *cap)
         return;
       }
 
-      /* When a count is given, turn it into a range.  Is this
-       * really what we want? */
+      // When a count is given, turn it into a range.  Is this
+      // really what we want?
       bool isman = (STRCMP(kp, "man") == 0);
       bool isman_s = (STRCMP(kp, "man -s") == 0);
       if (cap->count0 != 0 && !(isman || isman_s)) {
@@ -5141,8 +5141,8 @@ static void nv_ident(cmdarg_T *cap)
       if (vim_strchr(aux_ptr, *ptr) != NULL) {
         *p++ = '\\';
       }
-      /* When current byte is a part of multibyte character, copy all
-       * bytes of that character. */
+      // When current byte is a part of multibyte character, copy all
+      // bytes of that character.
       const size_t len = (size_t)(utfc_ptr2len(ptr) - 1);
       for (size_t i = 0; i < len && n > 0; i++, n--) {
         *p++ = *ptr++;
@@ -5415,10 +5415,9 @@ static void nv_left(cmdarg_T *cap)
   cap->oap->inclusive = false;
   for (n = cap->count1; n > 0; --n) {
     if (oneleft() == false) {
-      /* <BS> and <Del> wrap to previous line if 'whichwrap' has 'b'.
-       *                 'h' wraps to previous line if 'whichwrap' has 'h'.
-       *           CURS_LEFT wraps to previous line if 'whichwrap' has '<'.
-       */
+      // <BS> and <Del> wrap to previous line if 'whichwrap' has 'b'.
+      //                 'h' wraps to previous line if 'whichwrap' has 'h'.
+      //           CURS_LEFT wraps to previous line if 'whichwrap' has '<'.
       if ((((cap->cmdchar == K_BS || cap->cmdchar == Ctrl_H)
             && vim_strchr(p_ww, 'b') != NULL)
            || (cap->cmdchar == 'h' && vim_strchr(p_ww, 'h') != NULL)
@@ -5570,9 +5569,9 @@ static void nv_dollar(cmdarg_T *cap)
 {
   cap->oap->motion_type = kMTCharWise;
   cap->oap->inclusive = true;
-  /* In virtual mode when off the edge of a line and an operator
-   * is pending (whew!) keep the cursor where it is.
-   * Otherwise, send it to the end of the line. */
+  // In virtual mode when off the edge of a line and an operator
+  // is pending (whew!) keep the cursor where it is.
+  // Otherwise, send it to the end of the line.
   if (!virtual_active() || gchar_cursor() != NUL
       || cap->oap->op_type == OP_NOP) {
     curwin->w_curswant = MAXCOL;        // so we stay at the end
@@ -6278,9 +6277,9 @@ static void nv_replace(cmdarg_T *cap)
         ins_char(cap->ncharC2);
       }
     }
-    --curwin->w_cursor.col;         // cursor on the last replaced char
-    /* if the character on the left of the current cursor is a multi-byte
-     * character, move two characters left */
+    curwin->w_cursor.col--;         // cursor on the last replaced char
+    // if the character on the left of the current cursor is a multi-byte
+    // character, move two characters left
     mb_adjust_cursor();
     curbuf->b_op_end = curwin->w_cursor;
     curwin->w_set_curswant = true;
@@ -6802,8 +6801,8 @@ static void n_start_visual_mode(int c)
   if (p_smd && msg_silent == 0) {
     redraw_cmdline = true;      // show visual mode later
   }
-  /* Only need to redraw this line, unless still need to redraw an old
-   * Visual area (when 'lazyredraw' is set). */
+  // Only need to redraw this line, unless still need to redraw an old
+  // Visual area (when 'lazyredraw' is set).
   if (curwin->w_redr_type < INVERTED) {
     curwin->w_old_cursor_lnum = curwin->w_cursor.lnum;
     curwin->w_old_visual_lnum = curwin->w_cursor.lnum;
@@ -7571,8 +7570,8 @@ static void nv_home(cmdarg_T *cap)
     cap->count0 = 1;
     nv_pipe(cap);
   }
-  ins_at_eol = false;       /* Don't move cursor past eol (only necessary in a
-                               one-character line). */
+  ins_at_eol = false;       // Don't move cursor past eol (only necessary in a
+                            // one-character line).
 }
 
 /*
@@ -7589,8 +7588,8 @@ static void nv_pipe(cmdarg_T *cap)
   } else {
     curwin->w_curswant = 0;
   }
-  /* keep curswant at the column where we wanted to go, not where
-   * we ended; differs if line is too short */
+  // keep curswant at the column where we wanted to go, not where
+  // we ended; differs if line is too short
   curwin->w_set_curswant = false;
 }
 
@@ -7661,8 +7660,8 @@ static void nv_wordcmd(cmdarg_T *cap)
     n = fwd_word(cap->count1, cap->arg, cap->oap->op_type != OP_NOP);
   }
 
-  /* Don't leave the cursor on the NUL past the end of line. Unless we
-   * didn't move it forward. */
+  // Don't leave the cursor on the NUL past the end of line. Unless we
+  // didn't move it forward.
   if (lt(startpos, curwin->w_cursor)) {
     adjust_cursor(cap->oap);
   }
@@ -7711,8 +7710,8 @@ static void nv_beginline(cmdarg_T *cap)
   if ((fdo_flags & FDO_HOR) && KeyTyped && cap->oap->op_type == OP_NOP) {
     foldOpenCursor();
   }
-  ins_at_eol = false;       /* Don't move cursor past eol (only necessary in a
-                               one-character line). */
+  ins_at_eol = false;       // Don't move cursor past eol (only necessary in a
+                            // one-character line).
 }
 
 /*
@@ -7857,8 +7856,8 @@ static void nv_esc(cmdarg_T *cap)
       }
     }
 
-    /* Don't reset "restart_edit" when 'insertmode' is set, it won't be
-     * set again below when halfway through a mapping. */
+    // Don't reset "restart_edit" when 'insertmode' is set, it won't be
+    // set again below when halfway through a mapping.
     if (!p_im) {
       restart_edit = 0;
     }
@@ -7885,8 +7884,8 @@ static void nv_esc(cmdarg_T *cap)
   }
   clearop(cap->oap);
 
-  /* A CTRL-C is often used at the start of a menu.  When 'insertmode' is
-   * set return to Insert mode afterwards. */
+  // A CTRL-C is often used at the start of a menu.  When 'insertmode' is
+  // set return to Insert mode afterwards.
   if (restart_edit == 0 && goto_im()
       && ex_normal_busy == 0) {
     restart_edit = 'a';
@@ -7940,8 +7939,8 @@ static void nv_edit(cmdarg_T *cap)
       break;
 
     case 'a':           // "a"ppend is like "i"nsert on the next character.
-      /* increment coladd when in virtual space, increment the
-       * column otherwise, also to append after an unprintable char */
+      // increment coladd when in virtual space, increment the
+      // column otherwise, also to append after an unprintable char
       if (virtual_active()
           && (curwin->w_cursor.coladd > 0
               || *get_cursor_pos_ptr() == NUL
@@ -8209,11 +8208,10 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
     }
 
     if (VIsual_active) {
-      /* Putting in Visual mode: The put text replaces the selected
-       * text.  First delete the selected text, then put the new text.
-       * Need to save and restore the registers that the delete
-       * overwrites if the old contents is being put.
-       */
+      // Putting in Visual mode: The put text replaces the selected
+      // text.  First delete the selected text, then put the new text.
+      // Need to save and restore the registers that the delete
+      // overwrites if the old contents is being put.
       was_visual = true;
       regname = cap->oap->regname;
       // '+' and '*' could be the same selection
@@ -8286,14 +8284,14 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
       }
     }
 
-    /* When all lines were selected and deleted do_put() leaves an empty
-     * line that needs to be deleted now. */
+    // When all lines were selected and deleted do_put() leaves an empty
+    // line that needs to be deleted now.
     if (empty && *ml_get(curbuf->b_ml.ml_line_count) == NUL) {
       ml_delete(curbuf->b_ml.ml_line_count, true);
       deleted_lines(curbuf->b_ml.ml_line_count + 1, 1);
 
-      /* If the cursor was in that line, move it to the end of the last
-       * line. */
+      // If the cursor was in that line, move it to the end of the last
+      // line.
       if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
         curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
         coladvance(MAXCOL);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -391,8 +391,8 @@ static void shift_block(oparg_T *oap, int amount)
       total += incr;
       bd.start_vcol += incr;
     }
-    /* OK, now total=all the VWS reqd, and textstart points at the 1st
-     * non-ws char in the block. */
+    // OK, now total=all the VWS reqd, and textstart points at the 1st
+    // non-ws char in the block.
     if (!curbuf->b_p_et) {
       tabstop_fromto(ws_vcol, ws_vcol + total, p_ts, p_vts, &i, &j);
     } else {
@@ -459,14 +459,14 @@ static void shift_block(oparg_T *oap, int amount)
     // The column to which we will shift the text.
     destination_col = non_white_col - shift_amount;
 
-    /* Now let's find out how much of the beginning of the line we can
-     * reuse without modification.  */
+    // Now let's find out how much of the beginning of the line we can
+    // reuse without modification.
     verbatim_copy_end = bd.textstart;
     verbatim_copy_width = bd.start_vcol;
 
-    /* If "bd.startspaces" is set, "bd.textstart" points to the character
-     * preceding the block. We have to subtract its width to obtain its
-     * column number.  */
+    // If "bd.startspaces" is set, "bd.textstart" points to the character
+    // preceding the block. We have to subtract its width to obtain its
+    // column number.
     if (bd.startspaces) {
       verbatim_copy_width -= bd.start_char_vcols;
     }
@@ -482,9 +482,9 @@ static void shift_block(oparg_T *oap, int amount)
       MB_PTR_ADV(verbatim_copy_end);
     }
 
-    /* If "destination_col" is different from the width of the initial
-    * part of the line that will be copied, it means we encountered a tab
-    * character, which we will have to partly replace with spaces.  */
+    // If "destination_col" is different from the width of the initial
+    // part of the line that will be copied, it means we encountered a tab
+    // character, which we will have to partly replace with spaces.
     assert(destination_col - verbatim_copy_width >= 0);
     fill = (size_t)(destination_col - verbatim_copy_width);
 
@@ -1500,8 +1500,8 @@ int op_delete(oparg_T *oap)
       did_yank = true;
     }
 
-    /* Yank into small delete register when no named register specified
-     * and the delete is within one line. */
+    // Yank into small delete register when no named register specified
+    // and the delete is within one line.
     if (oap->regname == 0 && oap->motion_type != kMTLineWise
         && oap->line_count == 1) {
       reg = get_yank_register('-', YREG_YANK);
@@ -1659,9 +1659,8 @@ int op_delete(oparg_T *oap)
       n = oap->end.col - oap->start.col + 1 - !oap->inclusive;
 
       if (virtual_op) {
-        /* fix up things for virtualedit-delete:
-         * break the tabs which are going to get in our way
-         */
+        // fix up things for virtualedit-delete:
+        // break the tabs which are going to get in our way
         char_u *curline = get_cursor_line_ptr();
         int len = (int)STRLEN(curline);
 
@@ -1818,12 +1817,11 @@ int op_replace(oparg_T *oap, int c)
         continue;                     // nothing to replace
       }
 
-      /* n == number of extra chars required
-       * If we split a TAB, it may be replaced by several characters.
-       * Thus the number of characters may increase!
-       */
-      /* If the range starts in virtual space, count the initial
-       * coladd offset as part of "startspaces" */
+      // n == number of extra chars required
+      // If we split a TAB, it may be replaced by several characters.
+      // Thus the number of characters may increase!
+      // If the range starts in virtual space, count the initial
+      // coladd offset as part of "startspaces"
       if (virtual_op && bd.is_short && *bd.textstart == NUL) {
         pos_T vpos;
 
@@ -2255,15 +2253,15 @@ void op_insert(oparg_T *oap, long count1)
 
   // When a tab was inserted, and the characters in front of the tab
   // have been converted to a tab as well, the column of the cursor
-  // might have actually been reduced, so need to adjust here. */
+  // might have actually been reduced, so need to adjust here.
   if (t1.lnum == curbuf->b_op_start_orig.lnum
       && lt(curbuf->b_op_start_orig, t1)) {
     oap->start = curbuf->b_op_start_orig;
   }
 
-  /* If user has moved off this line, we don't know what to do, so do
-   * nothing.
-   * Also don't repeat the insert when Insert mode ended with CTRL-C. */
+  // If user has moved off this line, we don't know what to do, so do
+  // nothing.
+  // Also don't repeat the insert when Insert mode ended with CTRL-C.
   if (curwin->w_cursor.lnum != oap->start.lnum || got_int) {
     return;
   }
@@ -2440,8 +2438,8 @@ int op_change(oparg_T *oap)
 
     ins_len = (long)STRLEN(firstline) - pre_textlen;
     if (ins_len > 0) {
-      /* Subsequent calls to ml_get() flush the firstline data - take a
-       * copy of the inserted text.  */
+      // Subsequent calls to ml_get() flush the firstline data - take a
+      // copy of the inserted text.
       ins_text = (char_u *)xmalloc((size_t)(ins_len + 1));
       STRLCPY(ins_text, firstline + bd.textcol, ins_len + 1);
       for (linenr = oap->start.lnum + 1; linenr <= oap->end.lnum;
@@ -2450,8 +2448,8 @@ int op_change(oparg_T *oap)
         if (!bd.is_short || virtual_op) {
           pos_T vpos;
 
-          /* If the block starts in virtual space, count the
-           * initial coladd offset as part of "startspaces" */
+          // If the block starts in virtual space, count the
+          // initial coladd offset as part of "startspaces"
           if (bd.is_short) {
             vpos.lnum = linenr;
             (void)getvpos(&vpos, oap->start_vcol);
@@ -3834,9 +3832,8 @@ char_u *skip_comment(char_u *line, bool process, bool include_space, bool *is_co
 
   *is_comment = false;
   if (leader_offset != -1) {
-    /* Let's check whether the line ends with an unclosed comment.
-     * If the last comment leader has COM_END in flags, there's no comment.
-     */
+    // Let's check whether the line ends with an unclosed comment.
+    // If the last comment leader has COM_END in flags, there's no comment.
     while (*comment_flags) {
       if (*comment_flags == COM_END
           || *comment_flags == ':') {
@@ -3859,11 +3856,10 @@ char_u *skip_comment(char_u *line, bool process, bool include_space, bool *is_co
     return line;
   }
 
-  /* Find:
-   * - COM_END,
-   * - colon,
-   * whichever comes first.
-   */
+  // Find:
+  // - COM_END,
+  // - colon,
+  // whichever comes first.
   while (*comment_flags) {
     if (*comment_flags == COM_END
         || *comment_flags == ':') {
@@ -4655,8 +4651,8 @@ static void block_prep(oparg_T *oap, struct block_def *bdp, linenr_T lnum, bool 
       bdp->endspaces = oap->end_vcol - oap->start_vcol + 1;
     }
   } else {
-    /* notice: this converts partly selected Multibyte characters to
-     * spaces, too. */
+    // notice: this converts partly selected Multibyte characters to
+    // spaces, too.
     bdp->startspaces = bdp->start_vcol - oap->start_vcol;
     if (is_del && bdp->startspaces) {
       bdp->startspaces = bdp->start_char_vcols - bdp->startspaces;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -568,12 +568,11 @@ void set_init_1(bool clean_arg)
 
   save_file_ff(curbuf);         // Buffer is unchanged
 
-  /* Detect use of mlterm.
-   * Mlterm is a terminal emulator akin to xterm that has some special
-   * abilities (bidi namely).
-   * NOTE: mlterm's author is being asked to 'set' a variable
-   *       instead of an environment variable due to inheritance.
-   */
+  // Detect use of mlterm.
+  // Mlterm is a terminal emulator akin to xterm that has some special
+  // abilities (bidi namely).
+  // NOTE: mlterm's author is being asked to 'set' a variable
+  //       instead of an environment variable due to inheritance.
   if (os_env_exists("MLTERM")) {
     set_option_value("tbidi", 1L, NULL, 0);
   }
@@ -1308,16 +1307,16 @@ int do_set(char_u *arg, int opt_flags)
             int comma;
             bool new_value_alloced = false;  // new string option was allocated
 
-            /* When using ":set opt=val" for a global option
-             * with a local value the local value will be
-             * reset, use the global value here. */
+            // When using ":set opt=val" for a global option
+            // with a local value the local value will be
+            // reset, use the global value here.
             if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0
                 && ((int)options[opt_idx].indir & PV_BOTH)) {
               varp = options[opt_idx].var;
             }
 
-            /* The old value is kept until we are sure that the
-             * new value is valid. */
+            // The old value is kept until we are sure that the
+            // new value is valid.
             oldval = *(char_u **)varp;
 
             // When setting the local value of a global
@@ -1493,8 +1492,8 @@ int do_set(char_u *arg, int opt_flags)
                 }
               }
 
-              /* locate newval[] in origval[] when removing it
-               * and when adding to avoid duplicates */
+              // locate newval[] in origval[] when removing it
+              // and when adding to avoid duplicates
               i = 0;                    // init for GCC
               if (removing || (flags & P_NODUP)) {
                 i = (int)STRLEN(newval);
@@ -1724,9 +1723,9 @@ static void did_set_option(int opt_idx, int opt_flags, int new_value, int value_
 {
   options[opt_idx].flags |= P_WAS_SET;
 
-  /* When an option is set in the sandbox, from a modeline or in secure mode
-   * set the P_INSECURE flag.  Otherwise, if a new value is stored reset the
-   * flag. */
+  // When an option is set in the sandbox, from a modeline or in secure mode
+  // set the P_INSECURE flag.  Otherwise, if a new value is stored reset the
+  // flag.
   uint32_t *p = insecure_flag(curwin, opt_idx, opt_flags);
   if (!value_checked && (secure
                          || sandbox != 0
@@ -5259,8 +5258,8 @@ int makeset(FILE *fd, int opt_flags, int local_only)
           }
         }
 
-        /* Round 1: fresh value for window-local options.
-         * Round 2: other values */
+        // Round 1: fresh value for window-local options.
+        // Round 2: other values
         for (; round <= 2; varp = varp_local, round++) {
           if (round == 1 || (opt_flags & OPT_GLOBAL)) {
             cmd = "set";
@@ -6229,13 +6228,13 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_sua = vim_strsave(p_sua);
       buf->b_p_keymap = vim_strsave(p_keymap);
       buf->b_kmap_state |= KEYMAP_INIT;
-      /* This isn't really an option, but copying the langmap and IME
-      * state from the current buffer is better than resetting it. */
+      // This isn't really an option, but copying the langmap and IME
+      // state from the current buffer is better than resetting it.
       buf->b_p_iminsert = p_iminsert;
       buf->b_p_imsearch = p_imsearch;
 
-      /* options that are normally global but also have a local value
-       * are not copied, start using the global value */
+      // options that are normally global but also have a local value
+      // are not copied, start using the global value
       buf->b_p_ar = -1;
       buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
       buf->b_p_bkc = empty_option;
@@ -6486,8 +6485,8 @@ void set_context_in_set_cmd(expand_T *xp, char_u *arg, int opt_flags)
     }
   }
 
-  /* For an option that is a list of file names, find the start of the
-   * last file name. */
+  // For an option that is a list of file names, find the start of the
+  // last file name.
   for (p = arg + STRLEN(arg) - 1; p > xp->xp_pattern; p--) {
     // count number of backslashes before ' ' or ','
     if (*p == ' ' || *p == ',') {
@@ -6521,10 +6520,9 @@ int ExpandSettings(expand_T *xp, regmatch_T *regmatch, int *num_file, char_u ***
   static char *(names[]) = { "all" };
   int ic = regmatch->rm_ic;  // remember the ignore-case flag
 
-  /* do this loop twice:
-   * loop == 0: count the number of matching options
-   * loop == 1: copy the matching options into allocated memory
-   */
+  // do this loop twice:
+  // loop == 0: count the number of matching options
+  // loop == 1: copy the matching options into allocated memory
   for (loop = 0; loop <= 1; loop++) {
     regmatch->rm_ic = ic;
     if (xp->xp_context != EXPAND_BOOL_SETTINGS) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -461,8 +461,8 @@ static int toggle_Magic(int x)
  */
 #define UCHARAT(p)      ((int)*(char_u *)(p))
 
-/* Used for an error (down from) vim_regcomp(): give the error message, set
- * rc_did_emsg and return NULL */
+// Used for an error (down from) vim_regcomp(): give the error message, set
+// rc_did_emsg and return NULL
 #define EMSG_RET_NULL(m) return (EMSG(m), rc_did_emsg = true, (void *)NULL)
 #define IEMSG_RET_NULL(m) return (IEMSG(m), rc_did_emsg = true, (void *)NULL)
 #define EMSG_RET_FAIL(m) return (EMSG(m), rc_did_emsg = true, FAIL)
@@ -715,9 +715,9 @@ static int reg_magic;           /* magicness of the pattern: */
 #define MAGIC_ON        3       /* "\m" or 'magic' */
 #define MAGIC_ALL       4       /* "\v" very magic */
 
-static int reg_string;          /* matching with a string instead of a buffer
-                                   line */
-static int reg_strict;          /* "[abc" is illegal */
+static int reg_string;          // matching with a string instead of a buffer
+                                // line
+static int reg_strict;          // "[abc" is illegal
 
 /*
  * META contains all characters that may be magic, except '^' and '$'.
@@ -741,10 +741,10 @@ static char_u META_flags[] = {
   1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1
 };
 
-static int curchr;              /* currently parsed character */
-/* Previous character.  Note: prevchr is sometimes -1 when we are not at the
- * start, eg in /[ ^I]^ the pattern was never found even if it existed,
- * because ^ was taken to be magic -- webb */
+static int curchr;              // currently parsed character
+// Previous character.  Note: prevchr is sometimes -1 when we are not at the
+// start, eg in /[ ^I]^ the pattern was never found even if it existed,
+// because ^ was taken to be magic -- webb
 static int prevchr;
 static int prevprevchr;         /* previous-previous character */
 static int nextchr;             /* used for ungetchr() */
@@ -2835,21 +2835,22 @@ static int peekchr(void)
       curchr = Magic(curchr);
     break;
   case '*':
-    /* * is not magic as the very first character, eg "?*ptr", when
-     * after '^', eg "/^*ptr" and when after "\(", "\|", "\&".  But
-     * "\(\*" is not magic, thus must be magic if "after_slash" */
+    // * is not magic as the very first character, eg "?*ptr", when
+    // after '^', eg "/^*ptr" and when after "\(", "\|", "\&".  But
+    // "\(\*" is not magic, thus must be magic if "after_slash"
     if (reg_magic >= MAGIC_ON
         && !at_start
         && !(prev_at_start && prevchr == Magic('^'))
         && (after_slash
             || (prevchr != Magic('(')
                 && prevchr != Magic('&')
-                && prevchr != Magic('|'))))
+                && prevchr != Magic('|')))) {
       curchr = Magic('*');
+    }
     break;
   case '^':
-    /* '^' is only magic as the very first character and if it's after
-     * "\(", "\|", "\&' or "\n" */
+    // '^' is only magic as the very first character and if it's after
+    // "\(", "\|", "\&' or "\n"
     if (reg_magic >= MAGIC_OFF
         && (at_start
             || reg_magic == MAGIC_ALL
@@ -2865,8 +2866,8 @@ static int peekchr(void)
     }
     break;
   case '$':
-    /* '$' is only magic as the very last char and if it's in front of
-     * either "\|", "\)", "\&", or "\n" */
+    // '$' is only magic as the very last char and if it's in front of
+    // either "\|", "\)", "\&", or "\n"
     if (reg_magic >= MAGIC_OFF) {
       char_u *p = regparse + 1;
       bool is_magic_all = (reg_magic == MAGIC_ALL);
@@ -5811,8 +5812,8 @@ static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T e
   if (bytelen != NULL)
     *bytelen = 0;
   for (;; ) {
-    /* Since getting one line may invalidate the other, need to make copy.
-     * Slow! */
+    // Since getting one line may invalidate the other, need to make copy.
+    // Slow!
     if (rex.line != reg_tofree) {
       len = (int)STRLEN(rex.line);
       if (reg_tofree == NULL || len >= (int)reg_tofreelen) {
@@ -6445,9 +6446,9 @@ static int cstrncmp(char_u *s1, char_u *s2, int *n)
   return result;
 }
 
-/***************************************************************
-*		      regsub stuff			       *
-***************************************************************/
+////////////////////////////////////////////////////////////////
+//                    regsub stuff                            //
+////////////////////////////////////////////////////////////////
 
 /* This stuff below really confuses cc on an SGI -- webb */
 
@@ -6512,9 +6513,10 @@ char_u *regtilde(char_u *source, int magic)
         memmove(tmpsub, newsub, (size_t)len);
         /* interpret tilde */
         memmove(tmpsub + len, reg_prev_sub, (size_t)prevlen);
-        /* copy postfix */
-        if (!magic)
-          ++p;                                /* back off \ */
+        // copy postfix
+        if (!magic) {
+          p++;                                // back off backslash
+        }
         STRCPY(tmpsub + len + prevlen, p + 1);
 
         if (newsub != source)                 /* already allocated newsub */

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -48,14 +48,14 @@ enum {
   NFA_MATCH,
   NFA_EMPTY,                        /* matches 0-length */
 
-  NFA_START_COLL,                   /* [abc] start */
-  NFA_END_COLL,                     /* [abc] end */
-  NFA_START_NEG_COLL,               /* [^abc] start */
-  NFA_END_NEG_COLL,                 /* [^abc] end (postfix only) */
-  NFA_RANGE,                        /* range of the two previous items
-                                     * (postfix only) */
-  NFA_RANGE_MIN,                    /* low end of a range  */
-  NFA_RANGE_MAX,                    /* high end of a range  */
+  NFA_START_COLL,                   // [abc] start
+  NFA_END_COLL,                     // [abc] end
+  NFA_START_NEG_COLL,               // [^abc] start
+  NFA_END_NEG_COLL,                 // [^abc] end (postfix only)
+  NFA_RANGE,                        // range of the two previous items
+                                    // (postfix only)
+  NFA_RANGE_MIN,                    // low end of a range
+  NFA_RANGE_MAX,                    // high end of a range
 
   NFA_CONCAT,                       // concatenate two previous items (postfix
                                     // only)
@@ -88,9 +88,9 @@ enum {
   NFA_END_INVISIBLE,
   NFA_END_INVISIBLE_NEG,
   NFA_END_PATTERN,
-  NFA_COMPOSING,                    /* Next nodes in NFA are part of the
-                                       composing multibyte char */
-  NFA_END_COMPOSING,                /* End of a composing char in the NFA */
+  NFA_COMPOSING,                    // Next nodes in NFA are part of the
+                                    // composing multibyte char
+  NFA_END_COMPOSING,                // End of a composing char in the NFA
   NFA_ANY_COMPOSING,                // \%C: Any composing characters.
   NFA_OPT_CHARS,                    /* \%[abc] */
 
@@ -256,9 +256,9 @@ static char_u e_ill_char_class[] = N_(
     "E877: (NFA regexp) Invalid character class: %" PRId64);
 static char_u e_value_too_large[] = N_("E951: \\% value too large");
 
-/* Since the out pointers in the list are always
- * uninitialized, we use the pointers themselves
- * as storage for the Ptrlists. */
+// Since the out pointers in the list are always
+// uninitialized, we use the pointers themselves
+// as storage for the Ptrlists.
 typedef union Ptrlist Ptrlist;
 union Ptrlist {
   Ptrlist     *next;
@@ -310,9 +310,9 @@ struct nfa_pim_S {
 typedef struct {
   nfa_state_T *state;
   int count;
-  nfa_pim_T pim;                /* if pim.result != NFA_PIM_UNUSED: postponed
-                                 * invisible match */
-  regsubs_T subs;               /* submatch info, only party used */
+  nfa_pim_T pim;                // if pim.result != NFA_PIM_UNUSED: postponed
+                                // invisible match
+  regsubs_T subs;               // submatch info, only party used
 } nfa_thread_T;
 
 // nfa_list_T contains the alternative NFA execution states.
@@ -1675,13 +1675,13 @@ collection:
           }
           /* Try collating class like [. .]  */
           if (collclass != 0) {
-            startc = collclass;                  /* allow [.a.]-x as a range */
-            /* Will emit the proper atom at the end of the
-             * while loop. */
+            startc = collclass;                  // allow [.a.]-x as a range
+            // Will emit the proper atom at the end of the
+            // while loop.
           }
         }
-        /* Try a range like 'a-x' or '\t-z'. Also allows '-' as a
-         * start character. */
+        // Try a range like 'a-x' or '\t-z'. Also allows '-' as a
+        // start character.
         if (*regparse == '-' && oldstartc != -1) {
           emit_range = true;
           startc = oldstartc;
@@ -1689,11 +1689,10 @@ collection:
           continue;                         // reading the end of the range
         }
 
-        /* Now handle simple and escaped characters.
-         * Only "\]", "\^", "\]" and "\\" are special in Vi.  Vim
-         * accepts "\t", "\e", etc., but only when the 'l' flag in
-         * 'cpoptions' is not included.
-         */
+        // Now handle simple and escaped characters.
+        // Only "\]", "\^", "\]" and "\\" are special in Vi.  Vim
+        // accepts "\t", "\e", etc., but only when the 'l' flag in
+        // 'cpoptions' is not included.
         if (*regparse == '\\'
             && regparse + 1 <= endp
             && (vim_strchr(REGEXP_INRANGE, regparse[1]) != NULL
@@ -1736,13 +1735,14 @@ collection:
           }
 
           if (endc > startc + 2) {
-            /* Emit a range instead of the sequence of
-             * individual characters. */
-            if (startc == 0)
-              /* \x00 is translated to \x0a, start at \x01. */
+            // Emit a range instead of the sequence of
+            // individual characters.
+            if (startc == 0) {
+              // \x00 is translated to \x0a, start at \x01.
               EMIT(1);
-            else
-              --post_ptr;                   /* remove NFA_CONCAT */
+            } else {
+              post_ptr--;                   // remove NFA_CONCAT
+            }
             EMIT(endc);
             EMIT(NFA_RANGE);
             EMIT(NFA_CONCAT);
@@ -1755,8 +1755,8 @@ collection:
               EMIT(NFA_CONCAT);
             }
           } else {
-            /* Emit the range. "startc" was already emitted, so
-             * skip it. */
+            // Emit the range. "startc" was already emitted, so
+            // skip it.
             for (c = startc + 1; c <= endc; c++) {
               EMIT(c);
               EMIT(NFA_CONCAT);
@@ -1765,19 +1765,20 @@ collection:
           emit_range = false;
           startc = -1;
         } else {
-          /* This char (startc) is not part of a range. Just
-           * emit it.
-           * Normally, simply emit startc. But if we get char
-           * code=0 from a collating char, then replace it with
-           * 0x0a.
-           * This is needed to completely mimic the behaviour of
-           * the backtracking engine. */
+          // This char (startc) is not part of a range. Just
+          // emit it.
+          // Normally, simply emit startc. But if we get char
+          // code=0 from a collating char, then replace it with
+          // 0x0a.
+          // This is needed to completely mimic the behaviour of
+          // the backtracking engine.
           if (startc == NFA_NEWL) {
-            /* Line break can't be matched as part of the
-             * collection, add an OR below. But not for negated
-             * range. */
-            if (!negated)
+            // Line break can't be matched as part of the
+            // collection, add an OR below. But not for negated
+            // range.
+            if (!negated) {
               extra = NFA_ADD_NL;
+            }
           } else {
             if (got_coll_char == true && startc == 0) {
               EMIT(0x0a);
@@ -1831,14 +1832,14 @@ nfa_do_multibyte:
         || utf_iscomposing(c)) {
       int i = 0;
 
-      /* A base character plus composing characters, or just one
-       * or more composing characters.
-       * This requires creating a separate atom as if enclosing
-       * the characters in (), where NFA_COMPOSING is the ( and
-       * NFA_END_COMPOSING is the ). Note that right now we are
-       * building the postfix form, not the NFA itself;
-       * a composing char could be: a, b, c, NFA_COMPOSING
-       * where 'b' and 'c' are chars with codes > 256. */
+      // A base character plus composing characters, or just one
+      // or more composing characters.
+      // This requires creating a separate atom as if enclosing
+      // the characters in (), where NFA_COMPOSING is the ( and
+      // NFA_END_COMPOSING is the ). Note that right now we are
+      // building the postfix form, not the NFA itself;
+      // a composing char could be: a, b, c, NFA_COMPOSING
+      // where 'b' and 'c' are chars with codes > 256. */
       for (;; ) {
         EMIT(c);
         if (i > 0)
@@ -3109,9 +3110,9 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
 
     case NFA_END_COLL:
     case NFA_END_NEG_COLL:
-      /* On the stack is the sequence starting with NFA_START_COLL or
-       * NFA_START_NEG_COLL and all possible characters. Patch it to
-       * add the output to the start. */
+      // On the stack is the sequence starting with NFA_START_COLL or
+      // NFA_START_NEG_COLL and all possible characters. Patch it to
+      // add the output to the start.
       if (nfa_calc_size == true) {
         nstate++;
         break;
@@ -3233,12 +3234,12 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
       if (before)
         n = *++p;         /* get the count */
 
-      /* The \@= operator: match the preceding atom with zero width.
-       * The \@! operator: no match for the preceding atom.
-       * The \@<= operator: match for the preceding atom.
-       * The \@<! operator: no match for the preceding atom.
-       * Surrounds the preceding atom with START_INVISIBLE and
-       * END_INVISIBLE, similarly to MOPEN. */
+      // The \@= operator: match the preceding atom with zero width.
+      // The \@! operator: no match for the preceding atom.
+      // The \@<= operator: match for the preceding atom.
+      // The \@<! operator: no match for the preceding atom.
+      // Surrounds the preceding atom with START_INVISIBLE and
+      // END_INVISIBLE, similarly to MOPEN.
 
       if (nfa_calc_size == true) {
         nstate += pattern ? 4 : 2;
@@ -3269,11 +3270,12 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
         patch(e.out, s1);
         PUSH(frag(s, list1(&s1->out)));
         if (before) {
-          if (n <= 0)
-            /* See if we can guess the maximum width, it avoids a
-             * lot of pointless tries. */
+          if (n <= 0) {
+            // See if we can guess the maximum width, it avoids a
+            // lot of pointless tries.
             n = nfa_max_width(e.start, 0);
-          s->val = n;           /* store the count */
+          }
+          s->val = n;           // store the count
         }
       }
       break;
@@ -3516,8 +3518,8 @@ static void nfa_postprocess(nfa_regprog_T *prog)
             directly = ch_follows * 10 < ch_invisible;
           }
         } else {
-          /* normal invisible, first do the one with the
-           * highest failure chance */
+          // normal invisible, first do the one with the
+          // highest failure chance
           directly = ch_follows < ch_invisible;
         }
       }
@@ -4012,8 +4014,8 @@ static regsubs_T *addstate(
   case NFA_ZEND:
   case NFA_SPLIT:
   case NFA_EMPTY:
-    /* These nodes are not added themselves but their "out" and/or
-     * "out1" may be added below.  */
+    // These nodes are not added themselves but their "out" and/or
+    // "out1" may be added below.
     break;
 
   case NFA_BOL:
@@ -4051,21 +4053,20 @@ static regsubs_T *addstate(
   case NFA_ZOPEN9:
   case NFA_NOPEN:
   case NFA_ZSTART:
-  /* These nodes need to be added so that we can bail out when it
-   * was added to this list before at the same position to avoid an
-   * endless loop for "\(\)*" */
+  // These nodes need to be added so that we can bail out when it
+  // was added to this list before at the same position to avoid an
+  // endless loop for "\(\)*"
 
   default:
     if (state->lastlist[nfa_ll_index] == l->id && state->c != NFA_SKIP) {
-      /* This state is already in the list, don't add it again,
-       * unless it is an MOPEN that is used for a backreference or
-       * when there is a PIM. For NFA_MATCH check the position,
-       * lower position is preferred. */
+      // This state is already in the list, don't add it again,
+      // unless it is an MOPEN that is used for a backreference or
+      // when there is a PIM. For NFA_MATCH check the position,
+      // lower position is preferred.
       if (!rex.nfa_has_backref && pim == NULL && !l->has_pim
           && state->c != NFA_MATCH) {
-
-        /* When called from addstate_here() do insert before
-         * existing states. */
+        // When called from addstate_here() do insert before
+        // existing states.
         if (add_here) {
           for (k = 0; k < l->n && k < listindex; ++k) {
             if (l->t[k].state->id == state->id) {
@@ -4088,10 +4089,11 @@ skip_add:
         }
       }
 
-      /* Do not add the state again when it exists with the same
-       * positions. */
-      if (has_state_with_pos(l, state, subs, pim))
+      // Do not add the state again when it exists with the same
+      // positions.
+      if (has_state_with_pos(l, state, subs, pim)) {
         goto skip_add;
+      }
     }
 
     // When there are backreferences or PIMs the number of states may
@@ -4362,9 +4364,9 @@ static regsubs_T *addstate_here(
   int count;
   int listidx = *ip;
 
-  /* First add the state(s) at the end, so that we know how many there are.
-   * Pass the listidx as offset (avoids adding another argument to
-   * addstate(). */
+  // First add the state(s) at the end, so that we know how many there are.
+  // Pass the listidx as offset (avoids adding another argument to
+  // addstate().
   regsubs_T *r = addstate(l, state, subs, pim, -listidx - ADDSTATE_HERE_OFFSET);
   if (r == NULL) {
     return NULL;
@@ -4385,8 +4387,8 @@ static regsubs_T *addstate_here(
     l->t[listidx] = l->t[l->n - 1];
   } else if (count > 1) {
     if (l->n + count - 1 >= l->len) {
-      /* not enough space to move the new states, reallocate the list
-       * and move the states to the right position */
+      // not enough space to move the new states, reallocate the list
+      // and move the states to the right position
       const int newlen = l->len * 3 / 2 + 50;
       const size_t newsize = newlen * sizeof(nfa_thread_T);
 
@@ -4408,8 +4410,8 @@ static regsubs_T *addstate_here(
       xfree(l->t);
       l->t = newl;
     } else {
-      /* make space for new states, then move them from the
-       * end to the current position */
+      // make space for new states, then move them from the
+      // end to the current position
       memmove(&(l->t[listidx + count]),
           &(l->t[listidx + 1]),
           sizeof(nfa_thread_T) * (l->n - listidx - 1));
@@ -6582,10 +6584,11 @@ static long nfa_regexec_both(char_u *line, colnr_T startcol,
   }
 
   if (prog->regstart != NUL) {
-    /* Skip ahead until a character we know the match must start with.
-     * When there is none there is no match. */
-    if (skip_to_start(prog->regstart, &col) == FAIL)
+    // Skip ahead until a character we know the match must start with.
+    // When there is none there is no match.
+    if (skip_to_start(prog->regstart, &col) == FAIL) {
       return 0L;
+    }
 
     // If match_text is set it contains the full text that must match.
     // Nothing else to try. Doesn't handle combining chars well.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -694,7 +694,7 @@ void conceal_check_cursor_line(void)
   if (curwin->w_p_cole > 0 && (conceal_cursor_used != should_conceal)) {
     redrawWinline(curwin, curwin->w_cursor.lnum);
     // Need to recompute cursor column, e.g., when starting Visual mode
-    // without concealing. */
+    // without concealing.
     curs_columns(curwin, true);
   }
 }
@@ -4827,8 +4827,8 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, 
   }
 
   if (clear_next) {
-    /* Clear the second half of a double-wide character of which the left
-     * half was overwritten with a single-wide character. */
+    // Clear the second half of a double-wide character of which the left
+    // half was overwritten with a single-wide character.
     schar_from_ascii(grid->chars[off_to], ' ');
     end_dirty++;
   }
@@ -5175,9 +5175,9 @@ void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches, in
         }
         wild_menu_showing = WM_SCROLLED;
       } else {
-        /* Create status line if needed by setting 'laststatus' to 2.
-         * Set 'winminheight' to zero to avoid that the window is
-         * resized. */
+        // Create status line if needed by setting 'laststatus' to 2.
+        // Set 'winminheight' to zero to avoid that the window is
+        // resized.
         if (lastwin->w_status_height == 0) {
           save_p_ls = p_ls;
           save_p_wmh = p_wmh;
@@ -7324,8 +7324,8 @@ void draw_tabline(void)
     }
   }
 
-  /* Reset the flag here again, in case evaluating 'tabline' causes it to be
-   * set. */
+  // Reset the flag here again, in case evaluating 'tabline' causes it to be
+  // set.
   redraw_tabline = false;
 }
 
@@ -7390,9 +7390,9 @@ int fillchar_status(int *attr, win_T *wp)
     *attr = win_hl_attr(wp, HLF_SNC);
     fill = wp->w_p_fcs_chars.stlnc;
   }
-  /* Use fill when there is highlighting, and highlighting of current
-   * window differs, or the fillchars differ, or this is not the
-   * current window */
+  // Use fill when there is highlighting, and highlighting of current
+  // window differs, or the fillchars differ, or this is not the
+  // current window
   if (*attr != 0 && ((win_hl_attr(wp, HLF_S) != win_hl_attr(wp, HLF_SNC)
                       || !is_curwin || ONE_WINDOW)
                      || (wp->w_p_fcs_chars.stl != wp->w_p_fcs_chars.stlnc))) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -699,8 +699,8 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
                */
               if (vim_strchr(p_cpo, CPO_SEARCH) != NULL) {
                 if (nmatched > 1) {
-                  /* end is in next line, thus no match in
-                   * this line */
+                  // end is in next line, thus no match in
+                  // this line
                   match_ok = false;
                   break;
                 }
@@ -758,10 +758,10 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
              */
             match_ok = false;
             for (;; ) {
-              /* Remember a position that is before the start
-               * position, we use it if it's the last match in
-               * the line.  Always accept a position after
-               * wrapping around. */
+              // Remember a position that is before the start
+              // position, we use it if it's the last match in
+              // the line.  Always accept a position after
+              // wrapping around.
               if (loop
                   || ((options & SEARCH_END)
                       ? (lnum + regmatch.endpos[0].lnum
@@ -890,9 +890,9 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
           break;
         }
 
-        /* Cancel searching if a character was typed.  Used for
-         * 'incsearch'.  Don't check too often, that would slowdown
-         * searching too much. */
+        // Cancel searching if a character was typed.  Used for
+        // 'incsearch'.  Don't check too often, that would slowdown
+        // searching too much.
         if ((options & SEARCH_PEEK)
             && ((lnum - pos->lnum) & 0x3f) == 0
             && char_avail()) {
@@ -1082,8 +1082,8 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char_u *pat, long count,
     }
   }
 
-  /* If the cursor is in a closed fold, don't find another match in the same
-   * fold. */
+  // If the cursor is in a closed fold, don't find another match in the same
+  // fold.
   if (dirc == '/') {
     if (hasFolding(pos.lnum, NULL, &pos.lnum)) {
       pos.col = MAXCOL - 2;             // avoid overflow when adding 1
@@ -1892,8 +1892,8 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         } else if (!cpo_bsl) {
           int col, bslcnt = 0;
 
-          /* Set "match_escaped" if there are an odd number of
-           * backslashes. */
+          // Set "match_escaped" if there are an odd number of
+          // backslashes.
           for (col = pos.col; check_prevcol(linep, col, '\\', &col); ) {
             bslcnt++;
           }
@@ -2033,8 +2033,8 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
           || (lisp && comment_col != MAXCOL
               && pos.col == (colnr_T)comment_col)) {
         if (pos.lnum == curbuf->b_ml.ml_line_count          // end of file
-            /* line is exhausted and comment with it,
-             * don't search for match in code */
+            // line is exhausted and comment with it,
+            // don't search for match in code
             || lispcomm) {
           break;
         }
@@ -2271,8 +2271,8 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         break;
       }
 
-      /* Check for match outside of quotes, and inside of
-       * quotes when the start is also inside of quotes. */
+      // Check for match outside of quotes, and inside of
+      // quotes when the start is also inside of quotes.
       if ((!inquote || start_in_quotes == kTrue)
           && (c == initc || c == findc)) {
         int col, bslcnt = 0;
@@ -2340,8 +2340,8 @@ static int check_linecomment(const char_u *line)
     }
   } else {
     while ((p = vim_strchr(p, '/')) != NULL) {
-      /* accept a double /, unless it's preceded with * and followed by *,
-       * because * / / * is an end and start of a C comment */
+      // accept a double /, unless it's preceded with * and followed by *,
+      // because * / / * is an end and start of a C comment
       if (p[1] == '/' && (p == line || p[-1] != '*' || p[2] != '*')) {
         break;
       }
@@ -2427,9 +2427,9 @@ void showmatch(int c)
       showruler(false);
       setcursor();
       ui_flush();
-      /* Restore dollar_vcol(), because setcursor() may call curs_rows()
-       * which resets it if the matching position is in a previous line
-       * and has a higher column number. */
+      // Restore dollar_vcol(), because setcursor() may call curs_rows()
+      // which resets it if the matching position is in a previous line
+      // and has a higher column number.
       dollar_vcol = save_dollar_vcol;
 
       /*
@@ -2595,8 +2595,8 @@ bool findpar(bool *pincl, int dir, long count, int what, int both)
   bool first;               // true on first line
   linenr_T fold_first;      // first line of a closed fold
   linenr_T fold_last;       // last line of a closed fold
-  bool fold_skipped;        /* true if a closed fold was skipped this
-                               iteration */
+  bool fold_skipped;        // true if a closed fold was skipped this
+                            // iteration
 
   curr = curwin->w_cursor.lnum;
 
@@ -2658,10 +2658,10 @@ static int inmacro(char_u *opt, char_u *s)
 {
   char_u *macro;
 
-  for (macro = opt; macro[0]; ++macro) {
-    /* Accept two characters in the option being equal to two characters
-     * in the line.  A space in the option matches with a space in the
-     * line or the line having ended. */
+  for (macro = opt; macro[0]; macro++) {
+    // Accept two characters in the option being equal to two characters
+    // in the line.  A space in the option matches with a space in the
+    // line or the line having ended.
     if (       (macro[0] == s[0]
                 || (macro[0] == ' '
                     && (s[0] == NUL || s[0] == ' ')))
@@ -2756,8 +2756,8 @@ int fwd_word(long count, int bigword, int eol)
   curwin->w_cursor.coladd = 0;
   cls_bigword = bigword;
   while (--count >= 0) {
-    /* When inside a range of folded lines, move to the last char of the
-     * last line. */
+    // When inside a range of folded lines, move to the last char of the
+    // last line.
     if (hasFolding(curwin->w_cursor.lnum, NULL, &curwin->w_cursor.lnum)) {
       coladvance(MAXCOL);
     }
@@ -3675,9 +3675,9 @@ again:
   xfree(epat);
 
   if (r < 1 || lt(curwin->w_cursor, old_end)) {
-    /* Can't find other end or it's before the previous end.  Could be a
-     * HTML tag that doesn't have a matching end.  Search backwards for
-     * another starting tag. */
+    // Can't find other end or it's before the previous end.  Could be a
+    // HTML tag that doesn't have a matching end.  Search backwards for
+    // another starting tag.
     count = 1;
     curwin->w_cursor = start_pos;
     goto again;
@@ -3729,8 +3729,8 @@ again:
   }
 
   if (VIsual_active) {
-    /* If the end is before the start there is no text between tags, select
-     * the char under the cursor. */
+    // If the end is before the start there is no text between tags, select
+    // the char under the cursor.
     if (lt(end_pos, start_pos)) {
       curwin->w_cursor = start_pos;
     } else if (*p_sel == 'e') {
@@ -3744,8 +3744,8 @@ again:
     oap->start = start_pos;
     oap->motion_type = kMTCharWise;
     if (lt(end_pos, start_pos)) {
-      /* End is before the start: there is no text between tags; operate
-       * on an empty area. */
+      // End is before the start: there is no text between tags; operate
+      // on an empty area.
       curwin->w_cursor = start_pos;
       oap->inclusive = false;
     } else {
@@ -4112,10 +4112,10 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
         first_col = find_prev_quote(line, col_start, quotechar, NULL);
       }
     }
-    /* The cursor is on a quote, we don't know if it's the opening or
-     * closing quote.  Search from the start of the line to find out.
-     * Also do this when there is a Visual area, a' may leave the cursor
-     * in between two strings. */
+    // The cursor is on a quote, we don't know if it's the opening or
+    // closing quote.  Search from the start of the line to find out.
+    // Also do this when there is a Visual area, a' may leave the cursor
+    // in between two strings.
     col_start = 0;
     for (;; ) {
       // Find open quote character.
@@ -4169,18 +4169,17 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
     }
   }
 
-  /* Set start position.  After vi" another i" must include the ".
-   * For v2i" include the quotes. */
+  // Set start position.  After vi" another i" must include the ".
+  // For v2i" include the quotes.
   if (!include && count < 2
       && (vis_empty || !inside_quotes)) {
     ++col_start;
   }
   curwin->w_cursor.col = col_start;
   if (VIsual_active) {
-    /* Set the start of the Visual area when the Visual area was empty, we
-     * were just inside quotes or the Visual area didn't start at a quote
-     * and didn't include a quote.
-     */
+    // Set the start of the Visual area when the Visual area was empty, we
+    // were just inside quotes or the Visual area didn't start at a quote
+    // and didn't include a quote.
     if (vis_empty
         || (vis_bef_curs
             && !selected_quote
@@ -4211,9 +4210,9 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
         dec_cursor();
       }
     } else {
-      /* Cursor is at start of Visual area.  Set the end of the Visual
-       * area when it was just inside quotes or it didn't end at a
-       * quote. */
+      // Cursor is at start of Visual area.  Set the end of the Visual
+      // area when it was just inside quotes or it didn't end at a
+      // quote.
       if (inside_quotes
           || (!selected_quote
               && line[VIsual.col] != quotechar
@@ -4911,14 +4910,14 @@ void find_pattern_in_path(char_u *ptr, Direction dir, size_t len, bool whole, bo
           msg_home_replace(files[depth_displayed].name);
           MSG_PUTS(" -->\n");
         }
-        if (!got_int) {                     /* don't display if 'q' typed
-                                               for "--more--" message */
+        if (!got_int) {                     // don't display if 'q' typed
+                                            // for "--more--" message
           for (i = 0; i <= depth_displayed; i++) {
             MSG_PUTS("  ");
           }
           if (new_fname != NULL) {
-            /* using "new_fname" is more reliable, e.g., when
-             * 'includeexpr' is set. */
+            // using "new_fname" is more reliable, e.g., when
+            // 'includeexpr' is set.
             msg_outtrans_attr(new_fname, HL_ATTR(HLF_D));
           } else {
             /*

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -929,9 +929,9 @@ static void syn_update_ends(bool startofline)
   stateitem_T *cur_si;
 
   if (startofline) {
-    /* Check for a match carried over from a previous line with a
-     * contained region.  The match ends as soon as the region ends. */
-    for (int i = 0; i < current_state.ga_len; ++i) {
+    // Check for a match carried over from a previous line with a
+    // contained region.  The match ends as soon as the region ends.
+    for (int i = 0; i < current_state.ga_len; i++) {
       cur_si = &CUR_STATE(i);
       if (cur_si->si_idx >= 0
           && (SYN_ITEMS(syn_block)[cur_si->si_idx]).sp_type
@@ -1335,8 +1335,8 @@ static synstate_T *store_current_state(void)
     if (syn_block->b_sst_freecount == 0) {
       sp = NULL;
     } else {
-      /* Take the first item from the free list and put it in the used
-       * list, after *sp */
+      // Take the first item from the free list and put it in the used
+      // list, after *sp
       p = syn_block->b_sst_firstfree;
       syn_block->b_sst_firstfree = p->sst_next;
       --syn_block->b_sst_freecount;
@@ -1359,8 +1359,8 @@ static synstate_T *store_current_state(void)
     clear_syn_state(sp);
     sp->sst_stacksize = current_state.ga_len;
     if (current_state.ga_len > SST_FIX_STATES) {
-      /* Need to clear it, might be something remaining from when the
-       * length was less than SST_FIX_STATES. */
+      // Need to clear it, might be something remaining from when the
+      // length was less than SST_FIX_STATES.
       ga_init(&sp->sst_union.sst_ga, (int)sizeof(bufstate_T), 1);
       ga_grow(&sp->sst_union.sst_ga, current_state.ga_len);
       sp->sst_union.sst_ga.ga_len = current_state.ga_len;
@@ -1458,24 +1458,24 @@ static bool syn_stack_equal(synstate_T *sp)
     if (bp[i].bs_extmatch == CUR_STATE(i).si_extmatch) {
       continue;
     }
-    /* When the extmatch pointers are different, the strings in
-     * them can still be the same.  Check if the extmatch
-     * references are equal. */
+    // When the extmatch pointers are different, the strings in
+    // them can still be the same.  Check if the extmatch
+    // references are equal.
     bsx = bp[i].bs_extmatch;
     six = CUR_STATE(i).si_extmatch;
-    /* If one of the extmatch pointers is NULL the states are
-     * different. */
+    // If one of the extmatch pointers is NULL the states are
+    // different.
     if (bsx == NULL || six == NULL) {
       break;
     }
     int j;
-    for (j = 0; j < NSUBEXP; ++j) {
-      /* Check each referenced match string. They must all be
-       * equal. */
+    for (j = 0; j < NSUBEXP; j++) {
+      // Check each referenced match string. They must all be
+      // equal.
       if (bsx->matches[j] != six->matches[j]) {
-        /* If the pointer is different it can still be the
-         * same text.  Compare the strings, ignore case when
-         * the start item has the sp_ic flag set. */
+        // If the pointer is different it can still be the
+        // same text.  Compare the strings, ignore case when
+        // the start item has the sp_ic flag set.
         if (bsx->matches[j] == NULL || six->matches[j] == NULL) {
           break;
         }
@@ -1749,8 +1749,8 @@ static int syn_current_attr(const bool syncing, const bool displaying, bool *con
                            && (syn_block->b_keywtab.ht_used > 0
                                || syn_block->b_keywtab_ic.ht_used > 0);
 
-  /* Init the list of zero-width matches with a nextlist.  This is used to
-   * avoid matching the same item in the same position twice. */
+  // Init the list of zero-width matches with a nextlist.  This is used to
+  // avoid matching the same item in the same position twice.
   ga_init(&zero_width_next_ga, (int)sizeof(int), 10);
 
   // use syntax iskeyword option
@@ -1867,9 +1867,9 @@ static int syn_current_attr(const bool syncing, const bool displaying, bool *con
                               : in_id_list(cur_si,
                                            cur_si->si_cont_list, &spp->sp_syn,
                                            spp->sp_flags & HL_CONTAINED)))) {
-              /* If we already tried matching in this line, and
-               * there isn't a match before next_match_col, skip
-               * this item. */
+              // If we already tried matching in this line, and
+              // there isn't a match before next_match_col, skip
+              // this item.
               if (spp->sp_line_id == current_line_id
                   && spp->sp_startcol >= next_match_col) {
                 continue;
@@ -2037,9 +2037,9 @@ static int syn_current_attr(const bool syncing, const bool displaying, bool *con
             keep_next_list = true;
             zero_width_next_list = true;
 
-            /* Add the index to a list, so that we can check
-             * later that we don't match it again (and cause an
-             * endless loop). */
+            // Add the index to a list, so that we can check
+            // later that we don't match it again (and cause an
+            // endless loop).
             GA_APPEND(int, &zero_width_next_ga, next_match_idx);
             next_match_idx = -1;
           } else {
@@ -2136,10 +2136,10 @@ static int syn_current_attr(const bool syncing, const bool displaying, bool *con
           *can_spell = !in_id_list(sip, sip->si_cont_list, &sps, 0);
         }
       } else {
-        /* The @Spell cluster is defined: Do spelling in items with
-         * the @Spell cluster.  But not when @NoSpell is also there.
-         * At the toplevel only spell check when ":syn spell toplevel"
-         * was used. */
+        // The @Spell cluster is defined: Do spelling in items with
+        // the @Spell cluster.  But not when @NoSpell is also there.
+        // At the toplevel only spell check when ":syn spell toplevel"
+        // was used.
         if (current_trans_id == 0) {
           *can_spell = (syn_block->b_syn_spell == SYNSPL_TOP);
         } else {
@@ -2216,8 +2216,8 @@ static bool did_match_already(int idx, garray_T *gap)
     }
   }
 
-  /* Zero-width matches with a nextgroup argument are not put on the syntax
-   * stack, and can only be matched once anyway. */
+  // Zero-width matches with a nextgroup argument are not put on the syntax
+  // stack, and can only be matched once anyway.
   for (int i = gap->ga_len; --i >= 0; ) {
     if (((int *)(gap->ga_data))[i] == idx) {
       return true;
@@ -2353,8 +2353,8 @@ static void check_state_ends(void)
         next_match_col = MAXCOL;
         break;
       } else {
-        /* handle next_list, unless at end of line and no "skipnl" or
-         * "skipempty" */
+        // handle next_list, unless at end of line and no "skipnl" or
+        // "skipempty"
         current_next_list = cur_si->si_next_list;
         current_next_flags = cur_si->si_flags;
         if (!(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY))

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -284,17 +284,16 @@ int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
             tagstackidx = 0;
             goto end_do_tag;
           }
-          /* We weren't at the bottom of the stack, so jump all the
-           * way to the bottom now.
-           */
+          // We weren't at the bottom of the stack, so jump all the
+          // way to the bottom now.
           tagstackidx = 0;
         } else if (tagstackidx >= tagstacklen) {        // count == 0?
           EMSG(_(topmsg));
           goto end_do_tag;
         }
 
-        /* Make a copy of the fmark, autocommands may invalidate the
-         * tagstack before it's used. */
+        // Make a copy of the fmark, autocommands may invalidate the
+        // tagstack before it's used.
         saved_fmark = tagstack[tagstackidx].fmark;
         if (saved_fmark.fnum != curbuf->b_fnum) {
           /*
@@ -306,8 +305,8 @@ int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
             tagstackidx = oldtagstackidx;              // back to old posn
             goto end_do_tag;
           }
-          /* A BufReadPost autocommand may jump to the '" mark, but
-           * we don't what that here. */
+          // A BufReadPost autocommand may jump to the '" mark, but
+          // we don't what that here.
           curwin->w_cursor.lnum = saved_fmark.mark.lnum;
         } else {
           setpcmark();
@@ -488,9 +487,9 @@ int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
                                    // found: all matches found.
       }
 
-      /* If there already were some matches for the same name, move them
-       * to the start.  Avoids that the order changes when using
-       * ":tnext" and jumping to another file. */
+      // If there already were some matches for the same name, move them
+      // to the start.  Avoids that the order changes when using
+      // ":tnext" and jumping to another file.
       if (!new_tag && !other_name) {
         int j, k;
         int idx = 0;
@@ -561,9 +560,9 @@ int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
       }
 
       if (cur_match >= num_matches) {
-        /* Avoid giving this error when a file wasn't found and we're
-         * looking for a match in another file, which wasn't found.
-         * There will be an EMSG("file doesn't exist") below then. */
+        // Avoid giving this error when a file wasn't found and we're
+        // looking for a match in another file, which wasn't found.
+        // There will be an EMSG("file doesn't exist") below then.
         if ((type == DT_NEXT || type == DT_FIRST)
             && nofile_fname == NULL) {
           if (num_matches == 1) {
@@ -666,8 +665,8 @@ int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
         }
         EMSG2(_("E429: File \"%s\" does not exist"), nofile_fname);
       } else {
-        /* We may have jumped to another window, check that
-         * tagstackidx is still valid. */
+        // We may have jumped to another window, check that
+        // tagstackidx is still valid.
         if (use_tagstack && tagstackidx > curwin->w_tagstacklen) {
           tagstackidx = curwin->w_tagstackidx;
         }
@@ -1584,15 +1583,15 @@ int find_tags(char_u *pat, int *num_matches, char_u ***matchesp, int flags, int 
             }
           }
 
-          /* When searching for a specific language skip tags files
-           * for other languages. */
+          // When searching for a specific language skip tags files
+          // for other languages.
           if (help_lang_find != NULL
               && STRICMP(help_lang, help_lang_find) != 0) {
             continue;
           }
 
-          /* For CTRL-] in a help file prefer a match with the same
-           * language. */
+          // For CTRL-] in a help file prefer a match with the same
+          // language.
           if ((flags & TAG_KEEP_LANG)
               && help_lang_find == NULL
               && curbuf->b_fname != NULL
@@ -2234,8 +2233,8 @@ parse_line:
       tagname_free(&tn);
     }
 
-    /* stop searching when already did a linear search, or when TAG_NOIC
-     * used, and 'ignorecase' not set or already did case-ignore search */
+    // stop searching when already did a linear search, or when TAG_NOIC
+    // used, and 'ignorecase' not set or already did case-ignore search
     if (stop_searching || linear || (!p_ic && noic) || orgpat.regmatch.rm_ic) {
       break;
     }
@@ -2367,8 +2366,8 @@ int get_tagfname(tagname_T *tnp, int first, char_u *buf)
     }
 
     if (tnp->tn_hf_idx >= tag_fnames.ga_len) {
-      /* Not found in 'runtimepath', use 'helpfile', if it exists and
-       * wasn't used yet, replacing "help.txt" with "tags". */
+      // Not found in 'runtimepath', use 'helpfile', if it exists and
+      // wasn't used yet, replacing "help.txt" with "tags".
       if (tnp->tn_hf_idx > tag_fnames.ga_len || *p_hf == NUL) {
         return FAIL;
       }
@@ -2393,8 +2392,8 @@ int get_tagfname(tagname_T *tnp, int first, char_u *buf)
   }
 
   if (first) {
-    /* Init.  We make a copy of 'tags', because autocommands may change
-     * the value without notifying us. */
+    // Init.  We make a copy of 'tags', because autocommands may change
+    // the value without notifying us.
     tnp->tn_tags = vim_strsave((*curbuf->b_p_tags != NUL)
         ? curbuf->b_p_tags : p_tags);
     tnp->tn_np = tnp->tn_tags;
@@ -2431,8 +2430,8 @@ int get_tagfname(tagname_T *tnp, int first, char_u *buf)
       (void)copy_option_part(&tnp->tn_np, buf, MAXPATHL - 1, " ,");
 
       r_ptr = vim_findfile_stopdir(buf);
-      /* move the filename one char forward and truncate the
-       * filepath with a NUL */
+      // move the filename one char forward and truncate the
+      // filepath with a NUL
       filename = path_tail(buf);
       STRMOVE(filename + 1, filename);
       *filename++ = NUL;
@@ -2790,8 +2789,8 @@ static int jumpto_tag(const char_u *lbuf_arg, int forceit, int keep_help)
   }
 
   if (keep_help) {
-    /* A :ta from a help file will keep the b_help flag set.  For ":ptag"
-     * we need to use the flag from the window where we came from. */
+    // A :ta from a help file will keep the b_help flag set.  For ":ptag"
+    // we need to use the flag from the window where we came from.
     if (l_g_do_tagpreview != 0) {
       keep_help_flag = curwin_save->w_buffer->b_help;
     } else {
@@ -2905,8 +2904,8 @@ static int jumpto_tag(const char_u *lbuf_arg, int forceit, int keep_help)
       p_ic = save_p_ic;  // -V519
       p_scs = save_p_scs;
 
-      /* A search command may have positioned the cursor beyond the end
-       * of the line.  May need to correct that here. */
+      // A search command may have positioned the cursor beyond the end
+      // of the line.  May need to correct that here.
       check_cursor();
     } else {
       const int save_secure = secure;
@@ -3128,9 +3127,8 @@ int expand_tags(int tagnames, char_u *pat, int *num_file, char_u ***file)
                     TAG_MANY, curbuf->b_ffname);
   }
   if (ret == OK && !tagnames) {
-    /* Reorganize the tags for display and matching as strings of:
-     * "<tagname>\0<kind>\0<filename>\0"
-     */
+    // Reorganize the tags for display and matching as strings of:
+    // "<tagname>\0<kind>\0<filename>\0"
     for (i = 0; i < *num_file; i++) {
       size_t len;
 
@@ -3260,8 +3258,8 @@ int get_tags(list_T *list, char_u *pat, char_u *buf_fname)
             char_u *s, *n;
             int len;
 
-            /* Add extra field as a dict entry.  Fields are
-             * separated by Tabs. */
+            // Add extra field as a dict entry.  Fields are
+            // separated by Tabs.
             n = p;
             while (*p != NUL && *p >= ' ' && *p < 127 && *p != ':') {
               ++p;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -503,8 +503,8 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, int re
           break;
         }
 
-        /* If lines have been inserted/deleted we give up.
-         * Also when the line was included in a multi-line save. */
+        // If lines have been inserted/deleted we give up.
+        // Also when the line was included in a multi-line save.
         if ((buf->b_u_newhead->uh_getbot_entry != uep
              ? (uep->ue_top + uep->ue_size + 1
                 != (uep->ue_bot == 0
@@ -520,18 +520,18 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, int re
         // If it's the same line we can skip saving it again.
         if (uep->ue_size == 1 && uep->ue_top == top) {
           if (i > 0) {
-            /* It's not the last entry: get ue_bot for the last
-             * entry now.  Following deleted/inserted lines go to
-             * the re-used entry. */
+            // It's not the last entry: get ue_bot for the last
+            // entry now.  Following deleted/inserted lines go to
+            // the re-used entry.
             u_getbot(buf);
             buf->b_u_synced = false;
 
-            /* Move the found entry to become the last entry.  The
-             * order of undo/redo doesn't matter for the entries
-             * we move it over, since they don't change the line
-             * count and don't include this line.  It does matter
-             * for the found entry if the line count is changed by
-             * the executed command. */
+            // Move the found entry to become the last entry.  The
+            // order of undo/redo doesn't matter for the entries
+            // we move it over, since they don't change the line
+            // count and don't include this line.  It does matter
+            // for the found entry if the line count is changed by
+            // the executed command.
             prev_uep->ue_next = uep->ue_next;
             uep->ue_next = buf->b_u_newhead->uh_entry;
             buf->b_u_newhead->uh_entry = uep;
@@ -1213,8 +1213,8 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   // Strip any sticky and executable bits.
   perm = perm & 0666;
 
-  /* If the undo file already exists, verify that it actually is an undo
-   * file, and delete it. */
+  // If the undo file already exists, verify that it actually is an undo
+  // file, and delete it.
   if (os_path_exists((char_u *)file_name)) {
     if (name == NULL || !forceit) {
       // Check we can read it and it's an undo file.
@@ -1254,8 +1254,8 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
     os_remove(file_name);
   }
 
-  /* If there is no undo information at all, quit here after deleting any
-   * existing undo file. */
+  // If there is no undo information at all, quit here after deleting any
+  // existing undo file.
   if (buf->b_u_numhead == 0 && buf->b_u_line_ptr == NULL) {
     if (p_verbose > 0) {
       verb_msg(_("Skipping undo file write, nothing to undo"));
@@ -1883,10 +1883,10 @@ static void u_doit(int startcount, bool quiet, bool do_buf_event)
     u_oldcount = -1;
   }
   while (count--) {
-    /* Do the change warning now, so that it triggers FileChangedRO when
-     * needed.  This may cause the file to be reloaded, that must happen
-     * before we do anything, because it may change curbuf->b_u_curhead
-     * and more. */
+    // Do the change warning now, so that it triggers FileChangedRO when
+    // needed.  This may cause the file to be reloaded, that must happen
+    // before we do anything, because it may change curbuf->b_u_curhead
+    // and more.
     change_warning(curbuf, 0);
 
     if (undo_undoes) {
@@ -1987,16 +1987,16 @@ void undo_time(long step, bool sec, bool file, bool absolute)
           uhp = curbuf->b_u_newhead;
         }
         if (uhp != NULL && uhp->uh_save_nr != 0) {
-          /* "uh_save_nr" was set in the last block, that means
-           * there were no changes since the last write */
+          // "uh_save_nr" was set in the last block, that means
+          // there were no changes since the last write
           target = curbuf->b_u_save_nr_cur + step;
         } else {
           // count the changes since the last write as one step
           target = curbuf->b_u_save_nr_cur + step + 1;
         }
         if (target <= 0) {
-          /* Go to before first write: before the oldest change. Use
-           * the sequence number for that. */
+          // Go to before first write: before the oldest change. Use
+          // the sequence number for that.
           dofile = false;
         }
       } else {
@@ -2047,11 +2047,11 @@ void undo_time(long step, bool sec, bool file, bool absolute)
    * When using the closest time we use the sequence number in the second
    * round, because there may be several entries with the same time.
    */
-  for (round = 1; round <= 2; ++round) {
-    /* Find the path from the current state to where we want to go.  The
-     * desired state can be anywhere in the undo tree, need to go all over
-     * it.  We put "nomark" in uh_walk where we have been without success,
-     * "mark" where it could possibly be. */
+  for (round = 1; round <= 2; round++) {
+    // Find the path from the current state to where we want to go.  The
+    // desired state can be anywhere in the undo tree, need to go all over
+    // it.  We put "nomark" in uh_walk where we have been without success,
+    // "mark" where it could possibly be.
     mark = ++lastmark;
     nomark = ++lastmark;
 
@@ -2519,10 +2519,10 @@ static void u_undoredo(int undo, bool do_buf_event)
       beginline(BL_SOL | BL_FIX);
     }
   } else {
-    /* We get here with the current cursor line being past the end (eg
-     * after adding lines at the end of the file, and then undoing it).
-     * check_cursor() will move the cursor to the last line.  Move it to
-     * the first column here. */
+    // We get here with the current cursor line being past the end (eg
+    // after adding lines at the end of the file, and then undoing it).
+    // check_cursor() will move the cursor to the last line.  Move it to
+    // the first column here.
     curwin->w_cursor.col = 0;
     curwin->w_cursor.coladd = 0;
   }
@@ -2533,8 +2533,8 @@ static void u_undoredo(int undo, bool do_buf_event)
   // Remember where we are for "g-" and ":earlier 10s".
   curbuf->b_u_seq_cur = curhead->uh_seq;
   if (undo) {
-    /* We are below the previous undo.  However, to make ":earlier 1s"
-     * work we compute this as being just above the just undone change. */
+    // We are below the previous undo.  However, to make ":earlier 1s"
+    // work we compute this as being just above the just undone change.
     curbuf->b_u_seq_cur = curhead->uh_next.ptr ?
                           curhead->uh_next.ptr->uh_seq : 0;
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -464,9 +464,8 @@ wingotofile:
     }
     break;
 
-  /* Go to the first occurrence of the identifier under cursor along path in a
-   * new window -- webb
-   */
+  // Go to the first occurrence of the identifier under cursor along path in a
+  // new window -- webb
   case 'i':                         // Go to any match
   case Ctrl_I:
     type = FIND_ANY;
@@ -1046,8 +1045,8 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       win_setwidth_win(oldwin->w_width + new_size + 1, oldwin);
     }
 
-    /* Only make all windows the same width if one of them (except oldwin)
-     * is wider than one of the split windows. */
+    // Only make all windows the same width if one of them (except oldwin)
+    // is wider than one of the split windows.
     if (!do_equal && p_ea && size == 0 && *p_ead != 'v'
         && oldwin->w_frame->fr_parent != NULL) {
       frp = oldwin->w_frame->fr_parent->fr_child;
@@ -1125,9 +1124,9 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       do_equal = true;
     }
 
-    /* We don't like to take lines for the new window from a
-     * 'winfixheight' window.  Take them from a window above or below
-     * instead, if possible. */
+    // We don't like to take lines for the new window from a
+    // 'winfixheight' window.  Take them from a window above or below
+    // instead, if possible.
     if (oldwin->w_p_wfh) {
       // Set w_fraction now so that the cursor keeps the same relative
       // vertical position using the old height.
@@ -1142,8 +1141,8 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       }
     }
 
-    /* Only make all windows the same height if one of them (except oldwin)
-     * is higher than one of the split windows. */
+    // Only make all windows the same height if one of them (except oldwin)
+    // is higher than one of the split windows.
     if (!do_equal && p_ea && size == 0
         && *p_ead != 'h'
         && oldwin->w_frame->fr_parent != NULL) {
@@ -1874,15 +1873,14 @@ void win_move_after(win_T *win1, win_T *win2)
 
   // check if there is something to do
   if (win2->w_next != win1) {
-    /* may need move the status line/vertical separator of the last window
-     * */
+    // may need move the status line/vertical separator of the last window
     if (win1 == lastwin) {
       height = win1->w_prev->w_status_height;
       win1->w_prev->w_status_height = win1->w_status_height;
       win1->w_status_height = height;
       if (win1->w_prev->w_vsep_width == 1) {
-        /* Remove the vertical separator from the last-but-one window,
-         * add it to the last window.  Adjust the frame widths. */
+        // Remove the vertical separator from the last-but-one window,
+        // add it to the last window.  Adjust the frame widths.
         win1->w_prev->w_vsep_width = 0;
         win1->w_prev->w_frame->fr_width -= 1;
         win1->w_vsep_width = 1;
@@ -1974,8 +1972,8 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
     topfr->fr_height = height;
 
     if (dir != 'v') {                   // equalize frame widths
-      /* Compute the maximum number of windows horizontally in this
-       * frame. */
+      // Compute the maximum number of windows horizontally in this
+      // frame.
       n = frame_minwidth(topfr, NOWIN);
       // add one for the rightmost window, it doesn't have a separator
       if (col + width == Columns) {
@@ -2360,8 +2358,8 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, tabpage_T *prev
   char_u prev_idx[NUMBUFLEN];
   sprintf((char *)prev_idx, "%i", tabpage_index(prev_curtab));
 
-  /* Safety check: Autocommands may have closed the window when jumping
-   * to the other tab page. */
+  // Safety check: Autocommands may have closed the window when jumping
+  // to the other tab page.
   if (valid_tabpage(prev_curtab) && prev_curtab->tp_firstwin == win) {
     int h = tabline_height();
 
@@ -2421,15 +2419,15 @@ int win_close(win_T *win, bool free_buf)
     return FAIL;
   }
 
-  /* When closing the last window in a tab page first go to another tab page
-   * and then close the window and the tab page to avoid that curwin and
-   * curtab are invalid while we are freeing memory. */
+  // When closing the last window in a tab page first go to another tab page
+  // and then close the window and the tab page to avoid that curwin and
+  // curtab are invalid while we are freeing memory.
   if (close_last_window_tabpage(win, free_buf, prev_curtab)) {
     return FAIL;
   }
 
-  /* When closing the help window, try restoring a snapshot after closing
-   * the window.  Otherwise clear the snapshot, it's now invalid. */
+  // When closing the help window, try restoring a snapshot after closing
+  // the window.  Otherwise clear the snapshot, it's now invalid.
   if (bt_help(win->w_buffer)) {
     help_window = true;
   } else {
@@ -2575,9 +2573,9 @@ int win_close(win_T *win, bool free_buf)
     }
   }
 
-  /* Make sure curwin isn't invalid.  It can cause severe trouble when
-   * printing an error message.  For win_equal() curbuf needs to be valid
-   * too. */
+  // Make sure curwin isn't invalid.  It can cause severe trouble when
+  // printing an error message.  For win_equal() curbuf needs to be valid
+  // too.
   if (win == curwin) {
     curwin = wp;
     if (wp->w_p_pvw || bt_quickfix(wp->w_buffer)) {
@@ -2895,9 +2893,9 @@ win_T *winframe_remove(win_T *win, int *dirp, tabpage_T *tp)
                      frp2 == frp_close->fr_next, false);
     *dirp = 'v';
   } else {
-    /* When 'winfixwidth' is set, try to find another frame in the column
-     * (as close to the closed frame as possible) to distribute the width
-     * to. */
+    // When 'winfixwidth' is set, try to find another frame in the column
+    // (as close to the closed frame as possible) to distribute the width
+    // to.
     if (frp2->fr_win != NULL && frp2->fr_win->w_p_wfw) {
       frp = frp_close->fr_prev;
       frp3 = frp_close->fr_next;
@@ -3112,8 +3110,8 @@ static void frame_new_height(frame_T *topfrp, int height, bool topfirst, bool wf
       }
     } while (frp != NULL);
   } else {  // fr_layout == FR_COL
-    /* Complicated case: Resize a column of frames.  Resize the bottom
-     * frame first, frames above that when needed. */
+    // Complicated case: Resize a column of frames.  Resize the bottom
+    // frame first, frames above that when needed.
 
     frp = topfrp->fr_child;
     if (wfh) {
@@ -3310,8 +3308,8 @@ static void frame_new_width(frame_T *topfrp, int width, bool leftfirst, bool wfw
       }
     } while (frp != NULL);
   } else {  // fr_layout == FR_ROW
-    /* Complicated case: Resize a row of frames.  Resize the rightmost
-     * frame first, frames left of it when needed. */
+    // Complicated case: Resize a row of frames.  Resize the rightmost
+    // frame first, frames left of it when needed.
 
     frp = topfrp->fr_child;
     if (wfw) {
@@ -4043,8 +4041,8 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, bool trigger_enter_a
 
   lastused_tabpage = old_curtab;
 
-  /* Apply autocommands after updating the display, when 'rows' and
-   * 'columns' have been set correctly. */
+  // Apply autocommands after updating the display, when 'rows' and
+  // 'columns' have been set correctly.
   if (trigger_enter_autocmds) {
     apply_autocmds(EVENT_TABENTER, NULL, NULL, false, curbuf);
     if (old_curbuf != curbuf) {
@@ -4776,8 +4774,8 @@ static void win_free(win_T *wp, tabpage_T *tp)
   xfree(wp->w_localdir);
   xfree(wp->w_prevdir);
 
-  /* Remove the window from the b_wininfo lists, it may happen that the
-   * freed memory is re-used for another window. */
+  // Remove the window from the b_wininfo lists, it may happen that the
+  // freed memory is re-used for another window.
   FOR_ALL_BUFFERS(buf) {
     for (wip = buf->b_wininfo; wip != NULL; wip = wip->wi_next) {
       if (wip->wi_win == wp) {
@@ -4950,8 +4948,8 @@ void shell_new_rows(void)
     h = frame_minheight(topframe, NULL);
   }
 
-  /* First try setting the heights of windows with 'winfixheight'.  If
-   * that doesn't result in the right height, forget about that option. */
+  // First try setting the heights of windows with 'winfixheight'.  If
+  // that doesn't result in the right height, forget about that option.
   frame_new_height(topframe, h, false, true);
   if (!frame_check_height(topframe, h)) {
     frame_new_height(topframe, h, false, false);
@@ -4972,8 +4970,8 @@ void shell_new_columns(void)
     return;
   }
 
-  /* First try setting the widths of windows with 'winfixwidth'.  If that
-   * doesn't result in the right width, forget about that option. */
+  // First try setting the widths of windows with 'winfixwidth'.  If that
+  // doesn't result in the right width, forget about that option.
   frame_new_width(topframe, Columns, false, true);
   if (!frame_check_width(topframe, Columns)) {
     frame_new_width(topframe, Columns, false, false);
@@ -5572,8 +5570,8 @@ void win_drag_status_line(win_T *dragwin, int offset)
     }
   }
 
-  /* If this is the last frame in a column, may want to resize the parent
-   * frame instead (go two up to skip a row of frames). */
+  // If this is the last frame in a column, may want to resize the parent
+  // frame instead (go two up to skip a row of frames).
   while (curfr != topframe && curfr->fr_next == NULL) {
     if (fr != topframe) {
       fr = fr->fr_parent;
@@ -5699,8 +5697,8 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
     fr = fr->fr_parent;
   }
 
-  /* If this is the last frame in a row, may want to resize a parent
-   * frame instead. */
+  // If this is the last frame in a row, may want to resize a parent
+  // frame instead.
   while (curfr->fr_next == NULL) {
     if (fr == topframe) {
       break;


### PR DESCRIPTION
#### vim-patch:8.1.2368: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/c667da5185ce5dce914d2006d62da2be0cedb384


#### vim-patch:8.1.2378: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/5d18efecfd6c45d69f55268948a22cd0465bb955


#### vim-patch:8.1.2379: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/217e1b8359447f5550dcb0d1ee43380a90c253c5


#### vim-patch:8.1.2380: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/306139005c31ea7e6f892dd119beba3c94dcb982


#### vim-patch:8.1.2387: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/2ab2e8608f9b2c85432715bb9a7f226fdbf8cd35


#### vim-patch:8.1.2388: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/4ba37b5833de99db9e9afe8928b31c864182405c


#### vim-patch:8.1.2392: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/6e0ce171e19d0118ecd7c2b16e2a1bd50aa76013


#### vim-patch:8.1.2394: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/63d9e730f726341bf41ee4f4b829253cb9879110


#### vim-patch:8.1.2395: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/0d6f5d9740dbad1b0207f3ab257de806169dd905


#### vim-patch:8.1.2396: using old C style comments

Problem:    Using old C style comments.
Solution:   Use // comments where appropriate.
https://github.com/vim/vim/commit/e38eab22c1fb950127f0307a9904de6d4561dc70