### PR TITLE
fix(filetype): set default ft_ignore_pat in filetype.lua

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,6 +26,10 @@ read_globals = {
   "vim",
 }
 
+globals = {
+  "vim.g",
+}
+
 exclude_files = {
   'test/functional/fixtures/lua/syntax_error.lua',
 }

--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -20,3 +20,7 @@ let g:did_load_ftdetect = 1
 
 augroup END
 ]]
+
+if not vim.g.ft_ignore_pat then
+  vim.g.ft_ignore_pat = "\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$"
+end


### PR DESCRIPTION
This default value is also set in filetype.vim, but if filetype.vim is
disabled the variable is never defined, which causes errors in some of
the dist#ft detection functions.
