### PR TITLE
vim-patch:8.2.{4591,4614}: cursorline redrawing

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -119,7 +119,6 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   update_topline_win(win);
 
   redraw_later(win, VALID);
-  redraw_for_cursorline(win);
   win->w_redr_status = true;
 }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -95,11 +95,6 @@ static void comp_botline(win_T *wp)
   win_check_anchored_floats(wp);
 }
 
-void reset_cursorline(void)
-{
-  curwin->w_last_cursorline = 0;
-}
-
 // Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
 void redraw_for_cursorline(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
@@ -107,21 +102,8 @@ void redraw_for_cursorline(win_T *wp)
   if ((wp->w_p_rnu || win_cursorline_standout(wp))
       && (wp->w_valid & VALID_CROW) == 0
       && !pum_visible()) {
-    if (wp->w_p_rnu) {
-      // win_line() will redraw the number column only.
-      redraw_later(wp, VALID);
-    }
-    if (win_cursorline_standout(wp)) {
-      if (wp->w_redr_type <= VALID && wp->w_last_cursorline != 0) {
-        // "w_last_cursorline" may be outdated, worst case we redraw
-        // too much.  This is optimized for moving the cursor around in
-        // the current window.
-        redrawWinline(wp, wp->w_last_cursorline);
-        redrawWinline(wp, wp->w_cursor.lnum);
-      } else {
-        redraw_later(wp, SOME_VALID);
-      }
-    }
+    // win_line() will redraw the number column and cursorline only.
+    redraw_later(wp, VALID);
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1296,13 +1296,7 @@ static void normal_redraw(NormalState *s)
   }
 
   // Might need to update for 'cursorline'.
-  // When 'cursorlineopt' is "screenline" need to redraw always.
-  if (curwin->w_p_cul
-      && (curwin->w_last_cursorline != curwin->w_cursor.lnum
-          || (curwin->w_p_culopt_flags & CULOPT_SCRLINE))
-      && !char_avail()) {
-    redraw_later(curwin, VALID);
-  }
+  check_redraw_cursorline();
 
   if (VIsual_active) {
     update_curbuf(INVERTED);  // update inverted part

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3962,11 +3962,8 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
   } else if ((int *)varp == &p_lnr) {
     // 'langnoremap' -> !'langremap'
     p_lrm = !p_lnr;
-  } else if ((int *)varp == &curwin->w_p_cul && !value && old_value) {
-    // 'cursorline'
-    reset_cursorline();
-    // 'undofile'
   } else if ((int *)varp == &curbuf->b_p_udf || (int *)varp == &p_udf) {
+    // 'undofile'
     // Only take action when the option was set. When reset we do not
     // delete the undo file, the option may be set again without making
     // any changes in between.

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -268,4 +268,30 @@ END
   call delete('Xtextfile')
 endfunc
 
+func Test_cursorline_callback()
+  CheckScreendump
+  CheckFeature timers
+
+  let lines =<< trim END
+      call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
+      set cursorline
+      call cursor(4, 1)
+
+      func Func(timer)
+        call cursor(2, 1)
+      endfunc
+
+      call timer_start(300, 'Func')
+  END
+  call writefile(lines, 'Xcul_timer')
+
+  let buf = RunVimInTerminal('-S Xcul_timer', #{rows: 8})
+  call TermWait(buf, 310)
+  call VerifyScreenDump(buf, 'Test_cursorline_callback_1', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xcul_timer')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1081,6 +1081,46 @@ describe('CursorLine and CursorLineNr highlights', function()
     ]])
   end)
 
+  it('is updated if cursor is moved up from timer vim-patch:8.2.4591', function()
+    local screen = Screen.new(50, 8)
+    screen:set_default_attr_ids({
+      [1] = {background = Screen.colors.Gray90},  -- CursorLine
+      [2] = {bold = true, foreground = Screen.colors.Blue1},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
+      set cursorline
+      call cursor(4, 1)
+
+      func Func(timer)
+        call cursor(2, 1)
+      endfunc
+
+      call timer_start(300, 'Func')
+    ]])
+    screen:expect({grid = [[
+      aaaaa                                             |
+      bbbbb                                             |
+      ccccc                                             |
+      {1:^ddddd                                             }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]], timeout = 100})
+    screen:expect({grid = [[
+      aaaaa                                             |
+      {1:^bbbbb                                             }|
+      ccccc                                             |
+      ddddd                                             |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]]})
+  end)
+
   it('with split windows in diff mode', function()
     local screen = Screen.new(50,12)
     screen:set_default_attr_ids({


### PR DESCRIPTION
Fix #8159

#### vim-patch:8.2.4591: cursor line not updated when a callback moves the cursor

Problem:    Cursor line not updated when a callback moves the cursor.
Solution:   Check if the cursor moved.
https://github.com/vim/vim/commit/e7a74d53754765f22ef8ce71c915bb669d5f7f3f

redraw_after_callback() is N/A. Nvim handles timers on the main loop.


#### vim-patch:8.2.4614: redrawing too much when 'cursorline' is set

Problem:    Redrawing too much when 'cursorline' is set and jumping around.
Solution:   Rely on win_update() to redraw the current and previous cursor
            line, do not mark lines as modified. (closes vim/vim#9996)
https://github.com/vim/vim/commit/c20e46a4e3efcd408ef132872238144ea34f7ae5

This doesn't match the patch exactly, because I missed some lines when
porting patch 8.1.2029, and these lines were removed in this patch.

This also makes win_update() always update for 'concealcursor' like how
it always updates for 'cursorline', as 'cursorline' and 'concealcursor'
redrawing logic has been unified in Nvim.

As redrawing for 'cursorline' now always only requires VALID redraw
type, it is no longer necessary to call redraw_for_cursorline() in
nvim_win_set_cursor().