### PR TITLE
ci: use ubuntu-latest for vim-patches and coverity-scan

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/vim-patches.yml
+++ b/.github/workflows/vim-patches.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   update-vim-patches:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Since we're not running tests or other things that are more sensitive to changes in the VM environment, use ubuntu-latest to avoid the busy work of updating the VM image.