### PR TITLE
feat(channels): introduce v:parent

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1034,16 +1034,14 @@ VimEnter			After doing all the startup stuff, including
 				   endif
 <							*VimLeave*
 VimLeave			Before exiting Vim, just after writing the
-				.shada file.  Executed only once, like
-				VimLeavePre.
+				|shada| file.  Executed exactly once.
 				Use |v:dying| to detect an abnormal exit.
 				Use |v:exiting| to get the exit code.
 				Not triggered if |v:dying| is 2 or more.
 							*VimLeavePre*
 VimLeavePre			Before exiting Vim, just before writing the
-				.shada file.  This is executed only once,
-				if there is a match with the name of what
-				happens to be the current buffer when exiting.
+				|shada| file.  Executed once, if the pattern
+				matches the current buffer name when exiting.
 				Mostly useful with a "*" pattern. >
 				   :autocmd VimLeavePre * call CleanupStuff()
 <				Use |v:dying| to detect an abnormal exit.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4327,8 +4327,6 @@ jobstart({cmd} [, {opts}])				*jobstart()*
 							*jobstart-env*
 		The job environment is initialized as follows:
 		  $NVIM                is set to |v:servername| of the parent Nvim
-		  $NVIM_LISTEN_ADDRESS is unset
-		  $NVIM_LOG_FILE       is unset
 		  $VIM                 is unset
 		  $VIMRUNTIME          is unset
 		You can set these with the `env` option.

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -24,12 +24,12 @@ Commands ~
 *:wviminfo*		Deprecated alias to |:wshada| command.
 
 Environment Variables ~
-*$NVIM_LISTEN_ADDRESS*	Deprecated way to
+*$NVIM_LISTEN_ADDRESS*	Deprecated way to:
 			* set the server name (use |--listen| instead)
 			* get the server name (use |v:servername| instead)
 			* detect a parent Nvim (use |$NVIM| instead)
-			Unset by |terminal| and |jobstart()| (unless explicitly
-			given by the "env" option). Ignored if --listen is given.
+			It is unset at startup (when |v:servername|
+			is initialized). Ignored if --listen is given.
 
 Events ~
 *BufCreate*		Use |BufAdd| instead.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2097,6 +2097,11 @@ v:operator	The last operator given in Normal mode.  This is a single
 		commands.
 		Read-only.
 
+					*v:parent* *parent-variable*
+v:parent	|RPC| channel to the parent Nvim, established at startup if
+		the current Nvim process is a child of another Nvim process,
+		determined by the presence of |$NVIM|.
+
 					*v:prevcount* *prevcount-variable*
 v:prevcount	The count given for the last but one Normal mode command.
 		This is the v:count value of the previous command.  Useful if
@@ -2143,14 +2148,13 @@ v:servername	Primary listen-address of the current Nvim instance, the first
 		Read-only.
 
 								       *$NVIM*
-		$NVIM is set by |terminal| and |jobstart()|, and is thus
-		a hint that the current environment is a subprocess of Nvim.
-		Example: >
+		$NVIM is set by |terminal| and |jobstart()| to v:servername,
+		and is thus a strong hint that the current environment is
+		a child of Nvim. Nvim automatically sets |v:parent| at startup
+		if $NVIM is a valid server. Example: >
 		    if $NVIM
-		      echo nvim_get_chan_info(v:parent)
+		      echo v:parent
 		    endif
-
-<		Note the contents of $NVIM may change in the future.
 
 v:searchforward			*v:searchforward* *searchforward-variable*
 		Search direction:  1 after a forward search, 0 after a

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -835,7 +835,7 @@ You can use them to jump from file to file.  You can only use an uppercase
 mark with an operator if the mark is in the current file.  The line number of
 the mark remains correct, even if you insert/delete lines or edit another file
 for a moment.  When the 'shada' option is not empty, uppercase marks are
-kept in the .shada file.  See |shada-file-marks|.
+kept in the |shada| file.  See |shada-file-marks|.
 
 Numbered marks '0 to '9 are quite different.  They can not be set directly.
 They are only present when using a shada file |shada-file|.  Basically '0

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -841,7 +841,7 @@ Short explanation of each option:		*option-list*
 'selection'	  'sel'     what type of selection to use
 'selectmode'	  'slm'     when to use Select mode instead of Visual mode
 'sessionoptions'  'ssop'    options for |:mksession|
-'shada'		  'sd'	    use .shada file upon startup and exiting
+'shada'		  'sd'	    use |shada| file upon startup and exiting
 'shell'		  'sh'	    name of shell to use for external commands
 'shellcmdflag'	  'shcf'    flag to shell to execute one command
 'shellpipe'	  'sp'	    string to put output of ":make" in error file

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -141,14 +141,6 @@ function vim._server_init()
   vim.api.nvim_exec([[call extend(v:parent, nvim_get_chan_info(]]..parent..[[), 'force')]], false)
 end
 
--- Disposes v:parent (from server.c).
-function vim._server_teardown()
-  local chan = vim.v.parent.id
-  if chan and chan > 0 then
-    vim.fn.chanclose(chan)
-  end
-end
-
 --- Return a human-readable representation of the given object.
 ---
 ---@see https://github.com/kikito/inspect.lua

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -104,7 +104,7 @@ get_vim_sources() {
     if ! [ -d ".git" ] \
         && ! [ "$(git rev-parse --show-toplevel)" = "${VIM_SOURCE_DIR}" ]; then
       msg_err "${VIM_SOURCE_DIR} does not appear to be a git repository."
-      echo "  Please remove it and try again."
+      echo "  Remove it and try again."
       exit 1
     fi
     echo "Updating Vim sources: ${VIM_SOURCE_DIR}"

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -473,8 +473,7 @@ void channel_from_connection(SocketWatcher *watcher)
   channel_create_event(channel, watcher->addr);
 }
 
-/// Creates an API channel from stdin/stdout. This is used when embedding
-/// Neovim
+/// Creates an API channel from stdin/stdout. Used when embedding Nvim.
 uint64_t channel_from_stdio(bool rpc, CallbackReader on_output, const char **error)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -249,6 +249,7 @@ static struct vimvar {
   VV(VV__NULL_DICT,       "_null_dict",       VAR_DICT, VV_RO),
   VV(VV__NULL_BLOB,       "_null_blob",       VAR_BLOB, VV_RO),
   VV(VV_LUA,              "lua",              VAR_PARTIAL, VV_RO),
+  VV(VV_PARENT,           "parent",           VAR_DICT, VV_RO),
 };
 #undef VV
 
@@ -414,6 +415,7 @@ void eval_init(void)
 
   set_vim_var_dict(VV_MSGPACK_TYPES, msgpack_types_dict);
   set_vim_var_dict(VV_COMPLETED_ITEM, tv_dict_alloc_lock(VAR_FIXED));
+  set_vim_var_dict(VV_PARENT, tv_dict_alloc_lock(VAR_FIXED));
 
   set_vim_var_dict(VV_EVENT, tv_dict_alloc_lock(VAR_FIXED));
   set_vim_var_list(VV_ERRORS, tv_list_alloc(kListLenUnknown));

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -172,6 +172,7 @@ typedef enum {
   VV__NULL_DICT,  // Dictionary with NULL value. For test purposes only.
   VV__NULL_BLOB,  // Blob with NULL value. For test purposes only.
   VV_LUA,
+  VV_PARENT,
 } VimVarIndex;
 
 /// All recognized msgpack types

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -1,3 +1,9 @@
+-- Generates API <=> Lua bridge C code.
+--
+-- Look for the results here:
+--    build/src/nvim/auto/lua_api_c_bindings.generated.c
+--    build/src/nvim/auto/api/private/dispatch_wrappers.generated.h
+
 local mpack = require('mpack')
 
 -- we need at least 4 arguments since the last two are output files
@@ -125,7 +131,7 @@ for _,f in ipairs(shallowcopy(functions)) do
       -- duplicate
       print("Function "..f.name.." has deprecated alias\n"
             ..newname.." which has a separate implementation.\n"..
-            "Please remove it from src/nvim/api/dispatch_deprecated.lua")
+            "Remove it from src/nvim/api/dispatch_deprecated.lua")
       os.exit(1)
     end
     local newf = shallowcopy(f)
@@ -406,6 +412,10 @@ output:write('\n')
 
 local lua_c_functions = {}
 
+-- Generates C code to bridge RPC API <=> Lua.
+--
+-- Look for the result here:
+--    build/src/nvim/auto/api/private/dispatch_wrappers.generated.h
 local function process_function(fn)
   local lua_c_function_name = ('nlua_api_%s'):format(fn.name)
   write_shifted_output(output, string.format([[

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -132,7 +132,7 @@ void event_init(void)
 }
 
 /// @returns false if main_loop could not be closed gracefully
-bool event_teardown(void)
+static bool event_teardown(void)
 {
   if (!main_loop.events) {
     input_stop();

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1,9 +1,9 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
-/*
- * mark.c: functions for setting marks and jumping to them
- */
+//
+// mark.c: functions for setting marks and jumping to them.
+//
 
 #include <assert.h>
 #include <inttypes.h>
@@ -40,19 +40,14 @@
 #include "nvim/ui.h"
 #include "nvim/vim.h"
 
-/*
- * This file contains routines to maintain and manipulate marks.
- */
-
-/*
- * If a named file mark's lnum is non-zero, it is valid.
- * If a named file mark's fnum is non-zero, it is for an existing buffer,
- * otherwise it is from .shada and namedfm[n].fname is the file name.
- * There are marks 'A - 'Z (set by user) and '0 to '9 (set when writing
- * shada).
- */
-
 /// Global marks (marks with file number or name)
+//
+// If a named file mark's lnum is non-zero, it is valid.
+// If a named file mark's fnum is non-zero, it is for an existing buffer,
+// otherwise it is from shada and namedfm[n].fname is the file name.
+// There are marks 'A - 'Z (set by user) and '0 to '9 (set when writing
+// shada).
+//
 static xfmark_T namedfm[NGLOBALMARKS];
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -653,11 +648,9 @@ fmark_T *getnextmark(pos_T *startpos, int dir, int begin_line)
   return result;
 }
 
-/*
- * For an xtended filemark: set the fnum from the fname.
- * This is used for marks obtained from the .shada file.  It's postponed
- * until the mark is used to avoid a long startup delay.
- */
+/// For an xtended filemark: set the fnum from the fname.
+/// This is used for marks obtained from the shada file.  It's postponed
+/// until the mark is used to avoid a long startup delay.
 static void fname2fnum(xfmark_T *fm)
 {
   char_u *p;
@@ -690,11 +683,9 @@ static void fname2fnum(xfmark_T *fm)
   }
 }
 
-/*
- * Check all file marks for a name that matches the file name in buf.
- * May replace the name with an fnum.
- * Used for marks that come from the .shada file.
- */
+/// Checks all file marks for a name that matches the file name in buf.
+/// May replace the name with an fnum.
+/// Used for marks that come from the shada file.
 void fmarks_check_names(buf_T *buf)
 {
   char_u *name = buf->b_ffname;

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -660,11 +660,17 @@ static const char *const msgpack_error_messages[] = {
   [MSGPACK_UNPACK_NOMEM_ERROR + MUR_OFF] = "not enough memory",
 };
 
-static void log_server_msg(uint64_t channel_id, msgpack_sbuffer *packed)
+static void log_server_msg(uint64_t chan, msgpack_sbuffer *packed)
 {
   msgpack_unpacked unpacked;
   msgpack_unpacked_init(&unpacked);
-  DLOGN("RPC ->ch %" PRIu64 ": ", channel_id);
+  if (chan == VIML_INTERNAL_CALL) {
+    DLOGN("RPC ->ch <V>: ");
+  } else if (chan == LUA_INTERNAL_CALL) {
+    DLOGN("RPC ->ch <L>: ");
+  } else {
+    DLOGN("RPC ->ch %" PRIu64 ": ", chan);
+  }
   const msgpack_unpack_return result =
     msgpack_unpack_next(&unpacked, packed->data, packed->size, NULL);
   switch (result) {
@@ -692,9 +698,15 @@ static void log_server_msg(uint64_t channel_id, msgpack_sbuffer *packed)
   }
 }
 
-static void log_client_msg(uint64_t channel_id, bool is_request, const char *name)
+static void log_client_msg(uint64_t chan, bool is_request, const char *name)
 {
-  DLOGN("RPC <-ch %" PRIu64 ": ", channel_id);
+  if (chan == VIML_INTERNAL_CALL) {
+    DLOGN("RPC <-ch <V>: ");
+  } else if (chan == LUA_INTERNAL_CALL) {
+    DLOGN("RPC <-ch <L>: ");
+  } else {
+    DLOGN("RPC <-ch %" PRIu64 ": ", chan);
+  }
   log_lock();
   FILE *f = open_log_file();
   fprintf(f, "%s: %s", is_request ? REQ : RES, name);

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -98,13 +98,6 @@ static void set_vservername(garray_T *srvs)
 /// Teardown the server module
 void server_teardown(void)
 {
-  DLOG("v:parent dispose");
-  Error err = ERROR_INIT;
-  nlua_exec(STATIC_CSTR_AS_STRING("return vim._server_teardown()"), (Array)ARRAY_DICT_INIT, &err);
-  if (ERROR_SET(&err)) {
-    ELOG("v:parent dispose failed: %s", err.msg);
-  }
-
   GA_DEEP_CLEAR(&watchers, SocketWatcher *, close_socket_watcher);
 }
 

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -648,10 +648,10 @@ describe('jobs', function()
   end)
 
   it('jobstart() environment: $NVIM, $NVIM_LISTEN_ADDRESS #11009', function()
-    local function get_env_in_child_job(envname, env)
+    local function get_child_env(cmdtype, envname, env)
       return exec_lua([[
-        local envname, env = ...
-        local join = function(s) return vim.fn.join(s, '') end
+        local cmdtype, envname, env = ...
+        local join = function(s) return (vim.fn.join(s, ''):gsub('[\r\n]', '')) end
         local stdout = {}
         local stderr = {}
         local opt = {
@@ -661,10 +661,15 @@ describe('jobs', function()
           on_stderr = function(chan, data, name) stderr = data end,
           on_stdout = function(chan, data, name) stdout = data end,
         }
-        local j1 = vim.fn.jobstart({ vim.v.progpath, '-es', '-V1',( '+echo "%s="..getenv("%s")'):format(envname, envname), '+qa!' }, opt)
-        vim.fn.jobwait({ j1 }, 10000)
+        local echocmd = vim.fn.has('win32') == 1 and 'echo %'..envname..'%' or 'echo $'..envname
+        local cmd = (cmdtype == 'echo'
+          and echocmd
+          or { vim.v.progpath, '-es', '-V1', ('+echo "%s="..getenv("%s")'):format(envname, envname), '+qa!' })
+        local j1 = vim.fn.jobstart(cmd, opt)
+        vim.fn.jobwait({ j1 }, 5000)
         return join({ join(stdout), join(stderr) })
       ]],
+      cmdtype,
       envname,
       env)
     end
@@ -674,14 +679,16 @@ describe('jobs', function()
     -- $NVIM is _not_ defined in the top-level Nvim process.
     eq('', eval('$NVIM'))
     -- jobstart() shares its v:servername with the child via $NVIM.
-    eq('NVIM='..addr, get_env_in_child_job('NVIM'))
+    -- Must use "echo" (not "nvim") because Nvim unsets $NVIM at startup.
+    eq(addr, get_child_env('echo', 'NVIM'))
+    -- eq('NVIM='..addr, get_child_env('nvim', 'NVIM'))
     -- $NVIM_LISTEN_ADDRESS is unset by server_init in the child.
-    eq('NVIM_LISTEN_ADDRESS=null', get_env_in_child_job('NVIM_LISTEN_ADDRESS'))
-    eq('NVIM_LISTEN_ADDRESS=null', get_env_in_child_job('NVIM_LISTEN_ADDRESS',
+    eq('NVIM_LISTEN_ADDRESS=null', get_child_env('nvim', 'NVIM_LISTEN_ADDRESS'))
+    eq('NVIM_LISTEN_ADDRESS=null', get_child_env('nvim', 'NVIM_LISTEN_ADDRESS',
       { NVIM_LISTEN_ADDRESS='Xtest_jobstart_env' }))
     -- User can explicitly set $NVIM_LOG_FILE, $VIM, $VIMRUNTIME.
     eq('NVIM_LOG_FILE=Xtest_jobstart_env',
-      get_env_in_child_job('NVIM_LOG_FILE', { NVIM_LOG_FILE='Xtest_jobstart_env' }))
+      get_child_env('nvim', 'NVIM_LOG_FILE', { NVIM_LOG_FILE='Xtest_jobstart_env' }))
     os.remove('Xtest_jobstart_env')
   end)
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -366,7 +366,7 @@ local function remove_args(args, args_rm)
   return new_args
 end
 
---- @param io_extra used for stdin_fd, see :help ui-option
+--- @param io_extra number used for stdin_fd, see :help ui-option
 function module.spawn(argv, merge, env, keep, io_extra)
   if session and not keep then
     session:close()


### PR DESCRIPTION
followup to https://github.com/neovim/neovim/pull/11009

- [x] ~~open channel to `$NVIM` automatically, expose it as `v:parent`~~ Update: Decided against `v:parent` because:
    1. `$NVIM` serves that purpose well enough
    2. it's somewhat "noisy" for a relatively uncommon use-case
    3. haven't seen demand for it (upvotes, comments)
- [ ] also set $NVIM in system(), shell (`:!`) ?
- [ ] related: #1758
