### PR TITLE
vim-patch:8.2.4664: Elvish files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -416,6 +416,9 @@ au BufNewFile,BufRead *.ex call dist#ft#ExCheck()
 au BufRead,BufNewFile mix.lock,*.exs setf elixir
 au BufRead,BufNewFile *.eex,*.leex setf eelixir
 
+" Elvish
+au BufRead,BufNewFile *.elv setf elvish
+
 " Euphoria 3 or 4
 au BufNewFile,BufRead *.eu,*.ew,*.exu,*.exw  call dist#ft#EuphoriaCheck()
 if has("fname_case")

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -177,6 +177,7 @@ local extension = {
   leex = "eelixir",
   exs = "elixir",
   elm = "elm",
+  elv = "elvish",
   epp = "epuppet",
   erl = "erlang",
   hrl = "erlang",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -168,6 +168,7 @@ let s:filename_checks = {
     \ 'eelixir': ['file.eex', 'file.leex'],
     \ 'elm': ['file.elm'],
     \ 'elmfilt': ['filter-rules'],
+    \ 'elvish': ['file.elv'],
     \ 'epuppet': ['file.epp'],
     \ 'erlang': ['file.erl', 'file.hrl', 'file.yaws'],
     \ 'eruby': ['file.erb', 'file.rhtml'],


### PR DESCRIPTION
Problem:    Elvish files are not recognized.
Solution:   Recognize .elv files. (Bruno Roque, closes vim/vim#10058)
https://github.com/vim/vim/commit/c1658a196bb05dd96562fd0a92409be2201b62e9