### PR TITLE
docs: syntax is enabled by default

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -26,7 +26,8 @@ In the User Manual:
 1. Quick start						*:syn-qstart*
 
 				*:syn-enable* *:syntax-enable* *:syn-on* *:syntax-on*
-This command switches on syntax highlighting: >
+Syntax highlighting is enabled by default. If you need to enable it again
+after it was disabled (see below), use: >
 
 	:syntax enable
 

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -139,13 +139,11 @@ quite complicated things.  Still, it is just a sequence of commands that are
 executed like you typed them.
 
 >
-	syntax on
 	set hlsearch
 
-This switches on syntax highlighting.  And the 'hlsearch' option tells Vim to
-highlight matches with the last used search pattern.  The "if" command is very
-useful to set options only when some condition is met.  More about that in
-|usr_41.txt|.
+This option tells Vim to highlight matches with the last used search pattern.
+The "if" command is very useful to set options only when some condition is
+met.  More about that in |usr_41.txt|.
 
 							*vimrc-filetype*  >
 	filetype plugin indent on

--- a/runtime/doc/usr_06.txt
+++ b/runtime/doc/usr_06.txt
@@ -24,28 +24,8 @@ Table of contents: |usr_toc.txt|
 ==============================================================================
 *06.1*	Switching it on
 
-It all starts with one simple command: >
-
-	:syntax enable
-
-That should work in most situations to get color in your files.  Vim will
-automagically detect the type of file and load the right syntax highlighting.
-Suddenly comments are blue, keywords brown and strings red.  This makes it
-easy to overview the file.  After a while you will find that black&white text
-slows you down!
-
-If you always want to use syntax highlighting, put the ":syntax enable"
-command in your |init.vim| file.
-
-If you want syntax highlighting only when the terminal supports colors, you
-can put this in your |init.vim| file: >
-
-	if &t_Co > 1
-	   syntax enable
-	endif
-
-If you want syntax highlighting only in the GUI version, put the ":syntax
-enable" command in your |ginit.vim| file.
+Syntax highlighting is enabled by default.  Nvim will automagically detect the
+type of file and load the right syntax highlighting.
 
 ==============================================================================
 *06.2*	No or wrong colors?


### PR DESCRIPTION
`:syntax enable` is no longer necessary (and may even be harmful). Do not recommend it in `usr_05.txt` and `usr_06.txt`, and mention the new default in `syntax.txt`.