### PR TITLE
[Backport release-0.7] fix(filetype.lua): escape expansion of ~ when used as a pattern

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1463,8 +1463,18 @@ end
 local pattern_sorted = sort_by_priority(pattern)
 
 ---@private
-local function normalize_path(path)
-  return (path:gsub("\\", "/"):gsub("^~", vim.env.HOME))
+local function normalize_path(path, as_pattern)
+  local normal = path:gsub("\\", '/')
+  if normal:find('^~') then
+    if as_pattern then
+      -- Escape Lua's metacharacters when $HOME is used in a pattern.
+      -- The rest of path should already be properly escaped.
+      normal = vim.env.HOME:gsub('[-^$()%%.%[%]+?]', '%%%0') .. normal:sub(2)
+    else
+      normal = vim.env.HOME .. normal:sub(2)
+    end
+  end
+  return normal
 end
 
 --- Add new filetype mappings.
@@ -1533,7 +1543,7 @@ function M.add(filetypes)
   end
 
   for k, v in pairs(filetypes.pattern or {}) do
-    pattern[normalize_path(k)] = v
+    pattern[normalize_path(k, true)] = v
   end
 
   if filetypes.pattern then

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -70,6 +70,7 @@ describe('vim.filetype', function()
   it('works with patterns', function()
     eq('markdown', exec_lua([[
       local root = ...
+      vim.env.HOME = '/a-funky+home%dir'
       vim.filetype.add({
         pattern = {
           ['~/blog/.*%.txt'] = 'markdown',


### PR DESCRIPTION
Backport of #18353 to release-0.7