### PR TITLE
fix(lsp): do not detach LSP servers on Windows

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -4,6 +4,8 @@ local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
 local validate, schedule, schedule_wrap = vim.validate, vim.schedule, vim.schedule_wrap
 
+local is_win = uv.os_uname().version:find('Windows')
+
 ---@private
 --- Checks whether a given path exists and is a directory.
 ---@param filename (string) path to check
@@ -321,7 +323,7 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
     local spawn_params = {
       args = cmd_args,
       stdio = { stdin, stdout, stderr },
-      detached = true,
+      detached = not is_win,
     }
     if extra_spawn_params then
       spawn_params.cwd = extra_spawn_params.cwd


### PR DESCRIPTION
Detaching the process seems to have unintended side effects on Windows,
so only do it by default on non-Windows platforms.

Ref: https://github.com/neovim/nvim-lspconfig/issues/1907

The `is_win` check is copied from [`lsp/log.lua`](https://github.com/neovim/neovim/blob/52623ce9353bac2b4a82c0197c5a08202e74b156/runtime/lua/vim/lsp/log.lua#L23). I'm assuming this check is correct, I do not have a Windows machine to verify.
