### PR TITLE
ci: apply documentation label more freely

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,6 +39,7 @@
 
 "documentation":
   - all: ["runtime/doc/*"]
+  - any: ["**/*.md"]
 
 "clipboard":
   - runtime/autoload/provider/clipboard.vim

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,7 +39,7 @@
 
 "documentation":
   - all: ["runtime/doc/*"]
-  - any: ["**/*.md"]
+  - all: ["**/*.md"]
 
 "clipboard":
   - runtime/autoload/provider/clipboard.vim


### PR DESCRIPTION
Currently, we apply the documentation label to any change in runtime/doc with the catch that if there are changes elsewhere it does not get applied, fix that.

Make it so any change to runtime/doc and markdown files (there is documentation in this repo as markdown files) get labeled as documentation

Testing
<https://github.com/CleverRaven/Cataclysm-DDA/blob/master/.github/labeler.yml>
