### PR TITLE
vim-patch:8.2.{3933,3973,3978,4013,4032,4048}

### DIFF
--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -44,6 +44,15 @@ func Test_cd_minus()
   cd -
   call assert_equal(path, getcwd())
 
+  " Test for :cd - after a failed :cd
+  " v8.2.1183 is not ported yet
+  " call assert_fails('cd /nonexistent', 'E344:')
+  call assert_fails('cd /nonexistent', 'E472:')
+  call assert_equal(path, getcwd())
+  cd -
+  call assert_equal(path_dotdot, getcwd())
+  cd -
+
   " Test for :cd - without a previous directory
   let lines =<< trim [SCRIPT]
     call assert_fails('cd -', 'E186:')


### PR DESCRIPTION
Problem:    After ":cd" fails ":cd -" is incorrect.
Solution:   Set the previous directory only after successfully changing
            directory. (Richard Doty, closes vim/vim#9419, closes vim/vim#8983)
https://github.com/vim/vim/commit/3d0abad5bf4fe125e219f1b56c4e8200cb900e2a

I skipped whitespace changes to `cursor_*` functions because the related patch is not ported yet, and we should not have problems with whitespace in the first place. Also, Neovim produces a different error code because we haven't ported https://github.com/vim/vim/commit/9b7bf9e98f06ece595fed7a3ff53ecce89797a53 yet. Should I mark patch as partial based on that?

The other patches are ifdef tweaking and language-specific, hence N/A.