### PR TITLE
build(deps): bump luarocks to 3.8.0

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -157,8 +157,8 @@ set(LUAJIT_SHA256 6c9e46877db2df16ca0fa76db4043ed30a1ae60c89d9ba2c3e4d35eb2360cd
 set(LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz)
 set(LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333)
 
-set(LUAROCKS_URL https://github.com/luarocks/luarocks/archive/v3.7.0.tar.gz)
-set(LUAROCKS_SHA256 968c98ae894cea2c850f077133e3feb9f8ce94df7a33a5611bd4d25e07c94925)
+set(LUAROCKS_URL https://github.com/luarocks/luarocks/archive/v3.8.0.tar.gz)
+set(LUAROCKS_SHA256 ab6612ca9ab87c6984871d2712d05525775e8b50172701a0a1cabddf76de2be7)
 
 set(UNIBILIUM_URL https://github.com/neovim/unibilium/archive/92d929f.tar.gz)
 set(UNIBILIUM_SHA256 29815283c654277ef77a3adcc8840db79ddbb20a0f0b0c8f648bd8cd49a02e4b)


### PR DESCRIPTION
Full changelog:

>  * Support GitHub's protocol security changes transparently.
>   * The raw git:// protocol will stop working on GitHub. LuaRocks already
>     supports git+https:// as an alternative, but to avoid having to update
>     every rockspec in the repository that uses git://github.com, which would
>     require a large coordinated effort, LuaRocks now auto-converts github.com
>     and www.github.com URLs that use git:// to git+https://
> * `luarocks test` has a new flag `--prepare` that checks, downloads and
>   installs the tool requirements and rockspec dependencies but does not
>   run the test suite for the rockspec being tested.
> * Code tweaks so that LuaRocks can run on a Lua interpreter built without
>   the `debug` library.
> * `luarocks upload` supports uploading pre-packaged `.src.rock` files.
> * Configuration fixes for OpenBSD.
> * Respect the existing value for the `variables.LUALIB` configuration
>   variable if given explicitly by the user in the config file, rather
>   than trying to override it with auto-detection.
> * Windows fixes for setting file permissions:
>   * Revert the use of `Everyone` back to `*S-1-1-0`
>   * Quote the use of the `%USERNAME%` variable to support names with spaces
> 