### PR TITLE
vim-patch:8.2.3593: directory is wrong after executing "lcd" with win_execute()

### DIFF
--- a/src/nvim/testdir/test_execute_func.vim
+++ b/src/nvim/testdir/test_execute_func.vim
@@ -107,6 +107,18 @@ func Test_win_execute()
 
   call win_gotoid(otherwin)
   bwipe!
+
+  " check :lcd in another window does not change directory
+  let curid = win_getid()
+  let curdir = getcwd()
+  split Xother
+  lcd ..
+  " Use :pwd to get the actual current directory
+  let otherdir = execute('pwd')
+  call win_execute(curid, 'lcd testdir')
+  call assert_equal(otherdir, execute('pwd'))
+  bwipe!
+  execute 'cd ' .. curdir
 endfunc
 
 func Test_win_execute_update_ruler()


### PR DESCRIPTION
#### vim-patch:8.2.3593: directory is wrong after executing "lcd" with win_execute()

Problem:    Directory is wrong after executing "lcd" with win_execute().
Solution:   Correct the directory when going back to the original window.
https://github.com/vim/vim/commit/7f13b24ab6aca808262e68680d8fe5f082670ebd