### PR TITLE
vim-patch:8.1.{1846,1955},8.2.0156

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1441,7 +1441,7 @@ void set_curbuf(buf_T *buf, int action)
   set_bufref(&prevbufref, prevbuf);
   set_bufref(&newbufref, buf);
 
-  // Autocommands may delete the curren buffer and/or the buffer we want to go
+  // Autocommands may delete the current buffer and/or the buffer we want to go
   // to.  In those cases don't close the buffer.
   if (!apply_autocmds(EVENT_BUFLEAVE, NULL, NULL, false, curbuf)
       || (bufref_valid(&prevbufref) && bufref_valid(&newbufref)
@@ -1454,6 +1454,7 @@ void set_curbuf(buf_T *buf, int action)
     }
     if (bufref_valid(&prevbufref) && !aborting()) {
       win_T *previouswin = curwin;
+
       // Do not sync when in Insert mode and the buffer is open in
       // another window, might be a timer doing something in another
       // window.

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1439,7 +1439,7 @@ bool vim_isblankline(char_u *lbuf)
 /// @param unptr Returns the unsigned result.
 /// @param maxlen Max length of string to check.
 /// @param strict If true, fail if the number has unexpected trailing
-///               alpha-numeric chars: *len is set to 0 and nothing else is
+///               alphanumeric chars: *len is set to 0 and nothing else is
 ///               returned.
 void vim_str2nr(const char_u *const start, int *const prep, int *const len, const int what,
                 varnumber_T *const nptr, uvarnumber_T *const unptr, const int maxlen,
@@ -1585,7 +1585,7 @@ vim_str2nr_hex:
 #undef PARSE_NUMBER
 
 vim_str2nr_proceed:
-  // Check for an alpha-numeric character immediately following, that is
+  // Check for an alphanumeric character immediately following, that is
   // most likely a typo.
   if (strict && ptr - (const char *)start != maxlen && ASCII_ISALNUM(*ptr)) {
     return;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7485,7 +7485,7 @@ static void ex_edit(exarg_T *eap)
   do_exedit(eap, NULL);
 }
 
-/// ":edit <file>" command and alikes.
+/// ":edit <file>" command and alike.
 ///
 /// @param old_curwin  curwin before doing a split or NULL
 void do_exedit(exarg_T *eap, win_T *old_curwin)

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2466,7 +2466,7 @@ static int vgetorpeek(bool advance)
 ///      1. a scriptfile
 ///      2. the keyboard
 ///
-///  As much characters as we can get (up to 'maxlen') are put in "buf" and
+///  As many characters as we can get (up to 'maxlen') are put in "buf" and
 ///  NUL terminated (buffer length must be 'maxlen' + 1).
 ///  Minimum for "maxlen" is 3!!!!
 ///

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4277,7 +4277,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
   }
 
   // Save the global value before changing anything. This is needed as for
-  // a global-only option setting the "local value" infact sets the global
+  // a global-only option setting the "local value" in fact sets the global
   // value (since there is only one value).
   if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0) {
     old_global_value = *(long *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL);

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -502,7 +502,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
   [CODE]
 
   call writefile(content, 'Xvimrc')
-  call system(v:progpath. ' --headless -i NONE -u Xvimrc --noplugins -S Session.vim -c cq')
+  call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
   let errors = join(readfile('Xerrors'))
   call assert_match('E814', errors)
 
@@ -562,7 +562,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
   [CODE]
 
   call writefile(content, 'Xvimrc')
-  call system(v:progpath. ' --headless -i NONE -u Xvimrc --noplugins -S Session.vim -c cq')
+  call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
   let errors = join(readfile('Xerrors'))
   " This probably only ever matches on unix.
   call assert_notmatch('Caught deadly signal SEGV', errors)
@@ -1506,7 +1506,7 @@ func Test_bufunload_all()
   call writefile(content, 'Xtest')
 
   call delete('Xout')
-  call system(v:progpath. ' -u NORC -i NONE -N -S Xtest')
+  call system(GetVimCommandClean() .. ' -N --headless -S Xtest')
   call assert_true(filereadable('Xout'))
 
   call delete('Xxx1')

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -1,7 +1,7 @@
 " Test for breakindent
 "
 " Note: if you get strange failures when adding new tests, it might be that
-" while the test is run, the breakindent cacheing gets in its way.
+" while the test is run, the breakindent caching gets in its way.
 " It helps to change the tabstop setting and force a redraw (e.g. see
 " Test_breakindent08())
 if !exists('+breakindent')

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -815,7 +815,7 @@ func Test_cindent_1()
         }
      }
 
-  public: // <-- this was incoreectly indented before!!
+  public: // <-- this was incorectly indented before!!
      void testfall();
   protected:
      void testfall();
@@ -1792,7 +1792,7 @@ func Test_cindent_1()
   		}
   	}
 
-  	public: // <-- this was incoreectly indented before!!
+  	public: // <-- this was incorectly indented before!!
   	void testfall();
   	protected:
   	void testfall();

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -815,7 +815,7 @@ func Test_cindent_1()
         }
      }
 
-  public: // <-- this was incorectly indented before!!
+  public: // <-- this was incorrectly indented before!!
      void testfall();
   protected:
      void testfall();
@@ -1792,7 +1792,7 @@ func Test_cindent_1()
   		}
   	}
 
-  	public: // <-- this was incorectly indented before!!
+  	public: // <-- this was incorrectly indented before!!
   	void testfall();
   	protected:
   	void testfall();
@@ -5302,9 +5302,12 @@ endfunc
 " this was going beyond the end of the line.
 func Test_cindent_case()
   new
-  call setline(1, "case x: // x")
+  call setline(1, 'case x: // x')
   set cindent
   norm! f:a:
+  call assert_equal('case x:: // x', getline(1))
+
+  set cindent&
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_digraph.vim
+++ b/src/nvim/testdir/test_digraph.vim
@@ -81,7 +81,7 @@ func Test_digraphs()
   call Put_Dig(".e")
   call Put_Dig("a.") " not defined
   call assert_equal(['ḃ', 'ė', '.'], getline(line('.')-2,line('.')))
-  " Diaresis
+  " Diaeresis
   call Put_Dig("a:")
   call Put_Dig(":u")
   call Put_Dig("b:") " not defined
@@ -288,7 +288,7 @@ func Test_digraphs_option()
   call Put_Dig_BS(".","e")
   call Put_Dig_BS("a",".") " not defined
   call assert_equal(['ḃ', 'ė', '.'], getline(line('.')-2,line('.')))
-  " Diaresis
+  " Diaeresis
   call Put_Dig_BS("a",":")
   call Put_Dig_BS(":","u")
   call Put_Dig_BS("b",":") " not defined

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -590,7 +590,7 @@ func Test_edit_CTRL_K()
   call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal(['AA'], getline(1, '$'))
 
-  " press an unexecpted key after dictionary completion
+  " press an unexpected key after dictionary completion
   %d
   call setline(1, 'A')
   call cursor(1, 1)

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1118,7 +1118,7 @@ func Test_normal20_exmode()
   endif
   call writefile(['1a', 'foo', 'bar', '.', 'w! Xfile2', 'q!'], 'Xscript')
   call writefile(['1', '2'], 'Xfile')
-  call system(v:progpath .' -e -s < Xscript Xfile')
+  call system(GetVimCommand() .. ' -e -s < Xscript Xfile')
   let a=readfile('Xfile2')
   call assert_equal(['1', 'foo', 'bar', '2'], a)
 
@@ -1171,13 +1171,13 @@ func Test_normal22_zet()
   endfor
 
   call writefile(['1', '2'], 'Xfile_Test_normal22_zet')
-  let args = ' --headless -u NONE -N -U NONE -i NONE --noplugins'
-  call system(v:progpath . args . ' -c "%d" -c ":norm! ZZ" Xfile_Test_normal22_zet')
+  let args = ' -N -i NONE --noplugins -X --headless'
+  call system(GetVimCommand() .. args .. ' -c "%d" -c ":norm! ZZ" Xfile_Test_normal22_zet')
   let a = readfile('Xfile_Test_normal22_zet')
   call assert_equal([], a)
   " Test for ZQ
   call writefile(['1', '2'], 'Xfile_Test_normal22_zet')
-  call system(v:progpath . args . ' -c "%d" -c ":norm! ZQ" Xfile_Test_normal22_zet')
+  call system(GetVimCommand() . args . ' -c "%d" -c ":norm! ZQ" Xfile_Test_normal22_zet')
   let a = readfile('Xfile_Test_normal22_zet')
   call assert_equal(['1', '2'], a)
 

--- a/src/nvim/testdir/test_profile.vim
+++ b/src/nvim/testdir/test_profile.vim
@@ -1,8 +1,9 @@
 " Test Vim profiler
-if !has('profile')
-  finish
-endif
 
+source check.vim
+CheckFeature profile
+
+source shared.vim
 source screendump.vim
 
 func Test_profile_func()
@@ -37,7 +38,7 @@ func Test_profile_func()
   [CODE]
 
   call writefile(lines, 'Xprofile_func.vim')
-  call system(v:progpath
+  call system(GetVimCommand()
     \ . ' -es --clean'
     \ . ' -c "so Xprofile_func.vim"'
     \ . ' -c "qall!"')
@@ -124,8 +125,8 @@ func Test_profile_func_with_ifelse()
   [CODE]
 
   call writefile(lines, 'Xprofile_func.vim')
-  call system(v:progpath
-    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
+  call system(GetVimCommand()
+    \ . ' -es -i NONE --noplugin'
     \ . ' -c "profile start Xprofile_func.log"'
     \ . ' -c "profile func Foo*"'
     \ . ' -c "so Xprofile_func.vim"'
@@ -237,8 +238,8 @@ func Test_profile_func_with_trycatch()
   [CODE]
 
   call writefile(lines, 'Xprofile_func.vim')
-  call system(v:progpath
-    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
+  call system(GetVimCommand()
+    \ . ' -es -i NONE --noplugin'
     \ . ' -c "profile start Xprofile_func.log"'
     \ . ' -c "profile func Foo*"'
     \ . ' -c "so Xprofile_func.vim"'
@@ -324,8 +325,8 @@ func Test_profile_file()
   [CODE]
 
   call writefile(lines, 'Xprofile_file.vim')
-  call system(v:progpath
-    \ . ' -es --clean'
+  call system(GetVimCommandClean()
+    \ . ' -es'
     \ . ' -c "profile start Xprofile_file.log"'
     \ . ' -c "profile file Xprofile_file.vim"'
     \ . ' -c "so Xprofile_file.vim"'
@@ -369,8 +370,8 @@ func Test_profile_file_with_cont()
     \ ]
 
   call writefile(lines, 'Xprofile_file.vim')
-  call system(v:progpath
-    \ . ' -es -u NONE -U NONE -i NONE --noplugin'
+  call system(GetVimCommandClean()
+    \ . ' -es'
     \ . ' -c "profile start Xprofile_file.log"'
     \ . ' -c "profile file Xprofile_file.vim"'
     \ . ' -c "so Xprofile_file.vim"'
@@ -427,7 +428,7 @@ func Test_profile_truncate_mbyte()
     \ ]
 
   call writefile(lines, 'Xprofile_file.vim')
-  call system(v:progpath
+  call system(GetVimCommandClean()
     \ . ' -es --cmd "set enc=utf-8"'
     \ . ' -c "profile start Xprofile_file.log"'
     \ . ' -c "profile file Xprofile_file.vim"'
@@ -474,7 +475,7 @@ func Test_profdel_func()
     call Foo3()
   [CODE]
   call writefile(lines, 'Xprofile_file.vim')
-  call system(v:progpath . ' -es --clean -c "so Xprofile_file.vim" -c q')
+  call system(GetVimCommandClean() . ' -es -c "so Xprofile_file.vim" -c q')
   call assert_equal(0, v:shell_error)
 
   let lines = readfile('Xprofile_file.log')
@@ -509,7 +510,7 @@ func Test_profdel_star()
     call Foo()
   [CODE]
   call writefile(lines, 'Xprofile_file.vim')
-  call system(v:progpath . ' -es --clean -c "so Xprofile_file.vim" -c q')
+  call system(GetVimCommandClean() . ' -es -c "so Xprofile_file.vim" -c q')
   call assert_equal(0, v:shell_error)
 
   let lines = readfile('Xprofile_file.log')

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2739,7 +2739,7 @@ func Test_cwindow_jump()
   call assert_true(winnr('$') == 2)
   call assert_true(winnr() == 1)
 
-  " Jumping to a file from the location list window should find a usuable
+  " Jumping to a file from the location list window should find a usable
   " window by wrapping around the window list.
   enew | only
   call setloclist(0, [], 'f')

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -219,7 +219,7 @@ func Test_set_register()
   call setreg('=', 'b', 'a')
   call assert_equal('regwrite', getreg('='))
 
-  " Test for settting a list of lines to special registers
+  " Test for setting a list of lines to special registers
   call setreg('/', [])
   call assert_equal('', @/)
   call setreg('=', [])

--- a/src/nvim/testdir/test_stat.vim
+++ b/src/nvim/testdir/test_stat.vim
@@ -7,7 +7,7 @@ func CheckFileTime(doSleep)
   let times = []
   let result = 0
 
-  " Use three files istead of localtim(), with a network filesystem the file
+  " Use three files instead of localtim(), with a network filesystem the file
   " times may differ at bit
   let fl = ['Hello World!']
   for fname in fnames

--- a/src/nvim/testdir/test_suspend.vim
+++ b/src/nvim/testdir/test_suspend.vim
@@ -26,8 +26,8 @@ func Test_suspend()
   " Wait for shell prompt.
   call WaitForAssert({-> assert_match('[$#] $', term_getline(buf, '.'))})
 
-  call term_sendkeys(buf, v:progpath
-        \               . " --clean -X"
+  call term_sendkeys(buf, GetVimCommandClean()
+        \               . " -X"
         \               . " -c 'set nu'"
         \               . " -c 'call setline(1, \"foo\")'"
         \               . " Xfoo\<CR>")

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -50,11 +50,11 @@ endfunc
 
 func Test_system_exmode()
   if has('unix') " echo $? only works on Unix
-    let cmd = ' -es --headless -u NONE -c "source Xscript" +q; echo "result=$?"'
+    let cmd = ' -es -c "source Xscript" +q; echo "result=$?"'
     " Need to put this in a script, "catch" isn't found after an unknown
     " function.
     call writefile(['try', 'call doesnotexist()', 'catch', 'endtry'], 'Xscript')
-    let a = system(v:progpath . cmd)
+    let a = system(GetVimCommand() . cmd)
     call assert_match('result=0', a)
     call assert_equal(0, v:shell_error)
   endif
@@ -62,33 +62,33 @@ func Test_system_exmode()
   " Error before try does set error flag.
   call writefile(['call nosuchfunction()', 'try', 'call doesnotexist()', 'catch', 'endtry'], 'Xscript')
   if has('unix') " echo $? only works on Unix
-    let a = system(v:progpath . cmd)
+    let a = system(GetVimCommand() . cmd)
     call assert_notequal('0', a[0])
   endif
 
-  let cmd = ' -es --headless -u NONE -c "source Xscript" +q'
-  let a = system(v:progpath . cmd)
+  let cmd = ' -es -c "source Xscript" +q'
+  let a = system(GetVimCommand() . cmd)
   call assert_notequal(0, v:shell_error)
   call delete('Xscript')
 
   if has('unix') " echo $? only works on Unix
-    let cmd = ' -es --headless -u NONE -c "call doesnotexist()" +q; echo $?'
-    let a = system(v:progpath. cmd)
+    let cmd = ' -es -c "call doesnotexist()" +q; echo $?'
+    let a = system(GetVimCommand() . cmd)
     call assert_notequal(0, a[0])
   endif
 
-  let cmd = ' -es --headless -u NONE -c "call doesnotexist()" +q'
-  let a = system(v:progpath. cmd)
+  let cmd = ' -es -c "call doesnotexist()" +q'
+  let a = system(GetVimCommand(). cmd)
   call assert_notequal(0, v:shell_error)
 
   if has('unix') " echo $? only works on Unix
-    let cmd = ' -es --headless -u NONE -c "call doesnotexist()|let a=1" +q; echo $?'
-    let a = system(v:progpath. cmd)
+    let cmd = ' -es -c "call doesnotexist()|let a=1" +q; echo $?'
+    let a = system(GetVimCommand() . cmd)
     call assert_notequal(0, a[0])
   endif
 
-  let cmd = ' -es --headless -u NONE -c "call doesnotexist()|let a=1" +q'
-  let a = system(v:progpath. cmd)
+  let cmd = ' -es -c "call doesnotexist()|let a=1" +q'
+  let a = system(GetVimCommand() . cmd)
   call assert_notequal(0, v:shell_error)
 endfunc
 

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1,6 +1,9 @@
 " Test various aspects of the Vim script language.
 " Most of this was formerly in test49.
 
+source check.vim
+source shared.vim
+
 "-------------------------------------------------------------------------------
 " Test environment							    {{{1
 "-------------------------------------------------------------------------------
@@ -1744,7 +1747,7 @@ func Test_function_defined_line()
     [CODE]
 
     call writefile(lines, 'Xtest.vim')
-    let res = system(v:progpath .. ' --clean -es -X -S Xtest.vim')
+    let res = system(GetVimCommandClean() .. ' -es -X -S Xtest.vim')
     call assert_equal(0, v:shell_error)
 
     let m = matchstr(res, 'function F1()[^[:print:]]*[[:print:]]*')


### PR DESCRIPTION
#### vim-patch:8.1.1846: inconsistently using GetVimCommand() and v:progpath

Problem:    Inconsistently using GetVimCommand() and v:progpath. (Daniel
            Hahler)
Solution:   Use GetVimCommand(). (closes vim/vim#4806)
https://github.com/vim/vim/commit/93344c2d707d9953f351c944e6a237c9916f69a3

Cherry-pick a change to test_profile.vim from patch 8.1.1544.
Cherry-pick a change to test_vimscript.vim from patch 8.1.1826.

Some of the args are no-op in Nvim, and `-i NONE` and `--headless` are already added by `GetVimCommand()`. I'll try to match the order of args in upstream, substituting `--not-a-term` with `--headless`.


#### vim-patch:8.1.1955: tests contain typos

Problem:    Tests contain typos.
Solution:   Correct the typos. (Dominique Pelle)
https://github.com/vim/vim/commit/1bc353b6f1b063e189e0cef26f8dc586dcf9161f

Other changes are either N/A or already applied.

#### vim-patch:8.2.0156: various typos in source files and tests

Problem:    Various typos in source files and tests.
Solution:   Fix the typos. (Emir Sari, closes vim/vim#5532)
https://github.com/vim/vim/commit/4b96df5a017a04141c4e901b1fc5704a3ca48099