### PR TITLE
[Backport release-0.7] fix(decorations): nvim_buf_set_extmark breaks conceal (#19010)

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -68,7 +68,7 @@ void bufhl_add_hl_pos_offset(buf_T *buf, int src_id, int hl_id, lpos_T pos_start
 void decor_redraw(buf_T *buf, int row1, int row2, Decoration *decor)
 {
   if (row2 >= row1) {
-    if (!decor || decor->hl_id || decor_has_sign(decor)) {
+    if (!decor || decor->hl_id || decor_has_sign(decor) || decor->conceal) {
       redraw_buf_range_later(buf, row1+1, row2+1);
     }
   }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -69,6 +69,7 @@ void extmark_set(buf_T *buf, uint32_t ns_id, uint32_t *idp, int row, colnr_T col
   if (decor) {
     if (kv_size(decor->virt_text)
         || kv_size(decor->virt_lines)
+        || decor->conceal
         || decor_has_sign(decor)) {
       decor_full = true;
       decor = xmemdup(decor, sizeof *decor);

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -438,6 +438,7 @@ describe('extmark decorations', function()
       [23] = {foreground = Screen.colors.Magenta1, background = Screen.colors.LightGrey};
       [24] = {bold = true};
       [25] = {background = Screen.colors.LightRed};
+      [26] = {background=Screen.colors.DarkGrey, foreground=Screen.colors.LightGrey};
     }
 
     ns = meths.create_namespace 'test'
@@ -818,6 +819,20 @@ end]]
                                                         |
     ]]}
     helpers.assert_alive()
+  end)
+
+  it('conceal #19007', function()
+    screen:try_resize(50, 5)
+    insert('foo\n')
+    command('let &conceallevel=2')
+    meths.buf_set_extmark(0, ns, 0, 0, {end_col=0, end_row=2, conceal='X'})
+    screen:expect([[
+        {26:X}                                                 |
+        ^                                                  |
+        {1:~                                                 }|
+        {1:~                                                 }|
+                                                          |
+      ]])
   end)
 end)
 


### PR DESCRIPTION
Backport of https://github.com/neovim/neovim/pull/19010 to `release-0.7`