### PR TITLE
docs: clarify that nvim_strwidth counts control characters as one cell

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1706,7 +1706,7 @@ nvim_set_vvar({name}, {value})                               *nvim_set_vvar()*
 
 nvim_strwidth({text})                                        *nvim_strwidth()*
                 Calculates the number of display cells occupied by `text`.
-                <Tab> counts as one cell.
+                Control characters including <Tab> count as one cell.
 
                 Parameters: ~
                     {text}  Some text

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -480,7 +480,7 @@ Object nvim_notify(String msg, Integer log_level, Dictionary opts, Error *err)
 }
 
 /// Calculates the number of display cells occupied by `text`.
-/// <Tab> counts as one cell.
+/// Control characters including <Tab> count as one cell.
 ///
 /// @param text       Some text
 /// @param[out] err   Error details, if any


### PR DESCRIPTION
Close #18801