### PR TITLE
ci(provider): skip perl provider tests on macos

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -14,5 +14,7 @@ echo "Install neovim npm package"
 npm install -g neovim
 npm link neovim
 
-sudo cpanm -n Neovim::Ext || cat "$HOME/.cpanm/build.log"
-perl -W -e 'use Neovim::Ext; print $Neovim::Ext::VERSION'
+if [[ $CI_OS_NAME != osx ]]; then
+  sudo cpanm -n Neovim::Ext || cat "$HOME/.cpanm/build.log"
+  perl -W -e 'use Neovim::Ext; print $Neovim::Ext::VERSION'
+fi


### PR DESCRIPTION
```
--> Working on Eval::Safe
Fetching http://www.cpan.org/authors/id/M/MA/MATHIAS/Eval-Safe/Eval-Safe-0.02.tar.gz ... OK
! Configure failed for Eval-Safe-0.02. See /Users/runner/.cpanm/work/1654113036.13488/build.log for details.
! Installing the dependencies failed: Module 'Eval::Safe' is not installed, Module 'MsgPack::Raw' is not installed, Your Perl (5.018004) is not in the range '5.022'
```