### PR TITLE
feat(runtime): new checkhealth filetype

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -1,27 +1,3 @@
-function! s:enhance_syntax() abort
-  syntax case match
-
-  syntax keyword healthError ERROR[:]
-        \ containedin=markdownCodeBlock,mkdListItemLine
-  highlight default link healthError Error
-
-  syntax keyword healthWarning WARNING[:]
-        \ containedin=markdownCodeBlock,mkdListItemLine
-  highlight default link healthWarning WarningMsg
-
-  syntax keyword healthSuccess OK[:]
-        \ containedin=markdownCodeBlock,mkdListItemLine
-  highlight default healthSuccess guibg=#5fff00 guifg=#080808 ctermbg=82 ctermfg=232
-
-  syntax match healthHelp "|.\{-}|" contains=healthBar
-        \ containedin=markdownCodeBlock,mkdListItemLine
-  syntax match healthBar  "|" contained conceal
-  highlight default link healthHelp Identifier
-
-  " We do not care about markdown syntax errors in :checkhealth output.
-  highlight! link markdownError Normal
-endfunction
-
 " Runs the specified healthchecks.
 " Runs all discovered healthchecks if a:plugin_names is empty.
 function! health#check(plugin_names) abort
@@ -29,13 +5,9 @@ function! health#check(plugin_names) abort
         \ ? s:discover_healthchecks()
         \ : s:get_healthcheck(a:plugin_names)
 
-  tabnew
-  setlocal wrap breakindent linebreak
-  setlocal filetype=markdown
-  setlocal conceallevel=2 concealcursor=nc
-  setlocal keywordprg=:help
-  let &l:iskeyword='!-~,^*,^|,^",192-255'
-  call s:enhance_syntax()
+  " create scratch-buffer
+  execute 'tab sbuffer' nvim_create_buf(v:true, v:true)
+  setfiletype checkhealth
 
   if empty(healthchecks)
     call setline(1, 'ERROR: No healthchecks found.')
@@ -70,8 +42,6 @@ function! health#check(plugin_names) abort
 
   " needed for plasticboy/vim-markdown, because it uses fdm=expr
   normal! zR
-  setlocal nomodified
-  setlocal bufhidden=hide
   redraw|echo ''
 endfunction
 

--- a/runtime/ftplugin/checkhealth.vim
+++ b/runtime/ftplugin/checkhealth.vim
@@ -1,0 +1,20 @@
+" Vim filetype plugin
+" Language:     Neovim checkhealth buffer
+" Last Change:  2021 Dec 15
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/markdown.vim ftplugin/markdown_*.vim ftplugin/markdown/*.vim
+
+setlocal wrap breakindent linebreak
+setlocal conceallevel=2 concealcursor=nc
+setlocal keywordprg=:help
+let &l:iskeyword='!-~,^*,^|,^",192-255'
+
+if exists("b:undo_ftplugin")
+  let b:undo_ftplugin .= "|setl wrap< bri< lbr< cole< cocu< kp< isk<"
+else
+  let b:undo_ftplugin = "setl wrap< bri< lbr< cole< cocu< kp< isk<"
+endif

--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -1,0 +1,28 @@
+" Vim syntax file
+" Language:     Neovim checkhealth buffer
+" Last Change:  2021 Dec 15
+
+if exists("b:current_syntax")
+  finish
+endif
+
+runtime! syntax/markdown.vim
+unlet! b:current_syntax
+
+syn case match
+
+" We do not care about markdown syntax errors
+syn clear markdownError
+
+syn keyword healthError ERROR[:] containedin=markdownCodeBlock,mkdListItemLine
+syn keyword healthWarning WARNING[:] containedin=markdownCodeBlock,mkdListItemLine
+syn keyword healthSuccess OK[:] containedin=markdownCodeBlock,mkdListItemLine
+syn match healthHelp "|.\{-}|" containedin=markdownCodeBlock,mkdListItemLine contains=healthBar
+syn match healthBar  "|" contained conceal
+
+hi def link healthError Error
+hi def link healthWarning WarningMsg
+hi def healthSuccess guibg=#5fff00 guifg=#080808 ctermbg=82 ctermfg=232
+hi def link healthHelp Identifier
+
+let b:current_syntax = "checkhealth"

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -156,7 +156,7 @@ describe('health.vim', function()
         test_plug.submodule_failed: require("test_plug.submodule_failed.health").check()
         ========================================================================
           - ERROR: Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
-            function health#check, line 24]])
+            function health#check, line 20]])
       eq(expected, received)
     end)
 
@@ -167,7 +167,7 @@ describe('health.vim', function()
         broken: health#broken#check
         ========================================================================
           - ERROR: Failed to run healthcheck for "broken" plugin. Exception:
-            function health#check[24]..health#broken#check, line 1
+            function health#check[20]..health#broken#check, line 1
             caused an error
         ]])
     end)
@@ -186,7 +186,7 @@ describe('health.vim', function()
         test_plug.submodule_failed: require("test_plug.submodule_failed.health").check()
         ========================================================================
           - ERROR: Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
-            function health#check, line 24]])
+            function health#check, line 20]])
       eq(expected, received)
     end)
 


### PR DESCRIPTION
This is an alternative to PR #16649 which additionally creates a new filetype called "nvimdiag" to be re-used for health/diagnostic buffer(s).

Closes #8148 and #16639. Invalidates PR #16649.

Leaving to the core team to decide which, this one or #16649, is more preferable.