### PR TITLE
vim-patch:8.2.4759: CurSearch highlight does not work for multi-line match

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1027,6 +1027,7 @@ typedef struct {
   colnr_T startcol;     // in win_line() points to char where HL starts
   colnr_T endcol;       // in win_line() points to char where HL ends
   bool is_addpos;       // position specified directly by matchaddpos()
+  bool has_cursor;      // true if the cursor is inside the match, used for CurSearch
   proftime_T tm;        // for a time limit
 } match_T;
 

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -968,7 +968,17 @@ func Test_hlsearch_cursearch()
   call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_single_line_3', {})
 
   call term_sendkeys(buf, "gg/foo\\nbar\<CR>")
-  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line', {})
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line_1', {})
+
+  call term_sendkeys(buf, ":call setline(1, ['---', 'abcdefg', 'hijkl', '---', 'abcdefg', 'hijkl'])\<CR>")
+  call term_sendkeys(buf, "gg/efg\\nhij\<CR>")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line_2', {})
+  call term_sendkeys(buf, "h\<C-L>")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line_3', {})
+  call term_sendkeys(buf, "j\<C-L>")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line_4', {})
+  call term_sendkeys(buf, "h\<C-L>")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line_5', {})
 
   call StopVimInTerminal(buf)
   call delete('Xhlsearch_cursearch')

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -163,53 +163,68 @@ describe('search highlighting', function()
     end)
 
     it('works for multiline match', function()
-      insert([[
-        one
-        foo
-        bar
-        baz
-        foo
-        bar]])
-        feed('gg/foo<CR>')
-        screen:expect([[
-          one                                     |
-          {2:^foo}                                     |
-          bar                                     |
-          baz                                     |
-          {1:foo}                                     |
-          bar                                     |
-          /foo                                    |
-        ]])
-        feed('n')
-        screen:expect([[
-          one                                     |
-          {1:foo}                                     |
-          bar                                     |
-          baz                                     |
-          {2:^foo}                                     |
-          bar                                     |
-          /foo                                    |
-        ]])
-        feed('?<CR>')
-        screen:expect([[
-          one                                     |
-          {2:^foo}                                     |
-          bar                                     |
-          baz                                     |
-          {1:foo}                                     |
-          bar                                     |
-          ?foo                                    |
-        ]])
-        feed('gg/foo\\nbar<CR>')
-        screen:expect([[
-          one                                     |
-          {2:^foo}                                     |
-          {1:bar}                                     |
-          baz                                     |
-          {1:foo}                                     |
-          {1:bar}                                     |
-          /foo\nbar                               |
-        ]])
+      command([[call setline(1, ['one', 'foo', 'bar', 'baz', 'foo', 'bar'])]])
+      feed('gg/foo<CR>')
+      screen:expect([[
+        one                                     |
+        {2:^foo}                                     |
+        bar                                     |
+        baz                                     |
+        {1:foo}                                     |
+        bar                                     |
+        /foo                                    |
+      ]])
+      feed('n')
+      screen:expect([[
+        one                                     |
+        {1:foo}                                     |
+        bar                                     |
+        baz                                     |
+        {2:^foo}                                     |
+        bar                                     |
+        /foo                                    |
+      ]])
+      feed('?<CR>')
+      screen:expect([[
+        one                                     |
+        {2:^foo}                                     |
+        bar                                     |
+        baz                                     |
+        {1:foo}                                     |
+        bar                                     |
+        ?foo                                    |
+      ]])
+      feed('gg/foo\\nbar<CR>')
+      screen:expect([[
+        one                                     |
+        {2:^foo}                                     |
+        {2:bar}                                     |
+        baz                                     |
+        {1:foo}                                     |
+        {1:bar}                                     |
+        /foo\nbar                               |
+      ]])
+      command([[call setline(1, ['---', 'abcdefg', 'hijkl', '---', 'abcdefg', 'hijkl'])]])
+      feed('gg/efg\\nhij<CR>')
+      screen:expect([[
+        ---                                     |
+        abcd{2:^efg}                                 |
+        {2:hij}kl                                   |
+        ---                                     |
+        abcd{1:efg}                                 |
+        {1:hij}kl                                   |
+        /efg\nhij                               |
+      ]])
+      feed('n')
+      screen:expect([[
+        ---                                     |
+        abcd{1:efg}                                 |
+        {1:hij}kl                                   |
+        ---                                     |
+        abcd{2:^efg}                                 |
+        {2:hij}kl                                   |
+        /efg\nhij                               |
+      ]])
     end)
   end)
 


### PR DESCRIPTION
#### vim-patch:8.2.4759: CurSearch highlight does not work for multi-line match

Problem:    CurSearch highlight does not work for multi-line match.
Solution:   Check cursor position before adjusting columns. (closes vim/vim#10133)
https://github.com/vim/vim/commit/693ccd11606b59eb0f81c6c1948679e61ada4022