### PR TITLE
ci: fix lint errors caused by missing includes

### DIFF
--- a/src/nvim/os/fs.h
+++ b/src/nvim/os/fs.h
@@ -1,6 +1,9 @@
 #ifndef NVIM_OS_FS_H
 #define NVIM_OS_FS_H
 
+#include "nvim/os/fs_defs.h"  // for uv_*
+#include "nvim/types.h"  // for char_u
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/fs.h.generated.h"
 #endif


### PR DESCRIPTION
This will fix the `check-single-includes` check which started failing
after https://github.com/neovim/neovim/pull/18663/.
