### PR TITLE
vim-patch:8.2.2160: various typos

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3952,7 +3952,7 @@ static void ml_updatechunk(buf_T *buf, linenr_T line, long len, int updtype)
                && curix == buf->b_ml.ml_usedchunks - 1
                && buf->b_ml.ml_line_count - line <= 1) {
       /*
-       * We are in the last chunk and it is cheap to crate a new one
+       * We are in the last chunk and it is cheap to create a new one
        * after this. Do it now to avoid the loop above later on
        */
       curchnk = buf->b_ml.ml_chunksize + curix + 1;

--- a/src/nvim/testdir/test_debugger.vim
+++ b/src/nvim/testdir/test_debugger.vim
@@ -976,7 +976,7 @@ func Test_debug_backtrace_level()
         \ 'line 1: let s:file1_var = ''file1'''
         \ ])
 
-  " step throught the initial declarations
+  " step through the initial declarations
   call RunDbgCmd(buf, 'step', [ 'line 2: let g:global_var = ''global''' ] )
   call RunDbgCmd(buf, 'step', [ 'line 4: func s:File1Func( arg )' ] )
   call RunDbgCmd(buf, 'echo s:file1_var', [ 'file1' ] )

--- a/src/nvim/testdir/test_increment.vim
+++ b/src/nvim/testdir/test_increment.vim
@@ -285,7 +285,7 @@ endfunc
 " 1
 "     1
 "     1
-"     Expexted:
+"     Expected:
 "     1) g Ctrl-A on block selected indented lines
 "     2
 " 1

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -1356,7 +1356,7 @@ func Test_sort_cmd()
     endif
   endfor
 
-  " Needs atleast two lines for this test
+  " Needs at least two lines for this test
   call setline(1, ['line1', 'line2'])
   call assert_fails('sort no', 'E474:')
   call assert_fails('sort c', 'E475:')


### PR DESCRIPTION
Problem:    Various typos.
Solution:   Fix spelling mistakes. (closes vim/vim#7494)
https://github.com/vim/vim/commit/8e7d6223f630690b72b387eaed704bf01f3f29d2
