### PR TITLE
revert: "oldtests: use expand() to fix pathsep"

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -305,7 +305,7 @@ func Test_getcompletion()
   call assert_equal([], l)
 
   let l = getcompletion('', 'dir')
-  call assert_true(index(l, expand('sautest/')) >= 0)
+  call assert_true(index(l, 'sautest/') >= 0)
   let l = getcompletion('NoMatch', 'dir')
   call assert_equal([], l)
 
@@ -415,7 +415,7 @@ func Test_getcompletion()
 
   " Command line completion tests
   let l = getcompletion('cd ', 'cmdline')
-  call assert_true(index(l, expand('sautest/')) >= 0)
+  call assert_true(index(l, 'sautest/') >= 0)
   let l = getcompletion('cd NoMatch', 'cmdline')
   call assert_equal([], l)
   let l = getcompletion('let v:n', 'cmdline')
@@ -539,7 +539,7 @@ func Test_expand_star_star()
   call mkdir('a/b', 'p')
   call writefile(['asdfasdf'], 'a/b/fileXname')
   call feedkeys(":find **/fileXname\<Tab>\<CR>", 'xt')
-  call assert_equal('find '.expand('a/b/fileXname'), getreg(':'))
+  call assert_equal('find a/b/fileXname', getreg(':'))
   bwipe!
   call delete('a', 'rf')
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -1060,17 +1060,17 @@ func s:dir_stack_tests(cchar)
 
   let qf = g:Xgetlist()
 
-  call assert_equal(expand('dir1/a/habits2.txt'), bufname(qf[1].bufnr))
+  call assert_equal('dir1/a/habits2.txt', bufname(qf[1].bufnr))
   call assert_equal(1, qf[1].lnum)
-  call assert_equal(expand('dir1/a/b/habits3.txt'), bufname(qf[3].bufnr))
+  call assert_equal('dir1/a/b/habits3.txt', bufname(qf[3].bufnr))
   call assert_equal(2, qf[3].lnum)
-  call assert_equal(expand('dir1/a/habits2.txt'), bufname(qf[4].bufnr))
+  call assert_equal('dir1/a/habits2.txt', bufname(qf[4].bufnr))
   call assert_equal(7, qf[4].lnum)
-  call assert_equal(expand('dir1/c/habits4.txt'), bufname(qf[6].bufnr))
+  call assert_equal('dir1/c/habits4.txt', bufname(qf[6].bufnr))
   call assert_equal(3, qf[6].lnum)
   call assert_equal('habits1.txt', bufname(qf[9].bufnr))
   call assert_equal(4, qf[9].lnum)
-  call assert_equal(expand('dir2/habits5.txt'), bufname(qf[11].bufnr))
+  call assert_equal('dir2/habits5.txt', bufname(qf[11].bufnr))
   call assert_equal(5, qf[11].lnum)
 
   let &efm=save_efm
@@ -1300,7 +1300,7 @@ func Test_efm2()
   call assert_equal(8, len(l))
   call assert_equal(89, l[4].lnum)
   call assert_equal(1, l[4].valid)
-  call assert_equal(expand('unittests/dbfacadeTest.py'), bufname(l[4].bufnr))
+  call assert_equal('unittests/dbfacadeTest.py', bufname(l[4].bufnr))
   call assert_equal('W', l[4].type)
 
   " Test for %o
@@ -2074,11 +2074,11 @@ func Test_two_windows()
   laddexpr 'one.txt:3:one one one'
 
   let loc_one = getloclist(one_id)
-  call assert_equal(expand('Xone/a/one.txt'), bufname(loc_one[1].bufnr))
+  call assert_equal('Xone/a/one.txt', bufname(loc_one[1].bufnr))
   call assert_equal(3, loc_one[1].lnum)
 
   let loc_two = getloclist(two_id)
-  call assert_equal(expand('Xtwo/a/two.txt'), bufname(loc_two[1].bufnr))
+  call assert_equal('Xtwo/a/two.txt', bufname(loc_two[1].bufnr))
   call assert_equal(5, loc_two[1].lnum)
 
   call win_gotoid(one_id)


### PR DESCRIPTION
This reverts commit e3687165a74ba2f3234cd6acc156ec12f85a5f3a.

No longer needed after #10679