### PR TITLE
ci: remove src/nvim/**.lua from docgen pattern

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -6,7 +6,6 @@ on:
       - 'marvim/api-doc-update**'
     paths:
       - 'src/nvim/api/*.[ch]'
-      - 'src/nvim/**.lua'
       - 'runtime/lua/**.lua'
 
 jobs:

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -6,7 +6,6 @@ on:
   push:
     paths:
       - 'src/nvim/api/*.[ch]'
-      - 'src/nvim/**.lua'
       - 'runtime/lua/**.lua'
     branches:
       - 'master'


### PR DESCRIPTION
After #17623 this pattern is no longer necessary.