### PR TITLE
feat: add `undo!`

### DIFF
--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -22,6 +22,14 @@ u			Undo [count] changes.
 :u[ndo] {N}		Jump to after change number {N}.  See |undo-branches|
 			for the meaning of {N}.
 
+:u[ndo]!		Undo one change and remove it from undo history.
+								*E5767*
+:u[ndo]! {N}		Like ":u[ndo] {N}", but forget all changes in the
+			current undo branch up until {N}. You may only use
+			":undo! {N}" to move backwards in the same undo
+			branch, not to redo or switch to a different undo
+			branch.
+
 							*CTRL-R*
 CTRL-R			Redo [count] changes which were undone.
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2947,7 +2947,7 @@ module.cmds = {
   },
   {
     command='undo',
-    flags=bit.bor(RANGE, COUNT, ZEROR, TRLBAR, CMDWIN),
+    flags=bit.bor(BANG, RANGE, COUNT, ZEROR, TRLBAR, CMDWIN),
     addr_type='ADDR_OTHER',
     func='ex_undo',
   },

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1013,6 +1013,9 @@ EXTERN char e_line_number_out_of_range[] INIT(= N_("E1247: Line number out of ra
 
 EXTERN char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group name too long"));
 
+EXTERN char e_undobang_cannot_redo_or_move_branch[]
+INIT(= N_("E5767: Cannot use :undo! to redo or move to a different undo branch"));
+
 EXTERN char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 


### PR DESCRIPTION
Allows using `undo!` to undo changes without saving them to the undo-tree