### PR TITLE
fix(lsp): change rpc start notify level to warn

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -329,7 +329,7 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
       else
         msg = msg .. string.format(" with error message: %s", pid)
       end
-      vim.notify(msg, vim.log.levels.ERROR)
+      vim.notify(msg, vim.log.levels.WARN)
       return
     end
   end


### PR DESCRIPTION
* This is less obtrusive, and does not require a confirmation to dismiss