### PR TITLE
feat(lua): add subprocess module

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2039,4 +2039,53 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
                 See also: ~
                     |nvim_set_keymap()|
 
+
+==============================================================================
+Lua module: subprocess                                        *lua-subprocess*
+
+subprocess({spec}, {on_exit})                    *vim.subprocess.subprocess()*
+                Run a subprocess
+
+                Convenience wrapper for vim.loop.spawn with automatic IO
+                handling.
+
+                Examples: >
+
+                  local on_exit = function(code, signal, stdout, stderr)
+                    print(code)
+                    print(signal)
+                    print(stdout)
+                    print(stderr)
+                  end
+
+                  vim.subprocess('echo hello', on_exit)
+                  vim.subprocess({'echo', 'hello'}, on_exit)
+                  vim.subprocess({command = 'echo', args = {'hello'}}, on_exit)
+<
+
+                When passed as a keyed table, accepts all options as
+                vim.loop.spawn in addition to:
+                • command: (string) command to execute
+                • input: (string|string array) cannot be used with stdin
+                • stdin: (uv_pipe_t) cannot be used with input
+                • stdout: (uv_pipe_t)
+                • stderr: (uv_pipe_t)
+
+                Parameters: ~
+                    {spec}  table When passed as a string or a string array,
+                            the argument is interpreted as a command.
+
+                Parameters: ~
+                    {on_exit}  function Called when subprocess exits. Has the
+                               following arguments:
+                               • code: (integer)
+                               • signal: (integer)
+                               • stdout: (string), nil if stdout argument is
+                                 passed
+                               • stderr: (string), nil if stderr argument is
+                                 passed
+
+                Return: ~
+                    process handle (uv_process_t userdata), PID (integer)
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -48,6 +48,7 @@ for k,v in pairs {
   highlight=true;
   diagnostic=true;
   keymap=true;
+  subprocess=true;
   ui=true;
 } do vim._submodules[k] = v end
 

--- a/runtime/lua/vim/subprocess.lua
+++ b/runtime/lua/vim/subprocess.lua
@@ -1,0 +1,167 @@
+local uv = vim.loop
+
+---@private
+local function handle_input(pipe, input)
+  if type(input) == 'table' then
+    for _, v in ipairs(input) do
+      pipe:write(v)
+      pipe:write('\n')
+    end
+  elseif type(input) == 'string' then
+    pipe:write(input)
+  end
+
+  -- Shutdown the write side of the duplex stream and then close the pipe.
+  -- Note shutdown will wait for all the pending write requests to complete
+  -- TODO(lewis6991): apparently shutdown doesn't behave this way.
+  -- (https://github.com/neovim/neovim/pull/17620#discussion_r820775616)
+  pipe:write('', function()
+    pipe:shutdown(function()
+      if pipe then
+        pipe:close()
+      end
+    end)
+  end)
+end
+
+---@private
+local function parse_spec(spec)
+  if type(spec) == 'string' then
+    spec = vim.split(spec, '%s')
+  end
+
+  return {
+    command = spec[1],
+    args = {select(2, unpack(spec))}
+  }
+end
+
+---@private
+local function handle_output(pipe, output)
+  pipe:read_start(function(err, data)
+    if err then error(err) end
+    output[#output+1] = data
+  end)
+end
+
+---@private
+local function close_pipe(pipe)
+  if pipe then
+    pipe:read_stop()
+    if not pipe:is_closing() then
+      pipe:close()
+    end
+  end
+end
+
+--- Run a subprocess
+---
+--- Convenience wrapper for vim.loop.spawn with automatic IO handling.
+---
+--- Examples:
+--- <pre>
+---
+---   local on_exit = function(code, signal, stdout, stderr)
+---     print(code)
+---     print(signal)
+---     print(stdout)
+---     print(stderr)
+---   end
+---
+---   vim.subprocess('echo hello', on_exit)
+---   vim.subprocess({'echo', 'hello'}, on_exit)
+---   vim.subprocess({command = 'echo', args = {'hello'}}, on_exit)
+---
+--- </pre>
+---
+--- @param spec table   When passed as a string or a string array, the argument is interpreted
+---                     as a command.
+---
+---                     When passed as a keyed table, accepts all options as vim.loop.spawn in
+---                     addition to:
+---                     - command: (string) command to execute
+---                     - input: (string|string array) cannot be used with stdin
+---                     - stdin: (uv_pipe_t) cannot be used with input
+---                     - stdout: (uv_pipe_t)
+---                     - stderr: (uv_pipe_t)
+---
+--- @param on_exit function  Called when subprocess exits. Has the following arguments:
+---                          - code: (integer)
+---                          - signal: (integer)
+---                          - stdout: (string), nil if stdout argument is passed
+---                          - stderr: (string), nil if stderr argument is passed
+---
+---  @returns process handle (uv_process_t userdata), PID (integer)
+local function subprocess(spec, on_exit)
+  vim.validate {
+    spec = { spec, { 'table', 'string' }},
+    on_exit = { on_exit, 'function' },
+  }
+
+  if spec.stdin and spec.input then
+    error('stdin cannot be used with input')
+  end
+
+  if not spec.command then
+    -- Assume spec is raw command as string or array
+    spec = parse_spec(spec)
+  end
+
+  local stdout = spec.stdout or uv.new_pipe(false)
+  local stderr = spec.stderr or uv.new_pipe(false)
+  local stdin
+
+  if not spec.stdin and spec.input then
+    stdin = uv.new_pipe(false)
+  end
+
+  -- Define data buckets as tables and concatenate the elements at the end as one operation.
+  local stdout_data, stderr_data
+
+  local spec0 = vim.deepcopy(spec)
+
+  -- Remove non luv.spawn arguments
+  for _, s in ipairs{'input', 'command', 'stdout', 'stderr', 'stdin'} do
+    spec0[s] = nil
+  end
+
+  spec0.stdio = { stdin, stdout, stderr }
+
+  local handle, pid = uv.spawn(spec.command, spec0,
+    function(code, signal)
+      close_pipe(stdin)
+      close_pipe(stdout)
+      close_pipe(stderr)
+
+      on_exit(
+        code, signal,
+        stdout_data and stdout_data[1] and table.concat(stdout_data) or nil,
+        stderr_data and stderr_data[1] and table.concat(stderr_data) or nil
+      )
+    end
+  )
+
+  if not handle then
+    close_pipe(stdin)
+    close_pipe(stdout)
+    close_pipe(stderr)
+  end
+
+  if not spec.stdout then
+    stdout_data = {}
+    handle_output(stdout, stdout_data)
+  end
+
+  if not spec.stderr then
+    stderr_data = {}
+    handle_output(stderr, stderr_data)
+  end
+
+  if not spec.stdin and spec.input then
+    handle_input(stdin, spec.input)
+  end
+
+  return handle, pid
+end
+
+return subprocess

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -127,6 +127,7 @@ CONFIG = {
             'ui.lua',
             'filetype.lua',
             'keymap.lua',
+            'subprocess.lua',
         ],
         'files': [
             'runtime/lua/vim/_editor.lua',
@@ -135,6 +136,7 @@ CONFIG = {
             'runtime/lua/vim/ui.lua',
             'runtime/lua/vim/filetype.lua',
             'runtime/lua/vim/keymap.lua',
+            'runtime/lua/vim/subprocess.lua',
         ],
         'file_patterns': '*.lua',
         'fn_name_prefix': '',
@@ -160,6 +162,7 @@ CONFIG = {
             'ui': 'vim.ui',
             'filetype': 'vim.filetype',
             'keymap': 'vim.keymap',
+            'subprocess': 'vim.subprocess',
         },
         'append_only': [
             'shared.lua',

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -66,6 +66,7 @@ set(LUA_META_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/_meta.lua)
 set(LUA_FILETYPE_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/filetype.lua)
 set(LUA_INIT_PACKAGES_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/_init_packages.lua)
 set(LUA_KEYMAP_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/keymap.lua)
+set(LUA_SUBPROCESS_MODULE_SOURCE ${PROJECT_SOURCE_DIR}/runtime/lua/vim/subprocess.lua)
 set(CHAR_BLOB_GENERATOR ${GENERATOR_DIR}/gen_char_blob.lua)
 set(LINT_SUPPRESS_FILE ${PROJECT_BINARY_DIR}/errors.json)
 set(LINT_SUPPRESS_URL_BASE "https://raw.githubusercontent.com/neovim/doc/gh-pages/reports/clint")
@@ -349,6 +350,7 @@ add_custom_command(
       ${LUA_META_MODULE_SOURCE} "vim._meta"
       ${LUA_FILETYPE_MODULE_SOURCE} "vim.filetype"
       ${LUA_KEYMAP_MODULE_SOURCE} "vim.keymap"
+      ${LUA_SUBPROCESS_MODULE_SOURCE} "vim.subprocess"
   DEPENDS
     ${CHAR_BLOB_GENERATOR}
     ${LUA_INIT_PACKAGES_MODULE_SOURCE}
@@ -360,6 +362,7 @@ add_custom_command(
     ${LUA_FILETYPE_MODULE_SOURCE}
     ${LUA_LOAD_PACKAGE_MODULE_SOURCE}
     ${LUA_KEYMAP_MODULE_SOURCE}
+    ${LUA_SUBPROCESS_MODULE_SOURCE}
   VERBATIM
 )
 

--- a/test/functional/lua/subprocess_spec.lua
+++ b/test/functional/lua/subprocess_spec.lua
@@ -1,0 +1,51 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local exec_lua = helpers.exec_lua
+local eq = helpers.eq
+
+local function subprocess(spec)
+  return exec_lua([[
+    test_stdout = nil
+
+    vim.subprocess(
+      ...,
+      function(code, signal, stdout)
+        test_stdout = stdout
+      end
+    )
+
+    vim.wait(1000, function()
+      return test_stdout ~= nil
+    end, 10)
+
+    return test_stdout
+  ]], spec)
+end
+
+describe('subprocess', function()
+  before_each(function()
+    clear()
+  end)
+
+  it('can run simple commands', function()
+    eq('hello\n',
+      subprocess { command = 'echo', args = {'hello'} })
+
+    eq('hello\n',
+      subprocess('echo hello'))
+  end)
+
+  it('handle input', function()
+    eq('hellocat',
+      subprocess {
+        command = 'cat',
+        input = 'hellocat'
+      })
+
+    eq('hello\ncat\n',
+      subprocess {
+        command = 'cat',
+        input = {'hello', 'cat'}
+      })
+  end)
+end)


### PR DESCRIPTION
Convenience wrapper for `vim.loop.spawn` with IO setup.

Designed to handle the main boilerplate for the majority of `vim.loop.spawn` applications, not intended to include the 
kitchen sink.

### Examples:

```lua
local on_exit = function(code, signal, stdout, stderr)
  print(code)
  print(signal)
  print(stdout)
  print(stderr)
end

vim.subprocess('echo hello', on_exit)
vim.subprocess({'echo', 'hello'}, on_exit)
vim.subprocess({command = 'echo', args = {'hello'}}, on_exit)
```
### API
```lua
--- Run a subprocess
---
--- Convenience wrapper for vim.loop.spawn with automatic IO handling.
---
--- @param spec string|table When passed as a string or a string array, the argument is interpreted
---                          as a command.
---
---                          When passed as a keyed table, accepts all options as vim.loop.spawn in
---                          addition to:
---                          - command: (string) command to execute
---                          - input: (string|string array) cannot be used with stdin
---                          - stdin: (uv_pipe_t) cannot be used with input
---                          - stdout: (uv_pipe_t)
---                          - stderr: (uv_pipe_t)
---
--- @param on_exit function  Called when subprocess exits. Has the following arguments:
---                          - code: (integer)
---                          - signal: (integer)
---                          - stdout: (string), nil if stdout argument is passed
---                          - stderr: (string), nil if stderr argument is passed
---
---  @returns process handle (uv_process_t userdata), PID (integer)
```

### Applications in mind:
- [gitsigns.nvim subprocess module](https://github.com/lewis6991/gitsigns.nvim/blob/779f4eb59047ef7faa41e71d261d041edfabfb39/teal/gitsigns/subprocess.tl)
- [null-ls.nvim generator factory](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/2f305569c85818e5c43d7b1ba592c3d047c3377b/lua/null-ls/helpers/generator_factory.lua#L108)
- [packer.nvim jobs](https://github.com/wbthomason/packer.nvim/blob/6afb67460283f0e990d35d229fd38fdc04063e0a/lua/packer/jobs.lua)
- Eliminate https://github.com/neovim/neovim/blob/fae754073289566051433fae74ec65783f9e7a6a/runtime/autoload/health/provider.vim#L38-L113

### Possible enhancements:
- add `on_stdout`/`on_stderr` callback functions similar to Plenary Jobs
- Make it synchronous if `on_exit` is not provided.
- Allow stdout/stderr pipes to be disabled by passing them as `false`

### Todo
- [ ] Rename to `jobstart()`
- [ ] Allow to be called synchronously