### PR TITLE
vim-patch:8.2.4251: vala files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2017,6 +2017,9 @@ au BufNewFile,BufRead */.init/*.conf,*/.init/*.override	       setf upstart
 au BufNewFile,BufRead */.config/upstart/*.conf		       setf upstart
 au BufNewFile,BufRead */.config/upstart/*.override	       setf upstart
 
+" Vala
+au BufNewFile,BufRead *.vala			setf vala
+
 " Vera
 au BufNewFile,BufRead *.vr,*.vri,*.vrh		setf vera
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -756,6 +756,7 @@ local extension = {
   zu = "zimbu",
   zut = "zimbutempl",
   zsh = "zsh",
+  vala = "vala",
   E = function() vim.fn["dist#ft#FTe"]() end,
   EU = function() vim.fn["dist#ft#EuphoriaCheck"]() end,
   EW = function() vim.fn["dist#ft#EuphoriaCheck"]() end,

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -556,6 +556,7 @@ let s:filename_checks = {
     \ 'usserverlog': ['usserver.log', 'USSERVER.LOG', 'usserver.file.log', 'USSERVER.FILE.LOG', 'file.usserver.log', 'FILE.USSERVER.LOG'],
     \ 'usw2kagtlog': ['usw2kagt.log', 'USW2KAGT.LOG', 'usw2kagt.file.log', 'USW2KAGT.FILE.LOG', 'file.usw2kagt.log', 'FILE.USW2KAGT.LOG'],
     \ 'vb': ['file.sba', 'file.vb', 'file.vbs', 'file.dsm', 'file.ctl'],
+    \ 'vala': ['file.vala'],
     \ 'vera': ['file.vr', 'file.vri', 'file.vrh'],
     \ 'verilog': ['file.v'],
     \ 'verilogams': ['file.va', 'file.vams'],


### PR DESCRIPTION
Problem:    Vala files are not recognized.
Solution:   Add the *.vala pattern. (closes vim/vim#9654)
https://github.com/vim/vim/commit/97c554d5149c2aa4a43d689c59563e77277265d4