### PR TITLE
vim-patch:8.1.1184: undo file left behind after running test

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2467,6 +2467,7 @@ func Test_FileChangedShell_reload()
 
   au! testreload
   bwipe!
+  call delete(undofile('Xchanged_r'))
   call delete('Xchanged')
 endfunc
 


### PR DESCRIPTION
Problem:    Undo file left behind after running test.
Solution:   Delete the undo file. (Dominique Pelle, closes vim/vim#4279)
https://github.com/vim/vim/commit/137c14bb4f18198ed38659dcfbdfd749115c7ab5
