### PR TITLE
vim-patch:8.2.4718: @@@ in the last line sometimes drawn in the wrong place

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1639,16 +1639,18 @@ static void win_update(win_T *wp, DecorProviders *providers)
       int scr_row = wp->w_grid.Rows - 1;
 
       // Last line isn't finished: Display "@@@" in the last screen line.
-      grid_puts_len(&wp->w_grid, (char_u *)"@@", 2, scr_row, 0, at_attr);
+      grid_puts_len(&wp->w_grid, (char_u *)"@@", MIN(wp->w_grid.Columns, 2), scr_row, 0, at_attr);
 
       grid_fill(&wp->w_grid, scr_row, scr_row + 1, 2, wp->w_grid.Columns,
                 '@', ' ', at_attr);
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     } else if (dy_flags & DY_LASTLINE) {      // 'display' has "lastline"
+      int start_col = wp->w_grid.Columns - 3;
+
       // Last line isn't finished: Display "@@@" at the end.
       grid_fill(&wp->w_grid, wp->w_grid.Rows - 1, wp->w_grid.Rows,
-                wp->w_grid.Columns - 3, wp->w_grid.Columns, '@', '@', at_attr);
+                MAX(start_col, 0), wp->w_grid.Columns, '@', '@', at_attr);
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     } else {
@@ -6001,9 +6003,9 @@ static void end_search_hl(void)
 }
 
 
-/// Fill the grid from 'start_row' to 'end_row', from 'start_col' to 'end_col'
-/// with character 'c1' in first column followed by 'c2' in the other columns.
-/// Use attributes 'attr'.
+/// Fill the grid from "start_row" to "end_row" (exclusive), from "start_col"
+/// to "end_col" (exclusive) with character "c1" in first column followed by
+/// "c2" in the other columns.  Use attributes "attr".
 void grid_fill(ScreenGrid *grid, int start_row, int end_row, int start_col, int end_col, int c1,
                int c2, int attr)
 {

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -325,4 +325,31 @@ func Test_display_linebreak_breakat()
   let &breakat=_breakat
 endfunc
 
+func Test_display_lastline()
+  CheckScreendump
+
+  let lines =<< trim END
+      call setline(1, ['aaa', 'b'->repeat(100)])
+      set display=truncate
+      vsplit
+      100wincmd <
+  END
+  call writefile(lines, 'XdispLastline')
+  let buf = RunVimInTerminal('-S XdispLastline', #{rows: 10})
+  call VerifyScreenDump(buf, 'Test_display_lastline_1', {})
+
+  call term_sendkeys(buf, ":set display=lastline\<CR>")
+  call VerifyScreenDump(buf, 'Test_display_lastline_2', {})
+
+  call term_sendkeys(buf, ":100wincmd >\<CR>")
+  call VerifyScreenDump(buf, 'Test_display_lastline_3', {})
+
+  call term_sendkeys(buf, ":set display=truncate\<CR>")
+  call VerifyScreenDump(buf, 'Test_display_lastline_4', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XdispLastline')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #13900

#### vim-patch:8.2.4718: @@@ in the last line sometimes drawn in the wrong place

Problem:    @@@ in the last line sometimes drawn in the wrong place.
Solution:   Make sure the column is valid.
https://github.com/vim/vim/commit/cee9c844f27bceaba90362a3fa27a04d4d06c0fd