### PR TITLE
vim-patch:8.1.2073: when editing a buffer 'colorcolumn' may not work

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1497,6 +1497,11 @@ void set_curbuf(buf_T *buf, int action)
  */
 void enter_buffer(buf_T *buf)
 {
+  // Get the buffer in the current window.
+  curwin->w_buffer = buf;
+  curbuf = buf;
+  curbuf->b_nwindows++;
+
   // Copy buffer and window local option values.  Not for a help buffer.
   buf_copy_options(buf, BCO_ENTER | BCO_NOHELP);
   if (!buf->b_help) {
@@ -1506,11 +1511,6 @@ void enter_buffer(buf_T *buf)
     clearFolding(curwin);
   }
   foldUpdateAll(curwin);        // update folds (later).
-
-  // Get the buffer in the current window.
-  curwin->w_buffer = buf;
-  curbuf = buf;
-  curbuf->b_nwindows++;
 
   if (curwin->w_p_diff) {
     diff_buf_add(curbuf);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1984,10 +1984,9 @@ static void didset_options(void)
   (void)did_set_spell_option(true);
   // set cedit_key
   (void)check_cedit();
-  briopt_check(curwin);
   // initialize the table for 'breakat'.
   fill_breakat_flags();
-  fill_culopt_flags(NULL, curwin);
+  didset_window_options(curwin);
 }
 
 // More side effects of setting options.
@@ -6174,6 +6173,7 @@ void win_copy_options(win_T *wp_from, win_T *wp_to)
 {
   copy_winopt(&wp_from->w_onebuf_opt, &wp_to->w_onebuf_opt);
   copy_winopt(&wp_from->w_allbuf_opt, &wp_to->w_allbuf_opt);
+  didset_window_options(wp_to);
 }
 
 /// Copy the options from one winopt_T to another.

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -597,6 +597,31 @@ func Test_cursorline_with_visualmode()
   call delete('Xtest_cursorline_with_visualmode')
 endfunc
 
+func Test_colorcolumn()
+  CheckScreendump
+
+  " check that setting 'colorcolumn' when entering a buffer works
+  let lines =<< trim END
+	split
+	edit X
+	call setline(1, ["1111111111","22222222222","3333333333"])
+	set nomodified
+	set colorcolumn=3,9
+	set number cursorline cursorlineopt=number
+	wincmd w
+	buf X
+  END
+  call writefile(lines, 'Xtest_colorcolumn')
+  let buf = RunVimInTerminal('-S Xtest_colorcolumn', {'rows': 10})
+  call term_sendkeys(buf, ":\<CR>")
+  call term_wait(buf)
+  call VerifyScreenDump(buf, 'Test_colorcolumn_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_colorcolumn')
+endfunc
+
 func Test_colorcolumn_bri()
   CheckScreendump
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1482,8 +1482,6 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
   copyFoldingState(oldp, newp);
 
   win_init_some(newp, oldp);
-
-  didset_window_options(newp);
 }
 
 /*


### PR DESCRIPTION
#### vim-patch:8.1.2073: when editing a buffer 'colorcolumn' may not work

Problem:    When editing a buffer 'colorcolumn' may not work.
Solution:   Set the buffer before copying option values. Call
            check_colorcolumn() after copying window options.
https://github.com/vim/vim/commit/010ee9657acf1a9f799079d718998c94e50ccadc

Fix #12918