### PR TITLE
fix(syntax): fix bindzone syntax for OwnerName

### DIFF
--- a/runtime/syntax/bindzone.vim
+++ b/runtime/syntax/bindzone.vim
@@ -26,7 +26,7 @@ syn match       zoneDirective   /^\$GENERATE\s/
 
 syn match       zoneUnknown     contained /\S\+/
 
-syn match       zoneOwnerName   contained /^[^[:space:]!"#$%&'()*+,\/:;<=>?@[\]\^`{|}~]\+\(\s\|;\)\@=/ nextgroup=zoneTTL,zoneClass,zoneRRType skipwhite
+syn match       zoneOwnerName   contained /^\(\*\.\)\?[^[:space:]!"#$%&'()*+,\/:;<=>?@[\]\^`{|}~]\+\(\s\|;\)\@=/ nextgroup=zoneTTL,zoneClass,zoneRRType skipwhite
 syn match       zoneOrigin      contained  /[^[:space:]!"#$%&'()*+,\/:;<=>?@[\]\^`{|}~]\+\(\s\|;\|$\)\@=/
 syn match       zoneDomain      contained  /[^[:space:]!"#$%&'()*+,\/:;<=>?@[\]\^`{|}~]\+\(\s\|;\|$\)\@=/
 


### PR DESCRIPTION
Now an OwnerName can begin with `*.` so as to accommodate bind's wildcard names