### PR TITLE
vim-patch:8.2.5123: using invalid index when looking for spell suggestions

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -4391,7 +4391,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
             sp->ts_fcharstart = sp->ts_fidx - 1;
             sp->ts_isdiff = (newscore != 0)
                             ? DIFF_YES : DIFF_NONE;
-          } else if (sp->ts_isdiff == DIFF_INSERT) {
+          } else if (sp->ts_isdiff == DIFF_INSERT && sp->ts_fidx > 0) {
             // When inserting trail bytes don't advance in the
             // bad word.
             sp->ts_fidx--;

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -72,6 +72,16 @@ func Test_z_equal_on_invalid_utf8_word()
   bwipe!
 endfunc
 
+func Test_z_equal_on_single_character()
+  " this was decrementing the index below zero
+  new
+  norm a0\Ê
+  norm zW
+  norm z=
+
+  bwipe!
+endfunc
+
 " Test spellbadword() with argument
 func Test_spellbadword()
   set spell


### PR DESCRIPTION
#### vim-patch:8.2.5123: using invalid index when looking for spell suggestions

Problem:    Using invalid index when looking for spell suggestions.
Solution:   Do not decrement the index when it is zero.
https://github.com/vim/vim/commit/156d3911952d73b03d7420dc3540215247db0fe8