### PR TITLE
vim-patch:8.1.0228, 8.1.1384, 8.1.1386, 8.1.1393, 8.2.3040

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -625,7 +625,7 @@ void ins_char_bytes(char_u *buf, size_t charlen)
     }
   }
 
-  char_u *newp = xmalloc((size_t)(linelen + newlen - oldlen));
+  char_u *newp = xmalloc(linelen + newlen - oldlen);
 
   // Copy bytes before the cursor.
   if (col > 0) {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -100,8 +100,8 @@ struct bw_info {
   char_u bw_rest[CONV_RESTLEN];  // not converted bytes
   int bw_restlen;                // nr of bytes in bw_rest[]
   int bw_first;                  // first write call
-  char_u *bw_conv_buf;      // buffer for writing converted chars
-  int bw_conv_buflen;            // size of bw_conv_buf
+  char_u *bw_conv_buf;           // buffer for writing converted chars
+  size_t bw_conv_buflen;         // size of bw_conv_buf
   int bw_conv_error;             // set for conversion error
   linenr_T bw_conv_error_lnum;   // first line with error or zero
   linenr_T bw_start_lnum;        // line number at start of buffer

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -80,7 +80,7 @@ static signgroup_T *sign_group_ref(const char_u *groupname)
   hi = hash_lookup(&sg_table, (char *)groupname, STRLEN(groupname), hash);
   if (HASHITEM_EMPTY(hi)) {
     // new group
-    group = xmalloc((unsigned)(sizeof(signgroup_T) + STRLEN(groupname)));
+    group = xmalloc(sizeof(signgroup_T) + STRLEN(groupname));
 
     STRCPY(group->sg_name, groupname);
     group->sg_refcount = 1;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5401,7 +5401,7 @@ static int get_id_list(char_u **const arg, const int keylen, int16_t **const lis
     do {
       for (end = p; *end && !ascii_iswhite(*end) && *end != ','; end++) {
       }
-      char_u *const name = xmalloc((int)(end - p + 3));   // leave room for "^$"
+      char_u *const name = xmalloc(end - p + 3);   // leave room for "^$"
       STRLCPY(name + 1, p, end - p + 1);
       if (STRCMP(name + 1, "ALLBUT") == 0
           || STRCMP(name + 1, "ALL") == 0


### PR DESCRIPTION
Drag&drop patches are N/A, there are no relevant changes. Ported several small changes from the memory allocation/type casts patches - those places and everything else already uses `xmalloc`. Comments added in those patches are also N/A because Neovim uses standard lib like `memcpy` instead of custom memory allocation.