### PR TITLE
vim-patch:8.2.4033: running filetype tests leaves directory behind

### DIFF
--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1042,7 +1042,7 @@ func Test_dep3patch_file()
   call assert_notequal('dep3patch', &filetype)
   bwipe!
 
-  call delete('debian/patches', 'rf')
+  call delete('debian', 'rf')
 endfunc
 
 func Test_patch_file()


### PR DESCRIPTION
#### vim-patch:8.2.4033: running filetype tests leaves directory behind

Problem:    Running filetype tests leaves directory behind.
Solution:   Delete the top directory. (closes vim/vim#9483)
https://github.com/vim/vim/commit/a4c96252b12c9ebc0ba563694c064e500d707b06