### PR TITLE
ci: add intercept_tls_get_addr=0 to ASAN_OPTIONS

### DIFF
--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -35,7 +35,7 @@ case "$FLAVOR" in
     cat <<EOF >> "$GITHUB_ENV"
 CLANG_SANITIZER=ASAN_UBSAN
 SYMBOLIZER=asan_symbolize-13
-ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan
+ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan:intercept_tls_get_addr=0
 UBSAN_OPTIONS=print_stacktrace=1 log_path=$GITHUB_WORKSPACE/build/log/ubsan
 EOF
     ;;


### PR DESCRIPTION
Inferring from <https://github.com/google/sanitizers/issues/1322>, this seems to be the real workaround for the LSAN failure that first happened in #16833, and has been happening for the lastest commits on `master`.