### PR TITLE
ci: remove "brew upgrade" from macos jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
           # Workaround brew issues
           rm -f /usr/local/bin/2to3
           brew update >/dev/null
-          brew upgrade
           brew install automake ccache perl cpanminus ninja
 
       - name: Setup interpreter packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
         run: |
           rm -f /usr/local/bin/2to3
           brew update >/dev/null
-          brew upgrade
           brew install automake ninja
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV


### PR DESCRIPTION
Packages are automatically upgraded on install. This will avoid
upgrading unrelated packages, cutting the macos job time to about a
half.
