### PR TITLE
fix(tui): fix piping output make nvim unusable

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -514,7 +514,7 @@ void ui_flush(void)
     api_free_array(style);
     pending_mode_info_update = false;
   }
-  if (pending_mode_update) {
+  if (pending_mode_update && !starting) {
     char *full_name = shape_table[ui_mode_idx].full_name;
     ui_call_mode_change(cstr_as_string(full_name), ui_mode_idx);
     pending_mode_update = false;


### PR DESCRIPTION
As discussed in the issue, ui_call_mode_change() should not be called when starting is true.

This will close #18470