### PR TITLE
docs: --remote alternatives

### DIFF
--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -35,23 +35,6 @@ The following command line arguments are available:
 				this use >
 				 nvim --remote-send "<C-\><C-N>:n filename<CR>"
 <
-   --remote-silent [+{cmd}] {file} ...			*--remote-silent*
-				As above, but don't complain if there is no
-				server and the file is edited locally.
-							*--remote-tab*
-   --remote-tab			Like --remote but open each file in a new
-				tabpage.
-							*--remote-tab-silent*
-   --remote-tab-silent		Like --remote-silent but open each file in a
-				new tabpage.
-								*--remote-send*
-   --remote-send {keys}		Send {keys} to server and exit.  The {keys}
-   				are not mapped.  Special key names are
-				recognized, e.g., "<CR>" results in a CR
-				character.
-								*--remote-expr*
-   --remote-expr {expr}		Evaluate {expr} in server and print the result
-				on stdout.
 								*--server*
    --server {addr}		Connect to the named pipe or socket at the
 				given address for executing remote commands.
@@ -80,45 +63,6 @@ rest of the command line and sent as described above.
 Note that the --remote and --remote-wait arguments will consume the rest of
 the command line.  I.e. all remaining arguments will be regarded as filenames.
 You can not put options there!
-
-
-==============================================================================
-2. Missing functionality			*E5600* *clientserver-missing*
-
-Vim supports additional functionality in clientserver that's not yet
-implemented in Nvim. In particular, none of the "wait" variants are supported
-yet. The following command line arguments are not yet available:
-
-    argument			meaning	~
-
-   --remote-wait [+{cmd}] {file} ...				*--remote-wait*
-				Not yet supported by Nvim.
-				As --remote, but wait for files to complete
-				(unload) in remote Vim.
-   --remote-wait-silent [+{cmd}] {file} ...		*--remote-wait-silent*
-				Not yet supported by Nvim.
-				As --remote-wait, but don't complain if there
-				is no server.
-							*--remote-tab-wait*
-   --remote-tab-wait		Not yet supported by Nvim.
-				Like --remote-wait but open each file in a new
-				tabpage.
-						*--remote-tab-wait-silent*
-   --remote-tab-wait-silent	Not yet supported by Nvim.
-				Like --remote-wait-silent but open each file
-				in a new tabpage.
-							    *--servername*
-   --servername {name}          Not yet supported by Nvim.
-				Become the server {name}.  When used together
-                                with one of the --remote commands: connect to
-                                server {name} instead of the default (see
-                                below).  The name used will be uppercase.
-
-								*--serverlist*
-   --serverlist			Not yet supported by Nvim.
-				Output a list of server names.
-
-
 
 
 SERVER NAME						*client-server-name*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -570,6 +570,30 @@ Startup:
   Restricted mode: rview, rvim, nvim -Z
   Vi mode: nvim -v
 
+                                                *E5600* *clientserver-missing*
+*--remote-expr*                 Removed. Use |-es| |-V1| instead. >
+                              nvim -V1 -Es --remote … "+echo 1+1" +q
+*--remote-send*                 Removed. Use "|-s| -" or |nvim_input()| instead: >
+                              echo "ifoo" | nvim -s - --remote …
+                              nvim --remote … "+call nvim_input('ifoo')"
+*--remote-silent*               Removed. Use |-Es| instead: >
+                              nvim -Es --remote …
+*--remote-tab*                  Removed. Use |-p| instead: >
+                              nvim -p --remote …
+*--remote-tab-silent*           Removed. Use |-Es| |-p| instead: >
+                              nvim -Es -p --remote …
+*--remote-wait*                 Removed. Use |--remote| instead.
+*--remote-wait-silent*          Removed. Use |-Es| |-p| instead: >
+                              nvim -Es -p --remote …
+*--remote-tab-wait*             Removed. Use |-p| instead: >
+                              nvim -p --remote …
+*--remote-tab-wait-silent*      Removed. Use |-Es| |-p| instead: >
+                              nvim -Es -p --remote … +0cq
+*--serverlist*                  Removed. Use instead: >
+                              nvim -es -V1 --server … --remote '+echom serverlist()'
+*--servername*                  Removed.
+
+
 Test functions:
   test_alloc_fail()
   test_autochdir()


### PR DESCRIPTION
WIP: sketching out how Nvim `--remote` should work. (Followup to https://github.com/neovim/neovim/pull/17856#pullrequestreview-951127037 )

Key ideas:

* The numerous `--remote-x-y` variants from Vim should not be mindlessly copied. Most use of `--remote` is for small one-liner shortcuts. Any non-trivial use of Vim's `--remote` is not going to work with Nvim because we don't and won't have exactly the same interface. So we can instead just make a better interface.
* If possible, the only `--remote` variant we will support is... `--remote`. Not the other stuff.
* The usual Nvim CLI options like `-p`, `-es`, etc., should "just work". For example,
    * `--remote -p` should work, then `--remote-tab` isn't needed.
    * `--remote -es "+echo 1+1"` should work, then `--remote-expr` isn't needed.
    * `echo <keys> | nvim -s - --remote` should work, then `--remote-send` isn't needed.
        * Alternatively `nvim --remote "+call nvim_input('<keys>')"`

Another note about the current behavior:

    This doesn't work, all arguments after --remote will be used as file names: >
        nvim --remote --server ~/.cache/nvim/server.pipe file.txt

What is the purpose of that? We already have `--` (`:help ---`) for declaring "all args hereafter are filenames".

close #18531
close #18519
