### PR TITLE
refactor(mappings)!: remove #n as a notation for a function key

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -540,28 +540,10 @@ See |:verbose-cmd| for more information.
 
 1.5 MAPPING SPECIAL KEYS				*:map-special-keys*
 
-There are two ways to map a special key:
-1. The Vi-compatible method: Map the key code.  Often this is a sequence that
-   starts with <Esc>.  To enter a mapping like this you type ":map " and then
-   you have to type CTRL-V before hitting the function key.  Note that when
-   the key code for the key is in the |terminfo| entry, it will automatically
-   be translated into the internal code and become the second way of mapping.
-2. The second method is to use the internal code for the function key.  To
-   enter such a mapping type CTRL-K and then hit the function key, or use
-   the form "#1", "#2", .. "#9", "#0", "<Up>", "<S-Down>", "<S-F7>", etc.
-   (see table of keys |key-notation|, all keys from <Up> can be used).  The
-   first ten function keys can be defined in two ways: Just the number, like
-   "#2", and with "<F>", like "<F2>".  Both stand for function key 2.  "#0"
-   refers to function key 10.
-
-DETAIL: Vim first checks if a sequence from the keyboard is mapped.  If it
-isn't the terminal key codes are tried.  If a terminal code is found it is
-replaced with the internal code.  Then the check for a mapping is done again
-(so you can map an internal code to something else).  What is written into the
-script file depends on what is recognized. If the terminal key code was
-recognized as a mapping the key code itself is written to the script file.  If
-it was recognized as a terminal code the internal code is written to the
-script file.
+To map a function key, use the internal code for it.  To enter such a mapping
+type CTRL-K and then hit the function key, or use the form "<F2>", "<F10>",
+"<Up>", "<S-Down>", "<S-F7>", etc. (see table of keys |key-notation|, all keys
+from <Up> can be used).
 
 
 1.6 SPECIAL CHARACTERS					*:map-special-chars*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -15,7 +15,8 @@ BREAKING CHANGES                                                *news-breaking*
 
 The following changes may require adaptations in user config or plugins.
 
-• ...
+• "#" followed by a digit no longer stands for a function key at the start of
+  the lhs of a mapping.
 
 ==============================================================================
 ADDED FEATURES                                                     *news-added*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -496,8 +496,10 @@ Macro/|recording| behavior
   the results of keys from 'keymap'.
 
 Mappings:
-  Creating a mapping for a simplifiable key (e.g. <C-I>) doesn't replace an
+- Creating a mapping for a simplifiable key (e.g. <C-I>) doesn't replace an
   existing mapping for its simplified form (e.g. <Tab>).
+- "#" followed by a digit doesn't stand for a function key at the start of the
+  lhs of a mapping.
 
 Motion:
   The |jumplist| avoids useless/phantom jumps.

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -905,19 +905,6 @@ char *replace_termcodes(const char *const from, const size_t from_len, char **co
 
   src = from;
 
-  // Check for #n at start only: function key n
-  if ((flags & REPTERM_FROM_PART) && from_len > 1 && src[0] == '#'
-      && ascii_isdigit(src[1])) {  // function key
-    result[dlen++] = (char)K_SPECIAL;
-    result[dlen++] = 'k';
-    if (src[1] == '0') {
-      result[dlen++] = ';';     // #0 is F10 is "k;"
-    } else {
-      result[dlen++] = src[1];  // #3 is F3 is "k3"
-    }
-    src += 2;
-  }
-
   // Copy each byte from *from to result[dlen]
   while (src <= end) {
     if (!allocated && dlen + 64 > buf_len) {


### PR DESCRIPTION
This notation is hardly used and makes the behavior of the `from_part` argument of `nvim_replace_termcodes` confusing.