### PR TITLE
fix(terminal): fix pointer comparison after free

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -404,7 +404,7 @@ void terminal_enter(void)
 
   // Disable these options in terminal-mode. They are nonsense because cursor is
   // placed at end of buffer to "follow" output. #11072
-  win_T *save_curwin = curwin;
+  handle_T save_curwin = curwin->handle;
   bool save_w_p_cul = curwin->w_p_cul;
   char_u *save_w_p_culopt = NULL;
   char_u save_w_p_culopt_flags = curwin->w_p_culopt_flags;
@@ -442,7 +442,7 @@ void terminal_enter(void)
   RedrawingDisabled = s->save_rd;
   apply_autocmds(EVENT_TERMLEAVE, NULL, NULL, false, curbuf);
 
-  if (save_curwin == curwin) {  // save_curwin may be invalid (window closed)!
+  if (save_curwin == curwin->handle) {
     curwin->w_p_cul = save_w_p_cul;
     if (save_w_p_culopt) {
       xfree(curwin->w_p_culopt);

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -442,7 +442,7 @@ void terminal_enter(void)
   RedrawingDisabled = s->save_rd;
   apply_autocmds(EVENT_TERMLEAVE, NULL, NULL, false, curbuf);
 
-  if (save_curwin == curwin->handle) {
+  if (save_curwin == curwin->handle) {  // Else: window was closed.
     curwin->w_p_cul = save_w_p_cul;
     if (save_w_p_culopt) {
       xfree(curwin->w_p_culopt);


### PR DESCRIPTION
At the moment of comparison, the pointer save_curwin can be invalid (as
suggested by the comment) because it has been free'd. Worst, the new
curwin could have been re-allocated to that same pointer, altering the
execution flow unpredictably.

While there are many other potential similar cases to fix in the
codebase, the presented scenario is not hypothetical and does happen in
practice (while spawning new windows from fzf for instance).

There are numerous other instances of curwin comparisons in the
codebase, and they may need further investigation.

closes #16941