### PR TITLE
fix: always close libuv handles on exit

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -115,14 +115,12 @@ void loop_on_put(MultiQueue *queue, void *data)
   uv_stop(&loop->uv);
 }
 
-#if !defined(EXITFREE)
 static void loop_walk_cb(uv_handle_t *handle, void *arg)
 {
   if (!uv_is_closing(handle)) {
     uv_close(handle, NULL);
   }
 }
-#endif
 
 /// Closes `loop` and its handles, and frees its structures.
 ///
@@ -155,9 +153,7 @@ bool loop_close(Loop *loop, bool wait)
       log_uv_handles(&loop->uv);
       break;
     }
-#if defined(EXITFREE)
-    (void)didstop;
-#else
+
     if (!didstop) {
       // Loop won’t block for I/O after this.
       uv_stop(&loop->uv);
@@ -166,7 +162,6 @@ bool loop_close(Loop *loop, bool wait)
       uv_walk(&loop->uv, loop_walk_cb, NULL);
       didstop = true;
     }
-#endif
   }
   multiqueue_free(loop->fast_events);
   multiqueue_free(loop->thread_events);


### PR DESCRIPTION
When EXITFREE is defined Nvim does not automatically close libuv handles, which causes a ~2 second delay when Nvim exits as it waits for the handles to be closed. It is very common for libuv handles to still be open when Nvim exits, as plugins use them and don't always close them (particularly with timers which are re-used and are thus never closed). Now that EXITFREE is defined in Debug builds by default, this causes a 2 second delay upon each exit which quickly becomes annoying.

Instead, Nvim should *always* close existing libuv handles, regardless of whether or not EXITFREE is defined.

Ref: https://github.com/neovim/neovim/pull/11887
