### PR TITLE
fix(api): change default value of 'pattern' in nvim_exec_autocmds

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -833,7 +833,7 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   }
 
   if (patterns.size == 0) {
-    ADD(patterns, STRING_OBJ(STATIC_CSTR_TO_STRING("*")));
+    ADD(patterns, STRING_OBJ(STATIC_CSTR_TO_STRING("")));
   }
 
   if (opts->data.type != kObjectTypeNil) {


### PR DESCRIPTION
Omitting 'pattern' in `nvim_exec_autocmds` should be equivalent to
omitting the 'fname' argument in :doautoall, which is equivalent to
using an empty string as the pattern.

Closes #19113.
