### PR TITLE
feat(highlight): ns=0 to set :highlight namespace

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -31,6 +31,7 @@
 #include "nvim/fileio.h"
 #include "nvim/getchar.h"
 #include "nvim/highlight.h"
+#include "nvim/highlight_defs.h"
 #include "nvim/lua/executor.h"
 #include "nvim/mark.h"
 #include "nvim/memline.h"
@@ -121,7 +122,9 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 
 /// Set a highlight group.
 ///
-/// @param ns_id number of namespace for this highlight
+/// @param ns_id number of namespace for this highlight. Use value 0
+///              to set a highlight group in the global (`:highlight`)
+///              namespace.
 /// @param name highlight group name, like ErrorMsg
 /// @param val highlight definition map, like |nvim_get_hl_by_name|.
 ///            in addition the following keys are also recognized:
@@ -135,18 +138,23 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///                               same as attributes of gui color
 /// @param[out] err Error details, if any
 ///
-/// TODO: ns_id = 0, should modify :highlight namespace
-/// TODO val should take update vs reset flag
+// TODO(bfredl): val should take update vs reset flag
 void nvim_set_hl(Integer ns_id, String name, Dictionary val, Error *err)
   FUNC_API_SINCE(7)
 {
   int hl_id = syn_check_group(name.data, (int)name.size);
   int link_id = -1;
 
-  HlAttrs attrs = dict2hlattrs(val, true, &link_id, err);
-  if (!ERROR_SET(err)) {
-    ns_hl_def((NS)ns_id, hl_id, attrs, link_id);
+  HlAttrNames *names = NULL;  // Only used when setting global namespace
+  if (ns_id == 0) {
+    names = xmalloc(sizeof(*names));
+    *names = HLATTRNAMES_INIT;
   }
+  HlAttrs attrs = dict2hlattrs(val, true, &link_id, names, err);
+  if (!ERROR_SET(err)) {
+    ns_hl_def((NS)ns_id, hl_id, attrs, link_id, names);
+  }
+  xfree(names);
 }
 
 /// Set active namespace for highlights.

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -46,6 +46,18 @@ typedef struct attr_entry {
   .hl_blend = -1, \
 }
 
+typedef struct {
+  char *bg_name;
+  char *fg_name;
+  char *sp_name;
+} HlAttrNames;
+
+#define HLATTRNAMES_INIT (HlAttrNames) { \
+  .bg_name = NULL, \
+  .fg_name = NULL, \
+  .sp_name = NULL, \
+}
+
 /// Values for index in highlight_attr[].
 /// When making changes, also update hlf_names below!
 typedef enum {

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -3,6 +3,7 @@ local clear, nvim = helpers.clear, helpers.nvim
 local Screen = require('test.functional.ui.screen')
 local eq, eval = helpers.eq, helpers.eval
 local command = helpers.command
+local exec_capture = helpers.exec_capture
 local meths = helpers.meths
 local funcs = helpers.funcs
 local pcall_err = helpers.pcall_err
@@ -251,5 +252,24 @@ describe("API: set highlight", function()
     meths.set_hl(ns, 'Test_hl', highlight3_config)
     eq(highlight3_result_gui, meths.get_hl_by_name('Test_hl', true))
     eq(highlight3_result_cterm, meths.get_hl_by_name('Test_hl', false))
+  end)
+
+  it ("can set a highlight in the global namespace", function()
+    meths.set_hl(0, 'Test_hl', highlight2_config)
+    eq('Test_hl        xxx cterm=underline,reverse ctermfg=8 ctermbg=15 gui=underline,reverse',
+      exec_capture('highlight Test_hl'))
+
+    meths.set_hl(0, 'Test_hl', { background = highlight_color.bg })
+    eq('Test_hl        xxx guibg=#0032aa',
+      exec_capture('highlight Test_hl'))
+
+    meths.set_hl(0, 'Test_hl2', highlight3_config)
+    eq('Test_hl2       xxx cterm=undercurl,italic,reverse ctermfg=8 ctermbg=15 gui=bold,underline,undercurl,italic,reverse guifg=#ff0000 guibg=#0032aa',
+      exec_capture('highlight Test_hl2'))
+
+    -- Colors are stored exactly as they are defined.
+    meths.set_hl(0, 'Test_hl3', { bg = 'reD', fg = 'bLue'})
+    eq('Test_hl3       xxx guifg=bLue guibg=reD',
+      exec_capture('highlight Test_hl3'))
   end)
 end)


### PR DESCRIPTION
Passing ns=0 to nvim_set_hl will alter the `:highlight` namespace.
