### PR TITLE
vim-patch:8.2.4645: 'shortmess' changed when session does not store options

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -589,11 +589,17 @@ static int makeopens(FILE *fd, char_u *dirnow)
               "if expand('%') == '' && !&modified && line('$') <= 1"
               " && getline(1) == ''\n"
               "  let s:wipebuf = bufnr('%')\n"
-              "endif\n"
-              // Now save the current files, current buffer first.
-              "set shortmess=aoO\n") < 0) {
+              "endif\n") < 0) {
     return FAIL;
   }
+
+  // save 'shortmess' if not storing options
+  if ((ssop_flags & SSOP_OPTIONS) == 0) {
+    PUTLINE_FAIL("let s:shortmess_save = &shortmess");
+  }
+
+  // Now save the current files, current buffer first.
+  PUTLINE_FAIL("set shortmess=aoO");
 
   // Put all buffers into the buffer list.
   // Do it very early to preserve buffer order after loading session (which
@@ -842,15 +848,21 @@ static int makeopens(FILE *fd, char_u *dirnow)
     return FAIL;
   }
 
-  // Re-apply 'winheight', 'winwidth' and 'shortmess'.
-  if (fprintf(fd,
-              "set winheight=%" PRId64 " winwidth=%" PRId64
-              " shortmess=%s\n",
-              (int64_t)p_wh,
-              (int64_t)p_wiw,
-              p_shm) < 0) {
+  // Re-apply 'winheight' and 'winwidth'.
+  if (fprintf(fd, "set winheight=%" PRId64 " winwidth=%" PRId64 "\n",
+              (int64_t)p_wh, (int64_t)p_wiw) < 0) {
     return FAIL;
   }
+
+  // Restore 'shortmess'.
+  if (ssop_flags & SSOP_OPTIONS) {
+    if (fprintf(fd, "set shortmess=%s\n", p_shm) < 0) {
+      return FAIL;
+    }
+  } else {
+    PUTLINE_FAIL("let &shortmess = s:shortmess_save");
+  }
+
   if (tab_firstwin != NULL && tab_firstwin->w_next != NULL) {
     // Restore 'winminheight' and 'winminwidth'.
     PUTLINE_FAIL("let &winminheight = s:save_winminheight");

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -795,6 +795,49 @@ func Test_mksession_winminheight()
   set sessionoptions&
 endfunc
 
+" Test for mksession with and without options restores shortmess
+func Test_mksession_shortmess()
+  " Without options
+  set sessionoptions-=options
+  split
+  mksession! Xtest_mks.out
+  let found_save = 0
+  let found_restore = 0
+  let lines = readfile('Xtest_mks.out')
+  for line in lines
+    let line = trim(line)
+
+    if line ==# 'let s:shortmess_save = &shortmess'
+      let found_save += 1
+    endif
+
+    if found_save !=# 0 && line ==# 'let &shortmess = s:shortmess_save'
+      let found_restore += 1
+    endif
+  endfor
+  call assert_equal(1, found_save)
+  call assert_equal(1, found_restore)
+  call delete('Xtest_mks.out')
+  close
+  set sessionoptions&
+
+  " With options
+  set sessionoptions+=options
+  split
+  mksession! Xtest_mks.out
+  let found_restore = 0
+  let lines = readfile('Xtest_mks.out')
+  for line in lines
+    if line =~# 's:shortmess_save'
+      let found_restore += 1
+    endif
+  endfor
+  call assert_equal(0, found_restore)
+  call delete('Xtest_mks.out')
+  close
+  set sessionoptions&
+endfunc
+
 " Test for mksession with 'compatible' option
 func Test_mksession_compatible()
   throw 'skipped: Nvim does not support "compatible" option'


### PR DESCRIPTION
#### vim-patch:8.2.4645: 'shortmess' changed when session does not store options

Problem:    'shortmess' changed when session does not store options.
Solution:   Save and restore 'shortmess' if needed. (James Charti,
            closes vim/vim#10037)
https://github.com/vim/vim/commit/fd01280d01c2270a320d8c962d24140a8176a400