### PR TITLE
fix(filetype): fixup cls filetype detection

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -686,6 +686,7 @@ local extension = {
   bbl = 'tex',
   latex = 'tex',
   sty = 'tex',
+  cls = 'tex',
   texi = 'texinfo',
   txi = 'texinfo',
   texinfo = 'texinfo',


### PR DESCRIPTION
With "pure lua" file detection (i.e `let g:do_filetype_lua = 1` and `let g:did_load_filetypes = 0`), files *.cls containing LaTeX classes are not recognized as tex files. This one-line pull-request aims at fixing that.