### PR TITLE
fix(runtime/genvimvim): omit s[ubstitute] from vimCommand

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -120,9 +120,6 @@ else
  com! -nargs=*	VimFoldt	<args>
 endif
 
-" commands not picked up by the generator (due to non-standard format) {{{2
-syn keyword vimCommand contained	py3
-
 " Deprecated variable options {{{2
 if exists("g:vim_minlines")
  let g:vimsyn_minlines= g:vim_minlines

--- a/scripts/genvimvim.lua
+++ b/scripts/genvimvim.lua
@@ -44,12 +44,13 @@ local function cmd_kw(prev_cmd, cmd)
 end
 
 -- Exclude these from the vimCommand keyword list, they are handled specially
--- in syntax/vim.vim (vimAugroupKey, vimAutoCmd). #9327
-local function is_autocmd_cmd(cmd)
+-- in syntax/vim.vim (vimAugroupKey, vimAutoCmd, vimSubst). #9327
+local function is_special_cased_cmd(cmd)
   return (cmd == 'augroup'
           or cmd == 'autocmd'
           or cmd == 'doautocmd'
-          or cmd == 'doautoall')
+          or cmd == 'doautoall'
+          or cmd == 'substitute')
 end
 
 local vimcmd_start = 'syn keyword vimCommand contained '
@@ -60,7 +61,7 @@ for _, cmd_desc in ipairs(ex_cmds.cmds) do
     w('\n' .. vimcmd_start)
   end
   local cmd = cmd_desc.command
-  if cmd:match('%w') and cmd ~= 'z' and not is_autocmd_cmd(cmd) then
+  if cmd:match('%w') and cmd ~= 'z' and not is_special_cased_cmd(cmd) then
     w(' ' .. cmd_kw(prev_cmd, cmd))
   end
   prev_cmd = cmd


### PR DESCRIPTION
It's special cased by the vimSubst syntax group, and isn't present in Vim's
vimCommand group.

For example, this fixes `call s:Foo()` highlighting `:` as Error in Nvim, as the
`s` is parsed as vimCommand rather than as vimUserFunc since
`contains=vimCommand` was added to vimUserFunc (and vimFunc) in a rt update.

Interestingly, `g:`, `l:`, etc. have the same issues due to :global, :list, etc.
Vim also has that problem, so it should ideally be fixed upstream.

_We could also omit g[lobal] from vimCommand and rely on vimGlobal instead, but
it doesn't work in some cases, like when there's a `:` before the command. Also,
Vim matches only `g` in vimCommand for some reason, which doesn't produce any
highlight for `:global/foo/bar` (with Nvim you at least get some highlights on
the `global` bit despite the leading `:`)._

Also, remove special handling of :py3 in syntax/vim.vim, as the generator seems
to have no problems finding it.