### PR TITLE
test(helpers): optimize read_file_list

### DIFF
--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -741,9 +741,20 @@ function module.read_file_list(filename, start)
   if not file then
     return nil
   end
+
+  -- There is no need to read more than the last 2MB of the log file, so seek
+  -- to that.
+  local file_size = file:seek("end")
+  local offset = file_size - 2000000
+  if offset < 0 then
+    offset = 0
+  end
+  file:seek("set", offset)
+
   local lines = {}
   local i = 1
-  for line in file:lines() do
+  local line = file:read("*l")
+  while line ~= nil do
     if i >= start then
       table.insert(lines, line)
       if #lines > maxlines then
@@ -751,6 +762,7 @@ function module.read_file_list(filename, start)
       end
     end
     i = i + 1
+    line = file:read("*l")
   end
   file:close()
   return lines


### PR DESCRIPTION
Read_file_list is used to read back data from the nvim log file as the
testsuite executes. However, the nvim log file can get really big
(each full run of the testsuite appends roughly 150MB of data to this
file). Reading each line of this file can thus be extremely slow, and so
are the repeated table.insert/table.removes that are done for each line.

A solution to this issue is to attempt to only read the end
of the file.

This results in a sizeable improvement in testsuite run times in some
cases, e.g. on my computer:

Without this commit:
real	20m0.431s
user	17m11.163s
sys	1m59.422s

With this commit:
real	4m25.356s
user	1m41.673s
sys	1m31.253s
