### PR TITLE
fix(ts): escape lang when loading parsers

### DIFF
--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -14,7 +14,7 @@ function M.require_language(lang, path, silent)
     return true
   end
   if path == nil then
-    local fname = 'parser/' .. lang .. '.*'
+    local fname = 'parser/' .. vim.fn.fnameescape(lang) .. '.*'
     local paths = a.nvim_get_runtime_file(fname, false)
     if #paths == 0 then
       if silent then

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -666,6 +666,21 @@ int x = INT_MAX;
                           -- READ_STRING_OK(x, y) (char_u *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
+
+      it("should not inject bad languages", function()
+        if helpers.pending_win32(pending) then return end
+        exec_lua([=[
+        vim.treesitter.add_directive("inject-bad!", function(match, _, _, pred, metadata)
+          metadata.language = "{"
+          metadata.combined = true
+          metadata.content = pred[2]
+        end)
+
+        parser = vim.treesitter.get_parser(0, "c", {
+          injections = {
+            c = "(preproc_function_def value: ((preproc_arg) @_a (#inject-bad! @_a)))"}})
+        ]=])
+      end)
     end)
 
     describe("when using the offset directive", function()


### PR DESCRIPTION
When trying to load a language parser, escape the value of the language.

With language injection, the language might be picked up from the buffer. If this value is erroneous it can cause `nvim_get_runtime_file` to hard error.

E.g. The markdown expression `~~~{` will extract `{` as a language and then try to get the parser using `parser/{*` as the pattern. This will then cause the error `E220: Missing }.` to be reported for every path in `runtimepath`.
