### PR TITLE
vim-patch:8.2.0580: window size wrong if 'ea' is off and 'splitright' is on

### DIFF
--- a/src/nvim/testdir/test_winbuf_close.vim
+++ b/src/nvim/testdir/test_winbuf_close.vim
@@ -194,3 +194,22 @@ func Test_tabwin_close()
   call assert_true(v:true)
   %bwipe!
 endfunc
+
+" Test when closing a split window (above/below) restores space to the window
+" below when 'noequalalways' and 'splitright' are set.
+func Test_window_close_splitright_noequalalways()
+  set noequalalways
+  set splitright
+  new
+  let w1 = win_getid()
+  new
+  let w2 = win_getid()
+  execute "normal \<c-w>b"
+  let h = winheight(0)
+  let w = win_getid()
+  new 
+  q
+  call assert_equal(h, winheight(0), "Window height does not match eight before opening and closing another window")
+  call assert_equal(w, win_getid(), "Did not return to original window after opening and closing a window")
+endfunc
+

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3079,9 +3079,21 @@ static frame_T *win_altframe(win_T *win, tabpage_T *tp)
     return frp->fr_prev;
   }
 
+  // By default the next window will get the space that was abandoned by this
+  // window
   frame_T *target_fr = frp->fr_next;
   frame_T *other_fr  = frp->fr_prev;
-  if (p_spr || p_sb) {
+
+  // If this is part of a column of windows and 'splitbelow' is true then the
+  // previous window will get the space.
+  if (frp->fr_parent != NULL && frp->fr_parent->fr_layout == FR_COL && p_sb) {
+    target_fr = frp->fr_prev;
+    other_fr  = frp->fr_next;
+  }
+
+  // If this is part of a row of windows, and 'splitright' is true then the
+  // previous window will get the space.
+  if (frp->fr_parent != NULL && frp->fr_parent->fr_layout == FR_ROW && p_spr) {
     target_fr = frp->fr_prev;
     other_fr  = frp->fr_next;
   }


### PR DESCRIPTION
#### vim-patch:8.2.0580: window size wrong if 'ea' is off and 'splitright' is on

Problem:    Window size wrong if 'ea' is off and 'splitright' is on and
            splitting then closing a window.
Solution:   Put abandoned window space in the right place. (Mark Waggoner)
https://github.com/vim/vim/commit/edd327cc070d9a05c12e88bc5c43a1e2a3086ae6