### PR TITLE
fix(treesitter): correctly check for existing highlight groups

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -1,4 +1,5 @@
 local a = vim.api
+local fn = vim.fn
 local query = require"vim.treesitter.query"
 
 -- support reload for quick experimentation
@@ -84,8 +85,7 @@ TSHighlighter.hl_map = setmetatable({
 
 ---@private
 local function is_highlight_name(capture_name)
-  local firstc = string.sub(capture_name, 1, 1)
-  return firstc ~= string.lower(firstc)
+  return fn.hlID(capture_name) ~= 0
 end
 
 ---@private
@@ -126,9 +126,10 @@ end
 function TSHighlighterQuery:_get_hl_from_capture(capture)
   local name = self._query.captures[capture]
 
-  if is_highlight_name(name) then
-    -- From "Normal.left" only keep "Normal"
-    return vim.split(name, '.', true)[1], true
+  -- From "Normal.left" only keep "Normal"
+  local first = vim.split(name, '.', true)[1]
+  if is_highlight_name(first) then
+    return first, true
   else
     return TSHighlighter.hl_map[name] or 0, false
   end


### PR DESCRIPTION
Rather than use a heuristic that existing highlight groups begin with an
upper case letter, explicitly check for the existence of the highlight
group. This allows query captures to also use highlights that start with
a lower case letter.

This is useful for existing syntax specific groups, like `cFunction`, `vimOption`, or `luaTable`, which are used by the existing syntax highlighting files and which color schemes may already have definitions for.

cc @theHamsta @clason. I think this is safe to do because the only way this would break something is if someone has a highlight group defined with the same name as a capture, e.g. `function` (lower case) or something. Still, while I think this is useful I don't want it to be a breaking change so I'm ok with a zero-tolerance policy for this.