### PR TITLE
vim-patch:8.2.0859: no Turkish translation of the manual

### DIFF
--- a/runtime/doc/evim-tr.1
+++ b/runtime/doc/evim-tr.1
@@ -1,0 +1,48 @@
+.TH EVIM 1 "16 Þubat 2002"
+.SH AD
+evim \- kolay Vim, bir dosyayý Vim ile herhangi bir kip olmadan düzenleyin
+.SH ÖZET
+.br
+.B evim
+[seçenekler] [dosya ..]
+.br
+.B eview
+.SH TANIM
+.B eVim,
+.B Vim'i
+baþlatýr ve onu herhangi bir kipsiz düzenleyici gibi davranmasýný saðlar.
+Bu bildiðiniz Vim'dir, ancak bir týkla ve yaz düzenleyicisi gibi çalýþýr.
+Bir örnek vermek gerekirse MS-Windows üzerindeki Not Defteri gibi düþünün.
+.B eVim
+menülere ve araç çubuklarýna eriþim saðlayabilmeniz için grafik arabirimde çalýþýr.
+.PP
+Yalnýzca Vim ile normal biçimde çalýþamayan kiþilerin kullanýmý içindir.
+Dosya düzenleme iþi çok daha verimsiz olacaktýr.
+.PP
+.B eview'ün
+aynýsýdýr, ancak saltokunur kipte baþlar. evim \-R ile de baþlatýlabilir.
+.PP
+Vim hakkýnda ayrýntýlý bilgi için: vim(1)
+.PP
+Doðrudan metin giriþini saðlayabilmek için 'insertmode' seçeneði açýlýr.
+.br
+Eþlemlemeler Kopyala ve Yapýþtýr MS-Windows ile ayný olacak biçimde ayarlanýr.
+CTRL-X metni keser, CTRL-C metni kopyalar ve CTRL-V metni yapýþtýrýr.
+CTRL-V'nin orijinal iþlevi için CTRL-Q kullanýn.
+.SH SEÇENEKLER
+Bilgi için: vim(1).
+.SH DOSYALAR
+.TP 15
+/usr/local/lib/vim/evim.vim
+eVim'i ilklendirmek için kullanýlan betik.
+.SH NAM-I DÝÐER
+Nam-ý diðer "Lastik Çizmeliler için Vim" (Gumbies, Monty Python).
+eVim'i kullanýrken bir mendili alýp iki ucundan birer düðüm yapmanýz
+ve kafanýza takmanýz beklenir.
+.SH AYRICA BAKINIZ
+vim(1)
+.SH YAZAR
+.B Vim'in
+büyük çoðunluðu Bram Moolenaar tarafýndan baþkalarýnýn kayda deðer
+yardýmlarýyla yazýlmýþtýr.
+Ek bilgi için Yardým/Teþekkürler menüsüne bakýn.

--- a/runtime/doc/evim-tr.UTF-8.1
+++ b/runtime/doc/evim-tr.UTF-8.1
@@ -1,0 +1,48 @@
+.TH EVIM 1 "16 Şubat 2002"
+.SH AD
+evim \- kolay Vim, bir dosyayı Vim ile herhangi bir kip olmadan düzenleyin
+.SH ÖZET
+.br
+.B evim
+[seçenekler] [dosya ..]
+.br
+.B eview
+.SH TANIM
+.B eVim,
+.B Vim'i
+başlatır ve onu herhangi bir kipsiz düzenleyici gibi davranmasını sağlar.
+Bu bildiğiniz Vim'dir, ancak bir tıkla ve yaz düzenleyicisi gibi çalışır.
+Bir örnek vermek gerekirse MS-Windows üzerindeki Not Defteri gibi düşünün.
+.B eVim
+menülere ve araç çubuklarına erişim sağlayabilmeniz için grafik arabirimde çalışır.
+.PP
+Yalnızca Vim ile normal biçimde çalışamayan kişilerin kullanımı içindir.
+Dosya düzenleme işi çok daha verimsiz olacaktır.
+.PP
+.B eview'ün
+aynısıdır, ancak saltokunur kipte başlar. evim \-R ile de başlatılabilir.
+.PP
+Vim hakkında ayrıntılı bilgi için: vim(1)
+.PP
+Doğrudan metin girişini sağlayabilmek için 'insertmode' seçeneği açılır.
+.br
+Eşlemlemeler Kopyala ve Yapıştır MS-Windows ile aynı olacak biçimde ayarlanır.
+CTRL-X metni keser, CTRL-C metni kopyalar ve CTRL-V metni yapıştırır.
+CTRL-V'nin orijinal işlevi için CTRL-Q kullanın.
+.SH SEÇENEKLER
+Bilgi için: vim(1).
+.SH DOSYALAR
+.TP 15
+/usr/local/lib/vim/evim.vim
+eVim'i ilklendirmek için kullanılan betik.
+.SH NAM-I DİĞER
+Nam-ı diğer "Lastik Çizmeliler için Vim" (Gumbies, Monty Python).
+eVim'i kullanırken bir mendili alıp iki ucundan birer düğüm yapmanız
+ve kafanıza takmanız beklenir.
+.SH AYRICA BAKINIZ
+vim(1)
+.SH YAZAR
+.B Vim'in
+büyük çoğunluğu Bram Moolenaar tarafından başkalarının kayda değer
+yardımlarıyla yazılmıştır.
+Ek bilgi için Yardım/Teşekkürler menüsüne bakın.

--- a/runtime/doc/vim-tr.1
+++ b/runtime/doc/vim-tr.1
@@ -1,0 +1,544 @@
+.TH VIM 1 "11 Nisan 2006"
+.SH AD
+vim \- Vi IMproved, bir programcýnýn metin düzenleyicisi
+.SH ÖZET
+.br
+.B vim
+[seçenekler] [dosya ..]
+.br
+.B vim
+[seçenekler] \-
+.br
+.B vim
+[seçenekler] \-t etiket
+.br
+.B vim
+[seçenekler] \-q [hatadosyasý]
+.PP
+.br
+.B ex
+.br
+.B view
+.br
+.B gvim
+.B gview
+.B evim
+.B eview
+.br
+.B rvim
+.B rview
+.B rgvim
+.B rgview
+.SH TANIM
+.B Vim,
+Vi ile yukarýya doðru uyumlu olan bir metin düzenleyicisidir.
+Her tür düz metni düzenlemede kullanýlabilir.
+Özellikle programlarý düzenlemede yararlýdýr.
+.PP
+Vi üzerine yapýlmýþ birçok geliþtirme ve iyileþtirmeyi içerir:
+Çok düzeyli geri alma, çoklu pencereler ve arabellekler, sözdizim vurgulama,
+komut satýrý düzenleme, dosya adý tamamlama, çevrimiçi yardým, görsel seçim vb.
+.B Vim
+ve Vi arasýndaki deðiþikliklerin bir özeti için ":help vi_diff.txt"
+dosyasýna bir göz atýn.
+.PP
+.B Vim'i
+çalýþtýrýrken gerekli olan yardýmýn çoðu çevrimiçi yardým sisteminden elde
+edilebilir. Bunun için ":help" komutunu kullanabilirsiniz.
+Aþaðýda ÇEVRÝMÝÇÝ YARDIM bölümüne bakýn.
+.PP
+Genelde
+.B Vim
+tek bir dosyayý düzenlemek için þu komutla çalýþtýrýlýr:
+.PP
+	vim dosya
+.PP
+Biraz daha açacak olursak:
+.PP
+	vim [seçenekler] [dosyalistesi]
+.PP
+Eðer dosya listesi saðlanmamýþsa, düzenleyici boþ bir arabellek açar.
+Bunun dýþýnda aþaðýdaki dört seçenekten bir tanesi de bir veya birden çok
+dosyayý düzenlemek için kullanýlabilir.
+.TP 12
+dosya ..
+Dosya adlarýnýn bir listesi.
+Bunlardan ilki ekrana getirilip arabelleðe yüklenir.
+Ýmleç arabelleðin ilk satýrýnda konumlandýrýlýr.
+Diðer dosyalara ":next" komutu ile geçebilirsiniz.
+Adý tire ile baþlayan bir dosyayý düzenlemek için dosya listesinin baþýna
+"\-\-" koyun.
+.TP
+\-
+Düzenlenecek dosya stdin'den okunur.  Komutlar bir tty olmasý gereken
+stderr'den okunur.
+.TP
+\-t {etiket}
+Düzenlenecek dosya ve bu dosyanýn baþlangýç imleç konumu bir "etiket"e
+dayanýr, bir tür býraktýðýnýz konumu belirten bir ayraç gibi.
+Etiket dosyasýnda {etiket} aranýr, iliþkin dosya þu anki dosya olur ve
+iliþkin komut çalýþtýrýlýr.
+Bu genelde C programlarý için kullanýlýr, {etiket} bu durumda bir iþlev
+olabilir.
+Bunun sonucunda bu iþlevi içeren dosya o anki dosya olur ve imleç bu
+iþlevin baþlangýcýna konumlandýrýlýr.
+Ek bilgi için: ":help tag\-commands".
+.TP
+\-q [hatadosyasý]
+Hýzlý düzelt kipinde baþlat
+[hatadosyasý] okunur ve ilk hata görüntülenir.
+Eðer [hatadosyasý] saðlanmazsa, dosya adý 'errorfile' seçeneðinden alýnýr
+(öntanýmlý olarak Amiga için "AztecC.Err", diðer sistemlerde "errors.err").
+Sonraki hatalara ":cn" komutu ile geçilebilir.
+Ek bilgi için: ":help quickfix".
+.PP
+.B Vim
+girilen komutun adýna göre deðiþik biçimde davranýr (çalýþtýrýlabilir hâlâ
+ayný dosya olarak kalabilir).
+.TP 10
+vim
+"Normal" kip, standart çalýþma biçimi.
+.TP
+ex
+Ex kipinde baþlat.
+"\-e" deðiþkeni ile de baþlatýlabilir.
+Normal kipe ":vi" komutu ile geçilebilir.
+.TP
+view
+Saltokunur kipte baþlat.  Bu kipte dosya yazýmýna izin verilmez.
+"\-R" deðiþkeni ile de baþlatýlabilir.
+.TP
+gvim gview
+Grafik arabirim sürümü.
+Yeni bir pencere açar.
+"\-g" deðiþkeni ile de baþlatýlabilir.
+.TP
+evim eview
+Kolay kipte baþlatýlan grafik arabirim sürümü.
+Yeni bir pencere açar.
+"\-y" deðiþkeni ile de baþlatýlabilir.
+.TP
+rvim rview rgvim rgview
+Yukarýdaki ile ayný, ancak sýnýrlamalar içerir.  Kabuk komutlarý
+çalýþtýrýlamaz veya
+.B Vim
+askýya alýnamaz.
+"\-Z" deðiþkeni ile de baþlatýlabilir.
+.SH SEÇENEKLER
+Seçenekler bir sýra gözetmeksizin dosya adlarýndan önce veya sonra
+kullanýlabilir. 
+Herhangi bir deðiþken içermeyen seçenekler bir tirenin ardýnda sýralanabilir.
+.TP 12
++[num]
+Ýlk dosya için imleç "num" satýrýnda konumlandýrýlacaktýr.
+Eðer "num" eksikse imleç en son satýrda baþlar.
+.TP
++/{dizge}
+Ýlk dosya için imleç {dizgi}'nin ilk eþleþmesinin olduðu satýrda
+konumlandýrýlacaktýr.
+Kullanýlabilir arama dizgileri için ":help search\-pattern" yazýn.
+.TP
++{komut}
+.TP
+\-c {komut}
+Ýlk dosya okunduktan sonra {komut} çalýþtýrýlýr.
+{komut} bir Ex komutu olarak iþletilir.
+Eðer {komut} boþluk içeriyorsa çift týrnak içerisine alýnmalýdýr (bu
+kullanýlan kabuða baðlýdýr).
+Örnek: Vim "+set si" main.c
+.br
+Not: 10 taneye kadar "+" veya "\-c" komutu kullanabilirsiniz.
+.TP
+\-S {dosya}
+Ýlk dosya okunduktan sonra {dosya} kaynak alýnýr.
+\-c "source {dosya}" bu komutun eþdeðeridir.
+{dosya}, '\-' ile baþlayamaz.
+Eðer {dosya} saðlanmazsa "Session.vim" kullanýlýr (yalnýzca \-S son
+deðiþken olarak kullanýldýðýnda iþe yarar).
+.TP
+\-\-cmd {komut}
+"\-c" komutu gibi, ancak komut herhangi bir vimrc dosyasýný iþletmeden
+önce çalýþtýrýlýr.
+"\-c" komutundan baðýmsýz olarak bu komutlardan 10 taneye kadar
+çalýþtýrabilirsiniz.
+.TP
+\-A
+Eðer
+.B Vim
+saðdan sola yazýlan dosyalarý ve Arapça klavye dizilimini kullanabilmesi için
+ARAPÇA desteði ile derlenmiþe bu seçenek
+.B Vim'i
+Arapça kipinde baþlatýr ('arabic' seçeneði açýlýr).  Aksi durumda
+.B Vim
+hata verip çýkar.
+.TP
+\-b
+Ýkili kip.
+Bir çalýþtýrýlabiliri veya ikili dosyayý düzenlemeye olanacak saðlayacak
+birkaç seçenek ayarlanýr.
+.TP
+\-C
+Uyumlu kip. 'compatible' seçeneðini ayarlar.
+Bu kipte
+.B Vim
+bir .vimrc dosyasý var olsa bile genelde Vi gibi davranýr.
+.TP
+\-d
+Karþýlaþtýrma kipinde baþlat.
+Bir, iki, üç veya dört adet dosya adý deðiþkeni olmalýdýr.
+.B Vim
+bütün dosyalarý yan yana açar ve aralarýndaki deðiþiklikleri gösterir.
+vimdiff(1) gibi çalýþýr.
+.TP
+\-d {aygýt}
+{aygýt}'ý bir uçbirim olarak kullanmak için açar.
+Yalnýzca Amiga'da çalýþýr.
+Örnek:
+"\-d con:20/30/600/150".
+.TP
+\-D
+Hata ayýklama kipi.  Bir betiðin ilk komutunu çalýþtýrýrken hata ayýklama
+kipine geçer.
+.TP
+\-e
+.B Vim'i
+Ex kipinde baþlatýr, "ex" çalýþtýrýlabiliri ile ayný iþlevi görür.
+.TP
+\-E
+.B Vim'i
+geliþtirilmiþ Ex kipinde baþlatýr, "exim" çalýþtýrýlabiliri ile ayný
+iþlevi görür.
+.TP
+\-f
+Önplan.  Grafik arabirim sürümü için
+.B Vim
+baþladýðý kabuktan ayrýlmayacak ve kendisini çatallamayacaktýr.
+Amiga'da,
+.B Vim
+yeni bir pencere açmak için yeniden baþlatýlmaz.
+Bu seçenek
+.B Vim
+düzenleme oturumunun bitmesini bekleyecek bir program tarafýndan
+baþlatýldýðýnda kullanýlmalýdýr (örn. mail).
+Amiga'da ":sh" ve ":!" komutlarý çalýþmayacaktýr.
+.TP
+\-\-nofork
+Önplan.  Grafik arabirim sürümü için
+.B Vim
+baþladýðý kabuktan ayrýlmayacak ve kendisini çatallamayacaktýr.
+.TP
+\-F
+Eðer
+.B Vim
+saðdan sola yazýlan dosyalarý ve Farsça klavye dizilimini kullanabilmesi için
+FKMAP desteði ile derlenmiþse, bu seçenek
+.B Vim'i
+Farsça kipinde baþlatýr ('fkmap' ve 'rightleft' seçenekleri açýlýr).
+Aksi durumda
+.B Vim
+hata verip çýkar.
+.TP
+\-g
+Eðer
+.B Vim
+grafik arabirim desteði ile derlenmiþse bu seçenek grafik arabirimi çalýþtýrýr.
+Eðer grafik arabirim desteði eklenmemiþse
+.B Vim
+hata verir ve çýkar.
+.TP
+\-h
+Komut satýrý deðiþkenleri ve seçenekleri üzerine biraz yardým saðlar.
+Bu komuttan sonra
+.B Vim
+çýkar.
+.TP
+\-H
+Eðer
+.B Vim
+saðdan sola yazýlan dosyalarý ve Ýbranca klavye dizilimini kullanabilmesi için
+RIGHTLEFT desteði ile derlenmiþse, bu seçenek 
+.B Vim'i
+Ýbranca kipinde baþlatýr ('hkmap' ve 'rightleft' seçenekleri açýlýr).
+Aksi durumda
+.B Vim
+hata verir ve çýkar.
+.TP
+\-i {viminfo}
+Öntanýmlý "~/.viminfo" dosyasý yerine kullanýlacak olan viminfo dosyasýný
+belirtmek için kullanýlýr.
+Bu komut ayný zamanda viminfo kullanýmýný atlamak için de kullanýlabilir.
+Bunun için dosya adý yerine "NONE" vermeniz yeterlidir.
+.TP
+\-L
+\-r ile ayný.
+.TP
+\-l
+Lisp kipi.
+Bu deðiþken 'lisp' ve 'showmatch' seçeneklerini açar.
+.TP
+\-m
+Dosya yazma seçeneði kapalýdýr.
+\'write' seçeneðini sýfýrlar.
+Arabelleði hâlâ deðiþtirebilirsiniz, ancak dosyayý yazmak olanaklý deðildir.
+.TP
+\-M
+Deðiþikliklere izin verilmez. 'modifiable' ve 'write' seçenekleri kapatýlýr,
+böylece deðiþiklik yapýlamaz ve dosyalar yazýlamaz.
+Bu seçenekleri yeniden açýp deðiþiklik yapmayý etkinleþtirebilirsiniz.
+.TP
+\-N
+Uyumsuz kip. 'no-compatible' seçeneðini sýfýrlar.
+Bu seçenekle birlikte
+.B Vim
+biraz daha düzgünce çalýþýr, ancak bir .vimrc dosyasý olmamasýna raðmen
+Vi ile daha az uyumludur.
+.TP
+\-n
+Bir takas dosyasý kullanýlmaz.
+Çökme sonrasý kurtarma olanaklý olmayacaktýr.
+Eðer çok yavaþ bir ortamda dosya çalýþýyorsanýz (örn. disket) yararlý olabilir.
+":set uc=0" ile de yapýlabilir.
+Geri almak için ":set uc=200" yapýn.
+.TP
+\-nb
+NetBeans için bir düzenleyici sunucusu olur.  Ayrýntýlar için belgelere bakýn.
+.TP
+\-o[N]
+N sayýda pencereyi üst üste açar.
+N verilmezse, her dosya için bir pencere açar.
+.TP
+\-O[N]
+N sayýda pencereyi yan yana açar.
+N verilmezse, her dosya için bir pencere açar.
+.TP
+\-p[N]
+N sayýda sekme açar.
+N verilmezse, her dosya için bir sekme açar.
+.TP
+\-R
+Saltokunur kip.
+\'readonly' seçeneði açýlýr.
+Arabelleði hâlâ deðiþtirebilirsiniz, ancak yanlýþlýkla dosyanýn üzerine
+yazmaktan sizi korur.
+Dosyanýn üzerine yazmak istemiyorsanýz, Ex komutuna bir ünlem imi ekleyin,
+örn. ":w!".
+\-R seçeneði ayný zamanda \-n seçeneðini de uygular (yukarýda bakýn).
+\'readonly' seçeneði ":set noro" ile sýfýrlanabilir.
+Ek bilgi için: ":help 'readonly'".
+.TP
+\-r
+Takas dosyalarýný içerdikleri kurtarma bilgilerini gösterecek biçimde listeler.
+.TP
+\-r {dosya}
+Kurtarma kipi.
+Çökmüþ bir düzenleme oturumunu takas dosyasýný kullanarak kurtarýr.
+Takas dosyasý dosya ile ayný ada iye olup sonuna ".swp" eklenmiþtir.
+Ek bilgi için: ":help recovery".
+.TP
+\-s
+Sessiz kip. Yalnýzca "Ex" olarak baþlatýldýðýnda veya "\-e" seçeneði
+"\-s" seçeneðinden önce verildiðinde çalýþýr.
+.TP
+\-s {betikgir}
+{betikgir} betik dosyasý okunur.
+Dosyadaki karakterler onlarý siz girmiþsiniz gibi kabul edilir.
+Aynýsý ":source! {betikgir}" komutu ile de gerçekleþtirilebilir.
+Eðer dosyanýn sonuna düzenleyici çýkmadan önce gelinirse, sonraki karakterler
+klavyeden okunur.
+.TP
+\-T {uçbirim}
+.B Vim'e
+kullandýðýnýz uçbirimin adýný söyler.
+Yalnýzca kendiliðinden okunamazsa gereklidir.
+.B Vim'in
+tanýdýðý bir uçbirim olmalýdýr veya termcap veya terminfo dosyasýnda
+tanýmlý olmalýdýr.
+.TP
+\-u {vimrc}
+Ýlklendirme için {vimrc} dosyasýndaki komutlarý kullan.
+Diðer tüm ilklendirmeler atlanýr.
+Bunu özel türde dosyalarý düzenlemek için kullanýn.
+Dosya adý olarak "NONE" verilirse tüm özelleþtirmeler atlanýr.
+Ek bilgi için vim içinde ":help initialization" bölümüne bakýn.
+.TP
+\-U {gvimrc}
+Grafik arabirim ilklendirmesi için {gvimrc} dosyasýndaki komutlara bakýn.
+Diðer tüm grafik arabirim ilklendirmeleri atlanýr.
+Dosya adý olarak "NONE" verilirse tüm özelleþtirmeler atlanýr.
+Ek bilgi için vim içinde ":help gui\-init" bölümüne bakýn.
+.TP
+\-V[N]
+Sözlü anlatým.  Hangi dosyalarýn kaynak alýndýðýný ve viminfo dosyasýndan
+nelerin okunduðunu yazdýrýr.  'verbose' için isteðe baðlý N seçeneði 
+kullanýlabilir. Öntanýmlý sayý 10'dur.
+.TP
+\-v
+.B Vim'i
+"vi" yazarak baþlatýrmýþ gibi Vi kipinde baþlatýr.  Bu yalnýzca
+çalýþtýrýlabilir "ex" olduðunda bir iþe yarar.
+.TP
+\-w {betikçýk}
+Girdiðiniz tüm karakterler siz
+.B Vim'den
+çýkana deðin {betikçýk} dosyasýnda saklanýr.
+Bu "vim \-s" veya ":source" komutu ile kullanýlacak bir betik yaratmaya yarar.
+Eðer {betikçýk} dosyasý varsa karakterler dosyaya eklenir.
+.TP
+\-W {betikçýk}
+\-w gibi, ancak var olan bir dosyanýn üzerine yazar.
+.TP
+\-x
+Dosya yazarken þifreleme kullanýr.  Bir þifre girmeniz istenecektir.
+.TP
+\-X
+X sunucusuna baðlanmaz.  Vim'in uçbirimde baþlama süresini azaltýr ancak pencere baþlýðý
+ve pano kullanýlamaz.
+.TP
+\-y
+.B Vim'i
+"evim" veya "eview" yazarak baþlatýrmýþ gibi kolay kipte baþlatýr.
+.B Vim'i
+diðer týkla ve yaz düzenleyicileri gibi çalýþtýrýr.
+.TP
+\-Z
+Kýsýtlý kip.  Program "r" yazarak baþlatýlmýþ gibi davranýr.
+.TP
+\-\-
+Seçeneklerin bittiðini belirtir.
+Bundan sonraki deðiþkenler artýk bir dosya adý olarak iþletilir.
+Ayný zamanda '\-' ile baþlayan bir dosyayý tanýtmak için de kullanýlabilir.
+.TP
+\-\-echo\-wid
+Yalnýzca GTK grafik arabirimi: Pencere numarasýný stdout'a yankýla.
+.TP
+\-\-help
+Yardým iletisini yazdýrýr ve çýkar, "\-h" gibi.
+.TP
+\-\-literal
+Dosya adý deðiþkenlerini gerçek anlamda iþlet, joker karakterlerini
+geniþletme.  Bunun kabuðun karakterleri kendiliðinden geniþlettiði Unix'te
+bir etkisi bulunmamaktadýr.
+.TP
+\-\-noplugin
+Eklentileri yükleme.  "\-u NONE" da ayný iþlevi görür.
+.TP
+\-\-remote
+Bir Vim sunucusuna baðlan ve geri kalan deðiþkenlerde belirtilen dosyalarý
+düzenle. Eðer bir sunucu bulunamazsa bir uyarý verilir ve dosyalar þu anki
+Vim'de düzenlenir.
+.TP
+\-\-remote\-expr {ifade}
+Bir Vim sunucusuna baðlan ve {ifade}'yi deðerlendirip sonucu stdout'a yazdýr.
+.TP
+\-\-remote\-send {anahtarlar}
+Bir Vim sunucusuna baðlan ve ona {anahtarlar} gönder.
+.TP
+\-\-remote\-silent
+\-\-remote gibi, ancak bir sunucu bulunamazsa uyarý vermez.
+.TP
+\-\-remote\-wait
+\-\-remote gibi, ancak Vim dosyalar düzenlenene kadar çýkmaz.
+.TP
+\-\-remote\-wait\-silent
+\-\-remote\-wait gibi, ancak bir sunucu bulunamazsa uyarý vermez.
+.TP
+\-\-serverlist
+Bulunabilecek bütün Vim sunucularýný listeler.
+.TP
+\-\-servername {ad}
+{ad}'ý bir sunucu adý olarak kullanýr.  Bir \-\-remote deðiþkeni ve
+baðlanacaðý sunucunun adý ile kullanýlmadýðý sürece þu anki Vim için
+kullanýlýr.
+.TP
+\-\-socketid {id}
+Yalnýzca GTK grafik arabirimi: GtkPlug mekanizmasýný kullanarak gvim'i baþka
+bir pencerede çalýþtýr.
+.TP
+\-\-version
+Sürüm bilgisini yazdýrýr ve çýkar.
+.SH ÇEVRÝMÝÇÝ YARDIM
+.B Vim
+içinde ":help" yazarak baþlayýn.
+Belirli bir konu üzerine yardým almak için ":help subject" yazýn.
+Örneðin: "ZZ" komutu üzerine bilgi almak için ":help ZZ" yazýn.
+<Tab> ve CTRL-D kullanarak konularý tamamlayýn (":help cmdline\-completion").
+Bir konumdan diðerini atlamak için etiketler mevcuttur (bir tür köprü gibi),
+ek bilgi için ":help").
+Tüm belgelendirmeyi bu biçimde okuyabilirsiniz, örneðin: ":help syntax.txt".
+":help syntax.txt".
+.SH DOSYALAR
+.TP 15
+/usr/local/lib/vim/doc/*.txt
+.B Vim
+belgelendirme dosyalarý.
+Tüm listeyi görmek için ":help doc\-file\-list" yazýn.
+.TP
+/usr/local/lib/vim/doc/tags
+Belgelendirme içinde veri bulmak için kullanýlan etiketler dosyasý.
+.TP
+/usr/local/lib/vim/syntax/syntax.vim
+Sistem geneli sözdizim ilklendirmeleri.
+.TP
+/usr/local/lib/vim/syntax/*.vim
+Programlama dilleri için sözdizim dosyalarý.
+.TP
+/usr/local/lib/vim/vimrc
+Sistem geneli
+.B Vim
+ilklendirmeleri.
+.TP
+~/.vimrc
+Sizin kiþisel
+.B Vim
+ilklendirmeleriniz.
+.TP
+/usr/local/lib/vim/gvimrc
+Sistem geneli gvim ilklendirmeleri.
+.TP
+~/.gvimrc
+Sizin kiþisel gvim ilklendirmeleriniz.
+.TP
+/usr/local/lib/vim/optwin.vim
+":options" komutu için kullanýlan betik, görsel seçenek ayarlarý.
+.TP
+/usr/local/lib/vim/menu.vim
+gvim için sistem geneli menü ilklendirmeleri.
+.TP
+/usr/local/lib/vim/bugreport.vim
+Hata raporu oluþturmak için kullanýlan betik. Ek bilgi için: ":help bugs".
+.TP
+/usr/local/lib/vim/filetype.vim
+Dosya türünü adýndan tanýyan betik. Ek bilgi için: ":help 'filetype'".
+.TP
+/usr/local/lib/vim/scripts.vim
+Dosya türünü içeriðinden tanýyan betik. Ek bilgi için: ":help 'filetype'".
+.TP
+/usr/local/lib/vim/print/*.ps
+PostScript yazdýrmasý için kullanýlan dosyalar.
+.PP
+En güncel bilgiler için VÝM ana sayfasýný ziyaret edin:
+.br
+<URL:http://www.vim.org/>
+.SH AYRICA BAKINIZ
+vimtutor(1)
+.SH YAZAR
+.B Vim'in
+büyük çoðunluðu Bram Moolenaar tarafýndan baþkalarýnýn kayda deðer
+yardýmlarýyla yazýlmýþtýr.
+Ek bilgi için
+.B Vim
+içinde ":help credits" yazýn.
+.br
+.B Vim
+Stevie tabanlýdýr, yazarlarý: Tim Thompson,
+Tony Andrews ve G.R. (Fred) Walter.
+Orijinal koddan geriye pek bir þey kalmadýðýný söylemek yanlýþ olmaz.
+.SH HATALAR
+Bilinen hatalarýn bir listesi için ":help todo" yazýn.
+.PP
+Unutmayýn ki, baþkalarý tarafýndan hata olarak deðerlendirilebilecek konularýn
+bir çoðu Vi'nin davranýþlarýna sadýk kalýnmasý nedeniyle vardýr. Yine de
+bazý þeylerin "Vi bunu deðiþik biçimde yapýyor" diye hata olabileceðini
+düþünüyorsanýz, "vi_diff.txt" dosyasýný dikkatle okuyun (veya Vim içinde
+:help vi_diff.txt yazýn.
+Ek olarak 'compatible' ve 'cpoptions' seçeneklerine de bakabilirsiniz.

--- a/runtime/doc/vim-tr.UTF-8.1
+++ b/runtime/doc/vim-tr.UTF-8.1
@@ -1,0 +1,544 @@
+.TH VIM 1 "11 Nisan 2006"
+.SH AD
+vim \- Vi IMproved, bir programcının metin düzenleyicisi
+.SH ÖZET
+.br
+.B vim
+[seçenekler] [dosya ..]
+.br
+.B vim
+[seçenekler] \-
+.br
+.B vim
+[seçenekler] \-t etiket
+.br
+.B vim
+[seçenekler] \-q [hatadosyası]
+.PP
+.br
+.B ex
+.br
+.B view
+.br
+.B gvim
+.B gview
+.B evim
+.B eview
+.br
+.B rvim
+.B rview
+.B rgvim
+.B rgview
+.SH TANIM
+.B Vim,
+Vi ile yukarıya doğru uyumlu olan bir metin düzenleyicisidir.
+Her tür düz metni düzenlemede kullanılabilir.
+Özellikle programları düzenlemede yararlıdır.
+.PP
+Vi üzerine yapılmış birçok geliştirme ve iyileştirmeyi içerir:
+Çok düzeyli geri alma, çoklu pencereler ve arabellekler, sözdizim vurgulama,
+komut satırı düzenleme, dosya adı tamamlama, çevrimiçi yardım, görsel seçim vb.
+.B Vim
+ve Vi arasındaki değişikliklerin bir özeti için ":help vi_diff.txt"
+dosyasına bir göz atın.
+.PP
+.B Vim'i
+çalıştırırken gerekli olan yardımın çoğu çevrimiçi yardım sisteminden elde
+edilebilir. Bunun için ":help" komutunu kullanabilirsiniz.
+Aşağıda ÇEVRİMİÇİ YARDIM bölümüne bakın.
+.PP
+Genelde
+.B Vim
+tek bir dosyayı düzenlemek için şu komutla çalıştırılır:
+.PP
+	vim dosya
+.PP
+Biraz daha açacak olursak:
+.PP
+	vim [seçenekler] [dosyalistesi]
+.PP
+Eğer dosya listesi sağlanmamışsa, düzenleyici boş bir arabellek açar.
+Bunun dışında aşağıdaki dört seçenekten bir tanesi de bir veya birden çok
+dosyayı düzenlemek için kullanılabilir.
+.TP 12
+dosya ..
+Dosya adlarının bir listesi.
+Bunlardan ilki ekrana getirilip arabelleğe yüklenir.
+İmleç arabelleğin ilk satırında konumlandırılır.
+Diğer dosyalara ":next" komutu ile geçebilirsiniz.
+Adı tire ile başlayan bir dosyayı düzenlemek için dosya listesinin başına
+"\-\-" koyun.
+.TP
+\-
+Düzenlenecek dosya stdin'den okunur.  Komutlar bir tty olması gereken
+stderr'den okunur.
+.TP
+\-t {etiket}
+Düzenlenecek dosya ve bu dosyanın başlangıç imleç konumu bir "etiket"e
+dayanır, bir tür bıraktığınız konumu belirten bir ayraç gibi.
+Etiket dosyasında {etiket} aranır, ilişkin dosya şu anki dosya olur ve
+ilişkin komut çalıştırılır.
+Bu genelde C programları için kullanılır, {etiket} bu durumda bir işlev
+olabilir.
+Bunun sonucunda bu işlevi içeren dosya o anki dosya olur ve imleç bu
+işlevin başlangıcına konumlandırılır.
+Ek bilgi için: ":help tag\-commands".
+.TP
+\-q [hatadosyası]
+Hızlı düzelt kipinde başlat
+[hatadosyası] okunur ve ilk hata görüntülenir.
+Eğer [hatadosyası] sağlanmazsa, dosya adı 'errorfile' seçeneğinden alınır
+(öntanımlı olarak Amiga için "AztecC.Err", diğer sistemlerde "errors.err").
+Sonraki hatalara ":cn" komutu ile geçilebilir.
+Ek bilgi için: ":help quickfix".
+.PP
+.B Vim
+girilen komutun adına göre değişik biçimde davranır (çalıştırılabilir hâlâ
+aynı dosya olarak kalabilir).
+.TP 10
+vim
+"Normal" kip, standart çalışma biçimi.
+.TP
+ex
+Ex kipinde başlat.
+"\-e" değişkeni ile de başlatılabilir.
+Normal kipe ":vi" komutu ile geçilebilir.
+.TP
+view
+Saltokunur kipte başlat.  Bu kipte dosya yazımına izin verilmez.
+"\-R" değişkeni ile de başlatılabilir.
+.TP
+gvim gview
+Grafik arabirim sürümü.
+Yeni bir pencere açar.
+"\-g" değişkeni ile de başlatılabilir.
+.TP
+evim eview
+Kolay kipte başlatılan grafik arabirim sürümü.
+Yeni bir pencere açar.
+"\-y" değişkeni ile de başlatılabilir.
+.TP
+rvim rview rgvim rgview
+Yukarıdaki ile aynı, ancak sınırlamalar içerir.  Kabuk komutları
+çalıştırılamaz veya
+.B Vim
+askıya alınamaz.
+"\-Z" değişkeni ile de başlatılabilir.
+.SH SEÇENEKLER
+Seçenekler bir sıra gözetmeksizin dosya adlarından önce veya sonra
+kullanılabilir. 
+Herhangi bir değişken içermeyen seçenekler bir tirenin ardında sıralanabilir.
+.TP 12
++[num]
+İlk dosya için imleç "num" satırında konumlandırılacaktır.
+Eğer "num" eksikse imleç en son satırda başlar.
+.TP
++/{dizge}
+İlk dosya için imleç {dizgi}'nin ilk eşleşmesinin olduğu satırda
+konumlandırılacaktır.
+Kullanılabilir arama dizgileri için ":help search\-pattern" yazın.
+.TP
++{komut}
+.TP
+\-c {komut}
+İlk dosya okunduktan sonra {komut} çalıştırılır.
+{komut} bir Ex komutu olarak işletilir.
+Eğer {komut} boşluk içeriyorsa çift tırnak içerisine alınmalıdır (bu
+kullanılan kabuğa bağlıdır).
+Örnek: Vim "+set si" main.c
+.br
+Not: 10 taneye kadar "+" veya "\-c" komutu kullanabilirsiniz.
+.TP
+\-S {dosya}
+İlk dosya okunduktan sonra {dosya} kaynak alınır.
+\-c "source {dosya}" bu komutun eşdeğeridir.
+{dosya}, '\-' ile başlayamaz.
+Eğer {dosya} sağlanmazsa "Session.vim" kullanılır (yalnızca \-S son
+değişken olarak kullanıldığında işe yarar).
+.TP
+\-\-cmd {komut}
+"\-c" komutu gibi, ancak komut herhangi bir vimrc dosyasını işletmeden
+önce çalıştırılır.
+"\-c" komutundan bağımsız olarak bu komutlardan 10 taneye kadar
+çalıştırabilirsiniz.
+.TP
+\-A
+Eğer
+.B Vim
+sağdan sola yazılan dosyaları ve Arapça klavye dizilimini kullanabilmesi için
+ARAPÇA desteği ile derlenmişe bu seçenek
+.B Vim'i
+Arapça kipinde başlatır ('arabic' seçeneği açılır).  Aksi durumda
+.B Vim
+hata verip çıkar.
+.TP
+\-b
+İkili kip.
+Bir çalıştırılabiliri veya ikili dosyayı düzenlemeye olanacak sağlayacak
+birkaç seçenek ayarlanır.
+.TP
+\-C
+Uyumlu kip. 'compatible' seçeneğini ayarlar.
+Bu kipte
+.B Vim
+bir .vimrc dosyası var olsa bile genelde Vi gibi davranır.
+.TP
+\-d
+Karşılaştırma kipinde başlat.
+Bir, iki, üç veya dört adet dosya adı değişkeni olmalıdır.
+.B Vim
+bütün dosyaları yan yana açar ve aralarındaki değişiklikleri gösterir.
+vimdiff(1) gibi çalışır.
+.TP
+\-d {aygıt}
+{aygıt}'ı bir uçbirim olarak kullanmak için açar.
+Yalnızca Amiga'da çalışır.
+Örnek:
+"\-d con:20/30/600/150".
+.TP
+\-D
+Hata ayıklama kipi.  Bir betiğin ilk komutunu çalıştırırken hata ayıklama
+kipine geçer.
+.TP
+\-e
+.B Vim'i
+Ex kipinde başlatır, "ex" çalıştırılabiliri ile aynı işlevi görür.
+.TP
+\-E
+.B Vim'i
+geliştirilmiş Ex kipinde başlatır, "exim" çalıştırılabiliri ile aynı
+işlevi görür.
+.TP
+\-f
+Önplan.  Grafik arabirim sürümü için
+.B Vim
+başladığı kabuktan ayrılmayacak ve kendisini çatallamayacaktır.
+Amiga'da,
+.B Vim
+yeni bir pencere açmak için yeniden başlatılmaz.
+Bu seçenek
+.B Vim
+düzenleme oturumunun bitmesini bekleyecek bir program tarafından
+başlatıldığında kullanılmalıdır (örn. mail).
+Amiga'da ":sh" ve ":!" komutları çalışmayacaktır.
+.TP
+\-\-nofork
+Önplan.  Grafik arabirim sürümü için
+.B Vim
+başladığı kabuktan ayrılmayacak ve kendisini çatallamayacaktır.
+.TP
+\-F
+Eğer
+.B Vim
+sağdan sola yazılan dosyaları ve Farsça klavye dizilimini kullanabilmesi için
+FKMAP desteği ile derlenmişse, bu seçenek
+.B Vim'i
+Farsça kipinde başlatır ('fkmap' ve 'rightleft' seçenekleri açılır).
+Aksi durumda
+.B Vim
+hata verip çıkar.
+.TP
+\-g
+Eğer
+.B Vim
+grafik arabirim desteği ile derlenmişse bu seçenek grafik arabirimi çalıştırır.
+Eğer grafik arabirim desteği eklenmemişse
+.B Vim
+hata verir ve çıkar.
+.TP
+\-h
+Komut satırı değişkenleri ve seçenekleri üzerine biraz yardım sağlar.
+Bu komuttan sonra
+.B Vim
+çıkar.
+.TP
+\-H
+Eğer
+.B Vim
+sağdan sola yazılan dosyaları ve İbranca klavye dizilimini kullanabilmesi için
+RIGHTLEFT desteği ile derlenmişse, bu seçenek 
+.B Vim'i
+İbranca kipinde başlatır ('hkmap' ve 'rightleft' seçenekleri açılır).
+Aksi durumda
+.B Vim
+hata verir ve çıkar.
+.TP
+\-i {viminfo}
+Öntanımlı "~/.viminfo" dosyası yerine kullanılacak olan viminfo dosyasını
+belirtmek için kullanılır.
+Bu komut aynı zamanda viminfo kullanımını atlamak için de kullanılabilir.
+Bunun için dosya adı yerine "NONE" vermeniz yeterlidir.
+.TP
+\-L
+\-r ile aynı.
+.TP
+\-l
+Lisp kipi.
+Bu değişken 'lisp' ve 'showmatch' seçeneklerini açar.
+.TP
+\-m
+Dosya yazma seçeneği kapalıdır.
+\'write' seçeneğini sıfırlar.
+Arabelleği hâlâ değiştirebilirsiniz, ancak dosyayı yazmak olanaklı değildir.
+.TP
+\-M
+Değişikliklere izin verilmez. 'modifiable' ve 'write' seçenekleri kapatılır,
+böylece değişiklik yapılamaz ve dosyalar yazılamaz.
+Bu seçenekleri yeniden açıp değişiklik yapmayı etkinleştirebilirsiniz.
+.TP
+\-N
+Uyumsuz kip. 'no-compatible' seçeneğini sıfırlar.
+Bu seçenekle birlikte
+.B Vim
+biraz daha düzgünce çalışır, ancak bir .vimrc dosyası olmamasına rağmen
+Vi ile daha az uyumludur.
+.TP
+\-n
+Bir takas dosyası kullanılmaz.
+Çökme sonrası kurtarma olanaklı olmayacaktır.
+Eğer çok yavaş bir ortamda dosya çalışıyorsanız (örn. disket) yararlı olabilir.
+":set uc=0" ile de yapılabilir.
+Geri almak için ":set uc=200" yapın.
+.TP
+\-nb
+NetBeans için bir düzenleyici sunucusu olur.  Ayrıntılar için belgelere bakın.
+.TP
+\-o[N]
+N sayıda pencereyi üst üste açar.
+N verilmezse, her dosya için bir pencere açar.
+.TP
+\-O[N]
+N sayıda pencereyi yan yana açar.
+N verilmezse, her dosya için bir pencere açar.
+.TP
+\-p[N]
+N sayıda sekme açar.
+N verilmezse, her dosya için bir sekme açar.
+.TP
+\-R
+Saltokunur kip.
+\'readonly' seçeneği açılır.
+Arabelleği hâlâ değiştirebilirsiniz, ancak yanlışlıkla dosyanın üzerine
+yazmaktan sizi korur.
+Dosyanın üzerine yazmak istemiyorsanız, Ex komutuna bir ünlem imi ekleyin,
+örn. ":w!".
+\-R seçeneği aynı zamanda \-n seçeneğini de uygular (yukarıda bakın).
+\'readonly' seçeneği ":set noro" ile sıfırlanabilir.
+Ek bilgi için: ":help 'readonly'".
+.TP
+\-r
+Takas dosyalarını içerdikleri kurtarma bilgilerini gösterecek biçimde listeler.
+.TP
+\-r {dosya}
+Kurtarma kipi.
+Çökmüş bir düzenleme oturumunu takas dosyasını kullanarak kurtarır.
+Takas dosyası dosya ile aynı ada iye olup sonuna ".swp" eklenmiştir.
+Ek bilgi için: ":help recovery".
+.TP
+\-s
+Sessiz kip. Yalnızca "Ex" olarak başlatıldığında veya "\-e" seçeneği
+"\-s" seçeneğinden önce verildiğinde çalışır.
+.TP
+\-s {betikgir}
+{betikgir} betik dosyası okunur.
+Dosyadaki karakterler onları siz girmişsiniz gibi kabul edilir.
+Aynısı ":source! {betikgir}" komutu ile de gerçekleştirilebilir.
+Eğer dosyanın sonuna düzenleyici çıkmadan önce gelinirse, sonraki karakterler
+klavyeden okunur.
+.TP
+\-T {uçbirim}
+.B Vim'e
+kullandığınız uçbirimin adını söyler.
+Yalnızca kendiliğinden okunamazsa gereklidir.
+.B Vim'in
+tanıdığı bir uçbirim olmalıdır veya termcap veya terminfo dosyasında
+tanımlı olmalıdır.
+.TP
+\-u {vimrc}
+İlklendirme için {vimrc} dosyasındaki komutları kullan.
+Diğer tüm ilklendirmeler atlanır.
+Bunu özel türde dosyaları düzenlemek için kullanın.
+Dosya adı olarak "NONE" verilirse tüm özelleştirmeler atlanır.
+Ek bilgi için vim içinde ":help initialization" bölümüne bakın.
+.TP
+\-U {gvimrc}
+Grafik arabirim ilklendirmesi için {gvimrc} dosyasındaki komutlara bakın.
+Diğer tüm grafik arabirim ilklendirmeleri atlanır.
+Dosya adı olarak "NONE" verilirse tüm özelleştirmeler atlanır.
+Ek bilgi için vim içinde ":help gui\-init" bölümüne bakın.
+.TP
+\-V[N]
+Sözlü anlatım.  Hangi dosyaların kaynak alındığını ve viminfo dosyasından
+nelerin okunduğunu yazdırır.  'verbose' için isteğe bağlı N seçeneği 
+kullanılabilir. Öntanımlı sayı 10'dur.
+.TP
+\-v
+.B Vim'i
+"vi" yazarak başlatırmış gibi Vi kipinde başlatır.  Bu yalnızca
+çalıştırılabilir "ex" olduğunda bir işe yarar.
+.TP
+\-w {betikçık}
+Girdiğiniz tüm karakterler siz
+.B Vim'den
+çıkana değin {betikçık} dosyasında saklanır.
+Bu "vim \-s" veya ":source" komutu ile kullanılacak bir betik yaratmaya yarar.
+Eğer {betikçık} dosyası varsa karakterler dosyaya eklenir.
+.TP
+\-W {betikçık}
+\-w gibi, ancak var olan bir dosyanın üzerine yazar.
+.TP
+\-x
+Dosya yazarken şifreleme kullanır.  Bir şifre girmeniz istenecektir.
+.TP
+\-X
+X sunucusuna bağlanmaz.  Vim'in uçbirimde başlama süresini azaltır ancak pencere başlığı
+ve pano kullanılamaz.
+.TP
+\-y
+.B Vim'i
+"evim" veya "eview" yazarak başlatırmış gibi kolay kipte başlatır.
+.B Vim'i
+diğer tıkla ve yaz düzenleyicileri gibi çalıştırır.
+.TP
+\-Z
+Kısıtlı kip.  Program "r" yazarak başlatılmış gibi davranır.
+.TP
+\-\-
+Seçeneklerin bittiğini belirtir.
+Bundan sonraki değişkenler artık bir dosya adı olarak işletilir.
+Aynı zamanda '\-' ile başlayan bir dosyayı tanıtmak için de kullanılabilir.
+.TP
+\-\-echo\-wid
+Yalnızca GTK grafik arabirimi: Pencere numarasını stdout'a yankıla.
+.TP
+\-\-help
+Yardım iletisini yazdırır ve çıkar, "\-h" gibi.
+.TP
+\-\-literal
+Dosya adı değişkenlerini gerçek anlamda işlet, joker karakterlerini
+genişletme.  Bunun kabuğun karakterleri kendiliğinden genişlettiği Unix'te
+bir etkisi bulunmamaktadır.
+.TP
+\-\-noplugin
+Eklentileri yükleme.  "\-u NONE" da aynı işlevi görür.
+.TP
+\-\-remote
+Bir Vim sunucusuna bağlan ve geri kalan değişkenlerde belirtilen dosyaları
+düzenle. Eğer bir sunucu bulunamazsa bir uyarı verilir ve dosyalar şu anki
+Vim'de düzenlenir.
+.TP
+\-\-remote\-expr {ifade}
+Bir Vim sunucusuna bağlan ve {ifade}'yi değerlendirip sonucu stdout'a yazdır.
+.TP
+\-\-remote\-send {anahtarlar}
+Bir Vim sunucusuna bağlan ve ona {anahtarlar} gönder.
+.TP
+\-\-remote\-silent
+\-\-remote gibi, ancak bir sunucu bulunamazsa uyarı vermez.
+.TP
+\-\-remote\-wait
+\-\-remote gibi, ancak Vim dosyalar düzenlenene kadar çıkmaz.
+.TP
+\-\-remote\-wait\-silent
+\-\-remote\-wait gibi, ancak bir sunucu bulunamazsa uyarı vermez.
+.TP
+\-\-serverlist
+Bulunabilecek bütün Vim sunucularını listeler.
+.TP
+\-\-servername {ad}
+{ad}'ı bir sunucu adı olarak kullanır.  Bir \-\-remote değişkeni ve
+bağlanacağı sunucunun adı ile kullanılmadığı sürece şu anki Vim için
+kullanılır.
+.TP
+\-\-socketid {id}
+Yalnızca GTK grafik arabirimi: GtkPlug mekanizmasını kullanarak gvim'i başka
+bir pencerede çalıştır.
+.TP
+\-\-version
+Sürüm bilgisini yazdırır ve çıkar.
+.SH ÇEVRİMİÇİ YARDIM
+.B Vim
+içinde ":help" yazarak başlayın.
+Belirli bir konu üzerine yardım almak için ":help subject" yazın.
+Örneğin: "ZZ" komutu üzerine bilgi almak için ":help ZZ" yazın.
+<Tab> ve CTRL-D kullanarak konuları tamamlayın (":help cmdline\-completion").
+Bir konumdan diğerini atlamak için etiketler mevcuttur (bir tür köprü gibi),
+ek bilgi için ":help").
+Tüm belgelendirmeyi bu biçimde okuyabilirsiniz, örneğin: ":help syntax.txt".
+":help syntax.txt".
+.SH DOSYALAR
+.TP 15
+/usr/local/lib/vim/doc/*.txt
+.B Vim
+belgelendirme dosyaları.
+Tüm listeyi görmek için ":help doc\-file\-list" yazın.
+.TP
+/usr/local/lib/vim/doc/tags
+Belgelendirme içinde veri bulmak için kullanılan etiketler dosyası.
+.TP
+/usr/local/lib/vim/syntax/syntax.vim
+Sistem geneli sözdizim ilklendirmeleri.
+.TP
+/usr/local/lib/vim/syntax/*.vim
+Programlama dilleri için sözdizim dosyaları.
+.TP
+/usr/local/lib/vim/vimrc
+Sistem geneli
+.B Vim
+ilklendirmeleri.
+.TP
+~/.vimrc
+Sizin kişisel
+.B Vim
+ilklendirmeleriniz.
+.TP
+/usr/local/lib/vim/gvimrc
+Sistem geneli gvim ilklendirmeleri.
+.TP
+~/.gvimrc
+Sizin kişisel gvim ilklendirmeleriniz.
+.TP
+/usr/local/lib/vim/optwin.vim
+":options" komutu için kullanılan betik, görsel seçenek ayarları.
+.TP
+/usr/local/lib/vim/menu.vim
+gvim için sistem geneli menü ilklendirmeleri.
+.TP
+/usr/local/lib/vim/bugreport.vim
+Hata raporu oluşturmak için kullanılan betik. Ek bilgi için: ":help bugs".
+.TP
+/usr/local/lib/vim/filetype.vim
+Dosya türünü adından tanıyan betik. Ek bilgi için: ":help 'filetype'".
+.TP
+/usr/local/lib/vim/scripts.vim
+Dosya türünü içeriğinden tanıyan betik. Ek bilgi için: ":help 'filetype'".
+.TP
+/usr/local/lib/vim/print/*.ps
+PostScript yazdırması için kullanılan dosyalar.
+.PP
+En güncel bilgiler için VİM ana sayfasını ziyaret edin:
+.br
+<URL:http://www.vim.org/>
+.SH AYRICA BAKINIZ
+vimtutor(1)
+.SH YAZAR
+.B Vim'in
+büyük çoğunluğu Bram Moolenaar tarafından başkalarının kayda değer
+yardımlarıyla yazılmıştır.
+Ek bilgi için
+.B Vim
+içinde ":help credits" yazın.
+.br
+.B Vim
+Stevie tabanlıdır, yazarları: Tim Thompson,
+Tony Andrews ve G.R. (Fred) Walter.
+Orijinal koddan geriye pek bir şey kalmadığını söylemek yanlış olmaz.
+.SH HATALAR
+Bilinen hataların bir listesi için ":help todo" yazın.
+.PP
+Unutmayın ki, başkaları tarafından hata olarak değerlendirilebilecek konuların
+bir çoğu Vi'nin davranışlarına sadık kalınması nedeniyle vardır. Yine de
+bazı şeylerin "Vi bunu değişik biçimde yapıyor" diye hata olabileceğini
+düşünüyorsanız, "vi_diff.txt" dosyasını dikkatle okuyun (veya Vim içinde
+:help vi_diff.txt yazın.
+Ek olarak 'compatible' ve 'cpoptions' seçeneklerine de bakabilirsiniz.

--- a/runtime/doc/vimdiff-tr.1
+++ b/runtime/doc/vimdiff-tr.1
@@ -1,0 +1,45 @@
+.TH VIMDIFF 1 "30 Mart 2001"
+.SH AD
+vimdiff \- bir dosyanýn dört adede kadar sürümlerini Vim ile düzenle
+ve ayrýmlarýný göster
+.SH ÖZET
+.br
+.B vimdiff
+[seçenekler] dosya1 dosya2 [dosya3 [dosya4]]
+.PP
+.B gvimdiff
+.SH TANIM
+.B Vimdiff,
+.B Vim
+içinde iki (üç veya dört) dosyayý açar.
+Her dosya ayrý pencerelerde açýlýr.
+Dosyalar arasýndaki ayrýmlar vurgulanýr.
+Böylece deðiþiklikler kolayca denetlenebilir ve ayný dosyanýn baþka bir
+sürümüne kolaylýkla aktarýlabilir.
+.PP
+Vim hakkýnda ek bilgi için: vim(1)
+.PP
+.B gvimdiff
+olarak baþlatýlýrsa varsa grafik arabirim açýlýr.
+.PP
+Her pencerede 'diff' seçeneði açýlýr, böylece deðiþiklikler vurgulanýr.
+.br
+\'wrap' ve 'scrollbind' seçenekleri metnin düzgün görünmesi için açýlýr.
+.br
+\'foldmethod' seçeneði "diff"e, ayarlanýr, böylece satýr aralýklarý
+kývrýlýr. 'foldcolumn' seçeneði kývýrmalarý kolay ayrýmlama ve açýp kapama
+için iki olarak ayarlanýr.
+.SH SEÇENEKLER
+Satýrlar hizalama için "\-O" seçeneði kullanýlmýþçasýna dikey bölüntüler
+içinde görüntülenir.
+Yatay bölüntüler kullanmak için "\-o" kullanýn.
+Diðer tüm deðiþkenler için: vim(1).
+.SH AYRICA BAKINIZ
+vim(1)
+.SH YAZAR
+.B Vim'in
+büyük çoðunluðu Bram Moolenaar tarafýndan baþkalarýnýn kayda deðer
+yardýmlarýyla yazýlmýþtýr.
+Ek bilgi için
+.B Vim
+içinde ":help credits" yazýn.

--- a/runtime/doc/vimdiff-tr.UTF-8.1
+++ b/runtime/doc/vimdiff-tr.UTF-8.1
@@ -1,0 +1,45 @@
+.TH VIMDIFF 1 "30 Mart 2001"
+.SH AD
+vimdiff \- bir dosyanın dört adede kadar sürümlerini Vim ile düzenle
+ve ayrımlarını göster
+.SH ÖZET
+.br
+.B vimdiff
+[seçenekler] dosya1 dosya2 [dosya3 [dosya4]]
+.PP
+.B gvimdiff
+.SH TANIM
+.B Vimdiff,
+.B Vim
+içinde iki (üç veya dört) dosyayı açar.
+Her dosya ayrı pencerelerde açılır.
+Dosyalar arasındaki ayrımlar vurgulanır.
+Böylece değişiklikler kolayca denetlenebilir ve aynı dosyanın başka bir
+sürümüne kolaylıkla aktarılabilir.
+.PP
+Vim hakkında ek bilgi için: vim(1)
+.PP
+.B gvimdiff
+olarak başlatılırsa varsa grafik arabirim açılır.
+.PP
+Her pencerede 'diff' seçeneği açılır, böylece değişiklikler vurgulanır.
+.br
+\'wrap' ve 'scrollbind' seçenekleri metnin düzgün görünmesi için açılır.
+.br
+\'foldmethod' seçeneği "diff"e, ayarlanır, böylece satır aralıkları
+kıvrılır. 'foldcolumn' seçeneği kıvırmaları kolay ayrımlama ve açıp kapama
+için iki olarak ayarlanır.
+.SH SEÇENEKLER
+Satırlar hizalama için "\-O" seçeneği kullanılmışçasına dikey bölüntüler
+içinde görüntülenir.
+Yatay bölüntüler kullanmak için "\-o" kullanın.
+Diğer tüm değişkenler için: vim(1).
+.SH AYRICA BAKINIZ
+vim(1)
+.SH YAZAR
+.B Vim'in
+büyük çoğunluğu Bram Moolenaar tarafından başkalarının kayda değer
+yardımlarıyla yazılmıştır.
+Ek bilgi için
+.B Vim
+içinde ":help credits" yazın.

--- a/runtime/doc/vimtutor-tr.1
+++ b/runtime/doc/vimtutor-tr.1
@@ -1,0 +1,50 @@
+.TH VIMTUTOR 1 "2 Nisan 2001"
+.SH AD
+vimtutor \- Vim eðitmeni
+.SH ÖZET
+.br
+.B vimtutor [\-g] [dil]
+.SH TANIM
+.B Vimtutor,
+.B Vim
+eðitmenini baþlatýr.
+Önce orijinal eðitmen dosyasýnýn bir kopyasýný alýr, böylece bir deðiþikliðe
+uðramadan deðiþtirilebilir.
+.PP
+.B Vimtutor
+ilk
+.B Vim
+komutlarýný öðrenmek isteyen kiþiler için yararlýdýr.
+.PP
+Ýsteðe baðlý \-g deðiþkeni vimtutor'u vim yerine eðer yüklü ise gvim ile
+baþlatýr. Yüklü deðilse açmak için Vim kullanýlýr.
+.PP
+Ýsteðe baðlý [dil] deðiþkeni iki harfli dil kodunu belirtir, örneðin "tr"
+veya "es". Eðer [dil] deðiþkeni verilmemiþse mevcut yerelleþtirme
+kullanýlýr.
+Eðer bu dilde bir eðitmen varsa kullanýlýr.
+Yoksa Ýngilizce sürüm kullanýlacaktýr.
+.PP
+.B Vim
+her zaman Vi uyumlu kipte baþlatýlýr.
+.SH DOSYALAR
+.TP 15
+/usr/local/lib/vim/tutor/tutor[.dil]
+.B Vimtutor
+metin dosyalarý.
+.TP 15
+/usr/local/lib/vim/tutor/tutor.vim
+.B Vimtutor
+metin dosyasýný kopyalamak için kullanýlan betik.
+.SH YAZAR
+.B Vimtutor
+ilk olarak Vi için Michael C. Pierce ve Robert K. Ware, 
+Colorado School of Mines tarafýndan, Colorado State University'den Charles
+Smith'in verdiði fikirler kullanýlarak yazýldý.
+E-posta: bware@mines.colorado.edu.
+.br
+.B Vim
+uyarlamasý Bram Moolenaar tarafýndan yapýldý.
+Çevirmenlerin adlarý için eðitmen dosyalarýna bakýn.
+.SH AYRICA BAKINIz
+vim(1)

--- a/runtime/doc/vimtutor-tr.UTF-8.1
+++ b/runtime/doc/vimtutor-tr.UTF-8.1
@@ -1,0 +1,50 @@
+.TH VIMTUTOR 1 "2 Nisan 2001"
+.SH AD
+vimtutor \- Vim eğitmeni
+.SH ÖZET
+.br
+.B vimtutor [\-g] [dil]
+.SH TANIM
+.B Vimtutor,
+.B Vim
+eğitmenini başlatır.
+Önce orijinal eğitmen dosyasının bir kopyasını alır, böylece bir değişikliğe
+uğramadan değiştirilebilir.
+.PP
+.B Vimtutor
+ilk
+.B Vim
+komutlarını öğrenmek isteyen kişiler için yararlıdır.
+.PP
+İsteğe bağlı \-g değişkeni vimtutor'u vim yerine eğer yüklü ise gvim ile
+başlatır. Yüklü değilse açmak için Vim kullanılır.
+.PP
+İsteğe bağlı [dil] değişkeni iki harfli dil kodunu belirtir, örneğin "tr"
+veya "es". Eğer [dil] değişkeni verilmemişse mevcut yerelleştirme
+kullanılır.
+Eğer bu dilde bir eğitmen varsa kullanılır.
+Yoksa İngilizce sürüm kullanılacaktır.
+.PP
+.B Vim
+her zaman Vi uyumlu kipte başlatılır.
+.SH DOSYALAR
+.TP 15
+/usr/local/lib/vim/tutor/tutor[.dil]
+.B Vimtutor
+metin dosyaları.
+.TP 15
+/usr/local/lib/vim/tutor/tutor.vim
+.B Vimtutor
+metin dosyasını kopyalamak için kullanılan betik.
+.SH YAZAR
+.B Vimtutor
+ilk olarak Vi için Michael C. Pierce ve Robert K. Ware, 
+Colorado School of Mines tarafından, Colorado State University'den Charles
+Smith'in verdiği fikirler kullanılarak yazıldı.
+E-posta: bware@mines.colorado.edu.
+.br
+.B Vim
+uyarlaması Bram Moolenaar tarafından yapıldı.
+Çevirmenlerin adları için eğitmen dosyalarına bakın.
+.SH AYRICA BAKINIz
+vim(1)


### PR DESCRIPTION
Problem:    No Turkish translation of the manual.
Solution:   Add Turkish translations. (Emir Sarı, closes vim/vim#5641)
https://github.com/vim/vim/commit/f09715bc5c827dab4425736da9024727836997e5
