### PR TITLE
fix(highlight): global ns improvements

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -821,27 +821,27 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
   CHECK_FLAG(dict, mask, global, , HL_GLOBAL);
 
   if (HAS_KEY(dict->fg)) {
-    fg = object_to_color(dict->fg, "fg", err);
+    fg = object_to_color(dict->fg, "fg", true, err);
   } else if (HAS_KEY(dict->foreground)) {
-    fg = object_to_color(dict->foreground, "foreground", err);
+    fg = object_to_color(dict->foreground, "foreground", true, err);
   }
   if (ERROR_SET(err)) {
     return hlattrs;
   }
 
   if (HAS_KEY(dict->bg)) {
-    bg = object_to_color(dict->bg, "bg", err);
+    bg = object_to_color(dict->bg, "bg", true, err);
   } else if (HAS_KEY(dict->background)) {
-    bg = object_to_color(dict->background, "background", err);
+    bg = object_to_color(dict->background, "background", true, err);
   }
   if (ERROR_SET(err)) {
     return hlattrs;
   }
 
   if (HAS_KEY(dict->sp)) {
-    sp = object_to_color(dict->sp, "sp", err);
+    sp = object_to_color(dict->sp, "sp", true, err);
   } else if (HAS_KEY(dict->special)) {
-    sp = object_to_color(dict->special, "special", err);
+    sp = object_to_color(dict->special, "special", true, err);
   }
   if (ERROR_SET(err)) {
     return hlattrs;
@@ -882,14 +882,14 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
 #undef CHECK_FLAG
 
   if (HAS_KEY(dict->ctermfg)) {
-    ctermfg = object_to_color(dict->ctermfg, "ctermfg", err);
+    ctermfg = object_to_color(dict->ctermfg, "ctermfg", false, err);
     if (ERROR_SET(err)) {
       return hlattrs;
     }
   }
 
   if (HAS_KEY(dict->ctermbg)) {
-    ctermbg = object_to_color(dict->ctermbg, "ctermbg", err);
+    ctermbg = object_to_color(dict->ctermbg, "ctermbg", false, err);
     if (ERROR_SET(err)) {
       return hlattrs;
     }
@@ -916,14 +916,25 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
   return hlattrs;
 }
 
-int object_to_color(Object val, char *key, Error *err)
+int object_to_color(Object val, char *key, bool rgb, Error *err)
 {
   if (val.type == kObjectTypeInteger) {
     return (int)val.data.integer;
   } else if (val.type == kObjectTypeString) {
     String str = val.data.string;
     // TODO(bfredl): be more fancy with "bg", "fg" etc
-    return str.size ? name_to_color(str.data) : 0;
+    int color;
+    if (!str.size) {
+      color = 0;
+    } else if (rgb) {
+      color = name_to_color(str.data);
+    } else {
+      color = name_to_ctermcolor(str.data);
+    }
+    if (color < 0) {
+      api_set_error(err, kErrorTypeValidation, "'%s' is not a valid color", str.data);
+    }
+    return color;
   } else {
     api_set_error(err, kErrorTypeValidation, "'%s' must be string or integer", key);
     return 0;

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -904,15 +904,13 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     hlattrs.rgb_bg_color = bg;
     hlattrs.rgb_fg_color = fg;
     hlattrs.rgb_sp_color = sp;
-    hlattrs.cterm_bg_color =
-      ctermbg == -1 ? cterm_normal_bg_color : ctermbg + 1;
-    hlattrs.cterm_fg_color =
-      ctermfg == -1 ? cterm_normal_fg_color : ctermfg + 1;
+    hlattrs.cterm_bg_color = ctermbg == -1 ? 0 : ctermbg + 1;
+    hlattrs.cterm_fg_color = ctermfg == -1 ? 0 : ctermfg + 1;
     hlattrs.cterm_ae_attr = cterm_mask;
   } else {
     hlattrs.cterm_ae_attr = cterm_mask;
-    hlattrs.cterm_bg_color = bg == -1 ? cterm_normal_bg_color : bg + 1;
-    hlattrs.cterm_fg_color = fg == -1 ? cterm_normal_fg_color : fg + 1;
+    hlattrs.cterm_bg_color = bg == -1 ? 0 : bg + 1;
+    hlattrs.cterm_fg_color = fg == -1 ? 0 : fg + 1;
   }
 
   return hlattrs;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -6758,16 +6758,26 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
     { NULL, -1, NIL },
   };
 
+  char hex_name[8];
+  char *name;
+
   for (int j = 0; cattrs[j].dest; j++) {
-    if (cattrs[j].val != -1) {
+    if (cattrs[j].val < 0) {
+      XFREE_CLEAR(*cattrs[j].dest);
+      continue;
+    }
+
+    if (cattrs[j].name.type == kObjectTypeString && cattrs[j].name.data.string.size) {
+      name = cattrs[j].name.data.string.data;
+    } else {
+      snprintf(hex_name, sizeof(hex_name), "#%06x", cattrs[j].val);
+      name = hex_name;
+    }
+
+    if (!*cattrs[j].dest
+        || STRCMP(*cattrs[j].dest, name) != 0) {
       xfree(*cattrs[j].dest);
-      if (cattrs[j].name.type == kObjectTypeString && cattrs[j].name.data.string.size) {
-        *cattrs[j].dest = xstrdup(cattrs[j].name.data.string.data);
-      } else {
-        char hex_name[8];
-        snprintf(hex_name, sizeof(hex_name), "#%06x", cattrs[j].val);
-        *cattrs[j].dest = xstrdup(hex_name);
-      }
+      *cattrs[j].dest = xstrdup(name);
     }
   }
 

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -8859,6 +8859,22 @@ RgbValue name_to_color(const char *name)
   return -1;
 }
 
+int name_to_ctermcolor(const char *name)
+{
+  int i;
+  int off = TOUPPER_ASC(*name);
+  for (i = ARRAY_SIZE(color_names); --i >= 0;) {
+    if (off == color_names[i][0]
+        && STRICMP(name+1, color_names[i]+1) == 0) {
+      break;
+    }
+  }
+  if (i < 0) {
+    return -1;
+  }
+  TriState bold = kNone;
+  return lookup_color(i, false, &bold);
+}
 
 /**************************************
 *  End of Highlighting stuff          *

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -276,4 +276,26 @@ describe("API: set highlight", function()
     eq('Test_hl3       xxx guifg=bLue guibg=reD',
       exec_capture('highlight Test_hl3'))
   end)
+
+  it ("can modify a highlight in the global namespace", function()
+    meths.set_hl(0, 'Test_hl3', { bg = 'red', fg = 'blue'})
+    eq('Test_hl3       xxx guifg=blue guibg=red',
+      exec_capture('highlight Test_hl3'))
+
+    meths.set_hl(0, 'Test_hl3', { bg = 'red' })
+    eq('Test_hl3       xxx guibg=red',
+      exec_capture('highlight Test_hl3'))
+
+    meths.set_hl(0, 'Test_hl3', { ctermbg = 9, ctermfg = 12})
+    eq('Test_hl3       xxx ctermfg=12 ctermbg=9',
+      exec_capture('highlight Test_hl3'))
+
+    meths.set_hl(0, 'Test_hl3', { ctermbg = 9 })
+    eq('Test_hl3       xxx ctermbg=9',
+      exec_capture('highlight Test_hl3'))
+
+    meths.set_hl(0, 'Test_hl3', {})
+    eq('Test_hl3       xxx cleared',
+      exec_capture('highlight Test_hl3'))
+  end)
 end)

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -290,6 +290,10 @@ describe("API: set highlight", function()
     eq('Test_hl3       xxx ctermfg=12 ctermbg=9',
       exec_capture('highlight Test_hl3'))
 
+    meths.set_hl(0, 'Test_hl3', { ctermbg = 'red' , ctermfg = 'blue'})
+    eq('Test_hl3       xxx ctermfg=12 ctermbg=9',
+      exec_capture('highlight Test_hl3'))
+
     meths.set_hl(0, 'Test_hl3', { ctermbg = 9 })
     eq('Test_hl3       xxx ctermbg=9',
       exec_capture('highlight Test_hl3'))
@@ -297,5 +301,18 @@ describe("API: set highlight", function()
     meths.set_hl(0, 'Test_hl3', {})
     eq('Test_hl3       xxx cleared',
       exec_capture('highlight Test_hl3'))
+
+    eq("'redd' is not a valid color",
+      pcall_err(meths.set_hl, 0, 'Test_hl3', {fg='redd'}))
+
+    eq("'bleu' is not a valid color",
+      pcall_err(meths.set_hl, 0, 'Test_hl3', {ctermfg='bleu'}))
+
+    meths.set_hl(0, 'Test_hl3', {fg='#FF00FF'})
+    eq('Test_hl3       xxx guifg=#FF00FF',
+      exec_capture('highlight Test_hl3'))
+
+    eq("'#FF00FF' is not a valid color",
+      pcall_err(meths.set_hl, 0, 'Test_hl3', {ctermfg='#FF00FF'}))
   end)
 end)


### PR DESCRIPTION
- `nvim_set_hl(0, <name>, {...})` fully redefines `<name>` instead of modifying/setting individual fields. This means `nvim_set_hl(0, <name>, {})` will clear a highlight.
- `ctermfg` and `ctermbg` no longer fallback to `Normal`.
- Color names can now be passed to `ctermfg` and `ctermbg`. E.g. `ctermfg='blue'`.
- Invalid color names (for gui and cterm) now raise an error.

Fixes #17420
