### PR TITLE
test: allow excluding functional/unti tests using TEST_FILTER_OUT

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -46,6 +46,10 @@ if(DEFINED ENV{TEST_FILTER} AND NOT "$ENV{TEST_FILTER}" STREQUAL "")
   list(APPEND BUSTED_ARGS --filter $ENV{TEST_FILTER})
 endif()
 
+if(DEFINED ENV{TEST_FILTER_OUT} AND NOT "$ENV{TEST_FILTER_OUT}" STREQUAL "")
+  list(APPEND BUSTED_ARGS --filter-out $ENV{TEST_FILTER_OUT})
+endif()
+
 # TMPDIR: use relative test path (for parallel test runs / isolation).
 set(ENV{TMPDIR} "${BUILD_DIR}/Xtest_tmpdir/${TEST_PATH}")
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{TMPDIR})

--- a/test/README.md
+++ b/test/README.md
@@ -116,7 +116,7 @@ Filtering Tests
 
 ### Filter by name
 
-Another filter method is by setting a pattern of test name to `TEST_FILTER`.
+Another filter method is by setting a pattern of test name to `TEST_FILTER` or `TEST_FILTER_OUT`.
 
 ``` lua
 it('foo api',function()
@@ -130,6 +130,10 @@ end)
 To run only test with filter name:
 
     TEST_FILTER='foo.*api' make functionaltest
+
+To run all tests except ones matching a filter:
+
+    TEST_FILTER_OUT='foo.*api' make functionaltest
 
 ### Filter by file
 


### PR DESCRIPTION
Although this can already be done using `BUSTED_ARGS`, it complements our existing shortcut of `TEST_FILTER.`