### PR TITLE
fix(build): allow using the system's msgpack-c

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -222,7 +222,8 @@ if(USE_BUNDLED_LIBUV)
   include(BuildLibuv)
 endif()
 
-if(USE_BUNDLED_MSGPACK)
+find_package(msgpack)
+if(USE_BUNDLED_MSGPACK AND NOT MSGPACK_FOUND)
   include(BuildMsgpack)
 endif()
 


### PR DESCRIPTION
Allow cmake to use msgpack when `USE_BUNDLED_MSGPACK=OFF`

<details>
<summary>bundled msgpack</summary>

```console
$ readelf -d /usr/local/bin/nvim

Dynamic section at offset 0x59d8e8 contains 28 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x0000000000000015 (DEBUG)              0x0
 0x0000000000000007 (RELA)               0x2536c8
 0x0000000000000008 (RELASZ)             984 (bytes)
 0x0000000000000009 (RELAENT)            24 (bytes)
 0x0000000000000017 (JMPREL)             0x253aa0
 0x0000000000000002 (PLTRELSZ)           8232 (bytes)
 0x0000000000000003 (PLTGOT)             0x7b2350
 0x0000000000000014 (PLTREL)             RELA
 0x0000000000000006 (SYMTAB)             0x200320
 0x000000000000000b (SYMENT)             24 (bytes)
 0x0000000000000005 (STRTAB)             0x23c3fc
 0x000000000000000a (STRSZ)              94922 (bytes)
 0x000000006ffffef5 (GNU_HASH)           0x225dd0
 0x0000000000000004 (HASH)               0x230af4
 0x0000000000000019 (INIT_ARRAY)         0x79bc80
 0x000000000000001b (INIT_ARRAYSZ)       8 (bytes)
 0x000000000000001a (FINI_ARRAY)         0x79bc70
 0x000000000000001c (FINI_ARRAYSZ)       16 (bytes)
 0x000000000000000c (INIT)               0x7996c0
 0x000000000000000d (FINI)               0x7996dc
 0x000000006ffffff0 (VERSYM)             0x222e20
 0x000000006ffffffe (VERNEED)            0x225c60
 0x000000006fffffff (VERNEEDNUM)         4
 0x0000000000000000 (NULL)               0x0
```

</details>

<details>
<summary>system's msgpack</summary>

```console
$ readelf -d build/bin/nvim

Dynamic section at offset 0x4cb830 contains 28 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libmsgpackc.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x0000000000000015 (DEBUG)              0x0
 0x0000000000000007 (RELA)               0x247c50
 0x0000000000000008 (RELASZ)             984 (bytes)
 0x0000000000000009 (RELAENT)            24 (bytes)
 0x0000000000000017 (JMPREL)             0x248028
 0x0000000000000002 (PLTRELSZ)           8424 (bytes)
 0x0000000000000003 (PLTGOT)             0x6e3e08
 0x0000000000000014 (PLTREL)             RELA
 0x0000000000000006 (SYMTAB)             0x200338
 0x000000000000000b (SYMENT)             24 (bytes)
 0x0000000000000005 (STRTAB)             0x230a4c
 0x000000000000000a (STRSZ)              94718 (bytes)
 0x000000006ffffef5 (GNU_HASH)           0x225d68
 0x0000000000000019 (INIT_ARRAY)         0x6c99e0
 0x000000000000001b (INIT_ARRAYSZ)       8 (bytes)
 0x000000000000001a (FINI_ARRAY)         0x6c99d0
 0x000000000000001c (FINI_ARRAYSZ)       16 (bytes)
 0x000000000000000c (INIT)               0x6c73a0
 0x000000000000000d (FINI)               0x6c73bc
 0x000000006ffffff0 (VERSYM)             0x222dc0
 0x000000006ffffffe (VERNEED)            0x225bf8
 0x000000006fffffff (VERNEEDNUM)         4
 0x0000000000000000 (NULL)               0x0
```

</details>

fixes #15646
