### PR TITLE
feat(api): relax statusline fillchar width check

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2241,7 +2241,7 @@ Array nvim_get_mark(String name, Dictionary opts, Error *err)
 ///           - winid: (number) |window-ID| of the window to use as context for statusline.
 ///           - maxwidth: (number) Maximum width of statusline.
 ///           - fillchar: (string) Character to fill blank spaces in the statusline (see
-///                                'fillchars').
+///                                'fillchars'). Treated as single-width even if it isn't.
 ///           - highlights: (boolean) Return highlight information.
 ///           - use_tabline: (boolean) Evaluate tabline instead of statusline. When |TRUE|, {winid}
 ///                                    is ignored.
@@ -2277,11 +2277,12 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
 
   if (HAS_KEY(opts->fillchar)) {
     if (opts->fillchar.type != kObjectTypeString || opts->fillchar.data.string.size == 0
-        || char2cells(fillchar = utf_ptr2char((char_u *)opts->fillchar.data.string.data)) != 1
-        || (size_t)utf_char2len(fillchar) != opts->fillchar.data.string.size) {
-      api_set_error(err, kErrorTypeValidation, "fillchar must be a single-width character");
+        || ((size_t)utf_ptr2len((char_u *)opts->fillchar.data.string.data)
+            != opts->fillchar.data.string.size)) {
+      api_set_error(err, kErrorTypeValidation, "fillchar must be a single character");
       return result;
     }
+    fillchar = utf_ptr2char((char_u *)opts->fillchar.data.string.data);
   }
 
   if (HAS_KEY(opts->highlights)) {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2621,24 +2621,24 @@ describe('API', function()
       eq({ str = 'a━━━b', width = 5 },
          meths.eval_statusline('a%=b', { fillchar = '━', maxwidth = 5 }))
     end)
-    it('rejects double-width fillchar', function()
-      eq('fillchar must be a single-width character',
-         pcall_err(meths.eval_statusline, '', { fillchar = '哦' }))
+    it('treats double-width fillchar as single-width', function()
+      eq({ str = 'a哦哦哦b', width = 5 },
+         meths.eval_statusline('a%=b', { fillchar = '哦', maxwidth = 5 }))
     end)
-    it('rejects control character fillchar', function()
-      eq('fillchar must be a single-width character',
-         pcall_err(meths.eval_statusline, '', { fillchar = '\a' }))
+    it('treats control character fillchar as single-width', function()
+      eq({ str = 'a\031\031\031b', width = 5 },
+         meths.eval_statusline('a%=b', { fillchar = '\031', maxwidth = 5 }))
     end)
     it('rejects multiple-character fillchar', function()
-      eq('fillchar must be a single-width character',
+      eq('fillchar must be a single character',
          pcall_err(meths.eval_statusline, '', { fillchar = 'aa' }))
     end)
     it('rejects empty string fillchar', function()
-      eq('fillchar must be a single-width character',
+      eq('fillchar must be a single character',
          pcall_err(meths.eval_statusline, '', { fillchar = '' }))
     end)
     it('rejects non-string fillchar', function()
-      eq('fillchar must be a single-width character',
+      eq('fillchar must be a single character',
          pcall_err(meths.eval_statusline, '', { fillchar = 1 }))
     end)
     describe('highlight parsing', function()


### PR DESCRIPTION
Treat `fillchar` as single-width even if it isn't.

Ref <https://github.com/neovim/neovim/pull/17113#issuecomment-1063460790>.

When one calls `nvim_eval_statusline()`, they may want to use a placeholder character as `fillchar` or have a different assumption about character width. Since `build_stl_str_hl()` always assumes `fillchar` is single-width, allowing `nvim_eval_statusline()` to accept a non-single-width `fillchar` should be fine.