### PR TITLE
vim-patch:8.2.3532: the previous '' mark is restored after moving the cursor

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -217,8 +217,8 @@ void checkpcmark(void)
       && (equalpos(curwin->w_pcmark, curwin->w_cursor)
           || curwin->w_pcmark.lnum == 0)) {
     curwin->w_pcmark = curwin->w_prev_pcmark;
-    curwin->w_prev_pcmark.lnum = 0;             // Show it has been checked
   }
+  curwin->w_prev_pcmark.lnum = 0;  // it has been checked
 }
 
 /*

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -25,6 +25,16 @@ function! Test_Incr_Marks()
   enew!
 endfunction
 
+func Test_previous_jump_mark()
+  new
+  call setline(1, ['']->repeat(6))
+  normal Ggg
+  call assert_equal(6, getpos("''")[1])
+  normal jjjjj
+  call assert_equal(6, getpos("''")[1])
+  bwipe!
+endfunc
+
 func Test_setpos()
   new Xone
   let onebuf = bufnr('%')


### PR DESCRIPTION
#### vim-patch:8.2.3532: the previous '' mark is restored after moving the cursor

Problem:    The previous '' mark is restored after moving the cursor to the
            original jump position. (Tony Chen)
Solution:   Forget the previous position after checking.
https://github.com/vim/vim/commit/e08aee60abc59f517d3e263fdb9ba4a0196d507c