### PR TITLE
ci: automatic breaking change label

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,6 +30,8 @@ jobs:
       run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')" || true
     - name: "Extract commit scope and add as label"
       run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+\((.+)\)!?:.*|\1|')" || true
+    - name: "Extract if the PR is a breaking change and add it as label"
+      run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')" || true
 
   request-reviewer:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false


### PR DESCRIPTION
When the PR title contains the breaking change format apply the breaking-change label.

Just an idea I think would be nice, since finding PR's that are a breaking change is not easy, tried searching for "!:" in the pull request search bar gives no results. 

This might also be useful for future automation, perhaps when a breaking-change PR is merged an action creates a placeholder comment in the `Following HEAD: breaking changes on master` issue.

Note: a breaking-change label doesn't exist yet, needs to be created in the repo for it to work.

Example working: https://github.com/muniter/neovim/pull/24