### PR TITLE
Set bufhidden=hide for quickfix window

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3565,7 +3565,7 @@ static void qf_set_cwindow_options(void)
   // switch off 'swapfile'
   set_option_value("swf", 0L, NULL, OPT_LOCAL);
   set_option_value("bt", 0L, "quickfix", OPT_LOCAL);
-  set_option_value("bh", 0L, "wipe", OPT_LOCAL);
+  set_option_value("bh", 0L, "hide", OPT_LOCAL);
   RESET_BINDING(curwin);
   curwin->w_p_diff = false;
   set_option_value("fdm", 0L, "manual", OPT_LOCAL);


### PR DESCRIPTION
Resolves GitHub issue #14610.

Corresponding Vim change: https://github.com/vim/vim/commit/ee8188fc7#diff-044c1fb49b65ed4f32c8f526333ceba6e2aa59b618e0b18b1b97c87975636a9aR4029

Current corresponding Vim code: https://github.com/vim/vim/blob/3d14c0f2b964195d08b34bb43f89ec5f99255194/src/quickfix.c#L4146

The corresponding Vim patch had been merged, but was reverted in https://github.com/neovim/neovim/commit/dff3a0d4495df7de085d442fd0ad15b5a8b9355d to fix https://github.com/neovim/neovim/issues/13104.

Incidentally, it looks like Vim patches that get merged and later reverted don't show up in `scripts/vim-patch.sh -l`.