### PR TITLE
vim-patch:8.1.2184,8.2.3804: option context is not copied when splitting a window

### DIFF
--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -314,19 +314,48 @@ func Test_set_errors()
   set modifiable&
 endfunc
 
+func CheckWasSet(name)
+  let verb_cm = execute('verbose set ' .. a:name .. '?')
+  call assert_match('Last set from.*test_options.vim', verb_cm)
+endfunc
+func CheckWasNotSet(name)
+  let verb_cm = execute('verbose set ' .. a:name .. '?')
+  call assert_notmatch('Last set from', verb_cm)
+endfunc
+
 " Must be executed before other tests that set 'term'.
 func Test_000_term_option_verbose()
   if has('nvim') || has('gui_running')
     return
   endif
-  let verb_cm = execute('verbose set t_cm')
-  call assert_notmatch('Last set from', verb_cm)
+
+  call CheckWasNotSet('t_cm')
 
   let term_save = &term
   set term=ansi
-  let verb_cm = execute('verbose set t_cm')
-  call assert_match('Last set from.*test_options.vim', verb_cm)
+  call CheckWasSet('t_cm')
   let &term = term_save
+endfunc
+
+func Test_copy_context()
+  setlocal list
+  call CheckWasSet('list')
+  split
+  call CheckWasSet('list')
+  quit
+  setlocal nolist
+
+  set ai
+  call CheckWasSet('ai')
+  set filetype=perl
+  call CheckWasSet('filetype')
+  set fo=tcroq
+  call CheckWasSet('fo')
+
+  split Xsomebuf
+  call CheckWasSet('ai')
+  call CheckWasNotSet('filetype')
+  call CheckWasSet('fo')
 endfunc
 
 func Test_set_ttytype()


### PR DESCRIPTION
#### vim-patch:8.1.2184: option context is not copied when splitting a window

Problem:    Option context is not copied when splitting a window. (Daniel
            Hahler)
Solution:   Copy the option context, so that ":verbose set" works.
https://github.com/vim/vim/commit/cfb381421f8be7d6cb4e7dac5b827b23467d3e53

#### vim-patch:8.2.3804: script context not set when copying 'swf' and 'ts'
    
Problem:    Script context not set when copying 'swf' and 'ts'.
Solution:   Use COPY_OPT_SCTX with the right argument. (closes vim/vim#9347)
https://github.com/vim/vim/commit/6206877c511c636cbeb2a2b911451af316b62d00