### PR TITLE
feat(lsp): enable default debounce of 150 ms

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -887,10 +887,10 @@ start_client({config})                                *vim.lsp.start_client()*
                                            default true): Allow using
                                            incremental sync for buffer edits
                                          • debounce_text_changes (number,
-                                           default nil): Debounce didChange
+                                           default 150): Debounce didChange
                                            notifications to the server by the
                                            given number in milliseconds. No
-                                           debounce occurs if nil
+                                           debounce occurs if set to 0.
                                          • exit_timeout (number, default 500):
                                            Milliseconds to wait for server to
                                            exit cleanly after sending the

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -256,7 +256,7 @@ local function validate_client_config(config)
     (not config.flags
       or not config.flags.debounce_text_changes
       or type(config.flags.debounce_text_changes) == 'number'),
-    "flags.debounce_text_changes must be nil or a number with the debounce time in milliseconds"
+    "flags.debounce_text_changes must be a number with the debounce time in milliseconds"
   )
 
   local cmd, cmd_args = lsp._cmd_parts(config.cmd)
@@ -383,8 +383,8 @@ do
         return
       end
       local state = state_by_client[client.id]
-      local debounce = client.config.flags.debounce_text_changes
-      if not debounce then
+      local debounce = client.config.flags.debounce_text_changes or 150
+      if debounce == 0 then
         local changes = state.use_incremental_sync and incremental_changes(client) or full_changes()
         client.notify("textDocument/didChange", {
           textDocument = {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -73,8 +73,11 @@ local function fake_lsp_server_setup(test_name, timeout_ms, options)
       on_init = function(client, result)
         TEST_RPC_CLIENT = client
         vim.rpcrequest(1, "init", result)
-        client.config.flags.allow_incremental_sync = options.allow_incremental_sync or false
       end;
+      flags = {
+        allow_incremental_sync = options.allow_incremental_sync or false;
+        debounce_text_changes = 0;
+      };
       on_exit = function(...)
         vim.rpcnotify(1, "exit", ...)
       end;


### PR DESCRIPTION
I think we should enable debounce by default. It's well-tested now and this should avoid issues with slower servers. It can still be disabled by setting debounce_text_changes to 0 ms. Ofc users can replicate this in 0.6.1 by setting flags/debounce_text_changes in lspconfig/start_client.