### PR TITLE
vim-patch:8.2.2797: Search highlight disappears in the Visual area

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2993,6 +2993,10 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
 
       if (area_attr != 0) {
         char_attr = hl_combine_attr(line_attr, area_attr);
+        if (!highlight_match) {
+          // let search highlight show in Visual area if possible
+          char_attr = hl_combine_attr(search_attr, char_attr);
+        }
       } else if (search_attr != 0) {
         char_attr = hl_combine_attr(line_attr, search_attr);
       }

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -925,6 +925,26 @@ func Test_hlsearch_block_visual_match()
   call delete('Xhlsearch_block')
 endfunc
 
+func Test_hlsearch_and_visual()
+  CheckOption hlsearch
+  CheckScreendump
+
+  call writefile([
+	\ 'set hlsearch',
+        \ 'call setline(1, repeat(["xxx yyy zzz"], 3))',
+        \ 'hi Search cterm=bold',
+	\ '/yyy',
+	\ 'call cursor(1, 6)',
+	\ ], 'Xhlvisual_script')
+  let buf = RunVimInTerminal('-S Xhlvisual_script', {'rows': 6, 'cols': 40})
+  call term_sendkeys(buf, "vjj")
+  call VerifyScreenDump(buf, 'Test_hlsearch_visual_1', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+  call delete('Xhlvisual_script')
+endfunc
+
 func Test_incsearch_substitute()
   CheckFunction test_override
   CheckOption incsearch


### PR DESCRIPTION
#### vim-patch:8.2.2797: Search highlight disappears in the Visual area

Problem:    Search highlight disappears in the Visual area.
Solution:   Combine the search attributes.
https://github.com/vim/vim/commit/2d5f385cee3668c44089edcb9d60b0b5d751ee5d