### PR TITLE
vim-patch:8.2.3255: ci" finds following string but ci< and others don't

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1808,6 +1808,9 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
     initc = NUL;
   } else if (initc != '#' && initc != NUL) {
     find_mps_values(&initc, &findc, &backwards, true);
+    if (dir) {
+      backwards = (dir == FORWARD) ? false : true;
+    }
     if (findc == NUL) {
       return NULL;
     }
@@ -3427,12 +3430,22 @@ int current_block(oparg_T *oap, long count, int include, int what, int other)
   // user wants.
   save_cpo = p_cpo;
   p_cpo = (char_u *)(vim_strchr(p_cpo, CPO_MATCHBSL) != NULL ? "%M" : "%");
-  while (count-- > 0) {
-    if ((pos = findmatch(NULL, what)) == NULL) {
-      break;
+  if ((pos = findmatch(NULL, what)) != NULL) {
+    while (count-- > 0) {
+      if ((pos = findmatch(NULL, what)) == NULL) {
+        break;
+      }
+      curwin->w_cursor = *pos;
+      start_pos = *pos;   // the findmatch for end_pos will overwrite *pos
     }
-    curwin->w_cursor = *pos;
-    start_pos = *pos;  // the findmatch for end_pos will overwrite *pos
+  } else {
+    while (count-- > 0) {
+      if ((pos = findmatchlimit(NULL, what, FM_FORWARD, 0)) == NULL) {
+        break;
+      }
+      curwin->w_cursor = *pos;
+      start_pos = *pos;   // the findmatch for end_pos will overwrite *pos
+    }
   }
   p_cpo = save_cpo;
 

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -421,4 +421,36 @@ func Test_textobj_quote()
   close!
 endfunc
 
+" Test for i(, i<, etc. when cursor is in front of a block
+func Test_textobj_find_paren_forward()
+  new
+
+  " i< and a> when cursor is in front of a block
+  call setline(1, '#include <foo.h>')
+  normal 0yi<
+  call assert_equal('foo.h', @")
+  normal 0ya>
+  call assert_equal('<foo.h>', @")
+
+  " 2i(, 3i( in front of a block enters second/third nested '('
+  call setline(1, 'foo (bar (baz (quux)))')
+  normal 0yi)
+  call assert_equal('bar (baz (quux))', @")
+  normal 02yi)
+  call assert_equal('baz (quux)', @")
+  normal 03yi)
+  call assert_equal('quux', @")
+
+  " 3i( in front of a block doesn't enter third but un-nested '('
+  call setline(1, 'foo (bar (baz) (quux))')
+  normal 03di)
+  call assert_equal('foo (bar (baz) (quux))', getline(1))
+  normal 02di)
+  call assert_equal('foo (bar () (quux))', getline(1))
+  normal 0di)
+  call assert_equal('foo ()', getline(1))
+
+  close!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    ci" finds following string but ci< and others don't.
Solution:   When not inside an object find the start. (Connor Lane Smit,
            closes vim/vim#8670)
https://github.com/vim/vim/commit/b9115da4bec5e6cfff69da85cc47c42dd67e42e4