### PR TITLE
feat(folds): add 'foldoptions' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2671,6 +2671,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	To close folds you can re-apply 'foldlevel' with the |zx| command or
 	set the 'foldclose' option to "all".
 
+    						      *'foldoptions'* *'fop'*
+'foldoptions' 'fop'	string (default "")
+			local to window
+	List of words that change the behavor of the |foldcolumn|.
+          nodigits      Disable digits shown to indicate the nesting level.
+
 						*'foldtext'* *'fdt'*
 'foldtext' 'fdt'	string (default: "foldtext()")
 			local to window

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -261,6 +261,7 @@ Options:
   'fillchars'   flags: "msgsep" (see 'display'), "horiz", "horizup",
                 "horizdown", "vertleft", "vertright", "verthoriz"
   'foldcolumn'  supports up to 9 dynamic/fixed columns
+  'foldoptions' fold column customization options
   'inccommand'  shows interactive results for |:substitute|-like commands
                 and |:command-preview| commands
   'laststatus'  global statusline support

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -183,6 +183,8 @@ typedef struct {
 #define w_p_fdt w_onebuf_opt.wo_fdt   // 'foldtext'
   char *wo_fmr;
 #define w_p_fmr w_onebuf_opt.wo_fmr    // 'foldmarker'
+  char *wo_fop;
+#define w_p_fop w_onebuf_opt.wo_fop    // 'foldoptions'
   int wo_lbr;
 #define w_p_lbr w_onebuf_opt.wo_lbr    // 'linebreak'
   int wo_list;
@@ -1327,6 +1329,7 @@ struct window_S {
   uint32_t w_p_wbr_flags;           // flags for 'winbar'
   uint32_t w_p_fde_flags;           // flags for 'foldexpr'
   uint32_t w_p_fdt_flags;           // flags for 'foldtext'
+  uint32_t w_p_fop_flags;           // flags for 'foldoptions'
   int *w_p_cc_cols;                 // array of columns to highlight or NULL
   uint8_t w_p_culopt_flags;         // flags for cursorline highlighting
   long w_p_siso;                    // 'sidescrolloff' local value

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3534,6 +3534,8 @@ int makefoldset(FILE *fd)
       || put_setnum(fd, "setlocal", "fdl", &curwin->w_p_fdl) == FAIL
       || put_setnum(fd, "setlocal", "fml", &curwin->w_p_fml) == FAIL
       || put_setnum(fd, "setlocal", "fdn", &curwin->w_p_fdn) == FAIL
+      || put_setstring(fd, "setlocal", "fop", &curwin->w_p_fop, 0)
+      == FAIL
       || put_setbool(fd, "setlocal", "fen", curwin->w_p_fen) == FAIL) {
     return FAIL;
   }
@@ -3962,6 +3964,8 @@ static char_u *get_varp(vimoption_T *p)
     return (char_u *)&(curwin->w_p_fml);
   case PV_FDN:
     return (char_u *)&(curwin->w_p_fdn);
+  case PV_FOP:
+    return (char_u *)&(curwin->w_p_fop);
   case PV_FDE:
     return (char_u *)&(curwin->w_p_fde);
   case PV_FDT:
@@ -4235,6 +4239,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fdn = from->wo_fdn;
   to->wo_fde = copy_option_val(from->wo_fde);
   to->wo_fdt = copy_option_val(from->wo_fdt);
+  to->wo_fop = copy_option_val(from->wo_fop);
   to->wo_fmr = copy_option_val(from->wo_fmr);
   to->wo_scl = copy_option_val(from->wo_scl);
   to->wo_winhl = copy_option_val(from->wo_winhl);
@@ -4263,6 +4268,7 @@ static void check_winopt(winopt_T *wop)
   check_string_option(&wop->wo_fde);
   check_string_option(&wop->wo_fdt);
   check_string_option(&wop->wo_fmr);
+  check_string_option(&wop->wo_fop);
   check_string_option(&wop->wo_scl);
   check_string_option(&wop->wo_rlc);
   check_string_option(&wop->wo_sbr);
@@ -4289,6 +4295,7 @@ void clear_winopt(winopt_T *wop)
   clear_string_option(&wop->wo_fde);
   clear_string_option(&wop->wo_fdt);
   clear_string_option(&wop->wo_fmr);
+  clear_string_option(&wop->wo_fop);
   clear_string_option(&wop->wo_scl);
   clear_string_option(&wop->wo_rlc);
   clear_string_option(&wop->wo_sbr);

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -534,6 +534,7 @@ EXTERN unsigned fdo_flags;
 EXTERN char *p_fex;             ///< 'formatexpr'
 EXTERN char *p_flp;             ///< 'formatlistpat'
 EXTERN char *p_fo;              ///< 'formatoptions'
+#define FOP_NODIGITS           0x01
 EXTERN char_u *p_fp;            // 'formatprg'
 EXTERN int p_fs;                // 'fsync'
 EXTERN int p_gd;                // 'gdefault'
@@ -943,6 +944,7 @@ enum {
   WV_FDM,
   WV_FML,
   WV_FDN,
+  WV_FOP,
   WV_FDE,
   WV_FDT,
   WV_FMR,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -862,6 +862,14 @@ return {
       defaults={if_true="0"}
     },
     {
+      full_name='foldoptions', abbreviation='fop',
+      short_desc=N_("fold column options"),
+      type='string', list='onecomma', scope={'window'},
+      deny_duplicates=true,
+      redraw={'current_window'},
+      defaults={if_true=''}
+    },
+    {
       full_name='foldenable', abbreviation='fen',
       short_desc=N_("set to display all folds open"),
       type='bool', scope={'window'},

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -112,6 +112,7 @@ static char *(p_icm_values[]) = { "nosplit", "split", NULL };
 static char *(p_jop_values[]) = { "stack", "view", NULL };
 static char *(p_tpf_values[]) = { "BS", "HT", "FF", "ESC", "DEL", "C0", "C1", NULL };
 static char *(p_rdb_values[]) = { "compositor", "nothrottle", "invalid", "nodelta", NULL };
+static char *(p_fop_values[]) = { "nodigits", NULL };
 
 /// All possible flags for 'shm'.
 static char SHM_ALL[] = { SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW,
@@ -740,6 +741,10 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     }
   } else if (gvarp == &p_nf) {  // 'nrformats'
     if (check_opt_strings(*varp, p_nf_values, true) != OK) {
+      errmsg = e_invarg;
+    }
+  } else if (varp == &curwin->w_p_fop) {  // 'foldoptions'
+    if (opt_strings_flags(curwin->w_p_fop, p_fop_values, &curwin->w_p_fop_flags, true) != OK) {
       errmsg = e_invarg;
     }
   } else if (varp == &p_ssop) {  // 'sessionoptions'

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -192,6 +192,7 @@ size_t fill_foldcolumn(char_u *p, win_T *wp, foldinfo_T foldinfo, linenr_T lnum)
   int symbol = 0;
   int len = 0;
   bool closed = foldinfo.fi_lines > 0;
+  bool no_digits = wp->w_p_fop_flags & FOP_NODIGITS;
   // Init to all spaces.
   memset(p, ' ', MAX_MCO * (size_t)fdc + 1);
 
@@ -208,7 +209,7 @@ size_t fill_foldcolumn(char_u *p, win_T *wp, foldinfo_T foldinfo, linenr_T lnum)
     if (foldinfo.fi_lnum == lnum
         && first_level + i >= foldinfo.fi_low_level) {
       symbol = wp->w_p_fcs_chars.foldopen;
-    } else if (first_level == 1) {
+    } else if (first_level == 1 || (first_level >= 1 && no_digits)) {
       symbol = wp->w_p_fcs_chars.foldsep;
     } else if (first_level + i <= 9) {
       symbol = '0' + first_level + i;

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -1895,6 +1895,93 @@ describe("folded lines", function()
         ]])
       end
     end)
+
+    it('disables fold level digits #17446', function()
+      funcs.setline(1, 'function a() {')
+      funcs.setline(2, '	function b() {')
+      funcs.setline(3, '		function c() {')
+      funcs.setline(4, '			function d() {')
+      funcs.setline(5, '			}')
+      funcs.setline(6, '		}')
+      funcs.setline(7, '	}')
+      funcs.setline(8, '}')
+
+      command('set foldcolumn=auto foldlevel=999 foldmethod=indent')
+      if multigrid then
+        screen:expect([[
+          ## grid 1
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [3:---------------------------------------------]|
+          ## grid 2
+            {7: }^function a() {                              |
+            {7:-}        function b() {                      |
+            {7:-}                function c() {              |
+            {7:-}                        function d() {      |
+            {7:3}                        }                   |
+            {7:2}                }                           |
+            {7:│}        }                                   |
+
+          ## grid 3
+                                                         |
+        ]])
+      else
+        screen:expect([[
+          {7: }^function a() {                              |
+          {7:-}        function b() {                      |
+          {7:-}                function c() {              |
+          {7:-}                        function d() {      |
+          {7:3}                        }                   |
+          {7:2}                }                           |
+          {7:│}        }                                   |
+                                                       |
+        ]])
+      end
+
+      command('set foldoptions=nodigits')
+      if multigrid then
+        screen:expect([[
+          ## grid 1
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [2:---------------------------------------------]|
+            [3:---------------------------------------------]|
+          ## grid 2
+            {7: }^function a() {                              |
+            {7:-}        function b() {                      |
+            {7:-}                function c() {              |
+            {7:-}                        function d() {      |
+            {7:│}                        }                   |
+            {7:│}                }                           |
+            {7:│}        }                                   |
+
+          ## grid 3
+                                                         |
+        ]])
+      else
+        screen:expect([[
+          {7: }^function a() {                              |
+          {7:-}        function b() {                      |
+          {7:-}                function c() {              |
+          {7:-}                        function d() {      |
+          {7:│}                        }                   |
+          {7:│}                }                           |
+          {7:│}        }                                   |
+                                                       |
+        ]])
+      end
+
+      assert_alive()
+    end)
   end
 
   describe("with ext_multigrid", function()


### PR DESCRIPTION
Introduces a new option named 'foldoptions' for customizing the
fold column.

Comes with the word 'nodigits' that disables the digits shown to
indicate the nesting level. Instead 'foldsep' from 'fillchars' is
used.

---

I'm new to neovim hacking and very novice at C, so this is probably just one big mess... but I thought I would try to take a stab at implementing this option as I find the rendering of the nesting level as numbers quite disturbing over just showing the regular separator.

closes #14751