### PR TITLE
feat(diagnostic): add default mappings for diagnostics

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -341,20 +341,6 @@ Example: >lua
     })
 <
 ==============================================================================
-MAPS                                                    *diagnostic-maps*
-
-                                                       *]d-default*
-]d                        Goto the next diagnostic in the buffer.
-                            |vim.diagnostic.goto_next()|
-                                                       *[d-default*
-[d                        Goto the previous diagnostic in the buffer.
-                            |vim.diagnostic.goto_prev()|
-
-CTRL-W CTRL-D                                          *CTRL-W_d-default*
-CTRL-W d                  Open a floating window for diagnostics under
-                          the cursor. |vim.diagnostic.open_float()|.
-
-==============================================================================
 Lua module: vim.diagnostic                                    *diagnostic-api*
 
 *vim.Diagnostic*

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -341,6 +341,20 @@ Example: >lua
     })
 <
 ==============================================================================
+MAPS                                                    *diagnostic-maps*
+
+                                                       *]d-default*
+]d                        Goto the next diagnostic in the buffer.
+                            |vim.diagnostic.goto_next()|
+                                                       *[d-default*
+[d                        Goto the previous diagnostic in the buffer.
+                            |vim.diagnostic.goto_prev()|
+
+CTRL-W CTRL-D                                          *CTRL-W_d-default*
+CTRL-W d                  Open a floating window for diagnostics under
+                          the cursor. |vim.diagnostic.open_float()|.
+
+==============================================================================
 Lua module: vim.diagnostic                                    *diagnostic-api*
 
 *vim.Diagnostic*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -412,6 +412,10 @@ The following changes to existing APIs or features add new behavior.
   • |crr| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|.
   • "gr" in Normal mode maps to |vim.lsp.buf.references()| |gr-default|
   • |i_CTRL-S| in Insert mode maps to |vim.lsp.buf.signature_help()|
+  • "]d" and "[d" in Normal mode map to |vim.diagnostic.goto_next()| and
+    |vim.diagnostic.goto_prev()|, respectively. |]d-default| |[d-default|
+  • <C-W>d (and <C-W><C-D>) map to |vim.diagnostic.open_float()|
+    |CTRL-W_d-default|
   • Automatic linting of treesitter query files (see |ft-query-plugin|).
     Can be disabled via: >lua
       vim.g.query_lint_on = {}

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -780,8 +780,16 @@ CTRL-W i		Open a new window, with the cursor on the first line
 			beginning of the file.  If a count is given, the
 			count'th matching line is displayed.
 
+							*[d-default*
+			Mapped to |vim.diagnostic.goto_prev()| by default.
+			|default-mappings|
+
 							*]d*
 ]d			like "[d", but start at the current cursor position.
+
+							*]d-default*
+			Mapped to |vim.diagnostic.goto_next()| by default.
+			|default-mappings|
 
 							*:ds* *:dsearch*
 :[range]ds[earch][!] [count] [/]string[/]
@@ -828,6 +836,10 @@ CTRL-W d		Open a new window, with the cursor on the first
 			under the cursor.  The search starts from the
 			beginning of the file.  If a count is given, the
 			count'th matching line is jumped to.
+
+						*CTRL-W_d-default*
+			Mapped to |vim.diagnostic.open_float()| by default.
+			|default-mappings|
 
 							*:dsp* *:dsplit*
 :[range]dsp[lit][!] [count] [/]string[/]

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -141,6 +141,9 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - |crr|
 - gr |gr-default|
 - <C-S> |i_CTRL-S|
+- ]d |]d-default|
+- [d |[d-default|
+- <C-W>d |CTRL-W_d-default|
 - Nvim LSP client defaults |lsp-defaults|
   - K |K-lsp-default|
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -127,7 +127,9 @@ do
     end, { desc = gx_desc })
   end
 
-  --- Default maps for built-in commenting
+  --- Default maps for built-in commenting.
+  ---
+  --- See |gc-default| and |gcc-default|.
   do
     local operator_rhs = function()
       return require('vim._comment').operator()
@@ -168,6 +170,35 @@ do
     vim.keymap.set('i', '<C-S>', function()
       vim.lsp.buf.signature_help()
     end, { desc = 'vim.lsp.buf.signature_help()' })
+  end
+
+  --- Map [d and ]d to move to the previous/next diagnostic. Map <C-W>d to open a floating window
+  --- for the diagnostic under the cursor.
+  ---
+  --- See |[d-default|, |]d-default|, and |CTRL-W_d-default|.
+  do
+    vim.keymap.set('n', ']d', function()
+      vim.diagnostic.goto_next({ float = false })
+    end, {
+      desc = 'Jump to the next diagnostic with the highest severity',
+    })
+
+    vim.keymap.set('n', '[d', function()
+      vim.diagnostic.goto_prev({ float = false })
+    end, {
+      desc = 'Jump to the previous diagnostic with the highest severity',
+    })
+
+    vim.keymap.set('n', '<C-W>d', function()
+      vim.diagnostic.open_float({ border = 'rounded' })
+    end, {
+      desc = 'Open a floating window showing diagnostics under the cursor',
+    })
+
+    vim.keymap.set('n', '<C-W><C-D>', '<C-W>d', {
+      remap = true,
+      desc = 'Open a floating window showing diagnostics under the cursor',
+    })
   end
 end
 


### PR DESCRIPTION
Add mappings for `goto_next` and `goto_prev`.

By default, disables the floating window. Considering `virtual_text` is enabled by default, having the float feels very noisy to me. Happy to be convinced otherwise. I'd also be happy to disable `virtual_text` by default and enable float popups for these maps.
