### PR TITLE
vim-patch:8.2.3966: when using feedkeys() abbreviations may be blocked

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2304,6 +2304,10 @@ static int vgetorpeek(bool advance)
             c = ESC;
           }
           tc = c;
+
+          // no chars to block abbreviations for
+          typebuf.tb_no_abbr_cnt = 0;
+
           break;
         }
 

--- a/src/nvim/testdir/test_feedkeys.vim
+++ b/src/nvim/testdir/test_feedkeys.vim
@@ -12,3 +12,15 @@ func Test_feedkeys_x_with_empty_string()
   call assert_equal('foo', getline('.'))
   quit!
 endfunc
+
+func Test_feedkeys_with_abbreviation()
+  new
+  inoreabbrev trigger value
+  call feedkeys("atrigger ", 'x')
+  call feedkeys("atrigger ", 'x')
+  call assert_equal('value value ', getline(1))
+  bwipe!
+  iunabbrev trigger
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3966: when using feedkeys() abbreviations may be blocked

Problem:    When using feedkeys() abbreviations may be blocked.
Solution:   Reset tb_no_abbr_cnt when running out of characters.
https://github.com/vim/vim/commit/b37a65e4bf08c4eec4fa5b81a5efc3945fca44de

Fix #16854