### PR TITLE
vim-patch:8.2.4985: PVS warns for possible array underrun

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -443,7 +443,7 @@ size_t spell_check(win_T *wp, char_u *ptr, hlf_T *attrp, int *capcol, bool docou
                        MAXWLEN + 1);
   mi.mi_fwordlen = (int)STRLEN(mi.mi_fword);
 
-  if (camel_case) {
+  if (camel_case && mi.mi_fwordlen > 0) {
     // introduce a fake word end space into the folded word.
     mi.mi_fword[mi.mi_fwordlen - 1] = ' ';
   }


### PR DESCRIPTION
Problem:    PVS warns for possible array underrun.
Solution:   Add a check for a positive value. (closes vim/vim#10451)
https://github.com/vim/vim/commit/875339b22a989d0782097036169e8fb9e2100d7e
