### PR TITLE
fix(tests): remove misleading $TEST_PATH segment

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -51,8 +51,8 @@ if(DEFINED ENV{TEST_FILTER_OUT} AND NOT "$ENV{TEST_FILTER_OUT}" STREQUAL "")
   list(APPEND BUSTED_ARGS --filter-out $ENV{TEST_FILTER_OUT})
 endif()
 
-# TMPDIR: use relative test path (for parallel test runs / isolation).
-set(ENV{TMPDIR} "${BUILD_DIR}/Xtest_tmpdir/${TEST_PATH}")
+# TMPDIR: for helpers.tmpname() and Nvim tempname().
+set(ENV{TMPDIR} "${BUILD_DIR}/Xtest_tmpdir")
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{TMPDIR})
 
 # HISTFILE: do not write into user's ~/.bash_history

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -291,7 +291,8 @@ module.tmpname = (function()
     if tmpdir_is_local(tmpdir) then
       -- Cannot control os.tmpname() dir, so hack our own tmpname() impl.
       seq = seq + 1
-      local fname = tmpdir..'/nvim-test-lua-'..seq
+      -- "…/Xtest_tmpdir/T42.7"
+      local fname = ('%s/%s.%d'):format(tmpdir, (_G._nvim_test_id or 'nvim-test'), seq)
       io.open(fname, 'w'):close()
       return fname
     else


### PR DESCRIPTION
## Problem:
RunTests.cmake adds $TEST_PATH to $TMPDIR with the implication that it
gives more isolation. But this is misleading because $TEST_PATH is only
defined once. Full test runs use the same $TMPDIR for all tests.

This was likely added with the intention of invoking RunTests.cmake
once-per-testfile from a wrapper than does the isolation/orchestration.
But even so, Nvim's vim_maketempdir() / vim_mktempdir() _already_
creates a unique tempdir per session.

## Solution:
Don't append $TEST_PATH to $TMPDIR. Avoids confusion and makes the path
shorter.