### PR TITLE
fix(lsp): adjust offset encoding in lsp.buf.rename()

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -408,13 +408,13 @@ function M.rename(new_name, options)
   local cword = vfn.expand('<cword>')
 
   ---@private
-  local function get_text_at_range(range)
+  local function get_text_at_range(range, offset_encoding)
     return vim.api.nvim_buf_get_text(
       bufnr,
       range.start.line,
-      range.start.character,
+      util._get_line_byte_from_position(bufnr, range.start, offset_encoding),
       range['end'].line,
-      range['end'].character,
+      util._get_line_byte_from_position(bufnr, range['end'], offset_encoding),
       {}
     )[1]
   end
@@ -461,9 +461,9 @@ function M.rename(new_name, options)
         if result.placeholder then
           prompt_opts.default = result.placeholder
         elseif result.start then
-          prompt_opts.default = get_text_at_range(result)
+          prompt_opts.default = get_text_at_range(result, client.offset_encoding)
         elseif result.range then
-          prompt_opts.default = get_text_at_range(result.range)
+          prompt_opts.default = get_text_at_range(result.range, client.offset_encoding)
         else
           prompt_opts.default = cword
         end


### PR DESCRIPTION
Fix a bug in lsp.buf.rename() where the range returned by the server in
textDocument/prepareRename was interpreted as a byte range directly,
instead of taking the negotiated offset encoding into account. This
caused the placeholder value in vim.ui.input to be incorrect in some
cases, for example when non-ascii characters are used earlier on the
same line.