### PR TITLE
chore: set max_line_length in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
+[*.{c,lua}]
+max_line_length = 100
+
 [{Makefile,**/Makefile,runtime/doc/*.txt}]
 indent_style = tab
 indent_size = 8


### PR DESCRIPTION
We established a while ago that 100 chars is our line length for both C
and Lua. Not all editorconfig plugins support the `max_line_length`
option, but many do (including all of the ones available for Vim/Neovim
to the best of my knowledge).
