### PR TITLE
fix(float): fix potential heap corruption in win_redr_border

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5655,7 +5655,9 @@ static void win_redr_border(win_T *wp)
       int ic = (i == 0 && !adj[3] && chars[6][0]) ? 6 : 5;
       grid_put_schar(grid, irow+adj[0], i+adj[3], chars[ic], attrs[ic]);
     }
-    grid_put_schar(grid, irow+adj[0], icol+adj[3], chars[4], attrs[4]);
+    if (adj[1]) {
+      grid_put_schar(grid, irow+adj[0], icol+adj[3], chars[4], attrs[4]);
+    }
     grid_puts_line_flush(false);
   }
 }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -725,8 +725,11 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
 
   bool has_border = wp->w_floating && wp->w_float_config.border;
   for (int i = 0; i < 4; i++) {
-    wp->w_border_adj[i] =
-      has_border && wp->w_float_config.border_chars[2 * i+1][0];
+    int new_adj = has_border && wp->w_float_config.border_chars[2 * i + 1][0];
+    if (new_adj != wp->w_border_adj[i]) {
+      change_border = true;
+      wp->w_border_adj[i] = new_adj;
+    }
   }
 
   if (!ui_has(kUIMultigrid)) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1194,6 +1194,50 @@ describe('float window', function()
         ]]}
       end
 
+      meths.win_set_config(win, {border={"", "_", "", "", "", "-", "", ""}})
+      if multigrid then
+        command('redraw!') -- TODO: without a redraw this test fails, which should be fixed
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 5
+          {5:_________}|
+          {1: halloj! }|
+          {1: BORDAA  }|
+          {5:---------}|
+        ]], float_pos={
+          [5] = { { id = 1002 }, "NW", 1, 2, 5, true }
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1};
+          [5] = {win = {id = 1002}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2};
+        }}
+      else
+        screen:expect{grid=[[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }{5:_________}{0:                          }|
+          {0:~    }{1: halloj! }{0:                          }|
+          {0:~    }{1: BORDAA  }{0:                          }|
+          {0:~    }{5:---------}{0:                          }|
+                                                  |
+        ]]}
+      end
+
       insert [[
         neeed some dummy
         background text

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1196,7 +1196,6 @@ describe('float window', function()
 
       meths.win_set_config(win, {border={"", "_", "", "", "", "-", "", ""}})
       if multigrid then
-        command('redraw!') -- TODO: without a redraw this test fails, which should be fixed
         screen:expect{grid=[[
         ## grid 1
           [2:----------------------------------------]|


### PR DESCRIPTION
A conditional seems to be missing in `win_redr_border`, and it can cause heap corruption when running the following Ex command (`bufnr` is the number of a buffer): 
```
:call nvim_open_win(bufnr, v:true, { 'relative': 'win', 'width': 8, 'height': 3, 'row': 0, 'col': 0, 'border': ['', '-', '', '', '', '-', '', ''] })
```

Using `valgrind`:
```
valgrind --log-file=nvim.log ./build/bin/nvim --clean --cmd 'vnew' --cmd "call nvim_open_win(2, v:true, { 'relative': 'win', 'width': 8, 'height': 3, 'row': 0, 'col': 0, 'border': ['', '-', '', '', '', '-', '', ''] })"
```

Errors shown in `nvim.log`:
```
==163309== Memcheck, a memory error detector
==163309== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==163309== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==163309== Command: ./build/bin/nvim --clean --cmd vnew --cmd call\ nvim_open_win(2,\ v:true,\ {\ 'relative':\ 'win',\ 'width':\ 8,\ 'height':\ 3,\ 'row':\ 0,\ 'col':\ 0,\ 'border':\ ['',\ '-',\ '',\ '',\ '',\ '-',\ '',\ '']\ })
==163309== Parent PID: 163148
==163309== 
==163309== Invalid read of size 4
==163309==    at 0x3F88E1: grid_put_schar (screen.c:5803)
==163309==    by 0x3F8329: win_redr_border (screen.c:5658)
==163309==    by 0x3E979F: update_screen (screen.c:599)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309==  Address 0x511d5b0 is 0 bytes after a block of size 160 alloc'd
==163309==    at 0x483E7C5: malloc (vg_replace_malloc.c:380)
==163309==    by 0x34858A: try_malloc (memory.c:74)
==163309==    by 0x3485FD: xmalloc (memory.c:108)
==163309==    by 0x3FA6F6: grid_alloc (screen.c:6575)
==163309==    by 0x3FA244: win_grid_alloc (screen.c:6417)
==163309==    by 0x3E976C: update_screen (screen.c:596)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309== 
==163309== Invalid write of size 1
==163309==    at 0x348C14: xstrlcpy (memory.c:377)
==163309==    by 0x3F8483: schar_copy (screen.c:5704)
==163309==    by 0x3F8949: grid_put_schar (screen.c:5804)
==163309==    by 0x3F8329: win_redr_border (screen.c:5658)
==163309==    by 0x3E979F: update_screen (screen.c:599)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309==  Address 0x511d4c8 is 0 bytes after a block of size 1,160 alloc'd
==163309==    at 0x483E7C5: malloc (vg_replace_malloc.c:380)
==163309==    by 0x34858A: try_malloc (memory.c:74)
==163309==    by 0x3485FD: xmalloc (memory.c:108)
==163309==    by 0x3FA6DC: grid_alloc (screen.c:6574)
==163309==    by 0x3FA244: win_grid_alloc (screen.c:6417)
==163309==    by 0x3E976C: update_screen (screen.c:596)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309== 
==163309== Invalid write of size 4
==163309==    at 0x3F895F: grid_put_schar (screen.c:5805)
==163309==    by 0x3F8329: win_redr_border (screen.c:5658)
==163309==    by 0x3E979F: update_screen (screen.c:599)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309==  Address 0x511d5b0 is 0 bytes after a block of size 160 alloc'd
==163309==    at 0x483E7C5: malloc (vg_replace_malloc.c:380)
==163309==    by 0x34858A: try_malloc (memory.c:74)
==163309==    by 0x3485FD: xmalloc (memory.c:108)
==163309==    by 0x3FA6F6: grid_alloc (screen.c:6575)
==163309==    by 0x3FA244: win_grid_alloc (screen.c:6417)
==163309==    by 0x3E976C: update_screen (screen.c:596)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309== 
==163309== Invalid read of size 1
==163309==    at 0x4844E90: strncmp (vg_replace_strmem.c:663)
==163309==    by 0x3F8459: schar_cmp (screen.c:5698)
==163309==    by 0x3F8916: grid_put_schar (screen.c:5803)
==163309==    by 0x3F8329: win_redr_border (screen.c:5658)
==163309==    by 0x3E979F: update_screen (screen.c:599)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309==  Address 0x511d4c8 is 0 bytes after a block of size 1,160 alloc'd
==163309==    at 0x483E7C5: malloc (vg_replace_malloc.c:380)
==163309==    by 0x34858A: try_malloc (memory.c:74)
==163309==    by 0x3485FD: xmalloc (memory.c:108)
==163309==    by 0x3FA6DC: grid_alloc (screen.c:6574)
==163309==    by 0x3FA244: win_grid_alloc (screen.c:6417)
==163309==    by 0x3E976C: update_screen (screen.c:596)
==163309==    by 0x366C8F: normal_redraw (normal.c:1308)
==163309==    by 0x366ED9: normal_check (normal.c:1398)
==163309==    by 0x448D64: state_enter (state.c:27)
==163309==    by 0x3649EF: normal_enter (normal.c:469)
==163309==    by 0x31D028: main (main.c:547)
==163309== 
==163309== 
==163309== HEAP SUMMARY:
==163309==     in use at exit: 759,010 bytes in 970 blocks
==163309==   total heap usage: 12,735 allocs, 11,765 frees, 3,807,494 bytes allocated
==163309== 
==163309== LEAK SUMMARY:
==163309==    definitely lost: 0 bytes in 0 blocks
==163309==    indirectly lost: 0 bytes in 0 blocks
==163309==      possibly lost: 207 bytes in 9 blocks
==163309==    still reachable: 758,803 bytes in 961 blocks
==163309==         suppressed: 0 bytes in 0 blocks
==163309== Rerun with --leak-check=full to see details of leaked memory
==163309== 
==163309== For lists of detected and suppressed errors, rerun with: -s
==163309== ERROR SUMMARY: 5 errors from 4 contexts (suppressed: 0 from 0)
```

I'm fixing it in this PR by adding the seemingly missing condition. This fix is really trivial. Do I need to add a test?