### PR TITLE
chore: add a vim-patch ignore list for features we're undecided about

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -591,7 +591,9 @@ show_vimpatches() {
     if [[ "${runtime_commits[$vim_commit]-}" ]]; then
       printf '  • %s (+runtime)\n' "${vim_commit}"
     else
-      printf '  • %s\n' "${vim_commit}"
+      if ! grep -q "^${vim_commit%%:*}" "$NVIM_SOURCE_DIR"/scripts/vim_patch_ignore.txt; then
+        printf '  • %s\n' "${vim_commit}"
+      fi
     fi
   done
 

--- a/scripts/vim_patch_ignore.txt
+++ b/scripts/vim_patch_ignore.txt
@@ -1,0 +1,11 @@
+# This is an ignore file for vim-patches we haven't decided what to do with
+# yet. This is partly to make it easier for newcomers to not start working on
+# things we may not want, but also to make it easier to have a better overview
+# of which patches we need to focus on.
+
+# Listener functions
+# https://github.com/neovim/neovim/pull/15502#issuecomment-927361742
+v8.1.1320
+v8.1.1321
+v8.1.1332
+v8.1.1335


### PR DESCRIPTION
It is meant to be for patches that aren't strictly "Not Applicable", but
also not patches we're not sure if we actually want to import.
