### PR TITLE
fix(lsp): handle negative activeSignature in signatureHelp

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -842,7 +842,8 @@ function M.convert_signature_help_to_markdown_lines(signature_help, ft, triggers
   local active_hl
   local active_signature = signature_help.activeSignature or 0
   -- If the activeSignature is not inside the valid range, then clip it.
-  if active_signature >= #signature_help.signatures then
+  -- In 3.15 of the protocol, activeSignature was allowed to be negative
+  if active_signature >= #signature_help.signatures or active_signature < 0 then
     active_signature = 0
   end
   local signature = signature_help.signatures[active_signature + 1]

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2333,6 +2333,27 @@ describe('LSP', function()
     end)
   end)
 
+  describe('lsp.util.convert_signature_help_to_markdown_lines', function()
+    it('can handle negative activeSignature', function()
+      local result = exec_lua[[
+        local signature_help = {
+          activeParameter = 0,
+          activeSignature = -1,
+          signatures = {
+            {
+              documentation = "",
+              label = "TestEntity.TestEntity()",
+              parameters = {}
+            },
+          }
+        }
+        return vim.lsp.util.convert_signature_help_to_markdown_lines(signature_help, 'cs', {','})
+      ]]
+      local expected = {'```cs', 'TestEntity.TestEntity()', '```', ''}
+      eq(expected, result)
+    end)
+  end)
+
   describe('lsp.util.get_effective_tabstop', function()
     local function test_tabstop(tabsize, softtabstop)
       exec_lua(string.format([[


### PR DESCRIPTION
omnisharp-roslyn can send negative values:

    {
      activeParameter = 0,
      activeSignature = -1,
      signatures = { {
          documentation = "",
          label = "TestEntity.TestEntity()",
          parameters = {}
        } }
    }

In 3.16 of the specification `activeSignature` is defined as `uinteger`
and therefore negative values shouldn't be allowed, but within 3.15 it
was defined as `number` which makes me think we can be a bit lenient in
this case and handle them.

The expected behavior is quite clear:

    The active signature. If omitted or the value lies outside the
    range of `signatures` the value defaults to zero or is ignored if
    the `SignatureHelp` has no signatures.

Fixes an error:

    util.lua:1685: attempt to get length of local 'lines' (a nil value)
    util.lua:1685: in function 'trim_empty_lines'
    handlers.lua:334: in function 'textDocument/signatureHelp'
