### PR TITLE
vim-patch:8.2.4273: the EBCDIC support is outdated

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -217,9 +217,7 @@ int buf_init_chartab(buf_T *buf, int global)
             }
           } else if (i == 1) {
             // (re)set printable
-            // For double-byte we keep the cell width, so
-            // that we can detect it from the first byte.
-            if (((c < ' ') || (c > '~'))) {
+            if (c < ' ' || c > '~') {
               if (tilde) {
                 g_chartab[c] = (uint8_t)((g_chartab[c] & ~CT_CELL_MASK)
                                          + ((dy_flags & DY_UHEX) ? 4 : 2));
@@ -539,7 +537,7 @@ char_u *transchar_buf(const buf_T *buf, int c)
     c = K_SECOND(c);
   }
 
-  if ((!chartab_initialized && (((c >= ' ') && (c <= '~'))))
+  if ((!chartab_initialized && (c >= ' ' && c <= '~'))
       || ((c <= 0xFF) && vim_isprintc_strict(c))) {
     // printable character
     transchar_charbuf[i] = (char_u)c;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7131,9 +7131,7 @@ int stuff_inserted(int c, long count, int no_esc)
     stuffReadbuff((const char *)ptr);
     // A trailing "0" is inserted as "<C-V>048", "^" as "<C-V>^".
     if (last) {
-      stuffReadbuff((last == '0'
-                     ? "\026\060\064\070"
-                     : "\026^"));
+      stuffReadbuff(last == '0' ? "\026\060\064\070" : "\026^");
     }
   } while (--count > 0);
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5027,9 +5027,7 @@ static void nv_brackets(cmdarg_T *cap)
    * identifier     "]i"  "[i"   "]I"  "[I"     "]^I"  "[^I"
    * define           "]d"  "[d"   "]D"  "[D"   "]^D"  "[^D"
    */
-  if (vim_strchr((char_u *)
-                 "iI\011dD\004",
-                 cap->nchar) != NULL) {
+  if (vim_strchr((char_u *)"iI\011dD\004", cap->nchar) != NULL) {
     char_u *ptr;
     size_t len;
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2901,18 +2901,14 @@ static int peekchr(void)
   {
     int c = regparse[1];
 
-    if (c == NUL)
-      curchr = '\\';                  /* trailing '\' */
-    else if (
-      c <= '~' && META_flags[c]
-      ) {
-      /*
-       * META contains everything that may be magic sometimes,
-       * except ^ and $ ("\^" and "\$" are only magic after
-       * "\V").  We now fetch the next character and toggle its
-       * magicness.  Therefore, \ is so meta-magic that it is
-       * not in META.
-       */
+    if (c == NUL) {
+      curchr = '\\';  // trailing '\'
+    } else if (c <= '~' && META_flags[c]) {
+      // META contains everything that may be magic sometimes,
+      // except ^ and $ ("\^" and "\$" are only magic after
+      // "\V").  We now fetch the next character and toggle its
+      // magicness.  Therefore, \ is so meta-magic that it is
+      // not in META.
       curchr = -1;
       prev_at_start = at_start;
       at_start = false;  // be able to say "/\*ptr"

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1006,8 +1006,6 @@ func Test_edit_DROP()
 endfunc
 
 func Test_edit_CTRL_V()
-  CheckNotFeature ebcdic
-
   new
   call setline(1, ['abc'])
   call cursor(2, 1)
@@ -1561,11 +1559,7 @@ endfunc
 func Test_edit_special_chars()
   new
 
-  if has("ebcdic")
-    let t = "o\<C-V>193\<C-V>xc2\<C-V>o303 \<C-V>90a\<C-V>xfg\<C-V>o578\<Esc>"
-  else
-    let t = "o\<C-V>65\<C-V>x42\<C-V>o103 \<C-V>33a\<C-V>xfg\<C-V>o78\<Esc>"
-  endif
+  let t = "o\<C-V>65\<C-V>x42\<C-V>o103 \<C-V>33a\<C-V>xfg\<C-V>o78\<Esc>"
 
   exe "normal " . t
   call assert_equal("ABC !a\<C-O>g\<C-G>8", getline(2))

--- a/src/nvim/testdir/test_exec_while_if.vim
+++ b/src/nvim/testdir/test_exec_while_if.vim
@@ -6,11 +6,7 @@ func Test_exec_while_if()
   let i = 0
   while i < 12
     let i = i + 1
-    if has("ebcdic")
-      execute "normal o" . i . "\047"
-    else
-      execute "normal o" . i . "\033"
-    endif
+    execute "normal o" . i . "\033"
     if i % 2
       normal Ax
       if i == 9
@@ -21,21 +17,13 @@ func Test_exec_while_if()
       else
         let j = 9
         while j > 0
-          if has("ebcdic")
-            execute "normal" j . "a" . j . "\x27"
-          else
-            execute "normal" j . "a" . j . "\x1b"
-          endif
+          execute "normal" j . "a" . j . "\x1b"
           let j = j - 1
         endwhile
       endif
     endif
     if i == 9
-      if has("ebcdic")
-        execute "normal Az\047"
-      else
-        execute "normal Az\033"
-      endif
+      execute "normal Az\033"
     endif
   endwhile
   unlet i j

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -19,11 +19,7 @@ func Test_gf_url()
   call search("^second")
   call search("URL")
   call assert_equal("URL://machine.name/tmp/vimtest2b", expand("<cfile>"))
-  if has("ebcdic")
-      set isf=@,240-249,/,.,-,_,+,,,$,:,~,\
-  else
-      set isf=@,48-57,/,.,-,_,+,,,$,~,\
-  endif
+  set isf=@,48-57,/,.,-,_,+,,,$,~,\
   call search("^third")
   call search("name")
   call assert_equal("URL:\\\\machine.name\\vimtest2c", expand("<cfile>"))
@@ -76,11 +72,7 @@ endfunc
 
 " Test for invoking 'gf' on a ${VAR} variable
 func Test_gf()
-  if has("ebcdic")
-    set isfname=@,240-249,/,.,-,_,+,,,$,:,~,{,}
-  else
-    set isfname=@,48-57,/,.,-,_,+,,,$,:,~,{,}
-  endif
+  set isfname=@,48-57,/,.,-,_,+,,,$,:,~,{,}
 
   call writefile(["Test for gf command"], "Xtest1")
   if has("unix")

--- a/src/nvim/testdir/test_regexp_utf8.vim
+++ b/src/nvim/testdir/test_regexp_utf8.vim
@@ -152,9 +152,6 @@ func s:classes_test()
   if has('win32')
     let identchars_ok = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz ¡¢£¤¥¦§µÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
     let kwordchars_ok = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyzµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
-  elseif has('ebcdic')
-    let identchars_ok = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz¬®µº¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
-    let kwordchars_ok = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz¬®µº¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
   else
     let identchars_ok = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyzµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
     let kwordchars_ok = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyzµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
@@ -166,8 +163,6 @@ func s:classes_test()
     let fnamechars_ok = '$+,-./0123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
   elseif has('vms')
     let fnamechars_ok = '#$%+,-./0123456789:;<>ABCDEFGHIJKLMNOPQRSTUVWXYZ[]_abcdefghijklmnopqrstuvwxyz~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
-  elseif has('ebcdic')
-    let fnamechars_ok = '#$%+,-./=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
   else
     let fnamechars_ok = '#$%+,-./0123456789=ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
   endif


### PR DESCRIPTION
#### vim-patch:8.2.4273: the EBCDIC support is outdated

Problem:    The EBCDIC support is outdated.
Solution:   Remove the EBCDIC support.
https://github.com/vim/vim/commit/424bcae1fb0f69e0aef5e0cf84fd771cf34a0fb7

Also remove a comment in buf_init_chartab() as it is for enc_dbcs only.

Skip test_expr.vim: the check was already removed when patch 7.4.2265 was first ported.