### PR TITLE
fix(inccommand): never preview if parsing command failed

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2381,11 +2381,12 @@ static void cmdpreview_show(CommandLineState *s)
   // Copy the command line so we can modify it.
   char *cmdline = xstrdup((char *)ccline.cmdbuff);
   char *errormsg = NULL;
-
-  parse_cmdline(cmdline, &ea, &cmdinfo, &errormsg);
-  if (errormsg != NULL) {
+  emsg_off++;  // Block errors when parsing the command line, and don't update v:errmsg
+  if (!parse_cmdline(cmdline, &ea, &cmdinfo, &errormsg)) {
+    emsg_off--;
     goto end;
   }
+  emsg_off--;
 
   // Swap invalid command range if needed
   if ((ea.argt & EX_RANGE) && ea.line1 > ea.line2) {
@@ -2409,7 +2410,8 @@ static void cmdpreview_show(CommandLineState *s)
   cmdmod_T save_cmdmod = cmdmod;
 
   cmdpreview = true;
-  emsg_silent++;                 // Block error reporting as the command may be incomplete
+  emsg_silent++;                 // Block error reporting as the command may be incomplete,
+                                 // but still update v:errmsg
   msg_silent++;                  // Block messages, namely ones that prompt
   block_autocmds();              // Block events
   garray_T save_view;

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2947,6 +2947,32 @@ it(':substitute with inccommand, allows :redraw before first separator is typed 
   ]])
 end)
 
+it(':substitute with inccommand, does nothing if range contains invalid marks', function()
+  local screen = Screen.new(30, 6)
+  clear()
+  command('set undolevels=-1')
+  common_setup(screen, 'split', 'test')
+  feed([[:'a,'bs]])
+  screen:expect([[
+    test                          |
+    {15:~                             }|
+    {15:~                             }|
+    {15:~                             }|
+    {15:~                             }|
+    :'a,'bs^                       |
+  ]])
+  feed('/')
+  screen:expect([[
+    test                          |
+    {15:~                             }|
+    {15:~                             }|
+    {15:~                             }|
+    {15:~                             }|
+    :'a,'bs/^                      |
+  ]])
+  eq('', eval('v:errmsg'))
+end)
+
 it(":substitute doesn't crash with inccommand, if undo is empty #12932", function()
   local screen = Screen.new(10,5)
   clear()


### PR DESCRIPTION
`errormsg` is not always set when parsing the command failed (e.g. when
the range contains invalid marks). Check the return value is better.
