### PR TITLE
smarter signcol invalidation

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -862,9 +862,12 @@ struct file_buffer {
                                 // may use a different synblock_T.
 
   sign_entry_T *b_signlist;     // list of placed signs
-  int b_signcols;               // last calculated number of sign columns
-  bool b_signcols_valid;        // calculated sign columns is valid
-  int b_signcols_max;           // Maximum value b_signcols is valid for.
+  struct {
+    int size;                   // last calculated number of sign columns
+    bool valid;                 // calculated sign columns is valid
+    linenr_T sentinel;          // a line number which is holding up the signcolumn
+    int max;                    // Maximum value size is valid for.
+  } b_signcols;
 
   Terminal *terminal;           // Terminal instance associated with the buffer
 

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -1,6 +1,7 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
+#include "nvim/buffer.h"
 #include "nvim/decoration.h"
 #include "nvim/extmark.h"
 #include "nvim/highlight.h"
@@ -67,11 +68,6 @@ void bufhl_add_hl_pos_offset(buf_T *buf, int src_id, int hl_id, lpos_T pos_start
 void decor_redraw(buf_T *buf, int row1, int row2, Decoration *decor)
 {
   if (row2 >= row1) {
-    if (decor && decor->sign_text) {
-      buf->b_signcols_valid = false;
-      changed_line_abv_curs();
-    }
-
     if (!decor || decor->hl_id || decor_has_sign(decor)) {
       redraw_buf_range_later(buf, row1+1, row2+1);
     }
@@ -98,6 +94,9 @@ void decor_remove(buf_T *buf, int row, int row2, Decoration *decor)
     if (decor_has_sign(decor)) {
       assert(buf->b_signs > 0);
       buf->b_signs--;
+    }
+    if (row2 >= row && decor->sign_text) {
+      buf_signcols_del_check(buf, row+1, row2+1);
     }
   }
   decor_free(decor);

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -147,6 +147,10 @@ revised:
     if (decor_has_sign(decor)) {
       buf->b_signs++;
     }
+    if (decor->sign_text) {
+      // TODO(lewis6991): smarter invalidation
+      buf_signcols_add_check(buf, NULL);
+    }
     decor_redraw(buf, row, end_row > -1 ? end_row : row, decor);
   }
 

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -196,7 +196,8 @@ static void insert_sign(buf_T *buf, sign_entry_T *prev, sign_entry_T *next, int 
   if (next != NULL) {
     next->se_prev = newsign;
   }
-  buf->b_signcols_valid = false;
+
+  buf_signcols_add_check(buf, newsign);
 
   if (prev == NULL) {
     // When adding first sign need to redraw the windows to create the
@@ -541,7 +542,6 @@ linenr_T buf_delsign(buf_T *buf, linenr_T atlnum, int id, char_u *group)
   sign_entry_T *next;    // the next sign in a b_signlist
   linenr_T lnum;       // line number whose sign was deleted
 
-  buf->b_signcols_valid = false;
   lastp = &buf->b_signlist;
   lnum = 0;
   for (sign = buf->b_signlist; sign != NULL; sign = next) {
@@ -554,6 +554,7 @@ linenr_T buf_delsign(buf_T *buf, linenr_T atlnum, int id, char_u *group)
         next->se_prev = sign->se_prev;
       }
       lnum = sign->se_lnum;
+      buf_signcols_del_check(buf, lnum, lnum);
       if (sign->se_group != NULL) {
         sign_group_unref(sign->se_group->sg_name);
       }
@@ -675,7 +676,7 @@ void buf_delete_signs(buf_T *buf, char_u *group)
       lastp = &sign->se_next;
     }
   }
-  buf->b_signcols_valid = false;
+  buf_signcols_del_check(buf, 1, MAXLNUM);
 }
 
 /// List placed signs for "rbuf".  If "rbuf" is NULL do it for all buffers.
@@ -737,14 +738,19 @@ void sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_a
   int is_fixed = 0;
   int signcol = win_signcol_configured(curwin, &is_fixed);
 
-  curbuf->b_signcols_valid = false;
+  bool delete = amount == MAXLNUM;
+
+  if (delete) {
+    buf_signcols_del_check(curbuf, line1, line2);
+  }
+
   lastp = &curbuf->b_signlist;
 
   for (sign = curbuf->b_signlist; sign != NULL; sign = next) {
     next = sign->se_next;
     new_lnum = sign->se_lnum;
     if (sign->se_lnum >= line1 && sign->se_lnum <= line2) {
-      if (amount != MAXLNUM) {
+      if (!delete) {
         new_lnum += amount;
       } else if (!is_fixed || signcol >= 2) {
         *lastp = next;


### PR DESCRIPTION
Previously `b_signcols` was invalidated whenever a sign was added/removed or when a buffer line was added/removed.

This change introduces a sentinel `linenr_T` into the buffer state which is a line number used to determine the signcolumn. With this information, we can invalidate the signcolumn less often. Now the signcolumn is only invalidated when a sign or line at the sentinel line number is removed.
