### PR TITLE
feat(lsp): add `jump_type` config option for location handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -322,7 +322,8 @@ end
 M['textDocument/hover'] = M.hover
 
 ---(`textDocument/definition` can return `Location` or `Location[]`
---- |lsp-handler| for the method "textDocument/definition"
+--- |lsp-handler| for the method "textDocument/declaration", "textDocument/definition", "textDocument/typeDefinition"
+--- and "textDocument/implementation"
 --- <pre>
 --- -- for one mapping
 --- vim.keymap.set("n", "gv", function()


### PR DESCRIPTION
Hi, it's my first pr!
PR add config option for location handlers eg. `textDocument/definition` to open location in another type of window. If `jump_type` is `nil` handler behaves like it is working now.
```lua
-- for one mapping
vim.keymap.set("n", "gv", function()
  vim.lsp.buf.definition { jump_type = "vsplit" }
end, { buffer = bufnr })

-- or for all of them
vim.lsp.handlers["textDocument/definition"] = vim.lsp.with(
  vim.lsp.handlers.location, {
    -- Opens definition in new split
    jump_type = "vsplit"
  }
)
```