### PR TITLE
runtime: fix uri_to_fname on WSL

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -110,7 +110,13 @@ local function uri_to_fname(uri)
   -- TODO improve this.
   if is_windows_file_uri(uri) then
     uri = uri:gsub('^file:/+', '')
-    uri = uri:gsub('/', '\\')
+    if vim.fn.has('wsl') == 1 then
+      uri = uri:gsub('^([a-zA-Z]):', function(match)
+        return '/mnt/'.. match:lower()
+      end)
+    else
+      uri = uri:gsub('/', '\\')
+    end
   else
     uri = uri:gsub('^file:/+', '/')
   end


### PR DESCRIPTION
when using cland.exe as LSP for VC++ projects with compile_commands.json
generated via MSBuild from inside WSL2 go to definition was failing when
trying to find requested symbol in file using windows path

Issue:
![wsl_gotodefintion_issue](https://user-images.githubusercontent.com/5606370/145079415-985e7447-a97e-44ae-bf4d-7d8c1374c76d.gif)

Fixed:
![wsl_gotodefintion_fixed](https://user-images.githubusercontent.com/5606370/145079492-a3ddc9a0-fa8d-4655-8dc1-d2240d160c4b.gif)


