### PR TITLE
do not leave Terminal mode after entering to it using a mouse

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1296,6 +1296,12 @@ static bool send_mouse_event(Terminal *term, int c)
     return mouse_win == curwin;
   }
 
+  // ignore left release action if it was not proccessed above
+  // to prevent leaving Terminal mode after entering to it using a mouse
+  if (c == K_LEFTRELEASE && mouse_win->w_buffer->terminal == term) {
+    return false;
+  }
+
 end:
   ins_char_typebuf(c);
   return true;

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -45,6 +45,12 @@ describe(':terminal mouse', function()
       eq('nt', eval('mode(1)'))
     end)
 
+    it('does not leave terminal mode on left-release', function()
+      if helpers.pending_win32(pending) then return end
+      feed('<LeftRelease>')
+      eq('t', eval('mode(1)'))
+    end)
+
     describe('with mouse events enabled by the program', function()
       before_each(function()
         thelpers.enable_mouse()


### PR DESCRIPTION
there is a useful helper `au WinEnter term://* startinsert` for Terminal mode activation but it does not work when the window is entered using a mouse.

after [entering using a mouse](https://github.com/neovim/neovim/blob/f37c5f180a12d0f3a36a8f10ca6719c6f1eb0d49/src/nvim/mouse.c#L213-L215) the terminal still receives `left release` mouse action and the default behavior for the "unprocessed" action is leaving Terminal mode([1](https://github.com/neovim/neovim/blob/f37c5f180a12d0f3a36a8f10ca6719c6f1eb0d49/src/nvim/terminal.c#L1230-L1231), [2](https://github.com/neovim/neovim/blob/f37c5f180a12d0f3a36a8f10ca6719c6f1eb0d49/src/nvim/terminal.c#L1298-L1301)).

so the fix is about ignoring "left release" in such situation. it feels a little hacky, not sure if we can somehow to "eat" the left release action and do not propagate it in `mouse.c` on window activation.

closes #9483
closes #8691

