### PR TITLE
vim-patch:8.2.3779: using freed memory when defining a user command recursively

### DIFF
--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -572,4 +572,24 @@ func Test_delcommand_buffer()
   call assert_equal(0, exists(':Global'))
 endfunc
 
+func DefCmd(name)
+  if len(a:name) > 30
+    return
+  endif
+  exe 'command ' .. a:name .. ' call DefCmd("' .. a:name .. 'x")'
+  echo a:name
+  exe a:name
+endfunc
+
+func Test_recursive_define()
+  call DefCmd('Command')
+
+  let name = 'Command'
+  while len(name) < 30
+    exe 'delcommand ' .. name
+    let name ..= 'x'
+  endwhile
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Using freed memory when defining a user command from a user
            command.
Solution:   Do not use the command pointer after executing the command.
            (closes vim/vim#9318)
https://github.com/vim/vim/commit/205f29c3e9b895dbaa4f738046da455a93c3812a

just ran into this crash locally haha