### PR TITLE
docs: remove mentions of removed flag '#' in 'cpoptions'

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -42,8 +42,6 @@ For inserting text see |insert.txt|.
 			of the line and [count]-1 more lines [into register
 			x]; synonym for "d$".
 			(not |linewise|)
-			When the '#' flag is in 'cpoptions' the count is
-			ignored.
 
 {Visual}["x]x	or					*v_x* *v_d* *v_<Del>*
 {Visual}["x]d   or

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1872,14 +1872,10 @@ gi			Insert text in the same position as where Insert mode
 							*o*
 o			Begin a new line below the cursor and insert text,
 			repeat [count] times.
-			When the '#' flag is in 'cpoptions' the count is
-			ignored.
 
 							*O*
 O			Begin a new line above the cursor and insert text,
 			repeat [count] times.
-			When the '#' flag is in 'cpoptions' the count is
-			ignored.
 
 These commands are used to start inserting text.  You can end insert mode with
 <Esc>.  See |mode-ins-repl| for the other special characters in Insert mode.


### PR DESCRIPTION
Flag was removed in 96c27692b8e58a48e094cf5747dd51b26db75d39, and docs cleanup was in 85b7ea9a8770c42bf2cadb1d3fa605b58d82d7cb, but missed this mentions.