### PR TITLE
ci(docs): add a check for PR's to commit their doc changes

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -1,0 +1,17 @@
+name: Missing API docs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - 'marvim/api-doc-update**'
+    paths:
+      - 'src/nvim/api/*.[ch]'
+      - 'src/nvim/**.lua'
+      - 'runtime/lua/**.lua'
+
+jobs:
+  call-regen-api-docs:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/api-docs.yml
+    with:
+      check_only: true

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,3 +1,6 @@
+# Autogenerate the API docs on new commit to important branches
+# Also work as a check for PR's to not forget commiting their doc changes
+# called from api-docs-check.yml
 name: Autogenerate API docs
 on:
   push:
@@ -9,6 +12,12 @@ on:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      check_only:
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   regen-api-docs:
@@ -43,6 +52,12 @@ jobs:
           git checkout -b ${DOC_BRANCH}
           python3 scripts/gen_vimdoc.py
           printf '::set-output name=UPDATED_DOCS::%s\n' $([ -z "$(git diff)" ]; echo $?)
+
+      - name: FAIL, PR has not commited doc changes
+        if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && inputs.check_only }}
+        run: |
+          echo "Job failed, run ./scripts/gen_vimdoc.py and commit your doc changes"
+          exit 1
 
       - name: Automatic PR
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 }}


### PR DESCRIPTION
Repurpose the api-docs workflow to also run in all PR's but work only as
a check, if the changes in the PR introduce doc changes that are not
committed fail.

Closes #14009