### PR TITLE
fix(highlight): let winhighlight use cursor

### DIFF
--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -113,6 +113,7 @@ typedef enum {
   HLF_BORDER,     // Floating window border
   HLF_WBR,        // Window bars
   HLF_WBRNC,      // Window bars of not-current windows
+  HLF_CU,         // Cursor
   HLF_COUNT,      // MUST be the last one
 } hlf_T;
 
@@ -176,6 +177,7 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_BORDER] = "FloatBorder",
   [HLF_WBR] = "WinBar",
   [HLF_WBRNC] = "WinBarNC",
+  [HLF_CU] = "Cursor",
 });
 
 EXTERN int highlight_attr[HLF_COUNT];       // Highl. attr for each context.

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -212,7 +212,7 @@ describe('ui/cursor', function()
         if m.blinkwait then m.blinkwait = 700 end
       end
       if m.hl_id then
-          m.hl_id = 64
+          m.hl_id = 60
           m.attr = {background = Screen.colors.DarkGray}
       end
       if m.id_lm then m.id_lm = 65 end


### PR DESCRIPTION
Closes #18399 

Pretty simple fix, just added a highlight definition for Cursor  and `:set winhighlight=Cursor:Cursor` no longer shows an error