### PR TITLE
vim-patch:8.2.4929: off-by-one error in in statusline item

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3635,7 +3635,8 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
         // correct the start of the items for the truncation
         for (int idx = stl_groupitems[groupdepth] + 1; idx < curitem; idx++) {
           // Shift everything back by the number of removed bytes
-          stl_items[idx].start -= n;
+          // Minus one for the leading '<' added above.
+          stl_items[idx].start -= n - 1;
 
           // If the item was partially or completely truncated, set its
           // start to the start of the group

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -461,7 +461,6 @@ func Test_statusline_removed_group()
   call writefile(lines, 'XTest_statusline')
 
   let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 10, 'cols': 50})
-  call term_wait(buf, 100)
   call VerifyScreenDump(buf, 'Test_statusline_1', {})
 
   " clean up
@@ -533,6 +532,24 @@ func Test_statusline_verylong_filename()
   set previewwindow
   redraw
   bwipe!
+endfunc
+
+func Test_statusline_highlight_truncate()
+  CheckScreendump
+
+  let lines =<< trim END
+    set laststatus=2
+    hi! link User1 Directory
+    hi! link User2 ErrorMsg
+    set statusline=%.5(%1*ABC%2*DEF%1*GHI%)
+  END
+  call writefile(lines, 'XTest_statusline')
+
+  let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 6})
+  call VerifyScreenDump(buf, 'Test_statusline_hl', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XTest_statusline')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/statusline_spec.lua
+++ b/test/functional/legacy/statusline_spec.lua
@@ -1,0 +1,71 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local exec = helpers.exec
+local feed = helpers.feed
+
+before_each(clear)
+
+describe('statusline', function()
+  local screen
+
+  before_each(function()
+    screen = Screen.new(50, 7)
+    screen:attach()
+  end)
+
+  it('is updated in cmdline mode when using window-local statusline vim-patch:8.2.2737', function()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [2] = {bold = true, reverse = true},  -- StatusLine
+      [3] = {reverse = true},  -- StatusLineNC, VertSplit
+    })
+    exec([[
+      setlocal statusline=-%{mode()}-
+      split
+      setlocal statusline=+%{mode()}+
+    ]])
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|
+      {2:+n+                                               }|
+                                                        |
+      {1:~                                                 }|
+      {3:-n-                                               }|
+                                                        |
+    ]])
+    feed(':')
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|
+      {2:+c+                                               }|
+                                                        |
+      {1:~                                                 }|
+      {3:-c-                                               }|
+      :^                                                 |
+    ]])
+  end)
+
+  it('truncated item does not cause off-by-one highlight vim-patch:8.2.4929', function()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [2] = {foreground = Screen.colors.Blue},  -- User1
+      [3] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- User2
+    })
+    exec([[
+      set laststatus=2
+      hi! link User1 Directory
+      hi! link User2 ErrorMsg
+      set statusline=%.5(%1*ABC%2*DEF%1*GHI%)
+    ]])
+    screen:expect([[
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {3:<F}{2:GHI                                             }|
+                                                        |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:8.2.4929: off-by-one error in in statusline item

Problem:    Off-by-one error in in statusline item.
Solution:   Subtrace one less. (closes vim/vim#10394)
https://github.com/vim/vim/commit/57ff52677bf5ba1651281ffe40505df8feba4a36