### PR TITLE
fix(diagnostic): set effective buffer number for DiagnosticChanged autocmd

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -653,9 +653,11 @@ function M.set(namespace, bufnr, diagnostics, opts)
     M.show(namespace, bufnr, nil, opts)
   end
 
-  vim.api.nvim_command(
-    string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.api.nvim_buf_get_name(bufnr))
-  )
+  vim.api.nvim_buf_call(bufnr, function()
+    vim.api.nvim_command(
+      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.api.nvim_buf_get_name(bufnr))
+    )
+  end)
 end
 
 --- Get namespace metadata.


### PR DESCRIPTION
This enables use of `<abuf>` in autocommand handlers for DiagnosticChanged.
