### PR TITLE
feat(lsp): use uv_spawn to check if server executable

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -790,6 +790,9 @@ function lsp.start_client(config)
     env = config.cmd_env;
   })
 
+  -- Return nil if client fails to start
+  if not rpc then return end
+
   local client = {
     id = client_id;
     name = name;


### PR DESCRIPTION
Closes #15648

Previously, the built-in language server client checked if the first
argument of cmd was executable via vim.fn.executable. This ignores PATH
injected via cmd_env. Instead, we now start the client via uv.spawn, and
handle the failure mode, reporting the error back to the user.

cc @williamboman 