### PR TITLE
fix(substitute): subtract number of backslashes later

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4142,6 +4142,7 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
           // That is Vi compatible.
           for (p1 = new_end; *p1; p1++) {
             if (p1[0] == '\\' && p1[1] != NUL) {            // remove backslash
+              sublen--;  // correct the byte counts for extmark_splice()
               STRMOVE(p1, p1 + 1);
             } else if (*p1 == CAR) {
               if (u_inssub(lnum) == OK) {             // prepare for undo

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1737,10 +1737,6 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest, int des
   static char_u *eval_result = NULL;
   bool copy = flags & REGSUB_COPY;
 
-  // We need to keep track of how many backslashes we escape, so that the byte
-  // counts for `extmark_splice` are correct.
-  int num_escaped = 0;
-
   // Be paranoid...
   if ((source == NULL && expr == NULL) || dest == NULL) {
     emsg(_(e_null));
@@ -1928,7 +1924,6 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest, int des
           // later.  Used to insert a literal CR.
           default:
             if (flags & REGSUB_BACKSLASH) {
-              num_escaped += 1;
               if (copy) {
                 if (dst + 1 > dest + destlen) {
                   iemsg("vim_regsub_both(): not enough space");
@@ -2096,7 +2091,7 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest, int des
   }
 
 exit:
-  return (int)((dst - dest) + 1 - num_escaped);
+  return (int)((dst - dest) + 1);
 }
 
 /*

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -152,7 +152,6 @@ func Run_SubCmd_Tests(tests)
   for t in a:tests
     let start = line('.') + 1
     let end = start + len(t[2]) - 1
-    " TODO: why is there a one second delay the first time we get here?
     exe "normal o" . t[0]
     call cursor(start, 1)
     exe t[1]
@@ -187,7 +186,8 @@ func Test_sub_cmd_1()
 	      \ ['sSs', 's/S/\c/', ['scs']],
 	      \ ['tTt', "s/T/\<C-V>\<C-J>/", ["t\<C-V>\<C-J>t"]],
 	      \ ['U', 's/U/\L\uuUu\l\EU/', ['UuuU']],
-	      \ ['V', 's/V/\U\lVvV\u\Ev/', ['vVVv']]
+	      \ ['V', 's/V/\U\lVvV\u\Ev/', ['vVVv']],
+	      \ ['\', 's/\\/\\\\/', ['\\']]
 	      \ ]
   call Run_SubCmd_Tests(tests)
 endfunc
@@ -218,7 +218,8 @@ func Test_sub_cmd_2()
 	      \ ['sSs', 's/S/\c/', ['scs']],
 	      \ ['tTt', "s/T/\<C-V>\<C-J>/", ["t\<C-V>\<C-J>t"]],
 	      \ ['U', 's/U/\L\uuUu\l\EU/', ['UuuU']],
-	      \ ['V', 's/V/\U\lVvV\u\Ev/', ['vVVv']]
+	      \ ['V', 's/V/\U\lVvV\u\Ev/', ['vVVv']],
+	      \ ['\', 's/\\/\\\\/', ['\\']]
 	      \ ]
   call Run_SubCmd_Tests(tests)
 endfunc
@@ -672,10 +673,11 @@ func Test_nocatch_sub_failure_handling()
   endfunc
   new
   call setline(1, ['1 aaa', '2 aaa', '3 aaa'])
-  %s/aaa/\=Foo()/g
+  " need silent! to avoid a delay when entering Insert mode
+  silent! %s/aaa/\=Foo()/g
   call assert_equal(['1 0', '2 0', '3 0'], getline(1, 3))
 
-  " Trow without try-catch causes abort after the first line.
+  " Throw without try-catch causes abort after the first line.
   " We cannot test this, since it would stop executing the test script.
 
   " try/catch does not result in any changes

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -612,7 +612,15 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
 
       feed("<esc>")
-      -- replacing with escaped characters
+      -- replacing with expression register
+      feed([[:%s/b/\=5+5]])
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 };
+      }
+
+      feed("<esc>")
+      -- replacing with backslash
       feed([[:%s/b/\\]])
       check_events {
         { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 1, 1 };
@@ -620,8 +628,24 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
 
       feed("<esc>")
-      -- replacing with expression register
-      feed([[:%s/b/\=5+5]])
+      -- replacing with backslash from expression register
+      feed([[:%s/b/\='\']])
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 1, 1 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 1, 1, 0, 1, 1 };
+      }
+
+      feed("<esc>")
+      -- replacing with backslash followed by another character
+      feed([[:%s/b/\\!]])
+      check_events {
+        { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 };
+        { "test1", "bytes", 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 };
+      }
+
+      feed("<esc>")
+      -- replacing with backslash followed by another character from expression register
+      feed([[:%s/b/\='\!']])
       check_events {
         { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 };
         { "test1", "bytes", 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 };


### PR DESCRIPTION
Fix #18929

This also fixes buffer updates byte count when substituting with a backslash followed by another character from expression register. The last test I added fails without this fix:
```
[  ERROR   ] test/functional/lua/buffer_updates_spec.lua @ 569: lua: nvim_buf_attach on_bytes (without verify) handles inccomand=nosplit and substitute
test/helpers.lua:73: unexpected byte updates received.

received events:
  { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 3 };
  { "test1", "bytes", 1, 5, 0, 1, 1, 0, 2, 3, 0, 1, 1 };

expected events:
  { "test1", "bytes", 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 };
  { "test1", "bytes", 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 };
```