### PR TITLE
docs: change recommended commit type for static analysis to refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ see potential bugs found by [PVS Studio](https://www.viva64.com/en/pvs-studio/).
 
 - Use this format for commit messages (where `{id}` is the PVS warning-id)):
   ```
-  fix(PVS/V{id}): {description}
+  refactor(PVS/V{id}): {description}
   ```
 - Search the Neovim commit history to find examples:
   ```
@@ -178,7 +178,7 @@ master build. To view the defects, just request access; you will be approved.
 - Use this format for commit messages (where `{id}` is the CID (Coverity ID);
   ([example](https://github.com/neovim/neovim/pull/804))):
   ```
-  fix(coverity/{id}): {description}
+  refactor(coverity/{id}): {description}
   ```
 - Search the Neovim commit history to find examples:
   ```


### PR DESCRIPTION
The changelog tool uses the "fix" type to determine specific bug fixes.
The fixes from the static analysis tools may fix a bug, but that is not
certain. It's therefore more appropriate to default to using the
refactor type instead.
