### PR TITLE
vim-patch:8.2.{5120.5121}

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4057,6 +4057,11 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
 
     // Find out if we have a quote in the selection.
     while (i <= col_end) {
+      // check for going over the end of the line, which can happen if
+      // the line was changed after the Visual area was selected.
+      if (line[i] == NUL) {
+        break;
+      }
       if (line[i++] == quotechar) {
         selected_quote = true;
         break;

--- a/src/nvim/testdir/test_interrupt.vim
+++ b/src/nvim/testdir/test_interrupt.vim
@@ -13,15 +13,20 @@ func s:bufwritepost()
 endfunction
 
 func Test_interrupt()
-  new Xfile
+  new Xinterrupt
   let n = 0
   try
-    au BufWritePre Xfile call s:bufwritepre()
-    au BufWritePost Xfile call s:bufwritepost()
+    au BufWritePre Xinterrupt call s:bufwritepre()
+    au BufWritePost Xinterrupt call s:bufwritepost()
     w!
   catch /^Vim:Interrupt$/
   endtry
   call assert_equal(1, s:bufwritepre_called)
   call assert_equal(0, s:bufwritepost_called)
-  call assert_equal(0, filereadable('Xfile'))
+  call assert_equal(0, filereadable('Xinterrupt'))
+
+  au! BufWritePre
+  au! BufWritePost
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.5120: searching for quotes may go over the end of the line

Problem:    Searching for quotes may go over the end of the line.
Solution:   Check for running into the NUL.
https://github.com/vim/vim/commit/2f074f4685897ab7212e25931eeeb0212292829f


#### vim-patch:8.2.5121: interrupt test sometimes fails

Problem:    Interrupt test sometimes fails.
Solution:   Use a different file name.
https://github.com/vim/vim/commit/8d6420631c2bd73dbc1939c4bf04ab7bb39cc263

Add a modeline to test_interrupt.vim.