### PR TITLE
fix: correct event order and values for reusing the NoName buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1719,20 +1719,10 @@ buf_T *buflist_new(char_u *ffname_arg, char_u *sfname_arg, linenr_T lnum, int fl
     buf = curbuf;
     // It's like this buffer is deleted.  Watch out for autocommands that
     // change curbuf!  If that happens, allocate a new buffer anyway.
-    if (curbuf->b_p_bl) {
-      apply_autocmds(EVENT_BUFDELETE, NULL, NULL, false, curbuf);
-    }
-    if (buf == curbuf) {
-      apply_autocmds(EVENT_BUFWIPEOUT, NULL, NULL, false, curbuf);
-    }
+    buf_freeall(buf, BFA_WIPE | BFA_DEL);
     if (aborting()) {           // autocmds may abort script processing
       xfree(ffname);
       return NULL;
-    }
-    if (buf == curbuf) {
-      // Make sure 'bufhidden' and 'buftype' are empty
-      clear_string_option(&buf->b_p_bh);
-      clear_string_option(&buf->b_p_bt);
     }
   }
   if (buf != curbuf || curbuf == NULL) {
@@ -1766,14 +1756,6 @@ buf_T *buflist_new(char_u *ffname_arg, char_u *sfname_arg, linenr_T lnum, int fl
   }
 
   if (buf == curbuf) {
-    // free all things allocated for this buffer
-    buf_freeall(buf, 0);
-    if (buf != curbuf) {         // autocommands deleted the buffer!
-      return NULL;
-    }
-    if (aborting()) {           // autocmds may abort script processing
-      return NULL;
-    }
     free_buffer_stuff(buf, kBffInitChangedtick);  // delete local vars et al.
 
     // Init the options.

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -59,6 +59,23 @@ describe('autocmd', function()
     eq(expected, eval('g:evs'))
   end)
 
+  it('first edit causes BufUnload on NoName', function()
+    local expected = {
+      {'BufUnload', ''},
+      {'BufDelete', ''},
+      {'BufWipeout', ''},
+      {'BufEnter', 'testfile1'},
+    }
+    command('let g:evs = []')
+    command('autocmd BufEnter * :call add(g:evs, ["BufEnter", expand("<afile>")])')
+    command('autocmd BufDelete * :call add(g:evs, ["BufDelete", expand("<afile>")])')
+    command('autocmd BufLeave * :call add(g:evs, ["BufLeave", expand("<afile>")])')
+    command('autocmd BufUnload * :call add(g:evs, ["BufUnload", expand("<afile>")])')
+    command('autocmd BufWipeout * :call add(g:evs, ["BufWipeout", expand("<afile>")])')
+    command('edit testfile1')
+    eq(expected, eval('g:evs'))
+  end)
+
   it('WinClosed is non-recursive', function()
     command('let g:triggered = 0')
     command('autocmd WinClosed * :let g:triggered+=1 | :bdelete 2')


### PR DESCRIPTION
Editing a real file after opening nvim without a file to edit reuses the
"NoName" buffer that nvim uses as a placeholder. Previously the buffer
creation code would emit BufDelete and BufWipeout events manually for
the NoName buffer and then call buf_freeall a bit later with that
buffer. buf_freeall emits BufUnload and optionally emits BufDelete and
BufWipeout via flags that indicate to emit them. The buf_freeall call
for the NoName buffer wasn't given those flags, so it only emitted
BufUnload.

All of this means that when reusing the NoName buffer, we'd emit
BufDelete, BufWipeout, and then BufUnload. The docs state that BufUnload
is before BufDelete, so that's one bug. A second bug was that the buffer
filename was set to the newly edited file's name in the meantime, so the
BufUnload event had the new file in <afile> when it's called, not the empty
string.

This pulls the call to buf_freeall up to where the delete and wipeout
events were manually emitted. It uses buf_freeall to emit those events,
so removes that duplication. That gets the events to go in the correct
unload, delete, and wipeout order and corrects the filename for the
unload event.