### PR TITLE
vim-patch:8.2.{4303,4307}: a few messages should not be translated

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3168,9 +3168,9 @@ static void syn_cmd_foldlevel(exarg_T *eap, int syncing)
   if (*arg == NUL) {
     switch (curwin->w_s->b_syn_foldlevel) {
     case SYNFLD_START:
-      msg(_("syntax foldlevel start"));   break;
+      msg("syntax foldlevel start");   break;
     case SYNFLD_MINIMUM:
-      msg(_("syntax foldlevel minimum")); break;
+      msg("syntax foldlevel minimum"); break;
     default:
       break;
     }
@@ -3209,11 +3209,11 @@ static void syn_cmd_spell(exarg_T *eap, int syncing)
   next = skiptowhite(arg);
   if (*arg == NUL) {
     if (curwin->w_s->b_syn_spell == SYNSPL_TOP) {
-      msg(_("syntax spell toplevel"));
+      msg("syntax spell toplevel");
     } else if (curwin->w_s->b_syn_spell == SYNSPL_NOTOP) {
-      msg(_("syntax spell notoplevel"));
+      msg("syntax spell notoplevel");
     } else {
-      msg(_("syntax spell default"));
+      msg("syntax spell default");
     }
   } else if (STRNICMP(arg, "toplevel", 8) == 0 && next - arg == 8) {
     curwin->w_s->b_syn_spell = SYNSPL_TOP;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3112,9 +3112,9 @@ static void syn_cmd_conceal(exarg_T *eap, int syncing)
   next = skiptowhite(arg);
   if (*arg == NUL) {
     if (curwin->w_s->b_syn_conceal) {
-      msg(_("syntax conceal on"));
+      msg("syntax conceal on");
     } else {
-      msg(_("syntax conceal off"));
+      msg("syntax conceal off");
     }
   } else if (STRNICMP(arg, "on", 2) == 0 && next - arg == 2) {
     curwin->w_s->b_syn_conceal = true;
@@ -3141,9 +3141,9 @@ static void syn_cmd_case(exarg_T *eap, int syncing)
   next = skiptowhite(arg);
   if (*arg == NUL) {
     if (curwin->w_s->b_syn_ic) {
-      msg(_("syntax case ignore"));
+      msg("syntax case ignore");
     } else {
-      msg(_("syntax case match"));
+      msg("syntax case match");
     }
   } else if (STRNICMP(arg, "match", 5) == 0 && next - arg == 5) {
     curwin->w_s->b_syn_ic = false;
@@ -3245,7 +3245,7 @@ static void syn_cmd_iskeyword(exarg_T *eap, int syncing)
   if (*arg == NUL) {
     msg_puts("\n");
     if (curwin->w_s->b_syn_isk != empty_option) {
-      msg_puts(_("syntax iskeyword "));
+      msg_puts("syntax iskeyword ");
       msg_outtrans(curwin->w_s->b_syn_isk);
     } else {
       msg_outtrans((char_u *)_("syntax iskeyword not set"));


### PR DESCRIPTION
#### vim-patch:8.2.4303: a few messages should not be translated

Problem:    A few messages should not be translated.
Solution:   Remove _(). (Dominique Pellé, closes vim/vim#9702)
https://github.com/vim/vim/commit/cd53eed2c55f2256008962965b1de1d1df76d535


#### vim-patch:8.2.4307: a few more messages should not be translated

Problem:    A few more messages should not be translated.
Solution:   Remove _().
https://github.com/vim/vim/commit/0c1550d9e94046d3fc9a8ad70b895eaa1e53fca5