### PR TITLE
ci: restore FAILED=1

### DIFF
--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -14,6 +14,7 @@ fail() {
   local full_msg="$test_name :: $message"
   echo "${full_msg}" >> "${FAIL_SUMMARY_FILE}"
   echo "Failed: $full_msg"
+  FAILED=1
 }
 
 ended_successfully() {


### PR DESCRIPTION
Removing this breaks oldtests `runnvim.sh`.