### PR TITLE
refactor(lsp): debounce timer per buf and unify with non-debounce

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -920,6 +920,56 @@ describe('LSP', function()
       }
     end)
 
+    it('should check the body and didChange incremental', function()
+      local expected_handlers = {
+        {NIL, {}, {method="shutdown", client_id=1}};
+        {NIL, {}, {method="finish", client_id=1}};
+        {NIL, {}, {method="start", client_id=1}};
+      }
+      local client
+      test_rpc_server {
+        test_name = "basic_check_buffer_open_and_change_incremental";
+        options = {
+          allow_incremental_sync = true,
+        };
+        on_setup = function()
+          exec_lua [[
+            BUFFER = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(BUFFER, 0, -1, false, {
+              "testing";
+              "123";
+            })
+          ]]
+        end;
+        on_init = function(_client)
+          client = _client
+          local sync_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Incremental")
+          eq(sync_kind, client.resolved_capabilities().text_document_did_change)
+          eq(true, client.resolved_capabilities().text_document_open_close)
+          exec_lua [[
+            assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID))
+          ]]
+        end;
+        on_exit = function(code, signal)
+          eq(0, code, "exit code", fake_lsp_logfile)
+          eq(0, signal, "exit signal", fake_lsp_logfile)
+        end;
+        on_handler = function(err, result, ctx)
+          if ctx.method == 'start' then
+            exec_lua [[
+              vim.api.nvim_buf_set_lines(BUFFER, 1, 2, false, {
+                "123boop";
+              })
+            ]]
+            client.notify('finish')
+          end
+          eq(table.remove(expected_handlers), {err, result, ctx}, "expected handler")
+          if ctx.method == 'finish' then
+            client.stop()
+          end
+        end;
+      }
+    end)
     it('should check the body and didChange incremental with debounce', function()
       local expected_handlers = {
         {NIL, {}, {method="shutdown", client_id=1}};
@@ -961,8 +1011,6 @@ describe('LSP', function()
               vim.api.nvim_buf_set_lines(BUFFER, 1, 2, false, {
                 "123boop";
               })
-              -- wait for debounced change to trigger
-              vim.wait(10)
             ]]
             client.notify('finish')
           end


### PR DESCRIPTION
Part of the `pending_change` closure in the `changetracking.prepare` was
a bit confusing because it has access to `bufnr` and `uri` but it could
actually contain pending changes batched for multiple buffers.

(We accounted for that by grouping `pending_changes` by a `uri`, but
it's not obvious what's going on)

This commit changes the approach to do everything per buffer to avoid
any ambiguity.

It also brings the debounce/no-debounce a bit closer together: The
only difference is now whether a timer is used or if it is triggered
immediately