### PR TITLE
docs(behavior): add 'buflisted' behavior to terminal-start

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -41,6 +41,8 @@ There are several ways to create a terminal buffer:
 When the terminal starts, the buffer contents are updated and the buffer is
 named in the form of `term://{cwd}//{pid}:{cmd}`. This naming scheme is used
 by |:mksession| to restore a terminal buffer (by restarting the {cmd}).
+Additionally, starting the terminal in a buffer will set 'buflisted' = 1,
+regardless of the value of 'buflisted' or 'nobuflisted' when it was executed.
 
 ==============================================================================
 Input						*terminal-input*


### PR DESCRIPTION
Currently, it is undocumented that starting a terminal in a buffer will force that buffer to be listed, even if the buffer was unlisted prior. This caused me quite the headache the other day when someone requested that the terminal buffers from my plugin not appear in bufferline.

If this is unintentional behavior, I am happy to close this and follow it up with a different PR that causes terminals to inherit the properties of the buffer they are started in.