### PR TITLE
perf(_editor): no need to stop inside vim.defer_fn

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -406,7 +406,6 @@ function vim.defer_fn(fn, timeout)
     timeout,
     0,
     vim.schedule_wrap(function()
-      timer:stop()
       timer:close()
 
       fn()


### PR DESCRIPTION
uv_run:
1. remove timer handle from heap
2. will start again if repeat is not 0