### PR TITLE
vim-patch:8.2.{4901,4938}: NULL pointer access when using invalid pattern

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2366,7 +2366,7 @@ static char_u *buflist_match(regmatch_T *rmp, buf_T *buf, bool ignore_case)
 {
   // First try the short file name, then the long file name.
   char_u *match = fname_match(rmp, buf->b_sfname, ignore_case);
-  if (match == NULL) {
+  if (match == NULL && rmp->regprog != NULL) {
     match = fname_match(rmp, buf->b_ffname, ignore_case);
   }
   return match;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2387,7 +2387,7 @@ static char_u *fname_match(regmatch_T *rmp, char_u *name, bool ignore_case)
     rmp->rm_ic = p_fic || ignore_case;
     if (vim_regexec(rmp, name, (colnr_T)0)) {
       match = name;
-    } else {
+    } else if (rmp->regprog != NULL) {
       // Replace $(HOME) with '~' and try matching again.
       p = home_replace_save(NULL, name);
       if (vim_regexec(rmp, p, (colnr_T)0)) {

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -61,4 +61,11 @@ func Test_buffer_scheme()
   set shellslash&
 endfunc
 
+" this was using a NULL pointer after failing to use the pattern
+func Test_buf_pattern_invalid()
+  vsplit 0000000
+  silent! buf [0--]\&\zs*\zs*e
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -66,6 +66,10 @@ func Test_buf_pattern_invalid()
   vsplit 0000000
   silent! buf [0--]\&\zs*\zs*e
   bwipe!
+
+  vsplit 00000000000000000000000000
+  silent! buf [0--]\&\zs*\zs*e
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4901: NULL pointer access when using invalid pattern

Problem:    NULL pointer access when using invalid pattern.
Solution:   Check for failed regexp program.
https://github.com/vim/vim/commit/8e4b76da1d7e987d43ca960dfbc372d1c617466f


#### vim-patch:8.2.4938: crash when matching buffer with invalid pattern

Problem:    Crash when matching buffer with invalid pattern.
Solution:   Check for NULL regprog.
https://github.com/vim/vim/commit/a59f2dfd0cf9ee1a584d3de5b7c2d47648e79060