### PR TITLE
vim-patch:8.2.{4638,4630}: cursorlineopt=screenline redrawing

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1295,9 +1295,6 @@ static void normal_redraw(NormalState *s)
     redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 
-  // Might need to update for 'cursorline'.
-  check_redraw_cursorline();
-
   if (VIsual_active) {
     update_curbuf(INVERTED);  // update inverted part
   } else if (must_redraw) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -7617,16 +7617,3 @@ win_T *get_win_by_grid_handle(handle_T handle)
   }
   return NULL;
 }
-
-/// Check if the cursor moved and 'cursorline' is set.  Mark for a VALID redraw
-/// if needed.
-void check_redraw_cursorline(void)
-{
-  // When 'cursorlineopt' is "screenline" need to redraw always.
-  if (curwin->w_p_cul
-      && (curwin->w_last_cursorline != curwin->w_cursor.lnum
-          || (curwin->w_p_culopt_flags & CULOPT_SCRLINE))
-      && !char_avail()) {
-    redraw_later(curwin, VALID);
-  }
-}

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -293,5 +293,26 @@ func Test_cursorline_callback()
   call delete('Xcul_timer')
 endfunc
 
+func Test_cursorline_screenline_update()
+  CheckScreendump
+
+  let lines =<< trim END
+      call setline(1, repeat('xyz ', 30))
+      set cursorline cursorlineopt=screenline
+      inoremap <F2> <Cmd>call cursor(1, 1)<CR>
+  END
+  call writefile(lines, 'Xcul_screenline')
+
+  let buf = RunVimInTerminal('-S Xcul_screenline', #{rows: 8})
+  call term_sendkeys(buf, "A")
+  call VerifyScreenDump(buf, 'Test_cursorline_screenline_1', {})
+  call term_sendkeys(buf, "\<F2>")
+  call VerifyScreenDump(buf, 'Test_cursorline_screenline_2', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+  call delete('Xcul_screenline')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -597,6 +597,31 @@ func Test_cursorline_with_visualmode()
   call delete('Xtest_cursorline_with_visualmode')
 endfunc
 
+func Test_cursorcolumn_callback()
+  CheckScreendump
+  CheckFeature timers
+
+  let lines =<< trim END
+      call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
+      set cursorcolumn
+      call cursor(4, 5)
+
+      func Func(timer)
+        call cursor(1, 1)
+      endfunc
+
+      call timer_start(300, 'Func')
+  END
+  call writefile(lines, 'Xcuc_timer')
+
+  let buf = RunVimInTerminal('-S Xcuc_timer', #{rows: 8})
+  call TermWait(buf, 310)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_callback_1', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xcuc_timer')
+endfunc
+
 func Test_colorcolumn()
   CheckScreendump
 

--- a/src/nvim/testdir/test_number.vim
+++ b/src/nvim/testdir/test_number.vim
@@ -298,6 +298,31 @@ func Test_relativenumber_colors()
   call delete('XTest_relnr')
 endfunc
 
+func Test_relativenumber_callback()
+  CheckScreendump
+  CheckFeature timers
+
+  let lines =<< trim END
+      call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
+      set relativenumber
+      call cursor(4, 1)
+
+      func Func(timer)
+        call cursor(1, 1)
+      endfunc
+
+      call timer_start(300, 'Func')
+  END
+  call writefile(lines, 'Xrnu_timer')
+
+  let buf = RunVimInTerminal('-S Xrnu_timer', #{rows: 8})
+  call TermWait(buf, 310)
+  call VerifyScreenDump(buf, 'Test_relativenumber_callback_1', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xrnu_timer')
+endfunc
+
 " Test for displaying line numbers with 'rightleft'
 func Test_number_rightleft()
   CheckFeature rightleft

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1266,6 +1266,49 @@ describe('CursorLine and CursorLineNr highlights', function()
   end)
 end)
 
+describe('CursorColumn highlight', function()
+  before_each(clear)
+  it('is updated if cursor is moved from timer', function()
+    local screen = Screen.new(50, 8)
+    screen:set_default_attr_ids({
+      [1] = {background = Screen.colors.Gray90},  -- CursorColumn
+      [2] = {bold = true, foreground = Screen.colors.Blue1},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
+      set cursorcolumn
+      call cursor(4, 5)
+
+      func Func(timer)
+        call cursor(1, 1)
+      endfunc
+
+      call timer_start(300, 'Func')
+    ]])
+    screen:expect({grid = [[
+      aaaa{1:a}                                             |
+      bbbb{1:b}                                             |
+      cccc{1:c}                                             |
+      dddd^d                                             |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]], timeout = 100})
+    screen:expect({grid = [[
+      ^aaaaa                                             |
+      {1:b}bbbb                                             |
+      {1:c}cccc                                             |
+      {1:d}dddd                                             |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]]})
+  end)
+end)
+
 describe('ColorColumn highlight', function()
   local screen
 
@@ -1569,6 +1612,46 @@ describe("'number' and 'relativenumber' highlight", function()
       {3:  1 }8               |
                           |
     ]])
+  end)
+
+  it('relative number highlight is updated if cursor is moved from timer', function()
+    local screen = Screen.new(50, 8)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Brown},  -- LineNr
+      [2] = {bold = true, foreground = Screen.colors.Blue1},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
+      set relativenumber
+      call cursor(4, 1)
+
+      func Func(timer)
+        call cursor(1, 1)
+      endfunc
+
+      call timer_start(300, 'Func')
+    ]])
+    screen:expect({grid = [[
+      {1:  3 }aaaaa                                         |
+      {1:  2 }bbbbb                                         |
+      {1:  1 }ccccc                                         |
+      {1:  0 }^ddddd                                         |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]], timeout = 100})
+    screen:expect({grid = [[
+      {1:  0 }^aaaaa                                         |
+      {1:  1 }bbbbb                                         |
+      {1:  2 }ccccc                                         |
+      {1:  3 }ddddd                                         |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]]})
   end)
 end)
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -937,17 +937,18 @@ describe('CursorLine and CursorLineNr highlights', function()
       [2] = {foreground = Screen.colors.Yellow};
       [3] = {foreground = Screen.colors.Red, background = Screen.colors.Green};
       [4] = {foreground = Screen.colors.Green, background = Screen.colors.Red};
+      [5] = {bold = true},  -- ModeMsg
     })
     screen:attach()
 
-    feed_command('set wrap cursorline cursorlineopt=screenline')
-    feed_command('set showbreak=>>>')
-    feed_command('highlight clear NonText')
-    feed_command('highlight clear CursorLine')
-    feed_command('highlight NonText guifg=Yellow gui=NONE')
-    feed_command('highlight LineNr guifg=Red guibg=Green gui=NONE')
-    feed_command('highlight CursorLine guifg=Black guibg=White gui=NONE')
-    feed_command('highlight CursorLineNr guifg=Green guibg=Red gui=NONE')
+    command('set wrap cursorline cursorlineopt=screenline')
+    command('set showbreak=>>>')
+    command('highlight clear NonText')
+    command('highlight clear CursorLine')
+    command('highlight NonText guifg=Yellow gui=NONE')
+    command('highlight LineNr guifg=Red guibg=Green gui=NONE')
+    command('highlight CursorLine guifg=Black guibg=White gui=NONE')
+    command('highlight CursorLineNr guifg=Green guibg=Red gui=NONE')
 
     feed('30iø<esc>o<esc>30ia<esc>')
 
@@ -977,7 +978,7 @@ describe('CursorLine and CursorLineNr highlights', function()
     ]])
 
     -- CursorLineNr should not apply to line number when 'cursorlineopt' does not contain "number"
-    feed_command('set relativenumber numberwidth=2')
+    command('set relativenumber numberwidth=2')
     screen:expect([[
       {3:0 }{1:øøøøøøøøøøøø^øøøøøø}|
       {3:  }{2:>>>}øøøøøøøøøøøø   |
@@ -987,7 +988,7 @@ describe('CursorLine and CursorLineNr highlights', function()
     ]])
 
     -- CursorLineNr should apply to line number when 'cursorlineopt' contains "number"
-    feed_command('set cursorlineopt+=number')
+    command('set cursorlineopt+=number')
     screen:expect([[
       {4:0 }{1:øøøøøøøøøøøø^øøøøøø}|
       {3:  }{2:>>>}øøøøøøøøøøøø   |
@@ -1018,6 +1019,44 @@ describe('CursorLine and CursorLineNr highlights', function()
       {4:0 }aaaaaaaaaaaaaaaaaa|
       {3:  }{2:>>>}{1:aaaaaaaaa^aaa   }|
                           |
+    ]])
+
+    -- updated in Insert mode
+    feed('I')
+    screen:expect([[
+      {3:1 }øøøøøøøøøøøøøøøøøø|
+      {3:  }{2:>>>}øøøøøøøøøøøø   |
+      {4:0 }{1:^aaaaaaaaaaaaaaaaaa}|
+      {3:  }{2:>>>}aaaaaaaaaaaa   |
+      {5:-- INSERT --}        |
+    ]])
+
+    feed('<Esc>gg')
+    screen:expect([[
+      {4:0 }{1:^øøøøøøøøøøøøøøøøøø}|
+      {3:  }{2:>>>}øøøøøøøøøøøø   |
+      {3:1 }aaaaaaaaaaaaaaaaaa|
+      {3:  }{2:>>>}aaaaaaaaaaaa   |
+                          |
+    ]])
+
+    command('inoremap <F2> <Cmd>call cursor(1, 1)<CR>')
+    feed('A')
+    screen:expect([[
+      {4:0 }øøøøøøøøøøøøøøøøøø|
+      {3:  }{2:>>>}{1:øøøøøøøøøøøø^   }|
+      {3:1 }aaaaaaaaaaaaaaaaaa|
+      {3:  }{2:>>>}aaaaaaaaaaaa   |
+      {5:-- INSERT --}        |
+    ]])
+
+    feed('<F2>')
+    screen:expect([[
+      {4:0 }{1:^øøøøøøøøøøøøøøøøøø}|
+      {3:  }{2:>>>}øøøøøøøøøøøø   |
+      {3:1 }aaaaaaaaaaaaaaaaaa|
+      {3:  }{2:>>>}aaaaaaaaaaaa   |
+      {5:-- INSERT --}        |
     ]])
   end)
 


### PR DESCRIPTION
#### vim-patch:8.2.4638: superfluous check if a redraw is needed for 'cursorline'

Problem:    Superfluous check if a redraw is needed for 'cursorline'.
Solution:   Remove check_redraw_cursorline(). (closes vim/vim#10030)
https://github.com/vim/vim/commit/3e559cd88486ffab6b6fb4e0921b4600d137a617

redraw_after_callback() is N/A.
Omits changes that just revert code from patch 8.2.4630.


#### vim-patch:8.2.4630: 'cursorline' not always updated with 'culopt' is "screenline"

Problem:    'cursorline' not always updated with 'cursorlineopt' is
            "screenline".
Solution:   Call check_redraw_cursorline() more often.
https://github.com/vim/vim/commit/bf269ed0b0bd8414eea7bea17465b2738a9a2b55

Code was reverted in patch 8.2.4638, so this just ports the test.