### PR TITLE
vim-patch:8.2.3677: after a put the '] mark is on the last byte

### DIFF
--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -111,3 +111,16 @@ func Test_put_p_indent_visual()
   call assert_equal('select that text', getline(2))
   bwipe!
 endfunc
+
+func Test_multibyte_op_end_mark()
+   new
+   call setline(1, 'тест')
+   normal viwdp
+   call assert_equal([0, 1, 7, 0], getpos("'>"))
+   call assert_equal([0, 1, 7, 0], getpos("']"))
+
+   normal Vyp
+   call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
+   call assert_equal([0, 2, 7, 0], getpos("']"))
+   bwipe!
+ endfunc


### PR DESCRIPTION
Problem:    After a put the '] mark is on the last byte of a multi-byte
            character.
Solution:   Move it to the first byte. (closes vim/vim#9047)
https://github.com/vim/vim/commit/4d07253a485819b3a9fd923d263e722ea2109c12

closes #16148