### PR TITLE
fix(build): remove amalg build target for LuaJIT

### DIFF
--- a/third-party/cmake/BuildLuajit.cmake
+++ b/third-party/cmake/BuildLuajit.cmake
@@ -58,7 +58,7 @@ set(INSTALLCMD_UNIX ${MAKE_PRG} CFLAGS=-fPIC
                                 ${AMD64_ABI}
                                 CCDEBUG+=-g
                                 Q=
-                                amalg install)
+                                install)
 
 if(UNIX)
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
fixup for #16041 (`amalg` build is recommended by LuaJIT for performance
but this way of doing it breaks parallel build with `make -j`)

closes #16172 

(This change was part of the experimental PR and shouldn't have made it into the final commit; *mea culpa*!)