### PR TITLE
fix(mac): use same $LANG fallback mechanism as Vim

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -16,8 +16,8 @@ if(WIN32)
   # tell MinGW compiler to enable wmain
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreFoundation")
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework CoreFoundation")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework CoreServices")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -framework CoreServices")
 endif()
 
 set(TOUCHES_DIR ${PROJECT_BINARY_DIR}/touches)


### PR DESCRIPTION
In a locale "en_US", "en" is the language and "US" is the region.

Before this change, we were too clever for our own good and tried to handle the
region as well. But if the macOS primary language is set to "English" and the
region to "Norway", we would end up with "en_NO", which is a locale that does
not exist.

Now we only take the language into account. Taking the example from above would
yield "en_US", which is a sensible fallback.

If the region is important to you, set $LANG and the more specific LC_*
variables in your shell config or alternatively use `:help :language`.

References https://github.com/neovim/neovim/issues/18292