### PR TITLE
vim-patch:8.2.{4918,4923}: conceal character from matchadd() displayed too many times

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3666,13 +3666,12 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       }
 
       if (wp->w_p_cole > 0
-          && (wp != curwin || lnum != wp->w_cursor.lnum
-              || conceal_cursor_line(wp))
+          && (wp != curwin || lnum != wp->w_cursor.lnum || conceal_cursor_line(wp))
           && ((syntax_flags & HL_CONCEAL) != 0 || has_match_conc > 0 || decor_conceal > 0)
-          && !(lnum_in_visual_area
-               && vim_strchr(wp->w_p_cocu, 'v') == NULL)) {
+          && !(lnum_in_visual_area && vim_strchr(wp->w_p_cocu, 'v') == NULL)) {
         char_attr = conceal_attr;
-        if ((prev_syntax_id != syntax_seqnr || has_match_conc > 1 || decor_conceal > 1)
+        if (((prev_syntax_id != syntax_seqnr && (syntax_flags & HL_CONCEAL) != 0)
+             || has_match_conc > 1 || decor_conceal > 1)
             && (syn_get_sub_char() != NUL
                 || (has_match_conc && match_conc)
                 || (decor_conceal && decor_state.conceal_char)

--- a/src/nvim/testdir/test_matchadd_conceal.vim
+++ b/src/nvim/testdir/test_matchadd_conceal.vim
@@ -335,6 +335,27 @@ func Test_matchadd_and_syn_conceal()
   call assert_equal(screenattr(1, 11) , screenattr(1, 32))
 endfunc
 
+func Test_interaction_matchadd_syntax()
+  CheckRunVimInTerminal
+
+  new
+  " Test for issue #7268 fix.
+  " When redrawing the second column, win_line() was comparing the sequence
+  " number of the syntax-concealed region with a bogus zero value that was
+  " returned for the matchadd-concealed region. Before 8.0.0672 the sequence
+  " number was never reset, thus masking the problem.
+  call setline(1, 'aaa|bbb|ccc')
+  call matchadd('Conceal', '^..', 10, -1, #{conceal: 'X'})
+  syn match foobar '^.'
+  setl concealcursor=n conceallevel=1
+  redraw!
+
+  call assert_equal('Xa|bbb|ccc', Screenline(1))
+  call assert_notequal(screenattr(1, 1), screenattr(1, 2))
+
+  bwipe!
+endfunc
+
 func Test_cursor_column_in_concealed_line_after_window_scroll()
   CheckRunVimInTerminal
 

--- a/src/nvim/testdir/test_matchadd_conceal.vim
+++ b/src/nvim/testdir/test_matchadd_conceal.vim
@@ -336,8 +336,6 @@ func Test_matchadd_and_syn_conceal()
 endfunc
 
 func Test_interaction_matchadd_syntax()
-  CheckRunVimInTerminal
-
   new
   " Test for issue #7268 fix.
   " When redrawing the second column, win_line() was comparing the sequence


### PR DESCRIPTION
#### vim-patch:8.2.4918: conceal character from matchadd() displayed too many times

Problem:    Conceal character from matchadd() displayed too many times.
Solution:   Check the syntax flag. (closes vim/vim#10381)
https://github.com/vim/vim/commit/9830db63057db76044eca89cc4cfb2758ae7a543


#### vim-patch:8.2.4923: test checks for terminal feature unnecessarily

Problem:    Test checks for terminal feature unnecessarily.
Solution:   Remove CheckRunVimInTerminal. (closes vim/vim#10383)
https://github.com/vim/vim/commit/194843028ed486366b89e8f7d3bdd611a11ce7b4