### PR TITLE
docs(clang-format): one space in directives indent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -48,6 +48,7 @@ IncludeCategories:
 AlignConsecutiveMacros: AcrossEmptyLines
 IndentPPDirectives: AfterHash
 SpaceBeforeParens: ControlStatementsExceptControlMacros
+PPIndentWidth: 1
 ForEachMacros:
   - FOR_ALL_AUEVENTS
   - FOR_ALL_AUPATS_IN_EVENT


### PR DESCRIPTION
> The number of columns to use for indentation of preprocessor statements.
When set to -1 (default) IndentWidth is used also for preprocessor statements.

- before
  ```c
  #ifdef INCLUDE_GENERATED_DECLARATIONS
  #  include "api/vim.h.generated.h"
  #endif
  ```

- after
  ```c
  #ifdef INCLUDE_GENERATED_DECLARATIONS
  # include "api/vim.h.generated.h"
  #endif
  ```
