### PR TITLE
ci(api-docs): use latest doxygen version from brew

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   regen-api-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -25,10 +25,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3 luajit
-          conda install -c conda-forge doxygen=1.9.2 msgpack-python
-          echo "$CONDA/bin" >> $GITHUB_PATH
+          brew update --quiet
+          brew install luajit doxygen
+
+          pip install msgpack
 
       - name: Setup git config
         run: |


### PR DESCRIPTION
Each new version of doxygen makes the gen_vimdoc give a different output
which causes confusion when users who use the latest version doesn't get
the same output as the CI.
