### PR TITLE
fix(lsp): add placeholder cancel function

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1317,7 +1317,7 @@ function lsp.buf_request(bufnr, method, params, handler)
   if not tbl_isempty(all_buffer_active_clients[resolve_bufnr(bufnr)] or {}) and not method_supported then
     vim.notify(lsp._unsupported_method(method), vim.log.levels.ERROR)
     vim.api.nvim_command("redraw")
-    return
+    return {}, function() end
   end
 
   local client_request_ids = {}


### PR DESCRIPTION
Fixes a bug exposed by* (mea culpa) by https://github.com/neovim/neovim/pull/15949

When no supported clients for a given method are available, buf_request
returns early with a nil value. If buf_request_sync is called on a
buffer with no clients that support a given method, the returned
`cancel` method (which is nil), is invoked, resulting in an error.

Solution: return an empty function handle