### PR TITLE
vim-patch:8.1.1378: delete() can not handle a file name that looks like a pattern

### DIFF
--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -3,6 +3,8 @@
 
 #include "nvim/autocmd.h"
 #include "nvim/buffer_defs.h"
+#include "nvim/eval/typval.h"
+#include "nvim/garray.h"
 #include "nvim/os/os.h"
 
 // Values for readfile() flags
@@ -16,6 +18,8 @@
 #define READ_NOWINENTER 0x80    // do not trigger BufWinEnter
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
+
+typedef varnumber_T (*CheckItem)(void *expr, const char *name);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 // Events for autocommands

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1620,10 +1620,6 @@ func Test_platform_name()
 endfunc
 
 func Test_readdir()
-  if isdirectory('Xdir')
-    call delete('Xdir', 'rf')
-  endif
-
   call mkdir('Xdir')
   call writefile([], 'Xdir/foo.txt')
   call writefile([], 'Xdir/bar.txt')
@@ -1651,6 +1647,21 @@ func Test_readdir()
   call assert_equal(1, len(files))
 
   call delete('Xdir', 'rf')
+endfunc
+
+func Test_delete_rf()
+  call mkdir('Xdir')
+  call writefile([], 'Xdir/foo.txt')
+  call writefile([], 'Xdir/bar.txt')
+  call mkdir('Xdir/[a-1]')  " issue #696
+  call writefile([], 'Xdir/[a-1]/foo.txt')
+  call writefile([], 'Xdir/[a-1]/bar.txt')
+  call assert_true(filereadable('Xdir/foo.txt'))
+  call assert_true('Xdir/[a-1]/foo.txt'->filereadable())
+
+  call assert_equal(0, delete('Xdir', 'rf'))
+  call assert_false(filereadable('Xdir/foo.txt'))
+  call assert_false(filereadable('Xdir/[a-1]/foo.txt'))
 endfunc
 
 func Test_call()

--- a/test/functional/legacy/delete_spec.lua
+++ b/test/functional/legacy/delete_spec.lua
@@ -1,11 +1,29 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local eq, eval, command = helpers.eq, helpers.eval, helpers.command
+local exc_exec = helpers.exc_exec
 
 describe('Test for delete()', function()
   before_each(clear)
   after_each(function()
     os.remove('Xfile')
+  end)
+
+  it('file delete', function()
+    command('split Xfile')
+    command("call setline(1, ['a', 'b'])")
+    command('wq')
+    eq(eval("['a', 'b']"), eval("readfile('Xfile')"))
+    eq(0, eval("delete('Xfile')"))
+    eq(-1, eval("delete('Xfile')"))
+  end)
+
+  it('directory delete', function()
+    command("call mkdir('Xdir1')")
+    eq(1, eval("isdirectory('Xdir1')"))
+    eq(0, eval("delete('Xdir1', 'd')"))
+    eq(0, eval("isdirectory('Xdir1')"))
+    eq(-1, eval("delete('Xdir1', 'd')"))
   end)
 
   it('symlink delete', function()
@@ -43,39 +61,8 @@ describe('Test for delete()', function()
     eq(0, eval("delete('Xdir1', 'd')"))
   end)
 
-  it('symlink recursive delete', function()
-    source([[
-      call mkdir('Xdir3')
-      call mkdir('Xdir3/subdir')
-      call mkdir('Xdir4')
-      split Xdir3/Xfile
-      call setline(1, ['a', 'b'])
-      w
-      w Xdir3/subdir/Xfile
-      w Xdir4/Xfile
-      close
-      if has('win32')
-        silent !mklink /j Xdir3\Xlink Xdir4
-      else
-        silent !ln -s ../Xdir4 Xdir3/Xlink
-      endif
-    ]])
-
-    eq(1, eval("isdirectory('Xdir3')"))
-    eq(eval("['a', 'b']"), eval("readfile('Xdir3/Xfile')"))
-    eq(1, eval("isdirectory('Xdir3/subdir')"))
-    eq(eval("['a', 'b']"), eval("readfile('Xdir3/subdir/Xfile')"))
-    eq(1, eval("isdirectory('Xdir4')"))
-    eq(1, eval("isdirectory('Xdir3/Xlink')"))
-    eq(eval("['a', 'b']"), eval("readfile('Xdir4/Xfile')"))
-
-    eq(0, eval("delete('Xdir3', 'rf')"))
-    eq(0, eval("isdirectory('Xdir3')"))
-    eq(-1, eval("delete('Xdir3', 'd')"))
-    -- symlink is deleted, not the directory it points to
-    eq(1, eval("isdirectory('Xdir4')"))
-    eq(eval("['a', 'b']"), eval("readfile('Xdir4/Xfile')"))
-    eq(0, eval("delete('Xdir4/Xfile')"))
-    eq(0, eval("delete('Xdir4', 'd')"))
+  it('gives correct emsgs', function()
+    eq('Vim(call):E474: Invalid argument', exc_exec("call delete('')"))
+    eq('Vim(call):E15: Invalid expression: 0', exc_exec("call delete('foo', 0)"))
   end)
 end)


### PR DESCRIPTION
Continue of https://github.com/neovim/neovim/pull/12784

Fix https://github.com/Shougo/dein.vim/issues/437 https://github.com/wbthomason/packer.nvim/issues/669

Problem:    Delete() can not handle a file name that looks like a pattern.
Solution:   Use readdir() instead of appending "/*" and expanding wildcards.
            (Ken Takata, closes vim/vim#4424)
https://github.com/vim/vim/commit/701ff0a3e53d253d7300c385e582659bbff7860d