### PR TITLE
refactor: suppress false "redundant cast" warnings from clang-tidy

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3647,7 +3647,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
           group_len = (min_group_width - group_len) * utf_char2len(fillchar);
           memmove(t + group_len, t, (size_t)((char_u *)out_p - t));
           if (out_p + group_len >= (out_end_p + 1)) {
-            group_len = (long)(out_end_p - out_p);
+            group_len = (long)(out_end_p - out_p);  // NOLINT(google-readability-casting)
           }
           out_p += group_len;
           // }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6945,17 +6945,17 @@ static void f_readfile(typval_T *argvars, typval_T *rettv, FunPtr fptr)
          * small, to avoid repeatedly 'allocing' large and
          * 'reallocing' small. */
         if (prevsize == 0) {
-          prevsize = (long)(p - start);
+          prevsize = (long)(p - start);  // NOLINT(google-readability-casting)
         } else {
           long grow50pc = (prevsize * 3) / 2;
-          long growmin  = (long)((p - start) * 2 + prevlen);
+          long growmin  = (long)((p - start) * 2 + prevlen);  // NOLINT(google-readability-casting)
           prevsize = grow50pc > growmin ? grow50pc : growmin;
         }
         prev = xrealloc(prev, prevsize);
       }
       // Add the line part to end of "prev".
       memmove(prev + prevlen, start, p - start);
-      prevlen += (long)(p - start);
+      prevlen += (long)(p - start);  // NOLINT(google-readability-casting)
     }
   }   // while
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -557,7 +557,7 @@ void AppendToRedobuffLit(const char *str, int len)
       s--;
     }
     if (s > start) {
-      add_buff(&redobuff, start, (long)(s - start));
+      add_buff(&redobuff, start, (long)(s - start));  // NOLINT(google-readability-casting)
     }
 
     if (*s == NUL || (len >= 0 && s - str >= len)) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3778,7 +3778,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
       // flag to indicate whether prevcol equals startcol of search_hl or
       // one of the matches
       bool prevcol_hl_flag = get_prevcol_hl_flag(wp, &search_hl,
-                                                 (long)(ptr - line) - 1);
+                                                 (long)(ptr - line) - 1);  // NOLINT(google-readability-casting)
 
       // Invert at least one char, used for Visual and empty line or
       // highlight match at end of line. If it's beyond the last
@@ -3814,7 +3814,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
         if (area_attr == 0 && !has_fold) {
           // Use attributes from match with highest priority among
           // 'search_hl' and the match list.
-          get_search_match_hl(wp, &search_hl, (long)(ptr - line), &char_attr);
+          get_search_match_hl(wp, &search_hl, (long)(ptr - line), &char_attr);  // NOLINT(google-readability-casting)
         }
 
         int eol_attr = char_attr;


### PR DESCRIPTION
There casts are relevant for 32-bit builds.
