### PR TITLE
doc(man): omit misleading mention of environment for -u NORC

### DIFF
--- a/man/nvim.1
+++ b/man/nvim.1
@@ -177,8 +177,7 @@ If
 .Ar vimrc
 is
 .Cm NORC ,
-do not load any initialization files (except plugins),
-and do not attempt to parse environment variables.
+do not load any initialization files (except plugins).
 If
 .Ar vimrc
 is


### PR DESCRIPTION
The phrase referred specifically to `$VIMINIT` and `$EXRC`, which are parsed (and available with, e.g., `echo $VIMINIT` if set) but of course not loaded since _any_ initialization is skipped. So this is redundant and can be misleading, hence better to omit it entirely.

closes #13716 (again)

(An alternative would be to instead write "overrides `$VIMINIT` and `$EXRC` if set", but I think that's too verbose and not any more helpful.)