### PR TITLE
vim-patch:8.1.0999: use register one too often and not properly tested

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -8083,7 +8083,7 @@ static void ex_operators(exarg_T *eap)
 
   case CMD_yank:
     oa.op_type = OP_YANK;
-    (void)op_yank(&oa, true, false);
+    (void)op_yank(&oa, true);
     break;
 
   default:          // CMD_rshift or CMD_lshift

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -62,7 +62,6 @@ func Test_display_registers()
     call assert_match('^\nType Name Content\n'
           \ .         '  c  ""   a\n'
           \ .         '  c  "0   ba\n'
-          \ .         '  c  "1   b\n'
           \ .         '  c  "a   b\n'
           \ .         '.*'
           \ .         '  c  "-   a\n'
@@ -83,6 +82,90 @@ func Test_display_registers()
 
     bwipe!
     let g:clipboard = save_clipboard
+endfunc
+
+func Test_register_one()
+  " delete a line goes into register one
+  new
+  call setline(1, "one")
+  normal dd
+  call assert_equal("one\n", @1)
+
+  " delete a word does not change register one, does change "-
+  call setline(1, "two")
+  normal de
+  call assert_equal("one\n", @1)
+  call assert_equal("two", @-)
+
+  " delete a word with a register does not change register one
+  call setline(1, "three")
+  normal "ade
+  call assert_equal("three", @a)
+  call assert_equal("one\n", @1)
+
+  " delete a word with register DOES change register one with one of a list of
+  " operators
+  " %
+  call setline(1, ["(12)3"])
+  normal "ad%
+  call assert_equal("(12)", @a)
+  call assert_equal("(12)", @1)
+
+  " (
+  call setline(1, ["first second"])
+  normal $"ad(
+  call assert_equal("first secon", @a)
+  call assert_equal("first secon", @1)
+
+  " )
+  call setline(1, ["First Second."])
+  normal gg0"ad)
+  call assert_equal("First Second.", @a)
+  call assert_equal("First Second.", @1)
+
+  " `
+  call setline(1, ["start here."])
+  normal gg0fhmx0"ad`x
+  call assert_equal("start ", @a)
+  call assert_equal("start ", @1)
+
+  " /
+  call setline(1, ["searchX"])
+  exe "normal gg0\"ad/X\<CR>"
+  call assert_equal("search", @a)
+  call assert_equal("search", @1)
+
+  " ?
+  call setline(1, ["Ysearch"])
+  exe "normal gg$\"ad?Y\<CR>"
+  call assert_equal("Ysearc", @a)
+  call assert_equal("Ysearc", @1)
+
+  " n
+  call setline(1, ["Ynext"])
+  normal gg$"adn
+  call assert_equal("Ynex", @a)
+  call assert_equal("Ynex", @1)
+
+  " N
+  call setline(1, ["prevY"])
+  normal gg0"adN
+  call assert_equal("prev", @a)
+  call assert_equal("prev", @1)
+
+  " }
+  call setline(1, ["one", ""])
+  normal gg0"ad}
+  call assert_equal("one\n", @a)
+  call assert_equal("one\n", @1)
+
+  " {
+  call setline(1, ["", "two"])
+  normal 2G$"ad{
+  call assert_equal("\ntw", @a)
+  call assert_equal("\ntw", @1)
+
+  bwipe!
 endfunc
 
 func Test_recording_status_in_ex_line()


### PR DESCRIPTION
#### vim-patch:8.1.0999: use register one too often and not properly tested

Problem:    Use register one too often and not properly tested.
Solution:   Do not always use register one when specifying a register.
            (closes vim/vim#4085)  Add more tests.
https://github.com/vim/vim/commit/9d7fdd403a3a9ee0d008b6dcbcd2ecc9ec0f57b7