### PR TITLE
vim-patch:8.2.{3949,3950}: fix two crashes with /\%V

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -928,10 +928,12 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
     // continue until the NUL
     posptr = NULL;
   } else {
-    // Special check for an empty line, which can happen on exit, when
-    // ml_get_buf() always returns an empty string.
-    if (*ptr == NUL) {
-      pos->col = 0;
+    // In a few cases the position can be beyond the end of the line.
+    for (colnr_T i = 0; i < pos->col; i++) {
+      if (ptr[i] == NUL) {
+        pos->col = i;
+        break;
+      }
     }
     posptr = ptr + pos->col;
     posptr -= utf_head_off(line, posptr);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1136,8 +1136,8 @@ static bool reg_match_visual(void)
     return false;
   }
 
+  col = (colnr_T)(rex.input - rex.line);
   if (mode == 'v') {
-    col = (colnr_T)(rex.input - rex.line);
     if ((lnum == top.lnum && col < top.col)
         || (lnum == bot.lnum && col >= bot.col + (*p_sel != 'e'))) {
       return false;
@@ -1152,8 +1152,12 @@ static bool reg_match_visual(void)
     if (top.col == MAXCOL || bot.col == MAXCOL || curswant == MAXCOL) {
       end = MAXCOL;
     }
-    unsigned int cols_u = win_linetabsize(wp, rex.line,
-                                          (colnr_T)(rex.input - rex.line));
+
+    // getvvcol() flushes rex.line, need to get it again
+    rex.line = reg_getline(rex.lnum);
+    rex.input = rex.line + col;
+
+    unsigned int cols_u = win_linetabsize(wp, rex.line, col);
     assert(cols_u <= MAXCOL);
     colnr_T cols = (colnr_T)cols_u;
     if (cols < start || cols > end - (*p_sel == 'e')) {

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -803,4 +803,12 @@ func Test_using_visual_position()
   bwipe!
 endfunc
 
+func Test_using_invalid_visual_position()
+  " this was going beyond the end of the line
+  new
+  exe "norm 0o000\<Esc>0\<C-V>$s0"
+  /\%V
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -795,4 +795,12 @@ func Test_using_mark_position()
   bwipe!
 endfunc
 
+func Test_using_visual_position()
+  " this was using freed memory
+  new
+  exe "norm 0o\<Esc>\<C-V>k\<C-X>o0"
+  /\%V
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1193,4 +1193,23 @@ describe('completion', function()
     eq('foobar', eval('g:word'))
     feed('<esc>')
   end)
+
+  it('does not crash if text is changed by first call to complete function #17489', function()
+    source([[
+      func Complete(findstart, base) abort
+        if a:findstart
+          let col = col('.')
+          call complete_add('#')
+          return col - 1
+        else
+          return []
+        endif
+      endfunc
+
+      set completeopt=longest
+      set completefunc=Complete
+    ]])
+    feed('ifoo#<C-X><C-U>')
+    assert_alive()
+  end)
 end)


### PR DESCRIPTION
Fix #17489

#### vim-patch:8.2.3949: using freed memory with /\\%V

Problem:    Using freed memory with /\\%V.
Solution:   Get the line again after getvvcol().
https://github.com/vim/vim/commit/4c13e5e6763c6eb36a343a2b8235ea227202e952


#### vim-patch:8.2.3950: going beyond the end of the line with /\\%V

Problem:    Going beyond the end of the line with /\\%V.
Solution:   Check for valid column in getvcol().
https://github.com/vim/vim/commit/94f3192b03ed27474db80b4d3a409e107140738b