### PR TITLE
fix(events): make v:event readonly in more events

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -836,6 +836,7 @@ static void set_info_event(void **argv)
   typval_T retval;
   (void)object_to_vim(DICTIONARY_OBJ(info), &retval, NULL);
   tv_dict_add_dict(dict, S_LEN("info"), retval.vval.v_dict);
+  tv_dict_set_keys_readonly(dict);
 
   apply_autocmds(event, NULL, NULL, false, curbuf);
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -944,6 +944,7 @@ int do_record(int c)
     buf[0] = (char)regname;
     buf[1] = NUL;
     (void)tv_dict_add_str(dict, S_LEN("regname"), buf);
+    tv_dict_set_keys_readonly(dict);
 
     // Get the recorded key hits.  K_SPECIAL will be escaped, this
     // needs to be removed again to put it in a register.  exec_reg then

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -336,6 +336,7 @@ void terminal_close(Terminal *term, int status)
     save_v_event_T save_v_event;
     dict_T *dict = get_v_event(&save_v_event);
     tv_dict_add_nr(dict, S_LEN("status"), status);
+    tv_dict_set_keys_readonly(dict);
     apply_autocmds(EVENT_TERMCLOSE, NULL, NULL, false, buf);
     restore_v_event(dict, &save_v_event);
   }


### PR DESCRIPTION
Close #18063

This makes v:event readonly in these four events:
- ChanInfo
- ChanOpen
- RecordingLeave
- TermClose
