### PR TITLE
vim-patch:8.2.4767: openscad files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1271,6 +1271,9 @@ au BufNewFile,BufRead *.or			setf openroad
 " OPL
 au BufNewFile,BufRead *.[Oo][Pp][Ll]		setf opl
 
+" OpenSCAD
+au BufNewFile,BufRead *.scad		setf openscad		
+
 " Oracle config file
 au BufNewFile,BufRead *.ora			setf ora
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -436,6 +436,7 @@ local extension = {
   xin = "omnimark",
   opam = "opam",
   ["or"] = "openroad",
+  scad = "openscad",
   ora = "ora",
   org = "org",
   org_archive = "org",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -383,6 +383,7 @@ let s:filename_checks = {
     \ 'omnimark': ['file.xom', 'file.xin'],
     \ 'opam': ['opam', 'file.opam', 'file.opam.template'],
     \ 'openroad': ['file.or'],
+    \ 'openscad': ['file.scad'],
     \ 'ora': ['file.ora'],
     \ 'org': ['file.org', 'file.org_archive'],
     \ 'pamconf': ['/etc/pam.conf', '/etc/pam.d/file', 'any/etc/pam.conf', 'any/etc/pam.d/file'],


### PR DESCRIPTION
Problem:    Openscad files are not recognized.
Solution:   Add a filetype pattern. (Niklas Adam, closes vim/vim#10199)
https://github.com/vim/vim/commit/c360b2566ce2390d45d9436a6a85719fe2b387d5