### PR TITLE
fix(lsp): perform client side filtering of code actions

### DIFF
--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -766,8 +766,21 @@ function tests.code_action_filter()
         isPreferred = true,
         command = 'preferred_command',
       }
+      local quickfix_action = {
+        title = 'Action 3',
+        kind = 'quickfix',
+        command = 'quickfix_command',
+      }
+      local quickfix_foo_action = {
+        title = 'Action 4',
+        kind = 'quickfix.foo',
+        command = 'quickfix_foo_command',
+      }
       expect_request('textDocument/codeAction', function()
-        return nil, { action, preferred_action, }
+        return nil, { action, preferred_action, quickfix_action, quickfix_foo_action, }
+      end)
+      expect_request('textDocument/codeAction', function()
+        return nil, { action, preferred_action, quickfix_action, quickfix_foo_action, }
       end)
       notify('shutdown')
     end;


### PR DESCRIPTION
Implement filtering of actions based on the kind when passing the 'only'
parameter to code_action(). Action kinds are hierachical with a '.' as
the separator, and the filter thus allows, for example, both 'quickfix'
and 'quickfix.foo' when requestiong only 'quickfix'.

Fix https://github.com/neovim/neovim/pull/18221#issuecomment-1110179121