### PR TITLE
doc(stdioopen): add missing documentation for on_print param

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7412,6 +7412,9 @@ stdioopen({opts})			 *stdioopen()*
 
 		{opts} is a dictionary with these keys:
 		  |on_stdin| : callback invoked when stdin is written to.
+		  on_print : callback invoked when Nvim needs to print a
+			     message, with the message (whose type is string)
+			     as sole argument.
 		  stdin_buffered : read stdin in |channel-buffered| mode.
 		  rpc      : If set, |msgpack-rpc| will be used to communicate
 			     over stdio


### PR DESCRIPTION
This commit adds documentation for the feature introduced in #15910.
