### PR TITLE
fix(diagnostic): do not focus floats in goto functions

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -506,7 +506,10 @@ local function diagnostic_move_pos(opts, pos)
     vim.schedule(function()
       M.open_float(
         vim.api.nvim_win_get_buf(win_id),
-        vim.tbl_extend("keep", float_opts, {scope="cursor"})
+        vim.tbl_extend("keep", float_opts, {
+          scope = "cursor",
+          focusable = false,
+        })
       )
     end)
   end


### PR DESCRIPTION
Floating windows opened by `goto_next` and `goto_prev` should not be focused when repeating the `goto_` function. The float can still be focused by calling `open_float` with `scope = "cursor"`.

Closes https://github.com/neovim/neovim/issues/16425.