### PR TITLE
vim-patch:8.2.3956

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3991,7 +3991,6 @@ static void f_getregtype(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   MotionType reg_type = get_reg_type(regname, &reglen);
   format_reg_type(reg_type, reglen, buf, ARRAY_SIZE(buf));
 
-  rettv->v_type = VAR_STRING;
   rettv->vval.v_string = (char_u *)xstrdup(buf);
 }
 


### PR DESCRIPTION
#### vim-patch:8.2.3956: duplicate assignment

Problem:    Duplicate assignment.
Solution:   Remove the second assignment. (closes vim/vim#9442)
https://github.com/vim/vim/commit/4b1478093eb8b8bebc94b1f596e0afc25db4d189