### PR TITLE
fix(ui): use nowait for q mapping in floating window

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1314,7 +1314,7 @@ function M.open_floating_preview(contents, syntax, opts)
 
   api.nvim_buf_set_option(floating_bufnr, 'modifiable', false)
   api.nvim_buf_set_option(floating_bufnr, 'bufhidden', 'wipe')
-  api.nvim_buf_set_keymap(floating_bufnr, "n", "q", "<cmd>bdelete<cr>", {silent = true, noremap = true})
+  api.nvim_buf_set_keymap(floating_bufnr, "n", "q", "<cmd>bdelete<cr>", {silent = true, noremap = true, nowait = true})
   M.close_preview_autocmd(opts.close_events, floating_winnr)
 
   -- save focus_id


### PR DESCRIPTION
Fixes the `q` mapping waiting for timeout in lsp/diagnostic floating windows.