### PR TITLE
feat(lsp): default to botright for location handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -185,7 +185,7 @@ local function response_to_list(map_result, entity)
           title = 'Language Server';
           items = map_result(result, ctx.bufnr);
         })
-        api.nvim_command("copen")
+        api.nvim_command("botright copen")
       end
     end
   end


### PR DESCRIPTION
Closes #12241

I think this is the correct behavior, and we should not make this configurable. If a user wants this to be configurable, they can override the location handler.