### PR TITLE
feat(cmake): run busted tests with ctest

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,37 @@
+-- vim: ft=lua tw=80 sw=2 ts=2
+
+return {
+  _all = {
+    helper = 'test/preload.lua',
+    lpath = 'build/?.lua;runtime/lua/?.lua;./?.lua',
+    output = 'test.busted.outputHandlers.nvim',
+    Xhelper = { 'IS_FUNCTIONAL_TEST' },
+  },
+  ---
+  functional = { ROOT = { 'test/functional' } },
+  ----
+  api = { ROOT = { 'test/functional/api' } },
+  autocmd = { ROOT = { 'test/functional/autocmd' } },
+  core = { ROOT = { 'test/functional/core' } },
+  editor = { ROOT = { 'test/functional/editor' } },
+  exCmds = { ROOT = { 'test/functional/ex_cmds' } },
+  lua = { ROOT = { 'test/functional/lua' } },
+  options = { ROOT = { 'test/functional/options' } },
+  plugin = { ROOT = { 'test/functional/plugin' } },
+  provider = { ROOT = { 'test/functional/provider' } },
+  shada = { ROOT = { 'test/functional/shada' } },
+  terminal = { ROOT = { 'test/functional/terminal' } },
+  treesitter = { ROOT = { 'test/functional/treesitter' } },
+  ui = { ROOT = { 'test/functional/ui' } },
+  vimscript = { ROOT = { 'test/functional/vimscript' } },
+  ---
+  unit = {
+    ROOT = { 'test/unit' },
+    Xhelper = { 'IS_UNIT_TEST' },
+  },
+  ---
+  benchmark = {
+    ROOT = { 'test/benchmark' },
+    Xhelper = { 'IS_BENCHMARK_TEST' },
+  },
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,28 @@ jobs:
         name: Install nvim
         run: ./ci/run_tests.sh install_nvim
 
+      - if: matrix.flavor != 'tsan' && matrix.flavor != 'functionaltest-lua' && !cancelled()
+        name: Generate test-runners
+        run: |
+          cmake --build $GITHUB_WORKSPACE/build --target generate-test-runners
+
+
+      # macOS runners have 3 threads
+      - if: matrix.runner == 'macos-11.0' && !cancelled()
+        name: CTest isolated
+        run: |
+          unset CTEST_PROGRESS_OUTPUT
+          export CTEST_PARALLEL_LEVEL=$(node -r os -e 'process.stdout.write(os.cpus().length.toString())' 2>/dev/null || echo "2")
+          ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure -LE '_serial' -j${CTEST_PARALLEL_LEVEL} --repeat "until-pass:3"
+
+      - if: (matrix.runner == 'macos-11' || matrix.flavor == 'uchar') && !cancelled()
+        name: CTest benchmark
+        timeout-minutes: 10
+        run: |
+          unset CTEST_PROGRESS_OUTPUT
+          unset CTEST_PARALLEL_LEVEL
+          ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure -L '_serial'
+
       - name: Cache dependencies
         run: ./ci/before_cache.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ tags
 
 # vim patches
 /vim-*.patch
+
+# ctest artifcats
+Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,8 +698,8 @@ install_helper(
 
 add_subdirectory(src/nvim)
 get_directory_property(NVIM_VERSION_CFLAGS DIRECTORY src/nvim DEFINITION NVIM_VERSION_CFLAGS)
-add_subdirectory(test/includes)
 add_subdirectory(cmake.config)
+enable_testing()
 add_subdirectory(test/functional/fixtures)  # compile test programs
 add_subdirectory(runtime)
 get_directory_property(GENERATED_HELP_TAGS DIRECTORY runtime DEFINITION GENERATED_HELP_TAGS)
@@ -785,6 +785,9 @@ if(BUSTED_PRG)
     DEPENDS ${BENCHMARK_PREREQS}
     ${TEST_TARGET_ARGS})
   set_target_properties(benchmark PROPERTIES FOLDER test)
+
+  # needs to be run after defining unittest-prereqs
+  add_subdirectory(test)
 endif()
 
 if(BUSTED_LUA_PRG)

--- a/cmake/BustedAddTests.cmake
+++ b/cmake/BustedAddTests.cmake
@@ -1,0 +1,117 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+set(prefix "${TEST_PREFIX}")
+set(suffix "${TEST_SUFFIX}")
+set(extra_args ${TEST_EXTRA_ARGS})
+set(properties ${TEST_PROPERTIES})
+set(script)
+set(suite)
+set(tests)
+
+if(POLICY CMP0110)
+  # supports arbitrary characters in test names
+  cmake_policy(SET CMP0110 NEW)
+endif()
+
+function(add_command NAME)
+  set(_args "")
+  # use ARGV* instead of ARGN, because ARGN splits arrays into multiple arguments
+  math(EXPR _last_arg ${ARGC}-1)
+  foreach(_n RANGE 1 ${_last_arg})
+    set(_arg "${ARGV${_n}}")
+    if(_arg MATCHES "[^-./:a-zA-Z0-9_]")
+      set(_args "${_args} [==[${_arg}]==]") # form a bracket_argument
+    else()
+      set(_args "${_args} ${_arg}")
+    endif()
+  endforeach()
+  set(script "${script}${NAME}(${_args})\n" PARENT_SCOPE)
+endfunction()
+
+# Run test executable to get list of available tests
+if(NOT EXISTS "${SPEC_ROOT}")
+  message(
+    FATAL_ERROR
+    "Specified test file '${SPEC_ROOT}' does not exist"
+  )
+endif()
+
+get_filename_component(suite ${SPEC_ROOT} NAME_WLE CACHE)
+
+# This is useful to avoid long paths issues
+file(RELATIVE_PATH SPEC_ROOT_RELATIVE "${WORKING_DIR}" "${SPEC_ROOT}")
+
+# if(IS_ABSOLUTE ${SPEC_ROOT})
+#   file(RELATIVE_PATH SPEC_ROOT "${WORKING_DIR}" "${SPEC_ROOT}")
+# endif()
+
+execute_process(
+  COMMAND ${BUSTED_PRG} ${SPEC_ROOT_RELATIVE} --list ${extra_args}
+  OUTPUT_VARIABLE output
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY "${WORKING_DIR}"
+)
+
+if(NOT ${result} EQUAL 0)
+  message(
+    FATAL_ERROR
+    "Error running test file '${SPEC_ROOT_RELATIVE}':\n"
+    "  Result: ${result}\n"
+    "  Output: ${output}\n"
+  )
+endif()
+
+string(REPLACE "\n" ";" output "${output}")
+
+# Parse output
+foreach(line ${output})
+  string(REGEX REPLACE ".*:[0-9]+: (.*)" "\\1" testname ${line})
+
+  if(POLICY CMP0110)
+    # supports arbitrary characters in test names
+    set(testname_clean ${testname})
+  else()
+    # Escape certain problematic characters
+    string(REGEX REPLACE "[^-+./:a-zA-Z0-9_]" "." testname_clean ${testname})
+  endif()
+
+  set(guarded_testname "${prefix}${testname_clean}${suffix}")
+
+  # busted allows using wildcards
+  string(REGEX REPLACE "[-+%]" "." test_filter ${testname_clean})
+
+  if(BUSTED_ARGS)
+    list(APPEND extra_args "--output=${OUTPUT_HANDLER}")
+  endif()
+
+
+  separate_arguments(extra_args)
+
+  add_command(
+    add_test
+    "${guarded_testname}"
+    ${BUSTED_PRG}
+    ${SPEC_ROOT_RELATIVE}
+    --filter=${test_filter}
+    ${extra_args}
+  )
+
+  add_command(
+    set_tests_properties
+    "${guarded_testname}"
+    PROPERTIES
+    WORKING_DIRECTORY "${WORKING_DIR}"
+    LABELS "${suite}"
+    ENVIRONMENT "${TEST_ENVIRONMENT}"
+    ${TEST_PROPERTIES}
+  )
+  list(APPEND tests "${guarded_testname}")
+endforeach()
+
+# Create a list of all discovered tests, which users may use to e.g. set
+# properties on the tests
+add_command(set ${TEST_LIST} ${tests})
+
+# Write CTest script
+file(WRITE "${CTEST_FILE}" "${script}")

--- a/cmake/LuaBusted.cmake
+++ b/cmake/LuaBusted.cmake
@@ -1,0 +1,83 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+# See https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+Busted
+-----
+#]=======================================================================]
+
+#------------------------------------------------------------------------------
+function(busted_discover_tests TARGET)
+  cmake_parse_arguments(
+    ""
+    ""
+    "BUSTED_PRG;LUA_PRG;TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;BUILD_DIR;TEST_LIST"
+    "EXTRA_ARGS;TEST_ENVIRONMENT;PROPERTIES"
+    ${ARGN}
+  )
+
+  if(NOT _WORKING_DIRECTORY)
+    set(_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
+  endif()
+  if(NOT _TEST_LIST)
+    set(_TEST_LIST ${TARGET}_TESTS)
+  endif()
+
+  # TODO(kylo252): figure out if we can use a generator expression instead
+  get_target_property(SPECS ${TARGET} SOURCES)
+
+  foreach(SPEC_ROOT ${SPECS})
+    if(NOT IS_DIRECTORY "${SPEC_ROOT}")
+      get_filename_component(ctest_file_base ${SPEC_ROOT} NAME_WLE)
+    else()
+      file(RELATIVE_PATH ctest_file_base "${_WORKING_DIRECTORY}/test" "${SPEC_ROOT}")
+    endif()
+    set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${ctest_file_base}_include.cmake")
+    set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${ctest_file_base}_tests.cmake")
+
+    add_custom_command(
+      TARGET ${TARGET} POST_BUILD
+      BYPRODUCTS "${ctest_tests_file}"
+      COMMAND "${CMAKE_COMMAND}"
+      -D "TEST_TARGET=${TARGET}"
+      -D "BUSTED_PRG=${_BUSTED_PRG}"
+      -D "SPEC_ROOT=${SPEC_ROOT}"
+      -D "LUA_PRG=${_LUA_PRG}"
+      -D "WORKING_DIR=${_WORKING_DIRECTORY}"
+      -D "BUILD_DIR=${_BUILD_DIR}"
+      -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"
+      -D "TEST_PROPERTIES=${_PROPERTIES}"
+      -D "TEST_ENVIRONMENT=${_TEST_ENVIRONMENT}"
+      -D "TEST_PREFIX=${_TEST_PREFIX}"
+      -D "TEST_SUFFIX=${_TEST_SUFFIX}"
+      -D "TEST_LIST=${_TEST_LIST}"
+      -D "CTEST_FILE=${ctest_tests_file}"
+      -P "${_BUSTED_DISCOVER_TESTS_SCRIPT}"
+      VERBATIM
+    )
+
+    file(
+      WRITE "${ctest_include_file}"
+      "if(EXISTS \"${ctest_tests_file}\")\n"
+      "  include(\"${ctest_tests_file}\")\n"
+      "else()\n"
+      "  add_test(${TARGET}_NOT_BUILT ${TARGET}_NOT_BUILT)\n"
+      "endif()\n"
+    )
+
+    # Add discovered tests to directory TEST_INCLUDE_FILES
+    set_property(
+      DIRECTORY
+      APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
+    )
+  endforeach()
+
+endfunction()
+
+###############################################################################
+
+set(
+  _BUSTED_DISCOVER_TESTS_SCRIPT
+  ${CMAKE_CURRENT_LIST_DIR}/BustedAddTests.cmake
+  CACHE INTERNAL "busted full path to BustedAddTests.cmake helper file"
+)

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -23,9 +23,13 @@ endif()
 
 if(DEFINED ENV{TEST_FILE})
   set(TEST_PATH "$ENV{TEST_FILE}")
+elseif(TEST_PATH)
+  set(TEST_PATH "${TEST_PATH}")
 else()
   set(TEST_PATH "${TEST_DIR}/${TEST_TYPE}")
 endif()
+
+message(STATUS "Using TEST_PATH: ${TEST_PATH}")
 
 # Force $TEST_PATH to workdir-relative path ("test/…").
 if(IS_ABSOLUTE ${TEST_PATH})
@@ -34,21 +38,34 @@ endif()
 
 if(BUSTED_OUTPUT_TYPE STREQUAL junit)
   set(EXTRA_ARGS OUTPUT_FILE ${BUILD_DIR}/${TEST_TYPE}test-junit.xml)
+elseif(NOT BUSTED_OUTPUT_TYPE)
+  set(BUSTED_OUTPUT_TYPE nvim)
 endif()
 
-set(BUSTED_ARGS $ENV{BUSTED_ARGS})
+if(DEFINED ENV{BUSTED_ARGS})
+  set(BUSTED_ARGS "$ENV{BUSTED_ARGS}")
+elseif(BUSTED_ARGS)
+  set(BUSTED_ARGS "${BUSTED_ARGS}")
+endif()
+
 separate_arguments(BUSTED_ARGS)
 
 if(DEFINED ENV{TEST_TAG} AND NOT "$ENV{TEST_TAG}" STREQUAL "")
   list(APPEND BUSTED_ARGS --tags $ENV{TEST_TAG})
+elseif(TEST_TAG)
+  list(APPEND BUSTED_ARGS --tags ${TEST_TAG})
 endif()
 
 if(DEFINED ENV{TEST_FILTER} AND NOT "$ENV{TEST_FILTER}" STREQUAL "")
   list(APPEND BUSTED_ARGS --filter $ENV{TEST_FILTER})
+elseif(TEST_FILTER)
+  list(APPEND BUSTED_ARGS --filter ${TEST_FILTER})
 endif()
 
 if(DEFINED ENV{TEST_FILTER_OUT} AND NOT "$ENV{TEST_FILTER_OUT}" STREQUAL "")
   list(APPEND BUSTED_ARGS --filter-out $ENV{TEST_FILTER_OUT})
+elseif(TEST_FILTER_OUT)
+  list(APPEND BUSTED_ARGS --filter-out ${TEST_FILTER_OUT})
 endif()
 
 # TMPDIR: for helpers.tmpname() and Nvim tempname().
@@ -75,7 +92,8 @@ execute_process(
   WORKING_DIRECTORY ${WORKING_DIR}
   ERROR_VARIABLE err
   RESULT_VARIABLE res
-  ${EXTRA_ARGS})
+  ${EXTRA_ARGS}
+  )
 
 file(GLOB RM_FILES ${BUILD_DIR}/Xtest_*)
 file(REMOVE_RECURSE ${RM_FILES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,107 @@
+add_subdirectory(includes)
+
+# TODO:
+# - specify *all* the luarocks requirements for tests (what about ffi?)
+# - use impatient to make up for the (sizeable) overhead when running each test independently
+
+#################################
+########## test specs ###########
+#################################
+
+set(ENV{LC_ALL} "en_US.UTF-8")
+
+if(POLICY CMP0012)
+  # Handle CI=true, without dev warnings.
+  cmake_policy(SET CMP0012 NEW)
+endif()
+
+set(NVIM_PRG $<TARGET_FILE:nvim>)
+
+set(test_env)
+list(
+  APPEND test_env
+  "LC_ALL=en_US.UTF-8"
+  "NVIM_PRG=${NVIM_PRG}"
+  "NEOVIM_BUILD_DIR=${PROJECT_BINARY_DIR}"
+  "NEOVIM_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
+  "VIMRUNTIME=${PROJECT_SOURCE_DIR}/runtime"
+  "NVIM_RPLUGIN_MANIFEST=${PROJECT_BINARY_DIR}/Xtest_rplugin_manifest"
+  "LOG_DIR=${PROJECT_BINARY_DIR}/log"
+  "TEST_SKIP_FRAGILE=ON"
+  "SYSTEM_NAME=${CMAKE_HOST_SYSTEM_NAME}"
+)
+
+foreach(
+  task
+  api
+  autocmd
+  core
+  editor
+  exCmds
+  lua
+  options
+  plugin
+  provider
+  shada
+  terminal
+  treesitter
+  ui
+  vimscript
+)
+  add_test(
+    NAME ${task}_serial
+    COMMAND ${BUSTED_PRG} --run=${task}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
+  set_tests_properties(
+    ${task}_serial
+    PROPERTIES
+    LABELS ${task}_serial
+    ENVIRONMENT "${test_env}"
+  )
+endforeach()
+
+# set_tests_properties(
+#   terminal_serial
+#   PROPERTIES
+#   RUN_SERIAL ON
+# )
+
+if(NOT LUA_HAS_FFI)
+  message(INFO "disabling test discovery: no Luajit FFI in ${LUA_PRG}")
+  return()
+endif()
+
+# TODO: this currently doesn't work for test/unit because test/unit/helper.lua is loading all the tests instead
+add_custom_target(
+  generate-test-runners
+  DEPENDS ${FUNCTIONALTEST_PREREQS}
+  SOURCES ${PROJECT_SOURCE_DIR}/test/functional/api/autocmd_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/buffer_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/buffer_updates_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/command_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/extmark_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/highlight_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/keymap_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/menu_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/proc_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/server_notifications_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/server_requests_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/tabpage_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/ui_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/version_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/vim_spec.lua
+  ${PROJECT_SOURCE_DIR}/test/functional/api/window_spec.lua
+)
+
+include(LuaBusted)
+
+busted_discover_tests(
+  generate-test-runners
+  BUSTED_PRG ${BUSTED_PRG}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  LUA_PRG ${LUA_PRG}
+  BUILD_DIR ${PROJECT_BINARY_DIR}
+  EXTRA_ARGS -Xhelper IS_FUNCTIONAL_TEST --no-auto-insulate --no-lazy
+  TEST_ENVIRONMENT ${test_env}
+)

--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -173,7 +173,14 @@ return function(options)
     if randomseed then
       io.write(randomizeString:format(randomseed))
     end
-    io.write(globalSetup)
+    if os.getenv('DEBUG') then
+      io.write(globalSetup)
+      io.write('\n')
+      local buf = io.popen('env', 'r')
+      local output = buf:read('*a')
+      io.write(output)
+      io.write('\n')
+    end
     io.flush()
 
     return nil, true

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -474,6 +474,10 @@ function module.new_argv(...)
         'NVIM_RPLUGIN_MANIFEST',
         'GCOV_ERROR_FILE',
         'XDG_DATA_DIRS',
+        'XDG_CONFIG_HOME',
+        'XDG_DATA_HOME',
+        'XDG_STATE_HOME',
+        'XDG_CACHE_HOME',
         'TMPDIR',
         'VIMRUNTIME',
       }) do

--- a/test/preload.lua
+++ b/test/preload.lua
@@ -1,0 +1,184 @@
+-- Modules loaded here will not be cleared and reloaded by Busted.
+-- See #2082, Olivine-Labs/busted#62 and Olivine-Labs/busted#643
+
+local test_type
+
+for _, value in pairs(_G.arg) do
+  if value:match('IS_FUNCTIONAL_TEST') then
+    test_type = 'functional'
+  elseif value:match('IS_UNIT_TEST') then
+    test_type = 'unit'
+  elseif value:match('IS_BENCHMARK_TEST') then
+    test_type = 'benchmark'
+  end
+end
+
+local luv = require('luv')
+
+local function join_paths(...)
+  local path_sep = luv.os_uname().version:match('Windows') and '\\' or '/'
+  local result = table.concat({ ... }, path_sep)
+  return result
+end
+
+local function is_file(path)
+  local stat = luv.fs_stat(path)
+  return stat and stat.type == 'file' or false
+end
+
+local function is_directory(path)
+  local stat = luv.fs_stat(path)
+  return stat and stat.type == 'directory' or false
+end
+
+-- credit: treesitter.actions.remove_dir()
+local function remove_dir(path)
+  local handle = luv.fs_scandir(path)
+  if type(handle) == 'string' then
+    error(handle)
+  end
+
+  while true do
+    local name, t = luv.fs_scandir_next(handle)
+    if not name then
+      break
+    end
+
+    local new_cwd = join_paths(path, name)
+    if t == 'directory' then
+      local success = remove_dir(new_cwd)
+      if not success then
+        return false
+      end
+    else
+      local success = luv.fs_unlink(new_cwd)
+      if not success then
+        return false
+      end
+    end
+  end
+
+  return luv.fs_rmdir(path)
+end
+
+--[[
+  TODO(kylo252): we should probably override TMPDIR dynamically per test regardless,
+  but that seems to cause issues for rpc tests where TMPDIR isn't passed along
+  -- luv.os_setenv('TMPDIR', NVIM_TEST_TMPDIR)
+--]]
+
+local tmpname = function()
+  local fd, tmp_path = luv.fs_mkstemp(join_paths(os.getenv('TMPDIR'), 'nvim_XXXXXXXXXX'))
+
+  -- if not open, open with (0700) permissions
+  fd = fd or luv.fs_open(tmp_path, 'w', 384)
+  luv.fs_close(fd)
+
+  return tmp_path, function()
+    luv.fs_unlink(tmp_path)
+  end
+end
+
+local global_helpers = require('test.helpers')
+
+global_helpers.is_file = is_file
+global_helpers.is_directory = is_directory
+global_helpers.join_paths = join_paths
+global_helpers.remove_dir = remove_dir
+
+-- override tmpname
+global_helpers.tmpname = tmpname
+
+local ffi_ok, ffi = pcall(require, 'ffi')
+
+local iswin = global_helpers.iswin
+if iswin() and ffi_ok then
+  ffi.cdef([[
+  typedef int errno_t;
+  errno_t _set_fmode(int mode);
+  ]])
+  ffi.C._set_fmode(0x8000)
+end
+
+if test_type == 'unit' then
+  require('test.unit.preprocess')
+end
+
+require('test.' .. test_type .. '.helpers')(nil)
+package.loaded['test.' .. test_type .. '.helpers'] = nil
+
+local testid = (function()
+  local id = 0
+  return function()
+    id = id + 1
+    return id
+  end
+end)()
+
+local NEOVIM_BUILD_DIR = os.getenv('NEOVIM_BUILD_DIR') or join_paths(luv.cwd(), 'build')
+local get_artifcats_dir = function(context)
+  return join_paths(NEOVIM_BUILD_DIR, 'Testing', 'artifacts', context.test_pid)
+end
+
+local base_dirs = {
+  XDG_CONFIG_HOME = join_paths(NEOVIM_BUILD_DIR, 'Xtest_xdg', 'config'),
+  XDG_DATA_HOME = join_paths(NEOVIM_BUILD_DIR, 'Xtest_xdg', 'data'),
+  XDG_STATE_HOME = join_paths(NEOVIM_BUILD_DIR, 'Xtest_xdg', 'state'),
+  XDG_CACHE_HOME = join_paths(NEOVIM_BUILD_DIR, 'Xtest_xdg', 'cache'),
+  TMPDIR = join_paths(NEOVIM_BUILD_DIR, 'Xtest_tmpdir'),
+  LOG_DIR = join_paths(os.getenv('LOG_DIR') or NEOVIM_BUILD_DIR, 'Xtest_log'),
+}
+
+for k, path in pairs(base_dirs) do
+  luv.os_setenv(k, path)
+end
+
+local cleanupArtifacts = function(context)
+  local artifacts_dir = get_artifcats_dir(context)
+  if is_directory(artifacts_dir) then
+    return remove_dir(artifacts_dir)
+  end
+end
+
+local testEnd = function(context, _, status, _)
+  if status == 'error' then
+    return
+  end
+  cleanupArtifacts(context)
+  return nil, true
+end
+
+-- Global before_each. https://github.com/Olivine-Labs/busted/issues/613
+local before_each = function(context)
+  local id = ('T%d'):format(testid())
+  context.test_pid = luv.os_getpid()
+  context.test_id = id
+  _G._nvim_test_id = id
+
+  local NVIM_LOG_FILE = join_paths(os.getenv('LOG_DIR') or base_dirs.TMPDIR, '.nvimlog')
+  luv.os_setenv('NVIM_LOG_FILE', NVIM_LOG_FILE)
+
+  luv.os_unsetenv('XDG_DATA_DIRS')
+  luv.os_unsetenv('NVIM')
+
+  for k, path in pairs(base_dirs) do
+    local dir = require('pl.dir')
+    dir.makepath(join_paths(path, id, 'nvim'), tonumber('0700'))
+    luv.os_setenv(k, join_paths(path, id))
+  end
+  return nil, true
+end
+
+local busted = require('busted')
+
+busted.subscribe({ 'test', 'start' }, before_each, {
+  priority = 1,
+  -- Don't generate a test-id for skipped tests. /shrug
+  predicate = function(element, _, status)
+    return not (element.descriptor == 'pending' or status == 'pending')
+  end,
+})
+
+busted.subscribe({ 'test', 'end' }, testEnd, {
+  priority = 101,
+})


### PR DESCRIPTION
## Description

Make use of [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html) to streamline running busted tests\tasks

### Features

- add `busted_discover_tests` which enables running _each_ test in an isolated environment, with a nice short-hand
  ```console
  TEST_FILE=test/functional/api/autocmd_spec.lua TEST_FILTER='removes.an.autocommand' cmake --build build --target functionaltest
  # vs
  ctest --test-dir build -R 'removes.an.autocommand'
  ```
- add the ability to run tests by [labels](https://github.com/kylo252/neovim/blob/978649c15ea3269fa8d60bdfd69b31c77eac8df8/.github/workflows/ci.yml#L268-L280)

#### Additional improvements

- use the configuration file [.busted](https://github.com/Olivine-Labs/busted/blob/0fc1f4faedcfee287fb925fec78ef88488a2df3a/spec/.hidden/.busted) to set common flags needed to be passed to `busted` on every run
- create a single `test/preload.lua` that can detect which specific helper to load using based on args passed to `-Xhelper`

### How to use

- run all the tests
  ```sh
  ctest --test-dir build --progress
  # or
  cmake --build build --target test
  # or
  ninja -C build test
  ```
- list all available labels
  ```sh
  ctest --test-dir build --print-labels
  ```
- list all available tests
  ```sh
  ctest --test-dir build --list
  ```
- run tests by label `-L or --label-regex`, see all available [flags](https://cmake.org/cmake/help/latest/manual/ctest.1.html#options)
  ```sh
  ctest --test-dir build -L 'api_spec'
  ```


