### PR TITLE
ci: bump clang version to 13 in asan and tsan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - flavor: asan
-            cc: clang-12
+            cc: clang-13
             runner: ubuntu-20.04
             os: linux
           - flavor: lint
@@ -31,7 +31,7 @@ jobs:
             runner: ubuntu-20.04
             os: linux
           - flavor: tsan
-            cc: clang-12
+            cc: clang-13
             runner: ubuntu-20.04
             os: linux
           - cc: clang
@@ -63,7 +63,7 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod a+x llvm.sh
-          sudo ./llvm.sh 12
+          sudo ./llvm.sh 13
           rm llvm.sh
 
       - name: Install brew packages

--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -34,7 +34,7 @@ case "$FLAVOR" in
     BUILD_FLAGS="$BUILD_FLAGS -DPREFER_LUA=ON"
     cat <<EOF >> "$GITHUB_ENV"
 CLANG_SANITIZER=ASAN_UBSAN
-SYMBOLIZER=asan_symbolize-12
+SYMBOLIZER=asan_symbolize-13
 ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan
 UBSAN_OPTIONS=print_stacktrace=1 log_path=$GITHUB_WORKSPACE/build/log/ubsan
 EOF


### PR DESCRIPTION
Close #16833 

Maybe this is not the right solution, but this is easier than requiring `sudo` in asan CI.