### PR TITLE
terminal: Implement OSC 7 (CWD, current directory)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -617,6 +617,22 @@ A jump table for the options with a short description can be found at |Q_op|.
 	or selected.
 	Note: When this option is on some plugins may not work.
 
+			*'autoshelldir'* *'asd'* *'noautoshelldir'* *'noasd'*
+'autoshelldir' 'asd'	boolean (default off)
+			global
+	When on, Vim will change the current working directory whenever you
+	change the directory of the shell running in a terminal window. You
+	need proper setting-up, so whenever the shell's pwd changes an OSC 7
+	escape sequence will be emitted. For example, with zsh, you can add
+	the following to your zshrc:
+		if [[ ! -v chpwd_functions ]]; then
+		    chpwd_functions=()
+		fi
+		function print_osc7 () {
+		    printf "\033]7;file://$HOST/$PWD\033\\"
+		}
+		chpwd_functions+=print_osc7
+
 				*'arabic'* *'arab'* *'noarabic'* *'noarab'*
 'arabic' 'arab'		boolean (default off)
 			local to window

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -602,6 +602,7 @@ Short explanation of each option:		*option-list*
 'allowrevins'	  'ari'     allow CTRL-_ in Insert and Command-line mode
 'ambiwidth'	  'ambw'    what to do with Unicode chars of ambiguous width
 'autochdir'	  'acd'     change directory to the file in the current window
+'autoshelldir'	  'asd'     change directory to the shell's current directory
 'arabic'	  'arab'    for Arabic as a default second language
 'arabicshape'	  'arshape' do shaping for Arabic characters
 'autoindent'	  'ai'	    take indent for new line from previous line

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -267,6 +267,8 @@ if exists("+autochdir")
   call append("$", "autochdir\tchange to directory of file in buffer")
   call <SID>BinOptionG("acd", &acd)
 endif
+call append("$", "autoshelldir\tchange to pwd of shell in terminal buffer")
+call <SID>BinOptionG("asd", &asd)
 call append("$", "wrapscan\tsearch commands wrap around the end of the buffer")
 call <SID>BinOptionG("ws", &ws)
 call append("$", "incsearch\tshow match for partly typed search command")

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2835,6 +2835,13 @@ void buf_name_changed(buf_T *buf)
   ml_timestamp(buf);            // reset timestamp
 }
 
+/// Generate a terminal buffer name of the form "term://$CWD//$PID:$CMD" in buf.
+void buf_name_for_term(char_u *buf, size_t size, const char_u *cwd, varnumber_T pid,
+                       const char *cmd)
+{
+  snprintf((char *)buf, size, "term://%s//%li:%s", cwd, (long int)pid, cmd);
+}
+
 /// Set alternate file name for current window
 ///
 /// Used by do_one_cmd(), do_write() and do_ecmd().

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -307,6 +307,7 @@ enum {
 
 EXTERN long p_aleph;            // 'aleph'
 EXTERN int p_acd;               // 'autochdir'
+EXTERN int p_asd;               // 'autoshelldir'
 EXTERN char_u *p_ambw;        // 'ambiwidth'
 EXTERN int p_ar;                // 'autoread'
 EXTERN int p_aw;                // 'autowrite'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -97,6 +97,13 @@ return {
       defaults={if_true=false}
     },
     {
+      full_name='autoshelldir', abbreviation='asd',
+      short_desc=N_("change directory to the shell's current directory"),
+      type='bool', scope={'global'},
+      varname='p_asd',
+      defaults={if_true=false}
+    },
+    {
       full_name='autoindent', abbreviation='ai',
       short_desc=N_("take indent for new line from previous line"),
       type='bool', scope={'buffer'},

--- a/test/functional/options/autochdir_spec.lua
+++ b/test/functional/options/autochdir_spec.lua
@@ -6,7 +6,7 @@ local funcs = helpers.funcs
 local command = helpers.command
 
 describe("'autochdir'", function()
-  it('given on the shell gets processed properly', function()
+  it('given on the shell using --cmd gets processed properly', function()
     local targetdir = 'test/functional/fixtures'
 
     -- By default 'autochdir' is off, thus getcwd() returns the repo root.
@@ -40,5 +40,17 @@ describe("'autochdir'", function()
     eq(dir_a, funcs.getcwd())
     helpers.rmdir(dir_a)
     helpers.rmdir(dir_b)
+  end)
+
+  it('extracts CWD from term:// URI', function()
+    clear()
+    local targetdir = 'test/functional/fixtures'
+    local rootdir = funcs.getcwd()
+    local expected = rootdir .. '/' .. targetdir
+    funcs.chdir(targetdir)
+    command('terminal')
+    funcs.chdir(rootdir)
+    command('set autochdir')
+    eq(helpers.iswin() and expected:gsub('/', '\\') or expected, funcs.getcwd())
   end)
 end)


### PR DESCRIPTION
This commit introduces a new 'autoshelldir' setting controlling whether
Neovim should aknowledge OSC7 sequences emitted by the programs running
in its terminal buffer.

The OSC7 sequence is sent by the child process to indicate that its
current working directory changed.

When Neovim receives OSC7, it stores the received path in a buffer-local
variable named "terminal_job_cwd", which is available to the user. It
also stores the path as the terminal buffer's name. This enables
'autochdir' to work as expected with buffer terminals.

Note that Vim also has a setting named 'autoshelldir' that does
something similar. This setting was implemented in patch 8.2.2675
(Vim commit 8b9abfd86c736ed3f298dfa8b50a962c118b3983). However, Vim's
approach has several drawbacks causing possible desynchronization
between the child process' cwd and the parent window. This is why this
patch isn't a port of Vim's feature, but a new implementation. However,
in the hope of sharing code with Vim in the future, an attempt was made
to keep function names and interfaces similar to Vim's. Moreover, the
url_decode function was imported as-is.

This closes #2252.