### PR TITLE
fix(PVS/V560): ignore false "conditional expression is always false"

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2792,8 +2792,8 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit, int
     return NOTDONE;
   }
 
-  if (old_qf_curlist != qi->qf_curlist
-      || old_changetick != qfl->qf_changedtick
+  if (old_qf_curlist != qi->qf_curlist  // -V560
+      || old_changetick != qfl->qf_changedtick  // -V560
       || !is_qf_entry_present(qfl, qf_ptr)) {
     if (qfl_type == QFLT_QUICKFIX) {
       emsg(_(e_current_quickfix_list_was_changed));
@@ -2894,7 +2894,7 @@ static int qf_jump_open_window(qf_info_T *qi, qfline_T *qf_ptr, bool newwin, int
     }
   }
   if (old_qf_curlist != qi->qf_curlist
-      || old_changetick != qfl->qf_changedtick
+      || old_changetick != qfl->qf_changedtick  // -V560
       || !is_qf_entry_present(qfl, qf_ptr)) {
     if (qfl_type == QFLT_QUICKFIX) {
       emsg(_(e_current_quickfix_list_was_changed));


### PR DESCRIPTION
Quoting @yegappan:
"'qi' points to the global variable 'ql_info' or the window local location list stack 'wp->w_llist'.  The contents of these structures can be changed out-of-band by an autocmd."

https://github.com/vim/vim/pull/9993#issuecomment-1076544168
