### PR TITLE
fix(process): exit_event deadlock

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -27,6 +27,7 @@ void loop_init(Loop *loop, void *data)
   uv_signal_init(&loop->uv, &loop->children_watcher);
   uv_timer_init(&loop->uv, &loop->children_kill_timer);
   uv_timer_init(&loop->uv, &loop->poll_timer);
+  uv_timer_init(&loop->uv, &loop->exit_delay_timer);
   loop->poll_timer.data = xmalloc(sizeof(bool));  // "timeout expired" flag
 }
 
@@ -136,6 +137,7 @@ bool loop_close(Loop *loop, bool wait)
   uv_close((uv_handle_t *)&loop->children_watcher, NULL);
   uv_close((uv_handle_t *)&loop->children_kill_timer, NULL);
   uv_close((uv_handle_t *)&loop->poll_timer, timer_close_cb);
+  uv_close((uv_handle_t *)&loop->exit_delay_timer, NULL);
   uv_close((uv_handle_t *)&loop->async, NULL);
   uint64_t start = wait ? os_hrtime() : 0;
   bool didstop = false;

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -36,6 +36,8 @@ typedef struct loop {
   // generic timer, used by loop_poll_events()
   uv_timer_t poll_timer;
 
+  uv_timer_t exit_delay_timer;
+
   uv_async_t async;
   uv_mutex_t mutex;
   int recursive;

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -386,11 +386,13 @@ static void process_close_handles(void **argv)
 {
   Process *proc = argv[0];
 
+  exit_need_delay++;
   flush_stream(proc, &proc->out);
   flush_stream(proc, &proc->err);
 
   process_close_streams(proc);
   process_close(proc);
+  exit_need_delay--;
 }
 
 static void on_process_exit(Process *proc)

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1075,4 +1075,6 @@ typedef enum {
 // Only filled for Win32.
 EXTERN char windowsVersion[20] INIT(= { 0 });
 
+EXTERN int exit_need_delay INIT(= 0);
+
 #endif  // NVIM_GLOBALS_H

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -521,8 +521,19 @@ void rpc_close(Channel *channel)
   }
 }
 
+static void exit_delay_cb(uv_timer_t *handle)
+{
+  uv_timer_stop(&main_loop.exit_delay_timer);
+  multiqueue_put(main_loop.fast_events, exit_event, 0);
+}
+
 static void exit_event(void **argv)
 {
+  if (exit_need_delay) {
+    uv_timer_start(&main_loop.exit_delay_timer, exit_delay_cb, 0, 0);
+    return;
+  }
+
   if (!exiting) {
     os_exit(0);
   }


### PR DESCRIPTION
In the rare case that `exit_event` is called from within `process_close_handles`, it stalls to wait for the process to exit (The
process is currently underway to do just that). In CI, `job_spec.lua` would sometimes stall due to this.

In my local environment, 100 iterations are completed, so it should be fixed.