### PR TITLE
vim-patch:8.2.{3947,4283}: changedir_func() refactoring

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7870,9 +7870,11 @@ bool changedir_func(char_u *new_dir, CdScope scope)
     new_dir = NameBuff;
   }
 
-  bool dir_differs = new_dir == NULL || pdir == NULL
-                     || pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
-  if (new_dir != NULL && (!dir_differs || vim_chdir(new_dir) == 0)) {
+  bool dir_differs = pdir == NULL || pathcmp((char *)pdir, (char *)new_dir, -1) != 0;
+  if (dir_differs && vim_chdir(new_dir) != 0) {
+    emsg(_(e_failed));
+    xfree(pdir);
+  } else {
     char_u **pp;
 
     switch (scope) {
@@ -7890,9 +7892,6 @@ bool changedir_func(char_u *new_dir, CdScope scope)
 
     post_chdir(scope, dir_differs);
     retval = true;
-  } else {
-    emsg(_(e_failed));
-    xfree(pdir);
   }
 
   return retval;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7835,13 +7835,11 @@ void post_chdir(CdScope scope, bool trigger_dirchanged)
 /// @return true if the directory is successfully changed.
 bool changedir_func(char_u *new_dir, CdScope scope)
 {
-  char_u *pdir = NULL;
-  bool retval = false;
-
   if (new_dir == NULL || allbuf_locked()) {
     return false;
   }
 
+  char_u *pdir = NULL;
   // ":cd -": Change to previous directory
   if (STRCMP(new_dir, "-") == 0) {
     pdir = get_prevdir(scope);
@@ -7874,27 +7872,26 @@ bool changedir_func(char_u *new_dir, CdScope scope)
   if (dir_differs && vim_chdir(new_dir) != 0) {
     emsg(_(e_failed));
     xfree(pdir);
-  } else {
-    char_u **pp;
-
-    switch (scope) {
-    case kCdScopeTabpage:
-      pp = &curtab->tp_prevdir;
-      break;
-    case kCdScopeWindow:
-      pp = &curwin->w_prevdir;
-      break;
-    default:
-      pp = &prev_dir;
-    }
-    xfree(*pp);
-    *pp = pdir;
-
-    post_chdir(scope, dir_differs);
-    retval = true;
+    return false;
   }
 
-  return retval;
+  char_u **pp;
+  switch (scope) {
+  case kCdScopeTabpage:
+    pp = &curtab->tp_prevdir;
+    break;
+  case kCdScopeWindow:
+    pp = &curwin->w_prevdir;
+    break;
+  default:
+    pp = &prev_dir;
+  }
+  xfree(*pp);
+  *pp = pdir;
+
+  post_chdir(scope, dir_differs);
+
+  return true;
 }
 
 /// ":cd", ":tcd", ":lcd", ":chdir", "tchdir" and ":lchdir".


### PR DESCRIPTION
#### vim-patch:8.2.3947: unnecessary check for NULL pointer

Problem:    Unnecessary check for NULL pointer.
Solution:   Remove the check. (closes vim/vim#9434)
https://github.com/vim/vim/commit/f38aad85cf8e4e930c96cb843bc136949c8dbd29

Reorder the two if branches to match upstream.


#### vim-patch:8.2.4283: using a variable for the return value is not needed

Problem:    Using a variable for the return value is not needed.
Solution:   Return the value directly. (closes vim/vim#9687)
https://github.com/vim/vim/commit/73257149d759a8e6ddbe555d2b5aa37b6cb8db8b

Also move down variable declarations in changedir_func().
vim_chdirfile() doesn't need change.