### PR TITLE
vim-patch:8.2.{4844,4845,4846}

### DIFF
--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -187,22 +187,17 @@ void get_mode(char *buf)
     if (State & VREPLACE_FLAG) {
       buf[i++] = 'R';
       buf[i++] = 'v';
-      if (ins_compl_active()) {
-        buf[i++] = 'c';
-      } else if (ctrl_x_mode_not_defined_yet()) {
-        buf[i++] = 'x';
-      }
     } else {
       if (State & REPLACE_FLAG) {
         buf[i++] = 'R';
       } else {
         buf[i++] = 'i';
       }
-      if (ins_compl_active()) {
-        buf[i++] = 'c';
-      } else if (ctrl_x_mode_not_defined_yet()) {
-        buf[i++] = 'x';
-      }
+    }
+    if (ins_compl_active()) {
+      buf[i++] = 'c';
+    } else if (ctrl_x_mode_not_defined_yet()) {
+      buf[i++] = 'x';
     }
   } else if ((State & CMDLINE) || exmode_active) {
     buf[i++] = 'c';

--- a/test/functional/ex_cmds/cmd_map_spec.lua
+++ b/test/functional/ex_cmds/cmd_map_spec.lua
@@ -136,6 +136,12 @@ describe('mappings with <Cmd>', function()
     ]])
   end)
 
+  it('handles character containing K_SPECIAL (0x80) byte correctly', function()
+    command([[noremap <F3> <Cmd>let g:str = '‥'<CR>]])
+    feed('<F3>')
+    eq('‥', eval('g:str'))
+  end)
+
   it('works in various modes and sees correct `mode()` value', function()
     -- normal mode
     feed('<F3>')


### PR DESCRIPTION
#### vim-patch:8.2.4845: duplicate code

Problem:    Duplicate code.
Solution:   Move code below if/else. (closes vim/vim#10314)
https://github.com/vim/vim/commit/590f365f91511c164253c5b5812d4d0fc4a238d6

N/A patches for version.c:

vim-patch:8.2.4844: <C-S-I> is simplified to <S-Tab>

Problem:    <C-S-I> is simplified to <S-Tab>.
Solution:   Do not simplify CTRL if there is also SHIFT. (closes vim/vim#10313)
https://github.com/vim/vim/commit/758a8d199988b5b25566b2820db60dc2c9de3e58

vim-patch:8.2.4846: termcodes test fails

Problem:    Termcodes test fails.
Solution:   use CTRL-SHIFT-V to insert an unsimplified key. (closes vim/vim#10316)
https://github.com/vim/vim/commit/bad8a013c238595aa206690210eb1367fbc878f9