### PR TITLE
fix(api): force redefinition of user commands by default

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -667,14 +667,17 @@ nvim_add_user_command({name}, {command}, {*opts})
                     {opts}     Optional command attributes. See
                                |command-attributes| for more details. To use
                                boolean attributes (such as |:command-bang| or
-                               |:command-bar|) set the value to "true". When
-                               using a Lua function for {command} you can also
-                               provide a "desc" key that will be displayed
-                               when listing commands. In addition to the
-                               string options listed in |:command-complete|,
-                               the "complete" key also accepts a Lua function
-                               which works like the "customlist" completion
-                               mode |:command-completion-customlist|.
+                               |:command-bar|) set the value to "true". In
+                               addition to the string options listed in
+                               |:command-complete|, the "complete" key also
+                               accepts a Lua function which works like the
+                               "customlist" completion mode
+                               |:command-completion-customlist|. Additional
+                               parameters:
+                               • desc: (string) Used for listing the command
+                                 when a Lua function is used for {command}.
+                               • force: (boolean, default true) Override any
+                                 previous definition.
 
 nvim_call_atomic({calls})                                 *nvim_call_atomic()*
                 Calls many API methods atomically.

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1505,7 +1505,7 @@ void add_user_command(String name, Object command, Dict(user_command) *opts, int
     goto err;
   }
 
-  bool force = api_object_to_bool(opts->force, "force", false, err);
+  bool force = api_object_to_bool(opts->force, "force", true, err);
   if (ERROR_SET(err)) {
     goto err;
   }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2396,12 +2396,10 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
 ///                 boolean attributes (such as |:command-bang| or |:command-bar|) set the value to
 ///                 "true". In addition to the string options listed in |:command-complete|, the
 ///                 "complete" key also accepts a Lua function which works like the "customlist"
-///                 completion mode |:command-completion-customlist|.
-///
-///                 Additional parameters.
+///                 completion mode |:command-completion-customlist|. Additional parameters:
 ///                 - desc: (string) Used for listing the command when a Lua function is used for
 ///                                  {command}.
-///                 - force: (boolean) Override any previous definition.
+///                 - force: (boolean, default true) Override any previous definition.
 /// @param[out] err Error details, if any.
 void nvim_add_user_command(String name, Object command, Dict(user_command) *opts, Error *err)
   FUNC_API_SINCE(9)


### PR DESCRIPTION
Ref: discussion in https://github.com/neovim/neovim/pull/16752.
