### PR TITLE
vim-patch:8.2.2342: "char" functions may return wrong column in Insert mode

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1588,7 +1588,7 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
     line = tv_get_lnum(argvars);
     col = (long)tv_get_number_chk(&argvars[1], NULL);
     if (charcol) {
-      col = buf_charidx_to_byteidx(curbuf, line, col);
+      col = buf_charidx_to_byteidx(curbuf, line, col) + 1;
     }
     if (argvars[2].v_type != VAR_UNKNOWN) {
       coladd = (long)tv_get_number_chk(&argvars[2], NULL);
@@ -3327,7 +3327,7 @@ static void getpos_both(typval_T *argvars, typval_T *rettv, bool getcurpos, bool
     }
     if (fp != NULL && charcol) {
       pos = *fp;
-      pos.col = buf_byteidx_to_charidx(wp->w_buffer, pos.lnum, pos.col) - 1;
+      pos.col = buf_byteidx_to_charidx(wp->w_buffer, pos.lnum, pos.col);
       fp = &pos;
     }
   } else {


### PR DESCRIPTION
#### vim-patch:8.2.2342: "char" functions may return wrong column in Insert mode

Problem:    "char" functions return the wront column in Insert mode when the
            cursor is beyond the end of the line.
Solution:   Compute the column correctly. (Yegappan Lakshmanan, closes vim/vim#7669)
https://github.com/vim/vim/commit/9145846b6aa411e3ab5c0d145b37808654352877