### PR TITLE
vim-patch:8.2.3903: "gM" does not count tabs as expected

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6311,11 +6311,9 @@ static void nv_g_cmd(cmdarg_T *cap)
     break;
 
   case 'M': {
-    const char_u *const ptr = get_cursor_line_ptr();
-
     oap->motion_type = kMTCharWise;
     oap->inclusive = false;
-    i = (int)mb_string2cells_len(ptr, STRLEN(ptr));
+    i = linetabsize(get_cursor_line_ptr());
     if (cap->count0 > 0 && cap->count0 <= 100) {
       coladvance((colnr_T)(i * cap->count0 / 100));
     } else {

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1812,7 +1812,15 @@ fun! Test_normal33_g_cmd2()
   call assert_equal(87, col('.'))
   call assert_equal('E', getreg(0))
 
+  " Test for gM with Tab characters
+  call setline('.', "\ta\tb\tc\td\te\tf")
+  norm! gMyl
+  call assert_equal(6, col('.'))
+  call assert_equal("c", getreg(0))
+
   " Test for g Ctrl-G
+  call setline('.', lineC)
+  norm! 60gMyl
   set ff=unix
   let a=execute(":norm! g\<c-g>")
   call assert_match('Col 87 of 144; Line 2 of 2; Word 1 of 1; Byte 88 of 146', a)


### PR DESCRIPTION
#### vim-patch:8.2.3903: "gM" does not count tabs as expected

Problem:    "gM" does not count tabs as expected.
Solution:   Use linetabsize() instead of mb_string2cells().
https://github.com/vim/vim/commit/71c41255f6a074c4df4dc6f9e97d347e565253a1