### PR TITLE
Windows 7: Fix crash due to DLL linker error on startup

### DIFF
--- a/third-party/cmake/BuildLibuv.cmake
+++ b/third-party/cmake/BuildLibuv.cmake
@@ -66,7 +66,9 @@ elseif(WIN32)
     set(LIBUV_PATCH_COMMAND
       ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv init
       COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv apply --ignore-whitespace
-        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libuv-disable-typedef-MinGW.patch)
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libuv-disable-typedef-MinGW.patch
+      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv apply --ignore-whitespace
+        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libuv-gethostnamew-win7.patch)
   else()
     message(FATAL_ERROR "Trying to build libuv in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
   endif()

--- a/third-party/patches/libuv-gethostnamew-win7.patch
+++ b/third-party/patches/libuv-gethostnamew-win7.patch
@@ -1,0 +1,69 @@
+diff --git a/src/win/util.c b/src/win/util.c
+index 88602c7ee..086cc64e1 100644
+--- a/src/win/util.c
++++ b/src/win/util.c
+@@ -1664,6 +1664,9 @@ int uv_os_unsetenv(const char* name) {
+ 
+ 
+ int uv_os_gethostname(char* buffer, size_t* size) {
++  static HMODULE winsock_dll; 
++  static int WSAAPI (*gethostnamew)(PWSTR name, int namelen);
++
+   WCHAR buf[UV_MAXHOSTNAMESIZE];
+   size_t len;
+   char* utf8_str;
+@@ -1674,24 +1677,41 @@ int uv_os_gethostname(char* buffer, size_t* size) {
+ 
+   uv__once_init(); /* Initialize winsock */
+ 
+-  if (GetHostNameW(buf, UV_MAXHOSTNAMESIZE) != 0)
+-    return uv_translate_sys_error(WSAGetLastError());
++  if (!winsock_dll) {
++    winsock_dll = LoadLibraryA("Ws2_32.dll");
++    gethostnamew = GetProcAddress(winsock_dll, "GetHostNameW");
++  }
+ 
+-  convert_result = uv__convert_utf16_to_utf8(buf, -1, &utf8_str);
++  if (gethostnamew) {
++    if (gethostnamew(buf, UV_MAXHOSTNAMESIZE) != 0)
++      return uv_translate_sys_error(WSAGetLastError());
+ 
+-  if (convert_result != 0)
+-    return convert_result;
++    convert_result = uv__convert_utf16_to_utf8(buf, -1, &utf8_str);
+ 
+-  len = strlen(utf8_str);
+-  if (len >= *size) {
+-    *size = len + 1;
++    if (convert_result != 0)
++      return convert_result;
++
++    len = strlen(utf8_str);
++    if (len >= *size) {
++      *size = len + 1;
++      uv__free(utf8_str);
++      return UV_ENOBUFS;
++    }
++
++    memcpy(buffer, utf8_str, len + 1);
+     uv__free(utf8_str);
+-    return UV_ENOBUFS;
++    *size = len;
++  } else {
++    if (gethostname((char*)buf, sizeof(buf)) != 0)
++      return uv_translate_sys_error(WSAGetLastError());
++    len = strlen(buf);
++    if (len >= *size) {
++      *size = len + 1;
++      return UV_ENOBUFS;
++    }
++    *size = len;
++    memcpy(buffer, buf, len + 1);
+   }
+-
+-  memcpy(buffer, utf8_str, len + 1);
+-  uv__free(utf8_str);
+-  *size = len;
+   return 0;
+ }
+ 


### PR DESCRIPTION
GetHostNameW was introduced in Windows 8. Use regular gethostname as fallback on older systems.

Closes: #16482
