### PR TITLE
ci(backport): remove triggering by comment

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,8 +2,6 @@ name: Backport
 on:
   pull_request_target:
     types: [closed, labeled]
-  issue_comment:
-    types: [created]
 jobs:
   backport:
     permissions:
@@ -14,10 +12,6 @@ jobs:
       github.repository_owner == 'neovim' && (
         github.event_name == 'pull_request_target' &&
         github.event.pull_request.merged
-      ) || (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/backport')
       )
     runs-on: ubuntu-latest
     steps:

--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -57,11 +57,8 @@ has a major bug:
 
 The neovim repository includes a backport [github action](https://github.com/zeebe-io/backport-action).
 In order to trigger the action, a PR must be labeled with a label matching the
-form `backport release-0.X`. If the label is applied before the PR is merged,
-the backport will be filed automatically against the target branch. Otherwise,
-comment `\backport` on the merged PR *after* the label has been applied to trigger
-a backport. Note, the PR must have a description in the issue body, or the backport
-will fail.
+form `backport release-0.X`. Note, the PR must have a description in the issue body,
+or the backport will fail.
 
 Third-party dependencies
 --------------


### PR DESCRIPTION
Triggering by comment is not needed. Applying the label is enough to trigger the backport action. (e.g. #18158)