### PR TITLE
test(put_spec): call clear() in reset()

### DIFF
--- a/test/functional/editor/put_spec.lua
+++ b/test/functional/editor/put_spec.lua
@@ -15,6 +15,7 @@ local dedent = helpers.dedent
 local getreg = funcs.getreg
 
 local function reset()
+  clear()
   feed_command('enew!')
   insert([[
   Line of words 1


### PR DESCRIPTION
This seems to make tests less flaky.