### PR TITLE
vim-patch:8.2.{56,61,97,98}

### DIFF
--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -47,7 +47,7 @@ typedef struct AutoPat {
 ///
 /// Struct used to keep status while executing autocommands for an event.
 ///
-typedef struct AutoPatCmd {
+struct AutoPatCmd_S {
   AutoPat *curpat;          // next AutoPat to examine
   AutoCmd *nextcmd;         // next AutoCmd to execute
   int group;                    // group being used
@@ -57,8 +57,8 @@ typedef struct AutoPatCmd {
   event_T event;                // current event
   int arg_bufnr;                // initially equal to <abuf>, set to zero when
                                 // buf is deleted
-  struct AutoPatCmd *next;    // chain of active apc-s for auto-invalidation
-} AutoPatCmd;
+  AutoPatCmd *next;    // chain of active apc-s for auto-invalidation
+};
 
 
 // Set by the apply_autocmds_group function if the given event is equal to

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5214,6 +5214,7 @@ static int chk_modeline(linenr_T lnum, int flags)
   intmax_t vers;
   int end;
   int retval = OK;
+  ESTACK_CHECK_DECLARATION
 
   prev = -1;
   for (s = ml_get(lnum); *s != NUL; s++) {
@@ -5260,6 +5261,7 @@ static int chk_modeline(linenr_T lnum, int flags)
 
   // prepare for emsg()
   estack_push(ETYPE_MODELINE, (char_u *)"modelines", lnum);
+  ESTACK_CHECK_SETUP
 
   end = false;
   while (end == false) {
@@ -5318,6 +5320,7 @@ static int chk_modeline(linenr_T lnum, int flags)
     s = e + 1;                        // advance to next part
   }
 
+  ESTACK_CHECK_NOW
   estack_pop();
   xfree(linecopy);
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5261,6 +5261,24 @@ bool garbage_collect(bool testing)
     garbage_collect_at_exit = false;
   }
 
+  // The execution stack can grow big, limit the size.
+  if (exestack.ga_maxlen - exestack.ga_len > 500) {
+    size_t new_len;
+    // Keep 150% of the current size, with a minimum of the growth size.
+    int n = exestack.ga_len / 2;
+    if (n < exestack.ga_growsize) {
+      n = exestack.ga_growsize;
+    }
+
+    // Don't make it bigger though.
+    if (exestack.ga_len + n < exestack.ga_maxlen) {
+      new_len = exestack.ga_itemsize * (exestack.ga_len + n);
+      char_u *pp = xrealloc(exestack.ga_data, new_len);
+      exestack.ga_maxlen = exestack.ga_len + n;
+      exestack.ga_data = pp;
+    }
+  }
+
   // We advance by two (COPYID_INC) because we add one for items referenced
   // through previous_funccal.
   const int copyID = get_copyID();

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8120,16 +8120,16 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     // If this is called from a provider function, restore the scope
     // information of the caller.
     save_current_sctx = current_sctx;
-    save_sourcing_name = sourcing_name;
-    save_sourcing_lnum = sourcing_lnum;
+    save_sourcing_name = SOURCING_NAME;
+    save_sourcing_lnum = SOURCING_LNUM;
     save_autocmd_fname = autocmd_fname;
     save_autocmd_match = autocmd_match;
     save_autocmd_bufnr = autocmd_bufnr;
     save_funccal(&funccal_entry);
 
     current_sctx = provider_caller_scope.script_ctx;
-    sourcing_name = provider_caller_scope.sourcing_name;
-    sourcing_lnum = provider_caller_scope.sourcing_lnum;
+    SOURCING_NAME = provider_caller_scope.sourcing_name;
+    SOURCING_LNUM = provider_caller_scope.sourcing_lnum;
     autocmd_fname = provider_caller_scope.autocmd_fname;
     autocmd_match = provider_caller_scope.autocmd_match;
     autocmd_bufnr = provider_caller_scope.autocmd_bufnr;
@@ -8146,8 +8146,8 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   if (l_provider_call_nesting) {
     current_sctx = save_current_sctx;
-    sourcing_name = save_sourcing_name;
-    sourcing_lnum = save_sourcing_lnum;
+    SOURCING_NAME = save_sourcing_name;
+    SOURCING_LNUM = save_sourcing_lnum;
     autocmd_fname = save_autocmd_fname;
     autocmd_match = save_autocmd_match;
     autocmd_bufnr = save_autocmd_bufnr;

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -386,6 +386,7 @@ typedef enum {
   ETYPE_ENV,              // environment variable
   ETYPE_INTERNAL,         // internal operation
   ETYPE_SPELL,            // loading spell file
+  ETYPE_RPC_REQUEST,      // making RPC request
 } etype_T;
 
 typedef struct {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -837,6 +837,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
   int started_profiling = false;
   bool did_save_redo = false;
   save_redo_T save_redo;
+  ESTACK_CHECK_DECLARATION
 
   // If depth of calling is getting too high, don't execute the function
   if (depth >= p_mfd) {
@@ -1016,6 +1017,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
   }
 
   estack_push_ufunc(ETYPE_UFUNC, fp, 1);
+  ESTACK_CHECK_SETUP
   if (p_verbose >= 12) {
     no_wait_return++;
     verbose_enter_scroll();
@@ -1055,6 +1057,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     --no_wait_return;
   }
 
+  ESTACK_CHECK_NOW
   estack_pop();
 
   const bool do_profiling_yes = do_profiling == PROF_YES;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2042,6 +2042,7 @@ int do_source(char *fname, int check_other, int is_vimrc)
   scriptitem_T *si = NULL;
   proftime_T wait_start;
   bool trigger_source_post = false;
+  ESTACK_CHECK_DECLARATION
 
   p = expand_env_save((char_u *)fname);
   if (p == NULL) {
@@ -2138,6 +2139,7 @@ int do_source(char *fname, int check_other, int is_vimrc)
 
   // Keep the sourcing name/lnum, for recursive calls.
   estack_push(ETYPE_SCRIPT, fname_exp, 0);
+  ESTACK_CHECK_SETUP
 
   // start measuring script load time if --startuptime was passed and
   // time_fd was successfully opened afterwards.
@@ -2255,6 +2257,7 @@ int do_source(char *fname, int check_other, int is_vimrc)
   if (got_int) {
     emsg(_(e_interr));
   }
+  ESTACK_CHECK_NOW
   estack_pop();
   if (p_verbose > 1) {
     verbose_enter();

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -326,6 +326,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
   void *real_cookie;
   int getline_is_func;
   static int call_depth = 0;            // recursiveness
+  ESTACK_CHECK_DECLARATION
 
   // For every pair of do_cmdline()/do_one_cmd() calls, use an extra memory
   // location for storing error messages to be converted to an exception.
@@ -833,6 +834,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
       estack_push(ETYPE_EXCEPT, current_exception->throw_name, current_exception->throw_lnum);
       current_exception->throw_name = NULL;
 
+      ESTACK_CHECK_SETUP
       discard_current_exception();              // uses IObuff if 'verbose'
       suppress_errthrow = true;
       force_abort = true;
@@ -851,6 +853,7 @@ int do_cmdline(char_u *cmdline, LineGetter fgetline, void *cookie, int flags)
         xfree(p);
       }
       xfree(SOURCING_NAME);
+      ESTACK_CHECK_NOW
       estack_pop();
     } else if (got_int || (did_emsg && force_abort)) {
       // On an interrupt or an aborting error not converted to an exception,

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -22,6 +22,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/regexp.h"
+#include "nvim/scriptfile.h"
 #include "nvim/strings.h"
 #include "nvim/vim.h"
 
@@ -482,9 +483,11 @@ static int throw_exception(void *value, except_type_T type, char_u *cmdname)
   }
 
   excp->type = type;
-  excp->throw_name = vim_strsave(sourcing_name == NULL
-      ? (char_u *)"" : sourcing_name);
-  excp->throw_lnum = sourcing_lnum;
+  excp->throw_name = estack_sfile();
+  if (excp->throw_name == NULL) {
+    excp->throw_name = vim_strsave((char_u *)"");
+  }
+  excp->throw_lnum = SOURCING_LNUM;
 
   if (p_verbose >= 13 || debug_break_level > 0) {
     int save_msg_silent = msg_silent;

--- a/src/nvim/ex_eval.h
+++ b/src/nvim/ex_eval.h
@@ -2,7 +2,6 @@
 #define NVIM_EX_EVAL_H
 
 #include "nvim/ex_cmds_defs.h"  // for exarg_T
-#include "nvim/pos.h"           // for linenr_T
 
 /* There is no CSF_IF, the lack of CSF_WHILE, CSF_FOR and CSF_TRY means ":if"
  * was used. */
@@ -32,51 +31,6 @@
 #define CSTP_CONTINUE  16      // ":continue" is pending
 #define CSTP_RETURN    24      // ":return" is pending
 #define CSTP_FINISH    32      // ":finish" is pending
-
-/*
- * A list of error messages that can be converted to an exception.  "throw_msg"
- * is only set in the first element of the list.  Usually, it points to the
- * original message stored in that element, but sometimes it points to a later
- * message in the list.  See cause_errthrow() below.
- */
-struct msglist {
-  char *msg;             // original message
-  char *throw_msg;       // msg to throw: usually original one
-  struct msglist *next;            // next of several messages in a row
-};
-
-// The exception types.
-typedef enum
-{
-  ET_USER,       // exception caused by ":throw" command
-  ET_ERROR,      // error exception
-  ET_INTERRUPT,  // interrupt exception triggered by Ctrl-C
-} except_type_T;
-
-/*
- * Structure describing an exception.
- * (don't use "struct exception", it's used by the math library).
- */
-typedef struct vim_exception except_T;
-struct vim_exception {
-  except_type_T type;                   // exception type
-  char *value;           // exception value
-  struct msglist *messages;        // message(s) causing error exception
-  char_u *throw_name;      // name of the throw point
-  linenr_T throw_lnum;                  // line number of the throw point
-  except_T *caught;          // next exception on the caught stack
-};
-
-/*
- * Structure to save the error/interrupt/exception state between calls to
- * enter_cleanup() and leave_cleanup().  Must be allocated as an automatic
- * variable by the (common) caller of these functions.
- */
-typedef struct cleanup_stuff cleanup_T;
-struct cleanup_stuff {
-  int pending;                  // error/interrupt/exception state
-  except_T *exception;          // exception value
-};
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ex_eval.h.generated.h"

--- a/src/nvim/exception_defs.h
+++ b/src/nvim/exception_defs.h
@@ -1,0 +1,46 @@
+#ifndef NVIM_EXCEPTION_DEFS_H
+#define NVIM_EXCEPTION_DEFS_H
+
+#include "nvim/pos.h"           // for linenr_T
+#include "nvim/types.h"
+
+// A list of error messages that can be converted to an exception.  "throw_msg"
+// is only set in the first element of the list.  Usually, it points to the
+// original message stored in that element, but sometimes it points to a later
+// message in the list.  See cause_errthrow() below.
+struct msglist {
+  char *msg;             // original message
+  char *throw_msg;       // msg to throw: usually original one
+  struct msglist *next;            // next of several messages in a row
+};
+
+// The exception types.
+typedef enum
+{
+  ET_USER,       // exception caused by ":throw" command
+  ET_ERROR,      // error exception
+  ET_INTERRUPT,  // interrupt exception triggered by Ctrl-C
+} except_type_T;
+
+// Structure describing an exception.
+// (don't use "struct exception", it's used by the math library).
+typedef struct vim_exception except_T;
+struct vim_exception {
+  except_type_T type;                   // exception type
+  char *value;           // exception value
+  struct msglist *messages;        // message(s) causing error exception
+  char_u *throw_name;      // name of the throw point
+  linenr_T throw_lnum;                  // line number of the throw point
+  except_T *caught;          // next exception on the caught stack
+};
+
+// Structure to save the error/interrupt/exception state between calls to
+// enter_cleanup() and leave_cleanup().  Must be allocated as an automatic
+// variable by the (common) caller of these functions.
+typedef struct cleanup_stuff cleanup_T;
+struct cleanup_stuff {
+  int pending;                  // error/interrupt/exception state
+  except_T *exception;          // exception value
+};
+
+#endif  // NVIM_EXCEPTION_DEFS_H

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3049,7 +3049,7 @@ int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev, buf_T 
                 mp->m_mode = mode;
                 mp->m_expr = args->expr;
                 mp->m_script_ctx = current_sctx;
-                mp->m_script_ctx.sc_lnum += sourcing_lnum;
+                mp->m_script_ctx.sc_lnum += SOURCING_LNUM;
                 if (args->desc != NULL) {
                   mp->m_desc = xstrdup(args->desc);
                 }
@@ -3129,7 +3129,7 @@ int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev, buf_T 
   mp->m_mode = mode;
   mp->m_expr = args->expr;
   mp->m_script_ctx = current_sctx;
-  mp->m_script_ctx.sc_lnum += sourcing_lnum;
+  mp->m_script_ctx.sc_lnum += SOURCING_LNUM;
   mp->m_desc = NULL;
   if (args->desc != NULL) {
     mp->m_desc = xstrdup(args->desc);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -250,8 +250,13 @@ EXTERN int lines_left INIT(= -1);           // lines left for listing
 EXTERN int msg_no_more INIT(= false);       // don't use more prompt, truncate
                                             // messages
 
-EXTERN char_u *sourcing_name INIT(= NULL);  // name of error message source
-EXTERN linenr_T sourcing_lnum INIT(= 0);    // line number of the source file
+// Stack of execution contexts.  Each entry is an estack_T.
+// Current context is at ga_len - 1.
+EXTERN garray_T exestack INIT(= { 0 COMMA 0 COMMA sizeof(estack_T) COMMA 50 COMMA NULL });
+// name of error message source
+#define SOURCING_NAME (((estack_T *)exestack.ga_data)[exestack.ga_len - 1].es_name)
+// line number in the message source or zero
+#define SOURCING_LNUM (((estack_T *)exestack.ga_data)[exestack.ga_len - 1].es_lnum)
 
 EXTERN int ex_nesting_level INIT(= 0);          // nesting level
 EXTERN int debug_break_level INIT(= -1);        // break below this level

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -973,12 +973,12 @@ static void nlua_typval_exec(const char *lcmd, size_t lcmd_len, const char *name
 
 int nlua_source_using_linegetter(LineGetter fgetline, void *cookie, char *name)
 {
-  const linenr_T save_sourcing_lnum = sourcing_lnum;
+  const linenr_T save_sourcing_lnum = SOURCING_LNUM;
   const sctx_T save_current_sctx = current_sctx;
   current_sctx.sc_sid = SID_STR;
   current_sctx.sc_seq = 0;
   current_sctx.sc_lnum = 0;
-  sourcing_lnum = 0;
+  SOURCING_LNUM = 0;
 
   garray_T ga;
   char_u *line = NULL;
@@ -991,7 +991,7 @@ int nlua_source_using_linegetter(LineGetter fgetline, void *cookie, char *name)
   size_t len = strlen(code);
   nlua_typval_exec(code, len, name, NULL, 0, false, NULL);
 
-  sourcing_lnum = save_sourcing_lnum;
+  SOURCING_LNUM = save_sourcing_lnum;
   current_sctx = save_current_sctx;
   ga_clear_strings(&ga);
   xfree(code);

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -226,4 +226,15 @@
 
 #define EMPTY_POS(a) ((a).lnum == 0 && (a).col == 0 && (a).coladd == 0)
 
+#ifdef ABORT_ON_INTERNAL_ERROR
+# define ESTACK_CHECK_DECLARATION int estack_len_before;
+# define ESTACK_CHECK_SETUP estack_len_before = exestack.ga_len;
+# define ESTACK_CHECK_NOW if (estack_len_before != exestack.ga_len) \
+  siemsg("Exestack length expected: %d, actual: %d", estack_len_before, exestack.ga_len);
+#else
+# define ESTACK_CHECK_DECLARATION
+# define ESTACK_CHECK_SETUP
+# define ESTACK_CHECK_NOW
+#endif
+
 #endif  // NVIM_MACROS_H

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1663,14 +1663,17 @@ static void exe_pre_commands(mparm_T *parmp)
   char **cmds = parmp->pre_commands;
   int cnt = parmp->n_pre_commands;
   int i;
+  ESTACK_CHECK_DECLARATION
 
   if (cnt > 0) {
     curwin->w_cursor.lnum = 0;     // just in case..
     estack_push(ETYPE_ARGS, (char_u *)_("pre-vimrc command line"), 0);
+    ESTACK_CHECK_SETUP
     current_sctx.sc_sid = SID_CMDARG;
     for (i = 0; i < cnt; i++) {
       do_cmdline_cmd(cmds[i]);
     }
+    ESTACK_CHECK_NOW
     estack_pop();
     current_sctx.sc_sid = 0;
     TIME_MSG("--cmd commands");
@@ -1683,6 +1686,7 @@ static void exe_pre_commands(mparm_T *parmp)
 static void exe_commands(mparm_T *parmp)
 {
   int i;
+  ESTACK_CHECK_DECLARATION
 
   /*
    * We start commands on line 0, make "vim +/pat file" match a
@@ -1694,6 +1698,7 @@ static void exe_commands(mparm_T *parmp)
     curwin->w_cursor.lnum = 0;
   }
   estack_push(ETYPE_ARGS, (char_u *)"command line", 0);
+  ESTACK_CHECK_SETUP
   current_sctx.sc_sid = SID_CARG;
   current_sctx.sc_seq = 0;
   for (i = 0; i < parmp->n_commands; i++) {
@@ -1702,6 +1707,7 @@ static void exe_commands(mparm_T *parmp)
       xfree(parmp->commands[i]);
     }
   }
+  ESTACK_CHECK_NOW
   estack_pop();
   current_sctx.sc_sid = 0;
   if (curwin->w_cursor.lnum == 0) {
@@ -1913,13 +1919,18 @@ static int execute_env(char *env)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *initstr = os_getenv(env);
+  ESTACK_CHECK_DECLARATION
+
   if (initstr != NULL) {
     estack_push(ETYPE_ENV, (char_u *)env, 0);
+    ESTACK_CHECK_SETUP
     const sctx_T save_current_sctx = current_sctx;
     current_sctx.sc_sid = SID_ENV;
     current_sctx.sc_seq = 0;
     current_sctx.sc_lnum = 0;
     do_cmdline_cmd((char *)initstr);
+
+    ESTACK_CHECK_NOW
     estack_pop();
     current_sctx = save_current_sctx;
     return OK;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3861,7 +3861,7 @@ static void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)
     .script_ctx = {
       script_ctx.sc_sid,
       script_ctx.sc_seq,
-      script_ctx.sc_lnum + sourcing_lnum
+      script_ctx.sc_lnum + SOURCING_LNUM
     },
     current_channel_id
   };

--- a/src/nvim/scriptfile.c
+++ b/src/nvim/scriptfile.c
@@ -1,0 +1,106 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+/// @file scriptfile.c
+///
+/// functions for dealing with the runtime directories/files
+
+#include "nvim/scriptfile.h"
+#include "nvim/vim.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "scriptfile.c.generated.h"
+#endif
+
+// Initialize the execution stack.
+void estack_init(void)
+{
+  estack_T *entry;
+
+  ga_grow(&exestack, 10);
+  entry = ((estack_T *)exestack.ga_data) + exestack.ga_len;
+  entry->es_type = ETYPE_TOP;
+  entry->es_name = NULL;
+  entry->es_lnum = 0;
+  entry->es_info.ufunc = NULL;
+  exestack.ga_len++;
+}
+
+// Add an item to the execution stack.
+// Returns the new entry or NULL when out of memory.
+estack_T *estack_push(etype_T type, char_u *name, long lnum)
+{
+  estack_T *entry;
+
+  ga_grow(&exestack, 1);
+  entry = ((estack_T *)exestack.ga_data) + exestack.ga_len;
+  entry->es_type = type;
+  entry->es_name = name;
+  entry->es_lnum = lnum;
+  entry->es_info.ufunc = NULL;
+  exestack.ga_len++;
+  return entry;
+}
+
+// Add a user function to the execution stack.
+void estack_push_ufunc(etype_T type, ufunc_T *ufunc, long lnum)
+{
+  estack_T *entry
+      = estack_push(type, ufunc->uf_name_exp != NULL ? ufunc->uf_name_exp : ufunc->uf_name, lnum);
+  if (entry != NULL) {
+    entry->es_info.ufunc = ufunc;
+  }
+}
+
+// Take an item off of the execution stack.
+void estack_pop(void)
+{
+  if (exestack.ga_len > 1) {
+    exestack.ga_len--;
+  }
+}
+
+// Get the current value for <sfile> in allocated memory.
+char_u *estack_sfile(void)
+{
+  size_t len;
+  int idx;
+  estack_T *entry;
+  char *res;
+  size_t done;
+
+  entry = ((estack_T *)exestack.ga_data) + exestack.ga_len - 1;
+  if (entry->es_name == NULL) {
+    return NULL;
+  }
+  if (entry->es_info.ufunc == NULL) {
+    return vim_strsave(entry->es_name);
+  }
+
+  // For a function we compose the call stack, as it was done in the past:
+  //   "function One[123]..Two[456]..Three"
+  len = STRLEN(entry->es_name) + 10;
+  for (idx = exestack.ga_len - 2; idx >= 0; idx--) {
+    entry = ((estack_T *)exestack.ga_data) + idx;
+    if (entry->es_name == NULL || entry->es_info.ufunc == NULL) {
+      idx++;
+      break;
+    }
+    len += STRLEN(entry->es_name) + 15;
+  }
+
+  res = (char *)xmalloc(len);
+  if (res != NULL) {
+    STRCPY(res, "function ");
+    while (idx < exestack.ga_len - 1) {
+      done = STRLEN(res);
+      entry = ((estack_T *)exestack.ga_data) + idx;
+      vim_snprintf(res + done, len - done, "%s[%ld]..", entry->es_name, entry->es_lnum);
+      idx++;
+    }
+    done = STRLEN(res);
+    entry = ((estack_T *)exestack.ga_data) + idx;
+    vim_snprintf(res + done, len - done, "%s", entry->es_name);
+  }
+  return (char_u *)res;
+}

--- a/src/nvim/scriptfile.h
+++ b/src/nvim/scriptfile.h
@@ -1,0 +1,9 @@
+#ifndef NVIM_SCRIPTFILE_H
+#define NVIM_SCRIPTFILE_H
+
+#include "nvim/eval/typval.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "scriptfile.h.generated.h"
+#endif
+#endif  // NVIM_SCRIPTFILE_H

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -580,6 +580,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   int c = 0;
   int res;
   bool did_estack_push = false;
+  ESTACK_CHECK_DECLARATION
 
   fd = os_fopen((char *)fname, "r");
   if (fd == NULL) {
@@ -612,6 +613,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
 
   // Set sourcing_name, so that error messages mention the file name.
   estack_push(ETYPE_SPELL, fname, 0);
+  ESTACK_CHECK_SETUP
   did_estack_push = true;
 
   // <HEADER>: <fileID>
@@ -810,6 +812,7 @@ endOK:
     fclose(fd);
   }
   if (did_estack_push) {
+    ESTACK_CHECK_NOW
     estack_pop();
   }
 

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -579,6 +579,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   slang_T *lp = NULL;
   int c = 0;
   int res;
+  bool did_estack_push = false;
 
   fd = os_fopen((char *)fname, "r");
   if (fd == NULL) {
@@ -611,6 +612,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
 
   // Set sourcing_name, so that error messages mention the file name.
   estack_push(ETYPE_SPELL, fname, 0);
+  did_estack_push = true;
 
   // <HEADER>: <fileID>
   const int scms_ret = spell_check_magic_string(fd);
@@ -807,7 +809,9 @@ endOK:
   if (fd != NULL) {
     fclose(fd);
   }
-  estack_pop();
+  if (did_estack_push) {
+    estack_pop();
+  }
 
   return lp;
 }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -243,6 +243,7 @@
 #include "nvim/path.h"
 #include "nvim/regexp.h"
 #include "nvim/screen.h"
+#include "nvim/scriptfile.h"
 #include "nvim/spell.h"
 #include "nvim/spell_defs.h"
 #include "nvim/spellfile.h"
@@ -575,8 +576,6 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   char_u *p;
   int n;
   int len;
-  char_u *save_sourcing_name = sourcing_name;
-  linenr_T save_sourcing_lnum = sourcing_lnum;
   slang_T *lp = NULL;
   int c = 0;
   int res;
@@ -611,8 +610,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   }
 
   // Set sourcing_name, so that error messages mention the file name.
-  sourcing_name = fname;
-  sourcing_lnum = 0;
+  estack_push(ETYPE_SPELL, fname, 0);
 
   // <HEADER>: <fileID>
   const int scms_ret = spell_check_magic_string(fd);
@@ -809,8 +807,7 @@ endOK:
   if (fd != NULL) {
     fclose(fd);
   }
-  sourcing_name = save_sourcing_name;
-  sourcing_lnum = save_sourcing_lnum;
+  estack_pop();
 
   return lp;
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6824,7 +6824,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       if (dodefault && (forceit || hlgroup->sg_deflink == 0)) {
         hlgroup->sg_deflink = to_id;
         hlgroup->sg_deflink_sctx = current_sctx;
-        hlgroup->sg_deflink_sctx.sc_lnum += sourcing_lnum;
+        hlgroup->sg_deflink_sctx.sc_lnum += SOURCING_LNUM;
       }
     }
 
@@ -6833,7 +6833,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       // for the group, unless '!' is used
       if (to_id > 0 && !forceit && !init
           && hl_has_settings(from_id - 1, dodefault)) {
-        if (sourcing_name == NULL && !dodefault) {
+        if (SOURCING_NAME == NULL && !dodefault) {
           emsg(_("E414: group has settings, highlight link ignored"));
         }
       } else if (hlgroup->sg_link != to_id
@@ -6844,7 +6844,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         }
         hlgroup->sg_link = to_id;
         hlgroup->sg_script_ctx = current_sctx;
-        hlgroup->sg_script_ctx.sc_lnum += sourcing_lnum;
+        hlgroup->sg_script_ctx.sc_lnum += SOURCING_LNUM;
         hlgroup->sg_cleared = false;
         redraw_all_later(SOME_VALID);
 
@@ -7224,7 +7224,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       set_hl_attr(idx);
     }
     HL_TABLE()[idx].sg_script_ctx = current_sctx;
-    HL_TABLE()[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
+    HL_TABLE()[idx].sg_script_ctx.sc_lnum += SOURCING_LNUM;
   }
   xfree(key);
   xfree(arg);

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2382,6 +2382,28 @@ endfunc
 
 " FileChangedShell tested in test_filechanged.vim
 
+func Test_FileType_spell()
+  if !isdirectory('/tmp')
+    throw "Skipped: requires /tmp directory"
+  endif
+
+  " this was crashing with an invalid free()
+  setglobal spellfile=/tmp/en.utf-8.add
+  augroup crash
+    autocmd!
+    autocmd BufNewFile,BufReadPost crashfile setf somefiletype
+    autocmd BufNewFile,BufReadPost crashfile set ft=anotherfiletype
+    autocmd FileType anotherfiletype setlocal spell
+  augroup END
+  func! NoCrash() abort
+    edit /tmp/crashfile
+  endfunc
+  call NoCrash()
+
+  au! crash
+  setglobal spellfile=
+endfunc
+
 func LogACmd()
   call add(g:logged, line('$'))
 endfunc


### PR DESCRIPTION
- vim-patch:8.2.0056: execution stack is incomplete and inefficient
- vim-patch:8.2.0061: the execute stack can grow big and never shrinks
- vim-patch:8.2.0097: crash with autocommand and spellfile
- vim-patch:8.2.0098: exe stack length can be wrong without being detected

8.2.0056:

`check_map_keycodes` was removed in 3baba1e7bc6698e6bc9f1d37fce88b30d6274bc9.

It seems that `gw_grow` never fails in Neovim - so I made the same assumption when porting `scriptfile.c` code.

`term.c` changes are N/A.

Changes to `exception_defs` are N/A because it was converted to a Lua test in https://github.com/neovim/neovim/pull/8635

I had to extract `exception_defs.h` from `ex_eval.h` because otherwise I was getting an include loop as below. I decided to break it up at the first hop but let me know if you disagree.

typval.h -> ex_eval.h -> ex_cmds_defs.h -> normal.h -> buffer_defs.h -> option_defs.h -> typval.h

8.2.0061:

xrealloc never returns NULL in Neovim so I removed check for that.

8.2.0097

Changed int to boolean.

8.2.0098

No changes in `map.c` as `check_map_keycodes` was removed - see above.

