### PR TITLE
fix(screen): do not do syntax highlighting at filler or folded lines

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2159,7 +2159,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
     // To speed up the loop below, set extra_check when there is linebreak,
     // trailing white space and/or syntax processing to be done.
     extra_check = wp->w_p_lbr;
-    if (syntax_present(wp) && !wp->w_s->b_syn_error && !wp->w_s->b_syn_slow) {
+    if (syntax_present(wp) && !wp->w_s->b_syn_error && !wp->w_s->b_syn_slow
+        && !has_fold && !end_fill) {
       // Prepare for syntax highlighting in this line.  When there is an
       // error, stop syntax highlighting.
       save_did_emsg = did_emsg;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1111,6 +1111,27 @@ if (h->n_buckets < new_n_buckets) { // expand
     ]]}
   end)
 
+  it('does not cause syntax ml_get error at the end of a buffer #17816', function()
+    command([[syntax region foo keepend start='^foo' end='^$']])
+    command('syntax sync minlines=100')
+    insert('foo')
+    meths.buf_set_extmark(0, ns, 0, 0, {virt_lines = {{{'bar', 'Comment'}}}})
+    screen:expect([[
+      fo^o                                               |
+      {6:bar}                                               |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+  end)
+
   it('works with a block scrolling up', function()
     screen:try_resize(30, 7)
     insert("aa\nbb\ncc\ndd\nee\nff\ngg\nhh")


### PR DESCRIPTION
Fix #17816