### PR TITLE
vim-patch:8.2.4849: Gleam filetype not detected

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -715,6 +715,9 @@ au BufNewFile,BufRead *.git/*
 " Gkrellmrc
 au BufNewFile,BufRead gkrellmrc,gkrellmrc_?	setf gkrellmrc
 
+" Gleam
+au BufNewFile,BufRead *.gleam			setf gleam
+
 " GLSL
 au BufNewFile,BufRead *.glsl			setf glsl
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -241,6 +241,7 @@ local extension = {
   gmi = "gemtext",
   gemini = "gemtext",
   gift = "gift",
+  gleam = "gleam",
   glsl = "glsl",
   gpi = "gnuplot",
   gnuplot = "gnuplot",

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -211,6 +211,7 @@ let s:filename_checks = {
     \ 'gitrebase': ['git-rebase-todo'],
     \ 'gitsendemail': ['.gitsendemail.msg.xxxxxx'],
     \ 'gkrellmrc': ['gkrellmrc', 'gkrellmrc_x'],
+    \ 'gleam': ['file.gleam'],
     \ 'glsl': ['file.glsl'],
     \ 'gnash': ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
     \ 'gnuplot': ['file.gpi', '.gnuplot'],


### PR DESCRIPTION
Problem:    Gleam filetype not detected.
Solution:   Add a pattern for Gleam files. (Mathias Jean Johansen,
            closes vim/vim#10326)
https://github.com/vim/vim/commit/917c32c4f75351061a773cd5bc5b6f42c7d10e62