### PR TITLE
test: sanitize more of the test environment

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -12,6 +12,12 @@ set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)
 set(ENV{XDG_DATA_HOME} ${BUILD_DIR}/Xtest_xdg/share)
 unset(ENV{XDG_DATA_DIRS})
 
+# Test being run inside neovim :terminal unset inherited environment variables.
+if(DEFINED ENV{NVIM})
+  unset(ENV{NVIM_LOG_FILE})
+  unset(ENV{NVIM})
+endif()
+
 if(NOT DEFINED ENV{NVIM_LOG_FILE})
   set(ENV{NVIM_LOG_FILE} ${BUILD_DIR}/.nvimlog)
 endif()


### PR DESCRIPTION
Problem:

The inherited variables NVIM and NVIM_LOG_FILE create unexpected side effects. **This happens when running the test suite from inside nvim terminal**.

1. Logs from the test suite are written to the user filesystem nvim log file `/home/user/.local/state/nvim/log`, instead of the expected `build/.nvimlog` this is not ideal since we read the log to determine outcome of some tests.

2. Some test might fail because of it, like:

   `test/functional/core/job_spec.lua @ 650: jobs jobstart() environment: $NVIM, $NVIM_LISTEN_ADDRESS #11009`

Solution:

Unset nvim terminal 'parent' variables before running the test.
