### PR TITLE
refactor(uncrustify): change config to better align with style guide

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -91,13 +91,11 @@ typedef enum {
 #  pragma function(floor)
 # endif
 
-// uncrustify:off
 PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES
 PRAGMA_DIAG_PUSH_IGNORE_IMPLICIT_FALLTHROUGH
 # include "funcs.generated.h"
 PRAGMA_DIAG_POP
 PRAGMA_DIAG_POP
-// uncrustify:on
 #endif
 
 static char *e_listblobarg = N_("E899: Argument of %s must be a List or Blob");

--- a/src/nvim/eval/typval_encode.c.h
+++ b/src/nvim/eval/typval_encode.c.h
@@ -1,3 +1,5 @@
+// uncrustify:off
+
 /// @file eval/typval_encode.c.h
 ///
 /// Contains set of macros used to convert (possibly recursive) typval_T into

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4893,13 +4893,11 @@ int buf_check_timestamp(buf_T *buf)
   char *mesg2 = "";
   bool helpmesg = false;
 
-  // uncrustify:off
   enum {
     RELOAD_NONE,
     RELOAD_NORMAL,
-    RELOAD_DETECT
+    RELOAD_DETECT,
   } reload = RELOAD_NONE;
-  // uncrustify:on
 
   bool can_reload = false;
   uint64_t orig_size = buf->b_orig_size;

--- a/src/nvim/func_attr.h
+++ b/src/nvim/func_attr.h
@@ -113,7 +113,7 @@
 // void myfunc(void) REAL_FATTR_ALWAYS_INLINE;
 #  define REAL_FATTR_MALLOC __attribute__((malloc))
 #  define REAL_FATTR_ALLOC_ALIGN(x) __attribute__((alloc_align(x)))
-#  define REAL_FATTR_PURE __attribute__ ((pure))
+#  define REAL_FATTR_PURE __attribute__((pure))
 #  define REAL_FATTR_CONST __attribute__((const))
 #  define REAL_FATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #  define REAL_FATTR_ALWAYS_INLINE __attribute__((always_inline))

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3,7 +3,7 @@
 
 // for debugging
 // #define CHECK(c, s) do { if (c) emsg(s); } while (0)
-#define CHECK(c, s) do { } while (0)
+#define CHECK(c, s) do {} while (0)
 
 /*
  * memline.c: Contains the functions for appending, deleting and changing the

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1022,7 +1022,7 @@ static int normal_execute(VimState *state, int key)
 
   s->need_flushbuf = add_to_showcmd(s->c);
 
-  while (normal_get_command_count(s)) { }
+  while (normal_get_command_count(s)) {}
 
   if (s->c == K_EVENT) {
     // Save the count values so that ca.opcount and ca.count0 are exactly

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.75.0_f
+# Uncrustify-0.75.1_f
 
 #
 # General options
@@ -7,7 +7,7 @@
 # The type of line endings.
 #
 # Default: auto
-newlines                        = auto     # lf/crlf/cr/auto
+newlines                        = lf       # lf/crlf/cr/auto
 
 # The original size of tabs in the input.
 #
@@ -335,7 +335,7 @@ sp_inside_sparen                = remove   # ignore/add/remove/force/not_defined
 # Add or remove space after '(' of control statements other than 'for'.
 #
 # Overrides sp_inside_sparen.
-sp_inside_sparen_open           = remove   # ignore/add/remove/force/not_defined
+sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before ')' of control statements other than 'for'.
 #
@@ -591,7 +591,7 @@ sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force/not_defined
 sp_inside_braces                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{}'.
-sp_inside_braces_empty          = ignore   # ignore/add/remove/force/not_defined
+sp_inside_braces_empty          = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space around trailing return operator '->'.
 sp_trailing_return              = ignore   # ignore/add/remove/force/not_defined
@@ -691,10 +691,10 @@ sp_return_paren                 = force    # ignore/add/remove/force/not_defined
 sp_return_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '__attribute__' and '('.
-sp_attribute_paren              = ignore   # ignore/add/remove/force/not_defined
+sp_attribute_paren              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
-sp_defined_paren                = ignore   # ignore/add/remove/force/not_defined
+sp_defined_paren                = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'throw' and '(' in 'throw (something)'.
 sp_throw_paren                  = ignore   # ignore/add/remove/force/not_defined
@@ -1677,7 +1677,7 @@ nl_enum_colon_type              = ignore   # ignore/add/remove/force/not_defined
 nl_struct_brace                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'union' and '{'.
-nl_union_brace                  = ignore   # ignore/add/remove/force/not_defined
+nl_union_brace                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'if' and '{'.
 nl_if_brace                     = remove   # ignore/add/remove/force/not_defined
@@ -1921,7 +1921,7 @@ nl_func_call_paren              = ignore   # ignore/add/remove/force/not_defined
 nl_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function declaration.
-nl_func_decl_start              = ignore   # ignore/add/remove/force/not_defined
+nl_func_decl_start              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function definition.
 nl_func_def_start               = remove   # ignore/add/remove/force/not_defined
@@ -3508,10 +3508,12 @@ set QUESTION                     FUNC_ATTR_PRINTF
 set QUESTION                     FUNC_ATTR_PURE
 set QUESTION                     FUNC_ATTR_UNUSED
 set QUESTION                     FUNC_ATTR_WARN_UNUSED_RESULT
+set PP_PRAGMA                    PRAGMA_DIAG_PUSH_IGNORE_IMPLICIT_FALLTHROUGH
+set PP_PRAGMA                    PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES
 set QUESTION                     REAL_FATTR_ALWAYS_INLINE
 set QUESTION                     REAL_FATTR_CONST
 set QUESTION                     REAL_FATTR_NONNULL_ALL
 set QUESTION                     REAL_FATTR_PURE
 set QUESTION                     REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 97
+# option(s) with 'not default' value: 102
 #


### PR DESCRIPTION
Change style rules:

- ~~align comments~~
- add space around `=`, `+=` ...
- other small stuff.