### PR TITLE
vim-patch:8.2.4095: sed script not recognized by the first line

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -406,6 +406,12 @@ else
   elseif s:line1 =~# '^#.*by RouterOS.*$'
     set ft=routeros
 
+  " Sed scripts
+  " #ncomment is allowed but most likely a false positive so require a space
+  " before any trailing comment text
+  elseif s:line1 =~# '^#n\%($\|\s\)'
+    set ft=sed
+
   " CVS diff
   else
     let s:lnum = 1

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -653,7 +653,7 @@ let s:script_checks = {
       \                ['#!/path/nodejs'],
       \                ['#!/path/rhino']],
       \ 'bc': [['#!/path/bc']],
-      \ 'sed': [['#!/path/sed']],
+      \ 'sed': [['#!/path/sed'], ['#n'], ['#n comment']],
       \ 'ocaml': [['#!/path/ocaml']],
       \ 'awk': [['#!/path/awk'],
       \         ['#!/path/gawk']],


### PR DESCRIPTION
Problem:    Sed script not recognized by the first line.
Solution:   Recognize a sed script starting with "#n". (Doug Kearns)
https://github.com/vim/vim/commit/e3ce17a3ca838954728df21ccb6c2a724490203d