### PR TITLE
PVS fixes

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -143,7 +143,7 @@ bool loop_close(Loop *loop, bool wait)
   while (true) {
     // Run the loop to tickle close-callbacks (which should then free memory).
     // Use UV_RUN_NOWAIT to avoid a hang. #11820
-    uv_run(&loop->uv, didstop ? UV_RUN_DEFAULT : UV_RUN_NOWAIT);
+    uv_run(&loop->uv, didstop ? UV_RUN_DEFAULT : UV_RUN_NOWAIT);  // -V547
     if ((uv_loop_close(&loop->uv) != UV_EBUSY) || !wait) {
       break;
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1683,14 +1683,13 @@ void execute_cmd(exarg_T *eap, CmdParseInfo *cmdinfo)
                                    (eap->argt & EX_BUFUNL) != 0, false, false);
       eap->addr_count = 1;
       // Shift each argument by 1
-      if (eap->args != NULL) {
-        for (size_t i = 0; i < eap->argc - 1; i++) {
-          eap->args[i] = eap->args[i + 1];
-        }
-        // Make the last argument point to the NUL terminator at the end of string
-        eap->args[eap->argc - 1] = eap->args[eap->argc - 1] + eap->arglens[eap->argc - 1];
-        eap->argc -= 1;
+      for (size_t i = 0; i < eap->argc - 1; i++) {
+        eap->args[i] = eap->args[i + 1];
       }
+      // Make the last argument point to the NUL terminator at the end of string
+      eap->args[eap->argc - 1] = eap->args[eap->argc - 1] + eap->arglens[eap->argc - 1];
+      eap->argc -= 1;
+
       eap->arg = eap->args[0];
     }
     if (eap->line2 < 0) {  // failed

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -63,7 +63,7 @@ void grid_clear_line(ScreenGrid *grid, size_t off, int width, bool valid)
 
 void grid_invalidate(ScreenGrid *grid)
 {
-  (void)memset(grid->attrs, -1, sizeof(sattr_T) * (size_t)(grid->Rows * grid->Columns));
+  (void)memset(grid->attrs, -1, sizeof(sattr_T) * (size_t)grid->Rows * (size_t)grid->Columns);
 }
 
 bool grid_invalid_row(ScreenGrid *grid, int row)

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -634,12 +634,12 @@ static const void *tv_ptr(const typval_T *const tvs, int *const idxp)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
 #define OFF(attr) offsetof(union typval_vval_union, attr)
-  STATIC_ASSERT(OFF(v_string) == OFF(v_list)
+  STATIC_ASSERT(OFF(v_string) == OFF(v_list)  // -V568
                 && OFF(v_string) == OFF(v_dict)
                 && OFF(v_string) == OFF(v_partial)
-                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_list)      // -V568
-                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_dict)      // -V568
-                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_partial),  // -V568
+                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_list)
+                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_dict)
+                && sizeof(tvs[0].vval.v_string) == sizeof(tvs[0].vval.v_partial),
                 "Strings, dictionaries, lists and partials are expected to be pointers, "
                 "so that all three of them can be accessed via v_string");
 #undef OFF

--- a/test/unit/fixtures/rbuffer.c
+++ b/test/unit/fixtures/rbuffer.c
@@ -15,7 +15,7 @@ void ut_rbuffer_each_read_chunk(RBuffer *buf, each_ptr_cb cb)
 
 void ut_rbuffer_each_write_chunk(RBuffer *buf, each_ptr_cb cb)
 {
-  RBUFFER_UNTIL_FULL(buf, wptr, wcnt) {
+  RBUFFER_UNTIL_FULL(buf, wptr, wcnt) {  // -V1044
     cb(wptr, wcnt);
     rbuffer_produced(buf, wcnt);
   }


### PR DESCRIPTION
- fix(PVS/V1028): prevent potential overflow
- fix(PVS/V547): "expression is always false"
- fix(PVS/V568): correct placement of ignore directive
- fix(PVS/V1044): suppress warning