### PR TITLE
vim-patch:8.2.{3850,3855}

### DIFF
--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2565,20 +2565,20 @@ static void nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
     ga_concat(indent, (char_u *)"| ");
   else
     ga_concat(indent, (char_u *)"  ");
-  ga_append(indent, '\0');
+  ga_append(indent, NUL);
 
   nfa_print_state2(debugf, state->out, indent);
 
   /* replace last part of indent for state->out1 */
   indent->ga_len -= 3;
   ga_concat(indent, (char_u *)"  ");
-  ga_append(indent, '\0');
+  ga_append(indent, NUL);
 
   nfa_print_state2(debugf, state->out1, indent);
 
   /* shrink indent */
   indent->ga_len -= 3;
-  ga_append(indent, '\0');
+  ga_append(indent, NUL);
 }
 
 /*

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -346,4 +346,12 @@ func Test_blob_sort()
   endif
 endfunc
 
+" The following used to cause an out-of-bounds memory access
+func Test_blob2string()
+  let v = '0z' .. repeat('01010101.', 444)
+  let v ..= '01'
+  exe 'let b = ' .. v
+  call assert_equal(v, string(b))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -113,6 +113,6 @@ endfunc
 func Test_echo_string_partial()
   function CountSpaces()
   endfunction
-  echomsg function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])
+  call assert_equal("function('CountSpaces', [{'ccccccccccc': ['ab', 'cd'], 'aaaaaaaaaaa': v:false, 'bbbbbbbbbbbb': ''}])", string(function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])))
 endfunc
 

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -108,3 +108,11 @@ func Test_echospace()
 
   set ruler& showcmd&
 endfunc
+
+" this was missing a terminating NUL
+func Test_echo_string_partial()
+  function CountSpaces()
+  endfunction
+  echomsg function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])
+endfunc
+


### PR DESCRIPTION
- vim-patch:8.2.3850: illegal memory access when displaying a partial
- vim-patch:8.2.3855: illegal memory access when displaying a blob
