### PR TITLE
ci: treat warnings as errors for the msvc compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ int main(void)
 
 if(MSVC)
   # XXX: /W4 gives too many warnings. #3241
-  add_compile_options(/W3)
+  add_compile_options(/W1 /WX)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   add_definitions(-DWIN32)
 else()


### PR DESCRIPTION
Set the warning level to W1 to prioritize solving the most severe warning.

I may increase the warning level to its original value W3 in this PR. It depends on how big the PR becomes.