### PR TITLE
feat(events): add pattern `SIGWINCH` for autocmd event `Signal`

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -870,7 +870,7 @@ ShellCmdPost			After executing a shell command with |:!cmd|,
 							*Signal*
 Signal				After Nvim receives a signal. The pattern is
 				matched against the signal name. Only
-				"SIGUSR1" is supported.  Example: >
+				"SIGUSR1" and "SIGWINCH" are supported.  Example: >
 				    autocmd Signal SIGUSR1 call some#func()
 <							*ShellFilterPost*
 ShellFilterPost			After executing a shell command with

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -21,7 +21,7 @@
 #include "nvim/os/signal.h"
 #include "nvim/vim.h"
 
-static SignalWatcher spipe, shup, squit, sterm, susr1;
+static SignalWatcher spipe, shup, squit, sterm, susr1, swinch;
 #ifdef SIGPWR
 static SignalWatcher spwr;
 #endif
@@ -54,6 +54,9 @@ void signal_init(void)
 #ifdef SIGUSR1
   signal_watcher_init(&main_loop, &susr1, NULL);
 #endif
+#ifdef SIGWINCH
+  signal_watcher_init(&main_loop, &swinch, NULL);
+#endif
   signal_start();
 }
 
@@ -69,6 +72,9 @@ void signal_teardown(void)
 #endif
 #ifdef SIGUSR1
   signal_watcher_close(&susr1, NULL);
+#endif
+#ifdef SIGWINCH
+  signal_watcher_close(&swinch, NULL);
 #endif
 }
 
@@ -88,6 +94,9 @@ void signal_start(void)
 #ifdef SIGUSR1
   signal_watcher_start(&susr1, on_signal, SIGUSR1);
 #endif
+#ifdef SIGWINCH
+  signal_watcher_start(&swinch, on_signal, SIGWINCH);
+#endif
 }
 
 void signal_stop(void)
@@ -105,6 +114,9 @@ void signal_stop(void)
 #endif
 #ifdef SIGUSR1
   signal_watcher_stop(&susr1);
+#endif
+#ifdef SIGWINCH
+  signal_watcher_stop(&swinch);
 #endif
 }
 
@@ -140,6 +152,10 @@ static char *signal_name(int signum)
 #ifdef SIGUSR1
   case SIGUSR1:
     return "SIGUSR1";
+#endif
+#ifdef SIGWINCH
+  case SIGWINCH:
+    return "SIGWINCH";
 #endif
   default:
     return "Unknown";
@@ -195,6 +211,12 @@ static void on_signal(SignalWatcher *handle, int signum, void *data)
 #ifdef SIGUSR1
   case SIGUSR1:
     apply_autocmds(EVENT_SIGNAL, (char_u *)"SIGUSR1", curbuf->b_fname, true,
+                   curbuf);
+    break;
+#endif
+#ifdef SIGWINCH
+  case SIGWINCH:
+    apply_autocmds(EVENT_SIGNAL, (char_u *)"SIGWINCH", curbuf->b_fname, true,
                    curbuf);
     break;
 #endif

--- a/test/functional/autocmd/signal_spec.lua
+++ b/test/functional/autocmd/signal_spec.lua
@@ -30,6 +30,12 @@ describe('autocmd Signal', function()
     eq({'notification', 'foo', {}}, next_msg())
   end)
 
+  it('matches SIGWINCH', function()
+    command('autocmd Signal SIGWINCH call rpcnotify(1, "foo")')
+    posix_kill('WINCH', funcs.getpid())
+    eq({'notification', 'foo', {}}, next_msg())
+  end)
+
   it('does not match unknown patterns', function()
     command('autocmd Signal SIGUSR2 call rpcnotify(1, "foo")')
     posix_kill('USR1', funcs.getpid())


### PR DESCRIPTION
I have seen the #16030, which add support of `SIGWINCH` for `Signal`, but it seems not active. Following the suggestion [#16030 comment](https://github.com/neovim/neovim/pull/16030#discussion_r730481338), I implement it like `SIGUSR1`.

It works for me like this:

https://user-images.githubusercontent.com/40141251/162266482-2d915813-c1d9-4717-afa7-b89f0f60e9dd.mov

I'm not familiar with neovim, and I'm not sure if this change breaks something. ~~I have run test locally where I received an error during [early init](https://github.com/neovim/neovim/blob/master/test/functional/core/startup_spec.lua#L258), while the error also occurs on master.~~
edit: [CI passed on my fork](https://github.com/wangl-cc/neovim/actions/runs/2114310670).