### PR TITLE
chore: fix typos

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -523,7 +523,7 @@ function! s:check_virtualenv() abort
         let hint = '$PATH ambiguities in subshells typically are '
           \.'caused by your shell config overriding the $PATH previously set by the '
           \.'virtualenv. Either prevent them from doing so, or use this workaround: '
-          \.'https://vi.stackexchange.com/a/7654'
+          \.'https://vi.stackexchange.com/a/34996'
         let hints[hint] = v:true
       endif
     endfor

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -361,7 +361,7 @@ UTF-32 and UTF-16 sizes of the deleted region is also passed as additional
 arguments {old_utf32_size} and {old_utf16_size}.
 
 "on_changedtick" is invoked when |b:changedtick| was incremented but no text
-was changed. The parameters recieved are ("changedtick", {buf}, {changedtick}).
+was changed. The parameters received are ("changedtick", {buf}, {changedtick}).
 
                                                         *api-lua-detach*
 In-process Lua callbacks can detach by returning `true`. This will detach all
@@ -634,7 +634,7 @@ nvim_call_atomic({calls})                                 *nvim_call_atomic()*
                    atomically, i.e. without interleaving redraws, RPC requests
                    from other clients, or user interactions (however API
                    methods may trigger autocommands or event processing which
-                   have such side-effects, e.g. |:sleep| may wake timers).
+                   have such side effects, e.g. |:sleep| may wake timers).
                 2. To minimize RPC overhead (roundtrips) of a sequence of many
                    requests.
 
@@ -698,7 +698,7 @@ nvim_del_keymap({mode}, {lhs})                             *nvim_del_keymap()*
                     |nvim_set_keymap()|
 
 nvim_del_mark({name})                                        *nvim_del_mark()*
-                Deletes a uppercase/file named mark. See |mark-motions|.
+                Deletes an uppercase/file named mark. See |mark-motions|.
 
                 Note:
                     fails with error if a lowercase or buffer local named mark
@@ -2655,7 +2655,7 @@ nvim_win_is_valid({window})                              *nvim_win_is_valid()*
                     true if the window is valid, false otherwise
 
 nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
-                Sets the current buffer in a window, without side-effects
+                Sets the current buffer in a window, without side effects
 
                 Attributes: ~
                     not allowed when |textlock| is active

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -130,7 +130,7 @@ with |vim.notify()|: >
 In this example, there is nothing to do when diagnostics are hidden, so we
 omit the "hide" function.
 
-Existing handlers can be overriden. For example, use the following to only
+Existing handlers can be overridden. For example, use the following to only
 show a sign for the highest severity diagnostic on a given line: >
 
 	-- Create a custom namespace. This will aggregate signs from all other
@@ -175,8 +175,9 @@ All highlights defined for diagnostics begin with `Diagnostic` followed by
 the type of highlight (e.g., `Sign`, `Underline`, etc.) and the severity (e.g.
 `Error`, `Warn`, etc.)
 
-Sign, underline and virtual text highlights (by default) are linked to their
-corresponding default highlight.
+By default, highlights for signs, floating windows, and virtual text are linked to the
+corresponding default highlight. Underline highlights are not linked and use their
+own default highlight groups.
 
 For example, the default highlighting for |hl-DiagnosticSignError| is linked
 to |hl-DiagnosticError|. To change the default (and therefore the linked
@@ -296,7 +297,6 @@ Example: >
 	autocmd DiagnosticChanged * lua vim.diagnostic.setqflist({open = false })
 <
 ==============================================================================
-==============================================================================
 Lua module: vim.diagnostic                                    *diagnostic-api*
 
 config({opts}, {namespace})                          *vim.diagnostic.config()*
@@ -341,7 +341,10 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      |diagnostic-severity|
 
                                  • virtual_text: (default true) Use virtual
-                                   text for diagnostics. Options:
+                                   text for diagnostics. If multiple
+                                   diagnostics are set for a namespace, one
+                                   prefix per diagnostic + the last diagnostic
+                                   message are shown. Options:
                                    • severity: Only show virtual text for
                                      diagnostics matching the given severity
                                      |diagnostic-severity|
@@ -351,6 +354,11 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                      is more than one diagnostic source in the
                                      buffer. Otherwise, any truthy value means
                                      to always show the diagnostic source.
+                                   • spacing: (number) Amount of empty spaces
+                                     inserted at the beginning of the virtual
+                                     text.
+                                   • prefix: (string) Prepend diagnostic
+                                     message with prefix.
                                    • format: (function) A function that takes
                                      a diagnostic as input and returns a
                                      string. The return value is the text used

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2259,7 +2259,7 @@ USAGE				RESULT	DESCRIPTION	~
 abs({expr})			Float or Number  absolute value of {expr}
 acos({expr})			Float	arc cosine of {expr}
 add({object}, {item})		List/Blob   append {item} to {object}
-and({expr}, {expr})		Number  bitwise AND
+and({expr}, {expr})		Number	bitwise AND
 api_info()			Dict	api metadata
 append({lnum}, {string})	Number	append {string} below line {lnum}
 append({lnum}, {list})		Number	append lines {list} below line {lnum}
@@ -2291,7 +2291,7 @@ assert_notmatch({pat}, {text} [, {msg}])
 assert_report({msg})		Number	report a test failure
 assert_true({actual} [, {msg}])	Number	assert {actual} is true
 atan({expr})			Float	arc tangent of {expr}
-atan2({expr}, {expr})		Float   arc tangent of {expr1} / {expr2}
+atan2({expr}, {expr})		Float	arc tangent of {expr1} / {expr2}
 browse({save}, {title}, {initdir}, {default})
 				String	put up a file requester
 browsedir({title}, {initdir})	String	put up a directory requester
@@ -2317,7 +2317,7 @@ char2nr({expr}[, {utf8}])	Number	ASCII/UTF-8 value of first char in {expr}
 charidx({string}, {idx} [, {countcc}])
 				Number	char index of byte {idx} in {string}
 chdir({dir})			String	change current working directory
-cindent({lnum})		Number	C indent for line {lnum}
+cindent({lnum})			Number	C indent for line {lnum}
 clearmatches([{win}])		none	clear all matches
 col({expr})			Number	column nr of cursor or mark
 complete({startcol}, {matches}) none	set Insert mode completion
@@ -2330,7 +2330,7 @@ copy({expr})			any	make a shallow copy of {expr}
 cos({expr})			Float	cosine of {expr}
 cosh({expr})			Float	hyperbolic cosine of {expr}
 count({list}, {expr} [, {ic} [, {start}]])
-				Number	 count how many {expr} are in {list}
+				Number	count how many {expr} are in {list}
 cscope_connection([{num}, {dbpath} [, {prepend}]])
 				Number	checks existence of cscope connection
 ctxget([{index}])		Dict	return the |context| dict at {index}
@@ -2343,7 +2343,7 @@ ctxsize()			Number	return |context-stack| size
 cursor({lnum}, {col} [, {off}])
 				Number	move cursor to {lnum}, {col}, {off}
 cursor({list})			Number	move cursor to position in {list}
-debugbreak({pid})		Number  interrupt process being debugged
+debugbreak({pid})		Number	interrupt process being debugged
 deepcopy({expr} [, {noref}])	any	make a full copy of {expr}
 delete({fname} [, {flags}])	Number	delete the file or directory {fname}
 deletebufline({buf}, {first}[, {last}])
@@ -2362,7 +2362,7 @@ eval({string})			any	evaluate {string} into its value
 eventhandler()			Number	|TRUE| if inside an event handler
 executable({expr})		Number	1 if executable {expr} exists
 execute({command})		String	execute and capture output of {command}
-exepath({expr})		String  full path of the command {expr}
+exepath({expr})			String	full path of the command {expr}
 exists({expr})			Number	|TRUE| if {expr} exists
 extend({expr1}, {expr2} [, {expr3}])
 				List/Dict insert items of {expr2} into {expr1}
@@ -2482,11 +2482,11 @@ inputlist({textlist})		Number	let the user pick from a choice list
 inputrestore()			Number	restore typeahead
 inputsave()			Number	save and clear typeahead
 inputsecret({prompt} [, {text}])
-				String  like input() but hiding the text
+				String	like input() but hiding the text
 insert({object}, {item} [, {idx}])
 				List	insert {item} in {object} [before {idx}]
 interrupt()			none	interrupt script execution
-invert({expr})			Number  bitwise invert
+invert({expr})			Number	bitwise invert
 isdirectory({directory})	Number	|TRUE| if {directory} is a directory
 isinf({expr})			Number	determine if {expr} is infinity value
 					(positive or negative)
@@ -2506,7 +2506,7 @@ json_encode({expr})		String	Convert {expr} to JSON
 keys({dict})			List	keys in {dict}
 len({expr})			Number	the length of {expr}
 libcall({lib}, {func}, {arg})	String	call {func} in library {lib} with {arg}
-libcallnr({lib}, {func}, {arg})  Number  idem, but return a Number
+libcallnr({lib}, {func}, {arg})	Number	idem, but return a Number
 line({expr} [, {winid}])	Number	line nr of cursor, last line or mark
 line2byte({lnum})		Number	byte count of line {lnum}
 lispindent({lnum})		Number	Lisp indent for line {lnum}
@@ -2548,7 +2548,7 @@ msgpackparse({data})		List	parse msgpack to a list of objects
 nextnonblank({lnum})		Number	line nr of non-blank line >= {lnum}
 nr2char({expr}[, {utf8}])	String	single char with ASCII/UTF-8 value {expr}
 nvim_...({args}...)		any	call nvim |api| functions
-or({expr}, {expr})		Number  bitwise OR
+or({expr}, {expr})		Number	bitwise OR
 pathshorten({expr})		String	shorten directory names in a path
 perleval({expr})		any	evaluate |perl| expression
 pow({x}, {y})			Float	{x} to the power of {y}
@@ -2607,7 +2607,7 @@ screenrow()			Number	current cursor row
 screenstring({row}, {col})	String	characters at screen position
 search({pattern} [, {flags} [, {stopline} [, {timeout}]]])
 				Number	search for {pattern}
-searchcount([{options}])	Dict    Get or update the last search count
+searchcount([{options}])	Dict	Get or update the last search count
 searchdecl({name} [, {global} [, {thisblock}]])
 				Number	search for variable declaration
 searchpair({start}, {middle}, {end} [, {flags} [, {skip} [...]]])
@@ -2679,7 +2679,7 @@ split({expr} [, {pat} [, {keepempty}]])
 				List	make |List| from {pat} separated {expr}
 sqrt({expr})			Float	square root of {expr}
 stdioopen({dict})		Number	open stdio in a headless instance.
-stdpath({what})                 String/List  returns the standard path(s) for {what}
+stdpath({what})			String/List  returns the standard path(s) for {what}
 str2float({expr} [, {quoted}])	Float	convert String to Float
 str2list({expr} [, {utf8}])	List	convert each character of {expr} to
 					ASCII/UTF-8 value
@@ -2715,7 +2715,7 @@ synID({lnum}, {col}, {trans})	Number	syntax ID at {lnum} and {col}
 synIDattr({synID}, {what} [, {mode}])
 				String	attribute {what} of syntax ID {synID}
 synIDtrans({synID})		Number	translated syntax ID of {synID}
-synconcealed({lnum}, {col})	List    info about concealing
+synconcealed({lnum}, {col})	List	info about concealing
 synstack({lnum}, {col})	List	stack of syntax IDs at {lnum} and {col}
 system({cmd} [, {input}])	String	output of shell command/filter {cmd}
 systemlist({cmd} [, {input}])	List	output of shell command/filter {cmd}
@@ -2751,7 +2751,7 @@ values({dict})			List	values in {dict}
 virtcol({expr})			Number	screen column of cursor or mark
 visualmode([expr])		String	last visual mode used
 wait({timeout}, {condition}[, {interval}])
-				Number  Wait until {condition} is satisfied
+				Number	Wait until {condition} is satisfied
 wildmenumode()			Number	whether 'wildmenu' mode is active
 win_execute({id}, {command} [, {silent}])
 				String	execute {command} in window {id}

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -214,7 +214,7 @@ For |lsp-request|, each |lsp-handler| has this signature: >
                             request, a table with information about the error
                             is sent. Otherwise, it is `nil`. See |lsp-response|.
             {result}    (Result | Params | nil)
-                            When the language server is able to succesfully
+                            When the language server is able to successfully
                             complete a request, this contains the `result` key
                             of the response. See |lsp-response|.
             {ctx}       (table)
@@ -236,7 +236,7 @@ For |lsp-request|, each |lsp-handler| has this signature: >
             {config}    (table)
                             Configuration for the handler.
 
-                            Each handler can define it's own configuration
+                            Each handler can define its own configuration
                             table that allows users to customize the behavior
                             of a particular handler.
 
@@ -274,7 +274,7 @@ For |lsp-notification|, each |lsp-handler| has this signature: >
             {config}    (table)
                             Configuration for the handler.
 
-                            Each handler can define it's own configuration
+                            Each handler can define its own configuration
                             table that allows users to customize the behavior
                             of a particular handler.
 
@@ -369,7 +369,7 @@ Handlers can be set by:
     For example: >
 
   vim.lsp.start_client {
-    ..., -- Other configuration ommitted.
+    ..., -- Other configuration omitted.
     handlers = {
         ["textDocument/definition"] = my_custom_server_definition
     },
@@ -393,6 +393,9 @@ in the following order:
 1. Handler passed to |vim.lsp.buf_request()|, if any.
 2. Handler defined in |vim.lsp.start_client()|, if any.
 3. Handler defined in |vim.lsp.handlers|, if any.
+
+                                                            *vim.lsp.log_levels*
+Log levels are defined in |vim.log.levels|
 
 
 VIM.LSP.PROTOCOL                                              *vim.lsp.protocol*
@@ -444,7 +447,7 @@ LspCodeLens
    |nvim_buf_set_extmark()|.
 
 LspCodeLensSeparator                                 *hl-LspCodeLensSeparator*
-   Used to color the seperator between two or more code lens.
+   Used to color the separator between two or more code lens.
 
                                                      *lsp-highlight-signature*
 
@@ -819,10 +822,10 @@ start_client({config})                                *vim.lsp.start_client()*
                                          throws an error. `code` is a number
                                          describing the error. Other arguments
                                          may be passed depending on the error
-                                         kind. See |vim.lsp.client_errors| for
-                                         possible errors. Use
-                                         `vim.lsp.client_errors[code]` to get
-                                         human-friendly name.
+                                         kind. See |vim.lsp.rpc.client_errors|
+                                         for possible errors. Use
+                                         `vim.lsp.rpc.client_errors[code]` to
+                                         get human-friendly name.
                     {before_init}        Callback with parameters
                                          (initialize_params, config) invoked
                                          before the LSP "initialize" phase,
@@ -1285,7 +1288,7 @@ hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
                     {config}  table Configuration table.
                               • border: (default=nil)
                                 • Add borders to the floating window
-                                • See |vim.api.nvim_open_win()|
+                                • See |nvim_open_win()|
 
                                            *vim.lsp.handlers.signature_help()*
 signature_help({_}, {result}, {ctx}, {config})

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -759,9 +759,9 @@ vim.stricmp({a}, {b})                                   *vim.stricmp()*
         respectively.
 
 vim.str_utfindex({str}[, {index}])                      *vim.str_utfindex()*
-        Convert byte index to UTF-32 and UTF-16 indicies. If {index} is not
-        supplied, the length of the string is used. All indicies are zero-based.
-        Returns two values: the UTF-32 and UTF-16 indicies respectively.
+        Convert byte index to UTF-32 and UTF-16 indices. If {index} is not
+        supplied, the length of the string is used. All indices are zero-based.
+        Returns two values: the UTF-32 and UTF-16 indices respectively.
 
         Embedded NUL bytes are treated as terminating the string. Invalid
         UTF-8 bytes, and embedded surrogates are counted as one code
@@ -880,6 +880,15 @@ vim.types                                               *vim.types*
         values corresponding to `vim.types.float`, `vim.types.array` and
         `vim.types.dictionary` will not change or that `vim.types` table will
         only contain values for these three types.
+
+                                                   *log_levels* *vim.log.levels*
+Log levels are one of the values defined in `vim.log.levels`:
+
+        vim.log.levels.DEBUG
+        vim.log.levels.ERROR
+        vim.log.levels.INFO
+        vim.log.levels.TRACE
+        vim.log.levels.WARN
 
 ------------------------------------------------------------------------------
 LUA-VIMSCRIPT BRIDGE                                    *lua-vimscript*

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -90,7 +90,7 @@ Mouse input has the following behavior:
 - If another window is clicked, terminal focus will be lost and nvim will jump
   to the clicked window
 - If the mouse wheel is used while the mouse is positioned in another window,
-  the terminal wont lose focus and the hovered window will be scrolled.
+  the terminal won't lose focus and the hovered window will be scrolled.
 
 ==============================================================================
 Configuration					*terminal-config*
@@ -426,7 +426,7 @@ When 'background' is "dark":
   hi debugBreakpoint term=reverse ctermbg=red guibg=red
 
 
-Shorcuts						*termdebug_shortcuts*
+Shortcuts						*termdebug_shortcuts*
 
 You can define your own shortcuts (mappings) to control gdb, that can work in
 any window, using the TermDebugSendCommand() function.  Example: >

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -100,7 +100,7 @@ tsnode:prev_named_sibling()				*tsnode:prev_named_sibling()*
 
 tsnode:iter_children()					*tsnode:iter_children()*
 	Iterates over all the direct children of {tsnode}, regardless of
-	wether they are named or not.
+	whether they are named or not.
 	Returns the child node plus the eventual field name corresponding to
 	this child node.
 
@@ -155,9 +155,9 @@ tsnode:sexpr()						*tsnode:sexpr()*
 	Get an S-expression representing the node as a string.
 
 tsnode:id()						*tsnode:id()*
-	Get an unique identier for the node inside its own tree.
+	Get an unique identifier for the node inside its own tree.
 
-	No guarantees are made about this identifer's internal representation,
+	No guarantees are made about this identifier's internal representation,
 	except for being a primitive lua type with value equality (so not a table).
 	Presently it is a (non-printable) string.
 
@@ -195,7 +195,7 @@ to a match.
 Treesitter Query Predicates				*lua-treesitter-predicates*
 
 When writing queries for treesitter, one might use `predicates`, that is,
-special scheme nodes that are evaluted to verify things on a captured node for
+special scheme nodes that are evaluated to verify things on a captured node for
 example, the |eq?| predicate : >
 	((identifier) @foo (#eq? @foo "foo"))
 
@@ -203,7 +203,7 @@ This will only match identifier corresponding to the `"foo"` text.
 Here is a list of built-in predicates :
 
 	`eq?`						*ts-predicate-eq?*
-		This predicate will check text correspondance between nodes or
+		This predicate will check text correspondence between nodes or
 		strings : >
 			((identifier) @foo (#eq? @foo "foo"))
 			((node1) @left (node2) @right (#eq? @left @right))
@@ -212,7 +212,7 @@ Here is a list of built-in predicates :
 	`vim-match?`					*ts-predicate-vim-match?*
 		This will match if the provived vim regex matches the text
 		corresponding to a node : >
-			((idenfitier) @constant (#match? @constant "^[A-Z_]+$"))
+			((identifier) @constant (#match? @constant "^[A-Z_]+$"))
 <		Note: the `^` and `$` anchors will respectively match the
 			start and end of the node's text.
 
@@ -267,7 +267,7 @@ Here is a list of built-in directives:
 	`offset!`					*ts-predicate-offset!*
 		Takes the range of the captured node and applies the offsets
 		to it's range : >
-			((idenfitier) @constant (#offset! @constant 0 1 0 -1))
+			((identifier) @constant (#offset! @constant 0 1 0 -1))
 <		This will generate a range object for the captured node with the
 		offsets applied. The arguments are
 		`({capture_id}, {start_row}, {start_col}, {end_row}, {end_col}, {key?})`

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -556,13 +556,19 @@ end
 ---       - underline: (default true) Use underline for diagnostics. Options:
 ---                    * severity: Only underline diagnostics matching the given severity
 ---                    |diagnostic-severity|
----       - virtual_text: (default true) Use virtual text for diagnostics. Options:
+---       - virtual_text: (default true) Use virtual text for diagnostics. If multiple diagnostics
+---                       are set for a namespace, one prefix per diagnostic + the last diagnostic
+---                       message are shown.
+---                       Options:
 ---                       * severity: Only show virtual text for diagnostics matching the given
 ---                       severity |diagnostic-severity|
 ---                       * source: (boolean or string) Include the diagnostic source in virtual
 ---                                 text. Use "if_many" to only show sources if there is more than
 ---                                 one diagnostic source in the buffer. Otherwise, any truthy value
 ---                                 means to always show the diagnostic source.
+---                       * spacing: (number) Amount of empty spaces inserted at the beginning
+---                                  of the virtual text.
+---                       * prefix: (string) Prepend diagnostic message with prefix.
 ---                       * format: (function) A function that takes a diagnostic as input and
 ---                                 returns a string. The return value is the text used to display
 ---                                 the diagnostic. Example:

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -290,7 +290,7 @@ end
 --- Memoizes a function. On first run, the function return value is saved and
 --- immediately returned on subsequent runs. If the function returns a multival,
 --- only the first returned value will be memoized and returned. The function will only be run once,
---- even if it has side-effects.
+--- even if it has side effects.
 ---
 ---@param fn (function) Function to run
 ---@returns (function) Memoized function
@@ -645,8 +645,8 @@ end
 ---@param on_error Callback with parameters (code, ...), invoked
 --- when the client operation throws an error. `code` is a number describing
 --- the error. Other arguments may be passed depending on the error kind.  See
---- |vim.lsp.client_errors| for possible errors.
---- Use `vim.lsp.client_errors[code]` to get human-friendly name.
+--- |vim.lsp.rpc.client_errors| for possible errors.
+--- Use `vim.lsp.rpc.client_errors[code]` to get human-friendly name.
 ---
 ---@param before_init Callback with parameters (initialize_params, config)
 --- invoked before the LSP "initialize" phase, where `params` contains the
@@ -757,8 +757,8 @@ function lsp.start_client(config)
   ---
   ---@param code (number) Error code
   ---@param err (...) Other arguments may be passed depending on the error kind
-  ---@see |vim.lsp.client_errors| for possible errors. Use
-  ---`vim.lsp.client_errors[code]` to get a human-friendly name.
+  ---@see |vim.lsp.rpc.client_errors| for possible errors. Use
+  ---`vim.lsp.rpc.client_errors[code]` to get a human-friendly name.
   function dispatch.on_error(code, err)
     local _ = log.error() and log.error(log_prefix, "on_error", { code = lsp.client_errors[code], err = err })
     err_message(log_prefix, ': Error ', lsp.client_errors[code], ': ', vim.inspect(err))
@@ -1708,14 +1708,14 @@ end
 --
 -- Can be used to lookup the number from the name or the
 -- name from the number.
--- Levels by name: "trace", "debug", "info", "warn", "error"
--- Level numbers begin with "trace" at 0
+-- Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+-- Level numbers begin with "TRACE" at 0
 lsp.log_levels = log.levels
 
 --- Sets the global log level for LSP logging.
 ---
---- Levels by name: "trace", "debug", "info", "warn", "error"
---- Level numbers begin with "trace" at 0
+--- Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+--- Level numbers begin with "TRACE" at 0
 ---
 --- Use `lsp.log_levels` for reverse lookup.
 ---

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -246,7 +246,7 @@ end
 ---@param config table Configuration table.
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
----         - See |vim.api.nvim_open_win()|
+---         - See |nvim_open_win()|
 function M.hover(_, result, ctx, config)
   config = config or {}
   config.focus_id = ctx.method

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -8,8 +8,8 @@ local log = {}
 -- Log level dictionary with reverse lookup as well.
 --
 -- Can be used to lookup the number from the name or the name from the number.
--- Levels by name: 'trace', 'debug', 'info', 'warn', 'error'
--- Level numbers begin with 'trace' at 0
+-- Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+-- Level numbers begin with "TRACE" at 0
 log.levels = vim.deepcopy(vim.log.levels)
 
 -- Default log level is warn.

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -133,7 +133,8 @@ local function request_parser_loop()
   end
 end
 
-local client_errors = vim.tbl_add_reverse_lookup {
+--- Mapping of error codes used by the client
+local client_errors = {
   INVALID_SERVER_MESSAGE       = 1;
   INVALID_SERVER_JSON          = 2;
   NO_RESULT_CALLBACK_FOUND     = 3;
@@ -142,6 +143,8 @@ local client_errors = vim.tbl_add_reverse_lookup {
   SERVER_REQUEST_HANDLER_ERROR = 6;
   SERVER_RESULT_CALLBACK_ERROR = 7;
 }
+
+client_errors = vim.tbl_add_reverse_lookup(client_errors)
 
 --- Constructs an error message from an LSP error object.
 ---

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1622,7 +1622,7 @@ Array nvim_list_chans(void)
 /// 1. To perform several requests from an async context atomically, i.e.
 ///    without interleaving redraws, RPC requests from other clients, or user
 ///    interactions (however API methods may trigger autocommands or event
-///    processing which have such side-effects, e.g. |:sleep| may wake timers).
+///    processing which have such side effects, e.g. |:sleep| may wake timers).
 /// 2. To minimize RPC overhead (roundtrips) of a sequence of many requests.
 ///
 /// @param channel_id
@@ -1979,7 +1979,7 @@ void nvim__screenshot(String path)
 }
 
 
-/// Deletes a uppercase/file named mark. See |mark-motions|.
+/// Deletes an uppercase/file named mark. See |mark-motions|.
 ///
 /// @note fails with error if a lowercase or buffer local named mark is used.
 /// @param name       Mark name

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -39,7 +39,7 @@ Buffer nvim_win_get_buf(Window window, Error *err)
   return win->w_buffer->handle;
 }
 
-/// Sets the current buffer in a window, without side-effects
+/// Sets the current buffer in a window, without side effects
 ///
 /// @param window   Window handle, or 0 for current window
 /// @param buffer   Buffer handle

--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -75,7 +75,7 @@ bool loop_poll_events(Loop *loop, int ms)
 /// @note Event is queued into `fast_events`, which is processed outside of the
 ///       primary `events` queue by loop_poll_events(). For `main_loop`, that
 ///       means `fast_events` is NOT processed in an "editor mode"
-///       (VimState.execute), so redraw and other side-effects are likely to be
+///       (VimState.execute), so redraw and other side effects are likely to be
 ///       skipped.
 /// @see loop_schedule_deferred
 void loop_schedule_fast(Loop *loop, Event event)

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -424,7 +424,7 @@ end
 --- Without a runtime, writes to :Messages
 ---@see :help nvim_notify
 ---@param msg string Content of the notification to show to the user
----@param log_level number|nil enum from vim.log.levels
+---@param log_level number|nil enum from |vim.log.levels|
 ---@param opts table|nil additional options (timeout, etc)
 function vim.notify(msg, log_level, opts) -- luacheck: no unused
   if log_level == vim.log.levels.ERROR then

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -113,14 +113,14 @@ func Test_put_p_indent_visual()
 endfunc
 
 func Test_multibyte_op_end_mark()
-   new
-   call setline(1, 'тест')
-   normal viwdp
-   call assert_equal([0, 1, 7, 0], getpos("'>"))
-   call assert_equal([0, 1, 7, 0], getpos("']"))
+  new
+  call setline(1, 'тест')
+  normal viwdp
+  call assert_equal([0, 1, 7, 0], getpos("'>"))
+  call assert_equal([0, 1, 7, 0], getpos("']"))
 
-   normal Vyp
-   call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
-   call assert_equal([0, 2, 7, 0], getpos("']"))
-   bwipe!
- endfunc
+  normal Vyp
+  call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
+  call assert_equal([0, 2, 7, 0], getpos("']"))
+  bwipe!
+endfunc

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1855,7 +1855,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term, const char *col
                         "\x1b[?c");
     } else if (konsolev > 0 && konsolev < 180770) {
       // Konsole before version 18.07.70: set up a nonce profile. This has
-      // side-effects on temporary font resizing. #6798
+      // side effects on temporary font resizing. #6798
       data->unibi_ext.set_cursor_style = (int)unibi_add_ext_str(ut, "Ss",
                                                                 TMUX_WRAP(tmux,
                                                                           "\x1b]50;CursorShape=%?"

--- a/test/README.md
+++ b/test/README.md
@@ -38,7 +38,7 @@ Layout
 - `/test/functional` : functional tests
 - `/test/unit` : unit tests
 - `/test/config` : contains `*.in` files which are transformed into `*.lua`
-  files using `configure_file` CMake command: this is for acessing CMake
+  files using `configure_file` CMake command: this is for accessing CMake
   variables in lua tests.
 - `/test/includes` : include-files for use by luajit `ffi.cdef` C definitions
   parser: normally used to make macros not accessible via this mechanism
@@ -197,7 +197,7 @@ Guidelines
   (success + fail + error + pending) is the same in all environments.
     - *Note:* `pending()` is ignored if it is missing an argument, unless it is
       [contained in an `it()` block](https://github.com/neovim/neovim/blob/d21690a66e7eb5ebef18046c7a79ef898966d786/test/functional/ex_cmds/grep_spec.lua#L11).
-      Provide empty function argument if the `pending()` call is outside of `it()`
+      Provide empty function argument if the `pending()` call is outside `it()`
       ([example](https://github.com/neovim/neovim/commit/5c1dc0fbe7388528875aff9d7b5055ad718014de#diff-bf80b24c724b0004e8418102f68b0679R18)).
 - Really long `source([=[...]=])` blocks may break Vim's Lua syntax
   highlighting. Try `:syntax sync fromstart` to fix it.


### PR DESCRIPTION
Manual backport of https://github.com/neovim/neovim/pull/16506 (sans `nvim_{get,set}_option_value` changes).