### PR TITLE
test(old): fix indent in Test_multibyte_op_end_mark()

### DIFF
--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -113,14 +113,14 @@ func Test_put_p_indent_visual()
 endfunc
 
 func Test_multibyte_op_end_mark()
-   new
-   call setline(1, 'тест')
-   normal viwdp
-   call assert_equal([0, 1, 7, 0], getpos("'>"))
-   call assert_equal([0, 1, 7, 0], getpos("']"))
+  new
+  call setline(1, 'тест')
+  normal viwdp
+  call assert_equal([0, 1, 7, 0], getpos("'>"))
+  call assert_equal([0, 1, 7, 0], getpos("']"))
 
-   normal Vyp
-   call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
-   call assert_equal([0, 2, 7, 0], getpos("']"))
-   bwipe!
- endfunc
+  normal Vyp
+  call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
+  call assert_equal([0, 2, 7, 0], getpos("']"))
+  bwipe!
+endfunc


### PR DESCRIPTION
cc @clason