### PR TITLE
Fix for issue #18112: nvim_eval_statusline() should throw an error for invalid statusline

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2276,6 +2276,14 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
   bool use_tabline = false;
   bool highlights = false;
 
+  if (str.size < 2 || memcmp(str.data, "%!", 2)) {
+    const char *const errmsg = check_stl_option((char_u *)str.data);
+    if (errmsg) {
+      api_set_error(err, kErrorTypeValidation, "%s", errmsg);
+      return result;
+    }
+  }
+
   if (HAS_KEY(opts->winid)) {
     if (opts->winid.type != kObjectTypeInteger) {
       api_set_error(err, kErrorTypeValidation, "winid must be an integer");

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3042,6 +3042,10 @@ describe('API', function()
       eq('fillchar must be a single character',
          pcall_err(meths.eval_statusline, '', { fillchar = 1 }))
     end)
+    it('rejects invalid string', function()
+      eq('E539: Illegal character <}>',
+         pcall_err(meths.eval_statusline, '%{%}', {}))
+    end)
     describe('highlight parsing', function()
       it('works', function()
         eq({


### PR DESCRIPTION
Fix #18112

This change aims to address the issue raised [here](https://github.com/neovim/neovim/issues/18112).

Return an error in nvim_eval_statusline() when an invalid status line string is detected.

Added a functional test to demonstrate this functionality.