### PR TITLE
feat(lsp): send didChangeConfiguration after init

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1117,6 +1117,10 @@ function lsp.start_client(config)
         end
       end
 
+      if next(config.settings) then
+        client.notify('workspace/didChangeConfiguration', { settings = config.settings })
+      end
+
       if config.on_init then
         local status, err = pcall(config.on_init, client, result)
         if not status then

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -116,6 +116,19 @@ function tests.basic_init()
   }
 end
 
+function tests.basic_init_did_change_configuration()
+  skeleton({
+    on_init = function(_)
+      return {
+        capabilities = {},
+      }
+    end,
+    body = function()
+      expect_notification('workspace/didChangeConfiguration', { settings = { dummy = 1 } })
+    end,
+  })
+end
+
 function tests.check_workspace_configuration()
   skeleton {
     on_init = function(_params)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -45,10 +45,10 @@ local function clear_notrace()
 end
 
 
-local function fake_lsp_server_setup(test_name, timeout_ms, options)
+local function fake_lsp_server_setup(test_name, timeout_ms, options, settings)
   exec_lua([=[
     lsp = require('vim.lsp')
-    local test_name, fixture_filename, logfile, timeout, options = ...
+    local test_name, fixture_filename, logfile, timeout, options, settings = ...
     TEST_RPC_CLIENT_ID = lsp.start_client {
       cmd_env = {
         NVIM_LOG_FILE = logfile;
@@ -79,17 +79,18 @@ local function fake_lsp_server_setup(test_name, timeout_ms, options)
         allow_incremental_sync = options.allow_incremental_sync or false;
         debounce_text_changes = options.debounce_text_changes or 0;
       };
+      settings = settings;
       on_exit = function(...)
         vim.rpcnotify(1, "exit", ...)
       end;
     }
-  ]=], test_name, fake_lsp_code, fake_lsp_logfile, timeout_ms or 1e3, options or {})
+  ]=], test_name, fake_lsp_code, fake_lsp_logfile, timeout_ms or 1e3, options or {}, settings or {})
 end
 
 local function test_rpc_server(config)
   if config.test_name then
     clear_notrace()
-    fake_lsp_server_setup(config.test_name, config.timeout_ms or 1e3, config.options)
+    fake_lsp_server_setup(config.test_name, config.timeout_ms or 1e3, config.options, config.settings)
   end
   local client = setmetatable({}, {
     __index = function(_, name)
@@ -296,6 +297,22 @@ describe('LSP', function()
           eq(table.remove(expected_handlers), {...}, "expected handler")
         end;
       }
+    end)
+
+    it('should send didChangeConfiguration after initialize if there are settings', function()
+      test_rpc_server({
+        test_name = 'basic_init_did_change_configuration',
+        on_init = function(client, _)
+          client.stop()
+        end,
+        on_exit = function(code, signal)
+          eq(0, code, 'exit code', fake_lsp_logfile)
+          eq(0, signal, 'exit signal', fake_lsp_logfile)
+        end,
+        settings = {
+          dummy = 1,
+        },
+      })
     end)
 
     it('should succeed with manual shutdown', function()


### PR DESCRIPTION
Most LSP servers require the notification to correctly load the
settings and for those who don't it doesn't cause any harm.

So far this is done in lspconfig, but with the addition of vim.lsp.start it
should be part of core. The alternative is to document that users need to add
the following snippet in their configuration:

```lua
on_init = function(client)
  if next(client.config.settings) then
    client.notify('workspace/didChangeConfiguration', { settings = client.config.settings })
  end
end
```

It is better to avoid that.
