### PR TITLE
fix(diagnostic): line clamping fixes

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -441,7 +441,9 @@ local function set_list(loclist, opts)
   if loclist then
     bufnr = vim.api.nvim_win_get_buf(winnr)
   end
-  local diagnostics = get_diagnostics(bufnr, opts, true)
+  -- Don't clamp line numbers since the quickfix list can already handle line
+  -- numbers beyond the end of the buffer
+  local diagnostics = get_diagnostics(bufnr, opts, false)
   local items = M.toqflist(diagnostics)
   if loclist then
     vim.fn.setloclist(winnr, {}, ' ', { title = title, items = items })

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -372,25 +372,35 @@ local function get_diagnostics(bufnr, opts, clamp)
 
   local namespace = opts.namespace
   local diagnostics = {}
-  local buf_line_count = clamp and vim.api.nvim_buf_line_count(bufnr) or math.huge
+
+  -- Memoized results of buf_line_count per bufnr
+  local buf_line_count = setmetatable({}, {
+    __index = function(t, k)
+      t[k] = vim.api.nvim_buf_line_count(k)
+      return rawget(t, k)
+    end,
+  })
 
   ---@private
-  local function add(d)
+  local function add(b, d)
     if not opts.lnum or d.lnum == opts.lnum then
-      if clamp and (d.lnum >= buf_line_count or d.end_lnum >= buf_line_count) then
-        d = vim.deepcopy(d)
-        d.lnum = math.max(math.min(d.lnum, buf_line_count - 1), 0)
-        d.end_lnum = math.max(math.min(d.end_lnum, buf_line_count - 1), 0)
+      if clamp and vim.api.nvim_buf_is_loaded(b) then
+        local line_count = buf_line_count[b] - 1
+        if (d.lnum > line_count or d.end_lnum > line_count) then
+          d = vim.deepcopy(d)
+          d.lnum = math.max(math.min(d.lnum, line_count), 0)
+          d.end_lnum = math.max(math.min(d.end_lnum, line_count), 0)
+        end
       end
       table.insert(diagnostics, d)
     end
   end
 
   if namespace == nil and bufnr == nil then
-    for _, t in pairs(diagnostic_cache) do
+    for b, t in pairs(diagnostic_cache) do
       for _, v in pairs(t) do
         for _, diagnostic in pairs(v) do
-          add(diagnostic)
+          add(b, diagnostic)
         end
       end
     end
@@ -398,19 +408,19 @@ local function get_diagnostics(bufnr, opts, clamp)
     bufnr = get_bufnr(bufnr)
     for iter_namespace in pairs(diagnostic_cache[bufnr]) do
       for _, diagnostic in pairs(diagnostic_cache[bufnr][iter_namespace]) do
-        add(diagnostic)
+        add(bufnr, diagnostic)
       end
     end
   elseif bufnr == nil then
-    for _, t in pairs(diagnostic_cache) do
+    for b, t in pairs(diagnostic_cache) do
       for _, diagnostic in pairs(t[namespace] or {}) do
-        add(diagnostic)
+        add(b, diagnostic)
       end
     end
   else
     bufnr = get_bufnr(bufnr)
     for _, diagnostic in pairs(diagnostic_cache[bufnr][namespace] or {}) do
-      add(diagnostic)
+      add(bufnr, diagnostic)
     end
   end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -925,7 +925,7 @@ describe('vim.diagnostic', function()
       ]]
 
       eq(1, exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]])
-      -- eq(1, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(1, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
     end)
 
     it('allows filtering by severity', function()


### PR DESCRIPTION
- Revert 5b0d8f85fdb705b07143fc4019189a9dcfe3c108
- Fix line clamping in `get_diagnostics` to consider the line count of the
  containing buffer for a diagnostic, rather than whatever the current buffer
  is.

Closes https://github.com/neovim/neovim/issues/16429.