### PR TITLE
fix: resolve nil arguments to API functions

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1372,16 +1372,16 @@ function M.reset(namespace, bufnr)
       diagnostic_cache[iter_bufnr][iter_namespace] = nil
       M.hide(iter_namespace, iter_bufnr)
     end
-  end
 
-  vim.api.nvim_buf_call(bufnr, function()
-    vim.api.nvim_command(
-      string.format(
-        "doautocmd <nomodeline> DiagnosticChanged %s",
-        vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))
+    vim.api.nvim_buf_call(iter_bufnr, function()
+      vim.api.nvim_command(
+        string.format(
+          "doautocmd <nomodeline> DiagnosticChanged %s",
+          vim.fn.fnameescape(vim.api.nvim_buf_get_name(iter_bufnr))
+        )
       )
-    )
-  end)
+    end)
+  end
 end
 
 --- Add all diagnostics to the quickfix list.

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1677,7 +1677,7 @@ function M.symbols_to_items(symbols, bufnr)
     end
     return _items
   end
-  return _symbols_to_items(symbols, {}, bufnr)
+  return _symbols_to_items(symbols, {}, bufnr or 0)
 end
 
 --- Removes empty lines from the beginning and end.
@@ -1796,7 +1796,7 @@ end
 ---@returns { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`current_position`, end = `current_position` } }
 function M.make_range_params(window, offset_encoding)
-  local buf = vim.api.nvim_win_get_buf(window)
+  local buf = vim.api.nvim_win_get_buf(window or 0)
   offset_encoding = offset_encoding or M._get_offset_encoding(buf)
   local position = make_position_param(window, offset_encoding)
   return {


### PR DESCRIPTION
As revealed by #16745, some functions pass a nil value to API functions,
which have been implicitly converted to 0. #16745 breaks this implicit
conversion, so explicitly pass a resolved buffer number to these API
functions.
