### PR TITLE
test: fixeol cleanup created files

### DIFF
--- a/test/functional/legacy/fixeol_spec.lua
+++ b/test/functional/legacy/fixeol_spec.lua
@@ -6,12 +6,11 @@ local clear, feed_command, expect = helpers.clear, helpers.feed_command, helpers
 
 describe('fixeol', function()
   local function rmtestfiles()
-    feed_command('%bwipeout!')
-    feed_command('call delete("test.out")')
-    feed_command('call delete("XXEol")')
-    feed_command('call delete("XXNoEol")')
-    feed_command('call delete("XXTestEol")')
-    feed_command('call delete("XXTestNoEol")')
+    os.remove("test.out")
+    os.remove("XXEol")
+    os.remove("XXNoEol")
+    os.remove("XXTestEol")
+    os.remove("XXTestNoEol")
   end
   setup(function()
     clear()


### PR DESCRIPTION
The non-sync nature of feed_command caused a race condition (they usually never got deleted) on the calls to delete, leaving the files on the root of the repo:

```
test.out
XXEol
XXNoEol
XXTestEol
XXTestNoEol
```

Just use `os.remove` and there's no need for `:bwipeout`