### PR TITLE
feat(autocmds): retrieve lua callback

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3610,7 +3610,11 @@ nvim_get_autocmds({*opts})                               *nvim_get_autocmds()*
                     • group_name (string): the autocommand group name.
                     • desc (string): the autocommand description.
                     • event (string): the autocommand event.
-                    • command (string): the autocommand command.
+                    • command (string): the autocommand command. Note: this
+                      will be empty if a callback is set.
+                    • callback (function|string|nil): Lua function or name of
+                      a Vim script function which is executed when this
+                      autocommand is triggered.
                     • once (boolean): whether the autocommand is only run
                       once.
                     • pattern (string): the autocommand pattern. If the

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2477,32 +2477,6 @@ bool autocmd_delete_id(int64_t id)
 //  AucmdExecutable Functions
 // ===========================================================================
 
-/// Generate a string description of a callback
-static char *aucmd_callback_to_string(Callback cb)
-{
-  // NOTE: this function probably belongs in a helper
-
-  size_t msglen = 100;
-  char *msg = (char *)xmallocz(msglen);
-
-  switch (cb.type) {
-  case kCallbackLua:
-    snprintf(msg, msglen, "<lua: %d>", cb.data.luaref);
-    break;
-  case kCallbackFuncref:
-    // TODO(tjdevries): Is this enough space for this?
-    snprintf(msg, msglen, "<vim function: %s>", cb.data.funcref);
-    break;
-  case kCallbackPartial:
-    snprintf(msg, msglen, "<vim partial: %s>", cb.data.partial->pt_name);
-    break;
-  default:
-    snprintf(msg, msglen, "%s", "");
-    break;
-  }
-  return msg;
-}
-
 /// Generate a string description for the command/callback of an autocmd
 char *aucmd_exec_to_string(AutoCmd *ac, AucmdExecutable acc)
   FUNC_ATTR_PURE
@@ -2511,7 +2485,7 @@ char *aucmd_exec_to_string(AutoCmd *ac, AucmdExecutable acc)
   case CALLABLE_EX:
     return xstrdup(acc.callable.cmd);
   case CALLABLE_CB:
-    return aucmd_callback_to_string(acc.callable.cb);
+    return callback_to_string(&acc.callable.cb);
   case CALLABLE_NONE:
     return "This is not possible";
   }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1205,6 +1205,30 @@ void callback_copy(Callback *dest, Callback *src)
   }
 }
 
+/// Generate a string description of a callback
+char *callback_to_string(Callback *cb)
+{
+  size_t msglen = 100;
+  char *msg = (char *)xmallocz(msglen);
+
+  switch (cb->type) {
+  case kCallbackLua:
+    snprintf(msg, msglen, "<lua: %d>", cb->data.luaref);
+    break;
+  case kCallbackFuncref:
+    // TODO(tjdevries): Is this enough space for this?
+    snprintf(msg, msglen, "<vim function: %s>", cb->data.funcref);
+    break;
+  case kCallbackPartial:
+    snprintf(msg, msglen, "<vim partial: %s>", cb->data.partial->pt_name);
+    break;
+  default:
+    snprintf(msg, msglen, "%s", "");
+    break;
+  }
+  return msg;
+}
+
 /// Remove watcher from a dictionary
 ///
 /// @param  dict  Dictionary to remove watcher from.


### PR DESCRIPTION
continues the work done in #18617

feat(autocmds): retrieve lua callback

### Example

```lua
  -- vim.api.nvim_create_augroup("test_group", { clear = true })
vim.api.nvim_create_autocmd("BufWritePre", {
  pattern = "*.py",
  group = "test_group",
  callback = function()
    print "hello1"
  end,
  desc = "dispatch hello1",
})
```

output of `:lua =vim.api.nvim_get_autocmds { group = "test_group" })`

```lua
{ {
    buflocal = false,
    callback = <function 1>,
    command = "", -- avoids a breaking change by setting to this as empty
    desc = "dispatch hello1",
    event = "BufWritePre",
    group = 52,
    group_name = "test_group",
    id = 60,
    once = false,
    pattern = "*.py"
  } }
```

you can use it as

```lua
local aus = vim.api.nvim_get_autocmds { group = "test_group" }
print(type(aus[1].callback)) -- --> function
aus[1].callback() -- --> hello1
```