### PR TITLE
test: add VIMRUNTIME variable to the clear function

### DIFF
--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -668,11 +668,7 @@ describe('runtime:', function()
     mkdir_p(ftdetect_folder)
     write_file(ftdetect_file , [[vim.g.lua_ftdetect = 1]])
 
-    -- TODO(shadmansaleh): Figure out why this test fails without
-    --                     setting VIMRUNTIME
-    clear{ args_rm={'-u'}, env={XDG_CONFIG_HOME=xconfig,
-                                XDG_DATA_HOME=xdata,
-                                VIMRUNTIME='runtime/'}}
+    clear{ args_rm={'-u'}, env=xenv }
 
     eq(1, eval('g:lua_ftdetect'))
     rmdir(ftdetect_folder)

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -451,6 +451,7 @@ function module.new_argv(...)
         'GCOV_ERROR_FILE',
         'XDG_DATA_DIRS',
         'TMPDIR',
+        'VIMRUNTIME',
       }) do
         if not env_tbl[k] then
           env_tbl[k] = os.getenv(k)


### PR DESCRIPTION
Some of the tests will fail if this isn't explicitly set.
