### PR TITLE
chore(build): compile lua only on release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,7 +543,11 @@ endif()
 
 message(STATUS "Using Lua interpreter: ${LUA_PRG}")
 
-option(COMPILE_LUA "Pre-compile Lua sources into bytecode (for sources that are included in the binary)" ON)
+if(DEBUG)
+  option(COMPILE_LUA "Pre-compile Lua sources into bytecode (for sources that are included in the binary)" OFF)
+else()
+  option(COMPILE_LUA "Pre-compile Lua sources into bytecode (for sources that are included in the binary)" ON)
+endif()
 
 if(COMPILE_LUA AND NOT WIN32)
   if(PREFER_LUA)


### PR DESCRIPTION
Compile lua files only on release builds. Compiling them removes line number from tracebacks and makes them harder to debug