### PR TITLE
vim-patch:8.2.4711: when 'insermode' is set :edit from <Cmd> mapping misbehaves

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2875,7 +2875,7 @@ int do_ecmd(int fnum, char_u *ffname, char_u *sfname, exarg_T *eap, linenr_T new
     redraw_curbuf_later(NOT_VALID);     // redraw this buffer later
   }
 
-  if (p_im) {
+  if (p_im && (State & INSERT) == 0) {
     need_start_insertmode = true;
   }
 

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1627,6 +1627,29 @@ func Test_edit_is_a_directory()
   call delete(dirname, 'rf')
 endfunc
 
+" Using :edit without leaving 'insertmode' should not cause Insert mode to be
+" re-entered immediately after <C-L>
+func Test_edit_insertmode_ex_edit()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set insertmode noruler
+    inoremap <C-B> <Cmd>edit Xfoo<CR>
+  END
+  call writefile(lines, 'Xtest_edit_insertmode_ex_edit')
+
+  let buf = RunVimInTerminal('-S Xtest_edit_insertmode_ex_edit', #{rows: 6})
+  call TermWait(buf, 50)
+  call assert_match('^-- INSERT --\s*$', term_getline(buf, 6))
+  call term_sendkeys(buf, "\<C-B>\<C-L>")
+  call TermWait(buf, 50)
+  call assert_notmatch('^-- INSERT --\s*$', term_getline(buf, 6))
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_edit_insertmode_ex_edit')
+endfunc
+
 func Test_edit_browse()
   " in the GUI this opens a file picker, we only test the terminal behavior
   CheckNotGui

--- a/test/functional/editor/mode_insert_spec.lua
+++ b/test/functional/editor/mode_insert_spec.lua
@@ -6,6 +6,8 @@ local expect = helpers.expect
 local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
+local meths = helpers.meths
+local poke_eventloop = helpers.poke_eventloop
 
 describe('insert-mode', function()
   before_each(function()
@@ -126,6 +128,28 @@ describe('insert-mode', function()
       expect('<M-x><D-x><M-X><D-X>')
       feed('cc<C-V><M-1><C-V><D-2><C-V><M-7><C-V><D-8><Esc>')
       expect('<M-1><D-2><M-7><D-8>')
+    end)
+  end)
+
+  describe([[With 'insertmode', Insert mode is not re-entered immediately after <C-L>]], function()
+    before_each(function()
+      command('set insertmode')
+      poke_eventloop()
+      eq({mode = 'i', blocking = false}, meths.get_mode())
+    end)
+
+    it('after calling :edit from <Cmd> mapping', function()
+      command('inoremap <C-B> <Cmd>edit Xfoo<CR>')
+      feed('<C-B><C-L>')
+      poke_eventloop()
+      eq({mode = 'n', blocking = false}, meths.get_mode())
+    end)
+
+    it('after calling :edit from RPC #16823', function()
+      command('edit Xfoo')
+      feed('<C-L>')
+      poke_eventloop()
+      eq({mode = 'n', blocking = false}, meths.get_mode())
     end)
   end)
 end)


### PR DESCRIPTION
Fix #16823

#### vim-patch:8.2.4711: when 'insermode' is set :edit from <Cmd> mapping misbehaves

Problem:    When 'insermode' is set :edit from <Cmd> mapping misbehaves.
Solution:   Don't set "need_start_insertmode" when already in Insert mode.
            (closes vim/vim#10116)
https://github.com/vim/vim/commit/3a56b6d405fc0f1ca928b77382f97d0c552bea64