### PR TITLE
fix(input): never reinterpret unmapped ALT- chords in Terminal mode

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1579,7 +1579,8 @@ int vgetc(void)
       // If mappings are enabled (i.e., not Ctrl-v) and the user directly typed
       // something with a meta- or alt- modifier that was not mapped, interpret
       // <M-x> as <Esc>x rather than as an unbound meta keypress. #8213
-      if (!no_mapping && KeyTyped
+      // In Terminal mode, however, this is not desirable. #16220
+      if (!no_mapping && KeyTyped && !(State & TERM_FOCUS)
           && (mod_mask == MOD_MASK_ALT || mod_mask == MOD_MASK_META)) {
         mod_mask = 0;
         ins_char_typebuf(c);


### PR DESCRIPTION
Fix #16220

In non-Terminal mode, unmapped ALT- chords are no-op, so reinterpreting them as `<Esc>` followed by a key is safe. In Terminal mode, however, unmapped ALT- chords can still have a meaning in the terminal process, so it is better to send the ALT- chord as-is, otherwise ALT- chords becomes unusable in terminal processes when one has mapping `:tnoremap <Esc> <C-\><C-N>`. The behavior of reinterpreting ALT- chords as `<Esc>` followed by a key itself is a hack to work around terminal key encoding ambiguities anyway.