### PR TITLE
fix(event-loop): do not make vgetc() called from state_enter() block

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -148,6 +148,8 @@ EXTERN bool cmdline_was_last_drawn INIT(= false);  // cmdline was last drawn
 
 EXTERN bool exec_from_reg INIT(= false);         // executing register
 
+EXTERN bool no_block_input INIT(= false);
+
 // When '$' is included in 'cpoptions' option set:
 // When a change command is given that deletes only part of a line, a dollar
 // is put at the end of the changed text. dollar_vcol is set to the virtual

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -39,11 +39,12 @@ void state_enter(VimState *s)
     int key;
 
 getkey:
+    no_block_input = true;
     if (char_avail() || using_script() || input_available()) {
       // Don't block for events if there's a character already available for
       // processing. Characters can come from mappings, scripts and other
       // sources, so this scenario is very common.
-      key = safe_vgetc();
+      key = vgetc();
     } else if (!multiqueue_empty(main_loop.events)) {
       // Event was made available after the last multiqueue_process_events call
       key = K_EVENT;
@@ -57,7 +58,12 @@ getkey:
       // If an event was put into the queue, we send K_EVENT directly.
       key = !multiqueue_empty(main_loop.events)
             ? K_EVENT
-            : safe_vgetc();
+            : vgetc();
+    }
+    no_block_input = false;
+
+    if (key == NUL) {
+      goto getkey;
     }
 
     if (key == K_EVENT) {

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -140,6 +140,25 @@ describe('input utf sequences that contain CSI (0x9B)', function()
   end)
 end)
 
+describe('input split utf sequences', function()
+  it('ok', function()
+    local str = '►'
+    feed('i' .. str:sub(1, 1))
+    helpers.sleep(10)
+    feed(str:sub(2, 3))
+    expect('►')
+  end)
+
+  it('can be mapped', function()
+    command('inoremap ► E296BA')
+    local str = '►'
+    feed('i' .. str:sub(1, 1))
+    helpers.sleep(10)
+    feed(str:sub(2, 3))
+    expect('E296BA')
+  end)
+end)
+
 describe('input non-printable chars', function()
   after_each(function()
     os.remove('Xtest-overwrite')


### PR DESCRIPTION
Fix #17257

`state_enter()` does blocking wait by calling `os_inchar()`. When `state_enter()` calls `vgetc()`, there is input available, so it expects getting a character immediately. This is not always the case though, as there can be mappings that map to an empty string, which can lead to a blocking wait where events are not processed. I'm not sure whether adding a global variable to prevent a blocking wait is the best solution.