### PR TITLE
vim-patch:8.2.{2508,2641,3846}

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -116,10 +116,12 @@ other windows.  If 'mouse' is enabled, a status line can be dragged to resize
 windows.
 
 							*filler-lines*
-The lines after the last buffer line in a window are called filler lines.
-These lines start with a tilde (~) character. By default, these are
-highlighted as NonText (|hl-NonText|). The EndOfBuffer highlight group
-(|hl-EndOfBuffer|) can be used to change the highlighting of filler lines.
+The lines after the last buffer line in a window are called filler lines.  By
+default, these lines start with a tilde (~) character. The 'eob' item in the
+'fillchars' option can be used to change this character. By default, these
+characters are highlighted as NonText (|hl-NonText|). The EndOfBuffer
+highlight group (|hl-EndOfBuffer|) can be used to change the highlighting of
+the filler characters.
 
 ==============================================================================
 3. Opening and closing a window				*opening-window* *E36*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3610,7 +3610,7 @@ static char *set_chars_option(win_T *wp, char_u **varp, bool set)
           c2 = c3 = 0;
           s = p + len + 1;
           c1 = get_encoded_char_adv(&s);
-          if (c1 == 0 || utf_char2cells(c1) > 1) {
+          if (c1 == 0 || char2cells(c1) > 1) {
             return e_invarg;
           }
           if (tab[i].cp == &wp->w_p_lcs_chars.tab2) {
@@ -3618,12 +3618,12 @@ static char *set_chars_option(win_T *wp, char_u **varp, bool set)
               return e_invarg;
             }
             c2 = get_encoded_char_adv(&s);
-            if (c2 == 0 || utf_char2cells(c2) > 1) {
+            if (c2 == 0 || char2cells(c2) > 1) {
               return e_invarg;
             }
             if (!(*s == ',' || *s == NUL)) {
               c3 = get_encoded_char_adv(&s);
-              if (c3 == 0 || utf_char2cells(c3) > 1) {
+              if (c3 == 0 || char2cells(c3) > 1) {
                 return e_invarg;
               }
             }
@@ -3657,7 +3657,7 @@ static char *set_chars_option(win_T *wp, char_u **varp, bool set)
             multispace_len = 0;
             while (*s != NUL && *s != ',') {
               c1 = get_encoded_char_adv(&s);
-              if (c1 == 0 || utf_char2cells(c1) > 1) {
+              if (c1 == 0 || char2cells(c1) > 1) {
                 return e_invarg;
               }
               multispace_len++;

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -263,6 +263,28 @@ func Test_display_scroll_at_topline()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for 'eob' (EndOfBuffer) item in 'fillchars'
+func Test_eob_fillchars()
+  " default value (skipped)
+  " call assert_match('eob:\~', &fillchars)
+  " invalid values
+  call assert_fails(':set fillchars=eob:', 'E474:')
+  call assert_fails(':set fillchars=eob:xy', 'E474:')
+  call assert_fails(':set fillchars=eob:\255', 'E474:')
+  call assert_fails(':set fillchars=eob:<ff>', 'E474:')
+  " default is ~
+  new
+  call assert_equal('~', Screenline(2))
+  set fillchars=eob:+
+  redraw!
+  call assert_equal('+', Screenline(2))
+  set fillchars=eob:\ 
+  redraw!
+  call assert_equal(' ', nr2char(screenchar(2, 1)))
+  set fillchars&
+  close
+endfunc
+
 func Test_display_linebreak_breakat()
   new
   vert resize 25

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -272,6 +272,8 @@ func Test_eob_fillchars()
   call assert_fails(':set fillchars=eob:xy', 'E474:')
   call assert_fails(':set fillchars=eob:\255', 'E474:')
   call assert_fails(':set fillchars=eob:<ff>', 'E474:')
+  call assert_fails(":set fillchars=eob:\x01", 'E474:')
+  call assert_fails(':set fillchars=eob:\\x01', 'E474:')
   " default is ~
   new
   redraw

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -274,12 +274,13 @@ func Test_eob_fillchars()
   call assert_fails(':set fillchars=eob:<ff>', 'E474:')
   " default is ~
   new
+  redraw
   call assert_equal('~', Screenline(2))
   set fillchars=eob:+
-  redraw!
+  redraw
   call assert_equal('+', Screenline(2))
   set fillchars=eob:\ 
-  redraw!
+  redraw
   call assert_equal(' ', nr2char(screenchar(2, 1)))
   set fillchars&
   close

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -331,13 +331,27 @@ func Test_listchars_invalid()
   call assert_fails('set listchars=space:xx', 'E474:')
   call assert_fails('set listchars=tab:xxxx', 'E474:')
 
-  " Has non-single width character
+  " Has double-width character
   call assert_fails('set listchars=space:·', 'E474:')
   call assert_fails('set listchars=tab:·x', 'E474:')
   call assert_fails('set listchars=tab:x·', 'E474:')
   call assert_fails('set listchars=tab:xx·', 'E474:')
   call assert_fails('set listchars=multispace:·', 'E474:')
   call assert_fails('set listchars=multispace:xxx·', 'E474:')
+
+  " Has control character
+  call assert_fails("set listchars=space:\x01", 'E474:')
+  call assert_fails("set listchars=tab:\x01x", 'E474:')
+  call assert_fails("set listchars=tab:x\x01", 'E474:')
+  call assert_fails("set listchars=tab:xx\x01", 'E474:')
+  call assert_fails("set listchars=multispace:\x01", 'E474:')
+  call assert_fails("set listchars=multispace:xxx\x01", 'E474:')
+  call assert_fails('set listchars=space:\\x01', 'E474:')
+  call assert_fails('set listchars=tab:\\x01x', 'E474:')
+  call assert_fails('set listchars=tab:x\\x01', 'E474:')
+  call assert_fails('set listchars=tab:xx\\x01', 'E474:')
+  call assert_fails('set listchars=multispace:\\x01', 'E474:')
+  call assert_fails('set listchars=multispace:xxx\\x01', 'E474:')
 
   enew!
   set ambiwidth& listchars& ff&


### PR DESCRIPTION
#### vim-patch:8.2.2508: cannot change the character displayed in non existing lines

Problem:    Cannot change the character displayed in non existing lines.
Solution:   Add the "eob" item to 'fillchars'. (closes vim/vim#7832)
https://github.com/vim/vim/commit/a98f8a230596d8fb44cc68321de72980a21428cb

Nvim has already implemented this feature, so this just ports the tests
and docs.

#### vim-patch:8.2.2641: display test fails because of lacking redraw

Problem:    Display test fails because of lacking redraw.
Solution:   Add a redraw command.
https://github.com/vim/vim/commit/2cec027af461095f96dec3bfd036c267f790b0f4

#### vim-patch:8.2.3846: no error when using control character for 'lcs' or 'fcs'

Problem:    No error when using control character for 'lcs' or 'fcs'.
Solution:   Use char2cells() to check the width. (closes vim/vim#9369)
https://github.com/vim/vim/commit/60618c8f1a7ea55452837a446525272142286471