### PR TITLE
refactor(api): use hashy hash for looking up api method and event names

### DIFF
--- a/src/nvim/api/private/dispatch.h
+++ b/src/nvim/api/private/dispatch.h
@@ -10,6 +10,7 @@ typedef Object (*ApiDispatchWrapper)(uint64_t channel_id,
 /// The rpc_method_handlers table, used in msgpack_rpc_dispatch(), stores
 /// functions of this type.
 typedef struct {
+  const char *name;
   ApiDispatchWrapper fn;
   bool fast;  // Function is safe to be executed immediately while running the
               // uv loop (the loop is run very frequently due to breakcheck).

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -121,7 +121,6 @@ void event_init(void)
   resize_events = multiqueue_new_child(main_loop.events);
 
   // early msgpack-rpc initialization
-  msgpack_rpc_init_method_table();
   msgpack_rpc_helpers_init();
   input_init();
   signal_init();

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "nvim/api/private/dispatch.h"
 #include "nvim/lib/khash.h"
 #include "nvim/map.h"
 #include "nvim/map_defs.h"
@@ -171,13 +170,10 @@ MAP_IMPL(uint64_t, ssize_t, SSIZE_INITIALIZER)
 MAP_IMPL(uint64_t, uint64_t, DEFAULT_INITIALIZER)
 MAP_IMPL(uint32_t, uint32_t, DEFAULT_INITIALIZER)
 MAP_IMPL(handle_T, ptr_t, DEFAULT_INITIALIZER)
-#define MSGPACK_HANDLER_INITIALIZER { .fn = NULL, .fast = false }
-MAP_IMPL(String, MsgpackRpcRequestHandler, MSGPACK_HANDLER_INITIALIZER)
 MAP_IMPL(HlEntry, int, DEFAULT_INITIALIZER)
 MAP_IMPL(String, handle_T, 0)
 MAP_IMPL(String, int, DEFAULT_INITIALIZER)
 MAP_IMPL(int, String, DEFAULT_INITIALIZER)
-MAP_IMPL(String, UIClientHandler, NULL)
 
 MAP_IMPL(ColorKey, ColorItem, COLOR_ITEM_INITIALIZER)
 

--- a/src/nvim/map.h
+++ b/src/nvim/map.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 
 #include "nvim/api/private/defs.h"
-#include "nvim/api/private/dispatch.h"
 #include "nvim/extmark_defs.h"
 #include "nvim/highlight_defs.h"
 #include "nvim/map_defs.h"
@@ -44,12 +43,10 @@ MAP_DECLS(uint64_t, uint64_t)
 MAP_DECLS(uint32_t, uint32_t)
 
 MAP_DECLS(handle_T, ptr_t)
-MAP_DECLS(String, MsgpackRpcRequestHandler)
 MAP_DECLS(HlEntry, int)
 MAP_DECLS(String, handle_T)
 MAP_DECLS(String, int)
 MAP_DECLS(int, String)
-MAP_DECLS(String, UIClientHandler)
 
 MAP_DECLS(ColorKey, ColorItem)
 

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -6,6 +6,7 @@
 #include <uv.h>
 
 #include "nvim/api/private/defs.h"
+#include "nvim/api/private/dispatch.h"
 #include "nvim/event/process.h"
 #include "nvim/event/socket.h"
 #include "nvim/vim.h"

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -3,7 +3,10 @@
 
 #include "nvim/api/private/defs.h"
 
-typedef void (*UIClientHandler)(Array args);
+typedef struct {
+  const char *name;
+  void (*fn)(Array args);
+} UIClientHandler;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui_client.h.generated.h"


### PR DESCRIPTION
This avoids generating khash tables at runtime, and is consistent with how evalfuncs lookup work.