### PR TITLE
feat(codelens): Use virt lines

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -138,8 +138,9 @@ function M.display(lenses, bufnr, client_id)
       end
     end
     if #chunks > 0 then
-      api.nvim_buf_set_extmark(bufnr, ns, i, 0, { virt_text = chunks,
-                                                  hl_mode="combine" })
+      api.nvim_buf_set_extmark(bufnr, ns, i, 0, { virt_lines = { chunks },
+                                                  hl_mode="combine",
+                                                  virt_lines_above = true })
     end
   end
 end
@@ -200,8 +201,8 @@ local function resolve_lenses(lenses, bufnr, client_id, callback)
             ns,
             lens.range.start.line,
             0,
-            { virt_text = {{ lens.command.title, 'LspCodeLens' }},
-                hl_mode="combine" }
+            { virt_lines = {{{ lens.command.title, 'LspCodeLens' }}},
+                hl_mode="combine", virt_lines_above = true }
           )
         end
         countdown()


### PR DESCRIPTION
Issues: The virt line doesn't show up when the codelens is on the first line. We should hold off from merging this before that issue is fixed.