### PR TITLE
Reduce lint warnings

### DIFF
--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -14,8 +14,8 @@
 /// @return Folded variant.
 #define CH_FOLD(c) \
   utf_fold((sizeof(c) == sizeof(char)) \
-             ?((int)(uint8_t)(c)) \
-             :((int)(c)))
+           ? ((int)(uint8_t)(c)) \
+           : ((int)(c)))
 
 /// Flags for vim_str2nr()
 typedef enum {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5241,7 +5241,7 @@ static int ins_complete(int c, bool enable_pum)
       funcname = get_complete_funcname(ctrl_x_mode);
       if (*funcname == NUL) {
         semsg(_(e_notset), ctrl_x_mode == CTRL_X_FUNCTION
-            ? "completefunc" : "omnifunc");
+              ? "completefunc" : "omnifunc");
         // restore did_ai, so that adding comment leader works
         did_ai = save_did_ai;
         return FAIL;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4523,7 +4523,7 @@ static int eval_index(char_u **arg, typval_T *rettv, int evaluate, int verbose)
      * dict.name
      */
     key = *arg + 1;
-    for (len = 0; ASCII_ISALNUM(key[len]) || key[len] == '_'; ++len) {
+    for (len = 0; ASCII_ISALNUM(key[len]) || key[len] == '_'; len++) {
     }
     if (len == 0) {
       return FAIL;
@@ -6603,8 +6603,9 @@ void common_function(typval_T *argvars, typval_T *rettv, bool is_funcref, FunPtr
                          : (const char *)s));
     // Don't check an autoload name for existence here.
   } else if (trans_name != NULL
-             && (is_funcref ? find_func(trans_name) == NULL
-                            : !translated_function_exists((const char *)trans_name))) {
+             && (is_funcref
+                 ? find_func(trans_name) == NULL
+                 : !translated_function_exists((const char *)trans_name))) {
     semsg(_("E700: Unknown function: %s"), s);
   } else {
     int dict_idx = 0;
@@ -9649,8 +9650,8 @@ bool var_check_func_name(const char *const name, const bool new_var)
 {
   // Allow for w: b: s: and t:.
   if (!(vim_strchr((char_u *)"wbst", name[0]) != NULL && name[1] == ':')
-      && !ASCII_ISUPPER((name[0] != NUL && name[1] == ':') ? name[2]
-                                                           : name[0])) {
+      && !ASCII_ISUPPER((name[0] != NUL && name[1] == ':')
+                        ? name[2] : name[0])) {
     semsg(_("E704: Funcref variable name must start with a capital: %s"), name);
     return false;
   }

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -209,8 +209,8 @@ typedef enum {
 
 /// flags for find_name_end()
 #define FNE_INCL_BR     1       // find_name_end(): include [] in name
-#define FNE_CHECK_START 2       /* find_name_end(): check name starts with
-                                   valid character */
+#define FNE_CHECK_START 2       // find_name_end(): check name starts with
+                                // valid character
 
 typedef struct {
   TimeWatcher tw;

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -730,7 +730,7 @@ json_decode_string_cycle_start:
                       ? (DICT_LEN(last_container.container.vval.v_dict) == 0)
                       : (tv_list_len(last_container.container.vval.v_list)
                          == 0))
-                      : (tv_list_len(last_container.special_val) == 0)) {
+                   : (tv_list_len(last_container.special_val) == 0)) {
         semsg(_("E474: Leading comma: %.*s"), LENP(p, e));
         goto json_decode_string_fail;
       }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -305,9 +305,8 @@ void ex_align(exarg_T *eap)
                */
               do {
                 (void)set_indent(++new_indent, 0);
-              }
-              while (linelen(NULL) <= width);
-              --new_indent;
+              } while (linelen(NULL) <= width);
+              new_indent--;
               break;
             }
             --new_indent;
@@ -1457,7 +1456,7 @@ error:
 filterend:
 
   if (curbuf != old_curbuf) {
-    --no_wait_return;
+    no_wait_return--;
     emsg(_("E135: *Filter* Autocommands must not change current buffer"));
   }
   if (itmp != NULL) {
@@ -2094,7 +2093,7 @@ void do_wqall(exarg_T *eap)
     }
     if (buf->b_ffname == NULL) {
       semsg(_("E141: No file name for buffer %" PRId64), (int64_t)buf->b_fnum);
-      ++error;
+      error++;
     } else if (check_readonly(&eap->forceit, buf)
                || check_overwrite(eap, buf, buf->b_fname, buf->b_ffname,
                                   FALSE) == FAIL) {
@@ -2120,17 +2119,15 @@ void do_wqall(exarg_T *eap)
   }
 }
 
-/*
- * Check the 'write' option.
- * Return TRUE and give a message when it's not st.
- */
-int not_writing(void)
+// Check the 'write' option.
+// Return true and give a message when it's not st.
+bool not_writing(void)
 {
   if (p_write) {
-    return FALSE;
+    return false;
   }
   emsg(_("E142: File not written: Writing is disabled by 'write' option"));
-  return TRUE;
+  return true;
 }
 
 /*
@@ -2945,7 +2942,7 @@ void ex_append(exarg_T *eap)
   }
 
   for (;;) {
-    msg_scroll = TRUE;
+    msg_scroll = true;
     need_wait_return = false;
     if (curbuf->b_p_ai) {
       if (append_indent >= 0) {
@@ -3131,7 +3128,7 @@ void ex_z(exarg_T *eap)
 
   // the number of '-' and '+' multiplies the distance
   if (*kind == '-' || *kind == '+') {
-    for (x = kind + 1; *x == *kind; ++x) {
+    for (x = kind + 1; *x == *kind; x++) {
     }
   }
 
@@ -3214,26 +3211,24 @@ void ex_z(exarg_T *eap)
   ex_no_reprint = true;
 }
 
-/*
- * Check if the secure flag is set (.exrc or .vimrc in current directory).
- * If so, give an error message and return TRUE.
- * Otherwise, return FALSE.
- */
-int check_secure(void)
+// Check if the secure flag is set (.exrc or .vimrc in current directory).
+// If so, give an error message and return true.
+// Otherwise, return false.
+bool check_secure(void)
 {
   if (secure) {
     secure = 2;
     emsg(_(e_curdir));
-    return TRUE;
+    return true;
   }
 
   // In the sandbox more things are not allowed, including the things
   // disallowed in secure mode.
   if (sandbox != 0) {
     emsg(_(e_sandbox));
-    return TRUE;
+    return true;
   }
-  return FALSE;
+  return false;
 }
 
 /// Previous substitute replacement string

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -435,7 +435,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
         && cstack.cs_idx < 0
         && !(getline_is_func
              && func_has_abort(real_cookie))) {
-      did_emsg = FALSE;
+      did_emsg = false;
     }
 
     /*
@@ -2717,7 +2717,7 @@ static char_u *find_ucmd(exarg_T *eap, char_u *p, int *full, expand_T *xp, int *
    */
   gap = &curbuf->b_ucmds;
   for (;;) {
-    for (j = 0; j < gap->ga_len; ++j) {
+    for (j = 0; j < gap->ga_len; j++) {
       uc = USER_CMD_GA(gap, j);
       cp = eap->cmd;
       np = uc->uc_name;
@@ -5328,7 +5328,7 @@ static void uc_list(char_u *name, size_t name_len)
     ? &prevwin->w_buffer->b_ucmds
     : &curbuf->b_ucmds;
   for (;;) {
-    for (i = 0; i < gap->ga_len; ++i) {
+    for (i = 0; i < gap->ga_len; i++) {
       cmd = USER_CMD_GA(gap, i);
       a = cmd->uc_argt;
 
@@ -5715,7 +5715,7 @@ static void ex_delcommand(exarg_T *eap)
 
   gap = &curbuf->b_ucmds;
   for (;;) {
-    for (i = 0; i < gap->ga_len; ++i) {
+    for (i = 0; i < gap->ga_len; i++) {
       cmd = USER_CMD_GA(gap, i);
       cmp = STRCMP(eap->arg, cmd->uc_name);
       if (cmp <= 0) {
@@ -8338,9 +8338,7 @@ static void ex_redir(exarg_T *eap)
       if (var_redir_start(skipwhite(arg), append) == OK) {
         redir_vname = 1;
       }
-    }
-    // TODO: redirect to a buffer
-    else {
+    } else {  // TODO(vim): redirect to a buffer
       semsg(_(e_invarg2), eap->arg);
     }
   }

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -437,7 +437,7 @@ char *get_exception_string(void *value, except_type_T type, char_u *cmdname, int
       }
     }
   } else {
-    *should_free = FALSE;
+    *should_free = false;
     ret = value;
   }
 
@@ -888,11 +888,10 @@ void ex_endif(exarg_T *eap)
  */
 void ex_else(exarg_T *eap)
 {
-  int skip;
   int result;
   cstack_T *const cstack = eap->cstack;
 
-  skip = CHECK_SKIP;
+  bool skip = CHECK_SKIP;
 
   if (cstack->cs_idx < 0
       || (cstack->cs_flags[cstack->cs_idx]
@@ -902,14 +901,14 @@ void ex_else(exarg_T *eap)
       return;
     }
     eap->errmsg = N_("E582: :elseif without :if");
-    skip = TRUE;
+    skip = true;
   } else if (cstack->cs_flags[cstack->cs_idx] & CSF_ELSE) {
     if (eap->cmdidx == CMD_else) {
       eap->errmsg = N_("E583: multiple :else");
       return;
     }
     eap->errmsg = N_("E584: :elseif after :else");
-    skip = TRUE;
+    skip = true;
   }
 
   // if skipping or the ":if" was TRUE, reset ACTIVE, otherwise set it
@@ -917,7 +916,7 @@ void ex_else(exarg_T *eap)
     if (eap->errmsg == NULL) {
       cstack->cs_flags[cstack->cs_idx] = CSF_TRUE;
     }
-    skip = TRUE;        // don't evaluate an ":elseif"
+    skip = true;        // don't evaluate an ":elseif"
   } else {
     cstack->cs_flags[cstack->cs_idx] = CSF_ACTIVE;
   }
@@ -932,7 +931,7 @@ void ex_else(exarg_T *eap)
   // later on.
   if (!skip && dbg_check_skipped(eap) && got_int) {
     (void)do_intthrow(cstack);
-    skip = TRUE;
+    skip = true;
   }
 
   if (eap->cmdidx == CMD_elseif) {
@@ -1322,9 +1321,9 @@ void ex_try(exarg_T *eap)
 void ex_catch(exarg_T *eap)
 {
   int idx = 0;
-  int give_up = FALSE;
-  int skip = FALSE;
-  int caught = FALSE;
+  bool give_up = false;
+  bool skip = false;
+  bool caught = false;
   char_u *end;
   char_u save_char = 0;
   char_u *save_cpo;
@@ -1335,13 +1334,13 @@ void ex_catch(exarg_T *eap)
 
   if (cstack->cs_trylevel <= 0 || cstack->cs_idx < 0) {
     eap->errmsg = N_("E603: :catch without :try");
-    give_up = TRUE;
+    give_up = true;
   } else {
     if (!(cstack->cs_flags[cstack->cs_idx] & CSF_TRY)) {
       // Report what's missing if the matching ":try" is not in its
       // finally clause.
       eap->errmsg = get_end_emsg(cstack);
-      skip = TRUE;
+      skip = true;
     }
     for (idx = cstack->cs_idx; idx > 0; --idx) {
       if (cstack->cs_flags[idx] & CSF_TRY) {
@@ -1352,7 +1351,7 @@ void ex_catch(exarg_T *eap)
       // Give up for a ":catch" after ":finally" and ignore it.
       // Just parse.
       eap->errmsg = N_("E604: :catch after :finally");
-      give_up = TRUE;
+      give_up = true;
     } else {
       rewind_conditionals(cstack, idx, CSF_WHILE | CSF_FOR,
                           &cstack->cs_looplevel);
@@ -1425,7 +1424,7 @@ void ex_catch(exarg_T *eap)
           // CTRL-C while matching should abort it.
           //
           prev_got_int = got_int;
-          got_int = FALSE;
+          got_int = false;
           caught = vim_regexec_nl(&regmatch, (char_u *)current_exception->value,
                                   (colnr_T)0);
           got_int |= prev_got_int;
@@ -1602,8 +1601,7 @@ void ex_finally(exarg_T *eap)
 void ex_endtry(exarg_T *eap)
 {
   int idx;
-  int skip;
-  int rethrow = FALSE;
+  bool rethrow = false;
   int pending = CSTP_NONE;
   void *rettv = NULL;
   cstack_T *const cstack = eap->cstack;
@@ -1621,20 +1619,19 @@ void ex_endtry(exarg_T *eap)
     // made inactive by a ":continue", ":break", ":return", or ":finish" in
     // the finally clause.  The latter case need not be tested since then
     // anything pending has already been discarded.
-    skip = (did_emsg || got_int || current_exception
-            || !(cstack->cs_flags[cstack->cs_idx] & CSF_TRUE));
+    bool skip = did_emsg || got_int || current_exception
+            || !(cstack->cs_flags[cstack->cs_idx] & CSF_TRUE);
 
     if (!(cstack->cs_flags[cstack->cs_idx] & CSF_TRY)) {
       eap->errmsg = get_end_emsg(cstack);
       // Find the matching ":try" and report what's missing.
       idx = cstack->cs_idx;
       do {
-        --idx;
-      }
-      while (idx > 0 && !(cstack->cs_flags[idx] & CSF_TRY));
+        idx--;
+      } while (idx > 0 && !(cstack->cs_flags[idx] & CSF_TRY));
       rewind_conditionals(cstack, idx, CSF_WHILE | CSF_FOR,
                           &cstack->cs_looplevel);
-      skip = TRUE;
+      skip = true;
 
       /*
        * If an exception is being thrown, discard it to prevent it from
@@ -1677,7 +1674,7 @@ void ex_endtry(exarg_T *eap)
       // before the ":endtry".  That is, throw an interrupt exception and
       // set "skip" and "rethrow".
       if (got_int) {
-        skip = TRUE;
+        skip = true;
         (void)do_intthrow(cstack);
         // The do_intthrow() call may have reset current_exception or
         // cstack->cs_pending[idx].

--- a/src/nvim/ex_eval.h
+++ b/src/nvim/ex_eval.h
@@ -17,8 +17,8 @@
 #define CSF_THROWN     0x0400  // exception thrown to this try conditional
 #define CSF_CAUGHT     0x0800  // exception caught by this try conditional
 #define CSF_SILENT     0x1000  // "emsg_silent" reset by ":try"
-/* Note that CSF_ELSE is only used when CSF_TRY and CSF_WHILE are unset
- * (an ":if"), and CSF_SILENT is only used when CSF_TRY is set. */
+// Note that CSF_ELSE is only used when CSF_TRY and CSF_WHILE are unset
+// (an ":if"), and CSF_SILENT is only used when CSF_TRY is set.
 
 /*
  * What's pending for being reactivated at the ":endtry" of this try

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2491,27 +2491,25 @@ char *get_text_locked_msg(void)
 }
 
 /// Check if "curbuf->b_ro_locked" or "allbuf_lock" is set and
-/// return TRUE when it is and give an error message.
-int curbuf_locked(void)
+/// return true when it is and give an error message.
+bool curbuf_locked(void)
 {
   if (curbuf->b_ro_locked > 0) {
     emsg(_("E788: Not allowed to edit another buffer now"));
-    return TRUE;
+    return true;
   }
   return allbuf_locked();
 }
 
-/*
- * Check if "allbuf_lock" is set and return TRUE when it is and give an error
- * message.
- */
-int allbuf_locked(void)
+// Check if "allbuf_lock" is set and return true when it is and give an error
+// message.
+bool allbuf_locked(void)
 {
   if (allbuf_lock > 0) {
     emsg(_("E811: Not allowed to change buffer information now"));
-    return TRUE;
+    return true;
   }
-  return FALSE;
+  return false;
 }
 
 static int cmdline_charsize(int idx)

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1851,7 +1851,7 @@ failed:
       msg_scrolled_ign = true;
 
       if (!read_stdin && !read_buffer) {
-        p = (char_u *)msg_trunc_attr((char *)IObuff, FALSE, 0);
+        p = (char_u *)msg_trunc_attr((char *)IObuff, false, 0);
       }
 
       if (read_stdin || read_buffer || restart_edit != 0

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -14,10 +14,10 @@
  */
 typedef struct foldinfo {
   linenr_T fi_lnum;             // line number where fold starts
-  int fi_level;                 /* level of the fold; when this is zero the
-                                   other fields are invalid */
-  int fi_low_level;             /* lowest fold level that starts in the same
-                                   line */
+  int fi_level;                 // level of the fold; when this is zero the
+                                // other fields are invalid
+  int fi_low_level;             // lowest fold level that starts in the same
+                                // line
   long fi_lines;
 } foldinfo_T;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1794,11 +1794,9 @@ static int vgetorpeek(bool advance)
        * try re-mapping.
        */
       for (;;) {
-        /*
-         * os_breakcheck() is slow, don't use it too often when
-         * inside a mapping.  But call it each time for typed
-         * characters.
-         */
+        // os_breakcheck() is slow, don't use it too often when
+        // inside a mapping.  But call it each time for typed
+        // characters.
         if (typebuf.tb_maplen) {
           line_breakcheck();
         } else {

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -223,9 +223,9 @@ void ex_cstag(exarg_T *eap)
   switch (p_csto) {
   case 0:
     if (cs_check_for_connections()) {
-      ret = cs_find_common("g", (char *)(eap->arg), eap->forceit, FALSE,
-                           FALSE, *eap->cmdlinep);
-      if (ret == FALSE) {
+      ret = cs_find_common("g", (char *)(eap->arg), eap->forceit, false,
+                           false, *eap->cmdlinep);
+      if (ret == false) {
         cs_free_tags();
         if (msg_col) {
           msg_putchar('\n');
@@ -249,16 +249,16 @@ void ex_cstag(exarg_T *eap)
 
         if (cs_check_for_connections()) {
           ret = cs_find_common("g", (char *)(eap->arg), eap->forceit,
-                               FALSE, FALSE, *eap->cmdlinep);
-          if (ret == FALSE) {
+                               false, false, *eap->cmdlinep);
+          if (ret == false) {
             cs_free_tags();
           }
         }
       }
     } else if (cs_check_for_connections()) {
-      ret = cs_find_common("g", (char *)(eap->arg), eap->forceit, FALSE,
-                           FALSE, *eap->cmdlinep);
-      if (ret == FALSE) {
+      ret = cs_find_common("g", (char *)(eap->arg), eap->forceit, false,
+                           false, *eap->cmdlinep);
+      if (ret == false) {
         cs_free_tags();
       }
     }
@@ -520,7 +520,7 @@ add_err:
 }
 
 
-static int cs_check_for_connections(void)
+static bool cs_check_for_connections(void)
 {
   return cs_cnt_connections() > 0;
 }
@@ -887,20 +887,20 @@ static int cs_find(exarg_T *eap)
 {
   char *opt, *pat;
 
-  if (cs_check_for_connections() == FALSE) {
+  if (cs_check_for_connections() == false) {
     (void)emsg(_("E567: no cscope connections"));
-    return FALSE;
+    return false;
   }
 
   if ((opt = strtok((char *)NULL, (const char *)" ")) == NULL) {
     cs_usage_msg(Find);
-    return FALSE;
+    return false;
   }
 
   pat = opt + strlen(opt) + 1;
   if (pat >= (char *)eap->arg + eap_arg_len) {
     cs_usage_msg(Find);
-    return FALSE;
+    return false;
   }
 
   /*
@@ -919,8 +919,8 @@ static int cs_find(exarg_T *eap)
 
 
 /// Common code for cscope find, shared by cs_find() and ex_cstag().
-static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int use_ll,
-                          char_u *cmdline)
+static bool cs_find_common(char *opt, char *pat, int forceit, int verbose,
+                           bool use_ll, char_u *cmdline)
 {
   char *cmd;
   int *nummatches;
@@ -967,7 +967,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
     // next symbol must be + or -
     if (strchr(CSQF_FLAGS, *qfpos) == NULL) {
       (void)semsg(_("E469: invalid cscopequickfix flag %c for %c"), *qfpos, *(qfpos - 1));
-      return FALSE;
+      return false;
     }
 
     if (*qfpos != '0'
@@ -982,7 +982,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
   // create the actual command to send to cscope
   cmd = cs_create_cmd(opt, pat);
   if (cmd == NULL) {
-    return FALSE;
+    return false;
   }
 
   nummatches = xmalloc(sizeof(int) * csinfo_size);
@@ -1019,7 +1019,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
       (void)semsg(_("E259: no matches found for cscope query %s of %s"), opt, pat);
     }
     xfree(nummatches);
-    return FALSE;
+    return false;
   }
 
   if (qfpos != NULL && *qfpos != '0') {
@@ -1064,7 +1064,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
     os_remove((char *)tmp);
     xfree(tmp);
     xfree(nummatches);
-    return TRUE;
+    return true;
   } else {
     char **matches = NULL, **contexts = NULL;
     size_t matched = 0;
@@ -1073,7 +1073,7 @@ static int cs_find_common(char *opt, char *pat, int forceit, int verbose, int us
     cs_fill_results(pat, totmatches, nummatches, &matches, &contexts, &matched);
     xfree(nummatches);
     if (matches == NULL) {
-      return FALSE;
+      return false;
     }
 
     (void)cs_manage_matches(matches, contexts, matched, Store);
@@ -1499,12 +1499,13 @@ static void cs_file_results(FILE *f, int *nummatches_a)
         continue;
       }
 
-      context = xmalloc(strlen(cntx) + 5);
+      size_t context_len = strlen(cntx) + 5;
+      context = xmalloc(context_len);
 
       if (strcmp(cntx, "<global>") == 0) {
-        strcpy(context, "<<global>>");
+        xstrlcpy(context, "<<global>>", context_len);
       } else {
-        sprintf(context, "<<%s>>", cntx);
+        snprintf(context, context_len, "<<%s>>", cntx);
       }
 
       if (search == NULL) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -839,13 +839,11 @@ void msg_schedule_semsg(const char *const fmt, ...)
   multiqueue_put(main_loop.events, msg_semsg_event, 1, s);
 }
 
-/*
- * Like msg(), but truncate to a single line if p_shm contains 't', or when
- * "force" is TRUE.  This truncates in another way as for normal messages.
- * Careful: The string may be changed by msg_may_trunc()!
- * Returns a pointer to the printed message, if wait_return() not called.
- */
-char *msg_trunc_attr(char *s, int force, int attr)
+// Like msg(), but truncate to a single line if p_shm contains 't', or when
+// "force" is true.  This truncates in another way as for normal messages.
+// Careful: The string may be changed by msg_may_trunc()!
+// Returns a pointer to the printed message, if wait_return() not called.
+char *msg_trunc_attr(char *s, bool force, int attr)
 {
   int n;
 
@@ -869,7 +867,7 @@ char *msg_trunc_attr(char *s, int force, int attr)
  * Return a pointer to where the truncated message starts.
  * Note: May change the message by replacing a character with '<'.
  */
-char_u *msg_may_trunc(int force, char_u *s)
+char_u *msg_may_trunc(bool force, char_u *s)
 {
   int room;
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1760,13 +1760,14 @@ static char_u *regpiece(int *flagp)
     break;
   }
   if (re_multi_type(peekchr()) != NOT_MULTI) {
-    /* Can't have a multi follow a multi. */
-    if (peekchr() == Magic('*'))
-      sprintf((char *)IObuff, _("E61: Nested %s*"),
-          reg_magic >= MAGIC_ON ? "" : "\\");
-    else
-      sprintf((char *)IObuff, _("E62: Nested %s%c"),
-          reg_magic == MAGIC_ALL ? "" : "\\", no_Magic(peekchr()));
+    // Can't have a multi follow a multi.
+    if (peekchr() == Magic('*')) {
+      snprintf((char *)IObuff, IOSIZE, _("E61: Nested %s*"),
+               reg_magic >= MAGIC_ON ? "" : "\\");
+    } else {
+      snprintf((char *)IObuff, IOSIZE, _("E62: Nested %s%c"),
+               reg_magic == MAGIC_ALL ? "" : "\\", no_Magic(peekchr()));
+    }
     EMSG_RET_NULL((char *)IObuff);
   }
 
@@ -1926,11 +1927,11 @@ static char_u *regatom(int *flagp)
   case Magic('{'):
   case Magic('*'):
     c = no_Magic(c);
-    sprintf((char *)IObuff, _("E64: %s%c follows nothing"),
-        (c == '*' ? reg_magic >= MAGIC_ON : reg_magic == MAGIC_ALL)
-        ? "" : "\\", c);
+    snprintf((char *)IObuff, IOSIZE, _("E64: %s%c follows nothing"),
+             (c == '*' ? reg_magic >= MAGIC_ON : reg_magic == MAGIC_ALL)
+             ? "" : "\\", c);
     EMSG_RET_NULL((char *)IObuff);
-  /* NOTREACHED */
+  // NOTREACHED
 
   case Magic('~'):              /* previous substitute pattern */
     if (reg_prev_sub != NULL) {
@@ -3152,8 +3153,8 @@ static int read_limits(long *minval, long *maxval)
     regparse++;         // Allow either \{...} or \{...\}
   }
   if (*regparse != '}') {
-    sprintf((char *)IObuff, _("E554: Syntax error in %s{...}"),
-        reg_magic == MAGIC_ALL ? "" : "\\");
+    snprintf((char *)IObuff, IOSIZE, _("E554: Syntax error in %s{...}"),
+             reg_magic == MAGIC_ALL ? "" : "\\");
     EMSG_RET_FAIL((char *)IObuff);
   }
 
@@ -7263,9 +7264,10 @@ regprog_T *vim_regcomp(char_u *expr_arg, int re_flags)
       if (f) {
         fprintf(f, "Syntax error in \"%s\"\n", expr);
         fclose(f);
-      } else
+      } else {
         semsg("(NFA) Could not open \"%s\" to write !!!",
-            BT_REGEXP_DEBUG_LOG_NAME);
+              BT_REGEXP_DEBUG_LOG_NAME);
+      }
     }
 #endif
     // If the NFA engine failed, try the backtracking engine. The NFA engine

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -141,12 +141,12 @@ static int tfu_in_use = false;  // disallow recursive call of tagfunc
 /// type == DT_LTAG:     use location list for displaying tag matches
 /// type == DT_FREE:     free cached matches
 ///
-/// for cscope, returns TRUE if we jumped to tag or aborted, FALSE otherwise
+/// for cscope, returns true if we jumped to tag or aborted, false otherwise
 ///
 /// @param tag  tag (pattern) to jump to
 /// @param forceit  :ta with !
 /// @param verbose  print "tag not found" message
-int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
+bool do_tag(char_u *tag, int type, int count, int forceit, int verbose)
 {
   taggy_T *tagstack = curwin->w_tagstack;
   int tagstackidx = curwin->w_tagstackidx;
@@ -163,7 +163,7 @@ int do_tag(char_u *tag, int type, int count, int forceit, int verbose)
   int error_cur_match = 0;
   int save_pos = false;
   fmark_T saved_fmark;
-  int jumped_to_tag = false;
+  bool jumped_to_tag = false;
   int new_num_matches;
   char_u **new_matches;
   int use_tagstack;


### PR DESCRIPTION
Some were caused by uncrustify refactor or recent vim-patch ports. Difficult to fix all without reverting some uncrustify changes.