### PR TITLE
vim-patch:8.2.{3993,4002}: when recording a change in Select mode char appears twice

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -984,7 +984,7 @@ int ins_typebuf(char_u *str, int noremap, int offset, bool nottyped, bool silent
 /// @return the length of what was inserted
 int ins_char_typebuf(int c, int modifier)
 {
-  char_u buf[MB_MAXBYTES + 4];
+  char_u buf[MB_MAXBYTES * 3 + 4];
   int len = 0;
   if (modifier != 0) {
     buf[0] = K_SPECIAL;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1010,7 +1010,12 @@ static int normal_execute(VimState *state, int key)
     // restart automatically.
     // Insert the typed character in the typeahead buffer, so that it can
     // be mapped in Insert mode.  Required for ":lmap" to work.
-    ins_char_typebuf(s->c, mod_mask);
+    int len = ins_char_typebuf(s->c, mod_mask);
+
+    // When recording the character will be recorded again, remove the
+    // previously recording.
+    ungetchars(len);
+
     if (restart_edit != 0) {
       s->c = 'd';
     } else {

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -121,6 +121,17 @@ func Test_recording_esc_sequence()
   endif
 endfunc
 
+func Test_recording_with_select_mode()
+  new
+  call feedkeys("qacc12345\<Esc>gH98765\<Esc>q", "tx")
+  call assert_equal("98765", getline(1))
+  call assert_equal("cc12345\<Esc>gH98765\<Esc>", @a)
+  call setline(1, 'asdf')
+  normal! @a
+  call assert_equal("98765", getline(1))
+  bwipe!
+endfunc
+
 " Test for executing the last used register (@)
 func Test_last_used_exec_reg()
   " Test for the @: command

--- a/src/nvim/testdir/test_utf8.vim
+++ b/src/nvim/testdir/test_utf8.vim
@@ -1,5 +1,6 @@
 " Tests for Unicode manipulations
  
+source check.vim
 source view_util.vim
 
 " Visual block Insert adjusts for multi-byte char
@@ -146,6 +147,57 @@ func Test_print_overlong()
   s/x/\=nr2char(1629)/g
   print
   bwipe!
+endfunc
+
+func Test_recording_with_select_mode_utf8()
+  call Run_test_recording_with_select_mode_utf8()
+endfunc
+
+func Run_test_recording_with_select_mode_utf8()
+  new
+
+  " No escaping
+  call feedkeys("qacc12345\<Esc>gH哦\<Esc>q", "tx")
+  call assert_equal("哦", getline(1))
+  call assert_equal("cc12345\<Esc>gH哦\<Esc>", @a)
+  call setline(1, 'asdf')
+  normal! @a
+  call assert_equal("哦", getline(1))
+
+  " 固 is 0xE5 0x9B 0xBA where 0x9B is CSI
+  call feedkeys("qacc12345\<Esc>gH固\<Esc>q", "tx")
+  call assert_equal("固", getline(1))
+  call assert_equal("cc12345\<Esc>gH固\<Esc>", @a)
+  call setline(1, 'asdf')
+  normal! @a
+  call assert_equal("固", getline(1))
+
+  " 四 is 0xE5 0x9B 0x9B where 0x9B is CSI
+  call feedkeys("qacc12345\<Esc>gH四\<Esc>q", "tx")
+  call assert_equal("四", getline(1))
+  call assert_equal("cc12345\<Esc>gH四\<Esc>", @a)
+  call setline(1, 'asdf')
+  normal! @a
+  call assert_equal("四", getline(1))
+
+  " 倒 is 0xE5 0x80 0x92 where 0x80 is K_SPECIAL
+  call feedkeys("qacc12345\<Esc>gH倒\<Esc>q", "tx")
+  call assert_equal("倒", getline(1))
+  call assert_equal("cc12345\<Esc>gH倒\<Esc>", @a)
+  call setline(1, 'asdf')
+  normal! @a
+  call assert_equal("倒", getline(1))
+
+  bwipe!
+endfunc
+
+" This must be done as one of the last tests, because it starts the GUI, which
+" cannot be undone.
+func Test_zz_recording_with_select_mode_utf8_gui()
+  CheckCanRunGui
+
+  gui -f
+  call Run_test_recording_with_select_mode_utf8()
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3993: when recording a change in Select mode char appears twice

Problem:    When recording a change in Select mode the first typed character
            appears twice.
Solution:   When putting the character back into typeahead remove it from
            recorded characters.
https://github.com/vim/vim/commit/c88e977862ba6477a3b5b28706c45f96069a3073


#### vim-patch:8.2.4002: first char typed in Select mode can be wrong

Problem:    First char typed in Select mode can be wrong.
Solution:   Escape special bytes in the input buffer. (closes vim/vim#9469)
https://github.com/vim/vim/commit/6cac77016b1636e04073e8348b7cee02259ef928

The `buf` should already be large enough, but I'll change its size
anyway in case future patches change the meaning of `MB_MAXBYTES` macro.

`fix_input_buffer()` cannot be used here because of the `using_script()`
check, and there is already equivalent code in its place.