### PR TITLE
vim-patch:8.2.3952: first line not redrawn when adding lines to an empty buffer

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3006,7 +3006,12 @@ void ex_append(exarg_T *eap)
 
     did_undo = true;
     ml_append(lnum, theline, (colnr_T)0, false);
-    appended_lines_mark(lnum + (empty ? 1 : 0), 1L);
+    if (empty) {
+      // there are no marks below the inserted lines
+      appended_lines(lnum, 1L);
+    } else {
+      appended_lines_mark(lnum, 1L);
+    }
 
     xfree(theline);
     ++lnum;

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -1,6 +1,8 @@
 " Tests for various Ex commands.
 
 source check.vim
+source shared.vim
+source term_util.vim
 
 func Test_ex_delete()
   new
@@ -122,6 +124,27 @@ func Test_append_cmd()
   close!
 endfunc
 
+func Test_append_cmd_empty_buf()
+  CheckRunVimInTerminal
+  let lines =<< trim END
+    func Timer(timer)
+      append
+    aaaaa
+    bbbbb
+    .
+    endfunc
+    call timer_start(10, 'Timer')
+  END
+  call writefile(lines, 'Xtest_append_cmd_empty_buf')
+  let buf = RunVimInTerminal('-S Xtest_append_cmd_empty_buf', {'rows': 6})
+  call WaitForAssert({-> assert_equal('bbbbb', term_getline(buf, 2))})
+  call WaitForAssert({-> assert_equal('aaaaa', term_getline(buf, 1))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_append_cmd_empty_buf')
+endfunc
+
 " Test for the :insert command
 func Test_insert_cmd()
   set noautoindent " test assumes noautoindent, but it's on by default in Nvim
@@ -149,6 +172,27 @@ func Test_insert_cmd()
   call assert_true(&autoindent)
   set autoindent&
   close!
+endfunc
+
+func Test_insert_cmd_empty_buf()
+  CheckRunVimInTerminal
+  let lines =<< trim END
+    func Timer(timer)
+      insert
+    aaaaa
+    bbbbb
+    .
+    endfunc
+    call timer_start(10, 'Timer')
+  END
+  call writefile(lines, 'Xtest_insert_cmd_empty_buf')
+  let buf = RunVimInTerminal('-S Xtest_insert_cmd_empty_buf', {'rows': 6})
+  call WaitForAssert({-> assert_equal('bbbbb', term_getline(buf, 2))})
+  call WaitForAssert({-> assert_equal('aaaaa', term_getline(buf, 1))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_insert_cmd_empty_buf')
 endfunc
 
 " Test for the :change command


### PR DESCRIPTION
Fix #14109

#### vim-patch:8.2.3952: first line not redrawn when adding lines to an empty buffer

Problem:    First line not redrawn when adding lines to an empty buffer.
Solution:   Adjust the argument to appended_lines(). (closes vim/vim#9439)
https://github.com/vim/vim/commit/1fa3de1ce806ba18ebcc00c6d9a0678a84735463