### PR TITLE
vim-patch:8.1.2412: crash when evaluating expression with error

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4402,7 +4402,7 @@ static int eval_lambda(char_u **const arg, typval_T *const rettv, const bool eva
   rettv->v_type = VAR_UNKNOWN;
 
   int ret = get_lambda_tv(arg, rettv, evaluate);
-  if (ret == NOTDONE) {
+  if (ret != OK) {
     return FAIL;
   } else if (**arg != '(') {
     if (verbose) {

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -303,3 +303,8 @@ func Test_lambda_with_index()
   let Extract = {-> function(List, ['foobar'])()[0]}
   call assert_equal('foobar', Extract())
 endfunc
+
+func Test_lambda_error()
+  " This was causing a crash
+  call assert_fails('ec{@{->{d->()()', 'E15')
+endfunc


### PR DESCRIPTION
#### vim-patch:8.1.2412: crash when evaluating expression with error

Problem:    Crash when evaluating expression with error. (Dhiraj Mishra)
Solution:   Check parsing failed.
https://github.com/vim/vim/commit/0ff822d2ebf0d130516631734b00179ba8dd8251