### PR TITLE
vim-patch:8.2.4498: using <Plug> with "noremap" does not work

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -65,8 +65,8 @@ modes.
 			where the map command applies.  Disallow mapping of
 			{rhs}, to avoid nested and recursive mappings.  Often
 			used to redefine a command.
-			Note: A mapping whose {lhs} starts with <Plug> is
-			always applied even if mapping is disallowed.
+			Note: When <Plug> appears in the {rhs} this part is
+			always applied even if remapping is disallowed.
 
 
 :unm[ap]  {lhs}			|mapmode-nvo|		*:unm*  *:unmap*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -358,10 +358,6 @@ Macro/|recording| behavior
   macros and 'keymap' at the same time. This also means you can use |:imap| on
   the results of keys from 'keymap'.
 
-Mappings:
-- A mapping whose {lhs} starts with <Plug> is always applied even if mapping
-  is disallowed by |nore|.
-
 Motion:
   The |jumplist| avoids useless/phantom jumps.
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1712,11 +1712,10 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   int local_State = get_real_state();
   bool is_plug_map = false;
 
-  // Check if typehead starts with a <Plug> mapping.
-  // In that case we will ignore nore flag on it.
+  // If typehead starts with <Plug> then remap, even for a "noremap" mapping.
   if (typebuf.tb_buf[typebuf.tb_off] == K_SPECIAL
-      && typebuf.tb_buf[typebuf.tb_off+1] == KS_EXTRA
-      && typebuf.tb_buf[typebuf.tb_off+2] == KE_PLUG) {
+      && typebuf.tb_buf[typebuf.tb_off + 1] == KS_EXTRA
+      && typebuf.tb_buf[typebuf.tb_off + 2] == KE_PLUG) {
     is_plug_map = true;
   }
 

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -646,4 +646,34 @@ func Test_abbreviate_multi_byte()
   bwipe!
 endfunc
 
+" Test for <Plug> always being mapped, even when used with "noremap".
+func Test_plug_remap()
+  let g:foo = 0
+  nnoremap <Plug>(Increase_x) <Cmd>let g:foo += 1<CR>
+  nmap <F2> <Plug>(Increase_x)
+  nnoremap <F3> <Plug>(Increase_x)
+  call feedkeys("\<F2>", 'xt')
+  call assert_equal(1, g:foo)
+  call feedkeys("\<F3>", 'xt')
+  call assert_equal(2, g:foo)
+  nnoremap x <Nop>
+  nmap <F4> x<Plug>(Increase_x)x
+  nnoremap <F5> x<Plug>(Increase_x)x
+  call setline(1, 'Some text')
+  normal! gg$
+  call feedkeys("\<F4>", 'xt')
+  call assert_equal(3, g:foo)
+  call assert_equal('Some text', getline(1))
+  call feedkeys("\<F5>", 'xt')
+  call assert_equal(4, g:foo)
+  call assert_equal('Some te', getline(1))
+  nunmap <Plug>(Increase_x)
+  nunmap <F2>
+  nunmap <F3>
+  nunmap <F4>
+  nunmap <F5>
+  unlet g:foo
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4498: using \<Plug> with "noremap" does not work

Problem:    Using \<Plug> with "noremap" does not work.
Solution:   Always remap \<Plug>. (closes vim/vim#9879)
https://github.com/vim/vim/commit/1fc34225acbee5ddca2b9ec3f82b3014d385b7f8