### PR TITLE
vim-patch:8.2.{3611,3613}

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1433,11 +1433,11 @@ char_u *find_file_in_path_option(char_u *ptr, size_t len, int options, int first
     rel_fname = NULL;
   }
 
-  if (len == 0) {
-    return NULL;
-  }
-
   if (first == TRUE) {
+    if (len == 0) {
+      return NULL;
+    }
+
     // copy file name into NameBuff, expanding environment variables
     save_char = ptr[len];
     ptr[len] = NUL;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1433,6 +1433,10 @@ char_u *find_file_in_path_option(char_u *ptr, size_t len, int options, int first
     rel_fname = NULL;
   }
 
+  if (len == 0) {
+    return NULL;
+  }
+
   if (first == TRUE) {
     // copy file name into NameBuff, expanding environment variables
     save_char = ptr[len];

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4476,8 +4476,13 @@ bool get_visual_text(cmdarg_T *cap, char_u **pp, size_t *lenp)
       *pp = ml_get_pos(&VIsual);
       *lenp = (size_t)curwin->w_cursor.col - (size_t)VIsual.col + 1;
     }
-    // Correct the length to include the whole last character.
-    *lenp += (size_t)(utfc_ptr2len(*pp + (*lenp - 1)) - 1);
+    if (**pp == NUL) {
+      *lenp = 0;
+    }
+    if (*lenp > 0) {
+      // Correct the length to include the whole last character.
+      *lenp += (size_t)(utfc_ptr2len(*pp + (*lenp - 1)) - 1);
+    }
   }
   reset_VIsual_and_resel();
   return true;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1682,6 +1682,10 @@ char_u *find_file_name_in_path(char_u *ptr, size_t len, int options, long count,
   char_u *file_name;
   char_u *tofree = NULL;
 
+  if (len == 0) {
+    return NULL;
+  }
+
   if ((options & FNAME_INCL) && *curbuf->b_p_inex != NUL) {
     tofree = (char_u *)eval_includeexpr((char *)ptr, len);
     if (tofree != NULL) {

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1110,5 +1110,12 @@ func Test_visual_block_with_virtualedit()
   call delete('XTest_beval')
 endfunc
 
+func Test_visual_block_ctrl_w_f()
+  " Emtpy block selected in new buffer should not result in an error.
+  au! BufNew foo sil norm f
+  edit foo
+
+  au! BufNew
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
…name

Problem:    Crash when using CTRL-W f without finding a file name.
Solution:   Bail out when the file name length is zero.
https://github.com/vim/vim/commit/615ddd5342b50a6878a907062aa471740bd9a847