### PR TITLE
ci(commitlint): only trigger on PRs to master #18679

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,8 @@ on:
   # to merge a PR, it can't be skipped, so use pull_request_target
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
 jobs:
   lint-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will prevent a failure for backported PRs as they use a different
commit message.