### PR TITLE
feat(lsp): support workspace/codeLens/refresh

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -175,6 +175,11 @@ M['textDocument/codeLens'] = function(...)
   return require('vim.lsp.codelens').on_codelens(...)
 end
 
+M['workspace/codeLens/refresh'] = function(_, _, _, _)
+  require('vim.lsp.codelens').refresh()
+  return {}
+end
+
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
 M['textDocument/references'] = function(_, result, ctx, config)
   if not result or vim.tbl_isempty(result) then

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -764,6 +764,9 @@ function protocol.make_client_capabilities()
       workspaceEdit = {
         resourceOperations = { 'rename', 'create', 'delete' },
       },
+      codeLens = {
+        refreshSupport = true,
+      },
     },
     callHierarchy = {
       dynamicRegistration = false,


### PR DESCRIPTION
Suppport [`workspace/codeLens/refresh`] method of LSP. This allows the code lens to be displayed without a call to `vim.lsp.codelens.refresh()` when the project is loaded. I confirmed it works with rust-analyzer.

[`workspace/codeLens/refresh`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeLens_refresh