### PR TITLE
chore(vim-patch.sh): use piping instead of here string for `while read`

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -576,13 +576,13 @@ show_vimpatches() {
     runtime_commits[$commit]=1
   done
 
-  while read -r vim_commit; do
+  list_missing_vimpatches 1 "$@" | while read -r vim_commit; do
     if [[ "${runtime_commits[$vim_commit]-}" ]]; then
       printf '  • %s (+runtime)\n' "${vim_commit}"
     else
       printf '  • %s\n' "${vim_commit}"
     fi
-  done <<< "$(list_missing_vimpatches 1 "$@")"
+  done
 
   cat << EOF
 


### PR DESCRIPTION
Using a here string can cause an error if there are no missing patches:
`./scripts/vim-patch.sh: line 580: runtime_commits: bad array subscript`

Using piping doesn't cause the error.