### PR TITLE
refactor: allocate an empty string as unused orig_rhs for Lua mappings

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2640,9 +2640,10 @@ void set_maparg_lhs_rhs(const char_u *orig_lhs, const size_t orig_lhs_len,
     }
   } else {
     char tmp_buf[64];
+    // orig_rhs is not used for Lua mappings, but still needs to be a string.
+    mapargs->orig_rhs = xcalloc(1, sizeof(char_u));
+    mapargs->orig_rhs_len = 0;
     // stores <lua>ref_no<cr> in map_str
-    mapargs->orig_rhs_len = (size_t)vim_snprintf(S_LEN(tmp_buf), "<LUA>%d<CR>", rhs_lua);
-    mapargs->orig_rhs = vim_strsave((char_u *)tmp_buf);
     mapargs->rhs_len = (size_t)vim_snprintf(S_LEN(tmp_buf), "%c%c%c%d\r", K_SPECIAL,
                                             (char_u)KEY2TERMCAP0(K_LUA), KEY2TERMCAP1(K_LUA),
                                             rhs_lua);


### PR DESCRIPTION
For a Lua mapping, `orig_rhs` is actually not used anywhere, so there is no need for a call to `vim_snprintf()`. `orig_rhs` still needs to be a string though, as it is passed to `vim_strsave()`.