### PR TITLE
vim-patch:8.2.5064: no test for what 8.1.0052 fixes

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2585,8 +2585,8 @@ static int vgetorpeek(bool advance)
 
         // get a character: 3. from the user - get it
         if (typebuf.tb_len == 0) {
-          // timedout may have been set while waiting for a mapping
-          // that has a <Nop> RHS.
+          // timedout may have been set if a mapping with empty RHS
+          // fully matched while longer mappings timed out.
           timedout = false;
         }
 

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -1081,4 +1081,34 @@ func Test_expr_map_escape_special()
   nunmap …
 endfunc
 
+" Testing for mapping after an <Nop> mapping is triggered on timeout.
+" Test for what patch 8.1.0052 fixes.
+func Test_map_after_timed_out_nop()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set timeout timeoutlen=400
+    inoremap ab TEST
+    inoremap a <Nop>
+  END
+  call writefile(lines, 'Xtest_map_after_timed_out_nop')
+  let buf = RunVimInTerminal('-S Xtest_map_after_timed_out_nop', #{rows: 6})
+
+  " Enter Insert mode
+  call term_sendkeys(buf, 'i')
+  " Wait for the "a" mapping to timeout
+  call term_sendkeys(buf, 'a')
+  call term_wait(buf, 500)
+  " Send "a" and wait for a period shorter than 'timeoutlen'
+  call term_sendkeys(buf, 'a')
+  call term_wait(buf, 100)
+  " Send "b", should trigger the "ab" mapping
+  call term_sendkeys(buf, 'b')
+  call WaitForAssert({-> assert_equal("TEST", term_getline(buf, 1))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_map_after_timed_out_nop')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -162,4 +162,21 @@ describe('mapping', function()
     sleep(10)
     eq('n', eval('mode()'))
   end)
+
+  it('timeout works after an <Nop> mapping is triggered on timeout vim-patch:8.1.0052', function()
+    command('set timeout timeoutlen=400')
+    command('inoremap ab TEST')
+    command('inoremap a <Nop>')
+    -- Enter Insert mode
+    feed('i')
+    -- Wait for the "a" mapping to time out
+    feed('a')
+    sleep(500)
+    -- Send "a" and wait for a period shorter than 'timeoutlen'
+    feed('a')
+    sleep(100)
+    -- Send "b", should trigger the "ab" mapping
+    feed('b')
+    expect('TEST')
+  end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.5064: no test for what 8.1.0052 fixes

Problem:    No test for what 8.1.0052 fixes.
Solution:   Add a test. (closes vim/vim#10531)
https://github.com/vim/vim/commit/3760bfddc414e4d3e1c4203db8c22e293cf08d09