### PR TITLE
feat(api): add `nvim_cmd`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1711,17 +1711,49 @@ nvim_call_function({fn}, {args})                        *nvim_call_function()*
                 Return: ~
                     Result of the function call
 
+nvim_cmd({*cmd}, {*opts})                                         *nvim_cmd()*
+                Executes an Ex command.
+
+                Unlike |nvim_command()| this command takes a structured
+                Dictionary instead of a String. This allows for easier
+                construction and manipulation of an Ex command. This also
+                allows for things such as having spaces inside a command
+                argument, expanding filenames in a command that otherwise
+                doesn't expand filenames, etc.
+
+                Parameters: ~
+                    {cmd}   Command to execute. Must be a Dictionary that can
+                            contain the same values as the return value of
+                            |nvim_parse_cmd()| except "addr", "nargs" and
+                            "nextcmd" which are ignored if provided. All
+                            values except for "cmd" are optional.
+                    {opts}  Optional parameters.
+                            • output: (boolean, default false) Whether to
+                              return command output.
+
+                Return: ~
+                    Command output (non-error, non-shell |:!|) if `output` is
+                    true, else empty string.
+
+                See also: ~
+                    |nvim_exec()|
+                    |nvim_command()|
+
 nvim_command({command})                                       *nvim_command()*
-                Executes an ex-command.
+                Executes an Ex command.
 
                 On execution error: fails with VimL error, does not update
                 v:errmsg.
 
-                Parameters: ~
-                    {command}  Ex-command string
+                Prefer using |nvim_cmd()| or |nvim_exec()| over this. To
+                evaluate multiple lines of Vim script or an Ex command
+                directly, use |nvim_exec()|. To construct an Ex command using
+                a structured format and then execute it, use |nvim_cmd()|. To
+                modify an Ex command before evaluating it, use
+                |nvim_parse_cmd()| in conjunction with |nvim_cmd()|.
 
-                See also: ~
-                    |nvim_exec()|
+                Parameters: ~
+                    {command}  Ex command string
 
 nvim_eval({expr})                                                *nvim_eval()*
                 Evaluates a VimL |expression|. Dictionaries and Lists are
@@ -1737,7 +1769,7 @@ nvim_eval({expr})                                                *nvim_eval()*
                     Evaluation result or expanded object
 
 nvim_exec({src}, {output})                                       *nvim_exec()*
-                Executes Vimscript (multiline block of Ex-commands), like
+                Executes Vimscript (multiline block of Ex commands), like
                 anonymous |:source|.
 
                 Unlike |nvim_command()| this function supports heredocs,
@@ -1758,6 +1790,7 @@ nvim_exec({src}, {output})                                       *nvim_exec()*
                 See also: ~
                     |execute()|
                     |nvim_command()|
+                    |nvim_cmd()|
 
 nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
                 Parse command line.

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -155,5 +155,44 @@ return {
   create_augroup = {
     "clear";
   };
+  cmd = {
+    "cmd";
+    "range";
+    "count";
+    "reg";
+    "bang";
+    "args";
+    "magic";
+    "mods";
+    "nargs";
+    "addr";
+    "nextcmd";
+  };
+  cmd_magic = {
+    "file";
+    "bar";
+  };
+  cmd_mods = {
+    "silent";
+    "emsg_silent";
+    "sandbox";
+    "noautocmd";
+    "browse";
+    "confirm";
+    "hide";
+    "keepalt";
+    "keepjumps";
+    "keepmarks";
+    "keeppatterns";
+    "lockmarks";
+    "noswapfile";
+    "tab";
+    "verbose";
+    "vertical";
+    "split";
+  };
+  cmd_opts = {
+    "output";
+  };
 }
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -19,6 +19,7 @@
 #include "nvim/decoration.h"
 #include "nvim/eval.h"
 #include "nvim/eval/typval.h"
+#include "nvim/ex_cmds_defs.h"
 #include "nvim/extmark.h"
 #include "nvim/fileio.h"
 #include "nvim/getchar.h"
@@ -1690,4 +1691,175 @@ int init_sign_text(char **sign_text, char *text)
   }
 
   return OK;
+}
+
+/// Check if a string contains only whitespace characters.
+bool string_iswhite(String str)
+{
+  for (size_t i = 0; i < str.size; i++) {
+    if (!ascii_iswhite(str.data[i])) {
+      // Found a non-whitespace character
+      return false;
+    } else if (str.data[i] == NUL) {
+      // Terminate at first occurence of a NUL character
+      break;
+    }
+  }
+  return true;
+}
+
+// Add modifier string for command into the command line. Includes trailing whitespace if non-empty.
+// @return OK or FAIL.
+static int add_cmd_modifier_str(char *cmdline, size_t *pos, const size_t bufsize,
+                                CmdParseInfo *cmdinfo)
+{
+#define APPEND_MODIFIER(...) \
+  do { \
+    if (*pos < bufsize) { \
+      *pos += (size_t)snprintf(cmdline + *pos, bufsize - *pos, __VA_ARGS__); \
+    } \
+    if (*pos < bufsize) { \
+      cmdline[*pos] = ' '; \
+      *pos += 1; \
+    } else { \
+      goto err; \
+    } \
+  } while (0)
+
+#define APPEND_MODIFIER_IF(cond, mod) \
+  do { \
+    if (cond) { \
+      APPEND_MODIFIER(mod); \
+    } \
+  } while (0)
+
+  if (cmdinfo->cmdmod.tab != 0) {
+    APPEND_MODIFIER("%dtab", cmdinfo->cmdmod.tab - 1);
+  }
+  if (cmdinfo->verbose != -1) {
+    APPEND_MODIFIER("%ldverbose", cmdinfo->verbose);
+  }
+
+  switch (cmdinfo->cmdmod.split & (WSP_ABOVE | WSP_BELOW | WSP_TOP | WSP_BOT)) {
+  case WSP_ABOVE:
+    APPEND_MODIFIER("aboveleft");
+    break;
+  case WSP_BELOW:
+    APPEND_MODIFIER("belowright");
+    break;
+  case WSP_TOP:
+    APPEND_MODIFIER("topleft");
+    break;
+  case WSP_BOT:
+    APPEND_MODIFIER("botright");
+    break;
+  default:
+    break;
+  }
+
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.split & WSP_VERT, "vertical");
+
+  if (cmdinfo->emsg_silent) {
+    APPEND_MODIFIER("silent!");
+  } else if (cmdinfo->silent) {
+    APPEND_MODIFIER("silent");
+  }
+
+  APPEND_MODIFIER_IF(cmdinfo->sandbox, "sandbox");
+  APPEND_MODIFIER_IF(cmdinfo->noautocmd, "noautocmd");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.browse, "browse");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.confirm, "confirm");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.hide, "hide");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.keepalt, "keepalt");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.keepjumps, "keepjumps");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.keepmarks, "keepmarks");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.keeppatterns, "keeppatterns");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.lockmarks, "lockmarks");
+  APPEND_MODIFIER_IF(cmdinfo->cmdmod.noswapfile, "noswapfile");
+
+  return OK;
+err:
+  return FAIL;
+
+#undef APPEND_MODIFIER
+#undef APPEND_MODIFIER_IF
+}
+
+/// Build cmdline string for command, used by `nvim_cmd()`.
+///
+/// @return OK or FAIL.
+int build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdinfo, char **args,
+                      size_t argc)
+{
+  const size_t bufsize = IOSIZE;
+  size_t pos = 0;
+  char *cmdline = xcalloc(bufsize, sizeof(char));
+
+#define CMDLINE_APPEND(...) \
+  do { \
+    if (pos < bufsize) { \
+      pos += (size_t)snprintf(cmdline + pos, bufsize - pos, __VA_ARGS__); \
+    } else { \
+      goto err; \
+    } \
+  } while (0)
+
+  // Command modifiers.
+  if (add_cmd_modifier_str(cmdline, &pos, bufsize, cmdinfo) == FAIL) {
+    goto err;
+  }
+
+  // Command range / count.
+  if (eap->argt & EX_RANGE) {
+    if (eap->addr_count == 1) {
+      CMDLINE_APPEND("%ld", eap->line2);
+    } else if (eap->addr_count > 1) {
+      CMDLINE_APPEND("%ld,%ld", eap->line1, eap->line2);
+      eap->addr_count = 2;  // Make sure address count is not greater than 2
+    }
+  }
+
+  // Keep the index of the position where command name starts, so eap->cmd can point to it.
+  size_t cmdname_idx = pos;
+  CMDLINE_APPEND("%s", eap->cmd);
+  eap->cmd = cmdline + cmdname_idx;
+
+  // Command bang.
+  if (eap->argt & EX_BANG && eap->forceit) {
+    CMDLINE_APPEND("!");
+  }
+
+  // Command register.
+  if (eap->argt & EX_REGSTR && eap->regname) {
+    CMDLINE_APPEND(" %c", eap->regname);
+  }
+
+  // Iterate through each argument and store the starting position and length of each argument in
+  // the cmdline string in `eap->args` and `eap->arglens`, respectively.
+  eap->args = xcalloc(argc, sizeof(char *));
+  eap->arglens = xcalloc(argc, sizeof(size_t));
+  for (size_t i = 0; i < argc; i++) {
+    eap->args[i] = cmdline + pos + 1;  // add 1 to skip the leading space.
+    eap->arglens[i] = STRLEN(args[i]);
+    CMDLINE_APPEND(" %s", args[i]);
+  }
+  eap->argc = argc;
+  eap->arg = argc > 0 ? eap->args[0] : NULL;
+
+  // Replace, :make and :grep with 'makeprg' and 'grepprg'.
+  char *p = replace_makeprg(eap, eap->arg, cmdlinep);
+  if (p != eap->arg) {
+    // If replace_makeprg modified the cmdline string, correct the argument pointers.
+    assert(argc == 1);
+    eap->arg = p;
+    eap->args[0] = p;
+  }
+
+  *cmdlinep = cmdline;
+  return OK;
+err:
+  xfree(cmdline);
+  return FAIL;
+
+#undef CMDLINE_APPEND
 }

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -175,6 +175,9 @@ enum {
 /// Arguments used for Ex commands.
 struct exarg {
   char *arg;                    ///< argument of the command
+  char **args;                  ///< starting position of command arguments
+  size_t *arglens;              ///< length of command arguments
+  size_t argc;                  ///< number of command arguments
   char *nextcmd;                ///< next command (NULL if none)
   char *cmd;                    ///< the name of the command (except for :make)
   char **cmdlinep;              ///< pointer to pointer of allocated cmdline

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -33,6 +33,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/garray.h"
 #include "nvim/getchar.h"
+#include "nvim/globals.h"
 #include "nvim/highlight.h"
 #include "nvim/highlight_defs.h"
 #include "nvim/highlight_group.h"
@@ -2522,7 +2523,7 @@ char *get_text_locked_msg(void)
 bool curbuf_locked(void)
 {
   if (curbuf->b_ro_locked > 0) {
-    emsg(_("E788: Not allowed to edit another buffer now"));
+    emsg(_(e_cannot_edit_other_buf));
     return true;
   }
   return allbuf_locked();

--- a/src/nvim/generators/hashy.lua
+++ b/src/nvim/generators/hashy.lua
@@ -77,7 +77,7 @@ function M.switcher(put, tab, maxlen, worst_buck_size)
           put "break;\n"
         end
         put "      default: break;\n"
-        put "    }\n  "
+        put "    }\n    "
       else
           local startidx = #neworder
           table.insert(neworder, posbuck[keys[1]][1])
@@ -85,7 +85,7 @@ function M.switcher(put, tab, maxlen, worst_buck_size)
           put("low = "..startidx.."; ")
           if bucky then put("high = "..endidx.."; ") end
       end
-      put "  break;\n"
+      put "break;\n"
     end
   end
   put "    default: break;\n"
@@ -105,17 +105,23 @@ function M.hashy_hash(name, strings, access)
   end
   local neworder = M.switcher(put, len_pos_buckets, maxlen, worst_buck_size)
   if worst_buck_size > 1 then
-    error [[ not implemented yet ]] -- TODO(bfredl)
+    put ([[
+  for (int i = low; i < high; i++) {
+    if (!memcmp(str, ]]..access("i")..[[, len)) {
+      return i;
+    }
+  }
+  return -1;
+]])
   else
-    put [[
-  if (low < 0) {
+    put ([[
+  if (low < 0 || memcmp(str, ]]..access("low")..[[, len)) {
     return -1;
   }
-  ]]
-    put("if(memcmp(str, "..access("low")..", len)) {\n    return -1;\n  }\n")
-    put "  return low;\n"
-    put "}\n\n"
+  return low;
+]])
   end
+  put "}\n\n"
   return neworder, table.concat(stats)
 end
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -997,6 +997,7 @@ EXTERN char e_listarg[] INIT(= N_("E686: Argument of %s must be a List"));
 EXTERN char e_unsupportedoption[] INIT(= N_("E519: Option not supported"));
 EXTERN char e_fnametoolong[] INIT(= N_("E856: Filename too long"));
 EXTERN char e_float_as_string[] INIT(= N_("E806: using Float as a String"));
+EXTERN char e_cannot_edit_other_buf[] INIT(= N_("E788: Not allowed to edit another buffer now"));
 
 EXTERN char e_autocmd_err[] INIT(= N_("E5500: autocmd has thrown an exception: %s"));
 EXTERN char e_cmdmap_err[] INIT(= N_("E5520: <Cmd> mapping must end with <CR>"));

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1863,8 +1863,8 @@ void nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap)
   if (cmd->uc_argt & EX_NOSPC) {
     // Commands where nargs = 1 or "?" fargs is the same as args
     lua_rawseti(lstate, -2, 1);
-  } else {
-    // Commands with more than one possible argument we split
+  } else if (eap->args == NULL) {
+    // For commands with more than one possible argument, split if argument list isn't available.
     lua_pop(lstate, 1);  // Pop the reference of opts.args
     size_t length = STRLEN(eap->arg);
     size_t end = 0;
@@ -1881,6 +1881,13 @@ void nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap)
       }
     }
     xfree(buf);
+  } else {
+    // If argument list is available, just use it.
+    lua_pop(lstate, 1);
+    for (size_t i = 0; i < eap->argc; i++) {
+      lua_pushlstring(lstate, eap->args[i], eap->arglens[i]);
+      lua_rawseti(lstate, -2, (int)i + 1);
+    }
   }
   lua_setfield(lstate, -2, "fargs");
 


### PR DESCRIPTION
Adds the API function `nvim_cmd` which allows executing an Ex-command through a Dictionary which can have the same values as the return value of `nvim_parse_cmd()`. This makes it much easier to do things like passing arguments with a space to commands that otherwise may not allow it, or to make commands interpret certain characters literally when they otherwise would not.

Closes #14966