### PR TITLE
fix(lsp): include cancellable in progress message table

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -40,10 +40,12 @@ local function progress_handler(_, result, ctx, _)
     if val.kind == 'begin' then
       client.messages.progress[token] = {
         title = val.title,
+        cancellable = val.cancellable,
         message = val.message,
         percentage = val.percentage,
       }
     elseif val.kind == 'report' then
+      client.messages.progress[token].cancellable = val.cancellable
       client.messages.progress[token].message = val.message
       client.messages.progress[token].percentage = val.percentage
     elseif val.kind == 'end' then


### PR DESCRIPTION
Currently the `title`, `message` and `percentage` is stored for a
progress, but there is also an optional `cancellable` that comes in with
both the `WorkDoneProgressBegin` and also `WorkDoneProgressReport`. This
change also stores that value so that a plugin can access it when they
do a lookup in `client.messages`.

The use case for me is that my server has long running progress events
that a user _might_ want to cancel. In order for my plugin to ensure the
event can be cancelled, it needs to access this value. If the value
exists, it can then grab the token and send in the cancel request.

You can see a reference to the `cancellable` fields in the spec [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgressBegin).