### PR TITLE
vim-patch:partial:a2baa73d1d33

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6880,12 +6880,14 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 		    filename	name of a file; only used when "bufnr" is not
 				present or it is invalid.
 		    module	name of a module; if given it will be used in
-				quickfix error window instead of the filename
+				quickfix error window instead of the filename.
 		    lnum	line number in the file
+		    end_lnum	end of lines, if the item spans multiple lines
 		    pattern	search pattern used to locate the error
 		    col		column number
 		    vcol	when non-zero: "col" is visual column
 				when zero: "col" is byte index
+		    end_col	end column, if the item spans multiple columns
 		    nr		error number
 		    text	description of the error
 		    type	single-character error type, 'E', 'W', etc.

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1018,7 +1018,7 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			in [range] (default: current line |cmdline-ranges|),
 			[into register x].
 
-							*p* *put* *E353*
+						*p* *put* *E353* *E1240*
 ["x]p			Put the text [from register x] after the cursor
 			[count] times.
 

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -679,7 +679,7 @@ If more line specifiers are given than required for the command, the first
 one(s) will be ignored.
 
 Line numbers may be specified with:		*:range* *{address}*
-	{number}	an absolute line number
+	{number}	an absolute line number  *E1247*
 	.		the current line			  *:.*
 	$		the last line in the file		  *:$*
 	%		equal to 1,$ (the entire file)		  *:%*

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1575,10 +1575,8 @@ There are three different types of searching:
 	/u/user_x/include
 
 <   Note: If your 'path' setting includes a non-existing directory, Vim will
-   skip the non-existing directory, but continues searching in the parent of
-   the non-existing directory if upwards searching is used.  E.g. when
-   searching "../include" and that doesn't exist, and upward searching is
-   used, also searches in "..".
+   skip the non-existing directory, and also does not search in the parent of
+   the non-existing directory if upwards searching is used.
 
 3) Combined up/downward search:
    If Vim's current path is /u/user_x/work/release and you do >

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -140,7 +140,8 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.asm		g:asmsyntax	|ft-asm-syntax|
 	*.asp		g:filetype_asp	|ft-aspvbs-syntax| |ft-aspperl-syntax|
 	*.bas		g:filetype_bas	|ft-basic-syntax|
-	*.fs		g:filetype_fs   |ft-forth-syntax|
+	*.frm		g:filetype_frm	|ft-form-syntax|
+	*.fs		g:filetype_fs	|ft-forth-syntax|
 	*.i		g:filetype_i	|ft-progress-syntax|
 	*.inc		g:filetype_inc
 	*.m		g:filetype_m	|ft-mathematica-syntax|

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -188,7 +188,8 @@ A syntax group name doesn't specify any color or attributes itself.
 
 The name for a highlight or syntax group must consist of ASCII letters, digits
 and the underscore.  As a regexp: "[a-zA-Z0-9_]*".  However, Vim does not give
-an error when using other characters.
+an error when using other characters.  The maxium length of a group name is
+about 200 bytes.  *E1249*
 
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.
@@ -1499,6 +1500,14 @@ this mode define the following variable in your vimrc file >
 The enhanced mode also takes advantage of additional color features for a dark
 gvim display.  Here, statements are colored LightYellow instead of Yellow, and
 conditionals are LightBlue for better distinction.
+
+Both Visual Basic and FORM use the extension ".frm".  To detect which one
+should be used, Vim checks for the string "VB_Name" in the first five lines of
+the file.  If it is found, filetype will be "vb", otherwise "form".
+
+If the automatic detection doesn't work for you or you only edit, for
+example, FORM files, use this in your startup vimrc: >
+   :let filetype_frm = "form"
 
 
 FORTH						*forth.vim* *ft-forth-syntax*

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -133,7 +133,10 @@ something else.
 		    :tabclose +	    " close the next tab page
 		    :tabclose 3	    " close the third tab page
 		    :tabclose $	    " close the last tab page
-<
+		    :tabclose #     " close the last accessed tab page
+
+When a tab is closed the next tab page will become the current one.
+
 							*:tabo* *:tabonly*
 :tabo[nly][!]	Close all other tab pages.
 		When the 'hidden' option is set, all buffers in closed windows
@@ -159,6 +162,8 @@ something else.
 				    " one
 		    :tabonly 1	    " close all tab pages except the first one
 		    :tabonly $	    " close all tab pages except the last one
+		    :tabonly #	    " close all tab pages except the last
+				    " accessed one
 
 
 SWITCHING TO ANOTHER TAB PAGE:
@@ -181,6 +186,7 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 		    :+2tabnext	" go to the two next tab page
 		    :1tabnext	" go to the first tab page
 		    :$tabnext	" go to the last tab page
+		    :tabnext #  " go to the last accessed tab page
 		    :tabnext $	" as above
 		    :tabnext -	" go to the previous tab page
 		    :tabnext -1	" as above
@@ -245,6 +251,8 @@ REORDERING TAB PAGES:
 		    :tabmove	" move the tab page to the last
 		    :$tabmove	" as above
 		    :tabmove $	" as above
+		    :tabmove #  " move the tab page after the last accessed
+				" tab page
 
 :tabm[ove] +[N]
 :tabm[ove] -[N]

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -432,7 +432,7 @@ g8			Print the hex values of the bytes used in the
 			used.  In this example |:silent| is used to avoid the
 			message about reading the file and |:unsilent| to be
 			able to list the first line of each file. >
-    		:silent argdo unsilent echo expand('%') .. ": " .. getline(1)
+		:silent argdo unsilent echo expand('%') .. ": " .. getline(1)
 <
 
 						*:verb* *:verbose*


### PR DESCRIPTION
#### vim-patch:partial:a2baa73d1d33

Update runtime files.
https://github.com/vim/vim/commit/a2baa73d1d33014adea0fd9567949089ca21a782

Cherry-pick tabpage.txt changes from patch 8.2.1413.
Skip digraph functions: included in #17440.
Skip many error codes as they haven't been ported yet.