### PR TITLE
vim-patch:8.2.{4996.5002}: setbufline(), deletebufline() may change Visual selection

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6886,6 +6886,7 @@ void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append, const typval_T
   buf_T *curbuf_save = NULL;
   win_T *curwin_save = NULL;
   const bool is_curbuf = buf == curbuf;
+  const bool save_VIsual_active = VIsual_active;
 
   // When using the current buffer ml_mfp will be set if needed.  Useful when
   // setline() is used on startup.  For other buffers the buffer must be
@@ -6896,6 +6897,7 @@ void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append, const typval_T
   }
 
   if (!is_curbuf) {
+    VIsual_active = false;
     curbuf_save = curbuf;
     curwin_save = curwin;
     curbuf = buf;
@@ -6986,6 +6988,7 @@ void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append, const typval_T
   if (!is_curbuf) {
     curbuf = curbuf_save;
     curwin = curwin_save;
+    VIsual_active = save_VIsual_active;
   }
 }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1636,6 +1636,7 @@ static void f_deletebufline(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     return;
   }
   const bool is_curbuf = buf == curbuf;
+  const bool save_VIsual_active = VIsual_active;
 
   const linenr_T first = tv_get_lnum_buf(&argvars[1], buf);
   if (argvars[2].v_type != VAR_UNKNOWN) {
@@ -1651,6 +1652,7 @@ static void f_deletebufline(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   if (!is_curbuf) {
+    VIsual_active = false;
     curbuf_save = curbuf;
     curwin_save = curwin;
     curbuf = buf;
@@ -1694,6 +1696,7 @@ static void f_deletebufline(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (!is_curbuf) {
     curbuf = curbuf_save;
     curwin = curwin_save;
+    VIsual_active = save_VIsual_active;
   }
 }
 

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -153,3 +153,21 @@ func Test_appendbufline_redraw()
   call StopVimInTerminal(buf)
   call delete('XscriptMatchCommon')
 endfunc
+
+func Test_setbufline_select_mode()
+  new
+  call setline(1, ['foo', 'bar'])
+  call feedkeys("j^v2l\<C-G>", 'nx')
+
+  let bufnr = bufadd('Xdummy')
+  call bufload(bufnr)
+  call setbufline(bufnr, 1, ['abc'])
+
+  call feedkeys("x", 'nx')
+  call assert_equal(['foo', 'x'], getline(1, 2))
+
+  exe "bwipe! " .. bufnr
+  bwipe!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -170,4 +170,21 @@ func Test_setbufline_select_mode()
   bwipe!
 endfunc
 
+func Test_deletebufline_select_mode()
+  new
+  call setline(1, ['foo', 'bar'])
+  call feedkeys("j^v2l\<C-G>", 'nx')
+
+  let bufnr = bufadd('Xdummy')
+  call bufload(bufnr)
+  call setbufline(bufnr, 1, ['abc', 'def'])
+  call deletebufline(bufnr, 1)
+
+  call feedkeys("x", 'nx')
+  call assert_equal(['foo', 'x'], getline(1, 2))
+
+  exe "bwipe! " .. bufnr
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4996: setbufline() may change Visual selection

Problem:    setbufline() may change Visual selection. (Qiming Zhao)
Solution:   Disable Visual mode when using another buffer.
https://github.com/vim/vim/commit/0ad00a7fd3e0389f565876521e395c35144d8009


#### vim-patch:8.2.5002: deletebufline() may change Visual selection

Problem:    deletebufline() may change Visual selection.
Solution:   Disable Visual mode when using another buffer. (closes vim/vim#10469)
https://github.com/vim/vim/commit/9b2edfd3bf2f14a1faaee9b62930598a2e77a798