### PR TITLE
fix(lua): highlight.on_yank can close timer in twice

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -408,7 +408,9 @@ function vim.defer_fn(fn, timeout)
     timeout,
     0,
     vim.schedule_wrap(function()
-      timer:close()
+      if not timer:is_closing() then
+        timer:close()
+      end
 
       fn()
     end)

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -6,20 +6,29 @@ local command = helpers.command
 local clear = helpers.clear
 
 describe('vim.highlight.on_yank', function()
-
   before_each(function()
     clear()
   end)
 
   it('does not show errors even if buffer is wiped before timeout', function()
     command('new')
-    exec_lua[[
+    exec_lua([[
       vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y", regtype = "v"}})
       vim.cmd('bwipeout!')
-    ]]
+    ]])
     helpers.sleep(10)
     helpers.feed('<cr>') -- avoid hang if error message exists
     eq('', eval('v:errmsg'))
   end)
 
+  it('does not show errors even if it is executed between timeout and clearing highlight', function()
+    exec_lua([[
+      vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y"}})
+      vim.loop.sleep(10)
+      vim.schedule(function()
+        vim.highlight.on_yank({timeout = 0, on_macro = true, event = {operator = "y"}})
+      end)
+    ]])
+    eq('', eval('v:errmsg'))
+  end)
 end)

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -21,7 +21,7 @@ describe('vim.highlight.on_yank', function()
     eq('', eval('v:errmsg'))
   end)
 
-  it('does not show errors even if it is executed between timeout and clearing highlight', function()
+  it('does not close timer twice', function()
     exec_lua([[
       vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y"}})
       vim.loop.sleep(10)


### PR DESCRIPTION
This PR will fix the error in `vim.highlight.on_yank`.

### reproduce

1. setting `vim.highlight.on_yank`
```lua
vim.api.nvim_create_autocmd({ "TextYankPost" }, {
  pattern = { "*" },
  callback = function()
    vim.highlight.on_yank({ timeout = 200 })
  end,
})
```
2. repeat typing `yeye` ...
3. causes the following error.
```
Error executing vim.schedule lua callback: vim/_editor.lua:0: handle 0x01e96970 is already closing
stack traceback:
	[C]: in function 'close'
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

📝 test result before fix
```
[----------] Global test environment setup.
[----------] Running tests from test/functional/lua/highlight_spec.lua
[ RUN      ] vim.highlight.on_yank does not show errors even if buffer is wiped before timeout: 15.07 ms OK
[ RUN      ] vim.highlight.on_yank does not show errors even if executed between timeout and clearing highlight: 15.07 ms ERR
test/helpers.lua:73: Expected objects to be the same.
Passed in:
(string) 'Error executing vim.schedule lua callback: vim/_editor.lua:0: handle 0x02025260 is already closing
stack traceback:
        [C]: in function 'close'
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>'
Expected:
(string) ''
```

