### PR TITLE
ci(labeler): disable sync that interferes with other jobs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""
 
   type-scope:
     runs-on: ubuntu-latest
-    needs: ["triage"]
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Dumb workaround: https://github.com/actions/labeler/pull/113#issuecomment-1033963931