### PR TITLE
vim-patch:8.2.0791

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2373,8 +2373,13 @@ int parse_cmd_address(exarg_T *eap, char **errormsg, bool silent)
     switch (eap->addr_type) {
     case ADDR_LINES:
     case ADDR_OTHER:
-      // default is current line number
-      eap->line2 = curwin->w_cursor.lnum;
+      // Default is the cursor line number.  Avoid using an invalid
+      // line number though.
+      if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
+        eap->line2 = curbuf->b_ml.ml_line_count;
+      } else {
+        eap->line2 = curwin->w_cursor.lnum;
+      }
       break;
     case ADDR_WINDOWS:
       eap->line2 = CURRENT_WIN_NR;

--- a/test/functional/ex_cmds/quickfix_commands_spec.lua
+++ b/test/functional/ex_cmds/quickfix_commands_spec.lua
@@ -109,4 +109,17 @@ describe('quickfix', function()
     ]])
     eq({0, 6, 1, 0, 1}, funcs.getcurpos())
   end)
+
+  it('BufAdd does not cause E16 when reusing quickfix buffer #18135', function()
+    local file = file_base .. '_reuse_qfbuf_BufAdd'
+    write_file(file, ('\n'):rep(100) .. 'foo')
+    source([[
+      set grepprg=internal
+      autocmd BufAdd * call and(0, 0)
+      autocmd QuickFixCmdPost grep ++nested cclose | cwindow
+    ]])
+    command('grep foo ' .. file)
+    command('grep foo ' .. file)
+    os.remove(file)
+  end)
 end)


### PR DESCRIPTION
Fix #18135

#### vim-patch:8.2.0791: a second popup window with terminal causes trouble

Problem:    A second popup window with terminal causes trouble.
Solution:   Disallow opening a second terminal-popup window.
            Avoid defaulting to an invalid line number.
https://github.com/vim/vim/commit/b5383b174b2436b556f76f14badb1c1f55d6d8f6

This is the only applicable hunk.