### PR TITLE
fix(ci): use bundled version of libluv also in lint build

### DIFF
--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -46,7 +46,6 @@ CLANG_SANITIZER=TSAN
 EOF
     ;;
   lint)
-    BUILD_FLAGS="$BUILD_FLAGS -DLIBLUV_LIBRARY:FILEPATH=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/lua/5.1/luv.so -DLIBLUV_INCLUDE_DIR:PATH=/usr/include/lua5.1"
     cat <<EOF >> "$GITHUB_ENV"
 USE_BUNDLED=OFF
 CI_TARGET=lint


### PR DESCRIPTION
Master versions of nvim only works with the bundled version of libluv,
as code is frequently co-developed.

ref https://github.com/neovim/neovim/pull/17386#issuecomment-1053541651