### PR TITLE
vim-patch:8.1.2221,8.2.4336: filtering for :disp and :scriptnames

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -388,6 +388,8 @@ g8			Print the hex values of the bytes used in the
 			   |:marks|      - filter by text in the current file,
 					   or file name for other files
 			   |:oldfiles|   - filter by file name
+			   |:registers|  - filter by register contents
+					   (does not work multi-line)
 			   |:set|        - filter by option name
 
 			Only normal messages are filtered, error messages are

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "nvim/ascii.h"
+#include "nvim/globals.h"
 #include "nvim/vim.h"
 #ifdef HAVE_LOCALE_H
 # include <locale.h>
@@ -2190,9 +2191,11 @@ void ex_scriptnames(exarg_T *eap)
     if (SCRIPT_ITEM(i).sn_name != NULL) {
       home_replace(NULL, SCRIPT_ITEM(i).sn_name, NameBuff, MAXPATHL, true);
       vim_snprintf((char *)IObuff, IOSIZE, "%3d: %s", i, NameBuff);
-      msg_putchar('\n');
-      msg_outtrans(IObuff);
-      line_breakcheck();
+      if (!message_filtered(IObuff)) {
+        msg_putchar('\n');
+        msg_outtrans(IObuff);
+        line_breakcheck();
+      }
     }
   }
 }

--- a/src/nvim/testdir/test_filter_cmd.vim
+++ b/src/nvim/testdir/test_filter_cmd.vim
@@ -145,3 +145,30 @@ func Test_filter_commands()
   bwipe! file.h
   bwipe! file.hs
 endfunc
+
+func Test_filter_display()
+  edit Xdoesnotmatch
+  let @a = '!!willmatch'
+  let @b = '!!doesnotmatch'
+  let @c = "oneline\ntwoline\nwillmatch\n"
+  let @/ = '!!doesnotmatch'
+  call feedkeys(":echo '!!doesnotmatch:'\<CR>", 'ntx')
+  let lines = map(split(execute('filter /willmatch/ display'), "\n"), 'v:val[5:6]')
+
+  call assert_true(index(lines, '"a') >= 0)
+  call assert_false(index(lines, '"b') >= 0)
+  call assert_true(index(lines, '"c') >= 0)
+  call assert_false(index(lines, '"/') >= 0)
+  call assert_false(index(lines, '":') >= 0)
+  call assert_false(index(lines, '"%') >= 0)
+
+  let lines = map(split(execute('filter /doesnotmatch/ display'), "\n"), 'v:val[5:6]')
+  call assert_true(index(lines, '"a') < 0)
+  call assert_false(index(lines, '"b') < 0)
+  call assert_true(index(lines, '"c') < 0)
+  call assert_false(index(lines, '"/') < 0)
+  call assert_false(index(lines, '":') < 0)
+  call assert_false(index(lines, '"%') < 0)
+
+  bwipe!
+endfunc

--- a/src/nvim/testdir/test_filter_cmd.vim
+++ b/src/nvim/testdir/test_filter_cmd.vim
@@ -172,3 +172,11 @@ func Test_filter_display()
 
   bwipe!
 endfunc
+
+func Test_filter_scriptnames()
+  let lines = split(execute('filter /test_filter_cmd/ scriptnames'), "\n")
+  call assert_equal(1, len(lines))
+  call assert_match('filter_cmd', lines[0])
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.1.2221: cannot filter :disp output

Problem:    Cannot filter :disp output.
Solution:   Support filtereing :disp output. (Andi Massimino, closes vim/vim#5117)
https://github.com/vim/vim/commit/8fc42964363087025a27e8c80276c706536fc4e3

#### vim-patch:8.2.4336: using :filter for :scriptnames does not work

Problem:    Using :filter for :scriptnames does not work. (Ben Jackson)
Solution:   Call message_filtered().
https://github.com/vim/vim/commit/769f5895ebfd10535a0ad978f071da8f20178fc6

Cherry-pick a modeline from Vim patch 8.2.1432.