### PR TITLE
feat(lsp): sort codelens if multiple item per line

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -133,6 +133,9 @@ function M.display(lenses, bufnr, client_id)
     api.nvim_buf_clear_namespace(bufnr, ns, i, i + 1)
     local chunks = {}
     local num_line_lenses = #line_lenses
+    table.sort(line_lenses, function(a, b)
+      return a.range.start.character < b.range.start.character
+    end)
     for j, lens in ipairs(line_lenses) do
       local text = lens.command and lens.command.title or 'Unresolved lens ...'
       table.insert(chunks, { text, 'LspCodeLens' })


### PR DESCRIPTION
Sometimes there are multiple codelens per line, they must be sort with special order.
For example, ccls will send more than one codelens per line if there are multiple symbols in one line and their order should be the same as the symbol they refer to.
With this pr, ccls will display correct order of codelens:
![image](https://user-images.githubusercontent.com/50723480/173350385-6a0fb378-eef4-4b1c-a2b8-33ca3173fcdf.png)
