### PR TITLE
vim-patch:8.2.4190: all conceal tests are skipped without the screendumps feature

### DIFF
--- a/src/nvim/testdir/test_conceal.vim
+++ b/src/nvim/testdir/test_conceal.vim
@@ -4,10 +4,10 @@ source check.vim
 CheckFeature conceal
 
 source screendump.vim
-" CheckScreendump
 
 func Test_conceal_two_windows()
   CheckScreendump
+
   let code =<< trim [CODE]
     let lines = ["one one one one one", "two |hidden| here", "three |hidden| three"]
     call setline(1, lines)
@@ -111,6 +111,7 @@ endfunc
 
 func Test_conceal_with_cursorline()
   CheckScreendump
+
   " Opens a help window, where 'conceal' is set, switches to the other window
   " where 'cursorline' needs to be updated when the cursor moves.
   let code =<< trim [CODE]
@@ -139,6 +140,7 @@ endfunc
 
 func Test_conceal_resize_term()
   CheckScreendump
+
   let code =<< trim [CODE]
     call setline(1, '`one` `two` `three` `four` `five`, the backticks should be concealed')
     setl cocu=n cole=3


### PR DESCRIPTION
#### vim-patch:8.2.4190: all conceal tests are skipped without the screendumps feature

Problem:    All conceal tests are skipped without the screendumps feature.
Solution:   Only skip the tests that use screendumps. (closes vim/vim#9599)
https://github.com/vim/vim/commit/206919191fe1881dea00d60d392cc68a07c0106f