### PR TITLE
ci: download reviews.js through checkout instead of wget

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -38,10 +38,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - run: wget https://raw.githubusercontent.com/neovim/neovim/master/.github/scripts/reviews.js
+      - uses: actions/checkout@v2
       - name: 'Request reviewers'
         uses: actions/github-script@v6
         with:
           script: |
-            const script = require('./reviews.js')
+            const script = require('./.github/scripts/reviews.js')
             await script({github, context})

--- a/.github/workflows/reviews.yml
+++ b/.github/workflows/reviews.yml
@@ -9,10 +9,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - run: wget https://raw.githubusercontent.com/neovim/neovim/master/.github/scripts/reviews.js
+      - uses: actions/checkout@v2
       - name: 'Request reviewers'
         uses: actions/github-script@v6
         with:
           script: |
-            const script = require('./reviews.js')
+            const script = require('./.github/scripts/reviews.js')
             await script({github, context})


### PR DESCRIPTION
This makes testing the workflows much smoother.
