### PR TITLE
ci: disable tracing (set -x) from the shell scripts

### DIFF
--- a/ci/common/submit_coverage.sh
+++ b/ci/common/submit_coverage.sh
@@ -4,7 +4,7 @@
 # Args:
 # $1: Flag(s) for codecov, separated by comma.
 
-set -ex
+set -e
 
 # Change to grandparent dir (POSIXly).
 CDPATH='' cd -P -- "$(dirname -- "$0")/../.." || exit

--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -29,17 +29,14 @@ ci_fold() {
 }
 
 enter_suite() {
-  set +x
   FAILED=0
   rm -f "${END_MARKER}"
   local suite_name="$1"
   export NVIM_TEST_CURRENT_SUITE="${NVIM_TEST_CURRENT_SUITE}/$suite_name"
   ci_fold "start" "$suite_name"
-  set -x
 }
 
 exit_suite() {
-  set +x
   if test $FAILED -ne 0 ; then
     echo "Suite ${NVIM_TEST_CURRENT_SUITE} failed, summary:"
     echo "${FAIL_SUMMARY}"

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -119,7 +119,6 @@ run_oldtests() {(
 )}
 
 check_runtime_files() {(
-  set +x
   local test_name="$1" ; shift
   local message="$1" ; shift
   local tst="$1" ; shift


### PR DESCRIPTION
Output like

```
++ fail functionaltests F 'Functional tests failed'
++ local test_name=functionaltests
++ local fail_char=F
++ local 'message=Functional tests failed'
++ : F
++ : Functional tests failed
++ local 'full_msg=F /functionaltests|functionaltests :: Functional tests failed'
++ FAIL_SUMMARY='
F /functionaltests|functionaltests :: Functional tests failed'
++ echo 'F /functionaltests|functionaltests :: Functional tests failed'
++ echo 'Failed: F /functionaltests|functionaltests :: Functional tests failed'
Failed: F /functionaltests|functionaltests :: Functional tests failed
```

feels a bit excessive. 