### PR TITLE
ci: run lint only on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    if: (github.event_name == 'pull_request' && github.base_ref == 'master' && !github.event.pull_request.draft) || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    runs-on: ubuntu-20.04
+    env:
+      CC: gcc
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup common environment variables
+        run: ./.github/workflows/env.sh lint
+
+      - name: Install apt packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake build-essential ccache cmake cpanminus gettext gperf language-pack-tr libtool-bin locales ninja-build pkg-config python3 python3-pip python3-setuptools unzip
+
+      - name: Setup interpreter packages
+        run: |
+          ./ci/before_install.sh
+          ./ci/install.sh
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.CACHE_NVIM_DEPS_DIR }}
+            ~/.ccache
+          key: ${{ matrix.runner }}-lint-${{ matrix.cc }}-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
+
+      - name: Build third-party
+        run: ./ci/before_script.sh
+
+      - name: Run lint
+        run: ./ci/script.sh
+
+      - name: Cache dependencies
+        if: ${{ success() }}
+        run: ./ci/before_cache.sh
+
   unixish:
     name: ${{ matrix.runner }} ${{ matrix.flavor }} (cc=${{ matrix.cc }})
     strategy:
@@ -24,10 +63,6 @@ jobs:
         include:
           - flavor: asan
             cc: clang-12
-            runner: ubuntu-20.04
-            os: linux
-          - flavor: lint
-            cc: gcc
             runner: ubuntu-20.04
             os: linux
           - flavor: tsan


### PR DESCRIPTION
The list of known lint issues is only updated for the master branch, so other branches report lots of false positive issues.