### PR TITLE
vim-patch:8.2.{2887,3414,3999}: fullcommand() follow-up patches

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2891,12 +2891,16 @@ void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   exarg_T ea;
   char_u *name = argvars[0].vval.v_string;
 
-  while (name[0] != NUL && name[0] == ':') {
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = NULL;
+  if (name == NULL) {
+    return;
+  }
+
+  while (*name != NUL && *name == ':') {
     name++;
   }
   name = skip_range(name, NULL);
-
-  rettv->v_type = VAR_STRING;
 
   ea.cmd = (*name == '2' || *name == '3') ? name + 1 : name;
   ea.cmdidx = (cmdidx_T)0;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2897,7 +2897,7 @@ void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  while (*name != NUL && *name == ':') {
+  while (*name == ':') {
     name++;
   }
   name = skip_range(name, NULL);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2910,7 +2910,7 @@ void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   rettv->vval.v_string = vim_strsave(IS_USER_CMDIDX(ea.cmdidx)
-                                     ? get_user_commands(NULL, ea.useridx)
+                                     ? get_user_command_name(ea.useridx, ea.cmdidx)
                                      : cmdnames[ea.cmdidx].cmd_name);
 }
 
@@ -5155,7 +5155,7 @@ static int check_more(int message, bool forceit)
 char_u *get_command_name(expand_T *xp, int idx)
 {
   if (idx >= CMD_SIZE) {
-    return get_user_command_name(idx);
+    return expand_user_command_name(idx);
   }
   return cmdnames[idx].cmd_name;
 }
@@ -6270,7 +6270,7 @@ static void do_ucmd(exarg_T *eap)
   xfree(split_buf);
 }
 
-static char_u *get_user_command_name(int idx)
+static char_u *expand_user_command_name(int idx)
 {
   return get_user_commands(NULL, idx - CMD_SIZE);
 }
@@ -6299,6 +6299,24 @@ char_u *get_user_commands(expand_T *xp FUNC_ATTR_UNUSED, int idx)
   idx -= buf->b_ucmds.ga_len;
   if (idx < ucmds.ga_len) {
     return USER_CMD(idx)->uc_name;
+  }
+  return NULL;
+}
+
+// Get the name of user command "idx".  "cmdidx" can be CMD_USER or
+// CMD_USER_BUF.
+// Returns NULL if the command is not found.
+static char_u *get_user_command_name(int idx, int cmdidx)
+{
+  if (cmdidx == CMD_USER && idx < ucmds.ga_len) {
+    return USER_CMD(idx)->uc_name;
+  }
+  if (cmdidx == CMD_USER_BUF) {
+    // In cmdwin, the alternative buffer should be used.
+    buf_T *buf = (cmdwin_type != 0 && get_cmdline_type() == NUL) ? prevwin->w_buffer : curbuf;
+    if (idx < buf->b_ucmds.ga_len) {
+      return USER_CMD_GA(&buf->b_ucmds, idx)->uc_name;
+    }
   }
   return NULL;
 }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -503,6 +503,13 @@ func Test_fullcommand()
   call assert_equal('', fullcommand(v:_null_string))
 
   call assert_equal('syntax', 'syn'->fullcommand())
+
+  command -buffer BufferLocalCommand :
+  command GlobalCommand :
+  call assert_equal('GlobalCommand', fullcommand('GlobalCom'))
+  call assert_equal('BufferLocalCommand', fullcommand('BufferL'))
+  delcommand BufferLocalCommand
+  delcommand GlobalCommand
 endfunc
 
 func Test_shellcmd_completion()

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -500,6 +500,7 @@ func Test_fullcommand()
   for [in, want] in items(tests)
     call assert_equal(want, fullcommand(in))
   endfor
+  call assert_equal('', fullcommand(v:_null_string))
 
   call assert_equal('syntax', 'syn'->fullcommand())
 endfunc


### PR DESCRIPTION
#### vim-patch:8.2.2887: crash when passing null string to fullcommand()

Problem:    Crash when passing null string to fullcommand().
Solution:   Check for NULL pointer.
https://github.com/vim/vim/commit/4c8e8c6e19b75d632b042aa0ba0a2ab769b2162e


#### vim-patch:8.2.3414: fullcommand() gives wrong name with buffer-local user command

Problem:    fullcommand() gives the wrong name if there is a buffer-local user
            command. (Naohiro Ono)
Solution:   Use a separate function to get the user command name.
https://github.com/vim/vim/commit/80c88eac5a81dd9f1a96fc80cb8aab6c84fe7b86

#### vim-patch:8.2.3999: redundant check for NUL byte

Problem:    Redundant check for NUL byte.
Solution:   Remove the check for a NUL byte. (closes vim/vim#9471)
https://github.com/vim/vim/commit/c024ed9233feac4c8da7394a62bb50474803514f