### PR TITLE
vim-patch:8.2.4797: getwininfo() may get oudated values

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6401,6 +6401,9 @@ dict_T *get_win_info(win_T *wp, int16_t tpnr, int16_t winnr)
 {
   dict_T *const dict = tv_dict_alloc();
 
+  // make sure w_botline is valid
+  validate_botline(wp);
+
   tv_dict_add_nr(dict, S_LEN("tabnr"), tpnr);
   tv_dict_add_nr(dict, S_LEN("winnr"), winnr);
   tv_dict_add_nr(dict, S_LEN("winid"), wp->handle);

--- a/src/nvim/testdir/test_bufwintabinfo.vim
+++ b/src/nvim/testdir/test_bufwintabinfo.vim
@@ -145,6 +145,13 @@ function Test_get_win_options()
   endif
 endfunc
 
+function Test_getbufinfo_lastused()
+  new Xfoo
+  let info = getbufinfo('Xfoo')[0]
+  call assert_equal(has_key(info, 'lastused'), 1)
+  call assert_equal(type(info.lastused), type(0))
+endfunc
+
 func Test_getbufinfo_lines()
   new Xfoo
   call setline(1, ['a', 'bc', 'd'])
@@ -155,9 +162,26 @@ func Test_getbufinfo_lines()
   bw!
 endfunc
 
-function Test_getbufinfo_lastused()
-  new Xfoo
-  let info = getbufinfo('Xfoo')[0]
-  call assert_equal(has_key(info, 'lastused'), 1)
-  call assert_equal(type(info.lastused), type(0))
+func Test_getwininfo_au()
+  enew
+  call setline(1, range(1, 16))
+
+  let g:info = #{}
+  augroup T1
+    au!
+    au WinEnter * let g:info = getwininfo(win_getid())[0]
+  augroup END
+
+  4split
+  " Check that calling getwininfo() from WinEnter returns fresh values for
+  " topline and botline.
+  call assert_equal(1, g:info.topline)
+  call assert_equal(4, g:info.botline)
+  close
+
+  unlet g:info
+  augroup! T1
+  bwipe!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #13017
Fix #13510

#### vim-patch:8.2.4797: getwininfo() may get oudated values

Problem:    getwininfo() may get oudated values.
Solution:   Make sure w_botline is up-to-date. (closes vim/vim#10226)
https://github.com/vim/vim/commit/8530b41fd3872c9a1349b083470d565677948518

Correct test order and add a modeline in test_bufwintabinfo.vim.