### PR TITLE
docs(helphelp): remove extra backtick interference

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -358,7 +358,7 @@ When referring to a Vim option in the help file, place the option name between
 two single quotes, eg. 'statusline'
 
 When referring to any other technical term, such as a filename or function
-parameter, surround it in backticks (`), eg. `~/.path/to/init.vim`.
+parameter, surround it in backticks, eg. `~/.path/to/init.vim`.
 
 
 HIGHLIGHTING


### PR DESCRIPTION
An extra backtick was explicitly written to show what a backtick looked
like, but it interferes with the syntax highlighting which thinks that
it's a part of a concealed group and couples it with the wrong backtick.
