### PR TITLE
vim-patch:8.2.3883: crash when switching to other regexp engine fails

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4584,6 +4584,9 @@ void ex_global(exarg_T *eap)
       // a match on this line?
       match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
                                 (colnr_T)0, NULL, NULL);
+      if (regmatch.regprog == NULL) {
+        break;  // re-compiling regprog failed
+      }
       if ((type == 'g' && match) || (type == 'v' && !match)) {
         ml_setmarked(lnum);
         ndone++;


### PR DESCRIPTION
#### vim-patch:8.2.3883: crash when switching to other regexp engine fails

Problem:    Crash when switching to other regexp engine fails.
Solution:   Check for regprog being NULL.
https://github.com/vim/vim/commit/5937c7505f444dd896f336fa0119a93a55ebe9a2