### PR TITLE
vim-patch:partial:d899e5112079

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -455,8 +455,8 @@ only appear once.  Examples: >
 A key is always a String.  You can use a Number, it will be converted to a
 String automatically.  Thus the String '4' and the number 4 will find the same
 entry.  Note that the String '04' and the Number 04 are different, since the
-Number will be converted to the String '4'.  The empty string can also be used
-as a key.
+Number will be converted to the String '4', leading zeros are dropped.  The
+empty string can also be used as a key.
 						*literal-Dict*
 To avoid having to put quotes around every key the #{} form can be used.  This
 does require the key to consist only of ASCII letters, digits, '-' and '_'.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1269,7 +1269,7 @@ Context-sensitive completion on the command-line:
 |CTRL-W_^|	CTRL-W ^		split window and edit alternate file
 |CTRL-W_n|	CTRL-W n  or  :new	create new empty window
 |CTRL-W_q|	CTRL-W q  or  :q[uit]	quit editing and close window
-|CTRL-W_c|	CTRL-W c  or  :cl[ose]	make buffer hidden and close window
+|CTRL-W_c|	CTRL-W c  or  :clo[se]	make buffer hidden and close window
 |CTRL-W_o|	CTRL-W o  or  :on[ly]	make current window only one on the
 					   screen
 

--- a/runtime/ftplugin/wget.vim
+++ b/runtime/ftplugin/wget.vim
@@ -1,0 +1,29 @@
+" Vim filetype plugin file
+" Language:     Wget configuration file (/etc/wgetrc ~/.wgetrc)
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2022 Apr 28
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal comments=:#,://
+setlocal commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setl fo< com< cms<"
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Wget Configuration File (wgetrc, .wgetrc)\twgetrc;.wgetrc\n" .
+	\	       "All Files (*.*)\t*.*\n"
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8

--- a/runtime/ftplugin/wget2.vim
+++ b/runtime/ftplugin/wget2.vim
@@ -1,0 +1,29 @@
+" Vim filetype plugin file
+" Language:     Wget2 configuration file (/etc/wget2rc ~/.wget2rc)
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2022 Apr 28
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal comments=:#,://
+setlocal commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setl fo< com< cms<"
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Wget2 Configuration File (wget2rc, .wget2rc)\twget2rc;.wget2rc\n" .
+	\	       "All Files (*.*)\t*.*\n"
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: nowrap sw=2 sts=2 ts=8

--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -14,11 +14,6 @@ map: val
 # END_INDENT
 
 # START_INDENT
-map: multiline
-value
-# END_INDENT
-
-# START_INDENT
 map: |
 line1
 line2

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -14,11 +14,6 @@ map: val
 # END_INDENT
 
 # START_INDENT
-map: multiline
-  value
-# END_INDENT
-
-# START_INDENT
 map: |
   line1
   line2

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -2,7 +2,7 @@
 " Language:	YAML
 " Maintainer:	Nikolai Pavlov <zyx.vim@gmail.com>
 " Last Update:	Lukas Reineke
-" Last Change:	2021 Aug 13
+" Last Change:	2022 May 02
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')
@@ -54,7 +54,7 @@ let s:c_ns_anchor_name = s:c_ns_anchor_char.'+'
 let s:c_ns_anchor_property =  '\v\&'.s:c_ns_anchor_name
 
 let s:ns_word_char = '\v[[:alnum:]_\-]'
-let s:ns_tag_char  = '\v%('.s:ns_word_char.'|[#/;?:@&=+$.~*''()])'
+let s:ns_tag_char  = '\v%(%\x\x|'.s:ns_word_char.'|[#/;?:@&=+$.~*''()])'
 let s:c_named_tag_handle     = '\v\!'.s:ns_word_char.'+\!'
 let s:c_secondary_tag_handle = '\v\!\!'
 let s:c_primary_tag_handle   = '\v\!'
@@ -63,7 +63,7 @@ let s:c_tag_handle = '\v%('.s:c_named_tag_handle.
             \            '|'.s:c_primary_tag_handle.')'
 let s:c_ns_shorthand_tag = '\v'.s:c_tag_handle . s:ns_tag_char.'+'
 let s:c_non_specific_tag = '\v\!'
-let s:ns_uri_char  = '\v%('.s:ns_word_char.'\v|[#/;?:@&=+$,.!~*''()[\]])'
+let s:ns_uri_char  = '\v%(%\x\x|'.s:ns_word_char.'\v|[#/;?:@&=+$,.!~*''()[\]])'
 let s:c_verbatim_tag = '\v\!\<'.s:ns_uri_char.'+\>'
 let s:c_ns_tag_property = '\v'.s:c_verbatim_tag.
             \               '\v|'.s:c_ns_shorthand_tag.

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2022 Apr 16
+" Last Change: 2022 May 04
 "
 " WORK IN PROGRESS - The basics works stable, more to come
 " Note: In general you need at least GDB 7.12 because this provides the
@@ -924,7 +924,7 @@ func s:DeleteCommands()
     if empty(s:k_map_saved)
       nunmap K
     else
-      " call mapset('n', 0, s:k_map_saved)
+      " call mapset(s:k_map_saved)
       let mode = s:k_map_saved.mode !=# ' ' ? s:k_map_saved.mode : ''
       call nvim_set_keymap(mode, 'K', s:k_map_saved.rhs, {
         \ 'expr': s:k_map_saved.expr ? v:true : v:false,

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -3,7 +3,7 @@
 " Original Author: Mohamed Boughaba <mohamed dot bgb at gmail dot com>
 " Maintainer: Quentin Hibon (github user hiqua)
 " Version: 0.4
-" Last Change: 2022 Jan 15
+" Last Change: 2022 May 05
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -49,6 +49,10 @@ syn match i3ConfigVariableAndModifier /+\w\+/ contained contains=i3ConfigVariabl
 syn match i3ConfigVariable /\$\w\+\(\(-\w\+\)\+\)\?\(\s\|+\)\?/ contains=i3ConfigVariableModifier,i3ConfigVariableAndModifier
 syn keyword i3ConfigInitializeKeyword set contained
 syn match i3ConfigInitialize /^\s*set\s\+.*$/ contains=i3ConfigVariable,i3ConfigInitializeKeyword,i3ConfigColor,i3ConfigString
+
+" Include
+syn keyword i3ConfigIncludeKeyword include contained
+syn match i3ConfigInclude /^\s*include\s\+.*$/ contains=i3ConfigIncludeKeyword,i3ConfigString,i3ConfigVariable
 
 " Gaps
 syn keyword i3ConfigGapStyleKeyword inner outer horizontal vertical top right bottom left current all set plus minus toggle up down contained
@@ -221,6 +225,7 @@ hi def link i3ConfigAssignSpecial                   Special
 hi def link i3ConfigFontNamespace                   PreProc
 hi def link i3ConfigBindArgument                    PreProc
 hi def link i3ConfigNoStartupId                     PreProc
+hi def link i3ConfigIncludeKeyword                  Identifier
 hi def link i3ConfigFontKeyword                     Identifier
 hi def link i3ConfigBindKeyword                     Identifier
 hi def link i3ConfigOrientation                     Identifier

--- a/runtime/syntax/plsql.vim
+++ b/runtime/syntax/plsql.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer: Jeff Lanzarotta (jefflanzarotta at yahoo dot com)
 " Previous Maintainer: C. Laurence Gonsalves (clgonsal@kami.com)
 " URL: https://github.com/lee-lindley/vim_plsql_syntax
-" Last Change: April 25, 2022   
+" Last Change: April 28, 2022   
 " History  Lee Lindley (lee dot lindley at gmail dot com)
 "               updated to 19c keywords. refined quoting. 
 "               separated reserved, non-reserved keywords and functions
@@ -22,9 +22,6 @@
 "
 " To enable folding (It does setlocal foldmethod=syntax)
 " let plsql_fold = 1
-"
-" If you want to try procedure folding, it has issues
-" let plsql_procedure_fold = 1
 "
 "     From my vimrc file -- turn syntax and syntax folding on,
 "     associate file suffixes as plsql, open all the folds on file open
@@ -67,23 +64,23 @@ syn match   plsqlSymbol "[;,.()]"
 
 " Operators. and words that would be something else if not in operator mode
 syn match   plsqlOperator "[-+*/=<>@"]"
-syn match   plsqlOperator "\%\(\^=\|<=\|>=\|:=\|=>\|\.\.\|||\|<<\|>>\|\*\*\|!=\|\~=\)"
-syn match   plsqlOperator "\<\%\(NOT\|AND\|OR\|LIKE\|BETWEEN\|IN\)\>"
+syn match   plsqlOperator "\(\^=\|<=\|>=\|:=\|=>\|\.\.\|||\|<<\|>>\|\*\*\|!=\|\~=\)"
+syn match   plsqlOperator "\<\(NOT\|AND\|OR\|LIKE\|BETWEEN\|IN\)\>"
 syn match   plsqlBooleanLiteral "\<NULL\>"
-syn match   plsqlOperator "\<IS\\_s\+\%\(NOT\_s\+\)\?NULL\>"
+syn match   plsqlOperator "\<IS\\_s\+\(NOT\_s\+\)\?NULL\>"
 "
 " conditional compilation Preprocessor directives and sqlplus define sigil
 syn match plsqlPseudo "$[$a-z][a-z0-9$_#]*"
 syn match plsqlPseudo "&"
 
-syn match plsqlReserved "\<\%\(CREATE\|THEN\|UPDATE\|INSERT\|SET\)\>"
-syn match plsqlKeyword "\<\%\(REPLACE\|PACKAGE\|FUNCTION\|PROCEDURE\|TYPE|BODY\|WHEN\|MATCHED\)\>"
+syn match plsqlReserved "\<\(CREATE\|THEN\|UPDATE\|INSERT\|SET\)\>"
+syn match plsqlKeyword "\<\(REPLACE\|PACKAGE\|FUNCTION\|PROCEDURE\|TYPE|BODY\|WHEN\|MATCHED\)\>"
 syn region plsqlUpdate 
     \ matchgroup=plsqlReserved 
     \ start="\<UPDATE\>"
     \ end="\<SET\>"
     \ contains=@plsqlIdentifiers
-syn match plsqlReserved "\<WHEN\_s\+\%\(NOT\_s\+\)\?MATCHED\_s\+THEN\_s\+\%\(UPDATE\|INSERT\)\%\(\_s\+SET\)\?"
+syn match plsqlReserved "\<WHEN\_s\+\(NOT\_s\+\)\?MATCHED\_s\+THEN\_s\+\(UPDATE\|INSERT\)\(\_s\+SET\)\?"
 
 "
 " Oracle's non-reserved keywords
@@ -463,7 +460,9 @@ syn keyword plsqlReserved OCIDURATION OCIINTERVAL OCILOBLOCATOR OCINUMBER OCIRAW
 syn keyword plsqlReserved OCIROWID OCISTRING OCITYPE OF ON OPTION ORACLE ORADATA ORDER ORLANY ORLVARY
 syn keyword plsqlReserved OUT OVERRIDING PARALLEL_ENABLE PARAMETER PASCAL PCTFREE PIPE PIPELINED POLYMORPHIC
 syn keyword plsqlReserved PRAGMA PRIOR PUBLIC RAISE RECORD RELIES_ON REM RENAME RESOURCE RESULT REVOKE ROWID 
-syn keyword plsqlReserved SB1 SB2 SELECT SEPARATE SHARE SHORT SIZE SIZE_T SPARSE SQLCODE SQLDATA
+syn keyword plsqlReserved SB1 SB2 
+syn match plsqlReserved "\<SELECT\>"
+syn keyword plsqlReserved SEPARATE SHARE SHORT SIZE SIZE_T SPARSE SQLCODE SQLDATA
 syn keyword plsqlReserved SQLNAME SQLSTATE STANDARD START STORED STRUCT STYLE SYNONYM TABLE TDO
 syn keyword plsqlReserved TRANSACTIONAL TRIGGER UB1 UB4 UNION UNIQUE UNSIGNED UNTRUSTED VALIST
 syn keyword plsqlReserved VALUES VARIABLE VIEW VOID WHERE WITH
@@ -517,28 +516,30 @@ syn match   plsqlFunction "\.PREV\>"hs=s+1
 syn match   plsqlFunction "\.NEXT\>"hs=s+1
 
 if exists("plsql_legacy_sql_keywords")
-" Some of Oracle's SQL keywords.
-syn keyword plsqlSQLKeyword ABORT ACCESS ACCESSED ADD AFTER ALL ALTER AND ANY
-syn keyword plsqlSQLKeyword ASC ATTRIBUTE AUDIT AUTHORIZATION AVG BASE_TABLE
-syn keyword plsqlSQLKeyword BEFORE BETWEEN BY CASCADE CAST CHECK CLUSTER
-syn keyword plsqlSQLKeyword CLUSTERS COLAUTH COLUMN COMMENT COMPRESS CONNECT
-syn keyword plsqlSQLKeyword CONSTRAINT CRASH CURRENT DATA DATABASE
-syn keyword plsqlSQLKeyword DATA_BASE DBA DEFAULT DELAY DELETE DESC DISTINCT
-syn keyword plsqlSQLKeyword DROP DUAL EXCLUSIVE EXISTS EXTENDS EXTRACT
-syn keyword plsqlSQLKeyword FILE FORCE FOREIGN FROM GRANT GROUP HAVING HEAP
-syn keyword plsqlSQLKeyword IDENTIFIED IDENTIFIER IMMEDIATE IN INCLUDING
-syn keyword plsqlSQLKeyword INCREMENT INDEX INDEXES INITIAL INSERT INSTEAD
-syn keyword plsqlSQLKeyword INTERSECT INTO INVALIDATE ISOLATION KEY LIBRARY
-syn keyword plsqlSQLKeyword LIKE LOCK MAXEXTENTS MINUS MODE MODIFY MULTISET
-syn keyword plsqlSQLKeyword NESTED NOAUDIT NOCOMPRESS NOT NOWAIT OF OFF OFFLINE
-syn keyword plsqlSQLKeyword ON ONLINE OPERATOR OPTION ORDER ORGANIZATION
-syn keyword plsqlSQLKeyword PCTFREE PRIMARY PRIOR PRIVATE PRIVILEGES PUBLIC
-syn keyword plsqlSQLKeyword QUOTA RELEASE RENAME REPLACE RESOURCE REVOKE ROLLBACK
-syn keyword plsqlSQLKeyword ROW ROWLABEL ROWS SCHEMA SELECT SEPARATE SESSION SET
-syn keyword plsqlSQLKeyword SHARE SIZE SPACE START STORE SUCCESSFUL SYNONYM
-syn keyword plsqlSQLKeyword SYSDATE TABLE TABLES TABLESPACE TEMPORARY TO TREAT
-syn keyword plsqlSQLKeyword TRIGGER TRUNCATE UID UNION UNIQUE UNLIMITED UPDATE
-syn keyword plsqlSQLKeyword USE USER VALIDATE VALUES VIEW WHENEVER WHERE WITH
+    " Some of Oracle's SQL keywords.
+    syn keyword plsqlSQLKeyword ABORT ACCESS ACCESSED ADD AFTER ALL ALTER AND ANY
+    syn keyword plsqlSQLKeyword ASC ATTRIBUTE AUDIT AUTHORIZATION AVG BASE_TABLE
+    syn keyword plsqlSQLKeyword BEFORE BETWEEN BY CASCADE CAST CHECK CLUSTER
+    syn keyword plsqlSQLKeyword CLUSTERS COLAUTH COLUMN COMMENT COMPRESS CONNECT
+    syn keyword plsqlSQLKeyword CONSTRAINT CRASH CURRENT DATA DATABASE
+    syn keyword plsqlSQLKeyword DATA_BASE DBA DEFAULT DELAY DELETE DESC DISTINCT
+    syn keyword plsqlSQLKeyword DROP DUAL EXCLUSIVE EXISTS EXTENDS EXTRACT
+    syn keyword plsqlSQLKeyword FILE FORCE FOREIGN FROM GRANT GROUP HAVING HEAP
+    syn keyword plsqlSQLKeyword IDENTIFIED IDENTIFIER IMMEDIATE IN INCLUDING
+    syn keyword plsqlSQLKeyword INCREMENT INDEX INDEXES INITIAL INSERT INSTEAD
+    syn keyword plsqlSQLKeyword INTERSECT INTO INVALIDATE ISOLATION KEY LIBRARY
+    syn keyword plsqlSQLKeyword LIKE LOCK MAXEXTENTS MINUS MODE MODIFY MULTISET
+    syn keyword plsqlSQLKeyword NESTED NOAUDIT NOCOMPRESS NOT NOWAIT OF OFF OFFLINE
+    syn keyword plsqlSQLKeyword ON ONLINE OPERATOR OPTION ORDER ORGANIZATION
+    syn keyword plsqlSQLKeyword PCTFREE PRIMARY PRIOR PRIVATE PRIVILEGES PUBLIC
+    syn keyword plsqlSQLKeyword QUOTA RELEASE RENAME REPLACE RESOURCE REVOKE ROLLBACK
+    syn keyword plsqlSQLKeyword ROW ROWLABEL ROWS SCHEMA 
+    syn match plsqlSQLKeyword "\<SELECT\>"
+    syn keyword plsqlSQLKeyword SEPARATE SESSION SET
+    syn keyword plsqlSQLKeyword SHARE SIZE SPACE START STORE SUCCESSFUL SYNONYM
+    syn keyword plsqlSQLKeyword SYSDATE TABLE TABLES TABLESPACE TEMPORARY TO TREAT
+    syn keyword plsqlSQLKeyword TRIGGER TRUNCATE UID UNION UNIQUE UNLIMITED UPDATE
+    syn keyword plsqlSQLKeyword USE USER VALIDATE VALUES VIEW WHENEVER WHERE WITH
 endif
 
 
@@ -565,17 +566,16 @@ syn keyword plsqlException TIMEOUT_ON_RESOURCE TOO_MANY_ROWS VALUE_ERROR
 syn keyword plsqlException ZERO_DIVIDE
 
 if exists("plsql_highlight_triggers")
-  syn keyword plsqlTrigger INSERTING UPDATING DELETING
+    syn keyword plsqlTrigger INSERTING UPDATING DELETING
 endif
 
-" so can not contain it for folding
+" so can not contain it for folding. May no longer be necessary and can change them to plsqlKeyword
 syn match plsqlBEGIN "\<BEGIN\>"
 syn match plsqlEND "\<END\>"
-syn match plsqlISAS "\<\%\(IS\|AS\)\>"
-
+syn match plsqlISAS "\<\(IS\|AS\)\>"
 
 " Various types of comments.
-  syntax region plsqlCommentL start="--" skip="\\$" end="$" keepend extend contains=@plsqlCommentGroup,plsqlSpaceError
+syntax region plsqlCommentL start="--" skip="\\$" end="$" keepend extend contains=@plsqlCommentGroup,plsqlSpaceError
 if exists("plsql_fold")
     syntax region plsqlComment
         \ start="/\*" end="\*/"
@@ -599,11 +599,12 @@ syn match   plsqlStringError "'.*$"
 " Various types of literals.
 " the + and - get sucked up as operators. Not sure how to take precedence here. Something to do with word boundaries.
 " most other syntax files do not try to includ +/- in the number token, so leave them as unary operators
+" even though the oracle documentation counts the sign as part of the numeric literal
 syn match   plsqlNumbers transparent "\<\d\|\.\d" contains=plsqlIntLiteral,plsqlFloatLiteral
 syn match   plsqlNumbersCom contained transparent "\<\d\|\.\d" contains=plsqlIntLiteral,plsqlFloatLiteral
 syn match   plsqlIntLiteral contained "\d\+"
-syn match   plsqlFloatLiteral contained "\d\+\.\%\(\d\+\%\([eE][+-]\?\d\+\)\?\)\?"
-syn match   plsqlFloatLiteral contained "\.\%\(\d\+\%\([eE][+-]\?\d\+\)\?\)"
+syn match   plsqlFloatLiteral contained "\d\+\.\(\d\+\([eE][+-]\?\d\+\)\?\)\?[fd]\?"
+syn match   plsqlFloatLiteral contained "\.\(\d\+\([eE][+-]\?\d\+\)\?\)[fd]\?"
 
 " double quoted strings in SQL are database object names. Should be a subgroup of Normal.
 " We will use Character group as a proxy for that so color can be chosen close to Normal
@@ -639,146 +640,82 @@ syn match plsqlAttribute "%\(BULK_EXCEPTIONS\|BULK_ROWCOUNT\|ISOPEN\|FOUND\|NOTF
 syn cluster plsqlParenGroup contains=plsqlParenError,@plsqlCommentGroup,plsqlCommentSkip,plsqlIntLiteral,plsqlFloatLiteral,plsqlNumbersCom
 
 if exists("plsql_bracket_error")
-  if exists("plsql_fold")
-    syn region plsqlParen start='(' end=')' contains=ALLBUT,@plsqlParenGroup,plsqlErrInBracket fold keepend extend transparent
-  else
-    syn region plsqlParen transparent start='(' end=')' contains=ALLBUT,@plsqlParenGroup,plsqlErrInBracket
-  endif
-  syn match plsqlParenError "[\])]"
-  syn match plsqlErrInParen contained "[{}]"
-  syn region plsqlBracket transparent start='\[' end=']' contains=ALLBUT,@plsqlParenGroup,plsqlErrInParen
-  syn match plsqlErrInBracket contained "[);{}]"
+    " I suspect this code was copied from c.vim and never properly considered. Do
+    " we even use braces or brackets in sql or pl/sql?
+    if exists("plsql_fold")
+        syn region plsqlParen start='(' end=')' contains=ALLBUT,@plsqlParenGroup,plsqlErrInBracket fold keepend extend transparent
+    else
+        syn region plsqlParen transparent start='(' end=')' contains=ALLBUT,@plsqlParenGroup,plsqlErrInBracket
+    endif
+    syn match plsqlParenError "[\])]"
+    syn match plsqlErrInParen contained "[{}]"
+    syn region plsqlBracket transparent start='\[' end=']' contains=ALLBUT,@plsqlParenGroup,plsqlErrInParen
+    syn match plsqlErrInBracket contained "[);{}]"
 else
-  if exists("plsql_fold")
-    syn region plsqlParen start='(' end=')' contains=ALLBUT,@plsqlParenGroup,@plsqlFoldingGroupIgnore,plsqlErrInParen fold keepend extend transparent
-  else
-    syn region plsqlParen transparent start='(' end=')' contains=ALLBUT,@plsqlParenGroup,@plsqlFoldingGroupIgnore,plsqlErrInParen
-  endif
-  "syn region plsqlParen transparent start='(' end=')' contains=ALLBUT,@plsqlParenGroup,@plsqlProcedureGroup,plsqlBlock,plsqlBlockCont,plsqlPackage,plsqlProcedureJava
-  syn match plsqlParenError ")"
-  syn match plsqlErrInParen contained "[{}]"
+    if exists("plsql_fold")
+        syn region plsqlParen start='(' end=')' contains=ALLBUT,@plsqlParenGroup,plsqlErrInParen fold keepend extend transparent
+    else
+        syn region plsqlParen transparent start='(' end=')' contains=ALLBUT,@plsqlParenGroup,plsqlErrInParen
+    endif
+    syn match plsqlParenError ")"
+    " should this not be parens isntead of brackets? I never quite followed what this was doing
+    syn match plsqlErrInParen contained "[{}]"
 endif
 
 syn match plsqlReserved "\<BODY\>"
-syn match plsqlReserved "\<CREATE\_s\+\%\(OR\_s\+REPLACE\_s\+\)\?"
-" Loops.
-syn match   plsqlRepeat "\<\%\(FOR\|WHILE\|LOOP\|FORALL\)\>"
-syn match   plsqlRepeat "\<END\_s\+LOOP\>"
-syn match plsqlConditional "\<\%\(ELSIF\|IF\|ELSE\)\>"
-"syn match plsqlConditional "\<END\>\_s\+\<IF\>"
+syn match plsqlReserved "\<CREATE\_s\+\(OR\_s\+REPLACE\_s\+\)\?"
+" Loops
+syn match plsqlRepeat "\<\(FOR\|WHILE\|LOOP\|FORALL\)\>"
+syn match plsqlRepeat "\<END\_s\+LOOP\>"
+" conditionals
+syn match plsqlConditional "\<\(ELSIF\|IF\|ELSE\)\>"
+syn match plsqlConditional "\<END\>\_s\+\<IF\>"
+syn match plsqlCase "\<END\>\_s\+\<CASE\>"
 syn match plsqlCase "\<CASE\>"
-"syn match plsqlCase "\<END\>\s_\+\<CASE\>"
 
 if exists("plsql_fold")
     setlocal foldmethod=syntax
     syn sync fromstart
 
-    syn cluster plsqlFoldingGroupIgnore contains=plsqlProcedureDeclaration
+    syn cluster plsqlProcedureGroup contains=plsqlProcedure
+    syn cluster plsqlOnlyGroup contains=@plsqlProcedure,plsqlConditionalBlock,plsqlLoopBlock,plsqlBlock
 
-    "syntax match plsqlWhiteSpaceGroup "\_s\+" contained transparent
+    syntax region plsqlUpdateSet
+        \ start="\(\<update\>\_s\+\(\<set\>\)\@![a-z][a-z0-9$_#]*\_s\+\(\(\<set\>\)\@![a-z][a-z0-9$_#]*\_s\+\)\?\)\|\(\<when\>\_s\+\<matched\>\_s\+\<then\>\_s\+\<update\>\_s\+\)\<set\>"
+        \ end="\(\_s*\(;\|\<from\>\|\<where\>\|\<when\>\)\)\@="
+        \ fold
+        \ keepend 
+        \ extend
+        \ transparent
+        \ contains=ALLBUT,@plsqlOnlyGroup,plsqlSelect
 
+    syntax region plsqlSelect
+        \ start="\<select\>"
+        \ end="\(\_s*\<from\>\)\@="
+        \ fold
+        \ keepend 
+        \ extend
+        \ transparent
+        \ contains=ALLBUT,@plsqlOnlyGroup,plsqlUpdateSet
 
-  if exists("plsql_procedure_fold")
-  " this fails when a begin/end block is in a procedure. Unable to figure out why. - Lee
-
+    " this is brute force and requires you have the procedure/function name in the END
+    " statement. ALthough Oracle makes it optional, we cannot. If you do not
+    " have it, then you can fold the BEGIN/END block of the procedure but not
+    " the specification of it (other than a paren group). You also cannot fold
+    " BEGIN/END blocks in the procedure body. Local procedures will fold as
+    " long as the END statement includes the procedure/function name.
+    " As for why we cannot make it work any other way, I don't know. It is
+    " something to do with both plsqlBlock and plsqlProcedure both consuming BEGIN and END,
+    " even if we use a lookahead for one of them.
     syntax region plsqlProcedure
         "\ start="\(create\(\_s\+or\_s\+replace\)\?\_s\+\)\?\<\(procedure\|function\)\>\_s\+\z([a-z][a-z0-9$_#]*\)"
-        \ start="\(create\(\_s\+or\_s\+replace\)\?\_s\+\)\?\<\(procedure\|function\)\>\_s\+\z([a-z][a-z0-9$_#]*\)\([^;]\|\n\)\{-}\(\_s\+\<\(is\|as\)\>\)\@="
-        \ end="\(\<end\>\(\_s\+\z1\)\?\_s*;\)"
+        \ start="\<\(procedure\|function\)\>\_s\+\(\z([a-z][a-z0-9$_#]*\)\)\([^;]\|\n\)\{-}\<\(is\|as\)\>\_.\{-}\(\<end\>\_s\+\2\_s*;\)\@="
+        \ end="\<end\>\_s\+\z1\_s*;"
         \ fold
+        \ keepend 
         \ extend
         \ transparent
-        \ keepend 
-        \ contains=plsqlProcedureDeclaration,plsqlProcedureBlock,@plsqlCommentAll,plsqlKeyword,plsqlReserved,plsqlTypeAttribute,plsqlStorage
- 
-    syntax region plsqlProcedureDeclaration
-        \ transparent
-        \ fold
-        "\ start="\<\(is\|as\)\>\(\(\_.\)\{-}\<begin\>\)\@="
-        \ start="\<\(is\|as\)\>"
-        \ end="\(\_s\+\<begin\>\)\@="
-        \ nextgroup=plsqlProcedureBlock
-        \ contained
-        \ contains=ALLBUT,plsqlBlockCont,plsqlBlock,plsqlErrInBracket,plsqlPackage,plsqlProcedureDeclaration
-    ",plsqlProcedureBlock
-        \ keepend 
-        "\ extend
-" must have keepend which is weird because it is 0 lenght
-        " ,plsqlEnd,plsqlISAS
-    
-    syntax region plsqlProcedureBlock
-        \ start="\<begin\>"
-        "\ skip="\_s\+\<begin\>\_.\{-}\<end\>\_s*;"
-        \ matchgroup=NONE
-        \ end="\(\<end\>\(\_s\+\(if\|loop\|case\)\@![a-z][a-z0-9$_#]*\)\?\_s*;\)"
-        "\ end="\(\<end\>\)\@="
-        \ fold
-        \ contained
-        \ transparent
-        \ keepend
-        "\ extend
-        \ contains=ALLBUT,plsqlPackage,plsqlProcedure,plsqlProcedureBlock,plsqlProcedureDeclaration,plsqlProcedureJava,plsqlBlock
-
-    "syn cluster plsqlProcedureGroup contains=plsqlProcedure,plsqlProcedureDeclaration,plsqlProcedureBlock
-    syn cluster plsqlProcedureGroup contains=plsqlProcedure,plsqlProcedureDeclaration,plsqlProcedureBlock
-
-    " for inside packages
-    syn region plsqlProcedureSpec
-        \ start="\(procedure\|function\)\(\([^;]\|\n\)\{-}\<\(is\|as\)\>\)\@!"
-        "\ start="\(procedure\|function\)\(\([^;]\|\n\)\{-}\<\(is\|as\)\>\)\@!\(\_.*;\)\@="
-        \ end=";"
-        \ keepend extend
-        \ contains=@plsqlIdentifiers,plsqlKeyword,plsqlReserved,@plsqlCommentAll,plsqlParen
-        \ transparent
-    
-    syntax region plsqlBlockCont
-        \ transparent
-        \ start="\<begin\>"
-        \ end="\<end\>\_s*;"
-        \ fold
-        \ extend
-        \ contained
-        \ contains=ALLBUT,@plsqlProcedureGroup,plsqlPackage,plsqlErrInBracket,PlsqlProcedureJava,plsqlBlock
-        \ keepend
-        "\ end="\<end\>\_s*\;"
-
-    syntax region plsqlProcedureJava
-      \ matchgroup=NONE
-      \ start="\(\/\*\(\(\*\/\)\@!\_.\)*\*\/\_s*\)\?\(\(\(overriding\_s*\)\?member\|constructor\|static\)\_s*\)\?\<\(procedure\|function\)\>\_s*\(\k*\)\_[^;]\{-}\<\(is\|as\)\>\_s*language\_s*java\_s*name"
-      \ matchgroup=plsqlStringLiteral
-      \ end="'\_[^']*'\_s*;"
-      \ keepend extend
-      \ fold
-      \ contains=ALLBUT,plsqlProcedure,plsqlProcedureDeclaration,plsqlProcedureBlock,plsqlBlockCont,plsqlBlock,plsqlProcedureJava,plsqlErrInBracket,plsqlStringLiteral
-    
-    
-"    syntax region plsqlPackage
-"        \ start="\<create\>\_s\+\(or\_s\+replace\_s\+\)\?package\_s\+\(body\_s\+\)\?\z([a-z][a-z0-9$_#]*\)\>"
-"        \ matchgroup=plsqlEnd
-"        \ end="\<end\>\(\%\(\_s\+\z1\)\?\_s*;\)\@="
-"        \ fold
-"        \ transparent
-"        \ keepend extend
-"        \ contains=plsqlProcedure,plsqlBlockCont,@plsqlCommentAll,plsqlKeyword,plsqlReserved,@plsqlIdentifiers
-"        "\ contains=ALLBUT,plsqlPackage,plsqlProcedureDeclaration,plsqlBlock,plsqlConditionalBlock,plsqlLoopBlock,plsqlCaseBlock
-    
-    if exists("plsql_syntax_test_flag") 
-      hi plsqlProcedureDeclaration guifg='blue'
-      hi plsqlProcedureBlock guifg='red'
-      hi plsqlProcedure guifg='green'
-      hi plsqlCaseBlock guifg='pink'
-      hi plsqlBlock NONE
-    else
-      hi plsqlPackage NONE
-      hi plsqlProcedureDeclaration NONE
-      hi plsqlProcedureBlock NONE
-      hi plsqlProcedure NONE
-      hi plsqlBlock NONE
-      hi plsqlCaseBlock NONE
-    endif
-
-  " end plsql_procedure_fold
-  endif
+        \ contains=ALLBUT,plsqlBlock
 
     syntax region plsqlBlock
         \ start="\<begin\>"
@@ -809,7 +746,6 @@ if exists("plsql_fold")
         \ contained
         \ contains=ALLBUT,@plsqlProcedureGroup,plsqlPackage,plsqlErrInBracket,PlsqlProcedureJava
     
-    " Conditionals.
     syn region plsqlConditionalBlock
         \ transparent
         \ start="\<if\>\(\_s*;\)\@!"
@@ -827,45 +763,45 @@ endif
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet.
 
-  hi def link plsqlAttribute	    Macro
-  hi def link plsqlBlockError	    Error
-  hi def link plsqlBooleanLiteral   Boolean
-  hi def link plsqlQuotedIdentifier	Character
-  hi def link plsqlComment	        Comment
-  hi def link plsqlCommentL	        Comment
-  hi def link plsqlConditional	    Keyword
-  hi def link plsqlCase	            Conditional
-  hi def link plsqlError	        Error
-  hi def link plsqlErrInBracket	    Error
-  hi def link plsqlErrInBlock	    Error
-  hi def link plsqlErrInParen	    Error
-  hi def link plsqlException	    Function
-  hi def link plsqlFloatLiteral	    Float
-  hi def link plsqlFunction	        Function
-  hi def link plsqlGarbage	        Error
-  hi def link plsqlHostIdentifier   Label
-  hi def link plsqlIdentifier	    Normal
-  hi def link plsqlIntLiteral	    Number
-  hi def link plsqlOperator	        Operator
-  hi def link plsqlParenError	    Error
-  hi def link plsqlSpaceError	    Error
-  hi def link plsqlPseudo	        PreProc
-  hi def link plsqlKeyword	        Keyword
-  hi def link plsqlEND              Keyword
-  hi def link plsqlBEGIN            Keyword
-  hi def link plsqlISAS             Statement
-  hi def link plsqlReserved         Statement
-  hi def link plsqlRepeat	        Repeat
-  hi def link plsqlStorage	        StorageClass
-  hi def link plsqlFunction  	    Function
-  hi def link plsqlStringError	    Error
-  hi def link plsqlStringLiteral    String
-  hi def link plsqlCommentString    String
-  hi def link plsqlComment2String   String
-  hi def link plsqlTrigger	        Function
-  hi def link plsqlTypeAttribute    StorageClass
-  hi def link plsqlTodo		        Todo
-" to be able to change them, need override whether defined or not
+hi def link plsqlAttribute	        Macro
+hi def link plsqlBlockError	        Error
+hi def link plsqlBooleanLiteral     Boolean
+hi def link plsqlQuotedIdentifier	Character
+hi def link plsqlComment	        Comment
+hi def link plsqlCommentL	        Comment
+hi def link plsqlConditional	    Conditional
+hi def link plsqlCase	            Conditional
+hi def link plsqlError	            Error
+hi def link plsqlErrInBracket	    Error
+hi def link plsqlErrInBlock	        Error
+hi def link plsqlErrInParen	        Error
+hi def link plsqlException	        Function
+hi def link plsqlFloatLiteral	    Float
+hi def link plsqlFunction	        Function
+hi def link plsqlGarbage	        Error
+hi def link plsqlHostIdentifier     Label
+hi def link plsqlIdentifier	        Normal
+hi def link plsqlIntLiteral	        Number
+hi def link plsqlOperator	        Operator
+hi def link plsqlParenError	        Error
+hi def link plsqlSpaceError	        Error
+hi def link plsqlPseudo	            PreProc
+hi def link plsqlKeyword	        Keyword
+hi def link plsqlEND                Keyword
+hi def link plsqlBEGIN              Keyword
+hi def link plsqlISAS               Statement
+hi def link plsqlReserved           Statement
+hi def link plsqlRepeat	            Repeat
+hi def link plsqlStorage	        StorageClass
+hi def link plsqlFunction  	        Function
+hi def link plsqlStringError	    Error
+hi def link plsqlStringLiteral      String
+hi def link plsqlCommentString      String
+hi def link plsqlComment2String     String
+hi def link plsqlTrigger	        Function
+hi def link plsqlTypeAttribute      StorageClass
+hi def link plsqlTodo		        Todo
+" to be able to change them after loading, need override whether defined or not
 if exists("plsql_legacy_sql_keywords")
     hi link plsqlSQLKeyword         Function
     hi link plsqlSymbol	            Normal
@@ -876,6 +812,8 @@ else
 endif
 
 let b:current_syntax = "plsql"
+
+" restore setting from when we entered this file
 let &cpo = s:cpo_sav
 unlet! s:cpo_sav
 

--- a/runtime/syntax/wget.vim
+++ b/runtime/syntax/wget.vim
@@ -1,7 +1,9 @@
 " Vim syntax file
 " Language:     Wget configuration file (/etc/wgetrc ~/.wgetrc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2013 Jun 1
+" Last Change:	2022 Apr 28
+
+" GNU Wget 1.21 built on linux-gnu.
 
 if exists("b:current_syntax")
   finish
@@ -18,155 +20,206 @@ syn region wgetString start=+"+ skip=+\\\\\|\\"+ end=+"+ contained oneline
 syn region wgetString start=+'+ skip=+\\\\\|\\'+ end=+'+ contained oneline
 
 syn case ignore
-syn keyword wgetBoolean on off contained
-syn keyword wgetNumber  inf    contained
-syn case match
 
-syn match wgetNumber "\<\%(\d\+\|inf\)\>" contained
-syn match wgetQuota  "\<\d\+[kKmM]\>"     contained
-syn match wgetTime   "\<\d\+[smhdw]\>"    contained
+syn keyword wgetBoolean on off yes no contained
+syn keyword wgetNumber	inf	      contained
+
+syn match wgetNumber "\<\d\+>"		  contained
+syn match wgetQuota  "\<\d\+[kmgt]\>"	  contained
+syn match wgetTime   "\<\d\+[smhdw]\>"	  contained
 
 "{{{ Commands
-let s:commands = map([
-        \ "accept",
-	\ "add_hostdir",
-	\ "adjust_extension",
-	\ "always_rest",
-	\ "ask_password",
-	\ "auth_no_challenge",
-	\ "background",
-	\ "backup_converted",
-	\ "backups",
-	\ "base",
-	\ "bind_address",
-	\ "ca_certificate",
-	\ "ca_directory",
-	\ "cache",
-	\ "certificate",
-	\ "certificate_type",
-	\ "check_certificate",
-	\ "connect_timeout",
-	\ "content_disposition",
-	\ "continue",
-	\ "convert_links",
-	\ "cookies",
-	\ "cut_dirs",
-	\ "debug",
-	\ "default_page",
-	\ "delete_after",
-	\ "dns_cache",
-	\ "dns_timeout",
-	\ "dir_prefix",
-	\ "dir_struct",
-	\ "domains",
-	\ "dot_bytes",
-	\ "dots_in_line",
-	\ "dot_spacing",
-	\ "dot_style",
-	\ "egd_file",
-	\ "exclude_directories",
-	\ "exclude_domains",
-	\ "follow_ftp",
-	\ "follow_tags",
-	\ "force_html",
-	\ "ftp_passwd",
-	\ "ftp_password",
-	\ "ftp_user",
-	\ "ftp_proxy",
-	\ "glob",
-	\ "header",
-	\ "html_extension",
-	\ "htmlify",
-	\ "http_keep_alive",
-	\ "http_passwd",
-	\ "http_password",
-	\ "http_proxy",
-	\ "https_proxy",
-	\ "http_user",
-	\ "ignore_case",
-	\ "ignore_length",
-	\ "ignore_tags",
-	\ "include_directories",
-	\ "inet4_only",
-	\ "inet6_only",
-	\ "input",
-	\ "iri",
-	\ "keep_session_cookies",
-	\ "kill_longer",
-	\ "limit_rate",
-	\ "load_cookies",
-	\ "locale",
-	\ "local_encoding",
-	\ "logfile",
-	\ "login",
-	\ "max_redirect",
-	\ "mirror",
-	\ "netrc",
-	\ "no_clobber",
-	\ "no_parent",
-	\ "no_proxy",
-	\ "numtries",
-	\ "output_document",
-	\ "page_requisites",
-	\ "passive_ftp",
-	\ "passwd",
-	\ "password",
-	\ "post_data",
-	\ "post_file",
-	\ "prefer_family",
-	\ "preserve_permissions",
-	\ "private_key",
-	\ "private_key_type",
-	\ "progress",
-	\ "protocol_directories",
-	\ "proxy_passwd",
-	\ "proxy_password",
-	\ "proxy_user",
-	\ "quiet",
-	\ "quota",
-	\ "random_file",
-	\ "random_wait",
-	\ "read_timeout",
-	\ "reclevel",
-	\ "recursive",
-	\ "referer",
-	\ "reject",
-	\ "relative_only",
-	\ "remote_encoding",
-	\ "remove_listing",
-	\ "restrict_file_names",
-	\ "retr_symlinks",
-	\ "retry_connrefused",
-	\ "robots",
-	\ "save_cookies",
-	\ "save_headers",
-	\ "secure_protocol",
-	\ "server_response",
-	\ "show_all_dns_entries",
-	\ "simple_host_check",
-	\ "span_hosts",
-	\ "spider",
-	\ "strict_comments",
-	\ "sslcertfile",
-	\ "sslcertkey",
-	\ "timeout",
-	\ "time_stamping",
-	\ "use_server_timestamps",
-	\ "tries",
-	\ "trust_server_names",
-	\ "user",
-	\ "use_proxy",
-	\ "user_agent",
-	\ "verbose",
-	\ "wait",
-	\ "wait_retry"],
-	\ "substitute(v:val, '_', '[-_]\\\\=', 'g')")
+let s:commands =<< trim EOL
+  accept
+  accept_regex
+  add_host_dir
+  adjust_extension
+  always_rest
+  ask_password
+  auth_no_challenge
+  background
+  backup_converted
+  backups
+  base
+  bind_address
+  bind_dns_address
+  body_data
+  body_file
+  ca_certificate
+  ca_directory
+  cache
+  certificate
+  certificate_type
+  check_certificate
+  choose_config
+  ciphers
+  compression
+  connect_timeout
+  content_disposition
+  content_on_error
+  continue
+  convert_file_only
+  convert_links
+  cookies
+  crl_file
+  cut_dirs
+  debug
+  default_page
+  delete_after
+  dns_cache
+  dns_servers
+  dns_timeout
+  dir_prefix
+  dir_struct
+  domains
+  dot_bytes
+  dots_in_line
+  dot_spacing
+  dot_style
+  egd_file
+  exclude_directories
+  exclude_domains
+  follow_ftp
+  follow_tags
+  force_html
+  ftp_passwd
+  ftp_password
+  ftp_user
+  ftp_proxy
+  ftps_clear_data_connection
+  ftps_fallback_to_ftp
+  ftps_implicit
+  ftps_resume_ssl
+  hsts
+  hsts_file
+  ftp_stmlf
+  glob
+  header
+  html_extension
+  htmlify
+  http_keep_alive
+  http_passwd
+  http_password
+  http_proxy
+  https_proxy
+  https_only
+  http_user
+  if_modified_since
+  ignore_case
+  ignore_length
+  ignore_tags
+  include_directories
+  inet4_only
+  inet6_only
+  input
+  input_meta_link
+  iri
+  keep_bad_hash
+  keep_session_cookies
+  kill_longer
+  limit_rate
+  load_cookies
+  locale
+  local_encoding
+  logfile
+  login
+  max_redirect
+  metalink_index
+  metalink_over_http
+  method
+  mirror
+  netrc
+  no_clobber
+  no_config
+  no_parent
+  no_proxy
+  numtries
+  output_document
+  page_requisites
+  passive_ftp
+  passwd
+  password
+  pinned_pubkey
+  post_data
+  post_file
+  prefer_family
+  preferred_location
+  preserve_permissions
+  private_key
+  private_key_type
+  progress
+  protocol_directories
+  proxy_passwd
+  proxy_password
+  proxy_user
+  quiet
+  quota
+  random_file
+  random_wait
+  read_timeout
+  rec_level
+  recursive
+  referer
+  regex_type
+  reject
+  rejected_log
+  reject_regex
+  relative_only
+  remote_encoding
+  remove_listing
+  report_speed
+  restrict_file_names
+  retr_symlinks
+  retry_connrefused
+  retry_on_host_error
+  retry_on_http_error
+  robots
+  save_cookies
+  save_headers
+  secure_protocol
+  server_response
+  show_all_dns_entries
+  show_progress
+  simple_host_check
+  span_hosts
+  spider
+  start_pos
+  strict_comments
+  sslcertfile
+  sslcertkey
+  timeout
+  timestamping
+  use_server_timestamps
+  tries
+  trust_server_names
+  unlink
+  use_askpass
+  user
+  use_proxy
+  user_agent
+  verbose
+  wait
+  wait_retry
+  warc_cdx
+  warc_cdx_dedup
+  warc_compression
+  warc_digests
+  warc_file
+  warc_header
+  warc_keep_log
+  warc_max_size
+  warc_temp_dir
+  wdebug
+  xattr
+EOL
 "}}}
 
-syn case ignore
+call map(s:commands, "substitute(v:val, '_', '[-_]\\\\=', 'g')")
+
 for cmd in s:commands
-  exe 'syn match wgetCommand "' . cmd . '" nextgroup=wgetAssignmentOperator skipwhite contained'
+  exe 'syn match wgetCommand "\<' . cmd . '\>" nextgroup=wgetAssignmentOperator skipwhite contained'
 endfor
+
 syn case match
 
 syn match wgetStart "^" nextgroup=wgetCommand,wgetComment skipwhite
@@ -179,6 +232,7 @@ hi def link wgetComment		   Comment
 hi def link wgetNumber		   Number
 hi def link wgetQuota		   Number
 hi def link wgetString		   String
+hi def link wgetTime		   Number
 hi def link wgetTodo		   Todo
 
 let b:current_syntax = "wget"

--- a/runtime/syntax/wget2.vim
+++ b/runtime/syntax/wget2.vim
@@ -1,0 +1,250 @@
+" Vim syntax file
+" Language:     Wget2 configuration file (/etc/wget2rc ~/.wget2rc)
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2022 Apr 28
+
+" GNU Wget2 2.0.0 - multithreaded metalink/file/website downloader
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn match wgetComment "#.*$" contains=wgetTodo contained
+
+syn keyword wgetTodo TODO NOTE FIXME XXX contained
+
+syn region wgetString start=+"+ skip=+\\\\\|\\"+ end=+"+ contained oneline
+syn region wgetString start=+'+ skip=+\\\\\|\\'+ end=+'+ contained oneline
+
+syn case ignore
+
+syn keyword wgetBoolean on off yes no y n contained
+syn keyword wgetNumber	infinity inf	  contained
+
+syn match wgetNumber "\<\d\+>"		  contained
+syn match wgetQuota  "\<\d\+[kmgt]\>"	  contained
+syn match wgetTime   "\<\d\+[smhd]\>"	  contained
+
+"{{{ Commands
+let s:commands =<< trim EOL
+  accept
+  accept-regex
+  adjust-extension
+  append-output
+  ask-password
+  auth-no-challenge
+  background
+  backup-converted
+  backups
+  base
+  bind-address
+  bind-interface
+  body-data
+  body-file
+  ca-certificate
+  ca-directory
+  cache
+  certificate
+  certificate-type
+  check-certificate
+  check-hostname
+  chunk-size
+  clobber
+  compression
+  config
+  connect-timeout
+  content-disposition
+  content-on-error
+  continue
+  convert-file-only
+  convert-links
+  cookie-suffixes
+  cookies
+  crl-file
+  cut-dirs
+  cut-file-get-vars
+  cut-url-get-vars
+  debug
+  default-http-port
+  default-https-port
+  default-page
+  delete-after
+  directories
+  directory-prefix
+  dns-cache
+  dns-cache-preload
+  dns-timeout
+  domains
+  download-attr
+  egd-file
+  exclude-directories
+  exclude-domains
+  execute
+  filter-mime-type
+  filter-urls
+  follow-tags
+  force-atom
+  force-css
+  force-directories
+  force-html
+  force-metalink
+  force-progress
+  force-rss
+  force-sitemap
+  fsync-policy
+  gnupg-homedir
+  header
+  help
+  host-directories
+  hpkp
+  hpkp-file
+  hsts
+  hsts-file
+  hsts-preload
+  hsts-preload-file
+  html-extension
+  http-keep-alive
+  http-password
+  http-proxy
+  http-proxy-password
+  http-proxy-user
+  http-user
+  http2
+  http2-only
+  http2-request-window
+  https-enforce
+  https-only
+  https-proxy
+  hyperlink
+  if-modified-since
+  ignore-case
+  ignore-length
+  ignore-tags
+  include-directories
+  inet4-only
+  inet6-only
+  input-encoding
+  input-file
+  keep-extension
+  keep-session-cookies
+  level
+  limit-rate
+  list-plugins
+  load-cookies
+  local-db
+  local-encoding
+  local-plugin
+  max-redirect
+  max-threads
+  metalink
+  method
+  mirror
+  netrc
+  netrc-file
+  ocsp
+  ocsp-date
+  ocsp-file
+  ocsp-nonce
+  ocsp-server
+  ocsp-stapling
+  output-document
+  output-file
+  page-requisites
+  parent
+  password
+  plugin
+  plugin-dirs
+  plugin-help
+  plugin-opt
+  post-data
+  post-file
+  prefer-family
+  private-key
+  private-key-type
+  progress
+  protocol-directories
+  proxy
+  quiet
+  quota
+  random-file
+  random-wait
+  read-timeout
+  recursive
+  referer
+  regex-type
+  reject
+  reject-regex
+  remote-encoding
+  report-speed
+  restrict-file-names
+  retry-connrefused
+  retry-on-http-error
+  robots
+  save-content-on
+  save-cookies
+  save-headers
+  secure-protocol
+  server-response
+  signature-extensions
+  span-hosts
+  spider
+  start-pos
+  stats-dns
+  stats-ocsp
+  stats-server
+  stats-site
+  stats-tls
+  strict-comments
+  tcp-fastopen
+  timeout
+  timestamping
+  tls-false-start
+  tls-resume
+  tls-session-file
+  tries
+  trust-server-names
+  unlink
+  use-askpass
+  use-server-timestamps
+  user
+  user-agent
+  verbose
+  verify-save-failed
+  verify-sig
+  version
+  wait
+  waitretry
+  xattr
+EOL
+"}}}
+
+call map(s:commands, "substitute(v:val, '_', '[-_]\\\\=', 'g')")
+
+for cmd in s:commands
+  exe 'syn match wgetCommand "\<' . cmd . '\>" nextgroup=wgetAssignmentOperator skipwhite contained'
+endfor
+
+syn case match
+
+syn match wgetStart "^" nextgroup=wgetCommand,wgetComment skipwhite
+syn match wgetAssignmentOperator "=" nextgroup=wgetString,wgetBoolean,wgetNumber,wgetQuota,wgetTime skipwhite contained
+
+hi def link wgetAssignmentOperator Special
+hi def link wgetBoolean		   Boolean
+hi def link wgetCommand		   Identifier
+hi def link wgetComment		   Comment
+hi def link wgetNumber		   Number
+hi def link wgetQuota		   Number
+hi def link wgetString		   String
+hi def link wgetTime		   Number
+hi def link wgetTodo		   Todo
+
+let b:current_syntax = "wget"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: ts=8 fdm=marker:


### PR DESCRIPTION
Noticed a new rt update and had a bit of time. Hopefully you don't mind me snatching this one @clason :smile:  
I'll address reviews in the morn :zzz:

Update runtime files
https://github.com/vim/vim/commit/d899e51120798d3fb5420abb1f19dddf3f014d05

- Skip vimhelp.vim stuff (syntax/help.vim, syntax.txt; v8.2.4891).
- Skip :let heredoc eval stuff (eval.txt; v8.2.4770).
- Skip uk.cp1251.po.
- Skip `*hl-CurSearch*` change (syntax.txt):
  - Vim's CurSearch works differently (Nvim's uses current cursor pos).
    Dunno know how applicable the redrawing comment is to Nvim...
  - Might be preferred to move it under `*hl-Search*` like Vim?