### PR TITLE
ci: add a check with -funsigned-char

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
             cc: clang-13
             runner: ubuntu-20.04
             os: linux
+          - flavor: uchar
+            cc: gcc
+            runner: ubuntu-20.04
+            os: linux
           - cc: clang
             runner: macos-10.15
             os: osx

--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -45,6 +45,11 @@ TSAN_OPTIONS=log_path=$GITHUB_WORKSPACE/build/log/tsan
 CLANG_SANITIZER=TSAN
 EOF
     ;;
+  uchar)
+    cat <<EOF >> "$GITHUB_ENV"
+BUILD_UCHAR=1
+EOF
+    ;;
   lint)
 # Re-enable once system deps are available
 #    BUILD_FLAGS="$BUILD_FLAGS -DLIBLUV_LIBRARY:FILEPATH=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/lua/5.1/luv.so -DLIBLUV_INCLUDE_DIR:PATH=/usr/include/lua5.1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,7 @@ option(CI_BUILD "CI, extra flags will be set" OFF)
 if(CI_BUILD)
   message(STATUS "CI build enabled")
   add_compile_options(-Werror)
-  if(DEFINED ENV{BUILD_32BIT})
+  if(DEFINED ENV{BUILD_UCHAR})
     # Get some test coverage for unsigned char
     add_compile_options(-funsigned-char)
   endif()


### PR DESCRIPTION
Not sure if adding a new check is an overkill for this, but since there is currently also no CI test coverage on Linux with both gcc and LuaJIT, it may be nice to have one.