### PR TITLE
fix(vim.mpack): rename pack/unpack => encode/decode

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -698,15 +698,14 @@ vim.diff({a}, {b}, {opts})                                        *vim.diff()*
 ------------------------------------------------------------------------------
 VIM.MPACK                                                          *lua-mpack*
 
-The *vim.mpack* module provides packing and unpacking of lua objects to
-msgpack encoded strings. |vim.NIL| and |vim.empty_dict()| are supported.
+The *vim.mpack* module provides encoding and decoding of Lua objects to and
+from msgpack-encoded strings. Supports |vim.NIL| and |vim.empty_dict()|.
 
-vim.mpack.pack({obj})                                   *vim.mpack.pack*
-        Packs a lua object {obj} and returns the msgpack representation as
-        a string
+vim.mpack.encode({obj})                                 *vim.mpack.encode*
+        Encodes (or "packs") Lua object {obj} as msgpack in a Lua string.
 
-vim.mpack.unpack({str})                                 *vim.mpack.unpack*
-        Unpacks the msgpack encoded {str} and returns a lua object
+vim.mpack.decode({str})                                 *vim.mpack.decode*
+        Decodes (or "unpacks") the msgpack-encoded {str} to a Lua object.
 
 ------------------------------------------------------------------------------
 VIM                                                     *lua-builtin*

--- a/src/mpack/lmpack.c
+++ b/src/mpack/lmpack.c
@@ -34,7 +34,9 @@
 #include "rpc.h"
 
 #define UNPACKER_META_NAME "mpack.Unpacker"
+#define UNPACK_FN_NAME "decode"
 #define PACKER_META_NAME "mpack.Packer"
+#define PACK_FN_NAME "encode"
 #define SESSION_META_NAME "mpack.Session"
 #define NIL_NAME "mpack.NIL"
 #define EMPTY_DICT_NAME "mpack.empty_dict"
@@ -432,8 +434,8 @@ static int lmpack_unpacker_unpack_str(lua_State *L, Unpacker *unpacker,
 
   if (unpacker->unpacking) {
     return luaL_error(L, "Unpacker instance already working. Use another "
-                         "Unpacker or the module's \"unpack\" function if you "
-                         "need to unpack from the ext handler");
+                         "Unpacker or mpack." UNPACK_FN_NAME "() if you "
+                         "need to " UNPACK_FN_NAME " from the ext handler");
   }
   
   do {
@@ -784,8 +786,8 @@ static int lmpack_packer_pack(lua_State *L)
 
   if (packer->packing) {
     return luaL_error(L, "Packer instance already working. Use another Packer "
-                         "or the module's \"pack\" function if you need to "
-                         "pack from the ext handler");
+                         "or mpack." PACK_FN_NAME "() if you need to "
+                         PACK_FN_NAME " from the ext handler");
   }
 
   do {
@@ -1161,8 +1163,8 @@ static const luaL_reg mpack_functions[] = {
   {"Unpacker", lmpack_unpacker_new},
   {"Packer", lmpack_packer_new},
   {"Session", lmpack_session_new},
-  {"unpack", lmpack_unpack},
-  {"pack", lmpack_pack},
+  {UNPACK_FN_NAME, lmpack_unpack},
+  {PACK_FN_NAME, lmpack_pack},
   {NULL, NULL}
 };
 

--- a/test/functional/lua/mpack_spec.lua
+++ b/test/functional/lua/mpack_spec.lua
@@ -7,16 +7,16 @@ local exec_lua = helpers.exec_lua
 
 describe('lua vim.mpack', function()
   before_each(clear)
-  it('can pack vim.NIL', function()
+  it('encodes vim.NIL', function()
     eq({true, true, true, true}, exec_lua [[
-      local var = vim.mpack.unpack(vim.mpack.pack({33, vim.NIL, 77}))
+      local var = vim.mpack.decode(vim.mpack.encode({33, vim.NIL, 77}))
       return {var[1]==33, var[2]==vim.NIL, var[3]==77, var[4]==nil}
     ]])
   end)
 
-  it('can pack vim.empty_dict()', function()
+  it('encodes vim.empty_dict()', function()
     eq({{{}, "foo", {}}, true, false}, exec_lua [[
-      local var = vim.mpack.unpack(vim.mpack.pack({{}, "foo", vim.empty_dict()}))
+      local var = vim.mpack.decode(vim.mpack.encode({{}, "foo", vim.empty_dict()}))
       return {var, vim.tbl_islist(var[1]), vim.tbl_islist(var[3])}
     ]])
   end)


### PR DESCRIPTION
Problem:
1. "unpack" has an unrelated meaning in Lua.
    - https://www.lua.org/manual/5.1/manual.html#pdf-unpack
2. We already have msgpackparse()/msgpackdump() and
   json_encode/json_decode, so introducing another name for the same
   thing is entropy.

Solution:
Rename vim.mpack.pack/unpack => vim.mpack.encode/decode