### PR TITLE
vim-patch:8.2.3095: with 'virtualedit' set to "block" block selection is wrong

### DIFF
--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1124,6 +1124,9 @@ func Test_visual_block_with_virtualedit()
   call term_sendkeys(buf, "\<C-V>gg$")
   call VerifyScreenDump(buf, 'Test_visual_block_with_virtualedit', {})
 
+  call term_sendkeys(buf, "\<Esc>gg\<C-V>G$")
+  call VerifyScreenDump(buf, 'Test_visual_block_with_virtualedit2', {})
+
   " clean up
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)

--- a/test/functional/legacy/visual_mode_spec.lua
+++ b/test/functional/legacy/visual_mode_spec.lua
@@ -1,5 +1,3 @@
--- Test visual line mode selection redraw after scrolling
-
 local helpers = require('test.functional.helpers')(after_each)
 
 local Screen = require('test.functional.ui.screen')
@@ -10,6 +8,7 @@ local feed_command = helpers.feed_command
 local funcs = helpers.funcs
 local meths = helpers.meths
 local eq = helpers.eq
+local exec = helpers.exec
 
 describe('visual line mode', function()
   local screen
@@ -37,6 +36,47 @@ describe('visual line mode', function()
       ^g                             |
       }                             |
       {1:-- VISUAL LINE --}             |
+    ]])
+  end)
+end)
+
+describe('visual block mode', function()
+  it('shows selection correctly with virtualedit=block', function()
+    clear()
+    local screen = Screen.new(30, 7)
+    screen:set_default_attr_ids({
+      [1] = {bold = true},  -- ModeMsg
+      [2] = {background = Screen.colors.LightGrey},  -- Visual
+      [3] = {foreground = Screen.colors.Blue, bold = true}  -- NonText
+    })
+    screen:attach()
+
+    exec([[
+      call setline(1, ['aaaaaa', 'bbbb', 'cc'])
+      set virtualedit=block
+      normal G
+    ]])
+
+    feed('<C-V>gg$')
+    screen:expect([[
+      {2:aaaaaa}^                        |
+      {2:bbbb   }                       |
+      {2:cc     }                       |
+      {3:~                             }|
+      {3:~                             }|
+      {3:~                             }|
+      {1:-- VISUAL BLOCK --}            |
+    ]])
+
+    feed('<Esc>gg<C-V>G$')
+    screen:expect([[
+      {2:aaaaaa }                       |
+      {2:bbbb   }                       |
+      {2:cc}^ {2:    }                       |
+      {3:~                             }|
+      {3:~                             }|
+      {3:~                             }|
+      {1:-- VISUAL BLOCK --}            |
     ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.3095: with 'virtualedit' set to "block" block selection is wrong

Problem:    With 'virtualedit' set to "block" block selection is wrong after
            using "$".  (Marco Trosi)
Solution:   Compute the longest selected line.
https://github.com/vim/vim/commit/b17ab86e7b8712206aa9ea7198c28db969e25936