### PR TITLE
vim-patch:8.2.4911: the mode #defines are not clearly named

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -657,8 +657,7 @@ void modify_keymap(uint64_t channel_id, Buffer buffer, bool is_unmap, String mod
     mode_val = get_map_mode(&p, true);  // mapmode-ic
   } else {
     mode_val = get_map_mode(&p, false);
-    if ((mode_val == VISUAL + SELECTMODE + NORMAL + OP_PENDING)
-        && mode.size > 0) {
+    if (mode_val == (MODE_VISUAL | MODE_SELECT | MODE_NORMAL | MODE_OP_PENDING) && mode.size > 0) {
       // get_map_mode() treats unrecognized mode shortnames as ":map".
       // This is an error unless the given shortname was empty string "".
       api_set_error(err, kErrorTypeValidation, "Invalid mode shortname: \"%s\"", p);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1327,14 +1327,14 @@ Boolean nvim_paste(String data, Boolean crlf, Integer phase, Error *err)
     draining = true;
     goto theend;
   }
-  if (!(State & (CMDLINE | INSERT)) && (phase == -1 || phase == 1)) {
+  if (!(State & (MODE_CMDLINE | MODE_INSERT)) && (phase == -1 || phase == 1)) {
     ResetRedobuff();
     AppendCharToRedobuff('a');  // Dot-repeat.
   }
   // vim.paste() decides if client should cancel.  Errors do NOT cancel: we
   // want to drain remaining chunks (rather than divert them to main input).
   cancel = (rv.type == kObjectTypeBoolean && !rv.data.boolean);
-  if (!cancel && !(State & CMDLINE)) {  // Dot-repeat.
+  if (!cancel && !(State & MODE_CMDLINE)) {  // Dot-repeat.
     for (size_t i = 0; i < lines.size; i++) {
       String s = lines.items[i].data.string;
       assert(s.size <= INT_MAX);
@@ -1345,7 +1345,7 @@ Boolean nvim_paste(String data, Boolean crlf, Integer phase, Error *err)
       }
     }
   }
-  if (!(State & (CMDLINE | INSERT)) && (phase == -1 || phase == 3)) {
+  if (!(State & (MODE_CMDLINE | MODE_INSERT)) && (phase == -1 || phase == 3)) {
     AppendCharToRedobuff(ESC);  // Dot-repeat.
   }
 theend:

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1568,7 +1568,7 @@ bool has_event(event_T event) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 /// the current mode.
 bool has_cursorhold(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  return has_event((get_real_state() == NORMAL_BUSY ? EVENT_CURSORHOLD : EVENT_CURSORHOLDI));
+  return has_event((get_real_state() == MODE_NORMAL_BUSY ? EVENT_CURSORHOLD : EVENT_CURSORHOLDI));
   // return first_autopat[] != NULL;
 }
 
@@ -1578,7 +1578,7 @@ bool trigger_cursorhold(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
   if (!did_cursorhold && has_cursorhold() && reg_recording == 0
       && typebuf.tb_len == 0 && !ins_compl_active()) {
     int state = get_real_state();
-    if (state == NORMAL_BUSY || (state & INSERT) != 0) {
+    if (state == MODE_NORMAL_BUSY || (state & MODE_INSERT) != 0) {
       return true;
     }
   }
@@ -2706,9 +2706,9 @@ static void do_autocmd_focusgained(bool gained)
     // belongs.
     need_wait_return = false;
 
-    if (State & CMDLINE) {
+    if (State & MODE_CMDLINE) {
       redrawcmdline();
-    } else if ((State & NORMAL) || (State & INSERT)) {
+    } else if ((State & MODE_NORMAL) || (State & MODE_INSERT)) {
       if (must_redraw != 0) {
         update_screen(0);
       }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1476,7 +1476,7 @@ void set_curbuf(buf_T *buf, int action)
       // Do not sync when in Insert mode and the buffer is open in
       // another window, might be a timer doing something in another
       // window.
-      if (prevbuf == curbuf && ((State & INSERT) == 0 || curbuf->b_nwindows <= 1)) {
+      if (prevbuf == curbuf && ((State & MODE_INSERT) == 0 || curbuf->b_nwindows <= 1)) {
         u_sync(false);
       }
       close_buffer(prevbuf == curwin->w_buffer ? curwin : NULL,
@@ -3961,8 +3961,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
       break;
 
     case STL_COLUMN:
-      num = !(State & INSERT) && empty_line
-            ? 0 : (int)wp->w_cursor.col + 1;
+      num = (State & MODE_INSERT) == 0 && empty_line ? 0 : (int)wp->w_cursor.col + 1;
       break;
 
     case STL_VIRTCOL:
@@ -3970,7 +3969,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
       colnr_T virtcol = wp->w_virtcol + 1;
       // Don't display %V if it's the same as %c.
       if (opt == STL_VIRTCOL_ALT
-          && (virtcol == (colnr_T)(!(State & INSERT) && empty_line
+          && (virtcol == (colnr_T)((State & MODE_INSERT) == 0 && empty_line
                                    ? 0 : (int)wp->w_cursor.col + 1))) {
         break;
       }
@@ -4028,7 +4027,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
       long l = ml_find_line_or_offset(wp->w_buffer, wp->w_cursor.lnum, NULL,
                                       false);
       num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) || l < 0 ?
-            0L : l + 1 + (!(State & INSERT) && empty_line ?
+            0L : l + 1 + ((State & MODE_INSERT) == 0 && empty_line ?
                           0 : (int)wp->w_cursor.col);
       break;
     }

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -254,7 +254,7 @@ void buf_updates_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
-    if (cb.on_lines != LUA_NOREF && (cb.preview || !(State & CMDPREVIEW))) {
+    if (cb.on_lines != LUA_NOREF && (cb.preview || !(State & MODE_CMDPREVIEW))) {
       Array args = ARRAY_DICT_INIT;
       Object items[8];
       args.size = 6;  // may be increased to 8 below
@@ -313,7 +313,7 @@ void buf_updates_send_splice(buf_T *buf, int start_row, colnr_T start_col, bcoun
   for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
-    if (cb.on_bytes != LUA_NOREF && (cb.preview || !(State & CMDPREVIEW))) {
+    if (cb.on_bytes != LUA_NOREF && (cb.preview || !(State & MODE_CMDPREVIEW))) {
       FIXED_TEMP_ARRAY(args, 11);
 
       // the first argument is always the buffer handle

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1015,7 +1015,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
 
   if (cursor != NULL) {
     if ((*ptr == TAB)
-        && (State & NORMAL)
+        && (State & MODE_NORMAL)
         && !wp->w_p_list
         && !virtual_active()
         && !(VIsual_active && ((*p_sel == 'e') || ltoreq(*pos, VIsual)))) {

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -95,8 +95,8 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
   colnr_T col = 0;
   int head = 0;
 
-  int one_more = (State & INSERT)
-                 || (State & TERM_FOCUS)
+  int one_more = (State & MODE_INSERT)
+                 || (State & MODE_TERMINAL)
                  || restart_edit != NUL
                  || (VIsual_active && *p_sel != 'o')
                  || ((get_ve_flags() & VE_ONEMORE) && wcol < MAXCOL);
@@ -128,7 +128,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
       }
 
       if (wcol / width > (colnr_T)csize / width
-          && ((State & INSERT) == 0 || (int)wcol > csize + 1)) {
+          && ((State & MODE_INSERT) == 0 || (int)wcol > csize + 1)) {
         // In case of line wrapping don't move the cursor beyond the
         // right screen edge.  In Insert mode allow going just beyond
         // the last character (like what happens when typing and
@@ -350,7 +350,7 @@ void check_cursor_col_win(win_T *win)
     // - in Insert mode or restarting Insert mode
     // - in Visual mode and 'selection' isn't "old"
     // - 'virtualedit' is set */
-    if ((State & INSERT) || restart_edit
+    if ((State & MODE_INSERT) || restart_edit
         || (VIsual_active && *p_sel != 'o')
         || (cur_ve_flags & VE_ONEMORE)
         || virtual_active()) {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -320,15 +320,15 @@ bool cursor_mode_uses_syn_id(int syn_id)
 int cursor_get_mode_idx(void)
   FUNC_ATTR_PURE
 {
-  if (State == SHOWMATCH) {
+  if (State == MODE_SHOWMATCH) {
     return SHAPE_IDX_SM;
   } else if (State & VREPLACE_FLAG) {
     return SHAPE_IDX_R;
   } else if (State & REPLACE_FLAG) {
     return SHAPE_IDX_R;
-  } else if (State & INSERT) {
+  } else if (State & MODE_INSERT) {
     return SHAPE_IDX_I;
-  } else if (State & CMDLINE) {
+  } else if (State & MODE_CMDLINE) {
     if (cmdline_at_end()) {
       return SHAPE_IDX_C;
     } else if (cmdline_overstrike()) {

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -83,7 +83,7 @@ void do_debug(char_u *cmd)
   emsg_silent = false;          // display error messages
   redir_off = true;             // don't redirect debug commands
 
-  State = NORMAL;
+  State = MODE_NORMAL;
   debug_mode = true;
 
   if (!debug_did_msg) {

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -2122,7 +2122,7 @@ void ex_loadkeymap(exarg_T *eap)
     vim_snprintf((char *)buf, sizeof(buf), "<buffer> %s %s",
                  ((kmap_T *)curbuf->b_kmap_ga.ga_data)[i].from,
                  ((kmap_T *)curbuf->b_kmap_ga.ga_data)[i].to);
-    (void)do_map(0, buf, LANGMAP, false);
+    (void)do_map(0, buf, MODE_LANGMAP, false);
   }
 
   p_cpo = save_cpo;
@@ -2159,7 +2159,7 @@ static void keymap_unload(void)
 
   for (int i = 0; i < curbuf->b_kmap_ga.ga_len; i++) {
     vim_snprintf((char *)buf, sizeof(buf), "<buffer> %s", kp[i].from);
-    (void)do_map(1, buf, LANGMAP, false);
+    (void)do_map(1, buf, MODE_LANGMAP, false);
   }
   keymap_ga_clear(&curbuf->b_kmap_ga);
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1064,7 +1064,7 @@ static void f_col(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "complete()" function
 static void f_complete(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if ((State & INSERT) == 0) {
+  if ((State & MODE_INSERT) == 0) {
     emsg(_("E785: complete() can only be used in Insert mode"));
     return;
   }
@@ -11211,7 +11211,7 @@ static void f_visualmode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "wildmenumode()" function
 static void f_wildmenumode(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (wild_menu_showing || ((State & CMDLINE) && pum_visible())) {
+  if (wild_menu_showing || ((State & MODE_CMDLINE) && pum_visible())) {
     rettv->vval.v_number = 1;
   }
 }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2875,7 +2875,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     redraw_curbuf_later(NOT_VALID);     // redraw this buffer later
   }
 
-  if (p_im && (State & INSERT) == 0) {
+  if (p_im && (State & MODE_INSERT) == 0) {
     need_start_insertmode = true;
   }
 
@@ -2939,9 +2939,9 @@ void ex_append(exarg_T *eap)
     lnum = 0;
   }
 
-  State = INSERT;                   // behave like in Insert mode
+  State = MODE_INSERT;                   // behave like in Insert mode
   if (curbuf->b_p_iminsert == B_IMODE_LMAP) {
-    State |= LANGMAP;
+    State |= MODE_LANGMAP;
   }
 
   for (;;) {
@@ -2971,10 +2971,10 @@ void ex_append(exarg_T *eap)
       }
       eap->nextcmd = p;
     } else {
-      // Set State to avoid the cursor shape to be set to INSERT mode
-      // when getline() returns.
       int save_State = State;
-      State = CMDLINE;
+      // Set State to avoid the cursor shape to be set to MODE_INSERT
+      // state when getline() returns.
+      State = MODE_CMDLINE;
       theline = (char *)eap->getline(eap->cstack->cs_looplevel > 0 ? -1 :
                                      NUL, eap->cookie, indent, true);
       State = save_State;
@@ -3024,7 +3024,7 @@ void ex_append(exarg_T *eap)
       empty = 0;
     }
   }
-  State = NORMAL;
+  State = MODE_NORMAL;
 
   if (eap->forceit) {
     curbuf->b_p_ai = !curbuf->b_p_ai;
@@ -3477,7 +3477,7 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
   int start_nsubs;
   int save_ma = 0;
   int save_b_changed = curbuf->b_changed;
-  bool preview = (State & CMDPREVIEW);
+  bool preview = (State & MODE_CMDPREVIEW);
 
   bool did_save = false;
 
@@ -3823,10 +3823,10 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
         if (subflags.do_ask && !preview) {
           int typed = 0;
 
-          // change State to CONFIRM, so that the mouse works
+          // change State to MODE_CONFIRM, so that the mouse works
           // properly
           int save_State = State;
-          State = CONFIRM;
+          State = MODE_CONFIRM;
           setmouse();                   // disable mouse in xterm
           curwin->w_cursor.col = regmatch.startpos[0].col;
 
@@ -6050,7 +6050,7 @@ void close_preview_windows(void)
 /// from undo history.
 void ex_substitute(exarg_T *eap)
 {
-  bool preview = (State & CMDPREVIEW);
+  bool preview = (State & MODE_CMDPREVIEW);
   if (*p_icm == NUL || !preview) {  // 'inccommand' is disabled
     close_preview_windows();
     (void)do_sub(eap, profile_zero(), true, preview_bufnr);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -187,7 +187,7 @@ void do_exmode(void)
   varnumber_T changedtick;
 
   exmode_active = true;
-  State = NORMAL;
+  State = MODE_NORMAL;
   may_trigger_modechanged();
 
   // When using ":global /pat/ visual" and then "Q" we return to continue
@@ -595,7 +595,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
     recursive--;
 
     // Ignore trailing '|'-separated commands in preview-mode ('inccommand').
-    if ((State & CMDPREVIEW) && (flags & DOCMD_PREVIEW)) {
+    if ((State & MODE_CMDPREVIEW) && (flags & DOCMD_PREVIEW)) {
       next_cmdline = NULL;
     }
 
@@ -8584,7 +8584,7 @@ static void ex_redir(exarg_T *eap)
 /// ":redraw": force redraw
 static void ex_redraw(exarg_T *eap)
 {
-  if (State & CMDPREVIEW) {
+  if (State & MODE_CMDPREVIEW) {
     return;  // Ignore :redraw during 'inccommand' preview. #9777
   }
   int r = RedrawingDisabled;
@@ -8618,7 +8618,7 @@ static void ex_redraw(exarg_T *eap)
 /// ":redrawstatus": force redraw of status line(s)
 static void ex_redrawstatus(exarg_T *eap)
 {
-  if (State & CMDPREVIEW) {
+  if (State & MODE_CMDPREVIEW) {
     return;  // Ignore :redrawstatus during 'inccommand' preview. #9777
   }
   int r = RedrawingDisabled;
@@ -8802,7 +8802,7 @@ void restore_current_state(save_state_T *sst)
 /// ":normal[!] {commands}": Execute normal mode commands.
 static void ex_normal(exarg_T *eap)
 {
-  if (curbuf->terminal && State & TERM_FOCUS) {
+  if (curbuf->terminal && State & MODE_TERMINAL) {
     emsg("Can't re-enter normal mode from terminal mode");
     return;
   }
@@ -8893,7 +8893,7 @@ static void ex_startinsert(exarg_T *eap)
 
   // Ignore the command when already in Insert mode.  Inserting an
   // expression register that invokes a function can do this.
-  if (State & INSERT) {
+  if (State & MODE_INSERT) {
     return;
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -841,7 +841,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
   // doing ":@0" when register 0 doesn't contain a CR.
   msg_scroll = false;
 
-  State = CMDLINE;
+  State = MODE_CMDLINE;
 
   if (s->firstc == '/' || s->firstc == '?' || s->firstc == '@') {
     // Use ":lmap" mappings for search pattern and input().
@@ -852,7 +852,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
     }
 
     if (*s->b_im_ptr == B_IMODE_LMAP) {
-      State |= LANGMAP;
+      State |= MODE_LANGMAP;
     }
   }
 
@@ -1831,11 +1831,11 @@ static int command_line_handle_key(CommandLineState *s)
     return command_line_not_changed(s);
 
   case Ctrl_HAT:
-    if (map_to_exists_mode("", LANGMAP, false)) {
+    if (map_to_exists_mode("", MODE_LANGMAP, false)) {
       // ":lmap" mappings exists, toggle use of mappings.
-      State ^= LANGMAP;
+      State ^= MODE_LANGMAP;
       if (s->b_im_ptr != NULL) {
-        if (State & LANGMAP) {
+        if (State & MODE_LANGMAP) {
           *s->b_im_ptr = B_IMODE_LMAP;
         } else {
           *s->b_im_ptr = B_IMODE_NONE;
@@ -2353,10 +2353,10 @@ static int command_line_changed(CommandLineState *s)
       && !vpeekc_any()) {
     // Show 'inccommand' preview. It works like this:
     //    1. Do the command.
-    //    2. Command implementation detects CMDPREVIEW state, then:
+    //    2. Command implementation detects MODE_CMDPREVIEW state, then:
     //       - Update the screen while the effects are in place.
     //       - Immediately undo the effects.
-    State |= CMDPREVIEW;
+    State |= MODE_CMDPREVIEW;
     emsg_silent++;  // Block error reporting as the command may be incomplete
     msg_silent++;   // Block messages, namely ones that prompt
     do_cmdline((char *)ccline.cmdbuff, NULL, NULL, DOCMD_KEEPLINE|DOCMD_NOWAIT|DOCMD_PREVIEW);
@@ -2369,8 +2369,8 @@ static int command_line_changed(CommandLineState *s)
     update_topline(curwin);
 
     redrawcmdline();
-  } else if (State & CMDPREVIEW) {
-    State = (State & ~CMDPREVIEW);
+  } else if (State & MODE_CMDPREVIEW) {
+    State = (State & ~MODE_CMDPREVIEW);
     close_preview_windows();
     update_screen(SOME_VALID);  // Clear 'inccommand' preview.
   } else {
@@ -5938,7 +5938,7 @@ int get_history_idx(int histype)
 /// ccline and put the previous value in ccline.prev_ccline.
 static struct cmdline_info *get_ccline_ptr(void)
 {
-  if ((State & CMDLINE) == 0) {
+  if ((State & MODE_CMDLINE) == 0) {
     return NULL;
   } else if (ccline.cmdbuff != NULL) {
     return &ccline;
@@ -6438,8 +6438,8 @@ static int open_cmdwin(void)
   const int histtype = hist_char2type(cmdwin_type);
   if (histtype == HIST_CMD || histtype == HIST_DEBUG) {
     if (p_wc == TAB) {
-      add_map((char_u *)"<buffer> <Tab> <C-X><C-V>", INSERT, false);
-      add_map((char_u *)"<buffer> <Tab> a<C-X><C-V>", NORMAL, false);
+      add_map((char_u *)"<buffer> <Tab> <C-X><C-V>", MODE_INSERT, false);
+      add_map((char_u *)"<buffer> <Tab> a<C-X><C-V>", MODE_NORMAL, false);
     }
     set_option_value("ft", 0L, "vim", OPT_LOCAL);
   }
@@ -6482,7 +6482,7 @@ static int open_cmdwin(void)
   // No Ex mode here!
   exmode_active = false;
 
-  State = NORMAL;
+  State = MODE_NORMAL;
   setmouse();
 
   // Reset here so it can be set by a CmdWinEnter autocommand.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5078,7 +5078,7 @@ int buf_check_timestamp(buf_T *buf)
         reload = RELOAD_DETECT;
         break;
       }
-    } else if (State > NORMAL_BUSY || (State & CMDLINE) || already_warned) {
+    } else if (State > MODE_NORMAL_BUSY || (State & MODE_CMDLINE) || already_warned) {
       if (*mesg2 != NUL) {
         xstrlcat(tbuf, "; ", tbuf_len - 1);
         xstrlcat(tbuf, mesg2, tbuf_len - 1);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -775,7 +775,7 @@ void clearFolding(win_T *win)
 /// The changes in lines from top to bot (inclusive).
 void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
-  if (compl_busy || State & INSERT) {
+  if (compl_busy || State & MODE_INSERT) {
     return;
   }
 
@@ -1374,7 +1374,7 @@ void foldMarkAdjust(win_T *wp, linenr_T line1, linenr_T line2, long amount, long
   }
   // If appending a line in Insert mode, it should be included in the fold
   // just above the line.
-  if ((State & INSERT) && amount == (linenr_T)1 && line2 == MAXLNUM) {
+  if ((State & MODE_INSERT) && amount == (linenr_T)1 && line2 == MAXLNUM) {
     line1--;
   }
   foldMarkAdjustRecurse(wp, &wp->w_folds, line1, line2, amount, amount_after);
@@ -1394,7 +1394,7 @@ static void foldMarkAdjustRecurse(win_T *wp, garray_T *gap, linenr_T line1, line
 
   // In Insert mode an inserted line at the top of a fold is considered part
   // of the fold, otherwise it isn't.
-  if ((State & INSERT) && amount == (linenr_T)1 && line2 == MAXLNUM) {
+  if ((State & MODE_INSERT) && amount == (linenr_T)1 && line2 == MAXLNUM) {
     top = line1 + 1;
   } else {
     top = line1;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -605,7 +605,7 @@ EXTERN pos_T Insstart;                  // This is where the latest
 // op_insert(), to detect correctly where inserting by the user started.
 EXTERN pos_T Insstart_orig;
 
-// Stuff for VREPLACE mode.
+// Stuff for MODE_VREPLACE state.
 EXTERN linenr_T orig_line_count INIT(= 0);       // Line count when "gR" started
 EXTERN int vr_lines_changed INIT(= 0);      // #Lines changed by "gR" so far
 
@@ -631,13 +631,13 @@ EXTERN char_u *fenc_default INIT(= NULL);
 
 /// "State" is the main state of Vim.
 /// There are other variables that modify the state:
-///    Visual_mode:    When State is NORMAL or INSERT.
-///    finish_op  :    When State is NORMAL, after typing the operator and
+///    Visual_mode:    When State is MODE_NORMAL or MODE_INSERT.
+///    finish_op  :    When State is MODE_NORMAL, after typing the operator and
 ///                    before typing the motion command.
 ///    motion_force:   Last motion_force from do_pending_operator()
 ///    debug_mode:     Debug mode
-EXTERN int State INIT(= NORMAL);        // This is the current state of the
-                                        // command interpreter.
+EXTERN int State INIT(= MODE_NORMAL);
+
 EXTERN bool debug_mode INIT(= false);
 EXTERN bool finish_op INIT(= false);    // true while an operator is pending
 EXTERN long opcount INIT(= 0);          // count for pending operator
@@ -748,8 +748,8 @@ EXTERN int global_busy INIT(= 0);           ///< set when :global is executing
 EXTERN bool listcmd_busy INIT(= false);     ///< set when :argdo, :windo or :bufdo is executing
 EXTERN bool need_start_insertmode INIT(= false);  ///< start insert mode soon
 
-#define MODE_MAX_LENGTH 4       // max mode length returned in get_mode()
-                                // including the final NUL character
+#define MODE_MAX_LENGTH 4       // max mode length returned in get_mode(),
+                                // including the terminating NUL
 
 EXTERN char last_mode[MODE_MAX_LENGTH] INIT(= "n");
 EXTERN char_u *last_cmdline INIT(= NULL);      // last command line (for ":)

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -404,7 +404,7 @@ int get_number_indent(linenr_T lnum)
   pos.lnum = 0;
 
   // In format_lines() (i.e. not insert mode), fo+=q is needed too...
-  if ((State & INSERT) || has_format_option(FO_Q_COMS)) {
+  if ((State & MODE_INSERT) || has_format_option(FO_Q_COMS)) {
     lead_len = get_leader_len(ml_get(lnum), NULL, false, true);
   }
   regmatch.regprog = vim_regcomp(curbuf->b_p_flp, RE_MAGIC);
@@ -560,7 +560,7 @@ int get_expr_indent(void)
   // Pretend to be in Insert mode, allow cursor past end of line for "o"
   // command.
   save_State = State;
-  State = INSERT;
+  State = MODE_INSERT;
   curwin->w_cursor = save_pos;
   curwin->w_curswant = save_curswant;
   curwin->w_set_curswant = save_set_curswant;

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -1868,10 +1868,11 @@ int get_c_indent(void)
    * For unknown reasons the cursor might be past the end of the line, thus
    * check for that.
    */
-  if ((State & INSERT)
+  if ((State & MODE_INSERT)
       && curwin->w_cursor.col < (colnr_T)STRLEN(linecopy)
-      && linecopy[curwin->w_cursor.col] == ')')
+      && linecopy[curwin->w_cursor.col] == ')') {
     linecopy[curwin->w_cursor.col] = NUL;
+  }
 
   theline = (char_u *)skipwhite((char *)linecopy);
 

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -39,7 +39,7 @@ int ask_yesno(const char *const str, const bool direct)
   const int save_State = State;
 
   no_wait_return++;
-  State = CONFIRM;  // Mouse behaves like with :confirm.
+  State = MODE_CONFIRM;  // Mouse behaves like with :confirm.
   setmouse();  // Disable mouse in xterm.
   no_mapping++;
   allow_keys++;  // no mapping here, but recognize keys
@@ -235,7 +235,7 @@ int prompt_for_number(int *mouse_used)
   save_cmdline_row = cmdline_row;
   cmdline_row = 0;
   save_State = State;
-  State = ASKMORE;  // prevents a screen update when using a timer
+  State = MODE_ASKMORE;  // prevents a screen update when using a timer
   // May show different mouse shape.
   setmouse();
 

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1382,16 +1382,16 @@ static void execute_menu(const exarg_T *eap, vimmenu_T *menu)
   char *mode;
 
   // Use the Insert mode entry when returning to Insert mode.
-  if (((State & INSERT) || restart_edit) && !current_sctx.sc_sid) {
+  if (((State & MODE_INSERT) || restart_edit) && !current_sctx.sc_sid) {
     mode = "Insert";
     idx = MENU_INDEX_INSERT;
-  } else if (State & CMDLINE) {
+  } else if (State & MODE_CMDLINE) {
     mode = "Command";
     idx = MENU_INDEX_CMDLINE;
-  } else if (get_real_state() & VISUAL) {
-    /* Detect real visual mode -- if we are really in visual mode we
-     * don't need to do any guesswork to figure out what the selection
-     * is. Just execute the visual binding for the menu. */
+  } else if (get_real_state() & MODE_VISUAL) {
+    // Detect real visual mode -- if we are really in visual mode we
+    // don't need to do any guesswork to figure out what the selection
+    // is. Just execute the visual binding for the menu.
     mode = "Visual";
     idx = MENU_INDEX_VISUAL;
   } else if (eap != NULL && eap->addr_count) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1125,7 +1125,7 @@ void wait_return(int redraw)
     // just changed.
     screenalloc();
 
-    State = HITRETURN;
+    State = MODE_HITRETURN;
     setmouse();
     cmdline_row = msg_row;
     // Avoid the sequence that the user types ":" at the hit-return prompt
@@ -1250,7 +1250,7 @@ void wait_return(int redraw)
     XFREE_CLEAR(keep_msg);          // don't redisplay message, it's too long
   }
 
-  if (tmpState == SETWSIZE) {       // got resize event while in vgetc()
+  if (tmpState == MODE_SETWSIZE) {       // got resize event while in vgetc()
     ui_refresh();
   } else if (!skip_redraw) {
     if (redraw == true || (msg_scrolled != 0 && redraw != -1)) {
@@ -2186,7 +2186,7 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr, int recurs
       if (lines_left > 0) {
         --lines_left;
       }
-      if (p_more && lines_left == 0 && State != HITRETURN
+      if (p_more && lines_left == 0 && State != MODE_HITRETURN
           && !msg_no_more && !exmode_active) {
         if (do_more_prompt(NUL)) {
           s = confirm_msg_tail;
@@ -2707,7 +2707,7 @@ static int do_more_prompt(int typed_char)
   // We get called recursively when a timer callback outputs a message. In
   // that case don't show another prompt. Also when at the hit-Enter prompt
   // and nothing was typed.
-  if (no_need_more || entered || (State == HITRETURN && typed_char == 0)) {
+  if (no_need_more || entered || (State == MODE_HITRETURN && typed_char == 0)) {
     return false;
   }
   entered = true;
@@ -2721,7 +2721,7 @@ static int do_more_prompt(int typed_char)
     }
   }
 
-  State = ASKMORE;
+  State = MODE_ASKMORE;
   setmouse();
   if (typed_char == NUL) {
     msg_moremsg(FALSE);
@@ -2992,19 +2992,19 @@ void msg_moremsg(int full)
   }
 }
 
-/// Repeat the message for the current mode: ASKMORE, EXTERNCMD, CONFIRM or
-/// exmode_active.
+/// Repeat the message for the current mode: MODE_ASKMORE, MODE_EXTERNCMD,
+/// MODE_CONFIRM or exmode_active.
 void repeat_message(void)
 {
-  if (State == ASKMORE) {
-    msg_moremsg(TRUE);          // display --more-- message again
+  if (State == MODE_ASKMORE) {
+    msg_moremsg(true);          // display --more-- message again
     msg_row = Rows - 1;
-  } else if (State == CONFIRM) {
+  } else if (State == MODE_CONFIRM) {
     display_confirm_msg();      // display ":confirm" message again
     msg_row = Rows - 1;
-  } else if (State == EXTERNCMD) {
+  } else if (State == MODE_EXTERNCMD) {
     ui_cursor_goto(msg_row, msg_col);     // put cursor back
-  } else if (State == HITRETURN || State == SETWSIZE) {
+  } else if (State == MODE_HITRETURN || State == MODE_SETWSIZE) {
     if (msg_row == Rows - 1) {
       // Avoid drawing the "hit-enter" prompt below the previous one,
       // overwrite it.  Esp. useful when regaining focus and a
@@ -3076,9 +3076,9 @@ int msg_end(void)
    * we have to redraw the window.
    * Do not do this if we are abandoning the file or editing the command line.
    */
-  if (!exiting && need_wait_return && !(State & CMDLINE)) {
-    wait_return(FALSE);
-    return FALSE;
+  if (!exiting && need_wait_return && !(State & MODE_CMDLINE)) {
+    wait_return(false);
+    return false;
   }
 
   // NOTE: ui_flush() used to be called here. This had to be removed, as it
@@ -3436,7 +3436,7 @@ int do_dialog(int type, char_u *title, char_u *message, char_u *buttons, int dfl
   int oldState = State;
 
   msg_silent = 0;  // If dialog prompts for input, user needs to see it! #8788
-  State = CONFIRM;
+  State = MODE_CONFIRM;
   setmouse();
 
   /*

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -354,7 +354,7 @@ static void shift_block(oparg_T *oap, int amount)
 
   p_ri = 0;                     // don't want revins in indent
 
-  State = INSERT;               // don't want REPLACE for State
+  State = MODE_INSERT;          // don't want MODE_REPLACE for State
   block_prep(oap, &bd, curwin->w_cursor.lnum, true);
   if (bd.is_short) {
     return;
@@ -532,7 +532,7 @@ static void block_insert(oparg_T *oap, char_u *s, int b_insert, struct block_def
   char_u *newp, *oldp;     // new, old lines
   linenr_T lnum;                // loop var
   int oldstate = State;
-  State = INSERT;               // don't want REPLACE for State
+  State = MODE_INSERT;          // don't want MODE_REPLACE for State
 
   for (lnum = oap->start.lnum + 1; lnum <= oap->end.lnum; lnum++) {
     block_prep(oap, bdp, lnum, true);
@@ -1865,7 +1865,7 @@ static void replace_character(int c)
 {
   const int n = State;
 
-  State = REPLACE;
+  State = MODE_REPLACE;
   ins_char(c);
   State = n;
   // Backup to the replaced character.
@@ -3774,7 +3774,7 @@ void adjust_cursor_eol(void)
   if (curwin->w_cursor.col > 0
       && gchar_cursor() == NUL
       && (cur_ve_flags & VE_ONEMORE) == 0
-      && !(restart_edit || (State & INSERT))) {
+      && !(restart_edit || (State & MODE_INSERT))) {
     // Put the cursor on the last character in the line.
     dec_cursor();
 
@@ -4608,14 +4608,14 @@ void format_lines(linenr_T line_count, int avoid_fex)
         }
 
         // put cursor on last non-space
-        State = NORMAL;  // don't go past end-of-line
+        State = MODE_NORMAL;  // don't go past end-of-line
         coladvance(MAXCOL);
         while (curwin->w_cursor.col && ascii_isspace(gchar_cursor())) {
           dec_cursor();
         }
 
         // do the formatting, without 'showmode'
-        State = INSERT;         // for open_line()
+        State = MODE_INSERT;         // for open_line()
         smd_save = p_smd;
         p_smd = FALSE;
         insertchar(NUL, INSCHAR_FORMAT

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4053,7 +4053,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
   } else if ((int *)varp == &p_im) {
     // when 'insertmode' is set from an autocommand need to do work here
     if (p_im) {
-      if ((State & INSERT) == 0) {
+      if ((State & MODE_INSERT) == 0) {
         need_start_insertmode = true;
       }
       stop_insert_mode = false;
@@ -8260,7 +8260,7 @@ dict_T *get_winbuf_options(const int bufopt)
 long get_scrolloff_value(win_T *wp)
 {
   // Disallow scrolloff in terminal-mode. #11915
-  if (State & TERM_FOCUS) {
+  if (State & MODE_TERMINAL) {
     return 0;
   }
   return wp->w_p_so < 0 ? p_so : wp->w_p_so;

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -81,7 +81,7 @@ void input_stop(void)
 
 static void cursorhold_event(void **argv)
 {
-  event_T event = State & INSERT ? EVENT_CURSORHOLDI : EVENT_CURSORHOLD;
+  event_T event = State & MODE_INSERT ? EVENT_CURSORHOLDI : EVENT_CURSORHOLD;
   apply_autocmds(event, NULL, NULL, false, curbuf);
   did_cursorhold = true;
 }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -644,7 +644,7 @@ int os_call_shell(char_u *cmd, ShellOpts opts, char_u *extra_args)
   if (opts & (kShellOptHideMess | kShellOptExpand)) {
     forward_output = false;
   } else {
-    State = EXTERNCMD;
+    State = MODE_EXTERNCMD;
 
     if (opts & kShellOptWrite) {
       read_input(&input);

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -155,11 +155,11 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
   }
 
   // If *s is a TAB, and the TAB is not displayed as ^I, and we're not in
-  // INSERT mode, then col must be adjusted so that it represents the last
-  // screen position of the TAB.  This only fixes an error when the TAB wraps
-  // from one screen line to the next (when 'columns' is not a multiple of
-  // 'ts') -- webb.
-  if (*s == TAB && (State & NORMAL)
+  // MODE_INSERT state, then col must be adjusted so that it represents the
+  // last screen position of the TAB.  This only fixes an error when the TAB
+  // wraps from one screen line to the next (when 'columns' is not a multiple
+  // of 'ts') -- webb.
+  if (*s == TAB && (State & MODE_NORMAL)
       && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
     col += win_lbr_chartabsize(wp, line, s, col, NULL) - 1;
   }

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -111,10 +111,10 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
     // To keep the code simple, we only allow changing the
     // draw mode when the popup menu is not being displayed
     pum_external = ui_has(kUIPopupmenu)
-                   || (State == CMDLINE && ui_has(kUIWildmenu));
+                   || (State == MODE_CMDLINE && ui_has(kUIWildmenu));
   }
 
-  pum_rl = (curwin->w_p_rl && State != CMDLINE);
+  pum_rl = (curwin->w_p_rl && State != MODE_CMDLINE);
 
   do {
     // Mark the pum as visible already here,
@@ -126,7 +126,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
     below_row = cmdline_row;
 
     // wildoptions=pum
-    if (State == CMDLINE) {
+    if (State == MODE_CMDLINE) {
       pum_win_row = ui_has(kUICmdline) ? 0 : cmdline_row;
       cursor_col = cmd_startcol;
       pum_anchor_grid = ui_has(kUICmdline) ? -1 : DEFAULT_GRID_HANDLE;
@@ -419,7 +419,7 @@ void pum_redraw(void)
 
   grid_assign_handle(&pum_grid);
 
-  pum_grid.zindex = ((State == CMDLINE)
+  pum_grid.zindex = ((State == MODE_CMDLINE)
                      ? kZIndexCmdlinePopupMenu : kZIndexPopupMenu);
 
   bool moved = ui_comp_put_grid(&pum_grid, pum_row, pum_col - col_off,

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2428,7 +2428,7 @@ void showmatch(int c)
 
       save_dollar_vcol = dollar_vcol;
       save_state = State;
-      State = SHOWMATCH;
+      State = MODE_SHOWMATCH;
       ui_cursor_shape();                // may show different cursor shape
       curwin->w_cursor = mpos;          // move to matching char
       *so = 0;                          // don't use 'scrolloff' here

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -56,7 +56,7 @@ getkey:
       key = K_EVENT;
     } else {
       // Duplicate display updating logic in vgetorpeek()
-      if (((State & INSERT) != 0 || p_lz) && (State & CMDLINE) == 0
+      if (((State & MODE_INSERT) != 0 || p_lz) && (State & MODE_CMDLINE) == 0
           && must_redraw != 0 && !need_wait_return) {
         update_screen(0);
         setcursor();  // put cursor back where it belongs
@@ -136,21 +136,22 @@ bool virtual_active(void)
   }
   return cur_ve_flags == VE_ALL
          || ((cur_ve_flags & VE_BLOCK) && VIsual_active && VIsual_mode == Ctrl_V)
-         || ((cur_ve_flags & VE_INSERT) && (State & INSERT));
+         || ((cur_ve_flags & VE_INSERT) && (State & MODE_INSERT));
 }
 
-/// VISUAL, SELECTMODE and OP_PENDING State are never set, they are equal to
-/// NORMAL State with a condition.  This function returns the real State.
+/// MODE_VISUAL, MODE_SELECTMODE and MODE_OP_PENDING State are never set, they are
+/// equal to MODE_NORMAL State with a condition.  This function returns the real
+/// State.
 int get_real_state(void)
 {
-  if (State & NORMAL) {
+  if (State & MODE_NORMAL) {
     if (VIsual_active) {
       if (VIsual_select) {
-        return SELECTMODE;
+        return MODE_SELECT;
       }
-      return VISUAL;
+      return MODE_VISUAL;
     } else if (finish_op) {
-      return OP_PENDING;
+      return MODE_OP_PENDING;
     }
   }
   return State;
@@ -173,17 +174,17 @@ void get_mode(char *buf)
         buf[i++] = 's';
       }
     }
-  } else if (State == HITRETURN || State == ASKMORE || State == SETWSIZE
-             || State == CONFIRM) {
+  } else if (State == MODE_HITRETURN || State == MODE_ASKMORE || State == MODE_SETWSIZE
+             || State == MODE_CONFIRM) {
     buf[i++] = 'r';
-    if (State == ASKMORE) {
+    if (State == MODE_ASKMORE) {
       buf[i++] = 'm';
-    } else if (State == CONFIRM) {
+    } else if (State == MODE_CONFIRM) {
       buf[i++] = '?';
     }
-  } else if (State == EXTERNCMD) {
+  } else if (State == MODE_EXTERNCMD) {
     buf[i++] = '!';
-  } else if (State & INSERT) {
+  } else if (State & MODE_INSERT) {
     if (State & VREPLACE_FLAG) {
       buf[i++] = 'R';
       buf[i++] = 'v';
@@ -199,12 +200,12 @@ void get_mode(char *buf)
     } else if (ctrl_x_mode_not_defined_yet()) {
       buf[i++] = 'x';
     }
-  } else if ((State & CMDLINE) || exmode_active) {
+  } else if ((State & MODE_CMDLINE) || exmode_active) {
     buf[i++] = 'c';
     if (exmode_active) {
       buf[i++] = 'v';
     }
-  } else if (State & TERM_FOCUS) {
+  } else if (State & MODE_TERMINAL) {
     buf[i++] = 't';
   } else {
     buf[i++] = 'n';

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2129,7 +2129,7 @@ parse_line:
               STRLCPY(mfp, tagp.tagname, len + 1);
 
               // if wanted, re-read line to get long form too
-              if (State & INSERT) {
+              if (State & MODE_INSERT) {
                 get_it_again = p_sft;
               }
             }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -381,7 +381,7 @@ void terminal_check_size(Terminal *term)
   invalidate_terminal(term, -1, -1);
 }
 
-/// Implements TERM_FOCUS mode. :help Terminal-mode
+/// Implements MODE_TERMINAL state. :help Terminal-mode
 void terminal_enter(void)
 {
   buf_T *buf = curbuf;
@@ -398,8 +398,8 @@ void terminal_enter(void)
 
   int save_state = State;
   s->save_rd = RedrawingDisabled;
-  State = TERM_FOCUS;
-  mapped_ctrl_c |= TERM_FOCUS;  // Always map CTRL-C to avoid interrupt.
+  State = MODE_TERMINAL;
+  mapped_ctrl_c |= MODE_TERMINAL;  // Always map CTRL-C to avoid interrupt.
   RedrawingDisabled = false;
 
   // Disable these options in terminal-mode. They are nonsense because cursor is
@@ -1637,7 +1637,7 @@ static int linenr_to_row(Terminal *term, int linenr)
 
 static bool is_focused(Terminal *term)
 {
-  return State & TERM_FOCUS && curbuf->terminal == term;
+  return State & MODE_TERMINAL && curbuf->terminal == term;
 }
 
 static char *get_config_string(char *key)

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -549,13 +549,13 @@ void ui_check_mouse(void)
   int checkfor = MOUSE_NORMAL;  // assume normal mode
   if (VIsual_active) {
     checkfor = MOUSE_VISUAL;
-  } else if (State == HITRETURN || State == ASKMORE || State == SETWSIZE) {
+  } else if (State == MODE_HITRETURN || State == MODE_ASKMORE || State == MODE_SETWSIZE) {
     checkfor = MOUSE_RETURN;
-  } else if (State & INSERT) {
+  } else if (State & MODE_INSERT) {
     checkfor = MOUSE_INSERT;
-  } else if (State & CMDLINE) {
+  } else if (State & MODE_CMDLINE) {
     checkfor = MOUSE_COMMAND;
-  } else if (State == CONFIRM || State == EXTERNCMD) {
+  } else if (State == MODE_CONFIRM || State == MODE_EXTERNCMD) {
     checkfor = ' ';  // don't use mouse for ":confirm" or ":!cmd"
   }
 

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -38,42 +38,42 @@ enum { NUMBUFLEN = 65, };
 #define MSG_HIST                0x1000
 
 
-// values for State
+// Values for State
 //
-// The lower bits up to 0x20 are used to distinguish normal/visual/op_pending
-// and cmdline/insert+replace mode.  This is used for mapping.  If none of
-// these bits are set, no mapping is done.
-// The upper bits are used to distinguish between other states.
+// The lower bits up to 0x80 are used to distinguish normal/visual/op_pending
+// /cmdline/insert/replace/terminal mode.  This is used for mapping.  If none
+// of these bits are set, no mapping is done.  See the comment above do_map().
+// The upper bits are used to distinguish between other states and variants of
+// the base modes.
 
-#define NORMAL          0x01    // Normal mode, command expected
-#define VISUAL          0x02    // Visual mode - use get_real_state()
-#define OP_PENDING      0x04    // Normal mode, operator is pending - use
-                                // get_real_state()
-#define CMDLINE         0x08    // Editing command line
-#define INSERT          0x10    // Insert mode
-#define LANGMAP         0x20    // Language mapping, can be combined with
-                                // INSERT and CMDLINE
+#define MODE_NORMAL          0x01    // Normal mode, command expected
+#define MODE_VISUAL          0x02    // Visual mode - use get_real_state()
+#define MODE_OP_PENDING      0x04    // Normal mode, operator is pending - use
+                                     // get_real_state()
+#define MODE_CMDLINE         0x08    // Editing the command line
+#define MODE_INSERT          0x10    // Insert mode, also for Replace mode
+#define MODE_LANGMAP         0x20    // Language mapping, can be combined with
+                                     // MODE_INSERT and MODE_CMDLINE
+#define MODE_SELECT          0x40    // Select mode, use get_real_state()
+#define MODE_TERMINAL        0x80    // Terminal mode
 
-#define REPLACE_FLAG    0x40    // Replace mode flag
-#define REPLACE         (REPLACE_FLAG + INSERT)
-#define VREPLACE_FLAG  0x80    // Virtual-replace mode flag
-#define VREPLACE       (REPLACE_FLAG + VREPLACE_FLAG + INSERT)
-#define LREPLACE        (REPLACE_FLAG + LANGMAP)
+#define MAP_ALL_MODES        0xff    // all mode bits used for mapping
 
-#define NORMAL_BUSY     (0x100 + NORMAL)  // Normal mode, busy with a command
-#define HITRETURN       (0x200 + NORMAL)  // waiting for return or command
-#define ASKMORE         0x300   // Asking if you want --more--
-#define SETWSIZE        0x400   // window size has changed
-#define ABBREV          0x500   // abbreviation instead of mapping
-#define EXTERNCMD       0x600   // executing an external command
-#define SHOWMATCH       (0x700 + INSERT)  // show matching paren
-#define CONFIRM         0x800   // ":confirm" prompt
-#define SELECTMODE      0x1000  // Select mode, only for mappings
-#define TERM_FOCUS      0x2000  // Terminal focus mode
-#define CMDPREVIEW      0x4000  // Showing 'inccommand' command "live" preview.
+#define REPLACE_FLAG         0x100   // Replace mode flag
+#define MODE_REPLACE         (REPLACE_FLAG | MODE_INSERT)
+#define VREPLACE_FLAG        0x200   // Virtual-replace mode flag
+#define MODE_VREPLACE        (REPLACE_FLAG | VREPLACE_FLAG | MODE_INSERT)
+#define MODE_LREPLACE        (REPLACE_FLAG | MODE_LANGMAP)
 
-// all mode bits used for mapping
-#define MAP_ALL_MODES   (0x3f | SELECTMODE | TERM_FOCUS)
+#define MODE_NORMAL_BUSY     (0x1000 | MODE_NORMAL)  // Normal mode, busy with a command
+#define MODE_HITRETURN       (0x2000 | MODE_NORMAL)  // waiting for return or command
+#define MODE_ASKMORE         0x3000  // Asking if you want --more--
+#define MODE_SETWSIZE        0x4000  // window size has changed
+#define MODE_EXTERNCMD       0x5000  // executing an external command
+#define MODE_SHOWMATCH       (0x6000 | MODE_INSERT)  // show matching paren
+#define MODE_CONFIRM         0x7000  // ":confirm" prompt
+#define MODE_CMDPREVIEW      0x8000  // Showing 'inccommand' command "live" preview.
+
 
 /// Directions.
 typedef enum {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2376,7 +2376,7 @@ static void leaving_window(win_T *const win)
   // When leaving the window (or closing the window) was done from a
   // callback we need to break out of the Insert mode loop and restart Insert
   // mode when entering the window again.
-  if (State & INSERT) {
+  if (State & MODE_INSERT) {
     stop_insert_mode = true;
     if (win->w_buffer->b_prompt_insert == NUL) {
       win->w_buffer->b_prompt_insert = 'A';
@@ -2400,7 +2400,7 @@ void entering_window(win_T *const win)
 
   // When entering the prompt window restart Insert mode if we were in Insert
   // mode when we left it and not already in Insert mode.
-  if ((State & INSERT) == 0) {
+  if ((State & MODE_INSERT) == 0) {
     restart_edit = win->w_buffer->b_prompt_insert;
   }
 }


### PR DESCRIPTION
#### vim-patch:8.2.4911: the mode #defines are not clearly named

Problem:    The mode #defines are not clearly named.
Solution:   Prepend MODE_.  Renumber them to put the mapped modes first.
https://github.com/vim/vim/commit/249591057b4840785c50e41dd850efb8a8faf435

A hunk from the patch depends on patch 8.2.4861, which hasn't been
ported yet, but that should be easy to notice.