### PR TITLE
chore: convert more filetype patterns to Lua

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: unused-local
 local api = vim.api
 
 local M = {}
@@ -49,8 +50,26 @@ local extension = {
   art = "art",
   asciidoc = "asciidoc",
   adoc = "asciidoc",
+  asa = function(path, bufnr)
+    if vim.g.filetype_asa then
+      return vim.g.filetype_asa
+    else
+      return "aspvbs"
+    end
+  end,
   ["asn1"] = "asn",
   asn = "asn",
+  asp = function(path, bufnr)
+    if vim.g.filetype_asp then
+      return vim.g.filetype_asp
+    elseif getline(bufnr, 1):find("perlscript")
+      or getline(bufnr, 2):find("perlscript")
+      or getline(bufnr, 3):find("perlscript") then
+      return "aspperl"
+    else
+      return "aspvbs"
+    end
+  end,
   atl = "atlas",
   as = "atlas",
   ahk = "autohotkey",
@@ -679,6 +698,16 @@ local extension = {
   bbl = "tex",
   latex = "tex",
   sty = "tex",
+  cls = function(path, bufnr)
+    local line = getline(bufnr, 1)
+    if line[1] == "%" then
+      return "tex"
+    elseif line[1] == "#" and line:find("rexx") then
+      return "rexx"
+    else
+      return "st"
+    end
+  end,
   texi = "texinfo",
   txi = "texinfo",
   texinfo = "texinfo",
@@ -757,6 +786,13 @@ local extension = {
   csproj = "xml",
   wpl = "xml",
   xmi = "xml",
+  xpm = function(path, bufnr)
+    if getline(bufnr, 1):find("XPM2") then
+      return "xpm2"
+    else
+      return "xpm"
+    end
+  end,
   ["xpm2"] = "xpm2",
   xqy = "xquery",
   xqm = "xquery",
@@ -1225,6 +1261,7 @@ local pattern = {
   [".*/boot/grub/grub%.conf"] = "grub",
   [".*/boot/grub/menu%.lst"] = "grub",
   [".*/etc/grub%.conf"] = "grub",
+  [vim.env.VIMRUNTIME .. "/doc/.*%.txt"] = "help",
   ["hg%-editor%-.*%.txt"] = "hgcommit",
   [".*/etc/host%.conf"] = "hostconf",
   [".*/etc/hosts%.deny"] = "hostsaccess",
@@ -1279,6 +1316,7 @@ local pattern = {
   [".*/etc/passwd"] = "passwd",
   [".*/etc/passwd%.edit"] = "passwd",
   [".*/etc/shadow-"] = "passwd",
+  [".*%.php%d"] = "php",
   [".*/%.pinforc"] = "pinfo",
   [".*/etc/pinforc"] = "pinfo",
   [".*/etc/protocols"] = "protocols",

--- a/src/nvim/testdir/test_filetype_lua.vim
+++ b/src/nvim/testdir/test_filetype_lua.vim
@@ -1,2 +1,3 @@
 let g:do_filetype_lua = 1
+let g:did_load_filetypes = 0
 source test_filetype.vim


### PR DESCRIPTION
Start porting the missing filetype patterns to `filetype.lua`, and switch off fallback `filetype.vim` detection in the test.

I'm attaching a list of (after this PR) still missing patterns that I extracted from the output of the conversion script -- this may contain both false positives and negatives: [ftlua.txt](https://github.com/neovim/neovim/files/8540934/ftlua.txt)

This PR is free to a good home! (New patterns should be added in small batches and separate commits to make reviewing easier.)

