### PR TITLE
vim-patch:8.2.3551: checking first character of url twice

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1777,7 +1777,7 @@ int path_with_url(const char *fname)
   }
 
   // check body: alpha or dash
-  for (p = fname; (isalpha(*p) || (*p == '-')); p++) {}
+  for (p = fname + 1; (isalpha(*p) || (*p == '-')); p++) {}
 
   // check last char is not a dash
   if (p[-1] == '-') {


### PR DESCRIPTION
Problem:    Checking first character of url twice.
Solution:   Only check once. (closes vim/vim#9026)
https://github.com/vim/vim/commit/94e7d345c156a722bb161b73238c4ba1d27ec586
