### PR TITLE
fix(lsp): fix some small bugs in snippet-parser

### DIFF
--- a/test/functional/plugin/lsp/snippet_spec.lua
+++ b/test/functional/plugin/lsp/snippet_spec.lua
@@ -19,9 +19,9 @@ describe('vim.lsp._snippet', function()
         {
           type = snippet.NodeType.TEXT,
           raw = 'TE\\$\\}XT',
-          esc = 'TE$}XT'
-        }
-      }
+          esc = 'TE$}XT',
+        },
+      },
     }, parse('TE\\$\\}XT'))
   end)
 
@@ -36,8 +36,8 @@ describe('vim.lsp._snippet', function()
         {
           type = snippet.NodeType.TABSTOP,
           tabstop = 2,
-        }
-      }
+        },
+      },
     }, parse('$1${2}'))
   end)
 
@@ -56,7 +56,7 @@ describe('vim.lsp._snippet', function()
                 {
                   type = snippet.NodeType.TEXT,
                   raw = 'TE\\$\\}XT',
-                  esc = 'TE$}XT'
+                  esc = 'TE$}XT',
                 },
                 {
                   type = snippet.NodeType.TABSTOP,
@@ -73,21 +73,21 @@ describe('vim.lsp._snippet', function()
                       {
                         type = snippet.NodeType.FORMAT,
                         capture_index = 1,
-                        modifier = 'upcase'
-                      }
-                    }
+                        modifier = 'upcase',
+                      },
+                    },
                   },
                 },
                 {
                   type = snippet.NodeType.TEXT,
                   raw = 'TE\\$\\}XT',
-                  esc = 'TE$}XT'
+                  esc = 'TE$}XT',
                 },
-              }
-            }
-          }
+              },
+            },
+          },
         },
-      }
+      },
     }, parse('${1:${2:TE\\$\\}XT$3${1/regex/${1:/upcase}/i}TE\\$\\}XT}}'))
   end)
 
@@ -110,8 +110,8 @@ describe('vim.lsp._snippet', function()
             {
               type = snippet.NodeType.TABSTOP,
               tabstop = 1,
-            }
-          }
+            },
+          },
         },
         {
           type = snippet.NodeType.VARIABLE,
@@ -124,11 +124,11 @@ describe('vim.lsp._snippet', function()
                 type = snippet.NodeType.FORMAT,
                 capture_index = 1,
                 modifier = 'upcase',
-              }
-            }
-          }
+              },
+            },
+          },
         },
-      }
+      },
     }, parse('$VAR${VAR}${VAR:$1}${VAR/regex/${1:/upcase}/}'))
   end)
 
@@ -141,12 +141,96 @@ describe('vim.lsp._snippet', function()
           tabstop = 1,
           items = {
             ',',
-            '|'
-          }
-        }
-      }
+            '|',
+          },
+        },
+      },
     }, parse('${1|\\,,\\||}'))
   end)
 
-end)
+  it('should parse format', function()
+    eq({
+      type = snippet.NodeType.SNIPPET,
+      children = {
+        {
+          type = snippet.NodeType.VARIABLE,
+          name = 'VAR',
+          transform = {
+            type = snippet.NodeType.TRANSFORM,
+            pattern = 'regex',
+            format = {
+              {
+                type = snippet.NodeType.FORMAT,
+                capture_index = 1,
+                modifier = 'upcase',
+              },
+              {
+                type = snippet.NodeType.FORMAT,
+                capture_index = 1,
+                if_text = 'if_text',
+                else_text = '',
+              },
+              {
+                type = snippet.NodeType.FORMAT,
+                capture_index = 1,
+                if_text = '',
+                else_text = 'else_text',
+              },
+              {
+                type = snippet.NodeType.FORMAT,
+                capture_index = 1,
+                else_text = 'else_text',
+                if_text = 'if_text',
+              },
+              {
+                type = snippet.NodeType.FORMAT,
+                capture_index = 1,
+                if_text = '',
+                else_text = 'else_text',
+              },
+            },
+          },
+        },
+      },
+    }, parse('${VAR/regex/${1:/upcase}${1:+if_text}${1:-else_text}${1:?if_text:else_text}${1:else_text}/}'))
+  end)
 
+  it('should parse empty strings', function()
+    eq({
+      children = {
+        {
+          children = { {
+            esc = '',
+            raw = '',
+            type = 7,
+          } },
+          tabstop = 1,
+          type = 2,
+        },
+        {
+          esc = ' ',
+          raw = ' ',
+          type = 7,
+        },
+        {
+          name = 'VAR',
+          transform = {
+            format = {
+              {
+                capture_index = 1,
+                else_text = '',
+                if_text = '',
+                type = 6,
+              },
+            },
+            option = 'g',
+            pattern = 'erg',
+            type = 5,
+          },
+          type = 3,
+        },
+      },
+      type = 0,
+    }, parse('${1:} ${VAR/erg/${1:?:}/g}'))
+  end)
+end)


### PR DESCRIPTION
As mentioned in #18772, there are some small bugs in the current parser.

I've been able to fix the parsing of `the format`(`${VARIABLE/regex/format}}`)-variants (`:else_text`, `:-else_text`), but handling emtpy `if/else_text` (and empty placeholder text, which is also technically allowed) seems harder:
Accepting an empty string in `take_until` leads to infinite loops in [`P.many`](https://github.com/L3MON4D3/neovim/blob/cb1717d9639bd947c09cc44076bc808c4f2aba0d/runtime/lua/vim/lsp/_snippet.lua#L112-L117), and I have no idea how to prevent those.

(Empty strings are technically allowed, but any snippet that includes an empty string can be written without it (`${1:if_text?}` -> `${1:+if_text}`, `${1:}` -> `$1`))

(vscode seems to handle empty strings just fine, but IIRC they also use a parser combinator, so I'll have to look into that)