### PR TITLE
refactor(dispatcher): remove unused headers

### DIFF
--- a/src/nvim/api/private/dispatch.c
+++ b/src/nvim/api/private/dispatch.c
@@ -6,33 +6,10 @@
 #include <msgpack.h>
 #include <stdbool.h>
 
-#include "nvim/api/deprecated.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
-#include "nvim/log.h"
 #include "nvim/map.h"
-#include "nvim/msgpack_rpc/helpers.h"
-#include "nvim/vim.h"
-
-// ===========================================================================
-// NEW API FILES MUST GO HERE.
-//
-//  When creating a new API file, you must include it here,
-//  so that the dispatcher can find the C functions that you are creating!
-// ===========================================================================
-#include "nvim/api/autocmd.h"
-#include "nvim/api/buffer.h"
-#include "nvim/api/command.h"
-#include "nvim/api/extmark.h"
-#include "nvim/api/options.h"
-#include "nvim/api/tabpage.h"
-#include "nvim/api/ui.h"
-#include "nvim/api/vim.h"
-#include "nvim/api/vimscript.h"
-#include "nvim/api/win_config.h"
-#include "nvim/api/window.h"
-#include "nvim/ui_client.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/dispatch_wrappers.generated.h"

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -185,6 +185,29 @@ funcs_metadata_output:close()
 -- start building the dispatch wrapper output
 local output = io.open(dispatch_outputf, 'wb')
 
+--- ===========================================================================
+--- NEW API FILES MUST GO HERE.
+---
+--- When creating a new API file, you must include it here,
+--- so that the dispatcher can find the C functions that you are creating!
+--- ===========================================================================
+output:write([[
+#include "nvim/api/autocmd.h"
+#include "nvim/api/buffer.h"
+#include "nvim/api/command.h"
+#include "nvim/api/deprecated.h"
+#include "nvim/api/extmark.h"
+#include "nvim/api/private/helpers.h"
+#include "nvim/api/tabpage.h"
+#include "nvim/api/options.h"
+#include "nvim/api/ui.h"
+#include "nvim/api/vim.h"
+#include "nvim/api/vimscript.h"
+#include "nvim/api/win_config.h"
+#include "nvim/api/window.h"
+
+]])
+
 local function real_type(type)
   local rv = type
   local rmatch = string.match(type, "Dict%(([_%w]+)%)")


### PR DESCRIPTION
Remove unused includes in `src/nvim/api/private/dispatch.c` and its generated counter-part by using the IWYU library.

Yet another step towards #6371 and #549
