### PR TITLE
fix(diagnostic): check for negative column value

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -398,7 +398,14 @@ local function get_diagnostics(bufnr, opts, clamp)
     if not opts.lnum or d.lnum == opts.lnum then
       if clamp and vim.api.nvim_buf_is_loaded(b) then
         local line_count = buf_line_count[b] - 1
-        if d.lnum > line_count or d.end_lnum > line_count or d.lnum < 0 or d.end_lnum < 0  or d.col < 0 or d.end_col < 0 then
+        if
+          d.lnum > line_count
+          or d.end_lnum > line_count
+          or d.lnum < 0
+          or d.end_lnum < 0
+          or d.col < 0
+          or d.end_col < 0
+        then
           d = vim.deepcopy(d)
           d.lnum = math.max(math.min(d.lnum, line_count), 0)
           d.end_lnum = math.max(math.min(d.end_lnum, line_count), 0)

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -398,10 +398,12 @@ local function get_diagnostics(bufnr, opts, clamp)
     if not opts.lnum or d.lnum == opts.lnum then
       if clamp and vim.api.nvim_buf_is_loaded(b) then
         local line_count = buf_line_count[b] - 1
-        if d.lnum > line_count or d.end_lnum > line_count or d.lnum < 0 or d.end_lnum < 0 then
+        if d.lnum > line_count or d.end_lnum > line_count or d.lnum < 0 or d.end_lnum < 0  or d.col < 0 or d.end_col < 0 then
           d = vim.deepcopy(d)
           d.lnum = math.max(math.min(d.lnum, line_count), 0)
           d.end_lnum = math.max(math.min(d.end_lnum, line_count), 0)
+          d.col = math.max(d.col, 0)
+          d.end_col = math.max(d.end_col, 0)
         end
       end
       table.insert(diagnostics, d)

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -729,6 +729,19 @@ describe('vim.diagnostic', function()
         return vim.diagnostic.get_next_pos { namespace = diagnostic_ns }
       ]])
     end)
+
+    it('works with diagnostics before the start of the line', function()
+    eq({4, 0}, exec_lua [[
+    vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+        make_error('Diagnostic #1', 3, 9001, 3, 9001),
+        make_error('Diagnostic #2', 4, -1, 4, -1),
+    })
+    vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+    vim.api.nvim_win_set_cursor(0, {1, 1})
+    vim.diagnostic.goto_next { float = false }
+    return vim.diagnostic.get_next_pos { namespace = diagnostic_ns }
+    ]])
+end)
   end)
 
   describe('get_prev_pos()', function()


### PR DESCRIPTION
Some diagnostic sources have column value of `-1` and navigating between them gives this error.

```
E5108: Error executing lua /usr/share/nvim/runtime/lua/vim/diagnostic.lua:509: Error executing lua: /usr/share/nvim/runtime/lua/vim/diagnostic.lua:512:
 Column value outside range
stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        /usr/share/nvim/runtime/lua/vim/diagnostic.lua:512: in function </usr/share/nvim/runtime/lua/vim/diagnostic.lua:509>
        [C]: in function 'nvim_win_call'
        /usr/share/nvim/runtime/lua/vim/diagnostic.lua:509: in function 'goto_next'
        [string ":lua"]:1: in main chunk
stack traceback:
        [C]: in function 'nvim_win_call'
        /usr/share/nvim/runtime/lua/vim/diagnostic.lua:509: in function 'goto_next'
        [string ":lua"]:1: in main chunk
```