### PR TITLE
vim-patch:partial:cbaff5e06ec5

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1517,8 +1517,10 @@ deepcopy({expr} [, {noref}])				*deepcopy()* *E698*
 
 delete({fname} [, {flags}])				*delete()*
 		Without {flags} or with {flags} empty: Deletes the file by the
-		name {fname}.  This also works when {fname} is a symbolic link.
-		A symbolic link itself is deleted, not what it points to.
+		name {fname}.
+
+		This also works when {fname} is a symbolic link.  The symbolic
+		link itself is deleted, not what it points to.
 
 		When {flags} is "d": Deletes the directory by the name
 		{fname}.  This fails when directory {fname} is not empty.
@@ -5376,8 +5378,10 @@ printf({fmt}, {expr1} ...)				*printf()*
 		When used as a |method| the base is passed as the second
 		argument: >
 			Compute()->printf("result: %d")
+<
+		You can use `call()` to pass the items as a list.
 
-<		Often used items are:
+		Often used items are:
 		  %s	string
 		  %6S	string right-aligned in 6 display cells
 		  %6s	string right-aligned in 6 bytes

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -196,7 +196,7 @@ position in the sequence.
 
 List creation ~
 							*E696* *E697*
-A List is created with a comma separated list of items in square brackets.
+A List is created with a comma-separated list of items in square brackets.
 Examples: >
 	:let mylist = [1, two, 3, "four"]
 	:let emptylist = []
@@ -446,7 +446,7 @@ ordering.
 
 Dictionary creation ~
 						*E720* *E721* *E722* *E723*
-A Dictionary is created with a comma separated list of entries in curly
+A Dictionary is created with a comma-separated list of entries in curly
 braces.  Each entry has a key and a value, separated by a colon.  Each key can
 only appear once.  Examples: >
 	:let mydict = {1: 'one', 2: 'two', 3: 'three'}

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -555,7 +555,7 @@ the SQL completion plugin. >
 <	1. After typing SELECT press <C-C>t to display a list of tables.
 	2. Highlight the table you need the column list for.
 	3. Press <Enter> to choose the table from the list.
-	4. Press <C-C>l to request a comma separated list of all columns
+	4. Press <C-C>l to request a comma-separated list of all columns
 	   for this table.
 	5. Based on the table name chosen in step 3, the plugin attempts to
 	   decide on a reasonable table alias.	You are then prompted to
@@ -609,7 +609,7 @@ your |init.vim|: >
 >
     omni_sql_use_tbl_alias
 <	- Default: a
-	- This setting is only used when generating a comma separated
+	- This setting is only used when generating a comma-separated
 	  column list.	By default the map is <C-C>l.  When generating
 	  a column list, an alias can be prepended to the beginning of each
 	  column, for example:	e.emp_id, e.emp_name.  This option has three
@@ -693,9 +693,9 @@ plugin. >
     <C-C>c
 <       - Displays a list of columns for a specific table. >
     <C-C>l
-<       - Displays a comma separated list of columns for a specific table. >
+<       - Displays a comma-separated list of columns for a specific table. >
     <C-C>L
-<       - Displays a comma separated list of columns for a specific table.
+<       - Displays a comma-separated list of columns for a specific table.
 	  This should only be used when the completion window is active. >
     <Right>
 <	- Displays a list of columns for the table currently highlighted in

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -258,7 +258,7 @@ CTRL-]		Trigger abbreviation, without inserting a character.
 
 						*i_backspacing*
 The effect of the <BS>, CTRL-W, and CTRL-U depend on the 'backspace' option
-(unless 'revins' is set).  This is a comma separated list of items:
+(unless 'revins' is set).  This is a comma-separated list of items:
 
 item	    action ~
 indent	    allow backspacing over autoindent

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -120,7 +120,7 @@ Vim would never have become what it is now, without the help of these people!
 	Daniel Elstner		GTK+ 2 port
 	Eric Fischer		Mac port, 'cindent', and other improvements
 	Benji Fisher		Answering lots of user questions
-	Bill Foster		Athena GUI port
+	Bill Foster		Athena GUI port (later removed)
 	Google			Lets me work on Vim one day a week
 	Loic Grenie		xvim (ideas for multi windows version)
 	Sven Guckes		Vim promoter and previous WWW page maintainer

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -69,7 +69,7 @@ achieve special effects.  These options come in three forms:
 :se[t] {option}+={value}				*:set+=*
 			Add the {value} to a number option, or append the
 			{value} to a string option.  When the option is a
-			comma separated list, a comma is added, unless the
+			comma-separated list, a comma is added, unless the
 			value was empty.
 			If the option is a list of flags, superfluous flags
 			are removed.  When adding a flag that was already
@@ -79,7 +79,7 @@ achieve special effects.  These options come in three forms:
 :se[t] {option}^={value}				*:set^=*
 			Multiply the {value} to a number option, or prepend
 			the {value} to a string option.  When the option is a
-			comma separated list, a comma is added, unless the
+			comma-separated list, a comma is added, unless the
 			value was empty.
 			Also see |:set-args| above.
 
@@ -87,7 +87,7 @@ achieve special effects.  These options come in three forms:
 			Subtract the {value} from a number option, or remove
 			the {value} from a string option, if it is there.
 			If the {value} is not found in a string option, there
-			is no error or warning.  When the option is a comma
+			is no error or warning.  When the option is a comma-
 			separated list, a comma is deleted, unless the option
 			becomes empty.
 			When the option is a list of flags, {value} must be
@@ -779,7 +779,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'backupcopy' 'bkc'	string	(Vi default for Unix: "yes", otherwise: "auto")
 			global or local to buffer |global-local|
 	When writing a file and a backup is made, this option tells how it's
-	done.  This is a comma separated list of words.
+	done.  This is a comma-separated list of words.
 
 	The main values are:
 	"yes"	make a copy of the file and overwrite the original one
@@ -803,10 +803,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  file.
 	- When the file is a link the new file will not be a link.
 
-	The "auto" value is the middle way: When Vim sees that renaming file
-	is possible without side effects (the attributes can be passed on and
-	the file is not a link) that is used.  When problems are expected, a
-	copy will be made.
+	The "auto" value is the middle way: When Vim sees that renaming the
+	file is possible without side effects (the attributes can be passed on
+	and the file is not a link) that is used.  When problems are expected,
+	a copy will be made.
 
 	The "breaksymlink" and "breakhardlink" values can be used in
 	combination with any of "yes", "no" and "auto".  When included, they
@@ -825,13 +825,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	When a copy is made, the original file is truncated and then filled
 	with the new text.  This means that protection bits, owner and
-	symbolic links of the original file are unmodified.  The backup file
+	symbolic links of the original file are unmodified.  The backup file,
 	however, is a new file, owned by the user who edited the file.  The
 	group of the backup is set to the group of the original file.  If this
 	fails, the protection bits for the group are made the same as for
 	others.
 
-	When the file is renamed this is the other way around: The backup has
+	When the file is renamed, this is the other way around: The backup has
 	the same attributes of the original file, and the newly written file
 	is owned by the current user.  When the file was a (hard/symbolic)
 	link, the new file will not!  That's why the "auto" value doesn't
@@ -893,7 +893,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	accidentally overwriting existing files with a backup file.  You might
 	prefer using ".bak", but make sure that you don't have files with
 	".bak" that you want to keep.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only normal file name characters can be used; "/\*?[|<>" are illegal.
 
 	If you like to keep a lot of backups, you could use a BufWritePre
 	autocommand to change 'backupext' just before writing the file to
@@ -939,7 +939,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'belloff'* *'bo'*
 'belloff' 'bo'		string	(default "all")
 			global
-	Specifies for which events the bell will not be rung. It is a comma
+	Specifies for which events the bell will not be rung. It is a comma-
 	separated list of items. For each item that is present, the bell
 	will be silenced. This is most useful to specify specific events in
 	insert mode to be silenced.
@@ -1077,16 +1077,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option specifies what happens when a buffer is no longer
 	displayed in a window:
 	  <empty>	follow the global 'hidden' option
-	  hide		hide the buffer (don't unload it), also when 'hidden'
-			is not set
-	  unload	unload the buffer, also when 'hidden' is set or using
-			|:hide|
-	  delete	delete the buffer from the buffer list, also when
-			'hidden' is set or using |:hide|, like using
-			|:bdelete|
-	  wipe		wipe out the buffer from the buffer list, also when
-			'hidden' is set or using |:hide|, like using
-			|:bwipeout|
+	  hide		hide the buffer (don't unload it), even if 'hidden' is
+			not set
+	  unload	unload the buffer, even if 'hidden' is set; the
+			|:hide| command will also unload the buffer
+	  delete	delete the buffer from the buffer list, even if
+			'hidden' is set; the |:hide| command will also delete
+			the buffer, making it behave like |:bdelete|
+	  wipe		wipe the buffer from the buffer list, even if
+			'hidden' is set; the |:hide| command will also wipe
+			out the buffer, making it behave like |:bwipeout|
 
 	CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
 	are lost without a warning.  Also, these values may break autocommands
@@ -1291,7 +1291,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'clipboard'* *'cb'*
 'clipboard' 'cb'	string	(default "")
 			global
-	This option is a list of comma separated names.
+	This option is a list of comma-separated names.
 	These names are recognized:
 
 						*clipboard-unnamed*
@@ -1330,7 +1330,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'colorcolumn'* *'cc'*
 'colorcolumn' 'cc'	string	(default "")
 			local to window
-	'colorcolumn' is a comma separated list of screen columns that are
+	'colorcolumn' is a comma-separated list of screen columns that are
 	highlighted with ColorColumn |hl-ColorColumn|.  Useful to align
 	text.  Will make screen redrawing slower.
 	The screen column can be an absolute number, or a number preceded with
@@ -1363,7 +1363,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'comments' 'com'	string	(default
 				"s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-")
 			local to buffer
-	A comma separated list of strings that can start a comment line.  See
+	A comma-separated list of strings that can start a comment line.  See
 	|format-comments|.  See |option-backslash| about using backslashes to
 	insert a space.
 
@@ -1380,7 +1380,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option specifies how keyword completion |ins-completion| works
 	when CTRL-P or CTRL-N are used.  It is also used for whole-line
 	completion |i_CTRL-X_CTRL-L|.  It indicates the type of completion
-	and the places to scan.  It is a comma separated list of flags:
+	and the places to scan.  It is a comma-separated list of flags:
 	.	scan the current buffer ('wrapscan' is ignored)
 	w	scan buffers from other windows
 	b	scan other loaded buffers that are in the buffer list
@@ -1437,7 +1437,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'completeopt'* *'cot'*
 'completeopt' 'cot'	string	(default: "menu,preview")
 			global
-	A comma separated list of options for Insert mode completion
+	A comma-separated list of options for Insert mode completion
 	|ins-completion|.  The supported values are:
 
 	   menu	    Use a popup menu to show the possible completions.  The
@@ -1842,7 +1842,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cursorlineopt'* *'culopt'*
 'cursorlineopt' 'culopt' string (default: "number,line")
 			local to window
-	Comma separated list of settings for how 'cursorline' is displayed.
+	Comma-separated list of settings for how 'cursorline' is displayed.
 	Valid values:
 	"line"		Highlight the text line of the cursor with
 			CursorLine |hl-CursorLine|.
@@ -2107,7 +2107,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'display'* *'dy'*
 'display' 'dy'		string	(default "lastline,msgsep", Vi default: "")
 			global
-	Change the way text is displayed.  This is comma separated list of
+	Change the way text is displayed.  This is comma-separated list of
 	flags:
 	lastline	When included, as much as possible of the last line
 			in a window will be displayed.  "@@@" is put in the
@@ -2225,7 +2225,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	A list of autocommand event names, which are to be ignored.
 	When set to "all" or when "all" is one of the items, all autocommand
 	events are ignored, autocommands will not be executed.
-	Otherwise this is a comma separated list of event names.  Example: >
+	Otherwise this is a comma-separated list of event names.  Example: >
 	    :set ei=WinEnter,WinLeave
 <
 				 *'expandtab'* *'et'* *'noexpandtab'* *'noet'*
@@ -2437,7 +2437,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'fillchars' 'fcs'	string	(default "")
 			global or local to window |global-local|
 	Characters to fill the statuslines and vertical separators.
-	It is a comma separated list of items:
+	It is a comma-separated list of items:
 
 	  item		default		Used for ~
 	  stl:c		' ' or '^'	statusline of the current window
@@ -2618,7 +2618,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 							     search,tag,undo")
 			global
 	Specifies for which type of commands folds will be opened, if the
-	command moves the cursor into a closed fold.  It is a comma separated
+	command moves the cursor into a closed fold.  It is a comma-separated
 	list of items.
 	NOTE: When the command is part of a mapping this option is not used.
 	Add the |zv| command to the mapping to get the same effect.
@@ -2809,7 +2809,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
 		  \,sm:block-blinkwait175-blinkoff150-blinkon175
 
-<	The option is a comma separated list of parts.  Each part consists of a
+<	The option is a comma-separated list of parts.  Each part consists of a
 	mode-list and an argument-list:
 		mode-list:argument-list,mode-list:argument-list,..
 	The mode-list is a dash separated list of these modes:
@@ -3109,7 +3109,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'helplang'* *'hlg'*
 'helplang' 'hlg'	string	(default: messages language or empty)
 			global
-	Comma separated list of languages.  Vim will use the first language
+	Comma-separated list of languages.  Vim will use the first language
 	for which the desired help can be found.  The English help will always
 	be used as a last resort.  You can add "en" to prefer English over
 	another language, but that will only find tags that exist in that
@@ -3129,10 +3129,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	when it is |abandon|ed.  When on a buffer becomes hidden when it is
 	|abandon|ed.  A buffer displayed in another window does not become
 	hidden, of course.
+
 	Commands that move through the buffer list sometimes hide a buffer
-	although the 'hidden' option is off: when the buffer is modified,
-	'autowrite' is off or writing is not possible, and the '!' flag was
-	used.  See also |windows|.
+	although the 'hidden' option is off when these three are true:
+	- the buffer is modified
+	- 'autowrite' is off or writing is not possible
+	- the '!' flag was used
+	Also see |windows|.
+
 	To hide a specific buffer use the 'bufhidden' option.
 	'hidden' is set for one command with ":hide {command}" |:hide|.
 
@@ -3563,7 +3567,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'keymodel'* *'km'*
 'keymodel' 'km'		string	(default "")
 			global
-	List of comma separated words, which enable special things that keys
+	List of comma-separated words, which enable special things that keys
 	can do.  These values can be used:
 	   startsel	Using a shifted special key starts selection (either
 			Select mode or Visual mode, depending on "key" being
@@ -3738,7 +3742,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'lispwords'* *'lw'*
 'lispwords' 'lw'	string	(default is very long)
 			global or local to buffer |global-local|
-	Comma separated list of words that influence the Lisp indenting.
+	Comma-separated list of words that influence the Lisp indenting.
 	|'lisp'|
 
 						*'list'* *'nolist'*
@@ -3763,7 +3767,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 Vi default: "eol:$")
 			global or local to window |global-local|
 	Strings to use in 'list' mode and for the |:list| command.  It is a
-	comma separated list of string settings.
+	comma-separated list of string settings.
 
 							*lcs-eol*
 	  eol:c		Character to show at the end of each line.  When
@@ -4220,7 +4224,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					m:no,ml:up-arrow,v:rightup-arrow")
 			global
 	This option tells Vim what the mouse pointer should look like in
-	different modes.  The option is a comma separated list of parts, much
+	different modes.  The option is a comma-separated list of parts, much
 	like used for 'guicursor'.  Each part consist of a mode/location-list
 	and an argument-list:
 		mode-list:shape,mode-list:shape,..
@@ -5091,7 +5095,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'selectmode'* *'slm'*
 'selectmode' 'slm'	string	(default "")
 			global
-	This is a comma separated list of words, which specifies when to start
+	This is a comma-separated list of words, which specifies when to start
 	Select mode instead of Visual mode, when a selection is started.
 	Possible values:
 	   mouse	when using the mouse
@@ -5106,7 +5110,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 Vi default: "blank,buffers,curdir,folds,
 					       help,options,tabpages,winsize")
 			global
-	Changes the effect of the |:mksession| command.  It is a comma
+	Changes the effect of the |:mksession| command.  It is a comma-
 	separated list of words.  Each word enables saving and restoring
 	something:
 	   word		save and restore ~
@@ -5150,7 +5154,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 Vi default: "")
 			global
 	When non-empty, the shada file is read upon startup and written
-	when exiting Vim (see |shada-file|).  The string should be a comma
+	when exiting Vim (see |shada-file|).  The string should be a comma-
 	separated list of parameters, each consisting of a single character
 	identifying the particular parameter, followed by a number or string
 	which specifies the value of that parameter.  If a particular
@@ -5769,7 +5773,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	commands.  It must end in ".{encoding}.add".  You need to include the
 	path, otherwise the file is placed in the current directory.
 								*E765*
-	It may also be a comma separated list of names.  A count before the
+	It may also be a comma-separated list of names.  A count before the
 	|zg| and |zw| commands can be used to access each.  This allows using
 	a personal word list file and a project word list file.
 	When a word is added while this option is empty Vim will set it for
@@ -5789,7 +5793,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'spelllang'* *'spl'*
 'spelllang' 'spl'	string	(default "en")
 			local to buffer
-	A comma separated list of word list names.  When the 'spell' option is
+	A comma-separated list of word list names.  When the 'spell' option is
 	on spellchecking will be done for these languages.  Example: >
 		set spelllang=en_us,nl,medical
 <	This means US English, Dutch and medical words are recognized.  Words
@@ -5829,7 +5833,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'spelloptions'* *'spo'*
 'spelloptions' 'spo'	string	(default "")
 			local to buffer
-	A comma separated list of options for spell checking:
+	A comma-separated list of options for spell checking:
 	   camel	When a word is CamelCased, assume "Cased" is a
 			separate word: every upper-case character in a word
 			that comes after a lower case character indicates the
@@ -6149,7 +6153,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'suffixesadd'* *'sua'*
 'suffixesadd' 'sua'	string	(default "")
 			local to buffer
-	Comma separated list of suffixes, which are used when searching for a
+	Comma-separated list of suffixes, which are used when searching for a
 	file for the "gf", "[I", etc. commands.  Example: >
 		:set suffixesadd=.java
 <
@@ -6181,7 +6185,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option controls the behavior when switching between buffers.
 	Mostly for |quickfix| commands some values are also used for other
  	commands, as mentioned below.
-	Possible values (comma separated list):
+	Possible values (comma-separated list):
 	   useopen	If included, jump to the first open window that
 			contains the specified buffer (if there is one).
 			Otherwise: Do not examine other windows.
@@ -6439,7 +6443,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'termpastefilter'* *'tpf'*
 'termpastefilter' 'tpf'	string	(default: "BS,HT,ESC,DEL")
 			global
-	A comma separated list of options for specifying control characters
+	A comma-separated list of options for specifying control characters
 	to be removed from the text pasted into the terminal window. The
 	supported values are:
 
@@ -6779,7 +6783,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'viewoptions'* *'vop'*
 'viewoptions' 'vop'	string	(default: "folds,cursor,curdir")
 			global
-	Changes the effect of the |:mkview| command.  It is a comma separated
+	Changes the effect of the |:mkview| command.  It is a comma-separated
 	list of words.  Each word enables saving and restoring something:
 	   word		save and restore ~
 	   cursor	cursor position in file and in window
@@ -6795,7 +6799,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					    *'virtualedit'* *'ve'*
 'virtualedit' 've'	string	(default "")
 			global or local to window |global-local|
-	A comma separated list of these words:
+	A comma-separated list of these words:
 	    block	Allow virtual editing in Visual block mode.
 	    insert	Allow virtual editing in Insert mode.
 	    all		Allow virtual editing in all modes.
@@ -6952,7 +6956,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'wildmode' 'wim'	string	(default: "full")
 			global
 	Completion mode that is used for the character specified with
-	'wildchar'.  It is a comma separated list of up to four parts.  Each
+	'wildchar'.  It is a comma-separated list of up to four parts.  Each
 	part specifies what to do for each consecutive use of 'wildchar'.  The
 	first part specifies the behavior for the first use of 'wildchar',
 	The second part for the second use, etc.

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -2814,7 +2814,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				= 2: wide listing (multiple files in columns)
 				= 3: tree style listing
 
-  *g:netrw_list_hide*		comma separated pattern list for hiding files
+  *g:netrw_list_hide*		comma-separated pattern list for hiding files
 				Patterns are regular expressions (see |regexp|)
 				There's some special support for git-ignore
 				files: you may add the output from the helper

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4830,6 +4830,7 @@ in their own color.
 :hi[ghlight] {group-name}
 			List one highlight group.
 
+						*highlight-clear* *:hi-clear*
 :hi[ghlight] clear	Reset all highlighting to the defaults.  Removes all
 			highlighting for groups added by the user!
 			Uses the current value of 'background' to decide which
@@ -4889,7 +4890,7 @@ the same syntax file on all UIs.
 					*inverse* *italic* *standout*
 					*nocombine* *strikethrough*
 cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
-	attr-list is a comma separated list (without spaces) of the
+	attr-list is a comma-separated list (without spaces) of the
 	following items (in any order):
 		bold
 		underline


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/cbaff5e06ec525d31dc44093125c42029e01d508

Docs only.

- Omit `json_encode` (different impl, Nvim throws E474 instead; see v8.2.4695).
- Skip `<MouseMove>`, `'mousemoveevent'` (Nvim *kinda* has `<MouseMove>`, but most of this doc needs v8.2.4674 anyway...).
- Nvim's `'hidden'` doc was reworded somewhat, so manually integrate the changes (https://github.com/neovim/neovim/commit/8331cd13c45fb75bff0cec328ccba79b3ae61fa5).
- Also apply "comma-separated" changes to all possible places in options.txt.
- Cherry-pick `*highlight-clear*` tag from v8.2.3578.