### PR TITLE
fix(diagnostic): improve validation for list arguments

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -644,7 +644,11 @@ function M.set(namespace, bufnr, diagnostics, opts)
   vim.validate {
     namespace = {namespace, 'n'},
     bufnr = {bufnr, 'n'},
-    diagnostics = {diagnostics, 't'},
+    diagnostics = {
+      diagnostics,
+      vim.tbl_islist,
+      "a list of diagnostics",
+    },
     opts = {opts, 't', true},
   }
 
@@ -810,7 +814,11 @@ M.handlers.signs = {
     vim.validate {
       namespace = {namespace, 'n'},
       bufnr = {bufnr, 'n'},
-      diagnostics = {diagnostics, 't'},
+      diagnostics = {
+        diagnostics,
+        vim.tbl_islist,
+        "a list of diagnostics",
+      },
       opts = {opts, 't', true},
     }
 
@@ -873,7 +881,11 @@ M.handlers.underline = {
     vim.validate {
       namespace = {namespace, 'n'},
       bufnr = {bufnr, 'n'},
-      diagnostics = {diagnostics, 't'},
+      diagnostics = {
+        diagnostics,
+        vim.tbl_islist,
+        "a list of diagnostics",
+      },
       opts = {opts, 't', true},
     }
 
@@ -921,7 +933,11 @@ M.handlers.virtual_text = {
     vim.validate {
       namespace = {namespace, 'n'},
       bufnr = {bufnr, 'n'},
-      diagnostics = {diagnostics, 't'},
+      diagnostics = {
+        diagnostics,
+        vim.tbl_islist,
+        "a list of diagnostics",
+      },
       opts = {opts, 't', true},
     }
 
@@ -1081,7 +1097,11 @@ function M.show(namespace, bufnr, diagnostics, opts)
   vim.validate {
     namespace = { namespace, 'n', true },
     bufnr = { bufnr, 'n', true },
-    diagnostics = { diagnostics, 't', true },
+    diagnostics = {
+      diagnostics,
+      function(v) return v == nil or vim.tbl_islist(v) end,
+      "a list of diagnostics",
+    },
     opts = { opts, 't', true },
   }
 
@@ -1526,7 +1546,13 @@ local errlist_type_map = {
 ---@param diagnostics table List of diagnostics |diagnostic-structure|.
 ---@return array of quickfix list items |setqflist-what|
 function M.toqflist(diagnostics)
-  vim.validate { diagnostics = {diagnostics, 't'} }
+  vim.validate {
+    diagnostics = {
+      diagnostics,
+      vim.tbl_islist,
+      "a list of diagnostics",
+    },
+  }
 
   local list = {}
   for _, v in ipairs(diagnostics) do
@@ -1557,7 +1583,13 @@ end
 ---            |getloclist()|.
 ---@return array of diagnostics |diagnostic-structure|
 function M.fromqflist(list)
-  vim.validate { list = {list, 't'} }
+  vim.validate {
+    list = {
+      list,
+      vim.tbl_islist,
+      "a list of quickfix items",
+    },
+  }
 
   local diagnostics = {}
   for _, item in ipairs(list) do

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -587,7 +587,7 @@ do
         -- Check user-provided validation function.
         local valid, optional_message = t(val)
         if not valid then
-          local error_message = string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), val)
+          local error_message = string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), type(val))
           if optional_message ~= nil then
             error_message = error_message .. string.format(". Info: %s", optional_message)
           end

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -587,7 +587,7 @@ do
         -- Check user-provided validation function.
         local valid, optional_message = t(val)
         if not valid then
-          local error_message = string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), type(val))
+          local error_message = string.format("%s: expected %s, got %s", param_name, (spec[3] or '?'), tostring(val))
           if optional_message ~= nil then
             error_message = error_message .. string.format(". Info: %s", optional_message)
           end

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1119,6 +1119,11 @@ describe('vim.diagnostic', function()
   end)
 
   describe('set()', function()
+    it('validates its arguments', function()
+      matches("expected a list of diagnostics",
+        pcall_err(exec_lua, [[vim.diagnostic.set(1, 0, {lnum = 1, col = 2})]]))
+    end)
+
     it('can perform updates after insert_leave', function()
       exec_lua [[vim.api.nvim_set_current_buf(diagnostic_bufnr)]]
       nvim("input", "o")


### PR DESCRIPTION
Function arguments that expect a list should explicitly use tbl_islist
rather than just checking for a table. This helps catch some simple
errors where a single table item is passed as an argument, which passes
validation (since it's a table), but causes other errors later on.
