### PR TITLE
build(clint): remove "function size is too large" warning

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4544,7 +4544,7 @@ int build_stl_str_hl(win_T *wp, char_u *out, size_t outlen, char_u *fmt, int use
   }
 
   return width;
-}  // NOLINT(readability/fn_size)
+}
 
 /// Get relative cursor position in window into "buf[buflen]", in the form 99%,
 /// using "Top", "Bot" or "All" when appropriate.

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1802,7 +1802,7 @@ theend:
   xfree(next_line);
   xfree(allocated);
   return retval;
-}  // NOLINT(readability/fn_size)
+}
 
 /// Delete from cursor to end of line.
 /// Caller must have prepared for undo.

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2586,7 +2586,7 @@ ret_free:
   if (show_block) {
     ui_ext_cmdline_block_leave();
   }
-}  // NOLINT(readability/fn_size)
+}
 
 /// @return  5 if "p" starts with "<SID>" or "<SNR>" (ignoring case).
 ///          2 if "p" starts with "s:".

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4467,7 +4467,7 @@ skip:
   return preview_buf;
 #undef ADJUST_SUB_FIRSTLNUM
 #undef PUSH_PREVIEW_LINES
-}  // NOLINT(readability/fn_size)
+}
 
 /// Give message for number of substitutions.
 /// Can also be used after a ":global" command.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2219,7 +2219,7 @@ doend:
   --ex_nesting_level;
 
   return ea.nextcmd;
-}  // NOLINT(readability/fn_size)
+}
 
 static char ex_error_buf[MSG_BUF_LEN];
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3761,7 +3761,7 @@ end:
 
   // If the cursor is past the end of the line put it at the end.
   adjust_cursor_eol();
-}  // NOLINT(readability/fn_size)
+}
 
 /*
  * When the cursor is on the NUL past the end of the line and it should not be

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3382,7 +3382,7 @@ ambw_end:
   check_redraw(options[opt_idx].flags);
 
   return errmsg;
-}  // NOLINT(readability/fn_size)
+}
 
 /// Simple int comparison function for use with qsort()
 static int int_cmp(const void *a, const void *b)

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1748,7 +1748,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
   if (!got_int) {
     got_int = save_got_int;
   }
-}  // NOLINT(readability/fn_size)
+}
 
 /// Returns width of the signcolumn that should be used for the whole window
 ///

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -3067,7 +3067,7 @@ viml_pexpr_parse_end:
   }
   kvi_destroy(ast_stack);
   return ast;
-}  // NOLINT(readability/fn_size)
+}
 
 #undef NEW_NODE
 #undef HL


### PR DESCRIPTION
This warning is essentially only triggered for ported vim functions.
It's unlikely that we'll refactor vim functions solely based on their
size since it'd mean we'd greatly deviate from vim, which is a high cost
when it comes to importing the vim patches. Thus, this warning only
serves as an annoyance and should be removed.
