### PR TITLE
revert: "feat(mappings): do not simplify the rhs of a mapping"

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -368,9 +368,8 @@ Macro/|recording| behavior
   the results of keys from 'keymap'.
 
 Mappings:
-- Creating a mapping for a simplifiable key (e.g. <C-I>) doesn't replace an
+  Creating a mapping for a simplifiable key (e.g. <C-I>) doesn't replace an
   existing mapping for its simplified form (e.g. <Tab>).
-- The rhs of a mapping is not simplified when it is defined.
 
 Motion:
   The |jumplist| avoids useless/phantom jumps.

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2904,8 +2904,8 @@ void set_maparg_lhs_rhs(const char *const orig_lhs, const size_t orig_lhs_len,
       mapargs->rhs_len = 0;
       mapargs->rhs_is_noop = true;
     } else {
-      replaced = replace_termcodes(orig_rhs, orig_rhs_len, &rhs_buf,
-                                   REPTERM_DO_LT | REPTERM_NO_SIMPLIFY, NULL, cpo_flags);
+      replaced = replace_termcodes(orig_rhs, orig_rhs_len, &rhs_buf, REPTERM_DO_LT, NULL,
+                                   cpo_flags);
       mapargs->rhs_len = STRLEN(replaced);
       // XXX: even when orig_rhs is non-empty, replace_termcodes may produce an empty string.
       mapargs->rhs_is_noop = orig_rhs[0] != NUL && mapargs->rhs_len == 0;

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -313,11 +313,6 @@ it('unsimplified mapping works when there was a partial match vim-patch:8.2.4504
   expect('xb')
 end)
 
-it('rhs of a mapping is not simplified', function()
-  command('nnoremap <Plug>foo <C-J>')
-  eq('<C-J>', funcs.maparg('<Plug>foo'))
-end)
-
 describe('input non-printable chars', function()
   after_each(function()
     os.remove('Xtest-overwrite')


### PR DESCRIPTION
This reverts commit 7ac5359143ef25c4c8c0c427d5533f8d5824ed17.
This fix can cause more problems than it solves.