### PR TITLE
feat(terminal): do not leave Terminal mode on mouse clicks

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1296,6 +1296,12 @@ static bool send_mouse_event(Terminal *term, int c)
     return mouse_win == curwin;
   }
 
+  // do not leave terminal mode on mouse clicks
+  if ((mouse_win->w_buffer->terminal == term)
+      && (c == K_LEFTMOUSE || c == K_LEFTRELEASE || c == K_RIGHTMOUSE || c == K_RIGHTRELEASE)) {
+    return false;
+  }
+
 end:
   ins_char_typebuf(c);
   return true;

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -45,6 +45,18 @@ describe(':terminal mouse', function()
       eq('nt', eval('mode(1)'))
     end)
 
+    it('will not exit the terminal mode on mouse clicks', function()
+      if helpers.pending_win32(pending) then return end
+      feed('<LeftMouse>')
+      eq('t', eval('mode(1)'))
+      feed('<LeftRelease>')
+      eq('t', eval('mode(1)'))
+      feed('<RightMouse>')
+      eq('t', eval('mode(1)'))
+      feed('<RightRelease>')
+      eq('t', eval('mode(1)'))
+    end)
+
     describe('with mouse events enabled by the program', function()
       before_each(function()
         thelpers.enable_mouse()


### PR DESCRIPTION
the alternative solution for the issues below (supersedes #16596)
proposed in [this comment](https://github.com/neovim/neovim/issues/9483#issuecomment-461996053) by @justinmk 
> Mouse-click in a normal buffer places the cursor without leaving insert-mode. I don't see why clicking in a terminal-buffer in terminal-mode (insert-mode) should exit terminal-mode. 

but this one is more like a "feature" but not a "fix" :) the behavior is similar to Vim now(though, the terminal scrolling still leads to exit from Terminal mode).

closes #9483
closes #8691