### PR TITLE
ci(lint): remove unnecessary steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,7 @@ jobs:
       - name: Install apt packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential ccache cmake cpanminus gettext gperf language-pack-tr libtool-bin locales ninja-build pkg-config python3 python3-pip python3-setuptools unzip flake8
-
-      - name: Setup interpreter packages
-        run: |
-          ./ci/install.sh
+          sudo apt-get install -y autoconf automake build-essential ccache cmake gettext gperf libtool-bin locales ninja-build pkg-config flake8
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
Saves a little bit of CI time, but it's mostly for code cleanup.