### PR TITLE
feat(filetype): add foam filetype autocmds

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -829,6 +829,24 @@ func dist#ft#Dep3patch()
   endfor
 endfunc
 
+" This function checks the first 15 lines for appearance of 'FoamFile'
+" followed by 'object' on separate lines
+" In that case, it's probably an OpenFOAM file
+func dist#ft#FTfoam()
+    let lnum = 1
+    let ffile = 0
+    while lnum <= 15
+      if getline(lnum) =~# '^FoamFile'
+    let ffile = 1
+      endif
+      if ((ffile == 1) && (getline(lnum) =~# '^\s*object'))
+	setf foam
+	return
+      endif
+      let lnum = lnum + 1
+    endwhile
+endfunc
+
 " Restore 'cpoptions'
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1210,6 +1210,9 @@ au BufNewFile,BufRead *.xom,*.xin		setf omnimark
 " OPAM
 au BufNewFile,BufRead opam,*.opam,*.opam.template setf opam
 
+" OpenFOAM
+au BufNewFile,BufRead [a-zA-Z0-9]*Dict\(.*\)\=,[a-zA-Z]*Properties\(.*\)\=,*Transport\(.*\),fvSchemes,fvSolution,fvConstrains,fvModels,*/constant/g,*/0\(\.orig\)\=/* call dist#ft#FTfoam()
+
 " OpenROAD
 au BufNewFile,BufRead *.or			setf openroad
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1096,4 +1096,54 @@ func Test_git_file()
   filetype off
 endfunc
 
+func Test_foam_file()
+  filetype on
+  call assert_true(mkdir('0', 'p'))
+  call assert_true(mkdir('0.orig', 'p'))
+
+  call writefile(['FoamFile {', '    object something;'], 'Xfile1Dict')
+  split Xfile1Dict
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'Xfile1Dict.something')
+  split Xfile1Dict.something
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties')
+  split XfileProperties
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties.something')
+  split XfileProperties.something
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties')
+  split XfileProperties
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties.something')
+  split XfileProperties.something
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], '0/Xfile')
+  split 0/Xfile
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], '0.orig/Xfile')
+  split 0.orig/Xfile
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call delete('0', 'rf')
+  call delete('0.orig', 'rf')
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Adding the [OpenFOAM](https://github.com/OpenFOAM/OpenFOAM-dev) file type which was previously recognized as `cpp`.
Now we have a [TreeSitter grammar](https://github.com/FoamScience/tree-sitter-foam) and a [language server](https://github.com/FoamScience/foam-language-server), so I thought it's time NeoVim learns to detect OpenFOAM-related files.

- Unfortunately; the only reliable way to detect `foam` file type is by looking into the file; That's what the `dist#ft#FTfoam()` in `runtime/autoload/dist/ft.vim` does.
- The new autocmds in `runtime/autoload/dist/ft.vim` account for most of the OpenFOAM file patterns;

A typical set of OpenFOAM files can be found [here](https://github.com/OpenFOAM/OpenFOAM-dev/tree/master/tutorials/basic/scalarTransportFoam/pitzDaily) (Note the directory also contains shell scripts)
From [OpenFOAM tutorials](https://github.com/OpenFOAM/OpenFOAM-dev/tree/master/tutorials), here are the first 40 file patterns (but we're not just limited to these):
```
    241 system/fvSolution
    241 system/fvSchemes
    234 system/controlDict
    186 system/blockMeshDict
    163 constant/momentumTransport
    150 0/U
    142 0/p
    112 constant/transportProperties
    106 constant/g
     93 0/nut
     92 0/k
     91 system/decomposeParDict
     78 0/p_rgh
     77 constant/thermophysicalProperties
     67 0/epsilon
     64 0/T
     56 system/setFieldsDict
     44 0/alphat
     42 system/fvConstraints
     38 0/alpha.water.orig
     36 system/topoSetDict
     35 constant/fvModels
     28 constant/dynamicMeshDict
     25 constant/phaseProperties
     25 constant/combustionProperties
     24 0/omega
     23 system/snappyHexMeshDict
     19 system/meshQualityDict
     19 constant/thermophysicalProperties.air
     18 constant/momentumTransport.air
     18 constant/cloudProperties
     18 0/nuTilda
     17 0/U.orig
     17 0/U.air
     17 0/H2O
     16 system/surfaceFeaturesDict
     16 constant/thermophysicalProperties.water
     16 0/alpha.air.orig
     15 0/O2
     15 0/N2
```

For the test coverage; I couldn't find how the file type functions are tested with the lua framework, so I opted for a legacy `src/nvim/testdir/test_filetype.vim`