### PR TITLE
feat(tui): query terminal for CSI u support

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -117,6 +117,43 @@ go to the window below: >
   tmux send-keys 'Escape' [ 2 7 u 'C-W' j
 Where `'Escape' [ 2 7 u` is an unambiguous `CSI u` sequence for the <Esc> key.
 
+						*tui-modifyOtherKeys* *tui-csiu*
+Historically, terminal emulators could not distinguish between certain control
+key modifiers and other keys. For example, <C-I> and <Tab> are represented the
+same way, as are <Esc> and <C-[>, <CR> and <C-M>, and <NL> and <C-J>. This
+meant that Nvim also could not map these keys separately.
+
+Modern terminal emulators are able to distinguish between these pairs of keys
+by encoding control modifiers differently. There are two common but distinct
+ways of doing this, known as "modifyOtherKeys" and "CSI u". Nvim supports both
+encoding methods and at startup will tell the terminal emulator that it
+understands these key encodings. If your terminal emulator supports it then
+this will allow you to map the key pairs listed above separately.
+
+At startup Nvim will query your terminal to see if it supports the CSI u
+encoding by writing the sequence >
+
+	CSI ? u CSI c
+
+If your terminal emulator responds with >
+
+	CSI ? <flags> u
+
+this means your terminal supports the CSI u encoding and Nvim will tell your
+terminal to enable it by writing the sequence >
+
+	CSI > 1 u
+
+If your terminal does not support CSI u then Nvim will instead enable the
+"modifyOtherKeys" encoding by writing the sequence >
+
+	CSI > 4 ; 2 m
+
+When Nvim exits cleanly it will send the corresponding sequence to disable the
+special key encoding. If Nvim does not exit cleanly then your terminal
+emulator could be in a bad state. If this happens, simply run "reset".
+
+
 							*tui-colors*
 Nvim uses 256 colours by default, ignoring |terminfo| for most terminal types,
 including "linux" (whose virtual terminals have had 256-colour support since

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -6,6 +6,13 @@
 
 #include "nvim/event/stream.h"
 #include "nvim/event/time.h"
+#include "nvim/tui/tui.h"
+
+typedef enum {
+  kExtkeysNone,
+  kExtkeysCSIu,
+  kExtkeysXterm,
+} ExtkeysType;
 
 typedef struct term_input {
   int in_fd;
@@ -14,6 +21,8 @@ typedef struct term_input {
   bool waiting;
   bool ttimeout;
   int8_t waiting_for_bg_response;
+  int8_t waiting_for_csiu_response;
+  ExtkeysType extkeys_type;
   long ttimeoutlen;
   TermKey *tk;
 #if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
@@ -25,6 +34,7 @@ typedef struct term_input {
   RBuffer *key_buffer;
   uv_mutex_t key_buffer_mutex;
   uv_cond_t key_buffer_cond;
+  TUIData *tui_data;
 } TermInput;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/tui/tui.h
+++ b/src/nvim/tui/tui.h
@@ -4,6 +4,8 @@
 #include "nvim/cursor_shape.h"
 #include "nvim/ui.h"
 
+typedef struct TUIData TUIData;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "tui/tui.h.generated.h"
 #endif

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -52,11 +52,15 @@ describe('Command-line option', function()
       if helpers.pending_win32(pending) then return end
       local screen = Screen.new(40, 8)
       screen:attach()
-      funcs.termopen({
+      local args = {
         nvim_prog_abs(), '-u', 'NONE', '-i', 'NONE',
-         '--cmd', 'set noswapfile shortmess+=IFW fileformats=unix',
-         '-s', '-'
-      })
+        '--cmd', 'set noswapfile shortmess+=IFW fileformats=unix',
+        '-s', '-'
+      }
+
+      -- Need to explicitly pipe to stdin so that the embedded Nvim instance doesn't try to read
+      -- data from the terminal #18181
+      funcs.termopen(string.format([[echo "" | %s]], table.concat(args, " ")))
       screen:expect([[
         ^                                        |
         {1:~                                       }|


### PR DESCRIPTION
On startup query the terminal for CSI u support and enable it using the escape sequence from kitty's [progressive enhancement protocol][1].

See also https://github.com/neovim/neovim/pull/16570 for a broader implementation of the kitty keyboard protocol.

[1]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
