### PR TITLE
fix PVS warnings

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1153,7 +1153,7 @@ size_t aucmd_pattern_length(char *pat)
 
   char *endpat;
 
-  for (; *pat; pat = (*endpat == ',' ? endpat + 1 : endpat)) {
+  for (; *pat; pat = endpat + 1) {
     // Find end of the pattern.
     // Watch out for a comma in braces, like "*.\{obj,o\}".
     endpat = pat;

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1541,6 +1541,7 @@ void vim_str2nr(const char_u *const start, int *const prep, int *const len, cons
 
   // Do the conversion manually to avoid sscanf() quirks.
   abort();  // Should’ve used goto earlier.
+  // -V:PARSE_NUMBER:560
 #define PARSE_NUMBER(base, cond, conv) \
   do { \
     const char *const after_prefix = ptr; \

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10146,9 +10146,6 @@ repeat:
       *fnamep = xstrnsave(*fnamep, STRLEN(*fnamep) + 2);
       xfree(*bufp);          // free any allocated file name
       *bufp = *fnamep;
-      if (*fnamep == NULL) {
-        return -1;
-      }
       add_pathsep(*fnamep);
     }
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9711,25 +9711,24 @@ static void f_spellsuggest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
 
-  if (*curwin->w_s->b_p_spl != NUL) {
-    const char *const str = tv_get_string(&argvars[0]);
-    if (argvars[1].v_type != VAR_UNKNOWN) {
-      maxcount = tv_get_number_chk(&argvars[1], &typeerr);
-      if (maxcount <= 0) {
+  const char *const str = tv_get_string(&argvars[0]);
+  if (argvars[1].v_type != VAR_UNKNOWN) {
+    maxcount = tv_get_number_chk(&argvars[1], &typeerr);
+    if (maxcount <= 0) {
+      goto f_spellsuggest_return;
+    }
+    if (argvars[2].v_type != VAR_UNKNOWN) {
+      need_capital = tv_get_number_chk(&argvars[2], &typeerr);
+      if (typeerr) {
         goto f_spellsuggest_return;
       }
-      if (argvars[2].v_type != VAR_UNKNOWN) {
-        need_capital = tv_get_number_chk(&argvars[2], &typeerr);
-        if (typeerr) {
-          goto f_spellsuggest_return;
-        }
-      }
-    } else {
-      maxcount = 25;
     }
-
-    spell_suggest_list(&ga, (char_u *)str, maxcount, need_capital, false);
+  } else {
+    maxcount = 25;
   }
+
+  spell_suggest_list(&ga, (char_u *)str, maxcount, need_capital, false);
+
 
 f_spellsuggest_return:
   tv_list_alloc_ret(rettv, (ptrdiff_t)ga.ga_len);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9729,7 +9729,6 @@ static void f_spellsuggest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   spell_suggest_list(&ga, (char_u *)str, maxcount, need_capital, false);
 
-
 f_spellsuggest_return:
   tv_list_alloc_ret(rettv, (ptrdiff_t)ga.ga_len);
   for (int i = 0; i < ga.ga_len; i++) {

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -250,6 +250,8 @@
 #include "nvim/func_attr.h"
 #include "nvim/lib/kvec.h"
 
+// -V::1063
+
 /// Dummy variable used because some macros need lvalue
 ///
 /// Must not be written to, if needed one must check that address of the

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1012,15 +1012,6 @@ void ex_mkrc(exarg_T *eap)
             emsg(_(e_prev_dir));
           }
           shorten_fnames(true);
-          // restore original dir
-          if (*dirnow != NUL && ((ssop_flags & SSOP_SESDIR)
-                                 || ((ssop_flags & SSOP_CURDIR) && globaldir !=
-                                     NULL))) {
-            if (os_chdir((char *)dirnow) != 0) {
-              emsg(_(e_prev_dir));
-            }
-            shorten_fnames(true);
-          }
         }
         xfree(dirnow);
       } else {

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -56,12 +56,14 @@
 // Returns empty string if it is NULL.
 #define EMPTY_IF_NULL(x) (char *)((x) ? (x) : (char_u *)"")
 
-// Adjust chars in a language according to 'langmap' option.
-// NOTE that there is no noticeable overhead if 'langmap' is not set.
-// When set the overhead for characters < 256 is small.
-// Don't apply 'langmap' if the character comes from the Stuff buffer or from a
-// mapping and the langnoremap option was set.
-// The do-while is just to ignore a ';' after the macro.
+/// Adjust chars in a language according to 'langmap' option.
+/// NOTE that there is no noticeable overhead if 'langmap' is not set.
+/// When set the overhead for characters < 256 is small.
+/// Don't apply 'langmap' if the character comes from the Stuff buffer or from a
+/// mapping and the langnoremap option was set.
+/// The do-while is just to ignore a ';' after the macro.
+///
+/// -V:LANGMAP_ADJUST:560
 #define LANGMAP_ADJUST(c, condition) \
   do { \
     if (*p_langmap \

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2170,7 +2170,7 @@ static char *qf_push_dir(char *dirbuf, struct dir_stack_T **stackptr, bool is_fi
   // store directory on the stack
   if (vim_isAbsName((char_u *)dirbuf)
       || (*stackptr)->next == NULL
-      || (*stackptr && is_file_stack)) {
+      || is_file_stack) {
     (*stackptr)->dirname = xstrdup(dirbuf);
   } else {
     // Okay we don't have an absolute path.

--- a/src/nvim/rbuffer.h
+++ b/src/nvim/rbuffer.h
@@ -36,6 +36,8 @@
 //
 // Note that the rbuffer_{produced,consumed} calls are necessary or these macros
 // create infinite loops
+//
+// -V:RBUFFER_UNTIL_EMPTY:1044
 #define RBUFFER_UNTIL_EMPTY(buf, rptr, rcnt) \
   for (size_t rcnt = 0, _r = 1; _r; _r = 0)  /* NOLINT(readability/braces) */ \
   for (char *rptr = rbuffer_read_ptr(buf, &rcnt);  /* NOLINT(readability/braces) */ \

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -637,9 +637,9 @@ static const void *tv_ptr(const typval_T *const tvs, int *const idxp)
   STATIC_ASSERT(OFF(v_string) == OFF(v_list)
                 && OFF(v_string) == OFF(v_dict)
                 && OFF(v_string) == OFF(v_partial)
-                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_list)
-                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_dict)
-                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_partial),
+                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_list)      // -V568
+                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_dict)      // -V568
+                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_partial),  // -V568
                 "Strings, dictionaries, lists and partials are expected to be pointers, "
                 "so that all three of them can be accessed via v_string");
 #undef OFF


### PR DESCRIPTION
- fix(PVS/V547): remove ifs that are always true or false
- fix(PVS/V560): remove partial conditions that are always true
- fix(PVS/V1044): suppress warning about loop break conditions
- fix(PVS/V1063): suppress "modulo by 1 operation is meaningless"
- fix(PVS/V568): suppress "operator evaluates the size of a pointer"
