### PR TITLE
feat(lua): make :lua =expr print result of expr

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -249,13 +249,15 @@ arguments separated by " " (space) instead of "\t" (tab).
                                                         *:lua*
 :[range]lua {chunk}
                         Executes Lua chunk {chunk}.
-
+                        if {chunk} starts with "=" the rest of the chunk is
+                        evaluated as an expression and printed. `:lua =expr`
+                        is equivalent to `:lua print(vim.inspect(expr))`
                         Examples: >
                             :lua vim.api.nvim_command('echo "Hello, Nvim!"')
 <                        To see the Lua version: >
                             :lua print(_VERSION)
 <                        To see the LuaJIT version: >
-                            :lua print(jit.version)
+                            :lua =jit.version
 <
                                                         *:lua-heredoc*
 :[range]lua << [endmarker]

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -141,6 +141,15 @@ describe(':lua command', function()
       {4:Press ENTER or type command to continue}^ |
     ]]}
   end)
+
+  it('Can print results of =expr', function()
+    helpers.exec_lua("x = 5")
+    eq("5", helpers.exec_capture(':lua =x'))
+    helpers.exec_lua("function x() return 'hello' end")
+    eq([["hello"]], helpers.exec_capture(':lua = x()'))
+    helpers.exec_lua("x = {a = 1, b = 2}")
+    eq("{\n  a = 1,\n  b = 2\n}", helpers.exec_capture(':lua  =x'))
+  end)
 end)
 
 describe(':luado command', function()


### PR DESCRIPTION
With this running `:lua =expr` will evaluate expr and print out it's result . lua/luajit interpreter has a similer feature where typing `=expr` prints out the result of `expr`. I think this is quite convenient specially during plugin development. 

This is very simple implementation it just transforms
```lua
=expr
```
to
```lua
print(vim.inspect(expr))
```
before passing it to lua executor .
So 
```vim
:lua =expr
```
becomes same as
```vim
:lua print(vim.inspect(expr))
```