### PR TITLE
vim-patch:8.1.1756,8.2.{2472,2474,2475,2476,2477,4791,4802}: autocommand fixes

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4855,6 +4855,10 @@ void do_arg_all(int count, int forceit, int keep_tabs)
             if (keep_tabs) {
               new_curwin = wp;
               new_curtab = curtab;
+            } else if (wp->w_frame->fr_parent != curwin->w_frame->fr_parent) {
+              emsg(_("E249: window layout changed unexpectedly"));
+              i = count;
+              break;
             } else {
               win_move_after(wp, curwin);
             }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1748,20 +1748,13 @@ buf_T *buflist_new(char_u *ffname_arg, char_u *sfname_arg, linenr_T lnum, int fl
     buf = curbuf;
     // It's like this buffer is deleted.  Watch out for autocommands that
     // change curbuf!  If that happens, allocate a new buffer anyway.
-    if (curbuf->b_p_bl) {
-      apply_autocmds(EVENT_BUFDELETE, NULL, NULL, false, curbuf);
-    }
-    if (buf == curbuf) {
-      apply_autocmds(EVENT_BUFWIPEOUT, NULL, NULL, false, curbuf);
+    buf_freeall(buf, BFA_WIPE | BFA_DEL);
+    if (buf != curbuf) {  // autocommands deleted the buffer!
+      return NULL;
     }
     if (aborting()) {           // autocmds may abort script processing
       xfree(ffname);
       return NULL;
-    }
-    if (buf == curbuf) {
-      // Make sure 'bufhidden' and 'buftype' are empty
-      clear_string_option(&buf->b_p_bh);
-      clear_string_option(&buf->b_p_bt);
     }
   }
   if (buf != curbuf || curbuf == NULL) {
@@ -1782,14 +1775,6 @@ buf_T *buflist_new(char_u *ffname_arg, char_u *sfname_arg, linenr_T lnum, int fl
   buf->b_wininfo = xcalloc(1, sizeof(wininfo_T));
 
   if (buf == curbuf) {
-    // free all things allocated for this buffer
-    buf_freeall(buf, 0);
-    if (buf != curbuf) {         // autocommands deleted the buffer!
-      return NULL;
-    }
-    if (aborting()) {           // autocmds may abort script processing
-      return NULL;
-    }
     free_buffer_stuff(buf, kBffInitChangedtick);  // delete local vars et al.
 
     // Init the options.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -532,6 +532,8 @@ struct file_buffer {
   int b_flags;                  // various BF_ flags
   int b_locked;                 // Buffer is being closed or referenced, don't
                                 // let autocommands wipe it out.
+  int b_locked_split;           // Buffer is being closed, don't allow opening
+                                // a new window with it.
   int b_ro_locked;              // Non-zero when the buffer can't be changed.
                                 // Used for FileChangedRO
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6376,6 +6376,7 @@ static int open_cmdwin(void)
   // Create a window for the command-line buffer.
   if (win_split((int)p_cwh, WSP_BOT) == FAIL) {
     beep_flush();
+    ga_clear(&winsizes);
     return K_IGNORE;
   }
   cmdwin_type = get_cmdline_type();

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2313,7 +2313,10 @@ static bool qflist_valid(win_T *wp, unsigned int qf_id)
   qf_info_T *qi = &ql_info;
 
   if (wp) {
-    qi = GET_LOC_LIST(wp);
+    if (!win_valid(wp)) {
+      return false;
+    }
+    qi = GET_LOC_LIST(wp);  // Location list
     if (!qi) {
       return false;
     }

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2717,6 +2717,9 @@ endfunc
 
 " Fuzzer found some strange combination that caused a crash.
 func Test_autocmd_normal_mess()
+  " TODO: why does this hang on Windows?
+  CheckNotMSWindows
+
   augroup aucmd_normal_test
     au BufLeave,BufWinLeave,BufHidden,BufUnload,BufDelete,BufWipeout * norm 7q/qc
   augroup END

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2695,9 +2695,9 @@ func Test_autocmd_closes_window()
   au BufNew,BufWinLeave * e %e
   file yyy
   au BufNew,BufWinLeave * ball
-  call assert_fails('n xxx', 'E143:')
+  n xxx
 
-  bwipe %
+  %bwipe
   au! BufNew
   au! BufWinLeave
 endfunc
@@ -2711,6 +2711,23 @@ func Test_autocmd_quit_psearch()
   ps /
 
   augroup aucmd_win_test
+    au!
+  augroup END
+endfunc
+
+" Fuzzer found some strange combination that caused a crash.
+func Test_autocmd_normal_mess()
+  augroup aucmd_normal_test
+    au BufLeave,BufWinLeave,BufHidden,BufUnload,BufDelete,BufWipeout * norm 7q/qc
+  augroup END
+  " Nvim has removed :open
+  " o4
+  e4
+  silent! H
+  e xx
+  normal G
+
+  augroup aucmd_normal_test
     au!
   augroup END
 endfunc

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2713,6 +2713,8 @@ func Test_autocmd_quit_psearch()
   augroup aucmd_win_test
     au!
   augroup END
+  new
+  pclose
 endfunc
 
 " Fuzzer found some strange combination that caused a crash.
@@ -2748,12 +2750,12 @@ func Test_autocmd_closing_cmdwin()
 endfunc
 
 func Test_autocmd_vimgrep()
-  %bwipe!
   augroup aucmd_vimgrep
     au QuickfixCmdPre,BufNew,BufReadCmd * sb
-    au QuickfixCmdPre,BufNew,BufReadCmd * q9 
+    " Nvim makes aucmd_win the last window
+    " au QuickfixCmdPre,BufNew,BufReadCmd * q9
+    au QuickfixCmdPre,BufNew,BufReadCmd * exe 'q' .. (winnr('$') - (win_gettype(winnr('$')) == 'autocmd'))
   augroup END
-  %bwipe!
   call assert_fails('lv ?a? foo', 'E926:')
 
   augroup aucmd_vimgrep

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2717,17 +2717,14 @@ endfunc
 
 " Fuzzer found some strange combination that caused a crash.
 func Test_autocmd_normal_mess()
-  " TODO: why does this hang on Windows?
-  CheckNotMSWindows
-
   augroup aucmd_normal_test
     au BufLeave,BufWinLeave,BufHidden,BufUnload,BufDelete,BufWipeout * norm 7q/qc
   augroup END
   " Nvim has removed :open
-  " o4
-  e4
+  " call assert_fails('o4', 'E1159')
+  call assert_fails('e4', 'E1159')
   silent! H
-  e xx
+  call assert_fails('e xx', 'E1159')
   normal G
 
   augroup aucmd_normal_test
@@ -2749,7 +2746,7 @@ func Test_autocmd_vimgrep()
     au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * sb
     au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * q9 
   augroup END
-  " TODO: if this is executed directly valgrind reports errors
+  %bwipe!
   call assert_fails('lv?a?', 'E926:')
 
   augroup aucmd_vimgrep

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2717,6 +2717,9 @@ endfunc
 
 " Fuzzer found some strange combination that caused a crash.
 func Test_autocmd_normal_mess()
+  " For unknown reason this hangs on MS-Windows
+  CheckNotMSWindows
+
   augroup aucmd_normal_test
     au BufLeave,BufWinLeave,BufHidden,BufUnload,BufDelete,BufWipeout * norm 7q/qc
   augroup END
@@ -2733,6 +2736,9 @@ func Test_autocmd_normal_mess()
 endfunc
 
 func Test_autocmd_closing_cmdwin()
+  " For unknown reason this hangs on MS-Windows
+  CheckNotMSWindows
+
   au BufWinLeave * nested q
   call assert_fails("norm 7q?\n", 'E855:')
 
@@ -2747,7 +2753,7 @@ func Test_autocmd_vimgrep()
     au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * q9 
   augroup END
   %bwipe!
-  call assert_fails('lv?a?', 'E926:')
+  call assert_fails('lv ?a? foo', 'E926:')
 
   augroup aucmd_vimgrep
     au!

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2748,9 +2748,10 @@ func Test_autocmd_closing_cmdwin()
 endfunc
 
 func Test_autocmd_vimgrep()
+  %bwipe!
   augroup aucmd_vimgrep
-    au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * sb
-    au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * q9 
+    au QuickfixCmdPre,BufNew,BufReadCmd * sb
+    au QuickfixCmdPre,BufNew,BufReadCmd * q9 
   augroup END
   %bwipe!
   call assert_fails('lv ?a? foo', 'E926:')
@@ -2794,5 +2795,23 @@ func Test_v_event_readonly()
   au! TextYankPost
 endfunc
 
+
+func Test_noname_autocmd()
+  augroup test_noname_autocmd_group
+    autocmd!
+    autocmd BufEnter * call add(s:li, ["BufEnter", expand("<afile>")])
+    autocmd BufDelete * call add(s:li, ["BufDelete", expand("<afile>")])
+    autocmd BufLeave * call add(s:li, ["BufLeave", expand("<afile>")])
+    autocmd BufUnload * call add(s:li, ["BufUnload", expand("<afile>")])
+    autocmd BufWipeout * call add(s:li, ["BufWipeout", expand("<afile>")])
+  augroup END
+
+  let s:li = []
+  edit foo
+  call assert_equal([['BufUnload', ''], ['BufDelete', ''], ['BufWipeout', ''], ['BufEnter', 'foo']], s:li)
+
+  au! test_noname_autocmd_group
+  augroup! test_noname_autocmd_group
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2741,6 +2741,19 @@ func Test_autocmd_closing_cmdwin()
   only
 endfunc
 
+func Test_autocmd_vimgrep()
+  augroup aucmd_vimgrep
+    au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * sb
+    au QuickfixCmdPre,BufNew,BufDelete,BufReadCmd * q9 
+  augroup END
+  " TODO: if this is executed directly valgrind reports errors
+  call assert_fails('lv?a?', 'E926:')
+
+  augroup aucmd_vimgrep
+    au!
+  augroup END
+endfunc
+
 func Test_bufwipeout_changes_window()
   " This should not crash, but we don't have any expectations about what
   " happens, changing window in BufWipeout has unpredictable results.

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -513,14 +513,15 @@ func Test_window_colon_command()
 endfunc
 
 func Test_access_freed_mem()
+  call assert_equal(&columns, winwidth(0))
   " This was accessing freed memory (but with what events?)
   au BufEnter,BufLeave,WinEnter,WinLeave 0 vs xxx
   arg 0
   argadd
-  all
-  all
+  call assert_fails("all", "E242:")
   au!
   bwipe xxx
+  call assert_equal(&columns, winwidth(0))
 endfunc
 
 func Test_visual_cleared_after_window_split()

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -74,6 +74,35 @@ typedef enum {
 
 static char *m_onlyone = N_("Already only one window");
 
+/// When non-zero splitting a window is forbidden.  Used to avoid that nasty
+/// autocommands mess up the window structure.
+static int split_disallowed = 0;
+
+// #define WIN_DEBUG
+#ifdef WIN_DEBUG
+/// Call this method to log the current window layout.
+static void log_frame_layout(frame_T *frame)
+{
+  DLOG("layout %s, wi: %d, he: %d, wwi: %d, whe: %d, id: %d",
+       frame->fr_layout == FR_LEAF ? "LEAF" : frame->fr_layout == FR_ROW ? "ROW" : "COL",
+       frame->fr_width,
+       frame->fr_height,
+       frame->fr_win == NULL ? -1 : frame->fr_win->w_width,
+       frame->fr_win == NULL ? -1 : frame->fr_win->w_height,
+       frame->fr_win == NULL ? -1 : frame->fr_win->w_id);
+  if (frame->fr_child != NULL) {
+    DLOG("children");
+    log_frame_layout(frame->fr_child);
+    if (frame->fr_next != NULL) {
+      DLOG("END of children");
+    }
+  }
+  if (frame->fr_next != NULL) {
+    log_frame_layout(frame->fr_next);
+  }
+}
+#endif
+
 /// @return the current window, unless in the cmdline window and "prevwin" is
 /// set, then return "prevwin".
 win_T *prevwin_curwin(void)
@@ -909,6 +938,17 @@ void ui_ext_win_viewport(win_T *wp)
   }
 }
 
+/// If "split_disallowed" is set given an error and return FAIL.
+/// Otherwise return OK.
+static int check_split_disallowed(void)
+{
+  if (split_disallowed > 0) {
+    emsg(_("E242: Can't split a window while closing another"));
+    return FAIL;
+  }
+  return OK;
+}
+
 /*
  * split the current window, implements CTRL-W s and :split
  *
@@ -935,6 +975,9 @@ int win_split(int size, int flags)
   flags |= cmdmod.split;
   if ((flags & WSP_TOP) && (flags & WSP_BOT)) {
     emsg(_("E442: Can't split topleft and botright at the same time"));
+    return FAIL;
+  }
+  if (check_split_disallowed() == FAIL) {
     return FAIL;
   }
 
@@ -1886,6 +1929,9 @@ static void win_totop(int size, int flags)
   if (curwin == aucmd_win) {
     return;
   }
+  if (check_split_disallowed() == FAIL) {
+    return;
+  }
 
   if (curwin->w_floating) {
     ui_comp_remove_grid(&curwin->w_grid_alloc);
@@ -1929,6 +1975,11 @@ void win_move_after(win_T *win1, win_T *win2)
 
   // check if there is something to do
   if (win2->w_next != win1) {
+    if (win1->w_frame->fr_parent != win2->w_frame->fr_parent) {
+      iemsg("INTERNAL: trying to move a window into another frame");
+      return;
+    }
+
     // may need move the status line, horizontal or vertical separator of the last window
     if (win1 == lastwin) {
       height = win1->w_prev->w_status_height;
@@ -2742,6 +2793,10 @@ int win_close(win_T *win, bool free_buf, bool force)
     return FAIL;
   }
 
+  // Now we are really going to close the window.  Disallow any autocommand
+  // to split a window to avoid trouble.
+  split_disallowed++;
+
   // let terminal buffers know that this window dimensions may be ignored
   win->w_closing = true;
 
@@ -2808,6 +2863,8 @@ int win_close(win_T *win, bool free_buf, bool force)
       apply_autocmds(EVENT_BUFENTER, NULL, NULL, false, curbuf);
     }
   }
+
+  split_disallowed--;
 
   /*
    * If last window has a status line now and we don't want one,

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -548,18 +548,6 @@ describe('autocmd', function()
       neq({}, meths.get_autocmds { group = "filetypedetect" })
     end)
 
-    it('should not access freed mem', function()
-      source [[
-        au BufEnter,BufLeave,WinEnter,WinLeave 0 vs xxx
-        arg 0
-        argadd
-        all
-        all
-        au!
-        bwipe xxx
-      ]]
-    end)
-
     it('should allow comma-separated patterns', function()
       source [[
         augroup TestingPatterns

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -60,6 +60,23 @@ describe('autocmd', function()
     eq(expected, eval('g:evs'))
   end)
 
+  it('first edit causes BufUnload on NoName', function()
+    local expected = {
+      {'BufUnload', ''},
+      {'BufDelete', ''},
+      {'BufWipeout', ''},
+      {'BufEnter', 'testfile1'},
+    }
+    command('let g:evs = []')
+    command('autocmd BufEnter * :call add(g:evs, ["BufEnter", expand("<afile>")])')
+    command('autocmd BufDelete * :call add(g:evs, ["BufDelete", expand("<afile>")])')
+    command('autocmd BufLeave * :call add(g:evs, ["BufLeave", expand("<afile>")])')
+    command('autocmd BufUnload * :call add(g:evs, ["BufUnload", expand("<afile>")])')
+    command('autocmd BufWipeout * :call add(g:evs, ["BufWipeout", expand("<afile>")])')
+    command('edit testfile1')
+    eq(expected, eval('g:evs'))
+  end)
+
   it('WinClosed is non-recursive', function()
     command('let g:triggered = 0')
     command('autocmd WinClosed * :let g:triggered+=1 | :bdelete 2')


### PR DESCRIPTION
#### vim-patch:8.1.1756: autocommand that splits window messes up window layout

Problem:    Autocommand that splits window messes up window layout.
Solution:   Disallow splitting a window while closing one.  In ":all" give an
            error when moving a window will not work.
https://github.com/vim/vim/commit/1417c766f55e5959b31da488417b7d9b141404af

Expected error number was changed to E242 in Vim in patch 8.2.1183, and
patch 8.2.2420 (which has already been ported) made the test no longer
throw E249 in Vim, so just use E242 in the test.


#### vim-patch:8.2.2472: crash when using command line window in an autocommand

Problem:    Crash when using command line window in an autocommand.
            (houyunsong)
Solution:   Save and restore au_new_curbuf.
https://github.com/vim/vim/commit/aad5f9d79a2b71e9d2581eace3652be156102b9d

Nvim has removed :open, so use :edit in the test instead.


#### vim-patch:8.2.2474: using freed memory when window is closed by autocommand

Problem:    Using freed memory when window is closed by autocommand.
            (houyunsong)
Solution:   Check the window pointer is still valid.
https://github.com/vim/vim/commit/2c7080bf1ceef4a7779644fd428b2386a0676794

Add missing comment from Vim patch 8.0.1420.
Test fails.


#### vim-patch:8.2.2475: autocommand tests hangs on MS-Windows

Problem:    Autocommand tests hangs on MS-Windows.
Solution:   Skip one test.
https://github.com/vim/vim/commit/dfc3db76b9de217542cc9258301c1b4818a51cd0


#### vim-patch:8.2.2476: using freed memory when splitting window while closing buffer

Problem:    Using freed memory when using an autocommand to split a window
            while a buffer is being closed.
Solution:   Disallow splitting when the buffer has b_locked_split set.
https://github.com/vim/vim/commit/983d83ff1cd796ff321074335fa53fbe7ac45a46

Put the error message in window.c.
Cherry-pick a memory leak fix from Vim patch 8.2.0399.
Test still fails.


#### vim-patch:8.2.2477: autocommand tests hang on MS-Windows

Problem:    Autocommand tests hang on MS-Windows.
Solution:   Skip a couple of tests.  Fix file name.
https://github.com/vim/vim/commit/dd07c02232e91ee963b91a4477179d4b9548b862


#### vim-patch:8.2.4791: events triggered in different order when reusing buffer

Problem:    Autocmd events triggered in different order when reusing an empty
            buffer.
Solution:   Call buff_freeall() earlier. (Charlie Groves, closes vim/vim#10198)
https://github.com/vim/vim/commit/fef4485ef58d5937b170c6dc69431359469fc9cd

Test failure becomes very strange.


#### vim-patch:8.2.4802: test is not cleaned up

Problem:    Test is not cleaned up.
Solution:   Make test clean up after itself.  Avoid NUL. (closes vim/vim#10233)
https://github.com/vim/vim/commit/7851c69a120ea6ce8c122dd7198adbe5aec83ea5

Adapt test_autocmd_vimgrep() to Nvim.