### PR TITLE
vim-patch:8.2.3843: dep3patch files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -811,6 +811,23 @@ func dist#ft#Redif()
   endwhile
 endfunc
 
+" This function is called for all files under */debian/patches/*, make sure not
+" to non-dep3patch files, such as README and other text files.
+func dist#ft#Dep3patch()
+  if expand('%:t') ==# 'series'
+    return
+  endif
+
+  for ln in getline(1, 100)
+    if ln =~# '^\%(Description\|Subject\|Origin\|Bug\|Forwarded\|Author\|From\|Reviewed-by\|Acked-by\|Last-Updated\|Applied-Upstream\):'
+      setf dep3patch
+      return
+    elseif ln =~# '^---'
+      " end of headers found. stop processing
+      return
+    endif
+  endfor
+endfunc
 
 " Restore 'cpoptions'
 let &cpo = s:cpo_save

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -486,6 +486,9 @@ au BufNewFile,BufRead dict.conf,.dictrc		setf dictconf
 " Dictd config
 au BufNewFile,BufRead dictd*.conf		setf dictdconf
 
+" DEP3 formatted patch files
+au BufNewFile,BufRead */debian/patches/*	call dist#ft#Dep3patch()
+
 " Diff files
 au BufNewFile,BufRead *.diff,*.rej		setf diff
 au BufNewFile,BufRead *.patch


### PR DESCRIPTION
Problem:    Dep3patch files are not recognized.
Solution:   Recognize dep3patch files by their location and content. (James
            McCoy, closes vim/vim#9367)
https://github.com/vim/vim/commit/647ab4cede4dbf412d24748f8e0a64d1cb9239f4