### PR TITLE
fix(completion): update submode message when selecting from API

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1089,6 +1089,8 @@ check_pum:
     // equivalent to selecting the item with a typed key.
     if (pum_want.active) {
       if (pum_visible()) {
+        // Set this to NULL so that ins_complete() will update the message.
+        edit_submode_extra = NULL;
         insert_do_complete(s);
         if (pum_want.finish) {
           // accept the item and stop completion

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -26,6 +26,7 @@ describe('ui/ext_popupmenu', function()
       [5] = {bold = true, foreground = Screen.colors.SeaGreen},
       [6] = {background = Screen.colors.WebGray},
       [7] = {background = Screen.colors.LightMagenta},
+      [8] = {foreground = Screen.colors.Red},
     })
     source([[
       function! TestComplete() abort
@@ -419,6 +420,55 @@ describe('ui/ext_popupmenu', function()
     screen:expect([[
                                                                   |
       bar^                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]])
+
+    feed('<esc>ddiaa bb cc<cr>')
+    feed('<c-x><c-n>')
+    screen:expect([[
+      aa bb cc                                                    |
+      aa^                                                          |
+      {6:aa             }{1:                                             }|
+      {7:bb             }{1:                                             }|
+      {7:cc             }{1:                                             }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- Keyword Local completion (^N^P) }{5:match 1 of 3}             |
+    ]])
+
+    feed('<f1>')
+    screen:expect([[
+      aa bb cc                                                    |
+      cc^                                                          |
+      {7:aa             }{1:                                             }|
+      {7:bb             }{1:                                             }|
+      {6:cc             }{1:                                             }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- Keyword Local completion (^N^P) }{5:match 3 of 3}             |
+    ]])
+
+    feed('<f2>')
+    screen:expect([[
+      aa bb cc                                                    |
+      cc^                                                          |
+      {7:aa             }{1:                                             }|
+      {7:bb             }{1:                                             }|
+      {7:cc             }{1:                                             }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- Keyword Local completion (^N^P) }{8:Back at original}         |
+    ]])
+
+    feed('<f3>')
+    screen:expect([[
+      aa bb cc                                                    |
+      bb^                                                          |
       {1:~                                                           }|
       {1:~                                                           }|
       {1:~                                                           }|


### PR DESCRIPTION
Fix #15515
Set `edit_submode_extra` to `NULL` before calling `ins_complete()`, so that the submode message is updated.