### PR TITLE
perf(treesitter): cache query parsing

### DIFF
--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -167,6 +167,27 @@ void ui_refresh(void)
     eq('variable', ret)
   end)
 
+  it("supports caching queries", function()
+    local long_query = query:rep(100)
+    local first_run = exec_lua ([[
+      local before = vim.loop.hrtime()
+      cquery = vim.treesitter.parse_query("c", ...)
+      local after = vim.loop.hrtime()
+      return after - before
+    ]], long_query)
+
+    local subsequent_runs = exec_lua ([[
+      local before = vim.loop.hrtime()
+      for i=1,100,1 do
+        cquery = vim.treesitter.parse_query("c", ...)
+      end
+      local after = vim.loop.hrtime()
+      return after - before
+    ]], long_query)
+
+    assert.True(1000 * subsequent_runs < first_run)
+  end)
+
   it('support query and iter by capture', function()
     insert(test_text)
 


### PR DESCRIPTION
There were multiple performance regressions in query parsing in the past (https://github.com/nvim-treesitter/nvim-treesitter/issues/2182, https://github.com/nvim-treesitter/nvim-treesitter/issues/2126) that have now been more or less mitigated by the tree-sitter team.

However, during the discussion we concluded https://github.com/UserNobody14/tree-sitter-dart/issues/23#issuecomment-988151459  that we shouldn't do duplicate work parsing the queries even though it's only small duration for most of the languages (e.g. 8ms for the C query in the test, 190ms for 100 times this query). Other languages, with problematic queries/parsers still take longer. This shouldn't be the solution for that problem but still work that isn't done is always fastest.