### PR TITLE
vim-patch:partial:cfa8f9a3f285

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1207,7 +1207,7 @@ to their previous contents.  When the '>' flag is present in 'cpoptions' then
 a line break is inserted before the appended text.
 
 5. Read-only registers ":, ". and "%
-These are '%', '#', ':' and '.'.  You can use them only with the "p", "P",
+These are '%', ':' and '.'.  You can use them only with the "p", "P",
 and ":put" commands and with CTRL-R.
 						*quote_.* *quote.* *E29*
 	".	Contains the last inserted text (the same as what is inserted

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -48,6 +48,7 @@ modes.
 			allows for nested and recursive use of mappings.
 			Note: Trailing spaces are included in the {rhs},
 			because space is a valid Normal mode command.
+			See |map-trailing-white|.
 
 						*:nore* *:norem*
 :no[remap]  {lhs} {rhs}		|mapmode-nvo|	*:no*  *:noremap* *:nor*
@@ -85,10 +86,8 @@ modes.
 			for other modes where it applies.
 			It also works when {lhs} matches the {rhs} of a
 			mapping. This is for when an abbreviation applied.
-			Note: Trailing spaces are included in the {lhs}.  This
-			unmap does NOT work: >
-				:map @@ foo
-				:unmap @@ | print
+			Note: Trailing spaces are included in the {lhs}.
+			See |map-trailing-white|.
 
 :mapc[lear]			|mapmode-nvo|		*:mapc*   *:mapclear*
 :nmapc[lear]			|mapmode-n|		*:nmapc*  *:nmapclear*
@@ -151,6 +150,24 @@ decide if "aa" or "aaa" should be mapped.  This means that after typing "aa"
 that mapping won't get expanded yet, Vim is waiting for another character.
 If you type a space, then "foo" will get inserted, plus the space.  If you
 type "a", then "bar" will get inserted.
+
+Trailing white space ~
+							*map-trailing-white*
+This unmap command does NOT work: >
+	:map @@ foo
+	:unmap @@ | print
+
+Because it tries to unmap "@@ ", including the white space before the command
+separator "|".  Other examples with trailing white space: >
+	unmap @@ 
+	unmap @@     " comment
+
+An error will be issued, which is very hard to identify, because the ending
+whitespace character in `unmap @@ ` is not visible.
+
+A generic solution is to put the command separator "|" right after the mapped
+keys.  After that white space and a comment may follow: >
+	unmap @@|    " comment
 
 
 1.2 SPECIAL ARGUMENTS					*:map-arguments*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6063,10 +6063,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	If the statusline is not updated when you want it (e.g., after setting
 	a variable that's used in an expression), you can force an update by
-	setting an option without changing its value.  Example: >
-		:let &ro = &ro
+	using `:redrawstatus`.
 
-<	A result of all digits is regarded a number for display purposes.
+	A result of all digits is regarded a number for display purposes.
 	Otherwise the result is taken as flag text and applied to the rules
 	described above.
 

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -108,12 +108,14 @@ change again.  But you can do something like this: >
 
 After this a "u" command will undo the delete command and the previous
 change.
-
+							*undo-break*
 To do the opposite, break a change into two undo blocks, in Insert mode use
 CTRL-G u.  This is useful if you want an insert command to be undoable in
 parts.  E.g., for each sentence.  |i_CTRL-G_u|
+
 Setting the value of 'undolevels' also breaks undo.  Even when the new value
-is equal to the old value.
+is equal to the old value: >
+	let &undolevels = &undolevels
 
 ==============================================================================
 4. Undo branches				*undo-branches* *undo-tree*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Apr 25
+" Last Change:	2022 Jun 03
 
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")

--- a/runtime/ftplugin/confini.vim
+++ b/runtime/ftplugin/confini.vim
@@ -1,0 +1,10 @@
+" Vim filetype plugin file
+" Language: confini
+
+" Quit if a ftplugin file was already loaded
+if exists("b:did_ftplugin")
+  finish
+endif
+
+" Use the cfg plugin, it's similar enough.
+runtime! ftplugin/cfg.vim

--- a/runtime/ftplugin/fortran.vim
+++ b/runtime/ftplugin/fortran.vim
@@ -1,6 +1,6 @@
 " Vim settings file
 " Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, 77, 66)
-" Version:	(v53) 2021 April 06
+" Version:	(v53) 2021 April 06 (updated 2022 May 22)
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
 " Usage:	For instructions, do :help fortran-plugin from Vim
 " Credits:
@@ -105,12 +105,13 @@ if !exists("b:match_words")
   let s:notselect = '\%(\<select\s\+\)\@<!'
   let s:notelse = '\%(\<end\s\+\|\<else\s\+\)\@<!'
   let s:notprocedure = '\%(\s\+procedure\>\)\@!'
+  let s:nothash = '\%(^\s*#\s*\)\@<!'
   let b:match_ignorecase = 1
   let b:match_words =
     \ '(:),' .
     \ '\<select\s*case\>:' . s:notselect. '\<case\>:\<end\s*select\>,' .
     \ s:notelse . '\<if\s*(.\+)\s*then\>:' .
-    \ '\<else\s*\%(if\s*(.\+)\s*then\)\=\>:\<end\s*if\>,'.
+    \ s:nothash . '\<else\s*\%(if\s*(.\+)\s*then\)\=\>:' . s:nothash . '\<end\s*if\>,'.
     \ 'do\s\+\(\d\+\):\%(^\s*\)\@<=\1\s,'.
     \ s:notend . '\<do\>:\<end\s*do\>,'.
     \ s:notelse . '\<where\>:\<elsewhere\>:\<end\s*where\>,'.
@@ -122,7 +123,8 @@ if !exists("b:match_words")
     \ s:notend . '\<subroutine\>:\<end\s*subroutine\>,'.
     \ s:notend . '\<function\>:\<end\s*function\>,'.
     \ s:notend . '\<module\>' . s:notprocedure . ':\<end\s*module\>,'.
-    \ s:notend . '\<program\>:\<end\s*program\>'
+    \ s:notend . '\<program\>:\<end\s*program\>,'.
+    \ '\%(^\s*\)\@<=#\s*if\%(def\|ndef\)\=\>:\%(^\s*\)\@<=#\s*\%(elif\|else\)\>:\%(^\s*\)\@<=#\s*endif\>'
 endif
 
 " File filters for :browse e

--- a/runtime/indent/confini.vim
+++ b/runtime/indent/confini.vim
@@ -1,0 +1,10 @@
+" Vim indent file
+" Language: confini
+
+" Quit if an indent file was already loaded.
+if exists("b:did_indent")
+  finish
+endif
+
+" Use the cfg indenting, it's similar enough.
+runtime! indent/cfg.vim

--- a/runtime/syntax/confini.vim
+++ b/runtime/syntax/confini.vim
@@ -1,0 +1,12 @@
+" Vim syntax file
+" Language: confini
+
+" Quit if a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" Use the cfg syntax for now, it's similar.
+runtime! syntax/cfg.vim
+
+let b:current_syntax = 'confini'


### PR DESCRIPTION
Fixes #18754

Update runtime files
https://github.com/vim/vim/commit/cfa8f9a3f285060152ebbdbf86fbc7aecf1dd756

omit:
* translations
* manual rewrite
* most doc changes (for now, @seandewar or @zeertzjq let me know if there's a specific change that is valid for Neovim, then I'll add it)