### PR TITLE
vim-patch:8.2.4766: KRL files using "deffct" not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -992,20 +992,23 @@ func dist#ft#FTtf()
   setf tf
 endfunc
 
+let s:ft_krl_header = '\&\w+'
 " Determine if a *.src file is Kuka Robot Language
 func dist#ft#FTsrc()
+  let ft_krl_def_or_deffct = '%(global\s+)?def%(fct)?>'
   if exists("g:filetype_src")
     exe "setf " .. g:filetype_src
-  elseif getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|\%(global\s\+\)\?def\>\)'
+  elseif getline(nextnonblank(1)) =~? '\v^\s*%(' .. s:ft_krl_header .. '|' .. ft_krl_def_or_deffct .. ')'
     setf krl
   endif
 endfunc
 
 " Determine if a *.dat file is Kuka Robot Language
 func dist#ft#FTdat()
+  let ft_krl_defdat = 'defdat>'
   if exists("g:filetype_dat")
     exe "setf " .. g:filetype_dat
-  elseif getline(nextnonblank(1)) =~? '^\s*\%(&\w\+\|defdat\>\)'
+  elseif getline(nextnonblank(1)) =~? '\v^\s*%(' .. s:ft_krl_header .. '|' .. ft_krl_defdat .. ')'
     setf krl
   endif
 endfunc

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -743,7 +743,7 @@ func Test_setfiletype_completion()
 endfunc
 
 """""""""""""""""""""""""""""""""""""""""""""""""
-" Tests for specific extentions and filetypes.
+" Tests for specific extensions and filetypes.
 " Keep sorted.
 """""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -1535,11 +1535,13 @@ func Test_src_file()
   bwipe!
   call delete('srcfile.Src')
 
-  " KRL global def with embedded spaces, file starts with empty line(s).
-  call writefile(['', 'global  def  srcfile()'], 'srcfile.SRC')
-  split srcfile.SRC
-  call assert_equal('krl', &filetype)
-  bwipe!
+  " KRL global deffct with embedded spaces, file starts with empty line(s).
+  for text in ['global  def  srcfile()', 'global  deffct  srcfile()']
+    call writefile(['', text], 'srcfile.SRC')
+    split srcfile.SRC
+    call assert_equal('krl', &filetype, text)
+    bwipe!
+  endfor
 
   " User may overrule file inspection
   let g:filetype_src = 'src'


### PR DESCRIPTION
Problem:    KRL files using "deffct" not recognized.
Solution:   Adjust the pattern used for matching. (Patrick Meiser-Knosowski,
            closes vim/vim#10200)
https://github.com/vim/vim/commit/93c7a45e86934a92ec513b437fe9b8cc343c53e3