### PR TITLE
vim-patch:8.2.{4392,4394,4400}

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1004,20 +1004,9 @@ int ins_char_typebuf(int c, int modifier)
     buf[len + 2] = (char_u)K_THIRD(c);
     buf[len + 3] = NUL;
   } else {
-    char_u *p = buf + len;
-    int char_len = utf_char2bytes(c, p);
-    len += char_len;
-    // If the character contains K_SPECIAL bytes they need escaping.
-    for (int i = char_len; --i >= 0; p++) {
-      if ((uint8_t)(*p) == K_SPECIAL) {
-        memmove(p + 3, p + 1, (size_t)i);
-        *p++ = K_SPECIAL;
-        *p++ = KS_SPECIAL;
-        *p = KE_FILLER;
-        len += 2;
-      }
-    }
-    *p = NUL;
+    char_u *end = add_char2buf(c, buf + len);
+    *end = NUL;
+    len = (int)(end - buf);
   }
   (void)ins_typebuf(buf, KeyNoremap, 0, !KeyTyped, cmd_silent);
   return len;


### PR DESCRIPTION
#### vim-patch:8.2.4400: MS-Windows: cannot use the mouse in the console with VIMDLL

Problem:    MS-Windows: cannot use the mouse in the console with VIMDLL.
Solution:   use add_char2buf() instead of fix_input_buffer(). (closes vim/vim#9784)
https://github.com/vim/vim/commit/646bb7247ad6051aca223a2b04b008f682cdb57f

N/A patches for version.c:

vim-patch:8.2.4392: MS-Windows with VIMDLL: Escaping CSI is wrong

Problem:    MS-Windows with VIMDLL: Escaping CSI is wrong.
Solution:   Put back #ifdef. (Ken Takata)
https://github.com/vim/vim/commit/64d95cfc56406858a05032c6a134f1e08fe2ca78

vim-patch:8.2.4394: UTF8 select mode test fails on MS-Windows

Problem:    UTF8 select mode test fails on MS-Windows.
Solution:   Revert the #ifdef change.
https://github.com/vim/vim/commit/9fdde7992ab4c21517f447ca3d651b9ff4a770e8