### PR TITLE
vim-patch:8.2.3914

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4576,7 +4576,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
     cur_tab_rec->def.func = NULL;
   }
 
-  // When inside update_screen we do not want redrawing a stausline, ruler,
+  // When inside update_screen we do not want redrawing a statusline, ruler,
   // title, etc. to trigger another redraw, it may cause an endless loop.
   if (updating_screen) {
     must_redraw = save_must_redraw;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -37,8 +37,8 @@
 #include "nvim/path.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
-#include "nvim/undo.h"
 #include "nvim/ui.h"
+#include "nvim/undo.h"
 #include "nvim/vim.h"
 #include "nvim/window.h"
 #include "xdiff/xdiff.h"
@@ -674,11 +674,11 @@ void diff_redraw(bool dofold)
   }
   if (wp_other != NULL && curwin->w_p_scb) {
     if (used_max_fill_curwin) {
-      // The current window was set to used the maximum number of filler
+      // The current window was set to use the maximum number of filler
       // lines, may need to reduce them.
       diff_set_topline(wp_other, curwin);
     } else if (used_max_fill_other) {
-      // The other window was set to used the maximum number of filler
+      // The other window was set to use the maximum number of filler
       // lines, may need to reduce them.
       diff_set_topline(curwin, wp_other);
     }
@@ -1508,7 +1508,7 @@ void ex_diffoff(exarg_T *eap)
     diff_clear(curtab);
   }
 
-  // Remove "hor" from from 'scrollopt' if there are no diff windows left.
+  // Remove "hor" from 'scrollopt' if there are no diff windows left.
   if (!diffwin && (vim_strchr(p_sbo, 'h') != NULL)) {
     do_cmdline_cmd("set sbo-=hor");
   }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1600,8 +1600,8 @@ static void ins_ctrl_v(void)
  */
 static int pc_status;
 #define PC_STATUS_UNSET 0       // pc_bytes was not set
-#define PC_STATUS_RIGHT 1       // right halve of double-wide char
-#define PC_STATUS_LEFT  2       // left halve of double-wide char
+#define PC_STATUS_RIGHT 1       // right half of double-wide char
+#define PC_STATUS_LEFT  2       // left half of double-wide char
 #define PC_STATUS_SET   3       // pc_bytes was filled
 static char_u pc_bytes[MB_MAXBYTES + 1];  // saved bytes
 static int pc_attr;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3025,7 +3025,7 @@ void ex_append(exarg_T *eap)
   // "start" is set to eap->line2+1 unless that position is invalid (when
   // eap->line2 pointed to the end of the buffer and nothing was appended)
   // "end" is set to lnum when something has been appended, otherwise
-  // it is the same than "start"  -- Acevedo
+  // it is the same as "start"  -- Acevedo
   curbuf->b_op_start.lnum = (eap->line2 < curbuf->b_ml.ml_line_count) ?
                             eap->line2 + 1 : curbuf->b_ml.ml_line_count;
   if (eap->cmdidx != CMD_append) {

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2162,7 +2162,7 @@ int do_source(char *fname, int check_other, int is_vimrc)
   funccal_entry_T funccalp_entry;
   save_funccal(&funccalp_entry);
 
-  // Check if this script was sourced before to finds its SID.
+  // Check if this script was sourced before to find its SID.
   // If it's new, generate a new SID.
   // Always use a new sequence number.
   const sctx_T save_current_sctx = current_sctx;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -67,8 +67,8 @@
 #include "nvim/sign.h"
 #include "nvim/spell.h"
 #include "nvim/spellfile.h"
-#include "nvim/strings.h"
 #include "nvim/state.h"
+#include "nvim/strings.h"
 #include "nvim/syntax.h"
 #include "nvim/tag.h"
 #include "nvim/terminal.h"
@@ -7489,9 +7489,8 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
   if ((eap->cmdidx == CMD_new
        || eap->cmdidx == CMD_tabnew
        || eap->cmdidx == CMD_tabedit
-       || eap->cmdidx == CMD_vnew
-       ) && *eap->arg == NUL) {
-    // ":new" or ":tabnew" without argument: edit an new empty buffer
+       || eap->cmdidx == CMD_vnew) && *eap->arg == NUL) {
+    // ":new" or ":tabnew" without argument: edit a new empty buffer
     setpcmark();
     (void)do_ecmd(0, NULL, NULL, eap, ECMD_ONE,
                   ECMD_HIDE + (eap->forceit ? ECMD_FORCEIT : 0),
@@ -7845,7 +7844,7 @@ bool changedir_func(char_u *new_dir, CdScope scope)
   }
 
   bool dir_differs = new_dir == NULL || pdir == NULL
-    || pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
+                     || pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
   if (new_dir != NULL && (!dir_differs || vim_chdir(new_dir) == 0)) {
     post_chdir(scope, dir_differs);
     retval = true;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -607,7 +607,7 @@ char_u *vim_findfile(void *search_ctx_arg)
   for (;;) {
     // downward search loop
     for (;;) {
-      // check if user user wants to stop the search
+      // check if user wants to stop the search
       os_breakcheck();
       if (got_int) {
         break;
@@ -1139,7 +1139,7 @@ static int ff_check_visited(ff_visited_T **visited_list, char_u *fname, char_u *
   bool url = false;
 
   FileID file_id;
-  // For an URL we only compare the name, otherwise we compare the
+  // For a URL we only compare the name, otherwise we compare the
   // device/inode.
   if (path_with_url((char *)fname)) {
     STRLCPY(ff_expand_buffer, fname, MAXPATHL);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2332,7 +2332,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
        * firstlnum.
        */
       while (!got_int) {
-        // set concat to 1 if it's allowed to concatenated this fold
+        // set concat to 1 if it's allowed to concatenate this fold
         // with a previous one that touches it.
         if (flp->start != 0 || flp->had_end <= MAX_LEVEL) {
           concat = 0;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -146,7 +146,7 @@ static int KeyNoremap = 0;                  // remapping flags
 
 // typebuf.tb_buf has three parts: room in front (for result of mappings), the
 // middle for typeahead and room for new characters (which needs to be 3 *
-// MAXMAPLEN) for the Amiga).
+// MAXMAPLEN for the Amiga).
 #define TYPELEN_INIT    (5 * (MAXMAPLEN + 3))
 static char_u typebuf_init[TYPELEN_INIT];       // initial typebuf.tb_buf
 static char_u noremapbuf_init[TYPELEN_INIT];    // initial typebuf.tb_noremap
@@ -861,7 +861,7 @@ void init_default_mappings(void)
 //
 // If noremap is REMAP_YES, new string can be mapped again.
 // If noremap is REMAP_NONE, new string cannot be mapped again.
-// If noremap is REMAP_SKIP, fist char of new string cannot be mapped again,
+// If noremap is REMAP_SKIP, first char of new string cannot be mapped again,
 // but abbreviations are allowed.
 // If noremap is REMAP_SCRIPT, new string cannot be mapped again, except for
 //                             script-local mappings.
@@ -1693,7 +1693,7 @@ typedef enum {
   map_result_fail,    // failed, break loop
   map_result_get,     // get a character from typeahead
   map_result_retry,   // try to map again
-  map_result_nomatch  // no matching mapping, get char
+  map_result_nomatch,  // no matching mapping, get char
 } map_result_T;
 
 /// Handle mappings in the typeahead buffer.
@@ -2470,7 +2470,7 @@ static int vgetorpeek(bool advance)
 ///  Return the number of obtained characters.
 ///  Return -1 when end of input script reached.
 ///
-/// @param wait_time  milli seconds
+/// @param wait_time  milliseconds
 int inchar(char_u *buf, int maxlen, long wait_time)
 {
   int len = 0;  // Init for GCC.

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -924,7 +924,7 @@ static int cin_isfuncdecl(char_u **sp, linenr_T first_lnum, linenr_T min_lnum)
   while (*s && *s != ';' && *s != '\'' && *s != '"') {
     if (*s == ')' && cin_nocode(s + 1)) {
       /* ')' at the end: may have found a match
-       * Check for he previous line not to end in a backslash:
+       * Check for the previous line not to end in a backslash:
        *       #if defined(x) && \
        *		 defined(y)
        */
@@ -1635,7 +1635,7 @@ void parse_cino(buf_T *buf)
   buf->b_ind_unclosed2 = sw;
 
   /* Suppress ignoring spaces from the indent of a line starting with an
-   * unclosed parentheses. */
+   * unclosed parenthesis. */
   buf->b_ind_unclosed_noignore = 0;
 
   /* If the opening paren is the last nonwhite character on the line, and
@@ -1647,11 +1647,11 @@ void parse_cino(buf_T *buf)
    * an unclosed parentheses. */
   buf->b_ind_unclosed_whiteok = 0;
 
-  /* Indent a closing parentheses under the line start of the matching
-   * opening parentheses. */
+  /* Indent a closing parenthesis under the line start of the matching
+   * opening parenthesis. */
   buf->b_ind_matching_paren = 0;
 
-  // Indent a closing parentheses under the previous line.
+  // Indent a closing parenthesis under the previous line.
   buf->b_ind_paren_prev = 0;
 
   // Extra indent for comments.

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -923,11 +923,10 @@ static int cin_isfuncdecl(char_u **sp, linenr_T first_lnum, linenr_T min_lnum)
 
   while (*s && *s != ';' && *s != '\'' && *s != '"') {
     if (*s == ')' && cin_nocode(s + 1)) {
-      /* ')' at the end: may have found a match
-       * Check for the previous line not to end in a backslash:
-       *       #if defined(x) && \
-       *		 defined(y)
-       */
+      // ')' at the end: may have found a match
+      // Check for the previous line not to end in a backslash:
+      //       #if defined(x) && \
+      //           defined(y)
       lnum = first_lnum - 1;
       s = ml_get(lnum);
       if (*s == NUL || s[STRLEN(s) - 1] != '\\')
@@ -1634,8 +1633,8 @@ void parse_cino(buf_T *buf)
    * itself is also unclosed. */
   buf->b_ind_unclosed2 = sw;
 
-  /* Suppress ignoring spaces from the indent of a line starting with an
-   * unclosed parenthesis. */
+  // Suppress ignoring spaces from the indent of a line starting with an
+  // unclosed parenthesis.
   buf->b_ind_unclosed_noignore = 0;
 
   /* If the opening paren is the last nonwhite character on the line, and
@@ -1647,8 +1646,8 @@ void parse_cino(buf_T *buf)
    * an unclosed parentheses. */
   buf->b_ind_unclosed_whiteok = 0;
 
-  /* Indent a closing parenthesis under the line start of the matching
-   * opening parenthesis. */
+  // Indent a closing parenthesis under the line start of the matching
+  // opening parenthesis.
   buf->b_ind_matching_paren = 0;
 
   // Indent a closing parenthesis under the previous line.

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -361,7 +361,7 @@ static int add_menu_path(const char_u *const menu_path, vimmenu_T *menuarg,
         goto erret;
       }
 
-      // Not already there, so lets add it
+      // Not already there, so let's add it
       menu = xcalloc(1, sizeof(vimmenu_T));
 
       menu->modes = modes;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1269,7 +1269,7 @@ static void hit_return_msg(void)
 {
   int save_p_more = p_more;
 
-  p_more = FALSE;       // don't want see this message when scrolling back
+  p_more = false;       // don't want to see this message when scrolling back
   if (msg_didout) {     // start on a new line
     msg_putchar('\n');
   }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -909,7 +909,7 @@ void curs_columns(win_T *wp, int may_scroll)
       }
       wp->w_skipcol = n * width;
     } else if (extra == 1) {
-      // less then 'scrolloff' lines above, decrease skipcol
+      // less than 'scrolloff' lines above, decrease skipcol
       assert(so <= INT_MAX);
       extra = (wp->w_skipcol + (int)so * width - wp->w_virtcol
                + width - 1) / width;
@@ -920,7 +920,7 @@ void curs_columns(win_T *wp, int may_scroll)
         wp->w_skipcol -= extra * width;
       }
     } else if (extra == 2) {
-      // less then 'scrolloff' lines below, increase skipcol
+      // less than 'scrolloff' lines below, increase skipcol
       endcol = (n - wp->w_height_inner + 1) * width;
       while (endcol > wp->w_virtcol) {
         endcol -= width;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4123,7 +4123,7 @@ static int same_leader(linenr_T lnum, int leader1_len, char_u *leader1_flags, in
    * If first leader has 'f' flag, the lines can be joined only if the
    * second line does not have a leader.
    * If first leader has 'e' flag, the lines can never be joined.
-   * If fist leader has 's' flag, the lines can only be joined if there is
+   * If first leader has 's' flag, the lines can only be joined if there is
    * some text after it and the second line has the 'm' flag.
    */
   if (leader1_flags != NULL) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1345,7 +1345,7 @@ int do_set(char_u *arg, int opt_flags)
 
             if (nextchar == '&') {  // set to default val
               newval = options[opt_idx].def_val;
-              // expand environment variables and ~ (since the
+              // expand environment variables and ~ since the
               // default value was already expanded, only
               // required when an environment variable was set
               // later
@@ -4132,7 +4132,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
         }
       }
 
-      // Arabic requires a utf-8 encoding, inform the user if its not
+      // Arabic requires a utf-8 encoding, inform the user if it's not
       // set.
       if (STRCMP(p_enc, "utf-8") != 0) {
         static char *w_arabic = N_("W17: Arabic requires UTF-8, do ':set encoding=utf-8'");

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -83,7 +83,7 @@ int plines_win_nofill(win_T *wp, linenr_T lnum, bool winheight)
     return 1;
   }
 
-  // A folded lines is handled just like an empty line.
+  // Folded lines are handled just like an empty line.
   if (lineFolded(wp, lnum)) {
     return 1;
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3947,7 +3947,7 @@ static int qf_buf_add_line(qf_list_T *qfl, buf_T *buf, linenr_T lnum, const qfli
   int len;
   buf_T *errbuf;
 
-  // If the 'quickfixtextfunc' function returned an non-empty custom string
+  // If the 'quickfixtextfunc' function returned a non-empty custom string
   // for this entry, then use it.
   if (qftf_str != NULL && *qftf_str != NUL) {
     STRLCPY(IObuff, qftf_str, IOSIZE);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2013,7 +2013,7 @@ static int nfa_regpiece(void)
     // will emit NFA_STAR.
     // Bail out if we can use the other engine, but only, when the
     // pattern does not need the NFA engine like (e.g. [[:upper:]]\{2,\}
-    // does not work with with characters > 8 bit with the BT engine)
+    // does not work with characters > 8 bit with the BT engine)
     if ((nfa_re_flags & RE_AUTO)
         && (maxval > 500 || maxval > minval + 200)
         && (maxval != MAX_LIMIT && minval < 200)
@@ -4367,7 +4367,7 @@ static regsubs_T *addstate_here(
 
   // First add the state(s) at the end, so that we know how many there are.
   // Pass the listidx as offset (avoids adding another argument to
-  // addstate().
+  // addstate()).
   regsubs_T *r = addstate(l, state, subs, pim, -listidx - ADDSTATE_HERE_OFFSET);
   if (r == NULL) {
     return NULL;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4637,8 +4637,8 @@ void screen_adjust_grid(ScreenGrid **grid, int *row_off, int *col_off)
 static bool use_cursor_line_sign(win_T *wp, linenr_T lnum)
 {
   return wp->w_p_cul
-    && lnum == wp->w_cursor.lnum
-    && (wp->w_p_culopt_flags & CULOPT_NBR);
+         && lnum == wp->w_cursor.lnum
+         && (wp->w_p_culopt_flags & CULOPT_NBR);
 }
 
 // Get information needed to display the sign in line 'lnum' in window 'wp'.
@@ -4834,9 +4834,9 @@ static void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, 
       end_dirty = col + char_cells;
       // When writing a single-width character over a double-width
       // character and at the end of the redrawn text, need to clear out
-      // the right halve of the old character.
-      // Also required when writing the right halve of a double-width
-      // char over the left halve of an existing one
+      // the right half of the old character.
+      // Also required when writing the right half of a double-width
+      // char over the left half of an existing one
       if (col + char_cells == endcol
           && ((char_cells == 1
                && grid_off2cells(grid, off_to, max_off_to) > 1)
@@ -5887,8 +5887,8 @@ void grid_puts_len(ScreenGrid *grid, char_u *text, int textlen, int row, int col
   }
   off = grid->line_offset[row] + col;
 
-  /* When drawing over the right halve of a double-wide char clear out the
-   * left halve.  Only needed in a terminal. */
+  // When drawing over the right half of a double-wide char clear out the
+  // left half.  Only needed in a terminal.
   if (grid != &default_grid && col == 0 && grid_invalid_row(grid, row)) {
     // redraw the previous cell, make it empty
     put_dirty_first = -1;
@@ -5950,9 +5950,9 @@ void grid_puts_len(ScreenGrid *grid, char_u *text, int textlen, int row, int col
     if (need_redraw) {
       // When at the end of the text and overwriting a two-cell
       // character with a one-cell character, need to clear the next
-      // cell.  Also when overwriting the left halve of a two-cell char
-      // with the right halve of a two-cell char.  Do this only once
-      // (utf8_off2cells() may return 2 on the right halve).
+      // cell.  Also when overwriting the left half of a two-cell char
+      // with the right half of a two-cell char.  Do this only once
+      // (utf8_off2cells() may return 2 on the right half).
       if (clear_next_cell) {
         clear_next_cell = false;
       } else if ((len < 0 ? ptr[mbyte_blen] == NUL
@@ -6351,9 +6351,9 @@ void grid_fill(ScreenGrid *grid, int start_row, int end_row, int start_col, int 
   }
 
   for (int row = start_row; row < end_row; row++) {
-    // When drawing over the right halve of a double-wide char clear
-    // out the left halve.  When drawing over the left halve of a
-    // double wide-char clear out the right halve.  Only needed in a
+    // When drawing over the right half of a double-wide char clear
+    // out the left half.  When drawing over the left half of a
+    // double wide-char clear out the right half.  Only needed in a
     // terminal.
     if (start_col > 0 && grid_fix_col(grid, start_col, row) != start_col) {
       grid_puts_len(grid, (char_u *)" ", 1, row, start_col - 1, 0);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3771,7 +3771,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
 
             // Make sure, the highlighting for the tab char will be
             // correctly set further below (effectively reverts the
-            // FIX_FOR_BOGSUCOLS macro.
+            // FIX_FOR_BOGSUCOLS macro).
             if (n_extra == tab_len + vc_saved && wp->w_p_list
                 && wp->w_p_lcs_chars.tab1) {
               tab_len += vc_saved;
@@ -4294,7 +4294,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       // Store the character.
       //
       if (wp->w_p_rl && utf_char2cells(mb_c) > 1) {
-        // A double-wide character is: put first halve in left cell.
+        // A double-wide character is: put first half in left cell.
         off--;
         col--;
       }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -219,7 +219,7 @@ typedef struct {
 #define SCORE_THRES3    100     // word count threshold for COMMON3
 
 // When trying changed soundfold words it becomes slow when trying more than
-// two changes.  With less then two changes it's slightly faster but we miss a
+// two changes.  With less than two changes it's slightly faster but we miss a
 // few good suggestions.  In rare cases we need to try three of four changes.
 #define SCORE_SFMAX1    200     // maximum score for first try
 #define SCORE_SFMAX2    300     // maximum score for second try

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1628,7 +1628,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
 }
 
 // For spell checking: concatenate the start of the following line "line" into
-// "buf", blanking-out special characters.  Copy less then "maxlen" bytes.
+// "buf", blanking-out special characters.  Copy less than "maxlen" bytes.
 // Keep the blanks at the start of the next line, this is used in win_line()
 // to skip those bytes if the word was OK.
 void spell_cat_line(char_u *buf, char_u *line, int maxlen)
@@ -6106,7 +6106,7 @@ static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
       for (; ((ws = smp[n].sm_lead_w)[0] & 0xff) == (c & 0xff)
            && ws[0] != NUL; ++n) {
         // Quickly skip entries that don't match the word.  Most
-        // entries are less then three chars, optimize for that.
+        // entries are less than three chars, optimize for that.
         if (c != ws[0]) {
           continue;
         }
@@ -7057,7 +7057,7 @@ void spell_dump_compl(char_u *pat, int ic, Direction *dir, int dumpflags_arg)
             arridx[depth] = idxs[n];
             curi[depth] = 1;
 
-            // Check if this characters matches with the pattern.
+            // Check if this character matches with the pattern.
             // If not skip the whole tree below it.
             // Always ignore case here, dump_word() will check
             // proper case later.  This isn't exactly right when

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -4395,7 +4395,7 @@ static int write_vim_spell(spellinfo_T *spin, char_u *fname)
   //
   // The table with character flags and the table for case folding.
   // This makes sure the same characters are recognized as word characters
-  // when generating an when using a spell file.
+  // when generating and when using a spell file.
   // Skip this for ASCII, the table may conflict with the one used for
   // 'encoding'.
   // Also skip this for an .add.spl file, the main spell file must contain
@@ -5122,7 +5122,7 @@ static int sug_filltable(spellinfo_T *spin, wordnode_T *node, int startwordnr, g
       wordnr++;
 
       // Remove extra NUL entries, we no longer need them. We don't
-      // bother freeing the nodes, the won't be reused anyway.
+      // bother freeing the nodes, they won't be reused anyway.
       while (p->wn_sibling != NULL && p->wn_sibling->wn_byte == NUL) {
         p->wn_sibling = p->wn_sibling->wn_sibling;
       }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1591,7 +1591,7 @@ int make_windows(int count, bool vertical)
   int todo;
 
   if (vertical) {
-    // Each windows needs at least 'winminwidth' lines and a separator
+    // Each window needs at least 'winminwidth' lines and a separator
     // column.
     maxcount = (curwin->w_width + curwin->w_vsep_width
                 - (p_wiw - p_wmw)) / (p_wmw + 1);
@@ -2119,7 +2119,7 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
       m = frame_minheight(topfr, next_curwin);
       room = height - m;
       if (room < 0) {
-        // The room is less then 'winheight', use all space for the
+        // The room is less than 'winheight', use all space for the
         // current window.
         next_curwin_size = p_wh + room;
         room = 0;


### PR DESCRIPTION
#### vim-patch:8.2.3914: various spelling mistakes in comments

Problem:    Various spelling mistakes in comments.
Solution:   Fix the mistakes. (Dominique Pellé, closes vim/vim#9416)
https://github.com/vim/vim/commit/af4a61a85d6e8cacc35324f266934bc463a21673