### PR TITLE
vim-patch:8.1.2336,8.2.{4338,4401}: mapping cursor and redrawing patches

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1949,8 +1949,10 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
     // expression.  Also save and restore the command line
     // for "normal :".
     if (mp->m_expr) {
-      int save_vgetc_busy = vgetc_busy;
+      const int save_vgetc_busy = vgetc_busy;
       const bool save_may_garbage_collect = may_garbage_collect;
+      const int save_cursor_row = ui_current_row();
+      const int save_cursor_col = ui_current_col();
 
       vgetc_busy = 0;
       may_garbage_collect = false;
@@ -1960,6 +1962,12 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
         save_m_str = vim_strsave(mp->m_str);
       }
       map_str = eval_map_expr(mp, NUL);
+
+      // The mapping may do anything, but we expect it to take care of
+      // redrawing.  Do put the cursor back where it was.
+      ui_cursor_goto(save_cursor_row, save_cursor_col);
+      ui_flush();
+
       vgetc_busy = save_vgetc_busy;
       may_garbage_collect = save_may_garbage_collect;
     } else {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3519,6 +3519,7 @@ static void showmap(mapblock_T *mp, bool local)
   if (p_verbose > 0) {
     last_set_msg(mp->m_script_ctx);
   }
+  msg_clr_eos();
   ui_flush();                          // show one line at a time
 }
 

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -483,6 +483,38 @@ func Test_expr_map_restore_cursor()
   call delete('XtestExprMap')
 endfunc
 
+func Test_expr_map_error()
+  CheckScreendump
+
+  let lines =<< trim END
+      func Func()
+        throw 'test'
+        return ''
+      endfunc
+
+      nnoremap <expr> <F2> Func()
+      cnoremap <expr> <F2> Func()
+
+      call test_override('ui_delay', 10)
+  END
+  call writefile(lines, 'XtestExprMap')
+  let buf = RunVimInTerminal('-S XtestExprMap', #{rows: 10})
+  call TermWait(buf)
+  call term_sendkeys(buf, "\<F2>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "\<CR>")
+  call VerifyScreenDump(buf, 'Test_map_expr_2', {})
+
+  call term_sendkeys(buf, ":abc\<F2>")
+  call VerifyScreenDump(buf, 'Test_map_expr_3', {})
+  call term_sendkeys(buf, "\<Esc>0")
+  call VerifyScreenDump(buf, 'Test_map_expr_4', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XtestExprMap')
+endfunc
+
 " Test for mapping errors
 func Test_map_error()
   call assert_fails('unmap', 'E474:')

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -474,13 +474,28 @@ func Test_expr_map_restore_cursor()
   END
   call writefile(lines, 'XtestExprMap')
   let buf = RunVimInTerminal('-S XtestExprMap', #{rows: 10})
-  call term_wait(buf)
   call term_sendkeys(buf, "\<C-B>")
   call VerifyScreenDump(buf, 'Test_map_expr_1', {})
 
   " clean up
   call StopVimInTerminal(buf)
   call delete('XtestExprMap')
+endfunc
+
+func Test_map_listing()
+  CheckScreendump
+
+  let lines =<< trim END
+      nmap a b
+  END
+  call writefile(lines, 'XtestMapList')
+  let buf = RunVimInTerminal('-S XtestMapList', #{rows: 6})
+  call term_sendkeys(buf, ":                      nmap a\<CR>")
+  call VerifyScreenDump(buf, 'Test_map_list_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XtestMapList')
 endfunc
 
 func Test_expr_map_error()
@@ -499,7 +514,6 @@ func Test_expr_map_error()
   END
   call writefile(lines, 'XtestExprMap')
   let buf = RunVimInTerminal('-S XtestExprMap', #{rows: 10})
-  call TermWait(buf)
   call term_sendkeys(buf, "\<F2>")
   call TermWait(buf)
   call term_sendkeys(buf, "\<CR>")

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require("test.functional.helpers")(after_each)
+local Screen = require('test.functional.ui.screen')
 
 local eq = helpers.eq
 local feed = helpers.feed
@@ -24,5 +25,106 @@ describe(':*map', function()
     command('imap <M-"> foo')
     feed('i-<M-">-')
     expect('-foo-')
+  end)
+end)
+
+describe(':*map <expr>', function()
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(20, 5)
+    screen:attach()
+  end)
+
+  it('cursor is restored after :map <expr>', function()
+    command(':map <expr> x input("> ")')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+                          |
+    ]])
+    feed('x')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      > ^                  |
+    ]])
+    feed('\n')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+      >                   |
+    ]])
+  end)
+
+  it('cursor is restored after :imap <expr>', function()
+    command(':imap <expr> x input("> ")')
+    feed('i')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+      -- INSERT --        |
+    ]])
+    feed('x')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      > ^                  |
+    ]])
+    feed('\n')
+    screen:expect([[
+      ^                    |
+      ~                   |
+      ~                   |
+      ~                   |
+      >                   |
+    ]])
+  end)
+
+  it('error in :cmap <expr> handled correctly', function()
+    screen:try_resize(40, 5)
+    command(':cmap <expr> x execute("throw 42")')
+    feed(':echo "foo')
+    screen:expect([[
+                                              |
+      ~                                       |
+      ~                                       |
+      ~                                       |
+      :echo "foo^                              |
+    ]])
+    feed('x')
+    screen:expect([[
+                                              |
+      :echo "foo                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      :echo "foo^                              |
+    ]])
+    feed('"')
+    screen:expect([[
+                                              |
+      :echo "foo                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      :echo "foo"^                             |
+    ]])
+    feed('\n')
+    screen:expect([[
+      :echo "foo                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      foo                                     |
+      Press ENTER or type command to continue^ |
+    ]])
   end)
 end)

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -2,6 +2,7 @@ local helpers = require("test.functional.helpers")(after_each)
 local Screen = require('test.functional.ui.screen')
 
 local eq = helpers.eq
+local exec = helpers.exec
 local feed = helpers.feed
 local meths = helpers.meths
 local clear = helpers.clear
@@ -28,7 +29,7 @@ describe(':*map', function()
   end)
 end)
 
-describe(':*map <expr>', function()
+describe(':*map cursor and redrawing', function()
   local screen
   before_each(function()
     clear()
@@ -36,8 +37,8 @@ describe(':*map <expr>', function()
     screen:attach()
   end)
 
-  it('cursor is restored after :map <expr>', function()
-    command(':map <expr> x input("> ")')
+  it('cursor is restored after :map <expr> which calls input()', function()
+    command('map <expr> x input("> ")')
     screen:expect([[
       ^                    |
       ~                   |
@@ -63,8 +64,8 @@ describe(':*map <expr>', function()
     ]])
   end)
 
-  it('cursor is restored after :imap <expr>', function()
-    command(':imap <expr> x input("> ")')
+  it('cursor is restored after :imap <expr> which calls input()', function()
+    command('imap <expr> x input("> ")')
     feed('i')
     screen:expect([[
       ^                    |
@@ -91,9 +92,57 @@ describe(':*map <expr>', function()
     ]])
   end)
 
-  it('error in :cmap <expr> handled correctly', function()
+  it('cursor is restored after :map <expr> which redraws statusline vim-patch:8.1.2336', function()
+    exec([[
+      call setline(1, ['one', 'two', 'three'])
+      2
+      set ls=2
+      hi! link StatusLine ErrorMsg
+      noremap <expr> <C-B> Func()
+      func Func()
+	  let g:on = !get(g:, 'on', 0)
+	  redraws
+	  return ''
+      endfunc
+      func Status()
+	  return get(g:, 'on', 0) ? '[on]' : ''
+      endfunc
+      set stl=%{Status()}
+    ]])
+    feed('<C-B>')
+    screen:expect([[
+      one                 |
+      ^two                 |
+      three               |
+      [on]                |
+                          |
+    ]])
+  end)
+
+  it('error in :nmap <expr> does not mess up display vim-patch:4.2.4338', function()
     screen:try_resize(40, 5)
-    command(':cmap <expr> x execute("throw 42")')
+    command('nmap <expr> <F2> execute("throw 42")')
+    feed('<F2>')
+    screen:expect([[
+                                              |
+                                              |
+      Error detected while processing :       |
+      E605: Exception not caught: 42          |
+      Press ENTER or type command to continue^ |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                                        |
+      ~                                       |
+      ~                                       |
+      ~                                       |
+                                              |
+    ]])
+  end)
+
+  it('error in :cmap <expr> handled correctly vim-patch:4.2.4338', function()
+    screen:try_resize(40, 5)
+    command('cmap <expr> <F2> execute("throw 42")')
     feed(':echo "foo')
     screen:expect([[
                                               |
@@ -102,7 +151,7 @@ describe(':*map <expr>', function()
       ~                                       |
       :echo "foo^                              |
     ]])
-    feed('x')
+    feed('<F2>')
     screen:expect([[
                                               |
       :echo "foo                              |
@@ -125,6 +174,19 @@ describe(':*map <expr>', function()
       E605: Exception not caught: 42          |
       foo                                     |
       Press ENTER or type command to continue^ |
+    ]])
+  end)
+
+  it('listing mappings clears command line vim-patch:8.2.4401', function()
+    screen:try_resize(40, 5)
+    command('nmap a b')
+    feed(':                      nmap a<CR>')
+    screen:expect([[
+      ^                                        |
+      ~                                       |
+      ~                                       |
+      ~                                       |
+      n  a             b                      |
     ]])
   end)
 end)

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -33,7 +33,7 @@ before_each(function()
     let g:NUM_LVLS = 4
     function Redraw()
       mode
-      return ''
+      return "\<Ignore>"
     endfunction
     let g:id = ''
     cnoremap <expr> {REDRAW} Redraw()
@@ -42,7 +42,7 @@ before_each(function()
       let Cb = g:Nvim_color_input{g:id}
       let out = input({'prompt': ':', 'highlight': Cb})
       let g:out{id} = out
-      return (a:do_return ? out : '')
+      return (a:do_return ? out : "\<Ignore>")
     endfunction
     nnoremap <expr> {PROMPT} DoPrompt(0)
     cnoremap <expr> {PROMPT} DoPrompt(1)
@@ -410,7 +410,7 @@ describe('Command-line coloring', function()
   end)
   it('stops executing callback after a number of errors', function()
     set_color_cb('SplittedMultibyteStart')
-    start_prompt('let x = "«»«»«»«»«»"\n')
+    start_prompt('let x = "«»«»«»«»«»"')
     screen:expect([[
       {EOB:~                                       }|
       {EOB:~                                       }|
@@ -419,7 +419,7 @@ describe('Command-line coloring', function()
       :let x = "                              |
       {ERR:E5405: Chunk 0 start 10 splits multibyte}|
       {ERR: character}                              |
-      ^:let x = "«»«»«»«»«»"                   |
+      :let x = "«»«»«»«»«»"^                   |
     ]])
     feed('\n')
     screen:expect([[
@@ -432,6 +432,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
                                               |
     ]])
+    feed('\n')
     eq('let x = "«»«»«»«»«»"', meths.get_var('out'))
     local msg = '\nE5405: Chunk 0 start 10 splits multibyte character'
     eq(msg:rep(1), funcs.execute('messages'))
@@ -474,14 +475,14 @@ describe('Command-line coloring', function()
     ]])
     feed('\n')
     screen:expect([[
-                                              |
+      ^                                        |
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      ^:echo 42                                |
+      :echo 42                                |
     ]])
     feed('\n')
     eq('echo 42', meths.get_var('out'))


### PR DESCRIPTION
Fix #12707
Some tests are cherry-picked from #12837

#### vim-patch:8.1.2336: when an expr mapping moves the cursor it is not restored

Problem:    When an expr mapping moves the cursor it is not restored.
Solution:   Position the cursor after an expr mapping.
https://github.com/vim/vim/commit/4ebe0e62d097d68c5312f9c32714fb41a4c947a3


#### vim-patch:8.2.4338: an error from an expression mapping messes up the display

Problem:    An error from an expression mapping messes up the display.
Solution:   When the expression results in an empty string return K_IGNORE.
            In cmdline mode redraw the command line.
https://github.com/vim/vim/commit/74a0a5b26d0180f3ea89e9495dff6a26f0df23cb


#### vim-patch:8.2.4401: map listing does not clear the rest of the command line

Problem:    Map listing does not clear the rest of the command line.
Solution:   Call msg_clear_eos().
https://github.com/vim/vim/commit/d288eaad846f0e07e0141226f97d858dcf96cb78