### PR TITLE
vim-patch:519cc559b08b

### DIFF
--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -1,7 +1,7 @@
 " zip.vim: Handles browsing zipfiles
 "            AUTOLOAD PORTION
-" Date:		Jan 07, 2020
-" Version:	31
+" Date:		Nov 08, 2021
+" Version:	32
 " Maintainer:	Charles E Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " License:	Vim License  (see vim's :help license)
 " Copyright:    Copyright (C) 2005-2019 Charles E. Campbell {{{1
@@ -20,7 +20,7 @@
 if &cp || exists("g:loaded_zip")
  finish
 endif
-let g:loaded_zip= "v31"
+let g:loaded_zip= "v32"
 if v:version < 702
  echohl WarningMsg
  echo "***warning*** this version of zip needs vim 7.2 or later"
@@ -115,7 +115,13 @@ fun! zip#Browse(zipfile)
   setlocal bufhidden=hide
   setlocal nobuflisted
   setlocal nowrap
-  set ft=tar
+
+  " Oct 12, 2021: need to re-use Bram's syntax/tar.vim.
+  " Setting the filetype to zip doesn't do anything (currently),
+  " but it is perhaps less confusing to curious perusers who do
+  " a :echo &ft
+  setf zip
+  run! syntax/tar.vim
 
   " give header
   call append(0, ['" zip.vim version '.g:loaded_zip,
@@ -187,8 +193,8 @@ fun! s:ZipBrowseSelect()
    wincmd _
   endif
   let s:zipfile_{winnr()}= curfile
-"  call Decho("exe e ".fnameescape("zipfile:".zipfile.'::'.fname))
-  exe "noswapfile e ".fnameescape("zipfile:".zipfile.'::'.fname)
+"  call Decho("exe e ".fnameescape("zipfile://".zipfile.'::'.fname))
+  exe "noswapfile e ".fnameescape("zipfile://".zipfile.'::'.fname)
   filetype detect
 
   let &report= repkeep
@@ -203,11 +209,11 @@ fun! zip#Read(fname,mode)
   set report=10
 
   if has("unix")
-   let zipfile = substitute(a:fname,'zipfile:\(.\{-}\)::[^\\].*$','\1','')
-   let fname   = substitute(a:fname,'zipfile:.\{-}::\([^\\].*\)$','\1','')
+   let zipfile = substitute(a:fname,'zipfile://\(.\{-}\)::[^\\].*$','\1','')
+   let fname   = substitute(a:fname,'zipfile://.\{-}::\([^\\].*\)$','\1','')
   else
-   let zipfile = substitute(a:fname,'^.\{-}zipfile:\(.\{-}\)::[^\\].*$','\1','')
-   let fname   = substitute(a:fname,'^.\{-}zipfile:.\{-}::\([^\\].*\)$','\1','')
+   let zipfile = substitute(a:fname,'^.\{-}zipfile://\(.\{-}\)::[^\\].*$','\1','')
+   let fname   = substitute(a:fname,'^.\{-}zipfile://.\{-}::\([^\\].*\)$','\1','')
    let fname   = substitute(fname, '[', '[[]', 'g')
   endif
 "  call Decho("zipfile<".zipfile.">")
@@ -224,7 +230,7 @@ fun! zip#Read(fname,mode)
 
   " the following code does much the same thing as
   "   exe "keepj sil! r! ".g:zip_unzipcmd." -p -- ".s:Escape(zipfile,1)." ".s:Escape(fnameescape(fname),1)
-  " but allows zipfile:... entries in quickfix lists
+  " but allows zipfile://... entries in quickfix lists
   let temp = tempname()
 "  call Decho("using temp file<".temp.">")
   let fn   = expand('%:p')
@@ -296,11 +302,11 @@ fun! zip#Write(fname)
 "  call Decho("current directory now: ".getcwd())
 
   if has("unix")
-   let zipfile = substitute(a:fname,'zipfile:\(.\{-}\)::[^\\].*$','\1','')
-   let fname   = substitute(a:fname,'zipfile:.\{-}::\([^\\].*\)$','\1','')
+   let zipfile = substitute(a:fname,'zipfile://\(.\{-}\)::[^\\].*$','\1','')
+   let fname   = substitute(a:fname,'zipfile://.\{-}::\([^\\].*\)$','\1','')
   else
-   let zipfile = substitute(a:fname,'^.\{-}zipfile:\(.\{-}\)::[^\\].*$','\1','')
-   let fname   = substitute(a:fname,'^.\{-}zipfile:.\{-}::\([^\\].*\)$','\1','')
+   let zipfile = substitute(a:fname,'^.\{-}zipfile://\(.\{-}\)::[^\\].*$','\1','')
+   let fname   = substitute(a:fname,'^.\{-}zipfile://.\{-}::\([^\\].*\)$','\1','')
   endif
 "  call Decho("zipfile<".zipfile.">")
 "  call Decho("fname  <".fname.">")

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10291,7 +10291,9 @@ wildmenumode()					*wildmenumode()*
 win_execute({id}, {command} [, {silent}])		*win_execute()*
 		Like `execute()` but in the context of window {id}.
 		The window will temporarily be made the current window,
-		without triggering autocommands.
+		without triggering autocommands or changing directory.  When
+		executing {command} autocommands will be triggered, this may
+		have unexpected side effects.  Use |:noautocmd| if needed.
 		Example: >
 			call win_execute(winid, 'syntax enable')
 

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -319,21 +319,25 @@ Hints for translators:
 3. Writing help files					*help-writing*
 
 For ease of use, a Vim help file for a plugin should follow the format of the
-standard Vim help files.  If you are writing a new help file it's best to copy
-one of the existing files and use it as a template.
+standard Vim help files, except fot the fist line.  If you are writing a new
+help file it's best to copy one of the existing files and use it as a
+template.
 
 The first line in a help file should have the following format:
 
-*helpfile_name.txt*	For Vim version 7.3	Last change: 2010 June 4
+*plugin_name.txt*	{short description of the plugin}
 
-The first field is a link to the help file name.  The second field describes
-the applicable Vim version.  The last field specifies the last modification
-date of the file.  Each field is separated by a tab.
+The first field is a help tag where ":help plugin_name" will jump to.  The
+remainder of the line, after a Tab, describes the plugin purpose in a short
+way.  This will show up in the "LOCAL ADDITIONS" section of the main help
+file.  Check there that it shows up properly: |local-additions|.
+
+If you want to add a version number of last modification date, put it in the
+second line, right aligned.
 
 At the bottom of the help file, place a Vim modeline to set the 'textwidth'
 and 'tabstop' options and the 'filetype' to "help".  Never set a global option
-in such a modeline, that can have consequences undesired by whoever reads that
-help.
+in such a modeline, that can have undesired consequences.
 
 
 TAGS

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -45,6 +45,11 @@ To see what version of Python you have: >
 
 There is no need to "import sys", it's done by default.
 
+							*python-environment*
+Environment variables set in Vim are not always available in Python.  This
+depends on how Vim and Python were build.  Also see
+https://docs.python.org/3/library/os.html#os.environ
+
 Note: Python is very sensitive to indenting.  Make sure the "class" line and
 "EOF" do not have any indent.
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -46,6 +46,8 @@ modes.
 			where the map command applies.  The result, including
 			{rhs}, is then further scanned for mappings.  This
 			allows for nested and recursive use of mappings.
+			Note: Trailing spaces are included in the {rhs},
+			because space is a valid Normal mode command.
 
 						*:nore* *:norem*
 :no[remap]  {lhs} {rhs}		|mapmode-nvo|	*:no*  *:noremap* *:nor*
@@ -1419,6 +1421,7 @@ Possible values are (second column is the short name used in listing):
 Special cases ~
 					*:command-bang* *:command-bar*
 					*:command-register* *:command-buffer*
+					*:command-keepscript*
 There are some special cases as well:
 
 	-bang	    The command can take a ! modifier (like :q or :w)

--- a/runtime/doc/pi_zip.txt
+++ b/runtime/doc/pi_zip.txt
@@ -102,6 +102,9 @@ Copyright: Copyright (C) 2005-2015 Charles E Campbell	 *zip-copyright*
 
 ==============================================================================
 4. History							*zip-history* {{{1
+   v32 Oct 22, 2021 * to avoid an issue with a vim 8.2 patch, zipfile: has
+   		      been changed to zipfile:// . This often shows up
+		      as zipfile:/// with zipped files that are root-based.
    v29 Apr 02, 2017 * (Klartext) reported that an encrypted zip file could
    		      opened but the swapfile held unencrypted contents.
 		      The solution is to edit the contents of a zip file

--- a/runtime/doc/usr_20.txt
+++ b/runtime/doc/usr_20.txt
@@ -289,11 +289,11 @@ In chapter 3 we briefly mentioned the history.  The basics are that you can
 use the <Up> key to recall an older command line.  <Down> then takes you back
 to newer commands.
 
-There are actually four histories.  The ones we will mention here are for ":"
+There are actually five histories.  The ones we will mention here are for ":"
 commands and for "/" and "?" search commands.  The "/" and "?" commands share
-the same history, because they are both search commands.  The two other
-histories are for expressions and input lines for the input() function.
-|cmdline-history|
+the same history, because they are both search commands.  The three other
+histories are for expressions, debug more commands and input lines for the
+input() function.  |cmdline-history|
 
 Suppose you have done a ":set" command, typed ten more colon commands and then
 want to repeat that ":set" command again.  You could press ":" and then ten

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Oct 03
+" Last Change:	2021 Nov 16
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/ftplugin/aap.vim
+++ b/runtime/ftplugin/aap.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Aap recipe
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2013 Apr 05
+" Last Change:	2021 Nov 14
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -11,8 +11,9 @@ endif
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-" Reset 'formatoptions', 'comments' and 'expandtab' to undo this plugin.
-let b:undo_ftplugin = "setl fo< com< et<"
+" Reset 'formatoptions', 'comments', 'commentstring' and 'expandtab' to undo
+" this plugin.
+let b:undo_ftplugin = "setl fo< com< cms< et<"
 
 " Set 'formatoptions' to break comment lines but not other lines,
 " and insert the comment leader when hitting <CR> or using "o".
@@ -20,6 +21,12 @@ setlocal fo-=t fo+=croql
 
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=s:#\ -,m:#\ \ ,e:#,n:#,fb:-
+setlocal commentstring=#\ %s
 
 " Expand tabs to spaces to avoid trouble.
 setlocal expandtab
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Aap Recipe Files (*.aap)\t*.aap\nAll Files (*.*)\t*.*\n"
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif

--- a/runtime/ftplugin/diff.vim
+++ b/runtime/ftplugin/diff.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Diff
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2020 Jul 18
+" Last Change:	2021 Nov 14
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -9,10 +9,15 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl modeline<"
+let b:undo_ftplugin = "setl modeline< commentstring<"
 
 " Don't use modelines in a diff, they apply to the diffed file
 setlocal nomodeline
 
 " If there are comments they start with #
-let &commentstring = "# %s"
+let &l:commentstring = "# %s"
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Diff Files (*.diff)\t*.diff\nPatch Files (*.patch)\t*.h\nAll Files (*.*)\t*.*\n"
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file.
-" Language:	Lua 4.0+
-" Maintainer:	Max Ischenko <mfi@ukr.net>
-" Last Change:	2012 Mar 07
+" Language:	        Lua
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Previous Maintainer:	Max Ischenko <mfi@ukr.net>
+" Last Change:	        2021 Nov 15
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -16,27 +17,30 @@ set cpo&vim
 
 " Set 'formatoptions' to break comment lines but not other lines, and insert
 " the comment leader when hitting <CR> or using "o".
-setlocal fo-=t fo+=croql
+setlocal formatoptions-=t formatoptions+=croql
 
-setlocal com=:--
-setlocal cms=--%s
+setlocal comments=:--
+setlocal commentstring=--%s
 setlocal suffixesadd=.lua
 
+let b:undo_ftplugin = "setlocal fo< com< cms< sua<"
 
-" The following lines enable the macros/matchit.vim plugin for
-" extended matching with the % key.
-if exists("loaded_matchit")
-
+if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
   let b:match_words =
-    \ '\<\%(do\|function\|if\)\>:' .
-    \ '\<\%(return\|else\|elseif\)\>:' .
-    \ '\<end\>,' .
-    \ '\<repeat\>:\<until\>'
+        \ '\<\%(do\|function\|if\)\>:' .
+        \ '\<\%(return\|else\|elseif\)\>:' .
+        \ '\<end\>,' .
+        \ '\<repeat\>:\<until\>,' .
+        \ '\%(--\)\=\[\(=*\)\[:]\1]'
+  let b:undo_ftplugin .= " | unlet! b:match_words b:match_ignorecase"
+endif
 
-endif " exists("loaded_matchit")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Lua Source Files (*.lua)\t*.lua\n" .
+	\              "All Files (*.*)\t*.*\n"
+  let b:undo_ftplugin .= " | unlet! b:browsefilter"
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-
-let b:undo_ftplugin = "setlocal fo< com< cms< suffixesadd<"

--- a/runtime/ftplugin/routeros.vim
+++ b/runtime/ftplugin/routeros.vim
@@ -1,0 +1,29 @@
+" Vim filetype plugin file
+" Language:	MikroTik RouterOS Script
+" Maintainer:	zainin <z@wintr.dev>
+" Last Change:	2021 Nov 14
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:save_cpo = &cpo
+set cpo-=C
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setlocal com< cms< fo<"
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "RouterOS Script Files (*.rsc)\t*.rsc\n" ..
+	\	       "All Files (*.*)\t*.*\n"
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:save_cpo
+unlet! s:save_cpo
+
+" vim: nowrap sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/zimbu.vim
+++ b/runtime/ftplugin/zimbu.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Zimbu
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2017 Dec 05
+" Last Change:	2021 Nov 12
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -34,9 +34,11 @@ setlocal errorformat^=%f\ line\ %l\ col\ %c:\ %m,ERROR:\ %m
 
 " When the matchit plugin is loaded, this makes the % command skip parens and
 " braces in comments.
-let b:match_words = '\(^\s*\)\@<=\(MODULE\|CLASS\|INTERFACE\|BITS\|ENUM\|SHARED\|FUNC\|REPLACE\|DEFINE\|PROC\|EQUAL\|MAIN\|IF\|GENERATE_IF\|WHILE\|REPEAT\|WITH\|DO\|FOR\|SWITCH\|TRY\)\>\|{\s*$:\(^\s*\)\@<=\(ELSE\|ELSEIF\|GENERATE_ELSE\|GENERATE_ELSEIF\|CATCH\|FINALLY\)\>:\(^\s*\)\@<=\(}\|\<UNTIL\>\)'
-
-let b:match_skip = 's:comment\|string\|zimbuchar'
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_words = '\(^\s*\)\@<=\(MODULE\|CLASS\|INTERFACE\|BITS\|ENUM\|SHARED\|FUNC\|REPLACE\|DEFINE\|PROC\|EQUAL\|MAIN\|IF\|GENERATE_IF\|WHILE\|REPEAT\|WITH\|DO\|FOR\|SWITCH\|TRY\)\>\|{\s*$:\(^\s*\)\@<=\(ELSE\|ELSEIF\|GENERATE_ELSE\|GENERATE_ELSEIF\|CATCH\|FINALLY\)\>:\(^\s*\)\@<=\(}\|\<UNTIL\>\)'
+  let b:match_skip = 's:comment\|string\|zimbuchar'
+  let b:undo_ftplugin ..= " | unlet! b:match_words b:match_skip"
+endif
 
 setlocal tw=78
 setlocal et sts=2 sw=2
@@ -135,9 +137,60 @@ iabbr <buffer> <expr> until GCUpperSpace("until")
 iabbr <buffer> <expr> while GCUpperSpace("while")
 iabbr <buffer> <expr> repeat GCUpper("repeat")
 
+let b:undo_ftplugin ..=
+      \ " | iunabbr <buffer> alias" ..
+      \ " | iunabbr <buffer> arg" ..
+      \ " | iunabbr <buffer> break" ..
+      \ " | iunabbr <buffer> case" ..
+      \ " | iunabbr <buffer> catch" ..
+      \ " | iunabbr <buffer> check" ..
+      \ " | iunabbr <buffer> class" ..
+      \ " | iunabbr <buffer> interface" ..
+      \ " | iunabbr <buffer> implements" ..
+      \ " | iunabbr <buffer> shared" ..
+      \ " | iunabbr <buffer> continue" ..
+      \ " | iunabbr <buffer> default" ..
+      \ " | iunabbr <buffer> extends" ..
+      \ " | iunabbr <buffer> do" ..
+      \ " | iunabbr <buffer> else" ..
+      \ " | iunabbr <buffer> elseif" ..
+      \ " | iunabbr <buffer> enum" ..
+      \ " | iunabbr <buffer> exit" ..
+      \ " | iunabbr <buffer> false" ..
+      \ " | iunabbr <buffer> fail" ..
+      \ " | iunabbr <buffer> finally" ..
+      \ " | iunabbr <buffer> for" ..
+      \ " | iunabbr <buffer> func" ..
+      \ " | iunabbr <buffer> if" ..
+      \ " | iunabbr <buffer> import" ..
+      \ " | iunabbr <buffer> in" ..
+      \ " | iunabbr <buffer> io" ..
+      \ " | iunabbr <buffer> main" ..
+      \ " | iunabbr <buffer> module" ..
+      \ " | iunabbr <buffer> new" ..
+      \ " | iunabbr <buffer> nil" ..
+      \ " | iunabbr <buffer> ok" ..
+      \ " | iunabbr <buffer> proc" ..
+      \ " | iunabbr <buffer> proceed" ..
+      \ " | iunabbr <buffer> return" ..
+      \ " | iunabbr <buffer> step" ..
+      \ " | iunabbr <buffer> switch" ..
+      \ " | iunabbr <buffer> sys" ..
+      \ " | iunabbr <buffer> this" ..
+      \ " | iunabbr <buffer> throw" ..
+      \ " | iunabbr <buffer> try" ..
+      \ " | iunabbr <buffer> to" ..
+      \ " | iunabbr <buffer> true" ..
+      \ " | iunabbr <buffer> until" ..
+      \ " | iunabbr <buffer> while" ..
+      \ " | iunabbr <buffer> repeat"
+
 if !exists("no_plugin_maps") && !exists("no_zimbu_maps")
   nnoremap <silent> <buffer> [[ m`:call ZimbuGoStartBlock()<CR>
   nnoremap <silent> <buffer> ]] m`:call ZimbuGoEndBlock()<CR>
+  let b:undo_ftplugin ..=
+	\ " | silent! exe 'nunmap <buffer> [['" ..
+	\ " | silent! exe 'nunmap <buffer> ]]'"
 endif
 
 " Using a function makes sure the search pattern is restored

--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -1,10 +1,10 @@
-*matchit.txt*   Extended "%" matching
+*matchit.txt*	Extended "%" matching
 
 For instructions on installing this file, type
 	`:help matchit-install`
 inside Vim.
 
-For Vim version 8.1.  Last change:  2021 May 17
+For Vim version 8.1.  Last change:  2021 Nov 13
 
 
 		  VIM REFERENCE MANUAL    by Benji Fisher et al

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2021 Oct 26
+" Last Change: 2021 Nov 14
 "
 " WORK IN PROGRESS - Only the basics work
 " Note: On MS-Windows you need a recent version of gdb.  The one included with
@@ -1191,6 +1191,7 @@ func s:GotoAsmwinOrCreateIt()
     setlocal number
     setlocal noswapfile
     setlocal buftype=nofile
+    setlocal modifiable
 
     let asmbuf = bufnr('Termdebug-asm-listing')
     if asmbuf > 0
@@ -1273,6 +1274,7 @@ func s:HandleCursor(msg)
         endif
       endif
       exe lnum
+      normal! zv
       exe 'sign unplace ' . s:pc_id
       exe 'sign place ' . s:pc_id . ' line=' . lnum . ' name=debugPC file=' . fname
       if !exists('b:save_signcolumn')

--- a/runtime/plugin/zipPlugin.vim
+++ b/runtime/plugin/zipPlugin.vim
@@ -20,7 +20,7 @@
 if &cp || exists("g:loaded_zipPlugin")
  finish
 endif
-let g:loaded_zipPlugin = "v31"
+let g:loaded_zipPlugin = "v32"
 let s:keepcpo          = &cpo
 set cpo&vim
 

--- a/runtime/syntax/autoit.vim
+++ b/runtime/syntax/autoit.vim
@@ -5,6 +5,7 @@
 " Authored By:	Riccardo Casini <ric@libero.it>
 " Script URL:	http://www.vim.org/scripts/script.php?script_id=1239
 " ChangeLog:	Please visit the script URL for detailed change information
+" 		Included change from #970.
 
 " Quit when a syntax file was already loaded.
 if exists("b:current_syntax")
@@ -932,7 +933,7 @@ syn match autoitConst "\$SD_POWERDOWN"
 " constants - string
 syn match autoitConst "\$STR_NOCASESENSE"
 syn match autoitConst "\$STR_CASESENSE"
-syn match autoitConst "\STR_STRIPLEADING"
+syn match autoitConst "\$STR_STRIPLEADING"
 syn match autoitConst "\$STR_STRIPTRAILING"
 syn match autoitConst "\$STR_STRIPSPACES"
 syn match autoitConst "\$STR_STRIPALL"

--- a/runtime/syntax/gdb.vim
+++ b/runtime/syntax/gdb.vim
@@ -2,7 +2,8 @@
 " Language:	GDB command files
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:		http://www.fleiner.com/vim/syntax/gdb.vim
-" Last Change:	2012 Oct 05
+" Last Change:	2021 Nov 15
+" 		Additional changes by Simon Sobisch
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -21,19 +22,19 @@ syn match gdbInfo contained "all-registers"
 
 
 syn keyword gdbStatement contained actions apply attach awatch backtrace break bt call catch cd clear collect commands
-syn keyword gdbStatement contained complete condition continue delete detach directory disable disassemble display down
+syn keyword gdbStatement contained complete condition continue delete detach directory disable disas[semble] disp[lay] down
 syn keyword gdbStatement contained echo else enable end file finish frame handle hbreak help if ignore
 syn keyword gdbStatement contained inspect jump kill list load maintenance make next nexti ni output overlay
-syn keyword gdbStatement contained passcount path print printf ptype pwd quit rbreak remote return run rwatch
-syn keyword gdbStatement contained search section set sharedlibrary shell show si signal source step stepi stepping
+syn keyword gdbStatement contained passcount path print printf ptype python pwd quit rbreak remote return run rwatch
+syn keyword gdbStatement contained search section set sharedlibrary shell show si signal skip source step stepi stepping
 syn keyword gdbStatement contained stop target tbreak tdump tfind thbreak thread tp trace tstart tstatus tstop
-syn keyword gdbStatement contained tty undisplay unset until up watch whatis where while ws x
+syn keyword gdbStatement contained tty und[isplay] unset until up watch whatis where while ws x
 syn match gdbFuncDef "\<define\>.*"
 syn match gdbStatmentContainer "^\s*\S\+" contains=gdbStatement,gdbFuncDef
 syn match gdbStatement "^\s*info" nextgroup=gdbInfo skipwhite skipempty
 
 " some commonly used abbreviations
-syn keyword gdbStatement c disp undisp disas p
+syn keyword gdbStatement c cont p py
 
 syn region gdbDocument matchgroup=gdbFuncDef start="\<document\>.*$" matchgroup=gdbFuncDef end="^end\s*$"
 

--- a/runtime/syntax/gnuplot.vim
+++ b/runtime/syntax/gnuplot.vim
@@ -3,7 +3,8 @@
 " Maintainer:	Josh Wainwright <wainwright DOT ja AT gmail DOT com>
 " Last Maintainer:	Andrew Rasmussen andyras@users.sourceforge.net
 " Original Maintainer:	John Hoelzel johnh51@users.sourceforge.net
-" Last Change:	2020 May 12
+" Last Change:	2021 Nov 16
+" 		additional changes from PR #8949
 " Filenames:	*.gnu *.plt *.gpi *.gih *.gp *.gnuplot scripts: #!*gnuplot
 " URL:		http://www.vim.org/scripts/script.php?script_id=4873
 " Original URL:	http://johnh51.get.to/vim/syntax/gnuplot.vim
@@ -32,22 +33,22 @@ syn match gnuplotSpecial	"\\." contained
 " syn match gnuplotSpecial	"\\\o\o\o\|\\x\x\x\|\\c[^"]\|\\[a-z\\]" contained
 
 " measurements in the units in, cm and pt are special
-syn match gnuplotUnit		"[0-9]+in"
-syn match gnuplotUnit		"[0-9]+cm"
-syn match gnuplotUnit		"[0-9]+pt"
+syn match gnuplotUnit		"\d+in"
+syn match gnuplotUnit		"\d+cm"
+syn match gnuplotUnit		"\d+pt"
 
 " external (shell) commands are special
-syn region gnuplotExternal	start="!" end="$"
+syn region gnuplotExternal	start="^\s*!" end="$"
 
 " ---- Comments ---- "
 
-syn region gnuplotComment	start="#" end="$" contains=gnuplotTodo
+syn region gnuplotComment	start="#" end="$" contains=gnuplotTodo,@Spell
 
 " ---- Constants ---- "
 
 " strings
-syn region gnuplotString	start=+"+ skip=+\\"+ end=+"+ contains=gnuplotSpecial
-syn region gnuplotString	start="'" end="'"
+syn region gnuplotString	start=+"+ skip=+\\"+ end=+"+ contains=gnuplotSpecial,@Spell
+syn region gnuplotString	start="'" end="'" contains=@Spell
 
 " built-in variables
 syn keyword gnuplotNumber	GNUTERM GPVAL_TERM GPVAL_TERMOPTIONS GPVAL_SPLOT
@@ -76,7 +77,7 @@ syn keyword gnuplotNumber	GPVAL_TERM_YSIZE GPVAL_VIEW_MAP GPVAL_VIEW_ROT_X
 syn keyword gnuplotNumber	GPVAL_VIEW_ROT_Z GPVAL_VIEW_SCALE
 
 " function name variables
-syn match gnuplotNumber		"GPFUN_[a-zA-Z_]*"
+syn match gnuplotNumber		"GPFUN_\h*"
 
 " stats variables
 syn keyword gnuplotNumber	STATS_records STATS_outofrange STATS_invalid
@@ -104,23 +105,23 @@ syn keyword gnuplotError	FIT_LAMBDA_FACTOR FIT_LOG FIT_SCRIPT
 
 " integer number, or floating point number without a dot and with "f".
 syn case    ignore
-syn match   gnuplotNumber	"\<[0-9]\+\(u\=l\=\|lu\|f\)\>"
+syn match   gnuplotNumber	"\<\d\+\(u\=l\=\|lu\|f\)\>"
 
 " floating point number, with dot, optional exponent
-syn match   gnuplotFloat	"\<[0-9]\+\.[0-9]*\(e[-+]\=[0-9]\+\)\=[fl]\=\>"
+syn match   gnuplotFloat	"\<\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\=\>"
 
 " floating point number, starting with a dot, optional exponent
-syn match   gnuplotFloat	"\.[0-9]\+\(e[-+]\=[0-9]\+\)\=[fl]\=\>"
+syn match   gnuplotFloat	"\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
 
 " floating point number, without dot, with exponent
-syn match   gnuplotFloat	"\<[0-9]\+e[-+]\=[0-9]\+[fl]\=\>"
+syn match   gnuplotFloat	"\<\d\+e[-+]\=\d\+[fl]\=\>"
 
 " hex number
-syn match   gnuplotNumber	"\<0x[0-9a-f]\+\(u\=l\=\|lu\)\>"
+syn match   gnuplotNumber	"\<0x\x\+\(u\=l\=\|lu\)\>"
 syn case    match
 
 " flag an octal number with wrong digits by not highlighting
-syn match   gnuplotOctalError	"\<0[0-7]*[89]"
+syn match   gnuplotOctalError	"\<0\o*[89]"
 
 " ---- Identifiers: Functions ---- "
 
@@ -374,8 +375,8 @@ syn keyword gnuplotKeyword	nohead nooutliers nowedge off opaque outliers
 syn keyword gnuplotKeyword	palette pattern pi pointinterval pointsize
 syn keyword gnuplotKeyword	pointtype ps pt radius range rectangle
 syn keyword gnuplotKeyword	rowstacked screen separation size solid sorted
-syn keyword gnuplotKeyword	textbox transparent units unsorted userstyles
-syn keyword gnuplotKeyword	wedge x x2 xx xy yy
+syn keyword gnuplotKeyword	textbox units unsorted userstyles wedge
+syn keyword gnuplotKeyword	x x2 xx xy yy
 " set surface
 syn keyword gnuplotKeyword	surface implicit explicit
 " set table
@@ -477,9 +478,13 @@ syn keyword gnuplotKeyword	nooutput
 " keywords for 'test' command
 syn keyword gnuplotKeyword	terminal palette rgb rbg grb gbr brg bgr
 
+" The transparent gnuplot keyword cannot use 'syn keyword' as transparent
+" has a special meaning in :syntax commands.
+syn match gnuplotKeyword	"\<transparent\>"
+
 " ---- Macros ---- "
 
-syn match gnuplotMacro		"@[a-zA-Z0-9_]*"
+syn match gnuplotMacro		"@\w*"
 
 " ---- Todos ---- "
 

--- a/runtime/syntax/lisp.vim
+++ b/runtime/syntax/lisp.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language:    Lisp
 " Maintainer:  Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
-" Last Change: Jul 11, 2019
-" Version:     30
+" Last Change: Nov 10, 2021
+" Version:     31
 " URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_LISP
 "
 "  Thanks to F Xavier Noria for a list of 978 Common Lisp symbols taken from HyperSpec
@@ -54,20 +54,20 @@ if exists("g:lisp_rainbow") && g:lisp_rainbow != 0
  syn region lispParen8 contained matchgroup=hlLevel8 start="`\=(" end=")" skip="|.\{-}|" contains=@lispListCluster,lispParen9
  syn region lispParen9 contained matchgroup=hlLevel9 start="`\=(" end=")" skip="|.\{-}|" contains=@lispListCluster,lispParen0
 else
- syn region lispList			matchgroup=lispParen start="("   skip="|.\{-}|"			matchgroup=lispParen end=")"	contains=@lispListCluster
- syn region lispBQList			matchgroup=PreProc   start="`("  skip="|.\{-}|"			matchgroup=PreProc   end=")"		contains=@lispListCluster
+ syn region lispList		matchgroup=lispParen start="("   skip="|.\{-}|"		matchgroup=lispParen end=")"	contains=@lispListCluster
+ syn region lispBQList		matchgroup=PreProc   start="`("  skip="|.\{-}|"		matchgroup=PreProc   end=")"	contains=@lispListCluster
 endif
 
 " ---------------------------------------------------------------------
 " Atoms: {{{1
-syn match lispAtomMark			"'"
-syn match lispAtom			"'("me=e-1			contains=lispAtomMark	nextgroup=lispAtomList
-syn match lispAtom			"'[^ \t()]\+"			contains=lispAtomMark
-syn match lispAtomBarSymbol		!'|..\{-}|!			contains=lispAtomMark
-syn region lispAtom			start=+'"+			skip=+\\"+ end=+"+
-syn region lispAtomList			contained			matchgroup=Special start="("	skip="|.\{-}|" matchgroup=Special end=")"	contains=@lispAtomCluster,lispString,lispEscapeSpecial
-syn match lispAtomNmbr			contained			"\<\d\+"
-syn match lispLeadWhite			contained			"^\s\+"
+syn match lispAtomMark		"'"
+syn match lispAtom		"'("me=e-1			contains=lispAtomMark	nextgroup=lispAtomList
+syn match lispAtom		"'[^ \t()]\+"			contains=lispAtomMark
+syn match lispAtomBarSymbol	!'|..\{-}|!			contains=lispAtomMark
+syn region lispAtom		start=+'"+			skip=+\\"+ end=+"+
+syn region lispAtomList		contained			matchgroup=Special start="("	skip="|.\{-}|" matchgroup=Special end=")"	contains=@lispAtomCluster,lispString,lispEscapeSpecial
+syn match lispAtomNmbr		contained			"\<\d\+"
+syn match lispLeadWhite		contained			"^\s\+"
 
 " ---------------------------------------------------------------------
 " Standard Lisp Functions and Macros: {{{1
@@ -553,6 +553,8 @@ syn match lispParenError	")"
 syn cluster lispCommentGroup	contains=lispTodo,@Spell
 syn match   lispComment		";.*$"				contains=@lispCommentGroup
 syn region  lispCommentRegion	start="#|" end="|#"		contains=lispCommentRegion,@lispCommentGroup
+syn region  lispComment		start="#+nil"	end="\ze)"	contains=@lispCommentGroup
+syn match   lispComment		'^\s*#+nil.*$'			contains=@lispCommentGroup
 syn keyword lispTodo		contained			combak			combak:			todo			todo:
 
 " ---------------------------------------------------------------------

--- a/runtime/syntax/routeros.vim
+++ b/runtime/syntax/routeros.vim
@@ -1,0 +1,91 @@
+" Vim syntax file
+" Language:        MikroTik RouterOS Script
+" Maintainer:      zainin <z@wintr.dev>
+" Original Author: ndbjorne @ MikroTik forums
+" Last Change:     2021 Nov 14
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syn case ignore
+
+syn iskeyword @,48-57,-
+
+" comments
+syn match   routerosComment      /^\s*\zs#.*/
+
+" options submenus: /interface ether1 etc
+syn match   routerosSubMenu      "\([a-z]\)\@<!/[a-zA-Z0-9-]*"
+
+" variables are matched by looking at strings ending with "=", e.g. var=
+syn match   routerosVariable     "[a-zA-Z0-9-/]*\(=\)\@="
+syn match   routerosVariable     "$[a-zA-Z0-9-]*"
+
+" colored for clarity
+syn match   routerosDelimiter    "[,=]"
+" match slash in CIDR notation (1.2.3.4/24, 2001:db8::/48, ::1/128)
+syn match   routerosDelimiter    "\(\x\|:\)\@<=\/\(\d\)\@="
+" dash in IP ranges
+syn match   routerosDelimiter    "\(\x\|:\)\@<=-\(\x\|:\)\@="
+
+" match service names after "set", like in original routeros syntax
+syn match   routerosService      "\(set\)\@<=\s\(api-ssl\|api\|dns\|ftp\|http\|https\|pim\|ntp\|smb\|ssh\|telnet\|winbox\|www\|www-ssl\)"
+
+" colors various interfaces
+syn match   routerosInterface    "bridge\d\+\|ether\d\+\|wlan\d\+\|pppoe-\(out\|in\)\d\+"
+
+syn keyword routerosBoolean      yes no true false
+
+syn keyword routerosConditional  if
+
+" operators
+syn match   routerosOperator     " \zs[-+*<>=!~^&.,]\ze "
+syn match   routerosOperator     "[<>!]="
+syn match   routerosOperator     "<<\|>>"
+syn match   routerosOperator     "[+-]\d\@="
+
+syn keyword routerosOperator     and or in
+
+" commands
+syn keyword routerosCommands     beep delay put len typeof pick log time set find environment
+syn keyword routerosCommands     terminal error parse resolve toarray tobool toid toip toip6
+syn keyword routerosCommands     tonum tostr totime add remove enable disable where get print
+syn keyword routerosCommands     export edit find append as-value brief detail count-only file
+syn keyword routerosCommands     follow follow-only from interval terse value-list without-paging
+syn keyword routerosCommands     return
+
+" variable types
+syn keyword routerosType         global local
+
+" loop keywords
+syn keyword routerosRepeat       do while for foreach
+
+syn match   routerosSpecial      "[():[\]{|}]"
+
+syn match   routerosLineContinuation "\\$"
+
+syn match   routerosEscape       "\\["\\nrt$?_abfv]" contained display
+syn match   routerosEscape       "\\\x\x"            contained display
+
+syn region  routerosString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=routerosEscape,routerosLineContinuation
+
+hi link routerosComment              Comment
+hi link routerosSubMenu              Function
+hi link routerosVariable             Identifier
+hi link routerosDelimiter            Operator
+hi link routerosEscape               Special
+hi link routerosService              Type
+hi link routerosInterface            Type
+hi link routerosBoolean              Boolean
+hi link routerosConditional          Conditional
+hi link routerosOperator             Operator
+hi link routerosCommands             Operator
+hi link routerosType                 Type
+hi link routerosRepeat               Repeat
+hi link routerosSpecial              Delimiter
+hi link routerosString               String
+hi link routerosLineContinuation     Special
+
+let b:current_syntax = "routeros"

--- a/runtime/syntax/tcl.vim
+++ b/runtime/syntax/tcl.vim
@@ -6,8 +6,8 @@
 "		(previously Matt Neumann <mattneu@purpleturtle.com>)
 "		(previously Allan Kelly <allan@fruitloaf.co.uk>)
 " Original:	Robin Becker <robin@jessikat.demon.co.uk>
-" Last Change:	2021 Oct 03
-" Version:	1.14
+" Last Change:	2021 Nov 16
+" Version:	1.14 plus improvements from PR #8948
 " URL:		(removed, no longer worked)
 
 " quit when a syntax file was already loaded
@@ -192,18 +192,18 @@ syn region tcltkCommand matchgroup=tcltkCommandColor start="\<lsort\>" matchgrou
 syn keyword tclTodo contained	TODO
 
 " Sequences which are backslash-escaped: http://www.tcl.tk/man/tcl8.5/TclCmd/Tcl.htm#M16
-" Octal, hexadecimal, unicode codepoints, and the classics.
+" Octal, hexadecimal, Unicode codepoints, and the classics.
 " Tcl takes as many valid characters in a row as it can, so \xAZ in a string is newline followed by 'Z'.
-syn match   tclSpecial contained '\\\([0-7]\{1,3}\|x\x\{1,2}\|u\x\{1,4}\|[abfnrtv]\)'
+syn match   tclSpecial contained '\\\(\o\{1,3}\|x\x\{1,2}\|u\x\{1,4}\|[abfnrtv]\)'
 syn match   tclSpecial contained '\\[\[\]\{\}\"\$]'
 
 " Command appearing inside another command or inside a string.
 syn region tclEmbeddedStatement	start='\[' end='\]' contained contains=tclCommand,tclNumber,tclLineContinue,tclString,tclVarRef,tclEmbeddedStatement
 " A string needs the skip argument as it may legitimately contain \".
 " Match at start of line
-syn region  tclString		  start=+^"+ end=+"+ contains=@tclSpecialC skip=+\\\\\|\\"+
+syn region  tclString		  start=+^"+ end=+"+ contains=@tclSpecialC,@Spell skip=+\\\\\|\\"+
 "Match all other legal strings.
-syn region  tclString		  start=+[^\\]"+ms=s+1  end=+"+ contains=@tclSpecialC,@tclVarRefC,tclEmbeddedStatement skip=+\\\\\|\\"+
+syn region  tclString		  start=+[^\\]"+ms=s+1  end=+"+ contains=@tclSpecialC,@tclVarRefC,tclEmbeddedStatement,@Spell skip=+\\\\\|\\"+
 
 " Line continuation is backslash immediately followed by newline.
 syn match tclLineContinue '\\$'
@@ -222,12 +222,12 @@ syn match  tclNumber		"\.\d\+\(e[-+]\=\d\+\)\=[fl]\=\>"
 "floating point number, without dot, with exponent
 syn match  tclNumber		"\<\d\+e[-+]\=\d\+[fl]\=\>"
 "hex number
-syn match  tclNumber		"0x[0-9a-f]\+\(u\=l\=\|lu\)\>"
-"syn match  tclIdentifier	"\<[a-z_][a-z0-9_]*\>"
+syn match  tclNumber		"0x\x\+\(u\=l\=\|lu\)\>"
+"syn match  tclIdentifier	"\<\h\w*\>"
 syn case match
 
-syn region  tclComment		start="^\s*\#" skip="\\$" end="$" contains=tclTodo
-syn region  tclComment		start=/;\s*\#/hs=s+1 skip="\\$" end="$" contains=tclTodo
+syn region  tclComment		start="^\s*\#" skip="\\$" end="$" contains=tclTodo,@Spell
+syn region  tclComment		start=/;\s*\#/hs=s+1 skip="\\$" end="$" contains=tclTodo,@Spell
 
 "syn match tclComment /^\s*\#.*$/
 "syn match tclComment /;\s*\#.*$/hs=s+1

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -161,10 +161,13 @@ syn match vimFBVar      contained   "\<[bwglstav]:\h[a-zA-Z0-9#_]*\>"
 syn keyword vimCommand  contained	in
 
 " Insertions And Appends: insert append {{{2
+"   (buftype != nofile test avoids having append, change, insert show up in the command window)
 " =======================
-syn region vimInsert	matchgroup=vimCommand start="^[: \t]*\(\d\+\(,\d\+\)\=\)\=a\%[ppend]$"		matchgroup=vimCommand end="^\.$""
-syn region vimInsert	matchgroup=vimCommand start="^[: \t]*\(\d\+\(,\d\+\)\=\)\=c\%[hange]$"		matchgroup=vimCommand end="^\.$""
-syn region vimInsert	matchgroup=vimCommand start="^[: \t]*\(\d\+\(,\d\+\)\=\)\=i\%[nsert]$"		matchgroup=vimCommand end="^\.$""
+if &buftype != 'nofile'
+ syn region vimInsert	matchgroup=vimCommand start="^[: \t]*\(\d\+\(,\d\+\)\=\)\=a\%[ppend]$"		matchgroup=vimCommand end="^\.$""
+ syn region vimInsert	matchgroup=vimCommand start="^[: \t]*\(\d\+\(,\d\+\)\=\)\=c\%[hange]$"		matchgroup=vimCommand end="^\.$""
+ syn region vimInsert	matchgroup=vimCommand start="^[: \t]*\(\d\+\(,\d\+\)\=\)\=i\%[nsert]$"		matchgroup=vimCommand end="^\.$""
+endif
 
 " Behave! {{{2
 " =======


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/519cc559b08b800edc429688aece7ad6a00d41eb

skip: doc/terminal.txt (N/A)
skip: doc/syntax.txt (needs 8.2.3562)

include: doc/eval.txt (doc change from 8.1.1426, which seems unrelated)
