### PR TITLE
 fix(uri): change scheme pattern to not include the comma character

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -74,8 +74,8 @@ local function uri_from_fname(path)
   return table.concat(uri_parts)
 end
 
-local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):.*'
-local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9+-.]*):[a-zA-Z]:.*'
+local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*'
+local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
 
 --- Get a URI from a bufnr
 ---@param bufnr number

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -155,6 +155,12 @@ describe('URI methods', function()
           return pcall(vim.uri_to_fname, 'not_an_uri.txt')
         ]])
       end)
+
+      it('uri_to_fname should not treat comma as a scheme character', function()
+        eq(false, exec_lua [[
+          return pcall(vim.uri_to_fname, 'foo,://bar')
+        ]])
+      end)
     end)
 
   end)


### PR DESCRIPTION
The `+-.` notation accidentally created a character range, which would include the comma character (the characters between `+` and `.` in the ASCII table are `-` and `,`), which is not allowed in URI schemes.