### PR TITLE
vim-patch:8.2.3591: no event is triggered when closing a window

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1002,8 +1002,9 @@ VimResume			After Nvim resumes from |suspend| state.
 							*VimSuspend*
 VimSuspend			Before Nvim enters |suspend| state.
 							*WinClosed*
-WinClosed			After closing a window. <afile> expands to the
-				|window-ID|.
+WinClosed			After closing a window.  The pattern is
+				matched against the |window-ID|.  Both
+				<amatch> and <afile> are set to the |window-ID|.
 				After WinLeave.
 				Non-recursive (event cannot trigger itself).
 				See also |ExitPre|, |QuitPre|.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -186,7 +186,6 @@ Events:
   |TermOpen|
   |UIEnter|
   |UILeave|
-  |WinClosed|
 
 Functions:
   |dictwatcheradd()| notifies a callback whenever a |Dict| is modified


### PR DESCRIPTION
#### vim-patch:8.2.3591: no event is triggered when closing a window

Problem:    No event is triggered when closing a window.
Solution:   Add the WinClosed event. (Naohiro Ono, closes vim/vim#9110)
https://github.com/vim/vim/commit/23beefed73aadb243fb67cf944e3d60fe8c038bb

Nvim has already implemented this feature, so this only changes tests
and docs.