### PR TITLE
chore: align clang-format configuration with clint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,10 +2,10 @@ BasedOnStyle:  Google
 Language: Cpp
 ColumnLimit: 100
 IndentWidth: 2
-TabWidth: 2
+TabWidth: 8
 UseTab: Never
-IndentCaseLabels: true
-BreakBeforeBraces: Linux
+IndentCaseLabels: false
+BreakBeforeBraces: Custom
 AlignEscapedNewlinesLeft: false
 AllowShortFunctionsOnASingleLine: false
 AlignTrailingComments: true
@@ -17,4 +17,24 @@ AllowShortLoopsOnASingleLine: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: true
 BreakBeforeTernaryOperators: true
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 2
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: No
+AlwaysBreakTemplateDeclarations: No
+AlignEscapedNewlines: DontAlign
+BinPackArguments: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+PointerAlignment: Right
+SortIncludes: false
+Cpp11BracedListStyle: false


### PR DESCRIPTION
Some additional tweaks to make clang-format more compatible with `clint.py` rules.
This is especially useful for range-formatting with `clangd`.

Tested on #17443 (vim-patch)

Related #6226
