### PR TITLE
vim-patch:8.2.4672: using :normal with Ex mode may make :substitute hang

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3867,6 +3867,12 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
               if (resp != NULL) {
                 typed = *resp;
                 xfree(resp);
+                // When ":normal" runs out of characters we get
+                // an empty line.  Use "q" to get out of the
+                // loop.
+                if (ex_normal_busy && typed == NUL) {
+                  typed = 'q';
+                }
               }
             } else {
               char_u *orig_line = NULL;

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1843,6 +1843,16 @@ fun! Test_normal33_g_cmd2()
   bw!
 endfunc
 
+func Test_normal_ex_substitute()
+  " This was hanging on the substitute prompt.
+  new
+  call setline(1, 'a')
+  exe "normal! gggQs/a/b/c\<CR>"
+  call assert_equal('a', getline(1))
+  bwipe!
+endfunc
+
+" Test for g CTRL-G
 func Test_g_ctrl_g()
   new
 


### PR DESCRIPTION
#### vim-patch:8.2.4672: using :normal with Ex mode may make :substitute hang

Problem:    Using :normal with Ex mode may make :substitute hang.
Solution:   When getting an empty line behave like 'q' was typed.
https://github.com/vim/vim/commit/ce416b453a849c837f9f6ffc91dd4792d84e1bfd

Cherry-pick a comment from patch 8.2.0363.