### PR TITLE
fix(lsp): fix applying the multiple out-of-range TextEdits

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1322,6 +1322,20 @@ describe('LSP', function()
         'foobar';
       }, buf_lines(1))
     end)
+    it('applies multiple text edits at the end of the document', function()
+      local edits = {
+        make_edit(4, 0, 5, 0, "");
+        make_edit(5, 0, 5, 0, "foobar");
+      }
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      eq({
+        'First line of text';
+        'Second line of text';
+        'Third line of text';
+        'Fourth line of text';
+        'foobar';
+      }, buf_lines(1))
+    end)
 
     describe('cursor position', function()
       it('don\'t fix the cursor if the range contains the cursor', function()


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/16842

In the previous implementation, the out-of-range TextEdits will be fixed at the preparation phase.
However, The out-of-range TextEdit can't detect correctly at that time because another TextEdit can create a new ending line to the buffer.

So the new implementation will fix the out-of-range TextEdit at the run-time.