### PR TITLE
fix(diagnostic): handle an unknown or missing client

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -147,7 +147,7 @@ function M.get_namespace(client_id)
   vim.validate { client_id = { client_id, 'n' } }
   if not _client_namespaces[client_id] then
     local client = vim.lsp.get_client_by_id(client_id)
-    local name = string.format("vim.lsp.%s.%d", client.name, client_id)
+    local name = string.format("vim.lsp.%s.%d", client and client.name or "unknown", client_id)
     _client_namespaces[client_id] = vim.api.nvim_create_namespace(name)
   end
   return _client_namespaces[client_id]


### PR DESCRIPTION
Sometimes plugins use pseudo-client IDs (e.g. nvim-lint or null-ls) in order to hook into the LSP infrastructure without being a bona fide LSP client. In these cases, `get_client_by_id()` will return nil since the client ID given does not correspond to a real client recognized by the LSP subsystem. When this happens, use "unknown" for the client name.

Closes #16240.
