### PR TITLE
fix(lua): don't mutate opts parameter of vim.keymap.del

### DIFF
--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -130,7 +130,6 @@ function keymap.del(modes, lhs, opts)
   local buffer = false
   if opts.buffer ~= nil then
     buffer = opts.buffer == true and 0 or opts.buffer
-    opts.buffer = nil
   end
 
   if buffer == false then

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2755,6 +2755,39 @@ describe('vim.keymap', function()
     eq('\nNo mapping found', helpers.exec_capture('nmap asdf'))
   end)
 
+  it('works with buffer-local mappings', function()
+    eq(0, exec_lua [[
+      GlobalCount = 0
+      vim.keymap.set('n', 'asdf', function() GlobalCount = GlobalCount + 1 end, {buffer=true})
+      return GlobalCount
+    ]])
+
+    feed('asdf\n')
+
+    eq(1, exec_lua[[return GlobalCount]])
+
+    exec_lua [[
+      vim.keymap.del('n', 'asdf', {buffer=true})
+    ]]
+
+    feed('asdf\n')
+
+    eq(1, exec_lua[[return GlobalCount]])
+    eq('\nNo mapping found', helpers.exec_capture('nmap asdf'))
+  end)
+
+  it('does not mutate the opts parameter', function()
+    eq(true, exec_lua [[
+      opts = {buffer=true}
+      vim.keymap.set('n', 'asdf', function() end, opts)
+      return opts.buffer
+    ]])
+    eq(true, exec_lua [[
+      vim.keymap.del('n', 'asdf', opts)
+      return opts.buffer
+    ]])
+  end)
+
   it('can do <Plug> mappings', function()
     eq(0, exec_lua [[
       GlobalCount = 0


### PR DESCRIPTION
`vim.keymap.del` takes an `opts` parameter that lets caller refer to and
delete buffer-local mappings. For some reason the implementation of
`vim.keymap.del` mutates the table that is passed in, setting
`opts.buffer` to `nil`. I'm not sure why it does this since `opts` is
never again accessed/used by the implementation anyway.

This seems wrong and also is undocumented. This bit me because I was
setting and then later unsetting a collection of mappings for some
buffer, and I created a local `opts = {buffer=my_buffer_number}`, and
then I got "no such mapping" errors.