### PR TITLE
fix(lua): :lua =expr doesn't work if expr returns multiple values

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1316,6 +1316,18 @@ paste({lines}, {phase})                                          *vim.paste()*
                 See also: ~
                     |paste|
 
+pretty_print({...})                                       *vim.pretty_print()*
+                Prints given arguments in human-readable format. Example: >
+                  -- Print highlight group Normal and store it's contents in a variable.
+                  local hl_normal = vim.pretty_print(vim.api.nvim_get_hl_by_name("Normal", true))
+<
+
+                Return: ~
+                    given arguments.
+
+                See also: ~
+                    |vim.inspect()|
+
 region({bufnr}, {pos1}, {pos2}, {regtype}, {inclusive})         *vim.region()*
                 Get a table of lines with start, end columns for a region
                 marked by two points

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1131,12 +1131,12 @@ void ex_lua(exarg_T *const eap)
   }
   // When =expr is used transform it to print(vim.inspect(expr))
   if (code[0] == '=') {
-    len += sizeof("print(vim.inspect())") - sizeof("=");
+    len += sizeof("vim._pretty_print()") - sizeof("=");
     // code_buf needs to be 1 char larger then len for null byte in the end.
     // lua nlua_typval_exec doesn't expect null terminated string so len
     // needs to end before null byte.
     char *code_buf = xmallocz(len);
-    vim_snprintf(code_buf, len+1, "print(vim.inspect(%s))", code+1);
+    vim_snprintf(code_buf, len+1, "vim._pretty_print(%s)", code+1);
     xfree(code);
     code = code_buf;
   }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1131,12 +1131,12 @@ void ex_lua(exarg_T *const eap)
   }
   // When =expr is used transform it to print(vim.inspect(expr))
   if (code[0] == '=') {
-    len += sizeof("vim._pretty_print()") - sizeof("=");
+    len += sizeof("vim.pretty_print()") - sizeof("=");
     // code_buf needs to be 1 char larger then len for null byte in the end.
     // lua nlua_typval_exec doesn't expect null terminated string so len
     // needs to end before null byte.
     char *code_buf = xmallocz(len);
-    vim_snprintf(code_buf, len+1, "vim._pretty_print(%s)", code+1);
+    vim_snprintf(code_buf, len+1, "vim.pretty_print(%s)", code+1);
     xfree(code);
     code = code_buf;
   }

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -666,8 +666,15 @@ vim._expand_pat_get_parts = function(lua_string)
   return parts, search_index
 end
 
----@private
-function vim._pretty_print(...)
+---Prints given arguments in human-readable format.
+---Example:
+---<pre>
+---  -- Print highlight group Normal and store it's contents in a variable.
+---  local hl_normal = vim.pretty_print(vim.api.nvim_get_hl_by_name("Normal", true))
+---</pre>
+---@see |vim.inspect()|
+---@return given arguments.
+function vim.pretty_print(...)
   local objects = {}
   for i = 1, select('#', ...) do
     local v = select(i, ...)
@@ -675,6 +682,7 @@ function vim._pretty_print(...)
   end
 
   print(table.concat(objects, '    '))
+  return ...
 end
 
 return module

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -666,4 +666,15 @@ vim._expand_pat_get_parts = function(lua_string)
   return parts, search_index
 end
 
+---@private
+function vim._pretty_print(...)
+  local objects = {}
+  for i = 1, select('#', ...) do
+    local v = select(i, ...)
+    table.insert(objects, vim.inspect(v))
+  end
+
+  print(table.concat(objects, '    '))
+end
+
 return module

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -149,6 +149,15 @@ describe(':lua command', function()
     eq([["hello"]], helpers.exec_capture(':lua = x()'))
     helpers.exec_lua("x = {a = 1, b = 2}")
     eq("{\n  a = 1,\n  b = 2\n}", helpers.exec_capture(':lua  =x'))
+    helpers.exec_lua([[function x(success)
+      if success then
+        return true, "Return value"
+      else
+        return false, nil, "Error message"
+      end
+    end]])
+    eq([[true    "Return value"]], helpers.exec_capture(':lua  =x(true)'))
+    eq([[false    nil    "Error message"]], helpers.exec_capture(':lua  =x(false)'))
   end)
 end)
 


### PR DESCRIPTION
followup on #16912

Currently of you do something like:
```lua
:lua function x() return 'return value' end
:lua =pcall(x)
```
It only prints `true` and leaves out the `return value` .
With this patch it'll print 
```
true     "return value"
```

I've grabbed the pretty print function from  @nanotee s [guide](https://github.com/nanotee/nvim-lua-guide#tips-3) .With spaces used as deliminator in rather then new_line as that's what lua/luajit interpreters seems to use in this case.