### PR TITLE
vim-patch:8.2.{4349,4649}

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3893,7 +3893,7 @@ void ex_display(exarg_T *eap)
             msg_puts_attr("^J", attr);
             n -= 2;
           }
-          for (p = yb->y_array[j]; *p && (n -= ptr2cells(p)) >= 0; p++) {  // -V1019
+          for (p = yb->y_array[j]; *p != NUL && (n -= ptr2cells(p)) >= 0; p++) {  // -V1019
             clen = utfc_ptr2len(p);
             msg_outtrans_len(p, clen);
             p += clen - 1;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2780,6 +2780,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit, int
   // present.
   if (qfl_type == QFLT_LOCATION) {
     win_T *wp = win_id2wp(prev_winid);
+
     if (wp == NULL && curwin->w_llist != qi) {
       emsg(_("E924: Current window was closed"));
       *opened_window = false;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6249,8 +6249,10 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start,
       case NFA_MARK_GT:
       case NFA_MARK_LT:
       {
-        size_t col = rex.input - rex.line;
-        pos_T *pos = getmark_buf(rex.reg_buf, t->state->val, false);
+        pos_T *pos;
+        size_t col = REG_MULTI ? rex.input - rex.line : 0;
+
+        pos = getmark_buf(rex.reg_buf, t->state->val, false);
 
         // Line may have been freed, get it again.
         if (REG_MULTI) {

--- a/src/nvim/testdir/test_filechanged.vim
+++ b/src/nvim/testdir/test_filechanged.vim
@@ -142,8 +142,7 @@ endfunc
 func Test_FileChangedShell_edit_dialog()
   throw 'Skipped: requires a UI to be active'
   CheckNotGui
-  " FIXME: why does this not work on MS-Windows?
-  CheckUnix
+  CheckUnix  " Using low level feedkeys() does not work on MS-Windows.
 
   new Xchanged_r
   call setline(1, 'reload this')

--- a/src/nvim/testdir/test_filechanged.vim
+++ b/src/nvim/testdir/test_filechanged.vim
@@ -142,6 +142,8 @@ endfunc
 func Test_FileChangedShell_edit_dialog()
   throw 'Skipped: requires a UI to be active'
   CheckNotGui
+  " FIXME: why does this not work on MS-Windows?
+  CheckUnix
 
   new Xchanged_r
   call setline(1, 'reload this')


### PR DESCRIPTION
#### vim-patch:8.2.4349: FileChangedShell test fails on MS-Windows

Problem:    FileChangedShell test fails on MS-Windows.
Solution:   Skip the test on MS-Windows.
https://github.com/vim/vim/commit/c9e3187d053dcef03d11915b06be0c78ab45bc75


#### vim-patch:8.2.4649: various formatting problems

Problem:    Various formatting problems.
Solution:   Improve the code formatting.
https://github.com/vim/vim/commit/b4ad3b0deac12674a7773311890b48fd39c6807c