### PR TITLE
vim-patch:7.4.{1163,1164,1167,1173,1178,1181,1228},8.1.0711

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -4,7 +4,7 @@ source shared.vim
 source check.vim
 source term_util.vim
 
-func! s:cleanup_buffers() abort
+func s:cleanup_buffers() abort
   for bnr in range(1, bufnr('$'))
     if bufloaded(bnr) && bufnr('%') != bnr
       execute 'bd! ' . bnr

--- a/src/nvim/testdir/test_charsearch_utf8.vim
+++ b/src/nvim/testdir/test_charsearch_utf8.vim
@@ -1,7 +1,7 @@
 " Tests for related f{char} and t{char} using utf-8.
 
 " Test for t,f,F,T movement commands
-function! Test_search_cmds()
+func Test_search_cmds()
   new!
   call setline(1, "・最初から最後まで最強のVimは最高")
   1

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -41,7 +41,7 @@ func Test_display_foldcolumn()
   quit!
 endfunc
 
-func! Test_display_foldtext_mbyte()
+func Test_display_foldtext_mbyte()
   CheckFeature folding
 
   call NewWindow(10, 40)

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -213,7 +213,7 @@ func Test_edit_07()
   bw!
 endfunc
 
-func! Test_edit_08()
+func Test_edit_08()
   throw 'skipped: moved to test/functional/legacy/edit_spec.lua'
   " reset insertmode from i_ctrl-r_=
   let g:bufnr = bufnr('%')
@@ -417,7 +417,7 @@ func Test_edit_13()
   bwipe!
 endfunc
 
-func! Test_edit_CR()
+func Test_edit_CR()
   " Test for <CR> in insert mode
   " basically only in quickfix mode ist tested, the rest
   " has been taken care of by other tests
@@ -450,7 +450,7 @@ func! Test_edit_CR()
   call delete('Xqflist.txt')
 endfunc
 
-func! Test_edit_CTRL_()
+func Test_edit_CTRL_()
   " disabled for Windows builds, why?
   if !has("rightleft") || has("win32")
     return
@@ -734,7 +734,7 @@ func Test_edit_CTRL_O()
   bw!
 endfunc
 
-func! Test_edit_CTRL_R()
+func Test_edit_CTRL_R()
   " Insert Register
   new
   " call test_override("ALL", 1)

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -109,7 +109,7 @@ func s:CompleteDone_CompleteFuncNone( findstart, base )
   return v:none
 endfunc
 
-function! s:CompleteDone_CompleteFuncDict( findstart, base )
+func s:CompleteDone_CompleteFuncDict( findstart, base )
   if a:findstart
     return 0
   endif
@@ -126,7 +126,7 @@ function! s:CompleteDone_CompleteFuncDict( findstart, base )
             \ }
           \ ]
         \ }
-endfunction
+endfunc
 
 func s:CompleteDone_CheckCompletedItemNone()
   let s:called_completedone = 1

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -1,24 +1,24 @@
 " Test for lambda and closure
 
-function! Test_lambda_feature()
+func Test_lambda_feature()
   call assert_equal(1, has('lambda'))
-endfunction
+endfunc
 
-function! Test_lambda_with_filter()
+func Test_lambda_with_filter()
   let s:x = 2
   call assert_equal([2, 3], filter([1, 2, 3], {i, v -> v >= s:x}))
-endfunction
+endfunc
 
-function! Test_lambda_with_map()
+func Test_lambda_with_map()
   let s:x = 1
   call assert_equal([2, 3, 4], map([1, 2, 3], {i, v -> v + s:x}))
-endfunction
+endfunc
 
-function! Test_lambda_with_sort()
+func Test_lambda_with_sort()
   call assert_equal([1, 2, 3, 4, 7], sort([3,7,2,1,4], {a, b -> a - b}))
-endfunction
+endfunc
 
-function! Test_lambda_with_timer()
+func Test_lambda_with_timer()
   if !has('timers')
     return
   endif
@@ -54,10 +54,10 @@ function! Test_lambda_with_timer()
   call assert_true(s:n > m)
 endfunc
 
-function! Test_lambda_with_partial()
+func Test_lambda_with_partial()
   let l:Cb = function({... -> ['zero', a:1, a:2, a:3]}, ['one', 'two'])
   call assert_equal(['zero', 'one', 'two', 'three'], l:Cb('three'))
-endfunction
+endfunc
 
 function Test_lambda_fails()
   call assert_equal(3, {a, b -> a + b}(1, 2))
@@ -70,59 +70,59 @@ func Test_not_lambda()
   call assert_equal('foo', x['>'])
 endfunc
 
-function! Test_lambda_capture_by_reference()
+func Test_lambda_capture_by_reference()
   let v = 1
   let l:F = {x -> x + v}
   let v = 2
   call assert_equal(12, l:F(10))
-endfunction
+endfunc
 
-function! Test_lambda_side_effect()
-  function! s:update_and_return(arr)
+func Test_lambda_side_effect()
+  func! s:update_and_return(arr)
     let a:arr[1] = 5
     return a:arr
-  endfunction
+  endfunc
 
-  function! s:foo(arr)
+  func! s:foo(arr)
     return {-> s:update_and_return(a:arr)}
-  endfunction
+  endfunc
 
   let arr = [3,2,1]
   call assert_equal([3, 5, 1], s:foo(arr)())
-endfunction
+endfunc
 
-function! Test_lambda_refer_local_variable_from_other_scope()
-  function! s:foo(X)
+func Test_lambda_refer_local_variable_from_other_scope()
+  func! s:foo(X)
     return a:X() " refer l:x in s:bar()
-  endfunction
+  endfunc
 
-  function! s:bar()
+  func! s:bar()
     let x = 123
     return s:foo({-> x})
-  endfunction
+  endfunc
 
   call assert_equal(123, s:bar())
-endfunction
+endfunc
 
-function! Test_lambda_do_not_share_local_variable()
-  function! s:define_funcs()
+func Test_lambda_do_not_share_local_variable()
+  func! s:define_funcs()
     let l:One = {-> split(execute("let a = 'abc' | echo a"))[0]}
     let l:Two = {-> exists("a") ? a : "no"}
     return [l:One, l:Two]
-  endfunction
+  endfunc
 
   let l:F = s:define_funcs()
 
   call assert_equal('no', l:F[1]())
   call assert_equal('abc', l:F[0]())
   call assert_equal('no', l:F[1]())
-endfunction
+endfunc
 
-function! Test_lambda_closure_counter()
-  function! s:foo()
+func Test_lambda_closure_counter()
+  func! s:foo()
     let x = 0
     return {-> [execute("let x += 1"), x][-1]}
-  endfunction
+  endfunc
 
   let l:F = s:foo()
   call garbagecollect()
@@ -130,52 +130,52 @@ function! Test_lambda_closure_counter()
   call assert_equal(2, l:F())
   call assert_equal(3, l:F())
   call assert_equal(4, l:F())
-endfunction
+endfunc
 
-function! Test_lambda_with_a_var()
-  function! s:foo()
+func Test_lambda_with_a_var()
+  func! s:foo()
     let x = 2
     return {... -> a:000 + [x]}
-  endfunction
-  function! s:bar()
+  endfunc
+  func! s:bar()
     return s:foo()(1)
-  endfunction
+  endfunc
 
   call assert_equal([1, 2], s:bar())
-endfunction
+endfunc
 
-function! Test_lambda_call_lambda_from_lambda()
-  function! s:foo(x)
+func Test_lambda_call_lambda_from_lambda()
+  func! s:foo(x)
     let l:F1 = {-> {-> a:x}}
     return {-> l:F1()}
-  endfunction
+  endfunc
 
   let l:F = s:foo(1)
   call assert_equal(1, l:F()())
-endfunction
+endfunc
 
-function! Test_lambda_delfunc()
-  function! s:gen()
+func Test_lambda_delfunc()
+  func! s:gen()
     let pl = l:
     let l:Foo = {-> get(pl, "Foo", get(pl, "Bar", {-> 0}))}
     let l:Bar = l:Foo
     delfunction l:Foo
     return l:Bar
-  endfunction
+  endfunc
 
   let l:F = s:gen()
   call assert_fails(':call l:F()', 'E933:')
-endfunction
+endfunc
 
-function! Test_lambda_scope()
-  function! s:NewCounter()
+func Test_lambda_scope()
+  func! s:NewCounter()
     let c = 0
     return {-> [execute('let c += 1'), c][-1]}
-  endfunction
+  endfunc
 
-  function! s:NewCounter2()
+  func! s:NewCounter2()
     return {-> [execute('let c += 100'), c][-1]}
-  endfunction
+  endfunc
 
   let l:C = s:NewCounter()
   let l:D = s:NewCounter2()
@@ -183,37 +183,37 @@ function! Test_lambda_scope()
   call assert_equal(1, l:C())
   call assert_fails(':call l:D()', 'E121:')
   call assert_equal(2, l:C())
-endfunction
+endfunc
 
-function! Test_lambda_share_scope()
-  function! s:New()
+func Test_lambda_share_scope()
+  func! s:New()
     let c = 0
     let l:Inc0 = {-> [execute('let c += 1'), c][-1]}
     let l:Dec0 = {-> [execute('let c -= 1'), c][-1]}
     return [l:Inc0, l:Dec0]
-  endfunction
+  endfunc
 
   let [l:Inc, l:Dec] = s:New()
 
   call assert_equal(1, l:Inc())
   call assert_equal(2, l:Inc())
   call assert_equal(1, l:Dec())
-endfunction
+endfunc
 
-function! Test_lambda_circular_reference()
-  function! s:Foo()
+func Test_lambda_circular_reference()
+  func! s:Foo()
     let d = {}
     let d.f = {-> d}
     return d.f
-  endfunction
+  endfunc
 
   call s:Foo()
   call garbagecollect()
   let i = 0 | while i < 10000 | call s:Foo() | let i+= 1 | endwhile
   call garbagecollect()
-endfunction
+endfunc
 
-function! Test_lambda_combination()
+func Test_lambda_combination()
   call assert_equal(2, {x -> {x -> x}}(1)(2))
   call assert_equal(10, {y -> {x -> x(y)(10)}({y -> y})}({z -> z}))
   call assert_equal(5.0, {x -> {y -> x / y}}(10)(2.0))
@@ -226,17 +226,17 @@ function! Test_lambda_combination()
   let Z = {f -> {x -> f({y -> x(x)(y)})}({x -> f({y -> x(x)(y)})})}
   let Fact = {f -> {x -> x == 0 ? 1 : x * f(x - 1)}}
   call assert_equal(120, Z(Fact)(5))
-endfunction
+endfunc
 
-function! Test_closure_counter()
-  function! s:foo()
+func Test_closure_counter()
+  func! s:foo()
     let x = 0
-    function! s:bar() closure
+    func! s:bar() closure
       let x += 1
       return x
-    endfunction
+    endfunc
     return function('s:bar')
-  endfunction
+  endfunc
 
   let l:F = s:foo()
   call garbagecollect()
@@ -244,30 +244,30 @@ function! Test_closure_counter()
   call assert_equal(2, l:F())
   call assert_equal(3, l:F())
   call assert_equal(4, l:F())
-endfunction
+endfunc
 
-function! Test_closure_unlet()
-  function! s:foo()
+func Test_closure_unlet()
+  func! s:foo()
     let x = 1
-    function! s:bar() closure
+    func! s:bar() closure
       unlet x
-    endfunction
+    endfunc
     call s:bar()
     return l:
-  endfunction
+  endfunc
 
   call assert_false(has_key(s:foo(), 'x'))
   call garbagecollect()
-endfunction
+endfunc
 
-function! LambdaFoo()
+func LambdaFoo()
   let x = 0
-  function! LambdaBar() closure
+  func! LambdaBar() closure
     let x += 1
     return x
-  endfunction
+  endfunc
   return function('LambdaBar')
-endfunction
+endfunc
 
 func Test_closure_refcount()
   let g:Count = LambdaFoo()

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -516,22 +516,22 @@ func Test_dict_lock_operator()
 endfunc
 
 " No remove() of write-protected scope-level variable
-func! Tfunc(this_is_a_long_parameter_name)
+func Tfunc1(this_is_a_long_parameter_name)
   call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E742')
-endfun
+endfunc
 func Test_dict_scope_var_remove()
-  call Tfunc('testval')
+  call Tfunc1('testval')
 endfunc
 
 " No extend() of write-protected scope-level variable
 func Test_dict_scope_var_extend()
   call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
 endfunc
-func! Tfunc(this_is_a_long_parameter_name)
+func Tfunc2(this_is_a_long_parameter_name)
   call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
 endfunc
 func Test_dict_scope_var_extend_overwrite()
-  call Tfunc('testval')
+  call Tfunc2('testval')
 endfunc
 
 " No :unlet of variable in locked scope

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -1,6 +1,6 @@
 
 " Test that a deleted mark is restored after delete-undo-redo-undo.
-function! Test_Restore_DelMark()
+func Test_Restore_DelMark()
   enew!
   call append(0, ["	textline A", "	textline B", "	textline C"])
   normal! 2gg
@@ -11,10 +11,10 @@ function! Test_Restore_DelMark()
   call assert_equal(2, pos[1])
   call assert_equal(1, pos[2])
   enew!
-endfunction
+endfunc
 
 " Test that CTRL-A and CTRL-X updates last changed mark '[, '].
-function! Test_Incr_Marks()
+func Test_Incr_Marks()
   enew!
   call append(0, ["123 123 123", "123 123 123", "123 123 123"])
   normal! gg
@@ -23,7 +23,7 @@ function! Test_Incr_Marks()
   call assert_equal("123 XXXXXXX", getline(2))
   call assert_equal("XXX 123 123", getline(3))
   enew!
-endfunction
+endfunc
 
 func Test_previous_jump_mark()
   new

--- a/src/nvim/testdir/test_matchadd_conceal.vim
+++ b/src/nvim/testdir/test_matchadd_conceal.vim
@@ -7,7 +7,7 @@ source shared.vim
 source term_util.vim
 source view_util.vim
 
-function! Test_simple_matchadd()
+func Test_simple_matchadd()
   new
 
   1put='# This is a Test'
@@ -333,7 +333,7 @@ func Test_matchadd_and_syn_conceal()
   call assert_notequal(screenattr(1, 10) , screenattr(1, 11))
   call assert_notequal(screenattr(1, 11) , screenattr(1, 12))
   call assert_equal(screenattr(1, 11) , screenattr(1, 32))
-endfunction
+endfunc
 
 func Test_cursor_column_in_concealed_line_after_window_scroll()
   CheckRunVimInTerminal

--- a/src/nvim/testdir/test_matchadd_conceal_utf8.vim
+++ b/src/nvim/testdir/test_matchadd_conceal_utf8.vim
@@ -3,19 +3,19 @@ if !has('conceal')
   finish
 endif
 
-function! s:screenline(lnum) abort
+func s:screenline(lnum) abort
   let line = []
   for c in range(1, winwidth(0))
     call add(line, nr2char(a:lnum->screenchar(c)))
   endfor
   return s:trim(join(line, ''))
-endfunction
+endfunc
 
-function! s:trim(str) abort
+func s:trim(str) abort
   return matchstr(a:str,'^\s*\zs.\{-}\ze\s*$')
-endfunction
+endfunc
 
-function! Test_match_using_multibyte_conceal_char()
+func Test_match_using_multibyte_conceal_char()
   new
   setlocal concealcursor=n conceallevel=1
 

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -40,7 +40,7 @@ endfunc
 " indicator (e.g., "-- INSERT --") when ":stopinsert" is invoked.  Message
 " output could then be disturbed when 'cmdheight' was greater than one.
 " This test ensures that the bugfix for this issue remains in place.
-function! Test_stopinsert_does_not_break_message_output()
+func Test_stopinsert_does_not_break_message_output()
   set cmdheight=2
   redraw!
 
@@ -55,7 +55,7 @@ function! Test_stopinsert_does_not_break_message_output()
   redraw!
 
    set cmdheight&
-endfunction
+endfunc
 
 func Test_message_completion()
   call feedkeys(":message \<C-A>\<C-B>\"\<CR>", 'tx')

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -22,16 +22,16 @@ func Test_whichwrap()
   call assert_equal('h', &whichwrap)
 
   set whichwrap&
-endfunction
+endfunc
 
-function! Test_isfname()
+func Test_isfname()
   " This used to cause Vim to access uninitialized memory.
   set isfname=
   call assert_equal("~X", expand("~X"))
   set isfname&
-endfunction
+endfunc
 
-function Test_wildchar()
+func Test_wildchar()
   " Empty 'wildchar' used to access invalid memory.
   call assert_fails('set wildchar=', 'E521:')
   call assert_fails('set wildchar=abc', 'E521:')
@@ -42,7 +42,7 @@ function Test_wildchar()
   let a=execute('set wildchar?')
   call assert_equal("\n  wildchar=<Esc>", a)
   set wildchar&
-endfunction
+endfunc
 
 func Test_wildoptions()
   set wildoptions=
@@ -90,7 +90,7 @@ func Test_options_command()
   close
 endfunc
 
-function! Test_path_keep_commas()
+func Test_path_keep_commas()
   " Test that changing 'path' keeps two commas.
   set path=foo,,bar
   set path-=bar
@@ -98,7 +98,7 @@ function! Test_path_keep_commas()
   call assert_equal('foo,,bar', &path)
 
   set path&
-endfunction
+endfunc
 
 func Test_filetype_valid()
   set ft=valid_name

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -105,7 +105,7 @@ func Test_substitute_variants()
       call assert_equal(var.exp, getline('.'), msg)
     endfor
   endfor
-endfunction
+endfunc
 
 " Test the l, p, # flags.
 func Test_substitute_flags_lp()

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -46,9 +46,9 @@ func Test_System()
   bwipe!
 
   call assert_fails('call system("wc -l", 99999)', 'E86:')
-endfunction
+endfunc
 
-function! Test_system_exmode()
+func Test_system_exmode()
   if has('unix') " echo $? only works on Unix
     let cmd = ' -es --headless -u NONE -c "source Xscript" +q; echo "result=$?"'
     " Need to put this in a script, "catch" isn't found after an unknown

--- a/src/nvim/testdir/test_utf8_comparisons.vim
+++ b/src/nvim/testdir/test_utf8_comparisons.vim
@@ -1,12 +1,12 @@
 " Tests for case-insensitive UTF-8 comparisons (utf_strnicmp() in mbyte.c)
 " Also test "g~ap".
 
-function! Ch(a, op, b, expected)
+func Ch(a, op, b, expected)
   call assert_equal(eval(printf('"%s" %s "%s"', a:a, a:op, a:b)), a:expected,
         \ printf('"%s" %s "%s" should return %d', a:a, a:op, a:b, a:expected))
-endfunction
+endfunc
 
-function! Chk(a, b, result)
+func Chk(a, b, result)
   if a:result == 0
     call Ch(a:a, '==?', a:b, 1)
     call Ch(a:a, '!=?', a:b, 0)

--- a/src/nvim/testdir/test_vartabs.vim
+++ b/src/nvim/testdir/test_vartabs.vim
@@ -145,7 +145,7 @@ func Test_retab_invalid_arg()
   bwipe!
 endfunc
 
-func! Test_vartabs_breakindent()
+func Test_vartabs_breakindent()
   if !exists("+breakindent")
     return
   endif

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1212,6 +1212,16 @@ func Test_type()
     call assert_false(empty(v:true))
     call assert_true(empty(v:null))
     " call assert_true(empty(v:none))
+
+    func ChangeYourMind()
+      try
+	return v:true
+      finally
+        return 'something else'
+      endtry
+    endfunc
+
+    call ChangeYourMind()
 endfunc
 
 "-------------------------------------------------------------------------------

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1178,6 +1178,30 @@ func Test_type()
     call assert_false(v:null != 0)
     " call assert_true(v:none == 0)
     " call assert_false(v:none != 0)
+
+    call assert_true(v:false is v:false)
+    call assert_true(v:true is v:true)
+    " call assert_true(v:none is v:none)
+    call assert_true(v:null is v:null)
+
+    call assert_false(v:false isnot v:false)
+    call assert_false(v:true isnot v:true)
+    " call assert_false(v:none isnot v:none)
+    call assert_false(v:null isnot v:null)
+
+    call assert_false(v:false is 0)
+    call assert_false(v:true is 1)
+    call assert_false(v:true is v:false)
+    " call assert_false(v:none is 0)
+    call assert_false(v:null is 0)
+    " call assert_false(v:null is v:none)
+
+    call assert_true(v:false isnot 0)
+    call assert_true(v:true isnot 1)
+    call assert_true(v:true isnot v:false)
+    " call assert_true(v:none isnot 0)
+    call assert_true(v:null isnot 0)
+    " call assert_true(v:null isnot v:none)
 endfunc
 
 "-------------------------------------------------------------------------------

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1166,6 +1166,18 @@ func Test_type()
     call assert_equal('true', '' . v:true)
     " call assert_equal('none', '' . v:none)
     call assert_equal('null', '' . v:null)
+
+    call assert_true(v:false == 0)
+    call assert_false(v:false != 0)
+    call assert_true(v:true == 1)
+    call assert_false(v:true != 1)
+    call assert_false(v:true == v:false)
+    call assert_true(v:true != v:false)
+
+    call assert_true(v:null == 0)
+    call assert_false(v:null != 0)
+    " call assert_true(v:none == 0)
+    " call assert_false(v:none != 0)
 endfunc
 
 "-------------------------------------------------------------------------------

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -25,7 +25,7 @@ com! -nargs=1	     Xout     call Xout(<args>)
 " in the variable argument list.  This function is useful if similar tests are
 " to be made for a ":return" from a function call or a ":finish" in a script
 " file.
-function! MakeScript(funcname, ...)
+func MakeScript(funcname, ...)
     let script = tempname()
     execute "redir! >" . script
     execute "function" a:funcname
@@ -1224,11 +1224,11 @@ func Test_type()
     " call assert_true(empty(v:none))
 
     func ChangeYourMind()
-      try
-	return v:true
-      finally
-        return 'something else'
-      endtry
+	try
+	    return v:true
+	finally
+	    return 'something else'
+	endtry
     endfunc
 
     call ChangeYourMind()

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1202,6 +1202,11 @@ func Test_type()
     " call assert_true(v:none isnot 0)
     call assert_true(v:null isnot 0)
     " call assert_true(v:null isnot v:none)
+
+    call assert_equal(v:false, eval(string(v:false)))
+    call assert_equal(v:true, eval(string(v:true)))
+    " call assert_equal(v:none, eval(string(v:none)))
+    call assert_equal(v:null, eval(string(v:null)))
 endfunc
 
 "-------------------------------------------------------------------------------

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1208,6 +1208,16 @@ func Test_type()
     " call assert_equal(v:none, eval(string(v:none)))
     call assert_equal(v:null, eval(string(v:null)))
 
+    call assert_equal(v:false, copy(v:false))
+    call assert_equal(v:true, copy(v:true))
+    " call assert_equal(v:none, copy(v:none))
+    call assert_equal(v:null, copy(v:null))
+
+    call assert_equal([v:false], deepcopy([v:false]))
+    call assert_equal([v:true], deepcopy([v:true]))
+    " call assert_equal([v:none], deepcopy([v:none]))
+    call assert_equal([v:null], deepcopy([v:null]))
+
     call assert_true(empty(v:false))
     call assert_false(empty(v:true))
     call assert_true(empty(v:null))

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1207,6 +1207,11 @@ func Test_type()
     call assert_equal(v:true, eval(string(v:true)))
     " call assert_equal(v:none, eval(string(v:none)))
     call assert_equal(v:null, eval(string(v:null)))
+
+    call assert_true(empty(v:false))
+    call assert_false(empty(v:true))
+    call assert_true(empty(v:null))
+    " call assert_true(empty(v:none))
 endfunc
 
 "-------------------------------------------------------------------------------

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1156,6 +1156,16 @@ func Test_type()
     call assert_equal(v:t_list, type(v:_null_list))
     call assert_equal(v:t_dict, type(v:_null_dict))
     call assert_equal(v:t_blob, type(v:_null_blob))
+
+    call assert_equal(0, 0 + v:false)
+    call assert_equal(1, 0 + v:true)
+    " call assert_equal(0, 0 + v:none)
+    call assert_equal(0, 0 + v:null)
+
+    call assert_equal('false', '' . v:false)
+    call assert_equal('true', '' . v:true)
+    " call assert_equal('none', '' . v:none)
+    call assert_equal('null', '' . v:null)
 endfunc
 
 "-------------------------------------------------------------------------------

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -575,7 +575,7 @@ func Test_winrestcmd()
   only
 endfunc
 
-function! Fun_RenewFile()
+func Fun_RenewFile()
   " Need to wait a bit for the timestamp to be older.
   let old_ftime = getftime("tmp.txt")
   while getftime("tmp.txt") == old_ftime
@@ -585,7 +585,7 @@ function! Fun_RenewFile()
   sp
   wincmd p
   edit! tmp.txt
-endfunction
+endfunc
 
 func Test_window_prevwin()
   " Can we make this work on MS-Windows?

--- a/test/functional/legacy/eval_spec.lua
+++ b/test/functional/legacy/eval_spec.lua
@@ -666,7 +666,7 @@ describe('eval', function()
     source([[
       " Vim script used in test_eval.in.  Needed for script-local function.
 
-      func! s:Testje()
+      func s:Testje()
         return "foo"
       endfunc
 


### PR DESCRIPTION
#### vim-patch:7.4.1163
Problem:    Expressions "0 + v:true" and "'' . v:true" cause an error.
Solution:   Return something sensible when using a special variable as a
            number or as a string. (suggested by Damien)
https://github.com/vim/vim/commit/17a13437c9414a8693369a97f3be2fc8ad48c12e

Code is N/A. This only ports the tests.
Comment out tests involving v:none as Nvim as removed it.


#### vim-patch:7.4.1164
Problem:    No tests for comparing special variables.  Error in jsondecode()
            not reported.  test_json does not work Japanse system.
Solution:   Set scriptencoding. (Ken Takata) Add a few more tests. Add error.
https://github.com/vim/vim/commit/6039c7f05376f0e470cf62bf2757e653aea357f3

Code is be N/A. This only ports the tests.
Comment out tests involving v:none as Nvim has removed it.


#### vim-patch:7.4.1167
Problem:    No tests for "is" and "isnot" with the new variables.
Solution:   Add tests.
https://github.com/vim/vim/commit/04369229657f182d35b471eb8b38f273a4d9ef65

Comment out tests involving v:none as Nvim has removed it.


#### vim-patch:7.4.1173
Problem:    No test for new behavior of v:true et al.
Solution:   Add a test.
https://github.com/vim/vim/commit/65591001e405cbaaf9772c9375d0bb6049cf9a3a

Comment out tests involving v:none as Nvim has removed it.


#### vim-patch:7.4.1178
Problem:    empty() doesn't work for the new special variables.
Solution:   Make empty() work. (Damien)
https://github.com/vim/vim/commit/767d8c1a1ae762ecf47297c168b8c23caf05d30a

Code is N/A. This only ports the tests.
Comment out tests involving v:none as Nvim has removed it.


#### vim-patch:7.4.1181
Problem:    free_tv() can't handle special variables. (Damien)
Solution:   Add the variable type.
https://github.com/vim/vim/commit/6650a694547eb744afa060ec62dd8270e99db9f2

Code is N/A. This only ports the tests.


#### vim-patch:7.4.1228
Problem:    copy() and deepcopy() fail with special variables. (Nikolai
            Pavlov)
Solution:   Make it work.  Add a test.
https://github.com/vim/vim/commit/155500077c80cdb5d9c63996000c011b66a676bf

Code is N/A. This only ports the tests.
Comment out tests involving v:none as Nvim has removed it.


#### vim-patch:8.1.0711: test files still use function!

Problem:    Test files still use function!.
Solution:   Remove the exclamation mark.  Fix overwriting a function.
https://github.com/vim/vim/commit/1e1153600c0377472d62cc553173fe555ddcf5a7

Some of the changes were already applied previously.