### PR TITLE
vim-patch:8.2.3797: no good reason to limit the message history in tiny version

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -27,8 +27,7 @@ depends on the 'shortmess' option.
 				Clear messages, keeping only the {count} most
 				recent ones.
 
-The number of remembered messages is fixed at 20 for the tiny version and 200
-for other versions.
+The number of remembered messages is fixed at 200.
 
 								*g<*
 The "g<" command can be used to see the last page of previous command output.


### PR DESCRIPTION
#### vim-patch:8.2.3797: no good reason to limit the message history in tiny version

Problem:    No good reason to limit the message history in the tiny version.
Solution:   Always use 200.
https://github.com/vim/vim/commit/1e78deb0779bc403a914712f0842a65d2949dfdf

N/A patches:

vim-patch:495282b6e7e4

Correct list of patch numbers
https://github.com/vim/vim/commit/495282b6e7e418d072a8ab53c9056b269dc308b7

vim-patch:ed37d9b3241a

Update feature_request.md
https://github.com/vim/vim/commit/ed37d9b3241abe7c302c7ac606df80037aecdb46

vim-patch:fe712ced6e15

Fix duplicated code that only appears in git.
https://github.com/vim/vim/commit/fe712ced6e1509d1e16b12d2b5581f89d0f9f4df

vim-patch:87fda407f8ec

Also fix the patch number.
https://github.com/vim/vim/commit/87fda407f8ecf947ba6ce72ac21f69ff04d909cd

vim-patch:85d9b03f84f5

Correct list of patches.
https://github.com/vim/vim/commit/85d9b03f84f59c4c6013d6bd7e6d1bb8091ee8c5

vim-patch:b54f1202b3cd

Attempt to align the logo without a markdown table.
https://github.com/vim/vim/commit/b54f1202b3cd9e5e0510b546d8a9a4f2e7b6b451

vim-patch:4a27aefe3b56

Add links to discussion forums.
https://github.com/vim/vim/commit/4a27aefe3b5652ee58b2eb85e9d09b542b087aaa

vim-patch:c139aa8a2bf3

Remove table, it doesn't work
https://github.com/vim/vim/commit/c139aa8a2bf3de9fb524344e632eb323e0093fd2

vim-patch:0261a1aeeb4c

Tweak the style a bit.
https://github.com/vim/vim/commit/0261a1aeeb4ccec4ef75cc8e0685c78f5622dbf5

vim-patch:8.2.3488: issue template is not easy to use

Problem:    Issue template is not easy to use.
Solution:   Use a yaml template. (closes vim/vim#8928)
https://github.com/vim/vim/commit/26190b27011c25caedf3b9308e47005722b3f946

vim-patch:8.2.3496: crypt test fails if xxd was not installed yet

Problem:    Crypt test fails on MS-Windows if xxd was not installed yet.
Solution:   Use the just built xxd executable if it exists. (James McCoy,
            closes vim/vim#8929)
https://github.com/vim/vim/commit/a5d4f3b09d25006f7bc988d618152bd34177a579

vim-patch:8.2.3500: Github CI fails to install clang

Problem:    Github CI fails to install clang.
Solution:   Install llvm-11 explicitly. (Christian Brabandt, closes vim/vim#8993)
https://github.com/vim/vim/commit/3a724290c5dd8e4b7c9a1fa8941b81f6f80db00a

vim-patch:8.2.3507: generating proto files may fail

Problem:    Generating proto files may fail.
Solution:   Define __attribute().
https://github.com/vim/vim/commit/75aa92a16264e3511ba41aa306ffc1ffbbd2fe3a

vim-patch:8.2.3523: duplicated code in xxd

Problem:    Duplicated code in xxd.
Solution:   Remove duplicated lines. (closes vim/vim#8972)
https://github.com/vim/vim/commit/c89c91cafd91fbf17f431d800bbf4cafcffffe7a

vim-patch:8.2.3533: inefficient code in xxd

Problem:    Inefficient code in xxd.
Solution:   Don't use "p" when "hextype" is non-zero. (closes vim/vim#9013)
https://github.com/vim/vim/commit/375c35a63fdb91e8db2a9965f94d56ae87135fff

vim-patch:8.2.3539: GTK3: with 'rightleft' set scrollbar may move unintentionally

Problem:    GTK3: with 'rightleft' set scrollbar may move unintentionally.
Solution:   Ignore events while moving the scrollbar thumb. (closes vim/vim#8958)
https://github.com/vim/vim/commit/604e207e277767a67cbf4a6a179080efb830b9e7

vim-patch:8.2.3548: GTK GUI crashen when reading from stdin

Problem:    GTK GUI crashen when reading from stdin.
Solution:   Do not overwrite the NUL after the string. (closes vim/vim#9028)
https://github.com/vim/vim/commit/d68a0044858d00de6100def1e389a3a9c1cdbcdc

vim-patch:8.2.3552: xxd revert does not handle end of line correctly

Problem:    Xxd revert does not handle end of line correctly.
Solution:   Check for newline first. (closes vim/vim#9034)
https://github.com/vim/vim/commit/47810464aa4f9edbf222c02a860a3ec560b0b7a1

vim-patch:8.2.3553: xxd test fails on MS-Windows

Problem:    Xxd test fails on MS-Windows.
Solution:   Split shell command in two.
https://github.com/vim/vim/commit/5a5c111e79d1ea4b24133eaf44deab42a8e78eed

vim-patch:8.2.3554: xxd has various way to exit

Problem:    Xxd has various way to exit.
Solution:   Add function to print error and exit. (closes vim/vim#9035)
https://github.com/vim/vim/commit/a2ffb435209716dc7aeb4783333f6ea19f5d28a7

vim-patch:8.2.3565: Makefile dependencies are outdated

Problem:    Makefile dependencies are outdated. (Gary Johnson)
Solution:   Run "make depend" and add missing dependencies.
https://github.com/vim/vim/commit/2446ec9b567ce2b72bd06d121f200f40bbdc8a84

vim-patch:8.2.3566: build failure on old systems when using nano timestamp

Problem:    Build failure on old systems when using nano timestamp.
Solution:   Define _BSD_SOURCE, _SVID_SOURCE and _DEFAULT_SOURCE. (Gary
            Johnson, closes vim/vim#9054)
https://github.com/vim/vim/commit/44db603f691b58a8531e8ff528e0a7ce644257b2

vim-patch:8.2.3594: xxd code is a bit difficult to understand

Problem:    Xxd code is a bit difficult to understand.
Solution:   Move some lines to a separate function. (closes vim/vim#9037)
https://github.com/vim/vim/commit/786e05beb5bf4a50cffacd0968f1409aa6af3c6b

vim-patch:8.2.3606: file missing from list of distributed files

Problem:    File missing from list of distributed files.
Solution:   Add the file.
https://github.com/vim/vim/commit/d3682c5f28380695a53cbb927deb94ffa3261eca

vim-patch:8.2.3607: GTK3 screen updating is slow

Problem:    GTK3 screen updating is slow.
Solution:   Remove some of the GTK3-specific code. (closes vim/vim#9052)
https://github.com/vim/vim/commit/9459b8d461d6f8345bfa3fb9b3b4297a7950b0bc

vim-patch:8.2.3632: GTK3: undercurl does not get removed properly

Problem:    GTK3: undercurl does not get removed properly.
Solution:   Set the cairo cursor first. (closes vim/vim#9170)
https://github.com/vim/vim/commit/9cd9385db7d1d2b2dc38a511d121e366a5dae511

vim-patch:8.2.3635: GTK: composing underline does not show

Problem:    GTK: composing underline does not show.
Solution:   Include composing character in pango call. A few more
            optimizations for ligatures.  (Dusan Popovic, closes vim/vim#9171,
            closes vim/vim#9147)
https://github.com/vim/vim/commit/3c19b5050040fb74e4e39048f17dce853fdafc08

vim-patch:8.2.3641: xxd code has duplicate expressions

Problem:    Xxd code has duplicate expressions.
Solution:   Refactor to avoid duplication. (closes vim/vim#9185)
https://github.com/vim/vim/commit/581f41adb3ba1dc95bf4fc7c434427e1203be5e8

vim-patch:8.2.3642: list of distributed files is outdated

Problem:    List of distributed files is outdated.
Solution:   Rename term.h to termdefs.h.
https://github.com/vim/vim/commit/73448a27a8e13b9b26759abeb092fd13a0e93238

vim-patch:8.2.3647: GTK: when using ligatures the cursor is drawn wrong

Problem:    GTK: when using ligatures the cursor is drawn wrong.
Solution:   Clear more characters when ligatures are used. (Dusan Popovic,
            closes vim/vim#9190)
https://github.com/vim/vim/commit/ce59b9f29244d98e55e3ec6be341c4d521159e8f

vim-patch:8.2.3654: GTK: a touch-drag does not update the selection

Problem:    GTK: a touch-drag does not update the selection.
Solution:   Add GDK_BUTTON1_MASK to the state. (Chris Dalton, close vim/vim#9196,
            closes vim/vim#9194)
https://github.com/vim/vim/commit/ee93e327ba31e8efb1b7de6209bdc992778b809b

vim-patch:8.2.3658: duplicate code in xxd

Problem:    Duplicate code in xxd.
Solution:   Merge duplicated code. Add more tests. (closes vim/vim#9192)
https://github.com/vim/vim/commit/48608b4a4bfab4b9c0c9199d57b7e876c56db74c

vim-patch:8.2.3666: libvterm is outdated

Problem:    Libvterm is outdated.
Solution:   Include patches from revision 769 to revision 789.
https://github.com/vim/vim/commit/7da341560ec8db7e81cd80092b046b60a482fbbe

vim-patch:8.2.3667: building libvterm fails with MSVC

Problem:    Building libvterm fails with MSVC.
Solution:   Don't use C99 construct.
https://github.com/vim/vim/commit/510d8e6056d89d903511c4498afec23f76b4f2a4

vim-patch:8.2.3680: repeated code in xxd

Problem:    Repeated code in xxd.
Solution:   Change exit_on_ferror() to getc_or_die(). (closes vim/vim#9226)
https://github.com/vim/vim/commit/d1d8a595bd03bf9ff6ba1440101daa98b19249fd

vim-patch:8.2.3714: some unused assignments and ugly code in xxd

Problem:    Some unused assignments and ugly code in xxd.
Solution:   Leave out assignments.  Use marcro for fprintf(). (closes vim/vim#9246)
https://github.com/vim/vim/commit/7e5503c17a3f142e6b28f344d899c9ab9e75a844

vim-patch:8.2.3722: Amiga: superfluous messages for freeing lots of yanked text

Problem:    Amiga: superfluous messages for freeing lots of yanked text.
Solution:   Assume that the machine isn't that slow these days.
https://github.com/vim/vim/commit/5e86964bf48ddbfa20261bda84db391c80a36dca

vim-patch:8.2.3752: build error when using Photon GUI

Problem:    Build error when using Photon GUI.
Solution:   Adjust #ifdef. (closes vim/vim#9288)
https://github.com/vim/vim/commit/8603be338ac810446f23c092f21bc6082f787519

vim-patch:3e55a973b5ca

Add Huntr badge.
https://github.com/vim/vim/commit/3e55a973b5cab5823335e24b7e4885429c885921

vim-patch:8.2.3785: running CI on MacOS with gcc is not useful

Problem:    Running CI on MacOS with gcc is not useful.
Solution:   Only use clang. (Ozaki Kiichi, closes vim/vim#9326)  Also build with
            normal features.
https://github.com/vim/vim/commit/48c0196378a1fa408ebae4f578a62095d8a80c6f

vim-patch:4e30b5c3bc83

Update issue template.
https://github.com/vim/vim/commit/4e30b5c3bc83fe6a87f4d50720638e8bb4e16428

vim-patch:9a4ec5a62632

Use text area for environment in the bug template.
https://github.com/vim/vim/commit/9a4ec5a62632af040c278a189e256043740f5c7f

vim-patch:8.2.3800: when cross compiling the output of "uname" cannot be set

Problem:    When cross compiling the output of "uname" cannot be set. (Ben
            Reeves)
Solution:   Use cache variables. (closes vim/vim#9338)
https://github.com/vim/vim/commit/6840a0ffe8d27a8773a500ba17550cdf2ad12cbc

vim-patch:8.2.3821: ASAN test run fails

Problem:    ASAN test run fails.
Solution:   Use asan_symbolize-13 instead of asan_symbolize-11.
https://github.com/vim/vim/commit/19569ca6d805de7a2ac95ee7b0c52475a9d5d851

vim-patch:8.2.3827: huntr badge does not really fit in the list

Problem:    Huntr badge does not really fit in the list.
Solution:   Move the link to Huntr to the issue template.
https://github.com/vim/vim/commit/f79cbf6512863c167bc794035df067e3a3e474f3

vim-patch:8.2.3837: QNX: crash when compiled with GUI but using terminal

Problem:    QNX: crash when compiled with GUI but using terminal.
Solution:   Check gui.in_use is set. (Hirohito Higashi, closes vim/vim#9363)
https://github.com/vim/vim/commit/d2ff705af32862b4da49d213613233f93343874c

vim-patch:8.2.3881: QNX: crash when compiled with GUI but using terminal

Problem:    QNX: crash when compiled with GUI but using terminal.
Solution:   Check the gui.in_use flag. (Hirohito Higashi, closes vim/vim#9391)
https://github.com/vim/vim/commit/6073f13f557c53928a2a9071495178599c38e798

vim-patch:8.2.3891: github CI: workflows may overlap

Problem:    Github CI: workflows may overlap.
Solution:   Cancel previous workflows when starting a new one. (Yegappan
            Lakshmanan, closes vim/vim#9400)
https://github.com/vim/vim/commit/7f4a628efefd893a3cad3a1fdde340c98360f705

vim-patch:8.2.3922: cannot build with dynamic Ruby 3.1

Problem:    Cannot build with dynamic Ruby 3.1.
Solution:   Add "_EXTRA" variables for CI.  Add missing functions. (Ozaki
            Kiichi, closes vim/vim#9420)
https://github.com/vim/vim/commit/8bb3fe4d4dcd27c02e903f6772fdc8fe2e9eba70

vim-patch:8.2.3958: build failure compiling xxd with "-std=c2x"

Problem:    Build failure compiling xxd with "-std=c2x".
Solution:   define _XOPEN_SOURCE. (Yegappan Lakshmanan, closes vim/vim#9444)
https://github.com/vim/vim/commit/ef089f50f9d6685c7a0ab94f9133576d7beec32b

vim-patch:8.2.4039: the xdiff library is linked in even when not used

Problem:    The xdiff library is linked in even when not used.
Solution:   Use configure to decide whether xdiff object files are included.
https://github.com/vim/vim/commit/67ffb417861a90fd2c1b215a42fd230272ed94cb

vim-patch:8.2.4061: codecov bash script is deprecated

Problem:    Codecov bash script is deprecated.
Solution:   Use the codecov action. (Ozaki Kiichi, closes vim/vim#9505)
https://github.com/vim/vim/commit/0d47ad40274ed9c7ace636b2a4063182c905a2b4

vim-patch:8.2.4079: MS-Windows: "gvim --version" didn't work with VIMDLL

Problem:    MS-Windows: "gvim --version" didn't work when build with VIMDLL.
Solution:   Adjust #ifdef. (Ken Takata, closes vim/vim#9517)
https://github.com/vim/vim/commit/33b25d1317e4c06ec6b1cafb46ea9cde475a61ae

vim-patch:8.2.4080: not sufficient test coverage for xxd

Problem:    Not sufficient test coverage for xxd.
Solution:   Add a few more test cases. (Erki Auerswald, closes vim/vim#9515)
https://github.com/vim/vim/commit/a00e622a294b10671ee78216dcd21169a2b884cf

vim-patch:8.2.4092: MacOS CI: unnecessarily doing "Install packages"

Problem:    MacOS CI: unnecessarily doing "Install packages".
Solution:   Only do "Install packages" for huge build.  (Ozaki Kiichi,
            closes vim/vim#9521)
https://github.com/vim/vim/commit/ece07639f4989a300276d66b13553c21a7435030

vim-patch:8.2.4096: Linux CI: unnecessarily installing packages

Problem:    Linux CI: unnecessarily installing packages
Solution:   Only install packages for huge build.  (Ozaki Kiichi,
            closes vim/vim#9530)
https://github.com/vim/vim/commit/1050476ead81a49be0289f40b2041c47a70c95ab

vim-patch:8.2.4109: MS-Windows: high dpi support is outdated

Problem:    MS-Windows: high dpi support is outdated.
Solution:   Improve High DPI support by using PerMonitorV2. (closes vim/vim#9525,
            closes vim/vim#3102)
https://github.com/vim/vim/commit/c81e9bf4f07d350b860b934aa6bf0c2a7c91d07e

vim-patch:8.2.4126: crash on exit when built with dynamic Tcl

Problem:    Crash on exit when built with dynamic Tcl and EXITFREE is defined.
            (Dominique Pellé)
Solution:   Only call Tcl_Finalize() when initialized. (closes vim/vim#9546)
https://github.com/vim/vim/commit/afa76e1cf2e7e1f9e1097e345a4272e9ddbf14ad

vim-patch:8.2.4130: MS-Windows: MSVC build may have libraries duplicated

Problem:    MS-Windows: MSVC build may have libraries duplicated.
Solution:   Improve the MSVC Makefile. (Ken Takata, closes vim/vim#9547)
https://github.com/vim/vim/commit/31dcc8de463843e3378bb15a16247940d6a147e4

vim-patch:8.2.4142: build failure with normal features without persistent undo

Problem:    Build failure with normal features without persistent undo.
Solution:   Adjust #ifdef. (closes vim/vim#9557)
https://github.com/vim/vim/commit/b4868eddd9cdc7086c88a7a3699dd435d34ae904

vim-patch:8.2.4143: MS-Windows: IME support for Win9x is obsolete

Problem:    MS-Windows: IME support for Win9x is obsolete.
Solution:   Remove the Win9x code. (Ken Takata, closes vim/vim#9559)
https://github.com/vim/vim/commit/b0b2b73dca40c26ff1f4befe5c3aad3fd4bccfad

vim-patch:8.2.4144: cannot load libsodium dynamically

Problem:    Cannot load libsodium dynamically.
Solution:   Support dynamic loading on MS-Windows. (Ken Takata, closes vim/vim#9554)
https://github.com/vim/vim/commit/1a8825d7a3484d76ca16ea2aa9769cadca7758a4

vim-patch:8.2.4158: MS-Windows: memory leak in :browse

Problem:    MS-Windows: memory leak in :browse.
Solution:   Free stuff before returning. (Ken Takata, closes vim/vim#9574)
https://github.com/vim/vim/commit/14b8d6ac6b50f2f4f3e7463e4c335f51a512ad30

vim-patch:8.2.4159: MS-Windows: _WndProc() is very long

Problem:    MS-Windows: _WndProc() is very long.
Solution:   Move code to separate functions. (Ken Takata, closes vim/vim#9573)
https://github.com/vim/vim/commit/92000e2e713a68f80a25472cfa74058366c58c9c

vim-patch:8.2.4169: MS-Windows: unnessary casts and other minor things

Problem:    MS-Windows: unnessary casts and other minor things.
Solution:   Clean up the MS-Windows code. (Ken Takata, closes vim/vim#9583)
https://github.com/vim/vim/commit/45f9cfbdc75e10d420039fbe98d9f554bd415213

vim-patch:8.2.4170: MS-Windows: still using old message API calls

Problem:    MS-Windows: still using old message API calls.
Solution:   Call the "W" functions directly. (Ken Takata, closes vim/vim#9582)
https://github.com/vim/vim/commit/b7057bdd090ddcce96dc058e4e65340c8ec961d7

vim-patch:8.2.4189: MS-Windows: code for "old look" is obsolete

Problem:    MS-Windows: code for "old look" is obsolete.
Solution:   Delete obsolete code.  Use "MS Shell Dlg" font. (Ken Takata,
            closes vim/vim#9596)
https://github.com/vim/vim/commit/d1c58999c82afbdcbbe01548c1dea06d4d086f3e

vim-patch:8.2.4194: MS-Windows: code for calculating font size is duplicated

Problem:    MS-Windows: code for calculating font size is duplicated.
Solution:   Move the code to a function. (Ken Takata, closes vim/vim#9603)
https://github.com/vim/vim/commit/abe628e1bd92ecb85a526348f376891d56bf3ea8

vim-patch:8.2.4201: when using the GUI CTRL-Z does not stop gvim

Problem:    When using the GUI CTRL-Z does not stop gvim.
Solution:   When using the GUI set SIGTSTP to SIG_DFL. (Andrew Maltsev,
            closes vim/vim#9570)
https://github.com/vim/vim/commit/8e4af851fd3eff4b22fca962e5be783742e8f1bb

vim-patch:8.2.4222: MS-Windows: clumsy way to suppress progress on CI

Problem:    MS-Windows: clumsy way to suppress progress on CI.
Solution:   Check for "$CI" in the Makefile itself. (Ken Takata, closes vim/vim#9631)
https://github.com/vim/vim/commit/47d1666d605998a97d3827eca4d467ad0930b284

vim-patch:8.2.4230: MS-Windows: set_guifontwide() is included but won't work

Problem:    MS-Windows: set_guifontwide() is included but won't work.
Solution:   Include set_guifontwide() only for X11. (Ken Takata, closes vim/vim#9640)
https://github.com/vim/vim/commit/94373c48e7e438e5b924b34ce820e9b2eb9f810c

vim-patch:8.2.4244: MS-Windows: warning from MSVC on debug build

Problem:    MS-Windows: warning from MSVC on debug build.
Solution:   Adjust "/opt"o options.  Remove unused variables.  Make variables
            uppercase for consistency. (Ken Takata, closes vim/vim#9647)
https://github.com/vim/vim/commit/14cbf77845624e4bfc28a65a5debb81864cba2cf

vim-patch:8.2.4256: MS-Windows: compiler warnings when compiled with /W4

Problem:    MS-Windows: compiler warnings when compiled with /W4.
Solution:   Small adjustments to the code. (Ken Takata, closes vim/vim#9659)
https://github.com/vim/vim/commit/135e15251efd96c960e51e8ab31333c2d6887983

vim-patch:8.2.4259: number of test functions for GUI events is growing

Problem:    Number of test functions for GUI events is growing.
Solution:   Use one function with a dictionary. (Yegappan Lakshmanan,
            closes vim/vim#9660)
https://github.com/vim/vim/commit/06011e1a55f32e47fe0af4bd449be6f0e3ff0814

vim-patch:8.2.4263: no test for the GUI find/replace dialog

Problem:    No test for the GUI find/replace dialog.
Solution:   Add a test function and a test. (Yegappan Lakshmanan,
            closes vim/vim#9662)
https://github.com/vim/vim/commit/ec3637cbaf23730b6efe5e5c0047e23adc82160b

vim-patch:8.2.4268: CI log output is long

Problem:    CI log output is long.
Solution:   Group output in sections. (Ozaki Kiichi, closes vim/vim#9670)
https://github.com/vim/vim/commit/44d1f89c241c611a0904dbbca784facfa13b7916

vim-patch:8.2.4271: MS-Windows: cannot build with Ruby 3.1.0

Problem:    MS-Windows: cannot build with Ruby 3.1.0.
Solution:   Adjust the DLL name and include directory. (Ken Takata,
            closes vim/vim#9666)
https://github.com/vim/vim/commit/1f47a287ee4f8b1d007dff878b23dd0cd6104f38

vim-patch:8.2.4276: separate test function for the GUI scrollbar

Problem:    Separate test function for the GUI scrollbar.
Solution:   Use test_gui_event(). (Yegappan Lakshmanan, closes vim/vim#9674)
https://github.com/vim/vim/commit/9e0208f51cf1354ce0a7d3988133041a78681605