### PR TITLE
vim-patch:8.2.4715: Vagrantfile not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2049,6 +2049,9 @@ au BufNewFile,BufRead *.vala			setf vala
 " Vera
 au BufNewFile,BufRead *.vr,*.vri,*.vrh		setf vera
 
+" Vagrant (uses Ruby syntax)
+au BufNewFile,BufRead Vagrantfile		setf ruby
+
 " Verilog HDL
 au BufNewFile,BufRead *.v			setf verilog
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1061,6 +1061,7 @@ local filename = {
   Puppetfile = "ruby",
   [".irbrc"] = "ruby",
   irbrc = "ruby",
+  Vagrantfile = "ruby",
   ["smb.conf"] = "samba",
   screenrc = "screen",
   [".screenrc"] = "screen",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -455,7 +455,7 @@ let s:filename_checks = {
     \ 'rpl': ['file.rpl'],
     \ 'rst': ['file.rst'],
     \ 'rtf': ['file.rtf'],
-    \ 'ruby': ['.irbrc', 'irbrc', 'file.rb', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder', 'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file', 'Puppetfile'],
+    \ 'ruby': ['.irbrc', 'irbrc', 'file.rb', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder', 'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file', 'Puppetfile', 'Vagrantfile'],
     \ 'rust': ['file.rs'],
     \ 'samba': ['smb.conf'],
     \ 'sas': ['file.sas'],


### PR DESCRIPTION
Problem:    Vagrantfile not recognized.
Solution:   Recognize Vagrantfile as ruby. (Julien Voisin, closes vim/vim#10119)
https://github.com/vim/vim/commit/5e1792270a072a96157e5d5e1d6a97414e26d0bf