### PR TITLE
fix(lsp): unify progress message handling

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -33,7 +33,7 @@ local function progress_handler(_, result, ctx, _)
   local val = result.value    -- unspecified yet
   local token = result.token  -- string or number
 
-
+  if type(val) ~= 'table' then val = { content=val } end
   if val.kind then
     if val.kind == 'begin' then
       client.messages.progress[token] = {
@@ -53,7 +53,8 @@ local function progress_handler(_, result, ctx, _)
       end
     end
   else
-    table.insert(client.messages, {content = val, show_once = true, shown = 0})
+    client.messages.progress[token] = val
+    client.messages.progress[token].done = true
   end
 
   vim.api.nvim_command("doautocmd <nomodeline> User LspProgressUpdate")

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -302,7 +302,6 @@ end
 function M.get_progress_messages()
 
   local new_messages = {}
-  local msg_remove = {}
   local progress_remove = {}
 
   for _, client in ipairs(vim.lsp.get_active_clients()) do
@@ -324,29 +323,6 @@ function M.get_progress_messages()
           table.insert(progress_remove, {client = client, token = token})
         end
       end
-
-      for i, msg in ipairs(data.messages) do
-        if msg.show_once then
-          msg.shown = msg.shown + 1
-          if msg.shown > 1 then
-            table.insert(msg_remove, {client = client, idx = i})
-          end
-        end
-
-        table.insert(new_messages, {name = data.name, content = msg.content})
-      end
-
-      if next(data.status) ~= nil then
-        table.insert(new_messages, {
-          name = data.name,
-          content = data.status.content,
-          uri = data.status.uri,
-          status = true
-        })
-      end
-    for _, item in ipairs(msg_remove) do
-      table.remove(client.messages, item.idx)
-    end
 
   end
 


### PR DESCRIPTION
The LSP progress handler would put non-progress messages (such as from clangd or pyls; not part of the LSP spec) directly into `client.messages`, while `vim.lsp.util.get_progress_messages()` would try to fetch them from `client.messages.messages` instead (and come up empty everytime). This would result in these messages never being cleaned up by `get_progress_messages()`.

This commit fixes that by treating those messages like show-once progress messages (by setting `done=true` immediately).