### PR TITLE
feat: 'inccommand' support for :normal

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5144,6 +5144,8 @@ SignColumn	Column where |signs| are displayed.
 							*hl-IncSearch*
 IncSearch	'incsearch' highlighting; also used for the text replaced with
 		":s///c".
+							*hl-IncCursor*
+IncCursor	Cursor used by |:normal| 'inccommand' preview.
 							*hl-Substitute*
 Substitute	|:substitute| replacement text highlighting.
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -235,8 +235,8 @@ Options:
   'fillchars'   flags: "msgsep" (see 'display'), "horiz", "horizup",
                 "horizdown", "vertleft", "vertright", "verthoriz"
   'foldcolumn'  supports up to 9 dynamic/fixed columns
-  'inccommand'  shows interactive results for |:substitute|-like commands
-                and |:command-preview| commands
+  'inccommand'  shows interactive results for |:substitute|-like commands,
+                |:normal| and |:command-preview| commands
   'laststatus'  global statusline support
   'pumblend'    pseudo-transparent popupmenu
   'scrollback'

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1845,9 +1845,10 @@ module.cmds = {
   },
   {
     command='normal',
-    flags=bit.bor(RANGE, BANG, EXTRA, NEEDARG, NOTRLCOM, CTRLV, SBOXOK, CMDWIN),
+    flags=bit.bor(RANGE, BANG, EXTRA, NEEDARG, NOTRLCOM, CTRLV, SBOXOK, CMDWIN, PREVIEW),
     addr_type='ADDR_LINES',
     func='ex_normal',
+    preview_func='ex_normal_preview',
   },
   {
     command='number',

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -62,6 +62,7 @@ typedef enum {
   HLF_D,          // directories in CTRL-D listing
   HLF_E,          // error messages
   HLF_I,          // incremental search
+  HLF_IC,         // incremental cursor
   HLF_L,          // last search string
   HLF_LC,         // current search match
   HLF_M,          // "--More--" message
@@ -125,6 +126,7 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_D] = "Directory",
   [HLF_E] = "ErrorMsg",
   [HLF_I] = "IncSearch",
+  [HLF_IC] = "IncCursor",
   [HLF_L] = "Search",
   [HLF_LC] = "CurSearch",
   [HLF_M] = "MoreMsg",

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -94,6 +94,7 @@ static const char *highlight_init_both[] = {
   "DiffText     cterm=bold ctermbg=Red gui=bold guibg=Red",
   "ErrorMsg     ctermbg=DarkRed ctermfg=White guibg=Red guifg=White",
   "IncSearch    cterm=reverse gui=reverse",
+  "IncCursor    cterm=reverse gui=reverse",
   "ModeMsg      cterm=bold gui=bold",
   "NonText      ctermfg=Blue gui=bold guifg=Blue",
   "Normal       cterm=NONE gui=NONE",

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -212,10 +212,10 @@ describe('ui/cursor', function()
         if m.blinkwait then m.blinkwait = 700 end
       end
       if m.hl_id then
-          m.hl_id = 64
+          m.hl_id = 65
           m.attr = {background = Screen.colors.DarkGray}
       end
-      if m.id_lm then m.id_lm = 65 end
+      if m.id_lm then m.id_lm = 66 end
     end
 
     -- Assert the new expectation.

--- a/test/unit/viml/expressions/parser_spec.lua
+++ b/test/unit/viml/expressions/parser_spec.lua
@@ -38,6 +38,7 @@ local predefined_hl_defs = {
   DiffText=true,
   ErrorMsg=true,
   IncSearch=true,
+  IncCursor=true,
   ModeMsg=true,
   NonText=true,
   PmenuSbar=true,


### PR DESCRIPTION
Uses the new command preview protocol to implement 'inccommand' preview
support for the :normal command.

Partially addresses #11958.

Issues:
- Doesn't time-out when 'redrawtime' is exceeded
- Doesn't show cursor if it's at the end of line
- Preview with control characters can do things like change window layout, which isn't automatically reverted by Neovim