### PR TITLE
docs(api): fix nvim_buf_attach on_reload event name

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -133,7 +133,7 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
 ///               - buffer handle
 ///             - on_reload: Lua callback invoked on reload. The entire buffer
 ///                          content should be considered changed. Args:
-///               - the string "detach"
+///               - the string "reload"
 ///               - buffer handle
 ///             - utf_sizes: include UTF-32 and UTF-16 size of the replaced
 ///               region, as args to `on_lines`.


### PR DESCRIPTION
This corrects nvim_buf_attach's opts.on_reload callback argument on document.

```lua
local bufnr = 0
vim.api.nvim_buf_attach(bufnr, false, {
  on_reload = function(e)
    print(e) -- reload
  end,
})
```

