### PR TITLE
vim-patch:8.2.4762: using freed memory using synstack() and synID() in WinEnter

### DIFF
--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5802,8 +5802,8 @@ char_u *get_syntax_name(expand_T *xp, int idx)
 int syn_get_id(win_T *wp, long lnum, colnr_T col, int trans, bool *spellp, int keep_state)
 {
   // When the position is not after the current position and in the same
-  // line of the same buffer, need to restart parsing.
-  if (wp->w_buffer != syn_buf || lnum != current_lnum || col < current_col) {
+  // line of the same window with the same buffer, need to restart parsing.
+  if (wp != syn_win || wp->w_buffer != syn_buf || lnum != current_lnum || col < current_col) {
     syntax_start(wp, lnum);
   } else if (col > current_col) {
     // next_match may not be correct when moving around, e.g. with the

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -794,5 +794,18 @@ func Test_syn_include_contains_TOP()
   bw!
 endfunc
 
+" This was using freed memory
+func Test_WinEnter_synstack_synID()
+  autocmd WinEnter * call synstack(line("."), col("."))
+  autocmd WinEnter * call synID(line('.'), col('.') - 1, 1)
+  call setline(1, 'aaaaa')
+  normal! $
+  new
+  close
+
+  au! WinEnter
+  bw!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #18125

#### vim-patch:8.2.4762: using freed memory using synstack() and synID() in WinEnter

Problem:    Using freed memory when using synstack() and synID() in WinEnter.
Solution:   Check using the syntax window. (closes vim/vim#10204)
https://github.com/vim/vim/commit/ca7e86c23789eb0ed8f6400f25ea9e0e1036f9fc