### PR TITLE
fix(inccommand): avoid crash if callback changes inccommand option

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5872,7 +5872,7 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
   linenr_T highest_num_line = 0;
   int col_width = 0;
   // Use preview window only when inccommand=split and range is not just the current line
-  bool preview = (*p_icm != 'n') && (eap->line1 != old_cusr.lnum || eap->line2 != old_cusr.lnum);
+  bool preview = (*p_icm == 's') && (eap->line1 != old_cusr.lnum || eap->line2 != old_cusr.lnum);
 
   if (preview) {
     cmdpreview_buf = buflist_findnr(cmdpreview_bufnr);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2413,6 +2413,7 @@ static void cmdpreview_show(CommandLineState *s)
   int save_w_p_cuc = curwin->w_p_cuc;
   bool save_hls = p_hls;
   varnumber_T save_changedtick = buf_get_changedtick(curbuf);
+  bool icm_split = *p_icm == 's';  // inccommand=split
   buf_T *cmdpreview_buf;
   win_T *cmdpreview_win;
   cmdmod_T save_cmdmod = cmdmod;
@@ -2433,7 +2434,7 @@ static void cmdpreview_show(CommandLineState *s)
   cmdmod.noswapfile = true;      // Disable swap for preview buffer
 
   // Open preview buffer if inccommand=split.
-  if (*p_icm == 'n') {
+  if (!icm_split) {
     cmdpreview_bufnr = 0;
   } else if ((cmdpreview_buf = cmdpreview_open_buf()) == NULL) {
     abort();
@@ -2456,7 +2457,7 @@ static void cmdpreview_show(CommandLineState *s)
   }
 
   // If inccommand=split and preview callback returns 2, open preview window.
-  if (*p_icm != 'n' && cmdpreview_type == 2
+  if (icm_split && cmdpreview_type == 2
       && (cmdpreview_win = cmdpreview_open_win(cmdpreview_buf)) == NULL) {
     abort();
   }
@@ -2470,7 +2471,7 @@ static void cmdpreview_show(CommandLineState *s)
   }
 
   // Close preview window if it's open.
-  if (*p_icm != 'n' && cmdpreview_type == 2 && cmdpreview_win != NULL) {
+  if (icm_split && cmdpreview_type == 2 && cmdpreview_win != NULL) {
     cmdpreview_close_win();
   }
   // Clear preview highlights.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6678,7 +6678,7 @@ static bool resize_frame_for_winbar(frame_T *fr)
     frame_new_height(fp, fp->fr_height - 1, false, false);
     win_new_height(wp, wp->w_height + 1);
     frame_fix_height(wp);
-    win_comp_pos();
+    (void)win_comp_pos();
   }
 
   return true;

--- a/test/functional/ui/inccommand_user_spec.lua
+++ b/test/functional/ui/inccommand_user_spec.lua
@@ -336,4 +336,21 @@ describe("'inccommand' for user commands", function()
     feed('e')
     assert_alive()
   end)
+
+  it('no crash if preview callback changes inccommand option', function()
+    command('set inccommand=nosplit')
+    exec_lua([[
+      vim.api.nvim_create_user_command('Replace', function() end, {
+        nargs = '*',
+        preview = function()
+          vim.api.nvim_set_option('inccommand', 'split')
+          return 2
+        end,
+      })
+    ]])
+    feed(':R')
+    assert_alive()
+    feed('e')
+    assert_alive()
+  end)
 end)


### PR DESCRIPTION
clang: Result of operation is garbage or undefined
clang: Uninitialized argument value

Also check for == 's' instead of != 'n' as it is more straightforward.

Also fix another unrelated PVS warning:
PVS/V1071: Return value of win_comp_pos() is not always used