### PR TITLE
fix: do not pass aucmd to the callback

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7789,7 +7789,7 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
     break;
 
   case kCallbackLua:
-    nlua_call_ref(callback->data.luaref, "aucmd", args, false, NULL);
+    nlua_call_ref(callback->data.luaref, NULL, args, false, NULL);
 
     return false;
     break;


### PR DESCRIPTION
This shouldn't be getting passed here -- I didn't realize that it was actually getting passed to the function and/or I just forgot that it was.

Removing it here. There should be no expectations currently about what is passed to autocmd functions at this time (maybe someday we can pass `v:event` or similar directly to the autocmd, that could be quite nice.

Closes: #17619