### PR TITLE
fix(man.vim): support calling :Man without a section again

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -232,7 +232,11 @@ function! s:get_path(sect, name) abort
   "
   " Finally, we can avoid relying on -S or -s here since they are very
   " inconsistently supported. Instead, call -w with a section and a name.
-  let results = split(s:system(['man', s:find_arg, a:sect, a:name]))
+  if empty(a:sect)
+    let results = split(s:system(['man', s:find_arg, a:name]))
+  else
+    let results = split(s:system(['man', s:find_arg, a:sect, a:name]))
+  endif
 
   if empty(results)
     return ''


### PR DESCRIPTION
When `man -w` is called with an empty string as section name, it may fail with an error code, which causes `:Man` to no longer work without a section. Just remove that argument when no section is specified.