### PR TITLE
vim-patch:8.2.4857: Yaml indent for multiline is wrong

### DIFF
--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -17,3 +17,9 @@ map: val
 map: multiline
 value
 # END_INDENT
+
+# START_INDENT
+map: |
+line1
+line2
+# END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -17,3 +17,9 @@ map: val
 map: multiline
   value
 # END_INDENT
+
+# START_INDENT
+map: |
+  line1
+  line2
+# END_INDENT


### PR DESCRIPTION
Problem:    Yaml indent for multiline is wrong.
Solution:   Adjust patterns. (closes vim/vim#10328, closes vim/vim#8740)
https://github.com/vim/vim/commit/f4f579b46b27f5e1689912a3e84c6a2a96efd143