### PR TITLE
docs: remove ambiguous run-on sentence from nvim_set_hl

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1608,8 +1608,7 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                              • reverse: boolean
                              • nocombine: boolean
                              • link: name of another highlight group to link
-                               to, see |:hi-link|. Additionally, the following
-                               keys are recognized:
+                               to, see |:hi-link|.
                              • default: Don't override existing definition
                                |:hi-default|
                              • ctermfg: Sets foreground of cterm color

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -156,7 +156,6 @@ Dictionary nvim__get_hl_defs(Integer ns_id, Error *err)
 ///                - reverse: boolean
 ///                - nocombine: boolean
 ///                - link: name of another highlight group to link to, see |:hi-link|.
-///              Additionally, the following keys are recognized:
 ///                - default: Don't override existing definition |:hi-default|
 ///                - ctermfg: Sets foreground of cterm color |highlight-ctermfg|
 ///                - ctermbg: Sets background of cterm color |highlight-ctermbg|


### PR DESCRIPTION
The generated docs run this line together unintentionally, perhaps confusing the relationship to the `:link` key. Putting a blank line breaks the generator. Probably now that we enumerate all the keys, we don't really need the "Additionally ..." sentence and just list the keys?

https://github.com/neovim/neovim/blob/3e717da0f60eb7e4ce9c6ef01b79f62cb194b62e/src/nvim/api/vim.c#L158-L160

https://github.com/neovim/neovim/blob/3e717da0f60eb7e4ce9c6ef01b79f62cb194b62e/runtime/doc/api.txt#L1610-L1613

Minor continuation from: https://github.com/neovim/neovim/pull/18558