### PR TITLE
ci/simplify ci process

### DIFF
--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -44,7 +44,9 @@ build_deps() {
   cd "${CI_BUILD_DIR}"
 }
 
-prepare_build() {
+build_nvim() {
+  check_core_dumps --delete quiet
+
   if test -n "${CLANG_SANITIZER}" ; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DCLANG_${CLANG_SANITIZER}=ON"
   fi
@@ -53,9 +55,8 @@ prepare_build() {
   cd "${BUILD_DIR}"
   echo "Configuring with '${CMAKE_FLAGS} $@'."
   cmake -G Ninja ${CMAKE_FLAGS} "$@" "${CI_BUILD_DIR}"
-}
 
-build_nvim() {
+
   echo "Building nvim."
   if ! top_make nvim ; then
     exit 1

--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -65,12 +65,6 @@ fail() {
   FAILED=1
 }
 
-run_test() {
-  local cmd="$1"
-  local test_name="$2"
-  eval "$cmd" || fail "$test_name"
-}
-
 ended_successfully() {
   if test -f "${FAIL_SUMMARY_FILE}" ; then
     echo 'Test failed, complete summary:'
@@ -94,7 +88,7 @@ run_suite() {
   local suite_name="$2"
 
   enter_suite "$suite_name"
-  run_test "$command" "$suite_name"
+  eval "$command" || fail "$suite_name"
   exit_suite
 }
 

--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -50,9 +50,7 @@ exit_suite() {
   if test "$1" != "--continue" ; then
     exit $FAILED
   else
-    local saved_failed=$FAILED
     FAILED=0
-    return $saved_failed
   fi
 }
 

--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -47,11 +47,7 @@ exit_suite() {
     ci_fold "end" ""
   fi
   export NVIM_TEST_CURRENT_SUITE="${NVIM_TEST_CURRENT_SUITE%/*}"
-  if test "$1" != "--continue" ; then
-    exit $FAILED
-  else
-    FAILED=0
-  fi
+  FAILED=0
 }
 
 fail() {
@@ -99,6 +95,6 @@ run_suite() {
 
   enter_suite "$suite_name"
   run_test "$command" "$suite_name"
-  exit_suite --continue
+  exit_suite
 }
 

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -87,18 +87,15 @@ check_sanitizer() {
 }
 
 run_unittests() {(
-  enter_suite unittests
   ulimit -c unlimited || true
   if ! build_make unittest ; then
     fail 'unittests' F 'Unit tests failed'
   fi
   submit_coverage unittest
   check_core_dumps "$(command -v luajit)"
-  exit_suite
 )}
 
 run_functionaltests() {(
-  enter_suite functionaltests
   ulimit -c unlimited || true
   if ! build_make ${FUNCTIONALTEST}; then
     fail 'functionaltests' F 'Functional tests failed'
@@ -107,11 +104,9 @@ run_functionaltests() {(
   check_sanitizer "${LOG_DIR}"
   valgrind_check "${LOG_DIR}"
   check_core_dumps
-  exit_suite
 )}
 
 run_oldtests() {(
-  enter_suite oldtests
   ulimit -c unlimited || true
   if ! make oldtest; then
     reset
@@ -121,7 +116,6 @@ run_oldtests() {(
   check_sanitizer "${LOG_DIR}"
   valgrind_check "${LOG_DIR}"
   check_core_dumps
-  exit_suite
 )}
 
 check_runtime_files() {(
@@ -146,10 +140,9 @@ check_runtime_files() {(
 )}
 
 install_nvim() {(
-  enter_suite 'install_nvim'
   if ! build_make install ; then
     fail 'install' E 'make install failed'
-    exit_suite
+    exit_suite --continue
   fi
 
   "${INSTALL_PREFIX}/bin/nvim" --version
@@ -179,6 +172,4 @@ install_nvim() {(
   if ! grep -q "$gpat" "${INSTALL_PREFIX}/share/nvim/runtime/$genvimsynf" ; then
     fail 'funcnames' F "It appears that $genvimsynf does not contain $gpat."
   fi
-
-  exit_suite
 )}

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -142,7 +142,7 @@ check_runtime_files() {(
 install_nvim() {(
   if ! build_make install ; then
     fail 'install' E 'make install failed'
-    exit_suite --continue
+    exit_suite
   fi
 
   "${INSTALL_PREFIX}/bin/nvim" --version

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -3,34 +3,25 @@
 set -e
 set -o pipefail
 
+run_tests(){
+  if test "$CLANG_SANITIZER" != "TSAN"; then
+    # Additional threads are only created when the builtin UI starts, which
+    # doesn't happen in the unit/functional tests
+    if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
+      run_test run_unittests unittests
+    fi
+    run_test run_functionaltests functionaltests
+  fi
+  run_test run_oldtests oldtests
+  run_test install_nvim install_nvim
+}
+
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common/build.sh"
 source "${CI_DIR}/common/test.sh"
 source "${CI_DIR}/common/suite.sh"
 
-enter_suite build
-
-check_core_dumps --delete quiet
-
-prepare_build
-build_nvim
-
-exit_suite --continue
-
-enter_suite tests
-
-if test "$CLANG_SANITIZER" != "TSAN" ; then
-  # Additional threads are only created when the builtin UI starts, which
-  # doesn't happen in the unit/functional tests
-  if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
-    run_test run_unittests unittests
-  fi
-  run_test run_functionaltests functionaltests
-fi
-run_test run_oldtests oldtests
-
-run_test install_nvim install_nvim
-
-exit_suite --continue
+run_suite 'build_nvim' 'build'
+run_suite 'run_tests' 'tests'
 
 end_tests

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -3,25 +3,22 @@
 set -e
 set -o pipefail
 
-run_tests(){
-  if test "$CLANG_SANITIZER" != "TSAN"; then
-    # Additional threads are only created when the builtin UI starts, which
-    # doesn't happen in the unit/functional tests
-    if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
-      run_suite run_unittests unittests
-    fi
-    run_suite run_functionaltests functionaltests
-  fi
-  run_suite run_oldtests oldtests
-  run_suite install_nvim install_nvim
-}
-
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common/build.sh"
 source "${CI_DIR}/common/test.sh"
 source "${CI_DIR}/common/suite.sh"
 
 run_suite 'build_nvim' 'build'
-run_suite 'run_tests' 'tests'
+
+if test "$CLANG_SANITIZER" != "TSAN"; then
+  # Additional threads are only created when the builtin UI starts, which
+  # doesn't happen in the unit/functional tests
+  if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
+    run_suite run_unittests unittests
+  fi
+  run_suite run_functionaltests functionaltests
+fi
+run_suite run_oldtests oldtests
+run_suite install_nvim install_nvim
 
 end_tests

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -8,12 +8,12 @@ run_tests(){
     # Additional threads are only created when the builtin UI starts, which
     # doesn't happen in the unit/functional tests
     if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
-      run_test run_unittests unittests
+      run_suite run_unittests unittests
     fi
-    run_test run_functionaltests functionaltests
+    run_suite run_functionaltests functionaltests
   fi
-  run_test run_oldtests oldtests
-  run_test install_nvim install_nvim
+  run_suite run_oldtests oldtests
+  run_suite install_nvim install_nvim
 }
 
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
- ci: run all suites with run_suite function
- ci: run all tests with run_suite function
- ci: remove continue flag from exit_suite since it's always needed
- ci: remove meta-suite "tests"
- ci: remove function run_test
