### PR TITLE
fix(lsp): call config on_exit handler before context is cleared

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -777,6 +777,10 @@ function lsp.start_client(config)
   ---@param code (number) exit code of the process
   ---@param signal (number) the signal used to terminate (if any)
   function dispatch.on_exit(code, signal)
+    if config.on_exit then
+      pcall(config.on_exit, code, signal, client_id)
+    end
+
     active_clients[client_id] = nil
     uninitialized_clients[client_id] = nil
 
@@ -791,10 +795,6 @@ function lsp.start_client(config)
       vim.schedule(function()
         vim.notify(msg, vim.log.levels.WARN)
       end)
-    end
-
-    if config.on_exit then
-      pcall(config.on_exit, code, signal, client_id)
     end
   end
 


### PR DESCRIPTION
The `on_exit` handler provided to the client configuration is called after
the client's context is cleared (e.g. which buffers the client was
attached to). Calling the handler sooner allows these handlers to access
the client object and do their own cleanup with the full context.
