### PR TITLE
vim-patch:8.1.{partial:0822,1189,1192},8.2.5109: 'showmode' fixes

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4251,7 +4251,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
   // Otherwise remove the mode message.
   if (reg_recording != 0 || restart_edit != NUL) {
     showmode();
-  } else if (p_smd) {
+  } else if (p_smd && !skip_showmode()) {
     msg("");
   }
   // Exit Insert mode

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4251,7 +4251,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
   // Otherwise remove the mode message.
   if (reg_recording != 0 || restart_edit != NUL) {
     showmode();
-  } else if (p_smd && !skip_showmode()) {
+  } else if (p_smd && (got_int || !skip_showmode())) {
     msg("");
   }
   // Exit Insert mode

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2722,6 +2722,8 @@ static void getchar_common(typval_T *argvars, typval_T *rettv)
       // getchar(): blocking wait.
       // TODO(bfredl): deduplicate shared logic with state_enter ?
       if (!char_avail()) {
+        // flush output before waiting
+        ui_flush();
         (void)os_inchar(NULL, 0, -1, 0, main_loop.events);
         if (!multiqueue_empty(main_loop.events)) {
           state_handle_k_event();

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -145,6 +145,7 @@ EXTERN int vgetc_char INIT(= 0);
 EXTERN int cmdline_row;
 
 EXTERN bool redraw_cmdline INIT(= false);          // cmdline must be redrawn
+EXTERN bool redraw_mode INIT(= false);             // mode must be redrawn
 EXTERN bool clear_cmdline INIT(= false);           // cmdline must be cleared
 EXTERN bool mode_displayed INIT(= false);          // mode is being displayed
 EXTERN int cmdline_star INIT(= false);             // cmdline is encrypted

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1284,7 +1284,7 @@ static void normal_redraw(NormalState *s)
     update_screen(INVERTED);
   } else if (must_redraw) {
     update_screen(0);
-  } else if (redraw_cmdline || clear_cmdline) {
+  } else if (redraw_cmdline || clear_cmdline || redraw_mode) {
     showmode();
   }
 
@@ -6928,6 +6928,10 @@ static void nv_esc(cmdarg_T *cap)
       } else {
         msg(_("Type  :qa  and press <Enter> to exit Nvim"));
       }
+    }
+
+    if (restart_edit != 0) {
+      redraw_mode = true;  // remove "-- (insert) --"
     }
 
     restart_edit = 0;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -591,7 +591,7 @@ int update_screen(int type)
 
   // Clear or redraw the command line.  Done last, because scrolling may
   // mess up the command line.
-  if (clear_cmdline || redraw_cmdline) {
+  if (clear_cmdline || redraw_cmdline || redraw_mode) {
     showmode();
   }
 
@@ -5828,18 +5828,19 @@ bool skip_showmode(void)
   // Call char_avail() only when we are going to show something, because it
   // takes a bit of time.  redrawing() may also call char_avail().
   if (global_busy || msg_silent != 0 || !redrawing() || (char_avail() && !KeyTyped)) {
-    redraw_cmdline = true;  // show mode later
+    redraw_mode = true;  // show mode later
     return true;
   }
   return false;
 }
 
-// Show the current mode and ruler.
-//
-// If clear_cmdline is true, clear the rest of the cmdline.
-// If clear_cmdline is false there may be a message there that needs to be
-// cleared only if a mode is shown.
-// Return the length of the message (0 if no message).
+/// Show the current mode and ruler.
+///
+/// If clear_cmdline is true, clear the rest of the cmdline.
+/// If clear_cmdline is false there may be a message there that needs to be
+/// cleared only if a mode is shown.
+/// If redraw_mode is true show or clear the mode.
+/// @return the length of the message (0 if no message).
 int showmode(void)
 {
   bool need_clear;
@@ -5998,7 +5999,7 @@ int showmode(void)
     }
 
     mode_displayed = true;
-    if (need_clear || clear_cmdline) {
+    if (need_clear || clear_cmdline || redraw_mode) {
       msg_clr_eos();
     }
     msg_didout = false;                 // overwrite this message
@@ -6010,6 +6011,9 @@ int showmode(void)
   } else if (clear_cmdline && msg_silent == 0) {
     // Clear the whole command line.  Will reset "clear_cmdline".
     msg_clr_cmdline();
+  } else if (redraw_mode) {
+    msg_pos_mode();
+    msg_clr_eos();
   }
 
   // NB: also handles clearing the showmode if it was empty or disabled
@@ -6027,6 +6031,7 @@ int showmode(void)
     win_redr_ruler(last, true);
   }
   redraw_cmdline = false;
+  redraw_mode = false;
   clear_cmdline = false;
 
   return length;

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -19,7 +19,7 @@ func Test_setbufline_getbufline()
   let b = bufnr('%')
   wincmd w
   call assert_equal(1, setbufline(b, 5, ['x']))
-  call assert_equal(1, setbufline(1234, 1, ['x']))
+  call assert_equal(1, setbufline(bufnr('$') + 1, 1, ['x']))
   call assert_equal(0, setbufline(b, 4, ['d', 'e']))
   call assert_equal(['c'], b->getbufline(3))
   call assert_equal(['d'], getbufline(b, 4))

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -126,6 +126,34 @@ func Test_mode_message_at_leaving_insert_by_ctrl_c()
   call delete(testfile)
 endfunc
 
+func Test_mode_message_at_leaving_insert_with_esc_mapped()
+  if !has('terminal') || has('gui_running')
+    return
+  endif
+
+  " Set custom statusline built by user-defined function.
+  let testfile = 'Xtest.vim'
+  call writefile([
+        \ 'set laststatus=2',
+        \ 'inoremap <Esc> <Esc>00',
+        \ ], testfile)
+
+  let rows = 10
+  let buf = term_start([GetVimProg(), '--clean', '-S', testfile], {'term_rows': rows})
+  call term_wait(buf, 200)
+  call assert_equal('run', job_status(term_getjob(buf)))
+
+  call term_sendkeys(buf, "i")
+  call WaitForAssert({-> assert_match('^-- INSERT --\s*$', term_getline(buf, rows))})
+  call term_sendkeys(buf, "\<Esc>")
+  call WaitForAssert({-> assert_match('^\s*$', term_getline(buf, rows))})
+
+  call term_sendkeys(buf, ":qall!\<CR>")
+  call WaitForAssert({-> assert_equal('dead', job_status(term_getjob(buf)))})
+  exe buf . 'bwipe!'
+  call delete(testfile)
+endfunc
+
 func Test_echospace()
   set noruler noshowcmd laststatus=1
   call assert_equal(&columns - 1, v:echospace)

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -95,6 +95,37 @@ func Test_echoerr()
   call test_ignore_error('RESET')
 endfunc
 
+func Test_mode_message_at_leaving_insert_by_ctrl_c()
+  if !has('terminal') || has('gui_running')
+    return
+  endif
+
+  " Set custom statusline built by user-defined function.
+  let testfile = 'Xtest.vim'
+  call writefile([
+        \ 'func StatusLine() abort',
+        \ '  return ""',
+        \ 'endfunc',
+        \ 'set statusline=%!StatusLine()',
+        \ 'set laststatus=2',
+        \ ], testfile)
+
+  let rows = 10
+  let buf = term_start([GetVimProg(), '--clean', '-S', testfile], {'term_rows': rows})
+  call term_wait(buf, 200)
+  call assert_equal('run', job_status(term_getjob(buf)))
+
+  call term_sendkeys(buf, "i")
+  call WaitForAssert({-> assert_match('^-- INSERT --\s*$', term_getline(buf, rows))})
+  call term_sendkeys(buf, "\<C-C>")
+  call WaitForAssert({-> assert_match('^\s*$', term_getline(buf, rows))})
+
+  call term_sendkeys(buf, ":qall!\<CR>")
+  call WaitForAssert({-> assert_equal('dead', job_status(term_getjob(buf)))})
+  exe buf . 'bwipe!'
+  call delete(testfile)
+endfunc
+
 func Test_echospace()
   set noruler noshowcmd laststatus=1
   call assert_equal(&columns - 1, v:echospace)

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -3,6 +3,7 @@
 source shared.vim
 source check.vim
 source view_util.vim
+source screendump.vim
 
 func Setup_NewWindow()
   10new
@@ -2038,9 +2039,9 @@ func Test_normal33_g_cmd2()
   call assert_equal(2, line('.'))
   call assert_fails(':norm! g;', 'E662')
   call assert_fails(':norm! g,', 'E663')
-  let &ul=&ul
+  let &ul = &ul
   call append('$', ['a', 'b', 'c', 'd'])
-  let &ul=&ul
+  let &ul = &ul
   call append('$', ['Z', 'Y', 'X', 'W'])
   let a = execute(':changes')
   call assert_match('2\s\+0\s\+2', a)
@@ -2887,6 +2888,20 @@ func Test_message_when_using_ctrl_c()
   call assert_match("Type  :qa!  and press <Enter> to abandon all changes and exit Nvim", Screenline(&lines))
 
   bwipe!
+endfunc
+
+func Test_mode_updated_after_ctrl_c()
+  CheckScreendump
+
+  let buf = RunVimInTerminal('', {'rows': 5})
+  call term_sendkeys(buf, "i")
+  call term_sendkeys(buf, "\<C-O>")
+  " wait a moment so that the "-- (insert) --" message is displayed
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "\<C-C>")
+  call VerifyScreenDump(buf, 'Test_mode_updated_1', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " Test for '[m', ']m', '[M' and ']M'

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -402,6 +402,28 @@ describe('messages', function()
                                                 |
       ]])
     end)
+
+    -- oldtest: Test_mode_updated_after_ctrl_c()
+    it('pressing Ctrl-C in i_CTRL-O', function()
+      feed('i<C-O>')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {2:-- (insert) --}                          |
+      ]])
+      feed('<C-C>')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]])
+    end)
   end)
 
   -- oldtest: Test_ask_yesno()

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -376,6 +376,32 @@ describe('messages', function()
                                                 |
       ]])
     end)
+
+    -- oldtest: Test_mode_message_at_leaving_insert_with_esc_mapped()
+    it('leaving Insert mode with ESC in the middle of a mapping vim-patch:8.1.1192', function()
+      exec([[
+        set laststatus=2
+        inoremap <Esc> <Esc>00
+      ]])
+      feed('i')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {3:[No Name]                               }|
+        {2:-- INSERT --}                            |
+      ]])
+      feed('<Esc>')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {3:[No Name]                               }|
+                                                |
+      ]])
+    end)
   end)
 
   -- oldtest: Test_ask_yesno()

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -337,6 +337,47 @@ describe('messages', function()
     end)
   end)
 
+  describe('mode is cleared when', function()
+    before_each(function()
+      screen = Screen.new(40, 6)
+      screen:set_default_attr_ids({
+        [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+        [2] = {bold = true},  -- ModeMsg
+        [3] = {bold = true, reverse=true},  -- StatusLine
+      })
+      screen:attach()
+    end)
+
+    -- oldtest: Test_mode_message_at_leaving_insert_by_ctrl_c()
+    it('leaving Insert mode with Ctrl-C vim-patch:8.1.1189', function()
+      exec([[
+        func StatusLine() abort
+          return ""
+        endfunc
+        set statusline=%!StatusLine()
+        set laststatus=2
+      ]])
+      feed('i')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {3:                                        }|
+        {2:-- INSERT --}                            |
+      ]])
+      feed('<C-C>')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+        {3:                                        }|
+                                                |
+      ]])
+    end)
+  end)
+
   -- oldtest: Test_ask_yesno()
   it('y/n prompt works', function()
     screen = Screen.new(75, 6)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1243,6 +1243,19 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
                                                                   |
     ]])
   end)
+
+  it('echo messages are shown correctly when getchar() immediately follows', function()
+    feed([[:echo 'foo' | echo 'bar' | call getchar()<CR>]])
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {3:                                                            }|
+      foo                                                         |
+      bar^                                                         |
+    ]])
+  end)
 end)
 
 describe('ui/ext_messages', function()

--- a/test/functional/vimscript/null_spec.lua
+++ b/test/functional/vimscript/null_spec.lua
@@ -135,7 +135,7 @@ describe('NULL', function()
     null_test('does not make Neovim crash when v:oldfiles gets assigned to that', ':let v:oldfiles = L|oldfiles', 0)
     null_expr_test('does not make complete() crash or error out',
                    'execute(":normal i\\<C-r>=complete(1, L)[-1]\\n")',
-                   '', '\n', function()
+                   0, '', function()
       eq({''}, curbufmeths.get_lines(0, -1, false))
     end)
     null_expr_test('is accepted by setmatches()', 'setmatches(L)', 0, 0)


### PR DESCRIPTION
#### vim-patch:partial:8.1.0822: peeking and flushing output slows down execution

Problem:    Peeking and flushing output slows down execution.
Solution:   Do not update the mode message when global_busy is set.  Do not
            flush when only peeking for a character. (Ken Takata)
https://github.com/vim/vim/commit/cb574f415486adff645ce384979bfecf27f5be8c

Omit inchar() change: it breaks too many tests.


#### vim-patch:8.1.1189: mode is not cleared when leaving Insert mode

Problem:    Mode is not cleared when leaving Insert mode.
Solution:   Clear the mode when got_int is set. (Ozaki Kiichi)
https://github.com/vim/vim/commit/abc7c7fc5a098374f5543a237e6c9dd918848b34


#### vim-patch:8.1.1192: mode is not cleared when leaving Insert mode with mapped Esc

Problem:    Mode is not cleared when leaving Insert mode with mapped Esc.
Solution:   Clear the mode when redraw_cmdline is set.
https://github.com/vim/vim/commit/4c25bd785aa8b565bf973cbba12ed36b76daaa4f


#### vim-patch:8.2.5109: mode not updated after CTRL-O CTRL-C in Insert mode

Problem:    Mode not updated after CTRL-O CTRL-C in Insert mode.
Solution:   Set redraw_mode and use it.
https://github.com/vim/vim/commit/7a1d32809bb5c1527314000983e75125d79192e0