### PR TITLE
vim-patch:8.2.{3684,3687}: blockwise insert does not handle autoindent properly

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2311,6 +2311,13 @@ void op_insert(oparg_T *oap, long count1)
         }
       }
       bd.textcol = bd2.textcol;
+      /*
+       * If the insert was in the indent then include the indent
+       * change in the new text, otherwise don't.
+       */
+      if (did_indent && bd.textcol > ind_pre) {
+          bd.textcol += ind_post - ind_pre;
+      }
       bd.textlen = bd2.textlen;
     }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2162,7 +2162,8 @@ void op_insert(oparg_T *oap, long count1)
 {
   long ins_len, pre_textlen = 0;
   char_u *firstline, *ins_text;
-  colnr_T ind_pre = 0;
+  colnr_T ind_pre_col = 0, ind_post_col;
+  int ind_pre_vcol = 0, ind_post_vcol = 0;
   struct block_def bd;
   int i;
   pos_T t1;
@@ -2196,7 +2197,8 @@ void op_insert(oparg_T *oap, long count1)
     // Get the info about the block before entering the text
     block_prep(oap, &bd, oap->start.lnum, true);
     // Get indent information
-    ind_pre = (colnr_T)getwhitecols_curline();
+    ind_pre_col = (colnr_T)getwhitecols_curline();
+    ind_pre_vcol = get_indent();
     firstline = ml_get(oap->start.lnum) + bd.textcol;
 
     if (oap->op_type == OP_APPEND) {
@@ -2261,10 +2263,11 @@ void op_insert(oparg_T *oap, long count1)
 
     // if indent kicked in, the firstline might have changed
     // but only do that, if the indent actually increased
-    const colnr_T ind_post = (colnr_T)getwhitecols_curline();
-    if (curbuf->b_op_start.col > ind_pre && ind_post > ind_pre) {
-      bd.textcol += ind_post - ind_pre;
-      bd.start_vcol += ind_post - ind_pre;
+    ind_post_col = (colnr_T)getwhitecols_curline();
+    if (curbuf->b_op_start.col > ind_pre_col && ind_post_col > ind_pre_col) {
+      bd.textcol += ind_post_col - ind_pre_col;
+      ind_post_vcol = get_indent();
+      bd.start_vcol += ind_post_vcol - ind_pre_vcol;
       did_indent = true;
     }
 
@@ -2297,12 +2300,26 @@ void op_insert(oparg_T *oap, long count1)
       }
     }
 
-    /*
-     * Spaces and tabs in the indent may have changed to other spaces and
-     * tabs.  Get the starting column again and correct the length.
-     * Don't do this when "$" used, end-of-line will have changed.
-     */
+    // Spaces and tabs in the indent may have changed to other spaces and
+    // tabs.  Get the starting column again and correct the length.
+    // Don't do this when "$" used, end-of-line will have changed.
+    //
+    // if indent was added and the inserted text was after the indent,
+    // correct the selection for the new indent.
+    if (did_indent && bd.textcol - ind_post_col > 0) {
+      oap->start.col += ind_post_col - ind_pre_col;
+      oap->start_vcol += ind_post_vcol - ind_pre_vcol;
+      oap->end.col += ind_post_col - ind_pre_col;
+      oap->end_vcol += ind_post_vcol - ind_pre_vcol;
+    }
     block_prep(oap, &bd2, oap->start.lnum, true);
+    if (did_indent && bd.textcol - ind_post_col > 0) {
+      // undo for where "oap" is used below
+      oap->start.col -= ind_post_col - ind_pre_col;
+      oap->start_vcol -= ind_post_vcol - ind_pre_vcol;
+      oap->end.col -= ind_post_col - ind_pre_col;
+      oap->end_vcol -= ind_post_vcol - ind_pre_vcol;
+    }
     if (!bd.is_MAX || bd2.textlen < bd.textlen) {
       if (oap->op_type == OP_APPEND) {
         pre_textlen += bd2.textlen - bd.textlen;
@@ -2311,13 +2328,6 @@ void op_insert(oparg_T *oap, long count1)
         }
       }
       bd.textcol = bd2.textcol;
-      /*
-       * If the insert was in the indent then include the indent
-       * change in the new text, otherwise don't.
-       */
-      if (did_indent && bd.textcol > ind_pre) {
-          bd.textcol += ind_post - ind_pre;
-      }
       bd.textlen = bd2.textlen;
     }
 

--- a/src/nvim/testdir/test_blockedit.vim
+++ b/src/nvim/testdir/test_blockedit.vim
@@ -15,6 +15,33 @@ func Test_blockinsert_indent()
   bwipe!
 endfunc
 
+func Test_blockinsert_autoindent()
+  new
+  let lines =<< trim END
+      var d = {
+      a: () => 0,
+      b: () => 0,
+      c: () => 0,
+      }
+  END
+  call setline(1, lines)
+  filetype plugin indent on
+  setlocal sw=2 et ft=vim
+  setlocal indentkeys+=:
+  exe "norm! 2Gf)\<c-v>2jA: asdf\<esc>"
+  let expected =<< trim END
+      var d = {
+        a: (): asdf => 0,
+      b: (): asdf => 0,
+      c: (): asdf => 0,
+      }
+  END
+  call assert_equal(expected, getline(1, 5))
+
+  filetype off
+  bwipe!
+endfunc
+
 func Test_blockinsert_delete()
   new
   let _bs = &bs

--- a/src/nvim/testdir/test_blockedit.vim
+++ b/src/nvim/testdir/test_blockedit.vim
@@ -38,6 +38,31 @@ func Test_blockinsert_autoindent()
   END
   call assert_equal(expected, getline(1, 5))
 
+  " insert on the next column should do exactly the same
+  :%dele
+  call setline(1, lines)
+  exe "norm! 2Gf)l\<c-v>2jI: asdf\<esc>"
+  call assert_equal(expected, getline(1, 5))
+
+  :%dele
+  call setline(1, lines)
+  setlocal sw=8 noet
+  exe "norm! 2Gf)\<c-v>2jA: asdf\<esc>"
+  let expected =<< trim END
+      var d = {
+      	a: (): asdf => 0,
+      b: (): asdf => 0,
+      c: (): asdf => 0,
+      }
+  END
+  call assert_equal(expected, getline(1, 5))
+
+  " insert on the next column should do exactly the same
+  :%dele
+  call setline(1, lines)
+  exe "norm! 2Gf)l\<c-v>2jI: asdf\<esc>"
+  call assert_equal(expected, getline(1, 5))
+
   filetype off
   bwipe!
 endfunc


### PR DESCRIPTION
Problem:    Blockwise insert does not handle autoindent properly.
Solution:   Adjust text column for indent. (closes vim/vim#9229)
https://github.com/vim/vim/commit/e9b0b40b7978f683977922233b42dd439ef31920

Problem:    Blockwise insert does not handle autoindent properly when tab is inserted.
Solution:   Adjust text column for indent before computing column.
            (closes vim/vim#9229)
https://github.com/vim/vim/commit/59f4f9505ae7ca2499904b94100db103e5ada5a6
