### PR TITLE
feat(lsp): skip or reduce debounce after idle

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -306,7 +306,6 @@ local function once(fn)
   end
 end
 
-
 local changetracking = {}
 do
   --@private
@@ -327,6 +326,7 @@ do
     if not state then
       state = {
         pending_changes = {};
+        last_flush = {};
         use_incremental_sync = (
           if_nil(client.config.flags.allow_incremental_sync, true)
           and client.resolved_capabilities.text_document_did_change == protocol.TextDocumentSyncKind.Incremental
@@ -347,8 +347,11 @@ do
   function changetracking.reset_buf(client, bufnr)
     changetracking.flush(client)
     local state = state_by_client[client.id]
-    if state and state.buffers then
-      state.buffers[bufnr] = nil
+    if state then
+      if state.buffers then
+        state.buffers[bufnr] = nil
+      end
+      state.last_flush = {}
     end
   end
 
@@ -358,6 +361,33 @@ do
     if state then
       state_by_client[client_id] = nil
       changetracking._reset_timer(state)
+    end
+  end
+
+  ---@private
+  --
+  -- Adjust debounce time by taking time of last didChange notification into
+  -- consideration. If the last didChange happened more than `debounce` time ago,
+  -- debounce can be skipped and otherwise maybe reduced.
+  --
+  -- This turns the debounce into a kind of client rate limiting
+  local function next_debounce(debounce, state, bufnr)
+    if debounce == 0 then
+      return 0
+    end
+    local ns_to_ms = 0.000001
+    local last_flush = state.last_flush[bufnr]
+    if not last_flush then
+      return debounce
+    end
+    local now = uv.hrtime()
+    local ms_since_last_flush = (now - last_flush) * ns_to_ms
+    local remaining_debounce = (ms_since_last_flush - debounce) * -1
+    if remaining_debounce > 0 then
+      return remaining_debounce
+    else
+      state.last_flush[bufnr] = now
+      return 0
     end
   end
 
@@ -383,7 +413,7 @@ do
         return
       end
       local state = state_by_client[client.id]
-      local debounce = client.config.flags.debounce_text_changes or 150
+      local debounce = next_debounce(client.config.flags.debounce_text_changes or 150, state, bufnr)
       if debounce == 0 then
         local changes = state.use_incremental_sync and incremental_changes(client) or full_changes()
         client.notify("textDocument/didChange", {
@@ -406,6 +436,7 @@ do
       end
       state.pending_change = function()
         state.pending_change = nil
+        state.last_flush[bufnr] = uv.hrtime()
         if client.is_stopped() or not vim.api.nvim_buf_is_valid(bufnr) then
           return
         end

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -382,7 +382,7 @@ do
     end
     local now = uv.hrtime()
     local ms_since_last_flush = (now - last_flush) * ns_to_ms
-    local remaining_debounce = (ms_since_last_flush - debounce) * -1
+    local remaining_debounce = debounce - ms_since_last_flush
     if remaining_debounce > 0 then
       return remaining_debounce
     else


### PR DESCRIPTION
The idea of the debounce is to avoid overloading a server with didChange
notifications. So far this used a constant value to group changes within
an interval together and send a single notification. A side effect of
this is that when you were idle, notifications are still delayed.

This commit changes the logic to take the time the last notification
happened into consideration, if it has been greater than the debounce
interval, the debouncing is skipped or at least reduced.


Not entirely sure if it is worth it, but here are some "effective debounce" plots while test driving this:

![image](https://user-images.githubusercontent.com/38700/147870496-12b8a2e8-35cf-4435-a87d-935e82b2fc94.png)


![image](https://user-images.githubusercontent.com/38700/147870499-66b33152-f18a-4b81-b732-61caacbe20c3.png)


One can see that the majority of the time an edit happens after I was idling (enter insert mode, make change, exit insert mode, navigate - repeat)
