### PR TITLE
Fix coverity 353303 and 353302

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3739,7 +3739,6 @@ void ex_copen(exarg_T *eap)
   incr_quickfix_busy();
 
   if (eap->addr_count != 0) {
-    assert(eap->line2 <= INT_MAX);
     height = (int)eap->line2;
   } else {
     height = QF_WINHEIGHT;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3319,7 +3319,6 @@ void qf_age(exarg_T *eap)
   }
 
   if (eap->addr_count != 0) {
-    assert(eap->line2 <= INT_MAX);
     count = (int)eap->line2;
   } else {
     count = 1;


### PR DESCRIPTION
Not a really interesting PR, but I wanted to start working on fixing
coverity reports, and lower the number we have of them.

Here is a little fix for two completely redundant checks.

Maybe they can also be upstreamed ?
