### PR TITLE
vim-patch:8.1.{0846,0878,0884,2358},8.2.{0305,0352,0687,3797}

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4347,6 +4347,9 @@ line({expr} [, {winid}])				*line()*
 			line("'t")		line number of mark t
 			line("'" . marker)	line number of mark marker
 <
+		To jump to the last known position when opening a file see
+		|last-position-jump|.
+
 		Can also be used as a |method|: >
 			GetValue()->line()
 
@@ -4912,8 +4915,10 @@ min({expr})	Return the minimum value of all items in {expr}.
 <							*mkdir()* *E739*
 mkdir({name} [, {path} [, {prot}]])
 		Create directory {name}.
+
 		If {path} is "p" then intermediate directories are created as
 		necessary.  Otherwise it must be "".
+
 		If {prot} is given it is used to set the protection bits of
 		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 		the user, readable for others).  Use 0o700 to make it
@@ -4922,6 +4927,7 @@ mkdir({name} [, {path} [, {prot}]])
 		{prot} is applied for all parts of {name}.  Thus if you create
 		/tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >
 			:call mkdir($HOME . "/tmp/foo/bar", "p", 0o700)
+
 <		This function is not available in the |sandbox|.
 
 		If you try to create an existing directory with {path} set to
@@ -5758,8 +5764,10 @@ remove({list}, {idx} [, {end}])				*remove()*
 		Example: >
 			:echo "last item: " . remove(mylist, -1)
 			:call remove(mylist, 0, 9)
+<
+		Use |delete()| to remove a file.
 
-<		Can also be used as a |method|: >
+		Can also be used as a |method|: >
 			mylist->remove(idx)
 
 remove({blob}, {idx} [, {end}])
@@ -5778,8 +5786,6 @@ remove({dict}, {key})
 		Example: >
 			:echo "removed " . remove(dict, "one")
 <		If there is no {key} in {dict} this is an error.
-
-		Use |delete()| to remove a file.
 
 rename({from}, {to})					*rename()*
 		Rename the file by the name {from} to the name {to}.  This

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3543,24 +3543,25 @@ has({feature})	Returns 1 if {feature} is supported, 0 otherwise.  The
 			:if has("win32")
 <							*feature-list*
 		    List of supported pseudo-feature names:
-		        acl		|ACL| support
+			acl		|ACL| support.
 			bsd		BSD system (not macOS, use "mac" for that).
-		        iconv		Can use |iconv()| for conversion.
-		        +shellslash	Can use backslashes in filenames (Windows)
 			clipboard	|clipboard| provider is available.
 			fname_case	Case in file names matters (for Darwin and MS-Windows
 					this is not present).
+			iconv		Can use |iconv()| for conversion.
+			linux		Linux system.
 			mac		MacOS system.
 			nvim		This is Nvim.
 			python3		Legacy Vim |python3| interface. |has-python|
 			pythonx		Legacy Vim |python_x| interface. |has-pythonx|
-			ttyin		input is a terminal (tty)
-			ttyout		output is a terminal (tty)
+			sun		SunOS system.
+			ttyin		input is a terminal (tty).
+			ttyout		output is a terminal (tty).
 			unix		Unix system.
 			*vim_starting*	True during |startup|.
 			win32		Windows system (32 or 64 bit).
 			win64		Windows system (64 bit).
-			wsl		WSL (Windows Subsystem for Linux) system
+			wsl		WSL (Windows Subsystem for Linux) system.
 
 							*has-patch*
 		3.  Vim patch. For example the "patch123" feature means that

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -676,7 +676,7 @@ similar to -1. >
 	:let otherblob = myblob[:]	" make a copy of the Blob
 
 If the first index is beyond the last byte of the Blob or the second byte is
-before the first byte, the result is an empty Blob.  There is no error
+before the first index, the result is an empty Blob.  There is no error
 message.
 
 If the second index is equal to or greater than the length of the Blob the

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -27,8 +27,7 @@ depends on the 'shortmess' option.
 				Clear messages, keeping only the {count} most
 				recent ones.
 
-The number of remembered messages is fixed at 20 for the tiny version and 200
-for other versions.
+The number of remembered messages is fixed at 200.
 
 								*g<*
 The "g<" command can be used to see the last page of previous command output.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4433,6 +4433,12 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 #if defined(BSD) && !defined(__APPLE__)
     "bsd",
 #endif
+#ifdef __linux__
+    "linux",
+#endif
+#ifdef SUN_SYSTEM
+    "sun",
+#endif
 #ifdef UNIX
     "unix",
 #endif

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -63,6 +63,15 @@ func CheckUnix()
   endif
 endfunc
 
+" Command to check for not running on a BSD system.
+" TODO: using this checks should not be needed
+command CheckNotBSD call CheckNotBSD()
+func CheckNotBSD()
+  if has('bsd')
+    throw 'Skipped: does not work on BSD'
+  endif
+endfunc
+
 " Command to check that making screendumps is supported.
 " Caller must source screendump.vim
 command CheckScreendump call CheckScreendump()

--- a/src/nvim/testdir/test_alot_utf8.vim
+++ b/src/nvim/testdir/test_alot_utf8.vim
@@ -6,7 +6,6 @@
 
 source test_charsearch_utf8.vim
 source test_expr_utf8.vim
-source test_matchadd_conceal_utf8.vim
 source test_mksession_utf8.vim
 source test_regexp_utf8.vim
 source test_source_utf8.vim

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1397,6 +1397,8 @@ func Test_platform_name()
     let uname = system('uname')
     call assert_equal(uname =~? 'BeOS', has('beos'))
     call assert_equal(uname =~? 'BSD\|DragonFly', has('bsd'))
+    " GNU userland on BSD kernels (e.g., GNU/kFreeBSD) don't have BSD defined
+    call assert_equal(uname =~? '\%(GNU/k\w\+\)\@<!BSD\|DragonFly', has('bsd'))
     call assert_equal(uname =~? 'HP-UX', has('hpux'))
     call assert_equal(uname =~? 'Linux', has('linux'))
     call assert_equal(uname =~? 'Darwin', has('mac'))

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1396,7 +1396,6 @@ func Test_platform_name()
   if has('unix') && executable('uname')
     let uname = system('uname')
     call assert_equal(uname =~? 'BeOS', has('beos'))
-    call assert_equal(uname =~? 'BSD\|DragonFly', has('bsd'))
     " GNU userland on BSD kernels (e.g., GNU/kFreeBSD) don't have BSD defined
     call assert_equal(uname =~? '\%(GNU/k\w\+\)\@<!BSD\|DragonFly', has('bsd'))
     call assert_equal(uname =~? 'HP-UX', has('hpux'))

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1377,6 +1377,35 @@ func Test_func_exists_on_reload()
   delfunc ExistingFunction
 endfunc
 
+func Test_platform_name()
+  " The system matches at most only one name.
+  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32', 'win32unix']
+  call assert_inrange(0, 1, len(filter(copy(names), 'has(v:val)')))
+
+  " Is Unix?
+  call assert_equal(has('beos'), has('beos') && has('unix'))
+  call assert_equal(has('bsd'), has('bsd') && has('unix'))
+  call assert_equal(has('hpux'), has('hpux') && has('unix'))
+  call assert_equal(has('linux'), has('linux') && has('unix'))
+  call assert_equal(has('mac'), has('mac') && has('unix'))
+  call assert_equal(has('qnx'), has('qnx') && has('unix'))
+  call assert_equal(has('sun'), has('sun') && has('unix'))
+  call assert_equal(has('win32'), has('win32') && !has('unix'))
+  call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
+
+  if has('unix') && executable('uname')
+    let uname = system('uname')
+    call assert_equal(uname =~? 'BeOS', has('beos'))
+    call assert_equal(uname =~? 'BSD\|DragonFly', has('bsd'))
+    call assert_equal(uname =~? 'HP-UX', has('hpux'))
+    call assert_equal(uname =~? 'Linux', has('linux'))
+    call assert_equal(uname =~? 'Darwin', has('mac'))
+    call assert_equal(uname =~? 'QNX', has('qnx'))
+    call assert_equal(uname =~? 'SunOS', has('sun'))
+    call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
+  endif
+endfunc
+
 sandbox function Fsandbox()
   normal ix
 endfunc
@@ -1519,24 +1548,31 @@ func Test_libcall_libcallnr()
     let libc = 'msvcrt.dll'
   elseif has('mac')
     let libc = 'libSystem.B.dylib'
-  elseif system('uname -s') =~ 'SunOS'
-    " Set the path to libc.so according to the architecture.
-    let test_bits = system('file ' . GetVimProg())
-    let test_arch = system('uname -p')
-    if test_bits =~ '64-bit' && test_arch =~ 'sparc'
-      let libc = '/usr/lib/sparcv9/libc.so'
-    elseif test_bits =~ '64-bit' && test_arch =~ 'i386'
-      let libc = '/usr/lib/amd64/libc.so'
-    else
-      let libc = '/usr/lib/libc.so'
-    endif
-  elseif system('uname -s') =~ 'OpenBSD'
-    let libc = 'libc.so'
-  else
+  elseif executable('ldd')
+    let libc = matchstr(split(system('ldd ' . GetVimProg())), '/libc\.so\>')
+  endif
+  if get(l:, 'libc', '') ==# ''
     " On Unix, libc.so can be in various places.
-    " Interestingly, using an empty string for the 1st argument of libcall
-    " allows to call functions from libc which is not documented.
-    let libc = ''
+    if has('linux')
+      " There is not documented but regarding the 1st argument of glibc's
+      " dlopen an empty string and nullptr are equivalent, so using an empty
+      " string for the 1st argument of libcall allows to call functions.
+      let libc = ''
+    elseif has('sun')
+      " Set the path to libc.so according to the architecture.
+      let test_bits = system('file ' . GetVimProg())
+      let test_arch = system('uname -p')
+      if test_bits =~ '64-bit' && test_arch =~ 'sparc'
+        let libc = '/usr/lib/sparcv9/libc.so'
+      elseif test_bits =~ '64-bit' && test_arch =~ 'i386'
+        let libc = '/usr/lib/amd64/libc.so'
+      else
+        let libc = '/usr/lib/libc.so'
+      endif
+    else
+      " Unfortunately skip this test until a good way is found.
+      return
+    endif
   endif
 
   if has('win32')

--- a/src/nvim/testdir/test_number.vim
+++ b/src/nvim/testdir/test_number.vim
@@ -284,10 +284,10 @@ func Test_relativenumber_colors()
   " Default colors
   call VerifyScreenDump(buf, 'Test_relnr_colors_1', {})
 
-  call term_sendkeys(buf, ":hi LineNrAbove ctermfg=blue\<CR>")
+  call term_sendkeys(buf, ":hi LineNrAbove ctermfg=blue\<CR>:\<CR>")
   call VerifyScreenDump(buf, 'Test_relnr_colors_2', {})
 
-  call term_sendkeys(buf, ":hi LineNrBelow ctermfg=green\<CR>")
+  call term_sendkeys(buf, ":hi LineNrBelow ctermfg=green\<CR>:\<CR>")
   call VerifyScreenDump(buf, 'Test_relnr_colors_3', {})
 
   call term_sendkeys(buf, ":hi clear LineNrAbove\<CR>")

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1789,6 +1789,7 @@ func s:create_test_file(filename)
 endfunc
 
 func Test_switchbuf()
+  CheckNotBSD
   call s:create_test_file('Xqftestfile1')
   call s:create_test_file('Xqftestfile2')
   call s:create_test_file('Xqftestfile3')

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1789,7 +1789,6 @@ func s:create_test_file(filename)
 endfunc
 
 func Test_switchbuf()
-  CheckNotBSD
   call s:create_test_file('Xqftestfile1')
   call s:create_test_file('Xqftestfile2')
   call s:create_test_file('Xqftestfile3')
@@ -1915,6 +1914,7 @@ func Test_switchbuf()
 
   " If opening a file changes 'switchbuf', then the new value should be
   " retained.
+  set modeline&vim
   call writefile(["vim: switchbuf=split"], 'Xqftestfile1')
   enew | only
   set switchbuf&vim

--- a/src/nvim/testdir/test_source_utf8.vim
+++ b/src/nvim/testdir/test_source_utf8.vim
@@ -1,7 +1,10 @@
 " Test the :source! command
+source check.vim
 
 func Test_source_utf8()
   " check that sourcing a script with 0x80 as second byte works
+  " does not work correctly on BSD
+  CheckNotBSD
   new
   call setline(1, [':%s/àx/--à1234--/g', ':%s/Àx/--À1234--/g'])
   write! Xscript
@@ -31,6 +34,7 @@ endfunc
 
 " Test for sourcing a file with CTRL-V's at the end of the line
 func Test_source_ctrl_v()
+    CheckNotBSD
     call writefile(['map __1 afirst',
 		\ 'map __2 asecond',
 		\ 'map __3 athird',

--- a/src/nvim/testdir/test_source_utf8.vim
+++ b/src/nvim/testdir/test_source_utf8.vim
@@ -3,8 +3,6 @@ source check.vim
 
 func Test_source_utf8()
   " check that sourcing a script with 0x80 as second byte works
-  " does not work correctly on BSD
-  CheckNotBSD
   new
   call setline(1, [':%s/àx/--à1234--/g', ':%s/Àx/--À1234--/g'])
   write! Xscript
@@ -34,25 +32,24 @@ endfunc
 
 " Test for sourcing a file with CTRL-V's at the end of the line
 func Test_source_ctrl_v()
-    CheckNotBSD
-    call writefile(['map __1 afirst',
-		\ 'map __2 asecond',
-		\ 'map __3 athird',
-		\ 'map __4 afourth',
-		\ 'map __5 afifth',
-		\ "map __1 asd\<C-V>",
-		\ "map __2 asd\<C-V>\<C-V>",
-		\ "map __3 asd\<C-V>\<C-V>",
-		\ "map __4 asd\<C-V>\<C-V>\<C-V>",
-		\ "map __5 asd\<C-V>\<C-V>\<C-V>",
-		\ ], 'Xtestfile')
+  call writefile(['map __1 afirst',
+        \ 'map __2 asecond',
+        \ 'map __3 athird',
+        \ 'map __4 afourth',
+        \ 'map __5 afifth',
+        \ "map __1 asd\<C-V>",
+        \ "map __2 asd\<C-V>\<C-V>",
+        \ "map __3 asd\<C-V>\<C-V>",
+        \ "map __4 asd\<C-V>\<C-V>\<C-V>",
+        \ "map __5 asd\<C-V>\<C-V>\<C-V>",
+        \ ], 'Xtestfile')
   source Xtestfile
   enew!
   exe "normal __1\<Esc>\<Esc>__2\<Esc>__3\<Esc>\<Esc>__4\<Esc>__5\<Esc>"
   exe "%s/\<C-J>/0/g"
   call assert_equal(['sd',
-	      \ "map __2 asd\<Esc>secondsd\<Esc>sd0map __5 asd0fifth"],
-	      \ getline(1, 2))
+        \ "map __2 asd\<Esc>secondsd\<Esc>sd0map __5 asd0fifth"],
+        \ getline(1, 2))
 
   enew!
   call delete('Xtestfile')

--- a/src/nvim/testdir/test_utf8_comparisons.vim
+++ b/src/nvim/testdir/test_utf8_comparisons.vim
@@ -86,6 +86,9 @@ endfunc
 " test that g~ap changes one paragraph only.
 func Test_gap()
   new
-  call feedkeys("iabcd\n\ndefggg0g~ap", "tx")
+  " setup text
+  call feedkeys("iabcd\<cr>\<cr>defg", "tx")
+  " modify only first line
+  call feedkeys("gg0g~ap", "tx")
   call assert_equal(["ABCD", "", "defg"], getline(1,3))
 endfunc

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -43,7 +43,7 @@ func Test_writefile_fails_gently()
 endfunc
 
 func Test_writefile_fails_conversion()
-  if !has('iconv') || system('uname -s') =~ 'SunOS'
+  if !has('iconv') || has('sun')
     return
   endif
   " Without a backup file the write won't happen if there is a conversion


### PR DESCRIPTION
#### vim-patch:8.1.0846: not easy to recognize the system Vim runs on

Problem:    Not easy to recognize the system Vim runs on.
Solution:   Add more items to the features list. (Ozaki Kiichi, closes vim/vim#3855)
https://github.com/vim/vim/commit/39536dd557e847e80572044c2be319db5886abe3

Some doc changes have already been applied. Some others are N/A.
"moon" was removed in patch 8.2.0427 so I did not add it.


#### vim-patch:8.1.0878: test for has('bsd') fails on some BSD systems

Problem:    Test for has('bsd') fails on some BSD systems.
Solution:   Adjust the uname match. (James McCoy, closes vim/vim#3909)
https://github.com/vim/vim/commit/a02e3f65c52a2c8c987e7dcac5df1f8db9a7b0de


#### vim-patch:8.1.0884: double check for bsd systems

Problem:    Double check for bsd systems.
Solution:   Delete the old line.
https://github.com/vim/vim/commit/af630d4f7f8daa7edbda0b607d32d39a5feae9d9


#### vim-patch:8.1.2358: tests fail on Cirrus CI for FreeBSD

Problem:    Tests fail on Cirrus CI for FreeBSD.
Solution:   Fix a test and skip some. (Christian Brabandt, closes vim/vim#5281)
https://github.com/vim/vim/commit/9134f1ecd41207045db3cb47f0269497980395ad
    
Skip test_normal.vim: already applied in #11483.


#### vim-patch:8.2.0305: relativenumber test fails on some systems

Problem:    Relativenumber test fails on some systems. (James McCoy)
Solution:   Clear the command line.
https://github.com/vim/vim/commit/8040a7147f5b896a702d1684e7831df107490f45


#### vim-patch:8.2.0352: FreeBSD: test for sourcing utf-8 is skipped

Problem:    FreeBSD: test for sourcing utf-8 is skipped.
Solution:   Run the matchadd_conceal test separately to avoid that setting
            'term' to "ansi" causes problems for other tests. (Ozaki Kiichi,
            closes vim/vim#5721)
https://github.com/vim/vim/commit/36ddf9383181f93b080eb26121bdff37e394d2db


#### vim-patch:8.2.0687: some tests do not work on FreeBSD

Problem:    Some tests do not work on FreeBSD.
Solution:   Enable modeline.  Use WaitFor() in more cases. (Ozaki Kiichi,
            closes vim/vim#6036)
https://github.com/vim/vim/commit/41d4299f26cc98e253f9c63f8adc9dbb9d49ed5c


#### vim-patch:8.2.3797: no good reason to limit the message history in tiny version

Problem:    No good reason to limit the message history in the tiny version.
Solution:   Always use 200.
https://github.com/vim/vim/commit/1e78deb0779bc403a914712f0842a65d2949dfdf


Some of patch 8.1.0846 and patch 8.1.2358 were ported in #11483, which accidentally marked these two patches as fully ported.