### PR TITLE
vim-patch:8.1.0040: warnings from 64-bit compiler

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1685,7 +1685,7 @@ static void init_prompt(int cmdchar_todo)
   // Insert always starts after the prompt, allow editing text after it.
   if (Insstart_orig.lnum != curwin->w_cursor.lnum || Insstart_orig.col != (colnr_T)STRLEN(prompt)) {
     Insstart.lnum = curwin->w_cursor.lnum;
-    Insstart.col = STRLEN(prompt);
+    Insstart.col = (colnr_T)STRLEN(prompt);
     Insstart_orig = Insstart;
     Insstart_textlen = Insstart.col;
     Insstart_blank_vcol = MAXCOL;
@@ -1696,7 +1696,7 @@ static void init_prompt(int cmdchar_todo)
     coladvance(MAXCOL);
   }
   if (curwin->w_cursor.col < (colnr_T)STRLEN(prompt)) {
-    curwin->w_cursor.col = STRLEN(prompt);
+    curwin->w_cursor.col = (colnr_T)STRLEN(prompt);
   }
   // Make sure the cursor is in a valid position.
   check_cursor();


### PR DESCRIPTION
Problem:    Warnings from 64-bit compiler.
Solution:   Add type casts. (Mike Williams)
https://github.com/vim/vim/commit/e31e256ba1769a3a3ed7840d5cc9a01ab058b8bc
