### PR TITLE
vim-patch:8.2.4737: // in JavaScript string recognized as comment

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1186,7 +1186,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   end_comment_pending = NUL;
   if (flags & OPENLINE_DO_COM) {
     lead_len = get_leader_len(saved_line, &lead_flags, dir == BACKWARD, true);
-    if (lead_len == 0 && do_cindent && dir == FORWARD) {
+    if (lead_len == 0 && curbuf->b_p_cin && do_cindent && dir == FORWARD) {
       // Check for a line comment after code.
       comment_start = check_linecomment(saved_line);
       if (comment_start != MAXCOL) {

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -278,12 +278,25 @@ func Test_format_c_comment()
                       //
   END
   call assert_equal(expected, getline(1, '$'))
+
+  " using 'indentexpr' instead of 'cindent' does not repeat a comment
+  setl nocindent indentexpr=2
+  3delete
+  normal 2Gox
+  let expected =<< trim END
+      nop;
+      val = val;      // This is a comment
+        x
+  END
+  call assert_equal(expected, getline(1, '$'))
+  setl cindent indentexpr=
+  3delete
+
   normal 2GO
   let expected =<< trim END
       nop;
 
       val = val;      // This is a comment
-                      //
   END
   call assert_equal(expected, getline(1, '$'))
 


### PR DESCRIPTION
Problem:    // in JavaScript string recognized as comment.
Solution:   Only check for linecomment if 'cindent' is set.
https://github.com/vim/vim/commit/1655619717ff109ea8bf1002883636d5af345e48