### PR TITLE
vim-patch:8.2.2112: running tests may leave some files behind

### DIFF
--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -905,6 +905,7 @@ func Test_altfile()
   call assert_equal('Xtwoalt', bufname('#'))
   only
   bwipe!
+  call delete('Xtest_altfile')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Running tests may leave some files behind.
Solution:   Delete the right files.  Fix a few typos. (Dominique Pellé,
            closes vim/vim#7436
https://github.com/vim/vim/commit/ac665c24c97582a64ae2d151a812eca92c1ff2d6
