### PR TITLE
fix(api): highlight attribute for underline

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -11411,7 +11411,7 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   case 'u': {
     const size_t len = STRLEN(what);
     if (len <= 5 || (TOLOWER_ASC(what[5]) == 'l' && len <= 9)) {  // underline
-      p = highlight_has_attr(id, HL_UNDERCURL, modec);
+      p = highlight_has_attr(id, HL_UNDERLINE, modec);
     } else if (TOLOWER_ASC(what[5]) == 'c') {  // undercurl
        p = highlight_has_attr(id, HL_UNDERCURL, modec);
     } else if (len > 9 && TOLOWER_ASC(what[9]) == 'l') {  // underlineline

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -305,10 +305,17 @@ describe('synIDattr()', function()
     eq('79', eval('synIDattr(hlID("Keyword"), "fg")'))
   end)
 
-  it('returns "1" if group has "strikethrough" attribute', function()
-    eq('', eval('synIDattr(hlID("Normal"), "strikethrough")'))
-    eq('1', eval('synIDattr(hlID("Keyword"), "strikethrough")'))
-    eq('1', eval('synIDattr(hlID("Keyword"), "strikethrough", "gui")'))
+  it('returns "1" if group has given highlight attribute', function()
+    local hl_attrs = {
+      'underline', 'underlineline', 'undercurl', 'underdot', 'underdash', 'strikethrough'
+    }
+    for _,hl_attr in ipairs(hl_attrs) do
+      local context = 'using ' .. hl_attr .. ' attr'
+      command('highlight Keyword cterm=' .. hl_attr .. ' gui=' .. hl_attr)
+      eq('', eval('synIDattr(hlID("Normal"), "'.. hl_attr .. '")'), context)
+      eq('1', eval('synIDattr(hlID("Keyword"), "' .. hl_attr .. '")'), context)
+      eq('1', eval('synIDattr(hlID("Keyword"), "' .. hl_attr .. '", "gui")'), context)
+    end
   end)
 end)
 


### PR DESCRIPTION
This commit fixes regression introduced in c365de1 when checking for
highlight attribute for underline was returning '0' when it was present

Fixes #17624.

--

cc @kristijanhusak @jamessan