### PR TITLE
test: fix mksession terminal CWD test again

### DIFF
--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -10,6 +10,7 @@ local funcs = helpers.funcs
 local matches = helpers.matches
 local pesc = helpers.pesc
 local rmdir = helpers.rmdir
+local sleep = helpers.sleep
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
@@ -102,9 +103,11 @@ describe(':mksession', function()
     local session_path = cwd_dir..'/'..session_file
 
     command('cd '..tab_dir)
-    command('terminal echo $PWD')
+    command('terminal')
     command('cd '..cwd_dir)
     command('mksession '..session_path)
+    command('bd!')
+    sleep(100)  -- Make sure the process exits.
     command('qall!')
 
     -- Create a new test instance of Nvim.
@@ -113,5 +116,7 @@ describe(':mksession', function()
 
     local expected_cwd = cwd_dir..'/'..tab_dir
     matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
+    command('bd!')
+    sleep(100)  -- Make sure the process exits.
   end)
 end)


### PR DESCRIPTION
The test is failing again on Windows despite passing several hours ago. Try to fix that by making sure the process exits.