### PR TITLE
vim-patch:8.2.3729: no support for squirrels

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1752,6 +1752,9 @@ au BufNewFile,BufRead *.sqlj			setf sqlj
 " SQR
 au BufNewFile,BufRead *.sqr,*.sqi		setf sqr
 
+" Squirrel
+au BufNewFile,BufRead *.nut			setf squirrel
+
 " OpenSSH configuration
 au BufNewFile,BufRead ssh_config,*/.ssh/config		setf sshconfig
 au BufNewFile,BufRead */etc/ssh/ssh_config.d/*.conf	setf sshconfig

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -476,6 +476,7 @@ let s:filename_checks = {
     \ 'sqlj': ['file.sqlj'],
     \ 'sqr': ['file.sqr', 'file.sqi'],
     \ 'squid': ['squid.conf'],
+    \ 'squirrel': ['file.nut'],
     \ 'srec': ['file.s19', 'file.s28', 'file.s37', 'file.mot', 'file.srec'],
     \ 'sshconfig': ['ssh_config', '/.ssh/config', '/etc/ssh/ssh_config.d/file.conf', 'any/etc/ssh/ssh_config.d/file.conf', 'any/.ssh/config'],
     \ 'sshdconfig': ['sshd_config', '/etc/ssh/sshd_config.d/file.conf', 'any/etc/ssh/sshd_config.d/file.conf'],


### PR DESCRIPTION
Problem:    No support for 🐿. (closes vim/vim#9259)
Solution:   Recognize 🌰.
https://github.com/vim/vim/commit/6f42cb6e5159b323814a53bbc82def4f2cfb17ad
