### PR TITLE
ci: install doxygen with homebrew/conda instead of apt

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -26,8 +26,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-msgpack luajit
-          brew install doxygen
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3 luajit
+          conda install -c conda-forge doxygen=1.9.2 msgpack-python
+          echo "$CONDA/bin" >> $GITHUB_PATH
 
       - name: Setup git config
         run: |

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y doxygen python3 python3-msgpack luajit
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-msgpack luajit
+          brew install doxygen
 
       - name: Setup git config
         run: |


### PR DESCRIPTION
Closes #16498

Homebrew has a newer version of doxygen (1.9.2 at the time of writing)
which is needed to avoid a bug that results in inconsistent
documentation generation.
