### PR TITLE
vim-patch:8.2.4701: Kuka Robot Language files not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -899,6 +899,23 @@ func dist#ft#FTtf()
   setf tf
 endfunc
 
+" Determine if a *.src file is Kuka Robot Language
+func dist#ft#FTsrc()
+  if exists("g:filetype_src")
+    exe "setf " .. g:filetype_src
+  elseif getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|\%(global\s\+\)\?def\>\)'
+    setf krl
+  endif
+endfunc
+
+" Determine if a *.dat file is Kuka Robot Language
+func dist#ft#FTdat()
+  if exists("g:filetype_dat")
+    exe "setf " .. g:filetype_dat
+  elseif getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|defdat\>\)'
+    setf krl
+  endif
+endfunc
 
 " Restore 'cpoptions'
 let &cpo = s:cpo_save

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -947,6 +947,11 @@ au BufNewFile,BufRead *.jl			setf julia
 " Kixtart
 au BufNewFile,BufRead *.kix			setf kix
 
+" Kuka Robot Language
+au BufNewFile,BufRead *.src\c			call dist#ft#FTsrc()
+au BufNewFile,BufRead *.dat\c			call dist#ft#FTdat()
+au BufNewFile,BufRead *.sub\c			setf krl
+
 " Kimwitu[++]
 au BufNewFile,BufRead *.k			setf kwt
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1427,6 +1427,9 @@ local pattern = {
       return "git"
     end
   end,
+  [".*%.[Dd][Aa][Tt]"] = function() vim.fn["dist#ft#FTdat"]() end,
+  [".*%.[Ss][Rr][Cc]"] = function() vim.fn["dist#ft#FTsrc"]() end,
+  [".*%.[Ss][Uu][Bb]"] = "krl",
   -- Neovim only
   [".*/queries/.*%.scm"] = "query", -- tree-sitter queries
   -- END PATTERN

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -290,6 +290,7 @@ let s:filename_checks = {
     \ 'kivy': ['file.kv'],
     \ 'kix': ['file.kix'],
     \ 'kotlin': ['file.kt', 'file.ktm', 'file.kts'],
+    \ 'krl': ['file.sub', 'file.Sub', 'file.SUB'],
     \ 'kscript': ['file.ks'],
     \ 'kwt': ['file.k'],
     \ 'lace': ['file.ace', 'file.ACE'],
@@ -842,6 +843,30 @@ func Test_d_file()
   filetype off
 endfunc
 
+func Test_dat_file()
+  filetype on
+
+  call writefile(['&ACCESS'], 'datfile.dat')
+  split datfile.dat
+  call assert_equal('krl', &filetype)
+  bwipe!
+  call delete('datfile.dat')
+
+  call writefile(['  DEFDAT datfile'], 'datfile.Dat')
+  split datfile.Dat
+  call assert_equal('krl', &filetype)
+  bwipe!
+  call delete('datfile.Dat')
+
+  call writefile(['', 'defdat  datfile'], 'datfile.DAT')
+  split datfile.DAT
+  call assert_equal('krl', &filetype)
+  bwipe!
+  call delete('datfile.DAT')
+
+  filetype off
+endfunc
+
 func Test_dep3patch_file()
   filetype on
 
@@ -1281,6 +1306,30 @@ func Test_pp_file()
   bwipe!
 
   call delete('Xfile.pp')
+  filetype off
+endfunc
+
+func Test_src_file()
+  filetype on
+
+  call writefile(['&ACCESS'], 'srcfile.src')
+  split srcfile.src
+  call assert_equal('krl', &filetype)
+  bwipe!
+  call delete('srcfile.src')
+
+  call writefile(['  DEF srcfile()'], 'srcfile.Src')
+  split srcfile.Src
+  call assert_equal('krl', &filetype)
+  bwipe!
+  call delete('srcfile.Src')
+
+  call writefile(['', 'global  def  srcfile()'], 'srcfile.SRC')
+  split srcfile.SRC
+  call assert_equal('krl', &filetype)
+  bwipe!
+  call delete('srcfile.SRC')
+
   filetype off
 endfunc
 


### PR DESCRIPTION
Problem:    Kuka Robot Language files not recognized.
Solution:   Recognize *.src and *.dat files. (Patrick Meiser-Knosowski,
            closes vim/vim#10096)
https://github.com/vim/vim/commit/3ad2090316edc85e93094bba7af64f9991cc7f85