### PR TITLE
fix(vim-patch.sh): run nvim with -u NONE and -n

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -183,7 +183,7 @@ assign_commit_details() {
 # Patch surgery
 preprocess_patch() {
   local file="$1"
-  local nvim="nvim -u NORC -i NONE --headless"
+  local nvim="nvim -u NONE -n -i NONE --headless"
 
   # Remove Filelist, README
   local na_files='Filelist\|README.*'
@@ -683,7 +683,7 @@ review_commit() {
   msg_ok "Saved pull request diff to '${NVIM_SOURCE_DIR}/n${patch_file}'."
   CREATED_FILES+=("${NVIM_SOURCE_DIR}/n${patch_file}")
 
-  local nvim="nvim -u NORC -n -i NONE --headless"
+  local nvim="nvim -u NONE -n -i NONE --headless"
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'1,/^$/g/^ /-1join' +w +q "${NVIM_SOURCE_DIR}/n${patch_file}"
 
   local expected_commit_message


### PR DESCRIPTION
Because of `-u NORC`, `vim-patch.sh` would hang on my machine due to one of my plugins (start package)
waiting for prompt input.

Use `-u NONE` instead to disable all plugins. Also use `-n` to disable swapfiles.
These changes only apply to the `--headless` nvim instances used to process things.

It might be preferred to use `--clean` instead, but no built-in plugins are used here.