### PR TITLE
Only warn about offset encoding differences once per buffer

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1766,13 +1766,17 @@ function M._get_offset_encoding(bufnr)
   }
 
   local offset_encoding
+  local ok, _ = pcall(vim.api.nvim_buf_get_var, bufnr, "__lsp_offset_encoding_warn")
 
   for _, client in pairs(vim.lsp.buf_get_clients(bufnr)) do
     local this_offset_encoding = client.offset_encoding or "utf-16"
     if not offset_encoding then
       offset_encoding = this_offset_encoding
     elseif offset_encoding ~= this_offset_encoding then
-      vim.notify("warning: multiple different client offset_encodings detected for buffer, this is not supported yet", vim.log.levels.WARN)
+      if not ok then
+        vim.notify("warning: multiple different client offset_encodings detected for buffer, this is not supported yet", vim.log.levels.WARN)
+        vim.api.nvim_buf_set_var(bufnr, "__lsp_offset_encoding_warn", true)
+      end
     end
   end
 


### PR DESCRIPTION
Not sure if this is the right way to go about doing this, but after the commit [here](https://github.com/neovim/neovim/commit/22d7dd2aec9053028cc033e4c68335a81f845e06) every time I type in insert-mode with `clangd` (reports `{ "utf-8", "utf-16" }`) and `null-ls` (reports `"utf-16"`) attached attached to a buffer, I get this warning.

Perhaps there is something deeper going on where I should be forcing a client to use a particular encoding? If that is the case, feel free to close this.

Otherwise, it seems sufficient to only warn about this once per buffer; it can be assaulting to have it every time this function is called (especially if using something like `nvim-notify`).