### PR TITLE
refactor: include missing assert header

### DIFF
--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -2,6 +2,7 @@
 #define NVIM_MARKTREE_H
 
 #include <stdint.h>
+#include <assert.h>
 
 #include "nvim/assert.h"
 #include "nvim/garray.h"


### PR DESCRIPTION
This will solve the "implicit declaration of function ‘assert’" warning
when running "make lint".
