### PR TITLE
vim-patch:partial:8a3b805c6c9c

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -877,7 +877,7 @@ Note: these are typed literally, they are not special keys!
 		   When the match is with a file name, it is expanded to the
  		   full path.
 							*:<sfile>* *<sfile>*
-	<sfile>    When executing a ":source" command, is replaced with the
+	<sfile>    When executing a `:source` command, is replaced with the
 		   file name of the sourced file.  *E498*
 		   When executing a function, is replaced with:
 		   "function {function-name}[{lnum}]"
@@ -886,7 +886,7 @@ Note: these are typed literally, they are not special keys!
 		   Note that filename-modifiers are useless when <sfile> is
 		   used inside a function.
 							*:<slnum>* *<slnum>*
-	<slnum>	   When executing a ":source" command, is replaced with the
+	<slnum>	   When executing a `:source` command, is replaced with the
 		   line number.  *E842*
 		   When executing a function it's the line number relative to
 		   the start of the function.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1173,7 +1173,7 @@ Examples: >
 
 If you want to always use ":confirm", set the 'confirm' option.
 
-			*:browse* *:bro* *E338* *E614* *E615* *E616*
+					*:browse* *:bro* *E338* *E614* *E615* *E616*
 :bro[wse] {command}	Open a file selection dialog for an argument to
 			{command}.  At present this works for |:e|, |:w|,
 			|:wall|, |:wq|, |:wqall|, |:x|, |:xall|, |:exit|,

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -119,7 +119,7 @@ You will not get an error if you try to change the type of a variable.
 
 
 1.2 Function references ~
-						*Funcref* *E695* *E718*
+							*Funcref* *E695* *E718*
 A Funcref variable is obtained with the |function()| function, the |funcref()|
 function or created with the lambda expression |expr-lambda|.  It can be used
 in an expression in the place of a function name, before the parenthesis
@@ -1123,7 +1123,7 @@ Generally, if a |List| index is equal to or higher than the length of the
 error.
 
 
-expr8[expr1a : expr1b]	substring or sublist		*expr-[:]*
+expr8[expr1a : expr1b]	substring or |sublist|		*expr-[:]* *substring*
 
 If expr8 is a String this results in the substring with the bytes or
 characters from expr1a to and including expr1b.  expr8 is used as a String,

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -141,7 +141,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.asp		g:filetype_asp	|ft-aspvbs-syntax| |ft-aspperl-syntax|
 	*.bas		g:filetype_bas	|ft-basic-syntax|
 	*.cfg		g:filetype_cfg
-	*.csh		g:filetype_csh  |ft-csh-syntax|
+	*.csh		g:filetype_csh	|ft-csh-syntax|
 	*.dat		g:filetype_dat
 	*.frm		g:filetype_frm	|ft-form-syntax|
 	*.fs		g:filetype_fs	|ft-forth-syntax|

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -290,7 +290,7 @@ The examples below assume a 'shiftwidth' of 4.
 <
 							*cino-g*
 	gN    Place C++ scope declarations N characters from the indent of the
-	      block they are in.  (default 'shiftwidth'). By default, a scope 
+	      block they are in.  (default 'shiftwidth'). By default, a scope
 	      declaration is "public:", "protected:" or "private:". This can
 	      be adjusted with the 'cinscopedecls' option.
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -176,7 +176,8 @@ keys.  After that white space and a comment may follow: >
 "<unique>" can be used in any order.  They must appear right after the
 command, before any other arguments.
 
-			*:map-local* *:map-<buffer>* *:map-buffer* *E224* *E225*
+					*:map-local* *:map-<buffer>* *:map-buffer*
+					*E224* *E225*
 If the first argument to one of these commands is "<buffer>" the mapping will
 be effective in the current buffer only.  Example: >
 	:map <buffer>  ,w  /[.,;]<CR>

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -379,7 +379,7 @@ the "disasm_window_height" entry can be used to set the window height: >
 	let g:termdebug_config['disasm_window_height'] = 15
 or, if there is no g:termdebug_config: >
 	let g:termdebug_disasm_window = 15
-Any value greater than 1 will set the Asm window height to that value: >
+Any value greater than 1 will set the Asm window height to that value.
 
 Communication ~
 						*termdebug-communication*
@@ -445,7 +445,7 @@ get this error:
 Then your gdb is too old.
 
 
-Colors~
+Colors ~
 						*hl-debugPC* *hl-debugBreakpoint*
 The color of the signs can be adjusted with these highlight groups:
 - debugPC		the current position
@@ -460,7 +460,8 @@ When 'background' is "dark":
   hi debugBreakpoint term=reverse ctermbg=red guibg=red
 
 
-Shortcuts						*termdebug_shortcuts*
+Shortcuts ~
+							*termdebug_shortcuts*
 
 You can define your own shortcuts (mappings) to control gdb, that can work in
 any window, using the TermDebugSendCommand() function.  Example: >
@@ -468,7 +469,8 @@ any window, using the TermDebugSendCommand() function.  Example: >
 The argument is the gdb command.
 
 
-Vim window width						*termdebug_wide*
+Vim window width ~
+							*termdebug_wide*
 
 To change the width of the Vim window when debugging starts and use a vertical
 split: >

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3798,10 +3798,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 				:set listchars+=tab:>-,lead:.
 <							*lcs-leadmultispace*
 	  leadmultispace:c...
-			Like multispace value, but only for leading whitespace
-			Overrides |lcs-lead| for leading multiple spaces.
-			`:set listchars=leadmultispace:---+` shows ten consecutive
-			leading spaces as:
+			Like multispace value, but only for leading
+			whitespace.  Overrides |lcs-lead| for leading multiple
+			spaces.  `:set listchars=leadmultispace:---+` shows ten
+			consecutive leading spaces as:
 				---+---+--XXX ~
 			Where "XXX" denotes the first non-blank characters in
 			the line.
@@ -6969,7 +6969,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'wildoptions' 'wop'	string	(default "pum,tagfile")
 			global
 	List of words that change how |cmdline-completion| is done.
-	  pum		Display the completion matches using the popupmenu
+	  pum		Display the completion matches using the popup menu
 			in the same style as the |ins-completion-menu|.
 	  tagfile	When using CTRL-D to list matching tags, the kind of
 			tag and the file of the tag is listed.	Only one match

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -638,7 +638,7 @@ Short explanation of each option:		*option-list*
 'cinkeys'	  'cink'    keys that trigger indent when 'cindent' is set
 'cinoptions'	  'cino'    how to do indenting when 'cindent' is set
 'cinwords'	  'cinw'    words where 'si' and 'cin' add an indent
-'cinscopedecls'	  'cinsd'   words that are recognized by 'cino-g' 
+'cinscopedecls'	  'cinsd'   words that are recognized by 'cino-g'
 'clipboard'	  'cb'	    use the clipboard as the unnamed register
 'cmdheight'	  'ch'	    number of lines to use for the command-line
 'cmdwinheight'	  'cwh'     height of the command-line window

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -129,7 +129,7 @@ something else.
 		    :+tabclose	    " close the next tab page
 		    :1tabclose	    " close the first tab page
 		    :$tabclose	    " close the last tab page
-		    :tabclose -2    " close the 2nd previous tab page 
+		    :tabclose -2    " close the 2nd previous tab page
 		    :tabclose +	    " close the next tab page
 		    :tabclose 3	    " close the third tab page
 		    :tabclose $	    " close the last tab page

--- a/runtime/syntax/doxygen.vim
+++ b/runtime/syntax/doxygen.vim
@@ -120,7 +120,7 @@ try
 
 " end=+\(\n\s*\*\=\s*\([@\\]\([npcbea]\>\|em\>\|ref\>\|link\>\|f\$\|[$\\&<>#]\)\@!\)\|\s*$\)\@=+
 "syn region doxygenBriefLine contained start=+\<\k+ skip=+^\s*\(\*/\@!\s*\)\=\(\<\|[@\\]\<\([npcbea]\>\|em\>\|ref\|link\>\>\|f\$\|[$\\&<>#]\)\|[^ \t\\@*]\)+ end=+^+ contains=doxygenContinueCommentWhite,doxygenSmallSpecial,@doxygenHtmlGroup,doxygenTODO,doxygenHyperLink,doxygenHashLink,@Spell  skipwhite keepend matchgroup=xxx
-syn region doxygenBriefLine contained start=+\<\k+ skip=+^\s*\(\*/\@!\s*\)\=\(\<\|[@\\]\<\([npcbea]\>\|em\>\|ref\|link\>\>\|f\$\|[$\\&<>#]\)\|[^ \t\\@*]\)+ end=+^+  skipwhite keepend matchgroup=xxx
+syn region doxygenBriefLine contained start=+\<\k+ skip=+^\s*\(\*/\@!\s*\)\=\(\<\|[@\\]\<\([npcbea]\>\|em\>\|ref\|link\>\>\|f\$\|[$\\&<>#]\)\|[^ \t\\@*]\)+ end=+^+  skipwhite keepend matchgroup=xxx contains=@Spell
 " syn region doxygenBriefLine matchgroup=xxxy contained start=+\<\k.\++ skip=+^\s*\k+ end=+end+  skipwhite keepend
 "doxygenFindBriefSpecial,
   "" syn region doxygenSpecialMultilineDesc  start=+.\++ contained contains=doxygenSpecialContinueCommentWhite,doxygenSmallSpecial,doxygenHyperLink,doxygenHashLink,@doxygenHtmlGroup,@Spell  skipwhite keepend


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/8a3b805c6c9cae341d560df9c3567ebbe42a7404

skip builtin.txt (needs 8.2.4838)
skip message.txt (whitespace changes)