### PR TITLE
fix(lsp): convert range to byteidx before highlighting

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -349,7 +349,7 @@ M['textDocument/signatureHelp'] = M.signature_help
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
 M['textDocument/documentHighlight'] = function(_, result, ctx, _)
   if not result then return end
-  util.buf_highlight_references(ctx.bufnr, result)
+  util.buf_highlight_references(ctx.bufnr, result, ctx.client_id)
 end
 
 ---@private

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -152,7 +152,6 @@ end
 --- Returns a zero-indexed column, since set_lines() does the conversion to
 --- 1-indexed
 local function get_line_byte_from_position(bufnr, position, offset_encoding)
-  -- TODO handle offset_encoding
   -- LSP's line and characters are 0-indexed
   -- Vim's line and columns are 1-indexed
   local col = position.character

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1500,15 +1500,23 @@ do --[[ References ]]
   function M.buf_highlight_references(bufnr, references)
     validate { bufnr = {bufnr, 'n', true} }
     for _, reference in ipairs(references) do
-      local start_pos = {reference["range"]["start"]["line"], reference["range"]["start"]["character"]}
-      local end_pos = {reference["range"]["end"]["line"], reference["range"]["end"]["character"]}
+      local start_line, start_char = reference["range"]["start"]["line"], reference["range"]["start"]["character"]
+      local end_line, end_char = reference["range"]["end"]["line"], reference["range"]["end"]["character"]
+
+      local start_idx = vim.str_byteindex(vim.api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)[1] or '', start_char)
+      local end_idx = vim.str_byteindex(vim.api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)[1] or '', end_char)
+
       local document_highlight_kind = {
         [protocol.DocumentHighlightKind.Text] = "LspReferenceText";
         [protocol.DocumentHighlightKind.Read] = "LspReferenceRead";
         [protocol.DocumentHighlightKind.Write] = "LspReferenceWrite";
       }
       local kind = reference["kind"] or protocol.DocumentHighlightKind.Text
-      highlight.range(bufnr, reference_ns, document_highlight_kind[kind], start_pos, end_pos)
+      highlight.range(bufnr,
+                      reference_ns,
+                      document_highlight_kind[kind],
+                      { start_line, start_idx },
+                      { end_line, end_idx })
     end
   end
 end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1518,7 +1518,9 @@ do --[[ References ]]
   function M.buf_highlight_references(bufnr, references, client_id)
     validate { bufnr = {bufnr, 'n', true} }
     local client = vim.lsp.get_client_by_id(client_id)
-
+    if not client then
+      return
+    end
     for _, reference in ipairs(references) do
       local start_line, start_char = reference["range"]["start"]["line"], reference["range"]["start"]["character"]
       local end_line, end_char = reference["range"]["end"]["line"], reference["range"]["end"]["character"]

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1484,7 +1484,6 @@ end
 local function convert_utf_to_byte(line, idx, offset_encoding)
   -- convert to 0 based indexing
   idx = idx - 1
-  P(offset_encoding)
 
   local byte_idx
   -- Convert utf-{8,16,32} range to byte index and convert 1-based (lua) indexing to 0-based


### PR DESCRIPTION
closes https://github.com/neovim/neovim/issues/15116

converts range into byte index before applying highlight for `document_highlight()`

Before:
![image](https://user-images.githubusercontent.com/51877647/139999443-cf5c354d-15a7-44fd-8a33-186eda0aaa57.png)

After: 
![image](https://user-images.githubusercontent.com/51877647/139999323-acffcbbb-f0de-4c2e-a88e-014450e476b2.png)
