### PR TITLE
vim-patch:8.2.4646: using buffer line after it has been freed

### DIFF
--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -3130,9 +3130,17 @@ static bool regmatch(
         {
           int mark = OPERAND(scan)[0];
           int cmp = OPERAND(scan)[1];
-          pos_T   *pos;
+          pos_T *pos;
+          size_t col = REG_MULTI ? rex.input - rex.line : 0;
 
           pos = getmark_buf(rex.reg_buf, mark, false);
+
+          // Line may have been freed, get it again.
+          if (REG_MULTI) {
+            rex.line = reg_getline(rex.lnum);
+            rex.input = rex.line + col;
+          }
+
           if (pos == NULL                    // mark doesn't exist
               || pos->lnum <= 0) {           // mark isn't set in reg_buf
             status = RA_NOMATCH;

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -789,9 +789,16 @@ endfunc
 
 func Test_using_mark_position()
   " this was using freed memory
+  " new engine
   new
   norm O0
   call assert_fails("s/\\%')", 'E486:')
+  bwipe!
+
+  " old engine
+  new
+  norm O0
+  call assert_fails("s/\\%#=1\\%')", 'E486:')
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.4646: using buffer line after it has been freed

Problem:    Using buffer line after it has been freed in old regexp engine.
Solution:   After getting mark get the line again.
https://github.com/vim/vim/commit/b55986c52d4cd88a22d0b0b0e8a79547ba13e1d5