### PR TITLE
fix(diagnostic): assert that diagnostics have line number and column

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -272,6 +272,8 @@ end
 ---@private
 local function set_diagnostic_cache(namespace, bufnr, diagnostics)
   for _, diagnostic in ipairs(diagnostics) do
+    assert(diagnostic.lnum, "Diagnostic line number is required")
+    assert(diagnostic.col, "Diagnostic column is required")
     diagnostic.severity = diagnostic.severity and to_severity(diagnostic.severity) or M.severity.ERROR
     diagnostic.end_lnum = diagnostic.end_lnum or diagnostic.lnum
     diagnostic.end_col = diagnostic.end_col or diagnostic.col


### PR DESCRIPTION
Line number and column are required and much of the diagnostic API
assumes that these are both present. When one of the two is missing,
cryptic errors pop up in other parts of the diagnostic subsystem.
Instead, assert that diagnostics are well formed when they are entered
into the cache, which provides a clearer error.

Conflicts with #16675.