### PR TITLE
refactor(multibyte): eliminate mb_* aliases for utf_* functions

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3649,7 +3649,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
         long n = 0;
         while (group_len >= stl_items[stl_groupitems[groupdepth]].maxwid) {
           group_len -= ptr2cells(t + n);
-          n += (*mb_ptr2len)(t + n);
+          n += utfc_ptr2len(t + n);
         }
         // }
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3461,7 +3461,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
   if (fillchar == 0) {
     fillchar = ' ';
-  } else if (mb_char2len(fillchar) > 1) {
+  } else if (utf_char2len(fillchar) > 1) {
     // Can't handle a multi-byte fill character yet.
     fillchar = '-';
   }

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -602,7 +602,7 @@ void ins_char_bytes(char_u *buf, size_t charlen)
         if (vcol > new_vcol && oldp[col + oldlen] == TAB) {
           break;
         }
-        oldlen += (size_t)(*mb_ptr2len)(oldp + col + oldlen);
+        oldlen += (size_t)utfc_ptr2len(oldp + col + oldlen);
         // Deleted a bit too much, insert spaces.
         if (vcol > new_vcol) {
           newlen += (size_t)(vcol - new_vcol);
@@ -611,7 +611,7 @@ void ins_char_bytes(char_u *buf, size_t charlen)
       curwin->w_p_list = old_list;
     } else if (oldp[col] != NUL) {
       // normal replace
-      oldlen = (size_t)(*mb_ptr2len)(oldp + col);
+      oldlen = (size_t)utfc_ptr2len(oldp + col);
     }
 
 
@@ -725,7 +725,7 @@ int del_chars(long count, int fixpos)
 
   p = get_cursor_pos_ptr();
   for (i = 0; i < count && *p != NUL; i++) {
-    l = (*mb_ptr2len)(p);
+    l = utfc_ptr2len(p);
     bytes += l;
     p += l;
   }
@@ -1426,7 +1426,7 @@ int open_line(int dir, int flags, int second_line_indent)
             int l;
 
             for (i = 0; i < lead_len && p[i] != NUL; i += l) {
-              l = (*mb_ptr2len)(p + i);
+              l = utfc_ptr2len(p + i);
               if (vim_strnsize(p, i + l) > repl_size) {
                 break;
               }
@@ -1449,7 +1449,7 @@ int open_line(int dir, int flags, int second_line_indent)
                 lead_len--;
                 memmove(p, p + 1, (size_t)(leader + lead_len - p));
               } else {
-                int l = (*mb_ptr2len)(p);
+                int l = utfc_ptr2len(p);
 
                 if (l > 1) {
                   if (ptr2cells(p) > 1) {

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -281,7 +281,7 @@ void trans_characters(char_u *buf, int bufsize)
 
   while (*buf != 0) {
     // Assume a multi-byte character doesn't need translation.
-    if ((trs_len = (*mb_ptr2len)(buf)) > 1) {
+    if ((trs_len = utfc_ptr2len(buf)) > 1) {
       len -= trs_len;
     } else {
       trs = transchar_byte(*buf);
@@ -498,7 +498,7 @@ char_u *str_foldcase(char_u *str, int orglen, char_u *buf, int buflen)
     }
 
     // skip to next multi-byte char
-    i += (*mb_ptr2len)(STR_PTR(i));
+    i += utfc_ptr2len(STR_PTR(i));
   }
 
 
@@ -732,7 +732,7 @@ int vim_strnsize(char_u *s, int len)
   assert(s != NULL);
   int size = 0;
   while (*s != NUL && --len >= 0) {
-    int l = (*mb_ptr2len)(s);
+    int l = utfc_ptr2len(s);
     size += ptr2cells(s);
     s += l;
     len -= l - 1;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7167,7 +7167,7 @@ void replace_push(int c)
  */
 int replace_push_mb(char_u *p)
 {
-  int l = (*mb_ptr2len)(p);
+  int l = utfc_ptr2len(p);
   int j;
 
   for (j = l - 1; j >= 0; --j) {
@@ -7323,7 +7323,7 @@ static void replace_do_bs(int limit_col)
       vcol = start_vcol;
       for (i = 0; i < ins_len; i++) {
         vcol += win_chartabsize(curwin, p + i, vcol);
-        i += (*mb_ptr2len)(p) - 1;
+        i += utfc_ptr2len(p) - 1;
       }
       vcol -= start_vcol;
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1180,7 +1180,7 @@ static void f_col(typval_T *argvars, typval_T *rettv, FunPtr fptr)
                                          - curwin->w_cursor.coladd))) {
           int l;
 
-          if (*p != NUL && p[(l = (*mb_ptr2len)(p))] == NUL) {
+          if (*p != NUL && p[(l = utfc_ptr2len(p))] == NUL) {
             col += l;
           }
         }
@@ -6211,7 +6211,7 @@ static void find_some_match(typval_T *const argvars, typval_T *const rettv,
         idx++;
       } else {
         startcol = (colnr_T)(regmatch.startp[0]
-                             + (*mb_ptr2len)(regmatch.startp[0]) - str);
+                             + utfc_ptr2len(regmatch.startp[0]) - str);
         if (startcol > (colnr_T)len || str + startcol <= regmatch.startp[0]) {
           match = false;
           break;
@@ -10440,7 +10440,7 @@ static void f_split(typval_T *argvars, typval_T *rettv, FunPtr fptr)
         col = 0;
       } else {
         // Don't get stuck at the same match.
-        col = (*mb_ptr2len)(regmatch.endp[0]);
+        col = utfc_ptr2len(regmatch.endp[0]);
       }
       str = (const char *)regmatch.endp[0];
     }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3771,7 +3771,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
             skip_match = true;
           } else {
             // search for a match at next column
-            matchcol += mb_ptr2len(sub_firstline + matchcol);
+            matchcol += utfc_ptr2len(sub_firstline + matchcol);
           }
           // match will be pushed to preview_lines, bring it into a proper state
           current_match.start.col = matchcol;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8598,8 +8598,8 @@ static void ex_normal(exarg_T *eap)
     int len = 0;
 
     // Count the number of characters to be escaped.
-    for (p = eap->arg; *p != NUL; ++p) {
-      for (l = (*mb_ptr2len)(p) - 1; l > 0; --l) {
+    for (p = eap->arg; *p != NUL; p++) {
+      for (l = utfc_ptr2len(p) - 1; l > 0; l--) {
         if (*++p == K_SPECIAL             // trailbyte K_SPECIAL or CSI
             ) {
           len += 2;
@@ -8611,7 +8611,7 @@ static void ex_normal(exarg_T *eap)
       len = 0;
       for (p = eap->arg; *p != NUL; ++p) {
         arg[len++] = *p;
-        for (l = (*mb_ptr2len)(p) - 1; l > 0; --l) {
+        for (l = utfc_ptr2len(p) - 1; l > 0; l--) {
           arg[len++] = *++p;
           if (*p == K_SPECIAL) {
             arg[len++] = KS_SPECIAL;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3232,7 +3232,7 @@ void unputcmdline(void)
   if (ccline.cmdlen == ccline.cmdpos && !ui_has(kUICmdline)) {
     msg_putchar(' ');
   } else {
-    draw_cmdline(ccline.cmdpos, mb_ptr2len(ccline.cmdbuff + ccline.cmdpos));
+    draw_cmdline(ccline.cmdpos, utfc_ptr2len(ccline.cmdbuff + ccline.cmdpos));
   }
   msg_no_more = false;
   cursorcmd();

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2888,7 +2888,7 @@ int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev, buf_T 
         if (same == -1 && last != first) {
           same = n - 1;                       // count of same char type
         }
-        p += (*mb_ptr2len)(p);
+        p += utfc_ptr2len(p);
       }
       if (last && n > 2 && same >= 0 && same < n - 1) {
         retval = 1;
@@ -3812,7 +3812,7 @@ bool check_abbr(int c, char_u *ptr, int col, int mincol)
     while (p > ptr + mincol) {
       p = mb_prevptr(ptr, p);
       if (ascii_isspace(*p) || (!vim_abbr && is_id != vim_iswordp(p))) {
-        p += (*mb_ptr2len)(p);
+        p += utfc_ptr2len(p);
         break;
       }
       ++clen;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -572,7 +572,7 @@ static void prt_header(prt_settings_T *const psettings, const int pagenum, const
   int page_line = 0 - prt_header_height();
   mch_print_start_line(true, page_line);
   for (char_u *p = tbuf; *p != NUL; ) {
-    const int l = (*mb_ptr2len)(p);
+    const int l = utfc_ptr2len(p);
     assert(l >= 0);
     if (mch_print_text_out(p, (size_t)l)) {
       page_line++;
@@ -879,7 +879,7 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
    * Loop over the columns until the end of the file line or right margin.
    */
   for (col = ppos->column; line[col] != NUL && !need_break; col += outputlen) {
-    if ((outputlen = (*mb_ptr2len)(line + col)) < 1) {
+    if ((outputlen = utfc_ptr2len(line + col)) < 1) {
       outputlen = 1;
     }
     // syntax highlighting stuff.

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -689,7 +689,7 @@ int find_special_key(const char_u **srcp, const size_t src_len, int *const modp,
           // Special case for a double-quoted string
           off = l = 2;
         } else {
-          l = mb_ptr2len(last_dash + 1);
+          l = utfc_ptr2len(last_dash + 1);
         }
         if (modifiers != 0 && last_dash[l + 1] == '>') {
           key = PTR2CHAR(last_dash + off);

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -477,7 +477,7 @@ char_u *get_special_key_name(int c, int modifiers)
    * extract modifiers.
    */
   if (c > 0
-      && (*mb_char2len)(c) == 1) {
+      && utf_char2len(c) == 1) {
     if (table_idx < 0
         && (!vim_isprintc(c) || (c & 0x7f) == ' ')
         && (c & 0x80)) {

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -114,7 +114,6 @@
 #define MB_COPY_CHAR(f, t) mb_copy_char((const char_u **)(&f), &t);
 
 #define MB_CHARLEN(p)      mb_charlen(p)
-#define MB_CHAR2LEN(c)     mb_char2len(c)
 #define PTR2CHAR(p)        utf_ptr2char(p)
 
 #define RESET_BINDING(wp) \

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -102,7 +102,7 @@
 // PTR2CHAR(): get character from pointer.
 
 // Advance multi-byte pointer, skip over composing chars.
-#define MB_PTR_ADV(p)      (p += mb_ptr2len((char_u *)p))
+#define MB_PTR_ADV(p)      (p += utfc_ptr2len((char_u *)p))
 // Advance multi-byte pointer, do not skip over composing chars.
 #define MB_CPTR_ADV(p)     (p += utf_ptr2len(p))
 // Backup multi-byte pointer. Only use with "p" > "s" !

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -564,7 +564,7 @@ size_t mb_string2cells(const char_u *str)
 {
   size_t clen = 0;
 
-  for (const char_u *p = str; *p != NUL; p += (*mb_ptr2len)(p)) {
+  for (const char_u *p = str; *p != NUL; p += utfc_ptr2len(p)) {
     clen += utf_ptr2cells(p);
   }
 
@@ -705,7 +705,7 @@ int mb_ptr2char_adv(const char_u **const pp)
   int c;
 
   c = utf_ptr2char(*pp);
-  *pp += (*mb_ptr2len)(*pp);
+  *pp += utfc_ptr2len(*pp);
   return c;
 }
 
@@ -2054,7 +2054,7 @@ int mb_charlen(char_u *str)
   }
 
   for (count = 0; *p != NUL; count++) {
-    p += (*mb_ptr2len)(p);
+    p += utfc_ptr2len(p);
   }
 
   return count;
@@ -2069,7 +2069,7 @@ int mb_charlen_len(char_u *str, int len)
   int count;
 
   for (count = 0; *p != NUL && p < str + len; count++) {
-    p += (*mb_ptr2len)(p);
+    p += utfc_ptr2len(p);
   }
 
   return count;

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -39,7 +39,6 @@
 #define ENC_MACROMAN   0x800       // Mac Roman (not Macro Man! :-)
 
 // TODO(bfredl): eventually we should keep only one of the namings
-#define mb_ptr2len utfc_ptr2len
 #define mb_char2len utf_char2len
 
 /// Flags for vimconv_T

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -38,9 +38,6 @@
 #define ENC_LATIN9     0x400       // Latin9
 #define ENC_MACROMAN   0x800       // Mac Roman (not Macro Man! :-)
 
-// TODO(bfredl): eventually we should keep only one of the namings
-#define mb_char2len utf_char2len
-
 /// Flags for vimconv_T
 typedef enum {
   CONV_NONE      = 0,

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -41,7 +41,6 @@
 // TODO(bfredl): eventually we should keep only one of the namings
 #define mb_ptr2len utfc_ptr2len
 #define mb_char2len utf_char2len
-#define mb_char2cells utf_char2cells
 
 /// Flags for vimconv_T
 typedef enum {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1583,7 +1583,7 @@ int msg_outtrans_special(const char_u *strstart, bool from, int maxlen)
     }
     // Highlight special keys
     msg_puts_attr(text, (len > 1
-                         && (*mb_ptr2len)((char_u *)text) <= 1
+                         && utfc_ptr2len((char_u *)text) <= 1
                          ? attr : 0));
     retval += len;
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2931,7 +2931,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
           find_start_of_word(&VIsual);
           if (*p_sel == 'e' && *get_cursor_pos_ptr() != NUL) {
             curwin->w_cursor.col +=
-              (*mb_ptr2len)(get_cursor_pos_ptr());
+              utfc_ptr2len(get_cursor_pos_ptr());
           }
           find_end_of_word(&curwin->w_cursor);
         }
@@ -2998,7 +2998,7 @@ static void find_end_of_word(pos_T *pos)
   }
   cclass = get_mouse_class(line + pos->col);
   while (line[pos->col] != NUL) {
-    col = pos->col + (*mb_ptr2len)(line + pos->col);
+    col = pos->col + utfc_ptr2len(line + pos->col);
     if (get_mouse_class(line + col) != cclass) {
       if (*p_sel == 'e') {
         pos->col = col;
@@ -3437,7 +3437,7 @@ void clear_showcmd(void)
         e = ml_get_pos(&VIsual);
       }
       while ((*p_sel != 'e') ? s <= e : s < e) {
-        l = (*mb_ptr2len)(s);
+        l = utfc_ptr2len(s);
         if (l == 0) {
           ++bytes;
           ++chars;
@@ -5382,7 +5382,7 @@ static void nv_right(cmdarg_T *cap)
       if (virtual_active()) {
         oneright();
       } else {
-        curwin->w_cursor.col += (*mb_ptr2len)(get_cursor_pos_ptr());
+        curwin->w_cursor.col += utfc_ptr2len(get_cursor_pos_ptr());
       }
     }
   }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1847,7 +1847,7 @@ int op_replace(oparg_T *oap, int c)
 
       // Compute bytes needed, move character count to num_chars.
       num_chars = numc;
-      numc *= (*mb_char2len)(c);
+      numc *= utf_char2len(c);
 
       oldp = get_cursor_line_ptr();
       oldlen = (int)STRLEN(oldp);
@@ -1926,11 +1926,11 @@ int op_replace(oparg_T *oap, int c)
     while (ltoreq(curwin->w_cursor, oap->end)) {
       n = gchar_cursor();
       if (n != NUL) {
-        if ((*mb_char2len)(c) > 1 || (*mb_char2len)(n) > 1) {
+        if (utf_char2len(c) > 1 || utf_char2len(n) > 1) {
           // This is slow, but it handles replacing a single-byte
           // with a multi-byte and the other way around.
           if (curwin->w_cursor.lnum == oap->end.lnum) {
-            oap->end.col += (*mb_char2len)(c) - (*mb_char2len)(n);
+            oap->end.col += utf_char2len(c) - utf_char2len(n);
           }
           replace_character(c);
         } else {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1837,7 +1837,7 @@ int op_replace(oparg_T *oap, int c)
 
       // A double-wide character can be replaced only up to half the
       // times.
-      if ((*mb_char2cells)(c) > 1) {
+      if (utf_char2cells(c) > 1) {
         if ((numc & 1) && !bd.is_short) {
           ++bd.endspaces;
           ++n;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2939,7 +2939,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
         bool one_past_line = (*cursor_pos == NUL);
         bool eol = false;
         if (!one_past_line) {
-          eol = (*(cursor_pos + mb_ptr2len(cursor_pos)) == NUL);
+          eol = (*(cursor_pos + utfc_ptr2len(cursor_pos)) == NUL);
         }
 
         bool ve_allows = (ve_flags == VE_ALL || ve_flags == VE_ONEMORE);
@@ -3317,7 +3317,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       // if type is kMTCharWise, FORWARD is the same as BACKWARD on the next
       // char
       if (dir == FORWARD && gchar_cursor() != NUL) {
-        int bytelen = (*mb_ptr2len)(get_cursor_pos_ptr());
+        int bytelen = utfc_ptr2len(get_cursor_pos_ptr());
 
         // put it on the next of the multi-byte character.
         col += bytelen;
@@ -3703,7 +3703,7 @@ void ex_display(exarg_T *eap)
           n -= 2;
         }
         for (p = yb->y_array[j]; *p && (n -= ptr2cells(p)) >= 0; p++) {  // -V1019 NOLINT(whitespace/line_length)
-          clen = (*mb_ptr2len)(p);
+          clen = utfc_ptr2len(p);
           msg_outtrans_len(p, clen);
           p += clen - 1;
         }
@@ -5640,8 +5640,8 @@ static varnumber_T line_count_info(char_u *line, varnumber_T *wc, varnumber_T *c
     } else if (!ascii_isspace(line[i])) {
       is_word = 1;
     }
-    ++chars;
-    i += (*mb_ptr2len)(line + i);
+    chars++;
+    i += utfc_ptr2len(line + i);
   }
 
   if (is_word) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3529,7 +3529,7 @@ static char *set_chars_option(win_T *wp, char_u **varp, bool set)
           // TODO(bfredl): use schar_T representation and utfc_ptr2len
           int c1len = utf_ptr2len(s);
           c1 = mb_cptr2char_adv((const char_u **)&s);
-          if (mb_char2cells(c1) > 1 || (c1len == 1 && c1 > 127)) {
+          if (utf_char2cells(c1) > 1 || (c1len == 1 && c1 > 127)) {
             return e_invarg;
           }
           if (tab[i].cp == &wp->w_p_lcs_chars.tab2) {
@@ -3538,13 +3538,13 @@ static char *set_chars_option(win_T *wp, char_u **varp, bool set)
             }
             int c2len = utf_ptr2len(s);
             c2 = mb_cptr2char_adv((const char_u **)&s);
-            if (mb_char2cells(c2) > 1 || (c2len == 1 && c2 > 127)) {
+            if (utf_char2cells(c2) > 1 || (c2len == 1 && c2 > 127)) {
               return e_invarg;
             }
             if (!(*s == ',' || *s == NUL)) {
               int c3len = utf_ptr2len(s);
               c3 = mb_cptr2char_adv((const char_u **)&s);
-              if (mb_char2cells(c3) > 1 || (c3len == 1 && c3 > 127)) {
+              if (utf_char2cells(c3) > 1 || (c3len == 1 && c3 > 127)) {
                 return e_invarg;
               }
             }
@@ -3579,7 +3579,7 @@ static char *set_chars_option(win_T *wp, char_u **varp, bool set)
             while (*s != NUL && *s != ',') {
               int c1len = utf_ptr2len(s);
               c1 = mb_cptr2char_adv((const char_u **)&s);
-              if (mb_char2cells(c1) > 1 || (c1len == 1 && c1 > 127)) {
+              if (utf_char2cells(c1) > 1 || (c1len == 1 && c1 > 127)) {
                 return e_invarg;
               }
               multispace_len++;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -783,7 +783,7 @@ static int get_equi_class(char_u **pp)
   char_u      *p = *pp;
 
   if (p[1] == '=' && p[2] != NUL) {
-    l = (*mb_ptr2len)(p + 2);
+    l = utfc_ptr2len(p + 2);
     if (p[l + 2] == '=' && p[l + 3] == ']') {
       c = utf_ptr2char(p + 2);
       *pp += l + 4;
@@ -1144,7 +1144,7 @@ static char_u *skip_anyof(char_u *p)
   if (*p == ']' || *p == '-')
     ++p;
   while (*p != NUL && *p != ']') {
-    if ((l = (*mb_ptr2len)(p)) > 1) {
+    if ((l = utfc_ptr2len(p)) > 1) {
       p += l;
     } else if (*p == '-')  {
       p++;
@@ -3585,7 +3585,7 @@ static long bt_regexec_both(char_u *line,
       if (rex.line[col] == NUL) {
         break;
       }
-      col += (*mb_ptr2len)(rex.line + col);
+      col += utfc_ptr2len(rex.line + col);
       // Check for timeout once in a twenty times to avoid overhead.
       if (tm != NULL && ++tm_count == 20) {
         tm_count = 0;
@@ -4326,7 +4326,7 @@ static bool regmatch(
             const char_u *opnd = OPERAND(scan);
             // Safety check (just in case 'encoding' was changed since
             // compiling the program).
-            if ((len = (*mb_ptr2len)(opnd)) < 2) {
+            if ((len = utfc_ptr2len(opnd)) < 2) {
               status = RA_NOMATCH;
               break;
             }
@@ -5392,7 +5392,7 @@ do_class:
         if (got_int) {
           break;
         }
-      } else if ((l = (*mb_ptr2len)(scan)) > 1) {
+      } else if ((l = utfc_ptr2len(scan)) > 1) {
         if (testval != 0) {
           break;
         }
@@ -5507,12 +5507,12 @@ do_class:
 
     /* Safety check (just in case 'encoding' was changed since
      * compiling the program). */
-    if ((len = (*mb_ptr2len)(opnd)) > 1) {
+    if ((len = utfc_ptr2len(opnd)) > 1) {
       if (rex.reg_ic) {
         cf = utf_fold(utf_ptr2char(opnd));
       }
-      while (count < maxcount && (*mb_ptr2len)(scan) >= len) {
-        for (i = 0; i < len; ++i) {
+      while (count < maxcount && utfc_ptr2len(scan) >= len) {
+        for (i = 0; i < len; i++) {
           if (opnd[i] != scan[i]) {
             break;
           }
@@ -6532,7 +6532,7 @@ char_u *regtilde(char_u *source, int magic)
       if (*p == '\\' && p[1]) {         // skip escaped characters
         p++;
       }
-      p += (*mb_ptr2len)(p) - 1;
+      p += utfc_ptr2len(p) - 1;
     }
   }
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2255,8 +2255,8 @@ collection:
               if (startc > endc) {
                 EMSG_RET_NULL(_(e_reverse_range));
               }
-              if ((*mb_char2len)(startc) > 1
-                  || (*mb_char2len)(endc) > 1) {
+              if (utf_char2len(startc) > 1
+                  || utf_char2len(endc) > 1) {
                 // Limit to a range of 256 chars
                 if (endc > startc + 256) {
                   EMSG_RET_NULL(_(e_large_class));

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -543,7 +543,7 @@ static char_u *nfa_get_match_text(nfa_state_T *start)
     return NULL;     /* just in case */
   p = p->out;
   while (p->c > 0) {
-    len += MB_CHAR2LEN(p->c);
+    len += utf_char2len(p->c);
     p = p->out;
   }
   if (p->c != NFA_MCLOSE || p->out->c != NFA_MATCH)
@@ -1746,8 +1746,8 @@ collection:
             EMIT(endc);
             EMIT(NFA_RANGE);
             EMIT(NFA_CONCAT);
-          } else if ((*mb_char2len)(startc) > 1
-                     || (*mb_char2len)(endc) > 1) {
+          } else if (utf_char2len(startc) > 1
+                     || utf_char2len(endc) > 1) {
             // Emit the characters in the range.
             // "startc" was already emitted, so skip it.
             for (c = startc + 1; c <= endc; c++) {
@@ -1828,7 +1828,7 @@ collection:
 
 nfa_do_multibyte:
     // plen is length of current char with composing chars
-    if ((*mb_char2len)(c) != (plen = utfc_ptr2len(old_regparse))
+    if (utf_char2len(c) != (plen = utfc_ptr2len(old_regparse))
         || utf_iscomposing(c)) {
       int i = 0;
 
@@ -2972,8 +2972,8 @@ static int nfa_max_width(nfa_state_T *startstate, int depth)
       if (state->c < 0)
         /* don't know what this is */
         return -1;
-      /* normal character */
-      len += MB_CHAR2LEN(state->c);
+      // normal character
+      len += utf_char2len(state->c);
       break;
     }
 
@@ -5620,7 +5620,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
           // Only match composing character(s), ignore base
           // character.  Used for ".{composing}" and "{composing}"
           // (no preceding character).
-          len += mb_char2len(mc);
+          len += utf_char2len(mc);
         }
         if (rex.reg_icombine && len == 0) {
           // If \Z was present, then ignore composing characters.
@@ -5636,7 +5636,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
         } else if (len > 0 || mc == sta->c) {
           // Check base character matches first, unless ignored.
           if (len == 0) {
-            len += mb_char2len(mc);
+            len += utf_char2len(mc);
             sta = sta->out;
           }
 
@@ -5645,9 +5645,10 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
           while (len < clen) {
             mc = utf_ptr2char(rex.input + len);
             cchars[ccount++] = mc;
-            len += mb_char2len(mc);
-            if (ccount == MAX_MCO)
+            len += utf_char2len(mc);
+            if (ccount == MAX_MCO) {
               break;
+            }
           }
 
           // Check that each composing char in the pattern matches a

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2671,7 +2671,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       // Highlight one character for an empty match.
       if (shl->startcol == shl->endcol) {
         if (line[shl->endcol] != NUL) {
-          shl->endcol += (*mb_ptr2len)(line + shl->endcol);
+          shl->endcol += utfc_ptr2len(line + shl->endcol);
         } else {
           ++shl->endcol;
         }
@@ -3145,7 +3145,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
 
                 if (shl->startcol == shl->endcol) {
                   // highlight empty match, try again after it
-                  shl->endcol += (*mb_ptr2len)(line + shl->endcol);
+                  shl->endcol += utfc_ptr2len(line + shl->endcol);
                 }
 
                 // Loop to check if the match starts at the
@@ -3244,7 +3244,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
     // represent special characters (non-printable stuff) and other
     // things.  When all characters are the same, c_extra is used.
     // If c_final is set, it will compulsorily be used at the end.
-    // "p_extra" must end in a NUL to avoid mb_ptr2len() reads past
+    // "p_extra" must end in a NUL to avoid utfc_ptr2len() reads past
     // "p_extra[n_extra]".
     // For the '$' of the 'list' option, n_extra == 1, p_extra == "".
     if (n_extra > 0) {
@@ -5134,7 +5134,7 @@ void win_redr_status_matches(expand_T *xp, int num_matches, char_u **matches, in
       for (; *s != NUL; ++s) {
         s += skip_status_match_char(xp, s);
         clen += ptr2cells(s);
-        if ((l = (*mb_ptr2len)(s)) > 1) {
+        if ((l = utfc_ptr2len(s)) > 1) {
           STRNCPY(buf + len, s, l);  // NOLINT(runtime/printf)
           s += l - 1;
           len += l;
@@ -6169,7 +6169,7 @@ static void next_search_hl(win_T *win, match_T *shl, linenr_T lnum, colnr_T minc
         shl->lnum = 0;
         break;
       }
-      matchcol += mb_ptr2len(ml);
+      matchcol += utfc_ptr2len(ml);
     } else {
       matchcol = shl->rm.endpos[0].col;
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3705,7 +3705,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
             // if n_extra > 0, it gives the number of chars
             // to use for a tab, else we need to calculate the width
             // for a tab
-            int len = (tab_len * mb_char2len(wp->w_p_lcs_chars.tab2));
+            int len = (tab_len * utf_char2len(wp->w_p_lcs_chars.tab2));
             if (n_extra > 0) {
               len += n_extra - tab_len;
             }
@@ -3728,8 +3728,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
                 lcs = wp->w_p_lcs_chars.tab3;
               }
               utf_char2bytes(lcs, p);
-              p += mb_char2len(lcs);
-              n_extra += mb_char2len(lcs) - (saved_nextra > 0 ? 1 : 0);
+              p += utf_char2len(lcs);
+              n_extra += utf_char2len(lcs) - (saved_nextra > 0 ? 1 : 0);
             }
             p_extra = p_extra_free;
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3279,7 +3279,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
 
         // If a double-width char doesn't fit display a '>' in the last column.
         if ((wp->w_p_rl ? (col <= 0) : (col >= grid->Columns - 1))
-            && (*mb_char2cells)(mb_c) == 2) {
+            && utf_char2cells(mb_c) == 2) {
           c = '>';
           mb_c = c;
           mb_l = 1;
@@ -3393,7 +3393,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       // next line.
       if ((wp->w_p_rl ? (col <= 0) :
            (col >= grid->Columns - 1))
-          && (*mb_char2cells)(mb_c) == 2) {
+          && utf_char2cells(mb_c) == 2) {
         c = '>';
         mb_c = c;
         mb_utf8 = false;
@@ -3964,7 +3964,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         && c != NUL) {
       c = wp->w_p_lcs_chars.prec;
       lcs_prec_todo = NUL;
-      if ((*mb_char2cells)(mb_c) > 1) {
+      if (utf_char2cells(mb_c) > 1) {
         // Double-width character being overwritten by the "precedes"
         // character, need to fill up half the character.
         c_extra = MB_FILLER_CHAR;
@@ -4275,7 +4275,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       //
       // Store the character.
       //
-      if (wp->w_p_rl && (*mb_char2cells)(mb_c) > 1) {
+      if (wp->w_p_rl && utf_char2cells(mb_c) > 1) {
         // A double-wide character is: put first halve in left cell.
         off--;
         col--;
@@ -4292,7 +4292,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         linebuf_attr[off] = char_attr;
       }
 
-      if ((*mb_char2cells)(mb_c) > 1) {
+      if (utf_char2cells(mb_c) > 1) {
         // Need to fill two screen columns.
         off++;
         col++;
@@ -4353,7 +4353,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         }
 
 
-        if ((*mb_char2cells)(mb_c) > 1) {
+        if (utf_char2cells(mb_c) > 1) {
           // Need to fill two screen columns.
           if (wp->w_p_rl) {
             --boguscols;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -386,7 +386,7 @@ bool pat_has_uppercase(char_u *pat)
   char_u *p = pat;
 
   while (*p != NUL) {
-    const int l = mb_ptr2len(p);
+    const int l = utfc_ptr2len(p);
 
     if (l > 1) {
       if (mb_isupper(utf_ptr2char(p))) {
@@ -797,7 +797,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
                 // for empty match: advance one char
                 if (matchcol == matchpos.col
                     && ptr[matchcol] != NUL) {
-                  matchcol += mb_ptr2len(ptr + matchcol);
+                  matchcol += utfc_ptr2len(ptr + matchcol);
                 }
               } else {
                 // Stop when the match is in a next line.
@@ -806,7 +806,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
                 }
                 matchcol = matchpos.col;
                 if (ptr[matchcol] != NUL) {
-                  matchcol += mb_ptr2len(ptr + matchcol);
+                  matchcol += utfc_ptr2len(ptr + matchcol);
                 }
               }
               if (ptr[matchcol] == NUL
@@ -3955,7 +3955,7 @@ static int find_next_quote(char_u *line, int col, int quotechar, char_u *escape)
     } else if (c == quotechar) {
       break;
     }
-    col += mb_ptr2len(line + col);
+    col += utfc_ptr2len(line + col);
   }
   return col;
 }

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -870,7 +870,7 @@ static int sign_define_init_text(sign_T *sp, char_u *text)
   }
   // Count cells and check for non-printable chars
   cells = 0;
-  for (s = text; s < endp; s += (*mb_ptr2len)(s)) {
+  for (s = text; s < endp; s += utfc_ptr2len(s)) {
     if (!vim_isprintc(utf_ptr2char(s))) {
       break;
     }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2024,7 +2024,7 @@ static int count_syllables(slang_T *slang, const char_u *word)
     } else {
       // No recognized syllable item, at least a syllable char then?
       c = utf_ptr2char(p);
-      len = (*mb_ptr2len)(p);
+      len = utfc_ptr2len(p);
       if (vim_strchr(slang->sl_syllable, c) == NULL) {
         skip = false;               // No, search for next syllable
       } else if (!skip) {
@@ -4008,7 +4008,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
         c = su->su_badflags;
         if ((c & WF_ALLCAP)
             && su->su_badlen ==
-            (*mb_ptr2len)(su->su_badptr)) {
+            utfc_ptr2len(su->su_badptr)) {
           c = WF_ONECAP;
         }
         c |= flags;
@@ -6936,7 +6936,7 @@ void spell_dump_compl(char_u *pat, int ic, Direction *dir, int dumpflags_arg)
       if (n == WF_ONECAP) {
         dumpflags |= DUMPFLAG_ONECAP;
       } else if (n == WF_ALLCAP
-                 && (int)STRLEN(pat) > mb_ptr2len(pat)) {
+                 && (int)STRLEN(pat) > utfc_ptr2len(pat)) {
         dumpflags |= DUMPFLAG_ALLCAP;
       }
     }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4644,7 +4644,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
         PROF_STORE(sp->ts_state)
         sp->ts_state = STATE_UNSWAP;
         depth++;
-        fl = mb_char2len(c2);
+        fl = utf_char2len(c2);
         memmove(p, p + n, fl);
         utf_char2bytes(c, p + fl);
         stack[depth].ts_fidxtry = sp->ts_fidx + n + fl;
@@ -4700,7 +4700,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
         PROF_STORE(sp->ts_state)
         sp->ts_state = STATE_UNSWAP3;
         depth++;
-        tl = mb_char2len(c3);
+        tl = utf_char2len(c3);
         memmove(p, p + n + fl, tl);
         utf_char2bytes(c2, p + tl);
         utf_char2bytes(c, p + fl + tl);

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -2504,7 +2504,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
             // be empty or start with the same letter.
             if (aff_entry->ae_chop != NULL
                 && aff_entry->ae_add != NULL
-                && aff_entry->ae_chop[(*mb_ptr2len)(aff_entry->ae_chop)] ==
+                && aff_entry->ae_chop[utfc_ptr2len(aff_entry->ae_chop)] ==
                 NUL) {
               int c, c_up;
 

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5858,8 +5858,8 @@ static void set_map_str(slang_T *lp, char_u *map)
       // the hash table.  Each entry is the char, a NUL the headchar and
       // a NUL.
       if (c >= 256) {
-        int cl = mb_char2len(c);
-        int headcl = mb_char2len(headc);
+        int cl = utf_char2len(c);
+        int headcl = utf_char2len(headc);
         char_u *b;
         hash_T hash;
         hashitem_T *hi;

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -999,7 +999,7 @@ int vim_vsnprintf_typval(char *str, size_t str_m, const char *fmt, va_list ap, t
               size_t i = 0;
 
               for (p1 = (char_u *)str_arg; *p1;
-                   p1 += mb_ptr2len(p1)) {
+                   p1 += utfc_ptr2len(p1)) {
                 i += (size_t)utf_ptr2cells(p1);
                 if (i > precision) {
                   break;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4246,7 +4246,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
     } else if (flagtab[fidx].argtype == 11 && arg[5] == '=') {
       // cchar=?
       *conceal_char = utf_ptr2char(arg + 6);
-      arg += mb_ptr2len(arg + 6) - 1;
+      arg += utfc_ptr2len(arg + 6) - 1;
       if (!vim_isprintc_strict(*conceal_char)) {
         emsg(_("E844: invalid cchar value"));
         return NULL;
@@ -4483,7 +4483,7 @@ static void syn_cmd_keyword(exarg_T *eap, int syncing)
               kw = p + 1;
               break;   // skip over the "]"
             }
-            const int l = (*mb_ptr2len)(p + 1);
+            const int l = utfc_ptr2len(p + 1);
 
             memmove(p, p + 1, l);
             p += l;


### PR DESCRIPTION
There is some more obsolete multibyte macros in macros.h that also requires the treatment, but I will do that in a separate PR.