### PR TITLE
fix(tests): fix some screen.lua warnings

### DIFF
--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -23,7 +23,7 @@ describe('prompt buffer', function()
           close
         else
           call append(line("$") - 1, 'Command: "' . a:text . '"')
-          set nomodfied
+          set nomodified
           call timer_start(20, {id -> TimerFunc(a:text)})
         endif
       endfunc
@@ -33,7 +33,7 @@ describe('prompt buffer', function()
       endfunc
 
       func SwitchWindows()
-        call timer_start(0, {-> execute("wincmd p|wincmd p", "")})
+        call timer_start(0, {-> execute("wincmd p", "")})
       endfunc
     ]])
     feed_command("set noshowmode | set laststatus=0")
@@ -187,7 +187,19 @@ describe('prompt buffer', function()
       -- INSERT --             |
     ]])
     feed("<C-O>:call SwitchWindows()<CR>")
-    poke_eventloop()
+    screen:expect{grid=[[
+      cmd:                     |
+      ~                        |
+      ~                        |
+      ~                        |
+      [Prompt] [+]             |
+      ^other buffer             |
+      ~                        |
+      ~                        |
+      ~                        |
+                               |
+    ]]}
+    feed("<C-O>:call SwitchWindows()<CR>")
     screen:expect([[
       cmd: ^                    |
       ~                        |
@@ -201,7 +213,6 @@ describe('prompt buffer', function()
       -- INSERT --             |
     ]])
     feed("<Esc>")
-    poke_eventloop()
     screen:expect([[
       cmd:^                     |
       ~                        |

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -564,6 +564,16 @@ describe('Buffer highlighting', function()
     ]]
 
     clear_namespace(id, 0, -1)
+    screen:expect{grid=[[
+      fooba^r                                  |
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+                                              |
+    ]]}
 
     set_extmark(id, 0, 0, {
       end_line = 0,

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1209,7 +1209,6 @@ describe('ui/ext_messages', function()
   it('supports global statusline', function()
     feed(":set laststatus=3<cr>")
     feed(":sp<cr>")
-    feed("<c-l>")
     feed(":set cmdheight<cr>")
     screen:expect({grid=[[
       ^                                                                                |
@@ -1241,8 +1240,7 @@ describe('ui/ext_messages', function()
     }})
 
     feed("<c-w>+")
-    feed("<c-l>")
-    feed(":set cmdheight<cr>")
+    feed(":set laststatus<cr>")
     screen:expect({grid=[[
       ^                                                                                |
       {1:~                                                                               }|
@@ -1269,7 +1267,7 @@ describe('ui/ext_messages', function()
       {1:~                                                                               }|
       {7:[No Name]                                                                       }|
     ]], messages={
-      {content = { { "  cmdheight=0" } }, kind = "" }
+      {content = { { "  laststatus=3" } }, kind = "" }
     }})
 
     feed(":set mouse=a<cr>")

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -43,7 +43,7 @@ describe('search highlighting', function()
     insert("some text\nmore text")
     feed_command('1,2fold')
     feed("gg/text")
-    screen:expect([[
+    screen:expect{grid=[[
       {6:+--  2 lines: some text·················}|
       {1:~                                       }|
       {1:~                                       }|
@@ -51,7 +51,9 @@ describe('search highlighting', function()
       {1:~                                       }|
       {1:~                                       }|
       /text^                                   |
-    ]])
+    ]], win_viewport={
+      [2] = {win = {id = 1000}, topline = 0, botline = 3, curline = 0, curcol = 9, linecount = 2};
+    }}
   end)
 
   it('works', function()
@@ -579,19 +581,20 @@ describe('search highlighting', function()
   end)
 
   it('works with matchadd and syntax', function()
-    screen:set_default_attr_ids( {
-        [1] = {bold=true, foreground=Screen.colors.Blue},
-        [2] = {background = colors.Yellow},
-        [3] = {reverse = true},
-        [4] = {foreground = colors.Red},
-        [5] = {bold = true, background = colors.Green},
-        [6] = {italic = true, background = colors.Magenta},
-        [7] = {bold = true, background = colors.Yellow},
-    } )
+    screen:set_default_attr_ids {
+      [1] = {bold=true, foreground=Screen.colors.Blue};
+      [2] = {background = colors.Yellow};
+      [3] = {reverse = true};
+      [4] = {foreground = colors.Red};
+      [5] = {bold = true, background = colors.Green};
+      [6] = {italic = true, background = colors.Magenta};
+      [7] = {bold = true, background = colors.Yellow};
+      [8] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGray};
+    }
     feed_command('set hlsearch')
-    insert([[
+    insert [[
       very special text
-    ]])
+    ]]
     feed_command("syntax on")
     feed_command("highlight MyGroup guibg=Green gui=bold")
     feed_command("highlight MyGroup2 guibg=Magenta gui=italic")
@@ -601,7 +604,7 @@ describe('search highlighting', function()
     -- searchhl and matchadd matches are exclusive, only the highest priority
     -- is used (and matches with lower priorities are not combined)
     feed_command("/ial te")
-    screen:expect([[
+    screen:expect{grid=[[
         very {5:spec^ial}{2: te}{6:xt}                     |
                                               |
       {1:~                                       }|
@@ -609,10 +612,21 @@ describe('search highlighting', function()
       {1:~                                       }|
       {1:~                                       }|
       {4:search hit BOTTOM, continuing at TOP}    |
-    ]])
+    ]], win_viewport={
+      [2] = {win = {id = 1000}, topline = 0, botline = 3, curline = 0, curcol = 11, linecount = 2};
+    }}
 
     -- check highlights work also in folds
     feed("zf4j")
+    screen:expect{grid=[[
+      {8:^+--  2 lines: very special text·········}|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {1:~                                       }|
+      {4:search hit BOTTOM, continuing at TOP}    |
+    ]]}
     command("%foldopen")
     screen:expect([[
         very {5:spec^ial}{2: te}{6:xt}                     |

--- a/test/functional/vimscript/execute_spec.lua
+++ b/test/functional/vimscript/execute_spec.lua
@@ -153,7 +153,7 @@ describe('execute()', function()
       function! Test3()
         echo 1234
         let x = execute('echoerr "abcdef"', 'silent!')
-        echon 'ABCD'
+        echon 'ABCDXZYZ'
       endfunction
 
       " test 4: silenced echoerr goes as usual
@@ -214,7 +214,7 @@ describe('execute()', function()
       ~                                       |
       ~                                       |
       ~                                       |
-      1234ABCD                                |
+      1234ABCDXZYZ                            |
     ]])
 
     feed([[:call Test4()<cr>]])


### PR DESCRIPTION
Remove some warnings like "Screen test succeeded immediately" and "Screen changes were received after the expected state." from existing tests.

Nothing serious, but I figure we will take these more serious in new tests if they are not littered all over CI output in master build.