### PR TITLE
fix(api): allow empty list for cterm in nvim_set_hl

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -876,6 +876,10 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     CHECK_FLAG(cterm, cterm_mask, strikethrough, , HL_STRIKETHROUGH);
     CHECK_FLAG(cterm, cterm_mask, nocombine, , HL_NOCOMBINE);
 
+  } else if (dict->cterm.type == kObjectTypeArray && dict->cterm.data.array.size == 0) {
+    // empty list from Lua API should clear all cterm attributes
+    // TODO(clason): handle via gen_api_dispatch
+    cterm_mask_provided = true;
   } else if (HAS_KEY(dict->cterm)) {
     api_set_error(err, kErrorTypeValidation, "'cterm' must be a Dictionary.");
   }

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -242,6 +242,12 @@ describe("API: set highlight", function()
     eq(highlight2_result, meths.get_hl_by_name('Test_hl', false))
   end)
 
+  it ("can set emtpy cterm attr", function()
+    local ns = get_ns()
+    meths.set_hl(ns, 'Test_hl', { cterm = {} })
+    eq({}, meths.get_hl_by_name('Test_hl', false))
+  end)
+
   it ("cterm attr defaults to gui attr", function()
     local ns = get_ns()
     meths.set_hl(ns, 'Test_hl', highlight1)


### PR DESCRIPTION
Problem: when accessing `nvim_set_hl` from Lua, empty tables are converted
to empty lists, not dictionaries, resulting in an error for

    :lua vim.api.nvim_set_hl(0, "Comment", { cterm = {} })

Workaround: add an empty array as a special case when checking
`dict->cterm.type` and do nothing.

(Proper solution would be to handle this in `gen_api_dispatch.lua`.)

Resolves #17437 

@bfredl