### PR TITLE
feat(lua): add vim.iconv

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -881,6 +881,22 @@ vim.str_byteindex({str}, {index} [, {use_utf16}])        *vim.str_byteindex()*
     An {index} in the middle of a UTF-16 sequence is rounded upwards to
     the end of that sequence.
 
+vim.iconv({str}, {from}, {to}[, {opts}])                        *vim.iconv()*
+        The result is a String, which is the text {str} converted from
+        encoding {from} to encoding {to}. When the conversion fails `nil` is
+        returned.  When some characters could not be converted they
+        are replaced with "?".
+        The encoding names are whatever the iconv() library function
+        can accept, see ":Man 3 iconv".
+
+        Parameters: ~
+            {str}   (string) Text to convert
+            {from}  (string) Encoding of {str}
+            {to}    (string) Target encoding
+
+        Returns: ~
+            Converted string if conversion succeeds, `nil` otherwise.
+
 vim.schedule({callback})                                      *vim.schedule()*
     Schedules {callback} to be invoked soon by the main event-loop. Useful
     to avoid |textlock| or other temporary restrictions.

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2721,6 +2721,39 @@ describe('lua stdlib', function()
       ]]
     end)
   end)
+
+  describe('vim.iconv', function()
+    it('can convert strings', function()
+      eq('hello', exec_lua[[
+        return vim.iconv('hello', 'latin1', 'utf-8')
+      ]])
+    end)
+
+    it('can validate arguments', function()
+      eq({false, 'Expected at least 3 arguments'}, exec_lua[[
+        return {pcall(vim.iconv, 'hello')}
+      ]])
+
+      eq({false, 'bad argument #3 to \'?\' (expected string)'}, exec_lua[[
+        return {pcall(vim.iconv, 'hello', 'utf-8', true)}
+      ]])
+    end)
+
+    it('can handle bad encodings', function()
+      eq(NIL, exec_lua[[
+        return vim.iconv('hello', 'foo', 'bar')
+      ]])
+    end)
+
+    it('can handle strings with NUL bytes', function()
+      eq(7, exec_lua[[
+        local a = string.char(97, 98, 99, 0, 100, 101, 102) -- abc\0def
+        return string.len(vim.iconv(a, 'latin1', 'utf-8'))
+      ]])
+    end)
+
+  end)
+
 end)
 
 describe('lua: builtin modules', function()


### PR DESCRIPTION
Identical to `vim.fn.iconv` except:

- There is no typval conversion.
- Accepts **any** Lua string, whereas typval conversion may produce a Blob type which causes `vim.fn.iconv` to fail. 
- Does not rely on `NUL` byte for string length detection.
- Can be run in fast events.
- Can be run in Lua threads (via `vim.loop.new_work`).

### Demo

Here is a screenshot of Gitsigns opening a PNG file that is managed under git.

(left `vim.iconv`, right `vim.fn.iconv`)

![image](https://user-images.githubusercontent.com/7904185/165539457-456c96c1-b89c-41a2-8c17-09c2a547216a.png)

`vim.fn.iconv`:
```lua
   for i, l in ipairs(stdout) do
      -- Have to exclude Blob types, otherwise conversion will error.
      if vim.fn.type(l) == vim.v.t_string then
        stdout[i] = vim.fn.iconv(l, encoding, 'utf-8')
      end
    end
```

`vim.iconv`:

```lua
    for i, l in ipairs(stdout) do
      stdout[i] = vim.iconv(l, encoding, 'utf-8')
    end

```

