### PR TITLE
fix(diagnostic): use botright copen for qflist

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -447,7 +447,7 @@ local function set_list(loclist, opts)
     vim.fn.setqflist({}, ' ', { title = title, items = items })
   end
   if open then
-    vim.api.nvim_command(loclist and "lopen" or "copen")
+    vim.api.nvim_command(loclist and "lopen" or "botright copen")
   end
 end
 


### PR DESCRIPTION
This matches the LSP handlers, and forces the qflist for diagnostics to
span across the horizontal space, below all open windows.