### PR TITLE
fix(highlight): always update window highlight if highlight changed

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -451,9 +451,11 @@ int update_screen(int type)
   // reset cmdline_row now (may have been changed temporarily)
   compute_cmdrow();
 
+  bool hl_changed = false;
   // Check for changed highlighting
   if (need_highlight_changed) {
     highlight_changed();
+    hl_changed = true;
   }
 
   if (type == CLEAR) {          // first clear screen
@@ -554,7 +556,7 @@ int update_screen(int type)
    * buffer.  Each buffer must only be done once.
    */
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    update_window_hl(wp, type >= NOT_VALID);
+    update_window_hl(wp, type >= NOT_VALID || hl_changed);
 
     buf_T *buf = wp->w_buffer;
     if (buf->b_mod_set) {

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -276,6 +276,24 @@ describe('highlight defaults', function()
     ]], {[0] = {bold=true, foreground=Screen.colors.Blue}})
   end)
 
+  it('linking updates window highlight immediately #16552', function()
+    screen:try_resize(53, 4)
+    screen:expect([[
+      ^                                                     |
+      {0:~                                                    }|
+      {0:~                                                    }|
+                                                           |
+    ]], {[0] = {bold=true, foreground=Screen.colors.Blue}})
+    feed_command("hi NonTextAlt guifg=Red")
+    feed_command("hi! link NonText NonTextAlt")
+    screen:expect([[
+      ^                                                     |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      :hi! link NonText NonTextAlt                         |
+    ]], {[0] = {foreground=Screen.colors.Red}})
+  end)
+
   it('Cursor after `:hi clear|syntax reset` #6508', function()
     command('highlight clear|syntax reset')
     eq('guifg=bg guibg=fg', eval([[matchstr(execute('hi Cursor'), '\v(gui|cterm).*$')]]))


### PR DESCRIPTION
Fix #16552 

Test fails if I revert the change:
```
[  FAILED  ] 1 test, listed below:
[  FAILED  ] test/functional/ui/highlight_spec.lua @ 279: highlight defaults linking updates window highlight immediately #16552
test/functional/ui/highlight_spec.lua:291: Row 2 did not match.
Expected:
  |^                                                     |
  |*{0:~                                                    }|
  |*{0:~                                                    }|
  |:hi! link NonText NonTextAlt                         |
Actual:
  |^                                                     |
  |*{UNEXPECTED foreground = Screen.colors.Blue, bold = true:~                                                    }|
  |*{UNEXPECTED foreground = Screen.colors.Blue, bold = true:~                                                    }|
  |:hi! link NonText NonTextAlt                         |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/highlight_spec.lua:291: in function <test/functional/ui/highlight_spec.lua:279>


 1 FAILED TEST
```