### PR TITLE
fix(lsp): fix incremental sync issues during multibyte operations

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -363,42 +363,51 @@ end
 -- end
 
 ---@private
---- Finds the first line and column of the difference between old and new lines
+--- Finds the first line and byte index of the difference between old and new lines.
+--- Normalized to the previous codepoint.
 ---@param old_lines table list of lines
 ---@param new_lines table list of lines
----@returns (int, int) start_line_idx and start_col_idx of range
+---@returns (int, int) start_line_idx and start_byte_idx of range
 local function first_difference(old_lines, new_lines, start_line_idx)
   local line_count = math.min(#old_lines, #new_lines)
   if line_count == 0 then return 1, 1 end
+
+  -- Handle case where start_line_idx is not passed
   if not start_line_idx then
-    for i = 1, line_count do
-      start_line_idx = i
+    for idx = 1, line_count do
+      start_line_idx = idx
       if old_lines[start_line_idx] ~= new_lines[start_line_idx] then
         break
       end
     end
   end
+
   local old_line = old_lines[start_line_idx]
   local new_line = new_lines[start_line_idx]
   local length = math.min(#old_line, #new_line)
-  local start_col_idx = 1
-  while start_col_idx <= length do
-    if string.sub(old_line, start_col_idx, start_col_idx) ~= string.sub(new_line, start_col_idx, start_col_idx) then
+  local start_byte_idx = 1
+  while start_byte_idx <= length do
+    if string.byte(old_line, start_byte_idx) ~= string.byte(new_line, start_byte_idx) then
       break
     end
-    start_col_idx  = start_col_idx  + 1
+    start_byte_idx  = start_byte_idx  + 1
   end
-  return start_line_idx, start_col_idx
+
+  if #old_line > 1 and start_byte_idx <= #old_line then
+    start_byte_idx = start_byte_idx + vim.str_utf_start(old_line, start_byte_idx)
+  end
+  return start_line_idx, start_byte_idx
 end
 
 
 ---@private
---- Finds the last line and column of the differences between old and new lines
+--- Finds the last line and byte index of the differences between old and new lines>
+--- Normalized to the next codepoint.
 ---@param old_lines table list of lines
 ---@param new_lines table list of lines
----@param start_char integer First different character idx of range
+---@param start_byte integer First different byte idx of range
 ---@returns (int, int) end_line_idx and end_col_idx of range
-local function last_difference(old_lines, new_lines, start_char, end_line_idx)
+local function last_difference(old_lines, new_lines, start_byte, end_line_idx)
   local line_count = math.min(#old_lines, #new_lines)
   if line_count == 0 then return 0,0 end
   if not end_line_idx then
@@ -414,8 +423,8 @@ local function last_difference(old_lines, new_lines, start_char, end_line_idx)
   local new_line
   if end_line_idx <= -line_count then
     end_line_idx = -line_count
-    old_line  = string.sub(old_lines[#old_lines + end_line_idx + 1], start_char)
-    new_line  = string.sub(new_lines[#new_lines + end_line_idx + 1], start_char)
+    old_line  = string.sub(old_lines[#old_lines + end_line_idx + 1], start_byte)
+    new_line  = string.sub(new_lines[#new_lines + end_line_idx + 1], start_byte)
   else
     old_line  = old_lines[#old_lines + end_line_idx + 1]
     new_line  = new_lines[#new_lines + end_line_idx + 1]
@@ -423,44 +432,61 @@ local function last_difference(old_lines, new_lines, start_char, end_line_idx)
   local old_line_length = #old_line
   local new_line_length = #new_line
   local length = math.min(old_line_length, new_line_length)
-  local end_col_idx = -1
-  while end_col_idx >= -length do
-    local old_char =  string.sub(old_line, old_line_length + end_col_idx + 1, old_line_length + end_col_idx + 1)
-    local new_char =  string.sub(new_line, new_line_length + end_col_idx + 1, new_line_length + end_col_idx + 1)
-    if old_char ~= new_char then
+  local end_byte_idx = -1
+  while end_byte_idx >= -length do
+    if string.byte(old_line, old_line_length + end_byte_idx + 1) ~= string.byte(new_line, new_line_length + end_byte_idx + 1) then
       break
     end
-    end_col_idx = end_col_idx - 1
+    end_byte_idx = end_byte_idx - 1
   end
-  return end_line_idx, end_col_idx
+  end_byte_idx = end_byte_idx + vim.str_utf_end(old_line, old_line_length + end_byte_idx + 1)
+
+  return end_line_idx, end_byte_idx
 
 end
 
 ---@private
 --- Get the text of the range defined by start and end line/column
 ---@param lines table list of lines
----@param start_char integer First different character idx of range
----@param end_char integer Last different character idx of range
+---@param start_byte integer First different byte idx of range
+---@param end_byte integer Last different byte idx of range
 ---@param start_line integer First different line idx of range
 ---@param end_line integer Last different line idx of range
 ---@returns string text extracted from defined region
-local function extract_text(lines, start_line, start_char, end_line, end_char)
+local function extract_text(lines, start_line, start_byte, end_line, end_byte)
   if start_line == #lines + end_line + 1 then
     if end_line == 0 then return '' end
     local line = lines[start_line]
-    local length = #line + end_char - start_char
-    return string.sub(line, start_char, start_char + length + 1)
+    local length = #line + end_byte - start_byte
+    return string.sub(line, start_byte, start_byte + length + 1)
   end
-  local result = string.sub(lines[start_line], start_char) .. '\n'
+
+  local result = { string.sub(lines[start_line], start_byte) }
   for line_idx = start_line + 1, #lines + end_line do
-    result = result .. lines[line_idx] .. '\n'
+    table.insert(result, lines[line_idx])
   end
+
+  result = table.concat(result, '\n') .. '\n'
+
   if end_line ~= 0 then
     local line = lines[#lines + end_line + 1]
-    local length = #line + end_char + 1
+    local length = #line + end_byte + 1
     result = result .. string.sub(line, 1, length)
   end
   return result
+end
+
+local function get_utf_position(line, byte_idx, offset_encoding)
+  byte_idx = byte_idx - 1
+  local idx
+  if offset_encoding == "utf-16" then
+    _, idx = vim.str_utfindex(line, byte_idx)
+  elseif offset_encoding == "utf-32" then
+    idx, _ = vim.str_utfindex(line, byte_idx)
+  else
+    idx = byte_idx
+  end
+  return idx
 end
 
 ---@private
@@ -471,7 +497,7 @@ end
 ---@param start_line integer First different line idx of range
 ---@param end_line integer Last different line idx of range
 ---@returns (int, int) end_line_idx and end_col_idx of range
-local function compute_length(lines, start_line, start_char, end_line, end_char)
+local function compute_length(lines, start_line, start_char, end_line, end_char, offset_encoding)
   local adj_end_line = #lines + end_line + 1
   local adj_end_char
   if adj_end_line > #lines then
@@ -482,49 +508,72 @@ local function compute_length(lines, start_line, start_char, end_line, end_char)
   if start_line == adj_end_line then
     return adj_end_char - start_char + 1
   end
-  local result = #lines[start_line] - start_char + 1
-  for line = start_line + 1, adj_end_line -1 do
-    result = result + #lines[line] + 1
+  local result
+
+  if #lines[start_line] - start_char + 1 > 0 then
+    result = get_utf_position(lines[start_line], #lines[start_line] - start_char + 1, offset_encoding)
+  else
+    result = 0
   end
-  result = result + adj_end_char + 1
+
+  for line = start_line + 1, adj_end_line -1 do
+    result = result + get_utf_position(lines[line], #lines[line] + 1, offset_encoding)
+  end
+
+  if #lines[start_line] - start_char + 1 > 0 then
+    result = result + get_utf_position(lines[line], adj_end_char + 1, offset_encoding)
+  end
   return result
 end
 
 --- Returns the range table for the difference between old and new lines
 ---@param old_lines table list of lines
 ---@param new_lines table list of lines
----@param start_line_idx int line to begin search for first difference
----@param end_line_idx int line to begin search for last difference
+---@param start_line_idx number line to begin search for first difference
+---@param end_line_idx number line to begin search for last difference
 ---@param offset_encoding string encoding requested by language server
----@returns table start_line_idx and start_col_idx of range
+---@returns table range parameters matching language server specification
 function M.compute_diff(old_lines, new_lines, start_line_idx, end_line_idx, offset_encoding)
-  local start_line, start_char = first_difference(old_lines, new_lines, start_line_idx)
-  local end_line, end_char = last_difference(vim.list_slice(old_lines, start_line, #old_lines),
-      vim.list_slice(new_lines, start_line, #new_lines), start_char, end_line_idx)
-  local text = extract_text(new_lines, start_line, start_char, end_line, end_char)
-  local length = compute_length(old_lines, start_line, start_char, end_line, end_char)
+  -- Find first changed line, and the first utf-8 codepoint-aligned difference
+  local start_line, start_byte_idx = first_difference(old_lines, new_lines, start_line_idx)
 
-  local adj_end_line = #old_lines + end_line
-  local adj_end_char
+  -- Find the last changed line, and the last utf-8 codepoint-aligned byte difference
+  local end_line, end_byte_idx = last_difference(
+    vim.list_slice(old_lines, start_line, #old_lines),
+    vim.list_slice(new_lines, start_line, #new_lines),
+    start_byte_idx,
+    end_line_idx
+  )
+
+  -- Compute the rangeLength
+  local length = compute_length(old_lines, start_line, start_byte_idx, end_line, end_byte_idx, offset_encoding)
+
+  -- Extract the new text using the codepoint aligned byte range
+  local text = extract_text( new_lines, start_line, start_byte_idx, end_line, end_byte_idx)
+
   if end_line == 0 then
-    adj_end_char = 0
+    end_byte_idx = 0
   else
-    adj_end_char = #old_lines[#old_lines + end_line + 1] + end_char + 1
+    end_byte_idx = #old_lines[#old_lines + end_line + 1] + end_byte_idx + 1
   end
 
-  local _
+  local start_character, end_character, _
+  -- Convert the byte range to utf-{8,16,32} and convert 1-based (lua) indexing to 0-based
   if offset_encoding == "utf-16" then
-    _, start_char = vim.str_utfindex(old_lines[start_line], start_char - 1)
-    _, end_char = vim.str_utfindex(old_lines[#old_lines + end_line + 1], adj_end_char)
+    _, start_character = vim.str_utfindex(old_lines[start_line], start_byte_idx - 1)
+    _, end_character = vim.str_utfindex(old_lines[#old_lines + end_line + 1], end_byte_idx)
+  elseif offset_encoding == "utf-32" then
+    start_character, _ = vim.str_utfindex(old_lines[start_line], start_byte_idx - 1)
+    end_character, _ = vim.str_utfindex(old_lines[#old_lines + end_line + 1], end_byte_idx)
   else
-    start_char = start_char - 1
-    end_char = adj_end_char
+    start_character = start_byte_idx - 1
+    end_character = end_byte_idx
   end
 
   local result = {
     range = {
-      start = { line = start_line - 1, character = start_char},
-      ["end"] = { line = adj_end_line, character = end_char}
+      start = { line = start_line - 1, character = start_character},
+      ["end"] = { line = #old_lines + end_line, character = end_character}
     },
     text = text,
     rangeLength = length + 1,

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -567,7 +567,6 @@ function tests.basic_check_buffer_open_and_change_incremental()
               start = { line = 1; character = 3; };
               ["end"] = { line = 1; character = 3; };
             };
-            rangeLength = 0;
             text = "boop";
           };
         }
@@ -610,7 +609,6 @@ function tests.basic_check_buffer_open_and_change_incremental_editing()
               start = { line = 0; character = 0; };
               ["end"] = { line = 1; character = 0; };
             };
-            rangeLength = 4;
             text = "testing\n\n";
           };
         }


### PR DESCRIPTION
closes #14542

Cleaning up some of my naming (which was wrong) and added a fix for multibyte edits:

* extract text is receiving start/end byte ranges, which means it's sending nonsense in the event that the bytes are the same for the first char of a multibyte character but the others have changed
* compute length is computing the byte length (again, wrong, but lets remove it)
* adj_end_char is operating on the bytes when it should be operating on the utf-8/16/32 position (I think with the clamping of the byte range to codepoints I'm doing now its fine)
* handle utf-32 (not used but still)

Note, this only fixes the synchronization operations, not the text edit paths which still has some issues that need to be addressed before 0.6. Also does not fix the outstanding `\r` issue

Eventually all this incremental sync/diffing code will be handled internally by the same on_bytes changes that power treesitter, but the ETA for that is not within the release window of 0.6.

cc @dmitmel