### PR TITLE
vim-patch:8.2.{0188,4463,4465}: fuzzy command line completion

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6978,6 +6978,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 'wildoptions' 'wop'	string	(default "pum,tagfile")
 			global
 	List of words that change how |cmdline-completion| is done.
+	  fuzzy		Use fuzzy matching to find completion matches. When
+			this value is specified, wildcard expansion will not
+			be used for completion.  The matches will be sorted by
+			the "best match" rather than alphabetically sorted.
+			This will find more matches than the wildcard
+			expansion. Currently fuzzy matching based completion
+			is not supported for file and directory names and
+			instead wildcard expansion is used.
 	  pum		Display the completion matches using the popupmenu
 			in the same style as the |ins-completion-menu|.
 	  tagfile	When using CTRL-D to list matching tags, the kind of

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -723,10 +723,11 @@ EXTERN int p_warn;              // 'warn'
 EXTERN char_u *p_wop;         // 'wildoptions'
 EXTERN unsigned wop_flags;
 #ifdef IN_OPTION_C
-static char *(p_wop_values[]) =  { "tagfile", "pum", NULL };
+static char *(p_wop_values[]) =  { "tagfile", "pum", "fuzzy", NULL };
 #endif
 #define WOP_TAGFILE             0x01
 #define WOP_PUM                 0x02
+#define WOP_FUZZY               0x04
 EXTERN long p_window;           // 'window'
 EXTERN char_u *p_wak;         // 'winaltkeys'
 EXTERN char_u *p_wig;         // 'wildignore'

--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -97,6 +97,14 @@ typedef struct searchstat {
   int last_maxcount;  // the max count of the last search
 } searchstat_T;
 
+/// Fuzzy matched string list item. Used for fuzzy match completion. Items are
+/// usually sorted by 'score'. The 'idx' member is used for stable-sort.
+typedef struct {
+  int idx;
+  char_u *str;
+  int score;
+} fuzmatch_str_T;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "search.h.generated.h"
 #endif

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -1,11 +1,13 @@
 source shared.vim
 source term_util.vim
 
+command -nargs=1 MissingFeature throw 'Skipped: ' .. <args> .. ' feature missing'
+
 " Command to check for the presence of a feature.
 command -nargs=1 CheckFeature call CheckFeature(<f-args>)
 func CheckFeature(name)
   if !has(a:name)
-    throw 'Skipped: ' .. a:name .. ' feature missing'
+    MissingFeature a:name
   endif
 endfunc
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -3,6 +3,19 @@
 source check.vim
 source screendump.vim
 
+func SetUp()
+  func SaveLastScreenLine()
+    let g:Sline = Screenline(&lines - 1)
+    return ''
+  endfunc
+  cnoremap <expr> <F4> SaveLastScreenLine()
+endfunc
+
+func TearDown()
+  delfunc SaveLastScreenLine
+  cunmap <F4>
+endfunc
+
 func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
   call feedkeys(":e Xtestf\t\r", "tx")

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1500,7 +1500,9 @@ func Test_wildoptions_fuzzy()
   call assert_equal('"syntax list mpar', @:)
   set wildoptions=fuzzy
   call feedkeys(":syntax list mpar\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"syntax list MatchParen', @:)
+  " Fuzzy match favours NvimParenthesis over MatchParen
+  " call assert_equal('"syntax list MatchParen', @:)
+  call assert_equal('"syntax list NvimParenthesis', @:)
 
   " :syntime suboptions fuzzy completion
   if has('profile')
@@ -1526,6 +1528,25 @@ func Test_wildoptions_fuzzy()
   set wildoptions=fuzzy
   call feedkeys(":let SVar\<Tab>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"let SomeVariable', @:)
+
+  " Test for sorting the results by the best match
+  %bw!
+  command T123format :
+  command T123goformat :
+  command T123TestFOrmat :
+  command T123fendoff :
+  command T123state :
+  command T123FendingOff :
+  set wildoptions=fuzzy
+  call feedkeys(":T123fo\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"T123format T123TestFOrmat T123FendingOff T123goformat T123fendoff', @:)
+  delcommand T123format
+  delcommand T123goformat
+  delcommand T123TestFOrmat
+  delcommand T123fendoff
+  delcommand T123state
+  delcommand T123FendingOff
+  %bw
 
   set wildoptions&
   %bw!


### PR DESCRIPTION
WIP; these patches work, but https://github.com/vim/vim/commit/4df5b33f206210fec2a0297aea27e7db8b5173c0 also needs porting (+ general cleanup and whatever)

also depends on #17488 due to Test_cmdwin_tabpage being included in v8.2.4463; i'll probably move it over to that PR instead tbh

TODO: integrate https://github.com/vim/vim/commit/1588bc8ebee22f2855f27273fc2234fff370f86c#diff-f35d708d4c55517f9599b4a8f7a37a2089f32f421791055318bf1a3529b7abd9R1567-R1571 and the other stuff there