### PR TITLE
vim-patch:8.2.4626: Visual area not updated when removing sign in Visual mode

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -938,7 +938,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
     if (mod_top != 0
         && wp->w_topline == mod_top
         && (!wp->w_lines[0].wl_valid
-            || wp->w_topline <= wp->w_lines[0].wl_lnum)) {
+            || wp->w_topline == wp->w_lines[0].wl_lnum)) {
       // w_topline is the first changed line and window is not scrolled,
       // the scrolling from changed lines will be done further down.
     } else if (wp->w_lines[0].wl_valid

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -263,6 +263,27 @@ func Test_display_scroll_at_topline()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_display_scroll_update_visual()
+  CheckScreendump
+
+  let lines =<< trim END
+      set scrolloff=0
+      call setline(1, repeat(['foo'], 10))
+      call sign_define('foo', { 'text': '>' })
+      call sign_place(1, 'bar', 'foo', bufnr(), { 'lnum': 2 })
+      call sign_place(2, 'bar', 'foo', bufnr(), { 'lnum': 1 })
+      autocmd CursorMoved * if getcurpos()[1] == 2 | call sign_unplace('bar', { 'id': 1 }) | endif
+  END
+  call writefile(lines, 'XupdateVisual.vim')
+
+  let buf = RunVimInTerminal('-S XupdateVisual.vim', #{rows: 8, cols: 60})
+  call term_sendkeys(buf, "VG7kk")
+  call VerifyScreenDump(buf, 'Test_display_scroll_update_visual', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XupdateVisual.vim')
+endfunc
+
 " Test for 'eob' (EndOfBuffer) item in 'fillchars'
 func Test_eob_fillchars()
   " default value (skipped)


### PR DESCRIPTION
#### vim-patch:8.2.4626: Visual area not updated when removing sign in Visual mode

Problem:    Visual area not fully updated when removing sign in Visual mode
            while scrolling.
Solution:   Adjust check for topline.
https://github.com/vim/vim/commit/abb6fbd14d985b9b36a4e336d6edaf9853888ac1