### PR TITLE
ci(commitlint): use lintcommit.lua from main repo

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          path: pr_nvim
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-      - run: nvim --clean -es +"lua require('scripts.lintcommit').main({trace=true})"
+      - run: wget https://raw.githubusercontent.com/neovim/neovim/master/scripts/lintcommit.lua
+      - run: nvim --clean -es +"cd pr_nvim" +"lua dofile('../lintcommit.lua').main({trace=true})"


### PR DESCRIPTION
Ensure we're using a known good version of the script.