### PR TITLE
test(ts): skip test if C parser is not available

### DIFF
--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -70,6 +70,7 @@ describe('treesitter API', function()
   end)
 
   it('checks if vim.treesitter.get_parser tries to create a new parser on filetype change', function ()
+    if pending_c_parser(pending) then return end
     command("set filetype=c")
     -- Should not throw an error when filetype is c
     eq('c', exec_lua("return vim.treesitter.get_parser(0):lang()"))


### PR DESCRIPTION
Arbitrary description to satisfy our backport overlords.