### PR TITLE
perf: get rid of unnecessary allocations in highlight groups

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -686,10 +686,7 @@ Dictionary arena_dict(Arena *arena, size_t max_size)
 String arena_string(Arena *arena, String str)
 {
   if (str.size) {
-    char *mem = arena_alloc(arena, str.size + 1, false);
-    memcpy(mem, str.data, str.size);
-    mem[str.size] = NUL;
-    return cbuf_as_string(mem, str.size);
+    return cbuf_as_string(arena_memdupz(arena, str.data, str.size), str.size);
   } else {
     return (String)STRING_INIT;
   }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1293,7 +1293,8 @@ void nvim_unsubscribe(uint64_t channel_id, String event)
 Integer nvim_get_color_by_name(String name)
   FUNC_API_SINCE(1)
 {
-  return name_to_color(name.data);
+  int dummy;
+  return name_to_color(name.data, &dummy);
 }
 
 /// Returns a map of color names and RGB values.

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -43,43 +43,45 @@ cursorentry_T shape_table[SHAPE_IDX_COUNT] =
 };
 
 /// Converts cursor_shapes into an Array of Dictionaries
+/// @param arena initialized arena where memory will be alocated
+///
 /// @return Array of the form {[ "cursor_shape": ... ], ...}
-Array mode_style_array(void)
+Array mode_style_array(Arena *arena)
 {
-  Array all = ARRAY_DICT_INIT;
+  Array all = arena_array(arena, SHAPE_IDX_COUNT);
 
   for (int i = 0; i < SHAPE_IDX_COUNT; i++) {
-    Dictionary dic = ARRAY_DICT_INIT;
     cursorentry_T *cur = &shape_table[i];
+    Dictionary dic = arena_dict(arena, 3 + ((cur->used_for & SHAPE_CURSOR) ? 9 : 0));
+    PUT_C(dic, "name", STRING_OBJ(cstr_as_string(cur->full_name)));
+    PUT_C(dic, "short_name", STRING_OBJ(cstr_as_string(cur->name)));
     if (cur->used_for & SHAPE_MOUSE) {
-      PUT(dic, "mouse_shape", INTEGER_OBJ(cur->mshape));
+      PUT_C(dic, "mouse_shape", INTEGER_OBJ(cur->mshape));
     }
     if (cur->used_for & SHAPE_CURSOR) {
       String shape_str;
       switch (cur->shape) {
       case SHAPE_BLOCK:
-        shape_str = cstr_to_string("block"); break;
+        shape_str = cstr_as_string("block"); break;
       case SHAPE_VER:
-        shape_str = cstr_to_string("vertical"); break;
+        shape_str = cstr_as_string("vertical"); break;
       case SHAPE_HOR:
-        shape_str = cstr_to_string("horizontal"); break;
+        shape_str = cstr_as_string("horizontal"); break;
       default:
-        shape_str = cstr_to_string("unknown");
+        shape_str = cstr_as_string("unknown");
       }
-      PUT(dic, "cursor_shape", STRING_OBJ(shape_str));
-      PUT(dic, "cell_percentage", INTEGER_OBJ(cur->percentage));
-      PUT(dic, "blinkwait", INTEGER_OBJ(cur->blinkwait));
-      PUT(dic, "blinkon", INTEGER_OBJ(cur->blinkon));
-      PUT(dic, "blinkoff", INTEGER_OBJ(cur->blinkoff));
-      PUT(dic, "hl_id", INTEGER_OBJ(cur->id));
-      PUT(dic, "id_lm", INTEGER_OBJ(cur->id_lm));
-      PUT(dic, "attr_id", INTEGER_OBJ(cur->id ? syn_id2attr(cur->id) : 0));
-      PUT(dic, "attr_id_lm", INTEGER_OBJ(cur->id_lm ? syn_id2attr(cur->id_lm) : 0));
+      PUT_C(dic, "cursor_shape", STRING_OBJ(shape_str));
+      PUT_C(dic, "cell_percentage", INTEGER_OBJ(cur->percentage));
+      PUT_C(dic, "blinkwait", INTEGER_OBJ(cur->blinkwait));
+      PUT_C(dic, "blinkon", INTEGER_OBJ(cur->blinkon));
+      PUT_C(dic, "blinkoff", INTEGER_OBJ(cur->blinkoff));
+      PUT_C(dic, "hl_id", INTEGER_OBJ(cur->id));
+      PUT_C(dic, "id_lm", INTEGER_OBJ(cur->id_lm));
+      PUT_C(dic, "attr_id", INTEGER_OBJ(cur->id ? syn_id2attr(cur->id) : 0));
+      PUT_C(dic, "attr_id_lm", INTEGER_OBJ(cur->id_lm ? syn_id2attr(cur->id_lm) : 0));
     }
-    PUT(dic, "name", STRING_OBJ(cstr_to_string(cur->full_name)));
-    PUT(dic, "short_name", STRING_OBJ(cstr_to_string(cur->name)));
 
-    ADD(all, DICTIONARY_OBJ(dic));
+    ADD_C(all, DICTIONARY_OBJ(dic));
   }
 
   return all;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -392,7 +392,7 @@ static uint32_t prt_get_color(int hl_id, int modec)
 
   const char *color = highlight_color(hl_id, "fg#", 'g');
   if (color != NULL) {
-    RgbValue rgb = name_to_color(color);
+    RgbValue rgb = name_to_color(color, &colorindex);
     if (rgb != -1) {
       return (uint32_t)rgb;
     }

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -962,7 +962,8 @@ int object_to_color(Object val, char *key, bool rgb, Error *err)
     }
     int color;
     if (rgb) {
-      color = name_to_color(str.data);
+      int dummy;
+      color = name_to_color(str.data, &dummy);
     } else {
       color = name_to_ctermcolor(str.data);
     }

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -605,6 +605,14 @@ void arena_mem_free(ArenaMem mem, ArenaMem *reuse_blk)
   }
 }
 
+char *arena_memdupz(Arena *arena, const char *buf, size_t size)
+{
+  char *mem = arena_alloc(arena, size + 1, false);
+  memcpy(mem, buf, size);
+  mem[size] = NUL;
+  return mem;
+}
+
 #if defined(EXITFREE)
 
 # include "nvim/buffer.h"

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -257,7 +257,8 @@ Terminal *terminal_open(buf_T *buf, TerminalOptions opts)
     snprintf(var, sizeof(var), "terminal_color_%d", i);
     char *name = get_config_string(var);
     if (name) {
-      color_val = name_to_color(name);
+      int dummy;
+      color_val = name_to_color(name, &dummy);
       xfree(name);
 
       if (color_val != -1) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -507,10 +507,12 @@ void ui_flush(void)
     pending_cursor_update = false;
   }
   if (pending_mode_info_update) {
-    Array style = mode_style_array();
+    Arena arena = ARENA_EMPTY;
+    arena_start(&arena, &ui_ext_fixblk);
+    Array style = mode_style_array(&arena);
     bool enabled = (*p_guicursor != NUL);
     ui_call_mode_info_set(enabled, style);
-    api_free_array(style);
+    arena_mem_free(arena_finish(&arena), &ui_ext_fixblk);
     pending_mode_info_update = false;
   }
   if (pending_mode_update && !starting) {

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -293,19 +293,20 @@ describe("API: set highlight", function()
     eq('Test_hl2       xxx cterm=undercurl,italic,reverse,strikethrough ctermfg=8 ctermbg=15 gui=bold,underline,underlineline,undercurl,underdot,underdash,italic,reverse,strikethrough guifg=#ff0000 guibg=#0032aa',
       exec_capture('highlight Test_hl2'))
 
-    -- Colors are stored exactly as they are defined.
+    -- Colors are stored with the name they are defined, but
+    -- with canonical casing
     meths.set_hl(0, 'Test_hl3', { bg = 'reD', fg = 'bLue'})
-    eq('Test_hl3       xxx guifg=bLue guibg=reD',
+    eq('Test_hl3       xxx guifg=Blue guibg=Red',
       exec_capture('highlight Test_hl3'))
   end)
 
   it ("can modify a highlight in the global namespace", function()
     meths.set_hl(0, 'Test_hl3', { bg = 'red', fg = 'blue'})
-    eq('Test_hl3       xxx guifg=blue guibg=red',
+    eq('Test_hl3       xxx guifg=Blue guibg=Red',
       exec_capture('highlight Test_hl3'))
 
     meths.set_hl(0, 'Test_hl3', { bg = 'red' })
-    eq('Test_hl3       xxx guibg=red',
+    eq('Test_hl3       xxx guibg=Red',
       exec_capture('highlight Test_hl3'))
 
     meths.set_hl(0, 'Test_hl3', { ctermbg = 9, ctermfg = 12})
@@ -327,7 +328,7 @@ describe("API: set highlight", function()
       pcall_err(meths.set_hl, 0, 'Test_hl3', {ctermfg='bleu'}))
 
     meths.set_hl(0, 'Test_hl3', {fg='#FF00FF'})
-    eq('Test_hl3       xxx guifg=#FF00FF',
+    eq('Test_hl3       xxx guifg=#ff00ff',
       exec_capture('highlight Test_hl3'))
 
     eq("'#FF00FF' is not a valid color",
@@ -340,7 +341,7 @@ describe("API: set highlight", function()
     end
 
     meths.set_hl(0, 'Test_hl3', {fg='#FF00FF', blend=50})
-    eq('Test_hl3       xxx guifg=#FF00FF blend=50',
+    eq('Test_hl3       xxx guifg=#ff00ff blend=50',
       exec_capture('highlight Test_hl3'))
 
   end)


### PR DESCRIPTION
Reduce from 40.8 to 32.8 MFrees in test suite. Slightly artificial, as it mostly concerns startup/exit cost. However, every ms at ASAN startup accumulate and help CI time.. More generally, remove noise from things which shouldn't even be an allocation (de-pessimization) so we can profile runtime relevant allocations more robustly.
