### PR TITLE
refactor: rename keymap.{c,h} to keycodes.{c,h}

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -239,6 +239,10 @@ preprocess_patch() {
   LC_ALL=C sed -e 's/\( [ab]\/src\/nvim\)\/highlight\(\.[ch]\)/\1\/highlight_group\2/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"
 
+  # Rename keymap.h to keycodes.h
+  LC_ALL=C sed -e 's/\( [ab]\/src\/nvim\)\/keymap\.h/\1\/keycodes.h/g' \
+    "$file" > "$file".tmp && mv "$file".tmp "$file"
+
   # Rename test_urls.vim to check_urls.vim
   LC_ALL=C sed -e 's@\( [ab]\)/runtime/doc/test\(_urls\.vim\)@\1/scripts/check\2@g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -29,7 +29,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"
 #include "nvim/mbyte.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -41,7 +41,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/if_cscope.h"
 #include "nvim/input.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/lua/executor.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -39,7 +39,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/if_cscope.h"
 #include "nvim/indent.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/lib/kvec.h"
 #include "nvim/log.h"
 #include "nvim/lua/executor.h"

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -27,7 +27,7 @@
 #include "nvim/fold.h"
 #include "nvim/getchar.h"
 #include "nvim/globals.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/os/input.h"

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -31,7 +31,7 @@
 #include "nvim/garray.h"
 #include "nvim/getchar.h"
 #include "nvim/input.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/lua/executor.h"
 #include "nvim/main.h"
 #include "nvim/mbyte.h"

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -9,7 +9,7 @@
 #include "nvim/charset.h"
 #include "nvim/edit.h"
 #include "nvim/eval.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/mouse.h"
@@ -17,12 +17,10 @@
 #include "nvim/vim.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "keymap.c.generated.h"
+# include "keycodes.c.generated.h"
 #endif
 
-/*
- * Some useful tables.
- */
+// Some useful tables.
 
 static const struct modmasktable {
   uint16_t mod_mask;  ///< Bit-mask for particular key modifier.
@@ -43,10 +41,9 @@ static const struct modmasktable {
   // NOTE: when adding an entry, update MAX_KEY_NAME_LEN!
 };
 
-/*
- * Shifted key terminal codes and their unshifted equivalent.
- * Don't add mouse codes here, they are handled separately!
- */
+// Shifted key terminal codes and their unshifted equivalent.
+// Don't add mouse codes here, they are handled separately!
+
 #define MOD_KEYS_ENTRY_SIZE 5
 
 static char_u modifier_keys_table[] =
@@ -461,10 +458,7 @@ int handle_x_keys(const int key)
   return key;
 }
 
-/*
- * Return a string which contains the name of the given key when the given
- * modifiers are down.
- */
+/// @return  a string which contains the name of the given key when the given modifiers are down.
 char_u *get_special_key_name(int c, int modifiers)
 {
   static char_u string[MAX_KEY_NAME_LEN + 1];
@@ -481,10 +475,8 @@ char_u *get_special_key_name(int c, int modifiers)
     c = KEY2TERMCAP1(c);
   }
 
-  /*
-   * Translate shifted special keys into unshifted keys and set modifier.
-   * Same for CTRL and ALT modifiers.
-   */
+  // Translate shifted special keys into unshifted keys and set modifier.
+  // Same for CTRL and ALT modifiers.
   if (IS_SPECIAL(c)) {
     for (i = 0; modifier_keys_table[i] != 0; i += MOD_KEYS_ENTRY_SIZE) {
       if (KEY2TERMCAP0(c) == (int)modifier_keys_table[i + 1]
@@ -500,10 +492,8 @@ char_u *get_special_key_name(int c, int modifiers)
   // try to find the key in the special key table
   table_idx = find_special_key_in_table(c);
 
-  /*
-   * When not a known special key, and not a printable character, try to
-   * extract modifiers.
-   */
+  // When not a known special key, and not a printable character, try to
+  // extract modifiers.
   if (c > 0
       && utf_char2len(c) == 1) {
     if (table_idx < 0
@@ -798,10 +788,8 @@ static int extract_modifiers(int key, int *modp, const bool simplify, bool *cons
   return key;
 }
 
-/*
- * Try to find key "c" in the special key table.
- * Return the index when found, -1 when not found.
- */
+/// Try to find key "c" in the special key table.
+/// @return  the index when found, -1 when not found.
 int find_special_key_in_table(int c)
 {
   int i;
@@ -844,10 +832,8 @@ int get_special_key_code(const char_u *name)
   return 0;
 }
 
-/*
- * Look up the given mouse code to return the relevant information in the other
- * arguments.  Return which button is down or was released.
- */
+/// Look up the given mouse code to return the relevant information in the other arguments.
+/// @return  which button is down or was released.
 int get_mouse_button(int code, bool *is_click, bool *is_drag)
 {
   int i;
@@ -1009,7 +995,7 @@ char *replace_termcodes(const char *const from, const size_t from_len, char **co
       } else {
         result[dlen++] = *src;
       }
-      ++src;
+      src++;
     }
   }
   result[dlen] = NUL;

--- a/src/nvim/keycodes.h
+++ b/src/nvim/keycodes.h
@@ -1,13 +1,11 @@
-#ifndef NVIM_KEYMAP_H
-#define NVIM_KEYMAP_H
+#ifndef NVIM_KEYCODES_H
+#define NVIM_KEYCODES_H
 
 #include "nvim/strings.h"
 
-/*
- * Keycode definitions for special keys.
- *
- * Any special key code sequences are replaced by these codes.
- */
+// Keycode definitions for special keys.
+//
+// Any special key code sequences are replaced by these codes.
 
 //
 // For MS-DOS some keys produce codes larger than 0xff. They are split into two
@@ -15,66 +13,49 @@
 //
 #define K_NUL                   (0xce)  // for MS-DOS: special key follows
 
-/*
- * K_SPECIAL is the first byte of a special key code and is always followed by
- * two bytes.
- * The second byte can have any value. ASCII is used for normal termcap
- * entries, 0x80 and higher for special keys, see below.
- * The third byte is guaranteed to be between 0x02 and 0x7f.
- */
-
+/// K_SPECIAL is the first byte of a special key code and is always followed by
+/// two bytes.
+/// The second byte can have any value. ASCII is used for normal termcap
+/// entries, 0x80 and higher for special keys, see below.
+/// The third byte is guaranteed to be between 0x02 and 0x7f.
 #define K_SPECIAL               (0x80)
 
-/*
- * Positive characters are "normal" characters.
- * Negative characters are special key codes.  Only characters below -0x200
- * are used to so that the absolute value can't be mistaken for a single-byte
- * character.
- */
+/// Positive characters are "normal" characters.
+/// Negative characters are special key codes.  Only characters below -0x200
+/// are used to so that the absolute value can't be mistaken for a single-byte
+/// character.
 #define IS_SPECIAL(c)           ((c) < 0)
 
-/*
- * Characters 0x0100 - 0x01ff have a special meaning for abbreviations.
- * Multi-byte characters also have ABBR_OFF added, thus are above 0x0200.
- */
+/// Characters 0x0100 - 0x01ff have a special meaning for abbreviations.
+/// Multi-byte characters also have ABBR_OFF added, thus are above 0x0200.
 #define ABBR_OFF                0x100
 
-/*
- * NUL cannot be in the input string, therefore it is replaced by
- *      K_SPECIAL   KS_ZERO     KE_FILLER
- */
+/// NUL cannot be in the input string, therefore it is replaced by
+///      K_SPECIAL   KS_ZERO     KE_FILLER
 #define KS_ZERO                 255
 
-/*
- * K_SPECIAL cannot be in the input string, therefore it is replaced by
- *      K_SPECIAL   KS_SPECIAL  KE_FILLER
- */
+/// K_SPECIAL cannot be in the input string, therefore it is replaced by
+///      K_SPECIAL   KS_SPECIAL  KE_FILLER
 #define KS_SPECIAL              254
 
-/*
- * KS_EXTRA is used for keys that have no termcap name
- *      K_SPECIAL   KS_EXTRA    KE_xxx
- */
+/// KS_EXTRA is used for keys that have no termcap name
+///      K_SPECIAL   KS_EXTRA    KE_xxx
 #define KS_EXTRA                253
 
-/*
- * KS_MODIFIER is used when a modifier is given for a (special) key
- *      K_SPECIAL   KS_MODIFIER bitmask
- */
+/// KS_MODIFIER is used when a modifier is given for a (special) key
+///      K_SPECIAL   KS_MODIFIER bitmask
 #define KS_MODIFIER             252
 
-/*
- * These are used for the GUI
- *      K_SPECIAL   KS_xxx      KE_FILLER
- */
+// These are used for the GUI
+//      K_SPECIAL   KS_xxx      KE_FILLER
+
 #define KS_MOUSE                251
 #define KS_MENU                 250
 #define KS_VER_SCROLLBAR        249
 #define KS_HOR_SCROLLBAR        248
 
-/*
- * Used for switching Select mode back on after a mapping or menu.
- */
+// Used for switching Select mode back on after a mapping or menu.
+
 #define KS_SELECT               245
 #define K_SELECT_STRING         (char_u *)"\200\365X"
 
@@ -87,30 +68,24 @@
 // Used for menu in a tab pages line.
 #define KS_TABMENU              239
 
-/*
- * Filler used after KS_SPECIAL and others
- */
+/// Filler used after KS_SPECIAL and others
 #define KE_FILLER               ('X')
 
-/*
- * translation of three byte code "K_SPECIAL a b" into int "K_xxx" and back
- */
+// translation of three byte code "K_SPECIAL a b" into int "K_xxx" and back
+
 #define TERMCAP2KEY(a, b)       (-((a) + ((int)(b) << 8)))
 #define KEY2TERMCAP0(x)         ((-(x)) & 0xff)
 #define KEY2TERMCAP1(x)         (((unsigned)(-(x)) >> 8) & 0xff)
 
-/*
- * get second or third byte when translating special key code into three bytes
- */
+// get second or third byte when translating special key code into three bytes
+
 #define K_SECOND(c)     ((c) == K_SPECIAL ? KS_SPECIAL : (c) == \
                          NUL ? KS_ZERO : KEY2TERMCAP0(c))
 
 #define K_THIRD(c)      (((c) == K_SPECIAL || (c) == \
                           NUL) ? KE_FILLER : KEY2TERMCAP1(c))
 
-/*
- * get single int code from second byte after K_SPECIAL
- */
+/// get single int code from second byte after K_SPECIAL
 #define TO_SPECIAL(a, b)    ((a) == KS_SPECIAL ? K_SPECIAL : (a) == \
                              KS_ZERO ? K_ZERO : TERMCAP2KEY(a, b))
 
@@ -247,9 +222,8 @@ enum key_extra {
   KE_COMMAND = 104,  // <Cmd> special key
 };
 
-/*
- * the three byte codes are replaced with the following int when using vgetc()
- */
+// the three byte codes are replaced with the following int when using vgetc()
+
 #define K_ZERO          TERMCAP2KEY(KS_ZERO, KE_FILLER)
 
 #define K_UP            TERMCAP2KEY('k', 'u')
@@ -430,10 +404,9 @@ enum key_extra {
 #define K_TABLINE       TERMCAP2KEY(KS_TABLINE, KE_FILLER)
 #define K_TABMENU       TERMCAP2KEY(KS_TABMENU, KE_FILLER)
 
-/*
- * Symbols for pseudo keys which are translated from the real key symbols
- * above.
- */
+// Symbols for pseudo keys which are translated from the real key symbols
+// above.
+
 #define K_LEFTMOUSE     TERMCAP2KEY(KS_EXTRA, KE_LEFTMOUSE)
 #define K_LEFTMOUSE_NM  TERMCAP2KEY(KS_EXTRA, KE_LEFTMOUSE_NM)
 #define K_LEFTDRAG      TERMCAP2KEY(KS_EXTRA, KE_LEFTDRAG)
@@ -486,11 +459,8 @@ enum key_extra {
 #define MOD_MASK_MULTI_CLICK    (MOD_MASK_2CLICK|MOD_MASK_3CLICK| \
                                  MOD_MASK_4CLICK)
 
-/*
- * The length of the longest special key name, including modifiers.
- * Current longest is <M-C-S-T-D-A-4-ScrollWheelRight> (length includes '<' and
- * '>').
- */
+/// The length of the longest special key name, including modifiers.
+/// Current longest is <M-C-S-T-D-A-4-ScrollWheelRight> (length includes '<' and '>').
 #define MAX_KEY_NAME_LEN    32
 
 // Maximum length of a special key event as tokens.  This includes modifiers.
@@ -524,6 +494,6 @@ enum {
 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "keymap.h.generated.h"
+# include "keycodes.h.generated.h"
 #endif
-#endif  // NVIM_KEYMAP_H
+#endif  // NVIM_KEYCODES_H

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -18,7 +18,7 @@
 #include "nvim/ex_docmd.h"
 #include "nvim/garray.h"
 #include "nvim/getchar.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/memory.h"
 #include "nvim/menu.h"
 #include "nvim/message.h"

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -24,7 +24,7 @@
 #include "nvim/getchar.h"
 #include "nvim/highlight.h"
 #include "nvim/input.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/main.h"
 #include "nvim/mbyte.h"
 #include "nvim/memory.h"

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -33,7 +33,7 @@
 #include "nvim/getchar.h"
 #include "nvim/globals.h"
 #include "nvim/indent.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/log.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -49,7 +49,7 @@
 #include "nvim/highlight.h"
 #include "nvim/highlight_group.h"
 #include "nvim/indent_c.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/macros.h"
 #include "nvim/mbyte.h"
 #include "nvim/memfile.h"

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -13,7 +13,7 @@
 #include "nvim/ex_cmds2.h"
 #include "nvim/fileio.h"
 #include "nvim/getchar.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/main.h"
 #include "nvim/mbyte.h"
 #include "nvim/memory.h"

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -27,7 +27,7 @@
 #include "nvim/highlight.h"
 #include "nvim/highlight_group.h"
 #include "nvim/indent_c.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/lua/executor.h"
 #include "nvim/macros.h"
 #include "nvim/mbyte.h"

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -56,7 +56,7 @@
 #include "nvim/getchar.h"
 #include "nvim/highlight.h"
 #include "nvim/highlight_group.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/log.h"
 #include "nvim/macros.h"
 #include "nvim/main.h"

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -31,7 +31,7 @@ enum { NUMBUFLEN = 65, };
 #define ROOT_UID 0
 
 #include "nvim/gettext.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/macros.h"
 
 // special attribute addition: Put message in history

--- a/test/symbolic/klee/nvim/keymap.c
+++ b/test/symbolic/klee/nvim/keymap.c
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 
 #include "nvim/types.h"
-#include "nvim/keymap.h"
+#include "nvim/keycodes.h"
 #include "nvim/ascii.h"
 #include "nvim/eval/typval.h"
 

--- a/test/symbolic/klee/viml_expressions_lexer.c
+++ b/test/symbolic/klee/viml_expressions_lexer.c
@@ -17,7 +17,7 @@
 #include "nvim/charset.c"
 #include "nvim/garray.c"
 #include "nvim/gettext.c"
-#include "nvim/keymap.c"
+#include "nvim/keycodes.c"
 #include "nvim/viml/parser/expressions.c"
 
 #define INPUT_SIZE 7

--- a/test/symbolic/klee/viml_expressions_parser.c
+++ b/test/symbolic/klee/viml_expressions_parser.c
@@ -17,7 +17,7 @@
 #include "nvim/garray.c"
 #include "nvim/gettext.c"
 #include "nvim/viml/parser/expressions.c"
-#include "nvim/keymap.c"
+#include "nvim/keycodes.c"
 
 #define INPUT_SIZE 50
 

--- a/test/unit/keycodes_spec.lua
+++ b/test/unit/keycodes_spec.lua
@@ -5,10 +5,10 @@ local ffi     = helpers.ffi
 local eq      = helpers.eq
 local neq     = helpers.neq
 
-local keymap = helpers.cimport('./src/nvim/keymap.h')
+local keymap = helpers.cimport('./src/nvim/keycodes.h')
 local NULL = helpers.NULL
 
-describe('keymap.c', function()
+describe('keycodes.c', function()
 
   describe('find_special_key()', function()
     local srcp = ffi.new('const unsigned char *[1]')


### PR DESCRIPTION
Most code in keymap.h is for keycode definitions, while most code in
keymap.c is for the parsing and conversion of keycodes.

The name "keymap" may also make people think these two files are for
mappings, while in fact keycodes are used even when no mappings are
involved, so "keycodes" should be a better file name than "keymap".