### PR TITLE
vim-patch:8.2.{4723,4728}: the ModeChanged autocmd event is inefficient

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1549,10 +1549,11 @@ Dictionary nvim_get_mode(void)
   FUNC_API_SINCE(2) FUNC_API_FAST
 {
   Dictionary rv = ARRAY_DICT_INIT;
-  char *modestr = get_mode();
+  char modestr[MODE_MAX_LENGTH];
+  get_mode(modestr);
   bool blocked = input_blocking();
 
-  PUT(rv, "mode", STRING_OBJ(cstr_as_string(modestr)));
+  PUT(rv, "mode", STRING_OBJ(cstr_to_string(modestr)));
   PUT(rv, "blocking", BOOLEAN_OBJ(blocked));
 
   return rv;

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1083,8 +1083,7 @@ int autocmd_register(int64_t id, event_T event, char_u *pat, int patlen, int gro
 
     // need to initialize last_mode for the first ModeChanged autocmd
     if (event == EVENT_MODECHANGED && !has_event(EVENT_MODECHANGED)) {
-      xfree(last_mode);
-      last_mode = get_mode();
+      get_mode(last_mode);
     }
 
     // If the event is CursorMoved, update the last cursor position

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -387,7 +387,7 @@ static void insert_enter(InsertState *s)
     State = INSERT;
   }
 
-  trigger_modechanged();
+  may_trigger_modechanged();
   stop_insert_mode = false;
 
   // need to position cursor again when on a TAB
@@ -2097,7 +2097,7 @@ static void ins_ctrl_x(void)
     ctrl_x_mode = CTRL_X_CMDLINE_CTRL_X;
   }
 
-  trigger_modechanged();
+  may_trigger_modechanged();
 }
 
 // Whether other than default completion has been selected.
@@ -2710,7 +2710,7 @@ void set_completion(colnr_T startcol, list_T *list)
     show_pum(save_w_wrow, save_w_leftcol);
   }
 
-  trigger_modechanged();
+  may_trigger_modechanged();
   ui_flush();
 }
 
@@ -3890,7 +3890,7 @@ static bool ins_compl_prep(int c)
     ins_apply_autocmds(EVENT_COMPLETEDONE);
   }
 
-  trigger_modechanged();
+  may_trigger_modechanged();
 
   /* reset continue_* if we left expansion-mode, if we stay they'll be
    * (re)set properly in ins_complete() */
@@ -4641,7 +4641,7 @@ static int ins_compl_get_exp(pos_T *ini)
       compl_curr_match = compl_old_match;
     }
   }
-  trigger_modechanged();
+  may_trigger_modechanged();
 
   return i;
 }
@@ -8051,7 +8051,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
 
 
   State = NORMAL;
-  trigger_modechanged();
+  may_trigger_modechanged();
   // need to position cursor again when on a TAB
   if (gchar_cursor() == TAB) {
     curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL);
@@ -8155,7 +8155,7 @@ static void ins_insert(int replaceState)
   } else {
     State = replaceState | (State & LANGMAP);
   }
-  trigger_modechanged();
+  may_trigger_modechanged();
   AppendCharToRedobuff(K_INS);
   showmode();
   ui_cursor_shape();            // may show different cursor shape

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6094,15 +6094,17 @@ static void f_mkdir(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "mode()" function
 static void f_mode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  char *mode = get_mode();
+  char buf[MODE_MAX_LENGTH];
+
+  get_mode(buf);
 
   // Clear out the minor mode when the argument is not a non-zero number or
   // non-empty string.
   if (!non_zero_arg(&argvars[0])) {
-    mode[1] = NUL;
+    buf[1] = NUL;
   }
 
-  rettv->vval.v_string = (char_u *)mode;
+  rettv->vval.v_string = vim_strsave((char_u *)buf);
   rettv->v_type = VAR_STRING;
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -187,7 +187,7 @@ void do_exmode(void)
 
   exmode_active = true;
   State = NORMAL;
-  trigger_modechanged();
+  may_trigger_modechanged();
 
   // When using ":global /pat/ visual" and then "Q" we return to continue
   // the :global command.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -921,7 +921,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
     }
     tl_ret = true;
   }
-  trigger_modechanged();
+  may_trigger_modechanged();
 
   state_enter(&s->state);
 
@@ -6556,7 +6556,7 @@ static int open_cmdwin(void)
   cmdmsg_rl = save_cmdmsg_rl;
 
   State = save_State;
-  trigger_modechanged();
+  may_trigger_modechanged();
   setmouse();
 
   return cmdwin_result;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -746,7 +746,11 @@ EXTERN bool listcmd_busy INIT(= false);     // set when :argdo, :windo or
                                             // :bufdo is executing
 EXTERN bool need_start_insertmode INIT(= false);
 // start insert mode soon
-EXTERN char *last_mode INIT(= NULL);
+
+#define MODE_MAX_LENGTH 4       // max mode length returned in get_mode()
+                                // including the final NUL character
+
+EXTERN char last_mode[MODE_MAX_LENGTH] INIT(= "n");
 EXTERN char_u *last_cmdline INIT(= NULL);      // last command line (for ":)
 EXTERN char_u *repeat_cmdline INIT(= NULL);    // command line for "."
 EXTERN char_u *new_last_cmdline INIT(= NULL);  // new value for last_cmdline

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -631,7 +631,6 @@ void free_all_mem(void)
   clear_sb_text(true);            // free any scrollback text
 
   // Free some global vars.
-  xfree(last_mode);
   xfree(last_cmdline);
   xfree(new_last_cmdline);
   set_keep_msg(NULL, 0);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -481,7 +481,7 @@ static void normal_prepare(NormalState *s)
   if (finish_op != c) {
     ui_cursor_shape();  // may show different cursor shape
   }
-  trigger_modechanged();
+  may_trigger_modechanged();
 
   // When not finishing an operator and no register name typed, reset the count.
   if (!finish_op && !s->oa.regname) {
@@ -920,7 +920,7 @@ normal_end:
   // Reset finish_op, in case it was set
   s->c = finish_op;
   finish_op = false;
-  trigger_modechanged();
+  may_trigger_modechanged();
   // Redraw the cursor with another shape, if we were in Operator-pending
   // mode or did a replace command.
   if (s->c || s->ca.cmdchar == 'r') {
@@ -959,7 +959,7 @@ normal_end:
     if (restart_VIsual_select == 1) {
       VIsual_select = true;
       VIsual_select_reg = 0;
-      trigger_modechanged();
+      may_trigger_modechanged();
       showmode();
       restart_VIsual_select = 0;
     }
@@ -2299,7 +2299,7 @@ void end_visual_mode(void)
   may_clear_cmdline();
 
   adjust_cursor_eol();
-  trigger_modechanged();
+  may_trigger_modechanged();
 }
 
 /*
@@ -4113,7 +4113,7 @@ static void nv_ctrlg(cmdarg_T *cap)
 {
   if (VIsual_active) {  // toggle Selection/Visual mode
     VIsual_select = !VIsual_select;
-    trigger_modechanged();
+    may_trigger_modechanged();
     showmode();
   } else if (!checkclearop(cap->oap)) {
     // print full name if count given or :cd used
@@ -4157,7 +4157,7 @@ static void nv_ctrlo(cmdarg_T *cap)
 {
   if (VIsual_active && VIsual_select) {
     VIsual_select = false;
-    trigger_modechanged();
+    may_trigger_modechanged();
     showmode();
     restart_VIsual_select = 2;          // restart Select mode later
   } else {
@@ -5945,7 +5945,7 @@ static void nv_visual(cmdarg_T *cap)
                                               //           or char/line mode
       VIsual_mode = cap->cmdchar;
       showmode();
-      trigger_modechanged();
+      may_trigger_modechanged();
     }
     redraw_curbuf_later(INVERTED);          // update the inversion
   } else {                // start Visual mode
@@ -6056,7 +6056,7 @@ static void n_start_visual_mode(int c)
 
   foldAdjustVisual();
 
-  trigger_modechanged();
+  may_trigger_modechanged();
   setmouse();
   // Check for redraw after changing the state.
   conceal_check_cursor_line();

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -422,7 +422,7 @@ void terminal_enter(void)
   curwin->w_redr_status = true;  // For mode() in statusline. #8323
   ui_busy_start();
   apply_autocmds(EVENT_TERMENTER, NULL, NULL, false, curbuf);
-  trigger_modechanged();
+  may_trigger_modechanged();
 
   s->state.execute = terminal_execute;
   s->state.check = terminal_check;

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2661,5 +2661,23 @@ func Test_bufwipeout_changes_window()
   %bwipe!
 endfunc
 
+func Test_v_event_readonly()
+  autocmd CompleteChanged * let v:event.width = 0
+  call assert_fails("normal! i\<C-X>\<C-V>", 'E46:')
+  au! CompleteChanged
+
+  autocmd DirChangedPre * let v:event.directory = ''
+  call assert_fails('cd .', 'E46:')
+  au! DirChangedPre
+
+  autocmd ModeChanged * let v:event.new_mode = ''
+  call assert_fails('normal! cc', 'E46:')
+  au! ModeChanged
+
+  autocmd TextYankPost * let v:event.operator = ''
+  call assert_fails('normal! yy', 'E46:')
+  au! TextYankPost
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -72,8 +72,6 @@ enum { NUMBUFLEN = 65, };
 #define TERM_FOCUS      0x2000  // Terminal focus mode
 #define CMDPREVIEW      0x4000  // Showing 'inccommand' command "live" preview.
 
-#define MODE_MAX_LENGTH 4       // max mode length returned in mode()
-
 // all mode bits used for mapping
 #define MAP_ALL_MODES   (0x3f | SELECTMODE | TERM_FOCUS)
 


### PR DESCRIPTION
#### vim-patch:8.2.4723: the ModeChanged autocmd event is inefficient

Problem:    The ModeChanged autocmd event is inefficient.
Solution:   Avoid allocating memory. (closes vim/vim#10134)  Rename
            trigger_modechanged() to may_trigger_modechanged().
https://github.com/vim/vim/commit/2bf52dd065495cbf28e28792f2c2d50d44546d9f

Make v:event readonly for ModeChanged.

#### vim-patch:8.2.4728: no test that v:event cannot be modified

Problem:    No test that v:event cannot be modified.
Solution:   Add a test. (closes vim/vim#10139)
https://github.com/vim/vim/commit/021996ffaa933d9dc0c3553ca01de93fbf3d522b