### PR TITLE
fix(buffer_updates): save and restore current window cursor

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -356,6 +356,7 @@ In-process Lua plugins can receive buffer updates in the form of Lua
 callbacks. These callbacks are called frequently in various contexts;
 |textlock| prevents changing buffer contents and window layout (use
 |vim.schedule()| to defer such operations to the main loop instead).
+Moving the cursor is allowed, but it is restored afterwards.
 
 |nvim_buf_attach()| will take keyword args for the callbacks. "on_lines" will
 receive parameters ("lines", {buf}, {changedtick}, {firstline}, {lastline},

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -155,8 +155,18 @@ typedef struct {
     msglist_T *private_msg_list; \
     msg_list = &private_msg_list; \
     private_msg_list = NULL; \
-    code \
-      msg_list = saved_msg_list;  /* Restore the exception context. */ \
+    code; \
+    msg_list = saved_msg_list;  /* Restore the exception context. */ \
+  } while (0)
+
+// Execute code with cursor position saved and restored and textlock active.
+#define TEXTLOCK_WRAP(code) \
+  do { \
+    const pos_T save_cursor = curwin->w_cursor; \
+    textlock++; \
+    code; \
+    textlock--; \
+    curwin->w_cursor = save_cursor; \
   } while (0)
 
 // Useful macro for executing some `code` for each item in an array.

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -317,7 +317,18 @@ describe('lua buffer event callbacks: on_lines', function()
     feed('1G0')
     feed('P')
     eq(meths.get_var('linesev'), { "lines", 1, 6, 0, 3, 3, 9 })
+  end)
 
+  it('calling nvim_buf_call() from callback does not cause Normal mode CTRL-A to misbehave #16729', function()
+    exec_lua([[
+      vim.api.nvim_buf_attach(0, false, {
+        on_lines = function(...)
+          vim.api.nvim_buf_call(0, function() end)
+        end,
+      })
+    ]])
+    feed('itest123<Esc><C-A>')
+    eq('test124', meths.get_current_line())
   end)
 end)
 


### PR DESCRIPTION
Fix #16729

When a buffer update callback is called, textlock is active so buffer text cannot be changed, but cursor can still be moved. This can cause problems when the buffer update is in the middle of an operator, like the one mentioned in #16729. The solution is to save cursor position and restore it afterwards, like how cursor is saved and restored when evaluating an `<expr>` mapping.

The test I added fails on `master`:
```
[  ERROR   ] test/functional/lua/buffer_updates_spec.lua @ 299: lua buffer event callbacks: on_lines calling nvim_buf_call() from callback does not cause Normal mode CTRL-A to misbehave #16729
test/helpers.lua:73: Expected objects to be the same.
Passed in:
(string) 'tes124t'
Expected:
(string) 'test124'
```