### PR TITLE
fix(mksession): don't store floating windows in session

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -181,6 +181,10 @@ static bool ses_do_frame(const frame_T *fr)
 /// @return  non-zero if window "wp" is to be stored in the Session.
 static int ses_do_win(win_T *wp)
 {
+  // Skip floating windows to avoid issues when restoring the Session. #18432
+  if (wp->w_floating) {
+    return false;
+  }
   if (wp->w_buffer->b_fname == NULL
       // When 'buftype' is "nofile" can't restore the window contents.
       || (!wp->w_buffer->terminal && bt_nofile(wp->w_buffer))) {


### PR DESCRIPTION
If there are floats when `:mksession` runs, the session cannot be properly restored (Issue #18432).

This PR updates `:mksession` to skip floating windows. This matches the functionality of Vim for its popup windows.

An alternative approach could have `:mksession` save floating windows that can be _properly_ restored (rather than skip them entirely, which is what this PR does). While that would seemingly be a more complete fix, that could present additional issues since floating windows are ordinarily created by plugins, and they may no longer be properly under a plugin's control when restored.