### PR TITLE
ci(freebsd): enable oldtests

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -35,10 +35,6 @@ tasks:
 - unittest: |
     cd neovim
     gmake unittest
-
-# Unfortunately, oldtest is tanking hard on sourcehut's FreeBSD instance
-# and not producing any logs as a result. So don't do this task for now.
-# Ref: https://github.com/neovim/neovim/pull/11477#discussion_r352095005.
-# - test-oldtest: |
-#     cd neovim
-#     gmake oldtest
+- oldtest: |
+    cd neovim
+    gmake oldtest


### PR DESCRIPTION
`Test_writefile_fails_conversion()` now passes. Guess it is because of the difference in libiconv version between FreeBSD 12.x and latest images.