### PR TITLE
vim-patch:8.2.4704: using "else" after return or break increases indent

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1015,27 +1015,27 @@ retry:
                 }
                 read_buf_col += n;
                 break;
-              } else {
-                // Append whole line and new-line.  Change NL
-                // to NUL to reverse the effect done below.
-                for (ni = 0; ni < n; ni++) {
-                  if (p[ni] == NL) {
-                    ptr[tlen++] = NUL;
-                  } else {
-                    ptr[tlen++] = p[ni];
-                  }
+              }
+
+              // Append whole line and new-line.  Change NL
+              // to NUL to reverse the effect done below.
+              for (ni = 0; ni < n; ni++) {
+                if (p[ni] == NL) {
+                  ptr[tlen++] = NUL;
+                } else {
+                  ptr[tlen++] = p[ni];
                 }
-                ptr[tlen++] = NL;
-                read_buf_col = 0;
-                if (++read_buf_lnum > from) {
-                  // When the last line didn't have an
-                  // end-of-line don't add it now either.
-                  if (!curbuf->b_p_eol) {
-                    --tlen;
-                  }
-                  size = tlen;
-                  break;
+              }
+              ptr[tlen++] = NL;
+              read_buf_col = 0;
+              if (++read_buf_lnum > from) {
+                // When the last line didn't have an
+                // end-of-line don't add it now either.
+                if (!curbuf->b_p_eol) {
+                  tlen--;
                 }
+                size = tlen;
+                break;
               }
             }
           }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5140,42 +5140,42 @@ char *set_option_value(const char *const name, const long number, const char *co
         s = "";
       }
       return set_string_option(opt_idx, s, opt_flags);
-    } else {
-      varp = get_varp_scope(&(options[opt_idx]), opt_flags);
-      if (varp != NULL) {       // hidden option is not changed
-        if (number == 0 && string != NULL) {
-          int idx;
+    }
 
-          // Either we are given a string or we are setting option
-          // to zero.
-          for (idx = 0; string[idx] == '0'; idx++) {}
-          if (string[idx] != NUL || idx == 0) {
-            // There's another character after zeros or the string
-            // is empty.  In both cases, we are trying to set a
-            // num option using a string.
-            semsg(_("E521: Number required: &%s = '%s'"),
-                  name, string);
-            return NULL;  // do nothing as we hit an error
-          }
+    varp = get_varp_scope(&(options[opt_idx]), opt_flags);
+    if (varp != NULL) {       // hidden option is not changed
+      if (number == 0 && string != NULL) {
+        int idx;
+
+        // Either we are given a string or we are setting option
+        // to zero.
+        for (idx = 0; string[idx] == '0'; idx++) {}
+        if (string[idx] != NUL || idx == 0) {
+          // There's another character after zeros or the string
+          // is empty.  In both cases, we are trying to set a
+          // num option using a string.
+          semsg(_("E521: Number required: &%s = '%s'"),
+                name, string);
+          return NULL;  // do nothing as we hit an error
         }
-        long numval = number;
-        if (opt_flags & OPT_CLEAR) {
-          if ((int *)varp == &curbuf->b_p_ar) {
-            numval = -1;
-          } else if ((long *)varp == &curbuf->b_p_ul) {
-            numval = NO_LOCAL_UNDOLEVEL;
-          } else if ((long *)varp == &curwin->w_p_so || (long *)varp == &curwin->w_p_siso) {
-            numval = -1;
-          } else {
-            char *s = NULL;
-            (void)get_option_value(name, &numval, (char_u **)&s, OPT_GLOBAL);
-          }
-        }
-        if (flags & P_NUM) {
-          return set_num_option(opt_idx, varp, numval, NULL, 0, opt_flags);
+      }
+      long numval = number;
+      if (opt_flags & OPT_CLEAR) {
+        if ((int *)varp == &curbuf->b_p_ar) {
+          numval = -1;
+        } else if ((long *)varp == &curbuf->b_p_ul) {
+          numval = NO_LOCAL_UNDOLEVEL;
+        } else if ((long *)varp == &curwin->w_p_so || (long *)varp == &curwin->w_p_siso) {
+          numval = -1;
         } else {
-          return set_bool_option(opt_idx, varp, (int)numval, opt_flags);
+          char *s = NULL;
+          (void)get_option_value(name, &numval, (char_u **)&s, OPT_GLOBAL);
         }
+      }
+      if (flags & P_NUM) {
+        return set_num_option(opt_idx, varp, numval, NULL, 0, opt_flags);
+      } else {
+        return set_bool_option(opt_idx, varp, (int)numval, opt_flags);
       }
     }
   }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2289,55 +2289,52 @@ static void check_state_ends(void)
         next_match_idx = 0;
         next_match_col = MAXCOL;
         break;
-      } else {
-        // handle next_list, unless at end of line and no "skipnl" or
-        // "skipempty"
-        current_next_list = cur_si->si_next_list;
-        current_next_flags = cur_si->si_flags;
-        if (!(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY))
-            && syn_getcurline()[current_col] == NUL) {
-          current_next_list = NULL;
-        }
+      }
 
-        // When the ended item has "extend", another item with
-        // "keepend" now needs to check for its end.
-        had_extend = (cur_si->si_flags & HL_EXTEND);
+      // handle next_list, unless at end of line and no "skipnl" or
+      // "skipempty"
+      current_next_list = cur_si->si_next_list;
+      current_next_flags = cur_si->si_flags;
+      if (!(current_next_flags & (HL_SKIPNL | HL_SKIPEMPTY))
+          && syn_getcurline()[current_col] == NUL) {
+        current_next_list = NULL;
+      }
 
-        pop_current_state();
+      // When the ended item has "extend", another item with
+      // "keepend" now needs to check for its end.
+      had_extend = (cur_si->si_flags & HL_EXTEND);
 
+      pop_current_state();
+
+      if (GA_EMPTY(&current_state)) {
+        break;
+      }
+
+      if (had_extend && keepend_level >= 0) {
+        syn_update_ends(false);
         if (GA_EMPTY(&current_state)) {
           break;
         }
+      }
 
-        if (had_extend && keepend_level >= 0) {
-          syn_update_ends(false);
-          if (GA_EMPTY(&current_state)) {
-            break;
-          }
-        }
+      cur_si = &CUR_STATE(current_state.ga_len - 1);
 
-        cur_si = &CUR_STATE(current_state.ga_len - 1);
-
-        /*
-         * Only for a region the search for the end continues after
-         * the end of the contained item.  If the contained match
-         * included the end-of-line, break here, the region continues.
-         * Don't do this when:
-         * - "keepend" is used for the contained item
-         * - not at the end of the line (could be end="x$"me=e-1).
-         * - "excludenl" is used (HL_HAS_EOL won't be set)
-         */
-        if (cur_si->si_idx >= 0
-            && SYN_ITEMS(syn_block)[cur_si->si_idx].sp_type
-            == SPTYPE_START
-            && !(cur_si->si_flags & (HL_MATCH | HL_KEEPEND))) {
-          update_si_end(cur_si, (int)current_col, true);
-          check_keepend();
-          if ((current_next_flags & HL_HAS_EOL)
-              && keepend_level < 0
-              && syn_getcurline()[current_col] == NUL) {
-            break;
-          }
+      // Only for a region the search for the end continues after
+      // the end of the contained item.  If the contained match
+      // included the end-of-line, break here, the region continues.
+      // Don't do this when:
+      // - "keepend" is used for the contained item
+      // - not at the end of the line (could be end="x$"me=e-1).
+      // - "excludenl" is used (HL_HAS_EOL won't be set)
+      if (cur_si->si_idx >= 0
+          && SYN_ITEMS(syn_block)[cur_si->si_idx].sp_type == SPTYPE_START
+          && !(cur_si->si_flags & (HL_MATCH | HL_KEEPEND))) {
+        update_si_end(cur_si, (int)current_col, true);
+        check_keepend();
+        if ((current_next_flags & HL_HAS_EOL)
+            && keepend_level < 0
+            && syn_getcurline()[current_col] == NUL) {
+          break;
         }
       }
     } else {


### PR DESCRIPTION
#### vim-patch:8.2.4704: using "else" after return or break increases indent

Problem:    Using "else" after return or break increases indent.
Solution:   Remove "else" and reduce indent. (Goc Dundar, closes vim/vim#10099)
https://github.com/vim/vim/commit/f26c16144ddb27642c09f2cf5271afd163b36306