### PR TITLE
fix(mac): add CoreServices to flake buildInputs

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -16,6 +16,10 @@
           neovim = pkgs.neovim-unwrapped.overrideAttrs (oa: {
             version = "master";
             src = ../.;
+
+            buildInputs = oa.buildInputs ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+              CoreServices
+            ]);
           });
 
           # a development binary to help debug issues


### PR DESCRIPTION
The `include` was added in e038625b87dda2389d004017bd2dcf2b65bc40f6.

Before this change the latest `master` would fail with:

```
[100%] Generating auto/os/lang.c.generated.h, ../../include/os/lang.h.generated.h
/tmp/nix-build-neovim-unwrapped-master.drv-0/3rk742v567gi2kasjzh6436dzpk0kip8-source/src/nvim/os/lang.c:7:11: fatal error: 'CoreServices/CoreServices.h' file not found
# include <CoreServices/CoreServices.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Maybe this should be a `nixpkgs` PR?