### PR TITLE
fix(build): check for empty value of LUAC_PRG

### DIFF
--- a/src/nvim/generators/gen_char_blob.lua
+++ b/src/nvim/generators/gen_char_blob.lua
@@ -28,6 +28,7 @@ local target = io.open(target_file, 'w')
 
 target:write('#include <stdint.h>\n\n')
 
+local warn_on_missing_compiler = true
 local varnames = {}
 for argi = 2, #arg, 2 do
   local source_file = arg[argi]
@@ -42,10 +43,11 @@ for argi = 2, #arg, 2 do
   local output
   if options.c then
     local luac = os.getenv("LUAC_PRG")
-    if luac then
+    if luac and luac ~= "" then
       output = io.popen(luac:format(source_file), "r"):read("*a")
-    else
-      print("LUAC_PRG is undefined")
+    elseif warn_on_missing_compiler then
+      print("LUAC_PRG is missing, embedding raw source")
+      warn_on_missing_compiler = false
     end
   end
 


### PR DESCRIPTION
If the `LUAC_PRG` environment variable is defined, but empty, compilation
would still be attempted but would be malformed. This results in garbage
bytes being included.

Fix this by checking that `LUAC_PRG` is both defined *and* non-empty.

Ref #16709, #16690, #16688