### PR TITLE
vim-patch:8.2.4133: output of ":scriptnames" goes into the message history

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -2323,9 +2323,11 @@ void ex_scriptnames(exarg_T *eap)
 
   for (int i = 1; i <= script_items.ga_len && !got_int; i++) {
     if (SCRIPT_ITEM(i).sn_name != NULL) {
-      home_replace(NULL, SCRIPT_ITEM(i).sn_name,
-                   NameBuff, MAXPATHL, true);
-      smsg("%3d: %s", i, NameBuff);
+      home_replace(NULL, SCRIPT_ITEM(i).sn_name, NameBuff, MAXPATHL, true);
+      vim_snprintf((char *)IObuff, IOSIZE, "%3d: %s", i, NameBuff);
+      msg_putchar('\n');
+      msg_outtrans(IObuff);
+      line_breakcheck();
     }
   }
 }

--- a/src/nvim/testdir/test_scriptnames.vim
+++ b/src/nvim/testdir/test_scriptnames.vim
@@ -23,4 +23,10 @@ func Test_scriptnames()
 
   bwipe
   call delete('Xscripting')
+
+  let msgs = execute('messages')
+  scriptnames
+  call assert_equal(msgs, execute('messages'))
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4133: output of ":scriptnames" goes into the message history

Problem:    output of ":scriptnames" goes into the message history, while this
            des not happen for other commands, such as ":ls".
Solution:   Use msg_outtrans() instead of smsg().
https://github.com/vim/vim/commit/840f16202e1ae2d574507ef52a7e8a98775f243c