### PR TITLE
fix(input): use correct grid when restoring cursor for <expr> mapping

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2122,6 +2122,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
       const bool save_may_garbage_collect = may_garbage_collect;
       const int save_cursor_row = ui_current_row();
       const int save_cursor_col = ui_current_col();
+      const handle_T save_cursor_grid = ui_cursor_grid();
       const int prev_did_emsg = did_emsg;
 
       vgetc_busy = 0;
@@ -2135,7 +2136,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
 
       // The mapping may do anything, but we expect it to take care of
       // redrawing.  Do put the cursor back where it was.
-      ui_cursor_goto(save_cursor_row, save_cursor_col);
+      ui_grid_cursor_goto(save_cursor_grid, save_cursor_row, save_cursor_col);
       ui_flush();
 
       // If an error was displayed and the expression returns an empty

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -495,6 +495,11 @@ int ui_current_col(void)
   return cursor_col;
 }
 
+handle_T ui_cursor_grid(void)
+{
+  return cursor_grid_handle;
+}
+
 void ui_flush(void)
 {
   cmdline_ui_flush();

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -86,7 +86,7 @@ n  asdf1         qwert
   end)
 end)
 
-describe(':*map cursor and redrawing', function()
+describe('Screen', function()
   local screen
   before_each(function()
     clear()
@@ -149,6 +149,18 @@ describe(':*map cursor and redrawing', function()
     ]])
   end)
 
+  it('cursor position does not move after empty-string :cmap <expr> #19046', function()
+    command([[cnoremap <expr> <F2> '']])
+    feed(':<F2>')
+    screen:expect([[
+                          |
+      ~                   |
+      ~                   |
+      ~                   |
+      :^                   |
+    ]])
+  end)
+
   it('cursor is restored after :map <expr> which redraws statusline vim-patch:8.1.2336', function()
     exec([[
       call setline(1, ['one', 'two', 'three'])
@@ -157,12 +169,12 @@ describe(':*map cursor and redrawing', function()
       hi! link StatusLine ErrorMsg
       noremap <expr> <C-B> Func()
       func Func()
-	  let g:on = !get(g:, 'on', 0)
-	  redraws
-	  return ''
+          let g:on = !get(g:, 'on', 0)
+          redraws
+          return ''
       endfunc
       func Status()
-	  return get(g:, 'on', 0) ? '[on]' : ''
+          return get(g:, 'on', 0) ? '[on]' : ''
       endfunc
       set stl=%{Status()}
     ]])


### PR DESCRIPTION
Fix #19046
