### PR TITLE
vim-patch:8.2.4388: dead code in op_insert()

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2318,33 +2318,24 @@ void op_insert(oparg_T *oap, long count1)
     // The user may have moved the cursor before inserting something, try
     // to adjust the block for that.  But only do it, if the difference
     // does not come from indent kicking in.
-    if (oap->start.lnum == curbuf->b_op_start_orig.lnum
-        && !bd.is_MAX
-        && !did_indent) {
+    if (oap->start.lnum == curbuf->b_op_start_orig.lnum && !bd.is_MAX && !did_indent) {
       const int t = getviscol2(curbuf->b_op_start_orig.col, curbuf->b_op_start_orig.coladd);
 
-      if (!bd.is_MAX) {
-        if (oap->op_type == OP_INSERT
-            && oap->start.col + oap->start.coladd
-            != curbuf->b_op_start_orig.col + curbuf->b_op_start_orig.coladd) {
-          oap->start.col = curbuf->b_op_start_orig.col;
-          pre_textlen -= t - oap->start_vcol;
-          oap->start_vcol = t;
-        } else if (oap->op_type == OP_APPEND
-                   && oap->start.col + oap->start.coladd
-                   >= curbuf->b_op_start_orig.col
-                   + curbuf->b_op_start_orig.coladd) {
-          oap->start.col = curbuf->b_op_start_orig.col;
-          // reset pre_textlen to the value of OP_INSERT
-          pre_textlen += bd.textlen;
-          pre_textlen -= t - oap->start_vcol;
-          oap->start_vcol = t;
-          oap->op_type = OP_INSERT;
-        }
-      } else if (bd.is_MAX && oap->op_type == OP_APPEND) {
+      if (oap->op_type == OP_INSERT
+          && oap->start.col + oap->start.coladd
+          != curbuf->b_op_start_orig.col + curbuf->b_op_start_orig.coladd) {
+        oap->start.col = curbuf->b_op_start_orig.col;
+        pre_textlen -= t - oap->start_vcol;
+        oap->start_vcol = t;
+      } else if (oap->op_type == OP_APPEND
+                 && oap->start.col + oap->start.coladd
+                 >= curbuf->b_op_start_orig.col + curbuf->b_op_start_orig.coladd) {
+        oap->start.col = curbuf->b_op_start_orig.col;
         // reset pre_textlen to the value of OP_INSERT
         pre_textlen += bd.textlen;
         pre_textlen -= t - oap->start_vcol;
+        oap->start_vcol = t;
+        oap->op_type = OP_INSERT;
       }
     }
 


### PR DESCRIPTION
#### vim-patch:8.2.4388: dead code in op_insert()

Problem:    Dead code in op_insert().
Solution:   Remove condition and else block. (closes vim/vim#9782)
https://github.com/vim/vim/commit/7745f14ef324a7134b2f26a47451cf5032f44b89