### PR TITLE
chore: add default luarc.json for Lua development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Tools
 /venv/
 compile_commands.json
+/.luarc.json
 
 # IDEs
 /.vs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,10 @@ You can lint a single file (but this will _not_ exclude legacy errors):
   ("Exuberant ctags", the typical `ctags` binary provided by your distro, is
   unmaintained and won't recognize many function signatures in Neovim source.)
 - Explore the source code [on the web](https://sourcegraph.com/github.com/neovim/neovim).
+- If using [lua-language-server][], symlink `contrib/luarc.json` into the
+  project root:
+
+      $ ln -s contrib/luarc.json .luarc.json
 
 
 Reviewing
@@ -288,3 +292,4 @@ as context, use the `-W` argument as well.
 [pr-draft]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 [pr-ready]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
 [uncrustify]: https://formulae.brew.sh/formula/uncrustify
+[lua-language-server]: https://github.com/sumneko/lua-language-server/

--- a/contrib/luarc.json
+++ b/contrib/luarc.json
@@ -1,0 +1,15 @@
+{
+    "runtime.version": "LuaJIT",
+    "diagnostics": {
+        "enable": true,
+        "globals": ["vim"]
+    },
+    "workspace": {
+        "library": {
+            "runtime/lua": true
+        },
+        "maxPreload": 2000,
+        "preloadFileSize": 1000
+    },
+    "telemetry.enable": false
+}

--- a/contrib/luarc.json
+++ b/contrib/luarc.json
@@ -2,7 +2,15 @@
     "runtime.version": "LuaJIT",
     "diagnostics": {
         "enable": true,
-        "globals": ["vim"]
+        "globals": [
+          "vim",
+          "describe",
+          "it",
+          "before_each",
+          "after_each",
+          "setup",
+          "teardown"
+        ]
     },
     "workspace": {
         "library": {


### PR DESCRIPTION
The Sumneko Lua language server has matured quite a bit and many Neovim developers use it while working on Neovim. Having a default configuration for Neovim development is a nice convenience (and dovetails well with the auto-generated `compile_command.json` for C development).

The file is shipped under `contrib` and users can make use of it by symlinking to `.luarc.json` in the project root.
