### PR TITLE
vim-patch:8.2.{4440,4443}: crash with specific regexp pattern and string

### DIFF
--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -4083,6 +4083,10 @@ static bool regmatch(
                 break;
               if (rex.input == rex.line) {
                 // backup to last char of previous line
+                if (rex.lnum == 0) {
+                  status = RA_NOMATCH;
+                  break;
+                }
                 rex.lnum--;
                 rex.line = reg_getline(rex.lnum);
                 // Just in case regrepeat() didn't count right.

--- a/src/nvim/testdir/test_regexp_utf8.vim
+++ b/src/nvim/testdir/test_regexp_utf8.vim
@@ -594,7 +594,7 @@ endfunc
 
 func Test_match_too_complicated()
   set regexpengine=1
-  exe "vsplit \xeb\xdb\x99"
+  exe "noswapfile vsplit \xeb\xdb\x99"
   silent! buf \&\zs*\zs*0
   bwipe!
   set regexpengine=0

--- a/src/nvim/testdir/test_regexp_utf8.vim
+++ b/src/nvim/testdir/test_regexp_utf8.vim
@@ -540,7 +540,6 @@ endfunc
 " Check that [[:upper:]] matches for automatic engine
 func Test_match_char_class_upper()
   new
-  let _engine=&regexpengine
 
   " Test 1: [[:upper:]]\{2,\}
   set regexpengine=0
@@ -581,7 +580,7 @@ func Test_match_char_class_upper()
   call assert_equal(4, searchcount().total, 'TEST 3 lower')
 
   " clean up
-  let &regexpengine=_engine
+  set regexpengine=0
   bwipe!
 endfunc
 
@@ -592,5 +591,14 @@ func Test_match_invalid_byte()
   bwipe!
   call delete('Xinvalid')
 endfunc
+
+func Test_match_too_complicated()
+  set regexpengine=1
+  exe "vsplit \xeb\xdb\x99"
+  silent! buf \&\zs*\zs*0
+  bwipe!
+  set regexpengine=0
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4440: crash with specific regexp pattern and string

Problem:    Crash with specific regexp pattern and string.
Solution:   Stop at the start of the string.
https://github.com/vim/vim/commit/6456fae9ba8e72c74b2c0c499eaf09974604ff30


#### vim-patch:8.2.4443: regexp pattern test fails on Mac

Problem:    Regexp pattern test fails on Mac.
Solution:   Do not use a swapfile for the buffer.
https://github.com/vim/vim/commit/2457b2bbc28cce6e8c1106d427b8e867d4f58cfa