### PR TITLE
fix(api): check error after getting win/buf handle

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -43,6 +43,9 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
   if (opts->win.type == kObjectTypeInteger) {
     *opt_type = SREQ_WIN;
     *from = find_window_by_handle((int)opts->win.data.integer, err);
+    if (ERROR_SET(err)) {
+      return FAIL;
+    }
   } else if (HAS_KEY(opts->win)) {
     api_set_error(err, kErrorTypeValidation, "invalid value for key: win");
     return FAIL;
@@ -52,6 +55,9 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
     *scope = OPT_LOCAL;
     *opt_type = SREQ_BUF;
     *from = find_buffer_by_handle((int)opts->buf.data.integer, err);
+    if (ERROR_SET(err)) {
+      return FAIL;
+    }
   } else if (HAS_KEY(opts->buf)) {
     api_set_error(err, kErrorTypeValidation, "invalid value for key: buf");
     return FAIL;

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1400,6 +1400,8 @@ describe('lua stdlib', function()
        pcall_err(exec_lua, 'return vim.bo.nosuchopt'))
     matches("Expected lua string$",
        pcall_err(exec_lua, 'return vim.bo[0][0].autoread'))
+    matches("Invalid buffer id: %-1$",
+       pcall_err(exec_lua, 'return vim.bo[-1].filetype'))
   end)
 
   it('vim.wo', function()
@@ -1419,6 +1421,8 @@ describe('lua stdlib', function()
        pcall_err(exec_lua, 'return vim.wo.notanopt'))
     matches("Expected lua string$",
        pcall_err(exec_lua, 'return vim.wo[0][0].list'))
+    matches("Invalid window id: %-1$",
+       pcall_err(exec_lua, 'return vim.wo[-1].list'))
     eq(2, funcs.luaeval "vim.wo[1000].cole")
     exec_lua [[
     vim.wo[1000].cole = 0


### PR DESCRIPTION
Fixes a seg fault caused by e.g. `:lua =vim.bo[-1].filetype`.
