### PR TITLE
fix(channel): fix channel consistency

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1140,6 +1140,7 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   TerminalOptions topts;
   Channel *chan = channel_alloc(kChannelStreamInternal);
   chan->stream.internal.cb = cb;
+  chan->stream.internal.closed = false;
   topts.data = chan;
   // NB: overridden in terminal_check_size if a window is already
   // displaying the buffer

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -44,6 +44,7 @@ typedef struct {
 
 typedef struct {
   LuaRef cb;
+  bool closed;
 } InternalState;
 
 typedef struct {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -317,10 +317,14 @@ void terminal_close(Terminal *term, int status)
       term->opts.close_cb(term->opts.data);
     }
   } else if (!only_destroy) {
-    // This was called by channel_process_exit_cb() not in process_teardown().
+    // Associated channel has been closed and the editor is not exiting.
     // Do not call the close callback now. Wait for the user to press a key.
     char msg[sizeof("\r\n[Process exited ]") + NUMBUFLEN];
-    snprintf(msg, sizeof msg, "\r\n[Process exited %d]", status);
+    if (((Channel *)term->opts.data)->streamtype == kChannelStreamInternal) {
+      snprintf(msg, sizeof msg, "\r\n[Terminal closed]");
+    } else {
+      snprintf(msg, sizeof msg, "\r\n[Process exited %d]", status);
+    }
     terminal_receive(term, msg, strlen(msg));
   }
 

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -43,3 +43,13 @@ describe('associated channel is closed and later freed for terminal', function()
     eq("Vim(call):E900: Invalid channel id", pcall_err(command, [[call chansend(id, 'test')]]))
   end)
 end)
+
+describe('channel created by nvim_open_term', function()
+  before_each(clear)
+
+  it('can close', function()
+    command('let id = nvim_open_term(0, {})')
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[call chanclose(id) | call chansend(id, 'test')]]))
+  end)
+end)

--- a/test/functional/terminal/channel_spec.lua
+++ b/test/functional/terminal/channel_spec.lua
@@ -1,55 +1,94 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local eq = helpers.eq
+local eval = helpers.eval
 local command = helpers.command
 local pcall_err = helpers.pcall_err
 local feed = helpers.feed
-local sleep = helpers.sleep
 local poke_eventloop = helpers.poke_eventloop
 
-describe('associated channel is closed and later freed for terminal', function()
-  before_each(clear)
+describe('terminal channel is closed and later released if', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new()
+    screen:attach()
+  end)
 
   it('opened by nvim_open_term() and deleted by :bdelete!', function()
     command([[let id = nvim_open_term(0, {})]])
-    -- channel hasn't been freed yet
-    eq("Vim(call):Can't send data to closed stream", pcall_err(command, [[bdelete! | call chansend(id, 'test')]]))
-    -- channel has been freed after one main loop iteration
-    eq("Vim(call):E900: Invalid channel id", pcall_err(command, [[call chansend(id, 'test')]]))
+    local chans = eval('len(nvim_list_chans())')
+    -- channel hasn't been released yet
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[bdelete! | call chansend(id, 'test')]]))
+    -- channel has been released after one main loop iteration
+    eq(chans - 1, eval('len(nvim_list_chans())'))
   end)
 
-  it('opened by termopen(), exited, and deleted by pressing a key', function()
-    command([[let id = termopen('echo')]])
-    sleep(500)
-    -- process has exited
-    eq("Vim(call):Can't send data to closed stream", pcall_err(command, [[call chansend(id, 'test')]]))
+  it('opened by nvim_open_term(), closed by chanclose(), and deleted by pressing a key', function()
+    command('let id = nvim_open_term(0, {})')
+    local chans = eval('len(nvim_list_chans())')
+    -- channel has been closed but not released
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[call chanclose(id) | call chansend(id, 'test')]]))
+    screen:expect({any='%[Terminal closed]'})
+    eq(chans, eval('len(nvim_list_chans())'))
     -- delete terminal
     feed('i<CR>')
     -- need to first process input
     poke_eventloop()
-    -- channel has been freed after another main loop iteration
-    eq("Vim(call):E900: Invalid channel id", pcall_err(command, [[call chansend(id, 'test')]]))
+    -- channel has been released after another main loop iteration
+    eq(chans - 1, eval('len(nvim_list_chans())'))
+  end)
+
+  it('opened by nvim_open_term(), closed by chanclose(), and deleted by :bdelete', function()
+    command('let id = nvim_open_term(0, {})')
+    local chans = eval('len(nvim_list_chans())')
+    -- channel has been closed but not released
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[call chanclose(id) | call chansend(id, 'test')]]))
+    screen:expect({any='%[Terminal closed]'})
+    eq(chans, eval('len(nvim_list_chans())'))
+    -- channel still hasn't been released yet
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[bdelete | call chansend(id, 'test')]]))
+    -- channel has been released after one main loop iteration
+    eq(chans - 1, eval('len(nvim_list_chans())'))
+  end)
+
+  it('opened by termopen(), exited, and deleted by pressing a key', function()
+    command([[let id = termopen('echo')]])
+    local chans = eval('len(nvim_list_chans())')
+    -- wait for process to exit
+    screen:expect({any='%[Process exited 0%]'})
+    -- process has exited but channel has't been released
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[call chansend(id, 'test')]]))
+    eq(chans, eval('len(nvim_list_chans())'))
+    -- delete terminal
+    feed('i<CR>')
+    -- need to first process input
+    poke_eventloop()
+    -- channel has been released after another main loop iteration
+    eq(chans - 1, eval('len(nvim_list_chans())'))
   end)
 
   -- This indirectly covers #16264
   it('opened by termopen(), exited, and deleted by :bdelete', function()
     command([[let id = termopen('echo')]])
-    sleep(500)
-    -- process has exited
-    eq("Vim(call):Can't send data to closed stream", pcall_err(command, [[call chansend(id, 'test')]]))
-    -- channel hasn't been freed yet
-    eq("Vim(call):Can't send data to closed stream", pcall_err(command, [[bdelete | call chansend(id, 'test')]]))
-    -- channel has been freed after one main loop iteration
-    eq("Vim(call):E900: Invalid channel id", pcall_err(command, [[call chansend(id, 'test')]]))
-  end)
-end)
-
-describe('channel created by nvim_open_term', function()
-  before_each(clear)
-
-  it('can close', function()
-    command('let id = nvim_open_term(0, {})')
+    local chans = eval('len(nvim_list_chans())')
+    -- wait for process to exit
+    screen:expect({any='%[Process exited 0%]'})
+    -- process has exited but channel hasn't been released
     eq("Vim(call):Can't send data to closed stream",
-       pcall_err(command, [[call chanclose(id) | call chansend(id, 'test')]]))
+       pcall_err(command, [[call chansend(id, 'test')]]))
+    eq(chans, eval('len(nvim_list_chans())'))
+    -- channel still hasn't been released yet
+    eq("Vim(call):Can't send data to closed stream",
+       pcall_err(command, [[bdelete | call chansend(id, 'test')]]))
+    -- channel has been released after one main loop iteration
+    eq(chans - 1, eval('len(nvim_list_chans())'))
   end)
 end)


### PR DESCRIPTION
Continuation of #16289

- Fix the problem that `chanclose()` does not work for channel created by `nvim_open_term()`.
- Fix the problem that the loopback channel is not released.
- Fix the error message when sending raw data to the loopback channel.