### PR TITLE
fix(api): convert blob to NUL-terminated API string

### DIFF
--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -57,7 +57,7 @@ typedef struct {
     const size_t len_ = (size_t)(len); \
     const blob_T *const blob_ = (blob); \
     kvi_push(edata->stack, STRING_OBJ(((String) { \
-      .data = len_ != 0 ? xmemdup(blob_->bv_ga.ga_data, len_) : NULL, \
+      .data = len_ != 0 ? xmemdupz(blob_->bv_ga.ga_data, len_) : xstrdup(""), \
       .size = len_ \
     }))); \
   } while (0)

--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -102,6 +102,13 @@ describe('luaeval(vim.api.…)', function()
     eq(false, funcs.luaeval('vim.api.nvim__id(false)'))
     eq(NIL, funcs.luaeval('vim.api.nvim__id(nil)'))
 
+    -- API strings from Blobs can work as NUL-terminated C strings
+    eq('Vim(call):E5555: API call: Vim:E15: Invalid expression: ',
+       exc_exec('call nvim_eval(v:_null_blob)'))
+    eq('Vim(call):E5555: API call: Vim:E15: Invalid expression: ',
+       exc_exec('call nvim_eval(0z)'))
+    eq(1, eval('nvim_eval(0z31)'))
+
     eq(0, eval([[type(luaeval('vim.api.nvim__id(1)'))]]))
     eq(1, eval([[type(luaeval('vim.api.nvim__id("1")'))]]))
     eq(3, eval([[type(luaeval('vim.api.nvim__id({1})'))]]))


### PR DESCRIPTION
Looks like I did an oopsie; although API strings carry a size field, they should
still be usable as C-strings! (even though they may contain embedded NULs)