### PR TITLE
vim-patch:8.2.4750: small pieces of dead code

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4328,7 +4328,7 @@ skip:
       } \
       kv_push(preview_lines.subresults, current_match); \
     } \
-    } while (0)
+  } while (0)
 
             // Push the match to preview_lines.
             PUSH_PREVIEW_LINES();
@@ -4593,9 +4593,7 @@ void ex_global(exarg_T *eap)
     return;
   } else {
     delim = *cmd;               // get the delimiter
-    if (delim) {
-      ++cmd;                    // skip delimiter if there is one
-    }
+    cmd++;                      // skip delimiter if there is one
     pat = cmd;                  // remember start of pattern
     cmd = skip_regexp(cmd, delim, p_magic, &eap->arg);
     if (cmd[0] == delim) {                  // end delimiter found

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2661,9 +2661,7 @@ ambw_end:
       int x2 = -1;
       int x3 = -1;
 
-      if (*p != NUL) {
-        p += utfc_ptr2len(p);
-      }
+      p += utfc_ptr2len(p);
       if (*p != NUL) {
         x2 = *p++;
       }

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -715,7 +715,7 @@ void expand_env_esc(char_u *restrict srcp, char_u *restrict dst, int dstlen, boo
         int c = (int)STRLEN(var);
         // if var[] ends in a path separator and tail[] starts
         // with it, skip a character
-        if (*var != NUL && after_pathsep((char *)dst, (char *)dst + c)
+        if (after_pathsep((char *)dst, (char *)dst + c)
 #if defined(BACKSLASH_IN_FILENAME)
             && dst[-1] != ':'
 #endif

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -103,7 +103,7 @@ typedef struct qf_list_S {
   char_u *qf_title;        ///< title derived from the command that created
                            ///< the error list or set by setqflist
   typval_T *qf_ctx;          ///< context set by setqflist/setloclist
-  Callback qftf_cb;            ///< 'quickfixtextfunc' callback function
+  Callback qf_qftf_cb;            ///< 'quickfixtextfunc' callback function
 
   struct dir_stack_T *qf_dir_stack;
   char_u *qf_directory;
@@ -2040,7 +2040,7 @@ static int copy_loclist(qf_list_T *from_qfl, qf_list_T *to_qfl)
   } else {
     to_qfl->qf_ctx = NULL;
   }
-  callback_copy(&to_qfl->qftf_cb, &from_qfl->qftf_cb);
+  callback_copy(&to_qfl->qf_qftf_cb, &from_qfl->qf_qftf_cb);
 
   if (from_qfl->qf_count) {
     if (copy_loclist_entries(from_qfl, to_qfl) == FAIL) {
@@ -3448,7 +3448,7 @@ static void qf_free(qf_list_T *qfl)
   XFREE_CLEAR(qfl->qf_title);
   tv_free(qfl->qf_ctx);
   qfl->qf_ctx = NULL;
-  callback_free(&qfl->qftf_cb);
+  callback_free(&qfl->qf_qftf_cb);
   qfl->qf_id = 0;
   qfl->qf_changedtick = 0L;
 }
@@ -4109,10 +4109,10 @@ static list_T *call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long
   // If 'quickfixtextfunc' is set, then use the user-supplied function to get
   // the text to display. Use the local value of 'quickfixtextfunc' if it is
   // set.
-  if (qfl->qftf_cb.type != kCallbackNone) {
-    cb = &qfl->qftf_cb;
+  if (qfl->qf_qftf_cb.type != kCallbackNone) {
+    cb = &qfl->qf_qftf_cb;
   }
-  if (cb != NULL && cb->type != kCallbackNone) {
+  if (cb->type != kCallbackNone) {
     typval_T args[1];
     typval_T rettv;
 
@@ -6258,10 +6258,10 @@ static int qf_getprop_qftf(qf_list_T *qfl, dict_T *retdict)
 {
   int status;
 
-  if (qfl->qftf_cb.type != kCallbackNone) {
+  if (qfl->qf_qftf_cb.type != kCallbackNone) {
     typval_T tv;
 
-    callback_put(&qfl->qftf_cb, &tv);
+    callback_put(&qfl->qf_qftf_cb, &tv);
     status = tv_dict_add_tv(retdict, S_LEN("quickfixtextfunc"), &tv);
     tv_clear(&tv);
   } else {
@@ -6361,9 +6361,9 @@ static int qf_setprop_qftf(qf_list_T *qfl, dictitem_T *di)
 {
   Callback cb;
 
-  callback_free(&qfl->qftf_cb);
+  callback_free(&qfl->qf_qftf_cb);
   if (callback_from_typval(&cb, &di->di_tv)) {
-    qfl->qftf_cb = cb;
+    qfl->qf_qftf_cb = cb;
   }
   return OK;
 }


### PR DESCRIPTION
Problem:    Small pieces of dead code.
Solution:   Remove the dead code. (Goc Dundar, closes vim/vim#10190) Rename the
            qftf_cb struct member to avoid confusion.
https://github.com/vim/vim/commit/b836658a04ee5456deca2ee523de9efe51252da3
