### PR TITLE
fix(query.lua): check empty table for lines

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -199,11 +199,13 @@ function M.get_node_text(node, source)
       lines = a.nvim_buf_get_lines(source, start_row, end_row + 1, true)
     end
 
-    if #lines == 1 then
-      lines[1]      = string.sub(lines[1], start_col+1, end_col)
-    else
-      lines[1]      = string.sub(lines[1], start_col+1)
-      lines[#lines] = string.sub(lines[#lines], 1, end_col)
+    if #lines > 0 then
+      if #lines == 1 then
+        lines[1]      = string.sub(lines[1], start_col+1, end_col)
+      else
+        lines[1]      = string.sub(lines[1], start_col+1)
+        lines[#lines] = string.sub(lines[#lines], 1, end_col)
+      end
     end
 
     return table.concat(lines, "\n")

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -285,6 +285,25 @@ end]]
     eq(true, result)
   end)
 
+  it('support getting empty text if node range is zero width', function()
+    local text = [[
+```lua
+{}
+```]]
+    insert(text)
+    local result = exec_lua([[
+      local fake_node = {}
+      function fake_node:start()
+        return 1, 0, 7
+      end
+      function fake_node:end_()
+        return 1, 0, 7
+      end
+      return vim.treesitter.get_node_text(fake_node, 0) == ''
+    ]])
+    eq(true, result)
+  end)
+
   it('can match special regex characters like \\ * + ( with `vim-match?`', function()
     insert('char* astring = "\\n"; (1 + 1) * 2 != 2;')
 


### PR DESCRIPTION
The range of node may make `nvim_buf_get_lines` return an empty table.

Reproduce the issue:
`cat test.md`

<pre>
```lua
{}
```
</pre>
1. Install treesitter markdown parser;
2. open `test.md`.