### PR TITLE
vim-patch:0e6adf8a29d5

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -164,7 +164,7 @@ If you would like to open the help in the current window, see this tip:
 
 The initial height of the help window can be set with the 'helpheight' option
 (default 20).
-
+						*help-buffer-options*
 When the help buffer is created, several local options are set to make sure
 the help text is displayed as it was intended:
     'iskeyword'		nearly all ASCII chars except ' ', '*', '"' and '|'

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -158,7 +158,7 @@ type "a", then "bar" will get inserted.
 "<unique>" can be used in any order.  They must appear right after the
 command, before any other arguments.
 
-				*:map-local* *:map-<buffer>* *E224* *E225*
+			*:map-local* *:map-<buffer>* *:map-buffer* *E224* *E225*
 If the first argument to one of these commands is "<buffer>" the mapping will
 be effective in the current buffer only.  Example: >
 	:map <buffer>  ,w  /[.,;]<CR>
@@ -211,7 +211,7 @@ Note: ":map <script>" and ":noremap <script>" do the same thing.  The
 "<script>" overrules the command name.  Using ":noremap <script>" is
 preferred, because it's clearer that remapping is (mostly) disabled.
 
-						*:map-<unique>* *E226* *E227*
+				*:map-<unique>* *:map-unique* *E226* *E227*
 If the first argument to one of these commands is "<unique>" and it is used to
 define a new mapping or abbreviation, the command will fail if the mapping or
 abbreviation already exists.  Example: >

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -387,7 +387,7 @@ g8			Print the hex values of the bytes used in the
 			   |:marks|      - filter by text in the current file,
 					   or file name for other files
 			   |:oldfiles|   - filter by file name
-			   |:set|        - filter by variable name
+			   |:set|        - filter by option name
 
 			Only normal messages are filtered, error messages are
 			not.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Dec 03
+" Last Change:	2021 Dec 14
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/ftplugin/i3config.vim
+++ b/runtime/ftplugin/i3config.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language: i3 config file
+" Original Author: Mohamed Boughaba <mohamed dot bgb at gmail dot com>
+" Maintainer: Quentin Hibon
+" Version: 0.4
+" Last Change: 2021 Dec 14
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setlocal cms<"
+
+setlocal commentstring=#\ %s

--- a/runtime/ftplugin/solution.vim
+++ b/runtime/ftplugin/solution.vim
@@ -1,0 +1,37 @@
+" Vim filetype plugin file
+" Language:	Microsoft Visual Studio Solution
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2021 Dec 15
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setl com< cms<"
+
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_words =
+	\ '\<Project\>:\<EndProject\>,' ..
+	\ '\<ProjectSection\>:\<EndProjectSection\>,' ..
+	\ '\<Global\>:\<EndGlobal\>,' ..
+	\ '\<GlobalSection\>:\<EndGlobalSection\>'
+  let b:undo_ftplugin ..= " | unlet! b:match_words"
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Microsoft Visual Studio Solution Files\t*.sln\n" ..
+	\	       "All Files (*.*)\t*.*\n"
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	C
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 May 24
+" Last Change:	2021 Dec 07
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -196,7 +196,6 @@ syn match	cNumber		display contained "0x\x\+\(u\=l\{0,2}\|ll\=u\)\>"
 " Flag the first zero of an octal number as something special
 syn match	cOctal		display contained "0\o\+\(u\=l\{0,2}\|ll\=u\)\>" contains=cOctalZero
 syn match	cOctalZero	display contained "\<0"
-syn match	cFloat		display contained "\d\+f"
 "floating point number, with dot, optional exponent
 syn match	cFloat		display contained "\d\+\.\d*\(e[-+]\=\d\+\)\=[fl]\="
 "floating point number, starting with a dot, optional exponent

--- a/runtime/syntax/css.vim
+++ b/runtime/syntax/css.vim
@@ -7,7 +7,7 @@
 "               Nikolai Weibull (Add CSS2 support)
 " URL:          https://github.com/vim-language-dept/css-syntax.vim
 " Maintainer:   Jay Sitter <jay@jaysitter.com>
-" Last Change:  2021 Oct 15
+" Last Change:  2021 Oct 20
 
 " quit when a syntax file was already loaded
 if !exists("main_syntax")
@@ -116,7 +116,7 @@ syn keyword cssColor contained ActiveBorder ActiveCaption AppWorkspace ButtonFac
 syn case ignore
 
 syn match cssImportant contained "!\s*important\>"
-syn match cssCustomProp contained "--[a-zA-Z0-9-_]*"
+syn match cssCustomProp contained "\<--[a-zA-Z0-9-_]*\>"
 
 syn match cssColor contained "\<transparent\>"
 syn match cssColor contained "\<currentColor\>"
@@ -126,6 +126,7 @@ syn match cssColor contained "#\x\{6\}\>" contains=cssUnitDecorators
 syn match cssColor contained "#\x\{8\}\>" contains=cssUnitDecorators
 
 syn region cssURL contained matchgroup=cssFunctionName start="\<\(uri\|url\|local\|format\)\s*(" end=")" contains=cssStringQ,cssStringQQ oneline
+syn region cssMathGroup contained matchgroup=cssMathParens start="(" end=")" containedin=cssFunction,cssMathGroup contains=cssCustomProp,cssValue.*,cssFunction,cssColor,cssStringQ,cssStringQQ oneline
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(var\|calc\)\s*(" end=")" contains=cssCustomProp,cssValue.*,cssFunction,cssColor,cssStringQ,cssStringQQ oneline
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgb\|clip\|attr\|counter\|rect\|cubic-bezier\|steps\)\s*(" end=")" oneline  contains=cssValueInteger,cssValueNumber,cssValueLength,cssFunctionComma
 syn region cssFunction contained matchgroup=cssFunctionName start="\<\(rgba\|hsl\|hsla\|color-stop\|from\|to\)\s*(" end=")" oneline  contains=cssColor,cssValueInteger,cssValueNumber,cssValueLength,cssFunctionComma,cssFunction
@@ -395,9 +396,9 @@ syn match cssUIAttr contained '\<preserve-3d\>'
 syn match cssIEUIAttr contained '\<bicubic\>'
 
 " Webkit/iOS specific properties
-syn match cssUIProp contained '\<tap-highlight-color\|user-select\|touch-callout\>'
+syn match cssUIProp contained '\<\(tap-highlight-color\|user-select\|touch-callout\)\>'
 " IE specific properties
-syn match cssIEUIProp contained '\<interpolation-mode\|zoom\|filter\>'
+syn match cssIEUIProp contained '\<\(interpolation-mode\|zoom\|filter\)\>'
 
 " Webkit/Firebox specific properties/attributes
 syn keyword cssUIProp contained appearance
@@ -423,11 +424,15 @@ syn keyword cssAuralAttr contained male female child code digits continuous
 syn match cssMobileTextProp contained "\<text-size-adjust\>"
 
 syn keyword cssMediaProp contained width height orientation scan
-syn match cssMediaProp contained /\(\(max\|min\)-\)\=\(\(device\)-\)\=aspect-ratio/
-syn match cssMediaProp contained /\(\(max\|min\)-\)\=device-pixel-ratio/
-syn match cssMediaProp contained /\(\(max\|min\)-\)\=device-\(height\|width\)/
-syn match cssMediaProp contained /\(\(max\|min\)-\)\=\(height\|width\|resolution\|monochrome\|color\(-index\)\=\)/
+syn keyword cssMediaProp contained any-hover any-pointer color-gamut grid hover
+syn keyword cssMediaProp contained overflow-block overflow-inline pointer update
+syn match cssMediaProp contained /\<\(\(max\|min\)-\)\=\(\(device\)-\)\=aspect-ratio\>/
+syn match cssMediaProp contained /\<\(\(max\|min\)-\)\=device-pixel-ratio\>/
+syn match cssMediaProp contained /\<\(\(max\|min\)-\)\=device-\(height\|width\)\>/
+syn match cssMediaProp contained /\<\(\(max\|min\)-\)\=\(height\|width\|resolution\|monochrome\|color\(-index\)\=\)\>/
 syn keyword cssMediaAttr contained portrait landscape progressive interlace
+syn keyword cssMediaAttr contained coarse fast fine hover infinite p3 paged
+syn keyword cssMediaAttr contained rec2020 scroll slow srgb
 syn match cssKeyFrameProp contained /\(\d\+\(\.\d\+\)\?%\|\(\<from\|to\>\)\)/ nextgroup=cssDefinition
 syn match cssPageMarginProp /@\(\(top\|left\|right\|bottom\)-\(left\|center\|right\|middle\|bottom\)\)\(-corner\)\=/ contained nextgroup=cssDefinition
 syn keyword cssPageProp contained content size
@@ -445,17 +450,17 @@ syn match cssBraceError "}"
 syn match cssAttrComma ","
 
 " Pseudo class
-" http://www.w3.org/TR/css3-selectors/
+" https://www.w3.org/TR/selectors-4/
 syn match cssPseudoClass ":[A-Za-z0-9_-]*" contains=cssNoise,cssPseudoClassId,cssUnicodeEscape,cssVendor,cssPseudoClassFn
 syn keyword cssPseudoClassId contained link visited active hover before after left right
-syn keyword cssPseudoClassId contained root empty target enable disabled checked invalid
+syn keyword cssPseudoClassId contained root empty target enabled disabled checked invalid
 syn match cssPseudoClassId contained "\<first-\(line\|letter\)\>"
 syn match cssPseudoClassId contained "\<\(first\|last\|only\)-\(of-type\|child\)\>"
-syn region cssPseudoClassFn contained matchgroup=cssFunctionName start="\<\(not\|lang\|\(nth\|nth-last\)-\(of-type\|child\)\)(" end=")" contains=cssStringQ,cssStringQQ
+syn match cssPseudoClassId contained  "\<focus\(-within\|-visible\)\=\>"
+syn region cssPseudoClassFn contained matchgroup=cssFunctionName start="\<\(not\|is\|lang\|\(nth\|nth-last\)-\(of-type\|child\)\)(" end=")" contains=cssStringQ,cssStringQQ,cssTagName,cssAttributeSelector,cssClassName,cssIdentifier
 " ------------------------------------
 " Vendor specific properties
 syn match cssPseudoClassId contained  "\<selection\>"
-syn match cssPseudoClassId contained  "\<focus\(-inner\)\=\>"
 syn match cssPseudoClassId contained  "\<\(input-\)\=placeholder\>"
 
 " Misc highlight groups

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -1,0 +1,256 @@
+" Vim syntax file
+" Language: i3 config file
+" Maintainer: Mohamed Boughaba <mohamed dot bgb at gmail dot com>
+" Version: 0.4
+" Last Change: 2021 Dec 14
+
+" References:
+" http://i3wm.org/docs/userguide.html#configuring
+" http://vimdoc.sourceforge.net/htmldoc/syntax.html
+"
+"
+" Quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+scriptencoding utf-8
+
+" Error
+syn match i3ConfigError /.*/
+
+" Todo
+syn keyword i3ConfigTodo TODO FIXME XXX contained
+
+" Comment
+" Comments are started with a # and can only be used at the beginning of a line
+syn match i3ConfigComment /^\s*#.*$/ contains=i3ConfigTodo
+
+" Font
+" A FreeType font description is composed by:
+" a font family, a style, a weight, a variant, a stretch and a size.
+syn match i3ConfigFontSeparator /,/ contained
+syn match i3ConfigFontSeparator /:/ contained
+syn keyword i3ConfigFontKeyword font contained
+syn match i3ConfigFontNamespace /\w\+:/ contained contains=i3ConfigFontSeparator
+syn match i3ConfigFontContent /-\?\w\+\(-\+\|\s\+\|,\)/ contained contains=i3ConfigFontNamespace,i3ConfigFontSeparator,i3ConfigFontKeyword
+syn match i3ConfigFontSize /\s\=\d\+\(px\)\?\s\?$/ contained
+syn match i3ConfigFont /^\s*font\s\+.*$/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^\s*font\s\+.*\(\\\_.*\)\?$/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^\s*font\s\+.*\(\\\_.*\)\?[^\\]\+$/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^\s*font\s\+\(\(.*\\\_.*\)\|\(.*[^\\]\+$\)\)/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
+
+" variables
+syn match i3ConfigString /\(['"]\)\(.\{-}\)\1/ contained
+syn match i3ConfigColor /#\w\{6}/ contained
+syn match i3ConfigVariableModifier /+/ contained
+syn match i3ConfigVariableAndModifier /+\w\+/ contained contains=i3ConfigVariableModifier
+syn match i3ConfigVariable /\$\w\+\(\(-\w\+\)\+\)\?\(\s\|+\)\?/ contains=i3ConfigVariableModifier,i3ConfigVariableAndModifier
+syn keyword i3ConfigInitializeKeyword set contained
+syn match i3ConfigInitialize /^\s*set\s\+.*$/ contains=i3ConfigVariable,i3ConfigInitializeKeyword,i3ConfigColor,i3ConfigString
+
+" Gaps
+syn keyword i3ConfigGapStyleKeyword inner outer horizontal vertical top right bottom left current all set plus minus toggle up down contained
+syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+\(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,i3ConfigNumber,i3ConfigVariable
+syn keyword i3ConfigSmartGapKeyword on inverse_outer contained
+syn match i3ConfigSmartGap /^\s*smart_gaps\s\+\(on\|inverse_outer\)\s\?$/ contains=i3ConfigSmartGapKeyword
+syn keyword i3ConfigSmartBorderKeyword on no_gaps contained
+syn match i3ConfigSmartBorder /^\s*smart_borders\s\+\(on\|no_gaps\)\s\?$/ contains=i3ConfigSmartBorderKeyword
+
+" Keyboard bindings
+syn keyword i3ConfigAction toggle fullscreen restart key import kill shrink grow contained
+syn keyword i3ConfigAction focus move grow height width split layout resize restore reload mute unmute exit mode workspace container to contained
+syn match i3ConfigModifier /\w\++\w\+\(\(+\w\+\)\+\)\?/ contained contains=i3ConfigVariableModifier
+syn match i3ConfigNumber /\s\d\+/ contained
+syn match i3ConfigUnit /\sp\(pt\|x\)/ contained
+syn match i3ConfigUnitOr /\sor/ contained
+syn keyword i3ConfigBindKeyword bindsym bindcode exec gaps border contained
+syn match i3ConfigBindArgument /--\w\+\(\(-\w\+\)\+\)\?\s/ contained
+syn match i3ConfigBind /^\s*\(bindsym\|bindcode\)\s\+.*$/ contains=i3ConfigVariable,i3ConfigBindKeyword,i3ConfigVariableAndModifier,i3ConfigNumber,i3ConfigUnit,i3ConfigUnitOr,i3ConfigBindArgument,i3ConfigModifier,i3ConfigAction,i3ConfigString,i3ConfigGapStyleKeyword,i3ConfigBorderStyleKeyword
+
+" Floating
+syn keyword i3ConfigSizeSpecial x contained
+syn match i3ConfigNegativeSize /-/ contained
+syn match i3ConfigSize /-\?\d\+\s\?x\s\?-\?\d\+/ contained contains=i3ConfigSizeSpecial,i3ConfigNumber,i3ConfigNegativeSize
+syn match i3ConfigFloating /^\s*floating_modifier\s\+\$\w\+\d\?/ contains=i3ConfigVariable
+syn match i3ConfigFloating /^\s*floating_\(maximum\|minimum\)_size\s\+-\?\d\+\s\?x\s\?-\?\d\+/ contains=i3ConfigSize
+
+" Orientation
+syn keyword i3ConfigOrientationKeyword vertical horizontal auto contained
+syn match i3ConfigOrientation /^\s*default_orientation\s\+\(vertical\|horizontal\|auto\)\s\?$/ contains=i3ConfigOrientationKeyword
+
+" Layout
+syn keyword i3ConfigLayoutKeyword default stacking tabbed contained
+syn match i3ConfigLayout /^\s*workspace_layout\s\+\(default\|stacking\|tabbed\)\s\?$/ contains=i3ConfigLayoutKeyword
+
+" Border style
+syn keyword i3ConfigBorderStyleKeyword none normal pixel contained
+syn match i3ConfigBorderStyle /^\s*\(new_window\|new_float\|default_border\|default_floating_border\)\s\+\(none\|\(normal\|pixel\)\(\s\+\d\+\)\?\(\s\+\$\w\+\(\(-\w\+\)\+\)\?\(\s\|+\)\?\)\?\)\s\?$/ contains=i3ConfigBorderStyleKeyword,i3ConfigNumber,i3ConfigVariable
+
+" Hide borders and edges
+syn keyword i3ConfigEdgeKeyword none vertical horizontal both smart smart_no_gaps contained
+syn match i3ConfigEdge /^\s*hide_edge_borders\s\+\(none\|vertical\|horizontal\|both\|smart\|smart_no_gaps\)\s\?$/ contains=i3ConfigEdgeKeyword
+
+" Arbitrary commands for specific windows (for_window)
+syn keyword i3ConfigCommandKeyword for_window contained
+syn region i3ConfigWindowStringSpecial start=+"+  skip=+\\"+  end=+"+ contained contains=i3ConfigString
+syn region i3ConfigWindowCommandSpecial start="\[" end="\]" contained contains=i3ConfigWindowStringSpacial,i3ConfigString
+syn match i3ConfigArbitraryCommand /^\s*for_window\s\+.*$/ contains=i3ConfigWindowCommandSpecial,i3ConfigCommandKeyword,i3ConfigBorderStyleKeyword,i3ConfigLayoutKeyword,i3ConfigOrientationKeyword,Size,i3ConfigNumber
+
+" Disable focus open opening
+syn keyword i3ConfigNoFocusKeyword no_focus contained
+syn match i3ConfigDisableFocus /^\s*no_focus\s\+.*$/ contains=i3ConfigWindowCommandSpecial,i3ConfigNoFocusKeyword
+
+" Move client to specific workspace automatically
+syn keyword i3ConfigAssignKeyword assign contained
+syn match i3ConfigAssignSpecial /→/ contained
+syn match i3ConfigAssign /^\s*assign\s\+.*$/ contains=i3ConfigAssignKeyword,i3ConfigWindowCommandSpecial,i3ConfigAssignSpecial
+
+" X resources
+syn keyword i3ConfigResourceKeyword set_from_resource contained
+syn match i3ConfigResource /^\s*set_from_resource\s\+.*$/ contains=i3ConfigResourceKeyword,i3ConfigWindowCommandSpecial,i3ConfigColor,i3ConfigVariable
+
+" Auto start applications
+syn keyword i3ConfigExecKeyword exec exec_always contained
+syn match i3ConfigNoStartupId /--no-startup-id/ contained " We are not using i3ConfigBindArgument as only no-startup-id is supported here
+syn match i3ConfigExec /^\s*exec\(_always\)\?\s\+.*$/ contains=i3ConfigExecKeyword,i3ConfigNoStartupId,i3ConfigString
+
+" Automatically putting workspaces on specific screens
+syn keyword i3ConfigWorkspaceKeyword workspace contained
+syn keyword i3ConfigOutput output contained
+syn match i3ConfigWorkspace /^\s*workspace\s\+.*$/ contains=i3ConfigWorkspaceKeyword,i3ConfigNumber,i3ConfigString,i3ConfigOutput
+
+" Changing colors
+syn keyword i3ConfigClientColorKeyword client focused focused_inactive unfocused urgent placeholder background contained
+syn match i3ConfigClientColor /^\s*client.\w\+\s\+.*$/ contains=i3ConfigClientColorKeyword,i3ConfigColor,i3ConfigVariable
+
+syn keyword i3ConfigTitleAlignKeyword left center right contained
+syn match i3ConfigTitleAlign /^\s*title_align\s\+.*$/ contains=i3ConfigTitleAlignKeyword
+
+" Interprocess communication
+syn match i3ConfigInterprocessKeyword /ipc-socket/ contained
+syn match i3ConfigInterprocess /^\s*ipc-socket\s\+.*$/ contains=i3ConfigInterprocessKeyword
+
+" Mouse warping
+syn keyword i3ConfigMouseWarpingKeyword mouse_warping contained
+syn keyword i3ConfigMouseWarpingType output none contained
+syn match i3ConfigMouseWarping /^\s*mouse_warping\s\+\(output\|none\)\s\?$/ contains=i3ConfigMouseWarpingKeyword,i3ConfigMouseWarpingType
+
+" Focus follows mouse
+syn keyword i3ConfigFocusFollowsMouseKeyword focus_follows_mouse contained
+syn keyword i3ConfigFocusFollowsMouseType yes no contained
+syn match i3ConfigFocusFollowsMouse /^\s*focus_follows_mouse\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusFollowsMouseKeyword,i3ConfigFocusFollowsMouseType
+
+" Popups during fullscreen mode
+syn keyword i3ConfigPopupOnFullscreenKeyword popup_during_fullscreen contained
+syn keyword i3ConfigPopuponFullscreenType smart ignore leave_fullscreen contained
+syn match i3ConfigPopupOnFullscreen /^\s*popup_during_fullscreen\s\+\w\+\s\?$/ contains=i3ConfigPopupOnFullscreenKeyword,i3ConfigPopupOnFullscreenType
+
+" Focus wrapping
+syn keyword i3ConfigFocusWrappingKeyword force_focus_wrapping focus_wrapping contained
+syn keyword i3ConfigFocusWrappingType yes no contained
+syn match i3ConfigFocusWrapping /^\s*\(force_\)\?focus_wrapping\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigFocusWrappingKeyword
+
+" Forcing Xinerama
+syn keyword i3ConfigForceXineramaKeyword force_xinerama contained
+syn match i3ConfigForceXinerama /^\s*force_xinerama\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigForceXineramaKeyword
+
+" Automatic back-and-forth when switching to the current workspace
+syn keyword i3ConfigAutomaticSwitchKeyword workspace_auto_back_and_forth contained
+syn match i3ConfigAutomaticSwitch /^\s*workspace_auto_back_and_forth\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigAutomaticSwitchKeyword
+
+" Delay urgency hint
+syn keyword i3ConfigTimeUnit ms contained
+syn keyword i3ConfigDelayUrgencyKeyword force_display_urgency_hint contained
+syn match i3ConfigDelayUrgency /^\s*force_display_urgency_hint\s\+\d\+\s\+ms\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigDelayUrgencyKeyword,i3ConfigNumber,i3ConfigTimeUnit
+
+" Focus on window activation
+syn keyword i3ConfigFocusOnActivationKeyword focus_on_window_activation contained
+syn keyword i3ConfigFocusOnActivationType smart urgent focus none contained
+syn match i3ConfigFocusOnActivation /^\s*focus_on_window_activation\s\+\(smart\|urgent\|focus\|none\)\s\?$/  contains=i3ConfigFocusOnActivationKeyword,i3ConfigFocusOnActivationType
+
+" Automatic back-and-forth when switching to the current workspace
+syn keyword i3ConfigDrawingMarksKeyword show_marks contained
+syn match i3ConfigDrawingMarks /^\s*show_marks\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigDrawingMarksKeyword
+
+" Group mode/bar
+syn keyword i3ConfigBlockKeyword mode bar colors i3bar_command status_command position exec mode hidden_state modifier id position output background statusline tray_output tray_padding separator separator_symbol workspace_buttons strip_workspace_numbers binding_mode_indicator focused_workspace active_workspace inactive_workspace urgent_workspace binding_mode contained
+syn region i3ConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
+
+" Line continuation
+syn region i3ConfigLineCont start=/^.*\\$/ end=/^.*$/ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
+
+" Define the highlighting.
+hi def link i3ConfigError                           Error
+hi def link i3ConfigTodo                            Todo
+hi def link i3ConfigComment                         Comment
+hi def link i3ConfigFontContent                     Type
+hi def link i3ConfigFocusOnActivationType           Type
+hi def link i3ConfigPopupOnFullscreenType           Type
+hi def link i3ConfigOrientationKeyword              Type
+hi def link i3ConfigMouseWarpingType                Type
+hi def link i3ConfigFocusFollowsMouseType           Type
+hi def link i3ConfigGapStyleKeyword                 Type
+hi def link i3ConfigTitleAlignKeyword               Type
+hi def link i3ConfigSmartGapKeyword                 Type
+hi def link i3ConfigSmartBorderKeyword              Type
+hi def link i3ConfigLayoutKeyword                   Type
+hi def link i3ConfigBorderStyleKeyword              Type
+hi def link i3ConfigEdgeKeyword                     Type
+hi def link i3ConfigAction                          Type
+hi def link i3ConfigCommand                         Type
+hi def link i3ConfigOutput                          Type
+hi def link i3ConfigWindowCommandSpecial            Type
+hi def link i3ConfigFocusWrappingType               Type
+hi def link i3ConfigUnitOr                          Type
+hi def link i3ConfigFontSize                        Constant
+hi def link i3ConfigColor                           Constant
+hi def link i3ConfigNumber                          Constant
+hi def link i3ConfigUnit                            Constant
+hi def link i3ConfigVariableAndModifier             Constant
+hi def link i3ConfigTimeUnit                        Constant
+hi def link i3ConfigModifier                        Constant
+hi def link i3ConfigString                          Constant
+hi def link i3ConfigNegativeSize                    Constant
+hi def link i3ConfigFontSeparator                   Special
+hi def link i3ConfigVariableModifier                Special
+hi def link i3ConfigSizeSpecial                     Special
+hi def link i3ConfigWindowSpecial                   Special
+hi def link i3ConfigAssignSpecial                   Special
+hi def link i3ConfigFontNamespace                   PreProc
+hi def link i3ConfigBindArgument                    PreProc
+hi def link i3ConfigNoStartupId                     PreProc
+hi def link i3ConfigFontKeyword                     Identifier
+hi def link i3ConfigBindKeyword                     Identifier
+hi def link i3ConfigOrientation                     Identifier
+hi def link i3ConfigGapStyle                        Identifier
+hi def link i3ConfigTitleAlign                      Identifier
+hi def link i3ConfigSmartGap                        Identifier
+hi def link i3ConfigSmartBorder                     Identifier
+hi def link i3ConfigLayout                          Identifier
+hi def link i3ConfigBorderStyle                     Identifier
+hi def link i3ConfigEdge                            Identifier
+hi def link i3ConfigFloating                        Identifier
+hi def link i3ConfigCommandKeyword                  Identifier
+hi def link i3ConfigNoFocusKeyword                  Identifier
+hi def link i3ConfigInitializeKeyword               Identifier
+hi def link i3ConfigAssignKeyword                   Identifier
+hi def link i3ConfigResourceKeyword                 Identifier
+hi def link i3ConfigExecKeyword                     Identifier
+hi def link i3ConfigWorkspaceKeyword                Identifier
+hi def link i3ConfigClientColorKeyword              Identifier
+hi def link i3ConfigInterprocessKeyword             Identifier
+hi def link i3ConfigMouseWarpingKeyword             Identifier
+hi def link i3ConfigFocusFollowsMouseKeyword        Identifier
+hi def link i3ConfigPopupOnFullscreenKeyword        Identifier
+hi def link i3ConfigFocusWrappingKeyword            Identifier
+hi def link i3ConfigForceXineramaKeyword            Identifier
+hi def link i3ConfigAutomaticSwitchKeyword          Identifier
+hi def link i3ConfigDelayUrgencyKeyword             Identifier
+hi def link i3ConfigFocusOnActivationKeyword        Identifier
+hi def link i3ConfigDrawingMarksKeyword             Identifier
+hi def link i3ConfigBlockKeyword                    Identifier
+hi def link i3ConfigVariable                        Statement
+hi def link i3ConfigArbitraryCommand                Type
+
+let b:current_syntax = "i3config"

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2021 Feb 15
+" Last Change:	2021 Dec 10
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "
@@ -77,13 +77,14 @@ endif
 "
 " The list can be checked using:
 "
-" python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist, compact=True)'
+" python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist + keyword.softkwlist, compact=True)'
 "
 syn keyword pythonStatement	False None True
 syn keyword pythonStatement	as assert break continue del global
 syn keyword pythonStatement	lambda nonlocal pass return with yield
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite
 syn keyword pythonConditional	elif else if
+syn keyword pythonConditional	case match
 syn keyword pythonRepeat	for while
 syn keyword pythonOperator	and in is not or
 syn keyword pythonException	except finally raise try

--- a/runtime/syntax/texinfo.vim
+++ b/runtime/syntax/texinfo.vim
@@ -1,396 +1,46 @@
 " Vim syntax file
-" Language:	Texinfo (macro package for TeX)
-" Maintainer:	Sandor Kopanyi <sandor.kopanyi@mailbox.hu>
-" URL:		<->
-" Last Change:	2004 Jun 23
-"
-" the file follows the Texinfo manual structure; this file is based
-" on manual for Texinfo version 4.0, 28 September 1999
-" since @ can have special meanings, everything is 'match'-ed and 'region'-ed
-" (including @ in 'iskeyword' option has unexpected effects)
+" Language:         Texinfo (documentation format)
+" Maintainer:       Robert Dodier <robert.dodier@gmail.com>
+" Latest Revision:  2021-12-15
 
-" quit when a syntax file was already loaded
 if exists("b:current_syntax")
   finish
 endif
 
-if !exists("main_syntax")
-  let main_syntax = 'texinfo'
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn match texinfoControlSequence display '\(@end [a-zA-Z@]\+\|@[a-zA-Z@]\+\)'
+
+syn match texinfoComment         display '^\s*\(@comment\|@c\)\>.*$'
+
+syn region texinfoCode matchgroup=texinfoControlSequence start="@code{" end="}" contains=ALL
+syn region texinfoVerb matchgroup=texinfoControlSequence start="@verb{" end="}" contains=ALL
+
+syn region texinfoArgument matchgroup=texinfoBrace start="{" end="}" contains=ALLBUT
+
+syn region texinfoExample matchgroup=texinfoControlSequence start="^@example\s*$" end="^@end example\s*$" contains=ALL
+
+syn region texinfoVerbatim matchgroup=texinfoControlSequence start="^@verbatim\s*$" end="^@end verbatim\s*$"
+
+syn region texinfoMenu matchgroup=texinfoControlSequence start="^@menu\s*$" end="^@end menu\s*$"
+
+if exists("g:texinfo_delimiters")
+  syn match texinfoDelimiter display '[][{}]'
 endif
 
-"in Texinfo can be real big things, like tables; sync for that
-syn sync lines=200
-
-"some general stuff
-"syn match texinfoError     "\S" contained TODO
-syn match texinfoIdent	    "\k\+"		  contained "IDENTifier
-syn match texinfoAssignment "\k\+\s*=\s*\k\+\s*$" contained "assigment statement ( var = val )
-syn match texinfoSinglePar  "\k\+\s*$"		  contained "single parameter (used for several @-commands)
-syn match texinfoIndexPar   "\k\k\s*$"		  contained "param. used for different *index commands (+ @documentlanguage command)
-
-
-"marking words and phrases (chap. 9 in Texinfo manual)
-"(almost) everything appears as 'contained' too; is for tables (@table)
-
-"this chapter is at the beginning of this file to avoid overwritings
-
-syn match texinfoSpecialChar				    "@acronym"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@acronym{" end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@b"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@b{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@cite"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@cite{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@code"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@code{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@command"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@command{" end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@dfn"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@dfn{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@email"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@email{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@emph"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@emph{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@env"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@env{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@file"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@file{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@i"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@i{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@kbd"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@kbd{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@key"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@key{"	end="}" contains=texinfoSpecialChar
-syn match texinfoSpecialChar				    "@option"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@option{"	end="}" contains=texinfoSpecialChar
-syn match texinfoSpecialChar				    "@r"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@r{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@samp"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@samp{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@sc"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@sc{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@strong"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@strong{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@t"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@t{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@url"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@url{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoSpecialChar				    "@var"		contained
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@var{"	end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn match texinfoAtCmd "^@kbdinputstyle" nextgroup=texinfoSinglePar skipwhite
-
-
-"overview of Texinfo (chap. 1 in Texinfo manual)
-syn match texinfoComment  "@c .*"
-syn match texinfoComment  "@c$"
-syn match texinfoComment  "@comment .*"
-syn region texinfoMltlnAtCmd matchgroup=texinfoComment start="^@ignore\s*$" end="^@end ignore\s*$" contains=ALL
-
-
-"beginning a Texinfo file (chap. 3 in Texinfo manual)
-syn region texinfoPrmAtCmd     matchgroup=texinfoAtCmd start="@center "		 skip="\\$" end="$"		       contains=texinfoSpecialChar,texinfoBrcPrmAtCmd oneline
-syn region texinfoMltlnDMAtCmd matchgroup=texinfoAtCmd start="^@detailmenu\s*$"		    end="^@end detailmenu\s*$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoPrmAtCmd     matchgroup=texinfoAtCmd start="^@setfilename "    skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd     matchgroup=texinfoAtCmd start="^@settitle "       skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd     matchgroup=texinfoAtCmd start="^@shorttitlepage " skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd     matchgroup=texinfoAtCmd start="^@title "		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoBrcPrmAtCmd  matchgroup=texinfoAtCmd start="@titlefont{"		    end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoMltlnAtCmd   matchgroup=texinfoAtCmd start="^@titlepage\s*$"		    end="^@end titlepage\s*$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoMltlnDMAtCmd,texinfoAtCmd,texinfoPrmAtCmd,texinfoMltlnAtCmd
-syn region texinfoPrmAtCmd     matchgroup=texinfoAtCmd start="^@vskip "		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn match texinfoAtCmd "^@exampleindent"     nextgroup=texinfoSinglePar skipwhite
-syn match texinfoAtCmd "^@headings"	     nextgroup=texinfoSinglePar skipwhite
-syn match texinfoAtCmd "^\\input"	     nextgroup=texinfoSinglePar skipwhite
-syn match texinfoAtCmd "^@paragraphindent"   nextgroup=texinfoSinglePar skipwhite
-syn match texinfoAtCmd "^@setchapternewpage" nextgroup=texinfoSinglePar skipwhite
-
-
-"ending a Texinfo file (chap. 4 in Texinfo manual)
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="@author " skip="\\$" end="$" contains=texinfoSpecialChar oneline
-"all below @bye should be comment TODO
-syn match texinfoAtCmd "^@bye\s*$"
-syn match texinfoAtCmd "^@contents\s*$"
-syn match texinfoAtCmd "^@printindex" nextgroup=texinfoIndexPar skipwhite
-syn match texinfoAtCmd "^@setcontentsaftertitlepage\s*$"
-syn match texinfoAtCmd "^@setshortcontentsaftertitlepage\s*$"
-syn match texinfoAtCmd "^@shortcontents\s*$"
-syn match texinfoAtCmd "^@summarycontents\s*$"
-
-
-"chapter structuring (chap. 5 in Texinfo manual)
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@appendix"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@appendixsec"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@appendixsection"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@appendixsubsec"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@appendixsubsubsec"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@centerchap"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@chapheading"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@chapter"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@heading"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@majorheading"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@section"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@subheading "	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@subsection"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@subsubheading"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@subsubsection"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@subtitle"		 skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@unnumbered"		 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@unnumberedsec"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@unnumberedsubsec"	 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@unnumberedsubsubsec" skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn match  texinfoAtCmd "^@lowersections\s*$"
-syn match  texinfoAtCmd "^@raisesections\s*$"
-
-
-"nodes (chap. 6 in Texinfo manual)
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@anchor{"		  end="}"
-syn region texinfoPrmAtCmd    matchgroup=texinfoAtCmd start="^@top"    skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd    matchgroup=texinfoAtCmd start="^@node"   skip="\\$" end="$" contains=texinfoSpecialChar oneline
-
-
-"menus (chap. 7 in Texinfo manual)
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@menu\s*$" end="^@end menu\s*$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoMltlnDMAtCmd
-
-
-"cross references (chap. 8 in Texinfo manual)
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@inforef{" end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@pxref{"   end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@ref{"     end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@uref{"    end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@xref{"    end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-
-
-"marking words and phrases (chap. 9 in Texinfo manual)
-"(almost) everything appears as 'contained' too; is for tables (@table)
-
-"this chapter is at the beginning of this file to avoid overwritings
-
-
-"quotations and examples (chap. 10 in Texinfo manual)
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@cartouche\s*$"	    end="^@end cartouche\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@display\s*$"	    end="^@end display\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@example\s*$"	    end="^@end example\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@flushleft\s*$"	    end="^@end flushleft\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@flushright\s*$"	    end="^@end flushright\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@format\s*$"	    end="^@end format\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@lisp\s*$"		    end="^@end lisp\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@quotation\s*$"	    end="^@end quotation\s*$"	    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@smalldisplay\s*$"     end="^@end smalldisplay\s*$"    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@smallexample\s*$"     end="^@end smallexample\s*$"    contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@smallformat\s*$"	    end="^@end smallformat\s*$"     contains=ALL
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@smalllisp\s*$"	    end="^@end smalllisp\s*$"	    contains=ALL
-syn region texinfoPrmAtCmd   matchgroup=texinfoAtCmd start="^@exdent"	 skip="\\$" end="$"			    contains=texinfoSpecialChar oneline
-syn match texinfoAtCmd "^@noindent\s*$"
-syn match texinfoAtCmd "^@smallbook\s*$"
-
-
-"lists and tables (chap. 11 in Texinfo manual)
-syn match texinfoAtCmd "@asis"		   contained
-syn match texinfoAtCmd "@columnfractions"  contained
-syn match texinfoAtCmd "@item"		   contained
-syn match texinfoAtCmd "@itemx"		   contained
-syn match texinfoAtCmd "@tab"		   contained
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@enumerate"  end="^@end enumerate\s*$"  contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ftable"     end="^@end ftable\s*$"     contains=ALL
-syn region texinfoMltlnNAtCmd matchgroup=texinfoAtCmd start="^@itemize"    end="^@end itemize\s*$"    contains=ALL
-syn region texinfoMltlnNAtCmd matchgroup=texinfoAtCmd start="^@multitable" end="^@end multitable\s*$" contains=ALL
-syn region texinfoMltlnNAtCmd matchgroup=texinfoAtCmd start="^@table"      end="^@end table\s*$"      contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@vtable"     end="^@end vtable\s*$"     contains=ALL
-
-
-"indices (chap. 12 in Texinfo manual)
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@\(c\|f\|k\|p\|t\|v\)index"   skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@..index"			 skip="\\$" end="$" contains=texinfoSpecialChar oneline
-"@defcodeindex and @defindex is defined after chap. 15's @def* commands (otherwise those ones will overwrite these ones)
-syn match texinfoSIPar "\k\k\s*\k\k\s*$" contained
-syn match texinfoAtCmd "^@syncodeindex" nextgroup=texinfoSIPar skipwhite
-syn match texinfoAtCmd "^@synindex"     nextgroup=texinfoSIPar skipwhite
-
-"special insertions (chap. 13 in Texinfo manual)
-syn match texinfoSpecialChar "@\(!\|?\|@\|\s\)"
-syn match texinfoSpecialChar "@{"
-syn match texinfoSpecialChar "@}"
-"accents
-syn match texinfoSpecialChar "@=."
-syn match texinfoSpecialChar "@\('\|\"\|\^\|`\)[aeiouyAEIOUY]"
-syn match texinfoSpecialChar "@\~[aeinouyAEINOUY]"
-syn match texinfoSpecialChar "@dotaccent{.}"
-syn match texinfoSpecialChar "@H{.}"
-syn match texinfoSpecialChar "@,{[cC]}"
-syn match texinfoSpecialChar "@AA{}"
-syn match texinfoSpecialChar "@aa{}"
-syn match texinfoSpecialChar "@L{}"
-syn match texinfoSpecialChar "@l{}"
-syn match texinfoSpecialChar "@O{}"
-syn match texinfoSpecialChar "@o{}"
-syn match texinfoSpecialChar "@ringaccent{.}"
-syn match texinfoSpecialChar "@tieaccent{..}"
-syn match texinfoSpecialChar "@u{.}"
-syn match texinfoSpecialChar "@ubaraccent{.}"
-syn match texinfoSpecialChar "@udotaccent{.}"
-syn match texinfoSpecialChar "@v{.}"
-"ligatures
-syn match texinfoSpecialChar "@AE{}"
-syn match texinfoSpecialChar "@ae{}"
-syn match texinfoSpecialChar "@copyright{}"
-syn match texinfoSpecialChar "@bullet" contained "for tables and lists
-syn match texinfoSpecialChar "@bullet{}"
-syn match texinfoSpecialChar "@dotless{i}"
-syn match texinfoSpecialChar "@dotless{j}"
-syn match texinfoSpecialChar "@dots{}"
-syn match texinfoSpecialChar "@enddots{}"
-syn match texinfoSpecialChar "@equiv" contained "for tables and lists
-syn match texinfoSpecialChar "@equiv{}"
-syn match texinfoSpecialChar "@error{}"
-syn match texinfoSpecialChar "@exclamdown{}"
-syn match texinfoSpecialChar "@expansion{}"
-syn match texinfoSpecialChar "@minus" contained "for tables and lists
-syn match texinfoSpecialChar "@minus{}"
-syn match texinfoSpecialChar "@OE{}"
-syn match texinfoSpecialChar "@oe{}"
-syn match texinfoSpecialChar "@point" contained "for tables and lists
-syn match texinfoSpecialChar "@point{}"
-syn match texinfoSpecialChar "@pounds{}"
-syn match texinfoSpecialChar "@print{}"
-syn match texinfoSpecialChar "@questiondown{}"
-syn match texinfoSpecialChar "@result" contained "for tables and lists
-syn match texinfoSpecialChar "@result{}"
-syn match texinfoSpecialChar "@ss{}"
-syn match texinfoSpecialChar "@TeX{}"
-"other
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@dmn{"      end="}"
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@footnote{" end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@image{"    end="}"
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@math{"     end="}"
-syn match texinfoAtCmd "@footnotestyle" nextgroup=texinfoSinglePar skipwhite
-
-
-"making and preventing breaks (chap. 14 in Texinfo manual)
-syn match texinfoSpecialChar  "@\(\*\|-\|\.\)"
-syn match texinfoAtCmd	      "^@need"	   nextgroup=texinfoSinglePar skipwhite
-syn match texinfoAtCmd	      "^@page\s*$"
-syn match texinfoAtCmd	      "^@sp"	   nextgroup=texinfoSinglePar skipwhite
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@group\s*$"   end="^@end group\s*$" contains=ALL
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@hyphenation{" end="}"
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@w{"	    end="}"		  contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-
-
-"definition commands (chap. 15 in Texinfo manual)
-syn match texinfoMltlnAtCmdFLine "^@def\k\+" contained
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@def\k\+" end="^@end def\k\+$"      contains=ALL
-
-"next 2 commands are from chap. 12; must be defined after @def* commands above to overwrite them
-syn match texinfoAtCmd "@defcodeindex" nextgroup=texinfoIndexPar skipwhite
-syn match texinfoAtCmd "@defindex" nextgroup=texinfoIndexPar skipwhite
-
-
-"conditionally visible text (chap. 16 in Texinfo manual)
-syn match texinfoAtCmd "^@clear" nextgroup=texinfoSinglePar skipwhite
-syn region texinfoMltln2AtCmd matchgroup=texinfoAtCmd start="^@html\s*$"	end="^@end html\s*$"
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifclear"		end="^@end ifclear\s*$"   contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifhtml"		end="^@end ifhtml\s*$"	  contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifinfo"		end="^@end ifinfo\s*$"	  contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifnothtml"	end="^@end ifnothtml\s*$" contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifnotinfo"	end="^@end ifnotinfo\s*$" contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifnottex"	end="^@end ifnottex\s*$"  contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@ifset"		end="^@end ifset\s*$"	  contains=ALL
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@iftex"		end="^@end iftex\s*$"	  contains=ALL
-syn region texinfoPrmAtCmd    matchgroup=texinfoAtCmd start="^@set " skip="\\$" end="$" contains=texinfoSpecialChar oneline
-syn region texinfoTexCmd			      start="\$\$"		end="\$\$" contained
-syn region texinfoMltlnAtCmd  matchgroup=texinfoAtCmd start="^@tex"		end="^@end tex\s*$"	  contains=texinfoTexCmd
-syn region texinfoBrcPrmAtCmd matchgroup=texinfoAtCmd start="@value{"		end="}" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-
-
-"internationalization (chap. 17 in Texinfo manual)
-syn match texinfoAtCmd "@documentencoding" nextgroup=texinfoSinglePar skipwhite
-syn match texinfoAtCmd "@documentlanguage" nextgroup=texinfoIndexPar skipwhite
-
-
-"defining new texinfo commands (chap. 18 in Texinfo manual)
-syn match texinfoAtCmd	"@alias"		      nextgroup=texinfoAssignment skipwhite
-syn match texinfoDIEPar "\S*\s*,\s*\S*\s*,\s*\S*\s*$" contained
-syn match texinfoAtCmd	"@definfoenclose"	      nextgroup=texinfoDIEPar	  skipwhite
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@macro" end="^@end macro\s*$" contains=ALL
-
-
-"formatting hardcopy (chap. 19 in Texinfo manual)
-syn match texinfoAtCmd "^@afourlatex\s*$"
-syn match texinfoAtCmd "^@afourpaper\s*$"
-syn match texinfoAtCmd "^@afourwide\s*$"
-syn match texinfoAtCmd "^@finalout\s*$"
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@pagesizes" end="$" oneline
-
-
-"creating and installing Info Files (chap. 20 in Texinfo manual)
-syn region texinfoPrmAtCmd   matchgroup=texinfoAtCmd start="^@dircategory"  skip="\\$" end="$" oneline
-syn region texinfoMltlnAtCmd matchgroup=texinfoAtCmd start="^@direntry\s*$"	       end="^@end direntry\s*$" contains=texinfoSpecialChar
-syn match  texinfoAtCmd "^@novalidate\s*$"
-
-
-"include files (appendix E in Texinfo manual)
-syn match texinfoAtCmd "^@include" nextgroup=texinfoSinglePar skipwhite
-
-
-"page headings (appendix F in Texinfo manual)
-syn match texinfoHFSpecialChar "@|"		  contained
-syn match texinfoThisAtCmd     "@thischapter"	  contained
-syn match texinfoThisAtCmd     "@thischaptername" contained
-syn match texinfoThisAtCmd     "@thisfile"	  contained
-syn match texinfoThisAtCmd     "@thispage"	  contained
-syn match texinfoThisAtCmd     "@thistitle"	  contained
-syn match texinfoThisAtCmd     "@today{}"	  contained
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@evenfooting"  skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoThisAtCmd,texinfoHFSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@evenheading"  skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoThisAtCmd,texinfoHFSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@everyfooting" skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoThisAtCmd,texinfoHFSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@everyheading" skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoThisAtCmd,texinfoHFSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@oddfooting"   skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoThisAtCmd,texinfoHFSpecialChar oneline
-syn region texinfoPrmAtCmd matchgroup=texinfoAtCmd start="^@oddheading"   skip="\\$" end="$" contains=texinfoSpecialChar,texinfoBrcPrmAtCmd,texinfoThisAtCmd,texinfoHFSpecialChar oneline
-
-
-"refilling paragraphs (appendix H in Texinfo manual)
-syn match  texinfoAtCmd "@refill"
-
-
-syn cluster texinfoAll contains=ALLBUT,texinfoThisAtCmd,texinfoHFSpecialChar
-syn cluster texinfoReducedAll contains=texinfoSpecialChar,texinfoBrcPrmAtCmd
-"==============================================================================
-" highlighting
-
-" Only when an item doesn't have highlighting yet
-
-hi def link texinfoSpecialChar	Special
-hi def link texinfoHFSpecialChar	Special
-
-hi def link texinfoError		Error
-hi def link texinfoIdent		Identifier
-hi def link texinfoAssignment	Identifier
-hi def link texinfoSinglePar	Identifier
-hi def link texinfoIndexPar	Identifier
-hi def link texinfoSIPar		Identifier
-hi def link texinfoDIEPar		Identifier
-hi def link texinfoTexCmd		PreProc
-
-
-hi def link texinfoAtCmd		Statement	"@-command
-hi def link texinfoPrmAtCmd	String		"@-command in one line with unknown nr. of parameters
-					      "is String because is found as a region and is 'matchgroup'-ed
-					      "to texinfoAtCmd
-hi def link texinfoBrcPrmAtCmd	String		"@-command with parameter(s) in braces ({})
-					      "is String because is found as a region and is 'matchgroup'-ed to texinfoAtCmd
-hi def link texinfoMltlnAtCmdFLine  texinfoAtCmd	"repeated embedded First lines in @-commands
-hi def link texinfoMltlnAtCmd	String		"@-command in multiple lines
-					      "is String because is found as a region and is 'matchgroup'-ed to texinfoAtCmd
-hi def link texinfoMltln2AtCmd	PreProc		"@-command in multiple lines (same as texinfoMltlnAtCmd, just with other colors)
-hi def link texinfoMltlnDMAtCmd	PreProc		"@-command in multiple lines (same as texinfoMltlnAtCmd, just with other colors; used for @detailmenu, which can be included in @menu)
-hi def link texinfoMltlnNAtCmd	Normal		"@-command in multiple lines (same as texinfoMltlnAtCmd, just with other colors)
-hi def link texinfoThisAtCmd	Statement	"@-command used in headers and footers (@this... series)
-
-hi def link texinfoComment	Comment
-
-
+hi def link texinfoDelimiter       Delimiter
+hi def link texinfoComment         Comment
+hi def link texinfoControlSequence Identifier
+hi def link texinfoBrace           Operator
+hi def link texinfoArgument        Special
+hi def link texinfoExample         String
+hi def link texinfoVerbatim        String
+hi def link texinfoVerb            String
+hi def link texinfoCode            String
+hi def link texinfoMenu            String
 
 let b:current_syntax = "texinfo"
 
-if main_syntax == 'texinfo'
-  unlet main_syntax
-endif
-
-" vim: ts=8
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/0e6adf8a29d5c2c96c42cc7157f71bf22c2ad471

skip runtime/optwin.vim (included in #16618)
skip runtime/map.vim (needs 8.2.3619)
