### PR TITLE
fix(diagnostic): use nvim_exec_autocmds to trigger DiagnosticChanged

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -668,14 +668,10 @@ function M.set(namespace, bufnr, diagnostics, opts)
     M.show(namespace, bufnr, nil, opts)
   end
 
-  vim.api.nvim_buf_call(bufnr, function()
-    vim.api.nvim_command(
-      string.format(
-        "doautocmd <nomodeline> DiagnosticChanged %s",
-        vim.fn.fnameescape(vim.api.nvim_buf_get_name(bufnr))
-      )
-    )
-  end)
+  vim.api.nvim_exec_autocmds("DiagnosticChanged", {
+    modeline = false,
+    buffer = bufnr,
+  })
 end
 
 --- Get namespace metadata.
@@ -1382,14 +1378,10 @@ function M.reset(namespace, bufnr)
       M.hide(iter_namespace, iter_bufnr)
     end
 
-    vim.api.nvim_buf_call(iter_bufnr, function()
-      vim.api.nvim_command(
-        string.format(
-          "doautocmd <nomodeline> DiagnosticChanged %s",
-          vim.fn.fnameescape(vim.api.nvim_buf_get_name(iter_bufnr))
-        )
-      )
-    end)
+    vim.api.nvim_exec_autocmds("DiagnosticChanged", {
+      modeline = false,
+      buffer = iter_bufnr,
+    })
   end
 end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1939,24 +1939,31 @@ describe('vim.diagnostic', function()
     end)
 
     it('triggers the autocommand when diagnostics are set', function()
-      eq(1, exec_lua [[
+      eq(true, exec_lua [[
+        -- Set a different buffer as current to test that <abuf> is being set properly in
+        -- DiagnosticChanged callbacks
+        local tmp = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_set_current_buf(tmp)
+
         vim.g.diagnostic_autocmd_triggered = 0
-        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')
+        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = +expand("<abuf>")')
         vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
         vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
           make_error('Diagnostic', 0, 0, 0, 0)
         })
-        return vim.g.diagnostic_autocmd_triggered
+        return vim.g.diagnostic_autocmd_triggered == diagnostic_bufnr
       ]])
       end)
 
     it('triggers the autocommand when diagnostics are cleared', function()
-      eq(1, exec_lua [[
+      eq(true, exec_lua [[
+        local tmp = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_set_current_buf(tmp)
         vim.g.diagnostic_autocmd_triggered = 0
-        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = 1')
+        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = +expand("<abuf>")')
         vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
         vim.diagnostic.reset(diagnostic_ns, diagnostic_bufnr)
-        return vim.g.diagnostic_autocmd_triggered
+        return vim.g.diagnostic_autocmd_triggered == diagnostic_bufnr
       ]])
       end)
   end)


### PR DESCRIPTION
Use `nvim_exec_autocmds` to issue the DiagnosticChanged autocommand, rather than `nvim_buf_call,` which has some side effects when drawing statuslines.

Fixes #16872.
