### PR TITLE
fix: update last cursor on first CursorMoved

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -932,6 +932,12 @@ static int do_autocmd_event(event_T event, char_u *pat, bool once, int nested, c
           last_mode = get_mode();
         }
 
+        //  If the event is CursorMoved, update the last cursor position
+        //  position to avoid immediately triggering the autocommand
+        if (event == EVENT_CURSORMOVED && !has_event(EVENT_CURSORMOVED)) {
+          curwin->w_last_cursormoved = curwin->w_cursor;
+        }
+
         ap->cmds = NULL;
         *prev_ap = ap;
         last_autopat[(int)event] = ap;

--- a/test/functional/autocmd/cursormoved_spec.lua
+++ b/test/functional/autocmd/cursormoved_spec.lua
@@ -31,4 +31,12 @@ describe('CursorMoved', function()
     eq({'aaa'}, funcs.nvim_buf_get_lines(eval('g:buf'), 0, -1, true))
     eq(0, eval('g:cursormoved'))
   end)
+
+  it("is not triggered by cursor movement prior to first CursorMoved instantiation", function()
+    source([[
+    let g:cursormoved = 0
+    autocmd CursorMoved * let g:cursormoved += 1
+    ]])
+    eq(0, eval('g:cursormoved'))
+  end)
 end)


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/16625
Closes https://github.com/neovim/neovim/issues/12923

Supersedes https://github.com/neovim/neovim/pull/13867

The first defined CursorMoved autocommand will immediately
fire if the cursor has previously moved upon definition
of the autocommand.

Plugins add dummy autocommands such as:

```lua
autocmd CursorMoved * execute ''
```

to avoid this behavior.

Instead, when defining a new CursorHold autocommand, force
update the last cursor position.

See https://github.com/vim/vim/issues/2053