### PR TITLE
vim-patch:8.2.{1897,1898,5088}

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -284,8 +284,6 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
 {
   exarg_T ea;
   memset(&ea, 0, sizeof(ea));
-  ea.verbose_save = -1;
-  ea.save_msg_silent = -1;
 
   CmdParseInfo cmdinfo;
   memset(&cmdinfo, 0, sizeof(cmdinfo));
@@ -514,9 +512,9 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     if (HAS_KEY(mods.verbose)) {
       if (mods.verbose.type != kObjectTypeInteger) {
         VALIDATION_ERROR("'mods.verbose' must be a Integer");
-      } else if (mods.verbose.data.integer >= 0) {
+      } else if ((int)mods.verbose.data.integer >= 0) {
         // Silently ignore negative integers to allow mods.verbose to be set to -1.
-        cmdinfo.verbose = mods.verbose.data.integer;
+        cmdinfo.verbose = (int)mods.verbose.data.integer;
       }
     }
 
@@ -662,7 +660,7 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
     kv_printf(cmdline, "%dtab ", cmdinfo->cmdmod.tab - 1);
   }
   if (cmdinfo->verbose != -1) {
-    kv_printf(cmdline, "%ldverbose ", cmdinfo->verbose);
+    kv_printf(cmdline, "%dverbose ", cmdinfo->verbose);
   }
 
   if (cmdinfo->emsg_silent) {

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -222,27 +222,27 @@ Dictionary nvim_parse_cmd(String str, Dictionary opts, Error *err)
   PUT(mods, "emsg_silent", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_ERRSILENT));
   PUT(mods, "sandbox", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_SANDBOX));
   PUT(mods, "noautocmd", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_NOAUTOCMD));
-  PUT(mods, "tab", INTEGER_OBJ(cmdinfo.cmdmod.tab));
+  PUT(mods, "tab", INTEGER_OBJ(cmdinfo.cmdmod.cmod_tab));
   PUT(mods, "verbose", INTEGER_OBJ(cmdinfo.verbose));
-  PUT(mods, "browse", BOOLEAN_OBJ(cmdinfo.cmdmod.browse));
-  PUT(mods, "confirm", BOOLEAN_OBJ(cmdinfo.cmdmod.confirm));
-  PUT(mods, "hide", BOOLEAN_OBJ(cmdinfo.cmdmod.hide));
-  PUT(mods, "keepalt", BOOLEAN_OBJ(cmdinfo.cmdmod.keepalt));
-  PUT(mods, "keepjumps", BOOLEAN_OBJ(cmdinfo.cmdmod.keepjumps));
-  PUT(mods, "keepmarks", BOOLEAN_OBJ(cmdinfo.cmdmod.keepmarks));
-  PUT(mods, "keeppatterns", BOOLEAN_OBJ(cmdinfo.cmdmod.keeppatterns));
-  PUT(mods, "lockmarks", BOOLEAN_OBJ(cmdinfo.cmdmod.lockmarks));
-  PUT(mods, "noswapfile", BOOLEAN_OBJ(cmdinfo.cmdmod.noswapfile));
-  PUT(mods, "vertical", BOOLEAN_OBJ(cmdinfo.cmdmod.split & WSP_VERT));
+  PUT(mods, "browse", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_BROWSE));
+  PUT(mods, "confirm", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_CONFIRM));
+  PUT(mods, "hide", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_HIDE));
+  PUT(mods, "keepalt", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPALT));
+  PUT(mods, "keepjumps", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPJUMPS));
+  PUT(mods, "keepmarks", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPMARKS));
+  PUT(mods, "keeppatterns", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_KEEPPATTERNS));
+  PUT(mods, "lockmarks", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_LOCKMARKS));
+  PUT(mods, "noswapfile", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_NOSWAPFILE));
+  PUT(mods, "vertical", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_split & WSP_VERT));
 
   const char *split;
-  if (cmdinfo.cmdmod.split & WSP_BOT) {
+  if (cmdinfo.cmdmod.cmod_split & WSP_BOT) {
     split = "botright";
-  } else if (cmdinfo.cmdmod.split & WSP_TOP) {
+  } else if (cmdinfo.cmdmod.cmod_split & WSP_TOP) {
     split = "topleft";
-  } else if (cmdinfo.cmdmod.split & WSP_BELOW) {
+  } else if (cmdinfo.cmdmod.cmod_split & WSP_BELOW) {
     split = "belowright";
-  } else if (cmdinfo.cmdmod.split & WSP_ABOVE) {
+  } else if (cmdinfo.cmdmod.cmod_split & WSP_ABOVE) {
     split = "aboveleft";
   } else {
     split = "";
@@ -516,7 +516,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
       if (mods.tab.type != kObjectTypeInteger || mods.tab.data.integer < 0) {
         VALIDATION_ERROR("'mods.tab' must be a non-negative Integer");
       }
-      cmdinfo.cmdmod.tab = (int)mods.tab.data.integer + 1;
+      cmdinfo.cmdmod.cmod_tab = (int)mods.tab.data.integer + 1;
     }
 
     if (HAS_KEY(mods.verbose)) {
@@ -530,7 +530,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
 
     bool vertical;
     OBJ_TO_BOOL(vertical, mods.vertical, false, "'mods.vertical'");
-    cmdinfo.cmdmod.split |= (vertical ? WSP_VERT : 0);
+    cmdinfo.cmdmod.cmod_split |= (vertical ? WSP_VERT : 0);
 
     if (HAS_KEY(mods.split)) {
       if (mods.split.type != kObjectTypeString) {
@@ -541,14 +541,14 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
         // Empty string, do nothing.
       } else if (STRCMP(mods.split.data.string.data, "aboveleft") == 0
                  || STRCMP(mods.split.data.string.data, "leftabove") == 0) {
-        cmdinfo.cmdmod.split |= WSP_ABOVE;
+        cmdinfo.cmdmod.cmod_split |= WSP_ABOVE;
       } else if (STRCMP(mods.split.data.string.data, "belowright") == 0
                  || STRCMP(mods.split.data.string.data, "rightbelow") == 0) {
-        cmdinfo.cmdmod.split |= WSP_BELOW;
+        cmdinfo.cmdmod.cmod_split |= WSP_BELOW;
       } else if (STRCMP(mods.split.data.string.data, "topleft") == 0) {
-        cmdinfo.cmdmod.split |= WSP_TOP;
+        cmdinfo.cmdmod.cmod_split |= WSP_TOP;
       } else if (STRCMP(mods.split.data.string.data, "botright") == 0) {
-        cmdinfo.cmdmod.split |= WSP_BOT;
+        cmdinfo.cmdmod.cmod_split |= WSP_BOT;
       } else {
         VALIDATION_ERROR("Invalid value for 'mods.split'");
       }
@@ -558,15 +558,15 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     OBJ_TO_CMOD_FLAG(CMOD_ERRSILENT, mods.emsg_silent, false, "'mods.emsg_silent'");
     OBJ_TO_CMOD_FLAG(CMOD_SANDBOX, mods.sandbox, false, "'mods.sandbox'");
     OBJ_TO_CMOD_FLAG(CMOD_NOAUTOCMD, mods.noautocmd, false, "'mods.noautocmd'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.browse, mods.browse, false, "'mods.browse'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.confirm, mods.confirm, false, "'mods.confirm'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.hide, mods.hide, false, "'mods.hide'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.keepalt, mods.keepalt, false, "'mods.keepalt'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.keepjumps, mods.keepjumps, false, "'mods.keepjumps'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.keepmarks, mods.keepmarks, false, "'mods.keepmarks'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.keeppatterns, mods.keeppatterns, false, "'mods.keeppatterns'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.lockmarks, mods.lockmarks, false, "'mods.lockmarks'");
-    OBJ_TO_BOOL(cmdinfo.cmdmod.noswapfile, mods.noswapfile, false, "'mods.noswapfile'");
+    OBJ_TO_CMOD_FLAG(CMOD_BROWSE, mods.browse, false, "'mods.browse'");
+    OBJ_TO_CMOD_FLAG(CMOD_CONFIRM, mods.confirm, false, "'mods.confirm'");
+    OBJ_TO_CMOD_FLAG(CMOD_HIDE, mods.hide, false, "'mods.hide'");
+    OBJ_TO_CMOD_FLAG(CMOD_KEEPALT, mods.keepalt, false, "'mods.keepalt'");
+    OBJ_TO_CMOD_FLAG(CMOD_KEEPJUMPS, mods.keepjumps, false, "'mods.keepjumps'");
+    OBJ_TO_CMOD_FLAG(CMOD_KEEPMARKS, mods.keepmarks, false, "'mods.keepmarks'");
+    OBJ_TO_CMOD_FLAG(CMOD_KEEPPATTERNS, mods.keeppatterns, false, "'mods.keeppatterns'");
+    OBJ_TO_CMOD_FLAG(CMOD_LOCKMARKS, mods.lockmarks, false, "'mods.lockmarks'");
+    OBJ_TO_CMOD_FLAG(CMOD_NOSWAPFILE, mods.noswapfile, false, "'mods.noswapfile'");
 
     if ((cmdinfo.cmdmod.cmod_flags & CMOD_SANDBOX) && !(ea.argt & EX_SBOXOK)) {
       VALIDATION_ERROR("Command cannot be run in sandbox");
@@ -667,8 +667,8 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
   StringBuilder cmdline = KV_INITIAL_VALUE;
 
   // Add command modifiers
-  if (cmdinfo->cmdmod.tab != 0) {
-    kv_printf(cmdline, "%dtab ", cmdinfo->cmdmod.tab - 1);
+  if (cmdinfo->cmdmod.cmod_tab != 0) {
+    kv_printf(cmdline, "%dtab ", cmdinfo->cmdmod.cmod_tab - 1);
   }
   if (cmdinfo->verbose != -1) {
     kv_printf(cmdline, "%dverbose ", cmdinfo->verbose);
@@ -680,7 +680,7 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
     kv_concat(cmdline, "silent ");
   }
 
-  switch (cmdinfo->cmdmod.split & (WSP_ABOVE | WSP_BELOW | WSP_TOP | WSP_BOT)) {
+  switch (cmdinfo->cmdmod.cmod_split & (WSP_ABOVE | WSP_BELOW | WSP_TOP | WSP_BOT)) {
   case WSP_ABOVE:
     kv_concat(cmdline, "aboveleft ");
     break;
@@ -704,18 +704,18 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
     } \
   } while (0)
 
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.split & WSP_VERT, "vertical ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_split & WSP_VERT, "vertical ");
   CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_SANDBOX, "sandbox ");
   CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_NOAUTOCMD, "noautocmd ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.browse, "browse ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.confirm, "confirm ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.hide, "hide ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.keepalt, "keepalt ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.keepjumps, "keepjumps ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.keepmarks, "keepmarks ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.keeppatterns, "keeppatterns ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.lockmarks, "lockmarks ");
-  CMDLINE_APPEND_IF(cmdinfo->cmdmod.noswapfile, "noswapfile ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_BROWSE, "browse ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_CONFIRM, "confirm ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_HIDE, "hide ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_KEEPALT, "keepalt ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_KEEPJUMPS, "keepjumps ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_KEEPMARKS, "keepmarks ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_KEEPPATTERNS, "keeppatterns ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_LOCKMARKS, "lockmarks ");
+  CMDLINE_APPEND_IF(cmdinfo->cmdmod.cmod_flags & CMOD_NOSWAPFILE, "noswapfile ");
 #undef CMDLINE_APPEND_IF
 
   // Command range / count.

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -223,7 +223,7 @@ Dictionary nvim_parse_cmd(String str, Dictionary opts, Error *err)
   PUT(mods, "sandbox", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_SANDBOX));
   PUT(mods, "noautocmd", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_NOAUTOCMD));
   PUT(mods, "tab", INTEGER_OBJ(cmdinfo.cmdmod.cmod_tab));
-  PUT(mods, "verbose", INTEGER_OBJ(cmdinfo.verbose));
+  PUT(mods, "verbose", INTEGER_OBJ(cmdinfo.cmdmod.cmod_verbose - 1));
   PUT(mods, "browse", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_BROWSE));
   PUT(mods, "confirm", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_CONFIRM));
   PUT(mods, "hide", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_flags & CMOD_HIDE));
@@ -287,7 +287,6 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
 
   CmdParseInfo cmdinfo;
   memset(&cmdinfo, 0, sizeof(cmdinfo));
-  cmdinfo.verbose = -1;
 
   char *cmdline = NULL;
   char *cmdname = NULL;
@@ -524,7 +523,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
         VALIDATION_ERROR("'mods.verbose' must be a Integer");
       } else if ((int)mods.verbose.data.integer >= 0) {
         // Silently ignore negative integers to allow mods.verbose to be set to -1.
-        cmdinfo.verbose = (int)mods.verbose.data.integer;
+        cmdinfo.cmdmod.cmod_verbose = (int)mods.verbose.data.integer + 1;
       }
     }
 
@@ -670,8 +669,8 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
   if (cmdinfo->cmdmod.cmod_tab != 0) {
     kv_printf(cmdline, "%dtab ", cmdinfo->cmdmod.cmod_tab - 1);
   }
-  if (cmdinfo->verbose != -1) {
-    kv_printf(cmdline, "%dverbose ", cmdinfo->verbose);
+  if (cmdinfo->cmdmod.cmod_verbose > 0) {
+    kv_printf(cmdline, "%dverbose ", cmdinfo->cmdmod.cmod_verbose - 1);
   }
 
   if (cmdinfo->cmdmod.cmod_flags & CMOD_ERRSILENT) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1191,7 +1191,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     }
 
     if (!forceit && bufIsChanged(buf)) {
-      if ((p_confirm || cmdmod.confirm) && p_write) {
+      if ((p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && p_write) {
         dialog_changed(buf, false);
         if (!bufref_valid(&bufref)) {
           // Autocommand deleted buffer, oops! It's not changed now.
@@ -1211,7 +1211,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     }
 
     if (!forceit && buf->terminal && terminal_running(buf->terminal)) {
-      if (p_confirm || cmdmod.confirm) {
+      if (p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) {
         if (!dialog_close_terminal(buf)) {
           return FAIL;
         }
@@ -1393,7 +1393,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
 
   // Check if the current buffer may be abandoned.
   if (action == DOBUF_GOTO && !can_abandon(curbuf, forceit)) {
-    if ((p_confirm || cmdmod.confirm) && p_write) {
+    if ((p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && p_write) {
       bufref_T bufref;
       set_bufref(&bufref, buf);
       dialog_changed(curbuf, false);
@@ -1439,7 +1439,7 @@ void set_curbuf(buf_T *buf, int action)
   long old_tw = curbuf->b_p_tw;
 
   setpcmark();
-  if (!cmdmod.keepalt) {
+  if ((cmdmod.cmod_flags & CMOD_KEEPALT) == 0) {
     curwin->w_alt_fnum = curbuf->b_fnum;     // remember alternate file
   }
   buflist_altfpos(curwin);                       // remember curpos
@@ -2846,7 +2846,7 @@ buf_T *setaltfname(char_u *ffname, char_u *sfname, linenr_T lnum)
 
   // Create a buffer.  'buflisted' is not set if it's a new buffer
   buf = buflist_new(ffname, sfname, lnum, 0);
-  if (buf != NULL && !cmdmod.keepalt) {
+  if (buf != NULL && (cmdmod.cmod_flags & CMOD_KEEPALT) == 0) {
     curwin->w_alt_fnum = buf->b_fnum;
   }
   return buf;
@@ -4659,7 +4659,7 @@ void do_arg_all(int count, int forceit, int keep_tabs)
   alist_T *alist;           // argument list to be used
   buf_T *buf;
   tabpage_T *tpnext;
-  int had_tab = cmdmod.tab;
+  int had_tab = cmdmod.cmod_tab;
   win_T *old_curwin, *last_curwin;
   tabpage_T *old_curtab, *last_curtab;
   win_T *new_curwin = NULL;
@@ -4870,7 +4870,7 @@ void do_arg_all(int count, int forceit, int keep_tabs)
 
     // When ":tab" was used open a new tab for a new window repeatedly.
     if (had_tab > 0 && tabpage_index(NULL) <= p_tpm) {
-      cmdmod.tab = 9999;
+      cmdmod.cmod_tab = 9999;
     }
   }
 
@@ -4917,7 +4917,7 @@ void ex_buffer_all(exarg_T *eap)
   int r;
   long count;                   // Maximum number of windows to open.
   int all;                      // When true also load inactive buffers.
-  int had_tab = cmdmod.tab;
+  int had_tab = cmdmod.cmod_tab;
   tabpage_T *tpnext;
 
   if (eap->addr_count == 0) {   // make as many windows as possible
@@ -4943,7 +4943,7 @@ void ex_buffer_all(exarg_T *eap)
     for (wp = firstwin; wp != NULL; wp = wpnext) {
       wpnext = wp->w_next;
       if ((wp->w_buffer->b_nwindows > 1
-           || ((cmdmod.split & WSP_VERT)
+           || ((cmdmod.cmod_split & WSP_VERT)
                ? wp->w_height + wp->w_hsep_height + wp->w_status_height < Rows - p_ch
                - tabline_height() - global_stl_height()
                : wp->w_width != Columns)
@@ -5056,7 +5056,7 @@ void ex_buffer_all(exarg_T *eap)
     }
     // When ":tab" was used open a new tab for a new window repeatedly.
     if (had_tab > 0 && tabpage_index(NULL) <= p_tpm) {
-      cmdmod.tab = 9999;
+      cmdmod.cmod_tab = 9999;
     }
   }
   autocmd_no_enter--;
@@ -5322,7 +5322,7 @@ bool buf_hide(const buf_T *const buf)
   case 'h':
     return true;            // "hide"
   }
-  return p_hid || cmdmod.hide;
+  return p_hid || (cmdmod.cmod_flags & CMOD_HIDE);
 }
 
 /// @return  special buffer name or

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -148,7 +148,7 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T 
   }
 
   // set the '. mark
-  if (!cmdmod.keepjumps) {
+  if ((cmdmod.cmod_flags & CMOD_KEEPJUMPS) == 0) {
     RESET_FMARK(&curbuf->b_last_change, ((pos_T) { lnum, col, 0 }), 0);
 
     // Create a new entry if a new undo-able change was started or we

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -790,14 +790,14 @@ static int diff_write(buf_T *buf, diffin_T *din)
   // Always use 'fileformat' set to "unix".
   char_u *save_ff = buf->b_p_ff;
   buf->b_p_ff = vim_strsave((char_u *)FF_UNIX);
-  const bool save_lockmarks = cmdmod.lockmarks;
+  const bool save_cmod_flags = cmdmod.cmod_flags;
   // Writing the buffer is an implementation detail of performing the diff,
   // so it shouldn't update the '[ and '] marks.
-  cmdmod.lockmarks = true;
+  cmdmod.cmod_flags |= CMOD_LOCKMARKS;
   int r = buf_write(buf, (char *)din->din_fname, NULL,
                     (linenr_T)1, buf->b_ml.ml_line_count,
                     NULL, false, false, false, true);
-  cmdmod.lockmarks = save_lockmarks;
+  cmdmod.cmod_flags = save_cmod_flags;
   free_string_option(buf->b_p_ff);
   buf->b_p_ff = save_ff;
   return r;
@@ -1263,7 +1263,7 @@ void ex_diffpatch(exarg_T *eap)
     }
 
     // don't use a new tab page, each tab page has its own diffs
-    cmdmod.tab = 0;
+    cmdmod.cmod_tab = 0;
 
     if (win_split(0, (diff_flags & DIFF_VERTICAL) ? WSP_VERT : 0) != FAIL) {
       // Pretend it was a ":split fname" command
@@ -1323,7 +1323,7 @@ void ex_diffsplit(exarg_T *eap)
   set_fraction(curwin);
 
   // don't use a new tab page, each tab page has its own diffs
-  cmdmod.tab = 0;
+  cmdmod.cmod_tab = 0;
 
   if (win_split(0, (diff_flags & DIFF_VERTICAL) ? WSP_VERT : 0) != FAIL) {
     // Pretend it was a ":split fname" command

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7956,7 +7956,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
   }
 
   // Remember the last Insert position in the '^ mark.
-  if (!cmdmod.keepjumps) {
+  if ((cmdmod.cmod_flags & CMOD_KEEPJUMPS) == 0) {
     RESET_FMARK(&curbuf->b_last_insert, curwin->w_cursor, curbuf->b_fnum);
   }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -506,7 +506,7 @@ bool check_changed(buf_T *buf, int flags)
       && bufIsChanged(buf)
       && ((flags & CCGD_MULTWIN) || buf->b_nwindows <= 1)
       && (!(flags & CCGD_AW) || autowrite(buf, forceit) == FAIL)) {
-    if ((p_confirm || cmdmod.confirm) && p_write) {
+    if ((p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && p_write) {
       int count = 0;
 
       if (flags & CCGD_ALLBUF) {
@@ -719,7 +719,7 @@ bool check_changed_any(bool hidden, bool unload)
   ret = true;
   exiting = false;
   // When ":confirm" used, don't give an error message.
-  if (!(p_confirm || cmdmod.confirm)) {
+  if (!(p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM))) {
     // There must be a wait_return for this message, do_buffer()
     // may cause a redraw.  But wait_return() is a no-op when vgetc()
     // is busy (Quit used from window menu), then make sure we don't
@@ -1127,7 +1127,7 @@ void do_argfile(exarg_T *eap, int argn)
     setpcmark();
 
     // split window or create new tab page first
-    if (*eap->cmd == 's' || cmdmod.tab != 0) {
+    if (*eap->cmd == 's' || cmdmod.cmod_tab != 0) {
       if (win_split(0, 0) == FAIL) {
         return;
       }
@@ -3027,7 +3027,7 @@ void ex_drop(exarg_T *eap)
     return;
   }
 
-  if (cmdmod.tab) {
+  if (cmdmod.cmod_tab) {
     // ":tab drop file ...": open a tab for each argument that isn't
     // edited in a window yet.  It's like ":tab all" but without closing
     // windows or tabs.

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -264,28 +264,27 @@ enum {
 /// flag.  This needs to be saved for recursive commands, put them in a
 /// structure for easy manipulation.
 typedef struct {
-  int cmod_flags;                   ///< CMOD_ flags
+  int cmod_flags;  ///< CMOD_ flags
 
-  int cmod_split;                   ///< flags for win_split()
-  int cmod_tab;                     ///< > 0 when ":tab" was used
+  int cmod_split;  ///< flags for win_split()
+  int cmod_tab;  ///< > 0 when ":tab" was used
   regmatch_T cmod_filter_regmatch;  ///< set by :filter /pat/
-  bool cmod_filter_force;           ///< set for :filter!
+  bool cmod_filter_force;  ///< set for :filter!
 
-  int cmod_verbose;                 ///< non-zero to set 'verbose', -1 is used for zero override
+  int cmod_verbose;  ///< 0 if not set, > 0 to set 'verbose' to cmod_verbose - 1
 
   // values for undo_cmdmod()
-  char_u *cmod_save_ei;             ///< saved value of 'eventignore'
-  int cmod_did_sandbox;             ///< set when "sandbox" was incremented
-  long cmod_verbose_save;           ///< if 'verbose' was set: value of p_verbose plus one
-  int cmod_save_msg_silent;         ///< if non-zero: saved value of msg_silent + 1
-  int cmod_save_msg_scroll;         ///< for restoring msg_scroll
-  int cmod_did_esilent;             ///< incremented when emsg_silent is
+  char_u *cmod_save_ei;  ///< saved value of 'eventignore'
+  int cmod_did_sandbox;  ///< set when "sandbox" was incremented
+  long cmod_verbose_save;  ///< if 'verbose' was set: value of p_verbose plus one
+  int cmod_save_msg_silent;  ///< if non-zero: saved value of msg_silent + 1
+  int cmod_save_msg_scroll;  ///< for restoring msg_scroll
+  int cmod_did_esilent;  ///< incremented when emsg_silent is
 } cmdmod_T;
 
 /// Stores command modifier info used by `nvim_parse_cmd`
 typedef struct {
   cmdmod_T cmdmod;
-  int verbose;  ///< unlike cmod_verbose, -1 is used when unspecified and 0 for zero override
   struct {
     bool file;
     bool bar;

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -243,40 +243,44 @@ struct expand {
 #define XP_BS_ONE       1       // uses one backslash before a space
 #define XP_BS_THREE     2       // uses three backslashes before a space
 
+enum {
+  CMOD_SANDBOX      = 0x0001,  ///< ":sandbox"
+  CMOD_SILENT       = 0x0002,  ///< ":silent"
+  CMOD_ERRSILENT    = 0x0004,  ///< ":silent!"
+  CMOD_UNSILENT     = 0x0008,  ///< ":unsilent"
+  CMOD_NOAUTOCMD    = 0x0010,  ///< ":noautocmd"
+  CMOD_HIDE         = 0x0020,  ///< ":hide"
+  CMOD_BROWSE       = 0x0040,  ///< ":browse" - invoke file dialog
+  CMOD_CONFIRM      = 0x0080,  ///< ":confirm" - invoke yes/no dialog
+  CMOD_KEEPALT      = 0x0100,  ///< ":keepalt"
+  CMOD_KEEPMARKS    = 0x0200,  ///< ":keepmarks"
+  CMOD_KEEPJUMPS    = 0x0400,  ///< ":keepjumps"
+  CMOD_LOCKMARKS    = 0x0800,  ///< ":lockmarks"
+  CMOD_KEEPPATTERNS = 0x1000,  ///< ":keeppatterns"
+  CMOD_NOSWAPFILE   = 0x2000,  ///< ":noswapfile"
+};
+
 /// Command modifiers ":vertical", ":browse", ":confirm", ":hide", etc. set a
 /// flag.  This needs to be saved for recursive commands, put them in a
 /// structure for easy manipulation.
 typedef struct {
-  int cmod_flags;              ///< CMOD_ flags, see below
-  int split;                   ///< flags for win_split()
-  int tab;                     ///< > 0 when ":tab" was used
-  bool browse;                 ///< true to invoke file dialog
-  bool confirm;                ///< true to invoke yes/no dialog
-  bool hide;                   ///< true when ":hide" was used
-  bool keepalt;                ///< true when ":keepalt" was used
-  bool keepjumps;              ///< true when ":keepjumps" was used
-  bool keepmarks;              ///< true when ":keepmarks" was used
-  bool keeppatterns;           ///< true when ":keeppatterns" was used
-  bool lockmarks;              ///< true when ":lockmarks" was used
-  bool noswapfile;             ///< true when ":noswapfile" was used
-  regmatch_T filter_regmatch;  ///< set by :filter /pat/
-  bool filter_force;           ///< set for :filter!
+  int cmod_flags;                   ///< CMOD_ flags
 
-  int cmod_verbose;            ///< non-zero to set 'verbose', -1 is used for zero override
+  int cmod_split;                   ///< flags for win_split()
+  int cmod_tab;                     ///< > 0 when ":tab" was used
+  regmatch_T cmod_filter_regmatch;  ///< set by :filter /pat/
+  bool cmod_filter_force;           ///< set for :filter!
+
+  int cmod_verbose;                 ///< non-zero to set 'verbose', -1 is used for zero override
 
   // values for undo_cmdmod()
-  char_u *cmod_save_ei;        ///< saved value of 'eventignore'
-  int cmod_did_sandbox;        ///< set when "sandbox" was incremented
-  long cmod_verbose_save;      ///< if 'verbose' was set: value of p_verbose plus one
-  int cmod_save_msg_silent;    ///< if non-zero: saved value of msg_silent + 1
-  int cmod_did_esilent;        ///< incremented when emsg_silent is
+  char_u *cmod_save_ei;             ///< saved value of 'eventignore'
+  int cmod_did_sandbox;             ///< set when "sandbox" was incremented
+  long cmod_verbose_save;           ///< if 'verbose' was set: value of p_verbose plus one
+  int cmod_save_msg_silent;         ///< if non-zero: saved value of msg_silent + 1
+  int cmod_save_msg_scroll;         ///< for restoring msg_scroll
+  int cmod_did_esilent;             ///< incremented when emsg_silent is
 } cmdmod_T;
-
-#define CMOD_SANDBOX    0x01
-#define CMOD_SILENT     0x02
-#define CMOD_ERRSILENT  0x04
-#define CMOD_UNSILENT   0x08
-#define CMOD_NOAUTOCMD  0x10
 
 /// Stores command modifier info used by `nvim_parse_cmd`
 typedef struct {

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -280,12 +280,8 @@ typedef struct {
 
 /// Stores command modifier info used by `nvim_parse_cmd`
 typedef struct {
-  bool silent;
-  bool emsg_silent;
-  bool sandbox;
-  bool noautocmd;
-  int verbose;  ///< unlike cmod_verbose, -1 is used when unspecified and 0 for zero override
   cmdmod_T cmdmod;
+  int verbose;  ///< unlike cmod_verbose, -1 is used when unspecified and 0 for zero override
   struct {
     bool file;
     bool bar;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1411,7 +1411,6 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, char **er
   char *cmd;
   char *p;
   char *after_modifier = NULL;
-  cmdmod_T save_cmdmod = cmdmod;
 
   // Initialize cmdinfo
   memset(cmdinfo, 0, sizeof(*cmdinfo));
@@ -1426,18 +1425,16 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, char **er
   eap->cookie = NULL;
 
   // Parse command modifiers
-  if (parse_command_modifiers(eap, errormsg, false) == FAIL) {
+  if (parse_command_modifiers(eap, errormsg, &cmdinfo->cmdmod, false) == FAIL) {
     return false;
   }
   after_modifier = eap->cmd;
 
-  if (cmdmod.cmod_verbose != 0) {
-    cmdinfo->verbose = cmdmod.cmod_verbose < 0 ? 0 : cmdmod.cmod_verbose;
+  if (cmdinfo->cmdmod.cmod_verbose != 0) {
+    cmdinfo->verbose = cmdinfo->cmdmod.cmod_verbose < 0 ? 0 : cmdinfo->cmdmod.cmod_verbose;
   } else {
     cmdinfo->verbose = -1;
   }
-  cmdinfo->cmdmod = cmdmod;
-  cmdmod = save_cmdmod;
 
   // Save location after command modifiers
   cmd = eap->cmd;
@@ -1673,7 +1670,7 @@ end:
     emsg(errormsg);
   }
   // Undo command modifiers
-  undo_cmdmod(msg_scroll);
+  undo_cmdmod(&cmdmod);
   cmdmod = save_cmdmod;
   return retv;
 #undef ERROR
@@ -1704,7 +1701,6 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
   char *errormsg = NULL;  // error message
   char *after_modifier = NULL;
   exarg_T ea;
-  const int save_msg_scroll = msg_scroll;
   cmdmod_T save_cmdmod;
   const int save_reg_executing = reg_executing;
   const bool save_pending_end_reg_executing = pending_end_reg_executing;
@@ -1746,7 +1742,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
   ea.cookie = cookie;
   ea.cstack = cstack;
 
-  if (parse_command_modifiers(&ea, &errormsg, false) == FAIL) {
+  if (parse_command_modifiers(&ea, &errormsg, &cmdmod, false) == FAIL) {
     goto doend;
   }
   apply_cmdmod(&cmdmod);
@@ -2361,7 +2357,7 @@ doend:
               (ea.cmdidx != CMD_SIZE
                && !IS_USER_CMDIDX(ea.cmdidx)) ? cmdnames[(int)ea.cmdidx].cmd_name : NULL);
 
-  undo_cmdmod(save_msg_scroll);
+  undo_cmdmod(&cmdmod);
   cmdmod = save_cmdmod;
   reg_executing = save_reg_executing;
   pending_end_reg_executing = save_pending_end_reg_executing;
@@ -2389,25 +2385,25 @@ char *ex_errmsg(const char *const msg, const char *const arg)
 
 /// Parse and skip over command modifiers:
 /// - update eap->cmd
-/// - store flags in "cmdmod".
+/// - store flags in "cmod".
 /// - Set ex_pressedreturn for an empty command line.
-/// - set msg_silent for ":silent"
-/// - set 'eventignore' to "all" for ":noautocmd"
 ///
-/// @param skip_only      if true, the global variables are not changed, except for
-///                       "cmdmod".
+/// @param skip_only      if false, undo_cmdmod() must be called later to free
+///                       any cmod_filter_regmatch.regprog.
 /// @param[out] errormsg  potential error message.
 ///
 /// Call apply_cmdmod() to get the side effects of the modifiers:
 /// - Increment "sandbox" for ":sandbox"
 /// - set p_verbose for ":verbose"
+/// - set msg_silent for ":silent"
+/// - set 'eventignore' to "all" for ":noautocmd"
 ///
 /// @return  FAIL when the command is not to be executed.
-int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
+int parse_command_modifiers(exarg_T *eap, char **errormsg, cmdmod_T *cmod, bool skip_only)
 {
   char *p;
 
-  memset(&cmdmod, 0, sizeof(cmdmod));
+  memset(cmod, 0, sizeof(*cmod));
 
   // Repeat until no more command modifiers are found.
   for (;;) {
@@ -2445,48 +2441,48 @@ int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
       if (!checkforcmd(&eap->cmd, "aboveleft", 3)) {
         break;
       }
-      cmdmod.split |= WSP_ABOVE;
+      cmod->cmod_split |= WSP_ABOVE;
       continue;
 
     case 'b':
       if (checkforcmd(&eap->cmd, "belowright", 3)) {
-        cmdmod.split |= WSP_BELOW;
+        cmod->cmod_split |= WSP_BELOW;
         continue;
       }
       if (checkforcmd(&eap->cmd, "browse", 3)) {
-        cmdmod.browse = true;
+        cmod->cmod_flags |= CMOD_BROWSE;
         continue;
       }
       if (!checkforcmd(&eap->cmd, "botright", 2)) {
         break;
       }
-      cmdmod.split |= WSP_BOT;
+      cmod->cmod_split |= WSP_BOT;
       continue;
 
     case 'c':
       if (!checkforcmd(&eap->cmd, "confirm", 4)) {
         break;
       }
-      cmdmod.confirm = true;
+      cmod->cmod_flags |= CMOD_CONFIRM;
       continue;
 
     case 'k':
       if (checkforcmd(&eap->cmd, "keepmarks", 3)) {
-        cmdmod.keepmarks = true;
+        cmod->cmod_flags |= CMOD_KEEPMARKS;
         continue;
       }
       if (checkforcmd(&eap->cmd, "keepalt", 5)) {
-        cmdmod.keepalt = true;
+        cmod->cmod_flags |= CMOD_KEEPALT;
         continue;
       }
       if (checkforcmd(&eap->cmd, "keeppatterns", 5)) {
-        cmdmod.keeppatterns = true;
+        cmod->cmod_flags |= CMOD_KEEPPATTERNS;
         continue;
       }
       if (!checkforcmd(&eap->cmd, "keepjumps", 5)) {
         break;
       }
-      cmdmod.keepjumps = true;
+      cmod->cmod_flags |= CMOD_KEEPJUMPS;
       continue;
 
     case 'f': {  // only accept ":filter {pat} cmd"
@@ -2496,7 +2492,7 @@ int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
         break;
       }
       if (*p == '!') {
-        cmdmod.filter_force = true;
+        cmod->cmod_filter_force = true;
         p = skipwhite(p + 1);
         if (*p == NUL || ends_excmd(*p)) {
           break;
@@ -2512,8 +2508,8 @@ int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
         break;
       }
       if (!skip_only) {
-        cmdmod.filter_regmatch.regprog = vim_regcomp(reg_pat, RE_MAGIC);
-        if (cmdmod.filter_regmatch.regprog == NULL) {
+        cmod->cmod_filter_regmatch.regprog = vim_regcomp(reg_pat, RE_MAGIC);
+        if (cmod->cmod_filter_regmatch.regprog == NULL) {
           break;
         }
       }
@@ -2528,52 +2524,52 @@ int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
         break;
       }
       eap->cmd = p;
-      cmdmod.hide = true;
+      cmod->cmod_flags |= CMOD_HIDE;
       continue;
 
     case 'l':
       if (checkforcmd(&eap->cmd, "lockmarks", 3)) {
-        cmdmod.lockmarks = true;
+        cmod->cmod_flags |= CMOD_LOCKMARKS;
         continue;
       }
 
       if (!checkforcmd(&eap->cmd, "leftabove", 5)) {
         break;
       }
-      cmdmod.split |= WSP_ABOVE;
+      cmod->cmod_split |= WSP_ABOVE;
       continue;
 
     case 'n':
       if (checkforcmd(&eap->cmd, "noautocmd", 3)) {
-        cmdmod.cmod_flags |= CMOD_NOAUTOCMD;
+        cmod->cmod_flags |= CMOD_NOAUTOCMD;
         continue;
       }
       if (!checkforcmd(&eap->cmd, "noswapfile", 3)) {
         break;
       }
-      cmdmod.noswapfile = true;
+      cmod->cmod_flags |= CMOD_NOSWAPFILE;
       continue;
 
     case 'r':
       if (!checkforcmd(&eap->cmd, "rightbelow", 6)) {
         break;
       }
-      cmdmod.split |= WSP_BELOW;
+      cmod->cmod_split |= WSP_BELOW;
       continue;
 
     case 's':
       if (checkforcmd(&eap->cmd, "sandbox", 3)) {
-        cmdmod.cmod_flags |= CMOD_SANDBOX;
+        cmod->cmod_flags |= CMOD_SANDBOX;
         continue;
       }
       if (!checkforcmd(&eap->cmd, "silent", 3)) {
         break;
       }
-      cmdmod.cmod_flags |= CMOD_SILENT;
+      cmod->cmod_flags |= CMOD_SILENT;
       if (*eap->cmd == '!' && !ascii_iswhite(eap->cmd[-1])) {
         // ":silent!", but not "silent !cmd"
         eap->cmd = skipwhite(eap->cmd + 1);
-        cmdmod.cmod_flags |= CMOD_ERRSILENT;
+        cmod->cmod_flags |= CMOD_ERRSILENT;
       }
       continue;
 
@@ -2584,13 +2580,13 @@ int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
                                        false, 1);
 
           if (tabnr == MAXLNUM) {
-            cmdmod.tab = tabpage_index(curtab) + 1;
+            cmod->cmod_tab = tabpage_index(curtab) + 1;
           } else {
             if (tabnr < 0 || tabnr > LAST_TAB_NR) {
               *errormsg = _(e_invrange);
               return false;
             }
-            cmdmod.tab = tabnr + 1;
+            cmod->cmod_tab = tabnr + 1;
           }
         }
         eap->cmd = p;
@@ -2599,31 +2595,31 @@ int parse_command_modifiers(exarg_T *eap, char **errormsg, bool skip_only)
       if (!checkforcmd(&eap->cmd, "topleft", 2)) {
         break;
       }
-      cmdmod.split |= WSP_TOP;
+      cmod->cmod_split |= WSP_TOP;
       continue;
 
     case 'u':
       if (!checkforcmd(&eap->cmd, "unsilent", 3)) {
         break;
       }
-      cmdmod.cmod_flags |= CMOD_UNSILENT;
+      cmod->cmod_flags |= CMOD_UNSILENT;
       continue;
 
     case 'v':
       if (checkforcmd(&eap->cmd, "vertical", 4)) {
-        cmdmod.split |= WSP_VERT;
+        cmod->cmod_split |= WSP_VERT;
         continue;
       }
       if (!checkforcmd(&p, "verbose", 4)) {
         break;
       }
       if (ascii_isdigit(*eap->cmd)) {
-        cmdmod.cmod_verbose = atoi((char *)eap->cmd);
-        if (cmdmod.cmod_verbose == 0) {
-          cmdmod.cmod_verbose = -1;
+        cmod->cmod_verbose = atoi((char *)eap->cmd);
+        if (cmod->cmod_verbose == 0) {
+          cmod->cmod_verbose = -1;
         }
       } else {
-        cmdmod.cmod_verbose = 1;
+        cmod->cmod_verbose = 1;
       }
       eap->cmd = p;
       continue;
@@ -2652,6 +2648,7 @@ static void apply_cmdmod(cmdmod_T *cmod)
   if ((cmod->cmod_flags & (CMOD_SILENT | CMOD_UNSILENT))
       && cmod->cmod_save_msg_silent == 0) {
     cmod->cmod_save_msg_silent = msg_silent + 1;
+    cmod->cmod_save_msg_scroll = msg_scroll;
   }
   if (cmod->cmod_flags & CMOD_SILENT) {
     msg_silent++;
@@ -2665,50 +2662,50 @@ static void apply_cmdmod(cmdmod_T *cmod)
     cmod->cmod_did_esilent++;
   }
 
-  if ((cmod->cmod_flags & CMOD_NOAUTOCMD) && cmdmod.cmod_save_ei == NULL) {
+  if ((cmod->cmod_flags & CMOD_NOAUTOCMD) && cmod->cmod_save_ei == NULL) {
     // Set 'eventignore' to "all".
     // First save the existing option value for restoring it later.
-    cmdmod.cmod_save_ei = vim_strsave(p_ei);
+    cmod->cmod_save_ei = vim_strsave(p_ei);
     set_string_option_direct("ei", -1, (char_u *)"all", OPT_FREE, SID_NONE);
   }
 }
 
-/// Undo and free contents of "cmdmod".
-static void undo_cmdmod(int save_msg_scroll)
+/// Undo and free contents of "cmod".
+static void undo_cmdmod(cmdmod_T *cmod)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (cmdmod.cmod_verbose_save > 0) {
-    p_verbose = cmdmod.cmod_verbose_save - 1;
-    cmdmod.cmod_verbose_save = 0;
+  if (cmod->cmod_verbose_save > 0) {
+    p_verbose = cmod->cmod_verbose_save - 1;
+    cmod->cmod_verbose_save = 0;
   }
 
-  if (cmdmod.cmod_did_sandbox) {
+  if (cmod->cmod_did_sandbox) {
     sandbox--;
-    cmdmod.cmod_did_sandbox = false;
+    cmod->cmod_did_sandbox = false;
   }
 
-  if (cmdmod.cmod_save_ei != NULL) {
+  if (cmod->cmod_save_ei != NULL) {
     // Restore 'eventignore' to the value before ":noautocmd".
-    set_string_option_direct("ei", -1, (char_u *)cmdmod.cmod_save_ei, OPT_FREE, SID_NONE);
-    free_string_option((char_u *)cmdmod.cmod_save_ei);
-    cmdmod.cmod_save_ei = NULL;
+    set_string_option_direct("ei", -1, (char_u *)cmod->cmod_save_ei, OPT_FREE, SID_NONE);
+    free_string_option((char_u *)cmod->cmod_save_ei);
+    cmod->cmod_save_ei = NULL;
   }
 
-  vim_regfree(cmdmod.filter_regmatch.regprog);
+  vim_regfree(cmod->cmod_filter_regmatch.regprog);
 
-  if (cmdmod.cmod_save_msg_silent > 0) {
+  if (cmod->cmod_save_msg_silent > 0) {
     // messages could be enabled for a serious error, need to check if the
     // counters don't become negative
-    if (!did_emsg || msg_silent > cmdmod.cmod_save_msg_silent - 1) {
-      msg_silent = cmdmod.cmod_save_msg_silent - 1;
+    if (!did_emsg || msg_silent > cmod->cmod_save_msg_silent - 1) {
+      msg_silent = cmod->cmod_save_msg_silent - 1;
     }
-    emsg_silent -= cmdmod.cmod_did_esilent;
+    emsg_silent -= cmod->cmod_did_esilent;
     if (emsg_silent < 0) {
       emsg_silent = 0;
     }
     // Restore msg_scroll, it's set by file I/O commands, even when no
     // message is actually displayed.
-    msg_scroll = save_msg_scroll;
+    msg_scroll = cmod->cmod_save_msg_scroll;
 
     // "silent reg" or "silent echo x" inside "redir" leaves msg_col
     // somewhere in the line.  Put it back in the first column.
@@ -2716,8 +2713,8 @@ static void undo_cmdmod(int save_msg_scroll)
       msg_col = 0;
     }
 
-    cmdmod.cmod_save_msg_silent = 0;
-    cmdmod.cmod_did_esilent = 0;
+    cmod->cmod_save_msg_silent = 0;
+    cmod->cmod_did_esilent = 0;
   }
 }
 
@@ -5467,7 +5464,7 @@ static int check_more(int message, bool forceit)
   if (!forceit && only_one_window()
       && ARGCOUNT > 1 && !arg_had_last && n > 0 && quitmore == 0) {
     if (message) {
-      if ((p_confirm || cmdmod.confirm) && curbuf->b_fname != NULL) {
+      if ((p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && curbuf->b_fname != NULL) {
         char buff[DIALOG_MSG_SIZE];
 
         vim_snprintf((char *)buff, DIALOG_MSG_SIZE,
@@ -6534,8 +6531,8 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
   return result;
 }
 
-/// Add modifiers from "cmdmod.split" to "buf".  Set "multi_mods" when one was
-/// added.
+/// Add modifiers from "cmdmod.cmod_split" to "buf".  Set "multi_mods" when one
+/// was added.
 ///
 /// @return the number of bytes added
 size_t add_win_cmd_modifers(char *buf, bool *multi_mods)
@@ -6543,28 +6540,28 @@ size_t add_win_cmd_modifers(char *buf, bool *multi_mods)
   size_t result = 0;
 
   // :aboveleft and :leftabove
-  if (cmdmod.split & WSP_ABOVE) {
+  if (cmdmod.cmod_split & WSP_ABOVE) {
     result += add_cmd_modifier(buf, "aboveleft", multi_mods);
   }
   // :belowright and :rightbelow
-  if (cmdmod.split & WSP_BELOW) {
+  if (cmdmod.cmod_split & WSP_BELOW) {
     result += add_cmd_modifier(buf, "belowright", multi_mods);
   }
   // :botright
-  if (cmdmod.split & WSP_BOT) {
+  if (cmdmod.cmod_split & WSP_BOT) {
     result += add_cmd_modifier(buf, "botright", multi_mods);
   }
 
   // :tab
-  if (cmdmod.tab > 0) {
+  if (cmdmod.cmod_tab > 0) {
     result += add_cmd_modifier(buf, "tab", multi_mods);
   }
   // :topleft
-  if (cmdmod.split & WSP_TOP) {
+  if (cmdmod.cmod_split & WSP_TOP) {
     result += add_cmd_modifier(buf, "topleft", multi_mods);
   }
   // :vertical
-  if (cmdmod.split & WSP_VERT) {
+  if (cmdmod.cmod_split & WSP_VERT) {
     result += add_cmd_modifier(buf, "vertical", multi_mods);
   }
   return result;
@@ -6576,23 +6573,23 @@ size_t uc_mods(char *buf)
   bool multi_mods = false;
 
   typedef struct {
-    bool *set;
+    int flag;
     char *name;
   } mod_entry_T;
   static mod_entry_T mod_entries[] = {
-    { &cmdmod.browse, "browse" },
-    { &cmdmod.confirm, "confirm" },
-    { &cmdmod.hide, "hide" },
-    { &cmdmod.keepalt, "keepalt" },
-    { &cmdmod.keepjumps, "keepjumps" },
-    { &cmdmod.keepmarks, "keepmarks" },
-    { &cmdmod.keeppatterns, "keeppatterns" },
-    { &cmdmod.lockmarks, "lockmarks" },
-    { &cmdmod.noswapfile, "noswapfile" }
+    { CMOD_BROWSE, "browse" },
+    { CMOD_CONFIRM, "confirm" },
+    { CMOD_HIDE, "hide" },
+    { CMOD_KEEPALT, "keepalt" },
+    { CMOD_KEEPJUMPS, "keepjumps" },
+    { CMOD_KEEPMARKS, "keepmarks" },
+    { CMOD_KEEPPATTERNS, "keeppatterns" },
+    { CMOD_LOCKMARKS, "lockmarks" },
+    { CMOD_NOSWAPFILE, "noswapfile" }
   };
   // the modifiers that are simple flags
   for (size_t i = 0; i < ARRAY_SIZE(mod_entries); i++) {
-    if (*mod_entries[i].set) {
+    if (cmdmod.cmod_flags & mod_entries[i].flag) {
       result += add_cmd_modifier(buf, mod_entries[i].name, &multi_mods);
     }
   }
@@ -6611,7 +6608,7 @@ size_t uc_mods(char *buf)
   if (p_verbose > 0) {
     result += add_cmd_modifier(buf, "verbose", &multi_mods);
   }
-  // flags from cmdmod.split
+  // flags from cmdmod.cmod_split
   result += add_win_cmd_modifers(buf, &multi_mods);
 
   return result;
@@ -7159,7 +7156,7 @@ void ex_win_close(int forceit, win_T *win, tabpage_T *tp)
 
   need_hide = (bufIsChanged(buf) && buf->b_nwindows <= 1);
   if (need_hide && !buf_hide(buf) && !forceit) {
-    if ((p_confirm || cmdmod.confirm) && p_write) {
+    if ((p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && p_write) {
       bufref_T bufref;
       set_bufref(&bufref, buf);
       dialog_changed(buf, false);
@@ -7642,7 +7639,7 @@ void ex_splitview(exarg_T *eap)
 
   // A ":split" in the quickfix window works like ":new".  Don't want two
   // quickfix windows.  But it's OK when doing ":tab split".
-  if (bt_quickfix(curbuf) && cmdmod.tab == 0) {
+  if (bt_quickfix(curbuf) && cmdmod.cmod_tab == 0) {
     if (eap->cmdidx == CMD_split) {
       eap->cmdidx = CMD_new;
     }
@@ -7664,7 +7661,7 @@ void ex_splitview(exarg_T *eap)
    * Either open new tab page or split the window.
    */
   if (use_tab) {
-    if (win_new_tabpage(cmdmod.tab != 0 ? cmdmod.tab : eap->addr_count == 0
+    if (win_new_tabpage(cmdmod.cmod_tab != 0 ? cmdmod.cmod_tab : eap->addr_count == 0
                         ? 0 : (int)eap->line2 + 1, (char_u *)eap->arg) != FAIL) {
       do_exedit(eap, old_curwin);
       apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
@@ -7673,7 +7670,7 @@ void ex_splitview(exarg_T *eap)
       if (curwin != old_curwin
           && win_valid(old_curwin)
           && old_curwin->w_buffer != curbuf
-          && !cmdmod.keepalt) {
+          && (cmdmod.cmod_flags & CMOD_KEEPALT) == 0) {
         old_curwin->w_alt_fnum = curbuf->b_fnum;
       }
     }
@@ -7831,7 +7828,7 @@ static void ex_resize(exarg_T *eap)
   }
 
   n = (int)atol(eap->arg);
-  if (cmdmod.split & WSP_VERT) {
+  if (cmdmod.cmod_split & WSP_VERT) {
     if (*eap->arg == '-' || *eap->arg == '+') {
       n += wp->w_width;
     } else if (n == 0 && eap->arg[0] == NUL) {  // default is very wide
@@ -8002,7 +7999,7 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
       && curwin != old_curwin
       && win_valid(old_curwin)
       && old_curwin->w_buffer != curbuf
-      && !cmdmod.keepalt) {
+      && (cmdmod.cmod_flags & CMOD_KEEPALT) == 0) {
     old_curwin->w_alt_fnum = curbuf->b_fnum;
   }
 
@@ -8452,8 +8449,8 @@ static void ex_wincmd(exarg_T *eap)
     emsg(_(e_invarg));
   } else if (!eap->skip) {
     // Pass flags on for ":vertical wincmd ]".
-    postponed_split_flags = cmdmod.split;
-    postponed_split_tab = cmdmod.tab;
+    postponed_split_flags = cmdmod.cmod_split;
+    postponed_split_tab = cmdmod.cmod_tab;
     do_window(*eap->arg, eap->addr_count > 0 ? eap->line2 : 0L, xchar);
     postponed_split_flags = 0;
     postponed_split_tab = 0;
@@ -9289,8 +9286,8 @@ static void ex_pedit(exarg_T *eap)
 static void ex_stag(exarg_T *eap)
 {
   postponed_split = -1;
-  postponed_split_flags = cmdmod.split;
-  postponed_split_tab = cmdmod.tab;
+  postponed_split_flags = cmdmod.cmod_split;
+  postponed_split_tab = cmdmod.cmod_tab;
   ex_tag_cmd(eap, cmdnames[eap->cmdidx].cmd_name + 1);
   postponed_split_flags = 0;
   postponed_split_tab = 0;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1431,10 +1431,6 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, char **er
   }
   after_modifier = eap->cmd;
 
-  cmdinfo->silent = cmdmod.cmod_flags & CMOD_SILENT;
-  cmdinfo->emsg_silent = cmdmod.cmod_flags & CMOD_ERRSILENT;
-  cmdinfo->sandbox = cmdmod.cmod_flags & CMOD_SANDBOX;
-  cmdinfo->noautocmd = cmdmod.cmod_flags & CMOD_NOAUTOCMD;
   if (cmdmod.cmod_verbose != 0) {
     cmdinfo->verbose = cmdmod.cmod_verbose < 0 ? 0 : cmdmod.cmod_verbose;
   } else {
@@ -1566,18 +1562,6 @@ int execute_cmd(exarg_T *eap, CmdParseInfo *cmdinfo, bool preview)
   cmdmod = cmdinfo->cmdmod;
 
   // Apply command modifiers
-  if (cmdinfo->silent) {
-    cmdmod.cmod_flags |= CMOD_SILENT;
-  }
-  if (cmdinfo->emsg_silent) {
-    cmdmod.cmod_flags |= CMOD_ERRSILENT;
-  }
-  if (cmdinfo->sandbox) {
-    cmdmod.cmod_flags |= CMOD_SANDBOX;
-  }
-  if (cmdinfo->noautocmd) {
-    cmdmod.cmod_flags |= CMOD_NOAUTOCMD;
-  }
   if (cmdinfo->verbose >= 0) {
     cmdmod.cmod_verbose = cmdinfo->verbose == 0 ? -1 : cmdinfo->verbose;
   }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1890,7 +1890,7 @@ failed:
     check_cursor_lnum();
     beginline(BL_WHITE | BL_FIX);           // on first non-blank
 
-    if (!cmdmod.lockmarks) {
+    if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
       // Set '[ and '] marks to the newly read lines.
       curbuf->b_op_start.lnum = from + 1;
       curbuf->b_op_start.col = 0;
@@ -2425,7 +2425,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
     if (buf == NULL || (buf->b_ml.ml_mfp == NULL && !empty_memline)
         || did_cmd || nofile_err
         || aborting()) {
-      if (buf != NULL && cmdmod.lockmarks) {
+      if (buf != NULL && (cmdmod.cmod_flags & CMOD_LOCKMARKS)) {
         // restore the original '[ and '] positions
         buf->b_op_start = orig_start;
         buf->b_op_end = orig_end;
@@ -2511,7 +2511,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
     }
   }
 
-  if (cmdmod.lockmarks) {
+  if (cmdmod.cmod_flags & CMOD_LOCKMARKS) {
     // restore the original '[ and '] positions
     buf->b_op_start = orig_start;
     buf->b_op_end = orig_end;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -757,7 +757,7 @@ EXTERN bool did_cursorhold INIT(= false);      // set when CursorHold t'gerd
 
 EXTERN int postponed_split INIT(= 0);        // for CTRL-W CTRL-] command
 EXTERN int postponed_split_flags INIT(= 0);  // args for win_split()
-EXTERN int postponed_split_tab INIT(= 0);    // cmdmod.tab
+EXTERN int postponed_split_tab INIT(= 0);    // cmdmod.cmod_tab
 EXTERN int g_do_tagpreview INIT(= 0);  // for tag preview commands:
                                        // height of preview window
 EXTERN bool g_tag_at_cursor INIT(= false);  // whether the tag command comes

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -187,8 +187,8 @@ static void do_cscope_general(exarg_T *eap, int make_split)
       return;
     }
     postponed_split = -1;
-    postponed_split_flags = cmdmod.split;
-    postponed_split_tab = cmdmod.tab;
+    postponed_split_flags = cmdmod.cmod_split;
+    postponed_split_tab = cmdmod.cmod_tab;
   }
 
   cmdp->func(eap);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1920,7 +1920,9 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   lua_pushinteger(lstate, cmdmod.tab);
   lua_setfield(lstate, -2, "tab");
 
-  lua_pushinteger(lstate, eap->verbose_save != -1 ? p_verbose : -1);
+  lua_pushinteger(lstate, (cmdmod.cmod_verbose != 0
+                           ? cmdmod.cmod_verbose < 0 ? 0 : cmdmod.cmod_verbose
+                           : -1));
   lua_setfield(lstate, -2, "verbose");
 
   if (cmdmod.split & WSP_ABOVE) {
@@ -1938,13 +1940,13 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
 
   lua_pushboolean(lstate, cmdmod.split & WSP_VERT);
   lua_setfield(lstate, -2, "vertical");
-  lua_pushboolean(lstate, eap->save_msg_silent != -1 ? (msg_silent != 0) : 0);
+  lua_pushboolean(lstate, cmdmod.cmod_flags & CMOD_SILENT);
   lua_setfield(lstate, -2, "silent");
-  lua_pushboolean(lstate, eap->did_esilent);
+  lua_pushboolean(lstate, cmdmod.cmod_flags & CMOD_ERRSILENT);
   lua_setfield(lstate, -2, "emsg_silent");
-  lua_pushboolean(lstate, eap->did_sandbox);
+  lua_pushboolean(lstate, cmdmod.cmod_flags & CMOD_SANDBOX);
   lua_setfield(lstate, -2, "sandbox");
-  lua_pushboolean(lstate, cmdmod.save_ei != NULL);
+  lua_pushboolean(lstate, cmdmod.cmod_flags & CMOD_NOAUTOCMD);
   lua_setfield(lstate, -2, "noautocmd");
 
   typedef struct {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1917,7 +1917,7 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
 
   lua_newtable(lstate);  // smods table
 
-  lua_pushinteger(lstate, cmdmod.tab);
+  lua_pushinteger(lstate, cmdmod.cmod_tab);
   lua_setfield(lstate, -2, "tab");
 
   lua_pushinteger(lstate, (cmdmod.cmod_verbose != 0
@@ -1925,20 +1925,20 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
                            : -1));
   lua_setfield(lstate, -2, "verbose");
 
-  if (cmdmod.split & WSP_ABOVE) {
+  if (cmdmod.cmod_split & WSP_ABOVE) {
     lua_pushstring(lstate, "aboveleft");
-  } else if (cmdmod.split & WSP_BELOW) {
+  } else if (cmdmod.cmod_split & WSP_BELOW) {
     lua_pushstring(lstate, "belowright");
-  } else if (cmdmod.split & WSP_TOP) {
+  } else if (cmdmod.cmod_split & WSP_TOP) {
     lua_pushstring(lstate, "topleft");
-  } else if (cmdmod.split & WSP_BOT) {
+  } else if (cmdmod.cmod_split & WSP_BOT) {
     lua_pushstring(lstate, "botright");
   } else {
     lua_pushstring(lstate, "");
   }
   lua_setfield(lstate, -2, "split");
 
-  lua_pushboolean(lstate, cmdmod.split & WSP_VERT);
+  lua_pushboolean(lstate, cmdmod.cmod_split & WSP_VERT);
   lua_setfield(lstate, -2, "vertical");
   lua_pushboolean(lstate, cmdmod.cmod_flags & CMOD_SILENT);
   lua_setfield(lstate, -2, "silent");
@@ -1950,24 +1950,24 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   lua_setfield(lstate, -2, "noautocmd");
 
   typedef struct {
-    bool *set;
+    int flag;
     char *name;
   } mod_entry_T;
   static mod_entry_T mod_entries[] = {
-    { &cmdmod.browse, "browse" },
-    { &cmdmod.confirm, "confirm" },
-    { &cmdmod.hide, "hide" },
-    { &cmdmod.keepalt, "keepalt" },
-    { &cmdmod.keepjumps, "keepjumps" },
-    { &cmdmod.keepmarks, "keepmarks" },
-    { &cmdmod.keeppatterns, "keeppatterns" },
-    { &cmdmod.lockmarks, "lockmarks" },
-    { &cmdmod.noswapfile, "noswapfile" }
+    { CMOD_BROWSE, "browse" },
+    { CMOD_CONFIRM, "confirm" },
+    { CMOD_HIDE, "hide" },
+    { CMOD_KEEPALT, "keepalt" },
+    { CMOD_KEEPJUMPS, "keepjumps" },
+    { CMOD_KEEPMARKS, "keepmarks" },
+    { CMOD_KEEPPATTERNS, "keeppatterns" },
+    { CMOD_LOCKMARKS, "lockmarks" },
+    { CMOD_NOSWAPFILE, "noswapfile" }
   };
 
   // The modifiers that are simple flags
   for (size_t i = 0; i < ARRAY_SIZE(mod_entries); i++) {
-    lua_pushboolean(lstate, *mod_entries[i].set);
+    lua_pushboolean(lstate, cmdmod.cmod_flags & mod_entries[i].flag);
     lua_setfield(lstate, -2, mod_entries[i].name);
   }
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1920,9 +1920,7 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   lua_pushinteger(lstate, cmdmod.cmod_tab);
   lua_setfield(lstate, -2, "tab");
 
-  lua_pushinteger(lstate, (cmdmod.cmod_verbose != 0
-                           ? cmdmod.cmod_verbose < 0 ? 0 : cmdmod.cmod_verbose
-                           : -1));
+  lua_pushinteger(lstate, cmdmod.cmod_verbose - 1);
   lua_setfield(lstate, -2, "verbose");
 
   if (cmdmod.cmod_split & WSP_ABOVE) {

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -171,7 +171,7 @@ void setpcmark(void)
   xfmark_T *fm;
 
   // for :global the mark is set only once
-  if (global_busy || listcmd_busy || cmdmod.keepjumps) {
+  if (global_busy || listcmd_busy || (cmdmod.cmod_flags & CMOD_KEEPJUMPS)) {
     return;
   }
 
@@ -990,7 +990,7 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2, linenr_T amount
     return;
   }
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // named marks, lower case and upper case
     for (i = 0; i < NMARKS; i++) {
       ONE_ADJUST(&(curbuf->b_namedm[i].mark.lnum));
@@ -1059,7 +1059,7 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2, linenr_T amount
    * Adjust items in all windows related to the current buffer.
    */
   FOR_ALL_TAB_WINDOWS(tab, win) {
-    if (!cmdmod.lockmarks) {
+    if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
       // Marks in the jumplist.  When deleting lines, this may create
       // duplicate marks in the jumplist, they will be removed later.
       for (i = 0; i < win->w_jumplistlen; i++) {
@@ -1070,7 +1070,7 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2, linenr_T amount
     }
 
     if (win->w_buffer == curbuf) {
-      if (!cmdmod.lockmarks) {
+      if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
         // marks in the tag stack
         for (i = 0; i < win->w_tagstacklen; i++) {
           if (win->w_tagstack[i].fmark.fnum == fnum) {
@@ -1159,7 +1159,7 @@ void mark_col_adjust(linenr_T lnum, colnr_T mincol, linenr_T lnum_amount, long c
   int fnum = curbuf->b_fnum;
   pos_T *posp;
 
-  if ((col_amount == 0L && lnum_amount == 0L) || cmdmod.lockmarks) {
+  if ((col_amount == 0L && lnum_amount == 0L) || (cmdmod.cmod_flags & CMOD_LOCKMARKS)) {
     return;     // nothing to do
   }
   // named marks, lower case and upper case

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -264,7 +264,7 @@ int ml_open(buf_T *buf)
   buf->b_ml.ml_chunksize = NULL;
   buf->b_ml.ml_usedchunks = 0;
 
-  if (cmdmod.noswapfile) {
+  if (cmdmod.cmod_flags & CMOD_NOSWAPFILE) {
     buf->b_p_swf = false;
   }
 
@@ -391,7 +391,7 @@ void ml_setname(buf_T *buf)
      * When 'updatecount' is 0 and 'noswapfile' there is no swap file.
      * For help files we will make a swap file now.
      */
-    if (p_uc != 0 && !cmdmod.noswapfile) {
+    if (p_uc != 0 && (cmdmod.cmod_flags & CMOD_NOSWAPFILE) == 0) {
       ml_open_file(buf);  // create a swap file
     }
     return;
@@ -475,7 +475,8 @@ void ml_open_file(buf_T *buf)
   char_u *dirp;
 
   mfp = buf->b_ml.ml_mfp;
-  if (mfp == NULL || mfp->mf_fd >= 0 || !buf->b_p_swf || cmdmod.noswapfile
+  if (mfp == NULL || mfp->mf_fd >= 0 || !buf->b_p_swf
+      || (cmdmod.cmod_flags & CMOD_NOSWAPFILE)
       || buf->terminal) {
     return;  // nothing to do
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2324,12 +2324,12 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr, int recurs
 ///          "pattern".
 bool message_filtered(char_u *msg)
 {
-  if (cmdmod.filter_regmatch.regprog == NULL) {
+  if (cmdmod.cmod_filter_regmatch.regprog == NULL) {
     return false;
   }
 
-  bool match = vim_regexec(&cmdmod.filter_regmatch, msg, (colnr_T)0);
-  return cmdmod.filter_force ? match : !match;
+  bool match = vim_regexec(&cmdmod.cmod_filter_regmatch, msg, (colnr_T)0);
+  return cmdmod.cmod_filter_force ? match : !match;
 }
 
 /// including horizontal separator

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -268,7 +268,7 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
     msg_attr_keep((char *)IObuff, 0, true, false);
   }
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // Set "'[" and "']" marks.
     curbuf->b_op_start = oap->start;
     curbuf->b_op_end.lnum = oap->end.lnum;
@@ -693,7 +693,7 @@ void op_reindent(oparg_T *oap, Indenter how)
                   "%" PRId64 " lines indented ", i),
          (int64_t)i);
   }
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // set '[ and '] marks
     curbuf->b_op_start = oap->start;
     curbuf->b_op_end = oap->end;
@@ -1793,7 +1793,7 @@ int op_delete(oparg_T *oap)
   msgmore(curbuf->b_ml.ml_line_count - old_lcount);
 
 setmarks:
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     if (oap->motion_type == kMTBlockWise) {
       curbuf->b_op_end.lnum = oap->end.lnum;
       curbuf->b_op_end.col = oap->start.col;
@@ -2063,7 +2063,7 @@ static int op_replace(oparg_T *oap, int c)
   check_cursor();
   changed_lines(oap->start.lnum, oap->start.col, oap->end.lnum + 1, 0L, true);
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // Set "'[" and "']" marks.
     curbuf->b_op_start = oap->start;
     curbuf->b_op_end = oap->end;
@@ -2133,7 +2133,7 @@ void op_tilde(oparg_T *oap)
     redraw_curbuf_later(INVERTED);
   }
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // Set '[ and '] marks.
     curbuf->b_op_start = oap->start;
     curbuf->b_op_end = oap->end;
@@ -2825,7 +2825,7 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     }
   }
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // Set "'[" and "']" marks.
     curbuf->b_op_start = oap->start;
     curbuf->b_op_end = oap->end;
@@ -3708,7 +3708,7 @@ error:
   curwin->w_set_curswant = TRUE;
 
 end:
-  if (cmdmod.lockmarks) {
+  if (cmdmod.cmod_flags & CMOD_LOCKMARKS) {
     curbuf->b_op_start = orig_start;
     curbuf->b_op_end = orig_end;
   }
@@ -4051,7 +4051,7 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
   // and setup the array of space strings lengths
   for (t = 0; t < (linenr_T)count; t++) {
     curr = curr_start = ml_get((linenr_T)(curwin->w_cursor.lnum + t));
-    if (t == 0 && setmark && !cmdmod.lockmarks) {
+    if (t == 0 && setmark && (cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
       // Set the '[ mark.
       curwin->w_buffer->b_op_start.lnum = curwin->w_cursor.lnum;
       curwin->w_buffer->b_op_start.col = (colnr_T)STRLEN(curr);
@@ -4172,7 +4172,7 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
 
   ml_replace(curwin->w_cursor.lnum, (char *)newp, false);
 
-  if (setmark && !cmdmod.lockmarks) {
+  if (setmark && (cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // Set the '] mark.
     curwin->w_buffer->b_op_end.lnum = curwin->w_cursor.lnum;
     curwin->w_buffer->b_op_end.col = sumsize;
@@ -4309,7 +4309,7 @@ static void op_format(oparg_T *oap, int keep_cursor)
     redraw_curbuf_later(INVERTED);
   }
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // Set '[ mark at the start of the formatted area
     curbuf->b_op_start = oap->start;
   }
@@ -4334,7 +4334,7 @@ static void op_format(oparg_T *oap, int keep_cursor)
   old_line_count = curbuf->b_ml.ml_line_count - old_line_count;
   msgmore(old_line_count);
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // put '] mark on the end of the formatted area
     curbuf->b_op_end = curwin->w_cursor;
   }
@@ -4945,7 +4945,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
 
     // Set '[ mark if something changed. Keep the last end
     // position from do_addsub().
-    if (change_cnt > 0 && !cmdmod.lockmarks) {
+    if (change_cnt > 0 && (cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
       curbuf->b_op_start = startpos;
     }
 
@@ -5299,7 +5299,7 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
     }
   }
 
-  if (!cmdmod.lockmarks) {
+  if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
     // set the '[ and '] marks
     curbuf->b_op_start = startpos;
     curbuf->b_op_end = endpos;
@@ -6155,7 +6155,7 @@ static void op_function(const oparg_T *oap)
 
     virtual_op = save_virtual_op;
     finish_op = save_finish_op;
-    if (cmdmod.lockmarks) {
+    if (cmdmod.cmod_flags & CMOD_LOCKMARKS) {
       curbuf->b_op_start = orig_start;
       curbuf->b_op_end = orig_end;
     }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6515,7 +6515,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_ml_nobin = p_ml_nobin;
       buf->b_p_inf = p_inf;
       COPY_OPT_SCTX(buf, BV_INF);
-      if (cmdmod.noswapfile) {
+      if (cmdmod.cmod_flags & CMOD_NOSWAPFILE) {
         buf->b_p_swf = false;
       } else {
         buf->b_p_swf = p_swf;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2493,7 +2493,7 @@ static int jump_to_help_window(qf_info_T *qi, bool newwin, int *opened_window)
 {
   win_T *wp = NULL;
 
-  if (cmdmod.tab != 0 || newwin) {
+  if (cmdmod.cmod_tab != 0 || newwin) {
     wp = NULL;
   } else {
     wp = qf_find_help_win();
@@ -2505,7 +2505,7 @@ static int jump_to_help_window(qf_info_T *qi, bool newwin, int *opened_window)
     // Split off help window; put it at far top if no position
     // specified, the current window is vertically split and narrow.
     int flags = WSP_HELP;
-    if (cmdmod.split == 0
+    if (cmdmod.cmod_split == 0
         && curwin->w_width != Columns
         && curwin->w_width < 80) {
       flags |= WSP_TOP;
@@ -2880,7 +2880,7 @@ static int qf_jump_open_window(qf_info_T *qi, qfline_T *qf_ptr, bool newwin, int
   qfltype_T qfl_type = qfl->qfl_type;
 
   // For ":helpgrep" find a help window or open one.
-  if (qf_ptr->qf_type == 1 && (!bt_help(curwin->w_buffer) || cmdmod.tab != 0)) {
+  if (qf_ptr->qf_type == 1 && (!bt_help(curwin->w_buffer) || cmdmod.cmod_tab != 0)) {
     if (jump_to_help_window(qi, newwin, opened_window) == FAIL) {
       return FAIL;
     }
@@ -3655,13 +3655,13 @@ static int qf_open_new_cwindow(qf_info_T *qi, int height)
   // The current window becomes the previous window afterwards.
   win_T *const win = curwin;
 
-  if (IS_QF_STACK(qi) && cmdmod.split == 0) {
+  if (IS_QF_STACK(qi) && cmdmod.cmod_split == 0) {
     // Create the new quickfix window at the very bottom, except when
     // :belowright or :aboveleft is used.
     win_goto(lastwin);
   }
   // Default is to open the window below the current window
-  if (cmdmod.split == 0) {
+  if (cmdmod.cmod_split == 0) {
     flags = WSP_BELOW;
   }
   flags |= WSP_NEWLOC;
@@ -3747,9 +3747,9 @@ void ex_copen(exarg_T *eap)
   reset_VIsual_and_resel();  // stop Visual mode
 
   // Find an existing quickfix window, or open a new one.
-  if (cmdmod.tab == 0) {
+  if (cmdmod.cmod_tab == 0) {
     status = qf_goto_cwindow(qi, eap->addr_count != 0, height,
-                             cmdmod.split & WSP_VERT);
+                             cmdmod.cmod_split & WSP_VERT);
   }
   if (status == FAIL) {
     if (qf_open_new_cwindow(qi, height) == FAIL) {
@@ -5510,7 +5510,7 @@ static int vgr_process_files(win_T *wp, qf_info_T *qi, vgr_args_T *cmd_args, boo
           // with the same name.
           wipe_dummy_buffer(buf, dirname_start);
           buf = NULL;
-        } else if (!cmdmod.hide
+        } else if ((cmdmod.cmod_flags & CMOD_HIDE) == 0
                    || buf->b_p_bh[0] == 'u'             // "unload"
                    || buf->b_p_bh[0] == 'w'             // "wipe"
                    || buf->b_p_bh[0] == 'd') {          // "delete"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -176,7 +176,7 @@ int search_regcomp(char_u *pat, int pat_save, int pat_use, int options, regmmatc
    * Save the currently used pattern in the appropriate place,
    * unless the pattern should not be remembered.
    */
-  if (!(options & SEARCH_KEEP) && !cmdmod.keeppatterns) {
+  if (!(options & SEARCH_KEEP) && (cmdmod.cmod_flags & CMOD_KEEPPATTERNS) == 0) {
     // search or global command
     if (pat_save == RE_SEARCH || pat_save == RE_BOTH) {
       save_re_pat(RE_SEARCH, pat, magic);
@@ -1420,7 +1420,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char_u *pat, long count,
   curwin->w_set_curswant = TRUE;
 
 end_do_search:
-  if ((options & SEARCH_KEEP) || cmdmod.keeppatterns) {
+  if ((options & SEARCH_KEEP) || (cmdmod.cmod_flags & CMOD_KEEPPATTERNS)) {
     spats[0].off = old_off;
   }
   xfree(msgbuf);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2772,7 +2772,7 @@ static int jumpto_tag(const char_u *lbuf_arg, int forceit, int keep_help)
     }
   }
   if (getfile_result == GETFILE_UNUSED
-      && (postponed_split || cmdmod.tab != 0)) {
+      && (postponed_split || cmdmod.cmod_tab != 0)) {
     if (win_split(postponed_split > 0 ? postponed_split : 0,
                   postponed_split_flags) == FAIL) {
       RedrawingDisabled--;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -569,7 +569,7 @@ wingotofile:
 
     case 'f':                       // CTRL-W gf: "gf" in a new tab page
     case 'F':                       // CTRL-W gF: "gF" in a new tab page
-      cmdmod.tab = tabpage_index(curtab) + 1;
+      cmdmod.cmod_tab = tabpage_index(curtab) + 1;
       nchar = xchar;
       goto wingotofile;
     case 't':                       // CTRL-W gt: go to next tab page
@@ -985,7 +985,7 @@ int win_split(int size, int flags)
   }
 
   // Add flags from ":vertical", ":topleft" and ":botright".
-  flags |= cmdmod.split;
+  flags |= cmdmod.cmod_split;
   if ((flags & WSP_TOP) && (flags & WSP_BOT)) {
     emsg(_("E442: Can't split topleft and botright at the same time"));
     return FAIL;
@@ -3882,7 +3882,7 @@ void close_others(int message, int forceit)
       continue;
     }
     if (!r) {
-      if (message && (p_confirm || cmdmod.confirm) && p_write) {
+      if (message && (p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM)) && p_write) {
         dialog_changed(wp->w_buffer, false);
         if (!win_valid(wp)) {                 // autocommands messed wp up
           nextwp = firstwin;
@@ -4136,10 +4136,10 @@ int win_new_tabpage(int after, char_u *filename)
  */
 int may_open_tabpage(void)
 {
-  int n = (cmdmod.tab == 0) ? postponed_split_tab : cmdmod.tab;
+  int n = (cmdmod.cmod_tab == 0) ? postponed_split_tab : cmdmod.cmod_tab;
 
   if (n != 0) {
-    cmdmod.tab = 0;         // reset it to avoid doing it twice
+    cmdmod.cmod_tab = 0;         // reset it to avoid doing it twice
     postponed_split_tab = 0;
     return win_new_tabpage(n, NULL);
   }

--- a/test/unit/search_spec.lua
+++ b/test/unit/search_spec.lua
@@ -49,7 +49,7 @@ describe('search_regcomp', function()
     --crafted to call reverse_text with invalid utf
     globals.curwin.w_onebuf_opt.wo_rl = 1
     globals.curwin.w_onebuf_opt.wo_rlc = to_cstr('s')
-    globals.cmdmod.keeppatterns = 1
+    globals.cmdmod.cmod_flags = globals.CMOD_KEEPPATTERNS
     local fail = search_regcomp("a\192", 0,0,0)
     eq(1, fail)
     eq("\192a", get_search_pat())


### PR DESCRIPTION
#### vim-patch:8.2.1897: command modifiers are saved and set inconsistently

Problem:    Command modifiers are saved and set inconsistently.
Solution:   Separate parsing and applying command modifiers.  Save values in
            cmdmod_T.
https://github.com/vim/vim/commit/5661ed6c833e05467cab33cb9b1c535e7e5cc570

Cherry-pick: :0verbose fix from patch 8.2.4741


#### vim-patch:8.2.1898: command modifier parsing always uses global cmdmod

Problem:    Command modifier parsing always uses global cmdmod.
Solution:   Pass in cmdmod_T to use.  Rename struct fields consistently.
https://github.com/vim/vim/commit/e10044015841711b989f9a898d427bcc1fdb4c32


#### vim-patch:8.2.5088: value of cmod_verbose is a bit complicated to use

Problem:    Value of cmod_verbose is a bit complicated to use.
Solution:   Use zero for not set, value + 1 when set. (closes vim/vim#10564)
https://github.com/vim/vim/commit/cd7496382efc9e6748326c6cda7f01003fa07063

Omit has_cmdmod(): only used for Vim9 script