### PR TITLE
vim-patch:8.2.4993: smart/C/lisp indenting is optional

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1291,8 +1291,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'cinscopedecls'* *'cinsd'*
 'cinscopedecls' 'cinsd'	string	(default "public,protected,private")
 			local to buffer
-			{not available when compiled without the |+cindent|
-			feature}
 	Keywords that are interpreted as a C++ scope declaration by |cino-g|.
 	Useful e.g. for working with the Qt framework that defines additional
 	scope declarations "signals", "public slots" and "private slots": >

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1033,8 +1033,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
 
   // If 'autoindent' and/or 'smartindent' is set, try to figure out what
   // indent to use for the new line.
-  if (curbuf->b_p_ai
-      || do_si) {
+  if (curbuf->b_p_ai || do_si) {
     // count white space on current line
     newindent = get_indent_str_vtab(saved_line,
                                     curbuf->b_p_ts,
@@ -1482,8 +1481,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
         }
 
         // Recompute the indent, it may have changed.
-        if (curbuf->b_p_ai
-            || do_si) {
+        if (curbuf->b_p_ai || do_si) {
           newindent = get_indent_str_vtab(leader,
                                           curbuf->b_p_ts,
                                           curbuf->b_p_vts_array, false);
@@ -1526,15 +1524,13 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
 
       // if a new indent will be set below, remove the indent that
       // is in the comment leader
-      if (newindent
-          || did_si) {
+      if (newindent || did_si) {
         while (lead_len && ascii_iswhite(*leader)) {
           lead_len--;
           newcol--;
           leader++;
         }
       }
-
       did_si = can_si = false;
     } else if (comment_end != NULL) {
       // We have finished a comment, so we don't use the leader.
@@ -1646,8 +1642,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   }
 
   inhibit_delete_count++;
-  if (newindent
-      || did_si) {
+  if (newindent || did_si) {
     curwin->w_cursor.lnum++;
     if (did_si) {
       int sw = get_sw_value(curbuf);
@@ -1764,6 +1759,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   } else {
     vreplace_mode = 0;
   }
+
   // May do lisp indenting.
   if (!p_paste
       && leader == NULL
@@ -1772,11 +1768,13 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
     fixthisline(get_lisp_indent);
     ai_col = (colnr_T)getwhitecols_curline();
   }
+
   // May do indenting after opening a new line.
   if (do_cindent) {
     do_c_expr_indent();
     ai_col = (colnr_T)getwhitecols_curline();
   }
+
   if (vreplace_mode != 0) {
     State = vreplace_mode;
   }

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3799,6 +3799,7 @@ static bool ins_compl_prep(int c)
       }
 
       bool want_cindent = (can_cindent && cindent_on());
+
       // When completing whole lines: fix indent for 'cindent'.
       // Otherwise, break line if it's too long.
       if (compl_cont_mode == CTRL_X_WHOLE_LINE) {
@@ -8412,9 +8413,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
     mincol = 0;
     // keep indent
     if (mode == BACKSPACE_LINE
-        && (curbuf->b_p_ai
-            || cindent_on()
-            )
+        && (curbuf->b_p_ai || cindent_on())
         && !revins_on) {
       save_col = curwin->w_cursor.col;
       beginline(BL_WHITE);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6544,6 +6544,7 @@ void buf_copy_options(buf_T *buf, int flags)
       COPY_OPT_SCTX(buf, BV_SI);
       buf->b_p_channel = 0;
       buf->b_p_ci = p_ci;
+
       COPY_OPT_SCTX(buf, BV_CI);
       buf->b_p_cin = p_cin;
       COPY_OPT_SCTX(buf, BV_CIN);
@@ -6553,6 +6554,7 @@ void buf_copy_options(buf_T *buf, int flags)
       COPY_OPT_SCTX(buf, BV_CINO);
       buf->b_p_cinsd = vim_strsave(p_cinsd);
       COPY_OPT_SCTX(buf, BV_CINSD);
+
       // Don't copy 'filetype', it must be detected
       buf->b_p_ft = empty_option;
       buf->b_p_pi = p_pi;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1965,13 +1965,13 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
   clearpos(&match_pos);
 
   // backward search: Check if this line contains a single-line comment
-  if ((backwards && comment_dir)
-      || lisp) {
+  if ((backwards && comment_dir) || lisp) {
     comment_col = check_linecomment(linep);
   }
   if (lisp && comment_col != MAXCOL && pos.col > (colnr_T)comment_col) {
     lispcomm = true;        // find match inside this comment
   }
+
   while (!got_int) {
     /*
      * Go to the next position, forward or backward. We could use
@@ -1998,8 +1998,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         line_breakcheck();
 
         // Check if this line contains a single-line comment
-        if (comment_dir
-            || lisp) {
+        if (comment_dir || lisp) {
           comment_col = check_linecomment(linep);
         }
         // skip comment
@@ -2013,7 +2012,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
     } else {                          // forward search
       if (linep[pos.col] == NUL
           // at end of line, go to next one
-          // don't search for match in comment
+          // For lisp don't search for match in comment
           || (lisp && comment_col != MAXCOL
               && pos.col == (colnr_T)comment_col)) {
         if (pos.lnum == curbuf->b_ml.ml_line_count          // end of file
@@ -2323,8 +2322,8 @@ int check_linecomment(const char_u *line)
   } else {
     while ((p = (char_u *)vim_strchr((char *)p, '/')) != NULL) {
       // Accept a double /, unless it's preceded with * and followed by *,
-      // because * / / * is an end and start of a C comment.
-      // Only accept the position if it is not inside a string.
+      // because * / / * is an end and start of a C comment.  Only
+      // accept the position if it is not inside a string.
       if (p[1] == '/' && (p == line || p[-1] != '*' || p[2] != '*')
           && !is_pos_in_string(line, (colnr_T)(p - line))) {
         break;

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -395,15 +395,13 @@ endfunc
 
 func Test_edit_13()
   " Test smartindenting
-  if exists("+smartindent")
-    new
-    set smartindent autoindent
-    call setline(1, ["\tabc"])
-    call feedkeys("A {\<cr>more\<cr>}\<esc>", 'tnix')
-    call assert_equal(["\tabc {", "\t\tmore", "\t}"], getline(1, '$'))
-    set smartindent& autoindent&
-    bwipe!
-  endif
+  new
+  set smartindent autoindent
+  call setline(1, ["\tabc"])
+  call feedkeys("A {\<cr>more\<cr>}\<esc>", 'tnix')
+  call assert_equal(["\tabc {", "\t\tmore", "\t}"], getline(1, '$'))
+  set smartindent& autoindent&
+  bwipe!
 
   " Test autoindent removing indent of blank line.
   new


### PR DESCRIPTION
#### vim-patch:8.2.4993: smart/C/lisp indenting is optional

Problem:    smart/C/lisp indenting is optional, which makes the code more
            complex, while it only reduces the executable size a bit.
Solution:   Graduate FEAT_CINDENT, FEAT_SMARTINDENT and FEAT_LISP.
https://github.com/vim/vim/commit/8e145b82464a21ee4fdf7948f04e2a1d505f8bfa