### PR TITLE
ci: create automated PRs as draft PRs

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -50,4 +50,4 @@ jobs:
           git add -u
           git commit -m 'docs: regenerate [skip ci]'
           git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} ${DOC_BRANCH}
-          gh pr create --fill --base ${GITHUB_REF#refs/heads/} --head ${DOC_BRANCH} || true
+          gh pr create --draft --fill --base ${GITHUB_REF#refs/heads/} --head ${DOC_BRANCH} || true

--- a/.github/workflows/vim-patches.yml
+++ b/.github/workflows/vim-patches.yml
@@ -49,4 +49,4 @@ jobs:
           git add -u
           git commit -m 'version.c: update [skip ci]'
           git push --force https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} ${VERSION_BRANCH}
-          gh pr create --fill --label vim-patch --base ${GITHUB_REF#refs/heads/} --head ${VERSION_BRANCH} || true
+          gh pr create --draft --fill --label vim-patch --base ${GITHUB_REF#refs/heads/} --head ${VERSION_BRANCH} || true


### PR DESCRIPTION
GH workflows aren't allowed to trigger other GH workflows.  Since commitlint is a required check now, we need something manual to happen for it to run on vim-patch/api-doc PRs.

Creating these PRs as drafts and then marking them as "ready to review" when we want to merge them will provide the manual trigger to run commitlint.