### PR TITLE
fix(lsp): detach spawned LSP server processes

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -787,6 +787,13 @@ start_client({config})                                *vim.lsp.start_client()*
 
                  { "PRODUCTION=true"; "TEST=123"; PORT = 8080; HOST = "0.0.0.0"; }
 <
+                    {detached}           (boolean, default true) Daemonize the
+                                         server process so that it runs in a
+                                         separate process group from Nvim.
+                                         Nvim will shutdown the process on
+                                         exit, but if Nvim fails to exit
+                                         cleanly this could leave behind
+                                         orphaned server processes.
                     {workspace_folders}  (table) List of workspace folders
                                          passed to the language server. For
                                          backwards compatibility rootUri and

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -241,6 +241,7 @@ local function validate_client_config(config)
     capabilities    = { config.capabilities, "t", true };
     cmd_cwd         = { config.cmd_cwd, optional_validator(is_dir), "directory" };
     cmd_env         = { config.cmd_env, "t", true };
+    detached        = { config.detached, "b", true };
     name            = { config.name, 's', true };
     on_error        = { config.on_error, "f", true };
     on_exit         = { config.on_exit, "f", true };
@@ -663,6 +664,10 @@ end
 --- { "PRODUCTION=true"; "TEST=123"; PORT = 8080; HOST = "0.0.0.0"; }
 --- </pre>
 ---
+---@param detached: (boolean, default true) Daemonize the server process so that it runs in a
+--- separate process group from Nvim. Nvim will shutdown the process on exit, but if Nvim fails to
+--- exit cleanly this could leave behind orphaned server processes.
+---
 ---@param workspace_folders (table) List of workspace folders passed to the
 --- language server. For backwards compatibility rootUri and rootPath will be
 --- derived from the first workspace folder in this list. See `workspaceFolders` in
@@ -859,6 +864,7 @@ function lsp.start_client(config)
   local rpc = lsp_rpc.start(cmd, cmd_args, dispatch, {
     cwd = config.cmd_cwd;
     env = config.cmd_env;
+    detached = config.detached;
   })
 
   -- Return nil if client fails to start

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -319,10 +319,14 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
     local spawn_params = {
       args = cmd_args;
       stdio = {stdin, stdout, stderr};
+      detached = true;
     }
     if extra_spawn_params then
       spawn_params.cwd = extra_spawn_params.cwd
       spawn_params.env = env_merge(extra_spawn_params.env)
+      if extra_spawn_params.detached ~= nil then
+        spawn_params.detached = extra_spawn_params.detached
+      end
     end
     handle, pid = uv.spawn(cmd, spawn_params, onexit)
     if handle == nil then


### PR DESCRIPTION
LSP servers should be daemonized (detached) so that they run in a
separate process group from Neovim's. Among other things, this ensures
the process does not inherit Neovim's TTY.

Closes #18475.
