### PR TITLE
docs: make default-mappings more discoverable

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -105,7 +105,7 @@ modes.
 			command applies.
 			Use the <buffer> argument to remove buffer-local
 			mappings |:map-<buffer>|
-			Warning: This also removes the default mappings.
+			Warning: This also removes the |default-mappings|.
 
 :map				|mapmode-nvo|
 :nm[ap]				|mapmode-n|


### PR DESCRIPTION
It's easy for a newish user to take "default mappings" to refer to the
built-in commands (`dd`, etc.). Then `:mapclear` seems not to work since
it doesn't disable the built-ins, it just unmaps the `default-mappings`.
This link should help with discoverability.