### PR TITLE
vim-patch:8.2.{1844,2515,4156,4200,4577}: messages patches

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1486,6 +1486,10 @@ int msg_outtrans_len_attr(const char_u *msgstr, int len, int attr)
   char_u *s;
   int mb_l;
   int c;
+  int save_got_int = got_int;
+
+  // Only quit when got_int was set in here.
+  got_int = false;
 
   // if MSG_HIST flag set, add message to history
   if (attr & MSG_HIST) {
@@ -1503,7 +1507,7 @@ int msg_outtrans_len_attr(const char_u *msgstr, int len, int attr)
    * Go over the string.  Special characters are translated and printed.
    * Normal characters are printed several at a time.
    */
-  while (--len >= 0) {
+  while (--len >= 0 && !got_int) {
     // Don't include composing chars after the end.
     mb_l = utfc_ptr2len_len((char_u *)str, len + 1);
     if (mb_l > 1) {
@@ -1542,10 +1546,12 @@ int msg_outtrans_len_attr(const char_u *msgstr, int len, int attr)
     }
   }
 
-  if (str > plain_start) {
+  if (str > plain_start && !got_int) {
     // Print the printable chars at the end.
     msg_puts_attr_len(plain_start, str - plain_start, attr);
   }
+
+  got_int |= save_got_int;
 
   return retval;
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -382,6 +382,13 @@ void trunc_string(char_u *s, char_u *buf, int room_in, int buflen)
   int i;
   int n;
 
+  if (*s == NUL) {
+    if (buflen > 0) {
+      *buf = NUL;
+    }
+    return;
+  }
+
   if (room_in < 3) {
     room = 0;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -327,10 +327,11 @@ bool msg_attr_keep(const char *s, int attr, bool keep, bool multiline)
   }
   retval = msg_end();
 
-  if (keep && retval && vim_strsize((char_u *)s) < (Rows - cmdline_row - 1)
-      * Columns + sc_col) {
+  if (keep && retval && vim_strsize((char_u *)s) < (Rows - cmdline_row - 1) * Columns + sc_col) {
     set_keep_msg((char *)s, 0);
   }
+
+  need_fileinfo = false;
 
   xfree(buf);
   --entered;
@@ -1355,6 +1356,7 @@ void msg_start(void)
 
   if (!msg_silent) {
     XFREE_CLEAR(keep_msg);              // don't display old message now
+    need_fileinfo = false;
   }
 
   if (need_clr_eos) {
@@ -2026,6 +2028,8 @@ void msg_puts_attr_len(const char *const str, const ptrdiff_t len, int attr)
   if (!msg_use_printf() || (headless_mode && default_grid.chars)) {
     msg_puts_display((const char_u *)str, len, attr, false);
   }
+
+  need_fileinfo = false;
 }
 
 /// Print a formatted message

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -164,6 +164,7 @@ func Test_fileinfo_after_echo()
   " clean up
   call StopVimInTerminal(buf)
   call delete('Xtest_fileinfo_after_echo')
+  call delete('b.txt')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -2,6 +2,9 @@
 
 source check.vim
 source shared.vim
+source term_util.vim
+source view_util.vim
+source screendump.vim
 
 func Test_messages()
   let oldmore = &more
@@ -107,6 +110,22 @@ func Test_echospace()
   call assert_equal(&columns - 29, v:echospace)
 
   set ruler& showcmd&
+endfunc
+
+func Test_quit_long_message()
+  CheckScreendump
+
+  let content =<< trim END
+    echom range(9999)->join("\x01")
+  END
+  call writefile(content, 'Xtest_quit_message')
+  let buf = RunVimInTerminal('-S Xtest_quit_message', #{rows: 6})
+  call term_sendkeys(buf, "q")
+  call VerifyScreenDump(buf, 'Test_quit_long_message', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_quit_message')
 endfunc
 
 " this was missing a terminating NUL

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -135,3 +135,35 @@ func Test_echo_string_partial()
   call assert_equal("function('CountSpaces', [{'ccccccccccc': ['ab', 'cd'], 'aaaaaaaaaaa': v:false, 'bbbbbbbbbbbb': ''}])", string(function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])))
 endfunc
 
+" Message output was previously overwritten by the fileinfo display, shown
+" when switching buffers. If a buffer is switched to, then a message if
+" echoed, we should show the message, rather than overwriting it with
+" fileinfo.
+func Test_fileinfo_after_echo()
+  CheckScreendump
+
+  let content =<< trim END
+    file a.txt
+
+    hide edit b.txt
+    call setline(1, "hi")
+    setlocal modified
+
+    hide buffer a.txt
+
+    set updatetime=1
+    autocmd CursorHold * b b.txt | w | echo "'b' written"
+  END
+
+  call writefile(content, 'Xtest_fileinfo_after_echo')
+  let buf = RunVimInTerminal('-S Xtest_fileinfo_after_echo', #{rows: 6})
+  call VerifyScreenDump(buf, 'Test_fileinfo_after_echo', {})
+
+  call term_sendkeys(buf, ":q\<CR>")
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_fileinfo_after_echo')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -151,12 +151,13 @@ func Test_fileinfo_after_echo()
 
     hide buffer a.txt
 
-    set updatetime=1
-    autocmd CursorHold * b b.txt | w | echo "'b' written"
+    autocmd CursorHold * buf b.txt | w | echo "'b' written"
   END
 
   call writefile(content, 'Xtest_fileinfo_after_echo')
   let buf = RunVimInTerminal('-S Xtest_fileinfo_after_echo', #{rows: 6})
+  call term_sendkeys(buf, ":set updatetime=50\<CR>")
+  call term_sendkeys(buf, "0$")
   call VerifyScreenDump(buf, 'Test_fileinfo_after_echo', {})
 
   call term_sendkeys(buf, ":q\<CR>")

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local command = helpers.command
+local exec = helpers.exec
 local feed = helpers.feed
 
 before_each(clear)
@@ -33,6 +34,36 @@ describe('messages', function()
       {3:~                                       }|
       {3:~                                       }|
                                               |
+    ]])
+  end)
+
+  it('fileinfo does not overwrite echo message vim-patch:8.2.4156', function()
+    local screen = Screen.new(40, 6)
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      set shortmess-=F
+
+      file a.txt
+
+      hide edit b.txt
+      call setline(1, "hi")
+      setlocal modified
+
+      hide buffer a.txt
+
+      set updatetime=1
+      autocmd CursorHold * b b.txt | w | echo "'b' written"
+    ]])
+    screen:expect([[
+      ^hi                                      |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      'b' written                             |
     ]])
   end)
 end)

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -54,9 +54,10 @@ describe('messages', function()
 
       hide buffer a.txt
 
-      set updatetime=1
-      autocmd CursorHold * b b.txt | w | echo "'b' written"
+      autocmd CursorHold * buf b.txt | w | echo "'b' written"
     ]])
+    command('set updatetime=50')
+    feed('0$')
     screen:expect([[
       ^hi                                      |
       {1:~                                       }|

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -1,0 +1,38 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local command = helpers.command
+local feed = helpers.feed
+
+before_each(clear)
+
+describe('messages', function()
+  it('more prompt with control characters can be quit vim-patch:8.2.1844', function()
+    local screen = Screen.new(40, 6)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Blue},  -- SpecialKey
+      [2] = {bold = true, foreground = Screen.colors.SeaGreen},  -- MoreMsg
+      [3] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+    command('set more')
+    feed([[:echom range(9999)->join("\x01")<CR>]])
+    screen:expect([[
+      0{1:^A}1{1:^A}2{1:^A}3{1:^A}4{1:^A}5{1:^A}6{1:^A}7{1:^A}8{1:^A}9{1:^A}10{1:^A}11{1:^A}12|
+      {1:^A}13{1:^A}14{1:^A}15{1:^A}16{1:^A}17{1:^A}18{1:^A}19{1:^A}20{1:^A}21{1:^A}22|
+      {1:^A}23{1:^A}24{1:^A}25{1:^A}26{1:^A}27{1:^A}28{1:^A}29{1:^A}30{1:^A}31{1:^A}32|
+      {1:^A}33{1:^A}34{1:^A}35{1:^A}36{1:^A}37{1:^A}38{1:^A}39{1:^A}40{1:^A}41{1:^A}42|
+      {1:^A}43{1:^A}44{1:^A}45{1:^A}46{1:^A}47{1:^A}48{1:^A}49{1:^A}50{1:^A}51{1:^A}52|
+      {2:-- More --}^                              |
+    ]])
+    feed('q')
+    screen:expect([[
+      ^                                        |
+      {3:~                                       }|
+      {3:~                                       }|
+      {3:~                                       }|
+      {3:~                                       }|
+                                              |
+    ]])
+  end)
+end)

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -65,5 +65,6 @@ describe('messages', function()
       {1:~                                       }|
       'b' written                             |
     ]])
+    os.remove('b.txt')
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.1844: using "q" at the more prompt doesn't stop a long message

Problem:    Using "q" at the more prompt doesn't stop a long message.
Solution:   Check for "got_int".
https://github.com/vim/vim/commit/3d30af8783bf43fbfece641ec81ad8d2f01b3735

Cherry-pick file name change from patch 8.2.2112.


#### vim-patch:8.2.2515: memory access error when truncating an empty message

Problem:    Memory access error when truncating an empty message.
Solution:   Check for an empty string. (Dominique Pellé, closes vim/vim#7841)
https://github.com/vim/vim/commit/6281815eccc3ded54960f7798833ceb39561b9a0


#### vim-patch:8.2.4156: fileinfo message overwrites echo'ed message

Problem:    Fileinfo message overwrites echo'ed message.
Solution:   Reset need_fileinfo when displaying a message. (Rob Pilling,
            closes vim/vim#9569)
https://github.com/vim/vim/commit/726f7f91fd17e3e7eb39614a20d10ea83c134df0


#### vim-patch:8.2.4200: some tests do not clean up properly

Problem:    Some tests do not clean up properly.
Solution:   Delete created files. (Yegappan Lakshmanan, closes vim/vim#9611)
https://github.com/vim/vim/commit/7e765a39b795d5331bf2d4927b41df7b78915af9

Omit test_filetype.vim: already ported
Omit test_vim9_import.vim: N/A


#### vim-patch:8.2.4577: message test is flaky

Problem:    Message test is flaky. (Elimar Riesebieter)
Solution:   Trigger the autocommand event only after startup is finished.
https://github.com/vim/vim/commit/9323ca51c2b1522f26907a7b8879067245ebd1be