### PR TITLE
vim-patch:8.2.{4628,4895,4977,5146,5154}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4069,11 +4069,16 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
           // Save flags for recursion.  They can change for e.g.
           // :s/^/\=execute("s#^##gn")
           subflags_T subflags_save = subflags;
+
+          // Disallow changing text or switching window in an expression.
+          textlock++;
           // get length of substitution part
           sublen = vim_regsub_multi(&regmatch,
                                     sub_firstlnum - regmatch.startpos[0].lnum,
                                     (char_u *)sub, (char_u *)sub_firstline, 0,
                                     REGSUB_BACKSLASH | (p_magic ? REGSUB_MAGIC : 0));
+          textlock--;
+
           // If getting the substitute string caused an error, don't do
           // the replacement.
           // Don't keep flags set by a recursive call
@@ -4111,10 +4116,12 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
           int start_col = new_end - new_start;
           current_match.start.col = start_col;
 
+          textlock++;
           (void)vim_regsub_multi(&regmatch,
                                  sub_firstlnum - regmatch.startpos[0].lnum,
                                  (char_u *)sub, (char_u *)new_end, sublen,
                                  REGSUB_COPY | REGSUB_BACKSLASH | (p_magic ? REGSUB_MAGIC : 0));
+          textlock--;
           sub_nsubs++;
           did_sub = true;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2892,11 +2892,13 @@ static void append_command(char *cmd)
 
   STRCAT(IObuff, ": ");
   d = (char *)IObuff + STRLEN(IObuff);
-  while (*s != NUL && (char_u *)d - IObuff < IOSIZE - 7) {
+  while (*s != NUL && (char_u *)d - IObuff + 5 < IOSIZE) {
     if ((char_u)s[0] == 0xc2 && (char_u)s[1] == 0xa0) {
       s += 2;
       STRCPY(d, "<a0>");
       d += 4;
+    } else if ((char_u *)d - IObuff + utfc_ptr2len(s) + 1 >= IOSIZE) {
+      break;
     } else {
       mb_copy_char((const char_u **)&s, (char_u **)&d);
     }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1220,6 +1220,19 @@ func Test_recalling_cmdline()
   cunmap <Plug>(save-cmdline)
 endfunc
 
+" Test for expanding 2-letter and 3-letter :substitute command arguments.
+" These commands don't accept an argument.
+func Test_cmdline_complete_substitute_short()
+  for cmd in ['sc', 'sce', 'scg', 'sci', 'scI', 'scn', 'scp', 'scl',
+        \ 'sgc', 'sge', 'sg', 'sgi', 'sgI', 'sgn', 'sgp', 'sgl', 'sgr',
+        \ 'sic', 'sie', 'si', 'siI', 'sin', 'sip', 'sir',
+        \ 'sIc', 'sIe', 'sIg', 'sIi', 'sI', 'sIn', 'sIp', 'sIl', 'sIr',
+        \ 'src', 'srg', 'sri', 'srI', 'srn', 'srp', 'srl', 'sr']
+    call feedkeys(':' .. cmd .. " \<Tab>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"' .. cmd .. " \<Tab>", @:)
+  endfor
+endfunc
+
 func Check_completion()
   call assert_equal('let a', getcmdline())
   call assert_equal(6, getcmdpos())

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1220,6 +1220,17 @@ func Test_recalling_cmdline()
   cunmap <Plug>(save-cmdline)
 endfunc
 
+" this was going over the end of IObuff
+func Test_report_error_with_composing()
+  let caught = 'no'
+  try
+    exe repeat('0', 987) .. "0\xdd\x80\xdd\x80\xdd\x80\xdd\x80"
+  catch /E492:/
+    let caught = 'yes'
+  endtry
+  call assert_equal('yes', caught)
+endfunc
+
 " Test for expanding 2-letter and 3-letter :substitute command arguments.
 " These commands don't accept an argument.
 func Test_cmdline_complete_substitute_short()

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -831,7 +831,7 @@ func Test_using_old_sub()
     ~
     s/
   endfunc
-  silent!  s/\%')/\=Repl()
+  silent! s/\%')/\=Repl()
 
   delfunc Repl
   bwipe!
@@ -1132,6 +1132,16 @@ func Test_substitute_short_cmd()
   sIe
 
   bw!
+endfunc
+
+" This should be done last to reveal a memory leak when vim_regsub_both() is
+" called to evaluate an expression but it is not used in a second call.
+func Test_z_substitute_expr_leak()
+  func SubExpr()
+    ~n
+  endfunc
+  silent! s/\%')/\=SubExpr()
+  delfunc SubExpr
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -838,6 +838,19 @@ func Test_using_old_sub()
   set nocompatible
 endfunc
 
+" This was switching windows in between computing the length and using it.
+func Test_sub_change_window()
+  silent! lfile
+  sil! norm o0000000000000000000000000000000000000000000000000000
+  func Repl()
+    lopen
+  endfunc
+  silent!  s/\%')/\=Repl()
+  bwipe!
+  bwipe!
+  delfunc Repl
+endfunc
+
 " Test for the 2-letter and 3-letter :substitute commands
 func Test_substitute_short_cmd()
   new

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -1,4 +1,4 @@
-" Tests for multi-line regexps with ":s".
+" Tests for the substitute (:s) command
 
 func Test_multiline_subst()
   enew!
@@ -838,5 +838,287 @@ func Test_using_old_sub()
   set nocompatible
 endfunc
 
+" Test for the 2-letter and 3-letter :substitute commands
+func Test_substitute_short_cmd()
+  new
+  call setline(1, ['one', 'one one one'])
+  s/one/two
+  call cursor(2, 1)
+
+  " :sc
+  call feedkeys(":sc\<CR>y", 'xt')
+  call assert_equal('two one one', getline(2))
+
+  " :scg
+  call setline(2, 'one one one')
+  call feedkeys(":scg\<CR>nyq", 'xt')
+  call assert_equal('one two one', getline(2))
+
+  " :sci
+  call setline(2, 'ONE One onE')
+  call feedkeys(":sci\<CR>y", 'xt')
+  call assert_equal('two One onE', getline(2))
+
+  " :scI
+  set ignorecase
+  call setline(2, 'ONE One one')
+  call feedkeys(":scI\<CR>y", 'xt')
+  call assert_equal('ONE One two', getline(2))
+  set ignorecase&
+
+  " :scn
+  call setline(2, 'one one one')
+  let t = execute('scn')->split("\n")
+  call assert_equal(['1 match on 1 line'], t)
+  call assert_equal('one one one', getline(2))
+
+  " :scp
+  call setline(2, "\tone one one")
+  redir => output
+  call feedkeys(":scp\<CR>y", 'xt')
+  redir END
+  call assert_equal('        two one one', output->split("\n")[-1])
+  call assert_equal("\ttwo one one", getline(2))
+
+  " :scl
+  call setline(2, "\tone one one")
+  redir => output
+  call feedkeys(":scl\<CR>y", 'xt')
+  redir END
+  call assert_equal("^Itwo one one$", output->split("\n")[-1])
+  call assert_equal("\ttwo one one", getline(2))
+
+  " :sgc
+  call setline(2, 'one one one one one')
+  call feedkeys(":sgc\<CR>nyyq", 'xt')
+  call assert_equal('one two two one one', getline(2))
+
+  " :sg
+  call setline(2, 'one one one')
+  sg
+  call assert_equal('two two two', getline(2))
+
+  " :sgi
+  call setline(2, 'ONE One onE')
+  sgi
+  call assert_equal('two two two', getline(2))
+
+  " :sgI
+  set ignorecase
+  call setline(2, 'ONE One one')
+  sgI
+  call assert_equal('ONE One two', getline(2))
+  set ignorecase&
+
+  " :sgn
+  call setline(2, 'one one one')
+  let t = execute('sgn')->split("\n")
+  call assert_equal(['3 matches on 1 line'], t)
+  call assert_equal('one one one', getline(2))
+
+  " :sgp
+  call setline(2, "\tone one one")
+  redir => output
+  sgp
+  redir END
+  call assert_equal('        two two two', output->split("\n")[-1])
+  call assert_equal("\ttwo two two", getline(2))
+
+  " :sgl
+  call setline(2, "\tone one one")
+  redir => output
+  sgl
+  redir END
+  call assert_equal("^Itwo two two$", output->split("\n")[-1])
+  call assert_equal("\ttwo two two", getline(2))
+
+  " :sgr
+  call setline(2, "one one one")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  sgr
+  call assert_equal('xyz xyz xyz', getline(2))
+
+  " :sic
+  call cursor(1, 1)
+  s/one/two/e
+  call setline(2, "ONE One one")
+  call cursor(2, 1)
+  call feedkeys(":sic\<CR>y", 'xt')
+  call assert_equal('two One one', getline(2))
+
+  " :si
+  call setline(2, "ONE One one")
+  si
+  call assert_equal('two One one', getline(2))
+
+  " :siI
+  call setline(2, "ONE One one")
+  siI
+  call assert_equal('ONE One two', getline(2))
+
+  " :sin
+  call setline(2, 'ONE One onE')
+  let t = execute('sin')->split("\n")
+  call assert_equal(['1 match on 1 line'], t)
+  call assert_equal('ONE One onE', getline(2))
+
+  " :sip
+  call setline(2, "\tONE One onE")
+  redir => output
+  sip
+  redir END
+  call assert_equal('        two One onE', output->split("\n")[-1])
+  call assert_equal("\ttwo One onE", getline(2))
+
+  " :sir
+  call setline(2, "ONE One onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  sir
+  call assert_equal('xyz One onE', getline(2))
+
+  " :sIc
+  call cursor(1, 1)
+  s/one/two/e
+  call setline(2, "ONE One one")
+  call cursor(2, 1)
+  call feedkeys(":sIc\<CR>y", 'xt')
+  call assert_equal('ONE One two', getline(2))
+
+  " :sIg
+  call setline(2, "ONE one onE one")
+  sIg
+  call assert_equal('ONE two onE two', getline(2))
+
+  " :sIi
+  call setline(2, "ONE One one")
+  sIi
+  call assert_equal('two One one', getline(2))
+
+  " :sI
+  call setline(2, "ONE One one")
+  sI
+  call assert_equal('ONE One two', getline(2))
+
+  " :sIn
+  call setline(2, 'ONE One one')
+  let t = execute('sIn')->split("\n")
+  call assert_equal(['1 match on 1 line'], t)
+  call assert_equal('ONE One one', getline(2))
+
+  " :sIp
+  call setline(2, "\tONE One one")
+  redir => output
+  sIp
+  redir END
+  call assert_equal('        ONE One two', output->split("\n")[-1])
+  call assert_equal("\tONE One two", getline(2))
+
+  " :sIl
+  call setline(2, "\tONE onE one")
+  redir => output
+  sIl
+  redir END
+  call assert_equal("^IONE onE two$", output->split("\n")[-1])
+  call assert_equal("\tONE onE two", getline(2))
+
+  " :sIr
+  call setline(2, "ONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  sIr
+  call assert_equal('ONE xyz onE', getline(2))
+
+  " :src
+  call setline(2, "ONE one one")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  call feedkeys(":src\<CR>y", 'xt')
+  call assert_equal('ONE xyz one', getline(2))
+
+  " :srg
+  call setline(2, "one one one")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  srg
+  call assert_equal('xyz xyz xyz', getline(2))
+
+  " :sri
+  call setline(2, "ONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  sri
+  call assert_equal('xyz one onE', getline(2))
+
+  " :srI
+  call setline(2, "ONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  srI
+  call assert_equal('ONE xyz onE', getline(2))
+
+  " :srn
+  call setline(2, "ONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  let t = execute('srn')->split("\n")
+  call assert_equal(['1 match on 1 line'], t)
+  call assert_equal('ONE one onE', getline(2))
+
+  " :srp
+  call setline(2, "\tONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  redir => output
+  srp
+  redir END
+  call assert_equal('        ONE xyz onE', output->split("\n")[-1])
+  call assert_equal("\tONE xyz onE", getline(2))
+
+  " :srl
+  call setline(2, "\tONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  redir => output
+  srl
+  redir END
+  call assert_equal("^IONE xyz onE$", output->split("\n")[-1])
+  call assert_equal("\tONE xyz onE", getline(2))
+
+  " :sr
+  call setline(2, "ONE one onE")
+  call cursor(2, 1)
+  s/abc/xyz/e
+  let @/ = 'one'
+  sr
+  call assert_equal('ONE xyz onE', getline(2))
+
+  " :sce
+  s/abc/xyz/e
+  call assert_fails("sc", 'E486:')
+  sce
+  " :sge
+  call assert_fails("sg", 'E486:')
+  sge
+  " :sie
+  call assert_fails("si", 'E486:')
+  sie
+  " :sIe
+  call assert_fails("sI", 'E486:')
+  sIe
+
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4628: not enough testing for 2/3 letter substitute commands

Problem:    Not enough testing for 2/3 letter substitute commands.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#10019)
https://github.com/vim/vim/commit/5e877baf87530d5c4fe4da2c5a6269cf19526c27


#### vim-patch:8.2.4895: buffer overflow with invalid command with composing chars

Problem:    Buffer overflow with invalid command with composing chars.
Solution:   Check that the whole character fits in the buffer.
https://github.com/vim/vim/commit/d88934406c5375d88f8f1b65331c9f0cab68cc6c


#### vim-patch:8.2.4977: memory access error when substitute expression changes window

Problem:    Memory access error when substitute expression changes window.
Solution:   Disallow changing window in substitute expression.
https://github.com/vim/vim/commit/e2bd8600b873d2cd1f9d667c28cba8b1dba18839

"textwinlock" was renamed back to "textlock" in patch 8.2.5029.


#### vim-patch:8.2.5146: memory leak when substitute expression nests

Problem:    Memory leak when substitute expression nests.
Solution:   Use an array of expression results.
https://github.com/vim/vim/commit/44ddf19ec0ff59c969658ec7d9ed42070c59c51b

Cherry-pick a comment change from patch 8.2.5057.

N/A patches for version.c:

vim-patch:8.2.5154: still mentioning version8, some cosmetic issues

Problem:    Still mentioning version8, some cosmetic issues.
Solution:   Prefer mentioning version9, cosmetic improvements.
https://github.com/vim/vim/commit/abd56da30bae4a5c6c20b9363ccae12f7b126026