### PR TITLE
fix(api): allow nvim_buf_set_extmark to accept end_row key

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2355,6 +2355,8 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                               • id : id of the extmark to edit.
                               • end_line : ending line of the mark, 0-based
                                 inclusive.
+                              • end_row : alias of "end_line". It is an error
+                                to use both "end_row" and "end_line".
                               • end_col : ending col of the mark, 0-based
                                 exclusive.
                               • hl_group : name of the highlight group used to

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2353,10 +2353,8 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                               |api-indexing|
                     {opts}    Optional parameters.
                               • id : id of the extmark to edit.
-                              • end_line : ending line of the mark, 0-based
+                              • end_row : ending line of the mark, 0-based
                                 inclusive.
-                              • end_row : alias of "end_line". It is an error
-                                to use both "end_row" and "end_line".
                               • end_col : ending col of the mark, 0-based
                                 exclusive.
                               • hl_group : name of the highlight group used to

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -432,6 +432,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   int line2 = -1;
 
+  // For backward compatibility we support "end_line" as an alias for "end_row"
   if (HAS_KEY(opts->end_line)) {
     if (HAS_KEY(opts->end_row)) {
       api_set_error(err, kErrorTypeValidation, "cannot use both end_row and end_line");

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -431,6 +431,11 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   }
 
   int line2 = -1;
+
+  if (HAS_KEY(opts->end_row) && !HAS_KEY(opts->end_line)) {
+    opts->end_line = opts->end_row;
+  }
+
   if (opts->end_line.type == kObjectTypeInteger) {
     Integer val = opts->end_line.data.integer;
     if (val < 0 || val > buf->b_ml.ml_line_count) {

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -339,9 +339,7 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 /// @param col  Column where to place the mark, 0-based. |api-indexing|
 /// @param opts  Optional parameters.
 ///               - id : id of the extmark to edit.
-///               - end_line : ending line of the mark, 0-based inclusive.
-///               - end_row : alias of "end_line". It is an error to use both
-///                           "end_row" and "end_line".
+///               - end_row : ending line of the mark, 0-based inclusive.
 ///               - end_col : ending col of the mark, 0-based exclusive.
 ///               - hl_group : name of the highlight group used to highlight
 ///                   this mark.
@@ -434,24 +432,24 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   int line2 = -1;
 
-  if (HAS_KEY(opts->end_row)) {
-    if (HAS_KEY(opts->end_line)) {
+  if (HAS_KEY(opts->end_line)) {
+    if (HAS_KEY(opts->end_row)) {
       api_set_error(err, kErrorTypeValidation, "cannot use both end_row and end_line");
       goto error;
     }
-    opts->end_line = opts->end_row;
+    opts->end_row = opts->end_line;
   }
 
-  if (opts->end_line.type == kObjectTypeInteger) {
-    Integer val = opts->end_line.data.integer;
+  if (opts->end_row.type == kObjectTypeInteger) {
+    Integer val = opts->end_row.data.integer;
     if (val < 0 || val > buf->b_ml.ml_line_count) {
-      api_set_error(err, kErrorTypeValidation, "end_line value outside range");
+      api_set_error(err, kErrorTypeValidation, "end_row value outside range");
       goto error;
     } else {
       line2 = (int)val;
     }
-  } else if (HAS_KEY(opts->end_line)) {
-    api_set_error(err, kErrorTypeValidation, "end_line is not an integer");
+  } else if (HAS_KEY(opts->end_row)) {
+    api_set_error(err, kErrorTypeValidation, "end_row is not an integer");
     goto error;
   }
 
@@ -582,10 +580,10 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   OPTION_TO_BOOL(right_gravity, right_gravity, true);
 
   // Only error out if they try to set end_right_gravity without
-  // setting end_col or end_line
+  // setting end_col or end_row
   if (line2 == -1 && col2 == -1 && HAS_KEY(opts->end_right_gravity)) {
     api_set_error(err, kErrorTypeValidation,
-                  "cannot set end_right_gravity without setting end_line or end_col");
+                  "cannot set end_right_gravity without setting end_row or end_col");
     goto error;
   }
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -340,6 +340,8 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 /// @param opts  Optional parameters.
 ///               - id : id of the extmark to edit.
 ///               - end_line : ending line of the mark, 0-based inclusive.
+///               - end_row : alias of "end_line". It is an error to use both
+///                           "end_row" and "end_line".
 ///               - end_col : ending col of the mark, 0-based exclusive.
 ///               - hl_group : name of the highlight group used to highlight
 ///                   this mark.

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -432,7 +432,11 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   int line2 = -1;
 
-  if (HAS_KEY(opts->end_row) && !HAS_KEY(opts->end_line)) {
+  if (HAS_KEY(opts->end_row)) {
+    if (HAS_KEY(opts->end_line)) {
+      api_set_error(err, kErrorTypeValidation, "cannot use both end_row and end_line");
+      goto error;
+    }
     opts->end_line = opts->end_row;
   }
 

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -5,8 +5,6 @@ return {
   set_extmark = {
     "id";
     "end_line";
-    -- nvim_buf_get_extmark uses "end_row" rather than "end_line" in its
-    -- details dict, so allow that as an alias
     "end_row";
     "end_col";
     "hl_group";

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -5,6 +5,9 @@ return {
   set_extmark = {
     "id";
     "end_line";
+    -- nvim_buf_get_extmark uses "end_row" rather than "end_line" in its
+    -- details dict, so allow that as an alias
+    "end_row";
     "end_col";
     "hl_group";
     "virt_text";

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -104,10 +104,10 @@ describe('API/extmarks', function()
   it("can end extranges past final newline using end_col = 0", function()
     set_extmark(ns, marks[1], 0, 0, {
       end_col = 0,
-      end_line = 1
+      end_row = 1
     })
     eq("end_col value outside range",
-       pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = 1, end_line = 1 }))
+       pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = 1, end_row = 1 }))
   end)
 
   it('adds, updates  and deletes marks', function()
@@ -1425,10 +1425,10 @@ describe('API/extmarks', function()
         meths.buf_get_extmarks(0, ns, 0, -1, {}))
   end)
 
-  it('can accept "end_row" or "end_line"', function()
+  it('can accept "end_row" or "end_line" #16548', function()
     set_extmark(ns, marks[1], 0, 0, {
       end_col = 0,
-      end_row = 1
+      end_line = 1
     })
     eq({ {1, 0, 0, { end_col = 0, end_row = 1 }} }, get_extmarks(ns, 0, -1, {details=true}))
   end)

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1424,6 +1424,14 @@ describe('API/extmarks', function()
     eq({ {1, 0, 0}, {2, 0, 8} },
         meths.buf_get_extmarks(0, ns, 0, -1, {}))
   end)
+
+  it('can accept "end_row" or "end_line"', function()
+    set_extmark(ns, marks[1], 0, 0, {
+      end_col = 0,
+      end_row = 1
+    })
+    eq({ {1, 0, 0, { end_col = 0, end_row = 1 }} }, get_extmarks(ns, 0, -1, {details=true}))
+  end)
 end)
 
 describe('Extmarks buffer api with many marks', function()


### PR DESCRIPTION
`nvim_buf_get_extmark` uses `end_row` rather than `end_line` in its 'details' dict, which means callers must modify the key names if they want to re-use the information. Allow `nvim_buf_set_extmark` to take `end_row` as an alias to `end_line` to make this more compatible.

See https://github.com/neovim/neovim/pull/15011#discussion_r665336968.

This would allow us to remove the "hack" here: https://github.com/neovim/neovim/blob/0a3826646f9348f9a82b9c8a79efc16dbaf3a21d/runtime/lua/vim/diagnostic.lua#L300-L304
