### PR TITLE
fix: set RedrawingDisabled before entering aucmd_win

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1160,7 +1160,10 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     // Prevent chdir() call in win_enter_ext(), through do_autochdir()
     int save_acd = p_acd;
     p_acd = false;
+    // no redrawing and don't set the window title
+    RedrawingDisabled++;
     win_enter(aucmd_win, false);
+    RedrawingDisabled--;
     p_acd = save_acd;
     unblock_autocmds();
     curwin = aucmd_win;

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -6,6 +6,7 @@ local insert = helpers.insert
 local eq = helpers.eq
 local eval = helpers.eval
 local iswin = helpers.iswin
+local funcs, meths, exec_lua = helpers.funcs, helpers.meths, helpers.exec_lua
 
 describe('screen', function()
   local screen
@@ -127,12 +128,65 @@ local function screen_tests(linegrid)
     end)
 
     it('has correct default title with named file', function()
-      local expected = (iswin() and 'myfile (C:\\mydir) - NVIM'
-                                 or 'myfile (/mydir) - NVIM')
+      local expected = (iswin() and 'myfile (C:\\mydir) - NVIM' or 'myfile (/mydir) - NVIM')
       command('set title')
       command(iswin() and 'file C:\\mydir\\myfile' or 'file /mydir/myfile')
       screen:expect(function()
         eq(expected, screen.title)
+      end)
+    end)
+
+    describe('is not changed by', function()
+      local file1 = iswin() and 'C:\\mydir\\myfile1' or '/mydir/myfile1'
+      local file2 = iswin() and 'C:\\mydir\\myfile2' or '/mydir/myfile2'
+      local expected = (iswin() and 'myfile1 (C:\\mydir) - NVIM' or 'myfile1 (/mydir) - NVIM')
+      local buf2
+
+      before_each(function()
+        command('edit '..file1)
+        buf2 = funcs.bufadd(file2)
+        command('set title')
+      end)
+
+      it('calling setbufvar() to set an option in a hidden buffer from i_CTRL-R', function()
+        command([[inoremap <F2> <C-R>=setbufvar(]]..buf2..[[, '&autoindent', 1) ? '' : ''<CR>]])
+        feed('i<F2><Esc>')
+        command('redraw!')
+        screen:expect(function()
+          eq(expected, screen.title)
+        end)
+      end)
+
+      it('an RPC call to nvim_buf_set_option in a hidden buffer', function()
+        meths.buf_set_option(buf2, 'autoindent', true)
+        command('redraw!')
+        screen:expect(function()
+          eq(expected, screen.title)
+        end)
+      end)
+
+      it('a Lua callback calling nvim_buf_set_option in a hidden buffer', function()
+        exec_lua(string.format([[
+          vim.schedule(function()
+            vim.api.nvim_buf_set_option(%d, 'autoindent', true)
+          end)
+        ]], buf2))
+        command('redraw!')
+        screen:expect(function()
+          eq(expected, screen.title)
+        end)
+      end)
+
+      it('a Lua callback calling nvim_buf_call in a hidden buffer', function()
+        exec_lua(string.format([[
+          vim.schedule(function()
+            vim.api.nvim_buf_call(%d, function() end)
+          end)
+        ]], buf2))
+        command('redraw!')
+        screen:expect(function()
+          eq(expected, screen.title)
+        end)
       end)
     end)
   end)


### PR DESCRIPTION
Fix #17176

This is similar to Vim patch 8.2.4208 (<https://github.com/vim/vim/commit/dff97e65eb1bb24c44c2b7430a480888d8afb3f4>). That patch cannot be fully ported because it also makes a change to `Test_state()` which hasn't been ported yet, and the new test it introduced is skipped anyway, so I'll just leave it for later porting.