### PR TITLE
refactor(lsp): remove usage of deprecated function

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -489,7 +489,8 @@ local function text_document_did_open_handler(bufnr, client)
     -- Protect against a race where the buffer disappears
     -- between `did_open_handler` and the scheduled function firing.
     if vim.api.nvim_buf_is_valid(bufnr) then
-      vim.lsp.diagnostic.redraw(bufnr, client.id)
+      local namespace = vim.lsp.diagnostic.get_namespace(client.id)
+      vim.diagnostic.show(namespace, bufnr)
     end
   end)
 end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -565,7 +565,7 @@ end
 
 --- Redraw diagnostics for the given buffer and client
 ---
----@deprecated Prefer |vim.diagnostic.redraw()|
+---@deprecated Prefer |vim.diagnostic.show()|
 ---
 --- This calls the "textDocument/publishDiagnostics" handler manually using
 --- the cached diagnostics already received from the server. This can be useful


### PR DESCRIPTION
I forgot to leave a comment which broke the backport bot. - definitely gpanders