### PR TITLE
tree-sitter: injection language base on filetype.lua

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1572,4 +1572,12 @@ function M.match(name, bufnr)
   end
 end
 
+
+---@private
+-- Returns `:h filetype` based on based on extension
+-- ext string extension
+function M._ft_by_extension(ext)
+  return extension[ext]
+end
+
 return M

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -133,6 +133,13 @@ function LanguageTree:parse()
 
   for lang, injection_ranges in pairs(injections_by_lang) do
     local has_lang = language.require_language(lang, nil, true)
+    local lang_by_extension = require'vim.filetype'._ft_by_extension(lang)
+    if not has_lang and type(lang_by_extension) == 'string' then
+      has_lang = language.require_language(lang_by_extension, nil, true)
+      if has_lang then
+        lang = lang_by_extension
+      end
+    end
 
     -- Child language trees should just be ignored if not found, since
     -- they can depend on the text of a node. Intermediate strings


### PR DESCRIPTION
This is probably not the right way to do it. But anyway, I'm to tired too think of the right way right now and I think it is an interesting discussion: determine the injection language of tree-sitter parsers using `vim.filetype`

![image](https://user-images.githubusercontent.com/7189118/149832763-d498b383-de24-4305-9a5b-eea3fcb8e764.png)

This heuristic:

- could be an option on creation of language tree
- could be an over writable function in language tree module (and filetype.lua,_ft_by_extension just one possible implementation that can be chosen)
- this behavior could be connected to special directive that explicitly requests filetype.lua
- this behavior could be connected to special capture that explicitly requests filetype.lua (e.g. `@extension`)
- it could be documented that filetype.lua is used
- we could use vim global variables like `g:markdown_fenced_language` (I'm really not a fan)

Related https://github.com/nvim-treesitter/nvim-treesitter/issues/2131

 Disclaimer: I don't know about rationale and the discussions about filetype.lua so it's possible I'm totally abusing it.
