### PR TITLE
ci: label changes to Makefiles as build

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,6 +49,7 @@
 "build":
   - CMakeLists.txt
   - "**/CMakeLists.txt"
+  - "**/Makefile"
   - "**/*.cmake"
 
 "test":


### PR DESCRIPTION
Makefiles are used for builds, so why not label changes to these
files as build
I tested if the label was applied here <https://github.com/casswedson/neovim/pull/2>