### PR TITLE
fix(eval): fix has('wsl')

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -12,11 +12,6 @@ check_type_size("size_t" SIZEOF_SIZE_T)
 check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("void *" SIZEOF_VOID_PTR)
 
-if (CMAKE_HOST_SYSTEM_VERSION MATCHES ".*-(Microsoft|microsoft-standard)")
-  # Windows Subsystem for Linux
-  set(HAVE_WSL 1)
-endif()
-
 check_symbol_exists(_NSGetEnviron crt_externs.h HAVE__NSGETENVIRON)
 
 # Headers

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -39,7 +39,6 @@
 #cmakedefine HAVE_SYS_WAIT_H
 #cmakedefine HAVE_TERMIOS_H
 #cmakedefine HAVE_WORKING_LIBINTL
-#cmakedefine HAVE_WSL
 #cmakedefine UNIX
 #cmakedefine CASE_INSENSITIVE_FILENAME
 #cmakedefine USE_FNAME_CASE

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4552,9 +4552,6 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "windows",
     "winaltkeys",
     "writebackup",
-#if defined(HAVE_WSL)
-    "wsl",
-#endif
     "nvim",
   };
 
@@ -4601,6 +4598,8 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       n = syntax_present(curwin);
     } else if (STRICMP(name, "clipboard_working") == 0) {
       n = eval_has_provider("clipboard");
+    } else if (STRICMP(name, "wsl") == 0) {
+      n = has_wsl();
 #ifdef UNIX
     } else if (STRICMP(name, "unnamedplus") == 0) {
       n = eval_has_provider("clipboard");
@@ -4615,9 +4614,24 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->vval.v_number = n;
 }
 
-/*
- * "has_key()" function
- */
+static bool has_wsl(void)
+{
+  static TriState has_wsl = kNone;
+  if (has_wsl == kNone) {
+    Error err = ERROR_INIT;
+    Object o = nlua_exec(
+        STATIC_CSTR_AS_STRING("return vim.loop.os_uname()['release']:lower()"
+                              ":match('microsoft') and true or false"),
+        (Array)ARRAY_DICT_INIT, &err);
+    assert(!ERROR_SET(&err));
+    assert(o.type == kObjectTypeBoolean);
+    has_wsl = o.data.boolean ? kTrue : kFalse;
+    api_free_object(o);
+  }
+  return has_wsl == kTrue;
+}
+
+/// "has_key()" function
 static void f_has_key(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
   if (argvars[0].v_type != VAR_DICT) {

--- a/test/functional/vimscript/has_spec.lua
+++ b/test/functional/vimscript/has_spec.lua
@@ -59,7 +59,12 @@ describe('has()', function()
   end)
 
   it('"wsl"', function()
-    if 1 == funcs.has('win32') or 1 == funcs.has('mac') then
+    local luv = require('luv')
+    local is_wsl =
+      luv.os_uname()['release']:lower():match('microsoft') and true or false
+    if is_wsl then
+      eq(1, funcs.has('wsl'))
+    else
       eq(0, funcs.has('wsl'))
     end
   end)


### PR DESCRIPTION
Fix the problem that `has('wsl')` was returning build environment.

Ref #12642, #16143.



