### PR TITLE
vim-patch:8.2.4915: sometimes the cursor is in the wrong position

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -418,7 +418,8 @@ void check_cursor_moved(win_T *wp)
 {
   if (wp->w_cursor.lnum != wp->w_valid_cursor.lnum) {
     wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL
-                     |VALID_CHEIGHT|VALID_CROW|VALID_TOPLINE);
+                     |VALID_CHEIGHT|VALID_CROW|VALID_TOPLINE
+                     |VALID_BOTLINE|VALID_BOTLINE_AP);
     wp->w_valid_cursor = wp->w_cursor;
     wp->w_valid_leftcol = wp->w_leftcol;
     wp->w_viewport_invalid = true;


### PR DESCRIPTION
#### vim-patch:8.2.4915: sometimes the cursor is in the wrong position

Problem:    Sometimes the cursor is in the wrong position.
Solution:   When the cursor moved to another line, recompute w_botline.
https://github.com/vim/vim/commit/a91cb98bb36b0f9dc3c378c0bbd9a69de29830fa
