### PR TITLE
refactor(eval): remove redundant calls to gettext()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3936,7 +3936,7 @@ static void f_getreg(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       }
     }
   } else {
-    strregname = _(get_vim_var_str(VV_REG));
+    strregname = (char *)get_vim_var_str(VV_REG);
   }
 
   if (error) {
@@ -3978,7 +3978,7 @@ static void f_getregtype(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
   } else {
     // Default to v:register.
-    strregname = _(get_vim_var_str(VV_REG));
+    strregname = (char *)get_vim_var_str(VV_REG);
   }
 
   int regname = (uint8_t)(strregname == NULL ? '"' : *strregname);


### PR DESCRIPTION
Inferring from [`443af09` (#11828)](https://github.com/neovim/neovim/pull/11828/commits/443af0953401cc2a677c59ada200b22791476489) these are intended to perform a cast to avoid compiler warnings, but they also introduce redundant calls to `gettext()`. Just perform the cast.