### PR TITLE
fix(diagnostic): make set() go through cache when calling show()

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -650,7 +650,7 @@ function M.set(namespace, bufnr, diagnostics, opts)
   end
 
   if vim.api.nvim_buf_is_loaded(bufnr) then
-    M.show(namespace, bufnr, diagnostics, opts)
+    M.show(namespace, bufnr, nil, opts)
   end
 
   vim.api.nvim_command(

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -357,7 +357,7 @@ describe('vim.diagnostic', function()
 
     it("doesn't error after bwipeout on buffer", function()
       exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, { lnum = 0, end_lnum = 0, col = 0, end_col = 0 })
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {{ lnum = 0, end_lnum = 0, col = 0, end_col = 0 }})
         vim.cmd("bwipeout! " .. diagnostic_bufnr)
 
         vim.diagnostic.show(diagnostic_ns)
@@ -653,7 +653,7 @@ describe('vim.diagnostic', function()
 
     it("doesn't error after bwipeout called on buffer", function()
       exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, { lnum = 0, end_lnum = 0, col = 0, end_col = 0 })
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {{ lnum = 0, end_lnum = 0, col = 0, end_col = 0 }})
         vim.cmd("bwipeout! " .. diagnostic_bufnr)
 
         vim.diagnostic.reset(diagnostic_ns)


### PR DESCRIPTION
When `vim.diagnostic.set()` is called, the diagnostics passed to it are added to the diagnostic cache. `set()` then calls `show()` and passes those diagnostics along exactly as they were given to `set()`. However, we sometimes want to do some kind of post-processing on diagnostics when they come out of the cache, e.g. clamping line numbers. By forwarding the diagnostics to `show()` verbatim, `set()` skips this post-processing which can cause other bugs downstream.

Instead of passing the diagnostics directly, make the `show()` call from within `set()` retrieve diagnostics from the cache. In general, all diagnostics operations should follow the pattern of "producers put things in the cache" and "consumers get things out of the cache" and this change better adheres to that pattern.

Closes #16449.
