### PR TITLE
vim-patch:8.2.{2563,2569}: 'fillchars' "stl" and "stlnc" items must be single byte

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2450,7 +2450,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	This is similar to the default, except that these characters will also
 	be used when there is highlighting.
 
-	for "stl" and "stlnc" only single-byte values are supported.
+	For "stl" and "stlnc" single-byte and multibyte characters are
+	supported.  But double-width characters are not supported.
 
 	The highlighting used for these items:
 	  item		highlight group ~

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -19,6 +19,7 @@
 #include "nvim/ascii.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
+#include "nvim/charset.h"
 #include "nvim/context.h"
 #include "nvim/decoration.h"
 #include "nvim/edit.h"
@@ -2221,7 +2222,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
   Dictionary result = ARRAY_DICT_INIT;
 
   int maxwidth;
-  char fillchar = 0;
+  int fillchar = 0;
   Window window = 0;
   bool use_tabline = false;
   bool highlights = false;
@@ -2236,12 +2237,14 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
   }
 
   if (HAS_KEY(opts->fillchar)) {
-    if (opts->fillchar.type != kObjectTypeString || opts->fillchar.data.string.size > 1) {
-      api_set_error(err, kErrorTypeValidation, "fillchar must be an ASCII character");
+    if (opts->fillchar.type != kObjectTypeString
+        || vim_strnsize((char_u *)opts->fillchar.data.string.data,
+                        (int)opts->fillchar.data.string.size) != 1) {
+      api_set_error(err, kErrorTypeValidation, "fillchar must be a single-width character");
       return result;
     }
 
-    fillchar = opts->fillchar.data.string.data[0];
+    fillchar = utf_ptr2char((char_u *)opts->fillchar.data.string.data);
   }
 
   if (HAS_KEY(opts->highlights)) {
@@ -2272,7 +2275,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
 
     if (fillchar == 0) {
       int attr;
-      fillchar = (char)fillchar_status(&attr, wp);
+      fillchar = fillchar_status(&attr, wp);
     }
   }
 
@@ -2300,7 +2303,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
                                sizeof(buf),
                                (char_u *)str.data,
                                false,
-                               (char_u)fillchar,
+                               fillchar,
                                maxwidth,
                                hltab_ptr,
                                NULL);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3418,7 +3418,7 @@ typedef enum {
 ///
 /// @return The final width of the statusline
 int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use_sandbox,
-                     char_u fillchar, int maxwidth, stl_hlrec_t **hltab, StlClickRecord **tabtab)
+                     int fillchar, int maxwidth, stl_hlrec_t **hltab, StlClickRecord **tabtab)
 {
   static size_t stl_items_len = 20;  // Initial value, grows as needed.
   static stl_item_t *stl_items = NULL;
@@ -3461,9 +3461,6 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
   if (fillchar == 0) {
     fillchar = ' ';
-  } else if (utf_char2len(fillchar) > 1) {
-    // Can't handle a multi-byte fill character yet.
-    fillchar = '-';
   }
 
   // The cursor in windows other than the current one isn't always
@@ -3661,7 +3658,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
         out_p = out_p - n + 1;
         // Fill up space left over by half a double-wide char.
         while (++group_len < stl_items[stl_groupitems[groupdepth]].minwid) {
-          *out_p++ = fillchar;
+          MB_CHAR2BYTES(fillchar, out_p);
         }
         // }
 
@@ -3684,14 +3681,14 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
         if (min_group_width < 0) {
           min_group_width = 0 - min_group_width;
           while (group_len++ < min_group_width && out_p < out_end_p) {
-            *out_p++ = fillchar;
+            MB_CHAR2BYTES(fillchar, out_p);
           }
           // If the group is right-aligned, shift everything to the right and
           // prepend with filler characters.
         } else {
           // { Move the group to the right
-          memmove(t + min_group_width - group_len, t, (size_t)(out_p - t));
-          group_len = min_group_width - group_len;
+          group_len = (min_group_width - group_len) * utf_char2len(fillchar);
+          memmove(t + group_len, t, (size_t)(out_p - t));
           if (out_p + group_len >= (out_end_p + 1)) {
             group_len = (long)(out_end_p - out_p);
           }
@@ -3705,7 +3702,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
           // Prepend the fill characters
           for (; group_len > 0; group_len--) {
-            *t++ = fillchar;
+            MB_CHAR2BYTES(fillchar, t);
           }
         }
       }
@@ -4237,7 +4234,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
           if (l + 1 == minwid && fillchar == '-' && ascii_isdigit(*t)) {
             *out_p++ = ' ';
           } else {
-            *out_p++ = fillchar;
+            MB_CHAR2BYTES(fillchar, out_p);
           }
         }
         minwid = 0;
@@ -4248,20 +4245,21 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
       }
 
       // { Copy the string text into the output buffer
-      while (*t && out_p < out_end_p) {
-        *out_p++ = *t++;
+      for (; *t && out_p < out_end_p; t++) {
         // Change a space by fillchar, unless fillchar is '-' and a
         // digit follows.
-        if (fillable && out_p[-1] == ' '
-            && (!ascii_isdigit(*t) || fillchar != '-')) {
-          out_p[-1] = fillchar;
+        if (fillable && *t == ' '
+            && (!ascii_isdigit(*(t + 1)) || fillchar != '-')) {
+          MB_CHAR2BYTES(fillchar, out_p);
+        } else {
+          *out_p++ = *t;
         }
       }
       // }
 
       // For left-aligned items, fill any remaining space with the fillchar
       for (; l < minwid && out_p < out_end_p; l++) {
-        *out_p++ = fillchar;
+        MB_CHAR2BYTES(fillchar, out_p);
       }
 
       // Otherwise if the item is a number, copy that to the output buffer.
@@ -4454,7 +4452,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
       // Fill up for half a double-wide character.
       while (++width < maxwidth) {
-        *trunc_p++ = fillchar;
+        MB_CHAR2BYTES(fillchar, trunc_p);
         *trunc_p = NUL;
       }
       // }
@@ -4505,13 +4503,13 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
                          standard_spaces * (num_separators - 1);
 
       for (int i = 0; i < num_separators; i++) {
-        int dislocation = (i == (num_separators - 1))
-                          ? final_spaces : standard_spaces;
+        int dislocation = (i == (num_separators - 1)) ? final_spaces : standard_spaces;
+        dislocation *= utf_char2len(fillchar);
         char_u *start = stl_items[stl_separator_locations[i]].start;
         char_u *seploc = start + dislocation;
         STRMOVE(seploc, start);
-        for (char_u *s = start; s < seploc; s++) {
-          *s = fillchar;
+        for (char_u *s = start; s < seploc; ) {
+          MB_CHAR2BYTES(fillchar, s);
         }
 
         for (int item_idx = stl_separator_locations[i] + 1;

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -105,6 +105,9 @@
 #define MB_PTR_BACK(s, p) \
   (p -= utf_head_off((char_u *)s, (char_u *)p - 1) + 1)
 
+// MB_CHAR2BYTES(): convert character to bytes and advance pointer to bytes
+#define MB_CHAR2BYTES(c, b) ((b) += utf_char2bytes((c), (b)))
+
 #define RESET_BINDING(wp) \
   do { \
     (wp)->w_p_scb = false; \

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1960,7 +1960,7 @@ static size_t fill_foldcolumn(char_u *p, win_T *wp, foldinfo_T foldinfo, linenr_
   level = foldinfo.fi_level;
 
   // If the column is too narrow, we start at the lowest level that
-  // fits and use numbers to indicated the depth.
+  // fits and use numbers to indicate the depth.
   first_level = level - fdc - closed + 1;
   if (first_level < 1) {
     first_level = 1;

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -9,7 +9,7 @@ let s:did_load = 1
 " Align Nvim defaults to Vim.
 set backspace=
 set directory^=.
-set fillchars=vert:\|,fold:-
+set fillchars=vert:\|,fold:-,foldsep:\|
 set laststatus=1
 set listchars=eol:$
 set joinspaces

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -924,6 +924,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
   1,6fold
   call assert_equal([a:fc .. '  +--  6 '], ScreenLines(1, 10))
   " open all the folds
+  if !has('nvim')  " Skip this part: Nvim doesn't force an empty column
   normal zR
   call assert_equal([
         \ a:fo .. '  one    ',
@@ -961,6 +962,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ '2 five ',
         \ a:fs .. ' six  ',
         \ ], ScreenLines([1, 6], 7))
+  endif  " if !has('nvim')
 
   " set the fold column size to 1
   setlocal fdc=1
@@ -974,6 +976,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ a:fs .. 'six   ',
         \ ], ScreenLines([1, 6], 7))
 
+  if !has('nvim')  " Skip this part: Nvim doesn't force an empty column
   " Enable number and sign columns and place some signs
   setlocal fdc=3
   setlocal number
@@ -1032,6 +1035,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ a:fo .. a:fo .. ' one ',
         \ a:fs .. a:fs .. ' two '
         \ ], ScreenLines([1, 2], 7))
+  endif  " if !has('nvim')
 
   setlocal foldcolumn& number& signcolumn&
 endfunc

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -974,7 +974,66 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ a:fs .. 'six   ',
         \ ], ScreenLines([1, 6], 7))
 
-  setlocal foldcolumn&
+  " Enable number and sign columns and place some signs
+  setlocal fdc=3
+  setlocal number
+  setlocal signcolumn=auto
+  sign define S1 text=->
+  sign place 10 line=3 name=S1
+  call assert_equal([
+        \ a:fo .. '      1 one  ',
+        \ a:fs .. a:fo .. '     2 two  ',
+        \ '2' .. a:fo .. ' ->  3 three',
+        \ '23     4 four ',
+        \ a:fs .. a:fs .. '     5 five ',
+        \ a:fs .. '      6 six  '
+        \ ], ScreenLines([1, 6], 14))
+
+  " Test with 'rightleft'
+  if has('rightleft')
+    setlocal rightleft
+    let lines = ScreenLines([1, 6], winwidth(0))
+    call assert_equal('o 1      ' .. a:fo,
+          \  strcharpart(lines[0], strchars(lines[0]) - 10, 10))
+    call assert_equal('t 2     ' .. a:fo .. a:fs,
+          \  strcharpart(lines[1], strchars(lines[1]) - 10, 10))
+    call assert_equal('t 3  >- ' .. a:fo .. '2',
+          \  strcharpart(lines[2], strchars(lines[2]) - 10, 10))
+    call assert_equal('f 4     32',
+          \  strcharpart(lines[3], strchars(lines[3]) - 10, 10))
+    call assert_equal('f 5     ' .. a:fs .. a:fs,
+          \  strcharpart(lines[4], strchars(lines[4]) - 10, 10))
+    call assert_equal('s 6      ' .. a:fs,
+          \  strcharpart(lines[5], strchars(lines[5]) - 10, 10))
+    setlocal norightleft
+  endif
+
+  sign unplace *
+  sign undefine S1
+  setlocal number& signcolumn&
+
+  " Add a test with more than 9 folds (and then delete some folds)
+  normal zE
+  for i in range(1, 10)
+    normal zfGzo
+  endfor
+  normal zR
+  call assert_equal([
+        \ a:fo .. a:fo .. ' one ',
+        \ '9> two '
+        \ ], ScreenLines([1, 2], 7))
+  normal 1Gzd
+  call assert_equal([
+        \ a:fo .. a:fo .. ' one ',
+        \ '89 two '
+        \ ], ScreenLines([1, 2], 7))
+  normal 1Gzdzdzdzdzdzdzd
+  call assert_equal([
+        \ a:fo .. a:fo .. ' one ',
+        \ a:fs .. a:fs .. ' two '
+        \ ], ScreenLines([1, 2], 7))
+
+  setlocal foldcolumn& number& signcolumn&
 endfunc
 
 func Test_foldcolumn_multibyte_char()

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -498,5 +498,20 @@ func Test_statusline_after_split_vsplit()
   set ls& stl&
 endfunc
 
+" Test using a multibyte character for 'stl' and 'stlnc' items in 'fillchars'
+" with a custom 'statusline'
+func Test_statusline_mbyte_fillchar()
+  only
+  set laststatus=2
+  set fillchars=vert:\|,fold:-,stl:━,stlnc:═
+  set statusline=a%=b
+  call assert_match('^a\+━\+b$', s:get_statusline())
+  vnew
+  call assert_match('^a\+━\+b━a\+═\+b$', s:get_statusline())
+  wincmd w
+  call assert_match('^a\+═\+b═a\+━\+b$', s:get_statusline())
+  set statusline& fillchars& laststatus&
+  %bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2485,6 +2485,24 @@ describe('API', function()
           'Should be truncated%<',
           { maxwidth = 15 }))
     end)
+    it('supports ASCII fillchar', function()
+      eq({ str = 'a~~~b', width = 5 }, meths.eval_statusline('a%=b', { fillchar = '~', maxwidth = 5 }))
+    end)
+    it('supports single-cell multibyte fillchar', function()
+      eq({ str = 'a━━━b', width = 5 }, meths.eval_statusline('a%=b', { fillchar = '━', maxwidth = 5 }))
+    end)
+    it('rejects double-width fillchar', function()
+      eq('fillchar must be a single-width character',
+        pcall_err(meths.eval_statusline, '', { fillchar = '哦' }))
+    end)
+    it('rejects control character fillchar', function()
+      eq('fillchar must be a single-width character',
+        pcall_err(meths.eval_statusline, '', { fillchar = '\a' }))
+    end)
+    it('rejects multiple characters fillchar', function()
+      eq('fillchar must be a single-width character',
+        pcall_err(meths.eval_statusline, '', { fillchar = 'aa' }))
+    end)
     describe('highlight parsing', function()
       it('works', function()
         eq({

--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -249,7 +249,7 @@ describe('buffer functions', function()
     --
     -- @param arg Options can be placed in an optional dictionary as the last parameter
     --    .expected_cell_count The expected number of cells build_stl_str_hl will return
-    --    .expected_byte_length The expected byte length of the string
+    --    .expected_byte_length The expected byte length of the string (defaults to byte length of expected_stl)
     --    .file_name The name of the file to be tested (useful in %f type tests)
     --    .fillchar The character that will be used to fill any 'extra' space in the stl
     local function statusline_test (description,
@@ -264,7 +264,7 @@ describe('buffer functions', function()
 
       local fillchar = option.fillchar or (' '):byte()
       local expected_cell_count = option.expected_cell_count or statusline_cell_count
-      local expected_byte_length = option.expected_byte_length or expected_cell_count
+      local expected_byte_length = option.expected_byte_length or #expected_stl
 
       itp(description, function()
         if option.file_name then
@@ -314,7 +314,7 @@ describe('buffer functions', function()
       {fillchar=('~'):byte()})
     statusline_test('should put fillchar `━` in between text', 10,
       'abc%=def',            'abc━━━━def',
-      {fillchar=0x2501, expected_byte_length=18})
+      {fillchar=0x2501})
     statusline_test('should handle zero-fillchar as a space', 10,
       'abcde%=',             'abcde     ',
       {fillchar=0})
@@ -366,70 +366,86 @@ describe('buffer functions', function()
 
     statusline_test('should ignore trailing %', 3, 'abc%', 'abc')
 
-    -- alignment testing
-    statusline_test('should right align when using =', 20,
-      'neo%=vim',            'neo              vim')
-    statusline_test('should, when possible, center text when using %=text%=', 20,
-      'abc%=neovim%=def',    'abc    neovim    def')
-    statusline_test('should handle uneven spacing in the buffer when using %=text%=', 20,
-      'abc%=neo_vim%=def',   'abc   neo_vim    def')
-    statusline_test('should have equal spaces even with non-equal sides when using =', 20,
-      'foobar%=test%=baz',   'foobar   test    baz')
-    statusline_test('should have equal spaces even with longer right side when using =', 20,
-      'a%=test%=longtext',   'a   test    longtext')
-    statusline_test('should handle an empty left side when using ==', 20,
-      '%=test%=baz',         '      test       baz')
-    statusline_test('should handle an empty right side when using ==', 20,
-      'foobar%=test%=',      'foobar     test     ')
-    statusline_test('should handle consecutive empty ==', 20,
-      '%=%=test%=',          '          test      ')
-    statusline_test('should handle an = alone', 20,
-      '%=',                  '                    ')
-    statusline_test('should right align text when it is alone with =', 20,
-      '%=foo',               '                 foo')
-    statusline_test('should left align text when it is alone with =', 20,
-      'foo%=',               'foo                 ')
+    -- alignment testing with fillchar
+    local function statusline_test_align (description,
+                                                       statusline_cell_count,
+                                                       input_stl,
+                                                       expected_stl,
+                                                       arg)
+      arg = arg or {}
+      statusline_test(description .. ' without fillchar',
+        statusline_cell_count, input_stl, expected_stl:gsub('%~', ' '), arg)
+      arg.fillchar = ('!'):byte()
+      statusline_test(description .. ' with fillchar `!`',
+        statusline_cell_count, input_stl, expected_stl:gsub('%~', '!'), arg)
+      arg.fillchar = 0x2501
+      statusline_test(description .. ' with fillchar `━`',
+        statusline_cell_count, input_stl, expected_stl:gsub('%~', '━'), arg)
+    end
 
-    statusline_test('should approximately center text when using %=text%=', 21,
-      'abc%=neovim%=def',    'abc    neovim     def')
-    statusline_test('should completely fill the buffer when using %=text%=', 21,
-      'abc%=neo_vim%=def',   'abc    neo_vim    def')
-    statusline_test('should have equal spaces even with non-equal sides when using =', 21,
-      'foobar%=test%=baz',   'foobar    test    baz')
-    statusline_test('should have equal spaces even with longer right side when using =', 21,
-      'a%=test%=longtext',   'a    test    longtext')
-    statusline_test('should handle an empty left side when using ==', 21,
-      '%=test%=baz',         '       test       baz')
-    statusline_test('should handle an empty right side when using ==', 21,
-      'foobar%=test%=',      'foobar     test      ')
+    statusline_test_align('should right align when using =', 20,
+      'neo%=vim',            'neo~~~~~~~~~~~~~~vim')
+    statusline_test_align('should, when possible, center text when using %=text%=', 20,
+      'abc%=neovim%=def',    'abc~~~~neovim~~~~def')
+    statusline_test_align('should handle uneven spacing in the buffer when using %=text%=', 20,
+      'abc%=neo_vim%=def',   'abc~~~neo_vim~~~~def')
+    statusline_test_align('should have equal spaces even with non-equal sides when using =', 20,
+      'foobar%=test%=baz',   'foobar~~~test~~~~baz')
+    statusline_test_align('should have equal spaces even with longer right side when using =', 20,
+      'a%=test%=longtext',   'a~~~test~~~~longtext')
+    statusline_test_align('should handle an empty left side when using ==', 20,
+      '%=test%=baz',         '~~~~~~test~~~~~~~baz')
+    statusline_test_align('should handle an empty right side when using ==', 20,
+      'foobar%=test%=',      'foobar~~~~~test~~~~~')
+    statusline_test_align('should handle consecutive empty ==', 20,
+      '%=%=test%=',          '~~~~~~~~~~test~~~~~~')
+    statusline_test_align('should handle an = alone', 20,
+      '%=',                  '~~~~~~~~~~~~~~~~~~~~')
+    statusline_test_align('should right align text when it is alone with =', 20,
+      '%=foo',               '~~~~~~~~~~~~~~~~~foo')
+    statusline_test_align('should left align text when it is alone with =', 20,
+      'foo%=',               'foo~~~~~~~~~~~~~~~~~')
 
-    statusline_test('should quadrant the text when using 3 %=', 40,
-      'abcd%=n%=eovim%=ef',  'abcd         n         eovim          ef')
-    statusline_test('should work well with %t', 40,
-      '%t%=right_aligned',   'buffer_spec.lua            right_aligned',
+    statusline_test_align('should approximately center text when using %=text%=', 21,
+      'abc%=neovim%=def',    'abc~~~~neovim~~~~~def')
+    statusline_test_align('should completely fill the buffer when using %=text%=', 21,
+      'abc%=neo_vim%=def',   'abc~~~~neo_vim~~~~def')
+    statusline_test_align('should have equal spacing even with non-equal sides when using =', 21,
+      'foobar%=test%=baz',   'foobar~~~~test~~~~baz')
+    statusline_test_align('should have equal spacing even with longer right side when using =', 21,
+      'a%=test%=longtext',   'a~~~~test~~~~longtext')
+    statusline_test_align('should handle an empty left side when using ==', 21,
+      '%=test%=baz',         '~~~~~~~test~~~~~~~baz')
+    statusline_test_align('should handle an empty right side when using ==', 21,
+      'foobar%=test%=',      'foobar~~~~~test~~~~~~')
+
+    statusline_test_align('should quadrant the text when using 3 %=', 40,
+      'abcd%=n%=eovim%=ef',  'abcd~~~~~~~~~n~~~~~~~~~eovim~~~~~~~~~~ef')
+    statusline_test_align('should work well with %t', 40,
+      '%t%=right_aligned',   'buffer_spec.lua~~~~~~~~~~~~right_aligned',
       {file_name='test/unit/buffer_spec.lua'})
-    statusline_test('should work well with %t and regular text', 40,
-      'l%=m_l %t m_r%=r',    'l       m_l buffer_spec.lua m_r        r',
+    statusline_test_align('should work well with %t and regular text', 40,
+      'l%=m_l %t m_r%=r',    'l~~~~~~~m_l buffer_spec.lua m_r~~~~~~~~r',
       {file_name='test/unit/buffer_spec.lua'})
-    statusline_test('should work well with %=, %t, %L, and %l', 40,
-      '%t %= %L %= %l',      'buffer_spec.lua           1            0',
+    statusline_test_align('should work well with %=, %t, %L, and %l', 40,
+      '%t %= %L %= %l',      'buffer_spec.lua ~~~~~~~~~ 1 ~~~~~~~~~~ 0',
       {file_name='test/unit/buffer_spec.lua'})
 
-    statusline_test('should quadrant the text when using 3 %=', 41,
-      'abcd%=n%=eovim%=ef',  'abcd         n         eovim           ef')
-    statusline_test('should work well with %t', 41,
-      '%t%=right_aligned',   'buffer_spec.lua             right_aligned',
+    statusline_test_align('should quadrant the text when using 3 %=', 41,
+      'abcd%=n%=eovim%=ef',  'abcd~~~~~~~~~n~~~~~~~~~eovim~~~~~~~~~~~ef')
+    statusline_test_align('should work well with %t', 41,
+      '%t%=right_aligned',   'buffer_spec.lua~~~~~~~~~~~~~right_aligned',
       {file_name='test/unit/buffer_spec.lua'})
-    statusline_test('should work well with %t and regular text', 41,
-      'l%=m_l %t m_r%=r',    'l        m_l buffer_spec.lua m_r        r',
+    statusline_test_align('should work well with %t and regular text', 41,
+      'l%=m_l %t m_r%=r',    'l~~~~~~~~m_l buffer_spec.lua m_r~~~~~~~~r',
       {file_name='test/unit/buffer_spec.lua'})
-    statusline_test('should work well with %=, %t, %L, and %l', 41,
-      '%t %= %L %= %l',      'buffer_spec.lua            1            0',
+    statusline_test_align('should work well with %=, %t, %L, and %l', 41,
+      '%t %= %L %= %l',      'buffer_spec.lua ~~~~~~~~~~ 1 ~~~~~~~~~~ 0',
       {file_name='test/unit/buffer_spec.lua'})
 
-    statusline_test('should work with 10 %=', 50,
+    statusline_test_align('should work with 10 %=', 50,
       'aaaa%=b%=c%=d%=e%=fg%=hi%=jk%=lmnop%=qrstuv%=wxyz',
-      'aaaa  b  c  d  e  fg  hi  jk  lmnop  qrstuv   wxyz')
+      'aaaa~~b~~c~~d~~e~~fg~~hi~~jk~~lmnop~~qrstuv~~~wxyz')
 
     -- stl item testing
     local tabline = ''
@@ -452,11 +468,10 @@ describe('buffer functions', function()
 
     -- multi-byte testing
     statusline_test('should handle multibyte characters', 10,
-      'Ĉ%=x',                'Ĉ        x',
-      {expected_byte_length=11})
+      'Ĉ%=x',                'Ĉ        x')
     statusline_test('should handle multibyte characters and different fillchars', 10,
       'Ą%=mid%=end',         'Ą@mid@@end',
-      {fillchar=('@'):byte(), expected_byte_length=11})
+      {fillchar=('@'):byte()})
 
     -- escaping % testing
     statusline_test('should handle escape of %', 4, 'abc%%', 'abc%')

--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -312,12 +312,12 @@ describe('buffer functions', function()
     statusline_test('should put fillchar `~` in between text', 10,
       'abc%=def',            'abc~~~~def',
       {fillchar=('~'):byte()})
+    statusline_test('should put fillchar `━` in between text', 10,
+      'abc%=def',            'abc━━━━def',
+      {fillchar=0x2501, expected_byte_length=18})
     statusline_test('should handle zero-fillchar as a space', 10,
       'abcde%=',             'abcde     ',
       {fillchar=0})
-    statusline_test('should handle multibyte-fillchar as a dash', 10,
-      'abcde%=',             'abcde-----',
-      {fillchar=0x80})
     statusline_test('should print the tail file name', 80,
       '%t',                  'buffer_spec.lua',
       {file_name='test/unit/buffer_spec.lua', expected_cell_count=15})


### PR DESCRIPTION
Fix #15993

#### vim-patch:8.2.2563: cannot use multibyte characters for folding in 'fillchars'

Problem:    Cannot use multibyte characters for folding in 'fillchars'.
Solution:   Port pull request 11568 to Vim. (Yegappan Lakshmanan,
            closes vim/vim#7924)
https://github.com/vim/vim/commit/4fa1175765d55613302fc27d0f65e2c699452b6e

Nvim has already implemented this, so this just ports the tests.

Skip test_profile.vim: vim9script


#### vim-patch:8.2.2569: 'fillchars' "stl" and "stlnc" items must be single byte

Problem:    'fillchars' "stl" and "stlnc" items must be single byte.
Solution:   Accept multi-byte characters. (Christian Wellenbrock, Yegappan
            Lakshmanan, closes vim/vim#7927)
https://github.com/vim/vim/commit/008bff967f7fcaa6af066f71d65bfbba5ef5c7d3

- [x] ~Fix fold tests~ I skipped tests where Nvim diverges from Vim. I'm not very sure about this.
- [x] Add more statusline-related tests