### PR TITLE
fix: escape filename pipes in diagnostic.lua

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -658,7 +658,10 @@ function M.set(namespace, bufnr, diagnostics, opts)
 
   vim.api.nvim_buf_call(bufnr, function()
     vim.api.nvim_command(
-      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr)))
+      string.format(
+        "doautocmd <nomodeline> DiagnosticChanged %s",
+        vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))
+      )
     )
   end)
 end

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -658,7 +658,7 @@ function M.set(namespace, bufnr, diagnostics, opts)
 
   vim.api.nvim_buf_call(bufnr, function()
     vim.api.nvim_command(
-      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.api.nvim_buf_get_name(bufnr))
+      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr)))
     )
   end)
 end
@@ -1333,7 +1333,7 @@ function M.reset(namespace, bufnr)
   end
 
   vim.api.nvim_command(
-      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.api.nvim_buf_get_name(bufnr))
+      string.format("doautocmd <nomodeline> DiagnosticChanged %s", vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr)))
   )
 end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1924,11 +1924,9 @@ describe('vim.diagnostic', function()
         vim.g.diagnostic_autocmd_triggered = 0
         vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')
         vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
-        vim.wait(100, function ()
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic', 0, 0, 0, 0)
-          })
-        end)
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+          make_error('Diagnostic', 0, 0, 0, 0)
+        })
         return vim.g.diagnostic_autocmd_triggered
       ]])
       end)
@@ -1938,9 +1936,7 @@ describe('vim.diagnostic', function()
         vim.g.diagnostic_autocmd_triggered = 0
         vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')
         vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
-        vim.wait(100, function ()
-          vim.diagnostic.reset(diagnostic_ns, diagnostic_bufnr)
-        end)
+        vim.diagnostic.reset(diagnostic_ns, diagnostic_bufnr)
         return vim.g.diagnostic_autocmd_triggered
       ]])
       end)

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1931,7 +1931,7 @@ describe('vim.diagnostic', function()
       ]])
       end)
 
-    it('triggers the autocommand diagnostics are cleared', function()
+    it('triggers the autocommand when diagnostics are cleared', function()
       eq(1, exec_lua [[
         vim.g.diagnostic_autocmd_triggered = 0
         vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1918,5 +1918,31 @@ describe('vim.diagnostic', function()
         return {show_called, hide_called}
       ]])
     end)
+
+    it('triggers the autocommand when diagnostics are set', function()
+      eq(1, exec_lua [[
+        vim.g.diagnostic_autocmd_triggered = 0
+        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')
+        vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
+        vim.wait(100, function ()
+          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+            make_error('Diagnostic', 0, 0, 0, 0)
+          })
+        end)
+        return vim.g.diagnostic_autocmd_triggered
+      ]])
+      end)
+
+    it('triggers the autocommand diagnostics are cleared', function()
+      eq(1, exec_lua [[
+        vim.g.diagnostic_autocmd_triggered = 0
+        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')
+        vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
+        vim.wait(100, function ()
+          vim.diagnostic.reset(diagnostic_ns, diagnostic_bufnr)
+        end)
+        return vim.g.diagnostic_autocmd_triggered
+      ]])
+      end)
   end)
 end)


### PR DESCRIPTION
Hello! I noticed, while working on a file with a pipe (`|`) in it's name and an LSP running, that there were errors being throw in the lua file I've modified here. It looks like the formatted command didn't have pipes escaped correctly, so when it was evaluated, the autocommand's argument would only be the filename up to the point of the pipe, then everything after that point would be treated as a second command to be evaluated.

The change I made does some simple escaping, and works as expected after testing, though I'm not sure if it handles every edge case; I'm not a vimscript expert. I'm also not familiar with the codebase, so lmk if there's already a function somewhere for escaping this kind of value, and I'd be happy to update this solution to use that!