### PR TITLE
fix(runtime): correct load order for ftplugin/*

### DIFF
--- a/runtime/ftplugin.vim
+++ b/runtime/ftplugin.vim
@@ -1,7 +1,7 @@
 " Vim support file to switch on loading plugins for file types
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2006 Apr 30
+" Maintainer: Bram Moolenaar <Bram@vim.org>
+" Last change:  2006 Apr 30
 
 if exists("did_load_ftplugin")
   finish
@@ -20,17 +20,23 @@ augroup filetypeplugin
     let s = expand("<amatch>")
     if s != ""
       if &cpo =~# "S" && exists("b:did_ftplugin")
-	" In compatible mode options are reset to the global values, need to
-	" set the local values also when a plugin was already used.
-	unlet b:did_ftplugin
+        " In compatible mode options are reset to the global values, need to
+        " set the local values also when a plugin was already used.
+        unlet b:did_ftplugin
       endif
 
       " When there is a dot it is used to separate filetype names.  Thus for
       " "aaa.bbb" load "aaa" and then "bbb".
       for name in split(s, '\.')
-        exe 'runtime! ftplugin/' . name . '.vim ftplugin/' . name . '_*.vim ftplugin/' . name . '/*.vim'
-        " Load lua ftplugins
-        exe printf('runtime! ftplugin/%s.lua ftplugin/%s_*.lua ftplugin/%s/*.lua', name, name, name)
+        if !empty(name)
+          call nvim__get_runtime([
+                \ 'ftplugin/' . name . '.vim',
+                \ 'ftplugin/' . name . '.lua',
+                \ ], v:true, {'do_source': v:true})
+          " TODO(clason): nvim__get_runtime doesn't support globs
+          exe printf('runtime! ftplugin/%s_*.vim ftplugin/%s_*.lua', name, name)
+          exe printf('runtime! ftplugin/%s/*.vim ftplugin/%s/*.lua', name, name)
+        endif
       endfor
     endif
   endfunc

--- a/runtime/indent.vim
+++ b/runtime/indent.vim
@@ -24,8 +24,12 @@ augroup filetypeindent
       " When there is a dot it is used to separate filetype names.  Thus for
       " "aaa.bbb" load "indent/aaa.vim" and then "indent/bbb.vim".
       for name in split(s, '\.')
-        exe 'runtime! indent/' . name . '.vim'
-        exe 'runtime! indent/' . name . '.lua'
+        if !empty(name)
+          call nvim__get_runtime([
+                \ 'indent/' . name . '.vim',
+                \ 'indent/' . name . '.lua',
+                \ ], v:true, {'do_source': v:true})
+        endif
       endfor
     endif
   endfunc

--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -48,12 +48,12 @@ fun! s:SynSet()
     " load each in sequence.  Skip empty entries.
     for name in split(s, '\.')
       if !empty(name)
-          call nvim__get_runtime([
-                \ 'syntax/' . name . '.vim',
-                \ 'syntax/' . name . '.lua',
-                \ ], v:true, {'do_source': v:true})
-          " TODO(clason): nvim__get_runtime doesn't support globs
-          exe printf('runtime! syntax/%s/*.vim syntax/%s/*.lua', name, name)
+        call nvim__get_runtime([
+              \ 'syntax/' . name . '.vim',
+              \ 'syntax/' . name . '.lua',
+              \ ], v:true, {'do_source': v:true})
+        " TODO(clason): nvim__get_runtime doesn't support globs
+        exe printf('runtime! syntax/%s/*.vim syntax/%s/*.lua', name, name)
       endif
     endfor
   endif

--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -48,8 +48,12 @@ fun! s:SynSet()
     " load each in sequence.  Skip empty entries.
     for name in split(s, '\.')
       if !empty(name)
-        exe "runtime! syntax/" . name . ".vim syntax/" . name . "/*.vim"
-        exe "runtime! syntax/" . name . ".lua syntax/" . name . "/*.lua"
+          call nvim__get_runtime([
+                \ 'syntax/' . name . '.vim',
+                \ 'syntax/' . name . '.lua',
+                \ ], v:true, {'do_source': v:true})
+          " TODO(clason): nvim__get_runtime doesn't support globs
+          exe printf('runtime! syntax/%s/*.vim syntax/%s/*.lua', name, name)
       endif
     endfor
   endif


### PR DESCRIPTION
ensure that lua ftplugins are sourced after vim plugins per directory

fixes #16928

Quick fix for backporting; after 0.7.1, we should revisit this ~~and rewrite to Lua~~ (ideally using a version of `nvim__get_runtime` that allows sourcing the found runtime files @bfredl )

(As long as the actual filetype plugins are in Vim, there's no point in rewriting this due to the `b:undo_ftplugin` dance that needs to be handled. The big benefit here will be from using Neovim API instead of a loop.)