### PR TITLE
docs: specify CMAKE_BUILD_TYPE=RelWithDebInfo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After installing the dependencies, run the following command.
 
 To install to a non-default location:
 
-    make CMAKE_INSTALL_PREFIX=/full/path/
+    make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_INSTALL_PREFIX=/full/path/
     make install
 
 CMake hints for inspecting the build:


### PR DESCRIPTION
There have been complaints about the installation instructions being
inconsistent around the build type e.g.
https://github.com/neovim/neovim/issues/18670#issuecomment-1146468741.
Usr CMAKE_BUILD_TYPE for both examples in the README.
