### PR TITLE
test(old): reenable Test_virtual_replace()

### DIFF
--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -13,7 +13,7 @@ set fillchars=vert:\|,fold:-
 set laststatus=1
 set listchars=eol:$
 set joinspaces
-set nohidden smarttab noautoindent noautoread complete-=i noruler noshowcmd
+set nohidden nosmarttab noautoindent noautoread complete-=i noruler noshowcmd
 set nrformats+=octal
 set shortmess-=F
 set sidescroll=0

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -144,7 +144,6 @@ endfun
 
 " Test Virtual replace mode.
 func Test_virtual_replace()
-  throw 'skipped: TODO: '
   if exists('&t_kD')
     let save_t_kD = &t_kD
   endif
@@ -166,7 +165,6 @@ func Test_virtual_replace()
 	      \ ], getline(1, 6))
   normal G
   mark a
-  inoremap <C-D> <Del>
   exe "normal o0\<C-D>\nabcdefghi\njk\tlmn\n    opq\trst\n\<C-D>uvwxyz\n"
   exe "normal 'ajgR0\<C-D> 1\nA\nBCDEFGHIJ\n\tKL\nMNO\nPQR" . repeat("\<BS>", 29)
   call assert_equal([' 1',


### PR DESCRIPTION
The steps to reproduce in <https://github.com/neovim/neovim/commit/9af9ea6099d109982d642885c6b7fc5e5082c3f8> seem to longer cause an ASAN error.