### PR TITLE
vim-patch:8.2.1128: the write message mentions characters, but it's bytes

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5462,7 +5462,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	 flag	meaning when present	~
 	  f	use "(3 of 5)" instead of "(file 3 of 5)"
 	  i	use "[noeol]" instead of "[Incomplete last line]"
-	  l	use "999L, 888C" instead of "999 lines, 888 characters"
+	  l	use "999L, 888B" instead of "999 lines, 888 bytes"
 	  m	use "[+]" instead of "[Modified]"
 	  n	use "[New]" instead of "[New File]"
 	  r	use "[RO]" instead of "[readonly]"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3863,7 +3863,7 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
     *p++ = ' ';
   }
   if (shortmess(SHM_LINES)) {
-    vim_snprintf((char *)p, IOSIZE - (p - IObuff), "%" PRId64 "L, %" PRId64 "C",
+    vim_snprintf((char *)p, IOSIZE - (p - IObuff), "%" PRId64 "L, %" PRId64 "B",
                  (int64_t)lnum, (int64_t)nchars);
   } else {
     vim_snprintf((char *)p, IOSIZE - (p - IObuff),
@@ -3871,7 +3871,7 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
                  (int64_t)lnum);
     p += STRLEN(p);
     vim_snprintf((char *)p, IOSIZE - (p - IObuff),
-                 NGETTEXT("%" PRId64 " character", "%" PRId64 " characters", nchars),
+                 NGETTEXT("%" PRId64 " byte", "%" PRId64 " bytes", nchars),
                  (int64_t)nchars);
   }
 }

--- a/src/nvim/testdir/test_cscope.vim
+++ b/src/nvim/testdir/test_cscope.vim
@@ -102,7 +102,7 @@ func Test_cscopeWithCscopeConnections()
     for cmd in ['cs find f Xmemfile_test.c', 'cs find 7 Xmemfile_test.c']
       enew
       let a = execute(cmd)
-      call assert_true(a =~ '"Xmemfile_test.c" \d\+L, \d\+C')
+      call assert_true(a =~ '"Xmemfile_test.c" \d\+L, \d\+B')
       call assert_equal('Xmemfile_test.c', @%)
     endfor
 
@@ -112,7 +112,7 @@ func Test_cscopeWithCscopeConnections()
       let a = execute(cmd)
       let alines = split(a, '\n', 1)
       call assert_equal('', alines[0])
-      call assert_true(alines[1] =~ '"Xmemfile_test.c" \d\+L, \d\+C')
+      call assert_true(alines[1] =~ '"Xmemfile_test.c" \d\+L, \d\+B')
       call assert_equal('(1 of 1): <<global>> #include <assert.h>', alines[2])
       call assert_equal('#include <assert.h>', getline('.'))
     endfor

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -56,7 +56,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
       line 3                                            |
       line 4                                            |
       {5:xtest-foo                                         }|
-      "xtest-foo" 4L, 28C                               |
+      "xtest-foo" 4L, 28B                               |
       {3:-- TERMINAL --}                                    |
     ]]}
   end)

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -165,7 +165,7 @@ describe('input non-printable chars', function()
       {1:~                                                           }|
       {1:~                                                           }|
       {1:~                                                           }|
-      "Xtest-overwrite" [noeol] 1L, 6C                            |
+      "Xtest-overwrite" [noeol] 1L, 6B                            |
     ]])
 
     -- The timestamp is in second resolution, wait two seconds to be sure.


### PR DESCRIPTION
#### vim-patch:8.2.1128: the write message mentions characters, but it's bytes

Problem:    The write message mentions characters, but it's actually bytes.
Solution:   Change "C" to "B" and "characters" to "bytes".
https://github.com/vim/vim/commit/3f40ce78f5c178d15871bd784ed878c78f0b8a44