### PR TITLE
refactor: replace deprecated lua functions with their new versions

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -379,7 +379,7 @@ local make_call_hierarchy_handler = function(direction)
         })
       end
     end
-    vim.fn.setqflist({}, ' ', {title = 'LSP call hierarchy', items = util.locations_to_items(result))
+    vim.fn.setqflist({}, ' ', {title = 'LSP call hierarchy', items = items)
     api.nvim_command("copen")
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -286,7 +286,7 @@ local function location_handler(_, result, ctx, _)
     util.jump_to_location(result[1])
 
     if #result > 1 then
-      diag.setqflist(util.locations_to_items(result))
+      vim.fn.setqflist({}, ' ', {title = 'LSP locations', items = util.locations_to_items(result))
       api.nvim_command("copen")
     end
   else
@@ -380,7 +380,7 @@ local make_call_hierarchy_handler = function(direction)
         })
       end
     end
-    diag.setqflist(items)
+    vim.fn.setqflist({}, ' ', {title = 'LSP call hierarchy', items = util.locations_to_items(result))
     api.nvim_command("copen")
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -1,7 +1,6 @@
 local log = require 'vim.lsp.log'
 local protocol = require 'vim.lsp.protocol'
 local util = require 'vim.lsp.util'
-local diag = require 'vim.diagnostic'
 local vim = vim
 local api = vim.api
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -1,6 +1,7 @@
 local log = require 'vim.lsp.log'
 local protocol = require 'vim.lsp.protocol'
 local util = require 'vim.lsp.util'
+local diag = require 'vim.diagnostic'
 local vim = vim
 local api = vim.api
 
@@ -285,7 +286,7 @@ local function location_handler(_, result, ctx, _)
     util.jump_to_location(result[1])
 
     if #result > 1 then
-      util.set_qflist(util.locations_to_items(result))
+      diag.setqflist(util.locations_to_items(result))
       api.nvim_command("copen")
     end
   else
@@ -379,7 +380,7 @@ local make_call_hierarchy_handler = function(direction)
         })
       end
     end
-    util.set_qflist(items)
+    diag.setqflist(items)
     api.nvim_command("copen")
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -285,7 +285,7 @@ local function location_handler(_, result, ctx, _)
     util.jump_to_location(result[1])
 
     if #result > 1 then
-      vim.fn.setqflist({}, ' ', {title = 'LSP locations', items = util.locations_to_items(result))
+      vim.fn.setqflist({}, ' ', {title = 'LSP locations', items = util.locations_to_items(result)})
       api.nvim_command("copen")
     end
   else
@@ -379,7 +379,7 @@ local make_call_hierarchy_handler = function(direction)
         })
       end
     end
-    vim.fn.setqflist({}, ' ', {title = 'LSP call hierarchy', items = items)
+    vim.fn.setqflist({}, ' ', {title = 'LSP call hierarchy', items = items})
     api.nvim_command("copen")
   end
 end


### PR DESCRIPTION
Calling vim.lsp.buf.definition() sometimes gives a deprecation warning.
This will likely solve that.
