### PR TITLE
vim-patch:8.2.{5150,5151}: reading beyond the end of the line

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2826,10 +2826,13 @@ int parse_cmd_address(exarg_T *eap, char **errormsg, bool silent)
         curwin->w_cursor.lnum = eap->line2;
 
         // Don't leave the cursor on an illegal line or column, but do
-        // accept zero as address, so 0;/PATTERN/ works correctly.
+        // accept zero as address, so 0;/PATTERN/ works correctly
+        // (where zero usually means to use the first line).
         // Check the cursor position before returning.
         if (eap->line2 > 0) {
           check_cursor();
+        } else {
+          check_cursor_col();
         }
         need_check_cursor = true;
       }

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -697,8 +697,10 @@ int get_lisp_indent(void)
             && lisp_match(that + 1)) {
           amount += 2;
         } else {
-          that++;
-          amount++;
+          if (*that != NUL) {
+            that++;
+            amount++;
+          }
           firsttry = amount;
 
           while (ascii_iswhite(*that)) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -636,6 +636,14 @@ func Test_illegal_address2()
   call delete('Xtest.vim')
 endfunc
 
+func Test_mark_from_line_zero()
+  " this was reading past the end of the first (empty) line
+  new
+  norm oxxxx
+  call assert_fails("0;'(", 'E20:')
+  bwipe!
+endfunc
+
 func Test_cmdline_complete_wildoptions()
   help
   call feedkeys(":tag /\<c-a>\<c-b>\"\<cr>", 'tx')

--- a/src/nvim/testdir/test_lispwords.vim
+++ b/src/nvim/testdir/test_lispwords.vim
@@ -1,4 +1,5 @@
-" Tests for 'lispwords' settings being global-local
+" Tests for 'lispwords' settings being global-local.
+" And  other lisp indent stuff.
 
 set nocompatible viminfo+=nviminfo
 
@@ -83,6 +84,15 @@ func Test_lisp_indent()
   enew!
   let &cpoptions=save_copt
   set nolisp
+endfunc
+
+func Test_lisp_indent_works()
+  " This was reading beyond the end of the line
+  new
+  exe "norm a\tü(\<CR>="
+  set lisp
+  norm ==
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.5150: read past the end of the first line with ":0;'{"

Problem:    Read past the end of the first line with ":0;'{".
Solution:   When on line zero check the column is valid for line one.
https://github.com/vim/vim/commit/f7c7c3fad6d2135d558f3b36d0d1a943118aeb5e


#### vim-patch:8.2.5151: reading beyond the end of the line with lisp indenting

Problem:    Reading beyond the end of the line with lisp indenting.
Solution:   Avoid going over the NUL at the end of the line.
https://github.com/vim/vim/commit/8eba2bd291b347e3008aa9e565652d51ad638cfa