### PR TITLE
feat(api): enable nvim_exec_autocmds to pass arbitrary data

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3466,6 +3466,8 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
                                • buf: (number) the expanded value of |<abuf>|
                                • file: (string) the expanded value of
                                  |<afile>|
+                               • data: (any) arbitrary data passed to
+                                 |nvim_exec_autocmds()|
 
                              • command (string) optional: Vim command to
                                execute on event. Cannot be used with
@@ -3541,6 +3543,9 @@ nvim_exec_autocmds({event}, {*opts})                    *nvim_exec_autocmds()*
                              • modeline (bool) optional: defaults to true.
                                Process the modeline after the autocommands
                                |<nomodeline>|.
+                             • data (any): arbitrary data to send to the
+                               autocommand callback. See
+                               |nvim_create_autocmd()| for details.
 
                 See also: ~
                     |:doautocmd|

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -760,7 +760,7 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   bool set_buf = false;
 
   char *pattern = NULL;
-  void *data = NULL;
+  Object *data = NULL;
   bool set_pattern = false;
 
   Array event_array = ARRAY_DICT_INIT;

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -405,6 +405,7 @@ cleanup:
 ///                 - match: (string) the expanded value of |<amatch>|
 ///                 - buf: (number) the expanded value of |<abuf>|
 ///                 - file: (string) the expanded value of |<afile>|
+///                 - data: (any) arbitrary data passed to |nvim_exec_autocmds()|
 ///             - command (string) optional: Vim command to execute on event. Cannot be used with
 ///             {callback}
 ///             - once (boolean) optional: defaults to false. Run the autocommand
@@ -749,6 +750,8 @@ void nvim_del_augroup_by_name(String name, Error *err)
 ///             {pattern}.
 ///             - modeline (bool) optional: defaults to true. Process the
 ///             modeline after the autocommands |<nomodeline>|.
+///             - data (any): arbitrary data to send to the autocommand callback. See
+///             |nvim_create_autocmd()| for details.
 /// @see |:doautocmd|
 void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   FUNC_API_SINCE(9)

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -760,6 +760,7 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   bool set_buf = false;
 
   char *pattern = NULL;
+  void *data = NULL;
   bool set_pattern = false;
 
   Array event_array = ARRAY_DICT_INIT;
@@ -818,6 +819,10 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
     set_pattern = true;
   }
 
+  if (opts->data.type != kObjectTypeNil) {
+    data = &opts->data;
+  }
+
   modeline = api_object_to_bool(opts->modeline, "modeline", true, err);
 
   if (set_pattern && set_buf) {
@@ -829,7 +834,7 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   FOREACH_ITEM(event_array, event_str, {
     GET_ONE_EVENT(event_nr, event_str, cleanup)
 
-    did_aucmd |= apply_autocmds_group(event_nr, pattern, NULL, true, au_group, buf, NULL);
+    did_aucmd |= apply_autocmds_group(event_nr, pattern, NULL, true, au_group, buf, NULL, data);
   })
 
   if (did_aucmd && modeline) {

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -145,6 +145,7 @@ return {
     "group";
     "modeline";
     "pattern";
+    "data";
   };
   get_autocmds = {
     "event";

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1595,7 +1595,7 @@ bool trigger_cursorhold(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 ///
 /// @return true if some commands were executed.
 bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force, int group,
-                          buf_T *buf, exarg_T *eap, void *data)
+                          buf_T *buf, exarg_T *eap, Object *data)
 {
   char *sfname = NULL;  // short file name
   bool retval = false;
@@ -2030,7 +2030,7 @@ static bool call_autocmd_callback(const AutoCmd *ac, const AutoPatCmd *apc)
     PUT(data, "buf", INTEGER_OBJ(autocmd_bufnr));
 
     if (apc->data) {
-      PUT(data, "data", copy_object(*(Object *)apc->data));
+      PUT(data, "data", copy_object(*apc->data));
     }
 
     int group = apc->curpat->group;

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -57,6 +57,7 @@ typedef struct AutoPatCmd {
   char *tail;               // tail of fname
   event_T event;            // current event
   int arg_bufnr;            // initially equal to <abuf>, set to zero when buf is deleted
+  void *data;               // arbitrary data
   struct AutoPatCmd *next;  // chain of active apc-s for auto-invalidation
 } AutoPatCmd;
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -57,7 +57,7 @@ typedef struct AutoPatCmd {
   char *tail;               // tail of fname
   event_T event;            // current event
   int arg_bufnr;            // initially equal to <abuf>, set to zero when buf is deleted
-  void *data;               // arbitrary data
+  Object *data;             // arbitrary data
   struct AutoPatCmd *next;  // chain of active apc-s for auto-invalidation
 } AutoPatCmd;
 

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -230,6 +230,34 @@ describe('autocmd api', function()
       }, meths.get_var("autocmd_args"))
 
     end)
+
+    it('can receive arbitrary data', function()
+      local function test(data)
+        eq(data, exec_lua([[
+          local input = ...
+          local output
+          vim.api.nvim_create_autocmd("User", {
+            pattern = "Test",
+            callback = function(args)
+              output = args.data
+            end,
+          })
+
+          vim.api.nvim_exec_autocmds("User", {
+            pattern = "Test",
+            data = input,
+          })
+
+          return output
+        ]], data))
+      end
+
+      test("Hello")
+      test(42)
+      test(true)
+      test({ "list" })
+      test({ foo = "bar" })
+    end)
   end)
 
   describe('nvim_get_autocmds', function()


### PR DESCRIPTION
Add a "data" key to `nvim_exec_autocmds` that passes arbitrary data (API objects) to autocommand callbacks.
