### PR TITLE
feat(RecordingLeave) populate v:event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -840,6 +840,9 @@ RecordingLeave			When a macro stops recording.
 				register.
 				|reg_recorded()| is only updated after this
 				event.
+				Sets these |v:event| keys:
+				    regcontents
+				    regname
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using
 				the |:mksession| command.

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -920,16 +920,12 @@ int do_record(int c)
     dict_T *dict = get_v_event(&save_v_event);
 
     // The recorded text contents.
-    list_T *const list = tv_list_alloc(1);
     p = get_recorded();
     if (p != NULL) {
       // Remove escaping for CSI and K_SPECIAL in multi-byte chars.
       vim_unescape_csi(p);
-
-      tv_list_append_string(list, (const char *)p, -1);
+      (void)tv_dict_add_str(dict, S_LEN("regcontents"), (const char *)p);
     }
-    tv_list_set_lock(list, VAR_FIXED);
-    (void)tv_dict_add_list(dict, S_LEN("regcontents"), list);
 
     // Name of requested register, or empty string for unnamed operation.
     char buf[NUMBUFLEN+2];

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -915,10 +915,33 @@ int do_record(int c)
       apply_autocmds(EVENT_RECORDINGENTER, NULL, NULL, false, curbuf);
     }
   } else {  // stop recording
+    save_v_event_T save_v_event;
+    // Set the v:event dictionary with information about the recording.
+    dict_T *dict = get_v_event(&save_v_event);
+
+    // The recorded text contents.
+    list_T *const list = tv_list_alloc(1);
+    p = get_recorded();
+    if (p != NULL) {
+      // Remove escaping for CSI and K_SPECIAL in multi-byte chars.
+      vim_unescape_csi(p);
+
+      tv_list_append_string(list, (const char *)p, -1);
+    }
+    tv_list_set_lock(list, VAR_FIXED);
+    (void)tv_dict_add_list(dict, S_LEN("regcontents"), list);
+
+    // Name of requested register, or empty string for unnamed operation.
+    char buf[NUMBUFLEN+2];
+    buf[0] = (char)regname;
+    buf[1] = NUL;
+    (void)tv_dict_add_str(dict, S_LEN("regname"), buf);
+
     // Get the recorded key hits.  K_SPECIAL and CSI will be escaped, this
     // needs to be removed again to put it in a register.  exec_reg then
     // adds the escaping back later.
     apply_autocmds(EVENT_RECORDINGLEAVE, NULL, NULL, false, curbuf);
+    restore_v_event(dict, &save_v_event);
     reg_recorded = reg_recording;
     reg_recording = 0;
     if (ui_has(kUIMessages)) {
@@ -926,13 +949,9 @@ int do_record(int c)
     } else {
       msg("");
     }
-    p = get_recorded();
     if (p == NULL) {
       retval = FAIL;
     } else {
-      // Remove escaping for CSI and K_SPECIAL in multi-byte chars.
-      vim_unescape_csi(p);
-
       // We don't want to change the default register here, so save and
       // restore the current register name.
       old_y_previous = y_previous;

--- a/test/functional/autocmd/recording_spec.lua
+++ b/test/functional/autocmd/recording_spec.lua
@@ -59,7 +59,7 @@ describe('RecordingLeave', function()
       call feedkeys("qqyyq", 'xt')
     ]]
     eq('q', eval 'g:regname')
-    eq({'yy'}, eval 'g:regcontents')
+    eq('yy', eval 'g:regcontents')
   end)
 
   it('resets v:event', function()

--- a/test/functional/autocmd/recording_spec.lua
+++ b/test/functional/autocmd/recording_spec.lua
@@ -11,7 +11,7 @@ describe('RecordingEnter', function()
     source_vim [[
       let g:recorded = 0
       autocmd RecordingEnter * let g:recorded += 1
-      execute "normal! qqyyq"
+      call feedkeys("qqyyq", 'xt')
     ]]
     eq(1, eval('g:recorded'))
   end)
@@ -20,7 +20,7 @@ describe('RecordingEnter', function()
     source_vim [[
       let g:recording = ''
       autocmd RecordingEnter * let g:recording = reg_recording()
-      execute "normal! qqyyq"
+      call feedkeys("qqyyq", 'xt')
     ]]
     eq('q', eval('g:recording'))
   end)
@@ -32,7 +32,7 @@ describe('RecordingLeave', function()
     source_vim [[
       let g:recorded = 0
       autocmd RecordingLeave * let g:recorded += 1
-      execute "normal! qqyyq"
+      call feedkeys("qqyyq", 'xt')
     ]]
     eq(1, eval('g:recorded'))
   end)
@@ -43,10 +43,30 @@ describe('RecordingLeave', function()
       let g:recording = ''
       autocmd RecordingLeave * let g:recording = reg_recording()
       autocmd RecordingLeave * let g:recorded = reg_recorded()
-      execute "normal! qqyyq"
+      call feedkeys("qqyyq", 'xt')
     ]]
     eq('q', eval 'g:recording')
     eq('', eval 'g:recorded')
     eq('q', eval 'reg_recorded()')
+  end)
+
+  it('populates v:event', function()
+    source_vim [[
+      let g:regname = ''
+      let g:regcontents = ''
+      autocmd RecordingLeave * let g:regname = v:event.regname
+      autocmd RecordingLeave * let g:regcontents = v:event.regcontents
+      call feedkeys("qqyyq", 'xt')
+    ]]
+    eq('q', eval 'g:regname')
+    eq({'yy'}, eval 'g:regcontents')
+  end)
+
+  it('resets v:event', function()
+    source_vim [[
+      autocmd RecordingLeave * let g:event = v:event
+      call feedkeys("qqyyq", 'xt')
+    ]]
+    eq(0, eval 'len(v:event)')
   end)
 end)


### PR DESCRIPTION
Makes finalising a recording of a macro populate the entries `regname` and `regcontents` of `v:event` about what was recorded before `RecordingLeave` is triggered.