### PR TITLE
vim-patch:8.2.4865: :startinsert right after :stopinsert may not work

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -553,7 +553,7 @@ static int insert_check(VimState *state)
     Insstart_orig = Insstart;
   }
 
-  if (stop_insert_mode && !pum_visible()) {
+  if (stop_insert_mode && !compl_started) {
     // ":stopinsert" used or 'insertmode' reset
     s->count = 0;
     return 0;  // exit insert mode

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -516,6 +516,15 @@ func Test_pum_stopped_by_timer()
   call delete('Xpumscript')
 endfunc
 
+func Test_complete_stopinsert_startinsert()
+  nnoremap <F2> <Cmd>startinsert<CR>
+  inoremap <F2> <Cmd>stopinsert<CR>
+  " This just checks if this causes an error
+  call feedkeys("i\<C-X>\<C-N>\<F2>\<F2>", 'x')
+  nunmap <F2>
+  iunmap <F2>
+endfunc
+
 func Test_pum_with_folds_two_tabs()
   CheckScreendump
 


### PR DESCRIPTION
Fix #18395

#### vim-patch:8.2.4865: :startinsert right after :stopinsert may not work

Problem:    :startinsert right after :stopinsert does not work when popup menu
            is still visible.
Solution:   Use ins_compl_active() instead of pum_visible(). (closes vim/vim#10352)
https://github.com/vim/vim/commit/cd5dbad184e8235beb13dcd8a22302da09db9766