### PR TITLE
fix: lsp and diagnostic highlight priority

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -920,7 +920,10 @@ M.handlers.underline = {
         underline_ns,
         higroup,
         { diagnostic.lnum, diagnostic.col },
-        { diagnostic.end_lnum, diagnostic.end_col }
+        { diagnostic.end_lnum, diagnostic.end_col },
+        'v',
+        false,
+        150
       )
     end
     save_extmarks(underline_ns, bufnr)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1551,9 +1551,9 @@ do --[[ References ]]
                       document_highlight_kind[kind],
                       { start_line, start_idx },
                       { end_line, end_idx },
-                      nil,
+                      'v',
                       false,
-                      40)
+                      200)
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/17456

* treesitter uses the default highlight priority of 50
* diagnostic highlights have a priority of 150
* highlight references have a priority of 200

This ensures proper ordering.