### PR TITLE
fix(tui)!: remove `ESC NUL` forced escape

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -439,22 +439,6 @@ static HandleState handle_bracketed_paste(TermInput *input)
   return kNotApplicable;
 }
 
-// ESC NUL => <Esc>
-static bool handle_forced_escape(TermInput *input)
-{
-  if (rbuffer_size(input->read_stream.buffer) > 1
-      && !rbuffer_cmp(input->read_stream.buffer, "\x1b\x00", 2)) {
-    // skip the ESC and NUL and push one <esc> to the input buffer
-    size_t rcnt;
-    termkey_push_bytes(input->tk, rbuffer_read_ptr(input->read_stream.buffer,
-                                                   &rcnt), 1);
-    rbuffer_consumed(input->read_stream.buffer, 2);
-    tk_getkeys(input, true);
-    return true;
-  }
-  return false;
-}
-
 static void set_bg_deferred(void **argv)
 {
   char *bgvalue = argv[0];
@@ -583,7 +567,6 @@ static void handle_raw_buffer(TermInput *input, bool force)
     if (!force
         && (handle_focus_event(input)
             || (is_paste = handle_bracketed_paste(input)) != kNotApplicable
-            || handle_forced_escape(input)
             || (is_bc = handle_background_color(input)) != kNotApplicable)) {
       if (is_paste == kIncomplete || is_bc == kIncomplete) {
         // Wait for the next input, leaving it in the raw buffer due to an

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -7,7 +7,9 @@ local nvim_dir = helpers.nvim_dir
 local feed_command, nvim = helpers.feed_command, helpers.nvim
 
 local function feed_data(data)
-  nvim('set_var', 'term_data', data)
+  -- A string containing NUL bytes is not converted to a Blob when
+  -- calling nvim_set_var() API, so convert it using Lua instead.
+  nvim('exec_lua', 'vim.g.term_data = ...', {data})
   nvim('command', 'call jobsend(b:terminal_job_id, term_data)')
 end
 


### PR DESCRIPTION
Fix #14836

This make Nvim recognize `ESC NUL` as `<M-C-Space>` (unless terminfo declares it to be something else), as many terminal emulators (including libvterm) send `<M-C-Space>` as `ESC NUL`.

Nvim already supports another unambiguous way to encode a `ESC` key through libtermkey: `ESC [ 2 7 u`, which is an "extended keys" (a.k.a. "modifyOtherKeys" or `CSI u`) sequence.

For example, if one previously used `tmux send-keys 'Escape' 'C-@' 'C-W' j` (<https://github.com/neovim/neovim/pull/1820#issuecomment-74496769>) to leave Insert mode and go to the window below, that will no longer work, but they can still use `tmux send-keys 'Escape' [ 2 7 u 'C-W' j` to achieve that. I don't think many people use `ESC NUL` forced escape nowadays, as Nvim now reinterprets unmapped ALT- chords.

If one still wants to use `ESC NUL` as `ESC`, they can just map `<M-C-Space>` to `<Esc>`.