### PR TITLE
vim-patch:8.2.4298: divide by zero with huge tabstop value

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -7551,7 +7551,7 @@ bool tabstop_set(char_u *var, long **array)
     int n = atoi((char *)cp);
 
     // Catch negative values, overflow and ridiculous big values.
-    if (n < 0 || n > TABSTOP_MAX) {
+    if (n <= 0 || n > TABSTOP_MAX) {
       semsg(_(e_invarg2), cp);
       XFREE_CLEAR(*array);
       return false;

--- a/src/nvim/testdir/test_vartabs.vim
+++ b/src/nvim/testdir/test_vartabs.vim
@@ -135,6 +135,16 @@ func Test_vartabs()
   bwipeout!
 endfunc
 
+func Test_retab_invalid_arg()
+  new
+  call setline(1, "\ttext")
+  retab 0
+  call assert_fails("retab -8", 'E487: Argument must be positive')
+  call assert_fails("retab 10000", 'E475:')
+  call assert_fails("retab 720575940379279360", 'E475:')
+  bwipe!
+endfunc
+
 func! Test_vartabs_breakindent()
   if !exists("+breakindent")
     return


### PR DESCRIPTION
#### vim-patch:8.2.4298: divide by zero with huge tabstop value

Problem:    Divide by zero with huge tabstop value.
Solution:   Reject tabstop value that overflows to zero.
https://github.com/vim/vim/commit/fc88df42f1ae64bcc4d6cbc0fbd3445f8c59afdf