### PR TITLE
vim-patch:8.2.0577: not all modifiers supported for :options

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -1637,10 +1637,13 @@ void ex_compiler(exarg_T *eap)
 /// ":options"
 void ex_options(exarg_T *eap)
 {
-  os_setenv("OPTWIN_CMD", cmdmod.tab ? "tab" : "", 1);
-  os_setenv("OPTWIN_CMD",
-            cmdmod.tab ? "tab" :
-            (cmdmod.split & WSP_VERT) ? "vert" : "", 1);
+  char buf[500];
+  bool multi_mods = 0;
+
+  buf[0] = NUL;
+  (void)add_win_cmd_modifers(buf, &multi_mods);
+
+  os_setenv("OPTWIN_CMD", buf, 1);
   cmd_source(SYS_OPTWIN_FILE, NULL);
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6555,23 +6555,46 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
   return result;
 }
 
+/// Add modifiers from "cmdmod.split" to "buf".  Set "multi_mods" when one was
+/// added.
+///
+/// @return the number of bytes added
+size_t add_win_cmd_modifers(char *buf, bool *multi_mods)
+{
+  size_t result = 0;
+
+  // :aboveleft and :leftabove
+  if (cmdmod.split & WSP_ABOVE) {
+    result += add_cmd_modifier(buf, "aboveleft", multi_mods);
+  }
+  // :belowright and :rightbelow
+  if (cmdmod.split & WSP_BELOW) {
+    result += add_cmd_modifier(buf, "belowright", multi_mods);
+  }
+  // :botright
+  if (cmdmod.split & WSP_BOT) {
+    result += add_cmd_modifier(buf, "botright", multi_mods);
+  }
+
+  // :tab
+  if (cmdmod.tab > 0) {
+    result += add_cmd_modifier(buf, "tab", multi_mods);
+  }
+  // :topleft
+  if (cmdmod.split & WSP_TOP) {
+    result += add_cmd_modifier(buf, "topleft", multi_mods);
+  }
+  // :vertical
+  if (cmdmod.split & WSP_VERT) {
+    result += add_cmd_modifier(buf, "vertical", multi_mods);
+  }
+  return result;
+}
+
 size_t uc_mods(char *buf)
 {
   size_t result = 0;
   bool multi_mods = false;
-
-  // :aboveleft and :leftabove
-  if (cmdmod.split & WSP_ABOVE) {
-    result += add_cmd_modifier(buf, "aboveleft", &multi_mods);
-  }
-  // :belowright and :rightbelow
-  if (cmdmod.split & WSP_BELOW) {
-    result += add_cmd_modifier(buf, "belowright", &multi_mods);
-  }
-  // :botright
-  if (cmdmod.split & WSP_BOT) {
-    result += add_cmd_modifier(buf, "botright", &multi_mods);
-  }
 
   typedef struct {
     bool *set;
@@ -6602,14 +6625,6 @@ size_t uc_mods(char *buf)
   if (msg_silent > 0) {
     result += add_cmd_modifier(buf, emsg_silent > 0 ? "silent!" : "silent", &multi_mods);
   }
-  // :tab
-  if (cmdmod.tab > 0) {
-    result += add_cmd_modifier(buf, "tab", &multi_mods);
-  }
-  // :topleft
-  if (cmdmod.split & WSP_TOP) {
-    result += add_cmd_modifier(buf, "topleft", &multi_mods);
-  }
 
   // TODO(vim): How to support :unsilent?
 
@@ -6617,10 +6632,8 @@ size_t uc_mods(char *buf)
   if (p_verbose > 0) {
     result += add_cmd_modifier(buf, "verbose", &multi_mods);
   }
-  // :vertical
-  if (cmdmod.split & WSP_VERT) {
-    result += add_cmd_modifier(buf, "vertical", &multi_mods);
-  }
+  // flags from cmdmod.split
+  result += add_win_cmd_modifers(buf, &multi_mods);
 
   return result;
 }

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -98,6 +98,19 @@ func Test_options_command()
   " close option-window
   close
 
+  " Open the option-window at the top.
+  set splitbelow
+  topleft options
+  call assert_equal(1, winnr())
+  close
+
+  " Open the option-window at the bottom.
+  set nosplitbelow
+  botright options
+  call assert_equal(winnr('$'), winnr())
+  close
+  set splitbelow&
+
   " Open the option-window in a new tab.
   tab options
   " Check if the option-window is opened in a tab.
@@ -105,9 +118,15 @@ func Test_options_command()
   call assert_notequal('option-window', bufname(''))
   normal gt
   call assert_equal('option-window', bufname(''))
-
   " close option-window
   close
+
+  " Open the options window browse
+  if has('browse')
+    browse set
+    call assert_equal('option-window', bufname(''))
+    close
+  endif
 endfunc
 
 func Test_path_keep_commas()

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -4,63 +4,95 @@
 function Test_cmdmods()
   let g:mods = ''
 
-  command! -nargs=* MyCmd let g:mods .= '<mods> '
+  command! -nargs=* MyCmd let g:mods = '<mods>'
 
   MyCmd
+  call assert_equal('', g:mods)
   aboveleft MyCmd
+  call assert_equal('aboveleft', g:mods)
   abo MyCmd
+  call assert_equal('aboveleft', g:mods)
   belowright MyCmd
+  call assert_equal('belowright', g:mods)
   bel MyCmd
+  call assert_equal('belowright', g:mods)
   botright MyCmd
+  call assert_equal('botright', g:mods)
   bo MyCmd
+  call assert_equal('botright', g:mods)
   browse MyCmd
+  call assert_equal('browse', g:mods)
   bro MyCmd
+  call assert_equal('browse', g:mods)
   confirm MyCmd
+  call assert_equal('confirm', g:mods)
   conf MyCmd
+  call assert_equal('confirm', g:mods)
   hide MyCmd
+  call assert_equal('hide', g:mods)
   hid MyCmd
+  call assert_equal('hide', g:mods)
   keepalt MyCmd
+  call assert_equal('keepalt', g:mods)
   keepa MyCmd
+  call assert_equal('keepalt', g:mods)
   keepjumps MyCmd
+  call assert_equal('keepjumps', g:mods)
   keepj MyCmd
+  call assert_equal('keepjumps', g:mods)
   keepmarks MyCmd
+  call assert_equal('keepmarks', g:mods)
   kee MyCmd
+  call assert_equal('keepmarks', g:mods)
   keeppatterns MyCmd
+  call assert_equal('keeppatterns', g:mods)
   keepp MyCmd
+  call assert_equal('keeppatterns', g:mods)
   leftabove MyCmd  " results in :aboveleft
+  call assert_equal('aboveleft', g:mods)
   lefta MyCmd
+  call assert_equal('aboveleft', g:mods)
   lockmarks MyCmd
+  call assert_equal('lockmarks', g:mods)
   loc MyCmd
+  call assert_equal('lockmarks', g:mods)
   " noautocmd MyCmd
   noswapfile MyCmd
+  call assert_equal('noswapfile', g:mods)
   nos MyCmd
+  call assert_equal('noswapfile', g:mods)
   rightbelow MyCmd " results in :belowright
+  call assert_equal('belowright', g:mods)
   rightb MyCmd
+  call assert_equal('belowright', g:mods)
   " sandbox MyCmd
   silent MyCmd
+  call assert_equal('silent', g:mods)
   sil MyCmd
+  call assert_equal('silent', g:mods)
   tab MyCmd
+  call assert_equal('tab', g:mods)
   topleft MyCmd
+  call assert_equal('topleft', g:mods)
   to MyCmd
+  call assert_equal('topleft', g:mods)
   " unsilent MyCmd
   verbose MyCmd
+  call assert_equal('verbose', g:mods)
   verb MyCmd
+  call assert_equal('verbose', g:mods)
   vertical MyCmd
+  call assert_equal('vertical', g:mods)
   vert MyCmd
+  call assert_equal('vertical', g:mods)
 
   aboveleft belowright botright browse confirm hide keepalt keepjumps
-        \ keepmarks keeppatterns lockmarks noswapfile silent tab
-        \ topleft verbose vertical MyCmd
+	      \ keepmarks keeppatterns lockmarks noswapfile silent tab
+	      \ topleft verbose vertical MyCmd
 
-  call assert_equal(' aboveleft aboveleft belowright belowright botright ' .
-        \ 'botright browse browse confirm confirm hide hide ' .
-        \ 'keepalt keepalt keepjumps keepjumps keepmarks keepmarks ' .
-        \ 'keeppatterns keeppatterns aboveleft aboveleft lockmarks lockmarks noswapfile ' .
-        \ 'noswapfile belowright belowright silent silent tab topleft topleft verbose verbose ' .
-        \ 'vertical vertical ' .
-        \ 'aboveleft belowright botright browse confirm hide keepalt keepjumps ' .
-        \ 'keepmarks keeppatterns lockmarks noswapfile silent tab topleft ' .
-        \ 'verbose vertical ', g:mods)
+  call assert_equal('browse confirm hide keepalt keepjumps ' .
+      \ 'keepmarks keeppatterns lockmarks noswapfile silent ' .
+      \ 'verbose aboveleft belowright botright tab topleft vertical', g:mods)
 
   let g:mods = ''
   command! -nargs=* MyQCmd let g:mods .= '<q-mods> '


### PR DESCRIPTION
#### vim-patch:8.2.0577: not all modifiers supported for :options

Problem:    Not all modifiers supported for :options.
Solution:   Use all cmdmod.split flags.
https://github.com/vim/vim/commit/7a1637f4c00ac3d0cbf894803ada1586a1717470

Cherry-pick Test_options_command() change from patch 8.2.0540