### PR TITLE
vim-patch:8.2.4166: undo synced when switching buffer in another window

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1454,7 +1454,10 @@ void set_curbuf(buf_T *buf, int action)
     }
     if (bufref_valid(&prevbufref) && !aborting()) {
       win_T *previouswin = curwin;
-      if (prevbuf == curbuf) {
+      // Do not sync when in Insert mode and the buffer is open in
+      // another window, might be a timer doing something in another
+      // window.
+      if (prevbuf == curbuf && ((State & INSERT) == 0 || curbuf->b_nwindows <= 1)) {
         u_sync(false);
       }
       close_buffer(prevbuf == curwin->w_buffer ? curwin : NULL,


### PR DESCRIPTION
Fix #11439

#### vim-patch:8.2.4166: undo synced when switching buffer in another window

Problem:    Undo synced when switching buffer in another window.
Solution:   Do not sync undo when not needed.
https://github.com/vim/vim/commit/e615db06046312e74886fa1ef98feb5a9db2a7c3