### PR TITLE
build(MSVC): test building with multiple processes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ option(ENABLE_COMPILER_SUGGESTIONS "Enable -Wsuggest compiler warnings" OFF)
 if(MSVC)
   # XXX: /W4 gives too many warnings. #3241
   add_compile_options(/W3)
+  add_compile_options(/MP)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   add_definitions(-DWIN32)
 else()

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -288,6 +288,7 @@ endif()
 # resulting in MSVC build failure in CI.
 if (MSVC)
   set(ALL_DEPS ${THIRD_PARTY_DEPS})
+  add_compile_options(/MP)
 else()
   add_custom_target(clean-shared-libraries
     COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
Using `/MP` with MSVC builds it with multiple processes, reducing compile time. I want to test how significant the speedup is and if we can use it.