### PR TITLE
perf: only redraw concealed line if cursor has moved horizontally

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1480,8 +1480,6 @@ bool edit(int cmdchar, bool startln, long count)
 /// @param ready  not busy with something
 static void ins_redraw(bool ready)
 {
-  bool conceal_cursor_moved = false;
-
   if (char_avail()) {
     return;
   }
@@ -1504,7 +1502,6 @@ static void ins_redraw(bool ready)
       update_curswant();
       ins_apply_autocmds(EVENT_CURSORMOVEDI);
     }
-    conceal_cursor_moved = true;
     curwin->w_last_cursormoved = curwin->w_cursor;
   }
 
@@ -1558,11 +1555,6 @@ static void ins_redraw(bool ready)
       && !pum_visible()) {
     apply_autocmds(EVENT_BUFMODIFIEDSET, NULL, NULL, false, curbuf);
     curbuf->b_changed_invalid = false;
-  }
-
-  if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)
-      && conceal_cursor_moved) {
-    redrawWinline(curwin, curwin->w_cursor.lnum);
   }
 
   pum_check_clear();

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -96,12 +96,12 @@ static void comp_botline(win_T *wp)
 }
 
 /// Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
+/// Also when concealing is on and 'concealcursor' is not active.
 void redraw_for_cursorline(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  if ((wp->w_p_rnu || win_cursorline_standout(wp))
-      && (wp->w_valid & VALID_CROW) == 0
-      && !pum_visible()) {
+  if ((wp->w_valid & VALID_CROW) == 0 && !pum_visible()
+      && (wp->w_p_rnu || win_cursorline_standout(wp))) {
     // win_line() will redraw the number column and cursorline only.
     redraw_later(wp, VALID);
   }
@@ -109,6 +109,7 @@ void redraw_for_cursorline(win_T *wp)
 
 /// Redraw when w_virtcol changes and 'cursorcolumn' is set or 'cursorlineopt'
 /// contains "screenline".
+/// Also when concealing is on and 'concealcursor' is active.
 static void redraw_for_cursorcolumn(win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -120,6 +121,12 @@ static void redraw_for_cursorcolumn(win_T *wp)
       // When 'cursorlineopt' contains "screenline" need to redraw with VALID.
       redraw_later(wp, VALID);
     }
+  }
+  // If the cursor moves horizontally when 'concealcursor' is active, then the
+  // current line needs to be redrawn in order to calculate the correct
+  // cursor position.
+  if ((wp->w_valid & VALID_VIRTCOL) == 0 && wp->w_p_cole > 0 && conceal_cursor_line(wp)) {
+    redrawWinline(wp, wp->w_cursor.lnum);
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1288,13 +1288,6 @@ static void normal_redraw(NormalState *s)
   update_topline(curwin);
   validate_cursor();
 
-  // If the cursor moves horizontally when 'concealcursor' is active, then the
-  // current line needs to be redrawn in order to calculate the correct
-  // cursor position.
-  if (curwin->w_p_cole > 0 && conceal_cursor_line(curwin)) {
-    redrawWinline(curwin, curwin->w_cursor.lnum);
-  }
-
   if (VIsual_active) {
     update_curbuf(INVERTED);  // update inverted part
   } else if (must_redraw) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -667,15 +667,11 @@ void conceal_check_cursor_line(void)
 
 /// Whether cursorline is drawn in a special way
 ///
-/// If true, both old and new cursorline will need
-/// to be redrawn when moving cursor within windows.
-/// TODO(bfredl): VIsual_active shouldn't be needed, but is used to fix a glitch
-///               caused by scrolling.
+/// If true, both old and new cursorline will need to be redrawn when moving cursor within windows.
 bool win_cursorline_standout(const win_T *wp)
   FUNC_ATTR_NONNULL_ALL
 {
-  return wp->w_p_cul
-         || (wp->w_p_cole > 0 && (VIsual_active || !conceal_cursor_line(wp)));
+  return wp->w_p_cul || (wp->w_p_cole > 0 && !conceal_cursor_line(wp));
 }
 
 /*

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -3,6 +3,7 @@ local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
 local eq = helpers.eq
 local insert = helpers.insert
+local poke_eventloop = helpers.poke_eventloop
 
 describe('Screen', function()
   local screen
@@ -911,7 +912,57 @@ describe('Screen', function()
       {0:~                                                    }|
                                                            |
     ]]}
-    eq(grid_lines, {{2, 0, {{'c', 0, 3}}}})
+    eq({{2, 0, {{'c', 0, 3}}}}, grid_lines)
+  end)
+
+  it('K_EVENT should not cause extra redraws with concealcursor #13196', function()
+    command('set conceallevel=1')
+    command('set concealcursor=nv')
+    command('set redrawdebug+=nodelta')
+
+    insert([[
+    aaa
+    bbb
+    ccc
+    ]])
+    screen:expect{grid=[[
+      aaa                                                  |
+      bbb                                                  |
+      ccc                                                  |
+      ^                                                     |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+                                                           |
+    ]]}
+
+    -- XXX: hack to get notifications, and check only a single line is
+    --      updated.  Could use next_msg() also.
+    local orig_handle_grid_line = screen._handle_grid_line
+    local grid_lines = {}
+    function screen._handle_grid_line(self, grid, row, col, items)
+      table.insert(grid_lines, {row, col, items})
+      orig_handle_grid_line(self, grid, row, col, items)
+    end
+    feed('k')
+    screen:expect{grid=[[
+      aaa                                                  |
+      bbb                                                  |
+      ^ccc                                                  |
+                                                           |
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
+                                                           |
+    ]]}
+    eq({{2, 0, {{'c', 0, 3}}}}, grid_lines)
+    poke_eventloop()  -- causes K_EVENT key
+    screen:expect_unchanged()
+    eq({{2, 0, {{'c', 0, 3}}}}, grid_lines)
   end)
 
   -- Copy of Test_cursor_column_in_concealed_line_after_window_scroll in


### PR DESCRIPTION
Fix #13196

Building upon #17889, this moves conceal redrawing logic into `move.c`, so that concealed line is only redrawn if cursor has moved horizontally.

Test by sourcing the following file:
```vim
set cole=2 cocu=nv wd=30 rdb=compositor,nodelta
call timer_start(100, { _ -> 0 }, {'repeat': -1})
```
The current line is no longer redrawn every 0.1 second.