### PR TITLE
feat(diagnostic): do not require namespace for hide() and show()

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -536,7 +536,9 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
                 |vim.diagnostic.disable()|.
 
                 Parameters: ~
-                    {namespace}  number The diagnostic namespace
+                    {namespace}  number|nil Diagnostic namespace. When
+                                 omitted, hide diagnostics from all
+                                 namespaces.
                     {bufnr}      number|nil Buffer number. Defaults to the
                                  current buffer.
 
@@ -626,7 +628,9 @@ reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
                 |vim.diagnostic.hide()|.
 
                 Parameters: ~
-                    {namespace}  number
+                    {namespace}  number|nil Diagnostic namespace. When
+                                 omitted, remove diagnostics from all
+                                 namespaces.
                     {bufnr}      number|nil Remove diagnostics for the given
                                  buffer. When omitted, diagnostics are removed
                                  for all buffers.
@@ -677,7 +681,9 @@ show({namespace}, {bufnr}, {diagnostics}, {opts})
                 Display diagnostics for the given namespace and buffer.
 
                 Parameters: ~
-                    {namespace}    number Diagnostic namespace.
+                    {namespace}    number|nil Diagnostic namespace. When
+                                   omitted, show diagnostics from all
+                                   namespaces.
                     {bufnr}        number|nil Buffer number. Defaults to the
                                    current buffer.
                     {diagnostics}  table|nil The diagnostics to display. When
@@ -685,7 +691,8 @@ show({namespace}, {bufnr}, {diagnostics}, {opts})
                                    given namespace and buffer. This can be
                                    used to display a list of diagnostics
                                    without saving them or to display only a
-                                   subset of diagnostics.
+                                   subset of diagnostics. May not be used when
+                                   {namespace} is nil.
                     {opts}         table|nil Display options. See
                                    |vim.diagnostic.config()|.
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -268,6 +268,56 @@ describe('vim.diagnostic', function()
     ]])
   end)
 
+  describe('show() and hide()', function()
+    it('works', function()
+      local result = exec_lua [[
+        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+
+        local result = {}
+
+        vim.diagnostic.config({ underline = false, virtual_text = true })
+
+        local ns_1_diags = {
+          make_error("Error 1", 1, 1, 1, 5),
+          make_warning("Warning on Server 1", 2, 1, 2, 5),
+        }
+        local ns_2_diags = {
+          make_warning("Warning 1", 2, 1, 2, 5),
+        }
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
+
+        -- Both
+        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) + count_extmarks(diagnostic_bufnr, other_ns))
+
+        -- Hide one namespace
+        vim.diagnostic.hide(diagnostic_ns)
+        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns))
+
+        -- Show one namespace
+        vim.diagnostic.show(diagnostic_ns)
+        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns))
+
+        -- Hide all namespaces
+        vim.diagnostic.hide()
+        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) + count_extmarks(diagnostic_bufnr, other_ns))
+
+        -- Show all namespaces
+        vim.diagnostic.show()
+        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) + count_extmarks(diagnostic_bufnr, other_ns))
+
+        return result
+      ]]
+
+      eq(3, result[1])
+      eq(0, result[2])
+      eq(2, result[3])
+      eq(0, result[4])
+      eq(3, result[5])
+    end)
+  end)
+
   describe('reset()', function()
     it('diagnostic count is 0 and displayed diagnostics are 0 after call', function()
       -- 1 Error (1)


### PR DESCRIPTION
While doing this refactor I also fixed a few other small bugs regarding saving and restoring extmarks. In particular, now that the virtual text and underline handlers have their own dedicated namespaces, they should be responsible for saving and restoring their own extmarks. Also fix the wrong argument ordering in the call to `clear_diagnostic_cache` in the `on_detach` callback.