### PR TITLE
vim-patch:8.2.1835: ":help ??" finds the "!!" tag

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5097,7 +5097,7 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
     }
   } else {
     // Recognize a few exceptions to the rule.  Some strings that contain
-    // '*' with "star".  Otherwise '*' is recognized as a wildcard.
+    // '*'are changed to "star", otherwise '*' is recognized as a wildcard.
     for (i = 0; except_tbl[i][0] != NULL; i++) {
       if (STRCMP(arg, except_tbl[i][0]) == 0) {
         STRCPY(d, except_tbl[i][1]);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5106,7 +5106,7 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
     }
   }
 
-  if (d[0] == NUL) {    // no match in table
+  if (d[0] == NUL) {  // no match in table
     // Replace "\S" with "/\\S", etc.  Otherwise every tag is matched.
     // Also replace "\%^" and "\%(", they match every tag too.
     // Also "\zs", "\z1", etc.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5023,37 +5023,59 @@ static int help_compare(const void *s1, const void *s2)
 int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep_lang)
 {
   int i;
-  static const char *(mtable[]) = {
-    "*", "g*", "[*", "]*",
-    "/*", "/\\*", "\"*", "**",
-    "/\\(\\)", "/\\%(\\)",
-    "?", ":?", "?<CR>", "g?", "g?g?", "g??",
-    "-?", "q?", "v_g?",
-    "/\\?", "/\\z(\\)", "\\=", ":s\\=",
-    "[count]", "[quotex]",
-    "[range]", ":[range]",
-    "[pattern]", "\\|", "\\%$",
-    "s/\\~", "s/\\U", "s/\\L",
-    "s/\\1", "s/\\2", "s/\\3", "s/\\9"
+
+  // Specific tags that either have a specific replacement or won't go
+  // throught the generic rules.
+  static char *(except_tbl[][2]) = {
+    { "*",           "star" },
+    { "g*",          "gstar" },
+    { "[*",          "[star" },
+    { "]*",          "]star" },
+    { ":*",          ":star" },
+    { "/*",          "/star" },  // NOLINT
+    { "/\\*",        "/\\\\star" },
+    { "\"*",         "quotestar" },
+    { "**",          "starstar" },
+    { "cpo-*",       "cpo-star" },
+    { "/\\(\\)",     "/\\\\(\\\\)" },
+    { "/\\%(\\)",    "/\\\\%(\\\\)" },
+    { "?",           "?" },
+    { "??",          "??" },
+    { ":?",          ":?" },
+    { "?<CR>",       "?<CR>" },
+    { "g?",          "g?" },
+    { "g?g?",        "g?g?" },
+    { "g??",         "g??" },
+    { "-?",          "-?" },
+    { "q?",          "q?" },
+    { "v_g?",        "v_g?" },
+    { "/\\?",        "/\\\\?" },
+    { "/\\z(\\)",    "/\\\\z(\\\\)" },
+    { "\\=",         "\\\\=" },
+    { ":s\\=",       ":s\\\\=" },
+    { "[count]",     "\\[count]" },
+    { "[quotex]",    "\\[quotex]" },
+    { "[range]",     "\\[range]" },
+    { ":[range]",    ":\\[range]" },
+    { "[pattern]",   "\\[pattern]" },
+    { "\\|",         "\\\\bar" },
+    { "\\%$",        "/\\\\%\\$" },
+    { "s/\\~",       "s/\\\\\\~" },
+    { "s/\\U",       "s/\\\\U" },
+    { "s/\\L",       "s/\\\\L" },
+    { "s/\\1",       "s/\\\\1" },
+    { "s/\\2",       "s/\\\\2" },
+    { "s/\\3",       "s/\\\\3" },
+    { "s/\\9",       "s/\\\\9" },
+    { NULL, NULL }
   };
-  static const char *(rtable[]) = {
-    "star", "gstar", "[star", "]star",
-    "/star", "/\\\\star", "quotestar", "starstar",
-    "/\\\\(\\\\)", "/\\\\%(\\\\)",
-    "?", ":?", "?<CR>", "g?", "g?g?", "g??",
-    "-?", "q?", "v_g?",
-    "/\\\\?", "/\\\\z(\\\\)", "\\\\=", ":s\\\\=",
-    "\\[count]", "\\[quotex]",
-    "\\[range]", ":\\[range]",
-    "\\[pattern]", "\\\\bar", "/\\\\%\\$",
-    "s/\\\\\\~", "s/\\\\U", "s/\\\\L",
-    "s/\\\\1", "s/\\\\2", "s/\\\\3", "s/\\\\9"
-  };
+
   static const char *(expr_table[]) = {
     "!=?", "!~?", "<=?", "<?", "==?", "=~?",
     ">=?", ">?", "is?", "isnot?"
   };
   char *d = (char *)IObuff;       // assume IObuff is long enough!
+  d[0] = NUL;
 
   if (STRNICMP(arg, "expr-", 5) == 0) {
     // When the string starting with "expr-" and containing '?' and matches
@@ -5076,15 +5098,15 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
   } else {
     // Recognize a few exceptions to the rule.  Some strings that contain
     // '*' with "star".  Otherwise '*' is recognized as a wildcard.
-    for (i = (int)ARRAY_SIZE(mtable); --i >= 0;) {
-      if (STRCMP(arg, mtable[i]) == 0) {
-        STRCPY(d, rtable[i]);
+    for (i = 0; except_tbl[i][0] != NULL; i++) {
+      if (STRCMP(arg, except_tbl[i][0]) == 0) {
+        STRCPY(d, except_tbl[i][1]);
         break;
       }
     }
   }
 
-  if (i < 0) {  // no match in table
+  if (d[0] == NUL) {    // no match in table
     // Replace "\S" with "/\\S", etc.  Otherwise every tag is matched.
     // Also replace "\%^" and "\%(", they match every tag too.
     // Also "\zs", "\z1", etc.

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -28,9 +28,19 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*quote\*')
   helpclose
 
+  help *
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*star\*')
+  helpclose
+
   help "*
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*quotestar\*')
+  helpclose
+
+  help ??
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*??\*')
   helpclose
 
   help ch?ckhealth

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -38,6 +38,10 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*quotestar\*')
   helpclose
 
+  " The test result is different in vim. There ":help ??" will jump to the
+  " falsy operator ??, which hasn't been ported to neovim yet. Instead, neovim
+  " jumps to the tag "g??". This test result needs to be changed if neovim
+  " ports the falsy operator.
   help ??
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*g??\*')

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -40,7 +40,7 @@ func Test_help_tagjump()
 
   help ??
   call assert_equal("help", &filetype)
-  call assert_true(getline('.') =~ '\*??\*')
+  call assert_true(getline('.') =~ '\*g??\*')
   helpclose
 
   help ch?ckhealth


### PR DESCRIPTION
#### vim-patch:8.2.1835: ":help ??" finds the "!!" tag

Problem:    ":help ??" finds the "!!" tag.
Solution:   Do not translate "?" into ".".  (Naruhiko Nishino,
            closes vim/vim#7115)
https://github.com/vim/vim/commit/6eb36ade9883f54c84c739c6a3504ddfa3343063