### PR TITLE
Draft: feat(query): support setting a parsed query

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -114,9 +114,12 @@ local explicit_queries = setmetatable({}, {
 ---
 ---@param lang string: The language to use for the query
 ---@param query_name string: The name of the query (i.e. "highlights")
----@param text string: The query text (unparsed).
-function M.set_query(lang, query_name, text)
-  explicit_queries[lang][query_name] = M.parse_query(lang, text)
+---@param query string or Query: The query text (either unparsed or parsed).
+function M.set_query(lang, query_name, query)
+  if type(query) == 'string' then
+    query = M.parse_query(lang, query)
+  end
+  explicit_queries[lang][query_name] = query
 end
 
 --- Returns the runtime query {query_name} for {lang}.


### PR DESCRIPTION
This allows a user to set either a parsed or unparsed runtime query, effectively allowing:
```lua
vim.treesitter.set_query(lang, query_name, vim.treesittter.get_query(lang, query_name))
```

This is useful if a user for example wants to temporarily change a certain query and later replace it with the original one.

Questions:
- [ ] Should there maybe be a check that the argument is actually a `Query` object?