### PR TITLE
vim-patch:8.2.3874

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -122,8 +122,9 @@ See |sign_define()| for the equivalent Vim script function.
 		in.  Most useful is defining a background color.
 
 	numhl={group}
-                Highlighting group used for 'number' column at the associated
-                line.  Overrides |hl-LineNr|, |hl-CursorLineNr|.
+		Highlighting group used for the line number on the line where
+		the sign is placed.  Overrides |hl-LineNr|, |hl-LineNrAbove|,
+		|hl-LineNrBelow|, and |hl-CursorLineNr|.
 
 	text={text}						*E239*
 		Define the text that is displayed when there is no icon or the

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -1740,7 +1740,7 @@ char_u *get_sign_name(expand_T *xp, int idx)
   case EXP_SUBCMD:
     return (char_u *)cmds[idx];
   case EXP_DEFINE: {
-    char *define_arg[] = { "icon=", "linehl=", "text=", "texthl=", "numhl=",
+    char *define_arg[] = { "culhl=", "icon=", "linehl=", "numhl=", "text=", "texthl=",
                            NULL };
     return (char_u *)define_arg[idx];
   }
@@ -1849,6 +1849,7 @@ void set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     case SIGNCMD_DEFINE:
       if (STRNCMP(last, "texthl", 6) == 0
           || STRNCMP(last, "linehl", 6) == 0
+          || STRNCMP(last, "culhl", 5) == 0
           || STRNCMP(last, "numhl", 5) == 0) {
         xp->xp_context = EXPAND_HIGHLIGHT;
       } else if (STRNCMP(last, "icon", 4) == 0) {

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -218,15 +218,13 @@ func Test_sign_completion()
   call assert_equal('"sign define jump list place undefine unplace', @:)
 
   call feedkeys(":sign define Sign \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign icon= linehl= numhl= text= texthl=', @:)
+  call assert_equal('"sign define Sign culhl= icon= linehl= numhl= text= texthl=', @:)
 
-  call feedkeys(":sign define Sign linehl=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign linehl=SpellBad SpellCap ' .
-	      \ 'SpellLocal SpellRare', @:)
-
-  call feedkeys(":sign define Sign texthl=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign texthl=SpellBad SpellCap ' .
-	      \ 'SpellLocal SpellRare', @:)
+  for hl in ['culhl', 'linehl', 'numhl', 'texthl']
+    call feedkeys(":sign define Sign "..hl.."=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"sign define Sign '..hl..'=SpellBad SpellCap ' .
+                \ 'SpellLocal SpellRare', @:)
+  endfor
 
   call writefile(repeat(["Sun is shining"], 30), "XsignOne")
   call writefile(repeat(["Sky is blue"], 30), "XsignTwo")
@@ -417,20 +415,21 @@ func Test_sign_funcs()
 
   " Tests for sign_define()
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error',
-              \ 'culhl': 'Visual'}
+              \ 'culhl': 'Visual', 'numhl': 'Number'}
   call assert_equal(0, "sign1"->sign_define(attr))
-  call assert_equal([{'name' : 'sign1', 'texthl' : 'Error',
-	      \ 'linehl' : 'Search', 'culhl': 'Visual', 'text' : '=>'}],
+  call assert_equal([{'name' : 'sign1', 'texthl' : 'Error', 'linehl': 'Search',
+	      \ 'culhl': 'Visual', 'numhl': 'Number', 'text' : '=>'}],
               \ sign_getdefined())
 
   " Define a new sign without attributes and then update it
   call sign_define("sign2")
   let attr = {'text' : '!!', 'linehl' : 'DiffAdd', 'texthl' : 'DiffChange',
-	      \ 'culhl': 'DiffDelete', 'icon' : 'sign2.ico'}
+	      \ 'culhl': 'DiffDelete', 'numhl': 'Number', 'icon' : 'sign2.ico'}
   call Sign_define_ignore_error("sign2", attr)
   call assert_equal([{'name' : 'sign2', 'texthl' : 'DiffChange',
 	      \ 'linehl' : 'DiffAdd', 'culhl' : 'DiffDelete', 'text' : '!!',
-              \ 'icon' : 'sign2.ico'}], "sign2"->sign_getdefined())
+              \ 'numhl': 'Number', 'icon' : 'sign2.ico'}],
+              \ "sign2"->sign_getdefined())
 
   " Test for a sign name with digits
   call assert_equal(0, sign_define(0002, {'linehl' : 'StatusLine'}))


### PR DESCRIPTION
#### vim-patch:8.2.3874: cannot highlight the number column for a sign

Problem:    Cannot highlight the number column for a sign.
Solution:   Add the "numhl" argument. (James McCoy, closes vim/vim#9381)
https://github.com/vim/vim/commit/a80aad717464760a5a50ac2201ce35b24a0cf7a5