### PR TITLE
vim-patch:8.2.5022: 'completefunc'/'omnifunc' error does not end completion

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -5263,12 +5263,13 @@ static int ins_complete(int c, bool enable_pum)
         return FAIL;
       }
 
-      /* Return value -2 means the user complete function wants to
-       * cancel the complete without an error.
-       * Return value -3 does the same as -2 and leaves CTRL-X mode.*/
-      if (col == -2) {
+      // Return value -2 means the user complete function wants to cancel the
+      // complete without an error, do the same if the function did not execute
+      // successfully.
+      if (col == -2 || aborting()) {
         return FAIL;
       }
+      // Return value -3 does the same as -2 and leaves CTRL-X mode.
       if (col == -3) {
         ctrl_x_mode = CTRL_X_NORMAL;
         edit_submode = NULL;

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -287,6 +287,30 @@ func Test_omni_dash()
   set omnifunc=
 endfunc
 
+func Test_omni_throw()
+  let g:CallCount = 0
+  func Omni(findstart, base)
+    let g:CallCount += 1
+    if a:findstart
+      throw "he he he"
+    endif
+  endfunc
+  set omnifunc=Omni
+  new
+  try
+    exe "normal ifoo\<C-x>\<C-o>"
+    call assert_false(v:true, 'command should have failed')
+  catch
+    call assert_exception('he he he')
+    call assert_equal(1, g:CallCount)
+  endtry
+
+  bwipe!
+  delfunc Omni
+  unlet g:CallCount
+  set omnifunc=
+endfunc
+
 func Test_completefunc_args()
   let s:args = []
   func! CompleteFunc(findstart, base)


### PR DESCRIPTION
#### vim-patch:8.2.5022: 'completefunc'/'omnifunc' error does not end completion

Problem:    'completefunc'/'omnifunc' error does not end completion.
Solution:   Check if there was an error or exception. (closes vim/vim#10486)
https://github.com/vim/vim/commit/9bcb9ca9c7dd1632385dc3351b5e019739368658