### PR TITLE
ci(release): delete nightly/stable tag so release recreates it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
           (echo 'SUBJECT=Nvim development (prerelease) build';
            echo 'PRERELEASE=--prerelease') >> $GITHUB_ENV
           gh release delete nightly --yes || true
+          git push origin :nightly || true
       - if: env.TAG_NAME != 'nightly'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -183,6 +184,7 @@ jobs:
           (echo 'SUBJECT=Nvim release build';
            echo 'PRERELEASE=') >> $GITHUB_ENV
           gh release delete stable --yes || true
+          git push origin :stable || true
       # `sha256sum` outputs <sha> <path>, so we cd into each dir to drop the
       # containing folder from the output.
       - name: Generate Linux64 SHA256 checksums


### PR DESCRIPTION
Even though the releaes itself gets deleted, if the tag is not, then creating a new release just re-uses the same tag, even though we're using “--target <sha>”.

[skip ci]