### PR TITLE
vim-patch:8.1.0439: recursive use of getcmdline() still not protected

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -4001,7 +4001,6 @@ static char_u *eval_map_expr(mapblock_T *mp, int c)
   char_u *res;
   char_u *p = NULL;
   char_u *expr = NULL;
-  char_u *save_cmd;
   pos_T save_cursor;
   int save_msg_col;
   int save_msg_row;
@@ -4012,8 +4011,6 @@ static char_u *eval_map_expr(mapblock_T *mp, int c)
     expr = vim_strsave(mp->m_str);
     vim_unescape_ks(expr);
   }
-
-  save_cmd = save_cmdline_alloc();
 
   // Forbid changing text or using ":normal" to avoid most of the bad side
   // effects.  Also restore the cursor position.
@@ -4044,8 +4041,6 @@ static char_u *eval_map_expr(mapblock_T *mp, int c)
   curwin->w_cursor = save_cursor;
   msg_col = save_msg_col;
   msg_row = save_msg_row;
-
-  restore_cmdline_alloc(save_cmd);
 
   if (p == NULL) {
     return NULL;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -20,6 +20,7 @@
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/ex_getln.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
@@ -156,6 +157,7 @@ bool event_teardown(void)
 void early_init(mparm_T *paramp)
 {
   env_init();
+  cmdline_init();
   eval_init();          // init global variables
   init_path(argv0 ? argv0 : "nvim");
   init_normal_cmds();   // Init the table of Normal mode commands.


### PR DESCRIPTION
Continuation of #16628

#### vim-patch:8.1.0439: recursive use of getcmdline() still not protected

Problem:    Recursive use of getcmdline() still not protected.
Solution:   Instead of saving the command buffer when making a call which may
            cause recursiveness, save the buffer when actually being called
            recursively.
https://github.com/vim/vim/commit/438d176e35c16d56ff3bb7a80300197ce5a30c4f

Clear `ccline` earlier in `save_cmdline()` if `ccline` is in use so that `ccline.prev_ccline` can be assigned.