### PR TITLE
fix(eval): fixup for empty modifier in fnamemodify

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2663,7 +2663,7 @@ static void f_fnamemodify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   char buf[NUMBUFLEN];
   const char *fname = tv_get_string_chk(&argvars[0]);
   const char *const mods = tv_get_string_buf_chk(&argvars[1], buf);
-  if (fname == NULL) {
+  if (mods == NULL || fname == NULL) {
     fname = NULL;
   } else if (mods != NULL && *mods != NUL) {
     len = strlen(fname);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2667,7 +2667,7 @@ static void f_fnamemodify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     fname = NULL;
   } else {
     len = strlen(fname);
-    if (mods != NULL && *mods != NUL) {
+    if (*mods != NUL) {
       size_t usedlen = 0;
       if (*mods != NUL) {
         (void)modify_fname((char_u *)mods, false, &usedlen,

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2665,12 +2665,14 @@ static void f_fnamemodify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const char *const mods = tv_get_string_buf_chk(&argvars[1], buf);
   if (mods == NULL || fname == NULL) {
     fname = NULL;
-  } else if (mods != NULL && *mods != NUL) {
+  } else {
     len = strlen(fname);
-    size_t usedlen = 0;
-    if (*mods != NUL) {
-      (void)modify_fname((char_u *)mods, false, &usedlen,
-                         (char_u **)&fname, &fbuf, &len);
+    if (mods != NULL && *mods != NUL) {
+      size_t usedlen = 0;
+      if (*mods != NUL) {
+        (void)modify_fname((char_u *)mods, false, &usedlen,
+                           (char_u **)&fname, &fbuf, &len);
+      }
     }
   }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2669,10 +2669,8 @@ static void f_fnamemodify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     len = strlen(fname);
     if (*mods != NUL) {
       size_t usedlen = 0;
-      if (*mods != NUL) {
-        (void)modify_fname((char_u *)mods, false, &usedlen,
-                           (char_u **)&fname, &fbuf, &len);
-      }
+      (void)modify_fname((char_u *)mods, false, &usedlen,
+                         (char_u **)&fname, &fbuf, &len);
     }
   }
 


### PR DESCRIPTION
https://github.com/neovim/neovim/commit/1dbbaf89bf5d3bcd1edac3af9938c2e2dd18f816 erroneously removed a check for empty modifier and a PVS fix. Restore that check and fix.

Fixes #16367