### PR TITLE
feat(lua): add traceback to vim.deprecate

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1365,7 +1365,7 @@ notify({msg}, {level}, {opts})                                  *vim.notify()*
                     {opts}   (table|nil) Optional parameters. Unused by
                              default.
 
-notify_once({msg}, {level}, {opts}, {key})                 *vim.notify_once()*
+notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
                 Display a notification only one time.
 
                 Like |vim.notify()|, but subsequent calls with the same

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1365,7 +1365,7 @@ notify({msg}, {level}, {opts})                                  *vim.notify()*
                     {opts}   (table|nil) Optional parameters. Unused by
                              default.
 
-notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
+notify_once({msg}, {level}, {opts}, {key})                 *vim.notify_once()*
                 Display a notification only one time.
 
                 Like |vim.notify()|, but subsequent calls with the same

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1331,7 +1331,8 @@ defer_fn({fn}, {timeout})                                     *vim.defer_fn()*
                 Return: ~
                     timer luv timer object
 
-deprecate({name}, {alternative}, {version}, {plugin})        *vim.deprecate()*
+                                                             *vim.deprecate()*
+deprecate({name}, {alternative}, {version}, {plugin}, {backtrace})
                 Display a deprecation notification to the user.
 
                 Parameters: ~
@@ -1342,6 +1343,8 @@ deprecate({name}, {alternative}, {version}, {plugin})        *vim.deprecate()*
                                    function will be removed.
                     {plugin}       string|nil Plugin name that the function
                                    will be removed from. Defaults to "Nvim".
+                    {backtrace}    boolean|nil Prints backtrace. Defaults to
+                                   true.
 
 inspect({object}, {options})                                   *vim.inspect()*
                 Return a human-readable representation of the given object.
@@ -1378,6 +1381,9 @@ notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
                              |vim.log.levels|.
                     {opts}   (table|nil) Optional parameters. Unused by
                              default.
+
+                Return: ~
+                    (boolean) true if message was displayed, else false
 
 on_key({fn}, {ns_id})                                           *vim.on_key()*
                 Adds Lua function {fn} with namespace id {ns_id} as a listener

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -446,12 +446,14 @@ do
   ---@param msg string Content of the notification to show to the user.
   ---@param level number|nil One of the values from |vim.log.levels|.
   ---@param opts table|nil Optional parameters. Unused by default.
+  ---@return boolean true if message was displayed, else false
   function vim.notify_once(msg, level, opts)
     if not notified[msg] then
       vim.notify(msg, level, opts)
       notified[msg] = true
       return true
     end
+    return false
   end
 end
 
@@ -785,12 +787,13 @@ end
 ---                              be removed.
 ---@param plugin      string|nil Plugin name that the function will be removed
 ---                              from. Defaults to "Nvim".
-function vim.deprecate(name, alternative, version, plugin)
+---@param backtrace   boolean|nil Prints backtrace. Defaults to true.
+function vim.deprecate(name, alternative, version, plugin, backtrace)
   local message = name .. ' is deprecated'
   plugin = plugin or 'Nvim'
   message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message
   message = message .. ' See :h deprecated\nThis function will be removed in ' .. plugin .. ' version ' .. version
-  if vim.notify_once(message, vim.log.levels.WARN) then
+  if vim.notify_once(message, vim.log.levels.WARN) and backtrace ~= false then
     vim.notify(debug.traceback('', 2):sub(2), vim.log.levels.WARN)
   end
 end

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -446,17 +446,11 @@ do
   ---@param msg string Content of the notification to show to the user.
   ---@param level number|nil One of the values from |vim.log.levels|.
   ---@param opts table|nil Optional parameters. Unused by default.
-  function vim.notify_once(msg, level, opts, key)
-    -- TODO: `key` is used by vim.deprecated to exclude the traceback and use
-    --       just the actual message for the lookup.
-    --
-    --       It stays undocumented for now, until we can come up with a new
-    --       vim.notify() interface, that would include notify_once behavior
-    --       as an option, and have displaying the message decoupled to let
-    --       the plugins override it without having to reimplement the logic.
-    if not notified[key or msg] then
+  function vim.notify_once(msg, level, opts)
+    if not notified[msg] then
       vim.notify(msg, level, opts)
-      notified[key or msg] = true
+      notified[msg] = true
+      return true
     end
   end
 end
@@ -796,7 +790,9 @@ function vim.deprecate(name, alternative, version, plugin)
   plugin = plugin or 'Nvim'
   message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message
   message = message .. ' See :h deprecated\nThis function will be removed in ' .. plugin .. ' version ' .. version
-  vim.notify_once(debug.traceback(message, 2), vim.log.levels.WARN, nil, message)
+  if vim.notify_once(message, vim.log.levels.WARN) then
+    vim.notify(debug.traceback('', 2):sub(2), vim.log.levels.WARN)
+  end
 end
 
 require('vim._meta')

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -446,10 +446,17 @@ do
   ---@param msg string Content of the notification to show to the user.
   ---@param level number|nil One of the values from |vim.log.levels|.
   ---@param opts table|nil Optional parameters. Unused by default.
-  function vim.notify_once(msg, level, opts) -- luacheck: no unused args
-    if not notified[msg] then
+  function vim.notify_once(msg, level, opts, key)
+    -- TODO: `key` is used by vim.deprecated to exclude the traceback and use
+    --       just the actual message for the lookup.
+    --
+    --       It stays undocumented for now, until we can come up with a new
+    --       vim.notify() interface, that would include notify_once behavior
+    --       as an option, and have displaying the message decoupled to let
+    --       the plugins override it without having to reimplement the logic.
+    if not notified[key or msg] then
       vim.notify(msg, level, opts)
-      notified[msg] = true
+      notified[key or msg] = true
     end
   end
 end
@@ -789,7 +796,7 @@ function vim.deprecate(name, alternative, version, plugin)
   plugin = plugin or 'Nvim'
   message = alternative and (message .. ', use ' .. alternative .. ' instead.') or message
   message = message .. ' See :h deprecated\nThis function will be removed in ' .. plugin .. ' version ' .. version
-  vim.notify_once(message, vim.log.levels.WARN)
+  vim.notify_once(debug.traceback(message, 2), vim.log.levels.WARN, nil, message)
 end
 
 require('vim._meta')


### PR DESCRIPTION
* print traceback in `vim.deprecate` message
* `vim.notify_once` now takes optional `key` argument that, when given, is used for the lookup instead of message