### PR TITLE
docs(setqflist): clarify that there is a fourth `action` for `setqflist`: ' '

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6907,11 +6907,11 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 		'f'	All the quickfix lists in the quickfix stack are
 			freed.
 
-		If {action} is not present or is set to ' ', then a new list
-		is created. The new quickfix list is added after the current
-		quickfix list in the stack and all the following lists are
-		freed. To add a new quickfix list at the end of the stack,
-		set "nr" in {what} to "$".
+		' '     If {action} is not present or is set to ' ', then a new list
+			is created. The new quickfix list is added after the current
+			quickfix list in the stack and all the following lists are
+			freed. To add a new quickfix list at the end of the stack,
+			set "nr" in {what} to "$".
 
 		The following items can be specified in dictionary {what}:
 		    context	quickfix list context. See |quickfix-context|


### PR DESCRIPTION
When reading the docs for `setqflist`, one would see the three
possible values for `action` in a list format and decide which
option should be passed. Confusingly there is a fourth option,
passing " " or nothing at all, which creates a new quickfix list
on the quickfix list stack. This option could even be considered
the default, but it appears as an afterthought in the docs.

Move the paragraph explaining the " " option to the list with
the other options.
