### PR TITLE
fix(build): fix build failure in MinGW

### DIFF
--- a/third-party/cmake/BuildLibuv.cmake
+++ b/third-party/cmake/BuildLibuv.cmake
@@ -5,7 +5,7 @@ function(BuildLibuv)
   cmake_parse_arguments(_libuv
     "BUILD_IN_SOURCE"
     "TARGET"
-    "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
+    "PATCH_COMMAND;CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND"
     ${ARGN})
 
   if(NOT _libuv_CONFIGURE_COMMAND AND NOT _libuv_BUILD_COMMAND
@@ -28,6 +28,7 @@ function(BuildLibuv)
       -DTARGET=${_libuv_TARGET}
       -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
+    PATCH_COMMAND "${_libuv_PATCH_COMMAND}"
     BUILD_IN_SOURCE ${_libuv_BUILD_IN_SOURCE}
     CONFIGURE_COMMAND "${_libuv_CONFIGURE_COMMAND}"
     BUILD_COMMAND "${_libuv_BUILD_COMMAND}"
@@ -62,6 +63,10 @@ elseif(WIN32)
     set(BUILD_SHARED ON)
   elseif(MINGW)
     set(BUILD_SHARED OFF)
+    set(LIBUV_PATCH_COMMAND
+      ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv init
+      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv apply --ignore-whitespace
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libuv-disable-typedef-MinGW.patch)
   else()
     message(FATAL_ERROR "Trying to build libuv in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
   endif()
@@ -75,6 +80,7 @@ elseif(WIN32)
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DBUILD_SHARED_LIBS=${BUILD_SHARED}
         -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
+    PATCH_COMMAND ${LIBUV_PATCH_COMMAND}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install --config ${CMAKE_BUILD_TYPE})
 

--- a/third-party/patches/libuv-disable-typedef-MinGW.patch
+++ b/third-party/patches/libuv-disable-typedef-MinGW.patch
@@ -1,0 +1,19 @@
+diff --git a/include/uv/win.h b/include/uv/win.h
+index f5f1d3a3..64a0dfd9 100644
+--- a/include/uv/win.h
++++ b/include/uv/win.h
+@@ -45,7 +45,14 @@ typedef struct pollfd {
+ #endif
+ 
+ #include <mswsock.h>
++// Disable the typedef in mstcpip.h of MinGW.
++#define _TCP_INITIAL_RTO_PARAMETERS _TCP_INITIAL_RTO_PARAMETERS__
++#define TCP_INITIAL_RTO_PARAMETERS TCP_INITIAL_RTO_PARAMETERS__
++#define PTCP_INITIAL_RTO_PARAMETERS PTCP_INITIAL_RTO_PARAMETERS__
+ #include <ws2tcpip.h>
++#undef _TCP_INITIAL_RTO_PARAMETERS
++#undef TCP_INITIAL_RTO_PARAMETERS
++#undef PTCP_INITIAL_RTO_PARAMETERS
+ #include <windows.h>
+ 
+ #include <process.h>


### PR DESCRIPTION
The new MinGW fails to build libuv due to a `typedef` conflict between `mstcpip.h` and `src/win/winapi.h`. This change avoids conflicts by disabling `typedef` in the MinGW header.