### PR TITLE
refactor(lua): regularize builtin modules, phase 1

### DIFF
--- a/runtime/lua/vim/_load_package.lua
+++ b/runtime/lua/vim/_load_package.lua
@@ -47,3 +47,6 @@ end
 
 -- Insert vim._load_package after the preloader at position 2
 table.insert(package.loaders, 2, vim._load_package)
+
+-- should always be available
+vim.inspect = require'vim.inspect'

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -332,14 +332,14 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
       "LUAC_PRG=${LUAC_PRG}"
       ${LUA_PRG} ${CHAR_BLOB_GENERATOR} -c ${VIM_MODULE_FILE}
-      ${LUA_VIM_MODULE_SOURCE} vim_module
-      ${LUA_SHARED_MODULE_SOURCE} shared_module
-      ${LUA_INSPECT_MODULE_SOURCE} inspect_module
-      ${LUA_F_MODULE_SOURCE} lua_F_module
-      ${LUA_META_MODULE_SOURCE} lua_meta_module
-      ${LUA_FILETYPE_MODULE_SOURCE} lua_filetype_module
-      ${LUA_LOAD_PACKAGE_MODULE_SOURCE} lua_load_package_module
-      ${LUA_KEYMAP_MODULE_SOURCE} lua_keymap_module
+      ${LUA_LOAD_PACKAGE_MODULE_SOURCE} "vim._load_package"
+      ${LUA_INSPECT_MODULE_SOURCE} "vim.inspect"
+      ${LUA_VIM_MODULE_SOURCE} "vim"
+      ${LUA_SHARED_MODULE_SOURCE} "vim.shared"
+      ${LUA_F_MODULE_SOURCE} "vim.F"
+      ${LUA_META_MODULE_SOURCE} "vim._meta"
+      ${LUA_FILETYPE_MODULE_SOURCE} "vim.filetype"
+      ${LUA_KEYMAP_MODULE_SOURCE} "vim.keymap"
   DEPENDS
     ${CHAR_BLOB_GENERATOR}
     ${LUA_VIM_MODULE_SOURCE}

--- a/src/nvim/generators/gen_char_blob.lua
+++ b/src/nvim/generators/gen_char_blob.lua
@@ -28,16 +28,19 @@ local target = io.open(target_file, 'w')
 
 target:write('#include <stdint.h>\n\n')
 
+local index_items = {}
+
 local warn_on_missing_compiler = true
-local varnames = {}
+local modnames = {}
 for argi = 2, #arg, 2 do
   local source_file = arg[argi]
-  local varname = arg[argi + 1]
-  if varnames[varname] then
-    error(string.format("varname %q is already specified for file %q", varname, varnames[varname]))
+  local modname = arg[argi + 1]
+  if modnames[modname] then
+    error(string.format("modname %q is already specified for file %q", modname, modnames[modname]))
   end
-  varnames[varname] = source_file
+  modnames[modname] = source_file
 
+  local varname = string.gsub(modname,'%.','_dot_').."_module"
   target:write(('static const uint8_t %s[] = {\n'):format(varname))
 
   local output
@@ -78,6 +81,13 @@ for argi = 2, #arg, 2 do
   end
 
   target:write('  0};\n')
+  if modname ~= "_" then
+    table.insert(index_items, '  { "'..modname..'", '..varname..', sizeof '..varname..' },\n\n')
+  end
 end
+
+target:write('static ModuleDef builtin_modules[] = {\n')
+target:write(table.concat(index_items))
+target:write('};\n')
 
 target:close()

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -38,5 +38,6 @@ typedef struct {
 #endif
 
 EXTERN nlua_ref_state_t *nlua_global_refs INIT(= NULL);
+EXTERN bool nlua_disable_preload INIT(= false);
 
 #endif  // NVIM_LUA_EXECUTOR_H

--- a/src/nvim/lua/vim.lua
+++ b/src/nvim/lua/vim.lua
@@ -36,15 +36,7 @@
 
 local vim = vim
 assert(vim)
-
-vim.inspect = package.loaded['vim.inspect']
 assert(vim.inspect)
-
-vim.filetype = package.loaded['vim.filetype']
-assert(vim.filetype)
-
-vim.keymap = package.loaded['vim.keymap']
-assert(vim.keymap)
 
 -- These are for loading runtime modules lazily since they aren't available in
 -- the nvim binary as specified in executor.c
@@ -53,6 +45,9 @@ setmetatable(vim, {
     if key == 'treesitter' then
       t.treesitter = require('vim.treesitter')
       return t.treesitter
+    elseif key == 'filetype' then
+      t.filetype = require('vim.filetype')
+      return t.filetype
     elseif key == 'F' then
       t.F = require('vim.F')
       return t.F
@@ -69,6 +64,9 @@ setmetatable(vim, {
     elseif key == 'diagnostic' then
       t.diagnostic = require('vim.diagnostic')
       return t.diagnostic
+    elseif key == 'keymap' then
+      t.keymap = require('vim.keymap')
+      return t.keymap
     elseif key == 'ui' then
       t.ui = require('vim.ui')
       return t.ui
@@ -662,4 +660,7 @@ function vim.pretty_print(...)
   return ...
 end
 
-return module
+
+require('vim._meta')
+
+return vim

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -253,11 +253,11 @@ int main(int argc, char **argv)
   // Check if we have an interactive window.
   check_and_set_isatty(&params);
 
-  nlua_init();
-
   // Process the command line arguments.  File names are put in the global
   // argument list "global_alist".
   command_line_scan(&params);
+
+  nlua_init();
 
   if (embedded_mode) {
     const char *err;
@@ -918,6 +918,8 @@ static void command_line_scan(mparm_T *parmp)
           parmp->use_vimrc = "NONE";
           parmp->clean = true;
           set_option_value("shadafile", 0L, "NONE", 0);
+        } else if (STRNICMP(argv[0] + argv_idx, "luamod-dev", 9) == 0) {
+          nlua_disable_preload = true;
         } else {
           if (argv[0][argv_idx]) {
             mainerr(err_opt_unknown, argv[0]);
@@ -1990,6 +1992,8 @@ static void mainerr(const char *errstr, const char *str)
 /// Prints version information for "nvim -v" or "nvim --version".
 static void version(void)
 {
+  // TODO(bfred): not like this?
+  nlua_init();
   info_message = true;  // use mch_msg(), not mch_errmsg()
   list_version();
   msg_putchar('\n');

--- a/test/functional/lua/thread_spec.lua
+++ b/test/functional/lua/thread_spec.lua
@@ -102,6 +102,28 @@ describe('thread', function()
         print in thread                                   |
       ]])
     end)
+
+    it('vim.inspect', function()
+      exec_lua [[
+        local thread = vim.loop.new_thread(function()
+          print(vim.inspect({1,2}))
+        end)
+        vim.loop.thread_join(thread)
+      ]]
+
+      screen:expect([[
+        ^                                                  |
+        {1:~                                                 }|
+        {1:~                                                 }|
+        {1:~                                                 }|
+        {1:~                                                 }|
+        {1:~                                                 }|
+        {1:~                                                 }|
+        {1:~                                                 }|
+        {1:~                                                 }|
+        { 1, 2 }                                          |
+      ]])
+    end)
   end)
 
   describe('vim.*', function()


### PR DESCRIPTION
Over the times, neovim has accumulated more lua code that is considered "essential" and thus included as part of the binary. This aims to re-organized code so that instead of having a bunch of

```
  {
    const char *code = (char *)&shared_module[0];
    if (luaL_loadbuffer(lstate, code, sizeof(shared_module) - 1, "@vim/shared.lua")
        || nlua_pcall(lstate, 0, 0)) {
      nlua_error(lstate, _("E5106: Error while creating shared module: %.*s\n"));
      return;
    }
```

blocks spread all over the place, implement a proper pre-loader, so that builtin lua modules can be handled uniformly with modules in `runtime/`. In addition, this allows a "dev mode" where most (but not all) preloads are disabled, so it is possible to develop these modules by editing the source in `runtime/` and then re-invoke nvim without recompile.

I was considering doing larger reorganizations in light of #17386 and #17537 , though that could be separated into a follow-up PR, while this one only focuses on the change of _mechanism_.