### PR TITLE
vim-patch:8.2.4566: check for existing buffer in session file may not work

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -365,7 +365,7 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
       // edit that buffer, to not lose folding information (:edit resets
       // folds in other buffers)
       if (fprintf(fd,
-                  "if bufexists(\"%s\") | buffer %s | else | edit %s | endif\n"
+                  "if bufexists(fnamemodify(\"%s\", \":p\")) | buffer %s | else | edit %s | endif\n"
                   // Fixup :terminal buffer name. #7836
                   "if &buftype ==# 'terminal'\n"
                   "  silent file %s\n"

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -219,6 +219,7 @@ func Test_mksession_one_buffer_two_windows()
   let count1 = 0
   let count2 = 0
   let count2buf = 0
+  let bufexists = 0
   for line in lines
     if line =~ 'edit \f*Xtest1$'
       let count1 += 1
@@ -229,10 +230,14 @@ func Test_mksession_one_buffer_two_windows()
     if line =~ 'buffer \f\{-}Xtest2'
       let count2buf += 1
     endif
+    if line =~ 'bufexists(fnamemodify(.*, ":p")'
+      let bufexists += 1
+    endif
   endfor
   call assert_equal(1, count1, 'Xtest1 count')
   call assert_equal(2, count2, 'Xtest2 count')
   call assert_equal(2, count2buf, 'Xtest2 buffer count')
+  call assert_equal(2, bufexists)
 
   close
   bwipe!


### PR DESCRIPTION
#### vim-patch:8.2.4566: check for existing buffer in session file may not work

Problem:    Check for existing buffer in session file does not work for files
            in the home directory.
Solution:   Use fnamemodify(). (James Cherti, closes vim/vim#9945)  Add a test.
https://github.com/vim/vim/commit/7d42840033aedf36389208b62e28b4e0b251c199