### PR TITLE
Upstream nvim-treesitter utils to Neovim

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -382,6 +382,19 @@ get_captures_at_position({bufnr}, {row}, {col})
     Return: ~
         (table) A table of captures
 
+get_node_at_cursor({winnr}, {opts})                     *get_node_at_cursor()*
+    Gets the smallest named node under the cursor
+
+    Parameters: ~
+        {winnr}                   (number) Window handle or 0 for current
+                                  window
+        {opts}                    (table) Options table
+        {opts.ignore_injections}  (boolean) (default true) Ignore injected
+                                  languages.
+
+    Return: ~
+        (table) The named node under the cursor
+
 get_node_range({node_or_range})                             *get_node_range()*
     Get the node's range or unpack a range table
 
@@ -413,6 +426,49 @@ get_string_parser({str}, {lang}, {opts})                 *get_string_parser()*
         {lang}  The language of this string
         {opts}  Options to pass to the created language tree
 
+get_vim_range({bufnr}, {range})                              *get_vim_range()*
+    Gets a compatible vim range (1 index based) from a TS node range.
+
+    TS nodes start with 0 and the end col is ending exclusive. They also treat
+    a EOF/EOL char as a char ending in the first col of the next row.
+
+    Parameters: ~
+        {bufnr}  (number) The buffer handle from which the range is from
+        {range}  (table) The treesitter range to transform
+
+    Return: ~
+        start_row, starcol, end_row, end_col
+
+goto_node({node}, {opts})                                        *goto_node()*
+    • Call to `nvim_replace_termcodes()` is needed for sending appropriate
+    • command to enter blockwise mode Goes to the given node
+
+    Parameters: ~
+        {node}           (table) The node to go to
+        {opts}           (table) Options table
+        {opts.goto_end}  (boolean) (default false) set cursor at the end of
+                         the node
+        {opts.set_jump}  (boolean) (default false) mark current position
+                         before moving the cursor
+
+highlight_node({bufnr}, {node}, {ns}, {hlgroup})            *highlight_node()*
+    Highlights the given node
+
+    Parameters: ~
+        {bufnr}    (number) The buffer number
+        {node}     (table) The node to highlight
+        {ns}       (number) The namespace id
+        {hlgroup}  (string) The highlight group name
+
+highlight_range({bufnr}, {range}, {ns}, {hlgroup})         *highlight_range()*
+    Highlights the given range
+
+    Parameters: ~
+        {bufnr}    (number) The buffer number
+        {range}    (table) The treesitter range to highlight
+        {ns}       (number) The namespace id
+        {hlgroup}  (string) The highlight group name
+
 is_ancestor({dest}, {source})                                  *is_ancestor()*
     Determines whether a node is the ancestor of another
 
@@ -440,6 +496,40 @@ node_contains({node}, {range})                               *node_contains()*
 
     Return: ~
         (boolean) True if the node contains the range
+
+node_to_lsp_range({node})                                *node_to_lsp_range()*
+    Gets the node range in the lsp range format
+
+    Parameters: ~
+        {node}  (table) The node to convert
+
+    Return: ~
+        { start =`start_position`, end = `end_position` }
+
+                                                                *swap_nodes()*
+swap_nodes({bufnr}, {node_or_range1}, {node_or_range2}, {opts})
+    Swaps the two given nodes
+
+    Parameters: ~
+        {bufnr}                  (number) The buffer number
+        {node_or_range1}         (table) The 1st node or its range
+        {node_or_range2}         (table) The 2nd node or its range
+        {opts}                   (table) Options table
+        {opts.cursor_to_second}  (boolean) (default false) set cursor on the
+                                 second node after the swap
+
+update_selection({bufnr}, {node}, {opts})                 *update_selection()*
+    Sets visual selection for node
+
+    Parameters: ~
+        {bufnr}                (number) The buffer number
+        {node}                 (table) The node to visually select select
+        {opts}                 (table) Options table
+        {opts.selection_mode}  (string) (default 'charwise') Set the selection
+                               mode:
+                               • 'charwise'(or 'v')
+                               • 'linewise'(or 'V')
+                               • 'blockwise'(or '<C-v>')
 
 
 ==============================================================================

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -460,7 +460,8 @@ highlight_node({bufnr}, {node}, {ns}, {hlgroup})            *highlight_node()*
         {ns}       (number) The namespace id
         {hlgroup}  (string) The highlight group name
 
-highlight_range({bufnr}, {range}, {ns}, {hlgroup})         *highlight_range()*
+                                                           *highlight_range()*
+highlight_range({bufnr}, {range}, {ns}, {hlgroup}, {opts})
     Highlights the given range
 
     Parameters: ~
@@ -468,6 +469,7 @@ highlight_range({bufnr}, {range}, {ns}, {hlgroup})         *highlight_range()*
         {range}    (table) The treesitter range to highlight
         {ns}       (number) The namespace id
         {hlgroup}  (string) The highlight group name
+        {opts}     (table) Options to pass to |vim.highlight.range()|
 
 is_ancestor({dest}, {source})                                  *is_ancestor()*
     Determines whether a node is the ancestor of another

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -262,4 +262,32 @@ function M.get_node_at_cursor(winnr, opts)
   return root_lang_tree:named_node_for_range(ts_cursor_range, opts)
 end
 
+---Gets a compatible vim range (1 index based) from a TS node range.
+---
+---TS nodes start with 0 and the end col is ending exclusive.
+---They also treat a EOF/EOL char as a char ending in the first
+---col of the next row.
+---
+---@param bufnr number The buffer handle from which the range is from
+---@param range table The treesitter range to transform
+---
+---@returns start_row, starcol, end_row, end_col
+function M.get_vim_range(bufnr, range)
+  local srow, scol, erow, ecol = unpack(range)
+  srow = srow + 1
+  scol = scol + 1
+  erow = erow + 1
+
+  if ecol == 0 then
+    -- Use the value of the last col of the previous row instead.
+    erow = erow - 1
+    if not bufnr or bufnr == 0 then
+      ecol = vim.fn.col({ erow, '$' }) - 1
+    else
+      ecol = #a.nvim_buf_get_lines(bufnr, erow - 1, erow, false)[1]
+    end
+  end
+  return srow, scol, erow, ecol
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -337,4 +337,35 @@ function M.update_selection(bufnr, node, opts)
   vim.fn.setpos('.', { bufnr, end_row, end_col, 0 })
 end
 
+---Goes to the given node
+---
+---@param node table The node to go to
+---@param opts table Options table
+---@param opts.goto_end boolean (default false) set cursor at the end of the node
+---@param opts.set_jump boolean (default false) mark current position before moving the cursor
+function M.goto_node(node, opts)
+  opts = opts or {}
+  local goto_end = vim.F.if_nil(opts.goto_end, false)
+  local set_jump = vim.F.if_nil(opts.goto_end, false)
+
+  if not node then
+    return
+  end
+
+  if set_jump then
+    vim.cmd("normal! m'")
+  end
+
+  local range = { M.get_vim_range(nil, { node:range() }) }
+  local position
+  if goto_end then
+    position = { range[3], range[4] }
+  else
+    position = { range[1], range[2] }
+  end
+
+  -- Position is 1, 0 indexed.
+  a.nvim_win_set_cursor(0, { position[1], position[2] - 1 })
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -314,6 +314,14 @@ function M.highlight_node(bufnr, node, ns, hlgroup)
   M.highlight_range(bufnr, { node:range() }, ns, hlgroup)
 end
 
+local function get_node_range(node_or_range)
+  if type(node_or_range) == 'table' then
+    return unpack(node_or_range)
+  else
+    return node_or_range:range()
+  end
+end
+
 ---Sets visual selection for node
 ---@param bufnr number The buffer number
 ---@param node table The node to visually select select
@@ -323,8 +331,10 @@ end
 ---       - 'linewise'(or 'V')
 ---       - 'blockwise'(or '<C-v>')
 function M.update_selection(bufnr, node, opts)
+  opts = opts or {}
+
   local selection_mode = opts.selection_mode or 'charwise'
-  local start_row, start_col, end_row, end_col = M.get_vim_range({ M.get_node_range(node) }, bufnr)
+  local start_row, start_col, end_row, end_col = M.get_vim_range(bufnr, { get_node_range(node) })
 
   vim.fn.setpos('.', { bufnr, start_row, start_col, 0 })
 
@@ -332,8 +342,11 @@ function M.update_selection(bufnr, node, opts)
   local v_table = { charwise = 'v', linewise = 'V', blockwise = '<C-v>' }
   ---- Call to `nvim_replace_termcodes()` is needed for sending appropriate
   ---- command to enter blockwise mode
-  local mode_string = vim.api.nvim_replace_termcodes(v_table[selection_mode] or selection_mode, true, true, true)
+  local mode_string =
+    vim.api.nvim_replace_termcodes(v_table[selection_mode] or selection_mode, true, true, true)
   vim.cmd('normal! ' .. mode_string)
+  vim.fn.setpos('.', { bufnr, start_row, start_col, 0 })
+  vim.cmd('normal! o')
   vim.fn.setpos('.', { bufnr, end_row, end_col, 0 })
 end
 

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -314,4 +314,27 @@ function M.highlight_node(bufnr, node, ns, hlgroup)
   M.highlight_range(bufnr, { node:range() }, ns, hlgroup)
 end
 
+---Sets visual selection for node
+---@param bufnr number The buffer number
+---@param node table The node to visually select select
+---@param opts table Options table
+---@param opts.selection_mode string (default 'charwise') Set the selection mode:
+---       - 'charwise'(or 'v')
+---       - 'linewise'(or 'V')
+---       - 'blockwise'(or '<C-v>')
+function M.update_selection(bufnr, node, opts)
+  local selection_mode = opts.selection_mode or 'charwise'
+  local start_row, start_col, end_row, end_col = M.get_vim_range({ M.get_node_range(node) }, bufnr)
+
+  vim.fn.setpos('.', { bufnr, start_row, start_col, 0 })
+
+  -- Start visual selection in appropriate mode
+  local v_table = { charwise = 'v', linewise = 'V', blockwise = '<C-v>' }
+  ---- Call to `nvim_replace_termcodes()` is needed for sending appropriate
+  ---- command to enter blockwise mode
+  local mode_string = vim.api.nvim_replace_termcodes(v_table[selection_mode] or selection_mode, true, true, true)
+  vim.cmd('normal! ' .. mode_string)
+  vim.fn.setpos('.', { bufnr, end_row, end_col, 0 })
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -241,4 +241,25 @@ function M.get_captures_at_position(bufnr, row, col)
   return matches
 end
 
+--- Gets the smallest named node under the cursor
+---
+---@param winnr number Window handle or 0 for current window
+---@param opts table Options table
+---@param opts.ignore_injections boolean (default true) Ignore injected languages.
+---
+---@returns (table) The named node under the cursor
+function M.get_node_at_cursor(winnr, opts)
+  winnr = winnr or 0
+  local cursor = a.nvim_win_get_cursor(winnr)
+  local ts_cursor_range = { cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2] }
+
+  local buf = a.nvim_win_get_buf(winnr)
+  local root_lang_tree = M.get_parser(buf)
+  if not root_lang_tree then
+    return
+  end
+
+  return root_lang_tree:named_node_for_range(ts_cursor_range, opts)
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -301,4 +301,17 @@ function M.highlight_range(bufnr, range, ns, hlgroup)
   vim.highlight.range(bufnr, ns, hlgroup, { start_row, start_col }, { end_row, end_col })
 end
 
+---Highlights the given node
+---
+---@param bufnr number The buffer number
+---@param node table The node to highlight
+---@param ns number The namespace id
+---@param hlgroup string The highlight group name
+function M.highlight_node(bufnr, node, ns, hlgroup)
+  if not node then
+    return
+  end
+  M.highlight_range(bufnr, { node:range() }, ns, hlgroup)
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -368,4 +368,16 @@ function M.goto_node(node, opts)
   a.nvim_win_set_cursor(0, { position[1], position[2] - 1 })
 end
 
+---Gets the node range in the lsp range format
+---@param node table The node to convert
+---
+---@returns { start =`start_position`, end = `end_position` }
+function M.node_to_lsp_range(node)
+  local start_line, start_col, end_line, end_col = get_node_range(node)
+  local rtn = {}
+  rtn.start = { line = start_line, character = start_col }
+  rtn['end'] = { line = end_line, character = end_col }
+  return rtn
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -290,4 +290,15 @@ function M.get_vim_range(bufnr, range)
   return srow, scol, erow, ecol
 end
 
+---Highlights the given range
+---
+---@param bufnr number The buffer number
+---@param range table The treesitter range to highlight
+---@param ns number The namespace id
+---@param hlgroup string The highlight group name
+function M.highlight_range(bufnr, range, ns, hlgroup)
+  local start_row, start_col, end_row, end_col = unpack(range)
+  vim.highlight.range(bufnr, ns, hlgroup, { start_row, start_col }, { end_row, end_col })
+end
+
 return M

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -296,9 +296,10 @@ end
 ---@param range table The treesitter range to highlight
 ---@param ns number The namespace id
 ---@param hlgroup string The highlight group name
-function M.highlight_range(bufnr, range, ns, hlgroup)
+---@param opts table Options to pass to |vim.highlight.range()|
+function M.highlight_range(bufnr, range, ns, hlgroup, opts)
   local start_row, start_col, end_row, end_col = unpack(range)
-  vim.highlight.range(bufnr, ns, hlgroup, { start_row, start_col }, { end_row, end_col })
+  vim.highlight.range(bufnr, ns, hlgroup, { start_row, start_col }, { end_row, end_col }, opts)
 end
 
 ---Highlights the given node

--- a/test/functional/treesitter/utils_spec.lua
+++ b/test/functional/treesitter/utils_spec.lua
@@ -30,4 +30,20 @@ describe('treesitter utils', function()
     eq(true, exec_lua('return vim.treesitter.is_ancestor(ancestor, child)'))
     eq(false, exec_lua('return vim.treesitter.is_ancestor(child, ancestor)'))
   end)
+
+  it('can convert a ts range to a vim range', function()
+    insert([[
+      int main() {
+        int x = 3;
+      }]])
+
+    exec_lua([[
+      parser = vim.treesitter.get_parser(0, "c")
+      tree = parser:parse()[1]
+      node = tree:root():child(0)
+    ]])
+
+    eq({0, 0, 2, 1}, exec_lua('return {node:range()}'))
+    eq({1, 1, 3, 1}, exec_lua('return {vim.treesitter.get_vim_range(0, {node:range()})}'))
+  end)
 end)

--- a/test/functional/treesitter/utils_spec.lua
+++ b/test/functional/treesitter/utils_spec.lua
@@ -32,6 +32,8 @@ describe('treesitter utils', function()
   end)
 
   it('can convert a ts range to a vim range', function()
+    if pending_c_parser(pending) then return end
+
     insert([[
       int main() {
         int x = 3;


### PR DESCRIPTION
Closes #17974


The following is a list of all the utility functions found in nvim-treesitter. As mentioned in the issue, this does not mean all should be upstreamed as is or at all. Some change to `languagetree` could be necessary to simplify/optimize some of them.

This is a starting point to do some triage as I dive into each function and determine what and how to add each one (or with any of your suggestions)

## From [nvim-treesitter/lua/nvim-treesitter/ts_utils.lua](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/ts_utils.lua):

### Will not upstream
- get_next_node() -> node:next_named_sibling() exists + opts not useful enough
- get_previous_node() -> node:prev_named_sibling() exists + opts not useful enough
- get_node_text() (function with same name but different behavior exists, see [comment below](https://github.com/neovim/neovim/pull/18232#issuecomment-1107800511), option has been added to allow to get nvim-treesitter behavior)
- get_root_for_position() -> not needed with languagetree changes
- is_in_node_range() -> not needed with languagetree changes
- memoize_by_buf_tick()


### As a node methods
- [x] get_named_children() -> `node:named_children()` (could imply  `node:children()` [comment below](https://github.com/neovim/neovim/pull/18232#issuecomment-1110102914))
- [x] get_root_for_node() -> `node:root()`
- [x] node_length() -> `node:length`

### Will upstream
- [x] is_parent()
- [x] get_node_at_cursor()
- [x] highlight_range()
- [x] highlight_node()
- [x] get_vim_range()
- [x] update_selection()
- [x] goto_node()
- [x] node_to_lsp_range()
- [x] swap_nodes()
- [x] get_node_range()

## From [playground//lua/nvim-treesitter-playground/utils.lua](https://github.com/nvim-treesitter/playground/blob/master/lua/nvim-treesitter-playground/utils.lua):
### Will upstream
- [x] get_hl_groups_at_position()
- [x] node_contains()

### TODO
- [x] Fix coding style
- [x] https://github.com/neovim/neovim/pull/18232#issuecomment-1143252718
- [ ] ~~Tests~~