### PR TITLE
feat(filetype.lua): fix .env file not detected

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1069,6 +1069,7 @@ local filename = {
   [".alias"] = function() vim.fn["dist#ft#CSH"]() end,
   [".bashrc"] = function() vim.fn["dist#ft#SetFileTypeSH"]("bash") end,
   [".cshrc"] = function() vim.fn["dist#ft#CSH"]() end,
+  [".env"] = function() vim.fn["dist#ft#SetFileTypeSH"](vim.fn.getline(1)) end,
   [".kshrc"] = function() vim.fn["dist#ft#SetFileTypeSH"]("ksh") end,
   [".login"] = function() vim.fn["dist#ft#CSH"]() end,
   [".profile"] = function() vim.fn["dist#ft#SetFileTypeSH"](vim.fn.getline(1)) end,


### PR DESCRIPTION
File type with `.env` extension such as `foo.env` is detected as normal, however `.env` file itself is not detected.
After adding `.env` entry inside filename table, `.env` file is detected as normal.