### PR TITLE
ci(uncrustify): show expected formatting on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
       - if: "!cancelled()"
         name: uncrustify
         run: |
-          ${{ env.CACHE_UNCRUSTIFY }} -c ./src/uncrustify.cfg -q --check $(find ./src/nvim -name "*.[ch]") >/dev/null
+          ${{ env.CACHE_UNCRUSTIFY }} -c ./src/uncrustify.cfg -q --replace --no-backup $(find ./src/nvim -name "*.[ch]")
+          git diff --color --exit-code
 
       - if: "!cancelled()"
         name: lualint


### PR DESCRIPTION
This will make it possible to see what needs to be fixed without having uncrustify installed locally.