### PR TITLE
fix(runtime): check markdownError before syn-clear

### DIFF
--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -12,7 +12,9 @@ unlet! b:current_syntax
 syn case match
 
 " We do not care about markdown syntax errors
-syn clear markdownError
+if hlexists('markdownError')
+  syn clear markdownError
+endif
 
 syn keyword healthError ERROR[:] containedin=markdownCodeBlock,mkdListItemLine
 syn keyword healthWarning WARNING[:] containedin=markdownCodeBlock,mkdListItemLine


### PR DESCRIPTION
Avoids `E28: No such highlight group name: markdownError` when using a
foreign markdown syntax.

Tests not affected.

```
[----------] Running tests from test/functional/plugin/health_spec.lua
[ RUN      ] :checkhealth detects invalid $VIMRUNTIME: 26.50 ms OK
[ RUN      ] :checkhealth detects invalid 'runtimepath': 27.64 ms OK
[ RUN      ] :checkhealth detects invalid $VIM: 115.06 ms OK
[ RUN      ] :checkhealth completions can be listed via getcompletion(): 478.18 ms OK
[ RUN      ] health.vim :checkhealth functions health#report_*() render correctly: 48.67 ms OK
[ RUN      ] health.vim :checkhealth concatenates multiple reports: 56.37 ms OK
[ RUN      ] health.vim :checkhealth lua plugins, skips vimscript healthchecks with the same name: 41.74 ms OK
[ RUN      ] health.vim :checkhealth lua plugins submodules: 39.08 ms OK
[ RUN      ] health.vim :checkhealth lua plugins submodules with expression '*': 49.77 ms OK
[ RUN      ] health.vim :checkhealth gracefully handles broken healthcheck: 38.61 ms OK
[ RUN      ] health.vim :checkhealth gracefully handles broken lua healthcheck: 41.73 ms OK
[ RUN      ] health.vim :checkhealth highlights OK, ERROR: 84.87 ms OK
[ RUN      ] health.vim :checkhealth gracefully handles invalid healthcheck: 39.42 ms OK
[----------] 13 tests from test/functional/plugin/health_spec.lua (1636.18 ms total)
```
