### PR TITLE
fix(pty_process_win/wait_eof_timer_cb): also check for proc->out.did_eof

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -164,21 +164,17 @@ if (-not $NoTests) {
     exit $LastExitCode
   }
 
-  # FIXME: These tests freezes on github CI and causes all jobs to fail.
-  # Comment out until this is fixed.
-  
   # Old tests
   # Add MSYS to path, required for e.g. `find` used in test scripts.
   # But would break functionaltests, where its `more` would be used then.
-  
-  # $OldPath = $env:PATH
-  # $env:PATH = "C:\msys64\usr\bin;$env:PATH"
-  # & "C:\msys64\mingw$bits\bin\mingw32-make.exe" -C $(Convert-Path ..\src\nvim\testdir) VERBOSE=1 ; exitIfFailed
-  # $env:PATH = $OldPath
+  $OldPath = $env:PATH
+  $env:PATH = "C:\msys64\usr\bin;$env:PATH"
+  & "C:\msys64\mingw$bits\bin\mingw32-make.exe" -C $(Convert-Path ..\src\nvim\testdir) VERBOSE=1 ; exitIfFailed
+  $env:PATH = $OldPath
 
-  # if ($uploadToCodecov) {
-  #   bash -l /c/projects/neovim/ci/common/submit_coverage.sh oldtest
-  # }
+  if ($uploadToCodecov) {
+    bash -l /c/projects/neovim/ci/common/submit_coverage.sh oldtest
+  }
 }
 
 # Ensure choco's cpack is not in PATH otherwise, it conflicts with CMake's

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -281,7 +281,7 @@ static void wait_eof_timer_cb(uv_timer_t *wait_eof_timer)
   PtyProcess *ptyproc = wait_eof_timer->data;
   Process *proc = (Process *)ptyproc;
 
-  if (proc->out.closed || !uv_is_readable(proc->out.uvstream)) {
+  if (proc->out.closed || proc->out.did_eof || !uv_is_readable(proc->out.uvstream)) {
     uv_timer_stop(&ptyproc->wait_eof_timer);
     pty_process_finish2(ptyproc);
   }


### PR DESCRIPTION
This should fix the old test hangs.

Ref <https://github.com/libuv/libuv/commit/b2614a10a579ae6e9936eb483fe5ce14aa65a212>.