### PR TITLE
fix(terminal): use coladvance() to calculate buffer cursor position

### DIFF
--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -108,6 +108,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
   int head = 0;
 
   one_more = (State & INSERT)
+             || (State & TERM_FOCUS)
              || restart_edit != NUL
              || (VIsual_active && *p_sel != 'o')
              || ((ve_flags & VE_ONEMORE) && wcol < MAXCOL);

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -46,6 +46,7 @@
 #include "nvim/ascii.h"
 #include "nvim/buffer.h"
 #include "nvim/change.h"
+#include "nvim/cursor.h"
 #include "nvim/edit.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/time.h"
@@ -464,9 +465,7 @@ static void terminal_check_cursor(void)
                               row_to_linenr(term, term->cursor.row));
   // Nudge cursor when returning to normal-mode.
   int off = is_focused(term) ? 0 : (curwin->w_p_rl ? 1 : -1);
-  curwin->w_cursor.col = MAX(0, term->cursor.col + win_col_off(curwin) + off);
-  curwin->w_cursor.coladd = 0;
-  mb_check_adjust_col(curwin);
+  coladvance(MAX(0, term->cursor.col + off));
 }
 
 // Function executed before each iteration of terminal mode.

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -3,6 +3,8 @@ local Screen = require('test.functional.ui.screen')
 local thelpers = require('test.functional.terminal.helpers')
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local nvim_dir, command = helpers.nvim_dir, helpers.command
+local nvim_prog = helpers.nvim_prog
+local eq, eval = helpers.eq, helpers.eval
 local feed_command = helpers.feed_command
 local hide_cursor = thelpers.hide_cursor
 local show_cursor = thelpers.show_cursor
@@ -173,3 +175,705 @@ describe('cursor with customized highlighting', function()
   end)
 end)
 
+describe('buffer cursor position is correct in terminal without number column', function()
+  local screen
+
+  local function setup_ex_register(str)
+    screen = thelpers.screen_setup(0, '["'..nvim_prog
+      ..[[", "-u", "NONE", "-i", "NONE", "-E", "--cmd", "let @r = ']]..str..[['", ]]
+      -- <Left> and <Right> don't always work
+      ..[["--cmd", "cnoremap <C-X> <Left>", "--cmd", "cnoremap <C-O> <Right>"]]..']', 70)
+    screen:expect([[
+                                                                            |
+                                                                            |
+                                                                            |
+                                                                            |
+      Entering Ex mode.  Type "visual" to go to Normal mode.                |
+      :{1: }                                                                    |
+      {3:-- TERMINAL --}                                                        |
+    ]])
+  end
+
+  before_each(clear)
+
+  describe('in a line with no multibyte characters or trailing spaces,', function()
+    before_each(function()
+      setup_ex_register('aaaaaaaa')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaaaaa{1: }                                                            |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 9}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaaaa^a{2: }                                                            |
+                                                                              |
+      ]])
+      eq({6, 8}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaaa{1:a}a                                                             |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 7}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaa^a{2:a}a                                                             |
+                                                                              |
+      ]])
+      eq({6, 6}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :a{1:a}aaaaaa                                                             |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 2}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^a{2:a}aaaaaa                                                             |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+
+  describe('in a line with single-cell multibyte characters and no trailing spaces,', function()
+    before_each(function()
+      setup_ex_register('µµµµµµµµ')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµµµµ{1: }                                                            |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 17}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµµµ^µ{2: }                                                            |
+                                                                              |
+      ]])
+      eq({6, 15}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµµ{1:µ}µ                                                             |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 13}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµ^µ{2:µ}µ                                                             |
+                                                                              |
+      ]])
+      eq({6, 11}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ{1:µ}µµµµµµ                                                             |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 3}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^µ{2:µ}µµµµµµ                                                             |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+
+  describe('in a line with single-cell composed multibyte characters and no trailing spaces,', function()
+    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+
+    before_each(function()
+      setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳{1: }                                                            |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 33}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳{2: }                                                            |
+                                                                              |
+      ]])
+      eq({6, 29}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳µ̳{1:µ̳}µ̳                                                             |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 25}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳^µ̳{2:µ̳}µ̳                                                             |
+                                                                              |
+      ]])
+      eq({6, 21}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳{1:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                             |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 5}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^µ̳{2:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                             |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+
+  describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
+    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+
+    before_each(function()
+      setup_ex_register('哦哦哦哦哦哦哦哦')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦哦哦哦{1: }                                                    |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 25}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦哦哦^哦{2: }                                                    |
+                                                                              |
+      ]])
+      eq({6, 22}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦哦{1:哦}哦                                                     |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 19}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦^哦{2:哦}哦                                                     |
+                                                                              |
+      ]])
+      eq({6, 16}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦{1:哦}哦哦哦哦哦哦                                                     |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 4}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+                                                                              |
+                                                                              |
+                                                                              |
+                                                                              |
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^哦{2:哦}哦哦哦哦哦哦                                                     |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+end)
+
+describe('buffer cursor position is correct in terminal with number column', function()
+  local screen
+
+  local function setup_ex_register(str)
+    screen = thelpers.screen_setup(0, '["'..nvim_prog
+      ..[[", "-u", "NONE", "-i", "NONE", "-E", "--cmd", "let @r = ']]..str..[['", ]]
+      -- <Left> and <Right> don't always work
+      ..[["--cmd", "cnoremap <C-X> <Left>", "--cmd", "cnoremap <C-O> <Right>"]]..']', 70)
+    screen:expect([[
+      {7:  1 }                                                                  |
+      {7:  2 }                                                                  |
+      {7:  3 }                                                                  |
+      {7:  4 }                                                                  |
+      {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+      {7:  6 }:{1: }                                                                |
+      {3:-- TERMINAL --}                                                        |
+    ]])
+  end
+
+  before_each(function()
+    clear()
+    command('set number')
+  end)
+
+  describe('in a line with no multibyte characters or trailing spaces,', function()
+    before_each(function()
+      setup_ex_register('aaaaaaaa')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaaaaa{1: }                                                        |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 9}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaaaa^a{2: }                                                        |
+                                                                              |
+      ]])
+      eq({6, 8}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaaa{1:a}a                                                         |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 7}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaa^a{2:a}a                                                         |
+                                                                              |
+      ]])
+      eq({6, 6}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:a{1:a}aaaaaa                                                         |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 2}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^a{2:a}aaaaaa                                                         |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+
+  describe('in a line with single-cell multibyte characters and no trailing spaces,', function()
+    before_each(function()
+      setup_ex_register('µµµµµµµµ')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµµµµ{1: }                                                        |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 17}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµµµ^µ{2: }                                                        |
+                                                                              |
+      ]])
+      eq({6, 15}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµµ{1:µ}µ                                                         |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 13}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµ^µ{2:µ}µ                                                         |
+                                                                              |
+      ]])
+      eq({6, 11}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ{1:µ}µµµµµµ                                                         |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 3}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^µ{2:µ}µµµµµµ                                                         |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+
+  describe('in a line with single-cell composed multibyte characters and no trailing spaces,', function()
+    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+
+    before_each(function()
+      setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳{1: }                                                        |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 33}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳{2: }                                                        |
+                                                                              |
+      ]])
+      eq({6, 29}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳{1:µ̳}µ̳                                                         |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 25}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳^µ̳{2:µ̳}µ̳                                                         |
+                                                                              |
+      ]])
+      eq({6, 21}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳{1:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                         |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 5}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^µ̳{2:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                         |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+
+  describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
+    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+
+    before_each(function()
+      setup_ex_register('哦哦哦哦哦哦哦哦')
+    end)
+
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦哦哦哦{1: }                                                |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 25}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦哦哦^哦{2: }                                                |
+                                                                              |
+      ]])
+      eq({6, 22}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the end', function()
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦哦{1:哦}哦                                                 |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 19}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦^哦{2:哦}哦                                                 |
+                                                                              |
+      ]])
+      eq({6, 16}, eval('nvim_win_get_cursor(0)'))
+    end)
+
+    it('near the start', function()
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦{1:哦}哦哦哦哦哦哦                                                 |
+        {3:-- TERMINAL --}                                                        |
+      ]])
+      eq({6, 4}, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^哦{2:哦}哦哦哦哦哦哦                                                 |
+                                                                              |
+      ]])
+      eq({6, 1}, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
+end)


### PR DESCRIPTION
Fix #14671