### PR TITLE
feat: allow :map commands to create maps with description

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1584,11 +1584,11 @@ nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
                     {rhs}   Right-hand-side |{rhs}| of the mapping.
                     {opts}  Optional parameters map. Accepts all
                             |:map-arguments| as keys excluding |<buffer>| but
-                            including |noremap| and "desc". "desc" can be used
-                            to give a description to keymap. When called from
-                            Lua, also accepts a "callback" key that takes a
-                            Lua function to call when the mapping is executed.
-                            Values are Booleans. Unknown key is an error.
+                            including |noremap|. When called from Lua, also
+                            accepts a "callback" key that takes a Lua function
+                            to call when the mapping is executed. Values are
+                            Booleans except for "desc". Unknown key is an
+                            error.
 
 nvim_set_option({name}, {value})                           *nvim_set_option()*
                 Sets the global value of an option.

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -153,8 +153,8 @@ type "a", then "bar" will get inserted.
 
 1.2 SPECIAL ARGUMENTS					*:map-arguments*
 
-"<buffer>", "<nowait>", "<silent>", "<script>", "<expr>" and
-"<unique>" can be used in any order.  They must appear right after the
+"<buffer>", "<nowait>", "<silent>", "<script>", "<expr>",
+"<unique>", "<desc>" can be used in any order.  They must appear right after the
 command, before any other arguments.
 
 			*:map-local* *:map-<buffer>* *:map-buffer* *E224* *E225*
@@ -198,6 +198,18 @@ the executed command are still given though.  To shut them up too, add a
 Prompts will still be given, e.g., for inputdialog().
 Using "<silent>" for an abbreviation is possible, but will cause redrawing of
 the command line to fail.
+
+						*:map-<desc>* *:map-desc*
+"<desc>" can be used provide a description for mappings. Example: >
+	:map <desc=Save all files and quit nvim> <leader>q <Cmd>wqa<CR>
+Text between `<desc=` & `>` will be used as description.
+`>` can be used inside description by escaping it with `\`. Because `\`
+is the escape charecter it also needs to be escaped. A lone `\` is just
+ignored. So >
+	:map <desc=escape \> with \\> abc cba
+Is a valid way to set description and the description becomes "escape > with \".
+If a description is given during map creation it'll shown while listing
+mappings.
 
 						*:map-<script>* *:map-script*
 If the first argument to one of these commands is "<script>" and it is used to
@@ -502,9 +514,7 @@ Note: When using mappings for Visual mode, you can use the "'<" mark, which
 is the start of the last selected Visual area in the current buffer |'<|.
 
 The |:filter| command can be used to select what mappings to list.  The
-pattern is matched against the {lhs} and {rhs} in the raw form.  If a
-description was added using |nvim_set_keymap()| or |nvim_buf_set_keymap()|
-then the pattern is also matched against it.
+pattern is matched against the {lhs}, {rhs} and <desc> in the raw form.
 
 							*:map-verbose*
 When 'verbose' is non-zero, listing a key map will also display where it was

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1587,11 +1587,10 @@ ArrayOf(Dictionary) nvim_get_keymap(uint64_t channel_id, String mode)
 /// @param  lhs   Left-hand-side |{lhs}| of the mapping.
 /// @param  rhs   Right-hand-side |{rhs}| of the mapping.
 /// @param  opts  Optional parameters map. Accepts all |:map-arguments|
-///               as keys excluding |<buffer>| but including |noremap| and "desc".
-///               "desc" can be used to give a description to keymap.
+///               as keys excluding |<buffer>| but including |noremap|.
 ///               When called from Lua, also accepts a "callback" key that takes
 ///               a Lua function to call when the mapping is executed.
-///               Values are Booleans. Unknown key is an error.
+///               Values are Booleans except for "desc". Unknown key is an error.
 /// @param[out]   err   Error details, if any.
 void nvim_set_keymap(String mode, String lhs, String rhs, Dict(keymap) *opts, Error *err)
   FUNC_API_SINCE(6)

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2757,6 +2757,27 @@ int str_to_mapargs(const char_u *strargs, bool is_unmap, MapArguments *mapargs)
       parsed_args.unique = true;
       continue;
     }
+
+    if (STRNCMP(to_parse, "<desc=", 6) == 0) {
+      const char_u *p = to_parse + 6;
+      garray_T ga = GA_INIT(sizeof(char), 20);
+      while (*p != '>' && *p != NUL) {
+        if (*p == '\\') {
+          p++;  // skip escape char
+        }
+        ga_append(&ga, (char)(*p));
+        p++;
+      }
+      if (*p == NUL || p == to_parse + 6) {
+        // Unfinished description. Try it as lhs.
+        ga_clear(&ga);
+        break;
+      }
+      ga_append(&ga, NUL);
+      parsed_args.desc = (char *)ga.ga_data;
+      to_parse = skipwhite(p + 1);
+      continue;
+    }
     break;
   }
 
@@ -3226,6 +3247,7 @@ int do_map(int maptype, char_u *arg, int mode, bool is_abbrev)
 free_and_return:
   xfree(parsed_args.rhs);
   xfree(parsed_args.orig_rhs);
+  xfree(parsed_args.desc);
   return result;
 }
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2762,10 +2762,19 @@ int str_to_mapargs(const char_u *strargs, bool is_unmap, MapArguments *mapargs)
       const char_u *p = to_parse + 6;
       garray_T ga = GA_INIT(sizeof(char), 20);
       while (*p != '>' && *p != NUL) {
-        if (*p == '\\') {
-          p++;  // skip escape char
+        char p_char = (char)(*p);
+        if (p_char == '\\') {
+          p_char = (char)(*(++p));  // skip escape char
+          switch (p_char) {
+            case 'n':
+              p_char = '\n';
+              break;
+            case 't':
+              p_char = '\t';
+              break;
+          }
         }
-        ga_append(&ga, (char)(*p));
+        ga_append(&ga, p_char);
         p++;
       }
       if (*p == NUL || p == to_parse + 6) {

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -877,24 +877,6 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     eq("\nn  lhs           rhs\n                 map description",
        helpers.exec_capture("nmap lhs"))
   end)
-
-  it ('can :filter maps based on description', function()
-    meths.set_keymap('n', 'asdf1', 'qwert', {desc='do the one thing'})
-    meths.set_keymap('n', 'asdf2', 'qwert', {desc='doesnot really do anything'})
-    meths.set_keymap('n', 'asdf3', 'qwert', {desc='do the other thing'})
-    eq([[
-
-n  asdf3         qwert
-                 do the other thing
-n  asdf1         qwert
-                 do the one thing]],
-       helpers.exec_capture('filter the nmap'))
-  end)
-
-  it ('shows <nop> as map rhs', function()
-    meths.set_keymap('n', 'asdf', '<nop>', {})
-    eq('\nn  asdf          <Nop>', helpers.exec_capture('nmap asdf'))
-  end)
 end)
 
 describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -25,4 +25,22 @@ describe(':*map', function()
     feed('i-<M-">-')
     expect('-foo-')
   end)
+
+  it('can create maps with description', function()
+    command('nnoremap <silent><desc=Some interesting map> asdf <Nop>')
+    eq([[
+
+n  asdf        * <Nop>
+                 Some interesting map]],
+       helpers.exec_capture('nnoremap asdf'))
+  end)
+
+  it('accepts escaped > in map-description', function()
+    command([[nnoremap <silent><desc=escape \> with \\> asdf <Nop>]])
+    eq([[
+
+n  asdf        * <Nop>
+                 escape > with \]],
+       helpers.exec_capture('nnoremap asdf'))
+  end)
 end)

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -64,4 +64,13 @@ n  asdf        * <Nop>
                  escape > with \]],
        helpers.exec_capture('nnoremap asdf'))
   end)
+  it('can use newline & tab in description', function()
+    command([[nnoremap <silent><desc=can do multiline\n\t\t tabs too> asdf <Nop>]])
+    eq([[
+
+n  asdf        * <Nop>
+                 can do multiline
+		 tabs too]],
+       helpers.exec_capture('nnoremap asdf'))
+  end)
 end)

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -26,7 +26,28 @@ describe(':*map', function()
     expect('-foo-')
   end)
 
-  it('can create maps with description', function()
+  it('shows <nop> as mapping rhs', function()
+    command('nmap asdf <Nop>')
+    eq([[
+
+n  asdf          <Nop>]],
+       helpers.exec_capture('nmap asdf'))
+  end)
+
+  it('mappings with description can be filtered', function()
+    meths.set_keymap('n', 'asdf1', 'qwert', {desc='do the one thing'})
+    meths.set_keymap('n', 'asdf2', 'qwert', {desc='doesnot really do anything'})
+    meths.set_keymap('n', 'asdf3', 'qwert', {desc='do the other thing'})
+    eq([[
+
+n  asdf3         qwert
+                 do the other thing
+n  asdf1         qwert
+                 do the one thing]],
+       helpers.exec_capture('filter the nmap'))
+  end)
+
+  it('can create mappings with description', function()
     command('nnoremap <silent><desc=Some interesting map> asdf <Nop>')
     eq([[
 
@@ -35,7 +56,7 @@ n  asdf        * <Nop>
        helpers.exec_capture('nnoremap asdf'))
   end)
 
-  it('accepts escaped > in map-description', function()
+  it('accepts escaped > in description', function()
     command([[nnoremap <silent><desc=escape \> with \\> asdf <Nop>]])
     eq([[
 


### PR DESCRIPTION
Now `:map` commands can set map descriptions too . For example
```vim
:map <desc=Save all files and quit nvim> <leader>q <Cmd>wqa<CR>
```