### PR TITLE
feat: __tostring lua errors if possible before showing in messages

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -78,7 +78,22 @@ static void nlua_error(lua_State *const lstate, const char *const msg)
   FUNC_ATTR_NONNULL_ALL
 {
   size_t len;
-  const char *const str = lua_tolstring(lstate, -1, &len);
+  const char *str = NULL;
+
+  if (luaL_getmetafield(lstate, -1, "__tostring")) {
+    if (lua_isfunction(lstate, -1) && luaL_callmeta(lstate, -2, "__tostring")) {
+      // call __tostring, convert the result and pop result.
+      str = lua_tolstring(lstate, -1, &len);
+      lua_pop(lstate, 1);
+    }
+    // pop __tostring.
+    lua_pop(lstate, 1);
+  }
+
+  if (!str) {
+    // defer to lua default conversion, this will render tables as [NULL].
+    str = lua_tolstring(lstate, -1, &len);
+  }
 
   msg_ext_set_kind("lua_error");
   semsg_multiline(msg, (int)len, str);


### PR DESCRIPTION
Lua errors can be anything, not just strings. (Most?) Lua interpreters will convert these to strings if they have a `__tostring` metatable function.

This PR checks for a `__tostring` meta method on any error caught and runs it if possible, before we send the error upto the user.

I couldn't see where to put a test for this, but if someone can point me to a file/directory I can add one.

You can test in-nvim by running

```lua
 -- test.lua
local my_error = {message = "This is a custom error!", code = 100}
setmetatable(my_error, {
  __tostring = function(t)
    return "Custom Error with Code [" .. t.code .. "]: " .. t.message
  end
})
error(my_error)
```

`VIM_RUNTIME=runtime build/bin/nvim -u NONE -c 'luafile %' test.lua`

```
Error detected while processing command line:
E5113: Error while calling lua chunk: Custom Error with Code [100]: This
 is a custom error!
Press ENTER or type command to continue
```