### PR TITLE
fix: checkhealth skip vim.health

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -171,6 +171,11 @@ function! s:get_healthcheck(plugin_names) abort
   for v in values(healthchecks)
     let output[v[0]] = v[1:]
   endfor
+  try
+    " vim.health is not a healthcheck, skip it
+    call remove(output, 'vim')
+  catch
+  endtry
   return output
 endfunction
 

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -41,6 +41,8 @@ M._complete = function()
   vim.tbl_map(function(f)
     unique[f] = true
   end, names)
+  -- vim.health is this file, which is not a healthcheck
+  unique['vim'] = nil
   return vim.tbl_keys(unique)
 end
 

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -5,7 +5,7 @@ local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local curbuf_contents = helpers.curbuf_contents
 local command = helpers.command
-local eq = helpers.eq
+local eq, neq = helpers.eq, helpers.neq
 local getcompletion = helpers.funcs.getcompletion
 
 describe(':checkhealth', function()
@@ -37,6 +37,7 @@ describe(':checkhealth', function()
     eq('nvim', getcompletion('nvim', 'checkhealth')[1])
     eq('provider', getcompletion('prov', 'checkhealth')[1])
     eq('vim.lsp', getcompletion('vim.ls', 'checkhealth')[1])
+    neq('vim', getcompletion('^vim', 'checkhealth')[1])  -- should not complete vim.health
   end)
 end)
 
@@ -241,6 +242,13 @@ describe('health.vim', function()
         ========================================================================
           - ERROR: No healthcheck found for "non_existent_healthcheck" plugin.
         ]])
+    end)
+
+    it("does not use vim.health as a healtcheck", function()
+      -- vim.health is not a healthcheck
+      command("checkhealth vim")
+      helpers.expect([[
+      ERROR: No healthchecks found.]])
     end)
   end)
 end)


### PR DESCRIPTION
vim.health is not a healthcheck, it's the module that provides the
reporting functions and completion to :checkhealth

Regression reported in https://github.com/neovim/neovim/pull/18720#issuecomment-1142614996

Since it finds it self produces unwanted errors:

```markdown
vim: require("vim.health").check()
========================================================================
- ERROR: Failed to run healthcheck for "vim" plugin. Exception:
  function health#check, line 20
  Vim(eval):E5108: Error executing lua [string "luaeval()"]:1: attempt to call field 'check' (a nil value)
  stack traceback:
  [string "luaeval()"]:1: in main chunk
  ```
