### PR TITLE
test(old): test_help.vim: add a missing new line and remove an extra one

### DIFF
--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -1,4 +1,3 @@
-
 " Tests for :help
 
 func Test_help_restore_snapshot()
@@ -108,5 +107,6 @@ func Test_help_long_argument()
     call assert_match("E149:", v:exception)
   endtry
 endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Vim patch 8.2.3669 added two new lines at the bottom, but #16971 added only one.

Vim patch 8.0.0331 didn't add a blank line at the top, but #6323 added an extra one.