### PR TITLE
docs: add missing ampersand

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -921,7 +921,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	Note that environment variables are not expanded.  If you want to use
 	$HOME you must expand it explicitly, e.g.: >
-		:let backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
+		:let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
 
 <	Note that the default also makes sure that "crontab -e" works (when a
 	backup would be made by renaming the original file crontab won't see


### PR DESCRIPTION
From [Vim patch 7.4.1705](https://github.com/vim/vim/commit/7c1c6dbb6817640fd3956a0d5417da23fde336d8)

Should this go into the typo fix PR?