### PR TITLE
fix(screen): don't put empty sign text in line number column

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2792,7 +2792,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           // in 'lnum', then display the sign instead of the line
           // number.
           if (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u'
-              && num_signs > 0) {
+              && num_signs > 0 && sign_get_attr(SIGN_TEXT, sattrs, 0, 1)) {
             int count = win_signcol_count(wp);
             get_sign_display_info(true, wp, lnum, sattrs, row,
                                   startrow, filler_lines, filler_todo, count,

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -526,6 +526,32 @@ describe('Signs', function()
       ]])
     end)
 
+    it('shows the line number when signcolumn=number but no marks on a line have text', function()
+      feed('ia<cr>b<cr>c<cr><esc>')
+      command('set number signcolumn=number')
+      command('sign define pietSearch text=>> texthl=Search numhl=Error')
+      command('sign define pietError text=    texthl=Search numhl=Error')
+      command('sign place 1 line=1 name=pietSearch buffer=1')
+      command('sign place 2 line=2 name=pietError  buffer=1')
+      -- no signcolumn, line number for "a" is Search, for "b" is Error, for "c" is LineNr
+      screen:expect([[
+        {1: >> }a                                                |
+        {8:  2 }b                                                |
+        {6:  3 }c                                                |
+        {6:  4 }^                                                 |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+    end)
+
     it('can have 32bit sign IDs', function()
       command('sign define piet text=>> texthl=Search')
       command('sign place 100000 line=1 name=piet buffer=1')


### PR DESCRIPTION
When `signcolumn=number` but no sign on a given line has any text,
display the line's line number instead of the (empty) sign text in the
line number column.

Closes #14587