### PR TITLE
Store temporary directory beneath $XDG_RUNTIME_DIR if present

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -586,7 +586,7 @@ all files in it are deleted.  When Vim has the setuid bit set this may cause
 problems, the temp file is owned by the setuid user but the filter command
 probably runs as the original user.
 Directory for temporary files is created in the first suitable directory of:
-	Unix:    $TMPDIR, /tmp, current-dir, $HOME.
+	Unix:    $XDG_RUNTIME_DIR, $TMPDIR, /tmp, current-dir, $HOME.
 	Windows: $TMPDIR, $TMP, $TEMP, $USERPROFILE, current-dir.
 
 

--- a/src/nvim/os/unix_defs.h
+++ b/src/nvim/os/unix_defs.h
@@ -7,7 +7,7 @@
 // POSIX.1-2008 says that NAME_MAX should be in here
 #include <limits.h>
 
-#define TEMP_DIR_NAMES { "$TMPDIR", "/tmp", ".", "~" }
+#define TEMP_DIR_NAMES { "$XDG_RUNTIME_DIR", "$TMPDIR", "/tmp", ".", "~" }
 #define TEMP_FILE_PATH_MAXLEN 256
 
 #define HAVE_ACL (HAVE_POSIX_ACL || HAVE_SOLARIS_ACL)


### PR DESCRIPTION
Hi,

I got curious how difficult it would be to move the neovim temporary files beneath `$XDG_RUNTIME_DIR` and it turned out to be quite simple.  At least that's what it looks like - please let me know if I missed anything.

The [XDG Base Directory Specification] suggests to store "runtime files" below `$XDG_RUNTIME_DIR` when this environment variable is set. Currently, neovim defaults to using a directory below `$TMPDIR` or `/tmp`. This change makes the `XDG_RUNTIME_DIR` the preferred place for the temporary directory, but keeps fallback to the other locations when this environment variable is not set.

I see this topic was brought up before in #3517.  I think this PR would resolve that issue, but I have not dug through the entire history of it to be certain...

[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html