### PR TITLE
vim-patch:8.2.{3484,5007,5123}: spell suggestion fixes

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2596,6 +2596,8 @@ ambw_end:
         // only encoding=utf-8 allowed
         if (STRCMP(p_enc, "utf-8") != 0) {
           errmsg = e_unsupportedoption;
+        } else {
+          spell_reload();
         }
       }
     }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3663,6 +3663,12 @@ static void suggest_try_change(suginfo_T *su)
   p = su->su_badptr + su->su_badlen;
   (void)spell_casefold(curwin, p, (int)STRLEN(p), fword + n, MAXWLEN - n);
 
+  // Make sure the resulting text is not longer than the original text.
+  n = (int)STRLEN(su->su_badptr);
+  if (n < MAXWLEN) {
+    fword[n] = NUL;
+  }
+
   for (int lpi = 0; lpi < curwin->w_s->b_langp.ga_len; ++lpi) {
     lp = LANGP_ENTRY(curwin->w_s->b_langp, lpi);
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4381,7 +4381,9 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
 #endif
           ++depth;
           sp = &stack[depth];
-          ++sp->ts_fidx;
+          if (fword[sp->ts_fidx] != NUL) {
+            sp->ts_fidx++;
+          }
           tword[sp->ts_twordlen++] = c;
           sp->ts_arridx = idxs[arridx];
           if (newscore == SCORE_SUBST) {

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4399,7 +4399,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
             sp->ts_fcharstart = sp->ts_fidx - 1;
             sp->ts_isdiff = (newscore != 0)
                             ? DIFF_YES : DIFF_NONE;
-          } else if (sp->ts_isdiff == DIFF_INSERT) {
+          } else if (sp->ts_isdiff == DIFF_INSERT && sp->ts_fidx > 0) {
             // When inserting trail bytes don't advance in the
             // bad word.
             sp->ts_fidx--;

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -72,6 +72,16 @@ func Test_z_equal_on_invalid_utf8_word()
   bwipe!
 endfunc
 
+func Test_z_equal_on_single_character()
+  " this was decrementing the index below zero
+  new
+  norm a0\Ê
+  norm zW
+  norm z=
+
+  bwipe!
+endfunc
+
 " Test spellbadword() with argument
 func Test_spellbadword()
   set spell

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -768,6 +768,21 @@ func Test_spellfile_value()
   set spellfile=Xdir/Xtest.utf-8.add,Xtest_other.add
 endfunc
 
+func Test_no_crash_with_weird_text()
+  new
+  let lines =<< trim END
+      r<sfile>
+      
+
+
+      
+  END
+  call setline(1, lines)
+  exe "%norm \<C-v>ez=>\<C-v>wzG"
+
+  bwipe!
+endfunc
+
 " Invalid bytes may cause trouble when creating the word list.
 func Test_check_for_valid_word()
   call assert_fails("spellgood! 0\xac", 'E1280:')

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -631,7 +631,7 @@ func Test_spell_affix()
         \ ["bar", "barbork", "end", "fooa1", "fooa\u00E9", "nouend", "prebar", "prebarbork", "start"],
         \ [
         \   ["bad", ["bar", "end", "fooa1"]],
-        \   ["foo", ["fooa1", "fooa\u00E9", "bar"]],
+        \   ["foo", ["fooa1", "bar", "end"]],
         \   ["fooa2", ["fooa1", "fooa\u00E9", "bar"]],
         \   ["prabar", ["prebar", "bar", "bar bar"]],
         \   ["probarbirk", ["prebarbork"]],
@@ -649,7 +649,7 @@ func Test_spell_affix()
         \ ["bar", "barbork", "end", "lead", "meea1", "meea\u00E9", "prebar", "prebarbork"],
         \ [
         \   ["bad", ["bar", "end", "lead"]],
-        \   ["mee", ["meea1", "meea\u00E9", "bar"]],
+        \   ["mee", ["meea1", "bar", "end"]],
         \   ["meea2", ["meea1", "meea\u00E9", "lead"]],
         \   ["prabar", ["prebar", "bar", "leadbar"]],
         \   ["probarbirk", ["prebarbork"]],
@@ -666,7 +666,7 @@ func Test_spell_affix()
         \ ["bar", "barmeat", "lead", "meea1", "meea\u00E9", "meezero", "prebar", "prebarmeat", "tail"],
         \ [
         \   ["bad", ["bar", "lead", "tail"]],
-        \   ["mee", ["meea1", "meea\u00E9", "bar"]],
+        \   ["mee", ["meea1", "bar", "lead"]],
         \   ["meea2", ["meea1", "meea\u00E9", "lead"]],
         \   ["prabar", ["prebar", "bar", "leadbar"]],
         \   ["probarmaat", ["prebarmeat"]],
@@ -761,11 +761,15 @@ func Test_spell_sal_and_addition()
   set spl=Xtest_ca.utf-8.spl
   call assert_equal("elequint", FirstSpellWord())
   call assert_equal("elekwint", SecondSpellWord())
+
+  set spellfile=
+  set spl&
 endfunc
 
 func Test_spellfile_value()
   set spellfile=Xdir/Xtest.utf-8.add
   set spellfile=Xdir/Xtest.utf-8.add,Xtest_other.add
+  set spellfile=
 endfunc
 
 func Test_no_crash_with_weird_text()
@@ -786,6 +790,19 @@ endfunc
 " Invalid bytes may cause trouble when creating the word list.
 func Test_check_for_valid_word()
   call assert_fails("spellgood! 0\xac", 'E1280:')
+endfunc
+
+" This was going over the end of the word
+func Test_word_index()
+  new
+  norm R0
+  spellgood! ﬂ0
+  sil norm z=
+
+  bwipe!
+  " clear the word list
+  set enc=utf-8
+  call delete('Xtmpfile')
 endfunc
 
 

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -576,7 +576,6 @@ endfunc
 
 "Compound words
 func Test_spell_compound()
-  throw 'skipped: TODO: '
   call LoadAffAndDic(g:test_data_aff3, g:test_data_dic3)
   call RunGoodBad("foo m\u00EF foobar foofoobar barfoo barbarfoo",
         \ "bad: bar la foom\u00EF barm\u00EF m\u00EFfoo m\u00EFbar m\u00EFm\u00EF lala m\u00EFla lam\u00EF foola labar",
@@ -624,7 +623,7 @@ endfunc
 
 " Test affix flags with two characters
 func Test_spell_affix()
-  throw 'skipped: TODO: '
+  CheckNotMSWindows  " FIXME: Why does this fail with MSVC?
   call LoadAffAndDic(g:test_data_aff5, g:test_data_dic5)
   call RunGoodBad("fooa1 fooa\u00E9 bar prebar barbork prebarbork  startprebar start end startend  startmiddleend nouend",
         \ "bad: foo fooa2 prabar probarbirk middle startmiddle middleend endstart startprobar startnouend",
@@ -700,7 +699,6 @@ endfunc
 
 " Affix flags
 func Test_spell_affix_flags()
-  throw 'skipped: TODO: '
   call LoadAffAndDic(g:test_data_aff10, g:test_data_dic10)
   call RunGoodBad("drink drinkable drinkables drinktable drinkabletable",
 	\ "bad: drinks drinkstable drinkablestable",


### PR DESCRIPTION
#### vim-patch:8.2.3484: crash when going through spell suggestions

Problem:    Crash when going through spell suggestions.
Solution:   Limit the text length for finding suggestions to the original
            length.  Do not update buffers when exiting. (closes vim/vim#8965)
https://github.com/vim/vim/commit/e275ba4fc994474155fbafe8b87a6d3b477456ba


#### vim-patch:8.2.5007: spell suggestion may use uninitialized memory

Problem:    Spell suggestion may use uninitialized memory. (Zdenek Dohnal)
Solution:   Avoid going over the end of the word.
https://github.com/vim/vim/commit/6d24b4ff69913270ce1e5267dd6bd8454f75e2b9


#### vim-patch:8.2.5123: using invalid index when looking for spell suggestions

Problem:    Using invalid index when looking for spell suggestions.
Solution:   Do not decrement the index when it is zero.
https://github.com/vim/vim/commit/156d3911952d73b03d7420dc3540215247db0fe8