### PR TITLE
vim-patch:8.2.3550: getcompletion() does not work properly

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3359,7 +3359,7 @@ static void f_getcompletion(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   expand_T xpc;
   bool filtered = false;
   int options = WILD_SILENT | WILD_USE_NL | WILD_ADD_SLASH
-                | WILD_NO_BEEP;
+                | WILD_NO_BEEP | WILD_HOME_REPLACE;
 
   if (argvars[1].v_type != VAR_STRING) {
     EMSG2(_(e_invarg2), "type must be a string");

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2915,6 +2915,7 @@ const char *set_one_cmd_context(expand_T *xp, const char *buff)
 
   ExpandInit(xp);
   xp->xp_pattern = (char_u *)buff;
+  xp->xp_line = (char_u *)buff;
   xp->xp_context = EXPAND_COMMANDS;  // Default until we get past command
   ea.argt = 0;
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -309,6 +309,11 @@ func Test_getcompletion()
   let l = getcompletion('NoMatch', 'dir')
   call assert_equal([], l)
 
+ if glob('~/*') !=# ''
+    let l = getcompletion('~/', 'dir')
+    call assert_true(l[0][0] ==# '~')
+  endif
+
   let l = getcompletion('exe', 'expression')
   call assert_true(index(l, 'executable(') >= 0)
   let l = getcompletion('kill', 'expression')
@@ -421,6 +426,16 @@ func Test_getcompletion()
   call assert_true(index(l, 'taglist(') >= 0)
   let l = getcompletion('call paint', 'cmdline')
   call assert_equal([], l)
+
+  func T(a, c, p)
+    return "oneA\noneB\noneC"
+  endfunc
+  command -nargs=1 -complete=custom,T MyCmd
+  let l = getcompletion('MyCmd ', 'cmdline')
+  call assert_equal(['oneA', 'oneB', 'oneC'], l)
+
+  delcommand MyCmd
+  delfunc T
 
   " For others test if the name is recognized.
   let names = ['buffer', 'environment', 'file_in_path', 'mapping', 'tag', 'tag_listfiles', 'user']

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -309,7 +309,7 @@ func Test_getcompletion()
   let l = getcompletion('NoMatch', 'dir')
   call assert_equal([], l)
 
- if glob('~/*') !=# ''
+  if glob('~/*') !=# ''
     let l = getcompletion('~/', 'dir')
     call assert_true(l[0][0] ==# '~')
   endif


### PR DESCRIPTION
Problem:    completion() does not work properly.
Solution:   Set xp_line and add WILD_HOME_REPLACE. (Shougo Matsushita,
            closes vim/vim#9016)
https://github.com/vim/vim/commit/ae38a9db7770b38889fbf06908cc69d42b463a73

@shougo