### PR TITLE
feat(getchar): getchar(2) waits for character without moving the cursor

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2717,6 +2717,8 @@ getchar([expr])						*getchar()*
 			Return zero otherwise.
 		If [expr] is 1, only check if a character is available, it is
 			not consumed.  Return zero if no character available.
+		If [expr] is 2, wait until a character is available without
+			moving the cursor.
 		If you prefer always getting a string use |getcharstr()|.
 
 		Without [expr] and when [expr] is 0 a whole character or
@@ -2834,6 +2836,8 @@ getcharstr([expr])					*getcharstr()*
 		If [expr] is 1 or true, only check if a character is
 			available, it is not consumed.  Return an empty string
 			if no character is available.
+		If [expr] is 2, wait until a character is available without
+			moving the cursor.
 		Otherwise this works like |getchar()|, except that a number
 		result is converted to a string.
 


### PR DESCRIPTION
`getchar()` is useful for mapping dynamic key sequences, but the downside is that it moves the cursor to the command line when waiting for input. If the action depends on where the cursor is, you can lose the visual feedback on where you're about to make an edit. `getchar(2)` behaves just like `getchar()`, but bypasses the move of the cursor.

vim/vim#10603