### PR TITLE
fix(man.vim): fix E444 error on q mapping

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -125,9 +125,7 @@ endfunction
 function! s:set_options(pager) abort
   setlocal noswapfile buftype=nofile bufhidden=hide
   setlocal nomodified readonly nomodifiable
-  if a:pager
-    nnoremap <silent> <buffer> <nowait> q :lclose<CR>:q<CR>
-  endif
+  let b:pager = a:pager
   setlocal filetype=man
 endfunction
 

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -24,7 +24,11 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> k             gk
   nnoremap <silent> <buffer> gO            :call man#show_toc()<CR>
   nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
-  nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c
+  if get(b:, 'pager')
+    nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>q
+  else
+    nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c
+  endif
 endif
 
 if get(g:, 'ft_man_folding_enable', 0)

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -2,13 +2,19 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local command, eval, rawfeed = helpers.command, helpers.eval, helpers.rawfeed
 local clear = helpers.clear
+local funcs = helpers.funcs
+local nvim_prog = helpers.nvim_prog
+local matches = helpers.matches
 
 describe(':Man', function()
+  before_each(function()
+    clear()
+  end)
+
   describe('man.lua: highlight_line()', function()
     local screen
 
     before_each(function()
-      clear()
       command('syntax on')
       command('set filetype=man')
       command('syntax off')  -- Ignore syntax groups
@@ -136,5 +142,11 @@ describe(':Man', function()
                                                            |
       ]])
     end)
+  end)
+
+  it('q quits in "$MANPAGER mode" (:Man!) #18281', function()
+    -- This will hang if #18281 regresses.
+    local args = {nvim_prog, '--headless', '+autocmd VimLeave * echo "quit works!!"', '+Man!', '+call nvim_input("q")'}
+    matches('quit works!!', funcs.system(args, {'manpage contents'}))
   end)
 end)


### PR DESCRIPTION
This PR fixes the issue when Neovim is opened as a pager, and q mapping causes an error.

Fixes #18281
Ref #17791