### PR TITLE
docs: stop suggestion "good first issue" as a good first issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you want to help but don't know where to start, here are some
 low-risk/isolated tasks:
 
 - [Merge a Vim patch].
-- Try a [good first issue](../../labels/good-first-issue) or [complexity:low] issue.
+- Try a [complexity:low] issue.
 - Fix bugs found by [Clang](#clang-scan-build), [PVS](#pvs-studio) or
   [Coverity](#coverity).
 - [Improve documentation][wiki-contribute-help]


### PR DESCRIPTION
They're simply too difficult and too niche for an actual newcomer to
solve them. Instead, use the "complexity:low" as a substitute.