### PR TITLE
docs: properly escape to avoid doxygen weirdness

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -126,7 +126,7 @@
 ///       [ "╔", "═" ,"╗", "║", "╝", "═", "╚", "║" ].
 ///     If the number of chars are less than eight, they will be repeated. Thus
 ///     an ASCII border could be specified as
-///       [ "/", "-", "\\", "|" ],
+///       [ "/", "-", \"\\\\\", "|" ],
 ///     or all chars the same as
 ///       [ "x" ].
 ///     An empty string can be used to turn off a specific border, for instance,


### PR DESCRIPTION
If this is not properly escaped doxygen 1.9.3 will not work correctly,
and the documentation generated in local machines will differ with what
is generated in CI (1.9.2).

This unblocks https://github.com/neovim/neovim/pull/17768 and also allows https://github.com/neovim/neovim/pull/17774 

This is just another +1 to make sure people submit their generated docs, no need to go catching 🐛 
