### PR TITLE
refactor/clang tidy/remove redundant casts

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -191,7 +191,6 @@ _ERROR_CATEGORIES = [
     'readability/fn_size',
     'readability/multiline_comment',
     'readability/multiline_string',
-    'readability/nolint',
     'readability/nul',
     'readability/todo',
     'readability/utf8',
@@ -298,9 +297,6 @@ def ParseNolintSuppressions(filename, raw_line, linenum, error):
                 if category in _ERROR_CATEGORIES:
                     _error_suppressions.setdefault(
                         category, set()).add(linenum)
-                else:
-                    error(filename, linenum, 'readability/nolint', 5,
-                          'Unknown NOLINT error category: %s' % category)
 
 
 def ParseKnownErrorSuppressions(filename, raw_lines, linenum):

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -9441,7 +9441,7 @@ void new_script_vars(scid_T id)
   hashtab_T *ht;
   scriptvar_T *sv;
 
-  ga_grow(&ga_scripts, (int)(id - ga_scripts.ga_len));
+  ga_grow(&ga_scripts, id - ga_scripts.ga_len);
   {
     /* Re-allocating ga_data means that an ht_array pointing to
      * ht_smallarray becomes invalid.  We can recognize this: ht_mask is

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -11413,13 +11413,13 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if (len <= 5 || (TOLOWER_ASC(what[5]) == 'l' && len <= 9)) {  // underline
       p = highlight_has_attr(id, HL_UNDERCURL, modec);
     } else if (TOLOWER_ASC(what[5]) == 'c') {  // undercurl
-       p = highlight_has_attr(id, HL_UNDERCURL, modec);
+      p = highlight_has_attr(id, HL_UNDERCURL, modec);
     } else if (len > 9 && TOLOWER_ASC(what[9]) == 'l') {  // underlineline
-       p = highlight_has_attr(id, HL_UNDERLINELINE, modec);
+      p = highlight_has_attr(id, HL_UNDERLINELINE, modec);
     } else if (len > 6 && TOLOWER_ASC(what[6]) == 'o') {  // underdot
-       p = highlight_has_attr(id, HL_UNDERDOT, modec);
+      p = highlight_has_attr(id, HL_UNDERDOT, modec);
     } else {  // underdash
-       p = highlight_has_attr(id, HL_UNDERDASH, modec);
+      p = highlight_has_attr(id, HL_UNDERDASH, modec);
     }
     break;
   }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -516,7 +516,7 @@ static char_u *fname_trans_sid(const char_u *const name, char_u *const fname_buf
   if (llen > 0) {
     fname_buf[0] = K_SPECIAL;
     fname_buf[1] = KS_EXTRA;
-    fname_buf[2] = (int)KE_SNR;
+    fname_buf[2] = KE_SNR;
     int i = 3;
     if (eval_fname_sid((const char *)name)) {  // "<SID>" or "s:"
       if (current_sctx.sc_sid <= 0) {
@@ -1713,7 +1713,7 @@ char_u *trans_function_name(char_u **pp, bool skip, int flags, funcdict_T *fdp, 
   // Check for hard coded <SNR>: already translated function ID (from a user
   // command).
   if ((*pp)[0] == K_SPECIAL && (*pp)[1] == KS_EXTRA
-      && (*pp)[2] == (int)KE_SNR) {
+      && (*pp)[2] == KE_SNR) {
     *pp += 3;
     len = get_id_len((const char **)pp) + 3;
     return (char_u *)xmemdupz(start, len);
@@ -1821,7 +1821,7 @@ char_u *trans_function_name(char_u **pp, bool skip, int flags, funcdict_T *fdp, 
       // Change "<SNR>" to the byte sequence.
       name[0] = K_SPECIAL;
       name[1] = KS_EXTRA;
-      name[2] = (int)KE_SNR;
+      name[2] = KE_SNR;
       memmove(name + 3, name + 5, strlen((char *)name + 5) + 1);
     }
     goto theend;
@@ -1888,7 +1888,7 @@ char_u *trans_function_name(char_u **pp, bool skip, int flags, funcdict_T *fdp, 
   if (!skip && lead > 0) {
     name[0] = K_SPECIAL;
     name[1] = KS_EXTRA;
-    name[2] = (int)KE_SNR;
+    name[2] = KE_SNR;
     if (sid_buf_len > 0) {  // If it's "<SID>"
       memcpy(name + 3, sid_buf, sid_buf_len);
     }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1796,7 +1796,7 @@ scriptitem_T *new_script_item(char_u *const name, scid_T *const sid_out)
   if (sid_out != NULL) {
     *sid_out = sid;
   }
-  ga_grow(&script_items, (int)(sid - script_items.ga_len));
+  ga_grow(&script_items, sid - script_items.ga_len);
   while (script_items.ga_len < sid) {
     script_items.ga_len++;
     SCRIPT_ITEM(script_items.ga_len).sn_name = NULL;
@@ -2186,7 +2186,6 @@ scriptitem_T *get_current_script_id(char_u *fname, sctx_T *ret_sctx)
 
   return si;
 }
-
 
 
 /// ":scriptnames"

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -430,7 +430,7 @@ char *get_exception_string(void *value, except_type_T type, char_u *cmdname, int
 
           STRCAT(val, p);
           p[-2] = NUL;
-          sprintf((char *)(val + STRLEN(p)), " (%s)", &mesg[1]);
+          snprintf(val + STRLEN(p), strlen(" (%s)"), " (%s)", &mesg[1]);
           p[-2] = '"';
         }
         break;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3911,13 +3911,13 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
 
 static bool time_differs(const FileInfo *file_info, long mtime, long mtime_ns) FUNC_ATTR_CONST
 {
-  return (long)file_info->stat.st_mtim.tv_nsec != mtime_ns
+  return file_info->stat.st_mtim.tv_nsec != mtime_ns
 #if defined(__linux__) || defined(MSWIN)
          // On a FAT filesystem, esp. under Linux, there are only 5 bits to store
          // the seconds.  Since the roundoff is done when flushing the inode, the
          // time may change unexpectedly by one second!!!
-         || (long)file_info->stat.st_mtim.tv_sec - mtime > 1
-         || mtime - (long)file_info->stat.st_mtim.tv_sec > 1;
+         || file_info->stat.st_mtim.tv_sec - mtime > 1
+         || mtime - file_info->stat.st_mtim.tv_sec > 1;
 #else
          || (long)file_info->stat.st_mtim.tv_sec != mtime;
 #endif

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4140,7 +4140,7 @@ int makemap(FILE *fd, buf_T *buf)
         }
         for (p = mp->m_str; *p != NUL; p++) {
           if (p[0] == K_SPECIAL && p[1] == KS_EXTRA
-              && p[2] == (int)KE_SNR) {
+              && p[2] == KE_SNR) {
             break;
           }
         }

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -327,7 +327,7 @@ void update_window_hl(win_T *wp, bool invalid)
                                            wp->w_hl_attr_normal);
   }
 
-  for (int hlf = 0; hlf < (int)HLF_COUNT; hlf++) {
+  for (int hlf = 0; hlf < HLF_COUNT; hlf++) {
     int attr;
     if (wp->w_hl_ids[hlf] != 0) {
       attr = hl_get_ui_attr(hlf, wp->w_hl_ids[hlf], false);

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -558,8 +558,8 @@ void marktree_revise(MarkTree *b, MarkTreeIter *itr, uint8_t decor_level, mtkey_
 {
   // TODO(bfredl): clean up this mess and re-instantiate &= and |= forms
   // once we upgrade to a non-broken version of gcc in functionaltest-lua CI
-  rawkey(itr).flags = (uint16_t)((uint16_t)rawkey(itr).flags & (uint16_t)~MT_FLAG_DECOR_MASK);
-  rawkey(itr).flags = (uint16_t)((uint16_t)rawkey(itr).flags
+  rawkey(itr).flags = (uint16_t)(rawkey(itr).flags & (uint16_t)~MT_FLAG_DECOR_MASK);
+  rawkey(itr).flags = (uint16_t)(rawkey(itr).flags
                                  | (uint16_t)(decor_level << MT_FLAG_DECOR_OFFSET)
                                  | (uint16_t)(key.flags & MT_FLAG_DECOR_MASK));
   rawkey(itr).decor_full = key.decor_full;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -303,7 +303,7 @@ int ml_open(buf_T *buf)
 
   b0p->b0_id[0] = BLOCK0_ID0;
   b0p->b0_id[1] = BLOCK0_ID1;
-  b0p->b0_magic_long = (long)B0_MAGIC_LONG;
+  b0p->b0_magic_long = B0_MAGIC_LONG;
   b0p->b0_magic_int = (int)B0_MAGIC_INT;
   b0p->b0_magic_short = (short)B0_MAGIC_SHORT;
   b0p->b0_magic_char = B0_MAGIC_CHAR;
@@ -3709,7 +3709,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
 
 static int b0_magic_wrong(ZERO_BL *b0p)
 {
-  return b0p->b0_magic_long != (long)B0_MAGIC_LONG
+  return b0p->b0_magic_long != B0_MAGIC_LONG
          || b0p->b0_magic_int != (int)B0_MAGIC_INT
          || b0p->b0_magic_short != (short)B0_MAGIC_SHORT
          || b0p->b0_magic_char != B0_MAGIC_CHAR;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3851,7 +3851,7 @@ static bool parse_winhl_opt(win_T *wp)
     if (strncmp("Normal", p, nlen) == 0) {
       w_hl_id_normal = hl_id;
     } else {
-      for (hlf = 0; hlf < (int)HLF_COUNT; hlf++) {
+      for (hlf = 0; hlf < HLF_COUNT; hlf++) {
         if (strlen(hlf_names[hlf]) == nlen
             && strncmp(hlf_names[hlf], p, nlen) == 0) {
           w_hl_ids[hlf] = hl_id;
@@ -5267,7 +5267,7 @@ static void showoptions(int all, int opt_flags)
              && Columns + GAP >= INT_MIN + 3
              && (Columns + GAP - 3) / INC >= INT_MIN
              && (Columns + GAP - 3) / INC <= INT_MAX);
-      cols = (int)((Columns + GAP - 3) / INC);
+      cols = (Columns + GAP - 3) / INC;
       if (cols == 0) {
         cols = 1;
       }
@@ -5666,11 +5666,11 @@ void comp_col(void)
   assert(sc_col >= 0
          && INT_MIN + sc_col <= Columns
          && Columns - sc_col <= INT_MAX);
-  sc_col = (int)(Columns - sc_col);
+  sc_col = Columns - sc_col;
   assert(ru_col >= 0
          && INT_MIN + ru_col <= Columns
          && Columns - ru_col <= INT_MAX);
-  ru_col = (int)(Columns - ru_col);
+  ru_col = Columns - ru_col;
   if (sc_col <= 0) {            // screen too narrow, will become a mess
     sc_col = 1;
   }

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -5043,8 +5043,7 @@ static bool regmatch(
             } else {
               MB_PTR_BACK(rex.line, rp->rs_un.regsave.rs_u.ptr);
               if (limit > 0
-                  && (long)(behind_pos.rs_u.ptr
-                            - rp->rs_un.regsave.rs_u.ptr) > limit) {
+                  && (behind_pos.rs_u.ptr - rp->rs_un.regsave.rs_u.ptr) > (ptrdiff_t)limit) {
                 no = FAIL;
               }
             }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3824,7 +3824,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
 
         // At end of a prefix or at start of prefixtree: check for
         // following word.
-        if (byts[arridx] == 0 || n == (int)STATE_NOPREFIX) {
+        if (byts[arridx] == 0 || n == STATE_NOPREFIX) {
           // Set su->su_badflags to the caps type at this position.
           // Use the caps type until here for the prefix itself.
           n = nofold_len(fword, sp->ts_fidx, su->su_badptr);

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -639,8 +639,8 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
     }
   } else {
     // non-positive indicates no request
-    wp->w_height_request = (int)MAX(height, 0);
-    wp->w_width_request = (int)MAX(width, 0);
+    wp->w_height_request = MAX(height, 0);
+    wp->w_width_request = MAX(width, 0);
     win_set_inner_size(wp);
   }
 }


### PR DESCRIPTION
- ci(clint): remove "Unknown NOLINT error category" warning
- refactor: remove redundant casts and disable false clang-tidy warnings
