### PR TITLE
vim-patch:8.2.4987: after deletion a small fold may be closable

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -785,11 +785,18 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
   }
 
   if (wp->w_folds.ga_len > 0) {
-    // Mark all folds from top to bot as maybe-small.
+    linenr_T maybe_small_start = top;
+    linenr_T maybe_small_end = bot;
+
+    // Mark all folds from top to bot (or bot to top) as maybe-small.
+    if (top > bot) {
+      maybe_small_start = bot;
+      maybe_small_end = top;
+    }
     fold_T *fp;
-    (void)foldFind(&wp->w_folds, top, &fp);
+    (void)foldFind(&wp->w_folds, maybe_small_start, &fp);
     while (fp < (fold_T *)wp->w_folds.ga_data + wp->w_folds.ga_len
-           && fp->fd_top < bot) {
+           && fp->fd_top <= maybe_small_end) {
       fp->fd_small = kNone;
       fp++;
     }
@@ -1929,7 +1936,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
     bot = wp->w_buffer->b_ml.ml_line_count;
     wp->w_foldinvalid = false;
 
-    // Mark all folds a maybe-small.
+    // Mark all folds as maybe-small.
     setSmallMaybe(&wp->w_folds);
   }
 

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -901,4 +901,33 @@ func Test_fold_split()
   bw!
 endfunc
 
+" Make sure that when you delete 1 line of a fold whose length is 2 lines, the
+" fold can't be closed since its length (1) is now less than foldminlines.
+func Test_indent_one_line_fold_close()
+  let lines =<< trim END
+    line 1
+      line 2
+      line 3
+  END
+
+  new
+  setlocal sw=2 foldmethod=indent
+  call setline(1, lines)
+  " open all folds, delete line, then close all folds
+  normal zR
+  3delete
+  normal zM
+  call assert_equal(-1, foldclosed(2)) " the fold should not be closed
+
+  " Now do the same, but delete line 2 this time; this covers different code.
+  " (Combining this code with the above code doesn't expose both bugs.)
+  1,$delete
+  call setline(1, lines)
+  normal zR
+  2delete
+  normal zM
+  call assert_equal(-1, foldclosed(2))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    After deletion a small fold may be closable.
Solution:   Check for a reverse range. (Brandon Simmons, closes vim/vim#10457)
https://github.com/vim/vim/commit/3fcccf94e8bc142d2c79c3b62087145896df6b36