### PR TITLE
fix(options): disallow empty 'fdc' and 'scl'

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2991,7 +2991,7 @@ ambw_end:
     }
   } else if (varp == &curwin->w_p_fdc || varp == &curwin->w_allbuf_opt.wo_fdc) {
     // 'foldcolumn'
-    if (check_opt_strings(*varp, p_fdc_values, false) != OK) {
+    if (**varp == NUL || check_opt_strings(*varp, p_fdc_values, false) != OK) {
       errmsg = e_invarg;
     }
   } else if (varp == &p_pt) {
@@ -3370,6 +3370,9 @@ static int int_cmp(const void *a, const void *b)
 /// @return OK when the value is valid, FAIL otherwise
 int check_signcolumn(char_u *val)
 {
+  if (*val == NUL) {
+    return FAIL;
+  }
   // check for basic match
   if (check_opt_strings(val, p_scl_values, false) == OK) {
     return OK;

--- a/test/functional/legacy/options_spec.lua
+++ b/test/functional/legacy/options_spec.lua
@@ -83,4 +83,9 @@ describe('set', function()
       Press ENTER or type command to continue^   |
     ]])
   end)
+
+  it('foldcolumn and signcolumn to empty string is disallowed', function()
+    matches('E474: Invalid argument: fdc=', exc_exec('set fdc='))
+    matches('E474: Invalid argument: scl=', exc_exec('set scl='))
+  end)
 end)


### PR DESCRIPTION
Empty string values for these options aren't actually allowed, but
check_opt_strings allows empty string options.

It so happens that 'scl' handles empty string like "auto", but empty 'fdc'
causes glitchiness (win_fdccol_count returns an incorrect value).

Just disallow empty string values for these options completely.