### PR TITLE
tests: use "python3" to avoid skipped test

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -52,7 +52,7 @@ has a major bug:
 3. Cut a release from `release-x.y`.
     - Run `./scripts/release.sh`
     - Update (force-push) the remote `stable` tag.
-    - The [nightly job](https://github.com/neovim/neovim/blob/master/.github/workflows/release.yml#L4)
+    - The [CI job](https://github.com/neovim/neovim/blob/3d45706478cd030c3ee05b4f336164bb96138095/.github/workflows/release.yml#L11-L13)
       will update the release assets based on the `stable` tag.
 
 The neovim repository includes a backport [github action](https://github.com/zeebe-io/backport-action).

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -79,8 +79,8 @@ describe('system()', function()
     end)
 
     it('calls executable in $PATH', function()
-      if 0 == eval("executable('python')") then pending("missing `python`") end
-      eq("foo\n", eval([[system(['python', '-c', 'print("foo")'])]]))
+      if 0 == eval("executable('python3')") then pending("missing `python3`") end
+      eq("foo\n", eval([[system(['python3', '-c', 'print("foo")'])]]))
       eq(0, eval('v:shell_error'))
     end)
 
@@ -175,7 +175,7 @@ describe('system()', function()
 
     it('powershell w/ UTF-8 text #13713', function()
       if not helpers.has_powershell() then
-        pending("not tested; powershell was not found", function() end)
+        pending("powershell not found", function() end)
         return
       end
       helpers.set_shell_powershell()
@@ -613,7 +613,7 @@ describe('systemlist()', function()
 
   it('powershell w/ UTF-8 text #13713', function()
     if not helpers.has_powershell() then
-      pending("not tested; powershell was not found", function() end)
+      pending("powershell not found", function() end)
       return
     end
     helpers.set_shell_powershell()


### PR DESCRIPTION
Problem:
The "calls executable in $PATH" is skipped on some CI jobs because
"python" is not found.

Solution:
Use "python3" instead.