### PR TITLE
vim-patch:8.2.2969: subtracting from number option fails when result is zero

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1899,6 +1899,7 @@ static char_u *ex_let_one(char_u *arg, typval_T *const tv, const bool copy, cons
             case '%':
               n = num_modulus(numval, n); break;
             }
+            s = NULL;
           } else if (opt_type == 0 && stringval != NULL) {  // string
             char *const oldstringval = stringval;
             stringval = (char *)concat_str((const char_u *)stringval,

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1634,17 +1634,17 @@ func Test_compound_assignment_operators()
       call assert_equal(10.5, x)
       let x /= 2.5
       call assert_equal(4.2, x)
-      call assert_fails('let x %= 0.5', 'E734')
-      call assert_fails('let x .= "f"', 'E734')
+      call assert_fails('let x %= 0.5', 'E734:')
+      call assert_fails('let x .= "f"', 'E734:')
     endif
 
     " Test for environment variable
     let $FOO = 1
-    call assert_fails('let $FOO += 1', 'E734')
-    call assert_fails('let $FOO -= 1', 'E734')
-    call assert_fails('let $FOO *= 1', 'E734')
-    call assert_fails('let $FOO /= 1', 'E734')
-    call assert_fails('let $FOO %= 1', 'E734')
+    call assert_fails('let $FOO += 1', 'E734:')
+    call assert_fails('let $FOO -= 1', 'E734:')
+    call assert_fails('let $FOO *= 1', 'E734:')
+    call assert_fails('let $FOO /= 1', 'E734:')
+    call assert_fails('let $FOO %= 1', 'E734:')
     let $FOO .= 's'
     call assert_equal('1s', $FOO)
     unlet $FOO
@@ -1661,16 +1661,25 @@ func Test_compound_assignment_operators()
     call assert_equal(6, &scrolljump)
     let &scrolljump %= 5
     call assert_equal(1, &scrolljump)
-    call assert_fails('let &scrolljump .= "j"', 'E734')
+    call assert_fails('let &scrolljump .= "j"', 'E734:')
     set scrolljump&vim
+
+    let &foldlevelstart = 2
+    let &foldlevelstart -= 1
+    call assert_equal(1, &foldlevelstart)
+    let &foldlevelstart -= 1
+    call assert_equal(0, &foldlevelstart)
+    let &foldlevelstart = 2
+    let &foldlevelstart -= 2
+    call assert_equal(0, &foldlevelstart)
 
     " Test for register
     let @/ = 1
-    call assert_fails('let @/ += 1', 'E734')
-    call assert_fails('let @/ -= 1', 'E734')
-    call assert_fails('let @/ *= 1', 'E734')
-    call assert_fails('let @/ /= 1', 'E734')
-    call assert_fails('let @/ %= 1', 'E734')
+    call assert_fails('let @/ += 1', 'E734:')
+    call assert_fails('let @/ -= 1', 'E734:')
+    call assert_fails('let @/ *= 1', 'E734:')
+    call assert_fails('let @/ /= 1', 'E734:')
+    call assert_fails('let @/ %= 1', 'E734:')
     let @/ .= 's'
     call assert_equal('1s', @/)
     let @/ = ''


### PR DESCRIPTION
#### vim-patch:8.2.2969: subtracting from number option fails when result is zero

Problem:    Subtracting from number option fails when result is zero. (Ingo
            Karkat)
Solution:   Reset the string value when using the numeric value.
https://github.com/vim/vim/commit/a42e6e0082a6d564dbfa55317d4a698ac12ae898

Cherry-pick Test_compound_assignment_operators() changes from patch 8.2.1593