### PR TITLE
vim-patch:8.2.{4121,4968,4969}: invalid memory access

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -209,6 +209,10 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, long xtra
     curwin->w_changelistidx = curbuf->b_changelistlen;
   }
 
+  if (VIsual_active) {
+    check_visual_pos();
+  }
+
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == curbuf) {
       // Mark this window to be redrawn later.

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -399,6 +399,24 @@ void check_cursor(void)
   check_cursor_col();
 }
 
+/// Check if VIsual position is valid, correct it if not.
+/// Can be called when in Visual mode and a change has been made.
+void check_visual_pos(void)
+{
+  if (VIsual.lnum > curbuf->b_ml.ml_line_count) {
+    VIsual.lnum = curbuf->b_ml.ml_line_count;
+    VIsual.col = 0;
+    VIsual.coladd = 0;
+  } else {
+    int len = (int)STRLEN(ml_get(VIsual.lnum));
+
+    if (VIsual.col > len) {
+      VIsual.col = len;
+      VIsual.coladd = 0;
+    }
+  }
+}
+
 /// Make sure curwin->w_cursor is not on the NUL at the end of the line.
 /// Allow it when in Visual mode and 'selection' is not "old".
 void adjust_cursor_col(void)

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -6770,13 +6770,8 @@ static void stop_insert(pos_T *end_insert_pos, int esc, int nomove)
 
       // <C-S-Right> may have started Visual mode, adjust the position for
       // deleted characters.
-      if (VIsual_active && VIsual.lnum == curwin->w_cursor.lnum) {
-        int len = (int)STRLEN(get_cursor_line_ptr());
-
-        if (VIsual.col > len) {
-          VIsual.col = len;
-          VIsual.coladd = 0;
-        }
+      if (VIsual_active) {
+        check_visual_pos();
       }
     }
   }

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -150,7 +150,7 @@ static const char_u *skip_string(const char_u *p)
           i++;
         }
       }
-      if (p[i] == '\'') {                   // check for trailing '
+      if (p[i - 1] != NUL && p[i] == '\'') {  // check for trailing '
         p += i;
         continue;
       }

--- a/src/nvim/testdir/test_cindent.vim
+++ b/src/nvim/testdir/test_cindent.vim
@@ -5311,6 +5311,13 @@ func Test_cindent_case()
   bwipe!
 endfunc
 
+" This was reading past the end of the line
+func Test_cindent_check_funcdecl()
+  new
+  sil norm o0('\0=L
+  bwipe!
+endfunc
+
 func Test_cindent_scopedecls()
   new
   setl cindent ts=4 sw=4

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1258,6 +1258,16 @@ func Test_visual_block_append_invalid_char()
   set isprint&
 endfunc
 
+func Test_visual_block_with_substitute()
+  " this was reading beyond the end of the line
+  new
+  norm a0)
+  sil! norm  O
+  s/)
+  sil! norm 
+  bwipe!
+endfunc
+
 func Test_visual_reselect_with_count()
   " this was causing an illegal memory access
   let lines =<< trim END

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1249,11 +1249,13 @@ endfunc
 
 func Test_visual_block_append_invalid_char()
   " this was going over the end of the line
+  set isprint=@,161-255
   new
   call setline(1, ['	   let xxx', 'xxxxx', 'xxxxxxxxxxx'])
   exe "normal 0\<C-V>jjA-\<Esc>"
   call assert_equal(['	-   let xxx', 'xxxxx   -', 'xxxxxxxx-xxx'], getline(1, 3))
   bwipe!
+  set isprint&
 endfunc
 
 func Test_visual_reselect_with_count()


### PR DESCRIPTION
#### vim-patch:8.2.4121: Visual test fails on MS-Windows

Problem:    Visual test fails on MS-Windows.
Solution:   Set 'isprint' so that the character used is not printable.
https://github.com/vim/vim/commit/262898ae43fa223916cfa27b0de81e5d9f3fc4b0


#### vim-patch:8.2.4968: reading past end of the line when C-indenting

Problem:    Reading past end of the line when C-indenting.
Solution:   Check for NUL.
https://github.com/vim/vim/commit/60ae0e71490c97f2871a6344aca61cacf220f813


#### vim-patch:8.2.4969: changing text in Visual mode may cause invalid memory access

Problem:    Changing text in Visual mode may cause invalid memory access.
Solution:   Check the Visual position after making a change.
https://github.com/vim/vim/commit/7ce5b2b590256ce53d6af28c1d203fb3bc1d2d97