### PR TITLE
vim-patch:921bde888046

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2800,7 +2800,7 @@ getcmdcompltype()					*getcmdcompltype()*
 		Return the type of the current command-line completion.
 		Only works when the command line is being edited, thus
 		requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
-		See |command-completion| for the return string.
+		See |:command-completion| for the return string.
 		Also see |getcmdtype()|, |setcmdpos()| and |getcmdline()|.
 		Returns an empty string when completion is not defined.
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -105,7 +105,7 @@ modes.
 			command applies.
 			Use the <buffer> argument to remove buffer-local
 			mappings |:map-<buffer>|
-			Warning: This also removes the default mappings.
+			Warning: This also removes the |default-mappings|.
 
 :map				|mapmode-nvo|
 :nm[ap]				|mapmode-n|

--- a/runtime/ftplugin/abaqus.vim
+++ b/runtime/ftplugin/abaqus.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:     Abaqus finite element input file (www.abaqus.com)
 " Maintainer:   Carl Osterwisch <osterwischc@asme.org>
-" Last Change:  2012 Apr 30
+" Last Change:  2022 May 09
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -86,11 +86,11 @@ let b:undo_ftplugin .= "|unmap <buffer> [[|unmap <buffer> ]]"
     \ . "|unmap <buffer> <LocalLeader><LocalLeader>"
 
 " Undo must be done in nocompatible mode for <LocalLeader>.
-let b:undo_ftplugin = "let s:cpo_save = &cpoptions|"
+let b:undo_ftplugin = "let b:cpo_save = &cpoptions|"
     \ . "set cpoptions&vim|"
     \ . b:undo_ftplugin
-    \ . "|let &cpoptions = s:cpo_save"
-    \ . "|unlet s:cpo_save"
+    \ . "|let &cpoptions = b:cpo_save"
+    \ . "|unlet b:cpo_save"
 
 " Restore saved compatibility options
 let &cpoptions = s:cpo_save

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2022 May 04
+" Last Change: 2022 May 09
 "
 " WORK IN PROGRESS - The basics works stable, more to come
 " Note: In general you need at least GDB 7.12 because this provides the
@@ -205,8 +205,8 @@ func s:CheckGdbRunning()
   return 'ok'
 endfunc
 
+" Open a terminal window without a job, to run the debugged program in.
 func s:StartDebug_term(dict)
-  " Open a terminal window without a job, to run the debugged program in.
   execute s:vertical ? 'vnew' : 'new'
   let s:pty_job_id = termopen('tail -f /dev/null;#gdb program')
   if s:pty_job_id == 0
@@ -365,8 +365,8 @@ func s:StartDebug_term(dict)
   call s:StartDebugCommon(a:dict)
 endfunc
 
+" Open a window with a prompt buffer to run gdb in.
 func s:StartDebug_prompt(dict)
-  " Open a window with a prompt buffer to run gdb in.
   if s:vertical
     vertical new
   else


### PR DESCRIPTION
Update runtime files, translations
https://github.com/vim/vim/commit/921bde88804663a7cb825d7f7e8a5d8ae6b58650

skip: translations
skip: builtin.txt (requires 8.2.4861)