### PR TITLE
fix(treesitter): use regions for `LanguageTree:contains`

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -513,9 +513,19 @@ function LanguageTree:register_cbs(cbs)
   end
 end
 
+---Determine whether {range} is completely inside {region} (range(region)==range -> true).
+---@param region node or 6-tuple srow, scol, sbyte, erow, ecol, ebyte.
+---@param inner range, 4-tuple srow, scol, erow, ecol.
+---@return boolean
 ---@private
-local function tree_contains(tree, range)
-  local start_row, start_col, end_row, end_col = tree:root():range()
+local function region_contains(region, range)
+  local start_row, start_col, end_row, end_col
+  if type(region) == 'table' then
+    start_row, start_col, end_row, end_col = region[1], region[2], region[4], region[5]
+  else
+    start_row, start_col, end_row, end_col = region:range()
+  end
+
   local start_fits = start_row < range[1] or (start_row == range[1] and start_col <= range[2])
   local end_fits = end_row > range[3] or (end_row == range[3] and end_col >= range[4])
 
@@ -526,12 +536,13 @@ end
 ---
 ---@param range A range, that is a `{ start_line, start_col, end_line, end_col }` table.
 function LanguageTree:contains(range)
-  for _, tree in pairs(self._trees) do
-    if tree_contains(tree, range) then
-      return true
+  for _, combined_region in ipairs(self._regions) do
+    for _, region in ipairs(combined_region) do
+      if region_contains(region, range) then
+        return true
+      end
     end
   end
-
   return false
 end
 

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -749,7 +749,10 @@ int x = INT_MAX;
       parser = vim.treesitter.get_parser(0, "c", {
         injections = { c = "(preproc_def (preproc_arg) @c)"}})
 
-      local sub_tree = parser:language_for_range({1, 18, 1, 19})
+      -- check languagetree returned for " 123456789",
+      --                                  ^
+      -- it should be the injected one, since (preproc_arg) includes the space
+      local sub_tree = parser:language_for_range({1, 13, 1, 13})
 
       return sub_tree == parser:children().c
       ]])


### PR DESCRIPTION
The range of the tree-roots does not necessarily match that of the LanguageTrees regions (which are, afaict directly generated from injection-queries, and therefore correct (as per my limited understanding)).

The specific problem fixed by this is `language_for_range()` returning an incorrect filetype (`"markdown"` instead of `"lua"`, in this case) in empty fenced code blocks in markdown.
````markdown
```lua

```
````
To reproduce:
1. create markdown-file containing only
	````markdown
	```lua
	
	```
	````
2.
	```lua
	print(vim.treesitter.get_parser(0, "markdown"):language_for_range({1,0,1,0}):lang())
	```
Expected output: `"lua"`, actual output: `"markdown"`

I hope it's okay to open this as issue+solution.