### PR TITLE
fix(screen): do not update syntax_last_parsed when drawing folded line

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1545,17 +1545,17 @@ static void win_update(win_T *wp, DecorProviders *providers)
                        foldinfo.fi_lines ? srow : wp->w_grid.Rows,
                        mod_top == 0, false, foldinfo, &line_providers);
 
-        wp->w_lines[idx].wl_folded = foldinfo.fi_lines != 0;
-        wp->w_lines[idx].wl_lastlnum = lnum;
-        did_update = DID_LINE;
-
-        if (foldinfo.fi_lines > 0) {
-          did_update = DID_FOLD;
+        if (foldinfo.fi_lines == 0) {
+          wp->w_lines[idx].wl_folded = false;
+          wp->w_lines[idx].wl_lastlnum = lnum;
+          did_update = DID_LINE;
+          syntax_last_parsed = lnum;
+        } else {
           foldinfo.fi_lines--;
+          wp->w_lines[idx].wl_folded = true;
           wp->w_lines[idx].wl_lastlnum = lnum + foldinfo.fi_lines;
+          did_update = DID_FOLD;
         }
-
-        syntax_last_parsed = lnum;
       }
 
       wp->w_lines[idx].wl_lnum = lnum;


### PR DESCRIPTION
Fixup to #17818
Fix #17824

This matches the lines of code in Vim's `win_update()` after calling `win_line()` and `fold_line()` respectively:
```c
		// Display one line.
		row = win_line(wp, lnum, srow, wp->w_height,
							  mod_top == 0, FALSE);

#ifdef FEAT_FOLDING
		wp->w_lines[idx].wl_folded = FALSE;
		wp->w_lines[idx].wl_lastlnum = lnum;
#endif
#ifdef FEAT_SYN_HL
		did_update = DID_LINE;
		syntax_last_parsed = lnum;
#endif

```
```c
		fold_line(wp, fold_count, &win_foldinfo, lnum, row);
		++row;
		--fold_count;
		wp->w_lines[idx].wl_folded = TRUE;
		wp->w_lines[idx].wl_lastlnum = lnum + fold_count;
# ifdef FEAT_SYN_HL
		did_update = DID_FOLD;
# endif
```