### PR TITLE
perf(memory): use an arena for RPC decoding

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7893,7 +7893,8 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   uint64_t chan_id = (uint64_t)argvars[0].vval.v_number;
   const char *method = tv_get_string(&argvars[1]);
 
-  Object result = rpc_send_call(chan_id, method, args, &err);
+  ArenaMem res_mem = NULL;
+  Object result = rpc_send_call(chan_id, method, args, &res_mem, &err);
 
   if (l_provider_call_nesting) {
     current_sctx = save_current_sctx;
@@ -7928,7 +7929,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
 end:
-  api_free_object(result);
+  arena_mem_free(res_mem, NULL);
   api_clear_error(&err);
 }
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1016,10 +1016,11 @@ static int nlua_rpc(lua_State *lstate, bool request)
   }
 
   if (request) {
-    Object result = rpc_send_call(chan_id, name, args, &err);
+    ArenaMem res_mem = NULL;
+    Object result = rpc_send_call(chan_id, name, args, &res_mem, &err);
     if (!ERROR_SET(&err)) {
       nlua_push_Object(lstate, result, false);
-      api_free_object(result);
+      arena_mem_free(res_mem, NULL);
     }
   } else {
     if (!rpc_send_event(chan_id, name, args)) {

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -37,6 +37,20 @@ extern MemRealloc mem_realloc;
 extern bool entered_free_all_mem;
 #endif
 
+typedef struct consumed_blk {
+  struct consumed_blk *prev;
+} *ArenaMem;
+
+#define ARENA_ALIGN sizeof(void *)
+
+typedef struct {
+  char *cur_blk;
+  size_t pos, size;
+} Arena;
+
+// inits an empty arena. use arena_start() to actually allocate space!
+#define ARENA_EMPTY { .cur_blk = NULL, .pos = 0, .size = 0 }
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "memory.h.generated.h"
 #endif

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -9,15 +9,16 @@
 #include "nvim/api/private/dispatch.h"
 #include "nvim/event/process.h"
 #include "nvim/event/socket.h"
-#include "nvim/msgpack_rpc/unpacker.h"
 #include "nvim/vim.h"
 
 typedef struct Channel Channel;
+typedef struct Unpacker Unpacker;
 
 typedef struct {
   uint32_t request_id;
   bool returned, errored;
   Object result;
+  ArenaMem result_mem;
 } ChannelCallFrame;
 
 typedef struct {
@@ -26,6 +27,7 @@ typedef struct {
   MsgpackRpcRequestHandler handler;
   Array args;
   uint32_t request_id;
+  ArenaMem used_mem;
 } RequestEvent;
 
 typedef struct {

--- a/src/nvim/msgpack_rpc/unpacker.h
+++ b/src/nvim/msgpack_rpc/unpacker.h
@@ -9,8 +9,10 @@
 #include "mpack/object.h"
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/memory.h"
+#include "nvim/msgpack_rpc/channel_defs.h"
 
-typedef struct {
+struct Unpacker {
   mpack_parser_t parser;
   mpack_tokbuf_t reader;
 
@@ -28,7 +30,11 @@ typedef struct {
   Object error;  // error return
   Object result;  // arg list or result
   Error unpack_error;
-} Unpacker;
+
+  Arena arena;
+  // one lenght free-list of reusable blocks
+  ArenaMem reuse_blk;
+};
 
 // unrecovareble error. unpack_error should be set!
 #define unpacker_closed(p) ((p)->state < 0)

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -144,8 +144,10 @@ static void tinput_wait_enqueue(void **argv)
         Error err = ERROR_INIT;
         ADD(args, STRING_OBJ(copy_string(keys)));
         // TODO(bfredl): could be non-blocking now with paste?
-        Object result = rpc_send_call(ui_client_channel_id, "nvim_input", args, &err);
+        ArenaMem res_mem = NULL;
+        Object result = rpc_send_call(ui_client_channel_id, "nvim_input", args, &res_mem, &err);
         consumed = result.type == kObjectTypeInteger ? (size_t)result.data.integer : 0;
+        arena_mem_free(res_mem, NULL);
       } else {
         consumed = input_enqueue(keys);
       }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -229,15 +229,9 @@ void ui_refresh(void)
     p_lz = save_p_lz;
   } else {
     Array args = ARRAY_DICT_INIT;
-    Error err = ERROR_INIT;
     ADD(args, INTEGER_OBJ((int)width));
     ADD(args, INTEGER_OBJ((int)height));
-    rpc_send_call(ui_client_channel_id, "nvim_ui_try_resize", args, &err);
-
-    if (ERROR_SET(&err)) {
-      ELOG("ui_client resize: %s", err.msg);
-    }
-    api_clear_error(&err);
+    rpc_send_event(ui_client_channel_id, "nvim_ui_try_resize", args);
   }
 
   if (ext_widgets[kUIMessages]) {


### PR DESCRIPTION
drawback: tracing memory errors with ASAN is less accurate for arena allocated memory.
Therefore, to start with it will _only_ be used for Object types around serialization/deserialization exclusively. This is going to have a large impact especially when TUI is refactored as a co-prosess as all UI events will be serialized and deserialized by nvim itself.