### PR TITLE
[RFC] Call CursorHold events even if events are available

### DIFF
--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -89,11 +89,8 @@ static void cursorhold_event(void **argv)
 
 static void create_cursorhold_event(bool events_enabled)
 {
-  // If events are enabled and the queue has any items, this function should not
-  // have been called(inbuf_poll would return kInputAvail)
   // TODO(tarruda): Cursorhold should be implemented as a timer set during the
   // `state_check` callback for the states where it can be triggered.
-  assert(!events_enabled || multiqueue_empty(main_loop.events));
   multiqueue_put(main_loop.events, cursorhold_event, 0);
 }
 
@@ -118,7 +115,8 @@ int os_inchar(uint8_t *buf, int maxlen, int ms, int tb_change_cnt, MultiQueue *e
       return 0;
     }
   } else {
-    if ((result = inbuf_poll((int)p_ut, events)) == kInputNone) {
+    if ((result = inbuf_poll((int)p_ut, events)) == kInputNone
+        || !typebuf_changed(tb_change_cnt)) {
       if (read_stream.closed && silent_mode) {
         // Drained eventloop & initial input; exit silent/batch-mode (-es/-Es).
         read_error_exit();

--- a/test/functional/autocmd/cursorhold_spec.lua
+++ b/test/functional/autocmd/cursorhold_spec.lua
@@ -15,7 +15,7 @@ describe('CursorHoldI', function()
   --       issue (#3757) via timer's or RPC callbacks in the first place.
   it('is triggered after input', function()
     source([[
-    set updatetime=1
+    set updatetime=100
 
     let g:cursorhold = 0
     augroup test
@@ -24,7 +24,7 @@ describe('CursorHoldI', function()
     ]])
     feed('ifoo')
     retry(5, nil, function()
-      sleep(1)
+      sleep(50)
       eq(1, eval('g:cursorhold'))
     end)
   end)


### PR DESCRIPTION
Fix #12587 

It works for me.  But it may break other features.  Please check the patch.

Test code:

```vim
set updatetime=100

autocmd CursorMoved * echom "CursorMoved"
autocmd CursorHold  * echom "CursorHold"

function! s:timer_callback(timer_id)
  echomsg 'timer'
endfunction

let w:matchup_timer = timer_start(50,
      \ function('s:timer_callback'),
      \ {'repeat': -1})
```