### PR TITLE
fix(autocmds): separate command from desc

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -283,7 +283,7 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
 
         PUT(autocmd_info,
             "command",
-            STRING_OBJ(cstr_to_string(aucmd_exec_to_string(ac, ac->exec))));
+            STRING_OBJ(cstr_as_string(aucmd_exec_to_string(ac, ac->exec))));
 
         PUT(autocmd_info,
             "pattern",


### PR DESCRIPTION
Fixes the mangling of `desc` and `command` for `callbacks` when reading from `nvim_get_autocmds`.

I assume it was done to help support readability when using `:autocmd`, so I made sure to keep that behavior but with a small twist (appending callback type before), see examples below.

This also adds the benefit of seeing the description for string commands from `:autocmds`

Fixes #17588

Note: possibly related to https://github.com/neovim/neovim/issues/17639

### Example

```lua
  -- vim.api.nvim_create_augroup("test_group", { clear = true })
vim.api.nvim_create_autocmd("BufWritePre", {
  pattern = "*.py",
  group = "test_group",
  command = "echo 'hello1'",
  desc = "dispatch hello1",
})
vim.api.nvim_create_autocmd("BufWritePre", {
  pattern = "*.py",
  group = "test_group",
  callback = function()
    print "hello2"
  end,
  desc = "dispatch hello2",
})
```

- before

  with `:lua =vim.api.nvim_get_autocmds { group = "test_group" })`

  ```lua
  { {
    buflocal = false,
    command = "echo 'hello1'",
    desc = "dispatch hello1",
    event = "BufWritePre",
    group = 54,
    group_name = "test_group",
    id = 52,
    once = false,
    pattern = "*.py"
  }, {
    buflocal = false,
    command = "dispatch hello2",
    desc = "dispatch hello2",
    event = "BufWritePre",
    group = 54,
    group_name = "test_group",
    id = 53,
    once = false,
    pattern = "*.py"
  } }
  ```

  with `:autocmd BufWritePre`

  ```console
  --- Autocommands ---
  test_group  BufWritePre
      *.py      echo 'hello1'
                dispatch hello2
  ```

- after

  with `:lua =vim.api.nvim_get_autocmds { group = "test_group" })`

  ```lua
  { {
      buflocal = false,
      command = "echo 'hello1'",
      desc = "dispatch hello1",
      event = "BufWritePre",
      group = 54,
      group_name = "test_group",
      id = 55,
      once = false,
      pattern = "*.py"
    }, {
      buflocal = false,
      command = "<Lua function 113>",
      desc = "dispatch hello2",
      event = "BufWritePre",
      group = 54,
      group_name = "test_group",
      id = 56,
      once = false,
      pattern = "*.py"
    } }
  ```

  with `:autocmd BufWritePre`

  ```console
  --- Autocommands ---
  test_group  BufWritePre
      *.py      echo 'hello1' [dispatch hello1]
                <Lua function 113> [dispatch hello2]
  ```
