### PR TITLE
ci(macos): minimize log output from brew update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,8 @@ jobs:
       - name: Install brew packages
         if: matrix.os == 'osx'
         run: |
-          brew update >/dev/null
-          brew install automake ccache perl cpanminus ninja
+          brew update --quiet
+          brew install automake ccache cpanminus ninja
 
       - name: Setup interpreter packages
         run: ./ci/install.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
       - name: Install brew packages
         run: |
-          brew update >/dev/null
+          brew update --quiet
           brew install automake ninja
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV


### PR DESCRIPTION
Also remove perl from brew install to prevent a warning that states it's
already installed.

Summary: Removes ~1200 lines of log + a warning