### PR TITLE
vim-patch:8.2.{4233,4235,4236,4237}: follow-up patches for recording in Select mode

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -163,6 +163,7 @@ void free_buff(buffheader_T *buf)
     xfree(p);
   }
   buf->bh_first.b_next = NULL;
+  buf->bh_curr = NULL;
 }
 
 /// Return the contents of a buffer as a single string.

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -288,8 +288,12 @@ static void add_buff(buffheader_T *const buf, const char *const s, ptrdiff_t sle
 /// Only works when it was just added.
 static void delete_buff_tail(buffheader_T *buf, int slen)
 {
-  int len = (int)STRLEN(buf->bh_curr->b_str);
+  int len;
 
+  if (buf->bh_curr == NULL || buf->bh_curr->b_str == NULL) {
+    return;  // nothing to delete
+  }
+  len = (int)STRLEN(buf->bh_curr->b_str);
   if (len >= slen) {
     buf->bh_curr->b_str[len - slen] = NUL;
     buf->bh_space += (size_t)slen;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -290,7 +290,7 @@ static void delete_buff_tail(buffheader_T *buf, int slen)
 {
   int len;
 
-  if (buf->bh_curr == NULL || buf->bh_curr->b_str == NULL) {
+  if (buf->bh_curr == NULL) {
     return;  // nothing to delete
   }
   len = (int)STRLEN(buf->bh_curr->b_str);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1013,9 +1013,11 @@ static int normal_execute(VimState *state, int key)
     // be mapped in Insert mode.  Required for ":lmap" to work.
     int len = ins_char_typebuf(s->c, mod_mask);
 
-    // When recording the character will be recorded again, remove the
-    // previously recording.
-    ungetchars(len);
+    // When recording and gotchars() was called the character will be
+    // recorded again, remove the previous recording.
+    if (KeyTyped) {
+      ungetchars(len);
+    }
 
     if (restart_edit != 0) {
       s->c = 'd';

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -511,4 +511,14 @@ func Test_insert_small_delete()
   bwipe!
 endfunc
 
+func Test_record_in_select_mode()
+  new
+  call setline(1, 'text')
+  sil norm q00
+  sil norm q
+  call assert_equal('0ext', getline(1))
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -517,6 +517,17 @@ func Test_record_in_select_mode()
   sil norm q00
   sil norm q
   call assert_equal('0ext', getline(1))
+
+  %delete
+  let @r = ''
+  call setline(1, ['abc', 'abc', 'abc'])
+  smap <F2> <Right><Right>,
+  call feedkeys("qrgh\<F2>Dk\<Esc>q", 'xt')
+  call assert_equal("gh\<F2>Dk\<Esc>", @r)
+  norm j0@rj0@@
+  call assert_equal([',Dk', ',Dk', ',Dk'], getline(1, 3))
+  sunmap <F2>
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.4233: crash when recording and using Select mode

Problem:    Crash when recording and using Select mode.
Solution:   When deleting the last recorded character check there is something
to delete.
https://github.com/vim/vim/commit/a4bc2dd7cccf5a4a9f78b58b6f35a45d17164323


#### vim-patch:8.2.4235: invalid check for NULL pointer

Problem:    Invalid check for NULL pointer.
Solution:   Remove the check.
https://github.com/vim/vim/commit/37cf413e3e768b76c975e4a7081472d75d649c72


#### vim-patch:8.2.4236: accessing freed memory

Problem:    Accessing freed memory.
Solution:   Set the bh_curr pointer to NULL.
https://github.com/vim/vim/commit/166788c657f4b1090a31ea37a023b1f2c78790c8


#### vim-patch:8.2.4237: record buffer wrong if character in Select mode was not typed

Problem:    Record buffer wrong if character in Select mode was not typed.
Solution:   Only delete the tail from the record buffer if the character was
            typed. (closes vim/vim#9650)
https://github.com/vim/vim/commit/fbf4f1ca159028382eaeb3bfc31bb6bb96dbb67a