### PR TITLE
vim-patch:8.2.{4247,4258}: stack corruption when looking for spell suggestions

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3690,7 +3690,7 @@ static void suggest_try_change(suginfo_T *su)
 
 // Check the maximum score, if we go over it we won't try this change.
 #define TRY_DEEPER(su, stack, depth, add) \
-  ((depth) < MAXWLEN && (stack)[depth].ts_score + (add) < (su)->su_maxscore)
+  ((depth) < MAXWLEN - 1 && (stack)[depth].ts_score + (add) < (su)->su_maxscore)
 
 // Try finding suggestions by adding/removing/swapping letters.
 //
@@ -3828,7 +3828,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
 
         // At end of a prefix or at start of prefixtree: check for
         // following word.
-        if (depth < MAXWLEN && (byts[arridx] == 0 || n == STATE_NOPREFIX)) {
+        if (depth < MAXWLEN - 1 && (byts[arridx] == 0 || n == STATE_NOPREFIX)) {
           // Set su->su_badflags to the caps type at this position.
           // Use the caps type until here for the prefix itself.
           n = nofold_len(fword, sp->ts_fidx, su->su_badptr);

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -681,6 +681,14 @@ func Test_spell_long_word()
   set nospell
 endfunc
 
+func Test_spellsuggest_too_deep()
+  " This was incrementing "depth" over MAXWLEN.
+  new
+  norm s000G00ý000000000000
+  sil norm ..vzG................vvzG0     v z=
+  bwipe!
+endfunc
+
 func LoadAffAndDic(aff_contents, dic_contents)
   throw 'skipped: Nvim does not support enc=latin1'
   set enc=latin1

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -407,7 +407,7 @@ func Test_zz_basic()
         \ )
 
   call assert_equal("gebletegek", soundfold('goobledygoook'))
-  call assert_equal("kepereneven", 'kÃ³opÃ«rÃ¿nÃ´ven'->soundfold())
+  call assert_equal("kepereneven", 'kóopërÿnôven'->soundfold())
   call assert_equal("everles gesvets etele", soundfold('oeverloos gezwets edale'))
 endfunc
 
@@ -588,7 +588,7 @@ func Test_zz_sal_and_addition()
   mkspell! Xtest Xtest
   set spl=Xtest.latin1.spl spell
   call assert_equal('kbltykk', soundfold('goobledygoook'))
-  call assert_equal('kprnfn', soundfold('kÃ³opÃ«rÃ¿nÃ´ven'))
+  call assert_equal('kprnfn', soundfold('kóopërÿnôven'))
   call assert_equal('*fls kswts tl', soundfold('oeverloos gezwets edale'))
 
   "also use an addition file


### PR DESCRIPTION
#### vim-patch:8.2.4247: stack corruption when looking for spell suggestions

Problem:    Stack corruption when looking for spell suggestions.
Solution:   Prevent the depth increased too much.  Add a five second time
            limit to finding suggestions.
https://github.com/vim/vim/commit/06f15416bb8d5636200a10776f1752c4d6e49f31

Cherry-pick parentheses from patch 8.2.4402.


#### vim-patch:8.2.4258: Coverity warns for array overrun

Problem:    Coverity warns for array overrun.
Solution:   Restrict depth to MAXWLEN - 1.
https://github.com/vim/vim/commit/6970e1e36a1ecdb4d330d6ac9ca76f97fa515e36