### PR TITLE
Added two new functions to the api for modifying registers.

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1156,6 +1156,17 @@ nvim_get_proc_children({pid})                       *nvim_get_proc_children()*
                 Return: ~
                     Array of child process ids, empty if process not found.
 
+                                         *nvim_get_register()*
+nvim_get_register({reg})
+                Get vim register. |registers|
+
+		Parameters:~
+		    {reg}  Register name.
+
+                Return:~
+		    Content of register.
+
+
 nvim_get_runtime_file({name}, {all})                 *nvim_get_runtime_file()*
                 Find files in runtime directories
 
@@ -1698,6 +1709,14 @@ nvim_set_option_value({name}, {value}, {*opts})
                     {opts}   Optional parameters
                              • scope: One of 'global' or 'local'. Analogous to
                                |:setglobal| and |:setlocal|, respectively.
+                                                         *nvim_set_register()*
+nvim_set_register({reg}, {value})
+                Set vim register. |registers|
+
+		Parameters:~
+                    {reg}    Register name.
+		    {value}  Value to assign register.
+
 
 nvim_set_var({name}, {value})                                 *nvim_set_var()*
                 Sets a global (g:) variable.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -859,6 +859,16 @@ void nvim_set_option(uint64_t channel_id, String name, Object value, Error *err)
   set_option_to(channel_id, NULL, SREQ_GLOBAL, name, value, err);
 }
 
+/// Set vim register |registers|
+///
+/// @param reg    Register name.
+/// @param value  Value to assign register.
+void nvim_set_register(String reg, String value)
+  FUNC_API_SINCE(10)
+{
+  write_reg_contents(reg.data[0], (const char_u*) value.data, (ssize_t) value.size, false);
+}
+
 /// Echo a message.
 ///
 /// @param chunks  A list of [text, hl_group] arrays, each representing a
@@ -2066,6 +2076,25 @@ Object nvim_get_proc(Integer pid, Error *err)
   }
 #endif
   return rvobj;
+}
+
+/// Get vim register |registers|
+///
+/// @param reg  Register name.
+/// @return Content of register.
+String nvim_get_register(String reg)
+  FUNC_API_SINCE(10)
+{
+  String rv = STRING_INIT;
+
+  void* contents = get_reg_contents(reg.data[0], kGRegExprSrc);
+  if (contents == NULL) {
+    return rv;
+  }
+
+  rv.data = contents;
+  rv.size = STRLEN(rv.data);
+  return rv;
 }
 
 /// Selects an item in the completion popupmenu.

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1378,6 +1378,16 @@ describe('API', function()
     end)
   end)
 
+  describe('nvim_get_register, nvim_set_register', function()
+    it('works', function()
+      local reg = 'x'
+      local value = 'this is a test\nnew line here'
+      eq('', nvim('get_register', reg))
+      nvim('set_register', reg, value)
+      eq(value, nvim('get_register', reg))
+    end)
+  end)
+
   describe('nvim_get_option_value, nvim_set_option_value', function()
     it('works', function()
       ok(nvim('get_option_value', 'equalalways', {}))


### PR DESCRIPTION
`nvim_get_register()`
`nvim_set_register()`

Maybe there is a way to modify registers without using `let @reg`, but I did not find any.