### PR TITLE
vim-patch:8.2.{3471,3472,3489}: fix some crashes/errors with search

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4027,8 +4027,9 @@ static linenr_T get_address(exarg_T *eap, char_u **ptr, cmd_addr_T addr_type, in
 
         // When '/' or '?' follows another address, start from
         // there.
-        if (lnum != MAXLNUM) {
-          curwin->w_cursor.lnum = lnum;
+        if (lnum > 0 && lnum != MAXLNUM) {
+          curwin->w_cursor.lnum
+            = lnum > curbuf->b_ml.ml_line_count ? curbuf->b_ml.ml_line_count : lnum;
         }
 
         // Start a forward search at the end of the line (unless

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1606,6 +1606,10 @@ static int may_do_command_line_next_incsearch(int firstc, long count, incsearch_
 
   if (search_delim == ccline.cmdbuff[skiplen]) {
     pat = last_search_pattern();
+    if (pat == NULL) {
+      restore_last_search_pattern();
+      return FAIL;
+    }
     skiplen = 0;
     patlen = (int)STRLEN(pat);
   } else {

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1527,4 +1527,14 @@ func Test_incsearch_highlighting_newline()
   bw
 endfunc
 
+func Test_no_last_search_pattern()
+  CheckOption incsearch
+
+  let @/ = ""
+  set incsearch
+  " this was causing a crash
+  call feedkeys("//\x14", 'xt')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1539,5 +1539,19 @@ func Test_no_last_search_pattern()
   call feedkeys("??\<C-T>", 'xt')
 endfunc
 
+func Test_search_with_invalid_range()
+  new
+  let lines =<< trim END
+    /\%.v
+    5/
+    c
+  END
+  call writefile(lines, 'Xrangesearch')
+  source Xrangesearch
+
+  bwipe!
+  call delete('Xrangesearch')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1532,8 +1532,11 @@ func Test_no_last_search_pattern()
 
   let @/ = ""
   set incsearch
-  " this was causing a crash
-  call feedkeys("//\x14", 'xt')
+  " these were causing a crash
+  call feedkeys("//\<C-G>", 'xt')
+  call feedkeys("//\<C-T>", 'xt')
+  call feedkeys("??\<C-G>", 'xt')
+  call feedkeys("??\<C-T>", 'xt')
 endfunc
 
 


### PR DESCRIPTION
#### vim-patch:8.2.3471: crash when using CTRL-T after an empty search pattern

Problem:    Crash when using CTRL-T after an empty search pattern.
Solution:   Bail out when there is no previous search pattern.
https://github.com/vim/vim/commit/d8d957de86f218de9124ca1209548f8c6f61b69b


#### vim-patch:8.2.3472: other crashes with empty search pattern not tested

Problem:    Other crashes with empty search pattern not tested.
Solution:   Add a few more test lines. (Dominique Pellé)
https://github.com/vim/vim/commit/9af9fd6ab637ea507dd9015fa5a84a408c36c1e0


#### vim-patch:8.2.3489: ml_get error after search with range

Problem:    ml_get error after search with range.
Solution:   Limit the line number to the buffer line count.
https://github.com/vim/vim/commit/35a319b77f897744eec1155b736e9372c9c5575f