### PR TITLE
fix(signcol): always trigger a redraw

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5485,6 +5485,7 @@ void buf_signcols_add_check(buf_T *buf, sign_entry_T *added)
       buf->b_signcols.max++;
     }
     buf->b_signcols.size++;
+    redraw_buf_later(buf, NOT_VALID);
     return;
   }
 
@@ -5505,6 +5506,7 @@ void buf_signcols_add_check(buf_T *buf, sign_entry_T *added)
     buf->b_signcols.size = linesum;
     buf->b_signcols.max = linesum;
     buf->b_signcols.sentinel = added->se_lnum;
+    redraw_buf_later(buf, NOT_VALID);
   }
 }
 


### PR DESCRIPTION
Whenever we change the size of the buffer signcol value, always trigger a redraw.

Fixes #17693