### PR TITLE
vim-patch:partial 944697ae196

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1807,6 +1807,7 @@ exists({expr})	The result is a Number, which is |TRUE| if {expr} is
 			exists("$HOSTNAME")
 			exists("*strftime")
 			exists("*s:MyFunc")
+			exists("*MyFunc")
 			exists("bufcount")
 			exists(":Make")
 			exists("#CursorHold")
@@ -5863,16 +5864,22 @@ reltimestr({time})				*reltimestr()*
 <
 							*remote_expr()* *E449*
 remote_expr({server}, {string} [, {idvar} [, {timeout}]])
-		Send the {string} to {server}.  The string is sent as an
-		expression and the result is returned after evaluation.
-		The result must be a String or a |List|.  A |List| is turned
-		into a String by joining the items with a line break in
-		between (not at the end), like with join(expr, "\n").
+		Send the {string} to {server}.  The {server} argument is a
+		string, also see |{server}|.
+
+		The string is sent as an expression and the result is returned
+		after evaluation.  The result must be a String or a |List|.  A
+		|List| is turned into a String by joining the items with a
+		line break in between (not at the end), like with join(expr,
+		"\n").
+
 		If {idvar} is present and not empty, it is taken as the name
 		of a variable and a {serverid} for later use with
 		|remote_read()| is stored there.
+
 		If {timeout} is given the read times out after this many
 		seconds.  Otherwise a timeout of 600 seconds is used.
+
 		See also |clientserver| |RemoteReply|.
 		This function is not available in the |sandbox|.
 		Note: Any errors will cause a local error message to be issued
@@ -5890,7 +5897,7 @@ remote_expr({server}, {string} [, {idvar} [, {timeout}]])
 
 remote_foreground({server})				*remote_foreground()*
 		Move the Vim server with the name {server} to the foreground.
-		The {server} argument is a string.
+		The {server} argument is a string, also see |{server}|.
 		This works like: >
 			remote_expr({server}, "foreground()")
 <		Except that on Win32 systems the client does the work, to work
@@ -5926,12 +5933,17 @@ remote_read({serverid}, [{timeout}])			*remote_read()*
 <
 							*remote_send()* *E241*
 remote_send({server}, {string} [, {idvar}])
-		Send the {string} to {server}.  The string is sent as input
-		keys and the function returns immediately.  At the Vim server
-		the keys are not mapped |:map|.
+		Send the {string} to {server}.  The {server} argument is a
+		string, also see |{server}|.
+
+		The string is sent as input keys and the function returns
+		immediately.  At the Vim server the keys are not mapped
+		|:map|.
+
 		If {idvar} is present, it is taken as the name of a variable
 		and a {serverid} for later use with remote_read() is stored
 		there.
+
 		See also |clientserver| |RemoteReply|.
 		This function is not available in the |sandbox|.
 

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -196,7 +196,7 @@ If you want to keep the changed buffer without saving it, switch on the
 			Edit {file} always.  Discard any changes to the
 			current buffer.
 			Also see |++opt| and |+cmd|.
-
+							*:edit_#* *:e#*
 :e[dit] [++opt] [+cmd] #[count]
 			Edit the [count]th buffer (as shown by |:files|).
 			This command does the same as [count] CTRL-^.  But ":e
@@ -356,7 +356,7 @@ as a wildcard when "[" is in the 'isfname' option.  A simple way to avoid this
 is to use "path\[[]abc]", this matches the file "path\[abc]".
 
 					*starstar-wildcard*
-Expanding "**" is possible on Unix, Win32, Mac OS/X and a few other systems.
+Expanding "**" is possible on Unix, Win32, macOS and a few other systems.
 This allows searching a directory tree.  This goes up to 100 directories deep.
 Note there are some commands where this works slightly differently, see
 |file-searching|.
@@ -1495,7 +1495,7 @@ which version of the file you want to keep.
 
 The accuracy of the time check depends on the filesystem.  On Unix it is
 usually sub-second.  With old file sytems and on MS-Windows it is normally one
-second.  Use has('nanotime') check if sub-second time stamp checks are
+second.  Use `has('nanotime')` to check if sub-second time stamp checks are
 available.
 
 There is one situation where you get the message while there is nothing wrong:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3040,7 +3040,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'guitablabel'* *'gtl'*
 'guitablabel' 'gtl'	string	(default empty)
 			global
-	When nonempty describes the text to use in a label of the GUI tab
+	When non-empty describes the text to use in a label of the GUI tab
 	pages line.  When empty and when the result is empty Vim will use a
 	default label.  See |setting-guitablabel| for more info.
 
@@ -3057,7 +3057,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'guitabtooltip'* *'gtt'*
 'guitabtooltip' 'gtt'	string	(default empty)
 			global
-	When nonempty describes the text to use in a tooltip for the GUI tab
+	When non-empty describes the text to use in a tooltip for the GUI tab
 	pages line.  When empty Vim will use a default tooltip.
 	This option is otherwise just like 'guitablabel' above.
 	You can include a line break.  Simplest method is to use |:let|: >
@@ -5906,7 +5906,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			   *'statusline'* *'stl'* *E540* *E542*
 'statusline' 'stl'	string	(default empty)
 			global or local to window |global-local|
-	When nonempty, this option determines the content of the status line.
+	When non-empty, this option determines the content of the status line.
 	Also see |status-line|.
 
 	The option consists of printf style '%' items interspersed with
@@ -6222,7 +6222,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'tabline'* *'tal'*
 'tabline' 'tal'		string	(default empty)
 			global
-	When nonempty, this option determines the content of the tab pages
+	When non-empty, this option determines the content of the tab pages
 	line at the top of the Vim window.  When empty Vim will use a default
 	tab pages line.  See |setting-tabline| for more info.
 


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/944697ae19683441981539cd4d2469df89d6ec82

Doc changes:

Include remote_*() (even though +clientserver and remote.txt isn't ported yet)
Omit screenpos() (need v8.2.4389)
Other changes are N/A or cannot be directly applied

(At some point I may go back and port a few of the doc changes from previous RTs that weren't ported due to the whole vim9script avalanche)