### PR TITLE
vim-patch:8.2.3543: swapname has double slash when 'directory' ends in it

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1462,11 +1462,11 @@ int recover_names(char_u *fname, int list, int nr, char_u **fname_out)
   return file_count;
 }
 
-/*
- * Append the full path to name with path separators made into percent
- * signs, to dir. An unnamed buffer is handled as "" (<currentdir>/"")
- */
-char *make_percent_swname(const char *dir, const char *name)
+// Append the full path to name with path separators made into percent
+// signs, to "dir". An unnamed buffer is handled as "" (<currentdir>/"")
+// The last character in "dir" must be an extra slash or backslash, it is
+// removed.
+char *make_percent_swname(char *dir, const char *name)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   char *d = NULL;
@@ -1478,6 +1478,7 @@ char *make_percent_swname(const char *dir, const char *name)
         *d = '%';
       }
     }
+    dir[STRLEN(dir) - 1] = NUL;  // remove one trailing slash
     d = concat_fnames(dir, s, TRUE);
     xfree(s);
     xfree(f);

--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -366,7 +366,7 @@ func Test_swap_symlink()
 
   " Check that this also works when 'directory' ends with '//'
   edit Xtestlink
-  call assert_match('Xtestfile\.swp$', s:swapname())
+  call assert_match('Xswapdir[/\\]%.*testdir%Xtestfile\.swp$', s:swapname())
   bwipe!
 
   set dir&


### PR DESCRIPTION
Fix #14110

#### vim-patch:8.2.3543: swapname has double slash when 'directory' ends in it

Problem:    Swapname has double slash when 'directory' ends in double slash.
            (Shane Smith)
Solution:   Remove the superfluous slash.
https://github.com/vim/vim/commit/8b0e62c93b6dad5ec5b2c7558d4f7b78c46216d2