### PR TITLE
build: add a cmake target for all used linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,11 @@ jobs:
         run: ./ci/run_tests.sh build_nvim
 
       - if: "!cancelled()"
-        name: clint-full
-        run: ./ci/run_lint.sh clint-full
+        name: lint_c_full
+        run: ./ci/run_lint.sh lint_c_full
 
       - if: "!cancelled()"
-        name: stylua
+        name: lint_stylua
         uses: JohnnyMorganz/stylua-action@1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,16 +124,16 @@ jobs:
           git diff --color --exit-code
 
       - if: "!cancelled()"
-        name: lualint
-        run: ./ci/run_lint.sh lualint
+        name: lint_lua
+        run: ./ci/run_lint.sh lint_lua
 
       - if: "!cancelled()"
-        name: pylint
-        run: ./ci/run_lint.sh pylint
+        name: lint_py
+        run: ./ci/run_lint.sh lint_py
 
       - if: "!cancelled()"
-        name: shlint
-        run: ./ci/run_lint.sh shlint
+        name: lint_sh
+        run: ./ci/run_lint.sh lint_sh
 
       - if: "!cancelled()"
         name: check-single-includes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,11 @@ jobs:
         run: ./ci/run_tests.sh build_nvim
 
       - if: "!cancelled()"
-        name: lint_c_full
-        run: ./ci/run_lint.sh lint_c_full
+        name: lintcfull
+        run: ./ci/run_lint.sh lintcfull
 
       - if: "!cancelled()"
-        name: lint_stylua
+        name: lintstylua
         uses: JohnnyMorganz/stylua-action@1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,16 +124,16 @@ jobs:
           git diff --color --exit-code
 
       - if: "!cancelled()"
-        name: lint_lua
-        run: ./ci/run_lint.sh lint_lua
+        name: lintlua
+        run: ./ci/run_lint.sh lintlua
 
       - if: "!cancelled()"
-        name: lint_py
-        run: ./ci/run_lint.sh lint_py
+        name: lintpy
+        run: ./ci/run_lint.sh lintpy
 
       - if: "!cancelled()"
-        name: lint_sh
-        run: ./ci/run_lint.sh lint_sh
+        name: lintsh
+        run: ./ci/run_lint.sh lintsh
 
       - if: "!cancelled()"
         name: check-single-includes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,51 +745,13 @@ if(BUSTED_LUA_PRG)
     set_target_properties(functionaltest-lua PROPERTIES FOLDER test)
 endif()
 
-find_program(LUACHECK_PRG luacheck)
-find_program(STYLUA_PRG stylua)
-find_program(SHELLCHECK_PRG shellcheck)
-find_program(FLAKE8_PRG flake8)
-find_program(UNCRUSTIFY_PRG uncrustify)
-
-set(TARGET "lintlua")
-add_custom_target(${TARGET}
-  COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${LUACHECK_PRG}
-  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
-  -DTARGET=${TARGET}
-  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
-
-set(TARGET "lintstylua")
-add_custom_target(${TARGET}
-  COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${STYLUA_PRG}
-  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
-  -DTARGET=${TARGET}
-  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
-
-set(TARGET "lintsh")
-add_custom_target(${TARGET}
-  COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${SHELLCHECK_PRG}
-  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
-  -DTARGET=${TARGET}
-  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
-
-set(TARGET "lintpy")
-add_custom_target(${TARGET}
-  COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${FLAKE8_PRG}
-  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
-  -DTARGET=${TARGET}
-  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
-
-set(TARGET "lintuncrustify")
-add_custom_target(${TARGET}
-  COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${UNCRUSTIFY_PRG}
-  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
-  -DTARGET=${TARGET}
-  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+foreach(TARGET IN ITEMS lintlua lintsh lintpy lintuncrustify)
+  add_custom_target(${TARGET}
+    COMMAND ${CMAKE_COMMAND}
+    -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
+    -DTARGET=${TARGET}
+    -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+endforeach()
 
 #add uninstall target
 if(NOT TARGET uninstall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ find_program(SHELLCHECK_PRG shellcheck)
 find_program(FLAKE8_PRG flake8)
 find_program(UNCRUSTIFY_PRG uncrustify)
 
-set(TARGET "lint_lua")
+set(TARGET "lintlua")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${LUACHECK_PRG}
@@ -759,7 +759,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "lint_stylua")
+set(TARGET "lintstylua")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${STYLUA_PRG}
@@ -767,7 +767,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "lint_sh")
+set(TARGET "lintsh")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${SHELLCHECK_PRG}
@@ -775,7 +775,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "lint_py")
+set(TARGET "lintpy")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${FLAKE8_PRG}
@@ -783,7 +783,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "lint_uncrustify")
+set(TARGET "lintuncrustify")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${UNCRUSTIFY_PRG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ find_program(SHELLCHECK_PRG shellcheck)
 find_program(FLAKE8_PRG flake8)
 find_program(UNCRUSTIFY_PRG uncrustify)
 
-set(TARGET "lualint")
+set(TARGET "lint_lua")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${LUACHECK_PRG}
@@ -759,7 +759,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "stylua")
+set(TARGET "lint_stylua")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${STYLUA_PRG}
@@ -767,7 +767,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "shlint")
+set(TARGET "lint_sh")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${SHELLCHECK_PRG}
@@ -775,7 +775,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "pylint")
+set(TARGET "lint_py")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${FLAKE8_PRG}
@@ -783,7 +783,7 @@ add_custom_target(${TARGET}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
-set(TARGET "uncrustify")
+set(TARGET "lint_uncrustify")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
   -DPROGRAM=${UNCRUSTIFY_PRG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,9 +612,6 @@ if(NOT BUSTED_OUTPUT_TYPE)
   set(BUSTED_OUTPUT_TYPE "nvim")
 endif()
 
-find_program(LUACHECK_PRG luacheck)
-find_program(FLAKE8_PRG flake8)
-
 include(InstallHelpers)
 
 file(GLOB MANPAGES
@@ -748,15 +745,51 @@ if(BUSTED_LUA_PRG)
     set_target_properties(functionaltest-lua PROPERTIES FOLDER test)
 endif()
 
-if(LUACHECK_PRG)
-  add_custom_target(lualint
-    COMMAND ${LUACHECK_PRG} -q runtime/ scripts/ src/ test/
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-else()
-  add_custom_target(lualint false
-    COMMENT "lualint: LUACHECK_PRG not defined")
-endif()
+find_program(LUACHECK luacheck)
+find_program(STYLUA stylua)
+find_program(SHELLCHECK shellcheck)
+find_program(FLAKE8 flake8)
+find_program(UNCRUSTIFY uncrustify)
 
+set(TARGET "lualint")
+add_custom_target(${TARGET}
+  COMMAND ${CMAKE_COMMAND}
+  -DPROGRAM=${LUACHECK}
+  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
+  -DTARGET=${TARGET}
+  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+set(TARGET "stylua")
+add_custom_target(${TARGET}
+  COMMAND ${CMAKE_COMMAND}
+  -DPROGRAM=${STYLUA}
+  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
+  -DTARGET=${TARGET}
+  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+set(TARGET "shlint")
+add_custom_target(${TARGET}
+  COMMAND ${CMAKE_COMMAND}
+  -DPROGRAM=${SHELLCHECK}
+  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
+  -DTARGET=${TARGET}
+  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+set(TARGET "pylint")
+add_custom_target(${TARGET}
+  COMMAND ${CMAKE_COMMAND}
+  -DPROGRAM=${FLAKE8}
+  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
+  -DTARGET=${TARGET}
+  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+set(TARGET "uncrustify")
+add_custom_target(${TARGET}
+  COMMAND ${CMAKE_COMMAND}
+  -DPROGRAM=${UNCRUSTIFY}
+  -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
+  -DTARGET=${TARGET}
+  -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
 #add uninstall target
 if(NOT TARGET uninstall)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,16 +745,16 @@ if(BUSTED_LUA_PRG)
     set_target_properties(functionaltest-lua PROPERTIES FOLDER test)
 endif()
 
-find_program(LUACHECK luacheck)
-find_program(STYLUA stylua)
-find_program(SHELLCHECK shellcheck)
-find_program(FLAKE8 flake8)
-find_program(UNCRUSTIFY uncrustify)
+find_program(LUACHECK_PRG luacheck)
+find_program(STYLUA_PRG stylua)
+find_program(SHELLCHECK_PRG shellcheck)
+find_program(FLAKE8_PRG flake8)
+find_program(UNCRUSTIFY_PRG uncrustify)
 
 set(TARGET "lualint")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${LUACHECK}
+  -DPROGRAM=${LUACHECK_PRG}
   -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
@@ -762,7 +762,7 @@ add_custom_target(${TARGET}
 set(TARGET "stylua")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${STYLUA}
+  -DPROGRAM=${STYLUA_PRG}
   -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
@@ -770,7 +770,7 @@ add_custom_target(${TARGET}
 set(TARGET "shlint")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${SHELLCHECK}
+  -DPROGRAM=${SHELLCHECK_PRG}
   -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
@@ -778,7 +778,7 @@ add_custom_target(${TARGET}
 set(TARGET "pylint")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${FLAKE8}
+  -DPROGRAM=${FLAKE8_PRG}
   -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
@@ -786,7 +786,7 @@ add_custom_target(${TARGET}
 set(TARGET "uncrustify")
 add_custom_target(${TARGET}
   COMMAND ${CMAKE_COMMAND}
-  -DPROGRAM=${UNCRUSTIFY}
+  -DPROGRAM=${UNCRUSTIFY_PRG}
   -DPROJECT_ROOT=${PROJECT_SOURCE_DIR}
   -DTARGET=${TARGET}
   -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,8 @@ helphtml: | nvim build/runtime/doc/tags
 functionaltest functionaltest-lua unittest benchmark: | nvim
 	$(BUILD_TOOL) -C build $@
 
-lintstylua lintlua lintsh lintpy lintuncrustify lintc lintcfull check-single-includes generated-sources: | build/.ran-cmake
-	$(BUILD_TOOL) -C build $@
+lintlua lintsh lintpy lintuncrustify lintc lintcfull check-single-includes generated-sources: | build/.ran-cmake
+	$(CMAKE_PRG) --build build --target $@
 
 commitlint: | nvim
 	$(NVIM_PRG) -u NONE -es +"lua require('scripts.lintcommit').main({trace=false})"
@@ -171,7 +171,7 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-lint: check-single-includes lintc lintstylua lintlua lintpy lintsh _opt_commitlint
+lint: check-single-includes lintc lintlua lintpy lintsh _opt_commitlint lintuncrustify
 
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".
@@ -183,4 +183,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test lintstylua lintlua lintpy lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint
+.PHONY: test lintlua lintpy lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint

--- a/Makefile
+++ b/Makefile
@@ -140,50 +140,18 @@ build/runtime/doc/tags helptags: | nvim
 helphtml: | nvim build/runtime/doc/tags
 	+$(BUILD_TOOL) -C build doc_html
 
-functionaltest: | nvim
-	+$(BUILD_TOOL) -C build functionaltest
+functionaltest functionaltest-lua unittest benchmark: | nvim
+	$(BUILD_TOOL) -C build $@
 
-functionaltest-lua: | nvim
-	+$(BUILD_TOOL) -C build functionaltest-lua
+stylua lualint shlint pylint uncrustify clint clint-full check-single-includes generated-sources: | build/.ran-cmake
+	$(BUILD_TOOL) -C build $@
 
-stylua:
-	stylua --check runtime/
-
-lualint: | build/.ran-cmake deps
-	$(BUILD_TOOL) -C build lualint
-
-_opt_stylua:
-	@command -v stylua && { $(MAKE) stylua; exit $$?; } \
-		|| echo "SKIP: stylua (stylua not found)"
-
-shlint:
-	@shellcheck --version | head -n 2
-	shellcheck scripts/vim-patch.sh
-
-_opt_shlint:
-	@command -v shellcheck && { $(MAKE) shlint; exit $$?; } \
-		|| echo "SKIP: shlint (shellcheck not found)"
-
-pylint:
-	flake8 contrib/ scripts/ src/ test/
-
-# Run pylint only if flake8 is installed.
-_opt_pylint:
-	@command -v flake8 && { $(MAKE) pylint; exit $$?; } \
-		|| echo "SKIP: pylint (flake8 not found)"
-
-commitlint:
+commitlint: | nvim
 	$(NVIM_PRG) -u NONE -es +"lua require('scripts.lintcommit').main({trace=false})"
 
 _opt_commitlint:
 	@test -x build/bin/nvim && { $(MAKE) commitlint; exit $$?; } \
 		|| echo "SKIP: commitlint (build/bin/nvim not found)"
-
-unittest: | nvim
-	+$(BUILD_TOOL) -C build unittest
-
-benchmark: | nvim
-	+$(BUILD_TOOL) -C build benchmark
 
 test: functionaltest unittest
 
@@ -200,18 +168,6 @@ distclean:
 install: checkprefix nvim
 	+$(BUILD_TOOL) -C build install
 
-clint: build/.ran-cmake
-	+$(BUILD_TOOL) -C build clint
-
-clint-full: build/.ran-cmake
-	+$(BUILD_TOOL) -C build clint-full
-
-check-single-includes: build/.ran-cmake
-	+$(BUILD_TOOL) -C build check-single-includes
-
-generated-sources: build/.ran-cmake
-	+$(BUILD_TOOL) -C build generated-sources
-
 appimage:
 	bash scripts/genappimage.sh
 
@@ -221,7 +177,7 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-lint: check-single-includes clint _opt_stylua lualint _opt_pylint _opt_shlint _opt_commitlint
+lint: check-single-includes clint stylua lualint pylint shlint _opt_commitlint
 
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,7 @@ endif
 
 ifeq (,$(BUILD_TOOL))
   ifeq (Ninja,$(CMAKE_GENERATOR))
-    ifneq ($(shell $(CMAKE_PRG) --help 2>/dev/null | grep Ninja),)
-      BUILD_TOOL = ninja
-    else
-      # User's version of CMake doesn't support Ninja
-      BUILD_TOOL = $(MAKE)
-      CMAKE_GENERATOR := Unix Makefiles
-    endif
+    BUILD_TOOL = ninja
   else
     BUILD_TOOL = $(MAKE)
   endif

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ helphtml: | nvim build/runtime/doc/tags
 functionaltest functionaltest-lua unittest benchmark: | nvim
 	$(BUILD_TOOL) -C build $@
 
-lint_stylua lint_lua lint_sh lint_py lint_uncrustify lint_c lint_c_full check-single-includes generated-sources: | build/.ran-cmake
+lintstylua lintlua lintsh lintpy lintuncrustify lintc lintcfull check-single-includes generated-sources: | build/.ran-cmake
 	$(BUILD_TOOL) -C build $@
 
 commitlint: | nvim
@@ -171,7 +171,7 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-lint: check-single-includes lint_c lint_stylua lint_lua lint_py lint_sh _opt_commitlint
+lint: check-single-includes lintc lintstylua lintlua lintpy lintsh _opt_commitlint
 
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".
@@ -183,4 +183,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test lint_stylua lint_lua lint_py lint_sh functionaltest unittest lint lint_c clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint
+.PHONY: test lintstylua lintlua lintpy lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ helphtml: | nvim build/runtime/doc/tags
 functionaltest functionaltest-lua unittest benchmark: | nvim
 	$(BUILD_TOOL) -C build $@
 
-stylua lualint shlint pylint uncrustify clint clint-full check-single-includes generated-sources: | build/.ran-cmake
+lint_stylua lint_lua lint_sh lint_py lint_uncrustify lint_c lint_c_full check-single-includes generated-sources: | build/.ran-cmake
 	$(BUILD_TOOL) -C build $@
 
 commitlint: | nvim
@@ -171,7 +171,7 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-lint: check-single-includes clint stylua lualint pylint shlint _opt_commitlint
+lint: check-single-includes lint_c lint_stylua lint_lua lint_py lint_sh _opt_commitlint
 
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".
@@ -183,4 +183,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test stylua lualint pylint shlint functionaltest unittest lint clint clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint
+.PHONY: test lint_stylua lint_lua lint_py lint_sh functionaltest unittest lint lint_c clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint

--- a/ci/run_lint.sh
+++ b/ci/run_lint.sh
@@ -12,7 +12,7 @@ rm -f "$END_MARKER"
 
 # Run all tests if no input argument is given
 if (($# == 0)); then
-  tests=('clint-full' 'lualint' 'pylint' 'shlint' 'check-single-includes')
+  tests=('lint_c_full' 'lint_lua' 'lint_py' 'lint_sh' 'check-single-includes')
 else
   tests=("$@")
 fi

--- a/ci/run_lint.sh
+++ b/ci/run_lint.sh
@@ -12,7 +12,7 @@ rm -f "$END_MARKER"
 
 # Run all tests if no input argument is given
 if (($# == 0)); then
-  tests=('lint_c_full' 'lint_lua' 'lint_py' 'lint_sh' 'check-single-includes')
+  tests=('lintcfull' 'lintlua' 'lintpy' 'lintsh' 'check-single-includes')
 else
   tests=("$@")
 fi

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,24 +1,24 @@
 if(PROGRAM)
 
-  if(${TARGET} STREQUAL "uncrustify")
+  if(${TARGET} STREQUAL "lint_uncrustify")
     file(GLOB_RECURSE FILES ${PROJECT_ROOT}/src/nvim/*.[c,h])
     execute_process(COMMAND ${PROGRAM} -c src/uncrustify.cfg -q --check ${FILES}
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret
       OUTPUT_QUIET)
-  elseif(${TARGET} STREQUAL "pylint")
+  elseif(${TARGET} STREQUAL "lint_py")
     execute_process(COMMAND ${PROGRAM} contrib/ scripts/ src/ test/
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "shlint")
+  elseif(${TARGET} STREQUAL "lint_sh")
     execute_process(COMMAND ${PROGRAM} scripts/vim-patch.sh
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "stylua")
+  elseif(${TARGET} STREQUAL "lint_stylua")
     execute_process(COMMAND ${PROGRAM} --color=always --check runtime/
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lualint")
+  elseif(${TARGET} STREQUAL "lint_lua")
     execute_process(COMMAND ${PROGRAM} -q runtime/ scripts/ src/ test/
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,4 +1,4 @@
-function(LINT)
+function(lint)
   cmake_parse_arguments(LINT "QUIET" "PROGRAM" "FLAGS;FILES" ${ARGN})
 
   if(LINT_QUIET)

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,0 +1,35 @@
+if(PROGRAM)
+
+  if(${TARGET} STREQUAL "uncrustify")
+    file(GLOB_RECURSE FILES ${PROJECT_ROOT}/src/nvim/*.[c,h])
+    execute_process(COMMAND ${PROGRAM} -c src/uncrustify.cfg -q --check ${FILES}
+      WORKING_DIRECTORY ${PROJECT_ROOT}
+      RESULT_VARIABLE ret
+      OUTPUT_QUIET)
+  elseif(${TARGET} STREQUAL "pylint")
+    execute_process(COMMAND ${PROGRAM} contrib/ scripts/ src/ test/
+      WORKING_DIRECTORY ${PROJECT_ROOT}
+      RESULT_VARIABLE ret)
+  elseif(${TARGET} STREQUAL "shlint")
+    execute_process(COMMAND ${PROGRAM} scripts/vim-patch.sh
+      WORKING_DIRECTORY ${PROJECT_ROOT}
+      RESULT_VARIABLE ret)
+  elseif(${TARGET} STREQUAL "stylua")
+    execute_process(COMMAND ${PROGRAM} --color=always --check runtime/
+      WORKING_DIRECTORY ${PROJECT_ROOT}
+      RESULT_VARIABLE ret)
+  elseif(${TARGET} STREQUAL "lualint")
+    execute_process(COMMAND ${PROGRAM} -q runtime/ scripts/ src/ test/
+      WORKING_DIRECTORY ${PROJECT_ROOT}
+      RESULT_VARIABLE ret)
+  endif()
+
+  if(ret AND NOT ret EQUAL 0)
+    message(FATAL_ERROR "FAILED: ${TARGET}")
+  endif()
+
+else()
+  string(TOLOWER ${PROGRAM} PROGRAM)
+  string(REPLACE "-notfound" "" PROGRAM ${PROGRAM})
+  message(STATUS "${TARGET}: ${PROGRAM} not found. SKIP.")
+endif()

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,24 +1,24 @@
 if(PROGRAM)
 
-  if(${TARGET} STREQUAL "lint_uncrustify")
+  if(${TARGET} STREQUAL "lintuncrustify")
     file(GLOB_RECURSE FILES ${PROJECT_ROOT}/src/nvim/*.[c,h])
     execute_process(COMMAND ${PROGRAM} -c src/uncrustify.cfg -q --check ${FILES}
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret
       OUTPUT_QUIET)
-  elseif(${TARGET} STREQUAL "lint_py")
+  elseif(${TARGET} STREQUAL "lintpy")
     execute_process(COMMAND ${PROGRAM} contrib/ scripts/ src/ test/
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lint_sh")
+  elseif(${TARGET} STREQUAL "lintsh")
     execute_process(COMMAND ${PROGRAM} scripts/vim-patch.sh
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lint_stylua")
+  elseif(${TARGET} STREQUAL "lintstylua")
     execute_process(COMMAND ${PROGRAM} --color=always --check runtime/
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lint_lua")
+  elseif(${TARGET} STREQUAL "lintlua")
     execute_process(COMMAND ${PROGRAM} -q runtime/ scripts/ src/ test/
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret)

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,35 +1,34 @@
-if(PROGRAM)
+function(LINT)
+  cmake_parse_arguments(LINT "QUIET" "PROGRAM" "FLAGS;FILES" ${ARGN})
 
-  if(${TARGET} STREQUAL "lintuncrustify")
-    file(GLOB_RECURSE FILES ${PROJECT_ROOT}/src/nvim/*.[c,h])
-    execute_process(COMMAND ${PROGRAM} -c src/uncrustify.cfg -q --check ${FILES}
+  if(LINT_QUIET)
+    set(OUTPUT_QUIET OUTPUT_QUIET)
+  elseif()
+    set(OUTPUT_QUIET "")
+  endif()
+
+  find_program(PROGRAM_EXISTS ${LINT_PROGRAM})
+  if(PROGRAM_EXISTS)
+    execute_process(COMMAND ${LINT_PROGRAM} ${LINT_FLAGS} ${LINT_FILES}
       WORKING_DIRECTORY ${PROJECT_ROOT}
       RESULT_VARIABLE ret
-      OUTPUT_QUIET)
-  elseif(${TARGET} STREQUAL "lintpy")
-    execute_process(COMMAND ${PROGRAM} contrib/ scripts/ src/ test/
-      WORKING_DIRECTORY ${PROJECT_ROOT}
-      RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lintsh")
-    execute_process(COMMAND ${PROGRAM} scripts/vim-patch.sh
-      WORKING_DIRECTORY ${PROJECT_ROOT}
-      RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lintstylua")
-    execute_process(COMMAND ${PROGRAM} --color=always --check runtime/
-      WORKING_DIRECTORY ${PROJECT_ROOT}
-      RESULT_VARIABLE ret)
-  elseif(${TARGET} STREQUAL "lintlua")
-    execute_process(COMMAND ${PROGRAM} -q runtime/ scripts/ src/ test/
-      WORKING_DIRECTORY ${PROJECT_ROOT}
-      RESULT_VARIABLE ret)
+      ${OUTPUT_QUIET})
+    if(ret AND NOT ret EQUAL 0)
+      message(FATAL_ERROR "FAILED: ${TARGET}")
+    endif()
+  else()
+    message(STATUS "${TARGET}: ${LINT_PROGRAM} not found. SKIP.")
   endif()
+endfunction()
 
-  if(ret AND NOT ret EQUAL 0)
-    message(FATAL_ERROR "FAILED: ${TARGET}")
-  endif()
-
-else()
-  string(TOLOWER ${PROGRAM} PROGRAM)
-  string(REPLACE "-notfound" "" PROGRAM ${PROGRAM})
-  message(STATUS "${TARGET}: ${PROGRAM} not found. SKIP.")
+if(${TARGET} STREQUAL "lintuncrustify")
+  file(GLOB_RECURSE FILES ${PROJECT_ROOT}/src/nvim/*.[c,h])
+  lint(PROGRAM uncrustify FLAGS -c src/uncrustify.cfg -q --check FILES ${FILES} QUIET)
+elseif(${TARGET} STREQUAL "lintpy")
+  lint(PROGRAM flake8 FILES contrib/ scripts/ src/ test/)
+elseif(${TARGET} STREQUAL "lintsh")
+  lint(PROGRAM shellcheck FILES scripts/vim-patch.sh)
+elseif(${TARGET} STREQUAL "lintlua")
+  lint(PROGRAM luacheck FLAGS -q FILES runtime/ scripts/ src/ test/)
+  lint(PROGRAM stylua FLAGS --color=always --check FILES runtime/)
 endif()

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -800,10 +800,10 @@ foreach(sfile ${LINT_NVIM_SOURCES})
   list(APPEND LINT_TARGETS ${touch_file})
   list(APPEND LINT_NVIM_REL_SOURCES ${rsfile})
 endforeach()
-add_custom_target(clint DEPENDS ${LINT_TARGETS})
+add_custom_target(lint_c DEPENDS ${LINT_TARGETS})
 
 add_custom_target(
-  clint-full
+  lint_c_full
   COMMAND
     ${LINT_PRG} --suppress-errors=${LINT_SUPPRESS_FILE} ${LINT_NVIM_REL_SOURCES}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -800,10 +800,10 @@ foreach(sfile ${LINT_NVIM_SOURCES})
   list(APPEND LINT_TARGETS ${touch_file})
   list(APPEND LINT_NVIM_REL_SOURCES ${rsfile})
 endforeach()
-add_custom_target(lint_c DEPENDS ${LINT_TARGETS})
+add_custom_target(lintc DEPENDS ${LINT_TARGETS})
 
 add_custom_target(
-  lint_c_full
+  lintcfull
   COMMAND
     ${LINT_PRG} --suppress-errors=${LINT_SUPPRESS_FILE} ${LINT_NVIM_REL_SOURCES}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2307,6 +2307,7 @@ bool diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp)
 
   if ((dp == NULL) || (diff_check_sanity(curtab, dp) == FAIL)) {
     xfree(line_org);
+
     return false;
   }
 


### PR DESCRIPTION
build: add a cmake target for all used linters

Part 1 of the cmake saga (this one)
Part 2 is going to be checking the uncrustify version is OK, and warn if it isn't.
Part 3 is about creating a `make format` target that format everything.