### PR TITLE
vim-patch:8.2.0175: crash when removing list element in map()

### DIFF
--- a/src/nvim/testdir/test_filter_map.vim
+++ b/src/nvim/testdir/test_filter_map.vim
@@ -88,4 +88,14 @@ func Test_map_filter_fails()
   call assert_fails("let l = filter('abc', '\"> \" . v:val')", 'E896:')
 endfunc
 
+func Test_map_and_modify()
+  let l = ["abc"]
+  " cannot change the list halfway a map()
+  call assert_fails('call map(l, "remove(l, 0)[0]")', 'E741:')
+
+  let d = #{a: 1, b: 2, c: 3}
+  call assert_fails('call map(d, "remove(d, v:key)[0]")', 'E741:')
+  call assert_fails('echo map(d, {k,v -> remove(d, k)})', 'E741:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Crash when removing list element in map().
Solution:   Lock the list. (closes vim/vim#2652)
https://github.com/vim/vim/commit/db661fb95dc41b7a9438cf3cd4e77f8410bc81c0