### PR TITLE
build(lint): fix lintuncrustify

### DIFF
--- a/cmake/RunUncrustify.cmake
+++ b/cmake/RunUncrustify.cmake
@@ -1,5 +1,16 @@
 # HACK: This script is invoked with "cmake -P …" as a workaround to silence uncrustify.
 
+# Split space-separated string into a cmake list, so that execute_process()
+# will pass each file as individual arg to uncrustify.
+string(REPLACE " " ";" NVIM_SOURCES ${NVIM_SOURCES})
+string(REPLACE " " ";" NVIM_HEADERS ${NVIM_HEADERS})
+
 execute_process(
-  COMMAND ${UNCRUSTIFY_PRG} -c "${PROJECT_SOURCE_DIR}/src/uncrustify.cfg" -q --check ${LINT_NVIM_SOURCES}
-  OUTPUT_QUIET)
+  COMMAND ${UNCRUSTIFY_PRG} -c "${PROJECT_SOURCE_DIR}/src/uncrustify.cfg" -q --check ${NVIM_SOURCES} ${NVIM_HEADERS}
+  OUTPUT_VARIABLE crusty_out
+  ERROR_VARIABLE crusty_err
+  RESULT_VARIABLE crusty_res)
+
+if(NOT crusty_res EQUAL 0)
+  message(FATAL_ERROR "crusty: ${crusty_res} ${crusty_err}")
+endif()

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -808,9 +808,10 @@ def_cmd_target(lintuncrustify ${UNCRUSTIFY_PRG} UNCRUSTIFY_PRG false)  # Non-fat
 if(UNCRUSTIFY_PRG)
   add_custom_command(OUTPUT lintuncrustify-cmd APPEND
     COMMAND ${CMAKE_COMMAND}
-      -DUNCRUSTIFY_PRG=${UNCRUSTIFY_PRG}
-      -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
-      -DLINT_NVIM_SOURCES=${LINT_NVIM_SOURCES}
+      -D UNCRUSTIFY_PRG=${UNCRUSTIFY_PRG}
+      -D PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
+      -D NVIM_SOURCES="${NVIM_SOURCES}"
+      -D NVIM_HEADERS="${NVIM_HEADERS}"
       -P ${PROJECT_SOURCE_DIR}/cmake/RunUncrustify.cmake)
 endif()
 


### PR DESCRIPTION
Problem:
lintuncrustify doesn't actually do anything.

Solution:
- Fix the parameters.
- Fail correctly on nonzero result.

followup to #18940