### PR TITLE
vim-patch:8.2.4644: redrawing too often when 'relativenumber' is set 

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1211,6 +1211,8 @@ struct window_S {
   colnr_T w_old_visual_col;         ///< last known start of visual part
   colnr_T w_old_curswant;           ///< last known value of Curswant
 
+  linenr_T w_last_cursor_lnum_rnu;  ///< cursor lnum when 'rnu' was last redrawn
+
   // 'listchars' characters. Defaults set in set_chars_option().
   struct {
     int eol;

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -287,7 +287,7 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra
       }
 
       // Relative numbering may require updating more.
-      if (wp->w_p_rnu) {
+      if (wp->w_p_rnu && xtra != 0) {
         redraw_later(wp, SOME_VALID);
       }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1577,9 +1577,9 @@ static void win_update(win_T *wp, DecorProviders *providers)
       idx++;
       lnum += foldinfo.fi_lines + 1;
     } else {
-      if (wp->w_p_rnu) {
-        // 'relativenumber' set: The text doesn't need to be drawn, but
-        // the number column nearly always does.
+      if (wp->w_p_rnu && wp->w_last_cursor_lnum_rnu != wp->w_cursor.lnum) {
+        // 'relativenumber' set and cursor moved vertically: The
+        // text doesn't need to be drawn, but the number column does.
         foldinfo_T info = fold_info(wp, lnum);
         (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true,
                        info, &line_providers);
@@ -1606,6 +1606,8 @@ static void win_update(win_T *wp, DecorProviders *providers)
   // Now that the window has been redrawn with the old and new cursor line,
   // update w_last_cursorline.
   wp->w_last_cursorline = cursorline_standout ? wp->w_cursor.lnum : 0;
+
+  wp->w_last_cursor_lnum_rnu = wp->w_p_rnu ? wp->w_cursor.lnum : 0;
 
   if (idx > wp->w_lines_valid) {
     wp->w_lines_valid = idx;


### PR DESCRIPTION
Fixes #9984

To test use `set nu rnu wd=10 rdb=nodelta`.