### PR TITLE
vim-patch:8.2.5010: the terminal debugger uses various global variables

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -304,7 +304,7 @@ breakpoint, or use the "Clear breakpoint" right-click menu entry.
 Inspecting variables ~
 					*termdebug-variables* *:Evaluate*
  `:Evaluate`	    evaluate the expression under the cursor
- `K`		    same
+ `K`		    same (see |termdebug_map_K| to disable)
  `:Evaluate` {expr}   evaluate {expr}
  `:'<,'>Evaluate`     evaluate the Visually selected text
 
@@ -363,6 +363,10 @@ This works slightly differently:
 						*termdebug_use_prompt*
 Prompt mode can be used with: >
 	let g:termdebug_use_prompt = 1
+<
+						*termdebug_map_K*
+The K key is normally mapped to :Evaluate. If you do not want this use: >
+	let g:termdebug_map_K = 0
 
 <
 						*termdebug_disasm_window*
@@ -387,11 +391,11 @@ communication channel.
 
 Customizing ~
 
-GDB command						 *termdebug-customizing*
-
-To change the name of the gdb command, set the "termdebugger" variable before
+GDB command						*termdebug-customizing*
+							*g:termdebugger*
+To change the name of the gdb command, set the "g:termdebugger" variable before
 invoking `:Termdebug`: >
-	let termdebugger = "mygdb"
+	let g:termdebugger = "mygdb"
 If the command needs an argument use a List: >
 	let g:termdebugger = ['rr', 'replay', '--']
 
@@ -439,16 +443,18 @@ The argument is the gdb command.
 
 Vim window width						*termdebug_wide*
 
-To change the width of the Vim window when debugging starts, and use a
-vertical split: >
-  let g:termdebug_wide = 163
-This will set &columns to 163 when `:Termdebug` is used.  The value is restored
-when quitting the debugger.
-If g:termdebug_wide is set and &columns is already larger than
-g:termdebug_wide then a vertical split will be used without changing &columns.
-Set it to 1 to get a vertical split without every changing &columns (useful
-for when the terminal can't be resized by Vim).
+To change the width of the Vim window when debugging starts and use a vertical
+split: >
+	let g:termdebug_wide = 163
 
+This will set 'columns' to 163 when `:Termdebug` is used.  The value is
+restored when quitting the debugger.
+
+If g:termdebug_wide is set and 'columns' is already a greater value, then a
+vertical split will be used without modifying 'columns'.
+
+Set g:termdebug_wide to 1 to use a vertical split without ever changing
+'columns'.  This is useful when the terminal can't be resized by Vim.
 
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -333,7 +333,7 @@ Four autocommands can be used: >
 						*TermdebugStartPre*
 TermdebugStartPre		Before starting debugging.
 				Not triggered if the debugger is already
-				running or |g:termdebugger| cannot be
+				running or the debugger command cannot be
 				executed.
 						*TermdebugStartPost*
 TermdebugStartPost		After debugging has initialized.
@@ -362,18 +362,24 @@ This works slightly differently:
 
 						*termdebug_use_prompt*
 Prompt mode can be used with: >
+	let g:termdebug_config['use_prompt'] = 1
+Or if there is no g:termdebug_config: >
 	let g:termdebug_use_prompt = 1
 <
 						*termdebug_map_K*
 The K key is normally mapped to :Evaluate. If you do not want this use: >
+	let g:termdebug_config['map_K'] = 0
+Or if there is no g:termdebug_config: >
 	let g:termdebug_map_K = 0
-
 <
 						*termdebug_disasm_window*
-If you want the Asm window shown by default, set this to 1. Setting to
-any value greater than 1 will set the Asm window height to that value: >
+If you want the Asm window shown by default, set the flag to 1.
+the "disasm_window_height" entry can be used to set the window height: >
+	let g:termdebug_config['disasm_window'] = 1
+	let g:termdebug_config['disasm_window_height'] = 15
+or, if there is no g:termdebug_config: >
 	let g:termdebug_disasm_window = 15
-<
+Any value greater than 1 will set the Asm window height to that value: >
 
 Communication ~
 						*termdebug-communication*
@@ -390,13 +396,24 @@ communication channel.
 
 
 Customizing ~
+				*termdebug-customizing* *g:termdebug_config*
+In the past several global variables were used for configuration.  These are
+deprecated, using the g:termdebug_config dictionary is preferred.  When
+g:termdebug_config exists the other global variables will not be used.
 
-GDB command						*termdebug-customizing*
+
+GDB command ~
 							*g:termdebugger*
-To change the name of the gdb command, set the "g:termdebugger" variable before
-invoking `:Termdebug`: >
+To change the name of the gdb command, set "debugger" entry in
+g:termdebug_config or the "g:termdebugger" variable before invoking
+`:Termdebug`: >
+	let g:termdebug_config['command'] = "mygdb"
+Or if there is no g:termdebug_config: >
 	let g:termdebugger = "mygdb"
+
 If the command needs an argument use a List: >
+	let g:termdebug_config['command'] = ['rr', 'replay', '--']
+Or if there is no g:termdebug_config: >
 	let g:termdebugger = ['rr', 'replay', '--']
 
 To not use neovim floating windows for previewing variable evaluation, set the
@@ -410,7 +427,17 @@ cursor: >
 or set/unset a breakpoint: >
 	nnoremap <RightMouse> :Break<CR>
 
-<							*gdb-version*
+
+Several arguments will be added to make gdb work well for the debugger.
+If you want to modify them, add a function to filter the argument list: >
+	let g:termdebug_config['command_filter'] = MyDebugFilter
+
+If you do not want the arguments to be added, but you do need to set the
+"pty", use a function to add the necessary arguments: >
+	let g:termdebug_config['command_add_args'] = MyAddArguments
+The function will be called with the list of arguments so far, and a second
+argument that is the name of the pty.
+							*gdb-version*
 Only debuggers fully compatible with gdb will work.  Vim uses the GDB/MI
 interface.  The "new-ui" command  requires gdb version 7.12 or later.  if you
 get this error:
@@ -418,8 +445,8 @@ get this error:
 Then your gdb is too old.
 
 
-Colors						*hl-debugPC* *hl-debugBreakpoint*
-
+Colors~
+						*hl-debugPC* *hl-debugBreakpoint*
 The color of the signs can be adjusted with these highlight groups:
 - debugPC		the current position
 - debugBreakpoint	a breakpoint
@@ -445,15 +472,17 @@ Vim window width						*termdebug_wide*
 
 To change the width of the Vim window when debugging starts and use a vertical
 split: >
+	let g:termdebug_config['wide'] = 163
+Or if there is no g:termdebug_config: >
 	let g:termdebug_wide = 163
 
 This will set 'columns' to 163 when `:Termdebug` is used.  The value is
 restored when quitting the debugger.
 
-If g:termdebug_wide is set and 'columns' is already a greater value, then a
+If the wide value is set and 'columns' is already a greater value, then a
 vertical split will be used without modifying 'columns'.
 
-Set g:termdebug_wide to 1 to use a vertical split without ever changing
+Set the wide value to 1 to use a vertical split without ever changing
 'columns'.  This is useful when the terminal can't be resized by Vim.
 
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -243,6 +243,10 @@ preprocess_patch() {
   LC_ALL=C sed -e 's/\( [ab]\/src\/nvim\)\/keymap\.h/\1\/keycodes.h/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"
 
+  # Rename terminal.txt to nvim_terminal_emulator.txt
+  LC_ALL=C sed -e 's/\( [ab]\/runtime\/doc\)\/terminal\.txt/\1\/nvim_terminal_emulator.txt/g' \
+    "$file" > "$file".tmp && mv "$file".tmp "$file"
+
   # Rename test_urls.vim to check_urls.vim
   LC_ALL=C sed -e 's@\( [ab]\)/runtime/doc/test\(_urls\.vim\)@\1/scripts/check\2@g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"


### PR DESCRIPTION
#### docs: add missing termdebug docs from Vim runtime updates

https://github.com/vim/vim/commit/388a5d4f20b4b64341d1604aa238cab85827b892
https://github.com/vim/vim/commit/4466ad6baa22485abb1147aca3340cced4778a66
https://github.com/vim/vim/commit/6aa57295cfbe8f21c15f0671e45fd53cf990d404

Rename terminal.txt to nvim_terminal_emulator.txt in vim-patch.sh.


#### vim-patch:8.2.5010: the terminal debugger uses various global variables

Problem:    The terminal debugger uses various global variables.
Solution:   Add a dictionary to hold the terminal debugger preferences.
https://github.com/vim/vim/commit/c9a431c7638ecebb6f2cb3eabd0e1b2b5e269c1e

Omit popup menu.