### PR TITLE
vim-patch:8.1.2136,8.2.2465

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -5248,6 +5248,9 @@ search_line:
           if (depth == -1) {
             // match in current file
             if (l_g_do_tagpreview != 0) {
+              if (!win_valid(curwin_save)) {
+                break;
+              }
               if (!GETFILE_SUCCESS(getfile(curwin_save->w_buffer->b_fnum, NULL,
                                            NULL, true, lnum, false))) {
                 break;    // failed to jump to file

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -33,7 +33,7 @@ if has('timers')
     let g:triggered = 0
     au CursorHoldI * let g:triggered += 1
     set updatetime=20
-    call timer_start(LoadAdjust(100), 'ExitInsertMode')
+    call timer_start(LoadAdjust(200), 'ExitInsertMode')
     call feedkeys('a', 'x!')
     call assert_equal(1, g:triggered)
     unlet g:triggered
@@ -1900,12 +1900,21 @@ endfunc
 func Test_autocmd_was_using_freed_memory()
   pedit xx
   n x
-  au WinEnter * quit
+  augroup winenter
+    au WinEnter * if winnr('$') > 2 | quit | endif
+  augroup END
   " Nvim needs large 'winwidth' and 'nowinfixwidth' to crash
   set winwidth=99999 nowinfixwidth
   split
-  au! WinEnter
+
+  augroup winenter
+    au! WinEnter
+  augroup END
+
   set winwidth& winfixwidth&
+  bwipe xx
+  bwipe x
+  pclose
 endfunc
 
 func Test_FileChangedShell_reload()
@@ -2134,6 +2143,19 @@ func Test_autocmd_closes_window()
   bwipe %
   au! BufNew
   au! BufWinLeave
+endfunc
+
+func Test_autocmd_quit_psearch()
+  sn aa bb
+  augroup aucmd_win_test
+    au!
+    au BufEnter,BufLeave,BufNew,WinEnter,WinLeave,WinNew * if winnr('$') > 1 | q | endif
+  augroup END
+  ps /
+
+  augroup aucmd_win_test
+    au!
+  augroup END
 endfunc
 
 func Test_autocmd_closing_cmdwin()

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1897,6 +1897,17 @@ func Test_autocmd_CmdWinEnter()
   call delete(filename)
 endfunc
 
+func Test_autocmd_was_using_freed_memory()
+  pedit xx
+  n x
+  au WinEnter * quit
+  " Nvim needs large 'winwidth' and 'nowinfixwidth' to crash
+  set winwidth=99999 nowinfixwidth
+  split
+  au! WinEnter
+  set winwidth& winfixwidth&
+endfunc
+
 func Test_FileChangedShell_reload()
   if !has('unix')
     return

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4525,6 +4525,7 @@ static void win_enter_ext(win_T *const wp, const int flags)
 
   fix_current_dir();
 
+  // Careful: autocommands may close the window and make "wp" invalid
   if (flags & WEE_TRIGGER_NEW_AUTOCMDS) {
     apply_autocmds(EVENT_WINNEW, NULL, NULL, false, curbuf);
   }
@@ -4558,7 +4559,7 @@ static void win_enter_ext(win_T *const wp, const int flags)
   }
 
   // set window width to desired minimal value
-  if (curwin->w_width < p_wiw && !curwin->w_p_wfw && !wp->w_floating) {
+  if (curwin->w_width < p_wiw && !curwin->w_p_wfw && !curwin->w_floating) {
     win_setwidth((int)p_wiw);
   }
 


### PR DESCRIPTION
**vim-patch:8.1.2136: using freed memory with autocmd from fuzzer**

Problem:    using freed memory with autocmd from fuzzer. (Dhiraj Mishra,
            Dominique Pelle)
Solution:   Avoid using "wp" after autocommands. (closes vim/vim#5041)
vim/vim@ec66c41

Nvim doesn't use Vim's terminal implementation.
Despite this, Nvim has its own *exclusive* way of crashing here.

Requires 'winwidth' > winwidth() and 'nowinfixwidth' to crash; adjust
the test ('nowfw' is the default, but ensure its disabled anyway).

---

**vim-patch:8.2.2465: using freed memory in :psearch**

Problem:    Using freed memory in :psearch. (houyunsong)
Solution:   Check the current window is still valid.  Fix flaky test.
vim/vim@92bb83e

Test_cursorhold_insert timer's 100ms delay was already LoadAdjusted, but change
to LoadAdjusted 200ms to match Vim anyway.