### PR TITLE
test(unit): use setup()/teardown() in buffer_spec.lua

### DIFF
--- a/test/unit/buffer_spec.lua
+++ b/test/unit/buffer_spec.lua
@@ -25,14 +25,14 @@ describe('buffer functions', function()
   local path2 = 'file_path_test'
   local path3 = 'path_test_file'
 
-  before_each(function()
+  setup(function()
     -- create the files
     io.open(path1, 'w').close()
     io.open(path2, 'w').close()
     io.open(path3, 'w').close()
   end)
 
-  after_each(function()
+  teardown(function()
     os.remove(path1)
     os.remove(path2)
     os.remove(path3)


### PR DESCRIPTION
In unit/buffer_spec.lua, before_each() and after_each() are used to create/remove test files path1,2,3. But these files need not be created/removed before/after each test; it is just enough to create them once before all the tests, and remove them after all the tests.

In theory this makes the test run faster, but the difference is negligible. The reason that this patch is useful for _me_ is the following:

On one of my Mac ((Monterey, the latest macOS)  buffer_spec.lua passes without problem. But on another Mac (10.14/Mojave, rather old macOS), this test file gives **lots** of errors. The first error occurs in the test:

build_stl_str_hl should handle an empty right side when using == with fillchar `!`

with the message:

test/unit/buffer_spec.lua:32: attempt to index a nil value

This indicates 'io.open(path3, 'w')' has failed (I have no idea why it fails). After this error, all the following tests give the similar error. If I comment out the above test then the next (and the following) tests give the same error.

But in these tests (build_stl_str_hl) the test files path1,2,3 are not used, and if I replace the {before,after}_each() by setup()/teardwon() then the tests pass without error.

I don't know what is the real origin of the error. But this patch will not cause any problem on any other OSes and/or hardwares.