### PR TITLE
feat: new option 'mappings' (buffer-local)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3894,6 +3894,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
+						*'mappings'* *'maps'*
+'mappings' 'maps'	string	(default "")
+			local to buffer
+	This option specifies what kind of user mappings will be processed
+	inside the current buffer:
+	  <empty>	both global and buffer-local mappings
+	  no		no user mappings will be processed
+	  global	only process global mappings (as if there were no
+			defined buffer-local mappings)
+	  buffer	only process buffer mappings (as if there were no
+			defined global mappings)
+
 						*'matchpairs'* *'mps'*
 'matchpairs' 'mps'	string	(default "(:),{:},[:]")
 			local to buffer

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1894,6 +1894,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_fp);
   clear_string_option(&buf->b_p_fex);
   clear_string_option(&buf->b_p_kp);
+  clear_string_option(&buf->b_p_maps);
   clear_string_option(&buf->b_p_mps);
   clear_string_option(&buf->b_p_fo);
   clear_string_option(&buf->b_p_flp);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -729,6 +729,7 @@ struct file_buffer {
   char_u *b_p_kp;               ///< 'keywordprg'
   int b_p_lisp;                 ///< 'lisp'
   char_u *b_p_menc;             ///< 'makeencoding'
+  char_u *b_p_maps;             ///< 'mappings'
   char_u *b_p_mps;              ///< 'matchpairs'
   int b_p_ml;                   ///< 'modeline'
   int b_p_ml_nobin;             ///< b_p_ml saved for binary mode

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -158,6 +158,7 @@ static int p_lisp;
 static int p_ml;
 static int p_ma;
 static int p_mod;
+static char_u *p_maps;
 static char_u *p_mps;
 static char_u *p_nf;
 static int p_pi;
@@ -303,7 +304,8 @@ static char *(p_buftype_values[]) =   { "nofile", "nowrite", "quickfix",
 
 static char *(p_bufhidden_values[]) = { "hide", "unload", "delete",
                                         "wipe", NULL };
-static char *(p_bs_values[]) = { "indent", "eol", "start", "nostop", NULL };
+static char *(p_maps_values[]) =      { "global", "buffer", "no", NULL };
+static char *(p_bs_values[]) =        { "indent", "eol", "start", "nostop", NULL };
 static char *(p_fdm_values[]) =       { "manual", "expr", "marker", "indent",
                                         "syntax",  "diff", NULL };
 static char *(p_fcl_values[]) =       { "all", NULL };
@@ -2040,6 +2042,7 @@ void check_buf_options(buf_T *buf)
   check_string_option(&buf->b_p_fp);
   check_string_option(&buf->b_p_fex);
   check_string_option(&buf->b_p_kp);
+  check_string_option(&buf->b_p_maps);
   check_string_option(&buf->b_p_mps);
   check_string_option(&buf->b_p_fo);
   check_string_option(&buf->b_p_flp);
@@ -2902,6 +2905,11 @@ ambw_end:
   } else if (gvarp == &p_bh) {
     // When 'bufhidden' is set, check for valid value.
     if (check_opt_strings(curbuf->b_p_bh, p_bufhidden_values, false) != OK) {
+      errmsg = e_invarg;
+    }
+  } else if (gvarp == &p_maps) {
+    // When 'mappings' is set, check for valid value.
+    if (check_opt_strings(curbuf->b_p_maps, p_maps_values, false) != OK) {
       errmsg = e_invarg;
     }
   } else if (gvarp == &p_bt) {
@@ -6092,6 +6100,8 @@ static char_u *get_varp(vimoption_T *p)
     return (char_u *)&(curbuf->b_p_lisp);
   case PV_ML:
     return (char_u *)&(curbuf->b_p_ml);
+  case PV_MAPS:
+    return (char_u *)&(curbuf->b_p_maps);
   case PV_MPS:
     return (char_u *)&(curbuf->b_p_mps);
   case PV_MA:

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -810,6 +810,7 @@ enum {
   BV_MA,
   BV_ML,
   BV_MOD,
+  BV_MAPS,
   BV_MPS,
   BV_NF,
   BV_OFU,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1478,6 +1478,15 @@ return {
       defaults={if_true="make"}
     },
     {
+      full_name='mappings', abbreviation='maps',
+      short_desc=N_("kind of mappings that are enabled for current buffer"),
+      type='string', scope={'buffer'},
+      noglob=true,
+      alloced=true,
+      varname='p_maps',
+      defaults={if_true=""}
+    },
+    {
       full_name='matchpairs', abbreviation='mps',
       short_desc=N_("pairs of characters that \"%\" can match"),
       type='string', list='onecomma', scope={'buffer'},


### PR DESCRIPTION
```
'mappings' 'maps'	string	(default "")
			local to buffer
	This option specifies what kind of user mappings will be processed
	inside the current buffer:
	  <empty>	both global and buffer-local mappings
	  no		no user mappings will be processed
	  global	only process global mappings (as if there were no
			defined buffer-local mappings)
	  buffer	only process buffer mappings (as if there were no
			defined global mappings)
```

Reason: the only way (that I know) to have global mappings ignored is to do a

    :mapclear

but you never want to do that because it's not reversible. Buffer mappings can be cleared with

    :mapclear <buffer>

but special buffers have little use for that.

When creating special buffers, you often don't want interferences from user mappings, especially global mappings. Possible uses:

- telescope.nvim uses a buffer to get user input, but all user mappings will be processed, so if the user has mappings that start with `j` they will interfere
- other special buffers don't really care about user mappings and they could also interfere
- in `diff` mode, one could want to ignore user mappings
- for testing purposes, one may want to temporarily ignore mappings to see if some of them is causing misbehaviours, without really clearing them permanently
