### PR TITLE
refactor: fix clang-tidy bugprone-signed-char-misuse warnings

### DIFF
--- a/src/cjson/lua_cjson.c
+++ b/src/cjson/lua_cjson.c
@@ -1110,7 +1110,7 @@ static int json_is_invalid_number(json_parse_t *json)
 
     /* Reject numbers starting with 0x, or leading zeros */
     if (*p == '0') {
-        int ch2 = *(p + 1);
+        char ch2 = *(p + 1);
 
         if ((ch2 | 0x20) == 'x' ||          /* Hex */
             ('0' <= ch2 && ch2 <= '9'))     /* Leading zero */

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1500,7 +1500,7 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len, cons
   } else if ((what & (STR2NR_HEX | STR2NR_OCT | STR2NR_OOCT | STR2NR_BIN))
              && !STRING_ENDED(ptr + 1) && ptr[0] == '0' && ptr[1] != '8'
              && ptr[1] != '9') {
-    pre = ptr[1];
+    pre = (char_u)ptr[1];
     // Detect hexadecimal: 0x or 0X followed by hex digit.
     if ((what & STR2NR_HEX)
         && !STRING_ENDED(ptr + 2)

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -201,7 +201,7 @@ void do_debug(char_u *cmd)
         if (last_cmd != 0) {
           // Check that the tail matches.
           p++;
-          while (*p != NUL && *p == *tail) {
+          while (*p != NUL && *p == (char_u)(*tail)) {
             p++;
             tail++;
           }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7776,7 +7776,7 @@ int hkmap(int c)
     case ';':
       c = 't'; break;
     default: {
-      static char str[] = "zqbcxlsjphmkwonu ydafe rig";
+      static char_u str[] = "zqbcxlsjphmkwonu ydafe rig";
 
       if (c < 'a' || c > 'z') {
         return c;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4858,7 +4858,6 @@ int get_option_tv(const char **const arg, typval_T *const rettv, const bool eval
   long numval;
   char_u *stringval;
   int opt_type;
-  int c;
   bool working = (**arg == '+');  // has("+option")
   int ret = OK;
   int opt_flags;
@@ -4877,7 +4876,7 @@ int get_option_tv(const char **const arg, typval_T *const rettv, const bool eval
     return OK;
   }
 
-  c = *option_end;
+  char c = *option_end;
   *option_end = NUL;
   opt_type = get_option_value(*arg, &numval,
                               rettv == NULL ? NULL : &stringval, opt_flags);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8296,7 +8296,7 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
   // Repeat until {skip} returns false.
   for (;;) {
     subpatnum
-        = searchit(curwin, curbuf, &pos, NULL, dir, (char_u *)pat, 1, options, RE_SEARCH, &sia);
+      = searchit(curwin, curbuf, &pos, NULL, dir, (char_u *)pat, 1, options, RE_SEARCH, &sia);
     // finding the first match again means there is no match where {skip}
     // evaluates to zero.
     if (firstpos.lnum != 0 && equalpos(pos, firstpos)) {
@@ -9339,7 +9339,7 @@ static void set_qf_ll_list(win_T *wp, typval_T *args, typval_T *rettv)
 {
   static char *e_invact = N_("E927: Invalid action: '%s'");
   const char *title = NULL;
-  int action = ' ';
+  char action = ' ';
   static int recursive = 0;
   rettv->vval.v_number = -1;
   dict_T *what = NULL;
@@ -9569,7 +9569,6 @@ static int get_yank_type(char_u **const pp, MotionType *const yank_type, long *c
  */
 static void f_setreg(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  int regname;
   bool append = false;
   MotionType yank_type;
   long block_len;
@@ -9583,13 +9582,13 @@ static void f_setreg(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (strregname == NULL) {
     return;  // Type error; errmsg already given.
   }
-  regname = (uint8_t)(*strregname);
+  char regname = (uint8_t)(*strregname);
   if (regname == 0 || regname == '@') {
     regname = '"';
   }
 
   const typval_T *regcontents = NULL;
-  int pointreg = 0;
+  char pointreg = 0;
   if (argvars[1].v_type == VAR_DICT) {
     dict_T *const d = argvars[1].vval.v_dict;
 
@@ -9759,7 +9758,7 @@ static void f_settagstack(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   static char *e_invact2 = N_("E962: Invalid action: '%s'");
   win_T *wp;
   dict_T *d;
-  int action = 'r';
+  char action = 'r';
 
   rettv->vval.v_number = -1;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -80,7 +80,7 @@
 
 static char *e_no_such_user_defined_command_str = N_("E184: No such user-defined command: %s");
 static char *e_no_such_user_defined_command_in_current_buffer_str
-    = N_("E1237: No such user-defined command in current buffer: %s");
+  = N_("E1237: No such user-defined command in current buffer: %s");
 
 static int quitmore = 0;
 static bool ex_pressedreturn = false;
@@ -2835,7 +2835,7 @@ int modifier_len(char_u *cmd)
   for (int i = 0; i < (int)ARRAY_SIZE(cmdmods); i++) {
     int j;
     for (j = 0; p[j] != NUL; j++) {
-      if (p[j] != cmdmods[i].name[j]) {
+      if (p[j] != (char_u)cmdmods[i].name[j]) {
         break;
       }
     }

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -1602,7 +1602,7 @@ void ex_endtry(exarg_T *eap)
 {
   int idx;
   bool rethrow = false;
-  int pending = CSTP_NONE;
+  char pending = CSTP_NONE;
   void *rettv = NULL;
   cstack_T *const cstack = eap->cstack;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1907,9 +1907,6 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   // complete match
   if (keylen >= 0 && keylen <= typebuf.tb_len) {
     char_u *map_str = NULL;
-    int save_m_expr;
-    int save_m_noremap;
-    int save_m_silent;
 
     // Write chars to script file(s).
     // Note: :lmap mappings are written *after* being applied. #5658
@@ -1946,9 +1943,9 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
     // Copy the values from *mp that are used, because evaluating the
     // expression may invoke a function that redefines the mapping, thereby
     // making *mp invalid.
-    save_m_expr = mp->m_expr;
-    save_m_noremap = mp->m_noremap;
-    save_m_silent = mp->m_silent;
+    char save_m_expr = mp->m_expr;
+    int save_m_noremap = mp->m_noremap;
+    char save_m_silent = mp->m_silent;
     char_u *save_m_keys = NULL;  // only saved when needed
     char_u *save_m_str = NULL;  // only saved when needed
     LuaRef save_m_luaref = mp->m_luaref;
@@ -2661,9 +2658,9 @@ int fix_input_buffer(char_u *buf, int len)
 /// @param[in] orig_rhs_len   `strlen` of orig_rhs.
 /// @param[in] cpo_flags  See param docs for @ref replace_termcodes.
 /// @param[out] mapargs   MapArguments struct holding the replaced strings.
-void set_maparg_lhs_rhs(const char_u *orig_lhs, const size_t orig_lhs_len,
-                        const char_u *orig_rhs, const size_t orig_rhs_len,
-                        LuaRef rhs_lua, int cpo_flags, MapArguments *mapargs)
+void set_maparg_lhs_rhs(const char_u *orig_lhs, const size_t orig_lhs_len, const char_u *orig_rhs,
+                        const size_t orig_rhs_len, LuaRef rhs_lua, int cpo_flags,
+                        MapArguments *mapargs)
 {
   char_u *lhs_buf = NULL;
   char_u *rhs_buf = NULL;
@@ -3988,7 +3985,7 @@ bool check_abbr(int c, char_u *ptr, int col, int mincol)
 /// special characters.
 ///
 /// @param c  NUL or typed character for abbreviation
-static char_u *eval_map_expr(mapblock_T  *mp, int c)
+static char_u *eval_map_expr(mapblock_T *mp, int c)
 {
   char_u *res;
   char_u *p = NULL;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -823,7 +823,6 @@ static void command_line_scan(mparm_T *parmp)
   bool had_stdin_file = false;          // found explicit "-" argument
   bool had_minmin = false;              // found "--" argument
   int want_argument;                    // option argument with argument
-  int c;
   long n;
 
   argc--;
@@ -845,7 +844,7 @@ static void command_line_scan(mparm_T *parmp)
       // Optional argument.
     } else if (argv[0][0] == '-' && !had_minmin) {
       want_argument = false;
-      c = argv[0][argv_idx++];
+      char c = argv[0][argv_idx++];
       switch (c) {
       case NUL:    // "nvim -"  read from stdin
         if (exmode_active) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1071,7 +1071,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char_u *pat, long count,
    * Find out the direction of the search.
    */
   if (dirc == 0) {
-    dirc = spats[0].off.dir;
+    dirc = (char_u)spats[0].off.dir;
   } else {
     spats[0].off.dir = dirc;
     set_vv_searchforward();

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -354,7 +354,7 @@ char *strcase_save(const char *const orig, bool upper)
     int l = utf_ptr2len((const char_u *)p);
     if (c == 0) {
       // overlong sequence, use only the first byte
-      c = *p;
+      c = (char_u)(*p);
       l = 1;
     }
     int uc = upper ? mb_toupper(c) : mb_tolower(c);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4208,7 +4208,7 @@ static char_u *get_syn_options(char_u *arg, syn_opt_arg_T *opt, int *conceal_cha
       p = flagtab[fidx].name;
       int i;
       for (i = 0, len = 0; p[i] != NUL; i += 2, ++len) {
-        if (arg[len] != p[i] && arg[len] != p[i + 1]) {
+        if (arg[len] != (char_u)p[i] && arg[len] != (char_u)p[i + 1]) {
           break;
         }
       }

--- a/test/unit/strings_spec.lua
+++ b/test/unit/strings_spec.lua
@@ -138,3 +138,15 @@ describe('vim_strchr()', function()
     eq(nil, vim_strchr('«\237\175\191\237\188\128»', 0x10FF00))
   end)
 end)
+
+describe('strcase_save()' , function()
+  local strcase_save = function(input_string, upper)
+    local res = strings.strcase_save(to_cstr(input_string), upper)
+    return ffi.string(res)
+  end
+
+  itp('decodes overlong encoded characters.', function()
+    eq("A", strcase_save("\xc1\x81", true))
+    eq("a", strcase_save("\xc1\x81", false))
+  end)
+end)


### PR DESCRIPTION
Prefer to declare variables with correct type instead of explicit casts
wherever possible.
