### PR TITLE
Add API functions for starting and stopping terminal ui input for use with e.g. OSC52 copy/paste to system clipboard

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2499,3 +2499,17 @@ void nvim_del_user_command(String name, Error *err)
 {
   nvim_buf_del_user_command(-1, name, err);
 }
+
+/// Stop processing of input stream of all attached terminal uis.
+void nvim_ui_terminput_start(void)
+  FUNC_API_SINCE(10)
+{
+  ui_terminput_start_impl();
+}
+
+/// Start processing of input stream of all attached terminal uis.
+void nvim_ui_terminput_stop(void)
+  FUNC_API_SINCE(10)
+{
+  ui_terminput_stop_impl();
+}

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -469,6 +469,7 @@ static void tui_main(UIBridgeData *bridge, UI *ui)
   loop_init(&tui_loop, NULL);
   TUIData *data = xcalloc(1, sizeof(TUIData));
   ui->data = data;
+  bridge->bridge.data = data;
   data->bridge = bridge;
   data->loop = &tui_loop;
   data->is_starting = true;
@@ -2235,4 +2236,27 @@ static const char *tui_tk_ti_getstr(const char *name, const char *value, void *d
 
   return value;
 }
+
+void tui_terminput_start_impl(UI *ui)
+{
+    TUIData *data = (TUIData *)ui->data;
+    if (!data) {
+      return;
+    }
+    if (os_isatty(data->input.in_fd)) {
+      tinput_start(&data->input);
+    }
+}
+
+void tui_terminput_stop_impl(UI *ui)
+{
+    TUIData *data = (TUIData *)ui->data;
+    if (!data) {
+      return;
+    }
+    if (os_isatty(data->input.in_fd)) {
+      tinput_stop(&data->input);
+    }
+}
+
 #endif

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -658,3 +658,17 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *error)
     win_set_inner_size(wp);
   }
 }
+
+void ui_terminput_start_impl(void)
+{
+  for (size_t i = 0; i < ui_count; i++) {
+    tui_terminput_start_impl(uis[i]);
+  }
+}
+
+void ui_terminput_stop_impl(void)
+{
+  for (size_t i = 0; i < ui_count; i++) {
+    tui_terminput_stop_impl(uis[i]);
+  }
+}


### PR DESCRIPTION
Additional API functions to start and stop processing of terminal input events to be able to communicate with the terminal synchronously without other input events interfering:

  void nvim_ui_terminput_start(void)
  void nvim_ui_terminput_stop(void)

This can be useful for a clipboard provider based on OSC52 ANSI terminal sequences. The advantage of using terminal sequences is that clipboard yank/paste also works when running neovim remotely or in a virtual environment without additional configuration (e.g. ports) or runtime requirements. A plugin that implements such a provider is available here:

https://github.com/captaingroove/oscillator.