### PR TITLE
docs: update documentation of `nvim_win_set_height()`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2859,8 +2859,7 @@ nvim_win_set_cursor({window}, {pos})                   *nvim_win_set_cursor()*
                     {pos}     (row, col) tuple representing the new position
 
 nvim_win_set_height({window}, {height})                *nvim_win_set_height()*
-                Sets the window height. This will only succeed if the screen
-                is split horizontally.
+                Sets the window height.
 
                 Parameters: ~
                     {window}  Window handle, or 0 for current window

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -139,8 +139,7 @@ Integer nvim_win_get_height(Window window, Error *err)
   return win->w_height;
 }
 
-/// Sets the window height. This will only succeed if the screen is split
-/// horizontally.
+/// Sets the window height.
 ///
 /// @param window   Window handle, or 0 for current window
 /// @param height   Height as a count of rows


### PR DESCRIPTION
It is now does resize even if window is not horizontally split. See #18039 and #17335.