### PR TITLE
vim-patch:8.1.2133: some tests fail when run as root

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -113,6 +113,14 @@ func CheckNotGui()
   endif
 endfunc
 
+" Command to check that test is not running as root
+command CheckNotRoot call CheckNotRoot()
+func CheckNotRoot()
+  if IsRoot()
+    throw 'Skipped: cannot run test as root'
+  endif
+endfunc
+
 " Command to check that the current language is English
 command CheckEnglish call CheckEnglish()
 func CheckEnglish()

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -343,6 +343,15 @@ func RunVimPiped(before, after, arguments, pipecmd)
   return 1
 endfunc
 
+func IsRoot()
+  if !has('unix')
+    return v:false
+  elseif $USER == 'root' || system('id -un') =~ '\<root\>'
+    return v:true
+  endif
+  return v:false
+endfunc
+
 " Get all messages but drop the maintainer entry.
 func GetMessages()
   redir => result

--- a/src/nvim/testdir/test_rename.vim
+++ b/src/nvim/testdir/test_rename.vim
@@ -1,5 +1,7 @@
 " Test rename()
 
+source shared.vim
+
 func Test_rename_file_to_file()
   call writefile(['foo'], 'Xrename1')
 
@@ -81,7 +83,7 @@ func Test_rename_copy()
 
   call assert_equal(0, rename('Xrenamedir/Xrenamefile', 'Xrenamefile'))
 
-  if !has('win32')
+  if !has('win32') && !IsRoot()
     " On Windows, the source file is removed despite
     " its directory being made not writable.
     call assert_equal(['foo'], readfile('Xrenamedir/Xrenamefile'))

--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -1,6 +1,7 @@
 " Tests for the swap feature
 
 source check.vim
+source shared.vim
 
 func s:swapname()
   return trim(execute('swapname'))
@@ -198,14 +199,17 @@ func Test_swapfile_delete()
   quit
   call assert_equal(fnamemodify(swapfile_name, ':t'), fnamemodify(s:swapname, ':t'))
 
-  " Write the swapfile with a modified PID, now it will be automatically
-  " deleted. Process one should never be Vim.
-  let swapfile_bytes[24:27] = 0z01000000
-  call writefile(swapfile_bytes, swapfile_name)
-  let s:swapname = ''
-  split XswapfileText
-  quit
-  call assert_equal('', s:swapname)
+  " This test won't work as root because root can successfully run kill(1, 0)
+  if !IsRoot()
+    " Write the swapfile with a modified PID, now it will be automatically
+    " deleted. Process one should never be Vim.
+    let swapfile_bytes[24:27] = 0z01000000
+    call writefile(swapfile_bytes, swapfile_name)
+    let s:swapname = ''
+    split XswapfileText
+    quit
+    call assert_equal('', s:swapname)
+  endif
 
   " Now set the modified flag, the swap file will not be deleted
   let swapfile_bytes[28 + 80 + 899] = 0x55


### PR DESCRIPTION
#### vim-patch:8.1.2133: some tests fail when run as root

Problem:    Some tests fail when run as root.
Solution:   Add CheckNotRoot and use it. (James McCoy, closes vim/vim#5020)
https://github.com/vim/vim/commit/07282f01da06c158bab4787adc89ec15d7eeb202

Skip test_terminal.vim and test_viminfo.vim: N/A