### PR TITLE
feat(healthcheck): check for slow shell invocation

### DIFF
--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -146,12 +146,9 @@ function! s:check_performance() abort
   endif
 
   " check for slow shell invocation
-  let shell_cmd = 'echo'
   let slow_cmd_time = 1.5
   let start_time = reltime()
-
-  call system(shell_cmd)
-
+  call system('echo')
   let elapsed_time = reltimefloat(reltime(start_time))
   if elapsed_time > slow_cmd_time
     call health#report_warn(

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -146,7 +146,7 @@ function! s:check_performance() abort
   endif
 
   " check for slow shell invocation
-  let shell_cmd = 'ls'
+  let shell_cmd = 'echo'
   let slow_cmd_time = 1.5
   if !executable(shell_cmd)
     return

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -152,8 +152,7 @@ function! s:check_performance() abort
   let elapsed_time = reltimefloat(reltime(start_time))
   if elapsed_time > slow_cmd_time
     call health#report_warn(
-          \ 'Slow shell invocation (took '.printf('%.2f', elapsed_time).' seconds).',
-          \ ['Optimize your shell configuration.'])
+          \ 'Slow shell invocation (took '.printf('%.2f', elapsed_time).' seconds).')
   endif
 endfunction
 

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -144,6 +144,23 @@ function! s:check_performance() abort
           \ ['Install a different Nvim package, or rebuild with `CMAKE_BUILD_TYPE=RelWithDebInfo`.',
           \  s:suggest_faq])
   endif
+
+  " check for slow shell invocation
+  let shell_cmd = 'ls'
+  let slow_cmd_time = 1.5
+  if !executable(shell_cmd)
+    return
+  endif
+  let start_time = reltime()
+
+  call system(shell_cmd)
+
+  let elapsed_time = reltimefloat(reltime(start_time))
+  if elapsed_time > slow_cmd_time
+    call health#report_warn(
+          \ 'Slow shell invocation (invocation took '.printf('%.2f', elapsed_time).' seconds).',
+          \ ['Optimize your shell configuration.'])
+  endif
 endfunction
 
 function! s:get_tmux_option(option) abort

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -148,9 +148,6 @@ function! s:check_performance() abort
   " check for slow shell invocation
   let shell_cmd = 'echo'
   let slow_cmd_time = 1.5
-  if !executable(shell_cmd)
-    return
-  endif
   let start_time = reltime()
 
   call system(shell_cmd)

--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -152,7 +152,7 @@ function! s:check_performance() abort
   let elapsed_time = reltimefloat(reltime(start_time))
   if elapsed_time > slow_cmd_time
     call health#report_warn(
-          \ 'Slow shell invocation (invocation took '.printf('%.2f', elapsed_time).' seconds).',
+          \ 'Slow shell invocation (took '.printf('%.2f', elapsed_time).' seconds).',
           \ ['Optimize your shell configuration.'])
   endif
 endfunction


### PR DESCRIPTION
Add check for slow shell invocation in performance health check. As a
slow shell invocation could negatively affect the neovim experience a
warning is added if executing a command takes longer than 1.5 seconds.