### PR TITLE
refactor(checkhealth): move completion to Lua, and module location

### DIFF
--- a/runtime/doc/pi_health.txt
+++ b/runtime/doc/pi_health.txt
@@ -48,27 +48,26 @@ Commands                                *health-commands*
                         :checkhealth vim*
 <
 ==============================================================================
-Lua Functions                           *health-functions-lua* *health-lua*
+Lua Functions                       *health-functions-lua* *health-lua* *vim.health*
 
 The Lua "health" module can be used to create new healthchecks (see also
-|health-functions-vim|). To get started, simply use:  >
-        local health = require('health')
-<
-health.report_start({name})                             *health.report_start()*
+|health-functions-vim|). To get started, simply use:
+
+vim.health.report_start({name})                         *vim.health.report_start()*
         Starts a new report. Most plugins should call this only once, but if
         you want different sections to appear in your report, call this once
         per section.
 
-health.report_info({msg})                               *health.report_info()*
+vim.health.report_info({msg})                           *vim.health.report_info()*
         Reports an informational message.
 
-health.report_ok({msg})                                 *health.report_ok()*
+vim.health.report_ok({msg})                             *vim.health.report_ok()*
         Reports a "success" message.
 
-health.report_warn({msg} [, {advice}])                  *health.report_warn()*
+vim.health.report_warn({msg} [, {advice}])              *vim.health.report_warn()*
         Reports a warning. {advice} is an optional List of suggestions.
 
-health.report_error({msg} [, {advice}])                 *health.report_error()*
+vim.health.report_error({msg} [, {advice}])             *vim.health.report_error()*
         Reports an error. {advice} is an optional List of suggestions.
 
 ==============================================================================
@@ -98,15 +97,14 @@ Copy this sample code into `lua/foo/health/init.lua` or `lua/foo/health.lua`,
 replacing "foo" in the path with your plugin name: >
 
         local M = {}
-        local health = require("health")
 
         M.check = function()
-          health.report_start("my_plugin report")
+          vim.health.report_start("my_plugin report")
           -- make sure setup function parameters are ok
           if check_setup() then
-            health.report_ok("Setup function is correct")
+            vim.health.report_ok("Setup function is correct")
           else
-            health.report_error("Setup function is incorrect")
+            vim.health.report_error("Setup function is incorrect")
           end
           -- do some more checking
           -- ...

--- a/runtime/lua/health.lua
+++ b/runtime/lua/health.lua
@@ -1,23 +1,6 @@
-local M = {}
-
-function M.report_start(msg)
-  vim.fn['health#report_start'](msg)
-end
-
-function M.report_info(msg)
-  vim.fn['health#report_info'](msg)
-end
-
-function M.report_ok(msg)
-  vim.fn['health#report_ok'](msg)
-end
-
-function M.report_warn(msg, ...)
-  vim.fn['health#report_warn'](msg, ...)
-end
-
-function M.report_error(msg, ...)
-  vim.fn['health#report_error'](msg, ...)
-end
-
-return M
+return setmetatable({}, {
+  __index = function(_, k)
+    vim.deprecate("require('health')", 'vim.health', '0.9', false)
+    return vim.health[k]
+  end,
+})

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -49,6 +49,7 @@ for k, v in pairs({
   diagnostic = true,
   keymap = true,
   ui = true,
+  health = true,
 }) do
   vim._submodules[k] = v
 end

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+function M.report_start(msg)
+  vim.fn['health#report_start'](msg)
+end
+
+function M.report_info(msg)
+  vim.fn['health#report_info'](msg)
+end
+
+function M.report_ok(msg)
+  vim.fn['health#report_ok'](msg)
+end
+
+function M.report_warn(msg, ...)
+  vim.fn['health#report_warn'](msg, ...)
+end
+
+function M.report_error(msg, ...)
+  vim.fn['health#report_error'](msg, ...)
+end
+
+local path2name = function(path)
+  if path:match('%.lua$') then
+    -- Lua: transform "../lua/vim/lsp/health.lua" into "vim.lsp"
+    return path:gsub('.-lua[%\\%/]', '', 1):gsub('[%\\%/]', '.'):gsub('%.health.-$', '')
+  else
+    -- Vim: transform "../autoload/health/provider.vim" into "provider"
+    return vim.fn.fnamemodify(path, ':t:r')
+  end
+end
+
+local PATTERNS = { '/autoload/health/*.vim', '/lua/**/**/health.lua', '/lua/**/**/health/init.lua' }
+-- :checkhealth completion function used by ex_getln.c get_healthcheck_names()
+M._complete = function()
+  local names = vim.tbl_flatten(vim.tbl_map(function(pattern)
+    return vim.tbl_map(path2name, vim.api.nvim_get_runtime_file(pattern, true))
+  end, PATTERNS))
+  -- Remove duplicates
+  local unique = {}
+  vim.tbl_map(function(f)
+    unique[f] = true
+  end, names)
+  return vim.tbl_keys(unique)
+end
+
+return M

--- a/test/functional/fixtures/lua/test_plug/health/init.lua
+++ b/test/functional/fixtures/lua/test_plug/health/init.lua
@@ -1,11 +1,10 @@
 local M = {}
-local health = require("health")
 
 M.check = function()
-  health.report_start("report 1")
-  health.report_ok("everything is fine")
-  health.report_start("report 2")
-  health.report_ok("nothing to see here")
+  vim.health.report_start("report 1")
+  vim.health.report_ok("everything is fine")
+  vim.health.report_start("report 2")
+  vim.health.report_ok("nothing to see here")
 end
 
 return M

--- a/test/functional/fixtures/lua/test_plug/submodule/health.lua
+++ b/test/functional/fixtures/lua/test_plug/submodule/health.lua
@@ -1,11 +1,10 @@
 local M = {}
-local health = require("health")
 
 M.check = function()
-  health.report_start("report 1")
-  health.report_ok("everything is fine")
-  health.report_start("report 2")
-  health.report_ok("nothing to see here")
+  vim.health.report_start("report 1")
+  vim.health.report_ok("everything is fine")
+  vim.health.report_start("report 2")
+  vim.health.report_ok("nothing to see here")
 end
 
 return M

--- a/test/functional/fixtures/lua/test_plug/submodule_failed/health.lua
+++ b/test/functional/fixtures/lua/test_plug/submodule_failed/health.lua
@@ -1,10 +1,9 @@
 local M = {}
-local health = require("health")
 
 M.check = function()
-  health.report_start("report 1")
-  health.report_ok("everything is fine")
-  health.report_warn("About to add a number to nil")
+  vim.health.report_start("report 1")
+  vim.health.report_ok("everything is fine")
+  vim.health.report_warn("About to add a number to nil")
   local a = nil + 2
   return a
 end


### PR DESCRIPTION
## Complete function

There was lots of unnecessary C code for the complete function, this was pointed out in https://github.com/neovim/neovim/pull/15259#discussion_r722326251 therefore this PR moves it to Lua and uses the plumbing we have in place.

## Moving the module

I think when I introduced `require('health')` it wasn't the best idea, we are using another spot in the Lua packages _namespace_, I believe is a better design to keep it under `vim.health`, and in our best interest considering we want to use nvim as a Lua interpreter 🚀