### PR TITLE
refactor(memline.c): make swapfile_unchanged() return bool

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1616,9 +1616,9 @@ static time_t swapfile_info(char_u *fname)
   return x;
 }
 
-/// Returns TRUE if the swap file looks OK and there are no changes, thus it
-/// can be safely deleted.
-static time_t swapfile_unchanged(char *fname)
+/// @return  true if the swap file looks OK and there are no changes, thus it
+///          can be safely deleted.
+static bool swapfile_unchanged(char *fname)
 {
   struct block0 b0;
   int ret = true;


### PR DESCRIPTION
vim-patch:8.2.4613: return type of swapfile_unchanged() is wrong

Problem:    Return type of swapfile_unchanged() is wrong.
Solution:   Use "int". (closes vim/vim#10000  Yeah!)
https://github.com/vim/vim/commit/3c5999e53d9f35a30abefb7224f66a75c8ffb009