### PR TITLE
fix(docs): fix a typo in vim.on_key() and unclosed block quotes

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -3584,7 +3584,7 @@ count({comp}, {expr} [, {ic} [, {start}]])			*count()*
 
 		Can also be used as a |method|: >
 			mylist->count(val)
-
+<
 							*cscope_connection()*
 cscope_connection([{num} , {dbpath} [, {prepend}]])
 		Checks for the existence of a |cscope| connection.  If no
@@ -3937,7 +3937,7 @@ exepath({expr})						*exepath()*
 
 		Can also be used as a |method|: >
 			GetCommand()->exepath()
-
+<
 							*exists()*
 exists({expr})	The result is a Number, which is |TRUE| if {expr} is
 		defined, zero otherwise.
@@ -4483,7 +4483,7 @@ foldlevel({lnum})					*foldlevel()*
 
 		Can also be used as a |method|: >
 			GetLnum()->foldlevel()
-
+<
 							*foldtext()*
 foldtext()	Returns a String, to be displayed for a closed fold.  This is
 		the default function used for the 'foldtext' option and should

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1235,7 +1235,7 @@ on_key({fn}, {ns_id})                                           *vim.on_key()*
                              it removes the callback for the associated
                              {ns_id}
                     {ns_id}  number? Namespace ID. If nil or 0, generates and
-                             returns a new |nvim_create_namesapce()| id.
+                             returns a new |nvim_create_namespace()| id.
 
                 Return: ~
                     number Namespace id associated with {fn}. Or count of all


### PR DESCRIPTION
Fixed the typo in the `nvim_create_namespace()` link, and unclosed block quotes in eval.txt that were messing up highlighting for some tags.