### PR TITLE
fix(ui): redraw winbar alongside statusline

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1389,8 +1389,7 @@ struct window_S {
                                     // w_redr_type is REDRAW_TOP
   linenr_T w_redraw_top;            // when != 0: first line needing redraw
   linenr_T w_redraw_bot;            // when != 0: last line needing redraw
-  bool w_redr_status;               // if true status line must be redrawn
-  bool w_redr_winbar;               // if true window bar must be redrawn
+  bool w_redr_status;               // if true statusline/winbar must be redrawn
   bool w_redr_border;               // if true border must be redrawn
 
   // remember what is shown in the ruler for this window (if 'ruler' set)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6709,7 +6709,7 @@ void set_winbar(void)
     if (wp->w_winbar_height != winbar_height) {
       wp->w_winbar_height = winbar_height;
       win_set_inner_size(wp);
-      wp->w_redr_winbar = winbar_height;
+      wp->w_redr_status = wp->w_redr_status || winbar_height;
 
       if (winbar_height == 0) {
         // When removing winbar, deallocate the w_winbar_click_defs array


### PR DESCRIPTION
Remove `w_redr_winbar` and use `w_redr_status` to redraw the winbar to
ensure that winbar redraw is triggered alongside the statusline redraw.