### PR TITLE
vim-patch:8.2.4520: using wrong highlight for cursor line number

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2890,9 +2890,9 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
             } else if (wp->w_p_cul
                        && lnum == wp->w_cursor.lnum
                        && (wp->w_p_culopt_flags & CULOPT_NBR)
-                       && (row == startrow
-                           || wp->w_p_culopt_flags & CULOPT_LINE)
-                       && filler_todo == 0) {
+                       && (row == startrow + filler_lines
+                           || (row > startrow + filler_lines
+                               && wp->w_p_culopt_flags & CULOPT_LINE))) {
               // When 'cursorline' is set highlight the line number of
               // the current line differently.
               // When 'cursorlineopt' has "screenline" only highlight

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1017,6 +1017,32 @@ func Test_diff_with_cursorline()
   call delete('Xtest_diff_cursorline')
 endfunc
 
+func Test_diff_with_cursorline_number()
+  CheckScreendump
+
+  let lines =<< trim END
+      hi CursorLine ctermbg=red ctermfg=white
+      hi CursorLineNr ctermbg=white ctermfg=black cterm=underline
+      set cursorline number
+      call setline(1, ["baz", "foo", "foo", "bar"])
+      2
+      vnew
+      call setline(1, ["foo", "foo", "bar"])
+      windo diffthis
+      1wincmd w
+  END
+  call writefile(lines, 'Xtest_diff_cursorline_number')
+  let buf = RunVimInTerminal('-S Xtest_diff_cursorline_number', {})
+
+  call VerifyScreenDump(buf, 'Test_diff_with_cursorline_number_01', {})
+  call term_sendkeys(buf, ":set cursorlineopt=number\r")
+  call VerifyScreenDump(buf, 'Test_diff_with_cursorline_number_02', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_diff_cursorline_number')
+endfunc
+
 func Test_diff_with_cursorline_breakindent()
   CheckScreendump
 

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -6,7 +6,7 @@ local clear = helpers.clear
 local command = helpers.command
 local insert = helpers.insert
 local write_file = helpers.write_file
-local source = helpers.source
+local exec = helpers.exec
 
 describe('Diff mode screen', function()
   local fname = 'Xtest-functional-diff-screen-1'
@@ -1075,10 +1075,8 @@ it('diff updates line numbers below filler lines', function()
     [9] = {background = Screen.colors.LightMagenta},
     [10] = {bold = true, foreground = Screen.colors.Brown},
     [11] = {foreground = Screen.colors.Brown},
-    [12] = {foreground = Screen.colors.Brown, bold = true, background = Screen.colors.Red};
-    [13] = {background = Screen.colors.Gray90};
   })
-  source([[
+  exec([[
     call setline(1, ['a', 'a', 'a', 'y', 'b', 'b', 'b', 'b', 'b'])
     vnew
     call setline(1, ['a', 'a', 'a', 'x', 'x', 'x', 'b', 'b', 'b', 'b', 'b'])
@@ -1135,24 +1133,6 @@ it('diff updates line numbers below filler lines', function()
     {3:[No Name] [+]       }{7:[No Name] [+]       }|
                                             |
   ]])
-  command("set signcolumn number tgc cursorline cursorlineopt=number,line")
-  command("hi CursorLineNr guibg=red")
-  screen:expect{grid=[[
-    {1:  }a                {3:│}{11:  2 }a               |
-    {1:  }a                {3:│}{11:  1 }a               |
-    {1:  }a                {3:│}{12:3   }{13:^a               }|
-    {1:  }{8:x}{9:                }{3:│}{11:  1 }{8:y}{9:               }|
-    {1:  }{4:x                }{3:│}{11:    }{2:----------------}|
-    {1:  }{4:x                }{3:│}{11:    }{2:----------------}|
-    {1:  }b                {3:│}{11:  2 }b               |
-    {1:  }b                {3:│}{11:  3 }b               |
-    {1:  }b                {3:│}{11:  4 }b               |
-    {1:  }b                {3:│}{11:  5 }b               |
-    {1:  }b                {3:│}{11:  6 }b               |
-    {6:~                  }{3:│}{6:~                   }|
-    {3:[No Name] [+]       }{7:[No Name] [+]       }|
-      signcolumn=auto                       |
-  ]]}
 end)
 
 it('Align the filler lines when changing text in diff mode', function()
@@ -1169,7 +1149,7 @@ it('Align the filler lines when changing text in diff mode', function()
     [7] = {foreground = Screen.colors.Blue1, bold = true};
     [8] = {reverse = true, bold = true};
   })
-  source([[
+  exec([[
     call setline(1, range(1, 15))
     vnew
     call setline(1, range(9, 15))

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -840,7 +840,7 @@ describe("'listchars' highlight", function()
   end)
 end)
 
-describe('CursorLine highlight', function()
+describe('CursorLine and CursorLineNr highlights', function()
   before_each(clear)
 
   it('overridden by Error, ColorColumn if fg not set', function()
@@ -1081,7 +1081,7 @@ describe('CursorLine highlight', function()
     ]])
   end)
 
-  it('with split-windows in diff-mode', function()
+  it('with split windows in diff mode', function()
     local screen = Screen.new(50,12)
     screen:set_default_attr_ids({
       [1] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
@@ -1093,7 +1093,6 @@ describe('CursorLine highlight', function()
       [7] = {background = Screen.colors.Red, foreground = Screen.colors.White},
       [8] = {bold = true, foreground = Screen.colors.Blue1},
       [9] = {bold = true, reverse = true},
-      [10] = {bold = true},
     })
     screen:attach()
 
@@ -1169,6 +1168,61 @@ describe('CursorLine highlight', function()
       [12] = {bold = true, underline = true,
               background = Screen.colors.Red},
     })
+  end)
+
+  it('CursorLineNr shows correctly just below filler lines', function()
+    local screen = Screen.new(50,12)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
+      [2] = {background = Screen.colors.LightCyan1, bold = true, foreground = Screen.colors.Blue1},
+      [3] = {reverse = true},
+      [4] = {background = Screen.colors.LightBlue},
+      [5] = {background = Screen.colors.Red, foreground = Screen.colors.White},
+      [6] = {background = Screen.colors.White, bold = true, foreground = Screen.colors.Black},
+      [7] = {bold = true, foreground = Screen.colors.Blue1},
+      [8] = {bold = true, reverse = true},
+      [9] = {foreground = Screen.colors.Brown},
+    })
+    screen:attach()
+
+    command('hi CursorLine guibg=red guifg=white')
+    command('hi CursorLineNr guibg=white guifg=black gui=bold')
+    command('set cursorline number')
+    command('call setline(1, ["baz", "foo", "foo", "bar"])')
+    feed('2gg0')
+    command('vnew')
+    command('call setline(1, ["foo", "foo", "bar"])')
+    command('windo diffthis')
+    command('1wincmd w')
+    screen:expect([[
+      {1:  }{9:    }{2:-------------------}{3:│}{1:  }{9:  1 }{4:baz               }|
+      {1:  }{6:  1 }{5:^foo                }{3:│}{1:  }{6:  2 }{5:foo               }|
+      {1:  }{9:  2 }foo                {3:│}{1:  }{9:  3 }foo               |
+      {1:  }{9:  3 }bar                {3:│}{1:  }{9:  4 }bar               |
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {8:[No Name] [+]             }{3:[No Name] [+]           }|
+                                                        |
+    ]])
+    command('set cursorlineopt=number')
+    screen:expect([[
+      {1:  }{9:    }{2:-------------------}{3:│}{1:  }{9:  1 }{4:baz               }|
+      {1:  }{6:  1 }^foo                {3:│}{1:  }{6:  2 }{5:foo               }|
+      {1:  }{9:  2 }foo                {3:│}{1:  }{9:  3 }foo               |
+      {1:  }{9:  3 }bar                {3:│}{1:  }{9:  4 }bar               |
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {7:~                        }{3:│}{7:~                       }|
+      {8:[No Name] [+]             }{3:[No Name] [+]           }|
+                                                        |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Fix #17617

#### vim-patch:8.2.4520: using wrong highlight for cursor line number

Problem:    Using wrong highlight for cursor line number.
Solution:   Take filler lines into account when using CursorLineNr.
            (closes vim/vim#9897)
https://github.com/vim/vim/commit/127969cf98000a760826ca3a0f3781a8b79522f1