### PR TITLE
test(old): fix test_regexp_latin.vim encoding

### DIFF
--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -6,7 +6,10 @@ scriptencoding latin1
 source check.vim
 
 func s:equivalence_test()
-  let str = "AÃ€ÃÃ‚ÃƒÃ„Ã… B C D EÃˆÃ‰ÃŠÃ‹ F G H IÃŒÃÃÃ J K L M NÃ‘ OÃ’Ã“Ã”Ã•Ã–Ã˜ P Q R S T UÃ™ÃšÃ›Ãœ V W X YÃ Z aÃ Ã¡Ã¢Ã£Ã¤Ã¥ b c d eÃ¨Ã©ÃªÃ« f g h iÃ¬Ã­Ã®Ã¯ j k l m nÃ± oÃ²Ã³Ã´ÃµÃ¶Ã¸ p q r s t uÃ¹ÃºÃ»Ã¼ v w x yÃ½Ã¿ z"
+  let str = 'AÀÁÂÃÄÅ B C D EÈÉÊË F G H IÌÍÎÏ J K L M NÑ OÒÓÔÕÖØ P Q R S T UÙÚÛÜ V W X Yİ Z '
+  \      .. 'aàáâãäå b c d eèéêë f g h iìíîï j k l m nñ oòóôõöø p q r s t uùúûü v w x yıÿ z '
+  \      .. "0 1 2 3 4 5 6 7 8 9 "
+  \      .. "` ~ ! ? ; : . , / \\ ' \" | < > [ ] { } ( ) @ # $ % ^ & * _ - + \b \e \f \n \r \t"
   let groups = split(str)
   for group1 in groups
       for c in split(group1, '\zs')
@@ -337,7 +340,7 @@ func Test_regexp_single_line_pat()
   call add(tl, [2, '\v((ab)|c*)+', 'abcccaba', 'abcccab', '', 'ab'])
   call add(tl, [2, '\v(a(c*)+b)+', 'acbababaaa', 'acbabab', 'ab', ''])
   call add(tl, [2, '\v(a|b*)+', 'aaaa', 'aaaa', ''])
-  call add(tl, [2, '\p*', 'aÃ¡ 	', 'aÃ¡ '])
+  call add(tl, [2, '\p*', 'aá 	', 'aá '])
 
   " Test greedy-ness and lazy-ness
   call add(tl, [2, 'a\{-2,7}','aaaaaaaaaaaaa', 'aa'])
@@ -790,12 +793,12 @@ endfunc
 " Check patterns matching cursor position.
 func s:curpos_test2()
   new
-  call setline(1, ['1', '2 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '3 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '4 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '5	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '6	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '7	foobar eins zwei drei vier fÃ¼nf sechse'])
+  call setline(1, ['1', '2 foobar eins zwei drei vier fünf sechse',
+        \ '3 foobar eins zwei drei vier fünf sechse',
+        \ '4 foobar eins zwei drei vier fünf sechse',
+        \ '5	foobar eins zwei drei vier fünf sechse',
+        \ '6	foobar eins zwei drei vier fünf sechse',
+        \ '7	foobar eins zwei drei vier fünf sechse'])
   call setpos('.', [0, 2, 10, 0])
   s/\%.c.*//g
   call setpos('.', [0, 3, 15, 0])
@@ -805,10 +808,10 @@ func s:curpos_test2()
   call assert_equal(['1',
         \ '2 foobar ',
         \ '',
-        \ '4 foobar eins zwei drei vier fÃ¼nf sechse',
+        \ '4 foobar eins zwei drei vier fünf sechse',
         \ '5	_',
-        \ '6	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '7	foobar eins zwei drei vier fÃ¼nf sechse'],
+        \ '6	foobar eins zwei drei vier fünf sechse',
+        \ '7	foobar eins zwei drei vier fünf sechse'],
         \ getline(1, '$'))
   call assert_fails('call search("\\%.1l")', 'E1204:')
   call assert_fails('call search("\\%.1c")', 'E1204:')
@@ -819,12 +822,12 @@ endfunc
 " Check patterns matching before or after cursor position.
 func s:curpos_test3()
   new
-  call setline(1, ['1', '2 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '3 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '4 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '5	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '6	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '7	foobar eins zwei drei vier fÃ¼nf sechse'])
+  call setline(1, ['1', '2 foobar eins zwei drei vier fünf sechse',
+        \ '3 foobar eins zwei drei vier fünf sechse',
+        \ '4 foobar eins zwei drei vier fünf sechse',
+        \ '5	foobar eins zwei drei vier fünf sechse',
+        \ '6	foobar eins zwei drei vier fünf sechse',
+        \ '7	foobar eins zwei drei vier fünf sechse'])
   call setpos('.', [0, 2, 10, 0])
   " Note: This removes all columns, except for the column directly in front of
   " the cursor. Bug????
@@ -838,27 +841,27 @@ func s:curpos_test3()
   call setpos('.', [0, 6, 4, 0])
   :s/\%>.v.*$/_/
   call assert_equal(['1',
-        \ ' eins zwei drei vier fÃ¼nf sechse',
+        \ ' eins zwei drei vier fünf sechse',
         \ '3 foobar e',
-        \ '4 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '_foobar eins zwei drei vier fÃ¼nf sechse',
+        \ '4 foobar eins zwei drei vier fünf sechse',
+        \ '_foobar eins zwei drei vier fünf sechse',
         \ '6	fo_',
-        \ '7	foobar eins zwei drei vier fÃ¼nf sechse'],
+        \ '7	foobar eins zwei drei vier fünf sechse'],
         \ getline(1, '$'))
   sil %d
-  call setline(1, ['1', '2 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '3 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '4 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '5	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '6	foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '7	foobar eins zwei drei vier fÃ¼nf sechse'])
+  call setline(1, ['1', '2 foobar eins zwei drei vier fünf sechse',
+        \ '3 foobar eins zwei drei vier fünf sechse',
+        \ '4 foobar eins zwei drei vier fünf sechse',
+        \ '5	foobar eins zwei drei vier fünf sechse',
+        \ '6	foobar eins zwei drei vier fünf sechse',
+        \ '7	foobar eins zwei drei vier fünf sechse'])
   call setpos('.', [0, 4, 4, 0])
   %s/\%<.l.*//
   call setpos('.', [0, 5, 4, 0])
   %s/\%>.l.*//
   call assert_equal(['', '', '',
-        \ '4 foobar eins zwei drei vier fÃ¼nf sechse',
-        \ '5	foobar eins zwei drei vier fÃ¼nf sechse',
+        \ '4 foobar eins zwei drei vier fünf sechse',
+        \ '5	foobar eins zwei drei vier fünf sechse',
         \ '', ''],
         \ getline(1, '$'))
   bwipe!


### PR DESCRIPTION
Cherry-pick a change from Vim patch 8.2.3982