### PR TITLE
revert: "ci: use continue-on-error instead of "|| true""

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,11 +27,9 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
     - name: "Extract commit type and add as label"
-      continue-on-error: true
-      run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')"
+      run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')" || true
     - name: "Extract commit scope and add as label"
-      continue-on-error: true
-      run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')"
+      run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')" || true
 
   upload-pr-number:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit 559aa4179c639f5ebd45474a36361343ac2371cf.

I mistakenly believed both ways of writing were equivalent; this is
untrue. Setting continue-on-error to true will make the job pass, but
an error annotation will still be created which is misleading since it's
not actually an error.
