### PR TITLE
vim-patch:8.2.3703: most people call F# "fsharp" and not "fs"

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -231,7 +231,7 @@ func dist#ft#FTfs()
 	  \ || line =~ '^\s*: \S'
       setf forth
     else
-      setf fs
+      setf fsharp
     endif
   endif
 endfunc

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -630,9 +630,6 @@ au BufNewFile,BufRead *.mas,*.master		setf master
 " Forth
 au BufNewFile,BufRead *.ft,*.fth		setf forth
 
-" F# or Forth
-au BufNewFile,BufRead *.fs			call dist#ft#FTfs()
-
 " Reva Forth
 au BufNewFile,BufRead *.frt			setf reva
 
@@ -647,6 +644,12 @@ au BufNewFile,BufRead *.fsl			setf framescript
 
 " FStab
 au BufNewFile,BufRead fstab,mtab		setf fstab
+
+" F# or Forth
+au BufNewFile,BufRead *.fs			call dist#ft#FTfs()
+
+" F#
+au BufNewFile,BufRead *.fsi,*.fsx		setf fsharp
 
 " GDB command files
 au BufNewFile,BufRead .gdbinit,gdbinit		setf gdb

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -187,7 +187,7 @@ let s:filename_checks = {
     \ 'fpcmake': ['file.fpc'],
     \ 'framescript': ['file.fsl'],
     \ 'freebasic': ['file.fb', 'file.bi'],
-    \ 'fs': ['file.fs'],
+    \ 'fsharp': ['file.fs', 'file.fsi', 'file.fsx'],
     \ 'fstab': ['fstab', 'mtab'],
     \ 'fvwm': ['/.fvwm/file', 'any/.fvwm/file'],
     \ 'gdb': ['.gdbinit', 'gdbinit'],
@@ -952,7 +952,7 @@ func Test_fs_file()
 
   call writefile(['looks like F#'], 'Xfile.fs')
   split Xfile.fs
-  call assert_equal('fs', &filetype)
+  call assert_equal('fsharp', &filetype)
   bwipe!
 
   let g:filetype_fs = 'forth'


### PR DESCRIPTION
#### vim-patch:8.2.3703: most people call F# "fsharp" and not "fs"

Problem:    Most people call F# "fsharp" and not "fs".
Solution:   Rename filetype "fs" to "fsharp".
https://github.com/vim/vim/commit/53ba95e4f0a82f6dab1791bb01f6cddc9b3f61b3