### PR TITLE
fix(tui): end streamed paste correctly when key buffer is empty

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -114,6 +114,12 @@ static void tinput_done_event(void **argv)
 static void tinput_wait_enqueue(void **argv)
 {
   TermInput *input = argv[0];
+  if (rbuffer_size(input->key_buffer) == 0 && input->paste == 3) {
+    const String keys = { .data = "", .size = 0 };
+    String copy = copy_string(keys);
+    multiqueue_put(main_loop.events, tinput_paste_event, 3,
+                   copy.data, copy.size, (intptr_t)input->paste);
+  }
   RBUFFER_UNTIL_EMPTY(input->key_buffer, buf, len) {
     const String keys = { .data = buf, .size = len };
     if (input->paste) {


### PR DESCRIPTION
Tests fails if the changes are reverted:
```
[  ERROR   ] test/functional/terminal/tui_spec.lua @ 768: TUI paste: streamed paste with isolated "stop paste" code
test/helpers.lua:73: Expected objects to be the same.
Passed in:
(table: 0x7f7ce69c1d78) {
  [1] = 1
  [2] = 2 }
Expected:
(table: 0x7f7ce69c1e10) {
  [1] = 1
  [2] = 2
 *[3] = 3 }

stack traceback:
	test/helpers.lua:73: in function 'eq'
	test/functional/terminal/tui_spec.lua:803: in function <test/functional/terminal/tui_spec.lua:768>
```