### PR TITLE
vim-patch:8.2.{4555,4559,4568,4569}: make `getmousepos()` return the text column

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3753,9 +3753,8 @@ static void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       winrow = row + 1 + wp->w_border_adj[0];  // Adjust by 1 for top border
       wincol = col + 1 + wp->w_border_adj[3];  // Adjust by 1 for left border
       if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
-        if (!mouse_comp_pos(wp, &row, &col, &lnum)) {
-          col = vcol2col(wp, lnum, col);
-        }
+        (void)mouse_comp_pos(wp, &row, &col, &lnum);
+        col = vcol2col(wp, lnum, col);
         column = col + 1;
       }
     }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3753,18 +3753,15 @@ static void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       winrow = row + 1 + wp->w_border_adj[0];  // Adjust by 1 for top border
       wincol = col + 1 + wp->w_border_adj[3];  // Adjust by 1 for left border
       if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
-        char_u *p;
         int count;
 
         mouse_comp_pos(wp, &row, &col, &line);
 
-        // limit to text length plus one
-        p = ml_get_buf(wp->w_buffer, line, false);
-        count = (int)STRLEN(p);
+        // limit to text size plus one
+        count = linetabsize(ml_get_buf(wp->w_buffer, line, false));
         if (col > count) {
           col = count;
         }
-
         column = col + 1;
       }
     }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3734,7 +3734,7 @@ static void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   varnumber_T winid = 0;
   varnumber_T winrow = 0;
   varnumber_T wincol = 0;
-  linenr_T line = 0;
+  linenr_T lnum = 0;
   varnumber_T column = 0;
 
   tv_dict_alloc_ret(rettv);
@@ -3753,14 +3753,8 @@ static void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       winrow = row + 1 + wp->w_border_adj[0];  // Adjust by 1 for top border
       wincol = col + 1 + wp->w_border_adj[3];  // Adjust by 1 for left border
       if (row >= 0 && row < wp->w_height && col >= 0 && col < wp->w_width) {
-        int count;
-
-        mouse_comp_pos(wp, &row, &col, &line);
-
-        // limit to text size plus one
-        count = linetabsize(ml_get_buf(wp->w_buffer, line, false));
-        if (col > count) {
-          col = count;
+        if (!mouse_comp_pos(wp, &row, &col, &lnum)) {
+          col = vcol2col(wp, lnum, col);
         }
         column = col + 1;
       }
@@ -3769,7 +3763,7 @@ static void f_getmousepos(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   tv_dict_add_nr(d, S_LEN("winid"), winid);
   tv_dict_add_nr(d, S_LEN("winrow"), winrow);
   tv_dict_add_nr(d, S_LEN("wincol"), wincol);
-  tv_dict_add_nr(d, S_LEN("line"), (varnumber_T)line);
+  tv_dict_add_nr(d, S_LEN("line"), (varnumber_T)lnum);
   tv_dict_add_nr(d, S_LEN("column"), column);
 }
 

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -535,6 +535,22 @@ static win_T *mouse_find_grid_win(int *gridp, int *rowp, int *colp)
   return NULL;
 }
 
+/// Convert a virtual (screen) column to a character column.
+/// The first column is one.
+colnr_T vcol2col(win_T *const wp, const linenr_T lnum, const colnr_T vcol)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  // try to advance to the specified column
+  char_u *ptr = ml_get_buf(wp->w_buffer, lnum, false);
+  char_u *const line = ptr;
+  colnr_T count = 0;
+  while (count < vcol && *ptr != NUL) {
+    count += win_lbr_chartabsize(wp, line, ptr, count, NULL);
+    MB_PTR_ADV(ptr);
+  }
+  return (colnr_T)(ptr - line);
+}
+
 /// Set UI mouse depending on current mode and 'mouse'.
 ///
 /// Emits mouse_on/mouse_off UI event (unless 'mouse' is empty).

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1801,6 +1801,33 @@ func Test_getmousepos()
         \ line: 1,
         \ column: 8,
         \ }, getmousepos())
+
+  " If the mouse is positioned past the last buffer line, "line" and "column"
+  " should act like it's positioned on the last buffer line.
+  " call test_setmouse(2, 25)
+  call nvim_input_mouse('left', 'press', '', 0, 1, 24)
+  call getchar() " wait for and consume the mouse press
+  call assert_equal(#{
+        \ screenrow: 2,
+        \ screencol: 25,
+        \ winid: win_getid(),
+        \ winrow: 2,
+        \ wincol: 25,
+        \ line: 1,
+        \ column: 4,
+        \ }, getmousepos())
+  " call test_setmouse(2, 50)
+  call nvim_input_mouse('left', 'press', '', 0, 1, 49)
+  call getchar() " wait for and consume the mouse press
+  call assert_equal(#{
+        \ screenrow: 2,
+        \ screencol: 50,
+        \ winid: win_getid(),
+        \ winrow: 2,
+        \ wincol: 50,
+        \ line: 1,
+        \ column: 8,
+        \ }, getmousepos())
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1762,6 +1762,36 @@ func Test_getcurpos_setpos()
   call assert_equal([0, 0, 0, 0, 0], getcurpos(1999))
 endfunc
 
+func Test_getmousepos()
+  enew!
+  call setline(1, "\t\t\t1234")
+  " call test_setmouse(1, 25)
+  call nvim_input_mouse('left', 'press', '', 0, 0, 24)
+  call getchar() " wait for and consume the mouse press
+  call assert_equal(#{
+        \ screenrow: 1,
+        \ screencol: 25,
+        \ winid: win_getid(),
+        \ winrow: 1,
+        \ wincol: 25,
+        \ line: 1,
+        \ column: 25,
+        \ }, getmousepos())
+  " call test_setmouse(1, 50)
+  call nvim_input_mouse('left', 'press', '', 0, 0, 49)
+  call getchar() " wait for and consume the mouse press
+  call assert_equal(#{
+        \ screenrow: 1,
+        \ screencol: 50,
+        \ winid: win_getid(),
+        \ winrow: 1,
+        \ wincol: 50,
+        \ line: 1,
+        \ column: 29,
+        \ }, getmousepos())
+  bwipe!
+endfunc
+
 func HasDefault(msg = 'msg')
   return a:msg
 endfunc

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1765,6 +1765,18 @@ endfunc
 func Test_getmousepos()
   enew!
   call setline(1, "\t\t\t1234")
+  " call test_setmouse(1, 1)
+  call nvim_input_mouse('left', 'press', '', 0, 0, 0)
+  call getchar() " wait for and consume the mouse press
+  call assert_equal(#{
+        \ screenrow: 1,
+        \ screencol: 1,
+        \ winid: win_getid(),
+        \ winrow: 1,
+        \ wincol: 1,
+        \ line: 1,
+        \ column: 1,
+        \ }, getmousepos())
   " call test_setmouse(1, 25)
   call nvim_input_mouse('left', 'press', '', 0, 0, 24)
   call getchar() " wait for and consume the mouse press
@@ -1775,7 +1787,7 @@ func Test_getmousepos()
         \ winrow: 1,
         \ wincol: 25,
         \ line: 1,
-        \ column: 25,
+        \ column: 4,
         \ }, getmousepos())
   " call test_setmouse(1, 50)
   call nvim_input_mouse('left', 'press', '', 0, 0, 49)
@@ -1787,7 +1799,7 @@ func Test_getmousepos()
         \ winrow: 1,
         \ wincol: 50,
         \ line: 1,
-        \ column: 29,
+        \ column: 8,
         \ }, getmousepos())
   bwipe!
 endfunc


### PR DESCRIPTION
**vim-patch:8.2.4555: getmousepos() returns the wrong column**

Problem:    getmousepos() returns the wrong column. (Ernie Rael)
Solution:   Limit to the text size, not the number of bytes.
https://github.com/vim/vim/commit/986b0fd0c550d9834a3cc45dd87555c13152c391

test_setmouse is N/A; adjust test for Nvim.


**vim-patch:8.2.4559: getmousepos() returns the screen column**

Problem:    getmousepos() returns the screen column. (Ernie Rael)
Solution:   Return the text column, as documented.
https://github.com/vim/vim/commit/533870a98501fac2b51ef4bc489fac3a055a41a9

Re-introduce vcol2col, which was removed in 71b1f4e for being unused.
Move it to mouse.c (like in v8.1.2062, which hasn't been ported yet).


**vim-patch:8.2.4568: getmousepos() does not compute the column below the last line**

Problem:    getmousepos() does not compute the column below the last line.
Solution:   Also compute the column when the mouse is below the last line.
            (Sean Dewar, closes vim/vim#9946)
https://github.com/vim/vim/commit/10792feebd237aee89270669e509e85cafdfac60

test_setmouse is N/A.
