### PR TITLE
feat(runtime): include Lua in C++ ftplugin

### DIFF
--- a/runtime/ftplugin/cpp.vim
+++ b/runtime/ftplugin/cpp.vim
@@ -10,6 +10,7 @@ endif
 
 " Behaves mostly just like C
 runtime! ftplugin/c.vim ftplugin/c_*.vim ftplugin/c/*.vim
+runtime! ftplugin/c.lua ftplugin/c_*.lua ftplugin/c/*.lua
 
 " C++ uses templates with <things>
 " Disabled, because it gives an error for typing an unmatched ">".


### PR DESCRIPTION
Poor Lua is being left out of the party.

I am not going through upstream for this change since Vim does not support Lua
ftplugins.
