### PR TITLE
feat(lsp): add WARN logs for spawn failures and non-OK exits

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -965,6 +965,7 @@ function lsp.start_client(config)
     changetracking.reset(client_id)
     if code ~= 0 or (signal ~= 0 and signal ~= 15) then
       local msg = string.format('Client %s quit with exit code %s and signal %s', client_id, code, signal)
+      log.warn(log_prefix, msg)
       vim.schedule(function()
         vim.notify(msg, vim.log.levels.WARN)
       end)

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -340,6 +340,7 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
       else
         msg = msg .. string.format(' with error message: %s', pid)
       end
+      log.warn(msg)
       vim.notify(msg, vim.log.levels.WARN)
       return
     end


### PR DESCRIPTION
These are currently only presented in the UI via `vim.notify`, I think it'd make sense to capture these in the LSP client log file as well.