### PR TITLE
vim-patch:8.2.4077: not all Libsensors files are recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2285,6 +2285,9 @@ au BufNewFile,BufRead Kconfig.*			call s:StarSetf('kconfig')
 " Lilo: Linux loader
 au BufNewFile,BufRead lilo.conf*		call s:StarSetf('lilo')
 
+" Libsensors
+au BufNewFile,BufRead */etc/sensors.d/[^.]*	call s:StarSetf('sensors')
+
 " Logcheck
 au BufNewFile,BufRead */etc/logcheck/*.d*/*	call s:StarSetf('logcheck')
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1346,6 +1346,7 @@ local pattern = {
   [".*/constant/g"] = function() vim.fn["dist#ft#FTfoam"]() end,
   [".*/0/.*"] = function() vim.fn["dist#ft#FTfoam"]() end,
   [".*/0%.orig/.*"] = function() vim.fn["dist#ft#FTfoam"]() end,
+  [".*/etc/sensors%.d/[^.].*"] = starsetf('sensors'),
   -- END PATTERN
 }
 -- luacheck: pop

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -446,7 +446,7 @@ let s:filename_checks = {
     \ 'sdc': ['file.sdc'],
     \ 'sdl': ['file.sdl', 'file.pr'],
     \ 'sed': ['file.sed'],
-    \ 'sensors': ['/etc/sensors.conf', '/etc/sensors3.conf', 'any/etc/sensors.conf', 'any/etc/sensors3.conf'],
+    \ 'sensors': ['/etc/sensors.conf', '/etc/sensors3.conf', '/etc/sensors.d/file', 'any/etc/sensors.conf', 'any/etc/sensors3.conf', 'any/etc/sensors.d/file'],
     \ 'services': ['/etc/services', 'any/etc/services'],
     \ 'setserial': ['/etc/serial.conf', 'any/etc/serial.conf'],
     \ 'sh': ['.bashrc', 'file.bash', '/usr/share/doc/bash-completion/filter.sh','/etc/udev/cdsymlinks.conf', 'any/etc/udev/cdsymlinks.conf'],


### PR DESCRIPTION
Problem:    Not all Libsensors files are recognized.
Solution:   Add "sensors.d/*" pattern. (Doug Kearns)
https://github.com/vim/vim/commit/8d9e470aa91a93da7d6bda62521aef69a79e956d