### PR TITLE
vim-patch:8.2.{3454,3455,3497,3540,3581,3678}: some "p" and "gp" patches

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8133,6 +8133,7 @@ static void ex_put(exarg_T *eap)
     eap->forceit = TRUE;
   }
   curwin->w_cursor.lnum = eap->line2;
+  check_cursor_col();
   do_put(eap->regname, NULL, eap->forceit ? BACKWARD : FORWARD, 1,
          PUT_LINE|PUT_CURSLINE);
 }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3616,6 +3616,10 @@ error:
         } else {
           curwin->w_cursor.lnum = new_lnum;
           curwin->w_cursor.col = col;
+          curbuf->b_op_end = curwin->w_cursor;
+          if (col > 1) {
+            curbuf->b_op_end.col = col - 1;
+          }
         }
       } else if (y_type == kMTLineWise) {
         // put cursor on first non-blank in first inserted line

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3591,7 +3591,7 @@ error:
 
       // Put the '] mark on the first byte of the last inserted character.
       // Correct the length for change in indent.
-      curbuf->b_op_end.lnum = lnum;
+      curbuf->b_op_end.lnum = new_lnum;
       col = (colnr_T)STRLEN(y_array[y_size - 1]) - lendiff;
       if (col > 1) {
         curbuf->b_op_end.col = col - 1 - utf_head_off(y_array[y_size - 1],

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3473,6 +3473,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       }
     } else {
       linenr_T new_lnum = new_cursor.lnum;
+      size_t len;
 
       // Insert at least one line.  When y_type is kMTCharWise, break the first
       // line in two.
@@ -3592,10 +3593,11 @@ error:
       // Put the '] mark on the first byte of the last inserted character.
       // Correct the length for change in indent.
       curbuf->b_op_end.lnum = new_lnum;
-      col = (colnr_T)STRLEN(y_array[y_size - 1]) - lendiff;
+      len = STRLEN(y_array[y_size - 1]);
+      col = (colnr_T)len - lendiff;
       if (col > 1) {
         curbuf->b_op_end.col = col - 1 - utf_head_off(y_array[y_size - 1],
-                                                      y_array[y_size - 1] + col - 1);
+                                                      y_array[y_size - 1] + len - 1);
       } else {
         curbuf->b_op_end.col = 0;
       }

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -1,5 +1,7 @@
 " Tests for put commands, e.g. ":put", "p", "gp", "P", "gP", etc.
 
+source check.vim
+
 func Test_put_block()
   new
   call feedkeys("i\<C-V>u2500\<CR>x\<ESC>", 'x')

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -112,6 +112,16 @@ func Test_put_p_indent_visual()
   bwipe!
 endfunc
 
+func Test_gp_with_count_leaves_cursor_at_end()
+  new
+  call setline(1, '<---->')
+  call setreg('@', "foo\nbar", 'c')
+  exe "normal 1G3|3gpix\<Esc>"
+  call assert_equal(['<--foo', 'barfoo', 'barfoo', 'barx-->'], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 func Test_multibyte_op_end_mark()
   new
   call setline(1, 'тест')

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -116,8 +116,10 @@ func Test_gp_with_count_leaves_cursor_at_end()
   new
   call setline(1, '<---->')
   call setreg('@', "foo\nbar", 'c')
-  exe "normal 1G3|3gpix\<Esc>"
-  call assert_equal(['<--foo', 'barfoo', 'barfoo', 'barx-->'], getline(1, '$'))
+  normal 1G3|3gp
+  call assert_equal([0, 4, 4, 0], getpos("."))
+  call assert_equal(['<--foo', 'barfoo', 'barfoo', 'bar-->'], getline(1, '$'))
+  call assert_equal([0, 4, 3, 0], getpos("']"))
 
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -138,6 +138,15 @@ func Test_p_with_count_leaves_mark_at_end()
   bwipe!
 endfunc
 
+func Test_put_above_first_line()
+  new
+  let @" = 'text'
+  silent! normal 0o00
+  0put
+  call assert_equal('text', getline(1))
+  bwipe!
+endfunc
+
 func Test_multibyte_op_end_mark()
   new
   call setline(1, 'тест')

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -126,6 +126,18 @@ func Test_gp_with_count_leaves_cursor_at_end()
   bwipe!
 endfunc
 
+func Test_p_with_count_leaves_mark_at_end()
+  new
+  call setline(1, '<---->')
+  call setreg('@', "start\nend", 'c')
+  normal 1G3|3p
+  call assert_equal([0, 1, 4, 0], getpos("."))
+  call assert_equal(['<--start', 'endstart', 'endstart', 'end-->'], getline(1, '$'))
+  call assert_equal([0, 4, 3, 0], getpos("']"))
+
+  bwipe!
+endfunc
+
 func Test_multibyte_op_end_mark()
   new
   call setline(1, 'тест')


### PR DESCRIPTION
#### vim-patch:8.2.3454: using a count with "gp" leave cursor in wrong position

Problem:    Using a count with "gp" leave cursor in wrong position. (Naohiro
            Ono)
Solution:   Count the inserted lines.
https://github.com/vim/vim/commit/23003e51e18371afda4420d9e171a3dcba5a31cc


#### vim-patch:8.2.3455: using a count with "gp" leaves '] in wrong position

Problem:    Using a count with "gp" leaves '] in wrong position. (Naohiro Ono)
Solution:   Correct the mark position.
https://github.com/vim/vim/commit/56858e4ed4e338e15821767b8303b06099e40384


#### vim-patch:8.2.3497: put test fails when run by itself

Problem:    Put test fails when run by itself.
Solution:   Source check.vim. (Dominique Pellé, closes vim/vim#8990)
https://github.com/vim/vim/commit/a9173d06f7ca320fc84f4ffa993861d21710bc41


#### vim-patch:8.2.3540: the mark '] is wrong after put with a count

Problem:    The mark '] is wrong after put with a count. (Naohiro Ono)
Solution:   Use the right line number.
https://github.com/vim/vim/commit/f47ebf1e1a0a6473b10fb4c92c9c6427aab4dc91


#### vim-patch:8.2.3581: reading character past end of line

Problem:    Reading character past end of line.
Solution:   Correct the cursor column.
https://github.com/vim/vim/commit/0b5b06cb4777d1401fdf83e7d48d287662236e7e


#### vim-patch:8.2.3678: illegal memory access

Problem:    Illegal memory access.
Solution:   Ignore changed indent when computing byte offset.
https://github.com/vim/vim/commit/85be8563fe5aff686e9e30d6afff401ccd976f2a