### PR TITLE
feat(ui): allow embedder to emulate "cat data | nvim -" behaviour

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -52,6 +52,11 @@ with these (optional) keys:
 	`term_name`		Sets the name of the terminal 'term'.
 	`term_colors`		Sets the number of supported colors 't_Co'.
 	`term_background`	Sets the default value of 'background'.
+	`stdin_fd`		Read buffer from `fd` as if it was a stdin pipe
+				This option can only used by |--embed| ui,
+				see |ui-startup-stdin|.
+
+
 
 Specifying an unknown option is an error; UIs can check the |api-metadata|
 `ui_options` key for supported options.
@@ -139,6 +144,19 @@ procedure:
 5. If step 3 was used, Nvim will send a blocking "vimenter" request to the UI.
    Inside this request handler, the UI can safely do any initialization before
    entering normal mode, for example reading variables set by init.vim.
+
+							   *ui-startup-stdin*
+An UI can support the native read from stdin feature as invoked with
+`command | nvim -` for the builtin TUI. |--|
+The embedding process can detect that its stdin is open to a file which
+not is a terminal, just like nvim does. It then needs to forward this fd
+to Nvim. As fd=0 is already is used to send rpc data from the embedder to
+Nvim, it needs to use some other file descriptor, like fd=3 or higher.
+
+Then, `stdin_fd` option should be passed to `nvim_ui_attach` and nvim will
+implicitly read it as a buffer. This option can only be used when Nvim is
+launched with `--embed` option, as described above.
+
 
 ==============================================================================
 Global Events							    *ui-global*

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -283,6 +283,22 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
     return;
   }
 
+  if (strequal(name.data, "stdin_fd")) {
+    if (value.type != kObjectTypeInteger || value.data.integer < 0) {
+      api_set_error(error, kErrorTypeValidation, "stdin_fd must be a non-negative Integer");
+      return;
+    }
+
+    if (starting != NO_SCREEN) {
+      api_set_error(error, kErrorTypeValidation,
+                    "stdin_fd can only be used with first attached ui");
+      return;
+    }
+
+    stdin_fd = (int)value.data.integer;
+    return;
+  }
+
   // LEGACY: Deprecated option, use `ext_cmdline` instead.
   bool is_popupmenu = strequal(name.data, "popupmenu_external");
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2661,35 +2661,3 @@ end:
   xfree(cmdline);
   return result;
 }
-
-/// Invokes the nvim server to read from stdin when it is not a tty
-///
-/// It enables functionalities like:
-/// - echo "1f u c4n r34d th1s u r34lly n33d t0 g37 r357"| nvim -
-/// - cat path/to/a/file | nvim -
-/// It has to be called before |nvim_ui_attach()| is called in order
-/// to ensure proper functioning.
-///
-/// @param channel_id: The channel id of the GUI-client
-/// @param filedesc: The file descriptor of the GUI-client process' stdin
-/// @param implicit: Tells if read_stdin call is implicit.
-///                  i.e for cases like `echo xxx | nvim`
-/// @param[out] err Error details, if any
-void nvim_read_stdin(uint64_t channel_id, Integer filedesc, Error *err)
-FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY
-{
-  if (starting != NO_SCREEN) {
-    api_set_error(err, kErrorTypeValidation,
-                  "nvim_read_stdin must be called before nvim_ui_attach");
-    return;
-  }
-  if (filedesc < 0) {
-    api_set_error(err, kErrorTypeValidation,
-                  "file descriptor must be non-negative");
-    return;
-  }
-
-  stdin_filedesc = (int)filedesc;
-  implicit_readstdin = implicit;
-  return;
-}

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -507,6 +507,9 @@ EXTERN int v_dying INIT(= 0);
 EXTERN int stdin_isatty INIT(= true);
 // is stdout a terminal?
 EXTERN int stdout_isatty INIT(= true);
+/// filedesc set by embedder for reading first buffer like `cmd | nvim -`
+EXTERN int stdin_fd INIT(= -1);
+
 // true when doing full-screen output, otherwise only writing some messages.
 // volatile because it is used in a signal handler.
 EXTERN volatile int full_screen INIT(= false);
@@ -704,7 +707,6 @@ EXTERN int RedrawingDisabled INIT(= 0);
 
 EXTERN int readonlymode INIT(= false);      // Set to true for "view"
 EXTERN int recoverymode INIT(= false);      // Set to true for "-r" option
-EXTERN int stdin_filedesc INIT(= -1);       // stdin filedesc set by embedder
 
 // typeahead buffer
 EXTERN typebuf_T typebuf INIT(= { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });
@@ -847,10 +849,6 @@ EXTERN linenr_T printer_page_num;
 
 EXTERN bool typebuf_was_filled INIT(= false);     // received text from client
                                                   // or from feedkeys()
-
-EXTERN bool implicit_readstdin INIT(= false);     // Used in embed job created
-                                                  // by TUI process only in
-                                                  // builtin tui
 
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char psepc INIT(= '\\');            // normal path separator character

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -704,6 +704,7 @@ EXTERN int RedrawingDisabled INIT(= 0);
 
 EXTERN int readonlymode INIT(= false);      // Set to true for "view"
 EXTERN int recoverymode INIT(= false);      // Set to true for "-r" option
+EXTERN int stdin_filedesc INIT(= -1);       // stdin filedesc set by embedder
 
 // typeahead buffer
 EXTERN typebuf_T typebuf INIT(= { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });
@@ -847,6 +848,9 @@ EXTERN linenr_T printer_page_num;
 EXTERN bool typebuf_was_filled INIT(= false);     // received text from client
                                                   // or from feedkeys()
 
+EXTERN bool implicit_readstdin INIT(= false);     // Used in embed job created
+                                                  // by TUI process only in
+                                                  // builtin tui
 
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char psepc INIT(= '\\');            // normal path separator character

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -454,7 +454,7 @@ int main(int argc, char **argv)
   // writing end of the pipe doesn't like, e.g., in case stdin and stderr
   // are the same terminal: "cat | vim -".
   // Using autocommands here may cause trouble...
-  if (params.edit_type == EDIT_STDIN && !recoverymode) {
+  if ((params.edit_type == EDIT_STDIN || implicit_readstdin) && !recoverymode) {
     read_stdin();
   }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -454,7 +454,7 @@ int main(int argc, char **argv)
   // writing end of the pipe doesn't like, e.g., in case stdin and stderr
   // are the same terminal: "cat | vim -".
   // Using autocommands here may cause trouble...
-  if ((params.edit_type == EDIT_STDIN || implicit_readstdin) && !recoverymode) {
+  if ((params.edit_type == EDIT_STDIN || stdin_fd >= 0) && !recoverymode) {
     read_stdin();
   }
 

--- a/third-party/cmake/BuildLuarocks.cmake
+++ b/third-party/cmake/BuildLuarocks.cmake
@@ -225,7 +225,7 @@ if(USE_BUNDLED_BUSTED)
   # nvim-client: https://github.com/neovim/lua-client
   add_custom_command(OUTPUT ${ROCKS_DIR}/nvim-client
     COMMAND ${LUAROCKS_BINARY}
-    ARGS build nvim-client 0.2.2-1 ${LUAROCKS_BUILDARGS}
+    ARGS build nvim-client 0.2.3-1 ${LUAROCKS_BUILDARGS}
     DEPENDS luv)
   add_custom_target(nvim-client DEPENDS ${ROCKS_DIR}/nvim-client)
 


### PR DESCRIPTION
originally done as part of #10071 . I changed it to be an option to `nvim_ui_attach` as it can only be used as part of ui attachment anyway.

Needed to implement `nvim -` natively when TUI will be externalized, but any UI can use it to implement `command | my_nvim_ui -` and forward the stdin data to nvim as a buffer.

I'll try to mangle lua-client to support the client side behavior, so we can has a test.