### PR TITLE
feat(man.vim): list flags in loclist. Fix loclist highlighting.

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -171,6 +171,12 @@ function! man#show_toc() abort
   while lnum && lnum < last_line
     let text = getline(lnum)
     if text =~# '^\%( \{3\}\)\=\S.*$'
+      " if text is a section title
+      call add(toc, {'bufnr': bufnr('%'), 'lnum': lnum, 'text': text})
+    elseif text =~# '^\s\+\%(+\|-\)\S\+'
+      " if text is a flag title. we strip whitespaces and prepend two
+      " spaces to have a consistent format in the loclist.
+      let text = '  ' .. substitute(text, '^\s*\(.\{-}\)\s*$', '\1', '')
       call add(toc, {'bufnr': bufnr('%'), 'lnum': lnum, 'text': text})
     endif
     let lnum = nextnonblank(lnum + 1)

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -10,7 +10,7 @@ syntax match manReference      display '[^()[:space:]]\+(\%([0-9][a-z]*\|[nlpox]
 syntax match manSectionHeading display '^\S.*$'
 syntax match manHeader         display '^\%1l.*$'
 syntax match manSubHeading     display '^ \{3\}\S.*$'
-syntax match manOptionDesc     display '^\s\+\%(+\|-\)\S\+'
+syntax match manOptionDesc     display '^\s\+\(\%(+\|-\)\S\+,\s\+\)*\%(+\|-\)\S\+'
 
 highlight default link manHeader         Title
 highlight default link manSectionHeading Statement


### PR DESCRIPTION
This PR introduces the following changes to the builtin man plugin:

* ~~A `show_flags` function to add flags to the loclist, binded by `gF`. Similar to the existing `gO` keybinding to show the man table of contents~~
* Currently, an example line that looks like:
```
-a, --all ...
```
  would only highlight the `-a`. This PR highlights `-a, --all`
* Do not add Man highlights to non-man pages. This was happening in the loclist buffer. (Try `gO` in a man page. Notice the first line is blue, and the rest are red)
