### PR TITLE
vim-patch:8.2.4826: .cshtml files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -817,6 +817,7 @@ au BufNewFile,BufRead *.t.html			setf tilde
 
 " HTML (.shtml and .stm for server side)
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
+au BufNewFile,BufRead *.cshtml			setf html
 
 " HTML with Ruby - eRuby
 au BufNewFile,BufRead *.erb,*.rhtml		setf eruby

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -142,6 +142,7 @@ local extension = {
   cs = "cs",
   csc = "csc",
   csdl = "csdl",
+  cshtml = "html",
   fdr = "csp",
   csp = "csp",
   css = "css",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -258,6 +258,7 @@ let s:filename_checks = {
     \ 'rnoweb': ['file.rnw', 'file.snw'],
     \ 'rrst': ['file.rrst', 'file.srst'],
     \ 'template': ['file.tmpl'],
+    \ 'html': ['file.html', 'file.htm', 'file.cshtml'],
     \ 'htmlm4': ['file.html.m4'],
     \ 'httest': ['file.htt', 'file.htb'],
     \ 'ibasic': ['file.iba', 'file.ibi'],


### PR DESCRIPTION
Problem:    .cshtml files are not recognized.
Solution:   Use html filetype for .cshtml files. (Julien Voisin, closes vim/vim#10212)
https://github.com/vim/vim/commit/1f435dafff2452e0b55d1ca457ce7402e526e92a