### PR TITLE
feat(lsp)!: Turn format filter into predicate

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1120,19 +1120,13 @@ format({options})                                       *vim.lsp.buf.format()*
                     • bufnr (number|nil): Restrict formatting to the clients
                       attached to the given buffer, defaults to the current
                       buffer (0).
-                    • filter (function|nil): Predicate to filter clients used
-                      for formatting. Receives the list of clients attached to
-                      bufnr as the argument and must return the list of
-                      clients on which to request formatting. Example:    • >
+                    • filter (function|nil): Predicate used to filter clients.
+                      Receives a client as argument and must return a boolean.
+                      Clients matching the predicate are included. Example:    • >
 
                         -- Never request typescript-language-server for formatting
                         vim.lsp.buf.format {
-                          filter = function(clients)
-                            return vim.tbl_filter(
-                              function(client) return client.name ~= "tsserver" end,
-                              clients
-                            )
-                          end
+                          filter = function(client) return client.name ~= "tsserver" end
                         }
 <
                     • async boolean|nil If true the method won't block.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -177,20 +177,15 @@ end
 ---     - bufnr (number|nil):
 ---         Restrict formatting to the clients attached to the given buffer, defaults to the current
 ---         buffer (0).
+---
 ---     - filter (function|nil):
----         Predicate to filter clients used for formatting. Receives the list of clients attached
----         to bufnr as the argument and must return the list of clients on which to request
----         formatting. Example:
+---         Predicate used to filter clients. Receives a client as argument and must return a
+---         boolean. Clients matching the predicate are included. Example:
 ---
 ---         <pre>
 ---         -- Never request typescript-language-server for formatting
 ---         vim.lsp.buf.format {
----           filter = function(clients)
----             return vim.tbl_filter(
----               function(client) return client.name ~= "tsserver" end,
----               clients
----             )
----           end
+---           filter = function(client) return client.name ~= "tsserver" end
 ---         }
 ---         </pre>
 ---
@@ -207,18 +202,14 @@ end
 function M.format(options)
   options = options or {}
   local bufnr = options.bufnr or vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.buf_get_clients(bufnr)
+  local clients = vim.lsp.get_active_clients({
+    id = options.id,
+    bufnr = bufnr,
+    name = options.name,
+  })
 
   if options.filter then
-    clients = options.filter(clients)
-  elseif options.id then
-    clients = vim.tbl_filter(function(client)
-      return client.id == options.id
-    end, clients)
-  elseif options.name then
-    clients = vim.tbl_filter(function(client)
-      return client.name == options.name
-    end, clients)
+    clients = vim.tbl_filter(options.filter, clients)
   end
 
   clients = vim.tbl_filter(function(client)


### PR DESCRIPTION
This makes the common use case easier.
If one really needs access to all clients to decide if a client should be included, one can call `get_active_clients` manually within the filter function

This also makes it a bit more consistent with other functions, like `code_action` where `filter` is already a predicate

---

If this looks good I'd do the same for `rename`

---

Note the breaking change is relative to master, the function is new in 0.8
