### PR TITLE
fix(aucmd_win): ensure aucmd_win stays floating

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1147,6 +1147,7 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     globaldir = NULL;
 
     block_autocmds();  // We don't want BufEnter/WinEnter autocommands.
+    make_snapshot(SNAP_AUCMD_IDX);
     if (need_append) {
       win_append(lastwin, aucmd_win);
       pmap_put(handle_T)(&window_handles, aucmd_win->handle, aucmd_win);
@@ -1212,6 +1213,8 @@ win_found:
       close_tabpage(curtab);
     }
 
+    restore_snapshot(SNAP_AUCMD_IDX, false);
+    win_comp_pos();  // recompute window positions
     unblock_autocmds();
 
     win_T *const save_curwin = win_find_by_handle(aco->save_curwin_handle);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1147,7 +1147,6 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     globaldir = NULL;
 
     block_autocmds();  // We don't want BufEnter/WinEnter autocommands.
-    make_snapshot(SNAP_AUCMD_IDX);
     if (need_append) {
       win_append(lastwin, aucmd_win);
       pmap_put(handle_T)(&window_handles, aucmd_win->handle, aucmd_win);
@@ -1213,8 +1212,6 @@ win_found:
       close_tabpage(curtab);
     }
 
-    restore_snapshot(SNAP_AUCMD_IDX, false);
-    win_comp_pos();  // recompute window positions
     unblock_autocmds();
 
     win_T *const save_curwin = win_find_by_handle(aco->save_curwin_handle);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4242,7 +4242,7 @@ static void win_move_into_split(win_T *wp, win_T *targetwin, int size, int flags
   int height = wp->w_height;
   win_T *oldwin = curwin;
 
-  if (wp == targetwin) {
+  if (wp == targetwin || wp == aucmd_win) {
     return;
   }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -958,6 +958,11 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   int wmh1;
   bool did_set_fraction = false;
 
+  // aucmd_win should always remain floating
+  if (new_wp != NULL && new_wp == aucmd_win) {
+    return FAIL;
+  }
+
   if (flags & WSP_TOP) {
     oldwin = firstwin;
   } else if (flags & WSP_BOT || curwin->w_floating) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1838,6 +1838,9 @@ static void win_totop(int size, int flags)
     beep_flush();
     return;
   }
+  if (curwin == aucmd_win) {
+    return;
+  }
 
   if (curwin->w_floating) {
     ui_comp_remove_grid(&curwin->w_grid_alloc);


### PR DESCRIPTION
Nvim uses a floating window for the autocmd window, but in certain situations,
it can be made non-floating (`:wincmd J`), which can cause issues due to the
previous setup and cleanup logic for a non-floating aucmd_win being removed from
aucmd_prepbuf and aucmd_restbuf.

This can cause glitchiness and crashes due to the aucmd_win's frame being
invalid after closing its tabpage, for example.

Ensure aucmd_win cannot be made non-floating. The only place this happens is in
win_split_ins.

Closes #13699.
Also fixes #13104 after re-applying the reverted patches in #13123.