### PR TITLE
feat(runtime): specify when deprecated functions will be removed

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1335,7 +1335,7 @@ deprecate({name}, {alternative}, {version}, {plugin})        *vim.deprecate()*
                     {version}      string Version in which the deprecated
                                    function will be removed.
                     {plugin}       string|nil Plugin name that the function
-                                   will be removed from. Defaults to "Neovim".
+                                   will be removed from. Defaults to "Nvim".
 
 inspect({object}, {options})                                   *vim.inspect()*
                 Return a human-readable representation of the given object.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1326,6 +1326,15 @@ defer_fn({fn}, {timeout})                                     *vim.defer_fn()*
                 Return: ~
                     timer luv timer object
 
+deprecate({name}, {alternative}, {version})                  *vim.deprecate()*
+                Display a deprecation notification to the user.
+
+                Parameters: ~
+                    {name}         string Deprecated function.
+                    {alternative}  string|nil Preferred alternative function.
+                    {version}      string Neovim version in which the
+                                   deprecated function will be removed.
+
 inspect({object}, {options})                                   *vim.inspect()*
                 Return a human-readable representation of the given object.
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1326,14 +1326,16 @@ defer_fn({fn}, {timeout})                                     *vim.defer_fn()*
                 Return: ~
                     timer luv timer object
 
-deprecate({name}, {alternative}, {version})                  *vim.deprecate()*
+deprecate({name}, {alternative}, {version}, {plugin})        *vim.deprecate()*
                 Display a deprecation notification to the user.
 
                 Parameters: ~
                     {name}         string Deprecated function.
                     {alternative}  string|nil Preferred alternative function.
-                    {version}      string Neovim version in which the
-                                   deprecated function will be removed.
+                    {version}      string Version in which the deprecated
+                                   function will be removed.
+                    {plugin}       string|nil Plugin name that the function
+                                   will be removed from. Defaults to "Neovim".
 
 inspect({object}, {options})                                   *vim.inspect()*
                 Return a human-readable representation of the given object.

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -742,7 +742,7 @@ end
 ---@param version     string     Version in which the deprecated function will
 ---                              be removed.
 ---@param plugin      string|nil Plugin name that the function will be removed
----                              from. Defaults to "Neovim".
+---                              from. Defaults to "Nvim".
 function vim.deprecate(name, alternative, version, plugin)
     local message = name .. ' is deprecated'
     plugin = plugin or "Nvim"

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -743,7 +743,7 @@ end
 ---                              function will be removed.
 function vim.deprecate(name, alternative, version)
     local message = name .. ' is deprecated'
-    message = alternative and (message..', use '..alternative..' instead.') or message
+    message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message
     message = message .. ' See :h deprecated\nThis function will be removed in version ' .. version
     vim.notify_once(message, vim.log.levels.WARN)
 end

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -735,6 +735,19 @@ function vim._cs_remote(rcid, server_addr, connect_error, args)
   }
 end
 
+--- Display a deprecation notification to the user.
+---
+---@param name        string     Deprecated function.
+---@param alternative string|nil Preferred alternative function.
+---@param version     string     Neovim version in which the deprecated
+---                              function will be removed.
+function vim.deprecate(name, alternative, version)
+    local message = name .. ' is deprecated'
+    message = alternative and (message..', use '..alternative..' instead.') or message
+    message = message .. ' See :h deprecated\nThis function will be removed in version ' .. version
+    vim.notify_once(message, vim.log.levels.WARN)
+end
+
 require('vim._meta')
 
 return vim

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -739,8 +739,8 @@ end
 ---
 ---@param name        string     Deprecated function.
 ---@param alternative string|nil Preferred alternative function.
----@param version     string     Neovim version in which the deprecated
----                              function will be removed.
+---@param version     string     Version in which the deprecated function will
+---                              be removed.
 function vim.deprecate(name, alternative, version)
     local message = name .. ' is deprecated'
     message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -741,10 +741,13 @@ end
 ---@param alternative string|nil Preferred alternative function.
 ---@param version     string     Version in which the deprecated function will
 ---                              be removed.
-function vim.deprecate(name, alternative, version)
+---@param plugin      string|nil Plugin name that the function will be removed
+---                              from. Defaults to "Neovim".
+function vim.deprecate(name, alternative, version, plugin)
     local message = name .. ' is deprecated'
+    plugin = plugin or "Neovim"
     message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message
-    message = message .. ' See :h deprecated\nThis function will be removed in version ' .. version
+    message = message .. ' See :h deprecated\nThis function will be removed in ' .. plugin .. ' version ' .. version
     vim.notify_once(message, vim.log.levels.WARN)
 end
 

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -745,7 +745,7 @@ end
 ---                              from. Defaults to "Neovim".
 function vim.deprecate(name, alternative, version, plugin)
     local message = name .. ' is deprecated'
-    plugin = plugin or "Neovim"
+    plugin = plugin or "Nvim"
     message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message
     message = message .. ' See :h deprecated\nThis function will be removed in ' .. plugin .. ' version ' .. version
     vim.notify_once(message, vim.log.levels.WARN)

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -241,6 +241,25 @@ end
 -- Deprecated Functions {{{
 
 
+--- Display a deprecation notification to the user.
+--- @private
+---
+---@param name        string Deprecated function.
+---@param alternative string Preferred alternative function.
+---@param version     string Neovim version in which the deprecated function
+---                          will be removed.
+local function deprecate(name, alternative, version)
+    local message = name .. ' is deprecated'
+    if alternative then
+      message = message.. ', use ' .. alternative .. ' instead.'
+    else
+      message = message .. '.'
+    end
+    message = message .. ' See :h deprecated.\nThis function will be removed in version ' .. version .. '.'
+    vim.notify_once(message, vim.log.levels.WARN)
+end
+
+
 --- Save diagnostics to the current buffer.
 ---
 ---@deprecated Prefer |vim.diagnostic.set()|
@@ -251,7 +270,7 @@ end
 ---@param client_id number
 ---@private
 function M.save(diagnostics, bufnr, client_id)
-  vim.notify_once('vim.lsp.diagnostic.save is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.save', 'vim.diagnostic.set', '0.8' )
   local namespace = M.get_namespace(client_id)
   vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
 end
@@ -265,7 +284,7 @@ end
 ---                        If nil, diagnostics of all clients are included.
 ---@return table with diagnostics grouped by bufnr (bufnr: Diagnostic[])
 function M.get_all(client_id)
-  vim.notify_once('vim.lsp.diagnostic.get_all is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_all', 'vim.diagnostic.get', '0.8' )
   local result = {}
   local namespace
   if client_id then
@@ -287,7 +306,7 @@ end
 ---                            Else, return just the diagnostics associated with the client_id.
 ---@param predicate function|nil Optional function for filtering diagnostics
 function M.get(bufnr, client_id, predicate)
-  vim.notify_once('vim.lsp.diagnostic.get is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get', 'vim.diagnostic.get', '0.8' )
   predicate = predicate or function() return true end
   if client_id == nil then
     local all_diagnostics = {}
@@ -349,7 +368,7 @@ end
 ---@param severity DiagnosticSeverity
 ---@param client_id number the client id
 function M.get_count(bufnr, severity, client_id)
-  vim.notify_once('vim.lsp.diagnostic.get_count is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_count', 'vim.diagnostic.get', '0.8' )
   severity = severity_lsp_to_vim(severity)
   local opts = { severity = severity }
   if client_id ~= nil then
@@ -366,7 +385,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic
 function M.get_prev(opts)
-  vim.notify_once('vim.lsp.diagnostic.get_prev is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_prev', 'vim.diagnostic.get_prev', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -384,7 +403,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic position
 function M.get_prev_pos(opts)
-  vim.notify_once('vim.lsp.diagnostic.get_prev_pos is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_prev_pos', 'vim.diagnostic.get_prev_pos', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -401,7 +420,7 @@ end
 ---
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 function M.goto_prev(opts)
-  vim.notify_once('vim.lsp.diagnostic.goto_prev is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.goto_prev', 'vim.diagnostic.goto_prev', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -419,7 +438,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic
 function M.get_next(opts)
-  vim.notify_once('vim.lsp.diagnostic.get_next is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_next', 'vim.diagnostic.get_next', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -437,7 +456,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic position
 function M.get_next_pos(opts)
-  vim.notify_once('vim.lsp.diagnostic.get_next_pos is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_next_pos', 'vim.diagnostic.get_next_pos', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -452,7 +471,7 @@ end
 ---
 ---@deprecated Prefer |vim.diagnostic.goto_next()|
 function M.goto_next(opts)
-  vim.notify_once('vim.lsp.diagnostic.goto_next is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.goto_next', 'vim.diagnostic.goto_next', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -476,7 +495,7 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_signs(diagnostics, bufnr, client_id, _, opts)
-  vim.notify_once('vim.lsp.diagnostic.set_signs is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.set_signs', nil , '0.8' )
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -497,7 +516,7 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_underline(diagnostics, bufnr, client_id, _, opts)
-  vim.notify_once('vim.lsp.diagnostic.set_underline is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.set_underline', nil , '0.8' )
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -519,7 +538,7 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_virtual_text(diagnostics, bufnr, client_id, _, opts)
-  vim.notify_once('vim.lsp.diagnostic.set_virtual_text is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.set_virtual_text', nil , '0.8' )
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -538,7 +557,7 @@ end
 ---@return an array of [text, hl_group] arrays. This can be passed directly to
 ---        the {virt_text} option of |nvim_buf_set_extmark()|.
 function M.get_virtual_text_chunks_for_line(bufnr, _, line_diags, opts)
-  vim.notify_once('vim.lsp.diagnostic.get_virtual_text_chunks_for_line is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.get_virtual_text_chunks_for_line', nil, '0.8' )
   return vim.diagnostic._get_virt_text_chunks(diagnostic_lsp_to_vim(line_diags, bufnr), opts)
 end
 
@@ -556,7 +575,7 @@ end
 ---@param position table|nil The (0,0)-indexed position
 ---@return table {popup_bufnr, win_id}
 function M.show_position_diagnostics(opts, buf_nr, position)
-  vim.notify_once('vim.lsp.diagnostic.show_position_diagnostics is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.show_position_diagnostics', 'vim.diagnostic.open_float', '0.8' )
   opts = opts or {}
   opts.scope = "cursor"
   opts.pos = position
@@ -580,7 +599,7 @@ end
 ---@param client_id number|nil the client id
 ---@return table {popup_bufnr, win_id}
 function M.show_line_diagnostics(opts, buf_nr, line_nr, client_id)
-  vim.notify_once('vim.lsp.diagnostic.show_line_diagnostics is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.show_line_diagnostics', 'vim.diagnostic.open_float', '0.8' )
   opts = opts or {}
   opts.scope = "line"
   opts.pos = line_nr
@@ -604,7 +623,7 @@ end
 ---       client. The default is to redraw diagnostics for all attached
 ---       clients.
 function M.redraw(bufnr, client_id)
-  vim.notify_once('vim.lsp.diagnostic.redraw is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.redraw', 'vim.diagnostic.show', '0.8' )
   bufnr = get_bufnr(bufnr)
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
@@ -632,7 +651,7 @@ end
 ---         - {workspace}: (boolean, default true)
 ---             - Set the list with workspace diagnostics
 function M.set_qflist(opts)
-  vim.notify_once('vim.lsp.diagnostic.set_qflist is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.set_qflist', 'vim.diagnostic.setqflist', '0.8' )
   opts = opts or {}
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
@@ -664,7 +683,7 @@ end
 ---         - {workspace}: (boolean, default false)
 ---             - Set the list with workspace diagnostics
 function M.set_loclist(opts)
-  vim.notify_once('vim.lsp.diagnostic.set_loclist is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.set_loclist', 'vim.diagnostic.setloclist', '0.8' )
   opts = opts or {}
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
@@ -692,7 +711,7 @@ end
 -- send diagnostic information and the client will still process it. The
 -- diagnostics are simply not displayed to the user.
 function M.disable(bufnr, client_id)
-  vim.notify_once('vim.lsp.diagnostic.disable is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.disable', 'vim.diagnostic.disable', '0.8' )
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
       M.disable(bufnr, client.id)
@@ -713,7 +732,7 @@ end
 ---       client. The default is to enable diagnostics for all attached
 ---       clients.
 function M.enable(bufnr, client_id)
-  vim.notify_once('vim.lsp.diagnostic.enable is deprecated. See :h deprecated', vim.log.levels.WARN)
+  deprecate('vim.lsp.diagnostic.enable', 'vim.diagnostic.enable', '0.8' )
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
       M.enable(bufnr, client.id)

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -250,12 +250,8 @@ end
 ---                          will be removed.
 local function deprecate(name, alternative, version)
     local message = name .. ' is deprecated'
-    if alternative then
-      message = message.. ', use ' .. alternative .. ' instead.'
-    else
-      message = message .. '.'
-    end
-    message = message .. ' See :h deprecated.\nThis function will be removed in version ' .. version .. '.'
+    message = alternative and (message..', use '..alternative..' instead.') or message
+    message = message .. ' See :h deprecated\nThis function will be removed in version ' .. version
     vim.notify_once(message, vim.log.levels.WARN)
 end
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -241,21 +241,6 @@ end
 -- Deprecated Functions {{{
 
 
---- Display a deprecation notification to the user.
---- @private
----
----@param name        string Deprecated function.
----@param alternative string Preferred alternative function.
----@param version     string Neovim version in which the deprecated function
----                          will be removed.
-local function deprecate(name, alternative, version)
-    local message = name .. ' is deprecated'
-    message = alternative and (message..', use '..alternative..' instead.') or message
-    message = message .. ' See :h deprecated\nThis function will be removed in version ' .. version
-    vim.notify_once(message, vim.log.levels.WARN)
-end
-
-
 --- Save diagnostics to the current buffer.
 ---
 ---@deprecated Prefer |vim.diagnostic.set()|
@@ -266,7 +251,7 @@ end
 ---@param client_id number
 ---@private
 function M.save(diagnostics, bufnr, client_id)
-  deprecate('vim.lsp.diagnostic.save', 'vim.diagnostic.set', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.save', 'vim.diagnostic.set', '0.8' )
   local namespace = M.get_namespace(client_id)
   vim.diagnostic.set(namespace, bufnr, diagnostic_lsp_to_vim(diagnostics, bufnr, client_id))
 end
@@ -280,7 +265,7 @@ end
 ---                        If nil, diagnostics of all clients are included.
 ---@return table with diagnostics grouped by bufnr (bufnr: Diagnostic[])
 function M.get_all(client_id)
-  deprecate('vim.lsp.diagnostic.get_all', 'vim.diagnostic.get', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_all', 'vim.diagnostic.get', '0.8' )
   local result = {}
   local namespace
   if client_id then
@@ -302,7 +287,7 @@ end
 ---                            Else, return just the diagnostics associated with the client_id.
 ---@param predicate function|nil Optional function for filtering diagnostics
 function M.get(bufnr, client_id, predicate)
-  deprecate('vim.lsp.diagnostic.get', 'vim.diagnostic.get', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get', 'vim.diagnostic.get', '0.8' )
   predicate = predicate or function() return true end
   if client_id == nil then
     local all_diagnostics = {}
@@ -364,7 +349,7 @@ end
 ---@param severity DiagnosticSeverity
 ---@param client_id number the client id
 function M.get_count(bufnr, severity, client_id)
-  deprecate('vim.lsp.diagnostic.get_count', 'vim.diagnostic.get', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_count', 'vim.diagnostic.get', '0.8' )
   severity = severity_lsp_to_vim(severity)
   local opts = { severity = severity }
   if client_id ~= nil then
@@ -381,7 +366,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic
 function M.get_prev(opts)
-  deprecate('vim.lsp.diagnostic.get_prev', 'vim.diagnostic.get_prev', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_prev', 'vim.diagnostic.get_prev', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -399,7 +384,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Previous diagnostic position
 function M.get_prev_pos(opts)
-  deprecate('vim.lsp.diagnostic.get_prev_pos', 'vim.diagnostic.get_prev_pos', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_prev_pos', 'vim.diagnostic.get_prev_pos', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -416,7 +401,7 @@ end
 ---
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 function M.goto_prev(opts)
-  deprecate('vim.lsp.diagnostic.goto_prev', 'vim.diagnostic.goto_prev', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.goto_prev', 'vim.diagnostic.goto_prev', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -434,7 +419,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic
 function M.get_next(opts)
-  deprecate('vim.lsp.diagnostic.get_next', 'vim.diagnostic.get_next', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_next', 'vim.diagnostic.get_next', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -452,7 +437,7 @@ end
 ---@param opts table See |vim.lsp.diagnostic.goto_next()|
 ---@return table Next diagnostic position
 function M.get_next_pos(opts)
-  deprecate('vim.lsp.diagnostic.get_next_pos', 'vim.diagnostic.get_next_pos', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_next_pos', 'vim.diagnostic.get_next_pos', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -467,7 +452,7 @@ end
 ---
 ---@deprecated Prefer |vim.diagnostic.goto_next()|
 function M.goto_next(opts)
-  deprecate('vim.lsp.diagnostic.goto_next', 'vim.diagnostic.goto_next', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.goto_next', 'vim.diagnostic.goto_next', '0.8' )
   if opts then
     if opts.severity then
       opts.severity = severity_lsp_to_vim(opts.severity)
@@ -491,7 +476,7 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_signs(diagnostics, bufnr, client_id, _, opts)
-  deprecate('vim.lsp.diagnostic.set_signs', nil , '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.set_signs', nil , '0.8' )
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -512,7 +497,7 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_underline(diagnostics, bufnr, client_id, _, opts)
-  deprecate('vim.lsp.diagnostic.set_underline', nil , '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.set_underline', nil , '0.8' )
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -534,7 +519,7 @@ end
 ---             - severity_limit (DiagnosticSeverity):
 ---                 - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
 function M.set_virtual_text(diagnostics, bufnr, client_id, _, opts)
-  deprecate('vim.lsp.diagnostic.set_virtual_text', nil , '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.set_virtual_text', nil , '0.8' )
   local namespace = M.get_namespace(client_id)
   if opts and not opts.severity and opts.severity_limit then
     opts.severity = {min=severity_lsp_to_vim(opts.severity_limit)}
@@ -553,7 +538,7 @@ end
 ---@return an array of [text, hl_group] arrays. This can be passed directly to
 ---        the {virt_text} option of |nvim_buf_set_extmark()|.
 function M.get_virtual_text_chunks_for_line(bufnr, _, line_diags, opts)
-  deprecate('vim.lsp.diagnostic.get_virtual_text_chunks_for_line', nil, '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.get_virtual_text_chunks_for_line', nil, '0.8' )
   return vim.diagnostic._get_virt_text_chunks(diagnostic_lsp_to_vim(line_diags, bufnr), opts)
 end
 
@@ -571,7 +556,7 @@ end
 ---@param position table|nil The (0,0)-indexed position
 ---@return table {popup_bufnr, win_id}
 function M.show_position_diagnostics(opts, buf_nr, position)
-  deprecate('vim.lsp.diagnostic.show_position_diagnostics', 'vim.diagnostic.open_float', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.show_position_diagnostics', 'vim.diagnostic.open_float', '0.8' )
   opts = opts or {}
   opts.scope = "cursor"
   opts.pos = position
@@ -595,7 +580,7 @@ end
 ---@param client_id number|nil the client id
 ---@return table {popup_bufnr, win_id}
 function M.show_line_diagnostics(opts, buf_nr, line_nr, client_id)
-  deprecate('vim.lsp.diagnostic.show_line_diagnostics', 'vim.diagnostic.open_float', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.show_line_diagnostics', 'vim.diagnostic.open_float', '0.8' )
   opts = opts or {}
   opts.scope = "line"
   opts.pos = line_nr
@@ -619,7 +604,7 @@ end
 ---       client. The default is to redraw diagnostics for all attached
 ---       clients.
 function M.redraw(bufnr, client_id)
-  deprecate('vim.lsp.diagnostic.redraw', 'vim.diagnostic.show', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.redraw', 'vim.diagnostic.show', '0.8' )
   bufnr = get_bufnr(bufnr)
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
@@ -647,7 +632,7 @@ end
 ---         - {workspace}: (boolean, default true)
 ---             - Set the list with workspace diagnostics
 function M.set_qflist(opts)
-  deprecate('vim.lsp.diagnostic.set_qflist', 'vim.diagnostic.setqflist', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.set_qflist', 'vim.diagnostic.setqflist', '0.8' )
   opts = opts or {}
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
@@ -679,7 +664,7 @@ end
 ---         - {workspace}: (boolean, default false)
 ---             - Set the list with workspace diagnostics
 function M.set_loclist(opts)
-  deprecate('vim.lsp.diagnostic.set_loclist', 'vim.diagnostic.setloclist', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.set_loclist', 'vim.diagnostic.setloclist', '0.8' )
   opts = opts or {}
   if opts.severity then
     opts.severity = severity_lsp_to_vim(opts.severity)
@@ -707,7 +692,7 @@ end
 -- send diagnostic information and the client will still process it. The
 -- diagnostics are simply not displayed to the user.
 function M.disable(bufnr, client_id)
-  deprecate('vim.lsp.diagnostic.disable', 'vim.diagnostic.disable', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.disable', 'vim.diagnostic.disable', '0.8' )
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
       M.disable(bufnr, client.id)
@@ -728,7 +713,7 @@ end
 ---       client. The default is to enable diagnostics for all attached
 ---       clients.
 function M.enable(bufnr, client_id)
-  deprecate('vim.lsp.diagnostic.enable', 'vim.diagnostic.enable', '0.8' )
+  vim.deprecate('vim.lsp.diagnostic.enable', 'vim.diagnostic.enable', '0.8' )
   if not client_id then
     return vim.lsp.for_each_buffer_client(bufnr, function(client)
       M.enable(bufnr, client.id)


### PR DESCRIPTION
This is primarily intended to act as documentation for the developer so
they know exactly when and what to remove. This will help prevent the
situation of deprecated code lingering for far too long as developers
don't have to worry if a function is safe to remove.

This could've been achieved just as well by a simple comment before the
function, but thought this information could be useful to end users as
well, which is why I opted to add the information to the deprecation
message itself.
