### PR TITLE
runtime: support once on s:GetAutocmdPrefix

### DIFF
--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -240,11 +240,11 @@ function! s:GetAutocmdPrefix(name, opts)
   endif
 
   if has_key(a:opts, 'nested') && a:opts.nested
-    call add(rv, 'nested')
+    call add(rv, '++nested')
   endif
 
   if has_key(a:opts, 'once') && a:opts.once
-    call add(rv, 'once')
+    call add(rv, '++once')
   endif
 
   return join(rv, ' ')

--- a/runtime/autoload/remote/define.vim
+++ b/runtime/autoload/remote/define.vim
@@ -243,6 +243,10 @@ function! s:GetAutocmdPrefix(name, opts)
     call add(rv, 'nested')
   endif
 
+  if has_key(a:opts, 'once') && a:opts.once
+    call add(rv, 'once')
+  endif
+
   return join(rv, ' ')
 endfunction
 


### PR DESCRIPTION
Support `once` on `s:GetAutocmdPrefix`.

I want to use the `++once` autocmd feature to remote plugin. (I'm neovim/go-client maintainer)

Regarding the test, it seems autocmd has not been tested yet on `test/functional/provider/define_spec.lua`, so I don't know how to write it.