### PR TITLE
fix(lsp): strictly enforce passing offset encoding

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -503,7 +503,7 @@ local function on_code_action_results(results, ctx)
   ---@private
   local function apply_action(action, client)
     if action.edit then
-      util.apply_workspace_edit(action.edit)
+      util.apply_workspace_edit(action.edit, client.offset_encoding)
     end
     if action.command then
       local command = type(action.command) == 'table' and action.command or action

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1291,7 +1291,7 @@ describe('LSP', function()
         make_edit(2, 0, 2, 2, {"3"});
         make_edit(3, 2, 3, 4, {""});
       }
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
       eq({
         '123First line of text';
         '2econd line of text';
@@ -1311,7 +1311,7 @@ describe('LSP', function()
         make_edit(3, #'', 3, #"Fourth", {"another line of text", "before this"});
         make_edit(3, #'Fourth', 3, #"Fourth line of text", {"!"});
       }
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
       eq({
         '';
         '123';
@@ -1335,7 +1335,7 @@ describe('LSP', function()
         make_edit(3, #"Fourth", 3, #'', {"another line of text", "before this"});
         make_edit(3, #"Fourth line of text", 3, #'Fourth', {"!"});
       }
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
       eq({
         '';
         '123';
@@ -1352,7 +1352,7 @@ describe('LSP', function()
       local edits = {
         make_edit(4, 3, 4, 4, {"ä"});
       }
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
       eq({
         'First line of text';
         'Second line of text';
@@ -1365,7 +1365,7 @@ describe('LSP', function()
       local edits = {
         make_edit(5, 0, 5, 0, "foobar");
       }
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
       eq({
         'First line of text';
         'Second line of text';
@@ -1380,7 +1380,7 @@ describe('LSP', function()
         make_edit(4, 0, 5, 0, "");
         make_edit(5, 0, 5, 0, "foobar");
       }
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
       eq({
         'First line of text';
         'Second line of text';
@@ -1396,7 +1396,7 @@ describe('LSP', function()
         local edits = {
           make_edit(1, 0, 1, 19, 'Second line of text')
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({
           'First line of text';
           'Second line of text';
@@ -1413,7 +1413,7 @@ describe('LSP', function()
           make_edit(1, 0, 1, 6, ''),
           make_edit(1, 6, 1, 19, '')
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({
           'First line of text';
           '';
@@ -1430,7 +1430,7 @@ describe('LSP', function()
           make_edit(1, 0, 1, 6, ''),
           make_edit(0, 18, 5, 0, '')
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({
           'First line of text';
         }, buf_lines(1))
@@ -1442,7 +1442,7 @@ describe('LSP', function()
         local edits = {
           make_edit(1, 0, 2, 0, '')
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({
           'First line of text';
           'Third line of text';
@@ -1457,7 +1457,7 @@ describe('LSP', function()
         local edits = {
           make_edit(1, 7, 1, 11, '')
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({
           'First line of text';
           'Second  of text';
@@ -1473,7 +1473,7 @@ describe('LSP', function()
         local edits = {
           make_edit(0, 11, 1, 12, '')
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({
           'First line of text';
           'Third line of text';
@@ -1489,21 +1489,21 @@ describe('LSP', function()
         local edits = {
           make_edit(0, 0, 5, 0, {"All replaced"});
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({'All replaced'}, buf_lines(1))
       end)
       it('applies edits when the end line is 2 larger than vim\'s', function()
         local edits = {
           make_edit(0, 0, 6, 0, {"All replaced"});
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({'All replaced'}, buf_lines(1))
       end)
       it('applies edits with a column offset', function()
         local edits = {
           make_edit(0, 0, 5, 2, {"All replaced"});
         }
-        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1)
+        exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, "utf-16")
         eq({'All replaced'}, buf_lines(1))
       end)
     end)
@@ -1531,7 +1531,7 @@ describe('LSP', function()
       ]]
     end)
     it('correctly goes ahead with the edit if all is normal', function()
-      exec_lua('vim.lsp.util.apply_text_document_edit(...)', text_document_edit(5))
+      exec_lua("vim.lsp.util.apply_text_document_edit(..., nil, 'utf-16')", text_document_edit(5))
       eq({
         'First ↥ 🤦 🦄 line of text';
         '2nd line of 语text';
@@ -1543,7 +1543,7 @@ describe('LSP', function()
         local bufnr = select(1, ...)
         local text_edit = select(2, ...)
         vim.lsp.util.buf_versions[bufnr] = 10
-        vim.lsp.util.apply_text_document_edit(text_edit)
+        vim.lsp.util.apply_text_document_edit(text_edit, nil, 'utf-16')
       ]], target_bufnr, text_document_edit(0))
       eq({
         'First ↥ 🤦 🦄 line of text';
@@ -1556,7 +1556,7 @@ describe('LSP', function()
           local args = {...}
           local versionedBuf = args[2]
           vim.lsp.util.buf_versions[versionedBuf.bufnr] = versionedBuf.currentVersion
-          vim.lsp.util.apply_text_document_edit(args[1])
+          vim.lsp.util.apply_text_document_edit(args[1], nil, 'utf-16')
         ]], edit, versionedBuf)
       end
 
@@ -1582,17 +1582,36 @@ describe('LSP', function()
 
   describe('workspace_apply_edit', function()
     it('workspace/applyEdit returns ApplyWorkspaceEditResponse', function()
-      local expected = {
-        applied = true;
-        failureReason = nil;
+      local expected_handlers = {
+        {NIL, {}, {method="test", client_id=1}};
       }
-      eq(expected, exec_lua [[
-        local apply_edit = {
-          label = nil;
-          edit = {};
-        }
-        return vim.lsp.handlers['workspace/applyEdit'](nil, apply_edit)
-      ]])
+      test_rpc_server {
+        test_name = "basic_init";
+        on_init = function(client, _)
+          client.stop()
+        end;
+        -- If the program timed out, then code will be nil.
+        on_exit = function(code, signal)
+          eq(0, code, "exit code", fake_lsp_logfile)
+          eq(0, signal, "exit signal", fake_lsp_logfile)
+        end;
+        -- Note that NIL must be used here.
+        -- on_handler(err, method, result, client_id)
+        on_handler = function(...)
+          local expected = {
+            applied = true;
+            failureReason = nil;
+          }
+          eq(expected, exec_lua [[
+            local apply_edit = {
+              label = nil;
+              edit = {};
+            }
+            return vim.lsp.handlers['workspace/applyEdit'](nil, apply_edit, {client_id = TEST_RPC_CLIENT_ID})
+          ]])
+          eq(table.remove(expected_handlers), {...})
+        end;
+      }
     end)
   end)
 
@@ -1666,7 +1685,7 @@ describe('LSP', function()
         local workspace_edits = args[1]
         local target_bufnr = args[2]
 
-        vim.lsp.util.apply_workspace_edit(workspace_edits)
+        vim.lsp.util.apply_workspace_edit(workspace_edits, 'utf-16')
 
         return vim.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)
       ]], make_workspace_edit(edits), target_bufnr))
@@ -1688,7 +1707,7 @@ describe('LSP', function()
         local workspace_edits = args[1]
         local target_bufnr = args[2]
 
-        vim.lsp.util.apply_workspace_edit(workspace_edits)
+        vim.lsp.util.apply_workspace_edit(workspace_edits, 'utf-16')
 
         return vim.api.nvim_buf_get_lines(target_bufnr, 0, -1, false)
       ]], make_workspace_edit(edits), target_bufnr))
@@ -1705,7 +1724,7 @@ describe('LSP', function()
           },
         }
       }
-      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit)
+      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
       eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
     end)
     it('createFile does not touch file if it exists and ignoreIfExists is set', function()
@@ -1723,7 +1742,7 @@ describe('LSP', function()
           },
         }
       }
-      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit)
+      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
       eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
       eq('Dummy content', read_file(tmpfile))
     end)
@@ -1743,7 +1762,7 @@ describe('LSP', function()
           },
         }
       }
-      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit)
+      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
       eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
       eq('', read_file(tmpfile))
     end)
@@ -1764,7 +1783,7 @@ describe('LSP', function()
           }
         }
       }
-      eq(true, pcall(exec_lua, 'vim.lsp.util.apply_workspace_edit(...)', edit))
+      eq(true, pcall(exec_lua, 'vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16'))
       eq(false, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
       eq(false, exec_lua('return vim.api.nvim_buf_is_loaded(vim.fn.bufadd(...))', tmpfile))
     end)
@@ -1925,7 +1944,7 @@ describe('LSP', function()
             }
           },
         }
-        return vim.lsp.util.locations_to_items(locations)
+        return vim.lsp.util.locations_to_items(locations, 'utf-16')
       ]]
       eq(expected, actual)
     end)
@@ -1955,7 +1974,7 @@ describe('LSP', function()
             }
           },
         }
-        return vim.lsp.util.locations_to_items(locations)
+        return vim.lsp.util.locations_to_items(locations, 'utf-16')
       ]]
       eq(expected, actual)
     end)
@@ -2259,7 +2278,7 @@ describe('LSP', function()
     end
 
     local jump = function(msg)
-      eq(true, exec_lua('return vim.lsp.util.jump_to_location(...)', msg))
+      eq(true, exec_lua('return vim.lsp.util.jump_to_location(...)', msg, "utf-16"))
       eq(target_bufnr, exec_lua[[return vim.fn.bufnr('%')]])
       return {
         line = exec_lua[[return vim.fn.line('.')]],


### PR DESCRIPTION
This removes the "fallback" to utf-16 in many of our helper functions.  We should always explicitly pass these around when possible except in two locations:

* generating params with help utilities called by buf.lua functions
* the buf.lua functions themselves

Anything that is called by the handler should be passed the offset encoding.