### PR TITLE
build(lua2dox): add parenthesis around parameter types in documentation

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -336,8 +336,8 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                       that returns any of the above.
 
                 Parameters: ~
-                    {opts}       table|nil When omitted or "nil", retrieve the
-                                 current configuration. Otherwise, a
+                    {opts}       (table|nil) When omitted or "nil", retrieve
+                                 the current configuration. Otherwise, a
                                  configuration table with the following keys:
                                  • underline: (default true) Use underline for
                                    diagnostics. Options:
@@ -401,7 +401,7 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                                    displayed before lower severities (e.g.
                                    ERROR is displayed before WARN). Options:
                                    • reverse: (boolean) Reverse sort order
-                    {namespace}  number|nil Update the options for the given
+                    {namespace}  (number|nil) Update the options for the given
                                  namespace. When omitted, update the global
                                  diagnostic options.
 
@@ -409,28 +409,28 @@ disable({bufnr}, {namespace})                       *vim.diagnostic.disable()*
                 Disable diagnostics in the given buffer.
 
                 Parameters: ~
-                    {bufnr}      number|nil Buffer number, or 0 for current
+                    {bufnr}      (number|nil) Buffer number, or 0 for current
                                  buffer. When omitted, disable diagnostics in
                                  all buffers.
-                    {namespace}  number|nil Only disable diagnostics for the
+                    {namespace}  (number|nil) Only disable diagnostics for the
                                  given namespace.
 
 enable({bufnr}, {namespace})                         *vim.diagnostic.enable()*
                 Enable diagnostics in the given buffer.
 
                 Parameters: ~
-                    {bufnr}      number|nil Buffer number, or 0 for current
+                    {bufnr}      (number|nil) Buffer number, or 0 for current
                                  buffer. When omitted, enable diagnostics in
                                  all buffers.
-                    {namespace}  number|nil Only enable diagnostics for the
+                    {namespace}  (number|nil) Only enable diagnostics for the
                                  given namespace.
 
 fromqflist({list})                               *vim.diagnostic.fromqflist()*
                 Convert a list of quickfix items to a list of diagnostics.
 
                 Parameters: ~
-                    {list}  table A list of quickfix items from |getqflist()|
-                            or |getloclist()|.
+                    {list}  (table) A list of quickfix items from
+                            |getqflist()| or |getloclist()|.
 
                 Return: ~
                     array of diagnostics |diagnostic-structure|
@@ -439,9 +439,10 @@ get({bufnr}, {opts})                                    *vim.diagnostic.get()*
                 Get current diagnostics.
 
                 Parameters: ~
-                    {bufnr}  number|nil Buffer number to get diagnostics from.
-                             Use 0 for current buffer or nil for all buffers.
-                    {opts}   table|nil A table with the following keys:
+                    {bufnr}  (number|nil) Buffer number to get diagnostics
+                             from. Use 0 for current buffer or nil for all
+                             buffers.
+                    {opts}   (table|nil) A table with the following keys:
                              • namespace: (number) Limit diagnostics to the
                                given namespace.
                              • lnum: (number) Limit diagnostics to the given
@@ -449,67 +450,68 @@ get({bufnr}, {opts})                                    *vim.diagnostic.get()*
                              • severity: See |diagnostic-severity|.
 
                 Return: ~
-                    table A list of diagnostic items |diagnostic-structure|.
+                    (table) A list of diagnostic items |diagnostic-structure|.
 
 get_namespace({namespace})                    *vim.diagnostic.get_namespace()*
                 Get namespace metadata.
 
                 Parameters: ~
-                    {namespace}  number Diagnostic namespace
+                    {namespace}  (number) Diagnostic namespace
 
                 Return: ~
-                    table Namespace metadata
+                    (table) Namespace metadata
 
 get_namespaces()                             *vim.diagnostic.get_namespaces()*
                 Get current diagnostic namespaces.
 
                 Return: ~
-                    table A list of active diagnostic namespaces
+                    (table) A list of active diagnostic namespaces
                     |vim.diagnostic|.
 
 get_next({opts})                                   *vim.diagnostic.get_next()*
                 Get the next diagnostic closest to the cursor position.
 
                 Parameters: ~
-                    {opts}  table See |vim.diagnostic.goto_next()|
+                    {opts}  (table) See |vim.diagnostic.goto_next()|
 
                 Return: ~
-                    table Next diagnostic
+                    (table) Next diagnostic
 
 get_next_pos({opts})                           *vim.diagnostic.get_next_pos()*
                 Return the position of the next diagnostic in the current
                 buffer.
 
                 Parameters: ~
-                    {opts}  table See |vim.diagnostic.goto_next()|
+                    {opts}  (table) See |vim.diagnostic.goto_next()|
 
                 Return: ~
-                    table Next diagnostic position as a (row, col) tuple.
+                    (table) Next diagnostic position as a (row, col) tuple.
 
 get_prev({opts})                                   *vim.diagnostic.get_prev()*
                 Get the previous diagnostic closest to the cursor position.
 
                 Parameters: ~
-                    {opts}  table See |vim.diagnostic.goto_next()|
+                    {opts}  (table) See |vim.diagnostic.goto_next()|
 
                 Return: ~
-                    table Previous diagnostic
+                    (table) Previous diagnostic
 
 get_prev_pos({opts})                           *vim.diagnostic.get_prev_pos()*
                 Return the position of the previous diagnostic in the current
                 buffer.
 
                 Parameters: ~
-                    {opts}  table See |vim.diagnostic.goto_next()|
+                    {opts}  (table) See |vim.diagnostic.goto_next()|
 
                 Return: ~
-                    table Previous diagnostic position as a (row, col) tuple.
+                    (table) Previous diagnostic position as a (row, col)
+                    tuple.
 
 goto_next({opts})                                 *vim.diagnostic.goto_next()*
                 Move to the next diagnostic.
 
                 Parameters: ~
-                    {opts}  table|nil Configuration table with the following
+                    {opts}  (table|nil) Configuration table with the following
                             keys:
                             • namespace: (number) Only consider diagnostics
                               from the given namespace.
@@ -533,7 +535,7 @@ goto_prev({opts})                                 *vim.diagnostic.goto_prev()*
                 Move to the previous diagnostic in the current buffer.
 
                 Parameters: ~
-                    {opts}  table See |vim.diagnostic.goto_next()|
+                    {opts}  (table) See |vim.diagnostic.goto_next()|
 
 hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
                 Hide currently displayed diagnostics.
@@ -547,10 +549,10 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
                 |vim.diagnostic.disable()|.
 
                 Parameters: ~
-                    {namespace}  number|nil Diagnostic namespace. When
+                    {namespace}  (number|nil) Diagnostic namespace. When
                                  omitted, hide diagnostics from all
                                  namespaces.
-                    {bufnr}      number|nil Buffer number, or 0 for current
+                    {bufnr}      (number|nil) Buffer number, or 0 for current
                                  buffer. When omitted, hide diagnostics in all
                                  buffers.
 
@@ -573,16 +575,16 @@ match({str}, {pat}, {groups}, {severity_map}, {defaults})
 <
 
                 Parameters: ~
-                    {str}           string String to parse diagnostics from.
-                    {pat}           string Lua pattern with capture groups.
-                    {groups}        table List of fields in a
+                    {str}           (string) String to parse diagnostics from.
+                    {pat}           (string) Lua pattern with capture groups.
+                    {groups}        (table) List of fields in a
                                     |diagnostic-structure| to associate with
                                     captures from {pat}.
-                    {severity_map}  table A table mapping the severity field
+                    {severity_map}  (table) A table mapping the severity field
                                     from {groups} with an item from
                                     |vim.diagnostic.severity|.
-                    {defaults}      table|nil Table of default values for any
-                                    fields not listed in {groups}. When
+                    {defaults}      (table|nil) Table of default values for
+                                    any fields not listed in {groups}. When
                                     omitted, numeric values default to 0 and
                                     "severity" defaults to ERROR.
 
@@ -594,7 +596,7 @@ open_float({opts}, {...})                        *vim.diagnostic.open_float()*
                 Show diagnostics in a floating window.
 
                 Parameters: ~
-                    {opts}  table|nil Configuration table with the same keys
+                    {opts}  (table|nil) Configuration table with the same keys
                             as |vim.lsp.util.open_floating_preview()| in
                             addition to the following:
                             • bufnr: (number) Buffer number to show
@@ -665,10 +667,10 @@ reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
                 |vim.diagnostic.hide()|.
 
                 Parameters: ~
-                    {namespace}  number|nil Diagnostic namespace. When
+                    {namespace}  (number|nil) Diagnostic namespace. When
                                  omitted, remove diagnostics from all
                                  namespaces.
-                    {bufnr}      number|nil Remove diagnostics for the given
+                    {bufnr}      (number|nil) Remove diagnostics for the given
                                  buffer. When omitted, diagnostics are removed
                                  for all buffers.
 
@@ -676,18 +678,18 @@ set({namespace}, {bufnr}, {diagnostics}, {opts})        *vim.diagnostic.set()*
                 Set diagnostics for the given namespace and buffer.
 
                 Parameters: ~
-                    {namespace}    number The diagnostic namespace
-                    {bufnr}        number Buffer number
-                    {diagnostics}  table A list of diagnostic items
+                    {namespace}    (number) The diagnostic namespace
+                    {bufnr}        (number) Buffer number
+                    {diagnostics}  (table) A list of diagnostic items
                                    |diagnostic-structure|
-                    {opts}         table|nil Display options to pass to
+                    {opts}         (table|nil) Display options to pass to
                                    |vim.diagnostic.show()|
 
 setloclist({opts})                               *vim.diagnostic.setloclist()*
                 Add buffer diagnostics to the location list.
 
                 Parameters: ~
-                    {opts}  table|nil Configuration table with the following
+                    {opts}  (table|nil) Configuration table with the following
                             keys:
                             • namespace: (number) Only add diagnostics from
                               the given namespace.
@@ -703,7 +705,7 @@ setqflist({opts})                                 *vim.diagnostic.setqflist()*
                 Add all diagnostics to the quickfix list.
 
                 Parameters: ~
-                    {opts}  table|nil Configuration table with the following
+                    {opts}  (table|nil) Configuration table with the following
                             keys:
                             • namespace: (number) Only add diagnostics from
                               the given namespace.
@@ -718,20 +720,20 @@ show({namespace}, {bufnr}, {diagnostics}, {opts})
                 Display diagnostics for the given namespace and buffer.
 
                 Parameters: ~
-                    {namespace}    number|nil Diagnostic namespace. When
+                    {namespace}    (number|nil) Diagnostic namespace. When
                                    omitted, show diagnostics from all
                                    namespaces.
-                    {bufnr}        number|nil Buffer number, or 0 for current
-                                   buffer. When omitted, show diagnostics in
-                                   all buffers.
-                    {diagnostics}  table|nil The diagnostics to display. When
-                                   omitted, use the saved diagnostics for the
-                                   given namespace and buffer. This can be
+                    {bufnr}        (number|nil) Buffer number, or 0 for
+                                   current buffer. When omitted, show
+                                   diagnostics in all buffers.
+                    {diagnostics}  (table|nil) The diagnostics to display.
+                                   When omitted, use the saved diagnostics for
+                                   the given namespace and buffer. This can be
                                    used to display a list of diagnostics
                                    without saving them or to display only a
                                    subset of diagnostics. May not be used when
                                    {namespace} or {bufnr} is nil.
-                    {opts}         table|nil Display options. See
+                    {opts}         (table|nil) Display options. See
                                    |vim.diagnostic.config()|.
 
 toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
@@ -739,7 +741,7 @@ toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
                 can be passed to |setqflist()| or |setloclist()|.
 
                 Parameters: ~
-                    {diagnostics}  table List of diagnostics
+                    {diagnostics}  (table) List of diagnostics
                                    |diagnostic-structure|.
 
                 Return: ~

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -669,10 +669,10 @@ for_each_buffer_client({bufnr}, {fn})
 
                 Parameters: ~
                     {bufnr}  (number) Buffer number
-                    {fn}     function Function to run on each client attached
-                             to buffer {bufnr}. The function takes the client,
-                             client ID, and buffer number as arguments.
-                             Example: >
+                    {fn}     (function) Function to run on each client
+                             attached to buffer {bufnr}. The function takes
+                             the client, client ID, and buffer number as
+                             arguments. Example: >
 
                                vim.lsp.for_each_buffer_client(0, function(client, client_id, bufnr)
                                  print(vim.inspect(client))
@@ -1879,8 +1879,9 @@ set_format_func({handle})                      *vim.lsp.log.set_format_func()*
                 Sets formatting function used to format logs
 
                 Parameters: ~
-                    {handle}  function function to apply to logging arguments,
-                              pass vim.inspect for multi-line formatting
+                    {handle}  (function) function to apply to logging
+                              arguments, pass vim.inspect for multi-line
+                              formatting
 
 set_level({level})                                   *vim.lsp.log.set_level()*
                 Sets the current log level.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -495,8 +495,8 @@ buf_detach_client({bufnr}, {client_id})          *vim.lsp.buf_detach_client()*
                 notification.
 
                 Parameters: ~
-                    {bufnr}      number Buffer handle, or 0 for current
-                    {client_id}  number Client id
+                    {bufnr}      (number) Buffer handle, or 0 for current
+                    {client_id}  (number) Client id
 
 buf_get_clients({bufnr})                           *vim.lsp.buf_get_clients()*
                 Gets a map of client_id:client pairs for the given buffer,
@@ -668,7 +668,7 @@ for_each_buffer_client({bufnr}, {fn})
                 Invokes a function for each LSP client attached to a buffer.
 
                 Parameters: ~
-                    {bufnr}  number Buffer number
+                    {bufnr}  (number) Buffer number
                     {fn}     function Function to run on each client attached
                              to buffer {bufnr}. The function takes the client,
                              client ID, and buffer number as arguments.
@@ -690,7 +690,7 @@ formatexpr({opts})                                      *vim.lsp.formatexpr()*
                 'v:lua.vim.lsp.formatexpr(#{timeout_ms:250})')`.
 
                 Parameters: ~
-                    {opts}  table options for customizing the formatting
+                    {opts}  (table) options for customizing the formatting
                             expression which takes the following optional
                             keys:
                             • timeout_ms (default 500ms). The timeout period
@@ -707,7 +707,7 @@ get_buffers_by_client_id({client_id})
                 Returns list of buffers attached to client_id.
 
                 Parameters: ~
-                    {client_id}  number client id
+                    {client_id}  (number) client id
 
                 Return: ~
                     list of buffer ids
@@ -717,7 +717,7 @@ get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
                 client may not yet be fully initialized.
 
                 Parameters: ~
-                    {client_id}  number client id
+                    {client_id}  (number) client id
 
                 Return: ~
                     |vim.lsp.client| object, or nil
@@ -820,7 +820,7 @@ start_client({config})                                *vim.lsp.start_client()*
                                          language server if requested via
                                          `workspace/configuration`. Keys are
                                          case-sensitive.
-                    {commands}           table Table that maps string of
+                    {commands}           (table) Table that maps string of
                                          clientside commands to user-defined
                                          functions. Commands passed to
                                          start_client take precedence over the
@@ -908,10 +908,10 @@ start_client({config})                                *vim.lsp.start_client()*
                                            kill -15. If set to false, nvim
                                            exits immediately after sending the
                                            'shutdown' request to the server.
-                    {root_dir}           string Directory where the LSP server
-                                         will base its workspaceFolders,
-                                         rootUri, and rootPath on
-                                         initialization.
+                    {root_dir}           (string) Directory where the LSP
+                                         server will base its
+                                         workspaceFolders, rootUri, and
+                                         rootPath on initialization.
 
                 Return: ~
                     Client id. |vim.lsp.get_client_by_id()| Note: client may
@@ -935,7 +935,7 @@ stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
                 Parameters: ~
                     {client_id}  client id or |vim.lsp.client| object, or list
                                  thereof
-                    {force}      boolean (optional) shutdown forcefully
+                    {force}      (boolean) (optional) shutdown forcefully
 
 tagfunc({...})                                             *vim.lsp.tagfunc()*
                 Provides an interface between the built-in client and
@@ -980,7 +980,7 @@ code_action({options})                             *vim.lsp.buf.code_action()*
                 position.
 
                 Parameters: ~
-                    {options}  table|nil Optional table which holds the
+                    {options}  (table|nil) Optional table which holds the
                                following optional fields:
                                • context (table|nil): Corresponds to `CodeActionContext` of the LSP specification:
                                  • diagnostics (table|nil): LSP`Diagnostic[]` . Inferred from the current position if not
@@ -1048,7 +1048,7 @@ execute_command({command_params})              *vim.lsp.buf.execute_command()*
                 Executes an LSP server command.
 
                 Parameters: ~
-                    {command_params}  table A valid `ExecuteCommandParams`
+                    {command_params}  (table) A valid `ExecuteCommandParams`
                                       object
 
                 See also: ~
@@ -1146,7 +1146,7 @@ formatting_sync({options}, {timeout_ms})
 <
 
                 Parameters: ~
-                    {options}     table|nil with valid `FormattingOptions`
+                    {options}     (table|nil) with valid `FormattingOptions`
                                   entries
                     {timeout_ms}  (number) Request timeout
 
@@ -1180,7 +1180,7 @@ range_code_action({context}, {start_pos}, {end_pos})
                 Performs |vim.lsp.buf.code_action()| for a given range.
 
                 Parameters: ~
-                    {context}    table|nil `CodeActionContext` of the LSP specification:
+                    {context}    (table|nil) `CodeActionContext` of the LSP specification:
                                  • diagnostics: (table|nil) LSP`Diagnostic[]` . Inferred from the current position if not
                                    provided.
                                  • only: (table|nil) List of LSP
@@ -1227,10 +1227,10 @@ rename({new_name}, {options})                           *vim.lsp.buf.rename()*
                 Renames all references to the symbol under the cursor.
 
                 Parameters: ~
-                    {new_name}  string|nil If not provided, the user will be
+                    {new_name}  (string|nil) If not provided, the user will be
                                 prompted for a new name using
                                 |vim.ui.input()|.
-                    {options}   table|nil additional options
+                    {options}   (table|nil) additional options
                                 • filter (function|nil): Predicate to filter
                                   clients used for rename. Receives the
                                   attached clients as argument and must return
@@ -1275,7 +1275,7 @@ get_namespace({client_id})                *vim.lsp.diagnostic.get_namespace()*
                 |vim.diagnostic|.
 
                 Parameters: ~
-                    {client_id}  number The id of the LSP client
+                    {client_id}  (number) The id of the LSP client
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
 on_publish_diagnostics({_}, {result}, {ctx}, {config})
@@ -1305,7 +1305,7 @@ on_publish_diagnostics({_}, {result}, {ctx}, {config})
 <
 
                 Parameters: ~
-                    {config}  table Configuration table (see
+                    {config}  (table) Configuration table (see
                               |vim.diagnostic.config()|).
 
 
@@ -1316,20 +1316,20 @@ display({lenses}, {bufnr}, {client_id})           *vim.lsp.codelens.display()*
                 Display the lenses using virtual text
 
                 Parameters: ~
-                    {lenses}     table of lenses to display (`CodeLens[] |
+                    {lenses}     (table) of lenses to display (`CodeLens[] |
                                  null`)
-                    {bufnr}      number
-                    {client_id}  number
+                    {bufnr}      (number)
+                    {client_id}  (number)
 
 get({bufnr})                                          *vim.lsp.codelens.get()*
                 Return all lenses for the given buffer
 
                 Parameters: ~
-                    {bufnr}  number Buffer number. 0 can be used for the
+                    {bufnr}  (number) Buffer number. 0 can be used for the
                              current buffer.
 
                 Return: ~
-                    table (`CodeLens[]`)
+                    (table) (`CodeLens[]`)
 
                                               *vim.lsp.codelens.on_codelens()*
 on_codelens({err}, {result}, {ctx}, {_})
@@ -1351,10 +1351,10 @@ save({lenses}, {bufnr}, {client_id})                 *vim.lsp.codelens.save()*
                 Store lenses for a specific buffer and client
 
                 Parameters: ~
-                    {lenses}     table of lenses to store (`CodeLens[] |
+                    {lenses}     (table) of lenses to store (`CodeLens[] |
                                  null`)
-                    {bufnr}      number
-                    {client_id}  number
+                    {bufnr}      (number)
+                    {client_id}  (number)
 
 
 ==============================================================================
@@ -1372,7 +1372,7 @@ hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
 <
 
                 Parameters: ~
-                    {config}  table Configuration table.
+                    {config}  (table) Configuration table.
                               • border: (default=nil)
                                 • Add borders to the floating window
                                 • See |nvim_open_win()|
@@ -1392,7 +1392,7 @@ signature_help({_}, {result}, {ctx}, {config})
 <
 
                 Parameters: ~
-                    {config}  table Configuration table.
+                    {config}  (table) Configuration table.
                               • border: (default=nil)
                                 • Add borders to the floating window
                                 • See |vim.api.nvim_open_win()|
@@ -1420,9 +1420,9 @@ apply_text_edits({text_edits}, {bufnr}, {offset_encoding})
                 Applies a list of text edits to a buffer.
 
                 Parameters: ~
-                    {text_edits}       table list of `TextEdit` objects
-                    {bufnr}            number Buffer id
-                    {offset_encoding}  string utf-8|utf-16|utf-32
+                    {text_edits}       (table) list of `TextEdit` objects
+                    {bufnr}            (number) Buffer id
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32
 
                 See also: ~
                     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textEdit
@@ -1432,24 +1432,24 @@ apply_workspace_edit({workspace_edit}, {offset_encoding})
                 Applies a `WorkspaceEdit`.
 
                 Parameters: ~
-                    {workspace_edit}   table `WorkspaceEdit`
-                    {offset_encoding}  string utf-8|utf-16|utf-32 (required)
+                    {workspace_edit}   (table) `WorkspaceEdit`
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32 (required)
 
 buf_clear_references({bufnr})            *vim.lsp.util.buf_clear_references()*
                 Removes document highlights from a buffer.
 
                 Parameters: ~
-                    {bufnr}  number Buffer id
+                    {bufnr}  (number) Buffer id
 
                                      *vim.lsp.util.buf_highlight_references()*
 buf_highlight_references({bufnr}, {references}, {offset_encoding})
                 Shows a list of document highlights for a certain buffer.
 
                 Parameters: ~
-                    {bufnr}            number Buffer id
-                    {references}       table List of `DocumentHighlight`
+                    {bufnr}            (number) Buffer id
+                    {references}       (table) List of `DocumentHighlight`
                                        objects to highlight
-                    {offset_encoding}  string One of "utf-8", "utf-16",
+                    {offset_encoding}  (string) One of "utf-8", "utf-16",
                                        "utf-32".
 
                 See also: ~
@@ -1464,9 +1464,9 @@ character_offset({buf}, {row}, {col}, {offset_encoding})
                     {buf}              buffer id (0 for current)
                     {row}              0-indexed line
                     {col}              0-indexed byte offset in line
-                    {offset_encoding}  string utf-8|utf-16|utf-32|nil defaults
-                                       to `offset_encoding` of first client of
-                                       `buf`
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
+                                       defaults to `offset_encoding` of first
+                                       client of `buf`
 
                 Return: ~
                     (number, number) `offset_encoding` index of the character
@@ -1543,8 +1543,8 @@ jump_to_location({location}, {offset_encoding})
                 Jumps to a location.
 
                 Parameters: ~
-                    {location}         table (`Location`|`LocationLink`)
-                    {offset_encoding}  string utf-8|utf-16|utf-32 (required)
+                    {location}         (table) (`Location`|`LocationLink`)
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32 (required)
 
                 Return: ~
                     `true` if the jump succeeded
@@ -1559,9 +1559,9 @@ locations_to_items({locations}, {offset_encoding})
                 |setqflist()| or |setloclist()|.
 
                 Parameters: ~
-                    {locations}        table list of `Location`s or
+                    {locations}        (table) list of `Location`s or
                                        `LocationLink`s
-                    {offset_encoding}  string offset_encoding for locations
+                    {offset_encoding}  (string) offset_encoding for locations
                                        utf-8|utf-16|utf-32
 
                 Return: ~
@@ -1606,7 +1606,7 @@ make_formatting_params({options})
                 buffer and cursor position.
 
                 Parameters: ~
-                    {options}  table|nil with valid `FormattingOptions`
+                    {options}  (table|nil) with valid `FormattingOptions`
                                entries
 
                 Return: ~
@@ -1629,9 +1629,9 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
                                        end of the last visual selection.
                     {bufnr}            (optional, number): buffer handle or 0
                                        for current, defaults to current
-                    {offset_encoding}  string utf-8|utf-16|utf-32|nil defaults
-                                       to `offset_encoding` of first client of
-                                       `bufnr`
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
+                                       defaults to `offset_encoding` of first
+                                       client of `bufnr`
 
                 Return: ~
                     { textDocument = { uri = `current_file_uri` }, range = {
@@ -1645,9 +1645,9 @@ make_position_params({window}, {offset_encoding})
                 Parameters: ~
                     {window}           (optional, number): window handle or 0
                                        for current, defaults to current
-                    {offset_encoding}  string utf-8|utf-16|utf-32|nil defaults
-                                       to `offset_encoding` of first client of
-                                       buffer of `window`
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
+                                       defaults to `offset_encoding` of first
+                                       client of buffer of `window`
 
                 Return: ~
                     `TextDocumentPositionParams` object
@@ -1666,9 +1666,9 @@ make_range_params({window}, {offset_encoding})
                 Parameters: ~
                     {window}           (optional, number): window handle or 0
                                        for current, defaults to current
-                    {offset_encoding}  string utf-8|utf-16|utf-32|nil defaults
-                                       to `offset_encoding` of first client of
-                                       buffer of `window`
+                    {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
+                                       defaults to `offset_encoding` of first
+                                       client of buffer of `window`
 
                 Return: ~
                     { textDocument = { uri = `current_file_uri` }, range = {
@@ -1702,9 +1702,9 @@ open_floating_preview({contents}, {syntax}, {opts})
                 Shows contents in a floating window.
 
                 Parameters: ~
-                    {contents}  table of lines to show in window
-                    {syntax}    string of syntax to set for opened buffer
-                    {opts}      table with optional fields (additional keys
+                    {contents}  (table) of lines to show in window
+                    {syntax}    (string) of syntax to set for opened buffer
+                    {opts}      (table) with optional fields (additional keys
                                 are passed on to |vim.api.nvim_open_win()|)
                                 • height: (number) height of floating window
                                 • width: (number) width of floating window
@@ -1739,10 +1739,10 @@ parse_snippet({input})                          *vim.lsp.util.parse_snippet()*
                 Parses snippets in a completion entry.
 
                 Parameters: ~
-                    {input}  string unparsed snippet
+                    {input}  (string) unparsed snippet
 
                 Return: ~
-                    string parsed snippet
+                    (string) parsed snippet
 
 preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
                 Previews a location in a floating window
@@ -1795,7 +1795,7 @@ stylize_markdown({bufnr}, {contents}, {opts})
                 `open_floating_preview` instead
 
                 Parameters: ~
-                    {contents}  table of lines to show in window
+                    {contents}  (table) of lines to show in window
                     {opts}      dictionary with optional fields
                                 • height of floating window
                                 • width of floating window
@@ -1873,7 +1873,7 @@ get_level()                                          *vim.lsp.log.get_level()*
                 Gets the current log level.
 
                 Return: ~
-                    string current log level
+                    (string) current log level
 
 set_format_func({handle})                      *vim.lsp.log.set_format_func()*
                 Sets formatting function used to format logs
@@ -1892,7 +1892,7 @@ should_log({level})                                 *vim.lsp.log.should_log()*
                 Checks whether the level is sufficient for logging.
 
                 Parameters: ~
-                    {level}  number log level
+                    {level}  (number) log level
 
                 Return: ~
                     (bool) true if would log, false if not
@@ -1998,19 +1998,19 @@ compute_diff({prev_lines}, {curr_lines}, {firstline}, {lastline},
                 curr lines
 
                 Parameters: ~
-                    {prev_lines}       table list of lines
-                    {curr_lines}       table list of lines
-                    {firstline}        number line to begin search for first
+                    {prev_lines}       (table) list of lines
+                    {curr_lines}       (table) list of lines
+                    {firstline}        (number) line to begin search for first
                                        difference
-                    {lastline}         number line to begin search in
+                    {lastline}         (number) line to begin search in
                                        old_lines for last difference
-                    {new_lastline}     number line to begin search in
+                    {new_lastline}     (number) line to begin search in
                                        new_lines for last difference
-                    {offset_encoding}  string encoding requested by language
+                    {offset_encoding}  (string) encoding requested by language
                                        server
 
                 Return: ~
-                    table TextDocumentContentChangeEvent see https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocumentContentChangeEvent
+                    (table) TextDocumentContentChangeEvent see https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocumentContentChangeEvent
 
 
 ==============================================================================
@@ -2027,10 +2027,10 @@ resolve_capabilities({server_capabilities})
                 capabilities.
 
                 Parameters: ~
-                    {server_capabilities}  table Table of capabilities
+                    {server_capabilities}  (table) Table of capabilities
                                            supported by the server
 
                 Return: ~
-                    table Normalized table of capabilities
+                    (table) Normalized table of capabilities
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1319,7 +1319,8 @@ deprecate({name}, {alternative}, {version}, {plugin})        *vim.deprecate()*
 
                 Parameters: ~
                     {name}         string Deprecated function.
-                    {alternative}  string|nil Preferred alternative function.
+                    {alternative}  (string|nil) Preferred alternative
+                                   function.
                     {version}      string Version in which the deprecated
                                    function will be removed.
                     {plugin}       string|nil Plugin name that the function
@@ -1340,11 +1341,12 @@ notify({msg}, {level}, {opts})                                  *vim.notify()*
                 notification provider). By default, writes to |:messages|.
 
                 Parameters: ~
-                    {msg}    string Content of the notification to show to the
-                             user.
-                    {level}  number|nil One of the values from
+                    {msg}    (string) Content of the notification to show to
+                             the user.
+                    {level}  (number|nil) One of the values from
                              |vim.log.levels|.
-                    {opts}   table|nil Optional parameters. Unused by default.
+                    {opts}   (table|nil) Optional parameters. Unused by
+                             default.
 
 notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
                 Display a notification only one time.
@@ -1353,11 +1355,12 @@ notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
                 message will not display a notification.
 
                 Parameters: ~
-                    {msg}    string Content of the notification to show to the
-                             user.
-                    {level}  number|nil One of the values from
+                    {msg}    (string) Content of the notification to show to
+                             the user.
+                    {level}  (number|nil) One of the values from
                              |vim.log.levels|.
-                    {opts}   table|nil Optional parameters. Unused by default.
+                    {opts}   (table|nil) Optional parameters. Unused by
+                             default.
 
 on_key({fn}, {ns_id})                                           *vim.on_key()*
                 Adds Lua function {fn} with namespace id {ns_id} as a listener
@@ -1383,8 +1386,8 @@ on_key({fn}, {ns_id})                                           *vim.on_key()*
                              returns a new |nvim_create_namespace()| id.
 
                 Return: ~
-                    number Namespace id associated with {fn}. Or count of all
-                    callbacks if on_key() is called without arguments.
+                    (number) Namespace id associated with {fn}. Or count of
+                    all callbacks if on_key() is called without arguments.
 
                 Note:
                     {fn} will be removed if an error occurs while calling.
@@ -1438,12 +1441,12 @@ region({bufnr}, {pos1}, {pos2}, {regtype}, {inclusive})         *vim.region()*
                 marked by two points
 
                 Parameters: ~
-                    {bufnr}      number of buffer
+                    {bufnr}      (number) of buffer
                     {pos1}       (line, column) tuple marking beginning of
                                  region
                     {pos2}       (line, column) tuple marking end of region
                     {regtype}    type of selection (:help setreg)
-                    {inclusive}  boolean indicating whether the selection is
+                    {inclusive}  (boolean) indicating whether the selection is
                                  end-inclusive
 
                 Return: ~
@@ -1470,7 +1473,7 @@ deep_equal({a}, {b})                                        *vim.deep_equal()*
                     {b}  any Second value
 
                 Return: ~
-                    boolean `true` if values are equals, else `false`
+                    (boolean) `true` if values are equals, else `false`
 
 deepcopy({orig})                                              *vim.deepcopy()*
                 Returns a deep copy of the given object. Non-table objects are
@@ -1481,29 +1484,29 @@ deepcopy({orig})                                              *vim.deepcopy()*
                 and will throw an error.
 
                 Parameters: ~
-                    {orig}  table Table to copy
+                    {orig}  (table) Table to copy
 
                 Return: ~
-                    table Table of copied keys and (nested) values.
+                    (table) Table of copied keys and (nested) values.
 
 endswith({s}, {suffix})                                       *vim.endswith()*
                 Tests if `s` ends with `suffix`.
 
                 Parameters: ~
-                    {s}       string String
-                    {suffix}  string Suffix to match
+                    {s}       (string) String
+                    {suffix}  (string) Suffix to match
 
                 Return: ~
-                    boolean `true` if `suffix` is a suffix of `s`
+                    (boolean) `true` if `suffix` is a suffix of `s`
 
 gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
                 Splits a string at each instance of a separator.
 
                 Parameters: ~
-                    {s}      string String to split
-                    {sep}    string Separator or pattern
-                    {plain}  boolean If `true` use `sep` literally (passed to
-                             string.find)
+                    {s}      (string) String to split
+                    {sep}    (string) Separator or pattern
+                    {plain}  (boolean) If `true` use `sep` literally (passed
+                             to string.find)
 
                 Return: ~
                     function Iterator over the split components
@@ -1520,7 +1523,7 @@ is_callable({f})                                           *vim.is_callable()*
                     {f}  any Any object
 
                 Return: ~
-                    boolean `true` if `f` is callable, else `false`
+                    (boolean) `true` if `f` is callable, else `false`
 
 list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
                 Extends a list-like table with the values of another list-like
@@ -1529,14 +1532,14 @@ list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
                 NOTE: This mutates dst!
 
                 Parameters: ~
-                    {dst}     table List which will be modified and appended
+                    {dst}     (table) List which will be modified and appended
                               to
-                    {src}     table List from which values will be inserted
-                    {start}   number Start index on src. Defaults to 1
-                    {finish}  number Final index on src. Defaults to `#src`
+                    {src}     (table) List from which values will be inserted
+                    {start}   (number) Start index on src. Defaults to 1
+                    {finish}  (number) Final index on src. Defaults to `#src`
 
                 Return: ~
-                    table dst
+                    (table) dst
 
                 See also: ~
                     |vim.tbl_extend()|
@@ -1546,22 +1549,22 @@ list_slice({list}, {start}, {finish})                       *vim.list_slice()*
                 to end (inclusive)
 
                 Parameters: ~
-                    {list}    table Table
-                    {start}   number Start range of slice
-                    {finish}  number End range of slice
+                    {list}    (table) Table
+                    {start}   (number) Start range of slice
+                    {finish}  (number) End range of slice
 
                 Return: ~
-                    table Copy of table sliced from start to finish
+                    (table) Copy of table sliced from start to finish
                     (inclusive)
 
 pesc({s})                                                         *vim.pesc()*
                 Escapes magic chars in a Lua pattern.
 
                 Parameters: ~
-                    {s}  string String to escape
+                    {s}  (string) String to escape
 
                 Return: ~
-                    string %-escaped pattern string
+                    (string) %-escaped pattern string
 
                 See also: ~
                     https://github.com/rxi/lume
@@ -1578,16 +1581,16 @@ split({s}, {sep}, {kwargs})                                      *vim.split()*
 <
 
                 Parameters: ~
-                    {s}       string String to split
-                    {sep}     string Separator or pattern
-                    {kwargs}  table Keyword arguments:
+                    {s}       (string) String to split
+                    {sep}     (string) Separator or pattern
+                    {kwargs}  (table) Keyword arguments:
                               • plain: (boolean) If `true` use `sep` literally
                                 (passed to string.find)
                               • trimempty: (boolean) If `true` remove empty
                                 items from the front and back of the list
 
                 Return: ~
-                    table List of split components
+                    (table) List of split components
 
                 See also: ~
                     |vim.gsplit()|
@@ -1596,11 +1599,11 @@ startswith({s}, {prefix})                                   *vim.startswith()*
                 Tests if `s` starts with `prefix`.
 
                 Parameters: ~
-                    {s}       string String
-                    {prefix}  string Prefix to match
+                    {s}       (string) String
+                    {prefix}  (string) Prefix to match
 
                 Return: ~
-                    boolean `true` if `prefix` is a prefix of `s`
+                    (boolean) `true` if `prefix` is a prefix of `s`
 
 tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
                 Add the reverse lookup values to an existing table. For
@@ -1610,20 +1613,20 @@ tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
                 Note that this modifies the input.
 
                 Parameters: ~
-                    {o}  table Table to add the reverse to
+                    {o}  (table) Table to add the reverse to
 
                 Return: ~
-                    table o
+                    (table) o
 
 tbl_contains({t}, {value})                                *vim.tbl_contains()*
                 Checks if a list-like (vector) table contains `value`.
 
                 Parameters: ~
-                    {t}      table Table to check
+                    {t}      (table) Table to check
                     {value}  any Value to compare
 
                 Return: ~
-                    boolean `true` if `t` contains `value`
+                    (boolean) `true` if `t` contains `value`
 
 tbl_count({t})                                               *vim.tbl_count()*
                 Counts the number of non-nil values in table `t`.
@@ -1634,10 +1637,10 @@ tbl_count({t})                                               *vim.tbl_count()*
 <
 
                 Parameters: ~
-                    {t}  table Table
+                    {t}  (table) Table
 
                 Return: ~
-                    number Number of non-nil values in table
+                    (number) Number of non-nil values in table
 
                 See also: ~
                     https://github.com/Tieske/Penlight/blob/master/lua/pl/tablex.lua
@@ -1646,15 +1649,15 @@ tbl_deep_extend({behavior}, {...})                     *vim.tbl_deep_extend()*
                 Merges recursively two or more map-like tables.
 
                 Parameters: ~
-                    {behavior}  string Decides what to do if a key is found in
-                                more than one map:
+                    {behavior}  (string) Decides what to do if a key is found
+                                in more than one map:
                                 • "error": raise an error
                                 • "keep": use value from the leftmost map
                                 • "force": use value from the rightmost map
-                    {...}       table Two or more map-like tables
+                    {...}       (table) Two or more map-like tables
 
                 Return: ~
-                    table Merged table
+                    (table) Merged table
 
                 See also: ~
                     |tbl_extend()|
@@ -1663,15 +1666,15 @@ tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
                 Merges two or more map-like tables.
 
                 Parameters: ~
-                    {behavior}  string Decides what to do if a key is found in
-                                more than one map:
+                    {behavior}  (string) Decides what to do if a key is found
+                                in more than one map:
                                 • "error": raise an error
                                 • "keep": use value from the leftmost map
                                 • "force": use value from the rightmost map
-                    {...}       table Two or more map-like tables
+                    {...}       (table) Two or more map-like tables
 
                 Return: ~
-                    table Merged table
+                    (table) Merged table
 
                 See also: ~
                     |extend()|
@@ -1681,20 +1684,20 @@ tbl_filter({func}, {t})                                     *vim.tbl_filter()*
 
                 Parameters: ~
                     {func}  function|table Function or callable table
-                    {t}     table Table
+                    {t}     (table) Table
 
                 Return: ~
-                    table Table of filtered values
+                    (table) Table of filtered values
 
 tbl_flatten({t})                                           *vim.tbl_flatten()*
                 Creates a copy of a list-like table such that any nested
                 tables are "unrolled" and appended to the result.
 
                 Parameters: ~
-                    {t}  table List-like table
+                    {t}  (table) List-like table
 
                 Return: ~
-                    table Flattened copy of the given list-like table
+                    (table) Flattened copy of the given list-like table
 
                 See also: ~
                     From https://github.com/premake/premake-core/blob/master/src/base/table.lua
@@ -1710,8 +1713,8 @@ tbl_get({o}, {...})                                            *vim.tbl_get()*
 <
 
                 Parameters: ~
-                    {o}    table Table to index
-                    {...}  string Optional strings (0 or more, variadic) via
+                    {o}    (table) Table to index
+                    {...}  (string) Optional strings (0 or more, variadic) via
                            which to index the table
 
                 Return: ~
@@ -1721,10 +1724,10 @@ tbl_isempty({t})                                           *vim.tbl_isempty()*
                 Checks if a table is empty.
 
                 Parameters: ~
-                    {t}  table Table to check
+                    {t}  (table) Table to check
 
                 Return: ~
-                    boolean `true` if `t` is empty
+                    (boolean) `true` if `t` is empty
 
                 See also: ~
                     https://github.com/premake/premake-core/blob/master/src/base/table.lua
@@ -1738,20 +1741,20 @@ tbl_islist({t})                                             *vim.tbl_islist()*
                 |vim.fn|.
 
                 Parameters: ~
-                    {t}  table Table
+                    {t}  (table) Table
 
                 Return: ~
-                    boolean `true` if array-like table, else `false`
+                    (boolean) `true` if array-like table, else `false`
 
 tbl_keys({t})                                                 *vim.tbl_keys()*
                 Return a list of all keys used in a table. However, the order
                 of the return table of keys is not guaranteed.
 
                 Parameters: ~
-                    {t}  table Table
+                    {t}  (table) Table
 
                 Return: ~
-                    table List of keys
+                    (table) List of keys
 
                 See also: ~
                     From https://github.com/premake/premake-core/blob/master/src/base/table.lua
@@ -1761,30 +1764,30 @@ tbl_map({func}, {t})                                           *vim.tbl_map()*
 
                 Parameters: ~
                     {func}  function|table Function or callable table
-                    {t}     table Table
+                    {t}     (table) Table
 
                 Return: ~
-                    table Table of transformed values
+                    (table) Table of transformed values
 
 tbl_values({t})                                             *vim.tbl_values()*
                 Return a list of all values used in a table. However, the
                 order of the return table of values is not guaranteed.
 
                 Parameters: ~
-                    {t}  table Table
+                    {t}  (table) Table
 
                 Return: ~
-                    table List of values
+                    (table) List of values
 
 trim({s})                                                         *vim.trim()*
                 Trim whitespace (Lua pattern "%s") from both sides of a
                 string.
 
                 Parameters: ~
-                    {s}  string String to trim
+                    {s}  (string) String to trim
 
                 Return: ~
-                    string String with whitespace removed from its beginning
+                    (string) String with whitespace removed from its beginning
                     and end
 
                 See also: ~
@@ -1827,9 +1830,9 @@ validate({opt})                                               *vim.validate()*
 <
 
                 Parameters: ~
-                    {opt}  table Names of parameters to validate. Each key is
-                           a parameter name; each value is a tuple in one of
-                           these forms:
+                    {opt}  (table) Names of parameters to validate. Each key
+                           is a parameter name; each value is a tuple in one
+                           of these forms:
                            1. (arg_value, type_name, optional)
                               • arg_value: argument value
                               • type_name: string|table type name, one of:
@@ -1857,38 +1860,38 @@ uri_from_bufnr({bufnr})                                 *vim.uri_from_bufnr()*
                 Get a URI from a bufnr
 
                 Parameters: ~
-                    {bufnr}  number
+                    {bufnr}  (number)
 
                 Return: ~
-                    string URI
+                    (string) URI
 
 uri_from_fname({path})                                  *vim.uri_from_fname()*
                 Get a URI from a file path.
 
                 Parameters: ~
-                    {path}  string Path to file
+                    {path}  (string) Path to file
 
                 Return: ~
-                    string URI
+                    (string) URI
 
 uri_to_bufnr({uri})                                       *vim.uri_to_bufnr()*
                 Get the buffer for a uri. Creates a new unloaded buffer if no
                 buffer for the uri already exists.
 
                 Parameters: ~
-                    {uri}  string
+                    {uri}  (string)
 
                 Return: ~
-                    number bufnr
+                    (number) bufnr
 
 uri_to_fname({uri})                                       *vim.uri_to_fname()*
                 Get a filename from a URI
 
                 Parameters: ~
-                    {uri}  string
+                    {uri}  (string)
 
                 Return: ~
-                    string filename or unchanged URI for non-file URIs
+                    (string) filename or unchanged URI for non-file URIs
 
 
 ==============================================================================
@@ -1905,7 +1908,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
 <
 
                 Parameters: ~
-                    {opts}        table Additional options. See |input()|
+                    {opts}        (table) Additional options. See |input()|
                                   • prompt (string|nil) Text of the prompt.
                                     Defaults to `Input:`.
                                   • default (string|nil) Default reply to the
@@ -1944,8 +1947,8 @@ select({items}, {opts}, {on_choice})                         *vim.ui.select()*
 <
 
                 Parameters: ~
-                    {items}      table Arbitrary items
-                    {opts}       table Additional options
+                    {items}      (table) Arbitrary items
+                    {opts}       (table) Additional options
                                  • prompt (string|nil) Text of the prompt.
                                    Defaults to `Select one of:`
                                  • format_item (function item -> text)
@@ -2026,16 +2029,16 @@ add({filetypes})                                          *vim.filetype.add()*
 <
 
                 Parameters: ~
-                    {filetypes}  table A table containing new filetype maps
+                    {filetypes}  (table) A table containing new filetype maps
                                  (see example).
 
 match({name}, {bufnr})                                  *vim.filetype.match()*
                 Set the filetype for the given buffer from a file name.
 
                 Parameters: ~
-                    {name}   string File name (can be an absolute or relative
-                             path)
-                    {bufnr}  number|nil The buffer to set the filetype for.
+                    {name}   (string) File name (can be an absolute or
+                             relative path)
+                    {bufnr}  (number|nil) The buffer to set the filetype for.
                              Defaults to the current buffer.
 
 
@@ -2051,7 +2054,7 @@ del({modes}, {lhs}, {opts})                                 *vim.keymap.del()*
 <
 
                 Parameters: ~
-                    {opts}  table A table of optional arguments:
+                    {opts}  (table) A table of optional arguments:
                             • buffer: (number or boolean) Remove a mapping
                               from the given buffer. When "true" or 0, use the
                               current buffer.
@@ -2095,12 +2098,12 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
                     {mode}  string|table Same mode short names as
                             |nvim_set_keymap()|. Can also be list of modes to
                             create mapping on multiple modes.
-                    {lhs}   string Left-hand side |{lhs}| of the mapping.
+                    {lhs}   (string) Left-hand side |{lhs}| of the mapping.
                     {rhs}   string|function Right-hand side |{rhs}| of the
                             mapping. Can also be a Lua function. If a Lua
                             function and `opts.expr == true`, returning `nil`
                             is equivalent to an empty string.
-                    {opts}  table A table of |:map-arguments| such as
+                    {opts}  (table) A table of |:map-arguments| such as
                             "silent". In addition to the options listed in
                             |nvim_set_keymap()|, this table also accepts the
                             following keys:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1509,7 +1509,7 @@ gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
                              to string.find)
 
                 Return: ~
-                    function Iterator over the split components
+                    (function) Iterator over the split components
 
                 See also: ~
                     |vim.split()|
@@ -1921,10 +1921,10 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                                     |:command-completion|
                                   • highlight (function) Function that will be
                                     used for highlighting user inputs.
-                    {on_confirm}  function ((input|nil) -> ()) Called once the
-                                  user confirms or abort the input. `input` is
-                                  what the user typed. `nil` if the user
-                                  aborted the dialog.
+                    {on_confirm}  (function) ((input|nil) -> ()) Called once
+                                  the user confirms or abort the input.
+                                  `input` is what the user typed. `nil` if the
+                                  user aborted the dialog.
 
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*
                 Prompts the user to pick a single item from a collection of
@@ -1960,7 +1960,7 @@ select({items}, {opts}, {on_choice})                         *vim.ui.select()*
                                    use this to infer the structure or
                                    semantics of `items`, or the context in
                                    which select() was called.
-                    {on_choice}  function ((item|nil, idx|nil) -> ()) Called
+                    {on_choice}  (function) ((item|nil, idx|nil) -> ()) Called
                                  once the user made a choice. `idx` is the
                                  1-based index of `item` within `items`. `nil`
                                  if the user aborted the dialog.

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -472,8 +472,8 @@ parse_query({lang}, {query})                                   *parse_query()*
                 • `info.patterns` contains information about predicates.
 
                 Parameters: ~
-                    {lang}   string The language
-                    {query}  string A string containing the query (s-expr
+                    {lang}   (string) The language
+                    {query}  (string) A string containing the query (s-expr
                              syntax)
 
                 Return: ~
@@ -704,7 +704,7 @@ LanguageTree:register_cbs({self}, {cbs})         *LanguageTree:register_cbs()*
                 Registers callbacks for the parser.
 
                 Parameters: ~
-                    {cbs}   table An |nvim_buf_attach()|-like table argument
+                    {cbs}   (table) An |nvim_buf_attach()|-like table argument
                             with the following keys :
                             • `on_bytes` : see |nvim_buf_attach()|, but this will be
                               called after the parsers callback.

--- a/scripts/lua2dox.lua
+++ b/scripts/lua2dox.lua
@@ -404,9 +404,9 @@ function TLua2DoX_filter.readfile(this,AppStamp,Filename)
           state = 'in_magic_comment'
           local magic = string.sub(line, 4 + offset)
 
-          magic_split = string_split(magic, ' ')
+          local magic_split = string_split(magic, ' ')
 
-          type_index = 2
+          local type_index = 2
           if magic_split[1] == 'param' then
             type_index = type_index + 1
           end

--- a/scripts/lua2dox.lua
+++ b/scripts/lua2dox.lua
@@ -418,7 +418,9 @@ function TLua2DoX_filter.readfile(this,AppStamp,Filename)
               magic_split[type_index] == 'table' or
               magic_split[type_index] == 'table|nil' or
               magic_split[type_index] == 'boolean' or
-              magic_split[type_index] == 'boolean|nil'
+              magic_split[type_index] == 'boolean|nil' or
+              magic_split[type_index] == 'function' or
+              magic_split[type_index] == 'function|nil'
               then
             magic_split[type_index] = '(' .. magic_split[type_index] .. ')'
           end

--- a/scripts/lua2dox.lua
+++ b/scripts/lua2dox.lua
@@ -403,6 +403,27 @@ function TLua2DoX_filter.readfile(this,AppStamp,Filename)
         if string.sub(line, 3, 3) == '@' or string.sub(line, 1, 4) == '---@' then -- it's a magic comment
           state = 'in_magic_comment'
           local magic = string.sub(line, 4 + offset)
+
+          magic_split = string_split(magic, ' ')
+
+          type_index = 2
+          if magic_split[1] == 'param' then
+            type_index = type_index + 1
+          end
+
+          if magic_split[type_index] == 'number' or
+              magic_split[type_index] == 'number|nil' or
+              magic_split[type_index] == 'string' or
+              magic_split[type_index] == 'string|nil' or
+              magic_split[type_index] == 'table' or
+              magic_split[type_index] == 'table|nil' or
+              magic_split[type_index] == 'boolean' or
+              magic_split[type_index] == 'boolean|nil'
+              then
+            magic_split[type_index] = '(' .. magic_split[type_index] .. ')'
+          end
+          magic = table.concat(magic_split, ' ')
+
           outStream:writeln('/// @' .. magic)
           fn_magic = checkComment4fn(fn_magic,magic)
         elseif string.sub(line,3,3)=='-' then -- it's a nonmagic doc comment


### PR DESCRIPTION
build(lua2dox): add parenthesis around parameter types in documentation

This will check if the string after the variable in a @param is either
"number", "string", "table", "boolean" and "function" and if so add a
parenthesis around it. This will help separate the variable type with
the following text. Had all our functions been annotated with emmylua
then a more robust solution might have been preferable (such as always
assuming the third string is parameter type without making any checks).
I believe however this is a clear improvement over the current situation
and will suffice for now.