### PR TITLE
vim-patch:8.1.1606: on a narrow screen ":hi" output is confusing

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -7536,6 +7536,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
 {
   int endcol = 19;
   bool newline = true;
+  int name_col = 0;
   bool adjust = true;
 
   if (!did_header) {
@@ -7544,6 +7545,7 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
       return true;
     }
     msg_outtrans(HL_TABLE()[id - 1].sg_name);
+    name_col = msg_col;
     endcol = 15;
   } else if ((ui_has(kUIMessages) || msg_silent) && !force_newline) {
     msg_putchar(' ');
@@ -7570,6 +7572,9 @@ static bool syn_list_header(const bool did_header, const int outlen, const int i
 
   // Show "xxx" with the attributes.
   if (!did_header) {
+    if (endcol == Columns - 1 && endcol <= name_col) {
+        msg_putchar(' ');
+    }
     msg_puts_attr("xxx", syn_id2attr(id));
     msg_putchar(' ');
   }

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -651,6 +651,16 @@ func Test_1_highlight_Normalgroup_exists()
   endif
 endfunc
 
+function Test_no_space_before_xxx()
+  " Note: we need to create this highlight group in the test because it does not exist in Neovim
+  execute('hi StatusLineTermNC ctermfg=green')
+  let l:org_columns = &columns
+  set columns=17
+  let l:hi_StatusLineTermNC = join(split(execute('hi StatusLineTermNC')))
+  call assert_match('StatusLineTermNC xxx', l:hi_StatusLineTermNC)
+  let &columns = l:org_columns
+endfunction
+
 " Test for using RGB color values in a highlight group
 func Test_xxlast_highlight_RGB_color()
   CheckCanRunGui


### PR DESCRIPTION
Problem:    On a narrow screen ":hi" output is confusing.
Solution:   Insert a space between highlight group name and "xxx". (Masato
            Nishihaga, closes vim/vim#4599)
https://github.com/vim/vim/commit/548be7f126dc57ca861cb26dc6492c3b2a9e2c99
