### PR TITLE
ci(msys): faster builds using msys2-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [ MINGW_64-gcov, MSVC_64 ]
+        config: [ 'MSVC_64' ]
     name: windows (${{ matrix.config }})
     steps:
       - uses: actions/checkout@v2
@@ -251,3 +251,63 @@ jobs:
         run: powershell ci\build.ps1
         env:
           CONFIGURATION: ${{ matrix.config }}
+
+  windows-mys2:
+    runs-on: windows-2022
+    timeout-minutes: 45
+    if: github.event.pull_request.draft == false
+
+    env:
+      DEPS_BUILD_DIR: ${{ format('{0}/nvim-deps', github.workspace) }}
+      DEPS_PREFIX: ${{ format('{0}/nvim-deps/usr', github.workspace) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sys: mingw64
+            env: x86_64
+    defaults:
+      run:
+        shell: msys2 {0}
+    name: windows (${{ matrix.sys }})
+    steps:
+      - name: Install msys packages
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: ${{matrix.sys}}
+          install: >-
+            git
+            gperf
+            mingw-w64-${{matrix.env}}-toolchain
+            mingw-w64-${{matrix.env}}-ccache
+            mingw-w64-${{matrix.env}}-ninja
+            mingw-w64-${{matrix.env}}-cmake
+            mingw-w64-${{matrix.env}}-diffutils
+
+      - uses: actions/checkout@v2
+
+      - name: Setup common environment variables
+        run: ./.github/workflows/env.sh
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.DEPS_BUILD_DIR }}
+          key: ${{ matrix.sys }}-${{ hashFiles('third-party/**') }}
+
+      - name: Build third-party
+        run: ./ci/before_script.sh
+
+      - name: Build
+        run: ./ci/run_tests.sh build_nvim
+
+      - if: "!cancelled()"
+        name: Functionaltests
+        run: ./ci/run_tests.sh functionaltests
+
+      - if: "!cancelled()"
+        name: Oldtests
+        run: ./ci/run_tests.sh oldtests
+
+      - name: Cache dependencies
+        run: ./ci/before_cache.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,9 +301,14 @@ jobs:
       - name: Build
         run: ./ci/run_tests.sh build_nvim
 
-      - if: "!cancelled()"
-        name: Functionaltests
-        run: ./ci/run_tests.sh functionaltests
+      # - if: "!cancelled()"
+      #   name: Functionaltests
+      #   run: ./ci/run_tests.sh functionaltests
+
+      - name: Run tests
+        run: powershell ./ci/run_tests.ps1
+        env:
+          CONFIGURATION: MINGW_64-gcov
 
       - if: "!cancelled()"
         name: Oldtests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,7 +367,7 @@ endif()
 
 option(CI_BUILD "CI, extra flags will be set" OFF)
 
-if(CI_BUILD)
+if(CI_BUILD AND NOT WIN32)
   message(STATUS "CI build enabled")
   add_compile_options(-Werror)
   if(DEFINED ENV{BUILD_UCHAR})

--- a/ci/run_tests.ps1
+++ b/ci/run_tests.ps1
@@ -1,0 +1,96 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$env:CONFIGURATION -match '^(?<compiler>\w+)_(?<bits>32|64)(?:-(?<option>\w+))?$'
+$bits = $Matches.bits
+$cmakeBuildType = $(if ($env:CMAKE_BUILD_TYPE -ne $null) {$env:CMAKE_BUILD_TYPE} else {'RelWithDebInfo'});
+$nvimCmakeVars = @{
+  CMAKE_BUILD_TYPE = $cmakeBuildType;
+  BUSTED_OUTPUT_TYPE = 'nvim';
+  DEPS_PREFIX=$(if ($env:DEPS_PREFIX -ne $null) {$env:DEPS_PREFIX} else {".deps/usr"});
+}
+if ($env:DEPS_BUILD_DIR -eq $null) {
+  $env:DEPS_BUILD_DIR = ".deps";
+}
+
+$uploadToCodecov = 0
+$bits = 64
+
+function convertToCmakeArgs($vars) {
+  return $vars.GetEnumerator() | ForEach-Object { "-D$($_.Key)=$($_.Value)" }
+}
+
+function exitIfFailed() {
+  if ($LastExitCode -ne 0) {
+    exit $LastExitCode
+  }
+}
+
+.\build\bin\nvim --version ; exitIfFailed
+
+# Ensure that the "win32" feature is set.
+.\build\bin\nvim -u NONE --headless -c 'exe !has(\"win32\").\"cq\"' ; exitIfFailed
+
+if ($env:USE_LUACOV -eq 1) {
+    $nvimCmakeVars['USE_GCOV'] = 'ON'
+    $uploadToCodecov = $true
+    $env:GCOV = "C:\msys64\mingw$bits\bin\gcov"
+
+    # Setup/build Lua coverage.
+    $env:BUSTED_ARGS = "--coverage"
+  & $env:DEPS_PREFIX\luarocks\luarocks.bat install cluacov
+}
+
+function ensureClients() {
+  python -m ensurepip
+  python -m pip install pynvim ; exitIfFailed
+# Sanity check
+  python  -c "import pynvim; print(str(pynvim))" ; exitIfFailed
+
+  gem.cmd install --pre neovim
+  Get-Command -CommandType Application neovim-ruby-host.bat
+
+  node --version
+  npm.cmd --version
+
+  npm.cmd install -g neovim
+  Get-Command -CommandType Application neovim-node-host.cmd
+  npm.cmd link neovim
+}
+
+# Functional tests
+# The $LastExitCode from MSBuild can't be trusted
+$failed = $false
+
+# Run only this test file:
+# $env:TEST_FILE = "test\functional\foo.lua"
+cmake --build build --config $cmakeBuildType --target functionaltest -- $env:CMAKE_GENERATORA_RGS 2>&1 |
+  ForEach-Object { $failed = $failed -or
+    $_ -match 'functional tests failed with error'; $_ }
+
+if ($uploadToCodecov -eq 1) {
+  & $env:DEPS_PREFIX\bin\luacov.bat
+  bash -l "./ci/common/submit_coverage.sh" functionaltest
+}
+if ($failed) {
+  exit $LastExitCode
+}
+
+# Old tests
+# Add MSYS to path, required for e.g. `find` used in test scripts.
+# But would break functionaltests, where its `more` would be used then.
+$OldPath = $env:PATH
+
+if (Get-Command -Name "ming32-make" -ErrorAction SilentlyContinue) {
+  $env:PATH = "C:\msys64\usr\bin;C:\msys64\mingw$bits\bin;$env:PATH"
+}
+
+& mingw32-make -C ".\src\nvim\testdir" VERBOSE=1 ; exitIfFailed
+
+$env:PATH = $OldPath
+
+if ($uploadToCodecov) {
+  bash -l "./ci/common/submit_coverage.sh"  oldtest
+}
+


### PR DESCRIPTION
It's currently ~15min just to configure and prepare the msys2 environment https://github.com/neovim/neovim/runs/6269540875?check_suite_focus=true#step:4:251
whereas nearly all the other jobs are completely done under 10min

This is now using a github-action https://github.com/msys2/setup-msys2 which is under the official msys2 org, and they claim to have solved those update issues, so I thought I could give it a try.


Related #18384 ~~15490~~

