### PR TITLE
refactor(highlight)!: optional arguments for vim.highlight as table

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -595,13 +595,33 @@ vim.highlight.on_yank({opts})                         *vim.highlight.on_yank()*
           - {on_visual} highlight when yanking visual selection (default `true`)
           - {event} event structure (default |v:event|)
 
-vim.highlight.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {rtype}, {inclusive})
+vim.highlight.range({bufnr}, {ns}, {hlgroup}, {start}, {finish}, {opts})
                                                        *vim.highlight.range()*
-        Highlights the range between {start} and {finish} (tuples of {line,col})
-        in buffer {bufnr} with the highlight group {higroup} using the namespace
-        {ns}. Optional arguments are the type of range (characterwise, linewise,
-        or blockwise, see |setreg|; default to characterwise) and whether the
-        range is inclusive (default false).
+
+        Apply highlight group to range of text.
+
+                Parameters: ~
+                    {bufnr}   buffer number
+                    {ns}      namespace for highlights
+                    {hlgroup} highlight group name
+                    {start}   starting position (tuple {line,col})
+                    {finish}  finish position (tuple {line,col})
+                    {opts}    optional parameters:
+                              • `regtype`: type of range (characterwise, linewise,
+                                or blockwise, see |setreg|), default `'v'`
+                              • `inclusive`: range includes end position, default
+                                `false`
+                              • `priority`: priority of highlight, default
+                                `vim.highlight.user` (see below)
+
+vim.highlight.priorities                           *vim.highlight.priorities*
+
+        Table with default priorities used for highlighting:
+            • `syntax`: `50`, used for standard syntax highlighting
+            • `treesitter`: `100`, used for tree-sitter-based highlighting
+            • `diagnostics`: `150`, used for code analysis such as diagnostics
+            • `user`: `200`, used for user-triggered highlights such as LSP
+              document symbols or `on_yank` autocommands
 
 ------------------------------------------------------------------------------
 VIM.REGEX                                                       *lua-regex*

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -921,9 +921,7 @@ M.handlers.underline = {
         higroup,
         { diagnostic.lnum, diagnostic.col },
         { diagnostic.end_lnum, diagnostic.end_col },
-        'v',
-        false,
-        150
+        { priority = vim.highlight.priorities.diagnostics }
       )
     end
     save_extmarks(underline_ns, bufnr)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1551,9 +1551,7 @@ do --[[ References ]]
                       document_highlight_kind[kind],
                       { start_line, start_idx },
                       { end_line, end_idx },
-                      'v',
-                      false,
-                      200)
+                      { priority = vim.highlight.priorities.user })
     end
   end
 end


### PR DESCRIPTION
* Refactor `vim.highlight.range` to make optional arguments a table. This may be a breaking change if non-default arguments for these are used in the wild, but should enable future non-breaking additions. New signature is
```lua
vim.highlight.range(bufnr, ns, hlgroup, start, finish, { regtype = regtype, inclusive = inclusive, priority = priority })
```

* Add `vim.highlight.priorities` global table for default priority levels:
  - `syntax`: `50`, used for standard syntax highlighting
  - `treesitter`: `100`, used for tree-sitter-based highlighting
  - `diagnostics`: `150`, used for code analysis such as diagnostics
  - `user`: `200`, used for user-triggered highlights such as LSP  document symbols or `on_yank`  autocommands

* While I was at it, I also updated the documentation which wasn't auto-generated.