### PR TITLE
feat(treesitter): show filetype associated with parser

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -182,8 +182,8 @@ int tslua_add_language(lua_State *L)
 
   uv_lib_t lib;
   if (uv_dlopen(path, &lib)) {
-    snprintf(IObuff, IOSIZE, "Failed to load parser: uv_dlopen: %s",
-             uv_dlerror(&lib));
+    snprintf(IObuff, IOSIZE, "Failed to load parser for language '%s': uv_dlopen: %s",
+             lang_name, uv_dlerror(&lib));
     uv_dlclose(&lib);
     lua_pushstring(L, IObuff);
     return lua_error(L);

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -17,7 +17,7 @@ describe('treesitter language API', function()
        pcall_err(exec_lua, "parser = vim.treesitter.get_parser(0, 'borklang')"))
 
     -- actual message depends on platform
-    matches("Failed to load parser: uv_dlopen: .+",
+    matches("Failed to load parser for language 'borklang': uv_dlopen: .+",
        pcall_err(exec_lua, "parser = vim.treesitter.require_language('borklang', 'borkbork.so')"))
 
     -- Should not throw an error when silent


### PR DESCRIPTION
to ease debug. There is now in nvim-treesitter a mapping between a filetype and the grammar. 
At one point I had an empty match and the current message was not helpful enough.