### PR TITLE
vim-patch:8.2.4925: trailing backslash may cause reading past end of line

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3969,6 +3969,9 @@ static int find_next_quote(char_u *line, int col, int quotechar, char_u *escape)
       return -1;
     } else if (escape != NULL && vim_strchr(escape, c)) {
       col++;
+      if (line[col] == NUL) {
+        return -1;
+      }
     } else if (c == quotechar) {
       break;
     }

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -188,10 +188,18 @@ func Test_string_html_objects()
     call assert_equal("<div><div\nattr=\"attr\"\n></div></div>", @", e)
 
     set quoteescape&
+
+    " this was going beyond the end of the line
+    %del
+    sil! norm i"\
+    sil! norm i"\
+    sil! norm i"\
+    call assert_equal('"\', getline(1))
+
+    bwipe!
   endfor
 
   set enc=utf-8
-  bwipe!
 endfunc
 
 func Test_empty_html_tag()


### PR DESCRIPTION
#### vim-patch:8.2.4925: trailing backslash may cause reading past end of line

Problem:    Trailing backslash may cause reading past end of line.
Solution:   Check for NUL after backslash.
https://github.com/vim/vim/commit/53a70289c2712808e6d4e88927e03cac01b470dd

N/A patches for version.c:

vim-patch:8.2.4926: #ifdef for crypt feature around too many lines

Problem:    #ifdef for crypt feature around too many lines.
Solution:   Move code outside of #ifdef. (closes vim/vim#10388)
https://github.com/vim/vim/commit/51f0bc31d3cf512508419064faac0e5b7e52c98b