### PR TITLE
fix(build): only pass -municode if MINGW

### DIFF
--- a/test/functional/fixtures/CMakeLists.txt
+++ b/test/functional/fixtures/CMakeLists.txt
@@ -4,7 +4,7 @@ target_link_libraries(tty-test ${LIBUV_LIBRARIES})
 add_executable(shell-test EXCLUDE_FROM_ALL shell-test.c)
 add_executable(printargs-test EXCLUDE_FROM_ALL printargs-test.c)
 add_executable(printenv-test EXCLUDE_FROM_ALL printenv-test.c)
-if(WIN32)
+if(MINGW)
   set_target_properties(printenv-test PROPERTIES LINK_FLAGS -municode)
 endif()
 


### PR DESCRIPTION
Avoids this warning in the Windows build:

    2022-06-22T08:58:13.0542153Z LINK : warning LNK4044: unrecognized option '/municode'; ignored [D:\a\neovim\neovim\build\test\functional\fixtures\printenv-test.vcxproj]