### PR TITLE
vim-patch:8.1.0535,8.2.4991: increment/decrement might get interrupted by updating folds

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -775,7 +775,7 @@ void clearFolding(win_T *win)
 /// The changes in lines from top to bot (inclusive).
 void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
-  if (compl_busy || State & MODE_INSERT) {
+  if (disable_fold_update || compl_busy || State & MODE_INSERT) {
     return;
   }
 

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -23,6 +23,7 @@ typedef struct foldinfo {
 
 #define FOLDINFO_INIT { 0, 0, 0, 0 }
 
+EXTERN int disable_fold_update INIT(= 0);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "fold.h.generated.h"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4911,12 +4911,19 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
   ssize_t change_cnt = 0;
   linenr_T amount = Prenum1;
 
+  // do_addsub() might trigger re-evaluation of 'foldexpr' halfway, when the
+  // buffer is not completly updated yet. Postpone updating folds until before
+  // the call to changed_lines().
+  disable_fold_update++;
+
   if (!VIsual_active) {
     pos = curwin->w_cursor;
     if (u_save_cursor() == FAIL) {
+      disable_fold_update--;
       return;
     }
     change_cnt = do_addsub(oap->op_type, &pos, 0, amount);
+    disable_fold_update--;
     if (change_cnt) {
       changed_lines(pos.lnum, 0, pos.lnum + 1, 0L, true);
     }
@@ -4927,6 +4934,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
 
     if (u_save((linenr_T)(oap->start.lnum - 1),
                (linenr_T)(oap->end.lnum + 1)) == FAIL) {
+      disable_fold_update--;
       return;
     }
 
@@ -4973,6 +4981,8 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
         amount += Prenum1;
       }
     }
+
+    disable_fold_update--;
     if (change_cnt) {
       changed_lines(oap->start.lnum, 0, oap->end.lnum + 1, 0L, true);
     }

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -217,6 +217,26 @@ func Test_update_folds_expr_read()
   set foldmethod& foldexpr&
 endfunc
 
+" Test for what patch 8.1.0535 fixes.
+func Test_foldexpr_no_interrupt_addsub()
+  new
+  func! FoldFunc()
+    call setpos('.', getcurpos())
+    return '='
+  endfunc
+
+  set foldmethod=expr
+  set foldexpr=FoldFunc()
+  call setline(1, '1.2')
+
+  exe "norm! $\<C-A>"
+  call assert_equal('1.3', getline(1))
+
+  bwipe!
+  delfunc FoldFunc
+  set foldmethod& foldexpr&
+endfunc
+
 func Check_foldlevels(expected)
   call assert_equal(a:expected, map(range(1, line('$')), 'foldlevel(v:val)'))
 endfunc


### PR DESCRIPTION
#### vim-patch:8.1.0535: increment/decrement might get interrupted by updating folds

Problem:    Increment/decrement might get interrupted by updating folds.
Solution:   Disable fold updating for a moment. (Christian Brabandt)
https://github.com/vim/vim/commit/6b731886ca94d66b9bdedfb7e603af44a6400399


#### vim-patch:8.2.4991: no test for hwat patch 8.1.0535 fixes

Problem:    No test for hwat patch 8.1.0535 fixes.
Solution:   Add a test. (closes vim/vim#10462)
https://github.com/vim/vim/commit/93c1573dd284dc9cf5ed9265a0143aaf520d2920