### PR TITLE
fix(lsp): `buf_clear_references` takes argument to clear current buffer

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -676,7 +676,7 @@ end
 --- Removes document highlights from current buffer.
 ---
 function M.clear_references()
-  util.buf_clear_references()
+  util.buf_clear_references(0)
 end
 
 ---@private


### PR DESCRIPTION
If the api doc is correct, `buf_clear_references` should take an argument for the buffer to clear.

Signed-off-by: Tsung-Ju Lii <usefulalgorithm@gmail.com>