### PR TITLE
vim-patch:8.2.4980: when 'shortmess' contains 'A' loading session may still warn

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -598,9 +598,14 @@ static int makeopens(FILE *fd, char_u *dirnow)
     PUTLINE_FAIL("let s:shortmess_save = &shortmess");
   }
 
-  // Now save the current files, current buffer first.
-  PUTLINE_FAIL("set shortmess=aoO");
+  // set 'shortmess' for the following.  Add the 'A' flag if it was there
+  PUTLINE_FAIL("if &shortmess =~ 'A'");
+  PUTLINE_FAIL("  set shortmess=aoOA");
+  PUTLINE_FAIL("else");
+  PUTLINE_FAIL("  set shortmess=aoO");
+  PUTLINE_FAIL("endif");
 
+  // Now save the current files, current buffer first.
   // Put all buffers into the buffer list.
   // Do it very early to preserve buffer order after loading session (which
   // can be disrupted by prior `edit` or `tabedit` calls).

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -838,6 +838,30 @@ func Test_mksession_shortmess()
   set sessionoptions&
 endfunc
 
+" Test that when Vim loading session has 'A' in 'shortmess' it does not
+" complain about an existing swapfile.
+func Test_mksession_shortmess_with_A()
+  edit Xtestfile
+  write
+  let fname = swapname('%')
+  " readblob() needs patch 8.2.2343
+  " let cont = readblob(fname)
+  let cont = readfile(fname, 'B')
+  set sessionoptions-=options
+  mksession Xtestsession
+  bwipe!
+
+  " Recreate the swap file to pretend the file is being edited
+  call writefile(cont, fname)
+  set shortmess+=A
+  source Xtestsession
+
+  set shortmess&
+  set sessionoptions&
+  call delete('Xtestsession')
+  call delete(fname)
+endfunc
+
 " Test for mksession with 'compatible' option
 func Test_mksession_compatible()
   throw 'skipped: Nvim does not support "compatible" option'


### PR DESCRIPTION
Fix #17397

#### vim-patch:8.2.4980: when 'shortmess' contains 'A' loading session may still warn

Problem:    When 'shortmess' contains 'A' loading a session may still warn for
            an existing swap file. (Melker Österberg)
Solution:   Keep the 'A' flag to 'shortmess' in the session file.
https://github.com/vim/vim/commit/aaadb5b6f76ea03e5eb460121f3dbf46ad04ce50

Use readfile() with "B" flag in test as readblob() needs patch 8.2.2343.