### PR TITLE
vim-patch:8.2.{3820,3823}: "vrc" does not replace composing characters

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1961,11 +1961,14 @@ static int op_replace(oparg_T *oap, int c)
     while (ltoreq(curwin->w_cursor, oap->end)) {
       n = gchar_cursor();
       if (n != NUL) {
-        if (utf_char2len(c) > 1 || utf_char2len(n) > 1) {
+        int new_byte_len = utf_char2len(c);
+        int old_byte_len = utfc_ptr2len(get_cursor_pos_ptr());
+
+        if (new_byte_len > 1 || old_byte_len > 1) {
           // This is slow, but it handles replacing a single-byte
           // with a multi-byte and the other way around.
           if (curwin->w_cursor.lnum == oap->end.lnum) {
-            oap->end.col += utf_char2len(c) - utf_char2len(n);
+            oap->end.col += new_byte_len - old_byte_len;
           }
           replace_character(c);
         } else {

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -636,6 +636,11 @@ func Test_characterwise_visual_mode()
   normal v$rx
   call assert_equal(['x'], getline(1, '$'))
 
+  " replace a character with composing characters
+  call setline(1, "xã̳x")
+  normal gg0lvrb
+  call assert_equal("xbx", getline(1))
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.3820: "vrc" does not replace composing characters

Problem:    "vrc" does not replace composing characters, while "rc" does.
Solution:   Check the byte length including composing characters.
https://github.com/vim/vim/commit/8ee6028de3daa9af9e5f90fa9e583ff407bee04f

#### vim-patch:8.2.3823: test for visual replace is in wrong function

Problem:    Test for visual replace is in wrong function.
Solution:   Move it to another function.
https://github.com/vim/vim/commit/6ecf58b0d7d9b8fbba780d19d2e6c0f227df715b