### PR TITLE
test(api): mark "notify cancels stale events on channel close" fragile

### DIFF
--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -81,6 +81,8 @@ describe('notify', function()
     if isCI() then
       pending('hangs on CI #14083 #15251')
       return
+    elseif helpers.skip_fragile(pending) then
+      return
     end
     if helpers.pending_win32(pending) then return end
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")


### PR DESCRIPTION
This is already skipped in all CI environments, so it should also be
skipped in environments that don't like fragile tests.  Since there's no
convenient way to express these concisely, add the explicit fragile
skip.