### PR TITLE
fix(diagnostic): provide default column value for diagnostics

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -272,6 +272,10 @@ end
 ---@private
 local function set_diagnostic_cache(namespace, bufnr, diagnostics)
   for _, diagnostic in ipairs(diagnostics) do
+    -- Producers *should* provide a column, but some LSP servers (for instance) do not. Rather
+    -- than throw an error later on, provide a dummy default value
+    diagnostic.col = diagnostic.col or 0
+
     diagnostic.severity = diagnostic.severity and to_severity(diagnostic.severity) or M.severity.ERROR
     diagnostic.end_lnum = diagnostic.end_lnum or diagnostic.lnum
     diagnostic.end_col = diagnostic.end_col or diagnostic.col


### PR DESCRIPTION
Some language servers (errantly) do not specify a column in their
diagnostics. This is a bug on their part, but we can compensate for
their bad behavior by treating a missing column as 0.

Closes #16673.

@mfussenegger @mjlbach Curious what you guys think. I'm not a fan of this defensive style of programming to compensate for bugs in other software. Should we make omitting a column an error and put pressure on the faulty language servers?