### PR TITLE
fix: off-by-one error in example code

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -272,7 +272,7 @@ arguments separated by " " (space) instead of "\t" (tab).
                             lua << EOF
                             local linenr = vim.api.nvim_win_get_cursor(0)[1]
                             local curline = vim.api.nvim_buf_get_lines(
-                                    0, linenr, linenr + 1, false)[1]
+                                    0, linenr - 1, linenr, false)[1]
                             print(string.format("Current line [%d] has %d bytes",
                                     linenr, #curline))
                             EOF


### PR DESCRIPTION
Fix for example code in `:help lua-heredoc`:
The `start` argument of `nvim_buf_get_lines` is zero-based whereas the line number returned by `nvim_win_get_cursor` is 1-based.