### PR TITLE
docs: vim.keymap.set can specify buffer as an option

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2055,6 +2055,9 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
                             "silent". In addition to the options listed in
                             |nvim_set_keymap()|, this table also accepts the
                             following keys:
+                            • buffer: (number or boolean) Add a mapping to the
+                              given buffer. When "true" or 0, use the current
+                              buffer.
                             • replace_keycodes: (boolean, default true) When
                               both this and expr is "true",
                               |nvim_replace_termcodes()| is applied to the

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -40,6 +40,8 @@ local keymap = {}
 --
 ---@param opts table A table of |:map-arguments| such as "silent". In addition to the options
 ---                  listed in |nvim_set_keymap()|, this table also accepts the following keys:
+---                  - buffer: (number or boolean) Add a mapping to the given buffer. When "true"
+---                    or 0, use the current buffer.
 ---                  - replace_keycodes: (boolean, default true) When both this and expr is "true",
 ---                  |nvim_replace_termcodes()| is applied to the result of Lua expr maps.
 ---                  - remap: (boolean) Make the mapping recursive. This is the


### PR DESCRIPTION
because the implementation does.
Added lines are copied from the corresponding document in the `vim.keymap.del`

https://github.com/neovim/neovim/blob/db851cb105ac9f295a836a39ff73da14a70ae754/runtime/lua/vim/keymap.lua#L92-L93