### PR TITLE
fix(api): validate command names in nvim_add_user_command

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1384,6 +1384,11 @@ void add_user_command(String name, Object command, Dict(user_command) *opts, int
   LuaRef luaref = LUA_NOREF;
   LuaRef compl_luaref = LUA_NOREF;
 
+  if (!uc_validate_name(name.data)) {
+    api_set_error(err, kErrorTypeValidation, "Invalid command name");
+    goto err;
+  }
+
   if (mb_islower(name.data[0])) {
     api_set_error(err, kErrorTypeValidation, "'name' must begin with an uppercase letter");
     goto err;

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -180,6 +180,28 @@ describe('nvim_add_user_command', function()
     feed('<C-U>Test b<Tab>')
     eq('Test bbb', funcs.getcmdline())
   end)
+
+  it('does not allow invalid command names', function()
+    matches("'name' must begin with an uppercase letter", pcall_err(exec_lua, [[
+      vim.api.nvim_add_user_command('test', 'echo "hi"', {})
+    ]]))
+
+    matches('Invalid command name', pcall_err(exec_lua, [[
+      vim.api.nvim_add_user_command('t@', 'echo "hi"', {})
+    ]]))
+
+    matches('Invalid command name', pcall_err(exec_lua, [[
+      vim.api.nvim_add_user_command('T@st', 'echo "hi"', {})
+    ]]))
+
+    matches('Invalid command name', pcall_err(exec_lua, [[
+      vim.api.nvim_add_user_command('Test!', 'echo "hi"', {})
+    ]]))
+
+    matches('Invalid command name', pcall_err(exec_lua, [[
+      vim.api.nvim_add_user_command('💩', 'echo "hi"', {})
+    ]]))
+  end)
 end)
 
 describe('nvim_del_user_command', function()


### PR DESCRIPTION
This uses the same validation used when defining commands with
`:command`.

Closes #17319.
