### PR TITLE
ci(coverity): correct order of minute and hour

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,7 +1,7 @@
 name: Coverity
 on:
   schedule:
-    - cron: '0 10 * * 1'  # Run every Monday at 00:10
+    - cron: '10 0 * * 1'  # Run every Monday at 00:10
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The comment says it should be run at 00:10 UTC, and in cron job format
minutes come before hours.