### PR TITLE
vim-patch:8.2.4464: Dtrace files are recognized as filetype D

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -211,6 +211,10 @@ func dist#ft#EuphoriaCheck()
 endfunc
 
 func dist#ft#DtraceCheck()
+  if did_filetype()
+    " Filetype was already detected
+    return
+  endif
   let lines = getline(1, min([line("$"), 100]))
   if match(lines, '^module\>\|^import\>') > -1
     " D files often start with a module and/or import statement.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -480,6 +480,7 @@ au BufNewFile,BufRead */etc/dnsmasq.conf	setf dnsmasq
 au BufNewFile,BufRead *.desc			setf desc
 
 " the D language or dtrace
+au BufNewFile,BufRead */dtrace/*.d		setf dtrace
 au BufNewFile,BufRead *.d			call dist#ft#DtraceCheck()
 
 " Desktop files

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1178,6 +1178,7 @@ local pattern = {
   [".*/etc/yum%.conf"] = "dosini",
   [".*lvs"] = "dracula",
   [".*lpe"] = "dracula",
+  [".*/dtrace/.*%.d"] = "dtrace",
   [".*esmtprc"] = "esmtprc",
   [".*Eterm/.*%.cfg"] = "eterm",
   [".*%.git/modules/.*/config"] = "gitconfig",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -132,6 +132,7 @@ let s:filename_checks = {
     \ 'cvs': ['cvs123'],
     \ 'cvsrc': ['.cvsrc'],
     \ 'cynpp': ['file.cyn'],
+    \ 'd': ['file.d'],
     \ 'dart': ['file.dart', 'file.drt'],
     \ 'datascript': ['file.ds'],
     \ 'dcd': ['file.dcd'],
@@ -154,6 +155,7 @@ let s:filename_checks = {
     \ 'dot': ['file.dot', 'file.gv'],
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
     \ 'dtd': ['file.dtd'],
+    \ 'dtrace': ['/usr/lib/dtrace/io.d'],
     \ 'dts': ['file.dts', 'file.dtsi'],
     \ 'dune': ['jbuild', 'dune', 'dune-project', 'dune-workspace'],
     \ 'dylan': ['file.dylan'],
@@ -799,6 +801,42 @@ func Test_bas_file()
   bwipe!
 
   call delete('Xfile.bas')
+  filetype off
+endfunc
+
+func Test_d_file()
+  filetype on
+
+  call writefile(['looks like D'], 'Xfile.d')
+  split Xfile.d
+  call assert_equal('d', &filetype)
+  bwipe!
+
+  call writefile(['#!/some/bin/dtrace'], 'Xfile.d')
+  split Xfile.d
+  call assert_equal('dtrace', &filetype)
+  bwipe!
+
+  call writefile(['#pragma  D  option'], 'Xfile.d')
+  split Xfile.d
+  call assert_equal('dtrace', &filetype)
+  bwipe!
+
+  call writefile([':some:thing:'], 'Xfile.d')
+  split Xfile.d
+  call assert_equal('dtrace', &filetype)
+  bwipe!
+
+  call writefile(['module this', '#pragma  D  option'], 'Xfile.d')
+  split Xfile.d
+  call assert_equal('d', &filetype)
+  bwipe!
+
+  call writefile(['import that', '#pragma  D  option'], 'Xfile.d')
+  split Xfile.d
+  call assert_equal('d', &filetype)
+  bwipe!
+
   filetype off
 endfunc
 


### PR DESCRIPTION
Problem:    Dtrace files are recognized as filetype D.
Solution:   Add a pattern for Dtrace files. (Teubel György, closes vim/vim#9841)
            Add some more testing.
https://github.com/vim/vim/commit/4d56b971cbae01cc454eb09713326224993e38ed