### PR TITLE
vim-patch:8.2.5110: icon filetype not recognized from the first line

### DIFF
--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -202,6 +202,10 @@ if s:line1 =~# "^#!"
   elseif s:name =~# 'gforth\>'
     set ft=forth
 
+    " Icon
+  elseif s:name =~# 'icon\>'
+    set ft=icon
+
   endif
   unlet s:name
 

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -717,6 +717,7 @@ let s:script_checks = {
       \ 'routeros': [['#!/path/rsc']],
       \ 'fish': [['#!/path/fish']],
       \ 'forth': [['#!/path/gforth']],
+      \ 'icon': [['#!/path/icon']],
       \ }
 
 " Various forms of "env" optional arguments.


### PR DESCRIPTION
Problem:    Icon filetype not recognized from the first line.
Solution:   Add a check for the first line. (Doug Kearns)
https://github.com/vim/vim/commit/bf6614643f656d38d220c04befdcb1d35774853a