### PR TITLE
fix(filetype.lua): always return a string in getline helper function

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -21,7 +21,7 @@ end
 
 ---@private
 local function getline(bufnr, lnum)
-  return api.nvim_buf_get_lines(bufnr, lnum-1, lnum, false)[1]
+  return api.nvim_buf_get_lines(bufnr, lnum-1, lnum, false)[1] or ""
 end
 
 -- Filetypes based on file extension


### PR DESCRIPTION
Uses of `getline` in `filetype.lua` currently assume it always returns a string. However, if the buffer is unloaded when filetype detection runs, `getline` returns `nil`. Fixing this prevents errors when filetype detection is run on unloaded buffers.