### PR TITLE
fix(lsp): correct prefix when filterText is present

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1599,10 +1599,14 @@ local function adjust_start_col(lnum, line, items, encoding)
   local min_start_char = nil
   for _, item in pairs(items) do
     if item.textEdit and item.textEdit.range.start.line == lnum - 1 then
-      if min_start_char and min_start_char ~= item.textEdit.range.start.character then
-        return nil
+      if item.filterText ~= nil
+        min_start_char = item.textEdit.range["end"].character
+      else
+        if min_start_char and min_start_char ~= item.textEdit.range.start.character then
+          return nil
+        end
+        min_start_char = item.textEdit.range.start.character
       end
-      min_start_char = item.textEdit.range.start.character
     end
   end
   if min_start_char then

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1598,15 +1598,11 @@ end
 local function adjust_start_col(lnum, line, items, encoding)
   local min_start_char = nil
   for _, item in pairs(items) do
-    if item.textEdit and item.textEdit.range.start.line == lnum - 1 then
-      if item.filterText ~= nil
-        min_start_char = item.textEdit.range["end"].character
-      else
-        if min_start_char and min_start_char ~= item.textEdit.range.start.character then
-          return nil
-        end
-        min_start_char = item.textEdit.range.start.character
+    if item.filterText == nil and item.textEdit and item.textEdit.range.start.line == lnum - 1 then
+      if min_start_char and min_start_char ~= item.textEdit.range.start.character then
+        return nil
       end
+      min_start_char = item.textEdit.range.start.character
     end
   end
   if min_start_char then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -575,9 +575,6 @@ end
 --- precedence is as follows: textEdit.newText > insertText > label
 --see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
 local function get_completion_word(item)
-  if item.filterText ~= nil then
-    return item.filterText
-  end
   if item.textEdit ~= nil and item.textEdit.newText ~= nil and item.textEdit.newText ~= "" then
     local insert_text_format = protocol.InsertTextFormat[item.insertTextFormat]
     if insert_text_format == "PlainText" or insert_text_format == nil then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -575,6 +575,9 @@ end
 --- precedence is as follows: textEdit.newText > insertText > label
 --see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
 local function get_completion_word(item)
+  if item.filterText ~= nil then
+    return item.filterText
+  end
   if item.textEdit ~= nil and item.textEdit.newText ~= nil and item.textEdit.newText ~= "" then
     local insert_text_format = protocol.InsertTextFormat[item.insertTextFormat]
     if insert_text_format == "PlainText" or insert_text_format == nil then


### PR DESCRIPTION
LSP server might return an item which would replace a token to another.
For example in typescript for a `jest.Mock` object `getProductsMock.` text I get the following response:
```
{
    commitCharacters = {
        ".",
        ",",
        "("
    },
    data = {
        entryNames = {
            "Symbol"
        },
        file = "/foo/bar/baz.service.spec.ts",
        line = 268,
        offset = 17
    },
    filterText = ".Symbol",
    kind = 6,
    label = "Symbol",
    sortText = "11",
    textEdit = {
        newText = "[Symbol]",
        range = {
            end = {
                character = 16,
                line = 267
            },
            start = {
                character = 15,
                line = 267
            }
        }
    }
},
```

In `lsp.omnifunc` to get a `prefix` we call the `adjust_start_col` which then returns the `textEdit.range.start.character`.
Th `prefix` then be the `.` character. Then when filter the items with `remove_unmatch_completion_items`, every item will be filtered out, since no completion word starts `.`.

To fix we return the `end.character`, which in that particular case will be the position after the `.`.

Im not sure that this is a correct way to fix the issue, but it might be a good starting point.
