### PR TITLE
fix: Respect os_proc_children rv of pid not found

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1991,7 +1991,7 @@ Array nvim_get_proc_children(Integer pid, Error *err)
 
   size_t proc_count;
   int rv = os_proc_children((int)pid, &proc_list, &proc_count);
-  if (rv != 0) {
+  if (rv == 2) {
     // syscall failed (possibly because of kernel options), try shelling out.
     DLOG("fallback to vim._os_proc_children()");
     Array a = ARRAY_DICT_INIT;


### PR DESCRIPTION
os_proc_children returns 2 if there's a failure in the underlying
syscall. Only shell out to pgrep in that case.

It returns 1 if the pid isn't found. In that case, we can roll forward
with returning an empty list.