### PR TITLE
docs(diagnostic): add doc for virtual_text `spacing` and `prefix`

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -341,7 +341,10 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      |diagnostic-severity|
 
                                  • virtual_text: (default true) Use virtual
-                                   text for diagnostics. Options:
+                                   text for diagnostics. If multiple
+                                   diagnostics are set for a namespace, one
+                                   prefix per diagnostic + the last diagnostic
+                                   message are shown. Options:
                                    • severity: Only show virtual text for
                                      diagnostics matching the given severity
                                      |diagnostic-severity|

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -348,6 +348,11 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                    • source: (string) Include the diagnostic
                                      source in virtual text. One of "always"
                                      or "if_many".
+                                   • spacing: (number) Amount of empty spaces
+                                     inserted at the beginning of the virtual
+                                     text.
+                                   • prefix: (string) Prepend diagnostic
+                                     message with prefix.
                                    • format: (function) A function that takes
                                      a diagnostic as input and returns a
                                      string. The return value is the text used

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -560,7 +560,10 @@ end
 ---       - underline: (default true) Use underline for diagnostics. Options:
 ---                    * severity: Only underline diagnostics matching the given severity
 ---                    |diagnostic-severity|
----       - virtual_text: (default true) Use virtual text for diagnostics. Options:
+---       - virtual_text: (default true) Use virtual text for diagnostics. If multiple diagnostics
+---                       are set for a namespace, one prefix per diagnostic + the last diagnostic
+---                       message are shown.
+---                       Options:
 ---                       * severity: Only show virtual text for diagnostics matching the given
 ---                       severity |diagnostic-severity|
 ---                       * source: (string) Include the diagnostic source in virtual

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -565,6 +565,9 @@ end
 ---                       severity |diagnostic-severity|
 ---                       * source: (string) Include the diagnostic source in virtual
 ---                       text. One of "always" or "if_many".
+---                       * spacing: (number) Amount of empty spaces inserted at the beginning
+---                       of the virtual text.
+---                       * prefix: (string) Prepend diagnostic message with prefix.
 ---                       * format: (function) A function that takes a diagnostic as input and
 ---                                 returns a string. The return value is the text used to display
 ---                                 the diagnostic. Example:


### PR DESCRIPTION
I was reading through `vim.diagnostic()` and noticed that these two options weren't yet documented.     

Somewhat related: I did recently stumble over the fact that for each source only the last diagnostic is displayed:    
https://github.com/neovim/neovim/blob/22d7dd2aec9053028cc033e4c68335a81f845e06/runtime/lua/vim/diagnostic.lua#L988-L1004

Would it make sense to explicitly mention this here too? WDYT @gpanders?     