### PR TITLE
docs: update description for 'list' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3705,8 +3705,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'list'* *'nolist'*
 'list'			boolean	(default off)
 			local to window
-	List mode: By default, show tabs as '>', trailing spaces as '-' and
-	non-breakable space characters as '+'. Useful to see the difference
+	List mode: By default, show tabs as ">", trailing spaces as "-" and
+	non-breakable space characters as "+". Useful to see the difference
 	between tabs and spaces and for trailing blanks. Further changed by
 	the 'listchars' option.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3705,7 +3705,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'list'* *'nolist'*
 'list'			boolean	(default off)
 			local to window
-	List mode: By default, show tabs as ">", trailing spaces as "-" and
+	List mode: By default, show tabs as ">", trailing spaces as "-", and
 	non-breakable space characters as "+". Useful to see the difference
 	between tabs and spaces and for trailing blanks. Further changed by
 	the 'listchars' option.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3705,10 +3705,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'list'* *'nolist'*
 'list'			boolean	(default off)
 			local to window
-	List mode: By default show tabs as CTRL-I is displayed, display $
-	after end of line.  Useful to see the difference between tabs and
-	spaces and for trailing blanks.  Further changed by the 'listchars'
-	option.
+	List mode: By default, show tabs as '>', trailing spaces as '-' and
+	non-breakable space characters as '+'. Useful to see the difference
+	between tabs and spaces and for trailing blanks. Further changed by
+	the 'listchars' option.
 
 	The cursor is displayed at the start of the space a Tab character
 	occupies, not at the end as usual in Normal mode.  To get this cursor

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -116,9 +116,9 @@ g8			Print the hex values of the bytes used in the
 
 							*:l* *:list*
 :[range]l[ist] [count] [flags]
-			Same as :print, but display unprintable characters
-			with '^' and put $ after the line.  This can be
-			further changed with the 'listchars' option.
+			Same as :print, but show tabs as '>', trailing spaces
+			as '-' and non-breakable space characters as '+' by
+			default.  Further changed by the 'listchars' option.
 			See |ex-flags| for [flags].
 
 							*:nu* *:number*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -117,7 +117,7 @@ g8			Print the hex values of the bytes used in the
 							*:l* *:list*
 :[range]l[ist] [count] [flags]
 			Same as :print, but show tabs as ">", trailing spaces
-			as "-" and non-breakable space characters as "+" by
+			as "-", and non-breakable space characters as "+" by
 			default.  Further changed by the 'listchars' option.
 			See |ex-flags| for [flags].
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -116,8 +116,8 @@ g8			Print the hex values of the bytes used in the
 
 							*:l* *:list*
 :[range]l[ist] [count] [flags]
-			Same as :print, but show tabs as '>', trailing spaces
-			as '-' and non-breakable space characters as '+' by
+			Same as :print, but show tabs as ">", trailing spaces
+			as "-" and non-breakable space characters as "+" by
 			default.  Further changed by the 'listchars' option.
 			See |ex-flags| for [flags].
 


### PR DESCRIPTION
Neovim has different defaults for 'list' compared to Vim which is why
the documentation needs to be updated.

Closes #12291