### PR TITLE
feat(completion): support selecting item via API from Lua mapping

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1082,6 +1082,8 @@ static int insert_handle_key(InsertState *s)
     map_execute_lua();
 
 check_pum:
+    // nvim_select_popupmenu_item() can be called from the handling of
+    // K_EVENT, K_COMMAND, or K_LUA.
     // TODO(bfredl): Not entirely sure this indirection is necessary
     // but doing like this ensures using nvim_select_popupmenu_item is
     // equivalent to selecting the item with a typed key.
@@ -4986,7 +4988,7 @@ void ins_compl_check_keys(int frequency, int in_compl_func)
  */
 static int ins_compl_key2dir(int c)
 {
-  if (c == K_EVENT || c == K_COMMAND) {
+  if (c == K_EVENT || c == K_COMMAND || c == K_LUA) {
     return pum_want.item < pum_selected_item ? BACKWARD : FORWARD;
   }
   if (c == Ctrl_P || c == Ctrl_L
@@ -5016,7 +5018,7 @@ static int ins_compl_key2count(int c)
 {
   int h;
 
-  if (c == K_EVENT || c == K_COMMAND) {
+  if (c == K_EVENT || c == K_COMMAND || c == K_LUA) {
     int offset = pum_want.item - pum_selected_item;
     return abs(offset);
   }
@@ -5050,6 +5052,7 @@ static bool ins_compl_use_match(int c)
     return false;
   case K_EVENT:
   case K_COMMAND:
+  case K_LUA:
     return pum_want.active && pum_want.insert;
   }
   return true;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -10,6 +10,7 @@ local funcs = helpers.funcs
 local get_pathsep = helpers.get_pathsep
 local eq = helpers.eq
 local pcall_err = helpers.pcall_err
+local exec_lua = helpers.exec_lua
 
 describe('ui/ext_popupmenu', function()
   local screen
@@ -322,6 +323,62 @@ describe('ui/ext_popupmenu', function()
 
     -- also should work for builtin popupmenu
     screen:set_option('ext_popupmenu', false)
+    feed('<C-r>=TestComplete()<CR>')
+    screen:expect([[
+                                                                  |
+      foo^                                                         |
+      {6:fo   x the foo }{1:                                             }|
+      {7:bar            }{1:                                             }|
+      {7:spam           }{1:                                             }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]])
+
+    feed('<f1>')
+    screen:expect([[
+                                                                  |
+      spam^                                                        |
+      {7:fo   x the foo }{1:                                             }|
+      {7:bar            }{1:                                             }|
+      {6:spam           }{1:                                             }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]])
+
+    feed('<f2>')
+    screen:expect([[
+                                                                  |
+      spam^                                                        |
+      {7:fo   x the foo }{1:                                             }|
+      {7:bar            }{1:                                             }|
+      {7:spam           }{1:                                             }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]])
+
+    feed('<f3>')
+    screen:expect([[
+                                                                  |
+      bar^                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {2:-- INSERT --}                                                |
+    ]])
+
+    command('iunmap <f1>')
+    command('iunmap <f2>')
+    command('iunmap <f3>')
+    exec_lua([[
+      vim.keymap.set('i', '<f1>', function() vim.api.nvim_select_popupmenu_item(2, true, false, {}) end)
+      vim.keymap.set('i', '<f2>', function() vim.api.nvim_select_popupmenu_item(-1, false, false, {}) end)
+      vim.keymap.set('i', '<f3>', function() vim.api.nvim_select_popupmenu_item(1, false, true, {}) end)
+    ]])
     feed('<C-r>=TestComplete()<CR>')
     screen:expect([[
                                                                   |


### PR DESCRIPTION
This makes calling `nvim_select_popupmenu_item()` from a Lua mapping behave like calling `nvim_select_popupmenu_item()` from a `<Cmd>` mapping or RPC.