### PR TITLE
fix(ci): provide necessary permissions for calling workflow

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   call-regen-api-docs:
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/api-docs.yml
     with:
       check_only: true

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -60,7 +60,7 @@ jobs:
           exit 1
 
       - name: Automatic PR
-        if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 }}
+        if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && !inputs.check_only }}
         run: |
           git add -u
           git commit -m 'docs: regenerate [skip ci]'


### PR DESCRIPTION
Fix issues with #17768 by providing necessary permissions for calling workflow:

The CI workflow is [failing](https://github.com/neovim/neovim/actions/runs/2020118627) with this error:

> The workflow is not valid. .github/workflows/api-docs-check.yml (Line: 13, Col: 3): Error calling workflow 'neovim/neovim/.github/workflows/api-docs.yml@e57b4679cab21149b47b803367ddca1685f5ebda'. The nested job 'regen-api-docs' is requesting '**contents: write**, **pull_requests: write**', but is only allowed 'contents: read, pull_requests: none'.

From [reading about permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) and looking at [the example](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api) I think this should fix the issue.

Also error on the side of security adding an extra check on the automatic PR step.

[skip ci]