### PR TITLE
fix(lua): use empty_dict when no opts given in vim.ui.input

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1935,8 +1935,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
 
                 Parameters: ~
                     {opts}        (table) Additional options. See |input()|
-                                  • prompt (string|nil) Text of the prompt.
-                                    Defaults to `Input:`.
+                                  • prompt (string|nil) Text of the prompt
                                   • default (string|nil) Default reply to the
                                     input
                                   • completion (string|nil) Specifies type of

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -59,7 +59,7 @@ end
 ---
 ---@param opts table Additional options. See |input()|
 ---     - prompt (string|nil)
----               Text of the prompt. Defaults to `Input: `.
+---               Text of the prompt
 ---     - default (string|nil)
 ---               Default reply to the input
 ---     - completion (string|nil)
@@ -87,7 +87,7 @@ function M.input(opts, on_confirm)
     on_confirm = { on_confirm, 'function', false },
   })
 
-  opts = opts or {}
+  opts = (opts and not vim.tbl_isempty(opts)) and opts or vim.empty_dict()
   local input = vim.fn.input(opts)
   if #input > 0 then
     on_confirm(input)

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -2,6 +2,8 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
 local exec_lua = helpers.exec_lua
 local clear = helpers.clear
+local feed = helpers.feed
+local eval = helpers.eval
 
 describe('vim.ui', function()
   before_each(function()
@@ -66,6 +68,20 @@ describe('vim.ui', function()
       ]]
       eq('Inputted text', result[1])
       eq('Input: ', result[2])
+    end)
+
+    it('can input text on nil opt', function()
+      feed(':lua vim.ui.input(nil, function(input) result = input end)<cr>')
+      eq('', eval('v:errmsg'))
+      feed('Inputted text<cr>')
+      eq('Inputted text', exec_lua('return result'))
+    end)
+
+    it('can input text on {} opt', function()
+      feed(':lua vim.ui.input({}, function(input) result = input end)<cr>')
+      eq('', eval('v:errmsg'))
+      feed('abcdefg<cr>')
+      eq('abcdefg', exec_lua('return result'))
     end)
   end)
 end)


### PR DESCRIPTION
I'm pretty sure `{}` makes an empty list which is not you want to put as input to `vim.fn.input`. Therefore, this change makes it so that when opts are `nil` or `{}`, an empty_dict is passed as the argument for `vim.fn.input`. 

I also removed the doc about `Defaults to Input:`, because by default it's `""` for `input()`.

Edit: looks like an issue was already made for this. Resolves #18143.