### PR TITLE
fix(cmd): make :-tabmove work with modifiers

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5248,7 +5248,9 @@ static int get_tabpage_arg(exarg_T *eap)
       tab_number = 0;
     } else {
       tab_number = (int)eap->line2;
-      if (!unaccept_arg0 && *skipwhite(*eap->cmdlinep) == '-') {
+      char *cmdp = eap->cmd;
+      while (--cmdp > *eap->cmdlinep && (*cmdp == ' ' || ascii_isdigit(*cmdp))) {}
+      if (!unaccept_arg0 && *cmdp == '-') {
         tab_number--;
         if (tab_number < unaccept_arg0) {
           eap->errmsg = e_invarg;

--- a/test/functional/editor/tabpage_spec.lua
+++ b/test/functional/editor/tabpage_spec.lua
@@ -7,6 +7,7 @@ local neq = helpers.neq
 local feed = helpers.feed
 local eval = helpers.eval
 local exec = helpers.exec
+local funcs = helpers.funcs
 
 describe('tabpage', function()
   before_each(clear)
@@ -51,5 +52,13 @@ describe('tabpage', function()
     ]])
     neq(999, eval('g:win_closed'))
   end)
-end)
 
+  it(":tabmove handles modifiers and addr", function()
+    command('tabnew | tabnew | tabnew')
+    eq(4, funcs.nvim_tabpage_get_number(0))
+    command('     silent      :keepalt   :: :::    silent!    -    tabmove')
+    eq(3, funcs.nvim_tabpage_get_number(0))
+    command('     silent      :keepalt   :: :::    silent!    -2    tabmove')
+    eq(1, funcs.nvim_tabpage_get_number(0))
+  end)
+end)


### PR DESCRIPTION
`:tabmove` takes either an argument (`:tabmove -`) or an address (`:-tabmove`).

The code assumed that `:tabmove` is the first command on the cmdline, but that
is not the case when using additional modifiers like `:silent`.

Make the addr parsing more robust by searching the command first, then going
back to check for a potential address `-`.