### PR TITLE
feat(runtime): add query filetype

### DIFF
--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -1,0 +1,6 @@
+-- Neovim filetype plugin file
+-- Language:	Tree-sitter query
+-- Last Change:	2022 Mar 29
+
+-- it's a lisp!
+vim.cmd [[ runtime! ftplugin/lisp.vim ]]

--- a/runtime/indent/query.lua
+++ b/runtime/indent/query.lua
@@ -1,0 +1,6 @@
+-- Neovim indent file
+-- Language:	Tree-sitter query
+-- Last Change:	2022 Mar 29
+
+-- it's a lisp!
+vim.cmd [[ runtime! indent/lisp.vim ]]

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1424,6 +1424,8 @@ local pattern = {
       return "git"
     end
   end,
+  -- Neovim only
+  [".*/queries/.*%.scm"] = "query", -- tree-sitter queries
   -- END PATTERN
 }
 -- luacheck: pop


### PR DESCRIPTION
used for tree-sitter queries

Since queries are written in a Lisp, just source the corresponding Lisp runtime files.

Note: These are deliberately in Lua (even though they just call `runtime!`) to distinguish them from upstream runtime files.