### PR TITLE
vim-patch:8.2.{4808,4810,4813}: pasting text while indent folding may mess up folds

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1058,7 +1058,7 @@ void cloneFoldGrowArray(garray_T *from, garray_T *to)
 
 // foldFind() {{{2
 /// Search for line "lnum" in folds of growarray "gap".
-/// Set *fpp to the fold struct for the fold that contains "lnum" or
+/// Set "*fpp" to the fold struct for the fold that contains "lnum" or
 /// the first fold below it (careful: it can be beyond the end of the array!).
 ///
 /// @return  false when there is no fold that contains "lnum".
@@ -2615,7 +2615,8 @@ static void foldSplit(buf_T *buf, garray_T *const gap, const int i, const linenr
   // any between top and bot, they have been removed by the caller.
   garray_T *const gap1 = &fp->fd_nested;
   garray_T *const gap2 = &fp[1].fd_nested;
-  if (foldFind(gap1, bot + 1 - fp->fd_top, &fp2)) {
+  (void)foldFind(gap1, bot + 1 - fp->fd_top, &fp2);
+  if (fp2 != NULL) {
     const int len = (int)((fold_T *)gap1->ga_data + gap1->ga_len - fp2);
     if (len > 0) {
       ga_grow(gap2, len);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -2222,7 +2222,6 @@ static regengine_T bt_regengine =
   bt_regfree,
   bt_regexec_nl,
   bt_regexec_multi,
-  (char_u *)""
 };
 
 static regengine_T nfa_regengine =
@@ -2231,7 +2230,6 @@ static regengine_T nfa_regengine =
   nfa_regfree,
   nfa_regexec_nl,
   nfa_regexec_multi,
-  (char_u *)""
 };
 
 // Which regexp engine to use? Needed for vim_regcomp().

--- a/src/nvim/regexp_defs.h
+++ b/src/nvim/regexp_defs.h
@@ -157,12 +157,15 @@ struct reg_extmatch {
 };
 
 struct regengine {
+  /// bt_regcomp or nfa_regcomp
   regprog_T *(*regcomp)(char_u *, int);
+  /// bt_regfree or nfa_regfree
   void (*regfree)(regprog_T *);
+  /// bt_regexec_nl or nfa_regexec_nl
   int (*regexec_nl)(regmatch_T *, char_u *, colnr_T, bool);
-  long (*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T,
-                        proftime_T *, int *);
-  char_u *expr;
+  /// bt_regexec_mult or nfa_regexec_mult
+  long (*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T, proftime_T *, int *);
+  // char_u *expr;
 };
 
 #endif  // NVIM_REGEXP_DEFS_H

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -881,4 +881,24 @@ func Test_fold_relative_move()
   set fdm& sw& wrap& tw&
 endfunc
 
+" Make sure a fold containing a nested fold is split correctly when using
+" foldmethod=indent
+func Test_fold_split()
+  new
+  let lines =<< trim END
+    line 1
+      line 2
+      line 3
+        line 4
+        line 5
+  END
+  call setline(1, lines)
+  setlocal sw=2
+  setlocal foldmethod=indent foldenable
+  call assert_equal([0, 1, 1, 2, 2], range(1, 5)->map('foldlevel(v:val)'))
+  call append(2, 'line 2.5')
+  call assert_equal([0, 1, 0, 1, 2, 2], range(1, 6)->map('foldlevel(v:val)'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4808: unused item in engine struct

Problem:    Unused item in engine struct.
Solution:   Remove "expr".  Add comment with tags.
https://github.com/vim/vim/commit/33d3ce640c63366e26b84c8d6f5798187a258ee2


#### vim-patch:8.2.4810: missing changes in one file

Problem:    Missing changes in one file.
Solution:   Also change the struct initializers.
https://github.com/vim/vim/commit/56dba60216a1bf72c1de299316f4d4ef19e50ad5


#### vim-patch:8.2.4813: pasting text while indent folding may mess up folds

Problem:    Pasting text while indent folding may mess up folds.
Solution:   Adjust the way folds are split. (Brandon Simmons, closes vim/vim#10254)
https://github.com/vim/vim/commit/2c40707baa13a53cac4137ffb8b2ac67f50cea63