### PR TITLE
feat(lsp): Add LspAttach and LspDetach autocommands

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -106,11 +106,13 @@ internally and are no longer exposed as part of the API. Instead, use
 *vim.lsp.diagnostic.set_underline()*
 *vim.lsp.diagnostic.set_virtual_text()*
 
-LSP Utility Functions ~
+LSP Functions ~
 
 *vim.lsp.util.diagnostics_to_items()*	Use |vim.diagnostic.toqflist()| instead.
 *vim.lsp.util.set_qflist()*		Use |setqflist()| instead.
 *vim.lsp.util.set_loclist()*		Use |setloclist()| instead.
+*vim.lsp.buf_get_clients()*		Use |vim.lsp.get_active_clients()| with
+                                        {buffer = bufnr} instead.
 
 Lua ~
 *vim.register_keystroke_callback()* Use |vim.on_key()| instead.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -461,6 +461,39 @@ LspSignatureActiveParameter
 ==============================================================================
 EVENTS                                                            *lsp-events*
 
+                                                                   *LspAttach*
+After an LSP client attaches to a buffer. The |autocmd-pattern| is the
+name of the buffer. When used from Lua, the client ID is passed to the
+callback in the "data" table. Example: >
+
+    vim.api.nvim_create_autocmd("LspAttach", {
+      callback = function(args)
+        local bufnr = args.buf
+        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        if client.server_capabilities.completionProvider then
+          vim.bo[bufnr].omnifunc = "v:lua.vim.lsp.omnifunc"
+        end
+        if client.server_capabilities.definitionProvider then
+          vim.bo[bufnr].tagfunc = "v:lua.vim.lsp.tagfunc"
+        end
+      end,
+    })
+<
+                                                                   *LspDetach*
+Just before an LSP client detaches from a buffer. The |autocmd-pattern| is the
+name of the buffer. When used from Lua, the client ID is passed to the
+callback in the "data" table. Example: >
+
+    vim.api.nvim_create_autocmd("LspDetach", {
+      callback = function(args)
+        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        -- Do something with the client
+        vim.cmd("setlocal tagfunc< omnifunc<")
+      end,
+    })
+<
+In addition, the following |User| |autocommands| are provided:
+
 LspProgressUpdate                                          *LspProgressUpdate*
    Upon receipt of a progress notification from the server. See
    |vim.lsp.util.get_progress_messages()|.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -531,14 +531,6 @@ buf_detach_client({bufnr}, {client_id})          *vim.lsp.buf_detach_client()*
                     {bufnr}      (number) Buffer handle, or 0 for current
                     {client_id}  (number) Client id
 
-buf_get_clients({bufnr})                           *vim.lsp.buf_get_clients()*
-                Gets a map of client_id:client pairs for the given buffer,
-                where each value is a |vim.lsp.client| object.
-
-                Parameters: ~
-                    {bufnr}  (optional, number): Buffer handle, or 0 for
-                             current
-
 buf_is_attached({bufnr}, {client_id})              *vim.lsp.buf_is_attached()*
                 Checks if a buffer is attached for a particular client.
 
@@ -729,11 +721,22 @@ formatexpr({opts})                                      *vim.lsp.formatexpr()*
                             • timeout_ms (default 500ms). The timeout period
                               for the formatting request.
 
-get_active_clients()                            *vim.lsp.get_active_clients()*
-                Gets all active clients.
+get_active_clients({filter})                    *vim.lsp.get_active_clients()*
+                Get active clients.
+
+                Parameters: ~
+                    {filter}  (table|nil) A table with key-value pairs used to
+                              filter the returned clients. The available keys
+                              are:
+                              • id (number): Only return clients with the
+                                given id
+                              • bufnr (number): Only return clients attached
+                                to this buffer
+                              • name (string): Only return clients with the
+                                given name
 
                 Return: ~
-                    Table of |vim.lsp.client| objects
+                    (table) List of |vim.lsp.client| objects
 
                                           *vim.lsp.get_buffers_by_client_id()*
 get_buffers_by_client_id({client_id})

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -70,6 +70,8 @@ return {
     'InsertEnter',            -- when entering Insert mode
     'InsertLeave',            -- just after leaving Insert mode
     'InsertLeavePre',         -- just before leaving Insert mode
+    'LspAttach',              -- after an LSP client attaches to a buffer
+    'LspDetach',              -- after an LSP client detaches from a buffer
     'MenuPopup',              -- just before popup menu is displayed
     'ModeChanged',            -- after changing the mode
     'OptionSet',              -- after setting any option
@@ -133,6 +135,8 @@ return {
   nvim_specific = {
     BufModifiedSet=true,
     DiagnosticChanged=true,
+    LspAttach=true,
+    LspDetach=true,
     RecordingEnter=true,
     RecordingLeave=true,
     Signal=true,


### PR DESCRIPTION
The current approach of using `on_attach` callbacks for configuring buffers for LSP is suboptimal:

1. It does not use the standard Nvim interface for driving and hooking into events (i.e. autocommands)
2. There is no way for "third parties" (e.g. plugins) to hook into the event. This means that *all* buffer configuration must go into the user-supplied on_attach callback. This also makes it impossible for these configurations to be modular, since it all must happen in the same place.
3. There is currently no way to do something when a client detaches from a buffer (there is no `on_detach` callback).

The solution is to use the traditional method of event handling in Nvim: autocommands. When a LSP client is attached to a buffer, fire a `LspAttach` event with the client's name as the pattern. Likewise, when a client detaches from a buffer fire a `LspDetach` event.

This enables plugins to easily add LSP-specific configuration to buffers as well as enabling users to make their own configurations more modular (e.g. by creating multiple LspAttach autocommands that each do something unique).