### PR TITLE
fix(mouse): check that mouse support is enabled for visual mode

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -280,6 +280,15 @@ static int get_fpos_of_mouse(pos_T *mpos)
   return IN_BUFFER;
 }
 
+/// Check that mouse support is enabled for visual mode
+static bool mouse_supports_visual(void)
+{
+  return !*p_mouse
+         || vim_strchr(p_mouse, 'a') != NULL
+         || vim_strchr(p_mouse, MOUSE_VISUAL) != NULL
+         || (curbuf->b_help && vim_strchr(p_mouse, MOUSE_HELP) != NULL);
+}
+
 /// Do the appropriate action for the current mouse click in the current mode.
 /// Not used for Command-line mode.
 ///
@@ -633,7 +642,7 @@ popupexit:
         if (VIsual_active) {
           jump_flags |= MOUSE_MAY_STOP_VIS;
         }
-      } else {
+      } else if (mouse_supports_visual()) {
         jump_flags |= MOUSE_MAY_VIS;
       }
     } else if (which_button == MOUSE_RIGHT) {
@@ -648,7 +657,9 @@ popupexit:
         }
       }
       jump_flags |= MOUSE_FOCUS;
-      jump_flags |= MOUSE_MAY_VIS;
+      if (mouse_supports_visual()) {
+        jump_flags |= MOUSE_MAY_VIS;
+      }
     }
   }
 
@@ -891,7 +902,8 @@ popupexit:
   } else if (in_status_line || in_sep_line) {
     // Do nothing if on status line or vertical separator
     // Handle double clicks otherwise
-  } else if ((mod_mask & MOD_MASK_MULTI_CLICK) && (State & (MODE_NORMAL | MODE_INSERT))) {
+  } else if ((mod_mask & MOD_MASK_MULTI_CLICK) && (State & (MODE_NORMAL | MODE_INSERT))
+             && mouse_supports_visual()) {
     if (is_click || !VIsual_active) {
       if (VIsual_active) {
         orig_cursor = VIsual;


### PR DESCRIPTION
Fixes #15007

---

If mouse support is not enabled for visual mode, dragging the mouse in another mode should not begin a selection.

This is a regression introduced in 6db86cb2d3d4ca152f156dc07362f8796150fae0.

---

For the record, the check is still in place in latest vim:

https://github.com/vim/vim/blob/056678184f679c2989b73bd48eda112f3c79a62f/src/mouse.c#L638-L639

https://github.com/vim/vim/blob/056678184f679c2989b73bd48eda112f3c79a62f/src/mouse.c#L659-L660

`mouse_has` definition:

https://github.com/vim/vim/blob/056678184f679c2989b73bd48eda112f3c79a62f/src/mouse.c#L1432-L1456

https://github.com/neovim/neovim/blob/d0668b36a3e2d0683059baead45bea27e2358e9c/src/nvim/mouse.c#L555-L575