### PR TITLE
vim-patch:8.2.3612: using freed memory with regexp using a mark

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -3232,7 +3232,7 @@ typedef struct {
   // The current match-position is remembered with these variables:
   linenr_T lnum;  ///< line number, relative to first line
   char_u *line;   ///< start of current line
-  char_u *input;  ///< current input, points into "regline"
+  char_u *input;  ///< current input, points into "line"
 
   int need_clear_subexpr;   ///< subexpressions still need to be cleared
   int need_clear_zsubexpr;  ///< extmatch subexpressions still need to be

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6071,7 +6071,14 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
       case NFA_MARK_GT:
       case NFA_MARK_LT:
       {
+        size_t col = rex.input - rex.line;
         pos_T *pos = getmark_buf(rex.reg_buf, t->state->val, false);
+
+        // Line may have been freed, get it again.
+        if (REG_MULTI) {
+          rex.line = reg_getline(rex.lnum);
+          rex.input = rex.line + col;
+        }
 
         // Compare the mark position to the match position, if the mark
         // exists and mark is set in reg_buf.

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -787,4 +787,12 @@ func Test_regexp_error()
   set re&
 endfunc
 
+func Test_using_mark_position()
+  " this was using freed memory
+  new
+  norm O0
+  call assert_fails("s/\\%')", 'E486:')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Using freed memory with regexp using a mark.
Solution:   Get the line again after getting the mark position.
https://github.com/vim/vim/commit/64066b9acd9f8cffdf4840f797748f938a13f2d6