### PR TITLE
vim-patch:8.2.0951: search stat test has leftover from debugging

### DIFF
--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -73,7 +73,6 @@ func Test_search_stat()
   let stat = '\[2/50\]'
   let g:a = execute(':unsilent :norm! n')
   call assert_notmatch(pat .. stat, g:a)
-  call writefile(getline(1, '$'), 'sample.txt')
   " n does not update search stat
   call assert_equal(
     \ #{current: 50, exact_match: 1, total: 50, incomplete: 0, maxcount: 99},


### PR DESCRIPTION
#### vim-patch:8.2.0951: search stat test has leftover from debugging

Problem:    Search stat test has leftover from debugging.
Solution:   Remove line that writes a file. (Christian Brabandt)
https://github.com/vim/vim/commit/6ba24d87630b1ec2b8c7ff71550c9e41d143800e