### PR TITLE
Add "buf" and "win" to nvim_get_option_value and use them in vim.bo and vim.wo

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2037,15 +2037,17 @@ nvim_get_option_value({name}, {*opts})               *nvim_get_option_value()*
                 matches that of |:set|: the local value of an option is
                 returned if it exists; otherwise, the global value is
                 returned. Local values always correspond to the current buffer
-                or window. To get a buffer-local or window-local option for a
-                specific buffer or window, use |nvim_buf_get_option()| or
-                |nvim_win_get_option()|.
+                or window, unless "buf" or "win" is set in {opts}.
 
                 Parameters: ~
                     {name}  Option name
                     {opts}  Optional parameters
-                            • scope: One of 'global' or 'local'. Analogous to
+                            • scope: One of "global" or "local". Analogous to
                               |:setglobal| and |:setlocal|, respectively.
+                            • win: |window-ID|. Used for getting window local
+                              options.
+                            • buf: Buffer number. Used for getting buffer
+                              local options. Implies {scope} is "local".
 
                 Return: ~
                     Option value

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -91,11 +91,11 @@ do -- buffer option accessor
         return new_buf_opt_accessor(k)
       end
 
-      return a.nvim_buf_get_option(bufnr or 0, k)
+      return a.nvim_get_option_value(k, { buf = bufnr or 0 })
     end
 
     local function set(k, v)
-      return a.nvim_buf_set_option(bufnr or 0, k, v)
+      return a.nvim_set_option_value(k, v, { buf = bufnr or 0 })
     end
 
     return make_meta_accessor(get, set, nil, function(k)
@@ -121,11 +121,11 @@ do -- window option accessor
       if winnr == nil and type(k) == 'number' then
         return new_win_opt_accessor(k)
       end
-      return a.nvim_win_get_option(winnr or 0, k)
+      return a.nvim_get_option_value(k, { win = winnr or 0 })
     end
 
     local function set(k, v)
-      return a.nvim_win_set_option(winnr or 0, k, v)
+      return a.nvim_set_option_value(k, v, { win = winnr or 0 })
     end
 
     return make_meta_accessor(get, set, nil, function(k)

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1453,10 +1453,21 @@ describe('API', function()
     it('set local window options', function()
       -- Different to nvim_win_set_option
       nvim('set_option_value', 'colorcolumn', '4,3', {win=0, scope='local'})
-      eq('4,3', nvim('get_option_value', 'colorcolumn', {scope = 'local'}))
+      eq('4,3', nvim('get_option_value', 'colorcolumn', {win = 0, scope = 'local'}))
       command("set modified hidden")
       command("enew") -- edit new buffer, window option is reset
-      eq('', nvim('get_option_value', 'colorcolumn', {scope = 'local'}))
+      eq('', nvim('get_option_value', 'colorcolumn', {win = 0, scope = 'local'}))
+    end)
+
+    it('get buffer or window-local options', function()
+      nvim('command', 'new')
+      local buf = nvim('get_current_buf').id
+      nvim('buf_set_option', buf, 'tagfunc', 'foobar')
+      eq('foobar', nvim('get_option_value', 'tagfunc', {buf = buf}))
+
+      local win = nvim('get_current_win').id
+      nvim('win_set_option', win, 'number', true)
+      eq(true, nvim('get_option_value', 'number', {win = win}))
     end)
   end)
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1396,7 +1396,7 @@ describe('lua stdlib', function()
     ]]
     eq('', funcs.luaeval "vim.bo.filetype")
     eq(true, funcs.luaeval "vim.bo[BUF].modifiable")
-    matches("Invalid option name: 'nosuchopt'$",
+    matches("unknown option 'nosuchopt'$",
        pcall_err(exec_lua, 'return vim.bo.nosuchopt'))
     matches("Expected lua string$",
        pcall_err(exec_lua, 'return vim.bo[0][0].autoread'))
@@ -1415,7 +1415,7 @@ describe('lua stdlib', function()
     eq(0, funcs.luaeval "vim.wo.cole")
     eq(0, funcs.luaeval "vim.wo[0].cole")
     eq(0, funcs.luaeval "vim.wo[1001].cole")
-    matches("Invalid option name: 'notanopt'$",
+    matches("unknown option 'notanopt'$",
        pcall_err(exec_lua, 'return vim.wo.notanopt'))
     matches("Expected lua string$",
        pcall_err(exec_lua, 'return vim.wo[0][0].list'))


### PR DESCRIPTION
Add "buf" and "win" options to `nvim_get_option_value`. Use `nvim_get_option_value` and `nvim_set_option_value` for `vim.bo` and `vim.wo`.

`nvim_get_option_value` and `nvim_set_option_value` better handle unsetting local options. For instance, this is currently not possible:

    vim.bo.tagfunc = nil

This does not work because 'tagfunc' is marked as "local to buffer" and does not have a fallback global option. However, using :setlocal *does* work as expected

    :setlocal tagfunc=

`nvim_set_option_value` behaves more like :set and :setlocal (by design), so using these as the underlying API functions beneath vim.bo and vim.wo makes those two tables act more like :setlocal. Note that vim.o *already* uses `nvim_set_option_value` under the hood, so that vim.o behaves like :set. Thus with this change the `vim.o`, `vim.go`, `vim.bo`, and `vim.wo` family of tables should perfectly match the usage as expected by `:set`, `:setglobal`, and `:setlocal`.
