### PR TITLE
fix(coverity): USE_AFTER_FREE in create_user_command

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1616,15 +1616,16 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
   if (uc_add_command(name.data, name.size, rep, argt, def, flags, compl, compl_arg, compl_luaref,
                      addr_type_arg, luaref, force) != OK) {
     api_set_error(err, kErrorTypeException, "Failed to create user command");
-    goto err;
+    // XXX: uc_add_command() frees compl_arg, luaref, compl_luaref on failure.
+    return;
   }
 
   return;
 
 err:
+  xfree(compl_arg);
   NLUA_CLEAR_REF(luaref);
   NLUA_CLEAR_REF(compl_luaref);
-  xfree(compl_arg);
 }
 
 int find_sid(uint64_t channel_id)


### PR DESCRIPTION
    *** CID 352839:  Memory - corruptions  (USE_AFTER_FREE)
    /src/nvim/api/private/helpers.c: 1627 in create_user_command()
    1621
    1622       return;
    1623
    1624     err:
    1625       NLUA_CLEAR_REF(luaref);
    1626       NLUA_CLEAR_REF(compl_luaref);
    >>>     CID 352839:  Memory - corruptions  (USE_AFTER_FREE)
    >>>     Calling "xfree" frees pointer "compl_arg" which has already been freed. [Note: The source code implementation of the function has been overridden by a user model.]
    1627       xfree(compl_arg);
    1628     }
    1629
    1630     int find_sid(uint64_t channel_id)
    1631     {
    1632       switch (channel_id) {