### PR TITLE
vim-patch: missing changes to src/nvim/po/check.vim from 01164a6546b4

### DIFF
--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -162,7 +162,10 @@ endwhile
 " Check that the file is well formed according to msgfmts understanding
 if executable("msgfmt")
   let filename = expand("%")
-  let a = system("msgfmt --statistics OLD_PO_FILE_INPUT=yes " . filename)
+  " Newer msgfmt does not take OLD_PO_FILE_INPUT argument, must be in
+  " environment.
+  let $OLD_PO_FILE_INPUT = 'yes'
+  let a = system("msgfmt --statistics " . filename)
   if v:shell_error != 0
     let error = matchstr(a, filename.':\zs\d\+\ze:')+0
     for line in split(a, '\n') | echomsg line | endfor


### PR DESCRIPTION
Fix #14187

https://github.com/vim/vim/commit/01164a6546b4c635daf96a1f17d1cb2d07f32a66#diff-ed3e88d59856bb5b62b2a394fb8c7293cd5794531e0718c0aa2d3d768d7973d1

Missing from <https://github.com/neovim/neovim/commit/4175dfac9a91e30d01e5aec6b45ed81e0288aaf9>.