### PR TITLE
refactor!: rename nvim_do_autocmd to nvim_exec_autocmd

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3284,7 +3284,7 @@ nvim_del_autocmd({id})                                    *nvim_del_autocmd()*
                 See also: ~
                     |nvim_create_autocmd()|
 
-nvim_do_autocmd({event}, {*opts})                          *nvim_do_autocmd()*
+nvim_exec_autocmd({event}, {*opts})                      *nvim_exec_autocmd()*
                 Execute an autocommand |autocmd-execute|.
 
                 Parameters: ~

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -697,7 +697,7 @@ void nvim_del_augroup_by_name(String name)
 ///             - modeline (bool) optional: defaults to true. Process the
 ///             modeline after the autocommands |<nomodeline>|.
 /// @see |:doautocmd|
-void nvim_do_autocmd(Object event, Dict(do_autocmd) *opts, Error *err)
+void nvim_exec_autocmd(Object event, Dict(exec_autocmd) *opts, Error *err)
   FUNC_API_SINCE(9)
 {
   int au_group = AUGROUP_ALL;

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -133,7 +133,7 @@ return {
     "nested";
     "pattern";
   };
-  do_autocmd = {
+  exec_autocmd = {
     "buffer";
     "group";
     "modeline";

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -168,7 +168,7 @@ describe('autocmd api', function()
       })
       ]]
 
-      meths.do_autocmd("User", {pattern = "Test"})
+      meths.exec_autocmd("User", {pattern = "Test"})
       eq({{
         buflocal = false,
         command = 'A test autocommand',
@@ -179,7 +179,7 @@ describe('autocmd api', function()
         pattern = 'Test',
       }}, meths.get_autocmds({event = "User", pattern = "Test"}))
       meths.set_var("some_condition", true)
-      meths.do_autocmd("User", {pattern = "Test"})
+      meths.exec_autocmd("User", {pattern = "Test"})
       eq({}, meths.get_autocmds({event = "User", pattern = "Test"}))
     end)
   end)
@@ -490,7 +490,7 @@ describe('autocmd api', function()
     end)
   end)
 
-  describe('nvim_do_autocmd', function()
+  describe('nvim_exec_autocmd', function()
     it("can trigger builtin autocmds", function()
       meths.set_var("autocmd_executed", false)
 
@@ -500,7 +500,7 @@ describe('autocmd api', function()
       })
 
       eq(false, meths.get_var("autocmd_executed"))
-      meths.do_autocmd("BufReadPost", {})
+      meths.exec_autocmd("BufReadPost", {})
       eq(true, meths.get_var("autocmd_executed"))
     end)
 
@@ -514,10 +514,10 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      meths.do_autocmd("CursorHold", { buffer = 1 })
+      meths.exec_autocmd("CursorHold", { buffer = 1 })
       eq(-1, meths.get_var("buffer_executed"))
 
-      meths.do_autocmd("BufLeave", { buffer = 1 })
+      meths.exec_autocmd("BufLeave", { buffer = 1 })
       eq(1, meths.get_var("buffer_executed"))
     end)
 
@@ -531,7 +531,7 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      meths.do_autocmd("CursorHold", { buffer = 1 })
+      meths.exec_autocmd("CursorHold", { buffer = 1 })
       eq('none', meths.get_var("filename_executed"))
 
       meths.command('edit __init__.py')
@@ -539,7 +539,7 @@ describe('autocmd api', function()
     end)
 
     it('cannot pass buf and fname', function()
-      local ok = pcall(meths.do_autocmd, "BufReadPre", { pattern = "literally_cannot_error.rs", buffer = 1 })
+      local ok = pcall(meths.exec_autocmd, "BufReadPre", { pattern = "literally_cannot_error.rs", buffer = 1 })
       eq(false, ok)
     end)
 
@@ -557,16 +557,16 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      meths.do_autocmd("CursorHoldI", { buffer = 1 })
+      meths.exec_autocmd("CursorHoldI", { buffer = 1 })
       eq('none', meths.get_var("filename_executed"))
 
-      meths.do_autocmd("CursorHoldI", { buffer = tonumber(meths.get_current_buf()) })
+      meths.exec_autocmd("CursorHoldI", { buffer = tonumber(meths.get_current_buf()) })
       eq('__init__.py', meths.get_var("filename_executed"))
 
       -- Reset filename
       meths.set_var("filename_executed", 'none')
 
-      meths.do_autocmd("CursorHoldI", { pattern = '__init__.py' })
+      meths.exec_autocmd("CursorHoldI", { pattern = '__init__.py' })
       eq('__init__.py', meths.get_var("filename_executed"))
     end)
 
@@ -578,9 +578,9 @@ describe('autocmd api', function()
         command = 'let g:matched = "matched"'
       })
 
-      meths.do_autocmd("User", { pattern = "OtherCommand" })
+      meths.exec_autocmd("User", { pattern = "OtherCommand" })
       eq('none', meths.get_var('matched'))
-      meths.do_autocmd("User", { pattern = "TestCommand" })
+      meths.exec_autocmd("User", { pattern = "TestCommand" })
       eq('matched', meths.get_var('matched'))
     end)
 
@@ -594,7 +594,7 @@ describe('autocmd api', function()
       })
 
       eq(false, meths.get_var("group_executed"))
-      meths.do_autocmd("FileType", { group = auid })
+      meths.exec_autocmd("FileType", { group = auid })
       eq(true, meths.get_var("group_executed"))
     end)
 
@@ -609,7 +609,7 @@ describe('autocmd api', function()
       })
 
       eq(false, meths.get_var("group_executed"))
-      meths.do_autocmd("FileType", { group = auname })
+      meths.exec_autocmd("FileType", { group = auname })
       eq(true, meths.get_var("group_executed"))
     end)
   end)


### PR DESCRIPTION
Prompted from https://github.com/neovim/neovim/pull/17545#discussion_r829991805 .

From `help :dev-api`.

```
Use existing common {action} names if possible:
    add   Append to, or insert into, a collection
    del   Delete a thing (or group of things)
*** exec  Execute code
    get   Get a thing (or group of things by query)
    list  Get all things
    set   Set a thing (or group of things)
```

**Let's decide if we want to keep the name or change it.**

I prefer `exec` 🚲 🛖 