### PR TITLE
vim-patch:8.2.3638: getcompletion() always passes zero as position

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3386,15 +3386,17 @@ static void f_getcompletion(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     emsg(_(e_invarg));
     return;
   }
+  const char *pattern = tv_get_string(&argvars[0]);
 
   if (strcmp(type, "cmdline") == 0) {
-    set_one_cmd_context(&xpc, tv_get_string(&argvars[0]));
+    set_one_cmd_context(&xpc, pattern);
     xpc.xp_pattern_len = STRLEN(xpc.xp_pattern);
+    xpc.xp_col = STRLEN(pattern);
     goto theend;
   }
 
   ExpandInit(&xpc);
-  xpc.xp_pattern = (char_u *)tv_get_string(&argvars[0]);
+  xpc.xp_pattern = (char_u *)pattern;
   xpc.xp_pattern_len = STRLEN(xpc.xp_pattern);
   xpc.xp_context = cmdcomplete_str_to_type(type);
   if (xpc.xp_context == EXPAND_NOTHING) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -428,14 +428,17 @@ func Test_getcompletion()
   call assert_equal([], l)
 
   func T(a, c, p)
+    let g:cmdline_compl_params = [a:a, a:c, a:p]
     return "oneA\noneB\noneC"
   endfunc
   command -nargs=1 -complete=custom,T MyCmd
   let l = getcompletion('MyCmd ', 'cmdline')
   call assert_equal(['oneA', 'oneB', 'oneC'], l)
+  call assert_equal(['', 'MyCmd ', 6], g:cmdline_compl_params)
 
   delcommand MyCmd
   delfunc T
+  unlet g:cmdline_compl_params
 
   " For others test if the name is recognized.
   let names = ['buffer', 'environment', 'file_in_path', 'mapping', 'tag', 'tag_listfiles', 'user']


### PR DESCRIPTION
Problem:    getcompletion() always passes zero as position to custom
            completion function.
Solution:   Pass the pattern length. (closes vim/vim#9173)
vim/vim@4785fe0