### PR TITLE
allow floating window style to be passed through options in vim.lsp.util.preview_location

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -977,6 +977,11 @@ function M.make_floating_popup_options(width, height, opts)
     col = 1
   end
 
+  local style = opts.style
+  if style == nil then
+    style = 'minimal'
+  end
+
   return {
     anchor = anchor,
     col = col + (opts.offset_x or 0),
@@ -984,7 +989,7 @@ function M.make_floating_popup_options(width, height, opts)
     focusable = opts.focusable,
     relative = 'cursor',
     row = row + (opts.offset_y or 0),
-    style = 'minimal',
+    style = style,
     width = width,
     border = opts.border or default_border,
     zindex = opts.zindex or 50,


### PR DESCRIPTION
Currently when you call `vim.lsp.util.preview_location` the `style` option is not passed through.

Use case: I'm adding a keymap to "peek" definitions in a floating window, sorta like VS Code, and I don't want to set the `minimal` style on the floating window because I want line numbers. This allows you to set `style` via the API, but still defaults to `minimal` if not present.