### PR TITLE
feat(job,terminal): unset Vim/Nvim-owned env vars

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5074,6 +5074,16 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
     tv_dict_add_str(env, S_LEN("NVIM"), nvim_addr);
   }
 
+  // Unset Vim/Nvim-owned env vars. #6764
+  // User can override this via `env` in jobstart().
+  const char *unwanted[] = { "VIM", "VIMRUNTIME" };
+  for (size_t i = 0; i < ARRAY_SIZE(unwanted); i++) {
+    dictitem_T *dv = tv_dict_find(env, unwanted[i], -1);
+    if (dv) {
+      tv_dict_item_remove(env, dv);
+    }
+  }
+
   if (job_env) {
 #ifdef WIN32
     TV_DICT_ITER(job_env->di_tv.vval.v_dict, var, {

--- a/src/nvim/testdir/runnvim.vim
+++ b/src/nvim/testdir/runnvim.vim
@@ -23,7 +23,7 @@ function Main()
   set lines=25
   set columns=80
   enew
-  let job = termopen(args, s:logger)
+  let job = termopen(args, s:logger, {'env': { 'NVIM_LOG_FILE': $NVIM_LOG_FILE, 'VIM': $VIM, 'VIMRUNTIME': $VIMRUNTIME })
   let results = jobwait([job], 5 * 60 * 1000)
   " TODO(ZyX-I): Get colors
   let screen = getline(1, '$')


### PR DESCRIPTION
- [ ] only if VIMRUNTIME _was not set by the user_. (env vars set by the user are _expected_ to pass to children)
- [ ] also in system(), shell (`:!`) ?

closes #6764

```
oldtest:
FAILED:   164 Tests
```