### PR TITLE
Fixes and tests for sending to terminal channel whose terminal has been deleted

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1006,7 +1006,6 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   Terminal *term = terminal_open(buf, topts);
   terminal_check_size(term);
   chan->term = term;
-  channel_incref(chan);
   return (Integer)chan->id;
 }
 
@@ -1036,6 +1035,8 @@ static void term_close(void *data)
   Channel *chan = data;
   terminal_destroy(chan->term);
   chan->term = NULL;
+  api_free_luaref(chan->stream.internal.cb);
+  chan->stream.internal.cb = LUA_NOREF;
   channel_decref(chan);
 }
 

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -535,7 +535,11 @@ size_t channel_send(uint64_t id, char *data, size_t len, bool data_owned, const 
     goto retfree;
   }
 
-  if (chan->streamtype == kChannelStreamInternal && chan->term) {
+  if (chan->streamtype == kChannelStreamInternal) {
+    if (!chan->term) {
+      *error = _("Can't send data to closed stream");
+      goto retfree;
+    }
     terminal_receive(chan->term, data, len);
     written = len;
     goto retfree;

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -281,4 +281,14 @@ describe('channels', function()
     -- works correctly with no output
     eq({"notification", "exit", {id, 1, {''}}}, next_msg())
   end)
+
+  it('should throw error when writing to a channel associated with a deleted terminal', function()
+    source([[
+      let id = nvim_open_term(0, {})
+      bdelete!
+      let v:errmsg = ''
+      silent! call chansend(id, 'test')
+    ]])
+    eq("Can't send data to closed stream", eval('v:errmsg'))
+  end)
 end)

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -3,6 +3,8 @@ local uname = helpers.uname
 local clear, eq, eval, next_msg, ok, source = helpers.clear, helpers.eq,
    helpers.eval, helpers.next_msg, helpers.ok, helpers.source
 local command, funcs, meths = helpers.command, helpers.funcs, helpers.meths
+local exc_exec = helpers.exc_exec
+local poke_eventloop = helpers.poke_eventloop
 local sleep = helpers.sleep
 local spawn, nvim_argv = helpers.spawn, helpers.nvim_argv
 local set_session = helpers.set_session
@@ -283,12 +285,14 @@ describe('channels', function()
   end)
 
   it('should throw error when writing to a channel associated with a deleted terminal', function()
-    source([[
-      let id = nvim_open_term(0, {})
-      bdelete!
-      let v:errmsg = ''
-      silent! call chansend(id, 'test')
-    ]])
-    eq("Can't send data to closed stream", eval('v:errmsg'))
+    command('let id = nvim_open_term(0, {})')
+    local err = exc_exec([[bdelete! | call chansend(id, 'test')]])
+    -- channel hasn't been freed yet
+    eq("Vim(call):Can't send data to closed stream", err)
+    -- process free_channel_event
+    poke_eventloop()
+    err = exc_exec([[call chansend(id, 'test')]])
+    -- channel has ben freed
+    eq("Vim(call):E900: Invalid channel id", err)
   end)
 end)

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -3,8 +3,6 @@ local uname = helpers.uname
 local clear, eq, eval, next_msg, ok, source = helpers.clear, helpers.eq,
    helpers.eval, helpers.next_msg, helpers.ok, helpers.source
 local command, funcs, meths = helpers.command, helpers.funcs, helpers.meths
-local exc_exec = helpers.exc_exec
-local poke_eventloop = helpers.poke_eventloop
 local sleep = helpers.sleep
 local spawn, nvim_argv = helpers.spawn, helpers.nvim_argv
 local set_session = helpers.set_session
@@ -282,17 +280,5 @@ describe('channels', function()
 
     -- works correctly with no output
     eq({"notification", "exit", {id, 1, {''}}}, next_msg())
-  end)
-
-  it('should throw error when writing to a channel associated with a deleted terminal', function()
-    command('let id = nvim_open_term(0, {})')
-    local err = exc_exec([[bdelete! | call chansend(id, 'test')]])
-    -- channel hasn't been freed yet
-    eq("Vim(call):Can't send data to closed stream", err)
-    -- process free_channel_event
-    poke_eventloop()
-    err = exc_exec([[call chansend(id, 'test')]])
-    -- channel has ben freed
-    eq("Vim(call):E900: Invalid channel id", err)
   end)
 end)

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -1,0 +1,49 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local eq = helpers.eq
+local command = helpers.command
+local exc_exec = helpers.exc_exec
+local feed = helpers.feed
+local sleep = helpers.sleep
+local poke_eventloop = helpers.poke_eventloop
+
+describe('associated channel is closed and later freed for terminal', function()
+  before_each(clear)
+
+  it('opened by nvim_open_term() and deleted by :bdelete!', function()
+    command([[let id = nvim_open_term(0, {})]])
+    -- channel hasn't been freed yet
+    eq("Vim(call):Can't send data to closed stream", exc_exec([[bdelete! | call chansend(id, 'test')]]))
+    -- process free_channel_event
+    poke_eventloop()
+    -- channel has been freed
+    eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
+  end)
+
+  it('opened by termopen(), exited, and deleted by pressing a key', function()
+    command([[let id = termopen('echo')]])
+    sleep(500)
+    -- process has exited
+    eq("Vim(call):Can't send data to closed stream", exc_exec([[call chansend(id, 'test')]]))
+    -- delete terminal
+    feed('i<CR>')
+    -- process term_delayed_free and free_channel_event
+    poke_eventloop()
+    -- channel has been freed
+    eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
+  end)
+
+  -- This indirectly covers #16264
+  it('opened by termopen(), exited, and deleted by :bdelete', function()
+    command([[let id = termopen('echo')]])
+    sleep(500)
+    -- process has exited
+    eq("Vim(call):Can't send data to closed stream", exc_exec([[call chansend(id, 'test')]]))
+    -- channel hasn't been freed yet
+    eq("Vim(call):Can't send data to closed stream", exc_exec([[bdelete | call chansend(id, 'test')]]))
+    -- process term_delayed_free and free_channel_event
+    poke_eventloop()
+    -- channel has been freed
+    eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
+  end)
+end)


### PR DESCRIPTION
Prevent SIGABRT when sending to a channel created by nvim_open_term() after the associated terminal has been deleted

The tests also indirectly cover #16264. 