### PR TITLE
vim-patch:8.2.2468: not easy to get the full command name from a shortened one

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4163,11 +4163,12 @@ expand({string} [, {nosuf} [, {list}]])				*expand()*
 		Can also be used as a |method|: >
 			Getpattern()->expand()
 
-expandcmd({expr})					*expandcmd()*
-		Expand special items in {expr} like what is done for an Ex
-		command such as `:edit`.  This expands special keywords, like
-		with |expand()|, and environment variables, anywhere in
-		{expr}.  "~user" and "~/path" are only expanded at the start.
+expandcmd({string})					*expandcmd()*
+		Expand special items in String {string} like what is done for
+		an Ex command such as `:edit`.  This expands special keywords,
+		like with |expand()|, and environment variables, anywhere in
+		{string}.  "~user" and "~/path" are only expanded at the
+		start.
 		Returns the expanded string.  Example: >
 			:echo expandcmd('make %<.o')
 
@@ -4555,8 +4556,8 @@ fullcommand({name})						*fullcommand()*
 		Get the full command name from a short abbreviated command
 		name; see |20.2| for details on command abbreviations.
 
-		{name} may start with a `:` and can include a [range], these
-		are skipped and not returned.
+		The string argument {name} may start with a `:` and can
+		include a [range], these are skipped and not returned.
 		Returns an empty string if a command doesn't exist or if it's
 		ambiguous (for user-defined functions).
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2410,10 +2410,11 @@ foldlevel({lnum})		Number	fold level at {lnum}
 foldtext()			String	line displayed for closed fold
 foldtextresult({lnum})		String	text for closed fold at {lnum}
 foreground()			Number	bring the Vim window to the foreground
+fullcommand({name})		String	get full command from {name}
 funcref({name} [, {arglist}] [, {dict}])
-				Funcref reference to function {name}
+				Funcref	reference to function {name}
 function({name} [, {arglist}] [, {dict}])
-				Funcref named reference to function {name}
+				Funcref	named reference to function {name}
 garbagecollect([{atexit}])	none	free memory, breaking cyclic references
 get({list}, {idx} [, {def}])	any	get item {idx} from {list} or {def}
 get({dict}, {key} [, {def}])	any	get item {key} from {dict} or {def}
@@ -4550,6 +4551,21 @@ foreground()	Move the Vim window to the foreground.  Useful when sent from
 		|remote_foreground()| instead.
 		{only in the Win32 GUI and console version}
 
+fullcommand({name})						*fullcommand()*
+		Get the full command name from a short abbreviated command
+		name; see |20.2| for details on command abbreviations.
+
+		{name} may start with a `:` and can include a [range], these
+		are skipped and not returned.
+		Returns an empty string if a command doesn't exist or if it's
+		ambiguous (for user-defined functions).
+
+		For example `fullcommand('s')`, `fullcommand('sub')`,
+		`fullcommand(':%substitute')` all return "substitute".
+
+		Can also be used as a |method|: >
+			GetName()->fullcommand()
+<
 						*funcref()*
 funcref({name} [, {arglist}] [, {dict}])
 		Just like |function()|, but the returned Funcref will lookup

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4559,7 +4559,7 @@ fullcommand({name})						*fullcommand()*
 		The string argument {name} may start with a `:` and can
 		include a [range], these are skipped and not returned.
 		Returns an empty string if a command doesn't exist or if it's
-		ambiguous (for user-defined functions).
+		ambiguous (for user-defined commands).
 
 		For example `fullcommand('s')`, `fullcommand('sub')`,
 		`fullcommand(':%substitute')` all return "substitute".

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -852,6 +852,7 @@ Command line:					*command-line-functions*
 	getcmdtype()		return the current command-line type
 	getcmdwintype()		return the current command-line window type
 	getcompletion()		list of command-line completion matches
+	fullcommand()		get full command name
 
 Quickfix and location lists:			*quickfix-functions*
 	getqflist()		list of quickfix errors

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -133,6 +133,7 @@ return {
     foldtext={},
     foldtextresult={args=1, base=1},
     foreground={},
+    fullcommand={args=1, base=1},
     funcref={args={1, 3}, base=1},
     ['function']={args={1, 3}, base=1},
     garbagecollect={args={0, 1}},

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2920,7 +2920,7 @@ void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  rettv->vval.v_string = vim_strsave(ea.cmdidx < 0
+  rettv->vval.v_string = vim_strsave(IS_USER_CMDIDX(ea.cmdidx)
                                      ? get_user_commands(NULL, ea.useridx)
                                      : cmdnames[ea.cmdidx].cmd_name);
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2900,6 +2900,31 @@ int cmd_exists(const char *const name)
   return ea.cmdidx == CMD_SIZE ? 0 : (full ? 2 : 1);
 }
 
+// "fullcommand" function
+void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  exarg_T ea;
+  char_u *name = argvars[0].vval.v_string;
+
+  while (name[0] != NUL && name[0] == ':') {
+    name++;
+  }
+  name = skip_range(name, NULL);
+
+  rettv->v_type = VAR_STRING;
+
+  ea.cmd = (*name == '2' || *name == '3') ? name + 1 : name;
+  ea.cmdidx = (cmdidx_T)0;
+  char_u *p = find_command(&ea, NULL);
+  if (p == NULL || ea.cmdidx == CMD_SIZE) {
+    return;
+  }
+
+  rettv->vval.v_string = vim_strsave(ea.cmdidx < 0
+                                     ? get_user_commands(NULL, ea.useridx)
+                                     : cmdnames[ea.cmdidx].cmd_name);
+}
+
 /// This is all pretty much copied from do_one_cmd(), with all the extra stuff
 /// we don't need/want deleted.  Maybe this could be done better if we didn't
 /// repeat all this stuff.  The only problem is that they may not stay

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -2,6 +2,7 @@
 #define NVIM_EX_DOCMD_H
 
 #include "nvim/ex_cmds_defs.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/globals.h"
 
 // flags for do_cmdline()

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -467,6 +467,43 @@ func Test_getcompletion()
   call assert_fails('call getcompletion("abc", [])', 'E475:')
 endfunc
 
+func Test_fullcommand()
+  let tests = {
+        \ '':           '',
+        \ ':':          '',
+        \ ':::':        '',
+        \ ':::5':       '',
+        \ 'not_a_cmd':  '',
+        \ 'Check':      '',
+        \ 'syntax':     'syntax',
+        \ ':syntax':    'syntax',
+        \ '::::syntax': 'syntax',
+        \ 'sy':         'syntax',
+        \ 'syn':        'syntax',
+        \ 'synt':       'syntax',
+        \ ':sy':        'syntax',
+        \ '::::sy':     'syntax',
+        \ 'match':      'match',
+        \ '2match':     'match',
+        \ '3match':     'match',
+        \ 'aboveleft':  'aboveleft',
+        \ 'abo':        'aboveleft',
+        \ 's':          'substitute',
+        \ '5s':         'substitute',
+        \ ':5s':        'substitute',
+        \ "'<,'>s":     'substitute',
+        \ ":'<,'>s":    'substitute',
+        \ 'CheckUni':   'CheckUnix',
+        \ 'CheckUnix':  'CheckUnix',
+  \ }
+
+  for [in, want] in items(tests)
+    call assert_equal(want, fullcommand(in))
+  endfor
+
+  call assert_equal('syntax', 'syn'->fullcommand())
+endfunc
+
 func Test_shellcmd_completion()
   let save_path = $PATH
 


### PR DESCRIPTION
#### vim-patch:8.2.2468: not easy to get the full command name from a shortened one

Problem:    Not easy to get the full command name from a shortened one.
Solution:   Add fullcommand(). (Martin Tournoij, closes vim/vim#7777)
https://github.com/vim/vim/commit/038e09ee7645731de0296d255aabb17603276443


#### vim-patch:partial:6aa57295cfbe

Update runtime files
https://github.com/vim/vim/commit/6aa57295cfbe8f21c15f0671e45fd53cf990d404


#### vim-patch:partial:6c391a74fe90

Update runtime files
https://github.com/vim/vim/commit/6c391a74fe90190796ca0b0c010112948a6e75d7