### PR TITLE
refactor(runtime): port remaining patterns from filetype.vim to filetype.lua

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1021,14 +1021,14 @@ end
 
 -- Debian Control
 function M.control(bufnr)
-  if getlines(bufnr, 1):lower():find('^Source:') then
+  if getlines(bufnr, 1):find('^Source:') then
     return 'debcontrol'
   end
 end
 
 -- Debian Copyright
 function M.copyright(bufnr)
-  if getlines(bufnr, 1):lower():find('^Format:') then
+  if getlines(bufnr, 1):find('^Format:') then
     return 'debcopyright'
   end
 end


### PR DESCRIPTION
Continuation of #18219 (see #18604).

To Do:
- [X] `*\,v setf rcs` (is that an escaped `,`?)
- [X] I added the patterns for `cmusrc` which were not part of [ftlua.txt](https://github.com/neovim/neovim/files/8806503/ftlua.txt)