### PR TITLE
fix(terminal): do not trim whitespace that is actually in the terminal

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1374,26 +1374,21 @@ static void fetch_row(Terminal *term, int row, int end_col)
   while (col < end_col) {
     VTermScreenCell cell;
     fetch_cell(term, row, col, &cell);
-    int cell_len = 0;
     if (cell.chars[0]) {
+      int cell_len = 0;
       for (int i = 0; cell.chars[i]; i++) {
         cell_len += utf_char2bytes((int)cell.chars[i], ptr + cell_len);
       }
-    } else {
-      *ptr = ' ';
-      cell_len = 1;
-    }
-    char c = *ptr;
-    ptr += cell_len;
-    if (c != ' ') {
-      // only increase the line length if the last character is not whitespace
+      ptr += cell_len;
       line_len = (size_t)(ptr - term->textbuf);
+    } else {
+      *ptr++ = ' ';
     }
     col += cell.width;
   }
 
-  // trim trailing whitespace
-  term->textbuf[line_len] = 0;
+  // end of line
+  term->textbuf[line_len] = NUL;
 }
 
 static bool fetch_cell(Terminal *term, int row, int col, VTermScreenCell *cell)

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -785,7 +785,8 @@ describe('API: buffer events:', function()
 
   local function lines_subset(first, second)
     for i = 1,#first do
-      if first[i] ~= second[i] then
+      -- need to ignore trailing spaces
+      if first[i]:gsub(' +$', '') ~= second[i]:gsub(' +$', '') then
         return false
       end
     end

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -496,12 +496,13 @@ describe('sysinit', function()
   it('fixed hang issue with -D (#12647)', function()
     if helpers.pending_win32(pending) then return end
     local screen
-    screen = Screen.new(60, 6)
+    screen = Screen.new(60, 7)
     screen:attach()
     command([[let g:id = termopen('"]]..nvim_prog..
     [[" -u NONE -i NONE --cmd "set noruler" -D')]])
     screen:expect([[
       ^                                                            |
+                                                                  |
       Entering Debug mode.  Type "cont" to continue.              |
       cmd: augroup nvim_terminal                                  |
       >                                                           |
@@ -511,6 +512,7 @@ describe('sysinit', function()
     command([[call chansend(g:id, "cont\n")]])
     screen:expect([[
       ^                                                            |
+      ~                                                           |
       ~                                                           |
       [No Name]                                                   |
                                                                   |


### PR DESCRIPTION
Fix #16234