### PR TITLE
vim-patch:8.2.4979: accessing freed memory when line is flushed

### DIFF
--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -1077,6 +1077,15 @@ Type number and <Enter> (q or empty cancels):
   %bwipe
 endfunc
 
+func Test_define_search()
+  " this was accessing freed memory
+  new
+  call setline(1, ['first line', '', '#define something 0'])
+  sil norm o0
+  sil! norm 
+  bwipe!
+endfunc
+
 " Test for the 'taglength' option
 func Test_tag_length()
   set tags=Xtags

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -515,9 +515,14 @@ wingotofile:
     if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0) {
       break;
     }
+
+    // Make a copy, if the line was changed it will be freed.
+    ptr = vim_strnsave(ptr, len);
+
     find_pattern_in_path(ptr, 0, len, true, Prenum == 0,
                          type, Prenum1, ACTION_SPLIT, 1, MAXLNUM);
-    curwin->w_set_curswant = TRUE;
+    xfree(ptr);
+    curwin->w_set_curswant = true;
     break;
 
   // Quickfix window only: view the result under the cursor in a new split.


### PR DESCRIPTION
#### vim-patch:8.2.4979: accessing freed memory when line is flushed

Problem:    Accessing freed memory when line is flushed.
Solution:   Make a copy of the pattern to search for.
https://github.com/vim/vim/commit/28d032cc688ccfda18c5bbcab8b50aba6e18cde5