### PR TITLE
refactor: source ftplugin.vim separately from filetype.vim

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -411,12 +411,7 @@ accordingly, proceeding as follows:
 
 5. Enable filetype and indent plugins.
 	This does the same as the command: >
-		:filetype plugin indent on
-<	which in turn is equivalent to: >
-		:runtime! filetype.lua
-		:runtime! filetype.vim
-		:runtime! ftplugin.vim
-		:runtime! indent.vim
+		:runtime! ftplugin.vim indent.vim
 <	Skipped if the "-u NONE" command line argument was given.
 
 6. Load user config (execute Ex commands from files, environment, …).
@@ -463,13 +458,19 @@ accordingly, proceeding as follows:
 	-  The file ".nvimrc"
 	-  The file ".exrc"
 
-7. Enable syntax highlighting.
+7. Enable filetype detection.
+	This does the same as the command: >
+		:runtime! filetype.lua filetype.vim
+<	Skipped if ":filetype off" was called or if the "-u NONE" command line
+	argument was given.
+
+8. Enable syntax highlighting.
 	This does the same as the command: >
 		:runtime! syntax/syntax.vim
 <	Skipped if ":syntax off" was called or if the "-u NONE" command
 	line argument was given.
 
-8. Load the plugin scripts.					*load-plugins*
+9. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >
 		:runtime! plugin/**/*.vim
 		:runtime! plugin/**/*.lua
@@ -499,21 +500,21 @@ accordingly, proceeding as follows:
 	if packages have been found, but that should not add a directory
 	ending in "after".
 
-9. Set 'shellpipe' and 'shellredir'
+10. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
 	This means that Nvim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
-10. Set 'updatecount' to zero, if "-n" command argument used
+11. Set 'updatecount' to zero, if "-n" command argument used
 
-11. Set binary options if the |-b| flag was given.
+12. Set binary options if the |-b| flag was given.
 
-12. Read the |shada-file|.
+13. Read the |shada-file|.
 
-13. Read the quickfix file if the |-q| flag was given, or exit on failure.
+14. Read the quickfix file if the |-q| flag was given, or exit on failure.
 
-14. Open all windows
+15. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
 	displayed yet).
 	When the |-p| flag was given, tab pages will be created (but not
@@ -523,7 +524,7 @@ accordingly, proceeding as follows:
 	Buffers for all windows will be loaded, without triggering |BufAdd|
 	autocommands.
 
-15. Execute startup commands
+16. Execute startup commands
 	If a |-t| flag was given, the tag is jumped to.
 	Commands given with |-c| and |+cmd| are executed.
 	If the 'insertmode' option is set, Insert mode is entered.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -23,12 +23,10 @@ centralized reference of the differences.
 ==============================================================================
 2. Defaults					            *nvim-defaults*
 
-- ":filetype plugin indent on" is enabled by default. This runs before
-  init.vim is sourced so that FileType autocommands in init.vim run after
-  those in filetype.vim.
-- Syntax highlighting is enabled by default. This runs after init.vim is
-  sourced so that users can optionally disable syntax highlighting with
-  ":syntax off".
+- Filetype detection is enabled by default. This can be disabled by adding
+  ":filetype off" to |init.vim|.
+- Syntax highlighting is enabled by default. This can be disabled by adding
+  ":syntax off" to |init.vim|.
 
 - 'autoindent' is enabled
 - 'autoread' is enabled

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9546,7 +9546,23 @@ static void ex_filetype(exarg_T *eap)
   }
 }
 
-/// Set all :filetype options ON if user did not explicitly set any to OFF.
+/// Source ftplugin.vim and indent.vim to create the necessary FileType
+/// autocommands. We do this separately from filetype.vim so that these
+/// autocommands will always fire first (and thus can be overriden) while still
+/// allowing general filetype detection to be disabled in the user's init file.
+void filetype_plugin_enable(void)
+{
+  if (filetype_plugin == kNone) {
+    source_runtime(FTPLUGIN_FILE, DIP_ALL);
+    filetype_plugin = kTrue;
+  }
+  if (filetype_indent == kNone) {
+    source_runtime(INDENT_FILE, DIP_ALL);
+    filetype_indent = kTrue;
+  }
+}
+
+/// Enable filetype detection if the user did not explicitly disable it.
 void filetype_maybe_enable(void)
 {
   if (filetype_detect == kNone) {
@@ -9555,14 +9571,6 @@ void filetype_maybe_enable(void)
     // autocommand to be defined first so that it runs first
     source_runtime(FILETYPE_FILE, DIP_ALL);
     filetype_detect = kTrue;
-  }
-  if (filetype_plugin == kNone) {
-    source_runtime(FTPLUGIN_FILE, DIP_ALL);
-    filetype_plugin = kTrue;
-  }
-  if (filetype_indent == kNone) {
-    source_runtime(INDENT_FILE, DIP_ALL);
-    filetype_indent = kTrue;
   }
 }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -354,10 +354,10 @@ int main(int argc, char **argv)
   exe_pre_commands(&params);
 
   if (!vimrc_none) {
-    // Does ":filetype plugin indent on". We do this *before* the user startup scripts to ensure
+    // Sources ftplugin.vim and indent.vim. We do this *before* the user startup scripts to ensure
     // ftplugins run before FileType autocommands defined in the init file (which allows those
     // autocommands to overwrite settings from ftplugins).
-    filetype_maybe_enable();
+    filetype_plugin_enable();
   }
 
   // Source startup scripts.
@@ -365,6 +365,9 @@ int main(int argc, char **argv)
 
   // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
   if (!vimrc_none) {
+    // Sources filetype.lua and filetype.vim unless the user explicitly disabled it with :filetype
+    // off.
+    filetype_maybe_enable();
     // Sources syntax/syntax.vim. We do this *after* the user startup scripts so that users can
     // disable syntax highlighting with `:syntax off` if they wish.
     syn_maybe_enable();


### PR DESCRIPTION
This is a follow-on to #17040. The real benefit of #17040 was ensuring
that the ftplugin FileType autocommand was defined first and thus always
fired first. A side effect of the implementation in #17040 was that
setting variables that modified the state of filetype detection (such as
`g:did_load_filetypes` or `g:do_filetype_lua`) could no longer be set in the
user's init file. Filetype detection can also no longer be prevented
from loading by using `:filetype off`.

This PR addresses both of those side effects by unconditionally sourcing
ftplugin.vim and indent.vim before the user's init file (which ensures
that these autocommands run first) and sourcing filetype.vim *after* the
user's init file (thus allowing it to be blocked or modified).
