### PR TITLE
vim-patch:8.2.{0156,2160}: typos

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1452,7 +1452,7 @@ void set_curbuf(buf_T *buf, int action)
   set_bufref(&prevbufref, prevbuf);
   set_bufref(&newbufref, buf);
 
-  // Autocommands may delete the curren buffer and/or the buffer we want to go
+  // Autocommands may delete the current buffer and/or the buffer we want to go
   // to.  In those cases don't close the buffer.
   if (!apply_autocmds(EVENT_BUFLEAVE, NULL, NULL, false, curbuf)
       || (bufref_valid(&prevbufref) && bufref_valid(&newbufref)
@@ -1465,6 +1465,7 @@ void set_curbuf(buf_T *buf, int action)
     }
     if (bufref_valid(&prevbufref) && !aborting()) {
       win_T *previouswin = curwin;
+
       if (prevbuf == curbuf) {
         u_sync(false);
       }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1587,7 +1587,7 @@ vim_str2nr_hex:
 #undef PARSE_NUMBER
 
 vim_str2nr_proceed:
-  // Check for an alpha-numeric character immediately following, that is
+  // Check for an alphanumeric character immediately following, that is
   // most likely a typo.
   if (strict && ptr - (const char *)start != maxlen && ASCII_ISALNUM(*ptr)) {
     return;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7424,7 +7424,7 @@ static void ex_edit(exarg_T *eap)
   do_exedit(eap, NULL);
 }
 
-/// ":edit <file>" command and alikes.
+/// ":edit <file>" command and alike.
 ///
 /// @param old_curwin  curwin before doing a split or NULL
 void do_exedit(exarg_T *eap, win_T *old_curwin)

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3989,10 +3989,8 @@ static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype)
     } else if (buf->b_ml.ml_chunksize[curix].mlcs_numlines >= MLCS_MINL
                && curix == buf->b_ml.ml_usedchunks - 1
                && buf->b_ml.ml_line_count - line <= 1) {
-      /*
-       * We are in the last chunk and it is cheap to crate a new one
-       * after this. Do it now to avoid the loop above later on
-       */
+      // We are in the last chunk and it is cheap to create a new one
+      // after this. Do it now to avoid the loop above later on
       curchnk = buf->b_ml.ml_chunksize + curix + 1;
       buf->b_ml.ml_usedchunks++;
       if (line == buf->b_ml.ml_line_count) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -5142,7 +5142,7 @@ search_line:
 
           // we read a line, set "already" to check this "line" later
           // if depth >= 0 we'll increase files[depth].lnum far
-          // bellow  -- Acevedo
+          // below  -- Acevedo
           already = aux = p = skipwhite(line);
           p = find_word_start(p);
           p = find_word_end(p);

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -1,7 +1,7 @@
 " Test for breakindent
 "
 " Note: if you get strange failures when adding new tests, it might be that
-" while the test is run, the breakindent cacheing gets in its way.
+" while the test is run, the breakindent caching gets in its way.
 " It helps to change the tabstop setting and force a redraw (e.g. see
 " Test_breakindent08())
 if !exists('+breakindent')

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -131,9 +131,12 @@ endfunc
 " this was going beyond the end of the line.
 func Test_cindent_case()
   new
-  call setline(1, "case x: // x")
+  call setline(1, 'case x: // x')
   set cindent
   norm! f:a:
+  call assert_equal('case x:: // x', getline(1))
+
+  set cindent&
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_debugger.vim
+++ b/src/nvim/testdir/test_debugger.vim
@@ -976,7 +976,7 @@ func Test_debug_backtrace_level()
         \ 'line 1: let s:file1_var = ''file1'''
         \ ])
 
-  " step throught the initial declarations
+  " step through the initial declarations
   call RunDbgCmd(buf, 'step', [ 'line 2: let g:global_var = ''global''' ] )
   call RunDbgCmd(buf, 'step', [ 'line 4: func s:File1Func( arg )' ] )
   call RunDbgCmd(buf, 'echo s:file1_var', [ 'file1' ] )

--- a/src/nvim/testdir/test_digraph.vim
+++ b/src/nvim/testdir/test_digraph.vim
@@ -81,7 +81,7 @@ func Test_digraphs()
   call Put_Dig(".e")
   call Put_Dig("a.") " not defined
   call assert_equal(['ḃ', 'ė', '.'], getline(line('.')-2,line('.')))
-  " Diaresis
+  " Diaeresis
   call Put_Dig("a:")
   call Put_Dig(":u")
   call Put_Dig("b:") " not defined
@@ -288,7 +288,7 @@ func Test_digraphs_option()
   call Put_Dig_BS(".","e")
   call Put_Dig_BS("a",".") " not defined
   call assert_equal(['ḃ', 'ė', '.'], getline(line('.')-2,line('.')))
-  " Diaresis
+  " Diaeresis
   call Put_Dig_BS("a",":")
   call Put_Dig_BS(":","u")
   call Put_Dig_BS("b",":") " not defined

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -590,7 +590,7 @@ func Test_edit_CTRL_K()
   call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal(['AA'], getline(1, '$'))
 
-  " press an unexecpted key after dictionary completion
+  " press an unexpected key after dictionary completion
   %d
   call setline(1, 'A')
   call cursor(1, 1)

--- a/src/nvim/testdir/test_increment.vim
+++ b/src/nvim/testdir/test_increment.vim
@@ -285,7 +285,7 @@ endfunc
 " 1
 "     1
 "     1
-"     Expexted:
+"     Expected:
 "     1) g Ctrl-A on block selected indented lines
 "     2
 " 1

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2715,7 +2715,7 @@ func Test_cwindow_jump()
   call assert_true(winnr('$') == 2)
   call assert_true(winnr() == 1)
 
-  " Jumping to a file from the location list window should find a usuable
+  " Jumping to a file from the location list window should find a usable
   " window by wrapping around the window list.
   enew | only
   call setloclist(0, [], 'f')

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -1354,7 +1354,7 @@ func Test_sort_cmd()
     endif
   endfor
 
-  " Needs atleast two lines for this test
+  " Needs at least two lines for this test
   call setline(1, ['line1', 'line2'])
   call assert_fails('sort no', 'E474:')
   call assert_fails('sort c', 'E475:')

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -5,7 +5,7 @@ func CheckFileTime(doSleep)
   let times = []
   let result = 0
 
-  " Use three files istead of localtim(), with a network filesystem the file
+  " Use three files instead of localtim(), with a network filesystem the file
   " times may differ at bit
   let fl = ['Hello World!']
   for fname in fnames


### PR DESCRIPTION
#### vim-patch:8.2.0156: various typos in source files and tests

Problem:    Various typos in source files and tests.
Solution:   Fix the typos. (Emir Sari, closes vim/vim#5532)
https://github.com/vim/vim/commit/4b96df5a017a04141c4e901b1fc5704a3ca48099


#### vim-patch:8.2.2160: various typos

Problem:    Various typos.
Solution:   Fix spelling mistakes. (closes vim/vim#7494)
https://github.com/vim/vim/commit/8e7d6223f630690b72b387eaed704bf01f3f29d2