### PR TITLE
refactor(provider): replace filter with list comprehension

### DIFF
--- a/runtime/autoload/health/provider.vim
+++ b/runtime/autoload/health/provider.vim
@@ -203,7 +203,7 @@ function! s:version_info(python) abort
   let nvim_path = s:trim(s:system([
         \ a:python, '-c',
         \ 'import sys; ' .
-        \ 'sys.path = list(filter(lambda x: x != "", sys.path)); ' .
+        \ 'sys.path = [p for p in sys.path if p != ""]; ' .
         \ 'import neovim; print(neovim.__file__)']))
   if s:shell_error || empty(nvim_path)
     return [python_version, 'unable to load neovim Python module', pypi_version,

--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -8,7 +8,7 @@ let s:loaded_pythonx_provider = 1
 function! provider#pythonx#Require(host) abort
   " Python host arguments
   let prog = provider#python3#Prog()
-  let args = [prog, '-c', 'import sys; sys.path = list(filter(lambda x: x != "", sys.path)); import neovim; neovim.start_host()']
+  let args = [prog, '-c', 'import sys; sys.path = [p for p in sys.path if p != ""]; import neovim; neovim.start_host()']
 
 
   " Collect registered Python plugins into args
@@ -63,7 +63,7 @@ endfunction
 function! s:import_module(prog, module) abort
   let prog_version = system([a:prog, '-c' , printf(
         \ 'import sys; ' .
-        \ 'sys.path = list(filter(lambda x: x != "", sys.path)); ' .
+        \ 'sys.path = [p for p in sys.path if p != ""]; ' .
         \ 'sys.stdout.write(str(sys.version_info[0]) + "." + str(sys.version_info[1])); ' .
         \ 'import pkgutil; ' .
         \ 'exit(2*int(pkgutil.get_loader("%s") is None))',


### PR DESCRIPTION
This commit replaces `filter(lambda ...)` with a list comprehension which is [more Pythonic](https://google.github.io/styleguide/pyguide.html):

```diff
- list(filter(lambda x: x != "", sys.path))
+ [p for p in sys.path if p != ""]
```

---

You could also remove the ` != ""` because `""` castes to `False` while all other strings cast to `True`; however, I think this makes the code slightly less clear:

    [p for p in sys.path if p]