### PR TITLE
ci(api-docs): add comment explaining why full clone is needed

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          # Fetch depth 0 is required if called through workflow_call. In order
+          # to create a PR we need to access other branches, which requires a
+          # full clone.
           fetch-depth: 0
 
       - name: Install dependencies


### PR DESCRIPTION
This will save 15 seconds of CI time per commit. Such time saving!!!