### PR TITLE
prevent checkhealth failure when plugin's check returns void

### DIFF
--- a/test/functional/fixtures/lua/test_plug/submodule_empty/health.lua
+++ b/test/functional/fixtures/lua/test_plug/submodule_empty/health.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+M.check = function()
+  return {}
+end
+
+return M

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -153,6 +153,10 @@ describe('health.vim', function()
         ## report 2
           - OK: nothing to see here
 
+        test_plug.submodule_empty: require("test_plug.submodule_empty.health").check()
+        ========================================================================
+          - ERROR: The healthcheck report for "test_plug.submodule_empty" plugin is empty.
+
         test_plug.submodule_failed: require("test_plug.submodule_failed.health").check()
         ========================================================================
           - ERROR: Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
@@ -170,6 +174,16 @@ describe('health.vim', function()
             function health#check[20]..health#broken#check, line 1
             caused an error
         ]])
+    end)
+
+    it("... including empty reports", function()
+      command("checkhealth test_plug.submodule_empty")
+      helpers.expect([[
+
+      test_plug.submodule_empty: require("test_plug.submodule_empty.health").check()
+      ========================================================================
+        - ERROR: The healthcheck report for "test_plug.submodule_empty" plugin is empty.
+      ]])
     end)
 
     it("gracefully handles broken lua healthcheck", function()


### PR DESCRIPTION
The `checkhealth` command currently fails outright in the event a  plugin's check health protocols failed to return *anything*.   This branch introduces a guard to catch this scenario.  It throws an error in the existing try/catch code block preventing the test from crashing all-together.  

Clearly, in the event this occurs, it is up to the plugin author to fix the issue.  

With this update the user will see all of the reports even when one of the reports fails as described.  The report that threw the error will display "ERROR" as they would anytime the plugin failed in the try block.  They will no longer see the `checkhealth` script fail outright.

\- E