### PR TITLE
chore: remove lspconfig checkhealth from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
@@ -29,13 +29,6 @@ body:
 
   - type: textarea
     attributes:
-      label: ':checkhealth'
-      description: |
-        Paste the results from `nvim -c ":checkhealth nvim lspconfig"`
-      render: markdown
-
-  - type: textarea
-    attributes:
       label: 'Steps to reproduce using "nvim -u minimal_init.lua"'
       description: |
         - Download the minimal config with `curl -LO https://raw.githubusercontent.com/neovim/nvim-lspconfig/master/test/minimal_init.lua` and modify it to include any specific commands or servers pertaining to your issues.


### PR DESCRIPTION
I removed the checkhealth, as it's only purpose was to check if servers were executable, and this was extremely frail. Also lspconfig is not required to use the built-in client, so we shouldn't be asking for this anyways.