### PR TITLE
fix(pum_redraw): rename col -> grid_col & truncate correctly

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -386,7 +386,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
 void pum_redraw(void)
 {
   int row = 0;
-  int col;
+  int grid_col;
   int attr_norm = win_hl_attr(curwin, HLF_PNI);
   int attr_select = win_hl_attr(curwin, HLF_PSI);
   int attr_scroll = win_hl_attr(curwin, HLF_PSB);
@@ -479,7 +479,7 @@ void pum_redraw(void)
 
     // Display each entry, use two spaces for a Tab.
     // Do this 3 times: For the main text, kind and extra info
-    col = col_off;
+    grid_col = col_off;
     totwidth = 0;
 
     for (round = 1; round <= 3; ++round) {
@@ -537,24 +537,33 @@ void pum_redraw(void)
                 }
               }
               grid_puts_len(&pum_grid, rt, (int)STRLEN(rt), row,
-                            col - size + 1, attr);
+                            grid_col - size + 1, attr);
               xfree(rt_start);
               xfree(st);
-              col -= width;
+              grid_col -= width;
             } else {
               int size = (int)STRLEN(st);
               int cells = (int)mb_string2cells(st);
 
-              // only draw the text that fits
-              while (size > 0 && col + cells > pum_width + pum_col) {
-                size--;
-                size -= utf_head_off(st, st + size);
-                cells -= utf_ptr2cells(st + size);
+              if (size > 0 && grid_col - col_off + cells > pum_width) {
+                // only draw the text that fits
+                do {
+                  size--;
+                  size -= utf_head_off(st, st + size);
+                  cells -= utf_ptr2cells(st + size);
+                } while (size > 0 && grid_col - col_off + cells > pum_width);
+
+                if (grid_col - col_off + cells < pum_width) {
+                  // Most right character requires 2-cells but only 1 cell
+                  // is available on screen.  Put a '>' on the right of the
+                  // pum item
+                  st[size++] = '>';
+                }
               }
 
-              grid_puts_len(&pum_grid, st, size, row, col, attr);
+              grid_puts_len(&pum_grid, st, size, row, grid_col, attr);
               xfree(st);
-              col += width;
+              grid_col += width;
             }
 
             if (*p != TAB) {
@@ -563,12 +572,11 @@ void pum_redraw(void)
 
             // Display two spaces for a Tab.
             if (pum_rl) {
-              grid_puts_len(&pum_grid, (char_u *)"  ", 2, row, col - 1,
-                            attr);
-              col -= 2;
+              grid_puts_len(&pum_grid, (char_u *)"  ", 2, row, grid_col - 1, attr);
+              grid_col -= 2;
             } else {
-              grid_puts_len(&pum_grid, (char_u *)"  ", 2, row, col, attr);
-              col += 2;
+              grid_puts_len(&pum_grid, (char_u *)"  ", 2, row, grid_col, attr);
+              grid_col += 2;
             }
             totwidth += 2;
             // start text at next char
@@ -599,21 +607,21 @@ void pum_redraw(void)
 
       if (pum_rl) {
         grid_fill(&pum_grid, row, row + 1, col_off - pum_base_width - n + 1,
-                  col + 1, ' ', ' ', attr);
-        col = col_off - pum_base_width - n + 1;
+                  grid_col + 1, ' ', ' ', attr);
+        grid_col = col_off - pum_base_width - n + 1;
       } else {
-        grid_fill(&pum_grid, row, row + 1, col,
+        grid_fill(&pum_grid, row, row + 1, grid_col,
                   col_off + pum_base_width + n, ' ', ' ', attr);
-        col = col_off + pum_base_width + n;
+        grid_col = col_off + pum_base_width + n;
       }
       totwidth = pum_base_width + n;
     }
 
     if (pum_rl) {
-      grid_fill(&pum_grid, row, row + 1, col_off - pum_width + 1, col + 1,
+      grid_fill(&pum_grid, row, row + 1, col_off - pum_width + 1, grid_col + 1,
                 ' ', ' ', attr);
     } else {
-      grid_fill(&pum_grid, row, row + 1, col, col_off + pum_width, ' ', ' ',
+      grid_fill(&pum_grid, row, row + 1, grid_col, col_off + pum_width, ' ', ' ',
                 attr);
     }
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2213,4 +2213,43 @@ describe('builtin popupmenu', function()
     feed('<c-y>')
     assert_alive()
   end)
+
+  it('with one long double-width completion item and an odd number of available columns', function()
+    screen:try_resize(32,8)
+    command('set completeopt+=menuone,noselect')
+    feed('i' .. string.rep(' ', 13))
+    funcs.complete(14, {'哦哦哦哦哦哦哦哦哦哦'})
+    screen:expect([[
+                   ^                   |
+      {1:~           }{n: 哦哦哦哦哦哦哦哦哦>}|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {2:-- INSERT --}                    |
+    ]])
+  end)
+
+  it('with many long double-width completion items and an even number of available columns', function()
+    screen:try_resize(32,8)
+    command('set completeopt+=noselect')
+    command('set pumheight=4')
+    feed('i' .. string.rep(' ', 12))
+    local items = {}
+    for _ = 1, 8 do
+      table.insert(items, {word = '哦哦哦哦哦哦哦哦哦哦', equal = 1, dup = 1})
+    end
+    funcs.complete(13, items)
+    screen:expect([[
+                  ^                    |
+      {1:~          }{n: 哦哦哦哦哦哦哦哦哦>}{c: }|
+      {1:~          }{n: 哦哦哦哦哦哦哦哦哦>}{c: }|
+      {1:~          }{n: 哦哦哦哦哦哦哦哦哦>}{s: }|
+      {1:~          }{n: 哦哦哦哦哦哦哦哦哦>}{s: }|
+      {1:~                               }|
+      {1:~                               }|
+      {2:-- INSERT --}                    |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Fix #16626

The renamed variable is initialized to `col_off`, while in Vim this variable `col` that is used in the same places is initialized to `pum_col`. This can cause confusion in patch porting, and it causes bug #16626. Rename it to `grid_col` to make it clear that it is different from Vim's `col` variable.

I chose the show a double-width character that is too wide as a `>` instead of showing an empty column. I've tried to leave an empty column like Vim, but this makes the popup menu fail to be captured in tests.

Vim's behavior:
![Screenshot_20211220_150608](https://user-images.githubusercontent.com/35768171/146726237-263e8699-6bc0-49be-9ab5-0e77f8203bcf.png)

The behavior I chose to implement:
![Screenshot_20211220_150730](https://user-images.githubusercontent.com/35768171/146726294-1fda41e6-ce95-40a2-b035-5d555844cf5e.png)
