### PR TITLE
<fix>([arduino.vim]): add INPUT_PULLUP to arduinoconstant line

### DIFF
--- a/runtime/syntax/arduino.vim
+++ b/runtime/syntax/arduino.vim
@@ -18,31 +18,31 @@ endif
 " Read the C syntax to start with
 runtime! syntax/cpp.vim
 
-syn keyword arduinoConstant HIGH LOW INPUT OUTPUT
+syn keyword arduinoConstant HIGH LOW INPUT INPUT_PULLUP OUTPUT
 syn keyword arduinoConstant DEC BIN HEX OCT BYTE
 syn keyword arduinoConstant PI HALF_PI TWO_PI
-syn keyword arduinoConstant LSBFIRST MSBFIRST 
-syn keyword arduinoConstant CHANGE FALLING RISING 
+syn keyword arduinoConstant LSBFIRST MSBFIRST
+syn keyword arduinoConstant CHANGE FALLING RISING
 syn keyword arduinoConstant SERIAL DISPLAY
 syn keyword arduinoConstant DEFAULT EXTERNAL INTERNAL INTERNAL1V1 INTERNAL2V56
 
 syn keyword arduinoStdFunc abs acos asin atan atan2 ceil constrain
 syn keyword arduinoStdFunc cos degrees exp floor log
-syn keyword arduinoStdFunc map max min pow radians 
+syn keyword arduinoStdFunc map max min pow radians
 syn keyword arduinoStdFunc round sin sq sqrt tan
 syn keyword arduinoStdFunc randomSeed random
 
-syn keyword arduinoFunc analogReference analogRead analogWrite 
-syn keyword arduinoFunc attachInterrupt detachInterrupt interrupts noInterrupts 
+syn keyword arduinoFunc analogReference analogRead analogWrite
+syn keyword arduinoFunc attachInterrupt detachInterrupt interrupts noInterrupts
 syn keyword arduinoFunc lowByte highByte bitRead bitWrite bitSet bitClear
-syn keyword arduinoFunc millis micros delay delayMicroseconds 
-syn keyword arduinoFunc pinMode digitalWrite digitalRead 
-syn keyword arduinoFunc tone noTone pulseIn shiftOut 
+syn keyword arduinoFunc millis micros delay delayMicroseconds
+syn keyword arduinoFunc pinMode digitalWrite digitalRead
+syn keyword arduinoFunc tone noTone pulseIn shiftOut
 
 syn keyword arduinoMethod setup loop
 syn keyword arduinoMethod begin end available read flush print println write peek
 
-syn keyword arduinoType boolean byte word String 
+syn keyword arduinoType boolean byte word String
 
 syn keyword arduinoModule Serial Serial1 Serial2 Serial3
 


### PR DESCRIPTION
INPUT_PULLUP is an Arduino keyword constant and was not being syntax highlighted with it's use.

Adding INPUT_PULLUP to syn keyword constant line will syntax highlight when used in Arduino sketches.
I only changed the one line, the additional diffs are from my neovim automatically erasing end of line whitespace.