### PR TITLE
chore(clang): avoid bogus warning

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4934,6 +4934,7 @@ static int fuzzy_match_recursive(const char_u *fuzpat, const char_u *str, uint32
 
   // Loop through fuzpat and str looking for a match
   bool first_match = true;
+  assert(*fuzpat != NUL && *str != NUL);  // Avoid bogus clang warning.
   while (*fuzpat != NUL && *str != NUL) {
     const int c1 = utf_ptr2char(fuzpat);
     const int c2 = utf_ptr2char(str);


### PR DESCRIPTION
<https://neovim.io/doc/reports/clang/report-f8ace2.html#EndPath>
![clang](https://user-images.githubusercontent.com/35768171/153093895-d48a08db-c6ad-49e9-a014-c3dd92945c95.png)

This is ridiculous, but I haven't found out minimal steps to reproduce this false positive yet.