### PR TITLE
vim-patch:8.2.{4795,4796,4801}: 'cursorbind' scrolling depends on whether 'cursorline' is set

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2279,9 +2279,7 @@ void do_check_cursorbind(void)
         int restart_edit_save = restart_edit;
         restart_edit = true;
         check_cursor();
-        if (win_cursorline_standout(curwin) || curwin->w_p_cuc) {
-          validate_cursor();
-        }
+        validate_cursor();
         restart_edit = restart_edit_save;
       }
       // Correct cursor for multi-byte character.

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -343,7 +343,7 @@ func Test_cursorline_cursorbind_horizontal_scroll()
   call VerifyScreenDump(buf, 'Test_hor_scroll_4', {})
 
   call StopVimInTerminal(buf)
-  "call delete('Xhor_scroll')
+  call delete('Xhor_scroll')
 endfunc
 
 

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -318,7 +318,7 @@ func Test_cursorline_cursorbind_horizontal_scroll()
   CheckScreendump
 
   let lines =<< trim END
-      call setline(1, 'aa bb cc dd ee ff gg hh ii jj kk ll mm' .. 
+      call setline(1, 'aa bb cc dd ee ff gg hh ii jj kk ll mm' ..
       \ ' nn oo pp qq rr ss tt uu vv ww xx yy zz')
       set nowrap
       " The following makes the cursor apparent on the screen dump
@@ -341,6 +341,10 @@ func Test_cursorline_cursorbind_horizontal_scroll()
   call VerifyScreenDump(buf, 'Test_hor_scroll_3', {})
   call term_sendkeys(buf, "10l")
   call VerifyScreenDump(buf, 'Test_hor_scroll_4', {})
+  call term_sendkeys(buf, ":windo :set nocursorline nocursorcolumn\<cr>")
+  call term_sendkeys(buf, "0")
+  call term_sendkeys(buf, "40l")
+  call VerifyScreenDump(buf, 'Test_hor_scroll_5', {})
 
   call StopVimInTerminal(buf)
   call delete('Xhor_scroll')

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -314,5 +314,37 @@ func Test_cursorline_screenline_update()
   call delete('Xcul_screenline')
 endfunc
 
+func Test_cursorline_cursorbind_horizontal_scroll()
+  CheckScreendump
+
+  let lines =<< trim END
+      call setline(1, 'aa bb cc dd ee ff gg hh ii jj kk ll mm' .. 
+      \ ' nn oo pp qq rr ss tt uu vv ww xx yy zz')
+      set nowrap
+      " The following makes the cursor apparent on the screen dump
+      set sidescroll=1 cursorcolumn
+      " add empty lines, required for cursorcolumn
+      call append(1, ['','','',''])
+      20vsp
+      windo :set cursorbind
+  END
+  call writefile(lines, 'Xhor_scroll')
+
+  let buf = RunVimInTerminal('-S Xhor_scroll', #{rows: 8})
+  call term_sendkeys(buf, "20l")
+  call VerifyScreenDump(buf, 'Test_hor_scroll_1', {})
+  call term_sendkeys(buf, "10l")
+  call VerifyScreenDump(buf, 'Test_hor_scroll_2', {})
+  call term_sendkeys(buf, ":windo :set cursorline\<cr>")
+  call term_sendkeys(buf, "0")
+  call term_sendkeys(buf, "20l")
+  call VerifyScreenDump(buf, 'Test_hor_scroll_3', {})
+  call term_sendkeys(buf, "10l")
+  call VerifyScreenDump(buf, 'Test_hor_scroll_4', {})
+
+  call StopVimInTerminal(buf)
+  "call delete('Xhor_scroll')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/options/cursorbind_spec.lua
+++ b/test/functional/options/cursorbind_spec.lua
@@ -1,0 +1,78 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local command = helpers.command
+local exec = helpers.exec
+local feed = helpers.feed
+
+before_each(clear)
+
+describe("'cursorbind'", function()
+  it("behaves consistently whether 'cursorline' is set or not vim-patch:8.2.4795", function()
+    local screen = Screen.new(60, 8)
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [2] = {bold = true, reverse = true},  -- StatusLine
+      [3] = {reverse = true},  -- StatusLineNC, VertSplit
+      [4] = {background = Screen.colors.Grey90},  -- CursorLine, CursorColumn
+    })
+    screen:attach()
+    exec([[
+      call setline(1, 'aa bb cc dd ee ff gg hh ii jj kk ll mm' ..
+      \ ' nn oo pp qq rr ss tt uu vv ww xx yy zz')
+      set nowrap
+      " The following makes the cursor apparent on the screen dump
+      set sidescroll=1 cursorcolumn
+      " add empty lines, required for cursorcolumn
+      call append(1, ['','','',''])
+      20vsp
+      windo :set cursorbind
+    ]])
+    feed('20l')
+    screen:expect([[
+      a bb cc dd ee ff gg {3:│}aa bb cc dd ee ff gg^ hh ii jj kk ll mm |
+                         {4: }{3:│}                    {4: }                  |
+                         {4: }{3:│}                    {4: }                  |
+                         {4: }{3:│}                    {4: }                  |
+                         {4: }{3:│}                    {4: }                  |
+      {1:~                   }{3:│}{1:~                                      }|
+      {3:[No Name] [+]        }{2:[No Name] [+]                          }|
+                                                                  |
+    ]])
+    feed('10l')
+    screen:expect([[
+       hh ii jj kk ll mm n{3:│}aa bb cc dd ee ff gg hh ii jj ^kk ll mm |
+                {4: }         {3:│}                              {4: }        |
+                {4: }         {3:│}                              {4: }        |
+                {4: }         {3:│}                              {4: }        |
+                {4: }         {3:│}                              {4: }        |
+      {1:~                   }{3:│}{1:~                                      }|
+      {3:[No Name] [+]        }{2:[No Name] [+]                          }|
+                                                                  |
+    ]])
+    command('windo :set cursorline')
+    feed('0')
+    feed('20l')
+    screen:expect([[
+      {4:a bb cc dd ee ff gg }{3:│}{4:aa bb cc dd ee ff gg^ hh ii jj kk ll mm }|
+                         {4: }{3:│}                    {4: }                  |
+                         {4: }{3:│}                    {4: }                  |
+                         {4: }{3:│}                    {4: }                  |
+                         {4: }{3:│}                    {4: }                  |
+      {1:~                   }{3:│}{1:~                                      }|
+      {3:[No Name] [+]        }{2:[No Name] [+]                          }|
+                                                                  |
+    ]])
+    feed('10l')
+    screen:expect([[
+      {4: hh ii jj kk ll mm n}{3:│}{4:aa bb cc dd ee ff gg hh ii jj ^kk ll mm }|
+                {4: }         {3:│}                              {4: }        |
+                {4: }         {3:│}                              {4: }        |
+                {4: }         {3:│}                              {4: }        |
+                {4: }         {3:│}                              {4: }        |
+      {1:~                   }{3:│}{1:~                                      }|
+      {3:[No Name] [+]        }{2:[No Name] [+]                          }|
+                                                                  |
+    ]])
+  end)
+end)

--- a/test/functional/options/cursorbind_spec.lua
+++ b/test/functional/options/cursorbind_spec.lua
@@ -74,5 +74,18 @@ describe("'cursorbind'", function()
       {3:[No Name] [+]        }{2:[No Name] [+]                          }|
                                                                   |
     ]])
+    command('windo :set nocursorline nocursorcolumn')
+    feed('0')
+    feed('40l')
+    screen:expect([[
+      kk ll mm nn oo pp qq{3:│} bb cc dd ee ff gg hh ii jj kk ll mm n^n|
+                          {3:│}                                       |
+                          {3:│}                                       |
+                          {3:│}                                       |
+                          {3:│}                                       |
+      {1:~                   }{3:│}{1:~                                      }|
+      {3:[No Name] [+]        }{2:[No Name] [+]                          }|
+                                                                  |
+    ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.4795: 'cursorbind' scrolling depends on whether 'cursorline' is set

Problem:    'cursorbind' scrolling depends on whether 'cursorline' is set.
Solution:   Always call validate_cursor(). (Christian Brabandt, closes vim/vim#10230)
https://github.com/vim/vim/commit/2c645e8b00641f504072f35e061b7392ed41f491


#### vim-patch:8.2.4796: file left behind after running cursorline tests

Problem:    File left behind after running cursorline tests.
Solution:   Uncomment the line that deletes the file.
https://github.com/vim/vim/commit/da1050cd6fbb67cfde5b4a149d8d9db80bb4351c


#### vim-patch:8.2.4801: fix for cursorbind fix not fully tested

Problem:    Fix for cursorbind fix not fully tested.
Solution:   Add another test case. (Christian Brabandt, closes vim/vim#10240)
https://github.com/vim/vim/commit/3fd7480cd25f1e939fc2362e0644d497bcc81b71