### PR TITLE
fix(lsp): avoid indexing vim.NIL for null workspaceFolders

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -831,9 +831,9 @@ function lsp.start_client(config)
       root_uri = workspace_folders[1].uri
       root_path = vim.uri_to_fname(root_uri)
     else
-      workspace_folders = vim.NIL
-      root_uri = vim.NIL
-      root_path = vim.NIL
+      workspace_folders = nil
+      root_uri = nil
+      root_path = nil
     end
 
     local initialize_params = {
@@ -851,15 +851,15 @@ function lsp.start_client(config)
       -- The rootPath of the workspace. Is null if no folder is open.
       --
       -- @deprecated in favour of rootUri.
-      rootPath = root_path;
+      rootPath = root_path or vim.NIL;
       -- The rootUri of the workspace. Is null if no folder is open. If both
       -- `rootPath` and `rootUri` are set `rootUri` wins.
-      rootUri = root_uri;
+      rootUri = root_uri or vim.NIL;
       -- The workspace folders configured in the client when the server starts.
       -- This property is only available if the client supports workspace folders.
       -- It can be `null` if the client supports workspace folders but none are
       -- configured.
-      workspaceFolders = workspace_folders;
+      workspaceFolders = workspace_folders or vim.NIL;
       -- User provided initialization options.
       initializationOptions = config.init_options;
       -- The capabilities provided by the client (editor or tool)
@@ -879,7 +879,9 @@ function lsp.start_client(config)
       rpc.notify('initialized', vim.empty_dict())
       client.initialized = true
       uninitialized_clients[client_id] = nil
-      client.workspaceFolders = initialize_params.workspaceFolders
+      client.workspace_folders = workspace_folders
+      -- TODO(mjlbach): Backwards compatbility, to be removed in 0.7
+      client.workspaceFolders = client.workspace_folders
       client.server_capabilities = assert(result.capabilities, "initialize result doesn't contain capabilities")
       -- These are the cleaned up capabilities we use for dynamically deciding
       -- when to send certain events to clients.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -369,7 +369,7 @@ end
 function M.list_workspace_folders()
   local workspace_folders = {}
   for _, client in pairs(vim.lsp.buf_get_clients()) do
-    for _, folder in pairs(client.workspaceFolders or {}) do
+    for _, folder in pairs(client.workspace_folders or {}) do
       table.insert(workspace_folders, folder.name)
     end
   end
@@ -389,7 +389,7 @@ function M.add_workspace_folder(workspace_folder)
   local params = util.make_workspace_params({{uri = vim.uri_from_fname(workspace_folder); name = workspace_folder}}, {{}})
   for _, client in pairs(vim.lsp.buf_get_clients()) do
     local found = false
-    for _, folder in pairs(client.workspaceFolders or {}) do
+    for _, folder in pairs(client.workspace_folders or {}) do
       if folder.name == workspace_folder then
         found = true
         print(workspace_folder, "is already part of this workspace")
@@ -398,10 +398,10 @@ function M.add_workspace_folder(workspace_folder)
     end
     if not found then
       vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
-      if not client.workspaceFolders then
-        client.workspaceFolders = {}
+      if not client.workspace_folders then
+        client.workspace_folders = {}
       end
-      table.insert(client.workspaceFolders, params.event.added[1])
+      table.insert(client.workspace_folders, params.event.added[1])
     end
   end
 end
@@ -415,10 +415,10 @@ function M.remove_workspace_folder(workspace_folder)
   if not (workspace_folder and #workspace_folder > 0) then return end
   local params = util.make_workspace_params({{}}, {{uri = vim.uri_from_fname(workspace_folder); name = workspace_folder}})
   for _, client in pairs(vim.lsp.buf_get_clients()) do
-    for idx, folder in pairs(client.workspaceFolders) do
+    for idx, folder in pairs(client.workspace_folders) do
       if folder.name == workspace_folder then
         vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
-        client.workspaceFolders[idx] = nil
+        client.workspace_folders[idx] = nil
         return
       end
     end


### PR DESCRIPTION
* internally represent no workspaceFolders as nil instead of vim.NIL
* rename workspaceFolders -> workspace_folders for consistency

see: https://github.com/neovim/nvim-lspconfig/issues/1471