### PR TITLE
vim-patch:8.2.4660: cursorcolumn is sometimes not correct

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -390,9 +390,13 @@ static void insert_enter(InsertState *s)
   trigger_modechanged();
   stop_insert_mode = false;
 
-  // Need to recompute the cursor position, it might move when the cursor is
-  // on a TAB or special character.
-  curs_columns(curwin, true);
+  // Need to recompute the cursor position, it might move when the cursor
+  // is on a TAB or special character.
+  // ptr2cells() treats a TAB character as double-width.
+  if (ptr2cells(get_cursor_pos_ptr()) > 1) {
+    curwin->w_valid &= ~VALID_VIRTCOL;
+    curs_columns(curwin, true);
+  }
 
   // Enable langmap or IME, indicated by 'iminsert'.
   // Note that IME may enabled/disabled without us noticing here, thus the

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -597,6 +597,28 @@ func Test_cursorline_with_visualmode()
   call delete('Xtest_cursorline_with_visualmode')
 endfunc
 
+func Test_cursorcolumn_insert_on_tab()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['123456789', "a\tb"])
+    set cursorcolumn
+    call cursor(2, 2)
+  END
+  call writefile(lines, 'Xcuc_insert_on_tab')
+
+  let buf = RunVimInTerminal('-S Xcuc_insert_on_tab', #{rows: 8})
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_insert_on_tab_1', {})
+
+  call term_sendkeys(buf, 'i')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_insert_on_tab_2', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xcuc_insert_on_tab')
+endfunc
+
 func Test_cursorcolumn_callback()
   CheckScreendump
   CheckFeature timers

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1306,14 +1306,48 @@ describe('CursorLine and CursorLineNr highlights', function()
 end)
 
 describe('CursorColumn highlight', function()
-  before_each(clear)
-  it('is updated if cursor is moved from timer', function()
-    local screen = Screen.new(50, 8)
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(50, 8)
     screen:set_default_attr_ids({
       [1] = {background = Screen.colors.Gray90},  -- CursorColumn
       [2] = {bold = true, foreground = Screen.colors.Blue1},  -- NonText
+      [3] = {bold = true},  -- ModeMsg
     })
     screen:attach()
+  end)
+
+  it('is updated when pressing "i" on a TAB character', function()
+    exec([[
+      call setline(1, ['123456789', "a\tb"])
+      set cursorcolumn
+      call cursor(2, 2)
+    ]])
+    screen:expect([[
+      1234567{1:8}9                                         |
+      a      ^ b                                         |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+                                                        |
+    ]])
+    feed('i')
+    screen:expect([[
+      1{1:2}3456789                                         |
+      a^       b                                         |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {3:-- INSERT --}                                      |
+    ]])
+  end)
+
+  it('is updated if cursor is moved from timer', function()
     exec([[
       call setline(1, ['aaaaa', 'bbbbb', 'ccccc', 'ddddd'])
       set cursorcolumn

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -256,6 +256,40 @@ describe('Screen', function()
         ]])
       end)
     end) -- a region of text (implicit concealing)
+
+    it("cursor position is correct when entering Insert mode with cocu=ni #13916", function()
+      insert([[foobarfoobarfoobar]])
+      -- move to end of line
+      feed("$")
+      command("set concealcursor=ni")
+      command("syn match Foo /foobar/ conceal cchar=&")
+      screen:expect([[
+        {1:&&&}^                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      feed("i")
+      -- cursor should stay in place, not jump to column 16
+      screen:expect([[
+        {1:&&&}^                                                  |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {4:-- INSERT --}                                         |
+      ]])
+    end)
   end) -- match and conceal
 
   describe("let the conceal level be", function()


### PR DESCRIPTION
Fix #13916

#### vim-patch:8.2.4660: cursorcolumn is sometimes not correct

Problem:    Cursorcolumn is sometimes not correct.
Solution:   Recompute the cursor column when entering Insert mode and the
            cursor is on a character wider than a screen cell.
https://github.com/vim/vim/commit/782c6744b49b30d9460ed00d4773666e42e07163