### PR TITLE
fix(windows):exepath, stdpath return wrong slashes

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2054,6 +2054,12 @@ static void f_exepath(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   (void)os_can_exe(tv_get_string(&argvars[0]), &path, true);
 
+#ifdef BACKSLASH_IN_FILENAME
+  if (path != NULL) {
+    slash_adjust((char_u *)path);
+  }
+#endif
+
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = path;
 }

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -115,6 +115,10 @@ char *get_xdg_home(const XDGVarType idx)
 #else
     dir = concat_fnames_realloc(dir, "nvim", true);
 #endif
+
+#ifdef BACKSLASH_IN_FILENAME
+    slash_adjust((char_u *)dir);
+#endif
   }
   return dir;
 }

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -24,6 +24,7 @@ local iswin = helpers.iswin
 local startswith = helpers.startswith
 local write_file = helpers.write_file
 local meths = helpers.meths
+local alter_slashes = helpers.alter_slashes
 
 local testfile = 'Xtest_startuptime'
 after_each(function()
@@ -33,9 +34,9 @@ end)
 describe('startup', function()
   it('--clean', function()
     clear()
-    ok(string.find(meths.get_option('runtimepath'), funcs.stdpath('config'), 1, true) ~= nil)
+    ok(string.find(alter_slashes(meths.get_option('runtimepath')), funcs.stdpath('config'), 1, true) ~= nil)
     clear('--clean')
-    ok(string.find(meths.get_option('runtimepath'), funcs.stdpath('config'), 1, true) == nil)
+    ok(string.find(alter_slashes(meths.get_option('runtimepath')), funcs.stdpath('config'), 1, true) == nil)
   end)
 
   it('--startuptime', function()

--- a/test/functional/vimscript/executable_spec.lua
+++ b/test/functional/vimscript/executable_spec.lua
@@ -17,6 +17,21 @@ describe('executable()', function()
     eq(1, call('executable', 'false'))
   end)
 
+  if iswin() then
+    it('exepath respects shellslash', function()
+      command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
+      eq([[test\functional\fixtures\bin\null.CMD]], call('fnamemodify', call('exepath', 'null'), ':.'))
+      command('set shellslash')
+      eq('test/functional/fixtures/bin/null.CMD', call('fnamemodify', call('exepath', 'null'), ':.'))
+    end)
+
+    it('stdpath respects shellslash', function()
+      eq([[build\Xtest_xdg\share\nvim-data]], call('fnamemodify', call('stdpath', 'data'), ':.'))
+      command('set shellslash')
+      eq('build/Xtest_xdg/share/nvim-data', call('fnamemodify', call('stdpath', 'data'), ':.'))
+    end)
+  end
+
   it('fails for invalid values', function()
     for _, input in ipairs({'v:null', 'v:true', 'v:false', '{}', '[]'}) do
       eq('Vim(call):E928: String required', exc_exec('call executable('..input..')'))


### PR DESCRIPTION
Closes #13787. `exepath` and `stdpath` should respect `shellslash` and return path with
proper file separator.