### PR TITLE
vim-patch:8.2.4935: with 'foldmethod' "indent" some lines not included in fold

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2003,7 +2003,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
       // start one line back, because a "<1" may indicate the end of a
       // fold in the topline
       if (top > 1) {
-        --fline.lnum;
+        fline.lnum--;
       }
     } else if (foldmethodIsSyntax(wp)) {
       getlevel = foldlevelSyntax;
@@ -2011,6 +2011,12 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
       getlevel = foldlevelDiff;
     } else {
       getlevel = foldlevelIndent;
+      // Start one line back, because if the line above "top" has an
+      // undefined fold level, folding it relies on the line under it,
+      // which is "top".
+      if (top > 1) {
+        fline.lnum--;
+      }
     }
 
     // Backup to a line for which the fold level is defined.  Since it's

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -921,6 +921,26 @@ func Test_fold_split()
   bw!
 endfunc
 
+" Make sure that when you append under a blank line that is under a fold with
+" the same indent level as your appended line, the fold expands across the
+" blank line
+func Test_indent_append_under_blank_line()
+  new
+  let lines =<< trim END
+    line 1
+      line 2
+      line 3
+  END
+  call setline(1, lines)
+  setlocal sw=2
+  setlocal foldmethod=indent foldenable
+  call assert_equal([0, 1, 1], range(1, 3)->map('foldlevel(v:val)'))
+  call append(3, '')
+  call append(4, '  line 5')
+  call assert_equal([0, 1, 1, 1, 1], range(1, 5)->map('foldlevel(v:val)'))
+  bw!
+endfunc
+
 " Make sure that when you delete 1 line of a fold whose length is 2 lines, the
 " fold can't be closed since its length (1) is now less than foldminlines.
 func Test_indent_one_line_fold_close()


### PR DESCRIPTION
#### vim-patch:8.2.4935: with 'foldmethod' "indent" some lines not included in fold

Problem:    With 'foldmethod' "indent" some lines are not included in the
            fold. (Oleg Koshovetc)
Solution:   Fix it. (Brandon Simmons, closes vim/vim#10399)
https://github.com/vim/vim/commit/d98e75e23666c159c7e00bcf5b6ad9a933bb0534