### PR TITLE
vim-patch:8.2.4065: computation overflow with large cound for :yank

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1784,8 +1784,11 @@ static char_u *do_one_cmd(char_u **cmdlinep, int flags, cstack_T *cstack, LineGe
         ea.addr_count = 1;
       }
     } else {
-      ea.line1 = ea.line2;
-      ea.line2 += n - 1;
+		ea.line1 = ea.line2;
+		if (ea.line2 >= LONG_MAX - (n - 1))
+			ea.line2 = LONG_MAX;  // avoid overflow
+		else
+			ea.line2 += n - 1;
       ++ea.addr_count;
       // Be vi compatible: no error message for out of range.
       if (ea.line2 > curbuf->b_ml.ml_line_count) {

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -400,3 +400,20 @@ func Test_winsize_cmd()
   call assert_fails('win_getid(1)', 'E475: Invalid argument: _getid(1)')
   " Actually changing the window size would be flaky.
 endfunc
+
+"Test for overflow in case of a large count to :yank
+func Test_address_line_overflow()
+  if v:sizeoflong < 8
+	throw 'Skipped: only works with 64 bit long ints'
+  endif
+  new
+  call setline(1, range(100))
+  call assert_fails('|.44444444444444444444444', 'E1247:')
+  call assert_fails('|.9223372036854775806', 'E1247:')
+
+  $
+  yank 77777777777777777777
+  call assert_equal("99\n", @")
+
+  bwipe!
+endfunc


### PR DESCRIPTION
Problem:    Computation overflow with large cound for :yank.
Solution:   Avoid an overflow.
https://github.com/vim/vim/commit/3cf21b305104e91a28e4ce3a473672b2e88a9469