### PR TITLE
vim-patch:8.2.4722: ending recording with mapping records too much

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1469,8 +1469,14 @@ int vgetc(void)
     mouse_row = old_mouse_row;
     mouse_col = old_mouse_col;
   } else {
+    // number of characters recorded from the last vgetc() call
+    static size_t last_vgetc_recorded_len = 0;
+
     mod_mask = 0;
-    last_recorded_len = 0;
+
+    // last_recorded_len can be larger than last_vgetc_recorded_len
+    // if peeking records more
+    last_recorded_len -= last_vgetc_recorded_len;
 
     for (;;) {                 // this is done twice if there are modifiers
       bool did_inc = false;
@@ -1621,6 +1627,8 @@ int vgetc(void)
 
       break;
     }
+
+    last_vgetc_recorded_len = last_recorded_len;
   }
 
   /*

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -690,6 +690,27 @@ func Test_record_in_select_mode()
   bwipe!
 endfunc
 
+" mapping that ends macro recording should be removed from recorded macro
+func Test_end_record_using_mapping()
+  call setline(1, 'aaa')
+  nnoremap s q
+  call feedkeys('safas', 'tx')
+  call assert_equal('fa', @a)
+  nunmap s
+
+  nnoremap xx q
+  call feedkeys('0xxafaxx', 'tx')
+  call assert_equal('fa', @a)
+  nunmap xx
+
+  nnoremap xsx q
+  call feedkeys('0qafaxsx', 'tx')
+  call assert_equal('fa', @a)
+  nunmap xsx
+
+  bwipe!
+endfunc
+
 func Test_end_reg_executing()
   nnoremap s <Nop>
   let @a = 's'


### PR DESCRIPTION
Fix #18043

#### vim-patch:8.2.4722: ending recording with mapping records too much

Problem:    When a recording is ended with a mapped key that key is also
            recorded.
Solution:   Remember the previous last_recorded_len. (closes vim/vim#10122)
https://github.com/vim/vim/commit/81b46a6ccd818609e1ca8cd410e26a58428c30ba