### PR TITLE
vim-patch:8.2.0997: cannot execute a register containing line continuation

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -161,6 +161,11 @@ Q			Repeat the last recorded register [count] times.
 			result of evaluating the expression is executed as an
 			Ex command.
 			Mappings are not recognized in these commands.
+			When the |line-continuation| character (\) is present
+			at the beginning of a line in a linewise register,
+			then it is combined with the previous line. This is
+			useful for yanking and executing parts of a Vim
+			script.
 
 							*:@:*
 :[addr]@:		Repeat last command-line.  First set cursor at line


### PR DESCRIPTION
#### vim-patch:8.2.0997: cannot execute a register containing line continuation

Problem:    Cannot execute a register containing line continuation.
Solution:   Concatenate lines where needed. (Yegappan Lakshmanan,
            closes vim/vim#6272)
https://github.com/vim/vim/commit/856c1110c1cf0d6e44e387b70732ca4b4c8ef0f2

According to #2542 the "Future:" part was removed intentionally.
Use `size_t` in more places to reduce type casts.