### PR TITLE
vim-patch:8.2.4151: reading beyond the end of a line

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -560,15 +560,8 @@ static void block_insert(oparg_T *oap, char_u *s, int b_insert, struct block_def
     }
 
     if (spaces > 0) {
-      int off;
-
-      // Avoid starting halfway through a multi-byte character.
-      if (b_insert) {
-        off = utf_head_off(oldp, oldp + offset + spaces);
-      } else {
-        off = (*mb_off_next)(oldp, oldp + offset);
-        offset += off;
-      }
+      // avoid copying part of a multi-byte character
+      int off = utf_head_off(oldp, oldp + offset + spaces);
       spaces -= off;
       count -= off;
     }

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1187,5 +1187,13 @@ func Test_visual_undo_deletes_last_line()
   bwipe!
 endfunc
 
+func Test_visual_block_insert_round_off()
+  new
+  " The number of characters are tuned to fill a 4096 byte allocated block,
+  " so that valgrind reports going over the end.
+  call setline(1, ['xxxxx', repeat('0', 1350), "\t", repeat('x', 60)])
+  exe "normal gg0\<C-V>GI" .. repeat('0', 1320) .. "\<Esc>"
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Reading beyond the end of a line.
Solution:   For block insert only use the offset for correcting the length.
https://github.com/vim/vim/commit/57df9e8a9f9ae1aafdde9b86b10ad907627a87dc

Note: 8.2.4152 seems NA

https://github.com/vim/vim/commit/fc6ccebea668c49e9e617e0657421b6a8ed9df1e

It is security fix.

https://nvd.nist.gov/vuln/detail/CVE-2022-0318
https://huntr.dev/bounties/0d10ba02-b138-4e68-a284-67f781a62d08/