### PR TITLE
vim-patch:8.2.{4029,4093,4100,4501,4882}: breakindent patches

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1059,14 +1059,20 @@ A jump table for the options with a short description can be found at |Q_op|.
 			    characters.  It permits dynamic French paragraph
 			    indentation (negative) or emphasizing the line
 			    continuation (positive).
+			    (default: 0)
 		sbr	    Display the 'showbreak' value before applying the
 			    additional indent.
+			    (default: off)
 		list:{n}    Adds an additional indent for lines that match a
 			    numbered or bulleted list (using the
 			    'formatlistpat' setting).
 		list:-1	    Uses the length of a match with 'formatlistpat'
 			    for indentation.
-	The default value for min is 20, shift and list is 0.
+			    (default: 0)
+		column:{n}  Indent at column {n}. Will overrule the other
+			    sub-options. Note: an additional indent may be
+			    added for the 'showbreak' setting.
+			    (default: off)
 
 						*'browsedir'* *'bsdir'*
 'browsedir' 'bsdir'	string	(default: "last")

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1053,6 +1053,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			    text should normally be narrower. This prevents
 			    text indented almost to the right window border
 			    occupying lot of vertical space when broken.
+			    (default: 20)
 		shift:{n}   After applying 'breakindent', the wrapped line's
 			    beginning will be shifted by the given number of
 			    characters.  It permits dynamic French paragraph

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -963,7 +963,8 @@ struct frame_S {
                             // for first
   // fr_child and fr_win are mutually exclusive
   frame_T *fr_child;        // first contained frame
-  win_T *fr_win;          // window that fills this frame
+  win_T *fr_win;        // window that fills this frame; for a snapshot
+                        // set to the current window
 };
 
 #define FR_LEAF 0       // frame is a leaf
@@ -1340,6 +1341,7 @@ struct window_S {
   int w_briopt_shift;               // additional shift for breakindent
   bool w_briopt_sbr;                // sbr in 'briopt'
   int w_briopt_list;                // additional indent for lists
+  int w_briopt_vcol;                // indent for specific column
 
   // transform a pointer to a "onebuf" option into a "allbuf" option
 #define GLOBAL_WO(p)    ((char *)(p) + sizeof(winopt_T))

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5225,7 +5225,6 @@ unsigned int get_bkc_value(buf_T *buf)
 /// @param buf The buffer.
 char *get_flp_value(buf_T *buf)
 {
-  return buf->b_p_flp ? buf->b_p_flp : p_flp;
   if (buf->b_p_flp == NULL || *buf->b_p_flp == NUL) {
     return p_flp;
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5220,6 +5220,18 @@ unsigned int get_bkc_value(buf_T *buf)
   return buf->b_bkc_flags ? buf->b_bkc_flags : bkc_flags;
 }
 
+/// Get the local or global value of 'formatlistpat'.
+///
+/// @param buf The buffer.
+char *get_flp_value(buf_T *buf)
+{
+  return buf->b_p_flp ? buf->b_p_flp : p_flp;
+  if (buf->b_p_flp == NULL || *buf->b_p_flp == NUL) {
+    return p_flp;
+  }
+  return buf->b_p_flp;
+}
+
 /// Get the local or global value of the 'virtualedit' flags.
 unsigned int get_ve_flags(void)
 {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -697,6 +697,10 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     if (briopt_check(curwin) == FAIL) {
       errmsg = e_invarg;
     }
+    // list setting requires a redraw
+    if (curwin->w_briopt_list) {
+      redraw_all_later(UPD_NOT_VALID);
+    }
   } else if (varp == &p_isi
              || varp == &(curbuf->b_p_isk)
              || varp == &p_isp
@@ -1599,6 +1603,12 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
 
   if (varp == &p_mouse) {
     setmouse();  // in case 'mouse' changed
+  }
+
+  // Changing Formatlistpattern when briopt includes the list setting:
+  // redraw
+  if ((varp == &p_flp || varp == &(curbuf->b_p_flp)) && curwin->w_briopt_list) {
+    redraw_all_later(UPD_NOT_VALID);
   }
 
   if (curwin->w_curswant != MAXCOL

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -444,9 +444,9 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
   // May have to add something for 'breakindent' and/or 'showbreak'
   // string at start of line.
   // Set *headp to the size of what we add.
+  // Do not use 'showbreak' at the NUL after the text.
   added = 0;
-
-  char *const sbr = (char *)get_showbreak_value(wp);
+  char *const sbr = c == NUL ? empty_option : (char *)get_showbreak_value(wp);
   if ((*sbr != NUL || wp->w_p_bri) && wp->w_p_wrap && vcol != 0) {
     colnr_T sbrlen = 0;
     int numberwidth = win_col_off(wp);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3370,8 +3370,8 @@ static void nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
     int last = indent->ga_len - 3;
     char_u save[2];
 
-    STRNCPY(save, &p[last], 2);
-    STRNCPY(&p[last], "+-", 2);
+    STRNCPY(save, &p[last], 2);  // NOLINT(runtime/printf)
+    memcpy(&p[last], "+-", 2);
     fprintf(debugf, " %s", p);
     STRNCPY(&p[last], save, 2);  // NOLINT(runtime/printf)
   } else {
@@ -4635,6 +4635,20 @@ static bool sub_equal(regsub_T *sub1, regsub_T *sub2)
 }
 
 #ifdef REGEXP_DEBUG
+static void open_debug_log(TriState result)
+{
+  log_fd = fopen(NFA_REGEXP_RUN_LOG, "a");
+  if (log_fd == NULL) {
+    emsg(_(e_log_open_failed));
+    log_fd = stderr;
+  }
+
+  fprintf(log_fd, "****************************\n");
+  fprintf(log_fd, "FINISHED RUNNING nfa_regmatch() recursively\n");
+  fprintf(log_fd, "MATCH = %s\n", result == kTrue ? "OK" : result == kNone ? "MAYBE" : "FALSE");
+  fprintf(log_fd, "****************************\n");
+}
+
 static void report_state(char *action, regsub_T *sub, nfa_state_T *state, int lid, nfa_pim_T *pim)
 {
   int col;
@@ -4647,6 +4661,9 @@ static void report_state(char *action, regsub_T *sub, nfa_state_T *state, int li
     col = (int)(sub->list.line[0].start - rex.line);
   }
   nfa_set_code(state->c);
+  if (log_fd == NULL) {
+    open_debug_log(kNone);
+  }
   fprintf(log_fd, "> %s state %d to list %d. char %d: %s (start col %d)%s\n",
           action, abs(state->id), lid, state->c, code, col,
           pim_info(pim));
@@ -5668,16 +5685,7 @@ static int recursive_regmatch(nfa_state_T *state, nfa_pim_T *pim, nfa_regprog_T 
   nfa_endp = save_nfa_endp;
 
 #ifdef REGEXP_DEBUG
-  log_fd = fopen(NFA_REGEXP_RUN_LOG, "a");
-  if (log_fd != NULL) {
-    fprintf(log_fd, "****************************\n");
-    fprintf(log_fd, "FINISHED RUNNING nfa_regmatch() recursively\n");
-    fprintf(log_fd, "MATCH = %s\n", !result ? "false" : "OK");
-    fprintf(log_fd, "****************************\n");
-  } else {
-    emsg(_(e_log_open_failed));
-    log_fd = stderr;
-  }
+  open_debug_log(result);
 #endif
 
   return result;
@@ -5983,16 +5991,15 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
 
 #ifdef REGEXP_DEBUG
   log_fd = fopen(NFA_REGEXP_RUN_LOG, "a");
-  if (log_fd != NULL) {
-    fprintf(log_fd, "**********************************\n");
-    nfa_set_code(start->c);
-    fprintf(log_fd, " RUNNING nfa_regmatch() starting with state %d, code %s\n",
-            abs(start->id), code);
-    fprintf(log_fd, "**********************************\n");
-  } else {
+  if (log_fd == NULL) {
     emsg(_(e_log_open_failed));
     log_fd = stderr;
   }
+  fprintf(log_fd, "**********************************\n");
+  nfa_set_code(start->c);
+  fprintf(log_fd, " RUNNING nfa_regmatch() starting with state %d, code %s\n",
+          abs(start->id), code);
+  fprintf(log_fd, "**********************************\n");
 #endif
 
   thislist = &list[0];

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -930,7 +930,22 @@ func Test_no_extra_indent()
   \ "~                   ",
   \ ]
   let lines = s:screen_lines2(1, 4, 20)
-  " 3) add something in front, no additional indent
+  " 3) no local formatlist pattern,
+  " so use global one -> indent
+  let g_flp = &g:flp
+  let &g:formatlistpat='^\s*\d\+\.\s\+'
+  let &l:formatlistpat=''
+  let expect = [
+  \ "  1. word word word ",
+  \ "     word word word ",
+  \ "     word word      ",
+  \ "~                   ",
+  \ ]
+  let lines = s:screen_lines2(1, 4, 20)
+  call s:compare_lines(expect, lines)
+  let &g:flp = g_flp
+  let &l:formatlistpat='^\s*\d\+\.'
+  " 4) add something in front, no additional indent
   norm! gg0
   exe ":norm! 5iword \<esc>"
   redraw!

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -8,6 +8,7 @@ source check.vim
 CheckOption breakindent
 
 source view_util.vim
+source screendump.vim
 
 let s:input ="\tabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP"
 
@@ -887,6 +888,27 @@ func Test_window_resize_with_linebreak()
   redraw!
   call assert_equal(["    >>aaa^@\"a:"], ScreenLines(2, 14))
   %bw!
+endfunc
+
+func Test_cursor_position_with_showbreak()
+  CheckScreendump
+
+  let lines =<< trim END
+      vim9script
+      &signcolumn = 'yes'
+      &showbreak = '+ '
+      var leftcol: number = win_getid()->getwininfo()->get(0, {})->get('textoff')
+      repeat('x', &columns - leftcol - 1)->setline(1)
+      'second line'->setline(2)
+  END
+  call writefile(lines, 'XscriptShowbreak')
+  let buf = RunVimInTerminal('-S XscriptShowbreak', #{rows: 6})
+
+  call term_sendkeys(buf, "AX")
+  call VerifyScreenDump(buf, 'Test_cursor_position_with_showbreak', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XscriptShowbreak')
 endfunc
 
 func Test_no_spurious_match()

--- a/test/functional/legacy/breakindent_spec.lua
+++ b/test/functional/legacy/breakindent_spec.lua
@@ -1,0 +1,44 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local exec = helpers.exec
+local feed = helpers.feed
+
+before_each(clear)
+
+describe('breakindent', function()
+  -- oldtest: Test_cursor_position_with_showbreak()
+  it('cursor shown at correct position with showbreak', function()
+    local screen = Screen.new(75, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Grey, foreground = Screen.colors.DarkBlue},  -- SignColumn
+      [2] = {bold = true},  -- ModeMsg
+    })
+    screen:attach()
+    exec([[
+      let &signcolumn = 'yes'
+      let &showbreak = '+'
+      let leftcol = win_getid()->getwininfo()->get(0, {})->get('textoff')
+      eval repeat('x', &columns - leftcol - 1)->setline(1)
+      eval 'second line'->setline(2)
+    ]])
+    screen:expect([[
+      {1:  }^xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx |
+      {1:  }second line                                                              |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+    feed('AX')
+    screen:expect([[
+      {1:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX|
+      {1:  }^second line                                                              |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {2:-- INSERT --}                                                               |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:8.2.4029: debugging NFA regexp my crash, cached indent may be wrong

Problem:    Debugging NFA regexp my crash, cached indent may be wrong.
Solution:   Fix some debug warnings in the NFA regexp code.  Make sure log_fd
            is set when used.  Fix breakindent and indent caching. (Christian
            Brabandt, closes vim/vim#9482)
https://github.com/vim/vim/commit/b2d85e3784ac89f5209489844c1ee0f54d117abb


#### vim-patch:8.2.4093: cached breakindent values not initialized properly

Problem:    Cached breakindent values not initialized properly.
Solution:   Initialize and cache formatlistpat. (Christian Brabandt,
            closes vim/vim#9526)
https://github.com/vim/vim/commit/c53b467473160b5cfce77277fbae414bf43e66ce

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:8.2.4100: early return when getting the 'formatlistpat' value

Problem:    Early return when getting the 'formatlistpat' value.
Solution:   Remove the first line. (Christian Brabandt)
https://github.com/vim/vim/commit/04b871da800768287a8a432de568b11297db8686


#### vim-patch:8.2.4501: with 'showbreak' set cursor displayed in wrong position

Problem:    With 'showbreak' set and after the end of the line the cursor
            may be displayed in the wrong position.
Solution:   Do not apply 'showbreak' after the end of the line.

https://github.com/vim/vim/commit/21efafe4c25373929979c72dc8aafa119f12dd8b

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4882: cannot make 'breakindent' use a specific column

Problem:    Cannot make 'breakindent' use a specific column.
Solution:   Add the "column" entry in 'breakindentopt'. (Christian Brabandt,
            closes vim/vim#10362)

https://github.com/vim/vim/commit/e7d6dbc5721342e3d6b04cf285e4510b5569e707

Co-authored-by: Christian Brabandt <cb@256bit.org>