### PR TITLE
fix(api): make `nvim_parse_cmd` propagate errors

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -802,10 +802,15 @@ Dictionary nvim_parse_cmd(String str, Dictionary opts, Error *err)
   // Parse command line
   exarg_T ea;
   CmdParseInfo cmdinfo;
-  char_u *cmdline = (char_u *)string_to_cstr(str);
+  char *cmdline = string_to_cstr(str);
+  char *errormsg = NULL;
 
-  if (!parse_cmdline(cmdline, &ea, &cmdinfo)) {
-    api_set_error(err, kErrorTypeException, "Error while parsing command line");
+  if (!parse_cmdline(cmdline, &ea, &cmdinfo, &errormsg)) {
+    if (errormsg != NULL) {
+      api_set_error(err, kErrorTypeException, "Error while parsing command line: %s", errormsg);
+    } else {
+      api_set_error(err, kErrorTypeException, "Error while parsing command line");
+    }
     goto end;
   }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3426,10 +3426,15 @@ describe('API', function()
       }, meths.parse_cmd('MyCommand test it', {}))
     end)
     it('errors for invalid command', function()
-      eq('Error while parsing command line', pcall_err(meths.parse_cmd, 'Fubar', {}))
+      eq('Error while parsing command line', pcall_err(meths.parse_cmd, '', {}))
+      eq('Error while parsing command line', pcall_err(meths.parse_cmd, '" foo', {}))
+      eq('Error while parsing command line: E492: Not an editor command: Fubar',
+         pcall_err(meths.parse_cmd, 'Fubar', {}))
       command('command! Fubar echo foo')
-      eq('Error while parsing command line', pcall_err(meths.parse_cmd, 'Fubar!', {}))
-      eq('Error while parsing command line', pcall_err(meths.parse_cmd, '4,6Fubar', {}))
+      eq('Error while parsing command line: E477: No ! allowed',
+         pcall_err(meths.parse_cmd, 'Fubar!', {}))
+      eq('Error while parsing command line: E481: No range allowed',
+         pcall_err(meths.parse_cmd, '4,6Fubar', {}))
     end)
   end)
 end)


### PR DESCRIPTION
Makes `nvim_parse_cmd` propagate any errors that occur while parsing to
give the user a better idea of what's wrong with the command.