### PR TITLE
fix(tui): resize at startup

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -85,6 +85,24 @@ describe('TUI', function()
     assert_alive()
   end)
 
+  it('resize at startup', function()
+    -- Issues: #17285 #15044 #11330
+    screen:try_resize(50, 10)
+    feed_command([[call termopen([v:progpath, '--clean', '--cmd', 'let start = reltime() | while v:true | if reltimefloat(reltime(start)) > 2 | break | endif | endwhile']) | sleep 500m | vs new]])
+    screen:expect([[
+      {1: }                        │                        |
+      {4:~                        }│{4:~                       }|
+      {4:~                        }│{4:~                       }|
+      {4:~                        }│{4:~                       }|
+      {4:~                        }│{4:~                       }|
+      {4:~                        }│{5:[No Name]   0,0-1    All}|
+      {4:~                        }│                        |
+      {5:new                       }{MATCH:<.*[/\]nvim }|
+                                                        |
+      {3:-- TERMINAL --}                                    |
+    ]])
+  end)
+
   it('accepts resize while pager is active', function()
     child_session:request("nvim_command", [[
     set more

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -383,7 +383,7 @@ function Screen:expect(expected, attr_ids, ...)
       for i, row in ipairs(expected_rows) do
         msg_expected_rows[i] = row
         local m = (row ~= actual_rows[i] and row:match('{MATCH:(.*)}') or nil)
-        if row ~= actual_rows[i] and (not m or not actual_rows[i]:match(m)) then
+        if row ~= actual_rows[i] and (not m or not (actual_rows[i] and actual_rows[i]:match(m))) then
           msg_expected_rows[i] = '*' .. msg_expected_rows[i]
           if i <= #actual_rows then
             actual_rows[i] = '*' .. actual_rows[i]


### PR DESCRIPTION
I've changed the PR of this approach to follow-on @erw7 https://github.com/neovim/neovim/issues/11330#issuecomment-1086617448

Which has two parts:

1. Removing the following code:

https://github.com/neovim/neovim/blob/af1b61f342618aa8d27c6e1dcbb0e360920ca89e/src/nvim/tui/tui.c#L1481-L1489

I debugged that this was the main issue in my system and perhaps in tiling window managers in general.

When the function `tui_guess_size` is called twice during startup the non-default 'columns' and 'lines' is usually true after the first time, because this same function already changed those values. Basically it's tricking itself, unrelated if the "lines" and "columns" options was set or not.

Added a test with the provided repro which fails before these changes.

2. Making got_winch a counter

If I understand things correctly this avoids resizing the host terminal until we have processed the last sigwinch, compared to the previous state of things:

> The second bug is that tui_grid_resize may change the size of the host terminal between the signal handler and the call to sigwinch_cb (note: the signal handle (uv__signal_handle) does not directly call the callback) when multiple SIGWINCH occur. I have confirmed that this actually happens in the following way using nvim with DLOG added.

Also removed the volatile since is not needed: https://github.com/neovim/neovim/pull/19210

PD: I'd be thrilled if @erw7 took over this, it's his proposed solution :D

Fixes #17285
Fixes #15044
Fixes #11330