### PR TITLE
refactor(treesitter): rely more on ts correctness

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -261,6 +261,8 @@ function TSHighlighter._on_line(_, _win, buf, line, _)
       return
     end
 
+    local synmaxcol = vim.api.nvim_buf_get_option(self.bufnr, 'synmaxcol')
+
     for capture, node, metadata in
       highlighter_query:query():iter_captures(root_node, self.bufnr, line, line + 1) do
 
@@ -269,6 +271,10 @@ function TSHighlighter._on_line(_, _win, buf, line, _)
       end
 
       local start_row, start_col, end_row, end_col = node:range()
+      if start_col > synmaxcol then
+        break
+      end
+
       local hl = highlighter_query.hl_cache[capture]
 
       if hl and end_row >= line then

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -277,15 +277,14 @@ function TSHighlighter._on_line(_, _win, buf, line, _)
 
       local hl = highlighter_query.hl_cache[capture]
 
-      if hl and end_row >= line then
-        a.nvim_buf_set_extmark(buf, ns, start_row, start_col, {
-          end_line = end_row,
-          end_col = end_col,
-          hl_group = hl,
-          ephemeral = true,
-          priority = tonumber(metadata.priority) or 100, -- Low but leaves room below
-          conceal = metadata.conceal,
-        })
+      if hl then
+        a.nvim_buf_set_extmark(buf, ns, start_row, start_col,
+                               { end_line = end_row, end_col = end_col,
+                                 hl_group = hl,
+                                 ephemeral = true,
+                                 priority = tonumber(metadata.priority) or 100, -- Low but leaves room below
+                                 conceal = metadata.conceal,
+                                })
       end
     end
   end, true)


### PR DESCRIPTION
Fixes #18108

@bfredl, this removes an old part of the code that was added a long
time ago.

Now comes the question of actually using ephemeral extmarks, and
rather use persistent extmarks and rely on tree updates.

I just leave that there...
