### PR TITLE
fix(screen): do not draw filler lines post eof if already at last row

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1692,7 +1692,7 @@ static void win_update(win_T *wp, Providers *providers)
     if (eof) {  // we hit the end of the file
       wp->w_botline = buf->b_ml.ml_line_count + 1;
       j = win_get_fill(wp, wp->w_botline);
-      if (j > 0 && !wp->w_botfill) {
+      if (j > 0 && !wp->w_botfill && row < wp->w_grid.Rows) {
         // Display filler text below last line. win_line() will check
         // for ml_line_count+1 and only draw filler lines
         foldinfo_T info = FOLDINFO_INIT;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1031,6 +1031,69 @@ if (h->n_buckets < new_n_buckets) { // expand
                                                         |
     ]]}
 
+    screen:try_resize(50, 11)
+    feed('gg')
+    screen:expect{grid=[[
+      ^if (h->n_buckets < new_n_buckets) { // expand     |
+        khkey_t *new_keys = (khkey_t *)krealloc((void *)|
+      h->keys, new_n_buckets * sizeof(khkey_t));        |
+        h->keys = new_keys;                             |
+        if (kh_is_map && val_size) {                    |
+          char *new_vals = krealloc( h->vals_buf, new_n_|
+      buckets * val_size);                              |
+          h->vals_buf = new_vals;                       |
+        }                                               |
+      }                                                 |
+                                                        |
+    ]]}
+
+    feed('G<C-E>')
+    screen:expect{grid=[[
+        khkey_t *new_keys = (khkey_t *)krealloc((void *)|
+      h->keys, new_n_buckets * sizeof(khkey_t));        |
+        h->keys = new_keys;                             |
+        if (kh_is_map && val_size) {                    |
+          char *new_vals = krealloc( h->vals_buf, new_n_|
+      buckets * val_size);                              |
+          h->vals_buf = new_vals;                       |
+        }                                               |
+      ^}                                                 |
+      Grugg                                             |
+                                                        |
+    ]]}
+
+    feed('gg')
+    screen:expect{grid=[[
+      ^if (h->n_buckets < new_n_buckets) { // expand     |
+        khkey_t *new_keys = (khkey_t *)krealloc((void *)|
+      h->keys, new_n_buckets * sizeof(khkey_t));        |
+        h->keys = new_keys;                             |
+        if (kh_is_map && val_size) {                    |
+          char *new_vals = krealloc( h->vals_buf, new_n_|
+      buckets * val_size);                              |
+          h->vals_buf = new_vals;                       |
+        }                                               |
+      }                                                 |
+                                                        |
+    ]]}
+
+    screen:try_resize(50, 12)
+    feed('G')
+    screen:expect{grid=[[
+      if (h->n_buckets < new_n_buckets) { // expand     |
+        khkey_t *new_keys = (khkey_t *)krealloc((void *)|
+      h->keys, new_n_buckets * sizeof(khkey_t));        |
+        h->keys = new_keys;                             |
+        if (kh_is_map && val_size) {                    |
+          char *new_vals = krealloc( h->vals_buf, new_n_|
+      buckets * val_size);                              |
+          h->vals_buf = new_vals;                       |
+        }                                               |
+      ^}                                                 |
+      Grugg                                             |
+                                                        |
+    ]]}
+
     meths.buf_del_extmark(0, ns, id)
     screen:expect{grid=[[
       if (h->n_buckets < new_n_buckets) { // expand     |

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -186,6 +186,19 @@ describe('Diff mode screen', function()
       {7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
       :set diffopt+=internal                  |
     ]])
+
+    screen:try_resize(40, 9)
+    screen:expect([[
+      {1:+ }{5:^+--  4 lines: 1···}{3:│}{1:+ }{5:+--  4 lines: 1··}|
+      {1:  }5                 {3:│}{1:  }5                |
+      {1:  }6                 {3:│}{1:  }6                |
+      {1:  }7                 {3:│}{1:  }7                |
+      {1:  }8                 {3:│}{1:  }8                |
+      {1:  }9                 {3:│}{1:  }9                |
+      {1:  }10                {3:│}{1:  }10               |
+      {7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
+                                              |
+    ]])
   end)
 
   it('Add a line at the end of file 1', function()
@@ -231,6 +244,19 @@ describe('Diff mode screen', function()
       {6:~                   }{3:│}{6:~                  }|
       {7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
       :set diffopt+=internal                  |
+    ]])
+
+    screen:try_resize(40, 9)
+    screen:expect([[
+      {1:+ }{5:^+--  4 lines: 1···}{3:│}{1:+ }{5:+--  4 lines: 1··}|
+      {1:  }5                 {3:│}{1:  }5                |
+      {1:  }6                 {3:│}{1:  }6                |
+      {1:  }7                 {3:│}{1:  }7                |
+      {1:  }8                 {3:│}{1:  }8                |
+      {1:  }9                 {3:│}{1:  }9                |
+      {1:  }10                {3:│}{1:  }10               |
+      {7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
+                                              |
     ]])
   end)
 


### PR DESCRIPTION
Fix #16500 

All three tests fail if I revert the changes:
```
[  FAILED  ] test/functional/ui/diff_spec.lua @ 145: Diff mode screen Add a line at the end of file 2
test/functional/ui/diff_spec.lua:191: Row 7 did not match.
Expected:
  |{1:+ }{5:^+--  4 lines: 1···}{3:│}{1:+ }{5:+--  4 lines: 1··}|
  |{1:  }5                 {3:│}{1:  }5                |
  |{1:  }6                 {3:│}{1:  }6                |
  |{1:  }7                 {3:│}{1:  }7                |
  |{1:  }8                 {3:│}{1:  }8                |
  |{1:  }9                 {3:│}{1:  }9                |
  |*{1:  }10                {3:│}{1:  }10               |
  |{7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
  |                                        |
Actual:
  |{1:+ }{5:^+--  4 lines: 1···}{3:│}{1:+ }{5:+--  4 lines: 1··}|
  |{1:  }5                 {3:│}{1:  }5                |
  |{1:  }6                 {3:│}{1:  }6                |
  |{1:  }7                 {3:│}{1:  }7                |
  |{1:  }8                 {3:│}{1:  }8                |
  |{1:  }9                 {3:│}{1:  }9                |
  |*{1:  }{2:------------------}{3:│}{1:  }10               |
  |{7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
  |                                        |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/diff_spec.lua:191: in function <test/functional/ui/diff_spec.lua:145>

[  FAILED  ] test/functional/ui/diff_spec.lua @ 204: Diff mode screen Add a line at the end of file 1
test/functional/ui/diff_spec.lua:250: Row 7 did not match.
Expected:
  |{1:+ }{5:^+--  4 lines: 1···}{3:│}{1:+ }{5:+--  4 lines: 1··}|
  |{1:  }5                 {3:│}{1:  }5                |
  |{1:  }6                 {3:│}{1:  }6                |
  |{1:  }7                 {3:│}{1:  }7                |
  |{1:  }8                 {3:│}{1:  }8                |
  |{1:  }9                 {3:│}{1:  }9                |
  |*{1:  }10                {3:│}{1:  }10               |
  |{7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
  |                                        |
Actual:
  |{1:+ }{5:^+--  4 lines: 1···}{3:│}{1:+ }{5:+--  4 lines: 1··}|
  |{1:  }5                 {3:│}{1:  }5                |
  |{1:  }6                 {3:│}{1:  }6                |
  |{1:  }7                 {3:│}{1:  }7                |
  |{1:  }8                 {3:│}{1:  }8                |
  |{1:  }9                 {3:│}{1:  }9                |
  |*{1:  }10                {3:│}{1:  }{2:-----------------}|
  |{7:<onal-diff-screen-1  }{3:<l-diff-screen-1.2 }|
  |                                        |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/diff_spec.lua:250: in function <test/functional/ui/diff_spec.lua:204>

[  FAILED  ] test/functional/ui/decorations_spec.lua @ 995: decorations: virtual lines works with text at the end of the buffer
test/functional/ui/decorations_spec.lua:1036: Row 10 did not match.
Expected:
  |^if (h->n_buckets < new_n_buckets) { // expand     |
  |  khkey_t *new_keys = (khkey_t *)krealloc((void *)|
  |h->keys, new_n_buckets * sizeof(khkey_t));        |
  |  h->keys = new_keys;                             |
  |  if (kh_is_map && val_size) {                    |
  |    char *new_vals = krealloc( h->vals_buf, new_n_|
  |buckets * val_size);                              |
  |    h->vals_buf = new_vals;                       |
  |  }                                               |
  |*}                                                 |
  |                                                  |
Actual:
  |^if (h->n_buckets < new_n_buckets) { // expand     |
  |  khkey_t *new_keys = (khkey_t *)krealloc((void *)|
  |h->keys, new_n_buckets * sizeof(khkey_t));        |
  |  h->keys = new_keys;                             |
  |  if (kh_is_map && val_size) {                    |
  |    char *new_vals = krealloc( h->vals_buf, new_n_|
  |buckets * val_size);                              |
  |    h->vals_buf = new_vals;                       |
  |  }                                               |
  |*Grugg                                             |
  |                                                  |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/decorations_spec.lua:1036: in function <test/functional/ui/decorations_spec.lua:995>

```