### PR TITLE
docs(api): fix wrong documentation of `nvim_create_autocmd`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1802,7 +1802,7 @@ nvim_parse_expression({expr}, {flags}, {highlight})
                           there for debugging purposes primary (debugging
                           parser and providing debug information).
                         • "children": a list of nodes described in top/"ast".
-                          There is always zero, one or two children, key will
+                          There always is zero, one or two children, key will
                           not be present if node has no children. Maximum
                           number of children may be found in node_maxchildren
                           array.
@@ -1967,7 +1967,7 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
                 current window already shows "buffer", the window is not
                 switched If a window inside the current tabpage (including a
                 float) already shows the buffer One of these windows will be
-                set as current window temporarily. Otherwise, a temporary
+                set as current window temporarily. Otherwise a temporary
                 scratch window (called the "autocmd window" for historical
                 reasons) will be used.
 
@@ -2362,7 +2362,7 @@ nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line}, {col_start},
                 it in to this function as `ns_id` to add highlights to the
                 namespace. All highlights in the same namespace can then be
                 cleared with single call to |nvim_buf_clear_namespace()|. If
-                the highlight will never be deleted by an API call, pass
+                the highlight never will be deleted by an API call, pass
                 `ns_id = -1`.
 
                 As a shorthand, `ns_id = 0` can be used to create a new
@@ -3029,7 +3029,7 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                                   double box style could be specified as [
                                   "╔", "═" ,"╗", "║", "╝", "═", "╚", "║" ]. If
                                   the number of chars are less than eight,
-                                  they will be repeated. Thus, an ASCII border
+                                  they will be repeated. Thus an ASCII border
                                   could be specified as [ "/", "-", "\\", "|"
                                   ], or all chars the same as [ "x" ]. An
                                   empty string can be used to turn off a
@@ -3188,16 +3188,14 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
                     -- Vimscript function name (as a string)
                     local myvimfun = "g:MyVimFunction"
 
-                    vim.api.nvim_create_autocmd({
-                      event = {"BufEnter", "BufWinEnter"},
+                    vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
                       pattern = {"*.c", "*.h"},
                       callback = myluafun,  -- Or myvimfun
                     })
 <
 
                 Example using command: >
-                    vim.api.nvim_create_autocmd({
-                      event = {"BufEnter", "BufWinEnter"},
+                    vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
                       pattern = {"*.c", "*.h"},
                       command = "echo 'Entering a C or C++ file'",
                     })
@@ -3209,8 +3207,8 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
 <
 
                 Examples values for event: >
-                  event = "BufPreWrite"
-                  event = {"CursorHold", "BufPreWrite", "BufPostWrite"}
+                  "BufPreWrite"
+                  {"CursorHold", "BufPreWrite", "BufPostWrite"}
 <
 
                 Parameters: ~

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -340,8 +340,7 @@ cleanup:
 ///     -- Vimscript function name (as a string)
 ///     local myvimfun = "g:MyVimFunction"
 ///
-///     vim.api.nvim_create_autocmd({
-///       event = {"BufEnter", "BufWinEnter"},
+///     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
 ///       pattern = {"*.c", "*.h"},
 ///       callback = myluafun,  -- Or myvimfun
 ///     })
@@ -349,8 +348,7 @@ cleanup:
 ///
 /// Example using command:
 /// <pre>
-///     vim.api.nvim_create_autocmd({
-///       event = {"BufEnter", "BufWinEnter"},
+///     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
 ///       pattern = {"*.c", "*.h"},
 ///       command = "echo 'Entering a C or C++ file'",
 ///     })
@@ -364,8 +362,8 @@ cleanup:
 ///
 /// Examples values for event:
 /// <pre>
-///   event = "BufPreWrite"
-///   event = {"CursorHold", "BufPreWrite", "BufPostWrite"}
+///   "BufPreWrite"
+///   {"CursorHold", "BufPreWrite", "BufPostWrite"}
 /// </pre>
 ///
 /// @param event (String|Array) The event or events to register this autocommand


### PR DESCRIPTION
This PR fixes examples of `nvim_create_autocmd`. It accepts events from 1st argument, but example says it accepts them from option objects.