### PR TITLE
fix: correct vertical dragging room calculation with global statusline

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5857,11 +5857,11 @@ void win_drag_status_line(win_T *dragwin, int offset)
   } else {  // drag down
     up = false;
     // Only dragging the last status line can reduce p_ch.
-    room = Rows - cmdline_row - global_stl_height();
+    room = Rows - cmdline_row;
     if (curfr->fr_next == NULL) {
       room -= 1;
     } else {
-      room -= p_ch;
+      room -= p_ch + global_stl_height();
     }
     if (room < 0) {
       room = 0;

--- a/test/functional/ui/global_statusline_spec.lua
+++ b/test/functional/ui/global_statusline_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, command, feed = helpers.clear, helpers.command, helpers.feed
+local eq, funcs, meths = helpers.eq, helpers.funcs, helpers.meths
 
 describe('global statusline', function()
   local screen
@@ -229,5 +230,31 @@ describe('global statusline', function()
       [2] = {foreground = Screen.colors.Blue, bold = true};
       [3] = {reverse = true, bold = true};
     }}
+  end)
+
+  it('win_move_statusline() can reduce cmdheight to 1', function()
+    eq(1, meths.get_option('cmdheight'))
+    funcs.win_move_statusline(0, -1)
+    eq(2, meths.get_option('cmdheight'))
+    funcs.win_move_statusline(0, -1)
+    eq(3, meths.get_option('cmdheight'))
+    funcs.win_move_statusline(0, 1)
+    eq(2, meths.get_option('cmdheight'))
+    funcs.win_move_statusline(0, 1)
+    eq(1, meths.get_option('cmdheight'))
+  end)
+
+  it('mouse dragging can reduce cmdheight to 1', function()
+    command('set mouse=a')
+    meths.input_mouse('left', 'press', '', 0, 14, 10)
+    eq(1, meths.get_option('cmdheight'))
+    meths.input_mouse('left', 'drag', '', 0, 13, 10)
+    eq(2, meths.get_option('cmdheight'))
+    meths.input_mouse('left', 'drag', '', 0, 12, 10)
+    eq(3, meths.get_option('cmdheight'))
+    meths.input_mouse('left', 'drag', '', 0, 13, 10)
+    eq(2, meths.get_option('cmdheight'))
+    meths.input_mouse('left', 'drag', '', 0, 14, 10)
+    eq(1, meths.get_option('cmdheight'))
   end)
 end)


### PR DESCRIPTION
This fixes the bug that win_move_statusline() or mouse dragging cannot
reduce 'cmdheight' to 1 when global statusline is used.
