### PR TITLE
ci: restore fail character and FAILED=1

### DIFF
--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -7,13 +7,16 @@ FAIL_SUMMARY_FILE="$BUILD_DIR/.test_errors"
 
 fail() {
   local test_name="$1"
-  local message="$2"
+  local fail_char="$2"
+  local message="$3"
 
+  : ${fail_char:=F}
   : ${message:=Test $test_name failed}
 
-  local full_msg="$test_name :: $message"
+  local full_msg="$fail_char $test_name :: $message"
   echo "${full_msg}" >> "${FAIL_SUMMARY_FILE}"
   echo "Failed: $full_msg"
+  FAILED=1
 }
 
 ended_successfully() {

--- a/ci/common/test.sh
+++ b/ci/common/test.sh
@@ -51,7 +51,7 @@ check_core_dumps() {
     fi
   done
   if test "$app" != quiet ; then
-    fail 'cores' 'Core dumps found'
+    fail 'cores' E 'Core dumps found'
   fi
 }
 
@@ -72,7 +72,7 @@ check_logs() {
     rm "${log}"
   done
   if test -n "${err}" ; then
-    fail 'logs' 'Runtime errors detected.'
+    fail 'logs' E 'Runtime errors detected.'
   fi
 }
 
@@ -89,7 +89,7 @@ check_sanitizer() {
 unittests() {(
   ulimit -c unlimited || true
   if ! build_make unittest ; then
-    fail 'unittests' 'Unit tests failed'
+    fail 'unittests' F 'Unit tests failed'
   fi
   submit_coverage unittest
   check_core_dumps "$(command -v luajit)"
@@ -98,7 +98,7 @@ unittests() {(
 functionaltests() {(
   ulimit -c unlimited || true
   if ! build_make ${FUNCTIONALTEST}; then
-    fail 'functionaltests' 'Functional tests failed'
+    fail 'functionaltests' F 'Functional tests failed'
   fi
   submit_coverage functionaltest
   check_sanitizer "${LOG_DIR}"
@@ -110,7 +110,7 @@ oldtests() {(
   ulimit -c unlimited || true
   if ! make oldtest; then
     reset
-    fail 'oldtests' 'Legacy tests failed'
+    fail 'oldtests' F 'Legacy tests failed'
   fi
   submit_coverage oldtest
   check_sanitizer "${LOG_DIR}"
@@ -129,17 +129,18 @@ check_runtime_files() {(
     # Prefer failing the build over using more robust construct because files
     # with IFS are not welcome.
     if ! test -e "$file" ; then
-      fail "$test_name" "It appears that $file is only a part of the file name"
+      fail "$test_name" E \
+        "It appears that $file is only a part of the file name"
     fi
     if ! test "$tst" "$INSTALL_PREFIX/share/nvim/runtime/$file" ; then
-      fail "$test_name" "$(printf "$message" "$file")"
+      fail "$test_name" F "$(printf "$message" "$file")"
     fi
   done
 )}
 
 install_nvim() {(
   if ! build_make install ; then
-    fail 'install' 'make install failed'
+    fail 'install' E 'make install failed'
     exit 1
   fi
 
@@ -147,7 +148,7 @@ install_nvim() {(
   if ! "${INSTALL_PREFIX}/bin/nvim" -u NONE -e -c ':help' -c ':qall' ; then
     echo "Running ':help' in the installed nvim failed."
     echo "Maybe the helptags have not been generated properly."
-    fail 'help' 'Failed running :help'
+    fail 'help' F 'Failed running :help'
   fi
 
   # Check that all runtime files were installed
@@ -168,6 +169,6 @@ install_nvim() {(
   local genvimsynf=syntax/vim/generated.vim
   local gpat='syn keyword vimFuncName .*eval'
   if ! grep -q "$gpat" "${INSTALL_PREFIX}/share/nvim/runtime/$genvimsynf" ; then
-    fail 'funcnames' "It appears that $genvimsynf does not contain $gpat."
+    fail 'funcnames' F "It appears that $genvimsynf does not contain $gpat."
   fi
 )}


### PR DESCRIPTION
I think fail character is useful.
`FAILED=1` is also needed by `runnvim.sh`.