### PR TITLE
feat(treesitter): use better error messages in query

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -169,11 +169,19 @@ function M.parse_query(lang, query)
     return cached
   else
     local self = setmetatable({}, Query)
-    self.query = vim._ts_parse_query(lang, query)
-    self.info = self.query:inspect()
-    self.captures = self.info.captures
-    query_cache[lang][query] = self
-    return self
+    print("OKAY")
+    local ok, content = pcall(vim._ts_parse_query, lang, query)
+
+    if ok then
+      self.query = content
+      self.info = self.query:inspect()
+      self.captures = self.info.captures
+      query_cache[lang][query] = self
+      return self
+    else
+      print(vim.inspect(content))
+      error()
+    end
   end
 end
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1187,8 +1187,12 @@ int tslua_parse_query(lua_State *L)
   TSQuery *query = ts_query_new(lang, src, len, &error_offset, &error_type);
 
   if (!query) {
-    return luaL_error(L, "query: %s at position %d",
-                      query_err_string(error_type), (int)error_offset);
+    lua_createtable(L, 0, 2); // [ table ]
+    lua_pushstring(L, query_err_string(error_type)); // [ table, error ]
+    lua_setfield(L, -2, "desc"); // [ table ]
+    lua_pushinteger(L, error_offset); // [ table, int ]
+    lua_setfield(L, -2, "offset"); // [ table ]
+    return lua_error(L);
   }
 
   TSQuery **ud = lua_newuserdata(L, sizeof(TSQuery *));  // [udata]


### PR DESCRIPTION
This PR is an attempt to return better error messages when parsing
queries.

Somehow I can't handle the error object from the lua side.
It is even weirder: when returning any error from the C-side, it is
not catched by `pcall` after, nor `xpcall`...

TODO:
- [ ] Actually handle the message on the lua side

Superseedes #14053
