### PR TITLE
vim-patch:8.2.4160: cannot change the register used for Select mode d…

### DIFF
--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -478,6 +478,10 @@ Commands in Select mode:
 - ESC stops Select mode.
 - CTRL-O switches to Visual mode for the duration of one command. *v_CTRL-O*
 - CTRL-G switches to Visual mode.
+- CTRL-R {register} selects the register to be used for the text that is
+  deleted when typing text.					  *v_CTRL-R*
+  Unless you specify the "_" (black hole) register, the unnamed register is
+  also overwritten.
 
 Otherwise, typed characters are handled as in Visual mode.
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -524,6 +524,8 @@ EXTERN pos_T VIsual;
 EXTERN int VIsual_active INIT(= false);
 /// Whether Select mode is active.
 EXTERN int VIsual_select INIT(= false);
+/// Register name for Select mode
+EXTERN int VIsual_select_reg INIT(= 0);
 /// Restart Select mode when next cmd finished
 EXTERN int restart_VIsual_select INIT(= 0);
 /// Whether to restart the selection after a Select-mode mapping or menu.

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1435,6 +1435,11 @@ int op_delete(oparg_T *oap)
     return FAIL;
   }
 
+  if (VIsual_select && oap->is_VIsual) {
+    // Use the register given with CTRL_R, defaults to zero
+    oap->regname = VIsual_select_reg;
+  }
+
   mb_adjust_opend(oap);
 
   /*

--- a/src/nvim/testdir/test_selectmode.vim
+++ b/src/nvim/testdir/test_selectmode.vim
@@ -1,0 +1,57 @@
+" Test for Select-mode
+
+source shared.vim
+
+" Test for selecting a register with CTRL-R
+func Test_selectmode_register()
+  new
+
+  " Default behavior: use unnamed register
+  call setline(1, 'foo')
+  call setreg('"', 'bar')
+  call setreg('a', 'baz')
+  exe ":norm! v\<c-g>a"
+  call assert_equal(getline('.'), 'aoo')
+  call assert_equal('f', getreg('"'))
+  call assert_equal('baz', getreg('a'))
+
+  " Use the black hole register
+  call setline(1, 'foo')
+  call setreg('"', 'bar')
+  call setreg('a', 'baz')
+  exe ":norm! v\<c-g>\<c-r>_a"
+  call assert_equal(getline('.'), 'aoo')
+  call assert_equal('bar', getreg('"'))
+  call assert_equal('baz', getreg('a'))
+
+  " Invalid register: use unnamed register
+  call setline(1, 'foo')
+  call setreg('"', 'bar')
+  call setreg('a', 'baz')
+  exe ":norm! v\<c-g>\<c-r>?a"
+  call assert_equal(getline('.'), 'aoo')
+  call assert_equal('f', getreg('"'))
+  call assert_equal('baz', getreg('a'))
+
+  " Use unnamed register
+  call setline(1, 'foo')
+  call setreg('"', 'bar')
+  call setreg('a', 'baz')
+  exe ":norm! v\<c-g>\<c-r>\"a"
+  call assert_equal(getline('.'), 'aoo')
+  call assert_equal('f', getreg('"'))
+  call assert_equal('baz', getreg('a'))
+
+  " use specicifed register, unnamed register is also written
+  call setline(1, 'foo')
+  call setreg('"', 'bar')
+  call setreg('a', 'baz')
+  exe ":norm! v\<c-g>\<c-r>aa"
+  call assert_equal(getline('.'), 'aoo')
+  call assert_equal('f', getreg('"'))
+  call assert_equal('f', getreg('a'))
+
+  bw!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Cannot change the register used for Select mode delete.
Solution:   Make CTRL-R set the register to be used when deleting text for
            Select mode. (Shougo Matsushita, closes vim/vim#9531)
https://github.com/vim/vim/commit/4ede01f18884961f2e008880b4964e5d61ea5c36

Continues of https://github.com/neovim/neovim/pull/17096