### PR TITLE
vim-patch:8.2.{4242,4315}: put in Visual mode cannot be repeated

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1118,8 +1118,11 @@ register.  With blockwise selection it also depends on the size of the block
 and whether the corners are on an existing character.  (Implementation detail:
 it actually works by first putting the register after the selection and then
 deleting the selection.)
-The previously selected text is put in the unnamed register.  If you want to
-put the same text into a Visual selection several times you need to use
+With 'p' the previously selected text is put in the unnamed register.  This is
+useful if you want to put that text somewhere else.  But you cannot repeat the
+same change.
+With 'P' the unnamed register is not changed, you can repeat the same change.
+But the deleted text cannot be used.  If you do need it you can use 'p' with
 another register.  E.g., yank the text to copy, Visually select the text to
 replace and use "0p .  You can repeat this as many times as you like, and the
 unnamed register will be changed each time.

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -923,7 +923,9 @@ tag		command	      note action in Visual mode	~
 				   before the highlighted area
 |v_J|		J		2  join the highlighted lines
 |v_K|		K		   run 'keywordprg' on the highlighted area
-|v_O|		O		   move horizontally to other corner of area.
+|v_O|		O		   move horizontally to other corner of area
+|v_P|		P		   replace highlighted area with register
+				   contents; unnamed register is unchanged
 		Q		   does not start Ex mode
 |v_R|		R		2  delete the highlighted lines and start
 				   insert

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -255,6 +255,7 @@ Additionally the following commands can be used:
 	X	delete (2)					|v_X|
 	Y	yank (2)					|v_Y|
 	p	put						|v_p|
+	P	put without unnamed register overwrite		|v_P|
 	J	join (1)					|v_J|
 	U	make uppercase					|v_U|
 	u	make lowercase					|v_u|

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9579,8 +9579,7 @@ free_lstval:
 
   if (set_unnamed) {
     // Discard the result. We already handle the error case.
-    if (op_reg_set_previous(regname)) {
-    }
+    (void)op_reg_set_previous(op_reg_index(regname));
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7523,6 +7523,8 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
       // 'virtualedit' and past the end of the line, we use the 'c' operator in
       // do_put(), which requires the visual selection to still be active.
       if (!VIsual_active || VIsual_mode == 'V' || regname != '.') {
+        bool save_unnamed = cap->cmdchar == 'P';
+        int old_unnamed_idx = get_unname_register();
         // Now delete the selected text. Avoid messages here.
         cap->cmdchar = 'd';
         cap->nchar = NUL;
@@ -7532,6 +7534,11 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
         do_pending_operator(cap, 0, false);
         empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
         msg_silent--;
+
+        if (save_unnamed) {
+          // Note: Discard the result
+          (void)op_reg_set_previous(old_unnamed_idx);
+        }
 
         // delete PUT_LINE_BACKWARD;
         cap->oap->regname = regname;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -7268,18 +7268,15 @@ const yankreg_T *op_reg_get(const char name)
 
 /// Set the previous yank register
 ///
-/// @param[in]  name  Register name.
+/// @param[in]  idx  Register index.
 ///
 /// @return true on success, false on failure.
-bool op_reg_set_previous(const char name)
-  FUNC_ATTR_WARN_UNUSED_RESULT
+bool op_reg_set_previous(int idx)
 {
-  int i = op_reg_index(name);
-  if (i == -1) {
+  if (idx < 0 || idx >= NUM_REGISTERS) {
     return false;
   }
-
-  y_previous = &y_regs[i];
+  y_previous = &y_regs[idx];
   return true;
 }
 

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1195,18 +1195,52 @@ func Test_visual_paste()
   call setline(1, ['xxxx'])
   call setreg('"', 'foo')
   call setreg('-', 'bar')
-  normal 1Gvp
-  call assert_equal(@", 'x')
-  call assert_equal(@-, 'x')
+  normal gg0vp
+  call assert_equal('x', @")
+  call assert_equal('x', @-)
+  call assert_equal('fooxxx', getline(1))
+  normal $vp
+  call assert_equal('x', @")
+  call assert_equal('x', @-)
+  call assert_equal('fooxxx', getline(1))
+  " Test with a different register as unnamed register.
+  call setline(2, ['baz'])
+  normal 2gg0"rD
+  call assert_equal('baz', @")
+  normal gg0vp
+  call assert_equal('f', @")
+  call assert_equal('f', @-)
+  call assert_equal('bazooxxx', getline(1))
+  normal $vp
+  call assert_equal('x', @")
+  call assert_equal('x', @-)
+  call assert_equal('bazooxxf', getline(1))
 
   if has('clipboard')
     " v_P does not overwrite unnamed register.
     call setline(1, ['xxxx'])
     call setreg('"', 'foo')
     call setreg('-', 'bar')
-    normal 1GvP
-    call assert_equal(@", 'foo')
-    call assert_equal(@-, 'x')
+    normal gg0vP
+    call assert_equal('foo', @")
+    call assert_equal('x', @-)
+    call assert_equal('fooxxx', getline(1))
+    normal $vP
+    call assert_equal('foo', @")
+    call assert_equal('x', @-)
+    call assert_equal('fooxxfoo', getline(1))
+    " Test with a different register as unnamed register.
+    call setline(2, ['baz'])
+    normal 2gg0"rD
+    call assert_equal('baz', @")
+    normal gg0vP
+    call assert_equal('baz', @")
+    call assert_equal('f', @-)
+    call assert_equal('bazooxxfoo', getline(1))
+    normal $vP
+    call assert_equal('baz', @")
+    call assert_equal('o', @-)
+    call assert_equal('bazooxxfobaz', getline(1))
   endif
 
   bwipe!

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1184,8 +1184,32 @@ func Test_visual_undo_deletes_last_line()
   exe "normal ggvjfxO"
   undo
   normal gNU
+
   bwipe!
 endfunc
 
+func Test_visual_paste()
+  new
+
+  " v_p overwrites unnamed register.
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  call setreg('-', 'bar')
+  normal 1Gvp
+  call assert_equal(@", 'x')
+  call assert_equal(@-, 'x')
+
+  if has('clipboard')
+    " v_P does not overwrite unnamed register.
+    call setline(1, ['xxxx'])
+    call setreg('"', 'foo')
+    call setreg('-', 'bar')
+    normal 1GvP
+    call assert_equal(@", 'foo')
+    call assert_equal(@-, 'x')
+  endif
+
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/editor/put_spec.lua
+++ b/test/functional/editor/put_spec.lua
@@ -507,7 +507,9 @@ describe('put command', function()
       return function(exception_table, after_redo)
         test_expect(exception_table, after_redo)
         if selection_string then
-          eq(selection_string, getreg('"'))
+          if not conversion_table.put_backwards then
+            eq(selection_string, getreg('"'))
+          end
         else
           eq('test_string"', getreg('"'))
         end
@@ -714,7 +716,9 @@ describe('put command', function()
             expect_base, conversion_table)
           return function(exception_table, after_redo)
             test_expect(exception_table, after_redo)
-            eq('Line of words 1\n', getreg('"'))
+            if not conversion_table.put_backwards then
+              eq('Line of words 1\n', getreg('"'))
+            end
           end
         end
         local base_expect_string = [[
@@ -748,7 +752,9 @@ describe('put command', function()
           end, expect_base, conversion_table)
         return function(e,c)
           test_expect(e,c)
-          eq('Lin\nLin', getreg('"'))
+          if not conversion_table.put_backwards then
+            eq('Lin\nLin', getreg('"'))
+          end
         end
       end
 


### PR DESCRIPTION
Close #1790

Problem:    Put in Visual mode cannot be repeated.
Solution:   Use "P" to put without yanking the deleted text into the unnamed
            register. (Shougo Matsushita, closes vim/vim#9591)
https://github.com/vim/vim/commit/fb55207ed17918c8a2a6cadf5ad9d5fcf686a7ab

continue of https://github.com/neovim/neovim/pull/17097