### PR TITLE
ci(lint): simplify cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             ${{ env.CACHE_NVIM_DEPS_DIR }}
             ~/.ccache
-          key: ${{ matrix.runner }}-lint-${{ matrix.cc }}-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
+          key: lint-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
 
       - name: Build third-party
         run: ./ci/before_script.sh


### PR DESCRIPTION
I know the key works as is, it just bothers me that the matrix variables aren't used.