### PR TITLE
[Backport release-0.7] vim-patch:8.2.5097: using uninitialized memory when using 'listchars'

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1812,8 +1812,8 @@ void msg_prt_line(char_u *s, int list)
       } else if (curwin->w_p_lcs_chars.nbsp != NUL && list
                  && (utf_ptr2char(s) == 160
                      || utf_ptr2char(s) == 0x202f)) {
-        utf_char2bytes(curwin->w_p_lcs_chars.nbsp, (char_u *)buf);
-        buf[utfc_ptr2len((char_u *)buf)] = NUL;
+        int len = utf_char2bytes(curwin->w_p_lcs_chars.nbsp, (char_u *)buf);
+        buf[len] = NUL;
       } else {
         memmove(buf, s, (size_t)l);
         buf[l] = NUL;


### PR DESCRIPTION
Problem:    Using uninitialized memory when using 'listchars'.
Solution:   Use the length returned by mb_char2bytes(). (closes vim/vim#10576)
https://github.com/vim/vim/commit/74ac29cecd56457ee93f3f71b31b7a2e6d9712d6