### PR TITLE
fix(logging): try harder to resolve Nvim "name"

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8199,7 +8199,7 @@ varnumber_T get_vim_var_nr(int idx) FUNC_ATTR_PURE
 
 /// Get string v: variable value.  Uses a static buffer, can only be used once.
 /// If the String variable has never been set, return an empty string.
-/// Never returns NULL;
+/// Never returns NULL.
 char *get_vim_var_str(int idx)
   FUNC_ATTR_PURE FUNC_ATTR_NONNULL_RET
 {

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -305,15 +305,15 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
 
   // Get a name for this Nvim instance.
   // TODO(justinmk): expose this as v:name ?
-  if (starting || name[0] == '\0') {
+  if (name[0] == '\0') {
     // Parent servername.
     const char *parent = path_tail(os_getenv(ENV_NVIM));
     // Servername. Empty until starting=false.
     const char *serv = path_tail(get_vim_var_str(VV_SEND_SERVER));
     if (parent && parent[0] != NUL) {
       snprintf(name, sizeof(name), "%s/c", parent);  // "/c" indicates child.
-    } else if (serv && serv[0] != NUL) {
-      snprintf(name, sizeof(name), "%s", serv ? serv : "");
+    } else if (serv[0] != NUL) {
+      snprintf(name, sizeof(name), "%s", serv);
     } else {
       int64_t pid = os_get_pid();
       snprintf(name, sizeof(name), "?.%-5" PRId64, pid);
@@ -329,6 +329,11 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
                                          log_levels[log_level], date_time, millis, name,
                                          (context == NULL ? "" : context),
                                          func_name, line_num);
+  if (name[0] == '?') {
+    // No v:servername yet. Clear `name` so that the next log can try again.
+    name[0] = '\0';
+  }
+
   if (rv < 0) {
     return false;
   }


### PR DESCRIPTION
Problem:
If startup finishes (starting=false) before the logger ever happens to
see a v:servername, we're stuck with the `"?.<PID>"` fallback name
forever.

Solution:
Drop the `starting` condition. Discard the `"?.<PID>"` fallback after
using it for the current log message. So logging will always check
v:servername next time.