### PR TITLE
vim-patch:8.2.3910: when compare function of sort() fails it does not abort

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9433,6 +9433,7 @@ static int item_compare2(const void *s1, const void *s2, bool keep_zero)
   typval_T argv[3];
   const char *func_name;
   partial_T *partial = sortinfo->item_compare_partial;
+  int did_emsg_before = did_emsg;
 
   // shortcut after failure in previous call; compare all items equal
   if (sortinfo->item_compare_func_err) {
@@ -9462,7 +9463,7 @@ static int item_compare2(const void *s1, const void *s2, bool keep_zero)
   tv_clear(&argv[0]);
   tv_clear(&argv[1]);
 
-  if (res == FAIL) {
+  if (res == FAIL || did_emsg > did_emsg_before) {
     res = ITEM_COMPARE_FAIL;
   } else {
     res = tv_get_number_chk(&rettv, &sortinfo->item_compare_func_err);


### PR DESCRIPTION
Problem:    When the compare function of sort() produces and error then sort()
            does not abort.
Solution:   Check if did_emsg was incremented.
https://github.com/vim/vim/commit/23018f2d4b6f85512af117d346eee9b14a4637a6
