### PR TITLE
feat(extmarks): add strict option

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -603,11 +603,10 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   bool strict = true;
   OPTION_TO_BOOL(strict, strict, true);
 
-  if (line < 0 ) {
+  if (line < 0) {
     api_set_error(err, kErrorTypeValidation, "line value outside range");
     goto error;
-  }
-  else if (line > buf->b_ml.ml_line_count) {
+  } else if (line > buf->b_ml.ml_line_count) {
     if (strict) {
       api_set_error(err, kErrorTypeValidation, "line value outside range");
       goto error;
@@ -627,7 +626,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     } else {
       col = (Integer)len;
     }
-  } else if (col < -1 ) {
+  } else if (col < -1) {
     api_set_error(err, kErrorTypeValidation, "col value outside range");
     goto error;
   }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -404,6 +404,10 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///                   for left). Defaults to false.
 ///               - priority: a priority value for the highlight group. For
 ///                   example treesitter highlighting uses a value of 100.
+///               - strict: boolean that indicates extmark should be placed
+///                   even if the line or column value is past the end of the
+///                   buffer or end of the line respectively. Defaults to true.
+///
 /// @param[out]  err   Error details, if any
 /// @return Id of the created/updated extmark
 Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer col,
@@ -596,7 +600,10 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   bool ephemeral = false;
   OPTION_TO_BOOL(ephemeral, ephemeral, false);
 
-  if (line < 0 || line > buf->b_ml.ml_line_count) {
+  bool strict = true;
+  OPTION_TO_BOOL(strict, strict, true);
+
+  if (line < 0 || (line > buf->b_ml.ml_line_count && strict)) {
     api_set_error(err, kErrorTypeValidation, "line value outside range");
     goto error;
   } else if (line < buf->b_ml.ml_line_count) {
@@ -605,7 +612,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   if (col == -1) {
     col = (Integer)len;
-  } else if (col < -1 || col > (Integer)len) {
+  } else if (col < -1 || (col > (Integer)len && strict)) {
     api_set_error(err, kErrorTypeValidation, "col value outside range");
     goto error;
   }
@@ -620,7 +627,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       // reuse len from before
       line2 = (int)line;
     }
-    if (col2 > (Integer)len) {
+    if (col2 > (Integer)len && strict) {
       api_set_error(err, kErrorTypeValidation, "end_col value outside range");
       goto error;
     }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -445,9 +445,18 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     opts->end_row = opts->end_line;
   }
 
+#define OPTION_TO_BOOL(target, name, val) \
+  target = api_object_to_bool(opts->name, #name, val, err); \
+  if (ERROR_SET(err)) { \
+    goto error; \
+  }
+
+  bool strict = true;
+  OPTION_TO_BOOL(strict, strict, true);
+
   if (opts->end_row.type == kObjectTypeInteger) {
     Integer val = opts->end_row.data.integer;
-    if (val < 0 || val > buf->b_ml.ml_line_count) {
+    if (val < 0 || (val > buf->b_ml.ml_line_count && strict)) {
       api_set_error(err, kErrorTypeValidation, "end_row value outside range");
       goto error;
     } else {
@@ -514,12 +523,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     api_set_error(err, kErrorTypeValidation,
                   "virt_text_win_col is not a Number of the correct size");
     goto error;
-  }
-
-#define OPTION_TO_BOOL(target, name, val) \
-  target = api_object_to_bool(opts->name, #name, val, err); \
-  if (ERROR_SET(err)) { \
-    goto error; \
   }
 
   OPTION_TO_BOOL(decor.virt_text_hide, virt_text_hide, false);
@@ -599,9 +602,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   bool ephemeral = false;
   OPTION_TO_BOOL(ephemeral, ephemeral, false);
-
-  bool strict = true;
-  OPTION_TO_BOOL(strict, strict, true);
 
   if (line < 0) {
     api_set_error(err, kErrorTypeValidation, "line value outside range");

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -21,6 +21,7 @@ return {
     "virt_lines";
     "virt_lines_above";
     "virt_lines_leftcol";
+    "strict";
   };
   keymap = {
     "noremap";

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -110,6 +110,22 @@ describe('API/extmarks', function()
        pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = 1, end_row = 1 }))
   end)
 
+  it("can end extranges past final newline when strict mode is false", function()
+    set_extmark(ns, marks[1], 0, 0, {
+      end_col = 1,
+      end_row = 1,
+      strict = false
+    })
+  end)
+
+  it("can end extranges past final column when strict mode is false", function()
+    set_extmark(ns, marks[1], 0, 0, {
+      end_col = 1,
+      end_row = 6,
+      strict = false
+    })
+  end)
+
   it('adds, updates  and deletes marks', function()
     local rv = set_extmark(ns, marks[1], positions[1][1], positions[1][2])
     eq(marks[1], rv)

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -114,15 +114,15 @@ describe('API/extmarks', function()
     set_extmark(ns, marks[1], 0, 0, {
       end_col = 1,
       end_row = 1,
-      strict = false
+      strict = false,
     })
   end)
 
   it("can end extranges past final column when strict mode is false", function()
     set_extmark(ns, marks[1], 0, 0, {
-      end_col = 1,
-      end_row = 6,
-      strict = false
+      end_col = 6,
+      end_row = 0,
+      strict = false,
     })
   end)
 


### PR DESCRIPTION
The strict option, when set to false, allows placing extmarks on
invalid row and column values greater than the maximum buffer row
or line column respectively.

This allows for nvim_buf_set_extmark
to be a drop-in replacement for nvim_buf_set_highlight.

Related: https://github.com/neovim/neovim/pull/16963