### PR TITLE
ci: limit CI checks to the main dev branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
   push:
-    branches: ['**']
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:


### PR DESCRIPTION
Now that we have various GH actions creating branches in the main repo, using the generic '**' pattern for the CI workflow is just wasting CI time and leading to more queued jobs.