### PR TITLE
feat(diagnostic): show first diagnostic per line in virtual text

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -976,19 +976,19 @@ function M._get_virt_text_chunks(line_diags, opts)
   -- Create a little more space between virtual text and contents
   local virt_texts = {{string.rep(" ", spacing)}}
 
-  for i = 1, #line_diags - 1 do
+  for i = 2, #line_diags do
     table.insert(virt_texts, {prefix, virtual_text_highlight_map[line_diags[i].severity]})
   end
-  local last = line_diags[#line_diags]
+
+  local first = line_diags[1]
 
   -- TODO(tjdevries): Allow different servers to be shown first somehow?
-  -- TODO(tjdevries): Display server name associated with these?
-  if last.message then
+  if first.message then
     table.insert(
       virt_texts,
       {
-        string.format("%s %s", prefix, last.message:gsub("\r", ""):gsub("\n", "  ")),
-        virtual_text_highlight_map[last.severity]
+        string.format("%s %s", prefix, first.message:gsub("\r", ""):gsub("\n", "  ")),
+        virtual_text_highlight_map[first.severity]
       }
     )
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -993,7 +993,7 @@ describe('vim.diagnostic', function()
 
       -- Virt texts are defined lowest priority to highest, signs from
       -- highest to lowest
-      eq({'Warn', 'Error', 'Info'}, result[1])
+      eq({'Error', 'Info', 'Warn'}, result[1])
       eq({'Info', 'Error', 'Warn'}, result[2])
 
       result = exec_lua [[return get_virt_text_and_signs(true)]]


### PR DESCRIPTION
Diagnostics are not sorted by severity by default. If there is a single
diagnostic position, conventionally the first diagnostic is the most
severe. Default to showing the first diagnostic instead of the last.

cc @ii14 