### PR TITLE
Add filetype detection for Gleam

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -737,6 +737,9 @@ au BufNewFile,BufRead gnashrc,.gnashrc,gnashpluginrc,.gnashpluginrc setf gnash
 au BufNewFile,BufRead gitolite.conf		setf gitolite
 au BufNewFile,BufRead {,.}gitolite.rc,example.gitolite.rc	setf perl
 
+" Gleam
+au BufNewFile,BufRead *.gleam setf gleam
+
 " Glimmer-flavored TypeScript and JavaScript
 au BufNewFile,BufRead *.gts	setf typescript.glimmer
 au BufNewFile,BufRead *.gjs	setf javascript.glimmer

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -91,6 +91,7 @@ local extension = {
   eni = "cl",
   dcl = "clean",
   icl = "clean",
+  gleam = "gleam",
   cljx = "clojure",
   clj = "clojure",
   cljc = "clojure",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -211,6 +211,7 @@ let s:filename_checks = {
     \ 'gitrebase': ['git-rebase-todo'],
     \ 'gitsendemail': ['.gitsendemail.msg.xxxxxx'],
     \ 'gkrellmrc': ['gkrellmrc', 'gkrellmrc_x'],
+    \ 'gleam': ['file.gleam'],
     \ 'glsl': ['file.glsl'],
     \ 'gnash': ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
     \ 'gnuplot': ['file.gpi', '.gnuplot'],


### PR DESCRIPTION
Since there is currently no filetype detection for [Gleam](https://gleam.run), I thought it would be worth adding to Neovim.

It was a bit unclear to me how to properly test this, but I've been using https://github.com/neovim/neovim/pull/18058 as a reference. Please, let me know if anything is missing.