### PR TITLE
fix(nvim_create_user_command): make `smods` work with `nvim_cmd`

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -1241,10 +1241,12 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     }
 
     if (HAS_KEY(mods.verbose)) {
-      if (mods.verbose.type != kObjectTypeInteger || mods.verbose.data.integer <= 0) {
-        VALIDATION_ERROR("'mods.verbose' must be a non-negative Integer");
+      if (mods.verbose.type != kObjectTypeInteger) {
+        VALIDATION_ERROR("'mods.verbose' must be a Integer");
+      } else if (mods.verbose.data.integer >= 0) {
+        // Silently ignore negative integers to allow mods.verbose to be set to -1.
+        cmdinfo.verbose = mods.verbose.data.integer;
       }
-      cmdinfo.verbose = mods.verbose.data.integer;
     }
 
     bool vertical;
@@ -1256,8 +1258,10 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
         VALIDATION_ERROR("'mods.split' must be a String");
       }
 
-      if (STRCMP(mods.split.data.string.data, "aboveleft") == 0
-          || STRCMP(mods.split.data.string.data, "leftabove") == 0) {
+      if (*mods.split.data.string.data == NUL) {
+        // Empty string, do nothing.
+      } else if (STRCMP(mods.split.data.string.data, "aboveleft") == 0
+                 || STRCMP(mods.split.data.string.data, "leftabove") == 0) {
         cmdinfo.cmdmod.split |= WSP_ABOVE;
       } else if (STRCMP(mods.split.data.string.data, "belowright") == 0
                  || STRCMP(mods.split.data.string.data, "rightbelow") == 0) {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1919,7 +1919,8 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
 
   lua_pushinteger(lstate, cmdmod.tab);
   lua_setfield(lstate, -2, "tab");
-  lua_pushinteger(lstate, p_verbose);
+
+  lua_pushinteger(lstate, eap->verbose_save != -1 ? p_verbose : -1);
   lua_setfield(lstate, -2, "verbose");
 
   if (cmdmod.split & WSP_ABOVE) {
@@ -1937,9 +1938,9 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
 
   lua_pushboolean(lstate, cmdmod.split & WSP_VERT);
   lua_setfield(lstate, -2, "vertical");
-  lua_pushboolean(lstate, msg_silent != 0);
+  lua_pushboolean(lstate, eap->save_msg_silent != -1 ? (msg_silent != 0) : 0);
   lua_setfield(lstate, -2, "silent");
-  lua_pushboolean(lstate, emsg_silent != 0);
+  lua_pushboolean(lstate, eap->did_esilent);
   lua_setfield(lstate, -2, "emsg_silent");
   lua_pushboolean(lstate, eap->did_sandbox);
   lua_setfield(lstate, -2, "sandbox");

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -136,7 +136,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 0,
@@ -170,7 +170,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 0,
@@ -204,7 +204,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 0,
@@ -238,7 +238,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "botright",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 1,
@@ -272,7 +272,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 1,
@@ -306,7 +306,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 0,
@@ -352,7 +352,7 @@ describe('nvim_create_user_command', function()
         silent = false,
         split = "",
         tab = 0,
-        verbose = 0,
+        verbose = -1,
         vertical = false,
       },
       range = 0,
@@ -417,6 +417,16 @@ describe('nvim_create_user_command', function()
     matches('Invalid command name', pcall_err(exec_lua, [[
       vim.api.nvim_create_user_command('💩', 'echo "hi"', {})
     ]]))
+  end)
+
+  it('smods can be used with nvim_cmd', function()
+    exec_lua[[
+      vim.api.nvim_create_user_command('MyEcho', function(opts)
+        vim.api.nvim_cmd({ cmd = 'echo', args = { '&verbose' }, mods = opts.smods }, {})
+      end, {})
+    ]]
+
+    eq("3", meths.cmd({ cmd = 'MyEcho', mods = { verbose = 3 } }, { output = true }))
   end)
 end)
 


### PR DESCRIPTION
Closes #18876.

Fixes errors that occur when trying to use `smods` with `nvim_cmd` by setting correct default values for `verbose`, `split`, `silent` and `emsg_silent` in `smods`, and making `nvim_cmd` accept sentinel values for `verbose` and `split`.