### PR TITLE
ci(bsd): conditional runs for faster builds

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -23,6 +23,11 @@ environment:
   CMAKE_EXTRA_FLAGS: -DCI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
+- should-run: |
+    # exclude runs when the only changes are made to these patterns
+    if ! git diff --quiet -- '!:.github'; then
+      complete-build;
+    fi
 - build-deps: |
     cd neovim
     gmake deps

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -23,6 +23,11 @@ environment:
   CMAKE_EXTRA_FLAGS: -DCI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
+- should-run: |
+    # exclude runs when the only changes are made to these patterns
+    if ! git diff --quiet -- '!:.github'; then
+      complete-build;
+    fi
 - build-deps: |
     export AUTOCONF_VERSION=2.71
     export AUTOMAKE_VERSION=1.16


### PR DESCRIPTION
I found this (undocumented) function which should be useful for conditionally running consequent tasks.

The current condition is based on git's pathspec, see `man gitglossary(7)`, which should skip commits that only has changed-files under `.github/*`.

### refs
- <https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec>
- <https://lists.sr.ht/~sircmpwn/sr.ht-discuss/%3C3cd90a91b7ce113bb3c5f07898c77543%40hacktivista.com%3E>
- <https://git.sr.ht/~sircmpwn/builds.sr.ht/tree/master/item/worker/tasks.go#L196-198>
