### PR TITLE
fix(eval/f_getmatches): return empty list for invalid win argument

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3214,7 +3214,7 @@ getmatches([{win}])					*getmatches()*
 		|getmatches()|.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.  If {win} is invalid,
-		`0` is returned.
+		an empty list is returned.
 		Example: >
 			:echo getmatches()
 <			[{'group': 'MyGroup1', 'pattern': 'TODO',

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -873,11 +873,11 @@ void f_getmatches(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   int i;
   win_T *win = get_optional_window(argvars, 0);
 
+  tv_list_alloc_ret(rettv, kListLenMayKnow);
   if (win == NULL) {
     return;
   }
 
-  tv_list_alloc_ret(rettv, kListLenMayKnow);
   cur = win->w_match_head;
   while (cur != NULL) {
     dict_T *dict = tv_dict_alloc();


### PR DESCRIPTION
Slight inaccuracy in v8.1.1084's port.
Like Vim, it should return [], not 0.
Ref #18890 