### PR TITLE
feat(filetype): support scripts.vim with filetype.lua

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -7,6 +7,7 @@ if vim.g.do_filetype_lua ~= 1 then
   return
 end
 
+-- TODO: Remove vim.cmd once Lua autocommands land
 vim.cmd [[
 augroup filetypedetect
 au BufRead,BufNewFile * call v:lua.vim.filetype.match(expand('<afile>'))
@@ -17,6 +18,12 @@ runtime! ftdetect/*.lua
 
 " Set a marker so that the ftdetect scripts are not sourced a second time by filetype.vim
 let g:did_load_ftdetect = 1
+
+" If filetype.vim is disabled, set up the autocmd to use scripts.vim
+if exists('did_load_filetypes')
+  au BufRead,BufNewFile * if !did_filetype() && expand('<amatch>') !~ g:ft_ignore_pat | runtime! scripts.vim | endif
+  au StdinReadPost * if !did_filetype() | runtime! scripts.vim | endif
+endif
 
 augroup END
 ]]


### PR DESCRIPTION
When filetype.vim is disabled, create the autocommand that runs scripts.vim in filetype.lua.

Closes #16940.

The filetype detection flow now works like this:

1. `filetype.lua` is not enabled (default): filetype.vim -> scripts.vim
2. `filetype.lua` is enabled, `filetype.vim` is enabled: filetype.lua -> filetype.vim -> scripts.vim
3. `filetype.lua` is enabled, `filetype.vim` is disabled: filetype.lua -> scripts.vim