### PR TITLE
vim-patch:8.2.5016: access before start of text with a put command

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3699,8 +3699,11 @@ error:
       len = STRLEN(y_array[y_size - 1]);
       col = (colnr_T)len - lendiff;
       if (col > 1) {
-        curbuf->b_op_end.col = col - 1 - utf_head_off(y_array[y_size - 1],
-                                                      y_array[y_size - 1] + len - 1);
+        curbuf->b_op_end.col = col - 1;
+        if (len > 0) {
+          curbuf->b_op_end.col -= utf_head_off(y_array[y_size - 1],
+                                               y_array[y_size - 1] + len - 1);
+        }
       } else {
         curbuf->b_op_end.col = 0;
       }

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -203,3 +203,15 @@ func Test_multibyte_op_end_mark()
   call assert_equal([0, 2, 7, 0], getpos("']"))
   bwipe!
 endfunc
+
+" this was putting a mark before the start of a line
+func Test_put_empty_register()
+  new
+  norm yy
+  norm [Pi00ggv)s0
+  sil! norm [P
+  bwipe!
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.5016: access before start of text with a put command

Problem:    Access before start of text with a put command.
Solution:   Check the length is more than zero.
https://github.com/vim/vim/commit/2a585c85013be22f59f184d49612074fd9b115d7