### PR TITLE
fix/PVS

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -380,7 +380,7 @@ run_analysis() {(
       --sourcetree-root . || true
 
   rm -rf PVS-studio.{xml,err,tsk,html.d}
-  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V011,V1042,V1051,V1074"
+  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V011,V1042,V1051,V1074,V002"
   plog-converter $plog_args --renderTypes xml       --output PVS-studio.xml
   plog-converter $plog_args --renderTypes errorfile --output PVS-studio.err
   plog-converter $plog_args --renderTypes tasklist  --output PVS-studio.tsk

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2445,7 +2445,7 @@ bool autocmd_delete_id(int64_t id)
 
   // Note that since multiple AutoCmd objects can have the same ID, we need to do a full scan.
   FOR_ALL_AUEVENTS(event) {
-    FOR_ALL_AUPATS_IN_EVENT(event, ap) {
+    FOR_ALL_AUPATS_IN_EVENT(event, ap) {  // -V756
       for (AutoCmd *ac = ap->cmds; ac != NULL; ac = ac->next) {
         if (ac->id == id) {
           aucmd_del(ac);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1118,7 +1118,7 @@ retry:
                   && tmpname == NULL
                   && (*fenc == 'u' || *fenc == NUL)))) {
         char_u *ccname;
-        int blen;
+        int blen = 0;
 
         // no BOM detection in a short file or in binary mode
         if (size < 2 || curbuf->b_p_bin) {

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2751,6 +2751,7 @@ static void truncate_fold(win_T *const wp, fold_T *fp, linenr_T end)
 }
 
 #define FOLD_END(fp) ((fp)->fd_top + (fp)->fd_len - 1)
+// -V:VALID_FOLD:V560
 #define VALID_FOLD(fp, gap) \
   ((gap)->ga_len > 0 && (fp) < ((fold_T *)(gap)->ga_data + (gap)->ga_len))
 #define FOLD_INDEX(fp, gap) ((size_t)((fp) - ((fold_T *)(gap)->ga_data)))


### PR DESCRIPTION
- fix(PVS/V002): disable rule completely
- fix(PVS/V756): ignore "counter is not used inside a nested loop" warning
- fix(PVS/V1048): the variable was assigned the same value.
- fix(PVS/V560): disable "a part of conditional expression is always true"
