### PR TITLE
vim-patch:8.2.3873

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1087,7 +1087,9 @@ au BufNewFile,BufRead *.mmp			setf mmp
 
 " Modsim III (or LambdaProlog)
 au BufNewFile,BufRead *.mod
-	\ if getline(1) =~ '\<module\>' |
+	\ if expand("<afile>") =~ '\<go.mod$' |
+	\   setf gomod |
+	\ elseif getline(1) =~ '\<module\>' |
 	\   setf lprolog |
 	\ else |
 	\   setf modsim3 |

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -204,6 +204,7 @@ let s:filename_checks = {
     \ 'gnash': ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
     \ 'gnuplot': ['file.gpi'],
     \ 'go': ['file.go'],
+    \ 'gomod': ['go.mod'],
     \ 'gp': ['file.gp', '.gprc'],
     \ 'gpg': ['/.gnupg/options', '/.gnupg/gpg.conf', '/usr/any/gnupg/options.skel', 'any/.gnupg/gpg.conf', 'any/.gnupg/options', 'any/usr/any/gnupg/options.skel'],
     \ 'grads': ['file.gs'],


### PR DESCRIPTION
#### vim-patch:8.2.3873: go.mod files are not recognized

Problem:    go.mod files are not recognized.
Solution:   Check for the file name. (closes vim/vim#9380)
https://github.com/vim/vim/commit/82b3b4c6cf2973fe767f8e2311482af0bd95267e