### PR TITLE
fix(clang/'Logic error'): avoid null pointer dereference

### DIFF
--- a/src/mpack/lmpack.c
+++ b/src/mpack/lmpack.c
@@ -320,6 +320,7 @@ static void lmpack_parse_enter(mpack_parser_t *parser, mpack_node_t *node)
       lua_pushnumber(L, mpack_unpack_number(node->tok)); break;
     case MPACK_TOKEN_CHUNK:
       assert(unpacker->string_buffer);
+      assert(((node)-1)->pos != (size_t)-1);
       memcpy(unpacker->string_buffer + MPACK_PARENT_NODE(node)->pos,
           node->tok.data.chunk_ptr, node->tok.length);
       break;


### PR DESCRIPTION
Added an assert just before the potential null dereference, but not sure if this is the idiomatic way to solve this problem.