### PR TITLE
fix(tui): correct CSI sequence

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2077,7 +2077,7 @@ static void augment_terminfo(TUIData *data, const char *term, long vte_version, 
     // Kitty does not support these sequences; it only supports it's own CSI > 1 u which enables the
     // Kitty keyboard protocol
     data->unibi_ext.enable_extended_keys = (int)unibi_add_ext_str(ut, "ext.enable_extended_keys",
-                                                                  "\x1b[>4;1m");
+                                                                  "\x1b[>4;2m");
     data->unibi_ext.disable_extended_keys = (int)unibi_add_ext_str(ut, "ext.disable_extended_keys",
                                                                    "\x1b[>4;0m");
   }


### PR DESCRIPTION
Follow up to #17771. The sequence `CSI > 4 ; 1 m` does not enable
distinguishing all available keys; notably, it excludes `<Tab>`. Using
`CSI > 4 ; 2 m` tells the terminal to disambiguate *all* keys, which is
much more useful.

The meaning of the final parameter is documented [here][1].

[1]: https://invisible-island.net/xterm/manpage/xterm.html#VT100-Widget-Resources:modifyOtherKeys
