### PR TITLE
fix(log): recursion warnings at DEBUG log-level

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -169,9 +169,9 @@ bool logmsg(int log_level, const char *context, const char *func_name, int line_
       loop_schedule_deferred(&main_loop, event_create(on_log_recursive_event, 2, arg1, line_num));
     }
     g_stats.log_skip++;
+    log_unlock();
     return false;
   }
-
   recursive = true;
   bool ret = false;
   FILE *log_file = open_log_file();


### PR DESCRIPTION
followup to #18845

Problem:
Because TUI runs in a separate thread, UI log messages can cause
"recursive log" warnings (very noticeable with LOGLVL_DBG):

    E5430: UI: :-1: recursive log!

Solution:
Call log_lock() before checking for recursion.