### PR TITLE
vim-patch:8.2.4710: smart indenting does not work after completion

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1393,6 +1393,7 @@ static void insert_do_complete(InsertState *s)
     compl_cont_status = 0;
   }
   compl_busy = false;
+  can_si = true;  // allow smartindenting
 }
 
 static void insert_do_cindent(InsertState *s)

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -707,4 +707,23 @@ func Test_z1_complete_no_history()
   close!
 endfunc
 
+func FooBarComplete(findstart, base)
+  if a:findstart
+    return col('.') - 1
+  else
+    return ["Foo", "Bar", "}"]
+  endif
+endfunc
+
+func Test_complete_smartindent()
+  new
+  setlocal smartindent completefunc=FooBarComplete
+
+  exe "norm! o{\<cr>\<c-x>\<c-u>\<c-p>}\<cr>\<esc>"
+  let result = getline(1,'$')
+  call assert_equal(['', '{','}',''], result)
+  bw!
+  delfunction! FooBarComplete
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4710: smart indenting does not work after completion

Problem:    Smart indenting does not work after completion.
Solution:   Set "can_si". (Christian Brabandt, closes vim/vim#10113)
https://github.com/vim/vim/commit/ac72c21da696cf6c31630a9e5ff4c0d3e2049c11