### PR TITLE
docs: add log section to lua

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -394,6 +394,9 @@ in the following order:
 2. Handler defined in |vim.lsp.start_client()|, if any.
 3. Handler defined in |vim.lsp.handlers|, if any.
 
+                                                            *vim.lsp.log_levels*
+Log levels are defined in |vim.log.levels|
+
 
 VIM.LSP.PROTOCOL                                              *vim.lsp.protocol*
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -881,6 +881,15 @@ vim.types                                               *vim.types*
         `vim.types.dictionary` will not change or that `vim.types` table will
         only contain values for these three types.
 
+                                                   *log_levels* *vim.log.levels*
+Log levels are one of the values defined in `vim.log.levels`:
+
+        vim.log.levels.DEBUG
+        vim.log.levels.ERROR
+        vim.log.levels.INFO
+        vim.log.levels.TRACE
+        vim.log.levels.WARN
+
 ------------------------------------------------------------------------------
 LUA-VIMSCRIPT BRIDGE                                    *lua-vimscript*
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1708,14 +1708,14 @@ end
 --
 -- Can be used to lookup the number from the name or the
 -- name from the number.
--- Levels by name: "trace", "debug", "info", "warn", "error"
--- Level numbers begin with "trace" at 0
+-- Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+-- Level numbers begin with "TRACE" at 0
 lsp.log_levels = log.levels
 
 --- Sets the global log level for LSP logging.
 ---
---- Levels by name: "trace", "debug", "info", "warn", "error"
---- Level numbers begin with "trace" at 0
+--- Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+--- Level numbers begin with "TRACE" at 0
 ---
 --- Use `lsp.log_levels` for reverse lookup.
 ---

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -8,8 +8,8 @@ local log = {}
 -- Log level dictionary with reverse lookup as well.
 --
 -- Can be used to lookup the number from the name or the name from the number.
--- Levels by name: 'trace', 'debug', 'info', 'warn', 'error'
--- Level numbers begin with 'trace' at 0
+-- Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+-- Level numbers begin with "TRACE" at 0
 log.levels = vim.deepcopy(vim.log.levels)
 
 -- Default log level is warn.

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -424,7 +424,7 @@ end
 --- Without a runtime, writes to :Messages
 ---@see :help nvim_notify
 ---@param msg string Content of the notification to show to the user
----@param log_level number|nil enum from vim.log.levels
+---@param log_level number|nil enum from |vim.log.levels|
 ---@param opts table|nil additional options (timeout, etc)
 function vim.notify(msg, log_level, opts) -- luacheck: no unused
   if log_level == vim.log.levels.ERROR then


### PR DESCRIPTION
There were links to nowhere for vim.log.levels. They were reverted in a commit, however there is clearly a need for documentation on log levels