### PR TITLE
refactor(autocmd): simplify check for freed callback

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2473,7 +2473,7 @@ bool aucmd_exec_is_deleted(AucmdExecutable acc)
   case CALLABLE_EX:
     return acc.callable.cmd == NULL;
   case CALLABLE_CB:
-    return callback_is_freed(acc.callable.cb);
+    return acc.callable.cb.type == kCallbackNone;
   case CALLABLE_NONE:
     return true;
   }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1155,27 +1155,6 @@ void callback_free(Callback *callback)
   callback->data.funcref = NULL;
 }
 
-/// Check if callback is freed
-bool callback_is_freed(Callback callback)
-{
-  switch (callback.type) {
-  case kCallbackFuncref:
-    return false;
-    break;
-  case kCallbackPartial:
-    return false;
-    break;
-  case kCallbackLua:
-    return callback.data.luaref == LUA_NOREF;
-    break;
-  case kCallbackNone:
-    return true;
-    break;
-  }
-
-  return true;
-}
-
 /// Copy a callback into a typval_T.
 void callback_put(Callback *cb, typval_T *tv)
   FUNC_ATTR_NONNULL_ALL


### PR DESCRIPTION
When a callback is freed the type is always set to kCallbackNone.