### PR TITLE
docs(api): remove reference to non-existent 'buf_open_scratch'

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -681,9 +681,6 @@ nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
                 Return: ~
                     Buffer handle, or 0 on error
 
-                See also: ~
-                    buf_open_scratch
-
                                                   *nvim_create_user_command()*
 nvim_create_user_command({name}, {command}, {*opts})
                 Create a new user command |user-commands|


### PR DESCRIPTION
The doc entry for nvim_create_buf contains a 'See Also' reference to a non-existent entry called `buf_open_scratch`. Grep reveals this as the sole reference in the entire documentation to it, so I believe this is an oversight.