### PR TITLE
feat(defaults): add binding to stay on visual mode after indent

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -85,6 +85,8 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 >
 	nnoremap Y y$
 	nnoremap <C-L> <Cmd>nohlsearch<Bar>diffupdate<Bar>normal! <C-L><CR>
+        vnoremap < <gv^
+        vnoremap > >gv^
 	inoremap <C-U> <C-G>u<C-U>
 	inoremap <C-W> <C-G>u<C-W>
 <

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -845,6 +845,9 @@ void init_default_mappings(void)
 {
   add_map((char_u *)"Y y$", NORMAL, true);
 
+  add_map((char_u *)"> >gv^", VISUAL, true);
+  add_map((char_u *)"< <gv^", VISUAL, true);
+
   // Use normal! <C-L> to prevent inserting raw <C-L> when using i_<C-O>
   // See https://github.com/neovim/neovim/issues/17473
   add_map((char_u *)"<C-L> <Cmd>nohlsearch<Bar>diffupdate<Bar>normal! <C-L><CR>", NORMAL, true);


### PR DESCRIPTION
Sets these default bindings:
- `vnoreamp > >gv^`
- `vnoremap < <gv^`

This prevents Neovim from leaving visual mode after indent.

Some oldtests seem to fail right now, but I'll only bother with fixing them if nobody objects to this addition.