### PR TITLE
Improve help for 'DiagnosticUnderline*' default highlighting

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -175,9 +175,9 @@ All highlights defined for diagnostics begin with `Diagnostic` followed by
 the type of highlight (e.g., `Sign`, `Underline`, etc.) and the severity (e.g.
 `Error`, `Warn`, etc.)
 
-Sign, floating and virtual text highlights (by default) are linked to their
-corresponding default highlight. Underline highlights (by default) are defined
-with corresponding color.
+By default, highlights for signs, floating windows, and virtual text are linked to the
+corresponding default highlight. Underline highlights are not linked and use their
+own default highlight groups.
 
 For example, the default highlighting for |hl-DiagnosticSignError| is linked
 to |hl-DiagnosticError|. To change the default (and therefore the linked

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -175,8 +175,9 @@ All highlights defined for diagnostics begin with `Diagnostic` followed by
 the type of highlight (e.g., `Sign`, `Underline`, etc.) and the severity (e.g.
 `Error`, `Warn`, etc.)
 
-Sign, underline and virtual text highlights (by default) are linked to their
-corresponding default highlight.
+Sign, floating and virtual text highlights (by default) are linked to their
+corresponding default highlight. Underline highlights (by default) are defined
+with corresponding color.
 
 For example, the default highlighting for |hl-DiagnosticSignError| is linked
 to |hl-DiagnosticError|. To change the default (and therefore the linked


### PR DESCRIPTION
This helps clarifying defaults of `DiagnosticUnderline*` highlight groups.

Didn't find any other place where this text is defined for doc generation script. Hope, this is where it should go.