### PR TITLE
Clarify replace_termcodes from_part behavior

### DIFF
--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -59,7 +59,7 @@ function keymap.set(mode, lhs, rhs, opts)
   if is_rhs_luaref and opts.expr and opts.replace_keycodes ~= false then
     local user_rhs = rhs
     rhs = function ()
-      return vim.api.nvim_replace_termcodes(user_rhs(), true, true, true)
+      return vim.api.nvim_replace_termcodes(user_rhs(), false, true, true)
     end
   end
   -- clear replace_keycodes from opts table

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -201,7 +201,7 @@ static void on_redraw_event(void **argv)
 ///
 /// Example:
 /// <pre>
-///     :let key = nvim_replace_termcodes("<C-o>", v:true, v:false, v:true)
+///     :let key = nvim_replace_termcodes("<C-o>", v:false, v:false, v:true)
 ///     :call nvim_feedkeys(key, 'n', v:false)
 /// </pre>
 ///
@@ -392,7 +392,8 @@ error:
 /// the internal representation.
 ///
 /// @param str        String to be converted.
-/// @param from_part  Legacy Vim parameter. Usually true.
+/// @param from_part  Replace "#n" (where n is a digit) at the beginning
+///                   with a functional key, like in the lhs of a mapping.
 /// @param do_lt      Also translate <lt>. Ignored if `special` is false.
 /// @param special    Replace |keycodes|, e.g. <CR> becomes a "\r" char.
 /// @see replace_termcodes

--- a/src/nvim/keymap.c
+++ b/src/nvim/keymap.c
@@ -821,31 +821,30 @@ int get_mouse_button(int code, bool *is_click, bool *is_drag)
   return 0;         // Shouldn't get here
 }
 
-/// Replace any terminal code strings with the equivalent internal
-/// representation
+/// Replace any terminal code strings with the equivalent internal representation.
 ///
-/// Used for the "from" and "to" part of a mapping, and the "to" part of
-/// a menu command. Any strings like "<C-UP>" are also replaced, unless
-/// `special` is false. K_SPECIAL by itself is replaced by K_SPECIAL
-/// KS_SPECIAL KE_FILLER.
+/// Used for the "from" and "to" part of a mapping, and the "to" part of a menu command.
+/// Any strings like "<C-UP>" are also replaced, unless `special` is false.
+/// K_SPECIAL by itself is replaced by K_SPECIAL KS_SPECIAL KE_FILLER.
+///
+/// When cpo_flags contains #FLAG_CPO_BSLASH, a backslash can be used in place of <C-v>.
+/// All other <C-v> characters are removed.
 ///
 /// @param[in]  from  What characters to replace.
 /// @param[in]  from_len  Length of the "from" argument.
-/// @param[out]  bufp  Location where results were saved in case of success
-///                    (allocated). Will be set to NULL in case of failure.
+/// @param[out]  bufp  Location where results were saved in case of success (allocated).
+///                    Will be set to NULL in case of failure.
 /// @param[in]  do_lt  If true, also translate <lt>.
-/// @param[in]  from_part  If true, trailing <C-v> is included, otherwise it is
-///                        removed (to make ":map xx ^V" map xx to nothing).
-///                        When cpo_flags contains #FLAG_CPO_BSLASH, a backslash
-///                        can be used in place of <C-v>. All other <C-v>
-///                        characters are removed.
+/// @param[in]  from_part  If true, trailing <C-v> is included, otherwise it is removed (to make
+///                        ":map xx ^V" map xx to nothing).
+///                        If true, "#n" (where n is a digit) at the beginning is replaced with a
+///                        functional key, like in the lhs of a mapping.
 /// @param[in]  special    Replace keycodes, e.g. <CR> becomes a "\n" char.
 /// @param[in]  cpo_flags  Relevant flags derived from p_cpo, see
 ///                        #CPO_TO_CPO_FLAGS.
 ///
-/// @return Pointer to an allocated memory in case of success, "from" in case of
-///         failure. In case of success returned pointer is also saved to
-///         "bufp".
+/// @return Pointer to an allocated memory in case of success, "from" in case of failure.
+///         In case of success returned pointer is also saved to "bufp".
 char_u *replace_termcodes(const char_u *from, const size_t from_len, char_u **bufp,
                           const bool from_part, const bool do_lt, const bool special, int cpo_flags)
   FUNC_ATTR_NONNULL_ALL

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -812,7 +812,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
 
   it('can make lua expr mappings', function()
     exec_lua [[
-      vim.api.nvim_set_keymap ('n', 'aa', '', {callback = function() return vim.api.nvim_replace_termcodes(':lua SomeValue = 99<cr>', true, false, true) end, expr = true })
+      vim.api.nvim_set_keymap ('n', 'aa', '', {callback = function() return vim.api.nvim_replace_termcodes(':lua SomeValue = 99<cr>', false, false, true) end, expr = true })
     ]]
 
     feed('aa')
@@ -989,7 +989,7 @@ describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()
 
   it('can make lua expr mappings', function()
     exec_lua [[
-      vim.api.nvim_buf_set_keymap (0, 'n', 'aa', '', {callback = function() return vim.api.nvim_replace_termcodes(':lua SomeValue = 99<cr>', true, false, true) end, expr = true })
+      vim.api.nvim_buf_set_keymap (0, 'n', 'aa', '', {callback = function() return vim.api.nvim_replace_termcodes(':lua SomeValue = 99<cr>', false, false, true) end, expr = true })
     ]]
 
     feed('aa')

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1325,15 +1325,15 @@ describe('API', function()
 
   describe('nvim_replace_termcodes', function()
     it('escapes K_SPECIAL as K_SPECIAL KS_SPECIAL KE_FILLER', function()
-      eq('\128\254X', helpers.nvim('replace_termcodes', '\128', true, true, true))
+      eq('\128\254X', helpers.nvim('replace_termcodes', '\128', false, true, true))
     end)
 
     it('leaves non-K_SPECIAL string unchanged', function()
-      eq('abc', helpers.nvim('replace_termcodes', 'abc', true, true, true))
+      eq('abc', helpers.nvim('replace_termcodes', 'abc', false, true, true))
     end)
 
     it('converts <expressions>', function()
-      eq('\\', helpers.nvim('replace_termcodes', '<Leader>', true, true, true))
+      eq('\\', helpers.nvim('replace_termcodes', '<Leader>', false, true, true))
     end)
 
     it('converts <LeftMouse> to K_SPECIAL KS_EXTRA KE_LEFTMOUSE', function()
@@ -1341,17 +1341,17 @@ describe('API', function()
       -- 0x80      0xfd     0x2c
       -- 128       253      44
       eq('\128\253\44', helpers.nvim('replace_termcodes',
-                                     '<LeftMouse>', true, true, true))
+                                     '<LeftMouse>', false, true, true))
     end)
 
     it('converts keycodes', function()
       eq('\nx\27x\rx<x', helpers.nvim('replace_termcodes',
-         '<NL>x<Esc>x<CR>x<lt>x', true, true, true))
+         '<NL>x<Esc>x<CR>x<lt>x', false, true, true))
     end)
 
     it('does not convert keycodes if special=false', function()
       eq('<NL>x<Esc>x<CR>x<lt>x', helpers.nvim('replace_termcodes',
-         '<NL>x<Esc>x<CR>x<lt>x', true, true, false))
+         '<NL>x<Esc>x<CR>x<lt>x', false, true, false))
     end)
 
     it('does not crash when transforming an empty string', function()
@@ -1362,7 +1362,16 @@ describe('API', function()
       -- then `return str` in vim_replace_termcodes body will make Neovim free
       -- `str.data` twice: once when freeing arguments, then when freeing return
       -- value.
-      eq('', meths.replace_termcodes('', true, true, true))
+      eq('', meths.replace_termcodes('', false, true, true))
+    end)
+
+    it('does not convert #1 to <F1> if from_part=false', function()
+      eq('#1', meths.replace_termcodes('#1', false, false, false))
+    end)
+
+    it('converts #1 to <F1> if from_part=true', function()
+      eq(meths.replace_termcodes('<F1>', false, false, true),
+         meths.replace_termcodes('#1', true, false, false))
     end)
   end)
 

--- a/test/functional/editor/langmap_spec.lua
+++ b/test/functional/editor/langmap_spec.lua
@@ -217,7 +217,7 @@ describe("'langmap'", function()
     if setup_function then setup_function() end
     feed('qa' .. command_string .. 'q')
     expect(expect_string)
-    eq(helpers.funcs.nvim_replace_termcodes(command_string, true, true, true),
+    eq(helpers.funcs.nvim_replace_termcodes(command_string, false, true, true),
       eval('@a'))
     if setup_function then setup_function() end
     -- n.b. may need nvim_replace_termcodes() here.

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -19,6 +19,7 @@ local NIL = helpers.NIL
 local retry = helpers.retry
 local next_msg = helpers.next_msg
 local remove_trace = helpers.remove_trace
+local expect = helpers.expect
 
 before_each(clear)
 
@@ -2562,6 +2563,16 @@ describe('vim.keymap', function()
     feed('aa')
 
     eq(99, exec_lua[[return SomeValue]])
+  end)
+
+  it('if an expr mapping returns "#1" it does not get converted to <F1>', function()
+    exec_lua([[
+      vim.keymap.set('i', '!', function() return '#1' end, {expr = true})
+    ]])
+
+    feed('i!<Esc>')
+
+    expect('#1')
   end)
 
   it('can overwrite a mapping', function()


### PR DESCRIPTION
Now that `cpo-<` has been removed, `from_part` still has a behavior previously not mentioned in docs: it replaces "#n" (where n is a digit) with a functional key, like the the lhs of a mapping. This behavior can be surprising when used on things other than the lhs of a mapping, so clarify it.