### PR TITLE
fix(float): fix floating window border drawing with winbar

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -5461,7 +5461,7 @@ static void win_redr_border(win_T *wp)
   int *attrs = wp->w_float_config.border_attr;
 
   int *adj = wp->w_border_adj;
-  int irow = wp->w_height_inner, icol = wp->w_width_inner;
+  int irow = wp->w_height, icol = wp->w_width;
 
   if (adj[0]) {
     grid_puts_line_start(grid, 0);

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -7900,6 +7900,55 @@ describe('float window', function()
         ]]}
       end
     end)
+
+    it('can use both border and winbar', function()
+      local buf = meths.create_buf(false,false)
+      local win1 = meths.open_win(buf, false, {relative='editor', width=15, height=3, row=0, col=4, border = 'single'})
+      meths.win_set_option(win1, 'winbar', 'floaty bar')
+
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {5:┌───────────────┐}|
+          {5:│}{3:floaty bar     }{5:│}|
+          {5:│}{1:               }{5:│}|
+          {5:│}{2:~              }{5:│}|
+          {5:└───────────────┘}|
+        ]], float_pos={
+          [4] = {{id = 1001}, "NW", 1, 0, 4, true, 50};
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1};
+          [4] = {win = {id = 1001}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1};
+        }}
+      else
+        screen:expect{grid=[[
+          ^    {5:┌───────────────┐}                   |
+          {0:~   }{5:│}{3:floaty bar     }{5:│}{0:                   }|
+          {0:~   }{5:│}{1:               }{5:│}{0:                   }|
+          {0:~   }{5:│}{2:~              }{5:│}{0:                   }|
+          {0:~   }{5:└───────────────┘}{0:                   }|
+          {0:~                                       }|
+                                                  |
+        ]]}
+      end
+    end)
   end
 
   describe('with ext_multigrid', function()


### PR DESCRIPTION
Without this fix:
```
[  FAILED  ] test/functional/ui/float_spec.lua @ 7904: float window with ext_multigrid can use both border and winbar
test/functional/ui/float_spec.lua:7910: Row 22 did not match.
Expected:
  |## grid 1
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [3:----------------------------------------]|
  |## grid 2
  |  ^                                        |
  |  {0:~                                       }|
  |  {0:~                                       }|
  |  {0:~                                       }|
  |  {0:~                                       }|
  |  {0:~                                       }|
  |## grid 3
  |                                          |
  |## grid 4
  |  {5:┌───────────────┐}|
  |  {5:│}{3:floaty bar     }{5:│}|
  |  {5:│}{1:               }{5:│}|
  |*  {5:│}{2:~              }{5:│}|
  |  {5:└───────────────┘}|
Actual:
  |## grid 1
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [2:----------------------------------------]|
  |  [3:----------------------------------------]|
  |## grid 2
  |  ^                                        |
  |  {0:~                                       }|
  |  {0:~                                       }|
  |  {0:~                                       }|
  |  {0:~                                       }|
  |  {0:~                                       }|
  |## grid 3
  |                                          |
  |## grid 4
  |  {5:┌───────────────┐}|
  |  {5:│}{3:floaty bar     }{5:│}|
  |  {5:│}{1:               }{5:│}|
  |*  {5:└}{2:~              }{5:┘}|
  |  {5:└───────────────┘}|

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:603: in function '_wait'
	test/functional/ui/screen.lua:351: in function 'expect'
	test/functional/ui/float_spec.lua:7910: in function <test/functional/ui/float_spec.lua:7904>

[  FAILED  ] test/functional/ui/float_spec.lua @ 7904: float window without ext_multigrid can use both border and winbar
test/functional/ui/float_spec.lua:7941: Row 4 did not match.
Expected:
  |^    {5:┌───────────────┐}                   |
  |{0:~   }{5:│}{3:floaty bar     }{5:│}{0:                   }|
  |{0:~   }{5:│}{1:               }{5:│}{0:                   }|
  |*{0:~   }{5:│}{2:~              }{5:│}{0:                   }|
  |{0:~   }{5:└───────────────┘}{0:                   }|
  |{0:~                                       }|
  |                                        |
Actual:
  |^    {5:┌───────────────┐}                   |
  |{0:~   }{5:│}{3:floaty bar     }{5:│}{0:                   }|
  |{0:~   }{5:│}{1:               }{5:│}{0:                   }|
  |*{0:~   }{5:└}{2:~              }{5:┘}{0:                   }|
  |{0:~   }{5:└───────────────┘}{0:                   }|
  |{0:~                                       }|
  |                                        |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.  

stack traceback:
	test/functional/ui/screen.lua:603: in function '_wait'
	test/functional/ui/screen.lua:351: in function 'expect'
	test/functional/ui/float_spec.lua:7941: in function <test/functional/ui/float_spec.lua:7904>
```