### PR TITLE
vim-patch:8.2.3580: gj does not move properly with a wide character

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3281,7 +3281,7 @@ static bool nv_screengo(oparg_T *oap, int dir, long dist)
   int col_off1;                 // margin offset for first screen line
   int col_off2;                 // margin offset for wrapped screen line
   int width1;                   // text width for first screen line
-  int width2;                   // test width for wrapped screen line
+  int width2;                   // text width for wrapped screen line
 
   oap->motion_type = kMTCharWise;
   oap->inclusive = (curwin->w_curswant == MAXCOL);
@@ -3403,6 +3403,13 @@ static bool nv_screengo(oparg_T *oap, int dir, long dist)
     colnr_T virtcol = curwin->w_virtcol;
     if (virtcol > (colnr_T)width1 && *get_showbreak_value(curwin) != NUL) {
       virtcol -= vim_strsize(get_showbreak_value(curwin));
+    }
+
+    int c = utf_ptr2char(get_cursor_pos_ptr());
+    if (dir == FORWARD && virtcol < curwin->w_curswant
+        && (curwin->w_curswant <= (colnr_T)width1)
+        && !vim_isprintc(c) && c > 255) {
+      oneright();
     }
 
     if (virtcol > curwin->w_curswant

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2759,4 +2759,16 @@ func Test_normal_count_after_operator()
   bw!
 endfunc
 
+func Test_normal_gj_on_extra_wide_char()
+  new | 25vsp
+  let text='1 foooooooo ar e  ins‍zwe1 foooooooo ins‍zwei' .
+         \ ' i drei vier fünf sechs sieben acht un zehn elf zwöfl' .
+         \ ' dreizehn v ierzehn fünfzehn'
+  put =text
+  call cursor(2,1)
+  norm! gj
+  call assert_equal([0,2,25,0], getpos('.'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3580: gj does not move properly with a wide character

Problem:    gj does not move properly with a wide character.
Solution:   Move one to the right. (Christian Brabandt, closes vim/vim#8702)
https://github.com/vim/vim/commit/aaec1d4fb12efb82b87ad322e95994de77b1a833