### PR TITLE
ci(distribution): auto-release on winget

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest # action can only be run on windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: Neovim.Neovim
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: nvim-linux64
-          path: build/nvim-linux64.tar.gz
-          retention-days: 1
-      - uses: actions/upload-artifact@v3
-        with:
-          name: nvim-linux64
-          path: build/nvim-linux64.deb
+          path: |
+            build/nvim-linux64.tar.gz
+            build/nvim-linux64.deb
           retention-days: 1
 
   appimage:
@@ -69,12 +66,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: appimage
-          path: build/bin/nvim.appimage
-          retention-days: 1
-      - uses: actions/upload-artifact@v3
-        with:
-          name: appimage
-          path: build/bin/nvim.appimage.zsync
+          path: |
+            build/bin/nvim.appimage
+            build/bin/nvim.appimage.zsync
           retention-days: 1
 
   macOS:
@@ -132,6 +126,7 @@ jobs:
     env:
       DEPS_BUILD_DIR: ${{ format('{0}/nvim-deps', github.workspace) }}
       DEPS_PREFIX: ${{ format('{0}/nvim-deps/usr', github.workspace) }}
+      CONFIGURATION: ${{ matrix.config }}
     strategy:
       matrix:
         include:
@@ -143,17 +138,12 @@ jobs:
         with:
           fetch-depth: 0
       - run: powershell ci\build.ps1 -NoTests
-        env:
-          CONFIGURATION: ${{ matrix.config }}
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.archive }}
-          path: build/${{ matrix.archive }}.zip
-          retention-days: 1
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.archive }}
-          path: build/${{ matrix.archive }}.msi
+          path: |
+            build/${{ matrix.archive }}.msi
+            build/${{ matrix.archive }}.zip
           retention-days: 1
 
   publish:
@@ -161,6 +151,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
     steps:
@@ -171,9 +162,7 @@ jobs:
       - uses: actions/download-artifact@v3
 
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gettext-base
+        run: sudo apt-get update && sudo apt-get install -y gettext-base
 
       - if: github.event_name == 'workflow_dispatch'
         run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
@@ -184,16 +173,12 @@ jobs:
           TAG_NAME=${{ github.ref }}
           echo "TAG_NAME=${TAG_NAME#refs/tags/}" >> $GITHUB_ENV
       - if: env.TAG_NAME == 'nightly'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (echo 'SUBJECT=Nvim development (prerelease) build';
            echo 'PRERELEASE=--prerelease') >> $GITHUB_ENV
           gh release delete nightly --yes || true
           git push origin :nightly || true
       - if: env.TAG_NAME != 'nightly'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (echo 'SUBJECT=Nvim release build';
            echo 'PRERELEASE=') >> $GITHUB_ENV
@@ -232,7 +217,6 @@ jobs:
           echo "SHA_WIN_64_MSI=$(cat nvim-win64.msi.sha256sum)" >> $GITHUB_ENV
       - name: Publish release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVIM_VERSION: ${{ needs.linux.outputs.version }}
           DEBUG: api
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,12 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: nvim-linux64
-          path: |
-            build/nvim-linux64.tar.gz
-            build/nvim-linux64.deb
+          path: build/nvim-linux64.tar.gz
+          retention-days: 1
+      - uses: actions/upload-artifact@v3
+        with:
+          name: nvim-linux64
+          path: build/nvim-linux64.deb
           retention-days: 1
 
   appimage:
@@ -66,9 +69,12 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: appimage
-          path: |
-            build/bin/nvim.appimage
-            build/bin/nvim.appimage.zsync
+          path: build/bin/nvim.appimage
+          retention-days: 1
+      - uses: actions/upload-artifact@v3
+        with:
+          name: appimage
+          path: build/bin/nvim.appimage.zsync
           retention-days: 1
 
   macOS:
@@ -126,7 +132,6 @@ jobs:
     env:
       DEPS_BUILD_DIR: ${{ format('{0}/nvim-deps', github.workspace) }}
       DEPS_PREFIX: ${{ format('{0}/nvim-deps/usr', github.workspace) }}
-      CONFIGURATION: ${{ matrix.config }}
     strategy:
       matrix:
         include:
@@ -138,12 +143,17 @@ jobs:
         with:
           fetch-depth: 0
       - run: powershell ci\build.ps1 -NoTests
+        env:
+          CONFIGURATION: ${{ matrix.config }}
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.archive }}
-          path: |
-            build/${{ matrix.archive }}.msi
-            build/${{ matrix.archive }}.zip
+          path: build/${{ matrix.archive }}.zip
+          retention-days: 1
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.archive }}
+          path: build/${{ matrix.archive }}.msi
           retention-days: 1
 
   publish:
@@ -151,7 +161,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
     steps:
@@ -162,7 +171,9 @@ jobs:
       - uses: actions/download-artifact@v3
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y gettext-base
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
 
       - if: github.event_name == 'workflow_dispatch'
         run: echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
@@ -173,12 +184,16 @@ jobs:
           TAG_NAME=${{ github.ref }}
           echo "TAG_NAME=${TAG_NAME#refs/tags/}" >> $GITHUB_ENV
       - if: env.TAG_NAME == 'nightly'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (echo 'SUBJECT=Nvim development (prerelease) build';
            echo 'PRERELEASE=--prerelease') >> $GITHUB_ENV
           gh release delete nightly --yes || true
           git push origin :nightly || true
       - if: env.TAG_NAME != 'nightly'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (echo 'SUBJECT=Nvim release build';
            echo 'PRERELEASE=') >> $GITHUB_ENV
@@ -217,6 +232,7 @@ jobs:
           echo "SHA_WIN_64_MSI=$(cat nvim-win64.msi.sha256sum)" >> $GITHUB_ENV
       - name: Publish release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVIM_VERSION: ${{ needs.linux.outputs.version }}
           DEBUG: api
         run: |


### PR DESCRIPTION
I had observed the existing release CI and the reason why it cannot be added as a step in the existing CI is:
- The action is only supported on windows runners.
- The action has GitHub event validation checks and can only be run on `release` event with the `released/prereleased` event type.

Before merging this:
1. Please add a GitHub token with `public_repo` scope as a repository secret and rename the secret name in the workflow.
2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under @neovim, the organisation or any maintainer.

If the fork is not present under the organisation:
- Please add another line in the workflow to tell the action where to find the fork, if the fork is not present under the organisation.
```yaml
- uses: vedantmgoyal2009/winget-releaser@latest
  with:
    identifier: Neovim.Neovim
    token: ${{ secrets.WINGET_TOKEN }}
    fork-user: <github-username> # don't put "@" when writing username
```
- Make sure, the fork and GitHub Personal Access Token (PAT) should come from the same account

---

* Resolves https://github.com/neovim/neovim/issues/19108

cc @justinmk