### PR TITLE
feat(highlight): overline attribute support

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -9915,6 +9915,7 @@ synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
 		"underline"	"1" if underlined
 		"undercurl"	"1" if undercurled
 		"strikethrough"	"1" if struckthrough
+		"overline"	"1" if overlined
 
 		Example (echoes the color of the syntax item under the
 		cursor): >

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4874,6 +4874,7 @@ the same syntax file on all UIs.
 					*bold* *underline* *undercurl*
 					*inverse* *italic* *standout*
 					*nocombine* *strikethrough*
+					*overline*
 cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 	attr-list is a comma separated list (without spaces) of the
 	following items (in any order):
@@ -4881,6 +4882,7 @@ cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 		underline
 		undercurl	curly underline
 		strikethrough
+		overline
 		reverse
 		inverse		same as reverse
 		italic

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -291,6 +291,7 @@ numerical highlight ids to the actual attributes.
 	`italic`:	italic text.
 	`bold`:		bold text.
 	`strikethrough`:  struckthrough text.
+	`overline`:	overlined text.
 	`underline`:	underlined text. The line has `special` color.
 	`undercurl`:	undercurled text. The curl has `special` color.
 	`blend`:	Blend level (0-100). Could be used by UIs to support
@@ -450,6 +451,7 @@ is not active. New UIs should implement |ui-linegrid| instead.
 	`italic`:	italic text.
 	`bold`:		bold text.
 	`strikethrough`:  struckthrough text.
+	`overline`:	overlined text.
 	`underline`:	underlined text. The line has `special` color.
 	`undercurl`:	undercurled text. The curl has `special` color.
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -11069,6 +11069,9 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   case 'n':    // name
     p = get_highlight_name_ext(NULL, id - 1, false);
     break;
+  case 'o':    // overline
+    p = highlight_has_attr(id, HL_OVERLINE, modec);
+    break;
   case 'r':    // reverse
     p = highlight_has_attr(id, HL_INVERSE, modec);
     break;

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -759,6 +759,10 @@ Dictionary hlattrs2dict(HlAttrs ae, bool use_rgb)
     PUT(hl, "strikethrough", BOOLEAN_OBJ(true));
   }
 
+  if (mask & HL_OVERLINE) {
+    PUT(hl, "overline", BOOLEAN_OBJ(true));
+  }
+
   if (use_rgb) {
     if (mask & HL_FG_INDEXED) {
       PUT(hl, "fg_indexed", BOOLEAN_OBJ(true));
@@ -817,6 +821,7 @@ HlAttrs dict2hlattrs(Dictionary dict, bool use_rgb, int *link_id, Error *err)
       { "standout", HL_STANDOUT },
       { "underline", HL_UNDERLINE },
       { "undercurl", HL_UNDERCURL },
+      { "overline", HL_OVERLINE },
       { "italic", HL_ITALIC },
       { "reverse", HL_INVERSE },
       { "default", HL_DEFAULT },

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -19,11 +19,12 @@ typedef enum {
   HL_UNDERCURL       = 0x10,
   HL_STANDOUT        = 0x20,
   HL_STRIKETHROUGH   = 0x40,
-  HL_NOCOMBINE       = 0x80,
-  HL_BG_INDEXED    = 0x0100,
-  HL_FG_INDEXED    = 0x0200,
-  HL_DEFAULT       = 0x0400,
-  HL_GLOBAL        = 0x0800,
+  HL_OVERLINE        = 0x80,
+  HL_NOCOMBINE     = 0x0100,
+  HL_BG_INDEXED    = 0x0200,
+  HL_FG_INDEXED    = 0x0400,
+  HL_DEFAULT       = 0x0800,
+  HL_GLOBAL        = 0x1000,
 } HlAttrFlags;
 
 /// Stores a complete highlighting entry, including colors and attributes

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -121,10 +121,10 @@ static int include_link = 0;    // when 2 include "nvim/link" and "clear"
 /// following names, separated by commas (but no spaces!).
 static char *(hl_name_table[]) =
 { "bold", "standout", "underline", "undercurl",
-  "italic", "reverse", "inverse", "strikethrough", "nocombine", "NONE" };
+  "italic", "reverse", "inverse", "strikethrough", "overline", "nocombine", "NONE" };
 static int hl_attr_table[] =
 { HL_BOLD, HL_STANDOUT, HL_UNDERLINE, HL_UNDERCURL, HL_ITALIC, HL_INVERSE,
-  HL_INVERSE, HL_STRIKETHROUGH, HL_NOCOMBINE, 0 };
+  HL_INVERSE, HL_STRIKETHROUGH, HL_OVERLINE, HL_NOCOMBINE, 0 };
 
 static char e_illegal_arg[] = N_("E390: Illegal argument: %s");
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -120,6 +120,7 @@ typedef struct {
     int enable_bracketed_paste, disable_bracketed_paste;
     int enable_lr_margin, disable_lr_margin;
     int enter_strikethrough_mode;
+    int enter_overline_mode;
     int set_rgb_foreground, set_rgb_background;
     int set_cursor_color;
     int reset_cursor_color;
@@ -215,6 +216,7 @@ static void terminfo_start(UI *ui)
   data->unibi_ext.enable_bracketed_paste = -1;
   data->unibi_ext.disable_bracketed_paste = -1;
   data->unibi_ext.enter_strikethrough_mode = -1;
+  data->unibi_ext.enter_overline_mode = -1;
   data->unibi_ext.enable_lr_margin = -1;
   data->unibi_ext.disable_lr_margin = -1;
   data->unibi_ext.enable_focus_reporting = -1;
@@ -550,6 +552,7 @@ static void update_attrs(UI *ui, int attr_id)
   bool reverse = attr & HL_INVERSE;
   bool standout = attr & HL_STANDOUT;
   bool strikethrough = attr & HL_STRIKETHROUGH;
+  bool overline = attr & HL_OVERLINE;
 
   bool underline;
   bool undercurl;
@@ -598,6 +601,9 @@ static void update_attrs(UI *ui, int attr_id)
   }
   if (strikethrough && data->unibi_ext.enter_strikethrough_mode != -1) {
     unibi_out_ext(ui, data->unibi_ext.enter_strikethrough_mode);
+  }
+  if (overline && data->unibi_ext.enter_overline_mode != -1) {
+    unibi_out_ext(ui, data->unibi_ext.enter_overline_mode);
   }
   if (undercurl && data->unibi_ext.set_underline_style != -1) {
     UNIBI_SET_NUM_VAR(data->params[0], 3);
@@ -653,13 +659,13 @@ static void update_attrs(UI *ui, int attr_id)
 
   data->default_attr = fg == -1 && bg == -1
                        && !bold && !italic && !underline && !undercurl && !reverse && !standout
-                       && !strikethrough;
+                       && !strikethrough && !overline;
 
   // Non-BCE terminals can't clear with non-default background color. Some BCE
   // terminals don't support attributes either, so don't rely on it. But assume
   // italic and bold has no effect if there is no text.
   data->can_clear_attr = !reverse && !standout && !underline && !undercurl
-                         && !strikethrough && (data->bce || bg == -1);
+                         && !strikethrough && !overline && (data->bce || bg == -1);
 }
 
 static void final_column_wrap(UI *ui)
@@ -1944,6 +1950,11 @@ static void augment_terminfo(TUIData *data, const char *term, long vte_version, 
   // terminfo describes strikethrough modes as rmxx/smxx with respect
   // to the ECMA-48 strikeout/crossed-out attributes.
   data->unibi_ext.enter_strikethrough_mode = unibi_find_ext_str(ut, "smxx");
+
+  // Tmux describes overline mode as Smol with respect to the ECMA-48 overlined
+  // attribute.
+  // TODO: don't just assume that this is supported
+  data->unibi_ext.enter_overline_mode = (int)unibi_add_ext_str(ut, "Smol", "\x1b[53m");
 
   // Dickey ncurses terminfo does not include the setrgbf and setrgbb
   // capabilities, proposed by Rüdiger Sonderfeld on 2013-10-15.  Adding


### PR DESCRIPTION
Currently the minimum (?) work that's required to support this attribute. Would there be any interest in this?

Supported by konsole, vte, and tmux(https://github.com/tmux/tmux/commit/1ee944a19def82cb62abf6ab92c17eb30df77a41).

Here's how it looks with `:hi StatusLine gui=overline,underline`:
![2022-01-12-14:51:27](https://user-images.githubusercontent.com/4656860/149152913-7250a056-612c-4ef8-9c18-f9ef58547cb5.png)
