### PR TITLE
vim-patch:8.2.4345

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1523,7 +1523,8 @@ static bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io,
         || event == EVENT_QUICKFIXCMDPOST || event == EVENT_QUICKFIXCMDPRE
         || event == EVENT_REMOTEREPLY || event == EVENT_SPELLFILEMISSING
         || event == EVENT_SYNTAX || event == EVENT_SIGNAL
-        || event == EVENT_TABCLOSED || event == EVENT_WINCLOSED) {
+        || event == EVENT_TABCLOSED || event == EVENT_USER
+        || event == EVENT_WINCLOSED) {
       fname = vim_strsave(fname);
     } else {
       fname = (char_u *)FullName_save((char *)fname, false);

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1827,6 +1827,14 @@ func Test_autocommand_all_events()
   call assert_fails('au * x bwipe', 'E1155:')
 endfunc
 
+func Test_autocmd_user()
+  au User MyEvent let s:res = [expand("<afile>"), expand("<amatch>")]
+  doautocmd User MyEvent
+  call assert_equal(['MyEvent', 'MyEvent'], s:res)
+  au! User
+  unlet s:res
+endfunc
+
 function s:Before_test_dirchanged()
   augroup test_dirchanged
     autocmd!
@@ -1850,11 +1858,11 @@ endfunc
 
 function Test_dirchanged_global()
   call s:Before_test_dirchanged()
-  autocmd test_dirchanged DirChangedPre global call add(s:li, "pre cd " .. v:event.directory)
+  autocmd test_dirchanged DirChangedPre global call add(s:li, expand("<amatch>") .. " pre cd " .. v:event.directory)
   autocmd test_dirchanged DirChanged global call add(s:li, "cd:")
   autocmd test_dirchanged DirChanged global call add(s:li, expand("<afile>"))
   call chdir(s:dir_foo)
-  let expected = ["pre cd " .. s:dir_foo, "cd:", s:dir_foo]
+  let expected = ["global pre cd " .. s:dir_foo, "cd:", s:dir_foo]
   call assert_equal(expected, s:li)
   call chdir(s:dir_foo)
   call assert_equal(expected, s:li)


### PR DESCRIPTION
#### vim-patch:8.2.4345: <amatch> is expanded like a file name for DirChangedPre

Problem:    <amatch> is expanded like a file name for DirChangedPre.
Solution:   Do not expand <amatch>. (closes vim/vim#9742)  Also for the User event.
https://github.com/vim/vim/commit/f6246f51e3d85a982a899b4a8fd9045a5e23016f