### PR TITLE
vim-patch:8.2.4191: json5 files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -882,6 +882,9 @@ au BufNewFile,BufRead *.jov,*.j73,*.jovial	setf jovial
 " JSON
 au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest	setf json
 
+" JSON5
+au BufNewFile,BufRead *.json5			setf json5
+
 " JSON Patch (RFC 6902)
 au BufNewFile,BufRead *.json-patch			setf json
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -293,6 +293,7 @@ local extension = {
   webmanifest = "json",
   ipynb = "json",
   ["json-patch"] = "json",
+  json5 = "json5",
   jsonc = "jsonc",
   jsp = "jsp",
   jl = "julia",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -265,6 +265,7 @@ let s:filename_checks = {
     \ 'jovial': ['file.jov', 'file.j73', 'file.jovial'],
     \ 'jproperties': ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file'],
     \ 'json': ['file.json', 'file.jsonp', 'file.json-patch', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb', '.babelrc', '.eslintrc', '.prettierrc', '.firebaserc', 'file.slnf'],
+    \ 'json5': ['file.json5'],
     \ 'jsonc': ['file.jsonc'],
     \ 'jsp': ['file.jsp'],
     \ 'julia': ['file.jl'],


### PR DESCRIPTION
Problem:    json5 files are not recognized.
Solution:   Add a pattern for json5 files. (closes vim/vim#9601)
https://github.com/vim/vim/commit/e15ebeffb35da4bb7d9054358671735ce6988c28
