### PR TITLE
vim-patch:8.2.0197: some Ex commands not sufficiently tested

### DIFF
--- a/src/nvim/testdir/test_global.vim
+++ b/src/nvim/testdir/test_global.vim
@@ -36,6 +36,36 @@ func Test_global_error()
   call assert_fails('g/\(/y', 'E476:')
 endfunc
 
+" Test for printing lines using :g with different search patterns
+func Test_global_print()
+  new
+  call setline(1, ['foo', 'bar', 'foo', 'foo'])
+  let @/ = 'foo'
+  let t = execute("g/")->trim()->split("\n")
+  call assert_equal(['foo', 'foo', 'foo'], t)
+
+  " Test for Vi compatible patterns
+  let @/ = 'bar'
+  let t = execute('g\/')->trim()->split("\n")
+  call assert_equal(['bar'], t)
+
+  normal gg
+  s/foo/foo/
+  let t = execute('g\&')->trim()->split("\n")
+  call assert_equal(['foo', 'foo', 'foo'], t)
+
+  let @/ = 'bar'
+  let t = execute('g?')->trim()->split("\n")
+  call assert_equal(['bar'], t)
+
+  " Test for the 'Pattern found in every line' message
+  let v:statusmsg = ''
+  v/foo\|bar/p
+  call assert_notequal('', v:statusmsg)
+
+  close!
+endfunc
+
 func Test_wrong_delimiter()
   call assert_fails('g x^bxd', 'E146:')
 endfunc

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -12,6 +12,18 @@ endfunc
 func Test_help_errors()
   call assert_fails('help doesnotexist', 'E149:')
   call assert_fails('help!', 'E478:')
+  if has('multi_lang')
+    call assert_fails('help help@xy', 'E661:')
+  endif
+
+  let save_hf = &helpfile
+  set helpfile=help_missing
+  help
+  call assert_equal(1, winnr('$'))
+  call assert_notequal('help', &buftype)
+  let &helpfile = save_hf
+
+  call assert_fails('help ' . repeat('a', 1048), 'E149:')
 
   new
   set keywordprg=:help

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -23,6 +23,11 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*bar\*')
   helpclose
 
+  help "
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*quote\*')
+  helpclose
+
   help "*
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*quotestar\*')
@@ -86,11 +91,40 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*i_^_CTRL-D\*')
   helpclose
 
+  help i^x^y
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*i_CTRL-X_CTRL-Y\*')
+  helpclose
+
+  exe "help i\<C-\>\<C-G>"
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*i_CTRL-\\_CTRL-G\*')
+  helpclose
+
   exec "help \<C-V>"
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*CTRL-V\*')
   helpclose
 
+  help /\|
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*/\\bar\*')
+  helpclose
+
+  help CTRL-\_CTRL-N
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*CTRL-\\_CTRL-N\*')
+  helpclose
+
+  help `:pwd`,
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*:pwd\*')
+  helpclose
+
+  help `:ls`.
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*:ls\*')
+  helpclose
 
   exec "help! ('textwidth'"
   call assert_equal("help", &filetype)
@@ -121,6 +155,15 @@ func Test_help_tagjump()
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*{address}\*')
   helpclose
+
+  " Use special patterns in the help tag
+  for h in ['/\w', '/\%^', '/\%(', '/\zs', '/\@<=', '/\_$', '[++opt]', '/\{']
+    exec "help! " . h
+    call assert_equal("help", &filetype)
+    let pat = '\*' . escape(h, '\$[') . '\*'
+    call assert_true(getline('.') =~ pat, pat)
+    helpclose
+  endfor
 
   exusage
   call assert_equal("help", &filetype)

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -656,6 +656,19 @@ func Test_buftype()
   close!
 endfunc
 
+" Test for the 'shellquote' option
+func Test_shellquote()
+  CheckUnix
+  set shellquote=#
+  set verbose=20
+  redir => v
+  silent! !echo Hello
+  redir END
+  set verbose&
+  set shellquote&
+  call assert_match(': "#echo Hello#"', v)
+endfunc
+
 " Test for setting option values using v:false and v:true
 func Test_opt_boolean()
   set number&

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -51,10 +51,12 @@ func Test_substitute_variants()
 	\ { 'cmd': ':s/t/r/cg', 'exp': 'Tesring srring', 'prompt': 'a' },
 	\ { 'cmd': ':s/t/r/ci', 'exp': 'resting string', 'prompt': 'y' },
 	\ { 'cmd': ':s/t/r/cI', 'exp': 'Tesring string', 'prompt': 'y' },
+	\ { 'cmd': ':s/t/r/c', 'exp': 'Testing string', 'prompt': 'n' },
 	\ { 'cmd': ':s/t/r/cn', 'exp': ln },
 	\ { 'cmd': ':s/t/r/cp', 'exp': 'Tesring string', 'prompt': 'y' },
 	\ { 'cmd': ':s/t/r/cl', 'exp': 'Tesring string', 'prompt': 'y' },
 	\ { 'cmd': ':s/t/r/gc', 'exp': 'Tesring srring', 'prompt': 'a' },
+	\ { 'cmd': ':s/i/I/gc', 'exp': 'TestIng string', 'prompt': 'l' },
 	\ { 'cmd': ':s/foo/bar/ge', 'exp': ln },
 	\ { 'cmd': ':s/t/r/g', 'exp': 'Tesring srring' },
 	\ { 'cmd': ':s/t/r/gi', 'exp': 'resring srring' },
@@ -86,6 +88,7 @@ func Test_substitute_variants()
 	\ { 'cmd': ':s//r/rp', 'exp': 'Testr string' },
 	\ { 'cmd': ':s//r/rl', 'exp': 'Testr string' },
 	\ { 'cmd': ':s//r/r', 'exp': 'Testr string' },
+	\ { 'cmd': ':s/i/I/gc', 'exp': 'Testing string', 'prompt': 'q' },
 	\]
 
   for var in variants
@@ -384,6 +387,10 @@ func Test_substitute_join()
   call assert_equal(["foo\tbarbar\<C-H>foo"], getline(1, '$'))
   call assert_equal('\n', histget("search", -1))
 
+  call setline(1, ['foo', 'bar', 'baz', 'qux'])
+  call execute('1,2s/\n//')
+  call assert_equal(['foobarbaz', 'qux'], getline(1, '$'))
+
   bwipe!
 endfunc
 
@@ -397,6 +404,11 @@ func Test_substitute_count()
   \                 getline(1, '$'))
 
   call assert_fails('s/foo/bar/0', 'E939:')
+
+  call setline(1, ['foo foo', 'foo foo', 'foo foo', 'foo foo', 'foo foo'])
+  2,4s/foo/bar/ 10
+  call assert_equal(['foo foo', 'foo foo', 'foo foo', 'bar foo', 'bar foo'],
+        \           getline(1, '$'))
 
   bwipe!
 endfunc
@@ -415,6 +427,10 @@ func Test_substitute_flag_n()
 
   " No substitution should have been done.
   call assert_equal(lines, getline(1, '$'))
+
+  %delete _
+  call setline(1, ['A', 'Bar', 'Baz'])
+  call assert_equal("\n1 match on 1 line", execute('s/\nB\@=//gn'))
 
   bwipe!
 endfunc
@@ -747,6 +763,45 @@ func Test_sub_beyond_end()
   s///e
   call assert_equal('#', getline(1))
   bwipe!
+endfunc
+
+" Test for repeating last substitution using :~ and :&r
+func Test_repeat_last_sub()
+  new
+  call setline(1, ['blue green yellow orange white'])
+  s/blue/red/
+  let @/ = 'yellow'
+  ~
+  let @/ = 'white'
+  :&r
+  let @/ = 'green'
+  s//gray
+  call assert_equal('red gray red orange red', getline(1))
+  close!
+endfunc
+
+" Test for Vi compatible substitution:
+"     \/{string}/, \?{string}? and \&{string}&
+func Test_sub_vi_compatibility()
+  new
+  call setline(1, ['blue green yellow orange blue'])
+  let @/ = 'orange'
+  s\/white/
+  let @/ = 'blue'
+  s\?amber?
+  let @/ = 'white'
+  s\&green&
+  call assert_equal('amber green yellow white green', getline(1))
+  close!
+endfunc
+
+" Test for substitute with the new text longer than the original text
+func Test_sub_expand_text()
+  new
+  call setline(1, 'abcabcabcabcabcabcabcabc')
+  s/b/\=repeat('B', 10)/g
+  call assert_equal(repeat('aBBBBBBBBBBc', 8), getline(1))
+  close!
 endfunc
 
 func Test_submatch_list_concatenate()

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -531,6 +531,21 @@ func Test_format_align()
   call assert_equal("\t\t Vim", getline(1))
   q!
 
+  " align text with 'rightleft'
+  if has('rightleft')
+    new
+    call setline(1, 'Vim')
+    setlocal rightleft
+    left 20
+    setlocal norightleft
+    call assert_equal("\t\t Vim", getline(1))
+    setlocal rightleft
+    right
+    setlocal norightleft
+    call assert_equal("Vim", getline(1))
+    close!
+  endif
+
   set tw&
 endfunc
 

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -169,9 +169,7 @@ endfunc
 " Test for ':w !<cmd>' to pipe lines from the current buffer to an external
 " command.
 func Test_write_pipe_to_cmd()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   new
   call setline(1, ['L1', 'L2', 'L3', 'L4'])
   2,3w !cat > Xfile


### PR DESCRIPTION
#### vim-patch:8.2.0197: some Ex commands not sufficiently tested

Problem:    Some Ex commands not sufficiently tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5565)
https://github.com/vim/vim/commit/ea3db914c0fa35797ad73f6d5bb3a4288d690065