### PR TITLE
vim-patch:8.2.5076: unnecessary code

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -990,31 +990,16 @@ int ins_typebuf(char *str, int noremap, int offset, bool nottyped, bool silent)
 /// Can be used for a character obtained by vgetc() that needs to be put back.
 /// Uses cmd_silent, KeyTyped and KeyNoremap to restore the flags belonging to
 /// the char.
+///
 /// @return the length of what was inserted
-int ins_char_typebuf(int c, int modifier)
+int ins_char_typebuf(int c, int modifiers)
 {
   char_u buf[MB_MAXBYTES * 3 + 4];
-  int len = 0;
-  if (modifier != 0) {
-    buf[0] = K_SPECIAL;
-    buf[1] = KS_MODIFIER;
-    buf[2] = (char_u)modifier;
-    buf[3] = NUL;
-    len = 3;
-  }
-  if (IS_SPECIAL(c)) {
-    buf[len] = K_SPECIAL;
-    buf[len + 1] = (char_u)K_SECOND(c);
-    buf[len + 2] = (char_u)K_THIRD(c);
-    buf[len + 3] = NUL;
-    len += 3;
-  } else {
-    char_u *end = add_char2buf(c, buf + len);
-    *end = NUL;
-    len = (int)(end - buf);
-  }
+  unsigned int len = special_to_buf(c, modifiers, true, buf);
+  assert(len < sizeof(buf));
+  buf[len] = NUL;
   (void)ins_typebuf((char *)buf, KeyNoremap, 0, !KeyTyped, cmd_silent);
-  return len;
+  return (int)len;
 }
 
 /// Return TRUE if the typeahead buffer was changed (while waiting for a

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -3440,8 +3440,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           }
         }
 
-        if ((trailcol != MAXCOL && ptr > line + trailcol && c == ' ')
-            || (leadcol != 0 && ptr < line + leadcol && c == ' ')) {
+        if (c == ' ' && ((trailcol != MAXCOL && ptr > line + trailcol)
+                         || (leadcol != 0 && ptr < line + leadcol))) {
           if (leadcol != 0 && in_multispace && ptr < line + leadcol
               && wp->w_p_lcs_chars.leadmultispace != NULL) {
             c = wp->w_p_lcs_chars.leadmultispace[multispace_pos++];
@@ -3452,7 +3452,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
             c = wp->w_p_lcs_chars.trail;
           } else if (ptr < line + leadcol && wp->w_p_lcs_chars.lead) {
             c = wp->w_p_lcs_chars.lead;
-          } else if (leadcol != 0 && c == ' ' && wp->w_p_lcs_chars.space) {
+          } else if (leadcol != 0 && wp->w_p_lcs_chars.space) {
             c = wp->w_p_lcs_chars.space;
           }
 


### PR DESCRIPTION
#### vim-patch:8.2.5076: unnecessary code

Problem:    Unnecessary code.
Solution:   Remove code and replace with function call. (closes vim/vim#10552)
https://github.com/vim/vim/commit/2e7cba347fc8b746add12aa5e0e9f6218a76c788