### PR TITLE
feat(terminal): respond to OSC background and foreground request

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -287,6 +287,8 @@ The following new APIs and features were added.
 • Terminal buffers emit a |TermRequest| autocommand event when the child
   process emits an OSC or DCS control sequence.
 
+• Terminal buffers respond to OSC background and foreground requests. |default-autocmds|
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -145,6 +145,12 @@ nvim_terminal:
 - BufReadCmd: Treats "term://" buffers as |terminal| buffers. |terminal-start|
 - TermClose: A |terminal| buffer started with no arguments (which thus uses
   'shell') and which exits with no error is closed automatically.
+- TermRequest: The terminal emulator responds to OSC background and foreground
+  requests, indicating (1) a black background and white foreground when Nvim
+  option 'background' is "dark" or (2) a white background and black foreground
+  when 'background' is "light". While this may not reflect the actual
+  foreground/background color, it permits 'background' to be retained for a
+  nested Nvim instance running in the terminal emulator.
 
 nvim_cmdwin:
 - CmdwinEnter: Limits syntax sync to maxlines=1 in the |cmdwin|.

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1369,12 +1369,19 @@ describe('inccommand on ex mode', function()
     local screen
     screen = Screen.new(60, 10)
     screen:attach()
-    local id = fn.termopen(
-      { nvim_prog, '-u', 'NONE', '-c', 'set termguicolors', '-E', 'test/README.md' },
-      {
-        env = { VIMRUNTIME = os.getenv('VIMRUNTIME') },
-      }
-    )
+    local id = fn.termopen({
+      nvim_prog,
+      '-u',
+      'NONE',
+      '-i',
+      'NONE',
+      '-c',
+      'set termguicolors background=dark',
+      '-E',
+      'test/README.md',
+    }, {
+      env = { VIMRUNTIME = os.getenv('VIMRUNTIME') },
+    })
     fn.chansend(id, '%s/N')
     screen:expect {
       grid = [[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -8,6 +8,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local Screen = require('test.functional.ui.screen')
 local eq = helpers.eq
+local feed_command = helpers.feed_command
 local feed_data = thelpers.feed_data
 local clear = helpers.clear
 local command = helpers.command
@@ -2126,7 +2127,7 @@ describe('TUI FocusGained/FocusLost', function()
       '--cmd',
       'colorscheme vim',
       '--cmd',
-      'set noswapfile noshowcmd noruler notermguicolors',
+      'set noswapfile noshowcmd noruler notermguicolors background=dark',
     })
 
     screen:expect([[
@@ -2776,10 +2777,73 @@ describe('TUI', function()
 end)
 
 describe('TUI bg color', function()
-  local screen
+  before_each(clear)
 
-  local function setup_bg_test()
-    clear()
+  local attr_ids = {
+    [1] = { reverse = true },
+    [2] = { bold = true },
+    [3] = { reverse = true, bold = true },
+    [4] = { foreground = tonumber('0x00000a') },
+  }
+
+  it('is properly set in a nested Nvim instance when background=dark', function()
+    command('highlight clear Normal')
+    command('set background=dark') -- set outer Nvim background
+    local screen = thelpers.setup_child_nvim({
+      '-u',
+      'NONE',
+      '-i',
+      'NONE',
+      '--cmd',
+      'colorscheme vim',
+      '--cmd',
+      'set noswapfile',
+    })
+    screen:set_default_attr_ids(attr_ids)
+    retry(nil, 30000, function() -- wait for automatic background processing
+      screen:sleep(20)
+      feed_command('set background?') -- check nested Nvim background
+      screen:expect([[
+      {1: }                                                 |
+      {2:~}                                                 |
+      {2:~}                                                 |
+      {2:~}                                                 |
+      {3:[No Name]                       0,0-1          All}|
+        background=dark                                 |
+      {4:-- TERMINAL --}                                    |
+      ]])
+    end)
+  end)
+
+  it('is properly set in a nested Nvim instance when background=light', function()
+    command('highlight clear Normal')
+    command('set background=light') -- set outer Nvim background
+    local screen = thelpers.setup_child_nvim({
+      '-u',
+      'NONE',
+      '-i',
+      'NONE',
+      '--cmd',
+      'colorscheme vim',
+      '--cmd',
+      'set noswapfile',
+    })
+    retry(nil, 30000, function() -- wait for automatic background processing
+      screen:sleep(20)
+      feed_command('set background?') -- check nested Nvim background
+      screen:expect([[
+      {1: }                                                 |
+      {3:~}                                                 |
+      {3:~}                                                 |
+      {3:~}                                                 |
+      {5:[No Name]                       0,0-1          All}|
+        background=light                                |
+      {3:-- TERMINAL --}                                    |
+      ]])
+    end)
+  end)
+
+  it('queries the terminal for background color', function()
     exec_lua([[
       vim.api.nvim_create_autocmd('TermRequest', {
         callback = function(args)
@@ -2791,8 +2855,7 @@ describe('TUI bg color', function()
         end,
       })
     ]])
-
-    screen = thelpers.setup_child_nvim({
+    thelpers.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
@@ -2800,109 +2863,38 @@ describe('TUI bg color', function()
       '--cmd',
       'colorscheme vim',
       '--cmd',
-      'set noswapfile notermguicolors',
-      '-c',
-      'autocmd OptionSet background echo "did OptionSet, yay!"',
+      'set noswapfile',
     })
-  end
-
-  before_each(setup_bg_test)
-
-  it('queries the terminal for background color', function()
     retry(nil, 1000, function()
       eq(true, eval("get(g:, 'oscrequest', v:false)"))
     end)
   end)
 
-  it('triggers OptionSet event on unsplit terminal-response', function()
-    screen:expect([[
+  it('triggers OptionSet from automatic background processing', function()
+    local screen = thelpers.setup_child_nvim({
+      '-u',
+      'NONE',
+      '-i',
+      'NONE',
+      '--cmd',
+      'colorscheme vim',
+      '--cmd',
+      'set noswapfile',
+      '-c',
+      'autocmd OptionSet background echo "did OptionSet, yay!"',
+    })
+    retry(nil, 30000, function() -- wait for automatic background processing
+      screen:sleep(20)
+      screen:expect([[
       {1: }                                                 |
-      {4:~                                                 }|*3
+      {3:~}                                                 |
+      {3:~}                                                 |
+      {3:~}                                                 |
       {5:[No Name]                       0,0-1          All}|
-                                                        |
+      did OptionSet, yay!                               |
       {3:-- TERMINAL --}                                    |
-    ]])
-    feed_data('\027]11;rgb:ffff/ffff/ffff\027\\')
-    screen:expect { any = 'did OptionSet, yay!' }
-
-    feed_data(':echo "new_bg=".&background\n')
-    screen:expect { any = 'new_bg=light' }
-
-    setup_bg_test()
-    screen:expect([[
-      {1: }                                                 |
-      {4:~                                                 }|*3
-      {5:[No Name]                       0,0-1          All}|
-                                                        |
-      {3:-- TERMINAL --}                                    |
-    ]])
-    feed_data('\027]11;rgba:ffff/ffff/ffff/8000\027\\')
-    screen:expect { any = 'did OptionSet, yay!' }
-
-    feed_data(':echo "new_bg=".&background\n')
-    screen:expect { any = 'new_bg=light' }
-  end)
-
-  it('triggers OptionSet event with split terminal-response', function()
-    screen:expect([[
-      {1: }                                                 |
-      {4:~                                                 }|*3
-      {5:[No Name]                       0,0-1          All}|
-                                                        |
-      {3:-- TERMINAL --}                                    |
-    ]])
-    -- Send a background response with the OSC command part split.
-    feed_data('\027]11;rgb')
-    feed_data(':ffff/ffff/ffff\027\\')
-    screen:expect { any = 'did OptionSet, yay!' }
-
-    feed_data(':echo "new_bg=".&background\n')
-    screen:expect { any = 'new_bg=light' }
-
-    setup_bg_test()
-    screen:expect([[
-      {1: }                                                 |
-      {4:~                                                 }|*3
-      {5:[No Name]                       0,0-1          All}|
-                                                        |
-      {3:-- TERMINAL --}                                    |
-    ]])
-    -- Send a background response with the Pt portion split.
-    feed_data('\027]11;rgba:ffff/fff')
-    feed_data('f/ffff/8000\027\\')
-    screen:expect { any = 'did OptionSet, yay!' }
-
-    feed_data(':echo "new_bg=".&background\n')
-    screen:expect { any = 'new_bg=light' }
-  end)
-
-  it('not triggers OptionSet event with invalid terminal-response', function()
-    screen:expect([[
-      {1: }                                                 |
-      {4:~                                                 }|*3
-      {5:[No Name]                       0,0-1          All}|
-                                                        |
-      {3:-- TERMINAL --}                                    |
-    ]])
-    feed_data('\027]11;rgb:ffff/ffff/ffff/8000\027\\')
-    screen:expect_unchanged()
-
-    feed_data(':echo "new_bg=".&background\n')
-    screen:expect { any = 'new_bg=dark' }
-
-    setup_bg_test()
-    screen:expect([[
-      {1: }                                                 |
-      {4:~                                                 }|*3
-      {5:[No Name]                       0,0-1          All}|
-                                                        |
-      {3:-- TERMINAL --}                                    |
-    ]])
-    feed_data('\027]11;rgba:ffff/foo/ffff/8000\027\\')
-    screen:expect_unchanged()
-
-    feed_data(':echo "new_bg=".&background\n')
-    screen:expect { any = 'new_bg=dark' }
+      ]])
+    end)
   end)
 end)
 


### PR DESCRIPTION
This PR updates `_defaults.lua` so that the terminal responds to OSC foreground/background color requests.

#### Motivation

The motivation for this update is Issue #15365, where `background=light` is not properly set for Neovim running from a Neovim `:terminal`. I encounter this when opening a terminal to make git commits, which opens `EDITOR=nvim` in the nested terminal.

#### Caveat

Under the current code in this PR, the terminal does not return the actual foreground/background colors, but rather returns:
-  `foreground=white` and `background=black` when Neovim option `background` is `dark`
-  `foreground=black` and `background=white` when Neovim option `background` is `light`

To return the actual foreground/background colors, an OSC foreground/background request would presumably have to be made to the host terminal. For `background`, this is done at startup, so a subsequent request could be avoided by retaining the color values from then.

Although the OSC responses are not correct, responding with black or white for background is sufficient to have nested Neovim sessions set `background` properly. This is how Vim [handles](https://github.com/neovim/neovim/pull/17197#discussion_r1451582798) the situation (https://github.com/vim/vim/blob/0023f82a76cf43a12b41e71f97a2e860d0444e1b/src/terminal.c#L4109-L4120). Loading Vim within a nested terminal of Vim has background set to match the host Vim.

#### Tests

I've added two tests in `test/functional/terminal/tui_spec.lua` to check that the update works as expected.

Some existing tests in `test/functional/terminal/tui_spec.lua`, added as part of #12004, were depending on the nested terminal not responding to an OSC background request. Because `background` was not automatically set at startup, the tests could trigger the option being set by simulating the OSC responses. I've removed these existing tests, ~porting two of the split OSC response tests to `test/unit/tui_spec.lua`. These new unit tests have no dependence on the nested terminal not responding to an OSC background request.~

The `sleep` and `retry` calls were added to tests to accommodate the delay in automatically setting `background`. Additionally the `nottimeout` setting was set in a `main_spec.lua` to avoid a failed test with the second part of the OSC response written to the command line.