### PR TITLE
refactor: use Lua autocommands in filetype.lua

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -7,26 +7,36 @@ if vim.g.do_filetype_lua ~= 1 then
   return
 end
 
--- TODO: Remove vim.cmd once Lua autocommands land
-vim.cmd [[
-augroup filetypedetect
-au BufRead,BufNewFile * call v:lua.vim.filetype.match(expand('<afile>'))
+vim.api.nvim_create_augroup("filetypedetect", {clear = false})
 
-" These *must* be sourced after the autocommand above is created
+vim.api.nvim_create_autocmd({"BufRead", "BufNewFile"}, {
+  group = "filetypedetect",
+  callback = function()
+    vim.filetype.match(vim.fn.expand("<afile>"))
+  end,
+})
+
+-- These *must* be sourced after the autocommand above is created
+vim.cmd [[
 runtime! ftdetect/*.vim
 runtime! ftdetect/*.lua
-
-" Set a marker so that the ftdetect scripts are not sourced a second time by filetype.vim
-let g:did_load_ftdetect = 1
-
-" If filetype.vim is disabled, set up the autocmd to use scripts.vim
-if exists('did_load_filetypes')
-  au BufRead,BufNewFile * if !did_filetype() && expand('<amatch>') !~ g:ft_ignore_pat | runtime! scripts.vim | endif
-  au StdinReadPost * if !did_filetype() | runtime! scripts.vim | endif
-endif
-
-augroup END
 ]]
+
+-- Set a marker so that the ftdetect scripts are not sourced a second time by filetype.vim
+vim.g.did_load_ftdetect = 1
+
+-- If filetype.vim is disabled, set up the autocmd to use scripts.vim
+if vim.g.did_load_filetypes then
+  vim.api.nvim_create_autocmd({"BufRead", "BufNewFile"}, {
+    group = "filetypedetect",
+    command = "if !did_filetype() && expand('<amatch>') !~ g:ft_ignore_pat | runtime! scripts.vim | endif",
+  })
+
+  vim.api.nvim_create_autocmd("StdinReadPost", {
+    group = "filetypedetect",
+    command = "if !did_filetype() | runtime! scripts.vim | endif",
+  })
+end
 
 if not vim.g.ft_ignore_pat then
   vim.g.ft_ignore_pat = "\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$"


### PR DESCRIPTION
N.B. Passing the equivalent of `expand("<amatch>")` as the first argument to
the `callback` function would be nice, and would reduce the need for
`vim.fn.expand("<amatch>")` in autocommand callbacks.
