### PR TITLE
fix(lsp): always split text edits on \r, \r\n, and \n

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -422,6 +422,9 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
   local is_cursor_fixed = false
   local has_eol_text_edit = false
   for _, text_edit in ipairs(text_edits) do
+    -- Normalize line ending
+    text_edit.newText, _ = string.gsub(text_edit.newText, '\r\n?', '\n')
+
     -- Convert from LSP style ranges to Neovim style ranges.
     local e = {
       start_row = text_edit.range.start.line,


### PR DESCRIPTION
Closes: https://github.com/neovim/neovim/issues/17053

Servers can return a mix of line endings per the language server
protocol. See:

https://microsoft.github.io/language-server-protocol/specification.html#textDocuments

All should be equally treated as line endings.