### PR TITLE
Allow nvim -es to be used interactively with a TTY

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -311,8 +311,7 @@ int main(int argc, char **argv)
   debug_break_level = params.use_debug_break_level;
 
   // Read ex-commands if invoked with "-es".
-  if (!params.input_isatty && !params.input_neverscript
-      && silent_mode && exmode_active) {
+  if (!params.input_neverscript && silent_mode && exmode_active) {
     input_start(STDIN_FILENO);
   }
 


### PR DESCRIPTION
When nvim -es is specified, the user enters ex mode and we don't enable the terminal UI.  In the modern day, the user is typically using this for scripting, but this also serves an important functionality as an editor of last resort when the user finds themselves without a terminal. ex mode is fully functional even on dumb terminals or when the terminfo database is broken, and this can allow a user to recover their system.

However, there's no reason that a user shouldn't be able to use this more interactively even if they do have a TTY.  This is not a common thing to want to do, but it should be possible.  At the moment, though, Neovim breaks this use case by explicitly checking for a missing terminal before enabling input.  As a result, since we've enabled silent mode, we have no terminal UI to read data from and we don't read from standard input, so we just silently read nothing, and exit.

This is definitely not what the user wanted or what they asked for, and it's bizarre to make this work only when the user is missing a TTY, so let's just skip the TTY check altogether here so it works the same regardless.

Note that there are no tests here because the testsuite does not allow us to spawn a process with `-e` and have a TTY attached to it at the same time.  For similar reasons, the behavior outlines in #16982 cannot be completely fixed by defaulting to `-s` when `-e` is given and a TTY is absent, like Vim does, but that breaks tests which check interactive `-e` and `-E` (without `-s`) behavior due to forcing on `-s`.  However, having _a_ functional behavior that's functional without a TTY and also works with a TTY is possible with this commit, and so I think it's sufficient to close the issue.

Fixes #16982