### PR TITLE
vim-patch:8.2.4908: no text formatting for // comment after a statement

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4710,7 +4710,22 @@ static int fmt_check_par(linenr_T lnum, int *leader_len, char_u **leader_flags, 
 
   ptr = ml_get(lnum);
   if (do_comments) {
-    *leader_len = get_leader_len(ptr, leader_flags, false, true);
+    char_u *line = ml_get_curline();
+
+    leader_len = get_leader_len(line, NULL, FALSE, TRUE);
+    if (leader_len == 0 && curbuf->b_p_cin) {
+      int comment_start;
+
+      // Check for a line comment after code.
+      comment_start = check_linecomment(line);
+      if (comment_start != MAXCOL) {
+        leader_len = get_leader_len(
+            line + comment_start, NULL, FALSE, TRUE);
+        if (leader_len != 0) {
+          leader_len += comment_start;
+        }
+      }
+    }
   } else {
     *leader_len = 0;
   }

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -330,6 +330,18 @@ func Test_format_c_comment()
   END
   call assert_equal(expected, getline(1, '$'))
 
+  " typing comment text auto-wraps
+  %del
+  call setline(1, text)
+  exe "normal! 2GA blah more text blah.\<Esc>"
+  let expected =<< trim END
+      {
+         val = val;      // This is a comment
+                         // blah more text
+                         // blah.
+  END
+  call assert_equal(expected, getline(1, '$'))
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:    No text formatting for // comment after a statement.
Solution:   format a comment when the 'c' flag is in 'formatoptions'.
https://github.com/vim/vim/commit/48a8a833033e10fc1eba96f2fc8dd19c2408eddf