### PR TITLE
Expose API for snippet parser.

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -500,6 +500,128 @@ Example: >
    autocmd User LspProgressUpdate redrawstatus
    autocmd User LspRequest redrawstatus
 <
+==============================================================================
+LSP SNIPPET PARSER                                        *lsp-snippet-parser*
+
+|vim.lsp.parser.parse| generates the AST for a snippet-string. This section
+describes the structure of the returned AST.
+For a general overview of lsp-snippets and their capabilities, refer to
+https://github.com/microsoft/language-server-protocol/blob/main/snippetSyntax.md.
+
+In the following, `node` refers to any of |lsp-parser-text|, |lsp-parser-choice|,
+|lsp-parser-tabstop|, |lsp-parser-variable| or |lsp-parser-placeholder|.
+Each node can be identified by comparing its {type} against `NodeType`s in
+`vim.lsp.parser.ast.node_types` (just `node_type` from now on).
+{*fieldname} denotes an optional field.
+
+Snippet                                                  *lsp-parser-snippet*
+                Fields:~
+                    {type}       (NodeType)  `node_type.SNIPPET`
+                    {children}   (node[])    Content of the snippet.
+                                             `${1|foo,bar|} or: $FOOBAR???` 
+                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^~
+                                             [     1     ][ 2 ][  3  ][4]~
+
+Text                                                        *lsp-parser-text*
+                Fields:~
+                    {type}       (NodeType)  `node_type.TEXT`
+                    {esc}        (string)    Escaped text.
+                    {raw}        (string)    Unescaped text.
+
+Tabstop                                                  *lsp-parser-tabstop*
+                Fields:~
+                    {type}       (NodeType)  `node_type.TABSTOP`
+                    {tabstop}    (number)    Position of this tabstop or
+                                             position of the tabstop that
+                                             should be mirrored (and
+                                             potentially transformed).
+                                             `${1}`
+                                               ^~
+                    {*transform} (transform) Optional transform that should
+                                             be applied to the mirrored text.
+                                             `${1/./${1:/upcase}/g}`
+                                                 ^^^^^^^^^^^^^^^^~
+
+Placeholder                                          *lsp-parser-placeholder*
+                Fields:~
+                    {type}       (NodeType)  `node_type.PLACEHOLDER`
+                    {tabstop}    (number)    Position of the placeholder.
+                                             `${1: abc$2}`
+                                               ^~
+                    {children}   (node[])    Default-content of the
+                                             placeholder.
+                                             `${1: default ${2:content}}`
+                                                 ^^^^^^^^^^^^^^^^^^^^^~
+
+Variable                                                *lsp-parser-variable*
+                A variable can be either transformed, or have a `default`, not
+                both.
+                Fields:~
+                    {type}       (NodeType)  `node_type.VARIABLE`
+                    {name}       (string)    Variable's name.
+                                             `$TM_FILENAME`
+                                              ^^^^^^^^^^^~
+                    {*transform} (transform) Optional transform applied to
+                                             the variable's value.
+                                             `${TM_FILENAME/(.*)/${1:/upcase}/}`
+                                                           ^^^^^^^^^^^^^^^^^^~
+                    {*children}  (node[])    Nodes that are inserted if the
+                                             variable is empty, also called
+                                             `default`.
+                                             `${EMPTY:${1:a placeholder}}`
+                                                     ^^^^^^^^^^^^^^^^^^~
+
+Choice                                                    *lsp-parser-choice*
+                Fields:~
+                    {type}       (NodeType)  `node_type.CHOICE`
+                    {tabstop}    (number)    Position.
+                                             `${1|a,b,c,d|}`
+                                               ^~
+                    {items}      (string[])  Different choices.
+                                             `${1|one,two,three}`
+                                                 ^^^ ^^^ ^^^^^~
+                                                 [1] [2] [ 3 ]~
+
+Transform                                              *lsp-parser-transform*
+                Fields:~
+                    {type}       (NodeType)  `node_type.TRANSFORM`
+                    {pattern}    (string)    Regex applied by this transform.
+                                             `([12])+/${1:?small:big} numbers/`
+                                             ^^^^^^^~
+                    {format}     (table)     List of `text` and `format` that make
+                                             up the resulting string.
+                                             `(.*)/${1:+yup}     ${1:-nope}/gi`
+                                                  ^^^^^^^^^^^^^^^^^^^^^^^~
+                                                  [   1   ][ 2 ][   3   ]~
+                    {option}     (string)    Regex-options.
+                                             `A/a/gi`
+                                                 ^^~
+Format                                                    *lsp-parser-format*
+		A format either
+		- inserts the capture unchanged,
+		- modifies the capture via {modifier} or
+		- inserts {if_text} if the capture is nonempty, and
+		  {else_text} otherwise.
+
+                Fields:~
+                    {type}          (NodeType) `node_type.FORMAT`
+                    {capture_index} (number)   The capture-group this format is
+                                               applied to.
+                                               `${1:?exists:doesn't}`
+                                                 ^~
+                    {*modifier}     (string)   Modifier applied to the capture-
+                                               group.
+                                               `${1/capitalize}`
+                                                   ^^^^^^^^^^~
+                    {*if_text}      (string)   Inserted if the capture group is
+                                               nonempty.
+                                               `${1:+ first capture group is OK}`
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^~
+                    {*else_text}    (string)   Inserted if the capture group is
+                                               empty or does not exist
+                                               (no match).
+                                               `${1:-not OK :( }`
+                                                    ^^^^^^^^^^~
 
 ==============================================================================
 Lua module: vim.lsp                                                 *lsp-core*
@@ -2134,5 +2256,131 @@ resolve_capabilities({server_capabilities})
 
                 Return: ~
                     (table) Normalized table of capabilities
+
+
+==============================================================================
+Lua module: vim.lsp.parser                                        *lsp-parser*
+
+parse({input})                                        *vim.lsp.parser.parse()*
+                Build the AST for {input}.
+
+                Parameters: ~
+                    {input}  (string) A snippet as defined in https://code.visualstudio.com/docs/editor/userdefinedsnippets#_grammar
+
+                Return: ~
+                    (Snippet)
+
+
+==============================================================================
+Lua module: vim.lsp.ast                                              *lsp-ast*
+
+choice({tabstop}, {items})                              *vim.lsp.ast.choice()*
+                Create a new choice.
+
+                Parameters: ~
+                    {tabstop}  (number) Position of the choice.
+                    {items}    (string[]) Choices.
+
+                Return: ~
+                    (table) |lsp-parser-choice|
+
+format({capture_index}, {capture_transform})            *vim.lsp.ast.format()*
+                Create a new format which either inserts the capture at
+                {capture_index}, applies a modifier to the capture or inserts
+                {if_text} if the capture is nonempty, and {else_text}
+                otherwise.
+
+                Parameters: ~
+                    {capture_index}      (number) Capture this format is
+                                         applied to.
+                    {capture_transform}  (string | table | nil)
+                                         • (string): {capture_transform} is a
+                                           modifier.
+                                         • (table): {capture_transform} can
+                                           contain either of
+                                           • {if_text} (string, default "")
+                                             Inserted for nonempty capture.
+                                           • {else_text} (string, default "")
+                                             Inserted for empty or undefined
+                                             capture.
+
+                Return: ~
+                    (table) |lsp-parser-format|
+
+is_node({t})                                           *vim.lsp.ast.is_node()*
+                Determine whether {t} is an AST-node.
+
+                Parameters: ~
+                    {t}  (table)
+
+                Return: ~
+                    (boolean)
+
+placeholder({tabstop}, {children})                 *vim.lsp.ast.placeholder()*
+                Create a new placeholder.
+
+                Parameters: ~
+                    {tabstop}   (number) Position of the placeholder.
+                    {children}  (ast-node[]) Content of the placeholder.
+
+                Return: ~
+                    (table) |lsp-parser-placeholder|
+
+snippet({children})                                    *vim.lsp.ast.snippet()*
+                Create a new snippet.
+
+                Parameters: ~
+                    {children}  (ast-node[]) Contents of the snippet.
+
+                Return: ~
+                    (table) |lsp-parser-snippet|
+
+tabstop({tabstop}, {transform})                        *vim.lsp.ast.tabstop()*
+                Create a new tabstop.
+
+                Parameters: ~
+                    {tabstop}    (number) Position of this tabstop.
+                    {transform}  (table|nil) optional transform applied to the
+                                 tabstop.
+
+                Return: ~
+                    (table) |lsp-parser-tabstop|
+
+text({esc}, {raw})                                        *vim.lsp.ast.text()*
+                Create new text.
+
+                Parameters: ~
+                    {esc}  (string) Escaped text.
+                    {raw}  (string|nil, default {esc}) Unescaped text.
+
+                Return: ~
+                    (table) |lsp-parser-text|
+
+transform({pattern}, {format}, {option})             *vim.lsp.ast.transform()*
+                Create a new transform.
+
+                Parameters: ~
+                    {pattern}  (string) Regex applied to the variable/tabstop
+                               this transform is supplied to.
+                    {format}   (table of Format|Text) Replacement for the
+                               regex.
+                    {option}   (string|nil) Regex-options, default "".
+
+                Return: ~
+                    (table) |lsp-parser-transform|
+
+variable({name}, {replacement})                       *vim.lsp.ast.variable()*
+                Create a new variable.
+
+                Parameters: ~
+                    {name}         (string) Name.
+                    {replacement}  (node[] | transform | nil)
+                                   • (node[]) Inserted when the variable is
+                                     empty.
+                                   • (transform) Applied to the variable's
+                                     value.
+
+                Return: ~
+                    (table) |lsp-parser-variable|
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -33,6 +33,8 @@ local lsp = {
 
   -- Export these directly from rpc.
   rpc_response_error = lsp_rpc.rpc_response_error,
+
+  snippet = require('vim.lsp.snippet'),
 }
 
 -- maps request name to the required server_capability in the client.

--- a/runtime/lua/vim/lsp/snippet.lua
+++ b/runtime/lua/vim/lsp/snippet.lua
@@ -204,7 +204,7 @@ end)
 S.var = P.pattern('[%a_][%w_]+')
 S.text = function(targets, specials)
   return P.map(P.take_until(targets, specials), function(value)
-    return ast.text(value.esc, value.raw)
+    return ast.Text.new(value.esc, value.raw)
   end)
 end
 
@@ -214,10 +214,10 @@ end)
 
 S.format = P.any(
   P.map(P.seq(S.dollar, S.int), function(values)
-    return ast.format(values[2])
+    return ast.Format.new(values[2])
   end),
   P.map(P.seq(S.dollar, S.open, S.int, S.close), function(values)
-    return ast.format(values[3])
+    return ast.Format.new(values[3])
   end),
   P.map(
     P.seq(
@@ -230,7 +230,7 @@ S.format = P.any(
       S.close
     ),
     function(values)
-      return ast.format(values[3], values[6])
+      return ast.Format.new(values[3], values[6])
     end
   ),
   P.map(
@@ -243,7 +243,7 @@ S.format = P.any(
       S.close
     ),
     function(values)
-      return ast.format(values[3], {
+      return ast.Format.new(values[3], {
         if_text = values[5][2] and values[5][2].esc,
         else_text = values[5][4] and values[5][4].esc,
       })
@@ -252,7 +252,7 @@ S.format = P.any(
   P.map(
     P.seq(S.dollar, S.open, S.int, S.colon, P.seq(S.plus, P.opt(P.take_until({ '}' }, { '\\' }))), S.close),
     function(values)
-      return ast.format(values[3], {
+      return ast.Format.new(values[3], {
         if_text = values[5][2] and values[5][2].esc,
       })
     end
@@ -260,13 +260,13 @@ S.format = P.any(
   P.map(
     P.seq(S.dollar, S.open, S.int, S.colon, S.minus, P.opt(P.take_until({ '}' }, { '\\' })), S.close),
     function(values)
-      return ast.format(values[3], {
+      return ast.Format.new(values[3], {
         else_text = values[6] and values[6].esc,
       })
     end
   ),
   P.map(P.seq(S.dollar, S.open, S.int, S.colon, P.opt(P.take_until({ '}' }, { '\\' })), S.close), function(values)
-    return ast.format(values[3], {
+    return ast.Format.new(values[3], {
       else_text = values[5] and values[5].esc,
     })
   end)
@@ -282,19 +282,19 @@ S.transform = P.map(
     P.opt(P.pattern('[ig]+'))
   ),
   function(values)
-    return ast.transform(values[2].raw, values[4], values[6])
+    return ast.Transform.new(values[2].raw, values[4], values[6])
   end
 )
 
 S.tabstop = P.any(
   P.map(P.seq(S.dollar, S.int), function(values)
-    return ast.tabstop(values[2])
+    return ast.Tabstop.new(values[2])
   end),
   P.map(P.seq(S.dollar, S.open, S.int, S.close), function(values)
-    return ast.tabstop(values[3])
+    return ast.Tabstop.new(values[3])
   end),
   P.map(P.seq(S.dollar, S.open, S.int, S.transform, S.close), function(values)
-    return ast.tabstop(values[3], values[4])
+    return ast.Tabstop.new(values[3], values[4])
   end)
 )
 
@@ -303,7 +303,7 @@ S.placeholder = P.any(
     P.seq(S.dollar, S.open, S.int, S.colon, P.opt(P.many(P.any(S.toplevel, S.text({ '$', '}' }, { '\\' })))), S.close),
     function(values)
       -- no children -> manually create empty text.
-      return ast.placeholder(values[3], values[5] or { ast.text('') })
+      return ast.Placeholder.new(values[3], values[5] or { ast.Text.new('') })
     end
   )
 )
@@ -321,30 +321,30 @@ S.choice = P.map(
     S.close
   ),
   function(values)
-    return ast.choice(values[3], values[5])
+    return ast.Choice.new(values[3], values[5])
   end
 )
 
 S.variable = P.any(
   P.map(P.seq(S.dollar, S.var), function(values)
-    return ast.variable(values[2])
+    return ast.Variable.new(values[2])
   end),
   P.map(P.seq(S.dollar, S.open, S.var, S.close), function(values)
-    return ast.variable(values[3])
+    return ast.Variable.new(values[3])
   end),
   P.map(P.seq(S.dollar, S.open, S.var, S.transform, S.close), function(values)
-    return ast.variable(values[3], values[4])
+    return ast.Variable.new(values[3], values[4])
   end),
   P.map(
     P.seq(S.dollar, S.open, S.var, S.colon, P.many(P.any(S.toplevel, S.text({ '$', '}' }, { '\\' }))), S.close),
     function(values)
-      return ast.variable(values[3], values[5])
+      return ast.Variable.new(values[3], values[5])
     end
   )
 )
 
 S.snippet = P.map(P.many(P.any(S.toplevel, S.text({ '$' }, { '}', '\\' }))), function(values)
-  return ast.snippet(values)
+  return ast.Snippet.new(values)
 end)
 
 local M = {}

--- a/runtime/lua/vim/lsp/snippet.lua
+++ b/runtime/lua/vim/lsp/snippet.lua
@@ -244,8 +244,8 @@ S.format = P.any(
     ),
     function(values)
       return ast.Format.new(values[3], {
-        if_text = values[5][2] and values[5][2].esc,
-        else_text = values[5][4] and values[5][4].esc,
+        if_text = values[5][2] and values[5][2].esc or "",
+        else_text = values[5][4] and values[5][4].esc or "",
       })
     end
   ),
@@ -253,7 +253,7 @@ S.format = P.any(
     P.seq(S.dollar, S.open, S.int, S.colon, P.seq(S.plus, P.opt(P.take_until({ '}' }, { '\\' }))), S.close),
     function(values)
       return ast.Format.new(values[3], {
-        if_text = values[5][2] and values[5][2].esc,
+        if_text = values[5][2] and values[5][2].esc or "",
       })
     end
   ),
@@ -261,13 +261,13 @@ S.format = P.any(
     P.seq(S.dollar, S.open, S.int, S.colon, S.minus, P.opt(P.take_until({ '}' }, { '\\' })), S.close),
     function(values)
       return ast.Format.new(values[3], {
-        else_text = values[6] and values[6].esc,
+        else_text = values[6] and values[6].esc or "",
       })
     end
   ),
   P.map(P.seq(S.dollar, S.open, S.int, S.colon, P.opt(P.take_until({ '}' }, { '\\' })), S.close), function(values)
     return ast.Format.new(values[3], {
-      else_text = values[5] and values[5].esc,
+      else_text = values[5] and values[5].esc or "",
     })
   end)
 )

--- a/runtime/lua/vim/lsp/snippet/ast.lua
+++ b/runtime/lua/vim/lsp/snippet/ast.lua
@@ -1,0 +1,176 @@
+local M = {}
+
+local node_type = {
+  SNIPPET = 0,
+  TABSTOP = 1,
+  PLACEHOLDER = 2,
+  VARIABLE = 3,
+  CHOICE = 4,
+  TRANSFORM = 5,
+  FORMAT = 6,
+  TEXT = 7,
+}
+
+M.node_type = node_type
+
+local Node = {}
+function Node:__tostring()
+  local insert_text = {}
+  if self.type == node_type.SNIPPET then
+    for _, c in ipairs(self.children) do
+      table.insert(insert_text, tostring(c))
+    end
+  elseif self.type == node_type.CHOICE then
+    table.insert(insert_text, self.items[1])
+  elseif self.type == node_type.PLACEHOLDER then
+    for _, c in ipairs(self.children or {}) do
+      table.insert(insert_text, tostring(c))
+    end
+  elseif self.type == node_type.TEXT then
+    table.insert(insert_text, self.esc)
+  end
+  return table.concat(insert_text, '')
+end
+
+--- @private
+local function new(t)
+  return setmetatable(t, Node)
+end
+
+---Determine whether {t} is an AST-node.
+---@param t table
+---@return boolean
+local function is_node(t)
+  return getmetatable(t) == Node
+end
+
+M.is_node = is_node
+
+---Create a new snippet.
+---@param children (ast-node[]) Contents of the snippet.
+---@return table |lsp-parser-snippet|
+function M.snippet(children)
+  return new({
+    type = node_type.SNIPPET,
+    children = children,
+  })
+end
+
+---Create a new tabstop.
+---@param tabstop (number) Position of this tabstop.
+---@param transform (table|nil) optional transform applied to the tabstop.
+---@return table |lsp-parser-tabstop|
+function M.tabstop(tabstop, transform)
+  return new({
+    type = node_type.TABSTOP,
+    tabstop = tabstop,
+    transform = transform,
+  })
+end
+
+---Create a new placeholder.
+---@param tabstop (number) Position of the placeholder.
+---@param children (ast-node[]) Content of the placeholder.
+---@return table |lsp-parser-placeholder|
+function M.placeholder(tabstop, children)
+  return new({
+    type = node_type.PLACEHOLDER,
+    tabstop = tabstop,
+    children = children,
+  })
+end
+
+---Create a new variable.
+---@param name (string) Name.
+---@param replacement (node[] | transform | nil)
+---         - (node[]) Inserted when the variable is empty.
+---         - (transform) Applied to the variable's value.
+---@return table |lsp-parser-variable|
+function M.variable(name, replacement)
+  local transform, children
+  -- transform is an ast-node, children a flat list of nodes.
+  if is_node(replacement) then
+    transform = replacement
+  else
+    children = replacement
+  end
+
+  return new({
+    type = node_type.VARIABLE,
+    name = name,
+    transform = transform,
+    children = children,
+  })
+end
+
+---Create a new choice.
+---@param tabstop (number) Position of the choice.
+---@param items (string[]) Choices.
+---@return table |lsp-parser-choice|
+function M.choice(tabstop, items)
+  return new({
+    type = node_type.CHOICE,
+    tabstop = tabstop,
+    items = items,
+  })
+end
+
+---Create a new transform.
+---@param pattern (string) Regex applied to the variable/tabstop this transform
+---                        is supplied to.
+---@param format (table of Format|Text) Replacement for the regex.
+---@param option (string|nil) Regex-options, default "".
+---@return table |lsp-parser-transform|
+function M.transform(pattern, format, option)
+  return new({
+    type = node_type.TRANSFORM,
+    pattern = pattern,
+    format = format,
+    option = option or '',
+  })
+end
+
+---Create a new format which either inserts the capture at {capture_index},
+---applies a modifier to the capture or inserts {if_text} if the capture is
+---nonempty, and {else_text} otherwise.
+---@param capture_index (number) Capture this format is applied to.
+---@param capture_transform (string | table | nil)
+---         - (string): {capture_transform} is a modifier.
+---         - (table): {capture_transform} can contain either of
+---                    - {if_text} (string, default "") Inserted for nonempty
+---                                                     capture.
+---                    - {else_text} (string, default "") Inserted for empty or
+---                                                       undefined capture.
+---@return table |lsp-parser-format|
+function M.format(capture_index, capture_transform)
+  local if_text, else_text, modifier
+  if type(capture_transform) == 'table' then
+    if_text = capture_transform.if_text or ''
+    else_text = capture_transform.else_text or ''
+  elseif type(capture_transform) == 'string' then
+    modifier = capture_transform
+  end
+
+  return new({
+    type = node_type.FORMAT,
+    capture_index = capture_index,
+    modifier = modifier,
+    if_text = if_text,
+    else_text = else_text,
+  })
+end
+
+---Create new text.
+---@param esc (string) Escaped text.
+---@param raw (string|nil, default {esc}) Unescaped text.
+---
+---@return table |lsp-parser-text|
+function M.text(esc, raw)
+  return new({
+    type = node_type.TEXT,
+    esc = esc,
+    raw = raw or esc,
+  })
+end
+
+return M

--- a/runtime/lua/vim/lsp/snippet/ast.lua
+++ b/runtime/lua/vim/lsp/snippet/ast.lua
@@ -13,72 +13,69 @@ local node_type = {
 
 M.node_type = node_type
 
-local Node = {}
-function Node:__tostring()
-  local insert_text = {}
-  if self.type == node_type.SNIPPET then
-    for _, c in ipairs(self.children) do
-      table.insert(insert_text, tostring(c))
-    end
-  elseif self.type == node_type.CHOICE then
-    table.insert(insert_text, self.items[1])
-  elseif self.type == node_type.PLACEHOLDER then
-    for _, c in ipairs(self.children or {}) do
-      table.insert(insert_text, tostring(c))
-    end
-  elseif self.type == node_type.TEXT then
-    table.insert(insert_text, self.esc)
+local function empty() return "" end
+
+local Snippet = {}
+Snippet.__index = Snippet
+function Snippet:__tostring()
+  local text = {}
+  for _, c in ipairs(self.children) do
+    table.insert(text, tostring(c))
   end
-  return table.concat(insert_text, '')
+  return table.concat(text, '')
 end
-
---- @private
-local function new(t)
-  return setmetatable(t, Node)
-end
-
----Determine whether {t} is an AST-node.
----@param t table
----@return boolean
-local function is_node(t)
-  return getmetatable(t) == Node
-end
-
-M.is_node = is_node
 
 ---Create a new snippet.
 ---@param children (ast-node[]) Contents of the snippet.
 ---@return table |lsp-parser-snippet|
-function M.snippet(children)
-  return new({
+function Snippet.new(children)
+  return setmetatable({
     type = node_type.SNIPPET,
-    children = children,
-  })
+    children = children
+  }, Snippet)
 end
+
+local Tabstop = {}
+Tabstop.__index = Tabstop
+Tabstop.__tostring = empty
 
 ---Create a new tabstop.
 ---@param tabstop (number) Position of this tabstop.
 ---@param transform (table|nil) optional transform applied to the tabstop.
 ---@return table |lsp-parser-tabstop|
-function M.tabstop(tabstop, transform)
-  return new({
+function Tabstop.new(tabstop, transform)
+  return setmetatable({
     type = node_type.TABSTOP,
     tabstop = tabstop,
     transform = transform,
-  })
+  }, Tabstop)
+end
+
+local Placeholder = {}
+Placeholder.__index = Placeholder
+function Placeholder:__tostring()
+  local text = {}
+  for _, c in ipairs(self.children or {}) do
+    table.insert(text, tostring(c))
+  end
+  return table.concat(text, '')
 end
 
 ---Create a new placeholder.
 ---@param tabstop (number) Position of the placeholder.
 ---@param children (ast-node[]) Content of the placeholder.
 ---@return table |lsp-parser-placeholder|
-function M.placeholder(tabstop, children)
-  return new({
+function Placeholder.new(tabstop, children)
+  return setmetatable({
     type = node_type.PLACEHOLDER,
     tabstop = tabstop,
     children = children,
-  })
+  }, Placeholder)
 end
+
+local Variable = {}
+Variable.__index = Variable
+Variable.__tostring = empty
 
 ---Create a new variable.
 ---@param name (string) Name.
@@ -86,34 +83,44 @@ end
 ---         - (node[]) Inserted when the variable is empty.
 ---         - (transform) Applied to the variable's value.
 ---@return table |lsp-parser-variable|
-function M.variable(name, replacement)
+function Variable.new(name, replacement)
   local transform, children
   -- transform is an ast-node, children a flat list of nodes.
-  if is_node(replacement) then
+  if M.is_node(replacement) then
     transform = replacement
   else
     children = replacement
   end
 
-  return new({
+  return setmetatable({
     type = node_type.VARIABLE,
     name = name,
     transform = transform,
     children = children,
-  })
+  }, Variable)
+end
+
+local Choice = {}
+Choice.__index = Choice
+function Choice:__tostring()
+  return self.items[1]
 end
 
 ---Create a new choice.
 ---@param tabstop (number) Position of the choice.
 ---@param items (string[]) Choices.
 ---@return table |lsp-parser-choice|
-function M.choice(tabstop, items)
-  return new({
+function Choice.new(tabstop, items)
+  return setmetatable({
     type = node_type.CHOICE,
     tabstop = tabstop,
     items = items,
-  })
+  }, Choice)
 end
+
+local Transform = {}
+Transform.__index = Transform
+Transform.__tostring = empty
 
 ---Create a new transform.
 ---@param pattern (string) Regex applied to the variable/tabstop this transform
@@ -121,14 +128,18 @@ end
 ---@param format (table of Format|Text) Replacement for the regex.
 ---@param option (string|nil) Regex-options, default "".
 ---@return table |lsp-parser-transform|
-function M.transform(pattern, format, option)
-  return new({
+function Transform.new(pattern, format, option)
+  return setmetatable({
     type = node_type.TRANSFORM,
     pattern = pattern,
     format = format,
     option = option or '',
-  })
+  }, Transform)
 end
+
+local Format = {}
+Format.__index = Format
+Format.__tostring = empty
 
 ---Create a new format which either inserts the capture at {capture_index},
 ---applies a modifier to the capture or inserts {if_text} if the capture is
@@ -142,7 +153,7 @@ end
 ---                    - {else_text} (string, default "") Inserted for empty or
 ---                                                       undefined capture.
 ---@return table |lsp-parser-format|
-function M.format(capture_index, capture_transform)
+function Format.new(capture_index, capture_transform)
   local if_text, else_text, modifier
   if type(capture_transform) == 'table' then
     if_text = capture_transform.if_text or ''
@@ -151,13 +162,19 @@ function M.format(capture_index, capture_transform)
     modifier = capture_transform
   end
 
-  return new({
+  return setmetatable({
     type = node_type.FORMAT,
     capture_index = capture_index,
     modifier = modifier,
     if_text = if_text,
     else_text = else_text,
-  })
+  }, Format)
+end
+
+local Text = {}
+Text.__index = Text
+function Text:__tostring()
+  return self.esc
 end
 
 ---Create new text.
@@ -165,12 +182,27 @@ end
 ---@param raw (string|nil, default {esc}) Unescaped text.
 ---
 ---@return table |lsp-parser-text|
-function M.text(esc, raw)
-  return new({
+function Text.new(esc, raw)
+  return setmetatable({
     type = node_type.TEXT,
     esc = esc,
     raw = raw or esc,
-  })
+  }, Text)
+end
+
+M.Format = Format
+M.Text = Text
+M.Placeholder = Placeholder
+M.Transform = Transform
+M.Choice = Choice
+M.Variable = Variable
+M.Snippet = Snippet
+M.Tabstop = Tabstop
+
+local node_mts = {Format, Text, Placeholder, Transform, Choice, Variable, Snippet, Tabstop}
+
+function M.is_node(t)
+  return vim.tbl_contains(node_mts, getmetatable(t))
 end
 
 return M

--- a/runtime/lua/vim/lsp/snippet/ast.lua
+++ b/runtime/lua/vim/lsp/snippet/ast.lua
@@ -148,16 +148,16 @@ Format.__tostring = empty
 ---@param capture_transform (string | table | nil)
 ---         - (string): {capture_transform} is a modifier.
 ---         - (table): {capture_transform} can contain either of
----                    - {if_text} (string, default "") Inserted for nonempty
----                                                     capture.
----                    - {else_text} (string, default "") Inserted for empty or
----                                                       undefined capture.
+---                    - {if_text} (string) Inserted for nonempty
+---                                         capture.
+---                    - {else_text} (string) Inserted for empty or
+---                                           undefined capture.
 ---@return table |lsp-parser-format|
 function Format.new(capture_index, capture_transform)
   local if_text, else_text, modifier
   if type(capture_transform) == 'table' then
-    if_text = capture_transform.if_text or ''
-    else_text = capture_transform.else_text or ''
+    if_text = capture_transform.if_text
+    else_text = capture_transform.else_text
   elseif type(capture_transform) == 'string' then
     modifier = capture_transform
   end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1,5 +1,5 @@
 local protocol = require('vim.lsp.protocol')
-local snippet = require('vim.lsp._snippet')
+local snippet = require('vim.lsp.snippet')
 local vim = vim
 local validate = vim.validate
 local api = vim.api

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -192,10 +192,13 @@ CONFIG = {
             'rpc.lua',
             'sync.lua',
             'protocol.lua',
+            'parser.lua',
+            'ast.lua'
         ],
         'files': [
             'runtime/lua/vim/lsp',
             'runtime/lua/vim/lsp.lua',
+            'runtime/lua/vim/lsp/parser',
         ],
         'file_patterns': '*.lua',
         'fn_name_prefix': '',

--- a/test/functional/plugin/lsp/snippet_spec.lua
+++ b/test/functional/plugin/lsp/snippet_spec.lua
@@ -171,12 +171,10 @@ describe('vim.lsp.snippet.parser', function()
                 type = type.FORMAT,
                 capture_index = 1,
                 if_text = 'if_text',
-                else_text = '',
               },
               {
                 type = type.FORMAT,
                 capture_index = 1,
-                if_text = '',
                 else_text = 'else_text',
               },
               {
@@ -188,7 +186,6 @@ describe('vim.lsp.snippet.parser', function()
               {
                 type = type.FORMAT,
                 capture_index = 1,
-                if_text = '',
                 else_text = 'else_text',
               },
             },

--- a/test/functional/plugin/lsp/snippet_spec.lua
+++ b/test/functional/plugin/lsp/snippet_spec.lua
@@ -1,23 +1,24 @@
 local helpers = require('test.functional.helpers')(after_each)
-local snippet = require('vim.lsp._snippet')
+local snippet = require('vim.lsp.snippet')
+local type = snippet.ast.node_type
 
 local eq = helpers.eq
 local exec_lua = helpers.exec_lua
 
-describe('vim.lsp._snippet', function()
+describe('vim.lsp.snippet.parser', function()
   before_each(helpers.clear)
   after_each(helpers.clear)
 
   local parse = function(...)
-    return exec_lua('return require("vim.lsp._snippet").parse(...)', ...)
+    return exec_lua('return vim.lsp.snippet.parse(...)', ...)
   end
 
   it('should parse only text', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = type.SNIPPET,
       children = {
         {
-          type = snippet.NodeType.TEXT,
+          type = type.TEXT,
           raw = 'TE\\$\\}XT',
           esc = 'TE$}XT',
         },
@@ -27,14 +28,14 @@ describe('vim.lsp._snippet', function()
 
   it('should parse tabstop', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = type.SNIPPET,
       children = {
         {
-          type = snippet.NodeType.TABSTOP,
+          type = type.TABSTOP,
           tabstop = 1,
         },
         {
-          type = snippet.NodeType.TABSTOP,
+          type = type.TABSTOP,
           tabstop = 2,
         },
       },
@@ -43,35 +44,35 @@ describe('vim.lsp._snippet', function()
 
   it('should parse placeholders', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = type.SNIPPET,
       children = {
         {
-          type = snippet.NodeType.PLACEHOLDER,
+          type = type.PLACEHOLDER,
           tabstop = 1,
           children = {
             {
-              type = snippet.NodeType.PLACEHOLDER,
+              type = type.PLACEHOLDER,
               tabstop = 2,
               children = {
                 {
-                  type = snippet.NodeType.TEXT,
+                  type = type.TEXT,
                   raw = 'TE\\$\\}XT',
                   esc = 'TE$}XT',
                 },
                 {
-                  type = snippet.NodeType.TABSTOP,
+                  type = type.TABSTOP,
                   tabstop = 3,
                 },
                 {
-                  type = snippet.NodeType.TABSTOP,
+                  type = type.TABSTOP,
                   tabstop = 1,
                   transform = {
-                    type = snippet.NodeType.TRANSFORM,
+                    type = type.TRANSFORM,
                     pattern = 'regex',
                     option = 'i',
                     format = {
                       {
-                        type = snippet.NodeType.FORMAT,
+                        type = type.FORMAT,
                         capture_index = 1,
                         modifier = 'upcase',
                       },
@@ -79,7 +80,7 @@ describe('vim.lsp._snippet', function()
                   },
                 },
                 {
-                  type = snippet.NodeType.TEXT,
+                  type = type.TEXT,
                   raw = 'TE\\$\\}XT',
                   esc = 'TE$}XT',
                 },
@@ -93,35 +94,36 @@ describe('vim.lsp._snippet', function()
 
   it('should parse variables', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = type.SNIPPET,
       children = {
         {
-          type = snippet.NodeType.VARIABLE,
+          type = type.VARIABLE,
           name = 'VAR',
         },
         {
-          type = snippet.NodeType.VARIABLE,
+          type = type.VARIABLE,
           name = 'VAR',
         },
         {
-          type = snippet.NodeType.VARIABLE,
+          type = type.VARIABLE,
           name = 'VAR',
           children = {
             {
-              type = snippet.NodeType.TABSTOP,
+              type = type.TABSTOP,
               tabstop = 1,
             },
           },
         },
         {
-          type = snippet.NodeType.VARIABLE,
+          type = type.VARIABLE,
           name = 'VAR',
           transform = {
-            type = snippet.NodeType.TRANSFORM,
+            type = type.TRANSFORM,
             pattern = 'regex',
+            option = '',
             format = {
               {
-                type = snippet.NodeType.FORMAT,
+                type = type.FORMAT,
                 capture_index = 1,
                 modifier = 'upcase',
               },
@@ -134,10 +136,10 @@ describe('vim.lsp._snippet', function()
 
   it('should parse choice', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = type.SNIPPET,
       children = {
         {
-          type = snippet.NodeType.CHOICE,
+          type = type.CHOICE,
           tabstop = 1,
           items = {
             ',',
@@ -150,40 +152,41 @@ describe('vim.lsp._snippet', function()
 
   it('should parse format', function()
     eq({
-      type = snippet.NodeType.SNIPPET,
+      type = type.SNIPPET,
       children = {
         {
-          type = snippet.NodeType.VARIABLE,
+          type = type.VARIABLE,
           name = 'VAR',
           transform = {
-            type = snippet.NodeType.TRANSFORM,
+            type = type.TRANSFORM,
             pattern = 'regex',
+            option = '',
             format = {
               {
-                type = snippet.NodeType.FORMAT,
+                type = type.FORMAT,
                 capture_index = 1,
                 modifier = 'upcase',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = type.FORMAT,
                 capture_index = 1,
                 if_text = 'if_text',
                 else_text = '',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = type.FORMAT,
                 capture_index = 1,
                 if_text = '',
                 else_text = 'else_text',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = type.FORMAT,
                 capture_index = 1,
                 else_text = 'else_text',
                 if_text = 'if_text',
               },
               {
-                type = snippet.NodeType.FORMAT,
+                type = type.FORMAT,
                 capture_index = 1,
                 if_text = '',
                 else_text = 'else_text',


### PR DESCRIPTION
Hi!
I'd like to make use of neovims snippet-parser in [Luasnip](https://github.com/L3MON4D3/LuaSnip), but it's currently not public.

So far I've added a few functions that will be useful for manipulating the produced AST, but I'm not yet sure where the api should be exposed.
* `vim.snippet.parser` would be compatible with #16499, but it'd be unclear that lsp-snippets are being parsed
* `vim.lsp.snippet` or `vim.lsp.snippet_parser` will seem a bit disconnected once #16499 is merged

If this should be split up more, or needs more discussion before a PR let me know, I'll open an issue instead.