### PR TITLE
vim-patch:8.2.5097: using uninitialized memory when using 'listchars'

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1851,8 +1851,8 @@ void msg_prt_line(char_u *s, int list)
       } else if (curwin->w_p_lcs_chars.nbsp != NUL && list
                  && (utf_ptr2char((char *)s) == 160
                      || utf_ptr2char((char *)s) == 0x202f)) {
-        utf_char2bytes(curwin->w_p_lcs_chars.nbsp, buf);
-        buf[utfc_ptr2len(buf)] = NUL;
+        int len = utf_char2bytes(curwin->w_p_lcs_chars.nbsp, buf);
+        buf[len] = NUL;
       } else {
         memmove(buf, s, (size_t)l);
         buf[l] = NUL;


### PR DESCRIPTION
#### vim-patch:8.2.5097: using uninitialized memory when using 'listchars'

Problem:    Using uninitialized memory when using 'listchars'.
Solution:   Use the length returned by mb_char2bytes().
https://github.com/vim/vim/commit/74ac29cecd56457ee93f3f71b31b7a2e6d9712d6