### PR TITLE
vim-patch:8.2.3598,3599,3600: some filetypes are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -643,7 +643,7 @@ au BufNewFile,BufRead *.fsl			setf framescript
 au BufNewFile,BufRead fstab,mtab		setf fstab
 
 " GDB command files
-au BufNewFile,BufRead .gdbinit			setf gdb
+au BufNewFile,BufRead .gdbinit,gdbinit		setf gdb
 
 " GDMO
 au BufNewFile,BufRead *.mo,*.gdmo		setf gdmo

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1486,6 +1486,9 @@ au BufNewFile,BufRead robots.txt		setf robots
 " Rpcgen
 au BufNewFile,BufRead *.x			setf rpcgen
 
+" MikroTik RouterOS script
+au BufRead,BufNewFile *.rsc			setf routeros
+
 " reStructuredText Documentation Format
 au BufNewFile,BufRead *.rst			setf rst
 

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -190,6 +190,10 @@ if s:line1 =~# "^#!"
   elseif s:name =~# 'fennel\>'
     set ft=fennel
 
+    " MikroTik RouterOS script
+  elseif s:name =~# 'rsc\>'
+    set ft=routeros
+
   endif
   unlet s:name
 
@@ -389,6 +393,10 @@ else
   " YAML
   elseif s:line1 =~# '^%YAML'
     set ft=yaml
+
+  " MikroTik RouterOS script
+  elseif s:line1 =~# '^#.*by RouterOS.*$'
+    set ft=routeros
 
   " CVS diff
   else

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -419,6 +419,7 @@ let s:filename_checks = {
     \ 'rnc': ['file.rnc'],
     \ 'rng': ['file.rng'],
     \ 'robots': ['robots.txt'],
+    \ 'routeros': ['file.rsc'],
     \ 'rpcgen': ['file.x'],
     \ 'rpl': ['file.rpl'],
     \ 'rst': ['file.rst'],
@@ -659,6 +660,7 @@ let s:script_checks = {
       \ 'yaml': [['%YAML 1.2']],
       \ 'pascal': [['#!/path/instantfpc']],
       \ 'fennel': [['#!/path/fennel']],
+      \ 'routeros': [['#!/path/rsc']],
       \ }
 
 " Various forms of "env" optional arguments.

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -188,7 +188,7 @@ let s:filename_checks = {
     \ 'freebasic': ['file.fb', 'file.bi'],
     \ 'fstab': ['fstab', 'mtab'],
     \ 'fvwm': ['/.fvwm/file', 'any/.fvwm/file'],
-    \ 'gdb': ['.gdbinit'],
+    \ 'gdb': ['.gdbinit', 'gdbinit'],
     \ 'gdmo': ['file.mo', 'file.gdmo'],
     \ 'gedcom': ['file.ged', 'lltxxxxx.txt', '/tmp/lltmp', '/tmp/lltmp-file', 'any/tmp/lltmp', 'any/tmp/lltmp-file'],
     \ 'gemtext': ['file.gmi', 'file.gemini'],


### PR DESCRIPTION
Problem:    RouterOS filetype is not recognized.
Solution:   Add file and script patterns. (closes vim/vim#9097)
https://github.com/vim/vim/commit/0818ab82e7058145366ebbe759f0b3f74724bdfd

Problem:    Not all gdbinit files are recognized.
Solution:   Add "gdbinit". (Doug Kearns)
https://github.com/vim/vim/commit/782b4bbc163e03ebe98d25bc62b9d82cba8f91a1

Problem:    Filetype test fails.
Solution:   Add missint change.
https://github.com/vim/vim/commit/314b773abbb9b1ce0020d83482c6daf7ad6a42a2
