### PR TITLE
fix(startup): nvim with --clean should not load user rplugins

### DIFF
--- a/runtime/plugin/rplugin.vim
+++ b/runtime/plugin/rplugin.vim
@@ -62,4 +62,6 @@ endfunction
 
 command! -bar UpdateRemotePlugins call remote#host#UpdateRemotePlugins()
 
-call s:LoadRemotePlugins()
+if index(v:argv, "--clean") < 0
+  call s:LoadRemotePlugins()
+endif

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -263,6 +263,8 @@ int main(int argc, char **argv)
 
   nlua_init();
 
+  TIME_MSG("init lua interpreter");
+
   if (embedded_mode) {
     const char *err;
     if (!channel_from_stdio(true, CALLBACK_READER_INIT, &err)) {


### PR DESCRIPTION
_Runtime_ rplugins such like legacy script providers are not affected by this change.