### PR TITLE
vim-patch:8.2.4631: crash when switching window in BufWipeout autocommand

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -590,6 +590,10 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last)
 
   // Remove the buffer from the list.
   if (wipe_buf) {
+    // Do not wipe out the buffer if it is used in a window.
+    if (buf->b_nwindows > 0) {
+      return false;
+    }
     if (buf->b_sfname != buf->b_ffname) {
       XFREE_CLEAR(buf->b_sfname);
     } else {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6839,7 +6839,7 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
 
     // Autocommands may delete the tab page under our fingers and we may
     // fail to close a window with a modified buffer.
-    if (!valid_tabpage(tp) || tp->tp_firstwin == wp) {
+    if (!valid_tabpage(tp) || tp->tp_lastwin == wp) {
       break;
     }
   }

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2611,4 +2611,21 @@ func Test_autocmd_closing_cmdwin()
   only
 endfunc
 
+func Test_bufwipeout_changes_window()
+  " This should not crash, but we don't have any expectations about what
+  " happens, changing window in BufWipeout has unpredictable results.
+  tabedit
+  let g:window_id = win_getid()
+  topleft new
+  setlocal bufhidden=wipe
+  autocmd BufWipeout <buffer> call win_gotoid(g:window_id)
+  tabprevious
+  +tabclose
+
+  unlet g:window_id
+  au! BufWipeout
+  %bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/editor/tabpage_spec.lua
+++ b/test/functional/editor/tabpage_spec.lua
@@ -3,8 +3,10 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
+local neq = helpers.neq
 local feed = helpers.feed
 local eval = helpers.eval
+local exec = helpers.exec
 
 describe('tabpage', function()
   before_each(clear)
@@ -33,6 +35,21 @@ describe('tabpage', function()
     feed('<C-W>gT')
 
     eq(3, eval('tabpagenr()'))
+  end)
+
+  it('does not crash or loop 999 times if BufWipeout autocommand switches window #17868', function()
+    exec([[
+      tabedit
+      let s:window_id = win_getid()
+      botright new
+      setlocal bufhidden=wipe
+      let g:win_closed = 0
+      autocmd WinClosed * let g:win_closed += 1
+      autocmd BufWipeout <buffer> call win_gotoid(s:window_id)
+      tabprevious
+      +tabclose
+    ]])
+    neq(999, eval('g:win_closed'))
   end)
 end)
 


### PR DESCRIPTION
Fix #17868

#### vim-patch:8.2.4631: crash when switching window in BufWipeout autocommand

Problem:    Crash when switching window in BufWipeout autocommand.
Solution:   Put any buffer in the window to avoid it being NULL.
https://github.com/vim/vim/commit/347538fad0c503249ebdedd5884c2081257c9f61

win_init_empty() cannot be made static because it is used in autocmd.c