### PR TITLE
vim-patch:8.2.{5079,5081,5083}

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1982,12 +1982,15 @@ function Test_dirchanged_global()
   exe 'lcd ' .. fnameescape(s:dir_bar)
   call assert_equal(expected, s:li)
 
+  let save_shellslash = &shellslash
+  set shellslash
   exe 'cd ' .. s:dir_foo
   exe 'cd ' .. s:dir_bar
   autocmd! test_dirchanged DirChanged global let g:result = expand("<afile>")
   cd -
   call assert_equal(s:dir_foo, g:result)
 
+  let &shellslash = save_shellslash
   call s:After_test_dirchanged()
 endfunc
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1981,6 +1981,13 @@ function Test_dirchanged_global()
   call assert_equal(expected, s:li)
   exe 'lcd ' .. fnameescape(s:dir_bar)
   call assert_equal(expected, s:li)
+
+  exe 'cd ' .. s:dir_foo
+  exe 'cd ' .. s:dir_bar
+  autocmd! test_dirchanged DirChanged global let g:result = expand("<afile>")
+  cd -
+  call assert_equal(s:dir_foo, g:result)
+
   call s:After_test_dirchanged()
 endfunc
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1982,15 +1982,12 @@ function Test_dirchanged_global()
   exe 'lcd ' .. fnameescape(s:dir_bar)
   call assert_equal(expected, s:li)
 
-  let save_shellslash = &shellslash
-  set shellslash
   exe 'cd ' .. s:dir_foo
   exe 'cd ' .. s:dir_bar
   autocmd! test_dirchanged DirChanged global let g:result = expand("<afile>")
   cd -
-  call assert_equal(s:dir_foo, g:result)
+  call assert_equal(s:dir_foo, substitute(g:result, '\\', '/', 'g'))
 
-  let &shellslash = save_shellslash
   call s:After_test_dirchanged()
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.5079: DirChanged autocommand may use freed memory

Problem:    DirChanged autocommand may use freed memory. (Shane-XB Qian)
Solution:   Free the memory later.
https://github.com/vim/vim/commit/d8c9d32c8932e93008bfd4e8828ed42f4e9f8315

Code change is N/A as Nvim gets the full current directory again before
applying the autocommand, so this just ports the tests.


#### vim-patch:8.2.5081: autocmd test fails on MS-Windows

Problem:    Autocmd test fails on MS-Windows.
Solution:   Set shellslash to get forward slashes.
https://github.com/vim/vim/commit/7c0d0c3c75151e716184397a41ff74ab0429db5a


#### vim-patch:8.2.5083: autocmd test still fails on MS-Windows

Problem:    Autocmd test still fails on MS-Windows.
Solution:   Change backward to forward slashes.
https://github.com/vim/vim/commit/db77c49401145d76441fbb3d22a1d7d987681c13