### PR TITLE
vim-patch:8.2.1762: when a timer uses :stopinsert completion isn't stopped

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -663,8 +663,12 @@ static int insert_execute(VimState *state, int key)
   InsertState *const s = (InsertState *)state;
   if (stop_insert_mode) {
     // Insert mode ended, possibly from a callback.
+    if (key != K_IGNORE && key != K_NOP) {
+      vungetc(key);
+    }
     s->count = 0;
     s->nomove = true;
+    ins_compl_prep(ESC);
     return 0;
   }
 

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -445,6 +445,28 @@ func Test_issue_7021()
   set completeslash=
 endfunc
 
+func Test_pum_stopped_by_timer()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['hello', 'hullo', 'heeee', ''])
+    func StartCompl()
+      call timer_start(100, { -> execute('stopinsert') })
+      call feedkeys("Gah\<C-N>")
+    endfunc
+  END
+
+  call writefile(lines, 'Xpumscript')
+  let buf = RunVimInTerminal('-S Xpumscript', #{rows: 12})
+  call term_sendkeys(buf, ":call StartCompl()\<CR>")
+  call TermWait(buf, 200)
+  call term_sendkeys(buf, "k")
+  call VerifyScreenDump(buf, 'Test_pum_stopped_by_timer', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xpumscript')
+endfunc
+
 func Test_pum_with_folds_two_tabs()
   CheckScreendump
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2271,6 +2271,47 @@ describe('builtin popupmenu', function()
     assert_alive()
   end)
 
+  it('is closed by :stopinsert from timer #12976', function()
+    screen:try_resize(32,14)
+    command([[call setline(1, ['hello', 'hullo', 'heeee', ''])]])
+    feed('Gah<C-N>')
+    screen:expect([[
+      hello                           |
+      hullo                           |
+      heeee                           |
+      hello^                           |
+      {s:hello          }{1:                 }|
+      {n:hullo          }{1:                 }|
+      {n:heeee          }{1:                 }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {2:-- }{5:match 1 of 3}                 |
+    ]])
+    command([[call timer_start(100, { -> execute('stopinsert') })]])
+    helpers.sleep(200)
+    feed('k')  -- cursor should move up in Normal mode
+    screen:expect([[
+      hello                           |
+      hullo                           |
+      heee^e                           |
+      hello                           |
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+      {1:~                               }|
+                                      |
+    ]])
+  end)
+
   it('truncates double-width character correctly when there is no scrollbar', function()
     screen:try_resize(32,8)
     command('set completeopt+=menuone,noselect')


### PR DESCRIPTION
Fix #12976 

#### vim-patch:8.2.1762: when a timer uses :stopinsert completion isn't stopped

Problem:    When a timer uses :stopinsert Insert mode completion isn't
            stopped. (Stanley Chan)
Solution:   Call ins_compl_prep(ESC).
https://github.com/vim/vim/commit/d0e1b7103c14eb0d175c6b245b4b6ed93a204da9