### PR TITLE
vim-patch:c51cf0329809

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1,7 +1,7 @@
 " Vim functions for file type detection
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Jan 31
+" Last Change:	2022 Feb 22
 
 " These functions are moved here from runtime/filetype.vim to make startup
 " faster.

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1406,7 +1406,7 @@ Examples for reading and writing compressed files: >
   :  autocmd BufReadPre,FileReadPre	*.gz set bin
   :  autocmd BufReadPost,FileReadPost	*.gz '[,']!gunzip
   :  autocmd BufReadPost,FileReadPost	*.gz set nobin
-  :  autocmd BufReadPost,FileReadPost	*.gz execute ":doautocmd BufReadPost " . expand("%:r")
+  :  autocmd BufReadPost,FileReadPost	*.gz execute ":doautocmd BufReadPost " .. expand("%:r")
   :  autocmd BufWritePost,FileWritePost	*.gz !mv <afile> <afile>:r
   :  autocmd BufWritePost,FileWritePost	*.gz !gzip <afile>:r
 
@@ -1505,7 +1505,7 @@ To insert the current date and time in a *.html file when writing it: >
   :  else
   :    let l = line("$")
   :  endif
-  :  exe "1," . l . "g/Last modified: /s/Last modified: .*/Last modified: " .
+  :  exe "1," .. l .. "g/Last modified: /s/Last modified: .*/Last modified: " ..
   :  \ strftime("%Y %b %d")
   :endfun
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -693,7 +693,7 @@ argv([{nr} [, {winid}]])
 	:let i = 0
 	:while i < argc()
 	:  let f = escape(fnameescape(argv(i)), '.')
-	:  exe 'amenu Arg.' . f . ' :e ' . f . '<CR>'
+	:  exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
 	:  let i = i + 1
 	:endwhile
 <		Without the {nr} argument, or when {nr} is -1, a |List| with
@@ -895,7 +895,7 @@ bufwinid({buf})						*bufwinid()*
 		see |bufname()| above.  If buffer {buf} doesn't exist or
 		there is no such window, -1 is returned.  Example: >
 
-	echo "A window containing buffer 1 is " . (bufwinid(1))
+	echo "A window containing buffer 1 is " .. (bufwinid(1))
 <
 		Only deals with the current tab page.
 
@@ -908,7 +908,7 @@ bufwinnr({buf})						*bufwinnr()*
 		If buffer {buf} doesn't exist or there is no such window, -1
 		is returned.  Example: >
 
-	echo "A window containing buffer 1 is " . (bufwinnr(1))
+	echo "A window containing buffer 1 is " .. (bufwinnr(1))
 
 <		The number can be used with |CTRL-W_w| and ":wincmd w"
 		|:wincmd|.
@@ -955,7 +955,7 @@ byteidx({expr}, {nr})					*byteidx()*
 byteidxcomp({expr}, {nr})					*byteidxcomp()*
 		Like byteidx(), except that a composing character is counted
 		as a separate character.  Example: >
-			let s = 'e' . nr2char(0x301)
+			let s = 'e' .. nr2char(0x301)
 			echo byteidx(s, 1)
 			echo byteidxcomp(s, 1)
 			echo byteidxcomp(s, 2)
@@ -1152,7 +1152,7 @@ col({expr})	The result is a Number, which is the byte index of the column
 			col(".")		column of cursor
 			col("$")		length of cursor line plus one
 			col("'t")		column of mark t
-			col("'" . markname)	column of mark markname
+			col("'" .. markname)	column of mark markname
 <		The first column is 1.  0 is returned for an error.
 		For an uppercase mark the column may actually be in another
 		buffer.
@@ -1161,7 +1161,7 @@ col({expr})	The result is a Number, which is the byte index of the column
 		line.  This can be used to obtain the column in Insert mode: >
 			:imap <F2> <C-O>:let save_ve = &ve<CR>
 				\<C-O>:set ve=all<CR>
-				\<C-O>:echo col(".") . "\n" <Bar>
+				\<C-O>:echo col(".") .. "\n" <Bar>
 				\let &ve = save_ve<CR>
 
 <		Can also be used as a |method|: >
@@ -1899,12 +1899,12 @@ expand({string} [, {nosuf} [, {list}]])				*expand()*
 			:e		extension only
 
 		Example: >
-			:let &tags = expand("%:p:h") . "/tags"
+			:let &tags = expand("%:p:h") .. "/tags"
 <		Note that when expanding a string that starts with '%', '#' or
 		'<', any following text is ignored.  This does NOT work: >
 			:let doesntwork = expand("%:h.bak")
 <		Use this: >
-			:let doeswork = expand("%:h") . ".bak"
+			:let doeswork = expand("%:h") .. ".bak"
 <		Also note that expanding "<cfile>" and others only returns the
 		referenced file name without further expansion.  If "<cfile>"
 		is "~/.cshrc", you need to do another expand() to have the
@@ -2240,7 +2240,7 @@ fnameescape({string})					*fnameescape()*
 		and |:write|).  And a "-" by itself (special after |:cd|).
 		Example: >
 			:let fname = '+some str%nge|name'
-			:exe "edit " . fnameescape(fname)
+			:exe "edit " .. fnameescape(fname)
 <		results in executing: >
 			edit \+some\ str\%nge\|name
 <
@@ -2395,7 +2395,7 @@ function({name} [, {arglist}] [, {dict}])
 <		The Dictionary is only useful when calling a "dict" function.
 		In that case the {dict} is passed in as "self". Example: >
 			function Callback() dict
-			   echo "called for " . self.name
+			   echo "called for " .. self.name
 			endfunction
 			...
 			let context = {"name": "example"}
@@ -2578,7 +2578,7 @@ getbufvar({buf}, {varname} [, {def}])				*getbufvar()*
 		string is returned, there is no error message.
 		Examples: >
 			:let bufmodified = getbufvar(1, "&mod")
-			:echo "todo myvar = " . getbufvar("todo", "myvar")
+			:echo "todo myvar = " .. getbufvar("todo", "myvar")
 
 <		Can also be used as a |method|: >
 			GetBufnr()->getbufvar(varname)
@@ -2639,9 +2639,9 @@ getchar([expr])						*getchar()*
 		This example positions the mouse as it would normally happen: >
 			let c = getchar()
 			if c == "\<LeftMouse>" && v:mouse_win > 0
-			  exe v:mouse_win . "wincmd w"
+			  exe v:mouse_win .. "wincmd w"
 			  exe v:mouse_lnum
-			  exe "normal " . v:mouse_col . "|"
+			  exe "normal " .. v:mouse_col .. "|"
 			endif
 <
 		There is no prompt, you will somehow have to make clear to the
@@ -3374,7 +3374,7 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])		*gettabwinvar()*
 		empty string is returned, there is no error message.
 		Examples: >
 			:let list_is_on = gettabwinvar(1, 2, '&list')
-			:echo "myvar = " . gettabwinvar(3, 1, 'myvar')
+			:echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
 <
 		To obtain all window-local variables use: >
 			gettabwinvar({tabnr}, {winnr}, '&')
@@ -3489,7 +3489,7 @@ getwinvar({winnr}, {varname} [, {def}])				*getwinvar()*
 		Like |gettabwinvar()| for the current tabpage.
 		Examples: >
 			:let list_is_on = getwinvar(2, '&list')
-			:echo "myvar = " . getwinvar(1, 'myvar')
+			:echo "myvar = " .. getwinvar(1, 'myvar')
 
 <		Can also be used as a |method|: >
 			GetWinnr()->getwinvar(varname)
@@ -3758,7 +3758,7 @@ histdel({history} [, {item}])				*histdel()*
 		The following three are equivalent: >
 			:call histdel("search", histnr("search"))
 			:call histdel("search", -1)
-			:call histdel("search", '^'.histget("search", -1).'$')
+			:call histdel("search", '^' .. histget("search", -1) .. '$')
 <
 		To delete the last search pattern and use the last-but-one for
 		the "n" command and 'hlsearch': >
@@ -3777,7 +3777,7 @@ histget({history} [, {index}])				*histget()*
 
 		Examples:
 		Redo the second last search from history. >
-			:execute '/' . histget("search", -2)
+			:execute '/' .. histget("search", -2)
 
 <		Define an Ex command ":H {num}" that supports re-execution of
 		the {num}th entry from the output of |:history|. >
@@ -3941,11 +3941,11 @@ input({opts})
 			  let lvl = 0
 			  while i < len(a:cmdline)
 			    if a:cmdline[i] is# '('
-			      call add(ret, [i, i + 1, 'RBP' . ((lvl % g:rainbow_levels) + 1)])
+			      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
 			      let lvl += 1
 			    elseif a:cmdline[i] is# ')'
 			      let lvl -= 1
-			      call add(ret, [i, i + 1, 'RBP' . ((lvl % g:rainbow_levels) + 1)])
+			      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
 			    endif
 			    let i += 1
 			  endwhile
@@ -3975,7 +3975,7 @@ input({opts})
 		|:execute| or |:normal|.
 
 		Example with a mapping: >
-			:nmap \x :call GetFoo()<CR>:exe "/" . Foo<CR>
+			:nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
 			:function GetFoo()
 			:  call inputsave()
 			:  let g:Foo = input("enter search pattern: ")
@@ -4134,7 +4134,7 @@ items({dict})						*items()*
 		order.  Also see |keys()| and |values()|.
 		Example: >
 			for [key, value] in items(mydict)
-			   echo key . ': ' . value
+			   echo key .. ': ' .. value
 			endfor
 
 <		Can also be used as a |method|: >
@@ -4270,7 +4270,7 @@ join({list} [, {sep}])					*join()*
 		{sep} is omitted a single space is used.
 		Note that {sep} is not added at the end.  You might want to
 		add it there too: >
-			let lines = join(mylist, "\n") . "\n"
+			let lines = join(mylist, "\n") .. "\n"
 <		String items are used as-is.  |Lists| and |Dictionaries| are
 		converted into a string like with |string()|.
 		The opposite function is |split()|.
@@ -4419,7 +4419,7 @@ line({expr} [, {winid}])				*line()*
 			line(".")		line number of the cursor
 			line(".", winid)	idem, in window "winid"
 			line("'t")		line number of mark t
-			line("'" . marker)	line number of mark marker
+			line("'" .. marker)	line number of mark marker
 <
 		To jump to the last known position when opening a file see
 		|last-position-jump|.
@@ -4520,7 +4520,7 @@ map({expr1}, {expr2})					*map()*
 		the current item.  For a |Blob| |v:key| has the index of the
 		current byte.
 		Example: >
-			:call map(mylist, '"> " . v:val . " <"')
+			:call map(mylist, '"> " .. v:val .. " <"')
 <		This puts "> " before and " <" after each item in "mylist".
 
 		Note that {expr2} is the result of an expression and is then
@@ -4534,19 +4534,19 @@ map({expr1}, {expr2})					*map()*
 		The function must return the new value of the item. Example
 		that changes each value by "key-value": >
 			func KeyValue(key, val)
-			  return a:key . '-' . a:val
+			  return a:key .. '-' .. a:val
 			endfunc
 			call map(myDict, function('KeyValue'))
 <		It is shorter when using a |lambda|: >
-			call map(myDict, {key, val -> key . '-' . val})
+			call map(myDict, {key, val -> key .. '-' .. val})
 <		If you do not use "val" you can leave it out: >
-			call map(myDict, {key -> 'item: ' . key})
+			call map(myDict, {key -> 'item: ' .. key})
 <		If you do not use "key" you can use a short name: >
-			call map(myDict, {_, val -> 'item: ' . val})
+			call map(myDict, {_, val -> 'item: ' .. val})
 <
 		The operation is done in-place.  If you want a |List| or
 		|Dictionary| to remain unmodified make a copy first: >
-			:let tlist = map(copy(mylist), ' v:val . "\t"')
+			:let tlist = map(copy(mylist), ' v:val .. "\t"')
 
 <		Returns {expr1}, the |List|, |Blob| or |Dictionary| that was
 		filtered.  When an error is encountered while evaluating
@@ -4612,7 +4612,7 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		then the global mappings.
 		This function can be used to map a key even when it's already
 		mapped, and have it do the original mapping too.  Sketch: >
-			exe 'nnoremap <Tab> ==' . maparg('<Tab>', 'n')
+			exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 
 <		Can also be used as a |method|: >
 			GetKey()->maparg('n')
@@ -5085,7 +5085,7 @@ mkdir({name} [, {path} [, {prot}]])
 
 		{prot} is applied for all parts of {name}.  Thus if you create
 		/tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >
-			:call mkdir($HOME . "/tmp/foo/bar", "p", 0o700)
+			:call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
 <		This function is not available in the |sandbox|.
 
@@ -5585,7 +5585,7 @@ prompt_setcallback({buf}, {expr})			*prompt_setcallback()*
 		       stopinsert
 		       close
 		     else
-		       call append(line('$') - 1, 'Entered: "' . a:text . '"')
+		       call append(line('$') - 1, 'Entered: "' .. a:text .. '"')
 		       " Reset 'modified' to allow the buffer to be closed.
 		       set nomodified
 		     endif
@@ -5732,7 +5732,7 @@ readdir({directory} [, {expr}])
                   function! s:tree(dir)
                       return {a:dir : map(readdir(a:dir),
 		      \ {_, x -> isdirectory(x) ?
-		      \          {x : s:tree(a:dir . '/' . x)} : x})}
+		      \          {x : s:tree(a:dir .. '/' .. x)} : x})}
                   endfunction
                   echo s:tree(".")
 <
@@ -5920,7 +5920,7 @@ remote_peek({serverid} [, {retvar}])		*remote_peek()*
 		This function is not available in the |sandbox|.
 		Examples: >
 			:let repl = ""
-			:echo "PEEK: ".remote_peek(id, "repl").": ".repl
+			:echo "PEEK: " .. remote_peek(id, "repl") .. ": " .. repl
 
 remote_read({serverid}, [{timeout}])			*remote_read()*
 		Return the oldest available reply from {serverid} and consume
@@ -5950,12 +5950,12 @@ remote_send({server}, {string} [, {idvar}])
 		Note: Any errors will be reported in the server and may mess
 		up the display.
 		Examples: >
-		:echo remote_send("gvim", ":DropAndReply ".file, "serverid").
+		:echo remote_send("gvim", ":DropAndReply " .. file, "serverid") ..
 		 \ remote_read(serverid)
 
 		:autocmd NONE RemoteReply *
 		 \ echo remote_read(expand("<amatch>"))
-		:echo remote_send("gvim", ":sleep 10 | echo ".
+		:echo remote_send("gvim", ":sleep 10 | echo " ..
 		 \ 'server2client(expand("<client>"), "HELLO")<CR>')
 <
 					*remote_startserver()* *E941* *E942*
@@ -5972,7 +5972,7 @@ remove({list}, {idx} [, {end}])				*remove()*
 		points to an item before {idx} this is an error.
 		See |list-index| for possible values of {idx} and {end}.
 		Example: >
-			:echo "last item: " . remove(mylist, -1)
+			:echo "last item: " .. remove(mylist, -1)
 			:call remove(mylist, 0, 9)
 <
 		Use |delete()| to remove a file.
@@ -5988,13 +5988,13 @@ remove({blob}, {idx} [, {end}])
 		byte as {end} a |Blob| with one byte is returned.  When {end}
 		points to a byte before {idx} this is an error.
 		Example: >
-			:echo "last byte: " . remove(myblob, -1)
+			:echo "last byte: " .. remove(myblob, -1)
 			:call remove(mylist, 0, 9)
 
 remove({dict}, {key})
 		Remove the entry from {dict} with key {key} and return it.
 		Example: >
-			:echo "removed " . remove(dict, "one")
+			:echo "removed " .. remove(dict, "one")
 <		If there is no {key} in {dict} this is an error.
 
 rename({from}, {to})					*rename()*
@@ -6135,7 +6135,7 @@ screencol()							*screencol()*
 		column inside the command line, which is 1 when the command is
 		executed. To get the cursor position in the file use one of
 		the following mappings: >
-			nnoremap <expr> GG ":echom ".screencol()."\n"
+			nnoremap <expr> GG ":echom " .. screencol() .. "\n"
 			nnoremap <silent> GG :echom screencol()<CR>
 			noremap GG <Cmd>echom screencol()<Cr>
 <
@@ -6256,7 +6256,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		Example (goes over all files in the argument list): >
 		    :let n = 1
 		    :while n <= argc()	    " loop over all files in arglist
-		    :  exe "argument " . n
+		    :  exe "argument " .. n
 		    :  " start at the last char in the file and wrap for the
 		    :  " first search to find match at start of file
 		    :  normal G$
@@ -6340,11 +6340,11 @@ searchcount([{options}])					*searchcount()*
 			  return printf(' /%s [%d/%d]', @/,
 			  \             result.current, result.total)
 			endfunction
-			let &statusline .= '%{LastSearchCount()}'
+			let &statusline ..= '%{LastSearchCount()}'
 
 			" Or if you want to show the count only when
 			" 'hlsearch' was on
-			" let &statusline .=
+			" let &statusline ..=
 			" \   '%{v:hlsearch ? LastSearchCount() : ""}'
 <
 		You can also update the search count, which can be useful in a
@@ -7146,10 +7146,10 @@ shellescape({string} [, {special}])			*shellescape()*
 		inside single quotes.
 
 		Example of use with a |:!| command: >
-		    :exe '!dir ' . shellescape(expand('<cfile>'), 1)
+		    :exe '!dir ' .. shellescape(expand('<cfile>'), 1)
 <		This results in a directory listing for the file under the
 		cursor.  Example of use with |system()|: >
-		    :call system("chmod +w -- " . shellescape(expand("%")))
+		    :call system("chmod +w -- " .. shellescape(expand("%")))
 <		See also |::S|.
 
 		Can also be used as a |method|: >
@@ -7841,7 +7841,7 @@ substitute({string}, {pat}, {sub}, {flags})		*substitute()*
 		When {sub} starts with "\=", the remainder is interpreted as
 		an expression. See |sub-replace-expression|.  Example: >
 			:echo substitute(s, '%\(\x\x\)',
-			   \ '\=nr2char("0x" . submatch(1))', 'g')
+			   \ '\=nr2char("0x" .. submatch(1))', 'g')
 
 <		When {sub} is a Funcref that function is called, with one
 		optional argument.  Example: >
@@ -7849,7 +7849,7 @@ substitute({string}, {pat}, {sub}, {flags})		*substitute()*
 <		The optional argument is a list which contains the whole
 		matched string and up to nine submatches, like what
 		|submatch()| returns.  Example: >
-		   :echo substitute(s, '%\(\x\x\)', {m -> '0x' . m[1]}, 'g')
+		   :echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
 
 <		Can also be used as a |method|: >
 			GetString()->substitute(pat, sub, flags)
@@ -8167,7 +8167,7 @@ tempname()					*tempname()* *temp-file-name*
 		The result is a String, which is the name of a file that
 		doesn't exist.  It can be used for a temporary file.  Example: >
 			:let tmpfile = tempname()
-			:exe "redir > " . tmpfile
+			:exe "redir > " .. tmpfile
 <		For Unix, the file will be in a private directory |tempfile|.
 		For MS-Windows forward slashes are used when the 'shellslash'
 		option is set or when 'shellcmdflag' starts with '-'.
@@ -8343,7 +8343,7 @@ trim({text} [, {mask} [, {dir}]])				*trim()*
 		Examples: >
 			echo trim("   some text ")
 <		returns "some text" >
-			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") . "_TAIL"
+			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
 <		returns "RESERVE_TAIL" >
 			echo trim("rm<Xrm<>X>rrm", "rm<>")
 <		returns "Xrm<>X" (characters in the middle are not removed) >
@@ -8521,7 +8521,7 @@ visualmode([{expr}])						*visualmode()*
 		character-wise, line-wise, or block-wise Visual mode
 		respectively.
 		Example: >
-			:exe "normal " . visualmode()
+			:exe "normal " .. visualmode()
 <		This enters the same Visual mode as before.  It is also useful
 		in scripts if you wish to act differently depending on the
 		Visual mode that was used.
@@ -8708,7 +8708,7 @@ winbufnr({nr})	The result is a Number, which is the number of the buffer
 		window is returned.
 		When window {nr} doesn't exist, -1 is returned.
 		Example: >
-  :echo "The file in the current window is " . bufname(winbufnr(0))
+  :echo "The file in the current window is " .. bufname(winbufnr(0))
 <
 		Can also be used as a |method|: >
 			FindWindow()->winbufnr()->bufname()
@@ -8733,7 +8733,7 @@ winheight({nr})						*winheight()*
 		An existing window always has a height of zero or more.
 		This excludes any window toolbar line.
 		Examples: >
-  :echo "The current window has " . winheight(0) . " lines."
+  :echo "The current window has " .. winheight(0) .. " lines."
 
 <		Can also be used as a |method|: >
 			GetWinid()->winheight()
@@ -8870,7 +8870,7 @@ winwidth({nr})						*winwidth()*
 		returned.  When window {nr} doesn't exist, -1 is returned.
 		An existing window always has a width of zero or more.
 		Examples: >
-  :echo "The current window has " . winwidth(0) . " columns."
+  :echo "The current window has " .. winwidth(0) .. " columns."
   :if winwidth(0) <= 50
   :  50 wincmd |
   :endif

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -906,7 +906,7 @@ Consider using a character like "@" or ":".  There is no problem if the result
 of the expression contains the separation character.
 
 Examples: >
-	:s@\n@\="\r" . expand("$HOME") . "\r"@
+	:s@\n@\="\r" .. expand("$HOME") .. "\r"@
 This replaces an end-of-line with a new line containing the value of $HOME. >
 
 	s/E/\="\<Char-0x20ac>"/g
@@ -1065,7 +1065,7 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			the command.  You need to escape the '|' and '"'
 			characters to prevent them from terminating the
 			command.  Example: >
-				:put ='path' . \",/test\"
+				:put ='path' .. \",/test\"
 <			If there is no expression after '=', Vim uses the
 			previous expression.  You can see it with ":dis =".
 

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -207,7 +207,7 @@ CTRL-\ e {expr}						*c_CTRL-\_e*
 		Example: >
 			:cmap <F7> <C-\>eAppendSome()<CR>
 			:func AppendSome()
-			   :let cmd = getcmdline() . " Some()"
+			   :let cmd = getcmdline() .. " Some()"
 			   :" place the cursor on the )
 			   :call setcmdpos(strlen(cmd))
 			   :return cmd

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -371,13 +371,13 @@ Example (this does almost the same as 'diffexpr' being empty): >
 	function MyDiff()
 	   let opt = ""
 	   if &diffopt =~ "icase"
-	     let opt = opt . "-i "
+	     let opt = opt .. "-i "
 	   endif
 	   if &diffopt =~ "iwhite"
-	     let opt = opt . "-b "
+	     let opt = opt .. "-b "
 	   endif
-	   silent execute "!diff -a --binary " . opt . v:fname_in . " " . v:fname_new .
-		\  " > " . v:fname_out
+	   silent execute "!diff -a --binary " .. opt .. v:fname_in .. " " .. v:fname_new ..
+		\  " > " .. v:fname_out
 	   redraw!
 	endfunction
 
@@ -427,8 +427,8 @@ Example (this does the same as 'patchexpr' being empty): >
 
 	set patchexpr=MyPatch()
 	function MyPatch()
-	   :call system("patch -o " . v:fname_out . " " . v:fname_in .
-	   \  " < " . v:fname_diff)
+	   :call system("patch -o " .. v:fname_out .. " " .. v:fname_in ..
+	   \  " < " .. v:fname_diff)
 	endfunction
 
 Make sure that using the "patch" program doesn't have unwanted side effects.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -411,9 +411,9 @@ does apply like to other wildcards.
 
 Environment variables in the expression are expanded when evaluating the
 expression, thus this works: >
-	:e `=$HOME . '/.vimrc'`
+	:e `=$HOME .. '/.vimrc'`
 This does not work, $HOME is inside a string and used literally: >
-	:e `='$HOME' . '/.vimrc'`
+	:e `='$HOME' .. '/.vimrc'`
 
 If the expression returns a string then names are to be separated with line
 breaks.  When the result is a |List| then each item is used as a name.  Line

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -402,7 +402,7 @@ It is also possible to put remaining items in a List variable: >
 	:for [i, j; rest] in listlist
 	:   call Doit(i, j)
 	:   if !empty(rest)
-	:      echo "remainder: " . string(rest)
+	:      echo "remainder: " .. string(rest)
 	:   endif
 	:endfor
 
@@ -430,11 +430,11 @@ Functions that are useful with a List: >
 	:let list = split("a b c")	" create list from items in a string
 	:let string = join(list, ', ')	" create string from list items
 	:let s = string(list)		" String representation of list
-	:call map(list, '">> " . v:val')  " prepend ">> " to each item
+	:call map(list, '">> " .. v:val')  " prepend ">> " to each item
 
 Don't forget that a combination of features can make things simple.  For
 example, to add up all the numbers in a list: >
-	:exe 'let sum = ' . join(nrlist, '+')
+	:exe 'let sum = ' .. join(nrlist, '+')
 
 
 1.4 Dictionaries ~
@@ -496,7 +496,7 @@ turn the Dictionary into a List and pass it to |:for|.
 
 Most often you want to loop over the keys, using the |keys()| function: >
 	:for key in keys(mydict)
-	:   echo key . ': ' . mydict[key]
+	:   echo key .. ': ' .. mydict[key]
 	:endfor
 
 The List of keys is unsorted.  You may want to sort them first: >
@@ -504,13 +504,13 @@ The List of keys is unsorted.  You may want to sort them first: >
 
 To loop over the values use the |values()| function:  >
 	:for v in values(mydict)
-	:   echo "value: " . v
+	:   echo "value: " .. v
 	:endfor
 
 If you want both the key and the value use the |items()| function.  It returns
 a List in which each item is a List with two items, the key and the value: >
 	:for [key, value] in items(mydict)
-	:   echo key . ': ' . value
+	:   echo key .. ': ' .. value
 	:endfor
 
 
@@ -605,7 +605,7 @@ Functions that can be used with a Dictionary: >
 	:let small = min(dict)		" minimum value in dict
 	:let xs = count(dict, 'x')	" count nr of times 'x' appears in dict
 	:let s = string(dict)		" String representation of dict
-	:call map(dict, '">> " . v:val')  " prepend ">> " to each item
+	:call map(dict, '">> " .. v:val')  " prepend ">> " to each item
 
 
 1.5 Blobs ~
@@ -840,7 +840,7 @@ Example: >
 All expressions within one level are parsed from left to right.
 
 
-expr1							*expr1* *trinary* *E109*
+expr1							*expr1* *ternary* *E109*
 -----
 
 expr2 ? expr1 : expr1
@@ -1362,7 +1362,7 @@ option						*expr-option* *E112* *E113*
 &l:option		local option value
 
 Examples: >
-	echo "tabstop is " . &tabstop
+	echo "tabstop is " .. &tabstop
 	if &insertmode
 
 Any option name can be used here.  See |options|.  When using the local value
@@ -1637,7 +1637,7 @@ maintain a counter: >
 	  echo "script executed for the first time"
 	else
 	  let s:counter = s:counter + 1
-	  echo "script executed " . s:counter . " times now"
+	  echo "script executed " .. s:counter .. " times now"
 	endif
 
 Note that this means that filetype plugins don't get a different set of script
@@ -1736,7 +1736,7 @@ v:completed_item
 					*v:count* *count-variable*
 v:count		The count given for the last Normal mode command.  Can be used
 		to get the count before a mapping.  Read-only.  Example: >
-	:map _x :<C-U>echo "the count is " . v:count<CR>
+	:map _x :<C-U>echo "the count is " .. v:count<CR>
 <		Note: The <C-U> is required to remove the line range that you
 		get when typing ':' after a count.
 		When there are two counts, as in "3d2w", they are multiplied,
@@ -2531,9 +2531,9 @@ Example: >
   :  echohl Title
   :  echo a:title
   :  echohl None
-  :  echo a:0 . " items:"
+  :  echo a:0 .. " items:"
   :  for s in a:000
-  :    echon ' ' . s
+  :    echon ' ' .. s
   :  endfor
   :endfunction
 
@@ -2572,7 +2572,7 @@ This function can then be called with: >
 		this works:
 						*function-range-example*  >
 	:function Mynumber(arg)
-	:  echo line(".") . " " . a:arg
+	:  echo line(".") .. " " .. a:arg
 	:endfunction
 	:1,5call Mynumber(getline("."))
 <
@@ -2583,7 +2583,7 @@ This function can then be called with: >
 		Example of a function that handles the range itself: >
 
 	:function Cont() range
-	:  execute (a:firstline + 1) . "," . a:lastline . 's/^/\t\\ '
+	:  execute (a:firstline + 1) .. "," .. a:lastline .. 's/^/\t\\ '
 	:endfunction
 	:4,8call Cont()
 <
@@ -2745,7 +2745,7 @@ This does NOT work: >
 			This cannot be used to add an item to a |List|.
 			This cannot be used to set a byte in a String.  You
 			can do that like this: >
-				:let var = var[0:2] . 'X' . var[4:]
+				:let var = var[0:2] .. 'X' .. var[4:]
 <			When {var-name} is a |Blob| then {idx} can be the
 			length of the blob, in which case one byte is
 			appended.
@@ -2807,7 +2807,7 @@ This does NOT work: >
 			is just like using the |:set| command: both the local
 			value and the global value are changed.
 			Example: >
-				:let &path = &path . ',/usr/local/include'
+				:let &path = &path .. ',/usr/local/include'
 
 :let &{option-name} .= {expr1}
 			For a string option: Append {expr1} to the value.
@@ -3064,6 +3064,8 @@ text...
 :if {expr1}			*:if* *:end* *:endif* *:en* *E171* *E579* *E580*
 :en[dif]		Execute the commands until the next matching ":else"
 			or ":endif" if {expr1} evaluates to non-zero.
+			Although the short forms work, it is recommended to
+			always use `:endif` to avoid confusion.
 
 			From Vim version 4.5 until 5.0, every Ex command in
 			between the ":if" and ":endif" is ignored.  These two
@@ -3661,7 +3663,7 @@ exception most recently caught as long it is not finished.
 
 	:function! Caught()
 	:  if v:exception != ""
-	:    echo 'Caught "' . v:exception . '" in ' . v:throwpoint
+	:    echo 'Caught "' .. v:exception .. '" in ' .. v:throwpoint
 	:  else
 	:    echo 'Nothing caught'
 	:  endif
@@ -4064,8 +4066,8 @@ a script in order to catch unexpected things.
 	:catch /^Vim:Interrupt$/
 	:    echo "Script interrupted"
 	:catch /.*/
-	:  echo "Internal error (" . v:exception . ")"
-	:  echo " - occurred at " . v:throwpoint
+	:  echo "Internal error (" .. v:exception .. ")"
+	:  echo " - occurred at " .. v:throwpoint
 	:endtry
 	:" end of script
 
@@ -4261,7 +4263,7 @@ parentheses can be cut out from |v:exception| with the ":substitute" command.
 
 	:function! CheckRange(a, func)
 	:  if a:a < 0
-	:    throw "EXCEPT:MATHERR:RANGE(" . a:func . ")"
+	:    throw "EXCEPT:MATHERR:RANGE(" .. a:func .. ")"
 	:  endif
 	:endfunction
 	:
@@ -4288,7 +4290,7 @@ parentheses can be cut out from |v:exception| with the ":substitute" command.
 	:  try
 	:    execute "write" fnameescape(a:file)
 	:  catch /^Vim(write):/
-	:    throw "EXCEPT:IO(" . getcwd() . ", " . a:file . "):WRITEERR"
+	:    throw "EXCEPT:IO(" .. getcwd() .. ", " .. a:file .. "):WRITEERR"
 	:  endtry
 	:endfunction
 	:
@@ -4307,9 +4309,9 @@ parentheses can be cut out from |v:exception| with the ":substitute" command.
 	:  let dir = substitute(v:exception, '.*(\(.\+\),\s*.\+).*', '\1', "")
 	:  let file = substitute(v:exception, '.*(.\+,\s*\(.\+\)).*', '\1', "")
 	:  if file !~ '^/'
-	:    let file = dir . "/" . file
+	:    let file = dir .. "/" .. file
 	:  endif
-	:  echo 'I/O error for "' . file . '"'
+	:  echo 'I/O error for "' .. file .. '"'
 	:
 	:catch /^EXCEPT/
 	:  echo "Unspecified error"
@@ -4377,7 +4379,7 @@ clauses, however, is executed.
 	:    echo "inner finally"
 	:  endtry
 	:catch
-	:  echo 'outer catch-all caught "' . v:exception . '"'
+	:  echo 'outer catch-all caught "' .. v:exception .. '"'
 	:  finally
 	:    echo "outer finally"
 	:endtry
@@ -4439,7 +4441,7 @@ Printing in Binary ~
   :  let n = a:nr
   :  let r = ""
   :  while n
-  :    let r = '01'[n % 2] . r
+  :    let r = '01'[n % 2] .. r
   :    let n = n / 2
   :  endwhile
   :  return r
@@ -4450,7 +4452,7 @@ Printing in Binary ~
   :func String2Bin(str)
   :  let out = ''
   :  for ix in range(strlen(a:str))
-  :    let out = out . '-' . Nr2Bin(char2nr(a:str[ix]))
+  :    let out = out .. '-' .. Nr2Bin(char2nr(a:str[ix]))
   :  endfor
   :  return out[1:]
   :endfunc

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -497,7 +497,7 @@ Note the use of backslashes to avoid some characters to be interpreted by the
     :function MyFoldText()
     :  let line = getline(v:foldstart)
     :  let sub = substitute(line, '/\*\|\*/\|{{{\d\=', '', 'g')
-    :  return v:folddashes . sub
+    :  return v:folddashes .. sub
     :endfunction
 
 Evaluating 'foldtext' is done in the |sandbox|.  The current window is set to

--- a/runtime/doc/ft_raku.txt
+++ b/runtime/doc/ft_raku.txt
@@ -47,20 +47,20 @@ Numbers, subscripts and superscripts are available with 's' and 'S':
 
 But some don't come defined by default. Those are digraph definitions you can
 add in your ~/.vimrc file. >
-	exec 'digraph \\ '.char2nr('∖')
-	exec 'digraph \< '.char2nr('≼')
-	exec 'digraph \> '.char2nr('≽')
-	exec 'digraph (L '.char2nr('⊈')
-	exec 'digraph )L '.char2nr('⊉')
-	exec 'digraph (/ '.char2nr('⊄')
-	exec 'digraph )/ '.char2nr('⊅')
-	exec 'digraph )/ '.char2nr('⊅')
-	exec 'digraph U+ '.char2nr('⊎')
-	exec 'digraph 0- '.char2nr('⊖')
+	exec 'digraph \\ ' .. char2nr('∖')
+	exec 'digraph \< ' .. char2nr('≼')
+	exec 'digraph \> ' .. char2nr('≽')
+	exec 'digraph (L ' .. char2nr('⊈')
+	exec 'digraph )L ' .. char2nr('⊉')
+	exec 'digraph (/ ' .. char2nr('⊄')
+	exec 'digraph )/ ' .. char2nr('⊅')
+	exec 'digraph )/ ' .. char2nr('⊅')
+	exec 'digraph U+ ' .. char2nr('⊎')
+	exec 'digraph 0- ' .. char2nr('⊖')
 	" Euler's constant
-	exec 'digraph ne '.char2nr('𝑒')
+	exec 'digraph ne ' .. char2nr('𝑒')
 	" Raku's atomic operations marker
-	exec 'digraph @@ '.char2nr('⚛')
+	exec 'digraph @@ ' .. char2nr('⚛')
 
 Alternatively, you can write Insert mode abbreviations that convert ASCII-
 based operators into their single-character Unicode equivalent. >

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -26,7 +26,7 @@ behavior of the plugin.
 g:rustc_path~
 	Set this option to the path to rustc for use in the |:RustRun| and
 	|:RustExpand| commands. If unset, "rustc" will be located in $PATH: >
-	    let g:rustc_path = $HOME."/bin/rustc"
+	    let g:rustc_path = $HOME .. "/bin/rustc"
 <
 
                                                   *g:rustc_makeprg_no_percent*
@@ -87,7 +87,7 @@ g:rust_bang_comment_leader~
 g:ftplugin_rust_source_path~
 	Set this option to a path that should be prepended to 'path' for Rust
 	source files: >
-	    let g:ftplugin_rust_source_path = $HOME.'/dev/rust'
+	    let g:ftplugin_rust_source_path = $HOME .. '/dev/rust'
 <
 
                                                        *g:rustfmt_command*

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -109,8 +109,8 @@ must be configurable.  The filetype plugin attempts to define many of the
 standard objects, plus many additional ones.  In order to make this as
 flexible as possible, you can override the list of objects from within your
 |vimrc| with the following: >
-    let g:ftplugin_sql_objects = 'function,procedure,event,table,trigger' .
-		\ ',schema,service,publication,database,datatype,domain' .
+    let g:ftplugin_sql_objects = 'function,procedure,event,table,trigger' ..
+		\ ',schema,service,publication,database,datatype,domain' ..
 		\ ',index,subscription,synchronization,view,variable'
 
 The following |Normal| mode and |Visual| mode maps have been created which use
@@ -131,10 +131,10 @@ Repeatedly pressing ]} will cycle through each of these create statements: >
     create index i1 on t1 (c1);
 
 The default setting for g:ftplugin_sql_objects is: >
-    let g:ftplugin_sql_objects = 'function,procedure,event,' .
-		\ '\\(existing\\\\|global\\s\\+temporary\\s\\+\\)\\\{,1}' .
-		\ 'table,trigger' .
-		\ ',schema,service,publication,database,datatype,domain' .
+    let g:ftplugin_sql_objects = 'function,procedure,event,' ..
+		\ '\\(existing\\\\|global\\s\\+temporary\\s\\+\\)\\\{,1}' ..
+		\ 'table,trigger' ..
+		\ ',schema,service,publication,database,datatype,domain' ..
 		\ ',index,subscription,synchronization,view,variable'
 
 The above will also handle these cases: >

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -658,7 +658,7 @@ To see what version of Python is being used: >
 							*has-pythonx*
 To check if `pyx*` functions and commands are available: >
 	if has('pythonx')
-	  echo 'pyx* commands are available. (Python ' . &pyx . ')'
+	  echo 'pyx* commands are available. (Python ' .. &pyx .. ')'
 	endif
 
 ==============================================================================

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -864,7 +864,7 @@ Groß): >
 	    else
 		let res = []
 		let h = ''
-		for l in split(system('aiksaurus '.shellescape(a:base)), '\n')
+		for l in split(system('aiksaurus ' .. shellescape(a:base)), '\n')
 		    if l[:3] == '=== '
 		    	let h = substitute(l[4:], ' =*$', '', '')
 		    elseif l[0] =~ '\a'
@@ -1199,7 +1199,7 @@ An example that completes the names of the months: >
 	    " find months matching with "a:base"
 	    let res = []
 	    for m in split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec")
-	      if m =~ '^' . a:base
+	      if m =~ '^' .. a:base
 		call add(res, m)
 	      endif
 	    endfor
@@ -1221,7 +1221,7 @@ The same, but now pretending searching for matches is slow: >
 	  else
 	    " find months matching with "a:base"
 	    for m in split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec")
-	      if m =~ '^' . a:base
+	      if m =~ '^' .. a:base
 		call complete_add(m)
 	      endif
 	      sleep 300m	" simulate searching for next match

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -285,7 +285,7 @@ Here is an example that inserts a list number that increases: >
 
 	func ListItem()
 	  let g:counter += 1
-	  return g:counter . '. '
+	  return g:counter .. '. '
 	endfunc
 
 	func ListReset()
@@ -1489,12 +1489,12 @@ The valid escape sequences are
 		Examples: >
 		    command! -nargs=+ -complete=file MyEdit
 				\ for f in expand(<q-args>, 0, 1) |
-				\ exe '<mods> split ' . f |
+				\ exe '<mods> split ' .. f |
 				\ endfor
 
 		    function! SpecialEdit(files, mods)
 			for f in expand(a:files, 0, 1)
-			    exe a:mods . ' split ' . f
+			    exe a:mods .. ' split ' .. f
 			endfor
 		    endfunction
 		    command! -nargs=+ -complete=file Sedit
@@ -1570,7 +1570,7 @@ This will invoke: >
    :   let i = 0
    :   while i < argc()
    :	  if filereadable(argv(i))
-   :	     execute "e " . argv(i)
+   :	     execute "e " .. argv(i)
    :	     execute a:command
    :      endif
    :      let i = i + 1

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -993,7 +993,7 @@ These commands are not marks themselves, but jump to a mark:
 				:let lnum = line(".")
 				:keepjumps normal gg
 				:call SetLastChange()
-				:keepjumps exe "normal " . lnum . "G"
+				:keepjumps exe "normal " .. lnum .. "G"
 <
 			Note that ":keepjumps" must be used for every command.
 			When invoking a function the commands in that function

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -897,7 +897,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If you like to keep a lot of backups, you could use a BufWritePre
 	autocommand to change 'backupext' just before writing the file to
 	include a timestamp. >
-		:au BufWritePre * let &bex = '-' . strftime("%Y%b%d%X") . '~'
+		:au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
 <	Use 'backupdir' to put the backup in a different directory.
 
 						*'backupskip'* *'bsk'*
@@ -920,7 +920,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	Note that environment variables are not expanded.  If you want to use
 	$HOME you must expand it explicitly, e.g.: >
-		:let backupskip = escape(expand('$HOME'), '\') . '/tmp/*'
+		:let backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
 
 <	Note that the default also makes sure that "crontab -e" works (when a
 	backup would be made by renaming the original file crontab won't see
@@ -1185,7 +1185,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If the default value taken from $CDPATH is not what you want, include
 	a modified version of the following command in your vimrc file to
 	override it: >
-	  :let &cdpath = ',' . substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
+	  :let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
 <	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 	(parts of 'cdpath' can be passed to the shell to expand file names).
@@ -1232,8 +1232,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		set charconvert=CharConvert()
 		fun CharConvert()
 		  system("recode "
-			\ . v:charconvert_from . ".." . v:charconvert_to
-			\ . " <" . v:fname_in . " >" v:fname_out)
+			\ .. v:charconvert_from .. ".." .. v:charconvert_to
+			\ .. " <" .. v:fname_in .. " >" .. v:fname_out)
 		  return v:shell_error
 		endfun
 <	The related Vim variables are:
@@ -3620,7 +3620,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	Language to use for menu translation.  Tells which file is loaded
 	from the "lang" directory in 'runtimepath': >
-		"lang/menu_" . &langmenu . ".vim"
+		"lang/menu_" .. &langmenu .. ".vim"
 <	(without the spaces).  For example, to always use the Dutch menus, no
 	matter what $LANG is set to: >
 		:set langmenu=nl_NL.ISO_8859-1
@@ -4522,7 +4522,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	To use an environment variable, you probably need to replace the
 	separator.  Here is an example to append $INCL, in which directory
 	names are separated with a semi-colon: >
-		:let &path = &path . "," . substitute($INCL, ';', ',', 'g')
+		:let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
 <	Replace the ';' with a ':' or whatever separator is used.  Note that
 	this doesn't work when $INCL contains a comma or white space.
 
@@ -6570,7 +6570,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option cannot be set in a modeline when 'modelineexpr' is off.
 
 	Example: >
-	    :auto BufEnter * let &titlestring = hostname() . "/" . expand("%:p")
+	    :auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
 	    :set title titlestring=%<%F%=%l/%L-%P titlelen=70
 <	The value of 'titlelen' is used to align items in the middle or right
 	of the available space.

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -923,7 +923,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	update the matches.  This means Syntax highlighting quickly becomes
 	wrong.
 	Example, to highlight the line where the cursor currently is: >
-		:exe '/\%' . line(".") . 'l.*'
+		:exe '/\%' .. line(".") .. 'l.*'
 <	When 'hlsearch' is set and you move the cursor around and make changes
 	this will clearly show when the match is updated or not.
 
@@ -939,7 +939,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	update the matches.  This means Syntax highlighting quickly becomes
 	wrong.
 	Example, to highlight the column where the cursor currently is: >
-		:exe '/\%' . col(".") . 'c'
+		:exe '/\%' .. col(".") .. 'c'
 <	When 'hlsearch' is set and you move the cursor around and make changes
 	this will clearly show when the match is updated or not.
 	Example for matching a single byte in column 44: >

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -968,7 +968,7 @@ itself:
      fun! NetReadFixup(method, line1, line2)
        if method == 3   " ftp (no <.netrc>)
         let fourblanklines= line2 - 3
-        silent fourblanklines.",".line2."g/^\s*/d"
+        silent fourblanklines .. "," .. line2 .. "g/^\s*/d"
        endif
      endfunction
     endif
@@ -1975,7 +1975,7 @@ To use this function, simply assign its output to |g:netrw_list_hide| option.  >
 	Example: let g:netrw_list_hide= netrw_gitignore#Hide('my_gitignore_file')
 		Function can take additional files with git-ignore patterns.
 
-	Example: g:netrw_list_hide= netrw_gitignore#Hide() . '.*\.swp$'
+	Example: let g:netrw_list_hide= netrw_gitignore#Hide() .. '.*\.swp$'
 		Combining 'netrw_gitignore#Hide' with custom patterns.
 <
 
@@ -2824,7 +2824,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 
 				Examples:
 				 let g:netrw_list_hide= '.*\.swp$'
-				 let g:netrw_list_hide= netrw_gitignore#Hide().'.*\.swp$'
+				 let g:netrw_list_hide= netrw_gitignore#Hide() .. '.*\.swp$'
 				default: ""
 
   *g:netrw_localcopycmd*	="cp"           Linux/Unix/MacOS/Cygwin

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -127,21 +127,21 @@ file: >
     system(['lpr']
            + (empty(&printdevice)?[]:['-P', &printdevice])
            + [v:fname_in])
-    . delete(v:fname_in)
+    .. delete(v:fname_in)
     + v:shell_error
 
 On MS-Dos and MS-Windows machines the default is to copy the file to the
 currently specified printdevice: >
 
     system(['copy', v:fname_in, empty(&printdevice)?'LPT1':&printdevice])
-    . delete(v:fname_in)
+    .. delete(v:fname_in)
 
 If you change this option, using a function is an easy way to avoid having to
 escape all the spaces.  Example: >
 
 	:set printexpr=PrintFile(v:fname_in)
 	:function PrintFile(fname)
-	:  call system("ghostview " . a:fname)
+	:  call system("ghostview " .. a:fname)
 	:  call delete(a:fname)
 	:  return v:shell_error
 	:endfunc

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -341,7 +341,7 @@ processing a quickfix or location list command, it will be aborted.
 			cursor position will not be changed. See |:cexpr| for
 			more information.
 			Example: >
-    :g/mypattern/caddexpr expand("%") . ":" . line(".") .  ":" . getline(".")
+    :g/mypattern/caddexpr expand("%") .. ":" .. line(".") ..  ":" .. getline(".")
 <
 						*:lad* *:addd* *:laddexpr*
 :lad[dexpr] {expr}	Same as ":caddexpr", except the location list for the
@@ -641,6 +641,24 @@ quickfix window.  If there already is a window for that file, it is used
 instead.  If the buffer in the used window has changed, and the error is in
 another file, jumping to the error will fail.  You will first have to make
 sure the window contains a buffer which can be abandoned.
+
+The following steps are used to find a window to open the file selected from
+the quickfix window:
+1. If 'switchbuf' contains "usetab", then find a window in any tabpage
+   (starting with the first tabpage) that has the selected file and jump to
+   it.
+2. Otherwise find a window displaying the selected file in the current tab
+   page (starting with the window before the quickfix window) and use it.
+3. Otherwise find a window displaying a normal buffer ('buftype' is empty)
+   starting with the window before the quickfix window. If a window is found,
+   open the file in that window.
+4. If a usable window is not found and 'switchbuf' contains "uselast", then
+   open the file in the last used window.
+5. Otherwise open the file in the window before the quickfix window.  If there
+   is no previous window, then open the file in the next window.
+6. If a usable window is not found in the above steps, then create a new
+   horizontally split window above the quickfix window and open the file.
+
 					*CTRL-W_<Enter>* *CTRL-W_<CR>*
 You can use CTRL-W <Enter> to open a new window and jump to the error there.
 
@@ -650,7 +668,7 @@ FileType event (also see |qf.vim|).  Then the BufReadPost event is triggered,
 using "quickfix" for the buffer name.  This can be used to perform some action
 on the listed errors.  Example: >
 	au BufReadPost quickfix  setlocal modifiable
-		\ | silent exe 'g/^/s//\=line(".")." "/'
+		\ | silent exe 'g/^/s//\=line(".") .. " "/'
 		\ | setlocal nomodifiable
 This prepends the line number to each line.  Note the use of "\=" in the
 substitute string of the ":s" command, which is used to evaluate an

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -87,7 +87,7 @@ the delete is undone the sign does not move back.
 Here is an example that places a sign "piet", displayed with the text ">>", in
 line 23 of the current file: >
 	:sign define piet text=>> texthl=Search
-	:exe ":sign place 2 line=23 name=piet file=" . expand("%:p")
+	:exe ":sign place 2 line=23 name=piet file=" .. expand("%:p")
 
 And here is the command to delete it again: >
 	:sign unplace 2

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -120,8 +120,8 @@ zuG			Undo |zW| and |zG|, remove the word from the internal
 			rare as this is a fairly uncommon command and all
 			intuitive commands for this are already taken. If you
 			want you can add mappings with e.g.: >
-		nnoremap z?  :exe ':spellrare  ' . expand('<cWORD>')<CR>
-		nnoremap z/  :exe ':spellrare! ' . expand('<cWORD>')<CR>
+		nnoremap z?  :exe ':spellrare  ' .. expand('<cWORD>')<CR>
+		nnoremap z/  :exe ':spellrare! ' .. expand('<cWORD>')<CR>
 <			|:spellundo|, |zuw|, or |zuW| can be used to undo this.
 
 :spellr[rare]! {word}	Add {word} as a rare word to the internal word

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -800,7 +800,7 @@ resulting file, when executed with a ":source" command:
 After restoring the Session, the full filename of your current Session is
 available in the internal variable |v:this_session|.
 An example mapping: >
-  :nmap <F2> :wa<Bar>exe "mksession! " . v:this_session<CR>:so ~/sessions/
+  :nmap <F2> :wa<Bar>exe "mksession! " .. v:this_session<CR>:so ~/sessions/
 This saves the current Session, and starts off the command to load another.
 
 A session includes all tab pages, unless "tabpages" was removed from

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -616,7 +616,7 @@ evaluate to get a unique string to append to each ID used in a given document,
 so that the full IDs will be unique even when combined with other content in a
 larger HTML document. Example, to append _ and the buffer number to each ID: >
 
-	:let g:html_id_expr = '"_".bufnr("%")'
+	:let g:html_id_expr = '"_" .. bufnr("%")'
 <
 To append a string "_mystring" to the end of each ID: >
 
@@ -3550,8 +3550,8 @@ Do you want to draw with the mouse?  Try the following: >
    :function! GetPixel()
    :   let c = getline(".")[col(".") - 1]
    :   echo c
-   :   exe "noremap <LeftMouse> <LeftMouse>r".c
-   :   exe "noremap <LeftDrag>	<LeftMouse>r".c
+   :   exe "noremap <LeftMouse> <LeftMouse>r" .. c
+   :   exe "noremap <LeftDrag>	<LeftMouse>r" .. c
    :endfunction
    :noremap <RightMouse> <LeftMouse>:call GetPixel()<CR>
    :set guicursor=n:hor20	   " to see the color beneath the cursor
@@ -5363,9 +5363,9 @@ types.vim: *.[ch]
 And put these lines in your vimrc: >
 
    " load the types.vim highlighting file, if it exists
-   autocmd BufRead,BufNewFile *.[ch] let fname = expand('<afile>:p:h') . '/types.vim'
+   autocmd BufRead,BufNewFile *.[ch] let fname = expand('<afile>:p:h') .. '/types.vim'
    autocmd BufRead,BufNewFile *.[ch] if filereadable(fname)
-   autocmd BufRead,BufNewFile *.[ch]   exe 'so ' . fname
+   autocmd BufRead,BufNewFile *.[ch]   exe 'so ' .. fname
    autocmd BufRead,BufNewFile *.[ch] endif
 
 ==============================================================================

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -366,24 +366,24 @@ pages and define labels for them.  Then get the label for each tab page. >
 	  for i in range(tabpagenr('$'))
 	    " select the highlighting
 	    if i + 1 == tabpagenr()
-	      let s .= '%#TabLineSel#'
+	      let s ..= '%#TabLineSel#'
 	    else
-	      let s .= '%#TabLine#'
+	      let s ..= '%#TabLine#'
 	    endif
 
 	    " set the tab page number (for mouse clicks)
-	    let s .= '%' . (i + 1) . 'T'
+	    let s ..= '%' .. (i + 1) .. 'T'
 
 	    " the label is made by MyTabLabel()
-	    let s .= ' %{MyTabLabel(' . (i + 1) . ')} '
+	    let s ..= ' %{MyTabLabel(' .. (i + 1) .. ')} '
 	  endfor
 
 	  " after the last tab fill with TabLineFill and reset tab page nr
-	  let s .= '%#TabLineFill#%T'
+	  let s ..= '%#TabLineFill#%T'
 
 	  " right-align the label to close the current tab page
 	  if tabpagenr('$') > 1
-	    let s .= '%=%#TabLine#%999Xclose'
+	    let s ..= '%=%#TabLine#%999Xclose'
 	  endif
 
 	  return s
@@ -446,14 +446,14 @@ windows in the tab page and a '+' if there is a modified buffer: >
 	  " Append the number of windows in the tab page if more than one
 	  let wincount = tabpagewinnr(v:lnum, '$')
 	  if wincount > 1
-	    let label .= wincount
+	    let label ..= wincount
 	  endif
 	  if label != ''
-	    let label .= ' '
+	    let label ..= ' '
 	  endif
 
 	  " Append the buffer name
-	  return label . bufname(bufnrlist[tabpagewinnr(v:lnum) - 1])
+	  return label .. bufname(bufnrlist[tabpagewinnr(v:lnum) - 1])
 	endfunction
 
 	set guitablabel=%{GuiTabLabel()}

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -705,7 +705,7 @@ matches the pattern "^# *define" it is not considered to be a comment.
 If you want to list matches, and then select one to jump to, you could use a
 mapping to do that for you.  Here is an example: >
 
-  :map <F4> [I:let nr = input("Which one: ")<Bar>exe "normal " . nr ."[\t"<CR>
+  :map <F4> [I:let nr = input("Which one: ")<Bar>exe "normal " .. nr .. "[\t"<CR>
 <
 							*[i*
 [i			Display the first line that contains the keyword

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -321,7 +321,7 @@ an #if/#else/#endif block, the selection becomes linewise.
 For MS-Windows and xterm the time for double clicking can be set with the
 'mousetime' option. For the other systems this time is defined outside of Vim.
 An example, for using a double click to jump to the tag under the cursor: >
-	:map <2-LeftMouse> :exe "tag ". expand("<cword>")<CR>
+	:map <2-LeftMouse> :exe "tag " .. expand("<cword>")<CR>
 
 Dragging the mouse with a double click (button-down, button-up, button-down
 and then drag) will result in whole words to be selected.  This continues

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -84,14 +84,14 @@ What you need:
   create it with the shell command "mkid file1 file2 ..".
 
 Put this in your |init.vim|: >
-	map _u :call ID_search()<Bar>execute "/\\<" . g:word . "\\>"<CR>
-	map _n :n<Bar>execute "/\\<" . g:word . "\\>"<CR>
+	map _u :call ID_search()<Bar>execute "/\\<" .. g:word .. "\\>"<CR>
+	map _n :n<Bar>execute "/\\<" .. g:word .. "\\>"<CR>
 
 	function! ID_search()
 	  let g:word = expand("<cword>")
-	  let x = system("lid --key=none ". g:word)
+	  let x = system("lid --key=none " .. g:word)
 	  let x = substitute(x, "\n", " ", "g")
-	  execute "next " . x
+	  execute "next " .. x
 	endfun
 
 To use it, place the cursor on a word, type "_u" and vim will load the file
@@ -285,13 +285,13 @@ This mapping will format any bullet list.  It requires that there is an empty
 line above and below each list entry.  The expression commands are used to
 be able to give comments to the parts of the mapping. >
 
-	:let m =     ":map _f  :set ai<CR>"    " need 'autoindent' set
-	:let m = m . "{O<Esc>"		      " add empty line above item
-	:let m = m . "}{)^W"		      " move to text after bullet
-	:let m = m . "i     <CR>     <Esc>"    " add space for indent
-	:let m = m . "gq}"		      " format text after the bullet
-	:let m = m . "{dd"		      " remove the empty line
-	:let m = m . "5lDJ"		      " put text after bullet
+	:let m =     ":map _f  :set ai<CR>"   " need 'autoindent' set
+	:let m ..= "{O<Esc>"		      " add empty line above item
+	:let m ..= "}{)^W"		      " move to text after bullet
+	:let m ..= "i     <CR>     <Esc>"     " add space for indent
+	:let m ..= "gq}"		      " format text after the bullet
+	:let m ..= "{dd"		      " remove the empty line
+	:let m ..= "5lDJ"		      " put text after bullet
 	:execute m			      |" define the mapping
 
 (<> notation |<>|.  Note that this is all typed literally.  ^W is "^" "W", not
@@ -429,15 +429,15 @@ A slightly more advanced version is used in the |matchparen| plugin.
 	    let c = '\['
 	    let c2 = '\]'
 	  endif
-	  let s_skip ='synIDattr(synID(line("."), col("."), 0), "name") ' .
+	  let s_skip ='synIDattr(synID(line("."), col("."), 0), "name") ' ..
 		\ '=~?	"string\\|comment"'
 	  execute 'if' s_skip '| let s_skip = 0 | endif'
 
 	  let [m_lnum, m_col] = searchpairpos(c, '', c2, s_flags, s_skip)
 
 	  if m_lnum > 0 && m_lnum >= line('w0') && m_lnum <= line('w$')
-	    exe 'match Search /\(\%' . c_lnum . 'l\%' . c_col .
-		  \ 'c\)\|\(\%' . m_lnum . 'l\%' . m_col . 'c\)/'
+	    exe 'match Search /\(\%' .. c_lnum .. 'l\%' .. c_col ..
+		  \ 'c\)\|\(\%' .. m_lnum .. 'l\%' .. m_col .. 'c\)/'
 	    let s:paren_hl_on = 1
 	  endif
 	endfunction

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -272,12 +272,12 @@ history file.  E.g.: >
 	au BufReadPost * call ReadUndo()
 	au BufWritePost * call WriteUndo()
 	func ReadUndo()
-	  if filereadable(expand('%:h'). '/UNDO/' . expand('%:t'))
+	  if filereadable(expand('%:h') .. '/UNDO/' .. expand('%:t'))
 	    rundo %:h/UNDO/%:t
 	  endif
 	endfunc
 	func WriteUndo()
-	  let dirname = expand('%:h') . '/UNDO'
+	  let dirname = expand('%:h') .. '/UNDO'
 	  if !isdirectory(dirname)
 	    call mkdir(dirname)
 	  endif

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -131,7 +131,7 @@ it worked before Vim 5.0.  Otherwise the "Q" command starts Ex mode, but you
 will not need it.
 
 >
-	vnoremap _g y:exe "grep /" . escape(@", '\\/') . "/ *.c *.h"<CR>
+	vnoremap _g y:exe "grep /" .. escape(@", '\\/') .. "/ *.c *.h"<CR>
 
 This mapping yanks the visually selected text and searches for it in C files.
 This is a complicated mapping.  You can see that mappings can be used to do

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -275,7 +275,7 @@ g8			Print the hex values of the bytes used in the
 			Special characters are not escaped, use quotes or
 			|shellescape()|: >
 				:!ls "%"
-				:exe "!ls " . shellescape(expand("%"))
+				:exe "!ls " .. shellescape(expand("%"))
 <
 			Newline character ends {cmd} unless a backslash
 			precedes the newline.  What follows is interpreted as
@@ -432,7 +432,7 @@ g8			Print the hex values of the bytes used in the
 			used.  In this example |:silent| is used to avoid the
 			message about reading the file and |:unsilent| to be
 			able to list the first line of each file. >
-    		:silent argdo unsilent echo expand('%') . ": " . getline(1)
+    		:silent argdo unsilent echo expand('%') .. ": " .. getline(1)
 <
 
 						*:verb* *:verbose*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -447,7 +447,7 @@ These commands can also be executed with ":wincmd":
 		the |CursorHold| autocommand event).  Or when a Normal mode
 		command is inconvenient.
 		The count can also be a window number.  Example: >
-			:exe nr . "wincmd w"
+			:exe nr .. "wincmd w"
 <		This goes to window "nr".
 
 ==============================================================================
@@ -909,12 +909,12 @@ CTRL-W g }						*CTRL-W_g}*
 		cursor.  This is less clever than using |:ptag|, but you don't
 		need a tags file and it will also find matches in system
 		include files.  Example: >
-  :au! CursorHold *.[ch] ++nested exe "silent! psearch " . expand("<cword>")
+  :au! CursorHold *.[ch] ++nested exe "silent! psearch " .. expand("<cword>")
 <		Warning: This can be slow.
 
 Example						*CursorHold-example*  >
 
-  :au! CursorHold *.[ch] ++nested exe "silent! ptag " . expand("<cword>")
+  :au! CursorHold *.[ch] ++nested exe "silent! ptag " .. expand("<cword>")
 
 This will cause a ":ptag" to be executed for the keyword under the cursor,
 when the cursor hasn't moved for the time set with 'updatetime'.  "++nested"
@@ -937,14 +937,14 @@ is no word under the cursor, and a few other things: >
   :
   :    " Delete any existing highlight before showing another tag
   :    silent! wincmd P			" jump to preview window
-  :    if &previewwindow			" if we really get there...
+  :    if &previewwindow		" if we really get there...
   :      match none			" delete existing highlight
   :      wincmd p			" back to old window
   :    endif
   :
   :    " Try displaying a matching tag for the word under the cursor
   :    try
-  :       exe "ptag " . w
+  :       exe "ptag " .. w
   :    catch
   :      return
   :    endtry
@@ -956,10 +956,10 @@ is no word under the cursor, and a few other things: >
   :	 endif
   :	 call search("$", "b")		" to end of previous line
   :	 let w = substitute(w, '\\', '\\\\', "")
-  :	 call search('\<\V' . w . '\>')	" position cursor on match
+  :	 call search('\<\V' .. w .. '\>')	" position cursor on match
   :	 " Add a match highlight to the word at this position
   :      hi previewWord term=bold ctermbg=green guibg=green
-  :	 exe 'match previewWord "\%' . line(".") . 'l\%' . col(".") . 'c\k*"'
+  :	 exe 'match previewWord "\%' .. line(".") .. 'l\%' .. col(".") .. 'c\k*"'
   :      wincmd p			" back to old window
   :    endif
   :  endif

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Vim script
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Nov 27
+" Last Change:	2022 Feb 23
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -10,7 +10,7 @@ endif
 let b:did_indent = 1
 
 setlocal indentexpr=GetVimIndent()
-setlocal indentkeys+==end,=},=else,=cat,=finall,=END,0\\,0=\"\\\ 
+setlocal indentkeys+==endif,=enddef,=endfu,=endfor,=endwh,=endtry,=},=else,=cat,=finall,=END,0\\,0=\"\\\ 
 setlocal indentkeys-=0#
 setlocal indentkeys-=:
 
@@ -103,10 +103,11 @@ function GetVimIndentIntern()
     " A line starting with :au does not increment/decrement indent.
     " A { may start a block or a dict.  Assume that when a } follows it's a
     " terminated dict.
+    " ":function" starts a block but "function(" doesn't.
     if prev_text !~ '^\s*au\%[tocmd]' && prev_text !~ '^\s*{.*}'
-      let i = match(prev_text, '\(^\||\)\s*\(export\s\+\)\?\({\|\(if\|wh\%[ile]\|for\|try\|cat\%[ch]\|fina\|finall\%[y]\|fu\%[nction]\|def\|el\%[seif]\)\>\)')
+      let i = match(prev_text, '\(^\||\)\s*\(export\s\+\)\?\({\|\(if\|wh\%[ile]\|for\|try\|cat\%[ch]\|fina\|finall\%[y]\|def\|el\%[seif]\)\>\|fu\%[nction]\s\)')
       if i >= 0
-	let ind += shiftwidth()
+        let ind += shiftwidth()
 	if strpart(prev_text, i, 1) == '|' && has('syntax_items')
 	      \ && synIDattr(synID(lnum, i, 1), "name") =~ '\(Comment\|String\|PatSep\)$'
 	  let ind -= shiftwidth()
@@ -170,10 +171,15 @@ function GetVimIndentIntern()
     let ind = ind + shiftwidth()
   endif
 
-  " Subtract a 'shiftwidth' on a :endif, :endwhile, :catch, :finally, :endtry,
-  " :endfun, :else and :augroup END.
-  if cur_text =~ '^\s*\(ene\@!\|cat\|finall\|el\|aug\%[roup]\s\+[eE][nN][dD]\)'
+  " Subtract a 'shiftwidth' on a :endif, :endwhile, :endfor, :catch, :finally,
+  " :endtry, :endfun, :enddef, :else and :augroup END.
+  " Although ":en" would be enough only match short command names as in
+  " 'indentkeys'.
+  if cur_text =~ '^\s*\(endif\|endwh\|endfor\|endtry\|endfu\|enddef\|cat\|finall\|else\|aug\%[roup]\s\+[eE][nN][dD]\)'
     let ind = ind - shiftwidth()
+    if ind < 0
+      let ind = 0
+    endif
   endif
 
   return ind


### PR DESCRIPTION
Update runtime files.
https://github.com/vim/vim/commit/c51cf0329809c7ae946c59d6f56699227efc9d1b

I think I got all the applicable "`.` -> `..`" changes?