### PR TITLE
vim-patch:8.2.4267: unused entry in keymap enum

### DIFF
--- a/src/nvim/keymap.h
+++ b/src/nvim/keymap.h
@@ -122,8 +122,6 @@
 //
 // Entries must be in the range 0x02-0x7f (see comment at K_SPECIAL).
 enum key_extra {
-  KE_NAME = 3,                 // name of this terminal entry
-
   KE_S_UP = 4,              // shift-up
   KE_S_DOWN = 5,             // shift-down
 


### PR DESCRIPTION
#### vim-patch:8.2.4267: unused entry in keymap enum

Problem:    Unused entry in keymap enum.
Solution:   Remove the entry.
https://github.com/vim/vim/commit/4c93aff20f228d0dfca11f4793eb2c8895d4984c