### PR TITLE
ci(sourcehut): skip failing treesitter test

### DIFF
--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -168,6 +168,10 @@ void ui_refresh(void)
   end)
 
   it("supports caching queries", function()
+    if helpers.isCI("sourcehut") then
+        pending("FIXME: Failing test on openbsd.")
+        return
+    end
     local long_query = query:rep(100)
     local first_run = exec_lua ([[
       local before = vim.loop.hrtime()


### PR DESCRIPTION
The openbsd job keeps failing with the following output:

[  FAILED  ] test/functional/treesitter/parser_spec.lua @ 170: treesitter parser API supports caching queries
test/functional/treesitter/parser_spec.lua:188: Expected objects to be the same.
Passed in:
(boolean) false
Expected:
(boolean) true
