### PR TITLE
vim-patch:8.2.4326: "o" and "O" copying comment not sufficiently tested

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1201,10 +1201,10 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   // Find out if the current line starts with a comment leader.
   // This may then be inserted in front of the new line.
   end_comment_pending = NUL;
-  if (flags & OPENLINE_DO_COM && dir == FORWARD) {
-    // Check for a line comment after code.
+  if (flags & OPENLINE_DO_COM) {
     lead_len = get_leader_len(saved_line, &lead_flags, dir == BACKWARD, true);
-    if (lead_len == 0 && do_cindent) {
+    if (lead_len == 0 && do_cindent && dir == FORWARD) {
+      // Check for a line comment after code.
       comment_start = check_linecomment(saved_line);
       if (comment_start != MAXCOL) {
         lead_len = get_leader_len(saved_line + comment_start,

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -238,7 +238,33 @@ func Test_format_c_comment()
   END
   call assert_equal(expected, getline(1, '$'))
 
-  " Using "o" repeats the line comment, "O" does not.
+  " Using either "o" or "O" repeats a line comment occupying a whole line.
+  %del
+  let text =<< trim END
+      nop;
+      // This is a comment
+      val = val;
+  END
+  call setline(1, text)
+  normal 2Go
+  let expected =<< trim END
+      nop;
+      // This is a comment
+      //
+      val = val;
+  END
+  call assert_equal(expected, getline(1, '$'))
+  normal 2GO
+  let expected =<< trim END
+      nop;
+      //
+      // This is a comment
+      //
+      val = val;
+  END
+  call assert_equal(expected, getline(1, '$'))
+
+  " Using "o" repeats a line comment after a statement, "O" does not.
   %del
   let text =<< trim END
       nop;


### PR DESCRIPTION
#### vim-patch:8.2.4326: "o" and "O" copying comment not sufficiently tested

Problem:    "o" and "O" copying comment not sufficiently tested.
Solution:   Add a test case. (closes vim/vim#9718)
https://github.com/vim/vim/commit/51ab7c7d0da08aac796acff22a6c075dac579e76

Fix a mistake when porting Vim patch 8.2.3934