### PR TITLE
test(vim_spec): fix MSVC_32 skip for nvim_parse_expression test

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1690,7 +1690,7 @@ describe('API', function()
     end)
 
     local it_maybe_pending = it
-    if (helpers.isCI('appveyor') and os.getenv('CONFIGURATION') == 'MSVC_32') then
+    if helpers.isCI() and os.getenv('CONFIGURATION') == 'MSVC_32' then
       -- For "works with &opt" (flaky on MSVC_32), but not easy to skip alone.  #10241
       it_maybe_pending = pending
     end


### PR DESCRIPTION
"works with &opt" is flaky; now it always fails after #15999 for some reason.

This test was skipped in #10773 due to previous flakiness, but after the switch away from appveyor
the check no longer works. Just skip for any CI running the MSVC_32 job.