### PR TITLE
vim-patch:8.2.{3121,3410}: two 'listchars' fixes

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4232,6 +4232,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
     // Show "extends" character from 'listchars' if beyond the line end and
     // 'list' is set.
     if (wp->w_p_lcs_chars.ext != NUL
+        && draw_state == WL_LINE
         && wp->w_p_list
         && !wp->w_p_wrap
         && filler_todo <= 0
@@ -4427,7 +4428,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
      */
     if ((wp->w_p_rl ? (col < 0) : (col >= grid->Columns))
         && foldinfo.fi_lines == 0
-        && (*ptr != NUL
+        && (draw_state != WL_LINE
+            || *ptr != NUL
             || filler_todo > 0
             || (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL
                 && p_extra != at_end_str)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3720,41 +3720,46 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
               tab_len += n_extra - tab_len;
             }
 
-            // if n_extra > 0, it gives the number of chars
+            // If n_extra > 0, it gives the number of chars
             // to use for a tab, else we need to calculate the width
-            // for a tab
+            // for a tab.
             int len = (tab_len * utf_char2len(wp->w_p_lcs_chars.tab2));
+            if (wp->w_p_lcs_chars.tab3) {
+              len += utf_char2len(wp->w_p_lcs_chars.tab3);
+            }
             if (n_extra > 0) {
               len += n_extra - tab_len;
             }
             c = wp->w_p_lcs_chars.tab1;
             p = xmalloc(len + 1);
-            memset(p, ' ', len);
-            p[len] = NUL;
-            xfree(p_extra_free);
-            p_extra_free = p;
-            for (i = 0; i < tab_len; i++) {
-              if (*p == NUL) {
-                tab_len = i;
-                break;
-              }
-              int lcs = wp->w_p_lcs_chars.tab2;
+            if (p == NULL) {
+              n_extra = 0;
+            } else {
+              memset(p, ' ', len);
+              p[len] = NUL;
+              xfree(p_extra_free);
+              p_extra_free = p;
+              for (i = 0; i < tab_len; i++) {
+                if (*p == NUL) {
+                  tab_len = i;
+                  break;
+                }
+                int lcs = wp->w_p_lcs_chars.tab2;
 
-              // if tab3 is given, need to change the char
-              // for tab
-              if (wp->w_p_lcs_chars.tab3 && i == tab_len - 1) {
-                lcs = wp->w_p_lcs_chars.tab3;
+                // if tab3 is given, use it for the last char
+                if (wp->w_p_lcs_chars.tab3 && i == tab_len - 1) {
+                  lcs = wp->w_p_lcs_chars.tab3;
+                }
+                p += utf_char2bytes(lcs, p);
+                n_extra += utf_char2len(lcs) - (saved_nextra > 0 ? 1 : 0);
               }
-              utf_char2bytes(lcs, p);
-              p += utf_char2len(lcs);
-              n_extra += utf_char2len(lcs) - (saved_nextra > 0 ? 1 : 0);
-            }
-            p_extra = p_extra_free;
+              p_extra = p_extra_free;
 
-            // n_extra will be increased by FIX_FOX_BOGUSCOLS
-            // macro below, so need to adjust for that here
-            if (vcol_off > 0) {
-              n_extra -= vcol_off;
+              // n_extra will be increased by FIX_FOX_BOGUSCOLS
+              // macro below, so need to adjust for that here
+              if (vcol_off > 0) {
+                n_extra -= vcol_off;
+              }
             }
           }
 

--- a/src/nvim/testdir/test_listchars.vim
+++ b/src/nvim/testdir/test_listchars.vim
@@ -1,6 +1,8 @@
 " Tests for 'listchars' display with 'list' and :list
 
+source check.vim
 source view_util.vim
+source screendump.vim
 
 func Test_listchars()
   enew!
@@ -516,5 +518,35 @@ func Test_listchars_window_local()
   %bw!
   set list& listchars&
 endfunc
+
+func Test_listchars_foldcolumn()
+  CheckScreendump
+
+  let lines =<< trim END
+      call setline(1, ['aaa', '', 'a', 'aaaaaa'])
+      vsplit
+      vsplit
+      windo set signcolumn=yes foldcolumn=1 winminwidth=0 nowrap list listchars=extends:>,precedes:<
+  END
+  call writefile(lines, 'XTest_listchars')
+
+  let buf = RunVimInTerminal('-S XTest_listchars', {'rows': 10, 'cols': 60})
+
+  call term_sendkeys(buf, "13\<C-W>>")
+  call VerifyScreenDump(buf, 'Test_listchars_01', {})
+  call term_sendkeys(buf, "\<C-W>>")
+  call VerifyScreenDump(buf, 'Test_listchars_02', {})
+  call term_sendkeys(buf, "\<C-W>>")
+  call VerifyScreenDump(buf, 'Test_listchars_03', {})
+  call term_sendkeys(buf, "\<C-W>>")
+  call VerifyScreenDump(buf, 'Test_listchars_04', {})
+  call term_sendkeys(buf, "\<C-W>>")
+  call VerifyScreenDump(buf, 'Test_listchars_05', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XTest_listchars')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_listlbr_utf8.vim
+++ b/src/nvim/testdir/test_listlbr_utf8.vim
@@ -69,6 +69,16 @@ func Test_nolinebreak_with_list()
   call s:close_windows()
 endfunc
 
+" this was causing a crash
+func Test_linebreak_with_list_and_tabs()
+  set linebreak list listchars=tab:⇤\ ⇥ tabstop=100
+  new
+  call setline(1, "\t\t\ttext")
+  redraw
+  bwipe!
+  set nolinebreak nolist listchars&vim tabstop=8
+endfunc
+
 func Test_linebreak_with_nolist()
   call s:test_windows('setl nolist')
   call setline(1, "\t*mask = nil;")


### PR DESCRIPTION
#### vim-patch:8.2.3121: 'listchars' "exceeds" character appears in foldcolumn

Problem:    'listchars' "exceeds" character appears in foldcolumn. Window
            separator is missing. (Leonid V.  Fedorenchik)
Solution:   Only draw the "exceeds" character in the text area.  Break the
            loop when not drawing the text.
https://github.com/vim/vim/commit/41fb723ee97baa2f095cde601a5a144b168b7a6b


#### vim-patch:8.2.3410: crash with linebreak, listchars and large tabstop

Problem:    Crash with linebreak, listchars and large tabstop.
Solution:   Account for different size listchars for a tab.
https://github.com/vim/vim/commit/89a54b413a8c96206ce7e038dde81a6eff6cd6b8