### PR TITLE
winbar

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -637,3 +637,16 @@ static bool parse_float_config(Dict(float_config) *config, FloatConfig *fconfig,
 
   return true;
 }
+
+void nvim__win_set_bar( Window window, Boolean bar, String thebar, Error *err)
+{
+  win_T *wp = find_window_by_handle(window, err);
+  if (!wp) {
+    return;
+  }
+  wp->w_winbar = bar ? 1 : 0;
+  xfree(wp->w_winbar_line);
+  wp->w_winbar_line = bar ? xstrdup(thebar.size ? thebar.data : "") : NULL;
+  win_set_inner_size(wp);
+  redraw_later(wp, NOT_VALID);
+}

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1291,6 +1291,9 @@ struct window_S {
   int w_height_outer;
   int w_width_outer;
 
+  int w_winbar; // HAIIIII
+  char *w_winbar_line;
+
   /*
    * === start of cached values ====
    */

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1274,6 +1274,11 @@ struct window_S {
   int w_vsep_width;                 // Number of separator columns (0 or 1).
   pos_save_T w_save_cursor;         // backup of cursor pos and topline
 
+  int w_winrow_off;  ///< offset from winrow to the inner window area
+  int w_wincol_off;  ///< offset from wincol to the inner window area
+                     ///< this includes float border but excludes special columns
+                     ///< implemented in win_line() (i.e. signs, folds, numbers)
+
   // inner size of window, which can be overridden by external UI
   int w_height_inner;
   int w_width_inner;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3887,11 +3887,12 @@ static void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (wp != NULL) {
     int height = wp->w_height + wp->w_status_height;
     // The height is adjusted by 1 when there is a bottom border. This is not
-    // necessary for a top border since `row` starts at -1 in that case.
+    // necessary for a top border since `row` already is adjusted for
+    // wp->w_winrow_off
     if (row < height + wp->w_border_adj[2]) {
       winid = wp->handle;
-      winrow = row + 1 + wp->w_border_adj[0];  // Adjust by 1 for top border
-      wincol = col + 1 + wp->w_border_adj[3];  // Adjust by 1 for left border
+      winrow = row + 1 + wp->w_winrow_off;  // Adjust by 1 for top border
+      wincol = col + 1 + wp->w_wincol_off;  // Adjust by 1 for left border
       if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
         char_u *p;
         int count;

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -497,6 +497,7 @@ win_T *mouse_find_win(int *gridp, int *rowp, int *colp)
   // exist.
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp == fp->fr_win) {
+      *rowp -= wp->w_height_inner;
       return wp;
     }
   }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -497,7 +497,7 @@ win_T *mouse_find_win(int *gridp, int *rowp, int *colp)
   // exist.
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp == fp->fr_win) {
-      *rowp -= wp->w_height_inner;
+      *rowp -= wp->w_winrow_off;
       return wp;
     }
   }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1011,7 +1011,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
     col -= wp->w_leftcol;
 
     if (col >= 0 && col < wp->w_width) {
-      coloff = col - scol + (local ? 0 : wp->w_wincol + wp->w_border_adj[3]) + 1;
+      coloff = col - scol + (local ? 0 : wp->w_wincol + wp->w_wincol_off) + 1;
     } else {
       scol = ccol = ecol = 0;
       // character is left or right of the window
@@ -1022,7 +1022,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       }
     }
   }
-  *rowp = (local ? 0 : wp->w_winrow + wp->w_border_adj[0]) + row + rowoff;
+  *rowp = (local ? 0 : wp->w_winrow + wp->w_winrow_off) + row + rowoff;
   *scolp = scol + coloff;
   *ccolp = ccol + coloff;
   *ecolp = ecol + coloff;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1308,7 +1308,8 @@ static void normal_redraw(NormalState *s)
   }
 
   if (VIsual_active) {
-    update_curbuf(INVERTED);  // update inverted part
+    redraw_curbuf_later(INVERTED); // update inverted part
+    update_screen(INVERTED);
   } else if (must_redraw) {
     update_screen(0);
   } else if (redraw_cmdline || clear_cmdline) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6519,6 +6519,9 @@ void win_grid_alloc(win_T *wp)
     grid->col_offset = wp->w_wincol;
   }
 
+  wp->w_winrow_off = wp->w_border_adj[0];
+  wp->w_wincol_off = wp->w_border_adj[3];
+
   // send grid resize event if:
   // - a grid was just resized
   // - screen_resize was called and all grid sizes must be sent

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -731,10 +731,8 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
   }
 
   if (!ui_has(kUIMultigrid)) {
-    wp->w_height = MIN(wp->w_height,
-                       Rows - 1 - (wp->w_border_adj[0] + wp->w_border_adj[2]));
-    wp->w_width = MIN(wp->w_width,
-                      Columns - (wp->w_border_adj[1] + wp->w_border_adj[3]));
+    wp->w_height = MIN(wp->w_height, Rows - 1 - win_extra_height(wp));
+    wp->w_width = MIN(wp->w_width, Columns - win_extra_width(wp));
   }
 
   win_set_inner_size(wp);
@@ -6037,10 +6035,18 @@ void win_set_inner_size(win_T *wp)
     terminal_check_size(wp->w_buffer->terminal);
   }
 
-  wp->w_height_outer = (wp->w_height_inner
-                        + wp->w_border_adj[0] + wp->w_border_adj[2]);
-  wp->w_width_outer = (wp->w_width_inner
-                       + wp->w_border_adj[1] + wp->w_border_adj[3]);
+  wp->w_height_outer = (wp->w_height_inner + win_extra_height(wp));
+  wp->w_width_outer = (wp->w_width_inner + win_extra_width(wp));
+}
+
+int win_extra_height(win_T *wp)
+{
+  return wp->w_border_adj[0] + wp->w_border_adj[2];
+}
+
+int win_extra_width(win_T *wp)
+{
+  return wp->w_border_adj[1] + wp->w_border_adj[3];
 }
 
 /// Set the width of a window.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6008,7 +6008,7 @@ void win_set_inner_size(win_T *wp)
         set_fraction(wp);
       }
     }
-    wp->w_height_inner = height;
+    wp->w_height_inner = height - wp->w_winbar;
     wp->w_skipcol = 0;
 
     // There is no point in adjusting the scroll position when exiting.  Some


### PR DESCRIPTION
TODO:

 - [x] implement proper window option. for demo testing use `nvim__win_set_bar(win, true, "statusline style string")`
 - [x] work correctly in a float
 - [x] support mouse click like tabline (and/or just general callback)
 - [ ] investigate compat with vim8 winbar (perhaps can be pollyfilled by some lua code)