### PR TITLE
docs: correct ordering between WinClosed/WinLeave

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1064,7 +1064,7 @@ WinLeave			Before leaving a window.  If the window to be
 				executes the BufLeave autocommands before the
 				WinLeave autocommands (but not for ":new").
 				Not used for ":qa" or ":q" when exiting Vim.
-				After WinClosed.
+				Before WinClosed.
 							*WinNew*
 WinNew				When a new window was created.  Not done for
 				the first window, when Vim has just started.


### PR DESCRIPTION
WinLeave fires before WinClosed.

https://github.com/neovim/neovim/blob/e3c09cb9ed8012db892ea62573dd3defce78f92f/src/nvim/window.c#L2542-L2578
