### PR TITLE
vim-patch:8.2.{4692,4691,4690}: fix Insert mode <LeftDrag> mapping bug

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1517,9 +1517,12 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
   for (;;) {
     which_button = get_mouse_button(KEY2TERMCAP1(c), &is_click, &is_drag);
     if (is_drag) {
-      /* If the next character is the same mouse event then use that
-       * one. Speeds up dragging the status line. */
-      if (vpeekc() != NUL) {
+      // If the next character is the same mouse event then use that
+      // one. Speeds up dragging the status line.
+      // Note: Since characters added to the stuff buffer in the code
+      // below need to come before the next character, do not do this
+      // when the current character was stuffed.
+      if (!KeyStuffed && vpeekc() != NUL) {
         int nc;
         int save_mouse_grid = mouse_grid;
         int save_mouse_row = mouse_row;

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -676,4 +676,38 @@ func Test_plug_remap()
   %bw!
 endfunc
 
+" Test for mapping <LeftDrag> in Insert mode
+func Test_mouse_drag_insert_map()
+  CheckFunction test_setmouse
+  set mouse=a
+  func ClickExpr()
+    call test_setmouse(1, 1)
+    return "\<LeftMouse>"
+  endfunc
+  func DragExpr()
+    call test_setmouse(1, 2)
+    return "\<LeftDrag>"
+  endfunc
+  inoremap <expr> <F2> ClickExpr()
+  imap <expr> <F3> DragExpr()
+
+  inoremap <LeftDrag> <LeftDrag><Cmd>let g:dragged = 1<CR>
+  exe "normal i\<F2>\<F3>"
+  call assert_equal(1, g:dragged)
+  call assert_equal('v', mode())
+  exe "normal! \<C-\>\<C-N>"
+  unlet g:dragged
+
+  inoremap <LeftDrag> <LeftDrag><C-\><C-N>
+  exe "normal i\<F2>\<F3>"
+  call assert_equal('n', mode())
+
+  iunmap <LeftDrag>
+  iunmap <F2>
+  iunmap <F3>
+  delfunc ClickExpr
+  delfunc DragExpr
+  set mouse&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -3,6 +3,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
 local feed_command, expect, poke_eventloop = helpers.feed_command, helpers.expect, helpers.poke_eventloop
+local command, eq, eval, meths = helpers.command, helpers.eq, helpers.eval, helpers.meths
+local sleep = helpers.sleep
 
 describe('mapping', function()
   before_each(clear)
@@ -125,5 +127,29 @@ describe('mapping', function()
       Test3: text with a (parenthesis here
       new line here
       ]])
+  end)
+
+  it('<LeftDrag> mapping in Insert mode works correctly vim-patch:8.2.4692', function()
+    command('set mouse=a')
+
+    command([[inoremap <LeftDrag> <LeftDrag><Cmd>let g:dragged = 1<CR>]])
+    feed('i')
+    sleep(10)
+    meths.input_mouse('left', 'press', '', 0, 0, 0)
+    sleep(10)
+    meths.input_mouse('left', 'drag', '', 0, 0, 1)
+    sleep(10)
+    eq(1, eval('g:dragged'))
+    eq('v', eval('mode()'))
+    feed([[<C-\><C-N>]])
+
+    command([[inoremap <LeftDrag> <LeftDrag><C-\><C-N>]])
+    feed('i')
+    sleep(10)
+    meths.input_mouse('left', 'press', '', 0, 0, 0)
+    sleep(10)
+    meths.input_mouse('left', 'drag', '', 0, 0, 1)
+    sleep(10)
+    eq('n', eval('mode()'))
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.{4692,4691,4690}: fix Insert mode \<LeftDrag\> mapping bug

vim-patch:8.2.4692: no test for what 8.2.4691 fixes

Problem:    No test for what 8.2.4691 fixes.
Solution:   Add a test.  Use a more generic sotlution. (closes vim/vim#10090)
https://github.com/vim/vim/commit/0f68e6c07aaf62c034a242f183b93c1bb44e7f93

Test cannot be used because it must use test_setmouse(). Use a Lua test.

Reverted patches:

vim-patch:8.2.4691: solution for <Cmd> in a mapping causes trouble

Problem:    Solution for <Cmd> in a mapping causes trouble.
Solution:   Use another solution: put back CTRL-O after reading the <Cmd>
            sequence.
https://github.com/vim/vim/commit/ca9d8d2cb9fc6b9240f2a74ccd36f9d966488294

vim-patch:8.2.4689: using <Cmd> in a mapping does not work for mouse keys

Problem:    Using <Cmd> in a mapping does not work for mouse keys in Insert
            mode. (Sergey Vlasov)
Solution:   When reading the <Cmd> argument do not use the stuff buffer.
https://github.com/vim/vim/commit/d0fb2d804183c2786578b4c32ba5b92938f93d0e