### PR TITLE
vim-patch:8.2.{4805,4812}: CurSearch used for all matches in current line

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1020,7 +1020,6 @@ typedef struct {
                         // match (may continue in next line)
   buf_T *buf;     // the buffer to search for a match
   linenr_T lnum;        // the line to search for a match
-  linenr_T lines;       // number of lines starting from lnum
   int attr;             // attributes to be used for a match
   int attr_cur;         // attributes currently active in win_line()
   linenr_T first_lnum;  // first lnum to search for multi-line pat

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -564,10 +564,10 @@ void prepare_search_hl(win_T *wp, match_T *search_hl, linenr_T lnum)
 /// position.
 static void check_cur_search_hl(win_T *wp, match_T *shl)
 {
-  long linecount = shl->rm.endpos[0].lnum - shl->rm.startpos[0].lnum;
+  linenr_T linecount = shl->rm.endpos[0].lnum - shl->rm.startpos[0].lnum;
 
   if (wp->w_cursor.lnum >= shl->lnum
-      && wp->w_cursor.lnum <= shl->lnum + shl->rm.endpos[0].lnum
+      && wp->w_cursor.lnum <= shl->lnum + linecount
       && (wp->w_cursor.lnum > shl->lnum || wp->w_cursor.col >= shl->rm.startpos[0].col)
       && (wp->w_cursor.lnum < shl->lnum + linecount || wp->w_cursor.col < shl->rm.endpos[0].col)) {
     shl->has_cursor = true;
@@ -599,7 +599,6 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char_u **l
     }
     shl->startcol = MAXCOL;
     shl->endcol = MAXCOL;
-    shl->lines = 0;
     shl->attr_cur = 0;
     shl->is_addpos = false;
     shl->has_cursor = false;
@@ -624,10 +623,6 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char_u **l
         shl->endcol = shl->rm.endpos[0].col;
       } else {
         shl->endcol = MAXCOL;
-      }
-      shl->lines = shl->rm.endpos[0].lnum - shl->rm.startpos[0].lnum;
-      if (shl->lines == 0) {
-        shl->lines = 1;
       }
 
       // check if the cursor is in the match before changing the columns

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -951,7 +951,7 @@ func Test_hlsearch_cursearch()
 
   let lines =<< trim END
     set hlsearch scrolloff=0
-    call setline(1, ['one', 'foo', 'bar', 'baz', 'foo', 'bar'])
+    call setline(1, ['one', 'foo', 'bar', 'baz', 'foo the foo and foo', 'bar'])
     hi Search ctermbg=yellow
     hi CurSearch ctermbg=blue
   END
@@ -964,7 +964,14 @@ func Test_hlsearch_cursearch()
   call term_sendkeys(buf, "n")
   call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_single_line_2', {})
 
-  call term_sendkeys(buf, "?\<CR>")
+  call term_sendkeys(buf, "n")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_single_line_2a', {})
+
+  call term_sendkeys(buf, "n")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_single_line_2b', {})
+
+  call term_sendkeys(buf, ":call setline(5, 'foo')\<CR>")
+  call term_sendkeys(buf, "0?\<CR>")
   call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_single_line_3', {})
 
   call term_sendkeys(buf, "gg/foo\\nbar\<CR>")

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -163,14 +163,14 @@ describe('search highlighting', function()
     end)
 
     it('works for multiline match', function()
-      command([[call setline(1, ['one', 'foo', 'bar', 'baz', 'foo', 'bar'])]])
+      command([[call setline(1, ['one', 'foo', 'bar', 'baz', 'foo the foo and foo', 'bar'])]])
       feed('gg/foo<CR>')
       screen:expect([[
         one                                     |
         {2:^foo}                                     |
         bar                                     |
         baz                                     |
-        {1:foo}                                     |
+        {1:foo} the {1:foo} and {1:foo}                     |
         bar                                     |
         /foo                                    |
       ]])
@@ -180,11 +180,32 @@ describe('search highlighting', function()
         {1:foo}                                     |
         bar                                     |
         baz                                     |
-        {2:^foo}                                     |
+        {2:^foo} the {1:foo} and {1:foo}                     |
         bar                                     |
         /foo                                    |
       ]])
-      feed('?<CR>')
+      feed('n')
+      screen:expect([[
+        one                                     |
+        {1:foo}                                     |
+        bar                                     |
+        baz                                     |
+        {1:foo} the {2:^foo} and {1:foo}                     |
+        bar                                     |
+        /foo                                    |
+      ]])
+      feed('n')
+      screen:expect([[
+        one                                     |
+        {1:foo}                                     |
+        bar                                     |
+        baz                                     |
+        {1:foo} the {1:foo} and {2:^foo}                     |
+        bar                                     |
+        /foo                                    |
+      ]])
+      command([[call setline(5, 'foo')]])
+      feed('0?<CR>')
       screen:expect([[
         one                                     |
         {2:^foo}                                     |


### PR DESCRIPTION
#### vim-patch:8.2.4805: CurSearch used for all matches in current line

Problem:    CurSearch used for all matches in current line.
Solution:   Don't use the non-zero line count.
https://github.com/vim/vim/commit/9b36750640e8e89f18afa1446ed80fdbdf0fcac0

#### vim-patch:8.2.4812: unused struct item

Problem:    Unused struct item.
Solution:   Remove "lines" match_T.  Simplify the code. (closes vim/vim#10256)
https://github.com/vim/vim/commit/8279cfe49961b3711c84c66a9954c9f70e9b78c8