### PR TITLE
vim-patch:8.2.{3227,3280,4094}: global-local 'virtualedit'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6782,12 +6782,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 					    *'virtualedit'* *'ve'*
 'virtualedit' 've'	string	(default "")
-			global
+			global or local to buffer |global-local|
 	A comma separated list of these words:
 	    block	Allow virtual editing in Visual block mode.
 	    insert	Allow virtual editing in Insert mode.
 	    all		Allow virtual editing in all modes.
 	    onemore	Allow the cursor to move just past the end of the line
+	    none	When used as the local value, do not allow virtual
+			editing even when the global value is set.  When used
+			as the global value, "none" is the same as "".
+	    NONE	Alternative spelling of "none".
 
 	Virtual editing means that the cursor can be positioned where there is
 	no actual character.  This can be halfway into a tab or beyond the end

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6782,7 +6782,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 					    *'virtualedit'* *'ve'*
 'virtualedit' 've'	string	(default "")
-			global or local to buffer |global-local|
+			global or local to window |global-local|
 	A comma separated list of these words:
 	    block	Allow virtual editing in Visual block mode.
 	    insert	Allow virtual editing in Insert mode.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1941,6 +1941,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_lw);
   clear_string_option(&buf->b_p_bkc);
   clear_string_option(&buf->b_p_menc);
+  clear_string_option(&buf->b_p_ve);
 }
 
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1941,7 +1941,6 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_lw);
   clear_string_option(&buf->b_p_bkc);
   clear_string_option(&buf->b_p_menc);
-  clear_string_option(&buf->b_p_ve);
 }
 
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -204,6 +204,10 @@ typedef struct {
 #define w_p_nu w_onebuf_opt.wo_nu       // 'number'
   int wo_rnu;
 #define w_p_rnu w_onebuf_opt.wo_rnu     // 'relativenumber'
+  char_u *wo_ve;
+#define w_p_ve w_onebuf_opt.wo_ve       // 'virtualedit'
+  unsigned wo_ve_flags;
+#define w_ve_flags w_onebuf_opt.wo_ve_flags  // flags for 'virtualedit'
   long wo_nuw;
 #define w_p_nuw w_onebuf_opt.wo_nuw    // 'numberwidth'
   int wo_wfh;
@@ -772,8 +776,6 @@ struct file_buffer {
   long b_p_ul;                  ///< 'undolevels' local value
   int b_p_udf;                  ///< 'undofile'
   char_u *b_p_lw;               ///< 'lispwords' local value
-  char_u *b_p_ve;               ///< 'virtualedit' local value
-  unsigned b_ve_flags;          ///< flags for 'virtualedit'
 
   // end of buffer options
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -772,6 +772,8 @@ struct file_buffer {
   long b_p_ul;                  ///< 'undolevels' local value
   int b_p_udf;                  ///< 'undofile'
   char_u *b_p_lw;               ///< 'lispwords' local value
+  char_u *b_p_ve;               ///< 'virtualedit' local value
+  unsigned b_ve_flags;          ///< flags for 'virtualedit'
 
   // end of buffer options
 

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -789,7 +789,7 @@ int del_bytes(colnr_T count, bool fixpos_arg, bool use_delcombine)
     // fixpos is true, we don't want to end up positioned at the NUL,
     // unless "restart_edit" is set or 'virtualedit' contains "onemore".
     if (col > 0 && fixpos && restart_edit == 0
-        && (ve_flags & VE_ONEMORE) == 0) {
+        && (get_ve_flags() & VE_ONEMORE) == 0) {
       curwin->w_cursor.col--;
       curwin->w_cursor.coladd = 0;
       curwin->w_cursor.col -= utf_head_off(oldp, oldp + curwin->w_cursor.col);

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -15,6 +15,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
+#include "nvim/option.h"
 #include "nvim/plines.h"
 #include "nvim/screen.h"
 #include "nvim/state.h"
@@ -110,7 +111,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
              || (State & TERM_FOCUS)
              || restart_edit != NUL
              || (VIsual_active && *p_sel != 'o')
-             || ((ve_flags & VE_ONEMORE) && wcol < MAXCOL);
+             || ((get_ve_flags() & VE_ONEMORE) && wcol < MAXCOL);
   line = ml_get_buf(curbuf, pos->lnum, false);
 
   if (wcol >= MAXCOL) {
@@ -366,6 +367,7 @@ void check_cursor_col_win(win_T *win)
   colnr_T len;
   colnr_T oldcol = win->w_cursor.col;
   colnr_T oldcoladd = win->w_cursor.col + win->w_cursor.coladd;
+  unsigned int cur_ve_flags = get_ve_flags();
 
   len = (colnr_T)STRLEN(ml_get_buf(win->w_buffer, win->w_cursor.lnum, false));
   if (len == 0) {
@@ -377,7 +379,7 @@ void check_cursor_col_win(win_T *win)
      * - 'virtualedit' is set */
     if ((State & INSERT) || restart_edit
         || (VIsual_active && *p_sel != 'o')
-        || (ve_flags & VE_ONEMORE)
+        || (cur_ve_flags & VE_ONEMORE)
         || virtual_active()) {
       win->w_cursor.col = len;
     } else {
@@ -394,7 +396,7 @@ void check_cursor_col_win(win_T *win)
   // line.
   if (oldcol == MAXCOL) {
     win->w_cursor.coladd = 0;
-  } else if (ve_flags == VE_ALL) {
+  } else if (cur_ve_flags == VE_ALL) {
     if (oldcoladd > win->w_cursor.col) {
       win->w_cursor.coladd = oldcoladd - win->w_cursor.col;
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -909,7 +909,7 @@ static int insert_handle_key(InsertState *s)
     ins_ctrl_o();
 
     // don't move the cursor left when 'virtualedit' has "onemore".
-    if (ve_flags & VE_ONEMORE) {
+    if (get_ve_flags() & VE_ONEMORE) {
       ins_at_eol = false;
       s->nomove = true;
     }
@@ -6905,8 +6905,7 @@ int oneright(void)
 
   // move "l" bytes right, but don't end up on the NUL, unless 'virtualedit'
   // contains "onemore".
-  if (ptr[l] == NUL
-      && (ve_flags & VE_ONEMORE) == 0) {
+  if (ptr[l] == NUL && (get_ve_flags() & VE_ONEMORE) == 0) {
     return FAIL;
   }
   curwin->w_cursor.col += l;
@@ -8028,7 +8027,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
               && !VIsual_active
               ))
       && !revins_on) {
-    if (curwin->w_cursor.coladd > 0 || ve_flags == VE_ALL) {
+    if (curwin->w_cursor.coladd > 0 || get_ve_flags() == VE_ALL) {
       oneleft();
       if (restart_edit != NUL) {
         curwin->w_cursor.coladd++;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6046,7 +6046,7 @@ static void n_start_visual_mode(int c)
   // Corner case: the 0 position in a tab may change when going into
   // virtualedit.  Recalculate curwin->w_cursor to avoid bad highlighting.
   //
-  if (c == Ctrl_V && (ve_flags & VE_BLOCK) && gchar_cursor() == TAB) {
+  if (c == Ctrl_V && (get_ve_flags() & VE_BLOCK) && gchar_cursor() == TAB) {
     validate_virtcol();
     coladvance(curwin->w_virtcol);
   }
@@ -6951,7 +6951,7 @@ static void adjust_cursor(oparg_T *oap)
   if (curwin->w_cursor.col > 0 && gchar_cursor() == NUL
       && (!VIsual_active || *p_sel == 'o')
       && !virtual_active()
-      && (ve_flags & VE_ONEMORE) == 0) {
+      && (get_ve_flags() & VE_ONEMORE) == 0) {
     curwin->w_cursor.col--;
     // prevent cursor from moving on the trail byte
     mb_adjust_cursor();
@@ -7157,7 +7157,7 @@ static void nv_esc(cmdarg_T *cap)
 void set_cursor_for_append_to_line(void)
 {
   curwin->w_set_curswant = true;
-  if (ve_flags == VE_ALL) {
+  if (get_ve_flags() == VE_ALL) {
     const int save_State = State;
 
     // Pretend Insert mode here to allow the cursor on the

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2197,21 +2197,21 @@ void op_insert(oparg_T *oap, long count1)
     // already disabled, but still need it when calling
     // coladvance_force().
     // coladvance_force() uses get_ve_flags() to get the 'virtualedit'
-    // state for the current buffer.  To override that state, we need to
-    // set the buffer-local value of ve_flags rather than the global value.
+    // state for the current window.  To override that state, we need to
+    // set the window-local value of ve_flags rather than the global value.
     if (curwin->w_cursor.coladd > 0) {
-      unsigned old_ve_flags = curbuf->b_ve_flags;
+      unsigned old_ve_flags = curwin->w_ve_flags;
 
       if (u_save_cursor() == FAIL) {
         return;
       }
-      curbuf->b_ve_flags = VE_ALL;
+      curwin->w_ve_flags = VE_ALL;
       coladvance_force(oap->op_type == OP_APPEND
           ? oap->end_vcol + 1 : getviscol());
       if (oap->op_type == OP_APPEND) {
         --curwin->w_cursor.col;
       }
-      curbuf->b_ve_flags = old_ve_flags;
+      curwin->w_ve_flags = old_ve_flags;
     }
     // Get the info about the block before entering the text
     block_prep(oap, &bd, oap->start.lnum, true);

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -705,12 +705,14 @@ EXTERN int p_vb;                ///< 'visualbell'
 EXTERN char_u *p_ve;            ///< 'virtualedit'
 EXTERN unsigned ve_flags;
 #ifdef IN_OPTION_C
-static char *(p_ve_values[]) = { "block", "insert", "all", "onemore", NULL };
+static char *(p_ve_values[]) = { "block", "insert", "all", "onemore", "none", "NONE", NULL };
 #endif
-#define VE_BLOCK       5       // includes "all"
-#define VE_INSERT      6       // includes "all"
-#define VE_ALL         4
-#define VE_ONEMORE     8
+#define VE_BLOCK       5U      // includes "all"
+#define VE_INSERT      6U      // includes "all"
+#define VE_ALL         4U
+#define VE_ONEMORE     8U
+#define VE_NONE        16U
+#define VE_NONEU       32U     // Upper-case NONE
 EXTERN long p_verbose;          // 'verbose'
 #ifdef IN_OPTION_C
 char_u *p_vfile = (char_u *)"";   // used before options are initialized
@@ -839,6 +841,7 @@ enum {
   BV_WM,
   BV_VSTS,
   BV_VTS,
+  BV_VE,
   BV_COUNT,  // must be the last one
 };
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -841,7 +841,6 @@ enum {
   BV_WM,
   BV_VSTS,
   BV_VTS,
-  BV_VE,
   BV_COUNT,  // must be the last one
 };
 
@@ -872,6 +871,7 @@ enum {
   WV_LBR,
   WV_NU,
   WV_RNU,
+  WV_VE,
   WV_NUW,
   WV_PVW,
   WV_RL,

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -711,8 +711,8 @@ static char *(p_ve_values[]) = { "block", "insert", "all", "onemore", "none", "N
 #define VE_INSERT      6U      // includes "all"
 #define VE_ALL         4U
 #define VE_ONEMORE     8U
-#define VE_NONE        16U
-#define VE_NONEU       32U     // Upper-case NONE
+#define VE_NONE        16U     // "none"
+#define VE_NONEU       32U     // "NONE"
 EXTERN long p_verbose;          // 'verbose'
 #ifdef IN_OPTION_C
 char_u *p_vfile = (char_u *)"";   // used before options are initialized

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2736,7 +2736,7 @@ return {
     {
       full_name='virtualedit', abbreviation='ve',
       short_desc=N_("when to use virtual editing"),
-      type='string', list='onecomma', scope={'global'},
+      type='string', list='onecomma', scope={'global', 'buffer'},
       deny_duplicates=true,
       redraw={'curswant'},
       varname='p_ve',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2736,7 +2736,7 @@ return {
     {
       full_name='virtualedit', abbreviation='ve',
       short_desc=N_("when to use virtual editing"),
-      type='string', list='onecomma', scope={'global', 'buffer'},
+      type='string', list='onecomma', scope={'global', 'window'},
       deny_duplicates=true,
       redraw={'curswant'},
       varname='p_ve',

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1215,14 +1215,14 @@ static void win_update(win_T *wp, Providers *providers)
        */
       if (VIsual_mode == Ctrl_V) {
         colnr_T fromc, toc;
-        unsigned int save_ve_flags = curbuf->b_ve_flags;
+        unsigned int save_ve_flags = curwin->w_ve_flags;
 
         if (curwin->w_p_lbr) {
-          curbuf->b_ve_flags = VE_ALL;
+          curwin->w_ve_flags = VE_ALL;
         }
 
         getvcols(wp, &VIsual, &curwin->w_cursor, &fromc, &toc);
-        curbuf->b_ve_flags = save_ve_flags;
+        curwin->w_ve_flags = save_ve_flags;
         toc++;
         // Highlight to the end of the line, unless 'virtualedit' has
         // "block".

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1215,18 +1215,18 @@ static void win_update(win_T *wp, Providers *providers)
        */
       if (VIsual_mode == Ctrl_V) {
         colnr_T fromc, toc;
-        int save_ve_flags = ve_flags;
+        unsigned int save_ve_flags = curbuf->b_ve_flags;
 
         if (curwin->w_p_lbr) {
-          ve_flags = VE_ALL;
+          curbuf->b_ve_flags = VE_ALL;
         }
 
         getvcols(wp, &VIsual, &curwin->w_cursor, &fromc, &toc);
-        ve_flags = save_ve_flags;
+        curbuf->b_ve_flags = save_ve_flags;
         toc++;
         // Highlight to the end of the line, unless 'virtualedit' has
         // "block".
-        if (curwin->w_curswant == MAXCOL && !(ve_flags & VE_BLOCK)) {
+        if (curwin->w_curswant == MAXCOL && !(get_ve_flags() & VE_BLOCK)) {
           toc = MAXCOL;
         }
 

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -12,6 +12,7 @@
 #include "nvim/lib/kvec.h"
 #include "nvim/log.h"
 #include "nvim/main.h"
+#include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/os/input.h"
 #include "nvim/state.h"
@@ -107,15 +108,17 @@ void state_handle_k_event(void)
 /// Return true if in the current mode we need to use virtual.
 bool virtual_active(void)
 {
+  unsigned int cur_ve_flags = get_ve_flags();
+
   // While an operator is being executed we return "virtual_op", because
   // VIsual_active has already been reset, thus we can't check for "block"
   // being used.
   if (virtual_op != kNone) {
     return virtual_op;
   }
-  return ve_flags == VE_ALL
-         || ((ve_flags & VE_BLOCK) && VIsual_active && VIsual_mode == Ctrl_V)
-         || ((ve_flags & VE_INSERT) && (State & INSERT));
+  return cur_ve_flags == VE_ALL
+         || ((cur_ve_flags & VE_BLOCK) && VIsual_active && VIsual_mode == Ctrl_V)
+         || ((cur_ve_flags & VE_INSERT) && (State & INSERT));
 }
 
 /// VISUAL, SELECTMODE and OP_PENDING State are never set, they are equal to

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -263,7 +263,7 @@ endfunc
 let s:result_ve_on  = 'a      x'
 let s:result_ve_off = 'x'
 
-" Utility function for Test_global_local()
+" Utility function for Test_global_local_virtualedit()
 func s:TryVirtualeditReplace()
   call setline(1, 'a')
   normal gg7l
@@ -271,7 +271,7 @@ func s:TryVirtualeditReplace()
 endfunc
 
 " Test for :set and :setlocal
-func Test_global_local()
+func Test_global_local_virtualedit()
   new
 
   " Verify that 'virtualedit' is initialized to empty, can be set globally to
@@ -291,8 +291,8 @@ func Test_global_local()
   call s:TryVirtualeditReplace()
   call assert_equal(s:result_ve_off, getline(1))
 
-  " Verify that :set affects multiple buffers
-  new
+  " Verify that :set affects multiple windows.
+  split
   set ve=all
   call s:TryVirtualeditReplace()
   call assert_equal(s:result_ve_on, getline(1))
@@ -305,17 +305,15 @@ func Test_global_local()
   call assert_equal(s:result_ve_off, getline(1))
   bwipe!
 
-  " Verify that :setlocal affects only the current buffer
-  setlocal ve=all
+  " Verify that :setlocal affects only the current window.
   new
-  call s:TryVirtualeditReplace()
-  call assert_equal(s:result_ve_off, getline(1))
+  split
   setlocal ve=all
-  wincmd p
-  setlocal ve=
-  wincmd p
   call s:TryVirtualeditReplace()
   call assert_equal(s:result_ve_on, getline(1))
+  wincmd p
+  call s:TryVirtualeditReplace()
+  call assert_equal(s:result_ve_off, getline(1))
   bwipe!
   call s:TryVirtualeditReplace()
   call assert_equal(s:result_ve_off, getline(1))
@@ -372,6 +370,23 @@ func Test_global_local()
   call s:TryVirtualeditReplace()
   call assert_equal(s:result_ve_off, getline(1))
 
+  bwipe!
+
+  " Verify that the 'virtualedit' state is copied to new windows.
+  new
+  call s:TryVirtualeditReplace()
+  call assert_equal(s:result_ve_off, getline(1))
+  split
+  setlocal ve=all
+  call s:TryVirtualeditReplace()
+  call assert_equal(s:result_ve_on, getline(1))
+  split
+  call s:TryVirtualeditReplace()
+  call assert_equal(s:result_ve_on, getline(1))
+  setlocal ve=
+  split
+  call s:TryVirtualeditReplace()
+  call assert_equal(s:result_ve_off, getline(1))
   bwipe!
 
   setlocal virtualedit&


### PR DESCRIPTION
#### vim-patch:8.2.3227: 'virtualedit' can only be set globally

Problem:    'virtualedit' can only be set globally.
Solution:   Make 'virtualedit' global-local. (Gary Johnson, closes vim/vim#8638)
https://github.com/vim/vim/commit/53ba05b09075f14227f9be831a22ed16f7cc26b2

I changed some macros to unsigned integer literals to avoid compiler warnings.

#### vim-patch:8.2.3280: 'virtualedit' local to buffer is not the best solution

Problem:    'virtualedit' local to buffer is not the best solution.
Solution:   Make it window-local. (Gary Johnson, closes vim/vim#8685)
https://github.com/vim/vim/commit/51ad850f5fbafa7aa3f60affa74ec9c9f992c6cc

#### vim-patch:8.2.4094: 'virtualedit' is window-local but using buffer-local enum

Problem:    'virtualedit' is window-local but using buffer-local enum.
Solution:   Use window-local enum. (closes vim/vim#9529)
https://github.com/vim/vim/commit/e1833bfd01c100896d2a01f281762c285192d84b