### PR TITLE
fix(input): only disable mapped CTRL-C interrupts when getting input

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4661,7 +4661,6 @@ void global_exe(char_u *cmd)
   linenr_T old_lcount;      // b_ml.ml_line_count before the command
   buf_T *old_buf = curbuf;  // remember what buffer we started in
   linenr_T lnum;            // line number according to old situation
-  int save_mapped_ctrl_c = mapped_ctrl_c;
 
   // Set current position only once for a global command.
   // If global_busy is set, setpcmark() will not do anything.
@@ -4670,8 +4669,6 @@ void global_exe(char_u *cmd)
 
   // When the command writes a message, don't overwrite the command.
   msg_didout = true;
-  // Disable CTRL-C mapping, let it interrupt (potentially long output).
-  mapped_ctrl_c = 0;
 
   sub_nsubs = 0;
   sub_nlines = 0;
@@ -4684,7 +4681,6 @@ void global_exe(char_u *cmd)
     os_breakcheck();
   }
 
-  mapped_ctrl_c = save_mapped_ctrl_c;
   global_busy = 0;
   if (global_need_beginline) {
     beginline(BL_WHITE | BL_FIX);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2317,6 +2317,10 @@ static int vgetorpeek(bool advance)
       // try re-mapping.
       for (;;) {
         check_end_reg_executing(advance);
+        // os_breakcheck() can call input_enqueue()
+        if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & get_real_state()) {
+          ctrl_c_interrupts = false;
+        }
         // os_breakcheck() is slow, don't use it too often when
         // inside a mapping.  But call it each time for typed
         // characters.
@@ -2325,6 +2329,7 @@ static int vgetorpeek(bool advance)
         } else {
           os_breakcheck();  // check for CTRL-C
         }
+        ctrl_c_interrupts = true;
         int keylen = 0;
         if (got_int) {
           // flush all input

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -670,6 +670,7 @@ EXTERN bool ins_at_eol INIT(= false);   // put cursor after eol when
 EXTERN bool no_abbr INIT(= true);       // true when no abbreviations loaded
 
 EXTERN int mapped_ctrl_c INIT(= 0);  // Modes where CTRL-C is mapped.
+EXTERN bool ctrl_c_interrupts INIT(= true);  // CTRL-C sets got_int
 
 EXTERN cmdmod_T cmdmod;                 // Ex command modifiers
 

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -2,7 +2,7 @@
 
 local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, insert = helpers.clear, helpers.feed, helpers.insert
-local feed_command, expect, poke_eventloop = helpers.feed_command, helpers.expect, helpers.poke_eventloop
+local expect, poke_eventloop = helpers.expect, helpers.poke_eventloop
 local command, eq, eval, meths = helpers.command, helpers.eq, helpers.eval, helpers.meths
 local sleep = helpers.sleep
 
@@ -15,7 +15,7 @@ describe('mapping', function()
       ]])
 
     -- Abbreviations with р (0x80) should work.
-    feed_command('inoreab чкпр   vim')
+    command('inoreab чкпр   vim')
     feed('GAчкпр <esc>')
 
     expect([[
@@ -25,17 +25,15 @@ describe('mapping', function()
 
   it('Ctrl-c works in Insert mode', function()
     -- Mapping of ctrl-c in insert mode
-    feed_command('set cpo-=< cpo-=k')
-    feed_command('inoremap <c-c> <ctrl-c>')
-    feed_command('cnoremap <c-c> dummy')
-    feed_command('cunmap <c-c>')
+    command('set cpo-=< cpo-=k')
+    command('inoremap <c-c> <ctrl-c>')
+    command('cnoremap <c-c> dummy')
+    command('cunmap <c-c>')
     feed('GA<cr>')
-    feed('TEST2: CTRL-C |')
+    -- XXX: editor must be in Insert mode before <C-C> is put into input buffer
     poke_eventloop()
-    feed('<c-c>A|<cr><esc>')
-    poke_eventloop()
-    feed_command('unmap <c-c>')
-    feed_command('unmap! <c-c>')
+    feed('TEST2: CTRL-C |<c-c>A|<cr><esc>')
+    command('unmap! <c-c>')
 
     expect([[
 
@@ -44,13 +42,12 @@ describe('mapping', function()
   end)
 
   it('Ctrl-c works in Visual mode', function()
-    feed_command([[vnoremap <c-c> :<C-u>$put ='vmap works'<cr>]])
+    command([[vnoremap <c-c> :<C-u>$put ='vmap works'<cr>]])
     feed('GV')
-    -- XXX: For some reason the mapping is only triggered
-    -- when <C-c> is in a separate feed command.
+    -- XXX: editor must be in Visual mode before <C-C> is put into input buffer
     poke_eventloop()
-    feed('<c-c>')
-    feed_command('vunmap <c-c>')
+    feed('vV<c-c>')
+    command('vunmap <c-c>')
 
     expect([[
 
@@ -59,23 +56,23 @@ describe('mapping', function()
 
   it('langmap', function()
     -- langmap should not get remapped in insert mode.
-    feed_command('inoremap { FAIL_ilangmap')
-    feed_command('set langmap=+{ langnoremap')
+    command('inoremap { FAIL_ilangmap')
+    command('set langmap=+{ langnoremap')
     feed('o+<esc>')
 
     -- Insert mode expr mapping with langmap.
-    feed_command('inoremap <expr> { "FAIL_iexplangmap"')
+    command('inoremap <expr> { "FAIL_iexplangmap"')
     feed('o+<esc>')
 
     -- langmap should not get remapped in cmdline mode.
-    feed_command('cnoremap { FAIL_clangmap')
+    command('cnoremap { FAIL_clangmap')
     feed('o+<esc>')
-    feed_command('cunmap {')
+    command('cunmap {')
 
     -- cmdline mode expr mapping with langmap.
-    feed_command('cnoremap <expr> { "FAIL_cexplangmap"')
+    command('cnoremap <expr> { "FAIL_cexplangmap"')
     feed('o+<esc>')
-    feed_command('cunmap {')
+    command('cunmap {')
 
     -- Assert buffer contents.
     expect([[
@@ -93,10 +90,10 @@ describe('mapping', function()
       ]])
 
     -- Vim's issue #212 (feedkeys insert mapping at current position)
-    feed_command('nnoremap . :call feedkeys(".", "in")<cr>')
+    command('nnoremap . :call feedkeys(".", "in")<cr>')
     feed('/^a b<cr>')
     feed('0qqdw.ifoo<esc>qj0@q<esc>')
-    feed_command('unmap .')
+    command('unmap .')
     expect([[
       fooc d
       fooc d
@@ -105,15 +102,15 @@ describe('mapping', function()
 
   it('i_CTRL-G_U', function()
     -- <c-g>U<cursor> works only within a single line
-    feed_command('imapclear')
-    feed_command('imap ( ()<c-g>U<left>')
+    command('imapclear')
+    command('imap ( ()<c-g>U<left>')
     feed('G2o<esc>ki<cr>Test1: text with a (here some more text<esc>k.')
     -- test undo
     feed('G2o<esc>ki<cr>Test2: text wit a (here some more text [und undo]<c-g>u<esc>k.u')
-    feed_command('imapclear')
-    feed_command('set whichwrap=<,>,[,]')
+    command('imapclear')
+    command('set whichwrap=<,>,[,]')
     feed('G3o<esc>2k')
-    feed_command([[:exe ":norm! iTest3: text with a (parenthesis here\<C-G>U\<Right>new line here\<esc>\<up>\<up>."]])
+    command([[:exe ":norm! iTest3: text with a (parenthesis here\<C-G>U\<Right>new line here\<esc>\<up>\<up>."]])
 
     expect([[
 

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -268,7 +268,7 @@ describe('system()', function()
         :call system("for /L %I in (1,0,2) do @echo y")      |]]
         or  [[
         :call system("yes")                                  |]]))
-      feed('<c-c>')
+      feed('foo<c-c>')
       screen:expect([[
         ^                                                     |
         ~                                                    |
@@ -284,6 +284,49 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         Type  :qa  and press <Enter> to exit Nvim            |
+      ]])
+    end)
+
+    it('`yes` interrupted with mapped CTRL-C', function()
+      command('nnoremap <C-C> i')
+      feed(':call system("' .. (iswin()
+        and 'for /L %I in (1,0,2) do @echo y'
+        or  'yes') .. '")<cr>')
+      screen:expect([[
+                                                             |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+]] .. (iswin()
+        and [[
+        :call system("for /L %I in (1,0,2) do @echo y")      |]]
+        or  [[
+        :call system("yes")                                  |]]))
+      feed('foo<c-c>')
+      screen:expect([[
+        ^                                                     |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        ~                                                    |
+        -- INSERT --                                         |
       ]])
     end)
   end)


### PR DESCRIPTION
Fix #15258