### PR TITLE
refactor: remove some chdir-related unnecessary calls and checks

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1082,15 +1082,13 @@ static void f_chdir(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   // Return the current directory
   cwd = xmalloc(MAXPATHL);
-  if (cwd != NULL) {
-    if (os_dirname(cwd, MAXPATHL) != FAIL) {
+  if (os_dirname(cwd, MAXPATHL) != FAIL) {
 #ifdef BACKSLASH_IN_FILENAME
-      slash_adjust(cwd);
+    slash_adjust(cwd);
 #endif
-      rettv->vval.v_string = vim_strsave(cwd);
-    }
-    xfree(cwd);
+    rettv->vval.v_string = vim_strsave(cwd);
   }
+  xfree(cwd);
 
   if (curwin->w_localdir != NULL) {
     scope = kCdScopeWindow;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7816,8 +7816,9 @@ bool changedir_func(char_u *new_dir, CdScope scope)
   }
 #endif
 
-  if (vim_chdir(new_dir) == 0) {
-    bool dir_differs = pdir == NULL || pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
+  bool dir_differs = new_dir == NULL || pdir == NULL
+    || pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
+  if (new_dir != NULL && (!dir_differs || vim_chdir(new_dir) == 0)) {
     post_chdir(scope, dir_differs);
     retval = true;
   } else {

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1667,12 +1667,17 @@ int vim_chdirfile(char_u *fname, CdCause cause)
     NameBuff[0] = NUL;
   }
 
-  if (os_chdir(dir) == 0) {
-    if (cause != kCdCauseOther && pathcmp(dir, (char *)NameBuff, -1) != 0) {
-      do_autocmd_dirchanged(dir, kCdScopeWindow, cause);
-    }
-  } else {
+  if (pathcmp(dir, (char *)NameBuff, -1) == 0) {
+    // nothing to do
+    return OK;
+  }
+
+  if (os_chdir(dir) != 0) {
     return FAIL;
+  }
+
+  if (cause != kCdCauseOther) {
+    do_autocmd_dirchanged(dir, kCdScopeWindow, cause);
   }
 
   return OK;


### PR DESCRIPTION
`xmalloc()` always retuns a valid pointer.

Calling `os_chdir()` with the same directory as the current one doesn't do anything other than wasting time.