### PR TITLE
vim-patch:8.2.5024: using freed memory with "]d"

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4826,6 +4826,8 @@ static void nv_brackets(cmdarg_T *cap)
     if ((len = find_ident_under_cursor(&ptr, FIND_IDENT)) == 0) {
       clearop(cap->oap);
     } else {
+      // Make a copy, if the line was changed it will be freed.
+      ptr = vim_strnsave(ptr, len);
       find_pattern_in_path(ptr, 0, len, true,
                            cap->count0 == 0 ? !isupper(cap->nchar) : false,
                            (((cap->nchar & 0xf) == ('d' & 0xf))
@@ -4839,6 +4841,7 @@ static void nv_brackets(cmdarg_T *cap)
                             ? curwin->w_cursor.lnum + 1
                             : (linenr_T)1),
                            MAXLNUM);
+      xfree(ptr);
       curwin->w_set_curswant = true;
     }
   } else if ((cap->cmdchar == '[' && vim_strchr("{(*/#mM", cap->nchar) != NULL)

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -1084,6 +1084,12 @@ func Test_define_search()
   sil norm o0
   sil! norm 
   bwipe!
+
+  new somefile
+  call setline(1, ['first line', '', '#define something 0'])
+  sil norm 0o0
+  sil! norm ]d
+  bwipe!
 endfunc
 
 " Test for the 'taglength' option


### PR DESCRIPTION
#### vim-patch:8.2.5024: using freed memory with "]d"

Problem:    Using freed memory with "]d".
Solution:   Copy the pattern before searching.
https://github.com/vim/vim/commit/e2fa213cf571041dbd04ab0329303ffdc980678a