### PR TITLE
feat(lsp): options to filter and auto-apply code actions

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -969,18 +969,28 @@ add_workspace_folder({workspace_folder})
 clear_references()                            *vim.lsp.buf.clear_references()*
                 Removes document highlights from current buffer.
 
-code_action({context})                             *vim.lsp.buf.code_action()*
+code_action({options})                             *vim.lsp.buf.code_action()*
                 Selects a code action available at the current cursor
                 position.
 
                 Parameters: ~
-                    {context}  table|nil `CodeActionContext` of the LSP specification:
-                               • diagnostics: (table|nil) LSP`Diagnostic[]` . Inferred from the current position if not
-                                 provided.
-                               • only: (string|nil) LSP `CodeActionKind` used
-                                 to filter the code actions. Most language
-                                 servers support values like `refactor` or
-                                 `quickfix`.
+                    {options}  table|nil Optional table which holds the
+                               following optional fields:
+                               • context (table|nil): Corresponds to `CodeActionContext` of the LSP specification:
+                                 • diagnostics (table|nil): LSP`Diagnostic[]` . Inferred from the current position if not
+                                   provided.
+                                 • only (string|nil): LSP `CodeActionKind`
+                                   used to filter the code actions. Most
+                                   language servers support values like
+                                   `refactor` or `quickfix`.
+
+                               • filter (function|nil): Predicate function
+                                 taking an `CodeAction` and returning a
+                                 boolean.
+                               • apply (boolean|nil): When set to `true`, and
+                                 there is just one remaining action (after
+                                 filtering), the action is applied without
+                                 user query.
 
                 See also: ~
                     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -645,6 +645,7 @@ function protocol.make_client_capabilities()
             end)();
           };
         };
+        isPreferredSupport = true;
         dataSupport = true;
         resolveSupport = {
           properties = { 'edit', }

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -673,6 +673,36 @@ function tests.code_action_with_resolve()
   }
 end
 
+function tests.code_action_filter()
+  skeleton {
+    on_init = function()
+      return {
+        capabilities = {
+          codeActionProvider = {
+            resolveProvider = false
+          }
+        }
+      }
+    end;
+    body = function()
+      notify('start')
+      local action = {
+        title = 'Action 1',
+        command = 'command'
+      }
+      local preferred_action = {
+        title = 'Action 2',
+        isPreferred = true,
+        command = 'preferred_command',
+      }
+      expect_request('textDocument/codeAction', function()
+        return nil, { action, preferred_action, }
+      end)
+      notify('shutdown')
+    end;
+  }
+end
+
 function tests.clientside_commands()
   skeleton {
     on_init = function()


### PR DESCRIPTION
Implement a select_preferred option to vim.lsp.buf.code_action() which
automatically selects and applies the action the server marked as
preferred. If there are more than one possible action after the
filtering, query the user as is normally done.
Fix #17514.

~~Opening as draft since I still need to add a test, but wanted some feedback on the API.~~ Test added.