### PR TITLE
vim-patch:8.2.5012: cannot select one character inside ()

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3453,11 +3453,11 @@ int current_block(oparg_T *oap, long count, int include, int what, int other)
       }
     }
 
-    /*
-     * In Visual mode, when the resulting area is not bigger than what we
-     * started with, extend it to the next block, and then exclude again.
-     */
+    // In Visual mode, when the resulting area is not bigger than what we
+    // started with, extend it to the next block, and then exclude again.
+    // Don't try to expand the area if the area is empty.
     if (!lt(start_pos, old_start) && !lt(old_end, curwin->w_cursor)
+        && !equalpos(start_pos, curwin->w_cursor)
         && VIsual_active) {
       curwin->w_cursor = old_start;
       decl(&curwin->w_cursor);

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -42,6 +42,24 @@ func Test_inner_block_with_cpo_M_right_backslash()
   call CpoM('(red (blue\) green)', 1, ['red (blue\) green', 'blue\', 'red (blue\) green'])
 endfunc
 
+func Test_inner_block_single_char()
+  new
+  call setline(1, "(a)")
+
+  set selection=inclusive
+  let @" = ''
+  call assert_nobeep('norm! 0faviby')
+  call assert_equal('a', @")
+
+  set selection=exclusive
+  let @" = ''
+  call assert_nobeep('norm! 0faviby')
+  call assert_equal('a', @")
+
+  set selection&
+  bwipe!
+endfunc
+
 func Test_quote_selection_selection_exclusive()
   new
   call setline(1, "a 'bcde' f")
@@ -50,11 +68,11 @@ func Test_quote_selection_selection_exclusive()
   exe "norm! fdvhi'y"
   call assert_equal('bcde', @")
 
-  let @"='dummy'
+  let @" = 'dummy'
   exe "norm! $gevi'y"
   call assert_equal('bcde', @")
 
-  let @"='dummy'
+  let @" = 'dummy'
   exe "norm! 0fbhvi'y"
   call assert_equal('bcde', @")
 


### PR DESCRIPTION
#### vim-patch:8.2.5012: cannot select one character inside ()

Problem:    Cannot select one character inside ().
Solution:   Do not try to extend the area if it is empty. (closes vim/vim#10472)
https://github.com/vim/vim/commit/53737b5eeeab1f95964f78b055d6094fab559533