### PR TITLE
fix(packaging): remove excess forward slash in Wix Patch

### DIFF
--- a/packaging/WixPatch.xml
+++ b/packaging/WixPatch.xml
@@ -1,8 +1,6 @@
 <CPackWiXPatch>
     <!--  Fragment ID is from: <your build dir>/_CPack_Packages/win64/WIX/files.wxs -->
     <CPackWiXFragment Id="CM_CP_bin.nvim.exe">
-      <!-- Note: if we were to specify Value='[INSTALL_ROOT]\bin' - with a backslash, the installer will still
-      use a forward slash in the path. -->
       <Environment
         Id='UpdatePath'
         Name='PATH'
@@ -10,7 +8,7 @@
         Permanent='no'
         System='yes'
         Part='last'
-        Value='[INSTALL_ROOT]/bin'
+        Value='[INSTALL_ROOT]bin'
       />
     </CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
Just noticed it today, the forward-slash could just be removed.
Before:
![image](https://user-images.githubusercontent.com/56180050/163593150-d833e70c-5431-4177-ac2b-b1080b45c127.png)
After:
![image](https://user-images.githubusercontent.com/56180050/163593312-80016074-f46d-4255-9a76-a246ac2a6366.png)

CC @RenFraser 