### PR TITLE
feat: ":write!" skips "file changed" warning

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -941,7 +941,7 @@ WRITING WITH MULTIPLE BUFFERS				*buffer-write*
 
 
 Vim will warn you if you try to overwrite a file that has been changed
-elsewhere.  See |timestamp|.
+elsewhere (unless "!" was used).  See |timestamp|.
 
 			    *backup* *E207* *E506* *E507* *E508* *E509* *E510*
 If you write to an existing file (but do not append) while the 'backup',
@@ -1481,8 +1481,8 @@ doing something there and closing it should be OK (if there are no side
 effects from other autocommands).  Closing unrelated windows and buffers will
 get you into trouble.
 
-Before writing a file the timestamp is checked.  If it has changed, Vim will
-ask if you really want to overwrite the file:
+Before writing a file, the timestamp is checked (unless "!" was used).
+If it has changed, Vim will ask if you really want to overwrite the file:
 
 	WARNING: The file has been changed since reading it!!!
 	Do you really want to write to it (y/n)?

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -372,6 +372,7 @@ Lua interface (|lua.txt|):
 Commands:
   |:doautocmd| does not warn about "No matching autocommands".
   |:wincmd| accepts a count.
+  `:write!` does not show a prompt if the file was updated externally.
 
 Command line completion:
   The meanings of arrow keys do not change depending on 'wildoptions'.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2534,8 +2534,8 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
       goto fail;
     }
 
-    // Check if the timestamp hasn't changed since reading the file.
-    if (overwriting) {
+    // If 'forceit' is false, check if the timestamp hasn't changed since reading the file.
+    if (overwriting && !forceit) {
       retval = check_mtime(buf, &file_info_old);
       if (retval == FAIL) {
         goto fail;


### PR DESCRIPTION
Small fix for https://github.com/neovim/neovim/issues/7270

I also added some tests to prevent regression.