### PR TITLE
vim-patch:8.2.0128: cannot list options one per line

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -20,9 +20,13 @@ achieve special effects.  These options come in three forms:
 1. Setting options					*set-option* *E764*
 
 							*:se* *:set*
-:se[t]			Show all options that differ from their default value.
+:se[t][!]		Show all options that differ from their default value.
+			When [!] is present every option is on a separate
+			line.
 
-:se[t] all		Show all options.
+:se[t][!] all		Show all options.
+			When [!] is present every option is on a separate
+			line.
 
 								*E518* *E519*
 :se[t] {option}?	Show value of {option}.
@@ -235,7 +239,7 @@ happens when the buffer is not loaded, but they are lost when the buffer is
 wiped out |:bwipe|.
 
 							*:setl* *:setlocal*
-:setl[ocal] ...		Like ":set" but set only the value local to the
+:setl[ocal][!] ...	Like ":set" but set only the value local to the
 			current buffer or window.  Not all options have a
 			local value.  If the option does not have a local
 			value the global value is set.
@@ -257,7 +261,7 @@ wiped out |:bwipe|.
 			{option}, so that the global value will be used.
 
 							*:setg* *:setglobal*
-:setg[lobal] ...	Like ":set" but set only the global value for a local
+:setg[lobal][!] ...	Like ":set" but set only the global value for a local
 			option without changing the local value.
 			When displaying an option, the global value is shown.
 			With the "all" argument: display global values for all

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2413,7 +2413,7 @@ module.cmds = {
   },
   {
     command='set',
-    flags=bit.bor(TRLBAR, EXTRA, CMDWIN, SBOXOK),
+    flags=bit.bor(BANG, TRLBAR, EXTRA, CMDWIN, SBOXOK),
     addr_type='ADDR_NONE',
     func='ex_set',
   },
@@ -2425,13 +2425,13 @@ module.cmds = {
   },
   {
     command='setglobal',
-    flags=bit.bor(TRLBAR, EXTRA, CMDWIN, SBOXOK),
+    flags=bit.bor(BANG, TRLBAR, EXTRA, CMDWIN, SBOXOK),
     addr_type='ADDR_NONE',
     func='ex_set',
   },
   {
     command='setlocal',
-    flags=bit.bor(TRLBAR, EXTRA, CMDWIN, SBOXOK),
+    flags=bit.bor(BANG, TRLBAR, EXTRA, CMDWIN, SBOXOK),
     addr_type='ADDR_NONE',
     func='ex_set',
   },

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -9600,18 +9600,6 @@ static void ex_digraphs(exarg_T *eap)
   }
 }
 
-static void ex_set(exarg_T *eap)
-{
-  int flags = 0;
-
-  if (eap->cmdidx == CMD_setlocal) {
-    flags = OPT_LOCAL;
-  } else if (eap->cmdidx == CMD_setglobal) {
-    flags = OPT_GLOBAL;
-  }
-  (void)do_set(eap->arg, flags);
-}
-
 void set_no_hlsearch(bool flag)
 {
   no_hlsearch = flag;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -281,7 +281,7 @@ typedef struct vimoption {
 # include "options.generated.h"
 #endif
 
-#define PARAM_COUNT ARRAY_SIZE(options)
+#define OPTION_COUNT ARRAY_SIZE(options)
 
 static char *(p_ambw_values[]) =      { "single", "double", NULL };
 static char *(p_bg_values[]) =        { "light", "dark", NULL };
@@ -929,6 +929,21 @@ void set_title_defaults(void)
     options[idx1].def_val = (char_u *)(intptr_t)0;
     p_icon = 0;
   }
+}
+
+void ex_set(exarg_T *eap)
+{
+  int flags = 0;
+
+  if (eap->cmdidx == CMD_setlocal) {
+    flags = OPT_LOCAL;
+  } else if (eap->cmdidx == CMD_setglobal) {
+    flags = OPT_GLOBAL;
+  }
+  if (eap->forceit) {
+    flags |= OPT_ONECOLUMN;
+  }
+  (void)do_set(eap->arg, flags);
 }
 
 /// Parse 'arg' for option settings.
@@ -5184,7 +5199,7 @@ static void showoptions(int all, int opt_flags)
 #define INC 20
 #define GAP 3
 
-  vimoption_T **items = xmalloc(sizeof(vimoption_T *) * PARAM_COUNT);
+  vimoption_T **items = xmalloc(sizeof(vimoption_T *) * OPTION_COUNT);
 
   // Highlight title
   if (opt_flags & OPT_GLOBAL) {
@@ -5198,6 +5213,7 @@ static void showoptions(int all, int opt_flags)
   // Do the loop two times:
   // 1. display the short items
   // 2. display the long items (only strings and numbers)
+  // When "opt_flags" has OPT_ONECOLUMN do everything in run 2.
   for (run = 1; run <= 2 && !got_int; run++) {
     // collect the items in items[]
     item_count = 0;
@@ -5208,7 +5224,7 @@ static void showoptions(int all, int opt_flags)
       }
 
       varp = NULL;
-      if (opt_flags != 0) {
+      if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) != 0) {
         if (p->indir != PV_NONE) {
           varp = get_varp_scope(p, opt_flags);
         }
@@ -5217,8 +5233,10 @@ static void showoptions(int all, int opt_flags)
       }
       if (varp != NULL
           && (all == 1 || (all == 0 && !optval_default(p, varp)))) {
-        if (p->flags & P_BOOL) {
-          len = 1;                      //  a toggle option fits always
+        if (opt_flags & OPT_ONECOLUMN) {
+          len = Columns;
+        } else if (p->flags & P_BOOL) {
+          len = 1;                      // a toggle option fits always
         } else {
           option_value2string(p, opt_flags);
           len = (int)STRLEN(p->fullname) + vim_strsize(NameBuff) + 1;

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -13,16 +13,16 @@
 /// When OPT_GLOBAL and OPT_LOCAL are both missing, set both local and global
 /// values, get local value.
 typedef enum {
-  OPT_FREE     = 1,   ///< Free old value if it was allocated.
-  OPT_GLOBAL   = 2,   ///< Use global value.
-  OPT_LOCAL    = 4,   ///< Use local value.
-  OPT_MODELINE = 8,   ///< Option in modeline.
-  OPT_WINONLY  = 16,  ///< Only set window-local options.
-  OPT_NOWIN    = 32,  ///< Don’t set window-local options.
-  OPT_ONECOLUMN = 64,  ///< list options one per line
-  OPT_NO_REDRAW = 128,  ///< ignore redraw flags on option
-  OPT_SKIPRTP = 256,  ///< "skiprtp" in 'sessionoptions'
-  OPT_CLEAR = 512,  ///< Clear local value of an option.
+  OPT_FREE      = 0x01,   ///< Free old value if it was allocated.
+  OPT_GLOBAL    = 0x02,   ///< Use global value.
+  OPT_LOCAL     = 0x04,   ///< Use local value.
+  OPT_MODELINE  = 0x08,   ///< Option in modeline.
+  OPT_WINONLY   = 0x10,   ///< Only set window-local options.
+  OPT_NOWIN     = 0x20,   ///< Don’t set window-local options.
+  OPT_ONECOLUMN = 0x40,   ///< list options one per line
+  OPT_NO_REDRAW = 0x80,   ///< ignore redraw flags on option
+  OPT_SKIPRTP   = 0x100,  ///< "skiprtp" in 'sessionoptions'
+  OPT_CLEAR     = 0x200,  ///< Clear local value of an option.
 } OptionFlags;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -51,7 +51,7 @@ func Test_wildoptions()
   call assert_equal('tagfile', &wildoptions)
 endfunc
 
-function! Test_options()
+func Test_options_command()
   let caught = 'ok'
   try
     options
@@ -88,7 +88,7 @@ function! Test_options()
 
   " close option-window
   close
-endfunction
+endfunc
 
 function! Test_path_keep_commas()
   " Test that changing 'path' keeps two commas.
@@ -366,6 +366,13 @@ func Test_set_all()
   call assert_match('iskeyword=a-z,A-Z', out)
   call assert_match('nosplitbelow', out)
   set tw& iskeyword& splitbelow&
+endfunc
+
+func Test_set_one_column()
+  let out_mult = execute('set all')->split("\n")
+  let out_one = execute('set! all')->split("\n")
+  " one column should be two to four times as many lines
+  call assert_inrange(len(out_mult) * 2, len(out_mult) * 4, len(out_one))
 endfunc
 
 func Test_set_values()


### PR DESCRIPTION
#### vim-patch:8.2.0128: cannot list options one per line

Problem:    Cannot list options one per line.
Solution:   Use ":set!" to list one option per line.
https://github.com/vim/vim/commit/6b915c0c0ee7ef82f8d3d310a4345e098cb929b0