### PR TITLE
docs(byteidxcomp): remove mention of 'encoding' being non-Unicode

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -966,8 +966,6 @@ byteidxcomp({expr}, {nr})					*byteidxcomp()*
 <		The first and third echo result in 3 ('e' plus composing
 		character is 3 bytes), the second echo results in 1 ('e' is
 		one byte).
-		Only works differently from byteidx() when 'encoding' is set
-		to a Unicode encoding.
 
 		Can also be used as a |method|: >
 			GetName()->byteidxcomp(idx)


### PR DESCRIPTION
This is the only remaining mention of 'encoding' being non-Unicode in
builtin.txt. It was once removed in 4ab3fe8, but added back in b16c7c51.