### PR TITLE
fix(lsp): don't spam the same warning when multiple clients have different offset encodings

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1779,7 +1779,7 @@ function M._get_offset_encoding(bufnr)
     if not offset_encoding then
       offset_encoding = this_offset_encoding
     elseif offset_encoding ~= this_offset_encoding then
-      vim.notify("warning: multiple different client offset_encodings detected for buffer, this is not supported yet", vim.log.levels.WARN)
+      warn_once("warning: multiple different client offset_encodings detected for buffer, this is not supported yet")
     end
   end
 


### PR DESCRIPTION
This `warn_once` function (which seems like a good idea to me) was here already, but doesn't seem to be used in places.

Hopefully making this warning only do so once makes sense, without it there's a ton of `:messages` spam.