### PR TITLE
vim-patch:8.2.3583: the "gd" and "gD" commands do not update search stats

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3098,8 +3098,14 @@ static void nv_gd(oparg_T *oap, int nchar, int thisblock)
   if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0
       || !find_decl(ptr, len, nchar == 'd', thisblock, SEARCH_START)) {
     clearopbeep(oap);
-  } else if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP) {
-    foldOpenCursor();
+  } else {
+    if ((fdo_flags & FDO_SEARCH) && KeyTyped && oap->op_type == OP_NOP) {
+      foldOpenCursor();
+    }
+    // clear any search statistics
+    if (messaging() && !msg_silent && !shortmess(SHM_SEARCHCOUNT)) {
+      clear_cmdline = true;
+    }
   }
 }
 

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -347,4 +347,29 @@ func! Test_search_stat_screendump()
   call delete('Xsearchstat')
 endfunc
 
+func Test_search_stat_then_gd()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['int cat;', 'int dog;', 'cat = dog;'])
+    set shortmess-=S
+    set hlsearch
+  END
+  call writefile(lines, 'Xsearchstatgd')
+
+  let buf = RunVimInTerminal('-S Xsearchstatgd', #{rows: 10})
+  call term_sendkeys(buf, "/dog\<CR>")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstatgd_1', {})
+
+  call term_sendkeys(buf, "G0gD")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstatgd_2', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xsearchstatgd')
+endfunc
+
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -1,14 +1,15 @@
 " Tests for search_stats, when "S" is not in 'shortmess'
 
-source screendump.vim
 source check.vim
+source screendump.vim
 
 func Test_search_stat()
   new
   set shortmess-=S
   " Append 50 lines with text to search for, "foobar" appears 20 times
   call append(0, repeat(['foobar', 'foo', 'fooooobar', 'foba', 'foobar'], 10))
-  call nvim_win_set_cursor(0, [1, 0])
+
+  call cursor(1, 1)
 
   " searchcount() returns an empty dictionary when previous pattern was not set
   call assert_equal({}, searchcount(#{pattern: ''}))
@@ -45,7 +46,6 @@ func Test_search_stat()
     \ searchcount(#{pattern: 'fooooobar', maxcount: 1}))
 
   " match at second line
-  call cursor(1, 1)
   let messages_before = execute('messages')
   let @/ = 'fo*\(bar\?\)\?'
   let g:a = execute(':unsilent :norm! n')
@@ -262,6 +262,34 @@ func Test_searchcount_fails()
   call assert_fails('echo searchcount("boo!")', 'E715:')
 endfunc
 
+func Test_searchcount_in_statusline()
+  CheckScreendump
+
+  let lines =<< trim END
+    set shortmess-=S
+    call append(0, 'this is something')
+    function TestSearchCount() abort
+      let search_count = searchcount()
+      if !empty(search_count)
+	return '[' . search_count.current . '/' . search_count.total . ']'
+      else
+	return ''
+      endif
+    endfunction
+    set hlsearch
+    set laststatus=2 statusline+=%{TestSearchCount()}
+  END
+  call writefile(lines, 'Xsearchstatusline')
+  let buf = RunVimInTerminal('-S Xsearchstatusline', #{rows: 10})
+  call TermWait(buf)
+  call term_sendkeys(buf, "/something")
+  call VerifyScreenDump(buf, 'Test_searchstat_4', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+  call delete('Xsearchstatusline')
+endfunc
+
 func Test_search_stat_foldopen()
   CheckScreendump
 
@@ -319,30 +347,4 @@ func! Test_search_stat_screendump()
   call delete('Xsearchstat')
 endfunc
 
-func Test_searchcount_in_statusline()
-  CheckScreendump
-
-  let lines =<< trim END
-    set shortmess-=S
-    call append(0, 'this is something')
-    function TestSearchCount() abort
-      let search_count = searchcount()
-      if !empty(search_count)
-        return '[' . search_count.current . '/' . search_count.total . ']'
-      else
-        return ''
-      endif
-    endfunction
-    set hlsearch
-    set laststatus=2 statusline+=%{TestSearchCount()}
-  END
-  call writefile(lines, 'Xsearchstatusline')
-  let buf = RunVimInTerminal('-S Xsearchstatusline', #{rows: 10})
-  call TermWait(buf)
-  call term_sendkeys(buf, "/something")
-  call VerifyScreenDump(buf, 'Test_searchstat_4', {})
-
-  call term_sendkeys(buf, "\<Esc>")
-  call StopVimInTerminal(buf)
-  call delete('Xsearchstatusline')
-endfunc
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -1,0 +1,121 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed, exec, command = helpers.clear, helpers.feed, helpers.exec, helpers.command
+local poke_eventloop = helpers.poke_eventloop
+
+describe('search stat', function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(30, 10)
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [2] = {background = Screen.colors.Yellow},  -- Search
+      [3] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGrey},  -- Folded
+    })
+    screen:attach()
+  end)
+
+  it('right spacing with silent mapping vim-patch:8.1.1970', function()
+    exec([[
+      set shortmess-=S
+      " Append 50 lines with text to search for, "foobar" appears 20 times
+      call append(0, repeat(['foobar', 'foo', 'fooooobar', 'foba', 'foobar'], 20))
+      call setline(2, 'find this')
+      call setline(70, 'find this')
+      nnoremap n n
+      let @/ = 'find this'
+      call cursor(1,1)
+      norm n
+    ]])
+    screen:expect([[
+      foobar                        |
+      {2:^find this}                     |
+      fooooobar                     |
+      foba                          |
+      foobar                        |
+      foobar                        |
+      foo                           |
+      fooooobar                     |
+      foba                          |
+      /find this             [1/2]  |
+    ]])
+    command('nnoremap <silent> n n')
+    feed('gg0n')
+    screen:expect([[
+      foobar                        |
+      {2:^find this}                     |
+      fooooobar                     |
+      foba                          |
+      foobar                        |
+      foobar                        |
+      foo                           |
+      fooooobar                     |
+      foba                          |
+                             [1/2]  |
+    ]])
+  end)
+
+  it('when only match is in fold vim-patch:8.2.0840', function()
+    exec([[
+      set shortmess-=S
+      setl foldenable foldmethod=indent foldopen-=search
+      call append(0, ['if', "\tfoo", "\tfoo", 'endif'])
+      let @/ = 'foo'
+      call cursor(1,1)
+      norm n
+    ]])
+    screen:expect([[
+      if                            |
+      {3:^+--  2 lines: foo·············}|
+      endif                         |
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /foo                   [1/2]  |
+    ]])
+    feed('n')
+    poke_eventloop()
+    screen:expect_unchanged()
+    feed('n')
+    poke_eventloop()
+    screen:expect_unchanged()
+  end)
+
+  it('is cleared by gd and gD vim-patch:8.2.3583', function()
+    exec([[
+      call setline(1, ['int cat;', 'int dog;', 'cat = dog;'])
+      set shortmess-=S
+      set hlsearch
+    ]])
+    feed('/dog<CR>')
+    screen:expect([[
+      int cat;                      |
+      int {2:^dog};                      |
+      cat = {2:dog};                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /dog                   [1/2]  |
+    ]])
+    feed('G0gD')
+    screen:expect([[
+      int {2:^cat};                      |
+      int dog;                      |
+      {2:cat} = dog;                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:8.2.3583: the "gd" and "gD" commands do not update search stats

Problem:    The "gd" and "gD" commands do not update search stats. (Gary
            Johnson)
Solution:   Clear search stats.
https://github.com/vim/vim/commit/0c71114aede81a209b7efc126b4bf19f11d58955