### PR TITLE
vim-patch:8.2.5009: fold may not be closeable after appending

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2323,6 +2323,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
               }
               fp->fd_len += fp->fd_top - firstlnum;
               fp->fd_top = firstlnum;
+              fp->fd_small = kNone;
               fold_changed = true;
             } else if ((flp->start != 0 && lvl == level)
                        || (firstlnum != startlnum)) {

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -970,4 +970,23 @@ func Test_indent_one_line_fold_close()
   bw!
 endfunc
 
+" Make sure that when appending [an indented line then a blank line] right
+" before a single indented line, the resulting extended fold can be closed
+func Test_indent_append_blank_small_fold_close()
+  new
+  setlocal sw=2 foldmethod=indent
+  " at first, the fold at the second line can't be closed since it's smaller
+  " than foldminlines
+  let lines =<< trim END
+    line 1
+      line 4
+  END
+  call setline(1, lines)
+  call append(1, ['  line 2', ''])
+  " close all folds
+  normal zM
+  call assert_notequal(-1, foldclosed(2)) " the fold should be closed now
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Fold may not be closeable after appending.
Solution:   Set the fd_small flag to MAYBE. (Brandon Simmons, closes vim/vim#10471)
https://github.com/vim/vim/commit/e8c4a64bffbe628a46dc172d04cfc2db6e8dd8b6