### PR TITLE
fix(keywordprg): retain terminal buffer after K

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4437,11 +4437,7 @@ static void nv_ident(cmdarg_T *cap)
       // Start insert mode in terminal buffer
       restart_edit = 'i';
 
-      add_map((char_u *)"<buffer> <esc> <Cmd>call jobstop(&channel)<CR>", TERM_FOCUS, true);
-      do_cmdline_cmd("autocmd TermClose <buffer> "
-                     " if !v:event.status |"
-                     "   exec 'bdelete! ' .. expand('<abuf>') |"
-                     " endif");
+      add_map((char_u *)"<buffer> <esc> <Cmd>bdelete!<CR>", TERM_FOCUS, true);
     }
   }
 

--- a/test/functional/editor/K_spec.lua
+++ b/test/functional/editor/K_spec.lua
@@ -33,6 +33,29 @@ describe('K', function()
     feed('i'..test_file..'<ESC>K')
     retry(nil, nil, function() eq(1, eval('filereadable("'..test_file..'")')) end)
     eq({'fnord'}, eval("readfile('"..test_file.."')"))
+    -- Confirm that Neovim is still in terminal mode after K is pressed (#16692).
+    helpers.sleep(500)
+    eq('t', eval('mode()'))
+    feed('<space>')  -- Any key, not just <space>, can be used here to escape.
+    eq('n', eval('mode()'))
+  end)
+
+  it("<esc> kills the buffer for a running 'keywordprg' command", function()
+    helpers.source('set keywordprg=less')
+    eval('writefile(["hello", "world"], "' .. test_file .. '")')
+    feed('i' .. test_file .. '<esc>K')
+    eq('t', eval('mode()'))
+    -- Confirm that an arbitrary keypress doesn't escape (i.e., the process is
+    -- still running). If the process were no longer running, an arbitrary
+    -- keypress would escape.
+    helpers.sleep(500)
+    feed('<space>')
+    eq('t', eval('mode()'))
+    -- Confirm that <esc> kills the buffer for the running command.
+    local bufnr = eval('bufnr()')
+    feed('<esc>')
+    eq('n', eval('mode()'))
+    helpers.neq(bufnr, eval('bufnr()'))
   end)
 
 end)


### PR DESCRIPTION
This addresses #16692.

Without this PR, pressing K will run `keywordprg` and close the terminal buffer when execution completes.

Per @zeertzjq's [comment](https://github.com/neovim/neovim/issues/16692#issuecomment-996407318), I've removed the `TermClose` autocommand. Per @gpanders's [comment](https://github.com/neovim/neovim/issues/16692#issuecomment-998430000), I've updated the `<esc>` mapping to close the buffer after ending the process.

I've added a test to confirm that Neovim is still in terminal mode after pressing `K`.