### PR TITLE
fix(event-loop): call vpeekc() directly first to check for character

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3180,7 +3180,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv)
     if (argvars[0].v_type == VAR_UNKNOWN) {
       // getchar(): blocking wait.
       // TODO(bfredl): deduplicate shared logic with state_enter ?
-      if (!(char_avail() || using_script() || input_available())) {
+      if (!char_avail()) {
         (void)os_inchar(NULL, 0, -1, 0, main_loop.events);
         if (!multiqueue_empty(main_loop.events)) {
           state_handle_k_event();

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -140,6 +140,25 @@ describe('input utf sequences that contain CSI (0x9B)', function()
   end)
 end)
 
+describe('input split utf sequences', function()
+  it('ok', function()
+    local str = '►'
+    feed('i' .. str:sub(1, 1))
+    helpers.sleep(10)
+    feed(str:sub(2, 3))
+    expect('►')
+  end)
+
+  it('can be mapped', function()
+    command('inoremap ► E296BA')
+    local str = '►'
+    feed('i' .. str:sub(1, 1))
+    helpers.sleep(10)
+    feed(str:sub(2, 3))
+    expect('E296BA')
+  end)
+end)
+
 describe('input non-printable chars', function()
   after_each(function()
     os.remove('Xtest-overwrite')

--- a/test/functional/vimscript/timer_spec.lua
+++ b/test/functional/vimscript/timer_spec.lua
@@ -272,4 +272,12 @@ describe('timers', function()
     ]]
     eq("Vim(call):E48: Not allowed in sandbox", exc_exec("sandbox call timer_start(0, 'Scary')"))
   end)
+
+  it('can be triggered after an empty string <expr> mapping', function()
+    local screen = Screen.new(40, 6)
+    screen:attach()
+    command([=[imap <expr> <F2> [timer_start(0, { _ -> execute("throw 'x'", "") }), ''][-1]]=])
+    feed('i<F2>')
+    screen:expect({any='E605: Exception not caught: x'})
+  end)
 end)


### PR DESCRIPTION
Fix #17257

Expand mappings first by calling `vpeekc()` directly.

- If `vpeekc()` returns non-`NUL`, there is a character already available for processing, so don't block for events. `vgetc()` may still block, in case of an incomplete UTF-8 sequence.

- If `vpeekc()` returns `NUL`, `vgetc()` will block, and there are three cases:
  - There is no input available.
  - All of available input maps to an empty string.
  - There is an incomplete mapping.

  A blocking wait for a character should only be done in the third case, which is the only case of the three where `typebuf.tb_len > 0` after `vpeekc()` returns `NUL`.

`using_script()` and `input_available()` also seem unnecessary after `vpeekc()` or `char_avail()`.