### PR TITLE
feat(QuitPre): allow aborting window closure with v:event.abort_close

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -250,6 +250,7 @@ static struct vimvar {
   VV(VV__NULL_DICT,       "_null_dict",       VAR_DICT, VV_RO),
   VV(VV__NULL_BLOB,       "_null_blob",       VAR_BLOB, VV_RO),
   VV(VV_LUA,              "lua",              VAR_PARTIAL, VV_RO),
+  VV(VV_EVENT_CANCEL,     "event_cancel",     VAR_BOOL, 0),
 };
 #undef VV
 
@@ -8213,6 +8214,12 @@ typval_T *get_vim_var_tv(int idx)
 varnumber_T get_vim_var_nr(int idx) FUNC_ATTR_PURE
 {
   return vimvars[idx].vv_nr;
+}
+
+/// Get bool v: variable value.
+BoolVarValue get_vim_var_bool(int idx) FUNC_ATTR_PURE
+{
+  return vimvars[idx].vv_bool;
 }
 
 /// Get string v: variable value.  Uses a static buffer, can only be used once.

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -172,6 +172,7 @@ typedef enum {
   VV__NULL_DICT,  // Dictionary with NULL value. For test purposes only.
   VV__NULL_BLOB,  // Blob with NULL value. For test purposes only.
   VV_LUA,
+  VV_EVENT_CANCEL
 } VimVarIndex;
 
 /// All recognized msgpack types

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6538,7 +6538,12 @@ void not_exiting(void)
 
 bool before_quit_autocmds(win_T *wp, bool quit_all, bool forceit)
 {
+  set_vim_var_bool(VV_EVENT_CANCEL, kBoolVarFalse);
   apply_autocmds(EVENT_QUITPRE, NULL, NULL, false, wp->w_buffer);
+
+  if (!forceit && get_vim_var_bool(VV_EVENT_CANCEL) == kBoolVarTrue) {
+    return true;
+  }
 
   // Bail out when autocommands closed the window.
   // Refuse to quit when the buffer in the last window is being closed (can


### PR DESCRIPTION
Adds a new entry to `v:event` `abort_close`, which allows an autocmd to choose to abort the closure of a window

I'm not really sure if this is a valid way for v:event to be used since it looks like most events use it for giving readonly info, except for `CmdlineLeave`'s `v:event.abort`? but that seems more like a special case... 

My use case for this is an autocmd that pre-quit checks if the alternate buffer is a terminal (i.e. after a `git commit` invokes `nvr --remote-wait`) and instead of closing the window swaps back to the terminal buffer. Which kind of mimics what would happen if you open neovim in the terminal emulator instead of using `--remote` 

<details>
<summary>example code</summary>

``` lua
local function buf_on_screen(in_bufnr)
	local windows = vim.fn.gettabinfo(vim.fn.tabpagenr())[1].windows
	for _, win_id in ipairs(windows) do
		local bufnr = vim.fn.getwininfo(win_id)[1].bufnr

		if in_bufnr == bufnr then
			return true
		end
	end
end

vim.api.nvim_create_autocmd('QuitPre', {
	pattern = '*',
	callback = function ()
		-- (crude?) check if the last buffer was a terminal
		local term_bufnr = vim.fn.bufnr '#'
		if term_bufnr == -1 or vim.api.nvim_buf_get_option(term_bufnr, 'buftype') ~= 'terminal' then
			return
		end

		-- I only need one view of a terminal on screen
		if buf_on_screen(term_bufnr) then
			return
		end

		-- for some reason this doesn't work?
		-- vim.v.event.abort_close = true

		vim.cmd 'let v:event.abort_close = v:true'
		vim.api.nvim_set_current_buf(term_bufnr)
	end
})

-- this will undo the effect of the autocmd above :/

-- vim.api.nvim_create_autocmd('QuitPre', {
-- 	pattern = '*',
-- 	callback = function ()
-- 		vim.cmd [[ let v:event.abort_close = v:false ]]
-- 	end
-- })

```

</details>