### PR TITLE
refactor: assume `STATUS_HEIGHT` to be 1

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -969,7 +969,6 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
   int before;
   int minheight;
   int wmh1;
-  int hsep_height;
   bool did_set_fraction = false;
 
   // aucmd_win should always remain floating
@@ -1082,7 +1081,6 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       }
     }
   } else {
-    hsep_height = STATUS_HEIGHT;
     layout = FR_COL;
 
     /*
@@ -1091,7 +1089,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
      */
     // Current window requires at least 1 space.
     wmh1 = p_wmh == 0 ? 1 : p_wmh;
-    needed = wmh1 + hsep_height;
+    needed = wmh1 + STATUS_HEIGHT;
     if (flags & WSP_ROOM) {
       needed += p_wh - wmh1;
     }
@@ -1133,15 +1131,15 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       new_size = oldwin_height / 2;
     }
 
-    if (new_size > available - minheight - hsep_height) {
-      new_size = available - minheight - hsep_height;
+    if (new_size > available - minheight - STATUS_HEIGHT) {
+      new_size = available - minheight - STATUS_HEIGHT;
     }
     if (new_size < wmh1) {
       new_size = wmh1;
     }
 
     // if it doesn't fit in the current window, need win_equal()
-    if (oldwin_height - new_size - hsep_height < p_wmh) {
+    if (oldwin_height - new_size - STATUS_HEIGHT < p_wmh) {
       do_equal = true;
     }
 
@@ -1154,7 +1152,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       set_fraction(oldwin);
       did_set_fraction = true;
 
-      win_setheight_win(oldwin->w_height + new_size + hsep_height,
+      win_setheight_win(oldwin->w_height + new_size + STATUS_HEIGHT,
                         oldwin);
       oldwin_height = oldwin->w_height;
       if (need_status) {
@@ -1171,7 +1169,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
       while (frp != NULL) {
         if (frp->fr_win != oldwin && frp->fr_win != NULL
             && (frp->fr_win->w_height > new_size
-                || frp->fr_win->w_height > oldwin_height - new_size - hsep_height)) {
+                || frp->fr_win->w_height > oldwin_height - new_size - STATUS_HEIGHT)) {
           do_equal = true;
           break;
         }
@@ -2019,7 +2017,6 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
   int room = 0;
   int new_size;
   int has_next_curwin = 0;
-  int hsep_height;
   bool hnc;
 
   if (topfr->fr_layout == FR_LEAF) {
@@ -2165,7 +2162,6 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
       totwincount -= wincount;
     }
   } else {  // topfr->fr_layout == FR_COL
-    hsep_height = STATUS_HEIGHT;
     topfr->fr_width = width;
     topfr->fr_height = height;
 
@@ -2180,7 +2176,7 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
       } else {
         extra_sep = 0;
       }
-      totwincount = (n + extra_sep) / (p_wmh + hsep_height);
+      totwincount = (n + extra_sep) / (p_wmh + STATUS_HEIGHT);
       has_next_curwin = frame_has_win(topfr, next_curwin);
 
       /*
@@ -2215,7 +2211,7 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
           } else {
             // These windows don't use up room.
             totwincount -= (n + (fr->fr_next == NULL
-                                 ? extra_sep : 0)) / (p_wmh + hsep_height);
+                                 ? extra_sep : 0)) / (p_wmh + STATUS_HEIGHT);
           }
           room -= new_size - n;
           if (room < 0) {
@@ -2261,7 +2257,7 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
         // Compute the maximum number of windows vert. in "fr".
         n = frame_minheight(fr, NOWIN);
         wincount = (n + (fr->fr_next == NULL ? extra_sep : 0))
-                   / (p_wmh + hsep_height);
+                   / (p_wmh + STATUS_HEIGHT);
         m = frame_minheight(fr, next_curwin);
         if (has_next_curwin) {
           hnc = frame_has_win(fr, next_curwin);
@@ -6503,37 +6499,31 @@ void last_status(bool morewin)
 }
 
 // Look for resizable frames and take lines from them to make room for the statusline
-static void resize_frame_for_status(frame_T *fr, int resize_amount)
+static void resize_frame_for_status(frame_T *fr)
 {
   // Find a frame to take a line from.
   frame_T *fp = fr;
   win_T *wp = fr->fr_win;
-  int n;
 
-  while (resize_amount > 0) {
-    while (fp->fr_height <= frame_minheight(fp, NULL)) {
-      if (fp == topframe) {
-        emsg(_(e_noroom));
-        return;
-      }
-      // In a column of frames: go to frame above.  If already at
-      // the top or in a row of frames: go to parent.
-      if (fp->fr_parent->fr_layout == FR_COL && fp->fr_prev != NULL) {
-        fp = fp->fr_prev;
-      } else {
-        fp = fp->fr_parent;
-      }
+  while (fp->fr_height <= frame_minheight(fp, NULL)) {
+    if (fp == topframe) {
+      emsg(_(e_noroom));
+      return;
     }
-    n = MIN(fp->fr_height - frame_minheight(fp, NULL), resize_amount);
-    resize_amount -= n;
-
-    if (fp != fr) {
-      frame_new_height(fp, fp->fr_height - n, false, false);
-      frame_fix_height(wp);
-      (void)win_comp_pos();
+    // In a column of frames: go to frame above.  If already at
+    // the top or in a row of frames: go to parent.
+    if (fp->fr_parent->fr_layout == FR_COL && fp->fr_prev != NULL) {
+      fp = fp->fr_prev;
     } else {
-      win_new_height(wp, wp->w_height - n);
+      fp = fp->fr_parent;
     }
+  }
+  if (fp != fr) {
+    frame_new_height(fp, fp->fr_height - 1, false, false);
+    frame_fix_height(wp);
+    (void)win_comp_pos();
+  } else {
+    win_new_height(wp, wp->w_height - 1);
   }
 }
 
@@ -6555,15 +6545,12 @@ static void last_status_rec(frame_T *fr, bool statusline, bool is_stl_global)
       } else if (wp->w_status_height == 0 && !is_stl_global && statusline) {
         // Add statusline to window if needed
         wp->w_status_height = STATUS_HEIGHT;
-        resize_frame_for_status(fr, STATUS_HEIGHT);
+        resize_frame_for_status(fr);
         comp_col();
       }
     } else if (wp->w_status_height != 0 && is_stl_global) {
       // If statusline is global and the window has a statusline, replace it with a horizontal
       // separator
-      if (STATUS_HEIGHT - 1 != 0) {
-        win_new_height(wp, wp->w_height + STATUS_HEIGHT - 1);
-      }
       wp->w_status_height = 0;
       wp->w_hsep_height = 1;
       comp_col();
@@ -6571,7 +6558,6 @@ static void last_status_rec(frame_T *fr, bool statusline, bool is_stl_global)
       // If statusline isn't global and the window doesn't have a statusline, re-add it
       wp->w_status_height = STATUS_HEIGHT;
       wp->w_hsep_height = 0;
-      resize_frame_for_status(fr, STATUS_HEIGHT - 1);
       comp_col();
     }
     redraw_all_later(SOME_VALID);


### PR DESCRIPTION
Since https://github.com/neovim/neovim/pull/17790 being merged means we can assume the value of `STATUS_HEIGHT` to always be 1, this commit removes code that's unnecessary if `STATUS_HEIGHT` is 1.