### PR TITLE
docs: expand nvim_set_hl attribute keys docs

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1577,11 +1577,11 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                     will clear the highlight group 'Visual'.
 
                 Note:
-                    The foreground and background keys also accept the string
-                    values `"fg"` or `"bg"` which act as aliases to the
-                    corresponding foreground and background values of the
-                    Normal group. If the Normal group has not been defined,
-                    using these values results in an error.
+                    The fg and bg keys also accept the string values `"fg"` or
+                    `"bg"` which act as aliases to the corresponding
+                    foreground and background values of the Normal group. If
+                    the Normal group has not been defined, using these values
+                    results in an error.
 
                 Parameters: ~
                     {ns_id}  Namespace id for this highlight
@@ -1590,11 +1590,11 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                     {name}   Highlight group name, e.g. "ErrorMsg"
                     {val}    Highlight definition map, accepts the following
                              keys:
-                             • foreground (or fg): color name or "#RRGGBB",
+                             • fg (or foreground): color name or "#RRGGBB",
                                see note.
-                             • background (or bg): color name or "#RRGGBB",
+                             • bg (or background): color name or "#RRGGBB",
                                see note.
-                             • special (or sp): color name or "#RRGGBB"
+                             • sp (or special): color name or "#RRGGBB"
                              • blend: integer between 0 and 100
                              • bold: boolean
                              • standout: boolean

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1570,10 +1570,18 @@ nvim_set_current_win({window})                        *nvim_set_current_win()*
 nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                 Sets a highlight group.
 
-                Note: Unlike the `:highlight` command which can update a
-                highlight group, this function completely replaces the
-                definition. For example: `nvim_set_hl(0, 'Visual', {})` will
-                clear the highlight group 'Visual'.
+                Note:
+                    Unlike the `:highlight` command which can update a
+                    highlight group, this function completely replaces the
+                    definition. For example: `nvim_set_hl(0, 'Visual', {})`
+                    will clear the highlight group 'Visual'.
+
+                Note:
+                    The foreground and background keys also accept the string
+                    values `"fg"` or `"bg"` which act as aliases to the
+                    corresponding foreground and background values of the
+                    Normal group. If the Normal group has not been defined,
+                    using these values results in an error.
 
                 Parameters: ~
                     {ns_id}  Namespace id for this highlight
@@ -1610,13 +1618,7 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                                |highlight-ctermbg|
                              • cterm: cterm attribute map, like
                                |highlight-args|. Note: Attributes default to
-                               those set for `gui` if not set. Note: The
-                               foreground and background keys also accept the
-                               string values `"fg"` or `"bg"` which act as
-                               aliases to the corresponding foreground and
-                               background values of the Normal group. If the
-                               Normal group has not been defined, using these
-                               values results in an error.
+                               those set for `gui` if not set.
 
 nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
                 Sets a global |mapping| for the given mode.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1580,8 +1580,28 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                              |nvim_create_namespace()|. Use 0 to set a
                              highlight group globally |:highlight|.
                     {name}   Highlight group name, e.g. "ErrorMsg"
-                    {val}    Highlight definition map, like |synIDattr()|. In
-                             addition, the following keys are recognized:
+                    {val}    Highlight definition map, accepts the following
+                             keys:
+                             • fg (or foreground): color name or "#RRGGBB",
+                               see note.
+                             • bg (or background): color name or "#RRGGBB",
+                               see note.
+                             • sp (or special): color name or "#RRGGBB"
+                             • blend: integer between 0 and 100
+                             • bold: boolean
+                             • standout: boolean
+                             • underline: boolean
+                             • underlineline: boolean
+                             • undercurl: boolean
+                             • underdot: boolean
+                             • underdash: boolean
+                             • strikethrough: boolean
+                             • italic: boolean
+                             • reverse: boolean
+                             • nocombine: boolean
+                             • link: name of another highlight group to link
+                               to, see |:hi-link|. Additionally, the following
+                               keys are recognized:
                              • default: Don't override existing definition
                                |:hi-default|
                              • ctermfg: Sets foreground of cterm color
@@ -1590,7 +1610,13 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                                |highlight-ctermbg|
                              • cterm: cterm attribute map, like
                                |highlight-args|. Note: Attributes default to
-                               those set for `gui` if not set.
+                               those set for `gui` if not set. Note: The fg
+                               and bg keys also accept the string values
+                               `"fg"` or `"bg"` which act as aliases to the
+                               corresponding fg and bg values of the Normal
+                               group. If the Normal group has not been
+                               defined, using these values results in an
+                               error.
 
 nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
                 Sets a global |mapping| for the given mode.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1617,8 +1617,9 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                              • ctermbg: Sets background of cterm color
                                |highlight-ctermbg|
                              • cterm: cterm attribute map, like
-                               |highlight-args|. Note: Attributes default to
-                               those set for `gui` if not set.
+                               |highlight-args|. If not set, cterm attributes
+                               will match those from the attribute map
+                               documented above.
 
 nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
                 Sets a global |mapping| for the given mode.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1582,11 +1582,11 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                     {name}   Highlight group name, e.g. "ErrorMsg"
                     {val}    Highlight definition map, accepts the following
                              keys:
-                             • fg (or foreground): color name or "#RRGGBB",
+                             • foreground (or fg): color name or "#RRGGBB",
                                see note.
-                             • bg (or background): color name or "#RRGGBB",
+                             • background (or bg): color name or "#RRGGBB",
                                see note.
-                             • sp (or special): color name or "#RRGGBB"
+                             • special (or sp): color name or "#RRGGBB"
                              • blend: integer between 0 and 100
                              • bold: boolean
                              • standout: boolean
@@ -1610,13 +1610,13 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                                |highlight-ctermbg|
                              • cterm: cterm attribute map, like
                                |highlight-args|. Note: Attributes default to
-                               those set for `gui` if not set. Note: The fg
-                               and bg keys also accept the string values
-                               `"fg"` or `"bg"` which act as aliases to the
-                               corresponding fg and bg values of the Normal
-                               group. If the Normal group has not been
-                               defined, using these values results in an
-                               error.
+                               those set for `gui` if not set. Note: The
+                               foreground and background keys also accept the
+                               string values `"fg"` or `"bg"` which act as
+                               aliases to the corresponding foreground and
+                               background values of the Normal group. If the
+                               Normal group has not been defined, using these
+                               values results in an error.
 
 nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
                 Sets a global |mapping| for the given mode.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -131,18 +131,18 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///       ``nvim_set_hl(0, 'Visual', {})`` will clear the highlight group
 ///       'Visual'.
 ///
-/// @note The foreground and background keys also accept the string values
-///       `"fg"` or `"bg"` which act as aliases to the corresponding foreground
-///       and background values of the Normal group. If the Normal group has not
-///       been defined, using these values results in an error.
+/// @note The fg and bg keys also accept the string values `"fg"` or `"bg"`
+///       which act as aliases to the corresponding foreground and background
+///       values of the Normal group. If the Normal group has not been defined,
+///       using these values results in an error.
 ///
 /// @param ns_id Namespace id for this highlight |nvim_create_namespace()|.
 ///              Use 0 to set a highlight group globally |:highlight|.
 /// @param name  Highlight group name, e.g. "ErrorMsg"
 /// @param val   Highlight definition map, accepts the following keys:
-///                - foreground (or fg): color name or "#RRGGBB", see note.
-///                - background (or bg): color name or "#RRGGBB", see note.
-///                - special (or sp): color name or "#RRGGBB"
+///                - fg (or foreground): color name or "#RRGGBB", see note.
+///                - bg (or background): color name or "#RRGGBB", see note.
+///                - sp (or special): color name or "#RRGGBB"
 ///                - blend: integer between 0 and 100
 ///                - bold: boolean
 ///                - standout: boolean

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -134,9 +134,9 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///              Use 0 to set a highlight group globally |:highlight|.
 /// @param name  Highlight group name, e.g. "ErrorMsg"
 /// @param val   Highlight definition map, accepts the following keys:
-///                - fg (or foreground): color name or "#RRGGBB", see note.
-///                - bg (or background): color name or "#RRGGBB", see note.
-///                - sp (or special): color name or "#RRGGBB"
+///                - foreground (or fg): color name or "#RRGGBB", see note.
+///                - background (or bg): color name or "#RRGGBB", see note.
+///                - special (or sp): color name or "#RRGGBB"
 ///                - blend: integer between 0 and 100
 ///                - bold: boolean
 ///                - standout: boolean
@@ -156,10 +156,11 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///                - ctermbg: Sets background of cterm color |highlight-ctermbg|
 ///                - cterm: cterm attribute map, like |highlight-args|.
 ///                  Note: Attributes default to those set for `gui` if not set.
-///             Note: The fg and bg keys also accept the string values `"fg"` or `"bg"`
-///                   which act as aliases to the corresponding fg and bg values of the
-///                   Normal group. If the Normal group has not been defined, using these
-///                   values results in an error.
+///             Note: The foreground and background keys also accept the string
+///                   values `"fg"` or `"bg"` which act as aliases to the
+///                   corresponding foreground and background values of the Normal group.
+///                   If the Normal group has not been defined, using these values
+///                   results in an error.
 /// @param[out] err Error details, if any
 ///
 // TODO(bfredl): val should take update vs reset flag

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -160,8 +160,9 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///                - default: Don't override existing definition |:hi-default|
 ///                - ctermfg: Sets foreground of cterm color |highlight-ctermfg|
 ///                - ctermbg: Sets background of cterm color |highlight-ctermbg|
-///                - cterm: cterm attribute map, like |highlight-args|.
-///                  Note: Attributes default to those set for `gui` if not set.
+///                - cterm: cterm attribute map, like |highlight-args|. If not set,
+///                         cterm attributes will match those from the attribute map
+///                         documented above.
 /// @param[out] err Error details, if any
 ///
 // TODO(bfredl): val should take update vs reset flag

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -133,15 +133,33 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 /// @param ns_id Namespace id for this highlight |nvim_create_namespace()|.
 ///              Use 0 to set a highlight group globally |:highlight|.
 /// @param name  Highlight group name, e.g. "ErrorMsg"
-/// @param val   Highlight definition map, like |synIDattr()|. In
-///              addition, the following keys are recognized:
+/// @param val   Highlight definition map, accepts the following keys:
+///                - fg (or foreground): color name or "#RRGGBB", see note.
+///                - bg (or background): color name or "#RRGGBB", see note.
+///                - sp (or special): color name or "#RRGGBB"
+///                - blend: integer between 0 and 100
+///                - bold: boolean
+///                - standout: boolean
+///                - underline: boolean
+///                - underlineline: boolean
+///                - undercurl: boolean
+///                - underdot: boolean
+///                - underdash: boolean
+///                - strikethrough: boolean
+///                - italic: boolean
+///                - reverse: boolean
+///                - nocombine: boolean
+///                - link: name of another highlight group to link to, see |:hi-link|.
+///              Additionally, the following keys are recognized:
 ///                - default: Don't override existing definition |:hi-default|
 ///                - ctermfg: Sets foreground of cterm color |highlight-ctermfg|
 ///                - ctermbg: Sets background of cterm color |highlight-ctermbg|
-///                - cterm: cterm attribute map, like
-///                  |highlight-args|.
-///                  Note: Attributes default to those set for `gui`
-///                        if not set.
+///                - cterm: cterm attribute map, like |highlight-args|.
+///                  Note: Attributes default to those set for `gui` if not set.
+///             Note: The fg and bg keys also accept the string values `"fg"` or `"bg"`
+///                   which act as aliases to the corresponding fg and bg values of the
+///                   Normal group. If the Normal group has not been defined, using these
+///                   values results in an error.
 /// @param[out] err Error details, if any
 ///
 // TODO(bfredl): val should take update vs reset flag

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -126,9 +126,15 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 
 /// Sets a highlight group.
 ///
-/// Note: Unlike the `:highlight` command which can update a highlight group,
-/// this function completely replaces the definition. For example:
-/// ``nvim_set_hl(0, 'Visual', {})`` will clear the highlight group 'Visual'.
+/// @note Unlike the `:highlight` command which can update a highlight group,
+///       this function completely replaces the definition. For example:
+///       ``nvim_set_hl(0, 'Visual', {})`` will clear the highlight group
+///       'Visual'.
+///
+/// @note The foreground and background keys also accept the string values
+///       `"fg"` or `"bg"` which act as aliases to the corresponding foreground
+///       and background values of the Normal group. If the Normal group has not
+///       been defined, using these values results in an error.
 ///
 /// @param ns_id Namespace id for this highlight |nvim_create_namespace()|.
 ///              Use 0 to set a highlight group globally |:highlight|.
@@ -156,11 +162,6 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///                - ctermbg: Sets background of cterm color |highlight-ctermbg|
 ///                - cterm: cterm attribute map, like |highlight-args|.
 ///                  Note: Attributes default to those set for `gui` if not set.
-///             Note: The foreground and background keys also accept the string
-///                   values `"fg"` or `"bg"` which act as aliases to the
-///                   corresponding foreground and background values of the Normal group.
-///                   If the Normal group has not been defined, using these values
-///                   results in an error.
 /// @param[out] err Error details, if any
 ///
 // TODO(bfredl): val should take update vs reset flag


### PR DESCRIPTION
The current docs for `nvim_set_hl` basically say "look at `synIDattr`", which is ok but:

It doesn't document:

- `link`
- `fg` & `bg` `"bg"` and `"fg"` "alias to Normal" color values.
- `blend`

Erroneously suggests:

- `font`
- `inverse`
- `fg#` & `bg#`

~~Not really sure what `nocombine` does, unsure if it should be documented there or if it's intended for internal use.~~ `:h nocombine`