### PR TITLE
vim-patch:8.1.2191,8.2.4848: mappings for completion keys not ignored

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1769,8 +1769,8 @@ static int put_string_in_typebuf(int offset, int slen, char_u *string, int new_s
 }
 
 /// Check if the bytes at the start of the typeahead buffer are a character used
-/// in CTRL-X mode.  This includes the form with a CTRL modifier.
-static bool at_ctrl_x_key(void)
+/// in Insert mode completion.  This includes the form with a CTRL modifier.
+static bool at_ins_compl_key(void)
 {
   char_u *p = typebuf.tb_buf + typebuf.tb_off;
   int c = *p;
@@ -1778,7 +1778,8 @@ static bool at_ctrl_x_key(void)
   if (typebuf.tb_len > 3 && c == K_SPECIAL && p[1] == KS_MODIFIER && (p[2] & MOD_MASK_CTRL)) {
     c = p[3] & 0x1f;
   }
-  return vim_is_ctrl_x_key(c);
+  return (ctrl_x_mode_not_default() && vim_is_ctrl_x_key(c))
+         || ((compl_cont_status & CONT_LOCAL) && (c == Ctrl_N || c == Ctrl_P));
 }
 
 /// Check if typebuf.tb_buf[] contains a modifer plus key that can be changed
@@ -1883,9 +1884,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
       && !(State == HITRETURN && (tb_c1 == CAR || tb_c1 == ' '))
       && State != ASKMORE
       && State != CONFIRM
-      && !((ctrl_x_mode_not_default() && at_ctrl_x_key())
-           || ((compl_cont_status & CONT_LOCAL)
-               && (tb_c1 == Ctrl_N || tb_c1 == Ctrl_P)))) {
+      && !at_ins_compl_key()) {
     if (tb_c1 == K_SPECIAL) {
       nolmaplen = 2;
     } else {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1768,6 +1768,19 @@ static int put_string_in_typebuf(int offset, int slen, char_u *string, int new_s
   return OK;
 }
 
+/// Check if the bytes at the start of the typeahead buffer are a character used
+/// in CTRL-X mode.  This includes the form with a CTRL modifier.
+static bool at_ctrl_x_key(void)
+{
+  char_u *p = typebuf.tb_buf + typebuf.tb_off;
+  int c = *p;
+
+  if (typebuf.tb_len > 3 && c == K_SPECIAL && p[1] == KS_MODIFIER && (p[2] & MOD_MASK_CTRL)) {
+    c = p[3] & 0x1f;
+  }
+  return vim_is_ctrl_x_key(c);
+}
+
 /// Check if typebuf.tb_buf[] contains a modifer plus key that can be changed
 /// into just a key, apply that.
 /// Check from typebuf.tb_buf[typebuf.tb_off] to typebuf.tb_buf[typebuf.tb_off + "max_offset"].
@@ -1870,7 +1883,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
       && !(State == HITRETURN && (tb_c1 == CAR || tb_c1 == ' '))
       && State != ASKMORE
       && State != CONFIRM
-      && !((ctrl_x_mode_not_default() && vim_is_ctrl_x_key(tb_c1))
+      && !((ctrl_x_mode_not_default() && at_ctrl_x_key())
            || ((compl_cont_status & CONT_LOCAL)
                && (tb_c1 == Ctrl_N || tb_c1 == Ctrl_P)))) {
     if (tb_c1 == K_SPECIAL) {

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -325,6 +325,21 @@ func Test_compl_vim_cmds_after_register_expr()
   bwipe!
 endfunc
 
+func Test_compl_ignore_mappings()
+  call setline(1, ['foo', 'bar', 'baz', 'foobar'])
+  inoremap <C-P> (C-P)
+  inoremap <C-N> (C-N)
+  normal! G
+  call feedkeys("o\<C-X>\<C-N>\<C-N>\<C-N>\<C-P>\<C-N>\<C-Y>", 'tx')
+  call assert_equal('baz', getline('.'))
+  " Also test with unsimplified keys
+  call feedkeys("o\<C-X>\<*C-N>\<*C-N>\<*C-N>\<*C-P>\<*C-N>\<C-Y>", 'tx')
+  call assert_equal('baz', getline('.'))
+  iunmap <C-P>
+  iunmap <C-N>
+  bwipe!
+endfunc
+
 func DummyCompleteOne(findstart, base)
   if a:findstart
     return 0


### PR DESCRIPTION
#### vim-patch:8.1.2191: when using modifyOtherKeys CTRL-X mode may not work

Problem:    When using modifyOtherKeys CTRL-X mode may not work.
Solution:   Recognize a control character also in the form with a modifier.
https://github.com/vim/vim/commit/88d3d09e07dbe0e3ea450bc554e2aadc451450d2


#### vim-patch:8.2.4848: local completion with mappings and simplification not working

Problem:    Local completion with mappings and simplification not working.
Solution:   Fix local completion \<C-N>/\<C-P> mappings not ignored if keys are
            not simplified. (closes vim/vim#10323)
https://github.com/vim/vim/commit/ee4460306917431d0d17a7cb11c6646f4c6540b6