### PR TITLE
ci: use python3 explicitly to fix macos warnings

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # Use default CC to avoid compilation problems when installing Python modules.
 echo "Install neovim module for Python."
-CC=cc python -m pip -q install --user --upgrade pynvim
+CC=cc python3 -m pip -q install --user --upgrade pynvim
 
 echo "Install neovim RubyGem."
 gem install --no-document --bindir "$HOME/.local/bin" --user-install --pre neovim


### PR DESCRIPTION
Fixes python2 deprecation warnings in "Setup interpreter packages"

> DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.


Testing `pynvim` compatibility with python2 should not be done in core, and there's only a provider_spec for python3 either way.
