### PR TITLE
fix(lua): restore priority of the preloader

### DIFF
--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -87,7 +87,8 @@ function vim._load_package(name)
   return nil
 end
 
-table.insert(package.loaders, 1, vim._load_package)
+-- Insert vim._load_package after the preloader at position 2
+table.insert(package.loaders, 2, vim._load_package)
 
 -- These are for loading runtime modules lazily since they aren't available in
 -- the nvim binary as specified in executor.c


### PR DESCRIPTION
Neovim currently places its own loader for searching runtime files at the front of `package.loaders`. This prevents any preloaders in `package.preload` from being used. This change fixes that by moving the default package preloader to run before Neovim's loader. For example, LuaJIT provides preloaders for the built-in modules `ffi` and `bit`, so this optimisation will improve the loading of those.
