### PR TITLE
docs(api): add example showing necessity to wrap callback function

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3221,6 +3221,22 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
                     })
 <
 
+                Lua functions receive a table with information about the
+                autocmd event as argument, if you're using a function which
+                already takes another optional parameter, you have to wrap the
+                function in a lambda:
+>
+    -- Lua function with an optional parameter.
+    -- The autocmd callback would pass a table as argument but this
+    -- function expects number|nil
+    local myluafun = function(bufnr) bufnr = bufnr or vim.api.nvim_get_current_buf() end
+
+    vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
+      pattern = {"*.c", "*.h"},
+      callback = function() myluafun() end,
+    })
+<
+
                 Example using command: >
                     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
                       pattern = {"*.c", "*.h"},

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3222,9 +3222,9 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
 <
 
                 Lua functions receive a table with information about the
-                autocmd event as argument, if you're using a function which
-                already takes another optional parameter, you have to wrap the
-                function in a lambda:
+                autocmd event as an argument. To use a function which itself
+                accepts another (optional) parameter, wrap the function in a
+                lambda:
 >
     -- Lua function with an optional parameter.
     -- The autocmd callback would pass a table as argument but this

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -346,6 +346,22 @@ cleanup:
 ///     })
 /// </pre>
 ///
+/// Lua functions receive a table with information about the autocmd event as argument, if you're
+/// using a function which already takes another optional parameter, you have to wrap the function
+/// in a lambda:
+///
+/// <pre>
+///     -- Lua function with an optional parameter.
+///     -- The autocmd callback would pass a table as argument but this
+///     -- function expects number|nil
+///     local myluafun = function(bufnr) bufnr = bufnr or vim.api.nvim_get_current_buf() end
+///
+///     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
+///       pattern = {"*.c", "*.h"},
+///       callback = function() myluafun() end,
+///     })
+/// </pre>
+///
 /// Example using command:
 /// <pre>
 ///     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -346,8 +346,8 @@ cleanup:
 ///     })
 /// </pre>
 ///
-/// Lua functions receive a table with information about the autocmd event as argument, if you're
-/// using a function which already takes another optional parameter, you have to wrap the function
+/// Lua functions receive a table with information about the autocmd event as an argument. To use
+/// a function which itself accepts another (optional) parameter, wrap the function
 /// in a lambda:
 ///
 /// <pre>


### PR DESCRIPTION
Some people ran into issues trying to use `callback = myluafun` because
of the event data payload.
