### PR TITLE
refactor(api)!: use singular/plural consistently in the autocmd API

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3151,7 +3151,7 @@ nvim_tabpage_set_var({tabpage}, {name}, {value})
 ==============================================================================
 Autocmd Functions                                                *api-autocmd*
 
-nvim_clear_autocmd({*opts})                             *nvim_clear_autocmd()*
+nvim_clear_autocmds({*opts})                           *nvim_clear_autocmds()*
                 Clear all autocommands that match the corresponding {opts}. To
                 delete a particular autocmd, see |nvim_del_autocmd|.
 
@@ -3310,8 +3310,9 @@ nvim_del_autocmd({id})                                    *nvim_del_autocmd()*
                 See also: ~
                     |nvim_create_autocmd()|
 
-nvim_exec_autocmd({event}, {*opts})                      *nvim_exec_autocmd()*
-                Execute an autocommand |autocmd-execute|.
+nvim_exec_autocmds({event}, {*opts})                    *nvim_exec_autocmds()*
+                Execute all autocommands for {event} that match the
+                corresponding {opts} |autocmd-execute|.
 
                 Parameters: ~
                     {event}  (String|Array) The event or events to execute
@@ -3333,7 +3334,7 @@ nvim_exec_autocmd({event}, {*opts})                      *nvim_exec_autocmd()*
                     |:doautocmd|
 
 nvim_get_autocmds({*opts})                               *nvim_get_autocmds()*
-                Get autocommands that match the requirements passed to {opts}.
+                Get all autocommands that match the corresponding {opts}.
 
                 These examples will get autocommands matching ALL the given
                 criteria: >

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -36,7 +36,7 @@
 // Used to delete autocmds from nvim_del_autocmd
 static int64_t next_autocmd_id = 1;
 
-/// Get autocommands that match the requirements passed to {opts}.
+/// Get all autocommands that match the corresponding {opts}.
 ///
 /// These examples will get autocommands matching ALL the given criteria:
 /// <pre>
@@ -562,7 +562,7 @@ void nvim_del_autocmd(Integer id)
 ///         - group: (string|int) The augroup name or id.
 ///             - NOTE: If not passed, will only delete autocmds *not* in any group.
 ///
-void nvim_clear_autocmd(Dict(clear_autocmd) *opts, Error *err)
+void nvim_clear_autocmds(Dict(clear_autocmds) *opts, Error *err)
   FUNC_API_SINCE(9)
 {
   // TODO(tjdevries): Future improvements:
@@ -697,7 +697,8 @@ void nvim_del_augroup_by_name(String name)
   augroup_del(name.data, false);
 }
 
-/// Execute an autocommand |autocmd-execute|.
+/// Execute all autocommands for {event} that match the corresponding
+///  {opts} |autocmd-execute|.
 /// @param event (String|Array) The event or events to execute
 /// @param opts Dictionary of autocommand options:
 ///             - group (string|integer) optional: the autocommand group name or
@@ -709,7 +710,7 @@ void nvim_del_augroup_by_name(String name)
 ///             - modeline (bool) optional: defaults to true. Process the
 ///             modeline after the autocommands |<nomodeline>|.
 /// @see |:doautocmd|
-void nvim_exec_autocmd(Object event, Dict(exec_autocmd) *opts, Error *err)
+void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   FUNC_API_SINCE(9)
 {
   int au_group = AUGROUP_ALL;

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -123,7 +123,7 @@ return {
     "nocombine";
   };
   -- Autocmds
-  clear_autocmd = {
+  clear_autocmds = {
     "buffer";
     "event";
     "group";
@@ -139,7 +139,7 @@ return {
     "once";
     "pattern";
   };
-  exec_autocmd = {
+  exec_autocmds = {
     "buffer";
     "group";
     "modeline";

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -168,7 +168,7 @@ describe('autocmd api', function()
       })
       ]]
 
-      meths.exec_autocmd("User", {pattern = "Test"})
+      meths.exec_autocmds("User", {pattern = "Test"})
       eq({{
         buflocal = false,
         command = 'A test autocommand',
@@ -179,7 +179,7 @@ describe('autocmd api', function()
         pattern = 'Test',
       }}, meths.get_autocmds({event = "User", pattern = "Test"}))
       meths.set_var("some_condition", true)
-      meths.exec_autocmd("User", {pattern = "Test"})
+      meths.exec_autocmds("User", {pattern = "Test"})
       eq({}, meths.get_autocmds({event = "User", pattern = "Test"}))
     end)
   end)
@@ -517,7 +517,7 @@ describe('autocmd api', function()
     end)
   end)
 
-  describe('nvim_exec_autocmd', function()
+  describe('nvim_exec_autocmds', function()
     it("can trigger builtin autocmds", function()
       meths.set_var("autocmd_executed", false)
 
@@ -527,7 +527,7 @@ describe('autocmd api', function()
       })
 
       eq(false, meths.get_var("autocmd_executed"))
-      meths.exec_autocmd("BufReadPost", {})
+      meths.exec_autocmds("BufReadPost", {})
       eq(true, meths.get_var("autocmd_executed"))
     end)
 
@@ -541,10 +541,10 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      meths.exec_autocmd("CursorHold", { buffer = 1 })
+      meths.exec_autocmds("CursorHold", { buffer = 1 })
       eq(-1, meths.get_var("buffer_executed"))
 
-      meths.exec_autocmd("BufLeave", { buffer = 1 })
+      meths.exec_autocmds("BufLeave", { buffer = 1 })
       eq(1, meths.get_var("buffer_executed"))
     end)
 
@@ -558,7 +558,7 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      meths.exec_autocmd("CursorHold", { buffer = 1 })
+      meths.exec_autocmds("CursorHold", { buffer = 1 })
       eq('none', meths.get_var("filename_executed"))
 
       meths.command('edit __init__.py')
@@ -566,7 +566,7 @@ describe('autocmd api', function()
     end)
 
     it('cannot pass buf and fname', function()
-      local ok = pcall(meths.exec_autocmd, "BufReadPre", { pattern = "literally_cannot_error.rs", buffer = 1 })
+      local ok = pcall(meths.exec_autocmds, "BufReadPre", { pattern = "literally_cannot_error.rs", buffer = 1 })
       eq(false, ok)
     end)
 
@@ -584,16 +584,16 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      meths.exec_autocmd("CursorHoldI", { buffer = 1 })
+      meths.exec_autocmds("CursorHoldI", { buffer = 1 })
       eq('none', meths.get_var("filename_executed"))
 
-      meths.exec_autocmd("CursorHoldI", { buffer = tonumber(meths.get_current_buf()) })
+      meths.exec_autocmds("CursorHoldI", { buffer = tonumber(meths.get_current_buf()) })
       eq('__init__.py', meths.get_var("filename_executed"))
 
       -- Reset filename
       meths.set_var("filename_executed", 'none')
 
-      meths.exec_autocmd("CursorHoldI", { pattern = '__init__.py' })
+      meths.exec_autocmds("CursorHoldI", { pattern = '__init__.py' })
       eq('__init__.py', meths.get_var("filename_executed"))
     end)
 
@@ -605,9 +605,9 @@ describe('autocmd api', function()
         command = 'let g:matched = "matched"'
       })
 
-      meths.exec_autocmd("User", { pattern = "OtherCommand" })
+      meths.exec_autocmds("User", { pattern = "OtherCommand" })
       eq('none', meths.get_var('matched'))
-      meths.exec_autocmd("User", { pattern = "TestCommand" })
+      meths.exec_autocmds("User", { pattern = "TestCommand" })
       eq('matched', meths.get_var('matched'))
     end)
 
@@ -621,7 +621,7 @@ describe('autocmd api', function()
       })
 
       eq(false, meths.get_var("group_executed"))
-      meths.exec_autocmd("FileType", { group = auid })
+      meths.exec_autocmds("FileType", { group = auid })
       eq(true, meths.get_var("group_executed"))
     end)
 
@@ -636,7 +636,7 @@ describe('autocmd api', function()
       })
 
       eq(false, meths.get_var("group_executed"))
-      meths.exec_autocmd("FileType", { group = auname })
+      meths.exec_autocmds("FileType", { group = auname })
       eq(true, meths.get_var("group_executed"))
     end)
   end)
@@ -973,7 +973,7 @@ describe('autocmd api', function()
     end)
   end)
 
-  describe('nvim_clear_autocmd', function()
+  describe('nvim_clear_autocmds', function()
     it('should clear based on event + pattern', function()
       command('autocmd InsertEnter *.py  :echo "Python can be cool sometimes"')
       command('autocmd InsertEnter *.txt :echo "Text Files Are Cool"')
@@ -985,7 +985,7 @@ describe('autocmd api', function()
       local before_delete_all = meths.get_autocmds { event = search.event }
       eq(2, #before_delete_all)
 
-      meths.clear_autocmd(search)
+      meths.clear_autocmds(search)
       local after_delete = meths.get_autocmds(search)
       eq(0, #after_delete)
 
@@ -1001,7 +1001,7 @@ describe('autocmd api', function()
       local before_delete = meths.get_autocmds(search)
       eq(2, #before_delete)
 
-      meths.clear_autocmd(search)
+      meths.clear_autocmds(search)
       local after_delete = meths.get_autocmds(search)
       eq(0, #after_delete)
     end)
@@ -1018,7 +1018,7 @@ describe('autocmd api', function()
       local before_delete_events = meths.get_autocmds { event = { "InsertEnter", "InsertLeave" } }
       eq(4, #before_delete_events)
 
-      meths.clear_autocmd(search)
+      meths.clear_autocmds(search)
       local after_delete = meths.get_autocmds(search)
       eq(0, #after_delete)
 
@@ -1035,7 +1035,7 @@ describe('autocmd api', function()
       local before_delete = meths.get_autocmds(search)
       eq(2, #before_delete)
 
-      meths.clear_autocmd { buffer = 0 }
+      meths.clear_autocmds { buffer = 0 }
       local after_delete = meths.get_autocmds(search)
       eq(1, #after_delete)
       eq("*.TestPat1", after_delete[1].pattern)
@@ -1053,12 +1053,12 @@ describe('autocmd api', function()
       eq(2, #before_delete)
 
       -- Doesn't clear without passing group.
-      meths.clear_autocmd { buffer = 0 }
+      meths.clear_autocmds { buffer = 0 }
       local without_group = meths.get_autocmds(search)
       eq(2, #without_group)
 
       -- Doest clear with passing group.
-      meths.clear_autocmd { buffer = 0, group = search.group }
+      meths.clear_autocmds { buffer = 0, group = search.group }
       local with_group = meths.get_autocmds(search)
       eq(1, #with_group)
     end)


### PR DESCRIPTION
Follow-up to https://github.com/neovim/neovim/pull/17854#issuecomment-1081823407.