### PR TITLE
vim-patch:8.1.2302,8.2.{3936,4112}

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -790,9 +790,14 @@ static int diff_write(buf_T *buf, diffin_T *din)
   // Always use 'fileformat' set to "unix".
   char_u *save_ff = buf->b_p_ff;
   buf->b_p_ff = vim_strsave((char_u *)FF_UNIX);
+  const bool save_lockmarks = cmdmod.lockmarks;
+  // Writing the buffer is an implementation detail of performing the diff,
+  // so it shouldn't update the '[ and '] marks.
+  cmdmod.lockmarks = true;
   int r = buf_write(buf, din->din_fname, NULL,
                     (linenr_T)1, buf->b_ml.ml_line_count,
                     NULL, false, false, false, true);
+  cmdmod.lockmarks = save_lockmarks;
   free_string_option(buf->b_p_ff);
   buf->b_p_ff = save_ff;
   return r;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -267,14 +267,14 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
     msg_attr_keep((char *)IObuff, 0, true, false);
   }
 
-  /*
-   * Set "'[" and "']" marks.
-   */
-  curbuf->b_op_start = oap->start;
-  curbuf->b_op_end.lnum = oap->end.lnum;
-  curbuf->b_op_end.col = (colnr_T)STRLEN(ml_get(oap->end.lnum));
-  if (curbuf->b_op_end.col > 0) {
-    curbuf->b_op_end.col--;
+  if (!cmdmod.lockmarks) {
+    // Set "'[" and "']" marks.
+    curbuf->b_op_start = oap->start;
+    curbuf->b_op_end.lnum = oap->end.lnum;
+    curbuf->b_op_end.col = (colnr_T)STRLEN(ml_get(oap->end.lnum));
+    if (curbuf->b_op_end.col > 0) {
+      curbuf->b_op_end.col--;
+    }
   }
 
   changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
@@ -694,9 +694,11 @@ void op_reindent(oparg_T *oap, Indenter how)
                   "%" PRId64 " lines indented ", i),
          (int64_t)i);
   }
-  // set '[ and '] marks
-  curbuf->b_op_start = oap->start;
-  curbuf->b_op_end = oap->end;
+  if (!cmdmod.lockmarks) {
+    // set '[ and '] marks
+    curbuf->b_op_start = oap->start;
+    curbuf->b_op_end = oap->end;
+  }
 }
 
 /*
@@ -1736,13 +1738,15 @@ int op_delete(oparg_T *oap)
   msgmore(curbuf->b_ml.ml_line_count - old_lcount);
 
 setmarks:
-  if (oap->motion_type == kMTBlockWise) {
-    curbuf->b_op_end.lnum = oap->end.lnum;
-    curbuf->b_op_end.col = oap->start.col;
-  } else {
-    curbuf->b_op_end = oap->start;
+  if (!cmdmod.lockmarks) {
+    if (oap->motion_type == kMTBlockWise) {
+      curbuf->b_op_end.lnum = oap->end.lnum;
+      curbuf->b_op_end.col = oap->start.col;
+    } else {
+      curbuf->b_op_end = oap->start;
+    }
+    curbuf->b_op_start = oap->start;
   }
-  curbuf->b_op_start = oap->start;
 
   return OK;
 }
@@ -2007,9 +2011,11 @@ static int op_replace(oparg_T *oap, int c)
   check_cursor();
   changed_lines(oap->start.lnum, oap->start.col, oap->end.lnum + 1, 0L, true);
 
-  // Set "'[" and "']" marks.
-  curbuf->b_op_start = oap->start;
-  curbuf->b_op_end = oap->end;
+  if (!cmdmod.lockmarks) {
+    // Set "'[" and "']" marks.
+    curbuf->b_op_start = oap->start;
+    curbuf->b_op_end = oap->end;
+  }
 
   return OK;
 }
@@ -2078,11 +2084,11 @@ void op_tilde(oparg_T *oap)
     redraw_curbuf_later(INVERTED);
   }
 
-  /*
-   * Set '[ and '] marks.
-   */
-  curbuf->b_op_start = oap->start;
-  curbuf->b_op_end = oap->end;
+  if (!cmdmod.lockmarks) {
+    // Set '[ and '] marks.
+    curbuf->b_op_start = oap->start;
+    curbuf->b_op_end = oap->end;
+  }
 
   if (oap->line_count > p_report) {
     smsg(NGETTEXT("%" PRId64 " line changed",
@@ -2774,14 +2780,14 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     }
   }
 
-  /*
-   * Set "'[" and "']" marks.
-   */
-  curbuf->b_op_start = oap->start;
-  curbuf->b_op_end = oap->end;
-  if (yank_type == kMTLineWise) {
-    curbuf->b_op_start.col = 0;
-    curbuf->b_op_end.col = MAXCOL;
+  if (!cmdmod.lockmarks) {
+    // Set "'[" and "']" marks.
+    curbuf->b_op_start = oap->start;
+    curbuf->b_op_end = oap->end;
+    if (yank_type == kMTLineWise) {
+      curbuf->b_op_start.col = 0;
+      curbuf->b_op_end.col = MAXCOL;
+    }
   }
 
   return;
@@ -2914,6 +2920,8 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
   char_u *insert_string = NULL;
   bool allocated = false;
   long cnt;
+  const pos_T orig_start = curbuf->b_op_start;
+  const pos_T orig_end = curbuf->b_op_end;
   unsigned int cur_ve_flags = get_ve_flags();
 
   if (flags & PUT_FIXINDENT) {
@@ -3618,6 +3626,10 @@ error:
   curwin->w_set_curswant = TRUE;
 
 end:
+  if (cmdmod.lockmarks) {
+    curbuf->b_op_start = orig_start;
+    curbuf->b_op_end = orig_end;
+  }
   if (allocated) {
     xfree(insert_string);
   }
@@ -3964,7 +3976,7 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
   // and setup the array of space strings lengths
   for (t = 0; t < (linenr_T)count; t++) {
     curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
-    if (t == 0 && setmark) {
+    if (t == 0 && setmark && !cmdmod.lockmarks) {
       // Set the '[ mark.
       curwin->w_buffer->b_op_start.lnum = curwin->w_cursor.lnum;
       curwin->w_buffer->b_op_start.col = (colnr_T)STRLEN(curr);
@@ -4085,7 +4097,7 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
 
   ml_replace(curwin->w_cursor.lnum, newp, false);
 
-  if (setmark) {
+  if (setmark && !cmdmod.lockmarks) {
     // Set the '] mark.
     curwin->w_buffer->b_op_end.lnum = curwin->w_cursor.lnum;
     curwin->w_buffer->b_op_end.col = sumsize;
@@ -4223,8 +4235,10 @@ static void op_format(oparg_T *oap, int keep_cursor)
     redraw_curbuf_later(INVERTED);
   }
 
-  // Set '[ mark at the start of the formatted area
-  curbuf->b_op_start = oap->start;
+  if (!cmdmod.lockmarks) {
+    // Set '[ mark at the start of the formatted area
+    curbuf->b_op_start = oap->start;
+  }
 
   // For "gw" remember the cursor position and put it back below (adjusted
   // for joined and split lines).
@@ -4246,8 +4260,10 @@ static void op_format(oparg_T *oap, int keep_cursor)
   old_line_count = curbuf->b_ml.ml_line_count - old_line_count;
   msgmore(old_line_count);
 
-  // put '] mark on the end of the formatted area
-  curbuf->b_op_end = curwin->w_cursor;
+  if (!cmdmod.lockmarks) {
+    // put '] mark on the end of the formatted area
+    curbuf->b_op_end = curwin->w_cursor;
+  }
 
   if (keep_cursor) {
     curwin->w_cursor = saved_cursor;
@@ -4845,7 +4861,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
 
     // Set '[ mark if something changed. Keep the last end
     // position from do_addsub().
-    if (change_cnt > 0) {
+    if (change_cnt > 0 && !cmdmod.lockmarks) {
       curbuf->b_op_start = startpos;
     }
 
@@ -5199,11 +5215,13 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
     }
   }
 
-  // set the '[ and '] marks
-  curbuf->b_op_start = startpos;
-  curbuf->b_op_end = endpos;
-  if (curbuf->b_op_end.col > 0) {
-    curbuf->b_op_end.col--;
+  if (!cmdmod.lockmarks) {
+    // set the '[ and '] marks
+    curbuf->b_op_start = startpos;
+    curbuf->b_op_end = endpos;
+    if (curbuf->b_op_end.col > 0) {
+      curbuf->b_op_end.col--;
+    }
   }
 
 theend:
@@ -6016,6 +6034,8 @@ static void op_function(const oparg_T *oap)
 {
   const TriState save_virtual_op = virtual_op;
   const bool save_finish_op = finish_op;
+  const pos_T orig_start = curbuf->b_op_start;
+  const pos_T orig_end = curbuf->b_op_end;
 
   if (*p_opfunc == NUL) {
     emsg(_("E774: 'operatorfunc' is empty"));
@@ -6049,6 +6069,10 @@ static void op_function(const oparg_T *oap)
 
     virtual_op = save_virtual_op;
     finish_op = save_finish_op;
+    if (cmdmod.lockmarks) {
+      curbuf->b_op_start = orig_start;
+      curbuf->b_op_end = orig_end;
+    }
   }
 }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2380,6 +2380,40 @@ func Test_autocmd_was_using_freed_memory()
   pclose
 endfunc
 
+func Test_BufWrite_lockmarks()
+  edit! Xtest
+  call setline(1, ['a', 'b', 'c', 'd'])
+
+  " :lockmarks preserves the marks
+  call SetChangeMarks(2, 3)
+  lockmarks write
+  call assert_equal([2, 3], [line("'["), line("']")])
+
+  " *WritePre autocmds get the correct line range, but lockmarks preserves the
+  " original values for the user
+  augroup lockmarks
+    au!
+    au BufWritePre,FilterWritePre * call assert_equal([1, 4], [line("'["), line("']")])
+    au FileWritePre * call assert_equal([3, 4], [line("'["), line("']")])
+  augroup END
+
+  lockmarks write
+  call assert_equal([2, 3], [line("'["), line("']")])
+
+  if executable('cat')
+    lockmarks %!cat
+    call assert_equal([2, 3], [line("'["), line("']")])
+  endif
+
+  lockmarks 3,4write Xtest2
+  call assert_equal([2, 3], [line("'["), line("']")])
+
+  au! lockmarks
+  augroup! lockmarks
+  call delete('Xtest')
+  call delete('Xtest2')
+endfunc
+
 " FileChangedShell tested in test_filechanged.vim
 
 func LogACmd()

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1146,6 +1146,25 @@ func Test_diff_followwrap()
   bwipe!
 endfunc
 
+func Test_diff_maintains_change_mark()
+  enew!
+  call setline(1, ['a', 'b', 'c', 'd'])
+  diffthis
+  new
+  call setline(1, ['a', 'b', 'c', 'e'])
+  " Set '[ and '] marks
+  2,3yank
+  call assert_equal([2, 3], [line("'["), line("']")])
+  " Verify they aren't affected by the implicit diff
+  diffthis
+  call assert_equal([2, 3], [line("'["), line("']")])
+  " Verify they aren't affected by an explicit diff
+  diffupdate
+  call assert_equal([2, 3], [line("'["), line("']")])
+  bwipe!
+  bwipe!
+endfunc
+
 func Test_diff_rnu()
   CheckScreendump
 

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1147,22 +1147,30 @@ func Test_diff_followwrap()
 endfunc
 
 func Test_diff_maintains_change_mark()
-  enew!
-  call setline(1, ['a', 'b', 'c', 'd'])
-  diffthis
-  new
-  call setline(1, ['a', 'b', 'c', 'e'])
-  " Set '[ and '] marks
-  2,3yank
-  call assert_equal([2, 3], [line("'["), line("']")])
-  " Verify they aren't affected by the implicit diff
-  diffthis
-  call assert_equal([2, 3], [line("'["), line("']")])
-  " Verify they aren't affected by an explicit diff
-  diffupdate
-  call assert_equal([2, 3], [line("'["), line("']")])
-  bwipe!
-  bwipe!
+  func DiffMaintainsChangeMark()
+    enew!
+    call setline(1, ['a', 'b', 'c', 'd'])
+    diffthis
+    new
+    call setline(1, ['a', 'b', 'c', 'e'])
+    " Set '[ and '] marks
+    2,3yank
+    call assert_equal([2, 3], [line("'["), line("']")])
+    " Verify they aren't affected by the implicit diff
+    diffthis
+    call assert_equal([2, 3], [line("'["), line("']")])
+    " Verify they aren't affected by an explicit diff
+    diffupdate
+    call assert_equal([2, 3], [line("'["), line("']")])
+    bwipe!
+    bwipe!
+  endfunc
+
+  set diffopt-=internal
+  call DiffMaintainsChangeMark()
+  set diffopt+=internal
+  call DiffMaintainsChangeMark()
+  set diffopt&
 endfunc
 
 func Test_diff_rnu()

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1170,7 +1170,9 @@ func Test_diff_maintains_change_mark()
   call DiffMaintainsChangeMark()
   set diffopt+=internal
   call DiffMaintainsChangeMark()
+
   set diffopt&
+  delfunc DiffMaintainsChangeMark
 endfunc
 
 func Test_diff_rnu()

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -207,6 +207,21 @@ func Test_mark_error()
   call assert_fails('mark _', 'E191:')
 endfunc
 
+" Test for :lockmarks when pasting content
+func Test_lockmarks_with_put()
+  new
+  call append(0, repeat(['sky is blue'], 4))
+  normal gg
+  1,2yank r
+  put r
+  normal G
+  lockmarks put r
+  call assert_equal(2, line("'["))
+  call assert_equal(3, line("']"))
+
+  bwipe!
+endfunc
+
 " Test for the getmarklist() function
 func Test_getmarklist()
   new
@@ -231,3 +246,5 @@ func Test_getmarklist()
   call assert_equal([], {}->getmarklist())
   close!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -174,15 +174,6 @@ func Test_get_register()
 
   call assert_equal('', getregtype('!'))
 
-  " Test for clipboard registers (* and +)
-  if has("clipboard_working")
-    call append(0, "text for clipboard test")
-    normal gg"*yiw
-    call assert_equal('text', getreg('*'))
-    normal gg2w"+yiw
-    call assert_equal('clipboard', getreg('+'))
-  endif
-
   " Test for inserting an invalid register content
   call assert_beeps('exe "normal i\<C-R>!"')
 
@@ -238,7 +229,99 @@ func Test_set_register()
   call feedkeys('qRhhq', 'xt')
   call assert_equal('llhh', getreg('r'))
 
+  " Appending a list of characters to a register from different lines
+  let @r = ''
+  call append(0, ['abcdef', '123456'])
+  normal gg"ry3l
+  call cursor(2, 4)
+  normal "Ry3l
+  call assert_equal('abc456', @r)
+
+  " Test for gP with multiple lines selected using characterwise motion
+  %delete
+  call append(0, ['vim editor', 'vim editor'])
+  let @r = ''
+  exe "normal ggwy/vim /e\<CR>gP"
+  call assert_equal(['vim editor', 'vim editor', 'vim editor'], getline(1, 3))
+
+  " Test for gP with . register
+  %delete
+  normal iabc
+  normal ".gp
+  call assert_equal('abcabc', getline(1))
+  normal 0".gP
+  call assert_equal('abcabcabc', getline(1))
+
   enew!
+endfunc
+
+" Test for clipboard registers (* and +)
+func Test_clipboard_regs()
+  throw 'skipped: needs clipboard=autoselect,autoselectplus'
+
+  CheckNotGui
+  CheckFeature clipboard_working
+
+  new
+  call append(0, "text for clipboard test")
+  normal gg"*yiw
+  call assert_equal('text', getreg('*'))
+  normal gg2w"+yiw
+  call assert_equal('clipboard', getreg('+'))
+
+  " Test for replacing the clipboard register contents
+  set clipboard=unnamed
+  let @* = 'food'
+  normal ggviw"*p
+  call assert_equal('text', getreg('*'))
+  call assert_equal('food for clipboard test', getline(1))
+  normal ggviw"*p
+  call assert_equal('food', getreg('*'))
+  call assert_equal('text for clipboard test', getline(1))
+
+  " Test for replacing the selection register contents
+  set clipboard=unnamedplus
+  let @+ = 'food'
+  normal ggviw"+p
+  call assert_equal('text', getreg('+'))
+  call assert_equal('food for clipboard test', getline(1))
+  normal ggviw"+p
+  call assert_equal('food', getreg('+'))
+  call assert_equal('text for clipboard test', getline(1))
+
+  " Test for auto copying visually selected text to clipboard register
+  call setline(1, "text for clipboard test")
+  let @* = ''
+  set clipboard=autoselect
+  normal ggwwviwy
+  call assert_equal('clipboard', @*)
+
+  " Test for auto copying visually selected text to selection register
+  let @+ = ''
+  set clipboard=autoselectplus
+  normal ggwviwy
+  call assert_equal('for', @+)
+
+  set clipboard&vim
+  bwipe!
+endfunc
+
+" Test for restarting the current mode (insert or virtual replace) after
+" executing the contents of a register
+func Test_put_reg_restart_mode()
+  new
+  call append(0, 'editor')
+  normal gg
+  let @r = "ivim \<Esc>"
+  call feedkeys("i\<C-O>@r\<C-R>=mode()\<CR>", 'xt')
+  call assert_equal('vimi editor', getline(1))
+
+  call setline(1, 'editor')
+  normal gg
+  call feedkeys("gR\<C-O>@r\<C-R>=mode()\<CR>", 'xt')
+  call assert_equal('vimReditor', getline(1))
+
+  bwipe!
 endfunc
 
 func Test_v_register()

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -84,42 +84,127 @@ func Test_edit_change()
   set virtualedit=
 endfunc
 
-" Test for pasting before and after a tab character
+" Tests for pasting at the beginning, end and middle of a tab character
+" in virtual edit mode.
 func Test_paste_in_tab()
   new
-  let @" = 'xyz'
+  call append(0, '')
   set virtualedit=all
-  call append(0, "a\tb")
-  call cursor(1, 2, 6)
-  normal p
-  call assert_equal("a\txyzb", getline(1))
+
+  " Tests for pasting a register with characterwise mode type
+  call setreg('"', 'xyz', 'c')
+
+  " paste (p) unnamed register at the beginning of a tab
   call setline(1, "a\tb")
-  call cursor(1, 2)
+  call cursor(1, 2, 0)
+  normal p
+  call assert_equal('a xyz      b', getline(1))
+
+  " paste (P) unnamed register at the beginning of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 0)
   normal P
   call assert_equal("axyz\tb", getline(1))
 
-  " Test for virtual block paste
-  call setreg('"', 'xyz', 'b')
+  " paste (p) unnamed register at the end of a tab
   call setline(1, "a\tb")
   call cursor(1, 2, 6)
   normal p
   call assert_equal("a\txyzb", getline(1))
+
+  " paste (P) unnamed register at the end of a tab
   call setline(1, "a\tb")
   call cursor(1, 2, 6)
   normal P
-  call assert_equal("a      xyz b", getline(1))
+  call assert_equal('a      xyz b', getline(1))
 
-  " Test for virtual block paste with gp and gP
+  " Tests for pasting a register with blockwise mode type
+  call setreg('"', 'xyz', 'b')
+
+  " paste (p) unnamed register at the beginning of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 0)
+  normal p
+  call assert_equal('a xyz      b', getline(1))
+
+  " paste (P) unnamed register at the beginning of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 0)
+  normal P
+  call assert_equal("axyz\tb", getline(1))
+
+  " paste (p) unnamed register at the end of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 6)
+  normal p
+  call assert_equal("a\txyzb", getline(1))
+
+  " paste (P) unnamed register at the end of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 6)
+  normal P
+  call assert_equal('a      xyz b', getline(1))
+
+  " Tests for pasting with gp and gP in virtual edit mode
+
+  " paste (gp) unnamed register at the beginning of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 0)
+  normal gp
+  call assert_equal('a xyz      b', getline(1))
+  call assert_equal([0, 1, 12, 0, 12], getcurpos())
+
+  " paste (gP) unnamed register at the beginning of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 0)
+  normal gP
+  call assert_equal("axyz\tb", getline(1))
+  call assert_equal([0, 1, 5, 0, 5], getcurpos())
+
+  " paste (gp) unnamed register at the end of a tab
   call setline(1, "a\tb")
   call cursor(1, 2, 6)
   normal gp
   call assert_equal("a\txyzb", getline(1))
   call assert_equal([0, 1, 6, 0, 12], getcurpos())
+
+  " paste (gP) unnamed register at the end of a tab
   call setline(1, "a\tb")
   call cursor(1, 2, 6)
   normal gP
-  call assert_equal("a      xyz b", getline(1))
-  call assert_equal([0, 1, 12, 0 ,12], getcurpos())
+  call assert_equal('a      xyz b', getline(1))
+  call assert_equal([0, 1, 12, 0, 12], getcurpos())
+
+  " Tests for pasting a named register
+  let @r = 'xyz'
+
+  " paste (gp) named register in the middle of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 2)
+  normal "rgp
+  call assert_equal('a   xyz    b', getline(1))
+  call assert_equal([0, 1, 8, 0, 8], getcurpos())
+
+  " paste (gP) named register in the middle of a tab
+  call setline(1, "a\tb")
+  call cursor(1, 2, 2)
+  normal "rgP
+  call assert_equal('a  xyz     b', getline(1))
+  call assert_equal([0, 1, 7, 0, 7], getcurpos())
+
+  bwipe!
+  set virtualedit=
+endfunc
+
+" Test for yanking a few spaces within a tab to a register
+func Test_yank_in_tab()
+  new
+  let @r = ''
+  call setline(1, "a\tb")
+  set virtualedit=all
+  call cursor(1, 2, 2)
+  normal "ry5l
+  call assert_equal('     ', @r)
 
   bwipe!
   set virtualedit=


### PR DESCRIPTION
vim-patch:8.1.2302: :lockmarks does not work for '[ and ']

Problem:    :lockmarks does not work for '[ and '].
Solution:   save and restore '[ and '] marks. (James McCoy, closes vim/vim#5222)
vim/vim@f4a1d1c

Test_diff_maintains_change_mark doesn't actually fail without these changes.
This is fixed in v8.2.3936. Ref: https://github.com/vim/vim/pull/9424.

vim-patch:8.2.3936: no proper test for maintaining change mark in diff mode

Problem:    No proper test for maintaining change mark in diff mode.
Solution:   Run the test with internal and external diff. (Sean Dewar,
            closes vim/vim#9424)
vim/vim@ccc1644

Closes #8807