### PR TITLE
docs: add a tag to all possible map prefixes to nvim_set_keymap

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1588,9 +1588,9 @@ nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
 <
 
                 Parameters: ~
-                    {mode}  Mode short-name (map command prefix: "n", "i",
-                            "v", "x", …) or "!" for |:map!|, or empty string
-                            for |:map|.
+                    {mode}  Map command prefix or "!" for |:map!|, or empty
+                            string for |:map|. See |map-overview| to see all
+                            possible prefixes.
                     {lhs}   Left-hand-side |{lhs}| of the mapping.
                     {rhs}   Right-hand-side |{rhs}| of the mapping.
                     {opts}  Optional parameters map. Accepts all

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1587,8 +1587,8 @@ ArrayOf(Dictionary) nvim_get_keymap(uint64_t channel_id, String mode)
 /// </pre>
 ///
 /// @param channel_id
-/// @param  mode  Mode short-name (map command prefix: "n", "i", "v", "x", …)
-///               or "!" for |:map!|, or empty string for |:map|.
+/// @param  mode  Map command prefix or "!" for |:map!|, or empty string for
+///               |:map|. See |map-overview| to see all possible prefixes.
 /// @param  lhs   Left-hand-side |{lhs}| of the mapping.
 /// @param  rhs   Right-hand-side |{rhs}| of the mapping.
 /// @param  opts  Optional parameters map. Accepts all |:map-arguments|


### PR DESCRIPTION
In general I prefer pointing to the full list when using "etc" or "..."
so a reader knows where to find more information.
