### PR TITLE
vim-patch:8.2.3219: :find searches non-existing directories

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1569,6 +1569,12 @@ There are three different types of searching:
 	/u/user_x/work/include
 	/u/user_x/include
 
+<   Note: If your 'path' setting includes a non-existing directory, Vim will
+   skip the non-existing directory, but continues searching in the parent of
+   the non-existing directory if upwards searching is used.  E.g. when
+   searching "../include" and that doesn't exist, and upward searching is
+   used, also searches in "..".
+
 3) Combined up/downward search:
    If Vim's current path is /u/user_x/work/release and you do >
 	set path=**;/u/user_x

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -483,8 +483,14 @@ void *vim_findfile_init(char_u *path, char_u *filename, char_u *stopdirs, int le
       int len = 0;
 
       if (p > search_ctx->ffsc_fix_path) {
+        // do not add '..' to the path and start upwards searching
         len = (int)(p - search_ctx->ffsc_fix_path) - 1;
-        STRNCAT(ff_expand_buffer, search_ctx->ffsc_fix_path, len);
+        if ((len >= 2 && STRNCMP(search_ctx->ffsc_fix_path, "..", 2) == 0)
+            && (len == 2 || search_ctx->ffsc_fix_path[2] == PATHSEP)) {
+          xfree(buf);
+          goto error_return;
+        }
+        STRLCAT(ff_expand_buffer, search_ctx->ffsc_fix_path, eb_len + (size_t)len + 1);
         add_pathsep((char *)ff_expand_buffer);
       } else {
         len = (int)STRLEN(search_ctx->ffsc_fix_path);

--- a/src/nvim/testdir/test_findfile.vim
+++ b/src/nvim/testdir/test_findfile.vim
@@ -226,4 +226,26 @@ func Test_find_cmd()
   call assert_fails('tabfind', 'E471:')
 endfunc
 
+func Test_find_non_existing_path()
+  new
+  let save_path = &path
+  let save_dir = getcwd()
+  call mkdir('dir1/dir2', 'p')
+  call writefile([], 'dir1/file.txt')
+  call writefile([], 'dir1/dir2/base.txt')
+  call chdir('dir1/dir2')
+  e base.txt
+  set path=../include
+
+  call assert_fails(':find file.txt', 'E345:')
+
+  call chdir(save_dir)
+  bw!
+  call delete('dir1/dir2/base.txt', 'rf')
+  call delete('dir1/dir2', 'rf')
+  call delete('dir1/file.txt', 'rf')
+  call delete('dir1', 'rf')
+  let &path = save_path
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3219: :find searches non-existing directories

Problem:    :find searches non-existing directories.
Solution:   Check the path is not "..".  Update help. (Christian Brabandt,
            closes vim/vim#8612)
https://github.com/vim/vim/commit/7a4ca32175bef0f9a177052796bd9addd10dc218

Change STRNCAT to STRLCAT as clint doesn't like the former.