### PR TITLE
vim-patch:8.2.4052: not easy to resize a window from a plugin

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2782,6 +2782,8 @@ win_gettype([{nr}])		String	type of window {nr}
 win_gotoid({expr})		Number	go to |window-ID| {expr}
 win_id2tabwin({expr})		List	get tab and window nr from |window-ID|
 win_id2win({expr})		Number	get window nr from |window-ID|
+win_move_separator({nr})	Number	move window vertical separator
+win_move_statusline({nr})	Number	move window status line
 win_screenpos({nr})		List	get screen position of window {nr}
 win_splitmove({nr}, {target} [, {options}])
 				Number	move window {nr} to split of {target}
@@ -10608,6 +10610,35 @@ win_id2win({expr})					*win_id2win()*
 
 		Can also be used as a |method|: >
 			GetWinid()->win_id2win()
+
+win_move_separator({nr}, {offset})			*win_move_separator()*
+		Move window {nr}'s vertical separator (i.e., the right border)
+		by {offset} columns, as if being dragged by the mouse. {nr}
+		can be a window number or |window-ID|. A positive {offset}
+		moves right and a negative {offset} moves left. Moving a
+		window's vertical separator will change the width of the
+		window and the width of other windows adjacent to the vertical
+		separator. The magnitude of movement may be smaller than
+		specified (e.g., as a consequence of maintaining
+		'winminwidth'). Returns TRUE if the window can be found and
+		FALSE otherwise.
+
+		Can also be used as a |method|: >
+			GetWinnr()->win_move_separator(offset)
+
+win_move_statusline({nr}, {offset})			*win_move_statusline()*
+		Move window {nr}'s status line (i.e., the bottom border) by
+		{offset} rows, as if being dragged by the mouse. {nr} can be a
+		window number or |window-ID|. A positive {offset} moves down
+		and a negative {offset} moves up. Moving a window's status
+		line will change the height of the window and the height of
+		other windows adjacent to the status line. The magnitude of
+		movement may be smaller than specified (e.g., as a consequence
+		of maintaining 'winminheight'). Returns TRUE if the window can
+		be found and FALSE otherwise.
+
+		Can also be used as a |method|: >
+			GetWinnr()->win_move_statusline(offset)
 
 win_screenpos({nr})					*win_screenpos()*
 		Return the screen position of window {nr} as a list with two

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -837,6 +837,8 @@ Buffers, windows and the argument list:
 	win_gotoid()		go to window with ID
 	win_id2tabwin()		get tab and window nr from window ID
 	win_id2win()		get window nr from window ID
+	win_move_separator()	move window vertical separator
+	win_move_statusline()	move window status line
 	getbufinfo()		get a list with buffer information
 	gettabinfo()		get a list with tab page information
 	getwininfo()		get a list with window information

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -413,6 +413,8 @@ return {
     win_gotoid={args=1, base=1},
     win_id2tabwin={args=1, base=1},
     win_id2win={args=1, base=1},
+    win_move_separator={args=2, base=1},
+    win_move_statusline={args=2, base=1},
     win_screenpos={args=1, base=1},
     win_splitmove={args={2, 3}, base=1},
     winbufnr={args=1, base=1},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -11985,6 +11985,42 @@ static void f_win_id2win(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->vval.v_number = win_id2win(argvars);
 }
 
+/// "win_move_separator()" function
+static void f_win_move_separator(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  win_T *wp;
+  int offset;
+
+  rettv->vval.v_number = false;
+
+  wp = find_win_by_nr_or_id(&argvars[0]);
+  if (wp == NULL || wp->w_floating) {
+    return;
+  }
+
+  offset = (int)tv_get_number(&argvars[1]);
+  win_drag_vsep_line(wp, offset);
+  rettv->vval.v_number = true;
+}
+
+/// "win_move_statusline()" function
+static void f_win_move_statusline(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  win_T *wp;
+  int offset;
+
+  rettv->vval.v_number = false;
+
+  wp = find_win_by_nr_or_id(&argvars[0]);
+  if (wp == NULL || wp->w_floating) {
+    return;
+  }
+
+  offset = (int)tv_get_number(&argvars[1]);
+  win_drag_status_line(wp, offset);
+  rettv->vval.v_number = true;
+}
+
 /// "winbufnr(nr)" function
 static void f_winbufnr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -939,4 +939,104 @@ func Test_window_resize()
   %bwipe!
 endfunc
 
+func Test_win_move_separator()
+  edit a
+  leftabove vsplit b
+  let w = winwidth(0)
+  " check win_move_separator from left window on left window
+  call assert_equal(1, winnr())
+  for offset in range(5)
+    call assert_true(win_move_separator(0, offset))
+    call assert_equal(w + offset, winwidth(0))
+    call assert_true(0->win_move_separator(-offset))
+    call assert_equal(w, winwidth(0))
+  endfor
+  " check win_move_separator from right window on left window number
+  wincmd l
+  call assert_notequal(1, winnr())
+  for offset in range(5)
+    call assert_true(1->win_move_separator(offset))
+    call assert_equal(w + offset, winwidth(1))
+    call assert_true(win_move_separator(1, -offset))
+    call assert_equal(w, winwidth(1))
+  endfor
+  " check win_move_separator from right window on left window ID
+  let id = win_getid(1)
+  for offset in range(5)
+    call assert_true(win_move_separator(id, offset))
+    call assert_equal(w + offset, winwidth(id))
+    call assert_true(id->win_move_separator(-offset))
+    call assert_equal(w, winwidth(id))
+  endfor
+  " check that win_move_separator doesn't error with offsets beyond moving
+  " possibility
+  call assert_true(win_move_separator(id, 5000))
+  call assert_true(winwidth(id) > w)
+  call assert_true(win_move_separator(id, -5000))
+  call assert_true(winwidth(id) < w)
+  " check that win_move_separator returns false for an invalid window
+  wincmd =
+  let w = winwidth(0)
+  call assert_false(win_move_separator(-1, 1))
+  call assert_equal(w, winwidth(0))
+  " check that win_move_separator returns false for a floating window
+  let id = nvim_open_win(
+        \ 0, 0, #{relative: 'editor', row: 2, col: 2, width: 5, height: 3})
+  let w = winwidth(id)
+  call assert_false(win_move_separator(id, 1))
+  call assert_equal(w, winwidth(id))
+  call nvim_win_close(id, 1)
+  %bwipe!
+endfunc
+
+func Test_win_move_statusline()
+  edit a
+  leftabove split b
+  let h = winheight(0)
+  " check win_move_statusline from top window on top window
+  call assert_equal(1, winnr())
+  for offset in range(5)
+    call assert_true(win_move_statusline(0, offset))
+    call assert_equal(h + offset, winheight(0))
+    call assert_true(0->win_move_statusline(-offset))
+    call assert_equal(h, winheight(0))
+  endfor
+  " check win_move_statusline from bottom window on top window number
+  wincmd j
+  call assert_notequal(1, winnr())
+  for offset in range(5)
+    call assert_true(1->win_move_statusline(offset))
+    call assert_equal(h + offset, winheight(1))
+    call assert_true(win_move_statusline(1, -offset))
+    call assert_equal(h, winheight(1))
+  endfor
+  " check win_move_statusline from bottom window on top window ID
+  let id = win_getid(1)
+  for offset in range(5)
+    call assert_true(win_move_statusline(id, offset))
+    call assert_equal(h + offset, winheight(id))
+    call assert_true(id->win_move_statusline(-offset))
+    call assert_equal(h, winheight(id))
+  endfor
+  " check that win_move_statusline doesn't error with offsets beyond moving
+  " possibility
+  call assert_true(win_move_statusline(id, 5000))
+  call assert_true(winheight(id) > h)
+  call assert_true(win_move_statusline(id, -5000))
+  call assert_true(winheight(id) < h)
+  " check that win_move_statusline returns false for an invalid window
+  wincmd =
+  let h = winheight(0)
+  call assert_false(win_move_statusline(-1, 1))
+  call assert_equal(h, winheight(0))
+  " check that win_move_statusline returns false for a floating window
+  let id = nvim_open_win(
+        \ 0, 0, #{relative: 'editor', row: 2, col: 2, width: 5, height: 3})
+  let h = winheight(id)
+  call assert_false(win_move_statusline(id, 1))
+  call assert_equal(h, winheight(id))
+  call nvim_win_close(id, 1)
+  %bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This ports `win_move_separator()` and `win_move_statusline()` (vim/vim@ee63031) to Neovim.

The patch was not applied as-is, having the following changes:

- Format updates: tabs to spaces, braces around statements following `if`, `TRUE`/`FALSE` to `true`/`false`
- Remove `vim9script` handling
- Add `fptr` arguments in `funcs.c`
- Switch popup handling to float handling
- Put documentation in `eval.txt` instead of `builtin.txt` (#16975)

#### vim-patch:8.2.4052: not easy to resize a window from a plugin

Problem:    Not easy to resize a window from a plugin.
Solution:   Add win_move_separator() and win_move_statusline() functions.
            (Daniel Steinberg, closes https://github.com/vim/vim/pull/9486)
https://github.com/vim/vim/commit/ee63031b572eb7aea27be4c7e3dafba0daaf681b