### PR TITLE
vim-patch:8.2.4064: foam files are not detected

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -829,6 +829,23 @@ func dist#ft#Dep3patch()
   endfor
 endfunc
 
+" This function checks the first 15 lines for appearance of 'FoamFile'
+" and then 'object' in a following line.
+" In that case, it's probably an OpenFOAM file
+func dist#ft#FTfoam()
+    let ffile = 0
+    let lnum = 1
+    while lnum <= 15
+      if getline(lnum) =~# '^FoamFile'
+	let ffile = 1
+      elseif ffile == 1 && getline(lnum) =~# '^\s*object'
+	setf foam
+	return
+      endif
+      let lnum = lnum + 1
+    endwhile
+endfunc
+
 " Restore 'cpoptions'
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1210,6 +1210,9 @@ au BufNewFile,BufRead *.xom,*.xin		setf omnimark
 " OPAM
 au BufNewFile,BufRead opam,*.opam,*.opam.template setf opam
 
+" OpenFOAM
+au BufNewFile,BufRead [a-zA-Z0-9]*Dict\(.*\)\=,[a-zA-Z]*Properties\(.*\)\=,*Transport\(.*\),fvSchemes,fvSolution,fvConstrains,fvModels,*/constant/g,*/0\(\.orig\)\=/* call dist#ft#FTfoam()
+
 " OpenROAD
 au BufNewFile,BufRead *.or			setf openroad
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -860,6 +860,10 @@ local filename = {
   ["exim.conf"] = "exim",
   exports = "exports",
   [".fetchmailrc"] = "fetchmail",
+  fvSchemes = function() vim.fn["dist#ft#FTfoam"]() end,
+  fvSolution = function() vim.fn["dist#ft#FTfoam"]() end,
+  fvConstraints = function() vim.fn["dist#ft#FTfoam"]() end,
+  fvModels = function() vim.fn["dist#ft#FTfoam"]() end,
   fstab = "fstab",
   mtab = "fstab",
   [".gdbinit"] = "gdb",
@@ -1334,6 +1338,14 @@ local pattern = {
   ["zlog.*"] = starsetf('zsh'),
   ["zsh.*"] = starsetf('zsh'),
   ["ae%d+%.txt"] = 'mail',
+  ["[a-zA-Z0-9]*Dict"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  ["[a-zA-Z0-9]*Dict%..*"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  ["[a-zA-Z]*Properties"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  ["[a-zA-Z]*Properties%..*"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  [".*Transport%..*"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  [".*/constant/g"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  [".*/0/.*"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  [".*/0%.orig/.*"] = function() vim.fn["dist#ft#FTfoam"]() end,
   -- END PATTERN
 }
 -- luacheck: pop

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1096,4 +1096,54 @@ func Test_git_file()
   filetype off
 endfunc
 
+func Test_foam_file()
+  filetype on
+  call assert_true(mkdir('0', 'p'))
+  call assert_true(mkdir('0.orig', 'p'))
+
+  call writefile(['FoamFile {', '    object something;'], 'Xfile1Dict')
+  split Xfile1Dict
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'Xfile1Dict.something')
+  split Xfile1Dict.something
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties')
+  split XfileProperties
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties.something')
+  split XfileProperties.something
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties')
+  split XfileProperties
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], 'XfileProperties.something')
+  split XfileProperties.something
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], '0/Xfile')
+  split 0/Xfile
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call writefile(['FoamFile {', '    object something;'], '0.orig/Xfile')
+  split 0.orig/Xfile
+  call assert_equal('foam', &filetype)
+  bwipe!
+
+  call delete('0', 'rf')
+  call delete('0.orig', 'rf')
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Foam files are not detected.
Solution:   Detect the foam filetype by the path and file contents. (Mohammed
            Elwardi Fadeli, closes vim/vim#9501)
https://github.com/vim/vim/commit/2284f6cca384e0ccc352bfec7277dc26386cac3d

closes #2224

@gpanders I don't trust myself porting _that_ pattern to `filetype.lua`...