### PR TITLE
Use system dependencies for lint CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
             ~/.ccache
           key: lint-${{ hashFiles('cmake/*', '**/CMakeLists.txt', '!third-party/**CMakeLists.txt') }}-${{ github.base_ref }}
 
+      - name: Build nvim
+        run: ./ci/run_tests.sh build
+
       - if: "!cancelled()"
         name: clint
         run: ./ci/run_lint.sh clint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,43 @@ jobs:
 
       - name: Install apt packages
         run: |
+          sudo add-apt-repository ppa:neovim-ppa/stable
           sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential ccache cmake gettext gperf libtool-bin locales ninja-build pkg-config flake8
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            build-essential \
+            ccache \
+            cmake \
+            flake8 \
+            gettext \
+            gperf \
+            libluajit-5.1-dev \
+            libmsgpack-dev \
+            libtermkey-dev \
+            libtool-bin \
+            libtree-sitter-dev \
+            libunibilium-dev \
+            libuv1-dev \
+            libvterm-dev \
+            locales \
+            lua-busted \
+            lua-check \
+            lua-filesystem \
+            lua-inspect \
+            lua-lpeg \
+            lua-luv-dev \
+            lua-nvim \
+            luajit \
+            ninja-build \
+            pkg-config
 
-      - name: Cache dependencies
+      - name: Cache artifacts
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.CACHE_NVIM_DEPS_DIR }}
             ~/.ccache
-          key: lint-${{ hashFiles('cmake/*', 'third-party/**', '**/CMakeLists.txt') }}-${{ github.base_ref }}
-
-      - name: Build third-party
-        run: ./ci/before_script.sh
+          key: lint-${{ hashFiles('cmake/*', '**/CMakeLists.txt', '!third-party/**CMakeLists.txt') }}-${{ github.base_ref }}
 
       - if: "!cancelled()"
         name: clint

--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -46,7 +46,9 @@ CLANG_SANITIZER=TSAN
 EOF
     ;;
   lint)
+    BUILD_FLAGS="$BUILD_FLAGS -DLIBLUV_LIBRARY:FILEPATH=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/lua/5.1/luv.so -DLIBLUV_INCLUDE_DIR:PATH=/usr/include/lua5.1"
     cat <<EOF >> "$GITHUB_ENV"
+USE_BUNDLED=OFF
 CI_TARGET=lint
 EOF
     ;;

--- a/ci/before_cache.sh
+++ b/ci/before_cache.sh
@@ -18,7 +18,7 @@ ccache -s 2>/dev/null || true
 find "${HOME}/.ccache" -name stats -delete
 
 # Update the third-party dependency cache only if the build was successful.
-if ended_successfully; then
+if ended_successfully && [ -d "${DEPS_BUILD_DIR}" ]; then
   # Do not cache downloads.  They should not be needed with up-to-date deps.
   rm -rf "${DEPS_BUILD_DIR}/build/downloads"
   rm -rf "${CACHE_NVIM_DEPS_DIR}"

--- a/ci/before_cache.sh
+++ b/ci/before_cache.sh
@@ -7,6 +7,8 @@ CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common/build.sh"
 source "${CI_DIR}/common/suite.sh"
 
+mkdir -p "${HOME}/.cache"
+
 echo "before_cache.sh: cache size"
 du -chd 1 "${HOME}/.cache" | sort -rh | head -20
 


### PR DESCRIPTION
This gives us some warm and fuzzies that we aren't pigeon holing ourselves into specifics of the bundled dependencies.

It relies on the stable PPA to pull in newer versions of packaged dependencies, if needed (currently only for tree-sitter).

Replaces #9326