### PR TITLE
fix(hl): set Normal hl group sg_attr value (fixes #18024)

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -738,6 +738,8 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
   g->sg_script_ctx = current_sctx;
   g->sg_script_ctx.sc_lnum += sourcing_lnum;
 
+  g->sg_attr = hl_get_syn_attr(0, id, attrs);
+
   // 'Normal' is special
   if (STRCMP(g->sg_name_u, "NORMAL") == 0) {
     cterm_normal_fg_color = g->sg_cterm_fg;
@@ -746,10 +748,7 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
     normal_bg = g->sg_rgb_bg;
     normal_sp = g->sg_rgb_sp;
     ui_default_colors_set();
-    g->sg_attr = hl_get_syn_attr(0, id, attrs);
   } else {
-    g->sg_attr = hl_get_syn_attr(0, id, attrs);
-
     // a cursor style uses this syn_id, make sure its attribute is updated.
     if (cursor_mode_uses_syn_id(id)) {
       ui_mode_info_set();

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -746,6 +746,7 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
     normal_bg = g->sg_rgb_bg;
     normal_sp = g->sg_rgb_sp;
     ui_default_colors_set();
+    g->sg_attr = hl_get_syn_attr(0, id, attrs);
   } else {
     g->sg_attr = hl_get_syn_attr(0, id, attrs);
 

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -337,4 +337,10 @@ describe("API: set highlight", function()
       exec_capture('highlight Test_hl3'))
 
   end)
+
+  it ("correctly sets 'Normal' internal properties", function()
+    -- Normal has some special handling internally. #18024
+    meths.set_hl(0, 'Normal', {fg='#000083', bg='#0000F3'})
+    eq({foreground = 131, background = 243}, nvim("get_hl_by_name", 'Normal', true))
+  end)
 end)


### PR DESCRIPTION
Re: https://github.com/neovim/neovim/issues/18024, see [comment for reasoning](https://github.com/neovim/neovim/issues/18024#issuecomment-1143111611).
 
This is a naive patch, it fixes the listed issue but I cant make a judgement on whether the line was intentionally omitted (because "Normal is special") or just mistakenly missed, so this probably needs at least a comment from someone knowledgeable on whether this is fine or needs more investigation.