### PR TITLE
fix(filetype.lua): always return a string in getlines function

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -33,7 +33,7 @@ end
 function M.getlines(bufnr, start_lnum, end_lnum)
   if not end_lnum then
     -- Return a single line as a string
-    return api.nvim_buf_get_lines(bufnr, start_lnum - 1, start_lnum, false)[1]
+    return api.nvim_buf_get_lines(bufnr, start_lnum - 1, start_lnum, false)[1] or ''
   end
   return api.nvim_buf_get_lines(bufnr, start_lnum - 1, end_lnum, false)
 end


### PR DESCRIPTION
This re-introduces the fix that the filetype.lua refactor inadvertently reverted. The fix ensures that in the case when end_lnum is omitted, a string is always returned. You can see the error this fixes by doing `nvim some_new_file.ts`.

See #17852 for the original fix.