### PR TITLE
fix lgtm warnings

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -369,7 +369,7 @@ def Search(pattern, s):
     return _regexp_compile_cache[pattern].search(s)
 
 
-class _IncludeState(dict):
+class _IncludeState(dict):  # lgtm [py/missing-equals]
 
     """Tracks line numbers for includes, and the order in which includes appear.
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9706,8 +9706,7 @@ free_lstval:
 
   if (set_unnamed) {
     // Discard the result. We already handle the error case.
-    if (op_reg_set_previous(regname)) {
-    }
+    op_reg_set_previous(regname);
   }
 }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4961,9 +4961,8 @@ int buf_check_timestamp(buf_T *buf)
       buf_store_file_info(buf, &file_info);
     }
 
-    // Don't do anything for a directory.  Might contain the file
-    // explorer.
     if (os_isdir(buf->b_fname)) {
+      // Don't do anything for a directory.  Might contain the file explorer.
     } else if ((buf->b_p_ar >= 0 ? buf->b_p_ar : p_ar)
                && !bufIsChanged(buf) && file_info_ok) {
       // If 'autoread' is set, the buffer has no changes and the file still

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -171,6 +171,7 @@ static NluaXdiffMode process_xdl_diff_opts(lua_State *lstate, xdemitconf_t *cfg,
         goto exit_1;
       }
       if (strequal("unified", v->data.string.data)) {
+        // the default
       } else if (strequal("indices", v->data.string.data)) {
         had_result_type_indices = true;
       } else {

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1159,8 +1159,6 @@ static size_t check_node(MarkTree *b, mtnode_t *x, mtpos_t *last, bool *last_rig
     if (i > 0) {
       unrelative(x->key[i-1].pos, last);
     }
-    if (x->level) {
-    }
     assert(pos_leq(*last, x->key[i].pos));
     if (last->row == x->key[i].pos.row && last->col == x->key[i].pos.col) {
       assert(!*last_right || mt_right(x->key[i]));

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2105,10 +2105,9 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
     } else {  // MOUSE_RIGHT
       stuffcharReadbuff('#');
     }
-  }
-  // Handle double clicks, unless on status line
-  else if (in_status_line) {
-  } else if (in_sep_line) {
+  } else if (in_status_line || in_sep_line) {
+    // Do nothing if on status line or vertical separator
+    // Handle double clicks otherwise
   } else if ((mod_mask & MOD_MASK_MULTI_CLICK) && (State & (NORMAL | INSERT))) {
     if (is_click || !VIsual_active) {
       if (VIsual_active) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -7382,7 +7382,6 @@ const yankreg_T *op_reg_get(const char name)
 ///
 /// @return true on success, false on failure.
 bool op_reg_set_previous(const char name)
-  FUNC_ATTR_WARN_UNUSED_RESULT
 {
   int i = op_reg_index(name);
   if (i == -1) {


### PR DESCRIPTION
- chore(lgtm): ignore "__eq__ not overridden" warning
- chore(lgtm): fix "empty block without comment" warnings
