### PR TITLE
Feat(filetype.lua): Add support for txt files

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -787,6 +787,12 @@ local extension = {
   xml = function() vim.fn["dist#ft#FTxml"]() end,
   y = function() vim.fn["dist#ft#FTy"]() end,
   zsql = function() vim.fn["dist#ft#SQL"]() end,
+  txt = function(path, bufnr)
+    --helpfiles match *.txt, but should have a modeline as last line
+    if not getline(bufnr, -1):match("vim:.*ft=help") then
+      return "text"
+    end
+  end,
   -- END EXTENSION
 }
 
@@ -1325,6 +1331,7 @@ local pattern = {
   ["tmac%..*"] = starsetf('nroff'),
   ["zlog.*"] = starsetf('zsh'),
   ["zsh.*"] = starsetf('zsh'),
+  ["ae%d+%.txt"] = 'mail',
   -- END PATTERN
 }
 -- luacheck: pop


### PR DESCRIPTION
I scoured `filetype.vim` for `txt` files, but most were taken care of already, except for the one regex at https://github.com/neovim/neovim/blob/master/runtime/filetype.vim#L1014. I could not discern some sort of sorting, so I just put the additions at a convenient spot.