### PR TITLE
backport highlight.on_yank timer fixes #18824 and #18976

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -373,9 +373,13 @@ end
 function vim.defer_fn(fn, timeout)
   vim.validate { fn = { fn, 'c', true}; }
   local timer = vim.loop.new_timer()
-  timer:start(timeout, 0, vim.schedule_wrap(function()
-    timer:stop()
-    timer:close()
+  timer:start(
+    timeout,
+    0,
+    vim.schedule_wrap(function()
+      if not timer:is_closing() then
+        timer:close()
+      end
 
     fn()
   end))

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -63,7 +63,8 @@ function M.range(bufnr, ns, higroup, start, finish, opts)
   end
 end
 
-local yank_ns = api.nvim_create_namespace("hlyank")
+local yank_ns = api.nvim_create_namespace('hlyank')
+local yank_timer
 --- Highlight the yanked region
 ---
 --- use from init.vim via
@@ -113,6 +114,9 @@ function M.on_yank(opts)
 
   local bufnr = api.nvim_get_current_buf()
   api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
+  if yank_timer then
+    yank_timer:close()
+  end
 
   local pos1 = vim.fn.getpos("'[")
   local pos2 = vim.fn.getpos("']")
@@ -129,7 +133,8 @@ function M.on_yank(opts)
     { regtype = event.regtype, inclusive = event.inclusive, priority = M.priorities.user }
   )
 
-  vim.defer_fn(function()
+  yank_timer = vim.defer_fn(function()
+    yank_timer = nil
     if api.nvim_buf_is_valid(bufnr) then
       api.nvim_buf_clear_namespace(bufnr, yank_ns, 0, -1)
     end

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -6,20 +6,29 @@ local command = helpers.command
 local clear = helpers.clear
 
 describe('vim.highlight.on_yank', function()
-
   before_each(function()
     clear()
   end)
 
   it('does not show errors even if buffer is wiped before timeout', function()
     command('new')
-    exec_lua[[
+    exec_lua([[
       vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y", regtype = "v"}})
       vim.cmd('bwipeout!')
-    ]]
+    ]])
     helpers.sleep(10)
     helpers.feed('<cr>') -- avoid hang if error message exists
     eq('', eval('v:errmsg'))
   end)
 
+  it('does not close timer twice', function()
+    exec_lua([[
+      vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y"}})
+      vim.loop.sleep(10)
+      vim.schedule(function()
+        vim.highlight.on_yank({timeout = 0, on_macro = true, event = {operator = "y"}})
+      end)
+    ]])
+    eq('', eval('v:errmsg'))
+  end)
 end)


### PR DESCRIPTION
close timer for `vim.highlight.on_yank` if called again before elapsing (but not if it's already being closed)