### PR TITLE
revert/coverity

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -7,7 +7,6 @@ include(CheckCSourceCompiles)
 
 check_type_size("int" SIZEOF_INT)
 check_type_size("long" SIZEOF_LONG)
-check_type_size("intmax_t" SIZEOF_INTMAX_T)
 check_type_size("size_t" SIZEOF_SIZE_T)
 check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("void *" SIZEOF_VOID_PTR)

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -7,8 +7,6 @@ include(CheckCSourceCompiles)
 
 check_type_size("int" SIZEOF_INT)
 check_type_size("long" SIZEOF_LONG)
-check_type_size("size_t" SIZEOF_SIZE_T)
-check_type_size("long long" SIZEOF_LONG_LONG)
 check_type_size("void *" SIZEOF_VOID_PTR)
 
 check_symbol_exists(_NSGetEnviron crt_externs.h HAVE__NSGETENVIRON)

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1362,13 +1362,11 @@ intmax_t getdigits(char_u **pp, bool strict, intmax_t def)
 int getdigits_int(char_u **pp, bool strict, int def)
 {
   intmax_t number = getdigits(pp, strict, def);
-#if SIZEOF_INTMAX_T > SIZEOF_INT
   if (strict) {
     assert(number >= INT_MIN && number <= INT_MAX);
   } else if (!(number >= INT_MIN && number <= INT_MAX)) {
     return def;
   }
-#endif
   return (int)number;
 }
 
@@ -1378,13 +1376,11 @@ int getdigits_int(char_u **pp, bool strict, int def)
 long getdigits_long(char_u **pp, bool strict, long def)
 {
   intmax_t number = getdigits(pp, strict, def);
-#if SIZEOF_INTMAX_T > SIZEOF_LONG
   if (strict) {
     assert(number >= LONG_MIN && number <= LONG_MAX);
   } else if (!(number >= LONG_MIN && number <= LONG_MAX)) {
     return def;
   }
-#endif
   return (long)number;
 }
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -377,9 +377,6 @@ int os_expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file
     fclose(fd);
     return FAIL;
   }
-#if SIZEOF_LONG_LONG > SIZEOF_SIZE_T
-  assert(templen <= (long long)SIZE_MAX);  // NOLINT(runtime/int)
-#endif
   len = (size_t)templen;
   fseek(fd, 0L, SEEK_SET);
   buffer = xmalloc(len + 1);


### PR DESCRIPTION
- revert: "coverity/100248: Operands don't affect result: HI."
- revert: "coverity/13745: Argument cannot be negative: RI."
