### PR TITLE
vim-patch:8.2.3669

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5068,8 +5068,7 @@ int find_help_tags(const char_u *arg, int *num_matches, char_u ***matches, bool 
         && ((arg[1] != NUL && arg[2] == NUL)
             || (vim_strchr((char_u *)"%_z@", arg[1]) != NULL
                 && arg[2] != NUL))) {
-      STRCPY(d, "/\\\\");
-      STRCPY(d + 3, arg + 1);
+      vim_snprintf((char *)d, IOSIZE, "/\\\\%s", arg + 1);
       // Check for "/\\_$", should be "/\\_\$"
       if (d[3] == '_' && d[4] == '$') {
         STRCPY(d + 4, "\\$");

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -101,4 +101,12 @@ func Test_helptag_cmd()
   call delete('Xdir', 'rf')
 endfunc
 
+func Test_help_long_argument()
+  try
+    exe 'help \%' .. repeat('0', 1021)
+  catch
+    call assert_match("E149:", v:exception)
+  endtry
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Buffer overflow with long help argument.
Solution:   Use snprintf().
https://github.com/vim/vim/commit/bd228fd097b41a798f90944b5d1245eddd484142