### PR TITLE
feat: ignore nore on <Plug> maps

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1994,9 +1994,7 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
                               result of Lua expr maps.
                             • remap: (boolean) Make the mapping recursive.
                               This is the inverse of the "noremap" option from
-                              |nvim_set_keymap()|. Default `true` if `lhs` is
-                              a string starting with `<plug>`
-                              (case-insensitive), `false` otherwise.
+                              |nvim_set_keymap()|. Default `false` .
 
                 See also: ~
                     |nvim_set_keymap()|

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -65,6 +65,9 @@ modes.
 			where the map command applies.  Disallow mapping of
 			{rhs}, to avoid nested and recursive mappings.  Often
 			used to redefine a command.
+			Note: "nore" is ignored for a mapping whose result
+			starts with <Plug>.  <Plug> is always remapped even if
+			"nore" is used.
 
 
 :unm[ap]  {lhs}			|mapmode-nvo|		*:unm*  *:unmap*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -442,6 +442,9 @@ Working directory (Vim implemented some of these later than Nvim):
 - `getcwd(-1)` is equivalent to `getcwd(-1, 0)` instead of returning the global
   working directory. Use `getcwd(-1, -1)` to get the global working directory.
 
+Mappings:
+- |nore| is ignored for rhs <Plug> mappings. <Plug> mappings are always remapped.
+
 ==============================================================================
 5. Missing legacy features				 *nvim-features-missing*
 

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -42,7 +42,7 @@ local keymap = {}
 ---                  |nvim_replace_termcodes()| is applied to the result of Lua expr maps.
 ---                  - remap: (boolean) Make the mapping recursive. This is the
 ---                  inverse of the "noremap" option from |nvim_set_keymap()|.
----                  Default `true` if `lhs` is a string starting with `<plug>` (case-insensitive), `false` otherwise.
+---                  Default `false`.
 ---@see |nvim_set_keymap()|
 function keymap.set(mode, lhs, rhs, opts)
   vim.validate {
@@ -66,8 +66,8 @@ function keymap.set(mode, lhs, rhs, opts)
   opts.replace_keycodes = nil
 
   if opts.remap == nil then
-    -- remap by default on <plug> mappings and don't otherwise.
-    opts.noremap = is_rhs_luaref or rhs:lower():match("^<plug>") == nil
+    -- default remap value is false
+    opts.noremap = true
   else
     -- remaps behavior is opposite of noremap option.
     opts.noremap = not opts.remap

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1710,6 +1710,15 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   int keylen = *keylenp;
   int i;
   int local_State = get_real_state();
+  bool is_plug_map = false;
+
+  // Check if typehead starts with a <Plug> mapping.
+  // In that case we will ignore nore flag on it.
+  if (typebuf.tb_buf[typebuf.tb_off] == K_SPECIAL
+      && typebuf.tb_buf[typebuf.tb_off+1] == KS_EXTRA
+      && typebuf.tb_buf[typebuf.tb_off+2] == KE_PLUG) {
+    is_plug_map = true;
+  }
 
   // Check for a mappable key sequence.
   // Walk through one maphash[] list until we find an entry that matches.
@@ -1725,7 +1734,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   tb_c1 = typebuf.tb_buf[typebuf.tb_off];
   if (no_mapping == 0 && maphash_valid
       && (no_zero_mapping == 0 || tb_c1 != '0')
-      && (typebuf.tb_maplen == 0
+      && (typebuf.tb_maplen == 0 || is_plug_map
           || (p_remap
               && !(typebuf.tb_noremap[typebuf.tb_off] & (RM_NONE|RM_ABBR))))
       && !(p_paste && (State & (INSERT + CMDLINE)))
@@ -1813,7 +1822,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
               break;
             }
           }
-          if (n >= 0) {
+          if (!is_plug_map && n >= 0) {
             continue;
           }
 


### PR DESCRIPTION
Currently `<Plug>` keymaps strictly requires users to map them without `nore` otherwise those maps don't work .

With this change `nore` will have no effect on `<Plug>` keymaps . When rhs is `<Plug>` keymap that map will always be remapped.

Hopefully that saves some poor soul from confusion with `nore` & `<Plug>` 😆