### PR TITLE
ci: use builtin runner.os instead of matrix.os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,19 @@ jobs:
           - flavor: asan
             cc: clang-13
             runner: ubuntu-20.04
-            os: linux
           - flavor: tsan
             cc: clang-13
             runner: ubuntu-20.04
-            os: linux
           - cc: clang
             runner: macos-10.15
-            os: osx
           - cc: clang
             runner: macos-11.0
-            os: osx
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     if: github.event.pull_request.draft == false
     env:
       CC: ${{ matrix.cc }}
-      CI_OS_NAME: ${{ matrix.os }}
+      CI_OS_NAME: ${{ runner.os }}
     steps:
       - uses: actions/checkout@v2
 
@@ -87,7 +83,7 @@ jobs:
         run: ./.github/workflows/env.sh ${{ matrix.flavor }}
 
       - name: Install apt packages
-        if: matrix.os == 'linux'
+        if: matrix.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y autoconf automake build-essential ccache cmake cpanminus cscope gcc-multilib gdb gettext gperf language-pack-tr libtool-bin locales ninja-build pkg-config python3 python3-pip python3-setuptools unzip valgrind xclip
@@ -101,7 +97,7 @@ jobs:
           rm llvm.sh
 
       - name: Install brew packages
-        if: matrix.os == 'osx'
+        if: matrix.os == 'macOS'
         run: |
           brew update >/dev/null
           brew install automake ccache perl cpanminus ninja
@@ -162,12 +158,11 @@ jobs:
           - flavor: functionaltest-lua
             cc: gcc
             runner: ubuntu-20.04
-            os: linux
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
       CC: ${{ matrix.cc }}
-      CI_OS_NAME: ${{ matrix.os }}
+      CI_OS_NAME: ${{ runner.os }}
     steps:
       - uses: actions/checkout@v2
 

--- a/ci/common/build.sh
+++ b/ci/common/build.sh
@@ -1,5 +1,5 @@
 _stat() {
-  if test "${CI_OS_NAME}" = osx ; then
+  if test "${CI_OS_NAME}" = macOS ; then
     stat -f %Sm "${@}"
   else
     stat -c %y "${@}"

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -15,7 +15,7 @@ print_core() {
     return 0
   fi
   echo "======= Core file $core ======="
-  if test "${CI_OS_NAME}" = osx ; then
+  if test "${CI_OS_NAME}" = macOS ; then
     lldb -Q -o "bt all" -f "${app}" -c "${core}"
   else
     gdb -n -batch -ex 'thread apply all bt full' "${app}" -c "${core}"
@@ -30,7 +30,7 @@ check_core_dumps() {
   fi
   local app="${1:-${BUILD_DIR}/bin/nvim}"
   local cores
-  if test "${CI_OS_NAME}" = osx ; then
+  if test "${CI_OS_NAME}" = macOS ; then
     cores="$(find /cores/ -type f -print)"
     local _sudo='sudo'
   else


### PR DESCRIPTION
Just a convenience thing. Also makes it easier to refactor in the future