### PR TITLE
fix(decorations): do not put empty virt_text

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -4333,6 +4333,9 @@ static int draw_virt_text_item(buf_T *buf, int col, VirtText vt, HlMode hl_mode,
         break;
       }
     }
+    if (!*s.p) {
+      continue;
+    }
     int attr;
     bool through = false;
     if (hl_mode == kHlModeCombine) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -437,6 +437,7 @@ describe('extmark decorations', function()
       [22] = {foreground = tonumber('0xb20000'), background = tonumber('0xf13f3f')};
       [23] = {foreground = Screen.colors.Magenta1, background = Screen.colors.LightGrey};
       [24] = {bold = true};
+      [25] = {background = Screen.colors.LightRed};
     }
 
     ns = meths.create_namespace 'test'
@@ -456,6 +457,31 @@ for _,item in ipairs(items) do
     end
 end]]
 
+  it('empty virtual text at eol should not break colorcolumn #17860', function()
+    insert(example_text)
+    feed('gg')
+    command('set colorcolumn=40')
+    screen:expect([[
+      ^for _,item in ipairs(items) do         {25: }          |
+          local text, hl_id_cell, count = unp{25:a}ck(item)  |
+          if hl_id_cell ~= nil then          {25: }          |
+              hl_id = hl_id_cell             {25: }          |
+          end                                {25: }          |
+          for _ = 1, (count or 1) do         {25: }          |
+              local cell = line[colpos]      {25: }          |
+              cell.text = text               {25: }          |
+              cell.hl_id = hl_id             {25: }          |
+              colpos = colpos+1              {25: }          |
+          end                                {25: }          |
+      end                                    {25: }          |
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+    meths.buf_set_extmark(0, ns, 4, 0, { virt_text={{''}}, virt_text_pos='eol'})
+    screen:expect_unchanged()
+  end)
+
   it('can have virtual text of overlay position', function()
     insert(example_text)
     feed 'gg'
@@ -471,7 +497,9 @@ end]]
     -- can "float" beyond end of line
     meths.buf_set_extmark(0, ns, 5, 28, { virt_text={{'loopy', 'ErrorMsg'}}, virt_text_pos='overlay'})
     -- bound check: right edge of window
-    meths.buf_set_extmark(0, ns, 2, 26, { virt_text={{'bork bork bork ' }, {'bork bork bork', 'ErrorMsg'}}, virt_text_pos='overlay'})
+    meths.buf_set_extmark(0, ns, 2, 26, { virt_text={{'bork bork bork '}, {'bork bork bork', 'ErrorMsg'}}, virt_text_pos='overlay'})
+    -- empty virt_text should not change anything
+    meths.buf_set_extmark(0, ns, 6, 16, { virt_text={{''}}, virt_text_pos='overlay'})
 
     screen:expect{grid=[[
       ^for _,item in ipairs(items) do                    |
@@ -621,6 +649,8 @@ end]]
     meths.buf_set_extmark(0, ns, 2, 10, { virt_text={{'Much', 'ErrorMsg'}},   virt_text_win_col=31, hl_mode='blend'})
     meths.buf_set_extmark(0, ns, 3, 15, { virt_text={{'Error', 'ErrorMsg'}}, virt_text_win_col=31, hl_mode='blend'})
     meths.buf_set_extmark(0, ns, 7, 21, { virt_text={{'-', 'NonText'}}, virt_text_win_col=4, hl_mode='blend'})
+    -- empty virt_text should not change anything
+    meths.buf_set_extmark(0, ns, 8, 0, { virt_text={{''}}, virt_text_win_col=14, hl_mode='blend'})
 
     screen:expect{grid=[[
       ^for _,item in ipairs(items) do                    |


### PR DESCRIPTION
This avoids putting a `NUL` character.

Fix #17860

All three changed test fail without the code change:
```
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] test/functional/ui/decorations_spec.lua @ 460: extmark decorations empty virtual text at eol should not break colorcolumn #17860
test/functional/ui/screen.lua:474: Row 5 did not match.
Expected:
  |^for _,item in ipairs(items) do         {25: }          |
  |    local text, hl_id_cell, count = unp{25:a}ck(item)  |
  |    if hl_id_cell ~= nil then          {25: }          |
  |        hl_id = hl_id_cell             {25: }          |
  |*    end                                {25: }          |
  |    for _ = 1, (count or 1) do         {25: }          |
  |        local cell = line[colpos]      {25: }          |
  |        cell.text = text               {25: }          |
  |        cell.hl_id = hl_id             {25: }          |
  |        colpos = colpos+1              {25: }          |
  |    end                                {25: }          |
  |end                                    {25: }          |
  |{1:~                                                 }|
  |{1:~                                                 }|
  |                                                  |
Actual:
  |^for _,item in ipairs(items) do         {25: }          |
  |    local text, hl_id_cell, count = unp{25:a}ck(item)  |
  |    if hl_id_cell ~= nil then          {25: }          |
  |        hl_id = hl_id_cell             {25: }          |
  |*    end                               {25: }          |
  |    for _ = 1, (count or 1) do         {25: }          |
  |        local cell = line[colpos]      {25: }          |
  |        cell.text = text               {25: }          |
  |        cell.hl_id = hl_id             {25: }          |
  |        colpos = colpos+1              {25: }          |
  |    end                                {25: }          |
  |end                                    {25: }          |
  |{1:~                                                 }|
  |{1:~                                                 }|
  |                                                  |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/screen.lua:474: in function 'expect_unchanged'
	test/functional/ui/decorations_spec.lua:482: in function <test/functional/ui/decorations_spec.lua:460>

[  FAILED  ] test/functional/ui/decorations_spec.lua @ 485: extmark decorations can have virtual text of overlay position
test/functional/ui/decorations_spec.lua:504: Row 7 did not match.
Expected:
  |^for _,item in ipairs(items) do                    |
  |{2:|}   local text, hl_id_cell, count = unpack(item)  |
  |{2:|}   if hl_id_cell ~= nil tbork bork bork {4:bork bork}|
  |{2:|}   {1:|}   hl_id = hl_id_cell                        |
  |{2:|}   end                                           |
  |{2:|}   for _ = 1, (count or 1) {4:loopy}                 |
  |*{2:|}   {1:|}   local cell = line[colpos]                 |
  |{2:|}   {1:|}   cell.text = text                          |
  |{2:|}   {1:|}   cell.hl_id = hl_id                        |
  |{2:|}   {1:|}   cofoo{3:bar}{4:!!}olpos+1                         |
  |    end                                           |
  |end                                               |
  |{1:~                                                 }|
  |{1:~                                                 }|
  |                                                  |
Actual:
  |^for _,item in ipairs(items) do                    |
  |{2:|}   local text, hl_id_cell, count = unpack(item)  |
  |{2:|}   if hl_id_cell ~= nil tbork bork bork {4:bork bork}|
  |{2:|}   {1:|}   hl_id = hl_id_cell                        |
  |{2:|}   end                                           |
  |{2:|}   for _ = 1, (count or 1) {4:loopy}                 |
  |*{2:|}   {1:|}   local cel = line[colpos]                 |
  |{2:|}   {1:|}   cell.text = text                          |
  |{2:|}   {1:|}   cell.hl_id = hl_id                        |
  |{2:|}   {1:|}   cofoo{3:bar}{4:!!}olpos+1                         |
  |    end                                           |
  |end                                               |
  |{1:~                                                 }|
  |{1:~                                                 }|
  |                                                  |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/decorations_spec.lua:504: in function <test/functional/ui/decorations_spec.lua:485>

[  FAILED  ] test/functional/ui/decorations_spec.lua @ 645: extmark decorations can have virtual text of fixed win_col position
test/functional/ui/decorations_spec.lua:655: Row 9 did not match.
Expected:
  |^for _,item in ipairs(items) do                    |
  |    local text, hl_id_cell, cou{4:Very} unpack(item)  |
  |    if hl_id_cell ~= nil then  {4:Much}               |
  |        hl_id = hl_id_cell     {4:Error}              |
  |    end                                           |
  |    for _ = 1, (count or 1) do                    |
  |        local cell = line[colpos]                 |
  |    {1:-}   cell.text = text                          |
  |*        cell.hl_id = hl_id                        |
  |        colpos = colpos+1                         |
  |    end                                           |
  |end                                               |
  |{1:~                                                 }|
  |{1:~                                                 }|
  |                                                  |
Actual:
  |^for _,item in ipairs(items) do                    |
  |    local text, hl_id_cell, cou{4:Very} unpack(item)  |
  |    if hl_id_cell ~= nil then  {4:Much}               |
  |        hl_id = hl_id_cell     {4:Error}              |
  |    end                                           |
  |    for _ = 1, (count or 1) do                    |
  |        local cell = line[colpos]                 |
  |    {1:-}   cell.text = text                          |
  |*        cell.h_id = hl_id                        |
  |        colpos = colpos+1                         |
  |    end                                           |
  |end                                               |
  |{1:~                                                 }|
  |{1:~                                                 }|
  |                                                  |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:595: in function '_wait'
	test/functional/ui/screen.lua:362: in function 'expect'
	test/functional/ui/decorations_spec.lua:655: in function <test/functional/ui/decorations_spec.lua:645>

```