### PR TITLE
ci(bsd): conditional runs for faster builds (v2)

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -23,6 +23,11 @@ environment:
   CMAKE_EXTRA_FLAGS: -DCI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
+- should-run: |
+    if ! git -C neovim diff --name-only HEAD^! | grep -E -v "^(.github|runtime/doc/.*)" >/dev/null; then
+      echo "Skipping build because only ignored files were changed"
+      complete-build
+    fi
 - build-deps: |
     cd neovim
     gmake deps

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -23,6 +23,11 @@ environment:
   CMAKE_EXTRA_FLAGS: -DCI_BUILD=ON -DMIN_LOG_LEVEL=3
 
 tasks:
+- should-run: |
+    if ! git -C neovim diff --name-only HEAD^! | grep -E -v "^(.github|runtime/doc/.*)" >/dev/null; then
+      echo "Skipping build because only ignored files were changed"
+      complete-build
+    fi
 - build-deps: |
     export AUTOCONF_VERSION=2.71
     export AUTOMAKE_VERSION=1.16


### PR DESCRIPTION
I found this (undocumented) function which should be useful for conditionally running consequent tasks.

should fix the issue from https://github.com/neovim/neovim/pull/18434, which is related to ~~yaml parsing~~ calling git-diff from the wrong cwd.

current rules:
- skip build if the only files changed are under `.github/*` or `runtime/doc/*`

### refs
- <https://lists.sr.ht/~sircmpwn/sr.ht-discuss/%3C3cd90a91b7ce113bb3c5f07898c77543%40hacktivista.com%3E>
- <https://git.sr.ht/~sircmpwn/builds.sr.ht/tree/master/item/worker/tasks.go#L196-198>
