### PR TITLE
Change checkhealth help link for ambiguous venv

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -523,7 +523,7 @@ function! s:check_virtualenv() abort
         let hint = '$PATH ambiguities in subshells typically are '
           \.'caused by your shell config overriding the $PATH previously set by the '
           \.'virtualenv. Either prevent them from doing so, or use this workaround: '
-          \.'https://vi.stackexchange.com/a/7654'
+          \.'https://vi.stackexchange.com/a/34996'
         let hints[hint] = v:true
       endif
     endfor


### PR DESCRIPTION
When checkhealth detects an ambiguous virtualenv, usually when running
neovim with pyenv or virtualenvwrapper virtualenvs it show a link on its
hints redirecting to an answer on stackexchange related to that problem.
Although the marked answer works solving `!python`, it does not entirely
fix the venv problem, as checkhealth still detects the ambiguity and tools
like pyright language server will still run with the wrong python.

Because of that I posted a new answer (https://vi.stackexchange.com/a/34996),
adapted from the original, to fix not only the `!python` problem for vim and
neovim, but also fixing neovim venv, lsp problems. The solution is well
detailed and I included a bash, zsh and also fish versions.