### PR TITLE
fix: add sync.lua to gen_vimdoc

### DIFF
--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -166,6 +166,7 @@ CONFIG = {
             'util.lua',
             'log.lua',
             'rpc.lua',
+            'sync.lua',
             'protocol.lua',
         ],
         'files': ' '.join([


### PR DESCRIPTION
I think this fixes the docgen regression introduced by #16252 

(it runs fine on my computer)