### PR TITLE
feat(lsp): add 'focus' option to open_floating_preview

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1631,6 +1631,10 @@ open_floating_preview({contents}, {syntax}, {opts})
                                   closes the floating window
                                 • focusable: (boolean, default true) Make
                                   float focusable
+                                • focus: (boolean, default true) If `true` ,
+                                  and if {focusable} is also `true` , focus an
+                                  existing floating window with the same
+                                  {focus_id}
 
                 Return: ~
                     bufnr,winnr buffer and window number of the newly created

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -520,7 +520,7 @@ local function diagnostic_move_pos(opts, pos)
         vim.api.nvim_win_get_buf(win_id),
         vim.tbl_extend("keep", float_opts, {
           scope = "cursor",
-          focusable = false,
+          focus = false,
         })
       )
     end)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1318,6 +1318,9 @@ end
 ---             - focus_id: (string) if a popup with this id is opened, then focus it
 ---             - close_events: (table) list of events that closes the floating window
 ---             - focusable: (boolean, default true) Make float focusable
+---             - focus: (boolean, default true) If `true`, and if {focusable}
+---                      is also `true`, focus an existing floating window with the same
+---                      {focus_id}
 ---@returns bufnr,winnr buffer and window number of the newly created floating
 ---preview window
 function M.open_floating_preview(contents, syntax, opts)
@@ -1329,12 +1332,13 @@ function M.open_floating_preview(contents, syntax, opts)
   opts = opts or {}
   opts.wrap = opts.wrap ~= false -- wrapping by default
   opts.stylize_markdown = opts.stylize_markdown ~= false
+  opts.focus = opts.focus ~= false
   opts.close_events = opts.close_events or {"CursorMoved", "CursorMovedI", "BufHidden", "InsertCharPre"}
 
   local bufnr = api.nvim_get_current_buf()
 
   -- check if this popup is focusable and we need to focus
-  if opts.focus_id and opts.focusable ~= false then
+  if opts.focus_id and opts.focusable ~= false and opts.focus then
     -- Go back to previous window if we are in a focusable one
     local current_winnr = api.nvim_get_current_win()
     if npcall(api.nvim_win_get_var, current_winnr, opts.focus_id) then


### PR DESCRIPTION
When the 'focusable' and 'focus_id' parameters are set,
`open_floating_preview` assumes that it should always move focus to an
existing floating window with the same 'focus_id'. However, there are
cases where we want to make a floating window focusable, but do not want
to focus it upon calling `open_floating_preview`. To distinguish these
cases, add a boolean parameter 'focus' that, when false, prevents
moving focus.

Ref https://github.com/neovim/neovim/issues/16425