### PR TITLE
vim-patch:8.2.4941: '[ and '] marks may be wrong after undo

### DIFF
--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -733,4 +733,21 @@ func Test_undofile_cryptmethod_blowfish2()
   set undofile& undolevels& cryptmethod&
 endfunc
 
+func Test_undo_mark()
+  new
+  " The undo is applied to the only line.
+  call setline(1, 'hello')
+  call feedkeys("ggyiw$p", 'xt')
+  undo
+  call assert_equal([0, 1, 1, 0], getpos("'["))
+  call assert_equal([0, 1, 1, 0], getpos("']"))
+  " The undo removes the last line.
+  call feedkeys("Goaaaa\<Esc>", 'xt')
+  call feedkeys("obbbb\<Esc>", 'xt')
+  undo
+  call assert_equal([0, 2, 1, 0], getpos("'["))
+  call assert_equal([0, 2, 1, 0], getpos("']"))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2418,10 +2418,11 @@ static void u_undoredo(int undo, bool do_buf_event)
 
     changed_lines(top + 1, 0, bot, newsize - oldsize, do_buf_event);
 
-    // set '[ and '] mark
+    // Set the '[ mark.
     if (top + 1 < curbuf->b_op_start.lnum) {
       curbuf->b_op_start.lnum = top + 1;
     }
+    // Set the '] mark.
     if (newsize == 0 && top + 1 > curbuf->b_op_end.lnum) {
       curbuf->b_op_end.lnum = top + 1;
     } else if (top + newsize > curbuf->b_op_end.lnum) {
@@ -2440,6 +2441,14 @@ static void u_undoredo(int undo, bool do_buf_event)
     nuep = uep->ue_next;
     uep->ue_next = newlist;
     newlist = uep;
+  }
+
+  // Ensure the '[ and '] marks are within bounds.
+  if (curbuf->b_op_start.lnum > curbuf->b_ml.ml_line_count) {
+    curbuf->b_op_start.lnum = curbuf->b_ml.ml_line_count;
+  }
+  if (curbuf->b_op_end.lnum > curbuf->b_ml.ml_line_count) {
+    curbuf->b_op_end.lnum = curbuf->b_ml.ml_line_count;
   }
 
   // Adjust Extmarks


### PR DESCRIPTION
#### vim-patch:8.2.4941: '[ and '] marks may be wrong after undo

Problem:    '[ and '] marks may be wrong after undo.
Solution:   Adjust the '[ and '] marks if needed. (closes vim/vim#10407)
https://github.com/vim/vim/commit/82444cefa3fef87624a078ea86a72af7ef4ef42e