### PR TITLE
fix(lsp): strictly enforce passing offset encoding for apply_text_edits

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -184,7 +184,7 @@ function M.formatting_sync(options, timeout_ms)
 
     local result, err = client.request_sync('textDocument/formatting', params, timeout_ms, bufnr)
     if result and result.result then
-      util.apply_text_edits(result.result, bufnr)
+      util.apply_text_edits(result.result, bufnr, client.offset_encoding)
     elseif err then
       vim.notify('vim.lsp.buf.formatting_sync: ' .. err, vim.log.levels.WARN)
     end
@@ -228,7 +228,7 @@ function M.formatting_seq_sync(options, timeout_ms, order)
       local params = util.make_formatting_params(options)
       local result, err = client.request_sync("textDocument/formatting", params, timeout_ms, vim.api.nvim_get_current_buf())
       if result and result.result then
-        util.apply_text_edits(result.result, bufnr)
+        util.apply_text_edits(result.result, bufnr, client.offset_encoding)
       elseif err then
         vim.notify(string.format("vim.lsp.buf.formatting_seq_sync: (%s) %s", client.name, err), vim.log.levels.WARN)
       end


### PR DESCRIPTION
When I try to use `lua vim.lsp.buf.formatting_sync()` I will receive the following error;
`E5108: Error executing lua /usr/local/share/nvim/runtime/lua/vim/lsp/util.lua:366: offset_encoding: expected string, got nil`

reference; https://github.com/neovim/neovim/pull/17049