### PR TITLE
fix(lsp): forward offset_encoding to apply_text_edits

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -184,7 +184,7 @@ function M.formatting_sync(options, timeout_ms)
 
     local result, err = client.request_sync('textDocument/formatting', params, timeout_ms, bufnr)
     if result and result.result then
-      util.apply_text_edits(result.result, bufnr)
+      util.apply_text_edits(result.result, bufnr, client.offset_encoding)
     elseif err then
       vim.notify('vim.lsp.buf.formatting_sync: ' .. err, vim.log.levels.WARN)
     end
@@ -228,7 +228,7 @@ function M.formatting_seq_sync(options, timeout_ms, order)
       local params = util.make_formatting_params(options)
       local result, err = client.request_sync("textDocument/formatting", params, timeout_ms, vim.api.nvim_get_current_buf())
       if result and result.result then
-        util.apply_text_edits(result.result, bufnr)
+        util.apply_text_edits(result.result, bufnr, client.offset_encoding)
       elseif err then
         vim.notify(string.format("vim.lsp.buf.formatting_seq_sync: (%s) %s", client.name, err), vim.log.levels.WARN)
       end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -233,13 +233,15 @@ end
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting
 M['textDocument/rangeFormatting'] = function(_, result, ctx, _)
   if not result then return end
-  util.apply_text_edits(result, ctx.bufnr)
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  util.apply_text_edits(result, ctx.bufnr, client.offset_encoding)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
 M['textDocument/formatting'] = function(_, result, ctx, _)
   if not result then return end
-  util.apply_text_edits(result, ctx.bufnr)
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  util.apply_text_edits(result, ctx.bufnr, client.offset_encoding)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -771,7 +771,7 @@ function M.apply_workspace_edit(workspace_edit, offset_encoding)
 
   for uri, changes in pairs(all_changes) do
     local bufnr = vim.uri_to_bufnr(uri)
-    M.apply_text_edits(changes, bufnr)
+    M.apply_text_edits(changes, bufnr, offset_encoding)
   end
 end
 


### PR DESCRIPTION
Closes #17074

I added stricter handling of offset_encoding, partly in preparation for multi-client offset encoding support and partly to fix some errors where we were *not* forwarding the encoding correctly. There were a few misses that were not covered by tests.