### PR TITLE
vim-patch:8.2.4593: unnecessary call to redraw_later()

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2835,9 +2835,7 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     curr->y_size = j;
     xfree(reg->y_array);
   }
-  if (curwin->w_p_rnu) {
-    redraw_later(curwin, SOME_VALID);  // cursor moved to start
-  }
+
   if (message) {  // Display message about yank?
     if (yank_type == kMTCharWise && yanklines == 1) {
       yanklines = 0;


### PR DESCRIPTION
#### vim-patch:8.2.4593: unnecessary call to redraw_later()

Problem:    Unnecessary call to redraw_later().
Solution:   Remove the call to redraw_later() in op_yank(). (closes vim/vim#9971)
https://github.com/vim/vim/commit/95d2e7634ccd8e0da78086002509a856999e180c