### PR TITLE
fix(lsp): fix rename capability checks and multi client support

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1216,13 +1216,21 @@ remove_workspace_folder({workspace_folder})
                 {path} is not provided, the user will be prompted for a path
                 using |input()|.
 
-rename({new_name})                                      *vim.lsp.buf.rename()*
+rename({new_name}, {options})                           *vim.lsp.buf.rename()*
                 Renames all references to the symbol under the cursor.
 
                 Parameters: ~
-                    {new_name}  (string) If not provided, the user will be
+                    {new_name}  string|nil If not provided, the user will be
                                 prompted for a new name using
                                 |vim.ui.input()|.
+                    {options}   table|nil additional options
+                                • filter (function|nil): Predicate to filter
+                                  clients used for rename. Receives the
+                                  attached clients as argument and must return
+                                  a list of clients.
+                                • name (string|nil): Restrict clients used for
+                                  rename to ones where client.name matches
+                                  this field.
 
 server_ready()                                    *vim.lsp.buf.server_ready()*
                 Checks whether the language servers attached to the current

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -222,10 +222,6 @@ function tests.prepare_rename_error()
       expect_request('textDocument/prepareRename', function()
         return {}, nil
       end)
-      expect_request('textDocument/rename', function(params)
-        assert_eq(params.newName, 'renameto')
-        return nil, nil
-      end)
       notify('shutdown')
     end;
   }

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2636,10 +2636,8 @@ describe('LSP', function()
         name = "prepare_rename_error",
         expected_handlers = {
           {NIL, {}, {method="shutdown", client_id=1}};
-          {NIL, NIL, {method="textDocument/rename", client_id=1, bufnr=1}};
           {NIL, {}, {method="start", client_id=1}};
         },
-        expected_text = "two", -- see test case
       },
     }) do
     it(test.it, function()


### PR DESCRIPTION
Adds filter and id options to filter the client to use for rename.
Similar to the recently added `format` function.

rename will use all matching clients one after another and can handle a
mix of prepareRename/rename support. Also ensures the right
`offset_encoding` is used for the `make_position_params` calls
