### PR TITLE
feat(api): add buf_execute function

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -11564,3 +11564,21 @@ static void f_xor(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->vval.v_number = tv_get_number_chk(&argvars[0], NULL)
                          ^ tv_get_number_chk(&argvars[1], NULL);
 }
+
+/// "buf_execute(win_id, command)" function
+static void f_buf_execute(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  // Return an empty string if something fails.
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = NULL;
+
+  buf_T *buf = tv_get_buf_from_arg(&argvars[0]);
+  if (buf != NULL) {
+    // rettv->vval.v_number = -1;
+    // return;
+    bufref_T save_buf;
+    switch_buffer_noblock(&save_buf, buf);
+    execute_common(argvars, rettv, fptr, 1);
+    restore_buffer(&save_buf);
+  }
+}

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7112,6 +7112,12 @@ void restore_win_noblock(switchwin_T *switchwin, bool no_display)
 void switch_buffer(bufref_T *save_curbuf, buf_T *buf)
 {
   block_autocmds();
+  switch_buffer_noblock(save_curbuf, buf);
+}
+
+// As switch_buffer() but without unblocking autocommands.
+void switch_buffer_noblock(bufref_T *save_curbuf, buf_T *buf)
+{
   set_bufref(save_curbuf, curbuf);
   curbuf->b_nwindows--;
   curbuf = buf;
@@ -7123,6 +7129,11 @@ void switch_buffer(bufref_T *save_curbuf, buf_T *buf)
 void restore_buffer(bufref_T *save_curbuf)
 {
   unblock_autocmds();
+  restore_buffer_noblock(save_curbuf);
+}
+
+// As restore_buffer() but without unblocking autocommands.
+void restore_buffer_noblock(bufref_T *save_curbuf) {
   // Check for valid buffer, just in case.
   if (bufref_valid(save_curbuf)) {
     curbuf->b_nwindows--;


### PR DESCRIPTION
Execute a command in a specific buffer.

This has not been tested yet (don't even know if this code makes sense) because the function is not being generated in `build/src/nvim/auto/funcs.generated.h` so I can't use the function inside the neovim build. I have no idea why this is happening. 
Need some help here, anyone has any idea of why this is happening?

Also, I'm not sure if this function falls into the `feat(api)` category.