### PR TITLE
fix(checkhealth): downgrade missing provider errors to warnings

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -312,7 +312,10 @@ function! s:check_python() abort
 
   " No Python executable could `import neovim`, or host_prog_var was used.
   if !empty(pythonx_errors)
-    call health#report_error('Python provider error:', pythonx_errors)
+    call health#report_warn(pythonx_errors, ["See :help provider-python for more information.", 
+          \ "You may disable this provider (and warning) by adding `let g:loaded_python3_provider = 0` to your init.vim"
+          \])
+"If you wish to disable the Python provider (and this warning), then "
 
   elseif !empty(pyname) && empty(python_exe)
     if !exists('g:'.host_prog_var)
@@ -573,7 +576,8 @@ function! s:check_ruby() abort
           \ ['Run `gem install neovim` to ensure the neovim RubyGem is installed.',
           \  'Run `gem environment` to ensure the gem bin directory is in $PATH.',
           \  'If you are using rvm/rbenv/chruby, try "rehashing".',
-          \  'See :help g:ruby_host_prog for non-standard gem installations.'])
+          \  'See :help g:ruby_host_prog for non-standard gem installations.',
+          \ "You may disable this provider (and warning) by adding `let g:loaded_ruby_provider = 0` to your init.vim"])
     return
   endif
   call health#report_info('Host: '. host)
@@ -634,7 +638,8 @@ function! s:check_node() abort
   if empty(host)
     call health#report_warn('Missing "neovim" npm (or yarn) package.',
           \ ['Run in shell: npm install -g neovim',
-          \  'Run in shell (if you use yarn): yarn global add neovim'])
+          \  'Run in shell (if you use yarn): yarn global add neovim',
+          \ "You may disable this provider (and warning) by adding `let g:loaded_node_provider = 0` to your init.vim"])
     return
   endif
   call health#report_info('Nvim node.js host: '. host)
@@ -683,10 +688,11 @@ function! s:check_perl() abort
     return
   endif
 
-  let [perl_exec, perl_errors] = provider#perl#Detect()
+  let [perl_exec, perl_warnings] = provider#perl#Detect()
   if empty(perl_exec)
-    if !empty(perl_errors)
-      call health#report_error('perl provider error:', perl_errors)
+    if !empty(perl_warnings)
+      call health#report_warn(perl_warnings,["See :help provider-perl for more information." ,
+            \ "You may disable this provider (and warning) by adding `let g:loaded_node_provider = 0` to your init.vim"])
 	else
       call health#report_warn('No usable perl executable found')
     endif

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -56,7 +56,7 @@ function! provider#pythonx#DetectByModule(module, major_version) abort
   endfor
 
   " No suitable Python executable found.
-  return ['', 'provider/pythonx: Could not load Python '.a:major_version.":\n".join(errors, "\n")]
+  return ['', 'Could not load Python '.a:major_version.":\n".join(errors, "\n")]
 endfunction
 
 " Returns array: [prog_exitcode, prog_version]
@@ -99,7 +99,7 @@ function! provider#pythonx#CheckForModule(prog, module, major_version) abort
   endif
 
   if prog_exitcode == 2
-    return [0, prog_path.' does not have the "' . a:module . '" module. :help provider-python']
+    return [0, prog_path.' does not have the "' . a:module . '" module.']
   elseif prog_exitcode == 127
     " This can happen with pyenv's shims.
     return [0, prog_path . ' does not exist: ' . prog_version]


### PR DESCRIPTION
I'm trying to come up with a smooth way to get rid of the warnings altogether
(for myself) since I don't use providers and feel the flashing WARNING
distracting. I'm considering adding a global variable, something like
g:ignore_provider_error to make checkhealth usable again.