### PR TITLE
vim-patch:8.1.2375: no suffucient testing for registers

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3154,11 +3154,12 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
 
   if (ve_flags == VE_ALL && y_type == kMTCharWise) {
     if (gchar_cursor() == TAB) {
-      /* Don't need to insert spaces when "p" on the last position of a
-       * tab or "P" on the first position. */
       int viscol = getviscol();
+      long ts = curbuf->b_p_ts;
+      // Don't need to insert spaces when "p" on the last position of a
+      // tab or "P" on the first position.
       if (dir == FORWARD
-          ? tabstop_padding(viscol, curbuf->b_p_ts, curbuf->b_p_vts_array) != 1
+          ? tabstop_padding(viscol, ts, curbuf->b_p_vts_array) != 1
           : curwin->w_cursor.coladd > 0) {
         coladvance_force(viscol);
       } else {

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -81,6 +81,48 @@ func Test_edit_change()
   normal Cx
   call assert_equal('x', getline(1))
   bwipe!
+  set virtualedit=
+endfunc
+
+" Test for pasting before and after a tab character
+func Test_paste_in_tab()
+  new
+  let @" = 'xyz'
+  set virtualedit=all
+  call append(0, "a\tb")
+  call cursor(1, 2, 6)
+  normal p
+  call assert_equal("a\txyzb", getline(1))
+  call setline(1, "a\tb")
+  call cursor(1, 2)
+  normal P
+  call assert_equal("axyz\tb", getline(1))
+
+  " Test for virtual block paste
+  call setreg('"', 'xyz', 'b')
+  call setline(1, "a\tb")
+  call cursor(1, 2, 6)
+  normal p
+  call assert_equal("a\txyzb", getline(1))
+  call setline(1, "a\tb")
+  call cursor(1, 2, 6)
+  normal P
+  call assert_equal("a      xyz b", getline(1))
+
+  " Test for virtual block paste with gp and gP
+  call setline(1, "a\tb")
+  call cursor(1, 2, 6)
+  normal gp
+  call assert_equal("a\txyzb", getline(1))
+  call assert_equal([0, 1, 6, 0, 12], getcurpos())
+  call setline(1, "a\tb")
+  call cursor(1, 2, 6)
+  normal gP
+  call assert_equal("a      xyz b", getline(1))
+  call assert_equal([0, 1, 12, 0 ,12], getcurpos())
+
+  bwipe!
+  set virtualedit=
 endfunc
 
 " Insert "keyword keyw", ESC, C CTRL-N, shows "keyword ykeyword".

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -433,6 +433,19 @@ func Test_Visual_Block()
   close!
 endfunc
 
+" Test for 'p'ut in visual block mode
+func Test_visual_block_put()
+  enew
+
+  call append(0, ['One', 'Two', 'Three'])
+  normal gg
+  yank
+  call feedkeys("jl\<C-V>ljp", 'xt')
+  call assert_equal(['One', 'T', 'Tee', 'One', ''], getline(1, '$'))
+
+  enew!
+endfunc
+
 func Test_visual_put_in_block()
   new
   call setline(1, ['xxxx', 'y∞yy', 'zzzz'])


### PR DESCRIPTION
#### vim-patch:8.1.2375: no suffucient testing for registers

Problem:    No suffucient testing for registers.
Solution:   Add more test cases. (Yegappan Lakshmanan, closes vim/vim#5296)
            Fix that "p" on last virtual column of tab inserts spaces.
https://github.com/vim/vim/commit/6f1f0ca3edf395102ff3109c998d81300c8be3c9

This patch doesn't actually change any behavior in Nvim, because Nvim always has vartabs feature.

I modified a line in the test because of #6137.