### PR TITLE
Revert "refactor(diagnostic): add warning to deprecated functions (#16536)"

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -153,6 +153,19 @@ function M.get_namespace(client_id)
   return _client_namespaces[client_id]
 end
 
+--- Save diagnostics to the current buffer.
+---
+--- Handles saving diagnostics from multiple clients in the same buffer.
+---@param diagnostics Diagnostic[]
+---@param bufnr number
+---@param client_id number
+---@private
+function M.save(diagnostics, bufnr, client_id)
+  local namespace = M.get_namespace(client_id)
+  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
+end
+-- }}}
+
 --- |lsp-handler| for the method "textDocument/publishDiagnostics"
 ---
 --- See |vim.diagnostic.config()| for configuration options. Handler-specific
@@ -232,23 +245,6 @@ end
 
 -- Deprecated Functions {{{
 
-
---- Save diagnostics to the current buffer.
----
----@deprecated Prefer |vim.diagnostic.set()|
----
---- Handles saving diagnostics from multiple clients in the same buffer.
----@param diagnostics Diagnostic[]
----@param bufnr number
----@param client_id number
----@private
-function M.save(diagnostics, bufnr, client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.save is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
-  local namespace = M.get_namespace(client_id)
-  vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
-end
--- }}}
-
 --- Get all diagnostics for clients
 ---
 ---@deprecated Prefer |vim.diagnostic.get()|
@@ -257,7 +253,6 @@ end
 ---                        If nil, diagnostics of all clients are included.
 ---@return table with diagnostics grouped by bufnr (bufnr: Diagnostic[])
 function M.get_all(client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_all is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   local result = {}
   local namespace
   if client_id then
@@ -279,7 +274,6 @@ end
 ---                            Else, return just the diagnostics associated with the client_id.
 ---@param predicate function|nil Optional function for filtering diagnostics
 function M.get(bufnr, client_id, predicate)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   predicate = predicate or function() return true end
   if client_id == nil then
     local all_diagnostics = {}
@@ -341,7 +335,6 @@ end
 ---@param severity DiagnosticSeverity
 ---@param client_id number the client id
 function M.get_count(bufnr, severity, client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_count is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   severity = severity_lsp_to_vim(severity)
   local opts = { severity = severity }
   if client_id ~= nil then
@@ -358,7 +351,6 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic
 function M.get_prev(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_prev is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -376,7 +368,6 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic position
 function M.get_prev_pos(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_prev_pos is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -393,7 +384,6 @@ end
 ---
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 function M.goto_prev(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.goto_prev is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -411,7 +401,6 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic
 function M.get_next(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_next is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -429,7 +418,6 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic position
 function M.get_next_pos(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_next_pos is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -444,7 +432,6 @@ end
 ---
 ---@deprecated Prefer |vim.diagnostic.goto_next()|
 function M.goto_next(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.goto_next is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -468,7 +455,6 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_signs(diagnostics, bufnr, client_id, _, opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.set_signs is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -489,7 +475,6 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_underline(diagnostics, bufnr, client_id, _, opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.set_underline is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -511,7 +496,6 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_virtual_text(diagnostics, bufnr, client_id, _, opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.set_virtual_text is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -530,7 +514,6 @@ end
 ---@return an array of [text, hl_group] arrays. This can be passed directly to
 ---        the {virt_text} option of |nvim_buf_set_extmark()|.
 function M.get_virtual_text_chunks_for_line(bufnr, _, line_diags, opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.get_virtual_text_chunks_for_line is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   return vim.diagnostic._get_virt_text_chunks(diagnostic_lsp_to_vim(line_diags, bufnr), opts)
 end
 
@@ -548,7 +531,6 @@ end
 ---@param position table|nil The (0,0)-indexed position
 ---@return table {popup_bufnr, win_id}
 function M.show_position_diagnostics(opts, buf_nr, position)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.show_position_diagnostics is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   opts = opts or {}
   opts.scope = "cursor"
   opts.pos = position
@@ -572,7 +554,6 @@ end
 ---@param client_id number|nil the client id
 ---@return table {popup_bufnr, win_id}
 function M.show_line_diagnostics(opts, buf_nr, line_nr, client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.show_line_diagnostics is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   opts = opts or {}
   opts.scope = "line"
   opts.pos = line_nr
@@ -596,7 +577,6 @@ end
 ---       client. The default is to redraw diagnostics for all attached
 ---       clients.
 function M.redraw(bufnr, client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.redraw is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   bufnr = get_bufnr(bufnr)
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
@@ -624,7 +604,6 @@ end
 ---         - {workspace}: (boolean, default true)
 ---             - Set the list with workspace diagnostics
 function M.set_qflist(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.set_qflist is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   opts = opts or {}
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
@@ -656,7 +635,6 @@ end
 ---         - {workspace}: (boolean, default false)
 ---             - Set the list with workspace diagnostics
 function M.set_loclist(opts)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.set_loclist is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   opts = opts or {}
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
@@ -684,7 +662,6 @@ end
 -- send diagnostic information and the client will still process it. The
 -- diagnostics are simply not displayed to the user.
 function M.disable(bufnr, client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.disable is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
       M.disable(bufnr, client.id)
@@ -705,7 +682,6 @@ end
 ---       client. The default is to enable diagnostics for all attached
 ---       clients.
 function M.enable(bufnr, client_id)
-  vim.api.nvim_echo({{'vim.lsp.diagnostic.enable is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
       M.enable(bufnr, client.id)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1611,7 +1611,6 @@ end
 ---
 ---@param items (table) list of items
 function M.set_loclist(items, win_id)
-  vim.api.nvim_echo({{'vim.lsp.util.set_loclist is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   vim.fn.setloclist(win_id or 0, {}, ' ', {
     title = 'Language Server';
     items = items;
@@ -1625,7 +1624,6 @@ end
 ---
 ---@param items (table) list of items
 function M.set_qflist(items)
-  vim.api.nvim_echo({{'vim.lsp.util.set_qflist is deprecated. See :h deprecated', 'WarningMsg'}}, true, {})
   vim.fn.setqflist({}, ' ', {
     title = 'Language Server';
     items = items;


### PR DESCRIPTION
This reverts commit c4d70dae802ef074aaf54bdcbbd5f73380f74a86.

end users have not much to do with the underlying LSP functions. what happened now is some plugins are still using the `get_count` functionality, and the user gets this annoying warning (that i don't even know how one could disable?).

you can search for `"vim.lsp.diagnostic.get_count is deprecated. See :h deprecated"` - it's already poping up in various places..

fwiw, i haven't looked much into it, i just found what my issue was (airline, [1]) and just undid the introducing change, but please verify yourselves.

otherwise, a way to disable specific warnings would be very much useful.

in general, not the biggest fan of such breaking changes, but oh well..

[1] https://github.com/vim-airline/vim-airline/blob/dd42c521ca88ad1d1d1099d014c6d0b1d88a8028/autoload/airline/extensions/nvimlsp.vim#L33
