### PR TITLE
test: unskip tests on Windows

### DIFF
--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -828,7 +828,6 @@ describe('API: buffer events:', function()
   end
 
   it('when :terminal lines change', function()
-    if helpers.pending_win32(pending) then return end
     local buffer_lines = {}
     local expected_lines = {}
     command('terminal "'..nvim_prog..'" -u NONE -i NONE -n -c "set shortmess+=A"')

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -53,7 +53,6 @@ describe('startup', function()
     ]])
   end)
   it('in a TTY: has("ttyin")==1 has("ttyout")==1', function()
-    if helpers.pending_win32(pending) then return end
     local screen = Screen.new(25, 4)
     screen:attach()
     if iswin() then
@@ -105,7 +104,6 @@ describe('startup', function()
     end)
   end)
   it('input from pipe (implicit) #7679', function()
-    if helpers.pending_win32(pending) then return end
     local screen = Screen.new(25, 4)
     screen:attach()
     if iswin() then
@@ -261,7 +259,6 @@ describe('startup', function()
   end)
 
   it('ENTER dismisses early message #7967', function()
-    if helpers.pending_win32(pending) then return end
     local screen
     screen = Screen.new(60, 6)
     screen:attach()
@@ -494,7 +491,6 @@ describe('sysinit', function()
   end)
 
   it('fixed hang issue with -D (#12647)', function()
-    if helpers.pending_win32(pending) then return end
     local screen
     screen = Screen.new(60, 7)
     screen:attach()

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -14,7 +14,6 @@ local rmdir = helpers.rmdir
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
 describe(':mksession', function()
-  if helpers.pending_win32(pending) then return end
   local session_file = file_prefix .. '.vim'
   local tab_dir = file_prefix .. '.d'
 
@@ -114,6 +113,5 @@ describe(':mksession', function()
 
     local expected_cwd = cwd_dir..'/'..tab_dir
     matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
-    command('qall!')
   end)
 end)

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -538,7 +538,7 @@ describe('buffer cursor position is correct in terminal without number column', 
       :aaaaaaaa    {1: }                                                        |
       {3:-- TERMINAL --}                                                        |
     ]])
-    matches('^:aaaaaaaa    ', eval('nvim_get_current_line()'))
+    matches('^:aaaaaaaa    [ ]*$', eval('nvim_get_current_line()'))
     eq({6, 13}, eval('nvim_win_get_cursor(0)'))
     feed([[<C-\><C-N>]])
     screen:expect([[
@@ -918,7 +918,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
       {7:  6 }:aaaaaaaa    {1: }                                                    |
       {3:-- TERMINAL --}                                                        |
     ]])
-    matches('^:aaaaaaaa    ', eval('nvim_get_current_line()'))
+    matches('^:aaaaaaaa    [ ]*$', eval('nvim_get_current_line()'))
     eq({6, 13}, eval('nvim_win_get_cursor(0)'))
     feed([[<C-\><C-N>]])
     screen:expect([[

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -117,7 +117,6 @@ describe(':terminal highlight', function()
 end)
 
 it(':terminal highlight has lower precedence than editor #9964', function()
-  if helpers.pending_win32(pending) then return end
   clear()
   local screen = Screen.new(30, 4)
   screen:set_default_attr_ids({

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -6,6 +6,7 @@ local feed, nvim_dir, feed_command = helpers.feed, helpers.nvim_dir, helpers.fee
 local iswin = helpers.iswin
 local eval = helpers.eval
 local command = helpers.command
+local matches = helpers.matches
 local poke_eventloop = helpers.poke_eventloop
 local retry = helpers.retry
 local curbufmeths = helpers.curbufmeths
@@ -460,8 +461,8 @@ describe("'scrollback' option", function()
     expect_lines(58)
 
     -- Verify off-screen state
-    eq((iswin() and '36: line' or '35: line'), eval("getline(line('w0') - 1)"))
-    eq((iswin() and '27: line' or '26: line'), eval("getline(line('w0') - 10)"))
+    matches((iswin() and '^36: line[ ]*$' or '^35: line[ ]*$'), eval("getline(line('w0') - 1)"))
+    matches((iswin() and '^27: line[ ]*$' or '^26: line[ ]*$'), eval("getline(line('w0') - 10)"))
   end)
 
   it('defaults to 10000 in :terminal buffers', function()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1312,7 +1312,6 @@ end)
 
 describe('ui/msg_puts_printf', function()
   it('output multibyte characters correctly', function()
-    if helpers.pending_win32(pending) then return end
     local screen
     local cmd = ''
     local locale_dir = test_build_dir..'/share/locale/ja/LC_MESSAGES'

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -14,7 +14,6 @@ local has_powershell = helpers.has_powershell
 local set_shell_powershell = helpers.set_shell_powershell
 
 describe("shell command :!", function()
-  if helpers.pending_win32(pending) then return end
   local screen
   before_each(function()
     clear()


### PR DESCRIPTION
Remove the `command('qall!')` from mksession_spec.lua because it prevents `helpers.rmdir()` from retrying.

Allow extra trailing spaces when matching terminal lines.