### PR TITLE
vim-patch:8.2.3664,8.2.3743,8.2.3747,8.2.3748,8.2.3757

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -47,6 +47,8 @@ The color of the column is set with the SignColumn highlight group
 
 	:highlight SignColumn guibg=darkgrey
 <
+If 'cursorline' is enabled, then the CursorLineSign highlight group is used
+|hl-CursorLineSign|.
 							*sign-identifier*
 Each placed sign is identified by a number called the sign identifier. This
 identifier is used to jump to the sign or to remove the sign. The identifier
@@ -156,6 +158,13 @@ See |sign_getdefined()| for the equivalent Vim script function.
 :sign list {name}
 		Lists one defined sign and its attributes.
 
+	culhl={group}
+		Highlighting group used for the text item when the cursor is
+		on the same line as the sign and 'cursorline' is enabled.
+
+	Example: >
+		:sign define MySign text=>> texthl=Search linehl=DiffText
+<
 
 PLACING SIGNS						*:sign-place* *E158*
 
@@ -377,6 +386,9 @@ sign_define({list})
 		   text		text that is displayed when there is no icon
 				or the GUI is not being used.
 		   texthl	highlight group used for the text item
+		   culhl	highlight group used for the text item when
+				the cursor is on the same line as the sign and
+				'cursorline' is enabled.
 		   numhl	highlight group used for 'number' column at the
 				associated line. Overrides |hl-LineNr|,
 				|hl-CursorLineNr|.
@@ -425,9 +437,13 @@ sign_getdefined([{name}])				*sign_getdefined()*
 				or the GUI is not being used.
 		   texthl	highlight group used for the text item; not
 				present if not set.
+		   culhl	highlight group used for the text item when
+				the cursor is on the same line as the sign and
+				'cursorline' is enabled; not present if not
+				set.
 		   numhl	highlight group used for 'number' column at the
 				associated line. Overrides |hl-LineNr|,
-				|hl-CursorLineNr|.
+				|hl-CursorLineNr|; not present if not set.
 
 		Returns an empty List if there are no signs and when {name} is
 		not found.

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -133,6 +133,10 @@ See |sign_define()| for the equivalent Vim script function.
 	texthl={group}
 		Highlighting group used for the text item.
 
+	culhl={group}
+		Highlighting group used for the text item when the cursor is
+		on the same line as the sign and 'cursorline' is enabled.
+
 	Example: >
 		:sign define MySign text=>> texthl=Search linehl=DiffText
 <
@@ -158,13 +162,6 @@ See |sign_getdefined()| for the equivalent Vim script function.
 :sign list {name}
 		Lists one defined sign and its attributes.
 
-	culhl={group}
-		Highlighting group used for the text item when the cursor is
-		on the same line as the sign and 'cursorline' is enabled.
-
-	Example: >
-		:sign define MySign text=>> texthl=Search linehl=DiffText
-<
 
 PLACING SIGNS						*:sign-place* *E158*
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5127,6 +5127,10 @@ LineNrBelow	Line number for when the 'relativenumber'
 							*hl-CursorLineNr*
 CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt'
 		contains "number" or is "both", for the cursor line.
+							*hl-CursorLineSign*
+CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
+							*hl-CursorLineFold*
+CursorLineFold	Like FoldColumn when 'cursorline' is set for the cursor line.
 							*hl-MatchParen*
 MatchParen	The character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -997,6 +997,8 @@ EXTERN char e_non_empty_string_required[] INIT(= N_("E1142: Non-empty string req
 
 EXTERN char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));
 
+EXTERN char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group name too long"));
+
 EXTERN char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -997,8 +997,6 @@ EXTERN char e_non_empty_string_required[] INIT(= N_("E1142: Non-empty string req
 
 EXTERN char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));
 
-EXTERN char e_group_name_missing_for_str[] INIT(= N_("E1249: Group name missing for %s"));
-
 EXTERN char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -997,6 +997,8 @@ EXTERN char e_non_empty_string_required[] INIT(= N_("E1142: Non-empty string req
 
 EXTERN char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));
 
+EXTERN char e_group_name_missing_for_str[] INIT(= N_("E1249: Group name missing for %s"));
+
 EXTERN char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -65,6 +65,8 @@ typedef enum {
   HLF_LNA,        // LineNrAbove
   HLF_LNB,        // LineNrBelow
   HLF_CLN,        // current line number when 'cursorline' is set
+  HLF_CLS,        // current line sign column
+  HLF_CLF,        // current line fold
   HLF_R,          // return to continue message and yes/no questions
   HLF_S,          // status lines
   HLF_SNC,        // status lines of not-current windows
@@ -122,6 +124,8 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_LNA] = "LineNrAbove",
   [HLF_LNB] = "LineNrBelow",
   [HLF_CLN] = "CursorLineNr",
+  [HLF_CLS] = "CursorLineSign",
+  [HLF_CLF] = "CursorLineFold",
   [HLF_R] = "Question",
   [HLF_S] = "StatusLine",
   [HLF_SNC] = "StatusLineNC",

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -262,6 +262,7 @@ typedef struct vimoption {
 #define HIGHLIGHT_INIT \
   "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText,d:Directory,e:ErrorMsg," \
   "i:IncSearch,l:Search,m:MoreMsg,M:ModeMsg,n:LineNr,a:LineNrAbove,b:LineNrBelow,N:CursorLineNr," \
+  "G:CursorLineSign,O:CursorLineFold" \
   "r:Question,s:StatusLine,S:StatusLineNC,c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg," \
   "W:WildMenu,f:Folded,F:FoldColumn,A:DiffAdd,C:DiffChange,D:DiffDelete,T:DiffText,>:SignColumn," \
   "-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,x:PmenuSbar," \

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -1148,15 +1148,6 @@ linenr_T sign_jump(int sign_id, char_u *sign_group, buf_T *buf)
   return lnum;
 }
 
-static int check_empty_group(size_t len, char *name)
-{
-  if (len == 0) {
-    semsg(_(e_group_name_missing_for_str), name);
-    return FAIL;
-  }
-  return OK;
-}
-
 /// ":sign define {name} ..." command
 static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
 {
@@ -1169,9 +1160,6 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
   char_u *culhl = NULL;
   char_u *numhl = NULL;
   int failed = false;
-  sign_T *sp_prev;
-
-  bool exists = sign_find(sign_name, &sp_prev) != NULL;
 
   // set values for a defined sign.
   for (;;) {
@@ -1188,31 +1176,15 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
       text = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "linehl=", 7) == 0) {
       arg += 7;
-      if (!exists && check_empty_group(p - arg, "linehl") == FAIL) {
-        failed = true;
-        break;
-      }
       linehl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "texthl=", 7) == 0) {
       arg += 7;
-      if (!exists && check_empty_group(p - arg, "texthl") == FAIL) {
-        failed = true;
-        break;
-      }
       texthl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "culhl=", 6) == 0) {
       arg += 6;
-      if (!exists && check_empty_group(p - arg, "culhl") == FAIL) {
-        failed = true;
-        break;
-      }
       culhl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "numhl=", 6) == 0) {
       arg += 6;
-      if (!exists && check_empty_group(p - arg, "numhl") == FAIL) {
-        failed = true;
-        break;
-      }
       numhl = vim_strnsave(arg, (size_t)(p - arg));
     } else {
       semsg(_(e_invarg2), arg);

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -1132,6 +1132,15 @@ linenr_T sign_jump(int sign_id, char_u *sign_group, buf_T *buf)
   return lnum;
 }
 
+static int check_empty_group(size_t len, char *name)
+{
+  if (len == 0) {
+    semsg(_(e_group_name_missing_for_str), name);
+    return FAIL;
+  }
+  return OK;
+}
+
 /// ":sign define {name} ..." command
 static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
 {
@@ -1160,15 +1169,31 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
       text = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "linehl=", 7) == 0) {
       arg += 7;
+      if (check_empty_group(p - arg, "linehl") == FAIL) {
+        failed = true;
+        break;
+      }
       linehl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "texthl=", 7) == 0) {
       arg += 7;
+      if (check_empty_group(p - arg, "texthl") == FAIL) {
+        failed = true;
+        break;
+      }
       texthl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "culhl=", 6) == 0) {
       arg += 6;
+      if (check_empty_group(p - arg, "culhl") == FAIL) {
+        failed = true;
+        break;
+      }
       culhl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "numhl=", 6) == 0) {
       arg += 6;
+      if (check_empty_group(p - arg, "numhl") == FAIL) {
+        failed = true;
+        break;
+      }
       numhl = vim_strnsave(arg, (size_t)(p - arg));
     } else {
       semsg(_(e_invarg2), arg);

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -943,19 +943,35 @@ int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_u *text
   }
 
   if (linehl != NULL) {
-    sp->sn_line_hl = syn_check_group((char *)linehl, (int)STRLEN(linehl));
+    if (*linehl == NUL) {
+      sp->sn_line_hl = 0;
+    } else {
+      sp->sn_line_hl = syn_check_group((char *)linehl, (int)STRLEN(linehl));
+    }
   }
 
   if (texthl != NULL) {
-    sp->sn_text_hl = syn_check_group((char *)texthl, (int)STRLEN(texthl));
+    if (*texthl == NUL) {
+      sp->sn_text_hl = 0;
+    } else {
+      sp->sn_text_hl = syn_check_group((char *)texthl, (int)STRLEN(texthl));
+    }
   }
 
   if (culhl != NULL) {
-    sp->sn_cul_hl = syn_check_group((char *)culhl, (int)STRLEN(culhl));
+    if (*culhl == NUL) {
+      sp->sn_cul_hl = 0;
+    } else {
+      sp->sn_cul_hl = syn_check_group((char *)culhl, (int)STRLEN(culhl));
+    }
   }
 
   if (numhl != NULL) {
-    sp->sn_num_hl = syn_check_group(numhl, (int)STRLEN(numhl));
+    if (*numhl == NUL) {
+      sp->sn_num_hl = 0;
+    } else {
+      sp->sn_num_hl = syn_check_group(numhl, (int)STRLEN(numhl));
+    }
   }
 
   return OK;
@@ -1153,6 +1169,9 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
   char_u *culhl = NULL;
   char_u *numhl = NULL;
   int failed = false;
+  sign_T *sp_prev;
+
+  bool exists = sign_find(sign_name, &sp_prev) != NULL;
 
   // set values for a defined sign.
   for (;;) {
@@ -1169,28 +1188,28 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
       text = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "linehl=", 7) == 0) {
       arg += 7;
-      if (check_empty_group(p - arg, "linehl") == FAIL) {
+      if (!exists && check_empty_group(p - arg, "linehl") == FAIL) {
         failed = true;
         break;
       }
       linehl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "texthl=", 7) == 0) {
       arg += 7;
-      if (check_empty_group(p - arg, "texthl") == FAIL) {
+      if (!exists && check_empty_group(p - arg, "texthl") == FAIL) {
         failed = true;
         break;
       }
       texthl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "culhl=", 6) == 0) {
       arg += 6;
-      if (check_empty_group(p - arg, "culhl") == FAIL) {
+      if (!exists && check_empty_group(p - arg, "culhl") == FAIL) {
         failed = true;
         break;
       }
       culhl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "numhl=", 6) == 0) {
       arg += 6;
-      if (check_empty_group(p - arg, "numhl") == FAIL) {
+      if (!exists && check_empty_group(p - arg, "numhl") == FAIL) {
         failed = true;
         break;
       }

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -31,6 +31,7 @@ struct sign {
   char_u *sn_text;       // text used instead of pixmap
   int sn_line_hl;     // highlight ID for line
   int sn_text_hl;     // highlight ID for text
+  int sn_cul_hl;      // highlight ID for text on current line when 'cursorline' is set
   int sn_num_hl;      // highlight ID for line number
 };
 
@@ -499,6 +500,9 @@ int buf_get_signattrs(buf_T *buf, linenr_T lnum, sign_attrs_T sattrs[])
         if (sp->sn_line_hl != 0) {
           sattr.sat_linehl = syn_id2attr(sp->sn_line_hl);
         }
+        if (sp->sn_cul_hl != 0) {
+          sattr.sat_culhl = syn_id2attr(sp->sn_cul_hl);
+        }
         if (sp->sn_num_hl != 0) {
           sattr.sat_numhl = syn_id2attr(sp->sn_num_hl);
         }
@@ -901,7 +905,7 @@ static int sign_define_init_text(sign_T *sp, char_u *text)
 
 /// Define a new sign or update an existing sign
 int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_u *text, char_u *texthl,
-                        char *numhl)
+                        char_u *culhl, char *numhl)
 {
   sign_T *sp_prev;
   sign_T *sp;
@@ -944,6 +948,10 @@ int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_u *text
 
   if (texthl != NULL) {
     sp->sn_text_hl = syn_check_group((char *)texthl, (int)STRLEN(texthl));
+  }
+
+  if (culhl != NULL) {
+    sp->sn_cul_hl = syn_check_group((char *)culhl, (int)STRLEN(culhl));
   }
 
   if (numhl != NULL) {
@@ -1133,6 +1141,7 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
   char_u *text = NULL;
   char_u *linehl = NULL;
   char_u *texthl = NULL;
+  char_u *culhl = NULL;
   char_u *numhl = NULL;
   int failed = false;
 
@@ -1155,6 +1164,9 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
     } else if (STRNCMP(arg, "texthl=", 7) == 0) {
       arg += 7;
       texthl = vim_strnsave(arg, (size_t)(p - arg));
+    } else if (STRNCMP(arg, "culhl=", 6) == 0) {
+      arg += 6;
+      culhl = vim_strnsave(arg, (size_t)(p - arg));
     } else if (STRNCMP(arg, "numhl=", 6) == 0) {
       arg += 6;
       numhl = vim_strnsave(arg, (size_t)(p - arg));
@@ -1166,13 +1178,14 @@ static void sign_define_cmd(char_u *sign_name, char_u *cmdline)
   }
 
   if (!failed) {
-    sign_define_by_name(sign_name, icon, linehl, text, texthl, (char *)numhl);
+    sign_define_by_name(sign_name, icon, linehl, text, texthl, culhl, (char *)numhl);
   }
 
   xfree(icon);
   xfree(text);
   xfree(linehl);
   xfree(texthl);
+  xfree(culhl);
   xfree(numhl);
 }
 
@@ -1481,6 +1494,13 @@ static void sign_getinfo(sign_T *sp, dict_T *retdict)
     }
     tv_dict_add_str(retdict, S_LEN("texthl"), (char *)p);
   }
+  if (sp->sn_cul_hl > 0) {
+    p = get_highlight_name_ext(NULL, sp->sn_cul_hl - 1, false);
+    if (p == NULL) {
+      p = "NONE";
+    }
+    tv_dict_add_str(retdict, S_LEN("culhl"), (char *)p);
+  }
   if (sp->sn_num_hl > 0) {
     p = get_highlight_name_ext(NULL, sp->sn_num_hl - 1, false);
     if (p == NULL) {
@@ -1603,6 +1623,16 @@ static void sign_list_defined(sign_T *sp)
     msg_puts(" texthl=");
     const char *const p = get_highlight_name_ext(NULL,
                                                  sp->sn_text_hl - 1, false);
+    if (p == NULL) {
+      msg_puts("NONE");
+    } else {
+      msg_puts(p);
+    }
+  }
+  if (sp->sn_cul_hl > 0) {
+    msg_puts(" culhl=");
+    const char *const p = get_highlight_name_ext(NULL,
+                                                 sp->sn_cul_hl - 1, false);
     if (p == NULL) {
       msg_puts("NONE");
     } else {
@@ -1847,6 +1877,7 @@ int sign_define_from_dict(const char *name_arg, dict_T *dict)
   char *linehl = NULL;
   char *text = NULL;
   char *texthl = NULL;
+  char *culhl = NULL;
   char *numhl = NULL;
   int retval = -1;
 
@@ -1866,11 +1897,12 @@ int sign_define_from_dict(const char *name_arg, dict_T *dict)
     linehl = tv_dict_get_string(dict, "linehl", true);
     text   = tv_dict_get_string(dict, "text", true);
     texthl = tv_dict_get_string(dict, "texthl", true);
+    culhl  = tv_dict_get_string(dict, "culhl", true);
     numhl  = tv_dict_get_string(dict, "numhl", true);
   }
 
   if (sign_define_by_name((char_u *)name, (char_u *)icon, (char_u *)linehl,
-                          (char_u *)text, (char_u *)texthl, numhl)
+                          (char_u *)text, (char_u *)texthl, (char_u *)culhl, numhl)
       == OK) {
     retval = 0;
   }
@@ -1881,6 +1913,7 @@ cleanup:
   xfree(linehl);
   xfree(text);
   xfree(texthl);
+  xfree(culhl);
   xfree(numhl);
 
   return retval;

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -38,6 +38,7 @@ typedef struct sign_attrs_S {
   char_u *sat_text;
   int sat_texthl;
   int sat_linehl;
+  int sat_culhl;
   int sat_numhl;
 } sign_attrs_T;
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6175,6 +6175,8 @@ static const char *highlight_init_both[] = {
   "default link LineNrAbove LineNr",
   "default link LineNrBelow LineNr",
   "default link QuickFixLine Search",
+  "default link CursorLineSign SignColumn",
+  "default link CursorLineFold FoldColumn",
   "default link Substitute Search",
   "default link Whitespace NonText",
   "default link MsgSeparator StatusLine",

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -115,6 +115,8 @@ static int include_none = 0;    // when 1 include "nvim/None"
 static int include_default = 0;  // when 1 include "nvim/default"
 static int include_link = 0;    // when 2 include "nvim/link" and "clear"
 
+#define MAX_SYN_NAME 200
+
 /// The "term", "cterm" and "gui" arguments can be any combination of the
 /// following names, separated by commas (but no spaces!).
 static char *(hl_name_table[]) =
@@ -7625,10 +7627,9 @@ int syn_name2id(const char *name)
 int syn_name2id_len(const char_u *name, size_t len)
   FUNC_ATTR_NONNULL_ALL
 {
-  char name_u[201];
+  char name_u[MAX_SYN_NAME + 1];
 
-  if (len == 0 || len > 200) {
-    // ID names over 200 chars don't deserve to be found!
+  if (len == 0 || len > MAX_SYN_NAME) {
     return 0;
   }
 
@@ -7686,6 +7687,10 @@ char_u *syn_id2name(int id)
 /// @return 0 for failure else the id of the group
 int syn_check_group(const char *name, int len)
 {
+  if (len > MAX_SYN_NAME) {
+    emsg(_(e_highlight_group_name_too_long));
+    return 0;
+  }
   int id = syn_name2id_len((char_u *)name, len);
   if (id == 0) {  // doesn't exist yet
     return syn_add_group(vim_strnsave((char_u *)name, len));

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -661,6 +661,13 @@ function Test_no_space_before_xxx()
   let &columns = l:org_columns
 endfunction
 
+" Test for :highlight command errors
+func Test_highlight_cmd_errors()
+  if has('gui_running') || has('nvim')
+    call assert_fails('hi ' .. repeat('a', 201) .. ' ctermfg=black', 'E1249:')
+  endif
+endfunc
+
 " Test for using RGB color values in a highlight group
 func Test_xxlast_highlight_RGB_color()
   CheckCanRunGui

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -15,13 +15,13 @@ func Test_sign()
   " the icon name when listing signs.
   sign define Sign1 text=x
 
-  call Sign_command_ignore_error('sign define Sign2 text=xy texthl=Title linehl=Error icon=../../pixmaps/stock_vim_find_help.png')
+  call Sign_command_ignore_error('sign define Sign2 text=xy texthl=Title linehl=Error culhl=Search icon=../../pixmaps/stock_vim_find_help.png')
 
   " Test listing signs.
   let a=execute('sign list')
   call assert_match('^\nsign Sign1 text=x \nsign Sign2 ' .
 	      \ 'icon=../../pixmaps/stock_vim_find_help.png .*text=xy ' .
-	      \ 'linehl=Error texthl=Title$', a)
+	      \ 'linehl=Error texthl=Title culhl=Search$', a)
 
   let a=execute('sign list Sign1')
   call assert_equal("\nsign Sign1 text=x ", a)
@@ -392,19 +392,21 @@ func Test_sign_funcs()
   call sign_undefine()
 
   " Tests for sign_define()
-  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
+  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error',
+              \ 'culhl': 'Visual'}
   call assert_equal(0, "sign1"->sign_define(attr))
   call assert_equal([{'name' : 'sign1', 'texthl' : 'Error',
-	      \ 'linehl' : 'Search', 'text' : '=>'}], sign_getdefined())
+	      \ 'linehl' : 'Search', 'culhl': 'Visual', 'text' : '=>'}],
+              \ sign_getdefined())
 
   " Define a new sign without attributes and then update it
   call sign_define("sign2")
   let attr = {'text' : '!!', 'linehl' : 'DiffAdd', 'texthl' : 'DiffChange',
-	      \ 'icon' : 'sign2.ico'}
+	      \ 'culhl': 'DiffDelete', 'icon' : 'sign2.ico'}
   call Sign_define_ignore_error("sign2", attr)
   call assert_equal([{'name' : 'sign2', 'texthl' : 'DiffChange',
-	      \ 'linehl' : 'DiffAdd', 'text' : '!!', 'icon' : 'sign2.ico'}],
-	      \ "sign2"->sign_getdefined())
+	      \ 'linehl' : 'DiffAdd', 'culhl' : 'DiffDelete', 'text' : '!!',
+              \ 'icon' : 'sign2.ico'}], "sign2"->sign_getdefined())
 
   " Test for a sign name with digits
   call assert_equal(0, sign_define(0002, {'linehl' : 'StatusLine'}))

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -126,9 +126,34 @@ func Test_sign()
   " call assert_fails("sign define Sign4 text= linehl=Comment", 'E239:')
   call assert_fails("sign define Sign4 text=\\ ab  linehl=Comment", 'E239:')
 
-  call assert_fails("sign define Sign4 linehl=", 'E1249: Group name missing for linehl')
-  call assert_fails("sign define Sign4 culhl=", 'E1249: Group name missing for culhl')
-  call assert_fails("sign define Sign4 texthl=", 'E1249: Group name missing for texthl')
+  " an empty highlight argument for a new sign is an error
+  call assert_fails("sign define SignX linehl=", 'E1249: Group name missing for linehl')
+  call assert_fails("sign define SignX culhl=", 'E1249: Group name missing for culhl')
+  call assert_fails("sign define SignX texthl=", 'E1249: Group name missing for texthl')
+
+  " an empty highlight argument for an existing sign clears it
+  sign define SignY texthl=TextHl culhl=CulHl linehl=LineHl
+  let sl = sign_getdefined('SignY')[0]
+  call assert_equal('TextHl', sl.texthl)
+  call assert_equal('CulHl', sl.culhl)
+  call assert_equal('LineHl', sl.linehl)
+
+  sign define SignY texthl= culhl=CulHl linehl=LineHl
+  let sl = sign_getdefined('SignY')[0]
+  call assert_false(has_key(sl, 'texthl'))
+  call assert_equal('CulHl', sl.culhl)
+  call assert_equal('LineHl', sl.linehl)
+
+  sign define SignY linehl=
+  let sl = sign_getdefined('SignY')[0]
+  call assert_false(has_key(sl, 'linehl'))
+  call assert_equal('CulHl', sl.culhl)
+
+  sign define SignY culhl=
+  let sl = sign_getdefined('SignY')[0]
+  call assert_false(has_key(sl, 'culhl'))
+
+  sign undefine SignY
 
   " define sign with whitespace
   sign define Sign4 text=\ X linehl=Comment

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -126,6 +126,10 @@ func Test_sign()
   " call assert_fails("sign define Sign4 text= linehl=Comment", 'E239:')
   call assert_fails("sign define Sign4 text=\\ ab  linehl=Comment", 'E239:')
 
+  call assert_fails("sign define Sign4 linehl=", 'E1249: Group name missing for linehl')
+  call assert_fails("sign define Sign4 culhl=", 'E1249: Group name missing for culhl')
+  call assert_fails("sign define Sign4 texthl=", 'E1249: Group name missing for texthl')
+
   " define sign with whitespace
   sign define Sign4 text=\ X linehl=Comment
   sign undefine Sign4

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -126,11 +126,6 @@ func Test_sign()
   " call assert_fails("sign define Sign4 text= linehl=Comment", 'E239:')
   call assert_fails("sign define Sign4 text=\\ ab  linehl=Comment", 'E239:')
 
-  " an empty highlight argument for a new sign is an error
-  call assert_fails("sign define SignX linehl=", 'E1249: Group name missing for linehl')
-  call assert_fails("sign define SignX culhl=", 'E1249: Group name missing for culhl')
-  call assert_fails("sign define SignX texthl=", 'E1249: Group name missing for texthl')
-
   " an empty highlight argument for an existing sign clears it
   sign define SignY texthl=TextHl culhl=CulHl linehl=LineHl
   let sl = sign_getdefined('SignY')[0]

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -212,10 +212,10 @@ describe('ui/cursor', function()
         if m.blinkwait then m.blinkwait = 700 end
       end
       if m.hl_id then
-          m.hl_id = 58
+          m.hl_id = 60
           m.attr = {background = Screen.colors.DarkGray}
       end
-      if m.id_lm then m.id_lm = 59 end
+      if m.id_lm then m.id_lm = 61 end
     end
 
     -- Assert the new expectation.

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -41,6 +41,7 @@ describe("folded lines", function()
         [9] = {bold = true, foreground = Screen.colors.Brown},
         [10] = {background = Screen.colors.LightGrey, underline = true},
         [11] = {bold=true},
+        [12] = {background = Screen.colors.Grey90},
       })
     end)
 
@@ -80,6 +81,117 @@ describe("folded lines", function()
           {1:~                                            }|
           {1:~                                            }|
                                                        |
+        ]])
+      end
+    end)
+
+    it("highlights with CursorLineFold when 'cursorline' is set", function()
+      command("set cursorline foldcolumn=2 foldmethod=marker")
+      command("hi link CursorLineFold Search")
+      insert(content1)
+      feed("zf3j")
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:  }This is a                                  |
+          {7:  }valid English                              |
+          {7:  }sentence composed by                       |
+          {7:  }an exhausted developer                     |
+          {7:  }in his cave.                               |
+          {6:  }{12:^                                           }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+        {7:  }This is a                                  |
+        {7:  }valid English                              |
+        {7:  }sentence composed by                       |
+        {7:  }an exhausted developer                     |
+        {7:  }in his cave.                               |
+        {6:  }{12:^                                           }|
+        {1:~                                            }|
+                                                     |
+        ]])
+      end
+      feed("k")
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:  }This is a                                  |
+          {7:  }valid English                              |
+          {7:  }sentence composed by                       |
+          {7:  }an exhausted developer                     |
+          {6:  }{12:^in his cave.                               }|
+          {7:  }                                           |
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+        {7:  }This is a                                  |
+        {7:  }valid English                              |
+        {7:  }sentence composed by                       |
+        {7:  }an exhausted developer                     |
+        {6:  }{12:^in his cave.                               }|
+        {7:  }                                           |
+        {1:~                                            }|
+                                                     |
+        ]])
+      end
+      command("set cursorlineopt=line")
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {7:  }This is a                                  |
+          {7:  }valid English                              |
+          {7:  }sentence composed by                       |
+          {7:  }an exhausted developer                     |
+          {7:  }{12:^in his cave.                               }|
+          {7:  }                                           |
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+        {7:  }This is a                                  |
+        {7:  }valid English                              |
+        {7:  }sentence composed by                       |
+        {7:  }an exhausted developer                     |
+        {7:  }{12:^in his cave.                               }|
+        {7:  }                                           |
+        {1:~                                            }|
+                                                     |
         ]])
       end
     end)

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -157,6 +157,99 @@ describe('Signs', function()
       ]])
     end)
 
+    it('higlights the cursorline sign with culhl', function()
+      feed('ia<cr>b<cr>c<esc>')
+      command('sign define piet text=>> texthl=Search culhl=ErrorMsg')
+      command('sign place 1 line=1 name=piet buffer=1')
+      command('sign place 2 line=2 name=piet buffer=1')
+      command('sign place 3 line=3 name=piet buffer=1')
+      command('set cursorline')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {1:>>}b                                                  |
+        {8:>>}{3:^c                                                  }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      feed('k')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {8:>>}{3:^b                                                  }|
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set nocursorline')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {1:>>}^b                                                  |
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set cursorline cursorlineopt=line')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {1:>>}{3:^b                                                  }|
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('set cursorlineopt=number')
+      screen:expect([[
+        {1:>>}a                                                  |
+        {8:>>}^b                                                  |
+        {1:>>}c                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+    end)
+
     it('multiple signs #9295', function()
       feed('ia<cr>b<cr>c<cr><esc>')
       command('set number')


### PR DESCRIPTION
#### vim-patch:8.2.3664: cannot adjust sign highlighting for 'cursorline'

Problem:    Cannot adjust sign highlighting for 'cursorline'.
Solution:   Add CursorLineSign and CursorLineFold highlight groups.
            (Gregory Anders, closes vim/vim#9201)
https://github.com/vim/vim/commit/e413ea04b716effb28eb49dbc98ad3f9f761545a


#### vim-patch:8.2.3743: ":sign" can add a highlight group without a name

Problem:    ":sign" can add a highlight group without a name.
Solution:   Give an error if the group name is missing. (closes vim/vim#9280)
https://github.com/vim/vim/commit/5e18ccc60bdddc4aa39ab039f1a7c918f29e67ce


#### vim-patch:8.2.3747: cannot remove highlight from an existing sign

Problem:    Cannot remove highlight from an existing sign. (James McCoy)
Solution:   Only reject empty argument for a new sign.
https://github.com/vim/vim/commit/0bac5fc5e125b7aa0f3b596c9b7f4381279e6688


#### vim-patch:8.2.3748: giving an error for an empty sign argument breaks a plugin

Problem:    Giving an error for an empty sign argument breaks a plugin.
Solution:   Do not give an error.
https://github.com/vim/vim/commit/e5710a02cb78c2a0a868ea55740835c78ddecbb4


#### vim-patch:partial 6304be625ce4

Update runtime files.
https://github.com/vim/vim/commit/6304be625ce44dcfedc6735164d0b853578581c8

Remaining changes left out of 03d250eb4504d5168a754d0f3b7e9992337d60b4

#### vim-patch:8.2.3757: an overlong highlight group name is silently truncated

Problem:    An overlong highlight group name is silently truncated.
Solution:   Give an error if the name is too long. (closes vim/vim#9289)
https://github.com/vim/vim/commit/f7f7aaf8aaad34a38d3f159e031c5bcf3394f8f1

---
Closes #16494