### PR TITLE
Make mode() return correct value in ex mode

### DIFF
--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -180,7 +180,7 @@ char *get_mode(void)
         buf[1] = 'x';
       }
     }
-  } else if (State & CMDLINE) {
+  } else if ((State & CMDLINE) || exmode_active) {
     buf[0] = 'c';
     if (exmode_active) {
       buf[1] = 'v';

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -224,6 +224,23 @@ describe('startup', function()
     end
   end)
 
+  it('-e sets ex mode', function()
+    local screen = Screen.new(25, 3)
+    clear('-e')
+    screen:attach()
+    -- Verify we set the proper mode both before and after :vi.
+    feed("put =mode(1)<CR>vi<CR>:put =mode(1)<CR>")
+    screen:expect([[
+      cv                       |
+      ^n                        |
+      :put =mode(1)            |
+    ]])
+
+    eq('cv\n',
+       funcs.system({nvim_prog, '-n', '-es' },
+                    { 'put =mode(1)', 'print', '' }))
+  end)
+
   it('fails on --embed with -es/-Es', function()
     matches('nvim[.exe]*: %-%-embed conflicts with %-es/%-Es',
       funcs.system({nvim_prog, '--embed', '-es' }))


### PR DESCRIPTION
When the user is in ex mode, a call to `mode(1)` is documented to return "cv".  However, it does not currently do so, because the check which checks for ex mode is nested inside a conditional which is never reached in ex mode.  Vim uses an explicit check for `exmode_active`, so let's do the same thing here.  Add some tests for this case both with a TTY and in silent mode.

Fixes #16981