### PR TITLE
vim-patch:8.2.4187: gnuplot file not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -710,7 +710,7 @@ au BufNewFile,BufRead gitolite.conf		setf gitolite
 au BufNewFile,BufRead {,.}gitolite.rc,example.gitolite.rc	setf perl
 
 " Gnuplot scripts
-au BufNewFile,BufRead *.gpi			setf gnuplot
+au BufNewFile,BufRead *.gpi,.gnuplot		setf gnuplot
 
 " Go (Google)
 au BufNewFile,BufRead *.go			setf go

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -230,6 +230,7 @@ local extension = {
   gemini = "gemtext",
   gift = "gift",
   gpi = "gnuplot",
+  gnuplot = "gnuplot",
   go = "go",
   gp = "gp",
   gs = "grads",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -203,7 +203,7 @@ let s:filename_checks = {
     \ 'gitsendemail': ['.gitsendemail.msg.xxxxxx'],
     \ 'gkrellmrc': ['gkrellmrc', 'gkrellmrc_x'],
     \ 'gnash': ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
-    \ 'gnuplot': ['file.gpi'],
+    \ 'gnuplot': ['file.gpi', '.gnuplot'],
     \ 'go': ['file.go'],
     \ 'gomod': ['go.mod'],
     \ 'gp': ['file.gp', '.gprc'],


### PR DESCRIPTION
Problem:    Gnuplot file not recognized.
Solution:   Recognize ".gnuplot". (closes vim/vim#9588)
https://github.com/vim/vim/commit/ff5cbe8133c6eb5dd86b9e042f32f589627e9bf9