### PR TITLE
test: make test for #14040 more stable

### DIFF
--- a/test/functional/legacy/memory_usage_spec.lua
+++ b/test/functional/legacy/memory_usage_spec.lua
@@ -195,10 +195,10 @@ describe('memory usage', function()
     local after = monitor_memory_usage(pid)
     source('bwipe!')
     poke_eventloop()
-    -- Allow for an increase of 5% in memory usage, which accommodates minor fluctuation,
+    -- Allow for an increase of 10% in memory usage, which accommodates minor fluctuation,
     -- but is small enough that if memory were not released (prior to PR #14884), the test
     -- would fail.
-    local upper = before.last * 1.05
+    local upper = before.last * 1.10
     check_result({before=before, after=after}, pcall(ok, after.last <= upper))
   end)
 end)


### PR DESCRIPTION
@gpanders [reported](https://github.com/neovim/neovim/pull/16600#issuecomment-1004351775) flakiness of a memory usage test that I added in PR #14884.

This is presumably from ordinary memory fluctuation being higher than accommodated.

This PR updates the test to allow for a 10% increase in memory usage, as opposed to 5%. At 10%, the test would still catch the memory leak from #14040, which would require accommodation of over 200% for the test to pass.