### PR TITLE
feat(lsp): show feedback on empty hover response

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -298,13 +298,13 @@ function M.hover(_, result, ctx, config)
   config = config or {}
   config.focus_id = ctx.method
   if not (result and result.contents) then
-    -- return { 'No information available' }
+    vim.notify('No information available')
     return
   end
   local markdown_lines = util.convert_input_to_markdown_lines(result.contents)
   markdown_lines = util.trim_empty_lines(markdown_lines)
   if vim.tbl_isempty(markdown_lines) then
-    -- return { 'No information available' }
+    vim.notify('No information available')
     return
   end
   return util.open_floating_preview(markdown_lines, "markdown", config)


### PR DESCRIPTION
Without any feedback it gives the impression that the language server is
not working properly, which isn't the case.
