### PR TITLE
vim-patch:8.2.4881: "P" in Visual mode still changes some registers

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1116,14 +1116,15 @@ register.  With blockwise selection it also depends on the size of the block
 and whether the corners are on an existing character.  (Implementation detail:
 it actually works by first putting the register after the selection and then
 deleting the selection.)
-With 'p' the previously selected text is put in the unnamed register.  This is
-useful if you want to put that text somewhere else.  But you cannot repeat the
-same change.
-With 'P' the unnamed register is not changed, you can repeat the same change.
-But the deleted text cannot be used.  If you do need it you can use 'p' with
-another register.  E.g., yank the text to copy, Visually select the text to
-replace and use "0p .  You can repeat this as many times as you like, and the
-unnamed register will be changed each time.
+With |p| the previously selected text is put in the unnamed register (and
+possibly the selection and/or clipboard).  This is useful if you want to put
+that text somewhere else.  But you cannot repeat the same change.
+With |P| the unnamed register is not changed (and neither the selection or
+clipboard), you can repeat the same change. But the deleted text cannot be
+used.  If you do need it you can use |p| with another register.  E.g., yank
+the text to copy, Visually select the text to replace and use "0p .  You can
+repeat this as many times as you like, and the unnamed register will be
+changed each time.
 
 When you use a blockwise Visual mode command and yank only a single line into
 a register, a paste on a visual selected area will paste that single line on

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -927,7 +927,7 @@ tag		command	      note action in Visual mode	~
 |v_K|		K		   run 'keywordprg' on the highlighted area
 |v_O|		O		   move horizontally to other corner of area
 |v_P|		P		   replace highlighted area with register
-				   contents; unnamed register is unchanged
+				   contents; registers are unchanged
 		Q		   does not start Ex mode
 |v_R|		R		2  delete the highlighted lines and start
 				   insert

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -255,7 +255,7 @@ Additionally the following commands can be used:
 	X	delete (2)					|v_X|
 	Y	yank (2)					|v_Y|
 	p	put						|v_p|
-	P	put without unnamed register overwrite		|v_P|
+	P	put without overwriting registers		|v_P|
 	J	join (1)					|v_J|
 	U	make uppercase					|v_U|
 	u	make lowercase					|v_u|

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -7108,7 +7108,7 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
       // overwrites if the old contents is being put.
       was_visual = true;
       regname = cap->oap->regname;
-      bool save_unnamed = cap->cmdchar == 'P';
+      bool keep_registers = cap->cmdchar == 'P';
       // '+' and '*' could be the same selection
       bool clipoverwrite = (regname == '+' || regname == '*') && (cb_flags & CB_UNNAMEDMASK);
       if (regname == 0 || regname == '"' || clipoverwrite
@@ -7123,22 +7123,14 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
       // do_put(), which requires the visual selection to still be active.
       if (!VIsual_active || VIsual_mode == 'V' || regname != '.') {
         // Now delete the selected text. Avoid messages here.
-        yankreg_T *old_y_previous;
-        if (save_unnamed) {
-          old_y_previous = get_y_previous();
-        }
         cap->cmdchar = 'd';
         cap->nchar = NUL;
-        cap->oap->regname = NUL;
+        cap->oap->regname = keep_registers ? '_' : NUL;
         msg_silent++;
         nv_operator(cap);
         do_pending_operator(cap, 0, false);
         empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
         msg_silent--;
-
-        if (save_unnamed) {
-          set_y_previous(old_y_previous);
-        }
 
         // delete PUT_LINE_BACKWARD;
         cap->oap->regname = regname;

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1350,34 +1350,74 @@ func Test_visual_paste()
   call assert_equal('x', @-)
   call assert_equal('bazooxxf', getline(1))
 
-  if has('clipboard')
-    " v_P does not overwrite unnamed register.
+  bwipe!
+endfunc
+
+func Test_visual_paste_clipboard()
+  CheckFeature clipboard_working
+
+  if has('gui')
+    " auto select feature breaks tests
+    set guioptions-=a
+  endif
+
+  " v_P does not overwrite unnamed register.
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  call setreg('-', 'bar')
+  normal gg0vP
+  call assert_equal('foo', @")
+  call assert_equal('bar', @-)
+  call assert_equal('fooxxx', getline(1))
+  normal $vP
+  call assert_equal('foo', @")
+  call assert_equal('bar', @-)
+  call assert_equal('fooxxfoo', getline(1))
+  " Test with a different register as unnamed register.
+  call setline(2, ['baz'])
+  normal 2gg0"rD
+  call assert_equal('baz', @")
+  normal gg0vP
+  call assert_equal('baz', @")
+  call assert_equal('bar', @-)
+  call assert_equal('bazooxxfoo', getline(1))
+  normal $vP
+  call assert_equal('baz', @")
+  call assert_equal('bar', @-)
+  call assert_equal('bazooxxfobaz', getline(1))
+
+  " Test for unnamed clipboard
+  set clipboard=unnamed
+  call setline(1, ['xxxx'])
+  call setreg('"', 'foo')
+  call setreg('-', 'bar')
+  call setreg('*', 'baz')
+  normal gg0vP
+  call assert_equal('foo', @")
+  call assert_equal('bar', @-)
+  call assert_equal('baz', @*)
+  call assert_equal('bazxxx', getline(1))
+
+  " Test for unnamedplus clipboard
+  if has('unnamedplus')
+    set clipboard=unnamedplus
     call setline(1, ['xxxx'])
     call setreg('"', 'foo')
     call setreg('-', 'bar')
+    call setreg('+', 'baz')
     normal gg0vP
     call assert_equal('foo', @")
-    call assert_equal('x', @-)
-    call assert_equal('fooxxx', getline(1))
-    normal $vP
-    call assert_equal('foo', @")
-    call assert_equal('x', @-)
-    call assert_equal('fooxxfoo', getline(1))
-    " Test with a different register as unnamed register.
-    call setline(2, ['baz'])
-    normal 2gg0"rD
-    call assert_equal('baz', @")
-    normal gg0vP
-    call assert_equal('baz', @")
-    call assert_equal('f', @-)
-    call assert_equal('bazooxxfoo', getline(1))
-    normal $vP
-    call assert_equal('baz', @")
-    call assert_equal('o', @-)
-    call assert_equal('bazooxxfobaz', getline(1))
+    call assert_equal('bar', @-)
+    call assert_equal('baz', @+)
+    call assert_equal('bazxxx', getline(1))
   endif
 
+  set clipboard&
+  if has('gui')
+    set guioptions&
+  endif
   bwipe!
 endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #18408

#### vim-patch:8.2.4881: "P" in Visual mode still changes some registers

Problem:    "P" in Visual mode still changes some registers.
Solution:   Make "P" in Visual mode not change any register. (Shougo
            Matsushita, closes vim/vim#10349)
https://github.com/vim/vim/commit/509142ab7a9db32114b6d0949722b9133c9c22f2