### PR TITLE
chore: add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,134 @@
+Abdelhakeem <abdelhakeem.osama@hotmail.com> Abdelhakeem Osama
+Alvaro Muñoz <alvaro@pwntester.com> Alvaro Muñoz
+Andreas Johansson <andreas@ndrs.xyz> <ndreas@users.noreply.github.com>
+Andrew Pyatkov <mrbiggfoot@gmail.com> <mrbiggfoot@users.noreply.github.com>
+Anmol Sethi <hi@nhooyr.io> <anmol@aubble.com>
+Anmol Sethi <hi@nhooyr.io> <me@anmol.io>
+Anmol Sethi <hi@nhooyr.io> <nhooyr@users.noreply.github.com>
+BK1603 <chouhan.shreyansh2702@gmail.com> Shreyansh Chouhan
+Billy Su <g4691821@gmail.com> Billy SU
+Billy Vong <billyvg@gmail.com> <billyvg@users.noreply.github.com>
+Björn Linse <bjorn.linse@gmail.com> bfredl
+Carlos Hernandez <carlos@techbyte.ca> <hurricanehrndz@users.noreply.github.com>
+Chris Kipp <ckipp@pm.me> ckipp01
+Christian Clason <c.clason@uni-graz.at> <christian.clason@uni-due.de>
+Cédric Barreteau <> <cbarrete@users.noreply.github.com>
+Dan Aloni <alonid@gmail.com> <dan@kernelim.com>
+Daniel Hahler <git@thequod.de> <github@thequod.de>
+Eisuke Kawashima <e-kwsm@users.noreply.github.com> E Kawashima
+ElPiloto <luis.r.piloto@gmail.com> Luis Piloto
+Eliseo Martínez <eliseomarmol@gmail.com> Eliseo Martínez
+Fabian Viöl <f.vioel@googlemail.com> Fabian
+Florian Walch <florian@fwalch.com> <fwalch@users.noreply.github.com>
+Gabriel Cruz <gabs.oficial98@gmail.com> <LTKills@users.noreply.github.com>
+Gaelan Steele <gbs@canishe.com> Gaelan
+Gavin D. Howard <gavin@schedmd.com> <yzena.tech@gmail.com>
+George Zhao <zhaozg@gmail.com> <zhaozg@aliyun.com>
+George Zhao <zhaozg@gmail.com> George  Zhao
+Gregory Anders <greg@gpanders.com> <8965202+gpanders@users.noreply.github.com>
+Gregory Anders <greg@gpanders.com> Greg Anders
+Grzegorz Milka <grzegorzmilka@gmail.com> Grzegorz
+Harm te Hennepe <dhtehennepe@gmail.com> <d.h.tehennepe@student.utwente.nl>
+Harm te Hennepe <dhtehennepe@gmail.com> <harm@tehennepe.org>
+Hirokazu Hata <h.hata.ai.t@gmail.com> <h-michael@users.noreply.github.com>
+Ihor Antonov <ngortheone@gmail.com> <ngortheone@users.noreply.github.com>
+J Phani Mahesh <phanimahesh@gmail.com> <github@phanimahesh.me>
+Jack Bracewell <FriedSock@users.noreply.github.com> <jack.bracewell@unboxedconsulting.com>
+Jack Bracewell <FriedSock@users.noreply.github.com> <jbtwentythree@gmail.com>
+Jacques Germishuys <jacquesg@striata.com> <jacquesg@users.noreply.github.com>
+Jakub Łuczyński <doubleloop@o2.pl> <doubleloop@users.noreply.github.com>
+James McCoy <jamessan@jamessan.com> <vega.james@gmail.com>
+Jan Edmund Lazo <jan.lazo@mail.utoronto.ca> <janedmundlazo@hotmail.com>
+Jan Viljanen <jan.a.viljanen@gmail.com> <jan.viljanen@greenpeace.org>
+Javier Lopez <graulopezjavier@gmail.com> Javier López
+Jit Yao Yap <jityao@gmail.com> <jityao+github@gmail.com>
+Jit Yao Yap <jityao@gmail.com> Jit
+John Gehrig <jdg.gehrig@gmail.com> <jgehrig@users.noreply.github.com>
+John Schmidt <john.schmidt.h@gmail.com> John
+John Szakmeister <john@szakmeister.net> <jszakmeister@users.noreply.github.com>
+Jonathan de Boyne Pollard <J.deBoynePollard-newsgroups@NTLWorld.com> <jdebp@users.noreply.github.com>
+Jonathan de Boyne Pollard <J.deBoynePollard-newsgroups@NTLWorld.com> <postmaster@localhost>
+Jurica Bradaric <jbradaric@gmail.com> <jbradaric@users.noreply.github.com>
+Jurica Bradaric <jbradaric@gmail.com> <jurica.bradaric@avl.com>
+KillTheMule <KillTheMule@users.noreply.github.com> <github@pipsfrank.de>
+Kwon-Young Choi <kwon-young.choi@hotmail.fr> Kwon-Young
+Lucas Hoffmann <l-m-h@web.de> <lucc@posteo.de>
+Lucas Hoffmann <l-m-h@web.de> <lucc@users.noreply.github.com>
+Marco Hinz <mh.codebro@gmail.com> <mh.codebro+github@gmail.com>
+Marvim the Paranoid Android <marvim@users.noreply.github.com> marvim
+Mateusz Czapliński <czapkofan@gmail.com> Mateusz Czaplinski
+Mathias Fussenegger <f.mathias@zignar.net> <mfussenegger@users.noreply.github.com>
+Mathias Fussenegger <f.mathias@zignar.net> Mathias Fußenegger
+Matt Wozniski <godlygeek@gmail.com> <godlygeek+git@gmail.com>
+Matthieu Coudron <mattator@gmail.com> <coudron@iij.ad.jp>
+Matthieu Coudron <mattator@gmail.com> <matthieu.coudron@upmc.fr>
+Matthieu Coudron <mattator@gmail.com> <mcoudron@hotmail.com>
+Matthieu Coudron <mattator@gmail.com> <teto@users.noreply.github.com>
+MichaHoffmann <michoffmann.potsdam@gmail.com> Michael Hoffmann
+MichaHoffmann <michoffmann.potsdam@gmail.com> micha
+Michael Ennen <mike.ennen@gmail.com> <brcolow@users.noreply.github.com>
+Michael Ennen <mike.ennen@gmail.com> brcolow
+Michael Reed <m.reed@mykolab.com> <Pyrohh@users.noreply.github.com>
+Michael Schupikov <michael@schupikov.de> <DarkDeepBlue@users.noreply.github.com>
+Nicolas Hillegeer <nicolas@hillegeer.com> <nicolashillegeer@gmail.com>
+Panashe M. Fundira <fundirap@gmail.com> Panashe Fundira
+Patrice Peterson <patrice.peterson@mailbox.org> runiq
+Pavel Platto <hinidu@gmail.com> Hinidu
+Petter Wahlman <petter@wahlman.no> <pwahlman@cisco.com>
+Poh Zi How <poh.zihow@gmail.com> pohzipohzi
+Rich Wareham <rjw57@cam.ac.uk> <rjw57@cantab.net>
+Rui Abreu Ferreira <equalsraf@users.noreply.github.com> @equalsraf
+Rui Abreu Ferreira <raf-ep@gmx.com> <equalsraf@users.noreply.github.com>
+Rui Abreu Ferreira <raf-ep@gmx.com> <rap-ep@gmx.com>
+Sam Wilson <tecywiz121@hotmail.com> <sawilson@akamai.com>
+Sander Bosma <sanderbosma@gmail.com> sander2
+Santos Gallegos <stsewd@protonmail.com> <santos_g@outlook.com>
+Sebastian Parborg <darkdefende@gmail.com> DarkDefender
+Shirasaka <tk.shirasaka@gmail.com> tk-shirasaka
+Shota <shotat@users.noreply.github.com> shotat
+Shougo Matsushita <Shougo.Matsu@gmail.com> Shougo
+Stephan Seitz <stephan.seitz@fau.de> <stephan.lauf@yahoo.de>
+Steven Sojka <Steven.Sojka@tdameritrade.com> <steelsojka@gmail.com>
+Steven Sojka <steelsojka@gmail.com> <steelsojka@users.noreply.github.com>
+TJ DeVries <devries.timothyj@gmail.com> <timothydvrs1234@gmail.com>
+Thomas Fehér <thomas.feher@yahoo.de> <thomasfeher@web.de>
+Thomas Vigouroux <tomvig38@gmail.com> <39092278+vigoux@users.noreply.github.com>
+Utkarsh Maheshwari <UtkarshME96@gmail.com> UTkarsh Maheshwari
+Utkarsh Maheshwari <utkarshme96@gmail.com> <UtkarshME96@gmail.com>
+VVKot <volodymyr.kot.ua@gmail.com> Volodymyr Kot
+Victor Adam <victor.adam@cofelyineo-gdfsuez.com> <Victor.Adam@derpymail.org>
+Wang Shidong <wsdjeg@outlook.com> <wsdjeg@users.noreply.github.com>
+Wei Huang <daviseago@gmail.com> davix
+Xu Cheng <xucheng@me.com> <xu-cheng@users.noreply.github.com>
+Yamakaky <yamakaky@gmail.com> <yamakaky@yamaworld.fr>
+Yegappan Lakshmanan <yegappan@yahoo.com> <4298407+yegappan@users.noreply.github.com>
+Yichao Zhou <broken.zhoug@gmail.com> Yichao Zhou <broken.zhou@gmail.com>
+Yichao Zhou <broken.zhoug@gmail.com> zhou13 <broken.zhou@gmail.com>
+Yorick Peterse <git@yorickpeterse.com> <yorick@yorickpeterse.com>
+ZyX <kp-pav@yandex.ru> <kp-pav@ya.ru>
+ZyX <kp-pav@yandex.ru> Nikolai Aleksandrovich Pavlov
+aph <a.hewson@gmail.com> Ashley Hewson
+butwerenotthereyet <58348703+butwerenotthereyet@users.noreply.github.com> We're Yet
+chemzqm <chemzqm@gmail.com> Qiming zhao
+chentau <tchen1998@gmail.com> Tony Chen
+dedmass <carlo.abelli@gmail.com> Carlo Abelli
+equal-l2 <eng.equall2@gmail.com> <equal-l2@users.noreply.github.com>
+francisco souza <fsouza@users.noreply.github.com> <108725+fsouza@users.noreply.github.com>
+glacambre <code@lacamb.re> <me@r4>
+glacambre <code@lacamb.re> Ghjuvan Lacambre
+ii14 <ii14@users.noreply.github.com> <59243201+ii14@users.noreply.github.com>
+jdrouhard <john@jmdtech.org> <github@jmdtech.org>
+kuuote <znmxodq1@gmail.com> <36663503+kuuote@users.noreply.github.com>
+matveyt <matthewtarasov@gmail.com> <35012635+matveyt@users.noreply.github.com>
+nate <nateozemon@gmail.com> nateozem
+ray-x <rayx.cn@gmail.com> rayx
+relnod <mail@paul-schiffers.de> <relnod@users.noreply.github.com>
+rockerBOO <rockerboo@gmail.com> Dave Lage
+rpigott <rpigott@berkeley.edu> Ronan Pigott
+sach1t <sach0010t@gmail.com> <sach1t@users.noreply.github.com>
+shade-of-noon <73705427+shade-of-noon@users.noreply.github.com> Edwin Pujols
+shadmansaleh <shadmansaleh3@gmail.com> <13149513+shadmansaleh@users.noreply.github.com>
+shadmansaleh <shadmansaleh3@gmail.com> Shadman
+sohnryang <loop.infinitely@gmail.com> 손량
+timeyyy <timeyyy_da_man@hotmail.com> Timothy C Eichler
+timeyyy <timeyyy_da_man@hotmail.com> timothy eichler


### PR DESCRIPTION
Consolidate commit author details

- Prefer user/email with either most commits or most recent commit
- Generally less preference for @users.noreply.github.com emails
- Avoided consolidating common names in case of conflict, e.g. John Doe
- Don't differentiate between handles and real names.
