### PR TITLE
vim-patch:8.2.{4916,4922}: mouse in Insert mode test fails

### DIFF
--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1141,26 +1141,36 @@ endfunc
 
 func Test_edit_MOUSE()
   " This is a simple test, since we not really using the mouse here
-  if !has("mouse")
-    return
-  endif
+  CheckFeature mouse
   10new
   call setline(1, range(1, 100))
   call cursor(1, 1)
+  call assert_equal(1, line('w0'))
+  call assert_equal(10, line('w$'))
   set mouse=a
+  " One scroll event moves three lines.
   call feedkeys("A\<ScrollWheelDown>\<esc>", 'tnix')
-  call assert_equal([0, 4, 1, 0], getpos('.'))
-  " This should move by one pageDown, but only moves
-  " by one line when the test is run...
+  call assert_equal(4, line('w0'))
+  call assert_equal(13, line('w$'))
+  " This should move by one page down.
   call feedkeys("A\<S-ScrollWheelDown>\<esc>", 'tnix')
-  call assert_equal([0, 5, 1, 0], getpos('.'))
+  call assert_equal(14, line('w0'))
   set nostartofline
+  " Another page down.
   call feedkeys("A\<C-ScrollWheelDown>\<esc>", 'tnix')
-  call assert_equal([0, 6, 1, 0], getpos('.'))
+  call assert_equal(24, line('w0'))
+
+  call assert_equal([0, 24, 2, 0], getpos('.'))
+  " call test_setmouse(4, 3)
+  call nvim_input_mouse('left', 'press', '', 0, 3, 2) " set mouse position
+  call getchar() " discard mouse event but keep mouse position
   call feedkeys("A\<LeftMouse>\<esc>", 'tnix')
-  call assert_equal([0, 6, 1, 0], getpos('.'))
-  call feedkeys("A\<RightMouse>\<esc>", 'tnix')
-  call assert_equal([0, 6, 1, 0], getpos('.'))
+  call assert_equal([0, 27, 2, 0], getpos('.'))
+  " call test_setmouse(5, 3)
+  call nvim_input_mouse('right', 'press', '', 0, 4, 2) " set mouse position
+  call getchar() " discard mouse event but keep mouse position
+  call feedkeys("A\<RightMouse>\<esc>\<esc>", 'tnix')
+  call assert_equal([0, 28, 2, 0], getpos('.'))
   call cursor(1, 100)
   norm! zt
   " this should move by a screen up, but when the test

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1166,11 +1166,13 @@ func Test_edit_MOUSE()
   call getchar() " discard mouse event but keep mouse position
   call feedkeys("A\<LeftMouse>\<esc>", 'tnix')
   call assert_equal([0, 27, 2, 0], getpos('.'))
+  set mousemodel=extend
   " call test_setmouse(5, 3)
   call nvim_input_mouse('right', 'press', '', 0, 4, 2) " set mouse position
   call getchar() " discard mouse event but keep mouse position
   call feedkeys("A\<RightMouse>\<esc>\<esc>", 'tnix')
   call assert_equal([0, 28, 2, 0], getpos('.'))
+  set mousemodel&
   call cursor(1, 100)
   norm! zt
   " this should move by a screen up, but when the test


### PR DESCRIPTION
#### vim-patch:8.2.4916: mouse in Insert mode test fails

Problem:    Mouse in Insert mode test fails.
Solution:   Fix the text and check relevant positions.
https://github.com/vim/vim/commit/8e8dc9b32326c6fbd37671b6072296404b481d4a

Use nvim_input_mouse() to set mouse position, and discard mouse event
using getchar().


#### vim-patch:8.2.4922: mouse test fails on MS-Windows

Problem:    Mouse test fails on MS-Windows.
Solution:   Set 'mousemodel' to "extend".
https://github.com/vim/vim/commit/b370771bffc8395204f53209b69e35dff95a9237