### PR TITLE
test: remove unnecessary calls to poke_eventloop()

### DIFF
--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -5,7 +5,6 @@ local command = helpers.command
 local exc_exec = helpers.exc_exec
 local feed = helpers.feed
 local sleep = helpers.sleep
-local poke_eventloop = helpers.poke_eventloop
 
 describe('associated channel is closed and later freed for terminal', function()
   before_each(clear)
@@ -14,8 +13,6 @@ describe('associated channel is closed and later freed for terminal', function()
     command([[let id = nvim_open_term(0, {})]])
     -- channel hasn't been freed yet
     eq("Vim(call):Can't send data to closed stream", exc_exec([[bdelete! | call chansend(id, 'test')]]))
-    -- process free_channel_event
-    poke_eventloop()
     -- channel has been freed
     eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
   end)
@@ -27,8 +24,6 @@ describe('associated channel is closed and later freed for terminal', function()
     eq("Vim(call):Can't send data to closed stream", exc_exec([[call chansend(id, 'test')]]))
     -- delete terminal
     feed('i<CR>')
-    -- process term_delayed_free and free_channel_event
-    poke_eventloop()
     -- channel has been freed
     eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
   end)
@@ -41,8 +36,6 @@ describe('associated channel is closed and later freed for terminal', function()
     eq("Vim(call):Can't send data to closed stream", exc_exec([[call chansend(id, 'test')]]))
     -- channel hasn't been freed yet
     eq("Vim(call):Can't send data to closed stream", exc_exec([[bdelete | call chansend(id, 'test')]]))
-    -- process term_delayed_free and free_channel_event
-    poke_eventloop()
     -- channel has been freed
     eq("Vim(call):E900: Invalid channel id", exc_exec([[call chansend(id, 'test')]]))
   end)


### PR DESCRIPTION
nvim_command is also a deferred API, so poke_eventloop() is not needed.