### PR TITLE
vim-patch:8.2.3603: fish filetype not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -613,6 +613,9 @@ autocmd BufRead,BufNewFile *.fnl		setf fennel
 " Fetchmail RC file
 au BufNewFile,BufRead .fetchmailrc		setf fetchmail
 
+" Fish shell
+au BufNewFile,BufRead *.fish			setf fish
+
 " FlexWiki - disabled, because it has side effects when a .wiki file
 " is not actually FlexWiki
 "au BufNewFile,BufRead *.wiki			setf flexwiki

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -194,6 +194,10 @@ if s:line1 =~# "^#!"
   elseif s:name =~# 'rsc\>'
     set ft=routeros
 
+    " Fish shell
+  elseif s:name =~# 'fish\>'
+    set ft=fish
+
   endif
   unlet s:name
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -180,6 +180,7 @@ let s:filename_checks = {
     \ 'fennel': ['file.fnl'],
     \ 'fetchmail': ['.fetchmailrc'],
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],
+    \ 'fish': ['file.fish'],
     \ 'focexec': ['file.fex', 'file.focexec'],
     \ 'forth': ['file.fs', 'file.ft', 'file.fth'],
     \ 'fortran': ['file.f', 'file.for', 'file.fortran', 'file.fpp', 'file.ftn', 'file.f77', 'file.f90', 'file.f95', 'file.f03', 'file.f08'],
@@ -661,6 +662,7 @@ let s:script_checks = {
       \ 'pascal': [['#!/path/instantfpc']],
       \ 'fennel': [['#!/path/fennel']],
       \ 'routeros': [['#!/path/rsc']],
+      \ 'fish': [['#!/path/fish']],
       \ }
 
 " Various forms of "env" optional arguments.


### PR DESCRIPTION
Problem:    Fish filetype not recognized.
Solution:   Add a file pattern and match script line. (Doug Kearns)
https://github.com/vim/vim/commit/b1b163efd7bb3ca68cce101d4e431559d2944a8e