### PR TITLE
fix: check for interrupt in nvim_echo, write_msg and nlua_print

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -842,7 +842,7 @@ void nvim_echo(Array chunks, Boolean history, Dictionary opts, Error *err)
   for (uint32_t i = 0; i < kv_size(hl_msg); i++) {
     HlMessageChunk chunk = kv_A(hl_msg, i);
     msg_multiline_attr((const char *)chunk.text.data, chunk.attr,
-                       false, &need_clear);
+                       true, &need_clear);
   }
   if (history) {
     msg_ext_set_kind("echomsg");
@@ -1842,6 +1842,9 @@ static void write_msg(String message, bool to_err)
 
   ++no_wait_return;
   for (uint32_t i = 0; i < message.size; i++) {
+    if (got_int) {
+      break;
+    }
     if (to_err) {
       PUSH_CHAR(i, err_pos, err_line_buf, emsg);
     } else {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -521,6 +521,9 @@ static void nlua_print_event(void **argv)
   const size_t len = (size_t)(intptr_t)argv[1]-1;  // exclude final NUL
 
   for (size_t i = 0; i < len;) {
+    if (got_int) {
+      break;
+    }
     const size_t start = i;
     while (i < len) {
       switch (str[i]) {


### PR DESCRIPTION
Fixes `q` in more pager, where `:highlight` can be quit out of with a
single `q` keystroke, while in `:lua print(vim.inspect(vim))` it just
scrolls down a page.

Fixes #11224