### PR TITLE
fix(tui): check len in forward_simple_utf8

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -213,9 +213,7 @@ static void forward_simple_utf8(TermInput *input, TermKeyKey *key)
   while (*ptr) {
     if (*ptr == '<') {
       int n = (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
-      if (n < 0 || n >= sizeof(buf) - len) {
-        break;
-      }
+      assert(n < 0 || n >= sizeof(buf) - len);
       len += n;
     } else {
       buf[len++] = *ptr;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -213,7 +213,7 @@ static void forward_simple_utf8(TermInput *input, TermKeyKey *key)
   while (*ptr) {
     if (*ptr == '<') {
       int n = (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
-      assert(n < 0 || n >= sizeof(buf) - len);
+      assert(n >= 0 && n < sizeof(buf) - len);
       len += n;
     } else {
       buf[len++] = *ptr;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -212,7 +212,11 @@ static void forward_simple_utf8(TermInput *input, TermKeyKey *key)
 
   while (*ptr) {
     if (*ptr == '<') {
-      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
+      int n = (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
+      if (n < 0 || n >= sizeof(buf) - len) {
+        break;
+      }
+      len += n;
     } else {
       buf[len++] = *ptr;
     }

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -212,7 +212,7 @@ static void forward_simple_utf8(TermInput *input, TermKeyKey *key)
 
   while (*ptr) {
     if (*ptr == '<') {
-      int n = (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
+      int n = snprintf(buf + len, sizeof(buf) - len, "<lt>");
       assert(n >= 0 && n < sizeof(buf) - len);
       len += n;
     } else {


### PR DESCRIPTION
The return value of snprintf can become greater than the buffer size in the event a character is discarded and the operation is at the end of the buffer; in the case of the forward_simple_utf8 function, len might overflow. This PR checks for len's size and breaks if it's less than 0 or greater than or equal to the value of the size of the buffer minus len.