### PR TITLE
vim-patch:8.2.4427: getchar() may return modifiers if no character is available

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3225,7 +3225,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv)
   set_vim_var_nr(VV_MOUSE_COL, 0);
 
   rettv->vval.v_number = n;
-  if (IS_SPECIAL(n) || mod_mask != 0) {
+  if (n != 0 && (IS_SPECIAL(n) || mod_mask != 0)) {
     char_u temp[10];                // modifier: 3, mbyte-char: 6, NUL: 1
     int i = 0;
 

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1451,6 +1451,10 @@ func Test_getchar()
   call assert_equal('', getcharstr(0))
   call assert_equal('', getcharstr(1))
 
+  call feedkeys("\<M-F2>", '')
+  call assert_equal("\<M-F2>", getchar(0))
+  call assert_equal(0, getchar(0))
+
   call setline(1, 'xxxx')
   " call test_setmouse(1, 3)
   " let v:mouse_win = 9


### PR DESCRIPTION
#### vim-patch:8.2.4427: getchar() may return modifiers if no character is available

Problem:    getchar() may return modifiers if no character is available.
Solution:   Do not process modifiers when there is no character. (closes vim/vim#9806)
https://github.com/vim/vim/commit/ad6c45f62558e03d3e3a927b3fe4dbaf30a36bef