### PR TITLE
vim-patch:8.2.3306: unexpected "No matching autocommands"

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1139,8 +1139,9 @@ char_u *aucmd_next_pattern(char_u *pat, size_t patlen)
 /// Return OK for success, FAIL for failure;
 ///
 /// @param do_msg  give message for no matching autocmds?
-int do_doautocmd(char_u *arg, bool do_msg, bool *did_something)
+int do_doautocmd(char_u *arg_start, bool do_msg, bool *did_something)
 {
+  char_u *arg = arg_start;
   int nothing_done = true;
 
   if (did_something != NULL) {
@@ -1172,8 +1173,8 @@ int do_doautocmd(char_u *arg, bool do_msg, bool *did_something)
     }
   }
 
-  if (nothing_done && do_msg) {
-    msg(_("No matching autocommands"));
+  if (nothing_done && do_msg && !aborting()) {
+    smsg(_("No matching autocommands: %s"), arg_start);
   }
   if (did_something != NULL) {
     *did_something = !nothing_done;


### PR DESCRIPTION
Problem:    Unexpected "No matching autocommands".
Solution:   Do not give the message when aborting.  Mention the arguments in
            the message.
https://github.com/vim/vim/commit/1b154ea121d8374a129c3e30d50fa9742cd5faa1
