### PR TITLE
vim-patch:8.2.4707: redrawing could be a bit more efficient

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -286,9 +286,11 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra
         set_topline(wp, wp->w_topline);
       }
 
-      // Relative numbering may require updating more.
+      // If lines have been added or removed, relative numbering always
+      // requires a redraw.
       if (wp->w_p_rnu && xtra != 0) {
-        redraw_later(wp, SOME_VALID);
+        wp->w_last_cursor_lnum_rnu = 0;
+        redraw_later(wp, VALID);
       }
 
       // Cursor line highlighting probably need to be updated with

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -615,6 +615,14 @@ func Test_cursorcolumn_insert_on_tab()
   call TermWait(buf)
   call VerifyScreenDump(buf, 'Test_cursorcolumn_insert_on_tab_2', {})
 
+  call term_sendkeys(buf, "\<C-O>")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_insert_on_tab_3', {})
+
+  call term_sendkeys(buf, 'i')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_cursorcolumn_insert_on_tab_2', {})
+
   call StopVimInTerminal(buf)
   call delete('Xcuc_insert_on_tab')
 endfunc

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1345,6 +1345,28 @@ describe('CursorColumn highlight', function()
       {2:~                                                 }|
       {3:-- INSERT --}                                      |
     ]])
+    feed('<C-O>')
+    screen:expect([[
+      1234567{1:8}9                                         |
+      a      ^ b                                         |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {3:-- (insert) --}                                    |
+    ]])
+    feed('i')
+    screen:expect([[
+      1{1:2}3456789                                         |
+      a^       b                                         |
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {2:~                                                 }|
+      {3:-- INSERT --}                                      |
+    ]])
   end)
 
   it('is updated if cursor is moved from timer', function()


### PR DESCRIPTION
#### vim-patch:8.2.4707: redrawing could be a bit more efficient

Problem:    Redrawing could be a bit more efficient.
Solution:   Optimize redrawing. (closes vim/vim#10105)
https://github.com/vim/vim/commit/8c9796085071950f9a03ca0fe116608e4f86aac2