### PR TITLE
vim-patch:8.2.4721: cooklang files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -393,6 +393,9 @@ au BufNewFile,BufRead *.cfm,*.cfi,*.cfc		setf cf
 " Configure scripts
 au BufNewFile,BufRead configure.in,configure.ac setf config
 
+" Cooklang
+au BufNewFile,BufRead *.cook			setf cook
+
 " CUDA Compute Unified Device Architecture
 au BufNewFile,BufRead *.cu,*.cuh		setf cuda
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -96,6 +96,7 @@ local extension = {
   clj = "clojure",
   cljc = "clojure",
   cljs = "clojure",
+  cook = "cook",
   cmake = "cmake",
   cmod = "cmod",
   lib = "cobol",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -116,6 +116,7 @@ let s:filename_checks = {
     \ 'conf': ['auto.master'],
     \ 'config': ['configure.in', 'configure.ac', '/etc/hostname.file'],
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
+    \ 'cook': ['file.cook'],
     \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh'],
     \ 'crm': ['file.crm'],
     \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],


### PR DESCRIPTION
Problem:    Cooklang files are not recognized.
Solution:   recognize *.cook files. (Goc Dundar, closes vim/vim#10120)
https://github.com/vim/vim/commit/36951ed1dab2b2e816dc8959c72b5732f36d9e3b