### PR TITLE
docs: prevent nondeterminism in vim.validate docgen

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1605,14 +1605,14 @@ validate({opt})                                               *vim.validate()*
 
                 Examples with explicit argument values (can be run directly): >
 
+                  -- This is a no-op (validation succeeds)
                   vim.validate{arg1={{'foo'}, 'table'}, arg2={'foo', 'string'}}
-                     => NOP (success)
 
+                  -- error('arg1: expected table, got number')
                   vim.validate{arg1={1, 'table'}}
-                     => error('arg1: expected table, got number')
 
+                  -- error('arg1: expected even number, got 3')
                   vim.validate{arg1={3, function(a) return (a % 2) == 0 end, 'even number'}}
-                     => error('arg1: expected even number, got 3')
 <
 
                 Parameters: ~

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -516,14 +516,14 @@ end
 ---
 --- Examples with explicit argument values (can be run directly):
 --- <pre>
+---  -- This is a no-op (validation succeeds)
 ---  vim.validate{arg1={{'foo'}, 'table'}, arg2={'foo', 'string'}}
----     => NOP (success)
 ---
+---  -- error('arg1: expected table, got number')
 ---  vim.validate{arg1={1, 'table'}}
----     => error('arg1: expected table, got number')
 ---
+---  -- error('arg1: expected even number, got 3')
 ---  vim.validate{arg1={3, function(a) return (a % 2) == 0 end, 'even number'}}
----     => error('arg1: expected even number, got 3')
 --- </pre>
 ---
 ---@param opt Map of parameter names to validations. Each key is a parameter


### PR DESCRIPTION
The `gen_vimdoc` script ping-pongs between two different outputs for the
vim.validate documentation, likely because of the `>` characters
contained within the snippet. Replace those with Lua comments to prevent
this.
