### PR TITLE
vim-patch:8.2.4778: pacman files use dosini filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1283,13 +1283,13 @@ au BufNewFile,BufRead *.org,*.org_archive	setf org
 " Packet filter conf
 au BufNewFile,BufRead pf.conf			setf pf
 
-" Pacman Config (close enough to dosini)
-au BufNewFile,BufRead */etc/pacman.conf		setf dosini
+" Pacman config
+au BufNewFile,BufRead */etc/pacman.conf		setf conf
 
 " Pacman hooks
 au BufNewFile,BufRead *.hook
 	\ if getline(1) == '[Trigger]' |
-	\   setf dosini |
+	\   setf conf |
 	\ endif
 
 " Pam conf

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -103,6 +103,11 @@ local extension = {
   cbl = "cobol",
   atg = "coco",
   recipe = "conaryrecipe",
+  hook = function(path, bufnr)
+    if getline(bufnr, 1) == '[Trigger]' then
+      return "conf"
+    end
+  end,
   mklx = "context",
   mkiv = "context",
   mkii = "context",
@@ -903,7 +908,7 @@ local filename = {
   Dockerfile = "dockerfile",
   npmrc = "dosini",
   ["/etc/yum.conf"] = "dosini",
-  ["/etc/pacman.conf"] = "dosini",
+  ["/etc/pacman.conf"] = "conf",
   [".npmrc"] = "dosini",
   [".editorconfig"] = "dosini",
   dune = "dune",
@@ -1182,7 +1187,7 @@ local pattern = {
   [".*/etc/DIR_COLORS"] = "dircolors",
   [".*/etc/dnsmasq%.conf"] = "dnsmasq",
   ["php%.ini%-.*"] = "dosini",
-  [".*/etc/pacman%.conf"] = "dosini",
+  [".*/etc/pacman%.conf"] = "conf",
   [".*/etc/yum%.conf"] = "dosini",
   [".*lvs"] = "dracula",
   [".*lpe"] = "dracula",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -113,7 +113,7 @@ let s:filename_checks = {
     \ 'cobol': ['file.cbl', 'file.cob', 'file.lib'],
     \ 'coco': ['file.atg'],
     \ 'conaryrecipe': ['file.recipe'],
-    \ 'conf': ['auto.master'],
+    \ 'conf': ['/etc/pacman.conf', 'any/etc/pacman.conf', 'auto.master'],
     \ 'config': ['configure.in', 'configure.ac', '/etc/hostname.file'],
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
     \ 'cook': ['file.cook'],
@@ -152,7 +152,7 @@ let s:filename_checks = {
     \ 'dnsmasq': ['/etc/dnsmasq.conf', '/etc/dnsmasq.d/file', 'any/etc/dnsmasq.conf', 'any/etc/dnsmasq.d/file'],
     \ 'dockerfile': ['Containerfile', 'Dockerfile', 'file.Dockerfile', 'Dockerfile.debian', 'Containerfile.something'],
     \ 'dosbatch': ['file.bat'],
-    \ 'dosini': ['.editorconfig', '/etc/pacman.conf', '/etc/yum.conf', 'file.ini', 'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', '/etc/yum.repos.d/file', 'any/etc/pacman.conf', 'any/etc/yum.conf', 'any/etc/yum.repos.d/file', 'file.wrap'],
+    \ 'dosini': ['.editorconfig', '/etc/yum.conf', 'file.ini', 'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', '/etc/yum.repos.d/file', 'any/etc/yum.conf', 'any/etc/yum.repos.d/file', 'file.wrap'],
     \ 'dot': ['file.dot', 'file.gv'],
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
     \ 'dtd': ['file.dtd'],
@@ -1172,12 +1172,12 @@ func Test_hook_file()
 
   call writefile(['[Trigger]', 'this is pacman config'], 'Xfile.hook')
   split Xfile.hook
-  call assert_equal('dosini', &filetype)
+  call assert_equal('conf', &filetype)
   bwipe!
 
   call writefile(['not pacman'], 'Xfile.hook')
   split Xfile.hook
-  call assert_notequal('dosini', &filetype)
+  call assert_notequal('conf', &filetype)
   bwipe!
 
   call delete('Xfile.hook')


### PR DESCRIPTION
Problem:    Pacman files use dosini filetype.
Solution:   Use conf instead. (Chaoren Lin, closes vim/vim#10213)
https://github.com/vim/vim/commit/35cff32dd82e5e2b72453b9f27d0655fc5b8a639