### PR TITLE
ci: create automated PRs as drafts

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -48,6 +48,6 @@ jobs:
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 }}
         run: |
           git add -u
-          git commit -m 'docs: regenerate'
+          git commit -m 'docs: regenerate [skip ci]'
           git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} ${DOC_BRANCH}
           gh pr create --draft --fill --base ${GITHUB_REF#refs/heads/} --head ${DOC_BRANCH} || true

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -50,4 +50,4 @@ jobs:
           git add -u
           git commit -m 'docs: regenerate'
           git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} ${DOC_BRANCH}
-          gh pr create --fill --base ${GITHUB_REF#refs/heads/} --head ${DOC_BRANCH} || true
+          gh pr create --draft --fill --base ${GITHUB_REF#refs/heads/} --head ${DOC_BRANCH} || true

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,13 +1,11 @@
 name: "Commit Linter"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   lint-commits:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/vim-patches.yml
+++ b/.github/workflows/vim-patches.yml
@@ -49,4 +49,4 @@ jobs:
           git add -u
           git commit -m 'version.c: update [skip ci]'
           git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} ${VERSION_BRANCH}
-          gh pr create --fill --label vim-patch --base ${GITHUB_REF#refs/heads/} --head ${VERSION_BRANCH} || true
+          gh pr create --draft --fill --label vim-patch --base ${GITHUB_REF#refs/heads/} --head ${VERSION_BRANCH} || true


### PR DESCRIPTION
Now that the "lint-commits" check is required to merge, we need it to be triggered before merging the automated PRs.  However, PRs created/updated by workflows cannot trigger other workflows.

Therefore, create the PRs as drafts and remove them from draft status when they're ready to merge.  Since that is a manual action, it will run the lint-commit checker.