### PR TITLE
fix(input): allow Ctrl-C to interrupt a recursive mapping even if mapped

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2328,19 +2328,19 @@ static int vgetorpeek(bool advance)
       // try re-mapping.
       for (;;) {
         check_end_reg_executing(advance);
-        // os_breakcheck() can call input_enqueue()
-        if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & get_real_state()) {
-          ctrl_c_interrupts = false;
-        }
         // os_breakcheck() is slow, don't use it too often when
         // inside a mapping.  But call it each time for typed
         // characters.
         if (typebuf.tb_maplen) {
           line_breakcheck();
         } else {
+          // os_breakcheck() can call input_enqueue()
+          if ((mapped_ctrl_c | curbuf->b_mapped_ctrl_c) & get_real_state()) {
+            ctrl_c_interrupts = false;
+          }
           os_breakcheck();  // check for CTRL-C
+          ctrl_c_interrupts = true;
         }
-        ctrl_c_interrupts = true;
         int keylen = 0;
         if (got_int) {
           // flush all input

--- a/test/functional/editor/ctrl_c_spec.lua
+++ b/test/functional/editor/ctrl_c_spec.lua
@@ -72,4 +72,23 @@ describe("CTRL-C (mapped)", function()
       -- INSERT --                                        |
     ]])
   end)
+
+  it('interrupts recursive mapping', function()
+    command('nnoremap <C-C> <Nop>')
+    command('nmap <F2> <Ignore><F2>')
+    feed('<F2>')
+    sleep(10)
+    feed('foo<C-C>')
+    -- wait for input buffer to be flushed
+    sleep(10)
+    feed('i')
+    screen:expect([[
+      ^                                                    |
+      ~                                                   |
+      ~                                                   |
+      ~                                                   |
+      ~                                                   |
+      -- INSERT --                                        |
+    ]])
+  end)
 end)


### PR DESCRIPTION
allow Ctrl-C to interrupt a recursive mapping even if mapped