### PR TITLE
fix(input): remove reinterpreted ALT/META chords from recorded macro

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1598,8 +1598,9 @@ int vgetc(void)
       if (!no_mapping && KeyTyped && !(State & TERM_FOCUS)
           && (mod_mask == MOD_MASK_ALT || mod_mask == MOD_MASK_META)) {
         mod_mask = 0;
-        ins_char_typebuf(c, 0);
-        ins_char_typebuf(ESC, 0);
+        int len = ins_char_typebuf(c, 0);
+        (void)ins_char_typebuf(ESC, 0);
+        ungetchars(len + 3);  // The ALT/META modifier takes three more bytes
         continue;
       }
 

--- a/test/functional/editor/meta_key_spec.lua
+++ b/test/functional/editor/meta_key_spec.lua
@@ -104,4 +104,20 @@ describe('meta-keys #8226 #13042', function()
     eq({ 0, 2, 1, 0, }, funcs.getpos('.'))
     eq('nt', eval('mode(1)'))
   end)
+
+  it('ALT/META when recording a macro #13235', function()
+    feed('ifoo<CR>bar<CR>baz<Esc>gg0')
+    -- <M-"> is reinterpreted as <Esc>"
+    feed('qrviw"ayC// This is some text: <M-">apq')
+    expect([[
+      // This is some text: foo
+      bar
+      baz]])
+    -- Should not insert an extra double quote when replaying
+    feed('j0@rj0@@')
+    expect([[
+      // This is some text: foo
+      // This is some text: bar
+      // This is some text: baz]])
+  end)
 end)


### PR DESCRIPTION
Fix #13235