### PR TITLE
Ensure buffer change cb does not read bad cursor

### DIFF
--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -282,7 +282,11 @@ void buf_updates_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
         args.items[7] = INTEGER_OBJ((Integer)deleted_codeunits);
       }
       textlock++;
+      pos_T save_cursor = curwin->w_cursor;
+      // Cursor may be in bad state during in progress editing operation
+      curwin->w_cursor = (pos_T) { 1, 0, 0 };
       Object res = nlua_call_ref(cb.on_lines, "lines", args, true, NULL);
+      curwin->w_cursor = save_cursor;
       textlock--;
 
       if (res.type == kObjectTypeBoolean && res.data.boolean == true) {


### PR DESCRIPTION
In multiple editing operations the cursor may temporarily be out of bounds during calls into user code from buffer update listeners. This means doing anything in a change callback that depends on the cursor position - including calling any function from Vim script - can throw an error. Moving the cursor is also not possible, since there is no way to restore the cursor to its previous invalid position via the public APIs.

This pull request attempts to fix the issue by always saving the location of the cursor before running each change callback with the cursor in a valid spot.

For some background, I fixed one instance of this in #11782, but there are many more, as evidenced by these issue reports for the Neovim version of [vim-strip-trailing-whitespace], all of which hit this issue:

* axelf4/vim-strip-trailing-whitespace#5

  (has reproduction steps)
* axelf4/vim-strip-trailing-whitespace#8
* axelf4/vim-strip-trailing-whitespace#9

[vim-strip-trailing-whitespace]: https://github.com/axelf4/vim-strip-trailing-whitespace