### PR TITLE
fix(lsp): avoid attaching to unloaded buffers

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1156,6 +1156,12 @@ function lsp.buf_attach_client(bufnr, client_id)
     client_id = {client_id, 'n'};
   }
   bufnr = resolve_bufnr(bufnr)
+  if not vim.api.nvim_buf_is_loaded(bufnr) then
+    local _ = log.warn() and log.warn(
+      string.format("buf_attach_client called on unloaded buffer (id: %d): ", bufnr)
+    )
+    return false
+  end
   local buffer_client_ids = all_buffer_active_clients[bufnr]
   -- This is our first time attaching to this buffer.
   if not buffer_client_ids then


### PR DESCRIPTION
Closes neovim#16562 
Closes neovim#16249 
Closes neovim#16297

* buf_attach_client can be called on an unloaded buffer
* on_attach will prematurely fail, while the language server client
  tracks this buffer as attached
* The language server client will track this buffer as attached despite
  textDocument/didChange notifications not being sent to the server
* Instead, check if the buffer is loaded and return early, warning via
  the lsp logger that buf_attach_client was called on an invalid buffer