### PR TITLE
fix: use ctermbg/fg instead of bg/fg when use_rgb is false

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -942,9 +942,9 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     hlattrs.cterm_fg_color = ctermfg == -1 ? 0 : ctermfg + 1;
     hlattrs.cterm_ae_attr = cterm_mask;
   } else {
+    hlattrs.cterm_bg_color = ctermbg == -1 ? 0 : ctermbg + 1;
+    hlattrs.cterm_fg_color = ctermfg == -1 ? 0 : ctermfg + 1;
     hlattrs.cterm_ae_attr = cterm_mask;
-    hlattrs.cterm_bg_color = bg == -1 ? 0 : bg + 1;
-    hlattrs.cterm_fg_color = fg == -1 ? 0 : fg + 1;
   }
 
   return hlattrs;


### PR DESCRIPTION
If `use_rgb` was false, we would attempt to set the `cterm_bg_color` to the variable `bg`, which is only retrieved from `bg` and `background` keys, not `ctermbg`. Same for `fg`. This means the values would be `-1` (the default, un-got value) and we'd always set the returned values to `0`.

My understanding is `fg/bg` is always "gui" values, so instead we should be using `ctermbg` when needed.

Nb: when looking around I think this function is currently *always* called with `use_rgb = true`.