### PR TITLE
fix(eval): v:lua support for `-` in module names

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8956,7 +8956,7 @@ static bool tv_is_luafunc(typval_T *tv)
 const char *skip_luafunc_name(const char *p)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  while (ASCII_ISALNUM(*p) || *p == '_' || *p == '.' || *p == '\'') {
+  while (ASCII_ISALNUM(*p) || *p == '_' || *p == '-' || *p == '.' || *p == '\'') {
     p++;
   }
   return p;

--- a/test/functional/fixtures/pack/foo/start/bar/lua/baz-quux.lua
+++ b/test/functional/fixtures/pack/foo/start/bar/lua/baz-quux.lua
@@ -1,0 +1,1 @@
+return {doit=function() return 9004 end}

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -532,6 +532,7 @@ describe('v:lua', function()
     command('set pp+=test/functional/fixtures')
     eq('\tbadval', eval("v:lua.require'leftpad'('badval')"))
     eq(9003, eval("v:lua.require'bar'.doit()"))
+    eq(9004, eval("v:lua.require'baz-quux'.doit()"))
   end)
 
   it('throw errors for invalid use', function()


### PR DESCRIPTION
I don't know of a good reason not to support hyphens.