### PR TITLE
fix: show autocmd output when F is in shortmess

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5532,8 +5532,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		"Pattern not found", "Back at original", etc.
 	  q	use "recording" instead of "recording @a"
 	  F	don't give the file info when editing a file, like `:silent`
-		was used for the command; note that this also affects messages
-		from autocommands
+		was used for the command
 	  S     do not show search count message when searching, e.g.
 	        "[1/5]"
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -375,6 +375,7 @@ Normal commands:
 Options:
   'ttimeout', 'ttimeoutlen' behavior was simplified
   |jumpoptions| "stack" behavior
+  'shortmess' the "F" flag does not affect output from autocommands
 
 Shell:
   Shell output (|:!|, |:make|, …) is always routed through the UI, so it

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1387,7 +1387,7 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char_u *cmd,
   if (do_out) {
     if (otmp != NULL) {
       if (readfile(otmp, NULL, line2, (linenr_T)0, (linenr_T)MAXLNUM, eap,
-                   READ_FILTER) != OK) {
+                   READ_FILTER, false) != OK) {
         if (!aborting()) {
           msg_putchar('\n');
           semsg(_(e_notread), otmp);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7703,13 +7703,13 @@ static void ex_read(exarg_T *eap)
         return;
       }
       i = readfile(curbuf->b_ffname, curbuf->b_fname,
-                   eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0);
+                   eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0, false);
     } else {
       if (vim_strchr(p_cpo, CPO_ALTREAD) != NULL) {
         (void)setaltfname(eap->arg, eap->arg, (linenr_T)1);
       }
       i = readfile(eap->arg, NULL,
-                   eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0);
+                   eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0, false);
     }
     if (i != OK) {
       if (!aborting()) {

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -994,7 +994,7 @@ void ml_recover(bool checkext)
    */
   if (curbuf->b_ffname != NULL) {
     orig_file_status = readfile(curbuf->b_ffname, NULL, (linenr_T)0,
-                                (linenr_T)0, (linenr_T)MAXLNUM, NULL, READ_NEW);
+                                (linenr_T)0, (linenr_T)MAXLNUM, NULL, READ_NEW, false);
   }
 
   // Use the 'fileformat' and 'fileencoding' as stored in the swap file.
@@ -1069,7 +1069,7 @@ void ml_recover(bool checkext)
               line_count = pp->pb_pointer[idx].pe_line_count;
               if (readfile(curbuf->b_ffname, NULL, lnum,
                            pp->pb_pointer[idx].pe_old_lnum - 1, line_count,
-                           NULL, 0) != OK) {
+                           NULL, 0, false) != OK) {
                 cannot_open = true;
               } else {
                 lnum += line_count;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5753,7 +5753,7 @@ static buf_T *load_dummy_buffer(char_u *fname, char_u *dirname_start, char_u *re
     newbuf_to_wipe.br_buf = NULL;
     readfile_result = readfile(fname, NULL, (linenr_T)0, (linenr_T)0,
                                (linenr_T)MAXLNUM, NULL,
-                               READ_NEW | READ_DUMMY);
+                               READ_NEW | READ_DUMMY, false);
     newbuf->b_locked--;
     if (readfile_result == OK
         && !got_int


### PR DESCRIPTION
The default value of including F in 'shortmess' has the unfortunate side effect of hiding output from autocommands. This is a common source of confusion and often leads people to think their autocommands are not working when they are. There is a small snippet in the docs for 'shortmess' indicating that the F flag suppresses autocmd output, but it's not easy to find if you don't already know to look for it.

This commit removes that behavior of the F flag to make it only suppress file info when opening a new file.

Ping @bfredl and @dundargoc, since we discussed this on Matrix.

Closes #14304
Closes #9314
