### PR TITLE
ci(freebsd): remove deprecated package sha to fix warning

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -5,7 +5,6 @@ packages:
 - gmake
 - ninja
 - libtool
-- sha
 - automake
 - pkgconf
 - unzip


### PR DESCRIPTION
It's already included by default, no need to replace it.
