### PR TITLE
Change api for Query:iter_matches()

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -429,10 +429,10 @@ add_predicate({name}, {handler}, {force})                    *add_predicate()*
                                be (match, pattern, bufnr, predicate)
 
 get_node_text({node}, {source})                              *get_node_text()*
-                Gets the text corresponding to a given node
+                Gets the text corresponding to a given node or a list of nodes
 
                 Parameters: ~
-                    {node}    the node
+                    {node}    the node or list of nodes
                     {source}  The buffer or string from which the node is
                               extracted
 
@@ -541,13 +541,14 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop})
 >
 
     for pattern, match, metadata in cquery:iter_matches(tree:root(), bufnr, first, last) do
-      for id, node in pairs(match) do
+      for id, nodes in pairs(match) do
         local name = query.captures[id]
-        -- `node` was captured by the `name` capture in the match
+        for _, node in ipairs(nodes) do
+          -- `node` was captured by the `name` capture in the match
 
-        local node_data = metadata[id] -- Node level metadata
-
-        ... use the info here ...
+          local node_data = metadata[id] -- Node level metadata
+          ... use the info here ...
+        end
       end
     end
 <

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -338,10 +338,12 @@ function LanguageTree:_get_injections()
 
         -- Allow for captured nodes to be used
         if type(content) == 'number' then
-          content = { match[content]:range() }
+          for _, node in ipairs(match[content]) do
+            ranges[#ranges + 1] = { node:range() }
+          end
         end
 
-        if type(content) == 'table' and #content >= 4 then
+        if type(content) == 'table' then
           vim.list_extend(ranges, content)
         end
       end
@@ -353,25 +355,27 @@ function LanguageTree:_get_injections()
       -- You can specify the content and language together
       -- using a tag with the language, for example
       -- @javascript
-      for id, node in pairs(match) do
-        local name = self._injection_query.captures[id]
+      for id, nodes in pairs(match) do
+        for _, node in ipairs(nodes) do
+          local name = self._injection_query.captures[id]
 
-        -- Lang should override any other language tag
-        if name == 'language' and not lang then
-          lang = query.get_node_text(node, self._source)
-        elseif name == 'combined' then
-          combined = true
-        elseif name == 'content' and #ranges == 0 then
-          table.insert(ranges, get_node_range(node, id, metadata))
+          -- Lang should override any other language tag
+          if name == "language" and not lang then
+            lang = query.get_node_text(node, self._source)
+          elseif name == "combined" then
+            combined = true
+          elseif name == "content" and #ranges == 0 then
+            table.insert(ranges, get_node_range(node, id, metadata))
           -- Ignore any tags that start with "_"
           -- Allows for other tags to be used in matches
-        elseif string.sub(name, 1, 1) ~= '_' then
-          if not lang then
-            lang = name
-          end
+          elseif string.sub(name, 1, 1) ~= "_" then
+            if not lang then
+              lang = name
+            end
 
-          if #ranges == 0 then
-            table.insert(ranges, get_node_range(node, id, metadata))
+            if #ranges == 0 then
+              table.insert(ranges, get_node_range(node, id, metadata))
+            end
           end
         end
       end

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1034,9 +1034,16 @@ static int node_prev_named_sibling(lua_State *L)
 /// assumes the match table being on top of the stack
 static void set_match(lua_State *L, TSQueryMatch *match, int nodeidx)
 {
+  // [match]
   for (int i = 0; i < match->capture_count; i++) {
-    push_node(L, match->captures[i].node, nodeidx);
-    lua_rawseti(L, -2, match->captures[i].index + 1);
+    lua_rawgeti(L, -1, match->captures[i].index + 1);  // [match, captures]
+    if (lua_isnil(L, -1)) {  // [match, nil]
+      lua_pop(L, 1);  // [match]
+      lua_createtable(L, 1, 0);  // [match, captures]
+    }
+    push_node(L, match->captures[i].node, nodeidx);  // [match, capture, node]
+    lua_rawseti(L, -2, lua_objlen(L, -2) + 1);  // [match, capture]
+    lua_rawseti(L, -2, match->captures[i].index + 1);  // [match]
   }
 }
 
@@ -1049,7 +1056,7 @@ static int query_next_match(lua_State *L)
   TSQueryMatch match;
   if (ts_query_cursor_next_match(cursor, &match)) {
     lua_pushinteger(L, match.pattern_index + 1);  // [index]
-    lua_createtable(L, ts_query_capture_count(query), 2);  // [index, match]
+    lua_createtable(L, ts_query_capture_count(query), 0);  // [index, match]
     set_match(L, &match, lua_upvalueindex(2));
     return 2;
   }
@@ -1090,7 +1097,8 @@ static int query_next_capture(lua_State *L)
     if (n_pred > 0 && (ud->max_match_id < (int)match.id)) {
       ud->max_match_id = match.id;
 
-      lua_pushvalue(L, lua_upvalueindex(4));  // [index, node, match]
+      // Create a new cleared match table
+      lua_createtable(L, ts_query_capture_count(query), 2);  // [index, node, match]
       set_match(L, &match, lua_upvalueindex(2));
       lua_pushinteger(L, match.pattern_index + 1);
       lua_setfield(L, -2, "pattern");
@@ -1100,6 +1108,10 @@ static int query_next_capture(lua_State *L)
         lua_pushboolean(L, false);
         lua_setfield(L, -2, "active");
       }
+
+      // Set current_match to the new match
+      lua_replace(L, lua_upvalueindex(4));  // [index, node]
+      lua_pushvalue(L, lua_upvalueindex(4));  // [index, node, match]
       return 3;
     }
     return 2;

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -37,7 +37,7 @@ local hl_query = [[
   ; Use lua regexes
   ((identifier) @Identifier (#contains? @Identifier "lua_"))
   ((identifier) @Constant (#lua-match? @Constant "^[A-Z_]+$"))
-  ((identifier) @Normal (#vim-match? @Constant "^lstate$"))
+  ((identifier) @Normal (#vim-match? @Normal "^lstate$"))
 
   ((binary_expression left: (identifier) @WarningMsg.left right: (identifier) @WarningMsg.right) (#eq? @WarningMsg.left @WarningMsg.right))
 

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -157,6 +157,7 @@ void ui_refresh(void)
     "for" @keyword
     (primitive_type) @type
     (field_expression argument: (identifier) @fieldarg)
+    (expression_statement (assignment_expression (call_expression)))+ @funccall
   ]]
 
   it("supports runtime queries", function()
@@ -207,12 +208,18 @@ void ui_refresh(void)
       { "type", "primitive_type", 8, 2, 8, 6 },
       { "keyword", "for", 9, 2, 9, 5 },
       { "type", "primitive_type", 9, 7, 9, 13 },
+      -- captured multiple times, see https://github.com/tree-sitter/tree-sitter/issues/1591
+      { "funccall", "expression_statement", 11, 4, 11, 34 },
+      { "funccall", "expression_statement", 11, 4, 11, 34 },
+      { "funccall", "expression_statement", 11, 4, 11, 34 },
       { "minfunc", "identifier", 11, 12, 11, 15 },
       { "fieldarg", "identifier", 11, 16, 11, 18 },
       { "min_id", "identifier", 11, 27, 11, 32 },
+      { "funccall", "expression_statement", 12, 4, 12, 37 },
       { "minfunc", "identifier", 12, 13, 12, 16 },
       { "fieldarg", "identifier", 12, 17, 12, 19 },
       { "min_id", "identifier", 12, 29, 12, 35 },
+      { "funccall", "expression_statement", 13, 4, 13, 34 },
       { "fieldarg", "identifier", 13, 14, 13, 16 }
     }, res)
   end)
@@ -228,8 +235,10 @@ void ui_refresh(void)
       for pattern, match in cquery:iter_matches(tree:root(), 0, 7, 14) do
         -- can't transmit node over RPC. just check the name and range
         local mrepr = {}
-        for cid,node in pairs(match) do
-          table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+        for cid, nodes in pairs(match) do
+          for _, node in ipairs(nodes) do
+            table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+          end
         end
         table.insert(res, {pattern, mrepr})
       end
@@ -244,7 +253,12 @@ void ui_refresh(void)
       { 1, { { "minfunc", "identifier", 11, 12, 11, 15 }, { "min_id", "identifier", 11, 27, 11, 32 } } },
       { 4, { { "fieldarg", "identifier", 12, 17, 12, 19 } } },
       { 1, { { "minfunc", "identifier", 12, 13, 12, 16 }, { "min_id", "identifier", 12, 29, 12, 35 } } },
-      { 4, { { "fieldarg", "identifier", 13, 14, 13, 16 } } }
+      { 4, { { "fieldarg", "identifier", 13, 14, 13, 16 } } },
+      { 5, {
+        { "funccall", "expression_statement", 11, 4, 11, 34 },
+        { "funccall", "expression_statement", 12, 4, 12, 37 },
+        { "funccall", "expression_statement", 13, 4, 13, 34 },
+      } },
     }, res)
   end)
 
@@ -319,8 +333,10 @@ end]]
       for pattern, match in cquery:iter_matches(tree:root(), 0) do
         -- can't transmit node over RPC. just check the name and range
         local mrepr = {}
-        for cid,node in pairs(match) do
-          table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+        for cid, nodes in pairs(match) do
+          for _, node in ipairs(nodes) do
+            table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+          end
         end
         table.insert(res, {pattern, mrepr})
       end
@@ -405,8 +421,10 @@ end]]
       for pattern, match in cquery:iter_matches(tree:root(), 0) do
         -- can't transmit node over RPC. just check the name and range
         local mrepr = {}
-        for cid,node in pairs(match) do
-          table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+        for cid, nodes in pairs(match) do
+          for _, node in ipairs(nodes) do
+            table.insert(mrepr, {cquery.captures[cid], node:type(), node:range()})
+          end
         end
         table.insert(res, {pattern, mrepr})
       end


### PR DESCRIPTION
See #17060.

This changes the `match` returned by `iter_matches` to be a map from `capture_id` to **list** of nodes instead of map from `capture_id` to **single** node, which is closer to the representation treesitter uses. The previous API could not represent matches where there were multiple nodes for a single capture.

The representation treesitter uses itself is a list of `capture_id, node` pairs. I think my implementation is a good compromise between that and compatability with existing code / usability, since it makes it more convenient to query the nodes for a specific capture.

Also this way I did not have to change a  lot of the code interacting with `iter_matches` and could instead change `get_node_text` to allow list of nodes. So `vim.treesitter.query.get_node_text(match[capture_id])` still behaves as before.

There is also some interaction with predicates and directives, as they also receive a `match` table as input.

Also regarding predicates and directives, at the moment the documentation says to set `metadata[capture_id]` to set metadata for a specific node. This will also not work with captures consisting of multiple nodes.