### PR TITLE
feat(diagnostic): add 'prefix' option to open_float

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -384,6 +384,17 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      a diagnostic as input and returns a
                                      string. The return value is the text used
                                      to display the diagnostic.
+                                   • prefix: (function or string) Prefix each
+                                     diagnostic in the floating window. If a
+                                     function, it must have the signature
+                                     (diagnostic, i, total) -> string, where
+                                     {i} is the index of the diagnostic being
+                                     evaluated and {total} is the total number
+                                     of diagnostics displayed in the window.
+                                     The returned string is prepended to each
+                                     diagnostic in the window. Otherwise, if
+                                     {prefix} is a string, it is prepended to
+                                     each diagnostic.
 
                                  • update_in_insert: (default false) Update
                                    diagnostics in Insert mode (if false,
@@ -614,6 +625,9 @@ open_float({bufnr}, {opts})                      *vim.diagnostic.open_float()*
                                return value is the text used to display the
                                diagnostic. Overrides the setting from
                                |vim.diagnostic.config()|.
+                             • prefix: (function or string) Prefix each
+                               diagnostic in the floating window. Overrides
+                               the setting from |vim.diagnostic.config()|.
 
                 Return: ~
                     tuple ({float_bufnr}, {win_id})


### PR DESCRIPTION
The 'prefix' option accepts a function or a string that is used to add a prefix string to each diagnostic displayed in the floating window.
