### PR TITLE
refactor: minimize variable scope and eliminate empty declarations

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -597,12 +597,11 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   if (start_row == end_row) {
     old_byte = (bcount_t)end_col - start_col;
   } else {
-    const char *bufline;
     old_byte += (bcount_t)strlen(str_at_start) - start_col;
     for (int64_t i = 1; i < end_row - start_row; i++) {
       int64_t lnum = start_row + i;
 
-      bufline = (char *)ml_get_buf(buf, lnum, false);
+      const char *bufline = (char *)ml_get_buf(buf, lnum, false);
       old_byte += (bcount_t)(strlen(bufline))+1;
     }
     old_byte += (bcount_t)end_col+1;

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -51,11 +51,10 @@ Integer nvim_buf_get_number(Buffer buffer, Error *err)
   FUNC_API_SINCE(1)
   FUNC_API_DEPRECATED_SINCE(2)
 {
-  Integer rv = 0;
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
   if (!buf) {
-    return rv;
+    return 0;
   }
 
   return buf->b_fnum;

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -102,11 +102,10 @@ void nvim_tabpage_del_var(Tabpage tabpage, String name, Error *err)
 Window nvim_tabpage_get_win(Tabpage tabpage, Error *err)
   FUNC_API_SINCE(1)
 {
-  Window rv = 0;
   tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab || !valid_tabpage(tab)) {
-    return rv;
+    return 0;
   }
 
   if (tab == curtab) {
@@ -130,11 +129,10 @@ Window nvim_tabpage_get_win(Tabpage tabpage, Error *err)
 Integer nvim_tabpage_get_number(Tabpage tabpage, Error *err)
   FUNC_API_SINCE(1)
 {
-  Integer rv = 0;
   tabpage_T *tab = find_tab_by_handle(tabpage, err);
 
   if (!tab) {
-    return rv;
+    return 0;
   }
 
   return tabpage_index(tab);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -137,8 +137,6 @@ static inline const char *get_deleted_augroup(void) FUNC_ATTR_ALWAYS_INLINE
 // Show the autocommands for one AutoPat.
 static void aupat_show(AutoPat *ap)
 {
-  AutoCmd *ac;
-
   // Check for "got_int" (here and at various places below), which is set
   // when "q" has been hit for the "--more--" prompt
   if (got_int) {
@@ -153,7 +151,7 @@ static void aupat_show(AutoPat *ap)
   msg_col = 4;
   msg_outtrans(ap->pat);
 
-  for (ac = ap->cmds; ac != NULL; ac = ac->next) {
+  for (AutoCmd *ac = ap->cmds; ac != NULL; ac = ac->next) {
     // skip removed commands
     if (aucmd_exec_is_deleted(ac->exec)) {
       continue;
@@ -278,9 +276,6 @@ static void aucmd_del(AutoCmd *ac)
 /// This is only done when not executing autocommands.
 static void au_cleanup(void)
 {
-  AutoPat *ap;
-  AutoPat **prev_ap;
-
   if (autocmd_busy || !au_need_clean) {
     return;
   }
@@ -288,8 +283,8 @@ static void au_cleanup(void)
   // Loop over all events.
   FOR_ALL_AUEVENTS(event) {
     // Loop over all autocommand patterns.
-    prev_ap = &(first_autopat[(int)event]);
-    for (ap = *prev_ap; ap != NULL; ap = *prev_ap) {
+    AutoPat **prev_ap = &(first_autopat[(int)event]);
+    for (AutoPat *ap = *prev_ap; ap != NULL; ap = *prev_ap) {
       bool has_cmd = false;
 
       // Loop over all commands for this pattern.
@@ -351,10 +346,8 @@ AutoPat *au_get_autopat_for_event(event_T event)
 // autocmds.
 void aubuflocal_remove(buf_T *buf)
 {
-  AutoPatCmd *apc;
-
   // invalidate currently executing autocommands
-  for (apc = active_apc_list; apc; apc = apc->next) {
+  for (AutoPatCmd *apc = active_apc_list; apc; apc = apc->next) {
     if (buf->b_fnum == apc->arg_bufnr) {
       apc->arg_bufnr = 0;
     }
@@ -586,13 +579,12 @@ event_T event_name2nr(const char_u *start, char_u **end)
 {
   const char_u *p;
   int i;
-  int len;
 
   // the event name ends with end of line, '|', a blank or a comma
   for (p = start; *p && !ascii_iswhite(*p) && *p != ',' && *p != '|'; p++) {
   }
   for (i = 0; event_names[i].name != NULL; i++) {
-    len = (int)event_names[i].len;
+    int len = (int)event_names[i].len;
     if (len == p - start && STRNICMP(event_names[i].name, start, len) == 0) {
       break;
     }
@@ -615,9 +607,7 @@ event_T event_name2nr(const char_u *start, char_u **end)
 const char *event_nr2name(event_T event)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_CONST
 {
-  int i;
-
-  for (i = 0; event_names[i].name != NULL; i++) {
+  for (int i = 0; event_names[i].name != NULL; i++) {
     if (event_names[i].event == event) {
       return event_names[i].name;
     }
@@ -670,11 +660,8 @@ int check_ei(void)
 // Returns the old value of 'eventignore' in allocated memory.
 char_u *au_event_disable(char *what)
 {
-  char_u *new_ei;
-  char_u *save_ei;
-
-  save_ei = vim_strsave(p_ei);
-  new_ei = vim_strnsave(p_ei, STRLEN(p_ei) + STRLEN(what));
+  char_u *save_ei = vim_strsave(p_ei);
+  char_u *new_ei = vim_strnsave(p_ei, STRLEN(p_ei) + STRLEN(what));
   if (*what == ',' && *p_ei == NUL) {
     STRCPY(new_ei, what + 1);
   } else {
@@ -729,7 +716,6 @@ void au_event_restore(char_u *old_ei)
 void do_autocmd(char_u *arg_in, int forceit)
 {
   char_u *arg = arg_in;
-  char_u *pat;
   char_u *envpat = NULL;
   char_u *cmd;
   int need_free = false;
@@ -747,7 +733,7 @@ void do_autocmd(char_u *arg_in, int forceit)
 
   // Scan over the events.
   // If we find an illegal name, return here, don't do anything.
-  pat = arg_event_skip(arg, group != AUGROUP_ALL);
+  char_u *pat = arg_event_skip(arg, group != AUGROUP_ALL);
   if (pat == NULL) {
     return;
   }
@@ -877,8 +863,6 @@ int do_autocmd_event(event_T event, char_u *pat, bool once, int nested, char_u *
   AutoPat *ap;
   AutoPat **prev_ap;
   int findgroup;
-  int patlen;
-  int is_buflocal;
   int buflocal_nr;
   char_u buflocal_pat[BUFLOCAL_PAT_LEN];  // for "<buffer=X>"
 
@@ -897,10 +881,10 @@ int do_autocmd_event(event_T event, char_u *pat, bool once, int nested, char_u *
   }
 
   // Loop through all the specified patterns.
-  patlen = (int)aucmd_pattern_length(pat);
+  int patlen = (int)aucmd_pattern_length(pat);
   while (patlen) {
     // detect special <buffer[=X]> buffer-local patterns
-    is_buflocal = aupat_is_buflocal(pat, patlen);
+    int is_buflocal = aupat_is_buflocal(pat, patlen);
 
     if (is_buflocal) {
       buflocal_nr = aupat_get_buflocal_nr(pat, patlen);
@@ -968,9 +952,6 @@ int autocmd_register(int64_t id, event_T event, char_u *pat, int patlen, int gro
   AutoPat *ap;
   AutoPat **prev_ap;
   AutoCmd *ac;
-  AutoCmd **prev_ac;
-  int is_buflocal;
-  int buflocal_nr;
   int findgroup;
   char_u buflocal_pat[BUFLOCAL_PAT_LEN];  // for "<buffer=X>"
 
@@ -986,8 +967,8 @@ int autocmd_register(int64_t id, event_T event, char_u *pat, int patlen, int gro
 
 
   // detect special <buffer[=X]> buffer-local patterns
-  is_buflocal = aupat_is_buflocal(pat, patlen);
-  buflocal_nr = 0;
+  int is_buflocal = aupat_is_buflocal(pat, patlen);
+  int buflocal_nr = 0;
 
   if (is_buflocal) {
     buflocal_nr = aupat_get_buflocal_nr(pat, patlen);
@@ -1083,7 +1064,7 @@ int autocmd_register(int64_t id, event_T event, char_u *pat, int patlen, int gro
   }
 
   // Add the autocmd at the end of the AutoCmd list.
-  prev_ac = &(ap->cmds);
+  AutoCmd **prev_ac = &(ap->cmds);
   while ((ac = *prev_ac) != NULL) {
     prev_ac = &ac->next;
   }
@@ -1160,16 +1141,14 @@ char_u *aucmd_next_pattern(char_u *pat, size_t patlen)
 /// @param do_msg  give message for no matching autocmds?
 int do_doautocmd(char_u *arg, bool do_msg, bool *did_something)
 {
-  char_u *fname;
   int nothing_done = true;
-  int group;
 
   if (did_something != NULL) {
     *did_something = false;
   }
 
   // Check for a legal group name.  If not, use AUGROUP_ALL.
-  group = arg_augroup_get(&arg);
+  int group = arg_augroup_get(&arg);
 
   if (*arg == '*') {
     emsg(_("E217: Can't execute autocommands for ALL events"));
@@ -1178,7 +1157,7 @@ int do_doautocmd(char_u *arg, bool do_msg, bool *did_something)
 
   // Scan over the events.
   // If we find an illegal name, return here, don't do anything.
-  fname = arg_event_skip(arg, group != AUGROUP_ALL);
+  char_u *fname = arg_event_skip(arg, group != AUGROUP_ALL);
   if (fname == NULL) {
     return FAIL;
   }
@@ -1542,11 +1521,9 @@ bool has_cursorhold(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 /// Return true if the CursorHold/CursorHoldI event can be triggered.
 bool trigger_cursorhold(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  int state;
-
   if (!did_cursorhold && has_cursorhold() && reg_recording == 0
       && typebuf.tb_len == 0 && !ins_compl_active()) {
-    state = get_real_state();
+    int state = get_real_state();
     if (state == NORMAL_BUSY || (state & INSERT) != 0) {
       return true;
     }
@@ -1570,19 +1547,8 @@ bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io, bool f
                           buf_T *buf, exarg_T *eap)
 {
   char_u *sfname = NULL;  // short file name
-  char_u *tail;
-  bool save_changed;
-  buf_T *old_curbuf;
   bool retval = false;
-  char_u *save_sourcing_name;
-  linenr_T save_sourcing_lnum;
-  char_u *save_autocmd_fname;
-  int save_autocmd_bufnr;
-  char_u *save_autocmd_match;
-  int save_autocmd_busy;
-  int save_autocmd_nested;
   static int nesting = 0;
-  AutoPatCmd patcmd;
   AutoPat *ap;
   char_u *save_cmdarg;
   long save_cmdbang;
@@ -1639,13 +1605,13 @@ bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io, bool f
   }
 
   // Save the autocmd_* variables and info about the current buffer.
-  save_autocmd_fname = autocmd_fname;
-  save_autocmd_bufnr = autocmd_bufnr;
-  save_autocmd_match = autocmd_match;
-  save_autocmd_busy = autocmd_busy;
-  save_autocmd_nested = autocmd_nested;
-  save_changed = curbuf->b_changed;
-  old_curbuf = curbuf;
+  char_u *save_autocmd_fname = autocmd_fname;
+  int save_autocmd_bufnr = autocmd_bufnr;
+  char_u *save_autocmd_match = autocmd_match;
+  int save_autocmd_busy = autocmd_busy;
+  int save_autocmd_nested = autocmd_nested;
+  bool save_changed = curbuf->b_changed;
+  buf_T *old_curbuf = curbuf;
 
   // Set the file name to be used for <afile>.
   // Make a copy to avoid that changing a buffer name or directory makes it
@@ -1738,9 +1704,9 @@ bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io, bool f
 
   // Don't redraw while doing autocommands.
   RedrawingDisabled++;
-  save_sourcing_name = sourcing_name;
+  char_u *save_sourcing_name = sourcing_name;
   sourcing_name = NULL;  // don't free this one
-  save_sourcing_lnum = sourcing_lnum;
+  linenr_T save_sourcing_lnum = sourcing_lnum;
   sourcing_lnum = 0;  // no line number here
 
   const sctx_T save_current_sctx = current_sctx;
@@ -1773,9 +1739,10 @@ bool apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io, bool f
     did_filetype = true;
   }
 
-  tail = path_tail(fname);
+  char_u *tail = path_tail(fname);
 
   // Find first autocommand that matches
+  AutoPatCmd patcmd;
   patcmd.curpat = first_autopat[(int)event];
   patcmd.nextcmd = NULL;
   patcmd.group = group;
@@ -2009,7 +1976,6 @@ char_u *getnextac(int c, void *cookie, int indent, bool do_concat)
 
   AutoPatCmd *acp = (AutoPatCmd *)cookie;
   char_u *retval;
-  AutoCmd *ac;
 
   // Can be called again after returning the last line.
   if (acp->curpat == NULL) {
@@ -2046,7 +2012,7 @@ char_u *getnextac(int c, void *cookie, int indent, bool do_concat)
     }
   }
 
-  ac = acp->nextcmd;
+  AutoCmd *ac = acp->nextcmd;
 
   if (p_verbose >= 9) {
     verbose_enter_scroll();
@@ -2099,12 +2065,10 @@ char_u *getnextac(int c, void *cookie, int indent, bool do_concat)
 /// @param buf buffer the file is open in
 bool has_autocmd(event_T event, char_u *sfname, buf_T *buf) FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  AutoPat *ap;
-  char_u *fname;
   char_u *tail = path_tail(sfname);
   bool retval = false;
 
-  fname = (char_u *)FullName_save((char *)sfname, false);
+  char_u *fname = (char_u *)FullName_save((char *)sfname, false);
   if (fname == NULL) {
     return false;
   }
@@ -2117,7 +2081,7 @@ bool has_autocmd(event_T event, char_u *sfname, buf_T *buf) FUNC_ATTR_WARN_UNUSE
   forward_slash(fname);
 #endif
 
-  for (ap = first_autopat[(int)event]; ap != NULL; ap = ap->next) {
+  for (AutoPat *ap = first_autopat[(int)event]; ap != NULL; ap = ap->next) {
     if (ap->pat != NULL && ap->cmds != NULL
         && (ap->buflocal_nr == 0
             ? match_file_pat(NULL,
@@ -2153,13 +2117,10 @@ char_u *expand_get_augroup_name(expand_T *xp, int idx)
 /// @param doautocmd  true for :doauto*, false for :autocmd
 char_u *set_context_in_autocmd(expand_T *xp, char_u *arg, int doautocmd)
 {
-  char_u *p;
-  int group;
-
   // check for a group name, skip it if present
   autocmd_include_groups = false;
-  p = arg;
-  group = arg_augroup_get(&arg);
+  char_u *p = arg;
+  int group = arg_augroup_get(&arg);
 
   // If there only is a group name that's what we expand.
   if (*arg == NUL && group != AUGROUP_ALL && !ascii_iswhite(arg[-1])) {
@@ -2205,7 +2166,6 @@ char_u *expand_get_event_name(expand_T *xp, int idx)
   // xp is a required parameter to be used with ExpandGeneric
   (void)xp;
 
-
   // List group names
   char *name = augroup_name(idx + 1);
   if (name != NULL) {
@@ -2247,10 +2207,7 @@ bool autocmd_supported(const char *const event)
 /// @param arg autocommand string
 bool au_exists(const char *const arg) FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  event_T event;
-  AutoPat *ap;
   buf_T *buflocal_buf = NULL;
-  int group;
   bool retval = false;
 
   // Make a copy so that we can change the '#' chars to a NUL.
@@ -2261,7 +2218,7 @@ bool au_exists(const char *const arg) FUNC_ATTR_WARN_UNUSED_RESULT
   }
 
   // First, look for an autocmd group name.
-  group = augroup_find(arg_save);
+  int group = augroup_find(arg_save);
   char *event_name;
   if (group == AUGROUP_ERROR) {
     // Didn't match a group name, assume the first argument is an event.
@@ -2285,7 +2242,7 @@ bool au_exists(const char *const arg) FUNC_ATTR_WARN_UNUSED_RESULT
   char *pattern = p;  // "pattern" is NULL when there is no pattern.
 
   // Find the index (enum) for the event name.
-  event = event_name2nr((char_u *)event_name, (char_u **)&p);
+  event_T event = event_name2nr((char_u *)event_name, (char_u **)&p);
 
   // return false if the event name is not recognized
   if (event == NUM_EVENTS) {
@@ -2295,7 +2252,7 @@ bool au_exists(const char *const arg) FUNC_ATTR_WARN_UNUSED_RESULT
   // Find the first autocommand for this event.
   // If there isn't any, return false;
   // If there is one and no pattern given, return true;
-  ap = first_autopat[(int)event];
+  AutoPat *ap = first_autopat[(int)event];
   if (ap == NULL) {
     goto theend;
   }
@@ -2535,7 +2492,6 @@ static char_u *arg_event_skip(char_u *arg, int have_group)
 // Returns the group ID or AUGROUP_ALL.
 static int arg_augroup_get(char_u **argp)
 {
-  char_u *group_name;
   char_u *p;
   char_u *arg = *argp;
   int group = AUGROUP_ALL;
@@ -2543,7 +2499,7 @@ static int arg_augroup_get(char_u **argp)
   for (p = arg; *p && !ascii_iswhite(*p) && *p != '|'; p++) {
   }
   if (p > arg) {
-    group_name = vim_strnsave(arg, (size_t)(p - arg));
+    char_u *group_name = vim_strnsave(arg, (size_t)(p - arg));
     group = augroup_find((char *)group_name);
     if (group == AUGROUP_ERROR) {
       group = AUGROUP_ALL;  // no match, use all groups

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -268,15 +268,12 @@ int buf_init_chartab(buf_T *buf, int global)
 /// @param bufsize
 void trans_characters(char_u *buf, int bufsize)
 {
-  int len;          // length of string needing translation
-  int room;         // room in buffer after string
-  char_u *trs;      // translated character
-  int trs_len;      // length of trs[]
-
-  len = (int)STRLEN(buf);
-  room = bufsize - len;
+  char_u *trs;                 // translated character
+  int len = (int)STRLEN(buf);  // length of string needing translation
+  int room = bufsize - len;    // room in buffer after string
 
   while (*buf != 0) {
+    int trs_len;      // length of trs[]
     // Assume a multi-byte character doesn't need translation.
     if ((trs_len = utfc_ptr2len(buf)) > 1) {
       len -= trs_len;
@@ -873,14 +870,11 @@ bool vim_isprintc_strict(int c)
 bool in_win_border(win_T *wp, colnr_T vcol)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(1)
 {
-  int width1;             // width of first line (after line number)
-  int width2;             // width of further lines
-
   if (wp->w_width_inner == 0) {
     // there is no border
     return false;
   }
-  width1 = wp->w_width_inner - win_col_off(wp);
+  int width1 = wp->w_width_inner - win_col_off(wp);  // width of first line (after line number)
 
   if ((int)vcol < width1 - 1) {
     return false;
@@ -889,7 +883,7 @@ bool in_win_border(win_T *wp, colnr_T vcol)
   if ((int)vcol == width1 - 1) {
     return true;
   }
-  width2 = width1 + win_col_off2(wp);
+  int width2 = width1 + win_col_off2(wp);  // width of further lines
 
   if (width2 <= 0) {
     return false;
@@ -911,18 +905,15 @@ bool in_win_border(win_T *wp, colnr_T vcol)
 /// @param end
 void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *end)
 {
-  colnr_T vcol;
   char_u *ptr;    // points to current char
   char_u *posptr;  // points to char at pos->col
-  char_u *line;   // start of the line
   int incr;
   int head;
   long *vts = wp->w_buffer->b_p_vts_array;
   int ts = (int)wp->w_buffer->b_p_ts;
-  int c;
 
-  vcol = 0;
-  line = ptr = ml_get_buf(wp->w_buffer, pos->lnum, false);
+  colnr_T vcol = 0;
+  char_u *line = ptr = ml_get_buf(wp->w_buffer, pos->lnum, false);  // start of the line
 
   if (pos->col == MAXCOL) {
     // continue until the NUL
@@ -949,7 +940,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
       && !wp->w_p_bri) {
     for (;;) {
       head = 0;
-      c = *ptr;
+      int c = *ptr;
 
       // make sure we don't go past the end of the line
       if (c == NUL) {
@@ -1066,19 +1057,16 @@ colnr_T getvcol_nolist(pos_T *posp)
 void getvvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *end)
 {
   colnr_T col;
-  colnr_T coladd;
-  colnr_T endadd;
-  char_u *ptr;
 
   if (virtual_active()) {
     // For virtual mode, only want one value
     getvcol(wp, pos, &col, NULL, NULL);
 
-    coladd = pos->coladd;
-    endadd = 0;
+    colnr_T coladd = pos->coladd;
+    colnr_T endadd = 0;
 
     // Cannot put the cursor on part of a wide character.
-    ptr = ml_get_buf(wp->w_buffer, pos->lnum, false);
+    char_u *ptr = ml_get_buf(wp->w_buffer, pos->lnum, false);
 
     if (pos->col < (colnr_T)STRLEN(ptr)) {
       int c = utf_ptr2char(ptr + pos->col);

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -92,19 +92,16 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
 {
   colnr_T wcol = wcol_arg;
   int idx;
-  char_u *ptr;
-  char_u *line;
   colnr_T col = 0;
-  int csize = 0;
-  int one_more;
   int head = 0;
 
-  one_more = (State & INSERT)
-             || (State & TERM_FOCUS)
-             || restart_edit != NUL
-             || (VIsual_active && *p_sel != 'o')
-             || ((get_ve_flags() & VE_ONEMORE) && wcol < MAXCOL);
-  line = ml_get_buf(curbuf, pos->lnum, false);
+  int one_more = (State & INSERT)
+                 || (State & TERM_FOCUS)
+                 || restart_edit != NUL
+                 || (VIsual_active && *p_sel != 'o')
+                 || ((get_ve_flags() & VE_ONEMORE) && wcol < MAXCOL);
+
+  char_u *line = ml_get_buf(curbuf, pos->lnum, false);
 
   if (wcol >= MAXCOL) {
     idx = (int)STRLEN(line) - 1 + one_more;
@@ -118,6 +115,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
     }
   } else {
     int width = curwin->w_width_inner - win_col_off(curwin);
+    int csize = 0;
 
     if (finetune
         && curwin->w_p_wrap
@@ -139,7 +137,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
       }
     }
 
-    ptr = line;
+    char_u *ptr = line;
     while (col <= wcol && *ptr != NUL) {
       // Count a tab for what it's worth (if list mode not on)
       csize = win_lbr_chartabsize(curwin, line, ptr, col, &head);
@@ -301,16 +299,13 @@ linenr_T get_cursor_rel_lnum(win_T *wp, linenr_T lnum)
 /// This allows for the col to be on the NUL byte.
 void check_pos(buf_T *buf, pos_T *pos)
 {
-  char_u *line;
-  colnr_T len;
-
   if (pos->lnum > buf->b_ml.ml_line_count) {
     pos->lnum = buf->b_ml.ml_line_count;
   }
 
   if (pos->col > 0) {
-    line = ml_get_buf(buf, pos->lnum, false);
-    len = (colnr_T)STRLEN(line);
+    char_u *line = ml_get_buf(buf, pos->lnum, false);
+    colnr_T len = (colnr_T)STRLEN(line);
     if (pos->col > len) {
       pos->col = len;
     }
@@ -343,12 +338,11 @@ void check_cursor_col(void)
 /// @see mb_check_adjust_col
 void check_cursor_col_win(win_T *win)
 {
-  colnr_T len;
   colnr_T oldcol = win->w_cursor.col;
   colnr_T oldcoladd = win->w_cursor.col + win->w_cursor.coladd;
   unsigned int cur_ve_flags = get_ve_flags();
 
-  len = (colnr_T)STRLEN(ml_get_buf(win->w_buffer, win->w_cursor.lnum, false));
+  colnr_T len = (colnr_T)STRLEN(ml_get_buf(win->w_buffer, win->w_cursor.lnum, false));
   if (len == 0) {
     win->w_cursor.col = 0;
   } else if (win->w_cursor.col >= len) {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -94,7 +94,6 @@ Array mode_style_array(void)
 /// @returns error message for an illegal option, NULL otherwise.
 char *parse_shape_opt(int what)
 {
-  char_u *modep;
   char_u *colonp;
   char_u *commap;
   char_u *slashp;
@@ -119,7 +118,7 @@ char *parse_shape_opt(int what)
       }
     }
     // Repeat for all comma separated parts.
-    modep = p_guicursor;
+    char_u *modep = p_guicursor;
     while (modep != NULL && *modep != NUL) {
       colonp = vim_strchr(modep, ':');
       commap = vim_strchr(modep, ',');

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -58,7 +58,6 @@ void do_debug(char_u *cmd)
   tasave_T typeaheadbuf;
   bool typeahead_saved = false;
   int save_ignore_script = 0;
-  int save_ex_normal_busy;
   int n;
   char_u *cmdline = NULL;
   char_u *p;
@@ -117,7 +116,7 @@ void do_debug(char_u *cmd)
     // with the commands being executed.  Reset "ex_normal_busy" to avoid
     // the side effects of using ":normal". Save the stuff buffer and make
     // it empty. Set ignore_script to avoid reading from script input.
-    save_ex_normal_busy = ex_normal_busy;
+    int save_ex_normal_busy = ex_normal_busy;
     ex_normal_busy = 0;
     if (!debug_greedy) {
       save_typeahead(&typeaheadbuf);
@@ -390,11 +389,10 @@ static char_u *debug_skipped_name;
 /// Called from do_one_cmd() before executing a command.
 void dbg_check_breakpoint(exarg_T *eap)
 {
-  char *p;
-
   debug_skipped = false;
   if (debug_breakpoint_name != NULL) {
     if (!eap->skip) {
+      char *p;
       // replace K_SNR with "<SNR>"
       if (debug_breakpoint_name[0] == K_SPECIAL
           && debug_breakpoint_name[1] == KS_EXTRA
@@ -430,12 +428,10 @@ void dbg_check_breakpoint(exarg_T *eap)
 /// @return true when the debug mode is entered this time.
 bool dbg_check_skipped(exarg_T *eap)
 {
-  int prev_got_int;
-
   if (debug_skipped) {
     // Save the value of got_int and reset it.  We don't want a previous
     // interruption cause flushing the input buffer.
-    prev_got_int = got_int;
+    int prev_got_int = got_int;
     got_int = false;
     debug_breakpoint_name = debug_skipped_name;
     // eap->skip is true
@@ -482,12 +478,11 @@ static int dbg_parsearg(char_u *arg, garray_T *gap)
 {
   char_u *p = arg;
   char_u *q;
-  struct debuggy *bp;
   bool here = false;
 
   ga_grow(gap, 1);
 
-  bp = &DEBUGGY(gap, gap->ga_len);
+  struct debuggy *bp = &DEBUGGY(gap, gap->ga_len);
 
   // Find "func" or "file".
   if (STRNCMP(p, "func", 4) == 0) {
@@ -564,16 +559,13 @@ static int dbg_parsearg(char_u *arg, garray_T *gap)
 /// ":breakadd".  Also used for ":profile".
 void ex_breakadd(exarg_T *eap)
 {
-  struct debuggy *bp;
-  garray_T *gap;
-
-  gap = &dbg_breakp;
+  garray_T *gap = &dbg_breakp;
   if (eap->cmdidx == CMD_profile) {
     gap = &prof_ga;
   }
 
   if (dbg_parsearg(eap->arg, gap) == OK) {
-    bp = &DEBUGGY(gap, gap->ga_len);
+    struct debuggy *bp = &DEBUGGY(gap, gap->ga_len);
     bp->dbg_forceit = eap->forceit;
 
     if (bp->dbg_type != DBG_EXPR) {
@@ -616,20 +608,18 @@ void ex_debuggreedy(exarg_T *eap)
 void ex_breakdel(exarg_T *eap)
 {
   struct debuggy *bp, *bpi;
-  int nr;
   int todel = -1;
   bool del_all = false;
   linenr_T best_lnum = 0;
-  garray_T *gap;
+  garray_T *gap = &dbg_breakp;
 
-  gap = &dbg_breakp;
   if (eap->cmdidx == CMD_profdel) {
     gap = &prof_ga;
   }
 
   if (ascii_isdigit(*eap->arg)) {
     // ":breakdel {nr}"
-    nr = atoi((char *)eap->arg);
+    int nr = atoi((char *)eap->arg);
     for (int i = 0; i < gap->ga_len; i++) {
       if (DEBUGGY(gap, i).dbg_nr == nr) {
         todel = i;
@@ -693,13 +683,11 @@ void ex_breakdel(exarg_T *eap)
 /// ":breaklist".
 void ex_breaklist(exarg_T *eap)
 {
-  struct debuggy *bp;
-
   if (GA_EMPTY(&dbg_breakp)) {
     msg(_("No breakpoints defined"));
   } else {
     for (int i = 0; i < dbg_breakp.ga_len; i++) {
-      bp = &BREAKP(i);
+      struct debuggy *bp = &BREAKP(i);
       if (bp->dbg_type == DBG_FILE) {
         home_replace(NULL, bp->dbg_name, NameBuff, MAXPATHL, true);
       }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -166,8 +166,7 @@ void diff_buf_add(buf_T *buf)
     return;
   }
 
-  int i;
-  for (i = 0; i < DB_COUNT; i++) {
+  for (int i = 0; i < DB_COUNT; i++) {
     if (curtab->tp_diffbuf[i] == NULL) {
       curtab->tp_diffbuf[i] = buf;
       curtab->tp_diff_invalid = true;
@@ -304,7 +303,6 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T
   diff_T *dprev = NULL;
   diff_T *dp = tp->tp_first_diff;
 
-  linenr_T last;
   linenr_T lnum_deleted = line1;  // lnum of remaining deletion
   int n;
   int off;
@@ -354,7 +352,7 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T
     //      3     5  6
 
     // compute last line of this change
-    last = dp->df_lnum[idx] + dp->df_count[idx] - 1;
+    linenr_T last = dp->df_lnum[idx] + dp->df_count[idx] - 1;
 
     // 1. change completely above line1: nothing to do
     if (last >= line1 - 1) {
@@ -628,8 +626,7 @@ static void diff_check_unchanged(tabpage_T *tp, diff_T *dp)
 /// @return OK if the diff block doesn't contain invalid line numbers.
 static int diff_check_sanity(tabpage_T *tp, diff_T *dp)
 {
-  int i;
-  for (i = 0; i < DB_COUNT; i++) {
+  for (int i = 0; i < DB_COUNT; i++) {
     if (tp->tp_diffbuf[i] != NULL) {
       if (dp->df_lnum[i] + dp->df_count[i] - 1
           > tp->tp_diffbuf[i]->b_ml.ml_line_count) {
@@ -719,16 +716,13 @@ static void clear_diffout(diffout_T *dout)
 /// @return FAIL for failure.
 static int diff_write_buffer(buf_T *buf, diffin_T *din)
 {
-  linenr_T lnum;
-  char_u *s;
   long len = 0;
-  char_u *ptr;
 
   // xdiff requires one big block of memory with all the text.
-  for (lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
+  for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
     len += (long)STRLEN(ml_get_buf(buf, lnum, false)) + 1;
   }
-  ptr = try_malloc(len);
+  char_u *ptr = try_malloc(len);
   if (ptr == NULL) {
     // Allocating memory failed.  This can happen, because we try to read
     // the whole buffer text into memory.  Set the failed flag, the diff
@@ -746,8 +740,8 @@ static int diff_write_buffer(buf_T *buf, diffin_T *din)
   din->din_mmfile.size = len;
 
   len = 0;
-  for (lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
-    for (s = ml_get_buf(buf, lnum, false); *s != NUL;) {
+  for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
+    for (char_u *s = ml_get_buf(buf, lnum, false); *s != NUL;) {
       if (diff_flags & DIFF_ICASE) {
         char_u cbuf[MB_MAXBYTES + 1];
 
@@ -811,9 +805,6 @@ static int diff_write(buf_T *buf, diffin_T *din)
 /// @param eap   can be NULL
 static void diff_try_update(diffio_T *dio, int idx_orig, exarg_T *eap)
 {
-  buf_T *buf;
-  int idx_new;
-
   if (dio->dio_internal) {
     ga_init(&dio->dio_diff.dout_ga, sizeof(char *), 1000);
   } else {
@@ -833,9 +824,11 @@ static void diff_try_update(diffio_T *dio, int idx_orig, exarg_T *eap)
     goto theend;
   }
 
+  buf_T *buf;
+
   // :diffupdate!
   if (eap != NULL && eap->forceit) {
-    for (idx_new = idx_orig; idx_new < DB_COUNT; idx_new++) {
+    for (int idx_new = idx_orig; idx_new < DB_COUNT; idx_new++) {
       buf = curtab->tp_diffbuf[idx_new];
       if (buf_valid(buf)) {
         buf_check_timestamp(buf);
@@ -850,7 +843,7 @@ static void diff_try_update(diffio_T *dio, int idx_orig, exarg_T *eap)
   }
 
   // Make a difference between the first buffer and every other.
-  for (idx_new = idx_orig + 1; idx_new < DB_COUNT; idx_new++) {
+  for (int idx_new = idx_orig + 1; idx_new < DB_COUNT; idx_new++) {
     buf = curtab->tp_diffbuf[idx_new];
     if (buf == NULL || buf->b_ml.ml_mfp == NULL) {
       continue;  // skip buffer that isn't loaded
@@ -893,10 +886,8 @@ int diff_internal(void)
 ///
 static int diff_internal_failed(void)
 {
-  int idx;
-
   // Only need to do something when there is another buffer.
-  for (idx = 0; idx < DB_COUNT; idx++) {
+  for (int idx = 0; idx < DB_COUNT; idx++) {
     if (curtab->tp_diffbuf[idx] != NULL
         && curtab->tp_diffbuf[idx]->b_diff_failed) {
       return true;
@@ -1775,9 +1766,8 @@ static void diff_copy_entry(diff_T *dprev, diff_T *dp, int idx_orig, int idx_new
 void diff_clear(tabpage_T *tp)
   FUNC_ATTR_NONNULL_ALL
 {
-  diff_T *p;
   diff_T *next_p;
-  for (p = tp->tp_first_diff; p != NULL; p = next_p) {
+  for (diff_T *p = tp->tp_first_diff; p != NULL; p = next_p) {
     next_p = p->df_next;
     xfree(p);
   }
@@ -1799,12 +1789,8 @@ void diff_clear(tabpage_T *tp)
 /// @return diff status.
 int diff_check(win_T *wp, linenr_T lnum)
 {
-  int idx;  // index in tp_diffbuf[] for this buffer
   diff_T *dp;
-  int maxcount;
-  int i;
   buf_T *buf = wp->w_buffer;
-  int cmp;
 
   if (curtab->tp_diff_invalid) {
     // update after a big change
@@ -1821,7 +1807,7 @@ int diff_check(win_T *wp, linenr_T lnum)
     return 0;
   }
 
-  idx = diff_buf_idx(buf);
+  int idx = diff_buf_idx(buf);  // index in tp_diffbuf[] for this buffer
 
   if (idx == DB_COUNT) {
     // no diffs for buffer "buf"
@@ -1850,9 +1836,9 @@ int diff_check(win_T *wp, linenr_T lnum)
     // Changed or inserted line.  If the other buffers have a count of
     // zero, the lines were inserted.  If the other buffers have the same
     // count, check if the lines are identical.
-    cmp = false;
+    int cmp = false;
 
-    for (i = 0; i < DB_COUNT; i++) {
+    for (int i = 0; i < DB_COUNT; i++) {
       if ((i != idx) && (curtab->tp_diffbuf[i] != NULL)) {
         if (dp->df_count[i] == 0) {
           zero = true;
@@ -1869,7 +1855,7 @@ int diff_check(win_T *wp, linenr_T lnum)
     if (cmp) {
       // Compare all lines.  If they are equal the lines were inserted
       // in some buffers, deleted in others, but not changed.
-      for (i = 0; i < DB_COUNT; i++) {
+      for (int i = 0; i < DB_COUNT; i++) {
         if ((i != idx)
             && (curtab->tp_diffbuf[i] != NULL)
             && (dp->df_count[i] != 0)) {
@@ -1898,8 +1884,8 @@ int diff_check(win_T *wp, linenr_T lnum)
 
   // Insert filler lines above the line just below the change.  Will return
   // 0 when this buf had the max count.
-  maxcount = 0;
-  for (i = 0; i < DB_COUNT; i++) {
+  int maxcount = 0;
+  for (int i = 0; i < DB_COUNT; i++) {
     if ((curtab->tp_diffbuf[i] != NULL) && (dp->df_count[i] > maxcount)) {
       maxcount = dp->df_count[i];
     }
@@ -2030,8 +2016,6 @@ void diff_set_topline(win_T *fromwin, win_T *towin)
   buf_T *frombuf = fromwin->w_buffer;
   linenr_T lnum = fromwin->w_topline;
   diff_T *dp;
-  int max_count;
-  int i;
 
   int fromidx = diff_buf_idx(frombuf);
   if (fromidx == DB_COUNT) {
@@ -2071,9 +2055,9 @@ void diff_set_topline(win_T *fromwin, win_T *towin)
     if (lnum >= dp->df_lnum[fromidx]) {
       // Inside a change: compute filler lines. With three or more
       // buffers we need to know the largest count.
-      max_count = 0;
+      int max_count = 0;
 
-      for (i = 0; i < DB_COUNT; i++) {
+      for (int i = 0; i < DB_COUNT; i++) {
         if ((curtab->tp_diffbuf[i] != NULL) && (max_count < dp->df_count[i])) {
           max_count = dp->df_count[i];
         }
@@ -2421,7 +2405,6 @@ bool diff_infold(win_T *wp, linenr_T lnum)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(1)
 {
   bool other = false;
-  diff_T *dp;
 
   // Return if 'diff' isn't set.
   if (!wp->w_p_diff) {
@@ -2453,7 +2436,7 @@ bool diff_infold(win_T *wp, linenr_T lnum)
     return true;
   }
 
-  for (dp = curtab->tp_first_diff; dp != NULL; dp = dp->df_next) {
+  for (diff_T *dp = curtab->tp_first_diff; dp != NULL; dp = dp->df_next) {
     // If this change is below the line there can't be any further match.
     if (dp->df_lnum[idx] - diff_context > lnum) {
       break;
@@ -2505,7 +2488,6 @@ void ex_diffgetput(exarg_T *eap)
   int count;
   linenr_T off = 0;
   diff_T *dp;
-  diff_T *dprev;
   diff_T *dfree;
   int i;
   int added;
@@ -2641,7 +2623,7 @@ void ex_diffgetput(exarg_T *eap)
     }
   }
 
-  dprev = NULL;
+  diff_T *dprev = NULL;
 
   for (dp = curtab->tp_first_diff; dp != NULL;) {
     if (dp->df_lnum[idx_cur] > eap->line2 + off) {
@@ -2924,13 +2906,10 @@ int diff_move_to(int dir, long count)
 /// "buf1" in diff mode.
 static linenr_T diff_get_corresponding_line_int(buf_T *buf1, linenr_T lnum1)
 {
-  int idx1;
-  int idx2;
-  diff_T *dp;
   int baseline = 0;
 
-  idx1 = diff_buf_idx(buf1);
-  idx2 = diff_buf_idx(curbuf);
+  int idx1 = diff_buf_idx(buf1);
+  int idx2 = diff_buf_idx(curbuf);
 
   if ((idx1 == DB_COUNT)
       || (idx2 == DB_COUNT)
@@ -2948,7 +2927,7 @@ static linenr_T diff_get_corresponding_line_int(buf_T *buf1, linenr_T lnum1)
     return lnum1;
   }
 
-  for (dp = curtab->tp_first_diff; dp != NULL; dp = dp->df_next) {
+  for (diff_T *dp = curtab->tp_first_diff; dp != NULL; dp = dp->df_next) {
     if (dp->df_lnum[idx1] > lnum1) {
       return lnum1 - baseline;
     }
@@ -3004,11 +2983,8 @@ linenr_T diff_get_corresponding_line(buf_T *buf1, linenr_T lnum1)
 linenr_T diff_lnum_win(linenr_T lnum, win_T *wp)
 {
   diff_T *dp;
-  int idx;
-  int i;
-  linenr_T n;
 
-  idx = diff_buf_idx(curbuf);
+  int idx = diff_buf_idx(curbuf);
 
   if (idx == DB_COUNT) {
     // safety check
@@ -3034,14 +3010,14 @@ linenr_T diff_lnum_win(linenr_T lnum, win_T *wp)
   }
 
   // Find index for "wp".
-  i = diff_buf_idx(wp->w_buffer);
+  int i = diff_buf_idx(wp->w_buffer);
 
   if (i == DB_COUNT) {
     // safety check
     return (linenr_T)0;
   }
 
-  n = lnum + (dp->df_lnum[i] - dp->df_lnum[idx]);
+  linenr_T n = lnum + (dp->df_lnum[i] - dp->df_lnum[idx]);
   if (n > dp->df_lnum[i] + dp->df_count[i]) {
     n = dp->df_lnum[i] + dp->df_count[i];
   }
@@ -3054,16 +3030,14 @@ linenr_T diff_lnum_win(linenr_T lnum, win_T *wp)
 ///
 static int parse_diff_ed(char_u *line, diffhunk_T *hunk)
 {
-  char_u *p;
-  long f1, l1, f2, l2;
-  int difftype;
+  long l1, l2;
 
   // The line must be one of three formats:
   // change: {first}[,{last}]c{first}[,{last}]
   // append: {first}a{first}[,{last}]
   // delete: {first}[,{last}]d{first}
-  p = line;
-  f1 = getdigits(&p, true, 0);
+  char_u *p = line;
+  long f1 = getdigits(&p, true, 0);
   if (*p == ',') {
     p++;
     l1 = getdigits(&p, true, 0);
@@ -3073,8 +3047,8 @@ static int parse_diff_ed(char_u *line, diffhunk_T *hunk)
   if (*p != 'a' && *p != 'c' && *p != 'd') {
     return FAIL;        // invalid diff format
   }
-  difftype = *p++;
-  f2 = getdigits(&p, true, 0);
+  int difftype = *p++;
+  long f2 = getdigits(&p, true, 0);
   if (*p == ',') {
     p++;
     l2 = getdigits(&p, true, 0);
@@ -3108,14 +3082,14 @@ static int parse_diff_ed(char_u *line, diffhunk_T *hunk)
 ///
 static int parse_diff_unified(char_u *line, diffhunk_T *hunk)
 {
-  char_u *p;
-  long oldline, oldcount, newline, newcount;
-
   // Parse unified diff hunk header:
   // @@ -oldline,oldcount +newline,newcount @@
-  p = line;
+  char_u *p = line;
   if (*p++ == '@' && *p++ == '@' && *p++ == ' ' && *p++ == '-') {
-    oldline = getdigits(&p, true, 0);
+    long oldcount;
+    long newline;
+    long newcount;
+    long oldline = getdigits(&p, true, 0);
     if (*p == ',') {
       p++;
       oldcount = getdigits(&p, true, 0);

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1506,7 +1506,6 @@ char_u *get_digraph_for_char(int val_arg)
 /// @returns composed character, or NUL when ESC was used.
 int get_digraph(bool cmdline)
 {
-  int cc;
   no_mapping++;
   int c = plain_vgetc();
   no_mapping--;
@@ -1526,7 +1525,7 @@ int get_digraph(bool cmdline)
       add_to_showcmd(c);
     }
     no_mapping++;
-    cc = plain_vgetc();
+    int cc = plain_vgetc();
     no_mapping--;
 
     if (cc != ESC) {
@@ -1614,17 +1613,14 @@ int getdigraph(int char1, int char2, bool meta_char)
 /// @param str
 void putdigraph(char_u *str)
 {
-  char_u char1, char2;
-  digr_T *dp;
-
   while (*str != NUL) {
     str = skipwhite(str);
 
     if (*str == NUL) {
       return;
     }
-    char1 = *str++;
-    char2 = *str++;
+    char_u char1 = *str++;
+    char_u char2 = *str++;
 
     if (char2 == 0) {
       emsg(_(e_invarg));
@@ -1644,7 +1640,7 @@ void putdigraph(char_u *str)
     int n = getdigits_int(&str, true, 0);
 
     // If the digraph already exists, replace the result.
-    dp = (digr_T *)user_digraphs.ga_data;
+    digr_T *dp = (digr_T *)user_digraphs.ga_data;
 
     int i;
     for (i = 0; i < user_digraphs.ga_len; i++) {
@@ -1677,12 +1673,11 @@ static void digraph_header(const char *msg)
 
 void listdigraphs(bool use_headers)
 {
-  digr_T *dp;
   result_T previous = 0;
 
   msg_putchar('\n');
 
-  dp = digraphdefault;
+  digr_T *dp = digraphdefault;
 
   for (int i = 0; dp->char1 != NUL && !got_int; i++) {
     digr_T tmp;
@@ -1749,11 +1744,7 @@ static void printdigraph(const digr_T *dp, result_T *previous)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u buf[30];
-  char_u *p;
-
-  int list_width;
-
-  list_width = 13;
+  int list_width = 13;
 
   if (dp->result != 0) {
     if (previous != NULL) {
@@ -1780,7 +1771,7 @@ static void printdigraph(const digr_T *dp, result_T *previous)
       }
     }
 
-    p = &buf[0];
+    char_u *p = &buf[0];
     *p++ = dp->char1;
     *p++ = dp->char2;
     *p++ = ' ';
@@ -1863,8 +1854,6 @@ char *keymap_init(void)
 /// @param eap
 void ex_loadkeymap(exarg_T *eap)
 {
-  char_u *line;
-  char_u *p;
   char_u *s;
 
 #define KMAP_LLEN 200  // max length of "to" and "from" together
@@ -1887,13 +1876,13 @@ void ex_loadkeymap(exarg_T *eap)
 
   // Get each line of the sourced file, break at the end.
   for (;;) {
-    line = eap->getline(0, eap->cookie, 0, true);
+    char_u *line = eap->getline(0, eap->cookie, 0, true);
 
     if (line == NULL) {
       break;
     }
 
-    p = skipwhite(line);
+    char_u *p = skipwhite(line);
 
     if ((*p != '"') && (*p != NUL)) {
       kmap_T *kp = GA_APPEND_VIA_PTR(kmap_T, &curbuf->b_kmap_ga);
@@ -1946,7 +1935,6 @@ static void keymap_unload(void)
 {
   char_u buf[KMAP_MAXLEN + 10];
   char_u *save_cpo = p_cpo;
-  kmap_T *kp;
 
   if (!(curbuf->b_kmap_state & KEYMAP_LOADED)) {
     return;
@@ -1956,7 +1944,7 @@ static void keymap_unload(void)
   p_cpo = (char_u *)"C";
 
   // clear the ":lmap"s
-  kp = (kmap_T *)curbuf->b_kmap_ga.ga_data;
+  kmap_T *kp = (kmap_T *)curbuf->b_kmap_ga.ga_data;
 
   for (int i = 0; i < curbuf->b_kmap_ga.ga_len; i++) {
     vim_snprintf((char *)buf, sizeof(buf), "<buffer> %s", kp[i].from);


### PR DESCRIPTION
I read on Stack overflow that restricting variable scope helps
preventing bugs and increases performance because the compiler can
optimize better. This sounds super useful, we should definitely try it
out.
