### PR TITLE
[RFC] select mode should not overwrite register

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5090,6 +5090,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |Select-mode|.
 	The 'selectmode' option is set by the |:behave| command.
 
+						*'selectregister'* *'slr'*
+'selectregister' 'slr'	string	(default "")
+			global
+	This is the register name when |Select-mode| text replace.
+	If it is empty string, unnamed register is used.
+	If it is invalid register name, it is ignored.
+
 						*'sessionoptions'* *'ssop'*
 'sessionoptions' 'ssop'	string	(default: "blank,buffers,curdir,folds,
 					       help,tabpages,winsize"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1478,12 +1478,11 @@ int op_delete(oparg_T *oap)
     return OK;
   }
 
-  /*
-   * Do a yank of whatever we're about to delete.
-   * If a yank register was specified, put the deleted text into that
-   * register.  For the black hole register '_' don't yank anything.
-   */
-  if (oap->regname != '_') {
+  // Do a yank of whatever we're about to delete.
+  // If a yank register was specified, put the deleted text into that
+  // register.
+  // Note: For the black hole register or select mode '_' don't yank anything.
+  if (oap->regname != '_' && !VIsual_select) {
     yankreg_T *reg = NULL;
     int did_yank = false;
     if (oap->regname != 0) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1435,6 +1435,15 @@ int op_delete(oparg_T *oap)
     return FAIL;
   }
 
+  if (VIsual_select && oap->is_VIsual) {
+      // Check 'selectregister'
+      int reg;
+      reg = *p_slr == '"' ? 0 : *p_slr;
+      if (reg == 0 || valid_yank_reg(reg, true)) {
+          oap->regname = reg;
+      }
+  }
+
   mb_adjust_opend(oap);
 
   /*
@@ -1478,11 +1487,12 @@ int op_delete(oparg_T *oap)
     return OK;
   }
 
-  // Do a yank of whatever we're about to delete.
-  // If a yank register was specified, put the deleted text into that
-  // register.
-  // Note: For the black hole register or select mode '_' don't yank anything.
-  if (oap->regname != '_' && !(VIsual_select && oap->is_VIsual)) {
+  /*
+   * Do a yank of whatever we're about to delete.
+   * If a yank register was specified, put the deleted text into that
+   * register.  For the black hole register '_' don't yank anything.
+   */
+  if (oap->regname != '_') {
     yankreg_T *reg = NULL;
     int did_yank = false;
     if (oap->regname != 0) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1482,7 +1482,7 @@ int op_delete(oparg_T *oap)
   // If a yank register was specified, put the deleted text into that
   // register.
   // Note: For the black hole register or select mode '_' don't yank anything.
-  if (oap->regname != '_' && !VIsual_select) {
+  if (oap->regname != '_' && !(VIsual_select && oap->is_VIsual)) {
     yankreg_T *reg = NULL;
     int did_yank = false;
     if (oap->regname != 0) {

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -575,6 +575,7 @@ EXTERN char_u *p_sections;    // 'sections'
 EXTERN int p_secure;            // 'secure'
 EXTERN char_u *p_sel;         // 'selection'
 EXTERN char_u *p_slm;         // 'selectmode'
+EXTERN char_u *p_slr;         // 'selectregister'
 EXTERN char_u *p_ssop;        // 'sessionoptions'
 EXTERN unsigned ssop_flags;
 #ifdef IN_OPTION_C

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2041,6 +2041,13 @@ return {
       defaults={if_true=""}
     },
     {
+      full_name='selectregister', abbreviation='slr',
+      short_desc=N_("overwrite register when Select mode"),
+      type='string', scope={'global'},
+      varname='p_slr',
+      defaults={if_true=""}
+    },
+    {
       full_name='sessionoptions', abbreviation='ssop',
       short_desc=N_("options for |:mksession|"),
       type='string', list='onecomma', scope={'global'},

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -123,8 +123,10 @@ func Test_normal02_selectmode()
   call assert_equal('y51', getline('.'))
   call setline(1, range(1,100))
   50
+  let save_register = getreg('"')
   exe ":norm! V9jo\<c-g>y"
   call assert_equal('y60', getline('.'))
+  call assert_equal(save_register, getreg('"'))
   " clean up
   bw!
 endfunc

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2759,14 +2759,52 @@ func Test_normal_count_after_operator()
   bw!
 endfunc
 
-" Test for selectmode register break
+" Test for selectmode register overwrite
 func Test_selectmode_register()
+  " Default behavior: use unnamed register
   new
   call setline(1, range(1,100))
-  50
+  let save_register = getreg('"')
+  exe ":norm! v\<c-g>a"
+  call assert_equal('1', getreg('"'))
+
+  " Disable overwrite registers
+  new
+  let &selectregister = '_'
+  call setline(1, range(1,100))
   let save_register = getreg('"')
   exe ":norm! v\<c-g>a"
   call assert_equal(save_register, getreg('"'))
+  set selectregister&
+
+  " Overwrite a register instead
+  new
+  let &selectregister = 'a'
+  call setline(1, range(1,100))
+  let save_register = getreg('"')
+  exe ":norm! v\<c-g>a"
+  call assert_equal('1', getreg('a'))
+  call assert_equal(save_register, getreg('"'))
+  set selectregister&
+
+  " Invalid register
+  new
+  let &selectregister = 'foo'
+  call setline(1, range(1,100))
+  let save_register = getreg('"')
+  exe ":norm! v\<c-g>a"
+  call assert_equal('1', getreg('"'))
+  set selectregister&
+
+  " Use unnamed register
+  new
+  let &selectregister = '"'
+  call setline(1, range(1,100))
+  let save_register = getreg('"')
+  exe ":norm! v\<c-g>a"
+  call assert_equal('1', getreg('"'))
+  set selectregister&
+
   bw!
 endfunc
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -123,10 +123,8 @@ func Test_normal02_selectmode()
   call assert_equal('y51', getline('.'))
   call setline(1, range(1,100))
   50
-  let save_register = getreg('"')
   exe ":norm! V9jo\<c-g>y"
   call assert_equal('y60', getline('.'))
-  call assert_equal(save_register, getreg('"'))
   " clean up
   bw!
 endfunc
@@ -2758,6 +2756,17 @@ func Test_normal_count_after_operator()
   call assert_equal('".!', @:)
   call feedkeys("gg!9!\<C-B>\"\<CR>", 'xt')
   call assert_equal('".,$!', @:)
+  bw!
+endfunc
+
+" Test for selectmode register break
+func Test_selectmode_register()
+  new
+  call setline(1, range(1,100))
+  50
+  let save_register = getreg('"')
+  exe ":norm! v\<c-g>a"
+  call assert_equal(save_register, getreg('"'))
   bw!
 endfunc
 


### PR DESCRIPTION
Fix https://github.com/Shougo/neocomplete.vim/issues/618

Current select mode implementation, overwrite registers because:

```c
  // In Select mode, typed text replaces the selection.
  if (VIsual_active && VIsual_select && (vim_isprintc(s->c)
                                         || s->c == NL || s->c == CAR || s->c == K_KENTER)) {
    // Fake a "c"hange command.  When "restart_edit" is set (e.g., because
    // 'insertmode' is set) fake a "d"elete command, Insert mode will
    // restart automatically.
    // Insert the typed character in the typeahead buffer, so that it can
    // be mapped in Insert mode.  Required for ":lmap" to work.
    ins_char_typebuf(s->c);
    if (restart_edit != 0) {
      s->c = 'd';
    } else {
      s->c = 'c';
    }
    msg_nowait = true;          // don't delay going to insert mode
    s->old_mapped_len = 0;      // do go to Insert mode
  }
```

I think the behavior is not intentional for users.  So I have fixed it.