### PR TITLE
feat(snippet): Minimal snippet API

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -37,6 +37,7 @@ for k, v in pairs({
   ui = true,
   health = true,
   secure = true,
+  snippet = true,
   _watch = true,
 }) do
   vim._submodules[k] = v

--- a/runtime/lua/vim/lsp/_snippet.lua
+++ b/runtime/lua/vim/lsp/_snippet.lua
@@ -481,6 +481,8 @@ S.snippet = P.map(P.many(P.any(S.toplevel, S.text({ '$' }, { '}', '\\' }))), fun
   }, Node)
 end)
 
+---@alias vim.lsp.snippet.Node table
+
 local M = {}
 
 ---The base snippet node.

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -1,15 +1,32 @@
 local lsp_snippet = require('vim.lsp._snippet')
 
+---@alias vim.snippet.MarkId number
+---@alias vim.snippet.Tabstop number
+---@alias vim.snippet.Changenr number
+---@alias vim.snippet.Position { [1]: number, [2]: number } # The 0-origin utf8 byte index.
+---@alias vim.snippet.Range { s: vim.snippet.Position, e: vim.snippet.Position } # The 0-origin utf8 byte index.
+
+---@class vim.snippet.TraverseContext
+---@field depth number
+---@field range vim.snippet.Range
+---@field replace fun(new_node: vim.lsp.snippet.Node): nil
+
 ---Feed keys.
 ---NOTE: This always enables `virtualedit=onemore`
 ---@param keys string
----@param mode string
-local function feedkeys(keys, mode)
+local function feedkeys(keys)
   local k = {}
   table.insert(k, '<Cmd>set virtualedit=onemore<CR>')
   table.insert(k, keys)
   table.insert(k, ('<Cmd>set virtualedit=%s<CR>'):format(vim.o.virtualedit))
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(table.concat(k), true, true, true), mode, true)
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(table.concat(k), true, true, true), 'ni', true)
+end
+
+---Return cursor position.
+---@return vim.snippet.Position
+local function cursor_position()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  return { cursor[1] - 1, cursor[2] }
 end
 
 ---Return one indent string of current buffer.
@@ -64,9 +81,9 @@ local function adjust_indent(snippet_text)
 end
 
 ---Get range from extmark.
----@param ns string
+---@param ns number
 ---@param mark_id number
----@return { s: number[], e: number[] }
+---@return vim.snippet.Range
 local function get_range_from_mark(ns, mark_id)
   local mark = vim.api.nvim_buf_get_extmark_by_id(0, ns, mark_id, { details = true })
   local s = { mark[1], mark[2] }
@@ -80,7 +97,7 @@ local function get_range_from_mark(ns, mark_id)
 end
 
 ---Get text from range.
----@param range { s: number[], e: number[] }
+---@param range vim.snippet.Range
 ---@return string
 local function get_text_by_range(range)
   local lines = vim.api.nvim_buf_get_lines(0, range.s[1], range.e[1] + 1, false)
@@ -94,65 +111,78 @@ local function get_text_by_range(range)
 end
 
 ---Traverse snippet ast.
----NOTE: The `context.range` calculated by `tostring(node)`.
+---The `context.range` is calculated by `tostring(node)`, so it can be used only for processing before snippet insertion.
 ---@param snippet_node table
----@param callback fun(node: table, context: { depth: number, index: number, range: { s: number[], e: number[] }, parent?: table, replace: fun(new_node: table) }): table|nil
----@param cursor? number[]
-local function traverse(snippet_node, callback, cursor)
+---@param callback fun(node: table, context: vim.snippet.TraverseContext): table|nil
+local function traverse(snippet_node, callback)
+  ---Traverse snippet ast.
   ---@param node table
-  ---@param context { depth: number, index: number, range: { s: number[], e: number[] }, parent?: table, replace: fun(new_node: table) }
-  ---@param cursor_ number[]
-  local function traverse_recursive(node, context, cursor_)
-    local s = { cursor_[1], cursor_[2] }
+  ---@param context vim.snippet.TraverseContext
+  ---@param position vim.snippet.Position
+  local function traverse_recursive(node, context, position)
+    -- Memoize starting position of this node.
+    local start_position = { position[1], position[2] }
+
+    -- Traverse children or this node.
     if node.children then
       for i, child in ipairs(node.children) do
         traverse_recursive(child, {
           depth = context.depth + 1,
-          index = i,
-          parent = node,
           replace = (function(children, index)
             return function(new_node)
               children[index] = new_node
             end
           end)(node.children, i)
-        }, cursor_)
+        }, position)
       end
     else
       local texts = vim.split(tostring(node), '\n')
-      cursor_[1] = cursor_[1] + #texts - 1
-      cursor_[2] = #texts > 1 and #texts[#texts] or (cursor_[2] + #texts[1])
+      position[1] = position[1] + #texts - 1
+      position[2] = #texts > 1 and #texts[#texts] or (position[2] + #texts[1])
     end
-    context.range = { s = s, e = { cursor_[1], cursor_[2] } }
+
+    -- Callback with range of this node.
+    context.range = { s = start_position, e = { position[1], position[2] } }
     callback(node, context)
   end
+
+  -- Start traversing.
   traverse_recursive(snippet_node, {
     depth = 0,
-    index = 1,
-    parent = nil,
     replace = function()
+      -- noop: the root node can't be replaced.
     end
-  }, cursor or { 0, 0 })
+  }, { 0, 0 })
 end
 
----Select specific mark.
+---Jump to specific mark.
 ---@param mark vim.snippet.SnippetMark
-local function select_mark(mark)
+local function jump_to_mark(mark)
   local range = mark:get_range()
   if mark.node.type == lsp_snippet.Node.Type.Choice then
-    feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>i]]):format(range.e[1] + 1, range.e[2] + 1), 'ni')
+    feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>i]]):format(range.e[1] + 1, range.e[2] + 1))
+
+    -- TODO: The key-sequence is asynchronous and it can't be waited via `vim.wait` so we use `vim.schedule` here.
     vim.schedule(function()
-      vim.fn.complete(range.s[2] + 1, mark.node.items)
+      vim.ui.select(mark.node.items, {
+        prompt = 'Select a choice:'
+      }, function(choise)
+        mark:set_node_text(choise)
+        mark:sync()
+      end)
     end)
   else
     if range.s[1] == range.e[1] and range.s[2] == range.e[2] then
-      feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>i]]):format(range.e[1] + 1, range.e[2] + 1), 'ni')
+      -- jump.
+      feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>i]]):format(range.e[1] + 1, range.e[2] + 1))
     else
+      -- select.
       feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>v<Cmd>call cursor(%s,%s)<CR><Esc>gvo<C-g>]]):format(
         range.s[1] + 1,
         range.s[2] + 1,
         range.e[1] + 1,
         range.e[2]
-      ), 'ni')
+      ))
     end
   end
 end
@@ -167,17 +197,16 @@ local function resolve_variable(var_name)
   elseif var_name == 'TM_CURRENT_LINE' then
     return vim.api.nvim_get_current_line()
   elseif var_name == 'TM_CURRENT_WORD' then
-    local cursor = vim.api.nvim_win_get_cursor(0)
     local line = vim.api.nvim_get_current_line()
-    local before = string.sub(line, 1, cursor[2])
+    local before = string.sub(line, 1, cursor_position()[2])
     local word_s = vim.regex([[\k\+$]]):match_str(before) or #before
     local word_after = string.sub(line, word_s + 1)
     local _, word_e = vim.regex([[^\k\+]]):match_str(word_after)
     return string.sub(line, word_s + 1, (word_e or word_s - 1) + 1)
   elseif var_name == 'TM_LINE_INDEX' then
-    return vim.api.nvim_win_get_cursor(0)[2]
+    return cursor_position()[1]
   elseif var_name == 'TM_LINE_NUMBER' then
-    return vim.api.nvim_win_get_cursor(0)[2] + 1
+    return cursor_position()[1] + 1
   elseif var_name == 'TM_FILENAME' then
     return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':p:t')
   elseif var_name == 'TM_FILENAME_BASE' then
@@ -207,15 +236,19 @@ local function analyze_snippet(snippet_text)
   }
 
   -- Normalize snippet nodes.
-  local has_trailing_tabstop, origins = false, {}
+  local has_trailing_tabstop = false
+  local origin_nodes = {} ---@type table<vim.snippet.Tabstop, vim.lsp.snippet.Node>
   traverse(analyzed.node, function(node, context)
     if type(node.tabstop) == 'number' then
-      local origin = origins[node.tabstop]
-      if origin then
-        context.replace(setmetatable(vim.tbl_deep_extend('keep', {}, origin), lsp_snippet.Node))
+      local origin_node = origin_nodes[node.tabstop]
+      if origin_node then
+        -- Replace as cloned origin if same tabstop already exists.
+        context.replace(setmetatable(vim.tbl_deep_extend('keep', {}, origin_node), lsp_snippet.Node))
       else
-        origins[node.tabstop] = node
+        -- Set node as origin.
+        origin_nodes[node.tabstop] = node
       end
+
       has_trailing_tabstop = has_trailing_tabstop or node.tabstop == 0
       analyzed.min_tabstop = math.min(analyzed.min_tabstop or node.tabstop, node.tabstop)
       analyzed.max_tabstop = math.max(analyzed.max_tabstop or node.tabstop, node.tabstop)
@@ -231,25 +264,24 @@ local function analyze_snippet(snippet_text)
   analyzed.min_tabstop = analyzed.min_tabstop or 0
   analyzed.max_tabstop = analyzed.max_tabstop or 0
 
-  -- Normalize tabstops.
+  -- Add final tabstop if not exist.
   if not has_trailing_tabstop then
     table.insert(analyzed.node.children, setmetatable({
       type = lsp_snippet.Node.Type.Tabstop,
       tabstop = 0,
     }, lsp_snippet.Node))
   end
+
+  -- Fix 0-tabstop to max-tabstop + 1.
   traverse(analyzed.node, function(node)
     if node.tabstop == 0 then
       node.tabstop = analyzed.max_tabstop + 1
     end
   end)
 
-  -- Create insertion text.
+  -- Create first insertion text.
   traverse(analyzed.node, function(node)
-    if vim.tbl_contains({
-          lsp_snippet.Node.Type.Text,
-          lsp_snippet.Node.Type.Choice,
-        }, node.type) then
+    if vim.tbl_contains({ lsp_snippet.Node.Type.Text, lsp_snippet.Node.Type.Choice, }, node.type) then
       analyzed.text = analyzed.text .. tostring(node)
     end
   end)
@@ -258,43 +290,46 @@ local function analyze_snippet(snippet_text)
 end
 
 ---@class vim.snippet.SnippetController
----@field public session vim.snippet.SnippetSession
+---@field public session? vim.snippet.SnippetSession
 local SnippetController = {
   session = nil,
 }
 
----@alias vim.snippet.JumpDirection "1" | "2"
-local JumpDirection = {}
-JumpDirection.Next = 1
-JumpDirection.Prev = 2
+---@enum vim.snippet.JumpDirection
+local JumpDirection = {
+  Next = 1,
+  Prev = 2,
+}
 
 ---@class vim.snippet.SnippetMark
----@field public ns string
----@field public mark_id number
----@field public node table
----@field public origin table
+---@field public bufnr number
+---@field public ns number
+---@field public mark_id vim.snippet.MarkId
+---@field public node vim.lsp.snippet.Node
+---@field public origin_node? vim.lsp.snippet.Node
 ---@field public text string
 local SnippetMark = {}
 
----@param params { ns: string, mark_id: number, node: table, range: { s: number[], e: number[] }, origin: table }
+---Create SnippetMark instance.
+---@param params { ns: number, mark_id: vim.snippet.MarkId, node: vim.lsp.snippet.Node, range: vim.snippet.Range, origin_node?: vim.lsp.snippet.Node }
 function SnippetMark.new(params)
   local self = setmetatable({}, { __index = SnippetMark })
   self.ns = params.ns
   self.mark_id = params.mark_id
   self.node = params.node
-  self.origin = params.origin
+  self.origin_node = params.origin_node
   self.text = get_text_by_range(get_range_from_mark(params.ns, params.mark_id))
   return self
 end
 
 ---Get actual range from extmark.
----@return { s: number[], e: number[] }
+---@return vim.snippet.Range
 function SnippetMark:get_range()
   return get_range_from_mark(self.ns, self.mark_id)
 end
 
 ---Set range.
----@param range { s: number[], e: number[] }
+---@param range vim.snippet.Range
 function SnippetMark:set_range(range)
   vim.api.nvim_buf_set_extmark(0, self.ns, range.s[1], range.s[2], {
     id = self.mark_id,
@@ -305,15 +340,15 @@ function SnippetMark:set_range(range)
   })
 end
 
----Get text.
+---Get current node text.
 ---@return string
-function SnippetMark:get_text()
+function SnippetMark:get_node_text()
   return self.text
 end
 
----Set text to the buffer.
+---Set current node text.
 ---@param new_text string
-function SnippetMark:set_text(new_text)
+function SnippetMark:set_node_text(new_text)
   self.text = new_text
 end
 
@@ -332,12 +367,12 @@ function SnippetMark:dispose()
 end
 
 ---@class vim.snippet.SnippetSession
----@field public ns string
+---@field public ns number
 ---@field public bufnr number
----@field public marks table
+---@field public marks vim.snippet.SnippetMark[]
+---@field public history table<vim.snippet.Changenr, table<vim.snippet.MarkId, vim.snippet.Range>>
 ---@field public disposed boolean
 ---@field public changedtick number
----@field public saved_ranges table<number, table<number, { s: number[], e: number[] }>>
 ---@field public current_tabstop number
 ---@field public snippet_mark_ns number
 ---@field public snippet_mark_id number
@@ -351,9 +386,9 @@ function SnippetSession.new(bufnr, namespace)
   self.ns = vim.api.nvim_create_namespace(namespace)
   self.bufnr = bufnr
   self.marks = {}
+  self.history = {}
   self.disposed = false
   self.changedtick = 0
-  self.saved_ranges = {}
   self.current_tabstop = 0
   self.snippet_mark_ns = vim.api.nvim_create_namespace(namespace .. ':snippet')
   self.snippet_mark_id = 0
@@ -365,34 +400,38 @@ end
 function SnippetSession:expand(snippet_text)
   local analyzed = analyze_snippet(adjust_indent(snippet_text))
   local texts = vim.split(analyzed.text, '\n')
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  cursor[1] = cursor[1] - 1
+  local cursor = cursor_position()
 
-  -- Insert normalized snippet text.
+  -- Insert snippet text.
   vim.api.nvim_buf_set_text(0, cursor[1], cursor[2], cursor[1], cursor[2], texts)
   vim.api.nvim_win_set_cursor(0, { cursor[1] + 1, cursor[2] })
 
-  -- Create extmarks.
-  local marks, origins = {}, {}
+  -- Create tabstop marks.
+  local origin_nodes = {} ---@type table<vim.snippet.Tabstop, vim.lsp.snippet.Node>
+  local marks = {} ---@type vim.snippet.SnippetMark[]
   traverse(analyzed.node, function(node, context)
     if type(node.tabstop) == 'number' then
+      local buffer_range = {
+        s = { context.range.s[1] + cursor[1], context.range.s[2] + (context.range.s[1] == 0 and cursor[2] or 0) },
+        e = { context.range.e[1] + cursor[1], context.range.e[2] + (context.range.e[1] == 0 and cursor[2] or 0) },
+      } ---@type vim.snippet.Range
       table.insert(marks, SnippetMark.new({
         ns = self.ns,
         node = node,
-        origin = origins[node.tabstop or -1],
-        mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, self.ns, context.range.s[1], context.range.s[2], {
-          end_line = context.range.e[1],
-          end_col = context.range.e[2],
+        origin_node = origin_nodes[node.tabstop],
+        mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, self.ns, buffer_range.s[1], buffer_range.s[2], {
+          end_line = buffer_range.e[1],
+          end_col = buffer_range.e[2],
           right_gravity = false,
           end_right_gravity = true,
         })
       }))
-      origins[node.tabstop] = node
+      origin_nodes[node.tabstop] = origin_nodes[node.tabstop] or node
     end
-  end, { cursor[1], cursor[2] })
+  end)
   self.marks = marks
 
-  -- Create snippet region marks.
+  -- Create whole region mark.
   self.snippet_mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, self.snippet_mark_ns, cursor[1], cursor[2], {
     end_line = cursor[1] + (#texts - 1),
     end_col = #texts > 1 and #texts[#texts] or cursor[2] + #texts[1],
@@ -411,7 +450,7 @@ function SnippetSession:jump(direction)
   local next_mark = self:find_next_mark(direction)
   if next_mark then
     self.current_tabstop = next_mark.node.tabstop
-    select_mark(next_mark)
+    jump_to_mark(next_mark)
     self:sync()
   end
 end
@@ -440,59 +479,75 @@ function SnippetSession:find_next_mark(direction)
 end
 
 ---Synchronize tabstop texts.
+---0. Check buffer's changedtick.
+---1. Check the changes are included in snippet range.
+---2. Restore memoized state if the changes are occurred by undo/redo.
+---3. Update memoized state if the changes are occurred by user input.
+---4. Dispose directly modified non-origin marks.
+---5. Update origin marks via buffer contents.
+---6. Update non-origin marks via origin mark contents.
 function SnippetSession:sync()
-  if not self:within() then
-    self:dispose()
-    return
-  end
-
+  --- Ignore if the buffer isn't changed.
   local changedtick = vim.api.nvim_buf_get_changedtick(0)
   if self.changedtick == changedtick then
     return
   end
 
+  -- Check the changes are included in snippet range.
+  if not self:within() then
+    self:dispose()
+    return
+  end
+
   local changenr = vim.fn.changenr()
 
-  -- Ignore undo/redo.
+  --- Restore memoized state if changes are occurred by undo/redo.
   local undotree = vim.fn.undotree()
   if undotree.seq_last ~= undotree.seq_cur then
     for _, mark in ipairs(self.marks) do
-      mark:set_text(get_text_by_range(mark:get_range()))
-      if self.saved_ranges[changenr] and self.saved_ranges[changenr][mark.mark_id] then
-        mark:set_range(self.saved_ranges[changenr][mark.mark_id])
+      mark:set_node_text(get_text_by_range(mark:get_range()))
+      if self.history[changenr] and self.history[changenr][mark.mark_id] then
+        mark:set_range(self.history[changenr][mark.mark_id])
       end
     end
     self.changedtick = changedtick
     return
   end
 
-  --- Save current mark ranges.
-  self.saved_ranges[changenr] = {}
+  --- Save current state.
+  self.history[changenr] = {}
   for _, mark in ipairs(self.marks) do
-    self.saved_ranges[changenr][mark.mark_id] = mark:get_range()
+    self.history[changenr][mark.mark_id] = mark:get_range()
   end
 
   -- Dispose directly modified non-origin marks.
   for i = #self.marks, 1, -1 do
     local mark = self.marks[i]
-    if mark.origin then
-      if mark:get_text() ~= get_text_by_range(mark:get_range()) then
+    if mark.origin_node then
+      if mark:get_node_text() ~= get_text_by_range(mark:get_range()) then
         table.remove(self.marks, i)
         mark:dispose()
       end
     end
   end
 
-  -- Sync non-origin marks.
-  local origins = {}
+  local origin_marks = {} ---@type table<vim.snippet.Tabstop, vim.snippet.SnippetMark>
+
+  -- Sync origin marks with pysical buffer text.
   for _, mark in ipairs(self.marks) do
-    origins[mark.node.tabstop] = origins[mark.node.tabstop] or mark
-    if mark == origins[mark.node.tabstop] then
-      mark:set_text(get_text_by_range(mark:get_range()))
-    else
-      mark:set_text(origins[mark.node.tabstop]:get_text())
+    if not mark.origin_node then
+      origin_marks[mark.node.tabstop] = mark
+      mark:set_node_text(get_text_by_range(mark:get_range()))
+      mark:sync()
     end
-    mark:sync()
+  end
+
+  -- Sync non-origin marks with origin marks.
+  for _, mark in ipairs(self.marks) do
+    if mark.origin_node then
+      mark:set_node_text(origin_marks[mark.node.tabstop]:get_node_text())
+      mark:sync()
+    end
   end
 
   self.changedtick = changedtick
@@ -505,20 +560,24 @@ function SnippetSession:within()
     return false
   end
 
+  -- Check the buffer is attched.
   if self.bufnr ~= vim.api.nvim_get_current_buf() then
     return false
   end
 
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  cursor[1] = cursor[1] - 1
-
+  local cursor = cursor_position()
   local range = get_range_from_mark(self.snippet_mark_ns, self.snippet_mark_id)
+
+  -- Check the cursor is before the snippet start position.
   if cursor[1] < range.s[1] or (cursor[1] == range.s[1] and cursor[2] < range.s[2]) then
     return false
   end
+
+  -- Check the cursor is after the snippet end position.
   if range.e[1] < cursor[1] or (range.e[1] == cursor[1] and range.e[2] < cursor[2]) then
     return false
   end
+
   return true
 end
 
@@ -531,9 +590,20 @@ function SnippetSession:dispose()
   self.disposed = true
 end
 
+---The vim.snippet's public APIs.
 local M = {}
 
 M.JumpDirection = JumpDirection
+
+---Return snippet session is active or not.
+---@return boolean
+function M.is_active()
+  local session = SnippetController.session
+  if not session or session.disposed then
+    return false
+  end
+  return true
+end
 
 ---Expand snippet text.
 ---@param snippet_text string
@@ -547,12 +617,14 @@ function M.expand(snippet_text)
   SnippetController.session:expand(snippet_text)
   SnippetController.session:jump(M.JumpDirection.Next)
 
-  local session = SnippetController.session
+  local session = SnippetController.session ---@type vim.snippet.SnippetSession
   vim.api.nvim_buf_attach(bufnr, false, {
     on_lines = function()
       if session.disposed then
         return true
       end
+
+      -- Avoid duplicate modification. (SnippetSession:sync also will modify the buffer contents).
       vim.schedule(function()
         session:sync()
       end)
@@ -564,7 +636,7 @@ end
 ---@param direction vim.snippet.JumpDirection
 ---@return boolean
 function M.jumpable(direction)
-  if not SnippetController.session or SnippetController.session.disposed then
+  if not M.is_active() or not SnippetController.session then
     return false
   end
   return not not SnippetController.session:find_next_mark(direction)
@@ -573,7 +645,7 @@ end
 ---Jump to next placeholder.
 ---@param direction vim.snippet.JumpDirection
 function M.jump(direction)
-  if not SnippetController.session or SnippetController.session.disposed then
+  if not M.is_active() or not SnippetController.session then
     return
   end
   SnippetController.session:jump(direction)
@@ -581,7 +653,7 @@ end
 
 ---Sync current modification.
 function M.sync()
-  if not SnippetController.session or SnippetController.session.disposed then
+  if not M.is_active() or not SnippetController.session then
     return
   end
   SnippetController.session:sync()
@@ -589,7 +661,7 @@ end
 
 ---Dispose current snippet session
 function M.dispose()
-  if not SnippetController.session or SnippetController.session.disposed then
+  if not M.is_active() or not SnippetController.session then
     return
   end
   SnippetController.session:dispose()

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -1,0 +1,599 @@
+local lsp_snippet = require('vim.lsp._snippet')
+
+---Feed keys.
+---NOTE: This always enables `virtualedit=onemore`
+---@param keys string
+---@param mode string
+local function feedkeys(keys, mode)
+  local k = {}
+  table.insert(k, '<Cmd>set virtualedit=onemore<CR>')
+  table.insert(k, keys)
+  table.insert(k, ('<Cmd>set virtualedit=%s<CR>'):format(vim.o.virtualedit))
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(table.concat(k), true, true, true), mode, true)
+end
+
+---Return one indent string of current buffer.
+---@return string
+local function get_one_indent()
+  local expandtab = vim.api.nvim_get_option('expandtab')
+  if not expandtab then
+    return '\t'
+  end
+  local shiftwidth = vim.api.nvim_get_option('shiftwidth')
+  if shiftwidth > 0 then
+    return string.rep(' ', shiftwidth)
+  end
+  return string.rep(' ', vim.api.nvim_get_option('tabstop'))
+end
+
+---Return base indent of current line.
+---@return string
+local function get_base_indent()
+  return string.match(vim.api.nvim_get_current_line(), '^%s*') or ''
+end
+
+---Adjust snippet indent
+---@param snippet_text string
+---@return string
+local function adjust_indent(snippet_text)
+  local one_indent = get_one_indent()
+  local base_indent = get_base_indent()
+
+  local adjusted_snippet_text = {}
+  local texts = vim.split(snippet_text, '\n', { plain = true })
+  for i, text in ipairs(texts) do
+    if i ~= #texts and string.match(text, '^%s*$') then
+      -- Remove space only lines except the last line.
+      table.insert(adjusted_snippet_text, '')
+    else
+      -- Adjust indent.
+      if i ~= 1 then
+        -- Change \t as one_indent.
+        text = string.gsub(text, '^(\t+)', function(indent)
+          return string.gsub(indent, '\t', one_indent)
+        end)
+        -- Add base_indent.
+        table.insert(adjusted_snippet_text, base_indent .. text)
+      else
+        -- Use first line as-is.
+        table.insert(adjusted_snippet_text, text)
+      end
+    end
+  end
+  return table.concat(adjusted_snippet_text, '\n')
+end
+
+---Get range from extmark.
+---@param ns string
+---@param mark_id number
+---@return { s: number[], e: number[] }
+local function get_range_from_mark(ns, mark_id)
+  local mark = vim.api.nvim_buf_get_extmark_by_id(0, ns, mark_id, { details = true })
+  local s = { mark[1], mark[2] }
+  local e = { mark[3].end_row, mark[3].end_col }
+  if s[1] > e[1] or (s[1] == e[1] and s[2] > e[2]) then
+    local t = s
+    s = e
+    e = t
+  end
+  return { s = s, e = e }
+end
+
+---Get text from range.
+---@param range { s: number[], e: number[] }
+---@return string
+local function get_text_by_range(range)
+  local lines = vim.api.nvim_buf_get_lines(0, range.s[1], range.e[1] + 1, false)
+  if range.s[1] ~= range.e[1] then
+    lines[1] = string.sub(lines[1], range.s[2] + 1)
+    lines[#lines] = string.sub(lines[#lines], 1, range.e[2])
+  else
+    lines[1] = string.sub(lines[1], range.s[2] + 1, range.e[2])
+  end
+  return table.concat(lines, '\n')
+end
+
+---Traverse snippet ast.
+---NOTE: The `context.range` calculated by `tostring(node)`.
+---@param snippet_node table
+---@param callback fun(node: table, context: { depth: number, index: number, range: { s: number[], e: number[] }, parent?: table, replace: fun(new_node: table) }): table|nil
+---@param cursor? number[]
+local function traverse(snippet_node, callback, cursor)
+  ---@param node table
+  ---@param context { depth: number, index: number, range: { s: number[], e: number[] }, parent?: table, replace: fun(new_node: table) }
+  ---@param cursor_ number[]
+  local function traverse_recursive(node, context, cursor_)
+    local s = { cursor_[1], cursor_[2] }
+    if node.children then
+      for i, child in ipairs(node.children) do
+        traverse_recursive(child, {
+          depth = context.depth + 1,
+          index = i,
+          parent = node,
+          replace = (function(children, index)
+            return function(new_node)
+              children[index] = new_node
+            end
+          end)(node.children, i)
+        }, cursor_)
+      end
+    else
+      local texts = vim.split(tostring(node), '\n')
+      cursor_[1] = cursor_[1] + #texts - 1
+      cursor_[2] = #texts > 1 and #texts[#texts] or (cursor_[2] + #texts[1])
+    end
+    context.range = { s = s, e = { cursor_[1], cursor_[2] } }
+    callback(node, context)
+  end
+  traverse_recursive(snippet_node, {
+    depth = 0,
+    index = 1,
+    parent = nil,
+    replace = function()
+    end
+  }, cursor or { 0, 0 })
+end
+
+---Select specific mark.
+---@param mark vim.snippet.SnippetMark
+local function select_mark(mark)
+  local range = mark:get_range()
+  if mark.node.type == lsp_snippet.Node.Type.Choice then
+    feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>i]]):format(range.e[1] + 1, range.e[2] + 1), 'ni')
+    vim.schedule(function()
+      vim.fn.complete(range.s[2] + 1, mark.node.items)
+    end)
+  else
+    if range.s[1] == range.e[1] and range.s[2] == range.e[2] then
+      feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>i]]):format(range.e[1] + 1, range.e[2] + 1), 'ni')
+    else
+      feedkeys(([[<Esc><Cmd>call cursor(%s,%s)<CR>v<Cmd>call cursor(%s,%s)<CR><Esc>gvo<C-g>]]):format(
+        range.s[1] + 1,
+        range.s[2] + 1,
+        range.e[1] + 1,
+        range.e[2]
+      ), 'ni')
+    end
+  end
+end
+
+---Resolve variables.
+---NOTE: This function doesn't support fast-event.
+---@param var_name string
+---@return (number|string)?
+local function resolve_variable(var_name)
+  if var_name == 'TM_SELECTED_TEXT' then
+    return ''
+  elseif var_name == 'TM_CURRENT_LINE' then
+    return vim.api.nvim_get_current_line()
+  elseif var_name == 'TM_CURRENT_WORD' then
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local line = vim.api.nvim_get_current_line()
+    local before = string.sub(line, 1, cursor[2])
+    local word_s = vim.regex([[\k\+$]]):match_str(before) or #before
+    local word_after = string.sub(line, word_s + 1)
+    local _, word_e = vim.regex([[^\k\+]]):match_str(word_after)
+    return string.sub(line, word_s + 1, (word_e or word_s - 1) + 1)
+  elseif var_name == 'TM_LINE_INDEX' then
+    return vim.api.nvim_win_get_cursor(0)[2]
+  elseif var_name == 'TM_LINE_NUMBER' then
+    return vim.api.nvim_win_get_cursor(0)[2] + 1
+  elseif var_name == 'TM_FILENAME' then
+    return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':p:t')
+  elseif var_name == 'TM_FILENAME_BASE' then
+    return (string.gsub(vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':p:t'), '%.[^%.]*$', ''))
+  elseif var_name == 'TM_DIRECTORY' then
+    return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':p:h:t')
+  elseif var_name == 'TM_FILEPATH' then
+    return vim.api.nvim_buf_get_name(0)
+  end
+  return nil -- unknown variable.
+end
+
+---Analyze snippet text.
+---1. Normalize same tabstop nodes (e.g. `${1:foo} ${1:bar}` -> `${1:foo} ${1:foo}`)
+---2. Resolve variables.
+---3. Append 0-tabstop if not exist.
+---4. Normalize tabstop order (0 tabstop will be a `max-tabstop + 1`).
+---5. Make text to first insertion.
+---@param snippet_text string
+---@return { node: table, text: string, max_tabstop: number, min_tabstop: number }
+local function analyze_snippet(snippet_text)
+  local analyzed = {
+    node = lsp_snippet.parse(snippet_text),
+    text = '',
+    min_tabstop = nil,
+    max_tabstop = nil,
+  }
+
+  -- Normalize snippet nodes.
+  local has_trailing_tabstop, origins = false, {}
+  traverse(analyzed.node, function(node, context)
+    if type(node.tabstop) == 'number' then
+      local origin = origins[node.tabstop]
+      if origin then
+        context.replace(setmetatable(vim.tbl_deep_extend('keep', {}, origin), lsp_snippet.Node))
+      else
+        origins[node.tabstop] = node
+      end
+      has_trailing_tabstop = has_trailing_tabstop or node.tabstop == 0
+      analyzed.min_tabstop = math.min(analyzed.min_tabstop or node.tabstop, node.tabstop)
+      analyzed.max_tabstop = math.max(analyzed.max_tabstop or node.tabstop, node.tabstop)
+    elseif lsp_snippet.Node.Type.Variable == node.type then
+      local resolved = resolve_variable(node.name)
+      context.replace(setmetatable({
+        type = lsp_snippet.Node.Type.Text,
+        raw = resolved,
+        esc = resolved,
+      }, lsp_snippet.Node))
+    end
+  end)
+  analyzed.min_tabstop = analyzed.min_tabstop or 0
+  analyzed.max_tabstop = analyzed.max_tabstop or 0
+
+  -- Normalize tabstops.
+  if not has_trailing_tabstop then
+    table.insert(analyzed.node.children, setmetatable({
+      type = lsp_snippet.Node.Type.Tabstop,
+      tabstop = 0,
+    }, lsp_snippet.Node))
+  end
+  traverse(analyzed.node, function(node)
+    if node.tabstop == 0 then
+      node.tabstop = analyzed.max_tabstop + 1
+    end
+  end)
+
+  -- Create insertion text.
+  traverse(analyzed.node, function(node)
+    if vim.tbl_contains({
+          lsp_snippet.Node.Type.Text,
+          lsp_snippet.Node.Type.Choice,
+        }, node.type) then
+      analyzed.text = analyzed.text .. tostring(node)
+    end
+  end)
+
+  return analyzed
+end
+
+---@class vim.snippet.SnippetController
+---@field public session vim.snippet.SnippetSession
+local SnippetController = {
+  session = nil,
+}
+
+---@alias vim.snippet.JumpDirection "1" | "2"
+local JumpDirection = {}
+JumpDirection.Next = 1
+JumpDirection.Prev = 2
+
+---@class vim.snippet.SnippetMark
+---@field public ns string
+---@field public mark_id number
+---@field public node table
+---@field public origin table
+---@field public text string
+local SnippetMark = {}
+
+---@param params { ns: string, mark_id: number, node: table, range: { s: number[], e: number[] }, origin: table }
+function SnippetMark.new(params)
+  local self = setmetatable({}, { __index = SnippetMark })
+  self.ns = params.ns
+  self.mark_id = params.mark_id
+  self.node = params.node
+  self.origin = params.origin
+  self.text = get_text_by_range(get_range_from_mark(params.ns, params.mark_id))
+  return self
+end
+
+---Get actual range from extmark.
+---@return { s: number[], e: number[] }
+function SnippetMark:get_range()
+  return get_range_from_mark(self.ns, self.mark_id)
+end
+
+---Set range.
+---@param range { s: number[], e: number[] }
+function SnippetMark:set_range(range)
+  vim.api.nvim_buf_set_extmark(0, self.ns, range.s[1], range.s[2], {
+    id = self.mark_id,
+    end_line = range.e[1],
+    end_col = range.e[2],
+    right_gravity = false,
+    end_right_gravity = true,
+  })
+end
+
+---Get text.
+---@return string
+function SnippetMark:get_text()
+  return self.text
+end
+
+---Set text to the buffer.
+---@param new_text string
+function SnippetMark:set_text(new_text)
+  self.text = new_text
+end
+
+---Synchronize text content.
+function SnippetMark:sync()
+  local range = self:get_range()
+  if get_text_by_range(range) ~= self.text then
+    vim.cmd([[silent! undojoin]])
+    vim.api.nvim_buf_set_text(0, range.s[1], range.s[2], range.e[1], range.e[2], vim.split(self.text, '\n'))
+  end
+end
+
+---Dispose.
+function SnippetMark:dispose()
+  vim.api.nvim_buf_del_extmark(0, self.ns, self.mark_id)
+end
+
+---@class vim.snippet.SnippetSession
+---@field public ns string
+---@field public bufnr number
+---@field public marks table
+---@field public disposed boolean
+---@field public changedtick number
+---@field public saved_ranges table<number, table<number, { s: number[], e: number[] }>>
+---@field public current_tabstop number
+---@field public snippet_mark_ns number
+---@field public snippet_mark_id number
+local SnippetSession = {}
+
+---Create SnippetSession instance.
+---@param bufnr number
+---@param namespace string
+function SnippetSession.new(bufnr, namespace)
+  local self = setmetatable({}, { __index = SnippetSession })
+  self.ns = vim.api.nvim_create_namespace(namespace)
+  self.bufnr = bufnr
+  self.marks = {}
+  self.disposed = false
+  self.changedtick = 0
+  self.saved_ranges = {}
+  self.current_tabstop = 0
+  self.snippet_mark_ns = vim.api.nvim_create_namespace(namespace .. ':snippet')
+  self.snippet_mark_id = 0
+  return self
+end
+
+---Expand snippet to the current buffer.
+---@param snippet_text string
+function SnippetSession:expand(snippet_text)
+  local analyzed = analyze_snippet(adjust_indent(snippet_text))
+  local texts = vim.split(analyzed.text, '\n')
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  cursor[1] = cursor[1] - 1
+
+  -- Insert normalized snippet text.
+  vim.api.nvim_buf_set_text(0, cursor[1], cursor[2], cursor[1], cursor[2], texts)
+  vim.api.nvim_win_set_cursor(0, { cursor[1] + 1, cursor[2] })
+
+  -- Create extmarks.
+  local marks, origins = {}, {}
+  traverse(analyzed.node, function(node, context)
+    if type(node.tabstop) == 'number' then
+      table.insert(marks, SnippetMark.new({
+        ns = self.ns,
+        node = node,
+        origin = origins[node.tabstop or -1],
+        mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, self.ns, context.range.s[1], context.range.s[2], {
+          end_line = context.range.e[1],
+          end_col = context.range.e[2],
+          right_gravity = false,
+          end_right_gravity = true,
+        })
+      }))
+      origins[node.tabstop] = node
+    end
+  end, { cursor[1], cursor[2] })
+  self.marks = marks
+
+  -- Create snippet region marks.
+  self.snippet_mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, self.snippet_mark_ns, cursor[1], cursor[2], {
+    end_line = cursor[1] + (#texts - 1),
+    end_col = #texts > 1 and #texts[#texts] or cursor[2] + #texts[1],
+    right_gravity = false,
+    end_right_gravity = true,
+  })
+
+  -- Initialize.
+  self.current_tabstop = analyzed.min_tabstop - 1
+  self:sync()
+end
+
+---Jump to the suitable placeholder.
+---@param direction vim.snippet.JumpDirection
+function SnippetSession:jump(direction)
+  local next_mark = self:find_next_mark(direction)
+  if next_mark then
+    self.current_tabstop = next_mark.node.tabstop
+    select_mark(next_mark)
+    self:sync()
+  end
+end
+
+---Find next mark.
+---@param direction vim.snippet.JumpDirection
+---@return table
+function SnippetSession:find_next_mark(direction)
+  local target_mark = nil
+  for _, mark in ipairs(self.marks) do
+    if direction == JumpDirection.Next then
+      if self.current_tabstop < mark.node.tabstop then
+        if not target_mark or mark.node.tabstop < target_mark.node.tabstop then
+          target_mark = mark
+        end
+      end
+    elseif direction == JumpDirection.Prev and self.current_tabstop > mark.node.tabstop then
+      if self.current_tabstop > mark.node.tabstop then
+        if not target_mark or mark.node.tabstop > target_mark.node.tabstop then
+          target_mark = mark
+        end
+      end
+    end
+  end
+  return target_mark
+end
+
+---Synchronize tabstop texts.
+function SnippetSession:sync()
+  if not self:within() then
+    self:dispose()
+    return
+  end
+
+  local changedtick = vim.api.nvim_buf_get_changedtick(0)
+  if self.changedtick == changedtick then
+    return
+  end
+
+  local changenr = vim.fn.changenr()
+
+  -- Ignore undo/redo.
+  local undotree = vim.fn.undotree()
+  if undotree.seq_last ~= undotree.seq_cur then
+    for _, mark in ipairs(self.marks) do
+      mark:set_text(get_text_by_range(mark:get_range()))
+      if self.saved_ranges[changenr] and self.saved_ranges[changenr][mark.mark_id] then
+        mark:set_range(self.saved_ranges[changenr][mark.mark_id])
+      end
+    end
+    self.changedtick = changedtick
+    return
+  end
+
+  --- Save current mark ranges.
+  self.saved_ranges[changenr] = {}
+  for _, mark in ipairs(self.marks) do
+    self.saved_ranges[changenr][mark.mark_id] = mark:get_range()
+  end
+
+  -- Dispose directly modified non-origin marks.
+  for i = #self.marks, 1, -1 do
+    local mark = self.marks[i]
+    if mark.origin then
+      if mark:get_text() ~= get_text_by_range(mark:get_range()) then
+        table.remove(self.marks, i)
+        mark:dispose()
+      end
+    end
+  end
+
+  -- Sync non-origin marks.
+  local origins = {}
+  for _, mark in ipairs(self.marks) do
+    origins[mark.node.tabstop] = origins[mark.node.tabstop] or mark
+    if mark == origins[mark.node.tabstop] then
+      mark:set_text(get_text_by_range(mark:get_range()))
+    else
+      mark:set_text(origins[mark.node.tabstop]:get_text())
+    end
+    mark:sync()
+  end
+
+  self.changedtick = changedtick
+end
+
+---Return the cursor is within the snippet range or not.
+---@return boolean
+function SnippetSession:within()
+  if self.disposed then
+    return false
+  end
+
+  if self.bufnr ~= vim.api.nvim_get_current_buf() then
+    return false
+  end
+
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  cursor[1] = cursor[1] - 1
+
+  local range = get_range_from_mark(self.snippet_mark_ns, self.snippet_mark_id)
+  if cursor[1] < range.s[1] or (cursor[1] == range.s[1] and cursor[2] < range.s[2]) then
+    return false
+  end
+  if range.e[1] < cursor[1] or (range.e[1] == cursor[1] and range.e[2] < cursor[2]) then
+    return false
+  end
+  return true
+end
+
+---Dispose snippet session.
+function SnippetSession:dispose()
+  for _, mark in ipairs(self.marks) do
+    mark:dispose()
+  end
+  vim.api.nvim_buf_del_extmark(self.bufnr, self.snippet_mark_ns, self.snippet_mark_id)
+  self.disposed = true
+end
+
+local M = {}
+
+M.JumpDirection = JumpDirection
+
+---Expand snippet text.
+---@param snippet_text string
+function M.expand(snippet_text)
+  if SnippetController.session then
+    SnippetController.session:dispose()
+  end
+
+  local bufnr = vim.api.nvim_get_current_buf()
+  SnippetController.session = SnippetSession.new(bufnr, 'vim.snippet:' .. vim.loop.now())
+  SnippetController.session:expand(snippet_text)
+  SnippetController.session:jump(M.JumpDirection.Next)
+
+  local session = SnippetController.session
+  vim.api.nvim_buf_attach(bufnr, false, {
+    on_lines = function()
+      if session.disposed then
+        return true
+      end
+      vim.schedule(function()
+        session:sync()
+      end)
+    end,
+  })
+end
+
+---Return jumpable for specified direction or not.
+---@param direction vim.snippet.JumpDirection
+---@return boolean
+function M.jumpable(direction)
+  if not SnippetController.session or SnippetController.session.disposed then
+    return false
+  end
+  return not not SnippetController.session:find_next_mark(direction)
+end
+
+---Jump to next placeholder.
+---@param direction vim.snippet.JumpDirection
+function M.jump(direction)
+  if not SnippetController.session or SnippetController.session.disposed then
+    return
+  end
+  SnippetController.session:jump(direction)
+end
+
+---Sync current modification.
+function M.sync()
+  if not SnippetController.session or SnippetController.session.disposed then
+    return
+  end
+  SnippetController.session:sync()
+end
+
+---Dispose current snippet session
+function M.dispose()
+  if not SnippetController.session or SnippetController.session.disposed then
+    return
+  end
+  SnippetController.session:dispose()
+  SnippetController.session = nil
+end
+
+return M

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -1,6 +1,6 @@
 local lsp_snippet = require('vim.lsp._snippet')
 
----@alias vim.snippet.MarkId 
+---@alias vim.snippet.MarkId integer
 ---@alias vim.snippet.Tabstop integer
 ---@alias vim.snippet.Changenr integer
 ---@alias vim.snippet.Position { [1]: integer, [2]: integer } # The 0-origin utf8 byte index.
@@ -388,7 +388,7 @@ end
 ---@field public changedtick integer
 ---@field public current_tabstop integer
 ---@field public snippet_mark_ns integer
----@field public snippet_mark_id integer
+---@field public snippet_mark_id vim.snippet.MarkId
 local SnippetSession = {}
 
 ---Create SnippetSession instance.
@@ -654,7 +654,7 @@ M.JumpDirection = JumpDirection
 
 ---Return the cursor is in the activated snippet or not.
 ---@return boolean
-function M.in_context()
+function M._in_context()
   local session = SnippetController.session
   if not session or session.disposed then
     return false
@@ -662,10 +662,18 @@ function M.in_context()
   return session:within()
 end
 
+---Sync current modification.
+---NOTE: for functionaltest.
+function M._sync()
+  if M._in_context() then
+    SnippetController.session:sync()
+  end
+end
+
 ---Expand snippet text.
 ---@param snippet_text string
 function M.expand(snippet_text)
-  if M.in_context() then
+  if M._in_context() then
     SnippetController.session:merge(snippet_text)
     return
   end
@@ -693,7 +701,7 @@ end
 ---@param direction vim.snippet.JumpDirection
 ---@return boolean
 function M.jumpable(direction)
-  if M.in_context() then
+  if M._in_context() then
     return not not SnippetController.session:find_next_mark(direction)
   end
   return false
@@ -702,21 +710,14 @@ end
 ---Jump to next placeholder.
 ---@param direction vim.snippet.JumpDirection
 function M.jump(direction)
-  if M.in_context() then
+  if M._in_context() then
     SnippetController.session:jump(direction)
-  end
-end
-
----Sync current modification.
-function M.sync()
-  if M.in_context() then
-    SnippetController.session:sync()
   end
 end
 
 ---Dispose current snippet session
 function M.dispose()
-  if M.in_context() then
+  if M._in_context() then
     SnippetController.session:dispose()
     SnippetController.session = nil
   end

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -6,326 +6,331 @@ local feed = helpers.feed
 local exec_lua = helpers.exec_lua
 
 describe('vim.snippet', function()
-  before_each(function()
-    clear()
-    exec_lua([[
-      vim.snippet.dispose()
-      vim.api.nvim_buf_set_keymap(0, 'n', '<C-l>', '<Cmd>lua vim.snippet.sync()<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 'i', '<C-l>', '<Cmd>lua vim.snippet.sync()<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 's', '<C-l>', '<Cmd>lua vim.snippet.sync()<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 'i', '<Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Next)<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 's', '<Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Next)<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 'i', '<S-Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Prev)<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 's', '<S-Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Prev)<CR>', { noremap = true })
-      vim.api.nvim_buf_set_keymap(0, 's', '<BS>', '"\\<BS>" .. (getcurpos()[2] == col("$") - 1 ? "a" : "i")', { noremap = true, expr = true })
+  for _, selection in ipairs({ 'inclusive', 'exclusive' }) do
+    for _, virtualedit in ipairs({ '', 'all', 'onemore' }) do
+      describe(('selection=%s, virtualedit=%s'):format(selection, virtualedit), function()
+        before_each(function()
+          clear()
+          exec_lua(([[
+            vim.o.selection = '%s';
+            vim.o.virtualedit = '%s';
+            vim.snippet.dispose()
+            vim.keymap.set({ 'n', 'i', 's' }, '<C-l>', '<Cmd>lua vim.snippet._sync()<CR>', { buffer = true })
+            vim.keymap.set({ 'i', 's' }, '<Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Next)<CR>', { buffer = true })
+            vim.keymap.set({ 'i', 's' }, '<S-Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Prev)<CR>', { buffer = true })
+            vim.keymap.set({ 's' }, '<BS>', '"\\<BS>" .. (getcurpos()[2] == col("$") - 1 ? "a" : "i")', { expr = true })
 
-      function get_state()
-        local m = vim.api.nvim_get_mode().mode
-        local select_s = vim.fn.getpos("'<")
-        local select_e = vim.fn.getpos("'>")
-        local cursor = vim.fn.getpos('.')
-        return {
-          m = m,
-          s = m ~= 's' and ({ cursor[2] - 1, cursor[3] - 1 }) or ({ select_s[2] - 1, select_s[3] - 1 }),
-          e = m ~= 's' and ({ cursor[2] - 1, cursor[3] - 1 }) or ({ select_e[2] - 1, select_e[3] }),
-        }
-      end
-    ]])
-  end)
-  after_each(function()
-    clear()
-  end)
+            function get_state()
+              local m = vim.api.nvim_get_mode().mode
+              local select_s = vim.fn.getpos("'<")
+              local select_e = vim.fn.getpos("'>")
+              local cursor = vim.fn.getpos('.')
+              local exclusive_offset = vim.o.selection == 'exclusive' and 1 or 0
+              return {
+                m = m,
+                s = m ~= 's' and ({ cursor[2] - 1, cursor[3] - 1 }) or ({ select_s[2] - 1, select_s[3] - 1 }),
+                e = m ~= 's' and ({ cursor[2] - 1, cursor[3] - 1 }) or ({ select_e[2] - 1, select_e[3] - exclusive_offset }),
+              }
+            end
+          ]]):format(selection, virtualedit))
+        end)
+        after_each(function()
+          clear()
+        end)
 
-  it('should expand snippet with considering buffer indent setting', function()
-    local snippet = table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n')
+        it('should expand snippet with considering buffer indent setting', function()
+          local snippet = table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n')
 
-    for _, case in ipairs({
-      {
-        base_indent = [[  ]],
-        indent_setting = [[
-          vim.o.expandtab = true
-          vim.o.shiftwidth = 2
-        ]],
-        expects = {
-          '  class ClassName {',
-          '    public ClassName() {',
-          '      ',
-          '    }',
-          '  }',
-          '  ',
-        }
-      }, {
-      base_indent = [[  ]],
-      indent_setting = [[
-          vim.o.expandtab = true
-          vim.o.shiftwidth = 0
-          vim.o.tabstop = 2
-        ]],
-      expects = {
-        '  class ClassName {',
-        '    public ClassName() {',
-        '      ',
-        '    }',
-        '  }',
-        '  ',
-      }
-    }, {
-      base_indent = [[<Tab>]],
-      indent_setting = [[
-          vim.o.expandtab = false
-        ]],
-      expects = {
-        '\tclass ClassName {',
-        '\t\tpublic ClassName() {',
-        '\t\t\t',
-        '\t\t}',
-        '\t}',
-        '\t',
-      }
-    }
-    }) do
-      clear()
-      exec_lua(case.indent_setting)
-      feed('i' .. case.base_indent)
-      exec_lua('vim.snippet.expand(...)', snippet)
-      eq(case.expects, helpers.buf_lines(0))
+          for _, case in ipairs({
+            {
+              base_indent = [[  ]],
+              indent_setting = [[
+                vim.o.expandtab = true
+                vim.o.shiftwidth = 2
+              ]],
+              expects = {
+                '  class ClassName {',
+                '    public ClassName() {',
+                '      ',
+                '    }',
+                '  }',
+                '  ',
+              }
+            }, {
+            base_indent = [[  ]],
+            indent_setting = [[
+              vim.o.expandtab = true
+              vim.o.shiftwidth = 0
+              vim.o.tabstop = 2
+            ]],
+            expects = {
+              '  class ClassName {',
+              '    public ClassName() {',
+              '      ',
+              '    }',
+              '  }',
+              '  ',
+            }
+          }, {
+            base_indent = [[<Tab>]],
+            indent_setting = [[
+              vim.o.expandtab = false
+            ]],
+            expects = {
+              '\tclass ClassName {',
+              '\t\tpublic ClassName() {',
+              '\t\t\t',
+              '\t\t}',
+              '\t}',
+              '\t',
+            }
+          }
+          }) do
+            clear()
+            exec_lua(case.indent_setting)
+            feed('i' .. case.base_indent)
+            exec_lua('vim.snippet.expand(...)', snippet)
+            eq(case.expects, helpers.buf_lines(0))
+          end
+        end)
+
+        it('should be able to jump through all placeholders', function()
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          local cases = {
+            { m = 's', s = { 0, 6 },  e = { 0, 15 }, },
+            { m = 'i', s = { 1, 18 }, e = { 1, 18 }, },
+            { m = 'i', s = { 2, 2 },  e = { 2, 2 }, },
+            { m = 'i', s = { 5, 0 },  e = { 5, 0 }, },
+          }
+          for i = 1, #cases do
+            eq(cases[i], exec_lua([[return get_state()]]))
+            eq(i ~= #cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Next)]]))
+            feed('<Tab>')
+          end
+          eq(cases[#cases], exec_lua([[return get_state()]]))
+          for i = #cases, 1, -1 do
+            eq(cases[i], exec_lua([[return get_state()]]))
+            eq(i ~= 1, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Prev)]]))
+            feed('<S-Tab>')
+          end
+          eq(cases[1], exec_lua([[return get_state()]]))
+        end)
+
+        it('should sync same tabstops', function()
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          feed('ModifiedClassName<C-l>')
+          eq({
+            'class ModifiedClassName {',
+            '\tpublic ModifiedClassName() {',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+        end)
+
+        -- We can't manage `complete(...)` in test.
+        -- it('should insert selected choice', function()
+        --   exec_lua('vim.snippet.expand(...)', table.concat({
+        --     'console.${1|log,info,warn,error|}($2);',
+        --   }, '\n'))
+        --   feed('<C-n><C-n><C-n><C-y>')
+        --   eq({
+        --     'console.warn();',
+        --   }, helpers.buf_lines(0))
+        -- end)
+
+        it('should dispose directly modified non-origin tabstop', function()
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          eq({
+            'class ClassName {',
+            '\tpublic ClassName() {',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+          feed('<Esc><Cmd>call cursor(2, 9)<CR>ciwDirectlyModified<C-l>')
+          eq({
+            'class ClassName {',
+            '\tpublic DirectlyModified() {',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+        end)
+
+        it('should restore the state with undo', function()
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          feed('ModifiedClassName<C-l><Tab>argument<Esc>')
+          eq({
+            'class ModifiedClassName {',
+            '\tpublic ModifiedClassName(argument) {',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+
+          feed('u<C-l>')
+          eq({
+            'class ClassName {',
+            '\tpublic ClassName() {',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+
+          local to_insert = selection == 'exclusive' and 'i' or 'a'
+          feed(('i<S-Tab><C-g>o<Esc>%sModified<C-l>'):format(to_insert))
+          eq({
+            'class ClassNameModified {',
+            '\tpublic ClassNameModified() {',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+        end)
+
+        it('should dispose snippet if edit outside of range', function()
+          feed('i<CR>')
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          feed('<Esc>ggiEdit')
+          local state = exec_lua([[return get_state()]])
+          feed('<Tab>')
+          eq(exec_lua([[return get_state()]]), state)
+        end)
+
+        it('should expand snippet even if cursor is in the middle of text', function()
+          feed('i()<Left>')
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          eq({
+            '(class ClassName {',
+            '\tpublic ClassName() {',
+            '\t\t',
+            '\t}',
+            '}',
+            ')',
+          }, helpers.buf_lines(0))
+        end)
+
+        it('should merge snippet with existing snippet', function()
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          feed('<Tab><Tab>') -- jump to $3
+
+          -- expand new snippet while already activating another snippet.
+          exec_lua('vim.snippet.expand(...)', table.concat({
+            'class ${1:ClassName} {',
+            '\tpublic $1($2) {',
+            '\t\t${3}',
+            '\t}',
+            '}',
+            ''
+          }, '\n'))
+          eq({
+            'class ClassName {',
+            '\tpublic ClassName() {',
+            '\t\tclass ClassName {',
+            '\t\t\tpublic ClassName() {',
+            '\t\t\t\t',
+            '\t\t\t}',
+            '\t\t}',
+            '\t\t',
+            '\t}',
+            '}',
+            '',
+          }, helpers.buf_lines(0))
+
+          -- jump through all placeholders.
+          local next_cases = {
+            { m = 's', s = { 2, 8 },  e = { 2, 17 }, },
+            { m = 'i', s = { 3, 20 }, e = { 3, 20 }, },
+            { m = 'i', s = { 4, 4 },  e = { 4, 4 }, },
+            { m = 'i', s = { 7, 2 },  e = { 7, 2 }, },
+            { m = 'i', s = { 10, 0 }, e = { 10, 0 }, },
+          }
+          for i = 1, #next_cases do
+            eq(next_cases[i], exec_lua([[return get_state()]]))
+            eq(i ~= #next_cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Next)]]))
+            feed('<Tab>')
+          end
+
+          local prev_cases = {
+            { m = 'i', s = { 10, 0 }, e = { 10, 0 }, },
+            { m = 'i', s = { 7, 2 },  e = { 7, 2 }, },
+            { m = 'i', s = { 4, 4 },  e = { 4, 4 }, },
+            { m = 'i', s = { 3, 20 }, e = { 3, 20 }, },
+            { m = 's', s = { 2, 8 },  e = { 2, 17 }, },
+            { m = 's', s = { 2, 2 },  e = { 7, 2 }, },
+            { m = 'i', s = { 1, 18 }, e = { 1, 18 }, },
+            { m = 's', s = { 0, 6 },  e = { 0, 15 }, },
+          }
+          for i = 1, #prev_cases do
+            eq(prev_cases[i], exec_lua([[return get_state()]]))
+            eq(i ~= #prev_cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Prev)]]))
+            feed('<S-Tab>')
+          end
+        end)
+      end)
     end
-  end)
-
-  it('should be able to jump through all placeholders', function()
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    local cases = {
-      { m = 's', s = { 0, 6 },  e = { 0, 15 }, },
-      { m = 'i', s = { 1, 18 }, e = { 1, 18 }, },
-      { m = 'i', s = { 2, 2 },  e = { 2, 2 }, },
-      { m = 'i', s = { 5, 0 },  e = { 5, 0 }, },
-    }
-    for i = 1, #cases do
-      eq(cases[i], exec_lua([[return get_state()]]))
-      eq(i ~= #cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Next)]]))
-      feed('<Tab>')
-    end
-    eq(cases[#cases], exec_lua([[return get_state()]]))
-    for i = #cases, 1, -1 do
-      eq(cases[i], exec_lua([[return get_state()]]))
-      eq(i ~= 1, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Prev)]]))
-      feed('<S-Tab>')
-    end
-    eq(cases[1], exec_lua([[return get_state()]]))
-  end)
-
-  it('should sync same tabstops', function()
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    feed('ModifiedClassName<C-l>')
-    eq({
-      'class ModifiedClassName {',
-      '\tpublic ModifiedClassName() {',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-  end)
-
-  -- We can't manage `complete(...)` in test.
-  -- it('should insert selected choice', function()
-  --   exec_lua('vim.snippet.expand(...)', table.concat({
-  --     'console.${1|log,info,warn,error|}($2);',
-  --   }, '\n'))
-  --   feed('<C-n><C-n><C-n><C-y>')
-  --   eq({
-  --     'console.warn();',
-  --   }, helpers.buf_lines(0))
-  -- end)
-
-  it('should dispose directly modified non-origin tabstop', function()
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    eq({
-      'class ClassName {',
-      '\tpublic ClassName() {',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-    feed('<Esc><Cmd>call cursor(2, 9)<CR>ciwDirectlyModified<C-l>')
-    eq({
-      'class ClassName {',
-      '\tpublic DirectlyModified() {',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-  end)
-
-  it('should restore the state with undo', function()
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    feed('ModifiedClassName<C-l><Tab>argument<Esc>')
-    eq({
-      'class ModifiedClassName {',
-      '\tpublic ModifiedClassName(argument) {',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-
-    feed('u<C-l>')
-    eq({
-      'class ClassName {',
-      '\tpublic ClassName() {',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-
-    feed('i<S-Tab><C-g>o<Esc>aModified<C-l>')
-    eq({
-      'class ClassNameModified {',
-      '\tpublic ClassNameModified() {',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-  end)
-
-  it('should dispose snippet if edit outside of range', function()
-    feed('i<CR>')
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    feed('<Esc>ggiEdit')
-    local state = exec_lua([[return get_state()]])
-    feed('<Tab>')
-    eq(exec_lua([[return get_state()]]), state)
-  end)
-
-  it('should expand snippet even if cursor is in the middle of text', function()
-    feed('i()<Left>')
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    eq({
-      '(class ClassName {',
-      '\tpublic ClassName() {',
-      '\t\t',
-      '\t}',
-      '}',
-      ')',
-    }, helpers.buf_lines(0))
-  end)
-
-  it('should merge snippet with existing snippet', function()
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    feed('<Tab><Tab>') -- jump to $3
-
-    -- expand new snippet while already activating another snippet.
-    exec_lua('vim.snippet.expand(...)', table.concat({
-      'class ${1:ClassName} {',
-      '\tpublic $1($2) {',
-      '\t\t${3}',
-      '\t}',
-      '}',
-      ''
-    }, '\n'))
-    eq({
-      'class ClassName {',
-      '\tpublic ClassName() {',
-      '\t\tclass ClassName {',
-      '\t\t\tpublic ClassName() {',
-      '\t\t\t\t',
-      '\t\t\t}',
-      '\t\t}',
-      '\t\t',
-      '\t}',
-      '}',
-      '',
-    }, helpers.buf_lines(0))
-
-    -- jump through all placeholders.
-    local next_cases = {
-      { m = 's', s = { 2, 8 },  e = { 2, 17 }, },
-      { m = 'i', s = { 3, 20 }, e = { 3, 20 }, },
-      { m = 'i', s = { 4, 4 },  e = { 4, 4 }, },
-      { m = 'i', s = { 7, 2 },  e = { 7, 2 }, },
-      { m = 'i', s = { 10, 0 }, e = { 10, 0 }, },
-    }
-    for i = 1, #next_cases do
-      eq(next_cases[i], exec_lua([[return get_state()]]))
-      eq(i ~= #next_cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Next)]]))
-      feed('<Tab>')
-    end
-
-    local prev_cases = {
-      { m = 'i', s = { 10, 0 }, e = { 10, 0 }, },
-      { m = 'i', s = { 7, 2 },  e = { 7, 2 }, },
-      { m = 'i', s = { 4, 4 },  e = { 4, 4 }, },
-      { m = 'i', s = { 3, 20 }, e = { 3, 20 }, },
-      { m = 's', s = { 2, 8 },  e = { 2, 17 }, },
-      { m = 's', s = { 2, 2 },  e = { 7, 2 }, },
-      { m = 'i', s = { 1, 18 }, e = { 1, 18 }, },
-      { m = 's', s = { 0, 6 },  e = { 0, 15 }, },
-    }
-    for i = 1, #prev_cases do
-      eq(prev_cases[i], exec_lua([[return get_state()]]))
-      eq(i ~= #prev_cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Prev)]]))
-      feed('<S-Tab>')
-    end
-  end)
+  end
 end)
-

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -1,0 +1,249 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local clear = helpers.clear
+local feed = helpers.feed
+local exec_lua = helpers.exec_lua
+
+describe('vim.snippet', function()
+  before_each(function()
+    clear()
+    exec_lua([[
+      vim.snippet.dispose()
+      vim.api.nvim_buf_set_keymap(0, 'n', '<C-l>', '<Cmd>lua vim.snippet.sync()<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 'i', '<C-l>', '<Cmd>lua vim.snippet.sync()<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 's', '<C-l>', '<Cmd>lua vim.snippet.sync()<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 'i', '<Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Next)<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 's', '<Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Next)<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 'i', '<S-Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Prev)<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 's', '<S-Tab>', '<Cmd>lua vim.snippet.jump(vim.snippet.JumpDirection.Prev)<CR>', { noremap = true })
+      vim.api.nvim_buf_set_keymap(0, 's', '<BS>', '"\\<BS>" .. (getcurpos()[2] == col("$") - 1 ? "a" : "i")', { noremap = true, expr = true })
+
+      function get_state()
+        local m = vim.api.nvim_get_mode().mode
+        local s = vim.fn.getpos("'<")
+        local e = vim.fn.getpos("'>")
+        local c = vim.fn.getpos('.')
+        return {
+          m = m,
+          s = m ~= 's' and ({ c[2] - 1, c[3] - 1 }) or ({ s[2] - 1, s[3] - 1 }),
+          e = m ~= 's' and ({ c[2] - 1, c[3] - 1 }) or ({ e[2] - 1, e[3] - 1 }),
+        }
+      end
+    ]])
+  end)
+  after_each(function()
+    clear()
+  end)
+
+  it('should expand snippet with considering buffer indent setting', function()
+    local snippet = table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n')
+
+    for _, case in ipairs({
+      {
+        base_indent = [[  ]],
+        indent_setting = [[
+          vim.o.expandtab = true
+          vim.o.shiftwidth = 2
+        ]],
+        expects = {
+          '  class ClassName {',
+          '    public ClassName() {',
+          '      ',
+          '    }',
+          '  }',
+          '  ',
+        }
+      }, {
+        base_indent = [[  ]],
+        indent_setting = [[
+          vim.o.expandtab = true
+          vim.o.shiftwidth = 0
+          vim.o.tabstop = 2
+        ]],
+        expects = {
+          '  class ClassName {',
+          '    public ClassName() {',
+          '      ',
+          '    }',
+          '  }',
+          '  ',
+        }
+      }, {
+        base_indent = [[<Tab>]],
+        indent_setting = [[
+          vim.o.expandtab = false
+        ]],
+        expects = {
+          '\tclass ClassName {',
+          '\t\tpublic ClassName() {',
+          '\t\t\t',
+          '\t\t}',
+          '\t}',
+          '\t',
+        }
+      }
+    }) do
+      clear()
+      exec_lua(case.indent_setting)
+      feed('i' .. case.base_indent)
+      exec_lua('vim.snippet.expand(...)', snippet)
+      eq(case.expects, helpers.buf_lines(0))
+    end
+  end)
+
+  it('should able to jump to all placeholders', function()
+    exec_lua('vim.snippet.expand(...)', table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n'))
+    local cases = {
+      { m = 's', s = { 0, 6 }, e = { 0, 14 }, },
+      { m = 'i', s = { 1, 18 }, e = { 1, 18 }, },
+      { m = 'i', s = { 2, 2 }, e = { 2, 2 }, },
+      { m = 'i', s = { 5, 0 }, e = { 5, 0 }, },
+    }
+    for i = 1, #cases do
+      eq(cases[i], exec_lua([[return get_state()]]))
+      eq(i ~= #cases, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Next)]]))
+      feed('<Tab>')
+    end
+    eq(cases[#cases], exec_lua([[return get_state()]]))
+    for i = #cases, 1, -1 do
+      eq(cases[i], exec_lua([[return get_state()]]))
+      eq(i ~= 1, exec_lua([[return vim.snippet.jumpable(vim.snippet.JumpDirection.Prev)]]))
+      feed('<S-Tab>')
+    end
+    eq(cases[1], exec_lua([[return get_state()]]))
+  end)
+
+  it('should sync same tabstop mark', function()
+    exec_lua('vim.snippet.expand(...)', table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n'))
+    feed('ModifiedClassName<C-l>')
+    eq({
+      'class ModifiedClassName {',
+      '\tpublic ModifiedClassName() {',
+      '\t\t',
+      '\t}',
+      '}',
+      '',
+    }, helpers.buf_lines(0))
+  end)
+
+  it('should dispose directly modified non-origin mark', function()
+    exec_lua('vim.snippet.expand(...)', table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n'))
+    feed('<Esc><Cmd>call cursor(2, 9)<CR>ciwDirectlyModified<C-l>')
+    eq({
+      'class ClassName {',
+      '\tpublic DirectlyModified() {',
+      '\t\t',
+      '\t}',
+      '}',
+      '',
+    }, helpers.buf_lines(0))
+  end)
+
+  it('should restore the state with undo', function()
+    exec_lua('vim.snippet.expand(...)', table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n'))
+
+    feed('ModifiedClassName<C-l><Tab>argument<Esc>')
+    eq({
+      'class ModifiedClassName {',
+      '\tpublic ModifiedClassName(argument) {',
+      '\t\t',
+      '\t}',
+      '}',
+      '',
+    }, helpers.buf_lines(0))
+
+    feed('u<C-l>')
+    eq({
+      'class ClassName {',
+      '\tpublic ClassName() {',
+      '\t\t',
+      '\t}',
+      '}',
+      '',
+    }, helpers.buf_lines(0))
+
+    feed('i<S-Tab><C-g>o<Esc>aModified<C-l>')
+    eq({
+      'class ClassNameModified {',
+      '\tpublic ClassNameModified() {',
+      '\t\t',
+      '\t}',
+      '}',
+      '',
+    }, helpers.buf_lines(0))
+  end)
+
+  it('should dispose snippet if edit outside of range', function()
+    feed('i<CR>')
+    exec_lua('vim.snippet.expand(...)', table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n'))
+    feed('<Esc>ggiEdit')
+    local state = exec_lua([[return get_state()]])
+    feed('<Tab>')
+    eq(exec_lua([[return get_state()]]), state)
+  end)
+
+  it('should expand snippet even if cursor is in the middle of text', function()
+    feed('i()<Left>')
+    exec_lua('vim.snippet.expand(...)', table.concat({
+      'class ${1:ClassName} {',
+      '\tpublic $1($2) {',
+      '\t\t${3}',
+      '\t}',
+      '}',
+      ''
+    }, '\n'))
+    eq({
+      '(class ClassName {',
+      '\tpublic ClassName() {',
+      '\t\t',
+      '\t}',
+      '}',
+      ')',
+    }, helpers.buf_lines(0))
+  end)
+
+end)
+

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -128,7 +128,7 @@ describe('vim.snippet', function()
     eq(cases[1], exec_lua([[return get_state()]]))
   end)
 
-  it('should sync same tabstop mark', function()
+  it('should sync same tabstop marks', function()
     exec_lua('vim.snippet.expand(...)', table.concat({
       'class ${1:ClassName} {',
       '\tpublic $1($2) {',
@@ -147,6 +147,16 @@ describe('vim.snippet', function()
       '',
     }, helpers.buf_lines(0))
   end)
+
+  -- it('should insert selected choice', function()
+  --   exec_lua('vim.snippet.expand(...)', table.concat({
+  --     'console.${1|log,info,warn,error|}($2);',
+  --   }, '\n'))
+  --   feed('3<CR>')
+  --   eq({
+  --     'console.warn();',
+  --   }, helpers.buf_lines(0))
+  -- end)
 
   it('should dispose directly modified non-origin mark', function()
     exec_lua('vim.snippet.expand(...)', table.concat({

--- a/test/functional/plugin/lsp/snippet_spec.lua
+++ b/test/functional/plugin/lsp/snippet_spec.lua
@@ -14,10 +14,10 @@ describe('vim.lsp._snippet', function()
 
   it('should parse only text', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = snippet.Node.Type.Snippet,
       children = {
         {
-          type = snippet.NodeType.TEXT,
+          type = snippet.Node.Type.Text,
           raw = 'TE\\$\\}XT',
           esc = 'TE$}XT',
         },
@@ -27,14 +27,14 @@ describe('vim.lsp._snippet', function()
 
   it('should parse tabstop', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = snippet.Node.Type.Snippet,
       children = {
         {
-          type = snippet.NodeType.TABSTOP,
+          type = snippet.Node.Type.Tabstop,
           tabstop = 1,
         },
         {
-          type = snippet.NodeType.TABSTOP,
+          type = snippet.Node.Type.Tabstop,
           tabstop = 2,
         },
       },
@@ -43,35 +43,35 @@ describe('vim.lsp._snippet', function()
 
   it('should parse placeholders', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = snippet.Node.Type.Snippet,
       children = {
         {
-          type = snippet.NodeType.PLACEHOLDER,
+          type = snippet.Node.Type.Placeholder,
           tabstop = 1,
           children = {
             {
-              type = snippet.NodeType.PLACEHOLDER,
+              type = snippet.Node.Type.Placeholder,
               tabstop = 2,
               children = {
                 {
-                  type = snippet.NodeType.TEXT,
+                  type = snippet.Node.Type.Text,
                   raw = 'TE\\$\\}XT',
                   esc = 'TE$}XT',
                 },
                 {
-                  type = snippet.NodeType.TABSTOP,
+                  type = snippet.Node.Type.Tabstop,
                   tabstop = 3,
                 },
                 {
-                  type = snippet.NodeType.TABSTOP,
+                  type = snippet.Node.Type.Tabstop,
                   tabstop = 1,
                   transform = {
-                    type = snippet.NodeType.TRANSFORM,
+                    type = snippet.Node.Type.Transform,
                     pattern = 'regex',
                     option = 'i',
                     format = {
                       {
-                        type = snippet.NodeType.FORMAT,
+                        type = snippet.Node.Type.Format,
                         capture_index = 1,
                         modifier = 'upcase',
                       },
@@ -79,7 +79,7 @@ describe('vim.lsp._snippet', function()
                   },
                 },
                 {
-                  type = snippet.NodeType.TEXT,
+                  type = snippet.Node.Type.Text,
                   raw = 'TE\\$\\}XT',
                   esc = 'TE$}XT',
                 },
@@ -93,35 +93,35 @@ describe('vim.lsp._snippet', function()
 
   it('should parse variables', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = snippet.Node.Type.Snippet,
       children = {
         {
-          type = snippet.NodeType.VARIABLE,
+          type = snippet.Node.Type.Variable,
           name = 'VAR',
         },
         {
-          type = snippet.NodeType.VARIABLE,
+          type = snippet.Node.Type.Variable,
           name = 'VAR',
         },
         {
-          type = snippet.NodeType.VARIABLE,
+          type = snippet.Node.Type.Variable,
           name = 'VAR',
           children = {
             {
-              type = snippet.NodeType.TABSTOP,
+              type = snippet.Node.Type.Tabstop,
               tabstop = 1,
             },
           },
         },
         {
-          type = snippet.NodeType.VARIABLE,
+          type = snippet.Node.Type.Variable,
           name = 'VAR',
           transform = {
-            type = snippet.NodeType.TRANSFORM,
+            type = snippet.Node.Type.Transform,
             pattern = 'regex',
             format = {
               {
-                type = snippet.NodeType.FORMAT,
+                type = snippet.Node.Type.Format,
                 capture_index = 1,
                 modifier = 'upcase',
               },
@@ -134,10 +134,10 @@ describe('vim.lsp._snippet', function()
 
   it('should parse choice', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = snippet.Node.Type.Snippet,
       children = {
         {
-          type = snippet.NodeType.CHOICE,
+          type = snippet.Node.Type.Choice,
           tabstop = 1,
           items = {
             ',',
@@ -150,40 +150,40 @@ describe('vim.lsp._snippet', function()
 
   it('should parse format', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = snippet.Node.Type.Snippet,
       children = {
         {
-          type = snippet.NodeType.VARIABLE,
+          type = snippet.Node.Type.Variable,
           name = 'VAR',
           transform = {
-            type = snippet.NodeType.TRANSFORM,
+            type = snippet.Node.Type.Transform,
             pattern = 'regex',
             format = {
               {
-                type = snippet.NodeType.FORMAT,
+                type = snippet.Node.Type.Format,
                 capture_index = 1,
                 modifier = 'upcase',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = snippet.Node.Type.Format,
                 capture_index = 1,
                 if_text = 'if_text',
                 else_text = '',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = snippet.Node.Type.Format,
                 capture_index = 1,
                 if_text = '',
                 else_text = 'else_text',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = snippet.Node.Type.Format,
                 capture_index = 1,
                 else_text = 'else_text',
                 if_text = 'if_text',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = snippet.Node.Type.Format,
                 capture_index = 1,
                 if_text = '',
                 else_text = 'else_text',


### PR DESCRIPTION
This PR implements the minimal snippet feature.

### API

- `vim.snippet.expand(snippet_text)`
- `vim.snippet.jump(direction)`
- `vim.snippet.jumpable(direction)`
- `vim.snippet.dispose()`

### Limitation
- current implementation can't handle adjacent placeholders.
- the `transform` feature is just ignored.

### TODO
- functionaltest
    - port test case from vim-vsnip
- documentation
    - learn how to write docs
