### PR TITLE
feat(statusline): support multibyte fillchar

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2458,7 +2458,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	This is similar to the default, except that these characters will also
 	be used when there is highlighting.
 
-	for "stl" and "stlnc" only single-byte values are supported.
+	For "stl" and "stlnc" single-byte and multibyte characters are
+	supported.  But double-width characters are not supported.
 
 	The highlighting used for these items:
 	  item		highlight group ~

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -19,6 +19,7 @@
 #include "nvim/ascii.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
+#include "nvim/charset.h"
 #include "nvim/context.h"
 #include "nvim/decoration.h"
 #include "nvim/edit.h"
@@ -2234,7 +2235,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
   Dictionary result = ARRAY_DICT_INIT;
 
   int maxwidth;
-  char fillchar = 0;
+  int fillchar = 0;
   Window window = 0;
   bool use_tabline = false;
   bool highlights = false;
@@ -2249,12 +2250,12 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
   }
 
   if (HAS_KEY(opts->fillchar)) {
-    if (opts->fillchar.type != kObjectTypeString || opts->fillchar.data.string.size > 1) {
-      api_set_error(err, kErrorTypeValidation, "fillchar must be an ASCII character");
+    if (opts->fillchar.type != kObjectTypeString || opts->fillchar.data.string.size == 0
+        || char2cells(fillchar = utf_ptr2char((char_u *)opts->fillchar.data.string.data)) != 1
+        || (size_t)utf_char2len(fillchar) != opts->fillchar.data.string.size) {
+      api_set_error(err, kErrorTypeValidation, "fillchar must be a single-width character");
       return result;
     }
-
-    fillchar = opts->fillchar.data.string.data[0];
   }
 
   if (HAS_KEY(opts->highlights)) {
@@ -2285,7 +2286,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
 
     if (fillchar == 0) {
       int attr;
-      fillchar = (char)fillchar_status(&attr, wp);
+      fillchar = fillchar_status(&attr, wp);
     }
   }
 
@@ -2313,7 +2314,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
                                sizeof(buf),
                                (char_u *)str.data,
                                false,
-                               (char_u)fillchar,
+                               fillchar,
                                maxwidth,
                                hltab_ptr,
                                NULL);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3418,7 +3418,7 @@ typedef enum {
 ///
 /// @return The final width of the statusline
 int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use_sandbox,
-                     char_u fillchar, int maxwidth, stl_hlrec_t **hltab, StlClickRecord **tabtab)
+                     int fillchar, int maxwidth, stl_hlrec_t **hltab, StlClickRecord **tabtab)
 {
   static size_t stl_items_len = 20;  // Initial value, grows as needed.
   static stl_item_t *stl_items = NULL;
@@ -3461,9 +3461,6 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
   if (fillchar == 0) {
     fillchar = ' ';
-  } else if (utf_char2len(fillchar) > 1) {
-    // Can't handle a multi-byte fill character yet.
-    fillchar = '-';
   }
 
   // The cursor in windows other than the current one isn't always
@@ -3661,7 +3658,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
         out_p = out_p - n + 1;
         // Fill up space left over by half a double-wide char.
         while (++group_len < stl_items[stl_groupitems[groupdepth]].minwid) {
-          *out_p++ = fillchar;
+          MB_CHAR2BYTES(fillchar, out_p);
         }
         // }
 
@@ -3684,14 +3681,14 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
         if (min_group_width < 0) {
           min_group_width = 0 - min_group_width;
           while (group_len++ < min_group_width && out_p < out_end_p) {
-            *out_p++ = fillchar;
+            MB_CHAR2BYTES(fillchar, out_p);
           }
           // If the group is right-aligned, shift everything to the right and
           // prepend with filler characters.
         } else {
           // { Move the group to the right
-          memmove(t + min_group_width - group_len, t, (size_t)(out_p - t));
-          group_len = min_group_width - group_len;
+          group_len = (min_group_width - group_len) * utf_char2len(fillchar);
+          memmove(t + group_len, t, (size_t)(out_p - t));
           if (out_p + group_len >= (out_end_p + 1)) {
             group_len = (long)(out_end_p - out_p);
           }
@@ -3705,7 +3702,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
           // Prepend the fill characters
           for (; group_len > 0; group_len--) {
-            *t++ = fillchar;
+            MB_CHAR2BYTES(fillchar, t);
           }
         }
       }
@@ -4237,7 +4234,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
           if (l + 1 == minwid && fillchar == '-' && ascii_isdigit(*t)) {
             *out_p++ = ' ';
           } else {
-            *out_p++ = fillchar;
+            MB_CHAR2BYTES(fillchar, out_p);
           }
         }
         minwid = 0;
@@ -4248,20 +4245,21 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
       }
 
       // { Copy the string text into the output buffer
-      while (*t && out_p < out_end_p) {
-        *out_p++ = *t++;
+      for (; *t && out_p < out_end_p; t++) {
         // Change a space by fillchar, unless fillchar is '-' and a
         // digit follows.
-        if (fillable && out_p[-1] == ' '
-            && (!ascii_isdigit(*t) || fillchar != '-')) {
-          out_p[-1] = fillchar;
+        if (fillable && *t == ' '
+            && (!ascii_isdigit(*(t + 1)) || fillchar != '-')) {
+          MB_CHAR2BYTES(fillchar, out_p);
+        } else {
+          *out_p++ = *t;
         }
       }
       // }
 
       // For left-aligned items, fill any remaining space with the fillchar
       for (; l < minwid && out_p < out_end_p; l++) {
-        *out_p++ = fillchar;
+        MB_CHAR2BYTES(fillchar, out_p);
       }
 
       // Otherwise if the item is a number, copy that to the output buffer.
@@ -4454,7 +4452,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
 
       // Fill up for half a double-wide character.
       while (++width < maxwidth) {
-        *trunc_p++ = fillchar;
+        MB_CHAR2BYTES(fillchar, trunc_p);
         *trunc_p = NUL;
       }
       // }
@@ -4505,13 +4503,13 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
                          standard_spaces * (num_separators - 1);
 
       for (int i = 0; i < num_separators; i++) {
-        int dislocation = (i == (num_separators - 1))
-                          ? final_spaces : standard_spaces;
+        int dislocation = (i == (num_separators - 1)) ? final_spaces : standard_spaces;
+        dislocation *= utf_char2len(fillchar);
         char_u *start = stl_items[stl_separator_locations[i]].start;
         char_u *seploc = start + dislocation;
         STRMOVE(seploc, start);
-        for (char_u *s = start; s < seploc; s++) {
-          *s = fillchar;
+        for (char_u *s = start; s < seploc; ) {
+          MB_CHAR2BYTES(fillchar, s);
         }
 
         for (int item_idx = stl_separator_locations[i] + 1;

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -105,6 +105,9 @@
 #define MB_PTR_BACK(s, p) \
   (p -= utf_head_off((char_u *)s, (char_u *)p - 1) + 1)
 
+// MB_CHAR2BYTES(): convert character to bytes and advance pointer to bytes
+#define MB_CHAR2BYTES(c, b) ((b) += utf_char2bytes((c), (b)))
+
 #define RESET_BINDING(wp) \
   do { \
     (wp)->w_p_scb = false; \

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1960,7 +1960,7 @@ static size_t fill_foldcolumn(char_u *p, win_T *wp, foldinfo_T foldinfo, linenr_
   level = foldinfo.fi_level;
 
   // If the column is too narrow, we start at the lowest level that
-  // fits and use numbers to indicated the depth.
+  // fits and use numbers to indicate the depth.
   first_level = level - fdc - closed + 1;
   if (first_level < 1) {
     first_level = 1;

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -498,5 +498,20 @@ func Test_statusline_after_split_vsplit()
   set ls& stl&
 endfunc
 
+" Test using a multibyte character for 'stl' and 'stlnc' items in 'fillchars'
+" with a custom 'statusline'
+func Test_statusline_mbyte_fillchar()
+  only
+  set laststatus=2
+  set fillchars=vert:\|,fold:-,stl:━,stlnc:═
+  set statusline=a%=b
+  call assert_match('^a\+━\+b$', s:get_statusline())
+  vnew
+  call assert_match('^a\+━\+b━a\+═\+b$', s:get_statusline())
+  wincmd w
+  call assert_match('^a\+═\+b═a\+━\+b$', s:get_statusline())
+  set statusline& fillchars& laststatus&
+  %bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2551,6 +2551,34 @@ describe('API', function()
           'Should be truncated%<',
           { maxwidth = 15 }))
     end)
+    it('supports ASCII fillchar', function()
+      eq({ str = 'a~~~b', width = 5 },
+         meths.eval_statusline('a%=b', { fillchar = '~', maxwidth = 5 }))
+    end)
+    it('supports single-width multibyte fillchar', function()
+      eq({ str = 'a━━━b', width = 5 },
+         meths.eval_statusline('a%=b', { fillchar = '━', maxwidth = 5 }))
+    end)
+    it('rejects double-width fillchar', function()
+      eq('fillchar must be a single-width character',
+         pcall_err(meths.eval_statusline, '', { fillchar = '哦' }))
+    end)
+    it('rejects control character fillchar', function()
+      eq('fillchar must be a single-width character',
+         pcall_err(meths.eval_statusline, '', { fillchar = '\a' }))
+    end)
+    it('rejects multiple-character fillchar', function()
+      eq('fillchar must be a single-width character',
+         pcall_err(meths.eval_statusline, '', { fillchar = 'aa' }))
+    end)
+    it('rejects empty string fillchar', function()
+      eq('fillchar must be a single-width character',
+         pcall_err(meths.eval_statusline, '', { fillchar = '' }))
+    end)
+    it('rejects non-string fillchar', function()
+      eq('fillchar must be a single-width character',
+         pcall_err(meths.eval_statusline, '', { fillchar = 1 }))
+    end)
     describe('highlight parsing', function()
       it('works', function()
         eq({


### PR DESCRIPTION
Fix #15993

This includes a partial port of Vim patch 8.2.2569 and some changes to `nvim_eval_statusline()` to allow a multibyte `fillchar`. Literally every line of C code touched by that patch has been refactored in Nvim, and that patch contains some irrelevant foldcolumn tests I'm not sure how to port (as Nvim's foldcolumn behavior has diverged from Vim's).