### PR TITLE
vim-patch:partial:8.1.2333: with modifyOtherKeys CTRL-^ doesn't work

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1590,11 +1590,19 @@ int vgetc(void)
         c = utf_ptr2char(buf);
       }
 
-      if ((mod_mask & MOD_MASK_CTRL) && (c >= '?' && c <= '_')) {
-        c = Ctrl_chr(c);
-        mod_mask &= ~MOD_MASK_CTRL;
-        if (c == 0) {  // <C-@> is <Nul>
-          c = K_ZERO;
+      // A modifier was not used for a mapping, apply it to ASCII
+      // keys.  Shift would already have been applied.
+      if (mod_mask & MOD_MASK_CTRL) {
+        if ((c >= '`' && c <= 0x7f) || (c >= '@' && c <= '_')) {
+          c &= 0x1f;
+          mod_mask &= ~MOD_MASK_CTRL;
+          if (c == 0) {
+            c = K_ZERO;
+          }
+        } else if (c == '6') {
+          // CTRL-6 is equivalent to CTRL-^
+          c = 0x1e;
+          mod_mask &= ~MOD_MASK_CTRL;
         }
       }
 

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -7,6 +7,7 @@ local curbuf_contents = helpers.curbuf_contents
 local meths = helpers.meths
 local exec_lua = helpers.exec_lua
 local write_file = helpers.write_file
+local funcs = helpers.funcs
 local Screen = require('test.functional.ui.screen')
 
 before_each(clear)
@@ -202,6 +203,13 @@ describe('input pairs', function()
       eq('dubbelHALLOJ!upp,dubbelHALLOJ!upp,', curbuf_contents())
     end)
   end)
+end)
+
+it('Ctrl-6 is Ctrl-^ vim-patch:8.1.2333', function()
+  command('split aaa')
+  command('edit bbb')
+  feed('<C-6>')
+  eq('aaa', funcs.bufname())
 end)
 
 describe('input non-printable chars', function()


### PR DESCRIPTION
Fix #18046

#### vim-patch:partial:8.1.2333: with modifyOtherKeys CTRL-^ doesn't work

Problem:    With modifyOtherKeys CTRL-^ doesn't work.
Solution:   Handle the exception.
https://github.com/vim/vim/commit/828ffd596394f714270a01a55fc3f949a8bd9b35