### PR TITLE
feat(api): expose extmark more details

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -115,7 +115,12 @@ static Array extmark_to_array(ExtmarkInfo extmark, bool id, bool add_dict)
     if (decor->hl_id) {
       String name = cstr_to_string((const char *)syn_id2name(decor->hl_id));
       PUT(dict, "hl_group", STRING_OBJ(name));
+      PUT(dict, "hl_eol", BOOLEAN_OBJ(decor->hl_eol));
     }
+    if (decor->hl_mode) {
+      PUT(dict, "hl_mode", STRING_OBJ(cstr_to_string(hl_mode_str[decor->hl_mode])));
+    }
+
     if (kv_size(decor->virt_text)) {
       Array chunks = ARRAY_DICT_INIT;
       for (size_t i = 0; i < decor->virt_text.size; i++) {
@@ -129,6 +134,36 @@ static Array extmark_to_array(ExtmarkInfo extmark, bool id, bool add_dict)
         ADD(chunks, ARRAY_OBJ(chunk));
       }
       PUT(dict, "virt_text", ARRAY_OBJ(chunks));
+      PUT(dict, "virt_text_hide", BOOLEAN_OBJ(decor->virt_text_hide));
+      if (decor->virt_text_pos == kVTWinCol) {
+        PUT(dict, "virt_text_win_col", INTEGER_OBJ(decor->col));
+      }
+      PUT(dict, "virt_text_pos",
+          STRING_OBJ(cstr_to_string(virt_text_pos_str[decor->virt_text_pos])));
+    }
+
+    if (kv_size(decor->virt_lines)) {
+      Array all_chunks = ARRAY_DICT_INIT;
+      bool virt_lines_leftcol = false;
+      for (size_t i = 0; i < decor->virt_lines.size; i++) {
+        Array chunks = ARRAY_DICT_INIT;
+        VirtText *vt = &decor->virt_lines.items[i].line;
+        virt_lines_leftcol = decor->virt_lines.items[i].left_col;
+        for (size_t j = 0; j < vt->size; j++) {
+          Array chunk = ARRAY_DICT_INIT;
+          VirtTextChunk *vtc = &vt->items[j];
+          ADD(chunk, STRING_OBJ(cstr_to_string(vtc->text)));
+          if (vtc->hl_id > 0) {
+            ADD(chunk,
+                STRING_OBJ(cstr_to_string((const char *)syn_id2name(vtc->hl_id))));
+          }
+          ADD(chunks, ARRAY_OBJ(chunk));
+        }
+        ADD(all_chunks, ARRAY_OBJ(chunks));
+      }
+      PUT(dict, "virt_lines", ARRAY_OBJ(all_chunks));
+      PUT(dict, "virt_lines_above", BOOLEAN_OBJ(decor->virt_lines_above));
+      PUT(dict, "virt_lines_leftcol", BOOLEAN_OBJ(virt_lines_leftcol));
     }
 
     if (decor->hl_id || kv_size(decor->virt_text)) {

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -17,12 +17,16 @@ typedef enum {
   kVTRightAlign,
 } VirtTextPos;
 
+EXTERN const char *const virt_text_pos_str[] INIT(= { "eol", "overlay", "win_col", "right_align" });
+
 typedef enum {
   kHlModeUnknown,
   kHlModeReplace,
   kHlModeCombine,
   kHlModeBlend,
 } HlMode;
+
+EXTERN const char *const hl_mode_str[] INIT(= { "", "replace", "combine", "blend" });
 
 typedef kvec_t(VirtTextChunk) VirtText;
 #define VIRTTEXT_EMPTY ((VirtText)KV_INITIAL_VALUE)

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1448,6 +1448,49 @@ describe('API/extmarks', function()
     })
     eq({ {1, 0, 0, { end_col = 0, end_row = 1 }} }, get_extmarks(ns, 0, -1, {details=true}))
   end)
+
+  it('can get details', function()
+    set_extmark(ns, marks[1], 0, 0, {
+      end_col = 0,
+      end_row = 1,
+      priority = 0,
+      hl_eol = true,
+      hl_mode = "blend",
+      hl_group = "String",
+      virt_text = { { "text", "Statement" } },
+      virt_text_pos = "right_align",
+      virt_text_hide = true,
+      virt_lines = { { { "lines", "Statement" } }},
+      virt_lines_above = true,
+      virt_lines_leftcol = true,
+    })
+    set_extmark(ns, marks[2], 0, 0, {
+      priority = 0,
+      virt_text = { { "text", "Statement" } },
+      virt_text_win_col = 1,
+    })
+    eq({0, 0, {
+      end_col = 0,
+      end_row = 1,
+      priority = 0,
+      hl_eol = true,
+      hl_mode = "blend",
+      hl_group = "String",
+      virt_text = { { "text", "Statement" } },
+      virt_text_pos = "right_align",
+      virt_text_hide = true,
+      virt_lines = { { { "lines", "Statement" } }},
+      virt_lines_above = true,
+      virt_lines_leftcol = true,
+    } }, get_extmark_by_id(ns, marks[1], { details = true }))
+    eq({0, 0, {
+      priority = 0,
+      virt_text = { { "text", "Statement" } },
+      virt_text_hide = false,
+      virt_text_pos = "win_col",
+      virt_text_win_col = 1,
+    } }, get_extmark_by_id(ns, marks[2], { details = true }))
+  end)
 end)
 
 describe('Extmarks buffer api with many marks', function()

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -755,12 +755,24 @@ describe('Buffer highlighting', function()
       -- TODO: only a virtual text from the same ns curretly overrides
       -- an existing virtual text. We might add a prioritation system.
       set_virtual_text(id1, 0, s1, {})
-      eq({{1, 0, 0, { priority = 0, virt_text = s1}}}, get_extmarks(id1, {0,0}, {0, -1}, {details=true}))
+      eq({{1, 0, 0, {
+        priority = 0,
+        virt_text = s1,
+        -- other details
+        virt_text_pos = 'eol',
+        virt_text_hide = false,
+      }}}, get_extmarks(id1, {0,0}, {0, -1}, {details=true}))
 
       -- TODO: is this really valid? shouldn't the max be line_count()-1?
       local lastline = line_count()
       set_virtual_text(id1, line_count(), s2, {})
-      eq({{3, lastline, 0, { priority = 0, virt_text = s2}}}, get_extmarks(id1, {lastline,0}, {lastline, -1}, {details=true}))
+      eq({{3, lastline, 0, {
+        priority = 0,
+        virt_text = s2,
+        -- other details
+        virt_text_pos = 'eol',
+        virt_text_hide = false,
+      }}}, get_extmarks(id1, {lastline,0}, {lastline, -1}, {details=true}))
 
       eq({}, get_extmarks(id1, {lastline+9000,0}, {lastline+9000, -1}, {}))
     end)


### PR DESCRIPTION
I Added more field to get_extmark api's detail response.
For example, This enable to get extmark's vert_lines.

```lua
local ns = vim.api.nvim_create_namespace("myplugin")
local bufnr = vim.api.nvim_create_buf(false, true)
vim.api.nvim_buf_set_extmark(bufnr, ns, 0, 0, {
  virt_lines = { { { "text", "Comment" } } },
})
vim.cmd([[buffer ]] .. bufnr)
local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
print(vim.inspect(marks))
```
```
{ { 1, 0, 0, {
      hl_eol = false,
      priority = 4096,
      virt_lines = { { { "text", "Comment" } } },
      virt_lines_above = false,
      virt_lines_leftcol = false
    } } }
```
