### PR TITLE
vim-patch:8.2.3453: autocmd not executed when editing a directory

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -361,7 +361,7 @@ int readfile(char_u *fname, char_u *sfname, linenr_T from, linenr_T lines_to_ski
       filemess(curbuf, fname, (char_u *)_(msg_is_a_directory), 0);
       msg_end();
       msg_scroll = msg_save;
-      return FAIL;
+      return NOTDONE;
     }
   }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2343,6 +2343,19 @@ func Test_throw_in_BufWritePre()
   au! throwing
 endfunc
 
+func Test_autocmd_in_try_block()
+  call mkdir('Xdir')
+  au BufEnter * let g:fname = expand('%')
+  try
+    edit Xdir/
+  endtry
+  call assert_match('Xdir', g:fname)
+
+  unlet g:fname
+  au! BufEnter
+  call delete('Xdir', 'rf')
+endfunc
+
 func Test_autocmd_CmdWinEnter()
   CheckRunVimInTerminal
   " There is not cmdwin switch, so


### PR DESCRIPTION
Fix #13726

#### vim-patch:8.2.3453: autocmd not executed when editing a directory

Problem:    Autocmd not executed when editing a directory ending in a path
            separator inside try block.
Solution:   Return NOTDONE instead of FAIL.
https://github.com/vim/vim/commit/40fa12aea352474d229f2f750e954a4318aead4e