### PR TITLE
revert: "man.vim: Ensure 'modifiable' in man#init_pager #11450"

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -123,12 +123,12 @@ function! s:system(cmd, ...) abort
 endfunction
 
 function! s:set_options(pager) abort
-  setlocal filetype=man
   setlocal noswapfile buftype=nofile bufhidden=hide
   setlocal nomodified readonly nomodifiable
   if a:pager
     nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
   endif
+  setlocal filetype=man
 endfunction
 
 function! s:get_page(path) abort
@@ -473,10 +473,6 @@ endfunction
 
 " Called when Nvim is invoked as $MANPAGER.
 function! man#init_pager() abort
-  " https://github.com/neovim/neovim/issues/6828
-  let og_modifiable = &modifiable
-  setlocal modifiable
-
   if getline(1) =~# '^\s*$'
     silent keepjumps 1delete _
   else
@@ -496,7 +492,6 @@ function! man#init_pager() abort
   endif
 
   call s:set_options(v:true)
-  let &l:modifiable = og_modifiable
 endfunction
 
 function! man#goto_tag(pattern, flags, info) abort


### PR DESCRIPTION
This reverts commit 526798a941b4cf80fd1f128b40e51fb47c77b654.

This makes manpage not modifiable, which was the original (and IMO
superior) behavior. I also find the motivation for the commit to be
kinda lackluster to begin with:
https://github.com/powerman/vim-plugin-viewdoc doesn't seem to work if
the manpage isn't modifiable. I don't think this is good enough of a
justification if I'm being honest. I obviously don't wish to block
plugins but I just don't think this is the correct solution. An ideal
solution in my mind would be something that would enable the viewdoc
plugin while still keeping the nomodifiable behavior.

Ironically, using viewdoc to read a man manpage makes the text not
modifiable lol.
