### PR TITLE
vim-patch:8.2.4248: no proper test for moving the window separator

### DIFF
--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -968,6 +968,12 @@ func Test_win_move_separator()
     call assert_true(id->win_move_separator(-offset))
     call assert_equal(w, winwidth(id))
   endfor
+  " check win_move_separator from right window on right window is no-op
+  let w0 = winwidth(0)
+  call assert_true(win_move_separator(0, 1))
+  call assert_equal(w0, winwidth(0))
+  call assert_true(win_move_separator(0, -1))
+  call assert_equal(w0, winwidth(0))
   " check that win_move_separator doesn't error with offsets beyond moving
   " possibility
   call assert_true(win_move_separator(id, 5000))
@@ -990,6 +996,7 @@ func Test_win_move_separator()
 endfunc
 
 func Test_win_move_statusline()
+  redraw  " This test fails in Nvim without a redraw to clear messages.
   edit a
   leftabove split b
   let h = winheight(0)
@@ -1010,6 +1017,19 @@ func Test_win_move_statusline()
     call assert_true(win_move_statusline(1, -offset))
     call assert_equal(h, winheight(1))
   endfor
+  " check win_move_statusline from bottom window on bottom window
+  let h0 = winheight(0)
+  for offset in range(5)
+    call assert_true(0->win_move_statusline(-offset))
+    call assert_equal(h0 - offset, winheight(0))
+    call assert_equal(1 + offset, &cmdheight)
+    call assert_true(win_move_statusline(0, offset))
+    call assert_equal(h0, winheight(0))
+    call assert_equal(1, &cmdheight)
+  endfor
+  call assert_true(win_move_statusline(0, 1))
+  call assert_equal(h0, winheight(0))
+  call assert_equal(1, &cmdheight)
   " check win_move_statusline from bottom window on top window ID
   let id = win_getid(1)
   for offset in range(5)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5795,7 +5795,6 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
     }
     fr = curfr;  // put fr at window that grows
   }
-  assert(fr);
 
   // Not enough room
   if (room < offset) {
@@ -5808,7 +5807,9 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
   }
 
   if (fr == NULL) {
-    return;  // Safety check, should not happen.
+    // This can happen when calling win_move_separator() on the rightmost
+    // window.  Just don't do anything.
+    return;
   }
 
   // grow frame fr by offset lines


### PR DESCRIPTION
#### vim-patch:8.2.4248: no proper test for moving the window separator

Problem:    No proper test for moving the window separator.
Solution:   Add a test.  Add comment in code. (closes vim/vim#9656)
https://github.com/vim/vim/commit/a0c4e2f2d7aa164d9d7692702c752ea063bd3a8c

Remove the assertion as it is now possible for `fr` to be `NULL`.

The test fails without clearing messages. Not sure if this is a bug.