### PR TITLE
vim-patch:8.2.3943: compiler warning from gcc for uninitialized variable

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1536,7 +1536,7 @@ static void diff_read(int idx_orig, int idx_new, diffio_T *dio)
   long off;
   int i;
   int notset = true;  // block "*dp" not set yet
-  diffhunk_T *hunk;
+  diffhunk_T *hunk = NULL;  // init to avoid gcc warning
   enum {
     DIFF_ED,
     DIFF_UNIFIED,


### PR DESCRIPTION
Problem:    Compiler warning from gcc for uninitialized variable.
Solution:   Initialize variable. (closes vim/vim#9429)
https://github.com/vim/vim/commit/491669701c72578f273db53e579d8a03a9deac0c
