### PR TITLE
vim-patch:8.2.{0004,4700,4706}: buffer closing is interrupted

### DIFF
--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -58,9 +58,10 @@ enum dobuf_start_values {
 
 // flags for buf_freeall()
 enum bfa_values {
-  BFA_DEL       = 1,  // buffer is going to be deleted
-  BFA_WIPE      = 2,  // buffer is going to be wiped out
-  BFA_KEEP_UNDO = 4,  // do not free undo information
+  BFA_DEL          = 1,  // buffer is going to be deleted
+  BFA_WIPE         = 2,  // buffer is going to be wiped out
+  BFA_KEEP_UNDO    = 4,  // do not free undo information
+  BFA_IGNORE_ABORT = 8,  // do not abort for aborting()
 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2527,9 +2527,9 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
         // Close the link to the current buffer. This will set
         // oldwin->w_buffer to NULL.
         u_sync(false);
-        const bool did_decrement = close_buffer(oldwin, curbuf,
-                                                (flags & ECMD_HIDE) || curbuf->terminal ? 0 : DOBUF_UNLOAD,
-                                                false);
+        const bool did_decrement
+          = close_buffer(oldwin, curbuf, (flags & ECMD_HIDE) || curbuf->terminal ? 0 : DOBUF_UNLOAD,
+                         false, false);
 
         // Autocommands may have closed the window.
         if (win_valid(the_curwin)) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6544,7 +6544,7 @@ static int open_cmdwin(void)
     // win_close() may have already wiped the buffer when 'bh' is
     // set to 'wipe', autocommands may have closed other windows
     if (bufref_valid(&bufref) && bufref.br_buf != curbuf) {
-      close_buffer(NULL, bufref.br_buf, DOBUF_WIPE, false);
+      close_buffer(NULL, bufref.br_buf, DOBUF_WIPE, false, false);
     }
 
     // Restore window sizes.

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -691,7 +691,7 @@ void free_all_mem(void)
     bufref_T bufref;
     set_bufref(&bufref, buf);
     nextbuf = buf->b_next;
-    close_buffer(NULL, buf, DOBUF_WIPE, false);
+    close_buffer(NULL, buf, DOBUF_WIPE, false, false);
     // Didn't work, try next one.
     buf = bufref_valid(&bufref) ? nextbuf : firstbuf;
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1721,7 +1721,7 @@ static void wipe_qf_buffer(qf_info_T *qi)
     if (qfbuf != NULL && qfbuf->b_nwindows == 0) {
       // If the quickfix buffer is not loaded in any window, then
       // wipe the buffer.
-      close_buffer(NULL, qfbuf, DOBUF_WIPE, false);
+      close_buffer(NULL, qfbuf, DOBUF_WIPE, false, false);
       qi->qf_bufnr = INVALID_QFBUFNR;
     }
   }
@@ -5843,7 +5843,7 @@ static void wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
 static void unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
 {
   if (curbuf != buf) {          // safety check
-    close_buffer(NULL, buf, DOBUF_UNLOAD, false);
+    close_buffer(NULL, buf, DOBUF_UNLOAD, false, true);
 
     // When autocommands/'autochdir' option changed directory: go back.
     restore_start_dir(dirname_start);

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -316,6 +316,23 @@ func Test_WinClosed_throws()
   augroup! test-WinClosed
 endfunc
 
+func Test_WinClosed_throws_with_tabs()
+  tabnew
+  let bnr = bufnr()
+  call assert_equal(1, bufloaded(bnr))
+  augroup test-WinClosed
+    autocmd WinClosed * throw 'foo'
+  augroup END
+  try
+    close
+  catch /.*/
+  endtry
+  call assert_equal(0, bufloaded(bnr))
+
+  autocmd! test-WinClosed
+  augroup! test-WinClosed
+endfunc
+
 func s:AddAnAutocmd()
   augroup vimBarTest
     au BufReadCmd * echo 'hello'

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -299,6 +299,23 @@ func Test_WinClosed()
   unlet g:triggered
 endfunc
 
+func Test_WinClosed_throws()
+  vnew
+  let bnr = bufnr()
+  call assert_equal(1, bufloaded(bnr))
+  augroup test-WinClosed
+    autocmd WinClosed * throw 'foo'
+  augroup END
+  try
+    close
+  catch /.*/
+  endtry
+  call assert_equal(0, bufloaded(bnr))
+
+  autocmd! test-WinClosed
+  augroup! test-WinClosed
+endfunc
+
 func s:AddAnAutocmd()
   augroup vimBarTest
     au BufReadCmd * echo 'hello'

--- a/src/nvim/testdir/test_trycatch.vim
+++ b/src/nvim/testdir/test_trycatch.vim
@@ -1972,6 +1972,29 @@ func Test_builtin_func_error()
   call assert_equal('jlmnpqrtueghivyzACD', g:Xpath)
 endfunc
 
-" Modelines								    {{{1
+func Test_reload_in_try_catch()
+  call writefile(['x'], 'Xreload')
+  set autoread
+  edit Xreload
+  tabnew
+  call writefile(['xx'], 'Xreload')
+  augroup ReLoad
+    au FileReadPost Xreload let x = doesnotexist
+    au BufReadPost Xreload let x = doesnotexist
+  augroup END
+  try
+    edit Xreload
+  catch
+  endtry
+  tabnew
+
+  tabclose
+  tabclose
+  autocmd! ReLoad
+  set noautoread
+  bwipe! Xreload
+  call delete('Xreload')
+endfunc
+
+" Modeline								    {{{1
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker
-"-------------------------------------------------------------------------------

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2563,7 +2563,7 @@ static void win_close_buffer(win_T *win, bool free_buf, bool abort_if_last)
     bufref_T bufref;
     set_bufref(&bufref, curbuf);
     win->w_closing = true;
-    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, abort_if_last, false);
+    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, abort_if_last, true);
     if (win_valid_any_tab(win)) {
       win->w_closing = false;
     }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2885,7 +2885,7 @@ void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
 
   if (win->w_buffer != NULL) {
     // Close the link to the buffer.
-    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, false, false);
+    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, false, true);
   }
 
   // Careful: Autocommands may have closed the tab page or made it the

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2563,7 +2563,7 @@ static void win_close_buffer(win_T *win, bool free_buf, bool abort_if_last)
     bufref_T bufref;
     set_bufref(&bufref, curbuf);
     win->w_closing = true;
-    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, abort_if_last);
+    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, abort_if_last, false);
     if (win_valid_any_tab(win)) {
       win->w_closing = false;
     }
@@ -2885,7 +2885,7 @@ void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
 
   if (win->w_buffer != NULL) {
     // Close the link to the buffer.
-    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, false);
+    close_buffer(win, win->w_buffer, free_buf ? DOBUF_UNLOAD : 0, false, false);
   }
 
   // Careful: Autocommands may have closed the tab page or made it the

--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -17,8 +17,8 @@ describe('buffer functions', function()
     return buffer.buflist_new(c_file, c_file, 1, flags)
   end
 
-  local close_buffer = function(win, buf, action, abort_if_last)
-    return buffer.close_buffer(win, buf, action, abort_if_last)
+  local close_buffer = function(win, buf, action, abort_if_last, ignore_abort)
+    return buffer.close_buffer(win, buf, action, abort_if_last, ignore_abort)
   end
 
   local path1 = 'test_file_path'
@@ -53,7 +53,7 @@ describe('buffer functions', function()
     itp('should view a closed and hidden buffer as valid', function()
       local buf = buflist_new(path1, buffer.BLN_LISTED)
 
-      close_buffer(NULL, buf, 0, 0)
+      close_buffer(NULL, buf, 0, 0, 0)
 
       eq(true, buffer.buf_valid(buf))
     end)
@@ -61,7 +61,7 @@ describe('buffer functions', function()
     itp('should view a closed and unloaded buffer as valid', function()
       local buf = buflist_new(path1, buffer.BLN_LISTED)
 
-      close_buffer(NULL, buf, buffer.DOBUF_UNLOAD, 0)
+      close_buffer(NULL, buf, buffer.DOBUF_UNLOAD, 0, 0)
 
       eq(true, buffer.buf_valid(buf))
     end)
@@ -69,7 +69,7 @@ describe('buffer functions', function()
     itp('should view a closed and wiped buffer as invalid', function()
       local buf = buflist_new(path1, buffer.BLN_LISTED)
 
-      close_buffer(NULL, buf, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf, buffer.DOBUF_WIPE, 0, 0)
 
       eq(false, buffer.buf_valid(buf))
     end)
@@ -90,7 +90,7 @@ describe('buffer functions', function()
 
       eq(buf.handle, buflist_findpat(path1, ONLY_LISTED))
 
-      close_buffer(NULL, buf, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf, buffer.DOBUF_WIPE, 0, 0)
     end)
 
     itp('should prefer to match the start of a file path', function()
@@ -102,9 +102,9 @@ describe('buffer functions', function()
       eq(buf2.handle, buflist_findpat("file", ONLY_LISTED))
       eq(buf3.handle, buflist_findpat("path", ONLY_LISTED))
 
-      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0)
-      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0)
-      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0, 0)
+      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0, 0)
+      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0, 0)
     end)
 
     itp('should prefer to match the end of a file over the middle', function()
@@ -118,7 +118,7 @@ describe('buffer functions', function()
       --}
 
       --{ When: We close buf2
-      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0, 0)
 
       -- And: Open buf1, which has 'file' in the middle of its name
       local buf1 = buflist_new(path1, buffer.BLN_LISTED)
@@ -127,8 +127,8 @@ describe('buffer functions', function()
       eq(buf3.handle, buflist_findpat("file", ONLY_LISTED))
       --}
 
-      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0)
-      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0, 0)
+      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0, 0)
     end)
 
     itp('should match a unique fragment of a file path', function()
@@ -138,9 +138,9 @@ describe('buffer functions', function()
 
       eq(buf3.handle, buflist_findpat("_test_", ONLY_LISTED))
 
-      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0)
-      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0)
-      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0, 0)
+      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0, 0)
+      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0, 0)
     end)
 
     itp('should include / ignore unlisted buffers based on the flag.', function()
@@ -152,7 +152,7 @@ describe('buffer functions', function()
       --}
 
       --{ When: We unlist the buffer
-      close_buffer(NULL, buf3, buffer.DOBUF_DEL, 0)
+      close_buffer(NULL, buf3, buffer.DOBUF_DEL, 0, 0)
 
       -- Then: It should not find the buffer when searching only listed buffers
       eq(-1, buflist_findpat("_test_", ONLY_LISTED))
@@ -162,7 +162,7 @@ describe('buffer functions', function()
       --}
 
       --{ When: We wipe the buffer
-      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf3, buffer.DOBUF_WIPE, 0, 0)
 
       -- Then: It should not find the buffer at all
       eq(-1, buflist_findpat("_test_", ONLY_LISTED))
@@ -180,7 +180,7 @@ describe('buffer functions', function()
       --}
 
       --{ When: The first buffer is unlisted
-      close_buffer(NULL, buf1, buffer.DOBUF_DEL, 0)
+      close_buffer(NULL, buf1, buffer.DOBUF_DEL, 0, 0)
 
       -- Then: The second buffer is preferred because
       --       unlisted buffers are not allowed
@@ -194,7 +194,7 @@ describe('buffer functions', function()
       --}
 
       --{ When: We unlist the second buffer
-      close_buffer(NULL, buf2, buffer.DOBUF_DEL, 0)
+      close_buffer(NULL, buf2, buffer.DOBUF_DEL, 0, 0)
 
       -- Then: The first buffer is preferred again
       --       because buf1 matches better which takes precedence
@@ -205,8 +205,8 @@ describe('buffer functions', function()
       eq(-1, buflist_findpat("test", ONLY_LISTED))
       --}
 
-      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0)
-      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0)
+      close_buffer(NULL, buf1, buffer.DOBUF_WIPE, 0, 0)
+      close_buffer(NULL, buf2, buffer.DOBUF_WIPE, 0, 0)
     end)
   end)
 


### PR DESCRIPTION
Fix #17970

#### vim-patch:8.2.0004: get E685 and E931 if buffer reload is interrupted

Problem:    Get E685 and E931 if buffer reload is interrupted.
Solution:   Do not abort deleting a dummy buffer.
https://github.com/vim/vim/commit/a6e8f888e7fc31b8ab7233509254fb2e2fe4089f


#### vim-patch:8.2.4700: buffer remains active if WinClosed event throws an exception

Problem:    Buffer remains active if a WinClosed event throws an exception.
Solution:   Ignore aborting() when closing the buffer.
https://github.com/vim/vim/commit/c947b9ae419114ebfef9725814ea41a466fcf879


#### vim-patch:8.2.4706: buffer remains active with WinClosed and tabpages

Problem:    Buffer remains active if a WinClosed event throws an exception
            when there are multiple tabpages.
Solution:   Ignore aborting() when closing the buffer. (closes vim/vim#10101)
https://github.com/vim/vim/commit/6a06940f8ae7283999c83ccdf268540220573105