### PR TITLE
fix(lsp): ensure buffers are re-attached on rename

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -466,7 +466,11 @@ local function text_document_did_open_handler(bufnr, client)
 
   -- Next chance we get, we should re-do the diagnostics
   vim.schedule(function()
-    vim.lsp.diagnostic.redraw(bufnr, client.id)
+    -- Protect against a race where the buffer disappears
+    -- between `did_open_handler` and the scheduled function firing.
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.lsp.diagnostic.redraw(bufnr, client.id)
+    end
   end)
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -720,18 +720,29 @@ end
 --         ignoreIfExists? bool
 function M.rename(old_fname, new_fname, opts)
   opts = opts or {}
-  local bufnr = vim.fn.bufadd(old_fname)
-  vim.fn.bufload(bufnr)
   local target_exists = vim.loop.fs_stat(new_fname) ~= nil
   if target_exists and not opts.overwrite or opts.ignoreIfExists then
     vim.notify('Rename target already exists. Skipping rename.')
     return
   end
+  local oldbuf = vim.fn.bufadd(old_fname)
+  vim.fn.bufload(oldbuf)
+
+  -- The there may be pending changes in the buffer
+  api.nvim_buf_call(oldbuf, function()
+    vim.cmd('w!')
+  end)
+
   local ok, err = os.rename(old_fname, new_fname)
   assert(ok, err)
-  api.nvim_buf_call(bufnr, function()
-    vim.cmd('saveas! ' .. vim.fn.fnameescape(new_fname))
-  end)
+
+  local newbuf = vim.fn.bufadd(new_fname)
+  for _, win in pairs(api.nvim_list_wins()) do
+    if api.nvim_win_get_buf(win) == oldbuf then
+      api.nvim_win_set_buf(win, newbuf)
+    end
+  end
+  api.nvim_buf_delete(oldbuf, { force = true })
 end
 
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1735,6 +1735,7 @@ describe('LSP', function()
 
         -- after rename the target file must have the contents of the source file
         local bufnr = vim.fn.bufadd(new)
+        vim.fn.bufload(new)
         return vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
       ]], old, new)
       eq({'Test content'}, lines)


### PR DESCRIPTION
If a LSP server sent a workspace edit containing a rename the buffers
file name changed without the server receiving a close notification for
the old buffer and without the client properly re-attaching on the new
file.

This affected `Move` code-actions in nvim-jdtls, but also
`vim.lsp.buf.rename` on a class level.


I think there is still an issue in that the server doesn't receive the message that the old file is gone. I think for that we either need https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workspace_didRenameFiles or https://github.com/neovim/neovim/pull/16214

https://user-images.githubusercontent.com/38700/140830418-71e5178f-cb8f-463d-879c-146e0809169a.mp4


