### PR TITLE
test: prevent stopinsert test flakiness

### DIFF
--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -110,6 +110,7 @@ describe(':terminal', function()
     feed('i[tui] insert-mode')
     eq({ blocking=false, mode='t' }, nvim('get_mode'))
     command('stopinsert')
+    poke_eventloop()  -- Terminal mode is not stopped immediately
     eq({ blocking=false, mode='nt' }, nvim('get_mode'))
   end)
 


### PR DESCRIPTION
`:stopinsert` doesn't stop Terminal mode immediately, but in the next loop iteration. `nvim_get_mode()` is a `{fast}` event, so it is possible `nvim_get_mode()` request arrived before Terminal mode is stopped. This rarely happens, but it did happen in <https://builds.sr.ht/~jmk/job/681377>.