### PR TITLE
ci(doc): improve missing docs workflow

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'src/nvim/api/*.[ch]'
       - 'runtime/lua/**.lua'
+      - 'runtime/doc/**'
 
 jobs:
   call-regen-api-docs:

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'src/nvim/api/*.[ch]'
       - 'runtime/lua/**.lua'
+      - 'runtime/doc/**'
     branches:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
@@ -56,6 +57,8 @@ jobs:
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && inputs.check_only }}
         run: |
           echo "Job failed, run ./scripts/gen_vimdoc.py and commit your doc changes"
+          echo "The doc generation produces the following changes:"
+          git --no-pager diff
           exit 1
 
       - name: Automatic PR


### PR DESCRIPTION
1. Add new pattern `runtime/doc/**`. This is a common case were the
   contributor modifies only the help file but the doc gen would discard
   their changes.

2. Add to the output what the changes after running doc gen would be.

<details>
<summary>previous intent</summary>

1. Add new pattern `runtime/doc/**`. This is a common case were the
   contributor modifies only the help file but the doc gen would discard
   their changes.

2. Make "skip ci" not skip the doc gen workflow. Since one of the most
   common uses for skip ci is doc changes and that's when this
   workflow is actually needed.

   This is a accomplished by using `pull_request_target` but by default
   `$GITHUB_SHA` in this event is the last commit of the base branch
   (`neovim@master`). Therefore generate the docs in the tip of the PR
   branch by providing a ref to the checkout action, which is also the
   same commit in which the user will run doc gen locally (should lead
   to less flakiness).

3. Add to the output what the changes after running doc gen would be.

A couple of tests:

- With skip ci, showing the diff: [Workflow](https://github.com/muniter/neovim/runs/5703782425?check_suite_focus=true), [PR](https://github.com/muniter/neovim/pull/29)
- Running on push to master and generating the PR: [Workflow](https://github.com/muniter/neovim/runs/5703787608?check_suite_focus=true), [Automatic PR](https://github.com/muniter/neovim/pull/30)
</details>