### PR TITLE
fix: make `inccommand=split` not abort when there's not enough room

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2325,19 +2325,9 @@ static buf_T *cmdpreview_open_buf(void)
 static win_T *cmdpreview_open_win(buf_T *cmdpreview_buf)
 {
   win_T *save_curwin = curwin;
-  bool win_found = false;
 
-  // Try to find an existing preview window.
-  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (wp->w_buffer == cmdpreview_buf) {
-      win_enter(wp, false);
-      win_found = true;
-      break;
-    }
-  }
-
-  // If an existing window is not found, create one.
-  if (!win_found && win_split((int)p_cwh, WSP_BOT) == FAIL) {
+  // Open preview window.
+  if (win_split((int)p_cwh, WSP_BOT) == FAIL) {
     return NULL;
   }
 
@@ -2459,7 +2449,8 @@ static void cmdpreview_show(CommandLineState *s)
   // If inccommand=split and preview callback returns 2, open preview window.
   if (icm_split && cmdpreview_type == 2
       && (cmdpreview_win = cmdpreview_open_win(cmdpreview_buf)) == NULL) {
-    abort();
+    // If there's not enough room to open the preview window, just preview without the window.
+    cmdpreview_type = 1;
   }
 
   // If preview callback is nonzero, update screen now.

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2051,6 +2051,16 @@ describe("'inccommand' split windows", function()
     end
   end)
 
+  it("don't open if there's not enough room", function()
+    refresh()
+    screen:try_resize(40, 3)
+    feed("gg:%s/tw")
+    screen:expect([[
+      Inc substitution on                     |
+      {12:tw}o lines                               |
+      :%s/tw^                                  |
+    ]])
+  end)
 end)
 
 describe("'inccommand' with 'gdefault'", function()


### PR DESCRIPTION
Command preview now behaves like `inccommand=nosplit` when there's not
enough room for the preview window to be opened instead of aborting,
which is consistent with old behavior of `'inccommand'`.