### PR TITLE
fix(lsp): avoid nil workspace/symbol query

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -447,6 +447,9 @@ end
 ---@param query (string, optional)
 function M.workspace_symbol(query)
   query = query or npcall(vfn.input, "Query: ")
+  if query == nil then
+    return
+  end
   local params = {query = query}
   request('workspace/symbol', params)
 end


### PR DESCRIPTION
When calling `:lua vim.lsp.buf.workspace_symbol()`, there is an input prompt to enter a query.

Canceling this with `<ctrl-c>` results in `npcall(vfn.input, ...)` returning `nil`.

The `workspace/symbol` request is then made with `{query = nil}`. With `clangd` this causes an error:
```
clangd: -32600: failed to decode request
```

This PR checks that the query is non-`nil` prior to making the request. As a result, canceling a `vim.lsp.buf.workspace_symbol()` input request with `<ctrl-c>` does not result in an error.

