### PR TITLE
refactor(log): simplify log_path_init

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -11,6 +11,7 @@ set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
 set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)
 set(ENV{XDG_DATA_HOME} ${BUILD_DIR}/Xtest_xdg/share)
 unset(ENV{XDG_DATA_DIRS})
+unset(ENV{NVIM})  # Clear $NVIM in case tests are running from Nvim. #11009
 
 if(NOT DEFINED ENV{NVIM_LOG_FILE})
   set(ENV{NVIM_LOG_FILE} ${BUILD_DIR}/.nvimlog)

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -54,17 +54,11 @@ static bool log_try_create(char *fname)
 
 /// Initializes path to log file. Sets $NVIM_LOG_FILE if empty.
 ///
-/// Tries $NVIM_LOG_FILE, or falls back to $XDG_STATE_HOME/nvim/log. Path to log
-/// file is cached, so only the first call has effect, unless first call was not
-/// successful. Failed initialization indicates either a bug in expand_env()
-/// or both $NVIM_LOG_FILE and $HOME environment variables are undefined.
-///
-/// @return true if path was initialized, false otherwise.
-static bool log_path_init(void)
+/// Tries $NVIM_LOG_FILE, or falls back to $XDG_STATE_HOME/nvim/log. Failed
+/// initialization indicates either a bug in expand_env() or both $NVIM_LOG_FILE
+/// and $HOME environment variables are undefined.
+static void log_path_init(void)
 {
-  if (log_file_path[0]) {
-    return true;
-  }
   size_t size = sizeof(log_file_path);
   expand_env((char_u *)"$" LOG_FILE_ENV, (char_u *)log_file_path,
              (int)size - 1);
@@ -72,7 +66,7 @@ static bool log_path_init(void)
       || log_file_path[0] == '\0'
       || os_isdir((char_u *)log_file_path)
       || !log_try_create(log_file_path)) {
-    // Make kXDGStateHome if it does not exist.
+    // Make $XDG_STATE_HOME if it does not exist.
     char *loghome = get_xdg_home(kXDGStateHome);
     char *failed_dir = NULL;
     bool log_dir_failure = false;
@@ -91,7 +85,6 @@ static bool log_path_init(void)
     // Fall back to stderr
     if (len >= size || !log_try_create(log_file_path)) {
       log_file_path[0] = '\0';
-      return false;
     }
     os_setenv(LOG_FILE_ENV, log_file_path, true);
     if (log_dir_failure) {
@@ -100,7 +93,6 @@ static bool log_path_init(void)
     }
     XFREE_CLEAR(failed_dir);
   }
-  return true;
 }
 
 void log_init(void)
@@ -166,20 +158,16 @@ bool logmsg(int log_level, const char *context, const char *func_name, int line_
     if (!did_msg) {
       did_msg = true;
       char *arg1 = func_name ? xstrdup(func_name) : (context ? xstrdup(context) : NULL);
+      // coverity[leaked_storage]
       loop_schedule_deferred(&main_loop, event_create(on_log_recursive_event, 2, arg1, line_num));
     }
     g_stats.log_skip++;
     log_unlock();
     return false;
   }
-
   recursive = true;
   bool ret = false;
   FILE *log_file = open_log_file();
-
-  if (log_file == NULL) {
-    goto end;
-  }
 
   va_list args;
   va_start(args, fmt);
@@ -190,7 +178,7 @@ bool logmsg(int log_level, const char *context, const char *func_name, int line_
   if (log_file != stderr && log_file != stdout) {
     fclose(log_file);
   }
-end:
+
   recursive = false;
   log_unlock();
   return ret;
@@ -202,46 +190,36 @@ void log_uv_handles(void *loop)
   log_lock();
   FILE *log_file = open_log_file();
 
-  if (log_file == NULL) {
-    goto end;
-  }
-
   uv_print_all_handles(l, log_file);
 
   if (log_file != stderr && log_file != stdout) {
     fclose(log_file);
   }
-end:
+
   log_unlock();
 }
 
 /// Open the log file for appending.
 ///
-/// @return FILE* decided by log_path_init() or stderr in case of error
+/// @return Log file, or stderr on failure
 FILE *open_log_file(void)
 {
-  static bool recursive = false;
-  if (recursive) {
-    abort();
-  }
-
-  FILE *log_file = NULL;
-  recursive = true;
-  if (log_path_init()) {
-    log_file = fopen(log_file_path, "a");
-  }
-  recursive = false;
-
-  if (log_file != NULL) {
-    return log_file;
+  errno = 0;
+  if (log_file_path[0]) {
+    FILE *f = fopen(log_file_path, "a");
+    if (f != NULL) {
+      return f;
+    }
   }
 
   // May happen if:
-  //  - LOG() is called before early_init()
+  //  - fopen() failed
+  //  - LOG() is called before log_init()
   //  - Directory does not exist
   //  - File is not writable
   do_log_to_file(stderr, LOGLVL_ERR, NULL, __func__, __LINE__, true,
-                 "failed to open $" LOG_FILE_ENV ": %s", log_file_path);
+                 "failed to open $" LOG_FILE_ENV " (%s): %s",
+                 strerror(errno), log_file_path);
   return stderr;
 }
 
@@ -285,13 +263,7 @@ void log_callstack(const char *const func_name, const int line_num)
 {
   log_lock();
   FILE *log_file = open_log_file();
-  if (log_file == NULL) {
-    goto end;
-  }
-
   log_callstack_to_file(log_file, func_name, line_num);
-
-end:
   log_unlock();
 }
 #endif

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -85,6 +85,7 @@ static void log_path_init(void)
     // Fall back to stderr
     if (len >= size || !log_try_create(log_file_path)) {
       log_file_path[0] = '\0';
+      return;
     }
     os_setenv(LOG_FILE_ENV, log_file_path, true);
     if (log_dir_failure) {


### PR DESCRIPTION
Problem:
Since 22b52dd462e5 #11501, log_path_init is called in log_init, which
means it is now called at a deterministic time. So the "just in time"
complexity of log_path_init is no longer needed.

Solution:
Remove logic intended to try to "heal" partial initialization.