### PR TITLE
vim-patch:8.2.4414: solidity files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1791,6 +1791,9 @@ au BufNewFile,BufRead *.mib,*.my		setf mib
 au BufNewFile,BufRead *.hog,snort.conf,vision.conf	setf hog
 au BufNewFile,BufRead *.rules			call dist#ft#FTRules()
 
+" Solidity
+au BufRead,BufNewFile *.sol			setf solidity
+
 " SPARQL queries
 au BufNewFile,BufRead *.rq,*.sparql		setf sparql
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -598,6 +598,7 @@ local extension = {
   sl = "slang",
   ice = "slice",
   score = "slrnsc",
+  sol = "solidity",
   tpl = "smarty",
   ihlp = "smcl",
   smcl = "smcl",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -478,6 +478,7 @@ let s:filename_checks = {
     \ 'skill': ['file.il', 'file.ils', 'file.cdf'],
     \ 'slang': ['file.sl'],
     \ 'slice': ['file.ice'],
+    \ 'solidity': ['file.sol'],
     \ 'solution': ['file.sln'],
     \ 'slpconf': ['/etc/slp.conf', 'any/etc/slp.conf'],
     \ 'slpreg': ['/etc/slp.reg', 'any/etc/slp.reg'],


### PR DESCRIPTION
Problem:    Solidity files are not recognized.
Solution:   Add the *.sol pattern. (Dundar Goc, closes vim/vim#9792)
https://github.com/vim/vim/commit/97b231541d4e82fbc85e51121448d95bd43c50ad