### PR TITLE
fix(windows): stdpath("state") => "nvim-data"

### DIFF
--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -103,7 +103,8 @@ char *get_xdg_home(const XDGVarType idx)
   if (dir) {
 #if defined(WIN32)
     dir = concat_fnames_realloc(dir,
-                                (idx == kXDGDataHome ? "nvim-data" : "nvim"),
+                                ((idx == kXDGDataHome
+                                  || idx == kXDGStateHome) ? "nvim-data" : "nvim"),
                                 true);
 #else
     dir = concat_fnames_realloc(dir, "nvim", true);

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -206,7 +206,7 @@ describe('startup defaults', function()
 
   describe('$NVIM_LOG_FILE', function()
     local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = xdgdir..'/nvim'
+    local xdgstatedir = xdgdir..'/nvim-data'
     after_each(function()
       os.remove('Xtest-logpath')
       rmdir(xdgdir)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -206,7 +206,7 @@ describe('startup defaults', function()
 
   describe('$NVIM_LOG_FILE', function()
     local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = xdgdir..'/nvim-data'
+    local xdgstatedir = iswin() and xdgdir..'/nvim-data' or xdgdir..'/nvim'
     after_each(function()
       os.remove('Xtest-logpath')
       rmdir(xdgdir)


### PR DESCRIPTION
The tests are failing as the stdpath('data') had a nvim-data in its path
while stdpath('state') does not.
