### PR TITLE
fix(ex_normal): spam \n in Ex mode only if in Cmdline mode

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2330,7 +2330,7 @@ static int vgetorpeek(bool advance)
           // cmdline window.
           if (p_im && (State & INSERT)) {
             c = Ctrl_L;
-          } else if (exmode_active) {
+          } else if ((State & CMDLINE) && exmode_active) {
             c = '\n';
           } else if ((State & CMDLINE) || (cmdwin_type > 0 && tc == ESC)) {
             c = Ctrl_C;

--- a/test/functional/ex_cmds/normal_spec.lua
+++ b/test/functional/ex_cmds/normal_spec.lua
@@ -1,0 +1,13 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local feed = helpers.feed
+local expect = helpers.expect
+
+before_each(clear)
+
+describe(':normal', function()
+  it('can get out of Insert mode if called from Ex mode #17924', function()
+    feed('gQnormal! Ifoo<CR>')
+    expect('foo')
+  end)
+end)


### PR DESCRIPTION
Fix #17924

When using `:normal` in Ex mode, the editor is no longer in Cmdline mode, but the `exmode_active` flag is still set, causing the wrong character to be spammed in Insert mode, leading to a hang.