### PR TITLE
ci: enable tests on drafts as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
@@ -24,7 +23,7 @@ jobs:
     # we are able to build neovim without pigeonholing ourselves into specifics
     # of the bundled dependencies.
 
-    if: (github.event_name == 'pull_request' && github.base_ref == 'master' && !github.event.pull_request.draft) || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     env:
@@ -148,7 +147,6 @@ jobs:
             cmake: minimum_required
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-    if: github.event.pull_request.draft == false
     env:
       CC: ${{ matrix.cc }}
       CI_OS_NAME: ${{ matrix.os }}
@@ -235,7 +233,6 @@ jobs:
   windows:
     runs-on: windows-2019
     timeout-minutes: 45
-    if: github.event.pull_request.draft == false
     env:
       DEPS_BUILD_DIR: ${{ format('{0}/nvim-deps', github.workspace) }}
       DEPS_PREFIX: ${{ format('{0}/nvim-deps/usr', github.workspace) }}


### PR DESCRIPTION
The CI tests were initially disabled on drafts as a way to manage the
large number of incoming jobs. While this did help, it had the drawback
of making the purpose of the ready-for-review a bit fuzzier. It went
from a clear "my PR is ready" signal to maintainers to somewhere between
"my PR is ready but I need the tests to confirm" to "please don't merge
yet, I just need to see the test results". Worse is that the specific
case of wanting to see the test results but not wanting it merged is
that this needs to be actively conveyed to the maintainers with a [DNM]
or a comment to not merge the PR yet. All of this causes weird
workarounds and noises which I believe isn't necessary.

The reason why I don't think this workaround is needed anymore is that
our CI now aborts a job if a new job from the same pull requests is
created, which makes the "10 simultaneous jobs per PR" situations that
started this workaround not possible.