### PR TITLE
fix(diagnostic): clamp diagnostics on negative line numbers

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -386,7 +386,7 @@ local function get_diagnostics(bufnr, opts, clamp)
     if not opts.lnum or d.lnum == opts.lnum then
       if clamp and vim.api.nvim_buf_is_loaded(b) then
         local line_count = buf_line_count[b] - 1
-        if (d.lnum > line_count or d.end_lnum > line_count) then
+        if (d.lnum > line_count or d.end_lnum > line_count or d.lnum < 0 or d.end_lnum < 0) then
           d = vim.deepcopy(d)
           d.lnum = math.max(math.min(d.lnum, line_count), 0)
           d.end_lnum = math.max(math.min(d.end_lnum, line_count), 0)


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/16492

Despite having logic for setting the maximum diagnostic line
number to at minimum 0, previously the conditional statement only
checked if lnum and end_lnum were greater than the line count.

Fix: also check if lnum and end_lnum are less than 0.