### PR TITLE
fix(filetype): expand tildes in filetype patterns

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1398,7 +1398,7 @@ local pattern_sorted = sort_by_priority(pattern)
 
 ---@private
 local function normalize_path(path)
-  return (path:gsub("\\", "/"))
+  return (path:gsub("\\", "/"):gsub("^~", vim.env.HOME))
 end
 
 --- Add new filetype mappings.

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -72,10 +72,10 @@ describe('vim.filetype', function()
       local root = ...
       vim.filetype.add({
         pattern = {
-          [root .. '/blog/.*%.txt'] = 'markdown',
+          ['~/blog/.*%.txt'] = 'markdown',
         }
       })
-      vim.filetype.match(root .. '/blog/why_neovim_is_awesome.txt')
+      vim.filetype.match('~/blog/why_neovim_is_awesome.txt')
       return vim.bo.filetype
     ]], root))
   end)


### PR DESCRIPTION
This allows patterns like

    ["~/.config/foo"] = "fooscript"

to work.
