### PR TITLE
vim-patch:8.2.4908: no text formatting for // comment after a statement

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6033,7 +6033,18 @@ static void internal_format(int textwidth, int second_indent, int flags, int for
 
     // Don't break until after the comment leader
     if (do_comments) {
-      leader_len = get_leader_len(get_cursor_line_ptr(), NULL, false, true);
+      char_u *line = get_cursor_line_ptr();
+      leader_len = get_leader_len(line, NULL, false, true);
+      if (leader_len == 0 && curbuf->b_p_cin) {
+        // Check for a line comment after code.
+        int comment_start = check_linecomment(line);
+        if (comment_start != MAXCOL) {
+          leader_len = get_leader_len(line + comment_start, NULL, false, true);
+          if (leader_len != 0) {
+            leader_len += comment_start;
+          }
+        }
+      }
     } else {
       leader_len = 0;
     }

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -342,6 +342,18 @@ func Test_format_c_comment()
   END
   call assert_equal(expected, getline(1, '$'))
 
+  " typing comment text auto-wraps
+  %del
+  call setline(1, text)
+  exe "normal! 2GA blah more text blah.\<Esc>"
+  let expected =<< trim END
+      {
+         val = val;      // This is a comment
+                         // blah more text
+                         // blah.
+  END
+  call assert_equal(expected, getline(1, '$'))
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.4908: no text formatting for // comment after a statement

Problem:    No text formatting for // comment after a statement.
Solution:   format a comment when the 'c' flag is in 'formatoptions'.
https://github.com/vim/vim/commit/48a8a833033e10fc1eba96f2fc8dd19c2408eddf