### PR TITLE
vim-patch:8.2.{3510,3512,3514,3515,3534}: nanosecond timestamp change detection

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -587,7 +587,9 @@ struct file_buffer {
                                 // where invoked
 
   long b_mtime;                 // last change time of original file
+  long b_mtime_ns;              // nanoseconds of last change time
   long b_mtime_read;            // last change time when reading
+  long b_mtime_read_ns;         // nanoseconds of last read time
   uint64_t b_orig_size;         // size of original file in bytes
   int b_orig_mode;              // mode of original file
   time_t b_last_used;           // time when the buffer was last used; used

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4539,6 +4539,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     "mouse",
     "multi_byte",
     "multi_lang",
+    "nanotime",
     "num64",
     "packages",
     "path_extra",

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3913,15 +3913,15 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
 
 static bool time_differs(const FileInfo *file_info, long mtime, long mtime_ns) FUNC_ATTR_CONST
 {
+  return (long)file_info->stat.st_mtim.tv_nsec != mtime_ns
 #if defined(__linux__) || defined(MSWIN)
-  // On a FAT filesystem, esp. under Linux, there are only 5 bits to store
-  // the seconds.  Since the roundoff is done when flushing the inode, the
-  // time may change unexpectedly by one second!!!
-  return (long)file_info->stat.st_mtim.tv_sec - mtime > 1
-         || mtime - (long)file_info->stat.st_mtim.tv_sec > 1
-         || (long)file_info->stat.st_mtim.tv_nsec != mtime_ns;
+         // On a FAT filesystem, esp. under Linux, there are only 5 bits to store
+         // the seconds.  Since the roundoff is done when flushing the inode, the
+         // time may change unexpectedly by one second!!!
+         || (long)file_info->stat.st_mtim.tv_sec - mtime > 1
+         || mtime - (long)file_info->stat.st_mtim.tv_sec > 1;
 #else
-  return (long)file_info->stat.st_mtim.tv_sec != mtime;
+         || (long)file_info->stat.st_mtim.tv_sec != mtime;
 #endif
 }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -704,11 +704,14 @@ static void set_b0_fname(ZERO_BL *b0p, buf_T *buf)
       long_to_char((long)os_fileinfo_inode(&file_info), b0p->b0_ino);
       buf_store_file_info(buf, &file_info);
       buf->b_mtime_read = buf->b_mtime;
+      buf->b_mtime_read_ns = buf->b_mtime_ns;
     } else {
       long_to_char(0L, b0p->b0_mtime);
       long_to_char(0L, b0p->b0_ino);
       buf->b_mtime = 0;
+      buf->b_mtime_ns = 0;
       buf->b_mtime_read = 0;
+      buf->b_mtime_read_ns = 0;
       buf->b_orig_size = 0;
       buf->b_orig_mode = 0;
     }
@@ -1720,6 +1723,7 @@ void ml_sync_all(int check_file, int check_char, bool do_fsync)
       FileInfo file_info;
       if (!os_fileinfo((char *)buf->b_ffname, &file_info)
           || file_info.stat.st_mtim.tv_sec != buf->b_mtime_read
+          || file_info.stat.st_mtim.tv_nsec != buf->b_mtime_read_ns
           || os_fileinfo_size(&file_info) != buf->b_orig_size) {
         ml_preserve(buf, false, do_fsync);
         did_check_timestamps = false;

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -1,5 +1,7 @@
 " Tests for stat functions and checktime
 
+source check.vim
+
 func CheckFileTime(doSleep)
   let fnames = ['Xtest1.tmp', 'Xtest2.tmp', 'Xtest3.tmp']
   let times = []
@@ -72,6 +74,40 @@ func Test_checktime()
   call assert_equal(fl[0], getline(1))
 
   call delete(fname)
+endfunc
+
+func Test_checktime_fast()
+  CheckFeature nanotime
+
+  let fname = 'Xtest.tmp'
+
+  let fl = ['Hello World!']
+  call writefile(fl, fname)
+  set autoread
+  exec 'e' fname
+  let fl = readfile(fname)
+  let fl[0] .= ' - checktime'
+  sleep 10m  " make test less flaky in Nvim
+  call writefile(fl, fname)
+  checktime
+  call assert_equal(fl[0], getline(1))
+
+  call delete(fname)
+endfunc
+
+func Test_autoread_fast()
+  CheckFeature nanotime
+
+  new Xautoread
+  set autoread
+  call setline(1, 'foo')
+
+  w!
+  silent !echo bar > Xautoread
+  checktime
+
+  call assert_equal('bar', trim(getline(1)))
+  call delete('Xautoread')
 endfunc
 
 func Test_autoread_file_deleted()

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -105,7 +105,8 @@ func Test_autoread_fast()
   setlocal autoread
   call setline(1, 'foo')
   w!
-  silent !echo bar > Xautoread
+  sleep 10m
+  call writefile(['bar'], 'Xautoread')
   sleep 10m
   checktime
   call assert_equal('bar', trim(getline(1)))

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -98,16 +98,18 @@ endfunc
 func Test_autoread_fast()
   CheckFeature nanotime
 
-  new Xautoread
-  set autoread
-  call setline(1, 'foo')
+  " this is timing sensitive
+  let g:test_is_flaky = 1
 
+  new Xautoread
+  setlocal autoread
+  call setline(1, 'foo')
   w!
   silent !echo bar > Xautoread
   sleep 10m
   checktime
-
   call assert_equal('bar', trim(getline(1)))
+
   call delete('Xautoread')
 endfunc
 

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -104,6 +104,7 @@ func Test_autoread_fast()
 
   w!
   silent !echo bar > Xautoread
+  sleep 10m
   checktime
 
   call assert_equal('bar', trim(getline(1)))


### PR DESCRIPTION
#### vim-patch:8.2.3510: changes are only detected with one second accuracy

Problem:    Changes are only detected with one second accuracy.
Solution:   Use the nanosecond time if possible.  (Leah Neukirchen,
            closes vim/vim#8875)
https://github.com/vim/vim/commit/0a7984af5601323fae7b3398f05a48087db7b767

In Nvim Test_checktime_fast() is also flaky. Add a delay to avoid that.


#### vim-patch:8.2.3512: timestamp test fails on some systems

Problem:    Timestamp test fails on some systems.
Solution:   Sleep for a short while.
https://github.com/vim/vim/commit/accf4ed352c07ffe59022377c42d36e12dd6d461


#### vim-patch:8.2.3514: autoread test with nano second time sometimes fails

Problem:    Autoread test with nano second time sometimes fails.
Solution:   Mark the test as being flaky.
https://github.com/vim/vim/commit/eaa006dae3d5730e3b6dead27905444998b2cf8e


#### vim-patch:8.2.3515: nano time test fails on Mac and FreeBSD

Problem:    Nano time test fails on Mac and FreeBSD.
Solution:   Also check nano time when not on Linux. (Ozaki Kiichi,
            closes vim/vim#9000)
https://github.com/vim/vim/commit/def69dffb3d09a69629b071c89b7893a1783ba53


#### vim-patch:8.2.3534: autoread test is a bit flaky

Problem:    Autoread test is a bit flaky.
Solution:   Wait a brief moment before overwriting the file.
https://github.com/vim/vim/commit/944eeb44fb6e9d6d28474a1348d27c07873892f9