### PR TITLE
feat(lua): add <f-args> to user commands callback

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -651,6 +651,9 @@ nvim_add_user_command({name}, {command}, {*opts})
                                that contains the following keys:
                                • args: (string) The args passed to the
                                  command, if any |<args>|
+                               • fargs: (table) The args split by unescaped
+                                 whitespace (when more than one argument is
+                                 allowed), if any |<f-args>|
                                • bang: (boolean) "true" if the command was
                                  executed with a ! modifier |<bang>|
                                • line1: (number) The starting line of the

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2415,6 +2415,8 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
 ///                 from Lua, the command can also be a Lua function. The function is called with a
 ///                 single table argument that contains the following keys:
 ///                 - args: (string) The args passed to the command, if any |<args>|
+///                 - fargs: (table) The args split by unescaped whitespace (when more than one
+///                 argument is allowed), if any |<f-args>|
 ///                 - bang: (boolean) "true" if the command was executed with a ! modifier |<bang>|
 ///                 - line1: (number) The starting line of the command range |<line1>|
 ///                 - line2: (number) The final line of the command range |<line2>|

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5802,6 +5802,30 @@ static void ex_delcommand(exarg_T *eap)
   }
 }
 
+/// Split a string by unescaped whitespace (space & tab), used for f-args on Lua commands callback.
+/// Similar to uc_split_args(), but does not allocate, add quotes, add commas and is an iterator.
+///
+/// @note  If no separator is found start = 0 and end = length - 1
+/// @param[in]  arg  String to split
+/// @param[in]  iter Iteration counter
+/// @param[out]  start Start of the split
+/// @param[out]  end End of the split
+/// @param[in]  length Length of the string
+/// @return  false if it's the last split (don't call again), true otherwise (call again).
+bool uc_split_args_iter(const char_u *arg, int iter, int *start, int *end, int length)
+{
+  int pos;
+  *start = *end + (iter > 1 ? 2 : 0);  // Skip whitespace after the first split
+  for (pos = *start; pos < length - 2; pos++) {
+    if (arg[pos] != '\\' && ascii_iswhite(arg[pos + 1])) {
+      *end = pos;
+      return true;
+    }
+  }
+  *end = length - 1;
+  return false;
+}
+
 /*
  * split and quote args for <f-args>
  */

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -107,7 +107,8 @@ describe('nvim_add_user_command', function()
     ]]
 
     eq({
-      args = "hello",
+      args = [[hello my\ friend how\ are\ you?]],
+      fargs = {[[hello]], [[my\ friend]], [[how\ are\ you?]]},
       bang = false,
       line1 = 1,
       line2 = 1,
@@ -115,13 +116,14 @@ describe('nvim_add_user_command', function()
       range = 0,
       count = 2,
       reg = "",
-    }, exec_lua [[
-      vim.api.nvim_command('CommandWithLuaCallback hello')
+    }, exec_lua [=[
+      vim.api.nvim_command([[CommandWithLuaCallback hello my\ friend how\ are\ you?]])
       return result
-    ]])
+    ]=])
 
     eq({
-      args = "",
+      args = 'h\tey',
+      fargs = {[[h]], [[ey]]},
       bang = true,
       line1 = 10,
       line2 = 10,
@@ -129,13 +131,14 @@ describe('nvim_add_user_command', function()
       range = 1,
       count = 10,
       reg = "",
-    }, exec_lua [[
-      vim.api.nvim_command('botright 10CommandWithLuaCallback!')
+    }, exec_lua [=[
+      vim.api.nvim_command('botright 10CommandWithLuaCallback! h\tey')
       return result
-    ]])
+    ]=])
 
     eq({
-      args = "",
+      args = "h",
+      fargs = {"h"},
       bang = false,
       line1 = 1,
       line2 = 42,
@@ -144,9 +147,52 @@ describe('nvim_add_user_command', function()
       count = 42,
       reg = "",
     }, exec_lua [[
-      vim.api.nvim_command('CommandWithLuaCallback 42')
+      vim.api.nvim_command('CommandWithLuaCallback 42 h')
       return result
     ]])
+
+    eq({
+      args = "",
+      fargs = {""},  -- fargs works without args
+      bang = false,
+      line1 = 1,
+      line2 = 1,
+      mods = "",
+      range = 0,
+      count = 2,
+      reg = "",
+    }, exec_lua [[
+      vim.api.nvim_command('CommandWithLuaCallback')
+      return result
+    ]])
+
+    -- f-args doesn't split when command nargs is 1 or "?"
+    exec_lua [[
+      result = {}
+      vim.api.nvim_add_user_command('CommandWithOneArg', function(opts)
+        result = opts
+      end, {
+        nargs = "?",
+        bang = true,
+        count = 2,
+      })
+    ]]
+
+    eq({
+      args = "hello I'm one argmuent",
+      fargs = {"hello I'm one argmuent"},  -- Doesn't split args
+      bang = false,
+      line1 = 1,
+      line2 = 1,
+      mods = "",
+      range = 0,
+      count = 2,
+      reg = "",
+    }, exec_lua [[
+      vim.api.nvim_command('CommandWithOneArg hello I\'m one argmuent')
+      return result
+    ]])
+
   end)
 
   it('can define buffer-local commands', function()


### PR DESCRIPTION
Adds the key fargs to the table passed to user commands Lua callback. 

Why: In the related issues the user splitting the arguments itself was proposed as a good alternative. Problem is you can't do it with the provided `vim.split` since it requires look-ahead or look-behind that Lua patterns do not provide. The alternative is to iterate over every byte of the string finding unescaped space or tab.

I believe this is needed to make the use of commands more ergonomic, mainly because **Nvim built-in command completion functions provides command arguments with properly escaped whitespace**. 


Closes https://github.com/neovim/neovim/issues/17419