### PR TITLE
fix(ci): use correct check for path-existence

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -171,7 +171,7 @@ if (-not $NoTests) {
 }
 
 # Ensure choco's cpack is not in PATH otherwise, it conflicts with CMake's
-if (Get-Item -Path $env:ChocolateyInstall\bin\cpack.exe) {
+if (Test-Path -Path $env:ChocolateyInstall\bin\cpack.exe) {
   Remove-Item -Path $env:ChocolateyInstall\bin\cpack.exe -Force
 }
 


### PR DESCRIPTION
[Previous attempt](https://github.com/neovim/neovim/pull/16191) used `Get-Item` but that raises an exception when the path doesn't exist.