### PR TITLE
fix(terminal): scrollback delete lines immediately

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4544,9 +4544,9 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
       check_colorcolumn(wp);
     }
   } else if (pp == &curbuf->b_p_scbk || pp == &p_scbk) {
-    if (curbuf->terminal) {
-      // Force the scrollback to take effect.
-      terminal_check_size(curbuf->terminal);
+    if (curbuf->terminal && value < old_value) {
+      // Force the scrollback to take immediate effect only when decreasing it.
+      on_scrollback_option_changed(curbuf->terminal);
     }
   } else if (pp == &curwin->w_p_nuw) {
     curwin->w_nrwidth_line_count = 0;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -233,7 +233,7 @@ Terminal *terminal_open(buf_T *buf, TerminalOptions opts)
   RESET_BINDING(curwin);
   // Reset cursor in current window.
   curwin->w_cursor = (pos_T){ .lnum = 1, .col = 0, .coladd = 0 };
-  // Intitialzie to check if the scrollback buffer has been allocated inside a TermOpen autocmd
+  // Initialize to check if the scrollback buffer has been allocated inside a TermOpen autocmd
   rv->sb_buffer = NULL;
   // Apply TermOpen autocmds _before_ configuring the scrollback buffer.
   apply_autocmds(EVENT_TERMOPEN, NULL, NULL, false, buf);
@@ -1485,8 +1485,7 @@ static void refresh_size(Terminal *term, buf_T *buf)
 
 void on_scrollback_option_changed(Terminal *term)
 {
-  // Guard against adjusting a scrollback buffer that doesn't exist yet. Which happens when the user
-  // sets the scrollback option in a TermOpen autocmd.
+  // Scrollback buffer may not exist yet, e.g. if 'scrollback' is set in a TermOpen autocmd.
   if (term->sb_buffer != NULL) {
     refresh_terminal(term);
   }

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -465,6 +465,34 @@ describe("'scrollback' option", function()
     matches((iswin() and '^27: line[ ]*$' or '^26: line[ ]*$'), eval("getline(line('w0') - 10)"))
   end)
 
+  it('deletes extra lines immediately', function()
+    -- Scrollback is 10 on screen_setup
+    local screen = thelpers.screen_setup(nil, nil, 30)
+    local lines = {}
+    for i = 1, 30 do
+      table.insert(lines, 'line'..tostring(i))
+    end
+    table.insert(lines, '')
+    feed_data(lines)
+      screen:expect([[
+        line26                        |
+        line27                        |
+        line28                        |
+        line29                        |
+        line30                        |
+        {1: }                             |
+        {3:-- TERMINAL --}                |
+      ]])
+    local term_height = 6  -- Actual terminal screen height, not the scrollback
+    -- Initial
+    local scrollback = curbufmeths.get_option('scrollback')
+    eq(scrollback + term_height, eval('line("$")'))
+    -- Reduction
+    scrollback = scrollback - 2
+    curbufmeths.set_option('scrollback', scrollback)
+    eq(scrollback + term_height, eval('line("$")'))
+  end)
+
   it('defaults to 10000 in :terminal buffers', function()
     set_fake_shell()
     command('terminal')


### PR DESCRIPTION
* `on_scrollback_option_changed` renamed to `adjust_scrollback`. The
  function name did not correspond to what it was doing. It is
  called unconditionally in every refresh of the terminal
  unrelated if the scrollback option was changed.

* new `on_scrollback_option_changed` function, which calls
  `refresh_terminal`, which then calls `adjust_scrollback`

* `terminal_check_size` is not the appropriate function to call when the
  option is changed since it only conditionally adjusts the scrollback.
  Use the new `on_scrollback_option_changed`

fixes: https://github.com/neovim/neovim/issues/15477 
I think it also fixes: https://github.com/neovim/neovim/issues/11811