### PR TITLE
docs: fix two typos in eval.txt

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -8970,7 +8970,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		Otherwise encloses {string} in single-quotes and replaces all
 		"'" with "'\''".
 
-		If {special} is a ||non-zero-arg|:
+		If {special} is a |non-zero-arg|:
 		- Special items such as "!", "%", "#" and "<cword>" will be
 		  preceded by a backslash. The backslash will be removed again
 		  by the |:!| command.
@@ -8980,7 +8980,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		- The "!" character will be escaped. This is because csh and
 		  tcsh use "!" for history replacement even in single-quotes.
 		- The <NL> character is escaped (twice if {special} is
-		  a ||non-zero-arg|).
+		  a |non-zero-arg|).
 
 		If 'shell' contains "fish" in the tail, the "\" character will
 		be escaped because in fish it is used as an escape character


### PR DESCRIPTION
From <https://github.com/neovim/neovim/commit/c2662210b5af8aeced68c9cae540567496926a44>.