### PR TITLE
vim-patch:8.1.1320: it is not possible to track changes to a buffer

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -396,6 +396,14 @@ struct stl_item {
   } type;
 };
 
+/// Structure used for listeners added with listener_add().
+typedef struct listener_S listener_T;
+struct listener_S {
+  listener_T *lr_next;
+  int lr_id;
+  Callback lr_callback;
+};
+
 // values for b_syn_spell: what to do with toplevel text
 #define SYNSPL_DEFAULT  0       // spell check if @Spell not defined
 #define SYNSPL_TOP      1       // spell check toplevel text
@@ -830,6 +838,8 @@ struct file_buffer {
 
   ScopeDictDictItem b_bufvar;  ///< Variable for "b:" Dictionary.
   dict_T *b_vars;  ///< b: scope dictionary.
+
+  listener_T *b_listener;
 
   /* When a buffer is created, it starts without a swap file.  b_may_swap is
    * then set to indicate that a swap file may be opened later.  It is reset


### PR DESCRIPTION
Problem:    It is not possible to track changes to a buffer.
Solution:   Add listener_add() and listener_remove(). No docs or tests yet.
https://github.com/vim/vim/commit/6d2399bd1053b367e13cc2b8991d3ff0bf724c7c
