### PR TITLE
vim-patch:8.2.4090: after restoring a session buffer order can be qui…

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -579,6 +579,24 @@ static int makeopens(FILE *fd, char_u *dirnow)
     return FAIL;
   }
 
+  // Put all buffers into the buffer list.
+  // Do it very early to preserve buffer order after loading session (which
+  // can be disrupted by prior `edit` or `tabedit` calls).
+  FOR_ALL_BUFFERS(buf) {
+    if (!(only_save_windows && buf->b_nwindows == 0)
+        && !(buf->b_help && !(ssop_flags & SSOP_HELP))
+        && buf->b_fname != NULL
+        && buf->b_p_bl) {
+      if (fprintf(fd, "badd +%" PRId64 " ",
+                  buf->b_wininfo == NULL
+                  ? (int64_t)1L
+                  : (int64_t)buf->b_wininfo->wi_fpos.lnum) < 0
+          || ses_fname(fd, buf, &ssop_flags, true) == FAIL) {
+        return FAIL;
+      }
+    }
+  }
+
   // the global argument list
   if (ses_arglist(fd, "argglobal", &global_alist.al_ga,
                   !(ssop_flags & SSOP_CURDIR), &ssop_flags) == FAIL) {
@@ -614,7 +632,10 @@ static int makeopens(FILE *fd, char_u *dirnow)
     // Similar to ses_win_rec() below, populate the tab pages first so
     // later local options won't be copied to the new tabs.
     FOR_ALL_TABS(tp) {
-      if (tp->tp_next != NULL && put_line(fd, "tabnew") == FAIL) {
+      // Use `bufhidden=wipe` to remove empty "placeholder" buffers once
+      // they are not needed. This prevents creating extra buffers (see
+      // cause of Vim patch 8.1.0829)
+      if (tp->tp_next != NULL && put_line(fd, "tabnew +setlocal\\ bufhidden=wipe") == FAIL) {
         return FAIL;
       }
     }
@@ -790,25 +811,6 @@ static int makeopens(FILE *fd, char_u *dirnow)
   }
   if (restore_stal && put_line(fd, "set stal=1") == FAIL) {
     return FAIL;
-  }
-
-  // Now put the remaining buffers into the buffer list.
-  // This is near the end, so that when 'hidden' is set we don't create extra
-  // buffers.  If the buffer was already created with another command the
-  // ":badd" will have no effect.
-  FOR_ALL_BUFFERS(buf) {
-    if (!(only_save_windows && buf->b_nwindows == 0)
-        && !(buf->b_help && !(ssop_flags & SSOP_HELP))
-        && buf->b_fname != NULL
-        && buf->b_p_bl) {
-      if (fprintf(fd, "badd +%" PRId64 " ",
-                  buf->b_wininfo == NULL
-                  ? (int64_t)1L
-                  : (int64_t)buf->b_wininfo->wi_fpos.lnum) < 0
-          || ses_fname(fd, buf, &ssop_flags, true) == FAIL) {
-        return FAIL;
-      }
-    }
   }
 
   //

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -309,6 +309,31 @@ func Test_mksession_buffer_count()
   set nohidden
 endfunc
 
+func Test_mksession_buffer_order()
+  %bwipe!
+  e Xfoo | e Xbar | e Xbaz | e Xqux
+  bufdo write
+  mksession! Xtest_mks.out
+
+  " Verify that loading the session preserves order of buffers
+  %bwipe!
+  source Xtest_mks.out
+
+  let s:buf_info = getbufinfo()
+  call assert_true(s:buf_info[0]['name'] =~# 'Xfoo$')
+  call assert_true(s:buf_info[1]['name'] =~# 'Xbar$')
+  call assert_true(s:buf_info[2]['name'] =~# 'Xbaz$')
+  call assert_true(s:buf_info[3]['name'] =~# 'Xqux$')
+
+  " Clean up.
+  call delete('Xfoo')
+  call delete('Xbar')
+  call delete('Xbaz')
+  call delete('Xqux')
+  call delete('Xtest_mks.out')
+  %bwipe!
+endfunc
+
 if has('extra_search')
 
 func Test_mksession_hlsearch()

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -5,6 +5,7 @@ local clear = helpers.clear
 local command = helpers.command
 local get_pathsep = helpers.get_pathsep
 local eq = helpers.eq
+local neq = helpers.neq
 local funcs = helpers.funcs
 local matches = helpers.matches
 local pesc = helpers.pesc
@@ -30,7 +31,8 @@ describe(':mksession', function()
     -- If the same :terminal is displayed in multiple windows, :mksession
     -- should restore it as such.
 
-    -- Create two windows showing the same :terminal buffer.
+    -- Create three windows: first two from top show same terminal, third -
+    -- another one (created earlier).
     command('terminal')
     command('split')
     command('terminal')
@@ -43,8 +45,8 @@ describe(':mksession', function()
     -- Restore session.
     command('source '..session_file)
 
-    eq({2,2,4},
-      {funcs.winbufnr(1), funcs.winbufnr(2), funcs.winbufnr(3)})
+    eq(funcs.winbufnr(1), funcs.winbufnr(2))
+    neq(funcs.winbufnr(1), funcs.winbufnr(3))
   end)
 
   it('restores tab-local working directories', function()
@@ -91,12 +93,7 @@ describe(':mksession', function()
     command('tabnext 1')
     eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '1', funcs.expand('%:p'))
     command('tabnext 2')
-    -- :mksession stores paths using unix slashes, but Nvim doesn't adjust these
-    -- for absolute paths in all cases yet. Absolute paths are used in the
-    -- session file after :tcd, so we need to expect unix slashes here for now
-    -- eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', funcs.expand('%:p'))
-    eq(cwd_dir:gsub([[\]], '/') .. '/' .. tmpfile_base .. '2',
-      funcs.expand('%:p'))
+    eq(cwd_dir .. get_pathsep() .. tmpfile_base .. '2', funcs.expand('%:p'))
   end)
 
   it('restores CWD for :terminal buffers #11288', function()


### PR DESCRIPTION
…te different

Problem:    After restoring a session buffer order can be quite different.
Solution:   Create buffers first. (Evgeni Chasnovski, closes vim/vim#9520)
vim/vim@26ebf1f

---------------
As in Vim, this basically reverts 8.1.0829 providing different solution
(see vim/vim#9520).

Regarding Neovim, this basically reverts changes from neovim#15062. Test about
restoring same terminals was a bit too restrictive with using actual
buffer ids, which changed with this patch (now they should be in the
same order as at `mksession` call), so I tweaked it.

**NOTE**:
These changes were done by hand and not with provided 'vim-patch.sh' script, but should be one-to-one change to source code and Vim's test.