### PR TITLE
vim-patch:8.2.4337

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10700,7 +10700,7 @@ repeat:
     pbuf = NULL;
     // Need full path first (use expand_env() to remove a "~/")
     if (!has_fullname && !has_homerelative) {
-      if ((c == '.' || c == '~') && **fnamep == '~') {
+      if (**fnamep == '~') {
         p = pbuf = expand_env_save(*fnamep);
       } else {
         p = pbuf = (char_u *)FullName_save((char *)*fnamep, FALSE);


### PR DESCRIPTION
#### vim-patch:8.2.4337: part of condition is always true

Problem:    Part of condition is always true.
Solution:   Remove that part of the condition. (closes vim/vim#9729)
https://github.com/vim/vim/commit/78a8404f8b6ad0152614d5fdc3ec277444c1eee5