### PR TITLE
vim-patch:8.2.4007: session does not restore help buffer properly

### DIFF
--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -696,6 +696,36 @@ func Test_mksession_foldopt()
   set sessionoptions&
 endfunc
 
+" Test for mksession with "help" but not "options" in 'sessionoptions'
+func Test_mksession_help_noopt()
+  set sessionoptions-=options
+  set sessionoptions+=help
+  help
+  let fname = expand('%')
+  mksession! Xtest_mks.out
+  bwipe
+
+  source Xtest_mks.out
+  call assert_equal('help', &buftype)
+  call assert_equal('help', &filetype)
+  call assert_equal(fname, expand('%'))
+  call assert_false(&modifiable)
+  call assert_true(&readonly)
+
+  helpclose
+  help index
+  let fname = expand('%')
+  mksession! Xtest_mks.out
+  bwipe
+
+  source Xtest_mks.out
+  call assert_equal('help', &buftype)
+  call assert_equal(fname, expand('%'))
+
+  call delete('Xtest_mks.out')
+  set sessionoptions&
+endfunc
+
 " Test for mksession with window position
 func Test_mksession_winpos()
   if !has('gui_running')


### PR DESCRIPTION
#### vim-patch:8.2.4007: session does not restore help buffer properly

Problem:    Session does not restore help buffer properly when "options' is
            missing from 'sessionoptions'.
Solution:   Use a ":help" command to create the help window. (closes vim/vim#9475,
            closes vim/vim#9472)
https://github.com/vim/vim/commit/8e7d9db32b53ca2b1cb7570d2042860bcd1e943f