### PR TITLE
vim-patch:8.2.5046: vim_regsub() can overwrite the destination

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -10413,7 +10413,7 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, char *flags
       // - The text up to where the match is.
       // - The substituted text.
       // - The text after the match.
-      sublen = vim_regsub(&regmatch, (char_u *)sub, expr, (char_u *)tail, false, true, false);
+      sublen = vim_regsub(&regmatch, (char_u *)sub, expr, (char_u *)tail, 0, REGSUB_MAGIC);
       ga_grow(&ga, (int)((end - tail) + sublen -
                          (regmatch.endp[0] - regmatch.startp[0])));
 
@@ -10421,8 +10421,9 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, char *flags
       int i = (int)(regmatch.startp[0] - (char_u *)tail);
       memmove((char_u *)ga.ga_data + ga.ga_len, tail, (size_t)i);
       // add the substituted text
-      (void)vim_regsub(&regmatch, (char_u *)sub, expr, (char_u *)ga.ga_data
-                       + ga.ga_len + i, true, true, false);
+      (void)vim_regsub(&regmatch, (char_u *)sub, expr,
+                       (char_u *)ga.ga_data + ga.ga_len + i, sublen,
+                       REGSUB_COPY | REGSUB_MAGIC);
       ga.ga_len += i + sublen - 1;
       tail = (char *)regmatch.endp[0];
       if (*tail == NUL) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4078,7 +4078,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
           // get length of substitution part
           sublen = vim_regsub_multi(&regmatch,
                                     sub_firstlnum - regmatch.startpos[0].lnum,
-                                    (char_u *)sub, (char_u *)sub_firstline, false, p_magic, true);
+                                    (char_u *)sub, (char_u *)sub_firstline, 0,
+                                    REGSUB_BACKSLASH | (p_magic ? REGSUB_MAGIC : 0));
           // If getting the substitute string caused an error, don't do
           // the replacement.
           // Don't keep flags set by a recursive call
@@ -4118,7 +4119,8 @@ static buf_T *do_sub(exarg_T *eap, proftime_T timeout, bool do_buf_event, handle
 
           (void)vim_regsub_multi(&regmatch,
                                  sub_firstlnum - regmatch.startpos[0].lnum,
-                                 (char_u *)sub, (char_u *)new_end, true, p_magic, true);
+                                 (char_u *)sub, (char_u *)new_end, sublen,
+                                 REGSUB_COPY | REGSUB_BACKSLASH | (p_magic ? REGSUB_MAGIC : 0));
           sub_nsubs++;
           did_sub = true;
 

--- a/src/nvim/regexp_defs.h
+++ b/src/nvim/regexp_defs.h
@@ -168,4 +168,9 @@ struct regengine {
   // char_u *expr;
 };
 
+// Flags used by vim_regsub() and vim_regsub_both()
+#define REGSUB_COPY      1
+#define REGSUB_MAGIC     2
+#define REGSUB_BACKSLASH 4
+
 #endif  // NVIM_REGEXP_DEFS_H


### PR DESCRIPTION
#### vim-patch:8.2.5046: vim_regsub() can overwrite the destination

Problem:    vim_regsub() can overwrite the destination.
Solution:   Pass the destination length, give an error when it doesn't fit.
https://github.com/vim/vim/commit/4aaf3e7f4db599932d01d87e5bbcdc342cccee27