### PR TITLE
feat(terminal): Add termpasteraw option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6437,6 +6437,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	   C1	    Control characters 0x80...0x9F
 
+						*'termpasteraw'* *'notermpasteraw'*
+'termpasteraw' boolean	(default off)
+			global
+	When set, text pasted into a terminal window is not escaped or filtered
+	and is processed as raw keystrokes by the terminal emulator (the value
+	of 'termpastefilter' is ignored). This allows control sequences to be
+	passed to terminal programs. This is potentially unsafe, so should only be
+	activated when dealing with trusted input.
 
 						*'terse'* *'noterse'*
 'terse'			boolean	(default off)

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -644,6 +644,7 @@ static char *(p_tpf_values[]) =
 #define TPF_DEL                0x010
 #define TPF_C0                 0x020
 #define TPF_C1                 0x040
+EXTERN int *p_tpr;             // 'termpasteraw'
 EXTERN char_u *p_sps;         // 'spellsuggest'
 EXTERN int p_spr;               // 'splitright'
 EXTERN int p_sol;               // 'startofline'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2519,6 +2519,13 @@ return {
       defaults={if_true="BS,HT,ESC,DEL"}
     },
     {
+      full_name='termpasteraw',
+      short_desc=N_("disables escaping of input pasted to a terminal window"),
+      type='bool', scope={'global'},
+      varname='p_tpr',
+      defaults={if_true=false}
+    },
+    {
       full_name='terse',
       short_desc=N_("hides notification of search wrap"),
       type='bool', scope={'global'},

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -641,6 +641,21 @@ void terminal_paste(long count, char_u **y_array, size_t y_size)
   if (y_size == 0) {
     return;
   }
+  // In termpasteraw mode, send all the lines directly without filtering control
+  // codes or setting paste mode in libvterm
+  if (p_tpr) {
+    for (int i = 0; i < count; i++) {  // -V756
+      // feed the lines to the terminal
+      for (size_t j = 0; j < y_size; j++) {
+        if (j) {
+          // terminate the previous line
+          terminal_send(curbuf->terminal, "\n", 1);
+        }
+        terminal_send(curbuf->terminal, (char *)y_array[j], STRLEN(y_array[j]));
+      }
+    }
+    return;
+  }
   vterm_keyboard_start_paste(curbuf->terminal->vt);
   size_t buff_len = STRLEN(y_array[0]);
   char_u *buff = xmalloc(buff_len);


### PR DESCRIPTION
So I hadn't updated neovim in a long while, and I've only just noticed some changes introduced in early 2020 (commits 81a30f43, 14158e8d, and 1e3fadb4) broke a few keymappings I have that do things like "write current file, send up-enter to terminal window". It's rather surprising to me that I'm the only person that seems to want to send control characters to the terminal emulator, but here we are :)

This PR adds an option to disable the filtering/escaping of text pasted into terminal windows, so it's possible again to send control sequences to the terminal emulator and have them interpreted as key codes (using `set termpastefilter=` is not sufficient, as the paste mode in libvterm is still enabled).