### PR TITLE
ci(api-docs): run in drafts as well

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -1,7 +1,6 @@
 name: Missing API docs
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     branches-ignore:
       - 'marvim/api-doc-update**'
     paths:
@@ -11,7 +10,6 @@ on:
 
 jobs:
   call-regen-api-docs:
-    if: github.event.pull_request.draft == false
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
A contributor should be able to be sure their PR passes the CI before
clicking "Ready for review".
