### PR TITLE
fix(lsp): use "text" filetype for plaintext

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1138,7 +1138,7 @@ function M.stylize_markdown(bufnr, contents, opts)
     block = {nil, "```+([a-zA-Z0-9_]*)", "```+"},
     pre = {"", "<pre>", "</pre>"},
     code = {"", "<code>", "</code>"},
-    text = {"plaintex", "<text>", "</text>"},
+    text = {"text", "<text>", "</text>"},
   }
 
   local match_begin = function(line)


### PR DESCRIPTION
Instead of `plaintex` (the "plain" variant of TeX), use `text` filetype for `"PlainText"`.
See https://github.com/neovim/neovim/pull/14765#issuecomment-1080216482.
cc: @jamessan