### PR TITLE
vim-patch:8.2.3679: objc file detected as Octave

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -272,6 +272,8 @@ func dist#ft#FTm()
   " excluding end(for|function|if|switch|while) common to Murphi
   let octave_block_terminators = '\<end\%(_try_catch\|classdef\|enumeration\|events\|methods\|parfor\|properties\)\>'
 
+  let objc_preprocessor = '^\s*#\s*\%(import\|include\|define\|if\|ifn\=def\|undef\|line\|error\|pragma\)\>'
+
   let n = 1
   let saw_comment = 0 " Whether we've seen a multiline comment leader.
   while n < 100
@@ -282,7 +284,7 @@ func dist#ft#FTm()
       " anything more definitive.
       let saw_comment = 1
     endif
-    if line =~ '^\s*\(#\s*\(include\|import\)\>\|@import\>\|//\)'
+    if line =~ '^\s*//' || line =~ '^\s*@import\>' || line =~ objc_preprocessor
       setf objc
       return
     endif

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -866,6 +866,16 @@ func Test_m_file()
   call assert_equal('objc', &filetype)
   bwipe!
 
+  call writefile(['#include <header.h>'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('objc', &filetype)
+  bwipe!
+
+  call writefile(['#define FORTY_TWO'], 'Xfile.m')
+  split Xfile.m
+  call assert_equal('objc', &filetype)
+  bwipe!
+
   " Octave
 
   call writefile(['# Octave line comment'], 'Xfile.m')


### PR DESCRIPTION
Problem:    objc file detected as Octave. (Antony Lee)
Solution:   Detect objc by preprocessor lines. (Doug Kearns, closes vim/vim#9223,
            closes vim/vim#9220)
https://github.com/vim/vim/commit/7329cfab36356c48edab7ed68f6244eb9e20a5b1