### PR TITLE
vim-patch:8.2.{3584,3586,3587}: :command "-keepscript" argument

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1434,6 +1434,9 @@ There are some special cases as well:
 	-register   The first argument to the command can be an optional
 		    register name (like :del, :put, :yank).
 	-buffer	    The command will only be available in the current buffer.
+	-keepscript Do not use the location of where the user command was
+		    defined for verbose messages, use the location of where
+		    the user command was invoked.
 
 In the cases of the -count and -register attributes, if the optional argument
 is supplied, it is removed from the argument list and is available to the

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -44,6 +44,7 @@ return {
     "count";
     "desc";
     "force";
+    "keepscript";
     "nargs";
     "range";
     "register";

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1510,6 +1510,12 @@ void add_user_command(String name, Object command, Dict(user_command) *opts, int
     goto err;
   }
 
+  if (api_object_to_bool(opts->keepscript, "keepscript", false, err)) {
+    argt |= EX_KEEPSCRIPT;
+  } else if (ERROR_SET(err)) {
+    goto err;
+  }
+
   bool force = api_object_to_bool(opts->force, "force", true, err);
   if (ERROR_SET(err)) {
     goto err;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1613,7 +1613,7 @@ void ex_compiler(exarg_T *eap)
       if (old_cur_comp != NULL) {
         old_cur_comp = vim_strsave(old_cur_comp);
       }
-      do_cmdline_cmd("command -nargs=* CompilerSet setlocal <args>");
+      do_cmdline_cmd("command -nargs=* -keepscript CompilerSet setlocal <args>");
     }
     do_unlet(S_LEN("g:current_compiler"), true);
     do_unlet(S_LEN("b:current_compiler"), true);

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -61,6 +61,7 @@
                                   // current buffer is locked
 #define EX_MODIFY       0x100000  // forbidden in non-'modifiable' buffer
 #define EX_FLAGS        0x200000  // allow flags after count in argument
+#define EX_KEEPSCRIPT  0x4000000  // keep sctx of where command was invoked
 #define EX_FILES (EX_XFILE | EX_EXTRA)  // multiple extra files allowed
 #define EX_FILE1 (EX_FILES | EX_NOSPC)  // 1 file, defaults to current file
 #define EX_WORD1 (EX_EXTRA | EX_NOSPC)  // one extra word allowed

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5517,6 +5517,8 @@ static int uc_scan_attr(char_u *attr, size_t len, uint32_t *argt, long *def, int
     *flags |= UC_BUFFER;
   } else if (STRNICMP(attr, "register", len) == 0) {
     *argt |= EX_REGSTR;
+  } else if (STRNICMP(attr, "keepscript", len) == 0) {
+    *argt |= EX_KEEPSCRIPT;
   } else if (STRNICMP(attr, "bar", len) == 0) {
     *argt |= EX_TRLBAR;
   } else {
@@ -6257,10 +6259,14 @@ static void do_ucmd(exarg_T *eap)
     buf = xmalloc(totlen + 1);
   }
 
-  current_sctx.sc_sid = cmd->uc_script_ctx.sc_sid;
+  if ((cmd->uc_argt & EX_KEEPSCRIPT) == 0) {
+    current_sctx.sc_sid = cmd->uc_script_ctx.sc_sid;
+  }
   (void)do_cmdline(buf, eap->getline, eap->cookie,
                    DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED);
-  current_sctx = save_current_sctx;
+  if ((cmd->uc_argt & EX_KEEPSCRIPT) == 0) {
+    current_sctx = save_current_sctx;
+  }
   xfree(buf);
   xfree(split_buf);
 }
@@ -6306,7 +6312,7 @@ char_u *get_user_cmd_flags(expand_T *xp, int idx)
 {
   static char *user_cmd_flags[] = { "addr",   "bang",     "bar",
                                     "buffer", "complete", "count",
-                                    "nargs",  "range",    "register" };
+                                    "nargs",  "range",    "register", "keepscript" };
 
   if (idx >= (int)ARRAY_SIZE(user_cmd_flags)) {
     return NULL;
@@ -9846,6 +9852,7 @@ Dictionary commands_array(buf_T *buf)
     PUT(d, "bang", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_BANG)));
     PUT(d, "bar", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_TRLBAR)));
     PUT(d, "register", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_REGSTR)));
+    PUT(d, "keepscript", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_KEEPSCRIPT)));
 
     switch (cmd->uc_argt & (EX_EXTRA | EX_NOSPC | EX_NEEDARG)) {
     case 0:

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -19,6 +19,9 @@ func Test_compiler()
   call assert_equal('perl', b:current_compiler)
   call assert_fails('let g:current_compiler', 'E121:')
 
+  let verbose_efm = execute('verbose set efm')
+  call assert_match('Last set from .*/compiler/perl.vim ', verbose_efm)
+
   call setline(1, ['#!/usr/bin/perl -w', 'use strict;', 'my $foo=1'])
   w!
   call feedkeys(":make\<CR>\<CR>", 'tx')

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -20,7 +20,7 @@ func Test_compiler()
   call assert_fails('let g:current_compiler', 'E121:')
 
   let verbose_efm = execute('verbose set efm')
-  call assert_match('Last set from .*/compiler/perl.vim ', verbose_efm)
+  call assert_match('Last set from .*[/\\]compiler[/\\]perl.vim ', verbose_efm)
 
   call setline(1, ['#!/usr/bin/perl -w', 'use strict;', 'my $foo=1'])
   w!

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -269,10 +269,10 @@ endfunc
 
 func Test_CmdCompletion()
   call feedkeys(":com -\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"com -addr bang bar buffer complete count nargs range register', @:)
+  call assert_equal('"com -addr bang bar buffer complete count keepscript nargs range register', @:)
 
   call feedkeys(":com -nargs=0 -\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"com -nargs=0 -addr bang bar buffer complete count nargs range register', @:)
+  call assert_equal('"com -nargs=0 -addr bang bar buffer complete count keepscript nargs range register', @:)
 
   call feedkeys(":com -nargs=\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -nargs=* + 0 1 ?', @:)

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -16,8 +16,8 @@ local feed = helpers.feed
 local funcs = helpers.funcs
 
 describe('nvim_get_commands', function()
-  local cmd_dict  = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='echo "Hello World"', name='Hello', nargs='1', range=NIL, register=false, script_id=0, }
-  local cmd_dict2 = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='pwd',                name='Pwd',   nargs='?', range=NIL, register=false, script_id=0, }
+  local cmd_dict  = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='echo "Hello World"', name='Hello', nargs='1', range=NIL, register=false, keepscript=false, script_id=0, }
+  local cmd_dict2 = { addr=NIL, bang=false, bar=false, complete=NIL, complete_arg=NIL, count=NIL, definition='pwd',                name='Pwd',   nargs='?', range=NIL, register=false, keepscript=false, script_id=0, }
   before_each(clear)
 
   it('gets empty list if no commands were defined', function()
@@ -59,11 +59,11 @@ describe('nvim_get_commands', function()
   end)
 
   it('gets various command attributes', function()
-    local cmd0 = { addr='arguments', bang=false, bar=false, complete='dir',    complete_arg=NIL,         count='10', definition='pwd <args>',                    name='TestCmd', nargs='1', range='10', register=false, script_id=0, }
-    local cmd1 = { addr=NIL,         bang=false, bar=false, complete='custom', complete_arg='ListUsers', count=NIL,  definition='!finger <args>',                name='Finger',  nargs='+', range=NIL,  register=false, script_id=1, }
-    local cmd2 = { addr=NIL,         bang=true,  bar=false, complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253R2_foo(<q-args>)', name='Cmd2',    nargs='*', range=NIL,  register=false, script_id=2, }
-    local cmd3 = { addr=NIL,         bang=false, bar=true,  complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253R3_ohyeah()',      name='Cmd3',    nargs='0', range=NIL,  register=false, script_id=3, }
-    local cmd4 = { addr=NIL,         bang=false, bar=false, complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253R4_just_great()',  name='Cmd4',    nargs='0', range=NIL,  register=true,  script_id=4, }
+    local cmd0 = { addr='arguments', bang=false, bar=false, complete='dir',    complete_arg=NIL,         count='10', definition='pwd <args>',                    name='TestCmd', nargs='1', range='10', register=false, keepscript=false, script_id=0, }
+    local cmd1 = { addr=NIL,         bang=false, bar=false, complete='custom', complete_arg='ListUsers', count=NIL,  definition='!finger <args>',                name='Finger',  nargs='+', range=NIL,  register=false, keepscript=false, script_id=1, }
+    local cmd2 = { addr=NIL,         bang=true,  bar=false, complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253R2_foo(<q-args>)', name='Cmd2',    nargs='*', range=NIL,  register=false, keepscript=false, script_id=2, }
+    local cmd3 = { addr=NIL,         bang=false, bar=true,  complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253R3_ohyeah()',      name='Cmd3',    nargs='0', range=NIL,  register=false, keepscript=false, script_id=3, }
+    local cmd4 = { addr=NIL,         bang=false, bar=false, complete=NIL,      complete_arg=NIL,         count=NIL,  definition='call \128\253R4_just_great()',  name='Cmd4',    nargs='0', range=NIL,  register=true,  keepscript=false, script_id=4, }
     source([[
       command -complete=custom,ListUsers -nargs=+ Finger !finger <args>
     ]])


### PR DESCRIPTION
#### vim-patch:8.2.3584: "verbose set efm" reports location of the :compiler command

Problem:    "verbose set efm" reports the location of the :compiler command.
            (Gary Johnson)
Solution:   Add the "-keepscript" argument to :command and use it when
            defining CompilerSet.
https://github.com/vim/vim/commit/58ef8a31d7087d495ab1582be5b7a22796ac2451


#### vim-patch:8.2.3586: command completion test fails

Problem:    Command completion test fails.
Solution:   Add new argument to expected output
https://github.com/vim/vim/commit/326e7da609a1b115b0ed535e89e970afebe99e35


#### vim-patch:8.2.3587: compiler test fails with backslash file separator

Problem:    Compiler test fails with backslash file separator.
Solution:   Accept slash and backslash.
https://github.com/vim/vim/commit/0a15c7676bccb0c9483579106318e785c6e40a7f