### PR TITLE
vim-patch:8.2.{4951,4953}: with 'si' inserting char after completion goes wrong

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -963,8 +963,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   char_u *p;
   char_u saved_char = NUL;        // init for GCC
   pos_T *pos;
-  bool do_si = (!p_paste && curbuf->b_p_si && !curbuf->b_p_cin
-                && *curbuf->b_p_inde == NUL);
+  bool do_si = may_do_si();
   bool do_cindent;
   bool no_si = false;             // reset did_si afterwards
   int first_char = NUL;           // init for GCC

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1396,7 +1396,7 @@ static void insert_do_complete(InsertState *s)
     compl_cont_status = 0;
   }
   compl_busy = false;
-  can_si = true;  // allow smartindenting
+  can_si = may_do_si();  // allow smartindenting
 }
 
 static void insert_do_cindent(InsertState *s)
@@ -9403,7 +9403,7 @@ static void ins_try_si(int c)
   /*
    * set indent of '#' always to 0
    */
-  if (curwin->w_cursor.col > 0 && can_si && c == '#') {
+  if (curwin->w_cursor.col > 0 && can_si && c == '#' && inindent(0)) {
     // remember current indent for next line
     old_indent = get_indent();
     (void)set_indent(0, SIN_CHANGED);

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -9344,10 +9344,8 @@ static void ins_try_si(int c)
   /*
    * do some very smart indenting when entering '{' or '}'
    */
-  if (((did_si || can_si_back) && c == '{') || (can_si && c == '}')) {
-    /*
-     * for '}' set indent equal to indent of line containing matching '{'
-     */
+  if (((did_si || can_si_back) && c == '{') || (can_si && c == '}' && inindent(0))) {
+    // for '}' set indent equal to indent of line containing matching '{'
     if (c == '}' && (pos = findmatch(NULL, '{')) != NULL) {
       old_pos = curwin->w_cursor;
       /*

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -522,6 +522,11 @@ int inindent(int extra)
   }
 }
 
+/// @return  true if the conditions are OK for smart indenting.
+bool may_do_si(void)
+{
+  return curbuf->b_p_si && !curbuf->b_p_cin && *curbuf->b_p_inde == NUL && !p_paste;
+}
 
 // Get indent level from 'indentexpr'.
 int get_expr_indent(void)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2507,10 +2507,7 @@ int op_change(oparg_T *oap)
   l = oap->start.col;
   if (oap->motion_type == kMTLineWise) {
     l = 0;
-    if (!p_paste && curbuf->b_p_si
-        && !curbuf->b_p_cin) {
-      can_si = true;            // It's like opening a new line, do si
-    }
+    can_si = may_do_si();  // Like opening a new line, do smart indent
   }
 
   // First delete the text in the region.  In an empty buffer only need to

--- a/src/nvim/testdir/test_smartindent.vim
+++ b/src/nvim/testdir/test_smartindent.vim
@@ -61,4 +61,21 @@ func Test_smartindent_braces()
   close!
 endfunc
 
+func Test_si_after_completion()
+  new
+  setlocal ai smartindent indentexpr=
+  call setline(1, 'foo foot')
+  call feedkeys("o  f\<C-X>\<C-N>#", 'tx')
+  call assert_equal('  foo#', getline(2))
+  bwipe!
+endfunc
+
+func Test_no_si_after_completion()
+  new
+  call setline(1, 'foo foot')
+  call feedkeys("o  f\<C-X>\<C-N>#", 'tx')
+  call assert_equal('  foo#', getline(2))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_smartindent.vim
+++ b/src/nvim/testdir/test_smartindent.vim
@@ -67,6 +67,11 @@ func Test_si_after_completion()
   call setline(1, 'foo foot')
   call feedkeys("o  f\<C-X>\<C-N>#", 'tx')
   call assert_equal('  foo#', getline(2))
+
+  call setline(2, '')
+  call feedkeys("1Go  f\<C-X>\<C-N>}", 'tx')
+  call assert_equal('  foo}', getline(2))
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
Fix #18565

#### vim-patch:8.2.4951: smart indenting done when not enabled

Problem:    Smart indenting done when not enabled.
Solution:   Check option values before setting can_si.
https://github.com/vim/vim/commit/de5cf287812510d2c8ffe66b99cf33c4e1a6e6f1


#### vim-patch:8.2.4953: with 'si' inserting '}' after completion goes wrong

Problem:    With 'smartindent' inserting '}' after completion goes wrong.
Solution:   Check the cursor is in indent.
https://github.com/vim/vim/commit/2e444bbef0f36535bf941f007f2961f3f66bbe87