### PR TITLE
test: make some tests more stable

### DIFF
--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -350,7 +350,7 @@ describe('on_lines does not emit out-of-bounds line indexes when', function()
   end)
 
   it('creating a terminal buffer #16394', function()
-    feed_command([[autocmd TermOpen * ++once call v:lua.register_callback(expand("<abuf>"))]])
+    feed_command('autocmd TermOpen * ++once call v:lua.register_callback(str2nr(expand("<abuf>")))')
     feed_command('terminal')
     sleep(500)
     eq('', exec_lua([[return _G.cb_error]]))


### PR DESCRIPTION
The first change is a mistake I found thanks to #16745. This test depends on an implicit cast, so I changed it.

The second change is to avoid having to match line number in `screen:expect()` by truncating the error message to the last 49 characters.