### PR TITLE
vim-patch:8.2.4469: Coverity warns for uninitialized variable

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6632,7 +6632,7 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
     // input() with a third argument: completion
     const int xp_namelen = (int)strlen(xp_name);
 
-    uint32_t argt;
+    uint32_t argt = 0;
     if (parse_compl_arg(xp_name, xp_namelen, &xp_type,
                         &argt, &xp_arg) == FAIL) {
       return;


### PR DESCRIPTION
Problem:    Coverity warns for uninitialized variable.
Solution:   Set the value to zero.
https://github.com/vim/vim/commit/05c1734c4f70a0d7fb2f06444e26afda018f8795
