### PR TITLE
fix(channel): fix channel consistency

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -995,6 +995,7 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   TerminalOptions topts;
   Channel *chan = channel_alloc(kChannelStreamInternal);
   chan->stream.internal.cb = cb;
+  chan->stream.internal.closed = false;
   topts.data = chan;
   // NB: overridden in terminal_check_size if a window is already
   // displaying the buffer

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -44,6 +44,7 @@ typedef struct {
 
 typedef struct {
   LuaRef cb;
+  bool closed;
 } InternalState;
 
 typedef struct {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -315,7 +315,11 @@ void terminal_close(Terminal *term, int status)
     // This was called by channel_process_exit_cb() not in process_teardown().
     // Do not call the close callback now. Wait for the user to press a key.
     char msg[sizeof("\r\n[Process exited ]") + NUMBUFLEN];
-    snprintf(msg, sizeof msg, "\r\n[Process exited %d]", status);
+    if (((Channel *)term->opts.data)->streamtype == kChannelStreamInternal) {
+      snprintf(msg, sizeof msg, "\r\n[Terminal closed]");
+    } else {
+      snprintf(msg, sizeof msg, "\r\n[Process exited %d]", status);
+    }
     terminal_receive(term, msg, strlen(msg));
   }
 

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -10,6 +10,8 @@ local nvim_prog = helpers.nvim_prog
 local is_os = helpers.is_os
 local retry = helpers.retry
 local expect_twostreams = helpers.expect_twostreams
+local assert_alive = helpers.assert_alive
+local pcall_err = helpers.pcall_err
 
 describe('channels', function()
   local init = [[
@@ -280,5 +282,24 @@ describe('channels', function()
 
     -- works correctly with no output
     eq({"notification", "exit", {id, 1, {''}}}, next_msg())
+  end)
+end)
+
+describe('loopback', function()
+  before_each(function()
+    clear()
+    command("let chan = sockconnect('pipe', v:servername, {'rpc': v:true})")
+  end)
+
+  it('does not crash when sending raw data', function()
+    eq("Vim(call):Can't send raw data to rpc channel",
+      pcall_err(command, "call chansend(chan, 'test')"))
+    assert_alive()
+  end)
+
+  it('are released when closed', function()
+    local chans = eval('len(nvim_list_chans())')
+    command('call chanclose(chan)')
+    eq(chans - 1, eval('len(nvim_list_chans())'))
   end)
 end)

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -47,3 +47,13 @@ describe('associated channel is closed and later freed for terminal', function()
     eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
   end)
 end)
+
+describe('channel created by nvim_open_term', function()
+  before_each(clear)
+
+  it('can close', function()
+    command('let id = nvim_open_term(0, {})')
+    eq("Vim(call):Can't send data to closed stream",
+      exc_exec([[call chanclose(id) | call chansend(id, 'test')]]))
+  end)
+end)


### PR DESCRIPTION
- Fix the problem that `chanclose()` does not work for channel created by `nvim_open_term()`.
- Fix the problem that the loopback channel is not released.
- Fix the error message when sending raw data to the loopback channel.