### PR TITLE
runtime(health): use scratch-buffer

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -29,7 +29,8 @@ function! health#check(plugin_names) abort
         \ ? s:discover_healthchecks()
         \ : s:get_healthcheck(a:plugin_names)
 
-  tabnew
+  " create scratch-buffer
+  execute 'tab sbuffer' nvim_create_buf(v:true, v:true)
   setlocal wrap breakindent linebreak
   setlocal filetype=markdown
   setlocal conceallevel=2 concealcursor=nc
@@ -70,8 +71,6 @@ function! health#check(plugin_names) abort
 
   " needed for plasticboy/vim-markdown, because it uses fdm=expr
   normal! zR
-  setlocal nomodified
-  setlocal bufhidden=hide
   redraw|echo ''
 endfunction
 

--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -19,7 +19,7 @@ function! s:enhance_syntax() abort
   highlight default link healthHelp Identifier
 
   " We do not care about markdown syntax errors in :checkhealth output.
-  highlight! link markdownError Normal
+  syn clear markdownError
 endfunction
 
 " Runs the specified healthchecks.


### PR DESCRIPTION
Using `nvim_create_buf()` to create `:h scratch-buffer` for `:checkhealth`'s report is logical and also allows for easy detection of this "special buffer" by user (by trapping `BufWinEnter` or by `after/ftplugin/markdown.vim` etc.).  Closes #16639 