### PR TITLE
vim-patch:8.2.4473: Coverity warns for not checking return value of ftell()

### DIFF
--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5580,6 +5580,9 @@ void spell_add_word(char_u *word, int len, SpellAddType what, int idx, bool undo
       while (!vim_fgets(line, MAXWLEN * 2, fd)) {
         fpos = fpos_next;
         fpos_next = ftell(fd);
+        if (fpos_next < 0) {
+          break;  // should never happen
+        }
         if (STRNCMP(word, line, len) == 0
             && (line[len] == '/' || line[len] < ' ')) {
           // Found duplicate word.  Remove it by writing a '#' at


### PR DESCRIPTION
Problem:    Coverity warns for not checking return value of ftell().
Solution:   Bail out if ftell() returns a negative value.
https://github.com/vim/vim/commit/416b5f4894196947ea87eea2ed4fda3504674f72
