### PR TITLE
refactor: remove cpo-& behavior

### DIFF
--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -108,7 +108,7 @@ command:
 					*:pre* *:preserve* *E313* *E314*
 :pre[serve]		Write all text for the current buffer into its swap
 			file.  The original file is no longer needed for
-			recovery.  This sets a flag in the current buffer.
+			recovery.
 
 A Vim swap file can be recognized by the first six characters: "b0VIM ".
 After that comes the version number, e.g., "3.0".

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -90,7 +90,6 @@ typedef struct {
 #define BF_NEW_W        0x20    // Warned for BF_NEW and file created
 #define BF_READERR      0x40    // got errors while reading the file
 #define BF_DUMMY        0x80    // dummy buffer, only used internally
-#define BF_PRESERVED    0x100   // ":preserve" was used
 #define BF_SYN_SET      0x200   // 'syntax' option was set
 
 // Mask to check for flags that prevent normal writing

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7250,7 +7250,6 @@ void alist_slash_adjust(void)
 /// ":preserve".
 static void ex_preserve(exarg_T *eap)
 {
-  curbuf->b_flags |= BF_PRESERVED;
   ml_preserve(curbuf, true, true);
 }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -585,16 +585,14 @@ void ml_close(buf_T *buf, int del_file)
   buf->b_flags &= ~BF_RECOVERED;
 }
 
-/*
- * Close all existing memlines and memfiles.
- * Only used when exiting.
- * When 'del_file' is TRUE, delete the memfiles.
- * But don't delete files that were ":preserve"d when we are POSIX compatible.
- */
-void ml_close_all(int del_file)
+/// Close all existing memlines and memfiles.
+/// Only used when exiting.
+///
+/// @param del_file  if true, delete the memfiles.
+void ml_close_all(bool del_file)
 {
   FOR_ALL_BUFFERS(buf) {
-    ml_close(buf, del_file && ((buf->b_flags & BF_PRESERVED) == 0));
+    ml_close(buf, del_file);
   }
   spell_delete_wordlist();      // delete the internal wordlist
   vim_deltempdir();             // delete created temp directory

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -10,6 +10,7 @@ local feed = helpers.feed
 local nvim_prog = helpers.nvim_prog
 local ok = helpers.ok
 local rmdir = helpers.rmdir
+local os_kill = helpers.os_kill
 local set_session = helpers.set_session
 local spawn = helpers.spawn
 local nvim_async = helpers.nvim_async
@@ -62,6 +63,7 @@ describe(':preserve', function()
 
     local swappath1 = eval('g:swapname')
 
+    os_kill(eval('getpid()'))
     -- Start another Nvim instance.
     local nvim2 = spawn({nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed'},
                                 true)
@@ -122,6 +124,7 @@ describe('swapfile detection', function()
     feed('isometext<esc>')
     command('preserve')
 
+    os_kill(eval('getpid()'))
     -- Start another Nvim instance.
     local nvim2 = spawn({nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed'},
                         true)


### PR DESCRIPTION
`cpo-&` has been removed, but its behavior was accidentally made the default behavior. That should be removed instead.