### PR TITLE
Clean up autocmds only when needed

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -239,7 +239,6 @@ void aupat_del_for_event_and_group(event_T event, int group)
     }
   }
 
-  au_need_clean = true;
   au_cleanup();  // may really delete removed patterns/commands now
 }
 


### PR DESCRIPTION
Fixes #17561.

`au_need_clean` should be set only when there's a group to be cleared, and this is done by `aupat_del`.