### PR TITLE
vim-patch:8.2.3475: expression register set by not executed put command

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1758,7 +1758,9 @@ static char_u *do_one_cmd(char_u **cmdlinep, int flags, cstack_T *cstack, LineGe
       ea.regname = *ea.arg++;
       // for '=' register: accept the rest of the line as an expression
       if (ea.arg[-1] == '=' && ea.arg[0] != NUL) {
-        set_expr_line(vim_strsave(ea.arg));
+        if (!ea.skip) {
+          set_expr_line(vim_strsave(ea.arg));
+        }
         ea.arg += STRLEN(ea.arg);
       }
       ea.arg = skipwhite(ea.arg);

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -400,3 +400,13 @@ func Test_winsize_cmd()
   call assert_fails('win_getid(1)', 'E475: Invalid argument: _getid(1)')
   " Actually changing the window size would be flaky.
 endfunc
+
+func Test_not_break_expression_register()
+  call setreg('=', '1+1')
+  if 0
+    put =1
+  endif
+  call assert_equal('1+1', getreg('=', 1))
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3475: expression register set by not executed put command

Problem:    Expression register set by not executed put command.
Solution:   Do not set the register if the command is skipped. (closes vim/vim#8909)
https://github.com/vim/vim/commit/08d7b1c82866a61b61a55e55b6c190dba04e54ea

That `did_set_expr_line` is for Vim9 script only.