### PR TITLE
fix(lua): don't use nlua_error when exiting early

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -565,7 +565,8 @@ static bool nlua_init_packages(lua_State *lstate)
   lua_getglobal(lstate, "require");
   lua_pushstring(lstate, "vim._init_packages");
   if (nlua_pcall(lstate, 1, 0)) {
-      nlua_error(lstate, _("E5106: Error while loading packages: %.*s\n"));
+      mch_errmsg(lua_tostring(lstate, -1));
+      mch_errmsg("\n");
       return false;
   }
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1,6 +1,5 @@
 -- Test suite for testing interactions with API bindings
 local helpers = require('test.functional.helpers')(after_each)
-local isCI = require('test.helpers').isCI
 local Screen = require('test.functional.ui.screen')
 
 local funcs = helpers.funcs
@@ -2558,9 +2557,6 @@ describe('lua: builtin modules', function()
 
 
   it('does not work when disabled without runtime', function()
-    if isCI('sourcehut') then
-      pending('causes a core dump')
-    end
     clear{args={'--luamod-dev'}, env={VIMRUNTIME='fixtures/a'}}
     -- error checking could be better here. just check that --luamod-dev
     -- does anything at all by breaking with missing runtime..


### PR DESCRIPTION
Screen state is not initialized yet. Print directly to stderr instead.

Proper fix for stacktrace in https://github.com/neovim/neovim/pull/17628#issuecomment-1060023468