### PR TITLE
vim-patch:8.2.5037: cursor position may be invalid after "0;" range

### DIFF
--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -422,5 +422,13 @@ func Test_address_line_overflow()
   bwipe!
 endfunc
 
+" This was leaving the cursor in line zero
+func Test_using_zero_in_range()
+  new
+  norm o00
+  silent!  0;s/\%')
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.5037: cursor position may be invalid after "0;" range

Problem:    Cursor position may be invalid after "0;" range.
Solution:   Check the cursor position when it was set by ";" in the range.
https://github.com/vim/vim/commit/4d97a565ae8be0d4debba04ebd2ac3e75a0c8010