### PR TITLE
ci(release): skip CoreServices system library on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           libs=($(otool -L nvim-osx64/bin/nvim | sed 1d | sed -E -e 's|^[[:space:]]*||' -e 's| .*||'))
           echo "libs:"
           for lib in "${libs[@]}"; do
-            if echo "$lib" | grep -q -E 'libSystem|CoreFoundation' 2>/dev/null; then
+            if echo "$lib" | grep -q -E 'libSystem|CoreServices' 2>/dev/null; then
               echo "  [skipped] $lib"
             else
               echo "  $lib"


### PR DESCRIPTION
Problem:
The release script bundles a system library (CoreServices) that was
added in #18294, which leads to errors on M1 since the architecture is
different from the Github runner.

Solution:
Skip CoreServices when bundling the libraries (as was done for the
CoreFoundation library that #18294 replaced with CoreServices).

Fixes  #18504