### PR TITLE
fix(diagnostics): don't allow 0 bufnr for metatable index

### DIFF
--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -111,7 +111,7 @@ describe('vim.diagnostic', function()
   it('retrieves diagnostics from all buffers and namespaces', function()
     local result = exec_lua [[
       local other_bufnr = vim.api.nvim_create_buf(true, false)
-      local lines = {"1st line of text", "2nd line of text", "wow", "cool", "more", "lines"}
+      local lines = vim.api.nvim_buf_get_lines(diagnostic_bufnr, 0, -1, true)
       vim.api.nvim_buf_set_lines(other_bufnr, 0, 1, false, lines)
 
       vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {


### PR DESCRIPTION
04bfd20bb introduced a subtle bug where using 0 as the buffer number in the diagnostic cache resets the cache for the current buffer. This happens because we were not checking to see if the _resolved_ buffer number already existed in the cache; rather, when the `__index` metamethod was called we assumed the index did not exist so we set its value to an empty table. The fix for this is to check `rawget()` for the resolved buffer number to see if the index already exists.

However, the reason this bug was introduced in the first place was because we are simply being too clever by allowing a 0 buffer number as the index which is automatically resolved to a real buffer number. In the interest of minimizing metatable magic, remove this "feature" by requiring the buffer number index to always be a valid buffer. This ensures that the `__index` metamethod is only ever called for non-existing buffers (which is what we wanted originally) as well as reduces some of the cognitive overhead for understanding how the diagnostic cache works. The tradeoff is that all public API functions must now resolve 0 buffer numbers to the current buffer number.

cc @smolck
