### PR TITLE
fix(build): don't disable byte precompilation on debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,11 +573,7 @@ endif()
 
 message(STATUS "Using Lua interpreter: ${LUA_PRG}")
 
-if(DEBUG)
-  option(COMPILE_LUA "Pre-compile Lua sources into bytecode (for sources that are included in the binary)" OFF)
-else()
-  option(COMPILE_LUA "Pre-compile Lua sources into bytecode (for sources that are included in the binary)" ON)
-endif()
+option(COMPILE_LUA "Pre-compile Lua sources into bytecode (for sources that are included in the binary)" ON)
 
 if(COMPILE_LUA AND NOT WIN32)
   if(PREFER_LUA)


### PR DESCRIPTION
This special casing is redundant since long, as you can disable the binary cache **regardless** of build type with the `--luamod-dev` flag (IIRC which provides slightly better lua debug info, which you might want independently of running c code in debug/ASAN mode).

this also avoids a very confusing `LUAC_PRG is missing, embedding raw source` message. LUAC_PRG is not missing, we just chose not to use it..