### PR TITLE
docs(api): clarify possible keys for `nvim_set_hl`

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -128,8 +128,15 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///              to set a highlight group in the global (`:highlight`)
 ///              namespace.
 /// @param name highlight group name, like ErrorMsg
-/// @param val highlight definition map, like |nvim_get_hl_by_name|.
-///            in addition the following keys are also recognized:
+/// @param val highlight definition map
+///            The following keys are recognized:
+///              `fg`     : sets the forground of gui color
+///              `bg`     : sets the background of gui color
+///              `{bold,italic,undercurl,
+///                 underline,strikethrough,reverse}`:
+///                         sets the specified attribute to `true`
+///                         or `false`
+///              `sp`     : sets the sp color for gui
 ///              `default`: don't override existing definition,
 ///                         like `hi default`
 ///              `ctermfg`: sets foreground of cterm color


### PR DESCRIPTION
Wrote down the keys that can be used for `nvim_set_hl` instead of
just referencing to `nvim_get_hl_by_name`.

The reason I am doing this is that you can't get the keys by using `nvim_get_hl_by_name`:
1. `nvim --clean`
2. `:hi Normal guisp=#FF0000`
3. `:lua print(vim.inspect(vim.api.nvim_get_hl_by_name("Normal",false)))`
prints
```
{
    [true] = 6
}
```

(`sp`was the one that wasn't obvious to me)
I'm not sure if this is the cleanest way to tell the user about them or if I've done sth wrong with `get_hl_by_name` so feel free to close this pr if you find a better way.