### PR TITLE
vim-patch:8.2.4696: delete() with "rf" argument does not report a failure

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5408,15 +5408,18 @@ int delete_recursive(const char *name)
       for (int i = 0; i < ga.ga_len; i++) {
         vim_snprintf((char *)NameBuff, MAXPATHL, "%s/%s", exp, ((char_u **)ga.ga_data)[i]);
         if (delete_recursive((const char *)NameBuff) != 0) {
+          // Remember the failure but continue deleting any further
+          // entries.
           result = -1;
         }
       }
       ga_clear_strings(&ga);
+      if (os_rmdir(exp) != 0) {
+        result = -1;
+      }
     } else {
       result = -1;
     }
-    // Note: "name" value may be changed in delete_recursive().  Must use the saved value.
-    result = os_rmdir(exp) == 0 ? 0 : -1;
     xfree(exp);
   } else {
     // Delete symlink only.

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1662,6 +1662,15 @@ func Test_delete_rf()
   call assert_equal(0, delete('Xdir', 'rf'))
   call assert_false(filereadable('Xdir/foo.txt'))
   call assert_false(filereadable('Xdir/[a-1]/foo.txt'))
+
+  if has('unix')
+    call mkdir('Xdir/Xdir2', 'p')
+    silent !chmod 555 Xdir
+    call assert_equal(-1, delete('Xdir/Xdir2', 'rf'))
+    call assert_equal(-1, delete('Xdir', 'rf'))
+    silent !chmod 755 Xdir
+    call assert_equal(0, delete('Xdir', 'rf'))
+  endif
 endfunc
 
 func Test_call()


### PR DESCRIPTION
#### vim-patch:8.2.4696: delete() with "rf" argument does not report a failure

Problem:    delete() with "rf" argument does not report a failure.
Solution:   Return -1 if the directory could not be removed. (closes vim/vim#10078)
https://github.com/vim/vim/commit/478700336d1c72e133b8ff6841e968c1bb1658ed