### PR TITLE
vim-patch:8.2.2350: using "void" for no reason

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -818,7 +818,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
     // of interrupts or errors to exceptions, and ensure that no more
     // commands are executed.
     if (current_exception) {
-      void *p = NULL;
+      char *p = NULL;
       char_u *saved_sourcing_name;
       int saved_sourcing_lnum;
       struct msglist *messages = NULL;
@@ -835,7 +835,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
         vim_snprintf((char *)IObuff, IOSIZE,
                      _("E605: Exception not caught: %s"),
                      current_exception->value);
-        p = vim_strsave(IObuff);
+        p = (char *)vim_strsave(IObuff);
         break;
       case ET_ERROR:
         messages = current_exception->messages;


### PR DESCRIPTION
#### vim-patch:8.2.2350: using "void" for no reason

Problem:    Using "void" for no reason.
Solution:   Use "char *".
https://github.com/vim/vim/commit/033135eb8eccd00c9ee72c6c0cf4b8b9f81bd269