### PR TITLE
vim-patch:8.2.4747: no filetype override for .sys files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -823,7 +823,9 @@ func dist#ft#FTperl()
 endfunc
 
 func dist#ft#FTsys()
-  if IsRapid()
+  if exists("g:filetype_sys")
+    exe "setf " .. g:filetype_sys
+  elseif IsRapid()
     setf rapid
   else
     setf bat

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -153,6 +153,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.pp		g:filetype_pp	|ft-pascal-syntax|
 	*.prg		g:filetype_prg
 	*.src		g:filetype_src
+	*.sys		g:filetype_sys
 	*.sh		g:bash_is_sh	|ft-sh-syntax|
 	*.tex		g:tex_flavor	|ft-tex-plugin|
 	*.w		g:filetype_w	|ft-cweb-syntax|

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1474,7 +1474,7 @@ endfunc
 func Test_sc_file()
   filetype on
 
-  " SC file mehtods are defined 'Class : Method'
+  " SC file methods are defined 'Class : Method'
   call writefile(['SCNvimDocRenderer : SCDocHTMLRenderer {'], 'srcfile.sc')
   split srcfile.sc
   call assert_equal('supercollider', &filetype)
@@ -1559,6 +1559,13 @@ func Test_sys_file()
   call writefile(['looks like dos batch'], 'sysfile.sys')
   split sysfile.sys
   call assert_equal('bat', &filetype)
+  bwipe!
+
+  " Users preference set by g:filetype_sys
+  let g:filetype_sys = 'sys'
+  split sysfile.sys
+  call assert_equal('sys', &filetype)
+  unlet g:filetype_sys
   bwipe!
 
   " RAPID header start with a line containing only "%%%", 


### PR DESCRIPTION
Problem:    No filetype override for .sys files.
Solution:   Add g:filetype_sys. (Patrick Meiser-Knosowski, closes vim/vim#10181)
https://github.com/vim/vim/commit/f420ff2440a009acd9573fdb6ad6d53509d78009