### PR TITLE
vim-patch:8.2.4154: ml_get error when exchanging windows in Visual mode

### DIFF
--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1280,6 +1280,16 @@ func Test_visual_block_insert_round_off()
   bwipe!
 endfunc
 
+" this was causing an ml_get error
+func Test_visual_exchange_windows()
+  enew!
+  new
+  call setline(1, ['foo', 'bar'])
+  exe "normal G\<C-V>gg\<C-W>\<C-X>OO\<Esc>"
+  bwipe!
+  bwipe!
+endfunc
+
 " this was leaving the end of the Visual area beyond the end of a line
 func Test_visual_ex_copy_line()
   new

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1727,6 +1727,12 @@ static void win_exchange(long Prenum)
 
   (void)win_comp_pos();                 // recompute window positions
 
+  if (wp->w_buffer != curbuf) {
+    reset_VIsual_and_resel();
+  } else if (VIsual_active) {
+    wp->w_cursor = curwin->w_cursor;
+  }
+
   win_enter(wp, true);
   redraw_later(curwin, NOT_VALID);
   redraw_later(wp, NOT_VALID);


### PR DESCRIPTION
#### vim-patch:8.2.4154: ml_get error when exchanging windows in Visual mode

Problem:    ml_get error when exchanging windows in Visual mode.
Solution:   Correct end of Visual area when entering another buffer.
https://github.com/vim/vim/commit/05b27615481e72e3b338bb12990fb3e0c2ecc2a9