### PR TITLE
feat(lsp): defaults: tagfunc, omnifunc

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -51,15 +51,14 @@ Starting a LSP client will automatically report diagnostics via
 |vim.diagnostic|. Read |vim.diagnostic.config| to learn how to customize the
 display.
 
-To get completion from the LSP server you can enable the |vim.lsp.omnifunc|:
->
-    vim.bo.omnifunc = 'v:lua.vim.lsp.omnifunc'
-<
-To trigger completion, use |i_CTRL-X_CTRL-O|
+It also sets some buffer options if the options are otherwise empty and if the
+language server supports the functionality.
 
-To get features like go-to-definition you can enable the |vim.lsp.tagfunc|
-which changes commands like |:tjump| to utilize the language server and also
-enables keymaps like |CTLR-]|, |CTRL-W_]|, |CTRL-W_}| and many more.
+- |omnifunc| is set to |vim.lsp.omnifunc|. This allows to trigger completion
+  using |i_CTRL-X_CTRL-o|
+- |tagfunc| is set to |vim.lsp.tagfunc|. This enables features like
+  go-to-definition, |:tjump|, and keymaps like |CTRL-]|, |CTRL-W_]|,
+  |CTRL-W_}| to utilize the language server.
 
 To use other LSP features like hover, rename, etc. you can setup some
 additional keymaps. It's recommended to setup them in a |LspAttach| autocmd to

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1325,6 +1325,13 @@ function lsp.start_client(config)
   function client._on_attach(bufnr)
     text_document_did_open_handler(bufnr, client)
 
+    if client.server_capabilities.definitionProvider and vim.bo[bufnr].tagfunc == '' then
+      vim.bo[bufnr].tagfunc = 'v:lua.vim.lsp.tagfunc'
+    end
+    if client.server_capabilities.completionProvider and vim.bo[bufnr].omnifunc == '' then
+      vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
+    end
+
     nvim_exec_autocmds('LspAttach', {
       buffer = bufnr,
       modeline = false,

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -562,7 +562,7 @@ end
 ---@private
 --- Default handler for the 'textDocument/didOpen' LSP notification.
 ---
----@param bufnr (Number) Number of the buffer, or 0 for current
+---@param bufnr number Number of the buffer, or 0 for current
 ---@param client Client object
 local function text_document_did_open_handler(bufnr, client)
   changetracking.init(client, bufnr)
@@ -948,6 +948,28 @@ function lsp.start_client(config)
   end
 
   ---@private
+  local function set_defaults(client, bufnr)
+    if client.server_capabilities.definitionProvider and vim.bo[bufnr].tagfunc == '' then
+      vim.bo[bufnr].tagfunc = 'v:lua.vim.lsp.tagfunc'
+    end
+    if client.server_capabilities.completionProvider and vim.bo[bufnr].omnifunc == '' then
+      vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
+    end
+  end
+
+  ---@private
+  --- Reset defaults set by `set_defaults`.
+  --- Must only be called if the last client attached to a buffer exits.
+  local function unset_defaults(bufnr)
+    if vim.bo[bufnr].tagfunc == 'v:lua.vim.lsp.tagfunc' then
+      vim.bo[bufnr].tagfunc = nil
+    end
+    if vim.bo[bufnr].omnifunc == 'v:lua.vim.lsp.omnifunc' then
+      vim.bo[bufnr].omnifunc = nil
+    end
+  end
+
+  ---@private
   --- Invoked on client exit.
   ---
   ---@param code (number) exit code of the process
@@ -971,6 +993,11 @@ function lsp.start_client(config)
         end)
 
         client_ids[client_id] = nil
+      end
+      if vim.tbl_isempty(client_ids) then
+        vim.schedule(function()
+          unset_defaults(bufnr)
+        end)
       end
     end
 
@@ -1325,12 +1352,7 @@ function lsp.start_client(config)
   function client._on_attach(bufnr)
     text_document_did_open_handler(bufnr, client)
 
-    if client.server_capabilities.definitionProvider and vim.bo[bufnr].tagfunc == '' then
-      vim.bo[bufnr].tagfunc = 'v:lua.vim.lsp.tagfunc'
-    end
-    if client.server_capabilities.completionProvider and vim.bo[bufnr].omnifunc == '' then
-      vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
-    end
+    set_defaults(client, bufnr)
 
     nvim_exec_autocmds('LspAttach', {
       buffer = bufnr,


### PR DESCRIPTION
Opening this up as draft to test the waters.

The main motivation is to make the LSP setup a bit easier. Currently `:help lsp-config` recommends users to setup `tagfunc`, `omnifunc`, and several keymaps. This is boilerplate that we may be able to avoid if we can come up with a choice that is uncontroversial enough. I think it would be acceptable if it removes boilerplate for ~90% of the use-cases, while maybe adding a bit of extra config for the remaining 10%.

A few of those are fairly unintrusive. That makes them candidates to start with. This PR starts with two:

- `omnifunc`: Is set if empty and if the server has the capability. I don't see any downsides to this.
- `tagfunc`: Is set if empty and if the server has the capability. This overrides regular ctags uses so that LSP symbols have priority. ctags will still be used as fallback if the LSP server times out. If a user wants to continue using regular ctags without querying the language server, they'd have to run `setlocal tagfunc<` in a `LspAttach` event.

The options are set shortly before `LspAttach` & `config.on_attach` gets triggered. This should ensure that custom configuration in `FileType` events would already have happened (so those are *not* overridden), and also give the option to *undo* the settings.

### Other options:

- Leave things as they are
- Add a `vim.lsp.set_defaults` function or something like that. Users could call that within a `LspAttach` event or the `on_attach` handler. (I fear this might explode into some kind of custom keymap DSL if users start requesting to have a subset of defaults) (*edit*: We'd probably need a `unset_defaults` to use for detach as well?)
- Add this, but only with explicit opt-in. E.g. add a `set_default` flags to `vim.lsp.start`.
- Add this, but with an opt-out. E.g. add a `set_default` flags to `vim.lsp.start`.

### Possible follow up:

- keywordprg or map K to hover
- formatexpr


This draft intentionally left out docs updates and detach logic. I'll add that only if this has a chance of moving forward.
