### PR TITLE
vim-patch:8.2.2675: directory change in a terminal window shell is not followed

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -617,6 +617,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 	or selected.
 	Note: When this option is on some plugins may not work.
 
+			*'autoshelldir'* *'asd'* *'noautoshelldir'* *'noasd'*
+'autoshelldir' 'asd'	boolean (default off)
+			global
+	When on, Vim will change the current working directory whenever you
+	change the directory of the shell running in a terminal window. You
+	need proper setting-up, so whenever the shell's pwd changes an OSC 7
+	escape sequence will be emitted. For example, on Linux, you can source
+	/etc/profile.d/vte.sh in your shell profile if you use bash or zsh.
+
 				*'arabic'* *'arab'* *'noarabic'* *'noarab'*
 'arabic' 'arab'		boolean (default off)
 			local to window

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -602,6 +602,7 @@ Short explanation of each option:		*option-list*
 'allowrevins'	  'ari'     allow CTRL-_ in Insert and Command-line mode
 'ambiwidth'	  'ambw'    what to do with Unicode chars of ambiguous width
 'autochdir'	  'acd'     change directory to the file in the current window
+'autoshelldir'	  'asd'     change directory to the shell's current directory
 'arabic'	  'arab'    for Arabic as a default second language
 'arabicshape'	  'arshape' do shaping for Arabic characters
 'autoindent'	  'ai'	    take indent for new line from previous line

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -269,6 +269,8 @@ if exists("+autochdir")
   call append("$", "autochdir\tchange to directory of file in buffer")
   call <SID>BinOptionG("acd", &acd)
 endif
+call append("$", "autoshelldir\tchange to pwd of shell in terminal buffer")
+call <SID>BinOptionG("asd", &asd)
 call append("$", "wrapscan\tsearch commands wrap around the end of the buffer")
 call <SID>BinOptionG("ws", &ws)
 call append("$", "incsearch\tshow match for partly typed search command")

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -307,6 +307,7 @@ enum {
 
 EXTERN long p_aleph;            // 'aleph'
 EXTERN int p_acd;               // 'autochdir'
+EXTERN int p_asd;               // 'autoshelldir'
 EXTERN char_u *p_ambw;        // 'ambiwidth'
 EXTERN int p_ar;                // 'autoread'
 EXTERN int p_aw;                // 'autowrite'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -97,6 +97,13 @@ return {
       defaults={if_true=false}
     },
     {
+      full_name='autoshelldir', abbreviation='asd',
+      short_desc=N_("change directory to the shell's current directory"),
+      type='bool', scope={'global'},
+      varname='p_asd',
+      defaults={if_true=false}
+    },
+    {
       full_name='autoindent', abbreviation='ai',
       short_desc=N_("take indent for new line from previous line"),
       type='bool', scope={'buffer'},

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -4,6 +4,7 @@ local assert_alive = helpers.assert_alive
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local poke_eventloop = helpers.poke_eventloop
 local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.source
+local funcs, meths = helpers.funcs, helpers.meths
 local eq, neq = helpers.eq, helpers.neq
 local write_file = helpers.write_file
 local command = helpers.command
@@ -297,6 +298,19 @@ describe(':terminal buffer', function()
     feed('<c-\\><c-n>')
     feed_command('put a')  -- register a is empty
     helpers.assert_alive()
+  end)
+
+  it('supports OSC7', function()
+    command('set autoshelldir')
+    command('split')
+    command('enew')
+    local term = meths.open_term(0, {})
+    -- cwd will be inserted in a file URI, which cannot contain backslashes
+    local cwd = funcs.getcwd():gsub('\\', '/')
+    local parent = cwd:match('^(.+/)')
+    meths.chan_send(term, '\027]7;file://host' .. parent .. '\027\\')
+    -- expected is parent, without final separator
+    eq(parent:match("^(.+)/"), funcs.getcwd():gsub('\\', '/'))
   end)
 end)
 


### PR DESCRIPTION
Problem:    Directory change in a terminal window shell is not followed.
Solution:   Add the 'autoshelldir' option. (closes vim/vim#6290)
https://github.com/vim/vim/commit/8b9abfd86c736ed3f298dfa8b50a962c118b3983

Closes #2252
Closes #16740
Closes #16989