### PR TITLE
chore: Experiments with profiling tree-sitter with Tracy and NVTX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #   best practices (3.0+): https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1
 
 # Version should match the tested CMAKE_URL in .github/workflows/ci.yml.
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(nvim C)
 
 if(POLICY CMP0065)
@@ -283,7 +283,7 @@ if(MSVC)
   add_definitions(-DWIN32)
 else()
   add_compile_options(-Wall -Wextra -pedantic -Wno-unused-parameter
-    -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion
+    -Wstrict-prototypes $<$<COMPILE_LANGUAGE:C>:-std=gnu99> -Wshadow -Wconversion
     -Wdouble-promotion
     -Wmissing-noreturn
     -Wmissing-format-attribute

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -312,12 +312,15 @@ end
 
 ---@private
 function TSHighlighter._on_line(_, _win, buf, line, _)
+  vim._perf_range_push('on_line')
   local self = TSHighlighter.active[buf]
   if not self then
+    vim._perf_range_pop()
     return
   end
 
   on_line_impl(self, buf, line)
+  vim._perf_range_pop()
 end
 
 ---@private

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -818,3 +818,31 @@ add_subdirectory(po)
 
 include(GetCompileFlags)
 get_compile_flags(NVIM_VERSION_CFLAGS)
+
+option(USE_NVTX "Use NVTX to set profiling markers (https://docs.nvidia.com/gameworks/content/gameworkslibrary/nvtx/nvidia_tools_extension_library_nvtx.htm)" OFF)
+if(USE_NVTX)
+  find_package(CUDAToolkit REQUIRED)
+  target_link_libraries(nvim CUDA::nvToolsExt)
+  target_compile_definitions(nvim PRIVATE USE_NVTX=1)
+endif()
+
+option(USE_TRACY "Use Tracy to set profiling markers (https://github.com/wolfpld/tracy)" OFF)
+if(USE_TRACY)
+  enable_language(CXX)
+
+  option(TRACY_ENABLE "" ON)
+  option(TRACY_ON_DEMAND "" OFF)
+  option(FETCHCONTENT_QUIET OFF)
+  include(FetchContent)
+  FetchContent_Declare (
+    tracy
+    GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+    GIT_TAG v0.8.1
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
+    )
+  FetchContent_MakeAvailable(tracy)
+
+  target_link_libraries(nvim Tracy::TracyClient)
+  target_compile_definitions(nvim PRIVATE USE_TRACY=1)
+endif()

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -30,6 +30,7 @@
 #include "nvim/lua/executor.h"
 #include "nvim/lua/stdlib.h"
 #include "nvim/lua/treesitter.h"
+#include "nvim/lua/perf_annotations.h"
 #include "nvim/macros.h"
 #include "nvim/map.h"
 #include "nvim/memline.h"
@@ -646,6 +647,9 @@ static bool nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 
   // internal vim._treesitter... API
   nlua_add_treesitter(lstate);
+
+  // internal vim._treesitter... API
+  nlua_add_perf_annotations(lstate);
 
   nlua_state_add_stdlib(lstate, false);
 
@@ -1589,6 +1593,18 @@ static void nlua_add_treesitter(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 
   lua_pushcfunction(lstate, tslua_get_minimum_language_version);
   lua_setfield(lstate, -2, "_ts_get_minimum_language_version");
+}
+
+static void nlua_add_perf_annotations(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
+{
+  lua_pushcfunction(lstate, nlua_perf_range_push);
+  lua_setfield(lstate, -2, "_perf_range_push");
+
+  lua_pushcfunction(lstate, nlua_perf_range_pop);
+  lua_setfield(lstate, -2, "_perf_range_pop");
+
+  lua_pushcfunction(lstate, nlua_perf_event);
+  lua_setfield(lstate, -2, "_perf_event");
 }
 
 int nlua_expand_pat(expand_T *xp, char_u *pat, int *num_results, char_u ***results)

--- a/src/nvim/lua/perf_annotations.c
+++ b/src/nvim/lua/perf_annotations.c
@@ -1,0 +1,23 @@
+#include "nvim/lua/perf_annotations.h"
+#include "nvim/perf_annotations.h"
+
+int nlua_perf_range_push(lua_State *L)
+{
+  const char *range_name = luaL_checkstring(L, 1);
+  perf_range_push(range_name);
+  return 0;
+}
+
+int nlua_perf_range_pop(lua_State *L)
+{
+  perf_range_pop();
+  return 0;
+}
+
+int nlua_perf_event(lua_State *L)
+{
+  const char *event_name = luaL_checkstring(L, 1);
+  perf_range_push(event_name);
+  return 0;
+}
+

--- a/src/nvim/lua/perf_annotations.h
+++ b/src/nvim/lua/perf_annotations.h
@@ -1,0 +1,14 @@
+#ifndef NVIM_LUA_PERF_ANNOTATIONS_H
+#define NVIM_LUA_PERF_ANNOTATIONS_H
+
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+
+#include "tree_sitter/api.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "lua/perf_annotations.h.generated.h"
+#endif
+
+#endif

--- a/src/nvim/perf_annotations.c
+++ b/src/nvim/perf_annotations.c
@@ -1,0 +1,26 @@
+#  include "nvim/perf_annotations.h"
+
+#if USE_TRACY
+#  include <TracyC.h>
+#  include <string.h>
+#  define STACK_MAX 1024
+static _Thread_local int counter = 0;
+static _Thread_local TracyCZoneCtx ctx_stack[STACK_MAX];
+
+void perf_range_push_tracy(const char* name) {
+  if (counter < STACK_MAX) {
+    TracyCZone(ctx, 1);
+    ctx_stack[counter] = ctx;
+    TracyCZoneName(ctx, name, strlen(name));
+  }
+  counter++;
+}
+
+void perf_range_pop_tracy(void) {
+  counter--;
+  if (counter < STACK_MAX) {
+    TracyCZoneCtx ctx = ctx_stack[counter];
+    TracyCZoneEnd(ctx);
+  }
+}
+#endif

--- a/src/nvim/perf_annotations.h
+++ b/src/nvim/perf_annotations.h
@@ -1,0 +1,53 @@
+#ifndef PERF_ANNOTATIONS_H
+#define PERF_ANNOTATIONS_H 1
+
+#ifdef USE_NVTX
+#  include "nvtx3/nvToolsExt.h"
+#endif
+
+#ifdef USE_TRACY
+#  include "TracyC.h"
+#  include <string.h>
+#endif
+
+#if USE_TRACY
+void perf_range_push_tracy(const char* name);
+void perf_range_pop_tracy(void);
+#endif
+
+static inline void perf_range_push(const char* name)
+{
+#if USE_NVTX
+  nvtxRangePushA(name);
+#endif
+#if USE_TRACY
+  perf_range_push_tracy(name);
+#endif
+#if !(USE_NVTX || USE_TRACY)
+  (void)name;
+#endif
+}
+
+static inline void perf_range_pop(void)
+{
+#ifdef USE_NVTX
+  nvtxRangePop();
+#endif
+#if USE_TRACY
+  perf_range_pop_tracy();
+#endif
+}
+
+static inline void perf_event(const char* name)
+{
+#ifdef USE_NVTX
+  nvtxMarkA(name);
+#endif
+#ifdef USE_TRACY
+  TracyCMessage(name, strlen(name));
+#endif
+#if !(USE_NVTX || USE_TRACY)
+  (void)name;
+#endif
+}
+#endif

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -64,6 +64,9 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
+#if USE_TRACY
+#include <TracyC.h>
+#endif
 
 #include "nvim/api/extmark.h"
 #include "nvim/api/private/helpers.h"
@@ -306,6 +309,9 @@ void redraw_win_signcol(win_T *wp)
 /// @param type set to a NOT_VALID to force redraw of entire screen
 int update_screen(int type)
 {
+  #if USE_TRACY
+  TracyCFrameMark;
+  #endif
   static bool did_intro = false;
   bool is_stl_global = global_stl_height() > 0;
 


### PR DESCRIPTION
This is mainly an experiment. In the context of https://github.com/nvim-treesitter/nvim-treesitter/issues/2916#issue-1228618601 I tried to get reliable perf data for tree-sitter parsing. I found it incredible to obtain such data with statistical profiler like Intel Vtune (you would need to run a benchmark where the same command sequence happens over and over again. I tried by running the parsing 1000 times instead of once in Neovim to get enough samples in the critical regions). So I added manually NVTX markers (https://docs.nvidia.com/nsight-visual-studio-edition/nvtx/index.html) to visualize the parsing timings to visualize those ranges even when the only happen once.

`parser_parse` of the  markdown parser was indeed that problem https://github.com/nvim-treesitter/nvim-treesitter/issues/2916#issuecomment-1120287849 . Using NVTX is easy and you can see the perf ranges along with traditional sampling points in NSight Systems https://developer.nvidia.com/nsight-systems If NSight Systems is not attached it is basically a noop. One problem that I had with using NSight was that I had to remember which keystrokes and experiments I performed in one recorded session to correlate them later with the traces.

This is why I experimented today with https://github.com/wolfpld/tracy which allows to attach to a session and see the perf data as you type. It is a frame profiler for games and very good in visualizing lots of perf events with moderate overhead. I found this incredible useful to debug problems as I could do a few keystrokes and have a look into the perf data and then continue editing.

Incremental parsing in Markdown
![Screenshot_20220526_161343](https://user-images.githubusercontent.com/7189118/170533089-b23ba65b-43d5-4b8c-b8f3-50595e951cad.png)
vs Lua (much shorter parsing times)
![Screenshot_20220526_161732-1](https://user-images.githubusercontent.com/7189118/170533169-063e853b-63c7-48cc-860b-4378d81dbdf1.png)

This is mainly targeted for dev-only use and mainly for experimentation. Probably this should never go to master. But for investigating perf problems I thought it would be good to share this branch. Tracy requires C++ for compilation. In addition to the client here in Neovim. You also have to have the Server of the same version installed (run `make -j$(nproc)` in `profiler/build/unix/` of https://github.com/wolfpld/tracy tag `v0.6.1`. Instrumented versions of Neovim should never be released and are for dev-usage only.