### PR TITLE
vim-patch:8.2.{3494,3611,3613}: two Visual mode crash fixes

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1433,11 +1433,11 @@ char_u *find_file_in_path_option(char_u *ptr, size_t len, int options, int first
     rel_fname = NULL;
   }
 
-  if (len == 0) {
-    return NULL;
-  }
+  if (first == true) {
+    if (len == 0) {
+      return NULL;
+    }
 
-  if (first == TRUE) {
     // copy file name into NameBuff, expanding environment variables
     save_char = ptr[len];
     ptr[len] = NUL;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1433,6 +1433,10 @@ char_u *find_file_in_path_option(char_u *ptr, size_t len, int options, int first
     rel_fname = NULL;
   }
 
+  if (len == 0) {
+    return NULL;
+  }
+
   if (first == TRUE) {
     // copy file name into NameBuff, expanding environment variables
     save_char = ptr[len];

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5963,11 +5963,8 @@ static void nv_visual(cmdarg_T *cap)
        * was only one -- webb
        */
       if (resel_VIsual_mode != 'v' || resel_VIsual_line_count > 1) {
-        curwin->w_cursor.lnum +=
-          resel_VIsual_line_count * cap->count0 - 1;
-        if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
-          curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
-        }
+        curwin->w_cursor.lnum += resel_VIsual_line_count * cap->count0 - 1;
+        check_cursor();
       }
       VIsual_mode = resel_VIsual_mode;
       if (VIsual_mode == 'v') {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4472,8 +4472,13 @@ bool get_visual_text(cmdarg_T *cap, char_u **pp, size_t *lenp)
       *pp = ml_get_pos(&VIsual);
       *lenp = (size_t)curwin->w_cursor.col - (size_t)VIsual.col + 1;
     }
-    // Correct the length to include the whole last character.
-    *lenp += (size_t)(utfc_ptr2len(*pp + (*lenp - 1)) - 1);
+    if (**pp == NUL) {
+      *lenp = 0;
+    }
+    if (*lenp > 0) {
+      // Correct the length to include all bytes of the last character.
+      *lenp += (size_t)(utfc_ptr2len(*pp + (*lenp - 1)) - 1);
+    }
   }
   reset_VIsual_and_resel();
   return true;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1682,6 +1682,10 @@ char_u *find_file_name_in_path(char_u *ptr, size_t len, int options, long count,
   char_u *file_name;
   char_u *tofree = NULL;
 
+  if (len == 0) {
+    return NULL;
+  }
+
   if ((options & FNAME_INCL) && *curbuf->b_p_inex != NUL) {
     tofree = (char_u *)eval_includeexpr((char *)ptr, len);
     if (tofree != NULL) {

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1120,7 +1120,27 @@ func Test_visual_block_with_virtualedit()
   " clean up
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
-  call delete('XTest_beval')
+  call delete('XTest_block')
+endfunc
+
+func Test_visual_reselect_with_count()
+  " this was causing an illegal memory access
+  let lines =<< trim END
+
+
+
+      :
+      r<sfile>
+      exe "%norm e3\<c-v>kr\t"
+      :
+
+      :
+  END
+  call writefile(lines, 'XvisualReselect')
+  source XvisualReselect
+
+  bwipe!
+  call delete('XvisualReselect')
 endfunc
 
 

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1123,6 +1123,14 @@ func Test_visual_block_with_virtualedit()
   call delete('XTest_block')
 endfunc
 
+func Test_visual_block_ctrl_w_f()
+  " Emtpy block selected in new buffer should not result in an error.
+  au! BufNew foo sil norm f
+  edit foo
+
+  au! BufNew
+endfunc
+
 func Test_visual_reselect_with_count()
   " this was causing an illegal memory access
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:8.2.3494: illegal memory access in utf_head_off

Problem:    Illegal memory access in utf_head_off.
Solution:   Check cursor position when reselecting the Visual area.
https://github.com/vim/vim/commit/b07626d4afa73dd2af0f03c0d59eed25ee159ef9

Including the `XTest_beval` -> `XTest_block` from patch 8.2.3096.


#### vim-patch:8.2.3611: crash when using CTRL-W f without finding a file name

Problem:    Crash when using CTRL-W f without finding a file name.
Solution:   Bail out when the file name length is zero.
https://github.com/vim/vim/commit/615ddd5342b50a6878a907062aa471740bd9a847

#### vim-patch:8.2.3613: :find test fails

Problem:    :find test fails.
Solution:   Put length check inside if block.
https://github.com/vim/vim/commit/e015d99abb4276f47ce97bad1ad5ff0c658b1c8a