### PR TITLE
Always run commitlint check

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -48,6 +48,6 @@ jobs:
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 }}
         run: |
           git add -u
-          git commit -m 'docs: regenerate'
+          git commit -m 'docs: regenerate [skip ci]'
           git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} ${DOC_BRANCH}
           gh pr create --fill --base ${GITHUB_REF#refs/heads/} --head ${DOC_BRANCH} || true

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,13 +1,13 @@
 name: "Commit Linter"
 on:
-  pull_request:
+  # Only pull_request and push honor [skip ci].  Since this workflow must pass
+  # to merge a PR, it can't be skipped, so use pull_request_target
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   lint-commits:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Since commitlint is a required check to merge a PR, we can't let it be skipped by "skip ci".  Since "skip ci" is only honored for the push/pull_request events, use pull_request_target for commitlint.

Also, disable CI for the api-docs workflow, since we don't need to waste resources on that.