### PR TITLE
Vim 8.2.{4214,4215,4217,4219} various illegal memory accesses

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1099,6 +1099,9 @@ void ex_copy(linenr_T line1, linenr_T line2, linenr_T n)
   }
 
   appended_lines_mark(n, count);
+  if (VIsual_active) {
+    check_pos(curbuf, &VIsual);
+  }
 
   msgmore((long)count);
 }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -772,7 +772,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent)
   ccline.cmdindent = (s->firstc > 0 ? s->indent : 0);
 
   // alloc initial ccline.cmdbuff
-  alloc_cmdbuff(exmode_active ? 250 : s->indent + 1);
+  alloc_cmdbuff(indent + 50);
   ccline.cmdlen = ccline.cmdpos = 0;
   ccline.cmdbuff[0] = NUL;
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2801,7 +2801,7 @@ static void yank_copy_line(yankreg_T *reg, struct block_def *bd, size_t y_idx,
   if (exclude_trailing_space) {
     int s = bd->textlen + bd->endspaces;
 
-    while (ascii_iswhite(*(bd->textstart + s - 1)) && s > 0) {
+    while (s > 0 && ascii_iswhite(*(bd->textstart + s - 1))) {
       s = s - utf_head_off(bd->textstart, bd->textstart + s - 1) - 1;
       pnew--;
     }

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -98,4 +98,14 @@ func Test_ex_mode_count_overflow()
   call delete('Xexmodescript')
 endfunc
 
+func Test_ex_mode_large_indent()
+  new
+  set ts=500 ai
+  call setline(1, "\t")
+  exe "normal gQi\<CR>."
+  set ts=8 noai
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1103,6 +1103,13 @@ func Test_visual_put_blockedit_zy_and_zp()
   bw!
 endfunc
 
+func Test_visual_block_yank_zy()
+  new
+  " this was reading before the start of the line
+  exe "norm o\<C-T>\<Esc>\<C-V>zy"
+  bwipe!
+endfunc
+
 func Test_visual_block_with_virtualedit()
   CheckScreendump
 

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1151,5 +1151,16 @@ func Test_visual_reselect_with_count()
   call delete('XvisualReselect')
 endfunc
 
+" this was leaving the end of the Visual area beyond the end of a line
+func Test_visual_ex_copy_line()
+  new
+  call setline(1, ["aaa", "bbbbbbbbbxbb"])
+  /x
+  exe "normal ggvjfxO"
+  t0
+  normal gNU
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1162,5 +1162,20 @@ func Test_visual_ex_copy_line()
   bwipe!
 endfunc
 
+" This was leaving the end of the Visual area beyond the end of a line.
+" Set 'undolevels' to start a new undo block.
+func Test_visual_undo_deletes_last_line()
+  new
+  call setline(1, ["aaa", "ccc", "dyd"])
+  set undolevels=100
+  exe "normal obbbbbbbbbxbb\<Esc>"
+  set undolevels=100
+  /y
+  exe "normal ggvjfxO"
+  undo
+  normal gNU
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2633,6 +2633,10 @@ static void u_undo_end(bool did_undo, bool absolute, bool quiet)
     }
   }
 
+  if (VIsual_active) {
+    check_pos(curbuf, &VIsual);
+  }
+
   smsg_attr_keep(0,
                  _("%" PRId64 " %s; %s #%" PRId64 "  %s"),
                  u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,


### PR DESCRIPTION
vim-patch:8.2.4219: reading before the start of the line

Problem:    Reading before the start of the line.
Solution:   Check boundary before trying to read the character.
https://github.com/vim/vim/commit/44db8213d38c39877d2148eff6a72f4beccfb94e

vim-patch:8.2.4217: illegal memory access when undo makes Visual area invalid

Problem:    Illegal memory access when undo makes Visual area invalid.
Solution:   Correct the Visual area after undo.
https://github.com/vim/vim/commit/8d02ce1ed75d008c34a5c9aaa51b67cbb9d33baa

vim-patch:8.2.4215: illegal memory access when copying lines in Visual mode

Problem:    Illegal memory access when copying lines in Visual mode.
Solution:   Adjust the Visual position after copying lines.
https://github.com/vim/vim/commit/dc5490e2cbc8c16022a23b449b48c1bd0083f366

vim-patch:8.2.4214: illegal memory access with large 'tabstop' in Ex mode

Problem:    Illegal memory access with large 'tabstop' in Ex mode.
Solution:   Allocate enough memory.
https://github.com/vim/vim/commit/85b6747abc15a7a81086db31289cf1b8b17e6cb1
