### PR TITLE
Enable hyperlinks in TUI (OSC-8)

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -659,6 +659,12 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     goto error;
   }
 
+  if (opts->uri.type == kObjectTypeString) {
+    decor.uri = opts->uri.data.string.data;
+  } else if (HAS_KEY(opts->uri)) {
+    api_set_error(err, kErrorTypeValidation, "uri is not a String");
+    goto error;
+  }
 
   OPTION_TO_BOOL(decor.virt_lines_above, virt_lines_above, false);
 

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -28,6 +28,7 @@ return {
     "line_hl_group";
     "cursorline_hl_group";
     "conceal";
+    "uri";
   };
   keymap = {
     "noremap";

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -879,6 +879,7 @@ struct file_buffer {
   Map(uint32_t, uint32_t) b_extmark_ns[1];         // extmark namespaces
   size_t b_virt_line_blocks;    // number of virt_line blocks
   size_t b_signs;               // number of sign extmarks
+  size_t b_uris;                // number of URI's defined by extmarks
 
   // array of channel_id:s which have asked to receive updates for this
   // buffer.

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -315,6 +315,7 @@ next_mark:
   bool conceal = 0;
   int conceal_char = 0;
   int conceal_attr = 0;
+  char *uri = NULL;
 
   for (size_t i = 0; i < kv_size(state->active); i++) {
     DecorRange item = kv_A(state->active, i);
@@ -348,6 +349,13 @@ next_mark:
         conceal_attr = item.attr_id;
       }
     }
+    if (active && item.decor.uri) {
+      if (item.start_row == state->row && item.start_col == col) {
+        uri = item.decor.uri;
+      } else if (item.end_row == state->row && item.end_col == col) {
+        uri = "";
+      }
+    }
     if ((item.start_row == state->row && item.start_col <= col)
         && kv_size(item.decor.virt_text)
         && item.decor.virt_text_pos == kVTOverlay && item.win_col == -1) {
@@ -364,6 +372,7 @@ next_mark:
   state->conceal = conceal;
   state->conceal_char = conceal_char;
   state->conceal_attr = conceal_attr;
+  state->uri = uri;
   return attr;
 }
 

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -60,10 +60,11 @@ struct Decoration {
   // TODO(bfredl): in principle this should be a schar_T, but we
   // probably want some kind of glyph cache for that..
   int conceal_char;
+  char *uri;
 };
 #define DECORATION_INIT { KV_INITIAL_VALUE, KV_INITIAL_VALUE, 0, kVTEndOfLine, \
                           kHlModeUnknown, false, false, false, false, DECOR_PRIORITY_BASE, \
-                          0, 0, NULL, 0, 0, 0, 0, 0 }
+                          0, 0, NULL, 0, 0, 0, 0, 0, NULL }
 
 typedef struct {
   int start_row;
@@ -89,6 +90,7 @@ typedef struct {
   bool conceal;
   int conceal_char;
   int conceal_attr;
+  char *uri;
 } DecorState;
 
 EXTERN DecorState decor_state INIT(= { 0 });

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -69,7 +69,8 @@ void extmark_set(buf_T *buf, uint32_t ns_id, uint32_t *idp, int row, colnr_T col
   if (decor) {
     if (kv_size(decor->virt_text)
         || kv_size(decor->virt_lines)
-        || decor_has_sign(decor)) {
+        || decor_has_sign(decor)
+        || decor->uri) {
       decor_full = true;
       decor = xmemdup(decor, sizeof *decor);
     }
@@ -146,6 +147,9 @@ revised:
     }
     if (decor_has_sign(decor)) {
       buf->b_signs++;
+    }
+    if (decor->uri) {
+      buf->b_uris++;
     }
     if (decor->sign_text) {
       // TODO(lewis6991): smarter invalidation

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -807,6 +807,12 @@ Dictionary hlattrs2dict(HlAttrs ae, bool use_rgb)
     PUT(hl, "blend", INTEGER_OBJ(ae.hl_blend));
   }
 
+  if (ae.uri) {
+    Dictionary metadata = ARRAY_DICT_INIT;
+    PUT(metadata, "uri", CSTR_TO_OBJ(ae.uri));
+    PUT(hl, "metadata", DICTIONARY_OBJ(metadata));
+  }
+
   return hl;
 }
 

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -37,6 +37,8 @@ typedef struct attr_entry {
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
   int hl_blend;
+  char *uri;
+  bool uri_end;
 } HlAttrs;
 
 #define HLATTRS_INIT (HlAttrs) { \
@@ -48,6 +50,7 @@ typedef struct attr_entry {
   .cterm_fg_color = 0, \
   .cterm_bg_color = 0, \
   .hl_blend = -1, \
+  .uri = NULL, \
 }
 
 /// Values for index in highlight_attr[].

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3354,6 +3354,13 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           if (decor_conceal && decor_state.conceal_char) {
             decor_conceal = 2;  // really??
           }
+
+          if (decor_state.uri) {
+            // ?????
+            // Need to get the uri into HlAttrs somehow so that it can be accessed by
+            // update_attrs in tui.c
+            syn_attr2entry(attr);
+          }
         }
 
         // Found last space before word: check for line break.

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -34,4 +34,6 @@ typedef enum {
 
 typedef struct Decoration Decoration;
 
+typedef struct UiMetadata UiMetadata;
+
 #endif  // NVIM_TYPES_H

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -68,6 +68,10 @@ struct ui_t {
   void (*inspect)(UI *ui, Dictionary *info);
 };
 
+struct UiMetadata {
+  char *uri;
+};
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.h.generated.h"
 


### PR DESCRIPTION
This is a WIP, nothing is even close to working yet. Just wanted to have a place to discuss the implementation.

My idea is to use extmarks to set a `uri` option and then any text between the start and end col of the extmark becomes the link text.

The hyperlink itself is accomplished with the OSC 8 escape sequence:

`\e]8;;<URI>\e\\<LINK TEXT>\e]8;;\e\\`

What I'm still trying to figure out is how to connect the `uri` option from the extmark into the TUI code so that it can emit this sequence.

The path I've started down (which may be/probably is wrong) is to add the URI from the extmark as a highlight attribute. Then when `update_attrs` is called in `tui.c` it can emit the OSC 8 sequence. However, I'm not sure if this will work because I think it would require a new hl attribute for each unique URI, which is not ideal.

Likely a better way to do this would be to add arbitrary metadata alongside the hl attributes. Then each `UICell` could have its own metadata alongside its `hl_id`, and we could extend `update_attrs` to handle both the hl attributes as well as the metadata.

There is also the question of extending this to UIs more generally, instead of just the TUI. The `grid_line` UI event sends an array of cells, each of which is itself an array of `[text(, hl_id, repeat)]`. If we can extend this array, we could add a metadata field (or an index into a metadata table similar to how `hl_id` works), but I'm not sure if that is considered a violation of the API contract or not.

Closes #11871.
