### PR TITLE
docs(options): mention how to disable `inccommand` preview

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3228,7 +3228,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	"nosplit": Shows the effects of a command incrementally, as you type.
 	"split"	 : Also shows partial off-screen results in a preview window.
-	""	 : Does not preview the changes directly.
+	""       : Disable preview.
 
 	Works for |:substitute|, |:smagic|, |:snomagic|. |hl-Substitute|
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3226,11 +3226,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 'inccommand' 'icm'	string	(default "nosplit")
 			global
 
-	"nosplit": Shows the effects of a command incrementally, as you type.
-	"split"	 : Also shows partial off-screen results in a preview window.
-	""       : Disable preview.
+	When nonempty, shows the effects of |:substitute|, |:smagic|, and
+	|:snomagic| as you type.
 
-	Works for |:substitute|, |:smagic|, |:snomagic|. |hl-Substitute|
+	Possible values:
+		nosplit	Shows the effects of a command incrementally in the
+			buffer.
+		split	Like "nosplit", but also shows partial off-screen
+			results in a preview window.
 
 	If the preview is too slow (exceeds 'redrawtime') then 'inccommand' is
 	automatically disabled until |Command-line-mode| is done.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3228,6 +3228,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	"nosplit": Shows the effects of a command incrementally, as you type.
 	"split"	 : Also shows partial off-screen results in a preview window.
+	""	 : Does not preview the changes directly.
 
 	Works for |:substitute|, |:smagic|, |:snomagic|. |hl-Substitute|
 


### PR DESCRIPTION
Added blank option for inccommand in case the user wants to disable the incremental command preview.