### PR TITLE
perf(map): some optimizations when setting mappings

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1822,7 +1822,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   // - waiting for a char with --more--
   // - in Ctrl-X mode, and we get a valid char for that mode
   tb_c1 = typebuf.tb_buf[typebuf.tb_off];
-  if (no_mapping == 0 && is_maphash_valid()
+  if (no_mapping == 0
       && (no_zero_mapping == 0 || tb_c1 != '0')
       && (typebuf.tb_maplen == 0 || is_plug_map
           || (!(typebuf.tb_noremap[typebuf.tb_off] & (RM_NONE|RM_ABBR))))

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -635,16 +635,18 @@ static int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev,
     // "bar" because of the abbreviation.
     for (int round = 0; (round == 0 || maptype == 1) && round <= 1
          && !did_it && !got_int; round++) {
-      // need to loop over all hash lists
-      for (int hash = 0; hash < 256 && !got_int; hash++) {
-        if (is_abbrev) {
-          if (hash > 0) {  // there is only one abbreviation list
-            break;
-          }
-          mpp = abbr_table;
-        } else {
-          mpp = &(map_table[hash]);
-        }
+      int hash_start, hash_end;
+      if (has_lhs || is_abbrev) {
+        // just use one hash
+        hash_start = is_abbrev ? 0 : MAP_HASH(mode, lhs[0]);
+        hash_end = hash_start + 1;
+      } else {
+        // need to loop over all hash lists
+        hash_start = 0;
+        hash_end = 256;
+      }
+      for (int hash = hash_start; hash < hash_end && !got_int; hash++) {
+        mpp = is_abbrev ?  abbr_table :  &(map_table[hash]);
         for (mp = *mpp; mp != NULL && !got_int; mp = *mpp) {
           if ((mp->m_mode & mode) == 0) {
             // skip entries with wrong mode

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -15,6 +15,7 @@
 #include "nvim/highlight.h"
 #include "nvim/highlight_group.h"
 #include "nvim/lua/executor.h"
+#include "nvim/mapping.h"
 #include "nvim/memfile.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
@@ -689,11 +690,9 @@ void free_all_mem(void)
   do_cmdline_cmd("menutranslate clear");
 
   // Clear mappings, abbreviations, breakpoints.
-  do_cmdline_cmd("lmapclear");
-  do_cmdline_cmd("xmapclear");
-  do_cmdline_cmd("mapclear");
-  do_cmdline_cmd("mapclear!");
-  do_cmdline_cmd("abclear");
+  // NB: curbuf not used with local=false arg
+  map_clear_int(curbuf, MAP_ALL_MODES, false, false);
+  map_clear_int(curbuf, MAP_ALL_MODES, false, true);
   do_cmdline_cmd("breakdel *");
   do_cmdline_cmd("profdel *");
   do_cmdline_cmd("set keymap=");

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -232,6 +232,7 @@ void ex_menu(exarg_T *eap)
     } else if (modes & MENU_TIP_MODE) {
       map_buf = NULL;  // Menu tips are plain text.
     } else {
+      map_buf = NULL;
       map_to = replace_termcodes(map_to, STRLEN(map_to), &map_buf,
                                  REPTERM_DO_LT, NULL, CPO_TO_CPO_FLAGS);
     }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3025,6 +3025,7 @@ ambw_end:
   } else if (varp == &p_pt) {
     // 'pastetoggle': translate key codes like in a mapping
     if (*p_pt) {
+      p = NULL;
       (void)replace_termcodes((char *)p_pt,
                               STRLEN(p_pt),
                               (char **)&p, REPTERM_FROM_PART | REPTERM_DO_LT, NULL,


### PR DESCRIPTION
visit only one hash bucket instead of all, like an actual hash table.
avoid extraneous heap allocations when setting mappings:

- don't immediately `vim_strsave` and then `xfree` a heap buffer.
- allow replace_termcodes to take in a buffer instead of allocating it
- grug! memory allocation bad!