### PR TITLE
vim-patch:8.2.2922,8.2.3639

### DIFF
--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -986,8 +986,7 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
 #define PRT_PS_DEFAULT_DPI          (72)    // Default user space resolution
 #define PRT_PS_DEFAULT_FONTSIZE     (10)
 
-#define PRT_MEDIASIZE_LEN  (sizeof(prt_mediasize) / \
-                            sizeof(struct prt_mediasize_S))
+#define PRT_MEDIASIZE_LEN  ARRAY_SIZE(prt_mediasize)
 
 static struct prt_mediasize_S prt_mediasize[] =
 {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -677,7 +677,7 @@ void getout(int exitval)
   if (did_emsg) {
     // give the user a chance to read the (error) message
     no_wait_return = FALSE;
-    wait_return(FALSE);
+//  wait_return(FALSE);
   }
 
   // Position the cursor again, the autocommands may have moved it

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -677,7 +677,7 @@ void getout(int exitval)
   if (did_emsg) {
     // give the user a chance to read the (error) message
     no_wait_return = FALSE;
-//  wait_return(FALSE);
+    wait_return(FALSE);
   }
 
   // Position the cursor again, the autocommands may have moved it

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -573,7 +573,6 @@ void free_all_mem(void)
     return;
   }
   entered_free_all_mem = true;
-
   // Don't want to trigger autocommands from here on.
   block_autocmds();
 


### PR DESCRIPTION
Problem:    Computing array length is done in various ways.
Solution:   Use ARRAY_LENGTH everywhere. (Ken Takata, closes vim/vim#8305)
https://github.com/vim/vim/commit/eeec2548785b2dd245a31ab25d7bde0f88ea1a6d
