### PR TITLE
vim-patch:8.2.4739: accessing freed memory after WinScrolled autocmd event

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1545,7 +1545,7 @@ static void ins_redraw(bool ready)
 
   if (ready) {
     // Trigger Scroll if viewport changed.
-    may_trigger_winscrolled(curwin);
+    may_trigger_winscrolled();
   }
 
   // Trigger BufModified if b_changed_invalid is set.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1225,7 +1225,7 @@ static void normal_check_window_scrolled(NormalState *s)
 {
   if (!finish_op) {
     // Trigger Scroll if the viewport changed.
-    may_trigger_winscrolled(curwin);
+    may_trigger_winscrolled();
   }
 }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -265,17 +265,17 @@ func Test_WinScrolled()
   CheckRunVimInTerminal
 
   let lines =<< trim END
-	set nowrap scrolloff=0
-        for ii in range(1, 18)
-          call setline(ii, repeat(nr2char(96 + ii), ii * 2))
-        endfor
-        let win_id = win_getid()
-        let g:matched = v:false
-        execute 'au WinScrolled' win_id 'let g:matched = v:true'
-        let g:scrolled = 0
-        au WinScrolled * let g:scrolled += 1
-        au WinScrolled * let g:amatch = str2nr(expand('<amatch>'))
-        au WinScrolled * let g:afile = str2nr(expand('<afile>'))
+    set nowrap scrolloff=0
+    for ii in range(1, 18)
+      call setline(ii, repeat(nr2char(96 + ii), ii * 2))
+    endfor
+    let win_id = win_getid()
+    let g:matched = v:false
+    execute 'au WinScrolled' win_id 'let g:matched = v:true'
+    let g:scrolled = 0
+    au WinScrolled * let g:scrolled += 1
+    au WinScrolled * let g:amatch = str2nr(expand('<amatch>'))
+    au WinScrolled * let g:afile = str2nr(expand('<afile>'))
   END
   call writefile(lines, 'Xtest_winscrolled')
   let buf = RunVimInTerminal('-S Xtest_winscrolled', {'rows': 6})
@@ -313,6 +313,30 @@ func Test_WinScrolled()
 
   call StopVimInTerminal(buf)
   call delete('Xtest_winscrolled')
+endfunc
+
+func Test_WinScrolled_close_curwin()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set nowrap scrolloff=0
+    call setline(1, ['aaa', 'bbb'])
+    vsplit
+    au WinScrolled * close
+    au VimLeave * call writefile(['123456'], 'Xtestout')
+  END
+  call writefile(lines, 'Xtest_winscrolled_close_curwin')
+  let buf = RunVimInTerminal('-S Xtest_winscrolled_close_curwin', {'rows': 6})
+
+  " This was using freed memory
+  call term_sendkeys(buf, "\<C-E>")
+  call TermWait(buf)
+  call StopVimInTerminal(buf)
+
+  call assert_equal(['123456'], readfile('Xtestout'))
+
+  call delete('Xtest_winscrolled_close_curwin')
+  call delete('Xtestout')
 endfunc
 
 func Test_WinClosed()

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5246,8 +5246,8 @@ void shell_new_columns(void)
   win_reconfig_floats();  // The size of floats might change
 }
 
-/// Trigger WinScrolled autocmd if window has scrolled.
-void may_trigger_winscrolled(win_T *wp)
+/// Trigger WinScrolled for "curwin" if needed.
+void may_trigger_winscrolled(void)
 {
   static bool recursive = false;
 
@@ -5255,6 +5255,7 @@ void may_trigger_winscrolled(win_T *wp)
     return;
   }
 
+  win_T *wp = curwin;
   if (wp->w_last_topline != wp->w_topline
       || wp->w_last_leftcol != wp->w_leftcol
       || wp->w_last_width != wp->w_width
@@ -5266,10 +5267,13 @@ void may_trigger_winscrolled(win_T *wp)
     apply_autocmds(EVENT_WINSCROLLED, winid, winid, false, wp->w_buffer);
     recursive = false;
 
-    wp->w_last_topline = wp->w_topline;
-    wp->w_last_leftcol = wp->w_leftcol;
-    wp->w_last_width = wp->w_width;
-    wp->w_last_height = wp->w_height;
+    // an autocmd may close the window, "wp" may be invalid now
+    if (win_valid_any_tab(wp)) {
+      wp->w_last_topline = wp->w_topline;
+      wp->w_last_leftcol = wp->w_leftcol;
+      wp->w_last_width = wp->w_width;
+      wp->w_last_height = wp->w_height;
+    }
   }
 }
 

--- a/test/functional/autocmd/winscrolled_spec.lua
+++ b/test/functional/autocmd/winscrolled_spec.lua
@@ -6,12 +6,14 @@ local eval = helpers.eval
 local command = helpers.command
 local feed = helpers.feed
 local meths = helpers.meths
+local assert_alive = helpers.assert_alive
+
+before_each(clear)
 
 describe('WinScrolled', function()
   local win_id
 
   before_each(function()
-    clear()
     win_id = meths.get_current_win().id
     command(string.format('autocmd WinScrolled %d let g:matched = v:true', win_id))
     command('let g:scrolled = 0')
@@ -71,4 +73,13 @@ describe('WinScrolled', function()
     feed('A<CR><Esc>')
     eq(1, eval('g:scrolled'))
   end)
+end)
+
+it('closing window in WinScrolled does not cause use-after-free #13265', function()
+  local lines = {'aaa', 'bbb'}
+  meths.buf_set_lines(0, 0, -1, true, lines)
+  command('vsplit')
+  command('autocmd WinScrolled * close')
+  feed('<C-E>')
+  assert_alive()
 end)


### PR DESCRIPTION
Fix #13265

#### vim-patch:8.2.4739: accessing freed memory after WinScrolled autocmd event

Problem:    Accessing freed memory after WinScrolled autocmd event.
Solution:   Check the window pointer is still valid. (closes vim/vim#10156)
            Remove the argument from may_trigger_winscrolled().
https://github.com/vim/vim/commit/d58862d18f091d3c14fa3647e724ef7eea1ecefa