### PR TITLE
docs: remove "chore" commit type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ the VCS/git logs more valuable. The general structure of a commit message is:
 ```
 
 - Prefix the commit subject with one of these [_types_](https://github.com/commitizen/conventional-commit-types/blob/master/index.json):
-    - `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `test`, `vim-patch`
+    - `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `test`, `vim-patch`, `dist`
     - You can **ignore this for "fixup" commits** or any commits you expect to be squashed.
 - Append optional scope to _type_ such as `(lsp)`, `(treesitter)`, `(float)`, …
 - _Description_ shouldn't start with a capital letter or end in a period.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ the VCS/git logs more valuable. The general structure of a commit message is:
 ```
 
 - Prefix the commit subject with one of these [_types_](https://github.com/commitizen/conventional-commit-types/blob/master/index.json):
-    - `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `test`, `vim-patch`, `chore`
+    - `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `test`, `vim-patch`
     - You can **ignore this for "fixup" commits** or any commits you expect to be squashed.
 - Append optional scope to _type_ such as `(lsp)`, `(treesitter)`, `(float)`, …
 - _Description_ shouldn't start with a capital letter or end in a period.

--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -78,7 +78,7 @@ local function validate_commit(commit_message)
 
   -- Check if type is correct
   local type = vim.split(before_colon, "%(")[1]
-  local allowed_types = {'build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'test', 'chore', 'vim-patch'}
+  local allowed_types = {'build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'test', 'vim-patch'}
   if not vim.tbl_contains(allowed_types, type) then
     return string.format(
       'Invalid commit type "%s". Allowed types are:\n    %s',
@@ -181,7 +181,6 @@ function M._test()
     ['refactor: normal message'] = true,
     ['revert: normal message'] = true,
     ['test: normal message'] = true,
-    ['chore: normal message'] = true,
     ['ci(window): message with scope'] = true,
     ['ci!: message with breaking change'] = true,
     ['ci(tui)!: message with scope and breaking change'] = true,
@@ -205,10 +204,10 @@ function M._test()
     ['ci :extra space before colon'] = false,
     ['refactor(): empty scope'] = false,
     ['ci( ): whitespace as scope'] = false,
-    ['chore: period at end of sentence.'] = false,
+    ['ci: period at end of sentence.'] = false,
     ['ci: Starting sentence capitalized'] = false,
     ['unknown: using unknown type'] = false,
-    ['chore: you\'re saying this commit message just goes on and on and on and on and on and on for way too long?'] = false,
+    ['ci: you\'re saying this commit message just goes on and on and on and on and on and on for way too long?'] = false,
   }
 
   local failed = 0

--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -190,6 +190,7 @@ function M._test()
     ['fixup'] = true,
     ['fixup: commit message'] = true,
     ['fixup! commit message'] = true,
+    ['chore: normal message'] = false,
     [':no type before colon 1'] = false,
     [' :no type before colon 2'] = false,
     ['  :no type before colon 3'] = false,

--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -78,7 +78,7 @@ local function validate_commit(commit_message)
 
   -- Check if type is correct
   local type = vim.split(before_colon, "%(")[1]
-  local allowed_types = {'build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'test', 'vim-patch'}
+  local allowed_types = {'build', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'test', 'dist', 'vim-patch'}
   if not vim.tbl_contains(allowed_types, type) then
     return string.format(
       'Invalid commit type "%s". Allowed types are:\n    %s',
@@ -181,6 +181,7 @@ function M._test()
     ['refactor: normal message'] = true,
     ['revert: normal message'] = true,
     ['test: normal message'] = true,
+    ['dist: normal message'] = true,
     ['ci(window): message with scope'] = true,
     ['ci!: message with breaking change'] = true,
     ['ci(tui)!: message with scope and breaking change'] = true,
@@ -190,7 +191,6 @@ function M._test()
     ['fixup'] = true,
     ['fixup: commit message'] = true,
     ['fixup! commit message'] = true,
-    ['chore: normal message'] = false,
     [':no type before colon 1'] = false,
     [' :no type before colon 2'] = false,
     ['  :no type before colon 3'] = false,


### PR DESCRIPTION
A chore commit type is vague and it can almost always be replaced with a
more descriptive commit type.
