### PR TITLE
[Backport release-0.7] ci(release): skip CoreServices system library on macOS (#19021)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           libs=($(otool -L nvim-osx64/bin/nvim | sed 1d | sed -E -e 's|^[[:space:]]*||' -e 's| .*||'))
           echo "libs:"
           for lib in "${libs[@]}"; do
-            if echo "$lib" | grep -q -E 'libSystem|CoreFoundation' 2>/dev/null; then
+            if echo "$lib" | grep -q -E 'libSystem|CoreServices' 2>/dev/null; then
               echo "  [skipped] $lib"
             else
               echo "  $lib"


### PR DESCRIPTION
Backport of #19021 to `release-0.7`