### PR TITLE
fix(api): nvim_win_set_cursor() redraw for cursorline and statusline

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -71,6 +71,7 @@ ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
 }
 
 /// Sets the (1,0)-indexed cursor position in the window. |api-indexing|
+/// Unlike |win_execute()| this scrolls the window.
 ///
 /// @param window   Window handle, or 0 for current window
 /// @param pos      (row, col) tuple representing the new position
@@ -118,6 +119,8 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   update_topline_win(win);
 
   redraw_later(win, VALID);
+  redraw_for_cursorline(win);
+  win->w_redr_status = true;
 }
 
 /// Gets the window height


### PR DESCRIPTION
Fix #17395

This still doesn't redraw for cursorcolumn, I'm not sure if I'll deal with that in this PR.