### PR TITLE
ci: fix reviews workflow by sending an artifact with PR number

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -32,3 +32,15 @@ jobs:
     - name: "Extract commit scope and add as label"
       continue-on-error: true
       run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')"
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p pr
+          echo ${{ github.event.number }} > pr/pr_number
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/reviews.yml
+++ b/.github/workflows/reviews.yml
@@ -11,13 +11,43 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v5
+      - if: github.event_name	== 'workflow_run'
+        name: 'Download artifact with PR number'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+
+      - if: github.event_name	== 'workflow_run'
+        name: 'Unzip artifact'
+        run: unzip pr_number.zip
+
+      - name: 'Request reviewers'
+        uses: actions/github-script@v5
         with:
           script: |
             // The number of the pull request that triggered this run. If label
             // was added manually by a person the number will be stored in current
-            // context, otherwise the number will be stored in the payload.
-            const pr_number = context.issue.number || context.payload.workflow_run.pull_requests[0].number
+            // context, otherwise the number will be stored in a text file that
+            // was stored as an artifact from previous workflow.
+
+            const fs = require('fs')
+            const pr_number =  context.issue.number || Number(fs.readFileSync('./pr_number'))
 
             const pr_data = await github.rest.pulls.get({
               owner: context.repo.owner,


### PR DESCRIPTION
I've spent around 6	hours trying to come up with a simpler solution. Github does NOT allow getting the PR number from only a API/REST request on forks.

The solution was taken straight from the official docs for the `workflow_run`: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow