### PR TITLE
fix(lsp): set tabSize from 'shiftwidth', not 'softtabstop'

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1458,17 +1458,17 @@ extract_completion_items({result})
                     https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
 
 get_effective_tabstop({bufnr})          *vim.lsp.util.get_effective_tabstop()*
-                Returns visual width of tabstop.
+                Returns indentation size.
 
                 Parameters: ~
                     {bufnr}  (optional, number): Buffer handle, defaults to
                              current
 
                 Return: ~
-                    (number) tabstop visual width
+                    (number) indentation size
 
                 See also: ~
-                    |softtabstop|
+                    |shiftwidth|
 
                                              *vim.lsp.util.jump_to_location()*
 jump_to_location({location}, {offset_encoding})

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1894,16 +1894,16 @@ end
 function M.make_workspace_params(added, removed)
   return { event = { added = added; removed = removed; } }
 end
---- Returns visual width of tabstop.
+--- Returns indentation size.
 ---
----@see |softtabstop|
+---@see |shiftwidth|
 ---@param bufnr (optional, number): Buffer handle, defaults to current
----@returns (number) tabstop visual width
+---@returns (number) indentation size
 function M.get_effective_tabstop(bufnr)
   validate { bufnr = {bufnr, 'n', true} }
   local bo = bufnr and vim.bo[bufnr] or vim.bo
-  local sts = bo.softtabstop
-  return (sts > 0 and sts) or (sts < 0 and bo.shiftwidth) or bo.tabstop
+  local sw = bo.shiftwidth
+  return (sw == 0 and bo.tabstop) or sw
 end
 
 --- Creates a `DocumentFormattingParams` object for the current buffer and cursor position.

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2374,18 +2374,16 @@ describe('LSP', function()
   end)
 
   describe('lsp.util.get_effective_tabstop', function()
-    local function test_tabstop(tabsize, softtabstop)
+    local function test_tabstop(tabsize, shiftwidth)
       exec_lua(string.format([[
-        vim.api.nvim_buf_set_option(0, 'softtabstop', %d)
+        vim.api.nvim_buf_set_option(0, 'shiftwidth', %d)
         vim.api.nvim_buf_set_option(0, 'tabstop', 2)
-        vim.api.nvim_buf_set_option(0, 'shiftwidth', 3)
-      ]], softtabstop))
+      ]], shiftwidth))
       eq(tabsize, exec_lua('return vim.lsp.util.get_effective_tabstop()'))
     end
 
-    it('with softtabstop = 1', function() test_tabstop(1, 1) end)
-    it('with softtabstop = 0', function() test_tabstop(2, 0) end)
-    it('with softtabstop = -1', function() test_tabstop(3, -1) end)
+    it('with shiftwidth = 1', function() test_tabstop(1, 1) end)
+    it('with shiftwidth = 0', function() test_tabstop(2, 0) end)
   end)
 
   describe('vim.lsp.buf.outgoing_calls', function()


### PR DESCRIPTION
The use of 'softtabstop' to set tabSize was introduced in 5d5b068, replacing 'tabstop'.  This was a step in the right direction, but if we look past the name tabSize and at the actual purpose of the field, it's the indentation width used when formatting.  (The field should have been called "indentSize", but there's nothing to be done about that now.)  This corresponds to the Vim option 'shiftwidth', not 'softtabstop'.  The latter has the comparatively mundane purpose of controlling what happens when you hit the tab key (and even this is incomplete, as it fails to account for 'smarttab').

See also [the coc.nvim implementation](https://github.com/neoclide/coc.nvim/blob/287c743c9f227fdf0e1db452bbb8ae3c5caffc36/autoload/coc/util.vim#L866-L876), which uses 'shiftwidth'.