### PR TITLE
fix(ui): require window-local value to show winbar on floating windows

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7004,6 +7004,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When changing something that is used in 'winbar' that does not trigger
 	it to be updated, use |:redrawstatus|.
 
+	Floating windows do not use the global value of 'winbar'. The
+	window-local value of 'winbar' must be set for a floating window to
+	have a window bar.
+
 	This option cannot be set in a modeline when 'modelineexpr' is off.
 
 						*'winblend'* *'winbl'*

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6689,7 +6689,10 @@ static void last_status_rec(frame_T *fr, bool statusline, bool is_stl_global)
 void set_winbar(void)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    int winbar_height = (*p_wbr != NUL || *wp->w_p_wbr != NUL) ? 1 : 0;
+    // Require the local value to be set in order to show winbar on a floating window.
+    int winbar_height = wp->w_floating ? ((*wp->w_p_wbr != NUL) ? 1 : 0)
+                                       : ((*p_wbr != NUL || *wp->w_p_wbr != NUL) ? 1 : 0);
+
     if (wp->w_winbar_height != winbar_height) {
       wp->w_winbar_height = winbar_height;
       win_set_inner_size(wp);

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -23,6 +23,8 @@ describe('winbar', function()
       [5] = {bold = true, foreground = Screen.colors.Red},
       [6] = {foreground = Screen.colors.Blue},
       [7] = {background = Screen.colors.LightGrey},
+      [8] = {background = Screen.colors.LightMagenta},
+      [9] = {bold = true, foreground = Screen.colors.Blue, background = Screen.colors.LightMagenta},
     })
     meths.set_option('winbar', 'Set Up The Bars')
   end)
@@ -399,6 +401,7 @@ describe('winbar', function()
     ]])
     eq(1, meths.get_option('cmdheight'))
   end)
+
   it('properly equalizes window height for window-local value', function()
     command('set equalalways | set winbar= | setlocal winbar=a | split')
     command('setlocal winbar= | split')
@@ -418,5 +421,42 @@ describe('winbar', function()
       {2:[No Name]                                                   }|
                                                                   |
     ]])
+  end)
+
+  it('requires window-local value for floating windows', function()
+    local win = meths.open_win(0, false, { relative = 'editor', row = 2, col = 10, height = 7,
+                                           width = 30 })
+    meths.set_option_value('winbar', 'bar', {})
+    screen:expect{grid=[[
+      {1:bar                                                         }|
+      ^                                                            |
+      {3:~         }{8:                              }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+                                                                  |
+    ]]}
+    meths.set_option_value('winbar', 'floaty bar', { scope = 'local', win = win.id })
+    screen:expect{grid=[[
+      {1:bar                                                         }|
+      ^                                                            |
+      {3:~         }{1:floaty bar                    }{3:                    }|
+      {3:~         }{8:                              }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~         }{9:~                             }{3:                    }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+      {3:~                                                           }|
+                                                                  |
+    ]]}
   end)
 end)


### PR DESCRIPTION
Previously, there was a bug where setting the local value of 'winbar' to
itself would cause winbar to appear on a floating window, which is
undesirable. This fix makes it so that it's explicitly required for the
window-local value of 'winbar' for a floating window to be set in order
for winbar to be shown on that window.