### PR TITLE
fix: make `nvim_cmd` not suppress errors inside key mapping

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -1304,20 +1304,23 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     capture_ga = &capture_local;
   }
 
-  try_start();
-  if (output) {
-    msg_silent++;
-  }
+  TRY_WRAP({
+    try_start();
+    if (output) {
+      msg_silent++;
+    }
 
-  WITH_SCRIPT_CONTEXT(channel_id, {
-    execute_cmd(&ea, &cmdinfo);
+    WITH_SCRIPT_CONTEXT(channel_id, {
+      execute_cmd(&ea, &cmdinfo);
+    });
+
+    if (output) {
+      capture_ga = save_capture_ga;
+      msg_silent = save_msg_silent;
+    }
+
+    try_end(err);
   });
-
-  if (output) {
-    capture_ga = save_capture_ga;
-    msg_silent = save_msg_silent;
-  }
-  try_end(err);
 
   if (ERROR_SET(err)) {
     goto clear_ga;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3636,5 +3636,13 @@ describe('API', function()
       meths.cmd({ cmd = "update" }, {})
       meths.cmd({ cmd = "buffer", count = 0 }, {})
     end)
+    it('doesn\'t suppress errors when used in keymapping', function()
+      meths.exec_lua([[
+        vim.keymap.set("n", "[l",
+                       function() vim.api.nvim_cmd({ cmd = "echo", args = {"foo"} }, {}) end)
+      ]], {})
+      feed("[l")
+      neq(nil, string.find(eval("v:errmsg"), "E5108:"))
+    end)
   end)
 end)


### PR DESCRIPTION
Fixes `nvim_cmd` not showing errors when it's used inside a key mapping. Also has an additional fix to make `nvim_cmd` properly undo the `:sandbox` modifier

Closes #18632