### PR TITLE
feat: add path lib

### DIFF
--- a/runtime/lua/vim/path.lua
+++ b/runtime/lua/vim/path.lua
@@ -55,7 +55,7 @@ end
 
 function Path:is_relative_to(root)
   local path_parts = self:parts()
-  local root_parts = Path:new(root):parts()
+  local root_parts = Path.new(root):parts()
 
   local root_parts_len = #root_parts
   local path_parts_len = #path_parts
@@ -105,27 +105,27 @@ function Path:parent()
   local result = self.path:gsub(strip_sep_pat, ''):gsub(strip_dir_pat, '')
   if #result == 0 then
     if self.is_windows then
-      return Path:new(self.path:sub(1, 2))
+      return Path.new(self.path:sub(1, 2))
     else
-      return Path:new('/')
+      return Path.new('/')
     end
   end
-  return Path:new(result)
+  return Path.new(result)
 end
 
-function Path:new(path)
+function Path.new(path)
   local path_obj = {
-    path = path,
     is_windows = uv.os_uname().version:match('Windows')
   }
-  setmetatable(path_obj, Path)
+  local self = setmetatable(path_obj, Path)
+
+  self.path = path
 
   if path_obj.is_windows then
-    if Path.is_absolute(path_obj) then
+    if self.is_absolute() then
       path = path:sub(1, 1):upper() .. path:sub(2)
     end
-    path = path:gsub('\\', '/')
-    path_obj.path = path
+    self.path = path:gsub('\\', '/')
   end
 
   return path_obj
@@ -133,13 +133,13 @@ end
 
 setmetatable(Path, {
   __call = function(_, path)
-    return Path:new(path)
+    return Path.new(path)
   end
 })
 
 local function join(...)
   local to_join = vim.map(tostring, vim.tbl_flatten(...))
-  return Path:new(table.concat(to_join, '/'))
+  return Path.new(table.concat(to_join, '/'))
 end
 
 return {

--- a/runtime/lua/vim/path.lua
+++ b/runtime/lua/vim/path.lua
@@ -12,7 +12,7 @@ function Path:exists()
 end
 
 function Path:expanduser()
-  if self.path == '/' or self.path:match '^~/' then
+  if self.path:match '^~/' then
     return os.getenv('HOME') .. self.path:sub(2)
   else
     return self.path
@@ -114,21 +114,19 @@ function Path:parent()
 end
 
 function Path.new(path)
-  local path_obj = {
-    is_windows = uv.os_uname().version:match('Windows')
-  }
-  local self = setmetatable(path_obj, Path)
+  local self = setmetatable({
+    is_windows = uv.os_uname().version:match('Windows') or false,
+    path = path
+  }, Path)
 
-  self.path = path
-
-  if path_obj.is_windows then
+  if self.is_windows then
     if self.is_absolute() then
       path = path:sub(1, 1):upper() .. path:sub(2)
     end
     self.path = path:gsub('\\', '/')
   end
 
-  return path_obj
+  return self
 end
 
 setmetatable(Path, {

--- a/runtime/lua/vim/path.lua
+++ b/runtime/lua/vim/path.lua
@@ -109,13 +109,14 @@ function Path:parent()
 end
 
 function Path:new(path)
-  local path_obj = { path = path }
+  local path_obj = {
+    path = path,
+    is_windows = uv.os_uname().version:match('Windows')
+  }
   setmetatable(path_obj, self)
   self.__index = self
 
-  self.is_windows = uv.os_uname().version:match('Windows')
-
-  if self.is_windows then
+  if path_obj.is_windows then
     if self.is_absolute(path_obj) then
       path = path:sub(1, 1):upper() .. path:sub(2)
     end

--- a/runtime/lua/vim/path.lua
+++ b/runtime/lua/vim/path.lua
@@ -1,0 +1,145 @@
+local uv = vim.loop
+
+local Path = {}
+
+function Path:__tostring()
+  return self.path
+end
+
+function Path:exists()
+  return uv.fs_realpath(self.path) and true
+end
+
+function Path:expanduser()
+  if self.path:match '^~' then
+    return os.getenv('HOME') .. self.path:sub(2)
+  else
+    return self.path
+  end
+end
+
+function Path:home()
+  return os.getenv('HOME')
+end
+
+function Path:parts()
+  if self.is_windows then
+    return vim.split(self.path, '/')
+  else
+    local parts = vim.split(self.path, '/')
+    if self.path:slice(1) == '/' then
+      parts[1] = '/'
+    end
+    return parts
+  end
+end
+
+function Path:is_dir()
+  local stat = uv.fs_realpath(self.path)
+  return stat and stat == 'directory'
+end
+
+function Path:is_file()
+  local stat = uv.fs_realpath(self.path)
+  return stat and stat == 'file'
+end
+
+function Path:is_absolute()
+  if self.is_windows then
+    return (self.path:match '^%a:' or self.path:match '^\\\\') or false
+  else
+    return self.path:match '^/' or false
+  end
+end
+
+function Path:is_relative_to(root)
+  local path_parts = self:parts()
+  local root_parts = Path:new(root):parts()
+
+  local root_parts_len = #root_parts
+  local path_parts_len = #path_parts
+
+  for i = 1,math.min(root_parts_len, path_parts_len) do
+    if root_parts[i] ~= path_parts[i] then
+      return false
+      end
+  end
+  return true
+end
+
+function Path:is_fs_root()
+  if self.is_windows then
+    return self.path:match '^%a:$'
+  else
+    return self.path == '/'
+  end
+end
+
+function Path:as_uri()
+  if self.is_windows then
+    return 'file:///' .. self.path
+  else
+    return 'file://' .. self.path
+  end
+end
+
+function Path:as_posix()
+  return self.path
+end
+
+function Path:as_windows()
+  return self.path:gsub('/', '\\')
+end
+
+function Path:parent()
+  local strip_dir_pat = '/([^/]+)$'
+  local strip_sep_pat = '/$'
+  if not self.path or #self.path == 0 then
+    return
+  end
+  local result = self.path:gsub(strip_sep_pat, ''):gsub(strip_dir_pat, '')
+  if #result == 0 then
+    if self.is_windows then
+      return Path:new(self.path:sub(1, 2))
+    else
+      return Path:new('/')
+    end
+  end
+  return Path:new(result)
+end
+
+function Path:new(path)
+  local path_obj = {}
+  setmetatable(path_obj, self)
+  self.__index = self
+
+  self.is_windows = uv.os_uname().version:match('Windows')
+
+  self.path = path
+
+  if self.is_windows then
+    if self:is_absolute() then
+      path = path:sub(1, 1):upper() .. path:sub(2)
+    end
+    path = path:gsub('\\', '/')
+    self.path = path
+  end
+
+  return path_obj
+end
+
+setmetatable(Path, {
+  __call = function(_, path)
+    return Path:new(path)
+  end
+})
+
+local function join(...)
+  local to_join = vim.map(tostring, vim.tbl_flatten(...))
+  return table.concat(to_join, '/')
+end
+
+return {
+  Path=Path,
+  join=join
+}

--- a/runtime/lua/vim/path.lua
+++ b/runtime/lua/vim/path.lua
@@ -109,20 +109,18 @@ function Path:parent()
 end
 
 function Path:new(path)
-  local path_obj = {}
+  local path_obj = { path = path }
   setmetatable(path_obj, self)
   self.__index = self
 
   self.is_windows = uv.os_uname().version:match('Windows')
 
-  self.path = path
-
   if self.is_windows then
-    if self:is_absolute() then
+    if self.is_absolute(path_obj) then
       path = path:sub(1, 1):upper() .. path:sub(2)
     end
     path = path:gsub('\\', '/')
-    self.path = path
+    path_obj.path = path
   end
 
   return path_obj

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -103,6 +103,9 @@ setmetatable(vim, {
     elseif key == 'lsp' then
       t.lsp = require('vim.lsp')
       return t.lsp
+    elseif key == 'path' then
+      t.path = require('vim.path')
+      return t.path
     elseif key == 'highlight' then
       t.highlight = require('vim.highlight')
       return t.highlight


### PR DESCRIPTION
I'm putting this out there as I want to start moving lspconfig core functionality to core. One of the useful components of lspconfig is the path library, which has some overlap with plenary. I think plenary includes some functions that are not strictly necessary. Some thoughts (to be updated):

* I don't try to explicitly handle different path separators. In practice this cannot be determined from system platform alone. We could try to dynamically determine this by parsing the path, but here I decided to just always normalize to a forward slash. I think the better solution is we internally use the same path separator, but allow for windows/unix style views of the path (as_unix() as_windows())
* I didn't yet include any of the root directory type functions
* I think this should be marked private until it stabilizes a bit
* I used an object style like python as that seems to be popular. I did not internally refactor anything to use the path lib yet.
* Not sure how to handle blankspace in the path, as that will get "normalized" to a forward slash incorrectly (on windows) if the user tries to be clever and escape it.

I will add test when we finalize the interface.