### PR TITLE
chore(editorconfig): remove "charset"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,13 +6,9 @@ indent_size = 2
 tab_width = 8
 end_of_line = lf
 insert_final_newline = true
-charset = utf-8
 
 [*.{c,h,in,lua}]
 max_line_length = 100
-
-[*.{vim,po}]
-charset = unset
 
 [{Makefile,**/Makefile,runtime/doc/*.txt}]
 indent_style = tab


### PR DESCRIPTION
Hardcoding a charset causes trouble when porting Vim patches.
I previously tried to unset "charset" for certain file extensions, but
vim-patch.sh can generate more files, and automatically detecting file
encoding is more correct anyway.