### PR TITLE
[RFC] fix: has('python') error

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -11004,10 +11004,7 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments, boo
 bool eval_has_provider(const char *feat)
 {
   if (!strequal(feat, "clipboard")
-      && !strequal(feat, "python")
       && !strequal(feat, "python3")
-      && !strequal(feat, "python_compiled")
-      && !strequal(feat, "python_dynamic")
       && !strequal(feat, "python3_compiled")
       && !strequal(feat, "python3_dynamic")
       && !strequal(feat, "perl")

--- a/test/functional/fixtures/autoload/provider/python3.vim
+++ b/test/functional/fixtures/autoload/provider/python3.vim
@@ -1,6 +1,6 @@
 " Dummy test provider, missing this required variable:
 "   let g:loaded_brokenenabled_provider = 0
 
-function! provider#python#Call(method, args)
+function! provider#python3#Call(method, args)
   return 42
 endfunction

--- a/test/functional/provider/provider_spec.lua
+++ b/test/functional/provider/provider_spec.lua
@@ -10,14 +10,6 @@ describe('providers', function()
     clear('--cmd', 'let &rtp = "test/functional/fixtures,".&rtp')
   end)
 
-  it('with #Call(), missing g:loaded_xx_provider', function()
-    command('set loadplugins')
-    -- Using test-fixture with broken impl:
-    -- test/functional/fixtures/autoload/provider/python.vim
-    eq('Vim:provider: python: missing required variable g:loaded_python_provider',
-      pcall_err(eval, "has('python')"))
-  end)
-
   it('with g:loaded_xx_provider, missing #Call()', function()
     -- Using test-fixture with broken impl:
     -- test/functional/fixtures/autoload/provider/ruby.vim

--- a/test/functional/provider/provider_spec.lua
+++ b/test/functional/provider/provider_spec.lua
@@ -10,6 +10,14 @@ describe('providers', function()
     clear('--cmd', 'let &rtp = "test/functional/fixtures,".&rtp')
   end)
 
+  it('with #Call(), missing g:loaded_xx_provider', function()
+    command('set loadplugins')
+    -- Using test-fixture with broken impl:
+    -- test/functional/fixtures/autoload/provider/python.vim
+    eq('Vim:provider: python3: missing required variable g:loaded_python3_provider',
+      pcall_err(eval, "has('python3')"))
+  end)
+
   it('with g:loaded_xx_provider, missing #Call()', function()
     -- Using test-fixture with broken impl:
     -- test/functional/fixtures/autoload/provider/ruby.vim


### PR DESCRIPTION
Fix https://github.com/neovim/neovim/pull/17222#issuecomment-1025213636

To reproduce the error:

`nvim --clean` and `:echo has('python')`

It breaks many plugins like `vim-plug`.  So it must be fixed.

![スクリーンショット_2022-01-31_11-13-51](https://user-images.githubusercontent.com/41495/151730099-4f0f3efd-e1e6-4119-a7ec-2ec10ea6521f.png)
