### PR TITLE
vim-patch:8.1.0753: printf format not checked for semsg()

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6184,7 +6184,7 @@ static void do_ucmd(exarg_T *eap)
         }
       }
 
-      // break if there no <item> is found
+      // break if no <item> is found
       if (start == NULL || end == NULL) {
         break;
       }


### PR DESCRIPTION
Problem:    printf format not checked for semsg().
Solution:   Add GNUC attribute and fix reported problems. (Dominique Pelle,
            closes vim/vim#3805)
https://github.com/vim/vim/commit/b5443cc46dd1485d6c785dd8c65a2c07bd5a17f3

Most of the changes do not apply because Neovim already uses `PRId64`. Other spelling mistakes were already fixed in other PRs. Change to this text does not apply because Neovim won't have this code in the first place: https://github.com/vim/vim/blob/64be6aa3a54ecfe355d4a03e1200650c301e7f29/src/ex_docmd.c#L6360-L6370
