### PR TITLE
ci(release): use system GPerf on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           OSX_FLAGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES=arm64\;x86_64"
           make CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} \
                CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH= $OSX_FLAGS" \
-               DEPS_CMAKE_FLAGS="$OSX_FLAGS"
+               DEPS_CMAKE_FLAGS="$OSX_FLAGS -DUSE_BUNDLED_GPERF=OFF"
           make DESTDIR="$GITHUB_WORKSPACE/build/release/nvim-macos" install
       - name: Create package
         run: |


### PR DESCRIPTION
GPerf gets upset at our attempts to build a universal binary.
Conveniently, macOS provides GPerf, so we don't need to build it.

@clason @justinmk
