### PR TITLE
feat: restore --remote

### DIFF
--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -1,0 +1,189 @@
+*remote.txt*    Nvim
+
+
+		  VIM REFERENCE MANUAL    by Bram Moolenaar
+
+
+Vim client-server communication				*client-server*
+
+                                      Type |gO| to see the table of contents.
+
+==============================================================================
+1. Common functionality					*clientserver*
+
+When compiled with the |+clientserver| option, Vim can act as a command
+server.  It accepts messages from a client and executes them.  At the same
+time, Vim can function as a client and send commands to a Vim server.
+
+The following command line arguments are available:
+
+    argument			meaning	~
+
+   --remote [+{cmd}] {file} ...					*--remote*
+				Open the file list in a remote Vim.  When
+				there is no Vim server, execute locally.
+				There is one optional init command: +{cmd}.
+				This must be an Ex command that can be
+				followed by "|".
+				The rest of the command line is taken as the
+				file list.  Thus any non-file arguments must
+				come before this.
+				You cannot edit stdin this way |--|.
+				The remote Vim is raised.  If you don't want
+				this use >
+				 vim --remote-send "<C-\><C-N>:n filename<CR>"
+<
+   --remote-silent [+{cmd}] {file} ...			*--remote-silent*
+				As above, but don't complain if there is no
+				server and the file is edited locally.
+   --remote-wait [+{cmd}] {file} ...				*--remote-wait*
+				As --remote, but wait for files to complete
+				(unload) in remote Vim.
+   --remote-wait-silent [+{cmd}] {file} ...		*--remote-wait-silent*
+				As --remote-wait, but don't complain if there
+				is no server.
+							*--remote-tab*
+   --remote-tab			Like --remote but open each file in a new
+				tabpage.
+							*--remote-tab-silent*
+   --remote-tab-silent		Like --remote-silent but open each file in a
+				new tabpage.
+							*--remote-tab-wait*
+   --remote-tab-wait		Like --remote-wait but open each file in a new
+				tabpage.
+
+						*--remote-tab-wait-silent*
+   --remote-tab-wait-silent	Like --remote-wait-silent but open each file
+				in a new tabpage.
+								*--remote-send*
+   --remote-send {keys}		Send {keys} to server and exit.  The {keys}
+   				are not mapped.  Special key names are
+				recognized, e.g., "<CR>" results in a CR
+				character.
+								*--remote-expr*
+   --remote-expr {expr}		Evaluate {expr} in server and print the result
+				on stdout.
+
+Examples ~
+
+Edit "file.txt" in an already running GVIM server: >
+    gvim --remote file.txt
+
+Edit "file.txt" in an already running server called FOOBAR: >
+    gvim --servername FOOBAR --remote file.txt
+
+Edit "file.txt" in server "FILES" if it exists, become server "FILES"
+otherwise: >
+    gvim --servername FILES --remote-silent file.txt
+
+This doesn't work, all arguments after --remote will be used as file names: >
+    gvim --remote --servername FOOBAR file.txt
+
+Edit file "+foo" in a remote server (note the use of "./" to avoid the special
+meaning of the leading plus): >
+    vim --remote ./+foo
+
+Tell the remote server "BLA" to write all files and exit: >
+    vim --servername BLA --remote-send '<C-\><C-N>:wqa<CR>'
+
+
+SERVER NAME						*client-server-name*
+
+By default Vim will try to register the name under which it was invoked (gvim,
+egvim ...).  This can be overridden with the --servername argument.  If the
+specified name is not available, a postfix is applied until a free name is
+encountered, i.e. "gvim1" for the second invocation of gvim on a particular
+X-server.  The resulting name is available in the servername builtin variable
+|v:servername|.  The case of the server name is ignored, thus "gvim" and
+"GVIM" are considered equal.
+
+When Vim is invoked with --remote, --remote-wait or --remote-send it will try
+to locate the server name determined by the invocation name and --servername
+argument as described above.  If an exact match is not available, the first
+server with the number postfix will be used.  If a name with the number
+postfix is specified with the --servername argument, it must match exactly.
+
+If no server can be located and --remote or --remote-wait was used, Vim will
+start up according to the rest of the command line and do the editing by
+itself.  This way it is not necessary to know whether gvim is already started
+when sending command to it.
+
+The --serverlist argument will cause Vim to print a list of registered command
+servers on the standard output (stdout) and exit.
+
+Win32 Note: Making the Vim server go to the foreground doesn't always work,
+because MS-Windows doesn't allow it.  The client will move the server to the
+foreground when using the --remote or --remote-wait argument and the server
+name starts with "g".
+
+
+REMOTE EDITING
+
+The --remote argument will cause a |:drop| command to be constructed from the
+rest of the command line and sent as described above.
+The --remote-wait argument does the same thing and additionally sets up to
+wait for each of the files to have been edited.  This uses the BufUnload
+event, thus as soon as a file has been unloaded, Vim assumes you are done
+editing it.
+Note that the --remote and --remote-wait arguments will consume the rest of
+the command line.  I.e. all remaining arguments will be regarded as filenames.
+You can not put options there!
+
+
+FUNCTIONS
+								*E240* *E573*
+There are a number of Vim functions for scripting the command server.  See
+the description in |eval.txt| or use CTRL-] on the function name to jump to
+the full explanation.
+
+    synopsis				     explanation ~
+    remote_startserver( name)		     run a server
+    remote_expr( server, string, idvar)      send expression
+    remote_send( server, string, idvar)      send key sequence
+    serverlist()			     get a list of available servers
+    remote_peek( serverid, retvar)	     check for reply string
+    remote_read( serverid)		     read reply string
+    server2client( serverid, string)	     send reply string
+    remote_foreground( server)		     bring server to the front
+
+See also the explanation of |CTRL-\_CTRL-N|.  Very useful as a leading key
+sequence.
+The {serverid} for server2client() can be obtained with expand("<client>")
+
+==============================================================================
+2. X11 specific items					*x11-clientserver*
+				    *E247* *E248* *E251* *E258* *E277*
+
+The communication between client and server goes through the X server.  The
+display of the Vim server must be specified.  The usual protection of the X
+server is used, you must be able to open a window on the X server for the
+communication to work.  It is possible to communicate between different
+systems.
+
+By default, a GUI Vim will register a name on the X-server by which it can be
+addressed for subsequent execution of injected strings.  Vim can also act as
+a client and send strings to other instances of Vim on the same X11 display.
+
+When an X11 GUI Vim (gvim) is started, it will try to register a send-server
+name on the 'VimRegistry' property on the root window.
+
+An empty --servername argument will cause the command server to be disabled.
+
+To send commands to a Vim server from another application, read the source
+file src/if_xcmdsrv.c, it contains some hints about the protocol used.
+
+==============================================================================
+3. Win32 specific items					*w32-clientserver*
+
+Every Win32 Vim can work as a server, also in the console.  You do not need a
+version compiled with OLE.  Windows messages are used, this works on any
+version of MS-Windows.  But only communication within one system is possible.
+
+Since MS-Windows messages are used, any other application should be able to
+communicate with a Vim server.
+
+When using gvim, the --remote-wait only works properly this way: >
+
+	start /w gvim --remote-wait file.txt
+<
+ vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -83,7 +83,7 @@ You can not put options there!
 
 
 ==============================================================================
-2. Missing functionality				*clientserver-missing*
+2. Missing functionality			*E5600* *clientserver-missing*
 
 Vim supports additional functionality in clientserver that's not yet
 implemented in Nvim. In particular, none of the 'wait' variants are supported

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -11,9 +11,10 @@ Vim client-server communication				*client-server*
 ==============================================================================
 1. Common functionality					*clientserver*
 
-When compiled with the |+clientserver| option, Vim can act as a command
-server.  It accepts messages from a client and executes them.  At the same
-time, Vim can function as a client and send commands to a Vim server.
+Nvim's |RPC| functionality allows clients to programmatically control Nvim. Nvim
+itself takes command-line arguments that cause it to become a client to another
+Nvim running as a server. These arguments match those provided by Vim's
+clientserver option.
 
 The following command line arguments are available:
 
@@ -22,39 +23,27 @@ The following command line arguments are available:
    --remote [+{cmd}] {file} ...					*--remote*
 				Open the file list in a remote Vim.  When
 				there is no Vim server, execute locally.
-				There is one optional init command: +{cmd}.
+				Vim allows one init command: +{cmd}.
 				This must be an Ex command that can be
-				followed by "|".
+				followed by "|". It's not yet supported by
+				Nvim.
 				The rest of the command line is taken as the
 				file list.  Thus any non-file arguments must
 				come before this.
 				You cannot edit stdin this way |--|.
 				The remote Vim is raised.  If you don't want
 				this use >
-				 vim --remote-send "<C-\><C-N>:n filename<CR>"
+				 nvim --remote-send "<C-\><C-N>:n filename<CR>"
 <
    --remote-silent [+{cmd}] {file} ...			*--remote-silent*
 				As above, but don't complain if there is no
 				server and the file is edited locally.
-   --remote-wait [+{cmd}] {file} ...				*--remote-wait*
-				As --remote, but wait for files to complete
-				(unload) in remote Vim.
-   --remote-wait-silent [+{cmd}] {file} ...		*--remote-wait-silent*
-				As --remote-wait, but don't complain if there
-				is no server.
 							*--remote-tab*
    --remote-tab			Like --remote but open each file in a new
 				tabpage.
 							*--remote-tab-silent*
    --remote-tab-silent		Like --remote-silent but open each file in a
 				new tabpage.
-							*--remote-tab-wait*
-   --remote-tab-wait		Like --remote-wait but open each file in a new
-				tabpage.
-
-						*--remote-tab-wait-silent*
-   --remote-tab-wait-silent	Like --remote-wait-silent but open each file
-				in a new tabpage.
 								*--remote-send*
    --remote-send {keys}		Send {keys} to server and exit.  The {keys}
    				are not mapped.  Special key names are
@@ -63,127 +52,80 @@ The following command line arguments are available:
 								*--remote-expr*
    --remote-expr {expr}		Evaluate {expr} in server and print the result
 				on stdout.
+								*--server*
+   --server {addr}		Connect to the named pipe or socket at the
+				given address for executing remote commands.
+				See |--listen| for specifying an address when
+				starting a server.
 
 Examples ~
 
-Edit "file.txt" in an already running GVIM server: >
-    gvim --remote file.txt
+Start an Nvim server listening on a named pipe at '~/.cache/nvim/server.pipe': >
+    nvim --listen ~/.cache/nvim/server.pipe
 
-Edit "file.txt" in an already running server called FOOBAR: >
-    gvim --servername FOOBAR --remote file.txt
-
-Edit "file.txt" in server "FILES" if it exists, become server "FILES"
-otherwise: >
-    gvim --servername FILES --remote-silent file.txt
+Edit "file.txt" in an Nvim server listening at '~/.cache/nvim/server.pipe': >
+    nvim --server ~/.cache/nvim/server.pipe --remote file.txt
 
 This doesn't work, all arguments after --remote will be used as file names: >
-    gvim --remote --servername FOOBAR file.txt
+    nvim --remote --server ~/.cache/nvim/server.pipe file.txt
 
-Edit file "+foo" in a remote server (note the use of "./" to avoid the special
-meaning of the leading plus): >
-    vim --remote ./+foo
-
-Tell the remote server "BLA" to write all files and exit: >
-    vim --servername BLA --remote-send '<C-\><C-N>:wqa<CR>'
-
-
-SERVER NAME						*client-server-name*
-
-By default Vim will try to register the name under which it was invoked (gvim,
-egvim ...).  This can be overridden with the --servername argument.  If the
-specified name is not available, a postfix is applied until a free name is
-encountered, i.e. "gvim1" for the second invocation of gvim on a particular
-X-server.  The resulting name is available in the servername builtin variable
-|v:servername|.  The case of the server name is ignored, thus "gvim" and
-"GVIM" are considered equal.
-
-When Vim is invoked with --remote, --remote-wait or --remote-send it will try
-to locate the server name determined by the invocation name and --servername
-argument as described above.  If an exact match is not available, the first
-server with the number postfix will be used.  If a name with the number
-postfix is specified with the --servername argument, it must match exactly.
-
-If no server can be located and --remote or --remote-wait was used, Vim will
-start up according to the rest of the command line and do the editing by
-itself.  This way it is not necessary to know whether gvim is already started
-when sending command to it.
-
-The --serverlist argument will cause Vim to print a list of registered command
-servers on the standard output (stdout) and exit.
-
-Win32 Note: Making the Vim server go to the foreground doesn't always work,
-because MS-Windows doesn't allow it.  The client will move the server to the
-foreground when using the --remote or --remote-wait argument and the server
-name starts with "g".
+Tell the remote server to write all files and exit: >
+    nvim --server ~/.cache/nvim/server.pipe --remote-send '<C-\><C-N>:wqa<CR>'
 
 
 REMOTE EDITING
 
 The --remote argument will cause a |:drop| command to be constructed from the
 rest of the command line and sent as described above.
-The --remote-wait argument does the same thing and additionally sets up to
-wait for each of the files to have been edited.  This uses the BufUnload
-event, thus as soon as a file has been unloaded, Vim assumes you are done
-editing it.
 Note that the --remote and --remote-wait arguments will consume the rest of
 the command line.  I.e. all remaining arguments will be regarded as filenames.
 You can not put options there!
 
 
-FUNCTIONS
-								*E240* *E573*
-There are a number of Vim functions for scripting the command server.  See
-the description in |eval.txt| or use CTRL-] on the function name to jump to
-the full explanation.
-
-    synopsis				     explanation ~
-    remote_startserver( name)		     run a server
-    remote_expr( server, string, idvar)      send expression
-    remote_send( server, string, idvar)      send key sequence
-    serverlist()			     get a list of available servers
-    remote_peek( serverid, retvar)	     check for reply string
-    remote_read( serverid)		     read reply string
-    server2client( serverid, string)	     send reply string
-    remote_foreground( server)		     bring server to the front
-
-See also the explanation of |CTRL-\_CTRL-N|.  Very useful as a leading key
-sequence.
-The {serverid} for server2client() can be obtained with expand("<client>")
-
 ==============================================================================
-2. X11 specific items					*x11-clientserver*
-				    *E247* *E248* *E251* *E258* *E277*
+2. Missing functionality				*clientserver-missing*
 
-The communication between client and server goes through the X server.  The
-display of the Vim server must be specified.  The usual protection of the X
-server is used, you must be able to open a window on the X server for the
-communication to work.  It is possible to communicate between different
-systems.
+Vim supports additional functionality in clientserver that's not yet
+implemented in Nvim. In particular, none of the 'wait' variants are supported
+yet. The following command line arguments are not yet available:
 
-By default, a GUI Vim will register a name on the X-server by which it can be
-addressed for subsequent execution of injected strings.  Vim can also act as
-a client and send strings to other instances of Vim on the same X11 display.
+    argument			meaning	~
 
-When an X11 GUI Vim (gvim) is started, it will try to register a send-server
-name on the 'VimRegistry' property on the root window.
+   --remote-wait [+{cmd}] {file} ...				*--remote-wait*
+				Not yet supported by Nvim.
+				As --remote, but wait for files to complete
+				(unload) in remote Vim.
+   --remote-wait-silent [+{cmd}] {file} ...		*--remote-wait-silent*
+				Not yet supported by Nvim.
+				As --remote-wait, but don't complain if there
+				is no server.
+							*--remote-tab-wait*
+   --remote-tab-wait		Not yet supported by Nvim.
+				Like --remote-wait but open each file in a new
+				tabpage.
+						*--remote-tab-wait-silent*
+   --remote-tab-wait-silent	Not yet supported by Nvim.
+				Like --remote-wait-silent but open each file
+				in a new tabpage.
+							    *--servername*
+   --servername {name}          Not yet supported by Nvim.
+				Become the server {name}.  When used together
+                                with one of the --remote commands: connect to
+                                server {name} instead of the default (see
+                                below).  The name used will be uppercase.
 
-An empty --servername argument will cause the command server to be disabled.
+								*--serverlist*
+   --serverlist			Not yet supported by Nvim.
+				Output a list of server names.
 
-To send commands to a Vim server from another application, read the source
-file src/if_xcmdsrv.c, it contains some hints about the protocol used.
 
-==============================================================================
-3. Win32 specific items					*w32-clientserver*
 
-Every Win32 Vim can work as a server, also in the console.  You do not need a
-version compiled with OLE.  Windows messages are used, this works on any
-version of MS-Windows.  But only communication within one system is possible.
 
-Since MS-Windows messages are used, any other application should be able to
-communicate with a Vim server.
+SERVER NAME						*client-server-name*
 
-When using gvim, the --remote-wait only works properly this way: >
+By default Vim will try to register the name under which it was invoked (gvim,
+egvim ...).  This can be overridden with the --servername argument.  Nvim
+either listens on a named pipe or a socket and does not yet support this
+--servername functionality.
 
-	start /w gvim --remote-wait file.txt
-<
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -636,6 +636,78 @@ function vim.pretty_print(...)
   return ...
 end
 
+local function __rpcrequest(...)
+  return vim.api.nvim_call_function("rpcrequest", {...})
+end
+
+function vim._cs_remote(rcid, args)
+
+  local f_silent = false
+  local f_wait = false
+  local f_tab = false
+  local should_exit = true
+  local command = 'edit '
+
+  local subcmd = string.sub(args[1],10)
+
+  if subcmd == '' then
+    -- no flags to set
+  elseif subcmd == 'tab' then
+    f_tab = true
+  elseif subcmd == 'silent' then
+    f_silent = true
+  elseif subcmd == 'wait' then
+    f_wait = true
+  elseif subcmd == 'wait-silent' then
+    f_wait = true
+    f_silent = true
+  elseif subcmd == 'tab-wait' then
+    f_tab = true
+    f_wait = true
+  elseif subcmd == 'tab-silent' then
+    f_tab = true
+    f_silent = true
+  elseif subcmd == 'tab-wait-silent' then
+    f_tab = true
+    f_wait = true
+    f_silent = true
+  elseif subcmd == 'send' then
+    __rpcrequest(rcid, 'nvim_input', args[2])
+    return { should_exit = should_exit, tabbed = f_tab, files = 0 }
+    -- should we show warning if --server doesn't exist in --send and --expr?
+  elseif subcmd == 'expr' then
+    local res = __rpcrequest(rcid, 'vim_eval', args[2])
+    print(res)
+    return { should_exit = should_exit, tabbed = f_tab, files = 0 }
+  else
+    print('--remote subcommand not found')
+  end
+
+  table.remove(args,1)
+
+  if not f_silent and rcid == 0 then
+    print('Remote server does not exist.')
+  end
+
+  if f_silent and rcid == 0 then
+    print('Remote server does not exist. starting new server')
+    should_exit = false
+  end
+
+  if f_tab then command = 'tabedit ' end
+
+  if rcid ~= 0 then
+    for _, key in ipairs(args) do
+      __rpcrequest(rcid, 'nvim_command', command .. key)
+    end
+  end
+
+  return {
+    should_exit = should_exit,
+    tabbed = f_tab,
+    files = table.getn(args)
+  }
+end
 
 require('vim._meta')
 

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -638,56 +638,39 @@ end
 
 function vim._cs_remote(rcid, args)
   local f_silent = false
-  local f_wait = false
   local f_tab = false
 
   local subcmd = string.sub(args[1],10)
 
-  if subcmd == '' then
-    -- no flags to set
-  elseif subcmd == 'tab' then
+  if subcmd == 'tab' then
     f_tab = true
   elseif subcmd == 'silent' then
     f_silent = true
-  elseif subcmd == 'wait' then
-    f_wait = true
-  elseif subcmd == 'wait-silent' then
-    f_wait = true
-    f_silent = true
-  elseif subcmd == 'tab-wait' then
-    f_tab = true
-    f_wait = true
+  elseif subcmd == 'wait' or subcmd == 'wait-silent' or subcmd == 'tab-wait' or subcmd == 'tab-wait-silent' then
+    return { errmsg = 'E5600: Wait commands not yet implemented in nvim' }
   elseif subcmd == 'tab-silent' then
     f_tab = true
     f_silent = true
-  elseif subcmd == 'tab-wait-silent' then
-    f_tab = true
-    f_wait = true
-    f_silent = true
   elseif subcmd == 'send' then
     if rcid == 0 then
-      vim.cmd('echoerr "E247: Remote server does not exist. Send failed."')
-      return
+      return { errmsg = 'E247: Remote server does not exist. Send failed.' }
     end
     vim.fn.rpcrequest(rcid, 'nvim_input', args[2])
     return { should_exit = true, tabbed = false }
   elseif subcmd == 'expr' then
     if rcid == 0 then
-      vim.cmd('echoerr "E247: Remote server does not exist. Send expression failed."')
-      return
+      return { errmsg = 'E247: Remote server does not exist. Send expression failed.' }
     end
-    vim.fn.rpcrequest(rcid, 'nvim_eval', args[2])
+    print(vim.fn.rpcrequest(rcid, 'nvim_eval', args[2]))
     return { should_exit = true, tabbed = false }
-  else
-    vim.cmd('echoerr "Unknown option argument: ' .. args[1] .. '"')
-    return
+  elseif subcmd ~= '' then
+    return { errmsg='Unknown option argument: ' .. args[1] }
   end
 
   if rcid == 0 then
     if not f_silent then
       vim.cmd('echohl WarningMsg | echomsg "E247: Remote server does not exist. Editing locally" | echohl None')
     end
-    should_exit = false
   else
     local command = {}
     if f_tab then table.insert(command, 'tab') end

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1997,7 +1997,7 @@ Array nvim_get_proc_children(Integer pid, Error *err)
     DLOG("fallback to vim._os_proc_children()");
     Array a = ARRAY_DICT_INIT;
     ADD(a, INTEGER_OBJ(pid));
-    String s = cstr_to_string("return vim._os_proc_children(select(...))");
+    String s = cstr_to_string("return vim._os_proc_children(...)");
     Object o = nlua_exec(s, a, err);
     api_free_string(s);
     api_free_array(a);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1997,7 +1997,7 @@ Array nvim_get_proc_children(Integer pid, Error *err)
     DLOG("fallback to vim._os_proc_children()");
     Array a = ARRAY_DICT_INIT;
     ADD(a, INTEGER_OBJ(pid));
-    String s = cstr_to_string("return vim._os_proc_children(select(1, ...))");
+    String s = cstr_to_string("return vim._os_proc_children(select(...))");
     Object o = nlua_exec(s, a, err);
     api_free_string(s);
     api_free_array(a);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -835,9 +835,8 @@ static void handle_remote_client(mparm_T *params, int remote_args,
     ADD(a, CSTR_TO_OBJ(server_addr));
     ADD(a, CSTR_TO_OBJ(connect_error));
     ADD(a, ARRAY_OBJ(args));
-    String s = cstr_to_string("return vim._cs_remote(...)");
+    String s = STATIC_CSTR_AS_STRING("return vim._cs_remote(...)");
     Object o = nlua_exec(s, a, &err);
-    api_free_string(s);
     api_free_array(a);
     if (ERROR_SET(&err)) {
       mch_errmsg(err.msg);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -815,17 +815,10 @@ static void handle_remote_client(mparm_T *params, int remote_args,
     rvobj.data.dictionary = (Dictionary)ARRAY_DICT_INIT;
     rvobj.type = kObjectTypeDictionary;
     CallbackReader on_data = CALLBACK_READER_INIT;
-    const char *error = NULL;
+    const char *connect_error = NULL;
     uint64_t rc_id = 0;
     if (server_addr != NULL) {
-      rc_id = channel_connect(false, server_addr, true, on_data, 50, &error);
-    }
-    if (error) {
-      mch_msg("Failed to connect to server ");
-      mch_msg(server_addr);
-      mch_msg("\nReason: ");
-      mch_msg(error);
-      mch_msg("Continuing with remote command in case we can execute locally\n");
+      rc_id = channel_connect(false, server_addr, true, on_data, 50, &connect_error);
     }
 
     int t_argc = remote_args;
@@ -839,6 +832,8 @@ static void handle_remote_client(mparm_T *params, int remote_args,
     Error err = ERROR_INIT;
     Array a = ARRAY_DICT_INIT;
     ADD(a, INTEGER_OBJ((int)rc_id));
+    ADD(a, CSTR_TO_OBJ(server_addr));
+    ADD(a, CSTR_TO_OBJ(connect_error));
     ADD(a, ARRAY_OBJ(args));
     String s = cstr_to_string("return vim._cs_remote(...)");
     Object o = nlua_exec(s, a, &err);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -836,7 +836,7 @@ static void handle_remote_client(mparm_T *params, int remote_args,
     ADD(a, INTEGER_OBJ((int)rc_id));
     ADD(a, ARRAY_OBJ(args));
     String s = cstr_to_string("return vim._cs_remote(...)");
-    Object o = executor_exec_lua_api(s, a, &err);
+    Object o = nlua_exec(s, a, &err);
     api_free_string(s);
     api_free_array(a);
 
@@ -859,7 +859,7 @@ static void handle_remote_client(mparm_T *params, int remote_args,
     }
 
     if (should_exit) {
-      mch_exit(0);
+      os_exit(0);
     } else {
       if (tabbed) {
         params->window_count = files;

--- a/src/nvim/main.h
+++ b/src/nvim/main.h
@@ -39,6 +39,8 @@ typedef struct {
   int diff_mode;                        // start with 'diff' set
 
   char *listen_addr;                    // --listen {address}
+  int remote;                           // --remote-[subcmd] {file1} {file2}
+  char *server_addr;                    // --server {address}
 } mparm_T;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -9,7 +9,6 @@ local insert = helpers.insert
 local meths = helpers.meths
 local new_argv = helpers.new_argv
 local neq = helpers.neq
-local run = helpers.run
 local set_session = helpers.set_session
 local spawn = helpers.spawn
 local tmpname = helpers.tmpname
@@ -38,7 +37,7 @@ describe('Remote', function()
       server:close()
     end)
 
-    function run_remote(...)
+    local function run_remote(...)
       set_session(server)
       local addr = funcs.serverlist()[1]
       local client_argv = new_argv({args={'--server', addr, ...}})
@@ -121,7 +120,7 @@ describe('Remote', function()
       -- to wait for the remote instance to exit and calling jobwait blocks
       -- the event loop. If the server event loop is blocked, it can't process
       -- our incoming --remote calls.
-      local client_starter = clear()
+      clear()
       local bogus_job_id = funcs.jobstart(bogus_argv)
       eq({2}, funcs.jobwait({bogus_job_id}))
     end
@@ -135,6 +134,9 @@ describe('Remote', function()
 
     it('expr without server', function()
       run_and_check_exit_code('--remote-expr', 'setline(1, "Yo")')
+    end)
+    it('wait subcommand', function()
+      run_and_check_exit_code('--remote-wait', fname)
     end)
   end)
 end)

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -1,0 +1,140 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local expect = helpers.expect
+local funcs = helpers.funcs
+local insert = helpers.insert
+local meths = helpers.meths
+local new_argv = helpers.new_argv
+local neq = helpers.neq
+local run = helpers.run
+local set_session = helpers.set_session
+local spawn = helpers.spawn
+local tmpname = helpers.tmpname
+local write_file = helpers.write_file
+
+describe('Remote', function()
+  local fname, other_fname
+  local contents = 'The call is coming from outside the process'
+  local other_contents = "A second file's contents"
+
+  before_each(function()
+    fname = tmpname() .. ' with spaces in the filename'
+    other_fname = tmpname()
+    write_file(fname, contents)
+    write_file(other_fname, other_contents)
+  end)
+
+  describe('connect to server and', function()
+    local server
+    before_each(function()
+      server = spawn(new_argv(), true)
+      set_session(server)
+    end)
+
+    after_each(function()
+      server:close()
+    end)
+
+    function run_remote(...)
+      set_session(server)
+      local addr = funcs.serverlist()[1]
+      local client_argv = new_argv({args={'--server', addr, ...}})
+
+      -- Create an nvim instance just to run the remote-invoking nvim. We want
+      -- to wait for the remote instance to exit and calling jobwait blocks
+      -- the event loop. If the server event loop is blocked, it can't process
+      -- our incoming --remote calls.
+      local client_starter = spawn(new_argv(), false, nil, true)
+      set_session(client_starter)
+      local client_job_id = funcs.jobstart(client_argv)
+      eq({ 0 }, funcs.jobwait({client_job_id}))
+      client_starter:close()
+      set_session(server)
+    end
+
+    it('edit a single file', function()
+      run_remote('--remote', fname)
+      expect(contents)
+      eq(2, #funcs.getbufinfo())
+    end)
+
+    it('tab edit a single file with a non-changed buffer', function()
+      run_remote('--remote-tab', fname)
+      expect(contents)
+      eq(1, #funcs.gettabinfo())
+    end)
+
+    it('tab edit a single file with a changed buffer', function()
+      insert('hello')
+      run_remote('--remote-tab', fname)
+      expect(contents)
+      eq(2, #funcs.gettabinfo())
+    end)
+
+    it('edit multiple files', function()
+      run_remote('--remote', fname, other_fname)
+      expect(contents)
+      command('next')
+      expect(other_contents)
+      eq(3, #funcs.getbufinfo())
+    end)
+
+    it('send keys', function()
+      run_remote('--remote-send', ':edit '..fname..'<CR><C-W>v')
+      expect(contents)
+      eq(2, #funcs.getwininfo())
+      -- Only a single buffer as we're using edit and not drop like --remote does
+      eq(1, #funcs.getbufinfo())
+    end)
+
+    it('evaluate expressions', function()
+      run_remote('--remote-expr', 'setline(1, "Yo")')
+      expect('Yo')
+    end)
+  end)
+
+  it('creates server if not found', function()
+    clear('--remote', fname)
+    expect(contents)
+    eq(1, #funcs.getbufinfo())
+    -- Since we didn't pass silent, we should get a complaint
+    neq(nil, string.find(meths.exec('messages', true), 'E247'))
+  end)
+
+  it('creates server if not found with tabs', function()
+    clear('--remote-tab-silent', fname, other_fname)
+    expect(contents)
+    eq(2, #funcs.gettabinfo())
+    eq(2, #funcs.getbufinfo())
+    -- We passed silent, so no message should be issued about the server not being found
+    eq(nil, string.find(meths.exec('messages', true), 'E247'))
+  end)
+
+  describe('exits with error on', function()
+    local function run_and_check_exit_code(...)
+      local bogus_argv = new_argv(...)
+
+      -- Create an nvim instance just to run the remote-invoking nvim. We want
+      -- to wait for the remote instance to exit and calling jobwait blocks
+      -- the event loop. If the server event loop is blocked, it can't process
+      -- our incoming --remote calls.
+      local client_starter = clear()
+      local bogus_job_id = funcs.jobstart(bogus_argv)
+      eq({2}, funcs.jobwait({bogus_job_id}))
+    end
+    it('bogus subcommand', function()
+      run_and_check_exit_code('--remote-bogus')
+    end)
+
+    it('send without server', function()
+      run_and_check_exit_code('--remote-send', 'i')
+    end)
+
+    it('expr without server', function()
+      run_and_check_exit_code('--remote-expr', 'setline(1, "Yo")')
+    end)
+  end)
+end)


### PR DESCRIPTION
This starts from @geekodour's work on https://github.com/neovim/neovim/pull/8326 to resolve https://github.com/neovim/neovim/issues/1750. It adds tests, docs, and fixes a bunch of minor things found in testing.

As with the initial PR, I've left out the `-wait` variants, `--servername`, and `+cmd` support. I believe this is useful as it stands and I can add each of those in followup PRs. I tried to make it clear what isn't supported yet in the docs and error handling.

I took the liberty of adding a "remote" scope to the commit messages as I'm guessing I'll have a fair number of followup commits to get the rest of the features. Happy to drop that or change it to a better existing scope.