### PR TITLE
fix(treesitter): create new parser if language is not the same as cached parser

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -90,7 +90,7 @@ function M.get_parser(bufnr, lang, opts)
     lang = a.nvim_buf_get_option(bufnr, "filetype")
   end
 
-  if parsers[bufnr] == nil then
+  if parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then
     parsers[bufnr] = M._create_parser(bufnr, lang, opts)
   end
 

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local eq = helpers.eq
+local command = helpers.command
 local exec_lua = helpers.exec_lua
 local pcall_err = helpers.pcall_err
 local matches = helpers.matches
@@ -66,6 +67,16 @@ describe('treesitter API', function()
       end
     end
     eq({true,true}, {has_named,has_anonymous})
+  end)
+
+  it('checks if vim.treesitter.get_parser tries to create a new parser on filetype change', function ()
+    command("set filetype=c")
+    -- Should not throw an error when filetype is c
+    eq('c', exec_lua("return vim.treesitter.get_parser(0):lang()"))
+    command("set filetype=borklang")
+    -- Should throw an error when filetype changes to borklang
+    eq("Error executing lua: .../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
+       pcall_err(exec_lua, "new_parser = vim.treesitter.get_parser(0)"))
   end)
 end)
 


### PR DESCRIPTION
Currently `vim.treesitter.get_parser()` create a new parser only if there is no cached parser for that buffer. This is problematic when the filetype of a buffer is changed afterwards - the cached parser (with the wrong language) is still used.

This PR adds an additional condition for creating a new parser, ie when `cached_parser._lang` is not equal to the current lang

Closes #18148 